### PR TITLE
fix: og:image not working

### DIFF
--- a/web/docusaurus.config.js
+++ b/web/docusaurus.config.js
@@ -20,7 +20,7 @@ module.exports = {
     },
     forceDarkMode: true,
     darkMode: true,
-    image: 'https://supabase.io/favicon.png', // used for meta tag, in particular og:image and twitter:image
+    image: 'https://supabase.io/img/supabase-og-image.png', // used for meta tag, in particular og:image and twitter:image
     metaImage: '/img/supabase-og-image.png',
     googleAnalytics: {
       trackingID: 'UA-155232740-1',

--- a/web/docusaurus.config.js
+++ b/web/docusaurus.config.js
@@ -20,7 +20,7 @@ module.exports = {
     },
     forceDarkMode: true,
     darkMode: true,
-    image: 'https://supabase.io/img/supabase-og-image.png', // used for meta tag, in particular og:image and twitter:image
+    image: '/img/supabase-og-image.png', // used for meta tag, in particular og:image and twitter:image
     metaImage: '/img/supabase-og-image.png',
     googleAnalytics: {
       trackingID: 'UA-155232740-1',

--- a/web/docusaurus.config.js
+++ b/web/docusaurus.config.js
@@ -20,7 +20,7 @@ module.exports = {
     },
     forceDarkMode: true,
     darkMode: true,
-    image: 'favicon.png', // used for meta tag, in particular og:image and twitter:image
+    image: 'https://supabase.io/favicon.png', // used for meta tag, in particular og:image and twitter:image
     metaImage: '/img/supabase-og-image.png',
     googleAnalytics: {
       trackingID: 'UA-155232740-1',


### PR DESCRIPTION
The og:image tag is not working, ~presumably because it's using relative path instead of absolute~ because /favicon.png doesn't exist.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

`og:image` tag is not working

* **What is the new behavior (if this is a feature change)?**

This should fix the above

* **Other information**:
