### PR TITLE
fix: Swap out api reference links to point to guide home page

### DIFF
--- a/apps/www/data/Footer.json
+++ b/apps/www/data/Footer.json
@@ -70,7 +70,7 @@
       },
       {
         "text": "API Reference",
-        "url": "/docs/client/supabase-client"
+        "url": "/docs/guides/api"
       },
       {
         "text": "Guides",

--- a/studio/components/layouts/AccountLayout/AccountLayout.tsx
+++ b/studio/components/layouts/AccountLayout/AccountLayout.tsx
@@ -100,7 +100,7 @@ const AccountLayout = ({ children, title, breadcrumbs }: any) => {
           key: 'ext-guides',
           icon: '/img/book-open.svg',
           label: 'API Reference',
-          href: 'https://supabase.com/docs/reference/javascript/supabase-client',
+          href: 'https://supabase.com/docs/guides/api',
           external: true,
         },
       ],

--- a/studio/components/layouts/DocsLayout/DocsLayout.utils.tsx
+++ b/studio/components/layouts/DocsLayout/DocsLayout.utils.tsx
@@ -72,7 +72,7 @@ export const generateDocsMenu = (
         {
           name: 'API Reference',
           key: 'api-reference',
-          url: `https://supabase.com/docs/reference/javascript/supabase-client`,
+          url: `https://supabase.com/docs/guides/api`,
           icon: <IconBookOpen size={14} strokeWidth={2} />,
           items: [],
           isExternal: true,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Doc update

## What is the current behavior?

https://github.com/supabase/supabase/issues/6699

## What is the new behavior?

Updates API reference link from js client to api guide home page which is more appropriate for all users and not just limited to js users.

## Additional context

N/A