### PR TITLE
sveltekit quickstart - add npm install, clarifying comments, and consistent syntax

### DIFF
--- a/web/docs/guides/with-sveltekit.mdx
+++ b/web/docs/guides/with-sveltekit.mdx
@@ -169,7 +169,7 @@ And finally we want to save the environment variables in a `.env`.
 All we need are the `SUPABASE_URL` and the `SUPABASE_KEY` key that you copied [earlier](#get-the-api-keys).
 
 ```bash title=".env"
-VITE_SUPABASE_"URL=YOUR_SUPABASE_URL"
+VITE_SUPABASE_URL="YOUR_SUPABASE_URL"
 VITE_SUPABASE_ANON_KEY="YOUR_SUPABASE_KEY"
 ```
 

--- a/web/docs/guides/with-sveltekit.mdx
+++ b/web/docs/guides/with-sveltekit.mdx
@@ -151,11 +151,12 @@ Let's start building the Svelte app from scratch.
 ### Initialize a Svelte app
 
 We can use the [SvelteKit Skeleton Project](https://kit.svelte.dev/docs) to initialize 
-an app called `supabase-sveltekit`:
+an app called `supabase-sveltekit` (for this tutorial you do not need TypeScript, ESLint, Prettier, or Playwright):
 
 ```bash
-npm init svelte@next supabase-sveltekit
+npm create svelte supabase-sveltekit
 cd supabase-sveltekit
+npm install
 ```
 
 Then let's install the only additional dependency: [supabase-js](https://github.com/supabase/supabase-js)
@@ -168,8 +169,8 @@ And finally we want to save the environment variables in a `.env`.
 All we need are the `SUPABASE_URL` and the `SUPABASE_KEY` key that you copied [earlier](#get-the-api-keys).
 
 ```bash title=".env"
-VITE_SUPABASE_URL=YOUR_SUPABASE_URL
-VITE_SUPABASE_ANON_KEY=YOUR_SUPABASE_KEY
+VITE_SUPABASE_"URL=YOUR_SUPABASE_URL"
+VITE_SUPABASE_ANON_KEY="YOUR_SUPABASE_KEY"
 ```
 
 Now that we have the API credentials in place, let's create a helper file to initialize the Supabase client. These variables will be exposed
@@ -234,9 +235,9 @@ Let's set up a Svelte component to manage logins and sign ups. We'll use Magic L
 ### User store
 To access the user information in other places, we use a writable store. Create a new file called `sessionStore.js`
 ```javascript title="lib/sessionStore.js"
-import { writable } from 'svelte/store';
+import { writable } from 'svelte/store'
 
-export const user = writable(false);
+export const user = writable(false)
 ```
 
 
@@ -402,7 +403,7 @@ Let's create an avatar for the user so that they can upload a profile photo. We 
 
 ```html title="lib/Avatar.svelte"
 <script>
-  import { createEventDispatcher } from 'svelte';
+  import { createEventDispatcher } from 'svelte'
   import { supabase } from '$lib/supabaseClient'
 
   export let path;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Documentation update

## What is the current behavior?

These are things that tripped me up in the tutorial and some consistency updates:

1. You cannot run npm run dev at the end of the tutorial without npm install first
2. Unsure if typescript and other extras were required upon sveltekit install
3. Unsure if semicolons were required on env variables
4. Removed semicolons from some scripts for consistency with the rest of the doc

## What is the new behavior?

Added extra line "npm install", comment, and syntax updates to the doc.

## Additional context

None
