### PR TITLE
fix: 404 error on txt files and OSS page

### DIFF
--- a/www/next.config.js
+++ b/www/next.config.js
@@ -45,18 +45,6 @@ module.exports = withMDX({
       },
       // misc rewrites
       {
-        source: '/humans.txt',
-        destination: `/docs/humans.txt`,
-      },
-      {
-        source: '/lawyers.txt',
-        destination: `/docs/lawyers.txt`,
-      },
-      {
-        source: '/.well-known/security.txt.txt',
-        destination: `/docs/.well-known/security.txt.txt`,
-      },
-      {
         source: '/feed.xml',
         destination: `/rss.xml`,
       },
@@ -580,6 +568,26 @@ module.exports = withMDX({
         permanent: false,
         source: '/docs/guides/self-hosting',
         destination: '/docs/guides/hosting/overview',
+      },
+      {
+        permanent: false,
+        source: '/humans.txt',
+        destination: `/docs/humans.txt`,
+      },
+      {
+        permanent: false,
+        source: '/lawyers.txt',
+        destination: `/docs/lawyers.txt`,
+      },
+      {
+        permanent: false,
+        source: '/.well-known/security.txt.txt',
+        destination: `/docs/.well-known/security.txt.txt`,
+      },
+      {
+        permanent: false,
+        source: '/oss',
+        destination: `/docs/oss`,
       },
     ]
   },


### PR DESCRIPTION
## What kind of change does this PR introduce?

[OSS page](https://supabase.io/oss) and txt files such as [humans.txt](https://supabase.io/humans.txt) are returning 404. This PR will redirect those links to `/doc/` where they are now located. 

Related https://github.com/supabase/supabase/issues/3797

## What is the current behavior?

OSS page and txt files return 404. 

This is due to the following reasons:
- txt files had rewrite rule set up in `next.config.js`, but since the rewrite path is not on the same next.js app, the rule was ignored, hence returning 404. 
- OSS page did not have any rewrite or redirect configurations on `next.config.js`

## What is the new behavior?

When users try to access OSS page and txt files on the old URL, they will be redirected to `/docs/` path. 

## Additional context

Not sure if this is the fix we want to do, so any inputs/opinions are welsome!