### PR TITLE
Fixed Floating Icons

### DIFF
--- a/www/components/FloatingIcons/FloatingIcons.module.css
+++ b/www/components/FloatingIcons/FloatingIcons.module.css
@@ -6,7 +6,7 @@
 .icon-electron {
   @apply absolute w-16 z-0;
   left: 17%;
-  top: 35%;
+  top: 25%;
 }
 .icon-vue {
   @apply absolute w-16 z-10;

--- a/www/components/FloatingIcons/FloatingIcons.module.css
+++ b/www/components/FloatingIcons/FloatingIcons.module.css
@@ -15,7 +15,7 @@
 }
 .icon-angular {
   @apply absolute w-12 z-10;
-  right: 24%;
+  right: 21%;
   top: 28%;
 }
 .icon-flutter {

--- a/www/components/FloatingIcons/FloatingIcons.module.css
+++ b/www/components/FloatingIcons/FloatingIcons.module.css
@@ -15,8 +15,8 @@
 }
 .icon-angular {
   @apply absolute w-12 z-10;
-  right: 21%;
-  top: 33%;
+  right: 24%;
+  top: 28%;
 }
 .icon-flutter {
   @apply absolute w-16 z-10;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix #3962 by moving angular and electron away from the examples making it less confusing.

## What is the current behavior?

<img width="1392" alt="Screen Shot 2021-11-20 at 1 32 22 PM" src="https://user-images.githubusercontent.com/70828596/142737360-3be03f0a-05b9-4842-928e-8d3b5ed16364.png">

## What is the new behavior?

<img width="1392" alt="Screen Shot 2021-11-20 at 1 39 02 PM" src="https://user-images.githubusercontent.com/70828596/142737534-8e2bdadf-d514-4478-8cd3-81ea21125230.png">