### PR TITLE
fix: correct projectRef for self-hosted/local

### DIFF
--- a/studio/lib/pingPostgrest.ts
+++ b/studio/lib/pingPostgrest.ts
@@ -16,12 +16,12 @@ import { API_URL } from './constants'
  */
 async function pingPostgrest(
   restUrl: string,
+  projectRef: string,
   options?: {
     kpsVersion?: string
     timeout?: number
   }
 ) {
-  const projectRef = restUrl.match(/https:\/\/(\w+)\.supabase\./)?.[1]
   if (projectRef === undefined) return false
   const serviceApiKey = await getServiceApiKey(projectRef, options?.timeout)
   if (serviceApiKey === undefined) return false
@@ -41,7 +41,10 @@ async function pingPostgrest(
 }
 export default pingPostgrest
 
-const getServiceApiKey = async (projectRef: string, timeout = DEFAULT_TIMEOUT_MILLISECONDS): Promise<string | undefined> => {
+const getServiceApiKey = async (
+  projectRef: string,
+  timeout = DEFAULT_TIMEOUT_MILLISECONDS
+): Promise<string | undefined> => {
   const response = await getWithTimeout(`${API_URL}/props/project/${projectRef}/api`, { timeout })
   if (response.error || response.autoApiService.service_api_keys.length === 0) return undefined
   return response.autoApiService.serviceApiKey

--- a/studio/stores/app/ProjectStore.ts
+++ b/studio/stores/app/ProjectStore.ts
@@ -62,11 +62,8 @@ export default class ProjectStore extends PostgresMetaInterface<Project> {
   }
 
   async pingPostgrest(project: Project): Promise<'ONLINE' | 'OFFLINE' | undefined> {
-    if (
-      project.status === PROJECT_STATUS.ACTIVE_HEALTHY &&
-      project.restUrl
-    ) {
-      const success = await pingPostgrest(project.restUrl, {
+    if (project.status === PROJECT_STATUS.ACTIVE_HEALTHY && project.restUrl) {
+      const success = await pingPostgrest(project.restUrl, project.ref, {
         kpsVersion: project.kpsVersion,
       })
       return success ? 'ONLINE' : 'OFFLINE'


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix for self-hosted (and local) Supabase studio for  projects.

## What is the current behavior?

The `projectRef` field is being parsed out of the `restUrl` using a regex which only works for 1. HTTPS and 2. Supabase Cloud. This parsing will always fail for values of `SUPABASE_REST_URL` which do not match this pattern.

## What is the new behavior?

The `projectRef` field is passed from the `Project` object's `ref` field when it is called rather than attempting to parse it from `restUrl`.

