### PR TITLE
Chore/allow toggling of realtime in table editor

### DIFF
--- a/studio/components/interfaces/Database/Publications/PublicationsTableItem.tsx
+++ b/studio/components/interfaces/Database/Publications/PublicationsTableItem.tsx
@@ -54,11 +54,11 @@ const PublicationsTableItem: FC<Props> = ({ table, selectedPublication }) => {
     <Table.tr key={table.id}>
       <Table.td className="whitespace-nowrap">{table.name}</Table.td>
       <Table.td className="whitespace-nowrap">{table.schema}</Table.td>
-      <Table.td className="whitespace-nowrap truncate max-w-sm hidden lg:table-cell">
+      <Table.td className="hidden max-w-sm truncate whitespace-nowrap lg:table-cell">
         {table.comment}
       </Table.td>
       <Table.td className="px-4 py-3 pr-2">
-        <div className="flex gap-2 justify-end">
+        <div className="flex justify-end gap-2">
           {enabledForAllTables ? (
             // @ts-ignore
             <Badge
@@ -74,7 +74,7 @@ const PublicationsTableItem: FC<Props> = ({ table, selectedPublication }) => {
               size="tiny"
               align="right"
               disabled={loading}
-              className="m-0 p-0 ml-2 mt-1 -mb-1"
+              className="m-0 ml-2 mt-1 -mb-1 p-0"
               checked={checked}
               onChange={() => toggleReplicationForTable(table, publication)}
             />

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
@@ -165,10 +165,9 @@ const SidePanelEditor: FC<Props> = ({
           category: 'loading',
           message: `Duplicating table: ${duplicateTable.name}...`,
         })
-
-        // Need to duplicate realtime perhaps?
         const table: any = await meta.duplicateTable(payload, {
           isRLSEnabled,
+          isRealtimeEnabled,
           isDuplicateRows,
           duplicateTable,
         })

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
@@ -148,13 +148,15 @@ const SidePanelEditor: FC<Props> = ({
       tableId?: number
       importContent?: ImportContent
       isRLSEnabled: boolean
+      isRealtimeEnabled: boolean
       isDuplicateRows: boolean
     },
     resolve: any
   ) => {
     let toastId
     let saveTableError = false
-    const { tableId, importContent, isRLSEnabled, isDuplicateRows } = configuration
+    const { tableId, importContent, isRLSEnabled, isRealtimeEnabled, isDuplicateRows } =
+      configuration
 
     try {
       if (isDuplicating) {
@@ -163,6 +165,8 @@ const SidePanelEditor: FC<Props> = ({
           category: 'loading',
           message: `Duplicating table: ${duplicateTable.name}...`,
         })
+
+        // Need to duplicate realtime perhaps?
         const table: any = await meta.duplicateTable(payload, {
           isRLSEnabled,
           isDuplicateRows,
@@ -179,7 +183,14 @@ const SidePanelEditor: FC<Props> = ({
           category: 'loading',
           message: `Creating new table: ${payload.name}...`,
         })
-        const table = await meta.createTable(toastId, payload, isRLSEnabled, columns, importContent)
+        const table = await meta.createTable(
+          toastId,
+          payload,
+          columns,
+          isRLSEnabled,
+          isRealtimeEnabled,
+          importContent
+        )
         ui.setNotification({
           id: toastId,
           category: 'success',
@@ -195,7 +206,8 @@ const SidePanelEditor: FC<Props> = ({
           toastId,
           selectedTableToEdit,
           payload,
-          columns
+          columns,
+          isRealtimeEnabled
         )
         if (hasError) {
           ui.setNotification({
@@ -258,8 +270,6 @@ const SidePanelEditor: FC<Props> = ({
       )}
       <TableEditor
         table={selectedTableToEdit}
-        tables={tables}
-        enumTypes={enumTypes}
         selectedSchema={selectedSchema}
         isDuplicating={isDuplicating}
         visible={sidePanelKey === 'table'}

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.tsx
@@ -20,8 +20,6 @@ import {
 
 interface Props {
   table?: PostgresTable
-  tables: PostgresTable[]
-  enumTypes: PostgresType[]
   selectedSchema: string
   isDuplicating: boolean
   visible: boolean
@@ -34,6 +32,7 @@ interface Props {
       tableId?: number
       importContent?: ImportContent
       isRLSEnabled: boolean
+      isRealtimeEnabled: boolean
       isDuplicateRows: boolean
     },
     resolve: any
@@ -43,8 +42,6 @@ interface Props {
 
 const TableEditor: FC<Props> = ({
   table,
-  tables = [],
-  enumTypes = [] as PostgresType[],
   selectedSchema,
   isDuplicating,
   visible = false,
@@ -52,8 +49,22 @@ const TableEditor: FC<Props> = ({
   saveChanges = () => {},
   updateEditorDirty = () => {},
 }) => {
-  const { ui } = useStore()
+  const { ui, meta } = useStore()
   const isNewRecord = isUndefined(table)
+
+  const tables = meta.tables.list()
+  const enumTypes = meta.types.list(
+    (type: PostgresType) => !meta.excludedSchemas.includes(type.schema)
+  )
+
+  const publications = meta.publications.list()
+  const realtimePublication = publications.find(
+    (publication) => publication.name === 'supabase_realtime'
+  )
+  const realtimeEnabledTables = realtimePublication?.tables ?? []
+  const isRealtimeEnabled = isNewRecord
+    ? false
+    : realtimeEnabledTables.some((t: any) => t.id === table.id)
 
   const [errors, setErrors] = useState<any>({})
   const [tableFields, setTableFields] = useState<TableField>()
@@ -70,7 +81,11 @@ const TableEditor: FC<Props> = ({
         const tableFields = generateTableField()
         setTableFields(tableFields)
       } else {
-        const tableFields = generateTableFieldFromPostgresTable(table!, isDuplicating)
+        const tableFields = generateTableFieldFromPostgresTable(
+          table!,
+          isDuplicating,
+          isRealtimeEnabled
+        )
         setTableFields(tableFields)
       }
     }
@@ -122,6 +137,7 @@ const TableEditor: FC<Props> = ({
           tableId: table?.id,
           importContent,
           isRLSEnabled: tableFields.isRLSEnabled,
+          isRealtimeEnabled: tableFields.isRealtimeEnabled,
           isDuplicateRows: isDuplicateRows,
         }
 
@@ -187,8 +203,16 @@ const TableEditor: FC<Props> = ({
                 </div>
               }
               description="Restrict access to your table by enabling RLS and writing Postgres policies"
-              checked={tableFields?.isRLSEnabled}
-              onChange={() => onUpdateField({ isRLSEnabled: !tableFields?.isRLSEnabled })}
+              checked={tableFields.isRLSEnabled}
+              onChange={() => onUpdateField({ isRLSEnabled: !tableFields.isRLSEnabled })}
+              size="medium"
+            />
+            <Checkbox
+              id="enable-realtime"
+              label="Enable Realtime"
+              description="Broadcast changes on this table to authorized subscribers"
+              checked={tableFields.isRealtimeEnabled}
+              onChange={() => onUpdateField({ isRealtimeEnabled: !tableFields.isRealtimeEnabled })}
               size="medium"
             />
           </div>

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.tsx
@@ -64,7 +64,7 @@ const TableEditor: FC<Props> = ({
   const realtimeEnabledTables = realtimePublication?.tables ?? []
   const isRealtimeEnabled = isNewRecord
     ? false
-    : realtimeEnabledTables.some((t: any) => t.id === table.id)
+    : realtimeEnabledTables.some((t: any) => t.id === table?.id)
 
   const [errors, setErrors] = useState<any>({})
   const [tableFields, setTableFields] = useState<TableField>()

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.types.ts
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.types.ts
@@ -7,6 +7,7 @@ export interface TableField {
   comment?: string
   columns: ColumnField[]
   isRLSEnabled: boolean
+  isRealtimeEnabled: boolean
 }
 
 export interface ImportContent {

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.utils.ts
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.utils.ts
@@ -30,12 +30,14 @@ export const generateTableField = (): TableField => {
     comment: '',
     columns: DEFAULT_COLUMNS,
     isRLSEnabled: false,
+    isRealtimeEnabled: false,
   }
 }
 
 export const generateTableFieldFromPostgresTable = (
   table: PostgresTable,
-  isDuplicating = false
+  isDuplicating = false,
+  isRealtimeEnabled = false
 ): TableField => {
   return {
     id: table.id,
@@ -46,6 +48,7 @@ export const generateTableFieldFromPostgresTable = (
       return generateColumnFieldFromPostgresColumn(column, table)
     }),
     isRLSEnabled: table.rls_enabled,
+    isRealtimeEnabled,
   }
 }
 

--- a/studio/components/layouts/TableEditorLayout/TableEditorLayout.tsx
+++ b/studio/components/layouts/TableEditorLayout/TableEditorLayout.tsx
@@ -37,6 +37,7 @@ const TableEditorLayout: FC<Props> = ({
       meta.schemas.load()
       meta.tables.load()
       meta.types.load()
+      meta.publications.load()
     }
   }, [ui.selectedProject])
 

--- a/studio/package-lock.json
+++ b/studio/package-lock.json
@@ -70,6 +70,7 @@
         "swr": "^1.2.1",
         "uniforms-bootstrap4": "^3.6.2",
         "uniforms-bridge-json-schema": "^3.6.2",
+        "uuid": "^8.3.2",
         "zxcvbn": "^4.4.2"
       },
       "devDependencies": {
@@ -100,6 +101,7 @@
         "@types/react-window-infinite-loader": "^1.0.5",
         "@types/semver": "^7.3.9",
         "@types/sqlstring": "^2.3.0",
+        "@types/uuid": "^8.3.4",
         "@types/zxcvbn": "^4.4.1",
         "autoprefixer": "^10.4.2",
         "babel-loader": "^8.2.3",
@@ -9048,6 +9050,12 @@
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==",
       "dev": true
     },
+    "node_modules/@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+      "dev": true
+    },
     "node_modules/@types/webpack": {
       "version": "4.41.32",
       "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.32.tgz",
@@ -9470,6 +9478,15 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/analytics-node/node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "bin": {
+        "uuid": "bin/uuid"
       }
     },
     "node_modules/anser": {
@@ -27444,12 +27461,11 @@
       }
     },
     "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "bin": {
-        "uuid": "bin/uuid"
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/uuid-browser": {
@@ -28141,6 +28157,16 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/webpack-log/node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "dev": true,
+      "bin": {
+        "uuid": "bin/uuid"
       }
     },
     "node_modules/webpack-sources": {
@@ -35769,6 +35795,12 @@
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==",
       "dev": true
     },
+    "@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+      "dev": true
+    },
     "@types/webpack": {
       "version": "4.41.32",
       "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.32.tgz",
@@ -36151,6 +36183,13 @@
         "ms": "^2.0.0",
         "remove-trailing-slash": "^0.1.0",
         "uuid": "^3.2.1"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        }
       }
     },
     "anser": {
@@ -49981,9 +50020,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "uuid-browser": {
       "version": "3.1.0",
@@ -50845,6 +50884,14 @@
       "requires": {
         "ansi-colors": "^3.0.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
+        }
       }
     },
     "webpack-sources": {


### PR DESCRIPTION
Add an option to toggle realtime for a table in the table editor side panel editor
- Available when creating/updating/duplicating a table
- Implementation is specifically for the supabase_realtime publication

![image](https://user-images.githubusercontent.com/19742402/174542415-a2742b79-1b9d-4ea9-8357-97f7ab38c17b.png)
