### PR TITLE
chore: correct "JavaScript" cases

### DIFF
--- a/about/docs/careers/developer-success.mdx
+++ b/about/docs/careers/developer-success.mdx
@@ -34,7 +34,7 @@ Supabase is hiring Developer Success Engineers. Help us build the easiest databa
 
 ## Bonus if you:
 
-- Are a Polyglot developer, with some skill in NodeJS/Javascript.
+- Are a Polyglot developer, with some skill in Node.js/JavaScript.
 - Have PostgreSQL experience.
 
 ## About Supabase

--- a/about/docs/careers/front-end-developers.mdx
+++ b/about/docs/careers/front-end-developers.mdx
@@ -42,7 +42,7 @@ You've worked in multi disciplinary teams before, working with designers, develo
 
 ## Must have skills
 
-- 5+ years experience in web development (Javascript, HTML5, CSS3, SCSS/LESS).
+- 5+ years experience in web development (JavaScript, HTML5, CSS3, SCSS/LESS).
 - Have an understanding of modern JS (ES6 etc).
 - Experience with Node.
 - Experience with React (We use NextJS everywhere).

--- a/examples/nuxtjs-user-management/plugins/README.md
+++ b/examples/nuxtjs-user-management/plugins/README.md
@@ -2,6 +2,6 @@
 
 **This directory is not required, you can delete it if you don't want to use it.**
 
