### PR TITLE
Chore: redirect link to greenhouse

### DIFF
--- a/about/docusaurus.config.js
+++ b/about/docusaurus.config.js
@@ -69,7 +69,7 @@ module.exports = {
         },
         {
           label: 'Careers',
-          to: '/careers',
+          to: 'https://boards.greenhouse.io/supabase',
           activeBasePath: '/careers',
           position: 'left',
         },

--- a/about/src/pages/index.js
+++ b/about/src/pages/index.js
@@ -38,7 +38,7 @@ export default function Home() {
                       'button hero--button button--md button--primary responsive-button',
                       styles.button
                     )}
-                    to={'/careers'}
+                    to={'https://boards.greenhouse.io/supabase'}
                     style={{ marginTop: 10 }}
                   >
                     Join the team →


### PR DESCRIPTION
## What kind of change does this PR introduce?

redirect career links to greenhouse

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

From Lu: "Can you now redirect the “Careers” link on the Supabase page to go directly to the Greenhouse job board?"