### PR TITLE
Ignore chrome debug events for sentry

### DIFF
--- a/studio/sentry.client.config.js
+++ b/studio/sentry.client.config.js
@@ -30,6 +30,9 @@ Sentry.init({
     // I'm unable to reproduce this error on local, staging nor prod across chrome, safari or firefox
     // Based on https://github.com/stripe/stripe-js/issues/26, it seems like this error is safe to ignore,
     'Failed to load Stripe.js',
+    // [Joshen] This is a chrome specific error, fix is out in chromium, pending chrome update
+    // Ref: https://stackoverflow.com/questions/72437786/chrome-evalerror-possible-side-effect-in-debug
+    'Possible side-effect in debug-evaluate',
   ],
 })
 

--- a/studio/sentry.server.config.js
+++ b/studio/sentry.server.config.js
@@ -18,5 +18,8 @@ Sentry.init({
     // I'm unable to reproduce this error on local, staging nor prod across chrome, safari or firefox
     // Based on https://github.com/stripe/stripe-js/issues/26, it seems like this error is safe to ignore,
     'Failed to load Stripe.js',
+    // [Joshen] This is a chrome specific error, fix is out in chromium, pending chrome update
+    // Ref: https://stackoverflow.com/questions/72437786/chrome-evalerror-possible-side-effect-in-debug
+    'Possible side-effect in debug-evaluate',
   ],
 })


### PR DESCRIPTION
ref: https://stackoverflow.com/questions/72437786/chrome-evalerror-possible-side-effect-in-debug