### PR TITLE
Fix: broken link

### DIFF
--- a/studio/components/layouts/AccountLayout/WithSidebar.tsx
+++ b/studio/components/layouts/AccountLayout/WithSidebar.tsx
@@ -164,18 +164,13 @@ const SidebarItem: FC<any> = ({ id, label, href, isActive, isSubitem, onClick, e
   return (
     <Link href={href || ''}>
       <a className="block" target={external ? '_blank' : '_self'}>
-        <Menu.Item
-          rounded
-          key={id}
-          style={{
-            marginLeft: isSubitem && '.5rem',
-          }}
-          active={isActive ? true : false}
+        <button
+          className="cursor-pointer flex space-x-2 items-center outline-none focus-visible:ring-1 ring-scale-1200 focus-visible:z-10 group py-1 font-normal border-scale-500 group-hover:border-scale-900"
           onClick={onClick || (() => {})}
-          icon={external && <IconArrowUpRight size={'tiny'} />}
         >
-          {isSubitem ? <Typography.Text small>{label}</Typography.Text> : label}
-        </Menu.Item>
+          <span className="transition truncate text-sm text-scale-900 group-hover:text-scale-1100">{external && <IconArrowUpRight size={'tiny'} />}</span>
+          <span className="transition truncate text-sm w-full text-scale-1100 group-hover:text-scale-1200">{isSubitem ? <p>{label}</p> : label}</span>
+        </button>
       </a>
     </Link>
   )


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix a problem with all the links on the sidebar leading to `/#`.

## What is the current behavior?

As you can see, all the links are leading to `/#` and lead nowhere. The reason why is because there are two `<a>` tags. the parent `<a>` as the correct link but the but child `<a>` has `/#` as the link.
<img width="428" alt="Screen Shot 2022-03-12 at 12 55 39 PM" src="https://user-images.githubusercontent.com/70828596/158029314-9eb91eaa-eac2-4782-8b64-e59d27e43bcd.png">

## What is the new behavior?

I removed the child `<a>` and now the problem is no longer there.
<img width="428" alt="Screen Shot 2022-03-12 at 12 56 11 PM" src="https://user-images.githubusercontent.com/70828596/158029320-19bc350c-beef-410b-ad31-b24e0079b777.png">

## Additional Contacts

The main problem seemed to be the `<Menu.Item>` component. I don't know why the component was creating a second blank `<a>` tag. 🤔