### PR TITLE
Feat: hide example projects and client libraries

### DIFF
--- a/studio/pages/account/me.tsx
+++ b/studio/pages/account/me.tsx
@@ -1,6 +1,6 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { observer } from 'mobx-react-lite'
-import { IconMoon, IconSun, Typography, Input, Listbox } from '@supabase/ui'
+import { IconMoon, IconSun, Typography, Input, Listbox, Toggle } from '@supabase/ui'
 
 import { useProfile, useStore, withAuth } from 'hooks'
 import { post } from 'lib/common/fetch'
@@ -98,6 +98,7 @@ const GithubProfile = observer(() => {
             disabled
             label="Username"
             layout="horizontal"
+            className="items-center"
             value={ui.profile?.username ?? ''}
           />
           <Input
@@ -105,6 +106,7 @@ const GithubProfile = observer(() => {
             disabled
             label="Email"
             layout="horizontal"
+            className="items-center"
             value={ui.profile?.primary_email ?? ''}
           />
         </div>
@@ -116,15 +118,36 @@ const GithubProfile = observer(() => {
 const ThemeSettings = observer(() => {
   const { ui } = useStore()
 
+  const [exampleProject, setExampleProject] = useState<string>('show')
+  const [clientLibraries, setClientLibraries] = useState<string>('show')
+
+  const toggleExampleProject = () => {
+    if (exampleProject === 'show') {
+      setExampleProject('hide')
+    } else {
+      setExampleProject('show')
+    }
+    localStorage.setItem('supabaseExampleProject', exampleProject)
+  }
+
+  const toggleClientLibraries = () => {
+    if (clientLibraries === 'show') {
+      setClientLibraries('hide')
+    } else {
+      setClientLibraries('show')
+    }
+    localStorage.setItem('supabaseClientLibraries', exampleProject)
+  }
+
   return (
     <Panel
       title={[
         <Typography.Title key="panel-title" level={5}>
-          Theme
+          Dashboard UI
         </Typography.Title>,
       ]}
     >
-      <Panel.Content>
+      <Panel.Content className="space-y-6">
         <Listbox
           value={ui.themeOption}
           label="Interface theme"
@@ -150,6 +173,14 @@ const ThemeSettings = observer(() => {
             Light
           </Listbox.Option>
         </Listbox>
+        <div className="text-scale-1100 text-sm flex justify-between items-center" style={{ width: '40%' }}>
+          <span>Client Libraries</span>
+          <Toggle checked={exampleProject === 'show' ? true : false} onChange={() => toggleClientLibraries()} />
+        </div>
+        <div className="text-scale-1100 text-sm flex justify-between items-center" style={{ width: '40%' }}>
+          <span>Example Projects</span>
+          <Toggle checked={exampleProject === 'show' ? true : false} onChange={() => toggleExampleProject()} />
+        </div>
       </Panel.Content>
     </Panel>
   )

--- a/studio/pages/project/[ref]/index.tsx
+++ b/studio/pages/project/[ref]/index.tsx
@@ -17,6 +17,9 @@ const Home: NextPage = () => {
       ? project?.name
       : 'Welcome to your project'
 
+  const SHOW_EXAMPLE_PROJECTS = localStorage.getItem('supabaseExampleProject')
+  const SHOW_CLIENT_LIBRARIES = localStorage.getItem('supabaseClientLibrary')
+
   return (
     <BaseLayout>
       <div className="max-w-7xl mx-auto w-full my-16 space-y-16">
@@ -24,26 +27,34 @@ const Home: NextPage = () => {
           <h1 className="text-3xl">{projectName}</h1>
         </div>
         {IS_PLATFORM && <ProjectUsageSection />}
-        <div className="space-y-8">
-          <div className="mx-6">
-            <Typography.Title level={4}>Client libraries</Typography.Title>
+        {SHOW_CLIENT_LIBRARIES === 'show' ? (
+          <div className="space-y-8">
+            <div className="mx-6">
+              <Typography.Title level={4}>Client libraries</Typography.Title>
+            </div>
+            <div className="mx-6 grid md:grid-cols-3 gap-12 mb-12">
+              {CLIENT_LIBRARIES.map((library) => (
+                <ClientLibrary key={library.language} {...library} />
+              ))}
+            </div>
           </div>
-          <div className="mx-6 grid md:grid-cols-3 gap-12 mb-12">
-            {CLIENT_LIBRARIES.map((library) => (
-              <ClientLibrary key={library.language} {...library} />
-            ))}
+        ) : (
+          <div className="sr-only">hide example projects</div>
+        )}
+        {SHOW_EXAMPLE_PROJECTS === 'show' ? (
+          <div className="space-y-8">
+            <div className="mx-6">
+              <Typography.Title level={4}>Example projects</Typography.Title>
+            </div>
+            <div className="mx-6 grid md:grid-cols-2 lg:grid-cols-3 gap-8">
+              {EXAMPLE_PROJECTS.map((project) => (
+                <ExampleProject key={project.url} {...project} />
+              ))}
+            </div>
           </div>
-        </div>
-        <div className="space-y-8">
-          <div className="mx-6">
-            <Typography.Title level={4}>Example projects</Typography.Title>
-          </div>
-          <div className="mx-6 grid md:grid-cols-2 lg:grid-cols-3 gap-8">
-            {EXAMPLE_PROJECTS.map((project) => (
-              <ExampleProject key={project.url} {...project} />
-            ))}
-          </div>
-        </div>
+        ) : (
+          <div className="sr-only">hide example projects</div>
+        )}
       </div>
     </BaseLayout>
   )


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature to hide and show the example projects and client libraries on the dashboard as requested [here](https://supabase.slack.com/archives/CSMGA08FP/p1647617692337579).

## What is the current behavior?

<img width="1280" alt="Screen Shot 2022-04-18 at 11 48 25 PM" src="https://user-images.githubusercontent.com/70828596/163916623-cc48e667-49d6-4887-a884-a6915c5aa767.png">

<img width="885" alt="Screen Shot 2022-04-18 at 11 28 36 PM" src="https://user-images.githubusercontent.com/70828596/163916012-21975bd4-b111-477a-948b-7f1709fe232e.png">

## What is the new behavior?

For example, I choose to hide the client libraries.

<img width="1280" alt="Screen Shot 2022-04-18 at 11 50 29 PM" src="https://user-images.githubusercontent.com/70828596/163916648-e965a519-2d6b-40e8-8917-5053a94345f5.png">

<img width="805" alt="Screen Shot 2022-04-18 at 11 28 12 PM" src="https://user-images.githubusercontent.com/70828596/163916031-ae029d98-ab41-4839-97cd-6b47c27d1126.png">

## Additional context

https://supabase.slack.com/archives/CSMGA08FP/p1647617692337579