### PR TITLE
docs: fix wrong server side auth example code

### DIFF
--- a/web/spec/supabase.yml
+++ b/web/spec/supabase.yml
@@ -740,7 +740,7 @@ pages:
         isSpotlight: true
         js: |
           ```js
-          const { user, error } = await supabase.auth.api.createUser({
+          const { data: user, error } = await supabase.auth.api.createUser({
             name: 'Yoda'
           })
           ```
@@ -756,7 +756,7 @@ pages:
         isSpotlight: true
         js: |
           ```js
-          const { user, error } = await supabase.auth.api.deleteUser(
+          const { data: user, error } = await supabase.auth.api.deleteUser(
             '715ed5db-f090-4b8c-a067-640ecee36aa0',
             'YOUR_SERVICE_ROLE_KEY'
           )
@@ -773,7 +773,7 @@ pages:
         isSpotlight: false
         js: |
           ```js
-          const { user, error } = await supabase.auth
+          const { data: user, error } = await supabase.auth
             .api
             .inviteUserByEmail('email@example.com')
           ```
@@ -789,7 +789,7 @@ pages:
         isSpotlight: false
         js: |
           ```js
-          const { user, error } = await supabase.auth
+          const { data: user, error } = await supabase.auth
             .api
             .sendMobileOTP('12345879')
           ```
@@ -805,7 +805,7 @@ pages:
         isSpotlight: false
         js: |
           ```js
-          const { user, error } = await supabase.auth
+          const { data: user, error } = await supabase.auth
             .api
             .resetPasswordForEmail('email@example.com')
           ```
@@ -821,7 +821,7 @@ pages:
         isSpotlight: false
         js: |
           ```js
-          const { user, error } = await supabase.auth.api.generateLink({
+          const { data: user, error } = await supabase.auth.api.generateLink({
             type: 'invite',
             email: 'email@example.com'
           })


### PR DESCRIPTION
Those functions do not return "user", instead, they return with "data". (GoTrueApi.ts)

## What kind of change does this PR introduce?

Fix wrong server side auth example code in docs.

- https://supabase.com/docs/reference/javascript/auth-api-createuser
- https://supabase.com/docs/reference/javascript/auth-api-deleteuser
- https://supabase.com/docs/reference/javascript/auth-api-generatelink
- https://supabase.com/docs/reference/javascript/auth-api-inviteuserbyemail
- https://supabase.com/docs/reference/javascript/auth-api-sendmobileotp
- https://supabase.com/docs/reference/javascript/auth-api-resetpasswordforemail

## What is the current behavior?

The returning values in those example code are wrong. Functions do not return "user". They return "data" as user or other things.

## What is the new behavior?

Fix the wrong returning values based on [GoTrueApi.ts](https://github.com/supabase/gotrue-js/blob/master/src/GoTrueApi.ts).

## Additional context

Null
