### PR TITLE
Feat: add npm and yarn tabs

### DIFF
--- a/web/docs/guides/with-angular.mdx
+++ b/web/docs/guides/with-angular.mdx
@@ -167,9 +167,27 @@ cd supabase-angular
 
 Then let's install the only additional dependency: [supabase-js](https://github.com/supabase/supabase-js)
 
+<Tabs
+defaultValue="NPM"
+values={[
+  {label: 'npm', value: 'NPM'},
+  {label: 'Yarn', value: 'YARN'},
+]}>
+<TabItem value="NPM">
+
 ```bash
 npm install @supabase/supabase-js
 ```
+
+</TabItem>
+<TabItem value="YARN">
+
+```bash
+yarn add @supabase/supabase-js
+```
+
+</TabItem>
+</Tabs>
 
 And finally we want to save the environment variables in the `environment.ts` file.
 All we need are the API URL and the `anon` key that you copied [earlier](#get-the-api-keys).
@@ -457,9 +475,27 @@ export class AppComponent implements OnInit {
 
 Once that's done, run this in a terminal window:
 
+<Tabs
+defaultValue="NPM"
+values={[
+  {label: 'npm', value: 'NPM'},
+  {label: 'Yarn', value: 'YARN'},
+]}>
+<TabItem value="NPM">
+
 ```bash
 npm run start
 ```
+
+</TabItem>
+<TabItem value="YARN">
+
+```bash
+yarn start
+```
+
+</TabItem>
+</Tabs>
 
 And then open the browser to [localhost:4200](http://localhost:4200) and you should see the completed app.
 

--- a/web/docs/guides/with-expo.mdx
+++ b/web/docs/guides/with-expo.mdx
@@ -153,13 +153,27 @@ cd supabaseReactNative
 
 Then let's install the additional dependencies: [supabase-js](https://github.com/supabase/supabase-js)
 
+<Tabs
+defaultValue="NPM"
+values={[
+  {label: 'npm', value: 'NPM'},
+  {label: 'Yarn', value: 'YARN'},
+]}>
+<TabItem value="NPM">
+
 ```bash
-yarn add @supabase/supabase-js
-yarn add react-native-elements
-yarn add react-native-safe-area-context
-yarn add @react-native-async-storage/async-storage
-yarn add react-native-url-polyfill
+npm install @supabase/supabase-js react-native-elements react-native-safe-area-context @react-native-async-storage/async-storage react-native-url-polyfill
 ```
+
+</TabItem>
+<TabItem value="YARN">
+
+```bash
+yarn add @supabase/supabase-js react-native-elements react-native-safe-area-context @react-native-async-storage/async-storage react-native-url-polyfill
+```
+
+</TabItem>
+</Tabs>
 
 Now let's create a helper file to initialize the Supabase client.
 We need the API URL and the `anon` key that you copied [earlier](#get-the-api-keys).
@@ -439,9 +453,27 @@ export default function App() {
 
 Once that's done, run this in a terminal window:
 
+<Tabs
+defaultValue="NPM"
+values={[
+  {label: 'npm', value: 'NPM'},
+  {label: 'Yarn', value: 'YARN'},
+]}>
+<TabItem value="NPM">
+
+```bash
+npm run start
+```
+
+</TabItem>
+<TabItem value="YARN">
+
 ```bash
 yarn start
 ```
+
+</TabItem>
+</Tabs>
 
 And then open the browser to [localhost:3000](http://localhost:3000) and you should see the completed app.
 

--- a/web/docs/guides/with-ionic-angular.mdx
+++ b/web/docs/guides/with-ionic-angular.mdx
@@ -160,17 +160,55 @@ Let's start building the Angular app from scratch.
 We can use the [Ionic CLI](https://ionicframework.com/docs/cli) to initialize
 an app called `supabase-ionic-angular`:
 
+<Tabs
+defaultValue="NPM"
+values={[
+  {label: 'npm', value: 'NPM'},
+  {label: 'Yarn', value: 'YARN'},
+]}>
+<TabItem value="NPM">
+
 ```bash
 npm install -g @ionic/cli
 ionic start supabase-ionic-angular blank --type angular
 cd supabase-ionic-angular
 ```
 
+</TabItem>
+<TabItem value="YARN">
+
+```bash
+yarn add -g @ionic/cli
+ionic start supabase-ionic-angular blank --type angular
+cd supabase-ionic-angular
+```
+
+</TabItem>
+</Tabs>
+
 Then let's install the only additional dependency: [supabase-js](https://github.com/supabase/supabase-js)
+
+<Tabs
+defaultValue="NPM"
+values={[
+  {label: 'npm', value: 'NPM'},
+  {label: 'Yarn', value: 'YARN'},
+]}>
+<TabItem value="NPM">
 
 ```bash
 npm install @supabase/supabase-js
 ```
+
+</TabItem>
+<TabItem value="YARN">
+
+```bash
+yarn add @supabase/supabase-js
+```
+
+</TabItem>
+</Tabs>
 
 And finally we want to save the environment variables in the `environment.ts` file.
 All we need are the API URL and the `anon` key that you copied [earlier](#get-the-api-keys).
@@ -535,9 +573,27 @@ Let's create an avatar for the user so that they can upload a profile photo.
 
 First install two packages in order to interact with the user's camera.
 
+<Tabs
+defaultValue="NPM"
+values={[
+  {label: 'npm', value: 'NPM'},
+  {label: 'Yarn', value: 'YARN'},
+]}>
+<TabItem value="NPM">
+
 ```bash
 npm install @ionic/pwa-elements @capacitor/camera
 ```
+
+</TabItem>
+<TabItem value="YARN">
+
+```bash
+yarn add @ionic/pwa-elements @capacitor/camera
+```
+
+</TabItem>
+</Tabs>
 
 [CapacitorJS](https://capacitorjs.com) is a cross platform native runtime from Ionic that enables web apps to be deployed through the app store and provides access to native deavice API.
 

--- a/web/docs/guides/with-ionic-react.mdx
+++ b/web/docs/guides/with-ionic-react.mdx
@@ -160,17 +160,55 @@ Let's start building the React app from scratch.
 We can use the [Ionic CLI](https://ionicframework.com/docs/cli) to initialize
 an app called `supabase-ionic-react`:
 
+<Tabs
+defaultValue="NPM"
+values={[
+  {label: 'npm', value: 'NPM'},
+  {label: 'Yarn', value: 'YARN'},
+]}>
+<TabItem value="NPM">
+
 ```bash
 npm install -g @ionic/cli
 ionic start supabase-ionic-react blank --type react
 cd supabase-ionic-react
 ```
 
+</TabItem>
+<TabItem value="YARN">
+
+```bash
+yarn add -g @ionic/cli
+ionic start supabase-ionic-react blank --type react
+cd supabase-ionic-react
+```
+
+</TabItem>
+</Tabs>
+
 Then let's install the only additional dependency: [supabase-js](https://github.com/supabase/supabase-js)
+
+<Tabs
+defaultValue="NPM"
+values={[
+  {label: 'npm', value: 'NPM'},
+  {label: 'Yarn', value: 'YARN'},
+]}>
+<TabItem value="NPM">
 
 ```bash
 npm install @supabase/supabase-js
 ```
+
+</TabItem>
+<TabItem value="YARN">
+
+```bash
+yarn add @supabase/supabase-js
+```
+
+</TabItem>
+</Tabs>
 
 And finally we want to save the environment variables in a `.env`.
 All we need are the API URL and the `anon` key that you copied [earlier](#get-the-api-keys).

--- a/web/docs/guides/with-ionic-vue.mdx
+++ b/web/docs/guides/with-ionic-vue.mdx
@@ -160,17 +160,55 @@ Let's start building the Vue app from scratch.
 We can use the [Ionic CLI](https://ionicframework.com/docs/cli) to initialize
 an app called `supabase-ionic-vue`:
 
+<Tabs
+defaultValue="NPM"
+values={[
+  {label: 'npm', value: 'NPM'},
+  {label: 'Yarn', value: 'YARN'},
+]}>
+<TabItem value="NPM">
+
 ```bash
 npm install -g @ionic/cli
 ionic start supabase-ionic-vue blank --type vue
 cd supabase-ionic-vue
 ```
 
+</TabItem>
+<TabItem value="YARN">
+
+```bash
+yarn add -g @ionic/cli
+ionic start supabase-ionic-vue blank --type vue
+cd supabase-ionic-vue
+```
+
+</TabItem>
+</Tabs>
+
 Then let's install the only additional dependency: [supabase-js](https://github.com/supabase/supabase-js)
+
+<Tabs
+defaultValue="NPM"
+values={[
+  {label: 'npm', value: 'NPM'},
+  {label: 'Yarn', value: 'YARN'},
+]}>
+<TabItem value="NPM">
 
 ```bash
 npm install @supabase/supabase-js
 ```
+
+</TabItem>
+<TabItem value="YARN">
+
+```bash
+yarn add @supabase/supabase-js
+```
+
+</TabItem>
+</Tabs>
 
 And finally we want to save the environment variables in a `.env`.
 All we need are the API URL and the `anon` key that you copied [earlier](#get-the-api-keys).
@@ -549,9 +587,27 @@ Every Supabase project is configured with [Storage](/docs/guides/storage) for ma
 
 First install two packages in order to interact with the user's camera.
 
+<Tabs
+defaultValue="NPM"
+values={[
+  {label: 'npm', value: 'NPM'},
+  {label: 'Yarn', value: 'YARN'},
+]}>
+<TabItem value="NPM">
+
 ```bash
 npm install @ionic/pwa-elements @capacitor/camera
 ```
+
+</TabItem>
+<TabItem value="YARN">
+
+```bash
+yarn add @ionic/pwa-elements @capacitor/camera
+```
+
+</TabItem>
+</Tabs>
 
 [CapacitorJS](https://capacitorjs.com) is a cross platform native runtime from Ionic that enables web apps to be deployed through the app store and provides access to native deavice API.
 

--- a/web/docs/guides/with-nextjs.mdx
+++ b/web/docs/guides/with-nextjs.mdx
@@ -177,9 +177,27 @@ cd supabase-nextjs
 
 Then let's install the only additional dependency: [supabase-js](https://github.com/supabase/supabase-js)
 
+<Tabs
+defaultValue="NPM"
+values={[
+  {label: 'npm', value: 'NPM'},
+  {label: 'Yarn', value: 'YARN'},
+]}>
+<TabItem value="NPM">
+
 ```bash
 npm install @supabase/supabase-js
 ```
+
+</TabItem>
+<TabItem value="YARN">
+
+```bash
+yarn add @supabase/supabase-js
+```
+
+</TabItem>
+</Tabs>
 
 And finally we want to save the environment variables in a `.env.local`. 
 All we need are the API URL and the `anon` key that you copied [earlier](#get-the-api-keys).
@@ -416,9 +434,27 @@ export default function Home() {
 
 Once that's done, run this in a terminal window:
 
+<Tabs
+defaultValue="NPM"
+values={[
+  {label: 'npm', value: 'NPM'},
+  {label: 'Yarn', value: 'YARN'},
+]}>
+<TabItem value="NPM">
+
 ```bash
 npm run dev
 ```
+
+</TabItem>
+<TabItem value="YARN">
+
+```bash
+yarn dev
+```
+
+</TabItem>
+</Tabs>
 
 And then open the browser to [localhost:3000](http://localhost:3000) and you should see the completed app.
 

--- a/web/docs/guides/with-react.mdx
+++ b/web/docs/guides/with-react.mdx
@@ -167,16 +167,53 @@ Let's start building the React app from scratch.
 We can use [Create React App](https://create-react-app.dev/docs/getting-started/) to initialize
 an app called `supabase-react`:
 
+<Tabs
+defaultValue="NPM"
+values={[
+  {label: 'npm', value: 'NPM'},
+  {label: 'Yarn', value: 'YARN'},
+]}>
+<TabItem value="NPM">
+
 ```bash
 npx create-react-app supabase-react --use-npm
 cd supabase-react
 ```
 
+</TabItem>
+<TabItem value="YARN">
+
+```bash
+npx create-react-app supabase-react
+cd supabase-react
+```
+
+</TabItem>
+</Tabs>
+
 Then let's install the only additional dependency: [supabase-js](https://github.com/supabase/supabase-js)
+
+<Tabs
+defaultValue="NPM"
+values={[
+  {label: 'npm', value: 'NPM'},
+  {label: 'Yarn', value: 'YARN'},
+]}>
+<TabItem value="NPM">
 
 ```bash
 npm install @supabase/supabase-js
 ```
+
+</TabItem>
+<TabItem value="YARN">
+
+```bash
+yarn add @supabase/supabase-js
+```
+
+</TabItem>
+</Tabs>
 
 And finally we want to save the environment variables in a `.env`.
 All we need are the API URL and the `anon` key that you copied [earlier](#get-the-api-keys).
@@ -407,9 +444,27 @@ export default function App() {
 
 Once that's done, run this in a terminal window:
 
+<Tabs
+defaultValue="NPM"
+values={[
+  {label: 'npm', value: 'NPM'},
+  {label: 'Yarn', value: 'YARN'},
+]}>
+<TabItem value="NPM">
+
 ```bash
 npm start
 ```
+
+</TabItem>
+<TabItem value="YARN">
+
+```bash
+yarn start
+```
+
+</TabItem>
+</Tabs>
 
 And then open the browser to [localhost:3000](http://localhost:3000) and you should see the completed app.
 
@@ -421,7 +476,7 @@ Every Supabase project is configured with [Storage](/docs/guides/storage) for ma
 
 ### Add @reach/visually-hidden
 
-The upload widget uses one additional npm library. You can install it like so: `npm install @reach/visually-hidden`.
+The upload widget uses one additional npm library. You can install it like so: `npm install @reach/visually-hidden` or `yarn add @reach/visually-hidden`.
 
 ### Create an upload widget
 

--- a/web/docs/guides/with-solidjs.mdx
+++ b/web/docs/guides/with-solidjs.mdx
@@ -173,9 +173,27 @@ cd supabase-solid
 
 Then let's install the only additional dependency: [supabase-js](https://github.com/supabase/supabase-js)
 
+<Tabs
+defaultValue="NPM"
+values={[
+  {label: 'npm', value: 'NPM'},
+  {label: 'Yarn', value: 'YARN'},
+]}>
+<TabItem value="NPM">
+
 ```bash
 npm install @supabase/supabase-js
 ```
+
+</TabItem>
+<TabItem value="YARN">
+
+```bash
+yarn add @supabase/supabase-js
+```
+
+</TabItem>
+</Tabs>
 
 And finally we want to save the environment variables in a `.env`.
 All we need are the API URL and the `anon` key that you copied [earlier](#get-the-api-keys).
@@ -407,9 +425,27 @@ export default () => {
 
 Once that's done, run this in a terminal window:
 
+<Tabs
+defaultValue="NPM"
+values={[
+  {label: 'npm', value: 'NPM'},
+  {label: 'Yarn', value: 'YARN'},
+]}>
+<TabItem value="NPM">
+
 ```bash
 npm start
 ```
+
+</TabItem>
+<TabItem value="YARN">
+
+```bash
+yarn start
+```
+
+</TabItem>
+</Tabs>
 
 And then open the browser to [localhost:3000](http://localhost:3000) and you should see the completed app.
 

--- a/web/docs/guides/with-svelte.mdx
+++ b/web/docs/guides/with-svelte.mdx
@@ -159,9 +159,27 @@ cd supabase-svelte
 
 Then let's install the only additional dependency: [supabase-js](https://github.com/supabase/supabase-js)
 
+<Tabs
+defaultValue="NPM"
+values={[
+  {label: 'npm', value: 'NPM'},
+  {label: 'Yarn', value: 'YARN'},
+]}>
+<TabItem value="NPM">
+
 ```bash
 npm install @supabase/supabase-js
 ```
+
+</TabItem>
+<TabItem value="YARN">
+
+```bash
+yarn add @supabase/supabase-js
+```
+
+</TabItem>
+</Tabs>
 
 And finally we want to save the environment variables in a `.env`. 
 All we need are the API URL and the `anon` key that you copied [earlier](#get-the-api-keys).
@@ -174,15 +192,51 @@ SVELTE_APP_SUPABASE_ANON_KEY=YOUR_SUPABASE_ANON_KEY
 Our app is almost functional, to make svelte work with supabase and .env files we first need to change the `rollup.config.js` file a bit.
 Supabase imports `json` files, to convert .json files to ES6 modules we need the `@rollup/plugin-json` install it by running: 
 
+<Tabs
+defaultValue="NPM"
+values={[
+  {label: 'npm', value: 'NPM'},
+  {label: 'Yarn', value: 'YARN'},
+]}>
+<TabItem value="NPM">
+
 ```bash
-  npm install --save-dev @rollup/plugin-json
+npm install --save-dev @rollup/plugin-json
 ```
+
+</TabItem>
+<TabItem value="YARN">
+
+```bash
+yarn add --save-dev @rollup/plugin-json
+```
+
+</TabItem>
+</Tabs>
 
 Furthermore, to use the .env with svelte we need another rollup plugin. Install:
 
+<Tabs
+defaultValue="NPM"
+values={[
+  {label: 'npm', value: 'NPM'},
+  {label: 'Yarn', value: 'YARN'},
+]}>
+<TabItem value="NPM">
+
 ```bash
-  npm install --save-dev dotenv @rollup/plugin-replace
+npm install --save-dev dotenv @rollup/plugin-replace
 ```
+
+</TabItem>
+<TabItem value="YARN">
+
+```bash
+yarn add --save-dev dotenv @rollup/plugin-replace
+```
+
+</TabItem>
+</Tabs>
 
 and add these plugins to the `rollup.config.js` file.
 
@@ -421,9 +475,27 @@ Now that we have all the components in place, let's update `App.svelte`:
 
 Once that's done, run this in a terminal window:
 
+<Tabs
+defaultValue="NPM"
+values={[
+  {label: 'npm', value: 'NPM'},
+  {label: 'Yarn', value: 'YARN'},
+]}>
+<TabItem value="NPM">
+
 ```bash
 npm run dev
 ```
+
+</TabItem>
+<TabItem value="YARN">
+
+```bash
+yarn dev
+```
+
+</TabItem>
+</Tabs>
 
 And then open the browser to [localhost:5000](http://localhost:5000) and you should see the completed app.
 

--- a/web/docs/guides/with-sveltekit.mdx
+++ b/web/docs/guides/with-sveltekit.mdx
@@ -153,16 +153,53 @@ Let's start building the Svelte app from scratch.
 We can use the [SvelteKit Skeleton Project](https://kit.svelte.dev/docs) to initialize 
 an app called `supabase-sveltekit`:
 
+<Tabs
+defaultValue="NPM"
+values={[
+  {label: 'npm', value: 'NPM'},
+  {label: 'Yarn', value: 'YARN'},
+]}>
+<TabItem value="NPM">
+
 ```bash
 npm init svelte@next supabase-sveltekit
 cd supabase-sveltekit
 ```
 
+</TabItem>
+<TabItem value="YARN">
+
+```bash
+yarn init svelte@next supabase-sveltekit
+cd supabase-sveltekit
+```
+
+</TabItem>
+</Tabs>
+
 Then let's install the only additional dependency: [supabase-js](https://github.com/supabase/supabase-js)
+
+<Tabs
+defaultValue="NPM"
+values={[
+  {label: 'npm', value: 'NPM'},
+  {label: 'Yarn', value: 'YARN'},
+]}>
+<TabItem value="NPM">
 
 ```bash
 npm install @supabase/supabase-js
 ```
+
+</TabItem>
+<TabItem value="YARN">
+
+```bash
+yarn add @supabase/supabase-js
+```
+
+</TabItem>
+</Tabs>
 
 And finally we want to save the environment variables in a `.env`. 
 All we need are the `SUPABASE_URL` and the `SUPABASE_KEY` key that you copied [earlier](#get-the-api-keys).
@@ -384,9 +421,27 @@ Now that we have all the components in place, let's update `src/routes/index.sve
 
 Once that's done, run this in a terminal window:
 
+<Tabs
+defaultValue="NPM"
+values={[
+  {label: 'npm', value: 'NPM'},
+  {label: 'Yarn', value: 'YARN'},
+]}>
+<TabItem value="NPM">
+
 ```bash
 npm run dev
 ```
+
+</TabItem>
+<TabItem value="YARN">
+
+```bash
+yarn dev
+```
+
+</TabItem>
+</Tabs>
 
 And then open the browser to [localhost:3000](http://localhost:3000) and you should see the completed app.
 

--- a/web/docs/guides/with-vue-3.mdx
+++ b/web/docs/guides/with-vue-3.mdx
@@ -152,6 +152,14 @@ Let's start building the Vue 3 app from scratch.
 We can quickly use [Vite with Vue 3 Template](https://vitejs.dev/guide/#scaffolding-your-first-vite-project) to initialize
 an app called `supabase-vue-3`:
 
+<Tabs
+defaultValue="NPM"
+values={[
+  {label: 'npm', value: 'NPM'},
+  {label: 'Yarn', value: 'YARN'},
+]}>
+<TabItem value="NPM">
+
 ```bash
 # npm 6.x
 npm init @vitejs/app supabase-vue-3 --template vue
@@ -162,11 +170,41 @@ npm init @vitejs/app supabase-vue-3 -- --template vue
 cd supabase-vue-3
 ```
 
+</TabItem>
+<TabItem value="YARN">
+
+```bash
+yarn init @vitejs/app supabase-vue-3 --template vue
+
+cd supabase-vue-3
+```
+
+</TabItem>
+</Tabs>
+
 Then let's install the only additional dependency: [supabase-js](https://github.com/supabase/supabase-js)
+
+<Tabs
+defaultValue="NPM"
+values={[
+  {label: 'npm', value: 'NPM'},
+  {label: 'Yarn', value: 'YARN'},
+]}>
+<TabItem value="NPM">
 
 ```bash
 npm install @supabase/supabase-js
 ```
+
+</TabItem>
+<TabItem value="YARN">
+
+```bash
+yarn add @supabase/supabase-js
+```
+
+</TabItem>
+</Tabs>
 
 And finally we want to save the environment variables in a `.env`. 
 All we need are the API URL and the `anon` key that you copied [earlier](#get-the-api-keys).
@@ -449,9 +487,27 @@ export default {
 
 Once that's done, run this in a terminal window:
 
+<Tabs
+defaultValue="NPM"
+values={[
+  {label: 'npm', value: 'NPM'},
+  {label: 'Yarn', value: 'YARN'},
+]}>
+<TabItem value="NPM">
+
 ```bash
 npm run dev
 ```
+
+</TabItem>
+<TabItem value="YARN">
+
+```bash
+yarn dev
+```
+
+</TabItem>
+</Tabs>
 
 And then open the browser to [localhost:3000](http://localhost:3000) and you should see the completed app.
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds `npm` and `yarn` tabs to quick starts examples.

## What is the current behavior?

Close https://github.com/supabase/supabase/issues/6826 either `npm` or `yarn`.

<img width="838" alt="image" src="https://user-images.githubusercontent.com/70828596/169732031-7262b2b7-8601-4bb4-b83f-8483f138ba9c.png">

## What is the new behavior?

Both `npm` and `yarn`.

<img width="814" alt="image" src="https://user-images.githubusercontent.com/70828596/169732388-1e183fe2-32d7-4be0-a84f-97eb1b0d4251.png">
<img width="814" alt="image" src="https://user-images.githubusercontent.com/70828596/169732346-42200e67-1aac-4b9c-abcf-25b6222cf461.png">