### PR TITLE
[Misc] Update self-hosting docs with GoTrue env example

### DIFF
--- a/web/docs/guides/self-hosting.mdx
+++ b/web/docs/guides/self-hosting.mdx
@@ -234,7 +234,7 @@ GOTRUE_EXTERNAL_FACEBOOK_ENABLED=true
 # Add other oAuth provider details below
 ```
 
-As above, more details can be found in the 'Configuring each service section' above.
+More details can be found in the 'Configuring each service section' above.
 
 ## One-click deploys 
 

--- a/web/docs/guides/self-hosting.mdx
+++ b/web/docs/guides/self-hosting.mdx
@@ -129,6 +129,113 @@ See the following guides to deploy Docker Compose setup using your preferred too
 - [AWS Fargate](https://aws.amazon.com/blogs/containers/deploy-applications-on-amazon-ecs-using-docker-compose/)
 - [Using Kompose for Kubernetes](https://kubernetes.io/docs/tasks/configure-pod-container/translate-compose-kubernetes/)
 
+
+### Example environment variable configuration
+
+The default environment variable configuration for most services should be sufficient. The default GoTrue config may not support all the settings you require to get up and running.
+
+For brevity, here is an example of what the environment variables for the auth / GoTrue container might look like once the service is deployed:
+
+```sh
+GOTRUE_OPERATOR_TOKEN=your-super-secret-operator-token
+GOTRUE_JWT_DEFAULT_GROUP_NAME=authenticated
+
+# Make sure this JWT secret matches what was configured during setup
+GOTRUE_JWT_SECRET=your-super-secret-jwt-token-with-at-least-32-characters-long
+
+# How long should JWT tokens be valid for?
+GOTRUE_JWT_EXP=3600
+
+# Since Supabase is based on Postgres, you shouldn't need to change this
+GOTRUE_DB_DRIVER=postgres
+
+# What schema should requests be routed to?
+# There should be no reason to change this
+DB_NAMESPACE=auth
+
+# Where is our auth/GoTrue located
+# You shouldn't need to change these unless the ports are mapped differently
+GOTRUE_API_HOST=0.0.0.0
+PORT=9999
+
+# Email settings
+# You must set these if you want to be able to send emails
+GOTRUE_SMTP_HOST=smtp.your-email-host.com
+GOTRUE_SMTP_PORT=465
+GOTRUE_SMTP_USER=your-smtp-user
+GOTRUE_SMTP_PASS=your-smtp-password
+
+# Should users be required to confirm their email address before they can log in?
+# If set to false, users won't have to confirm their registration
+# If set to true, users will have to click the link in their email to confirm
+GOTRUE_MAILER_AUTOCONFIRM=false
+
+# What is the 'from' address that emails are sent from?
+GOTRUE_SMTP_ADMIN_EMAIL=noreply@example.com
+
+# Remove this if you don't want debug logs
+GOTRUE_LOG_LEVEL=debug
+
+# The connection string for your database
+# `@db` says we're looking for the container called 'db' on our docker network
+DATABASE_URL=postgres://postgres:your-super-secret-and-long-postgres-password@db:5432/postgres
+
+# Email templates
+# Invite user - provide a URL to a HTML or Text template
+GOTRUE_MAILER_TEMPLATES_INVITE=https://example.com/path/to/your/invite/template.html
+
+# Confirm registration - provide a URL to a HTML or Text template
+GOTRUE_MAILER_TEMPLATES_CONFIRMATION=https://example.com/path/to/your/confirmation/template.html
+
+# Password recovery - provide a URL to a HTML or Text template
+GOTRUE_MAILER_TEMPLATES_RECOVERY=https://example.com/path/to/your/password_reset/template.HTML
+
+# Magic link - provide a URL to a HTML or Text template
+GOTRUE_MAILER_TEMPLATES_MAGIC_LINK=https://example.com/path/to/your/magic_link/template.html
+
+# GoTrue URLs
+# These are appended after the API_EXTERNAL_URL
+# You shouldn't need to change these
+GOTRUE_MAILER_URLPATHS_CONFIRMATION=/auth/v1/verify
+GOTRUE_MAILER_URLPATHS_INVITE=/auth/v1/verify
+GOTRUE_MAILER_URLPATHS_CONFIRMATION=/auth/v1/verify
+GOTRUE_MAILER_URLPATHS_RECOVERY=/auth/v1/verify
+
+# Site URLs
+# This is where the user will be redirected to after clicking a link in an email and after oAuth
+GOTRUE_SITE_URL=https://example.com/redirect_to_here
+GOTRUE_URI_ALLOW_LIST=https://example.com/redirect_to_here
+
+# This is the URL where your supabase stack is accessible
+# i.e. this is the endpoint URL you would pass into a `createClient()` call in the supabase-js library
+API_EXTERNAL_URL=https://database.example.com/
+
+# Set this to true if you want to prevent signing up with email and password
+GOTRUE_DISABLE_SIGNUP=true
+
+# oAuth
+# If you are not using oAuth to login (e.g. Login with Facebook), you can ignore the below
+# If you want to disable oAuth for a specific provider, set the `GOTRUE_EXTERNAL_<provider>_ENABLED` to false
+# Github oAuth
+GOTRUE_EXTERNAL_GITHUB_CLIENT_ID=your_github_client_id
+GOTRUE_EXTERNAL_GITHUB_SECRET=your_github_client_secret
+GOTRUE_EXTERNAL_GITHUB_ENABLED=true
+
+# Google oAuth
+GOTRUE_EXTERNAL_GOOGLE_CLIENT_ID=your-google-client-id.apps.googleusercontent.com
+GOTRUE_EXTERNAL_GOOGLE_SECRET=your-google-secret
+GOTRUE_EXTERNAL_GOOGLE_ENABLED=true
+
+# Facebook oAuth
+GOTRUE_EXTERNAL_FACEBOOK_CLIENT_ID=your-facebook-client-id
+GOTRUE_EXTERNAL_FACEBOOK_SECRET=your-facebook-app-secret
+GOTRUE_EXTERNAL_FACEBOOK_ENABLED=true
+
+# Add other oAuth provider details below
+```
+
+As above, more details can be found in the 'Configuring each service section' above.
+
 ## One-click deploys 
 
 For some tools we also provide images and deployments into cloud marketplaces:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Self-hosting docs update

## What is the current behavior?

Users currently have to piece different things together from the GoTrue docs which can take more time than necessary. Improving the docs in some areas can help streamline the process of self-hosting

## What is the new behavior?

 - Added an example config of environment variables for the GoTrue container
