### PR TITLE
chore: minor grammatical fixes

### DIFF
--- a/www/_blog/2021-07-26-epsilon3-self-hosting.mdx
+++ b/www/_blog/2021-07-26-epsilon3-self-hosting.mdx
@@ -13,7 +13,7 @@ date: '2021-07-26'
 toc_depth: 2
 ---
 
-Epsilon3 are a USA based Y-Combinator backed startup leveraging telemetry data to digitise paper based procedures for complex
+Epsilon3 are a USA-based Y-Combinator backed startup leveraging telemetry data to digitise paper-based procedures for complex
 testing and operations. Their product is rapidly becoming the OS for space projects and complex operations.
 
 Learn how the team at Epsilon3 use Supabase to help teams execute secure and reliable operations in an industry that
@@ -22,32 +22,32 @@ project spend runs into the billions.
 ### Space Operations
 
 Epsilon3 are modernising the industry by leveraging telemetry data to digitise paper procedures in space operations.
-Their customers need to run testing and operational procedures in real time. Using Epsilon3's solution means people can
+Their customers need to run testing and operational procedures in real-time. Using Epsilon3's solution means people can
 collaborate online as a team instead of being siloed and separated, an increasingly important requirement in a post-pandemic working world.
-Epsilon3 are powering an industry where reliability is a must. In the space industry missions cost billions and need to run reliably.
+Epsilon3 are powering an industry where reliability is a must&mdash;missions cost billions and need to run reliably.
 
 ![Epsilon3 digitize paper-based processes.](/new/images/blog/epsilon3/epsilon3-product.gif)
 
-The stakes are high when working on projects where failure entails huge potential financial losses. Epsilon3's software saves
+The stakes are high when working on projects where failure could entail huge financial losses. Epsilon3's software saves
 operators time and reduces errors to improve complex operations. Their customers are already using their software and successfully
 sending satellites into space, and are about to use Epsilon3's software for an operational Rocket Launch. As a result, their
-software reputation for improving the quality standard for complex operations has led to demand from other industries.
+software's reputation for improving the quality standard for complex operations has led to demand from other industries.
 The team now have enquiries from clients in the robotics, logistics and medical equipment sectors who need a structured and standardised
 way of running procedures and keeping audit trails.
 
 **Moving fast in regulated markets**
 
-The team has a background in engineering from Northrop, Google, and SpaceX and understand the technical benefits Postgres offers as a
-battle tested open-source relational database.
+The team have a background in engineering from Northrop, Google, and SpaceX, and understand the technical benefits Postgres offers as a
+battle-tested open-source relational database.
 
-Whilst the team know they want to use Postgres, they also understand setting up a scalable back-end takes time and must be maintained.
-Realtime functionality is also a key for their customers so they can see how running procedures are progressing in real time.
+Whilst the team know they want to use Postgres, they also understand that setting up a scalable back-end takes time, and imposes an ongoing maintenance burden.
+Realtime functionality is also a key for their customers so they can see how running procedures are progressing in real-time.
 
 As a startup, Epsilon3 need to move fast AND scale. They require security, reliability, and performance.
 
-The space industry is highly regulated adding complexity. For example, in the USA deployments must be in an ITAR-compliant way like AWS
-GovCloud while customers in countries outside the USA may need to host their data within their own country.
-This means that Epsilon3 must be able to offer flexible hosting options, including on premises deployment.
+The space industry is highly regulated, imposing additional complexity. For example, in the USA, deployments must be in an ITAR-compliant environment like AWS
+GovCloud, while customers in countries outside the USA may need to host their data within their own country.
+This means that Epsilon3 must be able to offer flexible hosting options, including on-premises deployment.
 
 <Quote
   img="aaron-epsilon3.png"
@@ -71,21 +71,21 @@ This means that Epsilon3 must be able to offer flexible hosting options, includi
 
 **Supabase gives Postgres users Supa-powers**
 
-The team implemented a self hosted Supabase setup. For a customer in production in the USA this means they can use AWS infrastructure with
-the Supabase API powering an RDS Postgres instance. This gives the perfect balance of rapid development, reduced DevOps, and flexible hosting
-options - crucial for their customers. As Supabase uniquely offers realtime for Postgres they are able to allow their customers to see updates
-from running procedures. Supabase also offers well supported client libraries that make row level security easy to use, which is crucial for the
-Epsilon3 team to deliver on their future roadmap. Finally all this is easy and fast for the team to set up, even when self hosting which means
-the team can focus on what they do best - helping their customers run complex operations smoothly.
+The team implemented a self-hosted Supabase setup. For a customer in production in the USA, this means they can use AWS infrastructure with
+the Supabase API powering an RDS Postgres instance. This gives the perfect balance of rapid development, reduced DevOps burden, and flexible hosting
+options&mdash;crucial for their customers. As Supabase uniquely offers Realtime for Postgres, they can allow their customers to see updates
+from running procedures. Supabase also offers well-supported client libraries that make row-level security easy to use, which is crucial for the
+Epsilon3 team to deliver on their future roadmap. Finally, all this is easy and fast for the team to set up, even when self-hosting, which means
+the team can focus on what they do best&mdash;helping their customers run complex operations smoothly.
 
-With this implementation Epsilon3 get all the benefits of Postgres plus the smooth developer experience and support that Supabase is known for,
+With this implementation, Epsilon3 get all the benefits of Postgres plus the smooth developer experience and support that Supabase is known for,
 without making compromises to meet compliance needs.
 
 ![Epsilon3 use Supabase for hosting their critical infrastructure.](/new/images/blog/epsilon3/supabase-epsilon3-architecture.png)
 
 ### Self-hosted Supabase, a superpower
 
-Self-hosting Supabase means the crew at Epsilon3 are able to move fast to revolutionise space operations securely and reliably in realtime
+Self-hosting Supabase means the crew at Epsilon3 are able to move fast to revolutionise space operations securely and reliably in real-time
 whilst staying compliant. The team are now seeing demand from other industries and are confident in their scaling capability because
 they know it's just Postgres under the hood. Check out the Epsilon3 website to learn more about the team and their OS for space operations.
-If you are interested in self-hosting Supabase then you can do XYZ action.
+If you are interested in self-hosting Supabase, then you can do XYZ action.


### PR DESCRIPTION
Mostly minor grammatical changes:
- hyphenation where appropriate
- em dashes instead of hyphens
- some minor rephrasing
- more consistently treating collective nouns as plural (TIL that British English does this)
