### PR TITLE
Fix/5778

### DIFF
--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.tsx
@@ -54,7 +54,7 @@ const ColumnEditor: FC<Props> = ({
 }) => {
   const isNewRecord = isUndefined(column)
   const hasPrimaryKey = (selectedTable?.primary_keys ?? []).length > 0
-  const foreignKey = column ? getColumnForeignKey(column, selectedTable) : undefined
+  const originalForeignKey = column ? getColumnForeignKey(column, selectedTable) : undefined
 
   const [errors, setErrors] = useState<Dictionary<any>>({})
   const [columnFields, setColumnFields] = useState<ColumnField>()
@@ -184,7 +184,7 @@ const ColumnEditor: FC<Props> = ({
           )}
           <ColumnForeignKey
             column={columnFields}
-            originalForeignKey={foreignKey}
+            originalForeignKey={originalForeignKey}
             onSelectEditRelation={() => setIsEditingRelation(true)}
             onSelectRemoveRelation={() => onUpdateField({ foreignKey: undefined })}
           />
@@ -263,7 +263,6 @@ const ColumnEditor: FC<Props> = ({
           <ForeignKeySelector
             tables={tables}
             column={columnFields}
-            foreignKey={foreignKey}
             visible={isEditingRelation}
             closePanel={() => setIsEditingRelation(false)}
             saveChanges={saveColumnForeignKey}

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnForeignKey.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnForeignKey.tsx
@@ -215,7 +215,7 @@ const ColumnForeignKeyUpdated: FC<{
         <div className="flex items-center justify-between">
           <div className="space-y-2">
             <Typography.Text>
-              The foreign key relation will be <span className="text-green-1000">updated</span> as
+              The foreign key relation will be <span className="text-green-900">updated</span> as
               such:
             </Typography.Text>
             <div className="flex items-start space-x-2">

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnForeignKey.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnForeignKey.tsx
@@ -129,7 +129,7 @@ const ColumnForeignKeyAdded: FC<{
           <div className="space-y-2">
             <span>
               The following foreign key relation will be{' '}
-              <span className="text-green-900">added</span>:
+              <span className="text-brand-900">added</span>:
             </span>
             <div className="text-scale-1200 flex items-center space-x-2">
               <span className={`${columnName.length > 0 ? 'text-code' : ''} max-w-xs truncate`}>
@@ -215,7 +215,7 @@ const ColumnForeignKeyUpdated: FC<{
         <div className="flex items-center justify-between">
           <div className="space-y-2">
             <Typography.Text>
-              The foreign key relation will be <span className="text-green-900">updated</span> as
+              The foreign key relation will be <span className="text-brand-900">updated</span> as
               such:
             </Typography.Text>
             <div className="flex items-start space-x-2">

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnForeignKey.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnForeignKey.tsx
@@ -132,7 +132,9 @@ const ColumnForeignKeyAdded: FC<{
               <span className="text-green-900">added</span>:
             </span>
             <div className="text-scale-1200 flex items-center space-x-2">
-              <span className="text-code max-w-xs truncate">{columnName}</span>
+              <span className={`${columnName.length > 0 ? 'text-code' : ''} max-w-xs truncate`}>
+                {columnName || 'This column'}
+              </span>
               <IconArrowRight size={14} strokeWidth={2} />
               <span className="text-code max-w-xs truncate">
                 {foreignKey?.target_table_schema}.{foreignKey?.target_table_name}.

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnForeignKey.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnForeignKey.tsx
@@ -88,7 +88,7 @@ const ColumnForeignKeyInformation: FC<{
       block
       icon={<IconLink />}
       title={
-        <div className="flex items-center justify-between text-scale-900">
+        <div className="text-scale-900 flex items-center justify-between">
           <div className="space-y-2">
             <span>This column has the following foreign key relation:</span>
             <div className="flex items-center space-x-2">
@@ -125,13 +125,13 @@ const ColumnForeignKeyAdded: FC<{
       block
       icon={<IconLink />}
       title={
-        <div className="flex items-center justify-between text-scale-1100">
+        <div className="text-scale-1100 flex items-center justify-between">
           <div className="space-y-2">
             <span>
               The following foreign key relation will be{' '}
               <span className="text-green-900">added</span>:
             </span>
-            <div className="flex items-center space-x-2 text-scale-1200">
+            <div className="text-scale-1200 flex items-center space-x-2">
               <span className="text-code max-w-xs truncate">{columnName}</span>
               <IconArrowRight size={14} strokeWidth={2} />
               <span className="text-code max-w-xs truncate">
@@ -213,7 +213,7 @@ const ColumnForeignKeyUpdated: FC<{
         <div className="flex items-center justify-between">
           <div className="space-y-2">
             <Typography.Text>
-              The foreign key relation will be <span className="text-green-500">updated</span> as
+              The foreign key relation will be <span className="text-green-1000">updated</span> as
               such:
             </Typography.Text>
             <div className="flex items-start space-x-2">

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.tsx
@@ -41,7 +41,6 @@ const ForeignKeySelector: FC<Props> = ({
     // Reset the state of the side panel
     if (visible) {
       setErrors({})
-      console.log('Foreign key', foreignKey)
       if (foreignKey) {
         setSelectedForeignKey({
           schema: foreignKey.target_table_schema,

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.tsx
@@ -2,7 +2,7 @@ import React, { FC, useEffect, useState } from 'react'
 import { get, find, isEmpty, sortBy } from 'lodash'
 import { Dictionary } from '@supabase/grid'
 import { SidePanel, Typography, Listbox, IconHelpCircle } from '@supabase/ui'
-import { PostgresTable, PostgresColumn, PostgresRelationship } from '@supabase/postgres-meta'
+import { PostgresTable, PostgresColumn } from '@supabase/postgres-meta'
 
 import ActionBar from '../ActionBar'
 import { ForeignKey } from './ForeignKeySelector.types'
@@ -12,7 +12,6 @@ import InformationBox from 'components/ui/InformationBox'
 interface Props {
   tables: PostgresTable[]
   column: ColumnField
-  foreignKey?: PostgresRelationship
   metadata?: any
   visible: boolean
   closePanel: () => void
@@ -22,7 +21,6 @@ interface Props {
 const ForeignKeySelector: FC<Props> = ({
   tables = [] as PostgresTable[],
   column,
-  foreignKey,
   visible = false,
   closePanel,
   saveChanges,
@@ -30,6 +28,7 @@ const ForeignKeySelector: FC<Props> = ({
   const [errors, setErrors] = useState<any>({})
   const [selectedForeignKey, setSelectedForeignKey] = useState<ForeignKey>()
 
+  const foreignKey = column?.foreignKey
   const selectedTable: PostgresTable | undefined = find(tables, {
     name: selectedForeignKey?.table,
     schema: selectedForeignKey?.schema,
@@ -42,6 +41,7 @@ const ForeignKeySelector: FC<Props> = ({
     // Reset the state of the side panel
     if (visible) {
       setErrors({})
+      console.log('Foreign key', foreignKey)
       if (foreignKey) {
         setSelectedForeignKey({
           schema: foreignKey.target_table_schema,
@@ -146,6 +146,7 @@ const ForeignKeySelector: FC<Props> = ({
             <Listbox.Option key="empty" value="" label="---">
               ---
             </Listbox.Option>
+            {/* @ts-ignore */}
             {sortBy(tables, ['schema']).map((table: PostgresTable) => {
               return (
                 <Listbox.Option key={table.id} value={table.id} label={table.name}>

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/ColumnManagement.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/ColumnManagement.tsx
@@ -142,8 +142,8 @@ const ColumnManagement: FC<Props> = ({
 
   return (
     <>
-      <div className="w-full table-editor-columns space-y-4">
-        <div className="w-full flex items-center justify-between">
+      <div className="table-editor-columns w-full space-y-4">
+        <div className="flex w-full items-center justify-between">
           <Typography.Title level={5}>Columns</Typography.Title>
           {isNewRecord && (
             <>
@@ -194,21 +194,21 @@ const ColumnManagement: FC<Props> = ({
 
         <div className="space-y-2">
           {/* Headers */}
-          <div className="w-full flex px-3">
+          <div className="flex w-full px-3">
             {/* Drag handle */}
             {isNewRecord && <div className="w-[5%]" />}
             <div className="w-[25%]">
-              <h5 className="text-xs text-scale-900">Name</h5>
+              <h5 className="text-scale-900 text-xs">Name</h5>
             </div>
             <div className="w-[25%]">
-              <h5 className="text-xs text-scale-900">Type</h5>
+              <h5 className="text-scale-900 text-xs">Type</h5>
             </div>
             <div className={`${isNewRecord ? 'w-[25%]' : 'w-[30%]'} flex items-center space-x-2`}>
-              <h5 className="text-xs text-scale-900">Default Value</h5>
+              <h5 className="text-scale-900 text-xs">Default Value</h5>
 
               <Tooltip.Root delayDuration={0}>
                 <Tooltip.Trigger>
-                  <h5 className="text-xs text-scale-900">
+                  <h5 className="text-scale-900 text-xs">
                     <IconHelpCircle size={15} strokeWidth={1.5} />
                   </h5>
                 </Tooltip.Trigger>
@@ -216,8 +216,8 @@ const ColumnManagement: FC<Props> = ({
                   <Tooltip.Arrow className="radix-tooltip-arrow" />
                   <div
                     className={[
-                      'bg-scale-100 shadow py-1 px-2 rounded leading-none', // background
-                      'border border-scale-200 ', //border
+                      'bg-scale-100 rounded py-1 px-2 leading-none shadow', // background
+                      'border-scale-200 border ', //border
                     ].join(' ')}
                   >
                     <span className="text-scale-1200 text-xs">
@@ -228,7 +228,7 @@ const ColumnManagement: FC<Props> = ({
               </Tooltip.Root>
             </div>
             <div className="w-[10%]">
-              <h5 className="text-xs text-scale-900">Primary</h5>
+              <h5 className="text-scale-900 text-xs">Primary</h5>
             </div>
             {/* Empty space */}
             <div className={`${hasImportContent ? 'w-[10%]' : 'w-0'}`} />
@@ -244,7 +244,7 @@ const ColumnManagement: FC<Props> = ({
                 {(droppableProvided: DroppableProvided) => (
                   <div
                     ref={droppableProvided.innerRef}
-                    className={`space-y-2 bg-gray-400 rounded-md px-3 py-2 ${
+                    className={`space-y-2 rounded-md bg-gray-400 px-3 py-2 ${
                       isNewRecord ? '' : '-mx-3'
                     }`}
                   >
@@ -321,7 +321,6 @@ const ColumnManagement: FC<Props> = ({
       <ForeignKeySelector
         tables={tables}
         column={selectedColumnToEditRelation as ColumnField}
-        foreignKey={selectedColumnToEditRelation?.foreignKey}
         visible={!isUndefined(selectedColumnToEditRelation)}
         closePanel={() => setSelectedColumnToEditRelation(undefined)}
         saveChanges={saveColumnForeignKey}


### PR DESCRIPTION
Resolves https://github.com/supabase/supabase/issues/5778
- Added empty state for column editor for when column has no name yet in the form
- Fixed foreign key selector component not showing updated foreign key config (as highlighted by hieu)

Empty state: will show "This column" until user starts typing into the name field
![image](https://user-images.githubusercontent.com/19742402/167903772-6d89cc88-b2a0-4a38-a5e5-cfd557dadfbc.png)