### PR TITLE
Fix/fix update table column if renaming column

### DIFF
--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/ColumnManagement.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/ColumnManagement.tsx
@@ -9,7 +9,7 @@ import {
   IconTrash,
   Typography,
 } from '@supabase/ui'
-import { PostgresTable, PostgresColumn } from '@supabase/postgres-meta'
+import { PostgresTable, PostgresColumn, PostgresRelationship } from '@supabase/postgres-meta'
 import {
   DragDropContext,
   Droppable,
@@ -85,7 +85,11 @@ const ColumnManagement: FC<Props> = ({
   const onUpdateColumn = (columnToUpdate: ColumnField, changes: Partial<ColumnField>) => {
     const updatedColumns = columns.map((column: ColumnField) => {
       if (column.id === columnToUpdate.id) {
-        return { ...column, ...changes }
+        const foreignKey =
+          'name' in changes && !isUndefined(column.foreignKey)
+            ? { ...column.foreignKey, source_column_name: changes.name }
+            : column.foreignKey
+        return { ...column, ...changes, foreignKey: foreignKey as PostgresRelationship }
       } else {
         return column
       }

--- a/studio/package-lock.json
+++ b/studio/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "studio",
       "version": "0.0.3",
       "dependencies": {
         "@auth0/nextjs-auth0": "^1.6.1",

--- a/studio/stores/pgmeta/MetaStore.ts
+++ b/studio/stores/pgmeta/MetaStore.ts
@@ -2,7 +2,12 @@ import Papa from 'papaparse'
 import { makeObservable, observable } from 'mobx'
 import { find, isUndefined, isEqual, isEmpty, chunk, maxBy } from 'lodash'
 import { Query } from '@supabase/grid'
-import { PostgresColumn, PostgresTable, PostgresRelationship } from '@supabase/postgres-meta'
+import {
+  PostgresColumn,
+  PostgresTable,
+  PostgresRelationship,
+  PostgresPrimaryKey,
+} from '@supabase/postgres-meta'
 
 import { IS_PLATFORM, API_URL } from 'lib/constants'
 import { post } from 'lib/common/fetch'
@@ -458,10 +463,24 @@ export default class MetaStore implements IMetaStore {
   }
 
   async updateTable(toastId: string, table: PostgresTable, payload: any, columns: ColumnField[]) {
-    // Remove any primary key constraints first (we'll add it back later)
-    if (table.primary_keys.length > 0) {
-      const removePK = await this.removePrimaryKey(table.schema, table.name)
-      if (removePK.error) throw removePK.error
+    // Prepare a check to see if primary keys to the tables were updated or not
+    const primaryKeyColumns = columns
+      .filter((column) => column.isPrimaryKey)
+      .map((column) => `"${column.name}"`)
+    const existingPrimaryKeyColumns = table.primary_keys.map(
+      (pk: PostgresPrimaryKey) => `"${pk.name}"`
+    )
+    const isPrimaryKeyUpdated = !isEqual(primaryKeyColumns, existingPrimaryKeyColumns)
+
+    if (isPrimaryKeyUpdated) {
+      // Remove any primary key constraints first (we'll add it back later)
+      // If we do it later, and if the user deleted a PK column, we'd need to do
+      // an additional check when removing PK if the column in the PK was removed
+      // So doing this one step earlier, lets us skip that additional check.
+      if (table.primary_keys.length > 0) {
+        const removePK = await this.removePrimaryKey(table.schema, table.name)
+        if (removePK.error) throw removePK.error
+      }
     }
 
     // Update the table
@@ -491,7 +510,12 @@ export default class MetaStore implements IMetaStore {
           category: 'loading',
           message: `Adding column ${column.name} to ${updatedTable.name}`,
         })
-        const columnPayload = generateCreateColumnPayload(updatedTable.id, column)
+        // Ensure that columns do not created as primary key first, cause the primary key will
+        // be added later on further down in the code
+        const columnPayload = generateCreateColumnPayload(updatedTable.id, {
+          ...column,
+          isPrimaryKey: false,
+        })
         await this.createColumn(columnPayload, column.foreignKey)
       } else {
         const originalColumn = find(originalColumns, { id: column.id })
@@ -515,11 +539,8 @@ export default class MetaStore implements IMetaStore {
       }
     }
 
-    // Add back the primary keys here
-    const primaryKeyColumns = columns
-      .filter((column) => column.isPrimaryKey)
-      .map((column) => `"${column.name}"`)
-    if (primaryKeyColumns.length > 0) {
+    // Then add back the primary keys again
+    if (isPrimaryKeyUpdated && primaryKeyColumns.length > 0) {
       const primaryKeys = await this.addPrimaryKey(
         updatedTable.schema,
         updatedTable.name,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Reference: https://support.supabase.org/a/tickets/3689

A couple of issues with updating a table (specifically updating columns via the table side panel editor)
- If the table has a column that is referencing another table
  - If we try to rename that column, the internal logic of the code when a column is update is that it'll first remove the existing FK, then add it back along with any changes.
  - Previously, the FK that we try to add back wouldn't capture the updates to a column's name, so it'd try to add the old column name which logically no longer exists, so this patches that

- If the table is being referenced by another table
  - If we try to edit the table, say edit its description, the internal logic of the code would remove the PK of the table and eventually add it in later (refer to code comments for more details)
  - Updated to only remove the PK if the PK changed, so this patches that

- If we try to add new PK columns to an existing table
  - UI will throw a "multiple PK" error message
  - This is cause when we add the columns via pg-meta, we'd set `isPrimaryKey` to true
  - But later on, we'd also add the primary keys of the table via direct query (Ref the second bug pointed out here)
  - Updated to set `isPrimaryKey` to false when adding new columns in updateTable
  - This is also done already in createTable, overlooked this logic when writing updateTable