### PR TITLE
fix: wrong video in Database Function documentation

### DIFF
--- a/web/docs/guides/database/functions.mdx
+++ b/web/docs/guides/database/functions.mdx
@@ -355,7 +355,7 @@ This limits the potential damage if you allow access to schemas which the user e
   className="w-full video-with-border"
   width="640"
   height="385"
-  src="https://www.youtube-nocookie.com/embed/I6nnp9AINJk"
+  src="https://www.youtube-nocookie.com/embed/rARgrELRCwY"
   frameBorder="1"
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
   allowFullScreen


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes wrong video in Database Function documentation

## What is the current behavior?

Currently the video for "Using Database Functions to call an external API" is a repeat of the previous video for "Call Database Functions using JavaScript" (see [link](https://supabase.com/docs/guides/database/functions#using-database-functions-to-call-an-external-api))

## What is the new behavior?

Fixes the embedded video to the correct [video](https://www.youtube.com/watch?v=rARgrELRCwY).