### PR TITLE
fix: link to css stylesheet in quickstart guides changed

### DIFF
--- a/web/docs/guides/with-redwoodjs.mdx
+++ b/web/docs/guides/with-redwoodjs.mdx
@@ -325,7 +325,7 @@ export default App
 ```
 
 And one optional step is to update the CSS file `web/src/index.css` to make the app look nice.
-You can find the full contents of this file [here](https://raw.githubusercontent.com/supabase/supabase/master/examples/react-user-management/src/index.css).
+You can find the full contents of this file [here](https://raw.githubusercontent.com/supabase/supabase/master/examples/user-management/react-user-management/src/index.css).
 
 ### Start RedwoodJS and your first Page
 

--- a/web/docs/guides/with-solidjs.mdx
+++ b/web/docs/guides/with-solidjs.mdx
@@ -198,7 +198,7 @@ export const supabase = createClient(supabaseUrl, supabaseAnonKey)
 ```
 
 And one optional step is to update the CSS file `src/index.css` to make the app look nice.
-You can find the full contents of this file [here](https://raw.githubusercontent.com/supabase/supabase/master/examples/react-user-management/src/index.css).
+You can find the full contents of this file [here](https://raw.githubusercontent.com/supabase/supabase/master/examples/user-management/react-user-management/src/index.css).
 
 ### Set up a Login component
 

--- a/web/docs/guides/with-svelte.mdx
+++ b/web/docs/guides/with-svelte.mdx
@@ -222,7 +222,7 @@ export const supabase = createClient(supabaseUrl, supabaseAnonKey)
 ```
 
 And one optional step is to update the CSS file `public/global.css` to make the app look nice. 
-You can find the full contents of this file [here](https://raw.githubusercontent.com/supabase/supabase/master/examples/react-user-management/src/index.css).
+You can find the full contents of this file [here](https://raw.githubusercontent.com/supabase/supabase/master/examples/user-management/react-user-management/src/index.css).
 
 ### Set up a Login component
 

--- a/web/docs/guides/with-vue-3.mdx
+++ b/web/docs/guides/with-vue-3.mdx
@@ -189,7 +189,7 @@ export const supabase = createClient(supabaseUrl, supabaseAnonKey)
 ```
 
 And one optional step is to update the CSS file `src/assets/main.css` to make the app look nice. 
-You can find the full contents of this file [here](https://raw.githubusercontent.com/supabase/supabase/master/examples/react-user-management/src/index.css).
+You can find the full contents of this file [here](https://raw.githubusercontent.com/supabase/supabase/master/examples/user-management/react-user-management/src/index.css).
 
 ```javascript title="src/main.js"
 import { createApp } from "vue"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The css links for the quickstarts are currently showing a 404 error and the page is not displayed.

## What is the new behavior?

The link has been changed so that the css file is shown

## Additional context

I havent changed `with-sveltekit-mdx` as this has been done in #6858 
