### PR TITLE
fix: aligned the behavior of signUp with the most recent gotrue-dart

### DIFF
--- a/web/spec/dart.yml
+++ b/web/spec/dart.yml
@@ -155,7 +155,7 @@ pages:
       Creates a new user.
     notes: |
       - By default, the user will need to verify their email address before logging in. If you would like to change this, you can disable "Email Confirmations" by going to Authentication -> Settings on [app.supabase.com](https://app.supabase.com)
-      - If "Email Confirmations" is turned on, both a `user` and a `session` will be null
+      - If "Email Confirmations" is turned on, a user is returned but session will be null
       - If "Email Confirmations" is turned off, both a `user` and a `session` will be returned
       - When the user confirms their email address, they will be redirected to localhost:3000 by default. To change this, you can go to Authentication -> Settings on [app.supabase.com](https://app.supabase.com)
     examples:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes the sentence of the Dart SDK on the docs to be aligned with the most up to date dart SDK behavior. 

## What is the current behavior?

The behavior on the docs is old. 

## What is the new behavior?

The description on the docs is aligned with the behavior of dart SDK >= 0.2.0. 

## Additional context

fixes https://github.com/supabase/gotrue/issues/529
