### PR TITLE
Fix link for storage blog post

### DIFF
--- a/web/docs/guides/storage.mdx
+++ b/web/docs/guides/storage.mdx
@@ -319,5 +319,5 @@ let us know on our [GitHub](https://github.com/supabase/supabase/discussions) an
 ## Next steps
 
 - Got a question? [Ask here](https://github.com/supabase/supabase/discussions).
-- Read more about storage in our [blog post](https://supabase.io/blog/2021/03/29/storage).
+- Read more about storage in our [blog post](https://supabase.io/blog/2021/03/30/supabase-storage).
 - Sign in: [app.supabase.io](https://app.supabase.io)


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

The blog post link in storage documentation is incorrect.

## What is the new behavior?

Updated the blog post link for storage.

## Additional context

Add any other context or screenshots.
