### PR TITLE
Fix policy editor from wrongly comparing undefined and null for definition and check

### DIFF
--- a/studio/components/interfaces/Authentication/Policies/Policies.types.ts
+++ b/studio/components/interfaces/Authentication/Policies/Policies.types.ts
@@ -5,8 +5,8 @@ export interface PolicyFormField {
   table: string
   table_id?: number
   command: 'SELECT' | 'INSERT' | 'UPDATE' | 'DELETE' | 'ALL' | null
-  check: string
-  definition: string
+  check: string | null
+  definition: string | null
   roles: string[]
 }
 

--- a/studio/components/interfaces/Authentication/Policies/Policies.utils.ts
+++ b/studio/components/interfaces/Authentication/Policies/Policies.utils.ts
@@ -19,9 +19,15 @@ export const createSQLPolicy = (
   const { definition, check } = policyFormFields
   const formattedPolicyFormFields = {
     ...policyFormFields,
-    definition: definition ? definition.replace(/\s+/g, ' ').trim() : definition,
-    check: check ? check.replace(/\s+/g, ' ').trim() : check,
+    definition: definition
+      ? definition.replace(/\s+/g, ' ').trim()
+      : definition === undefined
+      ? null
+      : definition,
+    check: check ? check.replace(/\s+/g, ' ').trim() : check === undefined ? null : check,
   }
+  console.log('Original', policyFormFields)
+  console.log('Formatted', formattedPolicyFormFields)
 
   if (isEmpty(originalPolicyFormFields)) {
     return createSQLStatementForCreatePolicy(formattedPolicyFormFields)

--- a/studio/components/interfaces/Authentication/Policies/Policies.utils.ts
+++ b/studio/components/interfaces/Authentication/Policies/Policies.utils.ts
@@ -26,8 +26,6 @@ export const createSQLPolicy = (
       : definition,
     check: check ? check.replace(/\s+/g, ' ').trim() : check === undefined ? null : check,
   }
-  console.log('Original', policyFormFields)
-  console.log('Formatted', formattedPolicyFormFields)
 
   if (isEmpty(originalPolicyFormFields)) {
     return createSQLStatementForCreatePolicy(formattedPolicyFormFields)

--- a/studio/components/interfaces/Authentication/Policies/PolicyEditorModal/index.tsx
+++ b/studio/components/interfaces/Authentication/Policies/PolicyEditorModal/index.tsx
@@ -71,6 +71,9 @@ const PolicyEditorModal: FC<Props> = ({
   )
   const [policyStatementForReview, setPolicyStatementForReview] = useState<any>('')
 
+  console.log('initializedPolicyFormFields', initializedPolicyFormFields)
+  console.log('policyFormFields', policyFormFields)
+
   useEffect(() => {
     if (visible) {
       if (isNewPolicy) {

--- a/studio/components/interfaces/Authentication/Policies/PolicyEditorModal/index.tsx
+++ b/studio/components/interfaces/Authentication/Policies/PolicyEditorModal/index.tsx
@@ -71,9 +71,6 @@ const PolicyEditorModal: FC<Props> = ({
   )
   const [policyStatementForReview, setPolicyStatementForReview] = useState<any>('')
 
-  console.log('initializedPolicyFormFields', initializedPolicyFormFields)
-  console.log('policyFormFields', policyFormFields)
-
   useEffect(() => {
     if (visible) {
       if (isNewPolicy) {

--- a/studio/components/to-be-cleaned/Storage/Storage.utils.ts
+++ b/studio/components/to-be-cleaned/Storage/Storage.utils.ts
@@ -94,7 +94,7 @@ export const createPayloadsForAddPolicy = (
   addSuffixToPolicyName = true
 ) => {
   const { name: policyName, definition, allowedOperations, roles } = policyFormFields
-  const formattedDefinition = definition.replace(/\s+/g, ' ').trim()
+  const formattedDefinition = definition ? definition.replace(/\s+/g, ' ').trim() : ''
 
   return allowedOperations.map((operation: any, idx: number) => {
     return createPayloadForNewPolicy(
@@ -182,7 +182,7 @@ export const createSQLPolicies = (
       idx,
       bucketName,
       policyName,
-      definition,
+      definition || '',
       operation,
       roles,
       addSuffixToPolicyName


### PR DESCRIPTION
Resolves https://github.com/supabase/supabase/issues/7481

Oddly in the comparison logic here, it was comparing `undefined` and `null` value to check if there were changes, hence why there was that 'undefined' showing up