### PR TITLE
Update kong.yml

### DIFF
--- a/docker/kong/kong.yml
+++ b/docker/kong/kong.yml
@@ -14,7 +14,7 @@ services:
         config:
             hide_credentials: true
 -   name: rest-v1
-    _comment: 'PosgREST: /rest/v1/* -> http://rest:3000/*'
+    _comment: 'PostgREST: /rest/v1/* -> http://rest:3000/*'
     url: http://rest:3000/
     routes:
     -   name: rest-v1-all


### PR DESCRIPTION
## What kind of change does this PR introduce?

Very dumb PR, proposes a fix to a typo in the kong config. Non-breaking.

## What is the current behavior?

`_comment: 'PosgREST: /rest/v1/* -> http://rest:3000/*'`

## What is the new behavior?

`_comment: 'PostgREST: /rest/v1/* -> http://rest:3000/*'`

## Additional context

Self-hosting directions work great, this just caught my eye while reading through source files before firing up
