### PR TITLE
Fix arguments in pg_dump / psql commands for migration

### DIFF
--- a/web/docs/guides/database.mdx
+++ b/web/docs/guides/database.mdx
@@ -118,10 +118,10 @@ Migrating projects can be achieved using standard PostgreSQL tooling. This is pa
 #### Migrate the database
 
 1. Run `ALTER ROLE postgres SUPERUSER` in the *old* project's SQL editor
-2. Run `pg_dump --clean --if-exists --quote-all-identifiers -d $OLD_DB_URL > dump.sql` from your terminal
+2. Run `pg_dump --clean --if-exists --quote-all-identifiers -h $OLD_DB_URL -U postgres > dump.sql` from your terminal
 3. Run `ALTER ROLE postgres NOSUPERUSER` in the *old* project's SQL editor
 4. Run `ALTER ROLE postgres SUPERUSER` in the *new* project's SQL editor
-5. Run `psql $NEW_DB_URL -f dump.sql` from your terminal
+5. Run `psql -h $NEW_DB_URL -U postgres -f dump.sql` from your terminal
 6. Run `TRUNCATE storage.objects` in the *new* project's SQL editor
 7. Run `ALTER ROLE postgres NOSUPERUSER` in the *new* project's SQL editor
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update to "Migrating between projects" section

## What is the current behavior?

The pg_dump / psql commands were using the incorrect switch -d (dbname) instead of -h (hostname) and did not specify the login username with -U switch. This meant the command did not execute successfully as is.

## What is the new behavior?

Once I corrected the commands as per this edit, I was able to migrate successfully from one project to another
