### PR TITLE
Add example to keep type definitions up-to-date

### DIFF
--- a/web/spec/supabase.yml
+++ b/web/spec/supabase.yml
@@ -200,6 +200,57 @@ pages:
         res.status(200).json(allOnlineUsers);
       };
       ```
+      
+      ### Update types automatically with a GitHub Action
+      
+      To keep your type definitions in sync with your database, you can setup a GitHub action that will update the type definitions on a schedule.
+      
+      First, add a script to your package.json to generate the types.
+      
+      ```
+      "update-types": "npx openapi-typescript https://your-project.supabase.co/rest/v1/?apikey=your-anon-key --output types/supabase.ts"
+      ```
+      
+      Next, in your repo, create the file `.github/workflows/update-types.yml`. Then, add the following snippet into this file to define the action. This action will create updated types, then if there was an update, it will commit the change to your repo.
+      
+      ```yml
+      name: Update database types
+
+      on:
+        schedule:
+          # sets the action to run daily. You can modify this to run the action more or less freqently
+          - cron: '0 0 * * *'
+
+      jobs:
+        update:
+          runs-on: ubuntu-latest
+          steps:
+            - uses: actions/checkout@v2
+              with:
+                persist-credentials: false
+                fetch-depth: 0
+            - uses: actions/setup-node@v2.1.5
+              with:
+                node-version: 14
+            - run: npm run update-database-types
+            - name: check for file changes
+              id: git_status
+              run: |
+                echo "::set-output name=status::$(git status -s)"
+            - name: Commit files
+              if: ${{contains(steps.git_status.outputs.status, ' ')}}
+              run: |
+                git add types/database/index.ts
+                git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+                git config --local user.name "github-actions[bot]"
+                git commit -m "Update database types" -a
+            - name: Push changes
+              if: ${{contains(steps.git_status.outputs.status, ' ')}}
+              uses: ad-m/github-push-action@master
+              with:
+                github_token: ${{ secrets.GITHUB_TOKEN }}
+                branch: ${{ github.ref }}
+      ```
 
   auth.signUp():
     $ref: '@supabase/gotrue-js."GoTrueClient".GoTrueClient.signUp'

--- a/web/spec/supabase.yml
+++ b/web/spec/supabase.yml
@@ -201,17 +201,17 @@ pages:
       };
       ```
       
-      ### Update types automatically with a GitHub Action
+      ### Update types automatically with GitHub Actions
       
-      To keep your type definitions in sync with your database, you can setup a GitHub action that will update the type definitions on a schedule.
+      One way to keep your type definitions in sync with your database is to set up a GitHub action that runs on a schedule.
       
-      First, add a script to your package.json to generate the types.
+      Add a script to your package.json to generate the types:
       
       ```
       "update-types": "npx openapi-typescript https://your-project.supabase.co/rest/v1/?apikey=your-anon-key --output types/supabase.ts"
       ```
       
-      Next, in your repo, create the file `.github/workflows/update-types.yml`. Then, add the following snippet into this file to define the action. This action will create updated types, then if there was an update, it will commit the change to your repo.
+      In your repo, create the file `.github/workflows/update-types.yml`. Add the following snippet into this file to define the action. If there is a change to your definitions, this script will commit the change to your repo.
       
       ```yml
       name: Update database types


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds an example of using GitHub actions to keep type definitions up-to-date as described in https://github.com/supabase/supabase/issues/907

The example is added to the end of this docs page: https://supabase.io/docs/reference/javascript/generating-types#usage-with-typescript

**NOTE**: Please check that the code snippets render correctly. I assume the docs file is Markdown (written inside of yaml), so that's the syntax I used.

## Additional context

close https://github.com/supabase/supabase/issues/907