### PR TITLE
docs: update properties order on parameters section

### DIFF
--- a/web/docs/client/auth-signup.mdx
+++ b/web/docs/client/auth-signup.mdx
@@ -40,95 +40,67 @@ const { user, error } = await supabase.auth.signUp({
 
 
 <ul className="method-list-group">
-  
-<li className="method-list-item">
-  <h4 className="method-list-item-label">
-    <span className="method-list-item-label-name">
+  <li className="method-list-item">
+    <h4 className="method-list-item-label">
+      <span className="method-list-item-label-name">
       credentials
-    </span>
-    <span className="method-list-item-label-badge required">
+      </span>
+      <span className="method-list-item-label-badge required">
       required
-    </span>
-    <span className="method-list-item-validation">
+      </span>
+      <span className="method-list-item-validation">
       <code>object</code>
-    </span>
-  </h4>
-  <div class="method-list-item-description">
-
-The user login details.
-  
-  </div>
-  
-<ul className="method-list-group">
-  <h5 class="method-list-title method-list-title-isChild expanded">Properties</h5>
-
-<li className="method-list-item">
-  <h4 className="method-list-item-label">
-    <span className="method-list-item-label-name">
-      password
-    </span>
-    <span className="method-list-item-label-badge required">
-      required
-    </span>
-    <span className="method-list-item-validation">
-      <code>string</code>
-    </span>
-  </h4>
-  <div class="method-list-item-description">
-
-The user's password.
-  
-  </div>
-  
-</li>
-
-
-<li className="method-list-item">
-  <h4 className="method-list-item-label">
-    <span className="method-list-item-label-name">
-      email
-    </span>
-    <span className="method-list-item-label-badge required">
-      required
-    </span>
-    <span className="method-list-item-validation">
-      <code>string</code>
-    </span>
-  </h4>
-  <div class="method-list-item-description">
-
-The user's email address.
-  
-  </div>
-  
-</li>
-
+      </span>
+    </h4>
+    <div class="method-list-item-description">
+      The user login details.
+    </div>
+    <ul className="method-list-group">
+      <h5 class="method-list-title method-list-title-isChild expanded">Properties</h5>
+      <li className="method-list-item">
+        <h4 className="method-list-item-label">
+          <span className="method-list-item-label-name">
+          email
+          </span>
+          <span className="method-list-item-label-badge required">
+          required
+          </span>
+          <span className="method-list-item-validation">
+          <code>string</code>
+          </span>
+        </h4>
+        <div class="method-list-item-description">
+          The user's email address.
+        </div>
+      </li>
+      <li className="method-list-item">
+        <h4 className="method-list-item-label">
+          <span className="method-list-item-label-name">
+          password
+          </span>
+          <span className="method-list-item-label-badge required">
+          required
+          </span>
+          <span className="method-list-item-validation">
+          <code>string</code>
+          </span>
+        </h4>
+        <div class="method-list-item-description">
+          The user's password.
+        </div>
+      </li>
+    </ul>
+  </li>
 </ul>
-
-</li>
-
-</ul>
-
 
 ## Notes
 
 - By default, the user will need to verify their email address before logging in. If you would like to change this, you can disable email confirmations by going to Authentication -> Settings on [app.supabase.io](https://app.supabase.io)
 - When the user confirms their email address, they will be redirected to localhost:3000 by default. To change this, you can go to Authentication -> Settings on [app.supabase.io](https://app.supabase.io)
 
-
-
-
-
-
-
-
-
-
 ## Examples
 
 ### Sign up
-
-
 
 <Tabs
   defaultValue="js"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Documentation update

## What is the current behavior?

We have two code samples and these parameters on this page, but the properties of the parameters are in a different order.

## What is the new behavior?

Change the properties order to be consistent as our code examples.

## Additional context

As we're using in both examples the properties in another order I would like to propose this small change to be consistent in all places of this page.
