### PR TITLE
[Feature] Support for local deployment via Terraform

### DIFF
--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,12 @@
+dotenv.tf
+thirdpartyauth.dotenv.tf
+kong.yml
+.terraform
+.terraform.lock.hcl
+terraform.tfstate
+terraform.tfstate.backup
+.terraform.tfstate.lock.info
+.DS_Store
+
+*.cer
+*.pem

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -4,9 +4,7 @@ This repo includes an example of starting a local copy of the Supabase stack via
 
 ### Very important notice
 
-This repo is still a work in progress - it should **NOT** be used for production deployments at this time. For example, the Terraform configuration currently created will destroy all volumes when `destroy` is called. You **WILL** lose all data.
-
-Known issues such as this will be resolved in due course.
+Terraform support is still a work in progress - it should **NOT** be used for production deployments at this time. For example, the Terraform configuration currently created will destroy all volumes when `destroy` is called. You **WILL** lose all data.
 
 ### Secure values
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,134 @@
+# Terraform Supabase
+
+This repo includes an example of starting a local copy of the Supabase stack via Terraform. At this time, it does not support deployment to a remote VPS.
+
+### Very important notice
+
+This repo is still a work in progress - it should **NOT** be used for production deployments at this time. For example, the Terraform configuration currently created will destroy all volumes when `destroy` is called. You **WILL** lose all data.
+
+Known issues such as this will be resolved in due course.
+
+### Secure values
+
+Please note that your Postgres password, JWT secret and JWT tokens are automatically generated during setup. If you are using the Watchtower plugin, the HTTP API token for that is also automatically generated. In order to retrieve these values for use in an application:
+
+- Your `anon_key` and `service_role_key` can be found in the `kong_data` docker volume, inside the `kong.yml` file
+- Your `jwt_secret` can be found in the environmental variables of the `supabase-auth` docker container
+- Your `postgres_password` can be found in the environmental variables of the `db` docker container
+- If you have enabled the Watchtower plugin, you can find your HTTP API token in the environmental variables of the `watchtower` docker container
+
+As of writing, these values are not output to the terminal or disk as they are considered very sensitive.
+
+The Postgres password is 96 characters in length, while the JWT secret is 64 characters in length. The watchtower HTTP API token is 128 characters in length.
+
+### Instructions
+
+1. Install docker - instructions at https://docs.docker.com/get-docker/
+2. Install the Terraform CLI - instructions at https://www.terraform.io/downloads
+3. Rename `./supabase/definitions/dotenv.tf.example` to `./supabase/definitions/dotenv.tf`
+   a. This file includes the **sensitive** Supabase-related environment variables (except for third-party auth variables)
+   b. You should never **commit** this file to git - `dotenv.tf` is already included in `.gitignore`
+4. Rename `./plugins/defintions/dotenv.tf.example` to `./plugins/definitions/dotenv.tf`
+   a. This file includes all **sensitive** plugin-related environment variables
+   b. It should **never** be commited to git
+5. Rename `./supabase/definitions/thirdpartyauth.dotenv.tf.example` to `./supabase/definitions/thirdpartyauth.dotenv.tf`
+   a. This file is where all third-party auth variables should be set
+   b. You should **never** commit this file to git - `thirdpartyauth.dotenv.tf` is already in `.gitignore`, so unless you use a different filename, change the gitignore or place the variables in a different file, you won't accidentally leak your secrets
+6. Run `terraform init` from the folder where this readme is located
+7. Run `terraform plan` from the folder where this readme is located
+8. Run `terraform apply` and type `yes` when prompted
+
+To stop the stack, type `terraform destroy` and type `yes` when prompted.
+
+If there are any errors, please, please, **please** read what the terminal outputs as it will often tell you how to resolve the issue.
+
+If you're still having trouble, you can remove the Terraform dependencies and packages by removing the following from your copy of this repo:
+
+- `.terraform/` folder
+- `terraform.tfstate` file
+- `terraform.tfstate.backup` file
+- `terraform.lock.hcl` file
+
+### Plugins
+
+This repo provides a 'plugin' system which allows you to add some common Docker images and containers to the project.
+
+Inside the `./plugins/definitions` folder, you will find a `provider.tf` file. This file is where you can control which plugins are enabled.
+
+Plugin secret environmental variables can be set in`./plugins/definitions/dotenv.tf.example`. Rename to `dotenv.tf` before attempting to run `terraform` commands.
+
+For example, there is a `USE_PORTAINER` variable block. Inside this block, there is a `default` field. By setting the value of this field to `true`, you will enable the download and provisioning of the Portainer image and container.
+
+- **Current plugins**
+  - Portainer (disabled by default)
+    - Main plugin file: `./plugins/definitions/WithPortainer.tf`
+  - Nginx (disabled by default)
+    - This plugin is already configured for use with Supabase
+    - Main plugin file: `./plugins/definitions/WithNginx.tf`
+    - All variables for Nginx are stored in this file
+    - You should ensure you read the comments left in that file if you intend to use this plugin
+  - Watchtower (disabled by default)
+    - Main plugin file: `./plugins/definitions/WithWatchtower.tf`
+    - Environment variable options: https://containrrr.dev/watchtower/arguments/
+    - HTTP API (to trigger image and container updates): https://containrrr.dev/watchtower/http-api-mode/
+    - The HTTP API token for watchtower is a 128-character random password
+
+### Adding a new plugin
+
+In essence, plugins are simply docker containers that will be initialized and included during setup.
+
+First, you need to ensure that it is possible to toggle the plugin. To do this, add a new `variable` block in `./plugins/definitions/provider.tf`;
+
+```
+variable "USE_PLUGIN" {
+  type        = bool
+  default     = false
+  description = "Set default to true if you want to add <Plugin name> to the deployment"
+}
+```
+
+You should ensure that the `default` is set to false - all plugins are considered optional, but disabled by default.
+
+Then create a new file with a `.tf` extension in the `./plugins/definitions` folder. This file should be named `With<Plugin>.tf` (replace `<plugin>` with the name of your plugin).
+
+Add your Docker images and containers as resources:
+
+```
+resource "docker_image" "plugin" {
+  name         = "myorganisation/plugin:latest"
+  keep_locally = true
+  count        = var.USE_PLUGIN ? 1 : 0
+}
+
+resource "docker_container" "plugin" {
+  count = var.USE_PLUGIN ? 1 : 0
+  image = "myorganisation/plugin:latest"
+  name  = "plugin"
+  ports {
+    internal = 11111
+    external = 11111
+  }
+}
+```
+
+**The above is just an example!**
+The most important part is ensuring that the `count` property of all resources is set to `1` if your variable is `true`, and `0` if it is `false`.
+
+If your container requires any secret environmental variables, place them in `./plugins/defintions/dotenv.tf`. Any non-secret variables should be stored in the same file as the plugin.
+
+You should also ensure that you add the same variables to the `./plugins/definitions/dotenv.tf.example` file **but ensure you remove the secret value before you commit the file**!
+
+### Additional information
+
+This repo allows you to customise the `postgresql.conf` file before deployment. The default config provided within the Supabase docker image (as of 28th February 2022) is included at `./volumes/db/config/postgresql.conf`. The default config should be sufficient, but feel free to adjust this according to your requirements.
+
+Also included is the `kong.yml` config file used by Kong - available at `./volumes/api/kong.tpl`. This is a Terraform template file, meaning that it includes some template variables which are replaced during deployment:
+
+- `${META_URL}` - The URL which docker containers can access the `pg-meta` container at
+- `${META_PORT}` - The port which the `pg-meta` container is running on
+- `${ANON_KEY}` - The Supabase anon key
+- `${SECRET_KEY}` - The supabase service role key
+
+These variables are passed into the template from `docker.containers.tf` and should not be modified. If you want to change any of these value, change them in the `dotenv.tf` file (see instructions section above for details).
+
+The reason for using a template file is that it allows us to keep the environmental variables secret, while also avoiding the need to change them in more than one place. With the normal docker-compose deployment, you have to change some env variables in `kong.yml` as well as in the `.env` file.

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,10 @@
+module "WithSupabase" {
+  source = "./supabase"
+}
+
+module "WithPlugins" {
+  source = "./plugins"
+  depends_on = [
+    module.WithSupabase
+  ]
+}

--- a/terraform/plugins/definitions/WithNginx.tf
+++ b/terraform/plugins/definitions/WithNginx.tf
@@ -1,0 +1,81 @@
+variable "BASE_DOMAIN" {
+  type        = string
+  default     = "example.com"
+  description = "Used for SSL. This would be the domain of your site - e.g. example.com"
+}
+
+variable "SUPABASE_SUBDOMAIN" {
+  type        = string
+  default     = "data"
+  description = "Used for SSL. This would be the subdomain of your site where you want to access the supabase stack - e.g. For data.example.com, this value would be 'data'"
+}
+
+variable "DOMAIN_CERT_PREFIX" {
+  type        = string
+  default     = "cloudflare."
+  description = "Used for SSL. This is the prefix applied to the filename of SSL certs and keys - e.g. cloudflare.example.com.key.pem would be 'cloudflare.' "
+}
+
+variable "NGINX_USE_SSL" {
+  type        = bool
+  default     = false
+  description = "Used for SSL. Determines whether SSL is enabled for Nginx or not. You should also set all variables above to valid values if this is set to true"
+}
+
+resource "docker_image" "nginx" {
+  name         = "nginx:latest"
+  keep_locally = true
+  count        = var.USE_NGINX ? 1 : 0
+}
+
+resource "docker_container" "nginx" {
+  image   = "nginx:latest"
+  name    = "nginx"
+  count   = var.USE_NGINX ? 1 : 0
+  restart = "always"
+  command = [
+    "nginx",
+    "-g",
+    "daemon off;"
+  ]
+  ports {
+    internal = 80
+    external = 80
+  }
+  ports {
+    internal = 443
+    external = 443
+  }
+
+  networks_advanced {
+    name    = "supabase-network"
+    aliases = ["nginx"]
+  }
+
+  upload {
+    source = "${path.module}/volumes/nginxconfig/nginx.conf"
+    file   = "/etc/nginx/nginx.conf"
+  }
+
+  upload {
+    content = templatefile(abspath("${path.module}/volumes/nginxconfig/conf.d/default.conf.tpl"), {
+      BASE_DOMAIN        = var.BASE_DOMAIN
+      SUPABASE_SUBDOMAIN = var.SUPABASE_SUBDOMAIN
+      DOMAIN_CERT_PREFIX = var.DOMAIN_CERT_PREFIX
+      KONG_URL           = "kong"
+      KONG_PORT          = "8000"
+      NGINX_USE_SSL      = var.NGINX_USE_SSL
+    })
+    file = "/etc/nginx/conf.d/default.conf"
+  }
+
+  upload {
+    content = fileexists("${path.module}/volumes/nginxconfig/ssl/${var.DOMAIN_CERT_PREFIX}${var.BASE_DOMAIN}.cert.pem") ? file("${path.module}/volumes/nginxconfig/ssl/${var.DOMAIN_CERT_PREFIX}${var.BASE_DOMAIN}.cert.pem") : ""
+    file    = "/etc/nginx/ssl/${var.DOMAIN_CERT_PREFIX}${var.BASE_DOMAIN}.cert.pem"
+  }
+
+  upload {
+    content = fileexists("${path.module}/volumes/nginxconfig/ssl/${var.DOMAIN_CERT_PREFIX}${var.BASE_DOMAIN}.key.pem") ? file("${path.module}/volumes/nginxconfig/ssl/${var.DOMAIN_CERT_PREFIX}${var.BASE_DOMAIN}.key.pem") : ""
+    file    = "/etc/nginx/ssl/${var.DOMAIN_CERT_PREFIX}${var.BASE_DOMAIN}.key.pem"
+  }
+}

--- a/terraform/plugins/definitions/WithPortainer.tf
+++ b/terraform/plugins/definitions/WithPortainer.tf
@@ -1,0 +1,33 @@
+resource "docker_image" "portainer" {
+  name         = "cr.portainer.io/portainer/portainer-ce:latest"
+  keep_locally = true
+  count        = var.USE_PORTAINER ? 1 : 0
+}
+
+resource "docker_volume" "portainer_data" {
+  name  = "portainer-data"
+  count = var.USE_PORTAINER ? 1 : 0
+}
+
+resource "docker_container" "portainer" {
+  image   = "cr.portainer.io/portainer/portainer-ce:latest"
+  name    = "portainer"
+  count   = var.USE_PORTAINER ? 1 : 0
+  restart = "always"
+  ports {
+    internal = 9000
+    external = 9000
+  }
+
+  mounts {
+    source = docker_volume.portainer_data[0].name
+    target = "/data"
+    type   = "volume"
+  }
+
+  mounts {
+    source = "/var/run/docker.sock"
+    target = "/var/run/docker.sock"
+    type   = "bind"
+  }
+}

--- a/terraform/plugins/definitions/WithWatchtower.tf
+++ b/terraform/plugins/definitions/WithWatchtower.tf
@@ -1,0 +1,49 @@
+resource "docker_volume" "watchtower_config" {
+  name  = "watchtower-config"
+  count = var.USE_WATCHTOWER ? 1 : 0
+}
+
+resource "docker_image" "watchtower" {
+  name         = "containrrr/watchtower:latest"
+  keep_locally = true
+  count        = var.USE_WATCHTOWER ? 1 : 0
+}
+
+resource "docker_container" "watchtower" {
+  count = var.USE_WATCHTOWER ? 1 : 0
+  image = "containrrr/watchtower:latest"
+  name  = "watchtower"
+  ports {
+    internal = 8080
+    external = 8091
+  }
+
+  mounts {
+    source    = "/var/run/docker.sock"
+    target    = "/var/run/docker.sock"
+    type      = "bind"
+    read_only = true
+  }
+
+  mounts {
+    source = docker_volume.watchtower_config[0].name
+    target = "/config"
+    type   = "volume"
+  }
+
+  upload {
+    content = templatefile(abspath("${path.module}/volumes/watchtower/config.json.tpl"), {
+      GHCR_IO_TOKEN = var.GHCR_IO_TOKEN,
+    })
+    file = "/config/config.json"
+  }
+
+  env = [
+    "WATCHTOWER_CLEANUP=true",
+    "WATCHTOWER_DEBUG=true",
+    "WATCHTOWER_INCLUDE_STOPPED=true",
+    "DOCKER_CONFIG=/config",
+    "HTTP-API-UPDATE=true",
+    "WATCHTOWER_HTTP_API_TOKEN=${random_password.WATCHTOWER_HTTP_API_TOKEN.result}",
+  ]
+}

