### PR TITLE
Docs: add new providers

### DIFF
--- a/studio/components/to-be-cleaned/Docs/Pages/UserManagement.js
+++ b/studio/components/to-be-cleaned/Docs/Pages/UserManagement.js
@@ -156,7 +156,7 @@ export default function UserManagement({ autoApiService, selectedLang, showApiKe
       <div className="doc-section ">
         <article className="text ">
           <p>
-            Users can log in with Google, Facebook, Gitlab, Github, Azure, or Bitbucket. You must
+            Users can log in with Third Party OAuth like Google, Facebook, Github, and more. You must
             first enable each of these in the{' '}
             <span className="text-green-500">
               <Link key={'AUTH'} href={`/project/${router.query.ref}/auth/settings`}>
@@ -166,9 +166,7 @@ export default function UserManagement({ autoApiService, selectedLang, showApiKe
             tab.
           </p>
           <p>
-            <code>provider</code> can be <code>google</code>, <code>gitlab</code>,{' '}
-            <code>azure</code>, <code>facebook</code>, <code>github</code>, or{' '}
-            <code>bitbucket</code>
+            Vew all the available <a href='https://supabase.com/docs/guides/auth#providers' target='_blank'>Third Part OAuth providers</a>
           </p>
           <p>
             After they have logged in, all interactions using the Supabase JS client will be

--- a/web/spec/supabase.yml
+++ b/web/spec/supabase.yml
@@ -515,11 +515,11 @@ pages:
           })
           ```
       - name: Sign in using third-party providers.
-        description: Supabase supports OAuth logins.
+        description: Supabase supports many different [third-party providers](https://supabase.com/docs/guides/auth#providers).
         js: |
           ```js
           const { user, session, error } = await supabase.auth.signIn({
-            // provider can be 'github', 'google', 'gitlab', or 'bitbucket'
+            // provider can be 'github', 'google', 'gitlab', and more
             provider: 'github'
           })
           ```

--- a/web/src/data/authProviders.js
+++ b/web/src/data/authProviders.js
@@ -99,6 +99,15 @@ const authProviders = [
     selfHosted: true,
   },
   {
+    name: 'Notion',
+    // logo: '/img/libraries/notion-icon.svg',
+    href: '/docs/guides/auth/auth-notion',
+    official: true,
+    supporter: 'Supabase',
+    platform: true,
+    selfHosted: true,
+  },
+  {
     name: 'Slack',
     // logo: '/img/libraries/dart-icon.svg',
     href: '/docs/guides/auth/auth-slack',


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add new providers to Auto-gen docs

[this list of providers](https://github.com/supabase/supabase/blob/94fdf5cff2751f61993a7df4daf7090d535b6b02/studio/components/to-be-cleaned/Docs/Pages/UserManagement.js#L170) is out of date,

- [x] we may want to just link to [the docs](https://supabase.com/docs/guides/auth/auth-apple) or [this](https://github.com/supabase/gotrue-js/blob/5d2f65a3d8b565b47e277211e6a4c8054c0b8e97/src/lib/types.ts#L2) instead of maintaining a separate list

- [x] Additionally we should add the same link or reference [here](https://supabase.com/docs/reference/javascript/auth-signin#sign-in-using-third-party-providers)

## What is the current behavior?

Close #5180

## What is the new behavior?

Add new providers to Auto-gen docs

## Additional context

@awalias is this something that you meant?

> we may want to just link to [the docs](https://supabase.com/docs/guides/auth/auth-apple) or [this](https://github.com/supabase/gotrue-js/blob/5d2f65a3d8b565b47e277211e6a4c8054c0b8e97/src/lib/types.ts#L2) instead of maintaining a separate list

Instead, I used these [Docs](https://supabase.com/docs/guides/auth#providers)