### PR TITLE
Improvement to swiper buttons

### DIFF
--- a/www/components/Sections/GithubExamples.tsx
+++ b/www/components/Sections/GithubExamples.tsx
@@ -116,17 +116,17 @@ function GithubExamples() {
               )
             })}
             <div className="container mx-auto hidden md:flex flex-row justify-between mt-3">
-                <div ref={prevRef} className="cursor-pointer ml-4">
-                  <Typography.Text>
-                    <IconArrowLeft />
-                  </Typography.Text>
-                </div>
-                <div ref={nextRef} className="cursor-pointer mr-4">
-                  <Typography.Text>
-                    <IconArrowRight />
-                  </Typography.Text>
-                </div>
+              <div ref={prevRef} className="cursor-pointer ml-4">
+                <Typography.Text>
+                  <IconArrowLeft />
+                </Typography.Text>
               </div>
+              <div ref={nextRef} className="cursor-pointer mr-4">
+                <Typography.Text>
+                  <IconArrowRight />
+                </Typography.Text>
+              </div>
+            </div>
           </Swiper>
         </div>
       </div>

--- a/www/components/Sections/GithubExamples.tsx
+++ b/www/components/Sections/GithubExamples.tsx
@@ -66,18 +66,6 @@ function GithubExamples() {
               </a>
             </Link>
           </div>
-          <div className="container w-min m-auto hidden md:flex flex-row mt-3">
-            <div ref={prevRef} className="cursor-pointer mr-1">
-              <Typography.Text>
-                <IconArrowLeft />
-              </Typography.Text>
-            </div>
-            <div ref={nextRef} className="cursor-pointer ml-1">
-              <Typography.Text>
-                <IconArrowRight />
-              </Typography.Text>
-            </div>
-          </div>
         </div>
       </div>
 
@@ -127,6 +115,18 @@ function GithubExamples() {
                 </SwiperSlide>
               )
             })}
+            <div className="container mx-auto hidden md:flex flex-row justify-between mt-3">
+                <div ref={prevRef} className="cursor-pointer ml-4">
+                  <Typography.Text>
+                    <IconArrowLeft />
+                  </Typography.Text>
+                </div>
+                <div ref={nextRef} className="cursor-pointer mr-4">
+                  <Typography.Text>
+                    <IconArrowRight />
+                  </Typography.Text>
+                </div>
+              </div>
           </Swiper>
         </div>
       </div>

--- a/www/components/Sections/GithubExamples.tsx
+++ b/www/components/Sections/GithubExamples.tsx
@@ -66,6 +66,18 @@ function GithubExamples() {
               </a>
             </Link>
           </div>
+          <div className="container w-min m-auto hidden md:flex flex-row mt-3">
+            <div ref={prevRef} className="cursor-pointer mr-1">
+              <Typography.Text>
+                <IconArrowLeft />
+              </Typography.Text>
+            </div>
+            <div ref={nextRef} className="cursor-pointer ml-1">
+              <Typography.Text>
+                <IconArrowRight />
+              </Typography.Text>
+            </div>
+          </div>
         </div>
       </div>
 
@@ -115,18 +127,6 @@ function GithubExamples() {
                 </SwiperSlide>
               )
             })}
-            <div className="container mx-auto hidden md:flex flex-row justify-between mt-3">
-              <div ref={prevRef} className="cursor-pointer">
-                <Typography.Text>
-                  <IconArrowLeft />
-                </Typography.Text>
-              </div>
-              <div ref={nextRef} className="cursor-pointer">
-                <Typography.Text>
-                  <IconArrowRight />
-                </Typography.Text>
-              </div>
-            </div>
           </Swiper>
         </div>
       </div>

