### PR TITLE
fix: pricing page links

### DIFF
--- a/apps/www/data/PricingFAQ.json
+++ b/apps/www/data/PricingFAQ.json
@@ -17,7 +17,7 @@
   },
   {
     "question": "Are you going to change your pricing in the future?",
-    "answer": "Our pricing is in Beta. You can read more about our decisions in our blog on pricing **[here](/blog/2021/03/29/pricing)**. Pricing may change in the future, however as a team of developers we are committed to pricing being as developer friendly as possible."
+    "answer": "Our pricing is in Beta. You can read more about our decisions in our blog on pricing [here](/blog/2021/03/29/pricing). Pricing may change in the future, however as a team of developers we are committed to pricing being as developer friendly as possible."
   },
   {
     "question": "What happens if I cancel my subscription",
@@ -33,6 +33,6 @@
   },
   {
     "question": "Can I self host Supabase for free?",
-    "answer": "Yes, our Docker setup can be found **[here](https://github.com/supabase/supabase)**, or in our **[CLI](https://github.com/supabase/cli)**. Supabase Studio is available in the docker setup, read more about it **[here](https://supabase.com/blog/2021/11/30/supabase-studio)**."
+    "answer": "Yes, our Docker setup can be found [here](https://github.com/supabase/supabase), or in our [CLI](https://github.com/supabase/cli). Supabase Studio is available in the docker setup, read more about it [here](https://supabase.com/blog/2021/11/30/supabase-studio)."
   }
 ]

--- a/apps/www/data/PricingFAQ.json
+++ b/apps/www/data/PricingFAQ.json
@@ -17,7 +17,7 @@
   },
   {
     "question": "Are you going to change your pricing in the future?",
-    "answer": "Our pricing is in Beta. You can read more about our decisions in our blog on pricing [here](/blog/2021/03/29/pricing). Pricing may change in the future, however as a team of developers we are committed to pricing being as developer friendly as possible."
+    "answer": "Our pricing is in Beta. You can read more about our decisions in our blog on pricing **[here](/blog/2021/03/29/pricing)**. Pricing may change in the future, however as a team of developers we are committed to pricing being as developer friendly as possible."
   },
   {
     "question": "What happens if I cancel my subscription",
@@ -33,6 +33,6 @@
   },
   {
     "question": "Can I self host Supabase for free?",
-    "answer": "Yes, our Docker setup can be found [here](https://github.com/supabase/supabase), or in our [CLI](https://github.com/supabase/cli). Supabase Studio is available in the docker setup, read more about it [here](https://supabase.com/blog/2021/11/30/supabase-studio)."
+    "answer": "Yes, our Docker setup can be found **[here](https://github.com/supabase/supabase)**, or in our **[CLI](https://github.com/supabase/cli)**. Supabase Studio is available in the docker setup, read more about it **[here](https://supabase.com/blog/2021/11/30/supabase-studio)**."
   }
 ]

--- a/apps/www/pages/pricing/index.tsx
+++ b/apps/www/pages/pricing/index.tsx
@@ -653,7 +653,9 @@ export default function IndexPage() {
                   {pricingFaq.map((faq, i) => {
                     return (
                       <Accordion.Item key={i} header={faq.question} id={`faq--${i.toString()}`}>
-                        <ReactMarkdown className="text-scale-1100 max-w-full prose">{faq.answer}</ReactMarkdown>
+                        <ReactMarkdown className="text-scale-1100 prose max-w-full">
+                          {faq.answer}
+                        </ReactMarkdown>
                       </Accordion.Item>
                     )
                   })}

--- a/apps/www/pages/pricing/index.tsx
+++ b/apps/www/pages/pricing/index.tsx
@@ -653,7 +653,7 @@ export default function IndexPage() {
                   {pricingFaq.map((faq, i) => {
                     return (
                       <Accordion.Item key={i} header={faq.question} id={`faq--${i.toString()}`}>
-                        <ReactMarkdown className="text-scale-1100">{faq.answer}</ReactMarkdown>
+                        <ReactMarkdown className="text-scale-1100 max-w-full prose">{faq.answer}</ReactMarkdown>
                       </Accordion.Item>
                     )
                   })}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase Docs - [Pricing](https://supabase.com/pricing) FAQ section

## What is the current behavior?

The links are currently the same style as normal text:

<img width="873" alt="Screenshot 2022-06-10 at 21 02 10" src="https://user-images.githubusercontent.com/22655069/173142116-ffe74823-3bfa-407e-a1fc-94dacdec50b0.png">


## What is the new behavior?

Text is now bold to show where the links are:

<img width="906" alt="Screenshot 2022-06-10 at 20 58 07" src="https://user-images.githubusercontent.com/22655069/173142170-187e6d1e-54e7-4f68-81ce-289865cc3879.png">


## Additional context

Linked with #7246
