### PR TITLE
Revert website cta link to just the dashboard and not new project

### DIFF
--- a/www/components/CTABanner/index.tsx
+++ b/www/components/CTABanner/index.tsx
@@ -16,7 +16,7 @@ const CTABanner = (props: any) => {
         </Typography.Title>
       </div>
       <div className="col-span-12 mt-4">
-        <a href="https://app.supabase.io/?next=new-project">
+        <a href="https://app.supabase.io/">
           <Button size="medium">Start your project</Button>
         </a>
       </div>

--- a/www/components/Nav/index.tsx
+++ b/www/components/Nav/index.tsx
@@ -253,7 +253,7 @@ const Nav = (props: Props) => {
                 <a href="https://app.supabase.io/">
                   <Button type="default">Sign in</Button>
                 </a>
-                <a href="https://app.supabase.io/?next=new-project">
+                <a href="https://app.supabase.io/">
                   <Button>Start your project</Button>
                 </a>
               </div>


### PR DESCRIPTION
Realised that the CTA button link was going to app.supabase.io/?next=new-project

Made it to just go to app.supabase.io

for context: the ?next=new-project is for the database.new url, we shouldn't be bringing users to the new project page if they're accessing the dashboard through the marketing site