### PR TITLE
chore/add-guards-for-invalid-projects-and-orgs

### DIFF
--- a/studio/components/interfaces/App/GoTrueWrapper/GoTrueWrapper.tsx
+++ b/studio/components/interfaces/App/GoTrueWrapper/GoTrueWrapper.tsx
@@ -1,0 +1,53 @@
+import { FC, useEffect, useState } from 'react'
+import { Subscription } from '@supabase/gotrue-js'
+
+import { auth } from 'lib/gotrue'
+import Connecting from 'components/ui/Loading'
+import { doesTokenDataExist } from './GoTrueWrapper.utils'
+
+/**
+ * On app first load, gotrue client may take a while to refresh access token
+ * We have to wait for that process to complete before showing children components
+ */
+const GoTrueWrapper: FC = ({ children }) => {
+  const [loading, setLoading] = useState(doesTokenDataExist())
+
+  useEffect(() => {
+    let subscription: Subscription | null
+    let timer: any
+    const currentSession = auth.session()
+
+    function tokenRefreshed() {
+      setLoading(false)
+      // clean subscription
+      if (subscription) subscription.unsubscribe()
+      // clean timer
+      if (timer) clearTimeout(timer)
+    }
+
+    if (currentSession != undefined && currentSession != null) {
+      // if there is an active session, go ahead
+      setLoading(false)
+    } else {
+      // else wait for TOKEN_REFRESHED event before continue
+      const response = auth.onAuthStateChange((_event, session) => {
+        if (loading && _event === 'TOKEN_REFRESHED') {
+          tokenRefreshed()
+        }
+      })
+      subscription = response.data ?? null
+
+      // we need a timeout here, in case token refresh fails
+      timer = setTimeout(() => setLoading(false), 5 * 1000)
+    }
+
+    return () => {
+      if (subscription) subscription.unsubscribe()
+      if (timer) clearTimeout(timer)
+    }
+  }, [])
+
+  return <>{loading ? <Connecting /> : children}</>
+}
+
+export default GoTrueWrapper

--- a/studio/components/interfaces/App/GoTrueWrapper/GoTrueWrapper.utils.ts
+++ b/studio/components/interfaces/App/GoTrueWrapper/GoTrueWrapper.utils.ts
@@ -1,0 +1,7 @@
+export function doesTokenDataExist() {
+  // ignore if server-side
+  if (typeof window === 'undefined') return false
+  // check tokenData on localstorage
+  const tokenData = window?.localStorage['supabase.auth.token']
+  return tokenData != undefined && typeof tokenData === 'string'
+}

--- a/studio/components/interfaces/App/PortalToast.tsx
+++ b/studio/components/interfaces/App/PortalToast.tsx
@@ -1,0 +1,51 @@
+import dynamic from 'next/dynamic'
+import { Toaster, ToastBar, toast } from 'react-hot-toast'
+import { Button, IconX } from '@supabase/ui'
+
+const PortalRootWithNoSSR = dynamic(
+  // @ts-ignore
+  () => import('@radix-ui/react-portal').then((portal) => portal.Root),
+  { ssr: false }
+)
+
+const PortalToast = () => (
+  // @ts-ignore
+  <PortalRootWithNoSSR className="portal--toast">
+    <Toaster
+      position="top-right"
+      toastOptions={{
+        className:
+          'bg-bg-primary-light dark:bg-bg-primary-dark text-typography-body-strong-light dark:text-typography-body-strong-dark border dark:border-dark',
+        style: {
+          padding: '8px',
+          paddingLeft: '16px',
+          paddingRight: '16px',
+          fontSize: '0.875rem',
+        },
+        error: {
+          duration: 8000,
+        },
+      }}
+    >
+      {(t) => (
+        <ToastBar toast={t} style={t.style}>
+          {({ icon, message }) => (
+            <>
+              {icon}
+              {message}
+              {t.type !== 'loading' && (
+                <div className="ml-4">
+                  <Button className="!p-1" type="text" onClick={() => toast.dismiss(t.id)}>
+                    <IconX size={14} strokeWidth={2} />
+                  </Button>
+                </div>
+              )}
+            </>
+          )}
+        </ToastBar>
+      )}
+    </Toaster>
+  </PortalRootWithNoSSR>
+)
+
+export default PortalToast

