### PR TITLE
feature: editor long column name and hover

### DIFF
--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/Column.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/Column.tsx
@@ -76,26 +76,28 @@ const Column: FC<Props> = ({
           </Typography>
         </div>
       </div>
-      <div className="w-[25%]">
+      <div className="w-[20%]">
         <div className="flex w-[95%] items-center justify-between">
           <Input
             value={column.name}
             size="small"
+            title={column.name}
             disabled={hasImportContent}
             className={`table-editor-columns-input bg-white dark:bg-transparent lg:gap-0 ${
               hasImportContent ? 'opacity-50' : ''
             } rounded-md`}
-            actions={
-              <Button
-                type={!isUndefined(column.foreignKey) ? 'secondary' : 'default'}
-                onClick={() => onEditRelation(column)}
-              >
-                <IconLink size={14} strokeWidth={!isUndefined(column.foreignKey) ? 2 : 1} />
-              </Button>
-            }
             onChange={(event: any) => onUpdateColumn({ name: event.target.value })}
           />
         </div>
+      </div>
+      <div className="w-[5%]  pl-0.5">
+        <Button
+          type={!isUndefined(column.foreignKey) ? 'secondary' : 'default'}
+          onClick={() => onEditRelation(column)}
+          className="px-1 py-2"
+        >
+          <IconLink size={14} strokeWidth={!isUndefined(column.foreignKey) ? 2 : 1} />
+        </Button>
       </div>
       <div className="w-[25%]">
         <div className="w-[95%]">

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/Column.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/Column.tsx
@@ -81,6 +81,7 @@ const Column: FC<Props> = ({
           <Input
             value={column.name}
             size="small"
+            placeholder="column name"
             title={column.name}
             disabled={hasImportContent}
             className={`table-editor-columns-input bg-white dark:bg-transparent lg:gap-0 ${


### PR DESCRIPTION
## What kind of change does this PR introduce?

Studio Feature

## What is the current behavior?

When you are in the editor and have a long column name the name isn't the easiest to read and you can not see the cursor

This is highlighted in #7673

## What is the new behavior?

<img width="666" alt="Screenshot 2022-07-14 at 10 40 26" src="https://user-images.githubusercontent.com/22655069/178953394-a504be24-0e3f-4610-a39d-515d311c29fa.png">

So the button is now in its own `div` and you can see the cursor of the field value. I've also added a `title` value so when you hover on the input you see the field name which should help. 

## Additional context

Linked with #7673
