### PR TITLE
Chore: use next/image for blog page

### DIFF
--- a/www/components/Blog/BlogListItem.tsx
+++ b/www/components/Blog/BlogListItem.tsx
@@ -18,9 +18,7 @@ const BlogListItem = ({ blog }: Props) => {
         <div className="inline-block min-w-full group">
           <div className="flex flex-col space-y-6">
             <div className="flex flex-col space-y-3">
-              <div
-                className={`relative overflow-auto w-full h-60 border dark:border-dark shadow-sm rounded-lg mb-4`}
-              >
+              <div className="relative overflow-auto w-full h-60 border dark:border-dark shadow-sm rounded-lg mb-4">
                 <Image
                   layout="fill"
                   src={

--- a/www/pages/blog.tsx
+++ b/www/pages/blog.tsx
@@ -2,6 +2,7 @@ import fs from 'fs'
 import { useEffect, useState } from 'react'
 
 import { useRouter } from 'next/router'
+import Image from 'next/image'
 
 import { NextSeo } from 'next-seo'
 import { generateRss } from '~/lib/rss'
@@ -137,10 +138,13 @@ function FeaturedThumb(blog: PostTypes) {
     <div key={blog.slug} className="cursor-pointer w-full">
       <a href={`/blog/${blog.url}`}>
         <a className="grid lg:grid-cols-2 gap-8 lg:gap-16">
-          <img
-            className="h-96 w-full object-cover border dark:border-dark rounded-lg"
-            src={`/images/blog/` + (blog.thumb ? blog.thumb : blog.image)}
-          />
+          <div className="relative overflow-auto w-full h-96 border dark:border-dark rounded-lg">
+            <Image
+              src={`/images/blog/` + (blog.thumb ? blog.thumb : blog.image)}
+              layout="fill"
+              objectFit="cover"
+            />
+          </div>
           <div className="flex flex-col space-y-4">
             <div className="flex space-x-2">
               <Typography.Text type="secondary">{blog.date}</Typography.Text>
@@ -158,7 +162,14 @@ function FeaturedThumb(blog: PostTypes) {
             {author && (
               <div className="flex space-x-3 items-center">
                 {author.author_image_url && (
-                  <img src={author.author_image_url} className="rounded-full w-10" />
+                  <div className="relative overflow-auto w-10 h-10">
+                    <Image
+                      src={author.author_image_url}
+                      className="rounded-full"
+                      layout="fill"
+                      objectFit="cover"
+                    />
+                  </div>
                 )}
                 <div className="flex flex-col">
                   <Typography.Text>{author.author}</Typography.Text>

--- a/www/pages/blog/[year]/[month]/[day]/[slug].tsx
+++ b/www/pages/blog/[year]/[month]/[day]/[slug].tsx
@@ -5,6 +5,7 @@ import hydrate from 'next-mdx-remote/hydrate'
 import renderToString from 'next-mdx-remote/render-to-string'
 import { NextSeo } from 'next-seo'
 import Link from 'next/link'
+import Image from 'next/image'
 import { useRouter } from 'next/router'
 import React from 'react'
 import ReactMarkdown from 'react-markdown'
@@ -217,10 +218,15 @@ function BlogPostPage(props: any) {
                         <a className="cursor-pointer">
                           <Space size={4}>
                             {author.author_image_url && (
-                              <img
-                                src={author.author_image_url}
-                                className="rounded-full w-10 border dark:border-dark"
-                              />
+                              <div className="w-10">
+                                <Image
+                                  src={author.author_image_url}
+                                  className="rounded-full border dark:border-dark"
+                                  width="100%"
+                                  height="100%"
+                                  layout="responsive"
+                                />
+                              </div>
                             )}
                             <Space direction="vertical" size={0}>
                               <Typography.Text>{author.author}</Typography.Text>
@@ -239,11 +245,13 @@ function BlogPostPage(props: any) {
                 {/* Content */}
                 <div className="col-span-12 lg:col-span-7 xl:col-span-7">
                   {props.blog.thumb && (
-                    <img
-                      src={'/images/blog/' + props.blog.thumb}
-                      className="object-cover mb-8 border dark:border-gray-600"
-                      style={{ maxHeight: '520px' }}
-                    />
+                    <div className="relative overflow-auto w-full h-96 mb-8 border dark:border-gray-600">
+                      <Image
+                        src={'/images/blog/' + props.blog.thumb}
+                        layout="fill"
+                        objectFit="cover"
+                      />
+                    </div>
                   )}
                   <article className={blogStyles['article']}>
                     <Typography>{content}</Typography>


### PR DESCRIPTION
## What kind of change does this PR introduce?

switch from `img` tag to [`next/image`](https://nextjs.org/docs/api-reference/next/image) for blog page. This should also help with the image load time.

## What is the current behavior?

using default `img` tag

## What is the new behavior?

using [`next/image`](https://nextjs.org/docs/api-reference/next/image)