### PR TITLE
fix: missing schema field on api settings

### DIFF
--- a/studio/next-env.d.ts
+++ b/studio/next-env.d.ts
@@ -1,3 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/studio/pages/project/[ref]/settings/api.tsx
+++ b/studio/pages/project/[ref]/settings/api.tsx
@@ -276,7 +276,7 @@ const ServiceList: FC<any> = ({ projectRef }) => {
   )
 }
 
-const PostgrestConfig = ({ config, projectRef }: any) => {
+const PostgrestConfig = observer(({ config, projectRef }: any) => {
   const PageState: any = useContext(PageContext)
   const { meta } = PageState
 
@@ -396,4 +396,4 @@ const PostgrestConfig = ({ config, projectRef }: any) => {
       </SchemaFormPanel>
     </>
   )
-}
+})


### PR DESCRIPTION
## What kind of change does this PR introduce?

- There is no Schema field when visiting the API tab on the first try