### PR TITLE
Docs: fix broken examples in full text search guide

### DIFF
--- a/web/docs/guides/database/full-text-search.mdx
+++ b/web/docs/guides/database/full-text-search.mdx
@@ -66,7 +66,7 @@ The functions we'll cover in this guide are:
 Converts your data into searchable "tokens". `to_tsvector()` stands for "to text search vector". For example:
 
 ```sql
-select to_tsvector("green eggs and ham")
+select to_tsvector('green eggs and ham')
 
 -- Returns 'egg':2 'green':1 'ham':4
 ``` 
@@ -99,7 +99,7 @@ values={[
 ```sql
 select * 
 from books 
-where name = 'Harry';
+where title = 'Harry';
 ```
 
 </TabItem>
@@ -109,7 +109,7 @@ where name = 'Harry';
 const { data, error } = await supabase
   .from('books')
   .select()
-  .eq('name', 'Harry')
+  .eq('title', 'Harry')
 ```
 
 </TabItem>
@@ -120,7 +120,7 @@ const { data, error } = await supabase
 final result = await client
   .from('books')
   .select()
-  .eq('name', 'Harry')
+  .eq('title', 'Harry')
   .execute();
 ```
 
@@ -143,7 +143,7 @@ values={[
 ```sql
 select * 
 from books 
-where to_tsvector(name) @@ to_tsquery('Harry');
+where to_tsvector(title) @@ to_tsquery('Harry');
 ```
 
 </TabItem>
@@ -153,7 +153,7 @@ where to_tsvector(name) @@ to_tsquery('Harry');
 const { data, error } = await supabase
   .from('books')
   .select()
-  .textSearch('name', `'Harry'`)
+  .textSearch('title', `'Harry'`)
 ```
 
 </TabItem>
@@ -163,7 +163,7 @@ const { data, error } = await supabase
 final result = await client
   .from('books')
   .select()
-  .textSearch('name', "'Harry'")
+  .textSearch('title', "'Harry'")
   .execute();
 ```
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to fix broken sql query exampels in full text seach guide.

## What is the current behavior?

The current sql query in that guide doesn't work.

## What is the new behavior?

The current sql query in that guide should work.

## Additional context

N/A
