### PR TITLE
Fix: Ctrl SVG visibility

### DIFF
--- a/web/src/css/custom.css
+++ b/web/src/css/custom.css
@@ -972,9 +972,6 @@ html[data-theme='dark'] .DocSearch {
   background: var(--custom-background-color-diff) !important;
   font-family: var(--ifm-font-family-base);
 }
-.DocSearch-Button svg {
-  display: none;
-}
 .DocSearch-Button-Placeholder {
   font-family: var(--ifm-font-family-base);
   line-height: 10px;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug

## What is the current behavior?

#1476 

## What is the new behavior?

SVG for Ctrl is visible.

