### PR TITLE
Update docker image

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -46,7 +46,7 @@ services:
 
   rest:
     container_name: supabase-rest
-    image: postgrest/postgrest:nightly-2021-03-05-19-03-d3a8b5f
+    image: postgrest/postgrest:latest
     ports:
       - ${REST_PORT}:3000
     depends_on:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       GOTRUE_MAILER_AUTOCONFIRM: 'true'
       GOTRUE_LOG_LEVEL: DEBUG
       GOTRUE_OPERATOR_TOKEN: ${OPERATOR_TOKEN}
-      DATABASE_URL: 'postgres://postgres:${POSTGRES_PASSWORD}@db:${POSTGRES_PORT}/postgres?sslmode=disable'
+      DATABASE_URL: 'postgres://postgres:${POSTGRES_PASSWORD}@db:${POSTGRES_PORT}/postgres?sslmode=disable&search_path=auth'
 
   rest:
     container_name: supabase-rest

--- a/docker/dockerfiles/postgres/00-initial-schema.sql
+++ b/docker/dockerfiles/postgres/00-initial-schema.sql
@@ -26,3 +26,5 @@ alter default privileges in schema public grant all on sequences to postgres, an
 
 alter role anon set statement_timeout = '3s';
 alter role authenticated set statement_timeout = '8s';
+
+ALTER ROLE postgres SET search_path = "$user", public, auth, extensions;

--- a/docker/dockerfiles/postgres/Dockerfile
+++ b/docker/dockerfiles/postgres/Dockerfile
@@ -1,4 +1,4 @@
-FROM supabase/postgres:0.13.0
+FROM supabase/postgres:13.3.0
 
 COPY --chown=postgres 00-initial-schema.sql /docker-entrypoint-initdb.d/00-initial-schema.sql
 COPY --chown=postgres auth-schema.sql /docker-entrypoint-initdb.d/auth-schema.sql

--- a/docker/dockerfiles/postgres/auth-schema.sql
+++ b/docker/dockerfiles/postgres/auth-schema.sql
@@ -88,6 +88,5 @@ $$ language sql stable;
 GRANT ALL PRIVILEGES ON SCHEMA auth TO postgres;
 GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA auth TO postgres;
 GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA auth TO postgres;
-ALTER ROLE postgres SET search_path = "$user", auth, public;
 
 GRANT USAGE ON SCHEMA auth TO anon, authenticated, service_role;


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Update self-hosted docker image version to make it closed to app.supabase.io version
- Update `search_path` fix: https://github.com/supabase/supabase/issues/338

## What is the current behavior?

- Some of self-hosted docker image version is different with app.supabase.io version
- Extension function need `extensions.` prefix eg: `extensions.generate_uuid_v4()`

## What is the new behavior?

- Updated supabase/postgres
- Updated postgrest/postgrest
- Updated `search_path` for role `postgres`

