### PR TITLE
docs: refactor comments in Dart code samples, to clarify intent

### DIFF
--- a/web/docs/guides/client-libraries.mdx
+++ b/web/docs/guides/client-libraries.mdx
@@ -116,7 +116,7 @@ import 'package:supabase/supabase.dart';
 void main() async {
   final client = SupabaseClient('supabaseUrl', 'supabaseKey');
 
-  // Sign up user with email and password
+  // Sign in user with email and password
   final response = await client
       .auth
       .signIn(email: 'example@email.com', password: 'example-password');
@@ -170,7 +170,7 @@ import 'package:supabase/supabase.dart';
 void main() async {
   final client = SupabaseClient('supabaseUrl', 'supabaseKey');
 
-  // Sign up user with email and password
+  // Sign in user with email and magic link
   final response = await client
       .auth
       .signIn(email: 'example@email.com');
@@ -270,7 +270,7 @@ import 'package:supabase/supabase.dart';
 void main() async {
   final client = SupabaseClient('supabaseUrl', 'supabaseKey');
 
-  // Sign up user with email and password
+  // Query tables and fetch related data in one round-trip, using select()
   final response = await client
       .from('countries')
       .select('name')
@@ -320,7 +320,7 @@ import 'package:supabase/supabase.dart';
 void main() async {
   final client = SupabaseClient('supabaseUrl', 'supabaseKey');
 
-  // Sign up user with email and password
+  // When fetching data, use advanced filtering to only extract data, that you need.
   final response = await client
       .from('cities')
       .select('name,country_id')
@@ -374,7 +374,7 @@ import 'package:supabase/supabase.dart';
 void main() async {
   final client = SupabaseClient('supabaseUrl', 'supabaseKey');
 
-  // Sign up user with email and password
+  // Create data easily, using insert()
   final response = await client
       .from('cities')
       .insert([
@@ -430,7 +430,7 @@ import 'package:supabase/supabase.dart';
 void main() async {
   final client = SupabaseClient('supabaseUrl', 'supabaseKey');
 
-  // Sign up user with email and password
+  // Listen to realtime database changes, using subscribe()
   final response = await client
       .from('countries')
       .on(SupabaseEventTypes.all, (payload) {
@@ -483,7 +483,7 @@ import 'package:supabase/supabase.dart';
 void main() async {
   final client = SupabaseClient('supabaseUrl', 'supabaseKey');
 
-  // Sign up user with email and password
+  // You can even listen to Row Level changes
   final response = await client
       .from('countries:id.eq.200')
       .on(SupabaseEventTypes.update, (payload) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Documentation updates

## What is the current behavior?

For [Dart code samples here](https://supabase.io/docs/guides/client-libraries#auth), the following comment appears, where intent is not to sign up user with email and password.

`// Sign up user with email and password`

Here's an example:

![comment-error](https://user-images.githubusercontent.com/48694187/126716811-b37d6cba-bd2b-47d3-b713-56ac8d2ccf67.png)

Here, the comment should have been:

`// Sign in user with email and password`

There are more scenarios like this one. 

## What is the new behavior?

This proposal adds relevant comments, to make the code intent clearer
