### PR TITLE
Allow symbols in Auth.constants.ts domainRegex

### DIFF
--- a/studio/components/interfaces/Auth/Auth.constants.ts
+++ b/studio/components/interfaces/Auth/Auth.constants.ts
@@ -11,4 +11,5 @@ export const domainRegexStrict =
   /^((ftp|http|https):\/\/)?(www.)?(?!.*(ftp|http|https|www.))[a-zA-Z0-9_-]+(\.[a-zA-Z]+)+((\/)[\w#]+)*(\/\w+\?[a-zA-Z0-9_]+=\w+(&[a-zA-Z0-9_]+=\w+)*)?$/gm
 
 // [Joshen] This regex allows for localhost as well, less strict
-export const domainRegex = /^(ftp|http|https):\/\/\w+(\.\w+)*(:[0-9]+)?\/?(\/[.\w]*)*$/g
+// [jchekanoff] Updated to allow for valid symbols in urls
+export const domainRegex = /(\b(https?|ftp|file):\/\/)?[-A-Za-z0-9+&@#\/%?=~*_|!:,.;]+[-A-Za-z0-9+&@#\/%=~_|]/gm


### PR DESCRIPTION
As explained in [this Discord thread](https://discord.com/channels/839993398554656828/843999948717555735/997149245826154629) and closes #7691.

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

See issue #7691 

## What is the new behavior?

The regex shown in #7691 should now be accepted.