--- a/www/components/Sections/TwitterSocialProof.tsx
+++ b/www/components/Sections/TwitterSocialProof.tsx
@@ -56,18 +56,6 @@ function TwitterSocialProof() {
                 </a>
               </Link>
             </div>
-            <div className="w-min mx-auto hidden md:flex flex-row">
-              <div ref={prevRef} className="cursor-pointer mr-1">
-                <Typography.Text>
-                  <IconArrowLeft />
-                </Typography.Text>
-              </div>
-              <div ref={nextRef} className="cursor-pointer ml-1">
-                <Typography.Text>
-                  <IconArrowRight />
-                </Typography.Text>
-              </div>
-            </div>
           </Typography.Text>
         </div>
       </div>
@@ -121,6 +109,18 @@ function TwitterSocialProof() {
                 </SwiperSlide>
               )
             })}
+              <div className="container mx-auto hidden md:flex flex-row justify-between mt-3">
+                <div ref={prevRef} className="cursor-pointer ml-4">
+                  <Typography.Text>
+                    <IconArrowLeft />
+                  </Typography.Text>
+                </div>
+                <div ref={nextRef} className="cursor-pointer mr-4">
+                  <Typography.Text>
+                    <IconArrowRight />
+                  </Typography.Text>
+                </div>
+              </div>
           </Swiper>
         </div>
       </div>

--- a/www/components/Sections/TwitterSocialProof.tsx
+++ b/www/components/Sections/TwitterSocialProof.tsx
@@ -56,6 +56,18 @@ function TwitterSocialProof() {
                 </a>
               </Link>
             </div>
+            <div className="w-min mx-auto hidden md:flex flex-row">
+              <div ref={prevRef} className="cursor-pointer mr-1">
+                <Typography.Text>
+                  <IconArrowLeft />
+                </Typography.Text>
+              </div>
+              <div ref={nextRef} className="cursor-pointer ml-1">
+                <Typography.Text>
+                  <IconArrowRight />
+                </Typography.Text>
+              </div>
+            </div>
           </Typography.Text>
         </div>
       </div>
@@ -109,18 +121,6 @@ function TwitterSocialProof() {
                 </SwiperSlide>
               )
             })}
-            <div className="container mx-auto hidden md:flex flex-row justify-between mt-3">
-              <div ref={prevRef} className="cursor-pointer">
-                <Typography.Text>
-                  <IconArrowLeft />
-                </Typography.Text>
-              </div>
-              <div ref={nextRef} className="cursor-pointer">
-                <Typography.Text>
-                  <IconArrowRight />
-                </Typography.Text>
-              </div>
-            </div>
           </Swiper>
         </div>
       </div>

--- a/www/components/Sections/TwitterSocialProof.tsx
+++ b/www/components/Sections/TwitterSocialProof.tsx
@@ -109,18 +109,18 @@ function TwitterSocialProof() {
                 </SwiperSlide>
               )
             })}
-              <div className="container mx-auto hidden md:flex flex-row justify-between mt-3">
-                <div ref={prevRef} className="cursor-pointer ml-4">
-                  <Typography.Text>
-                    <IconArrowLeft />
-                  </Typography.Text>
-                </div>
-                <div ref={nextRef} className="cursor-pointer mr-4">
-                  <Typography.Text>
-                    <IconArrowRight />
-                  </Typography.Text>
-                </div>
+            <div className="container mx-auto hidden md:flex flex-row justify-between mt-3">
+              <div ref={prevRef} className="cursor-pointer ml-4">
+                <Typography.Text>
+                  <IconArrowLeft />
+                </Typography.Text>
               </div>
+              <div ref={nextRef} className="cursor-pointer mr-4">
+                <Typography.Text>
+                  <IconArrowRight />
+                </Typography.Text>
+              </div>
+            </div>
           </Swiper>
         </div>
       </div>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Closes #3923. Moves swiper buttons to be more readable and easier to use.

## What is the current behavior?

<img width="1392" alt="Screen Shot 2021-11-24 at 1 47 58 AM" src="https://user-images.githubusercontent.com/70828596/143188687-0e7f6d0a-1dd3-4596-a056-10db6a805a26.png">

## What is the new behavior?

<img width="1392" alt="Screen Shot 2021-11-24 at 1 38 30 AM" src="https://user-images.githubusercontent.com/70828596/143187531-92da416c-3f26-43c7-93d1-0ad5186bd74c.png">