### PR TITLE
Clarify as "`id` in the `auth.users` table"

### DIFF
--- a/web/docs/guides/auth.mdx
+++ b/web/docs/guides/auth.mdx
@@ -68,7 +68,7 @@ Supabase makes it simple to manage your users.
   <source src="/videos/auth-zoom2.mp4" type="video/mp4" muted playsInline />
 </video>
 
-When users sign up, Supabase assigns them a unique ID. You can reference this ID anywhere in your database. For example, you might create a `profiles` table referencing the user using a `user_id` field.
+When users sign up, Supabase assigns them a unique ID. You can reference this ID anywhere in your database. For example, you might create a `profiles` table referencing `id` in the `auth.users` table using a `user_id` field.
 
 Supabase provides the routes to [sign up](/docs/reference/javascript/auth-signup), [log in](/docs/reference/javascript/auth-signin),
 [log out](/docs/reference/javascript/auth-signout), and manage users in your apps and websites.


### PR DESCRIPTION
As pointed out by @howesteve in #3102, this could be clearer. Resolves #3108.