### PR TITLE
Update Postgres docs links to "current" version

### DIFF
--- a/web/docs/guides/database/timeouts.mdx
+++ b/web/docs/guides/database/timeouts.mdx
@@ -8,7 +8,7 @@ By default, Supabase limits the maximum statement execution time to _3 seconds_ 
 
 ### Changing the default timeout
 
-The timeout values were picked as a reasonable default for the majority of use-cases, but can be modified using the [`alter role`](https://www.postgresql.org/docs/13/sql-alterrole.html) statement:
+The timeout values were picked as a reasonable default for the majority of use-cases, but can be modified using the [`alter role`](https://www.postgresql.org/docs/current/sql-alterrole.html) statement:
 
 ```sql
 alter role authenticated set statement_timeout = '15s';
@@ -22,6 +22,6 @@ set statement_timeout to 60000; -- 1 minute in milliseconds
 
 ### Statement Optimization
 
-All Supabase projects come with the [`pg_stat_statements`](https://www.postgresql.org/docs/13/pgstatstatements.html) extension installed, which tracks planning and execution statistics for all statements executed against it. These statistics can be used in order to diagnose the performance of your project.
+All Supabase projects come with the [`pg_stat_statements`](https://www.postgresql.org/docs/current/pgstatstatements.html) extension installed, which tracks planning and execution statistics for all statements executed against it. These statistics can be used in order to diagnose the performance of your project.
 
-This data can further be used in conjunction with the [`explain`](https://www.postgresql.org/docs/13/using-explain.html) functionality of Postgres to optimize your usage.
+This data can further be used in conjunction with the [`explain`](https://www.postgresql.org/docs/current/using-explain.html) functionality of Postgres to optimize your usage.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update.

## What is the current behavior?

Currently links to Postgres 13 documentation.

## What is the new behavior?

Now links to Postgres "current" documentation, which will stay up to date as new versions come out.   

## Additional context

Apologies in advance if I should have created an issue for this first. I hope it will be uncontroversial though, as the "current" version is already linked to on the [Functions](https://supabase.com/docs/guides/database/functions) and [Full Text Search](https://supabase.com/docs/guides/database/full-text-search) pages.