### PR TITLE
docs: added Azure and Facebook to 3rd Party Logins

### DIFF
--- a/web/docs/guides/auth.mdx
+++ b/web/docs/guides/auth.mdx
@@ -23,6 +23,8 @@ We currently support the following OAuth providers:
 - Google
 - Github
 - Gitlab
+- Azure
+- Facebook
 - Bitbucket
 
 ![OAuth Logins.](/img/supabase-oauth-logins.png)


### PR DESCRIPTION


## What kind of change does this PR introduce?

referring to [January 2021 News](https://supabase.io/blog/2021/02/02/supabase-beta-january-2021)

## What is the current behavior?

There is no current behavior.

## What is the new behavior?

I added two new Auth Providers in docs.

