### PR TITLE
fixed a typo in the docs

### DIFF
--- a/web/spec/supabase.yml
+++ b/web/spec/supabase.yml
@@ -473,7 +473,7 @@ pages:
           You can sign up with OAuth providers using the [`signIn()`](/docs/reference/javascript/auth-signin#sign-in-using-third-party-providers) method.
       - name: Sign up with Phone.
         description: |
-          Supabase supports Phone Auth. After a user verified thier number, they can use the [`signIn()`](/docs/reference/javascript/auth-signin#sign-in-using-phone) method.
+          Supabase supports Phone Auth. After a user verified their number, they can use the [`signIn()`](/docs/reference/javascript/auth-signin#sign-in-using-phone) method.
         js: |
           ```js
           const { user, session, error } = await supabase.auth.signIn({


### PR DESCRIPTION
change a mistype of "thier" to "their"

## What kind of change does this PR introduce?

Update on the docs, to fix the typo

## What is the current behavior?

Spelt "thier"

## What is the new behavior?

Spelt "their"

## Additional context

<img width="661" alt="image" src="https://user-images.githubusercontent.com/51441307/151756300-3436426e-2e86-412a-adbb-9bc34f153711.png">

