### PR TITLE
Add link to docs

### DIFF
--- a/studio/components/layouts/ProjectLayout/LayoutHeader/FeedbackDropdown/FeedbackWidget.tsx
+++ b/studio/components/layouts/ProjectLayout/LayoutHeader/FeedbackDropdown/FeedbackWidget.tsx
@@ -83,7 +83,7 @@ const FeedbackWidget = ({ onClose, feedback, setFeedback, category, setCategory 
                   <span className="cursor-pointer transition-colors text-green-600 hover:text-green-700">
                     browse our docs
                   </span>
-                </a>{' '}
+                </a>
                 .
               </p>
             </Typography.Text>

--- a/studio/components/layouts/ProjectLayout/LayoutHeader/HelpPopover.tsx
+++ b/studio/components/layouts/ProjectLayout/LayoutHeader/HelpPopover.tsx
@@ -48,7 +48,7 @@ const HelpPopover: FC<Props> = () => {
               </Link>
               <Link href="supabase.com/docs/">
                 <Button type="secondary" size="tiny" icon={<IconBookOpen />}>
-                  Documentation
+                  Docs
                 </Button>
               </Link>
             </div>

--- a/studio/components/layouts/ProjectLayout/LayoutHeader/HelpPopover.tsx
+++ b/studio/components/layouts/ProjectLayout/LayoutHeader/HelpPopover.tsx
@@ -3,6 +3,7 @@ import {
   Divider,
   IconHelpCircle,
   IconMail,
+  IconBookOpen,
   IconMessageCircle,
   Popover,
   Typography,
@@ -39,11 +40,18 @@ const HelpPopover: FC<Props> = () => {
                 hosted services.
               </p>
             </Typography.Text>
-            <Link href={supportUrl}>
-              <Button className="sbui-default-button--dark-white" icon={<IconMail />}>
-                Contact support team
-              </Button>
-            </Link>
+            <div className='flex space-x-1'>
+              <Link href={supportUrl}>
+                <Button className="sbui-default-button--dark-white" size="tiny" icon={<IconMail />}>
+                  Contact support
+                </Button>
+              </Link>
+              <Link href="supabase.com/docs/">
+                <Button type="secondary" size="tiny" icon={<IconBookOpen />}>
+                  Documentation
+                </Button>
+              </Link>
+            </div>
             <Typography.Text type="secondary" small className="block opacity-50">
               Expected response time is based on your billing tier. Pro and Pay as You Go plans are
               prioritised.
@@ -67,18 +75,18 @@ const HelpPopover: FC<Props> = () => {
                 className="relative px-5 py-4 pb-12 rounded overflow-hidden space-y-2 shadow-md"
                 style={{ background: '#404EED' }}
               >
-                <Image
-                  className="absolute left-0 top-0 opacity-50"
-                  src={'/img/support/discord-bg-small.jpg'}
-                  layout="fill"
-                  objectFit="cover"
-                  alt="discord illustration header"
-                />
                 <a
                   href="https://discord.supabase.com"
                   target="_blank"
-                  className="block  cursor-pointer"
+                  className="block cursor-pointer"
                 >
+                  <Image
+                    className="absolute left-0 top-0 opacity-50"
+                    src={'/img/support/discord-bg-small.jpg'}
+                    layout="fill"
+                    objectFit="cover"
+                    alt="discord illustration header"
+                  />
                   <Button
                     className="sbui-default-button--dark-white"
                     type="default"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add a link to the docs in `HelpPopover.tsx`, and removed unnecessary space.

## What is the current behavior?

no link

## What is the new behavior?

add link

## Additional context

<img width="340" alt="Screen Shot 2022-02-06 at 7 25 37 PM" src="https://user-images.githubusercontent.com/70828596/152710409-5b320dfe-3b66-44b8-835d-288a2063b6d2.png">