### PR TITLE
Realtime docs: added limitations for row level changes

### DIFF
--- a/web/spec/supabase.yml
+++ b/web/spec/supabase.yml
@@ -1451,7 +1451,7 @@ pages:
             .subscribe()
           ```
       - name: Listening to row level changes
-        description: You can listen to individual rows using the format `{table}:{col}=eq.{val}` - where `{col}` is the column name, and `{val}` is the value which you want to match. Only filtering by a single column and only using the `eq` operator is available now. Keep in mind, Supabase would not send an update event if `{col}` changed from `{val}` to `{val2}`.
+        description: You can listen to individual rows using the format `{table}:{col}=eq.{val}` - where `{col}` is the column name, and `{val}` is the value which you want to match. Only filtering by a single column and only using `eq`, `neq`, `lt`, `lte`, `gt`, `gte` operators is available now. Keep in mind, Supabase would not send an update event if `{col}` changed from `{val}` to `{val2}`.
         js: |
           ```js
           const mySubscription = supabase

--- a/web/spec/supabase.yml
+++ b/web/spec/supabase.yml
@@ -1451,7 +1451,7 @@ pages:
             .subscribe()
           ```
       - name: Listening to row level changes
-        description: You can listen to individual rows using the format `{table}:{col}=eq.{val}` - where `{col}` is the column name, and `{val}` is the value which you want to match.
+        description: You can listen to individual rows using the format `{table}:{col}=eq.{val}` - where `{col}` is the column name, and `{val}` is the value which you want to match. Only filtering by a single column and only using the `eq` operator is available now. Keep in mind, Supabase would not send an update event if `{col}` changed from `{val}` to `{val2}`.
         js: |
           ```js
           const mySubscription = supabase

--- a/web/spec/supabase.yml
+++ b/web/spec/supabase.yml
@@ -1452,6 +1452,11 @@ pages:
           ```
       - name: Listening to row level changes
         description: You can listen to individual rows using the format `{table}:{col}=eq.{val}` - where `{col}` is the column name, and `{val}` is the value which you want to match. Only filtering by a single column and only using `eq` operator is supported now. Keep in mind, Supabase would not send an update event if `{col}` changed from `{val}` to `{val2}` for example above.
+        description: | 
+          You can listen to individual rows using the format `{table}:{col}=eq.{val}` - where `{col}` is the column name, and `{val}` is the value which you want to match. 
+
+          Only filtering by a single column and only using `eq` operators is supported. 
+          When using the `eq` filter, keep in mind that an event will not be sent if a column is updated to a value that no longer matches your filter.
         js: |
           ```js
           const mySubscription = supabase

--- a/web/spec/supabase.yml
+++ b/web/spec/supabase.yml
@@ -1451,7 +1451,6 @@ pages:
             .subscribe()
           ```
       - name: Listening to row level changes
-        description: You can listen to individual rows using the format `{table}:{col}=eq.{val}` - where `{col}` is the column name, and `{val}` is the value which you want to match. Only filtering by a single column and only using `eq` operator is supported now. Keep in mind, Supabase would not send an update event if `{col}` changed from `{val}` to `{val2}` for example above.
         description: | 
           You can listen to individual rows using the format `{table}:{col}=eq.{val}` - where `{col}` is the column name, and `{val}` is the value which you want to match. 
 

--- a/web/spec/supabase.yml
+++ b/web/spec/supabase.yml
@@ -1451,7 +1451,7 @@ pages:
             .subscribe()
           ```
       - name: Listening to row level changes
-        description: You can listen to individual rows using the format `{table}:{col}=eq.{val}` - where `{col}` is the column name, and `{val}` is the value which you want to match. Only filtering by a single column and only using `eq`, `neq`, `lt`, `lte`, `gt`, `gte` operators is available now. Keep in mind, Supabase would not send an update event if `{col}` changed from `{val}` to `{val2}`.
+        description: You can listen to individual rows using the format `{table}:{col}=eq.{val}` - where `{col}` is the column name, and `{val}` is the value which you want to match. Only filtering by a single column and only using `eq`, `neq`, `lt`, `lte`, `gt`, `gte` operators are available. Keep in mind, Supabase would not send an update event if `{col}` changed from `{val}` to `{val2}`.
         js: |
           ```js
           const mySubscription = supabase

--- a/web/spec/supabase.yml
+++ b/web/spec/supabase.yml
@@ -1451,7 +1451,7 @@ pages:
             .subscribe()
           ```
       - name: Listening to row level changes
-        description: You can listen to individual rows using the format `{table}:{col}=eq.{val}` - where `{col}` is the column name, and `{val}` is the value which you want to match. Only filtering by a single column and only using `eq`, `neq`, `lt`, `lte`, `gt`, `gte` operators are available. Keep in mind, Supabase would not send an update event if `{col}` changed from `{val}` to `{val2}`.
+        description: You can listen to individual rows using the format `{table}:{col}=eq.{val}` - where `{col}` is the column name, and `{val}` is the value which you want to match. Only filtering by a single column and only using `eq` operator is supported now. Keep in mind, Supabase would not send an update event if `{col}` changed from `{val}` to `{val2}` for example above.
         js: |
           ```js
           const mySubscription = supabase


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs updated with limitations for row level changes.

## What is the current behavior?

1. Only `eq` operator is available.
2. Only filtering by a single column is available.
3. UPDATE event is not fired if filtered by a changed column.

Example:
```
const mySubscription = supabase
  .from('forms:request_id=eq.200')
  .on('UPDATE', handleRecordUpdated)
  .subscribe()
```
Changing row `{ id: 1, request_id: 200 }` to `{ id: 1, request_id: 201 }` would not fire UPDATE event.
Which might be expected, similar way as DELETE event fired with `payload.old` property having removed row.

## What is the new behavior?

Added these notes to docs.

## Additional context

Related Issue: [#132](https://github.com/supabase/realtime/issues/132)
Related PR: [#133](https://github.com/supabase/realtime/pull/133)