--- a/terraform/plugins/definitions/dotenv.tf.example
+++ b/terraform/plugins/definitions/dotenv.tf.example
@@ -1,0 +1,13 @@
+# This token should be sent in requests to Watchtower HTTP API to trigger an image and container update
+# To retrieve this value, check the environmental variables of the Watchtower container
+resource "random_password" "WATCHTOWER_HTTP_API_TOKEN" {
+  length  = 128
+  special = false
+}
+
+variable "GHCR_IO_TOKEN" {
+  description = "If you're pulling images from Github Container Registry, set your token here (https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry)"
+  type        = string
+  default     = ""
+  sensitive   = true
+}

--- a/terraform/plugins/definitions/provider.tf
+++ b/terraform/plugins/definitions/provider.tf
@@ -1,0 +1,28 @@
+terraform {
+  required_providers {
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "~> 2.16.0"
+    }
+  }
+}
+
+# DO NOT MODIFY ANYTHING ABOVE THIS LINE
+
+variable "USE_PORTAINER" {
+  type        = bool
+  default     = false
+  description = "Set default to true if you want to add portainer to the deployment"
+}
+
+variable "USE_WATCHTOWER" {
+  type        = bool
+  default     = false
+  description = "Set default to true if you want to add watchtower to the deployment"
+}
+
+variable "USE_NGINX" {
+  type        = bool
+  default     = false
+  description = "Set default to true if you want to add nginx to the deployment"
+}

--- a/terraform/plugins/definitions/volumes/nginxconfig/conf.d/default.conf.tpl
+++ b/terraform/plugins/definitions/volumes/nginxconfig/conf.d/default.conf.tpl
@@ -1,0 +1,70 @@
+# REQUIRED TEMPLATE VARIABLES
+# ------------------------------------------------------------------------------
+# BASE_DOMAIN
+#  - This would be the domain of your site - e.g. example.com
+# 
+# SUPABASE_SUBDOMAIN
+# - This would be the subdomain of your site where you want to access the supabase stack - e.g. For data.example.com, this value would be 'data'
+# - You should NOT provide the dot at the end of the subdomain
+# 
+# DOMAIN_CERT_PREFIX
+# - This is the prefix applied to the filename of SSL certs and keys
+# - e.g. cloudflare for example.com would use the files `cloudflare.example.com.cert.pem` and `cloudflare.example.com.key.pem`
+# - YOU MUST INCLUDE THE . AFTER THE PREFIX IF USING THIS OPTION AS IT IS NOT ADDED AUTOMATICALLY
+# 
+# KONG_URL
+# - This is the URL of your Kong instance
+# - Default is usually supabase-kong but the value should not be hard-coded into this file and MUST be passed in as an argument
+# 
+# KONG_PORT
+# - This is the port of your Kong instance
+# - Default is usually 8000 but the value should not be hard-coded into this file and MUST be passed in as an argument
+# 
+# NGINX_USE_SSL
+# - This is a boolean value that determines whether or not to use SSL
+# - The default is false but the value should not be hard-coded into this file and MUST be passed in as an argument
+# - It is *strongly* recommended that you use SSL when hosting on the web
+
+server {
+	listen ${NGINX_USE_SSL ? "443 ssl" : "80"};
+	server_name ${SUPABASE_SUBDOMAIN}.${BASE_DOMAIN};
+	${NGINX_USE_SSL ? "ssl_certificate ssl/${DOMAIN_CERT_PREFIX}${BASE_DOMAIN}.cert.pem;" : ""}
+	${NGINX_USE_SSL ? "ssl_certificate_key ssl/${DOMAIN_CERT_PREFIX}${BASE_DOMAIN}.key.pem;" : ""}
+
+	# REST
+	location ~ ^/rest/v1/(.*)$ {
+					proxy_set_header Host $host;
+					proxy_pass http://${KONG_URL}:${KONG_PORT};
+					proxy_redirect off;
+	}
+
+	# AUTH
+	location ~ ^/auth/v1/(.*)$ {
+					proxy_set_header Host $host;
+					proxy_pass http://${KONG_URL}:${KONG_PORT};
+					proxy_redirect off;
+	}
+
+	# REALTIME
+	location ~ ^/realtime/v1/(.*)$ {
+					proxy_redirect off;
+					proxy_pass http://${KONG_URL}:${KONG_PORT};
+					proxy_http_version 1.1;
+					proxy_set_header Upgrade $http_upgrade;
+					proxy_set_header Connection $connection_upgrade;
+					proxy_set_header Host $host;
+	}
+
+	# PG META - USED BY STUDIO
+	location ~ ^/pg-meta/(.*)$ {
+					proxy_set_header host $host;
+					proxy_pass http://${KONG_URL}:${KONG_PORT};
+					proxy_redirect off;
+	}
+
+	location ~ ^/storage/v1/(.*)$ {
+					proxy_set_header Host $host;
+					proxy_pass http://${KONG_URL}:${KONG_PORT};
+					proxy_redirect off;
+	}
+}

--- a/terraform/plugins/definitions/volumes/nginxconfig/nginx.conf
+++ b/terraform/plugins/definitions/volumes/nginxconfig/nginx.conf
@@ -1,0 +1,37 @@
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log notice;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        '' close;
+    }
+
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '[$time_local] CLOUDFLARE IP: $remote_addr --REMOTE_IP--> "$http_x_forwarded_for" (REAL IP: "$http_CF_Connecting_IP") (COUNTRY: $http_cf_ipcountry),  REQUEST: $http_referer --> "$request", '
+                      'STATUS: $status, BYTES: $body_bytes_sent, '
+                      'USER AGENT: "$http_user_agent"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/terraform/plugins/definitions/volumes/nginxconfig/ssl/add_ssl_certs_here.md
+++ b/terraform/plugins/definitions/volumes/nginxconfig/ssl/add_ssl_certs_here.md
@@ -1,0 +1,12 @@
+Place your SSL certificates and keys in this folder
+
+For example, with a cloudflare-based setup, you would have the following files in this folder:
+
+- cloudflare.example.com.cert.pem
+- cloudflare.example.com.key.pem
+
+You should ensure that the files have `.key.pem` (private key) and `.cert.pem` (certificate) at the end as demonstated above
+
+**NEVER, EVER, EVER COMMIT YOUR CERTS OR KEYS TO SOURCE CONTROL!**
+
+The gitignore in this repo ensures that `.pem` files are not committed automatically and you definitely should **not** change this.

--- a/terraform/plugins/definitions/volumes/watchtower/config.json.tpl
+++ b/terraform/plugins/definitions/volumes/watchtower/config.json.tpl
@@ -1,0 +1,7 @@
+{
+  "auths": {
+    "ghcr.io": {
+      "auth": "${GHCR_IO_TOKEN}"
+    }
+  }
+}

--- a/terraform/plugins/main.tf
+++ b/terraform/plugins/main.tf
@@ -1,0 +1,3 @@
+module "PluginDefinitions" {
+  source = "./definitions"
+}

