### PR TITLE
chore: fix failing tests due to improper mock of feature flag hooks/components

### DIFF
--- a/studio/tests/pages/projects/LogPanel.test.js
+++ b/studio/tests/pages/projects/LogPanel.test.js
@@ -3,6 +3,13 @@ import { render, waitFor, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { clickDropdown } from 'tests/helpers'
 
+jest.mock('components/ui/Flag/Flag')
+import Flag from 'components/ui/Flag/Flag'
+Flag.mockImplementation(({ children }) => <>{children}</>)
+jest.mock('hooks')
+import { useFlag } from 'hooks'
+useFlag.mockReturnValue(true)
+
 test('templates', async () => {
   const mockFn = jest.fn()
   render(<LogPanel templates={[{ label: 'Some option', onClick: mockFn }]} />)


### PR DESCRIPTION
Fix for failing ui tests, due to accidental auto-merge when I added in a feature flag. 🤦‍♂️ 

I really need to get around to setting up the global mocks.... 🌏 