### PR TITLE
fixing typo in supabase.js 1.0 blogpost

### DIFF
--- a/web/blog/2020-10-30-improved-dx.md
+++ b/web/blog/2020-10-30-improved-dx.md
@@ -53,7 +53,7 @@ After testing this for a while we're very happy with this pattern. Errors are ha
 
 Our goal for `supabase-js` is to tie together many sub-libaries. Each sub-library is a standalone implementation for a single external system. This is one of the ways we support existing open source tools.
 
-To maintain this philosophy, we created [`gotrue-js`](https://github.com/supabase/goture-js), a library for Netlify's GoTrue auth server. This libary includes a number of new additions, including third-party logins.
+To maintain this philosophy, we created [`gotrue-js`](https://github.com/supabase/gotrue-js), a library for Netlify's GoTrue auth server. This libary includes a number of new additions, including third-party logins.
 
 Previously:
 


### PR DESCRIPTION
fixing typo

## What kind of change does this PR introduce?

typo fix

## Additional context

as an ex netlify employee, the naming is a little unfortunate since netlify's own gotrue-js already exists. no doubt you are already aware of it but my pref would have been for a diff name
