### PR TITLE
GRANT EXECUTE auth schema for `authenticated`, `anon`, `service role`

### DIFF
--- a/docker/postgres/auth-schema.sql
+++ b/docker/postgres/auth-schema.sql
@@ -89,3 +89,6 @@ GRANT ALL PRIVILEGES ON SCHEMA auth TO postgres;
 GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA auth TO postgres;
 GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA auth TO postgres;
 ALTER ROLE postgres SET search_path = "$user", public, auth;
+
+GRANT USAGE ON SCHEMA auth TO authenticated;
+GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA auth TO authenticated;

--- a/docker/postgres/auth-schema.sql
+++ b/docker/postgres/auth-schema.sql
@@ -90,5 +90,4 @@ GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA auth TO postgres;
 GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA auth TO postgres;
 ALTER ROLE postgres SET search_path = "$user", public, auth;
 
-GRANT USAGE ON SCHEMA auth TO authenticated;
-GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA auth TO authenticated;
+GRANT USAGE ON SCHEMA auth TO anon, authenticated, service_role;


### PR DESCRIPTION
Currently, `authenticated` role does not have access to the auth schema, so permission is denied for `SECURITY INVOKER` functions that use functions like `auth.uid()`.

As discussed with @steve-chavez in https://github.com/supabase/supabase/discussions/1290, giving `authenticated` role access to execute auth schema functions in this PR.


