### PR TITLE
Chore: update redirects

### DIFF
--- a/apps/www/next.config.js
+++ b/apps/www/next.config.js
@@ -84,6 +84,26 @@ module.exports = withMDX({
   async redirects() {
     return [
       {
+        permanent: true,
+        source: '/auth/Auth',
+        destination: '/auth',
+      },
+      {
+        permanent: true,
+        source: '/database/Database',
+        destination: '/database',
+      },
+      {
+        permanent: true,
+        source: '/edge-functions/edge-functions',
+        destination: '/edge-functions',
+      },
+      {
+        permanent: true,
+        source: '/storage/Storage',
+        destination: '/storage',
+      },
+      {
         permanent: false,
         source: '/blog/2021/03/08/toad-a-link-shorterner-with-simple-apis-for-low-coders',
         destination: '/blog/2021/03/08/toad-a-link-shortener-with-simple-apis-for-low-coders',


### PR DESCRIPTION
## What kind of change does this PR introduce?

update redirects so users can visit links like `/database/Database` or `/storage/Storage`

## What is the current behavior?

`/database/Database`

## What is the new behavior?

`database/Database` redirects to `/database`

## Additional context

This is happening because we have files with the same name as the folder in the pages directory. in next.js this causing it to think that its a new route/page.