### PR TITLE
Update auth-keycloak.mdx

### DIFF
--- a/web/docs/guides/auth/auth-keycloak.mdx
+++ b/web/docs/guides/auth/auth-keycloak.mdx
@@ -34,7 +34,7 @@ Keycloak OAuth consists of five broad steps:
 
 - Once you've logged in to the Keycloak console, you can add a realm from the side panel. The default realm should be named "Master".
 - After you've added a new realm, you can retrieve the `issuer` from the "OpenID Endpoint Configuration" endpoint. The `issuer` will be used as the `Keycloak URL`. 
-- You can find this endpoint from the realm settings under the "General Tab" or visit [`http://localhost:8080/auth/realms/my_realm_name/.well-known/openid-configuration`](http://localhost:8080/auth/realms/my_realm_name/.well-known/openid-configuration)
+- You can find this endpoint from the realm settings under the "General Tab" or visit [`http://localhost:8080/realms/my_realm_name/.well-known/openid-configuration`](http://localhost:8080/realms/my_realm_name/.well-known/openid-configuration)
 
 ![Add a Keycloak Realm.](/img/guides/auth-keycloak/keycloak-create-realm.png)
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Keycloak link is dated -- /auth prefix is stripped in later versions. See [this issue on GoTrue](https://github.com/supabase/gotrue/pull/532)

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
