### PR TITLE
Change swagger-to-ts to openapi-typescript in docs

### DIFF
--- a/web/spec/supabase.yml
+++ b/web/spec/supabase.yml
@@ -179,20 +179,20 @@ pages:
       response.data // Response data will be of type Array<any>.
       ```
 
-      ### Generate database types from Swagger OpenAPI specification
+      ### Generate database types from OpenAPI specification
 
-      Supabase generates a Swagger specification file for your database which can be used to generate your data types for usage with TypeScript.
+      Supabase generates a OpenAPI specification file for your database which can be used to generate your data types for usage with TypeScript.
 
-      The Swagger specification for your Supabase project can be accessed as follows:
+      The OpenAPI specification for your Supabase project can be accessed as follows:
 
       ```txt
       https://your-project.supabase.co/rest/v1/?apikey=your-anon-key
       ```
 
-      Using the open source [swagger-to-ts](https://github.com/manifoldco/swagger-to-ts#%EF%B8%8F-reading-specs-from-remote-resource) tool you can generate your types and store them locally:
+      Using the open source [openapi-typescript](https://github.com/drwpow/openapi-typescript#%EF%B8%8F-reading-specs-from-remote-resource) tool you can generate your types and store them locally:
 
       ```bash
-      npx @manifoldco/swagger-to-ts https://your-project.supabase.co/rest/v1/?apikey=your-anon-key --output types/supabase.ts
+      npx openapi-typescript https://your-project.supabase.co/rest/v1/?apikey=your-anon-key --output types/supabase.ts
       ```
 
       **Note:** Do note that your local types won't automatically stay in sync with your database, so make sure to regenerate your types after your make changes to your database.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update.

## What is the current behavior?

The package `@manifoldco/swagger-to-ts` is now called `openapi-typescript`. If users follow the current docs, they will be using an outdated version of the package by a couple months.

## What is the new behavior?

The docs are updated to reference the new package name. That way users can access the newest package.