### PR TITLE
fix: Python client library updates typos

### DIFF
--- a/www/_blog/2021-11-29-community-day.mdx
+++ b/www/_blog/2021-11-29-community-day.mdx
@@ -91,9 +91,9 @@ Among many other awesome things, the SupaSquad has been absolutely on fire build
 
 - New maintainers [`@Dreinon`](https://github.com/dreinon), [`@anand2312`](https://github.com/anand2312), and [`@leynier`](https://github.com/leynier). 💚
 - `gotrue-py` rewritten and now at feature parity with `gotrue-js`.
-- Postgrest-py now support synchronous operations as well instead of just synchronous operations in the past. Also at feature-parity with postgrest-js.
-- Supabase-py is now Supabase (e.g. you do `pip3 install supabase` instead of `pip3 install supabase-py`).
-- Storage is working for the py client library but it's yet to be extracted out as a standalone lib.
+- `postgrest-py` now support synchronous operations as well instead of just asynchronous operations in the past. Also at feature parity with `postgrest-js`.
+- `supabase-py` is now `supabase` (e.g. you do `pip3 install supabase` instead of `pip3 install supabase-py`).
+- Storage is working for the Python client library but it's yet to be extracted out as a standalone lib.
 
 ## New tutorials and integration guides
 


### PR DESCRIPTION
Especially `just synchronous` instead of `just asynchronous`