### PR TITLE
doc: add note to Realtime removeSubscription() doc

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -6,6 +6,6 @@
 - `cd /web/spec/`
 - run `make` which will pull the latest TSDoc with your updates
 - add your comments to `supabase.yml` | `postgrest.yml` | `gotrue.yml` | `realtime.yml`
-- run `npm run gen:supabase` inside the /specs folder which will generate the Docusaurus pages
+- run `npm run gen:supabase` inside the `/spec` folder which will generate the Docusaurus pages
 - run `npm run build` to make sure the build is working
 - submit your PR

--- a/web/spec/supabase.yml
+++ b/web/spec/supabase.yml
@@ -853,6 +853,8 @@ pages:
   removeSubscription():
     title: 'removeSubscription()'
     $ref: '@supabase/supabase-js."SupabaseClient".SupabaseClient.removeSubscription'
+    notes: |
+      - Removing subscriptions will keep your Realtime Elixir server performant. Failing to do so will increase message latency and eventually cause message delivery failures as more of your users are simultaneously subscribed.
     examples:
       - name: Remove a subscription
         isSpotlight: true

--- a/web/spec/supabase.yml
+++ b/web/spec/supabase.yml
@@ -854,7 +854,7 @@ pages:
     title: 'removeSubscription()'
     $ref: '@supabase/supabase-js."SupabaseClient".SupabaseClient.removeSubscription'
     notes: |
-      - Removing subscriptions will keep your Realtime Elixir server performant. Failing to do so will increase message latency and eventually cause message delivery failures as more of your users are simultaneously subscribed.
+      - Removing subscriptions is a great way to maintain the performance of your project's database. Supabase will automatically handle cleanup 30 seconds after a user is disconnected, but unused subscriptions may cause degradation as more users are simultaneously subscribed.
     examples:
       - name: Remove a subscription
         isSpotlight: true


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

User isn't sure of the impact of removeSubscription().

## What is the new behavior?

User now knows that Realtime server will be less performant if there are more and more simultaneous users subscribed and unused subscriptions are not removed.

## Additional context

This is a follow up to a user specifically asking what happens if they do not remove subscriptions. 
