### PR TITLE
feat: studio docker CI/CD

### DIFF
--- a/.github/workflows/publish_docker_hub.yml
+++ b/.github/workflows/publish_docker_hub.yml
@@ -1,0 +1,35 @@
+name: Publish to Docker Hub
+
+on:
+  push:
+    branches:
+      - studio
+    paths:
+      - 'studio/**'
+  workflow_dispatch:
+
+jobs:
+  publish:
+    name: Publish to Docker Hub
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: docker/setup-qemu-action@v1
+        with:
+          platforms: amd64,arm64
+
+      - uses: docker/setup-buildx-action@v1
+
+      - uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - uses: docker/build-push-action@v2
+        with:
+          context: studio
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: supabase/studio:latest
+          target: production

--- a/studio/Dockerfile
+++ b/studio/Dockerfile
@@ -1,29 +1,25 @@
 ## USAGE:
-# Build:        docker build --target production -t supabase/studio:latest . 
+# Build:        docker build --target production -t supabase/studio:latest .
 # Run:          docker run -p 3000:3000 supabase/studio
 # Deploy:       docker push supabase/studio:latest
-# Clean build:  
+# Clean build:
 #    docker build --target production --no-cache -t supabase/studio:latest .
 #    docker builder prune
 
 
 FROM node:14 as base
 WORKDIR /usr/src/app
+# Do `npm ci` separately so we can cache `node_modules`
+# https://nodejs.org/en/docs/guides/nodejs-docker-webapp/
 COPY package*.json ./
-
-FROM base as build
-ENV NODE_ENV=build
-RUN npm install
+RUN npm clean-install
 COPY . .
-RUN npm run build
 
-FROM build as dev
-ENV NODE_ENV=dev
+FROM base as dev
 EXPOSE 8082
-CMD [ "npm", "run", "dev" ]
+CMD ["npm", "run", "dev"]
 
-FROM build as production
-ENV NODE_ENV=production
-COPY . .
+FROM base as production
+RUN npm run build
 EXPOSE 3000
-CMD ["npm", "start"]
+CMD ["npm", "run", "start"]


### PR DESCRIPTION
Fixes #4191.

Adds CD to publish to Docker Hub. Currently publishes to `latest` tag only (since versions aren't CI'd atm) for `linux/amd64` and `linux/arm64`.