### PR TITLE
Fixing docker-compose Kong Volumes

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       KONG_DNS_ORDER: LAST,A,CNAME
       KONG_PLUGINS: request-transformer,cors,key-auth,acl
     volumes:
-      - ./volumes/api/kong.yml:/var/lib/kong/kong.yml
+      - ./volumes/api:/var/lib/kong
 
   auth:
     container_name: supabase-auth


### PR DESCRIPTION
Docker Kong wouldn't start as the kong.yml file was created as a directory.  
This should reference the directory not the config file

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Kong doesn't start ( #6423 )

## What is the new behavior?

Kong container can now correctly reference the the volume and find the file `kong.yml` inside

## Additional context

None
