### PR TITLE
Fix: 404 highlight bug

### DIFF
--- a/studio/pages/404.tsx
+++ b/studio/pages/404.tsx
@@ -39,7 +39,7 @@ const Error404: NextPage = ({}) => {
       </div>
       <div className="absolute">
         <Typography.Title
-          className={`filter transition opacity-[5%] duration-200 ${
+          className={`select-none filter transition opacity-[5%] duration-200 ${
             show404 ? 'blur-sm' : 'blur-none'
           }`}
           style={{ fontSize: '28rem' }}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix #4478 

## What is the current behavior?

#4478 

## What is the new behavior?

No longer highlights 404 background text.

## Additional context

The bug is fixed but you can no longer highlight any text. The reason why is because the 404 background text overlaps the foreground text.

https://user-images.githubusercontent.com/70828596/146625704-5bde90a3-2b25-4f2a-8d9a-c4cf9899f788.mov