### PR TITLE
Add CTA to contact us for Enterprise plan

### DIFF
--- a/studio/components/interfaces/Home/Landing.tsx
+++ b/studio/components/interfaces/Home/Landing.tsx
@@ -78,14 +78,14 @@ const Landing = () => {
                 Docs
               </Button>
             </Link>
-            <p className="text-scale-1100 text-base sm:max-w-2xl sm:mx-auto md:mt-5 mb-10">
-              Ready to talk with us about our pay-as-you-go Enterprise plan?
+          </div>
+          <div className="sm:text-center">
+            <p className="text-scale-900 text-base sm:max-w-2xl sm:mx-auto md:mt-20 mb-5">
+              Ready to learn about our pay-as-you-go Enterprise plan?
             </p>
-            <Link href="https://supabase.com/contact/enterprise">
-              <Button size="medium" type="default">
-                Let's talk!
-              </Button>
-            </Link>
+              <Link href="https://supabase.com/contact/enterprise">
+                  Let's talk!
+              </Link>
           </div>
         </div>
       </div>

--- a/studio/components/interfaces/Home/Landing.tsx
+++ b/studio/components/interfaces/Home/Landing.tsx
@@ -78,6 +78,14 @@ const Landing = () => {
                 Docs
               </Button>
             </Link>
+            <p className="text-scale-1100 text-base sm:max-w-2xl sm:mx-auto md:mt-5 mb-10">
+              Ready to talk with us about our pay-as-you-go Enterprise plan?
+            </p>
+            <Link href="https://supabase.com/contact/enterprise">
+              <Button size="medium" type="default">
+                Let's talk!
+              </Button>
+            </Link>
           </div>
         </div>
       </div>

--- a/studio/components/interfaces/Home/Landing.tsx
+++ b/studio/components/interfaces/Home/Landing.tsx
@@ -83,9 +83,7 @@ const Landing = () => {
             <p className="text-scale-900 text-base sm:max-w-2xl sm:mx-auto md:mt-20 mb-5">
               Ready to learn about our pay-as-you-go Enterprise plan?
             </p>
-              <Link href="https://supabase.com/contact/enterprise">
-                  Let's talk!
-              </Link>
+            <Link href="https://supabase.com/contact/enterprise">Let's talk!</Link>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Chore update adding CTA to Enterprise contact form from logged out app homepage.

## What is the current behavior?

There are two CTAs now, one to sign up and one to visit docs. 
## What is the new behavior?

This adds a third button pointing to Enterprise contact form.

## Additional context

This is the first update to add Enterprise CTA in strategic spots of app and supabase.com
