### PR TITLE
docs: fix wrong links in prisma integration

### DIFF
--- a/web/docs/guides/integrations/prisma.mdx
+++ b/web/docs/guides/integrations/prisma.mdx
@@ -55,8 +55,8 @@ This project comes with TypeScript configured and has the following structure.
 - A `.env` file: Contains the `DATABASE_URL` variable, which Prisma will use.
 - A `script.ts` file: where we will run some queries using Prisma Client.
   This starter also comes with the following packages installed:
-- [`@prisma/client`](https://www.npmjs.com/package/prisma): An auto-generated and type-safe query builder that’s _tailored_ to your data.
-- [`prisma`](https://www.npmjs.com/package/@prisma/client): Prisma’s command-line interface (CLI). It allows you to initialize new project assets, generate Prisma Client, and analyze existing database structures through introspection to automatically create your application models.
+- [`@prisma/client`](https://www.npmjs.com/package/@prisma/client): An auto-generated and type-safe query builder that’s _tailored_ to your data.
+- [`prisma`](https://www.npmjs.com/package/prisma): Prisma’s command-line interface (CLI). It allows you to initialize new project assets, generate Prisma Client, and analyze existing database structures through introspection to automatically create your application models.
   > Note: Prisma works with both JavaScript and TypeScript. However, to get the best possible development experience, using TypeScript is highly recommended.
 
 ### Configuring the project to use PostgreSQL


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix links in the Prisma integration document.

## What is the current behavior?

Links to a wrong package.

## What is the new behavior?

Links to a correct package page.

## Additional context

