### PR TITLE
Fix broken link to docs in help popover

### DIFF
--- a/studio/components/layouts/ProjectLayout/LayoutHeader/HelpPopover.tsx
+++ b/studio/components/layouts/ProjectLayout/LayoutHeader/HelpPopover.tsx
@@ -40,7 +40,7 @@ const HelpPopover: FC<Props> = () => {
                 hosted services.
               </p>
             </Typography.Text>
-            <div className="flex space-x-1">
+            <div className="flex space-x-2">
               <Link href={supportUrl}>
                 <Button className="sbui-default-button--dark-white" size="tiny" icon={<IconMail />}>
                   Contact support

--- a/studio/components/layouts/ProjectLayout/LayoutHeader/HelpPopover.tsx
+++ b/studio/components/layouts/ProjectLayout/LayoutHeader/HelpPopover.tsx
@@ -40,13 +40,13 @@ const HelpPopover: FC<Props> = () => {
                 hosted services.
               </p>
             </Typography.Text>
-            <div className='flex space-x-1'>
+            <div className="flex space-x-1">
               <Link href={supportUrl}>
                 <Button className="sbui-default-button--dark-white" size="tiny" icon={<IconMail />}>
                   Contact support
                 </Button>
               </Link>
-              <Link href="supabase.com/docs/">
+              <Link href="https://supabase.com/docs/">
                 <Button type="secondary" size="tiny" icon={<IconBookOpen />}>
                   Docs
                 </Button>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Link in help popover to docs is broken and triggering a number of sentry errors