### PR TITLE
removed p tags not needed.

### DIFF
--- a/www/pages/auth/Auth.tsx
+++ b/www/pages/auth/Auth.tsx
@@ -100,7 +100,7 @@ function AuthPage() {
         <SectionContainer>
           <div className="grid grid-cols-12">
             <div className="mb-10 lg:mb-0 col-span-12 lg:col-span-3">
-              <p className="mb-4 -mt-[1.9rem]">
+              <div className="mb-4 -mt-[1.9rem]">
                 <div className="grid grid-rows-2 grid-flow-col gap-2 xl:w-64">
                   <div className="w-fit flex items-center">
                     <svg
@@ -130,7 +130,7 @@ function AuthPage() {
                     )
                   })}
                 </div>
-              </p>
+              </div>
               <h4 className="h4">All the social providers</h4>
               <p>
                 <span className="p text-base">
@@ -140,9 +140,9 @@ function AuthPage() {
               </p>
             </div>
             <div className="mb-10 lg:mb-0 col-span-12 lg:col-span-3 lg:col-start-5">
-              <p className="p mb-4">
+              <div className="p mb-4">
                 <IconLink />
-              </p>
+              </div>
               <h4 className="h4">Fully integrated</h4>
               <p className="p text-base">
                 Incredibly simple Auth, without a single external authentication service. Built-in
@@ -150,9 +150,9 @@ function AuthPage() {
               </p>
             </div>
             <div className="col-span-12 lg:col-span-3 lg:col-start-9">
-              <p className="p mb-4">
+              <div className="p mb-4">
                 <IconShield />
-              </p>
+              </div>
               <h4 className="h4">Own your data</h4>
               <p className="p text-base">
                 User data stored in your Supabase database so you never have to worry about 3rd

--- a/www/pages/auth/Auth.tsx
+++ b/www/pages/auth/Auth.tsx
@@ -132,11 +132,9 @@ function AuthPage() {
                 </div>
               </div>
               <h4 className="h4">All the social providers</h4>
-              <p>
-                <span className="p text-base">
-                  Enable social logins with the click of a button. Google, Facebook, GitHub, Azure,
-                  Gitlab, Twitter, Discord, and many more.
-                </span>
+              <p className="p text-base">
+                Enable social logins with the click of a button. Google, Facebook, GitHub, Azure,
+                Gitlab, Twitter, Discord, and many more.
               </p>
             </div>
             <div className="mb-10 lg:mb-0 col-span-12 lg:col-span-3 lg:col-start-5">

--- a/www/pages/auth/Auth.tsx
+++ b/www/pages/auth/Auth.tsx
@@ -132,9 +132,11 @@ function AuthPage() {
                 </div>
               </p>
               <h4 className="h4">All the social providers</h4>
-              <p className="p text-base">
-                Enable social logins with the click of a button. Google, Facebook, GitHub, Azure,
-                Gitlab, Twitter, Discord, and many more.
+              <p>
+                <span className="p text-base">
+                  Enable social logins with the click of a button. Google, Facebook, GitHub, Azure,
+                  Gitlab, Twitter, Discord, and many more.
+                </span>
               </p>
             </div>
             <div className="mb-10 lg:mb-0 col-span-12 lg:col-span-3 lg:col-start-5">


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update, related to issue #6331 

## What is the current behavior?

Noticed that on #6334 that the contrast on the `p` tag was not being picked up.

## What is the new behavior?

Added a `span` tag to the `p` tag and the contrast is now displaying correctly

Light Mode

<img width="722" alt="Screenshot 2022-04-12 at 14 18 51" src="https://user-images.githubusercontent.com/22655069/162971599-98c68f1e-8232-405e-9fb5-62e0102ecc3a.png">

Dark Mode

<img width="722" alt="Screenshot 2022-04-12 at 14 19 04" src="https://user-images.githubusercontent.com/22655069/162971631-86015045-6ad4-47ca-8192-99d8c5e237bd.png">

