### PR TITLE
Remove excessive error checking in saveTable method

### DIFF
--- a/studio/stores/pgmeta/MetaStore.ts
+++ b/studio/stores/pgmeta/MetaStore.ts
@@ -527,8 +527,7 @@ export default class MetaStore implements IMetaStore {
           ...column,
           isPrimaryKey: false,
         })
-        const addedColumn: any = await this.createColumn(columnPayload, column.foreignKey)
-        if (addedColumn.error) throw addedColumn.error
+        await this.createColumn(columnPayload, column.foreignKey)
       } else {
         const originalColumn = find(originalColumns, { id: column.id })
         if (originalColumn) {
@@ -545,13 +544,7 @@ export default class MetaStore implements IMetaStore {
               category: 'loading',
               message: `Updating column ${column.name} from ${updatedTable.name}`,
             })
-            const updatedColumn: any = await this.updateColumn(
-              column.id,
-              columnPayload,
-              updatedTable,
-              column.foreignKey
-            )
-            if (updatedColumn.error) throw updatedColumn.error
+            await this.updateColumn(column.id, columnPayload, updatedTable, column.foreignKey)
           }
         }
       }


### PR DESCRIPTION
Updating columns via the table side panel editor will throw errors because it was overly checking for `.error` from methods which do not return anything

this.createColumn and this.updateColumn do not return anything - they just `throw` errors, hence why doing the `if (createdColumn.error)` check was breaking