### PR TITLE
Incomplete reference to UI section in Quickstarts

### DIFF
--- a/apps/temp-docs/docs/guides/with-angular.mdx
+++ b/apps/temp-docs/docs/guides/with-angular.mdx
@@ -54,7 +54,7 @@ or you can just copy/paste the SQL from below and run it yourself.
 <TabsPanel id="UI" label="UI">
 
 ```sh
-1. Go to the "SQL" section.
+1. Go to the "SQL Editor" section.
 2. Click "User Management Starter".
 3. Click "Run".
 ```

--- a/apps/temp-docs/docs/guides/with-flutter.mdx
+++ b/apps/temp-docs/docs/guides/with-flutter.mdx
@@ -47,7 +47,7 @@ defaultActiveId="UI"
 <TabsPanel id="UI" label="UI">
 
 ```sh
-1. Go to the "SQL" section.
+1. Go to the "SQL Editor" section.
 2. Click "User Management Starter".
 3. Click "Run".
 ```

--- a/apps/temp-docs/docs/guides/with-nextjs.mdx
+++ b/apps/temp-docs/docs/guides/with-nextjs.mdx
@@ -65,7 +65,7 @@ or you can just copy/paste the SQL from below and run it yourself.
 <TabsPanel id="UI" label="Dashboard UI">
 
 ```sh
-1. Go to the "SQL" section.
+1. Go to the "SQL Editor" section.
 2. Click "User Management Starter".
 3. Click "Run".
 ```

--- a/apps/temp-docs/docs/guides/with-react.mdx
+++ b/apps/temp-docs/docs/guides/with-react.mdx
@@ -62,7 +62,7 @@ or you can just copy/paste the SQL from below and run it yourself.
 <TabsPanel id="UI" label="Dashboard UI">
 
 ```sh
-1. Go to the "SQL" section.
+1. Go to the "SQL Editor" section.
 2. Click "User Management Starter".
 3. Click "Run".
 ```

--- a/apps/temp-docs/docs/guides/with-redwoodjs.mdx
+++ b/apps/temp-docs/docs/guides/with-redwoodjs.mdx
@@ -114,7 +114,7 @@ defaultActiveId="UI"
 <TabsPanel id="UI" label="UI">
 
 ```sh
-1. Go to the "SQL" section.
+1. Go to the "SQL Editor" section.
 2. Click "User Management Starter".
 4. Click "Run".
 ```

--- a/apps/temp-docs/docs/guides/with-svelte.mdx
+++ b/apps/temp-docs/docs/guides/with-svelte.mdx
@@ -50,7 +50,7 @@ defaultActiveId="UI"
 <TabsPanel id="UI" label="UI">
 
 ```sh
-1. Go to the "SQL" section.
+1. Go to the "SQL Editor" section.
 2. Click "User Management Starter".
 3. Click "Run".
 ```

--- a/apps/temp-docs/docs/guides/with-vue-3.mdx
+++ b/apps/temp-docs/docs/guides/with-vue-3.mdx
@@ -47,7 +47,7 @@ defaultActiveId="UI"
 <TabsPanel id="UI" label="UI">
 
 ```sh
-1. Go to the "SQL" section.
+1. Go to the "SQL Editor" section.
 2. Click "User Management Starter".
 3. Click "Run".
 ```

