### PR TITLE
Storage explorer improvements for large folders

### DIFF
--- a/studio/localStores/storageExplorer/StorageExplorerStore.js
+++ b/studio/localStores/storageExplorer/StorageExplorerStore.js
@@ -46,7 +46,7 @@ const LIMIT = 200
 const OFFSET = 0
 const DEFAULT_EXPIRY = 10 * 365 * 24 * 60 * 60 // in seconds, default to 1 year
 const PREVIEW_SIZE_LIMIT = 10000000 // 10MB
-const BATCH_SIZE = 100
+const BATCH_SIZE = 10
 const EMPTY_FOLDER_PLACEHOLDER_FILE_NAME = '.emptyFolderPlaceholder'
 
 class StorageExplorerStore {

--- a/studio/localStores/storageExplorer/StorageExplorerStore.js
+++ b/studio/localStores/storageExplorer/StorageExplorerStore.js
@@ -1126,11 +1126,13 @@ class StorageExplorerStore {
           .concat(pathSegments.slice(columnIndex + 1))
           .join('/')
         return () => {
-          return new Promise(async (resolve, reject) => {
+          return new Promise(async (resolve) => {
             const { error } = await this.supabaseClient.storage
               .from(this.selectedBucket.name)
               .move(fromPath, toPath)
-            if (error) reject()
+              if (error) {
+                toast.error(`Failed to move ${fromPath} to the new folder`)
+              }
             resolve()
           })
         }

--- a/studio/localStores/storageExplorer/StorageExplorerStore.js
+++ b/studio/localStores/storageExplorer/StorageExplorerStore.js
@@ -1116,6 +1116,7 @@ class StorageExplorerStore {
       this.updateRowStatus(originalName, STORAGE_ROW_STATUS.LOADING, columnIndex, newName)
       const files = await this.getAllItemsAlongFolder(folder)
 
+      let hasErrors = false
       // Make this batched promises into a reusable function for storage, i think this will be super helpful
       const promises = files.map((file) => {
         const fromPath = `${file.prefix}/${file.name}`
@@ -1131,6 +1132,7 @@ class StorageExplorerStore {
               .from(this.selectedBucket.name)
               .move(fromPath, toPath)
               if (error) {
+                hasErrors = true
                 toast.error(`Failed to move ${fromPath} to the new folder`)
               }
             resolve()
@@ -1147,7 +1149,11 @@ class StorageExplorerStore {
           await Promise.all(nextBatch.map((batch) => batch()))
         }, Promise.resolve())
 
-        toast.success(`Successfully renamed folder to ${newName}`)
+        if (!hasErrors) {
+          toast.success(`Successfully renamed folder to ${newName}`)
+        } else {
+          toast.error(`Renamed folder to ${newName} with some errors`)
+        }
         await this.refetchAllOpenedFolders()
 
         // Clear file preview cache if the moved file exists in the cache

--- a/studio/localStores/storageExplorer/StorageExplorerStore.js
+++ b/studio/localStores/storageExplorer/StorageExplorerStore.js
@@ -1183,9 +1183,18 @@ class StorageExplorerStore {
     }
 
     const options = { limit: LIMIT, offset: OFFSET, sortBy: { column: this.sortBy, order: this.sortByOrder } }
-    const { data: folderContents } = await this.supabaseClient.storage
-      .from(this.selectedBucket.name)
-      .list(formattedPathToFolder, options)
+    let folderContents = []
+
+      for (;;) {
+        const { data } = await this.supabaseClient.storage
+          .from(this.selectedBucket.name)
+          .list(formattedPathToFolder, options)
+        folderContents = folderContents.concat(data)
+        options.offset += options.limit
+        if (data.length < options.limit) {
+          break
+        }
+      }
 
     const subfolders = folderContents?.filter((item) => isNull(item.id)) ?? []
     const folderItems = folderContents?.filter((item) => !isNull(item.id)) ?? []


### PR DESCRIPTION
- reduces batch size for move and delete to 10. This is slower but we dont run into rate limits and reduces the number of 502s we get from the backend. 
- Deletes and Moves are best effort. One file not being moved to the new folder doesn't block the entire move operation. 
- Only the first 200 files in each folder were being moved previously. Now all files are moved / deleted.

With this PR, I was able to upload, rename and delete a folder with 14k files without any issue. 