### PR TITLE
docs: add additional RLS policy example using security definer function

### DIFF
--- a/web/docs/guides/auth.mdx
+++ b/web/docs/guides/auth.mdx
@@ -191,6 +191,36 @@ create policy "Team members can update team details if they belong to the team."
   );
 ```
 
+### Policies with security definer functions
+
+Policies can also make use of `security definer functions`, this is useful in a many-to-many relationship where you want to restrict access to the linking table. Following the `teams` and `members` example from above this example shows how you can use security definer function in combination with a policy to control access to the `members` table.
+
+```sql
+-- 1. Follow example for 'Policies with joins' above
+
+-- 2.  Enable RLS
+alter table members 
+  enable row level security
+
+-- 3.  Create security definer function
+create or replace function get_teams_for_user(user_id uuid)
+returns setof bigint as $$
+    select team_id 
+    from members 
+    where user_id = $1
+$$ stable language sql security definer;
+
+-- 4. Create Policy
+create policy "Team members can update team members if they belong to the team."
+  on members
+  for all using (
+    team_id in (
+      select get_teams_for_user(auth.uid())
+    )
+  );
+
+```
+
 ### Verifying email domains
 
 Postgres has a function `right(string, n)` that returns the rightmost n characters of a string. 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Auth guide / documentation update, added a new example.

## What kind of change does this PR introduce?

Added example to docs for how to use a security definer function in a policy for a many to many link table as discussed in https://github.com/supabase/supabase/discussions/811 


