### PR TITLE
fix: overlapping backer images

### DIFF
--- a/www/components/Hero.tsx
+++ b/www/components/Hero.tsx
@@ -55,23 +55,23 @@ const Hero = () => {
                         url="https://app.supabase.io/api/login"
                       />
                       <p className="mt-8 text-sm text-dark-400 tracking-wide sm:mt-10">backed by</p>
-                      <div className="mt-5 w-full sm:mx-auto sm:max-w-lg lg:ml-0">
-                        <div className="flex flex-wrap items-center lg:justify-start">
+                      <div className="mt-5 w-full sm:max-w-lg lg:ml-0">
+                        <div className="flex flex-wrap items-center justify-start">
                           <img
-                            className="h-8 sm:h-10 pr-10"
+                            className="h-8 sm:h-10 pr-10 mb-5"
                             src={`${basePath}/images/logos/yc--grey.png`}
                             alt="Y Combinator"
                           />
                           <img
-                            className="relative -top-1 h-5 sm:h-7 pr-10"
+                            className="relative h-5 sm:h-7 pr-10 mb-5"
                             src={`${basePath}/images/logos/mozilla--grey.png`}
                             alt="Mozilla"
                           />
-                          {/* <img
-                            className="relative -top-1 h-5 sm:h-7 pr-10"
+                          <img
+                            className="relative h-5 sm:h-7 pr-10 mb-5"
                             src={`${basePath}/images/logos/coatue.png`}
                             alt="Coatue"
-                          /> */}
+                          />
                         </div>
                       </div>
                     </div>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix: Coatue image was overlapping other backer images when it was introduced and has since been commented out.  This PR re-introduces the Coatue image and adds some bottom margin on all backer images. 

While this _works_, as the number of backers increase, it may be better to use something other than flexbox to contain these images. Additionally, there is inherently some additional margin (some of which could be negated if we added a `xs` breakpoint). 

Image alignment was also modified to have all backer images aligned vertically (there was previously some top positioning) 

## What is the current behavior?

This is described in issue #722

## What is the new behavior?

Desktop view:
![image](https://user-images.githubusercontent.com/49932437/108107390-c9cab180-7054-11eb-9d78-ea524a098ef4.png)
Mobile view:
![image](https://user-images.githubusercontent.com/49932437/108107470-e8c94380-7054-11eb-86df-cbc21d386e85.png)


## Additional context

Add any other context or screenshots.
