### PR TITLE
Fix: missing hyperlink

### DIFF
--- a/studio/components/interfaces/Database/Pooling/PgBouncerConfig.tsx
+++ b/studio/components/interfaces/Database/Pooling/PgBouncerConfig.tsx
@@ -107,7 +107,7 @@ const PgbouncerConfig: FC<Props> = ({ projectRef, config }) => {
                   suitable mode for your use case,{' '}
                   <Typography.Link
                     target="_blank"
-                    href="https://supabase.com/blog/2021/04/02/supabase-pgbouncer#pool-modes"
+                    href="https://supabase.com/docs/guides/database/connecting-to-postgres#connection-pool"
                   >
                     click here
                   </Typography.Link>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix The Missing Hyperlink in Connection Pooling Config.

## What is the current behavior?

Fix #2214

## What is the new behavior?

Links to [Connection Pooling Docs](https://supabase.com/docs/guides/database/connecting-to-postgres#connection-pool).

## Additional context

Should I use another link or is this the current link fine?