### PR TITLE
docs: kong.yml is in the api folder, not volumes

### DIFF
--- a/web/docs/guides/hosting/docker.mdx
+++ b/web/docs/guides/hosting/docker.mdx
@@ -51,7 +51,7 @@ Replace the values in these files:
 - `.env`: 
   - `ANON_KEY` - replace with an `anon` key
   - `SERVICE_ROLE_KEY` - replace with a `service` key
-- `volumes/kong.yml`
+- `volumes/api/kong.yml`
   - `anon` - replace with an `anon` key
   - `service_role` - replace with a `service` key
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The `kong.yml` file is not in the `volumes` folder, it is in `volumes/api`.

## What is the new behavior?

It correctly points you to the file.
