### PR TITLE
background class corrected

### DIFF
--- a/apps/www/pages/support.tsx
+++ b/apps/www/pages/support.tsx
@@ -165,10 +165,10 @@ const Index = ({}: Props) => {
                 <div>
                   <div
                     className="
-                    bbg-white dark:bg-scale-400 
-                    flex flex-col justify-between rounded rounded-t-none
-                    border-b border-r
-                    border-l border-gray-100 p-5
+                    dark:bg-scale-400 flex 
+                    flex-col justify-between rounded rounded-t-none border-b
+                    border-r border-l
+                    border-gray-100 bg-white p-5
                     pt-10 dark:border-gray-600"
                   >
                     <a href="mailto:support@supabase.io">


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase website change

## What is the current behavior?

On the [support](https://supabase.com/support) page, on the email support card the lower half of the card on a light background does not show:

<img width="912" alt="Screenshot 2022-05-09 at 13 50 47" src="https://user-images.githubusercontent.com/22655069/167413673-4a340d94-d50b-4b40-b995-be6865997a2e.png">


## What is the new behavior?

The lower half of the card now has a background on light mode:

<img width="912" alt="Screenshot 2022-05-09 at 13 52 20" src="https://user-images.githubusercontent.com/22655069/167413787-01039316-2e7a-40b7-9369-5becbd21828c.png">
