### PR TITLE
Docs: migrate storage objects

### DIFF
--- a/web/docs/guides/database.mdx
+++ b/web/docs/guides/database.mdx
@@ -138,6 +138,73 @@ Migrating projects can be achieved using standard PostgreSQL tooling. This is pa
 6. Run `TRUNCATE storage.objects` in the *new* project's SQL editor
 7. Run `ALTER ROLE postgres NOSUPERUSER` in the *new* project's SQL editor
 
+#### Migrate storage objects
+
+This script moves storage objects from one project to another. If you have more than 10k objects, we can move the objects for you. Just contact us at [support@supabase.io](mailto:support@supabase.io).
+
+```js
+const { createClient } = require("@supabase/supabase-js");
+
+const OLD_PROJECT_URL = "https://xxx.supabase.co";
+const OLD_PROJECT_SERVICE_KEY = "old-project-service-key-xxx";
+
+const NEW_PROJECT_URL = "https://yyy.supabase.co";
+const NEW_PROJECT_SERVICE_KEY = "new-project-service-key-yyy";
+
+(async () => {
+  const oldSupabaseRestClient = createClient(
+    OLD_PROJECT_URL,
+    OLD_PROJECT_SERVICE_KEY,
+    { schema: "storage" }
+  );
+  const oldSupabaseClient = createClient(
+    OLD_PROJECT_URL,
+    OLD_PROJECT_SERVICE_KEY
+  );
+  const newSupabaseClient = createClient(
+    NEW_PROJECT_URL,
+    NEW_PROJECT_SERVICE_KEY
+  );
+
+  // make sure you update max_rows in postgrest settings if you have a lot of objects
+  // or paginate here
+  const { data: oldObjects, error } = await oldSupabaseRestClient
+    .from("objects")
+    .select();
+  if (error) {
+    console.log("error getting objects from old bucket");
+    throw error;
+  }
+
+  for (const objectData of oldObjects) {
+    console.log(`moving ${objectData.id}`);
+    try {
+      const { data, error: downloadObjectError } =
+        await oldSupabaseClient.storage
+          .from(objectData.bucket_id)
+          .download(objectData.name);
+      if (downloadObjectError) {
+        throw downloadObjectError;
+      }
+
+      const { _, error: uploadObjectError } = await newSupabaseClient.storage
+        .from(objectData.bucket_id)
+        .upload(objectData.name, data, {
+          upsert: true,
+          contentType: objectData.metadata.mimetype,
+          cacheControl: objectData.metadata.cacheControl,
+        });
+      if (uploadObjectError) {
+        throw uploadObjectError;
+      }
+    } catch (err) {
+      console.log("error moving ", objectData);
+      console.log(err);
+    }
+  }
+})();
+```
+
 #### Caveats
 
 - The new project will have the old project's Storage buckets, but not the objects. You will need to migrate Storage objects manually.


### PR DESCRIPTION
## What kind of change does this PR introduce?

adds a script to the docs that migrates storage objects from one project to another.

## What is the current behavior?

Fix https://github.com/supabase/storage-js/issues/29

## What is the new behavior?

new script to migrate storage objects.