### PR TITLE
fix: Fix file ownership for postgres and kong containers

### DIFF
--- a/docker/dockerfiles/kong/Dockerfile
+++ b/docker/dockerfiles/kong/Dockerfile
@@ -1,6 +1,6 @@
 FROM kong:2.1
 
-COPY kong.yml /var/lib/kong/kong.yml  
+COPY --chown=kong:nogroup kong.yml /var/lib/kong/kong.yml  
 
 # Build time defaults
 ARG build_KONG_DATABASE=off 

--- a/docker/dockerfiles/postgres/Dockerfile
+++ b/docker/dockerfiles/postgres/Dockerfile
@@ -1,8 +1,8 @@
 FROM supabase/postgres:0.13.0
 
-COPY 00-initial-schema.sql /docker-entrypoint-initdb.d/00-initial-schema.sql
-COPY auth-schema.sql /docker-entrypoint-initdb.d/auth-schema.sql
-COPY storage-schema.sql /docker-entrypoint-initdb.d/storage-schema.sql
+COPY --chown=postgres 00-initial-schema.sql /docker-entrypoint-initdb.d/00-initial-schema.sql
+COPY --chown=postgres auth-schema.sql /docker-entrypoint-initdb.d/auth-schema.sql
+COPY --chown=postgres storage-schema.sql /docker-entrypoint-initdb.d/storage-schema.sql
 
 # Build time defaults
 ARG build_POSTGRES_DB=postgres


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR fixes #2933 by setting the right ownership on `kong`'s config file and `postgres`'s init files.

## What is the current behavior?

See #2933

## What is the new behavior?

Containers start when using the local supabase developement environment
