### PR TITLE
chore/support updated free project limits

### DIFF
--- a/studio/hooks/queries/useProfile.ts
+++ b/studio/hooks/queries/useProfile.ts
@@ -19,7 +19,11 @@ export function useProfile(returning?: 'minimal') {
   function mutateProfile(updatedUser: User, revalidate?: boolean) {
     mutate(
       url,
-      { first_name: updatedUser.first_name, last_name: updatedUser.last_name },
+      {
+        first_name: updatedUser.first_name,
+        last_name: updatedUser.last_name,
+        total_free_projects: updatedUser.total_free_projects,
+      },
       revalidate ?? true
     )
   }

--- a/studio/lib/constants/infrastructure.ts
+++ b/studio/lib/constants/infrastructure.ts
@@ -23,7 +23,7 @@ export const REGIONS_DEFAULT = REGIONS.EAST_US
 export const PRICING_PLANS = {
   FREE: 'Free tier',
   PRO: 'Pro tier',
-  PAYG: 'Pay as you go',
+  // PAYG: 'Pay as you go',
 }
 
 export const PRICING_PLANS_DEFAULT = PRICING_PLANS.PRO

--- a/studio/lib/constants/infrastructure.ts
+++ b/studio/lib/constants/infrastructure.ts
@@ -130,3 +130,5 @@ export const PASSWORD_STRENGTH_PERCENTAGE = {
   3: '80%',
   4: '100%',
 }
+
+export const DEFAULT_FREE_PROJECTS_LIMIT = 2

--- a/studio/pages/index.tsx
+++ b/studio/pages/index.tsx
@@ -6,9 +6,9 @@ import { isUndefined } from 'lodash'
 import { Typography } from '@supabase/ui'
 
 import { Project } from 'types'
-import { useStore, withAuth } from 'hooks'
+import { useProfile, useStore, withAuth } from 'hooks'
 import { post, delete_ } from 'lib/common/fetch'
-import { API_URL, IS_PLATFORM, PROJECT_STATUS } from 'lib/constants'
+import { API_URL, IS_PLATFORM, PROJECT_STATUS, STRIPE_PRODUCT_IDS } from 'lib/constants'
 import { AccountLayout } from 'components/layouts'
 import Landing from 'components/interfaces/Home/Landing'
 import ProjectList from 'components/interfaces/Home/ProjectList'
@@ -20,6 +20,7 @@ const Home: NextPage = () => {
   const { profile } = ui
 
   const router = useRouter()
+  const { mutateProfile } = useProfile()
 
   const [isDeletingProject, setIsDeletingProject] = useState<boolean>(false)
   const [selectedProjectToDelete, setSelectedProjectToDelete] = useState<Project>()
@@ -41,7 +42,7 @@ const Home: NextPage = () => {
       return ui.setNotification({ category: 'error', message: response.error.message })
     }
 
-    app.onProjectDeleted(response)
+    app.onProjectDeleted(response, mutateProfile)
     ui.setNotification({ category: 'success', message: `Deleted ${project.name} successfully!` })
 
     setIsDeletingProject(false)

--- a/studio/pages/new/[slug].tsx
+++ b/studio/pages/new/[slug].tsx
@@ -94,14 +94,14 @@ export const Wizard = observer(() => {
   const isSelectFreeTier = dbPricingPlan === PRICING_PLANS.FREE
 
   const canCreateProject =
-    currentOrg?.is_owner &&
-    (!isSelectFreeTier || (isSelectFreeTier && !isOverFreeProjectLimit && !isEmptyPaymentMethod))
+    currentOrg?.is_owner && (!isSelectFreeTier || (isSelectFreeTier && !isOverFreeProjectLimit))
 
   const canSubmit =
     projectName != '' &&
     passwordStrengthScore >= DEFAULT_MINIMUM_PASSWORD_STRENGTH &&
     dbRegion != '' &&
-    dbPricingPlan != ''
+    dbPricingPlan != '' &&
+    (isSelectFreeTier || (!isSelectFreeTier && !isEmptyPaymentMethod))
 
   const passwordErrorMessage =
     dbPass != '' && passwordStrengthScore < DEFAULT_MINIMUM_PASSWORD_STRENGTH
@@ -268,12 +268,7 @@ export const Wizard = observer(() => {
             {!currentOrg?.is_owner ? (
               <NotOrganizationOwnerWarning />
             ) : (
-              <>
-                {isSelectFreeTier && isOverFreeProjectLimit && <FreeProjectLimitWarning />}
-                {!isSelectFreeTier && isEmptyPaymentMethod && (
-                  <EmptyPaymentMethodWarning stripeCustomerId={stripeCustomerId} />
-                )}
-              </>
+              <>{isSelectFreeTier && isOverFreeProjectLimit && <FreeProjectLimitWarning />}</>
             )}
           </Panel.Content>
 
@@ -390,6 +385,10 @@ export const Wizard = observer(() => {
                     </Listbox.Option>
                   ))}
                 </Listbox>
+
+                {!isSelectFreeTier && isEmptyPaymentMethod && (
+                  <EmptyPaymentMethodWarning stripeCustomerId={stripeCustomerId} />
+                )}
               </Panel.Content>
             </>
           )}
@@ -472,7 +471,7 @@ const EmptyPaymentMethodWarning = observer(
       } else {
         ui.setNotification({
           category: 'error',
-          message: `Invalid customer id`,
+          message: `Invalid customer ID`,
         })
       }
     }
@@ -486,7 +485,7 @@ const EmptyPaymentMethodWarning = observer(
           description={
             <div className="space-y-3">
               <p className="text-sm leading-normal">
-                It's required to add a payment method for your organization before creating a paid
+                You need to add a payment method for your organization before creating a paid
                 project.
               </p>
               <Button loading={loading} type="secondary" onClick={() => redirectToPortal()}>

--- a/studio/pages/new/[slug].tsx
+++ b/studio/pages/new/[slug].tsx
@@ -369,19 +369,8 @@ export const Wizard = observer(() => {
                   }
                 >
                   {Object.entries(PRICING_PLANS).map(([k, v]) => (
-                    <Listbox.Option
-                      key={k}
-                      label={v}
-                      value={v}
-                      addOnBefore={() => <IconDollarSign />}
-                    >
-                      {`${v}${
-                        v === PRICING_PLANS.PRO
-                          ? ' - $25/month'
-                          : v === PRICING_PLANS.PAYG
-                          ? ' - $25/month plus usage costs'
-                          : ''
-                      }`}
+                    <Listbox.Option key={k} label={v} value={v}>
+                      {`${v}${v === PRICING_PLANS.PRO ? ' - $25/month' : ''}`}
                     </Listbox.Option>
                   ))}
                 </Listbox>

--- a/studio/pages/new/[slug].tsx
+++ b/studio/pages/new/[slug].tsx
@@ -269,7 +269,7 @@ export const Wizard = observer(() => {
               <NotOrganizationOwnerWarning />
             ) : (
               <>
-                {!isSelectFreeTier && isOverFreeProjectLimit && <FreeProjectLimitWarning />}
+                {isSelectFreeTier && isOverFreeProjectLimit && <FreeProjectLimitWarning />}
                 {!isSelectFreeTier && isEmptyPaymentMethod && (
                   <EmptyPaymentMethodWarning stripeCustomerId={stripeCustomerId} />
                 )}

--- a/studio/pages/new/[slug].tsx
+++ b/studio/pages/new/[slug].tsx
@@ -251,8 +251,7 @@ export const Wizard = observer(() => {
               label="Organization"
               layout="horizontal"
               value={currentOrg?.slug}
-              // [Joshen] Should we use router.push?
-              onChange={(slug) => (window.location.href = `/new/${slug}`)}
+              onChange={(slug) => router.push(`/new/${slug}`)}
             >
               {organizations.map((x: any) => (
                 <Listbox.Option

--- a/studio/pages/new/index.tsx
+++ b/studio/pages/new/index.tsx
@@ -49,7 +49,11 @@ const Wizard = () => {
     } else {
       const org = response
       app.onOrgAdded(org)
-      Router.push('/new/[slug]', `/new/${org.slug}`)
+
+      // Router.push('/new/[slug]', `/new/${org.slug}`)
+      // Using window.location.href for now as organization metadata needs to refresh
+      // We do not get is_owner nor stripe_customer_id from the response here
+      window.location.href = `/new/${org.slug}`
     }
   }
 

--- a/studio/pages/project/[ref]/index.tsx
+++ b/studio/pages/project/[ref]/index.tsx
@@ -35,7 +35,7 @@ const Home: NextPage = () => {
   }
 
   const hasProjectData =
-    (usage && usage.bucketSize) || (usage && usage.authUsers !== '0') || (usage && usage.dbTables)
+    usage && (usage?.bucketSize || (usage?.authUsers ?? '0') !== '0' || usage?.dbTables)
       ? true
       : false
 

--- a/studio/pages/project/[ref]/settings/general.tsx
+++ b/studio/pages/project/[ref]/settings/general.tsx
@@ -17,7 +17,7 @@ import {
 import { API_URL } from 'lib/constants'
 import { pluckJsonSchemaFields, pluckObjectFields } from 'lib/helpers'
 import { post, delete_ } from 'lib/common/fetch'
-import { useStore, withAuth } from 'hooks'
+import { useProfile, useStore, withAuth } from 'hooks'
 import { SettingsLayout } from 'components/layouts'
 import Panel from 'components/to-be-cleaned/Panel'
 import SchemaFormPanel from 'components/to-be-cleaned/forms/SchemaFormPanel'
@@ -173,6 +173,7 @@ const GeneralSettings = observer(() => {
 
 const ProjectDeleteModal = ({ project }: any) => {
   const router = useRouter()
+  const { mutateProfile } = useProfile()
   const { ui, app } = useStore()
 
   const [isOpen, setIsOpen] = useState(false)
@@ -189,7 +190,7 @@ const ProjectDeleteModal = ({ project }: any) => {
     try {
       const response = await delete_(`${API_URL}/projects/${project.ref}/remove`)
       if (response.error) throw response.error
-      app.onProjectDeleted(response)
+      app.onProjectDeleted(response, mutateProfile)
       ui.setNotification({ category: 'success', message: `Successfully deleted ${project.name}` })
       router.push(`/`)
     } catch (error: any) {

--- a/studio/stores/UiStore.ts
+++ b/studio/stores/UiStore.ts
@@ -123,7 +123,7 @@ export default class UiStore implements IUiStore {
   }
 
   setProfile(value?: User) {
-    if (value && value?.id != this.profile?.id) {
+    if (value && value?.id !== this.profile?.id) {
       Telemetry.sendIdentify(value)
     }
 

--- a/studio/stores/app/AppStore.ts
+++ b/studio/stores/app/AppStore.ts
@@ -1,9 +1,8 @@
-import { Dictionary } from '@supabase/grid'
 import { cloneDeep } from 'lodash'
 import { values } from 'mobx'
 import { Project } from 'types'
 
-import { API_URL } from 'lib/constants'
+import { API_URL, STRIPE_PRODUCT_IDS } from 'lib/constants'
 import { IRootStore } from '../RootStore'
 import DatabaseStore, { IDatabaseStore } from './DatabaseStore'
 import OrganizationStore from './OrganizationStore'
@@ -14,7 +13,7 @@ export interface IAppStore {
   organizations: OrganizationStore
   database: IDatabaseStore
   onProjectUpdated: (project: any) => void
-  onProjectDeleted: (project: any) => void
+  onProjectDeleted: (project: any, mutateProfile: Function) => void
   onOrgAdded: (org: any) => void
   onOrgUpdated: (org: any) => void
   onOrgDeleted: (org: any) => void
@@ -53,12 +52,22 @@ export default class AppStore implements IAppStore {
     }
   }
 
-  onProjectDeleted(project: any) {
+  onProjectDeleted(project: any, mutateProfile: Function) {
     if (project && project.id) {
+      const profile = this.rootStore.ui.profile
+      const projectMetadata = this.projects.find((proj: any) => proj.id === project.id)
+
       // cleanup project saved queries
       localStorage.removeItem(`supabase-queries-state-${project.ref}`)
       localStorage.removeItem(`supabase_${project.ref}`)
       delete this.projects.data[project.id]
+
+      if (profile && projectMetadata?.subscription_tier_prod_id === STRIPE_PRODUCT_IDS.FREE) {
+        mutateProfile({
+          ...profile,
+          total_free_projects: profile.total_free_projects - 1,
+        })
+      }
     }
   }
 

--- a/studio/types/base.ts
+++ b/studio/types/base.ts
@@ -6,6 +6,7 @@ export interface Organization {
   project_limit: number
   stripe_customer_id?: string
   total_free_projects?: number
+  is_owner?: boolean
 }
 
 export interface Project {
@@ -18,6 +19,8 @@ export interface Project {
   region: string
   connectionString: string
   inserted_at: string
+  subscription_tier: string
+  subscription_tier_prod_id: string
 }
 
 export interface User {
@@ -28,7 +31,8 @@ export interface User {
   first_name: string
   last_name: string
   is_alpha_user: boolean
-  total_free_projects?: number
+  free_project_limit: number
+  total_free_projects: number
 }
 
 export interface Member {


### PR DESCRIPTION
### This is part of the "Unlimited project" feature as documented here: 
https://www.notion.so/supabase/Project-Unlimited-projects-7876da8db87c40378cf177f77b0a0fd6

Broadly these are the changes involved regarding this feature
- Users can create unlimited organizations
- Users can only create up to 2 free projects (by default) across all their organizations
- Users can create as many paid projects as they want
- Users can only create projects in the organizations that they own

This will be different from the current behaviour where users can create **up to 2 organizations**, and **3 free projects** per org (i.e **6 free projects in total per user**)

Corresponding API PR: https://github.com/supabase/infrastructure/pull/3317

Changes on Studio:
- Show corresponding information message when user is creating a new project
  - If user is not owner of the org
  - If user selected free tier and has exceeded free project limit
  - If user selected paid or payg tier but has no default payment option
- Billing page upgrade button to prevent downgrading a project if user has exceeded free project limit