### PR TITLE
Add `delimiters` option for replace plugin

### DIFF
--- a/web/docs/guides/with-svelte.mdx
+++ b/web/docs/guides/with-svelte.mdx
@@ -200,6 +200,7 @@ and add these plugins to the `rollup.config.js` file.
 					...config().parsed // attached the .env config
 				}
 			}),
+			delimiters: ['', '']
 		}),
 		json(),
     // ...


### PR DESCRIPTION
Due to this breaking change in the replace plugin: https://github.com/rollup/plugins/pull/903.

As reported by @ahl389 in #3015.