### PR TITLE
fix: restrict how many requests are made by app to api when no sql is…

### DIFF
--- a/studio/hooks/analytics/useLogsPreview.tsx
+++ b/studio/hooks/analytics/useLogsPreview.tsx
@@ -64,8 +64,9 @@ function useLogsPreview(
 
     // check that SQL is ready for the logs request
     if(!params.sql || !params.rawSql) {
-      // return empty url to restrict unnecessary requests to api
-      return ''
+      // return null to restrict unnecessary requests to api
+      // https://swr.vercel.app/docs/conditional-fetching#conditional
+      return null
     }
 
     // if prev page data is 100 items, could possibly have more records that are not yet fetched within this interval
@@ -97,8 +98,9 @@ function useLogsPreview(
     
     // check that SQL is ready for the count request
     if(!params.sql || !params.rawSql) {
-      // return empty url to restrict unnecessary requests to api
-      return ''
+      // return null to restrict unnecessary requests to api
+      // https://swr.vercel.app/docs/conditional-fetching#conditional
+      return null
     }
 
     return `${API_URL}/projects/${projectRef}/analytics/endpoints/logs.all?${genQueryParams(

--- a/studio/hooks/analytics/useLogsPreview.tsx
+++ b/studio/hooks/analytics/useLogsPreview.tsx
@@ -63,7 +63,7 @@ function useLogsPreview(
     let queryParams
 
     // check that SQL is ready for the logs request
-    if(!params.sql || !params.rawSql) {
+    if(!params.sql) {
       // return null to restrict unnecessary requests to api
       // https://swr.vercel.app/docs/conditional-fetching#conditional
       return null
@@ -97,7 +97,7 @@ function useLogsPreview(
   const countUrl = () => {
     
     // check that SQL is ready for the count request
-    if(!params.sql || !params.rawSql) {
+    if(!params.sql) {
       // return null to restrict unnecessary requests to api
       // https://swr.vercel.app/docs/conditional-fetching#conditional
       return null

--- a/studio/hooks/analytics/useLogsPreview.tsx
+++ b/studio/hooks/analytics/useLogsPreview.tsx
@@ -93,13 +93,22 @@ function useLogsPreview(
   } = useSWRInfinite<Logs>(getKeyLogs, get, { revalidateOnFocus: false, dedupingInterval: 3000 })
   let logData: LogData[] = []
 
-  const countUrl = `${API_URL}/projects/${projectRef}/analytics/endpoints/logs.all?${genQueryParams(
-    {
-      ...params,
-      sql: genCountQuery(table),
-      period_start: String(latestRefresh),
-    } as any
-  )}`
+  const countUrl = () => {
+    
+    // check that SQL is ready for the count request
+    if(!params.sql || !params.rawSql) {
+      // return empty url to restrict unnecessary requests to api
+      return ''
+    }
+
+    return `${API_URL}/projects/${projectRef}/analytics/endpoints/logs.all?${genQueryParams(
+      {
+        ...params,
+        sql: genCountQuery(table),
+        period_start: String(latestRefresh),
+      } as any
+    )}`
+  }
 
   const { data: countData } = useSWR<Count>(countUrl, get, {
     revalidateOnFocus: false,

--- a/studio/hooks/analytics/useLogsPreview.tsx
+++ b/studio/hooks/analytics/useLogsPreview.tsx
@@ -61,6 +61,13 @@ function useLogsPreview(
   // handle url generation for log pagination
   const getKeyLogs: SWRInfiniteKeyLoader = (_pageIndex: number, prevPageData: Logs) => {
     let queryParams
+
+    // check that SQL is ready for the logs request
+    if(!params.sql || !params.rawSql) {
+      // return empty url to restrict unnecessary requests to api
+      return ''
+    }
+
     // if prev page data is 100 items, could possibly have more records that are not yet fetched within this interval
     if (prevPageData === null) {
       // reduce interval window limit by using the timestamp of the last log

--- a/studio/hooks/analytics/useLogsPreview.tsx
+++ b/studio/hooks/analytics/useLogsPreview.tsx
@@ -62,7 +62,7 @@ function useLogsPreview(
   const getKeyLogs: SWRInfiniteKeyLoader = (_pageIndex: number, prevPageData: Logs) => {
     let queryParams
 
-    // check that SQL is ready for the logs request
+    // cancel request if no sql provided
     if(!params.sql) {
       // return null to restrict unnecessary requests to api
       // https://swr.vercel.app/docs/conditional-fetching#conditional
@@ -96,7 +96,7 @@ function useLogsPreview(
 
   const countUrl = () => {
     
-    // check that SQL is ready for the count request
+    // cancel request if no sql provided
     if(!params.sql) {
       // return null to restrict unnecessary requests to api
       // https://swr.vercel.app/docs/conditional-fetching#conditional


### PR DESCRIPTION
… present for logs request

## What kind of change does this PR introduce?

Stops a request to the API when there is no SQL ready to retrieve logs.

## What is the current behavior?

A request is made to API too soon, when the constructed SQL is not ready.
SWR then tries to refetch again once the SQL comes through which results in wasted requests to API.

## What is the new behavior?

Request is only made when SQL and raw SQL are defined

## Additional context

Add any other context or screenshots.
