### PR TITLE
Kotlin link updated

### DIFF
--- a/web/docs/guides/examples.mdx
+++ b/web/docs/guides/examples.mdx
@@ -88,7 +88,7 @@ Build a basic Todo List with Supabase and your favorite frontend framework:
 - Dart (in development): [GitHub](https://github.com/supabase/supabase-dart)
 - Python (in development): [GitHub](https://github.com/supabase/supabase-py)
 - C# (in development): [GitHub](https://github.com/supabase/supabase-csharp)
-- Kotlin (in development): [GitHub](https://github.com/supabase/supabase-kt)
+- Kotlin (in development): [GitHub](https://github.com/supabase-community/postgrest-kt)
 - `useSupabase`: Supabase React Hooks. [GitHub](https://github.com/gbibeaul/use-supabase)
 - `vue-supabase`: Supabase Vue wrapper. [GitHub](https://github.com/supabase/vue-supabase)
 - `vue-3-supabase`: Supabase Vue 3 wrapper. [GitHub](https://github.com/DidoMarchet/vue-3-supabase)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

In the [Example and Resources](https://supabase.com/docs/guides/examples#libraries) section under libraries, if you click on the Kotlin GitHub link you get a 404 error

## What is the new behavior?

The GitHub link is now linking to [this](https://github.com/supabase-community/postgrest-kt) respository.

Thankyou @kiwicopple for the pointer.

## Additional context

This is part of issue #6590 
