### PR TITLE
fix studio docker image build error

### DIFF
--- a/studio/Dockerfile
+++ b/studio/Dockerfile
@@ -8,6 +8,10 @@
 
 
 FROM node:14-slim as base
+RUN apt-get update && apt-get install -y \
+    python3 \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
 WORKDIR /usr/src/app
 # Do `npm ci` separately so we can cache `node_modules`
 # https://nodejs.org/en/docs/guides/nodejs-docker-webapp/


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to fix Studio docker image build failure.

## What is the current behavior?

The current Dockerfile doesn't include python/gcc/make etc. toolchain which failed node-gyp installation, thus failed building the docker image.

## What is the new behavior?

The Studio docker image should be build successfully and updated to Docker Hub.

## Additional context

Once the docker image is updated and published, this #5816 will also be fixed.
