### PR TITLE
feat: handle JWT secret update failure, progress and success

### DIFF
--- a/studio/components/to-be-cleaned/DisplayProjectSettings.tsx
+++ b/studio/components/to-be-cleaned/DisplayProjectSettings.tsx
@@ -2,7 +2,7 @@ import useSWR from 'swr'
 import { FC } from 'react'
 import { useRouter } from 'next/router'
 import { get } from 'lib/common/fetch'
-import { ProjectEvents } from '@supabase/shared-types/out/events'
+import { JwtSecretUpdateStatus, ProjectEvents } from '@supabase/shared-types/out/events'
 import { IconAlertCircle, Input, Loading, Typography } from '@supabase/ui'
 
 import { useJwtSecretUpdateStatus } from 'hooks'
@@ -23,14 +23,9 @@ export const DisplayApiSettings = () => {
     jwtSecretUpdateStatus,
   }: any = useJwtSecretUpdateStatus(ref)
 
-  const {
-    ProjectJwtSecretUpdated: JwtSecretUpdated,
-    ProjectJwtSecretUpdateFailure: JwtSecretUpdateFailure,
-    ProjectJwtSecretUpdateProgress: JwtSecretUpdateProgress,
-  } = ProjectEvents
-
   const isNotUpdatingJwtSecret =
