### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/examples/react-todo-list/src/components/Home.js
+++ b/examples/react-todo-list/src/components/Home.js
@@ -15,7 +15,7 @@ const Home = ({ user }) => {
          * Read more on https://supabase.com/docs/reference/javascript/reset-password-email#notes
          */
         let url = window.location.hash;
-        let query = url.substr(1);
+        let query = url.slice(1);
         let result = {};
 
         query.split("&").forEach((part) => {

--- a/studio/components/interfaces/Database/Functions/CreateFunction.tsx
+++ b/studio/components/interfaces/Database/Functions/CreateFunction.tsx
@@ -101,8 +101,9 @@ function convertArgumentTypes(value: string) {
   if (isEmpty(value) || !items || items?.length == 0) return { value: [] }
   const temp = items.map((x) => {
     const str = x.trim()
-    const name = str.substr(0, str.indexOf(' '))
-    const type = str.substr(str.indexOf(' ') + 1)
+    const space = str.indexOf(' ')
+    const name = str.slice(0, space !== 1 ? space : 0)
+    const type = str.slice(space + 1)
     return { name, type }
   })
   return { value: temp }

--- a/studio/pages/project/[ref]/api/index.tsx
+++ b/studio/pages/project/[ref]/api/index.tsx
@@ -34,7 +34,7 @@ const PageConfig = () => {
       let rpcs: any = {}
 
       Object.entries(paths || []).forEach(([name, val]) => {
-        let trimmed = name.substr(1)
+        let trimmed = name.slice(1)
         let id = trimmed.replace(functionPath, '')
         let displayName = id.replace(/_/g, ' ')
         let camelCase = snakeToCamel(id)


### PR DESCRIPTION
## What kind of change does this PR introduce?
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

## What is the current behavior?

Same as new

## What is the new behavior?

Same as current

## Additional context

