### PR TITLE
Docs update: [with-react] remove unnecessary updateProfile call

### DIFF
--- a/web/docs/guides/with-react.mdx
+++ b/web/docs/guides/with-react.mdx
@@ -527,7 +527,6 @@ return (
       size={150}
       onUpload={(url) => {
         setAvatarUrl(url)
-        updateProfile({ username, website, avatar_url: url })
       }}
     />
     {/* ... */}


### PR DESCRIPTION
In this quickstart guide example, updateProfile is expecting an event object as argument and will throw an error if called with something different. What's more, you can't call the updateProfile function after calling setAvatarUrl because useState set methods are effectively async - accessing the useState values from updateProfile would result in old values. As none of the other input fields update the profile when changed, maybe best to just remove this line.
