### PR TITLE
Fix org page links broken

### DIFF
--- a/studio/components/layouts/AccountLayout/AccountLayout.tsx
+++ b/studio/components/layouts/AccountLayout/AccountLayout.tsx
@@ -24,8 +24,7 @@ const AccountLayout = ({ children, title, breadcrumbs }: any) => {
     .map((x: any) => ({
       isActive: router.pathname.startsWith('/org/') && ui.selectedOrganization?.slug == x.slug,
       label: x.name,
-      href: '/org/[slug]/settings',
-      as: `/org/${x.slug}/settings`,
+      href: `/org/${x.slug}/settings`,
     }))
     .sort((a, b) => a.label.localeCompare(b.label))
 


### PR DESCRIPTION
Did a mistake in my previous refactor while removing `as` property for all `Link` components, broke the links in the org page