### PR TITLE
fix/logs: preserve newlines for preview navigation to explorer

### DIFF
--- a/studio/components/interfaces/Settings/Logs/Logs.SavedQueriesItem.tsx
+++ b/studio/components/interfaces/Settings/Logs/Logs.SavedQueriesItem.tsx
@@ -47,7 +47,7 @@ const SavedQueriesItem: FC<Props> = ({ item }: Props) => {
             type="alternative"
             iconRight={<IconPlay size={10} />}
             onClick={() =>
-              router.push(`/project/${ref}/logs-explorer?sql=${encodeURI(item.content.sql)}`)
+              router.push(`/project/${ref}/logs-explorer?sql=${encodeURIComponent(item.content.sql)}`)
             }
           >
             Run

--- a/studio/components/interfaces/Settings/Logs/LogsPreviewer.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogsPreviewer.tsx
@@ -159,7 +159,7 @@ export const LogsPreviewer: React.FC<Props> = ({
             : ''
         }
         onExploreClick={() => {
-          router.push(`/project/${projectRef}/logs-explorer?q=${params.rawSql}`)
+          router.push(`/project/${projectRef}/logs-explorer?q=${encodeURIComponent(params.rawSql)}`)
         }}
         onSelectTemplate={onSelectTemplate}
         dispatchWhereFilters={dispatchWhereFilters}

--- a/studio/tests/pages/projects/LogsPreviewer.test.js
+++ b/studio/tests/pages/projects/LogsPreviewer.test.js
@@ -283,3 +283,12 @@ test('bug: nav backwards with params change results in ui changing', async () =>
 
   await screen.findByDisplayValue('simple-query')
 })
+
+test("bug: nav to explorer preserves newlines", async ()=>{
+  render(
+    <LogsPreviewer projectRef="123" tableName={LogsTableName.EDGE} />
+  )
+  const router = useRouter()
+  userEvent.click(await screen.findByText(/Explore/))
+  await expect(router.push).toBeCalledWith(expect.stringContaining(encodeURIComponent("\n")))
+}


### PR DESCRIPTION
Fixes issue where clicking on "Explore with Query" does not preserve newlines of the generated query