### PR TITLE
Studio table hover description

### DIFF
--- a/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
+++ b/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
@@ -220,49 +220,51 @@ const TableEditorMenu: FC<Props> = ({
             {schemaTables.map((table) => {
               const isActive = Number(id) === table.id
               return (
-                <ProductMenuItem
-                  key={table.name}
-                  url={`/project/${projectRef}/editor/${table.id}`}
-                  name={table.name}
-                  isActive={isActive}
-                  action={
-                    isActive && (
-                      <Dropdown
-                        size="small"
-                        side="bottom"
-                        align="start"
-                        overlay={[
-                          <Dropdown.Item
-                            key="edit-table"
-                            icon={<IconEdit size="tiny" />}
-                            onClick={() => onEditTable(table)}
+                    <ProductMenuItem
+                      key={table.name}
+                      url={`/project/${projectRef}/editor/${table.id}`}
+                      name={table.name}
+                      hoverText={table.comment ? table.comment : table.name}
+                      isActive={isActive}
+                      action={
+                        isActive && (
+                          <Dropdown
+                            size="small"
+                            side="bottom"
+                            align="start"
+                            overlay={[
+                              <Dropdown.Item
+                                key="edit-table"
+                                icon={<IconEdit size="tiny" />}
+                                onClick={() => onEditTable(table)}
+                              >
+                                Edit Table
+                              </Dropdown.Item>,
+                              <Dropdown.Item
+                                key="duplicate-table"
+                                icon={<IconCopy size="tiny" />}
+                                onClick={() => onDuplicateTable(table)}
+                              >
+                                Duplicate Table
+                              </Dropdown.Item>,
+                              <Dropdown.Seperator />,
+                              <Dropdown.Item
+                                key="delete-table"
+                                icon={<IconTrash size="tiny" />}
+                                onClick={() => onDeleteTable(table)}
+                              >
+                                Delete Table
+                              </Dropdown.Item>,
+                            ]}
                           >
-                            Edit Table
-                          </Dropdown.Item>,
-                          <Dropdown.Item
-                            key="duplicate-table"
-                            icon={<IconCopy size="tiny" />}
-                            onClick={() => onDuplicateTable(table)}
-                          >
-                            Duplicate Table
-                          </Dropdown.Item>,
-                          <Dropdown.Seperator />,
-                          <Dropdown.Item
-                            key="delete-table"
-                            icon={<IconTrash size="tiny" />}
-                            onClick={() => onDeleteTable(table)}
-                          >
-                            Delete Table
-                          </Dropdown.Item>,
-                        ]}
-                      >
-                        <div className="text-scale-900 hover:text-scale-1200 transition-colors">
-                          <IconChevronDown size={14} strokeWidth={2} />
-                        </div>
-                      </Dropdown>
-                    )
-                  }
-                />
+                            <div className="text-scale-900 hover:text-scale-1200 transition-colors">
+                              <IconChevronDown size={14} strokeWidth={2} />
+                            </div>
+                          </Dropdown>
+                        )
+                      }
+                    />
+
               )
             })}
           </div>

--- a/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
+++ b/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
@@ -220,51 +220,50 @@ const TableEditorMenu: FC<Props> = ({
             {schemaTables.map((table) => {
               const isActive = Number(id) === table.id
               return (
-                    <ProductMenuItem
-                      key={table.name}
-                      url={`/project/${projectRef}/editor/${table.id}`}
-                      name={table.name}
-                      hoverText={table.comment ? table.comment : table.name}
-                      isActive={isActive}
-                      action={
-                        isActive && (
-                          <Dropdown
-                            size="small"
-                            side="bottom"
-                            align="start"
-                            overlay={[
-                              <Dropdown.Item
-                                key="edit-table"
-                                icon={<IconEdit size="tiny" />}
-                                onClick={() => onEditTable(table)}
-                              >
-                                Edit Table
-                              </Dropdown.Item>,
-                              <Dropdown.Item
-                                key="duplicate-table"
-                                icon={<IconCopy size="tiny" />}
-                                onClick={() => onDuplicateTable(table)}
-                              >
-                                Duplicate Table
-                              </Dropdown.Item>,
-                              <Dropdown.Seperator />,
-                              <Dropdown.Item
-                                key="delete-table"
-                                icon={<IconTrash size="tiny" />}
-                                onClick={() => onDeleteTable(table)}
-                              >
-                                Delete Table
-                              </Dropdown.Item>,
-                            ]}
+                <ProductMenuItem
+                  key={table.name}
+                  url={`/project/${projectRef}/editor/${table.id}`}
+                  name={table.name}
+                  hoverText={table.comment ? table.comment : table.name}
+                  isActive={isActive}
+                  action={
+                    isActive && (
+                      <Dropdown
+                        size="small"
+                        side="bottom"
+                        align="start"
+                        overlay={[
+                          <Dropdown.Item
+                            key="edit-table"
+                            icon={<IconEdit size="tiny" />}
+                            onClick={() => onEditTable(table)}
                           >
-                            <div className="text-scale-900 hover:text-scale-1200 transition-colors">
-                              <IconChevronDown size={14} strokeWidth={2} />
-                            </div>
-                          </Dropdown>
-                        )
-                      }
-                    />
-
+                            Edit Table
+                          </Dropdown.Item>,
+                          <Dropdown.Item
+                            key="duplicate-table"
+                            icon={<IconCopy size="tiny" />}
+                            onClick={() => onDuplicateTable(table)}
+                          >
+                            Duplicate Table
+                          </Dropdown.Item>,
+                          <Dropdown.Seperator />,
+                          <Dropdown.Item
+                            key="delete-table"
+                            icon={<IconTrash size="tiny" />}
+                            onClick={() => onDeleteTable(table)}
+                          >
+                            Delete Table
+                          </Dropdown.Item>,
+                        ]}
+                      >
+                        <div className="text-scale-900 hover:text-scale-1200 transition-colors">
+                          <IconChevronDown size={14} strokeWidth={2} />
+                        </div>
+                      </Dropdown>
+                    )
+                  }
+                />
               )
             })}
           </div>

--- a/studio/components/ui/ProductMenu/ProductMenuItem.tsx
+++ b/studio/components/ui/ProductMenu/ProductMenuItem.tsx
@@ -25,7 +25,7 @@ const ProductMenuItem: FC<Props> = ({
   target = '_self',
   onClick,
   textClassName = '',
-  hoverText = ''
+  hoverText = '',
 }) => {
   const menuItem = (
     <Menu.Item icon={icon} rounded active={isActive} onClick={onClick}>

--- a/studio/components/ui/ProductMenu/ProductMenuItem.tsx
+++ b/studio/components/ui/ProductMenu/ProductMenuItem.tsx
@@ -12,6 +12,7 @@ interface Props {
   target?: '_blank' | '_self'
   onClick?: () => void
   textClassName?: string
+  hoverText?: string
 }
 
 const ProductMenuItem: FC<Props> = ({
@@ -24,12 +25,13 @@ const ProductMenuItem: FC<Props> = ({
   target = '_self',
   onClick,
   textClassName = '',
+  hoverText = ''
 }) => {
   const menuItem = (
     <Menu.Item icon={icon} rounded active={isActive} onClick={onClick}>
       <div className="flex w-full items-center justify-between">
         <span
-          title={typeof name === 'string' ? name : ''}
+          title={hoverText ? hoverText : typeof name === 'string' ? name : ''}
           className={'flex items-center truncate ' + textClassName}
         >
           {name}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Studio Feature

## What is the current behavior?

At the moment you can not see the table description from the table editor you can only see the description in the database area.

## What is the new behavior?

When you hover over the table name in the editor instead of the name of the table appearing the table description will appear if a description has been added:


https://user-images.githubusercontent.com/22655069/177181232-1698ed99-a9fe-4951-8ee2-bcd315641900.mov

I've created a new prop named `hoverText` which is getting the value and then adding to the `title` attribute

## Additional context

This is linked with #7508
