### PR TITLE
Fix/doc search

### DIFF
--- a/web/docusaurus.config.js
+++ b/web/docusaurus.config.js
@@ -13,6 +13,7 @@ module.exports = {
   organizationName: 'supabase', // Usually your GitHub org/user name.
   projectName: 'Supabase Docs', // Usually your repo name.
   onBrokenLinks: 'ignore',
+  themes: ['docusaurus-theme-search-typesense'],
   themeConfig: {
     colorMode: {
       // "light" | "dark"
@@ -26,10 +27,30 @@ module.exports = {
       // using user system preferences, instead of the hardcoded defaultMode
       respectPrefersColorScheme: false,
     },
-    algolia: {
-      appId: 'W4BIZ4FKU9',
-      apiKey: 'ac408c5c0a323ee4d7952cee149d1474',
-      indexName: 'supabase',
+    // algolia: {
+    //   appId: 'W4BIZ4FKU9',
+    //   apiKey: 'ac408c5c0a323ee4d7952cee149d1474',
+    //   indexName: 'supabase',
+    // },
+    typesense: {
+      typesenseCollectionName: 'supabase', // Replace with your own doc site's name. Should match the collection name in the scraper settings.
+
+      typesenseServerConfig: {
+        nodes: [
+          {
+            host: '104.197.49.156',
+            port: 80,
+            protocol: 'http',
+          },
+        ],
+        apiKey: 't0HAJQy4KtcMk3aYGnm8ONqab2oAysJz',
+      },
+
+      // Optional: Typesense search parameters: https://typesense.org/docs/0.21.0/api/documents.md#search-parameters
+      typesenseSearchParameters: {},
+
+      // Optional
+      contextualSearch: true,
     },
     image: '/img/supabase-og-image.png', // used for meta tag, in particular og:image and twitter:image
     metaImage: '/img/supabase-og-image.png',

--- a/web/docusaurus.config.js
+++ b/web/docusaurus.config.js
@@ -27,11 +27,6 @@ module.exports = {
       // using user system preferences, instead of the hardcoded defaultMode
       respectPrefersColorScheme: false,
     },
-    // algolia: {
-    //   appId: 'W4BIZ4FKU9',
-    //   apiKey: 'ac408c5c0a323ee4d7952cee149d1474',
-    //   indexName: 'supabase',
-    // },
     typesense: {
       typesenseCollectionName: 'supabase', // Replace with your own doc site's name. Should match the collection name in the scraper settings.
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -12,6 +12,7 @@
         "@docusaurus/preset-classic": "^2.0.0-beta.18",
         "@kiwicopple/prism-react-renderer": "https://github.com/kiwicopple/prism-react-renderer.git",
         "@octokit/core": "^3.5.1",
+        "docusaurus-theme-search-typesense": "^0.4.0-2",
         "jsrsasign": "^10.4.1",
         "mermaid": "^8.13.8",
         "react": "^17.0.2",
@@ -3955,7 +3956,6 @@
       "version": "0.21.4",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
       "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "dev": true,
       "dependencies": {
         "follow-redirects": "^1.14.0"
       }
@@ -6424,6 +6424,162 @@
         "node": ">=6"
       }
     },
+    "node_modules/docusaurus-theme-search-typesense": {
+      "version": "0.4.0-2",
+      "resolved": "https://registry.npmjs.org/docusaurus-theme-search-typesense/-/docusaurus-theme-search-typesense-0.4.0-2.tgz",
+      "integrity": "sha512-a1IAsEYJblmEkhW2lREe/IY0gmv+ciUwec5mYC8aTVukV769Avb5Eq8/6m6eV2/QOpfE6PUvht5RLxh0xFEtGA==",
+      "dependencies": {
+        "@docusaurus/utils": "2.0.0-beta.17",
+        "@docusaurus/utils-validation": "2.0.0-beta.17",
+        "algoliasearch-helper": "^3.7.0",
+        "clsx": "^1.1.1",
+        "eta": "^1.12.1",
+        "lodash": "^4.17.20",
+        "typesense": "^1.2.2",
+        "typesense-docsearch-react": "^0.1.0",
+        "typesense-instantsearch-adapter": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=12.13.0"
+      },
+      "peerDependencies": {
+        "@docusaurus/core": "2.0.0-beta.17",
+        "@docusaurus/theme-common": "2.0.0-beta.17",
+        "react": "^16.8.4 || ^17.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0"
+      }
+    },
+    "node_modules/docusaurus-theme-search-typesense/node_modules/@docusaurus/logger": {
+      "version": "2.0.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.0.0-beta.17.tgz",
+      "integrity": "sha512-F9JDl06/VLg+ylsvnq9NpILSUeWtl0j4H2LtlLzX5gufEL4dGiCMlnUzYdHl7FSHSzYJ0A/R7vu0SYofsexC4w==",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/docusaurus-theme-search-typesense/node_modules/@docusaurus/utils": {
+      "version": "2.0.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.0.0-beta.17.tgz",
+      "integrity": "sha512-yRKGdzSc5v6M/6GyQ4omkrAHCleevwKYiIrufCJgRbOtkhYE574d8mIjjirOuA/emcyLxjh+TLtqAA5TwhIryA==",
+      "dependencies": {
+        "@docusaurus/logger": "2.0.0-beta.17",
+        "@svgr/webpack": "^6.0.0",
+        "file-loader": "^6.2.0",
+        "fs-extra": "^10.0.1",
+        "github-slugger": "^1.4.0",
+        "globby": "^11.0.4",
+        "gray-matter": "^4.0.3",
+        "js-yaml": "^4.1.0",
+        "lodash": "^4.17.21",
+        "micromatch": "^4.0.4",
+        "resolve-pathname": "^3.0.0",
+        "shelljs": "^0.8.5",
+        "tslib": "^2.3.1",
+        "url-loader": "^4.1.1",
+        "webpack": "^5.69.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/docusaurus-theme-search-typesense/node_modules/@docusaurus/utils-validation": {
+      "version": "2.0.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.0.0-beta.17.tgz",
+      "integrity": "sha512-5UjayUP16fDjgd52eSEhL7SlN9x60pIhyS+K7kt7RmpSLy42+4/bSr2pns2VlATmuaoNOO6iIFdB2jgSYJ6SGA==",
+      "dependencies": {
+        "@docusaurus/logger": "2.0.0-beta.17",
+        "@docusaurus/utils": "2.0.0-beta.17",
+        "joi": "^17.6.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/docusaurus-theme-search-typesense/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/docusaurus-theme-search-typesense/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
+    "node_modules/docusaurus-theme-search-typesense/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/docusaurus-theme-search-typesense/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/docusaurus-theme-search-typesense/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/docusaurus-theme-search-typesense/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/docusaurus-theme-search-typesense/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/docusaurus-theme-search-typesense/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/dom-converter": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.2.0.tgz",
@@ -8853,6 +9009,18 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
+    },
+    "node_modules/loglevel": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.8.0.tgz",
+      "integrity": "sha512-G6A/nJLRgWOuuwdNuA6koovfEV1YpqqAG4pRUlFaz3jj2QNZ8M4vBqnVA+HBTmU/AMNUtlOsMmSpF6NyOjztbA==",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
+      }
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -12652,6 +12820,89 @@
       },
       "engines": {
         "node": ">=4.2.0"
+      }
+    },
+    "node_modules/typesense": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/typesense/-/typesense-1.2.2.tgz",
+      "integrity": "sha512-MOKAIGTXbL0RkbHOvpr8RHP7it7UhCc0x4KJ8+p5lwh6Q9bSht6pJqMn6bXybomYA7CHVzIm4+IWVz6dHdUBow==",
+      "dependencies": {
+        "axios": "^0.21.1",
+        "loglevel": "^1.7.1"
+      },
+      "peerDependencies": {
+        "@babel/runtime": "^7.14.6"
+      }
+    },
+    "node_modules/typesense-docsearch-react": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/typesense-docsearch-react/-/typesense-docsearch-react-0.1.0.tgz",
+      "integrity": "sha512-NavWvAylFR1k03kZ8M00ZQwB5s52g3iqr2C2IzHLFjqicD4mt5cYxO/eKZJHBcva2FnG1jnjY01mBEn3z6c+eQ==",
+      "dependencies": {
+        "@algolia/autocomplete-core": "1.2.1",
+        "@algolia/autocomplete-preset-algolia": "1.2.1",
+        "@docsearch/css": "3.0.0-alpha.39",
+        "typesense": "^0.14.0",
+        "typesense-instantsearch-adapter": "^2.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">= 16.8.0 < 18.0.0",
+        "react": ">= 16.8.0 < 18.0.0",
+        "react-dom": ">= 16.8.0 < 18.0.0"
+      }
+    },
+    "node_modules/typesense-docsearch-react/node_modules/@algolia/autocomplete-core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.2.1.tgz",
+      "integrity": "sha512-/SLS6636Wpl7eFiX7eEy0E3wBo60sUm1qRYybJBDt1fs8reiJ1+OSy+dZgrLBfLL4mSFqRIIUHXbVp25QdZ+iw==",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.2.1"
+      }
+    },
+    "node_modules/typesense-docsearch-react/node_modules/@algolia/autocomplete-preset-algolia": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.2.1.tgz",
+      "integrity": "sha512-Lf4PpPVgHNXm1ytrnVdrZYV7hAYSCpAI/TrebF8UC6xflPY6sKb1RL/2OfrO9On7SDjPBtNd+6MArSar5JmK0g==",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.2.1"
+      },
+      "peerDependencies": {
+        "@algolia/client-search": "^4.9.1",
+        "algoliasearch": "^4.9.1"
+      }
+    },
+    "node_modules/typesense-docsearch-react/node_modules/@algolia/autocomplete-shared": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.2.1.tgz",
+      "integrity": "sha512-RHCwcXAYFwDXTlomstjWRFIzOfyxtQ9KmViacPE5P5hxUSSjkmG3dAb77xdydift1PaZNbho5TNTCi5UZe0RpA=="
+    },
+    "node_modules/typesense-docsearch-react/node_modules/@docsearch/css": {
+      "version": "3.0.0-alpha.39",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.0.0-alpha.39.tgz",
+      "integrity": "sha512-lr10MFTgcR3NRea/FtJ7uNtIpQz0XVwYxbpO5wxykgfHu1sxZTr6zwkuPquRgFYXnccxsTvfoIiK3rMH0fLr/w=="
+    },
+    "node_modules/typesense-docsearch-react/node_modules/typesense": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/typesense/-/typesense-0.14.0.tgz",
+      "integrity": "sha512-9ZLkjwhCYXCZuYmvS6En5hJm3AMhFZMbZ7hRMVFJlyK3essNqd8MSWEt2bpAvbvTN+1FgGLBQPJnpYdsbkVsKg==",
+      "dependencies": {
+        "axios": "^0.21.1",
+        "loglevel": "^1.7.1"
+      },
+      "peerDependencies": {
+        "@babel/runtime": "^7.14.6"
+      }
+    },
+    "node_modules/typesense-instantsearch-adapter": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/typesense-instantsearch-adapter/-/typesense-instantsearch-adapter-2.4.0.tgz",
+      "integrity": "sha512-zJCfrF7j/jgQnyqUoyshSj84IMMaMVYzZyfEnCM/6YQyPPmObbr/EzxL49u4lcl50SW4EjgBie4SRvjR/r8ttA==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "typesense": "^1.2.1"
+      },
+      "peerDependencies": {
+        "@babel/runtime": "^7.13.17"
       }
     },
     "node_modules/ua-parser-js": {
@@ -17012,7 +17263,6 @@
       "version": "0.21.4",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
       "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "dev": true,
       "requires": {
         "follow-redirects": "^1.14.0"
       }
@@ -18887,6 +19137,122 @@
         "@leichtgewicht/ip-codec": "^2.0.1"
       }
     },