--- a/studio/components/interfaces/App/RouteValidationWrapper.tsx
+++ b/studio/components/interfaces/App/RouteValidationWrapper.tsx
@@ -1,0 +1,50 @@
+import { FC, useEffect } from 'react'
+import { observer } from 'mobx-react-lite'
+import { useRouter } from 'next/router'
+
+import { useStore } from 'hooks'
+import { Organization, Project } from 'types'
+
+// Ideally these could all be within a _middleware when we use Next 12
+const RouteValidationWrapper: FC = ({ children }) => {
+  const { ui, app } = useStore()
+  const userProfile = ui.profile
+
+  const router = useRouter()
+  const projectRef = router.query.ref
+  const orgSlug = router.query.slug
+
+  useEffect(() => {
+    if (userProfile) {
+      // Check validity of organization that user is trying to access
+      if (orgSlug) {
+        const organizations = app.organizations.list()
+        const organizationSlugs = organizations.map((org: Organization) => org.slug)
+        const isValidOrg = organizationSlugs.includes(orgSlug as string)
+
+        if (!isValidOrg) {
+          ui.setNotification({ category: 'error', message: 'This organization does not exist' })
+          router.push('/')
+          return
+        }
+      }
+
+      // Check validity of project that the user is trying to access
+      if (projectRef) {
+        const projects = app.projects.list()
+        const projectRefs = projects.map((project: Project) => project.ref)
+        const isValidProject = projectRefs.includes(projectRef as string)
+
+        if (!isValidProject) {
+          ui.setNotification({ category: 'error', message: 'This project does not exist' })
+          router.push('/')
+          return
+        }
+      }
+    }
+  }, [userProfile])
+
+  return <>{children}</>
+}
+
+export default observer(RouteValidationWrapper)

--- a/studio/components/interfaces/App/index.ts
+++ b/studio/components/interfaces/App/index.ts
@@ -1,0 +1,5 @@
+import PortalToast from './PortalToast'
+import GoTrueWrapper from './GoTrueWrapper/GoTrueWrapper'
+import RouteValidationWrapper from './RouteValidationWrapper'
+
+export { PortalToast, GoTrueWrapper, RouteValidationWrapper }

--- a/studio/pages/_app.tsx
+++ b/studio/pages/_app.tsx
@@ -9,120 +9,17 @@ import 'styles/monaco.scss'
 import 'styles/contextMenu.scss'
 
 import Head from 'next/head'
-import dynamic from 'next/dynamic'
 import type { AppProps } from 'next/app'
 import { useRouter } from 'next/router'
-import { FC, useEffect, useState } from 'react'
-import { Subscription } from '@supabase/gotrue-js'
-import { Toaster, ToastBar, toast } from 'react-hot-toast'
-import { Button, IconX } from '@supabase/ui'
+import { useEffect, useState } from 'react'
 import { RootStore } from 'stores'
 import { StoreProvider } from 'hooks'
 import { getParameterByName } from 'lib/common/fetch'
 import { GOTRUE_ERRORS } from 'lib/constants'
-import { auth } from 'lib/gotrue'
+
+import { PortalToast, GoTrueWrapper, RouteValidationWrapper } from 'components/interfaces/App'
 import PageTelemetry from 'components/ui/PageTelemetry'
 import FlagProvider from 'components/ui/Flag/FlagProvider'
