### PR TITLE
Capitalize Supabase in the Developers menu

### DIFF
--- a/apps/www/data/Developers.json
+++ b/apps/www/data/Developers.json
@@ -13,13 +13,13 @@
   },
   {
     "text": "Guides",
-    "description": "Examples and references for using supabase.",
+    "description": "Examples and references for using Supabase.",
     "url": "/docs/guides/examples",
     "icon": "M19.428 15.428a2 2 0 00-1.022-.547l-2.387-.477a6 6 0 00-3.86.517l-.318.158a6 6 0 01-3.86.517L6.05 15.21a2 2 0 00-1.806.547M8 4h8l-1 1v5.172a2 2 0 00.586 1.414l5 5c1.26 1.26.367 3.414-1.415 3.414H4.828c-1.782 0-2.674-2.154-1.414-3.414l5-5A2 2 0 009 10.172V5L8 4z"
   },
   {
     "text": "Careers",
-    "description": "Join the supabase team and get involved.",
+    "description": "Join the Supabase team and get involved.",
     "url": "https://about.supabase.com/careers",
     "icon": "M21 13.255A23.931 23.931 0 0112 15c-3.183 0-6.22-.62-9-1.745M16 6V4a2 2 0 00-2-2h-4a2 2 0 00-2 2v2m4 6h.01M5 20h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
   }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Minor copy change to capitalize Supabase in the Developers menu

## What is the current behavior?

Inconsistent capitalization:
![image](https://user-images.githubusercontent.com/1454517/175792998-463e5cd5-c5bc-4b91-b4fc-10f6f4d79f5a.png)

## What is the new behavior?

Supabase capitalized:
![image](https://user-images.githubusercontent.com/1454517/175793010-3ddb8c20-fc7e-4fe9-bf09-e894c4c3b87f.png)

