### PR TITLE
Fix: feedback button

### DIFF
--- a/studio/components/layouts/ProjectLayout/LayoutHeader/FeedbackDropdown/FeedbackDropdown.tsx
+++ b/studio/components/layouts/ProjectLayout/LayoutHeader/FeedbackDropdown/FeedbackDropdown.tsx
@@ -18,8 +18,6 @@ const FeedbackDropdown = () => {
     setIsOpen((isOpen) => !isOpen)
   }
 
-  let width = window.innerWidth
-
   return (
     <div ref={clickContainerRef} className="relative inline-block text-left mr-1">
       <div>
@@ -28,7 +26,8 @@ const FeedbackDropdown = () => {
           type="default"
           icon={<IconMessageCircle size={16} strokeWidth={2} />}
         >
-          {width < 710 ? 'Feedback' : 'Feedback on this page?'}
+          <span className="block md:hidden">Feedback</span>
+          <span className="hidden md:block">Feedback on this page?</span>
         </Button>
       </div>
       <Transition

--- a/studio/components/layouts/ProjectLayout/LayoutHeader/FeedbackDropdown/FeedbackDropdown.tsx
+++ b/studio/components/layouts/ProjectLayout/LayoutHeader/FeedbackDropdown/FeedbackDropdown.tsx
@@ -18,6 +18,10 @@ const FeedbackDropdown = () => {
     setIsOpen((isOpen) => !isOpen)
   }
 
+  let width = window.innerWidth
+  let FeedbackSM = 'Feedback'
+  let feedbackLG = 'Feedback on this page?'
+
   return (
     <div ref={clickContainerRef} className="relative inline-block text-left mr-1">
       <div>
@@ -26,7 +30,7 @@ const FeedbackDropdown = () => {
           type="default"
           icon={<IconMessageCircle size={16} strokeWidth={2} />}
         >
-          Feedback on this page?
+          {width < 710 ? FeedbackSM : feedbackLG}
         </Button>
       </div>
       <Transition

--- a/studio/components/layouts/ProjectLayout/LayoutHeader/FeedbackDropdown/FeedbackDropdown.tsx
+++ b/studio/components/layouts/ProjectLayout/LayoutHeader/FeedbackDropdown/FeedbackDropdown.tsx
@@ -19,8 +19,6 @@ const FeedbackDropdown = () => {
   }
 
   let width = window.innerWidth
-  let FeedbackSM = 'Feedback'
-  let feedbackLG = 'Feedback on this page?'
 
   return (
     <div ref={clickContainerRef} className="relative inline-block text-left mr-1">
@@ -30,7 +28,7 @@ const FeedbackDropdown = () => {
           type="default"
           icon={<IconMessageCircle size={16} strokeWidth={2} />}
         >
-          {width < 710 ? FeedbackSM : feedbackLG}
+          {width < 710 ? 'Feedback' : 'Feedback on this page?'}
         </Button>
       </div>
       <Transition

--- a/studio/components/layouts/ProjectLayout/LayoutHeader/LayoutHeader.tsx
+++ b/studio/components/layouts/ProjectLayout/LayoutHeader/LayoutHeader.tsx
@@ -50,7 +50,7 @@ const LayoutHeader = ({ customHeaderComponents, breadcrumbs = [], headerBorder =
             {/* Additional breadcrumbs are supplied */}
             <BreadcrumbsView defaultValue={breadcrumbs} />
           </div>
-          <div className="flex space-x-2">
+          <div className="flex space-x-1 md:space-x-2">
             {customHeaderComponents && customHeaderComponents}
             {IS_PLATFORM && <HelpPopover />}
             {IS_PLATFORM && <FeedbackDropdown />}


### PR DESCRIPTION
## What kind of change does this PR introduce?

On smaller screens, the feedback button doesn't fit on the screen correctly.

## What is the current behavior?

<img width="398" alt="Screen Shot 2022-02-06 at 11 07 07 PM" src="https://user-images.githubusercontent.com/70828596/152722902-e4e02173-8ccc-42f2-9f22-bfbcd62a880f.png">

## What is the new behavior?

<img width="398" alt="Screen Shot 2022-02-06 at 11 08 20 PM" src="https://user-images.githubusercontent.com/70828596/152722993-ca2fdb39-d254-43bc-9789-e98fcc54d91c.png">

## Additional context

Still works on bigger screens.