### PR TITLE
docs(on().subscribe()) fixed grammar issue

### DIFF
--- a/web/spec/supabase.yml
+++ b/web/spec/supabase.yml
@@ -792,7 +792,7 @@ pages:
           ```
       - name: Listening to updates
         description: |
-          By default Supabase will send only the updated record. If you want to receive the previous values as well you can 
+          By default, Supabase will send only the updated record. If you want to receive the previous values as well you can 
           enable full replication for the table you are listening too: 
 
           ```sql
@@ -809,7 +809,7 @@ pages:
           ```
       - name: Listening to deletes
         description: |
-          By default Supabase not send deleted records. If you want to receive the deleted record you can 
+          By default, Supabase does not send deleted records. If you want to receive the deleted record you can 
           enable full replication for the table you are listening too: 
 
           ```sql


### PR DESCRIPTION
Relates to this issue: https://github.com/supabase/supabase/issues/1620

## What kind of change does this PR introduce?
This provides a docs update with some grammar changes. It focuses on the on().subscribe() page.

## What is the current behavior?

This paragraph is missing the word "does."
Commas are also missing in a few sentences.

## What is the new behavior?

"By default Supabase not send deleted records." should be "By default, Supabase does not send deleted records.

## Additional context

You can see this issue [here](https://github.com/supabase/supabase/issues/1620).
