### PR TITLE
chore: Docs compilation check

### DIFF
--- a/.github/workflows/docs-compilation-check.js.yml
+++ b/.github/workflows/docs-compilation-check.js.yml
@@ -1,0 +1,41 @@
+# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Docs Compilation Check
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+    paths:
+      - 'web/**'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [14.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - name: Install Deps
+      run: apt-get update && apt-get install -y jq && npm ci
+      working-directory: ./web
+      
+    - name: Pull Specs
+      run: make
+      working-directory: ./web/spec
+      
+    - name: Build
+      run: npm run build
+      working-directory: ./web


### PR DESCRIPTION
This GH action adds an additional check for web project compilation.

Trying to build and serve docs pages locally to add in additional platform docs, seems like there's quite a few errors that haven't been caught.