### PR TITLE
Adding realtime-go to go community libraries

### DIFF
--- a/web/spec/supabase.yml
+++ b/web/spec/supabase.yml
@@ -51,7 +51,7 @@ info:
         <td>-</td>
         <td><a href="https://github.com/supabase-community/postgrest-go" target="_blank" rel="noopener noreferrer">postgrest-go</a></td>
         <td>-</td>
-        <td>-</td>
+        <td><a href="https://github.com/overseedio/realtime-go" target="_blank" rel="noopener noreferrer">realtime-go</a></td>
         <td><a href="https://github.com/supabase-community/storage-go" target="_blank" rel="noopener noreferrer">storage-go</a></td>
       </tr>
       <tr>


### PR DESCRIPTION
PR to add realtime-go to the supabase go community libraries. 
Package currently hosted/maintained at overseedio: https://github.com/overseedio/realtime-go

## What kind of change does this PR introduce?

Proposes to add realtime-go as a community library in the supabase-community org.

## What is the current behavior?

No realtime-go package exists.

## What is the new behavior?

realtime-go added to the community-maintained packages.

## Additional context

Move https://github.com/overseedio/realtime-go to supabase-community.
