### PR TITLE
Fixed wrong heading for getSubscriptions() example

### DIFF
--- a/web/spec/supabase.yml
+++ b/web/spec/supabase.yml
@@ -827,7 +827,7 @@ pages:
     title: 'getSubscriptions()'
     $ref: '@supabase/supabase-js."SupabaseClient".SupabaseClient.getSubscriptions'
     examples:
-      - name: Remove a subscription
+      - name: Get all subscriptions
         isSpotlight: true
         js: |
           ```js


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

Header of getSubscriptions() example says "Remove subscription"

## What is the new behavior?

Changed Header to "Get all subscriptions"

## Additional context

This was probably caused by copy paste from the previous method.

![image](https://user-images.githubusercontent.com/5441654/106026605-545d6800-60ca-11eb-9a82-a7764d71b793.png)

