### PR TITLE
studio: remove publication ALL TABLES toggle

### DIFF
--- a/studio/components/interfaces/Database/Publications/PublicationsTables.tsx
+++ b/studio/components/interfaces/Database/Publications/PublicationsTables.tsx
@@ -5,7 +5,7 @@ import { Button, Toggle, Input, IconChevronLeft, IconSearch } from '@supabase/ui
 import { useStore } from 'hooks'
 import PublicationsTableItem from './PublicationsTableItem'
 import Table from 'components/to-be-cleaned/Table'
-import { confirmAlert } from 'components/to-be-cleaned/ModalsDeprecated/ConfirmModal'
+// import { confirmAlert } from 'components/to-be-cleaned/ModalsDeprecated/ConfirmModal'
 
 interface Props {
   selectedPublication: any
@@ -16,9 +16,12 @@ interface Props {
 const PublicationsTables: FC<Props> = ({
   selectedPublication,
   onSelectBack,
-  onPublicationUpdated,
+  // onPublicationUpdated,
 }) => {
-  const { ui, meta } = useStore()
+  const {
+    // ui,
+    meta,
+  } = useStore()
   const [filterString, setFilterString] = useState<string>('')
 
   const tables =
@@ -29,32 +32,32 @@ const PublicationsTables: FC<Props> = ({
             !meta.excludedSchemas.includes(table.schema) && table.name.includes(filterString)
         )
 
-  const publication = selectedPublication
-  const enabledForAllTables = publication.tables == null
+  // const publication = selectedPublication
+  // const enabledForAllTables = publication.tables == null
 
-  const toggleReplicationForAllTables = async (publication: any, disable: boolean) => {
-    const toggle = disable ? 'disable' : 'enable'
-    confirmAlert({
-      title: 'Confirm',
-      type: 'warn',
-      message: `Are you sure you want to ${toggle} replication for all tables in ${publication.name}?`,
-      onAsyncConfirm: async () => {
-        try {
-          const res: any = await meta.publications.recreate(publication.id)
-          if (res.error) {
-            throw res.error
-          } else {
-            onPublicationUpdated(res)
-          }
-        } catch (error: any) {
-          ui.setNotification({
-            category: 'error',
-            message: `Failed to toggle replication for all tables: ${error.message}`,
-          })
-        }
-      },
-    })
-  }
+  // const toggleReplicationForAllTables = async (publication: any, disable: boolean) => {
+  //   const toggle = disable ? 'disable' : 'enable'
+  //   confirmAlert({
+  //     title: 'Confirm',
+  //     type: 'warn',
+  //     message: `Are you sure you want to ${toggle} replication for all tables in ${publication.name}?`,
+  //     onAsyncConfirm: async () => {
+  //       try {
+  //         const res: any = await meta.publications.recreate(publication.id)
+  //         if (res.error) {
+  //           throw res.error
+  //         } else {
+  //           onPublicationUpdated(res)
+  //         }
+  //       } catch (error: any) {
+  //         ui.setNotification({
+  //           category: 'error',
+  //           message: `Failed to toggle replication for all tables: ${error.message}`,
+  //         })
+  //       }
+  //     },
+  //   })
+  // }
 
   return (
     <>
@@ -89,6 +92,7 @@ const PublicationsTables: FC<Props> = ({
               Description
             </Table.th>,
             <Table.th key="header-all">
+              {/* Temporarily disable All tables toggle for publications. See https://github.com/supabase/supabase/pull/7233.
               <div className="flex flex-row space-x-3 items-center justify-end">
                 <div className="text-xs leading-4 font-medium text-gray-400 text-right ">
                   All Tables
@@ -101,7 +105,7 @@ const PublicationsTables: FC<Props> = ({
                   checked={enabledForAllTables}
                   onChange={() => toggleReplicationForAllTables(publication, enabledForAllTables)}
                 />
-              </div>
+              </div> */}
             </Table.th>,
           ]}
           body={tables.map((table: any, i: number) => (


### PR DESCRIPTION
Once removal of superuser access is rolled out, the `postgres` role (which will be used for the dashboard vs. the `supabase_admin` role) won't have the privileges to create ALL TABLES publications, so this will just fail. Specifically, it will succeed in dropping the publication but fail in recreating it, which is *very* bad for Realtime.

There are plans to make it work again w/o a superuser role, at that point we can expose this again.