### PR TITLE
Fixed left join syntax: use _on_ not _where_.

### DIFF
--- a/www/_blog/2020-11-18-postgresql-views.mdx
+++ b/www/_blog/2020-11-18-postgresql-views.mdx
@@ -62,8 +62,8 @@ create view transcripts as
         courses.code,
         grades.result
     from grades
-    left join students where grades.student_id = students.id
-    left join courses where grades.course_id = courses.id;
+    left join students on grades.student_id = students.id
+    left join courses on grades.course_id = courses.id;
 ```
 
 Once done, we can now access the underlying query with:
@@ -95,8 +95,8 @@ select
     courses.code,
     grades.result
 from grades
-left join students where grades.student_id = students.id
-left join courses where grades.course_id = courses.id;
+left join students on grades.student_id = students.id
+left join courses on grades.course_id = courses.id;
 ```
 
 We can run this instead:
@@ -119,8 +119,8 @@ select
     courses.code,
     grades.result
 from grades
-    left join students where grades.student_id = students.id
-    left join courses where grades.course_id = courses.id
+    left join students on grades.student_id = students.id
+    left join courses on grades.course_id = courses.id
 where courses.code != 'PG101';
 ```
 
@@ -151,8 +151,8 @@ create materialized view transcripts as
         courses.code,
         grades.result
     from grades
-    left join students where grades.student_id = students.id
-    left join courses where grades.course_id = courses.id;
+    left join students on grades.student_id = students.id
+    left join courses on grades.course_id = courses.id;
 ```
 
 Reading from the materialized view is the same as a conventional view:


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update - I had used your blog post as a reference and it cost me 2 minutes to find out the syntax for the left join operator seems to be wrong.

## What is the current behavior?

Syntax error on query invocation.

## What is the new behavior?

No syntax error on query invocation.

## Additional context

-