### PR TITLE
Add different font style for docs sidebar headers

### DIFF
--- a/web/src/css/custom.css
+++ b/web/src/css/custom.css
@@ -512,6 +512,10 @@ a.card:hover {
 .menu > .menu__list > .menu__list-item > .menu__link {
   margin-bottom: 4px;
   color: gray;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 1px;
+  text-transform: uppercase;
 }
 
 /* Disable click events for large screens  */


### PR DESCRIPTION
## What kind of change does this PR introduce?

A style change on the headers of the docs sidebar, to improve the distinction from the link items.

## What is the current behavior?

The current sidebar headers on the docs are similar to link items, only differentiated by a lower-opacity colour and more spacing, possibly making someone think of it as a disabled link.

## What is the new behavior?

Proposed headers are more distinct from the links, with bolder and uppercase letters, for easier scannability and better hierarchy cue. 

## Additional context

This is a totally unrequested change to the style, which also might diverge from the brand styling, so I understand if this is not accepted.

And here's a quick overview of the new look.

<img src="https://user-images.githubusercontent.com/12413903/121378198-4571a680-c943-11eb-9c1d-df5ae4285fa2.png" alt="sidebar comparison" width="600"/>

