### PR TITLE
docs/fix: tiny typo

### DIFF
--- a/web/docs/guides/database/intro.mdx
+++ b/web/docs/guides/database/intro.mdx
@@ -20,7 +20,7 @@ This package included a query language called "PostQUEL".
 In 1994, Postgres95 was built on top of POSTGRES code, adding an SQL language interpreter as a replacement for PostQUEL.
 Eventually, Postgres95 was renamed to PostgreSQL to reflect the SQL query capability.
 
-After this, many people refereed to it as Postgres since it's less prone to confusion. Supabase is all about 
+After this, many people referred to it as Postgres since it's less prone to confusion. Supabase is all about 
 simplicity, so we also refer to it as Postgres.
 
 <!-- 


### PR DESCRIPTION
## What kind of change does this PR introduce?

- noticed small typo while going through docs, `refereed` should be `referred`

## What is the current behavior?

- ...many people **refereed** to it as Postgres...

## What is the new behavior?

- ...many people **referred** to it as Postgres...

## Additional context
