### PR TITLE
changed the pricing link

### DIFF
--- a/web/docs/faq.md
+++ b/web/docs/faq.md
@@ -10,7 +10,7 @@ Choose the support channel relevant for your situation here: [supabase.com/suppo
 
 ### How much does it cost?
 
-Self-hosting Supabase is free. If you wish to use our cloud-platform, we provide [simple, predictable pricing](/pricing).
+Self-hosting Supabase is free. If you wish to use our cloud-platform, we provide [simple, predictable pricing](https://supabase.com/pricing).
 
 ### How do I host Supabase?
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The current pricing link in the FAQ does not go to the pricing link. Linked with #6574 

## What is the new behavior?

The link now opens to https://supabase.com/pricing in a new tab.

