### PR TITLE
feat/studio/usage: added popover for query params rendering, p99 and p95 latency

### DIFF
--- a/studio/components/interfaces/Home/ChartData.types.ts
+++ b/studio/components/interfaces/Home/ChartData.types.ts
@@ -10,6 +10,9 @@ export interface PathsDatum {
   count: number
   method: string
   avg_origin_time: number
+  p95: number
+  p99: number
+  sum: number
 }
 
 export interface EndpointResponse<T> {

--- a/studio/components/interfaces/Home/ProjectUsage.tsx
+++ b/studio/components/interfaces/Home/ProjectUsage.tsx
@@ -12,6 +12,8 @@ import {
   Button,
   Dropdown,
   IconChevronDown,
+  Badge,
+  Popover,
 } from '@supabase/ui'
 
 import Panel from 'components/to-be-cleaned/Panel'
@@ -275,23 +277,66 @@ const ProjectUsage: FC<Props> = ({ project }) => {
               <Panel.Content className="space-y-4">
                 <PanelHeader title="Top Routes" />
                 <Table
-                  head={
-                    <>
-                      <Table.th>Path</Table.th>
-                      <Table.th>Count</Table.th>
-                      <Table.th>Avg. Latency (ms)</Table.th>
-                    </>
-                  }
+                  head={[
+                    <Table.th rowSpan={2}>Path</Table.th>,
+                    <Table.th rowSpan={2}>Count</Table.th>,
+                    <Table.th colSpan={3} className="text-center p-1">
+                      Latency (ms)
+                    </Table.th>,
+                  ]}
+                  headSecondRow={[
+                    <Table.th className="p-1">Avg</Table.th>,
+                    <Table.th className="p-1">p95</Table.th>,
+                    <Table.th className="p-1">p99</Table.th>,
+                  ]}
                   body={
                     <>
                       {(pathsData?.result ?? []).map((row: PathsDatum) => (
                         <Table.tr>
-                          <Table.td className="flex items-center space-x-2">
-                            <p className="font-mono text-sm text-scale-1200">{row.method}</p>
-                            <p className="font-mono text-sm">{row.path}</p>
+                          <Table.td className="flex items-center space-x-2 text-xl">
+                            <>
+                              <p className="font-mono text-xs text-scale-1200">{row.method}</p>
+                              <p className="font-mono text-xs">{row.path}</p>{' '}
+                              {row.query_params && (
+                                <Popover
+                                  align="end"
+                                  header={
+                                    <div className="flex justify-between items-center">
+                                      <h5>Query Params</h5>
+                                    </div>
+                                  }
+                                  onOpenChange={function noRefCheck() {}}
+                                  overlay={[
+                                    <>
+                                      <div className="py-6 px-2 space-y-4 max-w-sm">
+                                        <p className="font-mono text-sm whitespace-pre-line">{row.query_params}</p>
+                                      </div>
+                                    </>,
+                                  ]}
+                                  portalled
+                                  showClose
+                                  side="bottom"
+                                  size="content"
+                                >
+                                  <Badge color="scale">?...</Badge>
+                                </Popover>
+                              )}
+                            </>
                           </Table.td>
-                          <Table.td>{row.count}</Table.td>
-                          <Table.td>{Number(row.avg_origin_time).toFixed(2)}</Table.td>
+                          <Table.td>
+                            <span className="text-xs">{row.count}</span>
+                          </Table.td>
+                          <Table.td>
+                            <span className="text-xs">
+                              {Number(row.avg_origin_time).toFixed(0)}
+                            </span>
+                          </Table.td>
+                          <Table.td>
+                            <span className="text-xs">{Number(row.p95).toFixed(0)}</span>
+                          </Table.td>
+                          <Table.td>
+                            <span className="text-xs">{Number(row.p99).toFixed(0)}</span>
+                          </Table.td>
                         </Table.tr>
                       ))}
                     </>

--- a/studio/components/interfaces/Home/ProjectUsageSection.tsx
+++ b/studio/components/interfaces/Home/ProjectUsageSection.tsx
@@ -23,14 +23,14 @@ const ProjectUsageSection: FC = observer(({}) => {
     return <Typography.Text type="danger">Error loading data {usageError.message}</Typography.Text>
   }
 
-  return (
+    return (
     <>
       {usage === undefined ? (
         <div className="w-full flex justify-center items-center space-x-2">
           <IconLoader className="animate-spin" size={14} />
           <p className="text-sm">Retrieving project usage statistics</p>
         </div>
-      ) : !usage.error && hasProjectData ? (
+      ) : !usage.error && true ? (
         <ProjectUsage project={project} />
       ) : (
         <NewProjectPanel />

--- a/studio/components/layouts/DatabaseLayout/DatabaseMenu.utils.ts
+++ b/studio/components/layouts/DatabaseLayout/DatabaseMenu.utils.ts
@@ -1,13 +1,14 @@
 import { Project } from 'types'
 import { IS_PLATFORM } from 'lib/constants'
 import { ProductMenuGroup } from 'components/ui/ProductMenu/ProductMenu.types'
+import { useFlag } from 'hooks'
 
 export const generateDatabaseMenu = (project?: Project): ProductMenuGroup[] => {
   const ref = project?.ref ?? 'default'
 
   const HOOKS_RELEASED = '2021-07-30T15:33:54.383Z'
   const showHooksRoute = project?.inserted_at ? project.inserted_at > HOOKS_RELEASED : false
-
+  const logsUsageCodesPaths = useFlag('logsUsageCodesPaths')
   return [
     {
       title: 'Database',
@@ -26,82 +27,91 @@ export const generateDatabaseMenu = (project?: Project): ProductMenuGroup[] => {
           url: `/project/${ref}/database/replication`,
           items: [],
         },
-
       ],
     },
     ...(IS_PLATFORM
       ? [
-        {
-          title: 'Logs',
-          items: [
-            {
-              name: 'API logs',
-              key: 'api-logs',
-              url: `/project/${ref}/database/api-logs`,
-              items: [],
-            },
-            {
-              name: 'Postgres logs',
-              key: 'postgres-logs',
-              url: `/project/${ref}/database/postgres-logs`,
-              items: [],
-            },
-          ],
-        },
-      ]
+          {
+            title: 'Logs & Analytics',
+            items: [
+              {
+                name: 'API logs',
+                key: 'api-logs',
+                url: `/project/${ref}/database/api-logs`,
+                items: [],
+              },
+            ...(logsUsageCodesPaths
+                ? [
+                    {
+                      name: 'API requests',
+                      key: 'api-requests',
+                      url: `/project/${ref}/database/api-requests`,
+                      items: [],
+                    },
+                  ]
+                : []),
+              {
+                name: 'Postgres logs',
+                key: 'postgres-logs',
+                url: `/project/${ref}/database/postgres-logs`,
+                items: [],
+              },
+            ],
+          },
+        ]
       : []),
     ...(IS_PLATFORM
       ? [
-        {
-          title: 'Settings',
-          items: [
-            {
-              name: 'Backups',
-              key: 'backups',
-              url: `/project/${ref}/database/backups`,
-              items: [],
-            },
-            {
-              name: 'Connection Pooling',
-              key: 'pooling',
-              url: `/project/${ref}/database/pooling`,
-              items: [],
-            },
-          ],
-        },
-      ]
+          {
+            title: 'Settings',
+            items: [
+              {
+                name: 'Backups',
+                key: 'backups',
+                url: `/project/${ref}/database/backups`,
+                items: [],
+              },
+              {
+                name: 'Connection Pooling',
+                key: 'pooling',
+                url: `/project/${ref}/database/pooling`,
+                items: [],
+              },
+            ],
+          },
+        ]
       : []),
     ...(IS_PLATFORM
       ? [
-        {
-          title: 'Alpha Preview',
-          isPreview: true,
-          items: [
-            {
-              name: 'Triggers',
-              key: 'triggers',
-              url: `/project/${ref}/database/triggers`,
-              items: [],
-            },
-            {
-              name: 'Functions',
-              key: 'functions',
-              url: `/project/${ref}/database/functions`,
-              items: [],
-            },
-            ...(showHooksRoute
-              ? [
-                {
-                  name: 'Function Hooks',
-                  key: 'hooks',
-                  url: `/project/${ref}/database/hooks`,
-                  items: [],
-                },
-              ]
-              : []),
-          ],
-        },
-      ]
+          {
+            title: 'Alpha Preview',
+            isPreview: true,
+            items: [
+              {
+                name: 'Triggers',
+                key: 'triggers',
+                url: `/project/${ref}/database/triggers`,
+                items: [],
+              },
+              {
+                name: 'Functions',
+                key: 'functions',
+                url: `/project/${ref}/database/functions`,
+                items: [],
+              },
+              ...(showHooksRoute
+                ? [
+                    {
+                      name: 'Function Hooks',
+                      key: 'hooks',
+                      url: `/project/${ref}/database/hooks`,
+                      items: [],
+                    },
+                  ]
+                : []),
+            ],
+          },
+        ]
       : []),
   ]
 }

--- a/studio/components/to-be-cleaned/Table.tsx
+++ b/studio/components/to-be-cleaned/Table.tsx
@@ -4,6 +4,7 @@ import { Typography } from '@supabase/ui'
 type TableProps = {
   body: JSX.Element | JSX.Element[]
   head?: JSX.Element | JSX.Element[]
+  headSecondRow?: JSX.Element | JSX.Element[]
   className?: string
   containerClassName?: string
   borderless?: boolean
@@ -17,6 +18,7 @@ function Table({
   containerClassName,
   borderless,
   headTrClasses,
+  headSecondRow,
 }: TableProps) {
   let containerClasses = ['table-container']
   if (containerClassName) containerClasses.push(containerClassName)
@@ -30,6 +32,7 @@ function Table({
       <table className={classes.join(' ')}>
         <thead>
           <tr className={headTrClasses}>{head}</tr>
+          {headSecondRow && <tr>{headSecondRow}</tr>}
         </thead>
         <tbody>{body}</tbody>
       </table>
@@ -37,17 +40,19 @@ function Table({
   )
 }
 
-type ThProps = {
+interface ThProps {
   children?: React.ReactNode
   className?: string
   style?: React.CSSProperties
+  colSpan?: number
+  rowSpan?: number
 }
 
-const Th: React.FC<ThProps> = ({ children, className, style }) => {
+const Th: React.FC<ThProps> = ({ children, className, style, ...rest }) => {
   const classes = ['p-3 px-4 text-left']
   if (className) classes.push(className)
   return (
-    <th className={classes.join(' ')} style={style}>
+    <th className={classes.join(' ')} style={style} {...rest}>
       <Typography.Text type="secondary">{children}</Typography.Text>
     </th>
   )

--- a/studio/components/ui/Charts/Charts.constants.ts
+++ b/studio/components/ui/Charts/Charts.constants.ts
@@ -17,3 +17,17 @@ export const USAGE_COLORS = {
   404: 'var(--colors-amber7)',
   500: 'var(--colors-red9)',
 }
+
+
+
+export const CHART_INTERVALS = [
+  {
+    key: 'minutely',
+    label: '60 minutes',
+    startValue: 1,
+    startUnit: 'hour',
+    format: 'MMM D, h:mma',
+  },
+  { key: 'hourly', label: '24 hours', startValue: 24, startUnit: 'hour', format: 'MMM D, ha' },
+  { key: 'daily', label: '7 days', startValue: 7, startUnit: 'day', format: 'MMM D' },
+]

--- a/studio/pages/project/[ref]/database/api-requests.tsx
+++ b/studio/pages/project/[ref]/database/api-requests.tsx
@@ -1,0 +1,188 @@
+import React from 'react'
+import { NextPage } from 'next'
+import { useRouter } from 'next/router'
+import { observer } from 'mobx-react-lite'
+import { withAuth } from 'hooks'
+import { DatabaseLayout } from 'components/layouts/'
+import useSWR from 'swr'
+import Link from 'next/link'
+import { useState } from 'react'
+import { Typography, Button, Dropdown, IconChevronDown, Badge, Popover } from '@supabase/ui'
+
+import Panel from 'components/to-be-cleaned/Panel'
+import { get } from 'lib/common/fetch'
+import { API_URL } from 'lib/constants'
+import Table from 'components/to-be-cleaned/Table'
+import StackedAreaChart from 'components/ui/Charts/StackedAreaChart'
+import { CHART_INTERVALS, USAGE_COLORS } from 'components/ui/Charts/Charts.constants'
+import {
+  EndpointResponse,
+  PathsDatum,
+  StatusCodesDatum,
+} from 'components/interfaces/Home/ChartData.types'
+
+export const LogPage: NextPage = () => {
+  const router = useRouter()
+  const { ref } = router.query
+
+  const [interval, setInterval] = useState<string>('hourly')
+  const selectedInterval = CHART_INTERVALS.find((i) => i.key === interval) || CHART_INTERVALS[1]
+  const datetimeFormat = selectedInterval.format || 'MMM D, ha'
+
+  const { data: codesData, error: codesFetchError } = useSWR<EndpointResponse<StatusCodesDatum>>(
+    `${API_URL}/projects/${ref}/analytics/endpoints/usage.api-codes?interval=${interval}`,
+    get
+  )
+
+  const { data: pathsData, error: _pathsFetchError }: any = useSWR<EndpointResponse<PathsDatum>>(
+    `${API_URL}/projects/${ref}/analytics/endpoints/usage.api-paths?interval=${interval}`,
+    get
+  )
+  return (
+    <DatabaseLayout>
+      <div className=" container mx-auto p-4 flex flex-row items-center gap-4">
+        <h1 className="text-2xl ">API Requests</h1>
+        <Dropdown
+          side="bottom"
+          align="start"
+          overlay={
+            <Dropdown.RadioGroup value={interval} onChange={setInterval}>
+              {CHART_INTERVALS.map((i) => (
+                <Dropdown.Radio key={i.key} value={i.key}>
+                  {i.label}
+                </Dropdown.Radio>
+              ))}
+            </Dropdown.RadioGroup>
+          }
+        >
+          <Button as="span" type="default" iconRight={<IconChevronDown />}>
+            Past {selectedInterval.label}
+          </Button>
+        </Dropdown>
+      </div>
+
+      <div className="flex flex-col gap-4 lg:gap-8 w-full">
+        <Panel key="api-status-codes" className="col-start-1 col-span-2" wrapWithLoading={false}>
+          <Panel.Content className="space-y-4">
+            <PanelHeader title="API Status Codes" />
+            <StackedAreaChart
+              dateFormat={datetimeFormat}
+              data={codesData?.result}
+              stackKey="status_code"
+              xAxisKey="timestamp"
+              yAxisKey="count"
+              isLoading={!codesData && !codesFetchError ? true : false}
+              xAxisFormatAsDate
+              size="large"
+              styleMap={{
+                200: { stroke: USAGE_COLORS['200'], fill: USAGE_COLORS['200'] },
+                201: { stroke: USAGE_COLORS['201'], fill: USAGE_COLORS['201'] },
+                400: { stroke: USAGE_COLORS['400'], fill: USAGE_COLORS['400'] },
+                401: { stroke: USAGE_COLORS['401'], fill: USAGE_COLORS['401'] },
+                404: { stroke: USAGE_COLORS['404'], fill: USAGE_COLORS['404'] },
+                500: { stroke: USAGE_COLORS['500'], fill: USAGE_COLORS['500'] },
+              }}
+            />
+          </Panel.Content>
+        </Panel>
+        <Panel
+          key="top-routes"
+          className="col-start-3 col-span-2 pb-0"
+          bodyClassName="h-full"
+          wrapWithLoading={false}
+        >
+          <Panel.Content className="space-y-4">
+            <PanelHeader title="Top Routes" />
+            <Table
+              head={[
+                <Table.th rowSpan={2}>Path</Table.th>,
+                <Table.th rowSpan={2}>Count</Table.th>,
+                <Table.th colSpan={3} className="text-center p-1">
+                  Latency (ms)
+                </Table.th>,
+              ]}
+              headSecondRow={[
+                <Table.th className="p-1">Avg</Table.th>,
+                <Table.th className="p-1">p95</Table.th>,
+                <Table.th className="p-1">p99</Table.th>,
+              ]}
+              body={
+                <>
+                  {(pathsData?.result ?? []).map((row: PathsDatum) => (
+                    <Table.tr>
+                      <Table.td className="flex items-center space-x-2 text-xl">
+                        <>
+                          <p className="font-mono text-xs text-scale-1200">{row.method}</p>
+                          <p className="font-mono text-xs">{row.path}</p>{' '}
+                          {row.query_params && (
+                            <Popover
+                              align="end"
+                              header={
+                                <div className="flex justify-between items-center">
+                                  <h5>Query Params</h5>
+                                </div>
+                              }
+                              onOpenChange={function noRefCheck() {}}
+                              overlay={[
+                                <>
+                                  <div className="py-6 px-2 space-y-4 max-w-sm">
+                                    <p className="font-mono text-sm whitespace-pre-line">
+                                      {row.query_params}
+                                    </p>
+                                  </div>
+                                </>,
+                              ]}
+                              portalled
+                              showClose
+                              side="bottom"
+                              size="content"
+                            >
+                              <Badge color="scale">?...</Badge>
+                            </Popover>
+                          )}
+                        </>
+                      </Table.td>
+                      <Table.td>
+                        <span className="text-xs">{row.count}</span>
+                      </Table.td>
+                      <Table.td>
+                        <span className="text-xs">{Number(row.avg_origin_time).toFixed(0)}</span>
+                      </Table.td>
+                      <Table.td>
+                        <span className="text-xs">{Number(row.p95).toFixed(0)}</span>
+                      </Table.td>
+                      <Table.td>
+                        <span className="text-xs">{Number(row.p99).toFixed(0)}</span>
+                      </Table.td>
+                    </Table.tr>
+                  ))}
+                </>
+              }
+            />
+          </Panel.Content>
+        </Panel>
+      </div>
+    </DatabaseLayout>
+  )
+}
+
+const PanelHeader = (props: any) => {
+  const Tag = props?.href ? Link : 'div'
+  return (
+    <Tag href={props.href}>
+      <div
+        className={
+          'flex items-center space-x-3 opacity-80 transition ' +
+          (props.href ? 'cursor-pointer hover:opacity-100 hover:text-gray-1200' : '')
+        }
+      >
+        <Typography.Text>{props.icon}</Typography.Text>
+        <span className="flex items-center space-x-1">
+          <h4 className="mb-0 text-lg">{props.title}</h4>
+        </span>
+      </div>
+    </Tag>
+  )
+}
+
+export default withAuth(observer(LogPage))


### PR DESCRIPTION
Query params uses a popover for display, @MildTomato you might want to have a go and restyling stuff. We've got most of the info we wanted to cover here already. Was thinking that we can nav to the logs explorer on clicking a certain row, then we display all edge_logs with this specific path & query param.


<img width="761" alt="image" src="https://user-images.githubusercontent.com/22714384/159735488-a1947100-0765-4acf-8ff2-7d887ddd3db3.png">
