### PR TITLE
Fix: sponsor icons

### DIFF
--- a/web/src/components/Sponsors.js
+++ b/web/src/components/Sponsors.js
@@ -47,7 +47,7 @@ export default function Sponsors() {
                   <h4 className="">{t.heading}</h4>
                   <div className="row is-multiline" style={{ paddingLeft: 15 }}>
                     {t.transactions.map((x) => (
-                      <div className="col col--3" key={x.sponsor}>
+                      <div className="col col--4" key={x.sponsor}>
                         <a className="avatar" href={`https://github.com/${x.sponsor}`}>
                           <img
                             className="avatar__photo avatar__photo--sm"

--- a/web/src/css/custom.css
+++ b/web/src/css/custom.css
@@ -446,9 +446,6 @@ a.card:hover {
   border: 1px solid var(--custom-primary);
   box-shadow: var(--custom-shadow-xl), 0 0 0 1px var(--custom-primary) !important;
 }
-.avatar__intro {
-  padding-left: 15px;
-}
 
 /*
  * Docs


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix #3068

## What is the current behavior?

<img width="1392" alt="Screen Shot 2022-01-01 at 11 14 19 PM 1" src="https://user-images.githubusercontent.com/70828596/147866030-54f53e80-b5b5-4034-95a9-95f437b6bcb8.png">

## What is the new behavior?

<img width="1392" alt="Screen Shot 2022-01-01 at 11 14 27 PM" src="https://user-images.githubusercontent.com/70828596/147866033-bed45a42-d203-42fd-8b52-db6386544bfe.png">

## Additional context

still a little broken with sponsors with longer names.