### PR TITLE
Chore: update meta title

### DIFF
--- a/www/pages/support.tsx
+++ b/www/pages/support.tsx
@@ -37,7 +37,7 @@ type Props = {}
 const Index = ({}: Props) => {
   const router = useRouter()
 
-  const meta_title = 'Help &amp Support | Supabase'
+  const meta_title = 'Help & Support | Supabase'
   const meta_description =
     'Find help and support for Supabase. Our support agents provide answers on all types of issues, including account information, billing, and refunds.'
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

update meta title from `Help &amp Support | Supabase` to `Help & Support | Supabase`

## What is the current behavior?

As you can see this is not what we want.
<img width="140" alt="Screen Shot 2022-02-09 at 11 04 34 PM" src="https://user-images.githubusercontent.com/70828596/153335001-56747b19-909c-4ce4-b865-85b0b623436a.png">