### PR TITLE
Update FlagProvider to retrieve flags without profile

### DIFF
--- a/studio/components/ui/Flag/FlagProvider.tsx
+++ b/studio/components/ui/Flag/FlagProvider.tsx
@@ -13,12 +13,15 @@ const FlagProvider: FC = ({ children }) => {
   const { profile } = ui
 
   useEffect(() => {
-    if (IS_PLATFORM && profile) getFlags(profile)
+    if (IS_PLATFORM) getFlags(profile)
   }, [profile])
 
-  const getFlags = async (user: User) => {
+  const getFlags = async (user?: User) => {
     const setFlagValues = async () => {
-      const flagValues = await client.getAllValuesAsync({ identifier: user.primary_email })
+      const flagValues =
+        user !== undefined
+          ? await client.getAllValuesAsync({ identifier: user.primary_email })
+          : await client.getAllValuesAsync()
       const flagStore: any = {}
 
       flagValues.forEach((item: any) => {


### PR DESCRIPTION
So that incident banner can show up on landing page (cc @inian)

<img src="https://user-images.githubusercontent.com/19742402/175272688-e9eddf92-fda6-4201-bf4e-96abc8b2b49a.png" width="500" />

also cc @thebengeu just to make sure that im not overlooking anything that might go wrong doing this in FlagProvider
