### PR TITLE
fix: persist db volume

### DIFF
--- a/docker/dev/docker-compose.dev.yml
+++ b/docker/dev/docker-compose.dev.yml
@@ -13,4 +13,8 @@ services:
       - 5555:8080
   db:
     volumes:
+      - /var/lib/postgresql/data
       - ./dev/data.sql:/docker-entrypoint-initdb.d/data.sql
+  storage:
+    volumes:
+      - /var/lib/storage

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -154,5 +154,5 @@ services:
     environment:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     volumes:
-      - /var/lib/postgresql/data
+      - ./volumes/db/data:/var/lib/postgresql/data
       - ./volumes/db/init:/docker-entrypoint-initdb.d


### PR DESCRIPTION
Making the db use an anon volume will cause data loss - all persisted data (db, storage, etc.) should be preserved even if the user does `docker system prune`.

Instead use [Compose overrides](https://docs.docker.com/compose/extends/#adding-and-overriding-configuration) for dev mode.