### PR TITLE
Adding Examples for format of .or, .not and .filter to JS and Dart docs.

### DIFF
--- a/web/spec/dart.yml
+++ b/web/spec/dart.yml
@@ -1255,7 +1255,7 @@ pages:
 
   .not():
     description: |
-      Finds all rows which doesn't satisfy the filter
+      Finds all rows which doesn't satisfy the filter.
     notes: |
           - `.not()` expects you to use the raw [PostgREST syntax](https://postgrest.org/en/stable/api.html#horizontal-filtering-rows) for the filter names and values.
 

--- a/web/spec/dart.yml
+++ b/web/spec/dart.yml
@@ -1213,6 +1213,14 @@ pages:
   .or():
     description: |
       Finds all rows satisfying at least one of the filters.
+    notes: |
+      - `.or()` expects you to use the raw [PostgREST syntax](https://postgrest.org/en/stable/api.html#horizontal-filtering-rows) for the filter names and values.
+
+        ```dart
+        .or('id.in.(6,7),arraycol.cs.{"a","b"}')  // Use Postgres list () and 'in' for in_ filter. Array {} and 'cs' for contains.
+        .or('id.in.(${mylist.join(',')}),arraycol.cs.{${mylistArray.join(',')}}')	// You can insert a Dart list for list or array column.
+        .or('id.in.(${mylist.join(',')}),rangecol.cs.(${mylistRange.join(',')}]')	// You can insert a Dart list for list or range column.
+        ```  
     examples:
       - name: With `select()`
         isSpotlight: true
@@ -1248,6 +1256,16 @@ pages:
   .not():
     description: |
       Finds all rows which doesn't satisfy the filter.
+   notes: |
+          - `.not()` expects you to use the raw [PostgREST syntax](https://postgrest.org/en/stable/api.html#horizontal-filtering-rows) for the filter names and values.
+
+            ```dart
+            .not('name','eq','Paris')
+            .not('arraycol','cs','{"a","b"}') // Use Postgres array {} for array column and 'cs' for contains.
+            .not('rangecol','cs','(1,2]') // Use Postgres range syntax for range column.
+            .not('id','in','(6,7)')  // Use Postgres list () and 'in' for in_ filter.
+            .not('id','in','(${mylist.join(',')})')  // You can insert a Dart list array.
+            ```
     examples:
       - name: With `select()`
         isSpotlight: true
@@ -2144,7 +2162,13 @@ pages:
     description: |
       Finds all rows whose `column` satisfies the filter.
     notes: |
-      - `.filter()` expects you to use the raw [PostgREST syntax](https://postgrest.org/en/stable/api.html#horizontal-filtering-rows) for the filter values, so it should only be used as an escape hatch in case other filters don't work.
+      - `.filter()` expects you to use the raw [PostgREST syntax](https://postgrest.org/en/stable/api.html#horizontal-filtering-rows) for the filter names and values, so it should only be used as an escape hatch in case other filters don't work.
+        ```dart
+          .filter('arraycol','cs','{"a","b"}') // Use Postgres array {} and 'cs' for contains.
+          .filter('rangecol','cs','(1,2]') // Use Postgres range syntax for range column.
+          .filter('id','in','(6,7)')  // Use Postgres list () and 'in' for in_ filter.
+          .filter('id','cs','{${mylist.join(',')}}')  // You can insert a Dart array list.
+        ```
     examples:
       - name: With `select()`
         isSpotlight: true

--- a/web/spec/dart.yml
+++ b/web/spec/dart.yml
@@ -1256,7 +1256,7 @@ pages:
   .not():
     description: |
       Finds all rows which doesn't satisfy the filter.
-   notes: |
+    notes: |
           - `.not()` expects you to use the raw [PostgREST syntax](https://postgrest.org/en/stable/api.html#horizontal-filtering-rows) for the filter names and values.
 
             ```dart

--- a/web/spec/dart.yml
+++ b/web/spec/dart.yml
@@ -1255,7 +1255,7 @@ pages:
 
   .not():
     description: |
-      Finds all rows which doesn't satisfy the filter.
+      Finds all rows which doesn't satisfy the filter
     notes: |
           - `.not()` expects you to use the raw [PostgREST syntax](https://postgrest.org/en/stable/api.html#horizontal-filtering-rows) for the filter names and values.
 

--- a/web/spec/supabase.yml
+++ b/web/spec/supabase.yml
@@ -1882,6 +1882,14 @@ pages:
 
   .or():
     $ref: '@supabase/postgrest-js."lib/PostgrestFilterBuilder".PostgrestFilterBuilder.or'
+    notes: |
+      - `.or()` expects you to use the raw [PostgREST syntax](https://postgrest.org/en/stable/api.html#horizontal-filtering-rows) for the filter names and values.
+
+        ```js
+        .or('id.in.(6,7), arraycol.cs.{"a","b"}')  // Use Postgres list () for in filter. Array {} for array column and 'cs' for contains.
+        .or(`id.in.(${arrList}),arraycol.cs.{${arr}}`)	// You can insert a javascipt array for list or array on array column.
+        .or(`id.in.(${arrList}),rangecol.cs.[${arrRange})`)	// You can insert a javascipt array for list or range on a range column.
+        ```
     examples:
       - name: With `select()`
         isSpotlight: true
@@ -1913,6 +1921,16 @@ pages:
 
   .not():
     $ref: '@supabase/postgrest-js."lib/PostgrestFilterBuilder".PostgrestFilterBuilder.not'
+    notes: |
+      - `.not()` expects you to use the raw [PostgREST syntax](https://postgrest.org/en/stable/api.html#horizontal-filtering-rows) for the filter names and values.
+
+        ```js
+          .not('name','eq','Paris')
+          .not('arraycol','cs','{"a","b"}') // Use Postgres array {} for array column and 'cs' for contains.
+          .not('rangecol','cs','(1,2]') // Use Postgres range syntax for range column.
+          .not('id','in','(6,7)')  // Use Postgres list () for in filter.
+          .not('id','in',`(${arr})`)  // You can insert a javascript array.
+        ```
     examples:
       - name: With `select()`
         isSpotlight: true
@@ -2713,7 +2731,13 @@ pages:
   .filter():
     $ref: '@supabase/postgrest-js."lib/PostgrestFilterBuilder".PostgrestFilterBuilder.filter'
     notes: |
-      - `.filter()` expects you to use the raw [PostgREST syntax](https://postgrest.org/en/stable/api.html#horizontal-filtering-rows) for the filter values, so it should only be used as an escape hatch in case other filters don't work.
+      - `.filter()` expects you to use the raw [PostgREST syntax](https://postgrest.org/en/stable/api.html#horizontal-filtering-rows) for the filter names and values, so it should only be used as an escape hatch in case other filters don't work.
+        ```js
+          .filter('arraycol','cs','{"a","b"}') // Use Postgres array {} for array column and 'cs' for contains.
+          .filter('rangecol','cs','(1,2]') // Use Postgres range syntax for range column.
+          .filter('id','in','(6,7)')  // Use Postgres list () for in filter.
+          .filter('id','in',`(${arr})`)  // You can insert a javascript array.
+        ```
     examples:
       - name: With `select()`
         isSpotlight: true


### PR DESCRIPTION
## What kind of change does this PR introduce?
Document Update

## What is the current behavior?
It is unclear on format of filter names and values needing to use PostgREST format for .or, .not and .filter.

## What is the new behavior?

Adds examples to these filters.

Add any other context or screenshots.
