### PR TITLE
Feat/quota billing

### DIFF
--- a/studio/components/interfaces/Home/ProjectUsage.tsx
+++ b/studio/components/interfaces/Home/ProjectUsage.tsx
@@ -231,7 +231,6 @@ const ProjectUsage: FC<Props> = ({ project }) => {
                     isLoading={!charts && !error ? true : false}
                     onBarClick={(v) => handleBarClick(v, '/realtime')}
                   />
-                  <div className="py-[1.64rem]" />
                 </Panel.Content>
               </Panel>
             </div>

--- a/studio/components/to-be-cleaned/Usage.tsx
+++ b/studio/components/to-be-cleaned/Usage.tsx
@@ -272,6 +272,10 @@ export const ProjectUsageMinimal: FC<any> = ({ projectRef, subscription_id, filt
   const { data: stats, error: usageError } = useSWR(`${API_URL}/projects/${projectRef}/usage`, get)
   const { subscription, isLoading: loading, error } = useProjectSubscription(projectRef)
 
+  if (subscription?.tier?.supabase_prod_id === PRICING_TIER_PRODUCT_IDS.PAYG) {
+    return <></>
+  }
+
   const tier =
     subscription?.tier?.supabase_prod_id === PRICING_TIER_PRODUCT_IDS.PRO ? 'pro' : 'free'
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

PAYG users will no longer see 'usage spark charts' on the homepage

Pro (with no spend cap):
<img width="1380" alt="Screenshot 2022-04-27 at 12 12 34 PM" src="https://user-images.githubusercontent.com/8291514/165439067-d1c54815-bfe9-4e91-b240-be32db48f863.png">

Pro (with spend cap):
<img width="1597" alt="Screenshot 2022-04-27 at 12 12 59 PM" src="https://user-images.githubusercontent.com/8291514/165439107-d6895668-b713-4056-ad7b-99f16698097b.png">

Future considerations:
layout of charts obviously looks quite bad, would need refining.
This PR is more of a quicker fix to make sure we are displaying the correct usage/caps for different subscription tiers.

