### PR TITLE
Removed period for formatting consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For full documentation, visit [supabase.io/docs](https://supabase.io/docs)
 ## Status
 
 - [x] Alpha: We are testing Supabase with a closed set of customers
-- [x] Public Alpha: Anyone can sign up over at [app.supabase.io](https://app.supabase.io). But go easy on us, there are a few kinks.
+- [x] Public Alpha: Anyone can sign up over at [app.supabase.io](https://app.supabase.io). But go easy on us, there are a few kinks
 - [x] Public Beta: Stable enough for most non-enterprise use-cases
 - [ ] Public: Production-ready
 


### PR DESCRIPTION
'Public Alpha' bullet point in the 'Status' section has a period at the end.