### PR TITLE
removed coming soon label for CDN #5808

### DIFF
--- a/www/pages/storage/Storage.tsx
+++ b/www/pages/storage/Storage.tsx
@@ -224,7 +224,6 @@ function StoragePage() {
                     title="CDN"
                     text="Serve from the edge to reduce latency."
                   />
-                  <Badge color="blue">Coming soon</Badge>
                 </div>
                 <div className="col-span-6 lg:col-span-12 xl:col-span-4">
                   <FeatureColumn


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug Fix

## What is the current behavior?

<img width="240" alt="Screen Shot 2022-03-05 at 6 54 22 PM" src="https://user-images.githubusercontent.com/43625213/156903567-248bdfca-d68b-45be-a9db-c324b41cab1b.png">

## What is the new behavior?

<img width="242" alt="Screen Shot 2022-03-05 at 6 54 56 PM" src="https://user-images.githubusercontent.com/43625213/156903577-c68378ff-e664-4666-9c58-944377a0ca86.png">

## Additional context

N/A
