### PR TITLE
fix: syntax highlighting in pages example

### DIFF
--- a/studio/pages/README.md
+++ b/studio/pages/README.md
@@ -7,7 +7,7 @@
 
 ## Template for building pages
 
-```ts
+```tsx
 import { NextPage } from 'next'
 import { observer } from 'mobx-react-lite'
 


### PR DESCRIPTION
I fixed the syntax highlighting in the pages Readme

before:
<img width="542" alt="Bildschirmfoto 2021-11-30 um 22 46 34" src="https://user-images.githubusercontent.com/26602940/144133124-bc2c0433-6a5f-4951-8755-5f2e2f623b3b.png">



after:

<img width="545" alt="Bildschirmfoto 2021-11-30 um 22 47 22" src="https://user-images.githubusercontent.com/26602940/144133225-2f355f20-3600-49ab-8940-2cdaad0402c3.png">

