### PR TITLE
changed supabase_url to subabase_anon_key in generating-types guide

### DIFF
--- a/web/docs/guides/api/generating-types.mdx
+++ b/web/docs/guides/api/generating-types.mdx
@@ -82,7 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SUPABASE_URL: ${{secrets.SUPABASE_URL}}
-      SUPABASE_ANON_KEY: ${{secrets.SUPABASE_URL}}
+      SUPABASE_ANON_KEY: ${{secrets.SUPABASE_ANON_KEY}}
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR changes a single typo/error in the Generating Types doc (Under Automatic Github Actions) found at https://supabase.com/docs/guides/api/generating-types#update-types-automatically-with-github-actions. 

## What is the current behavior?

Currently, if the code is copy and pasted as is, the Github Action will not work because it is trying to use SUPABASE_URL key as the SUPABASE_ANON_KEY.

## What is the new behavior?
```
SUPABASE_ANON_KEY: ${{secrets.SUPABASE_URL}}
```
is replaced with
```
SUPABASE_ANON_KEY: ${{secrets.SUPABASE_ANON_KEY}}
```

The code can be copy and pasted as is and will work out of the box, as long as the secrets are configured on the specific Github repository.

## Additional context

This bug took me an embarrassing amount of time to figure out, and I was hoping to contribute so another lost soul won't run into the same problem.