### PR TITLE
functions example changed to hello-world

### DIFF
--- a/studio/pages/project/[ref]/functions/index.tsx
+++ b/studio/pages/project/[ref]/functions/index.tsx
@@ -76,40 +76,40 @@ const EmptyFunctions = () => {
     //   comment: 'Link this project',
     // },
     {
-      command: 'supabase functions new hello',
-      description: ' creates a function stub at ./functions/hello/hello.ts',
+      command: 'supabase functions new hello-world',
+      description: ' creates a function stub at ./functions/hello-world/index.ts',
       jsx: () => {
         return (
           <>
-            <span className="text-brand-1100">supabase</span> functions new hello
+            <span className="text-brand-1100">supabase</span> functions new hello-world
           </>
         )
       },
       comment: 'Create a function',
     },
     {
-      command: `supabase functions deploy hello --project-ref ${ref}`,
-      description: 'Deploys function at ./functions/hello/index.ts',
+      command: `supabase functions deploy hello-world --project-ref ${ref}`,
+      description: 'Deploys function at ./functions/hello-world/index.ts',
       jsx: () => {
         return (
           <>
-            <span className="text-brand-1100">supabase</span> functions deploy hello --project-ref{' '}
-            {ref}
+            <span className="text-brand-1100">supabase</span> functions deploy hello-world
+            --project-ref {ref}
           </>
         )
       },
       comment: 'Deploy your function',
     },
     {
-      command: `curl -L -X POST 'https://${ref}.functions.supabase.co/hello' -H 'Authorization: Bearer ${
+      command: `curl -L -X POST 'https://${ref}.functions.supabase.co/hello-world' -H 'Authorization: Bearer ${
         anonKey ?? '[YOUR ANON KEY]'
       }' --data '{"name":"Functions"}'`,
-      description: 'Invokes the hello function',
+      description: 'Invokes the hello-world function',
       jsx: () => {
         return (
           <>
             <span className="text-brand-1100">curl</span> -L -X POST 'https://{ref}
-            .functions.supabase.co/hello' -H 'Authorization: Bearer [YOUR ANON KEY]'{' '}
+            .functions.supabase.co/hello-world' -H 'Authorization: Bearer [YOUR ANON KEY]'{' '}
             {`--data '{"name":"Functions"}'`}
           </>
         )


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

In the current functions page the example is showing as `hello`:

<img width="566" alt="Screenshot 2022-04-09 at 14 55 05" src="https://user-images.githubusercontent.com/22655069/162577296-41305081-d878-4590-886f-44bfc6bf1c1b.png">

## What is the new behavior?

The command screen now shows `hello-world` like in the [docs](https://supabase.com/docs/guides/functions)
