### PR TITLE
Remove empty object

### DIFF
--- a/web/spec/supabase.yml
+++ b/web/spec/supabase.yml
@@ -548,7 +548,7 @@ pages:
           ```js
           const { data, error, count } = await supabase
             .from('cities')
-            .select('name', {}, { count: 'exact' }) // if you don't want to return any rows, you can use { count: 'exact', head: true }
+            .select('name', { count: 'exact' }) // if you don't want to return any rows, you can use { count: 'exact', head: true }
           ```
       - name: Querying JSON data
         description: |


### PR DESCRIPTION
I copy paste that example in my code and I didn't understand why count was `null`. In the current example, it looks like 3 arguments are accepted.