### PR TITLE
Adjusted search_path for postgres user

### DIFF
--- a/docker/dockerfiles/postgres/auth-schema.sql
+++ b/docker/dockerfiles/postgres/auth-schema.sql
@@ -88,6 +88,6 @@ $$ language sql stable;
 GRANT ALL PRIVILEGES ON SCHEMA auth TO postgres;
 GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA auth TO postgres;
 GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA auth TO postgres;
-ALTER ROLE postgres SET search_path = "$user", public, auth;
+ALTER ROLE postgres SET search_path = "$user", auth, public;
 
 GRANT USAGE ON SCHEMA auth TO anon, authenticated, service_role;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Self-hosting bugfix

## What is the current behavior?

Search path would prioritise the `public` schema for searching.

## What is the new behavior?

Proposed change: Will now prioritise the `auth` schema first.

Reasoning: If a `public.users` table exists, calling `signUp()` will fail unless the structure matches that of `auth.users`.

I have confirmed that this is the order that is set against a project hosted on the Supabase platform.

## Additional context

Relevant discussion: https://github.com/supabase/supabase/discussions/2499

If this could cause other issues, please let me know.