### PR TITLE
Added more explanation of how .single() works

### DIFF
--- a/web/spec/postgrest.json
+++ b/web/spec/postgrest.json
@@ -4264,7 +4264,7 @@
 										"isExported": true
 									},
 									"comment": {
-										"shortText": "Retrieves only one row from the result. Result must be one row (e.g. using\n`limit`), otherwise this will result in an error."
+										"shortText": "Retrieves only one row from the result. Result must be one row (e.g. using\n`limit`), otherwise this will result in an error.\n\nWithout using `.single()`, results are returned as an array of rows, even if there is only one.  When using `.single()` results are returned as an object without an enclosing array."
 									},
 									"type": {
 										"type": "reference",


### PR DESCRIPTION
## What kind of change does this PR introduce?

Documentation update for the `.single() `modifier.

When originally looking at this page, it was not clear to me why I would want to use `.single()` if I'm already using something like `.limit(1)`.  This change explains that, when using `.single()` the result is returned as an object that is not enclosed in an array.  

Without `.single()`:

```
[{"field": "value", "field2": "value2"}]
```

With `.single()`:

```
{"field": "value", "field2": "value2"}
```

