### PR TITLE
Fix examples/javascript-auth signup (data -> session)

### DIFF
--- a/examples/javascript-auth/index.js
+++ b/examples/javascript-auth/index.js
@@ -69,11 +69,11 @@ const logoutSubmitted = (event) => {
 }
 
 function setToken(response) {
-  if (response.user.confirmation_sent_at && !response?.data?.access_token) {
+  if (response.user.confirmation_sent_at && !response?.session?.access_token) {
     alert('Confirmation Email Sent')
   } else {
-    document.querySelector('#access-token').value = response.data.access_token
-    document.querySelector('#refresh-token').value = response.data.refresh_token
+    document.querySelector('#access-token').value = response.session.access_token
+    document.querySelector('#refresh-token').value = response.session.refresh_token
     alert('Logged in as ' + response.user.email)
   }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Fixed minor bug in the example due to the removal of deprecated
  data from the response:

    https://github.com/supabase/gotrue-js/commit/492d6d70e830a505b74a21874f4cca98776075ab

  Also addresses the comment here about data object not defined:

    https://github.com/supabase/supabase/pull/4373#issue-1074085323

## What is the current behavior?

<img width="1055" alt="Screen Shot 2022-02-01 at 1 44 55 PM" src="https://user-images.githubusercontent.com/939050/151914172-1e8babbd-26d8-48f3-b985-7a593deae949.png">

## What is the new behavior?

The new behavior fixes this problem and retrieves the access and refresh tokens and displays them.
