### PR TITLE
Chore/update loading logic for layouts

### DIFF
--- a/studio/components/layouts/AuthLayout/AuthLayout.tsx
+++ b/studio/components/layouts/AuthLayout/AuthLayout.tsx
@@ -15,16 +15,15 @@ interface Props {
 
 const AuthLayout: FC<Props> = ({ title, children }) => {
   const { ui, meta } = useStore()
-  const { isLoading, error } = meta.tables
+  const { isInitialized, isLoading, error } = meta.tables
   const projectRef = ui.selectedProject?.ref ?? 'default'
 
   const router = useRouter()
   const page = router.pathname.split('/')[4]
 
-  const [loaded, setLoaded] = useState<boolean>(false)
+  const [loaded, setLoaded] = useState<boolean>(isInitialized)
 
   useEffect(() => {
-    // I think we should just shift the loading of things into the page level
     meta.tables.load()
   }, [])
 

--- a/studio/components/layouts/DatabaseLayout/DatabaseLayout.tsx
+++ b/studio/components/layouts/DatabaseLayout/DatabaseLayout.tsx
@@ -15,13 +15,13 @@ interface Props {
 
 const DatabaseLayout: FC<Props> = ({ title, children }) => {
   const { meta, ui } = useStore()
-  const { isLoading, error } = meta.tables
+  const { isInitialized, isLoading, error } = meta.tables
   const project = ui.selectedProject
 
   const router = useRouter()
   const page = router.pathname.split('/')[4]
 
-  const [loaded, setLoaded] = useState<boolean>(false)
+  const [loaded, setLoaded] = useState<boolean>(isInitialized)
 
   useEffect(() => {
     // Eventually should only load the required stores based on the pages

--- a/studio/components/layouts/SQLEditorLayout/SQLEditorLayout.tsx
+++ b/studio/components/layouts/SQLEditorLayout/SQLEditorLayout.tsx
@@ -14,9 +14,9 @@ interface Props {
 
 const SQLEditorLayout: FC<Props> = ({ title, children }) => {
   const { content } = useStore()
-  const { isLoading, error } = content
+  const { isInitialized, isLoading, error } = content
 
-  const [loaded, setLoaded] = useState(false)
+  const [loaded, setLoaded] = useState(isInitialized)
 
   useEffect(() => {
     content.load()

--- a/studio/components/layouts/SQLEditorLayout/SQLEditorMenuOld.tsx
+++ b/studio/components/layouts/SQLEditorLayout/SQLEditorMenuOld.tsx
@@ -227,7 +227,7 @@ const SideBarContent = observer(() => {
                 })}
               </div>
             )}
-            <Loading active={contentStore.isLoading}>
+            <Loading active={contentStore.isInitialized}>
               <div className="px-3 space-y-6">
                 {favouriteTabs.length >= 1 && (
                   <div className="editor-product-menu">

--- a/studio/components/layouts/TableEditorLayout/TableEditorLayout.tsx
+++ b/studio/components/layouts/TableEditorLayout/TableEditorLayout.tsx
@@ -28,9 +28,9 @@ const TableEditorLayout: FC<Props> = ({
   children,
 }) => {
   const { meta } = useStore()
-  const { isLoading, error } = meta.tables
+  const { isInitialized, isLoading, error } = meta.tables
 
-  const [loaded, setLoaded] = useState<boolean>(false)
+  const [loaded, setLoaded] = useState<boolean>(isInitialized)
 
   useEffect(() => {
     meta.schemas.load()

--- a/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
+++ b/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
@@ -97,7 +97,7 @@ const TableEditorMenu: FC<Props> = ({
     <div className="my-6 flex flex-col flex-grow">
       {/* Schema selection dropdown */}
       <div className="mx-4">
-        {meta.schemas.isLoading ? (
+        {!meta.schemas.isInitialized ? (
           <div className="h-[30px] border border-gray-500 px-3 rounded flex items-center space-x-3">
             <IconLoader className="animate-spin" size={14} />
             <Typography.Text small>Loading schemas...</Typography.Text>

--- a/studio/components/to-be-cleaned/DisplayProjectSettings.tsx
+++ b/studio/components/to-be-cleaned/DisplayProjectSettings.tsx
@@ -39,7 +39,7 @@ export const DisplayApiSettings = () => {
 
   // Get the API service
   const apiService = (data?.services ?? []).find((x: any) => x.app.id == API_SERVICE_ID)
-  const apiKeys = apiService.service_api_keys
+  const apiKeys = apiService?.service_api_keys ?? []
 
   return (
     <ApiContentWrapper>

--- a/studio/pages/project/[ref]/settings/logs/[type].tsx
+++ b/studio/pages/project/[ref]/settings/logs/[type].tsx
@@ -85,10 +85,9 @@ export const LogPage: NextPage = () => {
       })
     }
     if (te) {
-      setParams(prev => ({ ...prev, timestamp_end: te as string }))
+      setParams((prev) => ({ ...prev, timestamp_end: te as string }))
     } else {
-      setParams(prev => ({ ...prev, timestamp_end: '' }))
-
+      setParams((prev) => ({ ...prev, timestamp_end: '' }))
     }
   }, [logsQueryParamsSyncing])
 
@@ -110,7 +109,7 @@ export const LogPage: NextPage = () => {
     if (prevPageData === null) {
       // reduce interval window limit by using the timestamp of the last log
       queryParams = genQueryParams(params)
-    } else if (prevPageData.data.length === 0) {
+    } else if ((prevPageData?.data ?? []).length === 0) {
       // no rows returned, indicates that no more data to retrieve and append.
       return null
     } else {
@@ -157,7 +156,7 @@ export const LogPage: NextPage = () => {
       pathname: router.pathname,
       query: {
         ...router.query,
-        te: undefined
+        te: undefined,
       },
     })
     setSize(1)
@@ -183,7 +182,7 @@ export const LogPage: NextPage = () => {
         where: isSelectQuery ? '' : template.searchString,
         sql: isSelectQuery ? template.searchString : '',
         search_query: '',
-        timestamp_end: ''
+        timestamp_end: '',
       }))
       setEditorId(uuidv4())
     }
@@ -202,7 +201,7 @@ export const LogPage: NextPage = () => {
         ...router.query,
         q: editorValue,
         s: undefined,
-        te: undefined
+        te: undefined,
       },
     })
   }
@@ -211,7 +210,7 @@ export const LogPage: NextPage = () => {
     setParams((prev) => ({
       ...prev,
       search_query: query || '',
-      timestamp_end: from ? String(unixMicro) : '' ,
+      timestamp_end: from ? String(unixMicro) : '',
       where: '',
       sql: '',
     }))
@@ -222,7 +221,7 @@ export const LogPage: NextPage = () => {
         ...router.query,
         q: undefined,
         s: query || '',
-        te: unixMicro
+        te: unixMicro,
       },
     })
     setEditorValue('')
@@ -239,7 +238,9 @@ export const LogPage: NextPage = () => {
           onRefresh={handleRefresh}
           onSearch={handleSearch}
           defaultSearchValue={params.search_query}
-          defaultFromValue={params.timestamp_end ? dayjs(Number(params.timestamp_end)/1000).toISOString() : ''}
+          defaultFromValue={
+            params.timestamp_end ? dayjs(Number(params.timestamp_end) / 1000).toISOString() : ''
+          }
           onCustomClick={handleModeToggle}
           onSelectTemplate={onSelectTemplate}
         />

--- a/studio/stores/common/PostgresMetaInterface.ts
+++ b/studio/stores/common/PostgresMetaInterface.ts
@@ -23,6 +23,12 @@ export interface IPostgresMetaInterface<T> {
   byId: (id: number | string) => T | undefined
   initialDataArray: (value: T[]) => void
 }
+
+// [TODO] Need to refactor the logic for 'isInitialized'
+// Should avoid page level "loaded" state like TableEditorLayout
+// The logic should be - state should be INITIAL at first, and only
+// taken as initialized after the first trigger of the load method.
+// https://github.com/supabase/supabase/pull/5128#pullrequestreview-860706726
 export default class PostgresMetaInterface<T> implements IPostgresMetaInterface<T> {
   STATES = {
     INITIAL: 'initial',

--- a/studio/stores/content/ProjectContentStore.ts
+++ b/studio/stores/content/ProjectContentStore.ts
@@ -11,6 +11,7 @@ import { API_URL } from 'lib/constants'
 
 export interface IProjectContentStore {
   isLoading: boolean
+  isInitialized: boolean
   error: any
 
   load: () => void
@@ -45,6 +46,10 @@ export default class ProjectContentStore implements IProjectContentStore {
 
   get isLoading() {
     return this.state === this.STATES.INITIAL || this.state === this.STATES.LOADING
+  }
+
+  get isInitialized() {
+    return this.state !== this.STATES.INITIAL
   }
 
   async fetchData() {


### PR DESCRIPTION
## What kind of change does this PR introduce?

- For table editor, SQL editor, database page and auth page, if the store has already been loaded, do not hide the entire UI with the loader, but let it fire "store.load" in the background
- Added some guards to prevent some errors