### PR TITLE
Remove parameter in storage download example

### DIFF
--- a/web/docs/guides/storage.mdx
+++ b/web/docs/guides/storage.mdx
@@ -187,7 +187,7 @@ values={[
 ```js
 // Use the JS library to create a bucket.
 
-const { data, error } = await supabase.storage.from('avatars').download('public/avatar1.png', 60)
+const { data, error } = await supabase.storage.from('avatars').download('public/avatar1.png')
 ```
 
 [Reference.](/docs/reference/javascript/storage-from-download)


### PR DESCRIPTION
In the example shown for downloading a storage file, there is a second parameter used in the `download` call.

## What kind of change does this PR introduce?

docs update

