### PR TITLE
docs: link added to follow github issue on prisma integration

### DIFF
--- a/web/docs/guides/integrations/prisma.mdx
+++ b/web/docs/guides/integrations/prisma.mdx
@@ -119,7 +119,7 @@ This will create a `prisma/migrations` folder inside your `prisma` directory and
 
 ### Confirming Realtime Functionality
 
-There is an existing issue where Prisma will create Enum Types wrapped in double quotation marks in PostgreSQL. This is not compatible with Realtime-enabled database tables whose columns rely on those Enum Types. We are working on a fix but the workaround is to alter and rename the Enum Types. You can use the following query to find all Types with double quotation marks in the `public` schema:
+There is an existing issue where Prisma will create Enum Types wrapped in double quotation marks in PostgreSQL. This is not compatible with Realtime-enabled database tables whose columns rely on those Enum Types. We are working on a fix which can be tracked on this [GitHub issue](https://github.com/supabase/supabase/issues/5685), but the workaround is to alter and rename the Enum Types. You can use the following query to find all Types with double quotation marks in the `public` schema:
 
 ```sql
 select distinct(a.atttypid::regtype)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

Mentioned on issue #5685 to add a link to track the status of the issue on the [guide](https://supabase.com/docs/guides/integrations/prisma#confirming-realtime-functionality):

<img width="801" alt="Screenshot 2022-05-30 at 11 01 51" src="https://user-images.githubusercontent.com/22655069/170970385-8691c49c-98a1-409d-af50-650f0694b9d6.png">


## What is the new behavior?

Add a couple of words and link to the issue on the guide:

<img width="801" alt="Screenshot 2022-05-30 at 11 04 57" src="https://user-images.githubusercontent.com/22655069/170970504-aff80aca-e81d-46ae-b2ec-240482ea1f31.png">

