### PR TITLE
Load types in the database tables editor

### DIFF
--- a/studio/pages/project/[ref]/database/tables.tsx
+++ b/studio/pages/project/[ref]/database/tables.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { observer } from 'mobx-react-lite'
 import { isUndefined } from 'lodash'
 import { PostgresColumn, PostgresTable } from '@supabase/postgres-meta'
@@ -23,6 +23,12 @@ const DatabaseTables: NextPageWithLayout = () => {
 
   const [selectedColumnToDelete, setSelectedColumnToDelete] = useState<PostgresColumn>()
   const [selectedTableToDelete, setSelectedTableToDelete] = useState<PostgresTable>()
+
+  useEffect(() => {
+    if (ui.selectedProject) {
+      meta.types.load()
+    }
+  }, [ui.selectedProject])
 
   const onAddTable = () => {
     setSidePanelKey('table')


### PR DESCRIPTION
## What kind of change does this PR introduce?
There's 2 places to create a new table: 

**project/eivrwpgafgqclvfbhqoe/editor**

and 

**project/eivrwpgafgqclvfbhqoe/database/tables**

The first loads `meta.types` ie: user-defined types, the second doesn't. 
**user-defined types:** 
<img width="395" alt="CleanShot 2022-06-27 at 11 29 06@2x" src="https://user-images.githubusercontent.com/105593/175959396-67ba93d4-86f4-49e0-bbe1-6e97ed76c5de.png">

**No user-defined types:**
<img width="498" alt="CleanShot 2022-06-27 at 11 29 35@2x" src="https://user-images.githubusercontent.com/105593/175959535-6755e787-3521-48e7-8f4d-8468ee74f528.png">



I've added a .load() there to mimic how it works in TableEditorLayout
https://github.com/supabase/supabase/blob/master/studio/components/layouts/TableEditorLayout/TableEditorLayout.tsx#L39


