### PR TITLE
feat: add kubernetes support with Helm

### DIFF
--- a/charts/.helmignore
+++ b/charts/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/README.md
+++ b/charts/README.md
@@ -1,0 +1,80 @@
+# Supabase for Kubernetes with Helm 3
+
+This directory contains the configurations and scripts required to run Supabase inside a Kubernetes cluster.
+
+## Disclamer
+
+We use [bitnami/postgres](https://github.com/bitnami/charts/tree/master/bitnami/postgresql) to create and manage the Postgres database. This permit you to use replication if needed but you'll have to use the Postgres image provided Bitnami or build your own on top of it. You can also choose to use other databases provider like [StackGres](https://stackgres.io/) or [Postgres Operator](https://github.com/zalando/postgres-operator).
+
+For the moment we are using a root container to permit the installation of the missing `pgjwt` and `wal2json` extension inside the `initdbScripts`. This is considered a security issue, but you can use your own Postgres image instead with the extension already installed to prevent this. We provide an example of `Dockerfile`for this purpose, you can use [ours](https://hub.docker.com/r/tdeoliv/supabase-bitnami-postgres) or build and host it on your own.
+
+The database configuration we provide is an example using only one master. If you want to go to production, we highly recommend you to use a replicated database.
+
+## How to use in local
+
+> For this section we're using Minikube and Docker to create a Kubernetes cluster
+
+You'll first need to replace the secrets and endpoints with correct values inside the `values.template.yaml`.
+
+You can create a copy of this file and update the following values:
+
+- `your-super-secret-jwt-token-with-at-least-32-characters-long`: With a generated secret key (`openssl rand 64 | base64`).
+- `JWT_ANON_KEY`: A JWT signed with the key above and the role `anon`.
+- `JWT_SERVICE_KEY`: A JWT signed with the key above and the role `service_role`. You can use the [JWT Tool](https://supabase.com/docs/guides/hosting/overview#api-keys) to generate your keys.
+- `MY_VERY_HARD_PASSWORD_FOR_DATABASE`: Postgres root password for the created database.
+- `RELEASE_NAME`: Name used for helm release.
+- `NAMESPACE`: Namespace used for the helm release.
+
+Considering that the database is local to the cluster you can use the following pattern: `RELEASE_NAME-database.NAMESPACE_NAME.svc.cluster.local`
+
+```bash
+helm install RELEASE_NAME charts/supabase --namespace NAMESPACE -f charts/supabase/values.yaml -f charts/supabase/values.example.yaml --create-namespace
+```
+
+The first deployment can take some time to complete. You can view the status of the pods using:
+
+```bash
+kubectl get pod -n NAMESPACE
+```
+
+### Tunnel with Minikube
+
+When the installation will be complete you'll be able to create a tunnel using minikube:
+
+```bash
+minikube tunnel
+```
+
+If you just use the `value.example.yaml` file, you can access the API or the Studio App using the following endpoints:
+
+- <http://api.localhost>
+- <http://studio.localhost>
+
+## How to use in production
+
+We didn't provide a complete configuration to go production because of the multiple possibility.
+
+But here are the important points you have to think about:
+
+- Use a replicated version of the Postgres database.
+- Add SSL to the Postgres database.
+- Add SSL configuration to the ingresses endpoints using either the `cert-manager` or a LoadBalancer provider.
+- Change the domain used in the ingresses endpoints.
+- Generate a new secure JWT Secret.
+
+## Troubleshooting
+
+### Ingress Controller and Ingress Class
+
+Depending on your Kubernetes version you might want to fill the `className` property instead of the `kubernetes.io/ingress.class` annotations. For example:
+
+```yml
+kong:
+  ingress:
+    enabled: 'true'
+    className: "nginx"
+    annotations:
+      nginx.ingress.kubernetes.io/rewrite-target: /
+```
+
+###

--- a/charts/supabase/Chart.lock
+++ b/charts/supabase/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: postgresql
+  repository: https://charts.bitnami.com/bitnami
+  version: 10.13.15
+digest: sha256:b48a2afb7fe126eb9c55910e2d90967ebc9eed6c694c254b63ae6b6e2d65a478
+generated: "2021-12-24T00:49:49.668094+01:00"

--- a/charts/supabase/Chart.yaml
+++ b/charts/supabase/Chart.yaml
@@ -1,0 +1,31 @@
+apiVersion: v2
+name: supabase
+description: The open source Firebase alternative.
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.0.1
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+# Not used because too difficult to follow correctly
+# appVersion: "1.16.0"
+
+dependencies:
+  - name: postgresql
+    version: 10.13.15
+    alias: database
+    repository: https://charts.bitnami.com/bitnami

--- a/charts/supabase/docker/Database.Dockerfile
+++ b/charts/supabase/docker/Database.Dockerfile
@@ -1,0 +1,11 @@
+FROM bitnami/postgresql:12.9.0-debian-10-r40
+
+USER root
+
+RUN install_packages make git gcc libc6-dev
+RUN git clone https://github.com/michelp/pgjwt.git
+RUN cd pgjwt && make install
+RUN git clone https://github.com/eulerto/wal2json.git
+RUN cd wal2json && make && make install
+
+USER 1001

--- a/charts/supabase/templates/_helpers.tpl
+++ b/charts/supabase/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "supabase.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "supabase.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "supabase.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "supabase.labels" -}}
+helm.sh/chart: {{ include "supabase.chart" . }}
+{{ include "supabase.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "supabase.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "supabase.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "supabase.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "supabase.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/supabase/templates/auth/_helpers.tpl
+++ b/charts/supabase/templates/auth/_helpers.tpl
@@ -1,0 +1,43 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "supabase.auth.name" -}}
+{{- default (print .Chart.Name "-auth") .Values.auth.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "supabase.auth.fullname" -}}
+{{- if .Values.auth.fullnameOverride }}
+{{- .Values.auth.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default (print .Chart.Name "-auth") .Values.auth.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "supabase.auth.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "supabase.auth.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "supabase.auth.serviceAccountName" -}}
+{{- if .Values.auth.serviceAccount.create }}
+{{- default (include "supabase.auth.fullname" .) .Values.auth.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.auth.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/supabase/templates/auth/config.yaml
+++ b/charts/supabase/templates/auth/config.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "supabase.auth.fullname" . }}
+  labels:
+    {{- include "supabase.labels" . | nindent 4 }}
+data:
+  {{- toYaml .Values.auth.environment | nindent 2 }}

--- a/charts/supabase/templates/auth/deployment.yaml
+++ b/charts/supabase/templates/auth/deployment.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "supabase.auth.fullname" . }}
+  labels:
+    {{- include "supabase.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.auth.autoscaling.enabled }}
+  replicas: {{ .Values.auth.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "supabase.auth.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.auth.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "supabase.auth.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.auth.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "supabase.auth.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.auth.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ include "supabase.auth.name" $ }}
+          securityContext:
+            {{- toYaml .Values.auth.securityContext | nindent 12 }}
+          image: "{{ .Values.auth.image.repository }}:{{ .Values.auth.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.auth.image.pullPolicy }}
+          env:
+            {{- range $key, $value := .Values.auth.environment }}
+            - name: {{ $key }}
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "supabase.auth.fullname" $ }}
+                  key: {{ $key }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: 9999
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.auth.resources | nindent 12 }}
+      {{- with .Values.auth.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.auth.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.auth.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/supabase/templates/auth/ingress.yaml
+++ b/charts/supabase/templates/auth/ingress.yaml
@@ -1,0 +1,55 @@
+{{- if .Values.auth.ingress.enabled -}}
+{{- $fullName := include "supabase.auth.fullname" . -}}
+{{- $svcPort := .Values.auth.service.port -}}
+{{- if and .Values.auth.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.auth.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.auth.ingress.annotations "kubernetes.io/ingress.class" .Values.auth.ingress.className}}
+  {{- end }}
+{{- end }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "supabase.labels" . | nindent 4 }}
+  {{- with .Values.auth.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.auth.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.auth.ingress.className }}
+  {{- end }}
+  {{- if .Values.auth.ingress.tls }}
+  tls:
+    {{- range .Values.auth.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.auth.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/supabase/templates/auth/service.yaml
+++ b/charts/supabase/templates/auth/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "supabase.auth.fullname" . }}
+  labels:
+    {{- include "supabase.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.auth.service.type }}
+  ports:
+    - port: {{ .Values.auth.service.port }}
+      targetPort: 9999
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "supabase.auth.selectorLabels" . | nindent 4 }}

--- a/charts/supabase/templates/auth/serviceaccount.yaml
+++ b/charts/supabase/templates/auth/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.auth.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "supabase.auth.serviceAccountName" . }}
+  labels:
+    {{- include "supabase.labels" . | nindent 4 }}
+  {{- with .Values.auth.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/supabase/templates/db/initdb.config.yaml
+++ b/charts/supabase/templates/db/initdb.config.yaml
@@ -1,0 +1,401 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{ .Release.Name }}-initdb
+  labels:
+    {{- include "supabase.labels" . | nindent 4 }}
+data:
+#   00-install-pgjwt.sh: |
+#     #!/bin/bash
+#     set -e
+#     install_packages make git gcc
+#     git clone https://github.com/michelp/pgjwt.git
+#     cd pgjwt
+#     make install
+#     cd ..
+#     git clone https://github.com/eulerto/wal2json.git
+#     cd wal2json
+#     make
+#     make install
+  01-initial-schema.sql: |
+    -- Set up realtime
+    create schema if not exists realtime;
+    -- create publication supabase_realtime; -- defaults to empty publication
+    create publication supabase_realtime;
+
+    -- Supabase super admin
+    create user supabase_admin;
+    alter user  supabase_admin with superuser createdb createrole replication bypassrls;
+
+    -- Extension namespacing
+    create schema if not exists extensions;
+    create extension if not exists "uuid-ossp"      with schema extensions;
+    create extension if not exists pgcrypto         with schema extensions;
+    create extension if not exists pgjwt            with schema extensions;
+
+    -- Set up auth roles for the developer
+    create role anon                nologin noinherit;
+    create role authenticated       nologin noinherit; -- "logged in" user: web_user, app_user, etc
+    create role service_role        nologin noinherit bypassrls; -- allow developers to create JWT's that bypass their policies
+
+    create user authenticator noinherit;
+    grant anon              to authenticator;
+    grant authenticated     to authenticator;
+    grant service_role      to authenticator;
+    grant supabase_admin    to authenticator;
+
+    grant usage                     on schema public to postgres, anon, authenticated, service_role;
+    alter default privileges in schema public grant all on tables to postgres, anon, authenticated, service_role;
+    alter default privileges in schema public grant all on functions to postgres, anon, authenticated, service_role;
+    alter default privileges in schema public grant all on sequences to postgres, anon, authenticated, service_role;
+
+    -- Allow Extensions to be used in the API
+    grant usage                     on schema extensions to postgres, anon, authenticated, service_role;
+
+    -- Set up namespacing
+    alter user supabase_admin SET search_path TO public, extensions; -- don't include the "auth" schema
+
+    -- These are required so that the users receive grants whenever "supabase_admin" creates tables/function
+    alter default privileges for user supabase_admin in schema public grant all
+        on sequences to postgres, anon, authenticated, service_role;
+    alter default privileges for user supabase_admin in schema public grant all
+        on tables to postgres, anon, authenticated, service_role;
+    alter default privileges for user supabase_admin in schema public grant all
+        on functions to postgres, anon, authenticated, service_role;
+
+    -- Set short statement/query timeouts for API roles
+    alter role anon set statement_timeout = '3s';
+    alter role authenticated set statement_timeout = '8s';
+  02-auth-schema.sql: |
+    CREATE SCHEMA IF NOT EXISTS auth AUTHORIZATION supabase_admin;
+
+    -- auth.users definition
+
+    CREATE TABLE auth.users (
+    instance_id uuid NULL,
+    id uuid NOT NULL UNIQUE,
+    aud varchar(255) NULL,
+    "role" varchar(255) NULL,
+    email varchar(255) NULL UNIQUE,
+    encrypted_password varchar(255) NULL,
+    confirmed_at timestamptz NULL,
+    invited_at timestamptz NULL,
+    confirmation_token varchar(255) NULL,
+    confirmation_sent_at timestamptz NULL,
+    recovery_token varchar(255) NULL,
+    recovery_sent_at timestamptz NULL,
+    email_change_token varchar(255) NULL,
+    email_change varchar(255) NULL,
+    email_change_sent_at timestamptz NULL,
+    last_sign_in_at timestamptz NULL,
+    raw_app_meta_data jsonb NULL,
+    raw_user_meta_data jsonb NULL,
+    is_super_admin bool NULL,
+    created_at timestamptz NULL,
+    updated_at timestamptz NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+    );
+    CREATE INDEX users_instance_id_email_idx ON auth.users USING btree (instance_id, email);
+    CREATE INDEX users_instance_id_idx ON auth.users USING btree (instance_id);
+    comment on table auth.users is 'Auth: Stores user login data within a secure schema.';
+
+    -- auth.refresh_tokens definition
+
+    CREATE TABLE auth.refresh_tokens (
+    instance_id uuid NULL,
+    id bigserial NOT NULL,
+    "token" varchar(255) NULL,
+    user_id varchar(255) NULL,
+    revoked bool NULL,
+    created_at timestamptz NULL,
+    updated_at timestamptz NULL,
+    CONSTRAINT refresh_tokens_pkey PRIMARY KEY (id)
+    );
+    CREATE INDEX refresh_tokens_instance_id_idx ON auth.refresh_tokens USING btree (instance_id);
+    CREATE INDEX refresh_tokens_instance_id_user_id_idx ON auth.refresh_tokens USING btree (instance_id, user_id);
+    CREATE INDEX refresh_tokens_token_idx ON auth.refresh_tokens USING btree (token);
+    comment on table auth.refresh_tokens is 'Auth: Store of tokens used to refresh JWT tokens once they expire.';
+
+    -- auth.instances definition
+
+    CREATE TABLE auth.instances (
+    id uuid NOT NULL,
+    uuid uuid NULL,
+    raw_base_config text NULL,
+    created_at timestamptz NULL,
+    updated_at timestamptz NULL,
+    CONSTRAINT instances_pkey PRIMARY KEY (id)
+    );
+    comment on table auth.instances is 'Auth: Manages users across multiple sites.';
+
+    -- auth.audit_log_entries definition
+
+    CREATE TABLE auth.audit_log_entries (
+    instance_id uuid NULL,
+    id uuid NOT NULL,
+    payload json NULL,
+    created_at timestamptz NULL,
+    CONSTRAINT audit_log_entries_pkey PRIMARY KEY (id)
+    );
+    CREATE INDEX audit_logs_instance_id_idx ON auth.audit_log_entries USING btree (instance_id);
+    comment on table auth.audit_log_entries is 'Auth: Audit trail for user actions.';
+
+    -- auth.schema_migrations definition
+
+    CREATE TABLE auth.schema_migrations (
+    "version" varchar(255) NOT NULL,
+    CONSTRAINT schema_migrations_pkey PRIMARY KEY ("version")
+    );
+    comment on table auth.schema_migrations is 'Auth: Manages updates to the auth system.';
+
+    INSERT INTO auth.schema_migrations (version)
+    VALUES  ('20171026211738'),
+            ('20171026211808'),
+            ('20171026211834'),
+            ('20180103212743'),
+            ('20180108183307'),
+            ('20180119214651'),
+            ('20180125194653');
+
+    create or replace function auth.uid() 
+    returns uuid 
+    language sql stable
+    as $$
+    select 
+        coalesce(
+        current_setting('request.jwt.claim.sub', true),
+        (current_setting('request.jwt.claims', true)::jsonb ->> 'sub')
+    )::uuid
+    $$;
+
+    create or replace function auth.role() 
+    returns text 
+    language sql stable
+    as $$
+    select 
+        coalesce(
+        current_setting('request.jwt.claim.role', true),
+        (current_setting('request.jwt.claims', true)::jsonb ->> 'role')
+    )::text
+    $$;
+
+    create or replace function auth.email() 
+    returns text 
+    language sql stable
+    as $$
+    select 
+        coalesce(
+        current_setting('request.jwt.claim.email', true),
+        (current_setting('request.jwt.claims', true)::jsonb ->> 'email')
+    )::text
+    $$;
+
+    -- usage on auth functions to API roles
+    GRANT USAGE ON SCHEMA auth TO anon, authenticated, service_role;
+
+    -- Supabase super admin
+    CREATE USER supabase_auth_admin NOINHERIT CREATEROLE LOGIN NOREPLICATION;
+    GRANT ALL PRIVILEGES ON SCHEMA auth TO supabase_auth_admin;
+    GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA auth TO supabase_auth_admin;
+    GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA auth TO supabase_auth_admin;
+    ALTER USER supabase_auth_admin SET search_path = "auth";
+    ALTER table "auth".users OWNER TO supabase_auth_admin;
+    ALTER table "auth".refresh_tokens OWNER TO supabase_auth_admin;
+    ALTER table "auth".audit_log_entries OWNER TO supabase_auth_admin;
+    ALTER table "auth".instances OWNER TO supabase_auth_admin;
+    ALTER table "auth".schema_migrations OWNER TO supabase_auth_admin;
+
+    ALTER FUNCTION "auth"."uid" OWNER TO supabase_auth_admin;
+    ALTER FUNCTION "auth"."role" OWNER TO supabase_auth_admin;
+    ALTER FUNCTION "auth"."email" OWNER TO supabase_auth_admin;
+    GRANT EXECUTE ON FUNCTION "auth"."uid"() TO PUBLIC;
+    GRANT EXECUTE ON FUNCTION "auth"."role"() TO PUBLIC;
+    GRANT EXECUTE ON FUNCTION "auth"."email"() TO PUBLIC;
+
+  03-storage-schema.sql: |
+    CREATE SCHEMA IF NOT EXISTS storage AUTHORIZATION supabase_admin;
+
+    grant usage on schema storage to postgres, anon, authenticated, service_role;
+    alter default privileges in schema storage grant all on tables to postgres, anon, authenticated, service_role;
+    alter default privileges in schema storage grant all on functions to postgres, anon, authenticated, service_role;
+    alter default privileges in schema storage grant all on sequences to postgres, anon, authenticated, service_role;
+
+    CREATE TABLE "storage"."buckets" (
+        "id" text not NULL,
+        "name" text NOT NULL,
+        "owner" uuid,
+        "created_at" timestamptz DEFAULT now(),
+        "updated_at" timestamptz DEFAULT now(),
+        CONSTRAINT "buckets_owner_fkey" FOREIGN KEY ("owner") REFERENCES "auth"."users"("id"),
+        PRIMARY KEY ("id")
+    );
+    CREATE UNIQUE INDEX "bname" ON "storage"."buckets" USING BTREE ("name");
+
+    CREATE TABLE "storage"."objects" (
+        "id" uuid NOT NULL DEFAULT extensions.uuid_generate_v4(),
+        "bucket_id" text,
+        "name" text,
+        "owner" uuid,
+        "created_at" timestamptz DEFAULT now(),
+        "updated_at" timestamptz DEFAULT now(),
+        "last_accessed_at" timestamptz DEFAULT now(),
+        "metadata" jsonb,
+        CONSTRAINT "objects_bucketId_fkey" FOREIGN KEY ("bucket_id") REFERENCES "storage"."buckets"("id"),
+        CONSTRAINT "objects_owner_fkey" FOREIGN KEY ("owner") REFERENCES "auth"."users"("id"),
+        PRIMARY KEY ("id")
+    );
+    CREATE UNIQUE INDEX "bucketid_objname" ON "storage"."objects" USING BTREE ("bucket_id","name");
+    CREATE INDEX name_prefix_search ON storage.objects(name text_pattern_ops);
+
+    ALTER TABLE storage.objects ENABLE ROW LEVEL SECURITY;
+
+    CREATE FUNCTION storage.foldername(name text)
+    RETURNS text[]
+    LANGUAGE plpgsql
+    AS $function$
+    DECLARE
+    _parts text[];
+    BEGIN
+    select string_to_array(name, '/') into _parts;
+    return _parts[1:array_length(_parts,1)-1];
+    END
+    $function$;
+
+    CREATE FUNCTION storage.filename(name text)
+    RETURNS text
+    LANGUAGE plpgsql
+    AS $function$
+    DECLARE
+    _parts text[];
+    BEGIN
+    select string_to_array(name, '/') into _parts;
+    return _parts[array_length(_parts,1)];
+    END
+    $function$;
+
+    CREATE FUNCTION storage.extension(name text)
+    RETURNS text
+    LANGUAGE plpgsql
+    AS $function$
+    DECLARE
+    _parts text[];
+    _filename text;
+    BEGIN
+    select string_to_array(name, '/') into _parts;
+    select _parts[array_length(_parts,1)] into _filename;
+    -- @todo return the last part instead of 2
+    return split_part(_filename, '.', 2);
+    END
+    $function$;
+
+    CREATE FUNCTION storage.search(prefix text, bucketname text, limits int DEFAULT 100, levels int DEFAULT 1, offsets int DEFAULT 0)
+    RETURNS TABLE (
+        name text,
+        id uuid,
+        updated_at TIMESTAMPTZ,
+        created_at TIMESTAMPTZ,
+        last_accessed_at TIMESTAMPTZ,
+        metadata jsonb
+    )
+    LANGUAGE plpgsql
+    AS $function$
+    DECLARE
+    _bucketId text;
+    BEGIN
+        -- will be replaced by migrations when server starts
+        -- saving space for cloud-init
+    END
+    $function$;
+
+    -- create migrations table
+    -- https://github.com/ThomWright/postgres-migrations/blob/master/src/migrations/0_create-migrations-table.sql
+    -- we add this table here and not let it be auto-created so that the permissions are properly applied to it
+    CREATE TABLE IF NOT EXISTS storage.migrations (
+    id integer PRIMARY KEY,
+    name varchar(100) UNIQUE NOT NULL,
+    hash varchar(40) NOT NULL, -- sha1 hex encoded hash of the file name and contents, to ensure it hasn't been altered since applying the migration
+    executed_at timestamp DEFAULT current_timestamp
+    );
+
+    CREATE USER supabase_storage_admin NOINHERIT CREATEROLE LOGIN NOREPLICATION;
+    GRANT ALL PRIVILEGES ON SCHEMA storage TO supabase_storage_admin;
+    GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA storage TO supabase_storage_admin;
+    GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA storage TO supabase_storage_admin;
+    ALTER USER supabase_storage_admin SET search_path = "storage";
+    ALTER table "storage".objects owner to supabase_storage_admin;
+    ALTER table "storage".buckets owner to supabase_storage_admin;
+    ALTER table "storage".migrations OWNER TO supabase_storage_admin;
+    ALTER function "storage".foldername(text) owner to supabase_storage_admin;
+    ALTER function "storage".filename(text) owner to supabase_storage_admin;
+    ALTER function "storage".extension(text) owner to supabase_storage_admin;
+    ALTER function "storage".search(text,text,int,int,int) owner to supabase_storage_admin;
+
+  04-post-setup.sql: |
+    ALTER ROLE postgres SET search_path TO "\$user",public,extensions;
+    CREATE OR REPLACE FUNCTION extensions.notify_api_restart()
+    RETURNS event_trigger
+    LANGUAGE plpgsql
+    AS $$
+    BEGIN
+        NOTIFY ddl_command_end;
+    END;
+    $$;
+    CREATE EVENT TRIGGER api_restart ON ddl_command_end
+    EXECUTE PROCEDURE extensions.notify_api_restart();
+    COMMENT ON FUNCTION extensions.notify_api_restart IS 'Sends a notification to the API to restart. If your database schema has changed, this is required so that Supabase can rebuild the relationships.';
+
+    -- Trigger for pg_cron
+    CREATE OR REPLACE FUNCTION extensions.grant_pg_cron_access()
+    RETURNS event_trigger
+    LANGUAGE plpgsql
+    AS $$
+    DECLARE
+    schema_is_cron bool;
+    BEGIN
+    schema_is_cron = (
+        SELECT n.nspname = 'cron'
+        FROM pg_event_trigger_ddl_commands() AS ev
+        LEFT JOIN pg_catalog.pg_namespace AS n
+        ON ev.objid = n.oid
+    );
+
+    IF schema_is_cron
+    THEN
+        grant usage on schema cron to postgres with grant option;
+
+        alter default privileges in schema cron grant all on tables to postgres with grant option;
+        alter default privileges in schema cron grant all on functions to postgres with grant option;
+        alter default privileges in schema cron grant all on sequences to postgres with grant option;
+
+        alter default privileges for user supabase_admin in schema cron grant all
+            on sequences to postgres with grant option;
+        alter default privileges for user supabase_admin in schema cron grant all
+            on tables to postgres with grant option;
+        alter default privileges for user supabase_admin in schema cron grant all
+            on functions to postgres with grant option;
+
+        grant all privileges on all tables in schema cron to postgres with grant option; 
+
+    END IF;
+
+    END;
+    $$;
+    CREATE EVENT TRIGGER issue_pg_cron_access ON ddl_command_end WHEN TAG in ('CREATE SCHEMA')
+    EXECUTE PROCEDURE extensions.grant_pg_cron_access();
+    COMMENT ON FUNCTION extensions.grant_pg_cron_access IS 'Grants access to pg_cron';
+
+    -- Supabase dashboard user
+    CREATE ROLE dashboard_user NOSUPERUSER CREATEDB CREATEROLE REPLICATION;
+    GRANT ALL ON DATABASE postgres TO dashboard_user;
+    GRANT ALL ON SCHEMA auth TO dashboard_user;
+    GRANT ALL ON SCHEMA extensions TO dashboard_user;
+    GRANT ALL ON SCHEMA storage TO dashboard_user;
+    GRANT ALL ON ALL TABLES IN SCHEMA auth TO dashboard_user;
+    GRANT ALL ON ALL TABLES IN SCHEMA extensions TO dashboard_user;
+    -- GRANT ALL ON ALL TABLES IN SCHEMA storage TO dashboard_user;
+    GRANT ALL ON ALL SEQUENCES IN SCHEMA auth TO dashboard_user;
+    GRANT ALL ON ALL SEQUENCES IN SCHEMA storage TO dashboard_user;
+    GRANT ALL ON ALL SEQUENCES IN SCHEMA extensions TO dashboard_user;
+    GRANT ALL ON ALL ROUTINES IN SCHEMA auth TO dashboard_user;
+    GRANT ALL ON ALL ROUTINES IN SCHEMA storage TO dashboard_user;
+    GRANT ALL ON ALL ROUTINES IN SCHEMA extensions TO dashboard_user;

--- a/charts/supabase/templates/kong/_helpers.tpl
+++ b/charts/supabase/templates/kong/_helpers.tpl
@@ -1,0 +1,43 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "supabase.kong.name" -}}
+{{- default (print .Chart.Name "-kong") .Values.kong.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "supabase.kong.fullname" -}}
+{{- if .Values.kong.fullnameOverride }}
+{{- .Values.kong.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default (print .Chart.Name "-kong") .Values.kong.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "supabase.kong.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "supabase.kong.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "supabase.kong.serviceAccountName" -}}
+{{- if .Values.kong.serviceAccount.create }}
+{{- default (include "supabase.kong.fullname" .) .Values.kong.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.kong.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/supabase/templates/kong/config.yaml
+++ b/charts/supabase/templates/kong/config.yaml
@@ -1,0 +1,149 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "supabase.kong.fullname" . }}
+  labels:
+    {{- include "supabase.labels" . | nindent 4 }}
+data:
+  {{- toYaml .Values.kong.environment | nindent 2 }}
+{{- if .Values.kong.config -}}
+  kong.yml:
+  {{- toYaml .Values.kong.config | nindent 4 }}
+{{- else }}
+  kong.yml: >-
+    _format_version: "1.1"
+
+    consumers:
+      - username: anon
+        keyauth_credentials:
+          - key: {{ .Values.kong.credentials.anonKey }}
+      - username: service_role
+        keyauth_credentials:
+          - key: {{ .Values.kong.credentials.serviceRoleKey }}
+
+    acls:
+      - consumer: anon
+        group: anon
+      - consumer: service_role
+        group: admin
+
+    services:
+      - name: auth-v1-open
+        url: http://{{ include "supabase.auth.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:9999/verify
+        routes:
+          - name: auth-v1-open
+            strip_path: true
+            paths:
+              - /auth/v1/verify
+        plugins:
+          - name: cors
+      - name: auth-v1-open-callback
+        url: http://{{ include "supabase.auth.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:9999/callback
+        routes:
+          - name: auth-v1-open-callback
+            strip_path: true
+            paths:
+              - /auth/v1/callback
+        plugins:
+          - name: cors
+      - name: auth-v1-open-authorize
+        url: http://{{ include "supabase.auth.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:9999/authorize
+        routes:
+          - name: auth-v1-open-authorize
+            strip_path: true
+            paths:
+              - /auth/v1/authorize
+        plugins:
+          - name: cors
+
+
+      - name: auth-v1
+        _comment: "GoTrue: /auth/v1/* -> http://{{ include "supabase.auth.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:9999/*"
+        url: http://{{ include "supabase.auth.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:9999
+        routes:
+          - name: auth-v1-all
+            strip_path: true
+            paths:
+              - /auth/v1/
+        plugins:
+          - name: cors
+          - name: key-auth
+            config:
+              hide_credentials: false
+          - name: acl
+            config:
+              hide_groups_header: true
+              allow:
+                - admin
+                - anon
+
+
+      - name: rest-v1
+        _comment: "PostgREST: /rest/v1/* -> http://{{ include "supabase.rest.fullname" . }}.{{ .Release.Namespace }}:3000/*"
+        url: http://{{ include "supabase.rest.fullname" . }}.{{ .Release.Namespace }}:3000/
+        routes:
+          - name: rest-v1-all
+            strip_path: true
+            paths:
+              - /rest/v1/
+        plugins:
+          - name: cors
+          - name: key-auth
+            config:
+              hide_credentials: true
+          - name: acl
+            config:
+              hide_groups_header: true
+              allow:
+                - admin
+                - anon
+
+      - name: realtime-v1
+        _comment: "Realtime: /realtime/v1/* -> ws://{{ include "supabase.realtime.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:4000/socket/*"
+        url: http://{{ include "supabase.realtime.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:4000/socket
+        routes:
+          - name: realtime-v1-all
+            strip_path: true
+            paths:
+              - /realtime/v1/
+        plugins:
+          - name: cors
+          - name: key-auth
+            config:
+              hide_credentials: false
+          - name: acl
+            config:
+              hide_groups_header: true
+              allow:
+                - admin
+                - anon
+
+      - name: storage-v1
+        _comment: "Storage: /storage/v1/* -> http://{{ include "supabase.storage.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:5000/*"
+        url: http://{{ include "supabase.storage.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:5000/
+        routes:
+          - name: storage-v1-all
+            strip_path: true
+            paths:
+              - /storage/v1/
+        plugins:
+          - name: cors
+
+      - name: meta
+        _comment: "pg-meta: /pg/* -> http://{{ include "supabase.meta.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:8080/*"
+        url: http://{{ include "supabase.meta.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:8080/
+        routes:
+          - name: meta-all
+            strip_path: true
+            paths:
+              - /pg/
+        plugins:
+          - name: key-auth
+            config:
+              hide_credentials: false
+          - name: acl
+            config:
+              hide_groups_header: true
+              allow:
+                - admin
+{{- end }}

--- a/charts/supabase/templates/kong/deployment.yaml
+++ b/charts/supabase/templates/kong/deployment.yaml
@@ -1,0 +1,72 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "supabase.kong.fullname" . }}
+  labels:
+    {{- include "supabase.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.kong.autoscaling.enabled }}
+  replicas: {{ .Values.kong.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "supabase.kong.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.kong.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "supabase.kong.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.kong.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "supabase.kong.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.kong.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ include "supabase.kong.name" $ }}
+          securityContext:
+            {{- toYaml .Values.kong.securityContext | nindent 12 }}
+          image: "{{ .Values.kong.image.repository }}:{{ .Values.kong.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.kong.image.pullPolicy }}
+          volumeMounts:
+            - name: config-volume
+              mountPath: /var/lib/kong/kong.yml
+              subPath: kong.yml
+          env:
+            {{- range $key, $value := .Values.kong.environment }}
+            - name: {{ $key }}
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "supabase.kong.fullname" $ }}
+                  key: {{ $key }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.kong.resources | nindent 12 }}
+      {{- with .Values.kong.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.kong.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.kong.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: config-volume
+          configMap:
+            name: {{ include "supabase.kong.fullname" $ }}
+            items:
+            - key: kong.yml
+              path: kong.yml

--- a/charts/supabase/templates/kong/ingress.yaml
+++ b/charts/supabase/templates/kong/ingress.yaml
@@ -1,0 +1,55 @@
+{{- if .Values.kong.ingress.enabled -}}
+{{- $fullName := include "supabase.kong.fullname" . -}}
+{{- $svcPort := .Values.kong.service.port -}}
+{{- if and .Values.kong.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.kong.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.kong.ingress.annotations "kubernetes.io/ingress.class" .Values.kong.ingress.className}}
+  {{- end }}
+{{- end }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "supabase.labels" . | nindent 4 }}
+  {{- with .Values.kong.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.kong.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.kong.ingress.className }}
+  {{- end }}
+  {{- if .Values.kong.ingress.tls }}
+  tls:
+    {{- range .Values.kong.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.kong.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/supabase/templates/kong/service.yaml
+++ b/charts/supabase/templates/kong/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "supabase.kong.fullname" . }}
+  labels:
+    {{- include "supabase.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.kong.service.type }}
+  ports:
+    - port: {{ .Values.kong.service.port }}
+      targetPort: 8000
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "supabase.kong.selectorLabels" . | nindent 4 }}

--- a/charts/supabase/templates/kong/serviceaccount.yaml
+++ b/charts/supabase/templates/kong/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.kong.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "supabase.kong.serviceAccountName" . }}
+  labels:
+    {{- include "supabase.labels" . | nindent 4 }}
+  {{- with .Values.kong.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/supabase/templates/meta/_helpers.tpl
+++ b/charts/supabase/templates/meta/_helpers.tpl
@@ -1,0 +1,43 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "supabase.meta.name" -}}
+{{- default (print .Chart.Name "-meta") .Values.meta.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "supabase.meta.fullname" -}}
+{{- if .Values.meta.fullnameOverride }}
+{{- .Values.meta.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default (print .Chart.Name "-meta") .Values.meta.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "supabase.meta.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "supabase.meta.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "supabase.meta.serviceAccountName" -}}
+{{- if .Values.meta.serviceAccount.create }}
+{{- default (include "supabase.meta.fullname" .) .Values.meta.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.meta.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/supabase/templates/meta/config.yaml
+++ b/charts/supabase/templates/meta/config.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "supabase.meta.fullname" . }}
+  labels:
+    {{- include "supabase.labels" . | nindent 4 }}
+data:
+  {{- toYaml .Values.meta.environment | nindent 2 }}

--- a/charts/supabase/templates/meta/deployment.yaml
+++ b/charts/supabase/templates/meta/deployment.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "supabase.meta.fullname" . }}
+  labels:
+    {{- include "supabase.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.meta.autoscaling.enabled }}
+  replicas: {{ .Values.meta.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "supabase.meta.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.meta.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "supabase.meta.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.meta.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "supabase.meta.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.meta.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ include "supabase.meta.name" $ }}
+          securityContext:
+            {{- toYaml .Values.meta.securityContext | nindent 12 }}
+          image: "{{ .Values.meta.image.repository }}:{{ .Values.meta.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.meta.image.pullPolicy }}
+          env:
+            {{- range $key, $value := .Values.meta.environment }}
+            - name: {{ $key }}
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "supabase.meta.fullname" $ }}
+                  key: {{ $key }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.meta.resources | nindent 12 }}
+      {{- with .Values.meta.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.meta.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.meta.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/supabase/templates/meta/ingress.yaml
+++ b/charts/supabase/templates/meta/ingress.yaml
@@ -1,0 +1,55 @@
+{{- if .Values.meta.ingress.enabled -}}
+{{- $fullName := include "supabase.meta.fullname" . -}}
+{{- $svcPort := .Values.meta.service.port -}}
+{{- if and .Values.meta.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.meta.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.meta.ingress.annotations "kubernetes.io/ingress.class" .Values.meta.ingress.className}}
+  {{- end }}
+{{- end }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "supabase.labels" . | nindent 4 }}
+  {{- with .Values.meta.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.meta.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.meta.ingress.className }}
+  {{- end }}
+  {{- if .Values.meta.ingress.tls }}
+  tls:
+    {{- range .Values.meta.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.meta.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/supabase/templates/meta/service.yaml
+++ b/charts/supabase/templates/meta/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "supabase.meta.fullname" . }}
+  labels:
+    {{- include "supabase.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.meta.service.type }}
+  ports:
+    - port: {{ .Values.meta.service.port }}
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "supabase.meta.selectorLabels" . | nindent 4 }}

--- a/charts/supabase/templates/meta/serviceaccount.yaml
+++ b/charts/supabase/templates/meta/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.meta.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "supabase.meta.serviceAccountName" . }}
+  labels:
+    {{- include "supabase.labels" . | nindent 4 }}
+  {{- with .Values.meta.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/supabase/templates/realtime/_helpers.tpl
+++ b/charts/supabase/templates/realtime/_helpers.tpl
@@ -1,0 +1,43 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "supabase.realtime.name" -}}
+{{- default (print .Chart.Name "-realtime") .Values.realtime.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "supabase.realtime.fullname" -}}
+{{- if .Values.realtime.fullnameOverride }}
+{{- .Values.realtime.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default (print .Chart.Name "-realtime") .Values.realtime.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "supabase.realtime.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "supabase.realtime.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "supabase.realtime.serviceAccountName" -}}
+{{- if .Values.realtime.serviceAccount.create }}
+{{- default (include "supabase.realtime.fullname" .) .Values.realtime.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.realtime.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/supabase/templates/realtime/config.yaml
+++ b/charts/supabase/templates/realtime/config.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "supabase.realtime.fullname" . }}
+  labels:
+    {{- include "supabase.labels" . | nindent 4 }}
+data:
+  {{- toYaml .Values.realtime.environment | nindent 2 }}

--- a/charts/supabase/templates/realtime/deployment.yaml
+++ b/charts/supabase/templates/realtime/deployment.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "supabase.realtime.fullname" . }}
+  labels:
+    {{- include "supabase.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.realtime.autoscaling.enabled }}
+  replicas: {{ .Values.realtime.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "supabase.realtime.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.realtime.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "supabase.realtime.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.realtime.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "supabase.realtime.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.realtime.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ include "supabase.realtime.name" $ }}
+          securityContext:
+            {{- toYaml .Values.realtime.securityContext | nindent 12 }}
+          image: "{{ .Values.realtime.image.repository }}:{{ .Values.realtime.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.realtime.image.pullPolicy }}
+          command: ["/bin/sh"]
+          args: ["-c", "./prod/rel/realtime/bin/realtime eval Realtime.Release.migrate && ./prod/rel/realtime/bin/realtime start"]
+          env:
+            {{- range $key, $value := .Values.realtime.environment }}
+            - name: {{ $key }}
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "supabase.realtime.fullname" $ }}
+                  key: {{ $key }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: 4000
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.realtime.resources | nindent 12 }}
+      {{- with .Values.realtime.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.realtime.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.realtime.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/supabase/templates/realtime/ingress.yaml
+++ b/charts/supabase/templates/realtime/ingress.yaml
@@ -1,0 +1,55 @@
+{{- if .Values.realtime.ingress.enabled -}}
+{{- $fullName := include "supabase.realtime.fullname" . -}}
+{{- $svcPort := .Values.realtime.service.port -}}
+{{- if and .Values.realtime.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.realtime.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.realtime.ingress.annotations "kubernetes.io/ingress.class" .Values.realtime.ingress.className}}
+  {{- end }}
+{{- end }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "supabase.labels" . | nindent 4 }}
+  {{- with .Values.realtime.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.realtime.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.realtime.ingress.className }}
+  {{- end }}
+  {{- if .Values.realtime.ingress.tls }}
+  tls:
+    {{- range .Values.realtime.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.realtime.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/supabase/templates/realtime/service.yaml
+++ b/charts/supabase/templates/realtime/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "supabase.realtime.fullname" . }}
+  labels:
+    {{- include "supabase.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.realtime.service.type }}
+  ports:
+    - port: {{ .Values.realtime.service.port }}
+      targetPort: 4000
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "supabase.realtime.selectorLabels" . | nindent 4 }}

--- a/charts/supabase/templates/realtime/serviceaccount.yaml
+++ b/charts/supabase/templates/realtime/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.realtime.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "supabase.realtime.serviceAccountName" . }}
+  labels:
+    {{- include "supabase.labels" . | nindent 4 }}
+  {{- with .Values.realtime.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/supabase/templates/rest/_helpers.tpl
+++ b/charts/supabase/templates/rest/_helpers.tpl
@@ -1,0 +1,43 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "supabase.rest.name" -}}
+{{- default (print .Chart.Name "-rest") .Values.rest.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "supabase.rest.fullname" -}}
+{{- if .Values.rest.fullnameOverride }}
+{{- .Values.rest.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default (print .Chart.Name "-rest") .Values.rest.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "supabase.rest.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "supabase.rest.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "supabase.rest.serviceAccountName" -}}
+{{- if .Values.rest.serviceAccount.create }}
+{{- default (include "supabase.rest.fullname" .) .Values.rest.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.rest.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/supabase/templates/rest/config.yaml
+++ b/charts/supabase/templates/rest/config.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "supabase.rest.fullname" . }}
+  labels:
+    {{- include "supabase.labels" . | nindent 4 }}
+data:
+  {{- toYaml .Values.rest.environment | nindent 2 }}

--- a/charts/supabase/templates/rest/deployment.yaml
+++ b/charts/supabase/templates/rest/deployment.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "supabase.rest.fullname" . }}
+  labels:
+    {{- include "supabase.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.rest.autoscaling.enabled }}
+  replicas: {{ .Values.rest.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "supabase.rest.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.rest.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "supabase.rest.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.rest.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "supabase.rest.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.rest.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ include "supabase.rest.name" $ }}
+          securityContext:
+            {{- toYaml .Values.rest.securityContext | nindent 12 }}
+          image: "{{ .Values.rest.image.repository }}:{{ .Values.rest.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.rest.image.pullPolicy }}
+          env:
+            {{- range $key, $value := .Values.rest.environment }}
+            - name: {{ $key }}
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "supabase.rest.fullname" $ }}
+                  key: {{ $key }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.rest.resources | nindent 12 }}
+      {{- with .Values.rest.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.rest.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.rest.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/supabase/templates/rest/ingress.yaml
+++ b/charts/supabase/templates/rest/ingress.yaml
@@ -1,0 +1,55 @@
+{{- if .Values.rest.ingress.enabled -}}
+{{- $fullName := include "supabase.rest.fullname" . -}}
+{{- $svcPort := .Values.rest.service.port -}}
+{{- if and .Values.rest.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.rest.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.rest.ingress.annotations "kubernetes.io/ingress.class" .Values.rest.ingress.className}}
+  {{- end }}
+{{- end }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "supabase.labels" . | nindent 4 }}
+  {{- with .Values.rest.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.rest.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.rest.ingress.className }}
+  {{- end }}
+  {{- if .Values.rest.ingress.tls }}
+  tls:
+    {{- range .Values.rest.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.rest.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/supabase/templates/rest/service.yaml
+++ b/charts/supabase/templates/rest/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "supabase.rest.fullname" . }}
+  labels:
+    {{- include "supabase.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.rest.service.type }}
+  ports:
+    - port: {{ .Values.rest.service.port }}
+      targetPort: 3000
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "supabase.rest.selectorLabels" . | nindent 4 }}

--- a/charts/supabase/templates/rest/serviceaccount.yaml
+++ b/charts/supabase/templates/rest/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.rest.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "supabase.rest.serviceAccountName" . }}
+  labels:
+    {{- include "supabase.labels" . | nindent 4 }}
+  {{- with .Values.rest.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/supabase/templates/storage/_helpers.tpl
+++ b/charts/supabase/templates/storage/_helpers.tpl
@@ -1,0 +1,43 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "supabase.storage.name" -}}
+{{- default (print .Chart.Name "-storage") .Values.storage.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "supabase.storage.fullname" -}}
+{{- if .Values.storage.fullnameOverride }}
+{{- .Values.storage.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default (print .Chart.Name "-storage") .Values.storage.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "supabase.storage.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "supabase.storage.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "supabase.storage.serviceAccountName" -}}
+{{- if .Values.storage.serviceAccount.create }}
+{{- default (include "supabase.storage.fullname" .) .Values.storage.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.storage.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/supabase/templates/storage/config.yaml
+++ b/charts/supabase/templates/storage/config.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "supabase.storage.fullname" . }}
+  labels:
+    {{- include "supabase.labels" . | nindent 4 }}
+data:
+  {{- toYaml .Values.storage.environment | nindent 2 }}

--- a/charts/supabase/templates/storage/deployment.yaml
+++ b/charts/supabase/templates/storage/deployment.yaml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "supabase.storage.fullname" . }}
+  labels:
+    {{- include "supabase.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.storage.autoscaling.enabled }}
+  replicas: {{ .Values.storage.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "supabase.storage.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.storage.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "supabase.storage.selectorLabels" . | nindent 8 }}
+    spec:
+      restartPolicy: Always
+      {{- with .Values.storage.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "supabase.storage.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.storage.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ include "supabase.storage.name" $ }}
+          securityContext:
+            {{- toYaml .Values.storage.securityContext | nindent 12 }}
+          image: "{{ .Values.storage.image.repository }}:{{ .Values.storage.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.storage.image.pullPolicy }}
+          env:
+            {{- range $key, $value := .Values.storage.environment }}
+            - name: {{ $key }}
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "supabase.storage.fullname" $ }}
+                  key: {{ $key }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: 5000
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.storage.resources | nindent 12 }}
+          volumeMounts:
+            - mountPath: /var/lib/storage
+              name: storage-data
+      {{- with .Values.storage.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.storage.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.storage.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+{{- if .Values.storage.persistence.enable }}
+        - name: storage-data
+          persistentVolumeClaim:
+            claimName: {{ include "supabase.storage.fullname" . }}
+{{- end }}

--- a/charts/supabase/templates/storage/ingress.yaml
+++ b/charts/supabase/templates/storage/ingress.yaml
@@ -1,0 +1,55 @@
+{{- if .Values.storage.ingress.enabled -}}
+{{- $fullName := include "supabase.storage.fullname" . -}}
+{{- $svcPort := .Values.storage.service.port -}}
+{{- if and .Values.storage.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.storage.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.storage.ingress.annotations "kubernetes.io/ingress.class" .Values.storage.ingress.className}}
+  {{- end }}
+{{- end }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "supabase.labels" . | nindent 4 }}
+  {{- with .Values.storage.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.storage.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.storage.ingress.className }}
+  {{- end }}
+  {{- if .Values.storage.ingress.tls }}
+  tls:
+    {{- range .Values.storage.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.storage.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/supabase/templates/storage/service.yaml
+++ b/charts/supabase/templates/storage/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "supabase.storage.fullname" . }}
+  labels:
+    {{- include "supabase.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.storage.service.type }}
+  ports:
+    - port: {{ .Values.storage.service.port }}
+      targetPort: 5000
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "supabase.storage.selectorLabels" . | nindent 4 }}

--- a/charts/supabase/templates/storage/serviceaccount.yaml
+++ b/charts/supabase/templates/storage/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.storage.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "supabase.storage.serviceAccountName" . }}
+  labels:
+    {{- include "supabase.labels" . | nindent 4 }}
+  {{- with .Values.storage.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/supabase/templates/storage/volume.yaml
+++ b/charts/supabase/templates/storage/volume.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.storage.persistence.enable -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "supabase.storage.fullname" . }}
+  labels:
+    {{- include "supabase.labels" . | nindent 4 }}
+  {{- with .Values.storage.persistence.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.storage.persistence.storageClassName }}
+  storageClassName: {{ .Values.storage.persistence.storageClassName }}
+  {{- end }}
+  accessModes:
+  {{- range .Values.storage.persistence.accessModes }}
+    - {{ . | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.storage.persistence.size | quote }}
+{{- end }}

--- a/charts/supabase/templates/studio/_helpers.tpl
+++ b/charts/supabase/templates/studio/_helpers.tpl
@@ -1,0 +1,43 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "supabase.studio.name" -}}
+{{- default (print .Chart.Name "-studio") .Values.studio.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "supabase.studio.fullname" -}}
+{{- if .Values.studio.fullnameOverride }}
+{{- .Values.studio.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default (print .Chart.Name "-studio") .Values.studio.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "supabase.studio.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "supabase.studio.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "supabase.studio.serviceAccountName" -}}
+{{- if .Values.studio.serviceAccount.create }}
+{{- default (include "supabase.studio.fullname" .) .Values.studio.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.studio.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/supabase/templates/studio/config.yaml
+++ b/charts/supabase/templates/studio/config.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.studio.enable -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "supabase.studio.fullname" . }}
+  labels:
+    {{- include "supabase.labels" . | nindent 4 }}
+data:
+  {{- toYaml .Values.studio.environment | nindent 2 }}
+{{- end }}

--- a/charts/supabase/templates/studio/deployment.yaml
+++ b/charts/supabase/templates/studio/deployment.yaml
@@ -1,0 +1,63 @@
+{{- if .Values.studio.enable -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "supabase.studio.fullname" . }}
+  labels:
+    {{- include "supabase.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.studio.autoscaling.enabled }}
+  replicas: {{ .Values.studio.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "supabase.studio.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.studio.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "supabase.studio.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.studio.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "supabase.studio.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.studio.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ include "supabase.studio.name" $ }}
+          securityContext:
+            {{- toYaml .Values.studio.securityContext | nindent 12 }}
+          image: "{{ .Values.studio.image.repository }}:{{ .Values.studio.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.studio.image.pullPolicy }}
+          env:
+            {{- range $key, $value := .Values.studio.environment }}
+            - name: {{ $key }}
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "supabase.studio.fullname" $ }}
+                  key: {{ $key }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.studio.resources | nindent 12 }}
+      {{- with .Values.studio.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.studio.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.studio.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/supabase/templates/studio/ingress.yaml
+++ b/charts/supabase/templates/studio/ingress.yaml
@@ -1,0 +1,57 @@
+{{- if .Values.studio.enable -}}
+{{- if .Values.studio.ingress.enabled -}}
+{{- $fullName := include "supabase.studio.fullname" . -}}
+{{- $svcPort := .Values.studio.service.port -}}
+{{- if and .Values.studio.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.studio.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.studio.ingress.annotations "kubernetes.io/ingress.class" .Values.studio.ingress.className}}
+  {{- end }}
+{{- end }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "supabase.labels" . | nindent 4 }}
+  {{- with .Values.studio.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.studio.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.studio.ingress.className }}
+  {{- end }}
+  {{- if .Values.studio.ingress.tls }}
+  tls:
+    {{- range .Values.studio.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.studio.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/supabase/templates/studio/service.yaml
+++ b/charts/supabase/templates/studio/service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.studio.enable -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "supabase.studio.fullname" . }}
+  labels:
+    {{- include "supabase.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.studio.service.type }}
+  ports:
+    - port: {{ .Values.studio.service.port }}
+      targetPort: 3000
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "supabase.studio.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/supabase/templates/studio/serviceaccount.yaml
+++ b/charts/supabase/templates/studio/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.studio.enable -}}
+{{- if .Values.studio.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "supabase.studio.serviceAccountName" . }}
+  labels:
+    {{- include "supabase.labels" . | nindent 4 }}
+  {{- with .Values.studio.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/supabase/values.example.yaml
+++ b/charts/supabase/values.example.yaml
@@ -1,0 +1,93 @@
+database:
+  postgresqlPassword: MY_SUPER_EXAMPLE_HARD_PASSWORD      
+
+studio:
+  enable: true
+  environment:
+    SUPABASE_URL: http://api.localhost
+    STUDIO_PG_META_URL: http://example-supabase-kong.example-namespace.svc.cluster.local:8000/pg
+    SUPABASE_ANON_KEY: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoiYW5vbiIsImlhdCI6MTY0MDMwMDQwMCwiZXhwIjoxNzk4MDY2ODAwfQ.JaEiRNdyxX3Pk6XupxauDazXeadLTgTHz5cV7joUrQE"
+    SUPABASE_SERVICE_KEY: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoic2VydmljZV9yb2xlIiwiaWF0IjoxNjQwMzAwNDAwLCJleHAiOjE3OTgwNjY4MDB9.sUJPVrhMsSaLgizyCWIgNOIRmjavxDB4Lm3hzb4dC5U"
+
+  ingress:
+    enabled: 'true'
+    className: ""
+    annotations:
+      kubernetes.io/ingress.class: nginx
+      nginx.ingress.kubernetes.io/rewrite-target: /
+    hosts:
+      - host: studio.localhost
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              serviceName: api
+              servicePort: 3000
+
+# Auth Service
+auth:
+  environment:
+    GOTRUE_DB_DATABASE_URL: postgres://postgres:MY_SUPER_EXAMPLE_HARD_PASSWORD@example-database.example-namespace.svc.cluster.local:5432/postgres?search_path=auth
+    GOTRUE_SITE_URL: http://studio.localhost
+    GOTRUE_URI_ALLOW_LIST: ""
+    GOTRUE_DISABLE_SIGNUP: "false"
+    GOTRUE_JWT_SECRET: "your-super-secret-jwt-token-with-at-least-32-characters-long"
+    GOTRUE_JWT_EXP: "3600"
+    GOTRUE_EXTERNAL_EMAIL_ENABLED: "true"
+    GOTRUE_MAILER_AUTOCONFIRM: "true"
+    GOTRUE_SMTP_ADMIN_EMAIL: "admin@example.com"
+    GOTRUE_SMTP_HOST: "mail"
+    GOTRUE_SMTP_PORT: "2500"
+    GOTRUE_SMTP_USER: "fake_mail_user"
+    GOTRUE_SMTP_PASS: "fake_mail_password"
+    GOTRUE_SMTP_SENDER_NAME: "fake_sender"
+    GOTRUE_EXTERNAL_PHONE_ENABLED: "false"
+    GOTRUE_SMS_AUTOCONFIRM: "false"
+
+rest:
+  environment:
+    PGRST_DB_URI: postgres://postgres:MY_SUPER_EXAMPLE_HARD_PASSWORD@example-database.example-namespace.svc.cluster.local:5432/postgres
+    PGRST_JWT_SECRET: "your-super-secret-jwt-token-with-at-least-32-characters-long"
+
+realtime:
+  environment:
+    DB_HOST: example-database.example-namespace.svc.cluster.local
+    DB_PORT: "5432"
+    DB_NAME: postgres
+    DB_USER: postgres
+    DB_PASSWORD: MY_SUPER_EXAMPLE_HARD_PASSWORD
+    DB_SSL: "false"
+    JWT_SECRET: "your-super-secret-jwt-token-with-at-least-32-characters-long"
+
+meta:
+  environment:
+    PG_META_DB_HOST: example-database.example-namespace.svc.cluster.local
+    PG_META_DB_PASSWORD: MY_SUPER_EXAMPLE_HARD_PASSWORD
+
+storage:
+  environment:
+    ANON_KEY: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoiYW5vbiIsImlhdCI6MTY0MDMwMDQwMCwiZXhwIjoxNzk4MDY2ODAwfQ.JaEiRNdyxX3Pk6XupxauDazXeadLTgTHz5cV7joUrQE"
+    SERVICE_KEY: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoic2VydmljZV9yb2xlIiwiaWF0IjoxNjQwMzAwNDAwLCJleHAiOjE3OTgwNjY4MDB9.sUJPVrhMsSaLgizyCWIgNOIRmjavxDB4Lm3hzb4dC5U"
+    POSTGREST_URL: http://example-supabase-rest.example-namespace.svc.cluster.local:3000
+    PGRST_JWT_SECRET: "your-super-secret-jwt-token-with-at-least-32-characters-long"
+    DATABASE_URL: postgres://postgres:MY_SUPER_EXAMPLE_HARD_PASSWORD@example-database.example-namespace.svc.cluster.local:5432/postgres
+    PGOPTIONS: -c search_path=storage,public
+
+kong:
+  ingress:
+    enabled: 'true'
+    className: ""
+    annotations:
+      kubernetes.io/ingress.class: nginx
+      nginx.ingress.kubernetes.io/rewrite-target: /
+    hosts:
+      - host: api.localhost
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              serviceName: api
+              servicePort: 80
+  credentials:
+    anonKey: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoiYW5vbiIsImlhdCI6MTY0MDMwMDQwMCwiZXhwIjoxNzk4MDY2ODAwfQ.JaEiRNdyxX3Pk6XupxauDazXeadLTgTHz5cV7joUrQE"
+    serviceRoleKey: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoic2VydmljZV9yb2xlIiwiaWF0IjoxNjQwMzAwNDAwLCJleHAiOjE3OTgwNjY4MDB9.sUJPVrhMsSaLgizyCWIgNOIRmjavxDB4Lm3hzb4dC5U"

--- a/charts/supabase/values.template.yaml
+++ b/charts/supabase/values.template.yaml
@@ -1,0 +1,100 @@
+# Postgres Database
+# A standalone Postgres database configured to work with Supabase services.
+database:
+  postgresqlPassword: MY_VERY_HARD_PASSWORD_FOR_DATABASE
+
+studio:
+  # enable: false # Disable the studio
+  environment:
+    SUPABASE_URL: http://api.localhost
+    STUDIO_PG_META_URL: http://RELEASE_NAME-kong.NAMESPACE.svc.cluster.local:8000/pg
+    SUPABASE_ANON_KEY: "JWT_ANON_KEY"
+    SUPABASE_SERVICE_KEY: "JWT_SERVICE_KEY"
+
+  ingress:
+    enabled: 'true'
+    className: ""
+    annotations:
+      kubernetes.io/ingress.class: nginx
+      nginx.ingress.kubernetes.io/rewrite-target: /
+    hosts:
+      - host: studio.localhost
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              serviceName: api
+              servicePort: 3000
+
+# Auth Service
+auth:
+  environment:
+    GOTRUE_DB_DATABASE_URL: postgres://postgres:MY_VERY_HARD_PASSWORD_FOR_DATABASE@RELEASE_NAME-database.NAMESPACE.svc.cluster.local:5432/postgres?search_path=auth
+    GOTRUE_SITE_URL: http://studio.localhost
+    GOTRUE_URI_ALLOW_LIST: ""
+    GOTRUE_DISABLE_SIGNUP: "false"
+    GOTRUE_JWT_SECRET: "your-super-secret-jwt-token-with-at-least-32-characters-long"
+    GOTRUE_JWT_EXP: "3600"
+    GOTRUE_EXTERNAL_EMAIL_ENABLED: "true"
+    GOTRUE_MAILER_AUTOCONFIRM: "true"
+    GOTRUE_SMTP_ADMIN_EMAIL: "admin@example.com"
+    GOTRUE_SMTP_HOST: "mail"
+    GOTRUE_SMTP_PORT: "2500"
+    GOTRUE_SMTP_USER: "fake_mail_user"
+    GOTRUE_SMTP_PASS: "fake_mail_password"
+    GOTRUE_SMTP_SENDER_NAME: "fake_sender"
+    GOTRUE_EXTERNAL_PHONE_ENABLED: "false"
+    GOTRUE_SMS_AUTOCONFIRM: "false"
+
+# Rest Service
+rest:
+  environment:
+    PGRST_DB_URI: postgres://postgres:MY_VERY_HARD_PASSWORD_FOR_DATABASE@RELEASE_NAME-database.NAMESPACE.svc.cluster.local:5432/postgres
+    PGRST_JWT_SECRET: "your-super-secret-jwt-token-with-at-least-32-characters-long"
+
+# Realtime Service
+realtime:
+  environment:
+    DB_HOST: RELEASE_NAME-database.NAMESPACE.svc.cluster.local
+    DB_PORT: "5432"
+    DB_NAME: postgres
+    DB_USER: postgres
+    DB_PASSWORD: MY_VERY_HARD_PASSWORD_FOR_DATABASE
+    DB_SSL: "false"
+    JWT_SECRET: "your-super-secret-jwt-token-with-at-least-32-characters-long"
+
+# Meta Service
+meta:
+  environment:
+    PG_META_DB_HOST: RELEASE_NAME-database.NAMESPACE.svc.cluster.local
+    PG_META_DB_PASSWORD: MY_VERY_HARD_PASSWORD_FOR_DATABASE
+
+# Storage Service
+storage:
+  environment:
+    ANON_KEY: "JWT_ANON_KEY"
+    SERVICE_KEY: "JWT_SERVICE_KEY"
+    POSTGREST_URL: http://RELEASE_NAME-rest.NAMESPACE.svc.cluster.local:3000
+    PGRST_JWT_SECRET: "your-super-secret-jwt-token-with-at-least-32-characters-long"
+    DATABASE_URL: postgres://postgres:MY_VERY_HARD_PASSWORD_FOR_DATABASE@RELEASE_NAME-database.NAMESPACE.svc.cluster.local:5432/postgres
+    PGOPTIONS: -c search_path=storage,public
+
+# Kong Service (API Gateway)
+kong:
+  ingress:
+    enabled: 'true' 
+    className: ""
+    annotations:
+      kubernetes.io/ingress.class: nginx
+      nginx.ingress.kubernetes.io/rewrite-target: /
+    hosts:
+      - host: api.localhost
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              serviceName: api
+              servicePort: 80
+    credentials:
+      anonKey: "JWT_ANON_KEY"
+      serviceRoleKey: "JWT_SERVICE_KEY"

--- a/charts/supabase/values.yaml
+++ b/charts/supabase/values.yaml
@@ -1,0 +1,770 @@
+# Studio Application
+studio:
+  enable: true
+  replicaCount: 1
+  image:
+    repository: supabase/studio
+    pullPolicy: IfNotPresent
+    tag: "latest"
+
+  imagePullSecrets: []
+  nameOverride: ""
+  fullnameOverride: ""
+
+  serviceAccount:
+    # Specifies whether a service account should be created
+    create: true
+    # Annotations to add to the service account
+    annotations: {}
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name: ""
+
+  podAnnotations: {}
+
+  podSecurityContext: {}
+    # fsGroup: 2000
+
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+
+  environment:
+    SUPABASE_URL: http://kong:8000
+    STUDIO_PG_META_URL: http://meta:8080
+    SUPABASE_ANON_KEY: ${ANON_KEY}
+    SUPABASE_SERVICE_KEY: ${SERVICE_ROLE_KEY}
+
+  service:
+    type: ClusterIP
+    port: 3000
+
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+    hosts: []
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
+
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 100
+    targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 80
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
+
+
+# Auth Service
+auth:
+  replicaCount: 1
+  image:
+    repository: supabase/gotrue
+    pullPolicy: IfNotPresent
+    tag: "v2.2.12"
+
+  imagePullSecrets: []
+  nameOverride: ""
+  fullnameOverride: ""
+
+  serviceAccount:
+    # Specifies whether a service account should be created
+    create: true
+    # Annotations to add to the service account
+    annotations: {}
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name: ""
+
+  podAnnotations: {}
+
+  podSecurityContext: {}
+    # fsGroup: 2000
+
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+
+  environment:
+    GOTRUE_API_HOST: "0.0.0.0"
+    GOTRUE_API_PORT: "9999"
+    GOTRUE_DB_DRIVER: postgres
+    GOTRUE_DB_DATABASE_URL: postgres://postgres:${POSTGRES_PASSWORD}@db:5432/postgres?search_path=auth
+    GOTRUE_SITE_URL: ${SITE_URL}
+    GOTRUE_URI_ALLOW_LIST: ${ADDITIONAL_REDIRECT_URLS}
+    GOTRUE_DISABLE_SIGNUP: ${DISABLE_SIGNUP}
+    GOTRUE_JWT_SECRET: ${JWT_SECRET}
+    GOTRUE_JWT_EXP: ${JWT_EXPIRY}
+    GOTRUE_JWT_DEFAULT_GROUP_NAME: authenticated
+    GOTRUE_EXTERNAL_EMAIL_ENABLED: ${ENABLE_EMAIL_SIGNUP}
+    GOTRUE_MAILER_AUTOCONFIRM: ${ENABLE_EMAIL_AUTOCONFIRM}
+    GOTRUE_SMTP_ADMIN_EMAIL: ${SMTP_ADMIN_EMAIL}
+    GOTRUE_SMTP_HOST: ${SMTP_HOST}
+    GOTRUE_SMTP_PORT: ${SMTP_PORT}
+    GOTRUE_SMTP_USER: ${SMTP_USER}
+    GOTRUE_SMTP_PASS: ${SMTP_PASS}
+    GOTRUE_SMTP_SENDER_NAME: ${SMTP_SENDER_NAME}
+    GOTRUE_MAILER_URLPATHS_INVITE: /auth/v1/verify
+    GOTRUE_MAILER_URLPATHS_CONFIRMATION: /auth/v1/verify
+    GOTRUE_MAILER_URLPATHS_RECOVERY: /auth/v1/verify
+    GOTRUE_MAILER_URLPATHS_EMAIL_CHANGE: /auth/v1/verify
+    GOTRUE_EXTERNAL_PHONE_ENABLED: ${ENABLE_PHONE_SIGNUP}
+    GOTRUE_SMS_AUTOCONFIRM: ${ENABLE_PHONE_AUTOCONFIRM}
+
+  service:
+    type: ClusterIP
+    port: 9999
+
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+    hosts: []
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
+
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 100
+    targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 80
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
+
+# Rest Service
+rest:
+  replicaCount: 1
+  image:
+    repository: postgrest/postgrest
+    pullPolicy: IfNotPresent
+    tag: "v9.0.0"
+
+  imagePullSecrets: []
+  nameOverride: ""
+  fullnameOverride: ""
+
+  serviceAccount:
+    # Specifies whether a service account should be created
+    create: true
+    # Annotations to add to the service account
+    annotations: {}
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name: ""
+
+  podAnnotations: {}
+
+  podSecurityContext: {}
+    # fsGroup: 2000
+
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+
+  environment:
+    PGRST_DB_URI: postgres://postgres:${POSTGRES_PASSWORD}@db:5432/postgres
+    PGRST_DB_SCHEMA: public,storage
+    PGRST_DB_ANON_ROLE: anon
+    PGRST_JWT_SECRET: ${JWT_SECRET}
+    PGRST_DB_USE_LEGACY_GUCS: "false"
+
+  service:
+    type: ClusterIP
+    port: 3000
+
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+    hosts: []
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
+
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 100
+    targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 80
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
+
+realtime:
+  replicaCount: 1
+  image:
+    repository: supabase/realtime
+    pullPolicy: IfNotPresent
+    tag: "v0.19.3"
+
+  imagePullSecrets: []
+  nameOverride: ""
+  fullnameOverride: ""
+
+  serviceAccount:
+    # Specifies whether a service account should be created
+    create: true
+    # Annotations to add to the service account
+    annotations: {}
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name: ""
+
+  podAnnotations: {}
+
+  podSecurityContext: {}
+    # fsGroup: 2000
+
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+
+  environment:
+    DB_HOST: db
+    DB_PORT: '5432'
+    DB_NAME: postgres
+    DB_USER: postgres
+    DB_PASSWORD: ${POSTGRES_PASSWORD}
+    DB_SSL: "false"
+    PORT: '4000'
+    JWT_SECRET: ${JWT_SECRET}
+    REPLICATION_MODE: RLS
+    REPLICATION_POLL_INTERVAL: '100'
+    SECURE_CHANNELS: "true"
+    SLOT_NAME: supabase_realtime_rls
+    TEMPORARY_SLOT: "true"
+
+  service:
+    type: ClusterIP
+    port: 4000
+
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+    hosts: []
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
+
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 100
+    targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 80
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
+
+# Meta Service
+meta:
+  replicaCount: 1
+  image:
+    repository: supabase/postgres-meta
+    pullPolicy: IfNotPresent
+    tag: "v0.29.0"
+
+  imagePullSecrets: []
+  nameOverride: ""
+  fullnameOverride: ""
+
+  serviceAccount:
+    # Specifies whether a service account should be created
+    create: true
+    # Annotations to add to the service account
+    annotations: {}
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name: ""
+
+  podAnnotations: {}
+
+  podSecurityContext: {}
+    # fsGroup: 2000
+
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+
+  environment:
+    PG_META_PORT: '8080'
+    PG_META_DB_HOST: db
+    PG_META_DB_PASSWORD: ${POSTGRES_PASSWORD}
+
+  service:
+    type: ClusterIP
+    port: 8080
+
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+    hosts: []
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
+
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 100
+    targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 80
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
+
+storage:
+  replicaCount: 1
+  image:
+    repository: supabase/storage-api
+    pullPolicy: IfNotPresent
+    tag: "v0.10.0"
+
+  imagePullSecrets: []
+  nameOverride: ""
+  fullnameOverride: ""
+
+  serviceAccount:
+    # Specifies whether a service account should be created
+    create: true
+    # Annotations to add to the service account
+    annotations: {}
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name: ""
+
+  podAnnotations: {}
+
+  podSecurityContext: {}
+    # fsGroup: 2000
+
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+
+  environment:
+    ANON_KEY: ${ANON_KEY}
+    SERVICE_KEY: ${SERVICE_ROLE_KEY}
+    POSTGREST_URL: http://rest:3000
+    PGRST_JWT_SECRET: ${JWT_SECRET}
+    DATABASE_URL: postgres://postgres:${POSTGRES_PASSWORD}@db:5432/postgres
+    PGOPTIONS: -c search_path=storage,public
+    FILE_SIZE_LIMIT: '52428800'
+    STORAGE_BACKEND: file
+    FILE_STORAGE_BACKEND_PATH: /var/lib/storage
+    TENANT_ID: stub
+    REGION: stub
+    GLOBAL_S3_BUCKET: stub
+
+  service:
+    type: ClusterIP
+    port: 5000
+
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+    hosts: []
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
+
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+  persistence:
+    enable: true
+    storageClassName: ""
+    annotations: {}
+    size: 10Gi
+    accessModes:
+      - ReadWriteOnce
+    class: ""
+
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 100
+    targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 80
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
+
+kong:
+  replicaCount: 1
+  image:
+    repository: kong
+    pullPolicy: IfNotPresent
+    tag: "2.1"
+
+  imagePullSecrets: []
+  nameOverride: ""
+  fullnameOverride: ""
+
+  serviceAccount:
+    # Specifies whether a service account should be created
+    create: true
+    # Annotations to add to the service account
+    annotations: {}
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name: ""
+
+  podAnnotations: {}
+
+  podSecurityContext: {}
+    # fsGroup: 2000
+
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+
+  environment:
+    KONG_DATABASE: "off"
+    KONG_DECLARATIVE_CONFIG: /var/lib/kong/kong.yml
+    # https://github.com/supabase/cli/issues/14
+    KONG_DNS_ORDER: LAST,A,CNAME
+    KONG_PLUGINS: request-transformer,cors,key-auth,acl
+
+  service:
+    type: NodePort
+    port: 8000
+
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+    hosts: []
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
+
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 100
+    targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 80
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
+
+  config: {}
+  # config: |
+  #   _format_version: "1.1"
+
+  #   ###
+  #   ### Consumers / Users
+  #   ###
+  #   consumers:
+  #     - username: anon
+  #       keyauth_credentials:
+  #         - key: JWT_ANON_KEY
+  #     - username: service_role
+  #       keyauth_credentials:
+  #         - key: JWT_SERVICE_KEY
+
+  #   ###
+  #   ### Access Control List
+  #   ###
+  #   acls:
+  #     - consumer: anon
+  #       group: anon
+  #     - consumer: service_role
+  #       group: admin
+
+  #   ###
+  #   ### API Routes
+  #   ###
+  #   services:
+  #     ## Open Auth routes
+  #     - name: auth-v1-open
+  #       url: http://svc.cluster.local:9999/verify
+  #       routes:
+  #         - name: auth-v1-open
+  #           strip_path: true
+  #           paths:
+  #             - /auth/v1/verify
+  #       plugins:
+  #         - name: cors
+  #     - name: auth-v1-open-callback
+  #       url: http://svc.cluster.local:9999/callback
+  #       routes:
+  #         - name: auth-v1-open-callback
+  #           strip_path: true
+  #           paths:
+  #             - /auth/v1/callback
+  #       plugins:
+  #         - name: cors
+  #     - name: auth-v1-open-authorize
+  #       url: http://svc.cluster.local:9999/authorize
+  #       routes:
+  #         - name: auth-v1-open-authorize
+  #           strip_path: true
+  #           paths:
+  #             - /auth/v1/authorize
+  #       plugins:
+  #         - name: cors
+
+  #     ## Secure Auth routes
+  #     - name: auth-v1
+  #       _comment: "GoTrue: /auth/v1/* -> http://svc.cluster.local:9999/*"
+  #       url: http://svc.cluster.local:9999/
+  #       routes:
+  #         - name: auth-v1-all
+  #           strip_path: true
+  #           paths:
+  #             - /auth/v1/
+  #       plugins:
+  #         - name: cors
+  #         - name: key-auth
+  #           config:
+  #             hide_credentials: false
+  #         - name: acl
+  #           config:
+  #             hide_groups_header: true
+  #             allow:
+  #               - admin
+  #               - anon
+
+  #     ## Secure REST routes
+  #     - name: rest-v1
+  #       _comment: "PostgREST: /rest/v1/* -> http://DATABASE_ENDPOINT:3000/*"
+  #       url: http://DATABASE_ENDPOINT:3000/
+  #       routes:
+  #         - name: rest-v1-all
+  #           strip_path: true
+  #           paths:
+  #             - /rest/v1/
+  #       plugins:
+  #         - name: cors
+  #         - name: key-auth
+  #           config:
+  #             hide_credentials: true
+  #         - name: acl
+  #           config:
+  #             hide_groups_header: true
+  #             allow:
+  #               - admin
+  #               - anon
+
+  #     ## Secure Realtime routes
+  #     - name: realtime-v1
+  #       _comment: "Realtime: /realtime/v1/* -> ws://svc.cluster.local:4000/socket/*"
+  #       url: http://svc.cluster.local:4000/socket/
+  #       routes:
+  #         - name: realtime-v1-all
+  #           strip_path: true
+  #           paths:
+  #             - /realtime/v1/
+  #       plugins:
+  #         - name: cors
+  #         - name: key-auth
+  #           config:
+  #             hide_credentials: false
+  #         - name: acl
+  #           config:
+  #             hide_groups_header: true
+  #             allow:
+  #               - admin
+  #               - anon
+
+  #     ## Storage routes: the storage server manages its own auth
+  #     - name: storage-v1
+  #       _comment: "Storage: /storage/v1/* -> http://svc.cluster.local:5000/*"
+  #       url: http://svc.cluster.local:5000/
+  #       routes:
+  #         - name: storage-v1-all
+  #           strip_path: true
+  #           paths:
+  #             - /storage/v1/
+  #       plugins:
+  #         - name: cors
+
+  #     ## Secure Database routes
+  #     - name: meta
+  #       _comment: "pg-meta: /pg/* -> http://svc.cluster.local:8080/*"
+  #       url: http://svc.cluster.local:8080/
+  #       routes:
+  #         - name: meta-all
+  #           strip_path: true
+  #           paths:
+  #             - /pg/
+  #       plugins:
+  #         - name: key-auth
+  #           config:
+  #             hide_credentials: false
+  #         - name: acl
+  #           config:
+  #             hide_groups_header: true
+  #             allow:
+  #               - admin
+
+
+
+
+# Postgres Database
+# A standalone Postgres database configured to work with Supabase services.
+database:
+  image:
+    repository: tdeoliv/supabase-bitnami-postgres
+    tag: latest
+  # image:
+  #   tag: "12.9.0-debian-10-r40"
+  #   debug: true
+  containerSecurityContext:
+    runAsUser: 0
+  postgresqlPassword: YOUR_PASSWORD
+  extraEnv:
+    - name: POSTGRESQL_WAL_LEVEL
+      value: LOGICAL
+  initdbScriptsConfigMap: "{{ .Release.Name }}-initdb"
+  # initdbScriptsConfigMap: my-release-initdb # This is required
+


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature, Docs

## What is the current behavior?

For the moment the only option to deploy Supabase is using Docker Compose or Kompose.

## What is the new behavior?

Adding a Helm chart to deploy a complete supabase architecture.

By following the README.me located in the `charts` directory you can start supabase in a `minikube` cluster easily.

It's also technically possible to deploy a production environment with replication and backup, but no documentation has been written on that.

_The Supabase Studio app is not protected, don't forget to disable it before going to production. You can also choose to use a Basic HTTP authentication if you use the nginx ingress controller_

## Additional context

- You need to have a kubernetes cluster to deploy the Helm chart. You can create have locally using [Minikube](https://minikube.sigs.k8s.io/docs/start/)
- We are using the bitnami chart to deploy the postgres database. 
- We are using a custom version of the bitnami postgres image to add the extension. You might want to publish this image on your account instead.
- I created another PR to allow the modification of the url used for the API documentation because at the moment it's hard coded. [ref](https://github.com/supabase/supabase/pull/4880)