### PR TITLE
Fix typo re: Slack channel

### DIFF
--- a/web/docs/support.md
+++ b/web/docs/support.md
@@ -18,4 +18,4 @@ If you need SLAs, guaranteed response times, or other enterprise level services,
 
 ## Slack Support
 
-If you are building with Supabase and you would like to set up a hared Slack channel (via [Slack Connect](https://slack.com/connect)), please reach out to us at beta@supabase.io.
+If you are building with Supabase and you would like to set up a shared Slack channel (via [Slack Connect](https://slack.com/connect)), please reach out to us at beta@supabase.io.


### PR DESCRIPTION
Added missing "s" for the shared Slack channel

## What kind of change does this PR introduce?

Documentation update

## What is the current behavior?

![image](https://user-images.githubusercontent.com/1944084/113074307-0cb99200-9188-11eb-8e12-d018e3ffb53a.png)

Just noticed and fixed a minor typo error on the documentation.

## What is the new behavior?
Docs updated with correct typo.
Feel free to include screenshots if it includes visual changes.

## Additional context

