### PR TITLE
Make tags clickable on full post

### DIFF
--- a/www/pages/blog/[year]/[month]/[day]/[slug].tsx
+++ b/www/pages/blog/[year]/[month]/[day]/[slug].tsx
@@ -122,7 +122,11 @@ function BlogPostPage(props: any) {
       <div>
         <Space>
           {props.blog.tags.map((tag: string) => {
-            return <Badge key={`categroy-badge-${tag}`}>{tag}</Badge>
+            return (
+              <a href={`/blog/tags/${tag}`}>
+                <Badge key={`categroy-badge-`}>{tag}</Badge>
+              </a>
+            )
           })}
         </Space>
       </div>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Improvement

## What is the current behavior?

At `blog/[year]/[month]/[slug]`, there is a list of the tags on the right but here are not clickable.

## What is the new behavior?

Clicking on a tag now goes to `/blog/tags/<tag>`