### PR TITLE
Fix: storage refresh button

### DIFF
--- a/studio/components/to-be-cleaned/Storage/StorageExplorer/FileExplorerHeader.js
+++ b/studio/components/to-be-cleaned/Storage/StorageExplorer/FileExplorerHeader.js
@@ -276,7 +276,7 @@ const FileExplorerHeader = ({
             size="tiny"
             icon={<IconRefreshCw />}
             type="text"
-            loading={PageState.usersLoading}
+            loading={loading.isLoading}
             onClick={refreshData}
           >
             Reload


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix storage refresh button

## What is the current behavior?

In [supabase staging](https://app.supabase.green) when trying to visit storage in the dashboard this error message shows.

![image](https://user-images.githubusercontent.com/70828596/169880560-ad79475c-bfa7-4b07-9164-973d7d4a02a9.png)

## What is the new behavior?

Can't test locally but should fix the problem.