### PR TITLE
Update supabase ui website from .io to .com

### DIFF
--- a/studio/README.md
+++ b/studio/README.md
@@ -4,7 +4,7 @@ A dashboard for managing your self-hosted Supabase project, and used on our [hos
 
 - [Next.js](https://nextjs.org/)
 - [Tailwind](https://tailwindcss.com/)
-- [Supabase UI](https://ui.supabase.io/)
+- [Supabase UI](https://ui.supabase.com/)
 - [MobX](https://www.mobxjs.com/)
 
 ## Disclaimer

--- a/www/_blog/2021-03-25-launch-week.mdx
+++ b/www/_blog/2021-03-25-launch-week.mdx
@@ -109,7 +109,7 @@ We are constantly iterating on our own UI, and having multiple devs working on d
 
 And now we're doing what we do best at Supabase and making it open source, so that the community can benefit from the UI work done at Supabase, and vice versa. The open source community is an invaluable asset to the work we do every day, and it's genuinely the main driver which enables our relatively small team to work fast and ship often.
 
-Check out the demo and documentation website directly here: [ui.supabase.io](https://ui.supabase.io/)
+Check out the demo and documentation website directly here: [ui.supabase.com](https://ui.supabase.com/)
 
 ![Supabase UI](/images/blog/launch-week/bernie-4.png)
 

--- a/www/_blog/2021-04-02-supabase-workflows.mdx
+++ b/www/_blog/2021-04-02-supabase-workflows.mdx
@@ -230,5 +230,5 @@ We've already open sourced the Workflow interpreter [here](https://github.com/su
 so you can find it on Hex [here](https://hexdocs.pm/workflows/Workflows.html).
 
 After we've ironed out a few bugs we will integrate it into the Supabase Stack. As with all Supabase features, we'll add a
-[nice UI](https://ui.supabase.io/) to make prototyping extremely rapid. We'll integrate the UI with the code (via Git) to make
+[nice UI](https://ui.supabase.com/) to make prototyping extremely rapid. We'll integrate the UI with the code (via Git) to make
 sure everything is version controlled.

--- a/www/_blog/2021-04-06-supabase-beta-march-2021.mdx
+++ b/www/_blog/2021-04-06-supabase-beta-march-2021.mdx
@@ -42,7 +42,7 @@ The Supabase API already handles Connection Pooling, but if you're connecting 
 
 ## React UI Component Library
 
-We open sourced our internal UI component library, so that anyone can use and contribute to the Supabase aesthetic. It lives at [ui.supabase.io](https://ui.supabase.io/) . It was also the #1 Product of the Day [on Product Hunt](https://www.producthunt.com/posts/supabase-ui).
+We open sourced our internal UI component library, so that anyone can use and contribute to the Supabase aesthetic. It lives at [ui.supabase.com](https://ui.supabase.com/) . It was also the #1 Product of the Day [on Product Hunt](https://www.producthunt.com/posts/supabase-ui).
 
 ![React UI Library](/images/blog/march-2021/supabase-ui.png)
 

--- a/www/_blog/2021-11-30-supabase-studio.mdx
+++ b/www/_blog/2021-11-30-supabase-studio.mdx
@@ -82,7 +82,7 @@ Studio is a Javascript application with a few key pieces of technology:
 
 - [Next.js](https://nextjs.org/) - A frontend Javascript framework built with React.
 - [Tailwind](https://tailwindcss.com/) - A utility-first CSS framework.
-- [Supabase UI](https://ui.supabase.io/) - Our own component library. 
+- [Supabase UI](https://ui.supabase.com/) - Our own component library. 
 - [MobX](https://www.mobxjs.com/) - A state management library.
 - A host of other [useful libraries](https://github.com/supabase/supabase/blob/master/studio/package.json), including [Radix UI](https://www.radix-ui.com), [Lottiefiles](https://lottiefiles.com/), [react-grid-layout](https://github.com/react-grid-layout/react-grid-layout), and [zxcvbn](https://github.com/dropbox/zxcvbn).
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Update supabase ui website from [ui.supabase.io](https://ui.supabase.io) to [ui.supabase.com](https://ui.supabase.com)

## What is the current behavior?

All of the links lead to [ui.supabase.io](https://ui.supabase.io)

## What is the new behavior?

All of the links lead to [ui.supabase.com](https://ui.supabase.com)