### PR TITLE
fix: onBarClick for empty tooltip payloads for LogEventChart

### DIFF
--- a/studio/components/interfaces/Settings/Logs/LogEventChart.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogEventChart.tsx
@@ -20,7 +20,7 @@ const LogEventChart: React.FC<Props> = ({ data, onBarClick }) => {
       data={aggregated}
       attribute="count"
       label="Events"
-      onBarClick={(v: {activePayload?: {payload: any}[]}) => {
+      onBarClick={(v?: {activePayload?: {payload: any}[]}) => {
         if (!v || !v?.activePayload?.[0]?.payload) return
         const timestamp = v.activePayload[0].payload.timestamp
         // 60s before

--- a/studio/components/interfaces/Settings/Logs/LogEventChart.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogEventChart.tsx
@@ -20,9 +20,8 @@ const LogEventChart: React.FC<Props> = ({ data, onBarClick }) => {
       data={aggregated}
       attribute="count"
       label="Events"
-      onBarClick={(v: any) => {
-        if (!v) return
-
+      onBarClick={(v: {activePayload?: {payload: any}[]}) => {
+        if (!v || !v?.activePayload?.[0]?.payload) return
         const timestamp = v.activePayload[0].payload.timestamp
         // 60s before
         onBarClick((Number(timestamp) + 60) * 1000 * 1000)


### PR DESCRIPTION
Fixes the bug where the rechart tooltip payload is empty, which is possible to occur for empty charts or bars.

Alternative fix is to wrap with a `try/catch`, which i think is unnecessary.

Ref sentry: https://sentry.io/organizations/supabase/issues/2999942976/?project=5459134&query=is%3Aunresolved&sort=date&statsPeriod=14d

