### PR TITLE
Fix: alert warning icon

### DIFF
--- a/web/src/css/custom.css
+++ b/web/src/css/custom.css
@@ -349,6 +349,10 @@ li + li {
   font-size: 0.9rem;
 }
 
+.alert--warning .admonition-icon svg {
+  fill: var(--custom-color-orange-600);
+}
+
 .navbar__brand strong {
   font-family: var(--ifm-heading-font-family);
   font-size: 1.5rem;


### PR DESCRIPTION
## What is the current behavior?

<img width="798" alt="image" src="https://user-images.githubusercontent.com/70828596/171754913-2c8e8fa8-c1a8-4fc4-94a6-446db964dfdc.png">

## What is the new behavior?

<img width="798" alt="image" src="https://user-images.githubusercontent.com/70828596/171755100-ef1d970f-e8c0-4ef9-b5e6-c48030b4336a.png">