### PR TITLE
Update start your project link

### DIFF
--- a/www/components/Nav/index.tsx
+++ b/www/components/Nav/index.tsx
@@ -253,7 +253,7 @@ const Nav = (props: Props) => {
                 <a href="https://app.supabase.io/">
                   <Button type="default">Sign in</Button>
                 </a>
-                <a href="https://app.supabase.io/">
+                <a href="https://app.supabase.io/new/project">
                   <Button>Start your project</Button>
                 </a>
               </div>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Update `start your project` link to take you to the new project page instead of [app.supabase.io](https://app.supabase.io)

## What is the current behavior?

Takes you to [app.supabase.io](https://app.supabase.io)

## What is the new behavior?

Takes you to [app.supabase.io/new/project](https://app.supabase.io/new/project?next=new-project)