### PR TITLE
Fix: confirm delete modal

### DIFF
--- a/studio/components/to-be-cleaned/Storage/StorageExplorer/ConfirmDeleteModal.js
+++ b/studio/components/to-be-cleaned/Storage/StorageExplorer/ConfirmDeleteModal.js
@@ -16,7 +16,7 @@ const ConfirmDeleteModal = ({
   const multipleFiles = selectedItemsToDelete.length > 1
 
   const title = multipleFiles
-    ? `Confirm deletion of items`
+    ? `Confirm deletion of ${selectedItemsToDelete.length} items`
     : selectedItemsToDelete.length === 1
     ? `Confirm deletion of ${selectedItemsToDelete[0].name}`
     : ``
@@ -35,7 +35,7 @@ const ConfirmDeleteModal = ({
   return (
     <Modal
       visible={visible}
-      header={title}
+      header={<span className="break-words">{title}</span>}
       size="small"
       onCancel={onSelectCancel}
       customFooter={


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix the text overflowing the modal.

## What is the current behavior?

<img width="585" alt="image" src="https://user-images.githubusercontent.com/70828596/175574683-c179e1cc-2dfb-4e98-a568-a9d4ab8c8677.png">

## What is the new behavior?

<img width="420" alt="image" src="https://user-images.githubusercontent.com/70828596/175574702-361b61ec-3eaa-450d-ba57-1fc839177d87.png">