### PR TITLE
docs: add article to Examples and Resources

### DIFF
--- a/web/docs/guides/examples.mdx
+++ b/web/docs/guides/examples.mdx
@@ -64,3 +64,4 @@ Build a basic Todo List with Supabase and your favourite frontend framework:
 - Track Real-time Page Views. [Blog](https://codebycorey.com/blog/page-views-nextjs-supabase)
 - Supabase as a Sentry alternative. [Blog](http://kopi.cloud/blog/2021/sentry-supabase/) 
 - Using Supabase with Chartbrew. [Blog](https://chartbrew.com/blog/how-to-visualize-your-supabase-data-with-chartbrew/)
+- Authentication with Supabase and React. [Blog](https://hyperfoo.io/posts/supabase-authentication-react)


### PR DESCRIPTION
Hey there!

I wrote a blog post about Supabase and thought it could be helpful to have it on the "Examples and Resources" page. 🙂

I'm not 100% sure if it fits better in the "Guides" section or "Blog Posts", but I can move it no problem.

### What kind of change does this PR introduce?

Adds [Authentication with Supabase and React (hyperfoo.io)](https://hyperfoo.io/posts/supabase-authentication-react) to the  [Examples and Resources](https://supabase.io/docs/guides/examples) page on the documentation (Blog Posts section).


