### PR TITLE
Fix/regex smtp domain

### DIFF
--- a/studio/components/interfaces/Auth/Auth.constants.ts
+++ b/studio/components/interfaces/Auth/Auth.constants.ts
@@ -5,8 +5,10 @@
 //  "www.vercel.com"
 //  "uptime-monitor-fe.vercel.app"
 //  "https://uptime-monitor-fe.vercel.app/"
+
+// Supports wildcards, port numbers at the end, paths at the end and query params
 const baseDomainRegex =
-  /^((ftp|http|https):\/\/)?(www.)?(?!.*(ftp|http|https|www.))[a-zA-Z0-9_*-]+(\.[a-zA-Z0-9_*-]+)+((\/)[\w#]+)*(\/\w+\?[a-zA-Z0-9_]+=\w+(&[a-zA-Z0-9_]+=\w+)*)?+(?:\.[a-z]+)*(?::\d+)?(?![^<]*(?:<\/\w+>|\/?>))(.*)?\/?(.)*$/gm
+  /^((ftp|http|https):\/\/)?(www.)?(?!.*(ftp|http|https|www.))[a-zA-Z0-9_*-]+(\.[a-zA-Z0-9_*-]+)+((\/)[\w#]+)*(\/\w+\?[a-zA-Z0-9_]+=\w+(&[a-zA-Z0-9_]+=\w+)*)+(?:\.[a-z]+)*(?::\d+)?(?![^<]*(?:<\/\w+>|\/?>))(.*)?\/?(.)*?$/gm
 
 // iOS deep linking scheme https://benoitpasquier.com/deep-linking-url-scheme-ios/
 const appRegex = /^[a-z0-9]+([.][a-z0-9]+)*:\/(\/[-a-z0-9._~!$&'()*+,;=:@%]+)+$/i

--- a/studio/components/interfaces/Auth/Auth.constants.ts
+++ b/studio/components/interfaces/Auth/Auth.constants.ts
@@ -11,7 +11,14 @@
 //  "uptime-monitor-fe.vercel.app"
 //  "https://uptime-monitor-fe.vercel.app/"
 const baseDomainRegex =
-  /^((ftp|http|https):\/\/)?(www.)?(?!.*(ftp|http|https|www.))[a-zA-Z0-9_-]+(\.[a-zA-Z0-9_-]+)+((\/)[\w#]+)*(\/\w+\?[a-zA-Z0-9_]+=\w+(&[a-zA-Z0-9_]+=\w+)*)?$/gm
+  // v4 - now allows for paths at the end, including query params
+  /^((ftp|http|https):\/\/)?(www.)?(?!.*(ftp|http|https|www.))[a-zA-Z0-9_*-]+(\.[a-zA-Z0-9_*-]+)+((\/)[\w#]+)*(\/\w+\?[a-zA-Z0-9_]+=\w+(&[a-zA-Z0-9_]+=\w+)*)?+(?:\.[a-z]+)*(?::\d+)?(?![^<]*(?:<\/\w+>|\/?>))(.*)?\/?(.)*$/gm
+// v3 - now allows for port numbers at the end
+// /^((ftp|http|https):\/\/)?(www.)?(?!.*(ftp|http|https|www.))[a-zA-Z0-9_*-]+(\.[a-zA-Z0-9_*-]+)+((\/)[\w#]+)*(\/\w+\?[a-zA-Z0-9_]+=\w+(&[a-zA-Z0-9_]+=\w+)*)?+(?:\.[a-z]+)*(?::\d+)?(?![^<]*(?:<\/\w+>|\/?>))$/gm
+// v2 - now supports wildcards. does not allow "ftp"|"http"|"https"|"www" in subdoain though
+// /^((ftp|http|https):\/\/)?(www.)?(?!.*(ftp|http|https|www.))[a-zA-Z0-9_*-]+(\.[a-zA-Z0-9_-]+)+((\/)[\w#]+)*(\/\w+\?[a-zA-Z0-9_]+=\w+(&[a-zA-Z0-9_]+=\w+)*)?$/gm
+// v1
+// /^((ftp|http|https):\/\/)?(www.)?(?!.*(ftp|http|https|www.))[a-zA-Z0-9_-]+(\.[a-zA-Z0-9_-]+)+((\/)[\w#]+)*(\/\w+\?[a-zA-Z0-9_]+=\w+(&[a-zA-Z0-9_]+=\w+)*)?$/gm
 
 // [Joshen] This regex allows for localhost as well, less strict
 // [MildTomato] no longer used
@@ -28,3 +35,5 @@ export const domainRegex = new RegExp(
   `(${baseDomainRegex.source})|(${localhostRegex.source})|(${appRegex.source})`,
   'i'
 )
+
+// zone-www-dot-*-supabase.vercel.app

--- a/studio/components/interfaces/Auth/Auth.constants.ts
+++ b/studio/components/interfaces/Auth/Auth.constants.ts
@@ -35,5 +35,3 @@ export const domainRegex = new RegExp(
   `(${baseDomainRegex.source})|(${localhostRegex.source})|(${appRegex.source})`,
   'i'
 )
-
-// zone-www-dot-*-supabase.vercel.app

--- a/studio/components/interfaces/Auth/Auth.constants.ts
+++ b/studio/components/interfaces/Auth/Auth.constants.ts
@@ -1,6 +1,8 @@
 // [Joshen] Currently using the latter regex as the former is too strict, doesn't support
 // localhost - if we can combine these 2 together that'll be great but my regex-foo isn't too strong
 
+// [MildTomato] Combined everything into domainRegex for now
+
 // Regex from: https://stackoverflow.com/a/68002755/4807782
 // modified to accept numbers in the body of domain though
 // examples of matches:
@@ -12,7 +14,8 @@ const baseDomainRegex =
   /^((ftp|http|https):\/\/)?(www.)?(?!.*(ftp|http|https|www.))[a-zA-Z0-9_-]+(\.[a-zA-Z0-9_-]+)+((\/)[\w#]+)*(\/\w+\?[a-zA-Z0-9_]+=\w+(&[a-zA-Z0-9_]+=\w+)*)?$/gm
 
 // [Joshen] This regex allows for localhost as well, less strict
-// export const webRegex = /^(ftp|http|https):\/\/\w+(\.\w+)*(:[0-9]+)?\/?(\/[.\w]*)*$/i
+// [MildTomato] no longer used
+const webRegex = /^(ftp|http|https):\/\/\w+(\.\w+)*(:[0-9]+)?\/?(\/[.\w]*)*$/i
 
 // iOS deep linking scheme https://benoitpasquier.com/deep-linking-url-scheme-ios/
 const appRegex = /^[a-z0-9]+([.][a-z0-9]+)*:\/(\/[-a-z0-9._~!$&'()*+,;=:@%]+)+$/i
@@ -21,7 +24,6 @@ const appRegex = /^[a-z0-9]+([.][a-z0-9]+)*:\/(\/[-a-z0-9._~!$&'()*+,;=:@%]+)+$/
 const localhostRegex = /^(?:^|\s)((https?:\/\/)?(?:localhost|[\w-]+(?:\.[\w-]+)+)(:\d+)?(\/\S*)?)/i
 
 // combine the above regexes
-// export const domainRegex = new RegExp(`(${webRegex.source})|(${appRegex.source})`, 'i')
 export const domainRegex = new RegExp(
   `(${baseDomainRegex.source})|(${localhostRegex.source})|(${appRegex.source})`,
   'i'

--- a/studio/components/interfaces/Auth/Auth.constants.ts
+++ b/studio/components/interfaces/Auth/Auth.constants.ts
@@ -2,18 +2,21 @@
 // localhost - if we can combine these 2 together that'll be great but my regex-foo isn't too strong
 
 // Regex from: https://stackoverflow.com/a/68002755/4807782
+// modified to accept numbers in the body of domain though
 // examples of matches:
 //  "vercel.com"
 //  "www.vercel.com"
 //  "uptime-monitor-fe.vercel.app"
 //  "https://uptime-monitor-fe.vercel.app/"
 export const domainRegexStrict =
-  /^((ftp|http|https):\/\/)?(www.)?(?!.*(ftp|http|https|www.))[a-zA-Z0-9_-]+(\.[a-zA-Z]+)+((\/)[\w#]+)*(\/\w+\?[a-zA-Z0-9_]+=\w+(&[a-zA-Z0-9_]+=\w+)*)?$/m
+  /^((ftp|http|https):\/\/)?(www.)?(?!.*(ftp|http|https|www.))[a-zA-Z0-9_-]+(\.[a-zA-Z0-9_-]+)+((\/)[\w#]+)*(\/\w+\?[a-zA-Z0-9_]+=\w+(&[a-zA-Z0-9_]+=\w+)*)?$/gm
 
 // [Joshen] This regex allows for localhost as well, less strict
 export const webRegex = /^(ftp|http|https):\/\/\w+(\.\w+)*(:[0-9]+)?\/?(\/[.\w]*)*$/i
 
 // iOS deep linking scheme https://benoitpasquier.com/deep-linking-url-scheme-ios/
 export const appRegex = /^[a-z0-9]+([.][a-z0-9]+)*:\/(\/[-a-z0-9._~!$&'()*+,;=:@%]+)+$/i
+
+// combine the above regexes
 
 export const domainRegex = new RegExp(`(${webRegex.source})|(${appRegex.source})`, 'i')

--- a/studio/components/interfaces/Auth/Auth.constants.ts
+++ b/studio/components/interfaces/Auth/Auth.constants.ts
@@ -13,10 +13,13 @@
 const baseDomainRegex =
   // v4 - now allows for paths at the end, including query params
   /^((ftp|http|https):\/\/)?(www.)?(?!.*(ftp|http|https|www.))[a-zA-Z0-9_*-]+(\.[a-zA-Z0-9_*-]+)+((\/)[\w#]+)*(\/\w+\?[a-zA-Z0-9_]+=\w+(&[a-zA-Z0-9_]+=\w+)*)?+(?:\.[a-z]+)*(?::\d+)?(?![^<]*(?:<\/\w+>|\/?>))(.*)?\/?(.)*$/gm
+
 // v3 - now allows for port numbers at the end
 // /^((ftp|http|https):\/\/)?(www.)?(?!.*(ftp|http|https|www.))[a-zA-Z0-9_*-]+(\.[a-zA-Z0-9_*-]+)+((\/)[\w#]+)*(\/\w+\?[a-zA-Z0-9_]+=\w+(&[a-zA-Z0-9_]+=\w+)*)?+(?:\.[a-z]+)*(?::\d+)?(?![^<]*(?:<\/\w+>|\/?>))$/gm
+
 // v2 - now supports wildcards. does not allow "ftp"|"http"|"https"|"www" in subdoain though
 // /^((ftp|http|https):\/\/)?(www.)?(?!.*(ftp|http|https|www.))[a-zA-Z0-9_*-]+(\.[a-zA-Z0-9_-]+)+((\/)[\w#]+)*(\/\w+\?[a-zA-Z0-9_]+=\w+(&[a-zA-Z0-9_]+=\w+)*)?$/gm
+
 // v1
 // /^((ftp|http|https):\/\/)?(www.)?(?!.*(ftp|http|https|www.))[a-zA-Z0-9_-]+(\.[a-zA-Z0-9_-]+)+((\/)[\w#]+)*(\/\w+\?[a-zA-Z0-9_]+=\w+(&[a-zA-Z0-9_]+=\w+)*)?$/gm
 

--- a/studio/components/interfaces/Auth/Auth.constants.ts
+++ b/studio/components/interfaces/Auth/Auth.constants.ts
@@ -8,15 +8,21 @@
 //  "www.vercel.com"
 //  "uptime-monitor-fe.vercel.app"
 //  "https://uptime-monitor-fe.vercel.app/"
-export const domainRegexStrict =
+const baseDomainRegex =
   /^((ftp|http|https):\/\/)?(www.)?(?!.*(ftp|http|https|www.))[a-zA-Z0-9_-]+(\.[a-zA-Z0-9_-]+)+((\/)[\w#]+)*(\/\w+\?[a-zA-Z0-9_]+=\w+(&[a-zA-Z0-9_]+=\w+)*)?$/gm
 
 // [Joshen] This regex allows for localhost as well, less strict
-export const webRegex = /^(ftp|http|https):\/\/\w+(\.\w+)*(:[0-9]+)?\/?(\/[.\w]*)*$/i
+// export const webRegex = /^(ftp|http|https):\/\/\w+(\.\w+)*(:[0-9]+)?\/?(\/[.\w]*)*$/i
 
 // iOS deep linking scheme https://benoitpasquier.com/deep-linking-url-scheme-ios/
-export const appRegex = /^[a-z0-9]+([.][a-z0-9]+)*:\/(\/[-a-z0-9._~!$&'()*+,;=:@%]+)+$/i
+const appRegex = /^[a-z0-9]+([.][a-z0-9]+)*:\/(\/[-a-z0-9._~!$&'()*+,;=:@%]+)+$/i
+
+// Regex from https://stackoverflow.com/a/18696953/4807782
+const localhostRegex = /^(?:^|\s)((https?:\/\/)?(?:localhost|[\w-]+(?:\.[\w-]+)+)(:\d+)?(\/\S*)?)/i
 
 // combine the above regexes
-
-export const domainRegex = new RegExp(`(${webRegex.source})|(${appRegex.source})`, 'i')
+// export const domainRegex = new RegExp(`(${webRegex.source})|(${appRegex.source})`, 'i')
+export const domainRegex = new RegExp(
+  `(${baseDomainRegex.source})|(${localhostRegex.source})|(${appRegex.source})`,
+  'i'
+)

--- a/studio/components/interfaces/Auth/SmtpForm/SmtpForm.constants.ts
+++ b/studio/components/interfaces/Auth/SmtpForm/SmtpForm.constants.ts
@@ -1,18 +1,3 @@
-/**
- * domain and IP address regex
- *
- * example of matches:
- *
- * "vercel.com"
- * "www.vercel.com"
- * "uptime-monitor-fe.vercel.app"
- * "https://uptime-monitor-fe.vercel.app/"
- * "127.0.0.0"
- *
- */
-export const domainRegex =
-  /^((ftp|http|https):\/\/)?(www.)?(?!.*(ftp|http|https|www.))[a-zA-Z0-9_-]+(\.[a-zA-Z]+)+((\/)[\w#]+)*(\/\w+\?[a-zA-Z0-9_]+=\w+(&[a-zA-Z0-9_]+=\w+)*)?$|^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.){3}(25[0-5]|(2[0-4]|1\d|[1-9]|)\d)$/gm
-
 export const defaultDisabledSmtpFormValues = {
   SMTP_ADMIN_EMAIL: null,
   SMTP_SENDER_NAME: null,

--- a/studio/components/interfaces/Auth/SmtpForm/SmtpForm.tsx
+++ b/studio/components/interfaces/Auth/SmtpForm/SmtpForm.tsx
@@ -1,9 +1,8 @@
+import { Alert, Form, Input, Toggle } from '@supabase/ui'
+import { observer } from 'mobx-react-lite'
 import { useEffect, useState } from 'react'
 import { number, object, string } from 'yup'
-import { observer } from 'mobx-react-lite'
-import { Form, Input, Toggle, Alert } from '@supabase/ui'
 
-import { useStore } from 'hooks'
 import {
   FormActions,
   FormHeader,
@@ -12,9 +11,10 @@ import {
   FormSectionContent,
   FormSectionLabel,
 } from 'components/ui/Forms'
-import { defaultDisabledSmtpFormValues } from './SmtpForm.constants'
+import { useStore } from 'hooks'
 import { domainRegex } from './../Auth.constants'
-import { isSmtpEnabled, generateFormValues } from './SmtpForm.utils'
+import { defaultDisabledSmtpFormValues } from './SmtpForm.constants'
+import { generateFormValues, isSmtpEnabled } from './SmtpForm.utils'
 
 const SmtpForm = () => {
   const { authConfig, ui } = useStore()

--- a/studio/components/interfaces/Auth/SmtpForm/SmtpForm.tsx
+++ b/studio/components/interfaces/Auth/SmtpForm/SmtpForm.tsx
@@ -12,7 +12,8 @@ import {
   FormSectionContent,
   FormSectionLabel,
 } from 'components/ui/Forms'
-import { domainRegex, defaultDisabledSmtpFormValues } from './SmtpForm.constants'
+import { defaultDisabledSmtpFormValues } from './SmtpForm.constants'
+import { domainRegexStrict } from './../Auth.constants'
 import { isSmtpEnabled, generateFormValues } from './SmtpForm.utils'
 
 const SmtpForm = () => {
@@ -50,7 +51,7 @@ const SmtpForm = () => {
       },
       then: (schema) =>
         schema
-          .matches(domainRegex, 'Must be a valid URL or IP address')
+          .matches(domainRegexStrict, 'Must be a valid URL or IP address')
           .required('Host URL is required.'),
       otherwise: (schema) => schema,
     }),

--- a/studio/components/interfaces/Auth/SmtpForm/SmtpForm.tsx
+++ b/studio/components/interfaces/Auth/SmtpForm/SmtpForm.tsx
@@ -13,7 +13,7 @@ import {
   FormSectionLabel,
 } from 'components/ui/Forms'
 import { defaultDisabledSmtpFormValues } from './SmtpForm.constants'
-import { domainRegexStrict } from './../Auth.constants'
+import { domainRegex } from './../Auth.constants'
 import { isSmtpEnabled, generateFormValues } from './SmtpForm.utils'
 
 const SmtpForm = () => {
@@ -51,7 +51,7 @@ const SmtpForm = () => {
       },
       then: (schema) =>
         schema
-          .matches(domainRegexStrict, 'Must be a valid URL or IP address')
+          .matches(domainRegex, 'Must be a valid URL or IP address')
           .required('Host URL is required.'),
       otherwise: (schema) => schema,
     }),

--- a/studio/tests/components/Auth/Auth.constants.test.js
+++ b/studio/tests/components/Auth/Auth.constants.test.js
@@ -1,0 +1,66 @@
+import { domainRegex } from 'components/interfaces/Auth/Auth.constants'
+
+describe('Auth.constants: domainRegex', () => {
+  test('should validate typical URLs', () => {
+    const mockInput1 = 'http://domain.com'
+    const output1 = domainRegex.test(mockInput1)
+    expect(output1).toBe(true)
+
+    const mockInput2 = 'https://supabase.io'
+    const output2 = domainRegex.test(mockInput2)
+    expect(output2).toBe(true)
+
+    const mockInput3 = 'https://new-domain-vercel.com'
+    const output3 = domainRegex.test(mockInput3)
+    expect(output3).toBe(true)
+
+    const mockInput4 = 'www.test-domain.com'
+    const output4 = domainRegex.test(mockInput4)
+    expect(output4).toBe(true)
+  })
+  test('should validate subdomains', () => {
+    const mockInput1 = 'https://app.supabase.com'
+    const output1 = domainRegex.test(mockInput1)
+    expect(output1).toBe(true)
+  })
+  test('should validate localhost URLs', () => {
+    const mockInput1 = 'http://localhost:3000'
+    const output1 = domainRegex.test(mockInput1)
+    expect(output1).toBe(true)
+  })
+  test('should validate URLs with query params', () => {
+    const mockInput1 = 'https://supabase.com?name=test'
+    const output1 = domainRegex.test(mockInput1)
+    expect(output1).toBe(true)
+
+    const mockInput2 = 'https://supabase.com?name=test&description=hello&page=2'
+    const output2 = domainRegex.test(mockInput2)
+    expect(output2).toBe(true)
+  })
+  test('should validate URLs with wildcards', () => {
+    const mockInput1 = 'https://supabase*.com'
+    const output1 = domainRegex.test(mockInput1)
+    expect(output1).toBe(true)
+
+    const mockInput2 = 'https://supabase.com/*'
+    const output2 = domainRegex.test(mockInput2)
+    expect(output2).toBe(true)
+  })
+  test('should invalidate invalid URLs', () => {
+    const mockInput1 = 'supabase'
+    const output1 = domainRegex.test(mockInput1)
+    expect(output1).toBe(false)
+
+    const mockInput2 = 'mailto:test@gmail.com'
+    const output2 = domainRegex.test(mockInput2)
+    expect(output2).toBe(false)
+
+    const mockInput4 = 'hello world.com'
+    const output4 = domainRegex.test(mockInput4)
+    expect(output4).toBe(false)
+
+    const mockInput5 = 'email@domain.com'
+    const output5 = domainRegex.test(mockInput5)
+    expect(output5).toBe(false)
+  })
+})


### PR DESCRIPTION
new updates to regex checks

allows for wildcards in subdomain, wildcards in domain, paths at end and url params, port number at the end