### PR TITLE
fix: grammar change on description for composite primary key

### DIFF
--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/ColumnManagement.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/ColumnManagement.tsx
@@ -193,7 +193,7 @@ const ColumnManagement: FC<Props> = ({
             block
             icon={<IconKey className="text-white" size="large" />}
             title="Composite primary key selected"
-            description="The columns that you've selected will grouped as a primary key, and will serve
+            description="The columns that you've selected will be grouped as a primary key, and will serve
             as the unique identifier for the rows in your table"
           />
         )}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Studio: Grammar change

## What is the current behavior?

Current description is:

`The columns that you've selected will grouped as a primary key, and will serve
            as the unique identifier for the rows in your table`

## What is the new behavior?

New description:

`The columns that you've selected will be grouped as a primary key, and will serve
            as the unique identifier for the rows in your table`

## Additional context

Fixes #7533 
