### PR TITLE
fix: Logs explorer now limits queries according to datepicker

### DIFF
--- a/studio/hooks/analytics/useLogsQuery.tsx
+++ b/studio/hooks/analytics/useLogsQuery.tsx
@@ -26,11 +26,10 @@ const useLogsQuery = (
 ): [Data, Handlers] => {
   const defaultHelper = getDefaultHelper(EXPLORER_DATEPICKER_HELPERS)
   const [params, setParams] = useState<LogsEndpointParams>({
-    project: projectRef,
     sql: '',
-    iso_timestamp_start: defaultHelper.calcFrom(),
-    iso_timestamp_end: defaultHelper.calcTo(),
-    ...initialParams,
+    project: projectRef,
+    iso_timestamp_start: initialParams.iso_timestamp_start ? initialParams.iso_timestamp_start :  defaultHelper.calcFrom(),
+    iso_timestamp_end: initialParams.iso_timestamp_end ? initialParams.iso_timestamp_end :  defaultHelper.calcTo(),
   })
 
   const queryParams = genQueryParams(params as any)

--- a/studio/pages/project/[ref]/logs-explorer/index.tsx
+++ b/studio/pages/project/[ref]/logs-explorer/index.tsx
@@ -35,8 +35,8 @@ export const LogsExplorerPage: NextPageWithLayout = () => {
 
   const [{ params, logData, error, isLoading }, { changeQuery, runQuery, setParams }] =
     useLogsQuery(ref as string, {
-      iso_timestamp_start: (its || '') as string,
-      iso_timestamp_end: (ite || '') as string,
+      iso_timestamp_start: its ? its as string : undefined,
+      iso_timestamp_end: ite ? ite as string : undefined,
     })
 
   useEffect(() => {

--- a/studio/tests/pages/projects/LogsPreviewer.test.js
+++ b/studio/tests/pages/projects/LogsPreviewer.test.js
@@ -96,6 +96,14 @@ test('can display log data and metadata', async () => {
     ],
   })
   render(<LogsPreviewer projectRef="123" tableName={LogsTableName.EDGE} />)
+
+  await waitFor(
+    () => {
+      expect(get).toHaveBeenCalledWith(expect.stringContaining('iso_timestamp_start'))
+      expect(get).not.toHaveBeenCalledWith(expect.stringContaining('iso_timestamp_end'))
+    },
+  )
+
   fireEvent.click(await screen.findByText(/some-event-happened-id/))
   await screen.findByText(/my_key/)
   await screen.findByText(/something_value/)

--- a/studio/tests/pages/projects/logs-query.test.js
+++ b/studio/tests/pages/projects/logs-query.test.js
@@ -179,6 +179,8 @@ test('custom sql querying', async () => {
       expect(get).toHaveBeenCalledWith(expect.stringContaining('sql='))
       expect(get).toHaveBeenCalledWith(expect.stringContaining('select'))
       expect(get).toHaveBeenCalledWith(expect.stringContaining('edge_logs'))
+      expect(get).toHaveBeenCalledWith(expect.stringContaining('iso_timestamp_start'))
+      expect(get).not.toHaveBeenCalledWith(expect.stringContaining('iso_timestamp_end')) // should not have an end date
       expect(get).not.toHaveBeenCalledWith(expect.stringContaining('where'))
       expect(get).not.toHaveBeenCalledWith(expect.stringContaining(encodeURIComponent('limit 123')))
     },


### PR DESCRIPTION
This PR fixes a bug relating to the datepicker value being overridden on mount, resulting in the daterange limitation not being respected in queries.

Ref: https://supabase.slack.com/archives/C02HE0AQPC6/p1654111306117179?thread_ts=1649990187.355999&cid=C02HE0AQPC6