### PR TITLE
Fix link to supabase.com

### DIFF
--- a/studio/components/interfaces/Home/Landing.tsx
+++ b/studio/components/interfaces/Home/Landing.tsx
@@ -20,7 +20,7 @@ const Landing = () => {
         <nav className="relative flex items-center justify-between sm:h-10">
           <div className="flex items-center flex-grow flex-shrink-0 lg:flex-grow-0">
             <div className="flex items-center justify-between w-full md:w-auto">
-              <a href="#">
+              <a href="https://supabase.io">
                 <Image
                   src={theme == 'dark' ? '/img/supabase-dark.svg' : '/img/supabase-light.svg'}
                   alt=""
@@ -38,7 +38,7 @@ const Landing = () => {
               type="success"
               className="ml-8 font-medium hover:text-gray-300 focus:outline-none focus:text-gray-300 transition duration-150 ease-in-out"
             >
-              <Link href={`${API_URL}/login`}>Sign in</Link>
+              <Link href={`${API_URL}/login`}>Sign In</Link>
             </Typography.Text>
           </div>
         </nav>

--- a/studio/components/interfaces/Home/Landing.tsx
+++ b/studio/components/interfaces/Home/Landing.tsx
@@ -20,7 +20,7 @@ const Landing = () => {
         <nav className="relative flex items-center justify-between sm:h-10">
           <div className="flex items-center flex-grow flex-shrink-0 lg:flex-grow-0">
             <div className="flex items-center justify-between w-full md:w-auto">
-              <a href="https://supabase.io">
+              <a href="https://supabase.com">
                 <Image
                   src={theme == 'dark' ? '/img/supabase-dark.svg' : '/img/supabase-light.svg'}
                   alt=""


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes link that leads to nowhere now leads back to [supabase.io](https://supabase.io).

## What is the current behavior?

Issue #3717 has been solved already, but this just makes sure that it's solved.

## What is the new behavior?

Now leads back to [supabase.io](https://supabase.io).