### PR TITLE
Update auth-facebook.mdx

### DIFF
--- a/web/docs/guides/auth/auth-facebook.mdx
+++ b/web/docs/guides/auth/auth-facebook.mdx
@@ -61,6 +61,13 @@ From the `Add Products to your App` screen:
 - Enter this in the `Valid OAuth Redirect URIs` box
 - Click `Save Changes` at the bottom right
 
+Be aware that you have to set the right access levels on your Facebook App to enable 3rd party applications to read the email address.
+From the `App Review -> Permissions and Features` screen:
+
+- Click the button `Request Advanced Access` on the right side of `public_profile` and `email`
+
+You can read more about access levels [here](https://developers.facebook.com/docs/graph-api/overview/access-levels/) 
+
 ### Copy your Facebook App ID and Secret
 
 - Click `Settings / Basic` in the left sidebar


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs updated: Added extra information about access levels on Facebook Apps as that's required to change from standard to advanced before you can use Facebook login with Supabase Auth.

## What is the current behavior?

If the access level of `email` on your Facebook App is set to `standard` instead of `advanced`, you get an error after redirecting back from Facebook.

`Error getting user email from external provider`

![image](https://user-images.githubusercontent.com/32297402/128127875-c32cf83a-7c24-4813-ab94-cedcb9e149f1.png)


## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
