### PR TITLE
feat: Self serve subscription and global spend cap

### DIFF
--- a/studio/components/interfaces/Billing/EnterpriseRequest.tsx
+++ b/studio/components/interfaces/Billing/EnterpriseRequest.tsx
@@ -7,6 +7,7 @@ import { post } from 'lib/common/fetch'
 import { useStore } from 'hooks'
 import { API_URL } from 'lib/constants'
 import { UpdateSuccess } from '.'
+import BackButton from 'components/ui/BackButton'
 
 interface Props {
   onSelectBack: () => void
@@ -21,7 +22,9 @@ const EnterpriseRequest: FC<Props> = ({ onSelectBack }) => {
   const [isSuccessful, setIsSuccessful] = useState(false)
 
   const initialValues = {
-    name: `${profile?.first_name} ${profile?.last_name}`,
+    name: `${profile?.first_name ? profile?.first_name : ''} ${
+      profile?.last_name ? profile.last_name : ''
+    }`,
     email: profile?.primary_email,
     company: '',
     message: '',
@@ -82,15 +85,11 @@ const EnterpriseRequest: FC<Props> = ({ onSelectBack }) => {
     >
       <div className="space-y-8 w-4/5">
         <div className="relative">
-          <div className="absolute top-[2px] -left-24">
-            <Button type="text" icon={<IconArrowLeft />} onClick={onSelectBack}>
-              Back
-            </Button>
-          </div>
+          <BackButton onClick={() => onSelectBack()} />
           <div className="space-y-1">
             <h4 className="text-lg">Customised plans tailored for your business needs</h4>
             <p className="text-scale-1100">
-              Let us know a few details and we’ll be in contact with you!
+              Let us know a few details and our team will get back to you as soon as possible.
             </p>
           </div>
           <Form

--- a/studio/components/interfaces/Billing/EnterpriseRequest.tsx
+++ b/studio/components/interfaces/Billing/EnterpriseRequest.tsx
@@ -84,39 +84,37 @@ const EnterpriseRequest: FC<Props> = ({ onSelectBack }) => {
       enterTo="transform opacity-100 translate-x-0"
     >
       <div className="space-y-8 w-4/5">
-        <div className="relative">
-          <BackButton onClick={() => onSelectBack()} />
-          <div className="space-y-1">
-            <h4 className="text-lg">Customised plans tailored for your business needs</h4>
-            <p className="text-scale-1100">
-              Let us know a few details and our team will get back to you as soon as possible.
-            </p>
-          </div>
-          <Form
-            validateOnBlur
-            initialValues={initialValues}
-            validate={onValidate}
-            onSubmit={onSubmit}
-          >
-            {({ isSubmitting }: { isSubmitting: boolean }) => (
-              <div className="space-y-12 py-16">
-                <div className="space-y-4 w-3/5">
-                  <Input layout="horizontal" label="Name" id="name" name="name" />
-                  <Input layout="horizontal" label="Email" id="email" name="email" />
-                  <Input layout="horizontal" label="Company" id="company" name="company" />
-                </div>
-                <Input.TextArea
-                  id="message"
-                  name="message"
-                  label="Let us know what you intend to use Supabase for"
-                />
-                <Button htmlType="submit" loading={isSubmitting}>
-                  Submit request
-                </Button>
-              </div>
-            )}
-          </Form>
+        <BackButton onClick={() => onSelectBack()} />
+        <div className="space-y-1">
+          <h4 className="text-lg">Customised plans tailored for your business needs</h4>
+          <p className="text-scale-1100">
+            Let us know a few details and our team will get back to you as soon as possible.
+          </p>
         </div>
+        <Form
+          validateOnBlur
+          initialValues={initialValues}
+          validate={onValidate}
+          onSubmit={onSubmit}
+        >
+          {({ isSubmitting }: { isSubmitting: boolean }) => (
+            <div className="space-y-12">
+              <div className="space-y-4 w-3/5">
+                <Input layout="horizontal" label="Name" id="name" name="name" />
+                <Input layout="horizontal" label="Email" id="email" name="email" />
+                <Input layout="horizontal" label="Company" id="company" name="company" />
+              </div>
+              <Input.TextArea
+                id="message"
+                name="message"
+                label="Let us know what you intend to use Supabase for"
+              />
+              <Button htmlType="submit" loading={isSubmitting}>
+                Submit request
+              </Button>
+            </div>
+          )}
+        </Form>
       </div>
     </Transition>
   )

--- a/studio/components/interfaces/Billing/PaymentSummaryPanel/PaymentTotal.tsx
+++ b/studio/components/interfaces/Billing/PaymentSummaryPanel/PaymentTotal.tsx
@@ -71,7 +71,7 @@ const PaymentTotal: FC<Props> = ({
                   {amountDueImmediately < 0 ? (
                     <p className="text-sm text-scale-1100">
                       A total of ${Math.abs(amountDueImmediately).toFixed(2)} will be returned on{' '}
-                      <span className="font-bold text-green-1100">
+                      <span className="text-brand-900">
                         {billingDate.toLocaleDateString('en-US', {
                           day: 'numeric',
                           month: 'long',
@@ -84,7 +84,7 @@ const PaymentTotal: FC<Props> = ({
                     <p className="text-sm text-scale-1100">
                       This amount {!isSpendCapEnabled && !isBillingToday && '+ usage fees '}will be
                       charged on{' '}
-                      <span className="font-bold text-green-1100">
+                      <span className="text-brand-900">
                         {billingDate.toLocaleDateString('en-US', {
                           day: 'numeric',
                           month: 'long',

--- a/studio/components/interfaces/Billing/PlanSelection/PlanSelection.tsx
+++ b/studio/components/interfaces/Billing/PlanSelection/PlanSelection.tsx
@@ -25,10 +25,15 @@ const PlanSelection: FC<Props> = ({ visible, tiers, currentPlan, onSelectPlan })
       <div className="space-y-8">
         <h4 className="text-lg">Change your project's subscription</h4>
         {/* FE will make a call to fetch all plans first at the page level */}
-        <Plans plans={formattedTiers} currentPlan={currentPlan} onSelectPlan={onSelectPlan} />
+        <div className="grid lg:grid-cols-3 gap-8 py-8">
+          <Plans plans={formattedTiers} currentPlan={currentPlan} onSelectPlan={onSelectPlan} />
+        </div>
         <div className="flex justify-center items-center">
           <Link href="https://supabase.com/pricing">
-            <a target="_blank" className="text-sm text-scale-1100 hover:text-scale-1200 transition">
+            <a
+              target="_blank"
+              className="text-sm underline text-scale-1100 hover:text-scale-1200 transition"
+            >
               See detailed comparisons across plans
             </a>
           </Link>

--- a/studio/components/interfaces/Billing/PlanSelection/Plans/PlanCTAButton.tsx
+++ b/studio/components/interfaces/Billing/PlanSelection/Plans/PlanCTAButton.tsx
@@ -59,7 +59,13 @@ const PlanCTAButton: FC<Props> = ({ plan, currentPlan, onSelectPlan }) => {
 
   return (
     <div className="flex items-center justify-center">
-      <Button disabled={disabled} type={type} onClick={() => onSelectPlan(plan)}>
+      <Button
+        disabled={disabled}
+        type={type}
+        onClick={() => onSelectPlan(plan)}
+        block
+        size="medium"
+      >
         {ctaText}
       </Button>
     </div>

--- a/studio/components/interfaces/Billing/PlanSelection/Plans/Plans.Constants.ts
+++ b/studio/components/interfaces/Billing/PlanSelection/Plans/Plans.Constants.ts
@@ -1,0 +1,71 @@
+import { STRIPE_PRODUCT_IDS } from 'lib/constants'
+
+/**
+ * @mildtomato same plan metadata is also in /www website
+ * would be good if this constant was shared across apps
+ *
+ * https://github.com/supabase/supabase/blob/master/studio/components/interfaces/Billing/PlanSelection/Plans/Plans.Constants.ts
+ */
+export const PRICING_META = {
+  [STRIPE_PRODUCT_IDS.FREE]: {
+    name: 'Free',
+    href: '#',
+    priceMonthly: 0,
+    warning: 'Limit of 2 free projects',
+    description: 'Perfect for passion projects & simple websites.',
+    features: [
+      'Up to 500MB database & 1GB file storage',
+      'Up to 2GB bandwidth',
+      'Up to 50MB file uploads',
+      'Social OAuth providers',
+      'Up to 500K Edge Function invocations',
+      '1-day log retention',
+      'Community support',
+    ],
+    additional: 'Free projects are paused after 1 week of inactivity.',
+
+    cta: 'Get Started',
+  },
+  [STRIPE_PRODUCT_IDS.PRO]: {
+    name: 'Pro',
+    href: '#',
+    from: true,
+    priceMonthly: 25,
+    warning: '+ additional use',
+    description: 'For production applications with the option to scale.',
+    features: [
+      '8GB database & 100GB file storage',
+      '50GB bandwith',
+      '3GB file uploads',
+      'Social OAuth providers',
+      '2M Edge Function invocations',
+      'Daily backups',
+      '7-day log retention',
+      'No project pausing',
+      'Email support',
+    ],
+    scale: 'Additional fees apply for usage and storage beyond the limits above.',
+    shutdown: '',
+    preface: 'Everything below included in the base plan',
+    additional: 'Need more? Turn off your spend cap to Pay As You Grow ',
+    cta: 'Get Started',
+  },
+  Enterprise: {
+    name: 'Enterprise',
+    href: '/contact/enterprise',
+    description: 'For large-scale applications managing serious workloads.',
+    features: [
+      `Point in time recovery`,
+      `Designated Support manager & SLAs`,
+      `Enterprise OAuth providers`,
+      `SSO/ SAML`,
+      `SOC2`,
+      `Custom contracts & invoicing`,
+      `On-premise support`,
+      `24×7×365 premium enterprise support`,
+    ],
+    scale: '',
+    shutdown: '',
+    cta: 'Contact Us',
+  },
+}

--- a/studio/components/interfaces/Billing/PlanSelection/Plans/Plans.tsx
+++ b/studio/components/interfaces/Billing/PlanSelection/Plans/Plans.tsx
@@ -1,9 +1,9 @@
-import { FC } from 'react'
-import { Badge } from '@supabase/ui'
-
+import { IconCheck } from '@supabase/ui'
 import { STRIPE_PRODUCT_IDS } from 'lib/constants'
+import { FC } from 'react'
 import { StripeProduct } from '../..'
 import PlanCTAButton from './PlanCTAButton'
+import { PRICING_META } from './Plans.Constants'
 
 interface Props {
   plans: any[]
@@ -23,17 +23,26 @@ const AnimatedGradientBackground = () => (
 const CurrentSubscriptionBanner = () => (
   <div
     className={[
-      'absolute top-0 right-0 flex items-center justify-center',
-      'bg-green-900 px-4 py-1 rounded-bl-md',
+      'absolute h-8 -top-7 left-0 w-full',
+      'flex items-center justify-center',
+      'bg-brand-400 text-brand-900',
+      'rounded-t-md border-t border-l border-r border border-b-0',
     ].join(' ')}
   >
     <p className="text-xs">Current plan</p>
   </div>
 )
 
+/**
+ * JSX below for the mapped plans is also very similar to www/pages/pricing
+ * TO DO: move to use shared components for these
+ *
+ * https://github.com/supabase/supabase/blob/master/www/pages/pricing/index.tsx
+ */
+
 const Plans: FC<Props> = ({ plans, currentPlan, onSelectPlan }) => {
   return (
-    <div className="flex justify-between space-x-4">
+    <>
       {plans.map((plan) => {
         const isCurrentPlan =
           plan.id === currentPlan?.prod_id ||
@@ -41,66 +50,122 @@ const Plans: FC<Props> = ({ plans, currentPlan, onSelectPlan }) => {
           (plan.id === STRIPE_PRODUCT_IDS.PRO && currentPlan?.prod_id === STRIPE_PRODUCT_IDS.PAYG)
 
         const pointers = plan.metadata.features.split('\\n').map((x: string) => x.trim())
+
+        console.log('STRIPE_PRODUCT_IDS', STRIPE_PRODUCT_IDS)
+        console.log('plans', plans)
+
+        // return null
+
         return (
           <div
-            key={plan.name}
-            className={[
-              'flex flex-col justify-between w-1/3 px-6 py-8',
-              'bg-gray-300 border border-gray-500 rounded-md relative',
-              'overflow-hidden',
-            ].join(' ')}
+            key={PRICING_META[plan.id].name}
+            className="
+            relative 
+                  "
           >
-            {/* [Joshen] Trying some animations here to make Pro pop, on the fence tbh */}
-            {plan.id === STRIPE_PRODUCT_IDS.PRO && <AnimatedGradientBackground />}
-
-            {/* Label to show current subscription (Pro and PAYG are treated as the same plan on the UI) */}
-            {isCurrentPlan && <CurrentSubscriptionBanner />}
-
-            <div className="mb-8">
-              <div className="flex items-center space-x-4">
-                <h3 className="text-xl">{plan.name}</h3>
-                {plan.isPopular && <Badge>Popular</Badge>}
-              </div>
-              <p className="text-scale-1100 text-sm mt-2">{plan.description}</p>
-              <div className="py-8">
-                {plan.prices.length === 0 ? (
-                  <p className="text-2xl text-center">Contact us</p>
-                ) : (
-                  <div className="flex items-end justify-center">
-                    <p className="text-3xl">${plan.prices[0].unit_amount / 100}</p>
-                    <p className="text-sm text-scale-1100 relative -top-[2px]"> /month</p>
-                  </div>
-                )}
-              </div>
-              <ul className="space-y-4">
-                {pointers.map((pointer: string, idx: number) => (
-                  <li key={`pointer-${idx}`} className="text-sm flex">
-                    <div className="w-[15%]">
-                      <svg
-                        className={`h-5 w-5 text-green-900`}
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewBox="0 0 20 20"
-                        fill="currentColor"
-                      >
-                        <path
-                          fillRule="evenodd"
-                          d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
-                          clipRule="evenodd"
-                        />
-                      </svg>
-                    </div>
-                    <div className="w-[85%]">
-                      <span>{pointer}</span>
-                    </div>
-                  </li>
-                ))}
-              </ul>
+            <div className="absolute overflow-hidden w-full h-full left-0 bottom-0 opacity-50">
+              {plan.id === STRIPE_PRODUCT_IDS.PRO && <AnimatedGradientBackground />}
             </div>
-            <PlanCTAButton plan={plan} currentPlan={currentPlan} onSelectPlan={onSelectPlan} />
+            <div className="flex flex-col rounded border overflow-hidden">
+              {isCurrentPlan && <CurrentSubscriptionBanner />}
+              <div className="h-64 px-8 pt-6 bg-white dark:bg-scale-300">
+                <span
+                  className="inline-flex text-cd font-normal tracking-wide rounded-full text-base text-scale-1200"
+                  id="tier-standard"
+                >
+                  {PRICING_META[plan.id].name}
+                </span>
+                <div className="flex items-baseline mt-2">
+                  <div className="flex flex-col">
+                    {PRICING_META[plan.id].priceMonthly !== undefined ? (
+                      <>
+                        <div className="flex items-end gap-1">
+                          {PRICING_META[plan.id].from && (
+                            <span className="text-base font-medium text-scale-900">From</span>
+                          )}
+                          <div>
+                            <span className="text-2xl">${PRICING_META[plan.id].priceMonthly}</span>
+                            <span className="ml-1 text-xl font-medium text-scale-900">/mo</span>
+                          </div>
+                        </div>
+                      </>
+                    ) : (
+                      <span className="text-2xl">Contact Us</span>
+                    )}
+                    <div className="flex h-8">
+                      {PRICING_META[plan.id].warning && (
+                        <div className="px-2 py-1 mt-2 text-xs rounded-md bg-brand-300 bg-opacity-30 text-brand-1000">
+                          {PRICING_META[plan.id].warning}
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                </div>
+                <div className="py-4">
+                  <PlanCTAButton
+                    plan={plan}
+                    currentPlan={currentPlan}
+                    onSelectPlan={onSelectPlan}
+                  />
+                </div>
+                <p className="text-sm text-scale-1100">{PRICING_META[plan.id].description}</p>
+              </div>
+              <div
+                className="
+                    flex-col justify-between flex-1
+                    
+                    space-y-6 
+                    border-t 
+                    dark:border-scale-400
+                    
+                    bg-scale-100 
+                    dark:bg-scale-300 
+
+                    px-8
+                    py-6
+
+                    h-full
+
+                    hidden
+                    lg:flex
+                  "
+              >
+                {PRICING_META[plan.id].preface && (
+                  <p className="text-sm text-scale-1200">{PRICING_META[plan.id].preface}</p>
+                )}
+                <ul role="list" className="divide-y dark:divide-scale-400">
+                  {PRICING_META[plan.id].features.map((feature) => (
+                    <li key={feature} className="flex items-center py-2">
+                      <IconCheck
+                        className="w-3 h-3 text-brand-900 "
+                        aria-hidden="true"
+                        strokeWidth={3}
+                      />
+                      <p className="mb-0 ml-3 text-xs text-scale-1100 dark:text-scale-1200">
+                        {feature}
+                      </p>
+                    </li>
+                  ))}
+                </ul>
+                <div className="flex flex-col gap-6">
+                  <div className="space-y-2">
+                    {PRICING_META[plan.id].additional && (
+                      <p className="text-sm text-scale-1200">{PRICING_META[plan.id].additional}</p>
+                    )}
+                    {PRICING_META[plan.id].scale && (
+                      <p className="text-xs text-scale-900">{PRICING_META[plan.id].scale}</p>
+                    )}
+                    {PRICING_META[plan.id].shutdown && (
+                      <p className="text-xs text-scale-900">{PRICING_META[plan.id].shutdown}</p>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
         )
       })}
-    </div>
+    </>
   )
 }
 

--- a/studio/components/interfaces/Billing/PlanSelection/Plans/Plans.tsx
+++ b/studio/components/interfaces/Billing/PlanSelection/Plans/Plans.tsx
@@ -49,26 +49,16 @@ const Plans: FC<Props> = ({ plans, currentPlan, onSelectPlan }) => {
           (plan.id === STRIPE_PRODUCT_IDS.PRO && currentPlan?.prod_id === STRIPE_PRODUCT_IDS.PRO) ||
           (plan.id === STRIPE_PRODUCT_IDS.PRO && currentPlan?.prod_id === STRIPE_PRODUCT_IDS.PAYG)
 
-        const pointers = plan.metadata.features.split('\\n').map((x: string) => x.trim())
-
-        console.log('STRIPE_PRODUCT_IDS', STRIPE_PRODUCT_IDS)
-        console.log('plans', plans)
-
-        // return null
-
         return (
-          <div
-            key={PRICING_META[plan.id].name}
-            className="
-            relative 
-                  "
-          >
-            <div className="absolute overflow-hidden w-full h-full left-0 bottom-0 opacity-50">
-              {plan.id === STRIPE_PRODUCT_IDS.PRO && <AnimatedGradientBackground />}
-            </div>
-            <div className="flex flex-col rounded border overflow-hidden">
+          <div key={PRICING_META[plan.id].name} className="relative h-full">
+            {plan.id === STRIPE_PRODUCT_IDS.PRO && (
+              <div className="absolute overflow-hidden w-full h-full left-0 bottom-0 opacity-50">
+                <AnimatedGradientBackground />
+              </div>
+            )}
+            <div className="flex flex-col rounded border overflow-hidden h-full">
               {isCurrentPlan && <CurrentSubscriptionBanner />}
-              <div className="h-64 px-8 pt-6 bg-white dark:bg-scale-300">
+              <div className="px-8 py-6 bg-white dark:bg-scale-300">
                 <span
                   className="inline-flex text-cd font-normal tracking-wide rounded-full text-base text-scale-1200"
                   id="tier-standard"
@@ -76,12 +66,12 @@ const Plans: FC<Props> = ({ plans, currentPlan, onSelectPlan }) => {
                   {PRICING_META[plan.id].name}
                 </span>
                 <div className="flex items-baseline mt-2">
-                  <div className="flex flex-col">
+                  <div className="flex space-x-2">
                     {PRICING_META[plan.id].priceMonthly !== undefined ? (
                       <>
                         <div className="flex items-end gap-1">
                           {PRICING_META[plan.id].from && (
-                            <span className="text-base font-medium text-scale-900">From</span>
+                            <span className="text-base font-medium text-scale-1200">From</span>
                           )}
                           <div>
                             <span className="text-2xl">${PRICING_META[plan.id].priceMonthly}</span>
@@ -111,24 +101,12 @@ const Plans: FC<Props> = ({ plans, currentPlan, onSelectPlan }) => {
                 <p className="text-sm text-scale-1100">{PRICING_META[plan.id].description}</p>
               </div>
               <div
-                className="
-                    flex-col justify-between flex-1
-                    
-                    space-y-6 
-                    border-t 
-                    dark:border-scale-400
-                    
-                    bg-scale-100 
-                    dark:bg-scale-300 
-
-                    px-8
-                    py-6
-
-                    h-full
-
-                    hidden
-                    lg:flex
-                  "
+                className={[
+                  'flex-col justify-between flex-1',
+                  'space-y-6 border-t dark:border-scale-400',
+                  'bg-scale-100 dark:bg-scale-300',
+                  'px-8 py-6 h-full hidden lg:flex',
+                ].join(' ')}
               >
                 {PRICING_META[plan.id].preface && (
                   <p className="text-sm text-scale-1200">{PRICING_META[plan.id].preface}</p>

--- a/studio/components/interfaces/Billing/ProUpgrade/ProUpgrade.tsx
+++ b/studio/components/interfaces/Billing/ProUpgrade/ProUpgrade.tsx
@@ -2,7 +2,7 @@ import { FC, useEffect, useState } from 'react'
 import { Transition } from '@headlessui/react'
 import { Badge, Button, IconArrowLeft, IconHelpCircle, Toggle, Modal } from '@supabase/ui'
 
-import { useStore } from 'hooks'
+import { useFlag, useStore } from 'hooks'
 import { post, patch } from 'lib/common/fetch'
 import { API_URL } from 'lib/constants'
 import { getURL } from 'lib/helpers'
@@ -18,6 +18,7 @@ import { SubscriptionPreview } from '../Billing.types'
 import UpdateSuccess from '../UpdateSuccess'
 import { formatComputeSizes } from '../AddOns/AddOns.utils'
 import { formSubscriptionUpdatePayload } from './ProUpgrade.utils'
+import BackButton from 'components/ui/BackButton'
 
 // Do not allow compute size changes for af-south-1
 
@@ -36,6 +37,11 @@ const ProUpgrade: FC<Props> = ({
   isLoadingPaymentMethods,
   onSelectBack,
 }) => {
+  /**
+   * Feature flags
+   */
+  const nativeBilling = useFlag('nativeBilling')
+
   const { ui } = useStore()
 
   const { addons } = products
@@ -151,39 +157,37 @@ const ProUpgrade: FC<Props> = ({
         className="w-full flex items-start justify-between"
       >
         <>
-          <div className="w-3/5 mt-10">
-            <div className="relative ml-64">
-              <div className="absolute top-[2px] -left-24">
-                <Button type="text" icon={<IconArrowLeft />} onClick={onSelectBack}>
-                  Back
-                </Button>
-              </div>
+          <div className="2xl:min-w-5xl mx-auto mt-10">
+            <div className="relative px-5 space-y-4">
+              <BackButton onClick={() => onSelectBack()} />
               <div className="space-y-8">
-                <h4 className="text-lg">Change your project's subscription</h4>
+                <h4 className="text-lg text-scale-900">Change your project's subscription</h4>
                 <div
-                  className="space-y-8 overflow-scroll pb-8 pr-20"
+                  className="space-y-8 overflow-scroll"
                   style={{ height: 'calc(100vh - 6.3rem - 49.5px)' }}
                 >
-                  {!isManagingProSubscription ? (
-                    <div className="space-y-1">
-                      <h3 className="text-xl">
-                        Welcome to <span className="text-green-1100">Pro</span>
-                        <p className="text-sm text-scale-1100">
+                  <div className="space-y-2">
+                    {!isManagingProSubscription ? (
+                      <>
+                        <h3 className="text-xl">
+                          Welcome to <span className="text-brand-900">Pro</span>
+                        </h3>
+                        <p className="text-base text-scale-1100">
                           Your new subscription will begin immediately after payment
                         </p>
-                      </h3>
-                    </div>
-                  ) : (
-                    <div className="space-y-1">
-                      <h3 className="text-xl">
-                        Managing your <span className="text-green-1100">Pro</span> plan
-                        <p className="text-sm text-scale-1100">
+                      </>
+                    ) : (
+                      <>
+                        <h3 className="text-3xl">
+                          Managing your <span className="text-brand-900">Pro</span> plan
+                        </h3>
+                        <p className="text-base text-scale-1100">
                           Your billing cycle will reset after payment
                         </p>
-                      </h3>
-                    </div>
-                  )}
-                  <div className="flex items-start justify-between">
+                      </>
+                    )}
+                  </div>
+                  <div className="flex items-center justify-between gap-16 border rounded px-6 py-4 bg-panel-body-light dark:bg-panel-body-dark drop-shadow-sm border-panel-border-light border-panel-border-dark">
                     <div>
                       <div className="flex items-center space-x-2">
                         <p>Enable spend cap</p>
@@ -195,7 +199,7 @@ const ProUpgrade: FC<Props> = ({
                         />
                       </div>
                       <p className="text-sm text-scale-1100">
-                        If disabled, additional resources will be charged on a per-usage basis
+                        If enabled, additional resources will not be charged on a per-usage basis
                       </p>
                     </div>
                     <Toggle
@@ -203,22 +207,27 @@ const ProUpgrade: FC<Props> = ({
                       onChange={() => setIsSpendCapEnabled(!isSpendCapEnabled)}
                     />
                   </div>
-                  {projectRegion !== 'af-south-1' && (
+                  {}
+                  {nativeBilling && (
                     <>
-                      <Divider light />
-                      <ComputeSizeSelection
-                        computeSizes={computeSizes || []}
-                        currentComputeSize={currentComputeSize}
-                        selectedComputeSize={selectedComputeSize}
-                        onSelectOption={onSelectComputeSizeOption}
-                      />
+                      {projectRegion !== 'af-south-1' && (
+                        <>
+                          <Divider light />
+                          <ComputeSizeSelection
+                            computeSizes={computeSizes || []}
+                            currentComputeSize={currentComputeSize}
+                            selectedComputeSize={selectedComputeSize}
+                            onSelectOption={onSelectComputeSizeOption}
+                          />
+                        </>
+                      )}
                     </>
                   )}
                 </div>
               </div>
             </div>
           </div>
-          <div className="w-2/5">
+          <div className="w-[32rem]">
             <PaymentSummaryPanel
               isRefreshingPreview={isRefreshingPreview}
               subscriptionPreview={subscriptionPreview}

--- a/studio/components/interfaces/Billing/Subscription/Subscription.tsx
+++ b/studio/components/interfaces/Billing/Subscription/Subscription.tsx
@@ -7,12 +7,11 @@ import { Dictionary } from '@supabase/grid'
 
 import { formatBytes } from 'lib/helpers'
 import { STRIPE_PRODUCT_IDS } from 'lib/constants'
-import { useStore, useFlag, useSubscriptionStats } from 'hooks'
+import { useStore, useSubscriptionStats } from 'hooks'
 import CostBreakdownRow from './CostBreakdownRow'
 import { StripeSubscription } from './Subscription.types'
 import { deriveFeatureCost, deriveProductCost } from '../PAYGUsage/PAYGUsage.utils'
 import { chargeableProducts } from '../PAYGUsage/PAYGUsage.constants'
-import UpgradeButton from './UpgradeButton'
 
 interface Props {
   project: any
@@ -80,13 +79,6 @@ const Subscription: FC<Props> = ({
                 </p>
               )}
             </div>
-            {/* ) : (
-              <UpgradeButton
-                paid={paid}
-                projectRef={project.ref}
-                subscriptionStats={subscriptionStats}
-              />
-            )} */}
           </div>
           {paid && (
             <div className="px-6 pt-4">

--- a/studio/components/interfaces/Billing/Subscription/Subscription.tsx
+++ b/studio/components/interfaces/Billing/Subscription/Subscription.tsx
@@ -37,7 +37,7 @@ const Subscription: FC<Props> = ({
   const { ui } = useStore()
   const isOrgOwner = ui.selectedOrganization?.is_owner
 
-  const nativeBilling = useFlag('nativeBilling')
+  // const nativeBilling = useFlag('nativeBilling')
   const subscriptionStats = useSubscriptionStats()
 
   const isPayg = subscription?.tier.prod_id === STRIPE_PRODUCT_IDS.PAYG
@@ -65,28 +65,28 @@ const Subscription: FC<Props> = ({
               </p>
               <h3 className="text-xl mb-0">{subscription?.tier.name ?? '-'}</h3>
             </div>
-            {nativeBilling ? (
-              <div className="flex flex-col items-end space-y-2">
-                <Button
-                  disabled={!isOrgOwner}
-                  onClick={() => router.push(`/project/${project.ref}/settings/billing/update`)}
-                  type="primary"
-                >
-                  Change subscription
-                </Button>
-                {!isOrgOwner && (
-                  <p className="text-sm text-scale-1100">
-                    Only the organization owner can amend subscriptions
-                  </p>
-                )}
-              </div>
-            ) : (
+            {/* {nativeBilling ? ( */}
+            <div className="flex flex-col items-end space-y-2">
+              <Button
+                disabled={!isOrgOwner}
+                onClick={() => router.push(`/project/${project.ref}/settings/billing/update`)}
+                type="primary"
+              >
+                Change subscription
+              </Button>
+              {!isOrgOwner && (
+                <p className="text-sm text-scale-1100">
+                  Only the organization owner can amend subscriptions
+                </p>
+              )}
+            </div>
+            {/* ) : (
               <UpgradeButton
                 paid={paid}
                 projectRef={project.ref}
                 subscriptionStats={subscriptionStats}
               />
-            )}
+            )} */}
           </div>
           {paid && (
             <div className="px-6 pt-4">

--- a/studio/components/interfaces/Billing/Subscription/UpgradeButton.tsx
+++ b/studio/components/interfaces/Billing/Subscription/UpgradeButton.tsx
@@ -11,7 +11,8 @@ import { CancellationReasons } from './SubcriptionCancellation.constants'
 
 /**
  * Generates a Stripe Billing Portal link for a project.
- * To be deprecate after native billing is completely rolled out
+ * This is now deprecated since 180422 since we have native billing
+ * Feel free to delete this file if we'd reckon we no longer need this fallback
  *
  * @param {Object}   props.projectRef        Project Ref
  * @param {Boolean}  props.paid              Tier name

--- a/studio/components/layouts/BillingLayout.tsx
+++ b/studio/components/layouts/BillingLayout.tsx
@@ -15,32 +15,34 @@ const BillingLayout: FC<Props> = ({ children }) => {
     <BaseLayout hideHeader hideIconBar>
       <div className="flex flex-col h-full w-full">
         {/* Header */}
-        <div className="px-3 py-2 border-b dark:border-dark flex items-center space-x-3">
-          <Link href={`/project/${ui.selectedProject?.ref}/settings/billing`}>
-            <a>
-              <Button type="text" size="tiny">
-                <IconX size={22} strokeWidth={1.5} />
-              </Button>
+        <div className="h-16 py-2 border-b dark:border-dark flex items-center space-x-3 px-5">
+          <Link href={`/project/${ui.selectedProject?.ref}/settings/billing`} passHref>
+            <a className="transition-colors text-scale-900 hover:text-scale-1200">
+              <IconX size={16} strokeWidth={1.5} />
             </a>
           </Link>
-          <div className="flex items-center space-x-2">
-            <p className="text-sm text-scale-1100">{ui.selectedOrganization?.name}</p>
-            <span className="text-scale-800">
-              <svg
-                viewBox="0 0 24 24"
-                width="16"
-                height="16"
-                stroke="currentColor"
-                strokeWidth="1.5"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                fill="none"
-                shapeRendering="geometricPrecision"
-              >
-                <path d="M16 3.549L7.12 20.600"></path>
-              </svg>
-            </span>
-            <p className="text-sm text-scale-1100">{ui.selectedProject?.name}</p>
+          <div className="flex items-center space-x-6">
+            <h1 className="text-base text-scale-1200">Customize your plan</h1>
+            <div className="h-6 w-px bg-scale-600"></div>
+            <div className="flex space-x-3 items-center">
+              <p className="text-sm text-scale-1100">{ui.selectedOrganization?.name}</p>
+              <span className="text-scale-800">
+                <svg
+                  viewBox="0 0 24 24"
+                  width="16"
+                  height="16"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  fill="none"
+                  shapeRendering="geometricPrecision"
+                >
+                  <path d="M16 3.549L7.12 20.600"></path>
+                </svg>
+              </span>
+              <p className="text-sm text-scale-1100">{ui.selectedProject?.name}</p>
+            </div>
           </div>
         </div>
         <div className="overflow-auto">

--- a/studio/components/layouts/BillingLayout.tsx
+++ b/studio/components/layouts/BillingLayout.tsx
@@ -15,7 +15,7 @@ const BillingLayout: FC<Props> = ({ children }) => {
     <BaseLayout hideHeader hideIconBar>
       <div className="flex flex-col h-full w-full">
         {/* Header */}
-        <div className="h-16 py-2 border-b dark:border-dark flex items-center space-x-3 px-5">
+        <div className="py-4 border-b dark:border-dark flex items-center space-x-3 px-5">
           <Link href={`/project/${ui.selectedProject?.ref}/settings/billing`} passHref>
             <a className="transition-colors text-scale-900 hover:text-scale-1200">
               <IconX size={16} strokeWidth={1.5} />

--- a/studio/components/ui/BackButton.tsx
+++ b/studio/components/ui/BackButton.tsx
@@ -1,0 +1,13 @@
+import { Button, IconArrowLeft } from '@supabase/ui'
+
+export function BackButton({ onClick }: { onClick: () => void }) {
+  return (
+    <div className="2xl:absolute 2xl:top-[2px] -ml-2 2xl:-left-24">
+      <Button type="text" icon={<IconArrowLeft />} onClick={onClick}>
+        Back
+      </Button>
+    </div>
+  )
+}
+
+export default BackButton

--- a/studio/lib/constants/infrastructure.ts
+++ b/studio/lib/constants/infrastructure.ts
@@ -105,10 +105,10 @@ export const PROJECT_STATUS = {
   RESTORING: 'RESTORING',
 }
 
-export const STRIPE_PRODUCT_IDS = {
-  FREE: process?.env?.NEXT_PUBLIC_STRIPE_FREE_TIER_ID,
-  PRO: process?.env?.NEXT_PUBLIC_STRIPE_PRO_TIER_ID,
-  PAYG: process?.env?.NEXT_PUBLIC_STRIPE_PAYG_TIER_ID,
+export const STRIPE_PRODUCT_IDS: { [x: string]: string } = {
+  FREE: process?.env?.NEXT_PUBLIC_STRIPE_FREE_TIER_ID || 'prod_Ip4vqwv3EJ7Mi0',
+  PRO: process?.env?.NEXT_PUBLIC_STRIPE_PRO_TIER_ID || 'prod_IsRLOp58Z7V4XN',
+  PAYG: process?.env?.NEXT_PUBLIC_STRIPE_PAYG_TIER_ID || 'prod_JlTbw91xcM6NY4',
 }
 
 export const DEFAULT_MINIMUM_PASSWORD_STRENGTH = 4

--- a/studio/pages/project/[ref]/settings/billing/update/index.tsx
+++ b/studio/pages/project/[ref]/settings/billing/update/index.tsx
@@ -106,7 +106,7 @@ const BillingUpdate: NextPage = () => {
 
   return (
     <BillingLayout>
-      <div className="mx-auto max-w-5xl my-10">
+      <div className="mx-auto max-w-6xl my-10 px-6">
         <PlanSelection
           visible={!selectedPlan || (selectedPlan && showConfirmDowngrade)}
           tiers={products?.tiers ?? []}

--- a/www/pages/pricing/index.tsx
+++ b/www/pages/pricing/index.tsx
@@ -21,6 +21,12 @@ export default function IndexPage() {
   const meta_description =
     'Explore Supabase fees and pricing information. Find our competitive pricing tiers, with no hidden pricing. We have generous free tiers for those getting started, and Pay As You Go for those scaling up.'
 
+  /**
+   * @mildtomato same plan metadata is also in /studio dashboard
+   * would be good if this constant was shared across apps
+   *
+   * https://github.com/supabase/supabase/blob/master/www/pages/pricing/index.tsx
+   */
   const tiers = [
     {
       name: 'Free',


### PR DESCRIPTION
chore: feature flagged compute size selection upgrade/downgrade

also:
• update billing pages with new plan details.
• tidying up of smaller screen size responsiveness
• fixed issue with undefined name in enterprise contact form

updated screens:
selection screen:
<img width="2127" alt="Screenshot 2022-04-13 at 2 30 49 PM" src="https://user-images.githubusercontent.com/8291514/163114168-20a40284-d415-468c-954c-6aa2a15c290d.png">
upgrade screen:
<img width="2127" alt="Screenshot 2022-04-13 at 2 31 07 PM" src="https://user-images.githubusercontent.com/8291514/163114205-7b25685f-896b-4dc3-bee1-dade36b09a0d.png">

