### PR TITLE
Docs don't reflect auth.api.SignOut behavior

### DIFF
--- a/web/spec/gotrue.json
+++ b/web/spec/gotrue.json
@@ -8075,7 +8075,7 @@
 							"flags": {},
 							"comment": {
 								"shortText": "Inside a browser context, `signOut()` will remove the logged in user from the browser session\nand log them out - removing all items from localstorage and then trigger a \"SIGNED_OUT\" event.",
-								"text": "For server-side management, you can revoke all refresh tokens for a user by passing a user's JWT through to `auth.api.signOut(JWT: string)`. There is currently no way to revoke a user's session JWT before it automatically expires.\n"
+								"text": "For server-side management, you can revoke all refresh tokens for a user by passing a user's JWT through to `auth.api.signOut(JWT: string)`. There is no way to revoke a user's session JWT before it automatically expires.\n"
 							},
 							"type": {
 								"type": "reference",

--- a/web/spec/gotrue.json
+++ b/web/spec/gotrue.json
@@ -8075,7 +8075,7 @@
 							"flags": {},
 							"comment": {
 								"shortText": "Inside a browser context, `signOut()` will remove the logged in user from the browser session\nand log them out - removing all items from localstorage and then trigger a \"SIGNED_OUT\" event.",
-								"text": "For server-side management, you can disable sessions by passing a JWT through to `auth.api.signOut(JWT: string)`\n"
+								"text": "For server-side management, you can revoke all refresh tokens for a user by passing a user's JWT through to `auth.api.signOut(JWT: string)`. There is currently no way to revoke a user's session JWT before it automatically expires.\n"
 							},
 							"type": {
 								"type": "reference",


### PR DESCRIPTION

## What kind of change does this PR introduce?

Bug fix for docs. `signOut()` docs currently seem to indicate that an access token is deleted on the server upon this function being called, but this isn't the case. Instead all refresh tokens are all revoked instead and access tokens will stay alive until they expire.

## Additional context

There is some discussion of changing this behavior in https://github.com/supabase/gotrue/issues/248, but the current behavior of `signOut()` is to just revoke all refresh tokens.

Before allowing this change through, can someone who is more familiar with the supabase source confirm that I am not totally wrong here. I believe I am right because the supabase GoTrue docs say that `/logout` only revokes refresh tokens (https://github.com/supabase/gotrue#post-logout), and the auth.api.SignOut() just seems to call this endpoint https://github.com/supabase/gotrue-js/blob/2f183f421096755d3ae2bd4f698503422a6b8eea/src/GoTrueApi.ts#L325-L337

If this is incorrect, feel free to reject this PR.