### PR TITLE
Studio components refactoring and cleanup (Area Chart)

### DIFF
--- a/studio/.storybook/main.js
+++ b/studio/.storybook/main.js
@@ -1,9 +1,16 @@
+const path = require('path')
+
 module.exports = {
   stories: ['./*.stories.mdx', '../components/**/*.stories.@(js|jsx|ts|tsx)'],
   addons: [
     '@storybook/addon-links',
     '@storybook/addon-essentials',
     '@storybook/addon-interactions',
+    '@storybook/addon-actions',
     'storybook-dark-mode',
   ],
+  webpackFinal: async (config) => {
+    config.resolve.modules.push(path.resolve(__dirname, '..', './'))
+    return config
+  },
 }

--- a/studio/components/ui/Charts/AreaChart/AreaChart.stories.tsx
+++ b/studio/components/ui/Charts/AreaChart/AreaChart.stories.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
+import AreaChart from './AreaChart'
+
+export default {
+  title: 'Charts/AreaChart',
+  component: AreaChart,
+} as ComponentMeta<typeof AreaChart>
+
+const Template: ComponentStory<typeof AreaChart> = (args) => <AreaChart {...args} />
+
+const data = [290, 430, 649, 422, 321, 893, 111].map(value => ({ram_usage : value}))
+
+export const Default = Template.bind({})
+const defaultArgs = {
+  attribute: 'ram_usage',
+  label: 'Memory usage',
+  data,  
+}
+Default.args = {...defaultArgs}
+
+
+export const withYAxisLimit = Template.bind({})
+withYAxisLimit.args = {
+  ...defaultArgs,
+  yAxisLimit: 'dataMax + 1000',
+}
+
+export const withFormat = Template.bind({})
+withFormat.args = {
+  ...defaultArgs,
+  format: '%',
+}
+
+export const withHighlightedValue = Template.bind({})
+withHighlightedValue.args = {
+  ...defaultArgs,
+  highlightedValue: 430,
+}
+
+export const withCustomDateFormat = Template.bind({})
+withCustomDateFormat.args = {
+  ...defaultArgs,
+  customDateFormat: 'MMM D, YYYY',
+}