--- a/terraform/supabase/definitions/docker.containers.tf
+++ b/terraform/supabase/definitions/docker.containers.tf
@@ -1,0 +1,426 @@
+module "generate_jwt_anon_key" {
+  source  = "github.com/matti/terraform-shell-resource"
+  command = "docker run --rm ghcr.io/chronsyn/docker-jwt-generator:master -e --role=\"anon\" --secret=\"'${random_password.JWT_SECRET.result}'\" --issuer=\"supabase\""
+}
+
+module "generate_jwt_service_role_key" {
+  source  = "github.com/matti/terraform-shell-resource"
+  command = "docker run --rm ghcr.io/chronsyn/docker-jwt-generator:master -e --role=\"service_role\" --secret=\"'${random_password.JWT_SECRET.result}'\" --issuer=\"supabase\""
+}
+
+resource "docker_volume" "pg_data" {
+  name = "pg_data"
+  lifecycle {
+    prevent_destroy       = false
+    create_before_destroy = true
+  }
+}
+
+resource "docker_volume" "pg_init" {
+  name = "pg_init"
+}
+
+resource "docker_volume" "pg_config" {
+  name = "pg_config"
+  lifecycle {
+    prevent_destroy       = false
+    create_before_destroy = true
+  }
+}
+
+resource "docker_volume" "kong_data" {
+  name = "kong_data"
+}
+
+resource "docker_volume" "storage_data" {
+  name  = "storage_data"
+  count = var.ENABLE_STORAGE ? 1 : 0
+  lifecycle {
+    prevent_destroy       = false
+    create_before_destroy = true
+  }
+}
+
+resource "docker_network" "supabase-network" {
+  name = "supabase-network"
+}
+
+resource "docker_container" "supabase-postgres" {
+  image = docker_image.supabase-postgres.name
+  name  = var.POSTGRES_HOST
+  ports {
+    internal = var.POSTGRES_PORT
+    external = var.POSTGRES_PORT
+  }
+  networks_advanced {
+    name    = "supabase-network"
+    aliases = ["db"]
+  }
+  env = [
+    "POSTGRES_PASSWORD=${random_password.POSTGRES_PASSWORD.result}",
+    "PGDATA=/var/lib/postgresql/data"
+  ]
+  command = ["postgres", "-c", "config-file=/etc/postgresql/postgresql.conf"]
+  restart = "unless-stopped"
+
+  mounts {
+    source = docker_volume.pg_data.name
+    target = "/var/lib/postgresql/data"
+    type   = "volume"
+  }
+
+  # remove_volumes = false
+
+  mounts {
+    source = docker_volume.pg_config.name
+    target = "/etc/postgresql"
+    type   = "volume"
+  }
+
+  # The file located at volumes/db/config/postgresql.conf will be uploaded into the 'pg_config' volume
+  # You can customise this file and then run 'terraform apply' to apply the updated config
+  upload {
+    source = "${path.module}/volumes/db/config/postgresql.conf"
+    file   = "/etc/postgresql/postgresql.conf"
+  }
+
+  # Create a place to upload our initialisation scripts
+  # These will be run after the container is started
+  mounts {
+    source = docker_volume.pg_init.name
+    target = "/home/init"
+    type   = "volume"
+  }
+
+  # Upload our init scripts
+  upload {
+    content = file("${path.module}/volumes/db/init/sql/00-initial-schema.sql")
+    file    = "/home/init/00-initial-schema.sql"
+  }
+
+  upload {
+    content = file("${path.module}/volumes/db/init/sql/01-auth-schema.sql")
+    file    = "/home/init/01-auth-schema.sql"
+  }
+
+  upload {
+    content = file("${path.module}/volumes/db/init/sql/02-storage-schema.sql")
+    file    = "/home/init/02-storage-schema.sql"
+  }
+
+  upload {
+    content = file("${path.module}/volumes/db/init/sql/03-post-setup.sql")
+    file    = "/home/init/03-post-setup.sql"
+  }
+}
+
+resource "docker_container" "supabase-studio" {
+  image = docker_image.supabase-studio.name
+  name  = "supabase-studio"
+  depends_on = [
+    docker_container.supabase-postgres
+  ]
+  ports {
+    internal = 3000
+    external = 2500
+  }
+  networks_advanced {
+    name    = "supabase-network"
+    aliases = ["studio"]
+  }
+  env = [
+    # You should not change this as Nginx plugin relies on the service being accessible at this location
+    "SUPABASE_URL=http://kong:8000",
+    "STUDIO_PG_META_URL=http://${var.META_URL}:${var.META_PORT}",
+  ]
+}
+
+resource "docker_container" "supabase-kong" {
+  image = docker_image.supabase-kong.name
+  name  = "supabase-kong"
+
+  networks_advanced {
+    name    = "supabase-network"
+    aliases = ["kong"]
+  }
+  ports {
+    internal = 8000
+    external = 8000
+  }
+  ports {
+    internal = 8443
+    external = 8443
+  }
+  restart = "unless-stopped"
+  env = [
+    "KONG_DATABASE=off",
+    "KONG_DECLARATIVE_CONFIG=/var/lib/kong/kong.yml",
+    "KONG_DNS_ORDER=LAST,A,CNAME",
+    "KONG_PLUGINS=request-transformer,cors,key-auth,acl"
+  ]
+
+  upload {
+    content = templatefile(abspath("${path.module}/volumes/api/kong.tpl"), {
+      ANON_KEY   = module.generate_jwt_anon_key.stdout,
+      SECRET_KEY = module.generate_jwt_service_role_key.stdout,
+      META_URL   = var.META_URL,
+      META_PORT  = var.META_PORT,
+    })
+    file = "/var/lib/kong/kong.yml"
+  }
+
+  mounts {
+    source = docker_volume.kong_data.name
+    target = "/var/lib/kong"
+    type   = "volume"
+  }
+}
+
+resource "docker_container" "pg-meta" {
+  image = docker_image.pg-meta.name
+  name  = "pg-meta"
+  depends_on = [
+    docker_container.supabase-postgres
+  ]
+  ports {
+    internal = 8080
+    external = 8080
+  }
+  networks_advanced {
+    name    = "supabase-network"
+    aliases = ["meta"]
+  }
+  env = [
+    "PG_META_PORT=${var.META_PORT}",
+    "PG_META_DB_HOST=${var.POSTGRES_HOST}",
+    "PG_META_DB_PASSWORD=${random_password.POSTGRES_PASSWORD.result}",
+  ]
+}
+
+resource "docker_container" "supabase-realtime" {
+  image = docker_image.supabase-realtime.name
+  name  = "supabase-realtime"
+  depends_on = [
+    docker_container.supabase-postgres,
+    null_resource.db_setup_03
+  ]
+  ports {
+    internal = 4000
+    external = 4000
+  }
+  networks_advanced {
+    name    = "supabase-network"
+    aliases = ["realtime"]
+  }
+  env = [
+    "DB_HOST=${var.POSTGRES_HOST}",
+    "DB_PORT=${var.POSTGRES_PORT}",
+    "DB_NAME=${var.POSTGRES_DB}",
+    "DB_USER=${var.POSTGRES_USER}",
+    "DB_PASSWORD=${random_password.POSTGRES_PASSWORD.result}",
+    "DB_SSL=false",
+    "PORT=4000",
+    "JWT_SECRET=${random_password.JWT_SECRET.result}",
+    "REPLICATION_MODE=RLS",
+    "REPLICATION_POLL_INTERVAL=300",
+    "SECURE_CHANNELS=true",
+    "SLOT_NAME=supabase_realtime_rls",
+    "TEMPORARY_SLOT=true",
+  ]
+
+
+  restart = "unless-stopped"
+  command = [
+    "bash",
+    "-c",
+    "./prod/rel/realtime/bin/realtime eval Realtime.Release.migrate && ./prod/rel/realtime/bin/realtime start"
+  ]
+}
+
+resource "docker_container" "supabase-storage" {
+  image = docker_image.supabase-storage[0].name
+  name  = "supabase-storage"
+  count = var.ENABLE_STORAGE ? 1 : 0
+  depends_on = [
+    docker_container.supabase-postgres,
+    docker_container.supabase-rest,
+    null_resource.db_setup_03
+  ]
+  ports {
+    internal = 5000
+    external = 5000
+  }
+  networks_advanced {
+    name    = "supabase-network"
+    aliases = ["storage"]
+  }
+  mounts {
+    source = docker_volume.storage_data[0].name
+    target = "/var/lib/storage"
+    type   = "volume"
+  }
+  env = [
+    "ANON_KEY=${module.generate_jwt_anon_key.stdout}",
+    "SERVICE_KEY=${module.generate_jwt_service_role_key.stdout}",
+    "POSTGREST_URL=http://rest:3000",
+    "PGRST_JWT_SECRET=${random_password.JWT_SECRET.result}",
+    "DATABASE_URL=postgres://${var.POSTGRES_USER}:${random_password.POSTGRES_PASSWORD.result}@${var.POSTGRES_HOST}:${var.POSTGRES_PORT}/postgres",
+    "PGOPTIONS=-c search_path=storage,public",
+    "FILE_SIZE_LIMIT=52428800", // Value in bytes
+    "STORAGE_BACKEND=file",
+    "FILE_STORAGE_BACKEND_PATH=/var/lib/storage",
+    "TENANT_ID=stub",
+    "REGION=stub",
+    "GLOBAL_S3_BUCKET=stub",
+  ]
+}
+
+resource "docker_container" "supabase-auth" {
+  image = docker_image.supabase-auth.name
+  name  = "supabase-auth"
+  depends_on = [
+    docker_container.supabase-postgres,
+    null_resource.db_setup_03
+  ]
+  restart = "unless-stopped"
+  ports {
+    internal = 9999
+    external = 9999
+  }
+  networks_advanced {
+    name    = "supabase-network"
+    aliases = ["auth"]
+  }
+  env = [
+    "GOTRUE_API_HOST=0.0.0.0",
+    "GOTRUE_API_PORT=9999",
+    "GOTRUE_DB_DRIVER=postgres",
+    "GOTRUE_DB_DATABASE_URL=postgres://${var.POSTGRES_USER}:${random_password.POSTGRES_PASSWORD.result}@${var.POSTGRES_HOST}:${var.POSTGRES_PORT}/${var.POSTGRES_DB}?search_path=auth",
+    "GOTRUE_SITE_URL=${var.SITE_URL}",
+    "GOTRUE_URI_ALLOW_LIST=${var.ADDITIONAL_REDIRECT_URLS}",
+    "GOTRUE_DISABLE_SIGNUP=${var.DISABLE_SIGNUP}",
+    "GOTRUE_JWT_SECRET=${random_password.JWT_SECRET.result}",
+    "GOTRUE_JWT_EXPIRY=${var.JWT_EXPIRY}",
+    "GOTRUE_JWT_DEFAULT_GROUP_NAME=authenticated",
+    "GOTRUE_EXTERNAL_EMAIL_ENABLED=${var.ENABLE_EMAIL_SIGNUP}",
+    "GOTRUE_MAILER_AUTOCONFIRM=${var.ENABLE_EMAIL_AUTOCONFIRM}",
+    "API_EXTERNAL_URL=${var.API_EXTERNAL_URL}",
+    "GOTRUE_MAILER_TEMPLATES_INVITE=${var.EMAIL_INVITE_TEMPLATE_URL}",
+    "GOTRUE_MAILER_TEMPLATES_CONFIRMATION=${var.EMAIL_CONFIRMATION_TEMPLATE_URL}",
+    "GOTRUE_MAILER_TEMPLATES_RECOVERY=${var.EMAIL_RECOVERY_TEMPLATE_URL}",
+    "GOTRUE_MAILER_TEMPLATES_MAGIC_LINK=${var.EMAIL_MAGICLINK_TEMPLATE_URL}",
+    "GOTRUE_SMTP_HOST=${var.SMTP_HOST}",
+    "GOTRUE_SMTP_PORT=${var.SMTP_PORT}",
+    "GOTRUE_SMTP_USER=${var.SMTP_USER}",
+    "GOTRUE_SMTP_PASSWORD=${var.SMTP_PASS}",
+    "GOTRUE_SMTP_ADMIN_EMAIL=${var.SMTP_ADMIN_EMAIL}",
+    "GOTRUE_MAILER_URLPATHS_INVITE=/auth/v1/verify",
+    "GOTRUE_MAILER_URLPATHS_CONFIRMATION=/auth/v1/verify",
+    "GOTRUE_MAILER_URLPATHS_RECOVERY=/auth/v1/verify",
+    "GOTRUE_MAILER_URLPATHS_EMAIL_CHANGE=/auth/v1/verify",
+    "GOTRUE_EXTERNAL_PHONE_ENABLED=${var.ENABLE_PHONE_SIGNUP}",
+    "GOTRUE_SMS_AUTOCONFIRM=${var.ENABLE_PHONE_AUTOCONFIRM}",
+    # 
+    # 
+    # THIRD PARTY AUTH
+    # 
+    # 
+    # APPLE AUTH VARS
+    "GOTRUE_EXTERNAL_APPLE_ENABLED=${var.THIRD_PARTY_AUTH_APPLE_ENABLED}",
+    "GOTRUE_EXTERNAL_APPLE_CLIENT_ID=${var.THIRD_PARTY_AUTH_APPLE_CLIENT_ID}",
+    "GOTRUE_EXTERNAL_APPLE_SECRET=${var.THIRD_PARTY_AUTH_APPLE_SECRET}",
+    "GOTRUE_EXTERNAL_APPLE_REDIRECT_URI=${var.THIRD_PARTY_AUTH_APPLE_REDIRECT_URI}",
+    # AZURE AUTH VARS
+    "GOTRUE_EXTERNAL_AZURE_ENABLED=${var.THIRD_PARTY_AUTH_AZURE_ENABLED}",
+    "GOTRUE_EXTERNAL_AZURE_CLIENT_ID=${var.THIRD_PARTY_AUTH_AZURE_CLIENT_ID}",
+    "GOTRUE_EXTERNAL_AZURE_SECRET=${var.THIRD_PARTY_AUTH_AZURE_SECRET}",
+    "GOTRUE_EXTERNAL_AZURE_REDIRECT_URI=${var.THIRD_PARTY_AUTH_AZURE_REDIRECT_URI}",
+    # BITBUCKET AUTH VARS
+    "GOTRUE_EXTERNAL_BITBUCKET_ENABLED=${var.THIRD_PARTY_AUTH_BITBUCKET_ENABLED}",
+    "GOTRUE_EXTERNAL_BITBUCKET_CLIENT_ID=${var.THIRD_PARTY_AUTH_BITBUCKET_CLIENT_ID}",
+    "GOTRUE_EXTERNAL_BITBUCKET_SECRET=${var.THIRD_PARTY_AUTH_BITBUCKET_SECRET}",
+    "GOTRUE_EXTERNAL_BITBUCKET_REDIRECT_URI=${var.THIRD_PARTY_AUTH_BITBUCKET_REDIRECT_URI}",
+    # DISCORD AUTH VARS
+    "GOTRUE_EXTERNAL_DISCORD_ENABLED=${var.THIRD_PARTY_AUTH_DISCORD_ENABLED}",
+    "GOTRUE_EXTERNAL_DISCORD_CLIENT_ID=${var.THIRD_PARTY_AUTH_DISCORD_CLIENT_ID}",
+    "GOTRUE_EXTERNAL_DISCORD_SECRET=${var.THIRD_PARTY_AUTH_DISCORD_SECRET}",
+    "GOTRUE_EXTERNAL_DISCORD_REDIRECT_URI=${var.THIRD_PARTY_AUTH_DISCORD_REDIRECT_URI}",
+    # FACEBOOK AUTH VARS
+    "GOTRUE_EXTERNAL_FACEBOOK_ENABLED=${var.THIRD_PARTY_AUTH_FACEBOOK_ENABLED}",
+    "GOTRUE_EXTERNAL_FACEBOOK_CLIENT_ID=${var.THIRD_PARTY_AUTH_FACEBOOK_CLIENT_ID}",
+    "GOTRUE_EXTERNAL_FACEBOOK_SECRET=${var.THIRD_PARTY_AUTH_FACEBOOK_SECRET}",
+    "GOTRUE_EXTERNAL_FACEBOOK_REDIRECT_URI=${var.THIRD_PARTY_AUTH_FACEBOOK_REDIRECT_URI}",
+    # GITHUB AUTH VARS
+    "GOTRUE_EXTERNAL_GITHUB_ENABLED=${var.THIRD_PARTY_AUTH_GITHUB_ENABLED}",
+    "GOTRUE_EXTERNAL_GITHUB_CLIENT_ID=${var.THIRD_PARTY_AUTH_GITHUB_CLIENT_ID}",
+    "GOTRUE_EXTERNAL_GITHUB_SECRET=${var.THIRD_PARTY_AUTH_GITHUB_SECRET}",
+    "GOTRUE_EXTERNAL_GITHUB_REDIRECT_URI=${var.THIRD_PARTY_AUTH_GITHUB_REDIRECT_URI}",
+    # GITLAB AUTH VARS
+    "GOTRUE_EXTERNAL_GITLAB_ENABLED=${var.THIRD_PARTY_AUTH_GITLAB_ENABLED}",
+    "GOTRUE_EXTERNAL_GITLAB_CLIENT_ID=${var.THIRD_PARTY_AUTH_GITLAB_CLIENT_ID}",
+    "GOTRUE_EXTERNAL_GITLAB_SECRET=${var.THIRD_PARTY_AUTH_GITLAB_SECRET}",
+    "GOTRUE_EXTERNAL_GITLAB_REDIRECT_URI=${var.THIRD_PARTY_AUTH_GITLAB_REDIRECT_URI}",
+    # GOOGLE AUTH VARS
+    "GOTRUE_EXTERNAL_GOOGLE_ENABLED=${var.THIRD_PARTY_AUTH_GOOGLE_ENABLED}",
+    "GOTRUE_EXTERNAL_GOOGLE_CLIENT_ID=${var.THIRD_PARTY_AUTH_GOOGLE_CLIENT_ID}",
+    "GOTRUE_EXTERNAL_GOOGLE_SECRET=${var.THIRD_PARTY_AUTH_GOOGLE_SECRET}",
+    "GOTRUE_EXTERNAL_GOOGLE_REDIRECT_URI=${var.THIRD_PARTY_AUTH_GOOGLE_REDIRECT_URI}",
+    # LINKEDIN AUTH VARS
+    "GOTRUE_EXTERNAL_LINKEDIN_ENABLED=${var.THIRD_PARTY_AUTH_LINKEDIN_ENABLED}",
+    "GOTRUE_EXTERNAL_LINKEDIN_CLIENT_ID=${var.THIRD_PARTY_AUTH_LINKEDIN_CLIENT_ID}",
+    "GOTRUE_EXTERNAL_LINKEDIN_SECRET=${var.THIRD_PARTY_AUTH_LINKEDIN_SECRET}",
+    "GOTRUE_EXTERNAL_LINKEDIN_REDIRECT_URI=${var.THIRD_PARTY_AUTH_LINKEDIN_REDIRECT_URI}",
+    # NOTION AUTH VARS
+    "GOTRUE_EXTERNAL_NOTION_ENABLED=${var.THIRD_PARTY_AUTH_NOTION_ENABLED}",
+    "GOTRUE_EXTERNAL_NOTION_CLIENT_ID=${var.THIRD_PARTY_AUTH_NOTION_CLIENT_ID}",
+    "GOTRUE_EXTERNAL_NOTION_SECRET=${var.THIRD_PARTY_AUTH_NOTION_SECRET}",
+    "GOTRUE_EXTERNAL_NOTION_REDIRECT_URI=${var.THIRD_PARTY_AUTH_NOTION_REDIRECT_URI}",
+    # SPOTIFY AUTH VARS
+    "GOTRUE_EXTERNAL_SPOTIFY_ENABLED=${var.THIRD_PARTY_AUTH_SPOTIFY_ENABLED}",
+    "GOTRUE_EXTERNAL_SPOTIFY_CLIENT_ID=${var.THIRD_PARTY_AUTH_SPOTIFY_CLIENT_ID}",
+    "GOTRUE_EXTERNAL_SPOTIFY_SECRET=${var.THIRD_PARTY_AUTH_SPOTIFY_SECRET}",
+    "GOTRUE_EXTERNAL_SPOTIFY_REDIRECT_URI=${var.THIRD_PARTY_AUTH_SPOTIFY_REDIRECT_URI}",
+    # SLACK AUTH VARS
+    "GOTRUE_EXTERNAL_SLACK_ENABLED=${var.THIRD_PARTY_AUTH_SLACK_ENABLED}",
+    "GOTRUE_EXTERNAL_SLACK_CLIENT_ID=${var.THIRD_PARTY_AUTH_SLACK_CLIENT_ID}",
+    "GOTRUE_EXTERNAL_SLACK_SECRET=${var.THIRD_PARTY_AUTH_SLACK_SECRET}",
+    "GOTRUE_EXTERNAL_SLACK_REDIRECT_URI=${var.THIRD_PARTY_AUTH_SLACK_REDIRECT_URI}",
+    # TWITCH AUTH VARS
+    "GOTRUE_EXTERNAL_TWITCH_ENABLED=${var.THIRD_PARTY_AUTH_TWITCH_ENABLED}",
+    "GOTRUE_EXTERNAL_TWITCH_CLIENT_ID=${var.THIRD_PARTY_AUTH_TWITCH_CLIENT_ID}",
+    "GOTRUE_EXTERNAL_TWITCH_SECRET=${var.THIRD_PARTY_AUTH_TWITCH_SECRET}",
+    "GOTRUE_EXTERNAL_TWITCH_REDIRECT_URI=${var.THIRD_PARTY_AUTH_TWITCH_REDIRECT_URI}",
+    # TWITTER AUTH VARS
+    "GOTRUE_EXTERNAL_TWITTER_ENABLED=${var.THIRD_PARTY_AUTH_TWITTER_ENABLED}",
+    "GOTRUE_EXTERNAL_TWITTER_CLIENT_ID=${var.THIRD_PARTY_AUTH_TWITTER_CLIENT_ID}",
+    "GOTRUE_EXTERNAL_TWITTER_SECRET=${var.THIRD_PARTY_AUTH_TWITTER_SECRET}",
+    "GOTRUE_EXTERNAL_TWITTER_REDIRECT_URI=${var.THIRD_PARTY_AUTH_TWITTER_REDIRECT_URI}"
+  ]
+
+  command = ["gotrue"]
+}
+
+resource "docker_container" "supabase-rest" {
+  image = docker_image.supabase-rest.name
+  name  = "supabase-rest"
+  depends_on = [
+    docker_container.supabase-postgres
+  ]
+  ports {
+    internal = 3000
+    external = 3000
+  }
+  networks_advanced {
+    name    = "supabase-network"
+    aliases = ["rest"]
+  }
+  env = [
+    "PGRST_DB_URI=postgres://${var.POSTGRES_USER}:${random_password.POSTGRES_PASSWORD.result}@${var.POSTGRES_HOST}:${var.POSTGRES_PORT}/${var.POSTGRES_DB}",
+    "PGRST_DB_SCHEMAS=public,storage",
+    "PGRST_DB_ANON_ROLE=anon",
+    "PGRST_JWT_SECRET=${random_password.JWT_SECRET.result}",
+    "PGRST_DB_USE_LEGACY_GUCS=false"
+  ]
+  command = ["/bin/postgrest"]
+  restart = "unless-stopped"
+}

