### PR TITLE
[FEAT] [Studio] Downgrade Next to 11.1.0 due to Windows bug

### DIFF
--- a/studio/package.json
+++ b/studio/package.json
@@ -33,7 +33,7 @@
     "markdown-table": "=2.0.0",
     "mobx": "^6.3.2",
     "mobx-react-lite": "^3.2.0",
-    "next": "11.1.1",
+    "next": "11.1.0",
     "next-compose-plugins": "^2.2.1",
     "openapi-types": "^9.1.0",
     "papaparse": "^5.3.1",


### PR DESCRIPTION
## What kind of change does this PR introduce?

Downgrade Next to 11.1.0 (from 11.1.1) for the `/studio` folder

## What is the current behavior?

When attempting to `npm run dev` the `/studio` folder, the following error is presented:

```
Global CSS cannot be imported from files other than your Custom <App>. 
Due to the Global nature of stylesheets, and to avoid conflicts, 
Please move all first-party global CSS imports to pages/_app.js. 
Or convert the import to Component-Level CSS (CSS Modules).

Read more: https://nextjs.org/docs/messages/css-global
Location: pages/_app.tsx
```

This issue appears to happen on Windows. Source: https://stackoverflow.com/a/69277312

## What is the new behavior?

The version of Next has been downgraded to 11.1.0 (from 11.1.1) for the `/studio` folder. This resolves the error and allows the dashboard to run and build correctly.