### PR TITLE
fix: remove double border in api section of homepage

### DIFF
--- a/www/components/Sections/APISection.tsx
+++ b/www/components/Sections/APISection.tsx
@@ -61,11 +61,11 @@ function APISection(props: Props) {
               </Tabs.Panel>
             ))}
         </Tabs>
-        <div className="border border-gray-100 dark:border-gray-600 rounded-md bg-gray-800 overflow-hidden">
+        <div className="bg-gray-800 overflow-hidden">
           <Swiper
             // @ts-ignore
             onSwiper={setApiSwiper}
-            style={{ zIndex: 0 }}
+            style={{ zIndex: 0, marginRight:'1px' }}
             initialSlide={apiSwiperActiveIndex}
             spaceBetween={0}
             slidesPerView={1}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Slight style change in the Code section of the homepage. Fixes #1319.

## What is the current behavior?

The current behavior is that there are two borders in the Code/Layout section on the homepage.

## What is the new behavior?

There is only one border now. I did have to tweak the margin slightly because otherwise the border of the next Swipe would show in the current one. I am open to other ideas. I tried width first but that seemed worse since in responsive scenarios it broke the layout.

