### PR TITLE
[404] Update Javascript URL on supabase.com/docs

### DIFF
--- a/web/docs/about.mdx
+++ b/web/docs/about.mdx
@@ -38,7 +38,7 @@ const frameworks = [
   {
     name: 'JavaScript',
     logo: JavascriptLogo,
-    href: 'https://github.com/supabase/supabase/tree/master/examples/javascript-auth',
+    href: 'https://github.com/supabase/supabase/tree/master/examples/auth/javascript-auth',
   },
   {
     name: 'Next.js',


### PR DESCRIPTION
Update on
https://supabase.com/docs
where "JavaScript" button is redirecting to 404 page. This 👇 https://github.com/supabase/supabase/tree/master/examples/javascript-auth

![image](https://user-images.githubusercontent.com/50055027/168925051-132ef0f2-527e-4c85-a009-805f1cb3b2bb.png)

![image](https://user-images.githubusercontent.com/50055027/168925195-41d21b10-c9c1-4fc6-8b23-4304b3ca6926.png)

but the rigth one is 👇 with "auth" folder
https://github.com/supabase/supabase/tree/master/examples/auth/javascript-auth

![image](https://user-images.githubusercontent.com/50055027/168925484-e9aae1e1-bf2b-41d4-ad9b-b20c3fef7715.png)




