### PR TITLE
Fix typo

### DIFF
--- a/web/docs/guides/auth.mdx
+++ b/web/docs/guides/auth.mdx
@@ -303,7 +303,7 @@ using (
 You can also put your authorization rules in your middleware, 
 similar to how you would create security rules with any other `backend <-> middleware <-> frontend` architecture.
 
-Policies are a tool. In the case of "serverless/Jastack" setups, they are especially effective because you don't have to deploy any middleware at all.
+Policies are a tool. In the case of "serverless/Jamstack" setups, they are especially effective because you don't have to deploy any middleware at all.
 
 However if you want to use another Authorization method for your applications, that's also fine. Supabase is "just Postgres", so if your application 
 works with Postgres, then it also works with Supabase. 


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

There's a typo for the word "Jastack" which I assume it means "Jamstack"

## What is the new behavior?

The typo is fixed

## Additional context

None