### PR TITLE
Rename script name to run on action

### DIFF
--- a/web/spec/supabase.yml
+++ b/web/spec/supabase.yml
@@ -253,7 +253,7 @@ pages:
             - uses: actions/setup-node@v2.1.5
               with:
                 node-version: 14
-            - run: npm run update-database-types
+            - run: npm run update-types
             - name: check for file changes
               id: git_status
               run: |


### PR DESCRIPTION
This change renames the script name that's run on the GitHub action to be equal to the name used on the instruction above ("Add a script to your package.json to generate the types").

## What kind of change does this PR introduce?

Docs update.

## What is the current behavior?

The script running on the GitHub action is called "update-database-types".

## What is the new behavior?

The script running on the GitHub action is called "update-types".
