### PR TITLE
Docs: update generate link example

### DIFF
--- a/web/spec/supabase.yml
+++ b/web/spec/supabase.yml
@@ -828,8 +828,8 @@ pages:
         js: |
           ```js
           const { data: user, error } = await supabase.auth.api.generateLink({
-            type: 'invite',
-            email: 'email@example.com'
+            'invite',
+            'email@example.com'
           })
           ```
 

--- a/web/spec/supabase.yml
+++ b/web/spec/supabase.yml
@@ -827,10 +827,10 @@ pages:
         isSpotlight: false
         js: |
           ```js
-          const { data: user, error } = await supabase.auth.api.generateLink({
+          const { data: user, error } = await supabase.auth.api.generateLink(
             'invite',
             'email@example.com'
-          })
+          )
           ```
 
   select():


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix #4720

## What is the current behavior?

#4720

## What is the new behavior?

```js
const { data: user, error } = await supabase.auth.api.generateLink({
  'invite',
  'email@example.com'
})
```

## Additional context

@ichbinedgar is this what you wanted?