### PR TITLE
fix/logs: correct selection expansion on long content

### DIFF
--- a/studio/components/interfaces/Settings/Logs/LogSelectionRenderers/DatabaseApiSelectionRender.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogSelectionRenderers/DatabaseApiSelectionRender.tsx
@@ -16,8 +16,8 @@ const DatabaseApiSelectionRender = ({ log }: any) => {
   const DetailedRow = ({ label, value }: { label: string; value: string | React.ReactNode }) => {
     return (
       <div className="grid grid-cols-12">
-        <span className="text-scale-900 text-sm col-span-4">{label}</span>
-        <span className="text-scale-1200 text-base col-span-8">{value}</span>
+        <span className="text-scale-900 text-sm col-span-4 whitespace-pre-wrap">{label}</span>
+        <span className="text-scale-1200 text-base col-span-8 whitespace-pre-wrap">{value}</span>
       </div>
     )
   }

--- a/studio/components/interfaces/Settings/Logs/LogSelectionRenderers/DatabasePostgresSelectionRender.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogSelectionRenderers/DatabasePostgresSelectionRender.tsx
@@ -12,8 +12,8 @@ const DatabasePostgresSelectionRender = ({ log }: any) => {
   const DetailedRow = ({ label, value }: { label: string; value: string | React.ReactNode }) => {
     return (
       <div className="grid grid-cols-12">
-        <span className="text-scale-900 text-sm col-span-4">{label}</span>
-        <span className="text-scale-1200 text-base col-span-8">{value}</span>
+        <p className="text-scale-900 text-sm col-span-4 whitespace-pre-wrap">{label}</p>
+        <p className="text-scale-1200 text-base col-span-8 whitespace-pre-wrap">{value}</p>
       </div>
     )
   }
@@ -23,12 +23,9 @@ const DatabasePostgresSelectionRender = ({ log }: any) => {
       <div className={LOGS_TAILWIND_CLASSES.log_selection_x_padding}>
         <span className="text-scale-900 text-sm col-span-4">Event message</span>
 
-        <div
-          className="text-xs text-wrap font-mono text-scale-1200 mt-2"
-          dangerouslySetInnerHTML={{
-            __html: log.event_message,
-          }}
-        />
+        <div className="text-xs text-wrap font-mono text-scale-1200 mt-2  whitespace-pre-wrap overflow-x-auto">
+          {log.event_message}
+        </div>
       </div>
       <LogsDivider />
       <div className={`${LOGS_TAILWIND_CLASSES.log_selection_x_padding} space-y-2`}>

--- a/studio/components/interfaces/Settings/Logs/LogSelectionRenderers/DefaultSelectionRenderer.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogSelectionRenderers/DefaultSelectionRenderer.tsx
@@ -13,8 +13,8 @@ const DefaultSelectionRenderer = ({ log }: any) => {
   }) => {
     return (
       <div className="grid grid-cols-12">
-        <span className="text-scale-900 text-sm col-span-4">{label}</span>
-        <span className={`text-scale-1200 text-sm col-span-8 ${code && 'text-xs font-mono'}`}>
+        <span className="text-scale-900 text-sm col-span-4 whitespace-prep-wrap">{label}</span>
+        <span className={`text-scale-1200 text-sm col-span-8 whitespace-prep-wrap ${code && 'text-xs font-mono'}`}>
           {value}
         </span>
       </div>
@@ -33,7 +33,11 @@ const DefaultSelectionRenderer = ({ log }: any) => {
     return (
       <div className="grid grid-cols-12">
         <span className="text-scale-900 text-sm col-span-4">{label}</span>
-        <span className={`text-scale-1200 text-sm col-span-8 ${code && 'text-xs font-mono'}`}>
+        <span
+          className={`text-scale-1200 text-sm col-span-8 overflow-x-auto ${
+            code && 'text-xs font-mono'
+          }`}
+        >
           <pre
             dangerouslySetInnerHTML={{
               __html: jsonSyntaxHighlight(value),
@@ -48,7 +52,10 @@ const DefaultSelectionRenderer = ({ log }: any) => {
     <div className="overflow-hidden overflow-x-auto space-y-6">
       {Object.entries(log).map(([key, value], index) => {
         return (
-          <div key={`${key}-${index}`} className={`${LOGS_TAILWIND_CLASSES.log_selection_x_padding}`}>
+          <div
+            key={`${key}-${index}`}
+            className={`${LOGS_TAILWIND_CLASSES.log_selection_x_padding}`}
+          >
             {value && typeof value === 'object' ? (
               <DetailedJsonRow label={key} value={value} />
             ) : (

--- a/studio/components/interfaces/Settings/Logs/LogSelectionRenderers/FunctionInvocationSelectionRender.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogSelectionRenderers/FunctionInvocationSelectionRender.tsx
@@ -23,8 +23,8 @@ const FunctionInvocationSelectionRender = ({ log }: any) => {
   }) => {
     return (
       <div className="grid grid-cols-12">
-        <span className="text-scale-900 text-sm col-span-4">{label}</span>
-        <span className={`text-scale-1200 text-sm col-span-8 ${code && 'text-xs font-mono'}`}>
+        <span className="text-scale-900 text-sm col-span-4 whitespace-pre-wrap">{label}</span>
+        <span className={`text-scale-1200 text-sm col-span-8 whitespace-pre-wrap ${code && 'text-xs font-mono'}`}>
           {value}
         </span>
       </div>

--- a/studio/components/interfaces/Settings/Logs/LogSelectionRenderers/FunctionLogsSelectionRender.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogSelectionRenderers/FunctionLogsSelectionRender.tsx
@@ -16,8 +16,12 @@ const FunctionLogsSelectionRender = ({ log }: any) => {
   }) => {
     return (
       <div className="grid grid-cols-12">
-        <span className="text-scale-900 text-sm col-span-4">{label}</span>
-        <span className={`text-scale-1200 text-sm col-span-8 ${code && 'text-xs font-mono'}`}>
+        <span className="text-scale-900 text-sm col-span-4 whitespace-pre-wrap">{label}</span>
+        <span
+          className={`text-scale-1200 text-sm col-span-8 whitespace-pre-wrap ${
+            code && 'text-xs font-mono'
+          }`}
+        >
           {value}
         </span>
       </div>
@@ -28,12 +32,9 @@ const FunctionLogsSelectionRender = ({ log }: any) => {
     <>
       <div className={`${LOGS_TAILWIND_CLASSES.log_selection_x_padding}`}>
         <span className="text-scale-900 text-sm col-span-4">Event message</span>
-        <div
-          className="text-xs text-wrap font-mono text-scale-1200 mt-2"
-          dangerouslySetInnerHTML={{
-            __html: log.event_message,
-          }}
-        />
+        <div className="text-xs text-wrap font-mono text-scale-1200 mt-2 whitespace-pre-wrap overflow-x-auto">
+          {log.event_message}
+        </div>
       </div>
       <div className="h-px w-full bg-panel-border-interior-light dark:bg-panel-border-interior-dark"></div>
       <div className={`${LOGS_TAILWIND_CLASSES.log_selection_x_padding} space-y-2`}>

--- a/studio/components/interfaces/Settings/Logs/LogTable.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogTable.tsx
@@ -204,23 +204,20 @@ const LogTable = ({
   return (
     <>
       <section
-        className={'flex flex-1 flex-col  ' + (!queryType ? 'shadow-lg' : '')}
+        className={'flex flex-col w-full ' + (!queryType ? 'shadow-lg' : '')}
         style={{ maxHeight }}
       >
         {!queryType && (
           <div>
             <div
               className="
-        w-full bg-scale-100 dark:bg-scale-300 
-
-       rounded-tl rounded-tr
-       border-t
-       border-l
-       border-r
-
-
-        flex items-center justify-between
-        px-5 py-2
+            w-full bg-scale-100 dark:bg-scale-300 
+            rounded-tl rounded-tr
+            border-t
+            border-l
+            border-r
+            flex items-center justify-between
+            px-5 py-2
       "
             >
               <div className="flex items-center gap-2">
@@ -249,7 +246,7 @@ const LogTable = ({
           </div>
         )}
         <div
-          className={'flex flex-row flex-grow h-full ' + (!queryType ? 'border-l border-r' : '')}
+          className={'flex flex-row h-full ' + (!queryType ? 'border-l border-r' : '')}
         >
           <DataGrid
             style={{ height: '100%' }}


### PR DESCRIPTION
Fixes bug where selection width increases on long event messages.

Also added whitespace preservation for event messages to make content easier to read.

<img width="1252" alt="image" src="https://user-images.githubusercontent.com/22714384/163157853-e9a470f1-190f-4e81-abf5-1efada06427a.png">
