### PR TITLE
update slack clone example project link

### DIFF
--- a/apps/temp-docs/docs/guides/examples.mdx
+++ b/apps/temp-docs/docs/guides/examples.mdx
@@ -26,7 +26,7 @@ Build a basic Todo List with Supabase and your favorite frontend framework:
 
 ## Collaborative
 
-- [Next.js Slack Clone.](https://github.com/supabase/supabase/tree/master/examples/nextjs-slack-clone)
+- [Next.js Slack Clone.](https://github.com/supabase/supabase/tree/master/examples/slack-clone/nextjs-slack-clone)
 
 ## Community
 

--- a/apps/www/data/Examples.json
+++ b/apps/www/data/Examples.json
@@ -21,7 +21,7 @@
     "author_url": "https://github.com/supabase",
     "author_img": "https://avatars.githubusercontent.com/u/54469796",
     "repo_name": "nextjs-slack-clone",
-    "repo_url": "https://github.com/supabase/supabase/tree/master/examples/nextjs-slack-clone",
+    "repo_url": "https://github.com/supabase/supabase/tree/master/examples/slack-clone/nextjs-slack-clone",
     "vercel_deploy_url": "",
     "demo_url": ""
   },

--- a/apps/www/data/ProjectExamples.json
+++ b/apps/www/data/ProjectExamples.json
@@ -23,7 +23,7 @@
   {
     "imgUrl": "images/slack-clone.jpg",
     "title": "Chat app with Next.js",
-    "url": "https://github.com/supabase/supabase/tree/master/examples/nextjs-slack-clone",
+    "url": "https://github.com/supabase/supabase/tree/master/examples/slack-clone/nextjs-slack-clone",
     "description": "Build a full-stack Slack clone using Next.js and Supabase.",
     "icons": [
       {

--- a/examples/slack-clone/nextjs-slack-clone/README.md
+++ b/examples/slack-clone/nextjs-slack-clone/README.md
@@ -138,7 +138,7 @@ Full schema here with role-based access control:
 
 ```sql
 --
--- For use with https://github.com/supabase/supabase/tree/master/examples/nextjs-slack-clone
+-- For use with https://github.com/supabase/supabase/tree/master/examples/slack-clone/nextjs-slack-clone
 --
 
 -- Custom types

--- a/examples/slack-clone/nextjs-slack-clone/full-schema.sql
+++ b/examples/slack-clone/nextjs-slack-clone/full-schema.sql
@@ -1,5 +1,5 @@
 --
--- For use with https://github.com/supabase/supabase/tree/master/examples/nextjs-slack-clone
+-- For use with https://github.com/supabase/supabase/tree/master/examples/slack-clone/nextjs-slack-clone
 --
 
 -- Custom types

--- a/studio/components/interfaces/Home/Home.constants.ts
+++ b/studio/components/interfaces/Home/Home.constants.ts
@@ -33,7 +33,7 @@ export const EXAMPLE_PROJECTS = [
     framework: 'NextJS',
     title: 'Next.js Realtime chat app',
     description: 'Next.js Slack clone app using Supabase realtime subscriptions',
-    url: 'https://github.com/supabase/supabase/tree/master/examples/nextjs-slack-clone',
+    url: 'https://github.com/supabase/supabase/tree/master/examples/slack-clone/nextjs-slack-clone',
   },
   {
     framework: 'NextJS',

--- a/studio/components/interfaces/SQLEditor/SQLEditor.constants.ts
+++ b/studio/components/interfaces/SQLEditor/SQLEditor.constants.ts
@@ -415,8 +415,7 @@ insert into public.countries (name,iso2,iso3,local_name,continent) values
     description: 'Build a basic slack clone with Row Level Security.',
     sql: `
 --
--- For use with https://github.com/supabase/supabase/tree/master/examples/nextjs-slack-clone
---
+-- For use with https://github.com/supabase/supabase/tree/master/examples/slack-clone/nextjs-slack-clone
 
 -- Custom types
 create type public.app_permission as enum ('channels.delete', 'messages.delete');


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

At the project page under "Example projects" the "Next.js Realtime chat app" card links to a 404 page, also [noted](https://github.com/supabase/supabase/issues/6590#issuecomment-1114037117) by #6590

## What is the new behavior?

New URL should lead to the actual repository, https://github.com/supabase/supabase/tree/master/examples/slack-clone/nextjs-slack-clone