### PR TITLE
docs: typo fix

### DIFF
--- a/web/spec/dart.yml
+++ b/web/spec/dart.yml
@@ -210,7 +210,7 @@ pages:
           ```
   auth.signInWithProvider():
     description: |
-      Signs the user in using thrid party OAuth providers.
+      Signs the user in using third party OAuth providers.
     notes: |
       - `auth.signInWithProvider()` is only available on `supabase_flutter`
       - It will open the browser to the relevant login page.


### PR DESCRIPTION
Description for auth.signInWithProvider() has a slight typo

## What kind of change does this PR introduce?

Docs update to fix typo

## What is the current behavior?

Description says: Signs the user in using thrid party OAuth providers.

## What is the new behavior?

Description will say: Signs the user in using third party OAuth providers.

## Additional context

