### PR TITLE
fix: SMTP settings included in free tier

### DIFF
--- a/www/data/Pricing.json
+++ b/www/data/Pricing.json
@@ -97,7 +97,7 @@
       {
         "title": "Custom SMTP server",
         "tiers": {
-          "free": false,
+          "free": true,
           "pro": true,
           "enterprise": true
         }


### PR DESCRIPTION
## What kind of change does this PR introduce?

We now show custom SMTP settings are free on the pricing page

