### PR TITLE
Minor: rename Architecture section

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ We are currently in Public Beta. Watch "releases" of this repo to get notified o
 
 Supabase is a combination of open source tools. We’re building the features of Firebase using enterprise-grade, open source products. If the tools and communities exist, with an MIT, Apache 2, or equivalent open license, we will use and support that tool. If the tool doesn't exist, we build and open source it ourselves. Supabase is not a 1-to-1 mapping of Firebase. Our aim is to give developers a Firebase-like developer experience using open source tools.
 
-**Current architecture**
+**Architecture**
 
 Supabase is a [hosted platform](https://app.supabase.io). You can sign up and start using Supabase without installing anything.
 You can also [self-host](https://supabase.com/docs/guides/self-hosting) and [develop locally](https://supabase.com/docs/guides/local-development).


### PR DESCRIPTION
Unless we intend to convey that the architecture is about to change soon, I think we should remove the word `Current` from the section title.

## What kind of change does this PR introduce?

Docs/README update.
