### PR TITLE
Remove Python reference from doc on JavaScript

### DIFF
--- a/web/spec/supabase.yml
+++ b/web/spec/supabase.yml
@@ -230,15 +230,7 @@ pages:
       //or
       <script src="https://unpkg.com/@supabase/supabase-js"></script>
       ```
-
-      ## Python
-
-      ```bash
-      pip install supabase-py
-      ```
-
-      Find the source code on [GitHub](https://github.com/supabase/supabase-py).
-
+      
   Initializing:
     $ref: '@supabase/supabase-js."SupabaseClient".SupabaseClient.constructor'
     description: |


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The docs for JS include install instructions for Python.

## What is the new behavior?

The JS page no longer references python.

## Additional context

I did not create a new page for the Python doc, mainly because I don't know how.
