### PR TITLE
docs: adding email update example. This addresses issue 1845

### DIFF
--- a/web/spec/gotrue.yml
+++ b/web/spec/gotrue.yml
@@ -173,6 +173,18 @@ pages:
           ```py
           # Not yet implemented
           ```
+      - name: Update a user's email address.
+        isSpotlight: true
+        js: |
+          ```js
+          const { user, error } = await auth.update({
+            email: 'new-email@example.com'
+          }) // Sends a "Confirm Email Change" email to the new email address
+          ```
+        py: |
+          ```py
+          # Not yet implemented
+          ```
 
   onAuthStateChange:
     $ref: '"GoTrueClient".GoTrueClient.onAuthStateChange'


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

no example for updating user's email as [highlighted by this issue](https://github.com/supabase/supabase/issues/1845) 

## What is the new behavior?

Adds email update example showing that `supabase.auth.update` when updating an email is equivalent to Firebase's `verifyBeforeUpdateEmail()` 
