### PR TITLE
src/index.css link in the Quickstart: React documentation has been updated

### DIFF
--- a/web/docs/guides/with-react.mdx
+++ b/web/docs/guides/with-react.mdx
@@ -199,7 +199,7 @@ export const supabase = createClient(supabaseUrl, supabaseAnonKey)
 ```
 
 And one optional step is to update the CSS file `src/index.css` to make the app look nice.
-You can find the full contents of this file [here](https://raw.githubusercontent.com/supabase/supabase/master/examples/react-user-management/src/index.css).
+You can find the full contents of this file [here](https://raw.githubusercontent.com/supabase/supabase/master/examples/user-management/react-user-management/src/index.css).
 
 ### Set up a Login component
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

The [link](https://raw.githubusercontent.com/supabase/supabase/master/examples/react-user-management/src/index.css) to show `src/index.css` on the [Quickstart: React](https://supabase.com/docs/guides/with-react#building-the-app) returns a 404 error.

## What is the new behavior?

The link has been updated to show [this](https://raw.githubusercontent.com/supabase/supabase/master/examples/user-management/react-user-management/src/index.css)

## Additional context

This is linked to #6668 