### PR TITLE
fix: comparison page link href changed

### DIFF
--- a/apps/www/layouts/comparison.tsx
+++ b/apps/www/layouts/comparison.tsx
@@ -39,7 +39,7 @@ const LayoutComparison = ({ components, props, gfm, slug }: Props) => {
   const NextCard = (props: any) => {
     const { post, label, className } = props
     return (
-      <Link href={`/blog/${post.url}`} as={`/blog/${post.url}`}>
+      <Link href={`${post.url}`} as={`${post.url}`}>
         <div className={className}>
           <div className="border-scale-500 hover:bg-scale-100 dark:hover:bg-scale-300 cursor-pointer rounded border p-6 transition">
             <div className="space-y-4">


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase website change

## What is the current behavior?

The [comparison](https://supabase.com/alternatives/supabase-vs-heroku-postgres) next/previous pages link in the footer is broken

## What is the new behavior?

Pages are now linking

## Additional context

Related to issue #7202 
