### PR TITLE
Fix github action's pathname for generated types

### DIFF
--- a/web/spec/supabase.yml
+++ b/web/spec/supabase.yml
@@ -238,8 +238,7 @@ pages:
       };
       ```
 
-      ### Update types automatically with GitHub 
-      s
+      ### Update types automatically with GitHub Actions
 
       One way to keep your type definitions in sync with your database is to set up a GitHub action that runs on a schedule.
 

--- a/web/spec/supabase.yml
+++ b/web/spec/supabase.yml
@@ -238,14 +238,15 @@ pages:
       };
       ```
 
-      ### Update types automatically with GitHub Actions
+      ### Update types automatically with GitHub 
+      s
 
       One way to keep your type definitions in sync with your database is to set up a GitHub action that runs on a schedule.
 
       Add a script to your package.json to generate the types:
 
       ```
-      "update-types": "npx openapi-typescript https://your-project.supabase.co/rest/v1/?apikey=your-anon-key --output types/supabase.ts"
+      "update-types": "npx openapi-typescript https://your-project.supabase.co/rest/v1/?apikey=your-anon-key --output types/database/index.ts"
       ```
 
       In your repo, create the file `.github/workflows/update-types.yml`. Add the following snippet into this file to define the action. If there is a change to your definitions, this script will commit the change to your repo.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes a minor typo in the docs, where there the generated types for a Github Action have mismatched pathnames.
