### PR TITLE
Addendum to feat/point-in-time-recovery pt 2

### DIFF
--- a/studio/components/interfaces/Database/Backups/PITRBackupSelection/index.tsx
+++ b/studio/components/interfaces/Database/Backups/PITRBackupSelection/index.tsx
@@ -121,7 +121,6 @@ const PITRBackupSelection: FC<Props> = () => {
 
     const { error } = await post(`${API_URL}/database/${projectRef}/backups/pitr`, {
       recovery_time_target_unix: recoveryTimeTargetUnix,
-      region: configuration.region,
     })
 
     if (error) {


### PR DESCRIPTION
* No longer pass `region` to `/pitr` api endpoint.