### PR TITLE
logo on beta page resized

### DIFF
--- a/www/pages/beta.tsx
+++ b/www/pages/beta.tsx
@@ -1001,7 +1001,7 @@ const Beta = (props: Props) => {
           <div className="flex items-center justify-between px-5 py-5 shadow-lg xl:px-20 bg-scale-1200 dark:bg-scale-300">
             <Link href="/">
               <a>
-                <Image src={`${basePath}/images/logo-dark.png`} height={20} width={20} />
+                <Image src={`${basePath}/images/logo-dark.png`} height={24} width={120} />
               </a>
             </Link>
             <HamburgerMenu openMenu={() => setMenuOpen(!menuOpen)} />


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix on the Supabase Beta page.

## What is the current behavior?

The Supabase logo is really small and stretched.

Linked to this https://github.com/supabase/supabase/issues/6330

## What is the new behavior?

The logo is now appearing:

<img width="1111" alt="Screenshot 2022-04-06 at 21 26 07" src="https://user-images.githubusercontent.com/22655069/162160554-9aaeee39-3a04-4370-ba83-c8de611854be.png">

## Additional context

New pull request from the original.
