### PR TITLE
fix: shows an 'active' state for columns with a foreign key assigned

### DIFF
--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/Column.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/Column.tsx
@@ -86,7 +86,7 @@ const Column: FC<Props> = ({
             } rounded-md`}
             actions={
               <Button
-                type={!isUndefined(column.foreignKey) ? 'default' : 'outline'}
+                type={!isUndefined(column.foreignKey) ? 'secondary' : 'default'}
                 onClick={() => onEditRelation(column)}
               >
                 <IconLink size={14} strokeWidth={!isUndefined(column.foreignKey) ? 2 : 1} />
@@ -216,7 +216,7 @@ const Column: FC<Props> = ({
                     {settingsCount}
                   </div>
                 )}
-                <div className="text-scale-900 transition-colors group-hover:text-scale-1200">
+                <div className="text-scale-1100 transition-colors group-hover:text-scale-1200">
                   <IconSettings size={18} strokeWidth={1} />
                 </div>
               </div>


### PR DESCRIPTION
## What kind of change does this PR introduce?

This is a rather short term solution but changed the buttons to show an active state when a foreign key is assigned to a column

### before:

FK is selected for column `id`
<img width="763" alt="Screenshot 2022-03-02 at 4 29 56 PM" src="https://user-images.githubusercontent.com/8291514/156404768-db1cbca6-245d-455b-ad11-2398b17c4d67.png">


### after:

<img width="753" alt="Screenshot 2022-03-02 at 4 28 27 PM" src="https://user-images.githubusercontent.com/8291514/156404690-5ecde2c2-e681-48bf-a5ca-4e1e04bb90a0.png">
<img width="730" alt="Screenshot 2022-03-02 at 4 28 14 PM" src="https://user-images.githubusercontent.com/8291514/156404694-8a3a7c82-d098-4487-aba6-dd99d4cb5bd0.png">
reenshots.
