### PR TITLE
Changing the argument order provided to execute function

### DIFF
--- a/web/docs/guides/database/extensions/plv8.mdx
+++ b/web/docs/guides/database/extensions/plv8.mdx
@@ -128,7 +128,7 @@ returns smallint as $$
 
     var num_affected = plv8.execute(
         'udpate profiles set first_name = $1 where id = $2', 
-        [id, first_name]
+        [first_name, id]
     );
 
     return num_affected;


### PR DESCRIPTION
On line 131 the arguments provided to the 'execute' function was in reverse order, Correcting the order

## What kind of change does this PR introduce?

Doc Update

## What is the current behavior?

https://supabase.io/docs/guides/database/extensions/plv8

https://paste.pics/fc16659c9c746a0b20a6702887aa00ae

## What is the new behavior?

Changed the order of arguments

## Additional context

Just a small argument order change 
