### PR TITLE
Update api.mdx to remove realtime limited to public schema note

### DIFF
--- a/web/docs/guides/api.mdx
+++ b/web/docs/guides/api.mdx
@@ -310,12 +310,6 @@ curl --request POST '<SUPABASE_URL>/graphql/v1' \
 
 By default Realtime is disabled on your database. Let's turn on Realtime for the `todos` table.
 
-:::note
-
-Realtime only works for tables in the public schema.
-
-:::
-
 <Tabs
 defaultValue="UI"
 values={[


### PR DESCRIPTION
remove note that realtime only works in public schema

## What kind of change does this PR introduce?

Document update

## What is the current behavior?

Document says realtime does not work with public schema

## What is the new behavior?

Remove that note

## Additional context

Add any other context or screenshots.
