### PR TITLE
add security.txt

### DIFF
--- a/web/static/.well-known/security.txt
+++ b/web/static/.well-known/security.txt
@@ -1,0 +1,2 @@
+Contact: security@supabase.io
+Canonical: https://supabase.io/.well-known/security.txt


### PR DESCRIPTION
## What kind of change does this PR introduce?

[Security.txt](https://securitytxt.org/) is the standardised way to make it easy for security researchers to report problems with Supabase.

Let's add other supported keys like link to jobs page, our hall of fame page, vulnerability disclosure policy as we go on. 
