### PR TITLE
Azure should be lowercase: azure

### DIFF
--- a/web/docs/guides/auth/auth-azure.mdx
+++ b/web/docs/guides/auth/auth-azure.mdx
@@ -62,7 +62,7 @@ The JavaScript client code is documented in the [Supabase OAuth Reference](/docs
 
 ```js
 const { user, session, error } = await supabase.auth.signIn({
-  provider: 'Azure',
+  provider: 'azure',
 })
 ```
 
@@ -71,7 +71,7 @@ Add a function which you can call from a button, link, or UI element.
 ```js
 async function signInWithAzure() {
   const { user, session, error } = await supabase.auth.signIn({
-    provider: 'Azure',
+    provider: 'azure',
   }, {
       scopes: 'email',
   })


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

`Azure` is spelled with a capital `A`

## What is the new behavior?

`azure` is spelled with a lower case `a`
