### PR TITLE
Link directly to examples folder

### DIFF
--- a/web/docs/guides/examples.mdx
+++ b/web/docs/guides/examples.mdx
@@ -4,7 +4,7 @@ title: Examples and Resources
 description: 'Examples you can use to get started with supabase'
 ---
 
-We have a set of examples in our [main repository](https://github.com/supabase/supabase/tree/master/examples) to help you get started.
+We have a [set of examples]((https://github.com/supabase/supabase/tree/master/examples) in our [main repository](https://github.com/supabase/supabase) to help you get started.
 
 ## Todo List
 

--- a/web/docs/guides/examples.mdx
+++ b/web/docs/guides/examples.mdx
@@ -4,7 +4,7 @@ title: Examples and Resources
 description: 'Examples you can use to get started with supabase'
 ---
 
-We have a set of examples in our [main repository](https://github.com/supabase/supabase) to help you get started.
+We have a set of examples in our [main repository](https://github.com/supabase/supabase/tree/master/examples) to help you get started.
 
 ## Todo List
 

--- a/web/docs/guides/examples.mdx
+++ b/web/docs/guides/examples.mdx
@@ -4,7 +4,7 @@ title: Examples and Resources
 description: 'Examples you can use to get started with supabase'
 ---
 
-We have a [set of examples]((https://github.com/supabase/supabase/tree/master/examples) in our [main repository](https://github.com/supabase/supabase) to help you get started.
+We have a [set of examples](https://github.com/supabase/supabase/tree/master/examples) in our [main repository](https://github.com/supabase/supabase) to help you get started.
 
 ## Todo List
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update to link to the `examples` folder, instead of the main repo.