### PR TITLE
fix: docs custom css changed for searchBox

### DIFF
--- a/web/src/css/custom.css
+++ b/web/src/css/custom.css
@@ -1383,6 +1383,25 @@ details summary:hover {
 /*
 * typesense doc search input
 */
+
+div[class^='searchBox_'] {
+  position: inherit !important;
+}
+
+div[class^='searchBox_'] button {
+  padding: 8px 14px !important;
+  font-size: inherit !important;
+}
+
+div[class^='searchBox_'] svg {
+  width: 16px;
+  height: 16px;
+}
+
+/*
+* typesense doc search input - for reference
+
+
 .searchBox_node_modules-\@docusaurus-theme-classic-lib-theme-Navbar-Search-styles-module {
   padding: 0 !important;
 }
@@ -1403,3 +1422,5 @@ details summary:hover {
   width: 16px;
   height: 16px;
 }
+
+*/


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs bug

## What is the current behavior?

On a mobile device/small screen the search input drifts under the header:

<img width="811" alt="Screenshot 2022-07-07 at 15 47 24" src="https://user-images.githubusercontent.com/22655069/177802900-960bf323-fcd4-4665-999c-11484461e603.png">

## What is the new behavior?

Changing the `searchBox` containers as mentioned by @burmecia aligns the header:

<img width="811" alt="Screenshot 2022-07-07 at 15 47 36" src="https://user-images.githubusercontent.com/22655069/177803232-f83ed0f1-96ac-4af6-8b76-3a818a17f747.png">

Also the other customised css linking to `searchBox_node_modules` has been changed.
## Additional context

Linked with issue #7381 
