### PR TITLE
Forces a change to allow a remerge into studio

### DIFF
--- a/studio/components/to-be-cleaned/Charts/ChartHandler.tsx
+++ b/studio/components/to-be-cleaned/Charts/ChartHandler.tsx
@@ -128,7 +128,7 @@ const ChartHandler: FC<Props> = ({
     ? chartData?.total
     : provider === 'log-stats'
     ? chartData?.totalGrouped?.[attribute]
-    : chartData?.data[chartData?.data.length -1]?.[attribute]
+    : chartData?.data[chartData?.data.length - 1]?.[attribute]
 
   if (loading) {
     return (


### PR DESCRIPTION
This was already fixed but there must have been a merge conflict when merged with studio and this was left out. This PR just forces a change to allow for another merge into studio.

On master, it's correct: 
https://github.com/supabase/supabase/blob/master/studio/components/to-be-cleaned/Charts/ChartHandler.tsx#L131

From this PR back in May: https://github.com/supabase/supabase/commit/c37ee44d4bdec0ad5d3fb7a03bbbc3cc3b303669


But on studio, it's still using the old value:
https://github.com/supabase/supabase/blob/studio/studio/components/to-be-cleaned/Charts/ChartHandler.tsx#L131

