### PR TITLE
fix issue in studio with uploading csvs from windows

### DIFF
--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/SpreadsheetImport/SpreadsheetImport.constants.ts
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/SpreadsheetImport/SpreadsheetImport.constants.ts
@@ -3,6 +3,7 @@ import { SpreadsheetData } from './SpreadsheetImport.types'
 export const UPLOAD_FILE_TYPES = [
   'text/csv',
   'text/tab-separated-values',
+  'application/vnd.ms-excel',
   'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
 ]
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Currently CSV files are not able to be uploaded from Windows machines
Relevant issue here: #6012 

## What is the new behavior?

CSV uploads are now possible from Windows

## Additional context

Additional discussion [here](https://github.com/supabase/supabase/discussions/5953)
