### PR TITLE
[Readme] Fix self-hosting docs link in readme

### DIFF
--- a/studio/README.md
+++ b/studio/README.md
@@ -38,7 +38,7 @@ Project settings are managed outside of the Dashboard. If you use docker-compose
 
 ## Running within a self-hosted environment
 
-Firstly, follow the guide [here](https://www.notion.so/supabase/'%3Chttps://supabase.com/docs/guides/hosting/docker%3E') to get started with self-hosted Supabase.
+Firstly, follow the guide [here](https://supabase.com/docs/guides/hosting/docker) to get started with self-hosted Supabase.
 
 ```
 cd ..


### PR DESCRIPTION
## What kind of change does this PR introduce?

Readme fix

## What is the current behavior?

The link in the last section was linking to a Notion page (requiring sign in), but was also followed by the link to the Supabase self-hosting docs

## What is the new behavior?

It now links to the self-hosting docs correctly
