### PR TITLE
fix typo in functions blog

### DIFF
--- a/www/_blog/2021-07-30-supabase-functions-updates.mdx
+++ b/www/_blog/2021-07-30-supabase-functions-updates.mdx
@@ -135,7 +135,7 @@ The extension is (currently) capable of >300 requests per second and is the netw
 
 ### **Usage**
 
-`pg_net` allows you to make asyncronous HTTP requests directly within your SQL queries.
+`pg_net` allows you to make asynchronous HTTP requests directly within your SQL queries.
 
 ```sql
 -- Make a request


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix typo in blog post

## What is the current behavior?

https://supabase.io/new/blog/2021/07/30/supabase-functions-updates

There is a typo for the word `asynchronous` spelt `asyncronous`

## What is the new behavior?

Typo fixed!

## Additional context

Just a tiny tiny change!

![](https://media.giphy.com/media/3QM17M3i4blNRuL4ai/giphy.gif)
