### PR TITLE
fix/logs: null formatting in logs explorer

### DIFF
--- a/studio/components/interfaces/Settings/Logs/LogSelectionRenderers/DefaultSelectionRenderer.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogSelectionRenderers/DefaultSelectionRenderer.tsx
@@ -14,7 +14,11 @@ const DefaultSelectionRenderer = ({ log }: any) => {
     return (
       <div className="grid grid-cols-12">
         <span className="text-scale-900 text-sm col-span-4 whitespace-prep-wrap">{label}</span>
-        <span className={`text-scale-1200 text-sm col-span-8 whitespace-prep-wrap ${code && 'text-xs font-mono'}`}>
+        <span
+          className={`text-scale-1200 text-sm col-span-8 whitespace-prep-wrap ${
+            code && 'text-xs font-mono'
+          }`}
+        >
           {value}
         </span>
       </div>
@@ -59,7 +63,7 @@ const DefaultSelectionRenderer = ({ log }: any) => {
             {value && typeof value === 'object' ? (
               <DetailedJsonRow label={key} value={value} />
             ) : (
-              <DetailedRow label={key} value={String(value)} />
+              <DetailedRow label={key} value={value === null ? 'NULL ' : String(value)} />
             )}
           </div>
         )

--- a/studio/components/interfaces/Settings/Logs/LogTable.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogTable.tsx
@@ -23,6 +23,24 @@ interface Props {
 }
 type LogMap = { [id: string]: LogData }
 
+interface FormatterArg {
+  column: {
+    key: string
+    name: string
+    resizable: boolean
+    header: string
+    minWidth: number
+    idx: number
+    frozen: boolean
+    isLastFrozenColumn: boolean
+    rowGroup: boolean
+    sortable: boolean
+  }
+  isCellSelected: boolean
+  onRowChange: Function
+  row: any
+}
+
 /**
  * Logs table view with focus side panel
  *
@@ -44,10 +62,16 @@ const LogTable = ({
 
   const DEFAULT_COLUMNS = columnNames.map((v) => {
     let formatter = undefined
-    const firstRow: any = data[0]
-    const value = firstRow?.[v]
-    if (typeof value === 'object') {
-      formatter = () => `[Object]`
+
+    formatter = (received: FormatterArg) => {
+      const value = received.row?.[v]
+      if (value && typeof value === 'object') {
+        return `[Object]`
+      } else if (value === null) {
+        return 'NULL'
+      } else {
+        return String(value)
+      }
     }
     return { key: v, name: v, resizable: true, formatter, header: v, minWidth: 128 }
   })


### PR DESCRIPTION
Fixes rendering bug of null values, which were being shown as `[Object]` or not being shown at all, instead of `NULL`.

<img width="618" alt="Screenshot 2022-04-25 at 11 54 24 PM" src="https://user-images.githubusercontent.com/22714384/165181573-a94d5cfb-19fe-421e-976b-4da99cf264db.png">

ref: https://www.notion.so/supabase/LogTable-null-should-not-be-shown-as-Object-74d7843014104161944b32a0ea53c57b

