### PR TITLE
fixed select data example for python and a typo

### DIFF
--- a/web/docs/guides/client-libraries.mdx
+++ b/web/docs/guides/client-libraries.mdx
@@ -377,7 +377,7 @@ assert data.get("status_code") in (200, 201)
 data = supabase.table('cities').insert([
 {'name': 'Gotham', 'country_id': 556 },
 {'name': 'The Shire', 'country_id': 557 }
-).execute()
+]).execute()
 
 ```
 

--- a/web/docs/guides/client-libraries.mdx
+++ b/web/docs/guides/client-libraries.mdx
@@ -263,7 +263,7 @@ url: str = os.environ.get("SUPABASE_TEST_URL")
 key: str = os.environ.get("SUPABASE_TEST_KEY")
 supabase: Client = create_client(url, key)
 
-data = supabase.from_('countries').select('name').execute()
+data = supabase.table('countries').select('name').execute()
 ```
 
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

https://supabase.io/docs/guides/client-libraries#managing-data

* Typo in bulk insert - missing closing bracket for list
* Select python example is not working


## What is the new behavior?

* Fixed typo for bulk insert
* fixed select example - replace from_ with table method
