### PR TITLE
fix: invalid query templates for db logs

### DIFF
--- a/studio/components/interfaces/Settings/Logs/Logs.constants.ts
+++ b/studio/components/interfaces/Settings/Logs/Logs.constants.ts
@@ -59,7 +59,7 @@ FROM edge_logs
 GROUP BY
   cf.country
 ORDER BY
-  DESC count
+  count DESC
 `,
     for: ['api'],
   },

--- a/studio/components/interfaces/Settings/Logs/Logs.constants.ts
+++ b/studio/components/interfaces/Settings/Logs/Logs.constants.ts
@@ -16,16 +16,24 @@ export const TEMPLATES: LogTemplate[] = [
 
   {
     label: '10 Minutes Ago',
-    mode: 'simple',
+    mode: 'custom',
     searchString: 'timestamp < TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 10 MINUTE)',
     for: ['database', 'api'],
   },
   {
-    label: 'POST or PATCH',
+    label: 'Commits By User',
     mode: 'custom',
-    searchString:
-      "REGEXP_CONTAINS(event_message, 'POST') OR REGEXP_CONTAINS(event_message, 'PATCH')",
-    for: ['api'],
+    searchString: `SELECT
+    p.user_name, count(*) as count
+FROM postgres_logs
+  LEFT JOIN UNNEST(metadata) as m ON TRUE
+  LEFT JOIN UNNEST(m.parsed) AS p ON TRUE
+WHERE
+  REGEXP_CONTAINS(event_message, 'COMMIT')
+GROUP BY
+  p.user_name
+    `,
+    for: ['database'],
   },
   {
     label: 'Metadata IP',
@@ -37,7 +45,7 @@ FROM edge_logs
   LEFT JOIN UNNEST(r.headers) AS h ON TRUE
 WHERE h.x_real_ip IS NOT NULL
 `,
-    for: ['database'],
+    for: ['api'],
   },
   {
     label: 'Requests by Country',

--- a/studio/pages/project/[ref]/settings/logs/[type].tsx
+++ b/studio/pages/project/[ref]/settings/logs/[type].tsx
@@ -268,10 +268,11 @@ export const LogPage: NextPage = () => {
                 onInputRun={handleRefresh}
               />
             </div>
-            <div className="flex flex-row justify-between items-center px-2 py-1 w-full">
+            <div className="flex flex-row justify-end items-center px-2 py-1 w-full">
               {isSelectQuery && (
                 <InformationBox
-                  block
+                className="shrink mr-auto"
+                  block={false}
                   size="tiny"
                   icon={<IconInfo size="tiny" />}
                   title={`Custom queries are restricted to a ${


### PR DESCRIPTION
Seems like an api template query was showing for the database page. Also added an an additional example for db logs querying.

Also added a fix for the `10 Minutes Ago` template being set as a regex query instead of a custom query.