### PR TITLE
Fix small typo.

### DIFF
--- a/web/docs/guides/auth.mdx
+++ b/web/docs/guides/auth.mdx
@@ -27,7 +27,7 @@ There are two parts to every Auth system:
 - **Authorization:** once they are in, what are they allowed to do?
 
 Supabase Auth is designed to work either as a standalone product, or deeply integrated with the other Supabase products. 
-Postgres is at the heart of everything we do, and the Auth system follows this principle. We leverage Postgres' build-in Auth functionality wherever possible.
+Postgres is at the heart of everything we do, and the Auth system follows this principle. We leverage Postgres' built-in Auth functionality wherever possible.
 
 ## Authentication
 


### PR DESCRIPTION
There's a small typo, "build-in" should be "built-in".

## What kind of change does this PR introduce?

Docs update.     