### PR TITLE
Fix minor things in Dart docs and Dart code samples in full-text-search guide

### DIFF
--- a/web/docs/guides/database/full-text-search.mdx
+++ b/web/docs/guides/database/full-text-search.mdx
@@ -118,10 +118,11 @@ const { data, error } = await supabase
 <TabItem value="DART">
 
 ```dart
-final result = client
+final result = await client
   .from('books')
   .select()
-  .eq('name', 'Harry');
+  .eq('name', 'Harry')
+  .execute();
 ```
 
 </TabItem>
@@ -160,10 +161,11 @@ const { data, error } = await supabase
 <TabItem value="DART">
 
 ```dart
-final result = client
+final result = await client
   .from('books')
   .select()
-  .textSearch('name', "'Harry'");
+  .textSearch('name', "'Harry'")
+  .execute();
 ```
 
 </TabItem>
@@ -209,10 +211,11 @@ const { data, error } = await supabase
 <TabItem value="DART">
 
 ```dart
-final result = client
+final result = await client
   .from('books')
   .select()
-  .textSearch('description', "'big'");
+  .textSearch('description', "'big'")
+  .execute();
 ```
 
 </TabItem>
@@ -297,10 +300,11 @@ const { data, error } = await supabase
 <TabItem value="DART">
 
 ```dart
-final result = client
+final result = await client
   .from('books')
   .select()
-  .textSearch('description', "'little' & 'big'");
+  .textSearch('description', "'little' & 'big'")
+  .execute();
 ```
 
 </TabItem>
@@ -351,10 +355,11 @@ const { data, error } = await supabase
 <TabItem value="DART">
 
 ```dart
-final result = client
+final result = await client
   .from('books')
   .select()
-  .textSearch('description', "'little' | 'big'");
+  .textSearch('description', "'little' | 'big'")
+  .execute();
 ```
 
 </TabItem>
@@ -454,10 +459,11 @@ const { data, error } = await supabase
 <TabItem value="DART">
 
 ```dart
-final result = client
+final result = await client
   .from('books')
   .select()
-  .textSearch('fts', "'little' & 'big'");
+  .textSearch('fts', "'little' & 'big'")
+  .execute();
 ```
 
 </TabItem>
@@ -513,10 +519,11 @@ const { data, error } = await supabase
 <TabItem value="DART">
 
 ```dart
-final result = client
+final result = await client
   .from('books')
   .select()
-  .textSearch('description', "'big' <-> 'dreams'");
+  .textSearch('description', "'big' <-> 'dreams'")
+  .execute();
 ```
 
 </TabItem>
@@ -557,10 +564,11 @@ const { data, error } = await supabase
 <TabItem value="DART">
 
 ```dart
-final result = client
+final result = await client
   .from('books')
   .select()
-  .textSearch('description', "'year' <2> 'school'");
+  .textSearch('description', "'year' <2> 'school'")
+  .execute();
 ```
 
 </TabItem>
@@ -604,10 +612,11 @@ const { data, error } = await supabase
 <TabItem value="DART">
 
 ```dart
-final result = client
+final result = await client
   .from('books')
   .select()
-  .textSearch('description', "'big' & !'little'");
+  .textSearch('description', "'big' & !'little'")
+  .execute();
 ```
 
 </TabItem>

--- a/web/spec/dart.yml
+++ b/web/spec/dart.yml
@@ -109,16 +109,16 @@ pages:
 
       ## Flutter 
 
-      For Flutter project, you can use [supabase-flutter](https://github.com/supabase/supabase-flutter).
+      For Flutter project, you can use [supabase_flutter](https://github.com/supabase/supabase-flutter).
 
       ```bash
       flutter pub add supabase_flutter
       ```
 
-      `supabase-flutter` plugin uses `supabase` plugin internally, and it adds some Flutter specific functionality such as handling deeplinks coming back from magic link verifications.
-      If you are creating a Flutter application, you should use `supabase-flutter` instead of `supabase-dart`. 
+      `supabase_flutter` plugin uses `supabase` plugin internally, and it adds some Flutter specific functionality such as handling deeplinks coming back from magic link verifications.
+      If you are creating a Flutter application, we recommend using `supabase_flutter` instead of `supabase`. 
 
-      For the most part `supabase-flutter` shares the same API as `supabase` with few exceptions such as initialization or OAuth sign in.
+      For the most part `supabase_flutter` shares the same API as `supabase` with few exceptions such as initialization or OAuth sign in.
 
   Initializing:
     description: |
@@ -131,7 +131,7 @@ pages:
 
       ## Flutter
 
-      For `supabase-flutter`, you will be using the static `initialize()` method on `Supabase` class.
+      For `supabase_flutter`, you will be using the static `initialize()` method on `Supabase` class.
 
     examples:
       - name: Dart SupabaseClient()
@@ -169,7 +169,7 @@ pages:
       - name: Sign up with third-party providers.
         hideCodeBlock: true
         description: |
-          If you are using Flutter, you can sign up with OAuth providers using the [`signInWithProvider()`](/docs/reference/dart/auth-signinwithprovider) method available on `supabase-flutter`.
+          If you are using Flutter, you can sign up with OAuth providers using the [`signInWithProvider()`](/docs/reference/dart/auth-signinwithprovider) method available on `supabase_flutter`.
 
   auth.signIn():
     description: |
@@ -213,7 +213,7 @@ pages:
     description: |
       Signs the user in using thrid party OAuth providers.
     notes: |
-      - `auth.signInWithProvider()` is only available on `supabase-flutter`
+      - `auth.signInWithProvider()` is only available on `supabase_flutter`
       - It will open the browser to the relevant login page.
     examples:
       - name: Sign in with provider.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixed few minor things that I found in Dart docs and Dart code samples in full-text-search guide

## What is the current behavior?

- Package names in Dart docs were not consistent. 
- `await` and `.execute()` were missing from code samples in full-text-search guide

## What is the new behavior?

- Consistent package names within Dart docs
- Added `await` and `execute()` to code samples
