### PR TITLE
Add $ to database space pricing

### DIFF
--- a/www/data/Pricing.json
+++ b/www/data/Pricing.json
@@ -42,7 +42,7 @@
         "tiers": {
           "free": "Up to 500 MB",
           "pro": "Up to 8 GB",
-          "enterprise": "0.125 per GB"
+          "enterprise": "$0.125 per GB"
         }
       },
       {


### PR DESCRIPTION
We got a report about this:

> I see it costs "0.125 per GB" but it doesn't specify if this is in USD or your own billing unit.