### PR TITLE
Add Note Regarding Array Columns Type Generation

### DIFF
--- a/web/spec/supabase.yml
+++ b/web/spec/supabase.yml
@@ -191,8 +191,12 @@ pages:
       ```bash
       npx openapi-typescript https://your-project.supabase.co/rest/v1/?apikey=your-anon-key --output types/supabase.ts
       ```
-
-      **Note:** Do note that your local types won't automatically stay in sync with your database, so make sure to regenerate your types after your make changes to your database.
+      
+      Important disclaimers:
+      
+      - The generator can't know if a column is specified as an array, and will thus just generate the type as `string`, even though supabase handles this automatically and returns arrays.
+        You can fix this manually in the files by changing the type, e.g. `names: string` -> `names: string[]`
+      - The types won't automatically stay in sync with your database, so make sure to regenerate your types after your make changes to your database.
 
       After you have generated your types, you can use them in your TypeScript projects:
 

--- a/web/spec/supabase.yml
+++ b/web/spec/supabase.yml
@@ -191,9 +191,9 @@ pages:
       ```bash
       npx openapi-typescript https://your-project.supabase.co/rest/v1/?apikey=your-anon-key --output types/supabase.ts
       ```
-      
+
       Important disclaimers:
-      
+
       - The generator can't know if a column is specified as an array, and will thus just generate the type as `string`, even though supabase handles this automatically and returns arrays.
         You can fix this manually in the files by changing the type, e.g. `names: string` -> `names: string[]`
       - The types won't automatically stay in sync with your database, so make sure to regenerate your types after your make changes to your database.

--- a/web/spec/supabase.yml
+++ b/web/spec/supabase.yml
@@ -192,9 +192,9 @@ pages:
       npx openapi-typescript https://your-project.supabase.co/rest/v1/?apikey=your-anon-key --output types/supabase.ts
       ```
 
-      Important disclaimers:
+      Important notes:
 
-      - The generator can't know if a column is specified as an array, and will thus just generate the type as `string`, even though supabase handles this automatically and returns arrays.
+      - Since the generator uses JSON API, there is no way to determine if a column is an Array. It will generate array types as `string`, even though Supabase handles this automatically and returns arrays.
         You can fix this manually in the files by changing the type, e.g. `names: string` -> `names: string[]`
       - The types won't automatically stay in sync with your database, so make sure to regenerate your types after your make changes to your database.
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs Update

## What is the new behavior?

I added a note regarding the types generated by array columns. AFAIK the types will always be generated as `string` as they're stored as JSON strings, while supabase returns proper arrays when using the client.

~~Not sure how I can check how this will be formatted in the docs though~~
well, there it is!

![image](https://user-images.githubusercontent.com/472500/115427044-f2d30400-a1b5-11eb-8b54-aebd4e8bac17.png)

