### PR TITLE
UI Fix: Overflow website along X-axis on openinig Nav options

### DIFF
--- a/www/components/UI/FlyOut.tsx
+++ b/www/components/UI/FlyOut.tsx
@@ -64,7 +64,7 @@ const FlyOut = (props: Props) => {
             style={{
               zIndex: 999,
               position: 'absolute',
-              width: '100vw',
+              width: '100%',
               margin: '0 auto',
               marginTop: '63px',
               left: '-50vw',


### PR DESCRIPTION
Issue: Overflow website along X-axis when user clicks on **Product or Developers under NAVBAR** to explore them further,
checked on chrome and firefox.

The changes will fix them
## Current with issue
![CurrentUi](https://user-images.githubusercontent.com/24385409/115753957-6002b700-a3b9-11eb-848d-3a59febb4915.jpg)


## After Fix
![AfterFix](https://user-images.githubusercontent.com/24385409/115754025-6ee96980-a3b9-11eb-932b-864413f2c383.jpg)


