### PR TITLE
chore: add gradient bg to blog images

### DIFF
--- a/apps/www/pages/blog/[year]/[month]/[day]/[slug].tsx
+++ b/apps/www/pages/blog/[year]/[month]/[day]/[slug].tsx
@@ -30,9 +30,26 @@ const components = {
   },
   ImageGrid,
   img: (props: any) => {
+    const classes = [
+      'next-image--dynamic-fill',
+      'from-brand-500 to-brand-500',
+      'rounded border bg-gradient-to-r via-blue-500',
+    ]
+
     return (
-      <div className="next-image--dynamic-fill">
-        <Image {...props} layout="fill" className="custom-img" />
+      <div
+        className="
+          next-image--dynamic-fill 
+            to-scale-400  
+            from-scale-500 rounded-md
+            border bg-gradient-to-r
+      "
+      >
+        <Image
+          {...props}
+          className="next-image--dynamic-fill to-brand-1000 from-brand-900 rounded-md border bg-gradient-to-r"
+          layout="fill"
+        />
       </div>
     )
   },


### PR DESCRIPTION

## What is the new behavior?

added bg to next/image images in blog posts

## Additional context

Add any other context or screenshots.
<img width="959" alt="Screenshot 2022-06-16 at 4 16 59 PM" src="https://user-images.githubusercontent.com/8291514/174025380-9cd3bea4-d3fc-4e3f-9115-4eb5541da7d4.png">

