### PR TITLE
fix(typo): fix "databse" typo in various places

### DIFF
--- a/web/spec/combined.json
+++ b/web/spec/combined.json
@@ -5869,7 +5869,7 @@
                         "isExported": true
                       },
                       "comment": {
-                        "shortText": "Subscribe to realtime changes in your databse."
+                        "shortText": "Subscribe to realtime changes in your database."
                       },
                       "parameters": [
                         {

--- a/web/spec/dart.yml
+++ b/web/spec/dart.yml
@@ -637,7 +637,7 @@ pages:
 
   subscribe():
     description: |
-      Subscribe to realtime changes in your databse.
+      Subscribe to realtime changes in your database.
     title: 'on().subscribe()'
     notes: |
       - Realtime is disabled by default for new Projects for better database performance and security. You can turn it on by [managing replication](/docs/guides/api#managing-realtime).

--- a/web/spec/supabase.json
+++ b/web/spec/supabase.json
@@ -5866,7 +5866,7 @@
 										"isExported": true
 									},
 									"comment": {
-										"shortText": "Subscribe to realtime changes in your databse."
+										"shortText": "Subscribe to realtime changes in your database."
 									},
 									"parameters": [
 										{


### PR DESCRIPTION
## What kind of change does this PR introduce?

Typo fix

## What is the current behavior?

The incorrect spelling for the word "database" shows up in various places.

## What is the new behavior?

Corrected spelling