### PR TITLE
feat: Realtime server logs

### DIFF
--- a/studio/components/interfaces/Settings/Logs/Logs.constants.ts
+++ b/studio/components/interfaces/Settings/Logs/Logs.constants.ts
@@ -234,6 +234,9 @@ export const SQL_FILTER_TEMPLATES: any = {
   auth_logs: {
     ..._SQL_FILTER_COMMON,
   },
+  realtime_logs: {
+    ..._SQL_FILTER_COMMON,
+  },
 }
 
 export enum LogsTableName {
@@ -242,6 +245,7 @@ export enum LogsTableName {
   FUNCTIONS = 'function_logs',
   FN_EDGE = 'function_edge_logs',
   AUTH = 'auth_logs',
+  REALTIME = 'realtime_logs',
 }
 
 export const LOGS_TABLES = {
@@ -250,6 +254,7 @@ export const LOGS_TABLES = {
   functions: LogsTableName.FUNCTIONS,
   fn_edge: LogsTableName.FN_EDGE,
   auth: LogsTableName.AUTH,
+  realtime: LogsTableName.REALTIME
 }
 
 export const LOGS_SOURCE_DESCRIPTION = {
@@ -258,6 +263,7 @@ export const LOGS_SOURCE_DESCRIPTION = {
   [LogsTableName.FUNCTIONS]: 'Function logs generated from runtime execution.',
   [LogsTableName.FN_EDGE]: 'Function call logs, containing the request and response.',
   [LogsTableName.AUTH]: 'Authentication logs from GoTrue',
+  [LogsTableName.REALTIME]: 'Realtime server for Postgres logical replication broadcasting',
 }
 
 export const genCountQuery = (table: string): string => `SELECT count(*) as count FROM ${table}`

--- a/studio/components/interfaces/Settings/Logs/Logs.types.ts
+++ b/studio/components/interfaces/Settings/Logs/Logs.types.ts
@@ -59,7 +59,7 @@ export type Count = LFResponse<CountData>
 
 export type Logs = LFResponse<LogData>
 
-export type QueryType = 'api' | 'database' | 'functions' | 'fn_edge' | 'auth'
+export type QueryType = 'api' | 'database' | 'functions' | 'fn_edge' | 'auth' | 'realtime'
 
 export type Mode = 'simple' | 'custom'
 

--- a/studio/components/layouts/DatabaseLayout/DatabaseMenu.utils.ts
+++ b/studio/components/layouts/DatabaseLayout/DatabaseMenu.utils.ts
@@ -1,9 +1,11 @@
 import { Project } from 'types'
 import { IS_PLATFORM } from 'lib/constants'
 import { ProductMenuGroup } from 'components/ui/ProductMenu/ProductMenu.types'
+import { useFlag } from 'hooks'
 
 export const generateDatabaseMenu = (project?: Project): ProductMenuGroup[] => {
   const ref = project?.ref ?? 'default'
+  const logsRealtime = useFlag('logsRealtime')
 
   const HOOKS_RELEASED = '2021-07-30T15:33:54.383Z'
   const showHooksRoute = project?.inserted_at ? project.inserted_at > HOOKS_RELEASED : false
@@ -36,56 +38,66 @@ export const generateDatabaseMenu = (project?: Project): ProductMenuGroup[] => {
     },
     ...(IS_PLATFORM
       ? [
-          {
-            title: 'Logs',
-            items: [
-              {
-                name: 'API logs',
-                key: 'api-logs',
-                url: `/project/${ref}/database/api-logs`,
-                items: [],
-              },
-              {
-                name: 'Postgres logs',
-                key: 'postgres-logs',
-                url: `/project/${ref}/database/postgres-logs`,
-                items: [],
-              },
-            ],
-          },
-        ]
+        {
+          title: 'Logs',
+          items: [
+            {
+              name: 'API logs',
+              key: 'api-logs',
+              url: `/project/${ref}/database/api-logs`,
+              items: [],
+            },
+            {
+              name: 'Postgres logs',
+              key: 'postgres-logs',
+              url: `/project/${ref}/database/postgres-logs`,
+              items: [],
+            },
+            ...(logsRealtime
+              ? [
+                {
+                  name: 'Realtime logs',
+                  key: 'realtime-logs',
+                  url: `/project/${ref}/database/realtime-logs`,
+                  items: [],
+                },
+              ]
+              : []),
+          ],
+        },
+      ]
       : []),
     ...(IS_PLATFORM
       ? [
-          {
-            title: 'Alpha Preview',
-            isPreview: true,
-            items: [
-              {
-                name: 'Triggers',
-                key: 'triggers',
-                url: `/project/${ref}/database/triggers`,
-                items: [],
-              },
-              {
-                name: 'Functions',
-                key: 'functions',
-                url: `/project/${ref}/database/functions`,
-                items: [],
-              },
-              ...(showHooksRoute
-                ? [
-                    {
-                      name: 'Function Hooks',
-                      key: 'hooks',
-                      url: `/project/${ref}/database/hooks`,
-                      items: [],
-                    },
-                  ]
-                : []),
-            ],
-          },
-        ]
+        {
+          title: 'Alpha Preview',
+          isPreview: true,
+          items: [
+            {
+              name: 'Triggers',
+              key: 'triggers',
+              url: `/project/${ref}/database/triggers`,
+              items: [],
+            },
+            {
+              name: 'Functions',
+              key: 'functions',
+              url: `/project/${ref}/database/functions`,
+              items: [],
+            },
+            ...(showHooksRoute
+              ? [
+                {
+                  name: 'Function Hooks',
+                  key: 'hooks',
+                  url: `/project/${ref}/database/hooks`,
+                  items: [],
+                },
+              ]
+              : []),
+          ],
+        },
+      ]
       : []),
   ]
 }

