### PR TITLE
Fix: announcement on small screen

### DIFF
--- a/apps/www/components/Nav/Announcement.tsx
+++ b/apps/www/components/Nav/Announcement.tsx
@@ -56,14 +56,9 @@ const Announcement = () => {
             lg:px-16 xl:px-20
           "
         >
-          <span className="hidden px-3 lg:block">{announcement.text}</span>
-          <span className="flex items-center space-x-2 px-3">
-            <span>
-              {
-                // @ts-ignore
-                announcement.cta
-              }
-            </span>
+          <span className="px-3">{announcement.text}</span>
+          <span className="hidden items-center space-x-2 px-3 lg:flex">
+            <span>{announcement.cta}</span>
             <IconChevronRight size={14} />
           </span>
         </div>


### PR DESCRIPTION
## What kind of change does this PR introduce?

update announcement banner text

## What is the current behavior?

<img width="884" alt="image" src="https://user-images.githubusercontent.com/70828596/177193155-3e2f19db-1ba8-4fc0-a01b-bcc679a149e7.png">

## What is the new behavior?

<img width="884" alt="image" src="https://user-images.githubusercontent.com/70828596/177193167-d0bcc045-8f7e-4d4d-8ef5-abfd7d062928.png">