### PR TITLE
fix: rendering and saving issues for RowEditor pertaining to time and…

### DIFF
--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/DateTimeInput/DateTimeInput.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/DateTimeInput/DateTimeInput.tsx
@@ -1,6 +1,7 @@
 import { FC } from 'react'
 import { Input } from '@supabase/ui'
 import { getColumnType } from './DateTimeInput.utils'
+import dayjs from 'dayjs'
 
 interface Props {
   name: string
@@ -11,8 +12,9 @@ interface Props {
 }
 
 /**
- * Postgres date/time format and html date/time input format are different.
- * So we to convert the value back and forth.
+ * Note: HTML Input cannot accept timezones within the value string
+ * e.g Yes: 2022-05-13T14:29:03
+ *     No:  2022-05-13T14:29:03+0800
  */
 const DateTimeInput: FC<Props> = ({ value, onChange, name, format, description }) => {
   const inputType = getColumnType(format)
@@ -32,7 +34,7 @@ const DateTimeInput: FC<Props> = ({ value, onChange, name, format, description }
         description && description.length !== 0
           ? description
           : format.includes('tz')
-          ? 'Your local timezone will be automatically applied'
+          ? `Your local timezone will be automatically applied (${dayjs().format('ZZ')})`
           : undefined
       }
       labelOptional={format}


### PR DESCRIPTION
Resolves https://github.com/supabase/supabase/issues/5545
Resolves https://github.com/supabase/supabase/issues/3291
Resolves https://github.com/supabase/supabase/issues/5877

- Fix when adding new row, value not getting rendered in RowEditor if default value `now() at time zone 'utc'` for column
- Fix when updating row, `timestamp` columns are getting rendered with consideration of session timezone when it should be an absolute value
- Fix when updating row, `timestamp` columns were getting appended with timezone in the payload
- Fix similar issues for `timetz` and `time` columns 
- Added session time zone in helper text for `timestamptz` or `timetz` columns

https://user-images.githubusercontent.com/19742402/168230152-406e6756-1d60-4893-9c86-a9fada13c752.mov

