### PR TITLE
Change PGRST_DB_SCHEMA setting to new-style PGRST_DB_SCHEMA

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -80,7 +80,7 @@ services:
     restart: unless-stopped
     environment:
       PGRST_DB_URI: postgres://postgres:${POSTGRES_PASSWORD}@db:5432/postgres
-      PGRST_DB_SCHEMA: public,storage
+      PGRST_DB_SCHEMAS: public,storage
       PGRST_DB_ANON_ROLE: anon
       PGRST_JWT_SECRET: ${JWT_SECRET}
       PGRST_DB_USE_LEGACY_GUCS: "false"


### PR DESCRIPTION
See discussion in https://github.com/PostgREST/postgrest-docs/issues/487.

Changing this to the new-style setting (plural) will avoid confusion, because users are more likely to use the same setting that's used in the docker-compose file when trying in-database configuration.

We have a docs PR open, too.