### PR TITLE
chore: clarify pro credits

### DIFF
--- a/www/_blog/2021-03-29-pricing.mdx
+++ b/www/_blog/2021-03-29-pricing.mdx
@@ -55,7 +55,7 @@ No company gets the pricing right first time. It would be arrogant to believe th
 
 Our success depends on the success of developers using Supabase. In short, if our users' projects succeed then Supabase adoption will continue. That is exactly what we want.
 
-We will issue credits for those who signed up during alpha, beta, and those who sign up through to the end of Launch Week. If you are not on board yet, [you can sign up here.](http://www.supabase.io) Projects on select incubators will also get credits, as founders we know the importance of credits when getting something new off the ground. We will continue to support code schools and their students. If you need Supabase credits to support your project, reach out to us here and we will do our best to help you.
+We will issue credits for those who signed up during alpha, beta, and those who sign up through to the end of Launch Week[^1]. If you are not on board yet, [you can sign up here.](http://www.supabase.io) Projects on select incubators will also get credits, as founders we know the importance of credits when getting something new off the ground. We will continue to support code schools and their students. If you need Supabase credits to support your project, reach out to us here and we will do our best to help you.
 
 ## Making pricing predictable
 
@@ -80,3 +80,5 @@ Check back throughout the week to see what else we're launching [here](https://s
 Sign up for the Supabase Beta [here](https://app.supabase.io).
 
 And check out the full pricing details [here](https://supabase.io/pricing). And we'd love to hear your opnions on our Pricing! You can let us know via beta@supabase.io.
+
+[^1]: Updated on Aug 17 2021 for clarity: the referenced Launch Week ended on the 4th of April 2021. Users that signed up prior to that date can request credits.

--- a/www/data/PricingFAQ.json
+++ b/www/data/PricingFAQ.json
@@ -53,7 +53,7 @@
   },
   {
     "question": "I read that you are giving credits to users who sign up during beta, do I get those?",
-    "answer": "If you sign up before the end of launch week we will issue credits for the Pro tier. You can claim them by getting in touch via <support@supabase.io>[](mailto:support@supabase.io)."
+    "answer": "If you signed up before the 4th of April 2021 we will issue credits for the Pro tier. You can claim them by getting in touch via <support@supabase.io>[](mailto:support@supabase.io)."
   },
   {
     "question": "What if I want to cancel my monthly subscription?",


### PR DESCRIPTION
While the reference to Launch Week was contextually accurate, it is confusing at this point; I'm adding specific dates to clarify.