### PR TITLE
fix: label whitespace and typo

### DIFF
--- a/about/src/css/custom.css
+++ b/about/src/css/custom.css
@@ -1032,6 +1032,7 @@ h4.method-list-item-label {
 h4.method-list-item-label .method-list-item-label-name {
   font-family: var(--ifm-font-family-monospace);
   font-size: 0.8rem;
+  margin-right: 4px;
   padding: var(--ifm-code-padding-vertical) 0;
 }
 h4.method-list-item-label .method-list-item-label-badge {

--- a/web/spec/supabase.yml
+++ b/web/spec/supabase.yml
@@ -1449,7 +1449,7 @@ pages:
       - name: Upload file using `ArrayBuffer` from base64 file data
         js: |
           ```js
-          import {decode} from 'base64-arraybuffer'
+          import { decode } from 'base64-arraybuffer'
 
           const { data, error } = await supabase
             .storage

--- a/web/src/css/custom.css
+++ b/web/src/css/custom.css
@@ -1285,6 +1285,7 @@ h4.method-list-item-label {
 h4.method-list-item-label .method-list-item-label-name {
   font-family: var(--ifm-font-family-monospace);
   font-size: 0.8rem;
+  margin-right: 4px;
   padding: var(--ifm-code-padding-vertical) 0;
 }
 h4.method-list-item-label .method-list-item-label-badge {


### PR DESCRIPTION
## Fix label whitespace and typo

This PR fix two things on documentation:
- Fix text label being hard to read with the following text
- Fix typo and making it consistent with rest of text

## Screenshots

### Fix text label being hard to read with the following text

Before:

![supabase com_docs_reference_javascript_storage-from-upload (2)](https://user-images.githubusercontent.com/31426677/173224314-8f940cde-96c3-4539-b3d1-34ae0109a66b.png)
(The label is too close the right text making it hard to read)

After:

![supabase com_docs_reference_javascript_storage-from-upload (1)](https://user-images.githubusercontent.com/31426677/173224282-5e9a0c23-994c-409b-b2a0-2685d6f020bc.png)
(The red underline highlights the label having margin right)

### Fix typo and making it consistent with rest of text

Before:

![supabase com_docs_reference_javascript_storage-from-upload (3)](https://user-images.githubusercontent.com/31426677/173224371-bedefb73-e996-4e8c-b10d-cc0a40a06d04.png)
(Nit-picky but the first line in code has missing spaces and other places in documentation has spaces)

After:

![supabase com_docs_reference_javascript_storage-from-upload (4)](https://user-images.githubusercontent.com/31426677/173224472-69c8d972-7aa5-4be7-9036-0532abe9630d.png)
(The red underline highlights added spaces)

