### PR TITLE
edge terminal gap size changed on apps

### DIFF
--- a/apps/www/pages/edge-functions/edge-functions.tsx
+++ b/apps/www/pages/edge-functions/edge-functions.tsx
@@ -159,7 +159,7 @@ function Database() {
 
         <SectionContainer>
           <div className="col-span-12 mb-10 space-y-12 lg:col-span-3 lg:mb-0 ">
-            <div className="grid items-center gap-6 lg:grid-cols-12 lg:gap-32">
+            <div className="grid items-center gap-6 lg:grid-cols-12 lg:gap-16">
               <div className="flex flex-col gap-8 lg:col-span-5">
                 <div>
                   <h3 className="h3">Anatomy of an Edge Function</h3>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

fixes #6401.

## What is the new behavior?

The overflow is now gone and aligned:

<img width="1438" alt="Screenshot 2022-04-11 at 12 36 52" src="https://user-images.githubusercontent.com/22655069/162731676-2f6dc4f0-f807-48d8-8e6a-4d11a37cc782.png">

## Additional context

This is a new pull request, original pull request is #6402 
