### PR TITLE
fix: spelling error in 'Querying with count option'

### DIFF
--- a/web/spec/supabase.yml
+++ b/web/spec/supabase.yml
@@ -538,7 +538,7 @@ pages:
           Allowed values for count option are `null`, `exact`, `planned` and `estimated`.
         js: |
           ```js
-          const { data, error, count } = await postgrest
+          const { data, error, count } = await supabase
             .from('cities')
             .select('name', { count: 'exact' })
           ```


### PR DESCRIPTION
• spelling mistake in snippet

not entirely sure were meant to be editing this file