### PR TITLE
Fix typo in 'Set up the database schema' list

### DIFF
--- a/web/docs/guides/with-nextjs.mdx
+++ b/web/docs/guides/with-nextjs.mdx
@@ -71,7 +71,7 @@ values={[
 ```sh
 1. Go to the "SQL" section.
 2. Click "User Management Starter".
-4. Click "Run".
+3. Click "Run".
 ```
 
 <video width="99%" muted playsInline controls="true">


### PR DESCRIPTION
The UI tab of the numbered list was 1, 2, 4. Correcting it to 1, 2, 3. I'm skipping creating an issue for this since it's such a straightforward change. 

## What kind of change does this PR introduce?

Docs update, fixes a typo in the numbered instructions. 

## What is the current behavior?

List numbers counted incorrectly as "1, 2, 4"

Please link any relevant issues here.
* Not related to any issues

## What is the new behavior?

List numbers counted correctly as "1, 2, 3"

## Additional context

Add any other context or screenshots.

![https://d1ro8r1rbfn3jf.cloudfront.net/ms_338883/a5IqP5wtNSyB6C3PxdnWx7EUbJawAJ/29%2B13-26-tcfhf-dzbzq.png?Expires=1627579800&Signature=oUJgmZ8OUx5hy8bAN0CSZpMhWYlyVyUWY3kNNCIGnuRwfHNzP~iHzAZITioNdSa9-zgECKojuwU~sIPFEYh6pJxMw3Q9ZAwm21t~suYIxDdPykRt051gJ3qO8jkEWjq5Q3IKmhSqgzicS4-dx40EcLVfT3nNnPQjLKalVzy9QrcCpkVVCoAWPrGemzA3aLqqYbrT9RyjdxBzKgXAxk0wFGjMaAtk7fwCXET0RdWEQnmnCutOz7rG2cIDBIjyX2jvsQIjzFupCWAgKpLoSBQQ5TRB0SXA1qziOkQkX5rNWf1HsgYlWqj9SK5YgAMP~a3SisMy4Q-xVK-4CBQGRfdMOg__&Key-Pair-Id=APKAJBCGYQYURKHBGCOA](https://d1ro8r1rbfn3jf.cloudfront.net/ms_338883/a5IqP5wtNSyB6C3PxdnWx7EUbJawAJ/29%2B13-26-tcfhf-dzbzq.png?Expires=1627579800&Signature=oUJgmZ8OUx5hy8bAN0CSZpMhWYlyVyUWY3kNNCIGnuRwfHNzP~iHzAZITioNdSa9-zgECKojuwU~sIPFEYh6pJxMw3Q9ZAwm21t~suYIxDdPykRt051gJ3qO8jkEWjq5Q3IKmhSqgzicS4-dx40EcLVfT3nNnPQjLKalVzy9QrcCpkVVCoAWPrGemzA3aLqqYbrT9RyjdxBzKgXAxk0wFGjMaAtk7fwCXET0RdWEQnmnCutOz7rG2cIDBIjyX2jvsQIjzFupCWAgKpLoSBQQ5TRB0SXA1qziOkQkX5rNWf1HsgYlWqj9SK5YgAMP~a3SisMy4Q-xVK-4CBQGRfdMOg__&Key-Pair-Id=APKAJBCGYQYURKHBGCOA)