### PR TITLE
Update annoucement nav to match discord brand color

### DIFF
--- a/www/components/Nav/Annoucement.tsx
+++ b/www/components/Nav/Annoucement.tsx
@@ -17,14 +17,16 @@ const a: A = data
 const Annoucement = () => {
   if (!a.show) return null
   return (
-    <div className="bg-indigo-400 dark:bg-indigo-400">
-      <div className="flex items-center justify-center py-2 mx-auto space-x-2 text-white lg:container lg:px-16 xl:px-20 text-sm md:text-base">
-        <span>{a.text}</span>
+    <div className="bg-[#5865F2]">
+      <div className="flex items-center justify-center py-2 mx-auto space-x-2 text-sm lg:container lg:px-16 xl:px-20 md:text-base">
+        <span className="text-white">{a.text}</span>
         <a
           href={a.link.url}
-          className="inline-flex items-center px-2 py-1 space-x-1 text-xs transition-colors bg-indigo-900 rounded text-white dark:hover:text-indigo-100 hover:text-indigo-100 hover:bg-opacity-90"
+          target="_blank"
+          className="inline-flex items-center px-2 py-1 space-x-1 text-xs transition-colors rounded-lg text-[#5865F2] bg-white border border-transparent dark:hover:border-white dark:hover:bg-[#5865F2]"
         >
-          {a.link.text} <IconArrowRight size="tiny" />
+          <span>{a.link.text}</span>
+          <IconArrowRight size="tiny" />
         </a>
       </div>
     </div>

--- a/www/package.json
+++ b/www/package.json
@@ -53,7 +53,7 @@
     "postcss": "8",
     "postcss-preset-env": "^6.7.0",
     "prettier": "^2.2.1",
-    "tailwindcss": "2.1.2"
+    "tailwindcss": "^2.2.7"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Improvement

## What is the current behavior?

The current annoucement nav uses the indigo color.

## What is the new behavior?

It now uses the "blurple" Discord color (`#5865F2`) thanks to the Tailwind CSS JIT arbitrary values.

## Additional context

I updated the Tailwind CSS version to the latest (`^2.2.7`)
