### PR TITLE
feat(studio): add system default option for theme

### DIFF
--- a/studio/components/layouts/ProjectLayout/NavigationBar/NavigationBar.tsx
+++ b/studio/components/layouts/ProjectLayout/NavigationBar/NavigationBar.tsx
@@ -1,9 +1,9 @@
-import React, { FC } from 'react'
+import React, { FC, useEffect, useState } from 'react'
 import Link from 'next/link'
 import { observer } from 'mobx-react-lite'
 import { useRouter } from 'next/router'
 import { isUndefined } from 'lodash'
-import { Button, Divider, IconHome, Dropdown, IconUser, Toggle, Typography } from '@supabase/ui'
+import { Button, Divider, IconHome, Dropdown, IconUser, Select, Typography } from '@supabase/ui'
 
 import { IS_PLATFORM } from 'lib/constants'
 import { useStore } from 'hooks'
@@ -20,6 +20,28 @@ const NavigationBar: FC<Props> = ({}) => {
   const activeRoute = router.pathname.split('/')[3]
   const productRoutes = generateProductRoutes(projectRef)
   const otherRoutes = generateOtherRoutes(projectRef)
+
+  const [value, setValue] = useState('')
+
+  useEffect(() => {
+    const localStorageThemeOption = window.localStorage.getItem('theme') as string
+    if (localStorageThemeOption) return setValue(localStorageThemeOption)
+    window.localStorage.setItem('theme', 'dark')
+    setValue('dark')
+  }, [])
+
+  const onThemeOptionChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const themeOption = e.target.value as 'dark' | 'light' | 'system'
+    setValue(themeOption)
+    if (themeOption === 'system') {
+      window.localStorage.setItem('theme', 'system')
+      return ui.setTheme(
+        window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+      )
+    }
+    window.localStorage.setItem('theme', themeOption)
+    ui.setTheme(themeOption)
+  }
 
   return (
     <div className="h-screen w-14 flex flex-col justify-between p-2 overflow-y-hidden bg-sidebar-light dark:bg-sidebar-dark border-r dark:border-dark">
@@ -77,13 +99,13 @@ const NavigationBar: FC<Props> = ({}) => {
               : []),
             <Divider key="d1" light />,
             <Dropdown.Misc key="theme">
-              <div className="w-[200px] pt-1">
-                <Toggle
-                  size="small"
-                  label="Enable dark mode"
-                  checked={ui.isDarkTheme}
-                  onChange={() => ui.toggleTheme()}
-                />
+              <div className="w-[240px] py-1 flex items-center justify-between">
+                <Typography.Text>Theme</Typography.Text>
+                <Select value={value} onChange={onThemeOptionChange}>
+                  <Select.Option value="system">System default</Select.Option>
+                  <Select.Option value="dark">Dark</Select.Option>
+                  <Select.Option value="light">Light</Select.Option>
+                </Select>
               </div>
             </Dropdown.Misc>,
           ]}

--- a/studio/components/layouts/ProjectLayout/NavigationBar/NavigationBar.tsx
+++ b/studio/components/layouts/ProjectLayout/NavigationBar/NavigationBar.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from 'react'
+import React, { FC } from 'react'
 import Link from 'next/link'
 import { observer } from 'mobx-react-lite'
 import { useRouter } from 'next/router'
