### PR TITLE
Docs/vue - Small refactoring  of the "Create an upload widget" example  

### DIFF
--- a/web/docs/guides/with-vue-3.mdx
+++ b/web/docs/guides/with-vue-3.mdx
@@ -553,7 +553,7 @@ export default {
     }
 
     watch(path, () => {
-      path.value ? downloadImage() : ""
+      if (path.value) downloadImage()
     })
 
     return {

--- a/web/docs/guides/with-vue-3.mdx
+++ b/web/docs/guides/with-vue-3.mdx
@@ -557,7 +557,6 @@ export default {
     })
 
     return {
-      path,
       size,
       uploading,
       src,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Vue Docs update -  small refactoring  of the "Create an upload widget" example  

## What is the current behavior?

Currently eslint is throwing two errors:

1. In the watch() there's a code that throws Eslint error: _Expected an assignment or function call and instead saw an expression._ https://eslint.org/docs/rules/no-unused-expressions. It was fixed.
2. In the "Create an upload widget" example there is unnecessary "path" property in the return statement. Because of that Eslint throws error: _Duplicated key 'path' - https://eslint.vuejs.org/rules/no-dupe-keys.html._ This property should be removed since it's already declared in props.

## What is the new behavior?
Now eslint is not throwing errors :) 

## Additional context
![CleanShot 2022-02-21 at 22 58 39](https://user-images.githubusercontent.com/4950739/155031045-76f982df-8302-4363-aa25-76992664d378.gif)

