### PR TITLE
Chore: update supabase logo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 <p align="center">
-<img width="300" src="https://raw.githubusercontent.com/supabase/supabase/master/web/static/supabase-light-rounded-corner-background.svg"/>
+<img width="300" src="https://raw.githubusercontent.com/supabase/supabase/master/apps/www/public/images/supabase-logo-wordmark--light.svg?sanitize=true#gh-light-mode-only">
+<img width="300" src="https://raw.githubusercontent.com/supabase/supabase/master/apps/www/public/images/supabase-logo-wordmark--dark.svg?sanitize=true#gh-dark-mode-only">
 </p>
 
 ---


### PR DESCRIPTION
## What kind of change does this PR introduce?

Update supabase logo in readme for better look. in darkmode.

## What is the current behavior?

![image](https://user-images.githubusercontent.com/70828596/167721801-25c8bc7f-33b3-4c37-ac17-f9563e590956.png)
![image](https://user-images.githubusercontent.com/70828596/167722142-7f246239-b291-47cd-a0b7-a7d248f0a3ab.png)

## What is the new behavior?

![image](https://user-images.githubusercontent.com/70828596/167721883-cf183881-16a0-48ae-b107-24977b452c89.png)
![image](https://user-images.githubusercontent.com/70828596/167722217-d5310943-7d24-40a2-999c-e298a0a62ad6.png)