### PR TITLE
Updated SignUp() docs to fix typo

### DIFF
--- a/web/spec/supabase.yml
+++ b/web/spec/supabase.yml
@@ -473,7 +473,7 @@ pages:
           You can sign up with OAuth providers using the [`signIn()`](/docs/reference/javascript/auth-signin#sign-in-using-third-party-providers) method.
       - name: Sign up with Phone.
         description: |
-          Supabase supports Phone Auth. After a user verified thier number, they can use the [`signIn()`](/docs/reference/javascript/auth-signin#sign-in-using-phone) method.
+          Supabase supports Phone Auth. After a user has verified their number, they can use the [`signIn()`](/docs/reference/javascript/auth-signin#sign-in-using-phone) method.
         js: |
           ```js
           const { user, session, error } = await supabase.auth.signIn({


### PR DESCRIPTION
Changed "verified thier" to "has verified their"

## What kind of change does this PR introduce?

Docs update: fixed typo

## What is the current behavior?

Incorrect grammar and spelling in the docs for SignUp() under auth

## What is the new behavior?

Fixed spelling.

## Additional context

<img width="873" alt="image" src="https://user-images.githubusercontent.com/51441307/151764055-2199b98a-d8d6-4261-a4b5-8be03dd80b44.png">

Add any other context or screenshots.
