### PR TITLE
docs: make app.supabase.io a proper link on Quickstarts

### DIFF
--- a/web/docs/guides/with-nextjs.mdx
+++ b/web/docs/guides/with-nextjs.mdx
@@ -557,4 +557,4 @@ return (
 At this stage you have a fully functional application!
 
 - Got a question? [Ask here](https://github.com/supabase/supabase/discussions).
-- Sign in: app.supabase.io
+- Sign in: [app.supabase.io](https://app.supabase.io)

--- a/web/docs/guides/with-react.mdx
+++ b/web/docs/guides/with-react.mdx
@@ -553,4 +553,4 @@ return (
 At this stage you have a fully functional application!
 
 - Got a question? [Ask here](https://github.com/supabase/supabase/discussions).
-- Sign in: app.supabase.io
+- Sign in: [app.supabase.io](https://app.supabase.io)

--- a/web/docs/guides/with-svelte.mdx
+++ b/web/docs/guides/with-svelte.mdx
@@ -547,4 +547,4 @@ And then we can add the widget to the Account page:
 At this stage you have a fully functional application!
 
 - Got a question? [Ask here](https://github.com/supabase/supabase/discussions).
-- Sign in: app.supabase.io
+- Sign in: [app.supabase.io](https://app.supabase.io)

--- a/web/docs/guides/with-vue-3.mdx
+++ b/web/docs/guides/with-vue-3.mdx
@@ -597,4 +597,4 @@ And then we can add the widget to the Account page:
 At this stage you have a fully functional application!
 
 - Got a question? [Ask here](https://github.com/supabase/supabase/discussions).
-- Sign in: app.supabase.io
+- Sign in: [app.supabase.io](https://app.supabase.io)


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

On the 'Next steps' step of the Quickstart Tutorials, `app.supabase.io` is a text content rather than a link.
For example https://supabase.io/docs/guides/with-nextjs#next-steps

![image](https://user-images.githubusercontent.com/32737308/125257661-ee723f00-e2fd-11eb-9375-22d1f770021a.png)


## What is the new behavior?

`app.subase.io` is a link : 
![image](https://user-images.githubusercontent.com/32737308/125258329-87a15580-e2fe-11eb-935a-b00d86fa5fb8.png)


## Additional context

The changes aren't reflected in the apps automatically deployed with Vercel on this PR.
The changes work fine when running the app locally by executing the following commands :

```bash
cd web
npm run gen:all
npm run start
```

