### PR TITLE
Documentation filter chaining order

### DIFF
--- a/web/docs/library/delete.mdx
+++ b/web/docs/library/delete.mdx
@@ -76,7 +76,7 @@ It is to note that it is required to apply filters when using `.delete()`. Not u
 <CustomCodeBlock
   header="Shows how to use filter( ) with delete( )"
   js={deleteFilterJs}
-  jsHighlight="{9}"
+  jsHighlight="{10}"
   response={`{
   "body": null,
   "status": 204,
@@ -94,7 +94,7 @@ It is to note that it is required to apply filters when using `.delete()`. Not u
 <CustomCodeBlock
   header="Shows how to use not( ) with delete( )"
   js={deleteNotJs}
-  jsHighlight="{9}"
+  jsHighlight="{10}"
   response={`{
   "body": null,
   "status": 204,
@@ -112,7 +112,7 @@ It is to note that it is required to apply filters when using `.delete()`. Not u
 <CustomCodeBlock
   header="Shows how to use match( ) with delete( )"
   js={deleteMatchJs}
-  jsHighlight="{9}"
+  jsHighlight="{10}"
   response={`{
   "body": null,
   "status": 204,
@@ -130,7 +130,7 @@ It is to note that it is required to apply filters when using `.delete()`. Not u
 <CustomCodeBlock
   header="Shows how to use eq( ) with delete( )"
   js={deleteEqJs}
-  jsHighlight="{9}"
+  jsHighlight="{10}"
   response={`{
   "body": null,
   "status": 204,
@@ -148,7 +148,7 @@ It is to note that it is required to apply filters when using `.delete()`. Not u
 <CustomCodeBlock
   header="Shows how to use neq( ) with delete( )"
   js={deleteNeqJs}
-  jsHighlight="{9}"
+  jsHighlight="{10}"
   response={`{
   "body": null,
   "status": 204,
@@ -166,7 +166,7 @@ It is to note that it is required to apply filters when using `.delete()`. Not u
 <CustomCodeBlock
   header="Shows how to use gt( ) with delete( )"
   js={deleteGtJs}
-  jsHighlight="{9}"
+  jsHighlight="{10}"
   response={`{
   "body": null,
   "status": 204,
@@ -184,7 +184,7 @@ It is to note that it is required to apply filters when using `.delete()`. Not u
 <CustomCodeBlock
   header="Shows how to use lt( ) with delete( )"
   js={deleteLtJs}
-  jsHighlight="{9}"
+  jsHighlight="{10}"
   response={`{
   "body": null,
   "status": 204,
@@ -202,7 +202,7 @@ It is to note that it is required to apply filters when using `.delete()`. Not u
 <CustomCodeBlock
   header="Shows how to use gte( ) with delete( )"
   js={deleteGteJs}
-  jsHighlight="{9}"
+  jsHighlight="{10}"
   response={`{
   "body": null,
   "status": 204,
@@ -220,7 +220,7 @@ It is to note that it is required to apply filters when using `.delete()`. Not u
 <CustomCodeBlock
   header="Shows how to use lte( ) with delete( )"
   js={deleteLteJs}
-  jsHighlight="{9}"
+  jsHighlight="{10}"
   response={`{
   "body": null,
   "status": 204,
@@ -238,7 +238,7 @@ It is to note that it is required to apply filters when using `.delete()`. Not u
 <CustomCodeBlock
   header="Shows how to use like( ) with delete( )"
   js={deleteLikeJs}
-  jsHighlight="{9}"
+  jsHighlight="{10}"
   response={`{
   "body": null,
   "status": 204,
@@ -256,7 +256,7 @@ It is to note that it is required to apply filters when using `.delete()`. Not u
 <CustomCodeBlock
   header="Shows how to use ilike( ) with delete( )"
   js={deleteIlikeJs}
-  jsHighlight="{9}"
+  jsHighlight="{10}"
   response={`{
   "body": null,
   "status": 204,
@@ -274,7 +274,7 @@ It is to note that it is required to apply filters when using `.delete()`. Not u
 <CustomCodeBlock
   header="Shows how to use is( ) with delete( )"
   js={deleteIsJs}
-  jsHighlight="{9}"
+  jsHighlight="{10}"
   response={`{
   "body": null,
   "status": 204,
@@ -292,7 +292,7 @@ It is to note that it is required to apply filters when using `.delete()`. Not u
 <CustomCodeBlock
   header="Shows how to use in( ) with delete( )"
   js={deleteInJs}
-  jsHighlight="{9}"
+  jsHighlight="{10}"
   response={`{
   "body": null,
   "status": 204,
@@ -310,7 +310,7 @@ It is to note that it is required to apply filters when using `.delete()`. Not u
 <CustomCodeBlock
   header="Shows how to use cs( ) with delete( )"
   js={deleteCsJs}
-  jsHighlight="{9}"
+  jsHighlight="{10}"
   response={`{
   "body": null,
   "status": 204,
@@ -328,7 +328,7 @@ It is to note that it is required to apply filters when using `.delete()`. Not u
 <CustomCodeBlock
   header="Shows how to use cd( ) with delete( )"
   js={deleteCdJs}
-  jsHighlight="{9}"
+  jsHighlight="{10}"
   response={`{
   "body": null,
   "status": 204,
@@ -346,7 +346,7 @@ It is to note that it is required to apply filters when using `.delete()`. Not u
 <CustomCodeBlock
   header="Shows how to use ova( ) with delete( )"
   js={deleteOvaJs}
-  jsHighlight="{9}"
+  jsHighlight="{10}"
   response={`{
   "body": null,
   "status": 204,
@@ -364,7 +364,7 @@ It is to note that it is required to apply filters when using `.delete()`. Not u
 <CustomCodeBlock
   header="Shows how to use ovr( ) with delete( )"
   js={deleteOvrJs}
-  jsHighlight="{9}"
+  jsHighlight="{10}"
   response={`{
   "body": null,
   "status": 204,
@@ -382,7 +382,7 @@ It is to note that it is required to apply filters when using `.delete()`. Not u
 <CustomCodeBlock
   header="Shows how to use sl( ) with delete( )"
   js={deleteSlJs}
-  jsHighlight="{9}"
+  jsHighlight="{10}"
   response={`{
   "body": null,
   "status": 204,
@@ -400,7 +400,7 @@ It is to note that it is required to apply filters when using `.delete()`. Not u
 <CustomCodeBlock
   header="Shows how to use sr( ) with delete( )"
   js={deleteSrJs}
-  jsHighlight="{9}"
+  jsHighlight="{10}"
   response={`{
   "body": null,
   "status": 204,
@@ -418,7 +418,7 @@ It is to note that it is required to apply filters when using `.delete()`. Not u
 <CustomCodeBlock
   header="Shows how to use nxl( ) with delete( )"
   js={deleteNxlJs}
-  jsHighlight="{9}"
+  jsHighlight="{10}"
   response={`{
   "body": null,
   "status": 204,
@@ -436,7 +436,7 @@ It is to note that it is required to apply filters when using `.delete()`. Not u
 <CustomCodeBlock
   header="Shows how to use nxr( ) with delete( )"
   js={deleteNxrJs}
-  jsHighlight="{9}"
+  jsHighlight="{10}"
   response={`{
   "body": null,
   "status": 204,
@@ -454,7 +454,7 @@ It is to note that it is required to apply filters when using `.delete()`. Not u
 <CustomCodeBlock
   header="Shows how to use adj( ) with delete( )"
   js={deleteAdjJs}
-  jsHighlight="{9}"
+  jsHighlight="{10}"
   response={`{
   "body": null,
   "status": 204,

--- a/web/docs/library/examples/delete.js
+++ b/web/docs/library/examples/delete.js
@@ -10,9 +10,8 @@ const deleteCity = async () => {
   try {
     let values = await supabase
       .from('cities')
-      .match({ id: 666 })
       .delete()
-
+      .match({ id: 666 })
     return values
   ${errorJs}
 `.trim()
@@ -23,8 +22,8 @@ const deleteCity = async () => {
   try {
     let cities = await supabase
       .from('cities')
-      .filter({'name', 'eq', 'Paris'})
       .delete()
+      .filter({'name', 'eq', 'Paris'})
     return cities
   ${errorJs}
 `.trim()
@@ -35,8 +34,8 @@ const getCities = async () => {
   try {
     let cities = await supabase
       .from('cities')
-      .not('name', 'eq', 'Paris')
       .delete()
+      .not('name', 'eq', 'Paris')
     return cities
   ${errorJs}
 `.trim()
@@ -47,8 +46,8 @@ const deleteCity = async () => {
   try {
     let cities = await supabase
       .from('cities')
-      .match({name: 'Beijing', country_id: 156})
       .delete()
+      .match({name: 'Beijing', country_id: 156})
     return cities
   ${errorJs}
 `.trim()
@@ -59,8 +58,8 @@ const deleteCity = async () => {
   try {
     let cities = await supabase
       .from('cities')
-      .eq('name', 'San Francisco')
       .delete()
+      .eq('name', 'San Francisco')
     return cities
   ${errorJs}
 `.trim()
@@ -71,8 +70,8 @@ const deleteCity = async () => {
   try {
     let cities = await supabase
       .from('cities')
-      .neq('name', 'Lagos')
       .delete()
+      .neq('name', 'Lagos')
     return cities
   ${errorJs}
 `.trim()
@@ -83,8 +82,8 @@ const deleteCity = async () => {
   try {
     let cities = await supabase
       .from('cities')
-      .gt('country_id', 250)
       .delete()
+      .gt('country_id', 250)
     return cities
   ${errorJs}
 `.trim()
@@ -95,8 +94,8 @@ const deleteCity = async () => {
   try {
     let cities = await supabase
       .from('cities')
-      .lt('country_id', 250)
       .delete()
+      .lt('country_id', 250)
     return cities
   ${errorJs}
 `.trim()
@@ -107,8 +106,8 @@ const deleteCity = async () => {
   try {
     let cities = await supabase
       .from('cities')
-      .gte('country_id', 250)
       .delete()
+      .gte('country_id', 250)
     return cities
   ${errorJs}
 `.trim()
@@ -119,8 +118,8 @@ const deleteCity = async () => {
   try {
     let cities = await supabase
       .from('cities')
-      .lte('country_id', 250)
       .delete()
+      .lte('country_id', 250)
     return cities
   ${errorJs}
 `.trim()
@@ -131,8 +130,8 @@ const deleteCity = async () => {
   try {
     let cities = await supabase
       .from('cities')
-      .like('name', '%la%')
       .delete()
+      .like('name', '%la%')
     return cities
   ${errorJs}
 `.trim()
@@ -143,8 +142,8 @@ const deleteCity = async () => {
   try {
     let cities = await supabase
       .from('cities')
-      .ilike('name', '%la%')
       .delete()
+      .ilike('name', '%la%')
     return cities
   ${errorJs}
 `.trim()
@@ -155,8 +154,8 @@ const deleteCity = async () => {
   try {
     let cities = await supabase
       .from('cities')
-      .is('name', null)
       .delete()
+      .is('name', null)
     return cities
   ${errorJs}
 `.trim()
@@ -167,8 +166,8 @@ const deleteCity = async () => {
   try {
     let cities = await supabase
       .from('cities')
-      .in('name', ['Rio de Janeiro', 'San Francisco'])
       .delete()
+      .in('name', ['Rio de Janeiro', 'San Francisco'])
     return cities
   ${errorJs}
 `.trim()
@@ -179,8 +178,8 @@ const deleteCountry = async () => {
   try {
     let countries = await supabase
       .from('countries')
+      .delete()
       .cs('main_exports', ['oil'])
-      delete()
     return countries
   ${errorJs}
 `.trim()
@@ -191,8 +190,8 @@ const deleteCountry = async () => {
   try {
     let countries = await supabase
       .from('countries')
-      .cd('main_exports', ['cars', 'food', 'machine'])
       .delete()
+      .cd('main_exports', ['cars', 'food', 'machine'])
     return countries
   ${errorJs}
 `.trim()
@@ -203,8 +202,8 @@ const deleteCountry = async () => {
   try {
     let countries = await supabase
       .from('countries')
-      .ova('main_exports', ['computers', 'minerals'])
       .delete()
+      .ova('main_exports', ['computers', 'minerals'])
     return countries
   ${errorJs}
 `.trim()
@@ -215,8 +214,8 @@ const deleteCountry = async () => {
   try {
     let countries = await supabase
       .from('countries')
-      .ovr('population_range_millions', [150, 250])
       .delete()
+      .ovr('population_range_millions', [150, 250])
     return countries
   ${errorJs}
 `.trim()
@@ -227,8 +226,8 @@ const deleteCountry = async () => {
   try {
     let countries = await supabase
       .from('countries')
-      .sl('population_range_millions', [150, 250])
       .delete()
+      .sl('population_range_millions', [150, 250])
     return countries
   ${errorJs}
 `.trim()
@@ -239,8 +238,8 @@ const deleteCountry = async () => {
   try {
     let countries = await supabase
       .from('countries')
-      .sr('population_range_millions', [150, 250])
       .delete()
+      .sr('population_range_millions', [150, 250])
     return countries
   ${errorJs}
 `.trim()
@@ -251,8 +250,8 @@ const deleteCountry = async () => {
   try {
     let countries = await supabase
       .from('countries')
-      .nxl('population_range_millions', [150, 250])
       .delete()
+      .nxl('population_range_millions', [150, 250])
     return countries
   ${errorJs}
 `.trim()
@@ -263,8 +262,8 @@ const deleteCountry = async () => {
   try {
     let countries = await supabase
       .from('countries')
-      .nxr('population_range_millions', [150, 250])
       .delete()
+      .nxr('population_range_millions', [150, 250])
     return countries
   ${errorJs}
 `.trim()
@@ -275,8 +274,8 @@ const deleteCountry = async () => {
   try {
     let countries = await supabase
       .from('countries')
-      .adj('population_range_millions', [70, 185])
       .delete()
+      .adj('population_range_millions', [70, 185])
     return countries
   ${errorJs}
 `.trim()

--- a/web/docs/library/examples/patch.js
+++ b/web/docs/library/examples/patch.js
@@ -12,7 +12,6 @@ const updateCityName = async () => {
       .from('cities')
       .update({ name: 'Middle Earth' })
       .match({ name: 'Auckland' })
-
     return updates
   ${errorJs}
 `.trim()
@@ -23,8 +22,8 @@ const updateCityName = async () => {
   try {
     let cities = await supabase
       .from('cities')
-      .filter('name', 'eq', 'Paris')
       .update({ name: 'Mordor' })
+      .filter('name', 'eq', 'Paris')
     return cities
   ${errorJs}
 `.trim()
@@ -35,8 +34,8 @@ const updateCities = async () => {
   try {
     let cities = await supabase
       .from('cities')
-      .not('name', 'eq', 'Paris')
       .update({ name: 'Mordor' })
+      .not('name', 'eq', 'Paris')
     return cities
   ${errorJs}
 `.trim()
@@ -47,8 +46,8 @@ const updateCityName = async () => {
   try {
     let cities = await supabase
       .from('cities')
-      .match({name: 'Beijing', country_id: 156})
       .update({ name: 'Mordor' })
+      .match({name: 'Beijing', country_id: 156})
     return cities
   ${errorJs}
 `.trim()
@@ -59,8 +58,8 @@ const updateCityName = async () => {
   try {
     let cities = await supabase
       .from('cities')
-      .eq('name', 'San Francisco')
       .update({ name: 'Mordor' })
+      .eq('name', 'San Francisco')
     return cities
   ${errorJs}
 `.trim()
@@ -71,8 +70,8 @@ const updateCityName = async () => {
   try {
     let cities = await supabase
       .from('cities')
-      .neq('name', 'Lagos')
       .update({ name: 'Mordor' })
+      .neq('name', 'Lagos')
     return cities
   ${errorJs}
 `.trim()
@@ -83,8 +82,8 @@ const updateCityName = async () => {
   try {
     let cities = await supabase
       .from('cities')
-      .gt('country_id', 250)
       .update({ name: 'Mordor' })
+      .gt('country_id', 250)
     return cities
   ${errorJs}
 `.trim()
@@ -95,8 +94,8 @@ const updateCityName = async () => {
   try {
     let cities = await supabase
       .from('cities')
-      .lt('country_id', 250)
       .update({ name: 'Mordor' })
+      .lt('country_id', 250)
     return cities
   ${errorJs}
 `.trim()
@@ -107,8 +106,8 @@ const updateCityName = async () => {
   try {
     let cities = await supabase
       .from('cities')
-      .gte('country_id', 250)
       .update({ name: 'Mordor' })
+      .gte('country_id', 250)
     return cities
   ${errorJs}
 `.trim()
@@ -119,8 +118,8 @@ const updateCityName = async () => {
   try {
     let cities = await supabase
       .from('cities')
-      .lte('country_id', 250)
       .update({ name: 'Mordor' })
+      .lte('country_id', 250)
     return cities
   ${errorJs}
 `.trim()
@@ -131,12 +130,10 @@ const updateCityName = async () => {
   try {
     let cities = await supabase
       .from('cities')
-      .like('name', '%la%')
       .update({ name: 'Mordor' })
+      .like('name', '%la%')
     return cities
-  } catch (error) {
-    console.log('Error: ', error)
-  }
+  ${errorJs}
 }
 `.trim()
 
@@ -146,8 +143,8 @@ const updateCityName = async () => {
   try {
     let cities = await supabase
       .from('cities')
-      .ilike('name', '%la%')
       .update({ name: 'Mordor' })
+      .ilike('name', '%la%')
     return cities
   ${errorJs}
 `.trim()
@@ -158,8 +155,8 @@ const updateCityName = async () => {
   try {
     let cities = await supabase
       .from('cities')
-      .is('name', null)
       .update({ name: 'Mordor' })
+      .is('name', null)
     return cities
   ${errorJs}
 `.trim()
@@ -170,8 +167,8 @@ const updateCityName = async () => {
   try {
     let cities = await supabase
       .from('cities')
-      .in('name', ['Rio de Janeiro', 'San Francisco'])
       .update({ name: 'Mordor' })
+      .in('name', ['Rio de Janeiro', 'San Francisco'])
     return cities
   ${errorJs}
 `.trim()
@@ -182,8 +179,8 @@ const updateCountryName = async () => {
   try {
     let countries = await supabase
       .from('countries')
-      .cs('main_exports', ['oil'])
       .update({ name: 'Mordor' })
+      .cs('main_exports', ['oil'])
     return countries
   ${errorJs}
 `.trim()
@@ -194,8 +191,8 @@ const updateCountryName = async () => {
   try {
     let countries = await supabase
       .from('countries')
-      .cd('main_exports', ['cars', 'food', 'machine'])
       .update({ name: 'Mordor' })
+      .cd('main_exports', ['cars', 'food', 'machine'])
     return countries
   ${errorJs}
 `.trim()
@@ -206,8 +203,8 @@ const updateCountryName = async () => {
   try {
     let countries = await supabase
       .from('countries')
-      .ova('main_exports', ['computers', 'minerals'])
       .update({ name: 'Mordor' })
+      .ova('main_exports', ['computers', 'minerals'])
     return countries
   ${errorJs}
 `.trim()
@@ -218,8 +215,8 @@ const updateCountryName = async () => {
   try {
     let countries = await supabase
       .from('countries')
-      .ovr('population_range_millions', [150, 250])
       .update({ name: 'Mordor' })
+      .ovr('population_range_millions', [150, 250])
     return countries
   ${errorJs}
 `.trim()
@@ -230,8 +227,8 @@ const updateCountryName = async () => {
   try {
     let countries = await supabase
       .from('countries')
-      .sl('population_range_millions', [150, 250])
       .update({ name: 'Mordor' })
+      .sl('population_range_millions', [150, 250])
     return countries
   ${errorJs}
 `.trim()
@@ -242,8 +239,8 @@ const updateCountryName = async () => {
   try {
     let countries = await supabase
       .from('countries')
-      .sr('population_range_millions', [150, 250])
       .update({ name: 'Mordor' })
+      .sr('population_range_millions', [150, 250])
     return countries
   ${errorJs}
 `.trim()
@@ -254,8 +251,8 @@ const updateCountryName = async () => {
   try {
     let countries = await supabase
       .from('countries')
-      .nxl('population_range_millions', [150, 250])
       .update({ name: 'Mordor' })
+      .nxl('population_range_millions', [150, 250])
     return countries
   ${errorJs}
 `.trim()
@@ -266,8 +263,8 @@ const updateCountryName = async () => {
   try {
     let countries = await supabase
       .from('countries')
-      .nxr('population_range_millions', [150, 250])
       .update({ name: 'Mordor' })
+      .nxr('population_range_millions', [150, 250])
     return countries
   ${errorJs}
 `.trim()
@@ -278,8 +275,8 @@ const updateCountryName = async () => {
   try {
     let countries = await supabase
       .from('countries')
-      .adj('population_range_millions', [70, 185])
       .update({ name: 'Mordor' })
+      .adj('population_range_millions', [70, 185])
     return countries
   ${errorJs}
 `.trim()

--- a/web/docs/library/patch.mdx
+++ b/web/docs/library/patch.mdx
@@ -83,7 +83,7 @@ New record values.
 <CustomCodeBlock
   header="Shows how to use filter( ) with update( )"
   js={patchFilterJs}
-  jsHighlight="{9}"
+  jsHighlight="{10}"
   response={`{
   "body": [
     { "name": "Mordor", "country_id": 250 },
@@ -103,7 +103,7 @@ New record values.
 <CustomCodeBlock
   header="Shows how to use not( ) with update( )"
   js={patchNotJs}
-  jsHighlight="{9}"
+  jsHighlight="{10}"
   response={`{
   "body": [
     { "name": "Mordor", "country_id": 76 },
@@ -127,7 +127,7 @@ New record values.
 <CustomCodeBlock
   header="Shows how to use match( ) with update( )"
   js={patchMatchJs}
-  jsHighlight="{9}"
+  jsHighlight="{10}"
   response={`{
   "body": [
     { "name": "Mordor", "country_id": 156 },
@@ -147,7 +147,7 @@ New record values.
 <CustomCodeBlock
   header="Shows how to use eq( ) with update( )"
   js={patchEqJs}
-  jsHighlight="{9}"
+  jsHighlight="{10}"
   response={`{
   "body": [
     { "name": "Mordor", "country_id": 840 },
@@ -167,7 +167,7 @@ New record values.
 <CustomCodeBlock
   header="Shows how to use neq( ) with update( )"
   js={patchNeqJs}
-  jsHighlight="{9}"
+  jsHighlight="{10}"
   response={`{
   "body": [
     { "name": "Mordor", "country_id": 76 },
@@ -193,7 +193,7 @@ New record values.
 <CustomCodeBlock
   header="Shows how to use gt( ) with update( )"
   js={patchGtJs}
-  jsHighlight="{9}"
+  jsHighlight="{10}"
   response={`{
   "body": [
     { "name": "Mordor", "country_id": 554 },
@@ -216,7 +216,7 @@ New record values.
 <CustomCodeBlock
   header="Shows how to use lt( ) with update( )"
   js={patchLtJs}
-  jsHighlight="{9}"
+  jsHighlight="{10}"
   response={`{
   "body": [
     { "name": "Mordor", "country_id": 76 },
@@ -237,7 +237,7 @@ New record values.
 <CustomCodeBlock
   header="Shows how to use gte( ) with update( )"
   js={patchGteJs}
-  jsHighlight="{9}"
+  jsHighlight="{10}"
   response={`{
   "body": [
     { "name": "Mordor", "country_id": 250 },
@@ -261,7 +261,7 @@ New record values.
 <CustomCodeBlock
   header="Shows how to use lte( ) with update( )"
   js={patchLteJs}
-  jsHighlight="{9}"
+  jsHighlight="{10}"
   response={`{
   "body": [
     { "name": "Mordor", "country_id": 76 },
@@ -283,7 +283,7 @@ New record values.
 <CustomCodeBlock
   header="Shows how to use like( ) with update( )"
   js={patchLikeJs}
-  jsHighlight="{9}"
+  jsHighlight="{10}"
   response={`{
   "body": [
     { "name": "Mordor", "country_id": 554 },
@@ -303,7 +303,7 @@ New record values.
 <CustomCodeBlock
   header="Shows how to use ilike( ) with update( )"
   js={patchIlikeJs}
-  jsHighlight="{9}"
+  jsHighlight="{10}"
   response={`{
   "body": [
     { "name": "Mordor", "country_id": 554 },
@@ -324,7 +324,7 @@ New record values.
 <CustomCodeBlock
   header="Shows how to use is( ) with update( )"
   js={patchIsJs}
-  jsHighlight="{9}"
+  jsHighlight="{10}"
   response={`{
   "body": [
   ],
@@ -343,7 +343,7 @@ New record values.
 <CustomCodeBlock
   header="Shows how to use in( ) with update( )"
   js={patchInJs}
-  jsHighlight="{9}"
+  jsHighlight="{10}"
   response={`{
   "body": [
     { "name": "Mordor", "country_id": 76 },
@@ -364,7 +364,7 @@ New record values.
 <CustomCodeBlock
   header="Shows how to use cs( ) with update( )"
   js={patchCsJs}
-  jsHighlight="{9}"
+  jsHighlight="{10}"
   response={`{
   "body": [
     { "id": 556,
@@ -393,7 +393,7 @@ New record values.
 <CustomCodeBlock
   header="Shows how to use cd( ) with update( )"
   js={patchCdJs}
-  jsHighlight="{9}"
+  jsHighlight="{10}"
   response={`{
   "body": [
     { "id": 250,
@@ -422,7 +422,7 @@ New record values.
 <CustomCodeBlock
   header="Shows how to use ova( ) with update( )"
   js={patchOvaJs}
-  jsHighlight="{9}"
+  jsHighlight="{10}"
   response={`{
   "body": [
     { "id": 76,
@@ -451,7 +451,7 @@ New record values.
 <CustomCodeBlock
   header="Shows how to use ovr( ) with update( )"
   js={patchOvrJs}
-  jsHighlight="{9}"
+  jsHighlight="{10}"
   response={`{
   "body": [
     { "id": 76,
@@ -480,7 +480,7 @@ New record values.
 <CustomCodeBlock
   header="Shows how to use sl( ) with update( )"
   js={patchSlJs}
-  jsHighlight="{9}"
+  jsHighlight="{10}"
   response={`{
   "body": [
     { "id": 250,
@@ -509,7 +509,7 @@ New record values.
 <CustomCodeBlock
   header="Shows how to use sr( ) with update( )"
   js={patchSrJs}
-  jsHighlight="{9}"
+  jsHighlight="{10}"
   response={`{
   "body": [
     { "id": 156,
@@ -538,7 +538,7 @@ New record values.
 <CustomCodeBlock
   header="Shows how to use nxl( ) with update( )"
   js={patchNxlJs}
-  jsHighlight="{9}"
+  jsHighlight="{10}"
   response={`{
   "body": [
     { "id": 76,
@@ -577,7 +577,7 @@ New record values.
 <CustomCodeBlock
   header="Shows how to use nxr( ) with update( )"
   js={patchNxrJs}
-  jsHighlight="{9}"
+  jsHighlight="{10}"
   response={`{
   "body": [
     { "id": 76,
@@ -616,7 +616,7 @@ New record values.
 <CustomCodeBlock
   header="Shows how to use adj( ) with update( )"
   js={patchAdjJs}
-  jsHighlight="{9}"
+  jsHighlight="{10}"
   response={`{
   "body": [
     { "id": 250,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix the chaining order for the documentation on `update` and `delete`. As @thorsten-stripe pointed out in the issue below, the filter calls should be after `update` and `delete`.

## Additional context

Link to issue: https://github.com/supabase/supabase/issues/160
