### PR TITLE
Change some mentions of React to Next

### DIFF
--- a/web/docs/guides/with-nextjs.mdx
+++ b/web/docs/guides/with-nextjs.mdx
@@ -1,7 +1,7 @@
 ---
 id: with-nextjs
 title: "Quickstart: Next.js"
-description: Learn how to use Supabase in your React App.
+description: Learn how to use Supabase in your Next App.
 ---
 
 import Tabs from '@theme/Tabs';
@@ -165,7 +165,7 @@ values={[
 
 Let's start building the Next.js app from scratch.
 
-### Initialize a react app
+### Initialize a Next.js app
 
 We can use [`create-next-app`](https://nextjs.org/docs/getting-started) to initialize 
 an app called `supabase-nextjs`:


### PR DESCRIPTION
## What kind of change does this PR introduce?

There are a couple times where React is mentioned in the Next.js quickstart, where it should really be Next. This PR fixes that.

## What is the current behavior?

The guide mentions React in the description and in the initializing section, but it should reference Next, not react.

## What is the new behavior?

This PR changes the incorrect mentions of React to Next.
