### PR TITLE
Update the wording for selecting all columns

### DIFF
--- a/web/docs/library/get.mdx
+++ b/web/docs/library/get.mdx
@@ -204,7 +204,7 @@ Also see [PostgREST](http://postgrest.org/en/v7.0.0/api.html#json-columns) docs 
 supabase.from(tableName).select(columnQuery)
 ```
 
-If not used, all columns in the table will be returned.
+If `'*'` is passd in for `columnQuery`(i.e. `.select('*')`) then all columns in the table will be returned.
 
 #### `columnQuery: string`
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Update the wording for the `.select()` call syntax to return all columns.

https://github.com/supabase/supabase-js/issues/27