### PR TITLE
feat: Add support for iOS deep-links in redirect URLs

### DIFF
--- a/studio/components/interfaces/Auth/Auth.constants.ts
+++ b/studio/components/interfaces/Auth/Auth.constants.ts
@@ -8,7 +8,12 @@
 //  "uptime-monitor-fe.vercel.app"
 //  "https://uptime-monitor-fe.vercel.app/"
 export const domainRegexStrict =
-  /^((ftp|http|https):\/\/)?(www.)?(?!.*(ftp|http|https|www.))[a-zA-Z0-9_-]+(\.[a-zA-Z]+)+((\/)[\w#]+)*(\/\w+\?[a-zA-Z0-9_]+=\w+(&[a-zA-Z0-9_]+=\w+)*)?$/gm
+  /^((ftp|http|https):\/\/)?(www.)?(?!.*(ftp|http|https|www.))[a-zA-Z0-9_-]+(\.[a-zA-Z]+)+((\/)[\w#]+)*(\/\w+\?[a-zA-Z0-9_]+=\w+(&[a-zA-Z0-9_]+=\w+)*)?$/m
 
 // [Joshen] This regex allows for localhost as well, less strict
-export const domainRegex = /^(ftp|http|https):\/\/\w+(\.\w+)*(:[0-9]+)?\/?(\/[.\w]*)*$/g
+export const webRegex = /^(ftp|http|https):\/\/\w+(\.\w+)*(:[0-9]+)?\/?(\/[.\w]*)*$/i
+
+// iOS deep linking scheme https://benoitpasquier.com/deep-linking-url-scheme-ios/
+export const appRegex = /^[a-z0-9]+([.][a-z0-9]+)*:\/(\/[-a-z0-9._~!$&'()*+,;=:@%]+)+$/i
+
+export const domainRegex = new RegExp(`(${webRegex.source})|(${appRegex.source})`, 'i')


### PR DESCRIPTION
## What kind of change does this PR introduce?

Redirect URLs are not only regular web URLs -- in iOS applications they have the structure of:

```
com.domain.app://view/inside/app
```

Some of our users use Supabase in iOS applications, and this PR fixes the new dashboard to support this type of URLs.

## What is the current behavior?

Treats deep-link iOS URLs as invalid.

