### PR TITLE
Fix: anchor links in DEVELOPERS.md would not bring you to corresponding section

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -71,9 +71,9 @@ Before you start a development server, you must choose if you want to work on th
 
 To debug code, and to see changes in real time, it is often useful to have a local HTTP server. Click one of the three links below to choose which development server you want to start.
 
-- [Supabase Website](###Supabase-Website-Development-Server)
-- [Supabase Docs](###Supabase-Docs-Development-Server)
-- [Supabase Studio](###Supabase-Studio-Development-Server)
+- [Supabase Website](#Supabase-Website-Development-Server)
+- [Supabase Docs](#Supabase-Docs-Development-Server)
+- [Supabase Studio](#Supabase-Studio-Development-Server)
 
 ### Supabase Website Development Server
 

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -1,9 +1,9 @@
 # Developing Supabase
 
-* [Development Setup](##Development-Setup)
-* [Installing Dependencies](###Installing-Dependencies)
-* [Building Supabase](##Building-Supabase)
-* [Start a Development Server](##Start-a-Development-Server)
+* [Development Setup](#Development-Setup)
+* [Installing Dependencies](##Installing-Dependencies)
+* [Building Supabase](#Building-Supabase)
+* [Start a Development Server](#Start-a-Development-Server)
 
 ## Development Setup
 

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -1,7 +1,7 @@
 # Developing Supabase
 
 * [Development Setup](#Development-Setup)
-* [Installing Dependencies](##Installing-Dependencies)
+* [Installing Dependencies](#Installing-Dependencies)
 * [Building Supabase](#Building-Supabase)
 * [Start a Development Server](#Start-a-Development-Server)
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update. Clicking the table-of-contents link in DEVELOPERS.md would not bring you to the corresponding section.

## What is the current behavior?

Anchor links would not bring you to the relevant section.

## What is the new behavior?

Anchor links now bring you to the relevant section.

## Additional context

None, just what is stated in this PR.
