### PR TITLE
fix dockerfile stuff

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -18,7 +18,7 @@ STORAGE_S3_BUCKET=supa-storage-testing  # name of s3 bucket where you want to st
 STORAGE_REGION=us-east-1 # region where your bucket is located
 # STORAGE_AWS_ACCESS_KEY_ID=XXXX # replace-with-your-aws-key and don't commit this to github
 # STORAGE_AWS_SECRET_ACCESS_KEY=XXXX # replace-with-your-aws-key and don't commit this to github
-FILE_SIZE_LIMIT=us-east-1 # region where your bucket is located
+FILE_SIZE_LIMIT=52428800 # max file size (in bytes)
 
 # predefined; don't change these unless you know what you're doing
 POSTGRES_PORT=5432

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -94,7 +94,7 @@ services:
         PGRST_JWT_SECRET: ${JWT_SECRET}
         DATABASE_URL: postgres://postgres:${POSTGRES_PASSWORD}@db:${POSTGRES_PORT}/postgres
         PGOPTIONS: "-c search_path=storage"
-        FILE_SIZE_LIMIT: 52428800
+        FILE_SIZE_LIMIT: ${FILE_SIZE_LIMIT}
         REGION: ${STORAGE_REGION} # region where your bucket is located
         GLOBAL_S3_BUCKET: ${STORAGE_S3_BUCKET}  # name of s3 bucket where you want to store objects
         # AWS_ACCESS_KEY_ID: replace-with-your-aws-key


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug Fix

## What is the new behavior?

docker-compose will now use the FILE_SIZE_LIMIT variable in the "global" docker-compose.yml file, instead of a hard-coded max file size