### PR TITLE
Fix (probably) wrong variable name in React Tutorial in `Avatar.js`

### DIFF
--- a/web/docs/guides/with-react.mdx
+++ b/web/docs/guides/with-react.mdx
@@ -440,8 +440,8 @@ export default function Avatar({ url, size, onUpload }) {
   const [uploading, setUploading] = useState(false)
 
   useEffect(() => {
-    if (url) downloadImage(url)
-  }, [url])
+    if (avatarUrl) downloadImage(avatarUrl)
+  }, [avatarUrl])
 
   async function downloadImage(path) {
     try {


### PR DESCRIPTION
Hi, I just went through this tutorial and saw that the `url` param in the `Avatar.js` component is wrong. I guess it should be `avatarUrl` defined in the state. If not, where is the url supposed to come from?

## What kind of change does this PR introduce?

- docs update

## What is the current behavior?

There is a variable (url) mentioned in the React Tutorial in the `Avatar.js` component which does not exist.

## What is the new behavior?

I guess the correct variable name is `avatarUrl`


Thank you 👍🏻