### PR TITLE
January 2022 blog: fix year typo

### DIFF
--- a/www/_blog/2022-02-22-supabase-beta-january-2022.mdx
+++ b/www/_blog/2022-02-22-supabase-beta-january-2022.mdx
@@ -1,5 +1,5 @@
 ---
-title: Supabase Beta January 2021
+title: Supabase Beta January 2022
 description: New auth providers, SMS providers, and new videos.
 author: paul_copplestone
 author_url: https://github.com/kiwicopple


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs typo

## What is the current behavior?

Wrong year in blog post.

## What is the new behavior?

Updated to correct year (2022).