### PR TITLE
Fix: www website icons

### DIFF
--- a/www/components/Sections/GithubExamples.tsx
+++ b/www/components/Sections/GithubExamples.tsx
@@ -100,15 +100,11 @@ function GithubExamples() {
               )
             })}
             <div className="container mx-auto hidden md:flex flex-row justify-between mt-3">
-              <div ref={prevRef} className="cursor-pointer ml-4">
-                <p>
-                  <IconArrowLeft />
-                </p>
+              <div ref={prevRef} className="cursor-pointer ml-4 p">
+                <IconArrowLeft />
               </div>
-              <div ref={nextRef} className="cursor-pointer mr-4">
-                <p>
-                  <IconArrowRight />
-                </p>
+              <div ref={nextRef} className="cursor-pointer mr-4 p">
+                <IconArrowRight />
               </div>
             </div>
           </Swiper>

--- a/www/pages/database/Database.tsx
+++ b/www/pages/database/Database.tsx
@@ -101,7 +101,7 @@ function Database() {
         <SectionContainer>
           <div className="grid grid-cols-12">
             <div className="mb-10 lg:mb-0 col-span-12 lg:col-span-3">
-              <div className="mb-4 flex items-center space-x-2">
+              <div className="mb-4 flex items-center space-x-2 p">
                 <ProductIcon icon={Solutions['database'].icon} />
                 <IconX />
                 <div className="w-fit flex items-center">
@@ -119,7 +119,7 @@ function Database() {
               </p>
             </div>
             <div className="mb-10 lg:mb-0 col-span-12 lg:col-span-3 lg:col-start-5">
-              <div className="mb-4 flex items-center space-x-2">
+              <div className="mb-4 flex items-center space-x-2 p">
                 <ProductIcon icon={Solutions['database'].icon} />
                 <IconX />
                 <ProductIcon icon={Solutions['authentication'].icon} />
@@ -133,7 +133,7 @@ function Database() {
               </p>
             </div>
             <div className="col-span-12 lg:col-span-3 lg:col-start-9">
-              <div className="mb-4 flex items-center space-x-2">
+              <div className="mb-4 flex items-center space-x-2 p">
                 <ProductIcon icon={Solutions['database'].icon} />
                 <IconX />
                 <ProductIcon icon={'M13 10V3L4 14h7v7l9-11h-7z'} />

--- a/www/pages/storage/Storage.tsx
+++ b/www/pages/storage/Storage.tsx
@@ -82,7 +82,7 @@ function StoragePage() {
         <SectionContainer>
           <div className="grid grid-cols-12">
             <div className="mb-10 lg:mb-0 col-span-12 lg:col-span-3">
-              <div className="mb-4 flex items-center space-x-2">
+              <div className="mb-4 flex items-center space-x-2 p">
                 <ProductIcon icon={Solutions['storage'].icon} />
                 <IconX />
                 <ProductIcon icon={Solutions['authentication'].icon} />


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix icons around the www website just like #6410

## What is the current behavior?

<img width="1057" alt="Screen Shot 2022-04-15 at 7 25 37 PM" src="https://user-images.githubusercontent.com/70828596/163652157-37f2975d-aab9-4b6c-a4fe-0362d781b228.png">

## What is the new behavior?

<img width="1039" alt="Screen Shot 2022-04-15 at 7 25 49 PM" src="https://user-images.githubusercontent.com/70828596/163652175-97efe777-a571-4bf1-aaa1-bb8bbfa2152e.png">