-import Connecting from 'components/ui/Loading'
-
-const PortalRootWithNoSSR = dynamic(
-  // @ts-ignore
-  () => import('@radix-ui/react-portal').then((portal) => portal.Root),
-  { ssr: false }
-)
-
-const PortalToast = () => (
-  // @ts-ignore
-  <PortalRootWithNoSSR className="portal--toast">
-    <Toaster
-      position="top-right"
-      toastOptions={{
-        className:
-          'bg-bg-primary-light dark:bg-bg-primary-dark text-typography-body-strong-light dark:text-typography-body-strong-dark border dark:border-dark',
-        style: {
-          padding: '8px',
-          paddingLeft: '16px',
-          paddingRight: '16px',
-          fontSize: '0.875rem',
-        },
-        error: {
-          duration: 8000,
-        },
-      }}
-    >
-      {(t) => (
-        <ToastBar toast={t} style={t.style}>
-          {({ icon, message }) => (
-            <>
-              {icon}
-              {message}
-              {t.type !== 'loading' && (
-                <div className="ml-4">
-                  <Button className="!p-1" type="text" onClick={() => toast.dismiss(t.id)}>
-                    <IconX size={14} strokeWidth={2} />
-                  </Button>
-                </div>
-              )}
-            </>
-          )}
-        </ToastBar>
-      )}
-    </Toaster>
-  </PortalRootWithNoSSR>
-)
-
-function doesTokenDataExist() {
-  // ignore if server-side
-  if (typeof window === 'undefined') return false
-  // check tokenData on localstorage
-  const tokenData = window?.localStorage['supabase.auth.token']
-  return tokenData != undefined && typeof tokenData === 'string'
-}
-
-/**
- * On app first load, gotrue client may take a while to refresh access token
- * We have to wait for that process to complete before showing children components
- */
-const GotrueWrapper: FC = ({ children }) => {
-  const [loading, setLoading] = useState(doesTokenDataExist())
-
-  useEffect(() => {
-    let subscription: Subscription | null
-    let timer: any
-    const currentSession = auth.session()
-
-    function tokenRefreshed() {
-      setLoading(false)
-      // clean subscription
-      if (subscription) subscription.unsubscribe()
-      // clean timer
-      if (timer) clearTimeout(timer)
-    }
-
-    if (currentSession != undefined && currentSession != null) {
-      // if there is an active session, go ahead
-      setLoading(false)
-    } else {
-      // else wait for TOKEN_REFRESHED event before continue
-      const response = auth.onAuthStateChange((_event, session) => {
-        if (loading && _event === 'TOKEN_REFRESHED') {
-          tokenRefreshed()
-        }
-      })
-      subscription = response.data ?? null
-
-      // we need a timeout here, in case token refresh fails
-      timer = setTimeout(() => setLoading(false), 5 * 1000)
-    }
-
-    return () => {
-      if (subscription) subscription.unsubscribe()
-      if (timer) clearTimeout(timer)
-    }
-  }, [])
-
-  return <>{loading ? <Connecting /> : children}</>
-}
 
 function MyApp({ Component, pageProps }: AppProps) {
   const [rootStore] = useState(() => new RootStore())
@@ -147,11 +44,13 @@ function MyApp({ Component, pageProps }: AppProps) {
           <meta name="viewport" content="initial-scale=1.0, width=device-width" />
           <link rel="stylesheet" type="text/css" href="/css/fonts.css" />
         </Head>
-        <GotrueWrapper>
+        <GoTrueWrapper>
           <PageTelemetry>
-            <Component {...pageProps} />
+            <RouteValidationWrapper>
+              <Component {...pageProps} />
+            </RouteValidationWrapper>
           </PageTelemetry>
-        </GotrueWrapper>
+        </GoTrueWrapper>
         <PortalToast />
       </FlagProvider>
     </StoreProvider>

--- a/studio/pages/org/[slug]/settings.tsx
+++ b/studio/pages/org/[slug]/settings.tsx
@@ -96,7 +96,7 @@ const PageLayout = observer(() => {
 
   return (
     <AccountLayout
-      title={PageState.organization.name || 'Supabase'}
+      title={PageState.organization?.name || 'Supabase'}
       // @ts-ignore
       breadcrumbs={[
         {
@@ -126,6 +126,8 @@ const OrganizationSettings = observer(() => {
     }
   }, [members, products, isOrgDetailError])
 
+  if (!PageState.organization) return <div />
+
   return (
     <div className="p-4 pt-0">
       <TabsView />
@@ -142,7 +144,7 @@ const TabsView = observer(() => {
       <div className="space-y-3">
         <section className="mt-4">
           <Typography.Title level={3}>
-            {PageState.organization.name || 'Organization'} settings
+            {PageState.organization?.name || 'Organization'} settings
           </Typography.Title>
         </section>
         <nav className="">


### PR DESCRIPTION
- Re direct users to home page if accessing an invalid org or project by wrapping a HOC (`RouteValidationWrapper`) around `<App />`
  - Ideally these could be done within a `_middleware` once we port to Next 12
- Note that when the user tries to access invalid pages (projects or orgs that they are not a part off), the UI will show the empty state for those pages for a sec before redirecting them
  - A little stuck on trying to figure out how to not render the page if invalid. Doing a conditional return within `RouteValidationWrapper` seems to throw this warning (e.g `return isValid ? <>{children}</> : <div />`)
  - IMO not exactly a blocker from getting this out first though
 
![image](https://user-images.githubusercontent.com/19742402/149467159-7e7dcee6-5bb6-41e0-b1d1-47857a188438.png)
