### PR TITLE
blog: changed deno testing link

### DIFF
--- a/www/_blog/2022-03-31-supabase-edge-functions.mdx
+++ b/www/_blog/2022-03-31-supabase-edge-functions.mdx
@@ -46,7 +46,7 @@ Deno even goes a step further than maintaining feature-parity, releasing all new
 
 ### Batteries included
 
-Deno comes with all the tools needed for a modern, productive developer experience, so you can spend less time searching through third party modules, and more time being productive. Out of the box, it includes support for Typescript, ES modules, and provides [test runners](https://deno.land/manual/tools/testing), [formatters](https://deno.land/manual/tools/formatter), [linters](https://deno.land/manual/tools/linter), [bundlers](https://deno.land/manual/tools/bundler) and a package manager.
+Deno comes with all the tools needed for a modern, productive developer experience, so you can spend less time searching through third party modules, and more time being productive. Out of the box, it includes support for Typescript, ES modules, and provides [test runners](https://deno.land/manual/testing), [formatters](https://deno.land/manual/tools/formatter), [linters](https://deno.land/manual/tools/linter), [bundlers](https://deno.land/manual/tools/bundler) and a package manager.
 
 ### Secure by default
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Blog change

## What is the current behavior?

The deno testing link results in a 404 error

Linked to [this](https://github.com/supabase/supabase/issues/6236) issue

## What is the new behavior?

Changed the link to the Deno testing page
