### PR TITLE
Update Auth.js 6794

### DIFF
--- a/examples/auth/nextjs-auth/components/Auth.js
+++ b/examples/auth/nextjs-auth/components/Auth.js
@@ -68,7 +68,7 @@ function Auth(props) {
         <>
           <h4>Sign in</h4>
           <form onSubmit={(e) => handleSignIn(e)}>
-            <label for="sign-in__email">Email</label>
+            <label htmlFor="sign-in__email">Email</label>
             <input
               id="sign-in__email"
               label="Email address"
@@ -77,7 +77,7 @@ function Auth(props) {
               defaultValue={email}
               onChange={(e) => setEmail(e.target.value)}
             />
-            <label for="sign-in__password">Password</label>
+            <label htmlFor="sign-in__password">Password</label>
             <input
               id="sign-in__password"
               label="Password"
@@ -98,7 +98,7 @@ function Auth(props) {
         <>
           <h4>Sign up</h4>
           <form onSubmit={(e) => handleSignUp(e)}>
-            <label for="sign-up__email">Email</label>
+            <label htmlFor="sign-up__email">Email</label>
             <input
               id="sign-up__email"
               label="Email address"
@@ -107,7 +107,7 @@ function Auth(props) {
               defaultValue={email}
               onChange={(e) => setEmail(e.target.value)}
             />
-            <label for="sign-up__password">Password</label>
+            <label htmlFor="sign-up__password">Password</label>
             <input
               id="sign-up__password"
               label="Password"
@@ -128,7 +128,7 @@ function Auth(props) {
         <>
           <h4>Forgotten password</h4>
           <form onSubmit={handlePasswordReset}>
-            <label for="forgotten_password__email">Email</label>
+            <label htmlFor="forgotten_password__email">Email</label>
             <input
               id="forgotten_password__email"
               label="Email address"


### PR DESCRIPTION
Fixing react warning, Invalid DOM property `for=` to `htmlFor=`

## What kind of change does this PR introduce?

docs update, ... 
Issue: #6794 