--- a/web/docs/guides/with-angular.mdx
+++ b/web/docs/guides/with-angular.mdx
@@ -61,7 +61,7 @@ values={[
 <TabItem value="UI">
 
 ```sh
-1. Go to the "SQL" section.
+1. Go to the "SQL Editor" section.
 2. Click "User Management Starter".
 3. Click "Run".
 ```

--- a/web/docs/guides/with-expo.mdx
+++ b/web/docs/guides/with-expo.mdx
@@ -45,7 +45,7 @@ values={[
 <TabItem value="UI">
 
 ```sh
-1. Go to the "SQL" section.
+1. Go to the "SQL Editor" section.
 2. Click "User Management Starter".
 3. Click "Run".
 ```

--- a/web/docs/guides/with-flutter.mdx
+++ b/web/docs/guides/with-flutter.mdx
@@ -51,7 +51,7 @@ values={[
 <TabItem value="UI">
 
 ```sh
-1. Go to the "SQL" section.
+1. Go to the "SQL Editor" section.
 2. Click "User Management Starter".
 3. Click "Run".
 ```

--- a/web/docs/guides/with-ionic-angular.mdx
+++ b/web/docs/guides/with-ionic-angular.mdx
@@ -61,7 +61,7 @@ values={[
 <TabItem value="UI">
 
 ```sh
-1. Go to the "SQL" section.
+1. Go to the "SQL Editor" section.
 2. Click "User Management Starter".
 3. Click "Run".
 ```

--- a/web/docs/guides/with-ionic-react.mdx
+++ b/web/docs/guides/with-ionic-react.mdx
@@ -61,7 +61,7 @@ values={[
 <TabItem value="UI">
 
 ```sh
-1. Go to the "SQL" section.
+1. Go to the "SQL Editor" section.
 2. Click "User Management Starter".
 3. Click "Run".
 ```

--- a/web/docs/guides/with-ionic-vue.mdx
+++ b/web/docs/guides/with-ionic-vue.mdx
@@ -61,7 +61,7 @@ values={[
 <TabItem value="UI">
 
 ```sh
-1. Go to the "SQL" section.
+1. Go to the "SQL Editor" section.
 2. Click "User Management Starter".
 3. Click "Run".
 ```

--- a/web/docs/guides/with-nextjs.mdx
+++ b/web/docs/guides/with-nextjs.mdx
@@ -69,7 +69,7 @@ values={[
 <TabItem value="UI">
 
 ```sh
-1. Go to the "SQL" section.
+1. Go to the "SQL Editor" section.
 2. Click "User Management Starter".
 3. Click "Run".
 ```

--- a/web/docs/guides/with-react.mdx
+++ b/web/docs/guides/with-react.mdx
@@ -68,7 +68,7 @@ values={[
 <TabItem value="UI">
 
 ```sh
-1. Go to the "SQL" section.
+1. Go to the "SQL Editor" section.
 2. Click "User Management Starter".
 3. Click "Run".
 ```

--- a/web/docs/guides/with-redwoodjs.mdx
+++ b/web/docs/guides/with-redwoodjs.mdx
@@ -115,7 +115,7 @@ values={[
 <TabItem value="UI">
 
 ```sh
-1. Go to the "SQL" section.
+1. Go to the "SQL Editor" section.
 2. Click "User Management Starter".
 4. Click "Run".
 ```

--- a/web/docs/guides/with-solidjs.mdx
+++ b/web/docs/guides/with-solidjs.mdx
@@ -68,7 +68,7 @@ values={[
 <TabItem value="UI">
 
 ```sh
-1. Go to the "SQL" section.
+1. Go to the "SQL Editor" section.
 2. Click "User Management Starter".
 3. Click "Run".
 ```

--- a/web/docs/guides/with-svelte.mdx
+++ b/web/docs/guides/with-svelte.mdx
@@ -51,7 +51,7 @@ values={[
 <TabItem value="UI">
 
 ```sh
-1. Go to the "SQL" section.
+1. Go to the "SQL Editor" section.
 2. Click "User Management Starter".
 3. Click "Run".
 ```

--- a/web/docs/guides/with-vue-3.mdx
+++ b/web/docs/guides/with-vue-3.mdx
@@ -51,7 +51,7 @@ values={[
 <TabItem value="UI">
 
 ```sh
-1. Go to the "SQL" section.
+1. Go to the "SQL Editor" section.
 2. Click "User Management Starter".
 3. Click "Run".
 ```


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

In the Quickstarts, in the section on setting up the database schema, the UI instructions say to go to the "SQL" section. However, on hover, the relevant UI icon says "SQL Editor".

## What is the new behavior?

The Quickstarts now reference "SQL Editor", not "SQL".
