### PR TITLE
[WIP]Feat: collapsible sidebar

### DIFF
--- a/studio/components/layouts/AccountLayout/WithSidebar.tsx
+++ b/studio/components/layouts/AccountLayout/WithSidebar.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import Image from 'next/image'
 import { FC, ReactNode } from 'react'
 import { isUndefined } from 'lodash'
 import { Menu, Typography, IconArrowUpRight, Badge } from '@supabase/ui'
@@ -47,10 +48,8 @@ const WithSidebar: FC<Props> = ({
         >
           {title && (
             <div className="mb-2">
-              <div className="dark:border-dark flex h-12 max-h-12 items-center border-b px-6">
-                <Typography.Title level={4} className="mb-0">
-                  {title}
-                </Typography.Title>
+              <div className="dark:border-dark flex max-h-12 items-center border-b px-6">
+                <Image src={`/img/${"supabase-dark.svg"}`} width="100%" height="48" alt="Supabase Logo" />
               </div>
             </div>
           )}

--- a/studio/components/layouts/ProjectLayout/NavigationBar/NavigationBar.tsx
+++ b/studio/components/layouts/ProjectLayout/NavigationBar/NavigationBar.tsx
@@ -1,5 +1,6 @@
-import React, { FC } from 'react'
+import React, { FC, useState } from 'react'
 import Link from 'next/link'
+import Image from 'next/image'
 import { observer } from 'mobx-react-lite'
 import { useRouter } from 'next/router'
 import { isUndefined } from 'lodash'
@@ -15,6 +16,7 @@ interface Props {}
 const NavigationBar: FC<Props> = ({}) => {
   const router = useRouter()
   const { ui } = useStore()
+  const [isCollapsed, setIsCollapsed] = useState(false)
   const projectRef = ui.selectedProjectRef as string
   const projectBaseInfo = ui.selectedProjectBaseInfo
 
@@ -28,21 +30,23 @@ const NavigationBar: FC<Props> = ({}) => {
     <div
       style={{ height: ongoingIncident ? 'calc(100vh - 44px)' : '100vh' }}
       className={[
-        'flex w-14 flex-col justify-between overflow-y-hidden p-2',
+        `${isCollapsed ? 'w-14' : 'w-48'}`,
+        'flex flex-col justify-between overflow-y-hidden p-2',
         'bg-sidebar-light dark:bg-sidebar-dark dark:border-dark border-r',
       ].join(' ')}
     >
       <ul className="flex flex-col space-y-2">
-        <Link href={'/'}>
-          <a className="block">
-            <img
-              src="/img/supabase-logo.svg"
-              alt="Supabase"
-              className="mx-auto h-[40px] w-6 cursor-pointer rounded"
-            />
+        <Link href='/'>
+          <a className="block mx-2 h-10">
+            {isCollapsed ? (
+              <Image src="/img/supabase-logo.svg" width="24" height="24" alt="Supabase Logo" />
+            ) : (
+              <Image src={`/img/${"supabase-dark.svg"}`} width="125" height="40" alt="Supabase Logo" />
+            )}
           </a>
         </Link>
         <NavigationIconButton
+          isCollapsed={isCollapsed}
           isActive={isUndefined(activeRoute) && !isUndefined(router.query.ref)}
           route={{
             key: 'HOME',
@@ -56,6 +60,7 @@ const NavigationBar: FC<Props> = ({}) => {
           <NavigationIconButton
             key={route.key}
             route={route}
+            isCollapsed={isCollapsed}
             isActive={activeRoute === route.key}
           />
         ))}
@@ -64,6 +69,7 @@ const NavigationBar: FC<Props> = ({}) => {
           <NavigationIconButton
             key={route.key}
             route={route}
+            isCollapsed={isCollapsed}
             isActive={activeRoute === route.key}
           />
         ))}

--- a/studio/components/layouts/ProjectLayout/NavigationBar/NavigationBar.tsx
+++ b/studio/components/layouts/ProjectLayout/NavigationBar/NavigationBar.tsx
@@ -104,8 +104,9 @@ const NavigationBar: FC<Props> = ({}) => {
           }
         >
           <Button as="span" type="text" size="tiny">
-            <div className="py-1">
+            <div className="py-1 flex items-start space-x-2">
               <IconUser size={18} strokeWidth={2} />
+              {isCollapsed === false && <span className='text-sm'>Account Preferences</span>}
             </div>
           </Button>
         </Dropdown>

--- a/studio/components/layouts/ProjectLayout/NavigationBar/NavigationBar.tsx
+++ b/studio/components/layouts/ProjectLayout/NavigationBar/NavigationBar.tsx
@@ -37,7 +37,7 @@ const NavigationBar: FC<Props> = ({}) => {
     >
       <ul className="flex flex-col space-y-2">
         <Link href='/'>
-          <a className="block mx-2 h-10">
+          <a className={`block ml-2 w-fit ${isCollapsed ? "h-6 my-2" : "h-10"}`}>
             {isCollapsed ? (
               <Image src="/img/supabase-logo.svg" width="24" height="24" alt="Supabase Logo" />
             ) : (

--- a/studio/components/layouts/ProjectLayout/NavigationBar/NavigationIconButton.tsx
+++ b/studio/components/layouts/ProjectLayout/NavigationBar/NavigationIconButton.tsx
@@ -15,21 +15,21 @@ const NavigationIconButton: FC<Props> = ({ route, isCollapsed, isActive = false 
     <Tooltip.Root delayDuration={0}>
       <Tooltip.Trigger>
         <Link href={route.link}>
-          <a className='flex items-center space-x-2'>
+          <a className='flex items-center space-x-2 group'>
             <div className={[
               'transition-colors duration-200',
               'flex items-center justify-center h-10 w-10 rounded', // Layout
-              'bg-scale-200 hover:bg-scale-500', // Light mode
-              'text-scale-900 hover:text-scale-1200 ', // Dark mode
+              'bg-scale-200 group-hover:bg-scale-500', // Light mode
+              'text-scale-900 group-hover:text-scale-1200 ', // Dark mode
               `${isActive ? 'bg-scale-500 shadow-sm text-scale-1200' : ''}`,
             ].join(' ')}>
               {route.icon}
             </div>
-            {isCollapsed === false && <span className={`text-sm ${isActive ? 'text-scale-1200' : 'text-scale-900'}`}>{route.label}</span>}
+            {isCollapsed === false && <span className={`transition-colors duration-200 text-sm group-hover:text-scale-1200 ${isActive ? 'text-scale-1200' : 'text-scale-900'}`}>{route.label}</span>}
           </a>
         </Link>
       </Tooltip.Trigger>
-      {isCollapsed === false && (
+      {isCollapsed === true && (
       <Tooltip.Content side="right">
         <Tooltip.Arrow className="radix-tooltip-arrow" />
         <div

--- a/studio/components/layouts/ProjectLayout/NavigationBar/NavigationIconButton.tsx
+++ b/studio/components/layouts/ProjectLayout/NavigationBar/NavigationIconButton.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react'
+import { FC, useState } from 'react'
 import Link from 'next/link'
 import * as Tooltip from '@radix-ui/react-tooltip'
 
@@ -7,26 +7,29 @@ import { Route } from 'components/ui/ui.types'
 interface Props {
   route: Route
   isActive?: boolean
+  isCollapsed: boolean
 }
 
-const NavigationIconButton: FC<Props> = ({ route, isActive = false }) => {
+const NavigationIconButton: FC<Props> = ({ route, isCollapsed, isActive = false }) => {
   return (
     <Tooltip.Root delayDuration={0}>
       <Tooltip.Trigger>
         <Link href={route.link}>
-          <a
-            className={[
+          <a className='flex items-center space-x-2'>
+            <div className={[
               'transition-colors duration-200',
               'flex items-center justify-center h-10 w-10 rounded', // Layout
               'bg-scale-200 hover:bg-scale-500', // Light mode
               'text-scale-900 hover:text-scale-1200 ', // Dark mode
               `${isActive ? 'bg-scale-500 shadow-sm text-scale-1200' : ''}`,
-            ].join(' ')}
-          >
-            {route.icon}
+            ].join(' ')}>
+              {route.icon}
+            </div>
+            {isCollapsed === false && <span className={`text-sm ${isActive ? 'text-scale-1200' : 'text-scale-900'}`}>{route.label}</span>}
           </a>
         </Link>
       </Tooltip.Trigger>
+      {isCollapsed === false && (
       <Tooltip.Content side="right">
         <Tooltip.Arrow className="radix-tooltip-arrow" />
         <div
@@ -38,6 +41,7 @@ const NavigationIconButton: FC<Props> = ({ route, isActive = false }) => {
           <span className="text-scale-1200 text-xs">{route.label}</span>
         </div>
       </Tooltip.Content>
+      )}
     </Tooltip.Root>
   )
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds the ability to collapse the sidebar in the dashboard.

## What is the current behavior?

<img width="815" alt="image" src="https://user-images.githubusercontent.com/70828596/175205533-8e033968-74af-4871-8999-0f0f9ce72043.png">

## What is the new behavior?

### **`UPDATED`**
<img width="815" alt="image" src="https://user-images.githubusercontent.com/70828596/175209700-05550a1b-8aa0-4402-b606-2b2a75364910.png">

## Additional context

Didn't know where to put the button to collapse the sidebar. @MildTomato any suggestion.
https://www.notion.so/supabase/Collapsible-Side-Nav-2e1c8b47e4fd4e2f90b8e4e4664084e4