### PR TITLE
fix #4100 developers.md to include npm run build 

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -63,6 +63,18 @@ Before you start a development server, you must choose if you want to work on th
     yarn install
     ```
 
+3. Build Project:
+
+    npm
+    ```sh
+    npm run build
+    ```
+
+    or with yarn
+    ```sh
+    yarn run build
+    ```
+
 ## Start a Development Server
 
 To debug code, and to see changes in real time, it is often useful to have a local HTTP server.


### PR DESCRIPTION
## What kind of change does this PR introduce?
fix #4100
documentation update:
developers.md

## What is the current behavior?
The current instructions do not ask to build the project, hence I got the following error while trying to start the server:
`Could not find a production build in the 'C:\jh\Dev\node\gh\supabase\www\.next' directory`


Please link any relevant issues here.
https://github.com/supabase/supabase/issues/4100

## What is the new behavior?
Provides better guidance to newcomers to build the web development servers web and www before running them.
This can positively result in more support from the community to resolve issues faster.

