### PR TITLE
display blog image correctly on small scree, fix #4556

### DIFF
--- a/www/pages/blog.tsx
+++ b/www/pages/blog.tsx
@@ -112,7 +112,7 @@ function Blog(props: any) {
               </div>
             </div>
 
-            <ol className="grid grid-cols-12 py-16 gap-8 lg:gap-16">
+            <ol className="grid grid-cols-12 py-16 lg:gap-16">
               {blogs.map((blog: PostTypes, idx: number) => (
                 <div className="col-span-12 md:col-span-12 lg:col-span-6 xl:col-span-4 mb-16">
                   <BlogListItem blog={blog} key={idx} />


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to fix the blog image display issue on small screen.

## What is the current behavior?

#4556 

## What is the new behavior?

Blog image can display correctly on small screen. Below are some screenshots.

![Screen Shot 2021-12-21 at 09 00 05](https://user-images.githubusercontent.com/19306324/146838608-e8cfbb6d-652e-4303-afd0-fdc9745b9b25.png)

![Screen Shot 2021-12-21 at 09 02 20](https://user-images.githubusercontent.com/19306324/146838631-047f2e65-2db6-431f-b68f-751b28a44339.png)

![Screen Shot 2021-12-21 at 09 01 27](https://user-images.githubusercontent.com/19306324/146838654-7c12f0f9-7c91-4258-8629-b44cf8fbd849.png)


## Additional context

N/A
