### PR TITLE
Added support for notes in Examples.

### DIFF
--- a/web/ReferenceGenerator.ts
+++ b/web/ReferenceGenerator.ts
@@ -169,7 +169,7 @@ function generateExamples(id: string, specExamples: any, allLanguages: any) {
     let allTabs = example.hideCodeBlock
       ? ''
       : Tabs(id, allLanguages, generateTabs(allLanguages, example))
-    return Example({ name: example.name, description: example.description, tabs: allTabs })
+    return Example({ name: example.name, description: example.description, tabs: allTabs, note: example.note })
   })
 }
 

--- a/web/spec/gen/components/Example.ts
+++ b/web/spec/gen/components/Example.ts
@@ -1,12 +1,24 @@
-type params = { name: string; description: string; tabs: string }
+type params = { name: string; description: string; tabs: string; note: string; }
 
-const Example = ({ name, description = '', tabs = '' }: params) =>
-  `
+const Example = ({name, description = '', tabs = '', note = ''}: params) => {
+    if (note !== '') {
+        const [noteTitle, ...noteText] = note.split('\n');
+        console.log(noteText);
+        note = `
+:::note ${noteTitle}
+  ${noteText.join('\n')}
+:::
+`;
+    }
+    return `
 ### ${name}
 
 ${description}
 
 ${tabs}
+
+${note}
 `.trim()
+}
 
 export default Example

--- a/web/spec/supabase.yml
+++ b/web/spec/supabase.yml
@@ -981,6 +981,11 @@ pages:
               )
             `)
           ```
+        note: |
+         What about join tables
+         If you're in a situation where your tables are **NOT** directly related, but instead are joined by a _join table_,
+         you can still use the `select()` method to query the related data. The PostgREST engine detects the relationship automatically.
+         For more details, [follow the link](https://postgrest.org/en/v9.0/api.html#embedding-through-join-tables).
       - name: Query the same foreign table multiple times
         description: |
           Sometimes you will need to query the same foreign table twice. 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Added support for note admonitions.
Also added a note about join tables in Select Reference.

## What is the current behavior?

We can't add notes in the docs

## What is the new behavior?

We can now add notes 🎉 

## Additional context

Here is how it looks:

<img width="869" alt="image" src="https://user-images.githubusercontent.com/7793347/156050204-aa803784-a1bb-4b3f-a64b-93c82629bac7.png">

