### PR TITLE
Fix: dead link

### DIFF
--- a/web/docs/about.mdx
+++ b/web/docs/about.mdx
@@ -120,7 +120,7 @@ The documentation is divided into 2 sections.
   <div class="row is-multiline">
     {/* Auth */}
     <div class="col col--6">
-      <Link class="card" to="/docs/guides" style={{ height: '100%' }}>
+      <Link class="card" to="/docs/" style={{ height: '100%' }}>
         <div class="card__body">
           <h4>Guides</h4>
           <p>In-depth explanations for each tool.</p>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix dead link in docs.

## What is the current behavior?

Fix #5092
The current link https://supabase.com/docs/guides

## What is the new behavior?

New link https://supabase.com/docs/