### PR TITLE
docs: Adds RedwoodJS Authentication Example

### DIFF
--- a/web/docs/guides/examples.mdx
+++ b/web/docs/guides/examples.mdx
@@ -20,6 +20,7 @@ Build a basic Todo List with Supabase and your favorite frontend framework:
 
 - [Supabase Auth with vanilla Javascript.](https://github.com/supabase/supabase/tree/master/examples/javascript-auth). Use Supabase without any frontend frameworks.
 - [Supabase Auth with Next.js SSR.](https://github.com/supabase/supabase/tree/master/examples/nextjs-with-supabase-auth) Uses cookies to persist auth between the server and the client.
+- [Supabase Auth with RedwoodJS.](https://redwood-playground-auth.netlify.app/supabase) Try out Supabase authentication in the [RedwoodJS](https://redwoodjs.com) Authenticaton Playground complete with OAuth support and code samples.
 
 ## Collaborative
 


### PR DESCRIPTION
This PR adds the RedwoodJS Authentication Example to the authentication documentation. 

This links to a showcase of the [Authentication Playground](https://redwood-playground-auth.netlify.app/supabase) which demos email and password sign up/in and also several third-party OAuth providers (Google and GitHub are enabled). 

RedwoodJS Code examples as also included to create a basic login and signup form.

## What is the current behavior?

RedwoodJS is not represented as an example.

## What is the new behavior?

RedwoodJS is represented as an example.

## Additional context

![image](https://user-images.githubusercontent.com/1051633/120519806-11c1da00-c3a1-11eb-970b-65b753edc470.png)
