### PR TITLE
Fix: backed by images

### DIFF
--- a/www/components/Hero.tsx
+++ b/www/components/Hero.tsx
@@ -51,17 +51,17 @@ const Hero = () => {
                     <div className="mt-5 w-full sm:max-w-lg lg:ml-0">
                       <div className="flex flex-wrap items-center justify-start">
                         <img
-                          className="h-8 sm:h-10 pr-10 mb-5"
+                          className="h-8 sm:h-10 pr-5 md:pr-10 mb-5"
                           src={`${basePath}/images/logos/yc--grey.png`}
                           alt="Y Combinator"
                         />
                         <img
-                          className="relative h-5 sm:h-7 pr-10 mb-5"
+                          className="relative h-5 sm:h-7 pr-5 md:pr-10 mb-5"
                           src={`${basePath}/images/logos/mozilla--grey.png`}
                           alt="Mozilla"
                         />
                         <img
-                          className="relative h-5 sm:h-7 pr-10 mb-5"
+                          className="relative h-5 sm:h-7 pr-5 md:pr-10 mb-5"
                           src={`${basePath}/images/logos/coatue.png`}
                           alt="Coatue"
                         />


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

<img width="468" alt="Screen Shot 2022-01-01 at 6 36 47 PM" src="https://user-images.githubusercontent.com/70828596/147865638-8d22411a-e359-403f-ae24-b3c798dc4faa.png">

## What is the new behavior?

<img width="468" alt="Screen Shot 2022-01-01 at 6 37 10 PM" src="https://user-images.githubusercontent.com/70828596/147865643-ef1b9d29-2e8c-445f-88da-11aad6bbf32d.png">

## Additional context

Add any other context or screenshots.
