### PR TITLE
studio: hide unsafe extensions

### DIFF
--- a/studio/components/interfaces/Database/Extensions/Extensions.constants.ts
+++ b/studio/components/interfaces/Database/Extensions/Extensions.constants.ts
@@ -1,0 +1,14 @@
+export const HIDDEN_EXTENSIONS = [
+  'adminpack',
+  'amcheck',
+  'file_fdw',
+  'lo',
+  'old_snapshot',
+  'pageinspect',
+  'pg_buffercache',
+  'pg_freespacemap',
+  'pg_prewarm',
+  'pg_surgery',
+  'pg_visibility',
+  'pgstattuple',
+]

--- a/studio/components/interfaces/Database/Extensions/Extensions.tsx
+++ b/studio/components/interfaces/Database/Extensions/Extensions.tsx
@@ -5,6 +5,7 @@ import { Input, IconSearch, Typography } from '@supabase/ui'
 
 import { useStore } from 'hooks'
 import ExtensionCard from './ExtensionCard'
+import { HIDDEN_EXTENSIONS } from './Extensions.constants'
 
 interface Props {}
 
@@ -16,8 +17,10 @@ const Extensions: FC<Props> = ({}) => {
     filterString.length === 0
       ? meta.extensions.list()
       : meta.extensions.list((ext: any) => ext.name.includes(filterString))
+  const extensionsWithoutHidden = extensions
+    .filter((ext: any) => !HIDDEN_EXTENSIONS.includes(ext.name))
   const [enabledExtensions, disabledExtensions] = partition(
-    extensions,
+    extensionsWithoutHidden,
     (ext: any) => !isNull(ext.installed_version)
   )
 


### PR DESCRIPTION
Once removal of superuser access is rolled out, the `postgres` role used by the dashboard won't be able to enable these.