### PR TITLE
fix: refactored the WithSidebar component and updated typing

### DIFF
--- a/studio/components/layouts/AccountLayout/AccountLayout.tsx
+++ b/studio/components/layouts/AccountLayout/AccountLayout.tsx
@@ -6,6 +6,7 @@ import { API_URL, IS_PLATFORM } from 'lib/constants'
 import { useStore, withAuth, useFlag } from 'hooks'
 import WithSidebar from './WithSidebar'
 import { auth } from 'lib/gotrue'
+import { ReactNode } from 'react'
 
 export type SidebarLink = {
   label: string
@@ -13,7 +14,7 @@ export type SidebarLink = {
   key: string
   icon?: string
   external?: boolean
-  isActive?: Boolean
+  isActive?: boolean
   subitemsKey?: string
   onClick?: () => Promise<void>
 }
@@ -25,6 +26,14 @@ export type SidebarSection = {
   links: SidebarLink[]
 }
 
+type AccountLayoutProps = {
+  title: string;
+  breadcrumbs: {
+    key: string;
+    label: string
+  }[]
+  children: ReactNode
+}
 /**
  * layout for dashboard homepage, account and org settings
  *
@@ -33,7 +42,7 @@ export type SidebarSection = {
  * @param {Array<Object>}               breadcrumbs
  */
 
-const AccountLayout = ({ children, title, breadcrumbs }: any) => {
+const AccountLayout = ({ children, title, breadcrumbs }: AccountLayoutProps) => {
   const router = useRouter()
   const { app, ui } = useStore()
 

--- a/studio/components/layouts/AccountLayout/AccountLayout.tsx
+++ b/studio/components/layouts/AccountLayout/AccountLayout.tsx
@@ -6,6 +6,7 @@ import { API_URL, IS_PLATFORM } from 'lib/constants'
 import { useStore, withAuth, useFlag } from 'hooks'
 import WithSidebar from './WithSidebar'
 import { auth } from 'lib/gotrue'
+import { ReactNode } from 'react'
 
 export type SidebarLink = {
   label: string
@@ -13,7 +14,7 @@ export type SidebarLink = {
   key: string
   icon?: string
   external?: boolean
-  isActive?: Boolean
+  isActive?: boolean
   subitemsKey?: string
   onClick?: () => Promise<void>
 }
@@ -25,6 +26,14 @@ export type SidebarSection = {
   links: SidebarLink[]
 }
 
+type AccountLayoutProps = {
+  title: string
+  breadcrumbs: {
+    key: string
+    label: string
+  }[]
+  children: ReactNode
+}
 /**
  * layout for dashboard homepage, account and org settings
  *
@@ -33,7 +42,7 @@ export type SidebarSection = {
  * @param {Array<Object>}               breadcrumbs
  */
 
-const AccountLayout = ({ children, title, breadcrumbs }: any) => {
+const AccountLayout = ({ children, title, breadcrumbs }: AccountLayoutProps) => {
   const router = useRouter()
   const { app, ui } = useStore()
 

--- a/studio/components/layouts/AccountLayout/AccountLayout.tsx
+++ b/studio/components/layouts/AccountLayout/AccountLayout.tsx
@@ -7,6 +7,24 @@ import { useStore, withAuth, useFlag } from 'hooks'
 import WithSidebar from './WithSidebar'
 import { auth } from 'lib/gotrue'
 
+export type SidebarLink = {
+  label: string
+  href?: string
+  key: string
+  icon?: string
+  external?: boolean
+  isActive?: Boolean
+  subitemsKey?: string
+  onClick?: () => Promise<void>
+}
+
+export type SidebarSection = {
+  key: string
+  heading?: string
+  versionLabel?: string
+  links: SidebarLink[]
+}
+
 /**
  * layout for dashboard homepage, account and org settings
  *
@@ -38,57 +56,64 @@ const AccountLayout = ({ children, title, breadcrumbs }: any) => {
 
   const organizationsLinks = app.organizations
     .list()
-    .map((x: any) => ({
-      isActive: router.pathname.startsWith('/org/') && ui.selectedOrganization?.slug == x.slug,
-      label: x.name,
-      href: `/org/${x.slug}/settings`,
+    .map((organization) => ({
+      isActive:
+        router.pathname.startsWith('/org/') && ui.selectedOrganization?.slug == organization.slug,
+      label: organization.name,
+      href: `/org/${organization.slug}/settings`,
+      key: organization.slug,
     }))
     .sort((a, b) => a.label.localeCompare(b.label))
 
-  let linksWithHeaders = [
+  let sectionsWithHeaders: SidebarSection[] = [
     {
       heading: 'Projects',
+      key: 'projects',
       links: [
         {
           isActive: router.pathname == '/',
           label: 'All projects',
           href: '/',
+          key: 'all-projects-item',
         },
       ],
     },
-    ...(IS_PLATFORM
-      ? [
+  ]
+
+  if (IS_PLATFORM) {
+    sectionsWithHeaders.push(
+      {
+        heading: 'Organizations',
+        key: 'organizations',
+        links: organizationsLinks,
+      },
+      {
+        heading: 'Account',
+        key: 'account',
+        links: [
           {
-            heading: 'Organizations',
-            links: organizationsLinks,
+            isActive: router.pathname == `/account/me`,
+            icon: '/img/user.svg',
+            label: 'Preferences',
+            href: `/account/me`,
+            key: `/account/me`,
           },
-        ]
-      : []),
-    ...(IS_PLATFORM
-      ? [
           {
-            heading: 'Account',
-            links: [
-              {
-                isActive: router.pathname == `/account/me`,
-                icon: '/img/user.svg',
-                label: 'Preferences',
-                href: `/account/me`,
-                key: `/account/me`,
-              },
-              {
-                isActive: router.pathname == `/account/tokens`,
-                icon: '/img/user.svg',
-                label: 'Access Tokens',
-                href: `/account/tokens`,
-                key: `/account/tokens`,
-              },
-            ],
+            isActive: router.pathname == `/account/tokens`,
+            icon: '/img/user.svg',
+            label: 'Access Tokens',
+            href: `/account/tokens`,
+            key: `/account/tokens`,
           },
-        ]
-      : []),
+        ],
+      }
+    )
+  }
+
+  sectionsWithHeaders.push(
     {
       heading: 'Documentation',
+      key: 'documentation',
       links: [
         {
           key: 'ext-guides',
@@ -107,11 +132,13 @@ const AccountLayout = ({ children, title, breadcrumbs }: any) => {
       ],
     },
     {
+      key: 'logout-link',
       links: [logoutLink],
-    },
-  ]
+    }
+  )
+
   if (!organizationsLinks?.length)
-    linksWithHeaders = linksWithHeaders.filter((x: any) => x.heading != 'Organizations')
+    sectionsWithHeaders = sectionsWithHeaders.filter((x) => x.heading != 'Organizations')
   return (
     <>
       <Head>
@@ -124,7 +151,7 @@ const AccountLayout = ({ children, title, breadcrumbs }: any) => {
           style={{ height: maxHeight, maxHeight }}
           className="flex w-full flex-1 flex-col overflow-y-auto"
         >
-          <WithSidebar title={title} breadcrumbs={breadcrumbs} links={linksWithHeaders}>
+          <WithSidebar title={title} breadcrumbs={breadcrumbs} sections={sectionsWithHeaders}>
             {children}
           </WithSidebar>
         </main>

--- a/studio/components/layouts/AccountLayout/WithSidebar.tsx
+++ b/studio/components/layouts/AccountLayout/WithSidebar.tsx
@@ -4,11 +4,12 @@ import { isUndefined } from 'lodash'
 import { Menu, Typography, IconArrowUpRight, Badge, IconLogOut } from '@supabase/ui'
 import { useFlag } from 'hooks'
 import LayoutHeader from '../ProjectLayout/LayoutHeader'
+import { SidebarLink, SidebarSection } from './AccountLayout'
 
 interface Props {
   title: string
   breadcrumbs: any[]
-  links: any[]
+  sections: SidebarSection[]
   header?: ReactNode
   subitems?: any[]
   subitemsParentKey?: number
@@ -16,21 +17,27 @@ interface Props {
   customSidebarContent?: ReactNode
   children: ReactNode
 }
-
+/*
+The information heirarchy for WithSidebar is:
+  WithSidebar
+    SectionsWithHeaders
+      SidebarItem
+        SidebarLink
+    SidebarItem
+      SidebarLink
+*/
 const WithSidebar: FC<Props> = ({
   title,
   header,
   breadcrumbs = [],
   children,
-  links,
+  sections,
   subitems,
   subitemsParentKey,
   hideSidebar = false,
   customSidebarContent,
 }) => {
-  const noContent = !links && !customSidebarContent
-  const linksHaveHeaders = links && links[0].heading
-
+  const noContent = !sections && !customSidebarContent
   const ongoingIncident = useFlag('ongoingIncident')
   const maxHeight = ongoingIncident ? 'calc(100vh - 44px)' : '100vh'
 
@@ -58,20 +65,24 @@ const WithSidebar: FC<Props> = ({
           <div className="-mt-1">
             <Menu>
               {customSidebarContent}
-              {links && linksHaveHeaders ? (
-                <LinksWithHeaders
-                  links={links}
-                  subitems={subitems}
-                  subitemsParentKey={subitemsParentKey}
-                />
-              ) : null}
-              {!linksHaveHeaders && links ? (
-                <LinksWithoutHeaders
-                  links={links}
-                  subitems={subitems}
-                  subitemsParentKey={subitemsParentKey}
-                />
-              ) : null}
+              {sections.map((section, i) => {
+                return Boolean(section.heading) ? (
+                  <SectionWithHeaders
+                    key={section.key}
+                    section={section}
+                    subitems={subitems}
+                    subitemsParentKey={subitemsParentKey}
+                  />
+                ) : (
+                  <div className="dark:border-dark border-b py-5 px-6" key={section.key}>
+                    <SidebarItem                      
+                      links={section.links}
+                      subitems={subitems}
+                      subitemsParentKey={subitemsParentKey}
+                    />
+                  </div>
+                )
+              })}
             </Menu>
           </div>
         </div>
@@ -85,67 +96,91 @@ const WithSidebar: FC<Props> = ({
 }
 export default WithSidebar
 
-const LinksWithHeaders: FC<any> = ({ links, subitems, subitemsParentKey }) => {
-  return links.map((x: any) => (
-    <div key={x.heading} className="dark:border-dark border-b py-5 px-6">
-      {x.heading && <Menu.Group title={x.heading} />}
-      {x.versionLabel && (
-        <div className="mb-1 px-3">
-          <Badge color="yellow">{x.versionLabel}</Badge>
-        </div>
-      )}
-      {
-        <LinksWithoutHeaders
-          links={x.links}
-          subitems={subitems}
-          subitemsParentKey={subitemsParentKey}
-        />
-      }
-    </div>
-  ))
+interface SectionWithHeadersProps {
+  section: SidebarSection
+  subitems?: any[]
+  subitemsParentKey?: number
 }
-const LinksWithoutHeaders: FC<any> = ({ links, subitems, subitemsParentKey }) => {
+
+const SectionWithHeaders: FC<SectionWithHeadersProps> = ({
+  section,
+  subitems,
+  subitemsParentKey,
+}) => (
+  <div key={section.heading} className="dark:border-dark border-b py-5 px-6">
+    {section.heading && <Menu.Group title={section.heading} />}
+    {section.versionLabel && (
+      <div className="mb-1 px-3">
+        <Badge color="yellow">{section.versionLabel}</Badge>
+      </div>
+    )}
+    {
+      <SidebarItem
+        links={section.links}
+        subitems={subitems}
+        subitemsParentKey={subitemsParentKey}
+      />
+    }
+  </div>
+)
+interface SidebarItemProps {
+  links: SidebarLink[]
+  subitems?: any[]
+  subitemsParentKey?: number
+}
+
+const SidebarItem: FC<SidebarItemProps> = ({ links, subitems, subitemsParentKey }) => {
   return (
     <ul className="space-y-1">
-      {links.map((x: any, i: number) => {
+      {links.map((link, i: number) => {
         // disable active state for link with subitems
-        const isActive = x.isActive && !subitems
+        const isActive = link.isActive && !subitems
 
         let render: any = (
-          <SidebarItem
-            key={`${x.key || x.as}-${i}-sidebarItem`}
-            id={`${x.key || x.as}-${i}`}
-            slug={x.key}
+          <SidebarLinkItem
+            key={`${link.key}-${i}-sidebarItem`}
+            id={`${link.key}-${i}`}
             isActive={isActive}
-            label={x.label}
-            href={x.href}
-            onClick={x.onClick}
-            external={x.external || false}
+            label={link.label}
+            href={link.href}
+            onClick={link.onClick}
+            external={link.external || false}
           />
         )
 
-        if (subitems && x.subitemsKey === subitemsParentKey) {
+        if (subitems && link.subitemsKey === subitemsParentKey) {
           const subItemsRender = subitems.map((y: any, i: number) => (
-            <SidebarItem
+            <SidebarLinkItem
               key={`${y.key || y.as}-${i}-sidebarItem`}
               id={`${y.key || y.as}-${i}`}
-              slug={y.key}
               isSubitem={true}
               label={y.label}
               onClick={y.onClick}
-              external={x.external || false}
+              external={link.external || false}
             />
           ))
           render = [render, ...subItemsRender]
         }
-
         return render
       })}
     </ul>
   )
 }
 
-const SidebarItem: FC<any> = ({ id, label, href, isActive, isSubitem, onClick, external }) => {
+interface SidebarLinkProps extends SidebarLink {
+  id: string
+  isSubitem?: boolean
+}
+
+const SidebarLinkItem: FC<SidebarLinkProps> = ({
+  id,
+  label,
+  href,
+  isActive,
+  isSubitem,
+  onClick,
+  external,
+}) => {
   if (isUndefined(href)) {
     let icon
     if (external) {
@@ -161,7 +196,7 @@ const SidebarItem: FC<any> = ({ id, label, href, isActive, isSubitem, onClick, e
         rounded
         key={id}
         style={{
-          marginLeft: isSubitem && '.5rem',
+          marginLeft: isSubitem ? '.5rem' : '0rem',
         }}
         active={isActive ? true : false}
         onClick={onClick || (() => {})}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix  - that took a it of a turn and ended up in a refactor.

## What is the current behavior?

Fixed the "list should have unique key" console warning.
Updated the typing of the `WithSidebar` component and refactored it a bit.

![Screenshot 2022-07-16 at 16 27 26](https://user-images.githubusercontent.com/3008147/179359002-683bc5f4-4d27-41d1-a739-a1d16aa32204.png)

The `WithSidebar` component looks like it needed a refactor.
The items (`linksWithHeaders`) passed to the `WithSidebar` component are created in `AccountLayout` which then checks to see if [only the initial item has a header](https://github.com/supabase/supabase/blob/e52523a2a9bc6b5a49265310543dd1cc4451d28a/studio/components/layouts/AccountLayout/WithSidebar.tsx#L32) - which it does as it's [hardcoded in AccountLayout](https://github.com/supabase/supabase/blob/e52523a2a9bc6b5a49265310543dd1cc4451d28a/studio/components/layouts/AccountLayout/AccountLayout.tsx#L50).
This means that [the conditional rendering in WithSidebar](https://github.com/supabase/supabase/blob/e52523a2a9bc6b5a49265310543dd1cc4451d28a/studio/components/layouts/AccountLayout/WithSidebar.tsx#L68) isn't needed and the rest of the component can be cleaned up and restructured.

## What is the new behavior?

The warning is gone and the component has typing and is possibly better structured.

## Additional context

It looks like the component is only being used from [AccountLayout](https://github.com/supabase/supabase/blob/e52523a2a9bc6b5a49265310543dd1cc4451d28a/studio/components/layouts/AccountLayout/AccountLayout.tsx#L127) with the following:
```
<WithSidebar title={title} breadcrumbs={breadcrumbs} links={linksWithHeaders}>
```

The [props](https://github.com/supabase/supabase/blob/e52523a2a9bc6b5a49265310543dd1cc4451d28a/studio/components/layouts/AccountLayout/WithSidebar.tsx#L20) for the `WithSidebar` component are:
```
interface Props {
  title: string
  breadcrumbs: any[]
  links: any[]
  header?: ReactNode
  subitems?: any[]
  subitemsParentKey?: number
  hideSidebar?: boolean
  customSidebarContent?: ReactNode
  children: ReactNode
}
```

Can the rest of the props be removed (`subitems`, etc) and the `WithSidebar` cleaned up or is there some "future use" functionality in here? (e.g. customSidebarContent)?


## Screenshots

These were done with `const IS_PLATFORM = true;`

From Master:
<img width="904" alt="master" src="https://user-images.githubusercontent.com/3008147/179360018-5cdd369f-8be8-400c-86f5-0e3e34940127.png">

From the PR branch:
<img width="706" alt="pr-branch" src="https://user-images.githubusercontent.com/3008147/179360026-d3e0381a-e026-43a8-b972-1fa8f35221ca.png">

