### PR TITLE
Fixed JWT link

### DIFF
--- a/web/docs/learn/auth-deep-dive/jwts.md
+++ b/web/docs/learn/auth-deep-dive/jwts.md
@@ -167,7 +167,7 @@ Now that you understand what JWTs are and where they're used in Supabase, you ca
 
 ### Resources
 
-- JWT debugger: https://jwt.io/​
+- JWT debugger: https://jwt.io/
 
 ### Next steps
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixed docs link

## What is the current behavior?

The JWT link on this page is broken because of a funky character: https://supabase.io/docs/learn/auth-deep-dive/auth-deep-dive-jwts

## What is the new behavior?

It links correctly
