### PR TITLE
Fix/inability to create relations in table editor

### DIFF
--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
@@ -154,16 +154,17 @@ const SidePanelEditor: FC<Props> = ({
     },
     resolve: any
   ) => {
+    let toastId
     let saveTableError = false
     const { tableId, importContent, isRLSEnabled, isDuplicateRows } = configuration
 
-    if (isDuplicating) {
-      const duplicateTable = find(tables, { id: tableId }) as PostgresTable
-      const toastId = ui.setNotification({
-        category: 'loading',
-        message: `Duplicating table: ${duplicateTable.name}...`,
-      })
-      try {
+    try {
+      if (isDuplicating) {
+        const duplicateTable = find(tables, { id: tableId }) as PostgresTable
+        toastId = ui.setNotification({
+          category: 'loading',
+          message: `Duplicating table: ${duplicateTable.name}...`,
+        })
         const table: any = await meta.duplicateTable(payload, {
           isRLSEnabled,
           isDuplicateRows,
@@ -175,16 +176,11 @@ const SidePanelEditor: FC<Props> = ({
           message: `Table ${duplicateTable.name} has been successfully duplicated into ${table.name}!`,
         })
         onTableCreated(table)
-      } catch (error: any) {
-        saveTableError = true
-        ui.setNotification({ id: toastId, category: 'error', message: error.message })
-      }
-    } else if (isNewRecord) {
-      const toastId = ui.setNotification({
-        category: 'loading',
-        message: `Creating new table: ${payload.name}...`,
-      })
-      try {
+      } else if (isNewRecord) {
+        toastId = ui.setNotification({
+          category: 'loading',
+          message: `Creating new table: ${payload.name}...`,
+        })
         const table = await meta.createTable(toastId, payload, isRLSEnabled, columns, importContent)
         ui.setNotification({
           id: toastId,
@@ -192,31 +188,28 @@ const SidePanelEditor: FC<Props> = ({
           message: `Table ${table.name} is good to go!`,
         })
         onTableCreated(table)
-      } catch (error: any) {
-        saveTableError = true
-        ui.setNotification({ id: toastId, category: 'error', message: error.message })
-      }
-    } else if (selectedTableToEdit) {
-      const toastId = ui.setNotification({
-        category: 'loading',
-        message: `Updating table: ${selectedTableToEdit?.name}...`,
-      })
-      try {
+      } else if (selectedTableToEdit) {
+        toastId = ui.setNotification({
+          category: 'loading',
+          message: `Updating table: ${selectedTableToEdit?.name}...`,
+        })
         const table: any = await meta.updateTable(toastId, selectedTableToEdit, payload, columns)
         ui.setNotification({
           id: toastId,
           category: 'success',
           message: `Successfully updated ${table.name}!`,
         })
-      } catch (error: any) {
-        saveTableError = true
-        ui.setNotification({ id: toastId, category: 'error', message: error.message })
       }
+    } catch (error: any) {
+      saveTableError = true
+      ui.setNotification({ id: toastId, category: 'error', message: error.message })
     }
 
     if (!saveTableError) {
       setIsEdited(false)
       closePanel()
+    } else {
+      meta.tables.load()
     }
     resolve()
   }

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
@@ -208,9 +208,8 @@ const SidePanelEditor: FC<Props> = ({
     if (!saveTableError) {
       setIsEdited(false)
       closePanel()
-    } else {
-      meta.tables.load()
     }
+
     resolve()
   }
 

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/ColumnManagement.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/ColumnManagement.tsx
@@ -85,11 +85,14 @@ const ColumnManagement: FC<Props> = ({
   const onUpdateColumn = (columnToUpdate: ColumnField, changes: Partial<ColumnField>) => {
     const updatedColumns = columns.map((column: ColumnField) => {
       if (column.id === columnToUpdate.id) {
-        const foreignKey =
-          'name' in changes && !isUndefined(column.foreignKey)
-            ? { ...column.foreignKey, source_column_name: changes.name }
-            : column.foreignKey
-        return { ...column, ...changes, foreignKey: foreignKey as PostgresRelationship }
+        if ('name' in changes && !isUndefined(column.foreignKey)) {
+          const foreignKey: PostgresRelationship = {
+            ...column.foreignKey,
+            source_column_name: changes?.name ?? '',
+          }
+          return { ...column, ...changes, foreignKey }
+        }
+        return { ...column, ...changes }
       } else {
         return column
       }

--- a/studio/pages/project/[ref]/editor/[id].tsx
+++ b/studio/pages/project/[ref]/editor/[id].tsx
@@ -113,10 +113,10 @@ const TableEditorPage: NextPage = () => {
 
   const onConfirmDeleteTable = async () => {
     try {
-      const tables = meta.tables.list((table: PostgresTable) => table.schema === selectedSchema)
       const response: any = await meta.tables.del(selectedTableToDelete!.id)
-
       if (response.error) throw response.error
+
+      const tables = meta.tables.list((table: PostgresTable) => table.schema === selectedSchema)
 
       // For simplicity for now, we just open the first table within the same schema
       if (tables.length > 0) {

--- a/studio/stores/pgmeta/MetaStore.ts
+++ b/studio/stores/pgmeta/MetaStore.ts
@@ -354,112 +354,123 @@ export default class MetaStore implements IMetaStore {
     const table: any = await this.tables.create(payload)
     if (table.error) throw table.error
 
-    // Toggle RLS if configured to be
-    if (isRLSEnabled) {
-      const updatedTable: any = await this.tables.update(table.id, {
-        rls_enabled: isRLSEnabled,
-      })
-      if (updatedTable.error) throw updatedTable.error
-    }
-
-    // Then insert the columns - we don't do Promise.all as we want to keep the integrity
-    // of the column order during creation. Note that we add primary key constraints separately
-    // via the query endpoint to support composite primary keys as pg-meta does not support that OOB
-    this.rootStore.ui.setNotification({
-      id: toastId,
-      category: 'loading',
-      message: `Adding ${columns.length} columns to ${table.name}...`,
-    })
-    for (const column of columns) {
-      // We create all columns without primary keys first
-      const columnPayload = generateCreateColumnPayload(table.id, {
-        ...column,
-        isPrimaryKey: false,
-      })
-      const newColumn: any = await this.columns.create(columnPayload)
-      if (newColumn.error) throw newColumn.error
-    }
-
-    // Then add the primary key constraints here to support composite keys
-    const primaryKeyColumns = columns
-      .filter((column: ColumnField) => column.isPrimaryKey)
-      .map((column: ColumnField) => `"${column.name}"`)
-    if (primaryKeyColumns.length > 0) {
-      const primaryKeys = await this.addPrimaryKey(table.schema, table.name, primaryKeyColumns)
-      if (primaryKeys.error) throw primaryKeys.error
-    }
-
-    // Then add the foreign key constraints here
-    for (const column of columns) {
-      if (!isUndefined(column.foreignKey)) {
-        const relationship = await this.addForeignKey(column.foreignKey)
-        if (relationship.error) throw relationship.error
+    // If we face any errors during this process after the actual table creation
+    // We'll delete the table as a way to clean up and not leave behind bits that
+    // got through successfully. This is so that the user can continue editing in
+    // the table side panel editor conveniently
+    try {
+      // Toggle RLS if configured to be
+      if (isRLSEnabled) {
+        const updatedTable: any = await this.tables.update(table.id, {
+          rls_enabled: isRLSEnabled,
+        })
+        if (updatedTable.error) throw updatedTable.error
       }
-    }
 
-    // If the user is importing data via a spreadsheet
-    if (!isUndefined(importContent)) {
-      if (importContent.file && importContent.rowCount > 0) {
-        // Via a CSV file
-        const { error }: any = await this.insertRowsViaSpreadsheet(
-          importContent.file,
-          table,
-          (progress: any) => {
+      // Then insert the columns - we don't do Promise.all as we want to keep the integrity
+      // of the column order during creation. Note that we add primary key constraints separately
+      // via the query endpoint to support composite primary keys as pg-meta does not support that OOB
+      this.rootStore.ui.setNotification({
+        id: toastId,
+        category: 'loading',
+        message: `Adding ${columns.length} columns to ${table.name}...`,
+      })
+
+      for (const column of columns) {
+        // We create all columns without primary keys first
+        const columnPayload = generateCreateColumnPayload(table.id, {
+          ...column,
+          isPrimaryKey: false,
+        })
+        const newColumn: any = await this.columns.create(columnPayload)
+        if (newColumn.error) throw newColumn.error
+      }
+
+      // Then add the primary key constraints here to support composite keys
+      const primaryKeyColumns = columns
+        .filter((column: ColumnField) => column.isPrimaryKey)
+        .map((column: ColumnField) => `"${column.name}"`)
+      if (primaryKeyColumns.length > 0) {
+        const primaryKeys = await this.addPrimaryKey(table.schema, table.name, primaryKeyColumns)
+        if (primaryKeys.error) throw primaryKeys.error
+      }
+
+      // Then add the foreign key constraints here
+      for (const column of columns) {
+        if (!isUndefined(column.foreignKey)) {
+          const relationship = await this.addForeignKey(column.foreignKey)
+          if (relationship.error) throw relationship.error
+        }
+      }
+
+      // If the user is importing data via a spreadsheet
+      if (!isUndefined(importContent)) {
+        if (importContent.file && importContent.rowCount > 0) {
+          // Via a CSV file
+          const { error }: any = await this.insertRowsViaSpreadsheet(
+            importContent.file,
+            table,
+            (progress: any) => {
+              this.rootStore.ui.setNotification({
+                id: toastId,
+                category: 'loading',
+                message: `Adding ${importContent.rowCount.toLocaleString()} rows to ${
+                  table.name
+                }... (${progress}%)`,
+              })
+            }
+          )
+
+          // For identity columns, manually raise the sequences
+          const identityColumns = columns.filter((column) => column.isIdentity)
+          for (const column of identityColumns) {
+            const identity = await this.rootStore.meta.query(
+              `SELECT setval('${table.name}_${column.name}_seq', (SELECT MAX("${column.name}") FROM "${table.name}"));`
+            )
+            if (identity.error) throw identity.error
+          }
+
+          if (!isUndefined(error)) {
+            this.rootStore.ui.setNotification({
+              id: toastId,
+              category: 'error',
+              message: `Table ${table.name} has been created but we ran into an error while inserting rows:
+            ${error.message} - ${error.details}`,
+            })
+            this.rootStore.ui.setNotification({
+              category: 'error',
+              message: 'Do check your spreadsheet if there are any discrepancies.',
+            })
+          }
+        } else {
+          // Via text copy and paste
+          await this.insertTableRows(table, importContent.rows, (progress: any) => {
             this.rootStore.ui.setNotification({
               id: toastId,
               category: 'loading',
-              message: `Adding ${importContent.rowCount.toLocaleString()} rows to ${
+              message: `Adding ${importContent.rows.length.toLocaleString()} rows to ${
                 table.name
               }... (${progress}%)`,
             })
+          })
+
+          // For identity columns, manually raise the sequences
+          const identityColumns = columns.filter((column) => column.isIdentity)
+          for (const column of identityColumns) {
+            const identity = await this.rootStore.meta.query(
+              `SELECT setval('${table.name}_${column.name}_seq', (SELECT MAX("${column.name}") FROM "${table.name}"));`
+            )
+            if (identity.error) throw identity.error
           }
-        )
-
-        // For identity columns, manually raise the sequences
-        const identityColumns = columns.filter((column) => column.isIdentity)
-        for (const column of identityColumns) {
-          const identity = await this.rootStore.meta.query(
-            `SELECT setval('${table.name}_${column.name}_seq', (SELECT MAX("${column.name}") FROM "${table.name}"));`
-          )
-          if (identity.error) throw identity.error
-        }
-
-        if (!isUndefined(error)) {
-          this.rootStore.ui.setNotification({
-            id: toastId,
-            category: 'error',
-            message: `Table ${table.name} has been created but we ran into an error while inserting rows:
-            ${error.message} - ${error.details}`,
-          })
-          this.rootStore.ui.setNotification({
-            category: 'error',
-            message: 'Do check your spreadsheet if there are any discrepancies.',
-          })
-        }
-      } else {
-        // Via text copy and paste
-        await this.insertTableRows(table, importContent.rows, (progress: any) => {
-          this.rootStore.ui.setNotification({
-            id: toastId,
-            category: 'loading',
-            message: `Adding ${importContent.rows.length.toLocaleString()} rows to ${
-              table.name
-            }... (${progress}%)`,
-          })
-        })
-
-        // For identity columns, manually raise the sequences
-        const identityColumns = columns.filter((column) => column.isIdentity)
-        for (const column of identityColumns) {
-          const identity = await this.rootStore.meta.query(
-            `SELECT setval('${table.name}_${column.name}_seq', (SELECT MAX("${column.name}") FROM "${table.name}"));`
-          )
-          if (identity.error) throw identity.error
         }
       }
-    }
 
-    return await this.tables.loadById(table.id)
+      // Finally, return the created table
+      return await this.tables.loadById(table.id)
+    } catch (error: any) {
+      this.tables.del(table.id)
+      throw error
+    }
   }
 
   async updateTable(toastId: string, table: PostgresTable, payload: any, columns: ColumnField[]) {

--- a/studio/stores/pgmeta/MetaStore.ts
+++ b/studio/stores/pgmeta/MetaStore.ts
@@ -516,7 +516,8 @@ export default class MetaStore implements IMetaStore {
           ...column,
           isPrimaryKey: false,
         })
-        await this.createColumn(columnPayload, column.foreignKey)
+        const addedColumn: any = await this.createColumn(columnPayload, column.foreignKey)
+        if (addedColumn.error) throw addedColumn.error
       } else {
         const originalColumn = find(originalColumns, { id: column.id })
         if (originalColumn) {
@@ -533,7 +534,13 @@ export default class MetaStore implements IMetaStore {
               category: 'loading',
               message: `Updating column ${column.name} from ${updatedTable.name}`,
             })
-            await this.updateColumn(column.id, columnPayload, updatedTable, column.foreignKey)
+            const updatedColumn: any = await this.updateColumn(
+              column.id,
+              columnPayload,
+              updatedTable,
+              column.foreignKey
+            )
+            if (updatedColumn.error) throw updatedColumn.error
           }
         }
       }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes https://github.com/supabase/supabase/issues/4249

- Fixed a wrong logic in ColumnManagement component that caused the foreign key setting to not get captured in the table editor side panel

Also other fixes:

- Small refactor to simplify saveTable logic in SidePanel Editor by wrapping it in one try catch, since each individual blocks' catch logic is the same
- Fixed a couple of UX issues when errors are faced during table creation
  - Table creation via the dashboard consists of separate steps 
  - If there are any errors faced during table creation after the table was created (meta.tables.create()), the table editor side panel would stay open to allow users to continue making edits and not restart
  - However, there would've been side effects already as the bits that went through successfully during the table creation process would have persisted
  - Fix: Clean up this by just deleting the created table if there are any errors faced during the table creation process
- Fixed deleting the first table in the table editor not redirecting to the next table properly