### PR TITLE
fix/studio/logs: metadata querying templates newline

### DIFF
--- a/studio/components/interfaces/Home/ProjectUsage.tsx
+++ b/studio/components/interfaces/Home/ProjectUsage.tsx
@@ -64,9 +64,9 @@ const ProjectUsage: FC<Props> = ({ project }) => {
     if (timestampDigits < 16) {
       // pad unix timestamp with additional 0 and then forward
       const paddedTimestamp = String(timestamp) + '0'.repeat(16 - timestampDigits)
-      router.push(`/project/${ref}/settings/logs/rest?te=${paddedTimestamp}&s=${search}`)
+      router.push(`/project/${ref}/settings/logs/api?te=${paddedTimestamp}`)
     } else {
-      router.push(`/project/${ref}/settings/logs/rest?te=${timestamp}&s=${search}`)
+      router.push(`/project/${ref}/settings/logs/api?te=${timestamp}`)
     }
   }
   return (

--- a/studio/components/interfaces/Settings/Logs/Logs.constants.ts
+++ b/studio/components/interfaces/Settings/Logs/Logs.constants.ts
@@ -8,6 +8,18 @@ export const TEMPLATES: LogTemplate[] = [
     searchString:
       "REGEXP_CONTAINS(event_message, 'POST') OR REGEXP_CONTAINS(event_message, 'PATCH')",
   },
+  {
+    label: 'Metadata IP',
+    mode: 'custom',
+    searchString:
+      `SELECT timestamp, h.x_real_ip
+FROM edge_logs
+  LEFT JOIN UNNEST(metadata) as m ON TRUE
+  LEFT JOIN UNNEST(m.request) AS r ON TRUE
+  LEFT JOIN UNNEST(r.headers) AS h ON TRUE
+WHERE h.x_real_ip IS NOT NULL
+`,
+  },
 ]
 
 export const DEFAULT_QUERY = 'SELECT timestamp, event_message FROM postgres_logs;'

