### PR TITLE
fix: Update GraphQL query in apis doc to match the generated api

### DIFF
--- a/web/docs/guides/api.mdx
+++ b/web/docs/guides/api.mdx
@@ -275,9 +275,13 @@ const client = createClient({
 // Prepare our GraphQL query
 const TodosQuery = `
   query {
-    todos {
-      id
-      title
+    todosCollection {
+      edges {
+        node {
+          id
+          title
+        }
+      }
     }
   }
 `


### PR DESCRIPTION
The current graphql query in https://supabase.com/docs/guides/api#graphql-api-1 does not actually work with the queries generated by pg_graphql. This is because all graphql queries are currently generated with a "collection" suffix.