### PR TITLE
Fix reload button for storage

### DIFF
--- a/studio/components/to-be-cleaned/Storage/StorageExplorer/FileExplorerHeader.js
+++ b/studio/components/to-be-cleaned/Storage/StorageExplorer/FileExplorerHeader.js
@@ -31,15 +31,15 @@ const HeaderPathEdit = ({ loading, breadcrumbs, togglePathEdit }) => {
             <IconLoader size={16} strokeWidth={2} className="animate-spin" />
           </Typography.Text>
           <Typography.Text>
-            <p className="text-sm ml-3">{loading.message}</p>
+            <p className="ml-3 text-sm">{loading.message}</p>
           </Typography.Text>
         </div>
       ) : (
-        <div className="cursor-pointer flex items-center">
+        <div className="flex cursor-pointer items-center">
           <Typography.Text>
-            <p className="text-sm ml-3">{breadcrumbs[breadcrumbs.length - 1] || ''}</p>
+            <p className="ml-3 text-sm">{breadcrumbs[breadcrumbs.length - 1] || ''}</p>
           </Typography.Text>
-          <div className="ml-3 space-x-2 flex items-center transition opacity-0 group-hover:opacity-100">
+          <div className="ml-3 flex items-center space-x-2 opacity-0 transition group-hover:opacity-100">
             <Button type="text" icon={<IconEdit2 />}>
               Navigate
             </Button>
@@ -77,11 +77,11 @@ const HeaderBreadcrumbs = ({ loading, breadcrumbs, selectBreadcrumb }) => {
         <IconLoader size={16} strokeWidth={2} className="animate-spin" />
       </Typography.Text>
       <Typography.Text>
-        <p className="text-sm ml-3">{loading.message}</p>
+        <p className="ml-3 text-sm">{loading.message}</p>
       </Typography.Text>
     </div>
   ) : (
-    <div className="flex items-center ml-3">
+    <div className="ml-3 flex items-center">
       {formattedBreadcrumbs.map((crumb, idx) => (
         <div className="flex items-center" key={crumb.name}>
           {idx !== 0 && (
@@ -92,7 +92,7 @@ const HeaderBreadcrumbs = ({ loading, breadcrumbs, selectBreadcrumb }) => {
           <Typography.Text>
             <p
               key={crumb.name}
-              className={`text-sm truncate ${crumb.name !== ellipsis ? 'cursor-pointer' : ''}`}
+              className={`truncate text-sm ${crumb.name !== ellipsis ? 'cursor-pointer' : ''}`}
               style={{ maxWidth: '6rem' }}
               onClick={() => (crumb.name !== ellipsis ? selectBreadcrumb(crumb.index) : {})}
             >
@@ -198,16 +198,12 @@ const FileExplorerHeader = ({
     onSelectBreadcrumb(columnIndex)
   }
 
-  function refreshData() {
-    PageState.fetchData(1)
-  }
-
   return (
     <div
       className="
     bg-panel-header-light dark:bg-panel-header-dark
-    border-b border-panel-border-light dark:border-panel-border-dark
-    px-3 h-[40px] flex rounded-t-md items-center justify-between z-10"
+    border-panel-border-light dark:border-panel-border-dark z-10
+    flex h-[40px] items-center justify-between rounded-t-md border-b px-3"
     >
       {/* Navigation */}
       <div className={`flex items-center ${isEditingPath ? 'w-1/2' : ''}`}>
@@ -271,16 +267,6 @@ const FileExplorerHeader = ({
       {/* Actions */}
       <div className="flex items-center space-x-4">
         <div className="flex items-center space-x-1">
-          <Button
-            className="mr-2"
-            size="tiny"
-            icon={<IconRefreshCw />}
-            type="text"
-            loading={loading.isLoading}
-            onClick={refreshData}
-          >
-            Reload
-          </Button>
           <Dropdown
             overlay={[
               <Dropdown.RadioGroup key="viewOptions" value={view} onChange={onChangeView}>
@@ -324,7 +310,7 @@ const FileExplorerHeader = ({
             </Button>
           </Dropdown>
         </div>
-        <div className="border-r border-panel-border-light dark:border-panel-border-dark h-6" />
+        <div className="border-panel-border-light dark:border-panel-border-dark h-6 border-r" />
         <div className="flex items-center space-x-1">
           <div className="hidden">
             <input ref={uploadButtonRef} type="file" multiple onChange={onFilesUpload} />
@@ -350,7 +336,7 @@ const FileExplorerHeader = ({
         {/* Search: Disabled for now */}
         {view === STORAGE_VIEWS.LIST && (
           <>
-            <div className="border-r border-panel-border-light dark:border-panel-border-dark h-6" />
+            <div className="border-panel-border-light dark:border-panel-border-dark h-6 border-r" />
             <div className="flex items-center">
               {isSearching ? (
                 <Input
@@ -361,7 +347,7 @@ const FileExplorerHeader = ({
                   actions={[
                     <IconX
                       key="close"
-                      className="text-white cursor-pointer mx-2"
+                      className="mx-2 cursor-pointer text-white"
                       size={'tiny'}
                       strokeWidth={2}
                       onClick={onCancelSearch}

--- a/studio/components/to-be-cleaned/Storage/StorageExplorer/FileExplorerHeader.js
+++ b/studio/components/to-be-cleaned/Storage/StorageExplorer/FileExplorerHeader.js
@@ -17,6 +17,7 @@ import {
   IconLoader,
   Typography,
 } from '@supabase/ui'
+import { useStorageStore } from 'localStores/storageExplorer/StorageExplorerStore'
 import { STORAGE_VIEWS, STORAGE_SORT_BY } from '../Storage.constants.ts'
 
 const HeaderPathEdit = ({ loading, breadcrumbs, togglePathEdit }) => {
@@ -125,11 +126,15 @@ const FileExplorerHeader = ({
 }) => {
   const debounceDuration = 300
   const [isEditingPath, setIsEditingPath] = useState(false)
+  const [isRefreshing, setIsRefreshing] = useState(false)
   const [pathString, setPathString] = useState('')
   const [searchString, setSearchString] = useState('')
 
   const uploadButtonRef = useRef(null)
   const previousBreadcrumbs = useRef(null)
+
+  const storageExplorerStore = useStorageStore()
+  const { refetchAllOpenedFolders } = storageExplorerStore
 
   useEffect(() => {
     if (itemSearchString) setSearchString(itemSearchString)
@@ -196,6 +201,12 @@ const FileExplorerHeader = ({
 
   const selectBreadcrumb = (columnIndex) => {
     onSelectBreadcrumb(columnIndex)
+  }
+
+  const refreshData = async () => {
+    setIsRefreshing(true)
+    await refetchAllOpenedFolders()
+    setIsRefreshing(false)
   }
 
   return (
@@ -267,6 +278,16 @@ const FileExplorerHeader = ({
       {/* Actions */}
       <div className="flex items-center space-x-4">
         <div className="flex items-center space-x-1">
+          <Button
+            className="mr-2"
+            size="tiny"
+            icon={<IconRefreshCw />}
+            type="text"
+            loading={isRefreshing}
+            onClick={refreshData}
+          >
+            Reload
+          </Button>
           <Dropdown
             overlay={[
               <Dropdown.RadioGroup key="viewOptions" value={view} onChange={onChangeView}>

--- a/studio/components/to-be-cleaned/Storage/StorageExplorer/StorageExplorer.js
+++ b/studio/components/to-be-cleaned/Storage/StorageExplorer/StorageExplorer.js
@@ -270,8 +270,8 @@ const StorageExplorer = observer(({ bucket }) => {
       ref={storageExplorerRef}
       className="
         bg-bg-primary-light dark:bg-bg-primary-dark
-        border border-panel-border-light dark:border-panel-border-dark
-        w-full h-full rounded-md flex flex-col"
+        border-panel-border-light dark:border-panel-border-dark flex
+        h-full w-full flex-col rounded-md border"
     >
       {selectedItems.length === 0 ? (
         <FileExplorerHeader


### PR DESCRIPTION
Relevant PRs:
- https://github.com/supabase/supabase/pull/6857
- https://github.com/supabase/supabase/pull/6945

@Isaiah-Hamilton just cc-ing you so you're in the loop here
There's no context of `PageState` in storage, as compared to auth, and the fix in 6945 doesn't address the error logs

The ideal state of explorer refresh should be that it pulls again the files of the folders that are currently in the opened in the explorer, in which should be looking into `StorageExplorerStore` - there's already a `refetchAllOpenedFolders` so think just calling that should do the trick