### PR TITLE
Fix: feedback button

### DIFF
--- a/studio/components/layouts/ProjectLayout/LayoutHeader/FeedbackDropdown/FeedbackDropdown.tsx
+++ b/studio/components/layouts/ProjectLayout/LayoutHeader/FeedbackDropdown/FeedbackDropdown.tsx
@@ -34,7 +34,8 @@ const FeedbackDropdown = () => {
         type="default"
         icon={<IconMessageCircle size={16} strokeWidth={1.5} className="text-scale-900" />}
       >
-        Feedback on this page?
+        <span className="block md:hidden">Feedback</span>
+        <span className="hidden md:block">Feedback on this page?</span>
       </Button>
     </Popover>
   )


### PR DESCRIPTION
## What kind of change does this PR introduce?

Just like the original #5346, on smaller screens the feedback button doesn't fit on the screen correctly.

## What is the current behavior?

<img width="393" alt="Screen Shot 2022-03-02 at 6 00 17 PM" src="https://user-images.githubusercontent.com/70828596/156464146-3750b634-31f3-4581-b0ec-fa6b76511125.png">

## What is the new behavior?

<img width="393" alt="Screen Shot 2022-03-02 at 6 00 05 PM" src="https://user-images.githubusercontent.com/70828596/156464160-8aedd7a2-f7c8-4325-99ad-e43a84fcedb5.png">