### PR TITLE
fix http postgresql extension typo

### DIFF
--- a/web/docs/guides/database/extensions/http.mdx
+++ b/web/docs/guides/database/extensions/http.mdx
@@ -52,10 +52,10 @@ values={[
 ```sql 
 
 -- Example: enable the "http" extension 
-create extenstion http with schema extensions;
+create extension http with schema extensions;
 
 -- Example: disable the "http" extension 
-drop extenstion if exists http;
+drop extension if exists http;
 
 ```
 


### PR DESCRIPTION
fixing a typo in 2 commands

## What kind of change does this PR introduce?

docs typo

## What is the current behavior?

cmd error

## What is the new behavior?

fixes the typo, therefore error

## Additional context

just a typo
