### PR TITLE
bugfix/studio/LogPage: fix for load older logs empty page bug.

### DIFF
--- a/studio/pages/project/[ref]/settings/logs/[type].tsx
+++ b/studio/pages/project/[ref]/settings/logs/[type].tsx
@@ -83,8 +83,7 @@ export const LogPage: NextPage = () => {
     } else if (prevPageData.data.length === 0) {
       // no rows returned, indicates that no more data to retrieve and append.
       return null
-    }else {
-
+    } else {
       const len = prevPageData.data.length
       const { timestamp: tsLimit }: LogData = prevPageData.data[len - 1]
       // create new key from params

--- a/studio/pages/project/[ref]/settings/logs/[type].tsx
+++ b/studio/pages/project/[ref]/settings/logs/[type].tsx
@@ -3,7 +3,15 @@ import React, { useEffect, useRef, useState } from 'react'
 import { NextPage } from 'next'
 import { useRouter } from 'next/router'
 import { observer } from 'mobx-react-lite'
-import { Typography, IconLoader, IconAlertCircle, IconRewind, Button, IconInfo } from '@supabase/ui'
+import {
+  Typography,
+  IconLoader,
+  IconAlertCircle,
+  IconRewind,
+  Button,
+  IconInfo,
+  Card,
+} from '@supabase/ui'
 
 import { withAuth } from 'hooks'
 import { get } from 'lib/common/fetch'
@@ -72,7 +80,11 @@ export const LogPage: NextPage = () => {
     if (prevPageData === null) {
       // reduce interval window limit by using the timestamp of the last log
       queryParams = genQueryParams(params)
-    } else {
+    } else if (prevPageData.data.length === 0) {
+      // no rows returned, indicates that no more data to retrieve and append.
+      return null
+    }else {
+
       const len = prevPageData.data.length
       const { timestamp: tsLimit }: LogData = prevPageData.data[len - 1]
       // create new key from params
@@ -84,18 +96,16 @@ export const LogPage: NextPage = () => {
   }
   const {
     data = [],
+    error: swrError,
     isValidating,
     mutate,
     size,
     setSize,
   } = useSWRInfinite<Logs>(getKeyLogs, get, { revalidateOnFocus: false })
-
-  // const { data, isValidating, mutate } = useSWR<Logs>(logUrl, get, { revalidateOnFocus: false })
   let logData: LogData[] = []
-  let error: null | string = null
-
+  let error: null | string = swrError ? swrError.message : null
   data.forEach((response: Logs) => {
-    if (response && response.data) {
+    if (!error && response && response.data) {
       logData = [...logData, ...response.data]
     }
     if (!error && response && response.error) {
@@ -220,9 +230,16 @@ export const LogPage: NextPage = () => {
             </div>
           )}
           {error && (
-            <div className="flex w-full h-full justify-center items-center space-x-2 mx-auto">
-              <IconAlertCircle size={16} />
-              <Typography.Text type="secondary">Sorry! Could not fetch data</Typography.Text>
+            <div className="flex w-full h-full justify-center items-center mx-auto">
+              <Card className="flex flex-col gap-y-2">
+                <div className="flex flex-row gap-x-2 py-2">
+                  <IconAlertCircle size={16} />
+                  <Typography.Text type="secondary">
+                    Sorry! An error occured when fetching data.
+                  </Typography.Text>
+                </div>
+                <Typography.Text type="warning">{error}</Typography.Text>
+              </Card>
             </div>
           )}
           <LogTable data={logData} isCustomQuery={mode === 'custom'} />


### PR DESCRIPTION
Bugfix for [this loading bug](https://sentry.io/organizations/supabase/issues/2903331460/?project=5459134&referrer=slack)

```
TypeError: Cannot read properties of undefined (reading 'timestamp')
  at t(./pages/project/[ref]/settings/logs/[type].tsx:73:15)
  at ? (./node_modules/swr/infinite/dist/index.esm.js:1:3546)
  at setSize(./node_modules/swr/infinite/dist/index.esm.js:1:3491)
  at apply(./pages/project/[ref]/settings/logs/[type].tsx:207:32)
```

Occurs when `Load older` is clicked when the previously fetched data response is empty (indicating an empty page).

The error would be thrown when executing the `getKeyLogs` function, which would be returned on the `error` key of the useSWR returned object. 

However, it was quite tricky to hunt down and replicate, because useSWR will auto-retry on error, making it invisible to the user in both staging and prod.

I've enhanced the error message displaying as well as added the necessary bugfix for this with accompanying unit test.