--- a/studio/components/layouts/DatabaseLayout/DatabaseMenu.utils.ts
+++ b/studio/components/layouts/DatabaseLayout/DatabaseMenu.utils.ts
@@ -38,66 +38,66 @@ export const generateDatabaseMenu = (project?: Project): ProductMenuGroup[] => {
     },
     ...(IS_PLATFORM
       ? [
-        {
-          title: 'Logs',
-          items: [
-            {
-              name: 'API logs',
-              key: 'api-logs',
-              url: `/project/${ref}/database/api-logs`,
-              items: [],
-            },
-            {
-              name: 'Postgres logs',
-              key: 'postgres-logs',
-              url: `/project/${ref}/database/postgres-logs`,
-              items: [],
-            },
-            ...(logsRealtime
-              ? [
-                {
-                  name: 'Realtime logs',
-                  key: 'realtime-logs',
-                  url: `/project/${ref}/database/realtime-logs`,
-                  items: [],
-                },
-              ]
-              : []),
-          ],
-        },
-      ]
+          {
+            title: 'Logs',
+            items: [
+              {
+                name: 'API logs',
+                key: 'api-logs',
+                url: `/project/${ref}/database/api-logs`,
+                items: [],
+              },
+              {
+                name: 'Postgres logs',
+                key: 'postgres-logs',
+                url: `/project/${ref}/database/postgres-logs`,
+                items: [],
+              },
+              ...(logsRealtime
+                ? [
+                    {
+                      name: 'Realtime logs',
+                      key: 'realtime-logs',
+                      url: `/project/${ref}/database/realtime-logs`,
+                      items: [],
+                    },
+                  ]
+                : []),
+            ],
+          },
+        ]
       : []),
     ...(IS_PLATFORM
       ? [
-        {
-          title: 'Alpha Preview',
-          isPreview: true,
-          items: [
-            {
-              name: 'Triggers',
-              key: 'triggers',
-              url: `/project/${ref}/database/triggers`,
-              items: [],
-            },
-            {
-              name: 'Functions',
-              key: 'functions',
-              url: `/project/${ref}/database/functions`,
-              items: [],
-            },
-            ...(showHooksRoute
-              ? [
-                {
-                  name: 'Function Hooks',
-                  key: 'hooks',
-                  url: `/project/${ref}/database/hooks`,
-                  items: [],
-                },
-              ]
-              : []),
-          ],
-        },
-      ]
+          {
+            title: 'Alpha Preview',
+            isPreview: true,
+            items: [
+              {
+                name: 'Triggers',
+                key: 'triggers',
+                url: `/project/${ref}/database/triggers`,
+                items: [],
+              },
+              {
+                name: 'Functions',
+                key: 'functions',
+                url: `/project/${ref}/database/functions`,
+                items: [],
+              },
+              ...(showHooksRoute
+                ? [
+                    {
+                      name: 'Function Hooks',
+                      key: 'hooks',
+                      url: `/project/${ref}/database/hooks`,
+                      items: [],
+                    },
+                  ]
+                : []),
+            ],
+          },
+        ]
       : []),
   ]
 }

--- a/studio/pages/project/[ref]/database/realtime-logs.tsx
+++ b/studio/pages/project/[ref]/database/realtime-logs.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import { useRouter } from 'next/router'
+import { observer } from 'mobx-react-lite'
+import { DatabaseLayout } from 'components/layouts'
+import LogsPreviewer from 'components/interfaces/Settings/Logs/LogsPreviewer'
+import { NextPageWithLayout } from 'types'
+
+export const LogPage: NextPageWithLayout = () => {
+  const router = useRouter()
+  const { ref } = router.query
+
+  return (
+    <LogsPreviewer
+      projectRef={ref as string}
+      condensedLayout={true}
+      // @ts-ignore
+      tableName={'realtime_logs'}
+      queryType={'realtime'}
+    />
+  )
+}
+
+LogPage.getLayout = (page) => <DatabaseLayout title="Database">{page}</DatabaseLayout>
+
+export default observer(LogPage)


### PR DESCRIPTION
Adds realtime server logs to `projects/[ref]/database`

- [x] get staging logs into LF
- [x] get prod logs into LF
- [x] Add project ref into LF logs https://github.com/supabase/multiplayer/issues/208
- [x] update dev/staging LF endpoint
- [x] add `logsRealtime` feature flag

todo:
- [ ] get dev logs into LF
- [ ] test with staging logs
- [ ] update prod LF endpoint
- [ ] test manually