### PR TITLE
Technical Writer Description: Fix typo of Postgres

### DIFF
--- a/about/docs/careers/technical-writers.mdx
+++ b/about/docs/careers/technical-writers.mdx
@@ -30,7 +30,7 @@ Responsibilities includes:
 
 Must Have: 
 
-- Intermediate understanding of PosgresSQL
+- Intermediate understanding of Postgres
 - Full stack development experience
 - Fluent in English
 - Track record of producing content for a developer audience


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix typo

## What is the current behavior?

The typo was originally `PosgresSQL`.

## What is the new behavior?

For consistency with other references to Postgres in the other roles, I renamed this to `Postgres` instead.