### PR TITLE
Fix #4109 - Add docs url for Dart

### DIFF
--- a/studio/components/interfaces/Home/Home.constants.ts
+++ b/studio/components/interfaces/Home/Home.constants.ts
@@ -17,7 +17,7 @@ export const CLIENT_LIBRARIES = [
     language: 'Dart',
     officialSupport: false,
     releaseState: 'Beta',
-    docsUrl: undefined,
+    docsUrl: 'https://supabase.com/docs/reference/dart/installing',
     gitUrl: 'https://github.com/supabase/supabase-dart',
   },
 ]


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bugfix

## What is the current behavior?

#4109 

## What is the new behavior?

Added docs URL for dart

<img width="1792" alt="Screenshot 2021-11-28 at 3 01 08 PM" src="https://user-images.githubusercontent.com/63534555/143761054-18cb8d10-a1ec-4ade-96a9-74c3c09bea6c.png">

## Additional context

None
