### PR TITLE
fix/blog: make "select a category" legible, use Dropdown component

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -16,7 +16,7 @@
     "@mdx-js/react": "^1.6.22",
     "@next/mdx": "^10.0.7",
     "@supabase/supabase-js": "^1.6.0",
-    "@supabase/ui": "^0.22.0",
+    "@supabase/ui": "^0.25.0",
     "classnames": "2.2.6",
     "date-fns": "2.10.0",
     "gray-matter": "^4.0.2",

--- a/www/pages/blog.tsx
+++ b/www/pages/blog.tsx
@@ -10,7 +10,7 @@ import { getSortedPosts, getAllCategories } from '~/lib/posts'
 import authors from 'lib/authors.json'
 
 import DefaultLayout from '~/components/Layouts/Default'
-import { Typography, Badge, Space, Select } from '@supabase/ui'
+import { Typography, Badge, Space, Dropdown, Button } from '@supabase/ui'
 import PostTypes from '~/types/post'
 import BlogListItem from '~/components/Blog/BlogListItem'
 import BlogHeader from '~/components/Blog/BlogHeader'
@@ -83,20 +83,23 @@ function Blog(props: any) {
                 <div className="col-span-12 lg:col-span-4 mt-4 lg:mt-0">
                   <Space className="lg:justify-end" size={6}>
                     <Typography.Text>Select a category</Typography.Text>
-                    <Select
-                      onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
-                        setCategory(e.target.value)
-                      }
+                    <Dropdown
+                      overlay={[
+                        <Dropdown.RadioGroup value={category} onChange={setCategory}>
+                          <Dropdown.Radio value="all">Show all</Dropdown.Radio>
+                          {props.categories.map((categoryId: string) => (
+                            <Dropdown.Radio value={categoryId}>{categoryId}</Dropdown.Radio>
+                          ))}
+                        </Dropdown.RadioGroup>,
+                      ]}
                     >
-                      <Select.Option key={'all'} value={'all'}>
-                        Show all
-                      </Select.Option>
-                      {props.categories.map((categoryId: string) => (
-                        <Select.Option key={categoryId} value={categoryId}>
-                          {categoryId}
-                        </Select.Option>
-                      ))}
-                    </Select>
+                      <Button
+                        type="outline"
+                        className="sbui-select--medium"
+                      >
+                        {category === 'all' ? 'Show all' : category}
+                      </Button>
+                    </Dropdown>
                   </Space>
                 </div>
               </div>

--- a/www/pages/blog.tsx
+++ b/www/pages/blog.tsx
@@ -84,6 +84,10 @@ function Blog(props: any) {
                   <Space className="lg:justify-end" size={6}>
                     <Typography.Text>Select a category</Typography.Text>
                     <Dropdown
+                      style={{
+                        height: '50vh',
+                        overflow: 'auto',
+                      }}
                       overlay={[
                         <Dropdown.RadioGroup value={category} onChange={setCategory}>
                           <Dropdown.Radio value="all">Show all</Dropdown.Radio>

--- a/www/pages/blog.tsx
+++ b/www/pages/blog.tsx
@@ -90,9 +90,13 @@ function Blog(props: any) {
                       }}
                       overlay={[
                         <Dropdown.RadioGroup value={category} onChange={setCategory}>
-                          <Dropdown.Radio value="all">Show all</Dropdown.Radio>
+                          <Dropdown.Radio key={'all'} value="all">
+                            Show all
+                          </Dropdown.Radio>
                           {props.categories.map((categoryId: string) => (
-                            <Dropdown.Radio value={categoryId}>{categoryId}</Dropdown.Radio>
+                            <Dropdown.Radio key={categoryId} value={categoryId}>
+                              {categoryId}
+                            </Dropdown.Radio>
                           ))}
                         </Dropdown.RadioGroup>,
                       ]}

--- a/www/pages/blog.tsx
+++ b/www/pages/blog.tsx
@@ -10,7 +10,7 @@ import { getSortedPosts, getAllCategories } from '~/lib/posts'
 import authors from 'lib/authors.json'
 
 import DefaultLayout from '~/components/Layouts/Default'
-import { Typography, Badge, Space, Dropdown, Button } from '@supabase/ui'
+import { Typography, Badge, Space, Dropdown, Button, IconChevronDown } from '@supabase/ui'
 import PostTypes from '~/types/post'
 import BlogListItem from '~/components/Blog/BlogListItem'
 import BlogHeader from '~/components/Blog/BlogHeader'
@@ -96,6 +96,7 @@ function Blog(props: any) {
                       <Button
                         type="outline"
                         className="sbui-select--medium"
+                        iconRight={<IconChevronDown />}
                       >
                         {category === 'all' ? 'Show all' : category}
                       </Button>


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Fixes https://github.com/supabase/supabase/issues/3924 using [this suggestion](https://github.com/supabase/supabase/issues/3924#issuecomment-971522030)
- Replaced `Select` component for filtering blogpost category with a scrollable `Dropdown` component
- minimum version of `supabase/ui` has been bumped to `^0.25.0` since a Radio Dropdown is used

## What is the current behavior?

- as described in the linked issue, a `Select` component is used which does not seem to be support and be readable in Dark Mode

## What is the new behavior?

- a `Dropdown` component (`RadioGroup` type) is now used to filter blogpost category
- the Dropdown's options are now readable
![supabase-fix](https://user-images.githubusercontent.com/29654756/142722157-d42c1491-1323-4b6c-b822-8e870d248032.gif)

## Additional context

- Not sure if this is the preferred way to implement scrollable behaviour in a `Dropdown` - but scrollable behaviour is required since the display for the number of possible tags exceeds most viewports
- Not sure if you want the button to have a fixed width based on viewport size - currently just uses as much space as the tag name requires