### PR TITLE
patch: fixes a few cases of misspellings

### DIFF
--- a/examples/expo-todo-list/README.md
+++ b/examples/expo-todo-list/README.md
@@ -52,7 +52,7 @@ npm start
 
 This project uses very high-level Authorization using Postgres' Role Level Security.
 When you start a Postgres database on Supabase, we populate it with an `auth` schema, and some helper functions.
-When a user logs in, they are issued a JWT with the role `authenticated` and thier UUID.
+When a user logs in, they are issued a JWT with the role `authenticated` and their UUID.
 We can use these details to provide fine-grained control over what each user can and cannot do.
 
 This is a trimmed-down schema, with the policies:

--- a/examples/react-todo-list/README.md
+++ b/examples/react-todo-list/README.md
@@ -45,7 +45,7 @@ You will be asked for a `REACT_APP_SUPABASE_URL` and `REACT_APP_SUPABASE_KEY`. U
 
 This project uses very high-level Authorization using Postgres' Role Level Security.
 When you start a Postgres database on Supabase, we populate it with an `auth` schema, and some helper functions.
-When a user logs in, they are issued a JWT with the role `authenticated` and thier UUID.
+When a user logs in, they are issued a JWT with the role `authenticated` and their UUID.
 We can use these details to provide fine-grained control over what each user can and cannot do.
 
 This is a trimmed-down schema, with the policies:

--- a/examples/vue3-ts-todo-list/src/vuetils/useAuth.ts
+++ b/examples/vue3-ts-todo-list/src/vuetils/useAuth.ts
@@ -33,7 +33,7 @@ async function handleLogin(credentials: Credentials) {
 async function handleSignup(credentials: Credentials) {
   try {
     const { email, password } = credentials
-    // prompt user if they have not filled populated thier credentials
+    // prompt user if they have not filled populated their credentials
     if (!email || !password) {
       alert('Please provide both your email and password.')
       return

--- a/web/docs/guides/auth.mdx
+++ b/web/docs/guides/auth.mdx
@@ -240,7 +240,7 @@ create table comments (
   comment_date  date      not null     default now()
 );
 
-create policy "Creator can see thier own posts"
+create policy "Creator can see their own posts"
 on posts
 for select
 using (


### PR DESCRIPTION
## What kind of change does this PR introduce?

I noticed in the documentation there were a few misspellings. `thier` ➟ `their`

## Additional context

I love what you're doing! Can't wait to see whats next.
