### PR TITLE
vue3-ts-todo: make user sessions persistent upon refresh

### DIFF
--- a/examples/vue3-ts-todo-list/src/App.vue
+++ b/examples/vue3-ts-todo-list/src/App.vue
@@ -40,6 +40,19 @@ export default {
     Footer,
   },
   setup() {
+    // Get the auth token in the local storage.
+    const json = localStorage.getItem('supabase.auth.token')
+    if (json) {
+      const data = JSON.parse(json)    
+      const { currentSession, expiresAt } = data
+      const timeNow = Math.round(Date.now() / 1000)
+      // If it hasn't expired yet, update userSession.
+      if (timeNow < expiresAt) {
+        userSession.value = currentSession
+      }
+    }
+    // NOTE: The pattern above is similar to that of the _recoverSession() function
+    // in supabase/gotrue-js: https://github.com/supabase/gotrue-js/blob/dc6cf10dcac016ba4831efdb9b8683bda109dab0/src/GoTrueClient.ts#L328
     return { userSession, handleLogout }
   },
 }

--- a/examples/vue3-ts-todo-list/src/vuetils/useTodo.ts
+++ b/examples/vue3-ts-todo-list/src/vuetils/useTodo.ts
@@ -9,6 +9,11 @@ const allTodos = ref<Todo[]>([])
  */
 async function fetchTodos() {
   try {
+    // Wait for the supabase client to be fully initialized
+    // before making the following query. Without this line,
+    // this query would return an empty array.
+    await supabase
+    
     const { data: todos, error } = await supabase
       .from('todos')
       .select('*')


### PR DESCRIPTION
### Step 1

Before this PR, vue3-ts-todo-list did not have a persistent user session upon refresh. Whenever you refresh the app, you were forced to log out.

I did a bunch of digging on this issue, and here's my theory about why this was happening.

When supabase.auth (an instance of GoTrueClient) is created, [a locally stored session is recovered](https://github.com/supabase/gotrue-js/blob/946d5d53f86c74d5b7388bbe90ce0dac06d216bd/src/GoTrueClient.ts#L57).

At first glance, it seems like this app *should be able to* capture this event since we have an onAuthStateChange listener [here](https://github.com/supabase/supabase/blob/master/examples/vue3-ts-todo-list/src/main.ts#L12).

However, based on my observation, it is not able to.

I think the reason might be that this listener depends on supabase.auth being initialized first. However, once it's initialized, the event has already happened - so the event listner won't be triggered.

To get around this issue, in this particular implementation, I decided to manually retrieve the auth token in the local storage. Then, I manually update the userSession assuming that it hasn't expired yet [here](https://github.com/supabase/supabase/compare/master...ykdojo:master#diff-dd297337cd5b129d9006db587cdaedaed616d4945ed90effe6340b8a2a72e295R51).

This is not the most elegant approach, but it seems to work well. Perhaps we can think about restructuring some of our client code so that our future users won't have to do the same.

### Step 2

Once I fixed this, I then had a new problem of [the main query of this app](https://bit.ly/3oQ3Hbi) returning an empty array. When I examined it, it seemed to be happening because the query was being run before the supabase.auth client was fully initialized (no user session).

To fix this, I decided to add [this line](https://github.com/supabase/supabase/compare/master...ykdojo:master#diff-fca20070a45693b7a4a67646e7ca5ee40c877315e5b81538fb8233c29ddd527cR15). It works, but I'm not 100% confident about this approach. I would appreciate anyone's feeback on it.

My hypothesis about why this problem was occurring in the first place is because part of supabase.auth (GoTrueClient)'s constructor is [an async function](https://github.com/supabase/gotrue-js/blob/dc6cf10dcac016ba4831efdb9b8683bda109dab0/src/GoTrueClient.ts#L328). (Of course, I could be wrong.)

[A comment on that function](https://github.com/supabase/gotrue-js/blob/dc6cf10dcac016ba4831efdb9b8683bda109dab0/src/GoTrueClient.ts#L329) says that it's for accomodating React Native - so I guess it's important?

Anyway, I'm not sure what a good long-term strategy would be here. I'd love to know what other people think.