### PR TITLE
enable default dark scrollbar when on dark mode

### DIFF
--- a/studio/styles/main.scss
+++ b/studio/styles/main.scss
@@ -143,6 +143,10 @@ input[type='radio'] {
   display: none;
 }
 
+.dark {
+  color-scheme: dark;
+}
+
 code {
   @apply p-1 m-0 font-mono text-sm bg-gray-100 dark:bg-gray-600 rounded;
 }


### PR DESCRIPTION
Feat: This enable browser to use dark scrollbar when available turning white scrollbar last contrast on dark mode