### PR TITLE
fix/studio/logs: Remove x element input button in timestamp filter

### DIFF
--- a/studio/components/interfaces/Settings/Logs/LogPanel.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogPanel.tsx
@@ -152,15 +152,6 @@ const LogPanel: FC<Props> = ({
                       error={from.error}
                       className="w-72 p-3"
                       actions={[
-                        from.value && (
-                          <IconX
-                            key="reset-from"
-                            size="tiny"
-                            className="cursor-pointer mx-1"
-                            title="Reset"
-                            onClick={handleFromReset}
-                          />
-                        ),
                         <Button
                           key="set"
                           size="tiny"

--- a/studio/tests/pages/projects/LogPanel.test.js
+++ b/studio/tests/pages/projects/LogPanel.test.js
@@ -84,7 +84,6 @@ test('timestamp from filter default value', async () => {
   await screen.findByDisplayValue('2022-01-18T10:43:39+0000')
   // TODO: use screen.findByLabelText when https://github.com/supabase/ui/issues/310 is resolved
   await screen.findByText('From')
-  await screen.findByTitle('Reset')
 })
 
 test('timestamp from filter error handling', async () => {


### PR DESCRIPTION
Removes duplicate `x` button in timestamp filter.

cc @chasers 

![image](https://user-images.githubusercontent.com/22714384/155370545-8e2d66b1-8d25-4908-99fb-4b4a13687f6f.png)
