### PR TITLE
docs/specs: correct typos

### DIFF
--- a/web/docs/gotrue/client/api-refreshaccesstoken.mdx
+++ b/web/docs/gotrue/client/api-refreshaccesstoken.mdx
@@ -53,7 +53,7 @@ A valid refresh token that was returned on login.
 
 ## Examples
 
-### Get a new access and refresh token using a valied refresh_token
+### Get a new access and refresh token using a valid refresh_token
 
 
 

--- a/web/docs/realtime/server/about.md
+++ b/web/docs/realtime/server/about.md
@@ -29,7 +29,7 @@ A few reasons:
 #### What are the benefits?
 
 1. The beauty of listening to the replication functionality is that you can make changes to your database from anywhere - your API, directly in the DB, via a console etc - and you will still receive the changes via websockets.
-2. Decoupling. For example, if you want to send a new slack message every time someone makes a new purchase you might build that funcitonality directly into your API. This allows you to decouple your async functionality from your API.
+2. Decoupling. For example, if you want to send a new slack message every time someone makes a new purchase you might build that functionality directly into your API. This allows you to decouple your async functionality from your API.
 3. This is built with Phoenix, an [extremely scalable Elixir framework](https://www.phoenixframework.org/blog/the-road-to-2-million-websocket-connections)
 
 
@@ -57,7 +57,7 @@ There are a some requirements for your database
    1. it must have the `wal_level` set to logical. You can check this by running `SHOW wal_level;`. To set the `wal_level`, you can call `ALTER SYSTEM SET wal_level = logical;`
    2. You must set `max_replication_slots` to at least 1: `ALTER SYSTEM SET max_replication_slots = 5;`
 3. Create a `PUBLICATION` for this server to listen to: `CREATE PUBLICATION supabase_realtime FOR ALL TABLES;`
-4. [OPTIONAL] If you want to recieve the old record (previous values) on UDPATE and DELETE, you can set the `REPLICA IDENTITY` to `FULL` like this: `ALTER TABLE your_table REPLICA IDENTITY FULL;`. This has to be set for each table unfortunately.
+4. [OPTIONAL] If you want to receive the old record (previous values) on UDPATE and DELETE, you can set the `REPLICA IDENTITY` to `FULL` like this: `ALTER TABLE your_table REPLICA IDENTITY FULL;`. This has to be set for each table unfortunately.
 
 ### Server set up
 

--- a/web/spec/gotrue.yml
+++ b/web/spec/gotrue.yml
@@ -259,7 +259,7 @@ pages:
   api.refreshAccessToken:
     $ref: '"GoTrueApi".GoTrueApi.refreshAccessToken'
     examples:
-      - name: Get a new access and refresh token using a valied refresh_token
+      - name: Get a new access and refresh token using a valid refresh_token
         js: |
           ```js
           const { error, data } = await api


### PR DESCRIPTION
## What kind of change does this PR introduce?

It is an update to the docs/specs of the GoTrue-Client (api-refreshAccessToken) and the docs of the realtime-server (about.md).

## What is the current behavior?

There are some typos.

## What is the new behavior?

Said typos have been fixed.
