### PR TITLE
Validate jwt string allowing alphanumeric, underscore, hyphen and che…

### DIFF
--- a/studio/pages/project/[ref]/settings/api.tsx
+++ b/studio/pages/project/[ref]/settings/api.tsx
@@ -389,7 +389,7 @@ const ServiceList: FC<any> = ({ projectRef }) => {
             </Button>
             <Button
               type="primary"
-              disabled={customToken.length < 32}
+              disabled={!customToken.match(/^[a-zA-Z0-9-_]{32,}$/)}
               loading={isSubmittingJwtSecretUpdateRequest}
               onClick={() => handleJwtSecretUpdate(customToken, setIsCreatingKey)}
             >

--- a/studio/pages/project/[ref]/settings/api.tsx
+++ b/studio/pages/project/[ref]/settings/api.tsx
@@ -31,6 +31,8 @@ import {
   IconRefreshCw,
   IconChevronDown,
   IconLoader,
+  IconEye,
+  IconEyeOff,
 } from '@supabase/ui'
 
 import { API_URL } from 'lib/constants'
@@ -117,6 +119,7 @@ const ServiceList: FC<any> = ({ projectRef }) => {
   const router = useRouter()
   const { ref } = router.query
 
+  const [showCustomTokenInput, setShowCustomTokenInput] = useState(false)
   const [customToken, setCustomToken] = useState<string>('')
   const [isRegeneratingKey, setIsGeneratingKey] = useState<boolean>(false)
   const [isCreatingKey, setIsCreatingKey] = useState<boolean>(false)
@@ -389,7 +392,9 @@ const ServiceList: FC<any> = ({ projectRef }) => {
             </Button>
             <Button
               type="primary"
-              disabled={!customToken.match(/^[a-zA-Z0-9-_]{32,}$/)}
+              disabled={
+                customToken.length < 32 || customToken.includes('@') || customToken.includes('$')
+              }
               loading={isSubmittingJwtSecretUpdateRequest}
               onClick={() => handleJwtSecretUpdate(customToken, setIsCreatingKey)}
             >
@@ -413,10 +418,19 @@ const ServiceList: FC<any> = ({ projectRef }) => {
               onChange={(e: any) => setCustomToken(e.target.value)}
               value={customToken}
               icon={<IconKey />}
-              type="password"
+              type={showCustomTokenInput ? 'text' : 'password'}
               className="w-full text-left"
               label="Custom JWT secret"
-              descriptionText="Must be at least 32 characters long"
+              descriptionText="Minimally 32 characters long, '@' and '$' are not allowed."
+              actions={
+                <div className="mr-1 flex items-center justify-center">
+                  <Button
+                    type="default"
+                    icon={showCustomTokenInput ? <IconEye /> : <IconEyeOff />}
+                    onClick={() => setShowCustomTokenInput(!showCustomTokenInput)}
+                  />
+                </div>
+              }
             />
           </div>
         </Modal.Content>


### PR DESCRIPTION
Resolves https://github.com/supabase/supabase/issues/6805

Validates input for: 

- alphanumeric
- underscore (_)
- dash (-)
- minimum 32 character length

https://regex101.com/r/tm9bQy/1

![CleanShot 2022-05-24 at 09 31 28@2x](https://user-images.githubusercontent.com/105593/170030014-f14d1f23-a685-490d-b283-e83a12f8b7d5.png)

