### PR TITLE
Update supabase youtube link

### DIFF
--- a/www/_blog/2020-11-02-supabase-alpha-october-2020.mdx
+++ b/www/_blog/2020-11-02-supabase-alpha-october-2020.mdx
@@ -72,7 +72,7 @@ We had a crazy month during Hacktoberfest. In case you missed it, here are some 
 - [@kiwicopple](https://twitter.com/kiwicopple) appeared on the [Open Sauced channel](https://www.youtube.com/watch?v=PHmiWXDx9-w) with [@bdougieYO](https://twitter.com/bdougieYO)
 - [@thorwebdev](https://twitter.com/thorwebdev) shows the [Engineers.sg](http://engineers.sg) group how to [build a realtime Slack clone](https://engineers.sg/video/building-a-slack-clone-with-authentication-and-realtime-data-syncing-using-supabase-io-singaporejs--4119) with Supabase
 
-If you want to keep up to date, make sure you [subscribe to our YouTube channel](https://www.youtube.com/channel/UCNTVzV1InxHV-YR0fSajqPQ) or [follow us on Twitter](https://twitter.com/supabase).
+If you want to keep up to date, make sure you [subscribe to our YouTube channel](https://www.youtube.com/c/supabase) or [follow us on Twitter](https://twitter.com/supabase).
 
 ### Coming next
 

--- a/www/_blog/2020-12-01-supabase-alpha-november-2020.mdx
+++ b/www/_blog/2020-12-01-supabase-alpha-november-2020.mdx
@@ -69,7 +69,7 @@ We had a crazy month during Hacktoberfest. In case you missed it, here are some 
 - [@elrhomariyounes](https://github.com/elrhomariyounes) started helping [@acupofjose](https://github.com/acupofjose) with the [postgrest-csharp](https://github.com/supabase/postgrest-csharp) extension
 - [@duncanhealy](https://github.com/duncanhealy) is [updating the Redwood example](https://github.com/redwoodjs/redwood/pull/1474) to work with Supabase.js v1.0
 
-If you want to keep up to date, make sure you [subscribe to our YouTube channel](https://www.youtube.com/channel/UCNTVzV1InxHV-YR0fSajqPQ) or [follow us on Twitter](https://twitter.com/supabase).
+If you want to keep up to date, make sure you [subscribe to our YouTube channel](https://www.youtube.com/c/supabase) or [follow us on Twitter](https://twitter.com/supabase).
 
 ### Coming next
 

--- a/www/_blog/2021-01-02-supabase-beta-december-2020.mdx
+++ b/www/_blog/2021-01-02-supabase-beta-december-2020.mdx
@@ -82,7 +82,7 @@ We raised $6M from Y Combinator, Mozilla, and Coatue. You can read more on [Tech
 
 ![This image shows GitHub star growth.](/images/blog/blog/dec-starcount.png)
 
-If you want to keep up to date, make sure you [subscribe to our YouTube channel](https://www.youtube.com/channel/UCNTVzV1InxHV-YR0fSajqPQ) or [follow us on Twitter](https://twitter.com/supabase).
+If you want to keep up to date, make sure you [subscribe to our YouTube channel](https://www.youtube.com/c/supabase) or [follow us on Twitter](https://twitter.com/supabase).
 
 ### Coming next
 

--- a/www/_blog/2021-02-02-supabase-beta-january-2021.mdx
+++ b/www/_blog/2021-02-02-supabase-beta-january-2021.mdx
@@ -127,5 +127,5 @@ We're ramping up to "Launch week" at the end of Q1, where we will be giving you 
 - Start using Supabase today: [app.supabase.io](https://app.supabase.io/)
 - Make sure to [star us on GitHub](https://github.com/supabase/supabase)
 - Follow us [on Twitter](https://twitter.com/supabase)
-- Subscribe to our [YouTube channel](https://www.youtube.com/channel/UCNTVzV1InxHV-YR0fSajqPQ)
+- Subscribe to our [YouTube channel](https://www.youtube.com/c/supabase)
 - Become a [sponsor](https://github.com/sponsors/supabase)

--- a/www/_blog/2021-03-02-supabase-beta-february-2021.mdx
+++ b/www/_blog/2021-03-02-supabase-beta-february-2021.mdx
@@ -107,5 +107,5 @@ Waiting for Supabase Storage? Here's a sneak peek for the upcoming Launch Week a
 - Start using Supabase today: [app.supabase.io](https://app.supabase.io/)
 - Make sure to [star us on GitHub](https://github.com/supabase/supabase)
 - Follow us [on Twitter](https://twitter.com/supabase)
-- Subscribe to our [YouTube channel](https://www.youtube.com/channel/UCNTVzV1InxHV-YR0fSajqPQ)
+- Subscribe to our [YouTube channel](https://www.youtube.com/c/supabase)
 - Become a [sponsor](https://github.com/sponsors/supabase)

--- a/www/_blog/2021-04-06-supabase-beta-march-2021.mdx
+++ b/www/_blog/2021-04-06-supabase-beta-march-2021.mdx
@@ -103,7 +103,7 @@ Thanks to a comunity contribution ([@\_mateomorris](https://twitter.com/_mateomo
   Source: <a href="https://repository.surf/supabase">repository.surf/supabase</a>
 </small>
 
-If you want to keep up to date, make sure you [subscribe to our YouTube channel](https://www.youtube.com/channel/UCNTVzV1InxHV-YR0fSajqPQ) or [follow us on Twitter](https://twitter.com/supabase).
+If you want to keep up to date, make sure you [subscribe to our YouTube channel](https://www.youtube.com/c/supabase) or [follow us on Twitter](https://twitter.com/supabase).
 
 ## Coming Next
 
@@ -118,5 +118,5 @@ For this we are working on our own [Workflow engine](/blog/2021/04/02/supabase-
 - Start using Supabase today: [app.supabase.io](https://app.supabase.io/)
 - Make sure to [star us on GitHub](https://github.com/supabase/supabase)
 - Follow us [on Twitter](https://twitter.com/supabase)
-- Subscribe to our [YouTube channel](https://www.youtube.com/channel/UCNTVzV1InxHV-YR0fSajqPQ)
+- Subscribe to our [YouTube channel](https://www.youtube.com/c/supabase)
 - Become a [sponsor](https://github.com/sponsors/supabase)

--- a/www/_blog/2021-05-03-supabase-beta-april-2021.mdx
+++ b/www/_blog/2021-05-03-supabase-beta-april-2021.mdx
@@ -154,7 +154,7 @@ Fireship reviewed Supabase last week, and despite being a (self-proclaimed) Fire
   Source: <a href="https://repository.surf/supabase">repository.surf/supabase</a>
 </small>
 
-If you want to keep up to date, make sure you [subscribe to our YouTube channel](https://www.youtube.com/channel/UCNTVzV1InxHV-YR0fSajqPQ) or [follow us on Twitter](https://twitter.com/supabase).
+If you want to keep up to date, make sure you [subscribe to our YouTube channel](https://www.youtube.com/c/supabase) or [follow us on Twitter](https://twitter.com/supabase).
 
 ## Coming Next
 
@@ -173,5 +173,5 @@ We're also working on our [Workflows engine](/blog/2021/04/02/supabase-workflows
 - Start using Supabase today: [app.supabase.io](https://app.supabase.io/)
 - Make sure to [star us on GitHub](https://github.com/supabase/supabase)
 - Follow us [on Twitter](https://twitter.com/supabase)
-- Subscribe to our [YouTube channel](https://www.youtube.com/channel/UCNTVzV1InxHV-YR0fSajqPQ)
+- Subscribe to our [YouTube channel](https://www.youtube.com/c/supabase)
 - Become a [sponsor](https://github.com/sponsors/supabase)

--- a/www/_blog/2021-06-02-supabase-beta-may-2021.mdx
+++ b/www/_blog/2021-06-02-supabase-beta-may-2021.mdx
@@ -116,7 +116,7 @@ We started a weekly 1-hour live stream where we build in public.
   Source: <a href="https://repository.surf/supabase">repository.surf/supabase</a>
 </small>
 
-If you want to keep up to date, make sure you [subscribe to our YouTube channel](https://www.youtube.com/channel/UCNTVzV1InxHV-YR0fSajqPQ) or [follow us on Twitter](https://twitter.com/supabase).
+If you want to keep up to date, make sure you [subscribe to our YouTube channel](https://www.youtube.com/c/supabase) or [follow us on Twitter](https://twitter.com/supabase).
 
 ## Coming Next
 
@@ -127,5 +127,5 @@ We're planning another Launch Week at the end of July. We'll probably have a qui
 - Start using Supabase today: [app.supabase.io](https://app.supabase.io/)
 - Make sure to [star us on GitHub](https://github.com/supabase/supabase)
 - Follow us [on Twitter](https://twitter.com/supabase)
-- Subscribe to our [YouTube channel](https://www.youtube.com/channel/UCNTVzV1InxHV-YR0fSajqPQ)
+- Subscribe to our [YouTube channel](https://www.youtube.com/c/supabase)
 - Become a [sponsor](https://github.com/sponsors/supabase)

--- a/www/_blog/2021-07-02-supabase-beta-june-2021.mdx
+++ b/www/_blog/2021-07-02-supabase-beta-june-2021.mdx
@@ -136,7 +136,7 @@ We run a weekly 1-hour live stream where we build in public.
   Source: <a href="https://repository.surf/supabase">repository.surf/supabase</a>
 </small>
 
-If you want to keep up to date, make sure you [subscribe to our YouTube channel](https://www.youtube.com/channel/UCNTVzV1InxHV-YR0fSajqPQ) or
+If you want to keep up to date, make sure you [subscribe to our YouTube channel](https://www.youtube.com/c/supabase) or
 [follow us on Twitter](https://twitter.com/supabase).
 
 ## External contributions
@@ -167,5 +167,5 @@ Let's goooooo.
 - Start using Supabase today: [app.supabase.io](https://app.supabase.io/)
 - Make sure to [star us on GitHub](https://github.com/supabase/supabase)
 - Follow us [on Twitter](https://twitter.com/supabase)
-- Subscribe to our [YouTube channel](https://www.youtube.com/channel/UCNTVzV1InxHV-YR0fSajqPQ)
+- Subscribe to our [YouTube channel](https://www.youtube.com/c/supabase)
 - Become a [sponsor](https://github.com/sponsors/supabase)

--- a/www/_blog/2021-08-12-supabase-beta-july-2021.mdx
+++ b/www/_blog/2021-08-12-supabase-beta-july-2021.mdx
@@ -126,7 +126,7 @@ Get your hands on some [Supabase Swag](https://store.supabase.com/), hand packed
   Source: <a href="https://repository.surf/supabase">repository.surf/supabase</a>
 </small>
 
-If you want to keep up to date, make sure you [subscribe to our YouTube channel](https://www.youtube.com/channel/UCNTVzV1InxHV-YR0fSajqPQ) or
+If you want to keep up to date, make sure you [subscribe to our YouTube channel](https://www.youtube.com/c/supabase) or
 [follow us on Twitter](https://twitter.com/supabase).
 
 ## Coming Next
@@ -138,5 +138,5 @@ Security, stability, performance ... and Functions.
 - Start using Supabase today: [app.supabase.io](https://app.supabase.io/)
 - Make sure to [star us on GitHub](https://github.com/supabase/supabase)
 - Follow us [on Twitter](https://twitter.com/supabase)
-- Subscribe to our [YouTube channel](https://www.youtube.com/channel/UCNTVzV1InxHV-YR0fSajqPQ)
+- Subscribe to our [YouTube channel](https://www.youtube.com/c/supabase)
 - Become a [sponsor](https://github.com/sponsors/supabase)

--- a/www/_blog/2021-09-10-supabase-beta-august-2021.mdx
+++ b/www/_blog/2021-09-10-supabase-beta-august-2021.mdx
@@ -87,7 +87,7 @@ We now provide a handy copy utility for various database connection strings beca
 ## We released a primer on Row Level Security
 
 RLS can be a bit foreign for developers getting started with Postgres.
-This video by [@\_dijonmusters](https://twitter.com/_dijonmusters) demystifies it. If you find the video a useful medium for learning, consider [subscribing to our channel](https://www.youtube.com/channel/UCNTVzV1InxHV-YR0fSajqPQ).
+This video by [@\_dijonmusters](https://twitter.com/_dijonmusters) demystifies it. If you find the video a useful medium for learning, consider [subscribing to our channel](https://www.youtube.com/c/supabase).
 
 <iframe
   className="w-full video-with-border"
@@ -128,7 +128,7 @@ We hit 18,000 stars on GitHub, and got to the [top of GitHub trending](https://t
   Source: <a href="https://repository.surf/supabase">repository.surf/supabase</a>
 </small>
 
-If you want to keep up to date, make sure you [subscribe to our YouTube channel](https://www.youtube.com/channel/UCNTVzV1InxHV-YR0fSajqPQ) or
+If you want to keep up to date, make sure you [subscribe to our YouTube channel](https://www.youtube.com/c/supabase) or
 [follow us on Twitter](https://twitter.com/supabase).
 
 ## Dependency contributions
@@ -161,5 +161,5 @@ By the time we're done, Supabase will be production-ready for all use cases.
 - Start using Supabase today: [app.supabase.io](https://app.supabase.io/)
 - Make sure to [star us on GitHub](https://github.com/supabase/supabase)
 - Follow us [on Twitter](https://twitter.com/supabase)
-- Subscribe to our [YouTube channel](https://www.youtube.com/channel/UCNTVzV1InxHV-YR0fSajqPQ)
+- Subscribe to our [YouTube channel](https://www.youtube.com/c/supabase)
 - Become a [sponsor](https://github.com/sponsors/supabase)

--- a/www/_blog/2021-10-04-supabase-beta-sept-2021.mdx
+++ b/www/_blog/2021-10-04-supabase-beta-sept-2021.mdx
@@ -127,5 +127,5 @@ We're warming up for another Launch Week! Last time was "[Launch Week II: the SQ
 - Start using Supabase today: **[app.supabase.io](https://app.supabase.io/)**
 - Make sure to **[star us on GitHub](https://github.com/supabase/supabase)**
 - Follow us **[on Twitter](https://twitter.com/supabase)**
-- Subscribe to our **[YouTube channel](https://www.youtube.com/channel/UCNTVzV1InxHV-YR0fSajqPQ)**
+- Subscribe to our **[YouTube channel](https://www.youtube.com/c/supabase)**
 - Become a **[sponsor](https://github.com/sponsors/supabase)**

--- a/www/_blog/2021-10-28-supabase-series-a.mdx
+++ b/www/_blog/2021-10-28-supabase-series-a.mdx
@@ -266,5 +266,5 @@ If you want to help us build the future of cloud-native Postgres, join us:
 - Start using Supabase today: **[app.supabase.io](https://app.supabase.io/)**
 - Make sure to **[star us on GitHub](https://github.com/supabase/supabase)**
 - Follow us **[on Twitter](https://twitter.com/supabase)**
-- Subscribe to our **[YouTube channel](https://www.youtube.com/channel/UCNTVzV1InxHV-YR0fSajqPQ)**
+- Subscribe to our **[YouTube channel](https://www.youtube.com/c/supabase)**
 - Become a **[sponsor](https://github.com/sponsors/supabase)**

--- a/www/_blog/2021-11-05-supabase-beta-october-2021.mdx
+++ b/www/_blog/2021-11-05-supabase-beta-october-2021.mdx
@@ -176,5 +176,5 @@ Now we're going even bigger with the third installment: `Launch Week III: The Tr
 - Start using Supabase today: **[app.supabase.io](https://app.supabase.io/)**
 - Make sure to **[star us on GitHub](https://github.com/supabase/supabase)**
 - Follow us **[on Twitter](https://twitter.com/supabase)**
-- Subscribe to our **[YouTube channel](https://www.youtube.com/channel/UCNTVzV1InxHV-YR0fSajqPQ)**
+- Subscribe to our **[YouTube channel](https://www.youtube.com/c/supabase)**
 - Become a **[sponsor](https://github.com/sponsors/supabase)**

--- a/www/_blog/2021-12-15-beta-november-2021-launch-week-recap.mdx
+++ b/www/_blog/2021-12-15-beta-november-2021-launch-week-recap.mdx
@@ -115,5 +115,5 @@ We hit 25K stars!! [github.com/supabase/supabase](http://github.com/supabase/sup
 - Start using Supabase today: **[app.supabase.io](https://app.supabase.io/)**
 - Make sure to **[star us on GitHub](https://github.com/supabase/supabase)**
 - Follow us **[on Twitter](https://twitter.com/supabase)**
-- Subscribe to our **[YouTube channel](https://www.youtube.com/channel/UCNTVzV1InxHV-YR0fSajqPQ)**
+- Subscribe to our **[YouTube channel](https://www.youtube.com/c/supabase)**
 - Become a **[sponsor](https://github.com/sponsors/supabase)**

--- a/www/_blog/2022-01-20-supabase-beta-december-2021.mdx
+++ b/www/_blog/2022-01-20-supabase-beta-december-2021.mdx
@@ -152,5 +152,5 @@ Check out some of our other community stats in our latest [Series A Blog Post](/
 - Start using Supabase today: **[app.supabase.io](https://app.supabase.io/)**
 - Make sure to **[star us on GitHub](https://github.com/supabase/supabase)**
 - Follow us **[on Twitter](https://twitter.com/supabase)**
-- Subscribe to our **[YouTube channel](https://www.youtube.com/channel/UCNTVzV1InxHV-YR0fSajqPQ)**
+- Subscribe to our **[YouTube channel](https://www.youtube.com/c/supabase)**
 - Become a **[sponsor](https://github.com/sponsors/supabase)**


### PR DESCRIPTION
## What kind of change does this PR introduce?

Update supabase youtube link from [youtube.com/channel/UCNTVzV1InxHV-YR0fSajqPQ](https://www.youtube.com/channel/UCNTVzV1InxHV-YR0fSajqPQ) to [youtube.com/c/supabase](https://www.youtube.com/c/supabase).

## What is the current behavior?

[youtube.com/channel/UCNTVzV1InxHV-YR0fSajqPQ](https://www.youtube.com/channel/UCNTVzV1InxHV-YR0fSajqPQ)

## What is the new behavior?

[youtube.com/c/supabase](https://www.youtube.com/c/supabase)