### PR TITLE
fix prisma starter command

### DIFF
--- a/web/docs/guides/integrations/prisma.mdx
+++ b/web/docs/guides/integrations/prisma.mdx
@@ -30,13 +30,13 @@ In case you don’t have a Prisma project or this is your first time working wit
 Navigate into a directory of your choice and run the following command in your terminal if you’re on a Windows machine:
 
 ```bash
-curl https://pris.ly/quickstart -L -o quickstart-master.tar.gz && tar -zxvf quickstart-master.tar.gz quickstart-master/typescript/starter && move quickstart-master\typescript\starter starter && rmdir /S /Q quickstart-master && del /Q quickstart-master.tar.gz
+curl https://pris.ly/quickstart -L -o quickstart-main.tar.gz && tar -zxvf quickstart-main.tar.gz quickstart-main/typescript/starter && move quickstart-main\typescript\starter starter && rmdir /S /Q quickstart-main && del /Q quickstart-main.tar.gz
 ```
 
 And if you’re using Mac OS or Linux, run the following command:
 
 ```bash
-curl -L https://pris.ly/quickstart | tar -xz --strip=2 quickstart-master/typescript/starter
+curl -L https://pris.ly/quickstart | tar -xz --strip=2 quickstart-main/typescript/starter
 ```
 
 You can now navigate into the directory and install the project’s dependencies:


### PR DESCRIPTION
The prisma team seems to have updated the starter to use the word `main` instead of `master`

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

When following the guide, the command to install create the prisma project from a starter template fails on mac
```
curl -L https://pris.ly/quickstart | tar -xz --strip=2 quickstart-master/typescript/starter
tar: quickstart-master/typescript/starter: Not found in archive
tar: Error exit delayed from previous errors.
```

## What is the new behavior?

The prisma starter can be downloaded just by replacing `master` with `main`
```
curl -L https://pris.ly/quickstart | tar -xz --strip=2 quickstart-main/typescript/starter
```

## Additional context

I found the right command in the [Prisma Quickstart page](https://www.prisma.io/docs/getting-started/quickstart)
![image](https://user-images.githubusercontent.com/86024/161369102-ad1cfb82-a40e-4fcd-9df5-95d390c4e908.png)

