### PR TITLE
docs: added docusaurus appId

### DIFF
--- a/web/docusaurus.config.js
+++ b/web/docusaurus.config.js
@@ -41,6 +41,7 @@ module.exports = {
     },
     algolia: {
       apiKey: '766d56f13dd1e82f43253559b7c86636',
+      appId: 'supabase',
       indexName: 'supabase',
     },
     image: '/img/supabase-og-image.png', // used for meta tag, in particular og:image and twitter:image


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docusaurus `appId` added to the config

## What is the current behavior?

Running `yarn build` comes back with an error with a missing `appId` in the docusaurus.config

## What is the new behavior?

Running `yarn build` now creates the development server.

## Additional context

<img width="339" alt="Screenshot 2022-03-21 at 14 13 32" src="https://user-images.githubusercontent.com/22655069/159279659-6bec9d95-c06e-417d-92c6-c07a3d13bc2c.png">


