### PR TITLE
:bug: Add type check for data object

### DIFF
--- a/web/docs/guides/with-angular.mdx
+++ b/web/docs/guides/with-angular.mdx
@@ -528,7 +528,11 @@ export class AvatarComponent {
   async downloadImage(path: string) {
     try {
       const {data} = await this.supabase.downLoadImage(path);
-      this._avatarUrl = this.dom.bypassSecurityTrustResourceUrl(URL.createObjectURL(data));
+       if (data instanceof Blob) {
+        this._avatarUrl = this.dom.bypassSecurityTrustResourceUrl(
+          URL.createObjectURL(data)
+        );
+      }
     } catch (error) {
       console.error('Error downloading image: ', error.message);
     }


### PR DESCRIPTION
hence typescript complains about "Argument of type 'Blob | null' is not assignable to parameter of type 'Blob | MediaSource'...", code implement to check Blob type before updating avatar URL

## What kind of change does this PR introduce?
Bug fix

## What is the current behaviour?
typescript complains
**const data: Blob | null
Argument of type 'Blob | null' is not assignable to parameter of type 'Blob | MediaSource'.
Type 'null' is not assignable to type 'Blob | MediaSource'**

## What is the new behaviour?
implement to check Blob type before updating avatar URL

