### PR TITLE
Update docs: auth.update() for email addresses

### DIFF
--- a/web/spec/supabase.yml
+++ b/web/spec/supabase.yml
@@ -426,6 +426,14 @@ pages:
             data: { hello: 'world' } 
           })
           ```
+        - name: Update a user's email address.
+        isSpotlight: true
+        js: |
+          ```js
+          const { user, error } = await auth.update({
+  email: 'new-email@example.com'
+}) // Sends a "Confirm Email Change" email to the new email address
+          ```
 
   auth.onAuthStateChange():
     $ref: '@supabase/gotrue-js."GoTrueClient".GoTrueClient.onAuthStateChange'


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

Missing a code example

## What is the new behavior?

I've reintroduced a code example from the old docs: https://supabase.io/docs/gotrue/client/update#update-a-users-email-address
I wasn't sure this was possible until I found this, and it looks like it works, so may be handy to have in up to date docs.

## Additional context

Add any other context or screenshots.
