### PR TITLE
No access to public tables by default for `anon`

### DIFF
--- a/docker/dockerfiles/postgres/00-initial-schema.sql
+++ b/docker/dockerfiles/postgres/00-initial-schema.sql
@@ -20,7 +20,7 @@ grant authenticated     to authenticator;
 grant service_role      to authenticator;
 
 grant usage                     on schema public to postgres, anon, authenticated, service_role;
-alter default privileges in schema public grant all on tables to postgres, anon, authenticated, service_role;
-alter default privileges in schema public grant all on functions to postgres, anon, authenticated, service_role;
-alter default privileges in schema public grant all on sequences to postgres, anon, authenticated, service_role;
+alter default privileges in schema public grant all on tables to postgres, authenticated, service_role;
+alter default privileges in schema public grant all on functions to postgres, authenticated, service_role;
+alter default privileges in schema public grant all on sequences to postgres, authenticated, service_role;
 


### PR DESCRIPTION
Users should explicitly grant privileges to `anon`(unauthenticated clients) if they want some db objects to be publicly accessed.

This caused confusion on https://github.com/supabase/supabase/discussions/1493. So the fix is to revoke default privileges for `anon`.