### PR TITLE
switches the days with footnote

### DIFF
--- a/www/_blog/2021-07-22-supabase-launch-week-sql.mdx
+++ b/www/_blog/2021-07-22-supabase-launch-week-sql.mdx
@@ -37,33 +37,33 @@ One of the best things about building Supabase is the community. We're even luck
 
 Blog post coming soon. Follow our [Twitter](https://twitter.com/supabase) to get notified immediately.
 
-## Tuesday 27 July: Auth v2
-
-![Supabase Auth v2](/new/images/blog/launch-week-sql/auth-v2.png)
-
-### **When?**
-
-Tuesday 27 July 2021.
-
-### What?
-
-What's cooler than Arnie in the 90's? Passwordless logins. We've [already](https://supabase.io/docs/guides/auth/auth-apple) [built](https://supabase.io/docs/guides/auth/auth-bitbucket) [support](https://supabase.io/docs/guides/auth/auth-discord) [for](https://supabase.io/docs/guides/auth/auth-facebook) [eight](https://supabase.io/docs/guides/auth/auth-github) [different](https://supabase.io/docs/guides/auth/auth-gitlab) [Oauth](https://supabase.io/docs/guides/auth/auth-google) [providers](https://supabase.io/docs/guides/auth/auth-twitter), so it's anyone's guess what can happen in Supabase Auth Episode II.
-
-### Where?
-
-Blog post coming soon. Follow our [Twitter](https://twitter.com/supabase) to get notified immediately.
-
-## Wednesday 28 July: Storage v2
+## Tuesday 27 July: Storage v2
 
 ![Supabase storage v2](/new/images/blog/launch-week-sql/storage.png)
 
 ### **When?**
 
-Wednesday 28 July 2021.
+Tuesday 27 July 2021.[^1]
 
 ### What?
 
 We shipped [Version 1 of Supabase Storage](https://supabase.io/blog/2021/03/30/supabase-storage) in the last Launch Week, and now we've had 4 months to work on Storage Reloaded.
+
+### Where?
+
+Blog post coming soon. Follow our [Twitter](https://twitter.com/supabase) to get notified immediately.
+
+## Wednesday 28 July: Auth v2
+
+![Supabase Auth v2](/new/images/blog/launch-week-sql/auth-v2.png)
+
+### **When?**
+
+Wednesday 28 July 2021.[^1]
+
+### What?
+
+What's cooler than Arnie in the 90's? Passwordless logins. We've [already](https://supabase.io/docs/guides/auth/auth-apple) [built](https://supabase.io/docs/guides/auth/auth-bitbucket) [support](https://supabase.io/docs/guides/auth/auth-discord) [for](https://supabase.io/docs/guides/auth/auth-facebook) [eight](https://supabase.io/docs/guides/auth/auth-github) [different](https://supabase.io/docs/guides/auth/auth-gitlab) [Oauth](https://supabase.io/docs/guides/auth/auth-google) [providers](https://supabase.io/docs/guides/auth/auth-twitter), so it's anyone's guess what can happen in Supabase Auth Episode II.
 
 ### Where?
 
@@ -100,3 +100,9 @@ We all know that the best [SeQueLs](https://www.reddit.com/r/SequelMemes/) are a
 ### Where?
 
 Blog post coming soon. Follow our [Twitter](https://twitter.com/supabase) to get notified immediately.
+
+
+[^1]: 
+When we first announced, Storage was on Wednesday and Auth was on Tuesday. We switchd the order of these as we are doing a 
+Storage [presentation](https://www.meetup.com/the-monthly-dev-world-class-talks-by-expert-developers/events/278158726/) with 
+[daily.dev](https://daily.dev/) on Wednesday.


### PR DESCRIPTION
When we first announced, Storage was on Wednesday and Auth was on Tuesday. We switchd the order of these as we are doing a Storage [presentation](https://www.meetup.com/the-monthly-dev-world-class-talks-by-expert-developers/events/278158726/) with [daily.dev](https://daily.dev/) on Wednesday.