### PR TITLE
Chore: careers page redirect

### DIFF
--- a/about/docs/careers.mdx
+++ b/about/docs/careers.mdx
@@ -4,8 +4,4 @@ title: Work at Supabase
 description: We're hiring. Start your career at Supabase.
 ---
 
-<script type="text/javascript">
-  window.location.replace("https://boards.greenhouse.io/supabase");
-</script>
-
 [Browse open roles](https://boards.greenhouse.io/supabase).

--- a/about/docs/careers.mdx
+++ b/about/docs/careers.mdx
@@ -4,4 +4,8 @@ title: Work at Supabase
 description: We're hiring. Start your career at Supabase.
 ---
 
+<script type="text/javascript">
+  window.location.replace("https://boards.greenhouse.io/supabase");
+</script>
+
 [Browse open roles](https://boards.greenhouse.io/supabase).

--- a/about/vercel.json
+++ b/about/vercel.json
@@ -1,0 +1,8 @@
+{
+  "redirects": [
+    {
+      "source": "/careers",
+      "destination": "https://boards.greenhouse.io/supabase"
+    }
+  ]
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Redirects careers page to https://boards.greenhouse.io/supabase.

## What is the current behavior?

Fix #6396

## What is the new behavior?

Redirects careers page to https://boards.greenhouse.io/supabase.