### PR TITLE
Chore: update drag and drop text color

### DIFF
--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/SpreadsheetImport/SpreadSheetFileUpload.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/SpreadsheetImport/SpreadSheetFileUpload.tsx
@@ -46,7 +46,7 @@ const SpreadSheetFileUpload: FC<Props> = ({
       </div>
       {!uploadedFile ? (
         <div
-          className={`flex items-center justify-center border dark:border-gray-500 border-dashed rounded-md h-48 ${
+          className={`cursor-pointer flex items-center justify-center border dark:border-gray-500 border-dashed rounded-md h-48 ${
             isDraggedOver ? 'bg-gray-500' : ''
           }`}
           onDragOver={onDragOver}
@@ -55,7 +55,7 @@ const SpreadSheetFileUpload: FC<Props> = ({
           onClick={() => (uploadButtonRef.current as any)?.click()}
         >
           <Typography.Text>
-            Drag and drop, or <span className="text-green-500 cursor-pointer">browse</span> your
+            Drag and drop, or <span className="text-green-1000">browse</span> your
             files
           </Typography.Text>
         </div>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Update the drag and drop text color.

## What is the current behavior?

<img width="672" alt="Screen Shot 2022-03-29 at 9 58 56 PM" src="https://user-images.githubusercontent.com/70828596/160735469-d206a17a-0c59-4a04-a054-5cace386e65d.png">

## What is the new behavior?

<img width="672" alt="Screen Shot 2022-03-29 at 9 58 42 PM" src="https://user-images.githubusercontent.com/70828596/160735444-9c9220e9-0cb9-4d01-b99d-4e1c26003862.png">