-    !jwtSecretUpdateStatus || jwtSecretUpdateStatus === JwtSecretUpdated
+    jwtSecretUpdateStatus === undefined || jwtSecretUpdateStatus === JwtSecretUpdateStatus.Updated
+  console.log(isNotUpdatingJwtSecret)
 
   if (!data || isJwtSecretUpdateStatusLoading)
     return (
@@ -95,9 +90,9 @@ export const DisplayApiSettings = () => {
               disabled
               reveal={x.tags !== 'anon' && isNotUpdatingJwtSecret}
               value={
-                jwtSecretUpdateStatus === JwtSecretUpdateFailure
+                jwtSecretUpdateStatus === JwtSecretUpdateStatus.Failed
                   ? 'JWT secret update failed, new API key may have issues'
-                  : jwtSecretUpdateStatus === JwtSecretUpdateProgress
+                  : jwtSecretUpdateStatus === JwtSecretUpdateStatus.Updating
                   ? 'Updating JWT secret...'
                   : x.api_key
               }
@@ -126,14 +121,8 @@ export const DisplayConfigSettings = () => {
     jwtSecretUpdateStatus,
   }: any = useJwtSecretUpdateStatus(ref)
 
-  const {
-    ProjectJwtSecretUpdated: JwtSecretUpdated,
-    ProjectJwtSecretUpdateFailure: JwtSecretUpdateFailure,
-    ProjectJwtSecretUpdateProgress: JwtSecretUpdateProgress,
-  } = ProjectEvents
-
   const isNotUpdatingJwtSecret =
-    !jwtSecretUpdateStatus || jwtSecretUpdateStatus === JwtSecretUpdated
+    jwtSecretUpdateStatus === undefined || jwtSecretUpdateStatus === JwtSecretUpdateStatus.Updated
 
   if (!data || isJwtSecretUpdateStatusLoading)
     return (
@@ -192,9 +181,9 @@ export const DisplayConfigSettings = () => {
             reveal={isNotUpdatingJwtSecret}
             disabled
             value={
-              jwtSecretUpdateStatus === JwtSecretUpdateFailure
+              jwtSecretUpdateStatus === JwtSecretUpdateStatus.Failed
                 ? 'JWT secret update failed'
-                : jwtSecretUpdateStatus === JwtSecretUpdateProgress
+                : jwtSecretUpdateStatus === JwtSecretUpdateStatus.Updating
                 ? 'Updating JWT secret...'
                 : jwtSecret
             }

--- a/studio/components/to-be-cleaned/DisplayProjectSettings.tsx
+++ b/studio/components/to-be-cleaned/DisplayProjectSettings.tsx
@@ -25,7 +25,6 @@ export const DisplayApiSettings = () => {
 
   const isNotUpdatingJwtSecret =
     jwtSecretUpdateStatus === undefined || jwtSecretUpdateStatus === JwtSecretUpdateStatus.Updated
-  console.log(isNotUpdatingJwtSecret)
 
   if (!data || isJwtSecretUpdateStatusLoading)
     return (

--- a/studio/components/to-be-cleaned/DisplayProjectSettings.tsx
+++ b/studio/components/to-be-cleaned/DisplayProjectSettings.tsx
@@ -2,8 +2,10 @@ import useSWR from 'swr'
 import { FC } from 'react'
 import { useRouter } from 'next/router'
 import { get } from 'lib/common/fetch'
+import { ProjectEvents } from '@supabase/shared-types/out/events'
 import { IconAlertCircle, Input, Loading, Typography } from '@supabase/ui'
 
+import { useJwtSecretUpdateStatus } from 'hooks'
 import { API_URL } from 'lib/constants'
 import Panel from './Panel'
 
@@ -15,12 +17,26 @@ export const DisplayApiSettings = () => {
   const { ref } = router.query
 
   const { data, error }: any = useSWR(`${API_URL}/props/project/${ref}/settings`, get)
+  const {
+    isError: isJwtSecretUpdateStatusError,
+    isLoading: isJwtSecretUpdateStatusLoading,
+    jwtSecretUpdateStatus,
+  }: any = useJwtSecretUpdateStatus(ref)
 
-  if (!data)
+  const {
+    ProjectJwtSecretUpdated: JwtSecretUpdated,
+    ProjectJwtSecretUpdateFailure: JwtSecretUpdateFailure,
+    ProjectJwtSecretUpdateProgress: JwtSecretUpdateProgress,
+  } = ProjectEvents
+
+  const isNotUpdatingJwtSecret =
+    !jwtSecretUpdateStatus || jwtSecretUpdateStatus === JwtSecretUpdated
+
+  if (!data || isJwtSecretUpdateStatusLoading)
     return (
       <ApiContentWrapper>
         <Panel.Content className="py-8">
-          {error ? (
+          {error || isJwtSecretUpdateStatusError ? (
             <div className="flex items-center space-x-2">
               <Typography.Text type="secondary">
                 <IconAlertCircle strokeWidth={2} />
@@ -43,7 +59,7 @@ export const DisplayApiSettings = () => {
 
   return (
     <ApiContentWrapper>
-      {!data ? (
+      {!data || isJwtSecretUpdateStatusLoading ? (
         // @ts-ignore
         <Loading active={true} />
       ) : (
@@ -74,11 +90,17 @@ export const DisplayApiSettings = () => {
                 </>
               }
               readOnly
-              copy
+              copy={isNotUpdatingJwtSecret}
               className="input-mono"
               disabled
-              reveal={x.tags !== 'anon' && true}
-              value={x.api_key}
+              reveal={x.tags !== 'anon' && isNotUpdatingJwtSecret}
+              value={
+                jwtSecretUpdateStatus === JwtSecretUpdateFailure
+                  ? 'JWT secret update failed, new API key may have issues'
+                  : jwtSecretUpdateStatus === JwtSecretUpdateProgress
+                  ? 'Updating JWT secret...'
+                  : x.api_key
+              }
               onChange={() => {}}
               descriptionText={
                 x.tags === 'service_role'
@@ -98,12 +120,26 @@ export const DisplayConfigSettings = () => {
   const { ref } = router.query
 
   const { data, error }: any = useSWR(`${API_URL}/props/project/${ref}/settings`, get)
+  const {
+    isError: isJwtSecretUpdateStatusError,
+    isLoading: isJwtSecretUpdateStatusLoading,
+    jwtSecretUpdateStatus,
+  }: any = useJwtSecretUpdateStatus(ref)
 
-  if (!data)
+  const {
+    ProjectJwtSecretUpdated: JwtSecretUpdated,
+    ProjectJwtSecretUpdateFailure: JwtSecretUpdateFailure,
+    ProjectJwtSecretUpdateProgress: JwtSecretUpdateProgress,
+  } = ProjectEvents
+
+  const isNotUpdatingJwtSecret =
+    !jwtSecretUpdateStatus || jwtSecretUpdateStatus === JwtSecretUpdated
+
+  if (!data || isJwtSecretUpdateStatusLoading)
     return (
       <ConfigContentWrapper>
         <Panel.Content className="py-8">
-          {error ? (
+          {error || isJwtSecretUpdateStatusError ? (
             <div className="flex items-center space-x-2">
               <Typography.Text type="secondary">
                 <IconAlertCircle strokeWidth={2} />
@@ -152,10 +188,16 @@ export const DisplayConfigSettings = () => {
           <Input
             label="JWT Secret"
             readOnly
-            copy
-            reveal
+            copy={isNotUpdatingJwtSecret}
+            reveal={isNotUpdatingJwtSecret}
             disabled
-            value={jwtSecret}
+            value={
+              jwtSecretUpdateStatus === JwtSecretUpdateFailure
+                ? 'JWT secret update failed'
+                : jwtSecretUpdateStatus === JwtSecretUpdateProgress
+                ? 'Updating JWT secret...'
+                : jwtSecret
+            }
             className="input-mono"
             descriptionText="Used to decode your JWTs. You can also use this to mint your own JWTs."
             layout="horizontal"

--- a/studio/hooks/queries/index.ts
+++ b/studio/hooks/queries/index.ts
@@ -1,3 +1,4 @@
+export * from './useJwtSecretUpdateStatus'
 export * from './useOrganizationDetail'
 export * from './useProfile'
 export * from './useProjectAuthConfig'

--- a/studio/hooks/queries/useJwtSecretUpdateStatus.ts
+++ b/studio/hooks/queries/useJwtSecretUpdateStatus.ts
@@ -1,24 +1,23 @@
 import useSWR from 'swr'
 import { get } from 'lib/common/fetch'
-import { ProjectEvents } from '@supabase/shared-types/out/events'
+import { JwtSecretUpdateStatus } from '@supabase/shared-types/out/events'
 import { API_URL } from 'lib/constants'
 
 export function useJwtSecretUpdateStatus(projectRef: string | string[] | undefined) {
   const url = `${API_URL}/props/project/${projectRef}/jwt-secret-update-status`
   const { data, error, mutate } = useSWR<any>(url, get, {
     refreshInterval: (data) =>
-      data?.jwtSecretUpdateStatus?.event_type === ProjectEvents.ProjectJwtSecretUpdateProgress
-        ? 1_000
-        : 0,
+      data?.jwtSecretUpdateStatus?.meta?.status === JwtSecretUpdateStatus.Updating ? 1_000 : 0,
   })
   const anyError = data?.error || error
-
+  const meta = data?.jwtSecretUpdateStatus?.meta
   return {
-    changeTrackingId: data?.jwtSecretUpdateStatus?.meta?.change_tracking_id,
+    changeTrackingId: meta?.change_tracking_id,
     isError: !!anyError,
     isLoading: !anyError && !data,
+    jwtSecretUpdateError: meta?.error,
+    jwtSecretUpdateProgress: meta?.progress,
+    jwtSecretUpdateStatus: meta?.status,
     mutateJwtSecretUpdateStatus: mutate,
-    jwtSecretUpdateMessage: data?.jwtSecretUpdateStatus?.meta?.message,
-    jwtSecretUpdateStatus: data?.jwtSecretUpdateStatus?.event_type,
   }
 }

--- a/studio/hooks/queries/useJwtSecretUpdateStatus.ts
+++ b/studio/hooks/queries/useJwtSecretUpdateStatus.ts
@@ -1,0 +1,24 @@
+import useSWR from 'swr'
+import { get } from 'lib/common/fetch'
+import { ProjectEvents } from '@supabase/shared-types/out/events'
+import { API_URL } from 'lib/constants'
+
+export function useJwtSecretUpdateStatus(projectRef: string | string[] | undefined) {
+  const url = `${API_URL}/props/project/${projectRef}/jwt-secret-update-status`
+  const { data, error, mutate } = useSWR<any>(url, get, {
+    refreshInterval: (data) =>
+      data?.jwtSecretUpdateStatus?.event_type === ProjectEvents.ProjectJwtSecretUpdateProgress
+        ? 1_000
+        : 0,
+  })
+  const anyError = data?.error || error
+
+  return {
+    changeTrackingId: data?.jwtSecretUpdateStatus?.meta?.change_tracking_id,
+    isError: !!anyError,
+    isLoading: !anyError && !data,
+    mutateJwtSecretUpdateStatus: mutate,
+    jwtSecretUpdateMessage: data?.jwtSecretUpdateStatus?.meta?.message,
+    jwtSecretUpdateStatus: data?.jwtSecretUpdateStatus?.event_type,
+  }
+}

--- a/studio/package-lock.json
+++ b/studio/package-lock.json
@@ -18,6 +18,7 @@
         "@supabase/grid": "^2.4.1",
         "@supabase/postgres-meta": "^0.26.1",
         "@supabase/react-data-grid": "^7.1.0-beta.7",
+        "@supabase/shared-types": "^0.1.14",
         "@supabase/supabase-js": "^1.29.1",
         "@supabase/ui": "^0.35.0",
         "ajv": "^8.6.3",
@@ -53,7 +54,7 @@
         "sass": "^1.43.4",
         "semver": "^6.3.0",
         "sqlstring": "^2.3.2",
-        "swr": "^1.0.1",
+        "swr": "^1.2.1",
         "uniforms-bootstrap4": "^3.6.2",
         "uniforms-bridge-json-schema": "^3.6.2",
         "zxcvbn": "^4.4.2"
@@ -2747,6 +2748,11 @@
         "websocket": "^1.0.34"
       }
     },
+    "node_modules/@supabase/shared-types": {
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/@supabase/shared-types/-/shared-types-0.1.14.tgz",
+      "integrity": "sha512-jvrbhg4W2x/zeEtu+H1s5huInnqcWtJmgfj8sC8TKM3DcjtRDcbCwuXgKHp63m815H0t58tbsP4YuvyjWBPgyg=="
+    },
     "node_modules/@supabase/storage-js": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-1.5.0.tgz",
@@ -4829,14 +4835,6 @@
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/dequal": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.2.tgz",
-      "integrity": "sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/des.js": {
@@ -12212,14 +12210,11 @@
       }
     },
     "node_modules/swr": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/swr/-/swr-1.0.1.tgz",
-      "integrity": "sha512-EPQAxSjoD4IaM49rpRHK0q+/NzcwoT8c0/Ylu/u3/6mFj/CWnQVjNJ0MV2Iuw/U+EJSd2TX5czdAwKPYZIG0YA==",
-      "dependencies": {
-        "dequal": "2.0.2"
-      },
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-1.2.1.tgz",
+      "integrity": "sha512-1cuWXqJqXcFwbgONGCY4PHZ8v05009JdHsC3CIC6u7d00kgbMswNr1sHnnhseOBxtzVqcCNpOHEgVDciRer45w==",
       "peerDependencies": {
-        "react": "^16.11.0 || ^17.0.0"
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/symbol-tree": {
@@ -15498,6 +15493,11 @@
         "websocket": "^1.0.34"
       }
     },
+    "@supabase/shared-types": {
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/@supabase/shared-types/-/shared-types-0.1.14.tgz",
+      "integrity": "sha512-jvrbhg4W2x/zeEtu+H1s5huInnqcWtJmgfj8sC8TKM3DcjtRDcbCwuXgKHp63m815H0t58tbsP4YuvyjWBPgyg=="
+    },
     "@supabase/storage-js": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-1.5.0.tgz",
@@ -17275,11 +17275,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
-    },
-    "dequal": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.2.tgz",
-      "integrity": "sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug=="
     },
     "des.js": {
       "version": "1.0.1",
@@ -22860,12 +22855,10 @@
       }
     },
     "swr": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/swr/-/swr-1.0.1.tgz",
-      "integrity": "sha512-EPQAxSjoD4IaM49rpRHK0q+/NzcwoT8c0/Ylu/u3/6mFj/CWnQVjNJ0MV2Iuw/U+EJSd2TX5czdAwKPYZIG0YA==",
-      "requires": {
-        "dequal": "2.0.2"
-      }
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-1.2.1.tgz",
+      "integrity": "sha512-1cuWXqJqXcFwbgONGCY4PHZ8v05009JdHsC3CIC6u7d00kgbMswNr1sHnnhseOBxtzVqcCNpOHEgVDciRer45w==",
+      "requires": {}
     },
     "symbol-tree": {
       "version": "3.2.4",

--- a/studio/package-lock.json
+++ b/studio/package-lock.json
@@ -18,7 +18,7 @@
         "@supabase/grid": "^2.4.1",
         "@supabase/postgres-meta": "^0.26.1",
         "@supabase/react-data-grid": "^7.1.0-beta.7",
-        "@supabase/shared-types": "^0.1.14",
+        "@supabase/shared-types": "^0.1.15",
         "@supabase/supabase-js": "^1.29.1",
         "@supabase/ui": "^0.35.0",
         "ajv": "^8.6.3",
@@ -2749,9 +2749,9 @@
       }
     },
     "node_modules/@supabase/shared-types": {
-      "version": "0.1.14",
-      "resolved": "https://registry.npmjs.org/@supabase/shared-types/-/shared-types-0.1.14.tgz",
-      "integrity": "sha512-jvrbhg4W2x/zeEtu+H1s5huInnqcWtJmgfj8sC8TKM3DcjtRDcbCwuXgKHp63m815H0t58tbsP4YuvyjWBPgyg=="
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/@supabase/shared-types/-/shared-types-0.1.15.tgz",
+      "integrity": "sha512-0IJqw0nU526NTxKnAW4N3eNNU9PSG961fXFS3BrguFPmhCUGuapW6zJOZM1FVFeMpn7y6pWw0iV7UqbRoiy8sg=="
     },
     "node_modules/@supabase/storage-js": {
       "version": "1.5.0",
@@ -15494,9 +15494,9 @@
       }
     },
     "@supabase/shared-types": {
-      "version": "0.1.14",
-      "resolved": "https://registry.npmjs.org/@supabase/shared-types/-/shared-types-0.1.14.tgz",
-      "integrity": "sha512-jvrbhg4W2x/zeEtu+H1s5huInnqcWtJmgfj8sC8TKM3DcjtRDcbCwuXgKHp63m815H0t58tbsP4YuvyjWBPgyg=="
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/@supabase/shared-types/-/shared-types-0.1.15.tgz",
+      "integrity": "sha512-0IJqw0nU526NTxKnAW4N3eNNU9PSG961fXFS3BrguFPmhCUGuapW6zJOZM1FVFeMpn7y6pWw0iV7UqbRoiy8sg=="
     },
     "@supabase/storage-js": {
       "version": "1.5.0",

--- a/studio/package-lock.json
+++ b/studio/package-lock.json
@@ -20,7 +20,7 @@
         "@supabase/react-data-grid": "^7.1.0-beta.7",
         "@supabase/shared-types": "^0.1.15",
         "@supabase/supabase-js": "^1.29.1",
-        "@supabase/ui": "^0.35.0",
+        "@supabase/ui": "^0.36.4",
         "ajv": "^8.6.3",
         "analytics-node": "^3.5.0",
         "clipboard": "^2.0.8",
@@ -2773,9 +2773,9 @@
       }
     },
     "node_modules/@supabase/ui": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/@supabase/ui/-/ui-0.35.0.tgz",
-      "integrity": "sha512-bftQoDcX2Vl6Gcu6IYUjteN7ZKNs5YhvhOz3c/8kTYU6DuD33VKOYCMQBKwU4IuBbEsNXVRlJxHK4RjXIiS4ww==",
+      "version": "0.36.4",
+      "resolved": "https://registry.npmjs.org/@supabase/ui/-/ui-0.36.4.tgz",
+      "integrity": "sha512-7Wq4D/5269q1wpmSo8V57hhWEXB83eKKEW9NHBdSS7wnsAb9hK+m6D/DN8ImpSdybDheHOdT/C4xjc2W6luOxg==",
       "dependencies": {
         "lodash": "^4.17.20",
         "prop-types": "^15.7.2"
@@ -15518,9 +15518,9 @@
       }
     },
     "@supabase/ui": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/@supabase/ui/-/ui-0.35.0.tgz",
-      "integrity": "sha512-bftQoDcX2Vl6Gcu6IYUjteN7ZKNs5YhvhOz3c/8kTYU6DuD33VKOYCMQBKwU4IuBbEsNXVRlJxHK4RjXIiS4ww==",
+      "version": "0.36.4",
+      "resolved": "https://registry.npmjs.org/@supabase/ui/-/ui-0.36.4.tgz",
+      "integrity": "sha512-7Wq4D/5269q1wpmSo8V57hhWEXB83eKKEW9NHBdSS7wnsAb9hK+m6D/DN8ImpSdybDheHOdT/C4xjc2W6luOxg==",
       "requires": {
         "fsevents": "^2.3.2",
         "lodash": "^4.17.20",

--- a/studio/package.json
+++ b/studio/package.json
@@ -20,7 +20,7 @@
     "@supabase/grid": "^2.4.1",
     "@supabase/postgres-meta": "^0.26.1",
     "@supabase/react-data-grid": "^7.1.0-beta.7",
-    "@supabase/shared-types": "^0.1.14",
+    "@supabase/shared-types": "^0.1.15",
     "@supabase/supabase-js": "^1.29.1",
     "@supabase/ui": "^0.35.0",
     "ajv": "^8.6.3",

--- a/studio/package.json
+++ b/studio/package.json
@@ -22,7 +22,7 @@
     "@supabase/react-data-grid": "^7.1.0-beta.7",
     "@supabase/shared-types": "^0.1.15",
     "@supabase/supabase-js": "^1.29.1",
-    "@supabase/ui": "^0.35.0",
+    "@supabase/ui": "^0.36.4",
     "ajv": "^8.6.3",
     "analytics-node": "^3.5.0",
     "clipboard": "^2.0.8",

--- a/studio/package.json
+++ b/studio/package.json
@@ -20,6 +20,7 @@
     "@supabase/grid": "^2.4.1",
     "@supabase/postgres-meta": "^0.26.1",
     "@supabase/react-data-grid": "^7.1.0-beta.7",
+    "@supabase/shared-types": "^0.1.14",
     "@supabase/supabase-js": "^1.29.1",
     "@supabase/ui": "^0.35.0",
     "ajv": "^8.6.3",
@@ -55,7 +56,7 @@
     "sass": "^1.43.4",
     "semver": "^6.3.0",
     "sqlstring": "^2.3.2",
-    "swr": "^1.0.1",
+    "swr": "^1.2.1",
     "uniforms-bootstrap4": "^3.6.2",
     "uniforms-bridge-json-schema": "^3.6.2",
     "zxcvbn": "^4.4.2"

--- a/studio/pages/project/[ref]/settings/api.tsx
+++ b/studio/pages/project/[ref]/settings/api.tsx
@@ -33,6 +33,7 @@ import MultiSelectUI from 'components/to-be-cleaned/MultiSelect'
 import SchemaFormPanel from 'components/to-be-cleaned/forms/SchemaFormPanel'
 import { DisplayApiSettings } from 'components/to-be-cleaned/DisplayProjectSettings'
 import ConfirmationModal from 'components/ui/ConfirmationModal'
+import Flag from 'components/ui/Flag/Flag'
 import { uuidv4 } from 'lib/helpers'
 
 const JWT_SECRET_UPDATE_ERROR_MESSAGES = {
@@ -262,74 +263,76 @@ const ServiceList: FC<any> = ({ projectRef }) => {
                 }
                 layout="horizontal"
               />
-              <div className="space-y-3">
-                <div className="p-3 px-6 dark:bg-bg-alt-dark bg-bg-alt-light rounded-md shadow-sm border dark:border-dark flex items-center justify-between">
-                  {isJwtSecretUpdateFailed ? (
-                    <Typography.Text type="danger">
-                      Failed to update JWT secret, please contact Supabase support with the
-                      following details: <br />
-                      Change tracking ID: {changeTrackingId} <br />
-                      Error message: {jwtSecretUpdateErrorMessage}
-                    </Typography.Text>
-                  ) : (
-                    <>
-                      {isUpdatingJwtSecret ? (
-                        <Typography.Text>
-                          JWT secret update progress: {jwtSecretUpdateProgressMessage}
-                        </Typography.Text>
-                      ) : (
-                        <div>
-                          <Typography.Text>Generate a new JWT secret</Typography.Text>
-                          <div>
-                            <Typography.Text type="danger">
-                              This will invalidate all existing API keys! <br />
-                              Your project will also be restarted during this process, which will
-                              terminate any existing connections.
-                            </Typography.Text>
-                            <br />
-                            <Typography.Text type="secondary">
-                              A random secret will be created, or you can create your own.
-                            </Typography.Text>
-                          </div>
-                        </div>
-                      )}
-                      <div className="flex flex-col items-end">
+              <Flag name="jwtSecretUpdate">
+                <div className="space-y-3">
+                  <div className="p-3 px-6 dark:bg-bg-alt-dark bg-bg-alt-light rounded-md shadow-sm border dark:border-dark flex items-center justify-between">
+                    {isJwtSecretUpdateFailed ? (
+                      <Typography.Text type="danger">
+                        Failed to update JWT secret, please contact Supabase support with the
+                        following details: <br />
+                        Change tracking ID: {changeTrackingId} <br />
+                        Error message: {jwtSecretUpdateErrorMessage}
+                      </Typography.Text>
+                    ) : (
+                      <>
                         {isUpdatingJwtSecret ? (
-                          <Button loading type="secondary">
-                            Updating JWT secret...
-                          </Button>
+                          <Typography.Text>
+                            JWT secret update progress: {jwtSecretUpdateProgressMessage}
+                          </Typography.Text>
                         ) : (
-                          <Dropdown
-                            align="end"
-                            side="bottom"
-                            overlay={
-                              <>
-                                <Dropdown.Item
-                                  onClick={() => setIsGeneratingKey(true)}
-                                  icon={<IconRefreshCw size={16} />}
-                                >
-                                  Generate a random secret
-                                </Dropdown.Item>
-                                <Divider light />
-                                <Dropdown.Item
-                                  onClick={() => setIsCreatingKey(true)}
-                                  icon={<IconPenTool size={16} />}
-                                >
-                                  Create my own secret
-                                </Dropdown.Item>
-                              </>
-                            }
-                          >
-                            <Button as="span" type="secondary" iconRight={<IconChevronDown />}>
-                              Generate a new secret
-                            </Button>
-                          </Dropdown>
+                          <div>
+                            <Typography.Text>Generate a new JWT secret</Typography.Text>
+                            <div>
+                              <Typography.Text type="danger">
+                                This will invalidate all existing API keys! <br />
+                                Your project will also be restarted during this process, which will
+                                terminate any existing connections.
+                              </Typography.Text>
+                              <br />
+                              <Typography.Text type="secondary">
+                                A random secret will be created, or you can create your own.
+                              </Typography.Text>
+                            </div>
+                          </div>
                         )}
-                      </div>
-                    </>
-                  )}
+                        <div className="flex flex-col items-end">
+                          {isUpdatingJwtSecret ? (
+                            <Button loading type="secondary">
+                              Updating JWT secret...
+                            </Button>
+                          ) : (
+                            <Dropdown
+                              align="end"
+                              side="bottom"
+                              overlay={
+                                <>
+                                  <Dropdown.Item
+                                    onClick={() => setIsGeneratingKey(true)}
+                                    icon={<IconRefreshCw size={16} />}
+                                  >
+                                    Generate a random secret
+                                  </Dropdown.Item>
+                                  <Divider light />
+                                  <Dropdown.Item
+                                    onClick={() => setIsCreatingKey(true)}
+                                    icon={<IconPenTool size={16} />}
+                                  >
+                                    Create my own secret
+                                  </Dropdown.Item>
+                                </>
+                              }
+                            >
+                              <Button as="span" type="secondary" iconRight={<IconChevronDown />}>
+                                Generate a new secret
+                              </Button>
+                            </Dropdown>
+                          )}
+                        </div>
+                      </>
+                    )}
+                  </div>
                 </div>
-              </div>
+              </Flag>
             </Panel.Content>
           </Panel>
         </section>

--- a/studio/pages/project/[ref]/settings/logs/[type].tsx
+++ b/studio/pages/project/[ref]/settings/logs/[type].tsx
@@ -31,7 +31,7 @@ import {
   LOG_TYPE_LABEL_MAPPING,
 } from 'components/interfaces/Settings/Logs'
 import { uuidv4 } from 'lib/helpers'
-import useSWRInfinite from 'swr/infinite'
+import useSWRInfinite, { SWRInfiniteKeyLoader } from 'swr/infinite'
 import { isUndefined } from 'lodash'
 import { useFlag } from 'hooks'
 import dayjs from 'dayjs'
@@ -107,7 +107,7 @@ export const LogPage: NextPage = () => {
     return qs
   }
   // handle log fetching
-  const getKeyLogs: KeyLoader<Logs> = (_pageIndex: number, prevPageData) => {
+  const getKeyLogs: SWRInfiniteKeyLoader = (_pageIndex: number, prevPageData) => {
     let queryParams
     // if prev page data is 100 items, could possibly have more records that are not yet fetched within this interval
     if (prevPageData === null) {


### PR DESCRIPTION
JWT secret update is behind a feature flag, there's some risk of breakage so it'd be good to be able to quickly turn it off in production.

While the JWT secret update is in progress or has failed, we may be in a state where neither the old API keys or new API keys are completely usable. So:

- While updating, we replace the API keys and JWT secret input fields with `Updating JWT secret...` messages.
- On failure, we replace the API keys and JWT secret input fields with `JWT secret update failed` messages, accompanied by a message to contact support with the change tracking ID and error message.

We update the UI with progress event messages but only show UI notifications on success or failure.

Progress and success:

https://user-images.githubusercontent.com/1154867/153330103-e732ba1c-736f-4ccb-a27c-78be10deadc4.mov

Failure:

https://user-images.githubusercontent.com/1154867/153330137-3cc06293-14af-417b-9be5-cc58afbe0948.mov

Depends on supabase/infrastructure#4330, supabase/shared-types#9 and supabase/ui#323.