### PR TITLE
Update with-react.mdx

### DIFF
--- a/web/docs/guides/with-react.mdx
+++ b/web/docs/guides/with-react.mdx
@@ -176,7 +176,7 @@ values={[
 <TabItem value="NPM">
 
 ```bash
-npx create-react-app supabase-react --use-npm
+npx create-react-app supabase-react
 cd supabase-react
 ```
 
@@ -184,7 +184,7 @@ cd supabase-react
 <TabItem value="YARN">
 
 ```bash
-npx create-react-app supabase-react
+yarn create react-app supabase-react
 cd supabase-react
 ```
 


### PR DESCRIPTION
Yarn is no longer used when using the `npx create-react-app` command.

reference: https://github.com/facebook/create-react-app/pull/11322