### PR TITLE
Fix typo in doc in Stored Procedures: rpc() section

### DIFF
--- a/web/spec/supabase.yml
+++ b/web/spec/supabase.yml
@@ -678,7 +678,7 @@ pages:
           Allowed values for count option are `null`, `exact`, `planned` and `estimated`.
         js: |
           ```js
-          const { data, error, count } = await postgrest
+          const { data, error, count } = await supabase
             .from('cities')
             .rpc('hello_world', { count: 'exact' })
           }


### PR DESCRIPTION
## What kind of change does this PR introduce?

There a typo in `Stored Procedures: rpc()` section's example snippet. Instead of importing from `supabase`, currently it's imported from `postgrest` (I believe it's a typo and so created this PR)

## What is the current behavior?
Currently the snippet is like this:
```
const { data, error, count } = await postgrest
  .from('cities')
  .rpc('hello_world', { count: 'exact' })
}
```
## What is the new behavior?

After the fix it'll be like this:
```
const { data, error, count } = await supabase
  .from('cities')
  .rpc('hello_world', { count: 'exact' })
}
```
## Additional context
N/A