### PR TITLE
Update docker-compose service name from gotrue to auth

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,7 +9,7 @@ services:
         ports:
         - 8000:8000/tcp
         - 8443:8443/tcp
-    gotrue:
+    auth:
       image: supabase/gotrue:latest
       ports:
         - '9999:9999'


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

ttps://github.com/supabase/supabase/issues/806

## What is the new behavior?

The kong hostname and docker-compose service name match.