### PR TITLE
fix: make org switch go the all list of project instead of settings

### DIFF
--- a/studio/components/layouts/ProjectLayout/LayoutHeader/OrgDropdown.tsx
+++ b/studio/components/layouts/ProjectLayout/LayoutHeader/OrgDropdown.tsx
@@ -21,7 +21,7 @@ const OrgDropdown = () => {
           {sortedOrganizations
             .sort((a, b) => a.name.localeCompare(b.name))
             .map((x) => (
-              <Dropdown.Item key={x.slug} onClick={() => router.push(`/org/${x.slug}/settings`)}>
+              <Dropdown.Item key={x.slug} onClick={() => router.push(`/`)}>
                 {x.name}
               </Dropdown.Item>
             ))}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Using the switch to switch project allow you to see other project but use the same for org lead you to got to setting.
For users, both should be use for the same purpose, changing project.
Since there not page to see all project of one org i propose to go to all project page, who is the page user will reach to follow the behaviour of changing project.

## What is the current behaviour?

Current switch usage lead you to orgs settings

## What is the new behaviour?

Go to all org/project list


