### PR TITLE
fix/logs: Add datepicker to logs explorer, ux fixes

### DIFF
--- a/studio/components/interfaces/Settings/Logs/Logs.DatePickers.tsx
+++ b/studio/components/interfaces/Settings/Logs/Logs.DatePickers.tsx
@@ -13,7 +13,6 @@ interface Props {
 const DatePickers: React.FC<Props> = ({ to, from, onChange, helpers }) => {
   const defaultHelper = getDefaultHelper(helpers)
   const [helperValue, setHelperValue] = useState<string>(to || from ? '' : defaultHelper.text)
-  // const selectedHelper = helpers.find((h) => h.text === helperValue)
   const handleHelperChange = (newValue: string) => {
     setHelperValue(newValue)
     const selectedHelper = helpers.find((h) => h.text === newValue)

--- a/studio/components/interfaces/Settings/Logs/Logs.DatePickers.tsx
+++ b/studio/components/interfaces/Settings/Logs/Logs.DatePickers.tsx
@@ -1,13 +1,13 @@
-import { Button, Dropdown, IconClock } from '@supabase/ui'
+import { Alert, Button, Dropdown, IconClock } from '@supabase/ui'
 import { DatePicker } from 'components/ui/DatePicker'
+import dayjs from 'dayjs'
 import { useEffect, useState } from 'react'
 import { DatetimeHelper, getDefaultHelper } from '.'
 
-type ToFrom = { to: string; from: string }
 interface Props {
   to: string
   from: string
-  onChange: ({ to, from }: ToFrom) => void
+  onChange: React.ComponentProps<typeof DatePicker>["onChange"]
   helpers: DatetimeHelper[]
 }
 const DatePickers: React.FC<Props> = ({ to, from, onChange, helpers }) => {
@@ -67,12 +67,21 @@ const DatePickers: React.FC<Props> = ({ to, from, onChange, helpers }) => {
       <DatePicker
         triggerButtonClassName="rounded-l-none"
         triggerButtonType={selectedHelper ? 'default' : 'secondary'}
-        onChange={(value: ToFrom) => {
+        onChange={(value) => {
           setHelperValue('')
           if (onChange) onChange(value)
         }}
         to={!helperValue ? to : undefined}
         from={!helperValue ? from : undefined}
+        renderFooter={({ to, from }) => {
+          if (to && from && Math.abs(dayjs(from).diff(dayjs(to), 'day')) > 50) {
+            return (
+              <Alert title="Large date range detected" variant="warning" className="mx-3 pl-2 pr-2 pt-2 pb-2">
+                Large ranges may result in memory errors for big projects.
+              </Alert>
+            )
+          }
+        }}
       />
     </div>
   )

--- a/studio/components/interfaces/Settings/Logs/Logs.DatePickers.tsx
+++ b/studio/components/interfaces/Settings/Logs/Logs.DatePickers.tsx
@@ -2,7 +2,7 @@ import { Alert, Button, Dropdown, IconClock } from '@supabase/ui'
 import { DatePicker } from 'components/ui/DatePicker'
 import dayjs from 'dayjs'
 import { useEffect, useState } from 'react'
-import { DatetimeHelper, getDefaultHelper } from '.'
+import { DatetimeHelper, getDefaultHelper, LOGS_LARGE_DATE_RANGE_DAYS_THRESHOLD } from '.'
 
 interface Props {
   to: string
@@ -73,7 +73,7 @@ const DatePickers: React.FC<Props> = ({ to, from, onChange, helpers }) => {
         to={!helperValue ? to : undefined}
         from={!helperValue ? from : undefined}
         renderFooter={({ to, from }) => {
-          if (to && from && Math.abs(dayjs(from).diff(dayjs(to), 'day')) > 4) {
+          if (to && from && Math.abs(dayjs(from).diff(dayjs(to), 'day')) > LOGS_LARGE_DATE_RANGE_DAYS_THRESHOLD) {
             return (
               <Alert title={""} variant="warning" className="mx-3 pl-2 pr-2 pt-1 pb-2">
                 Large ranges may result in memory errors for big projects.

--- a/studio/components/interfaces/Settings/Logs/Logs.DatePickers.tsx
+++ b/studio/components/interfaces/Settings/Logs/Logs.DatePickers.tsx
@@ -74,9 +74,9 @@ const DatePickers: React.FC<Props> = ({ to, from, onChange, helpers }) => {
         to={!helperValue ? to : undefined}
         from={!helperValue ? from : undefined}
         renderFooter={({ to, from }) => {
-          if (to && from && Math.abs(dayjs(from).diff(dayjs(to), 'day')) > 50) {
+          if (to && from && Math.abs(dayjs(from).diff(dayjs(to), 'day')) > 4) {
             return (
-              <Alert title="Large date range detected" variant="warning" className="mx-3 pl-2 pr-2 pt-2 pb-2">
+              <Alert title={""} variant="warning" className="mx-3 pl-2 pr-2 pt-1 pb-2">
                 Large ranges may result in memory errors for big projects.
               </Alert>
             )

--- a/studio/components/interfaces/Settings/Logs/Logs.constants.ts
+++ b/studio/components/interfaces/Settings/Logs/Logs.constants.ts
@@ -1,4 +1,5 @@
-import { FilterTableSet, LogTemplate } from '.'
+import dayjs from 'dayjs'
+import { DatetimeHelper, FilterTableSet, LogTemplate } from '.'
 
 export const TEMPLATES: LogTemplate[] = [
   {
@@ -185,10 +186,8 @@ export const LOG_TYPE_LABEL_MAPPING: { [k: string]: string } = {
   database: 'Database',
 }
 
-
-
 const _SQL_FILTER_COMMON = {
-  'search_query': (value: string) => `regexp_contains(event_message, '${value}')`
+  search_query: (value: string) => `regexp_contains(event_message, '${value}')`,
 }
 
 export const SQL_FILTER_TEMPLATES: any = {
@@ -424,3 +423,43 @@ export const LOGS_TAILWIND_CLASSES = {
   log_selection_x_padding: 'px-8',
   space_y: 'px-6',
 }
+
+export const PREVIEWER_DATEPICKER_HELPERS: DatetimeHelper[] = [
+  {
+    text: 'Last hour',
+    calcFrom: () => dayjs().subtract(1, 'hour').startOf('hour').toISOString(),
+    calcTo: () => '',
+  },
+  {
+    text: 'Last 3 hours',
+    calcFrom: () => dayjs().subtract(3, 'hour').startOf('hour').toISOString(),
+    calcTo: () => '',
+  },
+  {
+    text: 'Last day',
+    calcFrom: () => dayjs().subtract(1, 'day').startOf('day').toISOString(),
+    calcTo: () => '',
+    default: true,
+  },
+]
+export const EXPLORER_DATEPICKER_HELPERS: DatetimeHelper[] = [
+  {
+    text: 'Last day',
+    calcFrom: () => dayjs().subtract(1, 'day').startOf('day').toISOString(),
+    calcTo: () => '',
+    default: true,
+  },
+  {
+    text: 'Last 3 days',
+    calcFrom: () => dayjs().subtract(3, 'day').startOf('day').toISOString(),
+    calcTo: () => '',
+  },
+  {
+    text: 'Last 7 days',
+    calcFrom: () => dayjs().subtract(7, 'day').startOf('day').toISOString(),
+    calcTo: () => '',
+  },
+]
+
+export const getDefaultHelper = (helpers: DatetimeHelper[]) =>
+  helpers.find((helper) => helper.default) || helpers[0]

--- a/studio/components/interfaces/Settings/Logs/Logs.constants.ts
+++ b/studio/components/interfaces/Settings/Logs/Logs.constants.ts
@@ -1,6 +1,8 @@
 import dayjs from 'dayjs'
 import { DatetimeHelper, FilterTableSet, LogTemplate } from '.'
 
+export const LOGS_LARGE_DATE_RANGE_DAYS_THRESHOLD = 4
+
 export const TEMPLATES: LogTemplate[] = [
   {
     label: 'Recent Errors',

--- a/studio/components/interfaces/Settings/Logs/Logs.types.ts
+++ b/studio/components/interfaces/Settings/Logs/Logs.types.ts
@@ -1,17 +1,25 @@
 interface Metadata {
   [key: string]: string | number | Object | Object[]
 }
-export type LogSearchCallback = (filters: { query: string; to?: string; from?: string; fromMicro?: number, toMicro?: number }) => void
+export type LogSearchCallback = (filters: {
+  query: string
+  to?: string
+  from?: string
+  fromMicro?: number
+  toMicro?: number
+}) => void
 
 export interface LogsEndpointParams {
   // project ref
   project: string
-  // micro unix timestamp
+  // depreacted, micro unix timestamp
   timestamp_start?: string
-  // micro timestamp
   timestamp_end?: string
+  // deprecated, iso timestamps
   period_start?: string
   period_end?: string
+  iso_timestamp_start?: string
+  iso_timestamp_end?: string
   sql: string
   rawSql: string
 }
@@ -64,7 +72,6 @@ export interface FilterObject {
   // `te` for timestamp start value.
   te?: string
 }
-
 
 export interface FilterSet {
   label: string

--- a/studio/components/interfaces/Settings/Logs/Logs.types.ts
+++ b/studio/components/interfaces/Settings/Logs/Logs.types.ts
@@ -12,16 +12,10 @@ export type LogSearchCallback = (filters: {
 export interface LogsEndpointParams {
   // project ref
   project: string
-  // depreacted, micro unix timestamp
-  timestamp_start?: string
-  timestamp_end?: string
-  // deprecated, iso timestamps
-  period_start?: string
-  period_end?: string
   iso_timestamp_start?: string
   iso_timestamp_end?: string
-  sql: string
-  rawSql: string
+  sql?: string
+  rawSql?: string
 }
 
 export interface LogData {
@@ -97,4 +91,11 @@ export interface Filters {
 export type Override = {
   key: string
   value: string | string[] | undefined
+}
+
+export interface DatetimeHelper {
+  text: string
+  calcTo: () => string
+  calcFrom: () => string
+  default?: boolean
 }

--- a/studio/components/interfaces/Settings/Logs/Logs.types.ts
+++ b/studio/components/interfaces/Settings/Logs/Logs.types.ts
@@ -1,3 +1,5 @@
+import React from "react"
+
 interface Metadata {
   [key: string]: string | number | Object | Object[]
 }
@@ -10,6 +12,11 @@ export type LogSearchCallback = (
   } & DatePickerToFrom
 ) => void
 
+export interface LogsWarning {
+  text: string | React.ReactNode
+  link?: string
+  linkText?: string
+}
 export interface LogsEndpointParams {
   // project ref
   project: string

--- a/studio/components/interfaces/Settings/Logs/Logs.types.ts
+++ b/studio/components/interfaces/Settings/Logs/Logs.types.ts
@@ -1,13 +1,14 @@
 interface Metadata {
   [key: string]: string | number | Object | Object[]
 }
-export type LogSearchCallback = (filters: {
-  query: string
-  to?: string
-  from?: string
-  fromMicro?: number
-  toMicro?: number
-}) => void
+
+export type DatePickerToFrom = { to: string | null; from: string | null }
+
+export type LogSearchCallback = (
+  filters: {
+    query: string
+  } & DatePickerToFrom
+) => void
 
 export interface LogsEndpointParams {
   // project ref

--- a/studio/components/interfaces/Settings/Logs/Logs.utils.ts
+++ b/studio/components/interfaces/Settings/Logs/Logs.utils.ts
@@ -1,5 +1,13 @@
-import { get } from 'lodash'
 import { Filters, LogsTableName, SQL_FILTER_TEMPLATES } from '.'
+import dayjs from 'dayjs'
+import { get } from 'lodash'
+
+/**
+ * Convert a micro timestamp from number/string to iso timestamp
+ */
+export const unixMicroToIsoTimestamp = (unix: string | number): string => {
+  return dayjs.unix(Number(unix) / 1000).toISOString()
+}
 
 /**
  * Recursively retrieve all nested object key paths.

--- a/studio/components/interfaces/Settings/Logs/LogsPreviewer.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogsPreviewer.tsx
@@ -83,8 +83,8 @@ export const LogsPreviewer: React.FC<Props> = ({
     })
   }
 
-  const handleSearch: LogSearchCallback = async ({ query = '', to = '', from = '' }) => {
-    setParams((prev) => ({ ...prev, iso_timestamp_start: from, iso_timestamp_end: to }))
+  const handleSearch: LogSearchCallback = async ({ query = '', to, from }) => {
+    setParams((prev) => ({ ...prev, iso_timestamp_start: from || '', iso_timestamp_end: to || '' }))
     setFilters((prev) => ({ ...prev, search_query: query }))
     router.push({
       pathname: router.pathname,
@@ -141,7 +141,7 @@ export const LogsPreviewer: React.FC<Props> = ({
               data={!isLoading ? logData : undefined}
               onBarClick={(timestampMicro) => {
                 const to = unixMicroToIsoTimestamp(timestampMicro)
-                handleSearch({ query: filters.search_query as string, to })
+                handleSearch({ query: filters.search_query as string, to, from: null })
               }}
             />
           )}

--- a/studio/components/interfaces/Settings/Logs/LogsPreviewer.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogsPreviewer.tsx
@@ -84,15 +84,19 @@ export const LogsPreviewer: React.FC<Props> = ({
   }
 
   const handleSearch: LogSearchCallback = async ({ query = '', to, from }) => {
-    setParams((prev) => ({ ...prev, iso_timestamp_start: from || '', iso_timestamp_end: to || '' }))
+    setParams((prev) => ({
+      ...prev,
+      iso_timestamp_start: from || prev.iso_timestamp_start || '',
+      iso_timestamp_end: to || prev.iso_timestamp_end || '',
+    }))
     setFilters((prev) => ({ ...prev, search_query: query }))
     router.push({
       pathname: router.pathname,
       query: {
         ...router.query,
         s: query || '',
-        its: from,
-        ite: to,
+        its: from || its || '',
+        ite: to || ite || '',
       },
     })
   }

--- a/studio/components/interfaces/Settings/Logs/LogsPreviewer.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogsPreviewer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useReducer, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { useRouter } from 'next/router'
 import { Typography, IconAlertCircle, IconRewind, Button, Card, Input } from '@supabase/ui'
 
@@ -10,15 +10,13 @@ import {
   LogsTableName,
   QueryType,
   LogEventChart,
-  FilterObject,
   Filters,
+  unixMicroToIsoTimestamp,
 } from 'components/interfaces/Settings/Logs'
-import dayjs from 'dayjs'
 import useLogsPreview from 'hooks/analytics/useLogsPreview'
 import PreviewFilterPanel from 'components/interfaces/Settings/Logs/PreviewFilterPanel'
 
 import { LOGS_TABLES } from './Logs.constants'
-import { Override } from './Logs.types'
 import ShimmerLine from 'components/ui/ShimmerLine'
 import LoadingOpacity from 'components/ui/LoadingOpacity'
 
@@ -47,29 +45,26 @@ export const LogsPreviewer: React.FC<Props> = ({
   tableName,
 }) => {
   const router = useRouter()
-  const { s, te, ts } = router.query
+  const { s, ite, its } = router.query
   const [showChart, setShowChart] = useState(true)
 
   const table = !tableName ? LOGS_TABLES[queryType] : tableName
 
   const [
-    { error, logData, params, newCount, filters, isLoading, oldestTimestamp },
-    { loadOlder, setFilters, refresh, setTo, setFrom },
+    { error, logData, params, newCount, filters, isLoading },
+    { loadOlder, setFilters, refresh, setParams },
   ] = useLogsPreview(projectRef as string, table, filterOverride)
 
   useEffect(() => {
     setFilters((prev) => ({ ...prev, search_query: s as string }))
-    if (te) {
-      setTo(te as string)
-    } else {
-      setTo('')
+    if (ite || its) {
+      setParams((prev) => ({
+        ...prev,
+        iso_timestamp_start: (its || '') as string,
+        iso_timestamp_end: (ite || '') as string,
+      }))
     }
-    if (ts) {
-      setFrom(ts as string)
-    } else {
-      setFrom('')
-    }
-  }, [s, te, ts])
+  }, [s, ite, its])
 
   const onSelectTemplate = (template: LogTemplate) => {
     setFilters((prev: any) => ({ ...prev, search_query: template.searchString }))
@@ -81,33 +76,23 @@ export const LogsPreviewer: React.FC<Props> = ({
       pathname: router.pathname,
       query: {
         ...router.query,
-        te: undefined,
-        ts: undefined,
+        ite: undefined,
+        its: undefined,
         // ...whereFilters,
       },
     })
   }
 
-  const handleSearch: LogSearchCallback = async ({ query, to, from, fromMicro, toMicro }) => {
-    let toValue, fromValue
-    if (to || toMicro) {
-      toValue = toMicro ? toMicro : dayjs(to).valueOf() * 1000
-
-      setTo(String(toValue))
-    }
-    if (from || fromMicro) {
-      fromValue = fromMicro ? fromMicro : dayjs(from).valueOf() * 1000
-      setFrom(String(fromValue))
-    }
-    setFilters((prev) => ({ ...prev, search_query: query || '' }))
-
+  const handleSearch: LogSearchCallback = async ({ query = '', to = '', from = '' }) => {
+    setParams((prev) => ({ ...prev, iso_timestamp_start: from, iso_timestamp_end: to }))
+    setFilters((prev) => ({ ...prev, search_query: query }))
     router.push({
       pathname: router.pathname,
       query: {
         ...router.query,
         s: query || '',
-        ts: fromValue,
-        te: toValue,
+        its: from,
+        ite: to,
       },
     })
   }
@@ -123,18 +108,16 @@ export const LogsPreviewer: React.FC<Props> = ({
         onRefresh={handleRefresh}
         onSearch={handleSearch}
         defaultSearchValue={filters.search_query as string}
-        defaultToValue={
-          params.timestamp_end ? dayjs(Number(params.timestamp_end) / 1000).toISOString() : ''
-        }
-        defaultFromValue={
-          params.timestamp_start
-            ? dayjs(Number(params.timestamp_start) / 1000).toISOString()
-            : oldestTimestamp
-            ? dayjs(Number(oldestTimestamp) / 1000).toISOString()
-            : ''
-        }
+        defaultToValue={params.iso_timestamp_end}
+        defaultFromValue={params.iso_timestamp_start}
         onExploreClick={() => {
-          router.push(`/project/${projectRef}/logs-explorer?q=${encodeURIComponent(params.rawSql)}`)
+          router.push(
+            `/project/${projectRef}/logs-explorer?q=${encodeURIComponent(
+              params.rawSql || ''
+            )}&its=${encodeURIComponent(params.iso_timestamp_start || '')}&ite=${encodeURIComponent(
+              params.iso_timestamp_end || ''
+            )}`
+          )
         }}
         onSelectTemplate={onSelectTemplate}
         filters={filters}
@@ -157,7 +140,8 @@ export const LogsPreviewer: React.FC<Props> = ({
             <LogEventChart
               data={!isLoading ? logData : undefined}
               onBarClick={(timestampMicro) => {
-                handleSearch({ query: filters.search_query as string, toMicro: timestampMicro })
+                const to = unixMicroToIsoTimestamp(timestampMicro)
+                handleSearch({ query: filters.search_query as string, to })
               }}
             />
           )}

--- a/studio/components/interfaces/Settings/Logs/LogsQueryPanel.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogsQueryPanel.tsx
@@ -1,6 +1,5 @@
 import { Button, Dropdown, Typography, IconChevronDown, IconPlay } from '@supabase/ui'
 import Flag from 'components/ui/Flag/Flag'
-import dayjs from 'dayjs'
 import { EXPLORER_DATEPICKER_HELPERS, LogsTableName, LOGS_SOURCE_DESCRIPTION, LogTemplate } from '.'
 import DatePickers from './Logs.DatePickers'
 interface Props {
@@ -12,7 +11,7 @@ interface Props {
   onSave?: () => void
   hasEditorValue: boolean
   isLoading: boolean
-  onDateChange: (time: { to: string; from: string }) => void
+  onDateChange: React.ComponentProps<typeof DatePickers>['onChange']
   defaultTo: string
   defaultFrom: string
 }

--- a/studio/components/interfaces/Settings/Logs/LogsQueryPanel.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogsQueryPanel.tsx
@@ -1,7 +1,24 @@
-import { Button, Dropdown, Typography, IconChevronDown, IconPlay } from '@supabase/ui'
+import {
+  Button,
+  Dropdown,
+  Typography,
+  IconChevronDown,
+  IconPlay,
+  Badge,
+  Popover,
+  Alert,
+} from '@supabase/ui'
 import Flag from 'components/ui/Flag/Flag'
-import { EXPLORER_DATEPICKER_HELPERS, LogsTableName, LOGS_SOURCE_DESCRIPTION, LogTemplate } from '.'
+import {
+  EXPLORER_DATEPICKER_HELPERS,
+  LogsTableName,
+  LogsWarning,
+  LOGS_SOURCE_DESCRIPTION,
+  LogTemplate,
+} from '.'
 import DatePickers from './Logs.DatePickers'
+import Link from 'next/link'
+
 interface Props {
   templates?: LogTemplate[]
   onSelectTemplate: (template: LogTemplate) => void
@@ -14,6 +31,7 @@ interface Props {
   onDateChange: React.ComponentProps<typeof DatePickers>['onChange']
   defaultTo: string
   defaultFrom: string
+  warnings: LogsWarning[]
 }
 
 const LogsQueryPanel: React.FC<Props> = ({
@@ -28,6 +46,7 @@ const LogsQueryPanel: React.FC<Props> = ({
   defaultFrom,
   defaultTo,
   onDateChange,
+  warnings,
 }) => (
   <div
     className="
@@ -76,6 +95,35 @@ bg-panel-header-light dark:bg-panel-header-dark
             onChange={onDateChange}
             helpers={EXPLORER_DATEPICKER_HELPERS}
           />
+          <div className="overflow-hidden">
+            <div
+              className={` transition-all duration-300 ${
+                warnings.length > 0 ? 'opacity-100' : 'invisible w-0 h-0 opacity-0'
+              }`}
+            >
+              <Popover
+                portalled
+                overlay={
+                  <Alert variant="warning" title="">
+                    <div className="flex flex-col gap-3">
+                      {warnings.map((warning, index) => (
+                        <p key={index}>
+                          {warning.text}{' '}
+                          {warning.link && (
+                            <Link href={warning.link}>{warning.linkText || 'View'}</Link>
+                          )}
+                        </p>
+                      ))}
+                    </div>
+                  </Alert>
+                }
+              >
+                <Badge color="yellow">
+                  {warnings.length} {warnings.length > 1 ? 'warnings' : 'warning'}
+                </Badge>
+              </Popover>
+            </div>
+          </div>
         </div>
         <div>
           <div className="flex items-center gap-4">

--- a/studio/components/interfaces/Settings/Logs/LogsQueryPanel.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogsQueryPanel.tsx
@@ -1,6 +1,8 @@
 import { Button, Dropdown, Typography, IconChevronDown, IconPlay } from '@supabase/ui'
 import Flag from 'components/ui/Flag/Flag'
+import dayjs from 'dayjs'
 import { LogsTableName, LOGS_SOURCE_DESCRIPTION, LogTemplate } from '.'
+import DatePickers from './Logs.DatePickers'
 interface Props {
   templates?: LogTemplate[]
   onSelectTemplate: (template: LogTemplate) => void
@@ -10,6 +12,9 @@ interface Props {
   onSave?: () => void
   hasEditorValue: boolean
   isLoading: boolean
+  onDateChange: (time: { to: string; from: string }) => void
+  defaultTo: string
+  defaultFrom: string
 }
 
 const LogsQueryPanel: React.FC<Props> = ({
@@ -21,6 +26,9 @@ const LogsQueryPanel: React.FC<Props> = ({
   onSave,
   onSelectSource,
   isLoading,
+  defaultFrom,
+  defaultTo,
+  onDateChange,
 }) => (
   <div
     className="
@@ -63,6 +71,29 @@ bg-panel-header-light dark:bg-panel-header-dark
               Templates
             </Button>
           </Dropdown>
+          <DatePickers
+            changeOnMount
+            to={defaultTo}
+            from={defaultFrom}
+            onChange={onDateChange}
+            helpers={[
+              {
+                text: 'Last day',
+                calcFrom: () => dayjs().subtract(1, 'day').startOf('day').toISOString(),
+                calcTo: () => '',
+              },
+              {
+                text: 'Last 3 days',
+                calcFrom: () => dayjs().subtract(3, 'day').startOf('day').toISOString(),
+                calcTo: () => '',
+              },
+              {
+                text: 'Last 7 days',
+                calcFrom: () => dayjs().subtract(7, 'day').startOf('day').toISOString(),
+                calcTo: () => '',
+              },
+            ]}
+          />
         </div>
         <div>
           <div className="flex items-center gap-4">

--- a/studio/components/interfaces/Settings/Logs/LogsQueryPanel.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogsQueryPanel.tsx
@@ -1,7 +1,7 @@
 import { Button, Dropdown, Typography, IconChevronDown, IconPlay } from '@supabase/ui'
 import Flag from 'components/ui/Flag/Flag'
 import dayjs from 'dayjs'
-import { LogsTableName, LOGS_SOURCE_DESCRIPTION, LogTemplate } from '.'
+import { EXPLORER_DATEPICKER_HELPERS, LogsTableName, LOGS_SOURCE_DESCRIPTION, LogTemplate } from '.'
 import DatePickers from './Logs.DatePickers'
 interface Props {
   templates?: LogTemplate[]
@@ -72,27 +72,10 @@ bg-panel-header-light dark:bg-panel-header-dark
             </Button>
           </Dropdown>
           <DatePickers
-            changeOnMount
             to={defaultTo}
             from={defaultFrom}
             onChange={onDateChange}
-            helpers={[
-              {
-                text: 'Last day',
-                calcFrom: () => dayjs().subtract(1, 'day').startOf('day').toISOString(),
-                calcTo: () => '',
-              },
-              {
-                text: 'Last 3 days',
-                calcFrom: () => dayjs().subtract(3, 'day').startOf('day').toISOString(),
-                calcTo: () => '',
-              },
-              {
-                text: 'Last 7 days',
-                calcFrom: () => dayjs().subtract(7, 'day').startOf('day').toISOString(),
-                calcTo: () => '',
-              },
-            ]}
+            helpers={EXPLORER_DATEPICKER_HELPERS}
           />
         </div>
         <div>

--- a/studio/components/interfaces/Settings/Logs/PreviewFilterPanel.tsx
+++ b/studio/components/interfaces/Settings/Logs/PreviewFilterPanel.tsx
@@ -9,7 +9,7 @@ import {
   IconEye,
   IconEyeOff,
 } from '@supabase/ui'
-import { Filters, LogSearchCallback, LogTemplate } from '.'
+import { Filters, LogSearchCallback, LogTemplate, PREVIEWER_DATEPICKER_HELPERS } from '.'
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
 import { FILTER_OPTIONS, LogsTableName } from './Logs.constants'
@@ -152,6 +152,7 @@ const PreviewFilterPanel: FC<Props> = ({
           }}
           to={defaultToValue}
           from={defaultFromValue}
+          helpers={PREVIEWER_DATEPICKER_HELPERS}
         />
 
         <div>

--- a/studio/components/interfaces/Settings/Logs/PreviewFilterPanel.tsx
+++ b/studio/components/interfaces/Settings/Logs/PreviewFilterPanel.tsx
@@ -101,9 +101,8 @@ const PreviewFilterPanel: FC<Props> = ({
       Refresh
     </Button>
   )
-
-  const handleSearch = (partial: Partial<{ query: string; to: string; from: string }>) =>
-    onSearch({ query: search, ...partial })
+  const handleSearch = (partial: Partial<Parameters<LogSearchCallback>[0]>) =>
+    onSearch({ query: search, to: partial?.to || null, from: partial?.from || null })
 
   return (
     <div
@@ -147,9 +146,7 @@ const PreviewFilterPanel: FC<Props> = ({
         </form>
 
         <DatePickers
-          onChange={async (e: { to: string; from: string }) => {
-            handleSearch(e)
-          }}
+          onChange={handleSearch}
           to={defaultToValue}
           from={defaultFromValue}
           helpers={PREVIEWER_DATEPICKER_HELPERS}

--- a/studio/components/ui/DatePicker/DatePicker.tsx
+++ b/studio/components/ui/DatePicker/DatePicker.tsx
@@ -1,9 +1,5 @@
-import React, { useState, forwardRef, useEffect } from 'react'
-
+import React, { useState, useEffect } from 'react'
 import DatePicker from 'react-datepicker'
-
-// import dayjs from 'dayjs'
-
 import {
   Button,
   Popover,
@@ -11,40 +7,30 @@ import {
   IconChevronRight,
   IconArrowRight,
   IconCalendar,
-  IconGlobe,
-  Input,
-  Toggle,
-  Select,
 } from '@supabase/ui'
 
 import { format } from 'date-fns'
-
 import TimeSplitInput from './TimeSplitInput'
-// import DateSplitInput from './DateSplitInput'
-import DividerSlash from './DividerSlash'
-
 import dayjs from 'dayjs'
 import { ButtonProps } from '@supabase/ui/dist/cjs/components/Button/Button'
+import { DatePickerToFrom } from 'components/interfaces/Settings/Logs'
 
 var utc = require('dayjs/plugin/utc')
 var timezone = require('dayjs/plugin/timezone') // dependent on utc plugin
-
 dayjs.extend(utc)
 dayjs.extend(timezone)
 
-interface RootProps {
-  onChange?: ({ to, from }: { to: string; from: string }) => void
+export interface DatePickerProps {
+  onChange?: (args: DatePickerToFrom) => void
   to?: string
   from?: string
   triggerButtonType?: ButtonProps['type']
   triggerButtonClassName?: string
+  renderFooter?: (args: DatePickerToFrom) => React.ReactNode | void
 }
 
 const START_DATE_DEFAULT = new Date()
 const END_DATE_DEFAULT = new Date()
-
-// console.log('START_DATE_DEFAULT', START_DATE_DEFAULT)
-
 const START_TIME_DEFAULT = { HH: '00', mm: '00', ss: '00' }
 const END_TIME_DEFAULT = { HH: '23', mm: '59', ss: '59' }
 
@@ -54,24 +40,31 @@ function _DatePicker({
   onChange,
   triggerButtonType = 'default',
   triggerButtonClassName = '',
-}: RootProps) {
+  renderFooter = () => null,
+}: DatePickerProps) {
   const [open, setOpen] = useState<boolean>(false)
-
-  const [showTime, setShowTime] = useState<boolean>(true)
-
-  const [appliedStartDate, setAppliedStartDate] = useState<any>(null)
-  const [appliedEndDate, setAppliedEndDate] = useState<any>(null)
-
-  const [startDate, setStartDate] = useState<any>(START_DATE_DEFAULT)
-  const [endDate, setEndDate] = useState<any>(END_DATE_DEFAULT)
-
+  const [appliedStartDate, setAppliedStartDate] = useState<null | Date>(null)
+  const [appliedEndDate, setAppliedEndDate] = useState<null | Date>(null)
+  const [startDate, setStartDate] = useState<Date | null>(START_DATE_DEFAULT)
+  const [endDate, setEndDate] = useState<Date | null>(END_DATE_DEFAULT)
   const [startTime, setStartTime] = useState<any>(START_TIME_DEFAULT)
   const [endTime, setEndTime] = useState<any>(END_TIME_DEFAULT)
 
   useEffect(() => {
-    if (!to || !from) {
+    if (!from) {
       setAppliedStartDate(null)
+    } else if (from !== appliedStartDate?.toISOString()) {
+      const start = dayjs(from).toDate()
+      setAppliedStartDate(start)
+      setStartDate(start)
+    }
+
+    if (!to) {
       setAppliedEndDate(null)
+    } else if (to !== appliedEndDate?.toISOString()) {
+      const end = dayjs(to).toDate()
+      setAppliedEndDate(end)
+      setEndDate(end)
     }
   }, [to, from])
 
@@ -115,168 +108,77 @@ function _DatePicker({
     setAppliedStartDate(null)
     setAppliedEndDate(null)
   }
-
-  const DEFAULT_DATE_FORMAT = 'ddd MMM YYYY HH:mm:ss'
-
   return (
-    <>
-      <Popover
-        open={open}
-        onOpenChange={(e) => setOpen(e)}
-        size="small"
-        align="center"
-        side="bottom"
-        header={
-          <>
-            <div className="flex justify-between items-stretch py-2">
-              <div className="grow flex flex-col gap-1">
-                <TimeSplitInput
-                  type="start"
-                  startTime={startTime}
-                  endTime={endTime}
-                  time={startTime}
-                  setTime={setStartTime}
-                  setStartTime={setStartTime}
-                  setEndTime={setEndTime}
-                  startDate={startDate}
-                  endDate={endDate}
-                />
-              </div>
-              <div
-                className={`
+    <Popover
+      open={open}
+      onOpenChange={(e) => setOpen(e)}
+      size="small"
+      align="center"
+      side="bottom"
+      header={
+        <>
+          <div className="flex justify-between items-stretch py-2">
+            <div className="grow flex flex-col gap-1">
+              <TimeSplitInput
+                type="start"
+                startTime={startTime}
+                endTime={endTime}
+                time={startTime}
+                setTime={setStartTime}
+                setStartTime={setStartTime}
+                setEndTime={setEndTime}
+                startDate={startDate}
+                endDate={endDate}
+              />
+            </div>
+            <div
+              className={`
                       w-12 
                       flex 
                       items-center 
                       justify-center
                       text-scale-900
                     `}
-              >
-                <IconArrowRight strokeWidth={1.5} size={14} />
-              </div>
-              <div className="grow flex flex-col gap-1">
-                <TimeSplitInput
-                  type="end"
-                  startTime={startTime}
-                  endTime={endTime}
-                  time={endTime}
-                  setTime={setEndTime}
-                  setStartTime={setStartTime}
-                  setEndTime={setEndTime}
-                  startDate={startDate}
-                  endDate={endDate}
-                />
-              </div>
+            >
+              <IconArrowRight strokeWidth={1.5} size={14} />
             </div>
-          </>
-        }
-        overlay={
-          <>
-            <div className="px-3 py-4">
-              <DatePicker
-                selected={startDate}
-                onChange={(dates) => {
-                  handleDatePickerChange(dates)
-                }}
-                dateFormat="MMMM d, yyyy h:mm aa"
+            <div className="grow flex flex-col gap-1">
+              <TimeSplitInput
+                type="end"
+                startTime={startTime}
+                endTime={endTime}
+                time={endTime}
+                setTime={setEndTime}
+                setStartTime={setStartTime}
+                setEndTime={setEndTime}
                 startDate={startDate}
                 endDate={endDate}
-                selectsRange
-                // showTimeSelect
-                // nextMonthButtonLabel=">"
-                // previousMonthButtonLabel="<"
-                // popperClassName="react-datepicker-left"
-                // customInput={<ButtonInput />}
-                // dateFormat={DEFAULT_DATE_FORMAT}
-                // dateFormat={(locale, date) => dayjs(date).format('MM-YYYY')}
-                inline
-                dayClassName={() => 'cursor-pointer'}
-                renderCustomHeader={({
-                  date,
-                  decreaseMonth,
-                  increaseMonth,
-                  prevMonthButtonDisabled,
-                  nextMonthButtonDisabled,
-                }) => (
-                  <div className="flex items-center justify-between px-2 py-2">
-                    <div className="flex items-center justify-between w-full">
-                      <button
-                        onClick={decreaseMonth}
-                        disabled={prevMonthButtonDisabled}
-                        type="button"
-                        className={`
-                        ${prevMonthButtonDisabled && 'cursor-not-allowed opacity-50'}
-                        text-scale-1100 hover:text-scale-1200 focus:outline-none
-                    `}
-                      >
-                        <IconChevronLeft size={16} strokeWidth={2} />
-                      </button>
-                      <span className="text-sm text-scale-1100">{format(date, 'MMMM yyyy')}</span>
-                      <button
-                        onClick={increaseMonth}
-                        disabled={nextMonthButtonDisabled}
-                        type="button"
-                        className={`
-                        ${nextMonthButtonDisabled && 'cursor-not-allowed opacity-50'}
-                        text-scale-1100 hover:text-scale-1200 focus:outline-none
-                    `}
-                      >
-                        <IconChevronRight size={16} strokeWidth={2} />
-                      </button>
-                    </div>
-                  </div>
-                )}
               />
             </div>
-
-            <Popover.Seperator />
-            <div className="flex items-center justify-end gap-2 py-2 pb-4 px-3">
-              <Button type="default" onClick={() => handleClear()}>
-                Clear
-              </Button>
-              <Button onClick={() => handleSubmit()}>Apply</Button>
-            </div>
-          </>
-        }
-      >
-        <Button
-          type={triggerButtonType}
-          as="span"
-          icon={<IconCalendar />}
-          className={triggerButtonClassName}
-        >
-          {/* Custom */}
-          {appliedStartDate && appliedEndDate && appliedStartDate !== appliedEndDate ? (
-            <>
-              {format(new Date(appliedStartDate), 'dd MMM')} -{' '}
-              {format(new Date(appliedEndDate), 'dd MMM')}
-            </>
-          ) : appliedStartDate || appliedEndDate ? (
-            format(new Date(appliedStartDate || appliedEndDate), 'dd MMM')
-          ) : (
-            'Custom'
-          )}
-        </Button>
-      </Popover>
-
-      {/* <div className="relative w-40">
-          <DatePicker
-            selected={endDate}
-            onChange={(date) => setEndDate(date)}
-            selectsEnd
-            startDate={startDate}
-            endDate={endDate}
-            nextMonthButtonLabel=">"
-            previousMonthButtonLabel="<"
-            popperClassName="react-datepicker-right"
-            customInput={<ButtonInput />}
-            renderCustomHeader={({
-              date,
-              decreaseMonth,
-              increaseMonth,
-              prevMonthButtonDisabled,
-              nextMonthButtonDisabled,
-            }) => (
-              <>
+          </div>
+        </>
+      }
+      overlay={
+        <>
+          <div className="px-3 py-4">
+            <DatePicker
+              selected={startDate}
+              onChange={(dates) => {
+                handleDatePickerChange(dates)
+              }}
+              dateFormat="MMMM d, yyyy h:mm aa"
+              startDate={startDate}
+              endDate={endDate}
+              selectsRange
+              inline
+              dayClassName={() => 'cursor-pointer'}
+              renderCustomHeader={({
+                date,
+                decreaseMonth,
+                increaseMonth,
+                prevMonthButtonDisabled,
+                nextMonthButtonDisabled,
+              }) => (
                 <div className="flex items-center justify-between px-2 py-2">
                   <div className="flex items-center justify-between w-full">
                     <button
@@ -284,27 +186,19 @@ function _DatePicker({
                       disabled={prevMonthButtonDisabled}
                       type="button"
                       className={`
-                        ${
-                          prevMonthButtonDisabled &&
-                          'cursor-not-allowed opacity-50'
-                        }
+                        ${prevMonthButtonDisabled && 'cursor-not-allowed opacity-50'}
                         text-scale-1100 hover:text-scale-1200 focus:outline-none
                     `}
                     >
                       <IconChevronLeft size={16} strokeWidth={2} />
                     </button>
-                    <span className="text-sm text-scale-1100">
-                      {format(date, 'MMMM yyyy')}
-                    </span>
+                    <span className="text-sm text-scale-1100">{format(date, 'MMMM yyyy')}</span>
                     <button
                       onClick={increaseMonth}
                       disabled={nextMonthButtonDisabled}
                       type="button"
                       className={`
-                        ${
-                          nextMonthButtonDisabled &&
-                          'cursor-not-allowed opacity-50'
-                        }
+                        ${nextMonthButtonDisabled && 'cursor-not-allowed opacity-50'}
                         text-scale-1100 hover:text-scale-1200 focus:outline-none
                     `}
                     >
@@ -312,51 +206,43 @@ function _DatePicker({
                     </button>
                   </div>
                 </div>
-              </>
-            )}
-          />
-        </div>
-      </div>
-      <div className="flex items-center justify-center max-w-2xl py-20 mx-auto space-x-4">
-        <span className="font-medium text-gray-900">Default Components:</span>
-        <div className="relative w-40">
-          <DatePicker
-            selected={startDate}
-            onChange={(date) => setStartDate(date)}
-            selectsStart
-            startDate={startDate}
-            endDate={endDate}
-            nextMonthButtonLabel=">"
-            previousMonthButtonLabel="<"
-            popperClassName="react-datepicker-left"
-          />
-        </div>
-        <div className="relative w-40">
-          <DatePicker
-            selected={endDate}
-            onChange={(date) => setEndDate(date)}
-            selectsEnd
-            startDate={startDate}
-            endDate={endDate}
-            nextMonthButtonLabel=">"
-            previousMonthButtonLabel="<"
-            popperClassName="react-datepicker-right"
-          />
-        </div> */}
-    </>
+              )}
+            />
+          </div>
+          {renderFooter({
+            from: startDate?.toISOString() || null,
+            to: endDate?.toISOString() || null,
+          })}
+          <Popover.Seperator />
+          <div className="flex items-center justify-end gap-2 py-2 pb-4 px-3">
+            <Button type="default" onClick={() => handleClear()}>
+              Clear
+            </Button>
+            <Button onClick={() => handleSubmit()}>Apply</Button>
+          </div>
+        </>
+      }
+    >
+      <Button
+        type={triggerButtonType}
+        as="span"
+        icon={<IconCalendar />}
+        className={triggerButtonClassName}
+      >
+        {/* Custom */}
+        {appliedStartDate && appliedEndDate && appliedStartDate !== appliedEndDate ? (
+          <>
+            {format(new Date(appliedStartDate), 'dd MMM')} -{' '}
+            {format(new Date(appliedEndDate), 'dd MMM')}
+          </>
+        ) : appliedStartDate || appliedEndDate ? (
+          format(new Date((appliedStartDate || appliedEndDate)!), 'dd MMM')
+        ) : (
+          'Custom'
+        )}
+      </Button>
+    </Popover>
   )
 }
-
-const ButtonInput = forwardRef(({ value, onClick }: any, ref): any => (
-  <button
-    onClick={onClick}
-    // @ts-ignore
-    ref={ref}
-    type="button"
-    className="inline-flex justify-start w-full px-3 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-0 focus:ring-blue-500"
-  >
-    {value}
-  </button>
-))
 
 export default _DatePicker

--- a/studio/components/ui/DatePicker/index.tsx
+++ b/studio/components/ui/DatePicker/index.tsx
@@ -1,1 +1,2 @@
 export { default as DatePicker } from './DatePicker'
+export type {DatePickerProps} from "./DatePicker"

--- a/studio/hooks/analytics/useLogsQuery.tsx
+++ b/studio/hooks/analytics/useLogsQuery.tsx
@@ -1,11 +1,14 @@
-import { cleanQuery, genQueryParams } from 'components/interfaces/Settings/Logs'
+import {
+  cleanQuery,
+  EXPLORER_DATEPICKER_HELPERS,
+  genQueryParams,
+  getDefaultHelper,
+} from 'components/interfaces/Settings/Logs'
 import { Dispatch, SetStateAction, useState } from 'react'
 import { LogsEndpointParams, Logs, LogData } from 'components/interfaces/Settings/Logs/Logs.types'
-import useSWRInfinite, { SWRInfiniteKeyLoader } from 'swr/infinite/dist/infinite'
 import { API_URL } from 'lib/constants'
-import useSWR, { mutate } from 'swr'
+import useSWR from 'swr'
 import { get } from 'lib/common/fetch'
-import dayjs from 'dayjs'
 interface Data {
   params: LogsEndpointParams
   isLoading: boolean
@@ -22,12 +25,13 @@ const useLogsQuery = (
   projectRef: string,
   initialParams: Partial<LogsEndpointParams> = {}
 ): [Data, Handlers] => {
+  const defaultHelper = getDefaultHelper(EXPLORER_DATEPICKER_HELPERS)
   const [params, setParams] = useState<LogsEndpointParams>({
     project: projectRef,
     sql: '',
     rawSql: '',
-    iso_timestamp_start: '',
-    iso_timestamp_end: '',
+    iso_timestamp_start: defaultHelper.calcFrom(),
+    iso_timestamp_end: defaultHelper.calcTo(),
     ...initialParams,
   })
 

--- a/studio/hooks/analytics/useLogsQuery.tsx
+++ b/studio/hooks/analytics/useLogsQuery.tsx
@@ -5,6 +5,7 @@ import useSWRInfinite, { SWRInfiniteKeyLoader } from 'swr/infinite/dist/infinite
 import { API_URL } from 'lib/constants'
 import useSWR, { mutate } from 'swr'
 import { get } from 'lib/common/fetch'
+import dayjs from 'dayjs'
 interface Data {
   params: LogsEndpointParams
   isLoading: boolean
@@ -14,6 +15,7 @@ interface Data {
 interface Handlers {
   changeQuery: (newQuery?: string) => void
   runQuery: () => void
+  setParams: Dispatch<SetStateAction<LogsEndpointParams>>
 }
 
 const useLogsQuery = (
@@ -24,8 +26,8 @@ const useLogsQuery = (
     project: projectRef,
     sql: '',
     rawSql: '',
-    // timestamp_start: '',
-    // timestamp_end: '',
+    iso_timestamp_start: '',
+    iso_timestamp_end: '',
     ...initialParams,
   })
 
@@ -36,7 +38,9 @@ const useLogsQuery = (
     isValidating: isLoading,
     mutate,
   } = useSWR<Logs>(
-    params.sql ? `${API_URL}/projects/${projectRef}/analytics/endpoints/logs.all?${queryParams}` : null,
+    params.sql
+      ? `${API_URL}/projects/${projectRef}/analytics/endpoints/logs.all?${queryParams}`
+      : null,
     get,
     { revalidateOnFocus: false }
   )
@@ -51,7 +55,7 @@ const useLogsQuery = (
 
   return [
     { params, isLoading, logData: data?.result ? data?.result : [], error },
-    { changeQuery, runQuery: () => mutate() },
+    { changeQuery, runQuery: () => mutate(), setParams },
   ]
 }
 export default useLogsQuery

--- a/studio/pages/project/[ref]/logs-explorer/index.tsx
+++ b/studio/pages/project/[ref]/logs-explorer/index.tsx
@@ -2,10 +2,11 @@ import React, { useEffect, useState } from 'react'
 import { NextPage } from 'next'
 import { useRouter } from 'next/router'
 import { observer } from 'mobx-react-lite'
-import { Typography, IconAlertCircle, Card, Input, Alert, Modal, Form, Button } from '@supabase/ui'
+import { Input, Modal, Form, Button } from '@supabase/ui'
 import { useStore, withAuth } from 'hooks'
 import CodeEditor from 'components/ui/CodeEditor'
 import {
+  DatePickerToFrom,
   LogsQueryPanel,
   LogsTableName,
   LogTable,
@@ -79,15 +80,15 @@ export const LogsExplorerPage: NextPage = () => {
     setSaveModalOpen(!saveModalOpen)
   }
 
-  const handleDateChange = ({ to = '', from = '' }: { to: string; from: string }) => {
+  const handleDateChange = ({ to, from }: DatePickerToFrom) => {
     setParams((prev) => ({
       ...prev,
-      iso_timestamp_start: from,
-      iso_timestamp_end: to,
+      iso_timestamp_start: from || '',
+      iso_timestamp_end: to || '',
     }))
     router.push({
       pathname: router.pathname,
-      query: { ...router.query, its: from, ite: to },
+      query: { ...router.query, its: from || '', ite: to || '' },
     })
   }
 

--- a/studio/pages/project/[ref]/logs-explorer/index.tsx
+++ b/studio/pages/project/[ref]/logs-explorer/index.tsx
@@ -17,7 +17,7 @@ import useLogsQuery from 'hooks/analytics/useLogsQuery'
 import { LogsExplorerLayout } from 'components/layouts'
 import ShimmerLine from 'components/ui/ShimmerLine'
 import LoadingOpacity from 'components/ui/LoadingOpacity'
-import { LogSqlSnippets, UserContent } from 'types'
+import { UserContent } from 'types'
 import toast from 'react-hot-toast'
 
 export const LogsExplorerPage: NextPage = () => {
@@ -30,7 +30,10 @@ export const LogsExplorerPage: NextPage = () => {
   const { content } = useStore()
 
   const [{ params, logData, error, isLoading }, { changeQuery, runQuery, setParams }] =
-    useLogsQuery(ref as string)
+    useLogsQuery(ref as string, {
+      iso_timestamp_start: (its || '') as string,
+      iso_timestamp_end: (ite || '') as string,
+    })
 
   useEffect(() => {
     // on mount, set initial values
@@ -40,20 +43,12 @@ export const LogsExplorerPage: NextPage = () => {
         searchString: q as string,
       })
     }
-    if (its || ite) {
-      setParams((prev) => ({
-        ...prev,
-        iso_timestamp_start: (its || '') as string,
-        iso_timestamp_end: (ite || '') as string,
-      }))
-    }
   }, [])
 
   const onSelectTemplate = (template: LogTemplate) => {
     setEditorValue(template.searchString)
     changeQuery(template.searchString)
     setEditorId(uuidv4())
-    runQuery()
     router.push({
       pathname: router.pathname,
       query: { ...router.query, q: template.searchString },
@@ -84,7 +79,7 @@ export const LogsExplorerPage: NextPage = () => {
     setSaveModalOpen(!saveModalOpen)
   }
 
-  const handleDateChange = ({ to, from }: { to: string; from: string }) => {
+  const handleDateChange = ({ to = '', from = '' }: { to: string; from: string }) => {
     setParams((prev) => ({
       ...prev,
       iso_timestamp_start: from,
@@ -101,8 +96,8 @@ export const LogsExplorerPage: NextPage = () => {
       <div className="h-full flex flex-col flex-grow gap-4">
         <div className="border rounded">
           <LogsQueryPanel
-            defaultFrom={params.iso_timestamp_start!}
-            defaultTo={params.iso_timestamp_end!}
+            defaultFrom={params.iso_timestamp_start || ''}
+            defaultTo={params.iso_timestamp_end || ''}
             onDateChange={handleDateChange}
             onSelectSource={handleInsertSource}
             onClear={handleClear}

--- a/studio/tests/pages/projects/Logs.Datepickers.test.js
+++ b/studio/tests/pages/projects/Logs.Datepickers.test.js
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { PREVIEWER_DATEPICKER_HELPERS } from 'components/interfaces/Settings/Logs'
+import DatePickers from 'components/interfaces/Settings/Logs/Logs.DatePickers'
+import dayjs from 'dayjs'
+
+test('renders warning', async () => {
+  const from = dayjs().subtract(60, 'days')
+  const to = dayjs()
+  render(
+    <DatePickers
+      helpers={PREVIEWER_DATEPICKER_HELPERS}
+      to={to.toISOString()}
+      from={from.toISOString()}
+    />
+  )
+  userEvent.click(await screen.findByText(RegExp(from.format('DD MMM'))))
+  await screen.findByText(/memory errors/)
+})

--- a/studio/tests/pages/projects/LogsPreviewer.test.js
+++ b/studio/tests/pages/projects/LogsPreviewer.test.js
@@ -170,40 +170,36 @@ test('te= query param will populate the timestamp to input', async () => {
   // get time 20 mins before
   const newDate = new Date()
   newDate.setMinutes(new Date().getMinutes() - 20)
-  const isoString = newDate.toISOString()
-  const unixMicro = newDate.getTime() * 1000 //microseconds
+  const iso = newDate.toISOString()
   const router = defaultRouterMock()
-  router.query = { ...router.query, te: unixMicro }
+  router.query = { ...router.query, ite: iso }
   useRouter.mockReturnValue(router)
   render(<LogsPreviewer projectRef="123" tableName={LogsTableName.EDGE} />)
 
   await waitFor(() => {
     expect(get).toHaveBeenCalledWith(
-      expect.stringContaining(`timestamp_end=${encodeURIComponent(unixMicro)}`)
+      expect.stringContaining(`iso_timestamp_end=${encodeURIComponent(iso)}`)
     )
   })
   userEvent.click(await screen.findByText('Custom'))
-  expect(get).toHaveBeenCalledWith(expect.stringContaining('timestamp_end=' + unixMicro))
 })
 test('ts= query param will populate the timestamp from input', async () => {
   // get time 20 mins before
   const newDate = new Date()
   newDate.setMinutes(new Date().getMinutes() - 20)
-  const unixMicro = newDate.getTime() * 1000 //microseconds
+  const iso = newDate.toISOString()
   const router = defaultRouterMock()
-  router.query = { ...router.query, ts: unixMicro }
+  router.query = { ...router.query, its: iso }
   useRouter.mockReturnValue(router)
   render(<LogsPreviewer projectRef="123" tableName={LogsTableName.EDGE} />)
 
   await waitFor(() => {
     expect(get).toHaveBeenCalledWith(
-      expect.stringContaining(`timestamp_start=${encodeURIComponent(unixMicro)}`)
+      expect.stringContaining(`iso_timestamp_start=${encodeURIComponent(iso)}`)
     )
   })
   userEvent.click(await screen.findByText('Custom'))
   await screen.findByText(new RegExp(newDate.getFullYear()))
-  await screen.findByText(/Apply/)
-  expect(get).toHaveBeenCalledWith(expect.stringContaining('timestamp_start=' + unixMicro))
 })
 
 test('load older btn will fetch older logs', async () => {

--- a/studio/tests/pages/projects/LogsPreviewer.test.js
+++ b/studio/tests/pages/projects/LogsPreviewer.test.js
@@ -280,14 +280,12 @@ test('bug: nav backwards with params change results in ui changing', async () =>
   await screen.findByDisplayValue('simple-query')
 })
 
-test("bug: nav to explorer preserves newlines", async ()=>{
-  render(
-    <LogsPreviewer projectRef="123" tableName={LogsTableName.EDGE} />
-  )
+test('bug: nav to explorer preserves newlines', async () => {
+  render(<LogsPreviewer projectRef="123" tableName={LogsTableName.EDGE} />)
   const router = useRouter()
   userEvent.click(await screen.findByText(/Explore/))
-  await expect(router.push).toBeCalledWith(expect.stringContaining(encodeURIComponent("\n")))
-}
+  await expect(router.push).toBeCalledWith(expect.stringContaining(encodeURIComponent('\n')))
+})
 test('filters alter generated query', async () => {
   render(<LogsPreviewer projectRef="123" tableName={LogsTableName.EDGE} />)
   userEvent.click(await screen.findByRole('button', { name: 'Status' }))

--- a/studio/tests/pages/projects/LogsQueryPanel.test.js
+++ b/studio/tests/pages/projects/LogsQueryPanel.test.js
@@ -22,5 +22,4 @@ test('run and clear', async () => {
   const clear = await screen.findByText(/Clear/)
   userEvent.click(clear)
   expect(mockClear).toBeCalled()
-  
 })

--- a/studio/tests/pages/projects/LogsQueryPanel.test.js
+++ b/studio/tests/pages/projects/LogsQueryPanel.test.js
@@ -14,7 +14,7 @@ test.todo('templates')
 test('run and clear', async () => {
   const mockRun = jest.fn()
   const mockClear = jest.fn()
-  render(<LogsQueryPanel onRun={mockRun} onClear={mockClear} hasEditorValue/>)
+  render(<LogsQueryPanel warnings={[]} onRun={mockRun} onClear={mockClear} hasEditorValue />)
   await expect(screen.findByPlaceholderText(/Search/)).rejects.toThrow()
   const run = await screen.findByText(/Run/)
   userEvent.click(run)

--- a/studio/tests/pages/projects/PreviewFilterPanel.test.js
+++ b/studio/tests/pages/projects/PreviewFilterPanel.test.js
@@ -50,10 +50,10 @@ test('Manual refresh', async () => {
 })
 test('Datepicker dropdown', async () => {
   render(<PreviewFilterPanel />)
-  clickDropdown(await screen.findByText(/Last hour/))
+  clickDropdown(await screen.findByText(/Last day/))
   userEvent.click(await screen.findByText(/Last 3 hours/))
   await screen.findByText(/Last 3 hours/)
-  await expect(screen.findByText(/Last hour/)).rejects.toThrow()
+  await expect(screen.findByText(/Last day/)).rejects.toThrow()
 })
 
 test.todo('timestamp to/from filter default value')

--- a/studio/tests/pages/projects/logs-query.test.js
+++ b/studio/tests/pages/projects/logs-query.test.js
@@ -62,7 +62,8 @@ const LogsExplorerPage = (props) => (
 import { render, fireEvent, waitFor, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { logDataFixture } from '../../fixtures'
-
+import { clickDropdown } from 'tests/helpers'
+import dayjs from 'dayjs'
 beforeEach(() => {
   // reset mocks between tests
   get.mockReset()
@@ -80,7 +81,7 @@ test('can display log data', async () => {
       }),
     ],
   })
-  const {container} = render(<LogsExplorerPage />)
+  const { container } = render(<LogsExplorerPage />)
   let editor = container.querySelector('.monaco-editor')
   await waitFor(() => {
     editor = container.querySelector('.monaco-editor')
@@ -90,7 +91,7 @@ test('can display log data', async () => {
   userEvent.type(editor, 'select \ncount(*) as my_count \nfrom edge_logs')
 
   userEvent.click(await screen.findByText(/Run/))
-  const row  = await screen.findByText("some-event-happened")
+  const row = await screen.findByText('some-event-happened')
   userEvent.click(row)
   await screen.findByText(/something_value/)
 })
@@ -103,6 +104,27 @@ test('q= query param will populate the query input', async () => {
   // should populate editor with the query param
   await waitFor(() => {
     expect(get).toHaveBeenCalledWith(expect.stringContaining('sql=some_query'))
+  })
+})
+test('ite= and its= query param will populate the datepicker', async () => {
+  const router = defaultRouterMock()
+  const start = dayjs().subtract(1, 'day')
+  const end = dayjs()
+  router.query = {
+    ...router.query,
+    type: 'api',
+    q: 'some_query',
+    its: start.toISOString(),
+    ite: end.toISOString(),
+  }
+  useRouter.mockReturnValue(router)
+  render(<LogsExplorerPage />)
+  // should populate editor with the query param
+  await waitFor(() => {
+    expect(get).toHaveBeenCalledWith(
+      expect.stringContaining(encodeURIComponent(start.toISOString()))
+    )
+    expect(get).toHaveBeenCalledWith(expect.stringContaining(encodeURIComponent(end.toISOString())))
   })
 })
 
@@ -154,4 +176,19 @@ test('custom sql querying', async () => {
 
   // should not see chronological features
   await expect(screen.findByText(/Load older/)).rejects.toThrow()
+})
+
+test('datepicker interaction updates query params', async () => {
+  render(<LogsExplorerPage />)
+  clickDropdown(await screen.findByText(/Last day/))
+  userEvent.click(await screen.findByText(/Last 3 days/))
+
+  const router = useRouter()
+  expect(router.push).toBeCalledWith(
+    expect.objectContaining({
+      query: expect.objectContaining({
+        its: expect.any(String),
+      }),
+    })
+  )
 })

--- a/studio/tests/pages/projects/logs-query.test.js
+++ b/studio/tests/pages/projects/logs-query.test.js
@@ -192,3 +192,16 @@ test('datepicker interaction updates query params', async () => {
     })
   )
 })
+
+test('query warnings', async () => {
+  const router = defaultRouterMock()
+  router.query = {
+    ...router.query,
+    q: 'some_query',
+    its: dayjs().subtract(10, 'days').toISOString(),
+    ite: dayjs().toISOString(),
+  }
+  useRouter.mockReturnValue(router)
+  render(<LogsExplorerPage />)
+  await screen.findByText('1 warning')
+})


### PR DESCRIPTION
Querying restrictions required for optimal query timings + preventing PAYG/enterprise users from receiving 400 OrderBy memory errors with many cross joins.

Other fixes and improvements:
- selecting template adds a path to history and updates query params.
- query params in use is now `q`, `ite`, and `its`, ite and its stand for `iso_timestamp_start` and `iso_timestamp_end`.
- Datepickers behaviour has been tweaked to allow additional helpers to be passed in as parameter. Also allows triggering the `onDateChange` callback on mount, to allow syncing of parent components to the local state. Added a few tests as well.
- Datepicker behaviour has also been enhanced to recognize helper values based on the ISO parameters
- Removal of period_start/period_end/timestamp_start/timestamp_end usage, consolidating as above.
- Improved updating logic of datetime filters, to reduce requests.
- moving between previewer and explorer retains datepicker settings
- previewer now sets a default query range to 24h.

Pre-merge todos:
- [x] add in warning rendering for large date ranges, warn of query time and memory restrictions.
- [x] update prod endpoint to include iso_timestamp_start and iso_timestamp_end


<img width="1066" alt="image" src="https://user-images.githubusercontent.com/22714384/163408513-fe988d56-e6ed-4902-a9c5-74a10e957a92.png">

<img width="505" alt="image" src="https://user-images.githubusercontent.com/22714384/163821816-ba5aa746-3a69-4868-9ddf-5bc30c2913ef.png">