### PR TITLE
Improve wording for predefined queries

### DIFF
--- a/studio/components/layouts/SQLEditorLayout/SQLEditorMenu.tsx
+++ b/studio/components/layouts/SQLEditorLayout/SQLEditorMenu.tsx
@@ -90,7 +90,7 @@ const SqlEditorMenu: FC<Props> = ({
               <div>
                 <Menu.Item rounded active={page === 'templates'}>
                   <Typography.Text className="truncate" small>
-                    Welcome
+                    Query Templates
                   </Typography.Text>
                 </Menu.Item>
               </div>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Close #5263, rename the section `Welcome` to `Query Templates`

## What is the current behavior?

#5263, `Welcome`

## What is the new behavior?

`Query Templates`