### PR TITLE
fix(www): prevent dark flash when light mode

### DIFF
--- a/www/components/DarkModeToggle.tsx
+++ b/www/components/DarkModeToggle.tsx
@@ -1,4 +1,4 @@
-import { useRouter } from 'next/router'
+import { useEffect, useReducer } from 'react'
 
 interface Props {
   darkMode: boolean
@@ -51,8 +51,15 @@ function DarkModeToggle(props: Props) {
     updateTheme(!darkMode)
   }
 
+  // Force update because the SSR-ed markup might differ from the final output
+  // if the user is on light mode.
+  const [updateCounter, forceUpdate] = useReducer((x) => x + 1, 0)
+  useEffect(() => {
+    forceUpdate()
+  }, [])
+
   return (
-    <div className="flex items-center">
+    <div className="flex items-center" key={updateCounter}>
       <SunEmoji />
       <button
         type="button"

--- a/www/components/DarkModeToggle.tsx
+++ b/www/components/DarkModeToggle.tsx
@@ -48,7 +48,6 @@ function DarkModeToggle(props: Props) {
   const { darkMode, updateTheme } = props
 
   const toggleDarkMode = () => {
-    localStorage.setItem('supabaseDarkMode', (!darkMode).toString())
     updateTheme(!darkMode)
   }
 

--- a/www/components/Footer/index.tsx
+++ b/www/components/Footer/index.tsx
@@ -105,7 +105,10 @@ const Footer = (props: Props) => {
           <p className="mb-0 self-center text-base text-gray-400 dark:text-dark-400">
             &copy; Supabase Inc
           </p>
-          <DarkModeToggle darkMode={darkMode} updateTheme={updateTheme} />
+          {/* Render dark mode toggle only on the client since it depends on client-only data (localStorage) */}
+          {typeof window !== 'undefined' && (
+            <DarkModeToggle darkMode={darkMode} updateTheme={updateTheme} />
+          )}
         </div>
       </SectionContainer>
     </footer>

--- a/www/components/Footer/index.tsx
+++ b/www/components/Footer/index.tsx
@@ -105,10 +105,7 @@ const Footer = (props: Props) => {
           <p className="mb-0 self-center text-base text-gray-400 dark:text-dark-400">
             &copy; Supabase Inc
           </p>
-          {/* Render dark mode toggle only on the client since it depends on client-only data (localStorage) */}
-          {typeof window !== 'undefined' && (
-            <DarkModeToggle darkMode={darkMode} updateTheme={updateTheme} />
-          )}
+          <DarkModeToggle darkMode={darkMode} updateTheme={updateTheme} />
         </div>
       </SectionContainer>
     </footer>

--- a/www/components/Layouts/Default.tsx
+++ b/www/components/Layouts/Default.tsx
@@ -13,14 +13,14 @@ const DARK_COLOR_SCHEME_CLASSNAME = 'dark'
 // Prevents flash of dark if the user is on light theme by injecting the right classname while the page loads.
 // rather than after the page hydrates. Defaults to dark.
 const setInitialTheme = `
-  function getUserPreference() {
-    try {
-      return window.localStorage.getItem('${MODE_STORAGE_KEY}') === 'true' 
-        ? '${DARK_COLOR_SCHEME_CLASSNAME}' : ''
-    } catch (err) {}
-    return '${DARK_COLOR_SCHEME_CLASSNAME}'
-  }
-  document.documentElement.className = getUserPreference()
+function getUserPreference() {
+  try {
+    return window.localStorage.getItem('${MODE_STORAGE_KEY}') === 'true' 
+      ? '${DARK_COLOR_SCHEME_CLASSNAME}' : ''
+  } catch (err) {}
+  return '${DARK_COLOR_SCHEME_CLASSNAME}'
+}
+document.documentElement.className = getUserPreference()
 `
 
 const DefaultLayout = (props: Props) => {
@@ -31,7 +31,7 @@ const DefaultLayout = (props: Props) => {
 
   const updateTheme = (isDarkMode: boolean) => {
     document.documentElement.className = isDarkMode ? DARK_COLOR_SCHEME_CLASSNAME : ''
-    window.localStorage.setItem(MODE_STORAGE_KEY, (!darkMode).toString())
+    window.localStorage.setItem(MODE_STORAGE_KEY, isDarkMode.toString())
     setDarkMode(isDarkMode)
   }
 

--- a/www/components/Layouts/Default.tsx
+++ b/www/components/Layouts/Default.tsx
@@ -8,25 +8,36 @@ type Props = {
   children: React.ReactNode
 }
 
+const MODE_STORAGE_KEY = 'supabaseDarkMode'
+const DARK_COLOR_SCHEME_CLASSNAME = 'dark'
+// Prevents flash of dark if the user is on light theme by injecting the right classname while the page loads.
+// rather than after the page hydrates. Defaults to dark.
+const setInitialTheme = `
+  function getUserPreference() {
+    try {
+      return window.localStorage.getItem('${MODE_STORAGE_KEY}') === 'true' 
+        ? '${DARK_COLOR_SCHEME_CLASSNAME}' : ''
+    } catch (err) {}
+    return '${DARK_COLOR_SCHEME_CLASSNAME}'
+  }
+  document.documentElement.className = getUserPreference()
+`
+
 const DefaultLayout = (props: Props) => {
   const { hideHeader = false, hideFooter = false, children } = props
-  const [darkMode, setDarkMode] = useState<boolean>(true)
-
-  useEffect(() => {
-    const isDarkMode = localStorage.getItem('supabaseDarkMode')
-    if (isDarkMode) {
-      setDarkMode(isDarkMode === 'true')
-      document.documentElement.className = isDarkMode === 'true' ? 'dark' : ''
-    }
-  }, [])
+  const initialMode =
+    typeof window != 'undefined' ? window.localStorage.getItem(MODE_STORAGE_KEY) === 'true' : true
+  const [darkMode, setDarkMode] = useState<boolean>(initialMode)
 
   const updateTheme = (isDarkMode: boolean) => {
-    document.documentElement.className = isDarkMode ? 'dark' : ''
+    document.documentElement.className = isDarkMode ? DARK_COLOR_SCHEME_CLASSNAME : ''
+    window.localStorage.setItem(MODE_STORAGE_KEY, (!darkMode).toString())
     setDarkMode(isDarkMode)
   }
 
   return (
     <>
+      <script dangerouslySetInnerHTML={{ __html: setInitialTheme }} />
       {!hideHeader && <Nav darkMode={darkMode} />}
       <div className="min-h-screen bg-white dark:bg-gray-800">
         <main>{children}</main>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Prevents the page from flashing from dark to light if the user selected a light theme (via the footer).

## What is the current behavior?

https://user-images.githubusercontent.com/1315101/152717469-6066bcf2-ce6a-431e-9f1b-06d6dbaf07f6.mp4

See that when the page first loads, the page is black and then it turns white.

## What is the new behavior?

By setting the final class name while the HTML is loading and before the browser first paints to the screen (via `<script>` tags), we can prevent the browser from rendering a version which doesn't match the user's preferences. This technique is being used in [Docusaurus v2](https://github.com/facebook/docusaurus/blob/aa446b7a9c0076e848708e9ea71b8c2e26698be0/packages/docusaurus-theme-classic/src/index.ts).

Also refactored some of the code to be more robust.

