### PR TITLE
Add numeric data type and refactor some repeated logic

### DIFF
--- a/studio/components/interfaces/Database/Functions/CreateFunction.tsx
+++ b/studio/components/interfaces/Database/Functions/CreateFunction.tsx
@@ -16,11 +16,10 @@ import {
 import { Dictionary } from '@supabase/grid'
 import { makeAutoObservable } from 'mobx'
 
-import { POSTGRES_DATA_TYPES } from 'lib/constants'
 import { useStore } from 'hooks'
 import Panel from 'components/to-be-cleaned/Panel'
 import SqlEditor from 'components/to-be-cleaned/SqlEditor'
-
+import { POSTGRES_DATA_TYPES } from 'components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.constants'
 
 class CreateFunctionFormState {
   id: number | undefined
@@ -780,12 +779,16 @@ const SelectLanguage: FC = observer(({}) => {
         <Select.Option value="sql">sql</Select.Option>
         {
           //map through all selected extensions that start with pl
-          enabledExtensions.filter((ex:any) => {
-             return ex.name.startsWith('pl')
-          }).map(ex => (<Select.Option key={ex.name} value={ex.name}>{ex.name}</Select.Option>))
-          
+          enabledExtensions
+            .filter((ex: any) => {
+              return ex.name.startsWith('pl')
+            })
+            .map((ex) => (
+              <Select.Option key={ex.name} value={ex.name}>
+                {ex.name}
+              </Select.Option>
+            ))
         }
-        
       </Select>
     </div>
   )

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.constants.ts
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.constants.ts
@@ -2,7 +2,7 @@ import { sortBy, concat } from 'lodash'
 import { PostgresDataTypeOption } from './SidePanelEditor.types'
 
 export const DATE_FORMAT = 'YYYY-MM-DDTHH:mm:ssZ'
-export const NUMERICAL_TYPES = ['int2', 'int4', 'int8', 'float4', 'float8']
+export const NUMERICAL_TYPES = ['int2', 'int4', 'int8', 'float4', 'float8', 'numeric']
 export const JSON_TYPES = ['json', 'jsonb']
 export const TEXT_TYPES = ['text', 'varchar']
 export const TIMESTAMP_TYPES = ['date', 'time', 'timestamp', 'timetz', 'timestamptz']
@@ -35,6 +35,11 @@ export const POSTGRES_DATA_TYPE_OPTIONS: PostgresDataTypeOption[] = [
   {
     name: 'float8',
     description: 'Double precision floating-point number (8 bytes)',
+    type: 'number',
+  },
+  {
+    name: 'numeric',
+    description: 'Exact numeric of selectable precision',
     type: 'number',
   },
   {

--- a/studio/lib/constants/index.ts
+++ b/studio/lib/constants/index.ts
@@ -11,17 +11,6 @@ export const PG_META_URL = IS_PLATFORM
 
 export const DATE_FORMAT = 'YYYY-MM-DDTHH:mm:ssZ'
 
-// Data types primarily for mapping icon in editor
-
-export const NUMERICAL_TYPES = ['int2', 'int4', 'int8', 'float4', 'float8']
-export const JSON_TYPES = ['json', 'jsonb']
-export const TEXT_TYPES = ['text', 'varchar']
-export const TIMESTAMP_TYPES = ['date', 'time', 'timestamp', 'timetz', 'timestamptz']
-export const OTHER_DATA_TYPES = ['uuid', 'bool']
-export const POSTGRES_DATA_TYPES = sortBy(
-  concat(NUMERICAL_TYPES, JSON_TYPES, TEXT_TYPES, TIMESTAMP_TYPES, OTHER_DATA_TYPES)
-)
-
 // Keyboard Shortcuts Related
 export const SHORTCUT_KEYS = {
   VIEW_ALL_SHORTCUTS: 'VIEW_ALL_SHORTCUTS',


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add `numeric` data type for use in table editor. Note - we'll need to relook at the UX for this part as numeric accepts 2 other parameters, precision and scale ([ref](https://www.postgresqltutorial.com/postgresql-numeric/)), like varchar. Need to update the UI to allow users to input parameters for data types such as these.

For now, if you'd like greater control over using the numeric data type, I'd still recommend doing it through SQL 🙏 