### PR TITLE
Add an example to `db remote set` command in the doc

### DIFF
--- a/web/spec/cli.yml
+++ b/web/spec/cli.yml
@@ -150,8 +150,14 @@ pages:
       Set the remote database to push migrations to.
 
       Usage:
-        supabase db remote set <remote database url>
+        supabase db remote set <remote database connection url>
       ```
+    examples:
+      - name: `db remote set` command
+      sh: |
+        ```sh
+        supabase db remote set postgresql://postgres:[YOUR-PASSWORD]@db.azeazeiqsdiqswdsqdxc.supabase.co:5432/postgres
+        ```
 
   supabase db remote commit:
     description: |


### PR DESCRIPTION
Add an example to `db remote set` command

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

No example given

## What is the new behavior?

Adding an example to the command `db remote set`.
