### PR TITLE
Add yarn add script for easy copy pasting

### DIFF
--- a/web/spec/supabase.yml
+++ b/web/spec/supabase.yml
@@ -215,6 +215,11 @@ pages:
       ```bash
       npm install @supabase/supabase-js
       ```
+      
+      Via Yarn
+      ```bash
+      yarn add @supabase/supabase-js
+      ```
 
       Find the source code on [GitHub](https://github.com/supabase/supabase-js).  
 


### PR DESCRIPTION
Just a tiny detail for us yarn users so we don't have to write the script manually.

## What kind of change does this PR introduce?

Feature in docs

## What is the current behavior?

Doesn't share the yarn install script

## What is the new behavior?

Now it shows the yarn install script too

## Additional context

Nothing to add