### PR TITLE
docs: correct spelling of  user

### DIFF
--- a/web/spec/combined.json
+++ b/web/spec/combined.json
@@ -2754,7 +2754,7 @@
                       },
                       "comment": {
                         "shortText": "Gets the current user details.",
-                        "text": "This method is called by the GoTrueClient `update` where\nthe jwt is set to this.currentSession.access_token\nand therefore, acts like getting the currently authenticated used\n"
+                        "text": "This method is called by the GoTrueClient `update` where\nthe jwt is set to this.currentSession.access_token\nand therefore, acts like getting the currently authenticated user\n"
                       },
                       "parameters": [
                         {
@@ -27054,7 +27054,7 @@
                   "flags": {},
                   "comment": {
                     "shortText": "Gets the current user details.",
-                    "text": "This method is called by the GoTrueClient `update` where\nthe jwt is set to this.currentSession.access_token\nand therefore, acts like getting the currently authenticated used\n"
+                    "text": "This method is called by the GoTrueClient `update` where\nthe jwt is set to this.currentSession.access_token\nand therefore, acts like getting the currently authenticated user\n"
                   },
                   "parameters": [
                     {

--- a/web/spec/gotrue.json
+++ b/web/spec/gotrue.json
@@ -1484,7 +1484,7 @@
 							"flags": {},
 							"comment": {
 								"shortText": "Gets the current user details.",
-								"text": "This method is called by the GoTrueClient `update` where\nthe jwt is set to this.currentSession.access_token\nand therefore, acts like getting the currently authenticated used\n"
+								"text": "This method is called by the GoTrueClient `update` where\nthe jwt is set to this.currentSession.access_token\nand therefore, acts like getting the currently authenticated user\n"
 							},
 							"parameters": [
 								{

--- a/web/spec/supabase.json
+++ b/web/spec/supabase.json
@@ -2751,7 +2751,7 @@
 									},
 									"comment": {
 										"shortText": "Gets the current user details.",
-										"text": "This method is called by the GoTrueClient `update` where\nthe jwt is set to this.currentSession.access_token\nand therefore, acts like getting the currently authenticated used\n"
+										"text": "This method is called by the GoTrueClient `update` where\nthe jwt is set to this.currentSession.access_token\nand therefore, acts like getting the currently authenticated user\n"
 									},
 									"parameters": [
 										{


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

corrected a typo in [auth.api.getUser](https://supabase.com/docs/reference/javascript/auth-api-getuser) doc

![image](https://user-images.githubusercontent.com/47713814/177646012-13bf4ccd-10ff-456e-8d7e-0afe1c43c4ef.png)
