### PR TITLE
fix: bug where flutter guide images are returning 404

### DIFF
--- a/web/docs/guides/with-flutter.mdx
+++ b/web/docs/guides/with-flutter.mdx
@@ -19,7 +19,7 @@ This example provides the steps to build a simple user management app (from scra
 
 By the end of this guide you'll have an app which allows users to login and update some basic profile details:
 
-<img src="/img/supabase-flutter-demo.png" alt="Supabase User Management example" />
+![Supabase User Management example](/img/supabase-flutter-demo.png)
 
 ### Github
 
@@ -640,7 +640,7 @@ flutter run -d web-server --web-hostname localhost --web-port 3000
 
 And then open the browser to [localhost:3000](http://localhost:3000) and you should see the completed app.
 
-<img src="/img/supabase-flutter-account-page.png" alt="Supabase User Management example" />
+![Supabase User Management example](/img/supabase-flutter-account-page.png)
 
 
 ## Bonus: Profile photos

--- a/web/spec/combined.json
+++ b/web/spec/combined.json
@@ -2142,7 +2142,7 @@
                                     "types": [
                                       {
                                         "type": "reference",
-                                        "name": "Error"
+                                        "name": "ApiError"
                                       },
                                       {
                                         "type": "intrinsic",
@@ -2357,7 +2357,7 @@
                                 "types": [
                                   {
                                     "type": "reference",
-                                    "name": "Error"
+                                    "name": "ApiError"
                                   },
                                   {
                                     "type": "intrinsic",
@@ -2489,7 +2489,7 @@
                                     "types": [
                                       {
                                         "type": "reference",
-                                        "name": "Error"
+                                        "name": "ApiError"
                                       },
                                       {
                                         "type": "intrinsic",
@@ -2758,7 +2758,7 @@
                                     "types": [
                                       {
                                         "type": "reference",
-                                        "name": "Error"
+                                        "name": "ApiError"
                                       },
                                       {
                                         "type": "intrinsic",
@@ -3037,6 +3037,14 @@
                                       {
                                         "type": "stringLiteral",
                                         "value": "twitch"
+                                      },
+                                      {
+                                        "type": "stringLiteral",
+                                        "value": "spotify"
+                                      },
+                                      {
+                                        "type": "stringLiteral",
+                                        "value": "slack"
                                       }
                                     ]
                                   }
@@ -3264,7 +3272,7 @@
                                     "types": [
                                       {
                                         "type": "reference",
-                                        "name": "Error"
+                                        "name": "ApiError"
                                       },
                                       {
                                         "type": "intrinsic",
@@ -3484,7 +3492,7 @@
                                     "types": [
                                       {
                                         "type": "reference",
-                                        "name": "Error"
+                                        "name": "ApiError"
                                       },
                                       {
                                         "type": "intrinsic",
@@ -3868,7 +3876,7 @@
                                     "types": [
                                       {
                                         "type": "reference",
-                                        "name": "Error"
+                                        "name": "ApiError"
                                       },
                                       {
                                         "type": "intrinsic",
@@ -4078,7 +4086,7 @@
                                     "types": [
                                       {
                                         "type": "reference",
-                                        "name": "Error"
+                                        "name": "ApiError"
                                       },
                                       {
                                         "type": "intrinsic",
@@ -4462,7 +4470,7 @@
                                     "types": [
                                       {
                                         "type": "reference",
-                                        "name": "Error"
+                                        "name": "ApiError"
                                       },
                                       {
                                         "type": "intrinsic",
@@ -5869,7 +5877,7 @@
                         "isExported": true
                       },
                       "comment": {
-                        "shortText": "Subscribe to realtime changes in your database."
+                        "shortText": "Subscribe to realtime changes in your databse."
                       },
                       "parameters": [
                         {
@@ -16352,6 +16360,14 @@
                                       {
                                         "type": "stringLiteral",
                                         "value": "twitch"
+                                      },
+                                      {
+                                        "type": "stringLiteral",
+                                        "value": "spotify"
+                                      },
+                                      {
+                                        "type": "stringLiteral",
+                                        "value": "slack"
                                       }
                                     ]
                                   }
@@ -20660,7 +20676,7 @@
                   "sources": [
                     {
                       "fileName": "lib/types.ts",
-                      "line": 100,
+                      "line": 102,
                       "character": 8
                     }
                   ],
@@ -20690,7 +20706,7 @@
                   "sources": [
                     {
                       "fileName": "lib/types.ts",
-                      "line": 98,
+                      "line": 100,
                       "character": 10
                     }
                   ],
@@ -20720,7 +20736,7 @@
                   "sources": [
                     {
                       "fileName": "lib/types.ts",
-                      "line": 96,
+                      "line": 98,
                       "character": 6
                     }
                   ],
@@ -20750,7 +20766,7 @@
                   "sources": [
                     {
                       "fileName": "lib/types.ts",
-                      "line": 101,
+                      "line": 103,
                       "character": 6
                     }
                   ],
@@ -20780,7 +20796,7 @@
                   "sources": [
                     {
                       "fileName": "lib/types.ts",
-                      "line": 103,
+                      "line": 105,
                       "character": 10
                     }
                   ],
@@ -20815,7 +20831,7 @@
               "sources": [
                 {
                   "fileName": "lib/types.ts",
-                  "line": 94,
+                  "line": 96,
                   "character": 30
                 }
               ]
@@ -20840,7 +20856,7 @@
                   "sources": [
                     {
                       "fileName": "lib/types.ts",
-                      "line": 22,
+                      "line": 24,
                       "character": 14
                     }
                   ],
@@ -20864,7 +20880,7 @@
                   "sources": [
                     {
                       "fileName": "lib/types.ts",
-                      "line": 30,
+                      "line": 32,
                       "character": 12
                     }
                   ],
@@ -20897,7 +20913,7 @@
                   "sources": [
                     {
                       "fileName": "lib/types.ts",
-                      "line": 26,
+                      "line": 28,
                       "character": 12
                     }
                   ],
@@ -20927,7 +20943,7 @@
                   "sources": [
                     {
                       "fileName": "lib/types.ts",
-                      "line": 21,
+                      "line": 23,
                       "character": 16
                     }
                   ],
@@ -20957,7 +20973,7 @@
                   "sources": [
                     {
                       "fileName": "lib/types.ts",
-                      "line": 31,
+                      "line": 33,
                       "character": 15
                     }
                   ],
@@ -20986,7 +21002,7 @@
                   "sources": [
                     {
                       "fileName": "lib/types.ts",
-                      "line": 32,
+                      "line": 34,
                       "character": 12
                     }
                   ],
@@ -21006,7 +21022,7 @@
                   "sources": [
                     {
                       "fileName": "lib/types.ts",
-                      "line": 33,
+                      "line": 35,
                       "character": 6
                     }
                   ],
@@ -21044,7 +21060,7 @@
               "sources": [
                 {
                   "fileName": "lib/types.ts",
-                  "line": 20,
+                  "line": 22,
                   "character": 24
                 }
               ]
@@ -21072,7 +21088,7 @@
                   "sources": [
                     {
                       "fileName": "lib/types.ts",
-                      "line": 87,
+                      "line": 89,
                       "character": 10
                     }
                   ],
@@ -21143,7 +21159,7 @@
                       "sources": [
                         {
                           "fileName": "lib/types.ts",
-                          "line": 87,
+                          "line": 89,
                           "character": 11
                         }
                       ]
@@ -21164,7 +21180,7 @@
                   "sources": [
                     {
                       "fileName": "lib/types.ts",
-                      "line": 83,
+                      "line": 85,
                       "character": 4
                     }
                   ],
@@ -21187,7 +21203,7 @@
                   "sources": [
                     {
                       "fileName": "lib/types.ts",
-                      "line": 91,
+                      "line": 93,
                       "character": 13
                     }
                   ],
@@ -21219,7 +21235,7 @@
                       "sources": [
                         {
                           "fileName": "lib/types.ts",
-                          "line": 91,
+                          "line": 93,
                           "character": 14
                         }
                       ]
@@ -21241,7 +21257,7 @@
               "sources": [
                 {
                   "fileName": "lib/types.ts",
-                  "line": 79,
+                  "line": 81,
                   "character": 29
                 }
               ]
@@ -21267,7 +21283,7 @@
                   "sources": [
                     {
                       "fileName": "lib/types.ts",
-                      "line": 47,
+                      "line": 49,
                       "character": 13
                     }
                   ],
@@ -21296,7 +21312,7 @@
                   "sources": [
                     {
                       "fileName": "lib/types.ts",
-                      "line": 37,
+                      "line": 39,
                       "character": 14
                     }
                   ],
@@ -21353,7 +21369,7 @@
                           "sources": [
                             {
                               "fileName": "lib/types.ts",
-                              "line": 38,
+                              "line": 40,
                               "character": 12
                             }
                           ],
@@ -21384,7 +21400,7 @@
                       "sources": [
                         {
                           "fileName": "lib/types.ts",
-                          "line": 37,
+                          "line": 39,
                           "character": 15
                         }
                       ]
@@ -21402,7 +21418,7 @@
                   "sources": [
                     {
                       "fileName": "lib/types.ts",
-                      "line": 44,
+                      "line": 46,
                       "character": 5
                     }
                   ],
@@ -21423,7 +21439,7 @@
                   "sources": [
                     {
                       "fileName": "lib/types.ts",
-                      "line": 45,
+                      "line": 47,
                       "character": 22
                     }
                   ],
@@ -21453,7 +21469,7 @@
                   "sources": [
                     {
                       "fileName": "lib/types.ts",
-                      "line": 51,
+                      "line": 53,
                       "character": 14
                     }
                   ],
@@ -21482,7 +21498,7 @@
                   "sources": [
                     {
                       "fileName": "lib/types.ts",
-                      "line": 50,
+                      "line": 52,
                       "character": 12
                     }
                   ],
@@ -21503,7 +21519,7 @@
                   "sources": [
                     {
                       "fileName": "lib/types.ts",
-                      "line": 48,
+                      "line": 50,
                       "character": 7
                     }
                   ],
@@ -21533,7 +21549,7 @@
                   "sources": [
                     {
                       "fileName": "lib/types.ts",
-                      "line": 52,
+                      "line": 54,
                       "character": 20
                     }
                   ],
@@ -21562,7 +21578,7 @@
                   "sources": [
                     {
                       "fileName": "lib/types.ts",
-                      "line": 36,
+                      "line": 38,
                       "character": 4
                     }
                   ],
@@ -21583,7 +21599,7 @@
                   "sources": [
                     {
                       "fileName": "lib/types.ts",
-                      "line": 54,
+                      "line": 56,
                       "character": 17
                     }
                   ],
@@ -21613,7 +21629,7 @@
                   "sources": [
                     {
                       "fileName": "lib/types.ts",
-                      "line": 49,
+                      "line": 51,
                       "character": 7
                     }
                   ],
@@ -21643,7 +21659,7 @@
                   "sources": [
                     {
                       "fileName": "lib/types.ts",
-                      "line": 53,
+                      "line": 55,
                       "character": 20
                     }
                   ],
@@ -21673,7 +21689,7 @@
                   "sources": [
                     {
                       "fileName": "lib/types.ts",
-                      "line": 46,
+                      "line": 48,
                       "character": 18
                     }
                   ],
@@ -21703,7 +21719,7 @@
                   "sources": [
                     {
                       "fileName": "lib/types.ts",
-                      "line": 55,
+                      "line": 57,
                       "character": 6
                     }
                   ],
@@ -21733,7 +21749,7 @@
                   "sources": [
                     {
                       "fileName": "lib/types.ts",
-                      "line": 56,
+                      "line": 58,
                       "character": 12
                     }
                   ],
@@ -21762,7 +21778,7 @@
                   "sources": [
                     {
                       "fileName": "lib/types.ts",
-                      "line": 41,
+                      "line": 43,
                       "character": 15
                     }
                   ],
@@ -21809,7 +21825,7 @@
                       "sources": [
                         {
                           "fileName": "lib/types.ts",
-                          "line": 41,
+                          "line": 43,
                           "character": 16
                         }
                       ]
@@ -21844,7 +21860,7 @@
               "sources": [
                 {
                   "fileName": "lib/types.ts",
-                  "line": 35,
+                  "line": 37,
                   "character": 21
                 }
               ]
@@ -21873,7 +21889,7 @@
                   "sources": [
                     {
                       "fileName": "lib/types.ts",
-                      "line": 76,
+                      "line": 78,
                       "character": 6
                     }
                   ],
@@ -21906,7 +21922,7 @@
                   "sources": [
                     {
                       "fileName": "lib/types.ts",
-                      "line": 63,
+                      "line": 65,
                       "character": 7
                     }
                   ],
@@ -21939,7 +21955,7 @@
                   "sources": [
                     {
                       "fileName": "lib/types.ts",
-                      "line": 71,
+                      "line": 73,
                       "character": 20
                     }
                   ],
@@ -21972,7 +21988,7 @@
                   "sources": [
                     {
                       "fileName": "lib/types.ts",
-                      "line": 67,
+                      "line": 69,
                       "character": 10
                     }
                   ],
@@ -22006,7 +22022,7 @@
               "sources": [
                 {
                   "fileName": "lib/types.ts",
-                  "line": 59,
+                  "line": 61,
                   "character": 31
                 }
               ]
@@ -22032,7 +22048,7 @@
                   "sources": [
                     {
                       "fileName": "lib/types.ts",
-                      "line": 107,
+                      "line": 109,
                       "character": 7
                     }
                   ],
@@ -22062,7 +22078,7 @@
                   "sources": [
                     {
                       "fileName": "lib/types.ts",
-                      "line": 109,
+                      "line": 111,
                       "character": 10
                     }
                   ],
@@ -22092,7 +22108,7 @@
                   "sources": [
                     {
                       "fileName": "lib/types.ts",
-                      "line": 108,
+                      "line": 110,
                       "character": 7
                     }
                   ],
@@ -22122,7 +22138,7 @@
                   "sources": [
                     {
                       "fileName": "lib/types.ts",
-                      "line": 112,
+                      "line": 114,
                       "character": 10
                     }
                   ],
@@ -22144,7 +22160,7 @@
                   "sources": [
                     {
                       "fileName": "lib/types.ts",
-                      "line": 110,
+                      "line": 112,
                       "character": 14
                     }
                   ],
@@ -22179,7 +22195,7 @@
               "sources": [
                 {
                   "fileName": "lib/types.ts",
-                  "line": 106,
+                  "line": 108,
                   "character": 32
                 }
               ]
@@ -22204,7 +22220,7 @@
                   "sources": [
                     {
                       "fileName": "lib/types.ts",
-                      "line": 116,
+                      "line": 118,
                       "character": 7
                     }
                   ],
@@ -22224,7 +22240,7 @@
                   "sources": [
                     {
                       "fileName": "lib/types.ts",
-                      "line": 117,
+                      "line": 119,
                       "character": 7
                     }
                   ],
@@ -22247,7 +22263,7 @@
               "sources": [
                 {
                   "fileName": "lib/types.ts",
-                  "line": 115,
+                  "line": 117,
                   "character": 32
                 }
               ]
@@ -22263,7 +22279,7 @@
               "sources": [
                 {
                   "fileName": "lib/types.ts",
-                  "line": 13,
+                  "line": 15,
                   "character": 27
                 }
               ],
@@ -22350,6 +22366,14 @@
                   {
                     "type": "stringLiteral",
                     "value": "twitch"
+                  },
+                  {
+                    "type": "stringLiteral",
+                    "value": "spotify"
+                  },
+                  {
+                    "type": "stringLiteral",
+                    "value": "slack"
                   }
                 ]
               }

--- a/web/spec/gotrue.json
+++ b/web/spec/gotrue.json
@@ -7257,6 +7257,14 @@
 																	{
 																		"type": "stringLiteral",
 																		"value": "twitch"
+																	},
+																	{
+																		"type": "stringLiteral",
+																		"value": "spotify"
+																	},
+																	{
+																		"type": "stringLiteral",
+																		"value": "slack"
 																	}
 																]
 															}
@@ -11565,7 +11573,7 @@
 							"sources": [
 								{
 									"fileName": "lib/types.ts",
-									"line": 100,
+									"line": 102,
 									"character": 8
 								}
 							],
@@ -11595,7 +11603,7 @@
 							"sources": [
 								{
 									"fileName": "lib/types.ts",
-									"line": 98,
+									"line": 100,
 									"character": 10
 								}
 							],
@@ -11625,7 +11633,7 @@
 							"sources": [
 								{
 									"fileName": "lib/types.ts",
-									"line": 96,
+									"line": 98,
 									"character": 6
 								}
 							],
@@ -11655,7 +11663,7 @@
 							"sources": [
 								{
 									"fileName": "lib/types.ts",
-									"line": 101,
+									"line": 103,
 									"character": 6
 								}
 							],
@@ -11685,7 +11693,7 @@
 							"sources": [
 								{
 									"fileName": "lib/types.ts",
-									"line": 103,
+									"line": 105,
 									"character": 10
 								}
 							],
@@ -11720,7 +11728,7 @@
 					"sources": [
 						{
 							"fileName": "lib/types.ts",
-							"line": 94,
+							"line": 96,
 							"character": 30
 						}
 					]
@@ -11745,7 +11753,7 @@
 							"sources": [
 								{
 									"fileName": "lib/types.ts",
-									"line": 22,
+									"line": 24,
 									"character": 14
 								}
 							],
@@ -11769,7 +11777,7 @@
 							"sources": [
 								{
 									"fileName": "lib/types.ts",
-									"line": 30,
+									"line": 32,
 									"character": 12
 								}
 							],
@@ -11802,7 +11810,7 @@
 							"sources": [
 								{
 									"fileName": "lib/types.ts",
-									"line": 26,
+									"line": 28,
 									"character": 12
 								}
 							],
@@ -11832,7 +11840,7 @@
 							"sources": [
 								{
 									"fileName": "lib/types.ts",
-									"line": 21,
+									"line": 23,
 									"character": 16
 								}
 							],
@@ -11862,7 +11870,7 @@
 							"sources": [
 								{
 									"fileName": "lib/types.ts",
-									"line": 31,
+									"line": 33,
 									"character": 15
 								}
 							],
@@ -11891,7 +11899,7 @@
 							"sources": [
 								{
 									"fileName": "lib/types.ts",
-									"line": 32,
+									"line": 34,
 									"character": 12
 								}
 							],
@@ -11911,7 +11919,7 @@
 							"sources": [
 								{
 									"fileName": "lib/types.ts",
-									"line": 33,
+									"line": 35,
 									"character": 6
 								}
 							],
@@ -11949,7 +11957,7 @@
 					"sources": [
 						{
 							"fileName": "lib/types.ts",
-							"line": 20,
+							"line": 22,
 							"character": 24
 						}
 					]
@@ -11977,7 +11985,7 @@
 							"sources": [
 								{
 									"fileName": "lib/types.ts",
-									"line": 87,
+									"line": 89,
 									"character": 10
 								}
 							],
@@ -12048,7 +12056,7 @@
 									"sources": [
 										{
 											"fileName": "lib/types.ts",
-											"line": 87,
+											"line": 89,
 											"character": 11
 										}
 									]
@@ -12069,7 +12077,7 @@
 							"sources": [
 								{
 									"fileName": "lib/types.ts",
-									"line": 83,
+									"line": 85,
 									"character": 4
 								}
 							],
@@ -12092,7 +12100,7 @@
 							"sources": [
 								{
 									"fileName": "lib/types.ts",
-									"line": 91,
+									"line": 93,
 									"character": 13
 								}
 							],
@@ -12124,7 +12132,7 @@
 									"sources": [
 										{
 											"fileName": "lib/types.ts",
-											"line": 91,
+											"line": 93,
 											"character": 14
 										}
 									]
@@ -12146,7 +12154,7 @@
 					"sources": [
 						{
 							"fileName": "lib/types.ts",
-							"line": 79,
+							"line": 81,
 							"character": 29
 						}
 					]
@@ -12172,7 +12180,7 @@
 							"sources": [
 								{
 									"fileName": "lib/types.ts",
-									"line": 47,
+									"line": 49,
 									"character": 13
 								}
 							],
@@ -12201,7 +12209,7 @@
 							"sources": [
 								{
 									"fileName": "lib/types.ts",
-									"line": 37,
+									"line": 39,
 									"character": 14
 								}
 							],
@@ -12258,7 +12266,7 @@
 											"sources": [
 												{
 													"fileName": "lib/types.ts",
-													"line": 38,
+													"line": 40,
 													"character": 12
 												}
 											],
@@ -12289,7 +12297,7 @@
 									"sources": [
 										{
 											"fileName": "lib/types.ts",
-											"line": 37,
+											"line": 39,
 											"character": 15
 										}
 									]
@@ -12307,7 +12315,7 @@
 							"sources": [
 								{
 									"fileName": "lib/types.ts",
-									"line": 44,
+									"line": 46,
 									"character": 5
 								}
 							],
@@ -12328,7 +12336,7 @@
 							"sources": [
 								{
 									"fileName": "lib/types.ts",
-									"line": 45,
+									"line": 47,
 									"character": 22
 								}
 							],
@@ -12358,7 +12366,7 @@
 							"sources": [
 								{
 									"fileName": "lib/types.ts",
-									"line": 51,
+									"line": 53,
 									"character": 14
 								}
 							],
@@ -12387,7 +12395,7 @@
 							"sources": [
 								{
 									"fileName": "lib/types.ts",
-									"line": 50,
+									"line": 52,
 									"character": 12
 								}
 							],
@@ -12408,7 +12416,7 @@
 							"sources": [
 								{
 									"fileName": "lib/types.ts",
-									"line": 48,
+									"line": 50,
 									"character": 7
 								}
 							],
@@ -12438,7 +12446,7 @@
 							"sources": [
 								{
 									"fileName": "lib/types.ts",
-									"line": 52,
+									"line": 54,
 									"character": 20
 								}
 							],
@@ -12467,7 +12475,7 @@
 							"sources": [
 								{
 									"fileName": "lib/types.ts",
-									"line": 36,
+									"line": 38,
 									"character": 4
 								}
 							],
@@ -12488,7 +12496,7 @@
 							"sources": [
 								{
 									"fileName": "lib/types.ts",
-									"line": 54,
+									"line": 56,
 									"character": 17
 								}
 							],
@@ -12518,7 +12526,7 @@
 							"sources": [
 								{
 									"fileName": "lib/types.ts",
-									"line": 49,
+									"line": 51,
 									"character": 7
 								}
 							],
@@ -12548,7 +12556,7 @@
 							"sources": [
 								{
 									"fileName": "lib/types.ts",
-									"line": 53,
+									"line": 55,
 									"character": 20
 								}
 							],
@@ -12578,7 +12586,7 @@
 							"sources": [
 								{
 									"fileName": "lib/types.ts",
-									"line": 46,
+									"line": 48,
 									"character": 18
 								}
 							],
@@ -12608,7 +12616,7 @@
 							"sources": [
 								{
 									"fileName": "lib/types.ts",
-									"line": 55,
+									"line": 57,
 									"character": 6
 								}
 							],
@@ -12638,7 +12646,7 @@
 							"sources": [
 								{
 									"fileName": "lib/types.ts",
-									"line": 56,
+									"line": 58,
 									"character": 12
 								}
 							],
@@ -12667,7 +12675,7 @@
 							"sources": [
 								{
 									"fileName": "lib/types.ts",
-									"line": 41,
+									"line": 43,
 									"character": 15
 								}
 							],
@@ -12714,7 +12722,7 @@
 									"sources": [
 										{
 											"fileName": "lib/types.ts",
-											"line": 41,
+											"line": 43,
 											"character": 16
 										}
 									]
@@ -12749,7 +12757,7 @@
 					"sources": [
 						{
 							"fileName": "lib/types.ts",
-							"line": 35,
+							"line": 37,
 							"character": 21
 						}
 					]
@@ -12778,7 +12786,7 @@
 							"sources": [
 								{
 									"fileName": "lib/types.ts",
-									"line": 76,
+									"line": 78,
 									"character": 6
 								}
 							],
@@ -12811,7 +12819,7 @@
 							"sources": [
 								{
 									"fileName": "lib/types.ts",
-									"line": 63,
+									"line": 65,
 									"character": 7
 								}
 							],
@@ -12844,7 +12852,7 @@
 							"sources": [
 								{
 									"fileName": "lib/types.ts",
-									"line": 71,
+									"line": 73,
 									"character": 20
 								}
 							],
@@ -12877,7 +12885,7 @@
 							"sources": [
 								{
 									"fileName": "lib/types.ts",
-									"line": 67,
+									"line": 69,
 									"character": 10
 								}
 							],
@@ -12911,7 +12919,7 @@
 					"sources": [
 						{
 							"fileName": "lib/types.ts",
-							"line": 59,
+							"line": 61,
 							"character": 31
 						}
 					]
@@ -12937,7 +12945,7 @@
 							"sources": [
 								{
 									"fileName": "lib/types.ts",
-									"line": 107,
+									"line": 109,
 									"character": 7
 								}
 							],
@@ -12967,7 +12975,7 @@
 							"sources": [
 								{
 									"fileName": "lib/types.ts",
-									"line": 109,
+									"line": 111,
 									"character": 10
 								}
 							],
@@ -12997,7 +13005,7 @@
 							"sources": [
 								{
 									"fileName": "lib/types.ts",
-									"line": 108,
+									"line": 110,
 									"character": 7
 								}
 							],
@@ -13027,7 +13035,7 @@
 							"sources": [
 								{
 									"fileName": "lib/types.ts",
-									"line": 112,
+									"line": 114,
 									"character": 10
 								}
 							],
@@ -13049,7 +13057,7 @@
 							"sources": [
 								{
 									"fileName": "lib/types.ts",
-									"line": 110,
+									"line": 112,
 									"character": 14
 								}
 							],
@@ -13084,7 +13092,7 @@
 					"sources": [
 						{
 							"fileName": "lib/types.ts",
-							"line": 106,
+							"line": 108,
 							"character": 32
 						}
 					]
@@ -13109,7 +13117,7 @@
 							"sources": [
 								{
 									"fileName": "lib/types.ts",
-									"line": 116,
+									"line": 118,
 									"character": 7
 								}
 							],
@@ -13129,7 +13137,7 @@
 							"sources": [
 								{
 									"fileName": "lib/types.ts",
-									"line": 117,
+									"line": 119,
 									"character": 7
 								}
 							],
@@ -13152,7 +13160,7 @@
 					"sources": [
 						{
 							"fileName": "lib/types.ts",
-							"line": 115,
+							"line": 117,
 							"character": 32
 						}
 					]
@@ -13168,7 +13176,7 @@
 					"sources": [
 						{
 							"fileName": "lib/types.ts",
-							"line": 13,
+							"line": 15,
 							"character": 27
 						}
 					],
@@ -13255,6 +13263,14 @@
 							{
 								"type": "stringLiteral",
 								"value": "twitch"
+							},
+							{
+								"type": "stringLiteral",
+								"value": "spotify"
+							},
+							{
+								"type": "stringLiteral",
+								"value": "slack"
 							}
 						]
 					}

--- a/web/spec/supabase.json
+++ b/web/spec/supabase.json
@@ -2139,7 +2139,7 @@
 																"types": [
 																	{
 																		"type": "reference",
-																		"name": "Error"
+																		"name": "ApiError"
 																	},
 																	{
 																		"type": "intrinsic",
@@ -2354,7 +2354,7 @@
 														"types": [
 															{
 																"type": "reference",
-																"name": "Error"
+																"name": "ApiError"
 															},
 															{
 																"type": "intrinsic",
@@ -2486,7 +2486,7 @@
 																"types": [
 																	{
 																		"type": "reference",
-																		"name": "Error"
+																		"name": "ApiError"
 																	},
 																	{
 																		"type": "intrinsic",
@@ -2755,7 +2755,7 @@
 																"types": [
 																	{
 																		"type": "reference",
-																		"name": "Error"
+																		"name": "ApiError"
 																	},
 																	{
 																		"type": "intrinsic",
@@ -3034,6 +3034,14 @@
 																	{
 																		"type": "stringLiteral",
 																		"value": "twitch"
+																	},
+																	{
+																		"type": "stringLiteral",
+																		"value": "spotify"
+																	},
+																	{
+																		"type": "stringLiteral",
+																		"value": "slack"
 																	}
 																]
 															}
@@ -3261,7 +3269,7 @@
 																"types": [
 																	{
 																		"type": "reference",
-																		"name": "Error"
+																		"name": "ApiError"
 																	},
 																	{
 																		"type": "intrinsic",
@@ -3481,7 +3489,7 @@
 																"types": [
 																	{
 																		"type": "reference",
-																		"name": "Error"
+																		"name": "ApiError"
 																	},
 																	{
 																		"type": "intrinsic",
@@ -3865,7 +3873,7 @@
 																"types": [
 																	{
 																		"type": "reference",
-																		"name": "Error"
+																		"name": "ApiError"
 																	},
 																	{
 																		"type": "intrinsic",
@@ -4075,7 +4083,7 @@
 																"types": [
 																	{
 																		"type": "reference",
-																		"name": "Error"
+																		"name": "ApiError"
 																	},
 																	{
 																		"type": "intrinsic",
@@ -4459,7 +4467,7 @@
 																"types": [
 																	{
 																		"type": "reference",
-																		"name": "Error"
+																		"name": "ApiError"
 																	},
 																	{
 																		"type": "intrinsic",
@@ -5866,7 +5874,7 @@
 										"isExported": true
 									},
 									"comment": {
-										"shortText": "Subscribe to realtime changes in your database."
+										"shortText": "Subscribe to realtime changes in your databse."
 									},
 									"parameters": [
 										{


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix a bug where images in [quickstart Flutter guide](https://supabase.io/docs/guides/with-flutter) is returning 404. 

## What is the current behavior?

Images in flutter quickstart guide is returning 404 and now shown. 

## What is the new behavior?

Images are rendered properly. 
