### PR TITLE
Corrected: JSX expressions must have one parent element.

### DIFF
--- a/web/docs/guides/with-react.mdx
+++ b/web/docs/guides/with-react.mdx
@@ -489,18 +489,20 @@ export default function Avatar({ url, size, onUpload }) {
         style={{ height: size, width: size }}
       />
       {uploading ? "Uploading..." : (
-        <label className="button primary block" htmlFor="single">
-          Upload an avatar
-        </label>
-        <VisuallyHidden>
-          <input
-            type="file"
-            id="single"
-            accept="image/*"
-            onChange={uploadAvatar}
-            disabled={uploading}
-          />
-        </VisuallyHidden>
+        <>
+          <label className="button primary block" htmlFor="single">
+            Upload an avatar
+          </label>
+          <VisuallyHidden>
+            <input
+              type="file"
+              id="single"
+              accept="image/*"
+              onChange={uploadAvatar}
+              disabled={uploading}
+            />
+          </VisuallyHidden>
+        </>
       )}
     </div>
   )


### PR DESCRIPTION
## What kind of change does this PR introduce?
Documentation update

## What is the current behavior?
Warning being shown as follows on using the code from the react-quickstart.
![image](https://user-images.githubusercontent.com/73743535/167805108-7691658c-17f6-4058-8f57-db7c3fb5dc59.png)

## What is the new behavior?
Warning resolved.

## Additional context
I was following along with the React-Quickstart and when I reached this point in the tutorial, I noticed that `JSX expressions must have one parent element.` warning was being shown in `src/Avatar.js`. I have enclosed the label and input tag in a fragment which resolves the warning.