### PR TITLE
fixes `inviteUserByEmail()` JS snippet

### DIFF
--- a/studio/components/to-be-cleaned/Docs/Snippets.js
+++ b/studio/components/to-be-cleaned/Docs/Snippets.js
@@ -591,9 +591,7 @@ curl -X POST '${endpoint}/auth/v1/invite' \\
     js: {
       language: 'js',
       code: `
-let { user, error } = await supabase.auth.api.inviteUserByEmail(
-  email: 'someone@email.com'
-)
+let { data, error } = await supabase.auth.api.inviteUserByEmail('someone@email.com')
 `,
     },
   }),


### PR DESCRIPTION
Tiny fix to the `inviteUserByEmail()` JS sample call.

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

copy/pasting the example fails as the parameter should not be named

## What is the new behavior?

copy/pasting the sample piece of code works! :)

## Additional context

