### PR TITLE
Fix sticky table header on desktop

### DIFF
--- a/www/styles/index.css
+++ b/www/styles/index.css
@@ -197,7 +197,7 @@ table .thead--plans th {
   /* @apply py-4; */
   position: sticky;
   border-collapse: separate;
-  top: 76px;
+  top: 0;
   z-index: 5;
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Styling update on the pricing page

## What is the current behavior?

Go to the pricing page on desktop: https://supabase.io/pricing
Scroll the page, and on the table section (Database, Auth, ...) we can see the sticky offset is way too far from the top

<img width="1216" alt="Screen Shot 2021-08-21 at 12 50 04" src="https://user-images.githubusercontent.com/7563139/130312043-e5401769-451a-4f36-9b48-02d030935007.png">

## What is the new behavior?

<img width="1254" alt="Screen Shot 2021-08-21 at 12 49 08" src="https://user-images.githubusercontent.com/7563139/130312035-d1a04762-bb5e-4227-a74b-75e48d5d3e45.png">
