### PR TITLE
Fix: button size

### DIFF
--- a/www/components/ExampleCard.tsx
+++ b/www/components/ExampleCard.tsx
@@ -56,7 +56,7 @@ function ExampleCard(props: any) {
           <div className="flex gap-2 items-center mt-3">
             {props.vercel_deploy_url && (
               <a target="_blank" href={props.vercel_deploy_url}>
-                <img src="https://vercel.com/button" />
+                <img className="h-6" src="https://vercel.com/button" />
               </a>
             )}
             {props.demo_url && (


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix button size

## What is the current behavior?

<img width="1143" alt="Screen Shot 2022-04-16 at 2 18 32 PM" src="https://user-images.githubusercontent.com/70828596/163686859-6ec1569b-968b-4568-9364-a40508d32b8c.png">

## What is the new behavior?

<img width="1143" alt="Screen Shot 2022-04-16 at 2 18 48 PM" src="https://user-images.githubusercontent.com/70828596/163686848-9367feac-b15b-4551-8071-6a4ee12873e7.png">

## Additional context

Add any other context or screenshots.
