### PR TITLE
Chore/have pages trigger toast through UI store

### DIFF
--- a/studio/components/interfaces/Authentication/Templates.tsx
+++ b/studio/components/interfaces/Authentication/Templates.tsx
@@ -3,12 +3,11 @@ import { FC } from 'react'
 import { toJS } from 'mobx'
 import { observer } from 'mobx-react-lite'
 import { useRouter } from 'next/router'
-import { toast } from 'react-hot-toast'
 import { Typography } from '@supabase/ui'
 import { AutoField, LongTextField } from 'uniforms-bootstrap4'
 
 import { API_URL } from 'lib/constants'
-import { useProjectAuthConfig } from 'hooks'
+import { useProjectAuthConfig, useStore } from 'hooks'
 import { pluckJsonSchemaFields } from 'lib/helpers'
 import { patch } from 'lib/common/fetch'
 import { authConfig } from 'stores/jsonSchema'
@@ -16,6 +15,7 @@ import SchemaFormPanel from 'components/to-be-cleaned/forms/SchemaFormPanel'
 
 const Templates: FC<any> = ({ project }) => {
   const router = useRouter()
+  const { ui } = useStore()
   const magicLinkEnable = semver.gte(
     // @ts-ignore
     semver.coerce(toJS(project?.kpsVersion) || 'kps-v0.0.1'),
@@ -37,10 +37,16 @@ const Templates: FC<any> = ({ project }) => {
   const onFormSubmit = async (model: any) => {
     const response = await patch(`${API_URL}/auth/${router.query.ref}/config`, model)
     if (response.error) {
-      toast.error(`Update config failed: ${response.error.message}`)
+      ui.setNotification({
+        category: 'error',
+        message: `Update config failed: ${response.error.message}`,
+      })
     } else {
       mutateAuthConfig(response)
-      toast(`Settings saved`)
+      ui.setNotification({
+        category: 'success',
+        message: 'Settings saved!',
+      })
     }
   }
 

--- a/studio/components/interfaces/Authentication/Users/UserDropdown.tsx
+++ b/studio/components/interfaces/Authentication/Users/UserDropdown.tsx
@@ -1,8 +1,8 @@
 import { FC, useContext, useState } from 'react'
-import { toast } from 'react-hot-toast'
 import { observer } from 'mobx-react-lite'
 import { Button, Dropdown, Divider, IconTrash, IconMail, IconMoreHorizontal } from '@supabase/ui'
 
+import { useStore } from 'hooks'
 import { timeout } from 'lib/helpers'
 import { post, delete_ } from 'lib/common/fetch'
 import { API_URL } from 'lib/constants'
@@ -11,20 +11,29 @@ import { confirmAlert } from 'components/to-be-cleaned/ModalsDeprecated/ConfirmM
 
 const UserDropdown: FC<{ user: any }> = ({ user }) => {
   const PageState: any = useContext(PageContext)
-  const [loading, setLoading] = useState(false)
+  const { ui } = useStore()
+  const [loading, setLoading] = useState<boolean>(false)
 
   async function handleResetPassword() {
     try {
       setLoading(true)
       const response = await post(`${API_URL}/auth/${PageState.projectRef}/recover`, user)
       if (response.error) {
-        toast.error(`Send password recovery failed: ${response.error.message}`)
+        ui.setNotification({
+          category: 'error',
+          message: `Failed to send password recovery: ${response.error.message}`,
+        })
       } else {
-        toast(`Sent password recovery to ${user.email}`)
+        ui.setNotification({
+          category: 'success',
+          message: `Sent password recovery to ${user.email}`,
+        })
       }
-    } catch (error) {
-      console.error('handleResetPassword error:', error)
-      toast.error(`Send password recovery failed`)
+    } catch (error: any) {
+      ui.setNotification({
+        category: 'error',
+        message: `Send password recovery failed: ${error?.message}`,
+      })
     } finally {
       setLoading(false)
     }
@@ -35,13 +44,21 @@ const UserDropdown: FC<{ user: any }> = ({ user }) => {
       setLoading(true)
       const response = await post(`${API_URL}/auth/${PageState.projectRef}/magiclink`, user)
       if (response.error) {
-        toast.error(`Sending magic link failed: ${response.error.message}`)
+        ui.setNotification({
+          category: 'error',
+          message: `Failed to send magic link: ${response.error.message}`,
+        })
       } else {
-        toast(`Sent magic link to ${user.email}`)
+        ui.setNotification({
+          category: 'success',
+          message: `Sent magic link to ${user.email}`,
+        })
       }
-    } catch (error) {
-      console.error('handleSendMagicLink error:', error)
-      toast.error(`Sending magic link failed`)
+    } catch (error: any) {
+      ui.setNotification({
+        category: 'error',
+        message: `Failed to send magic link: ${error?.message}`,
+      })
     } finally {
       setLoading(false)
     }
@@ -52,13 +69,21 @@ const UserDropdown: FC<{ user: any }> = ({ user }) => {
       setLoading(true)
       const response = await post(`${API_URL}/auth/${PageState.projectRef}/otp`, user)
       if (response.error) {
-        toast.error(`Sending OTP failed: ${response.error.message}`)
+        ui.setNotification({
+          category: 'error',
+          message: `Failed to OTP: ${response.error.message}`,
+        })
       } else {
-        toast(`Sent OTP to ${user.phone}`)
+        ui.setNotification({
+          category: 'success',
+          message: `Sent OTP to ${user.phone}`,
+        })
       }
-    } catch (error) {
-      console.error('handleSendOtp error:', error)
-      toast.error(`Sending OTP failed`)
+    } catch (error: any) {
+      ui.setNotification({
+        category: 'error',
+        message: `Failed to send OTP: ${error?.message}`,
+      })
     } finally {
       setLoading(false)
     }
@@ -74,9 +99,12 @@ const UserDropdown: FC<{ user: any }> = ({ user }) => {
         setLoading(true)
         const response = await delete_(`${API_URL}/auth/${PageState.projectRef}/users`, user)
         if (response.error) {
-          toast.error(`Deleting user failed: ${response.error.message}`)
+          ui.setNotification({
+            category: 'error',
+            message: `Failed to delete user: ${response.error.message}`,
+          })
         } else {
-          toast(`User ${user.email} deleted`)
+          ui.setNotification({ category: 'success', message: `Successfully deleted ${user.email}` })
           PageState.users = PageState.users.filter((x: any) => x.id != user.id)
         }
         setLoading(false)

--- a/studio/components/interfaces/Billing/Subscription/UpgradeButton.tsx
+++ b/studio/components/interfaces/Billing/Subscription/UpgradeButton.tsx
@@ -1,9 +1,9 @@
 import React, { useReducer, useState } from 'react'
 import { useRouter } from 'next/router'
-import { toast } from 'react-hot-toast'
 import { includes, without } from 'lodash'
 import { Button, Modal, Input, Divider, Typography } from '@supabase/ui'
 
+import { useStore } from 'hooks'
 import { API_URL } from 'lib/constants'
 import { getURL } from 'lib/helpers'
 import { post } from 'lib/common/fetch'
@@ -18,8 +18,9 @@ import { CancellationReasons } from './SubcriptionCancellation.constants'
 
 export default function UpgradeButton({ projectRef, paid }: any) {
   const router = useRouter()
-  const [loading, setLoading] = useState(false)
-  const [exitSurveyVisible, setExitSurveyVisible] = useState(false)
+  const { ui } = useStore()
+  const [loading, setLoading] = useState<boolean>(false)
+  const [exitSurveyVisible, setExitSurveyVisible] = useState<boolean>(false)
 
   /**
    * Get a link and then redirect them
@@ -34,7 +35,7 @@ export default function UpgradeButton({ projectRef, paid }: any) {
       window.location.replace(subscriptionPortal || billingPortal)
       setExitSurveyVisible(false)
     } catch (error: any) {
-      toast.error(error.message)
+      ui.setNotification({ category: 'error', message: `Failed to redirect: ${error.message}` })
     } finally {
       setExitSurveyVisible(false)
       setLoading(false)
@@ -64,11 +65,15 @@ export default function UpgradeButton({ projectRef, paid }: any) {
 }
 
 function UnsubcribeExitSurvey({ visible, setVisible, handleDowngrade }: any) {
-  const [loading, setLoading] = useState(false)
-  const [selectedCancellationReasons, dispatchSelectedCancellationReasons] = useReducer(reducer, [])
-  const [additionalFeedback, setAdditionalFeedback] = useState('')
   const router = useRouter()
   const { ref } = router.query
+
+  const { ui } = useStore()
+
+  const [loading, setLoading] = useState<boolean>(false)
+  const [additionalFeedback, setAdditionalFeedback] = useState('')
+
+  const [selectedCancellationReasons, dispatchSelectedCancellationReasons] = useReducer(reducer, [])
 
   const sendExitSurvey = async () => {
     try {
@@ -97,8 +102,7 @@ function UnsubcribeExitSurvey({ visible, setVisible, handleDowngrade }: any) {
       setLoading(false)
       await handleDowngrade()
     } catch (error: any) {
-      console.error(error)
-      toast.error(error)
+      ui.setNotification({ category: 'error', message: `Failed to submit exit survey: ${error}` })
     }
   }
 

--- a/studio/components/interfaces/Database/Backups/BackupItem.tsx
+++ b/studio/components/interfaces/Database/Backups/BackupItem.tsx
@@ -2,9 +2,9 @@ import dayjs from 'dayjs'
 import { FC, useState } from 'react'
 import { useRouter } from 'next/router'
 import { observer } from 'mobx-react-lite'
-import { toast } from 'react-hot-toast'
 import { Badge, Button, Typography, IconDownload } from '@supabase/ui'
 
+import { useStore } from 'hooks'
 import { API_URL } from 'lib/constants'
 import { post } from 'lib/common/fetch'
 import { confirmAlert } from 'components/to-be-cleaned/ModalsDeprecated/ConfirmModal'
@@ -17,8 +17,10 @@ interface Props {
 
 const BackupItem: FC<Props> = ({ projectRef, backup, index }) => {
   const router = useRouter()
-  const [isDownloading, setDownloading] = useState(false)
-  const [isRestoring, setRestoring] = useState(false)
+  const { ui } = useStore()
+
+  const [isDownloading, setDownloading] = useState<boolean>(false)
+  const [isRestoring, setRestoring] = useState<boolean>(false)
 
   async function restore(backup: any) {
     setRestoring(true)
@@ -29,8 +31,11 @@ const BackupItem: FC<Props> = ({ projectRef, backup, index }) => {
         }, 3000)
       })
     } catch (error) {
-      console.error('Restore error:', error)
-      toast.error(`You do not have permission to restore from this backup`)
+      ui.setNotification({
+        error,
+        category: 'error',
+        message: `You do not have permission to restore from this backup`,
+      })
       setRestoring(false)
     }
   }
@@ -50,8 +55,11 @@ const BackupItem: FC<Props> = ({ projectRef, backup, index }) => {
 
       setDownloading(false)
     } catch (error) {
-      console.error('Download error:', error)
-      toast.error(`You do not have permission to download this backup`)
+      ui.setNotification({
+        error,
+        category: 'error',
+        message: `You do not have permission to download this backup`,
+      })
       setDownloading(false)
     }
   }

--- a/studio/components/interfaces/Database/Extensions/ExtensionCard.tsx
+++ b/studio/components/interfaces/Database/Extensions/ExtensionCard.tsx
@@ -1,6 +1,5 @@
 import { FC, useState } from 'react'
 import { observer } from 'mobx-react-lite'
-import { toast } from 'react-hot-toast'
 import { Badge, Typography, Toggle } from '@supabase/ui'
 
 import { useStore } from 'hooks'
@@ -11,7 +10,7 @@ interface Props {
 }
 
 const ExtensionCard: FC<Props> = ({ extension }) => {
-  const { meta } = useStore()
+  const { ui, meta } = useStore()
 
   const isOn = extension.installed_version !== null
   const [loading, setLoading] = useState(false)
@@ -32,10 +31,16 @@ const ExtensionCard: FC<Props> = ({ extension }) => {
           if (response.error) {
             throw response.error
           } else {
-            toast.success(`${extension.name.toUpperCase()} is on.`)
+            ui.setNotification({
+              category: 'success',
+              message: `${extension.name.toUpperCase()} is on.`,
+            })
           }
         } catch (error: any) {
-          toast.error(`Toggle ${extension.name.toUpperCase()} failed: ${error.message}`)
+          ui.setNotification({
+            category: 'error',
+            message: `Failed to toggle ${extension.name.toUpperCase()}: ${error.message}`,
+          })
         } finally {
           setLoading(false)
         }
@@ -54,10 +59,16 @@ const ExtensionCard: FC<Props> = ({ extension }) => {
           if (response.error) {
             throw response.error
           } else {
-            toast(`${extension.name.toUpperCase()} is off.`)
+            ui.setNotification({
+              category: 'success',
+              message: `${extension.name.toUpperCase()} is off.`,
+            })
           }
         } catch (error: any) {
-          toast.error(`Toggle ${extension.name.toUpperCase()} failed: ${error.message}`)
+          ui.setNotification({
+            category: 'error',
+            message: `Toggle ${extension.name.toUpperCase()} failed: ${error.message}`,
+          })
         } finally {
           // Need to reload them because the delete function
           // removes the extension from the store

--- a/studio/components/interfaces/Database/Functions/CreateFunction.tsx
+++ b/studio/components/interfaces/Database/Functions/CreateFunction.tsx
@@ -13,7 +13,6 @@ import {
   IconPlus,
   Toggle,
 } from '@supabase/ui'
-import { toast } from 'react-hot-toast'
 import { Dictionary } from '@supabase/grid'
 import { makeAutoObservable } from 'mobx'
 
@@ -292,7 +291,7 @@ type CreateFunctionProps = {
 } & any
 
 const CreateFunction: FC<CreateFunctionProps> = ({ func, visible, setVisible }) => {
-  const { meta } = useStore()
+  const { ui, meta } = useStore()
   const _localState = useLocalObservable(() => new CreateFunctionStore())
   _localState.meta = meta as any
 
@@ -321,18 +320,29 @@ const CreateFunction: FC<CreateFunctionProps> = ({ func, visible, setVisible }) 
           : await (_localState!.meta as any).functions.create(body)
 
         if (response.error) {
-          toast.error(`Error: ${response.error.message ?? 'submit request failed'}`)
+          ui.setNotification({
+            category: 'error',
+            message: `Failed to create function: ${
+              response.error?.message ?? 'Submit request failed'
+            }`,
+          })
           _localState.setLoading(false)
         } else {
-          toast.success(
-            `${_localState.isEditing ? 'Updated' : 'Created new'} function called ${response.name}`
-          )
+          ui.setNotification({
+            category: 'success',
+            message: `${_localState.isEditing ? 'Updated' : 'Created new'} function called ${
+              response.name
+            }`,
+          })
           _localState.setLoading(false)
           setVisible(!visible)
         }
       }
     } catch (error: any) {
-      toast.error(error.message)
+      ui.setNotification({
+        category: 'error',
+        message: `Failed to create function: ${error.message}`,
+      })
       _localState.setLoading(false)
     }
   }

--- a/studio/components/interfaces/Database/Functions/DeleteFunction.tsx
+++ b/studio/components/interfaces/Database/Functions/DeleteFunction.tsx
@@ -1,5 +1,4 @@
 import { FC, useState } from 'react'
-import toast from 'react-hot-toast'
 import { observer } from 'mobx-react-lite'
 import { useStore } from 'hooks'
 import TextConfirmModal from 'components/to-be-cleaned/ModalsDeprecated/TextConfirmModal'
@@ -11,7 +10,7 @@ type DeleteFunctionProps = {
 } & any
 
 const DeleteFunction: FC<DeleteFunctionProps> = ({ func, visible, setVisible }) => {
-  const { meta } = useStore()
+  const { ui, meta } = useStore()
   const [loading, setLoading] = useState(false)
   const { id, name, schema } = func ?? {}
 
@@ -25,11 +24,17 @@ const DeleteFunction: FC<DeleteFunctionProps> = ({ func, visible, setVisible }) 
       if (response.error) {
         throw response.error
       } else {
-        toast.success(`Function ${name} removed`)
+        ui.setNotification({
+          category: 'success',
+          message: `Successfully removed ${name}`,
+        })
         setVisible(false)
       }
     } catch (error: any) {
-      toast.error(`Deleting ${name} failed: ${error.message}`)
+      ui.setNotification({
+        category: 'error',
+        message: `Failed to delete ${name}: ${error.message}`,
+      })
     } finally {
       setLoading(false)
     }

--- a/studio/components/interfaces/Database/Hooks/DeleteHook.tsx
+++ b/studio/components/interfaces/Database/Hooks/DeleteHook.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import toast from 'react-hot-toast'
 import { observer } from 'mobx-react-lite'
 import { useStore } from 'hooks'
 import TextConfirmModal from 'components/to-be-cleaned/ModalsDeprecated/TextConfirmModal'
@@ -11,7 +10,7 @@ type DeleteHookProps = {
 } & any
 
 const DeleteHook: React.FC<DeleteHookProps> = ({ hook, visible, setVisible }) => {
-  const { meta } = useStore()
+  const { ui, meta } = useStore()
   const [loading, setLoading] = React.useState(false)
   const { id, name, schema } = hook ?? {}
 
@@ -25,31 +24,32 @@ const DeleteHook: React.FC<DeleteHookProps> = ({ hook, visible, setVisible }) =>
       if (response.error) {
         throw response.error
       } else {
-        toast.success(`Hook ${name} removed`)
+        ui.setNotification({ category: 'success', message: `Successfully removed ${name}` })
         setVisible(false)
       }
     } catch (error: any) {
-      toast.error(`Deleting ${name} failed: ${error.message}`)
+      ui.setNotification({
+        category: 'error',
+        message: `Failed to delete ${name}: ${error.message}`,
+      })
     } finally {
       setLoading(false)
     }
   }
 
   return (
-    <>
-      <TextConfirmModal
-        visible={visible}
-        onCancel={() => setVisible(!visible)}
-        onConfirm={handleDelete}
-        title="Delete this hook"
-        loading={loading}
-        confirmLabel={`Delete hook ${name}`}
-        confirmPlaceholder="Type in name of hook"
-        confirmString={name}
-        text={`This will delete your hook called ${name} of schema ${schema}.`}
-        alert="You cannot recover this hook once it is deleted!"
-      />
-    </>
+    <TextConfirmModal
+      visible={visible}
+      onCancel={() => setVisible(!visible)}
+      onConfirm={handleDelete}
+      title="Delete this hook"
+      loading={loading}
+      confirmLabel={`Delete hook ${name}`}
+      confirmPlaceholder="Type in name of hook"
+      confirmString={name}
+      text={`This will delete your hook called ${name} of schema ${schema}.`}
+      alert="You cannot recover this hook once it is deleted!"
+    />
   )
 }
 

--- a/studio/components/interfaces/Database/Pooling/PgBouncerConfig.tsx
+++ b/studio/components/interfaces/Database/Pooling/PgBouncerConfig.tsx
@@ -1,9 +1,9 @@
 import { FC, useState } from 'react'
 import { observer } from 'mobx-react-lite'
 import { Divider } from '@supabase/ui'
-import { toast } from 'react-hot-toast'
 import { AutoField } from 'uniforms-bootstrap4'
 
+import { useStore } from 'hooks'
 import { API_URL } from 'lib/constants'
 import { patch } from 'lib/common/fetch'
 import ToggleField from 'components/to-be-cleaned/forms/ToggleField'
@@ -15,7 +15,9 @@ interface Props {
 }
 
 const PgbouncerConfig: FC<Props> = ({ projectRef, config }) => {
-  const [updates, setUpdates] = useState({
+  const { ui } = useStore()
+
+  const [updates, setUpdates] = useState<any>({
     // pgbouncer_status: config.pgbouncer_status,
     pgbouncer_enabled: config.pgbouncer_enabled,
     pool_mode: config.pool_mode || 'transaction',
@@ -30,14 +32,17 @@ const PgbouncerConfig: FC<Props> = ({ projectRef, config }) => {
         throw response.error
       } else {
         setUpdates({ ...response.project })
-        toast(`Settings saved`)
+        ui.setNotification({ category: 'success', message: 'Successfully saved settings' })
       }
     } catch (error: any) {
-      toast.error(`Update config failed: ${error.message}`)
+      ui.setNotification({
+        category: 'error',
+        message: `Failed to update config: ${error.message}`,
+      })
     }
   }
 
-  let formSchema = {
+  const formSchema = {
     properties: {
       pgbouncer_enabled: {
         title: 'Enabled',

--- a/studio/components/interfaces/Database/Publications/PublicationsList.tsx
+++ b/studio/components/interfaces/Database/Publications/PublicationsList.tsx
@@ -1,6 +1,5 @@
 import { FC, useState } from 'react'
 import { observer } from 'mobx-react-lite'
-import { toast } from 'react-hot-toast'
 import { Button, Input, Toggle, IconSearch } from '@supabase/ui'
 
 import { useStore } from 'hooks'
@@ -12,7 +11,7 @@ interface Props {
 }
 
 const PublicationsList: FC<Props> = ({ onSelectPublication = () => {} }) => {
-  const { meta } = useStore()
+  const { ui, meta } = useStore()
   const [filterString, setFilterString] = useState<string>('')
 
   const publications =
@@ -36,7 +35,10 @@ const PublicationsList: FC<Props> = ({ onSelectPublication = () => {} }) => {
             return data
           }
         } catch (error: any) {
-          toast.error(`Error: ${error.message}`)
+          ui.setNotification({
+            category: 'error',
+            message: `Failed to toggle for ${publication.name}: ${error.message}`,
+          })
           return false
         }
       },

--- a/studio/components/interfaces/Database/Publications/PublicationsTableItem.tsx
+++ b/studio/components/interfaces/Database/Publications/PublicationsTableItem.tsx
@@ -1,6 +1,5 @@
 import { FC, useState } from 'react'
 import { observer } from 'mobx-react-lite'
-import { toast } from 'react-hot-toast'
 import { Badge, Toggle } from '@supabase/ui'
 
 import { useStore } from 'hooks'
@@ -12,7 +11,7 @@ interface Props {
 }
 
 const PublicationsTableItem: FC<Props> = ({ table, selectedPublication }) => {
-  const { meta } = useStore()
+  const { ui, meta } = useStore()
 
   const publication = selectedPublication
   const enabledForAllTables = publication.tables == null
@@ -42,7 +41,10 @@ const PublicationsTableItem: FC<Props> = ({ table, selectedPublication }) => {
       if (error) throw error
       setLoading(false)
     } catch (error: any) {
-      toast.error(error.message)
+      ui.setNotification({
+        category: 'error',
+        message: `Failed to toggle replication for ${table.name}: ${error.message}`,
+      })
       setChecked(originalChecked)
       setLoading(false)
     }

--- a/studio/components/interfaces/Database/Publications/PublicationsTables.tsx
+++ b/studio/components/interfaces/Database/Publications/PublicationsTables.tsx
@@ -1,6 +1,5 @@
 import { FC, useState } from 'react'
 import { observer } from 'mobx-react-lite'
-import { toast } from 'react-hot-toast'
 import { Button, Toggle, Input, IconChevronLeft, IconSearch } from '@supabase/ui'
 
 import { useStore } from 'hooks'
@@ -19,7 +18,7 @@ const PublicationsTables: FC<Props> = ({
   onSelectBack,
   onPublicationUpdated,
 }) => {
-  const { meta } = useStore()
+  const { ui, meta } = useStore()
   const [filterString, setFilterString] = useState<string>('')
 
   const tables =
@@ -48,7 +47,10 @@ const PublicationsTables: FC<Props> = ({
             onPublicationUpdated(res)
           }
         } catch (error: any) {
-          toast.error(error.message)
+          ui.setNotification({
+            category: 'error',
+            message: `Failed to toggle replication for all tables: ${error.message}`,
+          })
         }
       },
     })

--- a/studio/components/interfaces/Database/Tables/ColumnList.tsx
+++ b/studio/components/interfaces/Database/Tables/ColumnList.tsx
@@ -1,6 +1,5 @@
 import { FC, ReactNode, useState } from 'react'
 import { observer } from 'mobx-react-lite'
-import { toast } from 'react-hot-toast'
 import {
   Input,
   Button,
@@ -59,7 +58,7 @@ const ColumnList: FC<{
   onSelectBack = () => {},
   onColumnDeleted = () => {},
 }) => {
-  const { meta } = useStore()
+  const { ui, meta } = useStore()
   const [filterString, setFilterString] = useState<string>('')
   const columns =
     filterString.length === 0
@@ -77,10 +76,16 @@ const ColumnList: FC<{
             throw response.error
           } else {
             onColumnDeleted()
-            toast(`${column.name} removed.`)
+            ui.setNotification({
+              category: 'success',
+              message: `Successfully removed ${column.name}.`,
+            })
           }
         } catch (error: any) {
-          toast.error(`Deleting ${column.name} failed: ${error.message}`)
+          ui.setNotification({
+            category: 'error',
+            message: `Failed to delete ${column.name}: ${error.message}`,
+          })
         }
       },
     })

--- a/studio/components/interfaces/Database/Tables/TableList.tsx
+++ b/studio/components/interfaces/Database/Tables/TableList.tsx
@@ -1,6 +1,5 @@
 import { FC, ReactNode, useState } from 'react'
 import { observer } from 'mobx-react-lite'
-import { toast } from 'react-hot-toast'
 import {
   Button,
   IconPlus,
@@ -51,7 +50,7 @@ const TableList: FC<{
   onEditTable: (table: any) => void
   onOpenTable: (table: any) => void
 }> = observer(({ onAddTable = () => {}, onEditTable = () => {}, onOpenTable = () => {} }) => {
-  const { meta } = useStore()
+  const { ui, meta } = useStore()
   const [filterString, setFilterString] = useState<string>('')
   const tables =
     filterString.length === 0
@@ -70,10 +69,16 @@ const TableList: FC<{
           if (response.error) {
             throw response.error
           } else {
-            toast.success(`Successfully removed ${table.name}.`)
+            ui.setNotification({
+              category: 'success',
+              message: `Successfully removed ${table.name}.`,
+            })
           }
         } catch (error: any) {
-          toast.error(`Deleting ${table.name} failed: ${error.message}`)
+          ui.setNotification({
+            category: 'error',
+            message: `Failed to delete ${table.name}: ${error.message}`,
+          })
         }
       },
     })

--- a/studio/components/interfaces/Database/Triggers/CreateTrigger.tsx
+++ b/studio/components/interfaces/Database/Triggers/CreateTrigger.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import { FC, useEffect, createContext, useContext } from 'react'
 import { makeAutoObservable } from 'mobx'
 import { observer, useLocalObservable } from 'mobx-react-lite'
 import { isEmpty, mapValues, has, without, union } from 'lodash'
@@ -15,7 +15,6 @@ import {
   IconTool,
   Badge,
 } from '@supabase/ui'
-import toast from 'react-hot-toast'
 import { Dictionary } from '@supabase/grid'
 import { useRouter } from 'next/router'
 import SVG from 'react-inlinesvg'
@@ -241,7 +240,7 @@ function hasWhitespace(value: string) {
   return /\s/.test(value)
 }
 
-const CreateTriggerContext = React.createContext<ICreateTriggerStore | null>(null)
+const CreateTriggerContext = createContext<ICreateTriggerStore | null>(null)
 
 type CreateTriggerProps = {
   trigger?: any
@@ -249,8 +248,8 @@ type CreateTriggerProps = {
   setVisible: (value: boolean) => void
 } & any
 
-const CreateTrigger: React.FC<CreateTriggerProps> = ({ trigger, visible, setVisible }) => {
-  const { meta } = useStore()
+const CreateTrigger: FC<CreateTriggerProps> = ({ trigger, visible, setVisible }) => {
+  const { ui, meta } = useStore()
   const _localState = useLocalObservable(() => new CreateTriggerStore())
   _localState.meta = meta as any
 
@@ -258,7 +257,7 @@ const CreateTrigger: React.FC<CreateTriggerProps> = ({ trigger, visible, setVisi
   const router = useRouter()
   const { ref } = router.query
 
-  React.useEffect(() => {
+  useEffect(() => {
     const fetchTables = async () => {
       await (_localState!.meta as any)!.tables!.load()
       const tables = (_localState!.meta as any)!.tables.list()
@@ -274,7 +273,7 @@ const CreateTrigger: React.FC<CreateTriggerProps> = ({ trigger, visible, setVisi
     fetchFunctions()
   }, [])
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (trigger) {
       _localState.formState.reset(trigger)
     } else {
@@ -294,19 +293,29 @@ const CreateTrigger: React.FC<CreateTriggerProps> = ({ trigger, visible, setVisi
           : await (_localState.meta as any).triggers.create(body)
 
         if (response.error) {
-          toast.error(`Error: ${response.error.message ?? 'submit request failed'}`)
+          ui.setNotification({
+            category: 'error',
+            message: `Failed to create trigger: ${
+              response.error?.message ?? 'submit request failed'
+            }`,
+          })
           _localState.setLoading(false)
         } else {
-          toast.success(
-            `${_localState.isEditing ? 'Updated' : 'Created new'} trigger called ${response.name}`
-          )
+          ui.setNotification({
+            category: 'success',
+            message: `${_localState.isEditing ? 'Updated' : 'Created new'} trigger called ${
+              response.name
+            }`,
+          })
           _localState.setLoading(false)
           setVisible(!visible)
         }
       }
     } catch (error: any) {
-      console.error('Handle submit error:', error)
-      toast.error(error.message)
+      ui.setNotification({
+        category: 'error',
+        message: `Filed to create trigger: ${error.message}`,
+      })
       _localState.setLoading(false)
     }
   }
@@ -375,7 +384,7 @@ const CreateTrigger: React.FC<CreateTriggerProps> = ({ trigger, visible, setVisi
   )
 }
 
-const NoTableState: React.FC = ({}) => {
+const NoTableState: FC = ({}) => {
   // for the empty 'no tables' state link
   const router = useRouter()
   const { ref } = router.query
@@ -397,8 +406,8 @@ const NoTableState: React.FC = ({}) => {
 
 export default observer(CreateTrigger)
 
-const InputName: React.FC = observer(({}) => {
-  const _localState = React.useContext(CreateTriggerContext)
+const InputName: FC = observer(({}) => {
+  const _localState = useContext(CreateTriggerContext)
   return (
     <Input
       id="name"
@@ -419,8 +428,8 @@ const InputName: React.FC = observer(({}) => {
   )
 })
 
-const SelectEnabledMode: React.FC = observer(({}) => {
-  const _localState = React.useContext(CreateTriggerContext)
+const SelectEnabledMode: FC = observer(({}) => {
+  const _localState = useContext(CreateTriggerContext)
   return (
     <Listbox
       id="enabled-mode"
@@ -490,8 +499,8 @@ const SelectEnabledMode: React.FC = observer(({}) => {
   )
 })
 
-const SelectOrientation: React.FC = observer(({}) => {
-  const _localState = React.useContext(CreateTriggerContext)
+const SelectOrientation: FC = observer(({}) => {
+  const _localState = useContext(CreateTriggerContext)
   return (
     <Listbox
       id="orientation"
@@ -519,8 +528,8 @@ const SelectOrientation: React.FC = observer(({}) => {
   )
 })
 
-const ListboxTable: React.FC = observer(({}) => {
-  const _localState = React.useContext(CreateTriggerContext)
+const ListboxTable: FC = observer(({}) => {
+  const _localState = useContext(CreateTriggerContext)
 
   return (
     <Listbox
@@ -582,8 +591,8 @@ const ListboxTable: React.FC = observer(({}) => {
   )
 })
 
-const CheckboxEvents: React.FC = observer(({}) => {
-  const _localState = React.useContext(CreateTriggerContext)
+const CheckboxEvents: FC = observer(({}) => {
+  const _localState = useContext(CreateTriggerContext)
   return (
     // @ts-ignore
     <Checkbox.Group
@@ -628,8 +637,8 @@ const CheckboxEvents: React.FC = observer(({}) => {
   )
 })
 
-const ListboxActivation: React.FC = observer(({}) => {
-  const _localState = React.useContext(CreateTriggerContext)
+const ListboxActivation: FC = observer(({}) => {
+  const _localState = useContext(CreateTriggerContext)
   return (
     <Listbox
       id="activation"
@@ -680,8 +689,8 @@ const ListboxActivation: React.FC = observer(({}) => {
   )
 })
 
-const FunctionForm: React.FC = observer(({}) => {
-  const _localState = React.useContext(CreateTriggerContext)
+const FunctionForm: FC = observer(({}) => {
+  const _localState = useContext(CreateTriggerContext)
 
   return (
     <div className="space-y-4">
@@ -699,8 +708,8 @@ const FunctionForm: React.FC = observer(({}) => {
   )
 })
 
-const FunctionEmpty: React.FC = observer(({}) => {
-  const _localState = React.useContext(CreateTriggerContext)
+const FunctionEmpty: FC = observer(({}) => {
+  const _localState = useContext(CreateTriggerContext)
   return (
     <button
       type="button"
@@ -722,8 +731,8 @@ const FunctionEmpty: React.FC = observer(({}) => {
   )
 })
 
-const FunctionWithArguments: React.FC = observer(({}) => {
-  const _localState = React.useContext(CreateTriggerContext)
+const FunctionWithArguments: FC = observer(({}) => {
+  const _localState = useContext(CreateTriggerContext)
 
   return (
     <>

--- a/studio/components/interfaces/Database/Triggers/DeleteTrigger.tsx
+++ b/studio/components/interfaces/Database/Triggers/DeleteTrigger.tsx
@@ -1,5 +1,4 @@
-import * as React from 'react'
-import toast from 'react-hot-toast'
+import { FC, useState } from 'react'
 import { observer } from 'mobx-react-lite'
 import { useStore } from 'hooks'
 import TextConfirmModal from 'components/to-be-cleaned/ModalsDeprecated/TextConfirmModal'
@@ -10,9 +9,9 @@ type DeleteTriggerProps = {
   setVisible: (value: boolean) => void
 } & any
 
-const DeleteTrigger: React.FC<DeleteTriggerProps> = ({ store, trigger, visible, setVisible }) => {
-  const { meta } = useStore()
-  const [loading, setLoading] = React.useState(false)
+const DeleteTrigger: FC<DeleteTriggerProps> = ({ store, trigger, visible, setVisible }) => {
+  const { ui, meta } = useStore()
+  const [loading, setLoading] = useState(false)
   const { id, name, schema } = trigger ?? {}
 
   async function handleDelete() {
@@ -25,31 +24,32 @@ const DeleteTrigger: React.FC<DeleteTriggerProps> = ({ store, trigger, visible, 
       if (response.error) {
         throw response.error
       } else {
-        toast.success(`Trigger ${name} removed`)
+        ui.setNotification({ category: 'success', message: `Successfully removed ${name}` })
         setVisible(false)
       }
     } catch (error: any) {
-      toast.error(`Deleting ${name} failed: ${error.message}`)
+      ui.setNotification({
+        category: 'error',
+        message: `Failed to delete ${name}: ${error.message}`,
+      })
     } finally {
       setLoading(false)
     }
   }
 
   return (
-    <>
-      <TextConfirmModal
-        visible={visible}
-        onCancel={() => setVisible(!visible)}
-        onConfirm={handleDelete}
-        title="Delete this trigger"
-        loading={loading}
-        confirmLabel={`Delete trigger ${name}`}
-        confirmPlaceholder="Type in name of trigger"
-        confirmString={name}
-        text={`This will delete your trigger called ${name} of schema ${schema}.`}
-        alert="You cannot recover this trigger once it is deleted!"
-      />
-    </>
+    <TextConfirmModal
+      visible={visible}
+      onCancel={() => setVisible(!visible)}
+      onConfirm={handleDelete}
+      title="Delete this trigger"
+      loading={loading}
+      confirmLabel={`Delete trigger ${name}`}
+      confirmPlaceholder="Type in name of trigger"
+      confirmString={name}
+      text={`This will delete your trigger called ${name} of schema ${schema}.`}
+      alert="You cannot recover this trigger once it is deleted!"
+    />
   )
 }
 

--- a/studio/components/interfaces/Organization/BillingSettings/BillingSettings.tsx
+++ b/studio/components/interfaces/Organization/BillingSettings/BillingSettings.tsx
@@ -1,9 +1,9 @@
 import Link from 'next/link'
-import toast from 'react-hot-toast'
 import { useRouter } from 'next/router'
 import { FC, useState, useEffect } from 'react'
 import { Typography, Badge, Button, IconTrash, IconCreditCard } from '@supabase/ui'
 
+import { useStore } from 'hooks'
 import { API_URL } from 'lib/constants'
 import { getURL } from 'lib/helpers'
 import { post } from 'lib/common/fetch'
@@ -17,6 +17,7 @@ interface Props {
 
 const BillingSettings: FC<Props> = ({ organization, projects = [] }) => {
   const router = useRouter()
+  const { ui } = useStore()
 
   const [loading, setLoading] = useState<boolean>(false)
   const [error, setError] = useState<any>(undefined)
@@ -53,7 +54,10 @@ const BillingSettings: FC<Props> = ({ organization, projects = [] }) => {
       setPaymentMethods(paymentMethods)
       setCustomer(customer)
     } catch (error: any) {
-      toast.error(error.message)
+      ui.setNotification({
+        category: 'error',
+        message: `Failed to get Stripe account: ${error.message}`,
+      })
       setError(error)
     } finally {
       setLoading(false)
@@ -73,7 +77,7 @@ const BillingSettings: FC<Props> = ({ organization, projects = [] }) => {
       })
       window.location.replace(billingPortal + (path ? path : null))
     } catch (error: any) {
-      toast.error(error.message)
+      ui.setNotification({ category: 'error', message: `Failed to redirect: ${error.message}` })
     } finally {
       setLoading(false)
     }

--- a/studio/components/interfaces/Organization/BillingSettings/ProjectSubscription.tsx
+++ b/studio/components/interfaces/Organization/BillingSettings/ProjectSubscription.tsx
@@ -1,9 +1,9 @@
 import { FC, useState, useEffect } from 'react'
-import toast from 'react-hot-toast'
 import dayjs from 'dayjs'
 import { get as _get, maxBy } from 'lodash'
 import utc from 'dayjs/plugin/utc'
 
+import { useStore } from 'hooks'
 import { API_URL } from 'lib/constants'
 import { Dictionary } from '@supabase/grid'
 import { get, post } from 'lib/common/fetch'
@@ -17,6 +17,7 @@ interface Props {
 }
 
 const ProjectSubscription: FC<Props> = ({ project }) => {
+  const { ui } = useStore()
   const [loading, setLoading] = useState<boolean>(true)
   const [subscription, setSubscription] = useState<StripeSubscription>()
   const [paygStats, setPaygStats] = useState<Dictionary<number>>()
@@ -41,8 +42,10 @@ const ProjectSubscription: FC<Props> = ({ project }) => {
         fetchPaygStatistics()
       }
     } catch (error: any) {
-      console.error(error)
-      toast.error(error.message)
+      ui.setNotification({
+        category: 'error',
+        message: `Failed to get project subscription: ${error.message}`,
+      })
     } finally {
       setLoading(false)
     }

--- a/studio/components/interfaces/Organization/InvoicesSettings/InvoicesSettings.tsx
+++ b/studio/components/interfaces/Organization/InvoicesSettings/InvoicesSettings.tsx
@@ -1,7 +1,7 @@
-import toast from 'react-hot-toast'
 import { FC, useState, useEffect } from 'react'
 import { Button, Loading, Typography, IconFileText, IconDownload } from '@supabase/ui'
 
+import { useStore } from 'hooks'
 import { API_URL } from 'lib/constants'
 import { post } from 'lib/common/fetch'
 import Table from 'components/to-be-cleaned/Table'
@@ -11,6 +11,7 @@ interface Props {
 }
 
 const InvoicesSettings: FC<Props> = ({ organization }) => {
+  const { ui } = useStore()
   const [loading, setLoading] = useState<any>(false)
   const [error, setError] = useState<any>(null)
   const [stripeAccount, setStripeAccount] = useState<any>(null)
@@ -28,7 +29,10 @@ const InvoicesSettings: FC<Props> = ({ organization }) => {
       })
       setStripeAccount(response)
     } catch (error: any) {
-      toast.error(error.message)
+      ui.setNotification({
+        category: 'error',
+        message: `Failed to get Stripe account: ${error.message}`,
+      })
       setError(error)
     } finally {
       setLoading(false)

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/JsonEditor/JsonEditor.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/JsonEditor/JsonEditor.tsx
@@ -1,7 +1,7 @@
 import { FC, useState, useEffect } from 'react'
-import toast from 'react-hot-toast'
 import { SidePanel, Typography } from '@supabase/ui'
 
+import { useStore } from 'hooks'
 import JsonEditor from './JsonCodeEditor'
 import TwoOptionToggle from './TwoOptionToggle'
 import DrilldownViewer from './DrilldownViewer'
@@ -17,7 +17,8 @@ type JsonEditProps = {
 }
 
 const JsonEdit: FC<JsonEditProps> = ({ column, jsonString, visible, closePanel, onSaveJSON }) => {
-  const [view, setView] = useState('edit')
+  const { ui } = useStore()
+  const [view, setView] = useState<'edit' | 'view'>('edit')
   const [jsonStr, setJsonStr] = useState('')
 
   useEffect(() => {
@@ -33,22 +34,18 @@ const JsonEdit: FC<JsonEditProps> = ({ column, jsonString, visible, closePanel, 
       const message = error.message
         ? `Error: ${error.message}`
         : 'Hmm, invalid JSON seems to have an invalid structure.'
-      toast.error(message)
+      ui.setNotification({ category: 'error', message })
     } finally {
       resolve()
     }
-  }
-
-  function toggleView(option: string) {
-    setView(option)
   }
 
   function onInputChange(value: any) {
     setJsonStr(value ?? '')
   }
 
-  function onToggleClick(option: string) {
-    toggleView(option)
+  function onToggleClick(option: 'edit' | 'view') {
+    setView(option)
   }
 
   return (

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.tsx
@@ -1,6 +1,5 @@
 import { FC, useEffect, useState } from 'react'
 import { isUndefined, partition, isEmpty } from 'lodash'
-import { toast } from 'react-hot-toast'
 import { Divider, SidePanel, Space, Typography } from '@supabase/ui'
 import { Dictionary, Query } from '@supabase/grid'
 import { PostgresTable } from '@supabase/postgres-meta'
@@ -77,7 +76,10 @@ const RowEditor: FC<Props> = ({
     // Possible low prio refactor: Shift fetching reference row retrieval to ReferenceRowViewer
     // in a useEffect, rather than trying to manage a loading state in this method
     if (!row.value) {
-      return toast.error(`Please enter a value in the ${row.name} field first`)
+      ui.setNotification({
+        category: 'error',
+        message: `Please enter a value in the ${row.name} field first`,
+      })
     }
     const foreignKey = row.foreignKey
     setReferenceRow({ loading: true, foreignKey, row: undefined })

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.tsx
@@ -1,9 +1,9 @@
 import { FC, useEffect, useState } from 'react'
 import { isUndefined, isEmpty } from 'lodash'
-import { toast } from 'react-hot-toast'
 import { Badge, Checkbox, Divider, SidePanel, Space, Input, Typography } from '@supabase/ui'
 import { PostgresTable } from '@supabase/postgres-meta'
 
+import { useStore } from 'hooks'
 import ActionBar from '../ActionBar'
 import HeaderTitle from './HeaderTitle'
 import ColumnManagement from './ColumnManagement'
@@ -57,6 +57,7 @@ const TableEditor: FC<Props> = ({
   saveChanges = () => {},
   updateEditorDirty = () => {},
 }) => {
+  const { ui } = useStore()
   const isNewRecord = isUndefined(table)
 
   const [errors, setErrors] = useState<any>({})
@@ -102,7 +103,9 @@ const TableEditor: FC<Props> = ({
   const onSaveChanges = (resolve: any) => {
     if (tableFields) {
       const errors: any = validateFields(tableFields)
-      if (errors.columns) toast.error(errors.columns)
+      if (errors.columns) {
+        ui.setNotification({ category: 'error', message: errors.columns })
+      }
       setErrors(errors)
 
       if (isEmpty(errors)) {

--- a/studio/components/layouts/ProjectLayout/LayoutHeader/FeedbackDropdown/FeedbackWidget.tsx
+++ b/studio/components/layouts/ProjectLayout/LayoutHeader/FeedbackDropdown/FeedbackWidget.tsx
@@ -1,20 +1,23 @@
 import { useState, useEffect, useRef } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
-import { toast } from 'react-hot-toast'
 import { Button, Typography, Divider } from '@supabase/ui'
 
+import { useStore } from 'hooks'
 import { post } from 'lib/common/fetch'
 import { API_URL } from 'lib/constants'
 
 const FeedbackWidget = ({ onClose, feedback, setFeedback, category, setCategory }: any) => {
-  const inputRef = useRef(null)
   const router = useRouter()
   const { ref } = router.query
+
+  const { ui } = useStore()
+  const inputRef = useRef<any>(null)
+
   const [isSending, setSending] = useState(false)
 
   useEffect(() => {
-    ;(inputRef?.current as any)?.focus()
+    inputRef?.current?.focus()
   }, [inputRef])
 
   function onFeedbackChange(e: any) {
@@ -37,7 +40,7 @@ const FeedbackWidget = ({ onClose, feedback, setFeedback, category, setCategory 
       })
       setSending(false)
       setFeedback('')
-      toast.success(`Feedback sent. Thank you!`)
+      ui.setNotification({ category: 'success', message: 'Feedback sent. Thank you!' })
     }
 
     return onClose()

--- a/studio/components/layouts/SQLEditorLayout/SQLEditorMenuOld.tsx
+++ b/studio/components/layouts/SQLEditorLayout/SQLEditorMenuOld.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react'
 import { useRouter } from 'next/router'
 import { observer } from 'mobx-react-lite'
-import { toast } from 'react-hot-toast'
 import {
   Button,
   Dropdown,
@@ -133,8 +132,10 @@ const SideBarContent = observer(() => {
       if (snippet) sqlEditorStore.selectTab(snippet.id)
       setLoadingNewQuery(false)
     } catch (error: any) {
-      console.error(error)
-      toast.error(error.message)
+      ui.setNotification({
+        category: 'error',
+        message: `Failed to create new query: ${error.message}`,
+      })
       setLoadingNewQuery(false)
     }
   }

--- a/studio/components/layouts/StorageLayout/StorageLayout.tsx
+++ b/studio/components/layouts/StorageLayout/StorageLayout.tsx
@@ -1,6 +1,5 @@
 import { FC, ReactNode, useEffect } from 'react'
 import { find } from 'lodash'
-import { toast } from 'react-hot-toast'
 import { observer } from 'mobx-react-lite'
 
 import { useStore } from 'hooks'
@@ -67,10 +66,13 @@ const StorageLayout: FC<Props> = ({ title, children }) => {
           `StorageLayout: Failed to getProjectConfig - ${projectUrl} ${projectApiKey}`
         )
       }
-    } catch (e) {
-      toast.error(
-        'Failed to fetch project configuration. Try refreshing your browser, or reach out to us at support@supabase.io'
-      )
+    } catch (error: any) {
+      ui.setNotification({
+        error,
+        category: 'error',
+        message:
+          'Failed to fetch project configuration. Try refreshing your browser, or reach out to us at support@supabase.io',
+      })
     }
     storageExplorerStore.setLoaded(true)
   }

--- a/studio/components/to-be-cleaned/Auth/PolicyEditorModal.js
+++ b/studio/components/to-be-cleaned/Auth/PolicyEditorModal.js
@@ -1,7 +1,6 @@
 import { Modal, Typography, IconChevronLeft } from '@supabase/ui'
 import { useState, useEffect } from 'react'
 import { isEmpty } from 'lodash'
-import toast from 'react-hot-toast'
 
 import { POLICY_MODAL_VIEWS } from 'lib/constants'
 import { getGeneralPolicyTemplates } from './PolicyEditorModal.constants'
@@ -15,6 +14,7 @@ import PolicySelection from './PolicySelection'
 import PolicyEditor from './PolicyEditor'
 import PolicyReview from './PolicyReview'
 import PolicyTemplates from './PolicyTemplates'
+import { useStore } from 'hooks'
 
 const PolicyEditorModalTitle = ({
   view,
@@ -66,6 +66,8 @@ const PolicyEditorModal = ({
   onUpdatePolicy = () => {},
   onSaveSuccess = () => {},
 }) => {
+  const { ui } = useStore()
+
   const newPolicyTemplate = {
     schema,
     table,
@@ -126,21 +128,32 @@ const PolicyEditorModal = ({
     const { name, definition, check, command } = policyFormFields
 
     if (name.length === 0) {
-      return toast.error('Do give your policy a name')
+      return ui.setNotification({ category: 'error', message: 'Do give your policy a name' })
     }
     if (!command) {
-      return toast.error('You will need to allow at one operation in your policy')
+      return ui.setNotification({
+        category: 'error',
+        message: 'You will need to allow at one operation in your policy',
+      })
     }
     if (['SELECT', 'DELETE'].includes(command) && !definition) {
-      return toast.error('Did you forget to provide a USING expression for your policy?')
+      return ui.setNotification({
+        category: 'error',
+        message: 'Did you forget to provide a USING expression for your policy?',
+      })
     }
     if (command === 'INSERT' && !check) {
-      return toast.error('Did you forget to provide a WITH CHECK expression for your policy?')
+      return ui.setNotification({
+        category: 'error',
+        message: 'Did you forget to provide a WITH CHECK expression for your policy?',
+      })
     }
     if (command === 'UPDATE' && !definition && !check) {
-      return toast.error(
-        'You will need to provide either a USING, or WITH CHECK expression, or both for your policy'
-      )
+      return ui.setNotification({
+        category: 'error',
+        message:
+          'You will need to provide either a USING, or WITH CHECK expression, or both for your policy',
+      })
     }
     const policySQLStatement = createSQLPolicy(policyFormFields, selectedPolicyToEdit)
     setPolicyStatementForReview(policySQLStatement)

--- a/studio/components/to-be-cleaned/ModalsDeprecated/InviteMemberModal.js
+++ b/studio/components/to-be-cleaned/ModalsDeprecated/InviteMemberModal.js
@@ -72,13 +72,16 @@ function InviteMemberModal({ organization, members = [] }) {
       user_id: PageState.selectedProfile.id,
     })
     if (response?.error) {
-      toast.error(response.error.message)
+      ui.setNotification({
+        category: 'error',
+        message: `Failed to add member: ${response.error.message}`,
+      })
       PageState.addMemberLoading = false
     } else {
       const newMember = response
       mutateOrgMembers([...PageState.members, newMember], false)
       toggle()
-      toast(`New member added`)
+      ui.setNotification({ category: 'success', message: 'Successfully added new member' })
     }
   }
 
@@ -120,6 +123,7 @@ export default observer(InviteMemberModal)
 
 const InputSearchWithResults = observer(({ className }) => {
   const PageState = useContext(PageContext)
+  const { ui } = useStore()
   const [loading, setLoading] = useState(false)
   const debounceSearchProfile = useCallback(debounce(searchProfile, 500), [PageState.keywords])
 
@@ -137,7 +141,10 @@ const InputSearchWithResults = observer(({ className }) => {
     setLoading(true)
     const response = await post(`${API_URL}/profile/search`, { keywords: PageState.keywords })
     if (response.error) {
-      toast.error(response.error.message)
+      ui.setNotification({
+        category: 'error',
+        message: `Failed to search profile: ${response.error.message}`,
+      })
       setLoading(false)
     } else {
       PageState.setProfiles(response)

--- a/studio/components/to-be-cleaned/Reports/Reports.utils.ts
+++ b/studio/components/to-be-cleaned/Reports/Reports.utils.ts
@@ -2,11 +2,6 @@ import { useProjectContentStore } from 'stores/projectContentStore'
 import { NEW_REPORT_SKELETON } from './Reports.constants'
 import toast from 'react-hot-toast'
 
-function handleErr(error: any) {
-  console.error(error)
-  toast.error(error.message)
-}
-
 /*
  * createReport()
  *
@@ -17,15 +12,13 @@ function handleErr(error: any) {
  */
 export const createReport = async ({ router }: any) => {
   const { ref } = router.query
-  try {
-    const contentStore = useProjectContentStore(ref)
-    const { data: newReport, error } = await contentStore.create(NEW_REPORT_SKELETON)
-    if (error) throw error
-    await contentStore.load()
-    router.push(`/project/${ref}/reports/${newReport[0].id}`)
-  } catch (err) {
-    handleErr(err)
-  }
+  const contentStore = useProjectContentStore(ref)
+  const { data: newReport, error } = await contentStore.create(NEW_REPORT_SKELETON)
+
+  if (error) throw error
+
+  await contentStore.load()
+  router.push(`/project/${ref}/reports/${newReport[0].id}`)
 }
 
 /*
@@ -39,14 +32,12 @@ export const createReport = async ({ router }: any) => {
 export const deleteReport = async ({ router, id }: any) => {
   const { ref } = router.query
   const contentStore = useProjectContentStore(ref)
-  try {
-    const { data: delReport, error } = await contentStore.del(id)
-    if (error) throw error
-    await contentStore.load()
-    // push route to report index
-    router.push(`/project/${ref}/reports`)
-    return delReport
-  } catch (err) {
-    handleErr(err)
-  }
+  const { data: delReport, error } = await contentStore.del(id)
+
+  if (error) throw error
+
+  await contentStore.load()
+  // push route to report index
+  router.push(`/project/${ref}/reports`)
+  return delReport
 }

--- a/studio/components/to-be-cleaned/SqlEditor/RenameQuery.js
+++ b/studio/components/to-be-cleaned/SqlEditor/RenameQuery.js
@@ -4,11 +4,13 @@ import { useRouter } from 'next/router'
 import { AutoField } from 'uniforms-bootstrap4'
 import SchemaFormPanel from 'components/to-be-cleaned/forms/SchemaFormPanel'
 
+import { useStore } from 'hooks'
 import { useSqlStore } from 'localStores/sqlEditor/SqlEditorStore'
 import { useProjectContentStore } from 'stores/projectContentStore'
-import toast from 'react-hot-toast'
 
 const RenameQuery = observer(({ tabId, onComplete }) => {
+  const { ui } = useStore()
+
   const router = useRouter()
   const { ref } = router.query
 
@@ -40,8 +42,11 @@ const RenameQuery = observer(({ tabId, onComplete }) => {
       if (onComplete) onComplete()
       return Promise.resolve()
     } catch (error) {
-      toast.error(error.message)
-      console.error(error)
+      ui.setNotification({
+        error,
+        category: 'error',
+        message: `Failed to rename query: ${error.message}`,
+      })
     }
   }
 

--- a/studio/components/to-be-cleaned/SqlEditor/SqlEditor.utils.ts
+++ b/studio/components/to-be-cleaned/SqlEditor/SqlEditor.utils.ts
@@ -1,14 +1,8 @@
-import toast from 'react-hot-toast'
 import { UserContent } from 'types'
 import { useProjectContentStore } from 'stores/projectContentStore'
 import { NEW_SQL_SNIPPET_SKELETON } from './SqlEditor.constants'
 
-/*
- * createSqlSnippet()
- *
- * Creates a new SQL snippet with a basic skeleton
- *
- */
+/* Creates a new SQL snippet with a basic skeleton */
 export const createSqlSnippet = async ({
   router,
   sql,
@@ -19,28 +13,24 @@ export const createSqlSnippet = async ({
   name: any
 }) => {
   const { ref } = router.query
-  try {
-    const contentStore = useProjectContentStore(ref)
-    const skeleton: UserContent = {
-      ...NEW_SQL_SNIPPET_SKELETON,
-      ...(name && { name }),
-      content: {
-        ...NEW_SQL_SNIPPET_SKELETON.content,
-        content_id: '',
-        sql: sql,
-      },
-    }
-
-    const { data: sqlSnippet, error } = await contentStore.create(skeleton)
-    if (error) throw error
-
-    // reload store data
-    await contentStore.load()
-    return sqlSnippet[0]
-  } catch (error: any) {
-    console.error(error)
-    toast.error(error.message)
+  const contentStore = useProjectContentStore(ref)
+  const skeleton: UserContent = {
+    ...NEW_SQL_SNIPPET_SKELETON,
+    ...(name && { name }),
+    content: {
+      ...NEW_SQL_SNIPPET_SKELETON.content,
+      content_id: '',
+      sql: sql,
+    },
   }
+
+  const { data: sqlSnippet, error } = await contentStore.create(skeleton)
+
+  if (error) throw error
+
+  // reload store data
+  await contentStore.load()
+  return sqlSnippet[0]
 }
 
 /*
@@ -51,18 +41,13 @@ export const createSqlSnippet = async ({
  */
 export const deleteSqlSnippet = async ({ router, id }: { router: any; id: any }) => {
   const { ref } = router.query
-  try {
-    const contentStore = useProjectContentStore(ref)
+  const contentStore = useProjectContentStore(ref)
 
-    const { data: delReport, error } = await contentStore.del(id)
-    if (error) throw error
+  const { data: delReport, error } = await contentStore.del(id)
+  if (error) throw error
 
-    // reload store data
-    await contentStore.load()
+  // reload store data
+  await contentStore.load()
 
-    return delReport
-  } catch (error: any) {
-    console.error(error)
-    toast.error(error.message)
-  }
+  return delReport
 }

--- a/studio/components/to-be-cleaned/SqlEditor/TabSqlQuery.js
+++ b/studio/components/to-be-cleaned/SqlEditor/TabSqlQuery.js
@@ -18,7 +18,6 @@ import { timeout } from 'lib/helpers'
 import { IS_PLATFORM } from 'lib/constants'
 import { useSqlStore, UTILITY_TAB_TYPES } from 'localStores/sqlEditor/SqlEditorStore'
 import { useProjectContentStore } from 'stores/projectContentStore'
-import toast from 'react-hot-toast'
 
 import { SQL_SNIPPET_SCHEMA_VERSION } from './SqlEditor.constants'
 
@@ -401,8 +400,11 @@ const FavoriteButton = observer(() => {
       sqlEditorStore.selectTab(id)
       setLoading(false)
     } catch (error) {
-      toast.error(error.message)
-      console.error(error)
+      ui.setNotification({
+        error,
+        category: 'error',
+        message: `Failed to add to favourites: ${error.message}`,
+      })
       setLoading(false)
     }
   }
@@ -435,8 +437,11 @@ const FavoriteButton = observer(() => {
       sqlEditorStore.selectTab(id)
       setLoading(false)
     } catch (error) {
-      toast.error(error.message)
-      console.error(error)
+      ui.setNotification({
+        error,
+        category: 'error',
+        message: `Failed to remove from favourites: ${error.message}`,
+      })
       setLoading(false)
     }
   }

--- a/studio/components/to-be-cleaned/SqlEditor/TabWelcome.js
+++ b/studio/components/to-be-cleaned/SqlEditor/TabWelcome.js
@@ -1,7 +1,6 @@
 import React, { useState } from 'react'
 import { observer } from 'mobx-react-lite'
 import { useRouter } from 'next/router'
-import { toast } from 'react-hot-toast'
 import { IconChevronRight, IconLoader, Typography } from '@supabase/ui'
 
 import { useSqlStore } from 'localStores/sqlEditor/SqlEditorStore'
@@ -39,8 +38,11 @@ const TabWelcome = observer(() => {
       // select tab with new snippet
       sqlEditorStore.selectTab(snippet.id)
     } catch (error) {
-      console.error(error)
-      toast.error(error.message)
+      ui.setNotification({
+        error,
+        category: 'error',
+        message: `Failed to create new query: ${error.message}`,
+      })
     }
   }
 

--- a/studio/components/to-be-cleaned/Storage/StoragePolicies/StoragePolicies.js
+++ b/studio/components/to-be-cleaned/Storage/StoragePolicies/StoragePolicies.js
@@ -2,7 +2,6 @@ import { useEffect, useState } from 'react'
 import { observer } from 'mobx-react-lite'
 import { Typography } from '@supabase/ui'
 import { find, get, isEmpty, filter } from 'lodash'
-import toast from 'react-hot-toast'
 
 import { useStore } from 'hooks'
 import { formatPoliciesForStorage } from '../Storage.utils'
@@ -15,7 +14,7 @@ import { useStorageStore } from 'localStores/storageExplorer/StorageExplorerStor
 import PolicyEditorModal from 'components/to-be-cleaned/Auth/PolicyEditorModal'
 
 const StoragePolicies = () => {
-  const { meta } = useStore()
+  const { ui, meta } = useStore()
   const storageStore = useStorageStore()
   const { buckets } = storageStore
 
@@ -77,7 +76,7 @@ const StoragePolicies = () => {
   const onCancelPolicyDelete = () => setSelectedPolicyToDelete({})
 
   const onSavePolicySuccess = async () => {
-    toast.success('Policy successfully saved!')
+    ui.setNotification({ category: 'success', message: 'Successfully saved policy!' })
     await fetchPolicies()
     onCancelPolicyEdit()
   }
@@ -91,7 +90,10 @@ const StoragePolicies = () => {
       payloads.map(async (payload) => {
         const res = await meta.policies.create(payload)
         if (res.error) {
-          toast.error(`Error adding policy: ${res.error.message}`)
+          ui.setNotification({
+            category: 'error',
+            message: `Error adding policy: ${res.error.message}`,
+          })
           return true
         }
         return false
@@ -102,7 +104,10 @@ const StoragePolicies = () => {
   const onCreatePolicy = async (payload) => {
     const res = await meta.policies.create(payload)
     if (res.error) {
-      toast.error(`Error adding policy: ${res.error.message}`)
+      ui.setNotification({
+        category: 'error',
+        message: `Error adding policy: ${res.error.message}`,
+      })
       return true
     }
     return false
@@ -111,7 +116,10 @@ const StoragePolicies = () => {
   const onUpdatePolicy = async (payload) => {
     const res = await meta.policies.update(payload.id, payload)
     if (res.error) {
-      toast.error(`Error updating policy: ${res.error.message}`)
+      ui.setNotification({
+        category: 'error',
+        message: `Error updating policy: ${res.error.message}`,
+      })
       return true
     }
     return false
@@ -120,9 +128,12 @@ const StoragePolicies = () => {
   const onDeletePolicy = async () => {
     const res = await meta.policies.del(selectedPolicyToDelete.id)
     if (res.error) {
-      toast.error(`Error deleting policy: ${res.error.message}`)
+      ui.setNotification({
+        category: 'error',
+        message: `Failed to delete policy: ${res.error.message}`,
+      })
     } else {
-      toast.success('Successfully deleted policy!')
+      ui.setNotification({ category: 'success', message: 'Successfully deleted policy!' })
     }
     setSelectedPolicyToDelete({})
     await fetchPolicies()

--- a/studio/components/to-be-cleaned/Storage/StoragePolicies/StoragePoliciesEditPolicyModal.js
+++ b/studio/components/to-be-cleaned/Storage/StoragePolicies/StoragePoliciesEditPolicyModal.js
@@ -3,6 +3,7 @@ import { pull } from 'lodash'
 import { useState, useEffect } from 'react'
 import toast from 'react-hot-toast'
 
+import { useStore } from 'hooks'
 import { POLICY_MODAL_VIEWS } from 'lib/constants'
 import { STORAGE_POLICY_TEMPLATES } from './StoragePolicies.constants'
 import {
@@ -30,6 +31,7 @@ const StoragePoliciesEditPolicyModal = ({
   onCreatePolicies = () => {},
   onSaveSuccess = () => {},
 }) => {
+  const { ui } = useStore()
   const [previousView, setPreviousView] = useState('') // Mainly to decide which view to show when back from templates
   const [view, setView] = useState('')
 
@@ -103,14 +105,20 @@ const StoragePoliciesEditPolicyModal = ({
   const validatePolicyEditorFormFields = () => {
     const { name, definition, allowedOperations } = policyFormFields
     if (name.length === 0) {
-      return toast('Do give your policy a name')
+      return ui.setNotification({ category: 'info', message: 'Do give your policy a name' })
     }
     if (definition.length === 0) {
       // Will need to figure out how to strip away comments or something
-      return toast('Did you forget to provide a definition for your policy?')
+      return ui.setNotification({
+        category: 'info',
+        message: 'Did you forget to provide a definition for your policy?',
+      })
     }
     if (allowedOperations.length === 0) {
-      return toast('You will need to allow at least one operation in your policy')
+      return ui.setNotification({
+        category: 'info',
+        message: 'You will need to allow at least one operation in your policy',
+      })
     }
     const policySQLStatements = createSQLPolicies(bucketName, policyFormFields)
     setPolicyStatementsForReview(policySQLStatements)

--- a/studio/components/to-be-cleaned/Usage.tsx
+++ b/studio/components/to-be-cleaned/Usage.tsx
@@ -1,8 +1,8 @@
 import React, { FC, useEffect, useState } from 'react'
 import useSWR from 'swr'
 import { Loading, Typography } from '@supabase/ui'
-import { toast } from 'react-hot-toast'
 
+import { useStore } from 'hooks'
 import { API_URL } from 'lib/constants'
 import { get, post } from 'lib/common/fetch'
 import SparkBar from 'components/ui/SparkBar'
@@ -191,6 +191,7 @@ const usageLimits = {
 }
 
 const ProjectUsage: FC<any> = ({ projectRef, subscription_id }) => {
+  const { ui } = useStore()
   const { data: stats, error: usageError } = useSWR(`${API_URL}/projects/${projectRef}/usage`, get)
 
   const [loading, setLoading] = useState<boolean>(false)
@@ -213,7 +214,10 @@ const ProjectUsage: FC<any> = ({ projectRef, subscription_id }) => {
         if (!cancel) setSubscription(data)
         if (error) throw error
       } catch (error: any) {
-        toast.error(error.message)
+        ui.setNotification({
+          category: 'error',
+          message: `Failed to get subscription: ${error.message}`,
+        })
         if (!cancel) setError(error)
       } finally {
         if (!cancel) setLoading(false)

--- a/studio/hooks/misc/useStore.tsx
+++ b/studio/hooks/misc/useStore.tsx
@@ -36,14 +36,14 @@ export const StoreProvider: FC<StoreProvider> = ({ children, rootStore }) => {
 
     autorun(() => {
       if (ui.notification) {
-        const { id, category, message } = ui.notification
+        const { id, category, error, message } = ui.notification
         switch (category) {
           case 'info':
             return toast(message, { id })
           case 'success':
             return toast.success(message, { id })
           case 'error':
-            console.error(message)
+            console.error('Notification', { error, message })
             return toast.error(message, { id })
           case 'loading':
             return toast.loading(message, { id })

--- a/studio/pages/account/associate.tsx
+++ b/studio/pages/account/associate.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react'
 import { useRouter } from 'next/router'
-import { toast } from 'react-hot-toast'
 import { Button, Select } from '@supabase/ui'
 import { observer } from 'mobx-react-lite'
 
@@ -9,8 +8,9 @@ import { API_URL } from 'lib/constants'
 import { get, post } from 'lib/common/fetch'
 
 const Associate = observer(() => {
-  const { app } = useStore()
+  const { ui, app } = useStore()
   const sortedOrganizations = app.organizations.list()
+
   const [awsMarketplace, setAwsMarketplace] = useState<any>()
   const [error, setError] = useState<any>('')
   const [loading, setLoading] = useState<any>(true)
@@ -66,7 +66,10 @@ const Associate = observer(() => {
           onSave()
         }
       } catch (error: any) {
-        toast.error(error.message)
+        ui.setNotification({
+          category: 'error',
+          message: `Failed to get AWS Marketplace Information: ${error.message}`,
+        })
       }
     }
     getAwsMarketplaceInfo()

--- a/studio/pages/account/me.tsx
+++ b/studio/pages/account/me.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react'
 import { observer } from 'mobx-react-lite'
-import { toast } from 'react-hot-toast'
 import { IconMoon, IconSun, Select, Typography } from '@supabase/ui'
 
 import { useProfile, useStore, withAuth } from 'hooks'
@@ -40,10 +39,13 @@ const ProfileCard = observer(() => {
       const updatedUser = await post(`${API_URL}/profile/update`, model)
       mutateProfile(updatedUser, false)
       ui.setProfile(updatedUser)
-      toast(`Profile saved`)
+      ui.setNotification({ category: 'success', message: 'Successfully saved profile' })
     } catch (error) {
-      toast(`Couldn't update profile. Try again later.`)
-      console.error('updateUser error:', error)
+      ui.setNotification({
+        error,
+        category: 'error',
+        message: "Couldn't update profile. Please try again later.",
+      })
     }
   }
 

--- a/studio/pages/new/[slug].tsx
+++ b/studio/pages/new/[slug].tsx
@@ -4,7 +4,6 @@
 
 import { useRef, useState, createContext, useContext } from 'react'
 import Router, { useRouter } from 'next/router'
-import { toast } from 'react-hot-toast'
 import { debounce, values } from 'lodash'
 import { makeAutoObservable, toJS } from 'mobx'
 import { observer, useLocalObservable } from 'mobx-react-lite'
@@ -70,6 +69,8 @@ export const Wizard = () => {
 
   const router = useRouter()
   const { slug } = router.query
+
+  const { ui } = useStore()
 
   const [projectName, setProjectName] = useState('')
   const [dbPass, setDbPass] = useState('')
@@ -169,7 +170,10 @@ export const Wizard = () => {
     const response = await post(`${API_URL}/projects/new`, data)
     if (response.error) {
       setNewProjectLoading(false)
-      toast.error(response.error.message)
+      ui.setNotification({
+        category: 'error',
+        message: `Failed to create new project: ${response.error.message}`,
+      })
     } else {
       // Use redirect to reload store data properly
       // after creating a new project

--- a/studio/pages/new/index.tsx
+++ b/studio/pages/new/index.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react'
 import { observer } from 'mobx-react-lite'
 import { Button, Typography } from '@supabase/ui'
-import { toast } from 'react-hot-toast'
 import Router from 'next/router'
 
 import { API_URL } from 'lib/constants'
@@ -15,7 +14,7 @@ import Panel from 'components/to-be-cleaned/Panel'
  * No org selected yet, create a new one
  */
 const Wizard = () => {
-  const { app } = useStore()
+  const { ui, app } = useStore()
   const [orgName, setOrgName] = useState('')
   const [newOrgLoading, setNewOrgLoading] = useState(false)
 
@@ -32,7 +31,7 @@ const Wizard = () => {
     e.preventDefault()
     const isOrgNameValid = validateOrgName(orgName)
     if (!isOrgNameValid) {
-      toast.error('Organization name is empty')
+      ui.setNotification({ category: 'error', message: 'Organization name is empty' })
       return
     }
 
@@ -43,7 +42,10 @@ const Wizard = () => {
 
     if (response.error) {
       setNewOrgLoading(false)
-      toast.error(response.error?.message ?? response.error)
+      ui.setNotification({
+        category: 'error',
+        message: `Failed to create organization: ${response.error?.message ?? response.error}`,
+      })
     } else {
       const org = response
       app.onOrgAdded(org)

--- a/studio/pages/org/[slug]/settings.tsx
+++ b/studio/pages/org/[slug]/settings.tsx
@@ -2,7 +2,6 @@ import { createContext, useEffect, useContext, useState } from 'react'
 import { useRouter } from 'next/router'
 import { observer, useLocalObservable } from 'mobx-react-lite'
 import { toJS } from 'mobx'
-import toast from 'react-hot-toast'
 import { pluckJsonSchemaFields, pluckObjectFields, timeout } from 'lib/helpers'
 import { AutoField } from 'uniforms-bootstrap4'
 import { organizations } from 'stores/jsonSchema'
@@ -185,6 +184,8 @@ const TabsView = observer(() => {
 
 const GeneralSettings = observer(() => {
   const PageState: any = useContext(PageContext)
+  const { ui } = useStore()
+
   const formModel = toJS(PageState.organization)
   // remove warning null value for controlled input
   if (!formModel.billing_email) formModel.billing_email = ''
@@ -196,11 +197,14 @@ const GeneralSettings = observer(() => {
       model
     )
     if (response.error) {
-      toast.error(`Update organization failed: ${response.error.message}`)
+      ui.setNotification({
+        category: 'error',
+        message: `Failed to update organization: ${response.error.message}`,
+      })
     } else {
       const updatedOrg = response
       PageState.onOrgUpdated(updatedOrg)
-      toast(`Settings saved`)
+      ui.setNotification({ category: 'success', message: 'Successfully saved settings' })
     }
   }
 
@@ -261,6 +265,8 @@ const OrgDeletePanel = observer(() => {
 const OrgDeleteModal = observer(() => {
   const PageState: any = useContext(PageContext)
   const router = useRouter()
+  const { ui } = useStore()
+
   const { slug: orgSlug, name: orgName } = PageState.organization
 
   const [isOpen, setIsOpen] = useState(false)
@@ -277,7 +283,10 @@ const OrgDeleteModal = observer(() => {
 
     const response = await delete_(`${API_URL}/organizations/${orgSlug}/remove`)
     if (response.error) {
-      toast.error(`Delete organization failed: ${response.error.message}`)
+      ui.setNotification({
+        category: 'error',
+        message: `Failed to delete organization: ${response.error.message}`,
+      })
       setLoading(false)
     } else {
       PageState.onOrgDeleted(PageState.organization)
@@ -332,6 +341,7 @@ const OrgDeleteModal = observer(() => {
 
 const TeamSettings = observer(() => {
   const PageState: any = useContext(PageContext)
+  const { ui } = useStore()
   const [isLeaving, setIsLeaving] = useState(false)
 
   const orgSlug = PageState.organization.slug
@@ -352,7 +362,7 @@ const TeamSettings = observer(() => {
         },
       })
     } catch (error: any) {
-      toast.error(`Error leaving: ${error?.message}`)
+      ui.setNotification({ category: 'error', message: `Error leaving: ${error?.message}` })
     } finally {
       setIsLeaving(false)
     }
@@ -501,12 +511,15 @@ const OwnerDropdown = observer(({ members, member }: any) => {
           member_id: member.id,
         })
         if (response.error) {
-          toast.error(`Delete user failed: ${response.error.message}`)
+          ui.setNotification({
+            category: 'error',
+            message: `Failed to delete user: ${response.error.message}`,
+          })
           setLoading(false)
         } else {
           const updatedMembers = members.filter((x: any) => x.id !== member.id)
           mutateOrgMembers(updatedMembers)
-          toast(`Member removed`)
+          ui.setNotification({ category: 'success', message: 'Successfully removed member' })
         }
       },
     })
@@ -521,7 +534,10 @@ const OwnerDropdown = observer(({ members, member }: any) => {
       stripe_customer_id,
     })
     if (response.error) {
-      toast.error(`Transfer ownership failed: ${response.error.message}`)
+      ui.setNotification({
+        category: 'error',
+        message: `Failed to transfer ownership: ${response.error.message}`,
+      })
       setLoading(false)
     } else {
       const updatedMembers = [...members]
@@ -531,7 +547,7 @@ const OwnerDropdown = observer(({ members, member }: any) => {
       if (newOwner) newOwner.is_owner = true
       mutateOrgMembers(updatedMembers)
       setOwnerTransferIsVisble(false)
-      toast(`Organization transfered`)
+      ui.setNotification({ category: 'success', message: 'Successfully transfered organization' })
     }
   }
 

--- a/studio/pages/project/[ref]/auth/policies.tsx
+++ b/studio/pages/project/[ref]/auth/policies.tsx
@@ -1,13 +1,9 @@
 import { isEmpty } from 'lodash'
-import { useRouter } from 'next/router'
 import React, { createContext, useContext, useState, useEffect } from 'react'
 import { Button, IconSearch, Input } from '@supabase/ui'
 import { observer, useLocalObservable } from 'mobx-react-lite'
-import toast from 'react-hot-toast'
 
-import { API_URL } from 'lib/constants'
 import { withAuth, useStore } from 'hooks'
-import { get } from 'lib/common/fetch'
 import { AuthLayout } from 'components/layouts'
 import NoSearchResults from 'components/to-be-cleaned/NoSearchResults'
 import ConfirmModal from 'components/to-be-cleaned/ModalsDeprecated/ConfirmModalV2'
@@ -116,8 +112,7 @@ const AuthPolicies = observer(() => {
 })
 
 const AuthPoliciesTables = observer(() => {
-  const router = useRouter()
-  const { meta } = useStore()
+  const { ui, meta } = useStore()
   const PageState: any = useContext(PageContext)
 
   const [selectedSchemaAndTable, setSelectedSchemaAndTable] = useState<any>({})
@@ -153,7 +148,7 @@ const AuthPoliciesTables = observer(() => {
   }
 
   const onSavePolicySuccess = async () => {
-    toast.success('Policy successfully saved!')
+    ui.setNotification({ category: 'success', message: 'Policy successfully saved!' })
     await refreshTables()
     closePolicyEditorModal()
   }
@@ -176,7 +171,10 @@ const AuthPoliciesTables = observer(() => {
     // const url = `${API_URL}/database/${router.query.ref}/tables?id=${payload.id}`
     // const res = await patch(url, payload)
     if (res.error) {
-      toast.error(`Failed to toggle RLS: ${res.error.message}`)
+      ui.setNotification({
+        category: 'error',
+        message: `Failed to toggle RLS: ${res.error.message}`,
+      })
     } else {
       PageState.onTableUpdated(res)
     }
@@ -186,7 +184,10 @@ const AuthPoliciesTables = observer(() => {
   const onCreatePolicy = async (payload: any) => {
     const res = await PageState.meta.policies.create(payload)
     if (res.error) {
-      toast.error(`Error adding policy: ${res.error.message}`)
+      ui.setNotification({
+        category: 'error',
+        message: `Error adding policy: ${res.error.message}`,
+      })
       return true
     }
     return false
@@ -195,7 +196,10 @@ const AuthPoliciesTables = observer(() => {
   const onUpdatePolicy = async (payload: any) => {
     const res = await PageState.meta.policies.update(payload.id, payload)
     if (res.error) {
-      toast.error(`Error updating policy: ${res.error.message}`)
+      ui.setNotification({
+        category: 'error',
+        message: `Error updating policy: ${res.error.message}`,
+      })
       return true
     }
     return false
@@ -204,9 +208,12 @@ const AuthPoliciesTables = observer(() => {
   const onDeletePolicy = async () => {
     const res = await PageState.meta.policies.del(selectedPolicyToDelete.id)
     if (res.error) {
-      toast.error(`Error deleting policy: ${res.error.message}`)
+      ui.setNotification({
+        category: 'error',
+        message: `Error deleting policy: ${res.error.message}`,
+      })
     } else {
-      toast.success('Successfully deleted policy!')
+      ui.setNotification({ category: 'success', message: 'Successfully deleted policy!' })
     }
     await refreshTables()
     closeConfirmModal()

--- a/studio/pages/project/[ref]/reports/index.tsx
+++ b/studio/pages/project/[ref]/reports/index.tsx
@@ -59,7 +59,16 @@ const PageLayout = () => {
             ctaButtonLabel="Create report"
             // infoButtonLabel="About reports"
             // infoButtonUrl="https://supabase.com/docs/guides/storage"
-            onClickCta={() => createReport({ router })}
+            onClickCta={() => {
+              try {
+                createReport({ router })
+              } catch (error: any) {
+                ui.setNotification({
+                  category: 'error',
+                  message: `Failed to create report: ${error.message}`,
+                })
+              }
+            }}
           >
             <Text type="secondary">Create custom reports for your projects.</Text>
             <Text type="secondary">

--- a/studio/pages/project/[ref]/settings/api.tsx
+++ b/studio/pages/project/[ref]/settings/api.tsx
@@ -1,23 +1,10 @@
 import useSWR from 'swr'
 import { FC, createContext, useContext, useState } from 'react'
 import { indexOf } from 'lodash'
-import { toast } from 'react-hot-toast'
 import { useRouter } from 'next/router'
 import { AutoField } from 'uniforms-bootstrap4'
 import { observer, useLocalObservable } from 'mobx-react-lite'
-import {
-  Typography,
-  Input,
-  IconAlertCircle,
-  Button,
-  Modal,
-  IconKey,
-  Dropdown,
-  Divider,
-  IconRefreshCw,
-  IconPenTool,
-  IconChevronDown,
-} from '@supabase/ui'
+import { Typography, Input, IconAlertCircle, Modal, IconKey } from '@supabase/ui'
 
 import { API_URL } from 'lib/constants'
 import { useStore, withAuth } from 'hooks'
@@ -278,6 +265,7 @@ const ServiceList: FC<any> = ({ projectRef }) => {
 
 const PostgrestConfig = observer(({ config, projectRef }: any) => {
   const PageState: any = useContext(PageContext)
+  const { ui } = useStore()
   const { meta } = PageState
 
   const [updates, setUpdates] = useState({
@@ -295,10 +283,14 @@ const PostgrestConfig = observer(({ config, projectRef }: any) => {
       if (response.error) {
         throw response.error
       } else {
-        toast(`Settings saved`)
+        ui.setNotification({ category: 'success', message: 'Successfully saved settings' })
       }
     } catch (error: any) {
-      toast.error(`Update config failed: ${error.message}`)
+      ui.setNotification({
+        error,
+        category: 'error',
+        message: `Failed to update config: ${error.message}`,
+      })
     }
   }
 

--- a/studio/pages/project/[ref]/settings/billing.tsx
+++ b/studio/pages/project/[ref]/settings/billing.tsx
@@ -1,7 +1,6 @@
 import dayjs from 'dayjs'
 import { FC, useEffect, useState } from 'react'
 import { observer } from 'mobx-react-lite'
-import toast from 'react-hot-toast'
 import { Typography, Loading, IconArrowRight } from '@supabase/ui'
 import { get as _get, maxBy } from 'lodash'
 import { Dictionary } from '@supabase/grid'
@@ -79,8 +78,11 @@ const Settings: FC<SettingsProps> = ({ project }) => {
         fetchPaygStatistics()
       }
     } catch (error: any) {
-      console.error(error)
-      toast.error(error.message)
+      ui.setNotification({
+        error,
+        category: 'error',
+        message: `Failed to get subscription: ${error.message}`,
+      })
     } finally {
       setLoading(false)
     }

--- a/studio/pages/support/new.tsx
+++ b/studio/pages/support/new.tsx
@@ -11,7 +11,6 @@ import {
   Typography,
 } from '@supabase/ui'
 import SVG from 'react-inlinesvg'
-import toast from 'react-hot-toast'
 import Link from 'next/link'
 
 import { API_URL } from 'lib/constants'
@@ -49,7 +48,7 @@ function formReducer(state: any, action: any) {
 }
 
 const SupportNew = () => {
-  const { app } = useStore()
+  const { ui, app } = useStore()
   const [formState, formDispatch] = useReducer(formReducer, DEFAULT)
   const [errors, setErrors] = useState<any>([])
   const [loading, setLoading] = useState<boolean>(false)
@@ -150,10 +149,12 @@ const SupportNew = () => {
       })
       setLoading(false)
       if (response.error) {
-        console.error(response.error)
-        toast.error(response.error.message)
+        ui.setNotification({
+          category: 'error',
+          message: `Failed to submit support ticket: ${response.error.message}`,
+        })
       } else {
-        toast.success(`Support request sent. Thank you!`)
+        ui.setNotification({ category: 'success', message: 'Support request sent. Thank you!' })
         setSent(true)
       }
     }

--- a/studio/pages/vercel/setupOrg.tsx
+++ b/studio/pages/vercel/setupOrg.tsx
@@ -1,6 +1,5 @@
 import { FC, createContext, useEffect, useContext, useState } from 'react'
 import { useRouter } from 'next/router'
-import { toast } from 'react-hot-toast'
 import { observer, useLocalObservable } from 'mobx-react-lite'
 import { Transition } from '@headlessui/react'
 import { Button, Typography } from '@supabase/ui'
@@ -79,7 +78,7 @@ const CreateOrganization = observer(({}) => {
   const PageState: any = useContext(PageContext)
   const router = useRouter()
 
-  const { app } = useStore()
+  const { ui, app } = useStore()
   const sortedOrganizations = app.organizations.list()
 
   const [orgName, setOrgName] = useState('')
@@ -91,7 +90,10 @@ const CreateOrganization = observer(({}) => {
       name: orgName,
     })
     if (response.error) {
-      toast.error(response.error.message)
+      ui.setNotification({
+        category: 'error',
+        message: `Failed to set up organization: ${response.error.message}`,
+      })
       setLoading(false)
     } else {
       const org = response

--- a/studio/pages/vercel/setupProject.tsx
+++ b/studio/pages/vercel/setupProject.tsx
@@ -7,6 +7,7 @@ import { debounce } from 'lodash'
 import { Button, Typography } from '@supabase/ui'
 import { Dictionary } from '@supabase/grid'
 
+import { useStore } from 'hooks'
 import { post } from 'lib/common/fetch'
 import {
   PROVIDERS,
@@ -153,6 +154,8 @@ const Connecting = () => (
 const CreateProject = observer(() => {
   const _store = useContext(PageContext)
   const router = useRouter()
+  const { ui } = useStore()
+
   const [projectName, setProjectName] = useState('')
   const [dbPass, setDbPass] = useState('')
   const [passwordStrengthMessage, setPasswordStrengthMessage] = useState('')
@@ -230,7 +233,10 @@ const CreateProject = observer(() => {
       const response = await createSupabaseProject(dbSql)
       if (response.error) {
         setLoading(false)
-        toast.error(response.error.message)
+        ui.setNotification({
+          category: 'error',
+          message: `Failed to create project: ${response.error.message}`,
+        })
         return
       }
 

--- a/studio/types/ui.ts
+++ b/studio/types/ui.ts
@@ -1,5 +1,6 @@
 export interface Notification {
   id?: string
   category: 'info' | 'error' | 'success' | 'loading'
-  message: string
+  message: string // Readable message for users to understand
+  error?: any // Any other errors that needs to be logged out in the console
 }


### PR DESCRIPTION
- Unify all toast messages to be triggered from the UI store
- This is so that have one single point where we can control the behaviour of the messages
- More importantly, this is also to handle all toast error messages, which will be logged out in the browser console
  - Acts as a point of reference for users to self debug if possible, and also for us to debug if users face an issue (ask users to send us a SS of their browser console)

- Note: I didn't touch the files where toast is being used within a store (needs more refactor for next time):
  - StorageExplorerStore.tsx
  - integrate.tsx
  - setupProject.tsx