### PR TITLE
Www beta logo size

### DIFF
--- a/www/pages/auth/Auth.tsx
+++ b/www/pages/auth/Auth.tsx
@@ -100,7 +100,7 @@ function AuthPage() {
         <SectionContainer>
           <div className="grid grid-cols-12">
             <div className="mb-10 lg:mb-0 col-span-12 lg:col-span-3">
-              <p className="mb-4">
+              <p className="mb-4 lg:h-12">
                 <div className="grid grid-rows-2 grid-flow-col gap-2 xl:w-64">
                   <div className="w-fit flex items-center">
                     <svg
@@ -132,13 +132,13 @@ function AuthPage() {
                 </div>
               </p>
               <h4 className="h4">All the social providers</h4>
-              <p className="p text-base text-scale-1100">
+              <p className="p text-base">
                 Enable social logins with the click of a button. Google, Facebook, GitHub, Azure,
                 Gitlab, Twitter, Discord, and many more.
               </p>
             </div>
             <div className="mb-10 lg:mb-0 col-span-12 lg:col-span-3 lg:col-start-5">
-              <p className="p mb-4">
+              <p className="p mb-4 lg:h-12">
                 <IconLink />
               </p>
               <h4 className="h4">Fully integrated</h4>
@@ -148,7 +148,7 @@ function AuthPage() {
               </p>
             </div>
             <div className="col-span-12 lg:col-span-3 lg:col-start-9">
-              <p className="p mb-4">
+              <p className="p mb-4 lg:h-12">
                 <IconShield />
               </p>
               <h4 className="h4">Own your data</h4>

--- a/www/pages/beta.tsx
+++ b/www/pages/beta.tsx
@@ -1001,7 +1001,7 @@ const Beta = (props: Props) => {
           <div className="flex items-center justify-between px-5 py-5 shadow-lg xl:px-20 bg-scale-1200 dark:bg-scale-300">
             <Link href="/">
               <a>
-                <Image src={`${basePath}/images/logo-dark.png`} height={20} width={20} />
+                <Image src={`${basePath}/images/logo-dark.png`} height={24} width={120} />
               </a>
             </Link>
             <HamburgerMenu openMenu={() => setMenuOpen(!menuOpen)} />


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix on the Supabase Beta page.

## What is the current behavior?

The Supabase logo is really small and stretched.

Linked to this [issue](https://github.com/supabase/supabase/issues/6330)

## What is the new behavior?

The logo is now appearing:

<img width="1111" alt="Screenshot 2022-04-06 at 21 26 07" src="https://user-images.githubusercontent.com/22655069/162064863-309a3d5d-6a1e-49bd-97c7-1c37fe06be0e.png">

