### PR TITLE
Fix: theme select always in light mode

### DIFF
--- a/studio/pages/account/me.tsx
+++ b/studio/pages/account/me.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { observer } from 'mobx-react-lite'
-import { IconMoon, IconSun, Select, Typography, Input, Listbox } from '@supabase/ui'
+import { IconMoon, IconSun, Typography, Input, Listbox } from '@supabase/ui'
 
 import { useProfile, useStore, withAuth } from 'hooks'
 import { post } from 'lib/common/fetch'

--- a/studio/pages/account/me.tsx
+++ b/studio/pages/account/me.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { observer } from 'mobx-react-lite'
-import { IconMoon, IconSun, Select, Typography, Input } from '@supabase/ui'
+import { IconMoon, IconSun, Select, Typography, Input, Listbox } from '@supabase/ui'
 
 import { useProfile, useStore, withAuth } from 'hooks'
 import { post } from 'lib/common/fetch'
@@ -129,7 +129,7 @@ const ThemeSettings = observer(() => {
       ]}
     >
       <Panel.Content>
-        <Select
+        <Listbox
           value={ui.themeOption}
           label="Interface theme"
           descriptionText="Choose a theme preference"
@@ -142,12 +142,12 @@ const ThemeSettings = observer(() => {
               <IconMoon />
             ) : undefined
           }
-          onChange={(e: any) => ui.onThemeOptionChange(e.target.value)}
+          onChange={(themeOption: any) => ui.onThemeOptionChange(themeOption)}
         >
-          <Select.Option value="system">System default</Select.Option>
-          <Select.Option value="dark">Dark</Select.Option>
-          <Select.Option value="light">Light</Select.Option>
-        </Select>
+          <Listbox.Option label='System default' value="system">System default</Listbox.Option>
+          <Listbox.Option label='Dark' value="dark">Dark</Listbox.Option>
+          <Listbox.Option label='Light' value="light">Light</Listbox.Option>
+        </Listbox>
       </Panel.Content>
     </Panel>
   )


### PR DESCRIPTION
## What kind of change does this PR introduce?

The theme Select on [app.supabase.io/account/me](https://app.supabase.io/account/me) is always in light mode. Used Listbox to fix that problem.

## What is the current behavior?

https://user-images.githubusercontent.com/70828596/149422817-d84e6455-1861-479f-af25-ad8304809002.mov

## What is the new behavior?

https://user-images.githubusercontent.com/70828596/149422854-408e42f9-fc3e-499e-8e54-27a5e90846b6.mov