### PR TITLE
feat(studio): light theme for api docs

### DIFF
--- a/studio/components/to-be-cleaned/Docs/Param.js
+++ b/studio/components/to-be-cleaned/Docs/Param.js
@@ -22,7 +22,7 @@ const Param = ({
       {format && format != type && (
         <div className="mb-4">
           <h5 className="uppercase text-xs font-medium text-gray-400">Format</h5>
-          <code className="p-0 text-sm bg-gray-700">{format}</code>
+          <code className="p-0 text-sm bg-white dark:bg-gray-700">{format}</code>
         </div>
       )}
       {description !== false && (

--- a/studio/pages/project/[ref]/api/index.tsx
+++ b/studio/pages/project/[ref]/api/index.tsx
@@ -134,8 +134,8 @@ const DocView: FC<any> = observer(({}) => {
                 className={`${
                   selectedLang == 'js'
                     ? 'text-gray-600 dark:text-gray-300'
-                    : 'text-gray-400 dark:text-gray-400'
-                } relative inline-flex items-center p-1 px-2 bg-gray-100 dark:bg-gray-600 border-r border-gray-200 dark:border-gray-500 text-sm font-medium hover:text-gray-600 dark:hover:text-gray-300 focus:z-10 focus:outline-none focus:border-blue-300 focus:ring-blue active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150`}
+                    : 'text-gray-300 dark:text-gray-400'
+                } relative inline-flex items-center p-1 px-2 bg-coolGray-100 dark:bg-gray-600 border-r border-gray-200 dark:border-gray-500 text-sm font-medium hover:text-gray-600 dark:hover:text-gray-300 focus:z-10 focus:outline-none focus:border-blue-300 focus:ring-blue active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150`}
               >
                 JavaScript
               </button>
@@ -145,16 +145,16 @@ const DocView: FC<any> = observer(({}) => {
                 className={`${
                   selectedLang == 'bash'
                     ? 'text-gray-600 dark:text-gray-300'
-                    : 'text-gray-400 dark:text-gray-400'
-                } relative inline-flex items-center p-1 px-2 bg-gray-100 dark:bg-gray-600 border-r border-gray-200 dark:border-gray-500 text-sm font-medium hover:text-gray-600 dark:hover:text-gray-300 focus:z-10 focus:outline-none focus:border-blue-300 focus:ring-blue active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150`}
+                    : 'text-gray-300 dark:text-gray-400'
+                } relative inline-flex items-center p-1 px-2 bg-coolGray-100 dark:bg-gray-600 border-r border-gray-200 dark:border-gray-500 text-sm font-medium hover:text-gray-600 dark:hover:text-gray-300 focus:z-10 focus:outline-none focus:border-blue-300 focus:ring-blue active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150`}
               >
                 Bash
               </button>
               {selectedLang == 'bash' && (
                 <div className="flex">
-                  <span className="text-sm text-gray-300 p-1 pl-2">Key:</span>
+                  <span className="text-sm text-gray-600 dark:text-gray-300 p-1 pl-2">Key:</span>
                   <select
-                    className="text-sm text-gray-300 border-none cursor-pointer p-0 pl-2 pr-8"
+                    className="text-sm text-gray-600 dark:text-gray-300 border-none cursor-pointer p-0 pl-2 pr-8"
                     value={showApiKey}
                     onChange={(e) => setShowApiKey(e.target.value)}
                   >
@@ -339,7 +339,7 @@ const ResourceContent = ({
 
   return (
     <>
-      <h2 className="text-white mt-0">
+      <h2 className="text-black dark:text-white mt-0">
         <code className="text-lg px-4 py-2">{resourceId}</code>
       </h2>
 

--- a/studio/pages/project/[ref]/api/index.tsx
+++ b/studio/pages/project/[ref]/api/index.tsx
@@ -124,7 +124,7 @@ const DocView: FC<any> = observer(({}) => {
       <div className="Docs--inner-wrapper">
         <div className="sticky top-0 w-full flex flex-row-reverse z-40 ">
           <div
-            className="border-b border-gray-500 dark:border-gray-500 bg-gray-700"
+            className="border-b border-gray-200 dark:border-gray-500 bg-white dark:bg-gray-700"
             style={{ width: '50%' }}
           >
             <div className="z-0 flex ">
@@ -132,8 +132,10 @@ const DocView: FC<any> = observer(({}) => {
                 type="button"
                 onClick={() => setSelectedLang('js')}
                 className={`${
-                  selectedLang == 'js' ? 'text-gray-300' : 'text-gray-400'
-                } relative inline-flex items-center p-1 px-2 bg-gray-600 border-r border-gray-500 dark:border-gray-500 text-sm font-medium hover:text-gray-300 focus:z-10 focus:outline-none focus:border-blue-300 focus:ring-blue active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150`}
+                  selectedLang == 'js'
+                    ? 'text-gray-600 dark:text-gray-300'
+                    : 'text-gray-400 dark:text-gray-400'
+                } relative inline-flex items-center p-1 px-2 bg-gray-100 dark:bg-gray-600 border-r border-gray-200 dark:border-gray-500 text-sm font-medium hover:text-gray-600 dark:hover:text-gray-300 focus:z-10 focus:outline-none focus:border-blue-300 focus:ring-blue active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150`}
               >
                 JavaScript
               </button>
@@ -141,8 +143,10 @@ const DocView: FC<any> = observer(({}) => {
                 type="button"
                 onClick={() => setSelectedLang('bash')}
                 className={`${
-                  selectedLang == 'bash' ? 'text-gray-300' : 'text-gray-400'
-                } relative inline-flex items-center p-1 px-2 bg-gray-600 border-r border-gray-500 dark:border-gray-500 text-sm font-medium hover:text-gray-300 focus:z-10 focus:outline-none focus:border-blue-300 focus:ring-blue active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150`}
+                  selectedLang == 'bash'
+                    ? 'text-gray-600 dark:text-gray-300'
+                    : 'text-gray-400 dark:text-gray-400'
+                } relative inline-flex items-center p-1 px-2 bg-gray-100 dark:bg-gray-600 border-r border-gray-200 dark:border-gray-500 text-sm font-medium hover:text-gray-600 dark:hover:text-gray-300 focus:z-10 focus:outline-none focus:border-blue-300 focus:ring-blue active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150`}
               >
                 Bash
               </button>
@@ -533,8 +537,8 @@ const ResourceContent = ({
         <div className="doc-section">
           <article className="text ">
             <p>
-              Supabase provides realtime functionality and broadcasts database changes to authorized users depending on Row Level
-              Security (RLS) policies.
+              Supabase provides realtime functionality and broadcasts database changes to authorized
+              users depending on Row Level Security (RLS) policies.
             </p>
             <p>
               <a href="https://supabase.com/docs/client/subscribe" target="_blank">

--- a/studio/styles/code.scss
+++ b/studio/styles/code.scss
@@ -69,7 +69,6 @@
   }
 
   .codeBlock {
-    @apply bg-gray-600;
     margin-bottom: 0;
     overflow: hidden;
     overflow-wrap: break-word;

--- a/studio/styles/code.scss
+++ b/studio/styles/code.scss
@@ -49,11 +49,6 @@
     @apply text-green-500 #{!important};
   }
 
-  .token.console {
-    font-style: normal !important;
-    @apply text-teal-600 dark:text-teal-400 #{!important};
-  }
-
   .token.constant {
     font-style: normal !important;
     @apply text-blue-600 dark:text-blue-300 #{!important};

--- a/studio/styles/code.scss
+++ b/studio/styles/code.scss
@@ -14,10 +14,15 @@
     @apply text-sm;
   }
 
+  .token.imports,
+  .token.property-access {
+    @apply text-blueGray-500 dark:text-blueGray-300 #{!important};
+  }
+
   .token.keyword.module,
   .token.function {
     font-style: normal !important;
-    color: #ccc !important;
+    @apply text-gray-600 dark:text-gray-300 #{!important};
   }
 
   .token.plain,
@@ -30,42 +35,42 @@
   .token.doc-comment.parameter.punctuation,
   .token.doc-comment.optional-parameter.punctuation {
     font-style: normal !important;
-    color: #ccc !important;
+    @apply text-gray-600 dark:text-gray-300 #{!important};
   }
 
   .token.keyword,
   .token.doc-comment.keyword {
     font-style: normal !important;
-    color: #569cd6 !important;
+    @apply text-blue-600 dark:text-blue-300 #{!important};
   }
 
   .token.string {
     font-style: normal !important;
-    color: #24b47e !important;
+    @apply text-green-500 #{!important};
   }
 
   .token.console {
     font-style: normal !important;
-    color: #49c1ad !important;
+    @apply text-teal-600 dark:text-teal-400 #{!important};
   }
 
   .token.constant {
     font-style: normal !important;
-    color: #569cd6 !important;
+    @apply text-blue-600 dark:text-blue-300 #{!important};
   }
 
   .token.comment {
     font-style: normal !important;
-    color: #666 !important;
+    @apply text-gray-300 dark:text-gray-400 #{!important};
   }
 
   .token.number {
-    color: #b5cea8 !important;
+    @apply text-green-600 dark:text-green-200 #{!important};
   }
 
   .token.boolean,
   .token.doc-comment.class-name {
-    @apply text-green-500;
+    @apply text-green-500 dark:text-green-500;
   }
 
   .codeBlock {

--- a/studio/styles/main.scss
+++ b/studio/styles/main.scss
@@ -144,7 +144,7 @@ input[type='radio'] {
 }
 
 code {
-  @apply p-1 m-0 font-mono text-sm bg-gray-600 rounded;
+  @apply p-1 m-0 font-mono text-sm bg-gray-100 dark:bg-gray-600 rounded;
 }
 
 div[data-radix-portal]:not(.portal--toast) {

--- a/studio/styles/ui.scss
+++ b/studio/styles/ui.scss
@@ -195,12 +195,12 @@ label:not(.sbui-formlayout__label):not(.sbui-checkbox__label-container__label):n
 /* Docs */
 .Docs {
   &--inner-wrapper {
-    background: linear-gradient(90deg, #ffffff 50%, #eeeeee 50%);
+    background: linear-gradient(90deg, #ffffff 50%, #f3f4f6 50%); /* bg-white bg-coolGray-100 */
     width: 100%;
   }
 
   .dark &--inner-wrapper {
-    background: linear-gradient(90deg, #1f1f1f 50%, #2a2a2a 50%);
+    background: linear-gradient(90deg, #1f1f1f 50%, #2a2a2a 50%); /* bg-gray-700 bg-gray-600 */
   }
 
   h1,

--- a/studio/styles/ui.scss
+++ b/studio/styles/ui.scss
@@ -195,8 +195,12 @@ label:not(.sbui-formlayout__label):not(.sbui-checkbox__label-container__label):n
 /* Docs */
 .Docs {
   &--inner-wrapper {
-    background: linear-gradient(90deg, #1f1f1f 50%, #2a2a2a 50%);
+    background: linear-gradient(90deg, #ffffff 50%, #eeeeee 50%);
     width: 100%;
+  }
+
+  .dark &--inner-wrapper {
+    background: linear-gradient(90deg, #1f1f1f 50%, #2a2a2a 50%);
   }
 
   h1,
@@ -206,13 +210,13 @@ label:not(.sbui-formlayout__label):not(.sbui-checkbox__label-container__label):n
   }
 
   .doc-heading {
-    @apply text-white capitalize mt-4 w-1/2;
+    @apply text-black dark:text-white capitalize mt-4 w-1/2;
     hyphens: auto;
     max-width: 50%;
   }
 
   .doc-section {
-    @apply border-b dark:border-dark text-gray-300 flex;
+    @apply border-b dark:border-dark text-gray-600 dark:text-gray-300 flex;
   }
 
   .text {
@@ -233,7 +237,7 @@ label:not(.sbui-formlayout__label):not(.sbui-checkbox__label-container__label):n
   }
 
   .code {
-    @apply flex-1 p-2 w-1/2 bg-gray-600 pb-4;
+    @apply flex-1 p-2 w-1/2 pb-4;
     max-width: 50%;
 
     h4 {

--- a/studio/tailwind.config.js
+++ b/studio/tailwind.config.js
@@ -48,19 +48,6 @@ const coolGray = {
   900: '#111827',
 }
 
-const teal = {
-  50: '#f0fdfa',
-  100: '#ccfbf1',
-  200: '#99f6e4',
-  300: '#5eead4',
-  400: '#2dd4bf',
-  500: '#14b8a6',
-  600: '#0d9488',
-  700: '#0f766e',
-  800: '#115e59',
-  900: '#134e4a',
-}
-
 module.exports = {
   mode: 'jit',
   darkMode: 'class', // or 'media' or 'class'
@@ -90,7 +77,6 @@ module.exports = {
         green: { ...green },
         blueGray: { ...blueGray },
         coolGray: { ...coolGray },
-        teal: { ...teal },
 
         /*  typography */
         'typography-body': {

--- a/studio/tailwind.config.js
+++ b/studio/tailwind.config.js
@@ -48,6 +48,19 @@ const coolGray = {
   900: '#111827',
 }
 
+const teal = {
+  50: '#f0fdfa',
+  100: '#ccfbf1',
+  200: '#99f6e4',
+  300: '#5eead4',
+  400: '#2dd4bf',
+  500: '#14b8a6',
+  600: '#0d9488',
+  700: '#0f766e',
+  800: '#115e59',
+  900: '#134e4a',
+}
+
 module.exports = {
   mode: 'jit',
   darkMode: 'class', // or 'media' or 'class'
@@ -77,6 +90,7 @@ module.exports = {
         green: { ...green },
         blueGray: { ...blueGray },
         coolGray: { ...coolGray },
+        teal: { ...teal },
 
         /*  typography */
         'typography-body': {


### PR DESCRIPTION
**Description**

Closes #4330. The background for documentation is set as a `linear-gradient` from `white` to `coolGray-100`. The text color is set to `gray-600` and their respective headings are in `black`. Colors for syntax highlighting are also updated to support light theme and are derived from tailwind classes.

<details>
<summary>Screenshots</summary>
<br />

![image](https://user-images.githubusercontent.com/86551248/145679007-c44e97ec-4482-4445-b852-92a7d0160514.png)
![image](https://user-images.githubusercontent.com/86551248/145679025-3786297a-da7a-4397-80c2-d03f9e31d6cc.png)
![image](https://user-images.githubusercontent.com/86551248/145679054-8745f76f-24a9-4a7c-ad39-624f9f1ef7a8.png)

</details>

Edit: Changelog updated for commit 817e325b68dabc18f9ae1e13abd06ea3e8b1dcc2.