### PR TITLE
feat: npm and yarn tabs added for integration guides

### DIFF
--- a/web/docs/guides/integrations/auth0.mdx
+++ b/web/docs/guides/integrations/auth0.mdx
@@ -4,6 +4,9 @@ title: 'Auth0'
 description: 'Swap out Supabase authentication with Auth0. Let Auth0 handle tokens and signing users in and out, while Supabase enforces authorization policies with Row Level Security (RLS).'
 ---
 
+import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
+
 This guide steps through building a Next.js application with Auth0 and Supabase. We configure Auth0 to handle authenticating users and managing tokens, while writing our authorization logic in Supabase - using Row Level Security policies.
 
 > Note: This guide is heavily inspired by the [Using Next.js and Auth0 with Supabase](https://auth0.com/blog/using-nextjs-and-auth0-with-supabase/) article on [Auth0's blog](https://auth0.com/blog/). Check it out for a practical step-by-step guide on integrating Auth0 and Supabase.
@@ -129,17 +132,53 @@ SUPABASE_SIGNING_SECRET=get-from-supabase-dashboard
 
 Restart your Next.js development server to read in the new values from `.env.local`.
 
+<Tabs
+defaultValue="NPM"
+values={[
+  {label: 'npm', value: 'NPM'},
+  {label: 'Yarn', value: 'YARN'},
+]}>
+<TabItem value="NPM">
+
 ```bash
 npm run dev
 ```
+
+</TabItem>
+<TabItem value="YARN">
+
+```bash
+yarn dev
+```
+
+</TabItem>
+</Tabs>
 
 ## Step 6: Install Auth0 Next.js library
 
 Install the `@auth0/nextjs-auth0` library.
 
+<Tabs
+defaultValue="NPM"
+values={[
+  {label: 'npm', value: 'NPM'},
+  {label: 'Yarn', value: 'YARN'},
+]}>
+<TabItem value="NPM">
+
 ```bash
-npm i @auth0/nextjs-auth0
+npm install @auth0/nextjs-auth0
 ```
+
+</TabItem>
+<TabItem value="YARN">
+
+```bash
+yarn add @auth0/nextjs-auth0
+```
+
+</TabItem>
+</Tabs>
 
 Create a new file `pages/api/auth/[...auth0].js` and add:
 
@@ -221,9 +260,27 @@ We can do that using Auth0's `afterCallback` function, which gets called anytime
 
 Install the `jsonwebtoken` library.
 
+<Tabs
+defaultValue="NPM"
+values={[
+  {label: 'npm', value: 'NPM'},
+  {label: 'Yarn', value: 'YARN'},
+]}>
+<TabItem value="NPM">
+
 ```bash
-npm i jsonwebtoken
+npm install jsonwebtoken
 ```
+
+</TabItem>
+<TabItem value="YARN">
+
+```bash
+yarn add jsonwebtoken
+```
+
+</TabItem>
+</Tabs>
 
 Update `pages/api/auth/[...auth0].js` with the following:
 

--- a/web/docs/guides/integrations/clerk.mdx
+++ b/web/docs/guides/integrations/clerk.mdx
@@ -4,6 +4,9 @@ title: 'Clerk'
 description: 'This guide explains how to connect your Supabase database with Clerk, a powerful authentication provider built for the modern web.'
 ---
 
+import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
+
 This guide explains how to connect your Supabase database with [Clerk](https://clerk.dev), an authentication provider built for the modern web.
 
 Clerk authenticates users, manages session tokens, and provides user management functionality that can be used in combination with the authorization logic available in Supabase through PostgreSQL Row Level Security (RLS) policies.
@@ -70,9 +73,27 @@ After setting those three environment variables, you should be able to start up 
 
 Install the JavaScript client for Supabase with:
 
+<Tabs
+defaultValue="NPM"
+values={[
+  {label: 'npm', value: 'NPM'},
+  {label: 'Yarn', value: 'YARN'},
+]}>
+<TabItem value="NPM">
+
 ```bash
 npm install @supabase/supabase-js
 ```
+
+</TabItem>
+<TabItem value="YARN">
+
+```bash
+yarn add @supabase/supabase-js
+```
+
+</TabItem>
+</Tabs>
 
 Initialize the Supabase client by passing it the environment variables.
 
@@ -92,9 +113,27 @@ export default supabase;
 
 Install the latest Clerk Next.js SDK by running the following:
 
+<Tabs
+defaultValue="NPM"
+values={[
+  {label: 'npm', value: 'NPM'},
+  {label: 'Yarn', value: 'YARN'},
+]}>
+<TabItem value="NPM">
+
 ```bash
 npm install @clerk/nextjs@next
 ```
+
+</TabItem>
+<TabItem value="YARN">
+
+```bash
+yarn add @clerk/nextjs@next
+```
+
+</TabItem>
+</Tabs>
 
 **Note**: There is also a Clerk library for [React](https://github.com/clerkinc/javascript/tree/main/packages/react) and [React Native with Expo](https://github.com/clerkinc/javascript/tree/main/packages/expo).
 

--- a/web/docs/guides/integrations/plasmic.mdx
+++ b/web/docs/guides/integrations/plasmic.mdx
@@ -4,6 +4,9 @@ title: 'Plasmic'
 description: 'Get started with Supabase and Plasmic, an open-source framework for building internal tools.'
 ---
 
+import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
+
 In this guide, we will show you how to build a crowd-sourced Pokemon Pokedex, by connecting **Supabase**, an open source Firebase backend alternative, with **Plasmic**, a visual builder for the web. While many users leverage Plasmic to quickly launch and iterate on landing pages, in this tutorial we’ll show just how powerful Plasmic can be as a general-purpose visual builder for React, which can be used to design and implement fully featured read-write applications.
 
 You can play with the live demo here:  
@@ -53,19 +56,57 @@ We have a working code example for you [here](https://github.com/plasmicapp/plas
 
 First, clone the repo to your development machine and install the dependencies.
 
+<Tabs
+defaultValue="NPM"
+values={[
+  {label: 'npm', value: 'NPM'},
+  {label: 'Yarn', value: 'YARN'},
+]}>
+<TabItem value="NPM">
+
+```bash
+git clone git@github.com:plasmicapp/plasmic.git
+cd plasmic/examples/supabase-demo/
+npm install
+```
+
+</TabItem>
+<TabItem value="YARN">
+
 ```bash
 git clone git@github.com:plasmicapp/plasmic.git
 cd plasmic/examples/supabase-demo/
 yarn install
 ```
 
+</TabItem>
+</Tabs>
+
 Copy `.env.example` to `.env.local`, which will store the environment variables when running a local development server. Add your Supabase project’s URL and public key, which you can find in the `API` tab on the left pane of your Supabase dashboard.
 
 Now run the dev server, which listens at `http://localhost:3000`
 
+<Tabs
+defaultValue="NPM"
+values={[
+  {label: 'npm', value: 'NPM'},
+  {label: 'Yarn', value: 'YARN'},
+]}>
+<TabItem value="NPM">
+
+```bash
+npm run dev
+```
+
+</TabItem>
+<TabItem value="YARN">
+
 ```bash
 yarn dev
 ```
+
+</TabItem>
+</Tabs>
 
 ## Step 3: Explore the existing application
 
@@ -152,9 +193,27 @@ For your convenience, the following video shows you how to create the page end-t
 
 If you have been running your development server this whole time, you’ll see that we have been automatically fetching and rebuilding your site as you make changes in Plasmic Studio. If you need to restart your dev server, just run:
 
+<Tabs
+defaultValue="NPM"
+values={[
+  {label: 'npm', value: 'NPM'},
+  {label: 'Yarn', value: 'YARN'},
+]}>
+<TabItem value="NPM">
+
+```bash
+npm run dev
+```
+
+</TabItem>
+<TabItem value="YARN">
+
 ```bash
 yarn dev
 ```
+
+</TabItem>
+</Tabs>
 
 See the results at `http://localhost:3000/gallery`.
 

--- a/web/docs/guides/integrations/prisma.mdx
+++ b/web/docs/guides/integrations/prisma.mdx
@@ -4,6 +4,9 @@ title: 'Prisma'
 description: 'Connect your Supabase postgres database to your Prisma project.'
 ---
 
+import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
+
 This guide explains how to quickly connect the Postgres database provided by Supabase to a Prisma project.
 
 [Prisma](https://prisma.io) is an [open source](https://github.com/prisma/prisma) next-generation ORM. It consists of the following parts:
@@ -41,9 +44,27 @@ curl -L https://pris.ly/quickstart | tar -xz --strip=2 quickstart-main/typescrip
 
 You can now navigate into the directory and install the project’s dependencies:
 
+<Tabs
+defaultValue="NPM"
+values={[
+  {label: 'npm', value: 'NPM'},
+  {label: 'Yarn', value: 'YARN'},
+]}>
+<TabItem value="NPM">
+
 ```bash
 cd starter && npm install
 ```
+
+</TabItem>
+<TabItem value="YARN">
+
+```bash
+cd starter && yarn install
+```
+
+</TabItem>
+</Tabs>
 
 ### A look at the project’s structure
 

--- a/web/docs/guides/integrations/stytch.mdx
+++ b/web/docs/guides/integrations/stytch.mdx
@@ -4,6 +4,9 @@ title: 'Stytch'
 description: "Build a Next.js application powered by password-less authentication from Stytch, and Supabase's Row Level Security (RLS)."
 ---
 
+import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
+
 In this guide we will build a simple expense tracker web application using Stytch, Supabase, and Next.js.
 
 [Stytch](https://stytch.com?utm_source=supabase&utm_medium=guide) provides an all-in-one platform for passwordless auth. Stytch makes it easy for you to embed passwordless solutions into your websites and apps for better security, better conversion rates, and a better end user experience. Their easy-to-use SDKs and direct API access allows for maximum control and customization. In this example we will use [Email magic links](https://stytch.com/products/email-magic-links?utm_source=supabase&utm_medium=guide) to create and log in our users, and Session management. There is an additional, optional step to enable [Google One Tap](https://stytch.com/blog/improving-conversion-with-google-one-tap?utm_source=supabase&utm_medium=guide) which is an especially high-converting Google OAuth sign-up and login flow.
@@ -106,9 +109,27 @@ SUPABASE_SIGNING_SECRET=GET_FROM_SUPABASE_DASHBOARD
 
 Start your Next.js development server to read in the new values from `.env.local`.
 
+<Tabs
+defaultValue="NPM"
+values={[
+  {label: 'npm', value: 'NPM'},
+  {label: 'Yarn', value: 'YARN'},
+]}>
+<TabItem value="NPM">
+
 ```bash
 npm run dev
 ```
+
+</TabItem>
+<TabItem value="YARN">
+
+```bash
+yarn dev
+```
+
+</TabItem>
+</Tabs>
 
 You should have a running Next.js application on `localhost:3000`.
 
@@ -120,9 +141,27 @@ Now we will replace the default Next.js home page with a login UI. We will use t
 
 Install the `@stytch/stytch-react` library.
 
+<Tabs
+defaultValue="NPM"
+values={[
+  {label: 'npm', value: 'NPM'},
+  {label: 'Yarn', value: 'YARN'},
+]}>
+<TabItem value="NPM">
+
 ```bash
 npm install @stytch/stytch-react
 ```
+
+</TabItem>
+<TabItem value="YARN">
+
+```bash
+yarn add @stytch/stytch-react
+```
+
+</TabItem>
+</Tabs>
 
 In the root directory, create a new folder named `components` and file in that folder named `/StytchLogin.js`. Within this file, paste the snippet below. This will configure, and style the Stytch React component to use Email magic links.
 
@@ -241,15 +280,51 @@ However, if you click the link in the email you will get a 404. We need to build
 
 To make authentication easier we will use the Stytch Node.js library. Run
 
+<Tabs
+defaultValue="NPM"
+values={[
+  {label: 'npm', value: 'NPM'},
+  {label: 'Yarn', value: 'YARN'},
+]}>
+<TabItem value="NPM">
+
 ```bash
 npm install stytch
 ```
 
+</TabItem>
+<TabItem value="YARN">
+
+```bash
+yarn add stytch
+```
+
+</TabItem>
+</Tabs>
+
 Additionally, we will need to store the authenticated session in a cookie. Run
+
+<Tabs
+defaultValue="NPM"
+values={[
+  {label: 'npm', value: 'NPM'},
+  {label: 'Yarn', value: 'YARN'},
+]}>
+<TabItem value="NPM">
 
 ```bash
 npm install cookies-next
 ```
+
+</TabItem>
+<TabItem value="YARN">
+
+```bash
+yarn add cookies-next
+```
+
+</TabItem>
+</Tabs>
 
 Create a new folder named `utils` and inside a file named`stytchLogic.js` with the following contents
 
@@ -405,15 +480,51 @@ Now that we have a working login flow with persistent authentication it is time 
 
 First, install the Supabase client:
 
+<Tabs
+defaultValue="NPM"
+values={[
+  {label: 'npm', value: 'NPM'},
+  {label: 'Yarn', value: 'YARN'},
+]}>
+<TabItem value="NPM">
+
 ```bash
 npm install @supabase/supabase-js
 ```
 
+</TabItem>
+<TabItem value="YARN">
+
+```bash
+yarn add @supabase/supabase-js
+```
+
+</TabItem>
+</Tabs>
+
 In order to pass an authenticated `user_id` to Supabase we will package it within a JWT. Install jsonwebtoken:
+
+<Tabs
+defaultValue="NPM"
+values={[
+  {label: 'npm', value: 'NPM'},
+  {label: 'Yarn', value: 'YARN'},
+]}>
+<TabItem value="NPM">
 
 ```bash
 npm install jsonwebtoken
 ```
+
+</TabItem>
+<TabItem value="YARN">
+
+```bash
+yarn add jsonwebtoken
+```
+
+</TabItem>
+</Tabs>
 
 Create a new file `utils/supabase.js` and add the following:
 

--- a/web/docs/guides/integrations/vercel.mdx
+++ b/web/docs/guides/integrations/vercel.mdx
@@ -4,6 +4,9 @@ title: 'Vercel'
 description: The fastest way to get up and running with an application that uses Supabase is with Vercel's Next.js starter and Supabase integration.
 ---
 
+import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
+
 This guide steps through using Vercel's dashboard to create a Next.js project integrated with Supabase. To further streamline the process, we will be using the Next.js starter template, which can be automatically forked to a new GitHub repo, without leaving the dashboard!
 
 If you don’t have a Vercel account, create one [here](https://vercel.com/signup).
@@ -119,9 +122,27 @@ export default function Home() {
 
 Run a local development server.
 
+<Tabs
+defaultValue="NPM"
+values={[
+  {label: 'npm', value: 'NPM'},
+  {label: 'Yarn', value: 'YARN'},
+]}>
+<TabItem value="NPM">
+
 ```bash
 npm run dev
 ```
+
+</TabItem>
+<TabItem value="YARN">
+
+```bash
+yarn dev
+```
+
+</TabItem>
+</Tabs>
 
 Navigate to `http://localhost:3000` to confirm the project is "working".
 
@@ -161,9 +182,27 @@ This will create a `.env` file containing our Supabase environment variables. Re
 
 Install the `supabase-js` library.
 
+<Tabs
+defaultValue="NPM"
+values={[
+  {label: 'npm', value: 'NPM'},
+  {label: 'Yarn', value: 'YARN'},
+]}>
+<TabItem value="NPM">
+
 ```bash
-npm i @supabase/supabase-js
+npm install @supabase/supabase-js
 ```
+
+</TabItem>
+<TabItem value="YARN">
+
+```bash
+yarn add @supabase/supabase-js
+```
+
+</TabItem>
+</Tabs>
 
 Create a new file called `/utils/supabase.js` and add the following.
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

New docs feature

Adds `npm` and `Yarn` tabs to the integration examples.

## What is the current behavior?

The current guides show a combination of both `npm` and `Yarn`:

<img width="806" alt="Screenshot 2022-05-23 at 12 05 04" src="https://user-images.githubusercontent.com/22655069/169806008-c9b41522-5e7f-4677-910d-3dedc051e03c.png">


## What is the new behavior?

You can now choose to view either `npm` or `Yarn`:

<img width="826" alt="Screenshot 2022-05-23 at 12 04 33" src="https://user-images.githubusercontent.com/22655069/169806126-05f1897c-213f-4094-b450-e06c2adb652a.png">


## Additional context

Links with #6826
