### PR TITLE
Fix auth logs error and add helper modal for log retention

### DIFF
--- a/studio/components/interfaces/Settings/Logs/UpgradePrompt.tsx
+++ b/studio/components/interfaces/Settings/Logs/UpgradePrompt.tsx
@@ -1,16 +1,24 @@
-import { Button } from '@supabase/ui'
-import dayjs from 'dayjs'
-import { useProjectSubscription } from 'hooks'
 import Link from 'next/link'
+import dayjs from 'dayjs'
+import { useState } from 'react'
+import { Button, IconHelpCircle, IconLoader, Modal } from '@supabase/ui'
+
 import { TIER_QUERY_LIMITS } from '.'
+import { useProjectSubscription } from 'hooks'
+
 interface Props {
   projectRef: string
   from: string
 }
 
 const UpgradePrompt: React.FC<Props> = ({ projectRef, from }) => {
-  const sub = useProjectSubscription(projectRef)
-  const tier = sub?.subscription?.tier
+  const [showHelperModal, setShowHelperModal] = useState(false)
+  const { subscription, isLoading, isError } = useProjectSubscription(projectRef)
+
+  if (isLoading) return <IconLoader size={16} className="animate-spin" />
+  if (isError) console.error('Error fetching project subscription')
+
+  const tier = subscription?.tier
   const tierSupabaseProdId = tier?.supabase_prod_id.toLowerCase()
   const queryLimitKey = Object.keys(TIER_QUERY_LIMITS).find((key) =>
     tierSupabaseProdId?.includes(key.toLowerCase())
@@ -19,27 +27,84 @@ const UpgradePrompt: React.FC<Props> = ({ projectRef, from }) => {
   if (tier && !queryLimitKey) {
     console.error('Tier is unknown, defaulting to Free')
   }
+
   const queryLimit = TIER_QUERY_LIMITS[(queryLimitKey || 'FREE') as keyof typeof TIER_QUERY_LIMITS]
 
   const fromValue = from ? dayjs(from) : dayjs()
   const fromMax = dayjs().startOf('day').subtract(queryLimit.value, queryLimit.unit)
   const isExceedingLimit = fromValue.isBefore(fromMax)
-  
+
   return (
-    <div
-      className={`flex flex-row gap-3 items-center text-xs px-2 py-1 transition-all ${
-        isExceedingLimit
-          ? 'text-yellow-1100  rounded border border-yellow-700 bg-yellow-200 font-semibold'
-          : ''
-      }`}
-    >
-      <span>{`${queryLimit.text} retention`}</span>
-      {!tierSupabaseProdId?.includes('payg') && (
-        <Link href={`/project/${projectRef}/settings/billing`}>
-          <Button size="tiny">Upgrade</Button>
-        </Link>
-      )}
-    </div>
+    <>
+      <div
+        className={`flex flex-row items-center gap-3 px-2 py-1 text-xs transition-all ${
+          isExceedingLimit
+            ? 'text-yellow-1100  rounded border border-yellow-700 bg-yellow-200 font-semibold'
+            : ''
+        }`}
+      >
+        <span className="text-scale-1100">{`${queryLimit.text} retention`}</span>
+        <IconHelpCircle
+          size={16}
+          strokeWidth={1.5}
+          className="text-scale-1100 hover:text-scale-1200 cursor-pointer transition"
+          onClick={() => setShowHelperModal(true)}
+        />
+        {!tierSupabaseProdId?.includes('payg') && (
+          <Link href={`/project/${projectRef}/settings/billing`}>
+            <Button size="tiny">Upgrade</Button>
+          </Link>
+        )}
+      </div>
+
+      <Modal
+        hideFooter
+        visible={showHelperModal}
+        size="medium"
+        header="Log retention"
+        onCancel={() => setShowHelperModal(false)}
+      >
+        <div className="space-y-4 py-4">
+          <Modal.Content>
+            <div className="space-y-4">
+              <p className="text-sm">
+                Logs can be retained up to a duration of 3 months depending on the plan that your
+                project is on. The table below shows an overview of the duration for which your logs
+                will be retained for based on each plan.
+              </p>
+              <div className="border-scale-600 bg-scale-500 rounded border">
+                <div className="flex items-center px-4 pt-2 pb-1">
+                  <p className="text-scale-1100 w-[40%] text-sm">Plan</p>
+                  <p className="text-scale-1100 w-[60%] text-sm">Retention duration</p>
+                </div>
+                <div className="py-1">
+                  <div className="flex items-center px-4 py-1">
+                    <p className="w-[40%] text-sm">Free</p>
+                    <p className="w-[60%] text-sm">1 day</p>
+                  </div>
+                  <div className="flex items-center px-4 py-1">
+                    <p className="w-[40%] text-sm">Pro</p>
+                    <p className="w-[60%] text-sm">7 days</p>
+                  </div>
+                  <div className="flex items-center px-4 py-1">
+                    <p className="w-[40%] text-sm">Enterprise</p>
+                    <p className="w-[60%] text-sm">Contact us</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </Modal.Content>
+          <Modal.Seperator />
+          <Modal.Content>
+            <div className="flex items-center gap-2">
+              <Button block type="primary" onClick={() => setShowHelperModal(false)}>
+                Understood
+              </Button>
+            </div>
+          </Modal.Content>
+        </div>
+      </Modal>
+    </>
   )
 }
 

--- a/studio/tests/pages/projects/LogsPreviewer.test.js
+++ b/studio/tests/pages/projects/LogsPreviewer.test.js
@@ -61,10 +61,9 @@ LogsPreviewer.mockImplementation((props) => {
   )
 })
 
-jest.mock('hooks/queries/useProjectSubscription')
-import useProjectSubscription from 'hooks/queries/useProjectSubscription'
-useProjectSubscription = jest.fn()
-useProjectSubscription.mockImplementation((ref) => ({
+jest.mock('hooks')
+import { useProjectSubscription } from 'hooks'
+useProjectSubscription = jest.fn((ref) => ({
   subscription: {
     tier: {
       supabase_prod_id: 'tier_free',
@@ -74,7 +73,6 @@ useProjectSubscription.mockImplementation((ref) => ({
 
 import { render, fireEvent, waitFor, screen, act } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { getToggleByText } from '../../helpers'
 import { wait } from '@testing-library/user-event/dist/utils'
 import { logDataFixture } from '../../fixtures'
 import { LogsTableName } from 'components/interfaces/Settings/Logs'
@@ -97,12 +95,10 @@ test('can display log data and metadata', async () => {
   })
   render(<LogsPreviewer projectRef="123" tableName={LogsTableName.EDGE} />)
 
-  await waitFor(
-    () => {
-      expect(get).toHaveBeenCalledWith(expect.stringContaining('iso_timestamp_start'))
-      expect(get).not.toHaveBeenCalledWith(expect.stringContaining('iso_timestamp_end'))
-    },
-  )
+  await waitFor(() => {
+    expect(get).toHaveBeenCalledWith(expect.stringContaining('iso_timestamp_start'))
+    expect(get).not.toHaveBeenCalledWith(expect.stringContaining('iso_timestamp_end'))
+  })
 
   fireEvent.click(await screen.findByText(/some-event-happened-id/))
   await screen.findByText(/my_key/)

--- a/studio/tests/pages/projects/logs-query.test.js
+++ b/studio/tests/pages/projects/logs-query.test.js
@@ -48,10 +48,9 @@ useStore.mockImplementation(() => ({
   },
 }))
 
-jest.mock('hooks/queries/useProjectSubscription')
-import useProjectSubscription from 'hooks/queries/useProjectSubscription'
-useProjectSubscription = jest.fn()
-useProjectSubscription.mockImplementation((ref) => ({
+jest.mock('hooks')
+import { useProjectSubscription } from 'hooks'
+useProjectSubscription = jest.fn((ref) => ({
   subscription: {
     tier: {
       supabase_prod_id: 'tier_free',


### PR DESCRIPTION
- Fix xxx of undefined error at toLowerCase, probably due to the subscription stats was still loading
- Added a helper modal to depict log retention duration for each plan (as per pricing page)
<img width="227" alt="image" src="https://user-images.githubusercontent.com/19742402/177265593-6c8b34b0-9ee1-483f-91e1-67a776307dbe.png">

<img width="538" alt="image" src="https://user-images.githubusercontent.com/19742402/177265522-428c06d0-e58a-47c6-a043-633e795c464b.png">
