### PR TITLE
Ui Fix : Doc searchBar icon not showing

### DIFF
--- a/web/src/css/custom.css
+++ b/web/src/css/custom.css
@@ -806,7 +806,7 @@ a.hash-link {
 .DocSearch-Button {
   border-radius: 8px !important;
 }
-.DocSearch-Button svg {
+.DocSearch-Button>svg {
   display: none;
 }
 .DocSearch-Button-Placeholder {


### PR DESCRIPTION
Hope you try to hide only the circular search icon on docs, if you also want to show circular search icon, let me know as well

![uiError](https://user-images.githubusercontent.com/24385409/108456466-662fc680-7296-11eb-92d0-292c2cc7378e.png)



**After change** It's missing  **CTRL** icon

![uiError](https://user-images.githubusercontent.com/24385409/108456731-f706a200-7296-11eb-8030-9229a86b5d45.png)
