### PR TITLE
fix/docs: Fixed links to edge functions

### DIFF
--- a/web/docs/guides/database/functions.mdx
+++ b/web/docs/guides/database/functions.mdx
@@ -294,7 +294,7 @@ final res = await supabase
 For data-intensive operations we recommend using [Database Functions](/docs/guides/database/functions), which are executed within your database
 and can be called remotely using the [REST and GraphQL API](/docs/guides/database/api).
 
-For use-cases which require low-latency we recommend [Edge Functions](/docs/guides/database/functions), which are globally-distributed and can be written in Typescript.
+For use-cases which require low-latency we recommend [Edge Functions](/docs/guides/functions), which are globally-distributed and can be written in Typescript.
 
 ### Security `definer` vs `invoker`
 

--- a/web/docs/guides/functions.mdx
+++ b/web/docs/guides/functions.mdx
@@ -258,7 +258,7 @@ You can find a list of useful [Edge Function Examples](https://github.com/supaba
 For data-intensive operations we recommend using [Database Functions](/docs/guides/database/functions), which are executed within your database
 and can be called remotely using the [REST and GraphQL API](/docs/guides/database/api).
 
-For use-cases which require low-latency we recommend [Edge Functions](/docs/guides/database/functions), which are globally-distributed and can be written in Typescript.
+For use-cases which require low-latency we recommend [Edge Functions](/docs/guides/functions), which are globally-distributed and can be written in Typescript.
 
 
 ### Organizing your Edge Functions


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes a wrong link in the docs

## What is the current behavior?

Links points to the database functions

## What is the new behavior?
Links point to the correct edge functions