### PR TITLE
Fixed typo

### DIFF
--- a/web/spec/supabase.yml
+++ b/web/spec/supabase.yml
@@ -389,7 +389,7 @@ pages:
         isSpotlight: true
         js: |
           ```js
-          const { error } = supabase.auth.signOut()
+          const { error } = await supabase.auth.signOut()
           ```
 
   auth.session():


### PR DESCRIPTION
const { error } = supabase.auth.signOut()
changed to
const { error } = await supabase.auth.signOut()

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
