### PR TITLE
docs: next-js todo list - added note about auth logins on the live demo

### DIFF
--- a/examples/todo-list/nextjs-todo-list/README.md
+++ b/examples/todo-list/nextjs-todo-list/README.md
@@ -11,6 +11,8 @@
 
 - Live demo: https://supabase-nextjs-todo-list.vercel.app/
 
+**NOTE:** Both the Google and Github sign in buttons are not enabled on the Live demo.
+
 ## Deploy with Vercel
 
 The Vercel deployment will guide you through creating a Supabase account and project. After installation of the Supabase integration, all relevant environment variables will be set up so that the project is usable immediately after deployment 🚀


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The auth buttons in the [nextjs todo list](https://github.com/supabase/supabase/tree/master/examples/todo-list/nextjs-todo-list) on the [live demo](https://supabase-nextjs-todo-list.vercel.app/) return an error.

## What is the new behavior?

A line has been added to the README to highlight this as suggested in #3841

## Additional context

Linked with #3841
