### PR TITLE
fix: Within Flutter quick starter guide, add instructions to make the bucket public for profile image

### DIFF
--- a/web/docs/guides/with-flutter.mdx
+++ b/web/docs/guides/with-flutter.mdx
@@ -152,7 +152,7 @@ flutter create supabase_quickstart
 
 Then let's install the only additional dependency: [`supabase_flutter`](https://github.com/supabase/supabase-flutter)
 
-Run the following command to get the newest version of `supabase_flutter` to your project. 
+Run the following command to get the newest version of `supabase_flutter` to your project.
 
 ```bash
 flutter pub add supabase_flutter
@@ -307,8 +307,8 @@ class AuthRequiredState<T extends StatefulWidget>
 }
 ```
 
-Let's also create a constant file to make it easier to use Supabase client. 
-We will also include an extension method declaration to call `showSnackBar` with one line of code. 
+Let's also create a constant file to make it easier to use Supabase client.
+We will also include an extension method declaration to call `showSnackBar` with one line of code.
 
 ```dart title="lib/utils/constants.dart"
 import 'package:flutter/material.dart';
@@ -639,11 +639,16 @@ And then open the browser to [localhost:3000](http://localhost:3000) and you sho
 
 ![Supabase User Management example](/img/supabase-flutter-account-page.png)
 
-
 ## Bonus: Profile photos
 
-Every Supabase project is configured with [Storage](/docs/guides/storage) for managing large files like 
+Every Supabase project is configured with [Storage](/docs/guides/storage) for managing large files like
 photos and videos.
+
+### Making sure we have a public bucket
+
+We will be storing the image as a publicly sharable image.
+Make sure your `avatars` bucket is set to public, and if it is not, change the publicity by clicking the dot menu that appears when you hover over the bucket name.
+You should see an orange `Public` badge next to your bucket name if your bucket is set to public.
 
 ### Adding image uploading feature to Account page
 
@@ -655,14 +660,14 @@ Run the following command to install it.
 flutter pub add image_picker
 ```
 
-Using [`image_picker`](https://pub.dev/packages/image_picker) requires some additional preparation depending on the platform. 
-Follow the instruction on README.md of [`image_picker`](https://pub.dev/packages/image_picker) on how to set it up for the platform you are using. 
+Using [`image_picker`](https://pub.dev/packages/image_picker) requires some additional preparation depending on the platform.
+Follow the instruction on README.md of [`image_picker`](https://pub.dev/packages/image_picker) on how to set it up for the platform you are using.
 
 Once you are done with all of the above, it is time to dive into coding.
 
 ### Create an upload widget
 
-Let's create an avatar for the user so that they can upload a profile photo. 
+Let's create an avatar for the user so that they can upload a profile photo.
 We can start by creating a new component:
 
 ```dart title="lib/components/avatar.dart"
@@ -747,7 +752,6 @@ class _AvatarState extends State<Avatar> {
   }
 }
 ```
-
 
 ### Add the new widget
 

--- a/web/spec/dart.yml
+++ b/web/spec/dart.yml
@@ -429,7 +429,7 @@ pages:
         description: |
           If you want to filter a table based on a child table's values you can use the `!inner()` function. For example, if you wanted 
           to select all rows in a `message` table which belong to a user with the `username` "Jane":
-        js: |
+        dart: |
           ```dart
           final res = await supabase
             .from('messages')


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR fixes the issue discussed in [this](https://github.com/supabase-community/supabase-flutter-quickstart/pull/6) PR where the user creates a private bucket when they use the default user management starter script within Supabase console and is never asked to change the bucket to public. 

## What is the current behavior?

When user uses the user management example project for their Supabase project, they are never asked to change the bucket to public. 

## What is the new behavior?

There is an instruction to make sure that the bucket is public, and if not to change it to public. 
