### PR TITLE
Fix database replications page tables not toggling realtime properly

### DIFF
--- a/studio/components/interfaces/Database/Extensions/Extensions.tsx
+++ b/studio/components/interfaces/Database/Extensions/Extensions.tsx
@@ -6,6 +6,7 @@ import { Input, IconSearch, Typography } from '@supabase/ui'
 import { useStore } from 'hooks'
 import ExtensionCard from './ExtensionCard'
 import { HIDDEN_EXTENSIONS } from './Extensions.constants'
+import NoSearchResults from 'components/to-be-cleaned/NoSearchResults'
 
 interface Props {}
 
@@ -17,8 +18,9 @@ const Extensions: FC<Props> = ({}) => {
     filterString.length === 0
       ? meta.extensions.list()
       : meta.extensions.list((ext: any) => ext.name.includes(filterString))
-  const extensionsWithoutHidden = extensions
-    .filter((ext: any) => !HIDDEN_EXTENSIONS.includes(ext.name))
+  const extensionsWithoutHidden = extensions.filter(
+    (ext: any) => !HIDDEN_EXTENSIONS.includes(ext.name)
+  )
   const [enabledExtensions, disabledExtensions] = partition(
     extensionsWithoutHidden,
     (ext: any) => !isNull(ext.installed_version)
@@ -38,11 +40,13 @@ const Extensions: FC<Props> = ({}) => {
         </div>
       </div>
 
-      <div className="w-full my-8 space-y-12">
+      {extensions.length === 0 && <NoSearchResults />}
+
+      <div className="my-8 w-full space-y-12">
         {enabledExtensions.length > 0 && (
           <div className="space-y-4">
             <h4 className="text-lg">Enabled</h4>
-            <div className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3 mb-4">
+            <div className="mb-4 grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3">
               {enabledExtensions.map((extension) => (
                 <ExtensionCard key={extension.name} extension={extension} />
               ))}
@@ -53,7 +57,7 @@ const Extensions: FC<Props> = ({}) => {
         {disabledExtensions.length > 0 && (
           <div className="space-y-4">
             <h4 className="text-lg">Extensions</h4>
-            <div className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3 mb-4">
+            <div className="mb-4 grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3">
               {disabledExtensions.map((extension) => (
                 <ExtensionCard key={extension.name} extension={extension} />
               ))}

--- a/studio/components/interfaces/Database/Publications/PublicationsList.tsx
+++ b/studio/components/interfaces/Database/Publications/PublicationsList.tsx
@@ -7,7 +7,7 @@ import { confirmAlert } from 'components/to-be-cleaned/ModalsDeprecated/ConfirmM
 import Table from 'components/to-be-cleaned/Table'
 
 interface Props {
-  onSelectPublication: (publication: any) => void
+  onSelectPublication: (id: number) => void
 }
 
 const PublicationsList: FC<Props> = ({ onSelectPublication = () => {} }) => {
@@ -48,7 +48,7 @@ const PublicationsList: FC<Props> = ({ onSelectPublication = () => {} }) => {
   return (
     <>
       <div className="mb-4">
-        <div className="flex justify-between items-center">
+        <div className="flex items-center justify-between">
           <div className="flex items-center">
             <div>
               <Input
@@ -63,7 +63,7 @@ const PublicationsList: FC<Props> = ({ onSelectPublication = () => {} }) => {
           <div className=""></div>
         </div>
       </div>
-      <div className="rounded overflow-hidden">
+      <div className="overflow-hidden rounded">
         <Table
           head={[
             <Table.th key="header.name">Name</Table.th>,
@@ -131,11 +131,11 @@ const PublicationsList: FC<Props> = ({ onSelectPublication = () => {} }) => {
                 </div>
               </Table.td>
               <Table.td className="px-4 py-3 pr-2">
-                <div className="flex gap-2 justify-end">
+                <div className="flex justify-end gap-2">
                   <Button
                     type="default"
                     style={{ paddingTop: 3, paddingBottom: 3 }}
-                    onClick={() => onSelectPublication(x)}
+                    onClick={() => onSelectPublication(x.id)}
                   >
                     {x.tables == null
                       ? 'All tables'

--- a/studio/components/interfaces/Database/Publications/PublicationsList.tsx
+++ b/studio/components/interfaces/Database/Publications/PublicationsList.tsx
@@ -5,6 +5,7 @@ import { Button, Input, Toggle, IconSearch } from '@supabase/ui'
 import { useStore } from 'hooks'
 import { confirmAlert } from 'components/to-be-cleaned/ModalsDeprecated/ConfirmModal'
 import Table from 'components/to-be-cleaned/Table'
+import NoSearchResults from 'components/to-be-cleaned/NoSearchResults'
 
 interface Props {
   onSelectPublication: (id: number) => void
@@ -63,92 +64,96 @@ const PublicationsList: FC<Props> = ({ onSelectPublication = () => {} }) => {
           <div className=""></div>
         </div>
       </div>
-      <div className="overflow-hidden rounded">
-        <Table
-          head={[
-            <Table.th key="header.name">Name</Table.th>,
-            <Table.th key="header.id" className="hidden lg:table-cell">
-              System ID
-            </Table.th>,
-            <Table.th key="header.insert" className="text-center">
-              Insert
-            </Table.th>,
-            <Table.th key="header.update" className="text-center">
-              Update
-            </Table.th>,
-            <Table.th key="header.delete" className="text-center">
-              Delete
-            </Table.th>,
-            <Table.th key="header.truncate" className="text-center">
-              Truncate
-            </Table.th>,
-            <Table.th key="header.source" className="text-right">
-              Source
-            </Table.th>,
-          ]}
-          body={publications.map((x: any, i: number) => (
-            <Table.tr className="border-t " key={x.name}>
-              <Table.td className="px-4 py-3" style={{ width: '25%' }}>
-                {x.name}
-              </Table.td>
-              <Table.td className="hidden lg:table-cell" style={{ width: '25%' }}>
-                {x.id}
-              </Table.td>
-              <Table.td>
-                <div className="flex justify-center">
-                  <Toggle
-                    size="tiny"
-                    checked={x.publish_insert}
-                    onChange={() => toggleListenEvent(x, 'insert', x.publish_insert)}
-                  />
-                </div>
-              </Table.td>
-              <Table.td>
-                <div className="flex justify-center">
-                  <Toggle
-                    size="tiny"
-                    checked={x.publish_update}
-                    onChange={() => toggleListenEvent(x, 'update', x.publish_update)}
-                  />
-                </div>
-              </Table.td>
-              <Table.td>
-                <div className="flex justify-center">
-                  <Toggle
-                    size="tiny"
-                    checked={x.publish_delete}
-                    onChange={() => toggleListenEvent(x, 'delete', x.publish_delete)}
-                  />
-                </div>
-              </Table.td>
-              <Table.td>
-                <div className="flex justify-center">
-                  <Toggle
-                    size="tiny"
-                    checked={x.publish_truncate}
-                    onChange={() => toggleListenEvent(x, 'truncate', x.publish_truncate)}
-                  />
-                </div>
-              </Table.td>
-              <Table.td className="px-4 py-3 pr-2">
-                <div className="flex justify-end gap-2">
-                  <Button
-                    type="default"
-                    style={{ paddingTop: 3, paddingBottom: 3 }}
-                    onClick={() => onSelectPublication(x.id)}
-                  >
-                    {x.tables == null
-                      ? 'All tables'
-                      : `${x.tables.length} ${
-                          x.tables.length > 1 || x.tables.length == 0 ? 'tables' : 'table'
-                        }`}
-                  </Button>
-                </div>
-              </Table.td>
-            </Table.tr>
-          ))}
-        />
-      </div>
+      {publications.length === 0 ? (
+        <NoSearchResults />
+      ) : (
+        <div className="overflow-hidden rounded">
+          <Table
+            head={[
+              <Table.th key="header.name">Name</Table.th>,
+              <Table.th key="header.id" className="hidden lg:table-cell">
+                System ID
+              </Table.th>,
+              <Table.th key="header.insert" className="text-center">
+                Insert
+              </Table.th>,
+              <Table.th key="header.update" className="text-center">
+                Update
+              </Table.th>,
+              <Table.th key="header.delete" className="text-center">
+                Delete
+              </Table.th>,
+              <Table.th key="header.truncate" className="text-center">
+                Truncate
+              </Table.th>,
+              <Table.th key="header.source" className="text-right">
+                Source
+              </Table.th>,
+            ]}
+            body={publications.map((x: any, i: number) => (
+              <Table.tr className="border-t " key={x.name}>
+                <Table.td className="px-4 py-3" style={{ width: '25%' }}>
+                  {x.name}
+                </Table.td>
+                <Table.td className="hidden lg:table-cell" style={{ width: '25%' }}>
+                  {x.id}
+                </Table.td>
+                <Table.td>
+                  <div className="flex justify-center">
+                    <Toggle
+                      size="tiny"
+                      checked={x.publish_insert}
+                      onChange={() => toggleListenEvent(x, 'insert', x.publish_insert)}
+                    />
+                  </div>
+                </Table.td>
+                <Table.td>
+                  <div className="flex justify-center">
+                    <Toggle
+                      size="tiny"
+                      checked={x.publish_update}
+                      onChange={() => toggleListenEvent(x, 'update', x.publish_update)}
+                    />
+                  </div>
+                </Table.td>
+                <Table.td>
+                  <div className="flex justify-center">
+                    <Toggle
+                      size="tiny"
+                      checked={x.publish_delete}
+                      onChange={() => toggleListenEvent(x, 'delete', x.publish_delete)}
+                    />
+                  </div>
+                </Table.td>
+                <Table.td>
+                  <div className="flex justify-center">
+                    <Toggle
+                      size="tiny"
+                      checked={x.publish_truncate}
+                      onChange={() => toggleListenEvent(x, 'truncate', x.publish_truncate)}
+                    />
+                  </div>
+                </Table.td>
+                <Table.td className="px-4 py-3 pr-2">
+                  <div className="flex justify-end gap-2">
+                    <Button
+                      type="default"
+                      style={{ paddingTop: 3, paddingBottom: 3 }}
+                      onClick={() => onSelectPublication(x.id)}
+                    >
+                      {x.tables == null
+                        ? 'All tables'
+                        : `${x.tables.length} ${
+                            x.tables.length > 1 || x.tables.length == 0 ? 'tables' : 'table'
+                          }`}
+                    </Button>
+                  </div>
+                </Table.td>
+              </Table.tr>
+            ))}
+          />
+        </div>
+      )}
     </>
   )
 }

--- a/studio/components/interfaces/Database/Publications/PublicationsTableItem.tsx
+++ b/studio/components/interfaces/Database/Publications/PublicationsTableItem.tsx
@@ -1,42 +1,46 @@
 import { FC, useState } from 'react'
 import { observer } from 'mobx-react-lite'
 import { Badge, Toggle } from '@supabase/ui'
+import { PostgresPublication, PostgresTable } from '@supabase/postgres-meta'
 
 import { useStore } from 'hooks'
 import Table from 'components/to-be-cleaned/Table'
 
 interface Props {
-  table: any
-  selectedPublication: any
+  table: PostgresTable
+  selectedPublication: PostgresPublication
 }
 
 const PublicationsTableItem: FC<Props> = ({ table, selectedPublication }) => {
   const { ui, meta } = useStore()
+  const enabledForAllTables = selectedPublication.tables == null
 
-  const publication = selectedPublication
-  const enabledForAllTables = publication.tables == null
   const [loading, setLoading] = useState(false)
   const [checked, setChecked] = useState(
-    publication.tables?.find((x: any) => x.id == table.id) != undefined
+    selectedPublication.tables?.find((x: any) => x.id == table.id) != undefined
   )
 
-  const toggleReplicationForTable = async (table: any, publication: any) => {
+  const toggleReplicationForTable = async (
+    table: PostgresTable,
+    publication: PostgresPublication
+  ) => {
     const originalChecked = checked
     setChecked(!checked)
     setLoading(true)
 
-    let exists = publication.tables.some((x: any) => x.id == table.id)
-    let tables = !exists
+    const publicationTables = publication?.tables ?? []
+    const exists = publicationTables.some((x: any) => x.id == table.id)
+    const tables = !exists
       ? [`${table.schema}.${table.name}`].concat(
-          publication.tables.map((t: any) => `${t.schema}.${t.name}`)
+          publicationTables.map((t: any) => `${t.schema}.${t.name}`)
         )
-      : publication.tables
+      : publicationTables
           .filter((x: any) => x.id != table.id)
           .map((x: any) => `${x.schema}.${x.name}`)
 
     try {
       const id = publication.id
-      let payload = { tables, id }
+      const payload = { tables, id }
       const { error } = await meta.publications.update(id, payload)
       if (error) throw error
       setLoading(false)
@@ -60,12 +64,7 @@ const PublicationsTableItem: FC<Props> = ({ table, selectedPublication }) => {
       <Table.td className="px-4 py-3 pr-2">
         <div className="flex justify-end gap-2">
           {enabledForAllTables ? (
-            // @ts-ignore
-            <Badge
-              color="scale"
-              // className="hover:border-gray-500"
-              // style={{ paddingTop: 3, paddingBottom: 3 }}
-            >
+            <Badge color="scale">
               <span>Enabled</span>
               <span className="hidden lg:inline-block">&nbsp;for all tables</span>
             </Badge>
@@ -76,7 +75,7 @@ const PublicationsTableItem: FC<Props> = ({ table, selectedPublication }) => {
               disabled={loading}
               className="m-0 ml-2 mt-1 -mb-1 p-0"
               checked={checked}
-              onChange={() => toggleReplicationForTable(table, publication)}
+              onChange={() => toggleReplicationForTable(table, selectedPublication)}
             />
           )}
         </div>

--- a/studio/components/interfaces/Database/Publications/PublicationsTables.tsx
+++ b/studio/components/interfaces/Database/Publications/PublicationsTables.tsx
@@ -1,27 +1,19 @@
 import { FC, useState } from 'react'
 import { observer } from 'mobx-react-lite'
-import { Button, Toggle, Input, IconChevronLeft, IconSearch } from '@supabase/ui'
+import { Button, Input, IconChevronLeft, IconSearch } from '@supabase/ui'
+import { PostgresPublication } from '@supabase/postgres-meta'
 
 import { useStore } from 'hooks'
 import PublicationsTableItem from './PublicationsTableItem'
 import Table from 'components/to-be-cleaned/Table'
-// import { confirmAlert } from 'components/to-be-cleaned/ModalsDeprecated/ConfirmModal'
 
 interface Props {
-  selectedPublication: any
+  selectedPublication: PostgresPublication
   onSelectBack: () => void
-  onPublicationUpdated: (publication: any) => void
 }
 
-const PublicationsTables: FC<Props> = ({
-  selectedPublication,
-  onSelectBack,
-  // onPublicationUpdated,
-}) => {
-  const {
-    // ui,
-    meta,
-  } = useStore()
+const PublicationsTables: FC<Props> = ({ selectedPublication, onSelectBack }) => {
+  const { meta } = useStore()
   const [filterString, setFilterString] = useState<string>('')
 
   const tables =
@@ -62,7 +54,7 @@ const PublicationsTables: FC<Props> = ({
   return (
     <>
       <div className="mb-4">
-        <div className="flex justify-between items-center">
+        <div className="flex items-center justify-between">
           <div className="flex items-center space-x-3">
             <Button
               type="outline"
@@ -88,7 +80,7 @@ const PublicationsTables: FC<Props> = ({
           head={[
             <Table.th key="header-name">Name</Table.th>,
             <Table.th key="header-schema">Schema</Table.th>,
-            <Table.th key="header-desc" className="text-left hidden lg:table-cell">
+            <Table.th key="header-desc" className="hidden text-left lg:table-cell">
               Description
             </Table.th>,
             <Table.th key="header-all">

--- a/studio/components/interfaces/Database/Publications/PublicationsTables.tsx
+++ b/studio/components/interfaces/Database/Publications/PublicationsTables.tsx
@@ -6,6 +6,7 @@ import { PostgresPublication } from '@supabase/postgres-meta'
 import { useStore } from 'hooks'
 import PublicationsTableItem from './PublicationsTableItem'
 import Table from 'components/to-be-cleaned/Table'
+import NoSearchResults from 'components/to-be-cleaned/NoSearchResults'
 
 interface Props {
   selectedPublication: PostgresPublication
@@ -75,16 +76,19 @@ const PublicationsTables: FC<Props> = ({ selectedPublication, onSelectBack }) =>
           <div className=""></div>
         </div>
       </div>
-      <div>
-        <Table
-          head={[
-            <Table.th key="header-name">Name</Table.th>,
-            <Table.th key="header-schema">Schema</Table.th>,
-            <Table.th key="header-desc" className="hidden text-left lg:table-cell">
-              Description
-            </Table.th>,
-            <Table.th key="header-all">
-              {/* Temporarily disable All tables toggle for publications. See https://github.com/supabase/supabase/pull/7233.
+      {tables.length === 0 ? (
+        <NoSearchResults />
+      ) : (
+        <div>
+          <Table
+            head={[
+              <Table.th key="header-name">Name</Table.th>,
+              <Table.th key="header-schema">Schema</Table.th>,
+              <Table.th key="header-desc" className="hidden text-left lg:table-cell">
+                Description
+              </Table.th>,
+              <Table.th key="header-all">
+                {/* Temporarily disable All tables toggle for publications. See https://github.com/supabase/supabase/pull/7233.
               <div className="flex flex-row space-x-3 items-center justify-end">
                 <div className="text-xs leading-4 font-medium text-gray-400 text-right ">
                   All Tables
@@ -98,17 +102,18 @@ const PublicationsTables: FC<Props> = ({ selectedPublication, onSelectBack }) =>
                   onChange={() => toggleReplicationForAllTables(publication, enabledForAllTables)}
                 />
               </div> */}
-            </Table.th>,
-          ]}
-          body={tables.map((table: any, i: number) => (
-            <PublicationsTableItem
-              key={table.id}
-              table={table}
-              selectedPublication={selectedPublication}
-            />
-          ))}
-        />
-      </div>
+              </Table.th>,
+            ]}
+            body={tables.map((table: any, i: number) => (
+              <PublicationsTableItem
+                key={table.id}
+                table={table}
+                selectedPublication={selectedPublication}
+              />
+            ))}
+          />
+        </div>
+      )}
     </>
   )
 }

--- a/studio/components/interfaces/Database/Tables/ColumnList.tsx
+++ b/studio/components/interfaces/Database/Tables/ColumnList.tsx
@@ -14,6 +14,7 @@ import {
 import { useStore } from 'hooks'
 import { confirmAlert } from '../../../to-be-cleaned/ModalsDeprecated/ConfirmModal'
 import Table from '../../../to-be-cleaned/Table'
+import NoSearchResults from 'components/to-be-cleaned/NoSearchResults'
 
 const Header: FC<{
   filterString: string
@@ -28,7 +29,7 @@ const Header: FC<{
   leftComponents,
   rightComponents,
 }) => (
-  <div className="flex justify-between items-center">
+  <div className="flex items-center justify-between">
     <div className="flex items-center">
       <div>{leftComponents}</div>
       <div>
@@ -87,59 +88,63 @@ const ColumnList: FC<{
           }
         />
       </div>
-      <div className="">
-        <Table
-          head={[
-            <Table.th key="name">Name</Table.th>,
-            <Table.th key="description" className="hidden lg:table-cell">
-              Description
-            </Table.th>,
-            <Table.th key="type" className="hidden xl:table-cell">
-              Data Type
-            </Table.th>,
-            <Table.th key="format" className="hidden xl:table-cell">
-              Format
-            </Table.th>,
-            <Table.th key="buttons"></Table.th>,
-          ]}
-          body={columns.map((x: any, i: number) => (
-            <Table.tr className="border-t" key={x.name}>
-              <Table.td className="">
-                <Typography.Text>{x.name}</Typography.Text>
-              </Table.td>
-              <Table.td className="">
-                <Typography.Text>{x.comment}</Typography.Text>
-              </Table.td>
-              <Table.td className="">
-                <Typography.Text small code>
-                  {x.data_type}
-                </Typography.Text>
-              </Table.td>
-              <Table.td className="text-xs font-mono">
-                <Typography.Text small code>
-                  {x.format}
-                </Typography.Text>
-              </Table.td>
-              <Table.td className="px-4 py-3 pr-2">
-                <div className="flex gap-2 justify-end">
-                  <Button
-                    onClick={() => onEditColumn(x)}
-                    icon={<IconEdit3 />}
-                    style={{ padding: 5 }}
-                    type="text"
-                  />
-                  <Button
-                    onClick={() => onDeleteColumn(x)}
-                    icon={<IconTrash />}
-                    style={{ padding: 5 }}
-                    type="text"
-                  />
-                </div>
-              </Table.td>
-            </Table.tr>
-          ))}
-        />
-      </div>
+      {columns.length === 0 ? (
+        <NoSearchResults />
+      ) : (
+        <div>
+          <Table
+            head={[
+              <Table.th key="name">Name</Table.th>,
+              <Table.th key="description" className="hidden lg:table-cell">
+                Description
+              </Table.th>,
+              <Table.th key="type" className="hidden xl:table-cell">
+                Data Type
+              </Table.th>,
+              <Table.th key="format" className="hidden xl:table-cell">
+                Format
+              </Table.th>,
+              <Table.th key="buttons"></Table.th>,
+            ]}
+            body={columns.map((x: any, i: number) => (
+              <Table.tr className="border-t" key={x.name}>
+                <Table.td>
+                  <Typography.Text>{x.name}</Typography.Text>
+                </Table.td>
+                <Table.td>
+                  <Typography.Text>{x.comment}</Typography.Text>
+                </Table.td>
+                <Table.td>
+                  <Typography.Text small code>
+                    {x.data_type}
+                  </Typography.Text>
+                </Table.td>
+                <Table.td className="font-mono text-xs">
+                  <Typography.Text small code>
+                    {x.format}
+                  </Typography.Text>
+                </Table.td>
+                <Table.td className="px-4 py-3 pr-2">
+                  <div className="flex justify-end gap-2">
+                    <Button
+                      onClick={() => onEditColumn(x)}
+                      icon={<IconEdit3 />}
+                      style={{ padding: 5 }}
+                      type="text"
+                    />
+                    <Button
+                      onClick={() => onDeleteColumn(x)}
+                      icon={<IconTrash />}
+                      style={{ padding: 5 }}
+                      type="text"
+                    />
+                  </div>
+                </Table.td>
+              </Table.tr>
+            ))}
+          />
+        </div>
+      )}
     </>
   )
 }

--- a/studio/components/interfaces/Database/Tables/TableList.tsx
+++ b/studio/components/interfaces/Database/Tables/TableList.tsx
@@ -13,6 +13,7 @@ import {
 
 import { useStore } from 'hooks'
 import Table from 'components/to-be-cleaned/Table'
+import NoSearchResults from 'components/to-be-cleaned/NoSearchResults'
 
 const Header: FC<{
   filterString: string
@@ -27,7 +28,7 @@ const Header: FC<{
   leftComponents,
   rightComponents,
 }) => (
-  <div className="flex justify-between items-center">
+  <div className="flex items-center justify-between">
     <div className="flex items-center">
       <div>{leftComponents}</div>
       <div>
@@ -79,74 +80,78 @@ const TableList: FC<{
             }
           />
         </div>
-        <div className="w-full my-4">
-          <Table
-            head={[
-              <Table.th key="name">Name</Table.th>,
-              <Table.th key="schema">Schema</Table.th>,
-              <Table.th key="description" className="hidden lg:table-cell">
-                Description
-              </Table.th>,
-              <Table.th key="rows" className="hidden xl:table-cell">
-                Rows (Estimated)
-              </Table.th>,
-              <Table.th key="size" className="hidden xl:table-cell">
-                Size (Estimated)
-              </Table.th>,
-              <Table.th key="buttons"></Table.th>,
-            ]}
-            body={tables.map((x: any, i: any) => (
-              <Table.tr key={x.id} hoverable>
-                <Table.td>
-                  <Typography.Text>{x.name}</Typography.Text>
-                </Table.td>
-                <Table.td>
-                  <Typography.Text>{x.schema}</Typography.Text>
-                </Table.td>
-                <Table.td className=" truncate max-w-sm hidden lg:table-cell">
-                  <Typography.Text>{x.comment}</Typography.Text>
-                </Table.td>
-                <Table.td className=" hidden xl:table-cell">
-                  <Typography.Text small code>
-                    {x.live_rows_estimate ?? x.live_row_count}
-                  </Typography.Text>
-                </Table.td>
-                <Table.td className=" hidden xl:table-cell">
-                  <Typography.Text small code>
-                    {x.size}
-                  </Typography.Text>
-                </Table.td>
-                <Table.td>
-                  <div className="flex gap-2 justify-end">
-                    <Button
-                      iconRight={<IconColumns />}
-                      type="default"
-                      className="hover:border-gray-500 whitespace-nowrap"
-                      style={{ paddingTop: 3, paddingBottom: 3 }}
-                      onClick={() => {
-                        onOpenTable(x)
-                      }}
-                    >
-                      {x.columns.length} columns
-                    </Button>
-                    <Button
-                      onClick={() => onEditTable(x)}
-                      icon={<IconEdit3 />}
-                      style={{ padding: 5 }}
-                      type="text"
-                    />
-                    <Button
-                      onClick={() => onDeleteTable(x)}
-                      icon={<IconTrash />}
-                      style={{ padding: 5 }}
-                      type="text"
-                    />
-                  </div>
-                </Table.td>
-              </Table.tr>
-            ))}
-          />
-        </div>
+        {tables.length === 0 ? (
+          <NoSearchResults />
+        ) : (
+          <div className="my-4 w-full">
+            <Table
+              head={[
+                <Table.th key="name">Name</Table.th>,
+                <Table.th key="schema">Schema</Table.th>,
+                <Table.th key="description" className="hidden lg:table-cell">
+                  Description
+                </Table.th>,
+                <Table.th key="rows" className="hidden xl:table-cell">
+                  Rows (Estimated)
+                </Table.th>,
+                <Table.th key="size" className="hidden xl:table-cell">
+                  Size (Estimated)
+                </Table.th>,
+                <Table.th key="buttons"></Table.th>,
+              ]}
+              body={tables.map((x: any, i: any) => (
+                <Table.tr key={x.id} hoverable>
+                  <Table.td>
+                    <Typography.Text>{x.name}</Typography.Text>
+                  </Table.td>
+                  <Table.td>
+                    <Typography.Text>{x.schema}</Typography.Text>
+                  </Table.td>
+                  <Table.td className=" hidden max-w-sm truncate lg:table-cell">
+                    <Typography.Text>{x.comment}</Typography.Text>
+                  </Table.td>
+                  <Table.td className=" hidden xl:table-cell">
+                    <Typography.Text small code>
+                      {x.live_rows_estimate ?? x.live_row_count}
+                    </Typography.Text>
+                  </Table.td>
+                  <Table.td className=" hidden xl:table-cell">
+                    <Typography.Text small code>
+                      {x.size}
+                    </Typography.Text>
+                  </Table.td>
+                  <Table.td>
+                    <div className="flex justify-end gap-2">
+                      <Button
+                        iconRight={<IconColumns />}
+                        type="default"
+                        className="whitespace-nowrap hover:border-gray-500"
+                        style={{ paddingTop: 3, paddingBottom: 3 }}
+                        onClick={() => {
+                          onOpenTable(x)
+                        }}
+                      >
+                        {x.columns.length} columns
+                      </Button>
+                      <Button
+                        onClick={() => onEditTable(x)}
+                        icon={<IconEdit3 />}
+                        style={{ padding: 5 }}
+                        type="text"
+                      />
+                      <Button
+                        onClick={() => onDeleteTable(x)}
+                        icon={<IconTrash />}
+                        style={{ padding: 5 }}
+                        type="text"
+                      />
+                    </div>
+                  </Table.td>
+                </Table.tr>
+              ))}
+            />
+          </div>
+        )}
       </>
     )
   }

--- a/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
+++ b/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
@@ -184,7 +184,7 @@ const TableEditorMenu: FC<Props> = ({
                 <IconSearch size={12} strokeWidth={1.5} />
               </div>
             }
-            placeholder="Filter tables"
+            placeholder="Search tables"
             onChange={(e) => setSearchText(e.target.value)}
             value={searchText}
             size="tiny"

--- a/studio/components/to-be-cleaned/NoSearchResults.tsx
+++ b/studio/components/to-be-cleaned/NoSearchResults.tsx
@@ -1,18 +1,17 @@
 import SVG from 'react-inlinesvg'
-import { Typography } from '@supabase/ui'
 
 export const NoSearchResults = () => {
   return (
-    <div className="flex flex-col items-center justify-center h-64">
+    <div className="flex h-64 flex-col items-center justify-center">
       <SVG
         src="/img/no-search-results.svg"
         preProcessor={(code) =>
           code.replace(/svg/, 'svg className="mb-2 w-16 h-16 text-color-inherit"')
         }
       />
-      <Typography.Text className="text-sm w-64 text-center opacity-50">
+      <p className="w-64 text-center text-sm opacity-50">
         Hmm, we couldn't find any results that matches your query. Try another?
-      </Typography.Text>
+      </p>
     </div>
   )
 }

--- a/studio/pages/project/[ref]/database/replication.tsx
+++ b/studio/pages/project/[ref]/database/replication.tsx
@@ -1,23 +1,31 @@
 import { useState } from 'react'
-import { isUndefined } from 'lodash'
 import { observer } from 'mobx-react-lite'
 
+import { useStore } from 'hooks'
+import { NextPageWithLayout } from 'types'
 import { DatabaseLayout } from 'components/layouts'
 import { PublicationsList, PublicationsTables } from 'components/interfaces/Database'
-import { NextPageWithLayout } from 'types'
+
+// [Joshen] Technically, best that we have these as separate URLs
+// makes it easier to manage state, but foresee that this page might
+// be consolidated somewhere else eventually for better UX
 
 const DatabaseReplication: NextPageWithLayout = () => {
-  const [selectedPublication, setSelectedPublication] = useState<any>()
+  const { meta } = useStore()
+  const publications = meta.publications.list()
+
+  const [selectedPublicationId, setSelectedPublicationId] = useState<number>()
+  const selectedPublication = publications.find((pub) => pub.id === selectedPublicationId)
 
   return (
     <div className="p-4">
-      {isUndefined(selectedPublication) ? (
-        <PublicationsList onSelectPublication={setSelectedPublication} />
+      {selectedPublicationId === undefined ? (
+        <PublicationsList onSelectPublication={setSelectedPublicationId} />
       ) : (
         <PublicationsTables
           selectedPublication={selectedPublication}
-          onSelectBack={() => setSelectedPublication(undefined)}
-          onPublicationUpdated={setSelectedPublication}
+          onSelectBack={() => setSelectedPublicationId(undefined)}
+          // onPublicationUpdated={setSelectedPublication}
         />
       )}
     </div>

--- a/studio/pages/project/[ref]/database/replication.tsx
+++ b/studio/pages/project/[ref]/database/replication.tsx
@@ -25,7 +25,6 @@ const DatabaseReplication: NextPageWithLayout = () => {
         <PublicationsTables
           selectedPublication={selectedPublication}
           onSelectBack={() => setSelectedPublicationId(undefined)}
-          // onPublicationUpdated={setSelectedPublication}
         />
       )}
     </div>


### PR DESCRIPTION
Issue was because we were passing `selectedPublication` via react state, when we should be using the meta store to retrieve the selected publication - because of this, the client state for tables that were toggled for realtime was always stale