### PR TITLE
www: contrast and alignment change

### DIFF
--- a/www/pages/auth/Auth.tsx
+++ b/www/pages/auth/Auth.tsx
@@ -100,7 +100,7 @@ function AuthPage() {
         <SectionContainer>
           <div className="grid grid-cols-12">
             <div className="mb-10 lg:mb-0 col-span-12 lg:col-span-3">
-              <p className="mb-4">
+              <p className="mb-4 lg:h-12">
                 <div className="grid grid-rows-2 grid-flow-col gap-2 xl:w-64">
                   <div className="w-fit flex items-center">
                     <svg
@@ -132,13 +132,13 @@ function AuthPage() {
                 </div>
               </p>
               <h4 className="h4">All the social providers</h4>
-              <p className="p text-base text-scale-1100">
+              <p className="p text-base">
                 Enable social logins with the click of a button. Google, Facebook, GitHub, Azure,
                 Gitlab, Twitter, Discord, and many more.
               </p>
             </div>
             <div className="mb-10 lg:mb-0 col-span-12 lg:col-span-3 lg:col-start-5">
-              <p className="p mb-4">
+              <p className="p mb-4 lg:h-12">
                 <IconLink />
               </p>
               <h4 className="h4">Fully integrated</h4>
@@ -148,7 +148,7 @@ function AuthPage() {
               </p>
             </div>
             <div className="col-span-12 lg:col-span-3 lg:col-start-9">
-              <p className="p mb-4">
+              <p className="p mb-4 lg:h-12">
                 <IconShield />
               </p>
               <h4 className="h4">Own your data</h4>

--- a/www/pages/auth/Auth.tsx
+++ b/www/pages/auth/Auth.tsx
@@ -100,7 +100,7 @@ function AuthPage() {
         <SectionContainer>
           <div className="grid grid-cols-12">
             <div className="mb-10 lg:mb-0 col-span-12 lg:col-span-3">
-              <p className="mb-4 lg:h-12">
+              <p className="mb-4 -mt-[1.9rem]">
                 <div className="grid grid-rows-2 grid-flow-col gap-2 xl:w-64">
                   <div className="w-fit flex items-center">
                     <svg
@@ -138,7 +138,7 @@ function AuthPage() {
               </p>
             </div>
             <div className="mb-10 lg:mb-0 col-span-12 lg:col-span-3 lg:col-start-5">
-              <p className="p mb-4 lg:h-12">
+              <p className="p mb-4">
                 <IconLink />
               </p>
               <h4 className="h4">Fully integrated</h4>
@@ -148,7 +148,7 @@ function AuthPage() {
               </p>
             </div>
             <div className="col-span-12 lg:col-span-3 lg:col-start-9">
-              <p className="p mb-4 lg:h-12">
+              <p className="p mb-4">
                 <IconShield />
               </p>
               <h4 className="h4">Own your data</h4>


### PR DESCRIPTION
## What kind of change does this PR introduce?

bug fix on the Supabase website on the [auth](https://supabase.com/auth) page

## What is the current behavior?

Linked to this [issue](https://github.com/supabase/supabase/issues/6331).

The text colour is the same as the background colour.

Also the alignment of the section is off at the moment

## What is the new behavior?

The text colour is now showing correct and also the alignment of the section is now aligned on large screens:

<img width="876" alt="Screenshot 2022-04-06 at 21 09 45" src="https://user-images.githubusercontent.com/22655069/162063277-cbdb5414-4f2e-4fae-87db-7f94df4baed3.png">
