### PR TITLE
globals.css link has been updated

### DIFF
--- a/web/docs/guides/with-nextjs.mdx
+++ b/web/docs/guides/with-nextjs.mdx
@@ -203,7 +203,7 @@ export const supabase = createClient(supabaseUrl, supabaseAnonKey)
 ```
 
 And one optional step is to update the CSS file `styles/globals.css` to make the app look nice. 
-You can find the full contents of this file [here](https://raw.githubusercontent.com/supabase/supabase/master/examples/react-user-management/src/index.css).
+You can find the full contents of this file [here](https://raw.githubusercontent.com/supabase/supabase/master/examples/user-management/nextjs-ts-user-management/styles/globals.css).
 
 ### Set up a Login component
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs Update

## What is the current behavior?

The [link](https://raw.githubusercontent.com/supabase/supabase/master/examples/react-user-management/src/index.css) to show the `globals.css` on the [Next JS Quickstart](https://supabase.com/docs/guides/with-nextjs#intro) returns a 404 error.

## What is the new behavior?

The link has been updated to show [this](https://raw.githubusercontent.com/supabase/supabase/master/examples/user-management/nextjs-ts-user-management/styles/globals.css)

## Additional context

This is linked to #6668 