--- a/terraform/supabase/definitions/docker.images.tf
+++ b/terraform/supabase/definitions/docker.images.tf
@@ -1,0 +1,46 @@
+resource "docker_image" "supabase-postgres" {
+  name         = "supabase/postgres:latest"
+  keep_locally = true
+}
+
+resource "docker_image" "supabase-storage" {
+  name         = "supabase/storage-api:latest"
+  keep_locally = true
+  count        = var.ENABLE_STORAGE ? 1 : 0
+}
+
+resource "docker_image" "supabase-studio" {
+  name         = "supabase/studio:latest"
+  keep_locally = true
+}
+
+resource "docker_image" "supabase-kong" {
+  name         = "kong:2.1"
+  keep_locally = true
+}
+
+resource "docker_image" "pg-meta" {
+  name         = "supabase/postgres-meta:latest"
+  keep_locally = true
+}
+
+resource "docker_image" "supabase-realtime" {
+  name         = "supabase/realtime:latest"
+  keep_locally = true
+}
+
+resource "docker_image" "supabase-rest" {
+  name         = "postgrest/postgrest:latest"
+  keep_locally = true
+}
+
+resource "docker_image" "supabase-auth" {
+  name         = "supabase/gotrue:latest"
+  keep_locally = true
+}
+
+# Used to generate JWT's during intial setup
+resource "docker_image" "jwt-generator" {
+  name         = "ghcr.io/chronsyn/docker-jwt-generator:master"
+  keep_locally = true
+}

--- a/terraform/supabase/definitions/dotenv.tf.example
+++ b/terraform/supabase/definitions/dotenv.tf.example
@@ -1,0 +1,174 @@
+
+# Security config
+
+# We will automatically generate a secure password for Postgres
+resource "random_password" "POSTGRES_PASSWORD" {
+  length  = 96
+  special = false
+}
+
+# We will automatically generate a JWT secret
+resource "random_password" "JWT_SECRET" {
+  length  = 64
+  special = false
+}
+
+variable "JWT_EXPIRY" {
+  type    = number
+  default = 3600
+}
+
+# API Config
+variable "ADDITIONAL_REDIRECT_URLS" {
+  type        = string
+  default     = ""
+  description = "CHANGE THIS BEFORE DEPLOYING - Comma separated list of additional redirect urls. Valid examples: https://example.com/reset-password,https://example.com/magiclink-login,https://example.com/signup-complete,myapp://some/deep/link"
+}
+
+variable "SITE_URL" {
+  type        = string
+  default     = "example.com"
+  description = "CHANGE THIS BEFORE DEPLOYING - The base domain for your site without subdomains OR protocols (e.g. example.com is correct, sub.example.com is incorrect, https://example.com is incorrect)"
+}
+
+variable "API_EXTERNAL_URL" {
+  type        = string
+  default     = "https://api.example.com"
+  description = "CHANGE THIS BEFORE DEPLOYING - What is the URL that your supabase instance is accessible at? For example, where can we access https://api.example.com/rest/v1, https://api.example.com/auth/v1, etc.?"
+}
+
+# Email config
+
+variable "SMTP_ADMIN_EMAIL" {
+  type        = string
+  default     = "admin@example.com"
+  description = "CHANGE THIS BEFORE DEPLOYING"
+}
+
+variable "SMTP_HOST" {
+  type        = string
+  default     = "smtp.example.com"
+  description = "CHANGE THIS BEFORE DEPLOYING"
+}
+
+variable "SMTP_PORT" {
+  type        = number
+  default     = 2500
+  description = "CHANGE THIS BEFORE DEPLOYING"
+}
+
+variable "SMTP_USER" {
+  type        = string
+  default     = "fake_mail_user"
+  description = "CHANGE THIS BEFORE DEPLOYING"
+}
+
+variable "SMTP_PASS" {
+  type        = string
+  default     = "fake_mail_pass"
+  description = "CHANGE THIS BEFORE DEPLOYING"
+}
+
+variable "SMTP_SENDER_NAME" {
+  type        = string
+  default     = "fake_sender"
+  description = "CHANGE THIS BEFORE DEPLOYING"
+}
+
+
+# Postgres connection config
+variable "POSTGRES_HOST" {
+  type    = string
+  default = "db"
+}
+
+variable "POSTGRES_PORT" {
+  type    = number
+  default = 5432
+}
+
+variable "POSTGRES_USER" {
+  type      = string
+  default   = "postgres"
+  sensitive = true
+}
+
+variable "POSTGRES_DB" {
+  type    = string
+  default = "postgres"
+}
+
+
+# Meta config
+variable "META_URL" {
+  type        = string
+  default     = "meta"
+  description = "Combines with META_HTTP_PORT to form the Meta URL"
+}
+
+variable "META_PORT" {
+  type    = number
+  default = 8080
+}
+
+# Studio config
+variable "STUDIO_PORT" {
+  type    = number
+  default = 3000
+}
+
+# Misc config
+variable "DISABLE_SIGNUP" {
+  type    = bool
+  default = false
+}
+
+variable "ENABLE_EMAIL_SIGNUP" {
+  type    = bool
+  default = true
+}
+
+variable "ENABLE_EMAIL_AUTOCONFIRM" {
+  type    = bool
+  default = true
+}
+
+variable "ENABLE_PHONE_SIGNUP" {
+  type    = bool
+  default = false
+}
+
+variable "ENABLE_PHONE_AUTOCONFIRM" {
+  type    = bool
+  default = false
+}
+
+variable "EMAIL_INVITE_TEMPLATE_URL" {
+  type        = string
+  default     = ""
+  description = "A URL which points towards a HTML template for inviting users"
+}
+
+variable "EMAIL_CONFIRMATION_TEMPLATE_URL" {
+  type        = string
+  default     = ""
+  description = "A URL which points towards a HTML template to allow users to confirm their account"
+}
+
+variable "EMAIL_RECOVERY_TEMPLATE_URL" {
+  type        = string
+  default     = ""
+  description = "A URL which points towards a HTML template to allow users to recover their account"
+}
+
+variable "EMAIL_MAGICLINK_TEMPLATE_URL" {
+  type        = string
+  default     = ""
+  description = "A URL which points towards a HTML template which allows users to login with a magic link"
+}
+
+variable "ENABLE_STORAGE" {
+  type        = bool
+  default     = true
+  description = "Set this to false if you don't want the Supabase storage container to be created"
+}

--- a/terraform/supabase/definitions/init-postgres.tf
+++ b/terraform/supabase/definitions/init-postgres.tf
@@ -1,0 +1,48 @@
+resource "time_sleep" "sleep_wait" {
+  depends_on = [docker_container.supabase-postgres]
+
+  create_duration = "20s"
+}
+
+resource "null_resource" "db_setup_00" {
+  provisioner "local-exec" {
+    command = "docker exec -e PGPASSWORD=${random_password.POSTGRES_PASSWORD.result} -i ${var.POSTGRES_HOST} psql -h ${var.POSTGRES_HOST} -p ${var.POSTGRES_PORT} -U ${var.POSTGRES_USER} -d ${var.POSTGRES_DB} -f \"/home/init/00-initial-schema.sql\""
+  }
+  depends_on = [
+    docker_container.supabase-postgres,
+    time_sleep.sleep_wait
+  ]
+}
+
+resource "null_resource" "db_setup_01" {
+  provisioner "local-exec" {
+    command = "docker exec -e PGPASSWORD=${random_password.POSTGRES_PASSWORD.result} -i ${var.POSTGRES_HOST} psql -h ${var.POSTGRES_HOST} -p ${var.POSTGRES_PORT} -U ${var.POSTGRES_USER} -d ${var.POSTGRES_DB} -f \"/home/init/01-auth-schema.sql\""
+  }
+  depends_on = [
+    docker_container.supabase-postgres,
+    null_resource.db_setup_00,
+    time_sleep.sleep_wait
+  ]
+}
+
+resource "null_resource" "db_setup_02" {
+  provisioner "local-exec" {
+    command = "docker exec -e PGPASSWORD=${random_password.POSTGRES_PASSWORD.result} -i ${var.POSTGRES_HOST} psql -h ${var.POSTGRES_HOST} -p ${var.POSTGRES_PORT} -U ${var.POSTGRES_USER} -d ${var.POSTGRES_DB} -f \"/home/init/02-storage-schema.sql\""
+  }
+  depends_on = [
+    docker_container.supabase-postgres,
+    null_resource.db_setup_01,
+    time_sleep.sleep_wait
+  ]
+}
+
+resource "null_resource" "db_setup_03" {
+  provisioner "local-exec" {
+    command = "docker exec -e PGPASSWORD=${random_password.POSTGRES_PASSWORD.result} -i ${var.POSTGRES_HOST} psql -h ${var.POSTGRES_HOST} -p ${var.POSTGRES_PORT} -U ${var.POSTGRES_USER} -d ${var.POSTGRES_DB} -f \"/home/init/03-post-setup.sql\""
+  }
+  depends_on = [
+    docker_container.supabase-postgres,
+    null_resource.db_setup_02,
+    time_sleep.sleep_wait
+  ]
+}

--- a/terraform/supabase/definitions/provider.tf
+++ b/terraform/supabase/definitions/provider.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "~> 2.16.0"
+    }
+  }
+}
+
+# DO NOT MODIFY ANYTHING ABOVE THIS LINE

