### PR TITLE
add missing text search configuration

### DIFF
--- a/web/docs/guides/database/full-text-search.mdx
+++ b/web/docs/guides/database/full-text-search.mdx
@@ -395,7 +395,7 @@ values={[
 alter table 
   books 
 add column 
-  fts tsvector generated always as to_tsvector(description || ' ' || title) stored;
+  fts tsvector generated always as (to_tsvector('english', description || ' ' || title)) stored;
   
 create index books_fts on books using gin (fts); -- generate the index
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs are not including mandatory search text configuration (added default 'english'). Also add column statement has not correct syntax (wrap to_tsvector).

## What is the current behavior?

Add column statement does not work according to the docs. 

## What is the new behavior?

Generated column fts can be created. 

