### PR TITLE
Fix parameter typo in connection URL

### DIFF
--- a/web/docs/guides/integrations/prisma.mdx
+++ b/web/docs/guides/integrations/prisma.mdx
@@ -147,7 +147,7 @@ When running migrations you need to use the non pooled connection URL (like the 
 
 ```env
 # prisma/.env
-postgres://postgres:[YOUR-PASSWORD]@db.vdbnhqozmlzdsaejdxwr.supabase.co:6543/postgres?pgbouncer=true&connection_limtit=1
+postgres://postgres:[YOUR-PASSWORD]@db.vdbnhqozmlzdsaejdxwr.supabase.co:6543/postgres?pgbouncer=true&connection_limit=1
 ```
 
 Prisma Migrate uses database transactions to check out the current state of the database and the migrations table. However, the Migration Engine is designed to use a single connection to the database, and does not support connection pooling with PgBouncer. If you attempt to run Prisma Migrate commands in any environment that uses PgBouncer for connection pooling, you might see the following error:


### PR DESCRIPTION
Replace `connection_limtit` with `connection_limit`.