--- a/terraform/supabase/definitions/thirdpartyauth.dotenv.tf.example
+++ b/terraform/supabase/definitions/thirdpartyauth.dotenv.tf.example
@@ -1,0 +1,393 @@
+# Rename this file to thirdpartyauth.dotenv.tf
+# That filename is in gitignore, so you won't accidentally leak your third party auth credentials
+
+// =================================================
+// APPLE THIRD PARTY AUTH CONFIG
+// =================================================
+variable "THIRD_PARTY_AUTH_APPLE_ENABLED" {
+  type      = bool
+  default   = false
+  sensitive = false
+}
+
+variable "THIRD_PARTY_AUTH_APPLE_CLIENT_ID" {
+  type      = string
+  default   = ""
+  sensitive = true
+}
+
+variable "THIRD_PARTY_AUTH_APPLE_SECRET" {
+  type      = string
+  default   = ""
+  sensitive = true
+}
+
+variable "THIRD_PARTY_AUTH_APPLE_REDIRECT_URI" {
+  type      = string
+  default   = ""
+  sensitive = false
+}
+
+
+// =================================================
+// AZURE THIRD PARTY AUTH CONFIG
+// =================================================
+variable "THIRD_PARTY_AUTH_AZURE_ENABLED" {
+  type      = bool
+  default   = false
+  sensitive = false
+}
+
+variable "THIRD_PARTY_AUTH_AZURE_CLIENT_ID" {
+  type      = string
+  default   = ""
+  sensitive = true
+}
+
+variable "THIRD_PARTY_AUTH_AZURE_SECRET" {
+  type      = string
+  default   = ""
+  sensitive = true
+}
+
+variable "THIRD_PARTY_AUTH_AZURE_REDIRECT_URI" {
+  type      = string
+  default   = ""
+  sensitive = false
+}
+
+
+// =================================================
+// BITBUCKET THIRD PARTY AUTH CONFIG
+// =================================================
+variable "THIRD_PARTY_AUTH_BITBUCKET_ENABLED" {
+  type      = bool
+  default   = false
+  sensitive = false
+}
+
+variable "THIRD_PARTY_AUTH_BITBUCKET_CLIENT_ID" {
+  type      = string
+  default   = ""
+  sensitive = true
+}
+
+variable "THIRD_PARTY_AUTH_BITBUCKET_SECRET" {
+  type      = string
+  default   = ""
+  sensitive = true
+}
+
+variable "THIRD_PARTY_AUTH_BITBUCKET_REDIRECT_URI" {
+  type      = string
+  default   = ""
+  sensitive = false
+}
+
+
+// =================================================
+// DISCORD THIRD PARTY AUTH CONFIG
+// =================================================
+variable "THIRD_PARTY_AUTH_DISCORD_ENABLED" {
+  type      = bool
+  default   = false
+  sensitive = false
+}
+
+variable "THIRD_PARTY_AUTH_DISCORD_CLIENT_ID" {
+  type      = string
+  default   = ""
+  sensitive = true
+}
+
+variable "THIRD_PARTY_AUTH_DISCORD_SECRET" {
+  type      = string
+  default   = ""
+  sensitive = true
+}
+
+variable "THIRD_PARTY_AUTH_DISCORD_REDIRECT_URI" {
+  type      = string
+  default   = ""
+  sensitive = false
+}
+
+
+// =================================================
+// FACEBOOK THIRD PARTY AUTH CONFIG
+// =================================================
+variable "THIRD_PARTY_AUTH_FACEBOOK_ENABLED" {
+  type      = bool
+  default   = false
+  sensitive = false
+}
+
+variable "THIRD_PARTY_AUTH_FACEBOOK_CLIENT_ID" {
+  type      = string
+  default   = ""
+  sensitive = true
+}
+
+variable "THIRD_PARTY_AUTH_FACEBOOK_SECRET" {
+  type      = string
+  default   = ""
+  sensitive = true
+}
+
+variable "THIRD_PARTY_AUTH_FACEBOOK_REDIRECT_URI" {
+  type      = string
+  default   = ""
+  sensitive = false
+}
+
+
+// =================================================
+// GITHUB THIRD PARTY AUTH CONFIG
+// =================================================
+variable "THIRD_PARTY_AUTH_GITHUB_ENABLED" {
+  type      = bool
+  default   = false
+  sensitive = false
+}
+
+variable "THIRD_PARTY_AUTH_GITHUB_CLIENT_ID" {
+  type      = string
+  default   = ""
+  sensitive = true
+}
+
+variable "THIRD_PARTY_AUTH_GITHUB_SECRET" {
+  type      = string
+  default   = ""
+  sensitive = true
+}
+
+variable "THIRD_PARTY_AUTH_GITHUB_REDIRECT_URI" {
+  type      = string
+  default   = ""
+  sensitive = false
+}
+
+
+// =================================================
+// GITLAB THIRD PARTY AUTH CONFIG
+// =================================================
+variable "THIRD_PARTY_AUTH_GITLAB_ENABLED" {
+  type      = bool
+  default   = false
+  sensitive = false
+}
+
+variable "THIRD_PARTY_AUTH_GITLAB_CLIENT_ID" {
+  type      = string
+  default   = ""
+  sensitive = true
+}
+
+variable "THIRD_PARTY_AUTH_GITLAB_SECRET" {
+  type      = string
+  default   = ""
+  sensitive = true
+}
+
+variable "THIRD_PARTY_AUTH_GITLAB_REDIRECT_URI" {
+  type      = string
+  default   = ""
+  sensitive = false
+}
+
+
+// =================================================
+// GOOGLE THIRD PARTY AUTH CONFIG
+// =================================================
+variable "THIRD_PARTY_AUTH_GOOGLE_ENABLED" {
+  type      = bool
+  default   = false
+  sensitive = false
+}
+
+variable "THIRD_PARTY_AUTH_GOOGLE_CLIENT_ID" {
+  type      = string
+  default   = ""
+  sensitive = true
+}
+
+variable "THIRD_PARTY_AUTH_GOOGLE_SECRET" {
+  type      = string
+  default   = ""
+  sensitive = true
+}
+
+variable "THIRD_PARTY_AUTH_GOOGLE_REDIRECT_URI" {
+  type      = string
+  default   = ""
+  sensitive = false
+}
+
+
+// =================================================
+// LINKEDIN THIRD PARTY AUTH CONFIG
+// =================================================
+variable "THIRD_PARTY_AUTH_LINKEDIN_ENABLED" {
+  type      = bool
+  default   = false
+  sensitive = false
+}
+
+variable "THIRD_PARTY_AUTH_LINKEDIN_CLIENT_ID" {
+  type      = string
+  default   = ""
+  sensitive = true
+}
+
+variable "THIRD_PARTY_AUTH_LINKEDIN_SECRET" {
+  type      = string
+  default   = ""
+  sensitive = true
+}
+
+variable "THIRD_PARTY_AUTH_LINKEDIN_REDIRECT_URI" {
+  type      = string
+  default   = ""
+  sensitive = false
+}
+
+
+// =================================================
+// NOTION THIRD PARTY AUTH CONFIG
+// =================================================
+variable "THIRD_PARTY_AUTH_NOTION_ENABLED" {
+  type      = bool
+  default   = false
+  sensitive = false
+}
+
+variable "THIRD_PARTY_AUTH_NOTION_CLIENT_ID" {
+  type      = string
+  default   = ""
+  sensitive = true
+}
+
+variable "THIRD_PARTY_AUTH_NOTION_SECRET" {
+  type      = string
+  default   = ""
+  sensitive = true
+}
+
+variable "THIRD_PARTY_AUTH_NOTION_REDIRECT_URI" {
+  type      = string
+  default   = ""
+  sensitive = false
+}
+
+
+// =================================================
+// SPOTIFY THIRD PARTY AUTH CONFIG
+// =================================================
+variable "THIRD_PARTY_AUTH_SPOTIFY_ENABLED" {
+  type      = bool
+  default   = false
+  sensitive = false
+}
+
+variable "THIRD_PARTY_AUTH_SPOTIFY_CLIENT_ID" {
+  type      = string
+  default   = ""
+  sensitive = true
+}
+
+variable "THIRD_PARTY_AUTH_SPOTIFY_SECRET" {
+  type      = string
+  default   = ""
+  sensitive = true
+}
+
+variable "THIRD_PARTY_AUTH_SPOTIFY_REDIRECT_URI" {
+  type      = string
+  default   = ""
+  sensitive = false
+}
+
+
+// =================================================
+// SLACK THIRD PARTY AUTH CONFIG
+// =================================================
+variable "THIRD_PARTY_AUTH_SLACK_ENABLED" {
+  type      = bool
+  default   = false
+  sensitive = false
+}
+
+variable "THIRD_PARTY_AUTH_SLACK_CLIENT_ID" {
+  type      = string
+  default   = ""
+  sensitive = true
+}
+
+variable "THIRD_PARTY_AUTH_SLACK_SECRET" {
+  type      = string
+  default   = ""
+  sensitive = true
+}
+
+variable "THIRD_PARTY_AUTH_SLACK_REDIRECT_URI" {
+  type      = string
+  default   = ""
+  sensitive = false
+}
+
+
+// =================================================
+// TWITCH THIRD PARTY AUTH CONFIG
+// =================================================
+variable "THIRD_PARTY_AUTH_TWITCH_ENABLED" {
+  type      = bool
+  default   = false
+  sensitive = false
+}
+
+variable "THIRD_PARTY_AUTH_TWITCH_CLIENT_ID" {
+  type      = string
+  default   = ""
+  sensitive = true
+}
+
+variable "THIRD_PARTY_AUTH_TWITCH_SECRET" {
+  type      = string
+  default   = ""
+  sensitive = true
+}
+
+variable "THIRD_PARTY_AUTH_TWITCH_REDIRECT_URI" {
+  type      = string
+  default   = ""
+  sensitive = false
+}
+
+
+// =================================================
+// TWITTER THIRD PARTY AUTH CONFIG
+// =================================================
+variable "THIRD_PARTY_AUTH_TWITTER_ENABLED" {
+  type      = bool
+  default   = false
+  sensitive = false
+}
+
+variable "THIRD_PARTY_AUTH_TWITTER_CLIENT_ID" {
+  type      = string
+  default   = ""
+  sensitive = true
+}
+
+variable "THIRD_PARTY_AUTH_TWITTER_SECRET" {
+  type      = string
+  default   = ""
+  sensitive = true
+}
+
+variable "THIRD_PARTY_AUTH_TWITTER_REDIRECT_URI" {
+  type      = string
+  default   = ""
+  sensitive = false
+}

--- a/terraform/supabase/definitions/volumes/api/kong.tpl
+++ b/terraform/supabase/definitions/volumes/api/kong.tpl
@@ -1,0 +1,148 @@
+_format_version: "1.1"
+
+###
+### Consumers / Users
+###
+consumers:
+  - username: anon
+    keyauth_credentials:
+      - key: ${ANON_KEY}
+  - username: service_role
+    keyauth_credentials:
+      - key: ${SECRET_KEY}
+
+###
+### Access Control List
+###
+acls:
+  - consumer: anon
+    group: anon
+  - consumer: service_role
+    group: admin
+
+###
+### API Routes
+###
+services:
+  ## Open Auth routes
+  - name: auth-v1-open
+    url: http://auth:9999/verify
+    routes:
+      - name: auth-v1-open
+        strip_path: true
+        paths:
+          - /auth/v1/verify
+    plugins:
+      - name: cors
+  - name: auth-v1-open-callback
+    url: http://auth:9999/callback
+    routes:
+      - name: auth-v1-open-callback
+        strip_path: true
+        paths:
+          - /auth/v1/callback
+    plugins:
+      - name: cors
+  - name: auth-v1-open-authorize
+    url: http://auth:9999/authorize
+    routes:
+      - name: auth-v1-open-authorize
+        strip_path: true
+        paths:
+          - /auth/v1/authorize
+    plugins:
+      - name: cors
+
+  ## Secure Auth routes
+  - name: auth-v1
+    _comment: "GoTrue: /auth/v1/* -> http://auth:9999/*"
+    url: http://auth:9999/
+    routes:
+      - name: auth-v1-all
+        strip_path: true
+        paths:
+          - /auth/v1/
+    plugins:
+      - name: cors
+      - name: key-auth
+        config:
+          hide_credentials: false
+      - name: acl
+        config:
+          hide_groups_header: true
+          allow:
+            - admin
+            - anon
+
+  ## Secure REST routes
+  - name: rest-v1
+    _comment: "PostgREST: /rest/v1/* -> http://rest:3000/*"
+    url: http://rest:3000/
+    routes:
+      - name: rest-v1-all
+        strip_path: true
+        paths:
+          - /rest/v1/
+    plugins:
+      - name: cors
+      - name: key-auth
+        config:
+          hide_credentials: true
+      - name: acl
+        config:
+          hide_groups_header: true
+          allow:
+            - admin
+            - anon
+
+  ## Secure Realtime routes
+  - name: realtime-v1
+    _comment: "Realtime: /realtime/v1/* -> ws://realtime:4000/socket/*"
+    url: http://realtime:4000/socket/
+    routes:
+      - name: realtime-v1-all
+        strip_path: true
+        paths:
+          - /realtime/v1/
+    plugins:
+      - name: cors
+      - name: key-auth
+        config:
+          hide_credentials: false
+      - name: acl
+        config:
+          hide_groups_header: true
+          allow:
+            - admin
+            - anon
+
+  ## Storage routes: the storage server manages its own auth
+  - name: storage-v1
+    _comment: "Storage: /storage/v1/* -> http://storage:5000/*"
+    url: http://storage:5000/
+    routes:
+      - name: storage-v1-all
+        strip_path: true
+        paths:
+          - /storage/v1/
+    plugins:
+      - name: cors
+
+  ## Secure Database routes
+  - name: meta
+    _comment: "pg-meta: /pg/* -> http://pg-meta:8080/*"
+    url: http://${META_URL}:${META_PORT}/
+    routes:
+      - name: meta-all
+        strip_path: true
+        paths:
+          - /pg/
+    plugins:
+      - name: key-auth
+        config:
+          hide_credentials: false
+      - name: acl
+        config:
+          hide_groups_header: true
+          allow:
+            - admin

