### PR TITLE
docs: add missing comma

### DIFF
--- a/web/spec/postgres.yml
+++ b/web/spec/postgres.yml
@@ -107,7 +107,7 @@ pages:
           ```sql
           create table table_name (
             column_1 data_type,
-            column_2 data_type
+            column_2 data_type,
             -- Constraints:
             primary key (column_1, column_2)
           );


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The [example SQL command](https://supabase.io/docs/reference/postgres/tables#primary-keys-using-multiple-columns) fails to run.

## What is the new behavior?

The SQL command should run with the added comma.