### PR TITLE
feat/studio/logs: Separated logs querying logic into two separate hooks

### DIFF
--- a/studio/components/interfaces/Settings/Logs/LogPanel.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogPanel.tsx
@@ -17,6 +17,7 @@ import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
 interface Props {
   defaultSearchValue?: string
+  defaultFromValue?: string
   defaultToValue?: string
   templates?: any
   isLoading: boolean
@@ -43,6 +44,7 @@ const LogPanel: FC<Props> = ({
   onRefresh,
   onSearch = () => {},
   defaultSearchValue = '',
+  defaultFromValue = '',
   defaultToValue = '',
   onCustomClick,
   onSelectTemplate,
@@ -51,6 +53,7 @@ const LogPanel: FC<Props> = ({
 }) => {
   const [search, setSearch] = useState('')
   const [to, setTo] = useState({ value: '', error: '' })
+  const [from, setFrom] = useState({ value: '', error: '' })
   const [defaultTimestamp, setDefaultTimestamp] = useState(dayjs().utc().toISOString())
 
   // Sync local state with provided default value
@@ -64,9 +67,12 @@ const LogPanel: FC<Props> = ({
     if (to.value !== defaultToValue) {
       setTo({ value: defaultToValue, error: '' })
     }
-  }, [defaultToValue])
+    if (from.value !== defaultFromValue) {
+      setFrom({ value: defaultFromValue, error: '' })
+    }
+  }, [defaultToValue, defaultFromValue])
 
-  const handleFromChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleToChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value
     if (value !== '' && isNaN(Date.parse(value))) {
       setTo({ value, error: 'Invalid ISO 8601 timestamp' })
@@ -74,16 +80,26 @@ const LogPanel: FC<Props> = ({
       setTo({ value, error: '' })
     }
   }
-  const handleFromReset = async () => {
+
+  const handleFromChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value
+    if (value !== '' && isNaN(Date.parse(value))) {
+      setFrom({ value, error: 'Invalid ISO 8601 timestamp' })
+    } else {
+      setFrom({ value, error: '' })
+    }
+  }
+  const handleReset = async () => {
     setTo({ value: '', error: '' })
+    setFrom({ value: '', error: '' })
     const value = dayjs().utc().toISOString()
     setDefaultTimestamp(value)
-    onSearch({ query: search, to: '' })
+    onSearch({ query: search, to: '', from: '' })
   }
 
-  const handleSearch = () => onSearch({ query: search, to: to.value })
+  const handleSearch = () => onSearch({ query: search, to: to.value, from: from.value })
 
-  const showFromReset = to.value !== ''
+  const showReset = to.value !== '' || from.value !== ''
   return (
     <div className="bg-panel-header-light dark:bg-panel-header-dark">
       <div className="px-2 py-1 flex items-center justify-between w-full">
@@ -147,14 +163,24 @@ const LogPanel: FC<Props> = ({
                   align="end"
                   portalled
                   overlay={
-                    <Input
-                      label="To"
-                      labelOptional="UTC"
-                      value={to.value === '' ? defaultTimestamp : to.value}
-                      onChange={handleFromChange}
-                      error={to.error}
-                      className="w-72 p-3"
-                      actions={[
+                    <>
+                      <Input
+                        label="From"
+                        labelOptional="UTC"
+                        value={from.value === '' ? defaultTimestamp : from.value}
+                        onChange={handleFromChange}
+                        error={from.error}
+                        className="w-72 p-3"
+                      />
+                      <Input
+                        label="To"
+                        labelOptional="UTC"
+                        value={to.value === '' ? defaultTimestamp : to.value}
+                        onChange={handleToChange}
+                        error={to.error}
+                        className="w-72 p-3"
+                      />
+                      <div className="flex flex-row justify-end pb-2 px-4">
                         <Button
                           key="set"
                           size="tiny"
@@ -163,29 +189,29 @@ const LogPanel: FC<Props> = ({
                           onClick={handleSearch}
                         >
                           Set
-                        </Button>,
-                      ]}
-                    />
+                        </Button>
+                      </div>
+                    </>
                   }
                 >
                   <Button
                     as="span"
                     size="tiny"
-                    className={showFromReset ? '!rounded-r-none' : ''}
-                    type={showFromReset ? 'outline' : 'text'}
+                    className={showReset ? '!rounded-r-none' : ''}
+                    type={showReset ? 'outline' : 'text'}
                     icon={<IconClock size="tiny" />}
                   >
-                    {to.value ? 'Custom' : 'Now'}
+                    {to.value || from.value ? 'Custom' : 'Now'}
                   </Button>
                 </Popover>
-                {showFromReset && (
+                {showReset && (
                   <Button
                     size="tiny"
-                    className={showFromReset ? '!rounded-l-none' : ''}
+                    className={showReset ? '!rounded-l-none' : ''}
                     icon={<IconX size="tiny" />}
                     type="outline"
                     title="Clear timestamp filter"
-                    onClick={handleFromReset}
+                    onClick={handleReset}
                   />
                 )}
               </div>

--- a/studio/components/interfaces/Settings/Logs/LogPanel.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogPanel.tsx
@@ -17,7 +17,7 @@ import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
 interface Props {
   defaultSearchValue?: string
-  defaultFromValue?: string
+  defaultToValue?: string
   templates?: any
   isLoading: boolean
   isCustomQuery: boolean
@@ -43,14 +43,14 @@ const LogPanel: FC<Props> = ({
   onRefresh,
   onSearch = () => {},
   defaultSearchValue = '',
-  defaultFromValue = '',
+  defaultToValue = '',
   onCustomClick,
   onSelectTemplate,
   isShowingEventChart,
   onToggleEventChart,
 }) => {
   const [search, setSearch] = useState('')
-  const [from, setFrom] = useState({ value: '', error: '' })
+  const [to, setTo] = useState({ value: '', error: '' })
   const [defaultTimestamp, setDefaultTimestamp] = useState(dayjs().utc().toISOString())
 
   // Sync local state with provided default value
@@ -61,61 +61,63 @@ const LogPanel: FC<Props> = ({
   }, [defaultSearchValue])
 
   useEffect(() => {
-    if (from.value !== defaultFromValue) {
-      setFrom({ value: defaultFromValue, error: '' })
+    if (to.value !== defaultToValue) {
+      setTo({ value: defaultToValue, error: '' })
     }
-  }, [defaultFromValue])
+  }, [defaultToValue])
 
   const handleFromChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value
     if (value !== '' && isNaN(Date.parse(value))) {
-      setFrom({ value, error: 'Invalid ISO 8601 timestamp' })
+      setTo({ value, error: 'Invalid ISO 8601 timestamp' })
     } else {
-      setFrom({ value, error: '' })
+      setTo({ value, error: '' })
     }
   }
   const handleFromReset = async () => {
-    setFrom({ value: '', error: '' })
+    setTo({ value: '', error: '' })
     const value = dayjs().utc().toISOString()
     setDefaultTimestamp(value)
-    onSearch({ query: search, from: '' })
+    onSearch({ query: search, to: '' })
   }
 
-  const handleSearch = () => onSearch({ query: search, from: from.value })
+  const handleSearch = () => onSearch({ query: search, to: to.value })
 
-  const showFromReset = from.value !== ''
+  const showFromReset = to.value !== ''
   return (
     <div className="bg-panel-header-light dark:bg-panel-header-dark">
       <div className="px-2 py-1 flex items-center justify-between w-full">
         <div className="flex flex-row gap-x-4 items-center">
-          <Button
-            type="text"
-            icon={
-              <div className="relative">
-                {newCount > 0 && (
-                  <div
-                    className={[
-                      'absolute flex items-center justify-center -top-3 right-3',
-                      'h-4 w-4 z-50',
-                    ].join(' ')}
-                  >
-                    <div className="absolute z-20">
-                      <Typography.Text style={{ fontSize: '0.6rem' }} className="opacity-80">
-                        {newCount}
-                      </Typography.Text>
+          {!isCustomQuery && (
+            <Button
+              type="text"
+              icon={
+                <div className="relative">
+                  {newCount > 0 && (
+                    <div
+                      className={[
+                        'absolute flex items-center justify-center -top-3 right-3',
+                        'h-4 w-4 z-50',
+                      ].join(' ')}
+                    >
+                      <div className="absolute z-20">
+                        <Typography.Text style={{ fontSize: '0.6rem' }} className="opacity-80">
+                          {newCount}
+                        </Typography.Text>
+                      </div>
+                      <div className="bg-green-800 rounded-full w-full h-full animate-ping opacity-60"></div>
+                      <div className="absolute z-60 top-0 right-0 bg-green-900 opacity-80 rounded-full w-full h-full"></div>
                     </div>
-                    <div className="bg-green-800 rounded-full w-full h-full animate-ping opacity-60"></div>
-                    <div className="absolute z-60 top-0 right-0 bg-green-900 opacity-80 rounded-full w-full h-full"></div>
-                  </div>
-                )}
-                <IconRefreshCw />
-              </div>
-            }
-            loading={isLoading}
-            onClick={onRefresh}
-          >
-            Refresh
-          </Button>
+                  )}
+                  <IconRefreshCw />
+                </div>
+              }
+              loading={isLoading}
+              onClick={onRefresh}
+            >
+              Refresh
+            </Button>
+          )}
           <Dropdown
             side="bottom"
             align="start"
@@ -130,12 +132,13 @@ const LogPanel: FC<Props> = ({
             </Button>
           </Dropdown>
 
-          <div className="flex items-center space-x-2">
-            <p className="text-xs">Search logs via query</p>
-            <Toggle size="tiny" checked={isCustomQuery} onChange={onCustomClick} />
-          </div>
+          {!isCustomQuery && (
+            <Button as="span" type="outline" onClick={onCustomClick}>
+              Explore via query
+            </Button>
+          )}
         </div>
-        <div className="flex items-center gap-x-4">
+        <div className="flex items-center   gap-x-4">
           {!isCustomQuery && (
             <>
               <div className="flex flex-row">
@@ -145,11 +148,11 @@ const LogPanel: FC<Props> = ({
                   portalled
                   overlay={
                     <Input
-                      label="From"
+                      label="To"
                       labelOptional="UTC"
-                      value={from.value === '' ? defaultTimestamp : from.value}
+                      value={to.value === '' ? defaultTimestamp : to.value}
                       onChange={handleFromChange}
-                      error={from.error}
+                      error={to.error}
                       className="w-72 p-3"
                       actions={[
                         <Button
@@ -172,7 +175,7 @@ const LogPanel: FC<Props> = ({
                     type={showFromReset ? 'outline' : 'text'}
                     icon={<IconClock size="tiny" />}
                   >
-                    {from.value ? 'Custom' : 'Now'}
+                    {to.value ? 'Custom' : 'Now'}
                   </Button>
                 </Popover>
                 {showFromReset && (

--- a/studio/components/interfaces/Settings/Logs/Logs.constants.ts
+++ b/studio/components/interfaces/Settings/Logs/Logs.constants.ts
@@ -172,15 +172,35 @@ LIMIT 100
 ]
 
 export const LOG_TYPE_LABEL_MAPPING: { [k: string]: string } = {
+  explorer: "Explorer",
   api: 'API',
   database: 'Database',
 }
 
-export const genDefaultQuery = (table: string): string => `SELECT
-  id, timestamp, event_message, metadata
+export const genDefaultQuery = (table: string, where: string = ''): string => `SELECT 
+  id, timestamp, event_message, metadata 
 FROM
-  ${table}
+  ${table}${where ? ' WHERE\n  ' + where : ''} 
 LIMIT 100
 `
+export const cleanQuery = (str: string) => str.replaceAll(/\n/g, ' ')
+// .replace(/\n.*\-\-.*(\n)?$?/, "")
 
+
+export enum LogsTableName {
+  EDGE = 'edge_logs',
+  POSTGRES = 'postgres_logs',
+}
 export const genCountQuery = (table: string): string => `SELECT count(*) as count FROM ${table}`
+
+export const genQueryParams = (params: { [k: string ]: string }) => {
+  // remove keys which are empty strings, null, or undefined
+  for (const k in params) {
+    const v = params[k]
+    if (v === null || v === '' || v === undefined) {
+      delete params[k]
+    }
+  }
+  const qs = new URLSearchParams(params).toString()
+  return qs
+}

--- a/studio/components/interfaces/Settings/Logs/Logs.constants.ts
+++ b/studio/components/interfaces/Settings/Logs/Logs.constants.ts
@@ -183,7 +183,7 @@ FROM
   ${table}${where ? ' WHERE\n  ' + where : ''} 
 LIMIT 100
 `
-export const cleanQuery = (str: string) => str.replaceAll(/\n/g, ' ')
+export const cleanQuery = (str: string) => str.replace(/\n/g, ' ')
 // .replace(/\n.*\-\-.*(\n)?$?/, "")
 
 

--- a/studio/components/interfaces/Settings/Logs/Logs.types.ts
+++ b/studio/components/interfaces/Settings/Logs/Logs.types.ts
@@ -1,7 +1,7 @@
 interface Metadata {
   [key: string]: string | number | Object | Object[]
 }
-export type LogSearchCallback = (filters: { query: string; to?: string; toMicro?: number }) => void
+export type LogSearchCallback = (filters: { query: string; to?: string; from?: string; fromMicro?: number, toMicro?: number }) => void
 
 export interface LogsEndpointParams {
   // project ref

--- a/studio/components/interfaces/Settings/Logs/Logs.types.ts
+++ b/studio/components/interfaces/Settings/Logs/Logs.types.ts
@@ -1,11 +1,21 @@
 interface Metadata {
   [key: string]: string | number | Object | Object[]
 }
-export type LogSearchCallback = (filters: {
-  query: string
-  from?: string
-  fromMicro?: number
-}) => void
+export type LogSearchCallback = (filters: { query: string; to?: string; toMicro?: number }) => void
+
+export interface LogsEndpointParams {
+  // project ref
+  project: string
+  // micro unix timestamp
+  timestamp_start?: string
+  // micro timestamp
+  timestamp_end?: string
+  period_start?: string
+  period_end?: string
+  sql: string
+  rawSql: string
+}
+
 export interface LogData {
   id: string
   timestamp: number

--- a/studio/components/layouts/SettingsLayout/SettingsMenu.utils.ts
+++ b/studio/components/layouts/SettingsLayout/SettingsMenu.utils.ts
@@ -2,7 +2,7 @@ import { LOG_TYPE_LABEL_MAPPING } from 'components/interfaces/Settings/Logs'
 import { ProductMenuGroup } from 'components/ui/ProductMenu/ProductMenu.types'
 
 export const generateSettingsMenu = (ref: string): ProductMenuGroup[] => {
-  const logTypes: string[] = ['database', 'api']
+  const logTypes: string[] = ['explorer', 'database', 'api']
 
   return [
     {

--- a/studio/hooks/analytics/useLogsPreview.tsx
+++ b/studio/hooks/analytics/useLogsPreview.tsx
@@ -23,6 +23,7 @@ interface Data<T> {
   pageSize: number
   filters: T
   params: LogsEndpointParams
+  oldestTimestamp?: string
 }
 interface Handlers<T> {
   loadOlder: () => void
@@ -58,6 +59,8 @@ function useLogsPreview<Filters>(
     rawSql: genDefaultQuery(table),
     period_start: '',
     period_end: '',
+    timestamp_start: '',
+    timestamp_end: '',
   })
   const [filters, setFilters] = useState<Filters>(options.initialFilters)
 
@@ -122,9 +125,18 @@ function useLogsPreview<Filters>(
       error = response.error
     }
   })
-
+  const oldestTimestamp = logData[logData.length - 1]?.timestamp
   return [
-    { newCount, logData, isLoading: isValidating, pageSize: size, error, filters, params },
+    {
+      newCount,
+      logData,
+      isLoading: isValidating,
+      pageSize: size,
+      error,
+      filters,
+      params,
+      oldestTimestamp: oldestTimestamp ? String(oldestTimestamp) : undefined,
+    },
     {
       setFrom: (value) => setParams((prev) => ({ ...prev, timestamp_start: value })),
       setTo: (value) => setParams((prev) => ({ ...prev, timestamp_end: value })),

--- a/studio/hooks/analytics/useLogsPreview.tsx
+++ b/studio/hooks/analytics/useLogsPreview.tsx
@@ -1,0 +1,137 @@
+import {
+  cleanQuery,
+  Count,
+  genCountQuery,
+  genDefaultQuery,
+  genQueryParams,
+  LogData,
+  Logs,
+  LogsEndpointParams,
+  LogsTableName,
+} from 'components/interfaces/Settings/Logs'
+import { Dispatch, SetStateAction, useEffect, useState } from 'react'
+import useSWR from 'swr'
+import useSWRInfinite, { SWRInfiniteKeyLoader } from 'swr/infinite'
+import { API_URL } from 'lib/constants'
+import { get } from 'lib/common/fetch'
+
+interface Data<T> {
+  logData: LogData[]
+  error: string | Object | null
+  newCount: number
+  isLoading: boolean
+  pageSize: number
+  filters: T
+  params: LogsEndpointParams
+}
+interface Handlers<T> {
+  loadOlder: () => void
+  refresh: () => void
+  setFilters: Dispatch<SetStateAction<T>>
+  setFrom: (value: string) => void
+  setTo: (value: string) => void
+}
+
+interface Options<Filters> {
+  initialFilters: Filters
+  whereStatementFactory: WhereStatementFactory<Filters>
+}
+
+type WhereStatementFactory<T> = (filters: T) => string
+
+function useLogsPreview<Filters>(
+  projectRef: string,
+  table: LogsTableName,
+  opts?: Partial<Options<Filters>>
+): [Data<Filters>, Handlers<Filters>] {
+  const options: Options<Filters> = {
+    initialFilters: {} as Filters,
+    whereStatementFactory: () => '',
+    ...(opts ?? {}),
+  }
+
+  const [latestRefresh, setLatestRefresh] = useState<string>(new Date().toISOString())
+
+  const [params, setParams] = useState<LogsEndpointParams>({
+    project: projectRef,
+    sql: cleanQuery(genDefaultQuery(table)),
+    rawSql: genDefaultQuery(table),
+    period_start: '',
+    period_end: '',
+  })
+  const [filters, setFilters] = useState<Filters>(options.initialFilters)
+
+  useEffect(() => {
+    if (filters !== {}) {
+      const generatedSql = genDefaultQuery(table, options.whereStatementFactory(filters))
+
+      setParams((prev) => ({ ...prev, sql: cleanQuery(generatedSql), rawSql: generatedSql }))
+    }
+  }, [JSON.stringify(filters)])
+
+  // handle url generation for log pagination
+  const getKeyLogs: SWRInfiniteKeyLoader = (_pageIndex: number, prevPageData: Logs) => {
+    let queryParams
+    // if prev page data is 100 items, could possibly have more records that are not yet fetched within this interval
+    if (prevPageData === null) {
+      // reduce interval window limit by using the timestamp of the last log
+      queryParams = genQueryParams(params as any)
+    } else if ((prevPageData.result ?? []).length === 0) {
+      // no rows returned, indicates that no more data to retrieve and append.
+      return null
+    } else {
+      const len = prevPageData.result.length
+      const { timestamp: tsLimit }: LogData = prevPageData.result[len - 1]
+      // create new key from params
+      queryParams = genQueryParams({ ...params, timestamp_end: String(tsLimit) } as any)
+    }
+    return `${API_URL}/projects/${projectRef}/analytics/endpoints/logs.all?${queryParams}`
+  }
+
+  const {
+    data = [],
+    error: swrError,
+    isValidating,
+    size,
+    setSize,
+  } = useSWRInfinite<Logs>(getKeyLogs, get, { revalidateOnFocus: false })
+  let logData: LogData[] = []
+
+  const countUrl = `${API_URL}/projects/${projectRef}/analytics/endpoints/logs.all?${genQueryParams(
+    {
+      ...params,
+      sql: genCountQuery(table),
+      period_start: String(latestRefresh),
+    } as any
+  )}`
+
+  const { data: countData } = useSWR<Count>(countUrl, get, { refreshInterval: 5000 })
+  const newCount = countData?.result?.[0]?.count ?? 0
+
+  const refresh = () => {
+    setLatestRefresh(new Date().toISOString())
+    setParams({ ...params, timestamp_end: '' })
+  }
+
+  let error: null | string | object = swrError ? swrError.message : null
+  data.forEach((response) => {
+    if (!error && response?.result) {
+      logData = [...logData, ...response.result]
+    }
+    if (!error && response && response.error) {
+      error = response.error
+    }
+  })
+
+  return [
+    { newCount, logData, isLoading: isValidating, pageSize: size, error, filters, params },
+    {
+      setFrom: (value) => setParams((prev) => ({ ...prev, timestamp_start: value })),
+      setTo: (value) => setParams((prev) => ({ ...prev, timestamp_end: value })),
+      setFilters,
+      refresh,
+      loadOlder: () => setSize((prev) => prev + 1),
+    },
+  ]
+}
+export default useLogsPreview

--- a/studio/hooks/analytics/useLogsQuery.tsx
+++ b/studio/hooks/analytics/useLogsQuery.tsx
@@ -1,0 +1,57 @@
+import { cleanQuery, genQueryParams } from 'components/interfaces/Settings/Logs'
+import { Dispatch, SetStateAction, useState } from 'react'
+import { LogsEndpointParams, Logs, LogData } from 'components/interfaces/Settings/Logs/Logs.types'
+import useSWRInfinite, { SWRInfiniteKeyLoader } from 'swr/infinite/dist/infinite'
+import { API_URL } from 'lib/constants'
+import useSWR, { mutate } from 'swr'
+import { get } from 'lib/common/fetch'
+interface Data {
+  params: LogsEndpointParams
+  isLoading: boolean
+  logData: LogData[]
+  error: string | Object | null
+}
+interface Handlers {
+  changeQuery: (newQuery?: string) => void
+  runQuery: () => void
+}
+
+const useLogsQuery = (
+  projectRef: string,
+  initialParams: Partial<LogsEndpointParams> = {}
+): [Data, Handlers] => {
+  const [params, setParams] = useState<LogsEndpointParams>({
+    project: projectRef,
+    sql: '',
+    rawSql: '',
+    // timestamp_start: '',
+    // timestamp_end: '',
+    ...initialParams,
+  })
+
+  const queryParams = genQueryParams(params as any)
+  const {
+    data,
+    error: swrError,
+    isValidating: isLoading,
+    mutate,
+  } = useSWR<Logs>(
+    `${API_URL}/projects/${projectRef}/analytics/endpoints/logs.all?${queryParams}`,
+    get,
+    { revalidateOnFocus: false }
+  )
+  let error: null | string | object = swrError ? swrError.message : null
+
+  if (!error && data?.error) {
+    error = data?.error
+  }
+  const changeQuery = (newQuery = '') => {
+    setParams((prev) => ({ ...prev, sql: cleanQuery(newQuery), rawSql: newQuery }))
+  }
+
+  return [
+    { params, isLoading, logData: data?.result ? data?.result : [], error },
+    { changeQuery, runQuery: () => mutate() },
+  ]
+}
+export default useLogsQuery

--- a/studio/pages/project/[ref]/settings/logs/[type].tsx
+++ b/studio/pages/project/[ref]/settings/logs/[type].tsx
@@ -54,13 +54,13 @@ import useLogsPreview from 'hooks/analytics/useLogsPreview'
  */
 export const LogPage: NextPage = () => {
   const router = useRouter()
-  const { ref, type, s, te } = router.query
+  const { ref, type, s, te, ts } = router.query
   const [showChart, setShowChart] = useState(true)
   const table = type === 'api' ? LogsTableName.EDGE : LogsTableName.POSTGRES
 
   const [
-    { error, logData, params, newCount, filters, isLoading },
-    { loadOlder, setFilters, refresh, setTo },
+    { error, logData, params, newCount, filters, isLoading, oldestTimestamp },
+    { loadOlder, setFilters, refresh, setTo, setFrom },
   ] = useLogsPreview(ref as string, table, {
     initialFilters: { search_query: s as string },
     whereStatementFactory: (filterObj) =>
@@ -78,8 +78,25 @@ export const LogPage: NextPage = () => {
     } else {
       setTo('')
     }
-  }, [s, te])
+    if (ts) {
+      setFrom(ts as string)
+    } else {
+      setFrom('')
+    }
+  }, [s, te, ts])
 
+  useEffect(() => {
+    router.push({
+      pathname: router.pathname,
+      query: {
+        ...router.query,
+        q: undefined,
+        s: filters.search_query || '',
+        ts: params.timestamp_start,
+        te: params.timestamp_end,
+      },
+    })
+  }, [params.timestamp_end, params.timestamp_start, filters.search_query])
   const onSelectTemplate = (template: LogTemplate) => {
     setFilters((prev) => ({ ...prev, search_query: template.searchString }))
   }
@@ -91,23 +108,23 @@ export const LogPage: NextPage = () => {
       query: {
         ...router.query,
         te: undefined,
+        ts: undefined,
       },
     })
   }
 
-  const handleSearch: LogSearchCallback = ({ query, to, toMicro }) => {
-    const unixMicro = toMicro ? toMicro : dayjs(to).valueOf() * 1000
-    setTo(unixMicro ? String(unixMicro) : '')
+  const handleSearch: LogSearchCallback = ({ query, to, from, fromMicro, toMicro }) => {
+    let toValue, fromValue
+    if (to || toMicro) {
+      toValue = toMicro ? toMicro : dayjs(to).valueOf() * 1000
+
+      setTo(String(toValue))
+    }
+    if (from || fromMicro) {
+      const fromValue = fromMicro ? fromMicro : dayjs(from).valueOf() * 1000
+      setFrom(String(fromValue))
+    }
     setFilters((prev) => ({ ...prev, search_query: query || '' }))
-    router.push({
-      pathname: router.pathname,
-      query: {
-        ...router.query,
-        q: undefined,
-        s: query || '',
-        te: unixMicro,
-      },
-    })
   }
 
   return (
@@ -127,6 +144,13 @@ export const LogPage: NextPage = () => {
           defaultSearchValue={filters.search_query}
           defaultToValue={
             params.timestamp_end ? dayjs(Number(params.timestamp_end) / 1000).toISOString() : ''
+          }
+          defaultFromValue={
+            params.timestamp_start
+              ? dayjs(Number(params.timestamp_start) / 1000).toISOString()
+              : oldestTimestamp
+              ? dayjs(Number(oldestTimestamp) / 1000).toISOString()
+              : ''
           }
           onCustomClick={() => {
             router.push(`/project/${ref}/settings/logs/explorer?q=${params.rawSql}`)

--- a/studio/tests/pages/projects/LogPanel.test.js
+++ b/studio/tests/pages/projects/LogPanel.test.js
@@ -78,42 +78,47 @@ test('reset search filter', async () => {
   expect(() => screen.getByDisplayValue(/something123/)).toThrow()
 })
 
-test('timestamp To filter default value', async () => {
+test('timestamp to/from filter default value', async () => {
   render(<LogPanel defaultToValue="2022-01-18T10:43:39+0000" />)
   userEvent.click(await screen.findByText('Custom'))
   await screen.findByDisplayValue('2022-01-18T10:43:39+0000')
   // TODO: use screen.findByLabelText when https://github.com/supabase/ui/issues/310 is resolved
   await screen.findByText('To')
+  await screen.findByText('From')
 })
 
-test('timestamp from filter error handling', async () => {
+test('timestamp to/from filter error handling', async () => {
   const mockFn = jest.fn()
   render(<LogPanel onSearch={mockFn} />)
   userEvent.click(await screen.findByText(/Now/))
 
   // display iso timestamp
   const year = new Date().getFullYear()
-  const input = await screen.findByDisplayValue(RegExp(year))
+  const inputs = await screen.findAllByDisplayValue(RegExp(year))
+  expect(inputs.length).toBe(2)
+  const input = inputs[0]
   userEvent.clear(input)
   userEvent.type(input, '123456')
   await screen.findByText(/[iI]nvalid ISO 8601 timestamp/)
 })
 
-test('timestamp To filter value change', async () => {
+test('timestamp to/from filter value change', async () => {
   const mockFn = jest.fn()
   render(<LogPanel onSearch={mockFn} />)
   userEvent.click(await screen.findByText(/Now/))
   // display iso timestamp
   const year = new Date().getFullYear()
-  const input = await screen.findByDisplayValue(RegExp(year))
+  const inputs = await screen.findAllByDisplayValue(RegExp(year))
 
-  // replace the input's value
-  userEvent.clear(input)
+  for (const input of inputs) {
+    // replace the input's value
+    userEvent.clear(input)
 
-  // get time 20 mins before
-  const newDate = new Date()
-  newDate.setMinutes(new Date().getMinutes() - 20)
-  userEvent.type(input, newDate.toISOString())
+    // get time 20 mins before
+    const newDate = new Date()
+    newDate.setMinutes(new Date().getMinutes() - 20)
+    userEvent.type(input, newDate.toISOString())
+  }
 
   // input actions
   const set = await screen.findByRole('button', { name: 'Set' })

--- a/studio/tests/pages/projects/LogPanel.test.js
+++ b/studio/tests/pages/projects/LogPanel.test.js
@@ -78,12 +78,12 @@ test('reset search filter', async () => {
   expect(() => screen.getByDisplayValue(/something123/)).toThrow()
 })
 
-test('timestamp from filter default value', async () => {
-  render(<LogPanel defaultFromValue="2022-01-18T10:43:39+0000" />)
+test('timestamp To filter default value', async () => {
+  render(<LogPanel defaultToValue="2022-01-18T10:43:39+0000" />)
   userEvent.click(await screen.findByText('Custom'))
   await screen.findByDisplayValue('2022-01-18T10:43:39+0000')
   // TODO: use screen.findByLabelText when https://github.com/supabase/ui/issues/310 is resolved
-  await screen.findByText('From')
+  await screen.findByText('To')
 })
 
 test('timestamp from filter error handling', async () => {
@@ -99,7 +99,7 @@ test('timestamp from filter error handling', async () => {
   await screen.findByText(/[iI]nvalid ISO 8601 timestamp/)
 })
 
-test('timestamp from filter value change', async () => {
+test('timestamp To filter value change', async () => {
   const mockFn = jest.fn()
   render(<LogPanel onSearch={mockFn} />)
   userEvent.click(await screen.findByText(/Now/))

--- a/studio/tests/pages/projects/logs-explorer.test.js
+++ b/studio/tests/pages/projects/logs-explorer.test.js
@@ -1,0 +1,154 @@
+// mock the fetch function
+jest.mock('lib/common/fetch')
+import { get } from 'lib/common/fetch'
+
+// mock the settings layout
+jest.mock('components/layouts', () => ({
+  SettingsLayout: jest.fn().mockImplementation(({ children }) => <div>{children}</div>),
+}))
+
+// mock mobx
+jest.mock('mobx-react-lite')
+import { observer } from 'mobx-react-lite'
+observer.mockImplementation((v) => v)
+
+// mock the router
+jest.mock('next/router')
+import { useRouter } from 'next/router'
+const defaultRouterMock = () => {
+  const router = jest.fn()
+  router.query = { ref: '123', type: 'auth' }
+  router.push = jest.fn()
+  router.pathname = 'logs/path'
+  return router
+}
+useRouter.mockReturnValue(defaultRouterMock())
+
+// mock monaco editor
+jest.mock('@monaco-editor/react')
+import Editor, { useMonaco } from '@monaco-editor/react'
+Editor = jest.fn()
+Editor.mockImplementation((props) => {
+  return (
+    <textarea className="monaco-editor" onChange={(e) => props.onChange(e.target.value)}></textarea>
+  )
+})
+useMonaco.mockImplementation((v) => v)
+
+// mock usage flags
+jest.mock('components/ui/Flag/Flag')
+import Flag from 'components/ui/Flag/Flag'
+Flag.mockImplementation(({ children }) => <>{children}</>)
+jest.mock('hooks')
+import { useFlag } from 'hooks'
+useFlag.mockReturnValue(true)
+
+import { SWRConfig } from 'swr'
+jest.mock('pages/project/[ref]/settings/logs/explorer')
+import { LogsExplorerPage } from 'pages/project/[ref]/settings/logs/explorer'
+LogsExplorerPage.mockImplementation((props) => {
+  const Page = jest.requireActual('pages/project/[ref]/settings/logs/explorer').LogsExplorerPage
+  // wrap with SWR to reset the cache each time
+  return (
+    <SWRConfig
+      value={{
+        provider: () => new Map(),
+        shouldRetryOnError: false,
+      }}
+    >
+      <Page {...props} />
+    </SWRConfig>
+  )
+})
+
+import { render, fireEvent, waitFor, screen, act } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { getToggleByText } from '../../helpers'
+import { wait } from '@testing-library/user-event/dist/utils'
+import { logDataFixture } from '../../fixtures'
+beforeEach(() => {
+  // reset mocks between tests
+  get.mockReset()
+  useRouter.mockReset()
+  useRouter.mockReturnValue(defaultRouterMock())
+})
+test('can display log data and metadata', async () => {
+  get.mockResolvedValue({
+    result: [
+      logDataFixture({
+        event_message: 'some event happened',
+        metadata: {
+          my_key: 'something_value',
+        },
+      }),
+    ],
+  })
+  render(<LogsExplorerPage />)
+  fireEvent.click(await screen.findByText(/happened/))
+  await screen.findByText(/my_key/)
+  await screen.findByText(/something_value/)
+})
+
+test('q= query param will populate the query input', async () => {
+  const router = defaultRouterMock()
+  router.query = { ...router.query, type: 'api', q: 'some_query', s: 'someSearch' }
+  useRouter.mockReturnValue(router)
+  render(<LogsExplorerPage />)
+  // should populate editor with the query param
+  await waitFor(() => {
+    expect(get).toHaveBeenCalledWith(expect.stringContaining('sql=some_query'))
+  })
+
+  // query takes precedence of search queryparam
+  expect(() => !screen.queryByDisplayValue(/someSearch/))
+})
+
+test('custom sql querying', async () => {
+  get.mockImplementation((url) => {
+    if (url.includes('sql=') && url.includes('select')) {
+      return {
+        result: [
+          {
+            my_count: 12345,
+          },
+        ],
+      }
+    }
+    return { result: [] }
+  })
+  const { container } = render(<LogsExplorerPage />)
+  let editor = container.querySelector('.monaco-editor')
+  expect(editor).toBeTruthy()
+
+  // type into the query editor
+  await waitFor(() => {
+    editor = container.querySelector('.monaco-editor')
+    expect(editor).toBeTruthy()
+  })
+  editor = container.querySelector('.monaco-editor')
+  // type new query
+  userEvent.type(editor, 'select \ncount(*) as my_count \nfrom edge_logs')
+
+  // should trigger query
+  userEvent.click(await screen.findByText('Run'))
+  await waitFor(
+    () => {
+      expect(get).toHaveBeenCalledWith(expect.stringContaining(encodeURI('\n')))
+      expect(get).toHaveBeenCalledWith(expect.stringContaining('sql='))
+      expect(get).toHaveBeenCalledWith(expect.stringContaining('select'))
+      expect(get).toHaveBeenCalledWith(expect.stringContaining('edge_logs'))
+      expect(get).not.toHaveBeenCalledWith(expect.stringContaining('where'))
+    },
+    { timeout: 1000 }
+  )
+
+  await screen.findByText(/my_count/) //column header
+  const rowValue = await screen.findByText(/12345/) // row value
+
+  // clicking on the row value should not show log selection panel
+  userEvent.click(rowValue)
+  await expect(screen.findByText(/Metadata/)).rejects.toThrow()
+
+  // should not see chronological features
+  await expect(screen.findByText(/Load older/)).rejects.toThrow()
+})

--- a/studio/tests/pages/projects/logs-preview.test.js
+++ b/studio/tests/pages/projects/logs-preview.test.js
@@ -178,7 +178,7 @@ test('s= query param will populate the search bar', async () => {
   expect(get).toHaveBeenCalledWith(expect.stringContaining('someSearch'))
 })
 
-test('te= query param will populate the timestamp from input', async () => {
+test('te= query param will populate the timestamp to input', async () => {
   // get time 20 mins before
   const newDate = new Date()
   newDate.setMinutes(new Date().getMinutes() - 20)
@@ -197,6 +197,26 @@ test('te= query param will populate the timestamp from input', async () => {
   userEvent.click(await screen.findByText('Custom'))
   await screen.findByDisplayValue(isoString)
 })
+test('ts= query param will populate the timestamp from input', async () => {
+  // get time 20 mins before
+  const newDate = new Date()
+  newDate.setMinutes(new Date().getMinutes() - 20)
+  const isoString = newDate.toISOString()
+  const unixMicro = newDate.getTime() * 1000 //microseconds
+  const router = defaultRouterMock()
+  router.query = { ...router.query, ts: unixMicro }
+  useRouter.mockReturnValue(router)
+  render(<LogPage />)
+
+  await waitFor(() => {
+    expect(get).toHaveBeenCalledWith(
+      expect.stringContaining(`timestamp_start=${encodeURIComponent(unixMicro)}`)
+    )
+  })
+  userEvent.click(await screen.findByText('Custom'))
+  await screen.findByDisplayValue(isoString)
+})
+
 
 test('load older btn will fetch older logs', async () => {
   get.mockImplementation((url) => {

--- a/studio/tests/pages/projects/logs-preview.test.js
+++ b/studio/tests/pages/projects/logs-preview.test.js
@@ -117,7 +117,7 @@ test('Refresh page', async () => {
 
 test('Search will trigger a log refresh', async () => {
   get.mockImplementation((url) => {
-    if (url.includes('search_query') && url.includes('something')) {
+    if (url.includes('something')) {
       return {
         result: [logDataFixture({ event_message: 'some event happened' })],
       }
@@ -131,7 +131,6 @@ test('Search will trigger a log refresh', async () => {
 
   await waitFor(
     () => {
-      expect(get).toHaveBeenCalledWith(expect.stringContaining('search_query'))
       expect(get).toHaveBeenCalledWith(expect.stringContaining('something'))
 
       // updates router query params
@@ -147,8 +146,7 @@ test('Search will trigger a log refresh', async () => {
     },
     { timeout: 1500 }
   )
-
-  await waitFor(() => screen.getByText(/happened/), { timeout: 1000 })
+  await screen.findByText(/happened/)
 })
 
 test('poll count for new messages', async () => {
@@ -177,21 +175,7 @@ test('s= query param will populate the search bar', async () => {
   render(<LogPage />)
   // should populate search input with the search param
   await screen.findByDisplayValue('someSearch')
-  expect(get).toHaveBeenCalledWith(expect.stringContaining('search_query=someSearch'))
-})
-
-test('q= query param will populate the query input', async () => {
-  const router = defaultRouterMock()
-  router.query = { ...router.query, type: 'api', q: 'some_query', s: 'someSearch' }
-  useRouter.mockReturnValue(router)
-  render(<LogPage />)
-  // should populate editor with the query param
-  await waitFor(() => {
-    expect(get).toHaveBeenCalledWith(expect.stringContaining('sql=some_query'))
-  })
-
-  // query takes precedence of search queryparam
-  expect(() => !screen.queryByDisplayValue(/someSearch/))
+  expect(get).toHaveBeenCalledWith(expect.stringContaining('someSearch'))
 })
 
 test('te= query param will populate the timestamp from input', async () => {
@@ -212,63 +196,6 @@ test('te= query param will populate the timestamp from input', async () => {
   })
   userEvent.click(await screen.findByText('Custom'))
   await screen.findByDisplayValue(isoString)
-})
-test('custom sql querying', async () => {
-  get.mockImplementation((url) => {
-    if (url.includes('sql=') && url.includes('select')) {
-      return {
-        result: [
-          {
-            my_count: 12345,
-          },
-        ],
-      }
-    }
-    return { result: [] }
-  })
-  const { container } = render(<LogPage />)
-  let editor = container.querySelector('.monaco-editor')
-  expect(editor).toBeFalsy()
-  // TODO: abstract this out into a toggle selection helper
-  const toggle = getToggleByText(/via query/)
-  expect(toggle).toBeTruthy()
-  userEvent.click(toggle)
-
-  // type into the query editor
-  await waitFor(() => {
-    editor = container.querySelector('.monaco-editor')
-    expect(editor).toBeTruthy()
-  })
-  editor = container.querySelector('.monaco-editor')
-  // clear the default query
-  userEvent.type(editor, '{backspace}'.repeat(100))
-  // type new query
-  userEvent.type(editor, 'select \ncount(*) as my_count \nfrom edge_logs')
-  // should show sandbox warning alert
-  await screen.findByText(/restricted to a 7 day querying window/)
-
-  // should trigger query
-  userEvent.click(await screen.findByText('Run'))
-  await waitFor(
-    () => {
-      expect(get).toHaveBeenCalledWith(expect.stringContaining(encodeURI('\n')))
-      expect(get).toHaveBeenCalledWith(expect.stringContaining('sql='))
-      expect(get).toHaveBeenCalledWith(expect.stringContaining('select'))
-      expect(get).toHaveBeenCalledWith(expect.stringContaining('edge_logs'))
-      expect(get).not.toHaveBeenCalledWith(expect.stringContaining('where'))
-    },
-    { timeout: 1000 }
-  )
-
-  await screen.findByText(/my_count/) //column header
-  const rowValue = await screen.findByText(/12345/) // row value
-
-  // clicking on the row value should not show log selection panel
-  userEvent.click(rowValue)
-  await expect(screen.findByText(/Metadata/)).rejects.toThrow()
-
-  // should not see chronological features
-  await expect(screen.findByText(/Load older/)).rejects.toThrow()
 })
 
 test('load older btn will fetch older logs', async () => {
@@ -319,31 +246,6 @@ test('bug: load older btn does not error out when previous page is empty', async
   })
 })
 
-test('bug: log selection gets hidden when custom query is run', async () => {
-  const result = [
-    logDataFixture({
-      event_message: 'some event happened',
-      metadata: {
-        my_key: 'something_value',
-      },
-    }),
-  ]
-  get.mockResolvedValue({ result })
-  const {container} =render(<LogPage />)
-  userEvent.click(await screen.findByText(/happened/))
-  await screen.findByDisplayValue(/something_value/)
-  get.mockResolvedValue({ data: [] })
-
-  const toggle = getToggleByText(/via query/)
-  expect(toggle).toBeTruthy()
-  userEvent.click(toggle)
-  const editor = container.querySelector('.monaco-editor')
-  userEvent.type(editor, 'select \ncount(*) as my_count \nfrom edge_logs')
-  userEvent.click(await screen.findByText('Run'))
-
-  await expect(screen.findByDisplayValue(/something_value/)).rejects.toThrow()
-})
-
 test('log event chart hide', async () => {
   render(<LogPage />)
   await screen.findByText('Events')
@@ -362,32 +264,12 @@ test('bug: nav backwards with params change results in ui changing', async () =>
   })
   const { container, rerender } = render(<LogPage />)
 
-  await waitFor(() => {
-    let editor = container.querySelector('.monaco-editor')
-    expect(editor).toBeFalsy()
-  })
   await expect(screen.findByDisplayValue('simple-query')).rejects.toThrow()
 
-  // change the router values for query editor
   const router = defaultRouterMock()
-  router.query = { ...router.query, q: 'advanced-query' }
+  router.query = { ...router.query, s: 'simple-query' }
   useRouter.mockReturnValue(router)
   rerender(<LogPage />)
 
-  await waitFor(() => {
-    let editor = container.querySelector('.monaco-editor')
-    expect(editor).toBeTruthy()
-  })
-  await expect(screen.findByDisplayValue('simple-query')).rejects.toThrow()
-
-  // change the router values
-  router.query = { ...router.query, q: undefined, s: 'simple-query' }
-  useRouter.mockReturnValue(router)
-  rerender(<LogPage />)
-
-  await waitFor(() => {
-    let editor = container.querySelector('.monaco-editor')
-    expect(editor).toBeFalsy()
-  })
   await screen.findByDisplayValue('simple-query')
 })


### PR DESCRIPTION
This PR separates the logging dashboard logic into two separate hooks. This is in preparation for the `<LogsPreviewer>` component and various implementations.

Other changes made:
- updated "From" input to be labelled as "To" 

Pre-merge checklist:
- [x] update staging LF endpoint `logs.all` endpoint query
- [x] update prod LF endpoint `logs.all` endpoint query
- [x] Add in default datetime range to previewer queries https://supabase.slack.com/archives/C02HE0AQPC6/p1647953970460309
  - explorer datetime range to be implemented post-merge 