### PR TITLE
change return to returns in line 124

### DIFF
--- a/web/docs/guides/database/functions.mdx
+++ b/web/docs/guides/database/functions.mdx
@@ -121,7 +121,7 @@ $$; --6
 At it's most basic a function has the following parts:
 
 1. `create or replace function hello_world()`: The function declaration, where `hello_world` is the name of the function. You can use either `create` when creating a new function or `replace` when replacing an existing function. Or you can use `create or replace` together to handle either.
-2. `returns text`: The type of data that the function returns. If it returns nothing, you can `return void`. 
+2. `returns text`: The type of data that the function returns. If it returns nothing, you can `returns void`. 
 3. `language sql`: The language used inside the function body. This can also be a procedural language: `plpgsql`, `plv8`, `plpython`, etc.
 4. `as $$`: The function wrapper. Anything enclosed inside the `$$` symbols will be part of the function body.
 5. `select 'hello world';`: A simple function body. The final `select` statement inside a function body will be returned if there are no statements following it.


### PR DESCRIPTION
in line 124, `return void` is wrong.
the correct syntax would be `returns`.

## What kind of change does this PR introduce?
docs update

## What is the current behavior?

in line 124 of `/docs/guides/database/functions.mdx`, there is a wrong syntax for returning void, `return void`.

## What is the new behavior?

as per the [postgres create function docs](https://www.postgresql.org/docs/14/sql-createfunction.html) it would be `returns void`. 

## Additional context
