### PR TITLE
Chore/table editor support non public schema management

### DIFF
--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
@@ -182,6 +182,7 @@ const SidePanelEditor: FC<Props> = ({
           category: 'loading',
           message: `Creating new table: ${payload.name}...`,
         })
+
         const table = await meta.createTable(
           toastId,
           payload,

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/HeaderTitle.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/HeaderTitle.tsx
@@ -2,13 +2,18 @@ import { PostgresTable } from '@supabase/postgres-meta'
 import { Typography } from '@supabase/ui'
 
 interface Props {
+  schema: string
   table: PostgresTable
   isDuplicating: boolean
 }
 
-const HeaderTitle: React.FC<Props> = ({ table, isDuplicating }) => {
+const HeaderTitle: React.FC<Props> = ({ schema, table, isDuplicating }) => {
   if (!table) {
-    return <>Create a new table</>
+    return (
+      <>
+        Create a new table under <code>{schema}</code>
+      </>
+    )
   }
   if (isDuplicating) {
     return (

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.tsx
@@ -141,6 +141,7 @@ const TableEditor: FC<Props> = ({
           isRealtimeEnabled: tableFields.isRealtimeEnabled,
           isDuplicateRows: isDuplicateRows,
         }
+
         saveChanges(payload, columns, isNewRecord, configuration, resolve)
       } else {
         resolve()

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.tsx
@@ -121,6 +121,7 @@ const TableEditor: FC<Props> = ({
       if (isEmpty(errors)) {
         const payload: CreateTablePayload | UpdateTablePayload = {
           name: tableFields.name,
+          schema: selectedSchema,
           comment: tableFields.comment,
           ...(!isNewRecord && { rls_enabled: tableFields.isRLSEnabled }),
         }
@@ -140,7 +141,6 @@ const TableEditor: FC<Props> = ({
           isRealtimeEnabled: tableFields.isRealtimeEnabled,
           isDuplicateRows: isDuplicateRows,
         }
-
         saveChanges(payload, columns, isNewRecord, configuration, resolve)
       } else {
         resolve()
@@ -156,7 +156,7 @@ const TableEditor: FC<Props> = ({
       key="TableEditor"
       visible={visible}
       // @ts-ignore
-      header={<HeaderTitle table={table} isDuplicating={isDuplicating} />}
+      header={<HeaderTitle schema={selectedSchema} table={table} isDuplicating={isDuplicating} />}
       className={`transition-all duration-100 ease-in ${isImportingSpreadsheet ? ' mr-32' : ''}`}
       onCancel={closePanel}
       onConfirm={() => (resolve: () => void) => onSaveChanges(resolve)}

--- a/studio/components/interfaces/TableGridEditor/TableGridEditor.tsx
+++ b/studio/components/interfaces/TableGridEditor/TableGridEditor.tsx
@@ -64,9 +64,10 @@ const TableGridEditor: FC<Props> = ({
   }
 
   const tableId = selectedTable?.id
-
+  // @ts-ignore
+  const schema = meta.schemas.list().find((schema) => schema.name === selectedSchema)
   const isViewSelected = Object.keys(selectedTable).length === 2
-  const isLocked = meta.excludedSchemas.includes(selectedSchema || '')
+  const isLocked = schema?.owner === 'supabase_admin'
 
   const gridTable = !isViewSelected
     ? parseSupaTable({

--- a/studio/components/interfaces/TableGridEditor/TableGridEditor.tsx
+++ b/studio/components/interfaces/TableGridEditor/TableGridEditor.tsx
@@ -66,6 +66,8 @@ const TableGridEditor: FC<Props> = ({
   const tableId = selectedTable?.id
 
   const isViewSelected = Object.keys(selectedTable).length === 2
+  const isLocked = meta.excludedSchemas.includes(selectedSchema || '')
+
   const gridTable = !isViewSelected
     ? parseSupaTable({
         table: selectedTable as PostgresTable,
@@ -102,6 +104,7 @@ const TableGridEditor: FC<Props> = ({
     // For some reason, selectedTable here is stale after adding a table
     // temporary workaround is to list grab the selected table again
     const tables: PostgresTable[] = meta.tables.list()
+    // @ts-ignore
     const table = tables.find((table) => table.id === Number(tableId))
     const column = find(table!.columns, { name }) as PostgresColumn
     if (column) {
@@ -135,11 +138,14 @@ const TableGridEditor: FC<Props> = ({
         theme={theme}
         gridProps={{ height: '100%' }}
         storageRef={projectRef}
-        editable={!isViewSelected && selectedTable.schema === 'public'}
+        editable={!isViewSelected && !isLocked}
         schema={selectedTable.schema}
         table={gridTable}
         headerActions={
-          !isViewSelected && selectedTable.schema === 'public' && <GridHeaderActions table={selectedTable as PostgresTable} />
+          !isViewSelected &&
+          selectedTable.schema === 'public' && (
+            <GridHeaderActions table={selectedTable as PostgresTable} />
+          )
         }
         onAddColumn={onAddColumn}
         onEditColumn={onSelectEditColumn}

--- a/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
+++ b/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
@@ -51,6 +51,8 @@ const TableEditorMenu: FC<Props> = ({
   const [schemaViews, setSchemaViews] = useState<SchemaView[]>([])
   const [isRefreshing, setIsRefreshing] = useState<boolean>(false)
 
+  const isLocked = meta.excludedSchemas.includes(selectedSchema || '')
+
   // We may need to shift this to the schema store and do something like meta.schema.loadViews()
   // I don't need we need a separate store for views
   useEffect(() => {
@@ -90,13 +92,13 @@ const TableEditorMenu: FC<Props> = ({
       : schemaViews.filter((view) => view.name.includes(searchText))
 
   return (
-    <div className="my-6 mx-4 flex flex-col flex-grow space-y-6">
+    <div className="my-6 mx-4 flex flex-grow flex-col space-y-6">
       {/* Schema selection dropdown */}
       <div className="px-3">
         {meta.schemas.isLoading ? (
-          <div className="h-[30px] border border-gray-500 px-3 rounded flex items-center space-x-3">
+          <div className="flex h-[30px] items-center space-x-3 rounded border border-gray-500 px-3">
             <IconLoader className="animate-spin" size={12} />
-            <span className="text-xs text-scale-900">Loading schemas...</span>
+            <span className="text-scale-900 text-xs">Loading schemas...</span>
           </div>
         ) : (
           <Listbox
@@ -114,14 +116,10 @@ const TableEditorMenu: FC<Props> = ({
                 key={schema.id}
                 value={schema.name}
                 // @ts-ignore
-                label={
-                  <>
-                    <span className="text-scale-900">schema</span> <span>{schema.name}</span>
-                  </>
-                }
+                label={schema.name}
+                addOnBefore={() => <span className="text-scale-900">schema</span>}
               >
-                <span className="text-sm text-scale-900">schema</span>{' '}
-                <span className="text-sm text-scale-1200">{schema.name}</span>
+                <span className="text-scale-1200 text-sm">{schema.name}</span>
               </Listbox.Option>
             ))}
           </Listbox>
@@ -129,7 +127,7 @@ const TableEditorMenu: FC<Props> = ({
       </div>
 
       <div className="space-y-1">
-        {selectedSchema === 'public' && (
+        {!isLocked && (
           <div className="px-3">
             {/* Add new table button */}
             <Button
@@ -149,7 +147,7 @@ const TableEditorMenu: FC<Props> = ({
           </div>
         )}
         {/* Table search input */}
-        <div className="block mb-2 px-3">
+        <div className="mb-2 block px-3">
           <Input
             className="border-none"
             icon={
@@ -179,7 +177,7 @@ const TableEditorMenu: FC<Props> = ({
             // @ts-ignore
             title={
               <>
-                <div className="w-full flex items-center justify-between">
+                <div className="flex w-full items-center justify-between">
                   <span>All tables</span>
                   <button className="cursor-pointer" onClick={refreshTables}>
                     <IconRefreshCw className={isRefreshing ? 'animate-spin' : ''} size={14} />
@@ -229,7 +227,7 @@ const TableEditorMenu: FC<Props> = ({
                           </Dropdown.Item>,
                         ]}
                       >
-                        <div className="text-scale-900 transition-colors hover:text-scale-1200">
+                        <div className="text-scale-900 hover:text-scale-1200 transition-colors">
                           <IconChevronDown size={14} strokeWidth={2} />
                         </div>
                       </Dropdown>
@@ -249,7 +247,7 @@ const TableEditorMenu: FC<Props> = ({
             // @ts-ignore
             title={
               <>
-                <div className="w-full flex items-center justify-between">
+                <div className="flex w-full items-center justify-between">
                   <span>All views</span>
                 </div>
               </>


### PR DESCRIPTION
- We'll still protect system schemas on Studio for now (specifically those owned by `supabase_admin`)
- Schema selection dropdown will group what's open and what's protected
<img src="https://user-images.githubusercontent.com/19742402/175223185-54a48b5b-88c2-4b58-ae0c-83995c56580f.png" width="400"/>
- Users can manage tables, columns and rows for their own schemas, as the way they can for the public schema