### PR TITLE
Update `database.tsx` python connection string

### DIFF
--- a/studio/pages/project/[ref]/settings/database.tsx
+++ b/studio/pages/project/[ref]/settings/database.tsx
@@ -465,7 +465,7 @@ const GeneralSettings: FC<any> = ({ projectRef }) => {
                     disabled
                     value={
                       `user=${connectionInfo.db_user} password=[YOUR-PASSWORD]` +
-                      `host=${connectionInfo.db_host} port=${connectionInfo.db_port.toString()}` +
+                      ` host=${connectionInfo.db_host} port=${connectionInfo.db_port.toString()}` +
                       ` database=${connectionInfo.db_name}`
                     }
                   />


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix: Update `database.tsx` python connection string.

## What is the current behavior?

There is no space between `[YOUR-PASSWORD]` and `host` in the python connection string.

## What is the new behavior?

This PR includes a space in between `[YOUR-PASSWORD]` and `host` in the python connection string to separate the two.

## Additional context

![Screenshot from 2022-04-14 21-38-15](https://user-images.githubusercontent.com/50144004/163429784-eea9f3bc-5190-482e-9bb0-1a33bc92f269.png)
