### PR TITLE
Make Example Auth Functions Async Functions

### DIFF
--- a/web/docs/guides/auth/auth-apple.mdx
+++ b/web/docs/guides/auth/auth-apple.mdx
@@ -190,7 +190,7 @@ const { user, session, error } = await supabase.auth.signIn({
 Add a function which you can call from a button, link, or UI element.
 
 ```js
-function signInWithApple() {
+async function signInWithApple() {
   const { user, session, error } = await supabase.auth.signIn({
     provider: 'apple'
   });
@@ -200,7 +200,7 @@ function signInWithApple() {
 To log out:
 
 ```js
-function signout() {
+async function signout() {
   const { error } = await supabase.auth.signOut();
 }
 ```

--- a/web/docs/guides/auth/auth-bitbucket.mdx
+++ b/web/docs/guides/auth/auth-bitbucket.mdx
@@ -81,7 +81,7 @@ const { user, session, error } = await supabase.auth.signIn({
 Add this function which you can call from a button, link, or UI element.
 
 ```js
-function signInWithBitbucket() {
+async function signInWithBitbucket() {
   const { user, session, error } = await supabase.auth.signIn({
     provider: 'bitbucket'
   });
@@ -91,7 +91,7 @@ function signInWithBitbucket() {
 To log out:
 
 ```js
-function signout() {
+async function signout() {
   const { error } = await supabase.auth.signOut();
 }
 ```

--- a/web/docs/guides/auth/auth-discord.mdx
+++ b/web/docs/guides/auth/auth-discord.mdx
@@ -81,7 +81,7 @@ const { user, session, error } = await supabase.auth.signIn({
 Add this function which you can call from a button, link, or UI element.
 
 ```js
-function signInWithDiscord() {
+async function signInWithDiscord() {
   const { user, session, error } = await supabase.auth.signIn({
     provider: 'discord'
   });
@@ -91,7 +91,7 @@ function signInWithDiscord() {
 To log out:
 
 ```js
-function signout() {
+async function signout() {
   const { error } = await supabase.auth.signOut();
 }
 ```

--- a/web/docs/guides/auth/auth-facebook.mdx
+++ b/web/docs/guides/auth/auth-facebook.mdx
@@ -98,7 +98,7 @@ const { user, session, error } = await supabase.auth.signIn({
 Add this function which you can call from a button, link, or UI element.
 
 ```js
-function signInWithFacebook() {
+async function signInWithFacebook() {
   const { user, session, error } = await supabase.auth.signIn({
     provider: 'facebook'
   });
@@ -108,7 +108,7 @@ function signInWithFacebook() {
 To log out:
 
 ```js
-function signout() {
+async function signout() {
   const { error } = await supabase.auth.signOut();
 }
 ```

--- a/web/docs/guides/auth/auth-github.mdx
+++ b/web/docs/guides/auth/auth-github.mdx
@@ -90,7 +90,7 @@ const { user, session, error } = await supabase.auth.signIn({
 Add this function which you can call from a button, link, or UI element.
 
 ```js
-function signInWithGithub() {
+async function signInWithGithub() {
   const { user, session, error } = await supabase.auth.signIn({
     provider: 'github'
   });
@@ -100,7 +100,7 @@ function signInWithGithub() {
 To log out:
 
 ```js
-function signout() {
+async function signout() {
   const { error } = await supabase.auth.signOut();
 }
 ```

--- a/web/docs/guides/auth/auth-gitlab.mdx
+++ b/web/docs/guides/auth/auth-gitlab.mdx
@@ -77,7 +77,7 @@ const { user, session, error } = await supabase.auth.signIn({
 Add this function which you can call from a button, link, or UI element.
 
 ```js
-function signInWithGitLab() {
+async function signInWithGitLab() {
   const { user, session, error } = await supabase.auth.signIn({
     provider: 'gitlab'
   });
@@ -87,7 +87,7 @@ function signInWithGitLab() {
 To log out:
 
 ```js
-function signout() {
+async function signout() {
   const { error } = await supabase.auth.signOut();
 }
 ```

--- a/web/docs/guides/auth/auth-google.mdx
+++ b/web/docs/guides/auth/auth-google.mdx
@@ -106,7 +106,7 @@ const { user, session, error } = await supabase.auth.signIn({
 Add this function which you can call from a button, link, or UI element.
 
 ```js
-function signInWithGoogle() {
+async function signInWithGoogle() {
   const { user, session, error } = await supabase.auth.signIn({
     provider: 'google'
   });
@@ -116,7 +116,7 @@ function signInWithGoogle() {
 To log out:
 
 ```js
-function signout() {
+async function signout() {
   const { error } = await supabase.auth.signOut();
 }
 ```

--- a/web/docs/guides/auth/auth-twitch.mdx
+++ b/web/docs/guides/auth/auth-twitch.mdx
@@ -95,7 +95,7 @@ const { user, session, error } = await supabase.auth.signIn({
 Add this function which you can call from a button, link, or UI element.
 
 ```js
-function signInWithTwitch() {
+async function signInWithTwitch() {
   const { user, session, error } = await supabase.auth.signIn({
     provider: 'twitch',
   })
@@ -105,7 +105,7 @@ function signInWithTwitch() {
 To log out:
 
 ```js
-function signout() {
+async function signout() {
   const { error } = await supabase.auth.signOut()
 }
 ```

--- a/web/docs/guides/auth/auth-twitter.mdx
+++ b/web/docs/guides/auth/auth-twitter.mdx
@@ -85,7 +85,7 @@ const { user, session, error } = await supabase.auth.signIn({
 Add this function which you can call from a button, link, or UI element.
 
 ```js
-function signInWithTwitter() {
+async function signInWithTwitter() {
   const { user, session, error } = await supabase.auth.signIn({
     provider: 'twitter'
   });
@@ -95,7 +95,7 @@ function signInWithTwitter() {
 To log out:
 
 ```js
-function signout() {
+async function signout() {
   const { error } = await supabase.auth.signOut();
 }
 ```


### PR DESCRIPTION
In the example docs, `await` is used inside of functions that are not async functions. JS doesn't allow this :( This PR makes these example functions async functions.