### PR TITLE
load sql query from previous session

### DIFF
--- a/studio/pages/project/[ref]/sql/index.tsx
+++ b/studio/pages/project/[ref]/sql/index.tsx
@@ -41,7 +41,7 @@ const PageConfig = () => {
    */
   async function loadPersistantData() {
     if (sqlEditorStore === undefined) return
-    sqlEditorStore.loadRemotePersistentData(contentStore, (user as any)?.id)
+    await sqlEditorStore.loadRemotePersistentData(contentStore, (user as any)?.id)
   }
 
   return (


### PR DESCRIPTION
## What kind of change does this PR introduce?

Resolves https://github.com/supabase/supabase/issues/4323
Low-hanging UX fruit: Load sql query from previous session if available