### PR TITLE
fix/logs: Add K display for new logs count values over 1000

### DIFF
--- a/studio/components/interfaces/Settings/Logs/PreviewFilterPanel.tsx
+++ b/studio/components/interfaces/Settings/Logs/PreviewFilterPanel.tsx
@@ -84,7 +84,7 @@ const PreviewFilterPanel: FC<Props> = ({
             >
               <div className="absolute z-20">
                 <Typography.Text style={{ fontSize: '0.6rem' }} className="opacity-80">
-                  {newCount}
+                  {newCount > 1000 ? `${Math.floor(newCount / 100) / 10}K` : newCount}
                 </Typography.Text>
               </div>
               <div className="bg-green-800 rounded-full w-full h-full animate-ping opacity-60"></div>

--- a/studio/tests/pages/projects/PreviewFilterPanel.test.js
+++ b/studio/tests/pages/projects/PreviewFilterPanel.test.js
@@ -93,3 +93,11 @@ test.todo('timestamp to/from filter value change')
 //   await screen.findByText('Custom')
 //   await screen.findByTitle(/Clear timestamp filter/)
 // })
+
+
+
+test('shortened count to K', async () => {
+  render(<PreviewFilterPanel newCount={1234} />)
+  await screen.findByText(/1\.2K/)
+})
+


### PR DESCRIPTION
Fixes for [this ticket](https://www.notion.so/supabase/Logs-Previewer-new-items-count-should-shorter-to-K-if-more-than-a-few-thousand-events-3d39984fee57413ea561470cd35b0f09)

fix for:
![image](https://user-images.githubusercontent.com/22714384/164283853-9ecd4ed1-6314-4897-9f2f-b70664041974.png)

Shortens value over 1000 with a K, so 1255 will be shortened to 1.2K