### PR TITLE
Set JWT_DEFAULT_GROUP_NAME in docker-compose

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       environment:
         GOTRUE_JWT_SECRET: super-secret-jwt-token
         GOTRUE_JWT_EXP: 3600
+        GOTRUE_JWT_DEFAULT_GROUP_NAME: authenticated
         GOTRUE_DB_DRIVER: postgres
         DB_NAMESPACE: auth
         API_EXTERNAL_URL: localhost


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

With the current docker-compose configuration, the JWT issued by
gotrue after a successful login or singup contains an empty role string.

https://github.com/supabase/supabase/issues/804

## What is the new behavior?

Specifying
`GOTRUE_DEFAULT_GROUP_NAME: "authenticated"` ensures that the JWT
contains a role string with value "authenticated", which matches
one of the created roles in docker/postgres/00-initial-schema.sql.