### PR TITLE
Update Dart Code examples

### DIFF
--- a/web/docs/guides/client-libraries.mdx
+++ b/web/docs/guides/client-libraries.mdx
@@ -56,7 +56,7 @@ user = supabase.auth.sign_up(
 ```dart
 import 'package:supabase/supabase.dart';
 
-main() {
+void main() async {
   final client = SupabaseClient('supabaseUrl', 'supabaseKey');
 
   // Sign up user with email and password
@@ -113,7 +113,7 @@ user = supabase.auth.sign_in(
 ```dart
 import 'package:supabase/supabase.dart';
 
-main() {
+void main() async {
   final client = SupabaseClient('supabaseUrl', 'supabaseKey');
 
   // Sign up user with email and password
@@ -167,7 +167,7 @@ user = supabase.auth.sign_in(
 ```dart
 import 'package:supabase/supabase.dart';
 
-main() {
+void main() async {
   final client = SupabaseClient('supabaseUrl', 'supabaseKey');
 
   // Sign up user with email and password
@@ -215,13 +215,11 @@ const { user, error } = await supabase.auth.signIn({
 ```dart
 import 'package:supabase/supabase.dart';
 
-main() {
+void main() async {
   final client = SupabaseClient('supabaseUrl', 'supabaseKey');
 
-  // Sign up user with email and password
   final response = await client
       .auth
-      // provider can be 'github', 'google', 'gitlab', or 'bitbucket'
       .signIn(provider: Provider.github);
 }
 ```
@@ -269,7 +267,7 @@ const { data, error } = await supabase
 ```dart
 import 'package:supabase/supabase.dart';
 
-main() {
+void main() async {
   final client = SupabaseClient('supabaseUrl', 'supabaseKey');
 
   // Sign up user with email and password
@@ -319,7 +317,7 @@ const { data, error } = await supabase
 ```dart
 import 'package:supabase/supabase.dart';
 
-main() {
+void main() async {
   final client = SupabaseClient('supabaseUrl', 'supabaseKey');
 
   // Sign up user with email and password
@@ -373,15 +371,15 @@ const { data, error } = await supabase
 ```dart
 import 'package:supabase/supabase.dart';
 
-main() {
+void main() async {
   final client = SupabaseClient('supabaseUrl', 'supabaseKey');
 
   // Sign up user with email and password
   final response = await client
       .from('cities')
       .insert([
-        { name: 'The Shire', country_id: 554 },
-        { name: 'Rohan', country_id: 555 },
+        { 'name': 'The Shire', 'country_id': 554 },
+        { 'name': 'Rohan', 'country_id': 555 },
        ])
       .execute();
 }
@@ -429,7 +427,7 @@ const mySubscription = supabase
 ```dart
 import 'package:supabase/supabase.dart';
 
-main() {
+void main() async {
   final client = SupabaseClient('supabaseUrl', 'supabaseKey');
 
   // Sign up user with email and password
@@ -477,12 +475,12 @@ const mySubscription = supabase
 
 </TabItem>
   
-  <TabItem value="dart">
+<TabItem value="dart">
 
 ```dart
 import 'package:supabase/supabase.dart';
 
-main() {
+void main() async {
   final client = SupabaseClient('supabaseUrl', 'supabaseKey');
 
   // Sign up user with email and password

--- a/web/docs/guides/storage.mdx
+++ b/web/docs/guides/storage.mdx
@@ -47,6 +47,7 @@ values={[
   {label: 'UI', value: 'UI'},
   {label: 'SQL', value: 'SQL'},
   {label: 'JavaScript', value: 'JS'},
+  {label: 'Dart', value: 'DART'},
 ]}>
 <TabItem value="UI">
 
@@ -83,6 +84,21 @@ const { data, error } = await supabase.storage.createBucket('avatars')
 [Reference.](/docs/reference/javascript/storage-createbucket)
 
 </TabItem>
+<TabItem value="DART">
+
+```dart
+void main() async {
+  final client = SupabaseClient('supabaseUrl', 'supabaseKey');
+  
+  final storageResponse = await client
+      .storage
+      .createBucket('avatars');
+}
+```
+
+[Reference.](https://pub.dev/documentation/storage_client/latest/storage_client/SupabaseStorageClient/createBucket.html)
+
+</TabItem>
 </Tabs>
 
 ### Upload a file
@@ -94,6 +110,7 @@ defaultValue="UI"
 values={[
   {label: 'UI', value: 'UI'},
   {label: 'JavaScript', value: 'JS'},
+  {label: 'Dart', value: 'DART'},
 ]}>
 <TabItem value="UI">
 
@@ -121,6 +138,23 @@ const { data, error } = await supabase.storage
 [Reference.](/docs/reference/javascript/storage-from-upload)
 
 </TabItem>
+<TabItem value="DART">
+
+```dart
+void main() async {
+  final client = SupabaseClient('supabaseUrl', 'supabaseKey');
+  
+  // Create file `example.txt` and upload it in `public` bucket
+  final file = File('example.txt');
+  file.writeAsStringSync('File content');
+  final storageResponse = await client
+      .storage
+      .from('public')
+      .upload('example.txt', file);
+}
+```
+
+</TabItem>
 </Tabs>
 
 ### Download a file
@@ -132,6 +166,7 @@ defaultValue="UI"
 values={[
   {label: 'UI', value: 'UI'},
   {label: 'JavaScript', value: 'JS'},
+  {label: 'Dart', value: 'DART'},
 ]}>
 <TabItem value="UI">
 
@@ -156,6 +191,20 @@ const { data, error } = await supabase.storage.from('avatars').download('public/
 ```
 
 [Reference.](/docs/reference/javascript/storage-from-download)
+
+</TabItem>
+<TabItem value="DART">
+
+```dart
+void main() async {
+  final client = SupabaseClient('supabaseUrl', 'supabaseKey');
+  
+  final storageResponse = await client
+      .storage
+      .from('public')
+      .download('example.txt');
+}
+```
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Documentation update

---

Continuation of #2407 

Added Dart code examples to "Storage" docs, and updated current dart code.

I don't know why, but dart code is not being highlighted:

![supabase-docs-dart](https://user-images.githubusercontent.com/45696119/126070570-4417527c-3e35-4d55-b1d6-20dfde5d6c14.png)

It should be something like:

```dart
import 'package:supabase/supabase.dart';

main() {
  final client = SupabaseClient('supabaseUrl', 'supabaseKey');
  // Sign up user with email and password
  final response = await client
      .auth
      .signUp('example@email.com', 'example-password');
}
```
