### PR TITLE
docs(guides): Add architecture blog post

### DIFF
--- a/web/docs/guides/examples.mdx
+++ b/web/docs/guides/examples.mdx
@@ -144,6 +144,7 @@ Build a basic Todo List with Supabase and your favorite frontend framework:
 - Supabase Schema Visualizer. [Blog](https://dev.to/zernonia/supabase-schema-visualizer-no-installation-login-49kg)
 - Create a real-time UI using Next.js + Supabase. [Blog](https://pablopunk.com/posts/how-to-create-a-real-time-ui-with-nextjs-and-supabase)
 - How to add Twitter auth quickly with Supabase to your Next.js site ⚡ [Blog](https://blog.avneesh.tech/how-to-add-twitter-auth-quickly-with-supabase-to-your-nextjs-site)
+- Under the hood: Architecture and Technology Stack of Supabase ⚡ [Blog](https://www.workingsoftware.dev/tech-stack-and-architecture-of-supabase/)
 
 ### Podcasts
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

* Update Examples and Resources
* Add blog post about architecture and tech stack of Supabase (see https://www.workingsoftware.dev/tech-stack-and-architecture-of-supabase/)

## What is the current behavior?

-

## What is the new behavior?

-

## Additional context

If you find any misunderstanding about Supabase architecture or tech stack in this blog post, please write me 😀