### PR TITLE
Don't override list function in roles store

### DIFF
--- a/studio/components/to-be-cleaned/Storage/StoragePolicies/StoragePolicies.js
+++ b/studio/components/to-be-cleaned/Storage/StoragePolicies/StoragePolicies.js
@@ -18,7 +18,7 @@ const StoragePolicies = () => {
   const storageStore = useStorageStore()
   const { loaded, buckets } = storageStore
 
-  const roles = meta.roles.list()
+  const roles = meta.roles.list((role) => !meta.roles.systemRoles.includes(role.name))
 
   const [policies, setPolicies] = useState([])
   const [selectedPolicyToEdit, setSelectedPolicyToEdit] = useState({})

--- a/studio/pages/project/[ref]/auth/policies.tsx
+++ b/studio/pages/project/[ref]/auth/policies.tsx
@@ -10,6 +10,7 @@ import NoTableState from 'components/ui/States/NoTableState'
 import { PolicyEditorModal, PolicyTableRow } from 'components/interfaces/Authentication/Policies'
 
 import NoSearchResults from 'components/to-be-cleaned/NoSearchResults'
+import { PostgresRole } from '@supabase/postgres-meta'
 
 const PageContext = createContext(null)
 
@@ -116,7 +117,7 @@ const AuthPoliciesTables = observer(() => {
   const { ui, meta } = useStore()
   const PageState: any = useContext(PageContext)
 
-  const roles = meta.roles.list()
+  const roles = meta.roles.list((role: PostgresRole) => !meta.roles.systemRoles.includes(role.name))
 
   const [selectedSchemaAndTable, setSelectedSchemaAndTable] = useState<any>({})
   const [selectedTableToToggleRLS, setSelectedTableToToggleRLS] = useState<any>({})

--- a/studio/stores/pgmeta/MetaStore.ts
+++ b/studio/stores/pgmeta/MetaStore.ts
@@ -31,7 +31,7 @@ import {
   generateUpdateColumnPayload,
 } from 'components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.utils'
 import { ImportContent } from 'components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.types'
-import RolesStore from './RolesStore'
+import RolesStore, { IRolesStore } from './RolesStore'
 import PoliciesStore from './PoliciesStore'
 import TriggersStore from './TriggersStore'
 import PublicationStore, { IPublicationStore } from './PublicationStore'
@@ -52,7 +52,7 @@ export interface IMetaStore {
   schemas: ISchemaStore
 
   hooks: IPostgresMetaInterface<any>
-  roles: IPostgresMetaInterface<any>
+  roles: IRolesStore
   policies: IPostgresMetaInterface<any>
   triggers: IPostgresMetaInterface<any>
   functions: IPostgresMetaInterface<any>

--- a/studio/stores/pgmeta/RolesStore.ts
+++ b/studio/stores/pgmeta/RolesStore.ts
@@ -1,6 +1,9 @@
-import PostgresMetaInterface from '../common/PostgresMetaInterface'
+import PostgresMetaInterface, { IPostgresMetaInterface } from '../common/PostgresMetaInterface'
 import { IRootStore } from '../RootStore'
 
+export interface IRolesStore extends IPostgresMetaInterface<any> {
+  systemRoles: string[]
+}
 export default class RolesStore extends PostgresMetaInterface<any> {
   constructor(
     rootStore: IRootStore,
@@ -13,23 +16,16 @@ export default class RolesStore extends PostgresMetaInterface<any> {
     super(rootStore, dataUrl, headers, options)
   }
 
-  list(filter: any) {
-    const systemRoles = [
-      'postgres',
-      'pgbouncer',
-      'supabase_admin',
-      'supabase_auth_admin',
-      'supabase_storage_admin',
-      'dashboard_user',
-      'authenticator',
-      'pg_database_owner',
-      'pg_read_all_data',
-      'pg_write_all_data',
-    ]
-
-    const rolesFilter = (role: any) =>
-      !systemRoles.includes(role.name) && (typeof filter === 'function' ? filter(role) : true)
-
-    return super.list(rolesFilter)
-  }
+  systemRoles = [
+    'postgres',
+    'pgbouncer',
+    'supabase_admin',
+    'supabase_auth_admin',
+    'supabase_storage_admin',
+    'dashboard_user',
+    'authenticator',
+    'pg_database_owner',
+    'pg_read_all_data',
+    'pg_write_all_data',
+  ]
 }


### PR DESCRIPTION
Shouldn't be hiding all the roles in the store - only do so on the policies page cause we only want selected options to be available when writing policies