### PR TITLE
Add `scroll-behavior: smooth` globally on the site

### DIFF
--- a/web/src/css/custom.css
+++ b/web/src/css/custom.css
@@ -224,6 +224,7 @@
 html,
 body {
   font-smoothing: antialiased;
+  scroll-behavior: smooth;
   text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;


### PR DESCRIPTION
## What kind of change does this PR introduce?

At the moment, when you link to a part of a page by id (url#id), you get a sudden move, and it's surprising, especially if you have slow page loads. This PR adds `scroll-behavior: smooth;` to the global CSS file to make that transition smoother.

## What is the current behavior?

When you link to a certain part of a page (e.g. https://supabase.io/docs/handbook/contributing#contributors), the page first links to the top of the page and then suddenly jumps to the part of the page that was linked to.

## What is the new behavior?

Now, the pages smoothly scroll, causing less of a sudden change and makes it easier on the eyes.

## Screenshots

#### Current

![current](https://user-images.githubusercontent.com/78233879/121092295-51316180-c7b9-11eb-89e0-a00a6ae647d5.gif)

#### New

![new](https://user-images.githubusercontent.com/78233879/121092322-5c848d00-c7b9-11eb-94f5-58bbfa127cb0.gif)

