### PR TITLE
cache static assets for 3 hours at least

### DIFF
--- a/web/_headers
+++ b/web/_headers
@@ -1,0 +1,23 @@
+/*.css
+  Cache-Control: public, max-age=10800
+
+/*.js
+  Cache-Control: public, max-age=10800
+
+/*.png
+  Cache-Control: public, max-age=10800
+
+/*.jpg
+  Cache-Control: public, max-age=10800
+
+/*.svg
+  Cache-Control: public, max-age=10800
+
+/*.gif
+  Cache-Control: public, max-age=10800
+
+/*front-integration-plugin.png
+  Cache-Control: public, max-age=100, s-maxage=10800
+
+/*
+  X-Frame-Options: DENY

--- a/web/static/_headers
+++ b/web/static/_headers
@@ -16,8 +16,5 @@
 /*.gif
   Cache-Control: public, max-age=10800
 
-/*front-integration-plugin.png
-  Cache-Control: public, max-age=100, s-maxage=10800
-
 /*
   X-Frame-Options: DENY


### PR DESCRIPTION
## What kind of change does this PR introduce?

Netlify's default caching policy doesn't cache anything on the browser. It sends `public, max-age=0, must-revalidate`) I have added a _headers file which is the way to tell Netlify to send custom headers. 