### PR TITLE
Fix docker-compose.yml to run Supabase services locally

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -12,7 +12,7 @@ You can run Supabase on your local machine using `docker-compose`:
 import { createClient } from '@supabase/supabase-js'
 
 const SUPABASE_URL = 'http://localhost:8000'
-const SUPABASE_KEY = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJzdXBhYmFzZSIsImlhdCI6MTYwMzk2ODgzNCwiZXhwIjoyNTUwNjUzNjM0LCJhdWQiOiIiLCJzdWIiOiIiLCJSb2xlIjoicG9zdGdyZXMifQ.kdRWxJKxqgFOlx4BZQj-GIIOEeMILqUvdHMh8ebcn8M'
+const SUPABASE_KEY = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJzdXBhYmFzZSIsImlhdCI6MTYwMzk2ODgzNCwiZXhwIjoyNTUwNjUzNjM0LCJhdWQiOiIiLCJzdWIiOiIiLCJSb2xlIjoicG9zdGdyZXMifQ.magCcozTMKNrl76Tj2dsM7XTl_YH0v0ilajzAvIlw3U'
 
 const supabase = createClient(SUPABASE_URL, SUPABASE_KEY)
 ```

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       ports:
         - '9999:9999'
       environment:
-        GOTRUE_JWT_SECRET: super-secret-jwt-token
+        GOTRUE_JWT_SECRET: super-secret-jwt-token-with-at-least-32-characters-long
         GOTRUE_JWT_EXP: 3600
         GOTRUE_JWT_DEFAULT_GROUP_NAME: authenticated
         GOTRUE_DB_DRIVER: postgres
@@ -41,7 +41,7 @@ services:
           PGRST_DB_URI: postgres://postgres:postgres@db:5432/postgres
           PGRST_DB_SCHEMA: public
           PGRST_DB_ANON_ROLE: postgres
-          PGRST_JWT_SECRET: super-secret-jwt-token
+          PGRST_JWT_SECRET: super-secret-jwt-token-with-at-least-32-characters-long
     realtime:
       image: supabase/realtime:latest
       ports:
@@ -57,7 +57,9 @@ services:
           DB_PORT: 5432
           PORT: 4000
           HOSTNAME: localhost
-          JWT_SECRET: super-secret-jwt-token
+          # Disable JWT Auth locally. The JWT_SECRET will be ignored.
+          SECURE_CHANNELS: 'false'
+          JWT_SECRET: super-secret-jwt-token-with-at-least-32-characters-long
     db:
       build:
           context: ./postgres

--- a/docker/kong/kong.yml
+++ b/docker/kong/kong.yml
@@ -42,4 +42,4 @@ services:
 consumers:
 -   username: 'private-key'
     keyauth_credentials:
-    -   key: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJzdXBhYmFzZSIsImlhdCI6MTYwMzk2ODgzNCwiZXhwIjoyNTUwNjUzNjM0LCJhdWQiOiIiLCJzdWIiOiIiLCJSb2xlIjoicG9zdGdyZXMifQ.kdRWxJKxqgFOlx4BZQj-GIIOEeMILqUvdHMh8ebcn8M
+    -   key: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJzdXBhYmFzZSIsImlhdCI6MTYwMzk2ODgzNCwiZXhwIjoyNTUwNjUzNjM0LCJhdWQiOiIiLCJzdWIiOiIiLCJSb2xlIjoicG9zdGdyZXMifQ.magCcozTMKNrl76Tj2dsM7XTl_YH0v0ilajzAvIlw3U


### PR DESCRIPTION
Add JWT example token longer than 32 characters and disable locally real-time security.

## What kind of change does this PR introduce?
Bug fix, docs update

## What is the current behavior?
Running docker-compose locally doesn't allow to make calls to the REST API with supabase-js.
I also add the option to disable the security in the real-time server. Disable false by default in the `docker-composer.yml` file. 

## What is the new behavior?
Now it is possible to run the rest server working with an example JWT token and the real-time server by disabling the security when running locally. 

## Notes
Apparently, PostgREST requires a signature for the JWT longer than 32 characters as mentioned here: https://github.com/PostgREST/postgrest/issues/977#issuecomment-329917367
