### PR TITLE
Fix create-next-app example URL

### DIFF
--- a/examples/nextjs-with-supabase-auth/README.md
+++ b/examples/nextjs-with-supabase-auth/README.md
@@ -11,9 +11,9 @@ This example shows how to use Supabase auth both on the client (`useUser` hook f
 Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/) or [npx](https://github.com/zkat/npx#readme) to bootstrap the example:
 
 ```bash
-npx create-next-app --example https://github.com/supabase/supabase/tree/master/examples/with-supabase-auth with-supabase-auth-app
+npx create-next-app --example https://github.com/supabase/supabase/tree/master/examples/nextjs-with-supabase-auth with-supabase-auth-app
 # or
-yarn create next-app --example https://github.com/supabase/supabase/tree/master/examples/with-supabase-auth with-supabase-auth-app
+yarn create next-app --example https://github.com/supabase/supabase/tree/master/examples/nextjs-with-supabase-auth with-supabase-auth-app
 ```
 
 ## Configuration


### PR DESCRIPTION
## What kind of change does this PR introduce?

Updates an example using `create-next-app` to make copying and pasting the command work correctly.

## What is the current behavior?

Copying and pasting the example URL resulted in an error:
```
Could not locate the repository for "https://github.com/supabase/supabase/tree/master/examples/with-supabase-auth". Please check that the repository exists and try again.
```

## What is the new behavior?

This fixes the path to the directory, making `create-next-app` work again. I tested it with both `npx` and `yarn`.
