### PR TITLE
fix: Add docs for signIn() with refresh token

### DIFF
--- a/web/spec/supabase.yml
+++ b/web/spec/supabase.yml
@@ -381,6 +381,25 @@ pages:
           })
           const oAuthToken = session.provider_token // use to access provider API
           ```
+      - name: Sign in using a refresh token (e.g. in React Native).
+        description: |
+          If you are completing a sign up or login in a React Native app you can pass the refresh token obtained from the provider to obtain a session.
+        js: |
+          ```js
+          // An example using Expo's `AuthSession`
+          const redirectUri = AuthSession.makeRedirectUri({ useProxy: false });
+          const provider = 'google';
+
+          AuthSession.startAsync({
+            authUrl: `https://MYSUPABASEAPP.supabase.co/auth/v1/authorize?provider=${provider}&redirect_to=${redirectUri}`,
+            returnUrl: redirectUri,
+          }).then(async (response: any) => {
+            if (!response) return;
+            const { user, session, error } = await supabase.auth.signIn({
+              refreshToken: response.params?.refresh_token,
+            });
+          });
+          ```
 
   auth.signOut():
     $ref: '@supabase/gotrue-js."GoTrueClient".GoTrueClient.signOut'


### PR DESCRIPTION
## What kind of change does this PR introduce?

This updates documentation with an example for login with a refresh token

## Additional context

I included an example using Expo's `AuthSession` API, that may or may not be helpful, let me know.
