### PR TITLE
chore: bump LICENSE year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2020 Supabase
+   Copyright 2021 Supabase
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bumps the LICENSE year.

## What is the current behavior?

Displays 2021 as the current license year.

## What is the new behavior?

Displays 2022 as the current license year.

## Additional context

N/A
