### PR TITLE
docker: properly notify PostgREST to reload schema cache on DDL command end

### DIFF
--- a/docker/volumes/db/init/03-post-setup.sql
+++ b/docker/volumes/db/init/03-post-setup.sql
@@ -4,7 +4,7 @@ RETURNS event_trigger
 LANGUAGE plpgsql
 AS $$
 BEGIN
-    NOTIFY ddl_command_end;
+    NOTIFY pgrst, 'reload schema';
 END;
 $$;
 CREATE EVENT TRIGGER api_restart ON ddl_command_end


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

PostgREST schema cache is not refreshed on DDL command end on local Docker Supabase.

## What is the new behavior?

PostgREST is notified to refresh its schema cache on DDL command end.

## Additional context

Ref. https://postgrest.org/en/stable/schema_cache.html#reloading-with-notify.
