### PR TITLE
chore: update Realtime API docs to specify public schema tables

### DIFF
--- a/web/docs/guides/api.mdx
+++ b/web/docs/guides/api.mdx
@@ -273,7 +273,7 @@ alter publication supabase_realtime add table products;
 
 #### Details and links:
 
-- You should only turn on realtime for Public tables (where all data should be accessible). 
+- Realtime only works for tables in the public schema.
 - [JS Reference](/docs/reference/javascript/subscribe): Subscribe to database changes using the realtime client
 
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the new behavior?

specify that realtime only works for tables in the public schema.

## Additional context

related: https://github.com/supabase/supabase/discussions/1550#discussioncomment-2013923
