### PR TITLE
docs: setAuth() - Fix syntax

### DIFF
--- a/web/spec/supabase.yml
+++ b/web/spec/supabase.yml
@@ -676,7 +676,7 @@ pages:
                withCredentials: true,
                credentials: 'include',
                headers: {
-                'Content-Type': 'application/json'
+                'Content-Type': 'application/json',
                 'Authorization': bearer, // Your own auth
                 'X-Supabase-Auth': token, // Set the Supabase user
                }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix syntax error in documentation.

## Additional context

[#5957](https://github.com/supabase/supabase/issues/5957)
