### PR TITLE
Fix/regex issues in auth settings

### DIFF
--- a/studio/components/interfaces/Auth/Auth.constants.ts
+++ b/studio/components/interfaces/Auth/Auth.constants.ts
@@ -1,6 +1,8 @@
 // [Joshen] Currently using the latter regex as the former is too strict, doesn't support
 // localhost - if we can combine these 2 together that'll be great but my regex-foo isn't too strong
 
+// [MildTomato] Combined everything into domainRegex for now
+
 // Regex from: https://stackoverflow.com/a/68002755/4807782
 // modified to accept numbers in the body of domain though
 // examples of matches:
@@ -12,7 +14,8 @@ const baseDomainRegex =
   /^((ftp|http|https):\/\/)?(www.)?(?!.*(ftp|http|https|www.))[a-zA-Z0-9_-]+(\.[a-zA-Z0-9_-]+)+((\/)[\w#]+)*(\/\w+\?[a-zA-Z0-9_]+=\w+(&[a-zA-Z0-9_]+=\w+)*)?$/gm
 
 // [Joshen] This regex allows for localhost as well, less strict
-// export const webRegex = /^(ftp|http|https):\/\/\w+(\.\w+)*(:[0-9]+)?\/?(\/[.\w]*)*$/i
+// [MildTomato] no longer used
+const webRegex = /^(ftp|http|https):\/\/\w+(\.\w+)*(:[0-9]+)?\/?(\/[.\w]*)*$/i
 
 // iOS deep linking scheme https://benoitpasquier.com/deep-linking-url-scheme-ios/
 const appRegex = /^[a-z0-9]+([.][a-z0-9]+)*:\/(\/[-a-z0-9._~!$&'()*+,;=:@%]+)+$/i
@@ -21,7 +24,6 @@ const appRegex = /^[a-z0-9]+([.][a-z0-9]+)*:\/(\/[-a-z0-9._~!$&'()*+,;=:@%]+)+$/
 const localhostRegex = /^(?:^|\s)((https?:\/\/)?(?:localhost|[\w-]+(?:\.[\w-]+)+)(:\d+)?(\/\S*)?)/i
 
 // combine the above regexes
-// export const domainRegex = new RegExp(`(${webRegex.source})|(${appRegex.source})`, 'i')
 export const domainRegex = new RegExp(
   `(${baseDomainRegex.source})|(${localhostRegex.source})|(${appRegex.source})`,
   'i'

--- a/studio/components/interfaces/Auth/Auth.constants.ts
+++ b/studio/components/interfaces/Auth/Auth.constants.ts
@@ -2,18 +2,21 @@
 // localhost - if we can combine these 2 together that'll be great but my regex-foo isn't too strong
 
 // Regex from: https://stackoverflow.com/a/68002755/4807782
+// modified to accept numbers in the body of domain though
 // examples of matches:
 //  "vercel.com"
 //  "www.vercel.com"
 //  "uptime-monitor-fe.vercel.app"
 //  "https://uptime-monitor-fe.vercel.app/"
 export const domainRegexStrict =
-  /^((ftp|http|https):\/\/)?(www.)?(?!.*(ftp|http|https|www.))[a-zA-Z0-9_-]+(\.[a-zA-Z]+)+((\/)[\w#]+)*(\/\w+\?[a-zA-Z0-9_]+=\w+(&[a-zA-Z0-9_]+=\w+)*)?$/m
+  /^((ftp|http|https):\/\/)?(www.)?(?!.*(ftp|http|https|www.))[a-zA-Z0-9_-]+(\.[a-zA-Z0-9_-]+)+((\/)[\w#]+)*(\/\w+\?[a-zA-Z0-9_]+=\w+(&[a-zA-Z0-9_]+=\w+)*)?$/gm
 
 // [Joshen] This regex allows for localhost as well, less strict
 export const webRegex = /^(ftp|http|https):\/\/\w+(\.\w+)*(:[0-9]+)?\/?(\/[.\w]*)*$/i
 
 // iOS deep linking scheme https://benoitpasquier.com/deep-linking-url-scheme-ios/
 export const appRegex = /^[a-z0-9]+([.][a-z0-9]+)*:\/(\/[-a-z0-9._~!$&'()*+,;=:@%]+)+$/i
+
+// combine the above regexes
 
 export const domainRegex = new RegExp(`(${webRegex.source})|(${appRegex.source})`, 'i')

--- a/studio/components/interfaces/Auth/Auth.constants.ts
+++ b/studio/components/interfaces/Auth/Auth.constants.ts
@@ -8,15 +8,21 @@
 //  "www.vercel.com"
 //  "uptime-monitor-fe.vercel.app"
 //  "https://uptime-monitor-fe.vercel.app/"
-export const domainRegexStrict =
+const baseDomainRegex =
   /^((ftp|http|https):\/\/)?(www.)?(?!.*(ftp|http|https|www.))[a-zA-Z0-9_-]+(\.[a-zA-Z0-9_-]+)+((\/)[\w#]+)*(\/\w+\?[a-zA-Z0-9_]+=\w+(&[a-zA-Z0-9_]+=\w+)*)?$/gm
 
 // [Joshen] This regex allows for localhost as well, less strict
-export const webRegex = /^(ftp|http|https):\/\/\w+(\.\w+)*(:[0-9]+)?\/?(\/[.\w]*)*$/i
+// export const webRegex = /^(ftp|http|https):\/\/\w+(\.\w+)*(:[0-9]+)?\/?(\/[.\w]*)*$/i
 
 // iOS deep linking scheme https://benoitpasquier.com/deep-linking-url-scheme-ios/
-export const appRegex = /^[a-z0-9]+([.][a-z0-9]+)*:\/(\/[-a-z0-9._~!$&'()*+,;=:@%]+)+$/i
+const appRegex = /^[a-z0-9]+([.][a-z0-9]+)*:\/(\/[-a-z0-9._~!$&'()*+,;=:@%]+)+$/i
+
+// Regex from https://stackoverflow.com/a/18696953/4807782
+const localhostRegex = /^(?:^|\s)((https?:\/\/)?(?:localhost|[\w-]+(?:\.[\w-]+)+)(:\d+)?(\/\S*)?)/i
 
 // combine the above regexes
-
-export const domainRegex = new RegExp(`(${webRegex.source})|(${appRegex.source})`, 'i')
+// export const domainRegex = new RegExp(`(${webRegex.source})|(${appRegex.source})`, 'i')
+export const domainRegex = new RegExp(
+  `(${baseDomainRegex.source})|(${localhostRegex.source})|(${appRegex.source})`,
+  'i'
+)

--- a/studio/components/interfaces/Auth/SmtpForm/SmtpForm.constants.ts
+++ b/studio/components/interfaces/Auth/SmtpForm/SmtpForm.constants.ts
@@ -1,18 +1,3 @@
-/**
- * domain and IP address regex
- *
- * example of matches:
- *
- * "vercel.com"
- * "www.vercel.com"
- * "uptime-monitor-fe.vercel.app"
- * "https://uptime-monitor-fe.vercel.app/"
- * "127.0.0.0"
- *
- */
-export const domainRegex =
-  /^((ftp|http|https):\/\/)?(www.)?(?!.*(ftp|http|https|www.))[a-zA-Z0-9_-]+(\.[a-zA-Z]+)+((\/)[\w#]+)*(\/\w+\?[a-zA-Z0-9_]+=\w+(&[a-zA-Z0-9_]+=\w+)*)?$|^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.){3}(25[0-5]|(2[0-4]|1\d|[1-9]|)\d)$/gm
-
 export const defaultDisabledSmtpFormValues = {
   SMTP_ADMIN_EMAIL: null,
   SMTP_SENDER_NAME: null,

--- a/studio/components/interfaces/Auth/SmtpForm/SmtpForm.tsx
+++ b/studio/components/interfaces/Auth/SmtpForm/SmtpForm.tsx
@@ -12,7 +12,8 @@ import {
   FormSectionContent,
   FormSectionLabel,
 } from 'components/ui/Forms'
-import { domainRegex, defaultDisabledSmtpFormValues } from './SmtpForm.constants'
+import { defaultDisabledSmtpFormValues } from './SmtpForm.constants'
+import { domainRegexStrict } from './../Auth.constants'
 import { isSmtpEnabled, generateFormValues } from './SmtpForm.utils'
 
 const SmtpForm = () => {
@@ -50,7 +51,7 @@ const SmtpForm = () => {
       },
       then: (schema) =>
         schema
-          .matches(domainRegex, 'Must be a valid URL or IP address')
+          .matches(domainRegexStrict, 'Must be a valid URL or IP address')
           .required('Host URL is required.'),
       otherwise: (schema) => schema,
     }),

--- a/studio/components/interfaces/Auth/SmtpForm/SmtpForm.tsx
+++ b/studio/components/interfaces/Auth/SmtpForm/SmtpForm.tsx
@@ -13,7 +13,7 @@ import {
   FormSectionLabel,
 } from 'components/ui/Forms'
 import { defaultDisabledSmtpFormValues } from './SmtpForm.constants'
-import { domainRegexStrict } from './../Auth.constants'
+import { domainRegex } from './../Auth.constants'
 import { isSmtpEnabled, generateFormValues } from './SmtpForm.utils'
 
 const SmtpForm = () => {
@@ -51,7 +51,7 @@ const SmtpForm = () => {
       },
       then: (schema) =>
         schema
-          .matches(domainRegexStrict, 'Must be a valid URL or IP address')
+          .matches(domainRegex, 'Must be a valid URL or IP address')
           .required('Host URL is required.'),
       otherwise: (schema) => schema,
     }),


### PR DESCRIPTION
domain regex in auth settings now works for patterns like

`localhost:3000`
`subdomain.domain123.com`

now works in redirect urls, auth provider urls, and SMTP host inputs
