### PR TITLE
Chore/add learn more redirect

### DIFF
--- a/apps/www/next.config.js
+++ b/apps/www/next.config.js
@@ -651,7 +651,7 @@ module.exports = withMDX({
       },
       {
         permanent: false,
-        source: '/learn-more'
+        source: '/learn-more',
         destination: '/?utm_source=event&utm_medium=billboard&utm_campaign=aws-atlanta',
       },
     ]

--- a/apps/www/next.config.js
+++ b/apps/www/next.config.js
@@ -649,6 +649,11 @@ module.exports = withMDX({
         source: '/partners',
         destination: '/partners/integrations',
       },
+      {
+        permanent: false,
+        source: '/learn-more'
+        destination: '/?utm_source=event&utm_medium=billboard&utm_campaign=aws-atlanta',
+      },
     ]
   },
 })


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add redirect for /learn-more page to see visits from mobile truck campaign

## What is the current behavior?

/learn-more leads to 404 page

## What is the new behavior?

/learn-more redirects to homepage with UTM link for campaign ID
