### PR TITLE
Update broken link (edge functions examples)

### DIFF
--- a/web/docs/guides/functions.mdx
+++ b/web/docs/guides/functions.mdx
@@ -234,7 +234,7 @@ supabase secrets list
 
 ## Examples
 
-You can find a list of useful [Edge Function Examples](https://github.com/supabase/supabase/tree/master/examples/flutter-user-management) in our GitHub repository.
+You can find a list of useful [Edge Function Examples](https://github.com/supabase/supabase/tree/master/examples/edge-functions) in our GitHub repository.
 
 <div class="container" style={{ padding: 0 }}>
   <div class="row is-multiline">


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix broken link in docs

## What is the current behavior?

Current link (broken): https://github.com/supabase/supabase/tree/master/examples/flutter-user-management

## What is the new behavior?

Updated link: https://github.com/supabase/supabase/tree/master/examples/edge-functions
