### PR TITLE
Chore/improve csv import error handling

### DIFF
--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/SpreadsheetImport/SpreadSheetFileUpload.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/SpreadsheetImport/SpreadSheetFileUpload.tsx
@@ -1,5 +1,5 @@
 import { DragEvent, useRef, useState, FC } from 'react'
-import { Button, Typography, IconLoader } from '@supabase/ui'
+import { Button, Typography, IconLoader, IconFileText } from '@supabase/ui'
 import SparkBar from 'components/ui/SparkBar'
 
 interface Props {
@@ -62,8 +62,11 @@ const SpreadSheetFileUpload: FC<Props> = ({
           </Typography.Text>
         </div>
       ) : (
-        <div className="flex flex-col items-center justify-center border dark:border-gray-500 border-dashed rounded-md h-48">
-          <Typography.Title level={4}>{uploadedFile.name}</Typography.Title>
+        <div className="flex flex-col items-center justify-center border dark:border-gray-500 border-dashed rounded-md h-32 space-y-2">
+          <div className="flex items-center space-x-2">
+            <IconFileText size={16} strokeWidth={2} />
+            <Typography.Title level={4}>{uploadedFile.name}</Typography.Title>
+          </div>
           {parseProgress === 100 ? (
             <Button type="outline" onClick={removeUploadedFile}>
               Remove File

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/SpreadsheetImport/SpreadsheetImport.constants.ts
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/SpreadsheetImport/SpreadsheetImport.constants.ts
@@ -1,5 +1,14 @@
+import { SpreadsheetData } from './SpreadsheetImport.types'
+
 export const UPLOAD_FILE_TYPES = [
   'text/csv',
   'text/tab-separated-values',
   'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
 ]
+
+export const EMPTY_SPREADSHEET_DATA: SpreadsheetData = {
+  headers: [],
+  rows: [],
+  rowCount: 0,
+  columnTypeMap: {},
+}

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/SpreadsheetImport/SpreadsheetImport.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/SpreadsheetImport/SpreadsheetImport.tsx
@@ -1,12 +1,12 @@
 import { useCallback, useState, FC, useEffect } from 'react'
 import { debounce, includes } from 'lodash'
-import { SidePanel, Typography } from '@supabase/ui'
+import { SidePanel, Typography, Tabs, IconArrowRight, IconChevronRight } from '@supabase/ui'
 
 import { useStore } from 'hooks'
-import Telemetry from 'lib/telemetry'
 import ActionBar from '../../ActionBar'
 import SpreadSheetTextInput from './SpreadSheetTextInput'
 import SpreadSheetFileUpload from './SpreadSheetFileUpload'
+import SpreadsheetPreview from './SpreadsheetPreview'
 import { SpreadsheetData } from './SpreadsheetImport.types'
 import { parseSpreadsheet, parseSpreadsheetText } from './SpreadsheetImport.utils'
 import { UPLOAD_FILE_TYPES, EMPTY_SPREADSHEET_DATA } from './SpreadsheetImport.constants'
@@ -33,24 +33,22 @@ const SpreadsheetImport: FC<Props> = ({
   useEffect(() => {
     if (visible) {
       if (headers.length === 0) {
-        setSpreadsheetData(EMPTY_SPREADSHEET_DATA)
-        setUploadedFile(null)
+        resetSpreadsheetImport()
       }
     }
   }, [visible])
 
+  const [input, setInput] = useState<string>('')
+  const [uploadedFile, setUploadedFile] = useState<any>(null)
+  const [parseProgress, setParseProgress] = useState<number>(0)
   const [spreadsheetData, setSpreadsheetData] = useState<SpreadsheetData>({
     headers: headers,
     rows: rows,
     rowCount: 0,
     columnTypeMap: {},
   })
-
-  const [input, setInput] = useState<string>('')
-  const [uploadedFile, setUploadedFile] = useState<any>(null)
-
-  const [view, setView] = useState<string>('fileUpload')
-  const [parseProgress, setParseProgress] = useState<number>(0)
+  const [errors, setErrors] = useState<any>([])
+  const [expandedErrors, setExpandedErrors] = useState<string[]>([])
 
   const onProgressUpdate = (progress: number) => {
     setParseProgress(progress)
@@ -71,48 +69,37 @@ const SpreadsheetImport: FC<Props> = ({
         file,
         onProgressUpdate
       )
-      if (errors.length <= 5) {
-        errors.map((error: any) => {
-          ui.setNotification({
-            category: 'error',
-            message: `Error found at row ${error.row} - ${error.type}: ${error.code}`,
-          })
-        })
-      } else if (errors.length > 5) {
+      if (errors.length > 0) {
         ui.setNotification({
           error: errors,
           category: 'error',
-          message: `Multiple errors have been detected on ${errors.length} rows. Do check the file you have uploaded for any discrepancies.`,
+          message: `Some issues have been detected on ${errors.length} rows. More details below the content preview.`,
         })
       }
+      setErrors(errors)
       setSpreadsheetData({ headers, rows: [], rowCount, columnTypeMap })
     }
     event.target.value = ''
   }
 
-  const removeUploadedFile = () => {
+  const resetSpreadsheetImport = () => {
     setSpreadsheetData(EMPTY_SPREADSHEET_DATA)
     setUploadedFile(null)
+    setErrors([])
+    setExpandedErrors([])
   }
 
   const readSpreadsheetText = async (text: string) => {
     if (text.length > 0) {
       const { headers, rows, errors } = await parseSpreadsheetText(text)
-      if (errors.length <= 5) {
-        errors.map((error: any) => {
-          ui.setNotification({
-            error,
-            category: 'error',
-            message: `Error found at row ${error.row || 0} - ${error.type}: ${error.code}`,
-          })
-        })
-      } else if (errors.length > 5) {
+      if (errors.length > 0) {
         ui.setNotification({
           error: errors,
           category: 'error',
-          message: `Multiple errors have been detected on ${errors.length} rows. Do check your input for any discrepancies.`,
+          message: `Some issues have been detected on ${errors.length} rows. More details below the content preview.`,
         })
       }
+      setErrors(errors)
       setSpreadsheetData({ headers, rows, rowCount: rows.length, columnTypeMap: {} })
     } else {
       setSpreadsheetData(EMPTY_SPREADSHEET_DATA)
@@ -125,13 +112,25 @@ const SpreadsheetImport: FC<Props> = ({
     handler(event.target.value)
   }
 
+  const onSelectExpandError = (key: string) => {
+    if (expandedErrors.includes(key)) {
+      setExpandedErrors(expandedErrors.filter((error) => error !== key))
+    } else {
+      setExpandedErrors(expandedErrors.concat([key]))
+    }
+  }
+
   return (
     <SidePanel
       wide
       visible={visible}
       align="right"
       title="Add content to new table"
-      onCancel={closePanel}
+      onCancel={(event: any) => {
+        // Only close if specifically hit the X button, this is to have the
+        // side panel work with toast messages (clicking on toast will close the panel)
+        if (event?.target) closePanel()
+      }}
       customFooter={
         <ActionBar
           backButtonLabel="Cancel"
@@ -142,72 +141,83 @@ const SpreadsheetImport: FC<Props> = ({
               file: uploadedFile,
               ...spreadsheetData,
             })
-            Telemetry.sendEvent('table_editor', 'spreadsheet_import_method', view)
           }}
         />
       }
     >
       <div className="flex flex-col">
-        <div className="flex items-center justify-center border dark:border-dark rounded-md w-full mb-4">
-          <div
-            className={`
-              flex items-center justify-center w-1/2 p-2 cursor-pointer hover:bg-bg-secondary-light dark:hover:bg-bg-alt-dark
-              transition ease-in-out duration-150 border-r dark:border-dark
-              ${
-                view === 'fileUpload'
-                  ? ' text-typography-body-light dark:text-typography-body-dark bg-bg-alt-light dark:bg-bg-alt-dark'
-                  : ' text-typography-body-secondary-light dark:text-typography-body-secondary-dark'
-              }
-            `}
-            onClick={() => setView('fileUpload')}
-          >
-            <p className="text-sm">Upload CSV</p>
-          </div>
-          <div
-            className={`
-              flex items-center justify-center w-1/2 p-2 cursor-pointer hover:bg-bg-secondary-light dark:hover:bg-bg-alt-dark
-              transition ease-in-out duration-150
-              ${
-                view === 'pasteText'
-                  ? ' text-typography-body-light dark:text-typography-body-dark bg-bg-alt-light dark:bg-bg-alt-dark'
-                  : ' text-typography-body-secondary-light dark:text-typography-body-secondary-dark'
-              }
-            `}
-            onClick={() => setView('pasteText')}
-          >
-            <p className="text-sm">Paste Text</p>
-          </div>
-        </div>
-
-        {view === 'pasteText' ? (
-          <SpreadSheetTextInput input={input} onInputChange={onInputChange} />
-        ) : (
-          <SpreadSheetFileUpload
-            parseProgress={parseProgress}
-            uploadedFile={uploadedFile}
-            onFileUpload={onFileUpload}
-            removeUploadedFile={removeUploadedFile}
-          />
-        )}
+        <Tabs block>
+          {/* @ts-ignore */}
+          <Tabs.Panel id="fileUpload" label="Upload CSV">
+            <SpreadSheetFileUpload
+              parseProgress={parseProgress}
+              uploadedFile={uploadedFile}
+              onFileUpload={onFileUpload}
+              removeUploadedFile={resetSpreadsheetImport}
+            />
+          </Tabs.Panel>
+          {/* @ts-ignore */}
+          <Tabs.Panel id="pasteText" label="Paste text">
+            <SpreadSheetTextInput input={input} onInputChange={onInputChange} />
+          </Tabs.Panel>
+        </Tabs>
       </div>
+
       {spreadsheetData.headers.length > 0 && (
-        <div className="py-5">
-          <Typography.Text>
-            <p>Content Preview</p>
-            <p className="mt-2 text-sm">
-              Your table will have {spreadsheetData.rowCount.toLocaleString()} rows and the
-              following {spreadsheetData.headers.length} columns.
-            </p>
-          </Typography.Text>
-          <div className="flex flex-wrap items-center mt-3">
-            {spreadsheetData.headers.map((header: string) => (
-              <Typography.Text key={`preview_${header}`}>
-                <div className="rounded-md border dark:border-gray-500 border-dashed py-1 px-3 mr-2 mb-2 text-sm">
-                  {header}
-                </div>
+        <div className="py-5 space-y-5">
+          <div className="space-y-2">
+            <div className="flex flex-col space-y-1">
+              <Typography.Text>Content Preview</Typography.Text>
+              <Typography.Text type="secondary">
+                Your table will have {spreadsheetData.rowCount.toLocaleString()} rows and the
+                following {spreadsheetData.headers.length} columns.
               </Typography.Text>
-            ))}
+            </div>
+            <SpreadsheetPreview headers={spreadsheetData.headers} />
           </div>
+          {errors.length > 0 && (
+            <div className="space-y-2">
+              <div className="flex flex-col space-y-1">
+                <Typography.Text>Issues found in spreadsheet</Typography.Text>
+                <Typography.Text type="secondary">
+                  Your table can still be created nonetheless despite issues in the following rows.
+                </Typography.Text>
+              </div>
+              <div className="space-y-2">
+                {errors.map((error: any, idx: number) => {
+                  const key = `import-error-${idx}`
+                  const isExpanded = expandedErrors.includes(key)
+                  return (
+                    <div className="space-y-2">
+                      <div key={key} className="flex items-center space-x-2">
+                        <IconChevronRight
+                          className={`cursor-pointer transform ${isExpanded ? 'rotate-90' : ''}`}
+                          size={14}
+                          onClick={() => onSelectExpandError(key)}
+                        />
+                        <Typography.Text className="w-14">Row: {error.row}</Typography.Text>
+                        <Typography.Text>{error.message}</Typography.Text>
+                        {error.data?.__parsed_extra && (
+                          <>
+                            <IconArrowRight size={14} />
+                            <Typography.Text>Extra field(s):</Typography.Text>
+                            {error.data?.__parsed_extra.map((value: any) => (
+                              <Typography.Text code small>
+                                {value}
+                              </Typography.Text>
+                            ))}
+                          </>
+                        )}
+                      </div>
+                      {isExpanded && (
+                        <SpreadsheetPreview headers={spreadsheetData.headers} rows={[error.data]} />
+                      )}
+                    </div>
+                  )
+                })}
+              </div>
+            </div>
+          )}
         </div>
       )}
     </SidePanel>

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/SpreadsheetImport/SpreadsheetImport.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/SpreadsheetImport/SpreadsheetImport.tsx
@@ -83,6 +83,7 @@ const SpreadsheetImport: FC<Props> = ({
   }
 
   const resetSpreadsheetImport = () => {
+    setInput('')
     setSpreadsheetData(EMPTY_SPREADSHEET_DATA)
     setUploadedFile(null)
     setErrors([])
@@ -91,7 +92,7 @@ const SpreadsheetImport: FC<Props> = ({
 
   const readSpreadsheetText = async (text: string) => {
     if (text.length > 0) {
-      const { headers, rows, errors } = await parseSpreadsheetText(text)
+      const { headers, rows, columnTypeMap, errors } = await parseSpreadsheetText(text)
       if (errors.length > 0) {
         ui.setNotification({
           error: errors,
@@ -100,7 +101,7 @@ const SpreadsheetImport: FC<Props> = ({
         })
       }
       setErrors(errors)
-      setSpreadsheetData({ headers, rows, rowCount: rows.length, columnTypeMap: {} })
+      setSpreadsheetData({ headers, rows, rowCount: rows.length, columnTypeMap })
     } else {
       setSpreadsheetData(EMPTY_SPREADSHEET_DATA)
     }

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/SpreadsheetImport/SpreadsheetImport.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/SpreadsheetImport/SpreadsheetImport.tsx
@@ -33,6 +33,7 @@ const SpreadsheetImport: FC<Props> = ({
     headers: headers,
     rows: rows,
     rowCount: 0,
+    columnTypeMap: {},
   })
 
   const [input, setInput] = useState<string>('')
@@ -56,7 +57,7 @@ const SpreadsheetImport: FC<Props> = ({
       })
     } else {
       setUploadedFile(file)
-      const { headers, rowCount, rowPreview, errors } = await parseSpreadsheet(
+      const { headers, rowCount, columnTypeMap, errors } = await parseSpreadsheet(
         file,
         onProgressUpdate
       )
@@ -74,13 +75,13 @@ const SpreadsheetImport: FC<Props> = ({
           message: `Multiple errors have been detected on ${errors.length} rows. Do check the file you have uploaded for any discrepancies.`,
         })
       }
-      setSpreadsheetData({ headers, rowCount, rows: rowPreview })
+      setSpreadsheetData({ headers, rows: [], rowCount, columnTypeMap })
     }
     event.target.value = ''
   }
 
   const removeUploadedFile = () => {
-    setSpreadsheetData({ headers: [], rows: [], rowCount: 0 })
+    setSpreadsheetData({ headers: [], rows: [], rowCount: 0, columnTypeMap: {} })
     setUploadedFile(null)
   }
 
@@ -102,9 +103,9 @@ const SpreadsheetImport: FC<Props> = ({
           message: `Multiple errors have been detected on ${errors.length} rows. Do check your input for any discrepancies.`,
         })
       }
-      setSpreadsheetData({ headers, rows, rowCount: rows.length })
+      setSpreadsheetData({ headers, rows, rowCount: rows.length, columnTypeMap: {} })
     } else {
-      setSpreadsheetData({ headers: [], rows: [], rowCount: 0 })
+      setSpreadsheetData({ headers: [], rows: [], rowCount: 0, columnTypeMap: {} })
     }
   }
 

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/SpreadsheetImport/SpreadsheetImport.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/SpreadsheetImport/SpreadsheetImport.tsx
@@ -188,8 +188,8 @@ const SpreadsheetImport: FC<Props> = ({
                   const key = `import-error-${idx}`
                   const isExpanded = expandedErrors.includes(key)
                   return (
-                    <div className="space-y-2">
-                      <div key={key} className="flex items-center space-x-2">
+                    <div key={key} className="space-y-2">
+                      <div className="flex items-center space-x-2">
                         <IconChevronRight
                           className={`cursor-pointer transform ${isExpanded ? 'rotate-90' : ''}`}
                           size={14}

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/SpreadsheetImport/SpreadsheetImport.types.ts
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/SpreadsheetImport/SpreadsheetImport.types.ts
@@ -1,0 +1,8 @@
+import { Dictionary } from '@supabase/grid'
+
+export interface SpreadsheetData {
+  headers: string[]
+  rows: any[]
+  rowCount: number
+  columnTypeMap: Dictionary<string>
+}

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/SpreadsheetImport/SpreadsheetImport.utils.ts
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/SpreadsheetImport/SpreadsheetImport.utils.ts
@@ -1,4 +1,7 @@
+import dayjs from 'dayjs'
 import Papa from 'papaparse'
+import { has, includes } from 'lodash'
+import { tryParseJson } from 'lib/helpers'
 
 const CHUNK_SIZE = 1024 * 1024 * 0.25 // 0.25MB
 
@@ -30,8 +33,10 @@ export const parseSpreadsheet = (file: File, onProgressUpdate: (progress: number
   let headers: string[] = []
   let chunkNumber = 0
   let rowCount = 0
-  const rowPreview: any[] = []
+
+  const columnTypeMap: any = {}
   const errors: any[] = []
+
   return new Promise((resolve) => {
     Papa.parse(file, {
       header: true,
@@ -43,9 +48,14 @@ export const parseSpreadsheet = (file: File, onProgressUpdate: (progress: number
       chunk: (results) => {
         headers = results.meta.fields as string[]
 
-        if (rowCount === 0) {
-          rowPreview.push(...results.data.slice(0, 50))
-        }
+        headers.forEach((header) => {
+          const type = inferColumnType(header, results.data as any[])
+          if (!has(columnTypeMap, header)) {
+            columnTypeMap[header] = type
+          } else if (columnTypeMap[header] !== type) {
+            columnTypeMap[header] = 'text'
+          }
+        })
 
         rowCount += results.data.length
 
@@ -58,7 +68,7 @@ export const parseSpreadsheet = (file: File, onProgressUpdate: (progress: number
         onProgressUpdate(progress > 1 ? 100 : Number((progress * 100).toFixed(2)))
       },
       complete: () => {
-        const data = { headers, rowCount, rowPreview, errors }
+        const data = { headers, rowCount, columnTypeMap, errors }
         resolve(data)
       },
     })
@@ -67,4 +77,57 @@ export const parseSpreadsheet = (file: File, onProgressUpdate: (progress: number
 
 export const revertSpreadsheet = (headers: string[], rows: any[]) => {
   return Papa.unparse(rows, { columns: headers })
+}
+
+const inferColumnType = (column: string, rows: object[]) => {
+  // General strategy is to check the first row first, before checking across all the rows
+  // to ensure uniformity in data type. Thinking we do this as an optimization instead of
+  // checking all the rows up front.
+
+  // If there are no rows to infer for, default to text
+  if (rows.length === 0) return 'text'
+
+  const columnData = (rows[0] as any)[column]
+  const columnDataAcrossRows = rows.map((row: object) => (row as any)[column])
+
+  // Unable to infer any type as there's no data, default to text
+  if (!columnData) {
+    return 'text'
+  }
+
+  // Infer numerical data type (defaults to either int8 or float8)
+  if (Number(columnData)) {
+    const columnNumberCheck = rows.map((row: object) => Number((row as any)[column]))
+    if (columnNumberCheck.includes(NaN)) {
+      return 'text'
+    } else {
+      const columnFloatCheck = columnNumberCheck.map((num: number) => num % 1)
+      return columnFloatCheck.every((item) => item === 0) ? 'int8' : 'float8'
+    }
+  }
+
+  // Infer boolean type
+  if (includes(['true', 'false'], columnData.toLowerCase())) {
+    const isAllBoolean = columnDataAcrossRows.every((item: any) =>
+      includes(['true', 'false'], item.toLowerCase())
+    )
+    if (isAllBoolean) {
+      return 'boolean'
+    }
+  }
+
+  // Infer json type
+  if (tryParseJson(columnData)) {
+    const isAllJson = columnDataAcrossRows.every((item: any) => tryParseJson(columnData))
+    if (isAllJson) {
+      return 'jsonb'
+    }
+  }
+
+  // Infer datetime type
+  if (dayjs(columnData, 'YYYY-MM-DD hh:mm:ss').isValid() && Date.parse(columnData)) {
+    return 'timestamptz'
+  }
+
+  return 'text'
 }

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/SpreadsheetImport/SpreadsheetImport.utils.ts
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/SpreadsheetImport/SpreadsheetImport.utils.ts
@@ -24,12 +24,12 @@ export const parseSpreadsheetText: any = (text: string) => {
 /**
  * For SpreadsheetImport side panel
  * @param file File object (CSV or TSV)
- * @returns {Object<headers, rows, errors>}
- * headers: String[]
- * rows: any[]
- * errors: Object[]
+ * @returns SpreadsheetData
  */
-export const parseSpreadsheet = (file: File, onProgressUpdate: (progress: number) => void): any => {
+export const parseSpreadsheet = (
+  file: File,
+  onProgressUpdate: (progress: number) => void
+): Promise<any> => {
   let headers: string[] = []
   let chunkNumber = 0
   let rowCount = 0
@@ -60,7 +60,10 @@ export const parseSpreadsheet = (file: File, onProgressUpdate: (progress: number
         rowCount += results.data.length
 
         if (results.errors.length > 0) {
-          errors.push(...results.errors)
+          const formattedErrors = results.errors.map((error) => {
+            return { ...error, data: results.data[error.row] }
+          })
+          errors.push(...formattedErrors)
         }
 
         chunkNumber += 1

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/SpreadsheetImport/SpreadsheetPreview.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/SpreadsheetImport/SpreadsheetPreview.tsx
@@ -1,0 +1,39 @@
+import { FC } from 'react'
+import { isUndefined } from 'lodash'
+import DataGrid from '@supabase/react-data-grid'
+import { Typography } from '@supabase/ui'
+
+interface Props {
+  headers: string[]
+  rows?: any[]
+}
+
+const SpreadsheetPreview: FC<Props> = ({ headers = [], rows = [] }) => {
+  return (
+    <DataGrid
+      columns={headers.map((header) => {
+        return {
+          key: header,
+          name: header,
+          width: header.length * 10,
+          resizable: true,
+          headerRenderer: () => (
+            <div className="flex items-center justify-center font-mono h-full">
+              <Typography.Text small>{header}</Typography.Text>
+            </div>
+          ),
+          formatter: ({ row }: { row: any }) => (
+            <span className="font-mono text-xs">
+              {isUndefined(row[header]) ? 'NULL' : row[header]}
+            </span>
+          ),
+        }
+      })}
+      rows={rows}
+      className="!border-l !border-r"
+      style={{ height: `${34 + 34 * rows.length}px` }}
+    />
+  )
+}
+
+export default SpreadsheetPreview

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.types.ts
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.types.ts
@@ -1,3 +1,4 @@
+import { Dictionary } from '@supabase/grid'
 import { ColumnField } from '../SidePanelEditor.types'
 
 export interface TableField {
@@ -13,4 +14,5 @@ export interface ImportContent {
   headers: string[]
   rowCount: number
   rows: object[]
+  columnTypeMap: Dictionary<any>
 }

--- a/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
+++ b/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
@@ -75,7 +75,9 @@ const TableEditorMenu: FC<Props> = ({
   }
 
   const schemas: PostgresSchema[] = meta.schemas.list()
-  const tables: PostgresTable[] = meta.tables.list((table: PostgresTable) => table.schema === selectedSchema)
+  const tables: PostgresTable[] = meta.tables.list(
+    (table: PostgresTable) => table.schema === selectedSchema
+  )
 
   const schemaTables =
     searchText.length === 0
@@ -89,7 +91,7 @@ const TableEditorMenu: FC<Props> = ({
 
   // Temp fix - Ideally we'd just take up all the remaining space but
   // can't seem to figure that out immediately
-  const maxScrollHeight = schemaViews.length > 0 ? 270 : 520
+  const maxScrollHeight = schemaViews.length > 0 ? 270 : 515
 
   return (
     <div className="my-6 flex flex-col flex-grow">

--- a/studio/stores/pgmeta/MetaStore.ts
+++ b/studio/stores/pgmeta/MetaStore.ts
@@ -432,15 +432,16 @@ export default class MetaStore implements IMetaStore {
           }
 
           if (!isUndefined(error)) {
-            this.rootStore.ui.setNotification({
-              id: toastId,
-              category: 'error',
-              message: `Table ${table.name} has been created but we ran into an error while inserting rows:
-            ${error.message} - ${error.details}`,
-            })
+            console.log(error)
             this.rootStore.ui.setNotification({
               category: 'error',
               message: 'Do check your spreadsheet if there are any discrepancies.',
+            })
+            this.rootStore.ui.setNotification({
+              category: 'error',
+              message: `Table ${table.name} has been created but we ran into an error while inserting rows:
+            ${error.message}`,
+              error,
             })
           }
         } else {

--- a/studio/stores/pgmeta/MetaStore.ts
+++ b/studio/stores/pgmeta/MetaStore.ts
@@ -432,7 +432,6 @@ export default class MetaStore implements IMetaStore {
           }
 
           if (!isUndefined(error)) {
-            console.log(error)
             this.rootStore.ui.setNotification({
               category: 'error',
               message: 'Do check your spreadsheet if there are any discrepancies.',


### PR DESCRIPTION
More details here on the thought process of around "better error handling at CSV import":
https://www.notion.so/supabase/CSV-Better-error-handling-77fa6d90fb1e4a20b8bbe2afebaa4e24
Rough aim is to give enough information to allow the users to self-debug

Broadly, there's 2 parts to where things can go wrong when importing CSV to create a table
- At the CSV parsing step
- At the table creation step

This PR address the former by showing users exactly which are the offending rows and persists the hints (instead of hiding them behind toast messages) (and along with a couple of cosmetic updates)
<video src="https://user-images.githubusercontent.com/19742402/145961866-44138d9c-9647-4562-b309-f6c9f790ac1f.mov" />

Limitation:
- I don't have many broken datasets on hand to test this thoroughly, the only one i have is from papaparse's website itself
- On the other hand, based on past user experiences i think most of the issues that users face happens at the table creation step instead of the CSV parsing step

For the latter however (handling errors at table creation step)
- Not super straightforward to direct the users exactly where went wrong like the parsing step as we're unable to identify exactly which row is causing issues
- e.g Selecting a column to be a PK, but the dataset has duplicate values in that column
FE is only able to return the error message that pg-meta sends (e.g `duplicate key value violates unique constraint "t9_pkey"`)
- We may need to revisit this again then

Cosmetic updates:
- Change tabs to use UI library's Tab component, reduces hard-coded styling within the dashboard
- Changed content preview header pills to use grid instead -> its just too much unnecessary clutter imo which users probably do not even go into detail with
- Made dropzone slightly shorter when a file has been uploaded to make space for preview content and errors if any