### PR TITLE
feat: use fly pgmeta apis

### DIFF
--- a/.github/workflows/deploy_vercel_prod.yml
+++ b/.github/workflows/deploy_vercel_prod.yml
@@ -12,6 +12,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      # remove ./studio/pages/api folder before deploying to vercel
+      - uses: JesseTG/rm@v1.0.2
+        with:
+          path: ./studio/pages/api
       - uses: amondnet/vercel-action@v19
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }} # Required

--- a/.github/workflows/deploy_vercel_staging.yml
+++ b/.github/workflows/deploy_vercel_staging.yml
@@ -12,6 +12,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      # remove ./studio/pages/api folder before deploying to vercel
+      - uses: JesseTG/rm@v1.0.2
+        with:
+          path: ./studio/pages/api
       - uses: amondnet/vercel-action@v19
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }} # Required

--- a/studio/stores/pgmeta/MetaStore.ts
+++ b/studio/stores/pgmeta/MetaStore.ts
@@ -119,7 +119,6 @@ export default class MetaStore implements IMetaStore {
 
   connectionString?: string
   baseUrl: string
-  queryBaseUrl: string
   excludedSchemas = [
     'auth',
     'extensions',
@@ -135,8 +134,7 @@ export default class MetaStore implements IMetaStore {
   constructor(rootStore: IRootStore, options: { projectRef: string; connectionString: string }) {
     const { projectRef, connectionString } = options
     this.rootStore = rootStore
-    this.baseUrl = `/api/pg-meta/${projectRef}`
-    this.queryBaseUrl = `${API_URL}/pg-meta/${projectRef}`
+    this.baseUrl = `${API_URL}/pg-meta/${projectRef}`
 
     const headers: any = {}
     if (IS_PLATFORM && connectionString) {
@@ -172,7 +170,7 @@ export default class MetaStore implements IMetaStore {
     try {
       const headers: any = { 'Content-Type': 'application/json' }
       if (this.connectionString) headers['x-connection-encrypted'] = this.connectionString
-      const url = `${this.queryBaseUrl}/query`
+      const url = `${this.baseUrl}/query`
       const response = await post(url, { query: value }, { headers })
       if (response.error) throw response.error
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

- feat: migrate to fly pg-meta apis
- chore: update github action to remove studio/pages/api before deploying to vercel
  - studio/pages/api is only for self-hosted dashboard.