### PR TITLE
Fix: Expose anon key to studio in docker-compose

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     environment:
       SUPABASE_URL: http://kong:8000
       STUDIO_PG_META_URL: http://meta:8080
+      SUPABASE_ANON_KEY: ${ANON_KEY}
       SUPABASE_SERVICE_KEY: ${SERVICE_ROLE_KEY}
 
   kong:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix for docker-compose

## What is the current behavior?

Currently if you change the anon key in the .env it does not get exposed to the studio image.

## What is the new behavior?

Expose ANON_KEY environment variable to studio image.
