### PR TITLE
fix: remove deprecated docusaurus config option 'colorMode.switchConfig'

### DIFF
--- a/web/docusaurus.config.js
+++ b/web/docusaurus.config.js
@@ -25,19 +25,6 @@ module.exports = {
       // Should we use the prefers-color-scheme media-query,
       // using user system preferences, instead of the hardcoded defaultMode
       respectPrefersColorScheme: false,
-
-      // Dark/light switch icon options
-      switchConfig: {
-        // Icon for the switch while in dark mode
-        darkIcon: '  ',
-        darkIconStyle: {
-          marginTop: '1px',
-        },
-        lightIcon: '  ',
-        lightIconStyle: {
-          marginTop: '1px',
-        },
-      },
     },
     algolia: {
       appId: 'W4BIZ4FKU9',


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix:  As mentioned [here](https://github.com/facebook/docusaurus/pull/6771), colorMode.switchConfig is deprecated.

[Issue-6570](https://github.com/supabase/supabase/issues/6570)

## What is the current behavior?

Docusaurus build error explained in [Issue-6570](https://github.com/supabase/supabase/issues/6570)

## What is the new behavior?

Theme Switcher is now displayed by an "icon-button".

**Before:**
![before](https://user-images.githubusercontent.com/32964262/165369372-1c03d2a9-f576-4aad-8f14-a28537104c3a.png)

**After:**
![after](https://user-images.githubusercontent.com/32964262/165369397-d0913579-d40e-45c6-b1ec-8d47b233c305.png)
