### PR TITLE
Fix: broken link in docs

### DIFF
--- a/apps/temp-docs/docs/guides/client-libraries.mdx
+++ b/apps/temp-docs/docs/guides/client-libraries.mdx
@@ -7,7 +7,7 @@ description: 'Supabase provides client libraries in several languages.'
 import Tabs from '@theme/Tabs'
 import TabsPanel from '@theme/TabsPanel'
 
-The [Supabase Client](/docs/reference/javascript/supabase-client) makes it simple for developers to build secure and scalable products.
+The [Supabase Client](/docs/reference/javascript/installing) makes it simple for developers to build secure and scalable products.
 
 ## Auth
 
@@ -479,5 +479,5 @@ void main() async {
 
 ## Next steps
 
-- View the [Client Docs](/docs/reference/javascript/supabase-client)
+- View the [Client Docs](/docs/reference/javascript/installing)
 - Sign in: [app.supabase.com](https://app.supabase.com)

--- a/apps/www/_blog/2020-10-30-improved-dx.mdx
+++ b/apps/www/_blog/2020-10-30-improved-dx.mdx
@@ -18,9 +18,9 @@ Today we're releasing [supabase-js](https://github.com/supabase/supabase-js) ver
 
 ### New Docs
 
-Before digging into the improvements, we're excited to point out our new [developer docs](/docs/reference/javascript/supabase-client). While they're still a work in progress, here are some things we think you'll like:
+Before digging into the improvements, we're excited to point out our new [developer docs](/docs/reference/javascript/installing). While they're still a work in progress, here are some things we think you'll like:
 
-- The [Reference Docs](/docs/reference/javascript/supabase-client) are auto-generated from our TypeScript definitions and then enriched with examples. This forces us to document our code and makes it easier to keep everything in sync.
+- The [Reference Docs](/docs/reference/javascript/installing) are auto-generated from our TypeScript definitions and then enriched with examples. This forces us to document our code and makes it easier to keep everything in sync.
 - We added placeholders for the other languages that the community is developing. They have already started with Python, C#, Dart, Rust, and Swift. Expect to see the docs filling up soon!
 - We've added sections for all of the open source tools we use, including [Postgres](/docs/postgres/server/about), PostgREST[^1], [GoTrue](/docs/gotrue/server/about), and Realtime[^2]. We'll be filling these with lots of valuable information including self-hosting, benchmarks, and simple guides.
 

--- a/apps/www/_blog/2020-11-02-supabase-alpha-october-2020.mdx
+++ b/apps/www/_blog/2020-11-02-supabase-alpha-october-2020.mdx
@@ -56,7 +56,7 @@ One of the most requested Auth features was the ability to send magic links that
 
 ### Kaizen
 
-- We have new and improved [docs](/docs/reference/javascript/supabase-client).
+- We have new and improved [docs](/docs/reference/javascript/installing).
 - We converted [realtime-js](https://github.com/supabase/realtime-js/) to TypeScript.
 - Dashboard Performance: we heavily optimised our dashboard routes.
 - With the help of the community, we [closed a lot of issues](https://github.com/orgs/supabase/projects/5) during Hacktoberfest.

--- a/apps/www/_blog/2021-03-30-supabase-storage.mdx
+++ b/apps/www/_blog/2021-03-30-supabase-storage.mdx
@@ -158,6 +158,6 @@ You may be itching to get started tinkering around with our new Supabase storage
 - We will integrate our storage service with a Content Delivery Network. With a CDN, objects are cached on a global network. This leads to faster access times for your users around the world.
 - We are working on transformations like resizing of images and automatic optimization of different media types. This makes it easy to embed Supabase objects directly in your websites and mobile applications without additional processing.
 - A better editor to make authoring policies easier and less error prone.
-- Reach out to us if you would like to help out with adding storage support in one of the [community maintained client libraries](/docs/reference/javascript/supabase-client).
+- Reach out to us if you would like to help out with adding storage support in one of the [community maintained client libraries](/docs/reference/javascript/installing).
 
 Take it for a spin on our [dashboard](https://app.supabase.com/) and let us know what you think!

--- a/apps/www/_blog/2021-11-29-community-day.mdx
+++ b/apps/www/_blog/2021-11-29-community-day.mdx
@@ -83,7 +83,7 @@ The beauty of building in the open is that the community can get involved in add
 
 The [SupaSquad](/docs/handbook/supasquad) is an official Supabase advocate program where community members help build and manage the Supabase community. 
 
-Among many other awesome things, the SupaSquad has been absolutely on fire building [client libraries](/docs/reference/javascript/supabase-client) for all flavors of backends and environments.
+Among many other awesome things, the SupaSquad has been absolutely on fire building [client libraries](/docs/reference/javascript/installing) for all flavors of backends and environments.
 
 ![client-libs.jpg](/images/blog/launch-week-three/community-day/client-libs.jpg)
 

--- a/web/docs/faq.md
+++ b/web/docs/faq.md
@@ -33,7 +33,7 @@ We only support PostgreSQL. It's unlikely we'll ever move away from Postgres; ho
 
 ### Do you have a library for `[some other language]`?
 
-We officially support [JavaScript](/docs/reference/javascript/supabase-client) and [Dart](/docs/reference/dart/installing). 
+We officially support [JavaScript](/docs/reference/javascript/installing) and [Dart](/docs/reference/dart/installing). 
 
 You can find community-supported libraries in our [GitHub Community](https://github.com/supabase-community), and you can also help us to identify the most popular languages by [voting for a new client library](https://github.com/supabase/supabase/discussions/5).
 

--- a/web/docs/guides/client-libraries.mdx
+++ b/web/docs/guides/client-libraries.mdx
@@ -9,7 +9,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 
-The [Supabase Client](/docs/reference/javascript/supabase-client) makes it simple for developers to build secure and scalable products. 
+The [Supabase Client](/docs/reference/javascript/installing) makes it simple for developers to build secure and scalable products. 
 
 ## Auth
 
@@ -521,5 +521,5 @@ void main() async {
 
 ## Next steps
 
-- View the [Client Docs](/docs/reference/javascript/supabase-client)
+- View the [Client Docs](/docs/reference/javascript/installing)
 - Sign in: [app.supabase.com](https://app.supabase.com)

--- a/web/docs/guides/integrations/clerk.mdx
+++ b/web/docs/guides/integrations/clerk.mdx
@@ -42,7 +42,7 @@ After the key is added, click the **Apply Changes** button to save your template
 
 ## Step 3: Configure client
 
-The next step is to configure your client. Supabase provides an official [JavaScript/TypeScript client library](https://github.com/supabase/supabase-js) and there are [libraries in other languages](https://supabase.com/docs/reference/javascript/supabase-client) built by the community.
+The next step is to configure your client. Supabase provides an official [JavaScript/TypeScript client library](https://github.com/supabase/supabase-js) and there are [libraries in other languages](https://supabase.com/docs/reference/javascript/installing) built by the community.
 
 This guide will use a Next.js project with the JS client as an example, but the mechanism of setting the authentication token should be similar with other libraries and frameworks.
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix broken link in docs.

## What is the current behavior?

Fix https://github.com/supabase/supabase/issues/7309

## What is the new behavior?

Changes the link to https://supabase.com/docs/reference/javascript/installing

## Additional context

Add any other context or screenshots.