### PR TITLE
Add supabase-py installation instructions.

### DIFF
--- a/web/spec/supabase.yml
+++ b/web/spec/supabase.yml
@@ -116,7 +116,16 @@ pages:
       npm install @supabase/supabase-js
       ```
 
-      Find the source code on [GitHub](https://github.com/supabase/supabase-js).
+      Find the source code on [GitHub](https://github.com/supabase/supabase-js).  
+      
+      ## Python
+
+      ```bash
+      pip install supabase-py
+      ```
+
+      Find the source code on [GitHub](https://github.com/supabase/supabase-py).
+      
 
   Initializing:
     $ref: '@supabase/supabase-js."SupabaseClient".SupabaseClient.constructor'


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add Python installation using ¨pip install supabase-py¨

## What is the current behavior?

The Installing page in the reference documentation only includes the Javascript version. 

## What is the new behavior?

Add instructions to install the Python version using pip.
