### PR TITLE
bug: adjusted ProjectUsage title to 24h instead of 7day

### DIFF
--- a/studio/components/interfaces/Home/ProjectUsage.tsx
+++ b/studio/components/interfaces/Home/ProjectUsage.tsx
@@ -37,7 +37,7 @@ const ProjectUsage: FC<Props> = ({ project }) => {
 
   return (
     <div className="mx-6 space-y-6">
-      <Typography.Title level={4}>Statistics for the past 7 days</Typography.Title>
+      <Typography.Title level={4}>Statistics for past 24 hours</Typography.Title>
       <div className="">
         {startDate && endDate && (
           <div className="grid lg:grid-cols-4 lg:gap-8">


### PR DESCRIPTION
## What kind of change does this PR introduce?
Hardcoded title bug, outdated since logs endpoint was adjusted to return 24h chart data instead of 7 day chart data.

<img width="552" alt="image" src="https://user-images.githubusercontent.com/22714384/143861175-d69287a8-31ab-4aac-8424-cc454d7cfd6c.png">
