### PR TITLE
example links updated

### DIFF
--- a/web/docs/guides/examples.mdx
+++ b/web/docs/guides/examples.mdx
@@ -58,23 +58,23 @@ By [Fireship](https://www.youtube.com/watch?v=WiwfiVdfRIc).
 
 Build a basic Todo List with Supabase and your favorite frontend framework:
 
-- [Expo Todo List.](https://github.com/supabase/supabase/tree/master/examples/expo-todo-list)
-- [Next.js Todo List.](https://github.com/supabase/supabase/tree/master/examples/nextjs-todo-list)
-- [React Todo List.](https://github.com/supabase/supabase/tree/master/examples/react-todo-list)
-- [Svelte Todo List.](https://github.com/supabase/supabase/tree/master/examples/sveltejs-todo-list)
-- [Vue 3 Todo List (Typescript).](https://github.com/supabase/supabase/tree/master/examples/vue3-ts-todo-list)
-- [Angular Todo List.](https://github.com/supabase/supabase/tree/master/examples/angular-todo-list)
+- [Expo Todo List.](https://github.com/supabase/supabase/tree/master/examples/todo-list/expo-todo-list)
+- [Next.js Todo List.](https://github.com/supabase/supabase/tree/master/examples/todo-list/nextjs-todo-list)
+- [React Todo List.](https://github.com/supabase/supabase/tree/master/examples/todo-list/react-todo-list)
+- [Svelte Todo List.](https://github.com/supabase/supabase/tree/master/examples/todo-list/sveltejs-todo-list)
+- [Vue 3 Todo List (Typescript).](https://github.com/supabase/supabase/tree/master/examples/todo-list/vue3-ts-todo-list)
+- [Angular Todo List.](https://github.com/supabase/supabase/tree/master/examples/todo-list/angular-todo-list)
 - [Nuxt 3 Todo List.](https://github.com/nuxt-community/supabase-module/tree/main/demo)
 
 ### Auth examples
 
-- [Supabase Auth with vanilla JavaScript.](https://github.com/supabase/supabase/tree/master/examples/javascript-auth). Use Supabase without any frontend frameworks.
+- [Supabase Auth with vanilla JavaScript.](https://github.com/supabase/supabase/tree/master/examples/auth/javascript-auth). Use Supabase without any frontend frameworks.
 - [Supabase Auth with Next.js SSR.](https://github.com/supabase/supabase/tree/master/examples/nextjs-with-supabase-auth) Uses cookies to persist auth between the server and the client.
 - [Supabase Auth with RedwoodJS.](https://redwood-playground-auth.netlify.app/supabase) Try out Supabase authentication in the [RedwoodJS](https://redwoodjs.com) Authentication Playground complete with OAuth support and code samples.
 
 ### Collaborative
 
-- [Next.js Slack Clone.](https://github.com/supabase/supabase/tree/master/examples/nextjs-slack-clone)
+- [Next.js Slack Clone.](https://github.com/supabase/supabase/tree/master/examples/slack-clone/nextjs-slack-clone)
 
 ## Community
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

This is for #6590 

## What is the current behavior?

In the example [to-do lists](https://supabase.com/docs/guides/examples#todo-list), [auth](https://supabase.com/docs/guides/examples#auth-examples) and [slack clone](https://supabase.com/docs/guides/examples#collaborative) the links return a 404 page not displayed error.

## What is the new behavior?

The links are now showing the repository based on the example. 
