### PR TITLE
chore: fix typo in step headings

### DIFF
--- a/web/docs/guides/integrations/auth0.mdx
+++ b/web/docs/guides/integrations/auth0.mdx
@@ -133,7 +133,7 @@ Restart your Next.js development server to read in the new values from `.env.loc
 npm run dev
 ```
 
-## Step 5: Install Auth0 Next.js library
+## Step 6: Install Auth0 Next.js library
 
 Install the `@auth0/nextjs-auth0` library.
 
@@ -211,7 +211,7 @@ You should now be able to view the landing page.
 
 ![Landing page](/img/guides/integrations/auth0/YdBKRy6.png)
 
-## Step 6: Sign Auth0 token for Supabase
+## Step 7: Sign Auth0 token for Supabase
 
 Currently, neither Supabase or Auth0 allow for a custom signing secret to be set for their JWT. They also use different [signing algorithms](https://auth0.com/docs/configure/applications/signing-algorithms).
 
@@ -263,7 +263,7 @@ We are signing this JWT using Supabase's signing secret, so Supabase will be abl
 
 Now we just need to send the token along with the request to Supabase.
 
-## Step 7: Requesting data from Supabase
+## Step 8: Requesting data from Supabase
 
 Create a new file called `utils/supabase.js` and add the following:
 
@@ -391,7 +391,7 @@ Either way, when we reload our application, we are still getting the empty state
 
 This is because we enabled Row Level Security, which blocks all requests by default. To enable our user to select their `todos` we need to write a policy.
 
-## Step 8: Write a policy to allow select
+## Step 9: Write a policy to allow select
 
 Our policy will need to know who our currently logged in user is to determine whether or not they should have access. Let's create a PostgreSQL function to extract the current user from our new JWT.
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix small typo - there are two headings titled "Step 5"

<img width="267" alt="Screen Shot 2022-01-11 at 3 04 28 pm" src="https://user-images.githubusercontent.com/13792200/148879327-d42e008c-2e87-4654-9290-4c9a82d2668f.png">
