### PR TITLE
fix: limit docs with embedded resources

### DIFF
--- a/web/spec/supabase.yml
+++ b/web/spec/supabase.yml
@@ -909,7 +909,7 @@ pages:
             .from('cities')
             .select('name, cities(name)')
             .eq('name', 'United States')
-            .limit(1, 'cities')
+            .limit(1, { foreignTable: 'cities' })
           ```
         py: |
           ```py

--- a/web/spec/supabase.yml
+++ b/web/spec/supabase.yml
@@ -906,7 +906,7 @@ pages:
         js: |
           ```js
           const { data, error } = await supabase
-            .from('cities')
+            .from('countries')
             .select('name, cities(name)')
             .eq('name', 'United States')
             .limit(1, { foreignTable: 'cities' })


### PR DESCRIPTION
The syntax seems to have changed at some point. 