### PR TITLE
Fix graphql url.

### DIFF
--- a/web/docs/guides/api.mdx
+++ b/web/docs/guides/api.mdx
@@ -133,7 +133,7 @@ Every Supabase project has a unique API URL. Your API is secured behind an API g
 The REST API and the GraphQL API are both accessible through this URL: 
 
 - REST: `https://<project_ref>.supabase.com/rest/v1`
-- GraphQL: `https://<project_ref>.supabase.com/rest/v1`
+- GraphQL: `https://<project_ref>.supabase.com/graphql/v1`
 
 Both of these routes require the `anon` key to be passed through an `apikey` header.
 


### PR DESCRIPTION
Fixes the url for graphql to the one that is called out on [the introductory blog post.](https://supabase.com/blog/2022/03/29/graphql-now-available)

## What kind of change does this PR introduce?
Docs update
## What is the current behavior?
Incorrect URL for graphql endpoint.

## What is the new behavior?

Correct URL for graphql endpoint.

## Additional context

This was confusing to me when I first approached the project and I wanted to fix it.