### PR TITLE
docs: Changed the gap size

### DIFF
--- a/www/pages/edge-functions/edge-functions.tsx
+++ b/www/pages/edge-functions/edge-functions.tsx
@@ -159,7 +159,7 @@ function Database() {
 
         <SectionContainer>
           <div className="col-span-12 mb-10 space-y-12 lg:mb-0 lg:col-span-3 ">
-            <div className="grid lg:grid-cols-12 gap-6 lg:gap-32 items-center">
+            <div className="grid lg:grid-cols-12 gap-6 lg:gap-16 items-center">
               <div className="flex flex-col lg:col-span-5 gap-8">
                 <div>
                   <h3 className="h3">Anatomy of an Edge Function</h3>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Linked to this #6401.

## What is the new behavior?

The overflow is now gone and aligned:

<img width="1438" alt="Screenshot 2022-04-11 at 12 36 52" src="https://user-images.githubusercontent.com/22655069/162731676-2f6dc4f0-f807-48d8-8e6a-4d11a37cc782.png">
