### PR TITLE
Fix button bug

### DIFF
--- a/www/components/Hero.tsx
+++ b/www/components/Hero.tsx
@@ -31,16 +31,16 @@ const Hero = () => {
                         href="https://app.supabase.io/api/login"
                         as="https://app.supabase.io/api/login"
                       >
-                        <a>
-                          <Button className="mt-10 py-3" size="medium">
+                        <a className="mt-10">
+                          <Button className="py-3" size="medium">
                             Start your project
                           </Button>
                         </a>
                       </Link>
                       <Link href="/docs" as="/docs">
-                        <a>
+                        <a className="mt-10">
                           <Button
-                            className="mt-10 py-3"
+                            className="py-3"
                             size="medium"
                             type="text"
                             icon={<IconBookOpen />}


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR fixes a problem with spacing for a button.

## What is the current behavior?

As you can see, you can click anywhere in the blue box and the link will work.
<img width="1392" alt="Screen Shot 2021-11-22 at 11 39 30 AM" src="https://user-images.githubusercontent.com/70828596/142900877-87798943-1509-4b0c-9b11-e44a7b473b5a.png">

## What is the new behavior?

but we want it to only work on the button like this.
<img width="1392" alt="Screen Shot 2021-11-22 at 11 40 22 AM" src="https://user-images.githubusercontent.com/70828596/142900945-81a0a360-a5db-4988-b599-c64ed4273d1d.png">

## Additional context

It's kind of hard to explain, for something simple.