--- a/studio/components/ui/Charts/AreaChart/AreaChart.tsx
+++ b/studio/components/ui/Charts/AreaChart/AreaChart.tsx
@@ -1,0 +1,245 @@
+import { IconBarChart2, Loading } from '@supabase/ui'
+import { useState } from 'react'
+import {
+  AreaChart as RechartAreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts'
+
+import dayjs from 'dayjs'
+import { formatBytes } from 'lib/helpers'
+import { CHART_COLORS } from 'components/ui/Charts/Charts.constants'
+import { AreaChartProps, DataPoint, HeaderType } from './AreaChart.types'
+import { CategoricalChartState } from 'recharts/types/chart/generateCategoricalChart'
+
+function dataCheck(data: DataPoint[] | undefined, attribute: string) {
+  const hasData = data?.find(record => record[attribute])
+  return hasData ? true : false
+}
+
+const CustomTooltip = () => null
+
+const DATE_FORMAT__DATE_ONLY = 'MMM D, YYYY'
+const DATE_FORMAT__WITH_TIME = `${DATE_FORMAT__DATE_ONLY} hh:mma`
+
+const Header = ({
+  attribute,
+  focus,
+  format,
+  highlightedValue,
+  data,
+  customDateFormat,
+  label,
+  minimalHeader = false,
+  displayDateInUtc = false,
+}: HeaderType) => {
+  const FOCUS_FORMAT = customDateFormat
+    ? customDateFormat
+    : format == '%'
+    ? DATE_FORMAT__WITH_TIME
+    : DATE_FORMAT__DATE_ONLY
+
+  let title = ''
+
+  if (focus) {
+    if (format === '%') {
+      title = data ? Number(data[focus]?.[attribute]).toFixed(2)  : ''
+    } else if (['ingress', 'egress', 'bytes'].some(str =>  attribute.includes(str))) {
+      title = data ? formatBytes(data[focus]?.[attribute]) : ''
+    } else {
+      title = data ? data[focus]?.[attribute]?.toLocaleString() : ''
+    }
+  } else {
+    if ((format === '%') && highlightedValue) {
+      title = highlightedValue.toFixed(2)
+    } else if (attribute.includes('ingress') || attribute.includes('egress') || attribute.includes('bytes')) {
+      title = formatBytes(highlightedValue)
+    } else {
+      title = highlightedValue?.toLocaleString() as string
+    }
+  }
+
+  const day = (value: number | string) => (displayDateInUtc ? dayjs(value).utc() : dayjs(value))
+
+  const chartTitle = (
+    <h3 className={'text-scale-900 ' + (minimalHeader ? 'text-xs' : 'text-sm')}>
+      {label ?? attribute}
+    </h3>
+  )
+  const highlighted = (
+    <h5
+      className={
+        'text-scale-1200 text-xl font-normal ' + (minimalHeader ? 'text-base' : 'text-2xl')
+      }
+    >
+      {title}
+      <span className="text-lg">{format}</span>
+    </h5>
+  )
+  const date = (
+    <h5 className="text-scale-900 text-xs">
+      {focus ? (
+        data?.[focus] && day(data[focus].period_start).format(FOCUS_FORMAT)
+      ) : (
+        <span className="opacity-0">x</span>
+      )}
+    </h5>
+  )
+
+  if (minimalHeader) {
+    return (
+      <div className="flex flex-row items-center gap-x-4" style={{ minHeight: '1.8rem' }}>
+        {chartTitle}
+        <div className="flex flex-row items-baseline gap-x-2">
+          {highlighted}
+          {date}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <>
+      {chartTitle}
+      {highlighted}
+      {date}
+    </>
+  )
+}
+
+const NoData = ({ title = 'No data to show', message = 'May take 24 hours for data to show' }) => (
+  <div
+    className="
+      border-scale-600 flex
+      h-full w-full flex-col
+      items-center justify-center space-y-2 border
+      border-dashed text-center
+    "
+  >
+    <IconBarChart2 className="text-scale-800" />
+    <div>
+      <p className="text-scale-1100 text-xs">{title}</p>
+      <p className="text-scale-900 text-xs">{message}</p>
+    </div>
+  </div>
+)
+
+export default function AreaChart({
+  data,
+  attribute,
+  yAxisLimit,
+  format,
+  highlightedValue,
+  customDateFormat,
+  label,
+}: AreaChartProps) {
+  const hasData = dataCheck(data, attribute)
+
+  const [focusBar, setFocusBar] = useState<any>(null)
+  const [mouseLeave, setMouseLeave] = useState(true)
+
+  const onMouseMove = (state: CategoricalChartState) => {
+    const {activeTooltipIndex} = state
+    setFocusBar(activeTooltipIndex || null)
+    setMouseLeave(activeTooltipIndex ? false : true)
+  }
+
+  const onMouseLeave = () => {
+    setFocusBar(false)
+    setMouseLeave(true)
+  }
+
+  // For future reference: https://github.com/supabase/supabase/pull/5311#discussion_r800852828
+  const chartHeight = 160
+
+  return (
+    <Loading active={!data}>
+      <Header
+        label={label}
+        attribute={attribute}
+        focus={focusBar}
+        highlightedValue={highlightedValue}
+        data={data}
+        format={format}
+        customDateFormat={customDateFormat}
+      />
+      <div
+        style={{
+          width: '100%',
+          height: `${chartHeight}px`,
+        }}
+      >
+        {hasData ? (
+          <>
+            <ResponsiveContainer width="100%" height={chartHeight}>
+              <RechartAreaChart
+                data={data}
+                margin={{
+                  top: 0,
+                  right: 0,
+                  left: 0,
+                  bottom: 0,
+                }}
+                className="overflow-visible"
+                onMouseMove={onMouseMove}
+                onMouseLeave={onMouseLeave}
+              >
+                <defs>
+                  <linearGradient id="colorUv" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="5%" stopColor={CHART_COLORS.GREEN_1} stopOpacity={0.8} />
+                    <stop offset="95%" stopColor={CHART_COLORS.GREEN_1} stopOpacity={0} />
+                  </linearGradient>
+                </defs>
+                <XAxis
+                  dataKey="period_start"
+                  //interval={size === 'small' ? 5 : 1}
+                  interval={data ? data.length - 2 : 0}
+                  angle={0}
+                  // stroke="#4B5563"
+                  tick={{
+                    fontSize: '0px',
+                    color: CHART_COLORS.TICK,
+                  }}
+                  axisLine={{
+                    stroke: CHART_COLORS.AXIS,
+                  }}
+                  tickLine={{
+                    stroke: CHART_COLORS.AXIS,
+                  }}
+                />
+                {yAxisLimit && <YAxis type="number" domain={[0, yAxisLimit]} hide />}
+                <Tooltip content={<CustomTooltip />} />
+                <Area
+                  type="monotone"
+                  dataKey={attribute}
+                  stroke={CHART_COLORS.GREEN_1}
+                  fillOpacity={1}
+                  fill="url(#colorUv)"
+                />
+              </RechartAreaChart>
+            </ResponsiveContainer>
+            {data && (
+              <div className="text-scale-900 -mt-5 flex items-center justify-between text-xs">
+                <span>
+                  {dayjs(data[0].period_start).format(
+                    customDateFormat ? customDateFormat : DATE_FORMAT__WITH_TIME
+                  )}
+                </span>
+                <span>
+                  {dayjs(data[data?.length - 1]?.period_start).format(
+                    customDateFormat ? customDateFormat : DATE_FORMAT__WITH_TIME
+                  )}
+                </span>
+              </div>
+            )}
+          </>
+        ) : (
+          <NoData />
+        )}
+      </div>
+    </Loading>
+  )
+}

--- a/studio/components/ui/Charts/AreaChart/AreaChart.types.ts
+++ b/studio/components/ui/Charts/AreaChart/AreaChart.types.ts
@@ -1,0 +1,26 @@
+export type  AreaChartProps = {
+  data?: DataPoint[],
+  attribute: string,
+  yAxisLimit: number | string | undefined,
+  format?: string,
+  highlightedValue?: number,
+  customDateFormat?: string,
+  label: string,
+}
+
+export type HeaderType = {
+  attribute: string,
+  focus: number | null,
+  format?: string,
+  highlightedValue?: number,
+  data?: DataPoint[],
+  customDateFormat?: string,
+  label: string,
+  minimalHeader?: boolean,
+  displayDateInUtc?: boolean,
+}
+
+
+export type DataPoint = {
+  [attribute: string]: number
+}

--- a/studio/components/ui/Charts/BarChart/BarChart.stories.tsx
+++ b/studio/components/ui/Charts/BarChart/BarChart.stories.tsx
@@ -1,0 +1,159 @@
+import React from 'react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
+import { action } from '@storybook/addon-actions';
+import { BarChart } from './BarChart'
+
+export default {
+  title: 'Charts/BarChart',
+  component: BarChart,
+} as ComponentMeta<typeof BarChart>
+
+const Template: ComponentStory<typeof BarChart> = (args) => <BarChart {...args} />
+
+
+const data = [{
+    "ram_usage": 290,
+  },{
+    "ram_usage": 430,
+  },{
+    "ram_usage": 620,
+  },{
+    "ram_usage": 20,
+  },{
+    "ram_usage": 40,
+  },{
+    "ram_usage": 630,
+  },{
+    "ram_usage": 200,
+  },{
+    "ram_usage": 140,
+  },{
+    "ram_usage": 360,
+  },{
+    "ram_usage": 240,
+  },{
+    "ram_usage": 400,
+  },{
+    "ram_usage": 60,
+  },{
+    "ram_usage": 20,
+  },{
+    "ram_usage": 40,
+  },{
+    "ram_usage": 60,
+  },{
+    "ram_usage": 20,
+  },{
+    "ram_usage": 40,
+  },{
+    "ram_usage": 60,
+  },{
+    "ram_usage": 20,
+  },{
+    "ram_usage": 40,
+  },{
+    "ram_usage": 60,
+  },]
+
+export const Default = Template.bind({})
+Default.args = {
+  attribute: 'ram_usage',
+  label: 'Memory usage',
+  onBarClick: action('clicked'),
+  className: 'ram-bar-chart',
+  data : data,
+}
+
+export const withYAxisLimit = Template.bind({})
+withYAxisLimit.args = {
+  attribute: 'ram_usage',
+  yAxisLimit: 'dataMax + 1000',
+  label: 'Memory usage',
+  onBarClick: action('clicked'),
+  className: 'ram-bar-chart',
+  data : data,
+}
+
+export const withFormat = Template.bind({})
+withFormat.args = {
+  attribute: 'ram_usage',
+  format: '%',
+  label: 'Memory usage',
+  onBarClick: action('clicked'),
+  className: 'ram-bar-chart',
+  data : data
+}
+
+export const withHighlightedValue = Template.bind({})
+withHighlightedValue.args = {
+  attribute: 'ram_usage',
+  highlightedValue:  430,
+  label: 'Memory usage',
+  onBarClick: action('clicked'),
+  className: 'ram-bar-chart',
+  data : data
+}
+
+export const withCustomDateFormat = Template.bind({})
+withCustomDateFormat.args = {
+  attribute: 'ram_usage',
+  customDateFormat: 'MMM D, YYYY',
+  label: 'Memory usage',
+  onBarClick: action('clicked'),
+  className: 'ram-bar-chart',
+  data : data
+}
+
+export const withDisplayDateInUtc = Template.bind({})
+withDisplayDateInUtc.args = {
+  attribute: 'ram_usage',
+  displayDateInUtc: true,
+  label: 'Memory usage',
+  onBarClick: action('clicked'),
+  className: 'ram-bar-chart',
+  data : data
+}
+
+export const withMinimalHeader = Template.bind({})
+withMinimalHeader.args = {
+  attribute: 'ram_usage',
+  label: 'Memory usage',
+  onBarClick: action('clicked'),
+  minimalHeader: true,
+  className: 'ram-bar-chart',
+  data : data
+}
+
+export const withChartSizeSmall = Template.bind({})
+withChartSizeSmall.args = {
+  attribute: 'ram_usage',
+  displayDateInUtc: true,
+  label: 'Memory usage',
+  onBarClick: action('clicked'),
+  chartSize: 'small',
+  className: 'ram-bar-chart',
+  data : data
+}
+
+export const withChartSizeTiny = Template.bind({})
+withChartSizeTiny.args = {
+  attribute: 'ram_usage',
+  displayDateInUtc: true,
+  label: 'Memory usage',
+  onBarClick: action('clicked'),
+  chartSize: 'tiny',
+  className: 'ram-bar-chart',
+  data : data
+}
+
+export const withNoData = Template.bind({})
+withNoData.args = {
+  attribute: 'ram_usage',
+  displayDateInUtc: true,
+  label: 'Memory usage',
+  onBarClick: action('clicked'),
+  className: 'ram-bar-chart',
+  noDataTitle: 'No data Found',
+  noDataMessage: "This is strange, we're looking into it",
+  data : []
+}

--- a/studio/components/ui/Charts/BarChart/BarChart.tsx
+++ b/studio/components/ui/Charts/BarChart/BarChart.tsx
@@ -1,0 +1,291 @@
+import { IconBarChart2, Loading } from '@supabase/ui'
+import { useState } from 'react'
+import {
+  BarChart as RechartBarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Cell,
+  ResponsiveContainer,
+} from 'recharts'
+
+import dayjs from 'dayjs'
+import { formatBytes } from 'lib/helpers'
+import utc from 'dayjs/plugin/utc'
+import { CHART_COLORS } from '../Charts.constants'
+import { BarChartProps } from './BarChart.types'
+import { CategoricalChartState } from 'recharts/types/chart/generateCategoricalChart'
+
+function dataCheck(data: any, attribute: any) {
+  const hasData = data && data.find((record: any) => record[attribute])
+  return hasData ? true : false
+}
+
+const CustomTooltip = () => {
+  return null
+}
+
+const DATE_FORMAT__WITH_TIME = 'MMM D, YYYY, hh:mma'
+const DATE_FORMAT__DATE_ONLY = 'MMM D, YYYY'
+
+const Header = ({
+  attribute,
+  focus,
+  format,
+  highlightedValue,
+  data,
+  customDateFormat,
+  label,
+  minimalHeader = false,
+  displayDateInUtc = false,
+}: any) => {
+  let FOCUS_FORMAT = customDateFormat
+    ? customDateFormat
+    : format == '%'
+    ? DATE_FORMAT__WITH_TIME
+    : DATE_FORMAT__DATE_ONLY
+
+  let title = ''
+
+  if (focus) {
+    if (!data) {
+      title = ''
+    } else if (format === '%') {
+      title = Number(data[focus]?.[attribute]).toFixed(2)
+    } else {
+      if (
+        attribute.includes('ingress') ||
+        attribute.includes('egress') ||
+        attribute.includes('bytes')
+      ) {
+        title = formatBytes(data[focus]?.[attribute])
+      } else {
+        title = data[focus]?.[attribute]?.toLocaleString()
+      }
+    }
+  } else {
+    if (format === '%' && highlightedValue) {
+      title = highlightedValue.toFixed(2)
+    } else {
+      if (
+        attribute.includes('ingress') ||
+        attribute.includes('egress') ||
+        attribute.includes('bytes')
+      ) {
+        title = formatBytes(highlightedValue)
+      } else {
+        title = highlightedValue?.toLocaleString()
+      }
+    }
+  }
+  const day = (value: number | string) => (displayDateInUtc ? dayjs(value).utc() : dayjs(value))
+
+  const chartTitle = (
+    <h3 className={'text-scale-900 ' + (minimalHeader ? 'text-xs' : 'text-sm')}>
+      {label ?? attribute}
+    </h3>
+  )
+  const highlighted = (
+    <h5
+      className={
+        'text-scale-1200 text-xl font-normal ' + (minimalHeader ? 'text-base' : 'text-2xl')
+      }
+    >
+      {title}
+      <span className="text-lg">{format}</span>
+    </h5>
+  )
+  const date = (
+    <h5 className="text-scale-900 text-xs">
+      {focus ? (
+        data && data[focus] && day(data[focus].period_start).format(FOCUS_FORMAT)
+      ) : (
+        <span className="opacity-0">x</span>
+      )}
+    </h5>
+  )
+
+  if (minimalHeader) {
+    return (
+      <div className="flex flex-row items-center gap-x-4" style={{ minHeight: '1.8rem' }}>
+        {chartTitle}
+        <div className="flex flex-row items-baseline gap-x-2">
+          {highlighted}
+          {date}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <>
+      {chartTitle}
+      {highlighted}
+      {date}
+    </>
+  )
+}
+
+const NoData = ({ title = 'No data to show', message = 'May take 24 hours for data to show' }) => (
+  <div
+    className="
+      border-scale-600 flex
+      h-full w-full flex-col
+      items-center justify-center space-y-2 border
+      border-dashed text-center
+    "
+  >
+    <IconBarChart2 className="text-scale-800" />
+    <div>
+      <p className="text-scale-1100 text-xs">{title}</p>
+      <p className="text-scale-900 text-xs">{message}</p>
+    </div>
+  </div>
+)
+
+function numberWithCommas(x: any) {
+  return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')
+}
+
+export function BarChart({
+    data,
+    attribute, 
+    displayDateInUtc = false,
+    chartSize = 'normal', 
+    className = '',  
+    minimalHeader,
+    highlightedValue,
+    format,
+    label,
+    customDateFormat,
+    onBarClick,
+    noDataTitle,
+    yAxisLimit,
+    noDataMessage,
+  }: BarChartProps) {
+  const hasData = data ? dataCheck(data, attribute) : true
+
+  const [focusBar, setFocusBar] = useState<any>(null)
+  const [mouseLeave, setMouseLeave] = useState<any>(true)
+
+  const onMouseMove = (state: any) => {
+    if (state?.activeTooltipIndex) {
+      setFocusBar(state.activeTooltipIndex)
+      setMouseLeave(false)
+    } else {
+      setFocusBar(null)
+      setMouseLeave(true)
+    }
+  }
+
+  const onMouseLeave = () => {
+    setFocusBar(false)
+    setMouseLeave(true)
+  }
+
+  dayjs.extend(utc);
+  const day = (value: number | string) => (displayDateInUtc ? dayjs(value).utc() : dayjs(value))
+
+  // For future reference: https://github.com/supabase/supabase/pull/5311#discussion_r800852828
+  const chartHeight = {
+    tiny: 76,
+    small: 96,
+    normal: 160,
+  }[chartSize as string] as number
+
+  return (
+    <Loading active={!data}>
+      <div className={className}>
+        <Header
+          minimalHeader={minimalHeader}
+          attribute={attribute}
+          focus={focusBar}
+          highlightedValue={highlightedValue}
+          data={data}
+          label={label}
+          format={format}
+          customDateFormat={customDateFormat}
+          displayDateInUtc={displayDateInUtc}
+        />
+        <div style={{ width: '100%', height: `${chartHeight}px` }}>
+          {hasData ? (
+            <>
+              <ResponsiveContainer width="100%" height={chartHeight}>
+                <RechartBarChart
+                  data={data}
+                  margin={{
+                    top: 0,
+                    right: 0,
+                    left: 0,
+                    bottom: 0,
+                  }}
+                  className="cursor-pointer overflow-visible"
+                  onMouseMove={onMouseMove}
+                  onMouseLeave={onMouseLeave}
+                  onClick={(tooltipData: CategoricalChartState) => {
+                    // receives tooltip data https://github.com/recharts/recharts/blob/2a3405ff64a0c050d2cf94c36f0beef738d9e9c2/src/chart/generateCategoricalChart.tsx
+                    if (onBarClick) onBarClick(tooltipData)
+                  }}
+                >
+                  <XAxis
+                    dataKey="period_start"
+                    //interval={size === 'small' ? 5 : 1}
+                    interval={data ? data.length - 2 : 0}
+                    angle={0}
+                    // stroke="#4B5563"
+                    tick={{ fontSize: '0px', color: CHART_COLORS.TICK }}
+                    axisLine={{ stroke: CHART_COLORS.AXIS }}
+                    tickLine={{ stroke: CHART_COLORS.AXIS }}
+                  />
+                  <Tooltip content={<CustomTooltip />} />
+                  {/* <YAxis dataKey={attribute} /> */}
+                  {/* <YAxis type="number" domain={[(0, 100)]} /> */}
+                  {yAxisLimit && <YAxis type="number" domain={[0, yAxisLimit]} hide />}
+                  <Bar
+                    dataKey={attribute}
+                    fill={CHART_COLORS.GREEN_1}
+                    // barSize={2}
+                    animationDuration={300}
+                  >
+                    {data?.map((entry: any, index: any) => (
+                      <Cell
+                        key={`cell-${index}`}
+                        className={`transition-all duration-300 ${
+                          onBarClick ? 'cursor-pointer' : ''
+                        }`}
+                        fill={
+                          focusBar === index || mouseLeave
+                            ? CHART_COLORS.GREEN_1
+                            : CHART_COLORS.GREEN_2
+                        }
+                        enableBackground={12}
+                        // for this, we make the hovered colour #2B5CE7, else its opacity decreases to 20%
+                      />
+                    ))}
+                  </Bar>
+                </RechartBarChart>
+              </ResponsiveContainer>
+              {data && (
+                <div className="text-scale-900 -mt-5 flex items-center justify-between text-xs">
+                  <span>
+                    {day(data[0].period_start).format(
+                      customDateFormat ? customDateFormat : DATE_FORMAT__WITH_TIME
+                    )}
+                  </span>
+                  <span>
+                    {day(data[data?.length - 1]?.period_start).format(
+                      customDateFormat ? customDateFormat : DATE_FORMAT__WITH_TIME
+                    )}
+                  </span>
+                </div>
+              )}
+            </>
+          ) : (
+            <NoData title={noDataTitle} message={noDataMessage} />
+          )}
+        </div>
+      </div>
+    </Loading>
+  )
+}

--- a/studio/components/ui/Charts/BarChart/BarChart.types.ts
+++ b/studio/components/ui/Charts/BarChart/BarChart.types.ts
@@ -1,0 +1,31 @@
+import { CategoricalChartState } from "recharts/types/chart/generateCategoricalChart"
+
+export type  BarChartProps = {
+  data?: DataPoint[],
+  attribute: string,
+  yAxisLimit: number | string | undefined,
+  format?: string,
+  highlightedValue?: string | number,
+  customDateFormat?: string,
+  displayDateInUtc: boolean ,
+  label: string,
+  onBarClick?: (v: CategoricalChartState) => void,
+  minimalHeader?: boolean,
+  chartSize?: string,
+  className?: string,
+  noDataTitle?: string,
+  noDataMessage?: string,
+}
+
+type DataPoint = Timestamp | Attribute
+
+interface Timestamp {
+  // ISO formatted
+  period_start: string
+  // unix timestamp (ms)
+  timestamp: number
+}
+
+interface Attribute {
+  [attribute: string]: number
+}

--- a/studio/package.json
+++ b/studio/package.json
@@ -79,7 +79,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.17.5",
-    "@storybook/addon-actions": "^6.4.19",
+    "@storybook/addon-actions": "^6.5.9",
     "@storybook/addon-essentials": "^6.4.19",
     "@storybook/addon-interactions": "^6.4.19",
     "@storybook/addon-links": "^6.4.19",

--- a/studio/postcss.config.js
+++ b/studio/postcss.config.js
@@ -1,6 +1,8 @@
 module.exports = {
   plugins: {
-    tailwindcss: {},
+    tailwindcss: {
+      config: './tailwind.config.js',
+    },
     autoprefixer: {},
   },
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature: These changes move the Area Chart to its own component, adds stories and ensures that it has proper types.

## What is the current behavior?
Partially fixes #6249 
[issue link](https://github.com/GitStartHQ/client-supabase/issues/47)
Currently we've got the Area Chart in the `components/to-be-cleaned/Charts/ChartRenderer` file, without proper types and stories.

## What is the new behavior?

The Area Chart has been moved to `components/ui/charts/LineChart`, with proper types added and stories showing its use with varying props.

<img width="1672" alt="Screenshot 2022-06-22 at 08 40 37" src="https://user-images.githubusercontent.com/5907294/174972316-1ca54a89-8f97-4e40-a05a-cc0a5ca297fa.png">

## Additional context

There isn't a component called LineChart in the ChartRenderer. I'm assuming that the component that needs to be refactored is the AreaChart, since its the only other component alongside the the BarChart in the ChartRenderer.
