### PR TITLE
Reorder to match diagram reading order

### DIFF
--- a/web/docs/guides/hosting/overview.mdx
+++ b/web/docs/guides/hosting/overview.mdx
@@ -22,14 +22,16 @@ If the tool doesn't exist, we build and open source it ourselves.
 
 ![Supabase Architecture](/img/supabase-architecture.png)
 
-
-- [PostgreSQL](https://www.postgresql.org/) is an object-relational database system with over 30 years of active development that has earned it a strong reputation for reliability, feature robustness, and performance.
-- [Realtime](https://github.com/supabase/realtime) is an Elixir server that allows you to listen to PostgreSQL inserts, updates, and deletes using websockets. Realtime polls Postgres' built-in replication functionality for database changes, converts changes to JSON, then broadcasts the JSON over websockets to authorized clients.
+- [Kong](https://github.com/Kong/kong) is a cloud-native API gateway.
+- [GoTrue](https://github.com/netlify/gotrue) is an SWT based API for managing users and issuing SWT tokens.
 - [PostgREST](http://postgrest.org/) is a web server that turns your PostgreSQL database directly into a RESTful API
+- [Realtime](https://github.com/supabase/realtime) is an Elixir server that allows you to listen to PostgreSQL inserts, updates, and deletes using websockets. Realtime polls Postgres' built-in replication functionality for database changes, converts changes to JSON, then broadcasts the JSON over websockets to authorized clients.
 - [Storage](https://github.com/supabase/storage-api) provides a RESTful interface for managing Files stored in S3, using Postgres to manage permissions.
 - [postgres-meta](https://github.com/supabase/postgres-meta) is a RESTful API for managing your Postgres, allowing you to fetch tables, add roles, and run queries, etc.
-- [GoTrue](https://github.com/netlify/gotrue) is an SWT based API for managing users and issuing SWT tokens.
-- [Kong](https://github.com/Kong/kong) is a cloud-native API gateway.
+- [PostgreSQL](https://www.postgresql.org/) is an object-relational database system with over 30 years of active development that has earned it a strong reputation for reliability, feature robustness, and performance.
+
+
+
 
 
 ## Configuration


### PR DESCRIPTION
## What kind of change does this PR introduce?

Making docs Architecture diagram's visual order match documentation bulleted list order.

## What is the current behavior?

Current docs are in a jumbled and somewhat reverse order to the visual order in the diagram

## What is the new behavior?

The order of the diagram and the bulleted list is now consistent.

## Additional context

PR Roughly reverses the order so bulleted items below the diagram read in the same order as the diagram. 

Old order
<img width="618" alt="image" src="https://user-images.githubusercontent.com/119403/178921878-65f8d79a-d435-4c81-b11e-31ee9bbde324.png">

