### PR TITLE
Fix: broken link in docs

### DIFF
--- a/web/docs/reference.mdx
+++ b/web/docs/reference.mdx
@@ -42,7 +42,7 @@ The Supabase Reference Docs provide technical descriptions of the products and h
   <div class="row is-multiline">
     {/* Examples - coming soon */}
     <div class="col col--6">
-      <Link class="card" to="/docs/reference/tools/auth" style={{ height: '100%' }}>
+      <Link class="card" to="/docs/guides/auth" style={{ height: '100%' }}>
         <div class="card__body">
           <h4>Auth</h4>
           <p>Auth reference.</p>
@@ -51,7 +51,7 @@ The Supabase Reference Docs provide technical descriptions of the products and h
     </div>
     {/* CLI */}
     <div class="col col--6">
-      <Link class="card" to="/docs/reference/tools/auth" style={{ height: '100%' }}>
+      <Link class="card" to="/docs/guides/database/connecting-to-postgres#finding-the-connection-pool-config" style={{ height: '100%' }}>
         <div class="card__body">
           <h4>Connection Pool</h4>
           <p>PgBouncer reference docs.</p>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix broken link in docs

## What is the current behavior?

Fix https://github.com/supabase/supabase/issues/7639
Broken

## What is the new behavior?

Not broken

## Additional context

Not 100% sure that this was what the link was supposed to go to.