### PR TITLE
fix: cache busting timestamp query param formatting

### DIFF
--- a/studio/localStores/storageExplorer/StorageExplorerStore.js
+++ b/studio/localStores/storageExplorer/StorageExplorerStore.js
@@ -286,7 +286,7 @@ class StorageExplorerStore {
     if (isNull(formattedName)) {
       return
     }
-    /** 
+    /**
      * todo: move this to a util file, as renameFolder() uses same logic
      */
     if (formattedName.includes('/') || formattedName.includes('\\')) {
@@ -376,13 +376,15 @@ class StorageExplorerStore {
     } else {
       // Need to generate signed URL, and might as well save it to cache as well
       const signedUrl = await this.fetchFilePreview(file.name)
-      const formattedUrl = `${signedUrl}?t=${new Date().toISOString()}`
-      copyToClipboard(formattedUrl, () => {
+      let formattedUrl = new URL(signedUrl)
+      formattedUrl.searchParams.set('t', new Date().toISOString())
+
+      copyToClipboard(formattedUrl.toString(), () => {
         toast(`Copied URL for ${file.name} to clipboard.`)
       })
       const fileCache = {
         id: file.id,
-        url: formattedUrl,
+        url: formattedUrl.toString(),
         expiresIn: DEFAULT_EXPIRY,
         fetchedAt: Date.now(),
       }
@@ -1093,10 +1095,10 @@ class StorageExplorerStore {
 
     /**
      * Catch any folder names that contain slash or backslash
-     * 
-     * this is because slashes are used to denote 
+     *
+     * this is because slashes are used to denote
      * children/parent relationships in bucket
-     * 
+     *
      * todo: move this to a util file, as createFolder() uses same logic
      */
     if (newName.includes('/') || newName.includes('\\')) {


### PR DESCRIPTION
Copy URL in storage for signed would lead to a double question mark in the URL, causing the URLs not to work.

For example:
`https://projectef.supabase.co/storage/v1/object/sign/2/0/13/file.png?token=jwt?t=2022-05-24T13:00:06.908Z`

This fix uses the regular URL class to format the URL instead of using string interpolation.