### PR TITLE
fix: oss changes

### DIFF
--- a/web/src/components/Sponsors.js
+++ b/web/src/components/Sponsors.js
@@ -41,13 +41,13 @@ export default function Sponsors() {
     <div >
     
           {tiers.map(
-            (t) =>
+            (t,index) =>
               !!t.transactions.length && (
-                <>
+                <div key={index}>
                   <h4 className="">{t.heading}</h4>
                   <div className="row is-multiline" style={{ paddingLeft: 15 }}>
-                    {t.transactions.map((x) => (
-                      <div className="col col--4" key={x.sponsor}>
+                    {t.transactions.map((x, index) => (
+                      <div className="col col--4" key={index}>
                         <a className="avatar" href={`https://github.com/${x.sponsor}`}>
                           <img
                             className="avatar__photo avatar__photo--sm"
@@ -61,7 +61,7 @@ export default function Sponsors() {
                     ))}
                   </div>
                   <br />
-                </>
+                </div>
               )
           )}
           

--- a/web/src/components/Sponsors.js
+++ b/web/src/components/Sponsors.js
@@ -1,71 +1,66 @@
 import React from 'react'
 import sponsors from '@site/src/data/sponsors.json'
 
-
 export default function Sponsors() {
-
   const tiers = [
     {
       tier_name: '$5,000 a month',
       heading: 'Enterprise: $5,000 per month',
-      transactions: sponsors.filter((x) => (x.tier == '$5,000 a month')),
+      transactions: sponsors.filter((x) => x.tier == '$5,000 a month'),
     },
     {
       tier_name: '$2,500 a month',
       heading: 'Agency: $2,500 per month',
-      transactions: sponsors.filter((x) => (x.tier == '$2,500 a month')),
+      transactions: sponsors.filter((x) => x.tier == '$2,500 a month'),
     },
     {
       tier_name: '$1,000 a month',
       heading: 'Startup: $1,000 per month',
-      transactions: sponsors.filter((x) => (x.tier == '$1,000 a month')),
+      transactions: sponsors.filter((x) => x.tier == '$1,000 a month'),
     },
     {
       tier_name: '$49 a month',
       heading: 'Evangelist: $49 per month',
-      transactions: sponsors.filter((x) => (x.tier == '$49 a month')),
+      transactions: sponsors.filter((x) => x.tier == '$49 a month'),
     },
     {
       tier_name: '$19 a month',
       heading: 'Supporter: $19 per month',
-      transactions: sponsors.filter((x) => (x.tier == '$19 a month')),
+      transactions: sponsors.filter((x) => x.tier == '$19 a month'),
     },
     {
       tier_name: '$5 a month',
       heading: 'Contributor: $5 per month',
-      transactions: sponsors.filter((x) => (x.tier == '$5 a month')),
+      transactions: sponsors.filter((x) => x.tier == '$5 a month'),
     },
   ]
 
   return (
-    <div >
-    
-          {tiers.map(
-            (t,index) =>
-              !!t.transactions.length && (
-                <div key={index}>
-                  <h4 className="">{t.heading}</h4>
-                  <div className="row is-multiline" style={{ paddingLeft: 15 }}>
-                    {t.transactions.map((x, index) => (
-                      <div className="col col--4" key={index}>
-                        <a className="avatar" href={`https://github.com/${x.sponsor}`}>
-                          <img
-                            className="avatar__photo avatar__photo--sm"
-                            src={`https://github.com/${x.sponsor}.png`}
-                          />
-                          <div className="avatar__intro">
-                            <h5 className="avatar__name" >{x.sponsor}</h5>
-                          </div>
-                        </a>
+    <div>
+      {tiers.map(
+        (t, index) =>
+          !!t.transactions.length && (
+            <div key={index}>
+              <h4 className="">{t.heading}</h4>
+              <div className="row is-multiline" style={{ paddingLeft: 15 }}>
+                {t.transactions.map((x, index) => (
+                  <div className="col col--4" key={index}>
+                    <a className="avatar" href={`https://github.com/${x.sponsor}`}>
+                      <img
+                        className="avatar__photo avatar__photo--sm"
+                        src={`https://github.com/${x.sponsor}.png`}
+                      />
+                      <div className="avatar__intro">
+                        <h5 className="avatar__name">{x.sponsor}</h5>
                       </div>
-                    ))}
+                    </a>
                   </div>
-                  <br />
-                </div>
-              )
-          )}
-          
+                ))}
+              </div>
+              <br />
+            </div>
+          )
+      )}
     </div>
   )
 }
-

--- a/web/src/pages/oss.js
+++ b/web/src/pages/oss.js
@@ -2,7 +2,6 @@ import React from 'react'
 import { Octokit } from '@octokit/core'
 import Layout from '@theme/Layout'
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext'
-import sponsors from '../data/sponsors.json'
 import maintainers from '../data/maintainers.json'
 import GithubCard from '../components/GithubCard'
 

--- a/web/src/pages/oss.js
+++ b/web/src/pages/oss.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Octokit } from "@octokit/core"
+import { Octokit } from '@octokit/core'
 import Layout from '@theme/Layout'
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext'
 import sponsors from '../data/sponsors.json'
@@ -9,7 +9,7 @@ import GithubCard from '../components/GithubCard'
 import Sponsors from '../components/Sponsors'
 
 export default function Oss() {
-  const octokit = new Octokit();
+  const octokit = new Octokit()
 
   const [activePill, setActivePill] = React.useState('All')
   const [repos, setRepos] = React.useState([])
@@ -24,14 +24,18 @@ export default function Oss() {
   const maintainerPills = ['All'].concat(maintainerTags)
 
   React.useEffect(async () => {
-    const reposResponse = await octokit.request("GET /orgs/{org}/repos", {
-      org: "supabase",
-      type: "public",
+    const reposResponse = await octokit.request('GET /orgs/{org}/repos', {
+      org: 'supabase',
+      type: 'public',
       per_page: 6,
-      page: 1
-    });
+      page: 1,
+    })
 
-    setRepos(reposResponse.data.filter((r) => !!r.stargazers_count).sort((a, b) => b.stargazers_count - a.stargazers_count))
+    setRepos(
+      reposResponse.data
+        .filter((r) => !!r.stargazers_count)
+        .sort((a, b) => b.stargazers_count - a.stargazers_count)
+    )
   })
 
   return (
@@ -63,7 +67,7 @@ export default function Oss() {
         <div className="container">
           <h2>Community Maintainers</h2>
 
-          <ul style={{overflow: "auto"}} className="pills">
+          <ul style={{ overflow: 'auto' }} className="pills">
             {maintainerPills.map((x) => (
               <li
                 key={x}
@@ -105,19 +109,19 @@ export default function Oss() {
         <div className="container">
           <h2>Repositories</h2>
           <div className="row is-multiline">
-            {repos.length < 1 && <div>
-            </div>}
-            {repos.length >= 1 && repos.map((props, idx) => (
-              <div className={'col col--6'} key={idx}>
-                <GithubCard
-                  title={props.name}
-                  description={props.description}
-                  href={props.html_url}
-                  stars={props.stargazers_count}
-                  handle={props.full_name}
-                />
-              </div>
-            ))}
+            {repos.length < 1 && <div></div>}
+            {repos.length >= 1 &&
+              repos.map((props, idx) => (
+                <div className={'col col--6'} key={idx}>
+                  <GithubCard
+                    title={props.name}
+                    description={props.description}
+                    href={props.html_url}
+                    stars={props.stargazers_count}
+                    handle={props.full_name}
+                  />
+                </div>
+              ))}
           </div>
         </div>
       </section>

--- a/web/src/pages/oss.js
+++ b/web/src/pages/oss.js
@@ -108,9 +108,8 @@ export default function Oss() {
             {repos.length < 1 && <div>
             </div>}
             {repos.length >= 1 && repos.map((props, idx) => (
-              <div className={'col col--6'}>
+              <div className={'col col--6'} key={idx}>
                 <GithubCard
-                  key={idx}
                   title={props.name}
                   description={props.description}
                   href={props.html_url}

--- a/web/src/pages/oss.js
+++ b/web/src/pages/oss.js
@@ -63,11 +63,11 @@ export default function Oss() {
         <div className="container">
           <h2>Community Maintainers</h2>
 
-          <ul class="pills">
+          <ul style={{overflow: "auto"}} className="pills">
             {maintainerPills.map((x) => (
               <li
                 key={x}
-                class={`pills__item ${activePill == x ? 'pills__item--active' : ''}`}
+                className={`pills__item ${activePill == x ? 'pills__item--active' : ''}`}
                 onClick={() => setActivePill(x)}
               >
                 {x}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs [open source](https://supabase.com/docs/oss) page changes

## What is the current behavior?

Currently on a mobile device on the Community Maintainers page the pill filter overflows:

<img width="452" alt="Screenshot 2022-06-18 at 13 45 47" src="https://user-images.githubusercontent.com/22655069/174439873-2f632a63-ba05-43f3-89e5-738074f1cce7.png">


## What is the new behavior?

The overflow is now scrollable:

<img width="408" alt="Screenshot 2022-06-18 at 14 16 58" src="https://user-images.githubusercontent.com/22655069/174439903-52d3b804-7df9-4676-a27c-b845c0017b06.png">


## Additional context

I've also done some minor changes:

- Removed un-needed import
- Added keys onto some of the map functions
- `className` now being used instead of `class`
