### PR TITLE
Fix localhost link in Storage documentation

### DIFF
--- a/web/docs/guides/storage.mdx
+++ b/web/docs/guides/storage.mdx
@@ -269,7 +269,7 @@ For example, if your file is stored in `public/subfolder/avatar.png` it would re
 ## Security
 
 Supabase Storage is integrated with your [Postgres Database](/docs/guides/database).
-This means that you can use the same [Policy](http://localhost:3005/docs/guides/auth#policies) engine 
+This means that you can use the same [Policy](/docs/guides/auth#policies) engine 
 for managing access to your files.
 
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

This fixes an incorrect link in the documentation which points to localhost.

## What is the current behavior?

The Policy link goes to http://localhost:3005/docs/guides/auth#policies

## What is the new behavior?

The Policy link goes to /docs/guides/auth#policies
