### PR TITLE
fix: solid-js quickstart example buttons

### DIFF
--- a/web/docs/guides/with-solidjs.mdx
+++ b/web/docs/guides/with-solidjs.mdx
@@ -359,7 +359,7 @@ const Account = (props) => {
             />
           </div>
           <div>
-            <button className="button block primary" disabled={loading}>
+            <button type="submit" className="button block primary" disabled={loading()}>
               Update profile
             </button>
           </div>

--- a/web/docs/guides/with-solidjs.mdx
+++ b/web/docs/guides/with-solidjs.mdx
@@ -245,7 +245,7 @@ export default function Auth() {
               value={email()}
               onChange={(e) => setEmail(e.target.value)}
             />
-            <button className="button block" aria-live="polite">
+            <button type="submit" className="button block" aria-live="polite">
               Send magic link
             </button>
           </form>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

When running through the example in the [solid-js quickstart example](https://supabase.com/docs/guides/with-solidjs#account-page) the submit button on the `Account.jsx` component stays disabled and no requests are made when submiting.


```
<button className="button block primary" disabled={loading}>
  Update profile
</button>
```

This is happening due to missing brackets on the disabled signal value

## What is the new behavior?

The disabled value is now referencing the `loading` signal and the button is now making requests:
```
<button type="submit" className="button block primary" disabled={loading()}>
  Update profile
</button>
```
## Additional context

I've also added a button attribute `type` of `submit` on the form buttons. I've noticed that some of the quickstart guides do not have a `type` attribute of `submit` in some of the forms. By default a button inside a form without a `type` attribute will submit but don't know if adding the attribute will help others out and be more readable? 

I can add the `type` attribute in the other guides if needed.
