### PR TITLE
Update gotrue image

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -40,7 +40,7 @@ services:
 
   auth:
     container_name: supabase-auth
-    image: supabase/gotrue:v2.5.21
+    image: supabase/gotrue:v2.7.1
     depends_on:
       - db # Disable this if you are using an external Postgres database
     restart: unless-stopped


### PR DESCRIPTION
Gotrue image tage version Update to v2.7.1
New provider like keycloak and another social login are applicable in this version and newer.