### PR TITLE
Correct the claim about background workers support

### DIFF
--- a/www/_blog/2021-03-05-postgres-as-a-cron-server.mdx
+++ b/www/_blog/2021-03-05-postgres-as-a-cron-server.mdx
@@ -199,11 +199,9 @@ You might have noticed [this](https://github.com/pramsey/pgsql-http#why-this-is-
 
 > "What happens if the web page takes a long time to return?" Your SQL call will just wait there until it does. Make sure your web service fails fast.
 
-Luckily pg_cron implements [Background Workers](https://paquier.xyz/postgresql-2/postgres-9-3-feature-highlight-custom-background-workers/):
-
-> Care is taken that these extra processes do not interfere with other postmaster tasks: only one such process is started on each ServerLoop iteration. This means a large number of them could be waiting to be started up and postmaster is still able to quickly service external connection requests.
-
-This means that even if your endpoint takes a long time to return, it's not going to be blocking your core Postgres functions. Either way, you should probably only call endpoints that will return a response quickly, or set the http extension to fail fast (`http.timeout_msec = 300`).
+pgsql-http is completely synchronous, as a network call is ongoing, any other work in the same extension is blocked,
+however core Postgres functions should remain unaffected.
+Either way, you should probably only call endpoints that will return a response quickly, or set the http extension to fail fast (`http.timeout_msec = 300`).
 
 If you're familiar with `C`, you could also help `@pramsey` to implement async functions: https://github.com/pramsey/pgsql-http/issues/105
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs

## What is the current behavior?

Incorrect claim about pgsql-http background workers support.

## What is the new behavior?

I have reworded the relevant section to correctly state that pgsql-http does not use background workers.
See pramsey/pgsql-http#127.

## Additional context

BTW, how do you do this?

> set the http extension to fail fast (`http.timeout_msec = 300`).

Just run that in the SQL console in the Supabase dash or is that a configuration option that needs to be set on the extension? It doesn't look like a SQL query to me, but I am not sure. I will PR this blog post again to show it in case this gets an answer.