+    "docusaurus-theme-search-typesense": {
+      "version": "0.4.0-2",
+      "resolved": "https://registry.npmjs.org/docusaurus-theme-search-typesense/-/docusaurus-theme-search-typesense-0.4.0-2.tgz",
+      "integrity": "sha512-a1IAsEYJblmEkhW2lREe/IY0gmv+ciUwec5mYC8aTVukV769Avb5Eq8/6m6eV2/QOpfE6PUvht5RLxh0xFEtGA==",
+      "requires": {
+        "@docusaurus/utils": "2.0.0-beta.17",
+        "@docusaurus/utils-validation": "2.0.0-beta.17",
+        "algoliasearch-helper": "^3.7.0",
+        "clsx": "^1.1.1",
+        "eta": "^1.12.1",
+        "lodash": "^4.17.20",
+        "typesense": "^1.2.2",
+        "typesense-docsearch-react": "^0.1.0",
+        "typesense-instantsearch-adapter": "^2.4.0"
+      },
+      "dependencies": {
+        "@docusaurus/logger": {
+          "version": "2.0.0-beta.17",
+          "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.0.0-beta.17.tgz",
+          "integrity": "sha512-F9JDl06/VLg+ylsvnq9NpILSUeWtl0j4H2LtlLzX5gufEL4dGiCMlnUzYdHl7FSHSzYJ0A/R7vu0SYofsexC4w==",
+          "requires": {
+            "chalk": "^4.1.2",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@docusaurus/utils": {
+          "version": "2.0.0-beta.17",
+          "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.0.0-beta.17.tgz",
+          "integrity": "sha512-yRKGdzSc5v6M/6GyQ4omkrAHCleevwKYiIrufCJgRbOtkhYE574d8mIjjirOuA/emcyLxjh+TLtqAA5TwhIryA==",
+          "requires": {
+            "@docusaurus/logger": "2.0.0-beta.17",
+            "@svgr/webpack": "^6.0.0",
+            "file-loader": "^6.2.0",
+            "fs-extra": "^10.0.1",
+            "github-slugger": "^1.4.0",
+            "globby": "^11.0.4",
+            "gray-matter": "^4.0.3",
+            "js-yaml": "^4.1.0",
+            "lodash": "^4.17.21",
+            "micromatch": "^4.0.4",
+            "resolve-pathname": "^3.0.0",
+            "shelljs": "^0.8.5",
+            "tslib": "^2.3.1",
+            "url-loader": "^4.1.1",
+            "webpack": "^5.69.1"
+          }
+        },
+        "@docusaurus/utils-validation": {
+          "version": "2.0.0-beta.17",
+          "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.0.0-beta.17.tgz",
+          "integrity": "sha512-5UjayUP16fDjgd52eSEhL7SlN9x60pIhyS+K7kt7RmpSLy42+4/bSr2pns2VlATmuaoNOO6iIFdB2jgSYJ6SGA==",
+          "requires": {
+            "@docusaurus/logger": "2.0.0-beta.17",
+            "@docusaurus/utils": "2.0.0-beta.17",
+            "joi": "^17.6.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "js-yaml": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+          "requires": {
+            "argparse": "^2.0.1"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "dom-converter": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.2.0.tgz",
@@ -20674,6 +21040,11 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
+    },
+    "loglevel": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.8.0.tgz",
+      "integrity": "sha512-G6A/nJLRgWOuuwdNuA6koovfEV1YpqqAG4pRUlFaz3jj2QNZ8M4vBqnVA+HBTmU/AMNUtlOsMmSpF6NyOjztbA=="
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -23420,6 +23791,72 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
       "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA=="
+    },
+    "typesense": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/typesense/-/typesense-1.2.2.tgz",
+      "integrity": "sha512-MOKAIGTXbL0RkbHOvpr8RHP7it7UhCc0x4KJ8+p5lwh6Q9bSht6pJqMn6bXybomYA7CHVzIm4+IWVz6dHdUBow==",
+      "requires": {
+        "axios": "^0.21.1",
+        "loglevel": "^1.7.1"
+      }
+    },
+    "typesense-docsearch-react": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/typesense-docsearch-react/-/typesense-docsearch-react-0.1.0.tgz",
+      "integrity": "sha512-NavWvAylFR1k03kZ8M00ZQwB5s52g3iqr2C2IzHLFjqicD4mt5cYxO/eKZJHBcva2FnG1jnjY01mBEn3z6c+eQ==",
+      "requires": {
+        "@algolia/autocomplete-core": "1.2.1",
+        "@algolia/autocomplete-preset-algolia": "1.2.1",
+        "@docsearch/css": "3.0.0-alpha.39",
+        "typesense": "^0.14.0",
+        "typesense-instantsearch-adapter": "^2.0.1"
+      },
+      "dependencies": {
+        "@algolia/autocomplete-core": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.2.1.tgz",
+          "integrity": "sha512-/SLS6636Wpl7eFiX7eEy0E3wBo60sUm1qRYybJBDt1fs8reiJ1+OSy+dZgrLBfLL4mSFqRIIUHXbVp25QdZ+iw==",
+          "requires": {
+            "@algolia/autocomplete-shared": "1.2.1"
+          }
+        },
+        "@algolia/autocomplete-preset-algolia": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.2.1.tgz",
+          "integrity": "sha512-Lf4PpPVgHNXm1ytrnVdrZYV7hAYSCpAI/TrebF8UC6xflPY6sKb1RL/2OfrO9On7SDjPBtNd+6MArSar5JmK0g==",
+          "requires": {
+            "@algolia/autocomplete-shared": "1.2.1"
+          }
+        },
+        "@algolia/autocomplete-shared": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.2.1.tgz",
+          "integrity": "sha512-RHCwcXAYFwDXTlomstjWRFIzOfyxtQ9KmViacPE5P5hxUSSjkmG3dAb77xdydift1PaZNbho5TNTCi5UZe0RpA=="
+        },
+        "@docsearch/css": {
+          "version": "3.0.0-alpha.39",
+          "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.0.0-alpha.39.tgz",
+          "integrity": "sha512-lr10MFTgcR3NRea/FtJ7uNtIpQz0XVwYxbpO5wxykgfHu1sxZTr6zwkuPquRgFYXnccxsTvfoIiK3rMH0fLr/w=="
+        },
+        "typesense": {
+          "version": "0.14.0",
+          "resolved": "https://registry.npmjs.org/typesense/-/typesense-0.14.0.tgz",
+          "integrity": "sha512-9ZLkjwhCYXCZuYmvS6En5hJm3AMhFZMbZ7hRMVFJlyK3essNqd8MSWEt2bpAvbvTN+1FgGLBQPJnpYdsbkVsKg==",
+          "requires": {
+            "axios": "^0.21.1",
+            "loglevel": "^1.7.1"
+          }
+        }
+      }
+    },
+    "typesense-instantsearch-adapter": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/typesense-instantsearch-adapter/-/typesense-instantsearch-adapter-2.4.0.tgz",
+      "integrity": "sha512-zJCfrF7j/jgQnyqUoyshSj84IMMaMVYzZyfEnCM/6YQyPPmObbr/EzxL49u4lcl50SW4EjgBie4SRvjR/r8ttA==",
+      "requires": {
+        "typesense": "^1.2.1"
+      }
     },
     "ua-parser-js": {
       "version": "0.7.31",

--- a/web/package.json
+++ b/web/package.json
@@ -19,6 +19,7 @@
     "@docusaurus/preset-classic": "^2.0.0-beta.18",
     "@kiwicopple/prism-react-renderer": "https://github.com/kiwicopple/prism-react-renderer.git",
     "@octokit/core": "^3.5.1",
+    "docusaurus-theme-search-typesense": "^0.4.0-2",
     "jsrsasign": "^10.4.1",
     "mermaid": "^8.13.8",
     "react": "^17.0.2",


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to replace Algolia with Typesense for doc search engine. Fix #6007

## What is the current behavior?

The doc search currently uses Algolia free tier and it can easily exceed quota and make the doc search broken.

## What is the new behavior?

We built our own doc search engine using Typesense and use it to replace Algolia.

## Additional context

N/A
