### PR TITLE
fix: fix supabase light mode issue

### DIFF
--- a/www/components/AuthWidget/AuthComponentExample.tsx
+++ b/www/components/AuthWidget/AuthComponentExample.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { createClient } from '@supabase/supabase-js'
 import {
   Badge,
@@ -17,17 +17,15 @@ import { Swiper, SwiperSlide } from 'swiper/react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 
+import { useTheme } from '../Providers'
+
 const supabase = createClient(
   'https://rsnibhkhsbfnncjmwnkj.supabase.co',
   'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoiYW5vbiIsImlhdCI6MTYxNTIxNDE1MywiZXhwIjoxOTMwNzkwMTUzfQ.OQEbAaTfgDdLCCht251P2JRD3QDnui6nsU8N-tZA_Mc'
 )
 
-type Props = {
-  darkMode: boolean
-}
-
-function AuthComponentExample(props: Props) {
-  const { darkMode } = props
+function AuthComponentExample() {
+  const { isDarkMode } = useTheme()
   const { basePath } = useRouter()
 
   // store API swiper instance
@@ -91,9 +89,9 @@ function AuthComponentExample(props: Props) {
                     <Space size={3} direction="vertical">
                       <img
                         src={
-                          darkMode
-                            ? `${basePath}/brand-assets/supabase-logo-wordmark--light.svg`
-                            : `${basePath}/brand-assets/supabase-logo-wordmark--dark.svg`
+                          isDarkMode
+                            ? `${basePath}/brand-assets/supabase-logo-wordmark--dark.svg`
+                            : `${basePath}/brand-assets/supabase-logo-wordmark--light.svg`
                         }
                         width="96"
                         alt="Logo"

--- a/www/components/DarkModeToggle.tsx
+++ b/www/components/DarkModeToggle.tsx
@@ -1,9 +1,4 @@
-import { useRouter } from 'next/router'
-
-interface Props {
-  darkMode: boolean
-  updateTheme: Function
-}
+import { useTheme } from '~/components/Providers'
 
 const SunEmoji = () => (
   <svg width="32" height="32" fill="none">
@@ -44,12 +39,15 @@ const MoonEmoji = () => (
   </svg>
 )
 
-function DarkModeToggle(props: Props) {
-  const { darkMode, updateTheme } = props
+function DarkModeToggle() {
+  const { isDarkMode, toggleTheme } = useTheme()
 
   const toggleDarkMode = () => {
-    localStorage.setItem('supabaseDarkMode', (!darkMode).toString())
-    updateTheme(!darkMode)
+    localStorage.setItem('supabaseDarkMode', (!isDarkMode).toString())
+    toggleTheme()
+
+    const key = localStorage.getItem('supabaseDarkMode')
+    document.documentElement.className = key === 'true' ? 'dark' : ''
   }
 
   return (
@@ -61,7 +59,7 @@ function DarkModeToggle(props: Props) {
         className={`
                 relative inline-flex flex-shrink-0 h-6 w-11 border-2 border-transparent rounded-full cursor-pointer 
                 transition-colors ease-in-out duration-200 focus:outline-none ${
-                  darkMode ? 'bg-dark-500' : 'bg-gray-200'
+                  isDarkMode ? 'bg-dark-500' : 'bg-gray-200'
                 } mx-5
               `}
         onClick={() => toggleDarkMode()}
@@ -70,7 +68,9 @@ function DarkModeToggle(props: Props) {
         <span
           aria-hidden="true"
           className={`
-                  ${darkMode ? 'translate-x-5' : 'translate-x-0'} inline-block h-5 w-5 rounded-full
+                  ${
+                    isDarkMode ? 'translate-x-5' : 'translate-x-0'
+                  } inline-block h-5 w-5 rounded-full
                   bg-white dark:bg-dark-700 shadow-lg transform ring-0 transition ease-in-out duration-200
                 `}
         />
@@ -79,4 +79,5 @@ function DarkModeToggle(props: Props) {
     </div>
   )
 }
+
 export default DarkModeToggle

--- a/www/components/Footer/index.tsx
+++ b/www/components/Footer/index.tsx
@@ -3,15 +3,11 @@ import FooterLinks from 'data/Footer.json'
 import SectionContainer from '../Layouts/SectionContainer'
 import DarkModeToggle from '../DarkModeToggle'
 import Link from 'next/link'
+import { useTheme } from '../Providers'
 
-type Props = {
-  darkMode: boolean
-  updateTheme: Function
-}
-
-const Footer = (props: Props) => {
+const Footer = () => {
   const { basePath } = useRouter()
-  const { darkMode, updateTheme } = props
+  const { isDarkMode } = useTheme()
 
   return (
     <footer
@@ -29,7 +25,7 @@ const Footer = (props: Props) => {
                 <img
                   className="w-40"
                   src={
-                    darkMode
+                    isDarkMode
                       ? `${basePath}/brand-assets/supabase-logo-wordmark--dark.svg`
                       : `${basePath}/brand-assets/supabase-logo-wordmark--light.svg`
                   }
@@ -105,7 +101,7 @@ const Footer = (props: Props) => {
           <p className="mb-0 self-center text-base text-gray-400 dark:text-dark-400">
             &copy; Supabase Inc
           </p>
-          <DarkModeToggle darkMode={darkMode} updateTheme={updateTheme} />
+          <DarkModeToggle />
         </div>
       </SectionContainer>
     </footer>

--- a/www/components/Layouts/Default.tsx
+++ b/www/components/Layouts/Default.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useEffect } from 'react'
 import Nav from 'components/Nav/index'
 import Footer from 'components/Footer/index'
 
@@ -10,28 +10,19 @@ type Props = {
 
 const DefaultLayout = (props: Props) => {
   const { hideHeader = false, hideFooter = false, children } = props
-  const [darkMode, setDarkMode] = useState<boolean>(true)
 
   useEffect(() => {
-    const isDarkMode = localStorage.getItem('supabaseDarkMode')
-    if (isDarkMode) {
-      setDarkMode(isDarkMode === 'true')
-      document.documentElement.className = isDarkMode === 'true' ? 'dark' : ''
-    }
+    const key = localStorage.getItem('supabaseDarkMode')
+    document.documentElement.className = key === 'true' ? 'dark' : ''
   }, [])
-
-  const updateTheme = (isDarkMode: boolean) => {
-    document.documentElement.className = isDarkMode ? 'dark' : ''
-    setDarkMode(isDarkMode)
-  }
 
   return (
     <>
-      {!hideHeader && <Nav darkMode={darkMode} />}
+      {!hideHeader && <Nav />}
       <div className="min-h-screen bg-white dark:bg-gray-800">
         <main>{children}</main>
       </div>
-      {!hideFooter && <Footer darkMode={darkMode} updateTheme={updateTheme} />}
+      {!hideFooter && <Footer />}
     </>
   )
 }

--- a/www/components/Nav/index.tsx
+++ b/www/components/Nav/index.tsx
@@ -12,13 +12,11 @@ import Solutions from '~/components/Nav/Product'
 import Developers from '~/components/Nav/Developers'
 import Announcement from '~/components/Nav/Announcement'
 
-type Props = {
-  darkMode: boolean
-}
+import { useTheme } from '~/components/Providers'
 
-const Nav = (props: Props) => {
+const Nav = () => {
   const { basePath } = useRouter()
-  const { darkMode } = props
+  const { isDarkMode } = useTheme()
   const [open, setOpen] = useState(false)
 
   const [openProduct, setOpenProduct] = useState(false)
@@ -199,7 +197,7 @@ const Nav = (props: Props) => {
                       <img
                         className="block h-6 w-auto"
                         src={
-                          darkMode
+                          isDarkMode
                             ? `${basePath}/brand-assets/supabase-logo-wordmark--dark.svg`
                             : `${basePath}/brand-assets/supabase-logo-wordmark--light.svg`
                         }

--- a/www/components/Providers/index.tsx
+++ b/www/components/Providers/index.tsx
@@ -1,0 +1,43 @@
+import { createContext, useContext, useEffect, useState } from 'react'
+
+interface UseThemeProps {
+  isDarkMode?: boolean
+  toggleTheme: () => void
+}
+
+interface ThemeProviderProps {
+  children?: any
+}
+
+export const ThemeContext = createContext<UseThemeProps>({
+  isDarkMode: true,
+  toggleTheme: () => {},
+})
+
+export const useTheme = () => useContext(ThemeContext)
+
+export const ThemeProvider = ({ children }: ThemeProviderProps) => {
+  const [isDarkMode, setIsDarkMode] = useState(false)
+
+  useEffect(() => {
+    const key = localStorage.getItem('supabaseDarkMode')
+    setIsDarkMode(key === 'true')
+  }, [])
+
+  const toggleTheme = () => {
+    setIsDarkMode(!isDarkMode)
+  }
+
+  return (
+    <>
+      <ThemeContext.Provider
+        value={{
+          isDarkMode,
+          toggleTheme,
+        }}
+      >
+        {children}
+      </ThemeContext.Provider>
+    </>
+  )
+}

--- a/www/pages/404.tsx
+++ b/www/pages/404.tsx
@@ -6,13 +6,11 @@ import { Button, Typography } from '@supabase/ui'
 
 import DefaultLayout from '../components/Layouts/Default'
 
-type Props = {
-  darkMode: boolean
-}
+import { useTheme } from '~/components/Providers'
 
-const Error404 = (props: Props) => {
+const Error404 = () => {
   const [show404, setShow404] = useState<boolean>(false)
-  const { darkMode } = props
+  const { isDarkMode } = useTheme()
 
   useEffect(() => {
     setTimeout(() => {
@@ -30,9 +28,9 @@ const Error404 = (props: Props) => {
                 <a href="/">
                   <Image
                     src={
-                      darkMode
-                        ? '/images/supabase-logo-wordmark--light.svg'
-                        : '/images/supabase-logo-wordmark--dark.svg'
+                      isDarkMode
+                        ? '/images/supabase-logo-wordmark--dark.svg'
+                        : '/images/supabase-logo-wordmark--light.svg'
                     }
                     alt=""
                     height={24}

--- a/www/pages/_app.tsx
+++ b/www/pages/_app.tsx
@@ -6,6 +6,7 @@ import { useEffect } from 'react'
 import Meta from '~/components/Favicons'
 import '../styles/index.css'
 import { post } from './../lib/fetchWrapper'
+import { ThemeProvider } from '~/components/Providers'
 
 export default function MyApp({ Component, pageProps }: AppProps) {
   const router = useRouter()
@@ -66,7 +67,9 @@ export default function MyApp({ Component, pageProps }: AppProps) {
           cardType: 'summary_large_image',
         }}
       />
-      <Component {...pageProps} />
+      <ThemeProvider>
+        <Component {...pageProps} />
+      </ThemeProvider>
     </>
   )
 }

--- a/www/pages/auth/Auth.tsx
+++ b/www/pages/auth/Auth.tsx
@@ -30,13 +30,7 @@ import GithubExamples from '~/components/Sections/GithubExamples'
 import ProductHeader from '~/components/Sections/ProductHeader'
 import AuthProviders from '~/data/auth.json'
 
-type Props = {
-  darkMode: boolean
-}
-
-function AuthPage(props: Props) {
-  const { darkMode } = props
-
+function AuthPage() {
   // base path for images
   const { basePath } = useRouter()
 
@@ -262,7 +256,7 @@ function AuthPage(props: Props) {
         <SectionContainer>
           <div className="grid grid-cols-12 lg:gap-16">
             <div className="order-last col-span-12 lg:order-first lg:col-span-6 mt-8 lg:mt-0">
-              <AuthComponentExample darkMode={darkMode} />
+              <AuthComponentExample />
             </div>
             <div className="col-span-12 lg:col-span-6 lg:col-start-7 xl:col-span-4 xl:col-start-8">
               <Space className="mb-4">


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix. This light mode bug seem to be happening to pages that were trying to get darkMode data as a prop from DefaultLayout (e.g, /auth, /404). 

Implemented react context to pass darkMode data globally to components.

closes #5297 

## What is the current behavior?
The supabase wordmark logo doesn't change to its light version on light mode

/auth page:
![SCR-20220220-ym](https://user-images.githubusercontent.com/48682663/154812464-4594af67-79ff-4d7c-baf4-6ff0046387e9.png)

/404 page:
![SCR-20220220-zd](https://user-images.githubusercontent.com/48682663/154812490-b0154deb-ef88-4f1d-8a70-ad4f91a05671.png)


## What is the new behavior?
The supabase wordmark logo now changes to its light version on light mode

/auth page:
![SCR-20220220-w5](https://user-images.githubusercontent.com/48682663/154812341-294a4327-5a7d-43e2-a90a-dd44824ebc8f.png)

/404 page:
![SCR-20220220-wv](https://user-images.githubusercontent.com/48682663/154812374-883552c8-78a3-4ca9-a72d-0608e060a595.png)


## Additional context

Previously, the darkMode prop data will be received as undefined because prop data cannot be passed to children. Trying to pass darkMode data as a prop may also cause "prop drilling" to many components.

Used react's context API to solve this darkMode data's undefined type and "prop drilling" issue so components can fetch darkMode data from the global theme context provided by the theme provider wrapping them.