### PR TITLE
chore: changed syntax highlighting

### DIFF
--- a/web/docs/guides/api.mdx
+++ b/web/docs/guides/api.mdx
@@ -228,7 +228,7 @@ values={[
 </TabItem>
 <TabItem value="SQL">
 
-```bash
+```sql
 alter publication supabase_realtime add table products;
 ```
 
@@ -260,7 +260,7 @@ values={[
 </TabItem>
 <TabItem value="SQL">
 
-```bash
+```sql
 alter table todos enable row level security;
 ```
 


### PR DESCRIPTION
Shouldn't it be `sql` rather than `bash`?


