### PR TITLE
update: selection color

### DIFF
--- a/www/styles/index.css
+++ b/www/styles/index.css
@@ -92,6 +92,11 @@ body {
   /* overflow: hidden; */
 }
 
+::selection {
+  @apply bg-green-300;
+  color: #333 !important;
+}
+
 .section--bg-masked {
   position: absolute;
   width: 100%;


### PR DESCRIPTION
## What kind of change does this PR introduce?

 Change highlight color to supabase brand color #4612 

## What is the current behavior?

Highlighted color is default blue color

## What is the new behavior?

Highlighted color is slightly lightly than the brand color

<img width="1440" alt="Screenshot 2021-12-23 at 10 37 30 PM" src="https://user-images.githubusercontent.com/32142878/147271963-cca6c1d1-1ec0-42e3-87b1-87a40f332dec.png">

<img width="1440" alt="Screenshot 2021-12-23 at 10 37 51 PM" src="https://user-images.githubusercontent.com/32142878/147272009-fc76b7a4-b953-42f9-abec-c76a84f1ec36.png">

## Additional context

Add any other context or screenshots.