@@ -20,8 +20,6 @@ const NavigationBar: FC<Props> = ({}) => {
   const activeRoute = router.pathname.split('/')[3]
   const productRoutes = generateProductRoutes(projectRef)
   const otherRoutes = generateOtherRoutes(projectRef)
-
-  const [value, setValue] = useState(ui.themeOption)
 
   return (
     <div className="h-screen w-14 flex flex-col justify-between p-2 overflow-y-hidden bg-sidebar-light dark:bg-sidebar-dark border-r dark:border-dark">
@@ -82,11 +80,8 @@ const NavigationBar: FC<Props> = ({}) => {
               <div className="w-[240px] py-1 flex items-center justify-between">
                 <Typography.Text>Theme</Typography.Text>
                 <Select
-                  value={value}
-                  onChange={(e: any) => {
-                    setValue(e.target.value)
-                    ui.onThemeOptionChange(e.target.value)
-                  }}
+                  value={ui.themeOption}
+                  onChange={(e: any) => ui.onThemeOptionChange(e.target.value)}
                 >
                   <Select.Option value="system">System default</Select.Option>
                   <Select.Option value="dark">Dark</Select.Option>

--- a/studio/components/layouts/ProjectLayout/NavigationBar/NavigationBar.tsx
+++ b/studio/components/layouts/ProjectLayout/NavigationBar/NavigationBar.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useState } from 'react'
+import React, { FC, useState } from 'react'
 import Link from 'next/link'
 import { observer } from 'mobx-react-lite'
 import { useRouter } from 'next/router'
@@ -21,27 +21,7 @@ const NavigationBar: FC<Props> = ({}) => {
   const productRoutes = generateProductRoutes(projectRef)
   const otherRoutes = generateOtherRoutes(projectRef)
 
-  const [value, setValue] = useState('')
-
-  useEffect(() => {
-    const localStorageThemeOption = window.localStorage.getItem('theme') as string
-    if (localStorageThemeOption) return setValue(localStorageThemeOption)
-    window.localStorage.setItem('theme', 'dark')
-    setValue('dark')
-  }, [])
-
-  const onThemeOptionChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const themeOption = e.target.value as 'dark' | 'light' | 'system'
-    setValue(themeOption)
-    if (themeOption === 'system') {
-      window.localStorage.setItem('theme', 'system')
-      return ui.setTheme(
-        window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
-      )
-    }
-    window.localStorage.setItem('theme', themeOption)
-    ui.setTheme(themeOption)
-  }
+  const [value, setValue] = useState(ui.themeOption)
 
   return (
     <div className="h-screen w-14 flex flex-col justify-between p-2 overflow-y-hidden bg-sidebar-light dark:bg-sidebar-dark border-r dark:border-dark">
@@ -101,7 +81,13 @@ const NavigationBar: FC<Props> = ({}) => {
             <Dropdown.Misc key="theme">
               <div className="w-[240px] py-1 flex items-center justify-between">
                 <Typography.Text>Theme</Typography.Text>
-                <Select value={value} onChange={onThemeOptionChange}>
+                <Select
+                  value={value}
+                  onChange={(e: any) => {
+                    setValue(e.target.value)
+                    ui.onThemeOptionChange(e.target.value)
+                  }}
+                >
                   <Select.Option value="system">System default</Select.Option>
                   <Select.Option value="dark">Dark</Select.Option>
                   <Select.Option value="light">Light</Select.Option>

--- a/studio/hooks/misc/useStore.tsx
+++ b/studio/hooks/misc/useStore.tsx
@@ -33,7 +33,10 @@ export const StoreProvider: FC<StoreProvider> = ({ children, rootStore }) => {
     }
   }, [theme, monaco])
 
-  const matchMediaEvent = useCallback(() => ui.theme === 'system' && ui.setTheme('system'), [])
+  const matchMediaEvent = useCallback(() => {
+    window.localStorage.getItem('theme') === 'system' &&
+      ui.setTheme(window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+  }, [])
 
   useEffect(() => {
     ui.load()

--- a/studio/hooks/misc/useStore.tsx
+++ b/studio/hooks/misc/useStore.tsx
@@ -1,6 +1,6 @@
 import { useMonaco } from '@monaco-editor/react'
 import { autorun } from 'mobx'
-import { createContext, FC, useContext, useEffect } from 'react'
+import { createContext, FC, useContext, useEffect, useCallback } from 'react'
 import toast from 'react-hot-toast'
 
 import { IRootStore } from 'stores'
@@ -33,8 +33,11 @@ export const StoreProvider: FC<StoreProvider> = ({ children, rootStore }) => {
     }
   }, [theme, monaco])
 
+  const matchMediaEvent = useCallback(() => ui.theme === 'system' && ui.setTheme('system'), [])
+
   useEffect(() => {
     ui.load()
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', matchMediaEvent)
 
     autorun(() => {
       if (ui.notification) {
@@ -71,6 +74,10 @@ export const StoreProvider: FC<StoreProvider> = ({ children, rootStore }) => {
         }
       }
     })
+    return () =>
+      window
+        .matchMedia('(prefers-color-scheme: dark)')
+        .removeEventListener('change', matchMediaEvent)
   }, [])
 
   return <StoreContext.Provider value={rootStore}>{children}</StoreContext.Provider>

--- a/studio/hooks/misc/useStore.tsx
+++ b/studio/hooks/misc/useStore.tsx
@@ -34,7 +34,7 @@ export const StoreProvider: FC<StoreProvider> = ({ children, rootStore }) => {
   }, [theme, monaco])
 
   const matchMediaEvent = useCallback(() => {
-    window.localStorage.getItem('theme') === 'system' &&
+    ui.themeOption === 'system' &&
       ui.setTheme(window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
   }, [])
 

--- a/studio/pages/account/me.tsx
+++ b/studio/pages/account/me.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React from 'react'
 import { observer } from 'mobx-react-lite'
 import { IconMoon, IconSun, Select, Typography } from '@supabase/ui'
 
@@ -77,9 +77,8 @@ const ProfileCard = observer(() => {
   )
 })
 
-function ThemeSettings() {
+const ThemeSettings = observer(() => {
   const { ui } = useStore()
-  const [value, setValue] = useState(ui.themeOption)
 
   return (
     <Panel
@@ -91,16 +90,19 @@ function ThemeSettings() {
     >
       <Panel.Content>
         <Select
-          value={value}
+          value={ui.themeOption}
           label="Interface theme"
           descriptionText="Choose a theme preference"
           layout="horizontal"
           style={{ width: '50%' }}
-          icon={value === 'light' ? <IconSun /> : value === 'dark' ? <IconMoon /> : undefined}
-          onChange={(e: any) => {
-            setValue(e.target.value)
-            ui.onThemeOptionChange(e.target.value)
-          }}
+          icon={
+            ui.themeOption === 'light' ? (
+              <IconSun />
+            ) : ui.themeOption === 'dark' ? (
+              <IconMoon />
+            ) : undefined
+          }
+          onChange={(e: any) => ui.onThemeOptionChange(e.target.value)}
         >
           <Select.Option value="system">System default</Select.Option>
           <Select.Option value="dark">Dark</Select.Option>
@@ -109,4 +111,4 @@ function ThemeSettings() {
       </Panel.Content>
     </Panel>
   )
-}
+})

--- a/studio/pages/account/me.tsx
+++ b/studio/pages/account/me.tsx
@@ -101,13 +101,13 @@ function ThemeSettings() {
           descriptionText="Choose a theme preference"
           layout="horizontal"
           style={{ width: '50%' }}
-          icon={theme === 'light' ? <IconSun /> : <IconMoon />}
+          icon={theme === 'light' ? <IconSun /> : theme === 'dark' ? <IconMoon /> : undefined}
           onChange={(e: any) => {
             setTheme(e.target.value)
             ui.setTheme(e.target.value)
           }}
         >
-          {/* <Select.Option value="system">System default</Select.Option> */}
+          <Select.Option value="system">System default</Select.Option>
           <Select.Option value="dark">Dark</Select.Option>
           <Select.Option value="light">Light</Select.Option>
         </Select>

--- a/studio/pages/account/me.tsx
+++ b/studio/pages/account/me.tsx
@@ -78,13 +78,28 @@ const ProfileCard = observer(() => {
 })
 
 function ThemeSettings() {
-  const [theme, setTheme] = useState('')
+  const [value, setValue] = useState('')
   const { ui } = useStore()
 
   useEffect(() => {
-    const localStorageTheme = window.localStorage.getItem('theme')
-    if (localStorageTheme) setTheme(localStorageTheme)
+    const localStorageThemeOption = window.localStorage.getItem('theme')
+    if (localStorageThemeOption) return setValue(localStorageThemeOption)
+    window.localStorage.setItem('theme', 'dark')
+    setValue('dark')
   }, [])
+
+  const onThemeOptionChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const themeOption = e.target.value as 'dark' | 'light' | 'system'
+    setValue(themeOption)
+    if (themeOption === 'system') {
+      window.localStorage.setItem('theme', 'system')
+      return ui.setTheme(
+        window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+      )
+    }
+    window.localStorage.setItem('theme', themeOption)
+    ui.setTheme(themeOption)
+  }
 
   return (
     <Panel
@@ -96,16 +111,13 @@ function ThemeSettings() {
     >
       <Panel.Content>
         <Select
-          value={theme}
+          value={value}
           label="Interface theme"
           descriptionText="Choose a theme preference"
           layout="horizontal"
           style={{ width: '50%' }}
-          icon={theme === 'light' ? <IconSun /> : theme === 'dark' ? <IconMoon /> : undefined}
-          onChange={(e: any) => {
-            setTheme(e.target.value)
-            ui.setTheme(e.target.value)
-          }}
+          icon={value === 'light' ? <IconSun /> : value === 'dark' ? <IconMoon /> : undefined}
+          onChange={onThemeOptionChange}
         >
           <Select.Option value="system">System default</Select.Option>
           <Select.Option value="dark">Dark</Select.Option>

--- a/studio/pages/account/me.tsx
+++ b/studio/pages/account/me.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 import { observer } from 'mobx-react-lite'
 import { IconMoon, IconSun, Select, Typography } from '@supabase/ui'
 
@@ -78,28 +78,8 @@ const ProfileCard = observer(() => {
 })
 
 function ThemeSettings() {
-  const [value, setValue] = useState('')
   const { ui } = useStore()
-
-  useEffect(() => {
-    const localStorageThemeOption = window.localStorage.getItem('theme')
-    if (localStorageThemeOption) return setValue(localStorageThemeOption)
-    window.localStorage.setItem('theme', 'dark')
-    setValue('dark')
-  }, [])
-
-  const onThemeOptionChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const themeOption = e.target.value as 'dark' | 'light' | 'system'
-    setValue(themeOption)
-    if (themeOption === 'system') {
-      window.localStorage.setItem('theme', 'system')
-      return ui.setTheme(
-        window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
-      )
-    }
-    window.localStorage.setItem('theme', themeOption)
-    ui.setTheme(themeOption)
-  }
+  const [value, setValue] = useState(ui.themeOption)
 
   return (
     <Panel
@@ -117,7 +97,10 @@ function ThemeSettings() {
           layout="horizontal"
           style={{ width: '50%' }}
           icon={value === 'light' ? <IconSun /> : value === 'dark' ? <IconMoon /> : undefined}
-          onChange={onThemeOptionChange}
+          onChange={(e: any) => {
+            setValue(e.target.value)
+            ui.onThemeOptionChange(e.target.value)
+          }}
         >
           <Select.Option value="system">System default</Select.Option>
           <Select.Option value="dark">Dark</Select.Option>

--- a/studio/stores/UiStore.ts
+++ b/studio/stores/UiStore.ts
@@ -6,7 +6,7 @@ import Telemetry from 'lib/telemetry'
 
 export interface IUiStore {
   language: 'en_US'
-  theme: 'dark' | 'light' | 'system'
+  theme: 'dark' | 'light'
 
   isDarkTheme: boolean
   selectedProject?: Project
@@ -16,7 +16,7 @@ export interface IUiStore {
 
   load: () => void
   toggleTheme: () => void
-  setTheme: (theme: 'dark' | 'light' | 'system') => void
+  setTheme: (theme: 'dark' | 'light') => void
   setProjectRef: (ref?: string) => void
   setOrganizationSlug: (slug?: string) => void
   setNotification: (notification: Notification) => string
@@ -25,7 +25,7 @@ export interface IUiStore {
 export default class UiStore implements IUiStore {
   rootStore: IRootStore
   language: 'en_US' = 'en_US'
-  theme: 'dark' | 'light' | 'system' = 'dark'
+  theme: 'dark' | 'light' = 'dark'
 
   selectedProjectRef?: string
   selectedOrganizationSlug?: string
@@ -68,33 +68,33 @@ export default class UiStore implements IUiStore {
   }
 
   get isDarkTheme() {
-    return (
-      this.theme === 'dark' ||
-      (this.theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
-    )
+    return this.theme === 'dark'
   }
 
   load() {
     if (typeof window === 'undefined') return
-    let savedTheme = (window.localStorage.getItem('theme') ?? 'dark') as 'dark' | 'light' | 'system'
-    if (['dark', 'light', 'system'].includes(savedTheme)) return this.setTheme(savedTheme)
+    const localStorageThemeOption = window.localStorage.getItem('theme')
+    if (localStorageThemeOption === 'system')
+      return this.setTheme(
+        window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+      )
+    if (localStorageThemeOption === 'light') return this.setTheme('light')
+    window.localStorage.setItem('theme', 'dark')
     this.setTheme('dark')
   }
 
   toggleTheme() {
-    if (this.theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
+    if (this.theme === 'dark') {
+      window.localStorage.setItem('theme', 'light')
       return this.setTheme('light')
-    if (this.theme === 'dark') return this.setTheme('light')
+    }
+    window.localStorage.setItem('theme', 'dark')
     this.setTheme('dark')
   }
 
-  setTheme(theme: 'dark' | 'light' | 'system') {
+  setTheme(theme: 'dark' | 'light') {
     this.theme = theme
-    window.localStorage.setItem('theme', theme)
-    if (theme !== 'system') return (document.body.className = theme)
-    if (window.matchMedia('(prefers-color-scheme: dark)').matches)
-      return (document.body.className = 'dark')
-    document.body.className = 'light'
+    document.body.className = theme
   }
 
   setProjectRef(ref?: string) {

--- a/studio/stores/UiStore.ts
+++ b/studio/stores/UiStore.ts
@@ -16,7 +16,7 @@ export interface IUiStore {
 
   load: () => void
   toggleTheme: () => void
-  setTheme: (theme: 'dark' | 'light') => void
+  setTheme: (theme: 'dark' | 'light' | 'system') => void
   setProjectRef: (ref?: string) => void
   setOrganizationSlug: (slug?: string) => void
   setNotification: (notification: Notification) => string

--- a/studio/stores/UiStore.ts
+++ b/studio/stores/UiStore.ts
@@ -15,7 +15,6 @@ export interface IUiStore {
   profile?: User
 
   load: () => void
-  toggleTheme: () => void
   setTheme: (theme: 'dark' | 'light') => void
   setProjectRef: (ref?: string) => void
   setOrganizationSlug: (slug?: string) => void
@@ -79,15 +78,6 @@ export default class UiStore implements IUiStore {
         window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
       )
     if (localStorageThemeOption === 'light') return this.setTheme('light')
-    window.localStorage.setItem('theme', 'dark')
-    this.setTheme('dark')
-  }
-
-  toggleTheme() {
-    if (this.theme === 'dark') {
-      window.localStorage.setItem('theme', 'light')
-      return this.setTheme('light')
-    }
     window.localStorage.setItem('theme', 'dark')
     this.setTheme('dark')
   }

--- a/studio/stores/UiStore.ts
+++ b/studio/stores/UiStore.ts
@@ -7,6 +7,7 @@ import Telemetry from 'lib/telemetry'
 export interface IUiStore {
   language: 'en_US'
   theme: 'dark' | 'light'
+  themeOption: 'dark' | 'light' | 'system'
 
   isDarkTheme: boolean
   selectedProject?: Project
@@ -16,6 +17,7 @@ export interface IUiStore {
 
   load: () => void
   setTheme: (theme: 'dark' | 'light') => void
+  onThemeOptionChange: (themeOption: 'dark' | 'light' | 'system') => void
   setProjectRef: (ref?: string) => void
   setOrganizationSlug: (slug?: string) => void
   setNotification: (notification: Notification) => string
@@ -25,6 +27,7 @@ export default class UiStore implements IUiStore {
   rootStore: IRootStore
   language: 'en_US' = 'en_US'
   theme: 'dark' | 'light' = 'dark'
+  themeOption: 'dark' | 'light' | 'system' = 'dark'
 
   selectedProjectRef?: string
   selectedOrganizationSlug?: string
@@ -73,18 +76,36 @@ export default class UiStore implements IUiStore {
   load() {
     if (typeof window === 'undefined') return
     const localStorageThemeOption = window.localStorage.getItem('theme')
-    if (localStorageThemeOption === 'system')
+    if (localStorageThemeOption === 'system') {
+      this.themeOption = localStorageThemeOption
       return this.setTheme(
         window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
       )
-    if (localStorageThemeOption === 'light') return this.setTheme('light')
+    }
+    if (localStorageThemeOption === 'light') {
+      this.themeOption = localStorageThemeOption
+      return this.setTheme('light')
+    }
     window.localStorage.setItem('theme', 'dark')
+    this.themeOption = 'dark'
     this.setTheme('dark')
   }
 
   setTheme(theme: 'dark' | 'light') {
     this.theme = theme
     document.body.className = theme
+  }
+
+  onThemeOptionChange(themeOption: 'dark' | 'light' | 'system') {
+    this.themeOption = themeOption
+    if (themeOption === 'system') {
+      window.localStorage.setItem('theme', 'system')
+      return this.setTheme(
+        window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+      )
+    }
+    window.localStorage.setItem('theme', themeOption)
+    this.setTheme(themeOption)
   }
 
   setProjectRef(ref?: string) {


### PR DESCRIPTION
**Description**

Closes #4329. Enables _System Default_ theme option for Studio. Removed icon for `<Select.Option  />` when on `system` theme. The toggle inside the project updates with current system theme scheme. Updating the toggle overrides the current theme setting. Also added a check for bad theme string in `localStorage`. Added an event listener to update theme automatically when system scheme changes.

Edit: Changelog updated for commit 95f9e54d199489110ad5cb011deab20b1668466f.