### PR TITLE
Update with-flutter.mdx

### DIFF
--- a/web/docs/guides/with-flutter.mdx
+++ b/web/docs/guides/with-flutter.mdx
@@ -411,8 +411,8 @@ class _LoginPageState extends AuthState<LoginPage> {
 
   @override
   void initState() {
-    _emailController = TextEditingController();
     super.initState();
+    _emailController = TextEditingController();
   }
 
   @override


### PR DESCRIPTION
"super.initState()" should always be called first.  For dispose, it's called last.

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
