### PR TITLE
Fix typo in Supabase alpha November 2020 blog

### DIFF
--- a/web/blog/2020-12-01-supabase-alpha-november-2020.md
+++ b/web/blog/2020-12-01-supabase-alpha-november-2020.md
@@ -11,7 +11,7 @@ tags:
     - supabase
 ---
 
-We've been building for 9 months now, are we're getting even closer to Beta. 
+We've been building for 9 months now, and we're getting even closer to Beta. 
 
 <!--truncate-->
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix a typo in the 2020-12-01 Supabase alpha November 2020 blog.
