### PR TITLE
Fix/5937

### DIFF
--- a/studio/components/interfaces/Authentication/Users/Users.utils.ts
+++ b/studio/components/interfaces/Authentication/Users/Users.utils.ts
@@ -1,0 +1,24 @@
+import { detectBrowser } from 'lib/helpers'
+
+/**
+ * Formats the user datetime string into a format that's
+ * readable across browsers.
+ * - Postgres: 2022-05-12 09:24:12.639463+00
+ *
+ * These are the acceptable formats that Joshen has experimented so far
+ * - Chrome:   2022-05-12 09:24:12.639463+00 (No format required)
+ * - Firefox:  2022-05-12 09:24:12.639463+00 (No format required)
+ * - Safari:   2022-05-12T09:24:12.639463+00
+ *
+ * Note: I've only seen this issue on the Auth page, hence why keeping
+ * this util here for now. But if it does happen elsewhere i'll bring it
+ * to lib/helpers
+ */
+export const formatUserDateString = (dateString: string) => {
+  const browser = detectBrowser()
+  if (browser === 'Safari') {
+    return dateString.replace(' ', 'T')
+  } else {
+    return dateString
+  }
+}

--- a/studio/components/interfaces/Authentication/Users/UsersListItem.tsx
+++ b/studio/components/interfaces/Authentication/Users/UsersListItem.tsx
@@ -3,10 +3,10 @@ import { FC } from 'react'
 import { observer } from 'mobx-react-lite'
 import { Badge } from '@supabase/ui'
 
-import { formatPgDateString } from 'lib/helpers'
 import Table from 'components/to-be-cleaned/Table'
 import SimpleCodeBlock from 'components/to-be-cleaned/SimpleCodeBlock'
 import UserDropdown from './UserDropdown'
