### PR TITLE
feat: Added example for how to use row level security to implement TTL

### DIFF
--- a/web/docs/guides/auth.mdx
+++ b/web/docs/guides/auth.mdx
@@ -248,6 +248,31 @@ create policy "Only Blizzard staff can update leaderboard"
   );
 ```
 
+### Time to live for rows
+
+Policies can also be used to implement TTL or time to live feature that you see in Instagram stories or Snapchat. 
+In the following example, rows of `stories` table are available only if they have been created within the last 24 hours. 
+
+```sql
+-- 1. Create table
+create table if not exists stories (
+  id uuid not null primary key DEFAULT uuid_generate_v4(),
+  created_at timestamp with time zone default timezone('utc' :: text, now()) not null,
+  content text not null
+);
+
+-- 2. Enable RLS
+alter table stories 
+  enable row level security;
+
+-- 3. Create Policy
+create policy "Stories are live for a day"
+  on stories
+  for select using (
+    created_at > (current_timestamp - interval '1 day')
+  ); 
+```
+
 ### Advanced policies
 
 Use the full power of SQL to build extremely advanced rules.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Inspired by the following discussion post, I added a new example for utilizing row level security policy for implementing TTL like in Instagram stories or Snapchat. 

https://github.com/supabase/supabase/discussions/2362

## What is the current behavior?

No example about TTL

## What is the new behavior?

I added an example for how to create row level security policy of how to restrict the access to those posts that were created within the last 24 hours. 
```sql
create policy "Stories are live for a day"
  on stories
  for select using (
    created_at > (current_timestamp - interval '1 day')
  ); 
```