### PR TITLE
Improve visibility of the policy command (eg SELECT) in policies table

### DIFF
--- a/studio/components/to-be-cleaned/Auth/PolicyTableRow.js
+++ b/studio/components/to-be-cleaned/Auth/PolicyTableRow.js
@@ -45,8 +45,10 @@ const PolicyRow = ({
           </Typography.Text>
         </div>
         <div className="relative w-64">
-          <div className="top-0 right-0 absolute inline-block visible-child my-2 font-mono text-xs text-gray-400 text-right ">
-            {policy.command}
+          <div className="top-0 right-0 absolute inline-block visible-child my-2">
+            <Typography.Text type="secondary" className='font-mono text-right' small>
+              {policy.command}
+            </Typography.Text>
           </div>
           <div className="top-0 right-0 absolute inline-block -mr-3 hidden-child">
             <Button type="outline" className="mx-2" onClick={() => onSelectEditPolicy(policy)}>


### PR DESCRIPTION
## What kind of change does this PR introduce?

UI tweak to improve the visibility of the RLS policy command (eg. SELECT, ALL) in the policy table row. IMO this should be more visible because it's safety-critical (eg. we might be okay with open SELECT but not open UPDATE)

## What is the current behavior?

Currently it can be difficult to see which commands a policy includes:

![Screenshot 2022-02-04 at 15 52 39](https://user-images.githubusercontent.com/1711350/152559893-1b2be8c5-4d30-495b-9c43-27dd39abfcee.png)

## What is the new behavior?

This PR makes them more visible:

![Screenshot 2022-02-04 at 15 53 57](https://user-images.githubusercontent.com/1711350/152560097-df4e22e6-c0b6-4977-a811-d27ad9fcc5d2.png)

Review tags (per studio/readme): @MildTomato, @phamhieu, @joshenlim 