### PR TITLE
docs: fixes wrong suggested filename in with-expo documentation

### DIFF
--- a/web/docs/guides/with-expo.mdx
+++ b/web/docs/guides/with-expo.mdx
@@ -271,7 +271,7 @@ const styles = StyleSheet.create({
 
 After a user is signed in we can allow them to edit their profile details and manage their account.
 
-Let's create a new component for that called `Account.js`.
+Let's create a new component for that called `Account.tsx`.
 
 ```jsx title="components/Account.tsx"
 import { useState, useEffect } from "react";


### PR DESCRIPTION
## What kind of change does this PR introduce?

Changes the suggested filename in the Expo guide to Accounts.tsx (instead of Accounts.js)

## What is the current behavior?

The Expo guide instructs new learners to create a file named Account.js, but what is needed is Account.tsx since it will contain TypeScript.

## What is the new behavior?

It now says **Accounts.tsx**

## Additional context

https://supabase.com/docs/guides/with-expo#account-page
