### PR TITLE
Fixes issue with grid Monaco instances not setting bg colour properly

### DIFF
--- a/studio/components/grid/SupabaseGrid.tsx
+++ b/studio/components/grid/SupabaseGrid.tsx
@@ -28,21 +28,20 @@ export const SupabaseGrid = forwardRef<SupabaseGridRef, SupabaseGridProps>((prop
   useEffect(() => {
     if (monaco) {
       const darkTheme = theme && theme === 'dark' ? true : false
-
       monaco.editor.defineTheme('supabase', {
-        base: 'vs-dark', // can also be vs-dark or hc-black
+        base: darkTheme ? 'vs-dark' : 'vs',
         inherit: true, // can also be false to completely replace the builtin rules
         rules: [
           { token: 'string.sql', foreground: '24b47e' },
           { token: 'comment', foreground: '666666' },
-          { token: 'predefined.sql', foreground: 'D4D4D4' },
+          { token: 'predefined.sql', foreground: '999999' },
         ],
         colors: {
-          'editor.background': darkTheme ? '#1f1f1f' : '#30313f',
+          'editor.background': darkTheme ? '#222222' : '#fbfcfd',
         },
       })
     }
-  }, [monaco])
+  }, [monaco, theme])
 
   return (
     <StoreProvider>

--- a/studio/pages/project/[ref]/editor/[id].tsx
+++ b/studio/pages/project/[ref]/editor/[id].tsx
@@ -167,6 +167,7 @@ const TableEditorPage: NextPage = () => {
         onEditColumn={onEditColumn}
         onDeleteColumn={onDeleteColumn}
         onClosePanel={onClosePanel}
+        theme={ui.themeOption == 'dark' ? 'dark' : 'light'}
       />
       <ConfirmationModal
         danger


### PR DESCRIPTION
## What kind of change does this PR introduce?

#7201  fixed bg colour theming for input field, but text fields in the editor are actually Monaco editor instances. 

The user's theme setting wasn't being passed to the editor, and so dark mode vars were always being used.

**Text fields before:** 

<img width="690" alt="CleanShot 2022-06-26 at 12 42 41@2x" src="https://user-images.githubusercontent.com/105593/175821028-b98b1bdc-f425-44da-b6b9-099b47e78c9a.png">


**Text fields after:**
<img width="340" alt="CleanShot 2022-06-26 at 12 45 15@2x" src="https://user-images.githubusercontent.com/105593/175821048-bb86ea15-c9ac-48db-82a7-f29b30dbef58.png">

