### PR TITLE
feat: @reach/visually-hidden install tabs added

### DIFF
--- a/web/docs/guides/with-react.mdx
+++ b/web/docs/guides/with-react.mdx
@@ -476,7 +476,29 @@ Every Supabase project is configured with [Storage](/docs/guides/storage) for ma
 
 ### Add @reach/visually-hidden
 
-The upload widget uses one additional npm library. You can install it like so: `npm install @reach/visually-hidden` or `yarn add @reach/visually-hidden`.
+The upload widget uses one additional npm library `@reach/visually-hidden`. You can install it like so:
+
+<Tabs
+defaultValue="NPM"
+values={[
+  {label: 'npm', value: 'NPM'},
+  {label: 'Yarn', value: 'YARN'},
+]}>
+<TabItem value="NPM">
+
+```bash
+npm install @reach/visually-hidden
+```
+
+</TabItem>
+<TabItem value="YARN">
+
+```bash
+yarn add @reach/visually-hidden
+```
+
+</TabItem>
+</Tabs>
 
 ### Create an upload widget
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Doc update/Feature

## What is the current behavior?

In the [with react quickstart guide](https://supabase.com/docs/guides/with-react) their are now tabs to show the npm/yarn command. In the [bonus profile picture upload](https://supabase.com/docs/guides/with-react#bonus-profile-photos) the commands are listed on a line:

<img width="813" alt="Screenshot 2022-05-25 at 15 01 55" src="https://user-images.githubusercontent.com/22655069/170281885-b5a9daf8-9099-4bbc-a10d-aea196b05884.png">


## What is the new behavior?

Tabs have been added for the npm and yarn command and also made a tweak to add the package into the opening statement in the section:

<img width="805" alt="Screenshot 2022-05-25 at 15 02 12" src="https://user-images.githubusercontent.com/22655069/170282084-f50ced83-c23c-4043-bfe7-06ed85d923c9.png">

