### PR TITLE
Add an "email change" example in the GoTrue docs

### DIFF
--- a/web/spec/gotrue.yml
+++ b/web/spec/gotrue.yml
@@ -291,6 +291,22 @@ pages:
 
   api.updateUser:
     $ref: '"GoTrueApi".GoTrueApi.updateUser'
+    notes: |
+      Updating the `email` field will cause a "Confirm Email Change" email to be sent to the new address.
+
+      When the user clicks the Confirm link in the Confirm Change email they will be forwarded to:
+
+      `<SITE_URL>?email_change_token=x&type=email_change&redirect_to=y`
+
+      Your app must detect the `email_change_token` in the search params.
+
+      You should then use the `email_change_token` in the url to update the user's email as follows:
+
+      ```js
+      const { error, data } = await supabase.auth.update({
+        email_change_token: emailChangeToken,
+      });
+      ```
     examples:
       - name: Update user info that Gotrue holds (also used for setting new passwords)
         js: |


### PR DESCRIPTION
## What kind of change does this PR introduce?
Docs update!

## What is the current behavior?
The flow for updating a user's e-mail is not described in the current docs.

## What is the new behavior?
I added an explanation of what happens after calling `updateUser` and clicking "Confirm" in the "Confirm Email Change" mail.

## Additional context
There is no issue but there is a discussion about it.
https://github.com/supabase/supabase/discussions/1763

The template for the "Confirm Email Change" e-mail and its subject is not yet available in the dashboard. Maybe create a follow-up issue to document the way of providing a template via API, and perhaps adding it to the dashboard (I know the dashboard's code is not open yet).

Keep up the good work! Supabase rocks.