### PR TITLE
docs update with-expo

### DIFF
--- a/web/docs/guides/with-expo.mdx
+++ b/web/docs/guides/with-expo.mdx
@@ -418,7 +418,7 @@ import { View } from 'react-native'
 import { Session } from '@supabase/supabase-js'
 
 export default function App() {
-  const [session, setSession] = (useState < Session) | (null > null)
+  const [session, setSession] = useState<Session | null>(null)
 
   useEffect(() => {
     setSession(supabase.auth.session())


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

#6081: The `App.tsx` example in `with-expo` seems malformed.

## What is the new behavior?

Updated document example to present valid TypeScript `useState` in example.

## Additional context

Add any other context or screenshots.
