### PR TITLE
fix: Add break words to a tags in blog pages

### DIFF
--- a/www/components/Nav/index.tsx
+++ b/www/components/Nav/index.tsx
@@ -239,6 +239,16 @@ const Nav = (props: Props) => {
                   >
                     Pricing
                   </a>
+                  <a
+                    href="/blog"
+                    className={`
+                    inline-flex items-center px-1 border-b-2 border-transparent text-sm font-medium
+                    text-gray-500 hover:text-gray-700 hover:border-gray-500 p-5
+                    dark:text-dark-100 dark:hover:border-dark-100
+                  `}
+                  >
+                    Blog
+                  </a>
                 </div>
               </div>
               <div className="hidden lg:flex items-center sm:space-x-3">

--- a/www/components/Nav/index.tsx
+++ b/www/components/Nav/index.tsx
@@ -335,6 +335,13 @@ const Nav = (props: Props) => {
                   >
                     GitHub
                   </a>
+                  <a
+                    href="/blog"
+                    target="_blank"
+                    className="block pl-3 pr-4 py-2 text-base font-medium text-gray-600 hover:text-gray-800 hover:bg-gray-50 dark:hover:bg-dark-600 hover:border-gray-300 dark:text-white"
+                  >
+                    Blog
+                  </a>
                 </div>
                 <div className="p-3">
                   <p className="mb-6 text-sm text-gray-400">Products available:</p>

--- a/www/styles/index.css
+++ b/www/styles/index.css
@@ -212,3 +212,7 @@ th {
 .sbui-typography-container thead {
   @apply text-gray-500 dark:text-gray-200;
 }
+
+.sbui-typography a {
+  @apply break-words;
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Blog pages were looking weird on mobile as some of the URL texts were too long - added some CSS to break em

Also added "Blog" to the mobile nav menu below the Github option