### PR TITLE
fix: solid-js supabaseClient env values

### DIFF
--- a/web/docs/guides/with-solidjs.mdx
+++ b/web/docs/guides/with-solidjs.mdx
@@ -191,8 +191,8 @@ on the browser, and that's completely fine since we have [Row Level Security](/d
 ```js title="src/supabaseClient.jsx"
 import { createClient } from '@supabase/supabase-js'
 
-const supabaseUrl = process.env.VITE_SUPABASE_URL
-const supabaseAnonKey = process.env.VITE_SUPABASE_ANON_KEY
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey)
 ```


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

This is for the [solid-js](https://supabase.com/docs/guides/with-solidjs#initialize-a-solidjs-app) quickstart guide.

Currently in the docs when creating the supabase client the following is created:

```js title="src/supabaseClient.jsx"
import { createClient } from '@supabase/supabase-js'

const supabaseUrl = process.env.VITE_SUPABASE_URL
const supabaseAnonKey = process.env.VITE_SUPABASE_ANON_KEY

export const supabase = createClient(supabaseUrl, supabaseAnonKey)
```

When the project is previewed using `npm start` nothing happens and you get an error in the console.

## What is the new behavior?

Changing the way the `.env` values are imported to the following results in the page loading:

```js title="src/supabaseClient.jsx"
import { createClient } from '@supabase/supabase-js'

const supabaseUrl = import.meta.env.VITE_SUPABASE_URL
const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY

export const supabase = createClient(supabaseUrl, supabaseAnonKey)
```

## Additional context

This is linked to #6807 which @hmatsu47 created.
