### PR TITLE
Improve documentation for local development

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -1,0 +1,92 @@
+# Developing Supabase
+
+* [Development Setup](##Development-Setup)
+* [Installing Dependencies](###Installing-Dependencies)
+* [Building Supabase](##Building-Supabase)
+* [Start a Development Server](##Start-a-Development-Server)
+
+## Development Setup
+
+This document describes how to set up your development environment to build and test Supabase, and explains the basic use of `git`, and `npm`.
+
+### Installing Dependencies
+
+Before you can build Supabase, you must install and configure the following dependencies on your
+machine:
+
+* [Git](http://git-scm.com/)
+
+* [Node.js v16.x (LTS)](http://nodejs.org)
+
+* [npm](https://www.npmjs.com/)
+
+### Forking Supabase on Github
+
+To contribute code to Supabase, you must fork the [Supabase Repository](https://github.com/supabase/supabase). After you forked the repository you may now begin editing the source code.
+
+## Building Supabase
+
+To build Supabase, you clone the source code repository:
+
+2. Clone your Github forked repository:
+   ```sh
+   git clone https://github.com/<github_username>/supabase.git
+   ```
+
+3. Go to the Supabase directory:
+   ```sh
+   cd supabase
+   ```
+
+## Choosing Directory
+
+Before you start a development server, you must choose if you want to work on the [Supabase website](https://supabase.io) or [Supabase Docs](https://supabase.io/docs/).
+
+1. Go to the supabase.io directory
+    ```sh
+    cd www
+    ```
+    or Go to the [Supabase Docs](https://supabase.io/docs/) directory
+    ```sh
+    cd web
+    ```
+
+2. Install npm dependencies:
+
+    npm
+    ```sh
+    npm install
+    ```
+
+    or with yarn
+    ```sh
+    yarn install
+    ```
+
+## Start a Development Server
+
+To debug code, and to see changes in real time, it is often useful to have a local HTTP server.
+
+1. Start development server
+
+    npm
+    ```sh
+    npm run start
+    ```
+
+    or with yarn
+    ```sh
+    yarn start
+    ```
+
+2. To access the local server, enter the following URL into your web browser:
+
+    [Supabase website](https://supabase.io)
+    ```sh
+    http://localhost:3000
+    ```
+
+    [Supabase Docs](https://supabase.io/docs/)
+    ```sh
+    http://localhost:3005/docs
+    ```

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -38,7 +38,7 @@ To build Supabase, you clone the source code repository:
    cd supabase
    ```
 
-## Choosing Directory
+### Choosing Directory
 
 Before you start a development server, you must choose if you want to work on the [Supabase website](https://supabase.io) or [Supabase Docs](https://supabase.io/docs/).
 
@@ -76,7 +76,7 @@ To debug code, and to see changes in real time, it is often useful to have a loc
 
     or with yarn
     ```sh
-    yarn start
+    yarn dev
     ```
 
 2. To access the local server, enter the following URL into your web browser:

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -7,7 +7,7 @@
 
 ## Development Setup
 
-This document describes how to set up your development environment to build and test Supabase, and explains the basic use of `git`, and `npm`.
+This document describes how to set up your development environment to build and test Supabase.
 
 ### Installing Dependencies
 
@@ -18,7 +18,7 @@ machine:
 
 * [Node.js v16.x (LTS)](http://nodejs.org)
 
-* [npm](https://www.npmjs.com/)
+* [npm](https://www.npmjs.com/) or [yarn](https://yarnpkg.com/)
 
 ### Forking Supabase on Github
 

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -22,7 +22,7 @@ machine:
 
 ### Forking Supabase on Github
 
-To contribute code to Supabase, you must fork the [Supabase Repository](https://github.com/supabase/supabase). After you forked the repository you may now begin editing the source code.
+To contribute code to Supabase, you must fork the [Supabase Repository](https://github.com/supabase/supabase). After you fork the repository, you may now begin editing the source code.
 
 ## Building Supabase
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 For full documentation, visit [supabase.io/docs](https://supabase.io/docs)
 
-To see how to Contribute, visit [Getting Started](##Getting-Started)
+To see how to Contribute, visit [Getting Started](./DEVELOPERS.md)
 
 ## Community & Support
 
@@ -76,67 +76,6 @@ Our client library is modular. Each sub-library is a standalone implementation f
 | `postgrest-{lang}`    | [`JS`](https://github.com/supabase/postgrest-js) | [`C#`](https://github.com/supabase/postgrest-csharp) \| [`Dart`](https://github.com/supabase/postgrest-dart) \| [`Python`](https://github.com/supabase/postgrest-py) \| [`Rust`](https://github.com/supabase/postgrest-rs) \| [`Ruby`](https://github.com/supabase/postgrest-rb) \| [`Go`](https://github.com/supabase/postgrest-go) |
 | `realtime-{lang}`     | [`JS`](https://github.com/supabase/realtime-js)  | [`C#`](https://github.com/supabase/realtime-csharp) \| [`Dart`](https://github.com/supabase/realtime-dart) \| [`Python`](https://github.com/supabase/realtime-py) \| `Rust` \| `Ruby` \| `Go`                                                                                                                                        |
 | `gotrue-{lang}`       | [`JS`](https://github.com/supabase/gotrue-js)    | [`C#`](https://github.com/supabase/gotrue-csharp) \| [`Dart`](https://github.com/supabase/gotrue-dart) \| [`Python`](https://github.com/supabase/gotrue-py) \| `Rust` \| `Ruby` \| `Go`                                                                                                                                              |
-
-# Getting Started
-
-If you want to help Contribute but don't know how to start a local development server or just don't know where to start, follow these steps.
-
-## Installation
-
-To get started you need to fork the repository and download it to your local machine, by following the steps.
-
-1. Fork the repo
-
-2. Clone the repo
-   ```sh
-   git clone https://github.com/your_username/supabase.git
-   ```
-
-3. cd into the base of the repo
-   ```sh
-   cd supabase
-   ```
-
-## To Start a Development Server
-
-To start a development server must choose if you want to work on [Supabase website](https://supabase.io) or [Supabase Docs](https://supabase.io/docs/).
-
-1. cd into supabase.io
-    ```sh
-    cd www
-    ```
-    or cd into [Supabase Docs](https://supabase.io/docs/)
-    ```sh
-    cd web
-    ```
-
-2. Install the npm packages
-
-    npm
-    ```sh
-    npm install
-    ```
-
-    or with yarn
-    ```sh
-    yarn install
-    ```
-
-3. Start development server
-
-    npm
-    ```sh
-    npm run start
-    ```
-
-    or with yarn
-    ```sh
-    yarn start
-    ```
-
-Your all set! To see changes on your development server for [Supabase website](https://supabase.io) go to [http://localhost:3000](http://localhost:3000/).
-
-And to see changes on your development server for [Supabase Docs](https://supabase.io/docs/) go to [http://localhost:3005/docs](http://localhost:3005/docs)
 
 <!--- Remove this list if you're translating to another language, it's hard to keep updated across multiple files-->
 <!--- Keep only the link to the list of translation files-->

--- a/README.md
+++ b/README.md
@@ -138,10 +138,6 @@ Your all set! To see changes on your development server for supabase.io go to [h
 
 And to see changes on your development server for [Supabase Docs](https://supabase.io/docs/) go to [http://localhost:3005/docs](http://localhost:3005/docs)
 
-## What you can help with
-
-If you are new to contributing to supabase, you can help out the supabase team by creating docs, finding spelling and grammar errors, solving issues, finding issues, feature requests, and many others.
-
 <!--- Remove this list if you're translating to another language, it's hard to keep updated across multiple files-->
 <!--- Keep only the link to the list of translation files-->
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ To get started you need to fork the repository and download it to your local mac
 
 ## To Start a Development Server
 
-To start a development server must choose if you want to work on supabase.io or [Supabase Docs](https://supabase.io/docs/).
+To start a development server must choose if you want to work on [Supabase website](https://supabase.io) or [Supabase Docs](https://supabase.io/docs/).
 
 1. cd into supabase.io
     ```sh
@@ -134,7 +134,7 @@ To start a development server must choose if you want to work on supabase.io or 
     yarn start
     ```
 
-Your all set! To see changes on your development server for supabase.io go to [http://localhost:3000](http://localhost:3000/).
+Your all set! To see changes on your development server for [Supabase website](https://supabase.io) go to [http://localhost:3000](http://localhost:3000/).
 
 And to see changes on your development server for [Supabase Docs](https://supabase.io/docs/) go to [http://localhost:3005/docs](http://localhost:3005/docs)
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@
 
 For full documentation, visit [supabase.io/docs](https://supabase.io/docs)
 
+To see how to Contribute visit [Getting Started](##Getting-Started)
+
 ## Community & Support
 
 - [Community Forum](https://github.com/supabase/supabase/discussions). Best for: help with building, discussion about database best practices.
@@ -74,6 +76,71 @@ Our client library is modular. Each sub-library is a standalone implementation f
 | `postgrest-{lang}`    | [`JS`](https://github.com/supabase/postgrest-js) | [`C#`](https://github.com/supabase/postgrest-csharp) \| [`Dart`](https://github.com/supabase/postgrest-dart) \| [`Python`](https://github.com/supabase/postgrest-py) \| [`Rust`](https://github.com/supabase/postgrest-rs) \| [`Ruby`](https://github.com/supabase/postgrest-rb) \| [`Go`](https://github.com/supabase/postgrest-go) |
 | `realtime-{lang}`     | [`JS`](https://github.com/supabase/realtime-js)  | [`C#`](https://github.com/supabase/realtime-csharp) \| [`Dart`](https://github.com/supabase/realtime-dart) \| [`Python`](https://github.com/supabase/realtime-py) \| `Rust` \| `Ruby` \| `Go`                                                                                                                                        |
 | `gotrue-{lang}`       | [`JS`](https://github.com/supabase/gotrue-js)    | [`C#`](https://github.com/supabase/gotrue-csharp) \| [`Dart`](https://github.com/supabase/gotrue-dart) \| [`Python`](https://github.com/supabase/gotrue-py) \| `Rust` \| `Ruby` \| `Go`                                                                                                                                              |
+
+# Getting Started
+
+If you want to help Contribute but don't know how to start a local development server or just don't know where to start, follow these steps.
+
+## Installation
+
+To get started you need to fork the repository and download it to your local machine, by following the steps.
+
+1. Fork the repo
+
+2. Clone the repo
+   ```sh
+   git clone https://github.com/your_username/supabase.git
+   ```
+
+3. cd into the base of the repo
+   ```sh
+   cd supabase
+   ```
+
+## To Start a Development Server
+
+To start a development server must choose if you want to work on supabase.io or [Supabase Docs](https://supabase.io/docs/).
+
+1. cd into supabase.io
+    ```sh
+    cd www
+    ```
+    or cd into [Supabase Docs](https://supabase.io/docs/)
+    ```sh
+    cd web
+    ```
+
+2. Install the npm packages
+
+    npm
+    ```sh
+    npm install
+    ```
+
+    or with yarn
+    ```sh
+    yarn install
+    ```
+
+3. Start development server
+
+    npm
+    ```sh
+    npm run start
+    ```
+
+    or with yarn
+    ```sh
+    yarn start
+    ```
+
+Your all set! To see changes on your development server for supabase.io go to [http://localhost:3000](http://localhost:3000/).
+
+And to see changes on your development server for [Supabase Docs](https://supabase.io/docs/) go to [http://localhost:3005/docs](http://localhost:3005/docs)
+
+## What you can help with
+
+If you are new to contributing to supabase, you can help out the supabase team by creating docs, finding spelling and grammar errors, solving issues, finding issues, feature requests, and many others.
 
 <!--- Remove this list if you're translating to another language, it's hard to keep updated across multiple files-->
 <!--- Keep only the link to the list of translation files-->

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 For full documentation, visit [supabase.io/docs](https://supabase.io/docs)
 
-To see how to Contribute visit [Getting Started](##Getting-Started)
+To see how to Contribute, visit [Getting Started](##Getting-Started)
 
 ## Community & Support
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR adds a feature request from #3860 to have local development docs, and closes #3860. Currently, there are no docs on starting a localhost, so this PR should help new people be able to start a localhost and contribute to the repo.

## What is the current behavior?

No docs on how to start a local development server.

## What is the new behavior?

Docs in the readme showing someone how to start a local development server.