### PR TITLE
docs: fix pricing typo 'bandwith' => 'bandwidth'

### DIFF
--- a/apps/www/pages/pricing/index.tsx
+++ b/apps/www/pages/pricing/index.tsx
@@ -56,7 +56,7 @@ export default function IndexPage() {
       description: 'For production applications with the option to scale.',
       features: [
         '8GB database & 100GB file storage',
-        '50GB bandwith',
+        '50GB bandwidth',
         '3GB file uploads',
         'Social OAuth providers',
         '2M Edge Function invocations',

--- a/studio/components/interfaces/Billing/PlanSelection/Plans/Plans.Constants.ts
+++ b/studio/components/interfaces/Billing/PlanSelection/Plans/Plans.Constants.ts
@@ -35,7 +35,7 @@ export const PRICING_META = {
     description: 'For production applications with the option to scale.',
     features: [
       '8GB database & 100GB file storage',
-      '50GB bandwith',
+      '50GB bandwidth',
       '3GB file uploads',
       'Social OAuth providers',
       '2M Edge Function invocations',


### PR DESCRIPTION
## What kind of change does this PR introduce?

Pricing page (https://supabase.com/pricing) typo fix. 'bandwith' should be 'bandwidth'