### PR TITLE
chore: increase the darkness of callouts left edge in docs

### DIFF
--- a/web/src/css/custom.css
+++ b/web/src/css/custom.css
@@ -216,7 +216,7 @@
   --ifm-color-gray-800: rgba(224, 235, 247, 0.5);
   --ifm-color-gray-900: rgba(224, 235, 247, 0.45);
   --ifm-color-secondary-darker: #000;
-  --ifm-color-secondary-dark: #1a1a1a;
+  --ifm-color-secondary-dark: #888888;
   --ifm-color-secondary: #2a2a2a;
   --ifm-color-secondary-light: #2f2f2f;
   --ifm-color-secondary-lighter: #313131;

--- a/web/src/css/custom.css
+++ b/web/src/css/custom.css
@@ -216,7 +216,7 @@
   --ifm-color-gray-800: rgba(224, 235, 247, 0.5);
   --ifm-color-gray-900: rgba(224, 235, 247, 0.45);
   --ifm-color-secondary-darker: #000;
-  --ifm-color-secondary-dark: #1f1f1f;
+  --ifm-color-secondary-dark: #1a1a1a;
   --ifm-color-secondary: #2a2a2a;
   --ifm-color-secondary-light: #2f2f2f;
   --ifm-color-secondary-lighter: #313131;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix and reference issue for this pull request: https://github.com/supabase/supabase/issues/7480

## What is the current behavior?

Dark mode:
<img width="960" alt="before-dark" src="https://user-images.githubusercontent.com/63534555/176747384-7577cbb6-e8a7-4344-a679-b1d91bba4a92.png">

The left edge of the call-outs in the docs aren't looking great in dark mode.

## What is the new behavior?

The darkness of the left edge has been improved by making it a bit darker than before, if the dark mode is enabled.

Dark mode:
<img width="966" alt="Screenshot 2022-06-30 at 11 28 05 PM" src="https://user-images.githubusercontent.com/63534555/176747036-f1fe5e0b-9836-4cba-81d8-72b21427e34b.png">
