### PR TITLE
Fix: link color in faq answer

### DIFF
--- a/apps/www/pages/pricing/index.tsx
+++ b/apps/www/pages/pricing/index.tsx
@@ -659,7 +659,9 @@ export default function IndexPage() {
                           header={<span className="text-scale-1200">{faq.question}</span>}
                           id={`faq--${i.toString()}`}
                         >
-                          <ReactMarkdown className="text-scale-900">{faq.answer}</ReactMarkdown>
+                          <ReactMarkdown className="text-scale-900 prose">
+                            {faq.answer}
+                          </ReactMarkdown>
                         </Accordion.Item>
                       </div>
                     )


### PR DESCRIPTION
## What kind of change does this PR introduce?

Makes the links color different from the text color.

## What is the current behavior?

Fix https://github.com/supabase/supabase/issues/7593

<img width="891" alt="image" src="https://user-images.githubusercontent.com/70828596/177634841-791d1988-2baa-4786-8fcf-589101c3512a.png">

## What is the new behavior?

<img width="899" alt="image" src="https://user-images.githubusercontent.com/70828596/177634872-465718da-6f2d-4346-bbaa-409fb583e780.png">