### PR TITLE
Docs: remove unused params in expo code fragment

### DIFF
--- a/web/docs/guides/with-expo.mdx
+++ b/web/docs/guides/with-expo.mdx
@@ -232,13 +232,13 @@ export default function Auth() {
       <View style={[styles.verticallySpaced, styles.mt20]}>
         <Button
           title="Sign in"
-          onPress={() => signInWithEmail(email, password)}
+          onPress={() => signInWithEmail()}
         />
       </View>
       <View style={styles.verticallySpaced}>
         <Button
           title="Sign up"
-          onPress={() => signUpWithEmail(email, password)}
+          onPress={() => signUpWithEmail()}
         />
       </View>
     </View>


### PR DESCRIPTION
## What kind of change does this PR introduce?
Update with-expo.mdx docs. Remove unused params in expo code fragment `signInWithEmail()` and  `signUpWithEmail()`

## What is the current behavior?

https://supabase.com/docs/guides/with-expo

## What is the new behavior?
N/A

## Additional context
N/A
