### PR TITLE
Add nullif in auth.uid() to handle empty strings

### DIFF
--- a/docker/volumes/db/init/01-auth-schema.sql
+++ b/docker/volumes/db/init/01-auth-schema.sql
@@ -95,8 +95,8 @@ language sql stable
 as $$
   select 
   	coalesce(
-		current_setting('request.jwt.claim.sub', true),
-		(current_setting('request.jwt.claims', true)::jsonb ->> 'sub')
+		nullif(current_setting('request.jwt.claim.sub', true), ''),
+		(nullif(current_setting('request.jwt.claims', true), '')::jsonb ->> 'sub')
 	)::uuid
 $$;
 
@@ -106,8 +106,8 @@ language sql stable
 as $$
   select 
   	coalesce(
-		current_setting('request.jwt.claim.role', true),
-		(current_setting('request.jwt.claims', true)::jsonb ->> 'role')
+		nullif(current_setting('request.jwt.claim.role', true), ''),
+		(nullif(current_setting('request.jwt.claims', true), '')::jsonb ->> 'role')
 	)::text
 $$;
 
@@ -117,8 +117,8 @@ language sql stable
 as $$
   select 
   	coalesce(
-		current_setting('request.jwt.claim.email', true),
-		(current_setting('request.jwt.claims', true)::jsonb ->> 'email')
+		nullif(current_setting('request.jwt.claim.email', true), ''),
+		(nullif(current_setting('request.jwt.claims', true), '')::jsonb ->> 'email')
 	)::text
 $$;
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Bug fix
- Adding `nullif` wrapper to handle empty strings in `auth.uid()`

## What is the current behavior?

Fixes #4794 

## What is the new behavior?

```sql
select nullif(current_setting('request.jwt.claims', true), '')::jsonb ->> 'sub';
-- NULL

set request.jwt.claims to '{"sub": "bla"}';
select nullif(current_setting('request.jwt.claims', true), '')::jsonb ->> 'sub';
-- bla

set request.jwt.claims to '';
select nullif(current_setting('request.jwt.claims', true), '')::jsonb ->> 'sub';
-- NULL
```
