### PR TITLE
Proposed changes to Fix Issue #4195

### DIFF
--- a/web/spec/supabase.yml
+++ b/web/spec/supabase.yml
@@ -1391,6 +1391,7 @@ pages:
             .on('UPDATE', handleRecordUpdated)
             .subscribe()
           ```
+          **Note** ``eq`` is a filter that can return events that match the filter, but as of now only works with Integers
 
   removeSubscription():
     title: 'removeSubscription()'

--- a/web/spec/supabase.yml
+++ b/web/spec/supabase.yml
@@ -1384,6 +1384,8 @@ pages:
           ```
       - name: Listening to row level changes
         description: You can listen to individual rows using the format `{table}:{col}=eq.{val}` - where `{col}` is the column name, and `{val}` is the value which you want to match.
+        notes: | 
+          - ``eq`` filter works with all database types as under the hood, it's casting both the filter value and the database value to the correct type and then comparing them.
         js: |
           ```js
           const mySubscription = supabase
@@ -1391,7 +1393,6 @@ pages:
             .on('UPDATE', handleRecordUpdated)
             .subscribe()
           ```
-          **Note** ``eq`` is a filter that can return events that match the filter.
 
   removeSubscription():
     title: 'removeSubscription()'

--- a/web/spec/supabase.yml
+++ b/web/spec/supabase.yml
@@ -1391,7 +1391,7 @@ pages:
             .on('UPDATE', handleRecordUpdated)
             .subscribe()
           ```
-          **Note** ``eq`` is a filter that can return events that match the filter, but as of now only works with Integers
+          **Note** ``eq`` is a filter that can return events that match the filter.
 
   removeSubscription():
     title: 'removeSubscription()'


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?
The documentation isn't clear on whether this "eq" syntax is an exact row match on a primary/unique key, or more of a "filter" that will match any row that equals a certain value.

Please link any relevant issues here. -> Fixes #4195

## What is the new behavior?
It looks like the ``col`` parameter in the ``{table}:{col}=eq.{val}`` syntax doesn't have to be a primary/unique key. So it looks like it can be used to listen to all todos by user_id, for example. But it only seems to allow for integers.

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
