### PR TITLE
Fixes theming broken on cells when you edit theme

### DIFF
--- a/studio/styles/grid.scss
+++ b/studio/styles/grid.scss
@@ -19,6 +19,11 @@
   line-height: inherit;
 }
 
+// Apply parent bg colour while editing
+.rdg-cell.rdg-editor-container > * {
+  background-color: inherit;
+}
+
 .rdg-cell > div[draggable='true'] {
   @apply h-full;
 }
@@ -702,3 +707,4 @@ header/sort/SortRow
 .sb-grid-sort-row__item__move {
   @apply flex cursor-move;
 }
+


### PR DESCRIPTION
Fixes theming broken in dark mode when you edit a cell. 
 
<img width="966" alt="CleanShot 2022-06-07 at 12 03 17@2x" src="https://user-images.githubusercontent.com/105593/172407200-87504c0d-c7ed-4caf-bc53-f278c40f33bf.png">

Resolves:  https://github.com/supabase/supabase/issues/7146