### PR TITLE
Update Docs: fixed cacheControl type in examples

### DIFF
--- a/web/spec/supabase.yml
+++ b/web/spec/supabase.yml
@@ -1003,7 +1003,7 @@ pages:
             .storage
             .from('avatars')
             .upload('public/avatar1.png', avatarFile, {
-              cacheControl: 3600,
+              cacheControl: '3600',
               upsert: false
             })
           ```
@@ -1038,7 +1038,7 @@ pages:
             .storage
             .from('avatars')
             .update('public/avatar1.png', avatarFile, {
-              cacheControl: 3600,
+              cacheControl: '3600',
               upsert: false
             })
           ```


### PR DESCRIPTION
## What kind of change does this PR introduce?
Docs update

## What is the current behavior?
CacheControl is typed as a string, but the example docs show it being used with a number. 

## What is the new behavior?
This corrects the example docs to use a string instead.
