### PR TITLE
fix: BecomeAPartners form layout changed

### DIFF
--- a/apps/www/components/Partners/BecomeAPartners.tsx
+++ b/apps/www/components/Partners/BecomeAPartners.tsx
@@ -89,7 +89,7 @@ export default function BecomeAPartner({ supabase }: { supabase: SupabaseClient 
                 </Select>
               </div>
 
-              <div className="flex space-x-4">
+              <div className="flex space-x-2">
                 <div className="flex-1">
                   <Input
                     label="First Name *"
@@ -111,46 +111,50 @@ export default function BecomeAPartner({ supabase }: { supabase: SupabaseClient 
                 </div>
               </div>
 
-              <div>
-                <Input
-                  label="Company Name"
-                  id="company"
-                  name="company"
-                  layout="vertical"
-                  placeholder="Supa Inc."
-                />
+              <div className="flex space-x-2">
+                <div className="flex-1">
+                  <Input
+                    label="Company Name"
+                    id="company"
+                    name="company"
+                    layout="vertical"
+                    placeholder="Supa Inc."
+                  />
+                </div>
+
+                <div className="flex-1">
+                  <InputNumber
+                    label="Company Size"
+                    id="size"
+                    name="size"
+                    layout="vertical"
+                    placeholder="1"
+                  />
+                </div>
               </div>
 
-              <div>
-                <InputNumber
-                  label="Company Size"
-                  id="size"
-                  name="size"
-                  layout="vertical"
-                  placeholder="1"
-                />
-              </div>
+              <div className="flex space-x-2">
+                <div className="flex-1">
+                  <Input
+                    label="Job Title"
+                    id="title"
+                    name="title"
+                    layout="vertical"
+                    placeholder="CEO"
+                  />
+                </div>
 
-              <div>
-                <Input
-                  label="Job Title"
-                  id="title"
-                  name="title"
-                  layout="vertical"
-                  placeholder="CEO"
-                />
+                <div className="flex-1">
+                  <Input
+                    label="Business email *"
+                    id="email"
+                    name="email"
+                    layout="vertical"
+                    placeholder="janedoe@example.sg"
+                  />
+                </div>
               </div>
-
-              <div>
-                <Input
-                  label="Business email *"
-                  id="email"
-                  name="email"
-                  layout="vertical"
-                  placeholder="janedoe@example.sg"
-                />
-              </div>
-
+              
               <div>
                 <Input
                   label="Phone Number"

--- a/apps/www/components/Partners/BecomeAPartners.tsx
+++ b/apps/www/components/Partners/BecomeAPartners.tsx
@@ -89,7 +89,7 @@ export default function BecomeAPartner({ supabase }: { supabase: SupabaseClient 
                 </Select>
               </div>
 
-              <div className="flex space-x-2">
+              <div className="flex space-x-2 sm:space-x-4">
                 <div className="flex-1">
                   <Input
                     label="First Name *"
@@ -111,7 +111,7 @@ export default function BecomeAPartner({ supabase }: { supabase: SupabaseClient 
                 </div>
               </div>
 
-              <div className="flex space-x-2">
+              <div className="flex space-x-2 sm:space-x-4">
                 <div className="flex-1">
                   <Input
                     label="Company Name"
@@ -133,7 +133,7 @@ export default function BecomeAPartner({ supabase }: { supabase: SupabaseClient 
                 </div>
               </div>
 
-              <div className="flex space-x-2">
+              <div className="flex space-x-2 sm:space-x-4">
                 <div className="flex-1">
                   <Input
                     label="Job Title"

--- a/apps/www/components/Partners/BecomeAPartners.tsx
+++ b/apps/www/components/Partners/BecomeAPartners.tsx
@@ -73,8 +73,8 @@ export default function BecomeAPartner({ supabase }: { supabase: SupabaseClient 
 
         <Form initialValues={INITIAL_VALUES} validate={validate} onSubmit={handleFormSubmit}>
           {({ isSubmitting }: any) => (
-            <div className="grid grid-cols-2 gap-x-6 gap-y-1">
-              <div className="col-span-2 h-24">
+            <div className="flex flex-col space-y-4">
+              <div>
                 <Select
                   id="type"
                   name="type"
@@ -89,27 +89,29 @@ export default function BecomeAPartner({ supabase }: { supabase: SupabaseClient 
                 </Select>
               </div>
 
-              <div className="h-24">
-                <Input
-                  label="First Name *"
-                  id="first"
-                  name="first"
-                  layout="vertical"
-                  placeholder="Jane"
-                />
+              <div className="flex space-x-4">
+                <div className="flex-1">
+                  <Input
+                    label="First Name *"
+                    id="first"
+                    name="first"
+                    layout="vertical"
+                    placeholder="Jane"
+                  />
+                </div>
+
+                <div className="flex-1">
+                  <Input
+                    label="Last Name *"
+                    id="last"
+                    name="last"
+                    layout="vertical"
+                    placeholder="Doe"
+                  />
+                </div>
               </div>
 
-              <div className="h-24">
-                <Input
-                  label="Last Name *"
-                  id="last"
-                  name="last"
-                  layout="vertical"
-                  placeholder="Doe"
-                />
-              </div>
-
-              <div className="h-24">
+              <div>
                 <Input
                   label="Company Name"
                   id="company"
@@ -119,7 +121,7 @@ export default function BecomeAPartner({ supabase }: { supabase: SupabaseClient 
                 />
               </div>
 
-              <div className="h-24">
+              <div>
                 <InputNumber
                   label="Company Size"
                   id="size"
@@ -129,7 +131,7 @@ export default function BecomeAPartner({ supabase }: { supabase: SupabaseClient 
                 />
               </div>
 
-              <div className="h-24">
+              <div>
                 <Input
                   label="Job Title"
                   id="title"
@@ -139,7 +141,7 @@ export default function BecomeAPartner({ supabase }: { supabase: SupabaseClient 
                 />
               </div>
 
-              <div className="h-24">
+              <div>
                 <Input
                   label="Business email *"
                   id="email"
@@ -149,7 +151,7 @@ export default function BecomeAPartner({ supabase }: { supabase: SupabaseClient 
                 />
               </div>
 
-              <div className="h-24">
+              <div>
                 <Input
                   label="Phone Number"
                   id="phone"
@@ -159,7 +161,7 @@ export default function BecomeAPartner({ supabase }: { supabase: SupabaseClient 
                 />
               </div>
 
-              <div className="h-24">
+              <div>
                 <Select
                   label="Country / Main Timezone"
                   id="country"

--- a/apps/www/components/Partners/BecomeAPartners.tsx
+++ b/apps/www/components/Partners/BecomeAPartners.tsx
@@ -154,7 +154,7 @@ export default function BecomeAPartner({ supabase }: { supabase: SupabaseClient 
                   />
                 </div>
               </div>
-              
+
               <div>
                 <Input
                   label="Phone Number"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase website fix

## What is the current behavior?

On the [Partners](https://supabase.com/partners/integrations) section, the layout of the form on the page is squashed and not aligned on mobile:

<img width="298" alt="Screenshot 2022-06-03 at 16 47 16" src="https://user-images.githubusercontent.com/22655069/171900384-20c74511-e657-48f6-a785-75aa04599a83.png">

## What is the new behavior?

The form has been change so that the fields are aligned on the mobile version and also matching in the same way as the layout on the [contact page](https://supabase.com/contact/enterprise):

<img width="290" alt="Screenshot 2022-06-03 at 16 42 52" src="https://user-images.githubusercontent.com/22655069/171900659-4c101a6c-0b97-40d2-b9dd-408ba857dc91.png">


## Additional context

The form on bigger screen sizes will match the mobile with just a form field per line apart from the first two fields of First Name and Last Name
