### PR TITLE
Added Note for Magic Link Documentation

### DIFF
--- a/web/spec/gotrue.yml
+++ b/web/spec/gotrue.yml
@@ -212,6 +212,8 @@ pages:
 
   api.sendMagicLinkEmail:
     $ref: '"GoTrueApi".GoTrueApi.sendMagicLinkEmail'
+    notes: |
+      - An account is created when a non-existing user email is passed.
     examples:
       - name: Send user a passwordless login link via email
         js: |


### PR DESCRIPTION
When the email used for the `api.sendMagicLinkEmail` does not yet exist on the users table, the account is instead created.

Added notes in the documentation to explain this behavior.

Refers to this [issue](https://github.com/supabase/supabase/issues/1176).

## What kind of change does this PR introduce?

Documentation update.

## What is the current behavior?

Documentation does not explain that magic link creates a new user account when email used is non-existent on the database.

## What is the new behavior?

Updated documentation explaining new account is being created.

## Additional context


