### PR TITLE
fix/logs: fixes the handling of the run query command through monaco

### DIFF
--- a/studio/components/interfaces/Settings/Logs/LogsQueryPanel.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogsQueryPanel.tsx
@@ -18,12 +18,13 @@ import {
 } from '.'
 import DatePickers from './Logs.DatePickers'
 import Link from 'next/link'
+import React from 'react'
 
 interface Props {
   templates?: LogTemplate[]
   onSelectTemplate: (template: LogTemplate) => void
   onSelectSource: (source: LogsTableName) => void
-  onRun: () => void
+  onRun: (e: React.MouseEvent<HTMLButtonElement>) => void
   onClear: () => void
   onSave?: () => void
   hasEditorValue: boolean

--- a/studio/pages/project/[ref]/logs-explorer/index.tsx
+++ b/studio/pages/project/[ref]/logs-explorer/index.tsx
@@ -74,12 +74,16 @@ export const LogsExplorerPage: NextPage = () => {
     })
   }
 
-  const handleRun = () => {
-    changeQuery(editorValue)
+  const handleRun = (value?: string) => {
+    const query = value || editorValue
+    if (value) {
+      setEditorValue(value)
+    }
+    changeQuery(query)
     runQuery()
     router.push({
       pathname: router.pathname,
-      query: { ...router.query, q: editorValue },
+      query: { ...router.query, q: query },
     })
   }
 

--- a/studio/pages/project/[ref]/logs-explorer/index.tsx
+++ b/studio/pages/project/[ref]/logs-explorer/index.tsx
@@ -74,9 +74,9 @@ export const LogsExplorerPage: NextPage = () => {
     })
   }
 
-  const handleRun = (value?: string) => {
-    const query = value || editorValue
-    if (value) {
+  const handleRun = (value?: string | React.MouseEvent<HTMLButtonElement>) => {
+    const query  = typeof value === 'string' ? (value || editorValue) : editorValue
+    if (value && typeof value === 'string') {
       setEditorValue(value)
     }
     changeQuery(query)

--- a/studio/tests/pages/projects/logs-query.test.js
+++ b/studio/tests/pages/projects/logs-query.test.js
@@ -154,8 +154,11 @@ test('custom sql querying', async () => {
   // type new query
   userEvent.type(editor, 'select \ncount(*) as my_count \nfrom edge_logs')
 
-  // should trigger query
+  // run query by button
   userEvent.click(await screen.findByText('Run'))
+  
+  // run query by editor
+  userEvent.type(editor, '\nlimit 123{ctrl}{enter}')
   await waitFor(
     () => {
       expect(get).toHaveBeenCalledWith(expect.stringContaining(encodeURI('\n')))
@@ -163,9 +166,11 @@ test('custom sql querying', async () => {
       expect(get).toHaveBeenCalledWith(expect.stringContaining('select'))
       expect(get).toHaveBeenCalledWith(expect.stringContaining('edge_logs'))
       expect(get).not.toHaveBeenCalledWith(expect.stringContaining('where'))
+      expect(get).not.toHaveBeenCalledWith(expect.stringContaining(encodeURIComponent("limit 123")))
     },
     { timeout: 1000 }
   )
+
 
   await screen.findByText(/my_count/) //column header
   const rowValue = await screen.findByText(/12345/) // row value


### PR DESCRIPTION
Able to press `cmd` + `enter` to run a query, which is the expected behaviour across our sql editors.

<img width="1049" alt="image" src="https://user-images.githubusercontent.com/22714384/165190131-0ede48e7-47c3-4c86-9500-fdc7075cd883.png">


ref: https://www.notion.so/supabase/LogsExplorer-Run-Query-in-context-menu-does-not-trigger-Run-https-github-com-supabase-supabase-pu-9fdda329e77641de8dc51809200351f0