### PR TITLE
Fix/table relation style

### DIFF
--- a/studio/styles/grid.scss
+++ b/studio/styles/grid.scss
@@ -617,7 +617,7 @@
 }
 
 .foreign-table-modal__row-item {
-  @apply border-scale-400 dark:border-scale-500 overflow-hidden rounded border border-solid px-5 py-2 shadow-sm first:mt-2;
+  @apply border-scale-400 dark:border-scale-500 w-max min-w-full overflow-hidden rounded border border-solid px-5 py-2 shadow-sm first:mt-2;
 }
 
 .foreign-table-modal__row-item__inner {
@@ -707,4 +707,3 @@ header/sort/SortRow
 .sb-grid-sort-row__item__move {
   @apply flex cursor-move;
 }
-


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix

## What is the current behavior?

In supabase studio, open table editor and go to any foreign key and click the open modal icon.
Foreign table modal does not allow users to scroll overflowing rows.

![supabeforechange](https://user-images.githubusercontent.com/41582680/174435057-3605d161-3f9a-4d7b-904a-4cc27aaed544.png)


## What is the new behavior?

If row overflows, allow users to scroll horizontally. If row doesn't overflow, border will extend to 100% width to make style consistent.

![supaafterchange](https://user-images.githubusercontent.com/41582680/174435136-9c641a9e-4646-4e35-a5d1-c2690009a591.png)

@MildTomato @phamhieu @joshenlim 