### PR TITLE
feat(auth): Add support for hCaptcha

### DIFF
--- a/studio/pages/project/[ref]/auth/settings.tsx
+++ b/studio/pages/project/[ref]/auth/settings.tsx
@@ -67,6 +67,12 @@ const Settings = () => {
   }, [config])
 
   const onFormSubmit = async (model: any) => {
+    model.SECURITY_CAPTCHA_PROVIDER = 'hcaptcha'
+
+    if (!model.SECURITY_CAPTCHA_SECRET) {
+      model.SECURITY_CAPTCHA_ENABLED = false
+    }
+
     for (const [key, value] of Object.entries(model)) {
       // remove any whitespaces in OAuth or Sms provider credentials
       if ((key.includes('EXTERNAL') || key.includes('SMS')) && typeof value === 'string') {
@@ -124,6 +130,8 @@ const Settings = () => {
             'PASSWORD_MIN_LENGTH',
             'SECURITY_UPDATE_PASSWORD_REQUIRE_REAUTHENTICATION',
             'SECURITY_REFRESH_TOKEN_REUSE_INTERVAL',
+            'SECURITY_CAPTCHA_ENABLED',
+            'SECURITY_CAPTCHA_SECRET',
           ])}
           model={{
             SITE_URL: model.SITE_URL || undefined,
@@ -131,11 +139,15 @@ const Settings = () => {
             DISABLE_SIGNUP: model.DISABLE_SIGNUP,
             JWT_EXP: model.JWT_EXP || undefined,
             PASSWORD_MIN_LENGTH: model.PASSWORD_MIN_LENGTH || undefined,
-            SECURITY_REFRESH_TOKEN_REUSE_INTERVAL: model.SECURITY_REFRESH_TOKEN_REUSE_INTERVAL || undefined,
+            SECURITY_REFRESH_TOKEN_REUSE_INTERVAL:
+              model.SECURITY_REFRESH_TOKEN_REUSE_INTERVAL || undefined,
             SECURITY_UPDATE_PASSWORD_REQUIRE_REAUTHENTICATION:
               model.SECURITY_UPDATE_PASSWORD_REQUIRE_REAUTHENTICATION || false,
-            }}
-            onSubmit={(model: any) => onFormSubmit(model)}
+            SECURITY_CAPTCHA_ENABLED: model.SECURITY_CAPTCHA_ENABLED || false,
+            SECURITY_CAPTCHA_SECRET: model.SECURITY_CAPTCHA_SECRET || undefined,
+          }}
+          onChangeModel={(model: any) => setModel(model)}
+          onSubmit={(model: any) => onFormSubmit(model)}
         >
           <AutoField
             name="SITE_URL"
@@ -149,9 +161,17 @@ const Settings = () => {
           />
           <NumField name="JWT_EXP" step="1" />
           <NumField name="PASSWORD_MIN_LENGTH" step="1" min={6} max={10} />
-          <NumField name="SECURITY_REFRESH_TOKEN_REUSE_INTERVAL" step="1" min={0}/>
+          <NumField name="SECURITY_REFRESH_TOKEN_REUSE_INTERVAL" step="1" min={0} />
           <ToggleField name="SECURITY_UPDATE_PASSWORD_REQUIRE_REAUTHENTICATION" />
           <ToggleField name="DISABLE_SIGNUP" />
+          <ToggleField name="SECURITY_CAPTCHA_ENABLED" />
+          {model.SECURITY_CAPTCHA_ENABLED && (
+            <AutoField
+              name="SECURITY_CAPTCHA_SECRET"
+              showInlineError
+              errorMessage="Please enter a valid hCaptcha sitekey."
+            />
+          )}
         </SchemaFormPanel>
       </div>
       <div className="my-8 mt-0">
@@ -195,7 +215,7 @@ const Settings = () => {
             checked={model.EXTERNAL_EMAIL_ENABLED}
             descriptionText={authConfig.properties.EXTERNAL_EMAIL_ENABLED.help}
           />
-          <NumField name="MAILER_OTP_EXP" step="1" min={0} max={86400}/>
+          <NumField name="MAILER_OTP_EXP" step="1" min={0} max={86400} />
           <UIToggle
             layout="horizontal"
             className="mb-4"
@@ -326,8 +346,8 @@ const Settings = () => {
                   showInlineError
                   errorMessage="Please enter the phone provider."
                 />
-                <NumField name="SMS_OTP_EXP" step="1" min={0}/>
-                <NumField name="SMS_OTP_LENGTH" step="1" min={6} max={10}/>
+                <NumField name="SMS_OTP_EXP" step="1" min={0} />
+                <NumField name="SMS_OTP_LENGTH" step="1" min={6} max={10} />
                 {smsProviderModel?.SMS_PROVIDER === 'messagebird' ? (
                   <>
                     <SecretField

--- a/studio/stores/jsonSchema/auth_gotrue_config.json
+++ b/studio/stores/jsonSchema/auth_gotrue_config.json
@@ -382,7 +382,7 @@
       "type": "integer",
       "help": "Duration before an email otp / link expires."
     },
-    
+
     "MAILER_SUBJECTS_CONFIRMATION": {
       "title": "Subject",
       "type": "string"
@@ -447,6 +447,16 @@
       "title": "Reuse Interval",
       "type": "integer",
       "help": "Time interval where the same refresh token can be used to request for an access token."
+    },
+    "SECURITY_CAPTCHA_ENABLED": {
+      "title": "hCaptcha protection",
+      "type": "boolean",
+      "help": "Enables hCaptcha protection on all auth endpoints."
+    },
+    "SECURITY_CAPTCHA_SECRET": {
+      "title": "hCaptcha sitekey",
+      "type": "string",
+      "help": "Secret (sitekey) used to verify hCaptcha challenges."
     },
     "SMS_AUTOCONFIRM": {
       "title": "Enable phone confirmations",


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds the ability for customers to enable / disable hCaptcha protection on their auth setup.

## What is the current behavior?

Support can do this when asked.

## What is the new behavior?

hCaptcha can be enabled from the UI.

