### PR TITLE
fix: minimally show type in column editor if column type is not a native psql type

### DIFF
--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnType.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnType.tsx
@@ -63,6 +63,11 @@ const ColumnType: FC<Props> = ({
       className={`${className} ${disabled ? 'column-type-disabled' : ''} rounded-md`}
       onChange={(value: string) => onOptionSelect(value)}
       optionsWidth={480}
+      descriptionText={
+        !isNativeDataType
+          ? 'Custom non-native psql data types cannot currently be changed to a different data type via Supabase Studio'
+          : ''
+      }
     >
       <Listbox.Option key="empty" value="" label="---">
         ---

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnType.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnType.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react'
-import { IconCalendar, IconType, IconHash, Listbox, IconToggleRight } from '@supabase/ui'
+import { IconCalendar, IconType, IconHash, Listbox, IconToggleRight, Input } from '@supabase/ui'
 import { PostgresType } from '@supabase/postgres-meta'
-import { POSTGRES_DATA_TYPE_OPTIONS } from '../SidePanelEditor.constants'
+import { POSTGRES_DATA_TYPES, POSTGRES_DATA_TYPE_OPTIONS } from '../SidePanelEditor.constants'
 import { PostgresDataTypeOption } from '../SidePanelEditor.types'
 
 interface Props {
@@ -25,6 +25,12 @@ const ColumnType: FC<Props> = ({
   showLabel = true,
   onOptionSelect = () => {},
 }) => {
+  const isNativeDataType = POSTGRES_DATA_TYPES.includes(value)
+
+  if (!isNativeDataType) {
+    return <Input readOnly disabled label="Type" layout="horizontal" value={value} />
+  }
+
   const inferIcon = (type: string) => {
     switch (type) {
       case 'number':
@@ -53,7 +59,7 @@ const ColumnType: FC<Props> = ({
       value={value}
       size={size}
       error={error}
-      disabled={disabled}
+      disabled={disabled || !isNativeDataType}
       className={`${className} ${disabled ? 'column-type-disabled' : ''} rounded-md`}
       onChange={(value: string) => onOptionSelect(value)}
       optionsWidth={480}
@@ -67,13 +73,14 @@ const ColumnType: FC<Props> = ({
       </Listbox.Option>
 
       {enumTypes.length > 0 ? (
+        // @ts-ignore
         enumTypes.map((enumType: PostgresType) => (
           <Listbox.Option
             key={enumType.name}
             value={enumType.name}
             label={enumType.name}
             addOnBefore={() => {
-              return <div className="mx-1 w-2 h-2 rounded-full bg-scale-1200" />
+              return <div className="bg-scale-1200 mx-1 h-2 w-2 rounded-full" />
             }}
           >
             <div className="flex items-center space-x-4">
@@ -88,7 +95,7 @@ const ColumnType: FC<Props> = ({
           value="no-enums"
           label="no-enums"
           addOnBefore={() => {
-            return <div className="mx-1 w-2 h-2 rounded-full bg-gray-500" />
+            return <div className="mx-1 h-2 w-2 rounded-full bg-gray-500" />
           }}
         >
           <div className="flex items-center space-x-4">

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnType.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnType.tsx
@@ -28,7 +28,16 @@ const ColumnType: FC<Props> = ({
   const isNativeDataType = POSTGRES_DATA_TYPES.includes(value)
 
   if (!isNativeDataType) {
-    return <Input readOnly disabled label="Type" layout="horizontal" value={value} />
+    return (
+      <Input
+        readOnly
+        disabled
+        label="Type"
+        layout="horizontal"
+        value={value}
+        descriptionText="Custom non-native psql data types cannot currently be changed to a different data type via Supabase Studio"
+      />
+    )
   }
 
   const inferIcon = (type: string) => {
@@ -59,15 +68,10 @@ const ColumnType: FC<Props> = ({
       value={value}
       size={size}
       error={error}
-      disabled={disabled || !isNativeDataType}
+      disabled={disabled}
       className={`${className} ${disabled ? 'column-type-disabled' : ''} rounded-md`}
       onChange={(value: string) => onOptionSelect(value)}
       optionsWidth={480}
-      descriptionText={
-        !isNativeDataType
-          ? 'Custom non-native psql data types cannot currently be changed to a different data type via Supabase Studio'
-          : ''
-      }
     >
       <Listbox.Option key="empty" value="" label="---">
         ---


### PR DESCRIPTION
If the column type is not a native psql data type, it'll show up as empty
Partial fix to show it as an unselectable option here

### Before
![image](https://user-images.githubusercontent.com/19742402/167819269-83fb0079-4dea-4a0d-add5-d21aea9d841c.png)

### After
![image](https://user-images.githubusercontent.com/19742402/167819320-7b8d302e-2625-4657-bae8-214cea32c4da.png)

Context:
pg-meta's yet to support retrieving types and enums from installed extensions, while that is getting done dashboard at least show the data type. Unselectable because if the user changes the data type of the column:
- that option will disappear from the type dropdown
- they can only change it back via SQL