### PR TITLE
fix: sql create from template

### DIFF
--- a/studio/components/to-be-cleaned/SqlEditor/TabWelcome.js
+++ b/studio/components/to-be-cleaned/SqlEditor/TabWelcome.js
@@ -62,7 +62,7 @@ const TabWelcome = observer(() => {
               description={x.description}
               sql={x.sql}
               onClick={(sql, title) => {
-                handleNewQuery(sql, title)
+                handleNewQuery({ sql, name: title })
                 Telemetry.sendEvent('quickstart', 'quickstart_clicked', x.title)
               }}
             />


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When creating an SQL snippet from a template it creates a blank query instead.

## What is the new behavior?

Correctly creates the SQL snippet with the template and title.
