### PR TITLE
change to use doc search domain name

### DIFF
--- a/web/docusaurus.config.js
+++ b/web/docusaurus.config.js
@@ -34,8 +34,8 @@ module.exports = {
         nodes: [
           {
             host: 'doc-search.supabase.com',
-            port: 80,
-            protocol: 'http',
+            port: 443,
+            protocol: 'https',
           },
         ],
         apiKey: 't0HAJQy4KtcMk3aYGnm8ONqab2oAysJz',

--- a/web/docusaurus.config.js
+++ b/web/docusaurus.config.js
@@ -33,7 +33,7 @@ module.exports = {
       typesenseServerConfig: {
         nodes: [
           {
-            host: '104.197.49.156',
+            host: 'doc-search.supabase.com',
             port: 80,
             protocol: 'http',
           },


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to change doc search to use sub-domain name `doc-search.supabase.com`.

## What is the current behavior?

#6007 

## What is the new behavior?

Doc search should be working by using this new sub domain.

## Additional context

N/A
