### PR TITLE
Fix link to Supabase realtime docker image

### DIFF
--- a/web/docs/guides/self-hosting.mdx
+++ b/web/docs/guides/self-hosting.mdx
@@ -128,7 +128,7 @@ For some tools we also provide images and deployments into cloud marketplaces:
 
 - AWS [one click deploy](https://aws.amazon.com/marketplace/pp/B089N4FH7N?qid=1617156168590&sr=0-2)
 - Digital Ocean [one click deploy](https://marketplace.digitalocean.com/apps/supabase-realtime)
-- Docker [image](https://hub.docker.com/r/supabase/postgres)
+- Docker [image](https://hub.docker.com/r/supabase/realtime)
 
 ## Next steps
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
 Docs update

## What is the current behavior?

Docker image hyperlink for realtime leads to postgres docker image instead.

## What is the new behavior?

Docker image hyperlink for realtime leads to realtime docker image.

## Additional context

N/A
