### PR TITLE
fix: docs bad yaml cli reference

### DIFF
--- a/web/ReferenceGenerator.ts
+++ b/web/ReferenceGenerator.ts
@@ -176,8 +176,11 @@ function generateExamples(id: string, specExamples: any, allLanguages: any) {
 /**
  * A spotlight is an example which appears at the top of the page.
  */
-function generateSpotlight(id: string, specExamples: any, allLanguages: any) {
-  const spotlight = specExamples.find((x) => x.isSpotlight) || null
+function generateSpotlight(id: string, specExamples: any | any[], allLanguages: any) {
+  if (!Array.isArray(specExamples)) {
+    throw new Error(`Examples for each spec should be an array, received: \n${specExamples}`)
+  }
+  const spotlight = (specExamples && specExamples.find((x) => x.isSpotlight)) || null
   const spotlightContent = !spotlight
     ? ''
     : Tabs(id, allLanguages, generateTabs(allLanguages, spotlight))

--- a/web/spec/cli.yml
+++ b/web/spec/cli.yml
@@ -153,11 +153,11 @@ pages:
         supabase db remote set <remote database connection url>
       ```
     examples:
-      - name: `db remote set` command
-      sh: |
-        ```sh
-        supabase db remote set postgresql://postgres:[YOUR-PASSWORD]@db.azeazeiqsdiqswdsqdxc.supabase.co:5432/postgres
-        ```
+      - name: "`db remote set` command"
+        sh: |
+          ```sh
+          supabase db remote set postgresql://postgres:[YOUR-PASSWORD]@db.azeazeiqsdiqswdsqdxc.supabase.co:5432/postgres
+          ```
 
   supabase db remote commit:
     description: |


### PR DESCRIPTION
There is a indentation in cli reference that has gone undetected. This fixes it, as well as throws some helpful errors when examples are given as an object instead of an array.