### PR TITLE
Update next.config.js

### DIFF
--- a/apps/www/next.config.js
+++ b/apps/www/next.config.js
@@ -49,6 +49,12 @@ module.exports = withMDX({
         destination: `${process.env.NEXT_PUBLIC_DOCS_URL}`,
       },
       {
+        // redirect /docs/
+        // trailing slash caused by docusaurus issue with multizone
+        source: '/docs/',
+        destination: `${process.env.NEXT_PUBLIC_DOCS_URL}`,
+      },
+      {
         source: '/docs/:path*',
         destination: `${process.env.NEXT_PUBLIC_DOCS_URL}/:path*`,
       },


### PR DESCRIPTION
Updates redirect rewrites to redirect `/docs/` (trailing slash) to `/docs`

An issue caused by docusaurus working with vercel multizone, as root pages always add a trailing slash.