### PR TITLE
statement timeouts for anon and authenticated

### DIFF
--- a/docker/dockerfiles/postgres/00-initial-schema.sql
+++ b/docker/dockerfiles/postgres/00-initial-schema.sql
@@ -24,3 +24,5 @@ alter default privileges in schema public grant all on tables to postgres, anon,
 alter default privileges in schema public grant all on functions to postgres, anon, authenticated, service_role;
 alter default privileges in schema public grant all on sequences to postgres, anon, authenticated, service_role;
 
+alter role anon set statement_timeout = '3s';
+alter role authenticated set statement_timeout = '8s';


### PR DESCRIPTION
## What kind of change does this PR introduce?
Adds a default `statement_timeout` to kill  long running statements/queries that come through postgrest to improve resiliency to accidentally slow queries, and DOS

## What is the current behavior?
2 minute global timeout

Please link any relevant issues here.
resolves https://github.com/supabase/supabase/issues/2887

## What is the new behavior?
unauthenticated users have a 3 second statement timeout & authenticated users have an 8 second timeout