### PR TITLE
fix: studio log explorer changes

### DIFF
--- a/studio/components/interfaces/Settings/Logs/LogsQueryPanel.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogsQueryPanel.tsx
@@ -63,7 +63,7 @@ bg-panel-header-light dark:bg-panel-header-dark
           <Dropdown
             side="bottom"
             align="start"
-            overlay={Object.values(LogsTableName).map((source) => (
+            overlay={Object.values(LogsTableName).sort((a, b) => a.localeCompare(b)).map((source) => (
               <Dropdown.Item key={source} onClick={() => onSelectSource(source)}>
                 <div className="flex flex-col gap-1">
                   <span className="font-mono text-scale-1100 font-bold">{source}</span>
@@ -76,11 +76,11 @@ bg-panel-header-light dark:bg-panel-header-dark
               Insert source
             </Button>
           </Dropdown>
-
+              {console.log(templates)}
           <Dropdown
             side="bottom"
             align="start"
-            overlay={templates.map((template: LogTemplate) => (
+            overlay={templates.sort((a, b) => a.label!.localeCompare(b.label!)).map((template: LogTemplate) => (
               <Dropdown.Item key={template.label} onClick={() => onSelectTemplate(template)}>
                 <Typography.Text>{template.label}</Typography.Text>
               </Dropdown.Item>

--- a/studio/components/interfaces/Settings/Logs/LogsQueryPanel.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogsQueryPanel.tsx
@@ -63,28 +63,32 @@ bg-panel-header-light dark:bg-panel-header-dark
           <Dropdown
             side="bottom"
             align="start"
-            overlay={Object.values(LogsTableName).sort((a, b) => a.localeCompare(b)).map((source) => (
-              <Dropdown.Item key={source} onClick={() => onSelectSource(source)}>
-                <div className="flex flex-col gap-1">
-                  <span className="font-mono text-scale-1100 font-bold">{source}</span>
-                  <span className="text-scale-1100">{LOGS_SOURCE_DESCRIPTION[source]}</span>
-                </div>
-              </Dropdown.Item>
-            ))}
+            overlay={Object.values(LogsTableName)
+              .sort((a, b) => a.localeCompare(b))
+              .map((source) => (
+                <Dropdown.Item key={source} onClick={() => onSelectSource(source)}>
+                  <div className="flex flex-col gap-1">
+                    <span className="font-mono text-scale-1100 font-bold">{source}</span>
+                    <span className="text-scale-1100">{LOGS_SOURCE_DESCRIPTION[source]}</span>
+                  </div>
+                </Dropdown.Item>
+              ))}
           >
             <Button as="span" type="default" iconRight={<IconChevronDown />}>
               Insert source
             </Button>
           </Dropdown>
-              {console.log(templates)}
+
           <Dropdown
             side="bottom"
             align="start"
-            overlay={templates.sort((a, b) => a.label!.localeCompare(b.label!)).map((template: LogTemplate) => (
-              <Dropdown.Item key={template.label} onClick={() => onSelectTemplate(template)}>
-                <Typography.Text>{template.label}</Typography.Text>
-              </Dropdown.Item>
-            ))}
+            overlay={templates
+              .sort((a, b) => a.label!.localeCompare(b.label!))
+              .map((template: LogTemplate) => (
+                <Dropdown.Item key={template.label} onClick={() => onSelectTemplate(template)}>
+                  <Typography.Text>{template.label}</Typography.Text>
+                </Dropdown.Item>
+              ))}
           >
             <Button as="span" type="default" iconRight={<IconChevronDown />}>
               Templates

--- a/studio/components/interfaces/Settings/Logs/LogsQueryPanel.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogsQueryPanel.tsx
@@ -66,7 +66,7 @@ bg-panel-header-light dark:bg-panel-header-dark
             overlay={Object.values(LogsTableName).map((source) => (
               <Dropdown.Item key={source} onClick={() => onSelectSource(source)}>
                 <div className="flex flex-col gap-1">
-                  <span className="font-mono text-white font-bold">{source}</span>
+                  <span className="font-mono text-scale-1100 font-bold">{source}</span>
                   <span className="text-scale-1100">{LOGS_SOURCE_DESCRIPTION[source]}</span>
                 </div>
               </Dropdown.Item>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Studio bug fixes and cleaning up

## What is the current behavior?

Currently on the log explorer the Sources titles are not displaying on a white background:

<img width="1009" alt="Screenshot 2022-07-08 at 16 30 41" src="https://user-images.githubusercontent.com/22655069/178023863-6e6f3586-cd68-4abb-8095-a7299b5a5e27.png">

Also the sort order is not alphabetical. This is also the same on the Templates list:

<img width="1009" alt="Screenshot 2022-07-08 at 16 32 13" src="https://user-images.githubusercontent.com/22655069/178024442-20ea0ae0-607a-4fe2-8bd4-0af3aba569a0.png">


## What is the new behavior?

The Source titles are now appearing on a white background and also the sort order has been changed:

<img width="1009" alt="Screenshot 2022-07-08 at 16 32 52" src="https://user-images.githubusercontent.com/22655069/178024221-a34041e8-d451-4927-bcd8-af47dd4fb535.png">

The sort order has also been changed on the Templates:

<img width="1009" alt="Screenshot 2022-07-08 at 16 32 13" src="https://user-images.githubusercontent.com/22655069/178024136-b923a07a-31da-45d4-ab6a-c672cc0a77f3.png">


## Additional context

Add any other context or screenshots.
