### PR TITLE
chore: add realtime schema to MetaStore excludedSchemas

### DIFF
--- a/studio/stores/pgmeta/MetaStore.ts
+++ b/studio/stores/pgmeta/MetaStore.ts
@@ -118,6 +118,7 @@ export default class MetaStore implements IMetaStore {
     'net',
     'pg_catalog',
     'pgbouncer',
+    'realtime',
     'storage',
     'supabase_functions',
   ]


### PR DESCRIPTION
## What kind of change does this PR introduce?

chore

## What is the new behavior?

Hide tables under `realtime` schema in places like `Replication` settings
