### PR TITLE
fix: update links from CTAs on pricing page

### DIFF
--- a/apps/www/pages/pricing/index.tsx
+++ b/apps/www/pages/pricing/index.tsx
@@ -30,7 +30,7 @@ export default function IndexPage() {
   const tiers = [
     {
       name: 'Free',
-      href: '#',
+      href: 'https://app.supabase.com/new/new-project',
       priceMonthly: 0,
       warning: 'Limit of 2 free projects',
       description: 'Perfect for passion projects & simple websites.',
@@ -49,7 +49,7 @@ export default function IndexPage() {
     },
     {
       name: 'Pro',
-      href: '#',
+      href: 'https://app.supabase.com/new/new-project',
       from: true,
       priceMonthly: 25,
       warning: 'per Project',


### PR DESCRIPTION
## What is the new behavior?

CTAs on pricing page now have working links for FREE and PRO

## Additional context

Add any other context or screenshots.

mentioned in #7069