### PR TITLE
Fix footer margin

### DIFF
--- a/www/components/Footer/index.tsx
+++ b/www/components/Footer/index.tsx
@@ -102,7 +102,9 @@ const Footer = (props: Props) => {
           </div>
         </div>
         <div className="mt-32 border-t dark:border-dark pt-8 flex justify-between">
-          <p className="mb-0 self-center text-base text-gray-400 dark:text-dark-400">&copy; Supabase Inc</p>
+          <p className="mb-0 self-center text-base text-gray-400 dark:text-dark-400">
+            &copy; Supabase Inc
+          </p>
           <DarkModeToggle darkMode={darkMode} updateTheme={updateTheme} />
         </div>
       </SectionContainer>

--- a/www/components/Footer/index.tsx
+++ b/www/components/Footer/index.tsx
@@ -102,7 +102,7 @@ const Footer = (props: Props) => {
           </div>
         </div>
         <div className="mt-32 border-t dark:border-dark pt-8 flex justify-between">
-          <p className="mb-0 text-base text-gray-400 dark:text-dark-400">&copy; Supabase Inc</p>
+          <p className="mb-0 self-center text-base text-gray-400 dark:text-dark-400">&copy; Supabase Inc</p>
           <DarkModeToggle darkMode={darkMode} updateTheme={updateTheme} />
         </div>
       </SectionContainer>

--- a/www/components/Footer/index.tsx
+++ b/www/components/Footer/index.tsx
@@ -102,7 +102,7 @@ const Footer = (props: Props) => {
           </div>
         </div>
         <div className="mt-32 border-t dark:border-dark pt-8 flex justify-between">
-          <p className="text-base text-gray-400 dark:text-dark-400">&copy; Supabase Inc</p>
+          <p className="mb-0 text-base text-gray-400 dark:text-dark-400">&copy; Supabase Inc</p>
           <DarkModeToggle darkMode={darkMode} updateTheme={updateTheme} />
         </div>
       </SectionContainer>


### PR DESCRIPTION
## What kind of change does this PR introduce?

fix margin and alignment on `© Supabase Inc` in the footer.

## What is the current behavior?

not aligned with `ThemeToggle`

## What is the new behavior?

aligned with `ThemeToggle`

## Additional context

Before:
<img width="1280" alt="Screen Shot 2021-12-16 at 4 07 24 PM" src="https://user-images.githubusercontent.com/70828596/146449655-c2f10bbe-c81b-4bd2-b388-ede6a4a13826.png">

After:
<img width="1280" alt="Screen Shot 2021-12-16 at 4 10 34 PM" src="https://user-images.githubusercontent.com/70828596/146449688-b4d732a4-3109-4101-93b1-30c9ee4eff3f.png">