### PR TITLE
feat: studio styling changes on header and footer

### DIFF
--- a/studio/components/grid/components/footer/pagination/Pagination.tsx
+++ b/studio/components/grid/components/footer/pagination/Pagination.tsx
@@ -150,7 +150,9 @@ const Pagination: FC<PaginationProps> = () => {
               style={{ padding: '3px 10px' }}
             >{`${state.rowsPerPage} rows`}</Button>
           </DropdownControl>
-          <p className="text-scale-1100 text-sm">{`${state.totalRows.toLocaleString()} records`}</p>
+          <p className="text-scale-1100 text-sm">{`${state.totalRows.toLocaleString()} ${
+            state.totalRows === 0 || state.totalRows > 1 ? `records` : 'record'
+          }`}</p>
           {state.isLoading && <IconLoader size={14} className="animate-spin" />}
         </>
       )}

--- a/studio/components/grid/components/header/Header.tsx
+++ b/studio/components/grid/components/header/Header.tsx
@@ -60,7 +60,7 @@ const DefaultHeader: FC<DefaultHeaderProps> = ({ sorts, filters, onAddColumn, on
   const renderNewColumn = (onAddColumn?: () => void) => {
     if (!onAddColumn) return null
     return (
-      <Button type="text" onClick={onAddColumn}>
+      <Button size="tiny" icon={<IconPlus size={14} strokeWidth={2} />} onClick={onAddColumn}>
         New Column
       </Button>
     )

--- a/studio/components/grid/components/header/Header.tsx
+++ b/studio/components/grid/components/header/Header.tsx
@@ -60,7 +60,7 @@ const DefaultHeader: FC<DefaultHeaderProps> = ({ sorts, filters, onAddColumn, on
   const renderNewColumn = (onAddColumn?: () => void) => {
     if (!onAddColumn) return null
     return (
-      <Button size="tiny" icon={<IconPlus size={14} strokeWidth={2} />} onClick={onAddColumn}>
+      <Button type="text" onClick={onAddColumn}>
         New Column
       </Button>
     )


### PR DESCRIPTION
## What kind of change does this PR introduce?

Studio features

## What is the current behavior?

Currently in the Table Editor the 'New Column' button is a `text` type button and does not have the same impact as the 'Insert Row' button.

Also when you only have one record the footer appears as `1 records`:

<img width="561" alt="Screenshot 2022-07-18 at 15 13 04" src="https://user-images.githubusercontent.com/22655069/179532535-1bdbc708-e195-47a9-a5ac-d6bc9f058cef.png">


## What is the new behavior?

The 'New Column' button is now the same styling as 'Insert Row' button and also the footer text will change based on the number of records:

<img width="561" alt="Screenshot 2022-07-18 at 15 16 41" src="https://user-images.githubusercontent.com/22655069/179532693-b8d34c62-3d6a-455b-9e7b-44384ca3dbe1.png">


https://user-images.githubusercontent.com/22655069/179532722-f0318d25-8796-4d65-a7f7-21cf5e7c6345.mov

