### PR TITLE
Convert empty string to null before saving

### DIFF
--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.tsx
@@ -71,6 +71,12 @@ const ColumnEditor: FC<Props> = ({
   }, [visible])
 
   const onUpdateField = (changes: Partial<ColumnField>) => {
+    // An <input> can't have null as its value, so we need to use ''
+    // and convert this '' to null before saving it
+    if (changes.defaultValue === '') {
+      changes.defaultValue = null
+    }
+
     const updatedColumnFields = { ...columnFields, ...changes } as ColumnField
     setColumnFields(updatedColumnFields)
     updateEditorDirty()

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.tsx
@@ -71,6 +71,8 @@ const ColumnEditor: FC<Props> = ({
     }
   }, [visible])
 
+  if (!columnFields) return null
+
   const onUpdateField = (changes: Partial<ColumnField>) => {
     const isTextBasedColumn = TEXT_TYPES.includes(columnFields.format)
     if (!isTextBasedColumn && changes.defaultValue === '') {
@@ -129,8 +131,6 @@ const ColumnEditor: FC<Props> = ({
       }
     }
   }
-
-  if (!columnFields) return null
 
   return (
     <SidePanel

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.tsx
@@ -1,7 +1,7 @@
 import { FC, useEffect, useState } from 'react'
 import { isUndefined, isEmpty } from 'lodash'
 import { Dictionary } from '@supabase/grid'
-import { Checkbox, SidePanel, Space, Input, Divider } from '@supabase/ui'
+import { Checkbox, SidePanel, Input } from '@supabase/ui'
 import {
   PostgresColumn,
   PostgresRelationship,
@@ -23,6 +23,7 @@ import {
   generateCreateColumnPayload,
   generateUpdateColumnPayload,
 } from './ColumnEditor.utils'
+import { TEXT_TYPES } from '../SidePanelEditor.constants'
 import { ColumnField, CreateColumnPayload, UpdateColumnPayload } from '../SidePanelEditor.types'
 
 interface Props {
@@ -71,9 +72,8 @@ const ColumnEditor: FC<Props> = ({
   }, [visible])
 
   const onUpdateField = (changes: Partial<ColumnField>) => {
-    // An <input> can't have null as its value, so we need to use ''
-    // and convert this '' to null before saving it
-    if (changes.defaultValue === '') {
+    const isTextBasedColumn = TEXT_TYPES.includes(columnFields.format)
+    if (!isTextBasedColumn && changes.defaultValue === '') {
       changes.defaultValue = null
     }
 

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/ColumnManagement.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/ColumnManagement.tsx
@@ -27,9 +27,10 @@ import * as Tooltip from '@radix-ui/react-tooltip'
 import Column from './Column'
 import InformationBox from 'components/ui/InformationBox'
 import ForeignKeySelector from '../ForeignKeySelector/ForeignKeySelector'
-import { ColumnField } from '../SidePanelEditor.types'
 import { ImportContent } from './TableEditor.types'
 import { generateColumnField } from '../ColumnEditor/ColumnEditor.utils'
+import { ColumnField } from '../SidePanelEditor.types'
+import { TEXT_TYPES } from '../SidePanelEditor.constants'
 
 interface Props {
   table?: Partial<PostgresTable>
@@ -91,6 +92,11 @@ const ColumnManagement: FC<Props> = ({
   const onUpdateColumn = (columnToUpdate: ColumnField, changes: Partial<ColumnField>) => {
     const updatedColumns = columns.map((column: ColumnField) => {
       if (column.id === columnToUpdate.id) {
+        const isTextBasedColumn = TEXT_TYPES.includes(columnToUpdate.format)
+        if (!isTextBasedColumn && changes.defaultValue === '') {
+          changes.defaultValue = null
+        }
+
         if ('name' in changes && !isUndefined(column.foreignKey)) {
           const foreignKey: PostgresRelationship = {
             ...column.foreignKey,


### PR DESCRIPTION
Addresses: https://github.com/supabase/supabase/issues/6996

To reproduce: 
1. Create a new column
2. use int4 as the type
3. type 1 into the Default Value input
4. Delete the 1 that you just entered
5. Hit save

It's trying to save the new int4 column with a default value of `''`.  

Since that isn't allowed, I convert it to null before saving.