### PR TITLE
fix: check if addEventListener() is available before listening to media changes

### DIFF
--- a/studio/hooks/misc/useStore.tsx
+++ b/studio/hooks/misc/useStore.tsx
@@ -40,7 +40,12 @@ export const StoreProvider: FC<StoreProvider> = ({ children, rootStore }) => {
 
   useEffect(() => {
     ui.load()
-    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', matchMediaEvent)
+
+    if (window.matchMedia('(prefers-color-scheme: dark)').addEventListener) {
+      // backwards compatibility for safari < v14
+      // limited support for addEventListener()
+      window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', matchMediaEvent)
+    }
 
     autorun(() => {
       if (ui.notification) {

--- a/studio/hooks/misc/useStore.tsx
+++ b/studio/hooks/misc/useStore.tsx
@@ -41,7 +41,7 @@ export const StoreProvider: FC<StoreProvider> = ({ children, rootStore }) => {
   useEffect(() => {
     ui.load()
 
-    if (window.matchMedia('(prefers-color-scheme: dark)').addEventListener) {
+    if (window?.matchMedia('(prefers-color-scheme: dark)')?.addEventListener) {
       // backwards compatibility for safari < v14
       // limited support for addEventListener()
       window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', matchMediaEvent)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Stops `window.matchMedia('(prefers-color-scheme: dark)').addEventListener()` from running on older versions of safari

