### PR TITLE
fix: issue with code labels in API settings panel

### DIFF
--- a/studio/components/to-be-cleaned/DisplayProjectSettings.tsx
+++ b/studio/components/to-be-cleaned/DisplayProjectSettings.tsx
@@ -71,18 +71,16 @@ export const DisplayApiSettings = () => {
               label={
                 <>
                   {x.tags?.split(',').map((x: any, i: number) => (
-                    <code key={`${x}${i}`} className="text-xs  text-white px-2">
+                    <code key={`${x}${i}`} className="text-xs text-code">
                       {x}
                     </code>
                   ))}
                   {x.tags === 'service_role' && (
                     <>
-                      <code className="text-xs bg-red-900 px-2 ml-1 text-white">{'secret'}</code>
+                      <code className="text-xs bg-red-900 text-white">{'secret'}</code>
                     </>
                   )}
-                  {x.tags === 'anon' && (
-                    <code className="text-xs text-white px-2 ml-1">{'public'}</code>
-                  )}
+                  {x.tags === 'anon' && <code className="text-xs text-code">{'public'}</code>}
                 </>
               }
               readOnly


### PR DESCRIPTION

before:
![Untitled](https://user-images.githubusercontent.com/8291514/156403439-c1174ff0-2d00-4042-84ca-cefe5bc08baa.png)

after:
<img width="840" alt="Screenshot 2022-03-02 at 4 23 03 PM" src="https://user-images.githubusercontent.com/8291514/156403463-fdbe1012-325c-419c-8524-fe9d699ee42a.png">

