### PR TITLE
fix/logs: Fix for nested log filters when set to false

### DIFF
--- a/studio/components/interfaces/Settings/Logs/Logs.utils.ts
+++ b/studio/components/interfaces/Settings/Logs/Logs.utils.ts
@@ -40,7 +40,7 @@ const getDotKeys = (obj: { [k: string]: unknown }, parent?: string): string[] =>
  * ```
  * with no template, it will be converted into `WHERE (my.nested.value = 123)
  *
- * @returns a whewhere statement with WHERE clause.
+ * @returns a where statement with WHERE clause.
  */
 const _genWhereStatement = (table: LogsTableName, filters: Filters) => {
   const keys = Object.keys(filters)

--- a/studio/components/interfaces/Settings/Logs/Logs.utils.ts
+++ b/studio/components/interfaces/Settings/Logs/Logs.utils.ts
@@ -1,37 +1,37 @@
-import { get } from "lodash"
-import { Filters, LogsTableName, SQL_FILTER_TEMPLATES } from "."
+import { get } from 'lodash'
+import { Filters, LogsTableName, SQL_FILTER_TEMPLATES } from '.'
 
 /**
  * Recursively retrieve all nested object key paths.
- * 
+ *
  * TODO: move to utils
- * 
+ *
  * @param obj any object
  * @param parent a string representing the parent key
  * @returns string[] all dot paths for keys.
  */
 const getDotKeys = (obj: { [k: string]: unknown }, parent?: string): string[] => {
-    const keys = Object.keys(obj).filter(k => obj[k])
-    return keys.flatMap(k => {
-        const currKey = parent ? `${parent}.${k}` : k
-        if (typeof obj[k] === 'object') {
-            return getDotKeys(obj[k] as any, currKey)
-        } else {
-            return [currKey]
-        }
-    })
+  const keys = Object.keys(obj).filter((k) => obj[k])
+  return keys.flatMap((k) => {
+    const currKey = parent ? `${parent}.${k}` : k
+    if (typeof obj[k] === 'object') {
+      return getDotKeys(obj[k] as any, currKey)
+    } else {
+      return [currKey]
+    }
+  })
 }
 
 /**
  * Root keys in the filter object are considered to be AND filters.
  * Nested keys under a root key are considered to be OR filters.
- * 
+ *
  * For example:
  * ```
  * {my_value: 'something', nested: {id: 123, test: 123 }}
  * ```
  * This would be converted into `WHERE (my_value = 'something') and (id = 123 or test = 123)
- * 
+ *
  * The template of the filter determines the actual filter statement. If no template is provided, a generic equality statement will be used.
  * This only applies for root keys of the filter.
  * For example:
@@ -39,60 +39,71 @@ const getDotKeys = (obj: { [k: string]: unknown }, parent?: string): string[] =>
  * {'my.nested.value': 123}
  * ```
  * with no template, it will be converted into `WHERE (my.nested.value = 123)
- * 
+ *
  * @returns a whewhere statement with WHERE clause.
  */
 const _genWhereStatement = (table: LogsTableName, filters: Filters) => {
-    const keys = Object.keys(filters)
-    const filterTemplates = SQL_FILTER_TEMPLATES[table]
-    const _resolveTemplateToStatement = (dotKey: string): string | null => {
-        const template = filterTemplates[dotKey]
-        const value = get(filters, dotKey)
-        if (value !== undefined && typeof template === 'function') {
-            return template(value)
-        } else if (template === undefined) {
-            // resolve unknwon filters (possibly from filter overrides)
-            // no template, set a default
-            if (typeof value === 'string') {
-                return `${dotKey} = '${value}'`
-            } else {
-                return `${dotKey} = ${value}`
-            }
-        } else if (value === undefined && typeof template === 'function') {
-            return null
-        } else {
-            return template
-        }
-    }
-
-    const statement = keys.map(rootKey => {
-        if (typeof filters[rootKey] === 'object') {
-            // join all statements with an OR
-            const nestedStatement = getDotKeys(filters[rootKey] as Filters, rootKey).map(_resolveTemplateToStatement).filter(Boolean).join(" or ")
-            return `(${nestedStatement})`
-        } else {
-            const nestedStatement = _resolveTemplateToStatement(rootKey)
-            if (nestedStatement === null) return null
-            return `(${nestedStatement})`
-        }
-
-    }).filter(Boolean)
-        // join all root statements with AND
-        .join(" and ")
-
-    if (statement) {
-        return 'where ' + statement
+  const keys = Object.keys(filters)
+  const filterTemplates = SQL_FILTER_TEMPLATES[table]
+  const _resolveTemplateToStatement = (dotKey: string): string | null => {
+    const template = filterTemplates[dotKey]
+    const value = get(filters, dotKey)
+    if (value !== undefined && typeof template === 'function') {
+      return template(value)
+    } else if (template === undefined) {
+      // resolve unknwon filters (possibly from filter overrides)
+      // no template, set a default
+      if (typeof value === 'string') {
+        return `${dotKey} = '${value}'`
+      } else {
+        return `${dotKey} = ${value}`
+      }
+    } else if (value === undefined && typeof template === 'function') {
+      return null
+    } else if (template && value === false) {
+      // template present, but value is false
+      return null
     } else {
-        return ''
+      return template
     }
+  }
+
+  const statement = keys
+    .map((rootKey) => {
+      if (typeof filters[rootKey] === 'object') {
+        // join all statements with an OR
+        const nestedStatements = getDotKeys(filters[rootKey] as Filters, rootKey)
+          .map(_resolveTemplateToStatement)
+          .filter(Boolean)
+
+        if (nestedStatements.length > 0) {
+          return `(${nestedStatements.join(' or ')})`
+        } else {
+          return null
+        }
+      } else {
+        const nestedStatement = _resolveTemplateToStatement(rootKey)
+        if (nestedStatement === null) return null
+        return `(${nestedStatement})`
+      }
+    })
+    .filter(Boolean)
+    // join all root statements with AND
+    .join(' and ')
+
+  if (statement) {
+    return 'where ' + statement
+  } else {
+    return ''
+  }
 }
 
 export const genDefaultQuery = (table: LogsTableName, filters: Filters) => {
-    const where = _genWhereStatement(table, filters)
+  const where = _genWhereStatement(table, filters)
 
-    switch (table) {
-        case 'edge_logs':
-            return `select id, timestamp, event_message, metadata, request, response, request.method, request.path, response.status_code
+  switch (table) {
+    case 'edge_logs':
+      return `select id, timestamp, event_message, metadata, request, response, request.method, request.path, response.status_code
   from ${table}
   cross join unnest(metadata) as m
   cross join unnest(m.request) as request
@@ -100,27 +111,27 @@ export const genDefaultQuery = (table: LogsTableName, filters: Filters) => {
   ${where}
   limit 100
   `
-            break
+      break
 
-        case 'postgres_logs':
-            return `select postgres_logs.timestamp, id, event_message, metadata, metadataparsed.error_severity from ${table} 
+    case 'postgres_logs':
+      return `select postgres_logs.timestamp, id, event_message, metadata, metadataparsed.error_severity from ${table} 
   cross join unnest(metadata) as m 
   cross join unnest(m.parsed) as metadataparsed 
   ${where} 
   limit 100
   `
-            break
+      break
 
-        case 'function_logs':
-            return `select id, ${table}.timestamp, event_message, metadata.event_type, metadata.function_id, metadata.level, metadata from ${table}
+    case 'function_logs':
+      return `select id, ${table}.timestamp, event_message, metadata.event_type, metadata.function_id, metadata.level, metadata from ${table}
   cross join unnest(metadata) as metadata
   ${where}
   limit 100
     `
-            break
+      break
 
-        case 'function_edge_logs':
-            return `select id, ${table}.timestamp, event_message, response.status_code, response, request, request.method, m.function_id, m.execution_time_ms, m.deployment_id, m.version from ${table} 
+    case 'function_edge_logs':
+      return `select id, ${table}.timestamp, event_message, response.status_code, response, request, request.method, m.function_id, m.execution_time_ms, m.deployment_id, m.version from ${table} 
   cross join unnest(metadata) as m
   cross join unnest(m.response) as response
   cross join unnest(m.request) as request
@@ -128,8 +139,8 @@ export const genDefaultQuery = (table: LogsTableName, filters: Filters) => {
   limit 100
   `
 
-        default:
-            return ""
-            break
-    }
+    default:
+      return ''
+      break
+  }
 }

--- a/studio/tests/pages/projects/Logs.utils.test.js
+++ b/studio/tests/pages/projects/Logs.utils.test.js
@@ -14,7 +14,6 @@ describe.each(Object.values(LogsTableName))('%s', (table) => {
     }
   })
   const [root, child] = (stringTemplateKey || '').split('.')
-  console.log(stringTemplateKey, templates[stringTemplateKey])
   describe.each([
     { filter: { search_query: '' } },
     { filter: { search_query: undefined } },
@@ -45,8 +44,9 @@ describe.each(Object.values(LogsTableName))('%s', (table) => {
     ...(stringTemplateKey
       ? [
           {
-            filter: { [root]: { [child]: false } },
+            filter: { search_query: 'some-search-query', [root]: { [child]: false } },
             excludes: [templates[stringTemplateKey], '()'],
+            contains: ['some-search-query'],
           },
         ]
       : []),

--- a/studio/tests/pages/projects/Logs.utils.test.js
+++ b/studio/tests/pages/projects/Logs.utils.test.js
@@ -46,7 +46,7 @@ describe.each(Object.values(LogsTableName))('%s', (table) => {
       ? [
           {
             filter: { [root]: { [child]: false } },
-            excludes: [root, child, stringTemplateKey, templates[stringTemplateKey], '()'],
+            excludes: [templates[stringTemplateKey], '()'],
           },
         ]
       : []),
@@ -57,9 +57,6 @@ describe.each(Object.values(LogsTableName))('%s', (table) => {
       expect(generated).not.toMatch(/function[ A-Za-z_-]+\(.+\).+\{.+return.+\}/)
       expect(generated).not.toMatch(/\=\>|\$\{.+\}/)
       expect(generated).not.toContain('return')
-      if (stringTemplateKey) {
-        console.log(generated)
-      }
       contains.forEach((str) => expect(generated).toContain(str))
       excludes.forEach((str) => expect(generated).not.toContain(str))
     })


### PR DESCRIPTION
Fixes the instance when filter is toggled on and off, resulting in the following error. 


<img width="642" alt="image" src="https://user-images.githubusercontent.com/22714384/163603182-25f96745-9a46-4f29-91b6-7d372c222a80.png">

Error results from query building when nested queries are by default wrapped with a `()`, resulting in `... where () limit 100`. 

Additional test case has been added to query builder.