### PR TITLE
fix: null channels bug in slack clone

### DIFF
--- a/examples/nextjs-slack-clone/lib/Store.js
+++ b/examples/nextjs-slack-clone/lib/Store.js
@@ -99,7 +99,7 @@ export const useStore = (props) => {
   return {
     // We can export computed values here to map the authors to each message
     messages: messages.map((x) => ({ ...x, author: users.get(x.user_id) })),
-    channels: channels.sort((a, b) => a.slug.localeCompare(b.slug)),
+    channels: (channels !== null) ? channels.sort((a, b) => a.slug.localeCompare(b.slug)) : [],
     users,
   }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?
Fixes a tiny bug in the slack clone where channels are null
