### PR TITLE
fix: pricing github button text

### DIFF
--- a/apps/www/pages/pricing/index.tsx
+++ b/apps/www/pages/pricing/index.tsx
@@ -636,7 +636,7 @@ export default function IndexPage() {
                 </Link>
                 <Link href="https://github.com/supabase/supabase/discussions">
                   <a>
-                    <Button type="default" size="small" className="text-white">
+                    <Button type="default" size="small">
                       GitHub
                     </Button>
                   </a>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase website fix

## What is the current behavior?

If you go onto the [pricing](https://supabase.com/pricing) page and go down to the FAQ section, the Github button is showing white text on the button:

<img width="958" alt="Screenshot 2022-05-12 at 09 41 41" src="https://user-images.githubusercontent.com/22655069/168029715-b8c0ceab-2651-45c4-b271-0cecbdcaf662.png">


## What is the new behavior?

The button text is now readable:

<img width="958" alt="Screenshot 2022-05-12 at 09 42 23" src="https://user-images.githubusercontent.com/22655069/168029861-10d505a7-6935-4859-8c55-4233f51b9674.png">

