### PR TITLE
fix: add overflow css to table in blog post

### DIFF
--- a/www/_blog/2021-12-01-realtime-row-level-security-in-postgresql.mdx
+++ b/www/_blog/2021-12-01-realtime-row-level-security-in-postgresql.mdx
@@ -140,9 +140,13 @@ and the resultant processing time also grows.
 
 ![supabase-realtime-processing-per-subscription](/images/blog/launch-week-three/realtime-row-level-security-in-postgresql/supabase-realtime-processing-per-subscription.png)
 
+<div class="overflow-x-scroll" markdown="block">
+
 | Subscribers         | 1    | 5    | 10   | 25   | 50   | 100  | 250  | 500  | 1,000 | 2,000 | 5,000 | 10,000 |
 |------------------------|------|------|------|------|------|------|------|------|-------|-------|-------|--------|
 | Processing Time (ms) | 11.2 | 12.5 | 14.2 | 16.7 | 18.8 | 24.5 | 27.8 | 29.1 | 64.7  | 75.5  | 158.4 | 303.8  |
+
+</div>
 
 ## Best Practices for Performance
 

--- a/www/tailwind.config.js
+++ b/www/tailwind.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  purge: ['./components/**/*.tsx', './pages/**/*.tsx'],
+  purge: ['./components/**/*.tsx', './pages/**/*.tsx', './_blog/*.mdx'],
   darkMode: 'class', // 'media' or 'class'
   mode: 'jit',
   theme: {


### PR DESCRIPTION
## What kind of change does this PR introduce?

## What is the current behavior?

• table in blog post is being cut off

## What is the new behavior?

• tailwind now purges the blog posts (we use some jsx in there)
• added `overflow-x-scroll` to div container around table in realtime blog post.
it does cut off the table but we can maybe improve it by showing an instruction to scroll the table.

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots
before:
![Screen Shot 2021-12-02 at 12 46 14 AM](https://user-images.githubusercontent.com/8291514/144276570-9520f5ef-283a-4f34-90da-02173d6cf7a4.png)
after:
![Screen Shot 2021-12-02 at 12 46 42 AM](https://user-images.githubusercontent.com/8291514/144276641-4e3cb8c4-df5e-476b-87dc-dd9e6e73e868.png)



.
