### PR TITLE
changed the example link in the storage guide

### DIFF
--- a/web/docs/guides/storage.mdx
+++ b/web/docs/guides/storage.mdx
@@ -30,7 +30,7 @@ keep all public files in a "public" bucket, and other files that require logged-
 ## Getting started
 
 This is a quick guide that shows the basic functionality of Supabase Storage. Find a full
-[example application in GitHub](https://github.com/supabase/supabase/edit/master/examples/nextjs-ts-user-management),
+[example application in GitHub](https://github.com/supabase/supabase/tree/master/examples/user-management/nextjs-ts-user-management),
 which you can deploy yourself.
 
 **Note before begin** : File, Folder, and Bucket names **must follow** [AWS Safe Characters naming guideline](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html) and avoid use of any other characters 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs Update

## What is the current behavior?

This is linked to issue #6590. The link is broken and you get a 404 error. 

## What is the new behavior?

The link has been changed to go [this](https://github.com/supabase/supabase/tree/master/examples/user-management/nextjs-ts-user-management) example
