### PR TITLE
Fix: new project link

### DIFF
--- a/www/components/CTABanner/index.tsx
+++ b/www/components/CTABanner/index.tsx
@@ -16,7 +16,7 @@ const CTABanner = (props: any) => {
         </Typography.Title>
       </div>
       <div className="col-span-12 mt-4">
-        <a href="https://app.supabase.io/new/new-project">
+        <a href="https://app.supabase.io/?next=new-project">
           <Button size="medium">Start your project</Button>
         </a>
       </div>

--- a/www/components/Nav/index.tsx
+++ b/www/components/Nav/index.tsx
@@ -253,7 +253,7 @@ const Nav = (props: Props) => {
                 <a href="https://app.supabase.io/">
                   <Button type="default">Sign in</Button>
                 </a>
-                <a href="https://app.supabase.io/new/project">
+                <a href="https://app.supabase.io/?next=new-project">
                   <Button>Start your project</Button>
                 </a>
               </div>


### PR DESCRIPTION
## What kind of change does this PR introduce?

A temporary fix to #4999.

## What is the current behavior?

#4999

## What is the new behavior?

The new link is [app.supabase.io/?next=new-project](https://app.supabase.io/?next=new-project), and is now solved.

## Additional context

This is a temporary fix because it still redirects to [`app.supabase.io/new/project`](https://app.supabase.io/new/project) but the issue is solved.