### PR TITLE
Improve demo video corners

### DIFF
--- a/www/components/Hero.tsx
+++ b/www/components/Hero.tsx
@@ -80,7 +80,7 @@ const Hero = () => {
                       <div className="h-2 w-2 mr-2 rounded-full bg-dark-500" />
                     </div>
                     <div
-                      className="w-full relative bg-dark-900 shadow-lg"
+                      className="w-full relative bg-dark-900 shadow-lg rounded-b-md"
                       style={{ padding: '56.25% 0 0 0' }}
                     >
                       <iframe


### PR DESCRIPTION
## What kind of change does this PR introduce?

This is a very small and nit-picky problem but this PR fixes a problem with the demo video not truly being rounded.

## What is the current behavior?

As you can see its kind of hard to notice but its not fully rounded.
<img width="1392" alt="Screen Shot 2021-11-17 at 8 50 08 PM" src="https://user-images.githubusercontent.com/70828596/142336793-929b8eb5-4fd7-47ea-9c26-72c697e89b3d.png">

## What is the new behavior?

As you can see its kind of hard to see but its fixed.
<img width="1392" alt="Screen Shot 2021-11-17 at 8 50 35 PM" src="https://user-images.githubusercontent.com/70828596/142336798-cab760f1-5841-498a-a833-0e7ccbb3e17a.png">

## Additional context

This is just something that I saw once and can't unsee.