### PR TITLE
Chore: reduce noisy studio test

### DIFF
--- a/studio/components/to-be-cleaned/Charts/ChartRenderer.tsx
+++ b/studio/components/to-be-cleaned/Charts/ChartRenderer.tsx
@@ -344,7 +344,7 @@ export function AreaChart({
       >
         {hasData ? (
           <>
-            <ResponsiveContainer>
+            <ResponsiveContainer width="100%" height={160}>
               <RechartAreaChart
                 data={data}
                 margin={{

--- a/studio/components/to-be-cleaned/Charts/ChartRenderer.tsx
+++ b/studio/components/to-be-cleaned/Charts/ChartRenderer.tsx
@@ -200,6 +200,9 @@ export function BarChart({
 
   const day = (value: number | string) => (displayDateInUtc ? dayjs(value).utc() : dayjs(value))
 
+  // For future reference: https://github.com/supabase/supabase/pull/5311#discussion_r800852828
+  const chartHeight = minimalChart ? 96 : 160
+
   return (
     <Loading active={!data}>
       <div className={className}>
@@ -214,10 +217,10 @@ export function BarChart({
           customDateFormat={customDateFormat}
           displayDateInUtc={displayDateInUtc}
         />
-        <div style={{ width: '100%', height: minimalChart ? '96px' : '160px' }}>
+        <div style={{ width: '100%', height: `${chartHeight}px` }}>
           {hasData ? (
             <>
-              <ResponsiveContainer>
+              <ResponsiveContainer width="100%" height={chartHeight}>
                 <RechartBarChart
                   data={data}
                   margin={{
@@ -270,7 +273,6 @@ export function BarChart({
                       />
                     ))}
                   </Bar>
-                </Bar>
                 </RechartBarChart>
               </ResponsiveContainer>
               {data && (
@@ -326,6 +328,9 @@ export function AreaChart({
     setMouseLeave(true)
   }
 
+  // For future reference: https://github.com/supabase/supabase/pull/5311#discussion_r800852828
+  const chartHeight = 160
+
   return (
     <Loading active={!data}>
       <Header
@@ -340,12 +345,12 @@ export function AreaChart({
       <div
         style={{
           width: '100%',
-          height: '160px',
+          height: `${chartHeight}px`,
         }}
       >
         {hasData ? (
           <>
-            <ResponsiveContainer width="100%" height={160}>
+            <ResponsiveContainer width="100%" height={chartHeight}>
               <RechartAreaChart
                 data={data}
                 margin={{

--- a/studio/components/to-be-cleaned/Charts/ChartRenderer.tsx
+++ b/studio/components/to-be-cleaned/Charts/ChartRenderer.tsx
@@ -175,7 +175,7 @@ export function BarChart({
   label,
   onBarClick,
   minimalHeader,
-  minmalChart,
+  minimalChart,
   className = '',
 }: any) {
   const hasData = data ? dataCheck(data, attribute) : true
@@ -214,7 +214,7 @@ export function BarChart({
           customDateFormat={customDateFormat}
           displayDateInUtc={displayDateInUtc}
         />
-        <div style={{ width: '100%', height: minmalChart ? '96px' : '160px' }}>
+        <div style={{ width: '100%', height: minimalChart ? '96px' : '160px' }}>
           {hasData ? (
             <>
               <ResponsiveContainer>
@@ -270,6 +270,7 @@ export function BarChart({
                       />
                     ))}
                   </Bar>
+                </Bar>
                 </RechartBarChart>
               </ResponsiveContainer>
               {data && (

--- a/studio/components/ui/Charts/StackedAreaChart.tsx
+++ b/studio/components/ui/Charts/StackedAreaChart.tsx
@@ -73,9 +73,9 @@ const StackedAreaChart: React.FC<Props> = ({
       return dayjs(value).format(dateFormat)
     }
   }
-  const minHeight = { small: '120px', normal: '160px', large: '280px' }[size]
+  const minHeight = { small: 120, normal: 160, large: 280 }[size]
   return (
-    <ResponsiveContainer height="100%" minHeight={minHeight} width="100%">
+    <ResponsiveContainer height={minHeight} minHeight={minHeight} width="100%">
       <AreaChart data={transformed} onClick={(_tooltipData: any) => {}}>
         <CartesianGrid strokeDasharray="3 3" style={{ stroke: '#444444' }} />
         <XAxis

--- a/studio/tests/components/Home/ProjectUsage.test.js
+++ b/studio/tests/components/Home/ProjectUsage.test.js
@@ -77,7 +77,6 @@ test('dropdown options changes chart query', async () => {
   render(<ProjectUsage project="12345" />)
   await waitFor(() => screen.getByText(/Statistics for past 24 hours/))
   await waitFor(() => screen.getAllByRole('button', { name: '24 hours' }))
-  console.log(get.mock.calls)
   await waitFor(() => {
     expect(get).toHaveBeenCalledWith(expect.stringContaining('interval=hourly'))
   })

--- a/studio/tests/pages/projects/LogPanel.test.js
+++ b/studio/tests/pages/projects/LogPanel.test.js
@@ -36,7 +36,6 @@ test('toggle event chart', async () => {
   const mockFn = jest.fn()
   const { rerender } = render(<LogPanel onToggleEventChart={mockFn} isShowingEventChart={true} />)
   const toggle = getToggleByText(/Show event chart/)
-  console.log('TOGGLE', toggle)
   userEvent.click(toggle)
   expect(mockFn).toBeCalled()
   rerender(<LogPanel isShowingEventChart={false} />)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Reduce the warnings in the studio test.

- [x] Fix ResponsiveContainer
```bash
 console.warn
      The width(0) and height(0) of chart should be greater than 0,
             please check the style of container, or the props width(100%) and height(100%),
             or add a minWidth(undefined) or minHeight(undefined) or use aspect(undefined) to control the
             height and width.
```

- [x] Fix Dropdown component
```bash
 console.error
      Warning: validateDOMNesting(...): <button> cannot appear as a descendant of <button>.
          at button
          at RenderedButton (/Users/tzeyiing/supabase/supabase/studio/node_modules/@supabase/ui/dist/cjs/components/Button/Button2.js:96:5)
          at span
          at /Users/tzeyiing/supabase/supabase/studio/node_modules/@supabase/ui/dist/cjs/components/Button/Button2.js:14:5
```

## What is the current behavior?

Fix #5301

## What is the new behavior?

fewer warnings.