### PR TITLE
feat/studio/logs: Load older logs

### DIFF
--- a/studio/components/interfaces/Settings/Logs/LogPanel.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogPanel.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react'
+import { FC, useEffect, useState } from 'react'
 import {
   Button,
   Input,
@@ -13,13 +13,11 @@ import {
 import { LogTemplate } from '.'
 
 interface Props {
-  searchValue?: string
+  defaultSearchValue?: string
   templates?: any
   isLoading: boolean
   isCustomQuery: boolean
   newCount: number
-  showReset: boolean
-  onReset: () => void
   onRefresh?: () => void
   onSearch?: (query: string) => void
   onCustomClick?: () => void
@@ -30,18 +28,25 @@ interface Props {
  * Logs control panel header + wrapper
  */
 const LogPanel: FC<Props> = ({
-  searchValue,
   templates = [],
   isLoading,
   isCustomQuery,
   newCount,
-  showReset,
-  onReset,
   onRefresh,
   onSearch = () => {},
+  defaultSearchValue = '',
   onCustomClick,
   onSelectTemplate,
 }) => {
+  const [search, setSearch] = useState('')
+
+  // sync local state with provided default value
+  useEffect(() => {
+    if (search !== defaultSearchValue) {
+      setSearch(defaultSearchValue)
+    }
+  }, [defaultSearchValue])
+
   return (
     <div className="bg-panel-header-light dark:bg-panel-header-dark">
       <div className="px-2 py-1 flex items-center justify-between w-full">
@@ -94,16 +99,43 @@ const LogPanel: FC<Props> = ({
           </div>
         </div>
         <div className="flex items-center gap-x-4">
-          <Input
-            size="tiny"
-            icon={<IconSearch size={16} />}
-            placeholder="Search event messages"
-            onChange={(e) => onSearch(e.target.value)}
-            value={searchValue}
-            actions={
-              showReset && <IconX size="tiny" className="cursor-pointer mx-1" title="Clear search" onClick={onReset} />
-            }
-          />
+          {/* wrap with form so that if user presses enter, the search value will submit automatically */}
+          <form
+            id="log-panel-search"
+            onSubmit={(e) => {
+              // prevent redirection
+              e.preventDefault()
+              onSearch(search)
+            }}
+          >
+            <Input
+              size="tiny"
+              icon={<IconSearch size={16} />}
+              placeholder="Search event messages"
+              onChange={(e) => setSearch(e.target.value)}
+              value={search}
+              actions={[
+                search && (
+                  <IconX
+                    key="clear-search"
+                    size="tiny"
+                    className="cursor-pointer mx-1"
+                    title="Clear search"
+                    onClick={() => setSearch('')}
+                  />
+                ),
+                <Button
+                  key="go"
+                  size="small"
+                  title="Go"
+                  type="secondary"
+                  onClick={() => onSearch(search)}
+                >
+                  Go
+                </Button>,
+              ]}
+            />
+          </form>
         </div>
       </div>
     </div>

--- a/studio/components/interfaces/Settings/Logs/LogPanel.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogPanel.tsx
@@ -111,7 +111,7 @@ const LogPanel: FC<Props> = ({
             <Input
               size="tiny"
               icon={<IconSearch size={16} />}
-              placeholder="Search event messages"
+              placeholder="Search events"
               onChange={(e) => setSearch(e.target.value)}
               value={search}
               actions={[
@@ -126,7 +126,7 @@ const LogPanel: FC<Props> = ({
                 ),
                 <Button
                   key="go"
-                  size="small"
+                  size="tiny"
                   title="Go"
                   type="secondary"
                   onClick={() => onSearch(search)}

--- a/studio/components/interfaces/Settings/Logs/LogTable.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogTable.tsx
@@ -1,5 +1,5 @@
 import dayjs from 'dayjs'
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useMemo } from 'react'
 import { Typography } from '@supabase/ui'
 import DataGrid from '@supabase/react-data-grid'
 
@@ -43,10 +43,12 @@ const LogTable = ({ isCustomQuery, data }: Props) => {
     },
   }))
 
-  const logMap = (data || []).reduce((acc: any, d) => {
-    acc[d.id] = d
-    return acc
-  }, {})
+  const logMap: { [id: string]: LogData } = useMemo(() => {
+    return (data || []).reduce((acc: any, d) => {
+      acc[d.id] = d
+      return acc
+    }, {})
+  }, [JSON.stringify(data)])
 
   useEffect(() => {
     if (!data) return
@@ -60,6 +62,9 @@ const LogTable = ({ isCustomQuery, data }: Props) => {
   // [Joshen] Hmm quite hacky now, but will do
   const maxHeight = isCustomQuery ? 'calc(100vh - 42px - 10rem)' : 'calc(100vh - 42px - 3rem)'
 
+  const logDataRows = useMemo(() => {
+    return Object.values(logMap).sort((a, b) => a.timestamp - b.timestamp)
+  }, [JSON.stringify(Object.keys(logMap))])
   return (
     <section className="flex flex-1 flex-row" style={{ maxHeight }}>
       <DataGrid
@@ -75,7 +80,7 @@ const LogTable = ({ isCustomQuery, data }: Props) => {
         }
         columns={columns as any}
         rowClass={(r) => `${r.id === focusedLog?.id ? 'bg-green-800' : 'cursor-pointer'}`}
-        rows={data}
+        rows={logDataRows}
         rowKeyGetter={(r) => r.id}
         onRowClick={(r) => setFocusedLog(logMap[r.id])}
       />

--- a/studio/pages/project/[ref]/settings/logs/[type].tsx
+++ b/studio/pages/project/[ref]/settings/logs/[type].tsx
@@ -162,16 +162,22 @@ export const LogPage: NextPage = () => {
                 onInputChange={(v) => setEditorValue(v || '')}
                 onInputRun={handleRefresh}
               />
-              <div className="flex flex-row justify-end mt-2">
-                {editorValue && (
-                  <Button type="text" onClick={() => setEditorValue('')}>
-                    Clear
-                  </Button>
-                )}
-                <Button type={editorValue ? 'secondary' : 'text'} onClick={handleEditorSubmit}>
-                  Run
+            </div>
+            <div className="flex flex-row gap-x-2 justify-end p-2">
+              {editorValue && (
+                <Button
+                  type="text"
+                  onClick={() => {
+                    setEditorValue('')
+                    setEditorId(uuidv4())
+                  }}
+                >
+                  Clear
                 </Button>
-              </div>
+              )}
+              <Button type={editorValue ? 'secondary' : 'text'} onClick={handleEditorSubmit}>
+                Run
+              </Button>
             </div>
           </React.Fragment>
         )}

--- a/studio/pages/project/[ref]/settings/logs/[type].tsx
+++ b/studio/pages/project/[ref]/settings/logs/[type].tsx
@@ -1,10 +1,10 @@
-import useSWR from 'swr'
+import useSWR, { KeyLoader } from 'swr'
 import debounce from 'lodash/debounce'
 import { useEffect, useRef, useState } from 'react'
 import { NextPage } from 'next'
 import { useRouter } from 'next/router'
 import { observer } from 'mobx-react-lite'
-import { Typography, IconLoader, IconAlertCircle } from '@supabase/ui'
+import { Typography, IconLoader, IconAlertCircle, IconRewind, Button } from '@supabase/ui'
 
 import { withAuth } from 'hooks'
 import { get } from 'lib/common/fetch'
@@ -18,11 +18,17 @@ import {
   Logs,
   LogTemplate,
   TEMPLATES,
+  LogData,
 } from 'components/interfaces/Settings/Logs'
 import { uuidv4 } from 'lib/helpers'
+import useSWRInfinite from 'swr/infinite'
+import { isUndefined } from 'lodash'
+import Flag from 'components/ui/Flag/Flag'
 
 /**
  * Acts as a container component for the entire log display
+ *
+ *
  */
 export const LogPage: NextPage = () => {
   const router = useRouter()
@@ -34,27 +40,76 @@ export const LogPage: NextPage = () => {
   const [where, setWhere] = useState<string>('')
   const [mode, setMode] = useState<'simple' | 'custom'>('simple')
   const [latestRefresh, setLatestRefresh] = useState<string>(new Date().toISOString())
-
+  const [params, setParams] = useState({
+    type: '',
+    search_query: '',
+    where: '',
+    timestamp_start: '',
+    timestamp_end: '',
+  })
   const title = `Logs - ${LOG_TYPE_LABEL_MAPPING[type as string]}`
   const debouncedQueryParams = useRef(debounce(setQueryParams, 600)).current
 
   useEffect(() => {
-    const params = {
-      type: type as string,
-      search_query: search || '',
-      where: mode === 'custom' ? where || '' : '',
-    }
-    const qs = new URLSearchParams(params).toString()
+    const qs = genQueryParams(params)
     debouncedQueryParams(qs)
     return () => debouncedQueryParams.cancel()
   }, [mode, search, where, type])
 
+  const genQueryParams = (params: { [k: string]: string }) => {
+    // remove keys which are empty strings, null, or undefined
+    for (const k in params) {
+      const v = params[k]
+      if (v === null || v === '' || isUndefined(v)) {
+        delete params[k]
+      }
+    }
+    const qs = new URLSearchParams(params).toString()
+    return qs
+  }
   // handle log fetching
-  const logUrl = `${API_URL}/projects/${ref}/logs?${queryParams}`
-  const { data, isValidating, mutate } = useSWR<Logs>(logUrl, get, { revalidateOnFocus: false })
-  const { data: logData, error } = data || {}
+  const getKeyLogs: KeyLoader<Logs> = (_pageIndex: number, prevPageData) => {
+    let queryParams
+    // if prev page data is 100 items, could possibly have more records that are not yet fetched within this interval
+    if (prevPageData === null) {
+      // reduce interval window limit by using the timestamp of the last log
+      queryParams = genQueryParams(params)
+    } else {
+      const len = prevPageData.data.length
+      const { timestamp: tsLimit }: LogData = prevPageData.data[len - 1]
+      // create new key from params
+      queryParams = genQueryParams({ ...params, timestamp_end: String(tsLimit) })
+    }
 
-  const countUrl = `${API_URL}/projects/${ref}/logs?${queryParams}&count=true&period_start=${latestRefresh}`
+    const logUrl = `${API_URL}/projects/${ref}/logs?${queryParams}`
+    return logUrl
+  }
+  const {
+    data = [],
+    isValidating,
+    mutate,
+    size,
+    setSize,
+  } = useSWRInfinite<Logs>(getKeyLogs, get, { revalidateOnFocus: false })
+
+  // const { data, isValidating, mutate } = useSWR<Logs>(logUrl, get, { revalidateOnFocus: false })
+  let logData: LogData[] = []
+  let error: null | string = null
+
+  data.forEach((response: Logs) => {
+    if (response && response.data) {
+      logData = [...logData, ...response.data]
+    }
+    if (!error && response && response.error) {
+      error = response.error
+    }
+  })
+
+  const countUrl = `${API_URL}/projects/${ref}/logs?${genQueryParams({
+    ...params,
+    count: String(true),
+    period_start: String(latestRefresh),
+  })}`
   const { data: countData } = useSWR<Count>(countUrl, get, { refreshInterval: 5000 })
   const newCount = countData?.data?.[0]?.count ?? 0
 
@@ -135,6 +190,19 @@ export const LogPage: NextPage = () => {
             </div>
           )}
           <LogTable data={logData} isCustomQuery={mode === 'custom'} />
+          {/* Footer section of log ui, appears below table */}
+          <div className="p-2">
+            <Flag name="logsLoadOlder">
+              <Button
+                // trigger page increase
+                onClick={() => setSize(size + 1)}
+                icon={<IconRewind />}
+                type="secondary"
+              >
+                Load older
+              </Button>
+            </Flag>
+          </div>
         </div>
       </div>
     </SettingsLayout>

--- a/studio/pages/project/[ref]/settings/logs/[type].tsx
+++ b/studio/pages/project/[ref]/settings/logs/[type].tsx
@@ -109,6 +109,7 @@ export const LogPage: NextPage = () => {
 
   const handleRefresh = () => {
     setLatestRefresh(new Date().toISOString())
+    setSize(1)
     mutate()
   }
 

--- a/studio/tests/pages/projects/LogPanel.test.js
+++ b/studio/tests/pages/projects/LogPanel.test.js
@@ -4,12 +4,9 @@ import userEvent from '@testing-library/user-event'
 
 test('templates', async () => {
   const mockFn = jest.fn()
-  render(<LogPanel templates={[
-    { label: 'Some option', onClick: mockFn }
-  ]} />)
+  render(<LogPanel templates={[{ label: 'Some option', onClick: mockFn }]} />)
   const search = screen.getByPlaceholderText(/Search/)
-  userEvent.type(search, "12345")
-
+  userEvent.type(search, '12345')
 
   // TODO templates dropdown interaction currently cannot be tested
   // https://github.com/supabase/ui/issues/299
@@ -21,21 +18,22 @@ test('templates', async () => {
   // expect(mockFn).toBeCalled()
 })
 
-test("filter input change", async () => {
+test('filter input change and submit', async () => {
   const mockFn = jest.fn()
   render(<LogPanel onSearch={mockFn} />)
   const search = screen.getByPlaceholderText(/Search/)
-  userEvent.type(search, "12345")
+  userEvent.type(search, '12345')
+  expect(mockFn).not.toBeCalled()
+  userEvent.click(screen.getByText('Go'))
   expect(mockFn).toBeCalled()
 })
 
-test("filter input value", async () => {
-  render(<LogPanel searchValue={"1234"} />)
-  screen.getByDisplayValue("1234")
+test('filter input value', async () => {
+  render(<LogPanel defaultSearchValue={'1234'} />)
+  screen.getByDisplayValue('1234')
 })
 
-
-test("Manual refresh", async () => {
+test('Manual refresh', async () => {
   const mockFn = jest.fn()
   render(<LogPanel onRefresh={mockFn} />)
   let btn
@@ -46,12 +44,13 @@ test("Manual refresh", async () => {
   expect(mockFn).toBeCalled()
 })
 
-test("reset filters", () => {
-  const mockFn = jest.fn()
-  const { rerender } = render(<LogPanel showReset={false} />)
-  expect(() => screen.getByText(/Clear search/)).toThrow()
+test('reset search filter', async () => {
+  const { rerender } = render(<LogPanel />)
+  expect(() => screen.getByTitle(/Clear search/)).toThrow()
 
-  rerender(<LogPanel showReset={true} onReset={mockFn} />)
+  rerender(<LogPanel defaultSearchValue="something123" />)
+  await waitFor(() => screen.getByDisplayValue(/something123/))
   userEvent.click(screen.getByTitle(/Clear search/))
-  expect(mockFn).toBeCalled()
+  expect(() => screen.getByTitle(/Clear search/)).toThrow()
+  expect(() => screen.getByDisplayValue(/something123/)).toThrow()
 })

--- a/studio/tests/pages/projects/LogTable.test.js
+++ b/studio/tests/pages/projects/LogTable.test.js
@@ -16,3 +16,18 @@ test('can display log data', async () => {
   await waitFor(() => screen.getByText(/my_key/))
   await waitFor(() => screen.getByText(/something_value/))
 })
+
+test ("dedupes log lines with exact id", async ()=>{
+  render(<LogTable data={[{
+    id: "seome-uuid",
+    timestamp: 1621323232312,
+    event_message: "some event happened",
+  },{
+    id: "seome-uuid",
+    timestamp: 1621323232312,
+    event_message: "some event happened",
+  }]} />)
+
+  // should only have one element, this line will fail if there are >1 element
+  await waitFor(() => screen.getByText(/happened/))
+})

--- a/studio/tests/pages/projects/logs.test.js
+++ b/studio/tests/pages/projects/logs.test.js
@@ -163,3 +163,38 @@ test("where clause will trigger a log refresh", async () => {
 
   await waitFor(() => screen.getByText(/happened/))
 })
+
+test('load older btn will fetch older logs', async () => {
+  get
+    .mockResolvedValueOnce({
+      data: [
+        {
+          id: 'some-uuid',
+          timestamp: 1621323232312,
+          event_message: 'first event',
+          metadata: {},
+        },
+      ],
+    })
+    .mockResolvedValueOnce({
+      data: [
+        {
+          id: 'some-uuid2',
+          timestamp: 1621323232310,
+          event_message: 'second event',
+          metadata: {},
+        },
+      ],
+    })
+  render(<LogPage />)
+  // should display first log but not second
+  await waitFor(() => screen.getByText('first event'))
+  expect(() => screen.getByText('second event')).toThrow()
+
+  userEvent.click(screen.getByText('Load older'))
+  // should display first and second log
+  await waitFor(() => screen.getByText('first event'))
+  await waitFor(() => screen.getByText('second event'))
+  expect(get).toBeCalledTimes(2)
+})
+

--- a/studio/tests/pages/projects/logs.test.js
+++ b/studio/tests/pages/projects/logs.test.js
@@ -4,33 +4,33 @@ import { get } from 'lib/common/fetch'
 
 // mock the settings layout
 jest.mock('components/layouts', () => ({
-  SettingsLayout: jest.fn()
-    .mockImplementation(({ children }) => <div>{children}</div>)
+  SettingsLayout: jest.fn().mockImplementation(({ children }) => <div>{children}</div>),
 }))
 
 // mock mobx
 jest.mock('mobx-react-lite')
 import { observer } from 'mobx-react-lite'
-observer.mockImplementation(v => v)
+observer.mockImplementation((v) => v)
 
 // mock the router
 jest.mock('next/router')
 import { useRouter } from 'next/router'
-useRouter.mockReturnValue({ query: { ref: "123", type: "auth" } })
+useRouter.mockReturnValue({ query: { ref: '123', type: 'auth' } })
 
 // mock monaco editor
-jest.mock("@monaco-editor/react")
-import Editor, { useMonaco } from "@monaco-editor/react"
+jest.mock('@monaco-editor/react')
+import Editor, { useMonaco } from '@monaco-editor/react'
 Editor = jest.fn()
 Editor.mockImplementation((props) => {
   return (
-    <textarea
-      className="monaco-editor"
-      onChange={e => props.onChange(e.target.value)}
-    ></textarea>
+    <textarea className="monaco-editor" onChange={(e) => props.onChange(e.target.value)}></textarea>
   )
 })
-useMonaco.mockImplementation(v => v)
+useMonaco.mockImplementation((v) => v)
+
+jest.mock('components/ui/Flag/Flag')
+import Flag from 'components/ui/Flag/Flag'
+Flag.mockImplementation(({ children }) => <>{children}</>)
 
 import { LogPage } from 'pages/project/[ref]/settings/logs/[type]'
 import { render, fireEvent, waitFor, screen } from '@testing-library/react'
@@ -40,14 +40,16 @@ beforeEach(() => {
   get.mockReset()
 })
 test('can display log data and metadata', async () => {
-  const data = [{
-    id: "seome-uuid",
-    timestamp: 1621323232312,
-    event_message: "some event happened",
-    metadata: {
-      my_key: "something_value"
-    }
-  }]
+  const data = [
+    {
+      id: 'seome-uuid',
+      timestamp: 1621323232312,
+      event_message: 'some event happened',
+      metadata: {
+        my_key: 'something_value',
+      },
+    },
+  ]
   get.mockResolvedValue({ data })
   render(<LogPage />)
 
@@ -59,15 +61,16 @@ test('can display log data and metadata', async () => {
 })
 
 test('Refresh', async () => {
-
-  const data = [{
-    id: "some-uuid",
-    timestamp: 1621323232312,
-    event_message: "some event happened",
-    metadata: {
-      my_key: "something_value"
-    }
-  }]
+  const data = [
+    {
+      id: 'some-uuid',
+      timestamp: 1621323232312,
+      event_message: 'some event happened',
+      metadata: {
+        my_key: 'something_value',
+      },
+    },
+  ]
   get.mockResolvedValueOnce({ data }).mockResolvedValueOnce({ data: [] })
   render(<LogPage />)
 
@@ -82,50 +85,53 @@ test('Refresh', async () => {
   await waitFor(() => screen.queryByText(/happened/) === null, { timeout: 1000 })
 })
 
-
-test("Search will trigger a log refresh", async () => {
+test('Search will trigger a log refresh', async () => {
   get.mockImplementation((url) => {
-
-    if (url.includes("search_query") && url.includes("something")) {
+    if (url.includes('search_query') && url.includes('something')) {
       return {
-        data: [{
-          id: "some-uuid",
-          timestamp: 1621323232312,
-          event_message: "some event happened",
-          metadata: {}
-        }]
+        data: [
+          {
+            id: 'some-uuid',
+            timestamp: 1621323232312,
+            event_message: 'some event happened',
+            metadata: {},
+          },
+        ],
       }
     }
     return { data: [] }
   })
   render(<LogPage />)
 
-  userEvent.type(screen.getByPlaceholderText(/Filter/), "something")
-  await waitFor(() => {
-    expect(get).toHaveBeenCalledWith(expect.stringContaining("search_query"))
-    expect(get).toHaveBeenCalledWith(expect.stringContaining("something"))
-  }, { timeout: 1500 })
+  userEvent.type(screen.getByPlaceholderText(/Filter/), 'something')
+  await waitFor(
+    () => {
+      expect(get).toHaveBeenCalledWith(expect.stringContaining('search_query'))
+      expect(get).toHaveBeenCalledWith(expect.stringContaining('something'))
+    },
+    { timeout: 1500 }
+  )
 
   await waitFor(() => screen.getByText(/happened/), { timeout: 1000 })
 })
 
-test("poll count for new messages", async () => {
+test('poll count for new messages', async () => {
   get.mockImplementation((url) => {
-    if (url.includes("count")) {
+    if (url.includes('count')) {
       return { data: [{ count: 3 }] }
     }
     return {
-      data: [{
-        id: "some-uuid",
-        timestamp: 1621323232312,
-        event_message: "some event happened",
-        metadata: {}
-      }]
+      data: [
+        {
+          id: 'some-uuid',
+          timestamp: 1621323232312,
+          event_message: 'some event happened',
+          metadata: {},
+        },
+      ],
     }
   })
-  render(
-    <LogPage />
-  )
+  render(<LogPage />)
   await waitFor(() => screen.queryByText(/happened/) === null)
   await waitFor(() => screen.getByText(/Load new logs/))
 
@@ -134,39 +140,45 @@ test("poll count for new messages", async () => {
   await waitFor(() => screen.getByText(/happened/))
 })
 
-
-test("where clause will trigger a log refresh", async () => {
+test('where clause will trigger a log refresh', async () => {
   get.mockImplementation((url) => {
-
-    if (url.includes("where") && url.includes("something")) {
+    if (url.includes('where') && url.includes('something')) {
       return {
-        data: [{
-          id: "some-uuid",
-          timestamp: 1621323232312,
-          event_message: "some event happened",
-          metadata: {}
-        }]
+        data: [
+          {
+            id: 'some-uuid',
+            timestamp: 1621323232312,
+            event_message: 'some event happened',
+            metadata: {},
+          },
+        ],
       }
     }
     return { data: [] }
   })
   const { container } = render(<LogPage />)
-  let editor = container.querySelector('.monaco-editor');
+  let editor = container.querySelector('.monaco-editor')
   expect(editor).toBeFalsy()
-  userEvent.click(screen.getByText("Custom query"))
-  editor = container.querySelector('.monaco-editor');
-  userEvent.type(editor, "metadata.field = something")
-  await waitFor(() => {
-    expect(get).toHaveBeenCalledWith(expect.stringContaining("where"))
-    expect(get).toHaveBeenCalledWith(expect.stringContaining("metadata.field"))
-  }, { timeout: 1000 })
+  userEvent.click(screen.getByText('Custom query'))
+  editor = container.querySelector('.monaco-editor')
+  userEvent.type(editor, 'metadata.field = something')
+  await waitFor(
+    () => {
+      expect(get).toHaveBeenCalledWith(expect.stringContaining('where'))
+      expect(get).toHaveBeenCalledWith(expect.stringContaining('metadata.field'))
+    },
+    { timeout: 1000 }
+  )
 
   await waitFor(() => screen.getByText(/happened/))
 })
 
 test('load older btn will fetch older logs', async () => {
-  get
-    .mockResolvedValueOnce({
+  get.mockImplementation((url) => {
+    if (url.includes('count')) {
+      return {}
+    }
+    return {
       data: [
         {
           id: 'some-uuid',
@@ -175,26 +187,28 @@ test('load older btn will fetch older logs', async () => {
           metadata: {},
         },
       ],
-    })
-    .mockResolvedValueOnce({
-      data: [
-        {
-          id: 'some-uuid2',
-          timestamp: 1621323232310,
-          event_message: 'second event',
-          metadata: {},
-        },
-      ],
-    })
+    }
+  })
   render(<LogPage />)
   // should display first log but not second
   await waitFor(() => screen.getByText('first event'))
   expect(() => screen.getByText('second event')).toThrow()
 
-  userEvent.click(screen.getByText('Load older'))
+  get.mockResolvedValueOnce({
+    data: [
+      {
+        id: 'some-uuid2',
+        timestamp: 1621323232310,
+        event_message: 'second event',
+        metadata: {},
+      },
+    ],
+  })
   // should display first and second log
+  userEvent.click(screen.getByText('Load older'))
   await waitFor(() => screen.getByText('first event'))
+  await waitFor(() => {
+    expect(get).toHaveBeenCalledWith(expect.stringContaining('timestamp_end=1'))
+  })
   await waitFor(() => screen.getByText('second event'))
-  expect(get).toBeCalledTimes(2)
 })
-


### PR DESCRIPTION
This PR introduces a "Load older" button to the LogsPage, and allows users to fetch more logs (currently, users are limited to 100 lines per fetch).

The internal logic will build up to allowing specific timestamp querying.