### PR TITLE
Added Quick Start info in Examples

### DIFF
--- a/examples/expo-todo-list/README.md
+++ b/examples/expo-todo-list/README.md
@@ -12,7 +12,7 @@ Sign up to Supabase - [https://app.supabase.io](https://app.supabase.io) and cre
 
 ### 2. Run "Todo List" Quickstart
 
-Once your database has started, run the "Todo List" quickstart.
+Once your database has started, run the "Todo List" quickstart. Inside of your project, enter the `SQL editor` tab and scroll down until you see `TODO LIST: Build a basic todo list with Row Level Security`.
 
 ### 3. Get the URL and Key
 

--- a/examples/nextjs-todo-list/README.md
+++ b/examples/nextjs-todo-list/README.md
@@ -25,7 +25,7 @@ Sign up to Supabase - [https://app.supabase.io](https://app.supabase.io) and cre
 
 ### 2. Run "Todo List" Quickstart
 
-Once your database has started, run the "Todo List" quickstart.
+Once your database has started, run the "Todo List" quickstart. Inside of your project, enter the `SQL editor` tab and scroll down until you see `TODO LIST: Build a basic todo list with Row Level Security`.
 
 ### 3. Get the URL and Key
 

--- a/examples/react-todo-list/README.md
+++ b/examples/react-todo-list/README.md
@@ -24,7 +24,7 @@ Sign up to Supabase - [https://app.supabase.io](https://app.supabase.io) and cre
 
 ### 2. Run "Todo List" Quickstart
 
-Once your database has started, run the "Todo List" quickstart.
+Once your database has started, run the "Todo List" quickstart. Inside of your project, enter the `SQL editor` tab and scroll down until you see `TODO LIST: Build a basic todo list with Row Level Security`  
 
 ### 3. Get the URL and Key
 

--- a/examples/vue3-ts-todo-list/README.md
+++ b/examples/vue3-ts-todo-list/README.md
@@ -14,7 +14,7 @@ Sign up to Supabase - [https://app.supabase.io](https://app.supabase.io) and cre
 
 ### 2. Run "Todo List" Quickstart
 
-Once your database has started, run the "Todo List" quickstart.
+Once your database has started, run the "Todo List" quickstart. Inside of your project, enter the `SQL editor` tab and scroll down until you see `TODO LIST: Build a basic todo list with Row Level Security`.
 
 ### 3. Get the URL and Key
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs Update: The examples require Quick Starts, but instructions on how to run these were too brief.

## What is the current behavior?

New users are unable to find the "Quick Start"s as mentioned in the example README.md's, getting stuck.

## What is the new behavior?

Readme.md now tells users where to find the Quick Starts. in the future a screenshot similar to the one used in the [Slack Scone example](https://github.com/supabase/supabase/tree/master/examples/nextjs-slack-clone) might also be a good idea.

## Additional context

I had trouble with the examples because I just assumed Quick Starts were TBA, and these were just being updated. That is until I realized that you had to run them from `https://app.supabase.io/`. So I'm just forking this in, hoping to save a few headaches.
