### PR TITLE
Update organization in store when saving AWS Marketplace association

### DIFF
--- a/studio/pages/account/associate.tsx
+++ b/studio/pages/account/associate.tsx
@@ -28,15 +28,17 @@ const Associate = observer(() => {
       return
     }
     setSaving(true)
-    const { error } = await post(
+    const organization = await post(
       `${API_URL}/organizations/${organizationSlug}/associate`,
       awsMarketplace
     )
+    const { error } = organization
     if (error) {
       setError(error.message)
     }
     setSaving(false)
     if (!error) {
+      app.onOrgUpdated(organization)
       router.push('/')
     }
   }


### PR DESCRIPTION
Otherwise the Billing tab won't reflect the change until a refresh.