### PR TITLE
fix: text overflow for menu items should not hide action button

### DIFF
--- a/studio/components/layouts/SQLEditorLayout/SQLEditorMenuOld.tsx
+++ b/studio/components/layouts/SQLEditorLayout/SQLEditorMenuOld.tsx
@@ -40,6 +40,7 @@ const OpenQueryItem = observer(({ tabInfo }: { tabInfo: any }) => {
       name={name}
       action={active && <DropdownMenu tabInfo={tabInfo} />}
       onClick={() => sqlEditorStore.selectTab(id)}
+      textClassName="w-44"
     />
   )
 })

--- a/studio/components/ui/ProductMenu/ProductMenuItem.tsx
+++ b/studio/components/ui/ProductMenu/ProductMenuItem.tsx
@@ -10,6 +10,7 @@ interface Props {
   url?: string
   target?: '_blank' | '_self'
   onClick?: () => void
+  textClassName?: string
 }
 
 const ProductMenuItem: FC<Props> = ({
@@ -20,11 +21,14 @@ const ProductMenuItem: FC<Props> = ({
   url = '',
   target = '_self',
   onClick,
+  textClassName = '',
 }) => {
   const menuItem = (
     <Menu.Item icon={icon} rounded active={isActive} onClick={onClick}>
       <div className="flex w-full justify-between">
-        <Typography.Text className="truncate flex items-center">{name}</Typography.Text>
+        <span className={'truncate flex items-center ' + textClassName}>
+          {name}
+        </span>
         {action}
       </div>
     </Menu.Item>


### PR DESCRIPTION
Ref: https://support.supabase.org/a/tickets/5678

Fixes text overflow hiding menu button in SQL editor 

<img width="296" alt="image" src="https://user-images.githubusercontent.com/22714384/161629173-dd7506e5-0952-457c-bc59-b852c9fb4682.png">

@MildTomato seems like text ellipses css for text overflow isn't getting rendered right... `truncate` should set `text-overflow: ellipsis`. The css rule gets set though. might be a stylesheet issue 