### PR TITLE
Fix jwt.io link

### DIFF
--- a/web/docs/learn/auth-deep-dive/row-level-security.md
+++ b/web/docs/learn/auth-deep-dive/row-level-security.md
@@ -116,7 +116,7 @@ In the next guide we will look at using Policies in combination with User Accoun
 
 ### Resources
 
-- JWT debugger: https://jwt.io/​
+- JWT debugger: https://jwt.io/
 - RESTED: https://github.com/RESTEDClient/RESTED
 
 ### Next steps


### PR DESCRIPTION
Docs update to fix jwt.io link on page `/docs/learn/auth-deep-dive/auth-row-level-security`
