### PR TITLE
ui: fix large loading text

### DIFF
--- a/studio/components/layouts/SQLEditorLayout/SQLEditorMenuOld.tsx
+++ b/studio/components/layouts/SQLEditorLayout/SQLEditorMenuOld.tsx
@@ -216,7 +216,7 @@ const SideBarContent = observer(() => {
         {(sqlEditorStore?.tabs ?? []).length === 0 ? (
           <div className="my-4 px-7 flex items-center space-x-2">
             <IconLoader className="animate-spin" size={16} strokeWidth={2} />
-            <Typography.Text type="secondary">Loading SQL snippets</Typography.Text>
+            <p>Loading SQL snippets</p>
           </div>
         ) : (
           <div className="space-y-6">


### PR DESCRIPTION
The "Loading SQL snippets" text is larger (relatively) than the rest of the text.

I think we deprecated the "Typography" component right?

Currently looks like this:

<img width="678" alt="image" src="https://user-images.githubusercontent.com/10214025/159461235-0328e099-be5e-4181-9b7a-284a94bddcfe.png">

( Also note I haven't tested this on a live dashboard, you can think of this as an Issue with a "guessed" solution, which could be wrong)
