### PR TITLE
fix: studio examples list

### DIFF
--- a/studio/components/interfaces/Home/Home.constants.ts
+++ b/studio/components/interfaces/Home/Home.constants.ts
@@ -55,7 +55,7 @@ export const EXAMPLE_PROJECTS = [
   },
   {
     framework: 'React',
-    title: 'React.js realtime chat app',
+    title: 'React realtime chat app',
     description: 'Example app of real-time chat using supabase realtime api',
     url: 'https://github.com/shwosner/realtime-chat-supabase-react',
   },
@@ -73,7 +73,7 @@ export const EXAMPLE_PROJECTS = [
   },
   {
     framework: 'NextJS',
-    title: 'NextJS todo list app',
+    title: 'Next.js todo list app',
     description: 'NextJS todo list example',
     url: 'https://github.com/supabase/supabase/tree/master/examples/todo-list/nextjs-todo-list',
   },

--- a/studio/pages/project/[ref]/index.tsx
+++ b/studio/pages/project/[ref]/index.tsx
@@ -38,7 +38,7 @@ const Home: NextPageWithLayout = () => {
           <Typography.Title level={4}>Example projects</Typography.Title>
         </div>
         <div className="mx-6 grid gap-8 md:grid-cols-2 lg:grid-cols-3">
-          {EXAMPLE_PROJECTS.map((project) => (
+          {EXAMPLE_PROJECTS.sort((a, b) => a.title.localeCompare(b.title)).map((project) => (
             <ExampleProject key={project.url} {...project} />
           ))}
         </div>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Studio Change

## What is the current behavior?

The example projects list isn't ordered and some of the names aren't the same:

<img width="1265" alt="Screenshot 2022-06-20 at 14 11 59" src="https://user-images.githubusercontent.com/22655069/174610978-936192b4-e620-4965-9703-64cd6f865e6c.png">


## What is the new behavior?

The list is now ordered so its easier for users to see whats available and also some of the libraries/frameworks have been renamed:

<img width="1265" alt="Screenshot 2022-06-20 at 14 17 20" src="https://user-images.githubusercontent.com/22655069/174611448-67231323-b2a0-42f6-91ec-4684b109747f.png">


## Additional context

Add any other context or screenshots.
