### PR TITLE
Fixed link markdown format

### DIFF
--- a/web/docs/guides/local-development.mdx
+++ b/web/docs/guides/local-development.mdx
@@ -33,7 +33,7 @@ In the meantime, here are some suggested tools for interacting with your Postgre
 ## Prerequisites
 
 Our CLI makes heavy use of [Docker Compose](https://docs.docker.com/compose/install), so make sure it is installed and configured to 
-[run with elevated priveleges][https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user].
+[run with elevated priveleges](https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user).
 
 You will also need to install [NPM](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm).
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixed the markdown format for a link under the **Prerequisites** section.

## What is the current behavior?

The link is not correctly formatted, so it’s not actionable. 

## What is the new behavior?

The link is now correctly formatted and actionable. 

## Additional context

n/a
