### PR TITLE
Chore: update studio selection color

### DIFF
--- a/studio/styles/ui.scss
+++ b/studio/styles/ui.scss
@@ -271,7 +271,7 @@
 }
 
 ::selection {
-  @apply bg-brand-900;
+  background-color: #6ee7b7;
   color: #333 !important;
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Update the selection background color. The reason is that `brand-900` when switching themes, the color does not stay the same and looks off.

## What is the current behavior?

Using `brand-900`

## What is the new behavior?

Using `#6ee7b7`