### PR TITLE
Change JWT claim from 'Role' to 'role' in self-hosting docs

### DIFF
--- a/web/docs/guides/self-hosting.mdx
+++ b/web/docs/guides/self-hosting.mdx
@@ -97,7 +97,7 @@ The data you will need to encode includes:
  "exp": 2550653634,
  "aud": "",
  "sub": "",
- "Role": "anon"
+ "role": "anon"
 }
 # service_role Payload:
 {
@@ -106,7 +106,7 @@ The data you will need to encode includes:
  "exp": 2550653634,
  "aud": "",
  "sub": "",
- "Role": "service_role"
+ "role": "service_role"
 }
 ```
  


### PR DESCRIPTION
Since [`auth.role()` relies on the `role` claim](https://github.com/supabase/supabase/blob/master/docker/dockerfiles/postgres/auth-schema.sql#L82), the payload should also have a lowercase `role` claim.

Spent a good amount of time wondering why my local `service_role` was not bypassing RLS :D