### PR TITLE
fix: experts page layout changed for smaller screens

### DIFF
--- a/apps/www/pages/partners/experts/index.tsx
+++ b/apps/www/pages/partners/experts/index.tsx
@@ -62,14 +62,14 @@ function ExpertPartnersPage(props: Props) {
             <h1 className="h1">{meta_title}</h1>
             <h2 className="text-scale-900 text-xl">{meta_description}</h2>
           </div>
-          <div className="grid space-y-12 md:gap-8 lg:grid-cols-12 lg:gap-16 lg:space-y-0 xl:gap-16">
+          <div className="grid space-y-12 md:gap-8 lg:grid-cols-12 lg:gap-16 lg:space-y-0 xl:gap-32">
             <div className="lg:col-span-4 xl:col-span-3">
               {/* Horizontal link menu */}
               <div className="space-y-6">
                 {/* Search Bar */}
                 <div className="space-y-4">
                   <div className="text-scale-900 mb-2 text-sm">Explore more</div>
-                  <div className="grid grid-cols-2 gap-8 lg:grid-cols-1">
+                  <div className="grid grid-cols-2 gap-4 lg:grid-cols-1">
                     <PartnerLinkBox
                       title="Integrations"
                       color="blue"

--- a/apps/www/pages/partners/experts/index.tsx
+++ b/apps/www/pages/partners/experts/index.tsx
@@ -62,61 +62,63 @@ function ExpertPartnersPage(props: Props) {
             <h1 className="h1">{meta_title}</h1>
             <h2 className="text-scale-900 text-xl">{meta_description}</h2>
           </div>
-          <div className="grid grid-cols-12 lg:gap-16 xl:gap-32">
-            <div className="col-span-3">
+          <div className="grid space-y-12 md:gap-8 lg:grid-cols-12 lg:gap-16 lg:space-y-0 xl:gap-16">
+            <div className="lg:col-span-4 xl:col-span-3">
               {/* Horizontal link menu */}
               <div className="space-y-6">
                 {/* Search Bar */}
                 <div className="space-y-4">
                   <div className="text-scale-900 mb-2 text-sm">Explore more</div>
-                  <PartnerLinkBox
-                    title="Integrations"
-                    color="blue"
-                    description="Extend and automate your workflow by using integrations for your favorite tools."
-                    href={`/partners/integrations`}
-                    icon={
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        className="h-6 w-6"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        stroke="currentColor"
-                        stroke-width="1"
-                      >
-                        <path
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          d="M11 4a2 2 0 114 0v1a1 1 0 001 1h3a1 1 0 011 1v3a1 1 0 01-1 1h-1a2 2 0 100 4h1a1 1 0 011 1v3a1 1 0 01-1 1h-3a1 1 0 01-1-1v-1a2 2 0 10-4 0v1a1 1 0 01-1 1H7a1 1 0 01-1-1v-3a1 1 0 00-1-1H4a2 2 0 110-4h1a1 1 0 001-1V7a1 1 0 011-1h3a1 1 0 001-1V4z"
-                        />
-                      </svg>
-                    }
-                  />
-                  <PartnerLinkBox
-                    title="Become a partner"
-                    color="brand"
-                    description="Fill out a quick 30 second form to apply to become a partner"
-                    href={`/partners/integrations#become-a-partner`}
-                    icon={
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        className="h-5 w-5"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        stroke="currentColor"
-                        stroke-width="1"
-                      >
-                        <path
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"
-                        />
-                      </svg>
-                    }
-                  />
+                  <div className="grid grid-cols-2 gap-8 lg:grid-cols-1">
+                    <PartnerLinkBox
+                      title="Integrations"
+                      color="blue"
+                      description="Extend and automate your workflow by using integrations for your favorite tools."
+                      href={`/partners/integrations`}
+                      icon={
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          className="h-6 w-6"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                          stroke-width="1"
+                        >
+                          <path
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            d="M11 4a2 2 0 114 0v1a1 1 0 001 1h3a1 1 0 011 1v3a1 1 0 01-1 1h-1a2 2 0 100 4h1a1 1 0 011 1v3a1 1 0 01-1 1h-3a1 1 0 01-1-1v-1a2 2 0 10-4 0v1a1 1 0 01-1 1H7a1 1 0 01-1-1v-3a1 1 0 00-1-1H4a2 2 0 110-4h1a1 1 0 001-1V7a1 1 0 011-1h3a1 1 0 001-1V4z"
+                          />
+                        </svg>
+                      }
+                    />
+                    <PartnerLinkBox
+                      title="Become a partner"
+                      color="brand"
+                      description="Fill out a quick 30 second form to apply to become a partner"
+                      href={`/partners/integrations#become-a-partner`}
+                      icon={
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          className="h-5 w-5"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                          stroke-width="1"
+                        >
+                          <path
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"
+                          />
+                        </svg>
+                      }
+                    />
+                  </div>
                 </div>
               </div>
             </div>
-            <div className="col-span-9">
+            <div className="lg:col-span-8 xl:col-span-9">
               {/* Partner Tiles */}
               <div className="grid">
                 {partners.length ? (


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase website changed

## What is the current behavior?

If you go onto the [experts](https://supabase.com/partners/experts) page on the supabase website on a mobile device/tablet  the layout of the content stays the same at a large breakpoint:

<img width="962" alt="Screenshot 2022-05-10 at 10 07 24" src="https://user-images.githubusercontent.com/22655069/167593226-b9781afd-e05b-433e-b12b-cb7e90529dc4.png">

## What is the new behavior?

I've changed the layout to mirror the partners section so that the layout is better for smaller devices:

<img width="982" alt="Screenshot 2022-05-10 at 10 06 32" src="https://user-images.githubusercontent.com/22655069/167593612-62fdd272-51cf-4c40-8444-4b3b827d823d.png">
