### PR TITLE
Fix statement in functions.mdx

### DIFF
--- a/web/docs/guides/database/functions.mdx
+++ b/web/docs/guides/database/functions.mdx
@@ -312,7 +312,7 @@ end;
 $$;
 ```
 
-It is best practice to use `security invoker` (which is also the default). If you ever use `security invoker`, you _must_ set the `search_path`. 
+It is best practice to use `security invoker` (which is also the default). If you ever use `security definer`, you _must_ set the `search_path`. 
 This limits the potential damage if you allow access to schemas which the user executing the function should not have.
 
 ## Resources


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs fix

## What is the current behavior?

Paragraph contains self-contradicting statement regarding 'security definer vs invoker'

## What is the new behavior?

Paragraph contains correct statement regarding 'security definer vs invoker'
