### PR TITLE
Update storage.mdx

### DIFF
--- a/web/docs/guides/storage.mdx
+++ b/web/docs/guides/storage.mdx
@@ -313,7 +313,7 @@ helper method returns the full public URL for an asset. This calls the `/object/
 
 <details> 
 <summary>Advanced: reverse proxy</summary>
-The URLs returned are proxied through the API Proxy. They are suffixed by <code>/storage/v1</code>. 
+The URLs returned are proxied through the API Proxy. They are prefixed by <code>/storage/v1</code>. 
 
 For example, on the hosted Platform they will be 
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix to storage docs

## What is the current behavior?

Docs say that URL is "suffixed" by `/storage/v1` whereas the example suggest that it is rather prefixed by that.

## What is the new behavior?

`suffixed` -> `prefixed`

## Additional context

None
