### PR TITLE
fix: emulate localStorage with AsyncLocalStorage

### DIFF
--- a/examples/expo-todo-list/App.tsx
+++ b/examples/expo-todo-list/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
 import { StatusBar } from 'expo-status-bar'
 import { StyleSheet, View, Platform } from 'react-native'
 import { ThemeProvider, colors, Text } from 'react-native-elements'
@@ -6,6 +6,7 @@ import { Styles } from './lib/constants'
 import { UserContextProvider, useUser } from './components/UserContext'
 import List from './components/TodoList'
 import Auth from './components/Auth'
+import { supabasePromise } from './lib/initSupabase'
 
 const theme = {
   colors: {
@@ -23,7 +24,13 @@ const Container = () => {
 }
 
 export default function App() {
-  return (
+  const [ready, setReady] = useState(false)
+
+  useEffect(() => {
+    supabasePromise.then(() => setReady(true))
+  }, [])
+
+  return ready ? (
     <UserContextProvider>
       <ThemeProvider theme={theme}>
         <View style={styles.container}>
@@ -35,7 +42,7 @@ export default function App() {
         </View>
       </ThemeProvider>
     </UserContextProvider>
-  )
+  ) : null
 }
 
 const styles = StyleSheet.create({

--- a/examples/expo-todo-list/lib/initSupabase.ts
+++ b/examples/expo-todo-list/lib/initSupabase.ts
@@ -1,7 +1,48 @@
 import AsyncStorage from '@react-native-async-storage/async-storage'
-import { createClient } from '@supabase/supabase-js'
+import { createClient, SupabaseClient } from '@supabase/supabase-js'
 import { SUPABASE_URL, SUPABASE_ANON_KEY } from './constants'
 
-export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
-  localStorage: AsyncStorage as any,
-})
+export let supabase: SupabaseClient
+
+export const supabasePromise = AsyncStorage.getAllKeys()
+  .then((k) => AsyncStorage.multiGet(k).then(Object.fromEntries))
+  .then((keys) => {
+    const storage = new LocalStorageEmulator(keys)
+    supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+      detectSessionInUrl: false,
+      localStorage: storage,
+    })
+  })
+
+class LocalStorageEmulator implements Storage {
+  public length = 0
+  private keys: Record<string, string | null> = {}
+
+  constructor(keys: Record<string, string | null>) {
+    this.keys = keys
+  }
+
+  key(n: number) {
+    return Object.keys(this.keys)[n]
+  }
+
+  clear() {
+    this.keys = {}
+    AsyncStorage.clear()
+  }
+
+  getItem(key: string) {
+    AsyncStorage.getItem(key).then((v) => (this.keys[key] = v))
+    return this.keys[key]
+  }
+
+  setItem(key: string, value: string) {
+    this.keys[key] = value
+    AsyncStorage.setItem(key, value)
+  }
+
+  removeItem(key: string) {
+    delete this.keys[key]
+    AsyncStorage.removeItem(key)
+  }
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Trying to emulate localStorage which is synchronous with AsyncLocalStorage in the Expo example. It's not the most elegant solution but it should do the job.

## What is the current behavior?

Supabase relies on localStorage but and does not expect it to return a promise, which causes that Supabase is not able to get values from the storage (e.g. auth).

## What is the new behavior?

Emulated storage retrieves all keys from the AsyncLocalStorage and stores them locally, so they can be accessed synchronously. Also, it pauses the rendering of the App until the storage is ready and SupabaseClient can be initialized. Additionally, I've disabled detecting of the session in the URL because window.location is not available in Expo.
