### PR TITLE
Chore/add payment modal error handling

### DIFF
--- a/studio/components/interfaces/Billing/AddNewPaymentMethodModal/AddNewPaymentMethodModal.tsx
+++ b/studio/components/interfaces/Billing/AddNewPaymentMethodModal/AddNewPaymentMethodModal.tsx
@@ -30,6 +30,15 @@ const AddNewPaymentMethodModal: FC<Props> = ({ visible, returnUrl, onCancel }) =
     setIntent(undefined)
     const orgSlug = ui.selectedOrganization?.slug ?? ''
     const intent = await post(`${API_URL}/organizations/${orgSlug}/payments/setup-intent`, {})
+
+    if (intent.error) {
+      return ui.setNotification({
+        category: 'error',
+        message: intent.error.message,
+        error: intent.error,
+      })
+    }
+
     setIntent(intent)
   }
 
@@ -47,13 +56,13 @@ const AddNewPaymentMethodModal: FC<Props> = ({ visible, returnUrl, onCancel }) =
       onCancel={onCancel}
       className="PAYMENT"
     >
-      <div className="py-4 space-y-4">
+      <div className="space-y-4 py-4">
         {intent !== undefined ? (
           <Elements stripe={stripePromise} options={options}>
             <AddPaymentMethodForm returnUrl={returnUrl} onCancel={onCancel} />
           </Elements>
         ) : (
-          <div className="w-full flex items-center justify-center py-20">
+          <div className="flex w-full items-center justify-center py-20">
             <IconLoader size={16} className="animate-spin" />
           </div>
         )}

--- a/studio/pages/project/[ref]/logs-explorer/index.tsx
+++ b/studio/pages/project/[ref]/logs-explorer/index.tsx
@@ -76,7 +76,7 @@ export const LogsExplorerPage: NextPage = () => {
   }
 
   const handleRun = (value?: string | React.MouseEvent<HTMLButtonElement>) => {
-    const query  = typeof value === 'string' ? (value || editorValue) : editorValue
+    const query = typeof value === 'string' ? value || editorValue : editorValue
     if (value && typeof value === 'string') {
       setEditorValue(value)
     }
@@ -87,7 +87,7 @@ export const LogsExplorerPage: NextPage = () => {
       query: { ...router.query, q: query },
     })
     content.addRecentLogSqlSnippet({
-      sql: query
+      sql: query,
     })
   }
 
@@ -120,8 +120,8 @@ export const LogsExplorerPage: NextPage = () => {
 
   return (
     <LogsExplorerLayout>
-      <div className="h-full flex flex-col flex-grow gap-4">
-        <div className="border rounded">
+      <div className="flex h-full flex-grow flex-col gap-4">
+        <div className="rounded border">
           <LogsQueryPanel
             defaultFrom={params.iso_timestamp_start || ''}
             defaultTo={params.iso_timestamp_end || ''}
@@ -137,7 +137,7 @@ export const LogsExplorerPage: NextPage = () => {
             warnings={warnings}
           />
 
-          <div className="min-h-[7rem] h-48">
+          <div className="h-48 min-h-[7rem]">
             <ShimmerLine active={isLoading} />
             <CodeEditor
               id={editorId}
@@ -148,13 +148,13 @@ export const LogsExplorerPage: NextPage = () => {
             />
           </div>
         </div>
-        <div className="flex flex-col flex-grow relative">
+        <div className="relative flex flex-grow flex-col">
           <LoadingOpacity active={isLoading}>
-            <div className="flex flex-grow h-full">
+            <div className="flex h-full flex-grow">
               <LogTable data={logData} error={error} />
             </div>
           </LoadingOpacity>
-          <div className="flex flex-row justify-end mt-2">
+          <div className="mt-2 flex flex-row justify-end">
             <UpgradePrompt projectRef={ref as string} from={params.iso_timestamp_start || ''} />
           </div>
         </div>
@@ -217,9 +217,9 @@ export const LogsExplorerPage: NextPage = () => {
                   </div>
                 </Modal.Content>
               </div>
-              <div className="bg-scale-300 py-3 border-t">
+              <div className="bg-scale-300 border-t py-3">
                 <Modal.Content>
-                  <div className="flex gap-2 items-center justify-end">
+                  <div className="flex items-center justify-end gap-2">
                     <Button size="tiny" type="default">
                       Cancel
                     </Button>

--- a/studio/stores/content/ProjectContentStore.ts
+++ b/studio/stores/content/ProjectContentStore.ts
@@ -160,7 +160,8 @@ export default class ProjectContentStore implements IProjectContentStore {
       return arr_filtered
     }
   }
-  public addRecentLogSqlSnippet(snippet: Partial<LogSqlSnippets.Content>) {
+
+  addRecentLogSqlSnippet(snippet: Partial<LogSqlSnippets.Content>) {
     if (typeof window === 'undefined') return
     const defaults: LogSqlSnippets.Content = {
       schema_version: '1',
@@ -174,7 +175,8 @@ export default class ProjectContentStore implements IProjectContentStore {
       JSON.stringify(this.recentLogSqlSnippets)
     )
   }
-  public clearRecentLogSqlSnippets() {
+
+  clearRecentLogSqlSnippets() {
     if (typeof window === 'undefined') return
     this.recentLogSqlSnippets = []
     ;(window as any).localStorage.setItem(this.recentLogSqlKey, JSON.stringify([]))

--- a/studio/tests/pages/projects/logs-query.test.js
+++ b/studio/tests/pages/projects/logs-query.test.js
@@ -43,7 +43,9 @@ jest.mock('hooks')
 import { useStore, useFlag } from 'hooks'
 useFlag.mockReturnValue(true)
 useStore.mockImplementation(() => ({
-  content: jest.fn(),
+  content: {
+    addRecentLogSqlSnippet: jest.fn(),
+  },
 }))
 
 jest.mock('hooks/queries/useProjectSubscription')
@@ -117,6 +119,7 @@ test('q= query param will populate the query input', async () => {
     expect(get).toHaveBeenCalledWith(expect.stringContaining('sql=some_query'))
   })
 })
+
 test('ite= and its= query param will populate the datepicker', async () => {
   const router = defaultRouterMock()
   const start = dayjs().subtract(1, 'day')
@@ -167,7 +170,7 @@ test('custom sql querying', async () => {
 
   // run query by button
   userEvent.click(await screen.findByText('Run'))
-  
+
   // run query by editor
   userEvent.type(editor, '\nlimit 123{ctrl}{enter}')
   await waitFor(
@@ -177,11 +180,10 @@ test('custom sql querying', async () => {
       expect(get).toHaveBeenCalledWith(expect.stringContaining('select'))
       expect(get).toHaveBeenCalledWith(expect.stringContaining('edge_logs'))
       expect(get).not.toHaveBeenCalledWith(expect.stringContaining('where'))
-      expect(get).not.toHaveBeenCalledWith(expect.stringContaining(encodeURIComponent("limit 123")))
+      expect(get).not.toHaveBeenCalledWith(expect.stringContaining(encodeURIComponent('limit 123')))
     },
     { timeout: 1000 }
   )
-
 
   await screen.findByText(/my_count/) //column header
   const rowValue = await screen.findByText(/12345/) // row value


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Add error handling on client side for when setting up intent fails on the API side to prevent UI from crashing
- Add error handling for form validation on submission for PaymentElement form