### PR TITLE
Fix Discord link in Twitter Social Proof section

### DIFF
--- a/www/components/Sections/TwitterSocialProof.tsx
+++ b/www/components/Sections/TwitterSocialProof.tsx
@@ -48,7 +48,7 @@ function TwitterSocialProof() {
                 GitHub discussions
               </Button>
             </Link>
-            <Link href={'https://github.com/supabase/supabase/discussions'} passHref>
+            <Link href={'https://discord.supabase.com/'} passHref>
               <Button
                 as="a"
                 type="default"


### PR DESCRIPTION
## What kind of change does this PR introduce?

This fixes the Discord link in the Twitter Social Proof section. It currently points to GitHub discussions.