### PR TITLE
Fix: landing button alignment on smaller screens

### DIFF
--- a/studio/components/interfaces/Home/Landing.tsx
+++ b/studio/components/interfaces/Home/Landing.tsx
@@ -72,7 +72,7 @@ const Landing = () => {
               Authentication, instant APIs, and realtime subscriptions.
             </p>
           </Typography.Text>
-          <div className="mt-5 sm:mt-8 sm:flex sm:justify-center space-x-3">
+          <div className="mt-5 sm:mt-8 sm:justify-center space-x-3 flex items-center">
             <Button onClick={handleGithubSignIn} size="large" icon={<IconGitHub />}>
               Sign In With Github
             </Button>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix landing button alignment. The docs button is slightly lower than the Sign In with Github button on mobile/smaller screen.

## What is the current behavior?

<img width="1392" alt="Screen Shot 2022-01-12 at 9 30 13 PM" src="https://user-images.githubusercontent.com/70828596/149256891-ca87af45-8bbc-4e0c-ae63-454fb98dafe4.png">

## What is the new behavior?

<img width="1392" alt="Screen Shot 2022-01-12 at 9 45 22 PM" src="https://user-images.githubusercontent.com/70828596/149256910-16f0b85c-2bd5-482e-93d9-afb2f5477dab.png">