### PR TITLE
docs: RedwoodJS Quickstart Guide - Update location of example repo

### DIFF
--- a/web/docs/guides/with-redwoodjs.mdx
+++ b/web/docs/guides/with-redwoodjs.mdx
@@ -38,7 +38,7 @@ Note: For RedwoodJS apps, port will be 8910
 
 ### GitHub
 
-If you get stuck at any point, take a look at [this repo](https://github.com/dthyresson/redwoodjs-supabase-quickstart).
+If you get stuck at any point, take a look at [this repo](https://github.com/redwoodjs/redwoodjs-supabase-quickstart).
 
 <!-- ## Video demo
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

RedwoodJS Quickstart Guide - Updates location of example repo

## What is the current behavior?

The current guide links to a repository in my personal GitHub account

## What is the new behavior?

But we elected ahead of both Supabase and Redwood launch week to move this example repo into the RedwoodJS organization to make it easier for people to find and maintain.

## Additional context

This is the Supabase + RW Quickstart and another one will be added that works more with Prisma ahead of Launch week.