### PR TITLE
Update local-development.mdx

### DIFF
--- a/web/docs/guides/local-development.mdx
+++ b/web/docs/guides/local-development.mdx
@@ -244,7 +244,7 @@ supabase functions deploy <function_name>
 
 ## Limitations
 	
-The local development environment is not as feature-complete as the Plaform. Here are some of the differences:
+The local development environment is not as feature-complete as the Platform. Here are some of the differences:
 	
 - The Storage interface is coming soon.
 - The Functions interface is coming soon.


### PR DESCRIPTION
- add missing t for platform

## What kind of change does this PR introduce?

documentation update (wording correction to be exact)

## What is the current behavior?

the current spelling for platform is missing letter t

