### PR TITLE
Bugfix[#4327]: stay on route when changing project

### DIFF
--- a/studio/components/layouts/ProjectLayout/LayoutHeader/ProjectDropdown.tsx
+++ b/studio/components/layouts/ProjectLayout/LayoutHeader/ProjectDropdown.tsx
@@ -4,16 +4,15 @@ import { Button, Dropdown, Divider, IconPlus } from '@supabase/ui'
 
 import { useStore } from 'hooks'
 import { IS_PLATFORM, PROJECT_STATUS } from 'lib/constants'
+import { useRouter } from 'next/router'
 
 const ProjectDropdown = () => {
   const { app, ui } = useStore()
   const selectedOrganizationProjects = app.projects.list()
   const selectedOrganizationSlug = ui.selectedOrganization?.slug
   const selectedProject: any = ui.selectedProject
-
-  // [Joshen] If let's say we want to support changing projects to retain sub-route
-  // const currentSubRoute = router.route.split('/[ref]/')[1] || ''
-  // But need to ensure that pages update correctly when the project ref changes
+  const router = useRouter()
+  const currentRoute = router?.route
 
   return IS_PLATFORM ? (
     <Dropdown
@@ -25,7 +24,7 @@ const ProjectDropdown = () => {
             .filter((x: any) => x.status !== PROJECT_STATUS.INACTIVE)
             .sort((a: any, b: any) => a.name.localeCompare(b.name))
             .map((x: any) => (
-              <Link key={x.ref} href={`/project/${x.ref}`}>
+              <Link key={x.ref} href={currentRoute?.replace('[ref]', x.ref) ?? `/project/${x.ref}`}>
                 <a className="block">
                   <Dropdown.Item>{x.name}</Dropdown.Item>
                 </a>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix #4327

## What is the current behavior?

Currently were redirecting the user to the page /project/[ref] when the project gets changed

## What is the new behavior?

The user stays on the same page when the project gets changed

## Additional context

Add any other context or screenshots.
