### PR TITLE
Changed supabase.auth.api.delete to .deleteUser

### DIFF
--- a/web/spec/supabase.yml
+++ b/web/spec/supabase.yml
@@ -471,7 +471,7 @@ pages:
         isSpotlight: true
         js: |
           ```js
-          const { user, error } = await supabase.auth.api.delete(
+          const { user, error } = await supabase.auth.api.deleteUser(
             '715ed5db-f090-4b8c-a067-640ecee36aa0',
             'YOUR_SERVICE_ROLE_KEY'
           )


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

The [Delete User Doc](https://supabase.io/docs/reference/javascript/delete-user) should use `supabase.auth.api.deleteUser` instead of `supabase.auth.api.delete` in accordance with the [GoTrueApi](https://supabase.github.io/gotrue-js/classes/gotrueapi.html#deleteuser).