### PR TITLE
New table CSV import: Spreadsheet Preview is empty

### DIFF
--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/SpreadsheetImport/SpreadsheetImport.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/SpreadsheetImport/SpreadsheetImport.tsx
@@ -160,17 +160,17 @@ const SpreadsheetImport: FC<Props> = ({
         </div>
 
         {spreadsheetData.headers.length > 0 && (
-          <div className="py-5 space-y-5">
-            <div className="space-y-2">
-              <div className="flex flex-col space-y-1">
-                <Typography.Text>Content Preview</Typography.Text>
-                <Typography.Text type="secondary">
-                  Your table will have {spreadsheetData.rowCount.toLocaleString()} rows and the
-                  following {spreadsheetData.headers.length} columns.
-                </Typography.Text>
-              </div>
-              <SpreadsheetPreview headers={spreadsheetData.headers} />
+        <div className="py-5 space-y-5">
+          <div className="space-y-2">
+            <div className="flex flex-col space-y-1">
+              <Typography.Text>Content Preview</Typography.Text>
+              <Typography.Text type="secondary">
+                Your table will have {spreadsheetData.rowCount.toLocaleString()} rows and the
+                following {spreadsheetData.headers.length} columns.
+              </Typography.Text>
             </div>
+            <SpreadsheetPreview headers={spreadsheetData.headers} rows={spreadsheetData.rows} />
+          </div>
             {errors.length > 0 && (
               <div className="space-y-2">
                 <div className="flex flex-col space-y-1">

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/SpreadsheetImport/SpreadsheetImport.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/SpreadsheetImport/SpreadsheetImport.tsx
@@ -165,8 +165,7 @@ const SpreadsheetImport: FC<Props> = ({
             <div className="flex flex-col space-y-1">
               <Typography.Text>Content Preview</Typography.Text>
               <Typography.Text type="secondary">
-                Your table will have {spreadsheetData.rowCount.toLocaleString()} rows and the
-                following {spreadsheetData.headers.length} columns.
+                Your table will have {spreadsheetData.rowCount.toLocaleString()} rows and {spreadsheetData.headers.length} columns.
                 <br />
                 Here is a preview of your table (up to the first 20 columns and first 100 rows).
               </Typography.Text>

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/SpreadsheetImport/SpreadsheetImport.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/SpreadsheetImport/SpreadsheetImport.tsx
@@ -167,6 +167,8 @@ const SpreadsheetImport: FC<Props> = ({
               <Typography.Text type="secondary">
                 Your table will have {spreadsheetData.rowCount.toLocaleString()} rows and the
                 following {spreadsheetData.headers.length} columns.
+                <br />
+                Here is a preview of your table (up to the first 20 columns and first 100 rows).
               </Typography.Text>
             </div>
             <SpreadsheetPreview headers={spreadsheetData.headers} rows={spreadsheetData.rows} />

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/SpreadsheetImport/SpreadsheetPreview.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/SpreadsheetImport/SpreadsheetPreview.tsx
@@ -8,10 +8,16 @@ interface Props {
   rows?: any[]
 }
 
+const MAX_ROWS = 100;
+const MAX_HEADERS = 20;
+
 const SpreadsheetPreview: FC<Props> = ({ headers = [], rows = [] }) => {
+  const previewHeaders = headers.slice(0, MAX_HEADERS);
+  const previewRows = rows.slice(0, MAX_ROWS);
+
   return (
     <DataGrid
-      columns={headers.map((header) => {
+      columns={previewHeaders.map((header) => {
         return {
           key: header,
           name: header,
@@ -29,9 +35,9 @@ const SpreadsheetPreview: FC<Props> = ({ headers = [], rows = [] }) => {
           ),
         }
       })}
-      rows={rows}
+      rows={previewRows}
       className="!border-l !border-r"
-      style={{ height: `${34 + 34 * rows.length}px` }}
+      style={{ height: `${34 + 34 * previewRows.length}px` }}
     />
   )
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

This fixes the bug: https://github.com/supabase/supabase/issues/5016

## What is the new behavior?

The Preview is showing now:
![imagen](https://user-images.githubusercontent.com/340766/153267416-6205c0c0-bcb5-4e58-a337-f44f0d154d36.png)

Sample CSV data from: 
https://www.stats.govt.nz/large-datasets/csv-files-for-download/

## Additional context

That's pretty much it! Well, maybe this should be caught by a test. 🤔 
Let me know if I can help with anything else.