### PR TITLE
fix: "possible fix" - always use project ref incase the project resturl is different

### DIFF
--- a/studio/components/layouts/ProjectLayout/ConnectingState.tsx
+++ b/studio/components/layouts/ProjectLayout/ConnectingState.tsx
@@ -37,7 +37,8 @@ const ConnectingState: FC<Props> = ({ project }) => {
   }, [project])
 
   const testProjectConnection = async () => {
-    const result = await pingPostgrest(project.restUrl!, {
+    console.log('project.restUrl', project.restUrl)
+    const result = await pingPostgrest(project.restUrl!, project.ref, {
       kpsVersion: project.kpsVersion,
     })
     if (result) {

--- a/studio/components/layouts/ProjectLayout/ConnectingState.tsx
+++ b/studio/components/layouts/ProjectLayout/ConnectingState.tsx
@@ -37,7 +37,6 @@ const ConnectingState: FC<Props> = ({ project }) => {
   }, [project])
 
   const testProjectConnection = async () => {
-    console.log('project.restUrl', project.restUrl)
     const result = await pingPostgrest(project.restUrl!, project.ref, {
       kpsVersion: project.kpsVersion,
     })

--- a/studio/components/layouts/ProjectLayout/ProjectLayout.tsx
+++ b/studio/components/layouts/ProjectLayout/ProjectLayout.tsx
@@ -114,8 +114,6 @@ const ContentWrapper: FC<ContentWrapperProps> = observer(({ isLoading, children 
   const isProjectPausing = ui.selectedProject?.status === PROJECT_STATUS.GOING_DOWN
   const isProjectOffline = ui.selectedProject?.postgrestStatus === 'OFFLINE'
 
-  console.log('ui.selectedProject', ui.selectedProject)
-
   return (
     <>
       {isLoading || ui.selectedProject === undefined ? (

--- a/studio/components/layouts/ProjectLayout/ProjectLayout.tsx
+++ b/studio/components/layouts/ProjectLayout/ProjectLayout.tsx
@@ -114,6 +114,8 @@ const ContentWrapper: FC<ContentWrapperProps> = observer(({ isLoading, children 
   const isProjectPausing = ui.selectedProject?.status === PROJECT_STATUS.GOING_DOWN
   const isProjectOffline = ui.selectedProject?.postgrestStatus === 'OFFLINE'
 
+  console.log('ui.selectedProject', ui.selectedProject)
+
   return (
     <>
       {isLoading || ui.selectedProject === undefined ? (

--- a/studio/lib/pingPostgrest.ts
+++ b/studio/lib/pingPostgrest.ts
@@ -1,3 +1,4 @@
+import { String } from 'lodash'
 import semver from 'semver'
 import { headWithTimeout, getWithTimeout } from './common/fetch'
 import { API_URL } from './constants'
@@ -16,12 +17,13 @@ import { API_URL } from './constants'
  */
 async function pingPostgrest(
   restUrl: string,
+  projectRef: string,
   options?: {
     kpsVersion?: string
     timeout?: number
   }
 ) {
-  const projectRef = restUrl.match(/https:\/\/(\w+)\.supabase\./)?.[1]
+  console.log('projectRef inside ping postgres', projectRef)
   if (projectRef === undefined) return false
   const serviceApiKey = await getServiceApiKey(projectRef, options?.timeout)
   if (serviceApiKey === undefined) return false
@@ -41,7 +43,10 @@ async function pingPostgrest(
 }
 export default pingPostgrest
 
-const getServiceApiKey = async (projectRef: string, timeout = DEFAULT_TIMEOUT_MILLISECONDS): Promise<string | undefined> => {
+const getServiceApiKey = async (
+  projectRef: string,
+  timeout = DEFAULT_TIMEOUT_MILLISECONDS
+): Promise<string | undefined> => {
   const response = await getWithTimeout(`${API_URL}/props/project/${projectRef}/api`, { timeout })
   if (response.error || response.autoApiService.service_api_keys.length === 0) return undefined
   return response.autoApiService.serviceApiKey

--- a/studio/lib/pingPostgrest.ts
+++ b/studio/lib/pingPostgrest.ts
@@ -23,7 +23,6 @@ async function pingPostgrest(
     timeout?: number
   }
 ) {
-  console.log('projectRef inside ping postgres', projectRef)
   if (projectRef === undefined) return false
   const serviceApiKey = await getServiceApiKey(projectRef, options?.timeout)
   if (serviceApiKey === undefined) return false

--- a/studio/stores/app/ProjectStore.ts
+++ b/studio/stores/app/ProjectStore.ts
@@ -62,11 +62,8 @@ export default class ProjectStore extends PostgresMetaInterface<Project> {
   }
 
   async pingPostgrest(project: Project): Promise<'ONLINE' | 'OFFLINE' | undefined> {
-    if (
-      project.status === PROJECT_STATUS.ACTIVE_HEALTHY &&
-      project.restUrl
-    ) {
-      const success = await pingPostgrest(project.restUrl, {
+    if (project.status === PROJECT_STATUS.ACTIVE_HEALTHY && project.restUrl) {
+      const success = await pingPostgrest(project.restUrl, project.ref, {
         kpsVersion: project.kpsVersion,
       })
       return success ? 'ONLINE' : 'OFFLINE'


### PR DESCRIPTION


## What kind of change does this PR introduce?

Uses the project.ref rather than relying on the rest url in ConnectingState 

## What is the current behavior?

Uses resturl to infer the project ref, which, is not reliable on older projects.

## What is the new behavior?

Always uses the project.ref

## Additional context

Add any other context or screenshots.