-This directory contains Javascript plugins that you want to run before mounting the root Vue.js application.
+This directory contains JavaScript plugins that you want to run before mounting the root Vue.js application.
 
 More information about the usage of this directory in [the documentation](https://nuxtjs.org/guide/plugins).

--- a/studio/components/interfaces/Home/Home.constants.ts
+++ b/studio/components/interfaces/Home/Home.constants.ts
@@ -1,6 +1,6 @@
 export const CLIENT_LIBRARIES = [
   {
-    language: 'Javascript',
+    language: 'JavaScript',
     officialSupport: true,
     releaseState: undefined,
     docsUrl: 'https://supabase.com/docs/reference/javascript/installing',

--- a/studio/components/to-be-cleaned/Storage/StoragePolicies/StoragePoliciesEditor.js
+++ b/studio/components/to-be-cleaned/Storage/StoragePolicies/StoragePoliciesEditor.js
@@ -55,7 +55,7 @@ const PolicyAllowedOperations = ({ allowedOperations = [], onToggleOperation = (
         </label>
         <p className="text-sm text-scale-900">
           Based on the operations you have selected, you can use any of the highlighted functions in
-          the supabase-js Javascript library
+          the supabase-js JavaScript library
         </p>
       </div>
       <div className="w-2/3">

--- a/web/docs/about.mdx
+++ b/web/docs/about.mdx
@@ -33,7 +33,7 @@ const frameworks = [
   },
   { name: 'Flutter', logo: DartLogo, href: '/docs/guides/with-flutter' },
   {
-    name: 'Javascript',
+    name: 'JavaScript',
     logo: JavascriptLogo,
     href: 'https://github.com/supabase/supabase/tree/master/examples/javascript-auth',
   },

--- a/web/docs/guides/api.mdx
+++ b/web/docs/guides/api.mdx
@@ -158,7 +158,7 @@ values={[
 ```sh
 1. Go to the "API" section.
 2. Find "todos" in the "Tables and Views" section.
-3. Switch between the Javascript and the cURL docs using the tabs.
+3. Switch between the JavaScript and the cURL docs using the tabs.
 ```
 
 </TabItem>
@@ -174,12 +174,12 @@ using the API URL (`[SUPABASE_URL]`) and Key (`[SUPABASE_ANON_KEY]`) we provided
 
 
 <Tabs
-defaultValue="Javascript"
+defaultValue="JavaScript"
 values={[
-  {label: 'Javascript', value: 'Javascript'},
+  {label: 'JavaScript', value: 'JavaScript'},
   {label: 'cURL', value: 'cURL'},
 ]}>
-<TabItem value="Javascript">
+<TabItem value="JavaScript">
 
 ```javascript
 // Initialize the JS client

--- a/web/docs/guides/auth/auth-email.mdx
+++ b/web/docs/guides/auth/auth-email.mdx
@@ -12,7 +12,7 @@ import TabItem from '@theme/TabItem'
 Setting up Email logins for your Supabase application.
 
 - Add Email authenticator to your [Supabase Project](https://app.supabase.io)
-- Add the login code to your application - [Javascript](https://github.com/supabase/supabase-js) | [Dart](https://github.com/supabase/supabase-dart)
+- Add the login code to your application - [JavaScript](https://github.com/supabase/supabase-js) | [Dart](https://github.com/supabase/supabase-dart)
 
 ## Add Email into your Supabase Project
 
@@ -27,7 +27,7 @@ Setting up Email logins for your Supabase application.
 
 Add logins using our client libraries:
 
-- [Javascript](/docs/reference/javascript/auth-signin#sign-in-with-email)
+- [JavaScript](/docs/reference/javascript/auth-signin#sign-in-with-email)
 - [Dart](/docs/reference/dart/auth-signin#sign-in-with-email)
 
 <Tabs

--- a/web/docs/guides/auth/auth-magic-link.mdx
+++ b/web/docs/guides/auth/auth-magic-link.mdx
@@ -14,7 +14,7 @@ By default, if no password is provided, the user will be sent a "magic link" to 
 Setting up Magic Link logins for your Supabase application.
 
 - Add Magic Link authenticator to your [Supabase Project](https://app.supabase.io)
-- Add the login code to your application - [Javascript](https://github.com/supabase/supabase-js) | [Dart](https://github.com/supabase/supabase-dart)
+- Add the login code to your application - [JavaScript](https://github.com/supabase/supabase-js) | [Dart](https://github.com/supabase/supabase-dart)
 
 ## Add Magic Link into your Supabase Project
 
@@ -29,7 +29,7 @@ Setting up Magic Link logins for your Supabase application.
 
 Add logins using our client libraries:
 
-- [Javascript](/docs/reference/javascript/auth-signin#sign-in-with-magic-link)
+- [JavaScript](/docs/reference/javascript/auth-signin#sign-in-with-magic-link)
 - [Dart](/docs/reference/dart/auth-signin#sign-in-with-magic-link)
 
 <Tabs

--- a/web/docs/guides/auth/auth-messagebird.mdx
+++ b/web/docs/guides/auth/auth-messagebird.mdx
@@ -83,7 +83,7 @@ Using supabase-js on the client you'll want to use the same `signUp` method that
 <Tabs
 defaultValue="JS"
 values={[
-  {label: 'Javascript', value: 'JS'},
+  {label: 'JavaScript', value: 'JS'},
   {label: 'HTTP', value: 'HTTP'},
 ]}>
 <TabItem value="JS">
@@ -118,7 +118,7 @@ You should present a form to the user so they can input the 6 digit pin, then se
 <Tabs
 defaultValue="JS"
 values={[
-  {label: 'Javascript', value: 'JS'},
+  {label: 'JavaScript', value: 'JS'},
   {label: 'HTTP', value: 'HTTP'},
 ]}>
 <TabItem value="JS">
@@ -165,7 +165,7 @@ Also now that the mobile has been verified, the user can use the number and pass
 <Tabs
 defaultValue="JS"
 values={[
-  {label: 'Javascript', value: 'JS'},
+  {label: 'JavaScript', value: 'JS'},
   {label: 'HTTP', value: 'HTTP'},
 ]}>
 <TabItem value="JS">
@@ -202,7 +202,7 @@ In javascript we can use the `signIn` method with a single parameter: `phone`
 <Tabs
 defaultValue="JS"
 values={[
-  {label: 'Javascript', value: 'JS'},
+  {label: 'JavaScript', value: 'JS'},
   {label: 'HTTP', value: 'HTTP'},
 ]}>
 <TabItem value="JS">
@@ -233,7 +233,7 @@ The second step is the same as the previous section, you need to collect the 6-d
 <Tabs
 defaultValue="JS"
 values={[
-  {label: 'Javascript', value: 'JS'},
+  {label: 'JavaScript', value: 'JS'},
   {label: 'HTTP', value: 'HTTP'},
 ]}>
 <TabItem value="JS">

--- a/web/docs/guides/auth/auth-twilio.mdx
+++ b/web/docs/guides/auth/auth-twilio.mdx
@@ -100,7 +100,7 @@ Using supabase-js on the client you'll want to use the same `signUp` method that
 <Tabs
 defaultValue="JS"
 values={[
-  {label: 'Javascript', value: 'JS'},
+  {label: 'JavaScript', value: 'JS'},
   {label: 'HTTP', value: 'HTTP'},
 ]}>
 <TabItem value="JS">
@@ -135,7 +135,7 @@ You should present a form to the user so they can input the 6 digit pin, then se
 <Tabs
 defaultValue="JS"
 values={[
-  {label: 'Javascript', value: 'JS'},
+  {label: 'JavaScript', value: 'JS'},
   {label: 'HTTP', value: 'HTTP'},
 ]}>
 <TabItem value="JS">
@@ -182,7 +182,7 @@ Also now that the mobile has been verified, the user can use the number and pass
 <Tabs
 defaultValue="JS"
 values={[
-  {label: 'Javascript', value: 'JS'},
+  {label: 'JavaScript', value: 'JS'},
   {label: 'HTTP', value: 'HTTP'},
 ]}>
 <TabItem value="JS">
@@ -219,7 +219,7 @@ In javascript we can use the `signIn` method with a single parameter: `phone`
 <Tabs
 defaultValue="JS"
 values={[
-  {label: 'Javascript', value: 'JS'},
+  {label: 'JavaScript', value: 'JS'},
   {label: 'HTTP', value: 'HTTP'},
 ]}>
 <TabItem value="JS">
@@ -250,7 +250,7 @@ The second step is the same as the previous section, you need to collect the 6-d
 <Tabs
 defaultValue="JS"
 values={[
-  {label: 'Javascript', value: 'JS'},
+  {label: 'JavaScript', value: 'JS'},
   {label: 'HTTP', value: 'HTTP'},
 ]}>
 <TabItem value="JS">

--- a/web/docs/guides/auth/auth-vonage.mdx
+++ b/web/docs/guides/auth/auth-vonage.mdx
@@ -75,7 +75,7 @@ Using supabase-js on the client you'll want to use the same `signUp` method that
 <Tabs
 defaultValue="JS"
 values={[
-  {label: 'Javascript', value: 'JS'},
+  {label: 'JavaScript', value: 'JS'},
   {label: 'HTTP', value: 'HTTP'},
 ]}>
 <TabItem value="JS">
@@ -110,7 +110,7 @@ You should present a form to the user so they can input the 6 digit pin, then se
 <Tabs
 defaultValue="JS"
 values={[
-  {label: 'Javascript', value: 'JS'},
+  {label: 'JavaScript', value: 'JS'},
   {label: 'HTTP', value: 'HTTP'},
 ]}>
 <TabItem value="JS">
@@ -157,7 +157,7 @@ Also now that the mobile has been verified, the user can use the number and pass
 <Tabs
 defaultValue="JS"
 values={[
-  {label: 'Javascript', value: 'JS'},
+  {label: 'JavaScript', value: 'JS'},
   {label: 'HTTP', value: 'HTTP'},
 ]}>
 <TabItem value="JS">
@@ -194,7 +194,7 @@ In javascript we can use the `signIn` method with a single parameter: `phone`
 <Tabs
 defaultValue="JS"
 values={[
-  {label: 'Javascript', value: 'JS'},
+  {label: 'JavaScript', value: 'JS'},
   {label: 'HTTP', value: 'HTTP'},
 ]}>
 <TabItem value="JS">
@@ -225,7 +225,7 @@ The second step is the same as the previous section, you need to collect the 6-d
 <Tabs
 defaultValue="JS"
 values={[
-  {label: 'Javascript', value: 'JS'},
+  {label: 'JavaScript', value: 'JS'},
   {label: 'HTTP', value: 'HTTP'},
 ]}>
 <TabItem value="JS">

--- a/web/docs/guides/database/arrays.mdx
+++ b/web/docs/guides/database/arrays.mdx
@@ -8,7 +8,7 @@ import Tabs from '@theme/Tabs'
 import TabItem from '@theme/TabItem'
 
 PostgreSQL supports flexible [array types](https://www.postgresql.org/docs/12/arrays.html).  
-These arrays are also supported in the Supabase dashboard and in the  API.
+These arrays are also supported in the Supabase dashboard and in the JavaScript API.
 
 ## Steps
 
@@ -79,7 +79,7 @@ INSERT INTO arraytest (id, textarray) VALUES (1, ARRAY['Harry', 'Larry', 'Moe'])
 </TabItem>
 
 <TabItem value="JavaScript">
-To insert a record from the  client:
+To insert a record from the JavaScript client:
 
 ```js
 const { data, error } = await supabase
@@ -131,7 +131,7 @@ Your first array data!
 
 ### Query Array Data
 
-To query an array, PostgreSQL uses 1-based arrays, so be careful, since you're probably used to 0-based arrays in .
+To query an array, PostgreSQL uses 1-based arrays, so be careful, since you're probably used to 0-based arrays in JavaScript.
 
 <Tabs
 defaultValue="SQL"

--- a/web/docs/guides/database/arrays.mdx
+++ b/web/docs/guides/database/arrays.mdx
@@ -8,7 +8,7 @@ import Tabs from '@theme/Tabs'
 import TabItem from '@theme/TabItem'
 
 PostgreSQL supports flexible [array types](https://www.postgresql.org/docs/12/arrays.html).  
-These arrays are also supported in the Supabase dashboard and in the Javascript API.
+These arrays are also supported in the Supabase dashboard and in the  API.
 
 ## Steps
 
@@ -79,7 +79,7 @@ INSERT INTO arraytest (id, textarray) VALUES (1, ARRAY['Harry', 'Larry', 'Moe'])
 </TabItem>
 
 <TabItem value="JavaScript">
-To insert a record from the Javascript client:
+To insert a record from the  client:
 
 ```js
 const { data, error } = await supabase
@@ -131,7 +131,7 @@ Your first array data!
 
 ### Query Array Data
 
-To query an array, PostgreSQL uses 1-based arrays, so be careful, since you're probably used to 0-based arrays in Javascript.
+To query an array, PostgreSQL uses 1-based arrays, so be careful, since you're probably used to 0-based arrays in .
 
 <Tabs
 defaultValue="SQL"

--- a/web/docs/guides/database/extensions/plv8.mdx
+++ b/web/docs/guides/database/extensions/plv8.mdx
@@ -1,18 +1,18 @@
 ---
 id: plv8
-title: "plv8:  Language"
-description:  language for PostgreSQL.
+title: "plv8: JavaScript Language"
+description: JavaScript language for PostgreSQL.
 ---
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-The `plv8` extension allows you use  within Postgres. 
+The `plv8` extension allows you use JavaScript within Postgres. 
 
 ## Overview
 
 While Postgres natively runs SQL, it can also run other "procedural languages". 
-`plv8` allows you to run  code - specifically any code that runs on the [V8  engine](https://v8.dev).
+`plv8` allows you to run JavaScript code - specifically any code that runs on the [V8 JavaScript engine](https://v8.dev).
 
 It can be used for database functions, triggers, queries and more.
 
@@ -66,7 +66,7 @@ with the `language` identifier set to `plv8`.
 ```sql
 create or replace function function_name() 
 returns void as $$
-    // V8 
+    // V8 JavaScript
     // code
     // here
 $$ language plv8;

--- a/web/docs/guides/database/extensions/plv8.mdx
+++ b/web/docs/guides/database/extensions/plv8.mdx
@@ -1,18 +1,18 @@
 ---
 id: plv8
-title: "plv8: Javascript Language"
-description: Javascript language for PostgreSQL.
+title: "plv8:  Language"
+description:  language for PostgreSQL.
 ---
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-The `plv8` extension allows you use Javascript within Postgres. 
+The `plv8` extension allows you use  within Postgres. 
 
 ## Overview
 
 While Postgres natively runs SQL, it can also run other "procedural languages". 
-`plv8` allows you to run Javascript code - specifically any code that runs on the [V8 Javascript engine](https://v8.dev).
+`plv8` allows you to run  code - specifically any code that runs on the [V8  engine](https://v8.dev).
 
 It can be used for database functions, triggers, queries and more.
 
@@ -66,7 +66,7 @@ with the `language` identifier set to `plv8`.
 ```sql
 create or replace function function_name() 
 returns void as $$
-    // V8 Javascript
+    // V8 
     // code
     // here
 $$ language plv8;
@@ -80,7 +80,7 @@ You can call `plv8` functions like any other Postgres function:
 defaultValue="SQL"
 values={[
   {label: 'SQL', value: 'SQL'},
-  {label: 'Javascript', value: 'JS'},
+  {label: 'JavaScript', value: 'JS'},
 ]}>
 <TabItem value="SQL">
 

--- a/web/docs/guides/database/full-text-search.mdx
+++ b/web/docs/guides/database/full-text-search.mdx
@@ -91,7 +91,7 @@ Take the following example:
 defaultValue="SQL"
 values={[
   {label: 'SQL', value: 'SQL'},
-  {label: 'Javascript', value: 'JS'},
+  {label: 'JavaScript', value: 'JS'},
   {label: 'Dart', value: 'DART'},
 ]}>
 <TabItem value="SQL">
@@ -135,7 +135,7 @@ example above:
 defaultValue="SQL"
 values={[
   {label: 'SQL', value: 'SQL'},
-  {label: 'Javascript', value: 'JS'},
+  {label: 'JavaScript', value: 'JS'},
   {label: 'Dart', value: 'DART'},
 ]}>
 <TabItem value="SQL">
@@ -180,7 +180,7 @@ To find all `books` where the `description` contain the word `big`:
 defaultValue="SQL"
 values={[
   {label: 'SQL', value: 'SQL'},
-  {label: 'Javascript', value: 'JS'},
+  {label: 'JavaScript', value: 'JS'},
   {label: 'Dart', value: 'DART'},
   {label: 'Data', value: 'Data'},
 ]}>
@@ -269,7 +269,7 @@ To find all `books` where `description` contains BOTH of the words `little` and 
 defaultValue="SQL"
 values={[
   {label: 'SQL', value: 'SQL'},
-  {label: 'Javascript', value: 'JS'},
+  {label: 'JavaScript', value: 'JS'},
   {label: 'Dart', value: 'DART'},
   {label: 'Data', value: 'Data'},
 ]}>
@@ -324,7 +324,7 @@ To find all `books` where `description` contain ANY of the words `little` or `bi
 defaultValue="SQL"
 values={[
   {label: 'SQL', value: 'SQL'},
-  {label: 'Javascript', value: 'JS'},
+  {label: 'JavaScript', value: 'JS'},
   {label: 'Dart', value: 'DART'},
   {label: 'Data', value: 'Data'},
 ]}>
@@ -429,7 +429,7 @@ Now that we've created and populated our index, we can search it using the same 
 defaultValue="SQL"
 values={[
   {label: 'SQL', value: 'SQL'},
-  {label: 'Javascript', value: 'JS'},
+  {label: 'JavaScript', value: 'JS'},
   {label: 'Dart', value: 'DART'},
   {label: 'Data', value: 'Data'},
 ]}>
@@ -490,7 +490,7 @@ For example, to find the phrase `big dreams`, where the a match for "big" is fol
 defaultValue="SQL"
 values={[
   {label: 'SQL', value: 'SQL'},
-  {label: 'Javascript', value: 'JS'},
+  {label: 'JavaScript', value: 'JS'},
   {label: 'Dart', value: 'DART'},
 ]}>
 <TabItem value="SQL">
@@ -535,7 +535,7 @@ We can also use the `<->` to find words within a certain distance of eachother. 
 defaultValue="SQL"
 values={[
   {label: 'SQL', value: 'SQL'},
-  {label: 'Javascript', value: 'JS'},
+  {label: 'JavaScript', value: 'JS'},
   {label: 'Dart', value: 'DART'},
 ]}>
 <TabItem value="SQL">
@@ -583,7 +583,7 @@ For example, to find records that have the word `big` but not `little`:
 defaultValue="SQL"
 values={[
   {label: 'SQL', value: 'SQL'},
-  {label: 'Javascript', value: 'JS'},
+  {label: 'JavaScript', value: 'JS'},
   {label: 'Dart', value: 'DART'},
 ]}>
 <TabItem value="SQL">

--- a/web/docs/guides/database/sql-to-api.mdx
+++ b/web/docs/guides/database/sql-to-api.mdx
@@ -1,7 +1,7 @@
 ---
 id: sql-to-api
-title: 'Converting SQL to  API'
-description: Implementing common SQL patterns in the  API
+title: 'Converting SQL to JavaScript API'
+description: Implementing common SQL patterns in the JavaScript API
 ---
 
 import Tabs from '@theme/Tabs'
@@ -78,6 +78,6 @@ const { data, error } = await supabase
 
 - [Supabase Account - Free Tier OK](https://supabase.com)
 - [Postgrest Operators](https://postgrest.org/en/stable/api.html#operators)
-- [Supabase  API: select](/docs/reference/javascript/select)
-- [Supabase  API: modifiers](/docs/reference/javascript/using-modifiers)
-- [Supabase  API: filters](/docs/reference/javascript/using-filters)
+- [Supabase  API: JavaScript select](/docs/reference/javascript/select)
+- [Supabase  API: JavaScript modifiers](/docs/reference/javascript/using-modifiers)
+- [Supabase  API: JavaScript filters](/docs/reference/javascript/using-filters)

--- a/web/docs/guides/database/sql-to-api.mdx
+++ b/web/docs/guides/database/sql-to-api.mdx
@@ -1,7 +1,7 @@
 ---
 id: sql-to-api
-title: 'Converting SQL to Javascript API'
-description: Implementing common SQL patterns in the Javascript API
+title: 'Converting SQL to  API'
+description: Implementing common SQL patterns in the  API
 ---
 
 import Tabs from '@theme/Tabs'
@@ -78,6 +78,6 @@ const { data, error } = await supabase
 
 - [Supabase Account - Free Tier OK](https://supabase.com)
 - [Postgrest Operators](https://postgrest.org/en/stable/api.html#operators)
-- [Supabase Javascript API: select](/docs/reference/javascript/select)
-- [Supabase Javascript API: modifiers](/docs/reference/javascript/using-modifiers)
-- [Supabase Javascript API: filters](/docs/reference/javascript/using-filters)
+- [Supabase  API: select](/docs/reference/javascript/select)
+- [Supabase  API: modifiers](/docs/reference/javascript/using-modifiers)
+- [Supabase  API: filters](/docs/reference/javascript/using-filters)

--- a/web/docs/guides/examples.mdx
+++ b/web/docs/guides/examples.mdx
@@ -67,7 +67,7 @@ Build a basic Todo List with Supabase and your favorite frontend framework:
 
 ### Auth examples
 
-- [Supabase Auth with vanilla Javascript.](https://github.com/supabase/supabase/tree/master/examples/javascript-auth). Use Supabase without any frontend frameworks.
+- [Supabase Auth with vanilla JavaScript.](https://github.com/supabase/supabase/tree/master/examples/javascript-auth). Use Supabase without any frontend frameworks.
 - [Supabase Auth with Next.js SSR.](https://github.com/supabase/supabase/tree/master/examples/nextjs-with-supabase-auth) Uses cookies to persist auth between the server and the client.
 - [Supabase Auth with RedwoodJS.](https://redwood-playground-auth.netlify.app/supabase) Try out Supabase authentication in the [RedwoodJS](https://redwoodjs.com) Authentication Playground complete with OAuth support and code samples.
 

--- a/web/sidebars.js
+++ b/web/sidebars.js
@@ -13,7 +13,7 @@ module.exports = {
   supabaseClient: [
     {
       type: 'category',
-      label: 'Javascript',
+      label: 'JavaScript',
       collapsed: false,
       items: supabaseClient.docs,
     },


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

Incorrectly writing "JavaScript".

## What is the new behavior?

Correctly writing "JavaScript".

## Additional context

I haven’t corrected the cases in the articles, lmk if it is OK to correct those too.
