### PR TITLE
studio: reduce Docker image size

### DIFF
--- a/studio/Dockerfile
+++ b/studio/Dockerfile
@@ -7,7 +7,7 @@
 #    docker builder prune
 
 
-FROM node:14-alpine as base
+FROM node:14-slim as base
 WORKDIR /usr/src/app
 # Do `npm ci` separately so we can cache `node_modules`
 # https://nodejs.org/en/docs/guides/nodejs-docker-webapp/

--- a/studio/Dockerfile
+++ b/studio/Dockerfile
@@ -7,12 +7,12 @@
 #    docker builder prune
 
 
-FROM node:14 as base
+FROM node:14-alpine as base
 WORKDIR /usr/src/app
 # Do `npm ci` separately so we can cache `node_modules`
 # https://nodejs.org/en/docs/guides/nodejs-docker-webapp/
 COPY package*.json ./
-RUN npm clean-install
+RUN npm clean-install && npm cache clean --force
 COPY . .
 
 FROM base as dev
@@ -20,6 +20,6 @@ EXPOSE 8082
 CMD ["npm", "run", "dev"]
 
 FROM base as production
-RUN npm run build
+RUN npm run build && rm -rf .next/cache/webpack && npm prune --production
 EXPOSE 3000
 CMD ["npm", "run", "start"]


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

The studio Docker image is very large (~1.7GB).

## What is the new behavior?

This switches to Alpine for generating the Docker image for the Studio.
Additionally, the Studio is built first and unused dependencies and
cache are removed. This reduces the uncompressed image size from ~1.7GB
to ~600MB.

Note: this has only been tested on an AMD64 machine.

## Additional context
Related to https://github.com/supabase/supabase/issues/4736.
