### PR TITLE
fix: description does not match the code

### DIFF
--- a/web/docs/guides/with-expo.mdx
+++ b/web/docs/guides/with-expo.mdx
@@ -179,7 +179,7 @@ export const supabase = createClient(supabaseUrl, supabaseAnonKey)
 ### Set up a Login component
 
 Let's set up a React Native component to manage logins and sign ups. 
-We'll use Magic Links, so users can sign in with their email without using passwords.
+Users would be able to sign in with their email and password.
 
 ```jsx title="components/Auth.js"
 import React, {useState} from 'react'


### PR DESCRIPTION


## What kind of change does this PR introduce?

docs update

## What is the current behavior?

Description says that we would use magic links to sign in with emails and without passwords.
But the code shows how to sign in with both email and password.

## What is the new behavior?

Description matches the code, it says that we sign in using both email and password.

## Additional context

Add any other context or screenshots.