--- a/terraform/supabase/definitions/volumes/db/config/postgresql.conf
+++ b/terraform/supabase/definitions/volumes/db/config/postgresql.conf
@@ -1,0 +1,796 @@
+# -----------------------------
+# PostgreSQL configuration file
+# -----------------------------
+#
+# This file consists of lines of the form:
+#
+#   name = value
+#
+# (The "=" is optional.)  Whitespace may be used.  Comments are introduced with
+# "#" anywhere on a line.  The complete list of parameter names and allowed
+# values can be found in the PostgreSQL documentation.
+#
+# The commented-out settings shown in this file represent the default values.
+# Re-commenting a setting is NOT sufficient to revert it to the default value;
+# you need to reload the server.
+#
+# This file is read on server startup and when the server receives a SIGHUP
+# signal.  If you edit the file on a running system, you have to SIGHUP the
+# server for the changes to take effect, run "pg_ctl reload", or execute
+# "SELECT pg_reload_conf()".  Some parameters, which are marked below,
+# require a server shutdown and restart to take effect.
+#
+# Any parameter can also be given as a command-line option to the server, e.g.,
+# "postgres -c log_connections=on".  Some parameters can be changed at run time
+# with the "SET" SQL command.
+#
+# Memory units:  B  = bytes            Time units:  us  = microseconds
+#                kB = kilobytes                     ms  = milliseconds
+#                MB = megabytes                     s   = seconds
+#                GB = gigabytes                     min = minutes
+#                TB = terabytes                     h   = hours
+#                                                   d   = days
+
+
+#------------------------------------------------------------------------------
+# FILE LOCATIONS
+#------------------------------------------------------------------------------
+
+# The default values of these variables are driven from the -D command-line
+# option or PGDATA environment variable, represented here as ConfigDir.
+
+data_directory = '/var/lib/postgresql/data'		# use data in another directory
+					# (change requires restart)
+hba_file = '/etc/postgresql/pg_hba.conf'	# host-based authentication file
+					# (change requires restart)
+ident_file = '/etc/postgresql/pg_ident.conf'	# ident configuration file
+					# (change requires restart)
+
+# If external_pid_file is not explicitly set, no extra PID file is written.
+#external_pid_file = ''			# write an extra PID file
+					# (change requires restart)
+
+
+#------------------------------------------------------------------------------
+# CONNECTIONS AND AUTHENTICATION
+#------------------------------------------------------------------------------
+
+# - Connection Settings -
+
+listen_addresses = '*'		# what IP address(es) to listen on;
+					# comma-separated list of addresses;
+					# defaults to 'localhost'; use '*' for all
+					# (change requires restart)
+#port = 5432				# (change requires restart)
+#max_connections = 100			# (change requires restart)
+#superuser_reserved_connections = 3	# (change requires restart)
+unix_socket_directories = '/var/run/postgresql'	# comma-separated list of directories
+					# (change requires restart)
+#unix_socket_group = ''			# (change requires restart)
+#unix_socket_permissions = 0777		# begin with 0 to use octal notation
+					# (change requires restart)
+#bonjour = off				# advertise server via Bonjour
+					# (change requires restart)
+#bonjour_name = ''			# defaults to the computer name
+					# (change requires restart)
+
+# - TCP settings -
+# see "man tcp" for details
+
+#tcp_keepalives_idle = 0		# TCP_KEEPIDLE, in seconds;
+					# 0 selects the system default
+#tcp_keepalives_interval = 0		# TCP_KEEPINTVL, in seconds;
+					# 0 selects the system default
+#tcp_keepalives_count = 0		# TCP_KEEPCNT;
+					# 0 selects the system default
+#tcp_user_timeout = 0			# TCP_USER_TIMEOUT, in milliseconds;
+					# 0 selects the system default
+
+#client_connection_check_interval = 0	# time between checks for client
+					# disconnection while running queries;
+					# 0 for never
+
+# - Authentication -
+
+authentication_timeout = 1min		# 1s-600s
+password_encryption = scram-sha-256	# scram-sha-256 or md5
+db_user_namespace = off
+
+# GSSAPI using Kerberos
+#krb_server_keyfile = 'FILE:${sysconfdir}/krb5.keytab'
+#krb_caseins_users = off
+
+# - SSL -
+
+ssl = off
+ssl_ca_file = ''
+ssl_cert_file = ''
+ssl_crl_file = ''
+ssl_crl_dir = ''
+ssl_key_file = ''
+ssl_ciphers = 'HIGH:MEDIUM:+3DES:!aNULL' # allowed SSL ciphers
+ssl_prefer_server_ciphers = on
+ssl_ecdh_curve = 'prime256v1'
+ssl_min_protocol_version = 'TLSv1.2'
+ssl_max_protocol_version = ''
+ssl_dh_params_file = ''
+ssl_passphrase_command = ''
+ssl_passphrase_command_supports_reload = off
+
+
+#------------------------------------------------------------------------------
+# RESOURCE USAGE (except WAL)
+#------------------------------------------------------------------------------
+
+# - Memory -
+
+shared_buffers = 128MB			# min 128kB
+					# (change requires restart)
+#huge_pages = try			# on, off, or try
+					# (change requires restart)
+#huge_page_size = 0			# zero for system default
+					# (change requires restart)
+#temp_buffers = 8MB			# min 800kB
+#max_prepared_transactions = 0		# zero disables the feature
+					# (change requires restart)
+# Caution: it is not advisable to set max_prepared_transactions nonzero unless
+# you actively intend to use prepared transactions.
+#work_mem = 4MB				# min 64kB
+#hash_mem_multiplier = 1.0		# 1-1000.0 multiplier on hash table work_mem
+#maintenance_work_mem = 64MB		# min 1MB
+#autovacuum_work_mem = -1		# min 1MB, or -1 to use maintenance_work_mem
+#logical_decoding_work_mem = 64MB	# min 64kB
+#max_stack_depth = 2MB			# min 100kB
+#shared_memory_type = mmap		# the default is the first option
+					# supported by the operating system:
+					#   mmap
+					#   sysv
+					#   windows
+					# (change requires restart)
+#dynamic_shared_memory_type = posix	# the default is the first option
+					# supported by the operating system:
+					#   posix
+					#   sysv
+					#   windows
+					#   mmap
+					# (change requires restart)
+#min_dynamic_shared_memory = 0MB	# (change requires restart)
+
+# - Disk -
+
+#temp_file_limit = -1			# limits per-process temp file space
+					# in kilobytes, or -1 for no limit
+
+# - Kernel Resources -
+
+#max_files_per_process = 1000		# min 64
+					# (change requires restart)
+
+# - Cost-Based Vacuum Delay -
+
+#vacuum_cost_delay = 0			# 0-100 milliseconds (0 disables)
+#vacuum_cost_page_hit = 1		# 0-10000 credits
+#vacuum_cost_page_miss = 2		# 0-10000 credits
+#vacuum_cost_page_dirty = 20		# 0-10000 credits
+#vacuum_cost_limit = 200		# 1-10000 credits
+
+# - Background Writer -
+
+#bgwriter_delay = 200ms			# 10-10000ms between rounds
+#bgwriter_lru_maxpages = 100		# max buffers written/round, 0 disables
+#bgwriter_lru_multiplier = 2.0		# 0-10.0 multiplier on buffers scanned/round
+#bgwriter_flush_after = 0		# measured in pages, 0 disables
+
+# - Asynchronous Behavior -
+
+#backend_flush_after = 0		# measured in pages, 0 disables
+#effective_io_concurrency = 1		# 1-1000; 0 disables prefetching
+#maintenance_io_concurrency = 10	# 1-1000; 0 disables prefetching
+#max_worker_processes = 8		# (change requires restart)
+#max_parallel_workers_per_gather = 2	# taken from max_parallel_workers
+#max_parallel_maintenance_workers = 2	# taken from max_parallel_workers
+#max_parallel_workers = 8		# maximum number of max_worker_processes that
+					# can be used in parallel operations
+#parallel_leader_participation = on
+#old_snapshot_threshold = -1		# 1min-60d; -1 disables; 0 is immediate
+					# (change requires restart)
+
+
+#------------------------------------------------------------------------------
+# WRITE-AHEAD LOG
+#------------------------------------------------------------------------------
+
+# - Settings -
+
+wal_level = logical			# minimal, replica, or logical
+					# (change requires restart)
+#fsync = on				# flush data to disk for crash safety
+					# (turning this off can cause
+					# unrecoverable data corruption)
+#synchronous_commit = on		# synchronization level;
+					# off, local, remote_write, remote_apply, or on
+#wal_sync_method = fsync		# the default is the first option
+					# supported by the operating system:
+					#   open_datasync
+					#   fdatasync (default on Linux and FreeBSD)
+					#   fsync
+					#   fsync_writethrough
+					#   open_sync
+#full_page_writes = on			# recover from partial page writes
+#wal_log_hints = off			# also do full page writes of non-critical updates
+					# (change requires restart)
+#wal_compression = off			# enable compression of full-page writes
+#wal_init_zero = on			# zero-fill new WAL files
+#wal_recycle = on			# recycle WAL files
+#wal_buffers = -1			# min 32kB, -1 sets based on shared_buffers
+					# (change requires restart)
+#wal_writer_delay = 200ms		# 1-10000 milliseconds
+#wal_writer_flush_after = 1MB		# measured in pages, 0 disables
+#wal_skip_threshold = 2MB
+
+#commit_delay = 0			# range 0-100000, in microseconds
+#commit_siblings = 5			# range 1-1000
+
+# - Checkpoints -
+
+#checkpoint_timeout = 5min		# range 30s-1d
+checkpoint_completion_target = 0.5	# checkpoint target duration, 0.0 - 1.0
+checkpoint_flush_after = 256kB		# measured in pages, 0 disables
+#checkpoint_warning = 30s		# 0 disables
+#max_wal_size = 1GB
+#min_wal_size = 80MB
+
+# - Archiving -
+
+#archive_mode = off		# enables archiving; off, on, or always
+				# (change requires restart)
+#archive_command = ''		# command to use to archive a logfile segment
+				# placeholders: %p = path of file to archive
+				#               %f = file name only
+				# e.g. 'test ! -f /mnt/server/archivedir/%f && cp %p /mnt/server/archivedir/%f'
+#archive_timeout = 0		# force a logfile segment switch after this
+				# number of seconds; 0 disables
+
+# - Archive Recovery -
+
+# These are only used in recovery mode.
+
+#restore_command = ''		# command to use to restore an archived logfile segment
+				# placeholders: %p = path of file to restore
+				#               %f = file name only
+				# e.g. 'cp /mnt/server/archivedir/%f %p'
+#archive_cleanup_command = ''	# command to execute at every restartpoint
+#recovery_end_command = ''	# command to execute at completion of recovery
+
+# - Recovery Target -
+
+# Set these only when performing a targeted recovery.
+
+#recovery_target = ''		# 'immediate' to end recovery as soon as a
+                                # consistent state is reached
+				# (change requires restart)
+#recovery_target_name = ''	# the named restore point to which recovery will proceed
+				# (change requires restart)
+#recovery_target_time = ''	# the time stamp up to which recovery will proceed
+				# (change requires restart)
+#recovery_target_xid = ''	# the transaction ID up to which recovery will proceed
+				# (change requires restart)
+#recovery_target_lsn = ''	# the WAL LSN up to which recovery will proceed
+				# (change requires restart)
+#recovery_target_inclusive = on # Specifies whether to stop:
+				# just after the specified recovery target (on)
+				# just before the recovery target (off)
+				# (change requires restart)
+#recovery_target_timeline = 'latest'	# 'current', 'latest', or timeline ID
+				# (change requires restart)
+#recovery_target_action = 'pause'	# 'pause', 'promote', 'shutdown'
+				# (change requires restart)
+
+
+#------------------------------------------------------------------------------
+# REPLICATION
+#------------------------------------------------------------------------------
+
+# - Sending Servers -
+
+# Set these on the primary and on any standby that will send replication data.
+
+max_wal_senders = 10		# max number of walsender processes
+				# (change requires restart)
+max_replication_slots = 5	# max number of replication slots
+				# (change requires restart)
+#wal_keep_size = 0		# in megabytes; 0 disables
+max_slot_wal_keep_size = 1024   # in megabytes; -1 disables
+#wal_sender_timeout = 60s	# in milliseconds; 0 disables
+#track_commit_timestamp = off	# collect timestamp of transaction commit
+				# (change requires restart)
+
+# - Primary Server -
+
+# These settings are ignored on a standby server.
+
+#synchronous_standby_names = ''	# standby servers that provide sync rep
+				# method to choose sync standbys, number of sync standbys,
+				# and comma-separated list of application_name
+				# from standby(s); '*' = all
+#vacuum_defer_cleanup_age = 0	# number of xacts by which cleanup is delayed
+
+# - Standby Servers -
+
+# These settings are ignored on a primary server.
+
+#primary_conninfo = ''			# connection string to sending server
+#primary_slot_name = ''			# replication slot on sending server
+#promote_trigger_file = ''		# file name whose presence ends recovery
+#hot_standby = on			# "off" disallows queries during recovery
+					# (change requires restart)
+#max_standby_archive_delay = 30s	# max delay before canceling queries
+					# when reading WAL from archive;
+					# -1 allows indefinite delay
+#max_standby_streaming_delay = 30s	# max delay before canceling queries
+					# when reading streaming WAL;
+					# -1 allows indefinite delay
+#wal_receiver_create_temp_slot = off	# create temp slot if primary_slot_name
+					# is not set
+#wal_receiver_status_interval = 10s	# send replies at least this often
+					# 0 disables
+#hot_standby_feedback = off		# send info from standby to prevent
+					# query conflicts
+#wal_receiver_timeout = 60s		# time that receiver waits for
+					# communication from primary
+					# in milliseconds; 0 disables
+#wal_retrieve_retry_interval = 5s	# time to wait before retrying to
+					# retrieve WAL after a failed attempt
+#recovery_min_apply_delay = 0		# minimum delay for applying changes during recovery
+
+# - Subscribers -
+
+# These settings are ignored on a publisher.
+
+#max_logical_replication_workers = 4	# taken from max_worker_processes
+					# (change requires restart)
+#max_sync_workers_per_subscription = 2	# taken from max_logical_replication_workers
+
+
+#------------------------------------------------------------------------------
+# QUERY TUNING
+#------------------------------------------------------------------------------
+
+# - Planner Method Configuration -
+
+#enable_async_append = on
+#enable_bitmapscan = on
+#enable_gathermerge = on
+#enable_hashagg = on
+#enable_hashjoin = on
+#enable_incremental_sort = on
+#enable_indexscan = on
+#enable_indexonlyscan = on
+#enable_material = on
+#enable_resultcache = on
+#enable_mergejoin = on
+#enable_nestloop = on
+#enable_parallel_append = on
+#enable_parallel_hash = on
+#enable_partition_pruning = on
+#enable_partitionwise_join = off
+#enable_partitionwise_aggregate = off
+#enable_seqscan = on
+#enable_sort = on
+#enable_tidscan = on
+
+# - Planner Cost Constants -
+
+#seq_page_cost = 1.0			# measured on an arbitrary scale
+#random_page_cost = 4.0			# same scale as above
+#cpu_tuple_cost = 0.01			# same scale as above
+#cpu_index_tuple_cost = 0.005		# same scale as above
+#cpu_operator_cost = 0.0025		# same scale as above
+#parallel_setup_cost = 1000.0	# same scale as above
+#parallel_tuple_cost = 0.1		# same scale as above
+#min_parallel_table_scan_size = 8MB
+#min_parallel_index_scan_size = 512kB
+effective_cache_size = 128MB
+
+#jit_above_cost = 100000		# perform JIT compilation if available
+					# and query more expensive than this;
+					# -1 disables
+#jit_inline_above_cost = 500000		# inline small functions if query is
+					# more expensive than this; -1 disables
+#jit_optimize_above_cost = 500000	# use expensive JIT optimizations if
+					# query is more expensive than this;
+					# -1 disables
+
+# - Genetic Query Optimizer -
+
+#geqo = on
+#geqo_threshold = 12
+#geqo_effort = 5			# range 1-10
+#geqo_pool_size = 0			# selects default based on effort
+#geqo_generations = 0			# selects default based on effort
+#geqo_selection_bias = 2.0		# range 1.5-2.0
+#geqo_seed = 0.0			# range 0.0-1.0
+
+# - Other Planner Options -
+
+#default_statistics_target = 100	# range 1-10000
+#constraint_exclusion = partition	# on, off, or partition
+#cursor_tuple_fraction = 0.1		# range 0.0-1.0
+#from_collapse_limit = 8
+#jit = on				# allow JIT compilation
+#join_collapse_limit = 8		# 1 disables collapsing of explicit
+					# JOIN clauses
+#plan_cache_mode = auto			# auto, force_generic_plan or
+					# force_custom_plan
+
+
+#------------------------------------------------------------------------------
+# REPORTING AND LOGGING
+#------------------------------------------------------------------------------
+
+# - Where to Log -
+
+log_destination = 'csvlog'		# Valid values are combinations of
+					# stderr, csvlog, syslog, and eventlog,
+					# depending on platform.  csvlog
+					# requires logging_collector to be on.
+
+# This is used when logging to stderr:
+logging_collector = on		# Enable capturing of stderr and csvlog
+					# into log files. Required to be on for
+					# csvlogs.
+					# (change requires restart)
+
+# These are only used if logging_collector is on:
+log_directory = '/var/log/postgresql'			# directory where log files are written,
+					# can be absolute or relative to PGDATA
+log_filename = 'postgresql.log'	# log file name pattern,
+					# can include strftime() escapes
+log_file_mode = 0640			# creation mode for log files,
+					# begin with 0 to use octal notation
+log_rotation_age = 0			# Automatic rotation of logfiles will
+					# happen after that time.  0 disables.
+log_rotation_size = 0		# Automatic rotation of logfiles will
+					# happen after that much log output.
+					# 0 disables.
+#log_truncate_on_rotation = off		# If on, an existing log file with the
+					# same name as the new log file will be
+					# truncated rather than appended to.
+					# But such truncation only occurs on
+					# time-driven rotation, not on restarts
+					# or size-driven rotation.  Default is
+					# off, meaning append to existing files
+					# in all cases.
+
+# These are relevant when logging to syslog:
+#syslog_facility = 'LOCAL0'
+#syslog_ident = 'postgres'
+#syslog_sequence_numbers = on
+#syslog_split_messages = on
+
+# This is only relevant when logging to eventlog (Windows):
+# (change requires restart)
+#event_source = 'PostgreSQL'
+
+# - When to Log -
+
+#log_min_messages = warning		# values in order of decreasing detail:
+					#   debug5
+					#   debug4
+					#   debug3
+					#   debug2
+					#   debug1
+					#   info
+					#   notice
+					#   warning
+					#   error
+					#   log
+					#   fatal
+					#   panic
+
+#log_min_error_statement = error	# values in order of decreasing detail:
+					#   debug5
+					#   debug4
+					#   debug3
+					#   debug2
+					#   debug1
+					#   info
+					#   notice
+					#   warning
+					#   error
+					#   log
+					#   fatal
+					#   panic (effectively off)
+
+#log_min_duration_statement = -1	# -1 is disabled, 0 logs all statements
+					# and their durations, > 0 logs only
+					# statements running at least this number
+					# of milliseconds
+
+#log_min_duration_sample = -1		# -1 is disabled, 0 logs a sample of statements
+					# and their durations, > 0 logs only a sample of
+					# statements running at least this number
+					# of milliseconds;
+					# sample fraction is determined by log_statement_sample_rate
+
+#log_statement_sample_rate = 1.0	# fraction of logged statements exceeding
+					# log_min_duration_sample to be logged;
+					# 1.0 logs all such statements, 0.0 never logs
+
+
+#log_transaction_sample_rate = 0.0	# fraction of transactions whose statements
+					# are logged regardless of their duration; 1.0 logs all
+					# statements from all transactions, 0.0 never logs
+
+# - What to Log -
+
+#debug_print_parse = off
+#debug_print_rewritten = off
+#debug_print_plan = off
+#debug_pretty_print = on
+#log_autovacuum_min_duration = -1	# log autovacuum activity;
+					# -1 disables, 0 logs all actions and
+					# their durations, > 0 logs only
+					# actions running at least this number
+					# of milliseconds.
+#log_checkpoints = off
+#log_connections = off
+#log_disconnections = off
+#log_duration = off
+#log_error_verbosity = default		# terse, default, or verbose messages
+#log_hostname = off
+log_line_prefix = '%h %m [%p] %q%u@%d '		# special values:
+					#   %a = application name
+					#   %u = user name
+					#   %d = database name
+					#   %r = remote host and port
+					#   %h = remote host
+					#   %b = backend type
+					#   %p = process ID
+					#   %P = process ID of parallel group leader
+					#   %t = timestamp without milliseconds
+					#   %m = timestamp with milliseconds
+					#   %n = timestamp with milliseconds (as a Unix epoch)
+					#   %Q = query ID (0 if none or not computed)
+					#   %i = command tag
+					#   %e = SQL state
+					#   %c = session ID
+					#   %l = session line number
+					#   %s = session start timestamp
+					#   %v = virtual transaction ID
+					#   %x = transaction ID (0 if none)
+					#   %q = stop here in non-session
+					#        processes
+					#   %% = '%'
+					# e.g. '<%u%%%d> '
+#log_lock_waits = off			# log lock waits >= deadlock_timeout
+#log_recovery_conflict_waits = off	# log standby recovery conflict waits
+					# >= deadlock_timeout
+#log_parameter_max_length = -1		# when logging statements, limit logged
+					# bind-parameter values to N bytes;
+					# -1 means print in full, 0 disables
+#log_parameter_max_length_on_error = 0	# when logging an error, limit logged
+					# bind-parameter values to N bytes;
+					# -1 means print in full, 0 disables
+log_statement = 'all'			# none, ddl, mod, all
+#log_replication_commands = off
+#log_temp_files = -1			# log temporary files equal or larger
+					# than the specified size in kilobytes;
+					# -1 disables, 0 logs all temp files
+log_timezone = 'UTC'
+
+#------------------------------------------------------------------------------
+# PROCESS TITLE
+#------------------------------------------------------------------------------
+
+cluster_name = 'main'			# added to process titles if nonempty
+					# (change requires restart)
+#update_process_title = on
+
+
+#------------------------------------------------------------------------------
+# STATISTICS
+#------------------------------------------------------------------------------
+
+# - Query and Index Statistics Collector -
+
+#track_activities = on
+#track_activity_query_size = 1024	# (change requires restart)
+#track_counts = on
+#track_io_timing = off
+#track_wal_io_timing = off
+#track_functions = none			# none, pl, all
+#stats_temp_directory = 'pg_stat_tmp'
+
+
+# - Monitoring -
+
+#compute_query_id = auto
+#log_statement_stats = off
+#log_parser_stats = off
+#log_planner_stats = off
+#log_executor_stats = off
+
+
+#------------------------------------------------------------------------------
+# AUTOVACUUM
+#------------------------------------------------------------------------------
+
+#autovacuum = on			# Enable autovacuum subprocess?  'on'
+					# requires track_counts to also be on.
+#autovacuum_max_workers = 3		# max number of autovacuum subprocesses
+					# (change requires restart)
+#autovacuum_naptime = 1min		# time between autovacuum runs
+#autovacuum_vacuum_threshold = 50	# min number of row updates before
+					# vacuum
+#autovacuum_vacuum_insert_threshold = 1000	# min number of row inserts
+					# before vacuum; -1 disables insert
+					# vacuums
+#autovacuum_analyze_threshold = 50	# min number of row updates before
+					# analyze
+#autovacuum_vacuum_scale_factor = 0.2	# fraction of table size before vacuum
+#autovacuum_vacuum_insert_scale_factor = 0.2	# fraction of inserts over table
+					# size before insert vacuum
+#autovacuum_analyze_scale_factor = 0.1	# fraction of table size before analyze
+#autovacuum_freeze_max_age = 200000000	# maximum XID age before forced vacuum
+					# (change requires restart)
+#autovacuum_multixact_freeze_max_age = 400000000	# maximum multixact age
+					# before forced vacuum
+					# (change requires restart)
+#autovacuum_vacuum_cost_delay = 2ms	# default vacuum cost delay for
+					# autovacuum, in milliseconds;
+					# -1 means use vacuum_cost_delay
+#autovacuum_vacuum_cost_limit = -1	# default vacuum cost limit for
+					# autovacuum, -1 means use
+					# vacuum_cost_limit
+
+
+#------------------------------------------------------------------------------
+# CLIENT CONNECTION DEFAULTS
+#------------------------------------------------------------------------------
+
+# - Statement Behavior -
+
+#client_min_messages = notice		# values in order of decreasing detail:
+					#   debug5
+					#   debug4
+					#   debug3
+					#   debug2
+					#   debug1
+					#   log
+					#   notice
+					#   warning
+					#   error
+#search_path = '"$user", public'	# schema names
+row_security = on
+#default_table_access_method = 'heap'
+#default_tablespace = ''		# a tablespace name, '' uses the default
+#default_toast_compression = 'pglz'	# 'pglz' or 'lz4'
+#temp_tablespaces = ''			# a list of tablespace names, '' uses
+					# only default tablespace
+#check_function_bodies = on
+#default_transaction_isolation = 'read committed'
+#default_transaction_read_only = off
+#default_transaction_deferrable = off
+#session_replication_role = 'origin'
+#statement_timeout = 0			# in milliseconds, 0 is disabled
+#lock_timeout = 0			# in milliseconds, 0 is disabled
+#idle_in_transaction_session_timeout = 0	# in milliseconds, 0 is disabled
+#idle_session_timeout = 0		# in milliseconds, 0 is disabled
+#vacuum_freeze_table_age = 150000000
+#vacuum_freeze_min_age = 50000000
+#vacuum_failsafe_age = 1600000000
+#vacuum_multixact_freeze_table_age = 150000000
+#vacuum_multixact_freeze_min_age = 5000000
+#vacuum_multixact_failsafe_age = 1600000000
+#bytea_output = 'hex'			# hex, escape
+#xmlbinary = 'base64'
+#xmloption = 'content'
+#gin_pending_list_limit = 4MB
+
+# - Locale and Formatting -
+
+#datestyle = 'iso, mdy'
+#intervalstyle = 'postgres'
+timezone = 'UTC'
+#timezone_abbreviations = 'Default'     # Select the set of available time zone
+					# abbreviations.  Currently, there are
+					#   Default
+					#   Australia (historical usage)
+					#   India
+					# You can create your own file in
+					# share/timezonesets/.
+extra_float_digits = 0			# min -15, max 3; any value >0 actually
+					# selects precise output mode
+#client_encoding = sql_ascii		# actually, defaults to database
+					# encoding
+
+# These settings are initialized by initdb, but they can be changed.
+lc_messages = 'en_US.UTF-8'			# locale for system error message
+					# strings
+lc_monetary = 'en_US.UTF-8'			# locale for monetary formatting
+lc_numeric = 'en_US.UTF-8'			# locale for number formatting
+lc_time = 'en_US.UTF-8'				# locale for time formatting
+
+# default configuration for text search
+default_text_search_config = 'pg_catalog.english'
+
+# - Shared Library Preloading -
+
+#local_preload_libraries = ''
+#session_preload_libraries = ''
+shared_preload_libraries = 'pg_stat_statements, pgaudit, plpgsql, plpgsql_check, pg_cron, pg_net'	# (change requires restart)
+jit_provider = 'llvmjit'		# JIT library to use
+
+# - Other Defaults -
+
+#dynamic_library_path = '$libdir'
+#gin_fuzzy_search_limit = 0
+
+#------------------------------------------------------------------------------
+# LOCK MANAGEMENT
+#------------------------------------------------------------------------------
+
+#deadlock_timeout = 1s
+#max_locks_per_transaction = 64		# min 10
+					# (change requires restart)
+#max_pred_locks_per_transaction = 64	# min 10
+					# (change requires restart)
+#max_pred_locks_per_relation = -2	# negative values mean
+					# (max_pred_locks_per_transaction
+					#  / -max_pred_locks_per_relation) - 1
+#max_pred_locks_per_page = 2            # min 0
+
+
+#------------------------------------------------------------------------------
+# VERSION AND PLATFORM COMPATIBILITY
+#------------------------------------------------------------------------------
+
+# - Previous PostgreSQL Versions -
+
+#array_nulls = on
+#backslash_quote = safe_encoding	# on, off, or safe_encoding
+#escape_string_warning = on
+#lo_compat_privileges = off
+#quote_all_identifiers = off
+#standard_conforming_strings = on
+#synchronize_seqscans = on
+
+# - Other Platforms and Clients -
+
+#transform_null_equals = off
+
+
+#------------------------------------------------------------------------------
+# ERROR HANDLING
+#------------------------------------------------------------------------------
+
+#exit_on_error = off			# terminate session on any error?
+#restart_after_crash = on		# reinitialize after backend crash?
+#data_sync_retry = off			# retry or panic on failure to fsync
+					# data?
+					# (change requires restart)
+#recovery_init_sync_method = fsync	# fsync, syncfs (Linux 5.8+)
+
+
+#------------------------------------------------------------------------------
+# CONFIG FILE INCLUDES
+#------------------------------------------------------------------------------
+
+# These options allow settings to be loaded from files other than the
+# default postgresql.conf.  Note that these are directives, not variable
+# assignments, so they can usefully be given more than once.
+
+#include_dir = '...'			# include files ending in '.conf' from
+					# a directory, e.g., 'conf.d'
+#include_if_exists = '...'		# include file only if it exists
+#include = '...'			# include file
+
+
+#------------------------------------------------------------------------------
+# CUSTOMIZED OPTIONS
+#------------------------------------------------------------------------------
+
+# Add settings for extensions here
+cron.database_name = 'postgres'
+pljava.libjvm_location = '/usr/lib/jvm/java-11-openjdk-amd64/lib/server/libjvm.so'

