### PR TITLE
Link to examples folder instead of GitHub org

### DIFF
--- a/www/components/BuiltWithSupabase/index.tsx
+++ b/www/components/BuiltWithSupabase/index.tsx
@@ -34,7 +34,7 @@ const BuiltExamples = () => {
           </div>
           <p className="mt-10 text-base text-gray-500 dark:text-dark-400">
             See all examples on our{' '}
-            <a className="text-brand-700" href="https://github.com/supabase">
+            <a className="text-brand-700" href="https://github.com/supabase/supabase/tree/master/examples">
               Github
             </a>
           </p>


### PR DESCRIPTION
## What kind of change does this PR introduce?

I've changed the homepage so that the examples link points to the examples folder in this repo.

## What is the current behavior?

A link to the supabase GitHub org.

## What is the new behavior?

A link to the examples folder in this repo.

