### PR TITLE
Change Supabase_py to supabase

### DIFF
--- a/web/docs/guides/client-libraries.mdx
+++ b/web/docs/guides/client-libraries.mdx
@@ -37,7 +37,7 @@ const { error, data } = await supabase.auth.signUp({
 
 ```py
 import os
-from supabase_py import create_client, Client
+from supabase import create_client, Client
 
 url: str = os.environ.get("SUPABASE_TEST_URL")
 key: str = os.environ.get("SUPABASE_TEST_KEY")
@@ -94,7 +94,7 @@ const { error, data } = await supabase.auth.signIn({
 
 ```py
 import os
-from supabase_py import create_client, Client
+from supabase import create_client, Client
 
 url: str = os.environ.get("SUPABASE_TEST_URL")
 key: str = os.environ.get("SUPABASE_TEST_KEY")
@@ -149,7 +149,7 @@ const { error, data } = await supabase.auth.signIn({
 
 ```py
 import os
-from supabase_py import create_client, Client
+from supabase import create_client, Client
 
 url: str = os.environ.get("SUPABASE_TEST_URL")
 key: str = os.environ.get("SUPABASE_TEST_KEY")
@@ -257,7 +257,7 @@ const { data, error } = await supabase
 
 ```py
 import os
-from supabase_py import create_client, Client
+from supabase import create_client, Client
 
 url: str = os.environ.get("SUPABASE_TEST_URL")
 key: str = os.environ.get("SUPABASE_TEST_KEY")


### PR DESCRIPTION
## What kind of change does this PR introduce?

Update docs after renaming of `supabase` python library to drop _py suffix

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
