### PR TITLE
try disabling hsts

### DIFF
--- a/vercel-local.json
+++ b/vercel-local.json
@@ -1,4 +1,15 @@
 {
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Strict-Transport-Security",
+          "value": ""
+        }
+      ]
+    }
+  ],
   "rewrites": [
     { "source": "/new/:match*", "destination": "http://localhost:3000/new/:match*" },
     { "source": "/", "destination": "http://localhost:3000/new" },

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,15 @@
 {
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Strict-Transport-Security",
+          "value": ""
+        }
+      ]
+    }
+  ],
   "rewrites": [
     { "source": "/new/:match*", "destination": "https://www.supabase.vercel.app/new/:match*" },
     { "source": "/", "destination": "https://www.supabase.vercel.app/new" },


### PR DESCRIPTION
hsts does a 307 which does not preserve referrer header. If this is disabled, vercel will send a 308 which will preserve the referrer header (i think)