### PR TITLE
FIX: Stop calling .user() like an async function

### DIFF
--- a/web/spec/supabase.yml
+++ b/web/spec/supabase.yml
@@ -322,7 +322,7 @@ pages:
         isSpotlight: true
         js: |
           ```js
-          const user = await supabase.auth.user()
+          const user = supabase.auth.user()
           ```
         py: |
           ```py


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

Current docs suggest calling `supabase.auth.user()` like an async function.

## What is the new behavior?

Don't imply that `supabase.auth.user()` returns a promise.

## Additional context

The Typescript defs already warn that `supabase.auth.user()` is a synchronous function if it is called with `await` (and won't  cause errors unless you want to chain it) but I am starting to see tutorials propagating this error. 
