### PR TITLE
fix: table row word overflowing

### DIFF
--- a/studio/styles/ui.scss
+++ b/studio/styles/ui.scss
@@ -142,7 +142,7 @@
 }
 
 .table-container tbody td {
-  @apply border-b p-3 px-4 text-sm text-gray-1100 border-table-border-light break-words dark:border-table-border-dark;
+  @apply border-b p-3 px-4 text-sm text-gray-1100 border-table-border-light truncate dark:border-table-border-dark;
 }
 
 .table-container tbody td:first-child {

--- a/studio/styles/ui.scss
+++ b/studio/styles/ui.scss
@@ -113,6 +113,10 @@
   border-spacing: 0;
 }
 
+.table-container table span {
+  @apply truncate;
+}
+
 .table-container thead th {
   @apply text-scale-900 font-normal text-sm;
   @apply bg-table-header-light dark:bg-table-header-dark;
@@ -142,7 +146,7 @@
 }
 
 .table-container tbody td {
-  @apply border-b p-3 px-4 text-sm text-gray-1100 border-table-border-light truncate dark:border-table-border-dark;
+  @apply border-b p-3 px-4 text-sm text-gray-1100 border-table-border-light dark:border-table-border-dark;
 }
 
 .table-container tbody td:first-child {

--- a/studio/styles/ui.scss
+++ b/studio/styles/ui.scss
@@ -142,7 +142,7 @@
 }
 
 .table-container tbody td {
-  @apply border-b p-3 px-4 text-sm text-gray-1100 border-table-border-light dark:border-table-border-dark;
+  @apply border-b p-3 px-4 text-sm text-gray-1100 border-table-border-light break-words dark:border-table-border-dark;
 }
 
 .table-container tbody td:first-child {


### PR DESCRIPTION
## Fix table row word overflowing

Long text values overflows in table rows. The fix is to add `overflow-wrap: break-word` to table rows.

Before:

![app supabase com_project_tmkjinhptbrflobdmgpn_database_triggers (2)](https://user-images.githubusercontent.com/31426677/173226537-4bc6231e-4944-48fa-876e-8c97c8f9fe9e.png)
(Table rows with text overflowing)

After:

![app supabase com_project_tmkjinhptbrflobdmgpn_database_triggers (3)](https://user-images.githubusercontent.com/31426677/173226569-144f08f5-eb1c-425b-bbc3-07292165c9ab.png)
(Table rows with fix)

