### PR TITLE
Update autoprefixer to 10.4.5

### DIFF
--- a/studio/package.json
+++ b/studio/package.json
@@ -94,7 +94,7 @@
     "@types/semver": "^7.3.9",
     "@types/sqlstring": "^2.3.0",
     "@types/zxcvbn": "^4.4.1",
-    "autoprefixer": "^10.4.2",
+    "autoprefixer": "^10.4.5",
     "babel-loader": "^8.2.3",
     "jest": "^27.4.0",
     "jest-canvas-mock": "^2.3.1",


### PR DESCRIPTION
## What kind of change does this PR introduce?
Looks like the recent supabase-ui update has caused a warning with autoprefixer. 

> (1:1) autoprefixer: Replace color-adjust to print-color-adjust. The color-adjust shorthand is currently deprecated.



This PR moves autoprefixer from 10.4.2 → 10.4.5. 

Per: 

https://github.com/twbs/bootstrap/issues/36259

https://exerror.com/autoprefixer-replace-color-adjust-to-print-color-adjust-the-color-adjust-shorthand-is-currently-deprecated/#:~:text=currently%20deprecated%20Error%3F-,To%20Solve%20autoprefixer%3A%20Replace%20color-adjust%20to%20print-color,Your%20error%20must%20be%20solved.