### PR TITLE
fix: recent sql snippets refinements

### DIFF
--- a/studio/components/interfaces/Settings/Logs/Logs.SavedQueriesItem.tsx
+++ b/studio/components/interfaces/Settings/Logs/Logs.SavedQueriesItem.tsx
@@ -3,6 +3,7 @@ import { FC, useState } from 'react'
 import { Button, IconChevronRight, IconMaximize2, IconPlay } from '@supabase/ui'
 import Table from 'components/to-be-cleaned/Table'
 import { useRouter } from 'next/router'
+import SqlSnippetCode from './Logs.SqlSnippetCode'
 
 interface Props {
   item: any
@@ -45,27 +46,21 @@ const SavedQueriesItem: FC<Props> = ({ item }: Props) => {
             type="alternative"
             iconRight={<IconPlay size={10} />}
             onClick={() =>
-              router.push(
-                `/project/${ref}/logs-explorer?q=${encodeURIComponent(item.content.sql)}`
-              )
+              router.push(`/project/${ref}/logs-explorer?q=${encodeURIComponent(item.content.sql)}`)
             }
           >
             Run
           </Button>
         </Table.td>
       </Table.tr>
-      <>
-        <td
-          className={
-            'bg-scale-100 border-l border-r !pt-0 !pb-0 text-scale-1200 transition-all expanded-row-content ' +
-            (expand ? ' h-auto opacity-100' : 'h-0 opacity-0')
-          }
-          colSpan={5}
-        >
-          {/* <CodeEditor defaultValue={item.content.sql} language="pgsql" classname /> */}
-          {expand && <pre className="text-sm break-words py-4 px-3 ">{item.content.sql}</pre>}
-        </td>
-      </>
+      <Table.td
+        className={`${
+          expand ? ' h-auto opacity-100' : 'h-0 opacity-0'
+        } transition-all expanded-row-content bg-scale-100 border-l border-r !pt-0 !pb-0`}
+        colSpan={5}
+      >
+        {expand && <SqlSnippetCode>{item.content.sql}</SqlSnippetCode>}
+      </Table.td>
     </>
   )
 }

--- a/studio/components/interfaces/Settings/Logs/Logs.SqlSnippetCode.tsx
+++ b/studio/components/interfaces/Settings/Logs/Logs.SqlSnippetCode.tsx
@@ -1,0 +1,6 @@
+
+const SqlSnippetCode: React.FC = ({ children }) =>( 
+  <pre className="text-scale-1200 text-sm break-words py-4 px-3 w-full">{children}</pre>
+)
+
+export default SqlSnippetCode;

--- a/studio/components/interfaces/Settings/Logs/RecentQueriesItem.tsx
+++ b/studio/components/interfaces/Settings/Logs/RecentQueriesItem.tsx
@@ -2,6 +2,7 @@ import { Button, IconPlay } from '@supabase/ui'
 import Table from 'components/to-be-cleaned/Table'
 import { useRouter } from 'next/router'
 import { LogSqlSnippets } from 'types'
+import SqlSnippetCode from './Logs.SqlSnippetCode'
 
 interface Props {
   item: LogSqlSnippets.Content
@@ -13,20 +14,18 @@ const RecentQueriesItem: React.FC<Props> = ({ item }) => {
 
   return (
       <Table.tr key={item.sql}>
-        <Table.td>
-          <div
-            className={ 'whitespace-nowrap bg-scale-100 border-l border-r !pt-0 !pb-0 text-scale-1200 transition-all expanded-row-content '}
-          >
-            <pre className="text-sm break-words py-4 px-3 ">{item.sql}</pre>
-          </div>
+        <Table.td
+          className={`transition-all expanded-row-content bg-scale-100 border-l border-r !pt-0 !pb-0 !px-3`}
+        >
+          <SqlSnippetCode>{item.sql}</SqlSnippetCode>
         </Table.td>
-        <Table.td className=" text-right">
+        <Table.td className="text-right">
           <Button
             type="alternative"
             iconRight={<IconPlay size={10} />}
             onClick={() =>
               router.push(
-                `/project/${ref}/logs-explorer?sql=${encodeURIComponent(item.sql)}`
+                `/project/${ref}/logs-explorer?q=${encodeURIComponent(item.sql)}`
               )
             }
           >

--- a/studio/pages/project/[ref]/logs-explorer/recent.tsx
+++ b/studio/pages/project/[ref]/logs-explorer/recent.tsx
@@ -54,7 +54,7 @@ export const LogsSavedPage: NextPageWithLayout = () => {
             <p className="text-scale-900 text-sm">
               Your recent queries run from the{' '}
               <Link href={`/project/${ref}/logs-explorer`}>
-                <span className="cursor-pointer font-bold text-white underline">Query</span>
+                <span className="cursor-pointer font-bold underline">Query</span>
               </Link>{' '}
               tab will show here.
             </p>

--- a/studio/pages/project/[ref]/logs-explorer/recent.tsx
+++ b/studio/pages/project/[ref]/logs-explorer/recent.tsx
@@ -22,38 +22,30 @@ export const LogsSavedPage: NextPageWithLayout = () => {
 
   return (
     <>
-      <div className="flex flex-col gap-3">
-        {recent.length > 0 && (
-          <>
-            <div className="flex flex-row justify-end">
-              <Button
-                size="tiny"
-                type="default"
-                onClick={() => {
-                  content.clearRecentLogSqlSnippets()
-                }}
-              >
-                Clear
-              </Button>
-            </div>
-            <Table
-              head={
-                <>
-                  <Table.th>Snippets</Table.th>
-                  <Table.th className="w-24"></Table.th>
-                </>
-              }
-              body={
-                <>
-                  {recent.map((item: LogSqlSnippets.Content) => (
-                    <RecentQueriesItem key={item.sql} item={item} />
-                  ))}
-                </>
-              }
-            />
-          </>
-        )}
-      </div>
+      {recent.length > 0 && (
+          <Table
+            head={
+              <>
+                <Table.th>Snippets</Table.th>
+                <Table.th className="w-24">
+                  <Button
+                    size="tiny"
+                    type="default"
+                    onClick={() => {
+                      content.clearRecentLogSqlSnippets()
+                    }}
+                  >
+                    Clear history
+                  </Button>
+                </Table.th>
+              </>
+            }
+            body={recent.map((item: LogSqlSnippets.Content) => (
+                  <RecentQueriesItem key={item.sql} item={item} />
+                ))
+            }
+          />
+      )}
       {recent.length === 0 && (
         <>
           <div className="my-auto flex h-full flex-grow flex-col items-center justify-center gap-1">

--- a/studio/pages/project/[ref]/logs-explorer/saved.tsx
+++ b/studio/pages/project/[ref]/logs-explorer/saved.tsx
@@ -47,7 +47,7 @@ export const LogsSavedPage: NextPageWithLayout = () => {
           <p className="text-scale-900 text-sm">
             Saved queries will appear here. Queries can be saved from the{' '}
             <Link href={`/project/${ref}/logs-explorer`}>
-              <span className="cursor-pointer font-bold text-white underline">Query</span>
+              <span className="cursor-pointer font-bold underline">Query</span>
             </Link>{' '}
             tab.
           </p>


### PR DESCRIPTION
Fixes recent sql snippets ui to be as similar to saved log snippets. Also fixes query param linking.
<img width="1005" alt="Screenshot 2022-06-24 at 3 24 24 PM" src="https://user-images.githubusercontent.com/22714384/175485128-5cd0d6ac-094f-458e-bfa8-bcf63fabe066.png">


depends on on #7405  and #7408 
