### PR TITLE
Fix self-hosted docker-compose.yml

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -59,11 +59,10 @@ services:
           HOSTNAME: localhost
           JWT_SECRET: super-secret-jwt-token
     db:
-      image: supabase/postgres:latest
+      build:
+          context: ./postgres
       ports:
       - 5432:5432
-      volumes:
-      - ./docker/db:/docker-entrypoint-initdb.d/
       command:
       - postgres
       - -c


### PR DESCRIPTION
Fix supabase docker-compose.yml: Fix db image pointing to base supabase pg image, effectively ignoring local db setup.

## What kind of change does this PR introduce?

The current docker-compose.yml ignores the init sql scripts as it references supabase/postgresql image directly (so not the nested pg directory w the docker build file.). It then specifies a mount point to, I assume, find those script files in /docker/db on the local system (which is something undocumented).

So there are basically 2 ways to fix this:

- Fix the mount point/document it (and remove the docker buildfile in the pg directory as it's currently completely ignored)
- Use the buildfile in the nested pg directory and remove mount point (which is what this PR does)

## What is the current behavior?

The current setup uses the hosted supabase pg image which lacks db initialization.

## What is the new behavior?

This fix uses the local supabase pg build file which includes db setup.
