### PR TITLE
Add link to support in Backups Error

### DIFF
--- a/studio/components/interfaces/Database/Backups/BackupsError.tsx
+++ b/studio/components/interfaces/Database/Backups/BackupsError.tsx
@@ -1,11 +1,18 @@
 import { IconInfo } from '@supabase/ui'
+import Link from 'next/link'
 
 const BackupsError = () => {
   return (
     <div className="block w-full rounded border border-gray-400 border-opacity-50 bg-gray-300 p-3">
       <div className="flex space-x-3">
         <IconInfo size={20} strokeWidth={1.5} />
-        <p className="text-sm">Failed to retrieve backups for project. Please contact support.</p>
+        <p className="text-sm">
+          Failed to retrieve backups for this project. Please contact{' '}
+          <Link href="mailto:support@supabase.com">
+            <a className="text-brand-900">support</a>
+          </Link>
+          .
+        </p>
       </div>
     </div>
   )

--- a/studio/components/interfaces/Database/Backups/BackupsError.tsx
+++ b/studio/components/interfaces/Database/Backups/BackupsError.tsx
@@ -8,7 +8,7 @@ const BackupsError = () => {
         <IconInfo size={20} strokeWidth={1.5} />
         <p className="text-sm">
           Failed to retrieve backups for this project. Please contact{' '}
-          <Link href="mailto:support@supabase.com">
+          <Link href="/support/new">
             <a className="text-brand-900">support</a>
           </Link>
           .


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add link to support in BackupsError

## What is the current behavior?

No link

## What is the new behavior?

Easier way to get to support

## Additional context

<img width="1129" alt="image" src="https://user-images.githubusercontent.com/70828596/179636357-1ef9d773-c41d-44d3-94fb-6bd1395f2383.png">