### PR TITLE
Fix a tiny formatting typo

### DIFF
--- a/web/docs/guides/integrations/pgmustard.mdx
+++ b/web/docs/guides/integrations/pgmustard.mdx
@@ -17,7 +17,7 @@ pgMustard requires plans to be in json format, and the buffers, verbose, and set
 So a good prefix for your query would be: 
 
 ```jsx
-explain (analyze, format json, buffers, verbose, settings)`
+explain (analyze, format json, buffers, verbose, settings)
 ```
 
 Run the query, and copy the output. 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

My explain command contains a tiny typo, which is suboptimal given it's likely to be copy pasted (sorry) 🤦‍♂️

## What is the new behavior?

Typo is gone!
