### PR TITLE
Chore: remove broken link

### DIFF
--- a/examples/nextjs-slack-clone/README.md
+++ b/examples/nextjs-slack-clone/README.md
@@ -12,7 +12,6 @@ This is a full-stack Slack clone example using:
 
 - Live demo: http://supabase-slack-clone-supabase.vercel.app/
 - CodeSandbox: https://codesandbox.io/s/github/supabase/supabase/tree/master/examples/nextjs-slack-clone
-- Video tutorial: https://www.loom.com/share/31eec9b656e44b8d87c88bde8a465676
 
 ![Demo animation gif](./public/slack-clone-demo.gif)
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Remove broken link to slack clone tutorial video.

## What is the current behavior?

Fix #5114

## What is the new behavior?

Remove broken link

## Additional context

I couldn't fix find the video 🙁