--- a/terraform/supabase/definitions/volumes/db/init/sql/00-initial-schema.sql
+++ b/terraform/supabase/definitions/volumes/db/init/sql/00-initial-schema.sql
@@ -1,0 +1,73 @@
+-- Set up realtime
+create schema if not exists realtime;
+-- create publication supabase_realtime; -- defaults to empty publication
+create publication supabase_realtime;
+-- Supabase super admin
+create user supabase_admin;
+alter user supabase_admin with superuser createdb createrole replication bypassrls;
+-- Extension namespacing
+create schema if not exists extensions;
+create extension if not exists "uuid-ossp" with schema extensions;
+create extension if not exists pgcrypto with schema extensions;
+create extension if not exists pgjwt with schema extensions;
+-- Set up auth roles for the developer
+create role anon nologin noinherit;
+create role authenticated nologin noinherit;
+-- "logged in" user: web_user, app_user, etc
+create role service_role nologin noinherit bypassrls;
+-- allow developers to create JWT's that bypass their policies
+create user authenticator noinherit;
+grant anon to authenticator;
+grant authenticated to authenticator;
+grant service_role to authenticator;
+grant supabase_admin to authenticator;
+grant usage on schema public to postgres,
+  anon,
+  authenticated,
+  service_role;
+alter default privileges in schema public
+grant all on tables to postgres,
+  anon,
+  authenticated,
+  service_role;
+alter default privileges in schema public
+grant all on functions to postgres,
+  anon,
+  authenticated,
+  service_role;
+alter default privileges in schema public
+grant all on sequences to postgres,
+  anon,
+  authenticated,
+  service_role;
+-- Allow Extensions to be used in the API
+grant usage on schema extensions to postgres,
+  anon,
+  authenticated,
+  service_role;
+-- Set up namespacing
+alter user supabase_admin
+SET search_path TO public,
+  extensions;
+-- don't include the "auth" schema
+-- These are required so that the users receive grants whenever "supabase_admin" creates tables/function
+alter default privileges for user supabase_admin in schema public
+grant all on sequences to postgres,
+  anon,
+  authenticated,
+  service_role;
+alter default privileges for user supabase_admin in schema public
+grant all on tables to postgres,
+  anon,
+  authenticated,
+  service_role;
+alter default privileges for user supabase_admin in schema public
+grant all on functions to postgres,
+  anon,
+  authenticated,
+  service_role;
+-- Set short statement/query timeouts for API roles
+alter role anon
+set statement_timeout = '3s';
+alter role authenticated
+set statement_timeout = '8s';

