### PR TITLE
fix: remove file upload timeout

### DIFF
--- a/studio/localStores/storageExplorer/StorageExplorerStore.js
+++ b/studio/localStores/storageExplorer/StorageExplorerStore.js
@@ -22,7 +22,7 @@ import {
   STORAGE_ROW_STATUS,
   STORAGE_SORT_BY,
 } from 'components/to-be-cleaned/Storage/Storage.constants.ts'
-import { timeout, copyToClipboard } from 'lib/helpers'
+import { copyToClipboard } from 'lib/helpers'
 
 /**
  * This is a preferred method rather than React Context and useStorageExplorerStore().
@@ -286,7 +286,7 @@ class StorageExplorerStore {
     if (isNull(formattedName)) {
       return
     }
-    /** 
+    /**
      * todo: move this to a util file, as renameFolder() uses same logic
      */
     if (formattedName.includes('/') || formattedName.includes('\\')) {
@@ -623,25 +623,22 @@ class StorageExplorerStore {
       }
 
       return () => {
-        return Promise.race([
-          new Promise(async (resolve) => {
-            const { error } = await this.supabaseClient.storage
-              .from(this.selectedBucket.name)
-              .upload(formattedPathToFile, file, fileOptions)
+        return new Promise(async (resolve) => {
+          const { error } = await this.supabaseClient.storage
+            .from(this.selectedBucket.name)
+            .upload(formattedPathToFile, file, fileOptions)
 
-            this.uploadProgress = this.uploadProgress + 1 / formattedFilesToUpload.length
+          this.uploadProgress = this.uploadProgress + 1 / formattedFilesToUpload.length
 
-            if (error) {
-              numberOfFilesUploadedFail += 1
-              toast.error(`Failed to upload ${file.name}: ${error.message}`)
-              resolve()
-            } else {
-              numberOfFilesUploadedSuccess += 1
-              resolve()
-            }
-          }),
-          timeout(30000),
-        ])
+          if (error) {
+            numberOfFilesUploadedFail += 1
+            toast.error(`Failed to upload ${file.name}: ${error.message}`)
+            resolve()
+          } else {
+            numberOfFilesUploadedSuccess += 1
+            resolve()
+          }
+        })
       }
     })
 
@@ -1093,10 +1090,10 @@ class StorageExplorerStore {
 
     /**
      * Catch any folder names that contain slash or backslash
-     * 
-     * this is because slashes are used to denote 
+     *
+     * this is because slashes are used to denote
      * children/parent relationships in bucket
-     * 
+     *
      * todo: move this to a util file, as createFolder() uses same logic
      */
     if (newName.includes('/') || newName.includes('\\')) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behaviour?

On large files, the timeout triggers even while the file is still uploading.

## What is the new behaviour?

There is no frontend timeout. Error handling comes from `storage-js` only now.

## Additional Context

We may like to consider some other form of timeout here, but I think we should get this in as a hot-fix for now.
@joshenlim any reasons not to add this in now?
