### PR TITLE
Fix: delete modal text overflow

### DIFF
--- a/studio/components/interfaces/Settings/Logs/Logs.constants.ts
+++ b/studio/components/interfaces/Settings/Logs/Logs.constants.ts
@@ -471,7 +471,7 @@ export const getDefaultHelper = (helpers: DatetimeHelper[]) =>
   helpers.find((helper) => helper.default) || helpers[0]
 
 export const TIER_QUERY_LIMITS: {
-  [x: string]: { text: string; value: 1 | 7 | 90; unit: 'day', promptUpgrade: boolean }
+  [x: string]: { text: string; value: 1 | 7 | 90; unit: 'day'; promptUpgrade: boolean }
 } = {
   FREE: { text: '1 day', value: 1, unit: 'day', promptUpgrade: true },
   PRO: { text: '7 days', value: 7, unit: 'day', promptUpgrade: true },

--- a/studio/components/ui/ConfirmationModal.tsx
+++ b/studio/components/ui/ConfirmationModal.tsx
@@ -5,7 +5,7 @@ import { FC, useState, useEffect } from 'react'
 interface Props {
   visible: boolean
   danger?: boolean
-  header: string
+  header: string | JSX.Element
   description?: string
   size?: 'small' | 'tiny' | 'medium' | 'large'
   buttonLabel: string

--- a/studio/pages/project/[ref]/database/tables.tsx
+++ b/studio/pages/project/[ref]/database/tables.tsx
@@ -139,7 +139,7 @@ const DatabaseTables: NextPageWithLayout = () => {
       <ConfirmationModal
         danger
         visible={isDeleting && !isUndefined(selectedTableToDelete)}
-        header={`Confirm deletion of table "${selectedTableToDelete?.name}"`}
+        header={<span className='break-words'>{`Confirm deletion of table "${selectedTableToDelete?.name}"`}</span>}
         children={
           <Modal.Content>
             <p className="text-scale-1100 py-4 text-sm">

--- a/studio/pages/project/[ref]/database/tables.tsx
+++ b/studio/pages/project/[ref]/database/tables.tsx
@@ -139,7 +139,9 @@ const DatabaseTables: NextPageWithLayout = () => {
       <ConfirmationModal
         danger
         visible={isDeleting && !isUndefined(selectedTableToDelete)}
-        header={<span className='break-words'>{`Confirm deletion of table "${selectedTableToDelete?.name}"`}</span>}
+        header={
+          <span className="break-words">{`Confirm deletion of table "${selectedTableToDelete?.name}"`}</span>
+        }
         children={
           <Modal.Content>
             <p className="text-scale-1100 py-4 text-sm">

--- a/studio/pages/project/[ref]/editor/[id].tsx
+++ b/studio/pages/project/[ref]/editor/[id].tsx
@@ -188,7 +188,9 @@ const TableEditorPage: NextPage = () => {
       <ConfirmationModal
         danger
         visible={isDeleting && !isUndefined(selectedTableToDelete)}
-        header={<span className='break-words'>{`Confirm deletion of table "${selectedTableToDelete?.name}"`}</span>}
+        header={
+          <span className="break-words">{`Confirm deletion of table "${selectedTableToDelete?.name}"`}</span>
+        }
         children={
           <Modal.Content>
             <p className="text-scale-1100 py-4 text-sm">

--- a/studio/pages/project/[ref]/editor/[id].tsx
+++ b/studio/pages/project/[ref]/editor/[id].tsx
@@ -188,7 +188,7 @@ const TableEditorPage: NextPage = () => {
       <ConfirmationModal
         danger
         visible={isDeleting && !isUndefined(selectedTableToDelete)}
-        header={`Confirm deletion of table "${selectedTableToDelete?.name}"`}
+        header={<span className='break-words'>{`Confirm deletion of table "${selectedTableToDelete?.name}"`}</span>}
         children={
           <Modal.Content>
             <p className="text-scale-1100 py-4 text-sm">

--- a/studio/pages/project/[ref]/editor/index.tsx
+++ b/studio/pages/project/[ref]/editor/index.tsx
@@ -78,7 +78,7 @@ const Editor: NextPage = () => {
       <ConfirmationModal
         danger
         visible={isDeleting && !isUndefined(selectedTableToDelete)}
-        header={`Confirm deletion of table "${selectedTableToDelete?.name}"`}
+        header={<span className='break-words'>{`Confirm deletion of table "${selectedTableToDelete?.name}"`}</span>}
         description={`Are you sure you want to delete the selected table? This action cannot be undone`}
         buttonLabel="Delete"
         buttonLoadingLabel="Deleting"

--- a/studio/pages/project/[ref]/editor/index.tsx
+++ b/studio/pages/project/[ref]/editor/index.tsx
@@ -78,7 +78,9 @@ const Editor: NextPage = () => {
       <ConfirmationModal
         danger
         visible={isDeleting && !isUndefined(selectedTableToDelete)}
-        header={<span className='break-words'>{`Confirm deletion of table "${selectedTableToDelete?.name}"`}</span>}
+        header={
+          <span className="break-words">{`Confirm deletion of table "${selectedTableToDelete?.name}"`}</span>
+        }
         description={`Are you sure you want to delete the selected table? This action cannot be undone`}
         buttonLabel="Delete"
         buttonLoadingLabel="Deleting"


### PR DESCRIPTION
## What kind of change does this PR introduce?

fix text overflow in table delete modal.

## What is the current behavior?

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/70828596/179439326-1829d202-0b61-4b07-a619-dea5957643af.png">

## What is the new behavior?

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/70828596/179439323-1bd42cd5-5629-4534-bb2d-f12e93f3c5d6.png">

## Additional context

not the exact same text but you get the point.