+import { formatUserDateString } from './Users.utils'
 
 interface Props {
   user: any
@@ -14,8 +14,8 @@ interface Props {
 
 const UserListItem: FC<Props> = ({ user }) => {
   const isUserConfirmed = user.email_confirmed_at || user.phone_confirmed_at
-  const createdAt = formatPgDateString(user.created_at)
-  const lastSignedIn = formatPgDateString(user.last_sign_in_at)
+  const createdAt = formatUserDateString(user.created_at)
+  const lastSignedIn = formatUserDateString(user.last_sign_in_at)
 
   return (
     <Table.tr key={user.id}>

--- a/studio/components/interfaces/Authentication/Users/UsersListItem.tsx
+++ b/studio/components/interfaces/Authentication/Users/UsersListItem.tsx
@@ -1,9 +1,10 @@
 import dayjs from 'dayjs'
 import { FC } from 'react'
 import { observer } from 'mobx-react-lite'
-import { Badge, IconUser, Typography } from '@supabase/ui'
-import Table from 'components/to-be-cleaned/Table'
+import { Badge } from '@supabase/ui'
 
+import { formatPgDateString } from 'lib/helpers'
+import Table from 'components/to-be-cleaned/Table'
 import SimpleCodeBlock from 'components/to-be-cleaned/SimpleCodeBlock'
 import UserDropdown from './UserDropdown'
 
@@ -13,6 +14,9 @@ interface Props {
 
 const UserListItem: FC<Props> = ({ user }) => {
   const isUserConfirmed = user.email_confirmed_at || user.phone_confirmed_at
+  const createdAt = formatPgDateString(user.created_at)
+  const lastSignedIn = formatPgDateString(user.last_sign_in_at)
+
   return (
     <Table.tr key={user.id}>
       <Table.td className="whitespace-nowrap">
@@ -29,15 +33,13 @@ const UserListItem: FC<Props> = ({ user }) => {
         </span>
       </Table.td>
       <Table.td className="hidden 2xl:table-cell">
-        <span className="text-scale-1200">
-          {dayjs(user.created_at).format('DD MMM, YYYY HH:mm')}
-        </span>
+        <span className="text-scale-1200">{dayjs(createdAt).format('DD MMM, YYYY HH:mm')}</span>
       </Table.td>
       <Table.td className="hidden xl:table-cell">
         {!isUserConfirmed ? (
           <Badge color="yellow">Waiting for verification..</Badge>
         ) : user.last_sign_in_at ? (
-          dayjs(user.last_sign_in_at).format('DD MMM, YYYY HH:mm')
+          dayjs(lastSignedIn).format('DD MMM, YYYY HH:mm')
         ) : (
           'Never'
         )}

--- a/studio/components/interfaces/Billing/Subscription/Subscription.tsx
+++ b/studio/components/interfaces/Billing/Subscription/Subscription.tsx
@@ -37,9 +37,6 @@ const Subscription: FC<Props> = ({
   const { ui } = useStore()
   const isOrgOwner = ui.selectedOrganization?.is_owner
 
-  // const nativeBilling = useFlag('nativeBilling')
-  const subscriptionStats = useSubscriptionStats()
-
   const isPayg = subscription?.tier.prod_id === STRIPE_PRODUCT_IDS.PAYG
   const addOns = subscription?.addons ?? []
   const paid = subscription && subscription.tier.unit_amount > 0

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.tsx
@@ -122,6 +122,7 @@ const RowEditor: FC<Props> = ({
 
     if (isEmpty(errors)) {
       updateEditorDirty()
+
       const payload = isNewRecord
         ? generateRowObjectFromFields(rowFields)
         : generateUpdateRowPayload(row, rowFields)

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.utils.ts
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.utils.ts
@@ -275,7 +275,11 @@ export const generateRowObjectFromFields = (
     } else if (field.format === 'bool' && value) {
       rowObject[field.name] = value === 'true'
     } else if (DATETIME_TYPES.includes(field.format)) {
-      rowObject[field.name] = convertInputDatetimeToPostgresDatetime(field.format, value)
+      // Seconds are missing if they are set to 0 in the HTML input
+      // Need to format that first, before passing to dayjs
+      const timeSegments = (value || '').split(':')
+      const formattedValue = timeSegments.length === 2 ? `${value}:00` : value
+      rowObject[field.name] = convertInputDatetimeToPostgresDatetime(field.format, formattedValue)
     } else {
       rowObject[field.name] = value
     }

--- a/studio/lib/helpers.ts
+++ b/studio/lib/helpers.ts
@@ -198,3 +198,34 @@ export async function passwordStrength(value: string) {
     strength,
   }
 }
+
+export const detectBrowser = () => {
+  if (!navigator) return undefined
+
+  if (navigator.userAgent.indexOf('Chrome') !== -1) {
+    return 'Chrome'
+  } else if (navigator.userAgent.indexOf('Firefox') !== -1) {
+    return 'Firefox'
+  } else if (navigator.userAgent.indexOf('Safari') !== -1) {
+    return 'Safari'
+  }
+}
+
+/**
+ * Formats a PG datetime string into a format that's
+ * readable across browsers.
+ * - Postgres: 2022-05-12 09:24:12.639463+00
+ *
+ * These are the acceptable formats that Joshen has experimented so far
+ * - Chrome:   2022-05-12 09:24:12.639463+00 (No format required)
+ * - Firefox:  2022-05-12 09:24:12.639463+00 (No format required)
+ * - Safari:   2022-05-12T09:24:12.639463+00
+ */
+export const formatPgDateString = (dateString: string) => {
+  const browser = detectBrowser()
+  if (browser === 'Safari') {
+    return dateString.replace(' ', 'T')
+  } else {
+    return dateString
+  }
+}

--- a/studio/lib/helpers.ts
+++ b/studio/lib/helpers.ts
@@ -210,22 +210,3 @@ export const detectBrowser = () => {
     return 'Safari'
   }
 }
-
-/**
- * Formats a PG datetime string into a format that's
- * readable across browsers.
- * - Postgres: 2022-05-12 09:24:12.639463+00
- *
- * These are the acceptable formats that Joshen has experimented so far
- * - Chrome:   2022-05-12 09:24:12.639463+00 (No format required)
- * - Firefox:  2022-05-12 09:24:12.639463+00 (No format required)
- * - Safari:   2022-05-12T09:24:12.639463+00
- */
-export const formatPgDateString = (dateString: string) => {
-  const browser = detectBrowser()
-  if (browser === 'Safari') {
-    return dateString.replace(' ', 'T')
-  } else {
-    return dateString
-  }
-}


### PR DESCRIPTION
Resolves https://github.com/supabase/supabase/issues/5937

Just FYI I've only observed the issue / seen reports of this issue on the Auth users page specifically
Mainly because the user's `created_at` and `last_signed_in_at` has an odd(?) format? - there's a space between the date and time segment, which fails on Safari but chrome and firefox are fine
Hence why i've made the solution within the Auth/Users folder

I did a quick check on the other pages that use `dayjs.format()`, but they don't seem to be broken
- e.g BackupsList component, each backup's `inserted_at` follows the correct format of having `T` in between the date and time segments
- Subscriptions component, its using a numerical timestamp value