### PR TITLE
fix: Fix grammar mistake in React quickstart docs

### DIFF
--- a/web/docs/guides/with-nextjs.mdx
+++ b/web/docs/guides/with-nextjs.mdx
@@ -14,7 +14,7 @@ This example provides the steps to build a simple user management app (from scra
 - Supabase [Database](/docs/guides/database): a Postgres database for storing your user data.
 - Supabase [Auth](/docs/guides/auth): users can sign in with magic links (no passwords, only email).
 - Supabase [Storage](/docs/guides/storage): users can upload a photo.
-- [Row Level Security](/docs/guides/auth#row-level-security): data is be protected so that individuals can only access their own data.
+- [Row Level Security](/docs/guides/auth#row-level-security): data is protected so that individuals can only access their own data.
 - Instant [APIs](/docs/guides/api): APIs will be automatically generated when you create your database tables.
 
 By the end of this guide you'll have an app which allows users to login and update some basic profile details:

--- a/web/docs/guides/with-react.mdx
+++ b/web/docs/guides/with-react.mdx
@@ -14,7 +14,7 @@ This example provides the steps to build a simple user management app (from scra
 - Supabase [Database](/docs/guides/database): a Postgres database for storing your user data.
 - Supabase [Auth](/docs/guides/auth): users can sign in with magic links (no passwords, only email).
 - Supabase [Storage](/docs/guides/storage): users can upload a photo.
-- [Row Level Security](/docs/guides/auth#row-level-security): data is be protected so that individuals can only access their own data.
+- [Row Level Security](/docs/guides/auth#row-level-security): data is protected so that individuals can only access their own data.
 - Instant [APIs](/docs/guides/api): APIs will be automatically generated when you create your database tables.
 
 By the end of this guide you'll have an app which allows users to login and update some basic profile details:

--- a/web/spec/combined.json
+++ b/web/spec/combined.json
@@ -3310,7 +3310,7 @@
                         "isExported": true
                       },
                       "comment": {
-                        "shortText": "Inside a browser context, `signOut()` will remove extract the logged in user from the browser session\nand log them out - removing all items from localstorage and then trigger a \"SIGNED_OUT\" event.",
+                        "shortText": "Inside a browser context, `signOut()` will remove the logged in user from the browser session\nand log them out - removing all items from localstorage and then trigger a \"SIGNED_OUT\" event.",
                         "text": "For server-side management, you can disable sessions by passing a JWT through to `auth.api.signOut(JWT: string)`\n"
                       },
                       "type": {
@@ -13230,7 +13230,7 @@
                         "isExported": true
                       },
                       "comment": {
-                        "shortText": "Inside a browser context, `signOut()` will remove extract the logged in user from the browser session\nand log them out - removing all items from localstorage and then trigger a \"SIGNED_OUT\" event.",
+                        "shortText": "Inside a browser context, `signOut()` will remove the logged in user from the browser session\nand log them out - removing all items from localstorage and then trigger a \"SIGNED_OUT\" event.",
                         "text": "For server-side management, you can disable sessions by passing a JWT through to `auth.api.signOut(JWT: string)`\n"
                       },
                       "type": {

--- a/web/spec/gotrue.json
+++ b/web/spec/gotrue.json
@@ -5871,7 +5871,7 @@
                     "isExported": true
                   },
                   "comment": {
-                    "shortText": "Inside a browser context, `signOut()` will remove extract the logged in user from the browser session\nand log them out - removing all items from localstorage and then trigger a \"SIGNED_OUT\" event.",
+                    "shortText": "Inside a browser context, `signOut()` will remove the logged in user from the browser session\nand log them out - removing all items from localstorage and then trigger a \"SIGNED_OUT\" event.",
                     "text": "For server-side management, you can disable sessions by passing a JWT through to `auth.api.signOut(JWT: string)`\n"
                   },
                   "type": {

--- a/web/spec/supabase.json
+++ b/web/spec/supabase.json
@@ -3307,7 +3307,7 @@
                     "isExported": true
                   },
                   "comment": {
-                    "shortText": "Inside a browser context, `signOut()` will remove extract the logged in user from the browser session\nand log them out - removing all items from localstorage and then trigger a \"SIGNED_OUT\" event.",
+                    "shortText": "Inside a browser context, `signOut()` will remove the logged in user from the browser session\nand log them out - removing all items from localstorage and then trigger a \"SIGNED_OUT\" event.",
                     "text": "For server-side management, you can disable sessions by passing a JWT through to `auth.api.signOut(JWT: string)`\n"
                   },
                   "type": {


### PR DESCRIPTION
## What kind of change does this PR introduce?
Removed "be" from sentence. Sentence originally read "data is be protected so...".
