### PR TITLE
docs: fix typo for extensions schema name

### DIFF
--- a/web/docs/guides/hosting/overview.mdx
+++ b/web/docs/guides/hosting/overview.mdx
@@ -69,7 +69,7 @@ Supabase requires some Postgres extensions to be enabled by default for the API 
 [schema initialization script](https://github.com/supabase/supabase/blob/master/docker/volumes/db/init/00-initial-schema.sql).
 
 
-We recommend installing all extensions into an `extenstions` schema. This will keep your API clean, 
+We recommend installing all extensions into an `extensions` schema. This will keep your API clean, 
 since all tables in the `public` schema are exposed via the API.
 
 ```sql


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix typo on documentation.