### PR TITLE
Fix: about site build broken

### DIFF
--- a/about/docusaurus.config.js
+++ b/about/docusaurus.config.js
@@ -12,6 +12,7 @@ module.exports = {
   favicon: '/favicon.ico',
   organizationName: 'supabase', // Usually your GitHub org/user name.
   projectName: 'supabase', // Usually your repo name.
+  onBrokenLinks: 'warn',
   themeConfig: {
     forceDarkMode: true,
     darkMode: true,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix about site build broken link

## What is the current behavior?

Fix #5148 broken link

## What is the new behavior?

Instead of failing build with an error, warn and build Successfully.

## Additional context

Even though That we are being warned that the link is broken, the links still work in the production build.
<img width="682" alt="Screen Shot 2022-01-24 at 11 23 02 PM" src="https://user-images.githubusercontent.com/70828596/150910533-39fe3987-957e-49ba-aaa9-46125262df5f.png">