### PR TITLE
fix: resend invite

### DIFF
--- a/studio/components/interfaces/Organization/Organization.utils.ts
+++ b/studio/components/interfaces/Organization/Organization.utils.ts
@@ -4,6 +4,7 @@ export function isInviteExpired(timestamp: Date) {
   const now = new Date()
   var timeBetween = now.valueOf() - inviteDate.valueOf()
   if (timeBetween / 1000 / 60 / 60 < 24) {
-    return true
+    return false
   }
+  return true
 }

--- a/studio/components/interfaces/Organization/OwnerDropdown.tsx
+++ b/studio/components/interfaces/Organization/OwnerDropdown.tsx
@@ -143,7 +143,7 @@ const OwnerDropdown = observer(({ members, member }: any) => {
                   </div>
                 </Dropdown.Item>
 
-                {!isInviteExpired(member.invited_at) && (
+                {isInviteExpired(member.invited_at) && (
                   <>
                     <Dropdown.Seperator />
                     <Dropdown.Item onClick={() => handleResendInvite(member)}>

--- a/studio/components/interfaces/Organization/OwnerDropdown.tsx
+++ b/studio/components/interfaces/Organization/OwnerDropdown.tsx
@@ -4,7 +4,7 @@ import { timeout } from 'lib/helpers'
 import { Button, IconMoreHorizontal, IconTrash, Dropdown } from '@supabase/ui'
 
 import { useOrganizationDetail, useStore } from 'hooks'
-import { Member } from 'types'
+import { Member, User } from 'types'
 import { API_URL } from 'lib/constants'
 import { post, delete_ } from 'lib/common/fetch'
 import { isInviteExpired } from './Organization.utils'
@@ -12,7 +12,7 @@ import { PageContext } from 'pages/org/[slug]/settings'
 import TextConfirmModal from 'components/ui/Modals/TextConfirmModal'
 import { confirmAlert } from 'components/to-be-cleaned/ModalsDeprecated/ConfirmModal'
 
-const OwnerDropdown = observer(({ members, member }: any) => {
+const OwnerDropdown = observer(({ members, member, user }: any) => {
   const { ui } = useStore()
   const { mutateOrgMembers } = useOrganizationDetail(ui.selectedOrganization?.slug || '')
 
@@ -75,12 +75,12 @@ const OwnerDropdown = observer(({ members, member }: any) => {
     }
   }
 
-  async function handleResendInvite(member: Member) {
+  async function handleResendInvite(member: Member, user: User) {
     setLoading(true)
 
     const response = await post(`${API_URL}/organizations/${orgSlug}/members/invite`, {
       invited_email: member.profile.primary_email,
-      owner_id: member.invited_id,
+      owner_id: user.id,
     })
 
     if (response.error) {
@@ -146,7 +146,7 @@ const OwnerDropdown = observer(({ members, member }: any) => {
                 {isInviteExpired(member.invited_at) && (
                   <>
                     <Dropdown.Seperator />
-                    <Dropdown.Item onClick={() => handleResendInvite(member)}>
+                    <Dropdown.Item onClick={() => handleResendInvite(member, user)}>
                       <div className="flex flex-col">
                         <p>Resend invitation</p>
                         <p className="block opacity-50">Invites expire after 24hrs.</p>

--- a/studio/pages/org/[slug]/settings.tsx
+++ b/studio/pages/org/[slug]/settings.tsx
@@ -415,7 +415,7 @@ const MembersView = observer(() => {
                 <Table.td>
                   {PageState.isOrgOwner && !x.is_owner && (
                     // @ts-ignore
-                    <OwnerDropdown members={PageState.members} member={x} />
+                    <OwnerDropdown members={PageState.members} member={x} user={PageState.user} />
                   )}
                 </Table.td>
               </Table.tr>

--- a/studio/pages/org/[slug]/settings.tsx
+++ b/studio/pages/org/[slug]/settings.tsx
@@ -401,8 +401,8 @@ const MembersView = observer(() => {
 
                 <Table.td>
                   {x.invited_id && (
-                    <Badge color={isInviteExpired(x.invited_at) ? 'yellow' : 'red'}>
-                      {isInviteExpired(x.invited_at) ? 'Invited' : 'Expired'}
+                    <Badge color={isInviteExpired(x.invited_at) ? 'red' : 'yellow'}>
+                      {isInviteExpired(x.invited_at) ? 'Expired' : 'Invited'}
                     </Badge>
                   )}
                 </Table.td>


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Fixes a bug where resend invite was using the invited member's id instead of the user's id
* This led to the wrong owner name being used in the email template