### PR TITLE
Fix broken markdown in createUser docs

### DIFF
--- a/web/spec/supabase.yml
+++ b/web/spec/supabase.yml
@@ -792,6 +792,7 @@ pages:
             password: 'password',
             data: { name: 'Yoda' }
           })
+          ```
       - name: Auto-confirm email.
         isSpotlight: true
         js: |


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes broken markdown in docs

## What is the current behavior?

See the current status of the page here https://supabase.com/docs/reference/javascript/auth-api-createuser

## What is the new behavior?

Markdown should work better now
