### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -147,6 +147,9 @@ services:
     environment:
       PG_META_PORT: 8080
       PG_META_DB_HOST: ${POSTGRES_HOST}
+      PG_META_DB_PORT: ${POSTGRES_PORT}
+      PG_META_DB_NAME: ${POSTGRES_DB}
+      PG_META_DB_USER: ${POSTGRES_USER}
       PG_META_DB_PASSWORD: ${POSTGRES_PASSWORD}
 
   # Comment out everything below this point if you are using an external Postgres database


### PR DESCRIPTION
Add the configuration of PG_META_DB_PORT PG_META_DB_NAME PG_META_DB_USER

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The Meta service does not correctly obtain the configuration of PG_META_DB_PORT PG_META_DB_NAME PG_META_DB_USER during local deployment

