### PR TITLE
fix: updated dart signup doc to correctly reflect the current dart SDK

### DIFF
--- a/web/spec/dart.yml
+++ b/web/spec/dart.yml
@@ -152,7 +152,7 @@ pages:
       Creates a new user.
     notes: |
       - By default, the user will need to verify their email address before logging in. If you would like to change this, you can disable "Email Confirmations" by going to Authentication -> Settings on [app.supabase.io](https://app.supabase.io)
-      - If "Email Confirmations" is turned on, a `user` is returned but `session` will be null
+      - If "Email Confirmations" is turned on, both a `user` and a `session` will be null
       - If "Email Confirmations" is turned off, both a `user` and a `session` will be returned
       - When the user confirms their email address, they will be redirected to localhost:3000 by default. To change this, you can go to Authentication -> Settings on [app.supabase.io](https://app.supabase.io)
     examples:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Corrected a mistake in Dart doc with the `signup()` method. 

Currently, if the email confirmation is enabled, `user` is not returned in Dart SDK, but our docs indicate that it will. 

There is an [issue](https://github.com/supabase-community/gotrue-dart/issues/54) to discuss fix for this, but in the meanwhile, doc should be aligned with the current SDK, hence this PR. 

## What is the current behavior?

It says `signup()` will return user when the email confirmation is enabled. 

## What is the new behavior?

`signup()` does not return user as of now in Dart SDK. 
