### PR TITLE
Fix auth policies text overflow

### DIFF
--- a/studio/components/interfaces/Authentication/Policies/PolicyEditorModal/PolicyEditorModalTitle.tsx
+++ b/studio/components/interfaces/Authentication/Policies/PolicyEditorModal/PolicyEditorModalTitle.tsx
@@ -42,7 +42,7 @@ const PolicyEditorModalTitle: FC<Props> = ({
   }
   return (
     <div className="flex items-center space-x-3">
-      <h4 className="m-0 text-lg">{getTitle()}</h4>
+      <h4 className="m-0 text-lg truncate">{getTitle()}</h4>
     </div>
   )
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix auth policies text overflow

## What is the current behavior?

auth policies text overflow

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/70828596/179634896-5f0f1f16-2507-4f9c-881c-60850bfed2bd.png">

## What is the new behavior?

auth policies text do not overflow.

![CleanShot 2022-07-18 at 19 42 17@2x](https://user-images.githubusercontent.com/70828596/179634917-18215c23-35ea-4319-8079-f3981169da9f.png)