### PR TITLE
Fix: padding style

### DIFF
--- a/www/components/Carousels/ImageCarousel.tsx
+++ b/www/components/Carousels/ImageCarousel.tsx
@@ -169,7 +169,7 @@ function ImageCarousel(props: ImageCarouselProps) {
           {props.content.map((content, i) => {
             return (
               <SwiperSlide key={i}>
-                <div className="bg-white dark:bg-gray-800">
+                <div className="bg-white dark:bg-gray-800 p-px">
                   <Typography.Title level={4}>{content.title}</Typography.Title>
                   <Typography.Text>
                     <p className="text-base">{content.text}</p>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix style problem thing.

## What is the current behavior?

<img width="1392" alt="Screen Shot 2021-12-21 at 3 37 37 PM" src="https://user-images.githubusercontent.com/70828596/146996971-701476b2-88a6-4af7-a00d-66f2626b4f1f.png">

## What is the new behavior?

<img width="1392" alt="Screen Shot 2021-12-21 at 4 00 15 PM" src="https://user-images.githubusercontent.com/70828596/146997131-3517b4d2-2a66-49c7-a6e0-288358b94967.png">