### PR TITLE
Add `✏ Edit this page` links to doc pages

### DIFF
--- a/web/ReferenceGenerator.ts
+++ b/web/ReferenceGenerator.ts
@@ -51,7 +51,7 @@ async function gen(inputFileName, outputDir) {
 
   // Index Page
   const indexFilename = outputDir + `/index.mdx`
-  const index = generateDocsIndexPage(docSpec)
+  const index = generateDocsIndexPage(docSpec, inputFileName)
   await writeToDisk(indexFilename, index)
   console.log('The index was saved: ', indexFilename)
 
@@ -70,6 +70,7 @@ async function gen(inputFileName, outputDir) {
       const content = Page({
         slug,
         id: slug,
+        specFileName: inputFileName,
         title: pageSpec.title || pageSpec.pageName,
         description,
         parameters: hasTsRef ? generateParameters(tsDefinition) : '',
@@ -156,7 +157,7 @@ const methodListItemLabel = ({ name, isOptional, type, description }, subContent
   <div class="method-list-item-description">
 
 ${description ? description : 'No description provided. '}
-  
+
   </div>
   ${subContent}
 </li>
@@ -244,11 +245,12 @@ function generateSidebar(docSpec: any) {
   return Sidebar(categories)
 }
 
-function generateDocsIndexPage(docSpec: any) {
+function generateDocsIndexPage(docSpec: any, inputFileName: string) {
   return Page({
     slug: slugify(docSpec.info.title),
     id: 'index',
     title: docSpec.info.title,
+    specFileName: inputFileName,
     description: docSpec.info.description,
   })
 }

--- a/web/docusaurus.config.js
+++ b/web/docusaurus.config.js
@@ -230,7 +230,7 @@ module.exports = {
       {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
-          editUrl: 'https://github.com/supabase/supabase/edit/master/web/',
+          editUrl: 'https://github.com/supabase/supabase/edit/master/web',
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),

--- a/web/docusaurus.config.js
+++ b/web/docusaurus.config.js
@@ -230,6 +230,7 @@ module.exports = {
       {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
+          editUrl: 'https://github.com/supabase/supabase/edit/master/web/',
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),

--- a/web/spec/gen/components/Page.ts
+++ b/web/spec/gen/components/Page.ts
@@ -1,7 +1,10 @@
+const EDIT_BASE_URL = 'https://github.com/supabase/supabase/edit/master/web';
+
 type PageParmas = {
   id: string
   title: string
   slug: string
+  specFileName: string
   description?: string
   parameters?: string
   examples?: string[]
@@ -15,6 +18,7 @@ const Page = ({
   id,
   title,
   slug,
+  specFileName,
   description = '',
   parameters = '',
   examples = [],
@@ -28,6 +32,7 @@ const Page = ({
 id: ${id}
 title: "${title}"
 slug: ${slug}
+custom_edit_url: ${EDIT_BASE_URL}/${specFileName}
 ---
 
 import Tabs from '@theme/Tabs';


### PR DESCRIPTION
This pull request make a single change to Docusaurus config to enable the `Edit this page` links at the end of **all pages** in the docs site. I think this reduces friction and makes it easy for contributors to make changes on the spot easily through pull requests.

From this [pull](https://github.com/supabase/supabase/pull/429) it appears you are auto generating some parts of the docs though 🤔. I am not familiar enough with Docusaurus or how you generate the docs at this time but, could we somehow mark the auto-generated parts inside source files to warn contributors?

## Additional context

See: [https://v2.docusaurus.io/docs/migration/manual/#customdocspath-docsurl-editurl-enableupdateby-enableupdatetime](https://v2.docusaurus.io/docs/migration/manual/#customdocspath-docsurl-editurl-enableupdateby-enableupdatetime)

![image](https://user-images.githubusercontent.com/21214427/103379696-901b0700-4af7-11eb-80f3-8c62a7c35a5f.png)


