### PR TITLE
Force a browser refresh upon project successfully built

### DIFF
--- a/studio/components/layouts/ProjectLayout/ProjectLayout.tsx
+++ b/studio/components/layouts/ProjectLayout/ProjectLayout.tsx
@@ -23,7 +23,7 @@ interface Props {
   hideIconBar?: boolean
 }
 
-const BaseLayout: FC<Props> = ({
+const ProjectLayout: FC<Props> = ({
   title,
   isLoading = false,
   product = '',
@@ -88,4 +88,4 @@ const BaseLayout: FC<Props> = ({
   )
 }
 
-export default observer(BaseLayout)
+export default observer(ProjectLayout)

--- a/studio/pages/project/[ref]/building.tsx
+++ b/studio/pages/project/[ref]/building.tsx
@@ -3,16 +3,16 @@ import { useRouter } from 'next/router'
 import { observer } from 'mobx-react-lite'
 import { useStore, withAuth } from 'hooks'
 
-import BaseLayout from 'components/layouts'
+import ProjectLayout from 'components/layouts'
 
 type ProjectBuildingPageState = {} & any
 const ProjectBuildingPage: React.FC<ProjectBuildingPageState> = () => {
   const { ui } = useStore()
   const project: any = ui.selectedProject
   return (
-    <BaseLayout title="Project Building">
+    <ProjectLayout title="Project Building">
       <RedirectToDashboard projectRef={project?.ref ?? ''} />
-    </BaseLayout>
+    </ProjectLayout>
   )
 }
 export default withAuth(observer(ProjectBuildingPage))
@@ -24,7 +24,10 @@ const RedirectToDashboard: React.FC<RedirectToDashboardState> = ({ projectRef })
   const router = useRouter()
 
   React.useEffect(() => {
-    router.push(`/project/${projectRef}`)
+    // Use redirect to reload store data properly after project has been
+    // been created or unpaused, this is necessarily especially for unpausing
+    // so that the dashboard fetches the updated connection strings
+    window.location.replace(`/project/${projectRef}`)
   }, [])
   return null
 }


### PR DESCRIPTION
For context, this is a possible fix for the 504s after unpausing a project

Relevant thread:
https://supabase.slack.com/archives/C023WTG3EMS/p1642722678013300?thread_ts=1642722678.013300&cid=C023WTG3EMS

Diagnosis from div is that there are 2 issues
- Stale connection string is being used by the dashboard after unpausing the project
- Dashboard is not showing loading state properly, and renders the page even before the pgmeta calls are completed (e.g table editor)

I think both of these can be resolved by ensuring connection string is updated.

Connection strings from projects are retrieved at the `/profile` endpoint, where we retrieve the user's profile that has a list of organizations, in which each organization has a list of projects, and each project has their own connection string. This is then later stored in the store

To ensure that the connection strings are updated, i'm just gonna force a browser refresh once the project is out of the "building" state