### PR TITLE
Add doc link to pages

### DIFF
--- a/www/pages/database/Database.tsx
+++ b/www/pages/database/Database.tsx
@@ -104,6 +104,7 @@ function Database() {
               />
             </div>,
           ]}
+          documentation_url={'/docs/guides/database'}
         />
 
         <SectionContainer>

--- a/www/pages/storage/Storage.tsx
+++ b/www/pages/storage/Storage.tsx
@@ -87,6 +87,7 @@ function StoragePage() {
               />
             </div>,
           ]}
+          documentation_url={'/docs/guides/storage'}
         />
 
         <SectionContainer>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add doc link to database pages and storage page

## What is the current behavior?

For both pages
<img width="1280" alt="Screen Shot 2022-01-05 at 10 59 05 PM" src="https://user-images.githubusercontent.com/70828596/148326181-4c561b0b-60d5-4b5f-8761-7ec0cbf32ed6.png">

## What is the new behavior?

For both pages
<img width="1280" alt="Screen Shot 2022-01-05 at 10 58 54 PM" src="https://user-images.githubusercontent.com/70828596/148326203-c50938f4-3c5b-408b-b2ef-91c113104559.png">