### PR TITLE
Improve RLS description

### DIFF
--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.tsx
@@ -175,7 +175,7 @@ const TableEditor: FC<Props> = ({
               <Badge color="green">Recommended</Badge>
             </div>
           }
-          description="Restrict access to your table by enabling RLS and writing Postgres policies"
+          description="Restrict access to your table by enabling RLS and writing Postgres policies. If RLS is not enabled, anyone with the anon key can modify and delete your data."
           checked={tableFields?.isRLSEnabled}
           onChange={() => onUpdateField({ isRLSEnabled: !tableFields?.isRLSEnabled })}
           size="medium"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Make the RLS description more clear by adding `If RLS is not enabled, anyone with the anon key can modify and delete your data.`

## What is the current behavior?

Close #4992

## What is the new behavior?

Make the RLS description more clear

## Additional context

<img width="600" alt="Screen Shot 2022-01-24 at 7 44 32 PM" src="https://user-images.githubusercontent.com/70828596/150889350-333cba7d-0b86-44a0-9c74-0936a113ded3.png">