--- a/terraform/supabase/definitions/volumes/db/init/sql/01-auth-schema.sql
+++ b/terraform/supabase/definitions/volumes/db/init/sql/01-auth-schema.sql
@@ -1,0 +1,121 @@
+CREATE SCHEMA IF NOT EXISTS auth AUTHORIZATION supabase_admin;
+-- auth.users definition
+CREATE TABLE auth.users (
+  instance_id uuid NULL,
+  id uuid NOT NULL UNIQUE,
+  aud varchar(255) NULL,
+  "role" varchar(255) NULL,
+  email varchar(255) NULL UNIQUE,
+  encrypted_password varchar(255) NULL,
+  confirmed_at timestamptz NULL,
+  invited_at timestamptz NULL,
+  confirmation_token varchar(255) NULL,
+  confirmation_sent_at timestamptz NULL,
+  recovery_token varchar(255) NULL,
+  recovery_sent_at timestamptz NULL,
+  email_change_token varchar(255) NULL,
+  email_change varchar(255) NULL,
+  email_change_sent_at timestamptz NULL,
+  last_sign_in_at timestamptz NULL,
+  raw_app_meta_data jsonb NULL,
+  raw_user_meta_data jsonb NULL,
+  is_super_admin bool NULL,
+  created_at timestamptz NULL,
+  updated_at timestamptz NULL,
+  CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE INDEX users_instance_id_email_idx ON auth.users USING btree (instance_id, email);
+CREATE INDEX users_instance_id_idx ON auth.users USING btree (instance_id);
+comment on table auth.users is 'Auth: Stores user login data within a secure schema.';
+-- auth.refresh_tokens definition
+CREATE TABLE auth.refresh_tokens (
+  instance_id uuid NULL,
+  id bigserial NOT NULL,
+  "token" varchar(255) NULL,
+  user_id varchar(255) NULL,
+  revoked bool NULL,
+  created_at timestamptz NULL,
+  updated_at timestamptz NULL,
+  CONSTRAINT refresh_tokens_pkey PRIMARY KEY (id)
+);
+CREATE INDEX refresh_tokens_instance_id_idx ON auth.refresh_tokens USING btree (instance_id);
+CREATE INDEX refresh_tokens_instance_id_user_id_idx ON auth.refresh_tokens USING btree (instance_id, user_id);
+CREATE INDEX refresh_tokens_token_idx ON auth.refresh_tokens USING btree (token);
+comment on table auth.refresh_tokens is 'Auth: Store of tokens used to refresh JWT tokens once they expire.';
+-- auth.instances definition
+CREATE TABLE auth.instances (
+  id uuid NOT NULL,
+  uuid uuid NULL,
+  raw_base_config text NULL,
+  created_at timestamptz NULL,
+  updated_at timestamptz NULL,
+  CONSTRAINT instances_pkey PRIMARY KEY (id)
+);
+comment on table auth.instances is 'Auth: Manages users across multiple sites.';
+-- auth.audit_log_entries definition
+CREATE TABLE auth.audit_log_entries (
+  instance_id uuid NULL,
+  id uuid NOT NULL,
+  payload json NULL,
+  created_at timestamptz NULL,
+  CONSTRAINT audit_log_entries_pkey PRIMARY KEY (id)
+);
+CREATE INDEX audit_logs_instance_id_idx ON auth.audit_log_entries USING btree (instance_id);
+comment on table auth.audit_log_entries is 'Auth: Audit trail for user actions.';
+-- auth.schema_migrations definition
+CREATE TABLE auth.schema_migrations (
+  "version" varchar(255) NOT NULL,
+  CONSTRAINT schema_migrations_pkey PRIMARY KEY ("version")
+);
+comment on table auth.schema_migrations is 'Auth: Manages updates to the auth system.';
+INSERT INTO auth.schema_migrations (version)
+VALUES ('20171026211738'),
+  ('20171026211808'),
+  ('20171026211834'),
+  ('20180103212743'),
+  ('20180108183307'),
+  ('20180119214651'),
+  ('20180125194653');
+create or replace function auth.uid() returns uuid language sql stable as $$
+select coalesce(
+    current_setting('request.jwt.claim.sub', true),
+    (
+      current_setting('request.jwt.claims', true)::jsonb->>'sub'
+    )
+  )::uuid $$;
+create or replace function auth.role() returns text language sql stable as $$
+select coalesce(
+    current_setting('request.jwt.claim.role', true),
+    (
+      current_setting('request.jwt.claims', true)::jsonb->>'role'
+    )
+  )::text $$;
+create or replace function auth.email() returns text language sql stable as $$
+select coalesce(
+    current_setting('request.jwt.claim.email', true),
+    (
+      current_setting('request.jwt.claims', true)::jsonb->>'email'
+    )
+  )::text $$;
+-- usage on auth functions to API roles
+GRANT USAGE ON SCHEMA auth TO anon,
+  authenticated,
+  service_role;
+-- Supabase super admin
+CREATE USER supabase_auth_admin NOINHERIT CREATEROLE LOGIN NOREPLICATION;
+GRANT ALL PRIVILEGES ON SCHEMA auth TO supabase_auth_admin;
+GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA auth TO supabase_auth_admin;
+GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA auth TO supabase_auth_admin;
+ALTER USER supabase_auth_admin
+SET search_path = "auth";
+ALTER table "auth".users OWNER TO supabase_auth_admin;
+ALTER table "auth".refresh_tokens OWNER TO supabase_auth_admin;
+ALTER table "auth".audit_log_entries OWNER TO supabase_auth_admin;
+ALTER table "auth".instances OWNER TO supabase_auth_admin;
+ALTER table "auth".schema_migrations OWNER TO supabase_auth_admin;
+ALTER FUNCTION "auth"."uid" OWNER TO supabase_auth_admin;
+ALTER FUNCTION "auth"."role" OWNER TO supabase_auth_admin;
+ALTER FUNCTION "auth"."email" OWNER TO supabase_auth_admin;
+GRANT EXECUTE ON FUNCTION "auth"."uid"() TO PUBLIC;
+GRANT EXECUTE ON FUNCTION "auth"."role"() TO PUBLIC;
+GRANT EXECUTE ON FUNCTION "auth"."email"() TO PUBLIC;

--- a/terraform/supabase/definitions/volumes/db/init/sql/02-storage-schema.sql
+++ b/terraform/supabase/definitions/volumes/db/init/sql/02-storage-schema.sql
@@ -1,0 +1,108 @@
+CREATE SCHEMA IF NOT EXISTS storage AUTHORIZATION supabase_admin;
+grant usage on schema storage to postgres,
+  anon,
+  authenticated,
+  service_role;
+alter default privileges in schema storage
+grant all on tables to postgres,
+  anon,
+  authenticated,
+  service_role;
+alter default privileges in schema storage
+grant all on functions to postgres,
+  anon,
+  authenticated,
+  service_role;
+alter default privileges in schema storage
+grant all on sequences to postgres,
+  anon,
+  authenticated,
+  service_role;
+CREATE TABLE "storage"."buckets" (
+  "id" text not NULL,
+  "name" text NOT NULL,
+  "owner" uuid,
+  "created_at" timestamptz DEFAULT now(),
+  "updated_at" timestamptz DEFAULT now(),
+  CONSTRAINT "buckets_owner_fkey" FOREIGN KEY ("owner") REFERENCES "auth"."users"("id"),
+  PRIMARY KEY ("id")
+);
+CREATE UNIQUE INDEX "bname" ON "storage"."buckets" USING BTREE ("name");
+CREATE TABLE "storage"."objects" (
+  "id" uuid NOT NULL DEFAULT extensions.uuid_generate_v4(),
+  "bucket_id" text,
+  "name" text,
+  "owner" uuid,
+  "created_at" timestamptz DEFAULT now(),
+  "updated_at" timestamptz DEFAULT now(),
+  "last_accessed_at" timestamptz DEFAULT now(),
+  "metadata" jsonb,
+  CONSTRAINT "objects_bucketId_fkey" FOREIGN KEY ("bucket_id") REFERENCES "storage"."buckets"("id"),
+  CONSTRAINT "objects_owner_fkey" FOREIGN KEY ("owner") REFERENCES "auth"."users"("id"),
+  PRIMARY KEY ("id")
+);
+CREATE UNIQUE INDEX "bucketid_objname" ON "storage"."objects" USING BTREE ("bucket_id", "name");
+CREATE INDEX name_prefix_search ON storage.objects(name text_pattern_ops);
+ALTER TABLE storage.objects ENABLE ROW LEVEL SECURITY;
+CREATE FUNCTION storage.foldername(name text) RETURNS text [] LANGUAGE plpgsql AS $function$
+DECLARE _parts text [];
+BEGIN
+select string_to_array(name, '/') into _parts;
+return _parts [1:array_length(_parts,1)-1];
+END $function$;
+CREATE FUNCTION storage.filename(name text) RETURNS text LANGUAGE plpgsql AS $function$
+DECLARE _parts text [];
+BEGIN
+select string_to_array(name, '/') into _parts;
+return _parts [array_length(_parts,1)];
+END $function$;
+CREATE FUNCTION storage.extension(name text) RETURNS text LANGUAGE plpgsql AS $function$
+DECLARE _parts text [];
+_filename text;
+BEGIN
+select string_to_array(name, '/') into _parts;
+select _parts [array_length(_parts,1)] into _filename;
+-- @todo return the last part instead of 2
+return split_part(_filename, '.', 2);
+END $function$;
+CREATE FUNCTION storage.search(
+  prefix text,
+  bucketname text,
+  limits int DEFAULT 100,
+  levels int DEFAULT 1,
+  offsets int DEFAULT 0
+) RETURNS TABLE (
+  name text,
+  id uuid,
+  updated_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ,
+  last_accessed_at TIMESTAMPTZ,
+  metadata jsonb
+) LANGUAGE plpgsql AS $function$
+DECLARE _bucketId text;
+BEGIN -- will be replaced by migrations when server starts
+-- saving space for cloud-init
+END $function$;
+-- create migrations table
+-- https://github.com/ThomWright/postgres-migrations/blob/master/src/migrations/0_create-migrations-table.sql
+-- we add this table here and not let it be auto-created so that the permissions are properly applied to it
+CREATE TABLE IF NOT EXISTS storage.migrations (
+  id integer PRIMARY KEY,
+  name varchar(100) UNIQUE NOT NULL,
+  hash varchar(40) NOT NULL,
+  -- sha1 hex encoded hash of the file name and contents, to ensure it hasn't been altered since applying the migration
+  executed_at timestamp DEFAULT current_timestamp
+);
+CREATE USER supabase_storage_admin NOINHERIT CREATEROLE LOGIN NOREPLICATION;
+GRANT ALL PRIVILEGES ON SCHEMA storage TO supabase_storage_admin;
+GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA storage TO supabase_storage_admin;
+GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA storage TO supabase_storage_admin;
+ALTER USER supabase_storage_admin
+SET search_path = "storage";
+ALTER table "storage".objects owner to supabase_storage_admin;
+ALTER table "storage".buckets owner to supabase_storage_admin;
+ALTER table "storage".migrations OWNER TO supabase_storage_admin;
+ALTER function "storage".foldername(text) owner to supabase_storage_admin;
+ALTER function "storage".filename(text) owner to supabase_storage_admin;
+ALTER function "storage".extension(text) owner to supabase_storage_admin;
+ALTER function "storage".search(text, text, int, int, int) owner to supabase_storage_admin;

--- a/terraform/supabase/definitions/volumes/db/init/sql/03-post-setup.sql
+++ b/terraform/supabase/definitions/volumes/db/init/sql/03-post-setup.sql
@@ -1,0 +1,62 @@
+ALTER ROLE postgres
+SET search_path TO "\$user",
+  public,
+  extensions;
+CREATE OR REPLACE FUNCTION extensions.notify_api_restart() RETURNS event_trigger LANGUAGE plpgsql AS $$ BEGIN NOTIFY pgrst,
+  'reload schema';
+END;
+$$;
+CREATE EVENT TRIGGER api_restart ON ddl_command_end EXECUTE PROCEDURE extensions.notify_api_restart();
+COMMENT ON FUNCTION extensions.notify_api_restart IS 'Sends a notification to the API to restart. If your database schema has changed, this is required so that Supabase can rebuild the relationships.';
+-- Trigger for pg_cron
+CREATE OR REPLACE FUNCTION extensions.grant_pg_cron_access() RETURNS event_trigger LANGUAGE plpgsql AS $$
+DECLARE schema_is_cron bool;
+BEGIN schema_is_cron = (
+  SELECT n.nspname = 'cron'
+  FROM pg_event_trigger_ddl_commands() AS ev
+    LEFT JOIN pg_catalog.pg_namespace AS n ON ev.objid = n.oid
+);
+IF schema_is_cron THEN
+grant usage on schema cron to postgres with
+grant option;
+alter default privileges in schema cron
+grant all on tables to postgres with
+grant option;
+alter default privileges in schema cron
+grant all on functions to postgres with
+grant option;
+alter default privileges in schema cron
+grant all on sequences to postgres with
+grant option;
+alter default privileges for user supabase_admin in schema cron
+grant all on sequences to postgres with
+grant option;
+alter default privileges for user supabase_admin in schema cron
+grant all on tables to postgres with
+grant option;
+alter default privileges for user supabase_admin in schema cron
+grant all on functions to postgres with
+grant option;
+grant all privileges on all tables in schema cron to postgres with
+grant option;
+END IF;
+END;
+$$;
+CREATE EVENT TRIGGER issue_pg_cron_access ON ddl_command_end
+WHEN TAG in ('CREATE SCHEMA') EXECUTE PROCEDURE extensions.grant_pg_cron_access();
+COMMENT ON FUNCTION extensions.grant_pg_cron_access IS 'Grants access to pg_cron';
+-- Supabase dashboard user
+CREATE ROLE dashboard_user NOSUPERUSER CREATEDB CREATEROLE REPLICATION;
+GRANT ALL ON DATABASE postgres TO dashboard_user;
+GRANT ALL ON SCHEMA auth TO dashboard_user;
+GRANT ALL ON SCHEMA extensions TO dashboard_user;
+GRANT ALL ON SCHEMA storage TO dashboard_user;
+GRANT ALL ON ALL TABLES IN SCHEMA auth TO dashboard_user;
+GRANT ALL ON ALL TABLES IN SCHEMA extensions TO dashboard_user;
+-- GRANT ALL ON ALL TABLES IN SCHEMA storage TO dashboard_user;
+GRANT ALL ON ALL SEQUENCES IN SCHEMA auth TO dashboard_user;
+GRANT ALL ON ALL SEQUENCES IN SCHEMA storage TO dashboard_user;
+GRANT ALL ON ALL SEQUENCES IN SCHEMA extensions TO dashboard_user;
+GRANT ALL ON ALL ROUTINES IN SCHEMA auth TO dashboard_user;
+GRANT ALL ON ALL ROUTINES IN SCHEMA storage TO dashboard_user;
+GRANT ALL ON ALL ROUTINES IN SCHEMA extensions TO dashboard_user;

--- a/terraform/supabase/main.tf
+++ b/terraform/supabase/main.tf
@@ -1,0 +1,3 @@
+module "Supabase" {
+  source = "./definitions"
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature - Support for local deployment of Supabase via Terraform (Original work from https://github.com/ChronSyn/terraform-supabase)

## What is the current behavior?

Users currently utilise the docker-compose method in order to run a local copy of Supabase, but this has some parts which are easy to overlook:

- Requires setting up several variables in both `kong.yml` and in env variables
- Users must manually generate JWT's and other secrets before beginning the process of deploying locally
- The initialisation schemas are not automatically executed, resulting in some of the containers crashing on startup until the schemas are executed

## What is the new behavior?

By using Terraform, I have been able to reduce the number of steps to 2 / 3 commands:

1. `terraform init`
2. `terraform plan` (optional)
3. `terraform init`

All important secrets such as Postgres password and JWT secret are generated automatically using the Terraform `random_password` provider resulting in cryptographically random values.

The anon and service role JWT's are generated via a docker container that I've built specifically for this purpose - source available at https://github.com/ChronSyn/docker-jwt-generator . There are a lack of JWT providers out there which would run on Terraform (either due to a lack of any documentation, or due to being incompatible with the ARM64 architecture of my M1 Pro MBP), and the existing docker-based solutions hardcoded some values such as `issuer`. This container resolves those issues, and you're more than welcome to fork it to the Supabase organisation if you wish to host it as part of the stack.

## Additional context

This work also includes several optional, but recommended, plugins such as Portainer, Watchtower and Nginx. These are disabled by default, but each is configured ready to run if the user chooses to enable them. Nginx is preconfigured for Supabase, and allows users to redirect `data.example.com` to the Kong container.

The kong container URL and port are hardcoded at this time to ensure compatibility with Nginx, but it might be a consideration to pass variable URL and port from a single location in the config.

As of writing, this doesn't support remote deployment to a VPS. I'm currently working on that, but I've not definite ETA for when it'll be ready.

Further context is included in the readme.