### PR TITLE
Fix: image link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 - [x] File Storage. [Docs](https://supabase.com/docs/guides/storage)
 - [x] Dashboard
 
-![Supabase Dashboard](https://raw.githubusercontent.com/supabase/supabase/master/www/public/images/github/supabase-dashboard.png)
+![Supabase Dashboard](https://raw.githubusercontent.com/supabase/supabase/master/apps/www/public/images/github/supabase-dashboard.png)
 
 ## Documentation
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix image link in readme.

## What is the current behavior?

<img width="1080" alt="Screen Shot 2022-04-28 at 12 56 09 AM" src="https://user-images.githubusercontent.com/70828596/165679423-cf0c8fdd-ed1c-4c23-be39-27ecafd5040b.png">

## What is the new behavior?

<img width="1080" alt="Screen Shot 2022-04-28 at 12 56 36 AM" src="https://user-images.githubusercontent.com/70828596/165679440-665e9df5-f654-4942-b404-e8b152e4cedd.png">