### PR TITLE
fix wrong kong and meta url for local dev

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -10,8 +10,8 @@ SERVICE_ROLE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJzZX
 
 ## General
 SITE_URL=http://localhost:3000
-KONG_URL=http://kong:8000
-META_URL=http://meta:8080
+KONG_URL=http://localhost:8000
+META_URL=http://localhost:8080
 ADDITIONAL_REDIRECT_URLS=
 JWT_EXPIRY=3600
 DISABLE_SIGNUP=false


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to fix wrong default kong and meta url settings for local development.

## What is the current behavior?

Currently those 2 urls are pointing to nonsense urls in the example env file, which caused Studio api section page showing 500 error.

## What is the new behavior?

Those 2 urls should point to localhost by default.

## Additional context

Some other related issues: 
supabase/supabase#5816 - The API section of the local Studio is inaccessible (500)
https://github.com/supabase/supabase/issues/5687 - API page does not load on web instance
https://github.com/supabase/supabase/issues/4550 - Studio API endpoint error
