### PR TITLE
Fix typo for "unset secrets" example.

### DIFF
--- a/studio/pages/project/[ref]/functions/[id]/details.tsx
+++ b/studio/pages/project/[ref]/functions/[id]/details.tsx
@@ -83,7 +83,7 @@ const PageLayout: NextPageWithLayout = () => {
     },
     {
       command: `supabase secrets unset NAME1 NAME2 `,
-      description: 'This will deleet secrets for your project',
+      description: 'This will delete secrets for your project',
       jsx: () => {
         return (
           <>

--- a/studio/pages/project/[ref]/functions/[id]/details.tsx
+++ b/studio/pages/project/[ref]/functions/[id]/details.tsx
@@ -91,7 +91,7 @@ const PageLayout: NextPageWithLayout = () => {
           </>
         )
       },
-      comment: 'Set secrets for your project',
+      comment: 'Unset secrets for your project',
     },
   ]
 


### PR DESCRIPTION
Currently, in the functions tab there is a typo. Both the `set secrets` and `unset secrets` example have the title of `Set secrets for your project`, as seen in the image below.

![image](https://user-images.githubusercontent.com/28601784/161380646-9f629ab0-339a-4d86-aa09-76e06d3db0f9.png)

This PR simply changes the second example title to `Unset secrets for your project.`