### PR TITLE
fix: add check for project variable to not read property of undefined

### DIFF
--- a/studio/stores/app/ProjectStore.ts
+++ b/studio/stores/app/ProjectStore.ts
@@ -17,9 +17,10 @@ export default class ProjectStore extends PostgresMetaInterface<Project> {
   initialDataArray(value: Project[]) {
     const finalValue = value.map((project: any) => {
       const kpsVersion =
-        project.services?.length > 0
+        project?.services?.length > 0
           ? project?.services[0]?.infrastructure[0]?.app_versions?.version
           : undefined
+
       return { ...project, kpsVersion }
     })
     super.initialDataArray(finalValue)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bugfix

## What is the current behavior?
After I signup for the first time using GitHub, I am redirected back to the app with an error. Same as shown [here](https://user-images.githubusercontent.com/1479241/145703005-2f191f9e-605f-4bc5-83c2-d41bd9ecf29f.png). 
#4448 

## What is the new behavior?
Check the variable and possibly fix the issue on the client-side. 

## Additional context
