### PR TITLE
Support for 4 to 16 xl add on options on billing page

### DIFF
--- a/studio/components/interfaces/Billing/AddOns/AddOns.utils.ts
+++ b/studio/components/interfaces/Billing/AddOns/AddOns.utils.ts
@@ -29,30 +29,23 @@ export const formatComputeSizes = (computeSizes: any[]) => {
     ],
   }
 
+  const addonsOrder = [
+    'addon_instance_small',
+    'addon_instance_medium',
+    'addon_instance_large',
+    'addon_instance_xlarge',
+    'addon_instance_xxlarge',
+    'addon_instance_4xlarge',
+    'addon_instance_8xlarge',
+    'addon_instance_12xlarge',
+    'addon_instance_16xlarge',
+  ]
+
   return [microOption]
     .concat(
-      computeSizes.filter(
-        (option: any) => option.metadata.supabase_prod_id === 'addon_instance_small'
-      )
+      addonsOrder.map((id: string) => {
+        return computeSizes.find((option: any) => option.metadata.supabase_prod_id === id)
+      })
     )
-    .concat(
-      computeSizes.filter(
-        (option: any) => option.metadata.supabase_prod_id === 'addon_instance_medium'
-      )
-    )
-    .concat(
-      computeSizes.filter(
-        (option: any) => option.metadata.supabase_prod_id === 'addon_instance_large'
-      )
-    )
-    .concat(
-      computeSizes.filter(
-        (option: any) => option.metadata.supabase_prod_id === 'addon_instance_xlarge'
-      )
-    )
-    .concat(
-      computeSizes.filter(
-        (option: any) => option.metadata.supabase_prod_id === 'addon_instance_xxlarge'
-      )
-    )
+    .filter((option) => option !== undefined)
 }


### PR DESCRIPTION
Refactored sorting logic a little, and wrote it such that we can add have new add ons reflected on the dashboard without waiting on a deploy thereafter (with the `undefined` check)