--- a/studio/components/interfaces/Settings/Logs/Logs.constants.ts
+++ b/studio/components/interfaces/Settings/Logs/Logs.constants.ts
@@ -1,25 +1,63 @@
-import { LogTemplate } from '.'
+import { LogTemplate, LogType } from '.'
 
 export const TEMPLATES: LogTemplate[] = [
-  { label: 'Recent Errors', mode: 'simple', searchString: '[Ee]rror|\\s[45][0-9][0-9]\\s' },
+  {
+    label: 'Recent Errors',
+    mode: 'simple',
+    searchString: '[Ee]rror|\\s[45][0-9][0-9]\\s',
+    for: ['api'],
+  },
+  {
+    label: 'Commits',
+    mode: 'simple',
+    searchString: 'COMMIT',
+    for: ['database'],
+  },
+
+  {
+    label: '10 Minutes Ago',
+    mode: 'simple',
+    searchString: 'timestamp < TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 10 MINUTE)',
+    for: ['database', 'api'],
+  },
   {
     label: 'POST or PATCH',
     mode: 'custom',
     searchString:
       "REGEXP_CONTAINS(event_message, 'POST') OR REGEXP_CONTAINS(event_message, 'PATCH')",
+    for: ['api'],
   },
   {
     label: 'Metadata IP',
     mode: 'custom',
-    searchString:
-      `SELECT timestamp, h.x_real_ip
+    searchString: `SELECT timestamp, h.x_real_ip
 FROM edge_logs
   LEFT JOIN UNNEST(metadata) as m ON TRUE
   LEFT JOIN UNNEST(m.request) AS r ON TRUE
   LEFT JOIN UNNEST(r.headers) AS h ON TRUE
 WHERE h.x_real_ip IS NOT NULL
 `,
+    for: ['database'],
+  },
+  {
+    label: 'Requests by Country',
+    mode: 'custom',
+    searchString: `SELECT 
+  cf.country, count(*) as count
+FROM edge_logs
+  LEFT JOIN UNNEST(metadata) as m ON TRUE
+  LEFT JOIN UNNEST(m.request) AS r ON TRUE
+  LEFT JOIN UNNEST(r.cf) AS cf ON TRUE
+GROUP BY
+  cf.country
+ORDER BY
+  DESC count
+`,
+    for: ['api'],
   },
 ]
 
-export const DEFAULT_QUERY = 'SELECT timestamp, event_message FROM postgres_logs;'
+export const LOG_TYPE_LABEL_MAPPING: { [k: LogType]: string } = {
+  api: 'API',
+  database: 'Database',
+}

--- a/studio/components/interfaces/Settings/Logs/Logs.constants.ts
+++ b/studio/components/interfaces/Settings/Logs/Logs.constants.ts
@@ -1,4 +1,4 @@
-import { LogTemplate, LogType } from '.'
+import { LogTemplate } from '.'
 
 export const TEMPLATES: LogTemplate[] = [
   {
@@ -57,7 +57,7 @@ ORDER BY
   },
 ]
 
-export const LOG_TYPE_LABEL_MAPPING: { [k: LogType]: string } = {
+export const LOG_TYPE_LABEL_MAPPING: { [k: string]: string } = {
   api: 'API',
   database: 'Database',
 }

--- a/studio/components/interfaces/Settings/Logs/Logs.types.ts
+++ b/studio/components/interfaces/Settings/Logs/Logs.types.ts
@@ -16,7 +16,7 @@ export interface LogData {
 export interface LogTemplate {
   label?: string
   mode: 'custom' | 'simple'
-  for?: LogType[]
+  for?: string[]
   searchString: string
 }
 

--- a/studio/components/interfaces/Settings/Logs/Logs.types.ts
+++ b/studio/components/interfaces/Settings/Logs/Logs.types.ts
@@ -1,7 +1,11 @@
 interface Metadata {
   [key: string]: string | number | Object | Object[]
 }
-export type LogSearchCallback =   (filters: { query: string; from?: string, fromMicro?: number }) => void
+export type LogSearchCallback = (filters: {
+  query: string
+  from?: string
+  fromMicro?: number
+}) => void
 export interface LogData {
   id: string
   timestamp: number
@@ -12,6 +16,7 @@ export interface LogData {
 export interface LogTemplate {
   label?: string
   mode: 'custom' | 'simple'
+  for?: LogType[]
   searchString: string
 }
 

--- a/studio/components/layouts/SettingsLayout/SettingsMenu.utils.ts
+++ b/studio/components/layouts/SettingsLayout/SettingsMenu.utils.ts
@@ -1,7 +1,9 @@
+import { LogType, LOG_TYPE_LABEL_MAPPING } from 'components/interfaces/Settings/Logs'
 import { ProductMenuGroup } from 'components/ui/ProductMenu/ProductMenu.types'
-import { LOG_TYPE_LABEL_MAPPING } from 'lib/constants'
 
 export const generateSettingsMenu = (ref: string): ProductMenuGroup[] => {
+  const logTypes: LogType[] = ['database', 'api']
+
   return [
     {
       title: 'Project settings',
@@ -20,15 +22,12 @@ export const generateSettingsMenu = (ref: string): ProductMenuGroup[] => {
     },
     {
       title: 'Logs',
-      // items: ['database', 'auth', 'realtime', 'rest', 'storage'].map((type: string) => {
-      items: ['database', 'rest'].map((type: string) => {
-        return {
-          name: LOG_TYPE_LABEL_MAPPING[type],
-          key: `logs-${type}`,
-          url: `/project/${ref}/settings/logs/${type}`,
-          items: [],
-        }
-      }),
+      items: logTypes.map((type: string) => ({
+        name: LOG_TYPE_LABEL_MAPPING[type],
+        key: `logs-${type}`,
+        url: `/project/${ref}/settings/logs/${type}`,
+        items: [],
+      })),
     },
   ]
 }

--- a/studio/components/layouts/SettingsLayout/SettingsMenu.utils.ts
+++ b/studio/components/layouts/SettingsLayout/SettingsMenu.utils.ts
@@ -1,8 +1,8 @@
-import { LogType, LOG_TYPE_LABEL_MAPPING } from 'components/interfaces/Settings/Logs'
+import { LOG_TYPE_LABEL_MAPPING } from 'components/interfaces/Settings/Logs'
 import { ProductMenuGroup } from 'components/ui/ProductMenu/ProductMenu.types'
 
 export const generateSettingsMenu = (ref: string): ProductMenuGroup[] => {
-  const logTypes: LogType[] = ['database', 'api']
+  const logTypes: string[] = ['database', 'api']
 
   return [
     {

--- a/studio/lib/constants/index.ts
+++ b/studio/lib/constants/index.ts
@@ -88,14 +88,6 @@ export const POLICY_MODAL_VIEWS = {
   REVIEW: 'REVIEW',
 }
 
-export const LOG_TYPE_LABEL_MAPPING: { [k: string]: string } = {
-  rest: 'API',
-  realtime: 'Realtime',
-  auth: 'Auth',
-  storage: 'Storage',
-  database: 'Database',
-}
-
 export const GOTRUE_ERRORS = {
   UNVERIFIED_GITHUB_USER: 'Error sending confirmation mail',
 }

--- a/studio/pages/project/[ref]/settings/logs/[type].tsx
+++ b/studio/pages/project/[ref]/settings/logs/[type].tsx
@@ -65,7 +65,9 @@ export const LogPage: NextPage = () => {
     timestamp_end: '',
   })
   const title = `Logs - ${LOG_TYPE_LABEL_MAPPING[type as string]}`
-  const isSelectQuery = editorValue.toLowerCase().includes('select') ? true : false
+  const checkIfSelectQuery = (value: string) =>
+    value.toLowerCase().includes('select') ? true : false
+  const isSelectQuery = checkIfSelectQuery(editorValue)
 
   useEffect(() => {
     setParams({ ...params, type: type as string })
@@ -180,8 +182,12 @@ export const LogPage: NextPage = () => {
       setEditorValue(template.searchString)
       setParams((prev) => ({
         ...prev,
-        where: isSelectQuery ? '' : cleanEditorValue(template.searchString),
-        sql: isSelectQuery ? cleanEditorValue(template.searchString) : '',
+        where: checkIfSelectQuery(template.searchString)
+          ? ''
+          : cleanEditorValue(template.searchString),
+        sql: checkIfSelectQuery(template.searchString)
+          ? cleanEditorValue(template.searchString)
+          : '',
         search_query: '',
         timestamp_end: '',
       }))
@@ -228,7 +234,7 @@ export const LogPage: NextPage = () => {
     setEditorValue('')
   }
   const cleanEditorValue = (value: string) => {
-    if (typeof value !== "string") return value
+    if (typeof value !== 'string') return value
     return value.replace(/\n/g, ' ')
   }
   return (

--- a/studio/pages/project/[ref]/settings/logs/[type].tsx
+++ b/studio/pages/project/[ref]/settings/logs/[type].tsx
@@ -15,7 +15,7 @@ import {
 
 import { withAuth } from 'hooks'
 import { get } from 'lib/common/fetch'
-import { API_URL, LOG_TYPE_LABEL_MAPPING } from 'lib/constants'
+import { API_URL } from 'lib/constants'
 import { SettingsLayout } from 'components/layouts/'
 import CodeEditor from 'components/ui/CodeEditor'
 import {
@@ -28,6 +28,8 @@ import {
   TEMPLATES,
   LogData,
   LogSearchCallback,
+  LogType,
+  LOG_TYPE_LABEL_MAPPING,
 } from 'components/interfaces/Settings/Logs'
 import { uuidv4 } from 'lib/helpers'
 import useSWRInfinite from 'swr/infinite'
@@ -64,7 +66,7 @@ export const LogPage: NextPage = () => {
     timestamp_start: '',
     timestamp_end: '',
   })
-  const title = `Logs - ${LOG_TYPE_LABEL_MAPPING[type as string]}`
+  const title = `Logs - ${LOG_TYPE_LABEL_MAPPING[type as LogType]}`
   const checkIfSelectQuery = (value: string) =>
     value.toLowerCase().includes('select') ? true : false
   const isSelectQuery = checkIfSelectQuery(editorValue)
@@ -246,7 +248,7 @@ export const LogPage: NextPage = () => {
           isCustomQuery={mode === 'custom'}
           isLoading={isValidating}
           newCount={newCount}
-          templates={TEMPLATES}
+          templates={TEMPLATES.filter((template) => template.for?.includes(type as LogType))}
           onRefresh={handleRefresh}
           onSearch={handleSearch}
           defaultSearchValue={params.search_query}

--- a/studio/pages/project/[ref]/settings/logs/[type].tsx
+++ b/studio/pages/project/[ref]/settings/logs/[type].tsx
@@ -180,8 +180,8 @@ export const LogPage: NextPage = () => {
       setEditorValue(template.searchString)
       setParams((prev) => ({
         ...prev,
-        where: isSelectQuery ? '' : template.searchString,
-        sql: isSelectQuery ? template.searchString : '',
+        where: isSelectQuery ? '' : cleanEditorValue(template.searchString),
+        sql: isSelectQuery ? cleanEditorValue(template.searchString) : '',
         search_query: '',
         timestamp_end: '',
       }))
@@ -191,8 +191,8 @@ export const LogPage: NextPage = () => {
   const handleEditorSubmit = () => {
     setParams((prev) => ({
       ...prev,
-      where: isSelectQuery ? '' : editorValue,
-      sql: isSelectQuery ? editorValue : '',
+      where: isSelectQuery ? '' : cleanEditorValue(editorValue),
+      sql: isSelectQuery ? cleanEditorValue(editorValue) : '',
       search_query: '',
     }))
     if (!logsQueryParamsSyncing) return
@@ -200,7 +200,7 @@ export const LogPage: NextPage = () => {
       pathname: router.pathname,
       query: {
         ...router.query,
-        q: editorValue,
+        q: cleanEditorValue(editorValue),
         s: undefined,
         te: undefined,
       },
@@ -227,7 +227,10 @@ export const LogPage: NextPage = () => {
     })
     setEditorValue('')
   }
-
+  const cleanEditorValue = (value: string) => {
+    if (typeof value !== "string") return value
+    return value.replace(/\n/g, ' ')
+  }
   return (
     <SettingsLayout title={title}>
       <div className="h-full flex flex-col flex-grow">

--- a/studio/pages/project/[ref]/settings/logs/[type].tsx
+++ b/studio/pages/project/[ref]/settings/logs/[type].tsx
@@ -28,7 +28,6 @@ import {
   TEMPLATES,
   LogData,
   LogSearchCallback,
-  LogType,
   LOG_TYPE_LABEL_MAPPING,
 } from 'components/interfaces/Settings/Logs'
 import { uuidv4 } from 'lib/helpers'
@@ -66,7 +65,7 @@ export const LogPage: NextPage = () => {
     timestamp_start: '',
     timestamp_end: '',
   })
-  const title = `Logs - ${LOG_TYPE_LABEL_MAPPING[type as LogType]}`
+  const title = `Logs - ${LOG_TYPE_LABEL_MAPPING[type as keyof typeof LOG_TYPE_LABEL_MAPPING]}`
   const checkIfSelectQuery = (value: string) =>
     value.toLowerCase().includes('select') ? true : false
   const isSelectQuery = checkIfSelectQuery(editorValue)
@@ -248,7 +247,7 @@ export const LogPage: NextPage = () => {
           isCustomQuery={mode === 'custom'}
           isLoading={isValidating}
           newCount={newCount}
-          templates={TEMPLATES.filter((template) => template.for?.includes(type as LogType))}
+          templates={TEMPLATES.filter((template) => template.for?.includes(type as string))}
           onRefresh={handleRefresh}
           onSearch={handleSearch}
           defaultSearchValue={params.search_query}

--- a/studio/pages/project/[ref]/settings/logs/[type].tsx
+++ b/studio/pages/project/[ref]/settings/logs/[type].tsx
@@ -200,7 +200,7 @@ export const LogPage: NextPage = () => {
       pathname: router.pathname,
       query: {
         ...router.query,
-        q: cleanEditorValue(editorValue),
+        q: editorValue,
         s: undefined,
         te: undefined,
       },

--- a/studio/tests/pages/projects/logs.test.js
+++ b/studio/tests/pages/projects/logs.test.js
@@ -297,7 +297,7 @@ test('custom sql querying', async () => {
     expect(editor).toBeTruthy()
   })
   editor = container.querySelector('.monaco-editor')
-  userEvent.type(editor, 'select count(*) as my_count from edge_logs')
+  userEvent.type(editor, 'select \ncount(*) as my_count \nfrom edge_logs')
   // should show sandbox warning alert
   await waitFor(() => screen.getByText(/restricted to a 7 day querying window/))
 
@@ -305,6 +305,7 @@ test('custom sql querying', async () => {
   userEvent.click(screen.getByText('Run'))
   await waitFor(
     () => {
+      expect(get).not.toHaveBeenCalledWith(expect.stringContaining(encodeURI('\n')))
       expect(get).toHaveBeenCalledWith(expect.stringContaining('sql='))
       expect(get).toHaveBeenCalledWith(expect.stringContaining('select'))
       expect(get).toHaveBeenCalledWith(expect.stringContaining('edge_logs'))


### PR DESCRIPTION
This PR adds in a custom SQL logs query, that demonstrates advanced metadata querying through array unnesting via joins.

The template query builds off this support ticket https://support.supabase.org/a/tickets/4494 .

Implementation notes:
- currently, sql needs to be cleaned of newlines, as there seems to be a sql parsing issue relating to newlines within the sql query parameter.
  - however, to preserve user-friendliness, newlines within the cached query param value is still preserved.

Additionally, row limits are currently not mentioned within the ui, which is set to a hard limit of 100 rows. As I'm investigating expanding the row limitation to 1k rows and beyond, this will be addressed at a later date.

