### PR TITLE
Fix filters docs example code snippet

### DIFF
--- a/web/spec/supabase.yml
+++ b/web/spec/supabase.yml
@@ -1386,7 +1386,7 @@ pages:
           ```js
           // Only valid if the Stored Procedure returns a table type.
           const { data, error } = await supabase
-            .rpc('echo_all_cities)
+            .rpc('echo_all_cities')
             .not('name', 'eq', 'Paris')
           ```
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

filters docs [`.not()` section with `rpc()` example code snippet ](https://supabase.io/docs/reference/javascript/not#with-rpc)is missing a closing quote.

<img width="460" alt="Screen Shot 2021-08-19 at 11 57 32 AM" src="https://user-images.githubusercontent.com/60201810/130102079-1818443a-5a7f-4adf-809e-cda486da2ea0.png">

Please link any relevant issues here.

## What is the new behavior?

filters docs `.not()` section with `rpc()` example code snippet is now correct.


