### PR TITLE
docs: added missing step in development.md tab 3

### DIFF
--- a/development.md
+++ b/development.md
@@ -20,6 +20,7 @@ npm run dev
 # tab 3
 cd web/spec
 make
+npm install
 npm run gen:supabase
 npm run build
 


### PR DESCRIPTION
# What kind of change does this PR introduce?
Development documentation change 

# What is the current behavior?

[_development.md_](https://github.com/supabase/supabase/blob/master/development.md)  is missing a step in __tab 3__ instructions

# What is the new behavior?

Adds `npm install` step to __tab 3__ instructions in _development.md_

# Additional context
Following current steps without running `npm install` generates cryptic errors giving no indication of what's wrong. 
Had to rely on common sense to realise no dependencies were installed for web dir. 
