### PR TITLE
Regenerated client docs

### DIFF
--- a/web/docs/client/filter.mdx
+++ b/web/docs/client/filter.mdx
@@ -256,12 +256,10 @@ const { data, error } = await supabase
 <TabItem value="js">
 
 ```js
-export const getFilterJsEmbedded = `
 const { data, error } = await supabase
   .from('cities')
   .select('name, countries ( name )')
   .filter('countries.name', 'eq', 'France')
-`.trim()
 ```
 
 

--- a/web/docs/client/insert.mdx
+++ b/web/docs/client/insert.mdx
@@ -87,27 +87,6 @@ No description provided.
 <li className="method-list-item">
   <h4 className="method-list-item-label">
     <span className="method-list-item-label-name">
-      onConflict
-    </span>
-    <span className="method-list-item-label-badge required">
-      required
-    </span>
-    <span className="method-list-item-validation">
-       | 
-    </span>
-  </h4>
-  <div class="method-list-item-description">
-
-By specifying the `on_conflict` query parameter, you can make UPSERT work on a column(s) that has a UNIQUE constraint.
-  
-  </div>
-  
-</li>
-
-
-<li className="method-list-item">
-  <h4 className="method-list-item-label">
-    <span className="method-list-item-label-name">
       upsert
     </span>
     <span className="method-list-item-label-badge required">
@@ -120,6 +99,27 @@ By specifying the `on_conflict` query parameter, you can make UPSERT work on a c
   <div class="method-list-item-description">
 
 If `true`, performs an UPSERT.
+  
+  </div>
+  
+</li>
+
+
+<li className="method-list-item">
+  <h4 className="method-list-item-label">
+    <span className="method-list-item-label-name">
+      onConflict
+    </span>
+    <span className="method-list-item-label-badge required">
+      required
+    </span>
+    <span className="method-list-item-validation">
+       | 
+    </span>
+  </h4>
+  <div class="method-list-item-description">
+
+By specifying the `on_conflict` query parameter, you can make UPSERT work on a column(s) that has a UNIQUE constraint.
   
   </div>
   

--- a/web/docs/client/order.mdx
+++ b/web/docs/client/order.mdx
@@ -86,7 +86,7 @@ No description provided.
 <li className="method-list-item">
   <h4 className="method-list-item-label">
     <span className="method-list-item-label-name">
-      ascending
+      nullsFirst
     </span>
     <span className="method-list-item-label-badge required">
       required
@@ -97,7 +97,7 @@ No description provided.
   </h4>
   <div class="method-list-item-description">
 
-If `true`, the result will be in ascending order.
+If `true`, `null`s appear first.
   
   </div>
   
@@ -128,7 +128,7 @@ The foreign table to use (if `column` is a foreign column).
 <li className="method-list-item">
   <h4 className="method-list-item-label">
     <span className="method-list-item-label-name">
-      nullsFirst
+      ascending
     </span>
     <span className="method-list-item-label-badge required">
       required
@@ -139,7 +139,7 @@ The foreign table to use (if `column` is a foreign column).
   </h4>
   <div class="method-list-item-description">
 
-If `true`, `null`s appear first.
+If `true`, the result will be in ascending order.
   
   </div>
   


### PR DESCRIPTION
Regenerated client docs with the following command in web:

ts-node ReferenceGenerator.ts -o docs/client spec/supabase.yml

It seems like the only changes it made were changing the order of the parameters for some reason.