### PR TITLE
chore: Fixed regression bug for logs ui, useSWRInfinite duplicate api call on refresh

### DIFF
--- a/studio/components/interfaces/Settings/Logs/LogTable.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogTable.tsx
@@ -50,12 +50,13 @@ const LogTable = ({ isCustomQuery, data }: Props) => {
     }, {})
   }, [JSON.stringify(data)])
 
+  const strLogMap = JSON.stringify(logMap)
   useEffect(() => {
-    if (!data) return
+    if (data === null || data === undefined) return
     if (focusedLog && !(focusedLog.id in logMap)) {
       setFocusedLog(null)
     }
-  }, [Object.keys(logMap)])
+  }, [strLogMap])
 
   if (!data) return null
 
@@ -64,7 +65,7 @@ const LogTable = ({ isCustomQuery, data }: Props) => {
 
   const logDataRows = useMemo(() => {
     return Object.values(logMap).sort((a, b) => a.timestamp - b.timestamp)
-  }, [JSON.stringify(Object.keys(logMap))])
+  }, [strLogMap])
   return (
     <section className="flex flex-1 flex-row" style={{ maxHeight }}>
       <DataGrid

--- a/studio/components/interfaces/Settings/Logs/LogTable.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogTable.tsx
@@ -5,6 +5,7 @@ import DataGrid from '@supabase/react-data-grid'
 
 import LogSelection from './LogSelection'
 import { LogData } from './Logs.types'
+import { isNil } from 'lodash'
 
 interface Props {
   isCustomQuery: boolean
@@ -52,7 +53,7 @@ const LogTable = ({ isCustomQuery, data }: Props) => {
 
   const strLogMap = JSON.stringify(logMap)
   useEffect(() => {
-    if (data === null || data === undefined) return
+    if (isNil(data)) return
     if (focusedLog && !(focusedLog.id in logMap)) {
       setFocusedLog(null)
     }

--- a/studio/pages/project/[ref]/settings/logs/[type].tsx
+++ b/studio/pages/project/[ref]/settings/logs/[type].tsx
@@ -110,7 +110,6 @@ export const LogPage: NextPage = () => {
   const handleRefresh = () => {
     setLatestRefresh(new Date().toISOString())
     setSize(1)
-    mutate()
   }
 
   const handleModeToggle = () => {

--- a/studio/tests/pages/projects/logs.test.js
+++ b/studio/tests/pages/projects/logs.test.js
@@ -97,7 +97,7 @@ test('Refreshpage', async () => {
   await waitFor(() => screen.getByText(/my_key/))
 
   // simulate refresh
-  await waitFor(() => userEvent.click(screen.getByText(/Refresh/)))
+  userEvent.click(screen.getByText(/Refresh/))
   // when log line unmounts and it was focused, should close focus panel
   await waitFor(() => screen.queryByText(/my_key/) === null, { timeout: 1000 })
   await waitFor(() => screen.queryByText(/happened/) === null, { timeout: 1000 })


### PR DESCRIPTION
Fixes failing ui test, where duplicate APIs are called on userSWRInfinite page.

could we also get #4537 merged to catch ui regressions? 