### PR TITLE
fix: removed extra curly brace from updateUserById

### DIFF
--- a/web/spec/supabase.yml
+++ b/web/spec/supabase.yml
@@ -892,55 +892,55 @@ pages:
         isSpotlight: true
         js: |
           ```js
-          const { data: user, error } = await supabase.auth.api.updateUserById({
-            uid: '6aa5d0d4-2a9f-4483-b6c8-0cf4c6c98ac4',
-            attributes: { email: 'new@email.com' },
-          })
+          const { data: user, error } = await supabase.auth.api.updateUserById(
+            '6aa5d0d4-2a9f-4483-b6c8-0cf4c6c98ac4',
+            { email: 'new@email.com' }
+          )
           ```
       - name: Updates a user's password.
         isSpotlight: true
         js: |
           ```js
-          const { data: user, error } = await supabase.auth.api.updateUserById({
-            uid: '6aa5d0d4-2a9f-4483-b6c8-0cf4c6c98ac4',
-            attributes: { password: 'new@email.com' },
-          })
+          const { data: user, error } = await supabase.auth.api.updateUserById(
+            '6aa5d0d4-2a9f-4483-b6c8-0cf4c6c98ac4',
+            { password: 'new@email.com' }
+          )
           ```
       - name: Updates a user's metadata.
         isSpotlight: true
         js: |
           ```js
-          const { data: user, error } = await supabase.auth.api.updateUserById({
-            uid: '6aa5d0d4-2a9f-4483-b6c8-0cf4c6c98ac4',
-            attributes: { user_metadata: { hello: 'world' } },
-          })
+          const { data: user, error } = await supabase.auth.api.updateUserById(
+            '6aa5d0d4-2a9f-4483-b6c8-0cf4c6c98ac4',
+            { user_metadata: { hello: 'world' } }
+          )
           ```
       - name: Updates a user's app_metadata.
         isSpotlight: true
         js: |
           ```js
-          const { data: user, error } = await supabase.auth.api.updateUserById({
-            uid: '6aa5d0d4-2a9f-4483-b6c8-0cf4c6c98ac4',
-            attributes: { app_metadata: { plan: 'trial' } },
-          })
+          const { data: user, error } = await supabase.auth.api.updateUserById(
+            '6aa5d0d4-2a9f-4483-b6c8-0cf4c6c98ac4',
+            { app_metadata: { plan: 'trial' } }
+          )
           ```
       - name: Confirms a user's email address.
         isSpotlight: true
         js: |
           ```js
-          const { data: user, error } = await supabase.auth.api.updateUserById({
-            uid: '6aa5d0d4-2a9f-4483-b6c8-0cf4c6c98ac4',
-            attributes: { email_confirm: true },
-          })
+          const { data: user, error } = await supabase.auth.api.updateUserById(
+            '6aa5d0d4-2a9f-4483-b6c8-0cf4c6c98ac4',
+            { email_confirm: true }
+          )
           ```
       - name: Confirms a user's phone number.
         isSpotlight: true
         js: |
           ```js
-          const { data: user, error } = await supabase.auth.api.updateUserById({
-            uid: '6aa5d0d4-2a9f-4483-b6c8-0cf4c6c98ac4',
-            attributes: { phone_number: true },
-          })
+          const { data: user, error } = await supabase.auth.api.updateUserById(
+            '6aa5d0d4-2a9f-4483-b6c8-0cf4c6c98ac4',
+            { phone_number: true }
+          )
           ```
 
   select():

--- a/web/spec/supabase.yml
+++ b/web/spec/supabase.yml
@@ -894,7 +894,7 @@ pages:
           ```js
           const { data: user, error } = await supabase.auth.api.updateUserById({
             uid: '6aa5d0d4-2a9f-4483-b6c8-0cf4c6c98ac4',
-            attributes: { email: 'new@email.com' } },
+            attributes: { email: 'new@email.com' },
           })
           ```
       - name: Updates a user's password.
@@ -903,7 +903,7 @@ pages:
           ```js
           const { data: user, error } = await supabase.auth.api.updateUserById({
             uid: '6aa5d0d4-2a9f-4483-b6c8-0cf4c6c98ac4',
-            attributes: { password: 'new@email.com' } },
+            attributes: { password: 'new@email.com' },
           })
           ```
       - name: Updates a user's metadata.

--- a/web/spec/supabase.yml
+++ b/web/spec/supabase.yml
@@ -903,7 +903,7 @@ pages:
           ```js
           const { data: user, error } = await supabase.auth.api.updateUserById(
             '6aa5d0d4-2a9f-4483-b6c8-0cf4c6c98ac4',
-            { password: 'new@email.com' }
+            { password: 'new_password' }
           )
           ```
       - name: Updates a user's metadata.


### PR DESCRIPTION
## What kind of change does this PR introduce?

It's a doc update

## What is the current behavior?

Currently, there is an extra curly brace after `attributes: ` value. Link: `https://supabase.com/docs/reference/javascript/auth-api-updateuserbyid`

## What is the new behavior?

The extra curly brace is being removed.


## Additional context

Add any other context or screenshots.
<img width="810" alt="Screenshot 2022-03-06 at 9 02 27 AM" src="https://user-images.githubusercontent.com/54183698/156908058-4bd6b222-3b19-46c6-bfdd-af4e224d672a.png">
