### PR TITLE
fix: 404 page styling

### DIFF
--- a/apps/www/pages/404.tsx
+++ b/apps/www/pages/404.tsx
@@ -41,7 +41,7 @@ const Error404 = () => {
         </div>
         <div className="absolute">
           <h1
-            className={`select-none opacity-[5%] filter transition duration-200 text-scale-1200 text-9xl ${
+            className={`text-scale-1200 select-none text-9xl opacity-[5%] filter transition duration-200 ${
               show404 ? 'blur-sm' : 'blur-none'
             }`}
           >

--- a/apps/www/pages/404.tsx
+++ b/apps/www/pages/404.tsx
@@ -41,7 +41,7 @@ const Error404 = () => {
         </div>
         <div className="absolute">
           <h1
-            className={`text-scale-1200 select-none text-9xl opacity-[5%] filter transition duration-200 ${
+            className={`text-scale-1200 select-none text-[12rem] opacity-[15%] filter transition duration-200 sm:text-[16rem] ${
               show404 ? 'blur-sm' : 'blur-none'
             }`}
           >

--- a/apps/www/pages/404.tsx
+++ b/apps/www/pages/404.tsx
@@ -41,10 +41,9 @@ const Error404 = () => {
         </div>
         <div className="absolute">
           <h1
-            className={`select-none opacity-[5%] filter transition duration-200 ${
+            className={`select-none opacity-[5%] filter transition duration-200 text-scale-1200 text-9xl ${
               show404 ? 'blur-sm' : 'blur-none'
             }`}
-            style={{ fontSize: '28rem' }}
           >
             404
           </h1>

--- a/apps/www/pages/404.tsx
+++ b/apps/www/pages/404.tsx
@@ -41,7 +41,7 @@ const Error404 = () => {
         </div>
         <div className="absolute">
           <h1
-            className={`text-scale-1200 select-none text-[14rem] sm:text-[18rem] lg:text-[28rem] opacity-[5%] filter transition duration-200 ${
+            className={`text-scale-1200 select-none text-[14rem] opacity-[5%] filter transition duration-200 sm:text-[18rem] lg:text-[28rem] ${
               show404 ? 'blur-sm' : 'blur-none'
             }`}
           >

--- a/apps/www/pages/404.tsx
+++ b/apps/www/pages/404.tsx
@@ -41,7 +41,7 @@ const Error404 = () => {
         </div>
         <div className="absolute">
           <h1
-            className={`text-scale-1200 select-none text-[12rem] opacity-[15%] filter transition duration-200 sm:text-[16rem] ${
+            className={`text-scale-1200 select-none text-[14rem] sm:text-[18rem] lg:text-[28rem] opacity-[5%] filter transition duration-200 ${
               show404 ? 'blur-sm' : 'blur-none'
             }`}
           >


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase website fix

## What is the current behavior?

On a mobile device if you get redirected to the 404 page you get the following:

<img width="336" alt="Screenshot 2022-07-14 at 15 14 23" src="https://user-images.githubusercontent.com/22655069/179004027-6e455b13-dd20-4b0b-a0c8-abdad3ed4b3c.png">

As you can see the content is not aligned centrally and also the 404 background text is not readable

## What is the new behavior?

<img width="336" alt="Screenshot 2022-07-14 at 15 13 54" src="https://user-images.githubusercontent.com/22655069/179003961-34291428-be6c-4e26-b433-d683e0006ff7.png">

Now the content is central and also the 404 is coming through now
