### PR TITLE
feat: add DocSearch as recommended by docusaurus

### DIFF
--- a/web/docusaurus.config.js
+++ b/web/docusaurus.config.js
@@ -14,6 +14,10 @@ module.exports = {
   organizationName: 'supabase', // Usually your GitHub org/user name.
   projectName: 'supabase', // Usually your repo name.
   themeConfig: {
+    algolia: {
+      apiKey: '766d56f13dd1e82f43253559b7c86636',
+      indexName: 'supabase',
+    },
     darkMode: true,
     image: 'favicon.png', // used for meta tag, in particular og:image and twitter:image
     googleAnalytics: {


### PR DESCRIPTION
👋 team,

I am working on DocSearch. [We have an integration for Docusaurus](https://docusaurus.io/docs/en/search#enabling-the-search-bar). We thought it is a shame you can not also used this search that you can [find on reactjs for example](https://reactjs.org/).

This PR will add DocSearch to the documentation website. It will allow an user to have a learn-as-you-type experience by displaying results thanks to a dropdown in a live way.

Let me know if you need anything.