### PR TITLE
fix: delayed metadata loading only on log focus

### DIFF
--- a/studio/components/interfaces/Settings/Logs/LogColumnRenderers/DatabaseApiColumnRender.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogColumnRenderers/DatabaseApiColumnRender.tsx
@@ -6,9 +6,9 @@ export default [
     formatter: (data: any) => (
       <div className="flex h-full w-full items-center justify-between gap-3">
         <div className="flex h-full w-full items-center gap-4">
-          <ResponseCodeFormatter row={data} value={data.row.metadata[0].response[0].status_code} />
-          <span className="text-xs w-14">{data.row.metadata[0].request[0].method}</span>
-          <span className="font-mono text-xs">{data.row.metadata[0].request[0].path}</span>
+          <ResponseCodeFormatter row={data} value={data.row.status_code} />
+          <span className="text-xs w-14">{data.row.request.method}</span>
+          <span className="font-mono text-xs">{data.row.request.path}</span>
         </div>
         <div>
           <span className="flex w-full h-full items-center gap-1">

--- a/studio/components/interfaces/Settings/Logs/LogColumnRenderers/DatabasePostgresColumnRender.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogColumnRenderers/DatabasePostgresColumnRender.tsx
@@ -11,7 +11,7 @@ export default [
             <span className="text-xs">{dayjs(data?.row?.timestamp / 1000).format('HH:mm:ss')}</span>
           </span>
           <div className="w-16 flex items-center">
-            <SeverityFormatter value={data?.row?.metadata[0].parsed[0].error_severity} />
+            <SeverityFormatter value={data.row.error_severity} />
           </div>
         </div>
         <div className="flex truncate">

--- a/studio/components/interfaces/Settings/Logs/LogSelection.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogSelection.tsx
@@ -45,10 +45,13 @@ const LogSelection: FC<Props> = ({ projectRef, log: partialLog, onClose, queryTy
         return <FunctionLogsSelectionRender log={fullLog} />
 
       default:
-        if (fullLog && isDefaultLogPreviewFormat(fullLog)) {
+        if (queryType && fullLog && isDefaultLogPreviewFormat(fullLog)) {
           return <DefaultPreviewSelectionRenderer log={fullLog} />
         }
-
+        if (queryType && !fullLog) {
+          return null
+        }
+        if (!partialLog) return null
         return <DefaultExplorerSelectionRenderer log={partialLog} />
     }
   }
@@ -128,7 +131,7 @@ const LogSelection: FC<Props> = ({ projectRef, log: partialLog, onClose, queryTy
         </div>
         {isLoading && <Connecting />}
         <div className="bg-scale-300 py-8 flex flex-col space-y-6">
-          {!isLoading && fullLog && <Formatter />}
+          {!isLoading && <Formatter />}
         </div>
       </div>
     </div>

--- a/studio/components/interfaces/Settings/Logs/LogSelection.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogSelection.tsx
@@ -13,52 +13,42 @@ import FunctionInvocationSelectionRender, {
 import FunctionLogsSelectionRender from './LogSelectionRenderers/FunctionLogsSelectionRender'
 import DefaultExplorerSelectionRenderer from './LogSelectionRenderers/DefaultExplorerSelectionRenderer'
 import DefaultPreviewSelectionRenderer from './LogSelectionRenderers/DefaultPreviewSelectionRenderer'
-import { isDefaultLogPreviewFormat } from '.'
+import { isDefaultLogPreviewFormat, LogsTableName } from '.'
+import useSingleLog from 'hooks/analytics/useSingleLog'
 
 interface Props {
   log: LogData | null
   onClose: () => void
   queryType?: QueryType
-  isLoading?: boolean
+  projectRef: string
 }
 
-const LogSelection: FC<Props> = ({ log, onClose, queryType, isLoading }) => {
+const LogSelection: FC<Props> = ({ projectRef, log: partialLog, onClose, queryType }) => {
+  const [{ logData: fullLog, isLoading }] = useSingleLog(projectRef, queryType, partialLog?.id)
   const Formatter = () => {
     switch (queryType) {
       case 'api':
-        return <DatabaseApiSelectionRender log={log} />
+        if (!fullLog) return null
+        return <DatabaseApiSelectionRender log={fullLog} />
 
       case 'database':
-        return <DatabasePostgresSelectionRender log={log} />
+        if (!fullLog) return null
+        return <DatabasePostgresSelectionRender log={fullLog} />
 
       case 'fn_edge':
-        return <FunctionInvocationSelectionRender log={log} />
-        break
+        if (!fullLog) return null
+        return <FunctionInvocationSelectionRender log={fullLog} />
 
       case 'functions':
-        return <FunctionLogsSelectionRender log={log} />
-        break
+        if (!fullLog) return null
+        return <FunctionLogsSelectionRender log={fullLog} />
 
       default:
-        if (log && isDefaultLogPreviewFormat(log)) {
-          return <DefaultPreviewSelectionRenderer log={log} />
+        if (fullLog && isDefaultLogPreviewFormat(fullLog)) {
+          return <DefaultPreviewSelectionRenderer log={fullLog} />
         }
 
-        return <DefaultExplorerSelectionRenderer log={log} />
-    }
-  }
-
-  function header() {
-    switch (queryType) {
-      case 'api':
-        return DatabaseApiSelectionHeaderRender(log)
-
-        break
-      case 'fn_edge':
-        return FunctionInvocationHeaderRender(log)
-
-      default:
-        return null
+        return <DefaultExplorerSelectionRenderer log={partialLog} />
     }
   }
 
@@ -74,7 +64,7 @@ const LogSelection: FC<Props> = ({ log, onClose, queryType, isLoading }) => {
         className={
           `overflow-y-scroll transition-all
           bg-scale-200 absolute w-full h-full text-center flex-col gap-2 flex items-center justify-center opacity-0 ` +
-          (log ? 'opacity-0 z-0' : 'opacity-100 z-10')
+          (partialLog ? 'opacity-0 z-0' : 'opacity-100 z-10')
         }
       >
         <div
@@ -90,7 +80,7 @@ const LogSelection: FC<Props> = ({ log, onClose, queryType, isLoading }) => {
           gap-6
           max-w-sm
           text-center scale-95 opacity-0 ` +
-            (log || isLoading ? 'mt-0 opacity-0 scale-95' : 'mt-8 opacity-100 scale-100')
+            (partialLog || isLoading ? 'mt-0 opacity-0 scale-95' : 'mt-8 opacity-100 scale-100')
           }
         >
           <div className="relative border border-scale-600 dark:border-scale-400 w-32 h-4 rounded px-2 flex items-center">
@@ -135,7 +125,7 @@ const LogSelection: FC<Props> = ({ log, onClose, queryType, isLoading }) => {
         >
           <IconX size={14} strokeWidth={2} />
         </div>
-        <div className="bg-scale-300 py-8 flex flex-col space-y-6">{log && <Formatter />}</div>
+        <div className="bg-scale-300 py-8 flex flex-col space-y-6">{fullLog && <Formatter />}</div>
       </div>
     </div>
   )

--- a/studio/components/interfaces/Settings/Logs/LogSelection.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogSelection.tsx
@@ -1,5 +1,5 @@
 import { FC } from 'react'
-import { IconX } from '@supabase/ui'
+import { IconX, Loading } from '@supabase/ui'
 
 import { LogData, QueryType } from './Logs.types'
 
@@ -15,6 +15,7 @@ import DefaultExplorerSelectionRenderer from './LogSelectionRenderers/DefaultExp
 import DefaultPreviewSelectionRenderer from './LogSelectionRenderers/DefaultPreviewSelectionRenderer'
 import { isDefaultLogPreviewFormat, LogsTableName } from '.'
 import useSingleLog from 'hooks/analytics/useSingleLog'
+import Connecting from 'components/ui/Loading/Loading'
 
 interface Props {
   log: LogData | null
@@ -125,7 +126,10 @@ const LogSelection: FC<Props> = ({ projectRef, log: partialLog, onClose, queryTy
         >
           <IconX size={14} strokeWidth={2} />
         </div>
-        <div className="bg-scale-300 py-8 flex flex-col space-y-6">{fullLog && <Formatter />}</div>
+        {isLoading && <Connecting />}
+        <div className="bg-scale-300 py-8 flex flex-col space-y-6">
+          {!isLoading && fullLog && <Formatter />}
+        </div>
       </div>
     </div>
   )

--- a/studio/components/interfaces/Settings/Logs/LogSelectionRenderers/DatabaseApiSelectionRender.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogSelectionRenderers/DatabaseApiSelectionRender.tsx
@@ -4,14 +4,14 @@ import LogsDivider from '../Logs.Divider'
 import { jsonSyntaxHighlight, ResponseCodeFormatter } from '../LogsFormatters'
 
 const DatabaseApiSelectionRender = ({ log }: any) => {
-  const request = log?.metadata[0]?.request[0]
-  const response = log?.metadata[0]?.response[0]
-  const method = log?.metadata[0]?.request[0]?.method
-  const status = log?.metadata[0]?.response[0].status_code
-  const ipAddress = log?.metadata[0]?.request[0].headers[0]?.cf_connecting_ip
-  const countryOrigin = log?.metadata[0]?.request[0].headers[0]?.cf_ipcountry
-  const clientInfo = log?.metadata[0]?.request[0].headers[0]?.x_client_info
-  const referer = log?.metadata[0]?.request[0].headers[0]?.referer
+  const request = log?.metadata[0]?.request?.[0]
+  const response = log?.metadata[0]?.response?.[0]
+  const method = request?.method
+  const status = response?.status_code
+  const ipAddress = request?.headers?.[0]?.cf_connecting_ip
+  const countryOrigin = request?.headers?.[0]?.cf_ipcountry
+  const clientInfo = request?.headers?.[0]?.x_client_info
+  const referer = request?.headers?.[0]?.referer
 
   const DetailedRow = ({ label, value }: { label: string; value: string | React.ReactNode }) => {
     return (

--- a/studio/components/interfaces/Settings/Logs/LogSelectionRenderers/FunctionInvocationSelectionRender.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogSelectionRenderers/FunctionInvocationSelectionRender.tsx
@@ -1,15 +1,18 @@
 import dayjs from 'dayjs'
 import { filterFunctionsRequestResponse } from 'lib/logs'
+import { PreviewLogData } from '..'
 import { LOGS_TAILWIND_CLASSES } from '../Logs.constants'
 import { jsonSyntaxHighlight, ResponseCodeFormatter } from '../LogsFormatters'
 
-const FunctionInvocationSelectionRender = ({ log }: any) => {
-  const request = log?.request
-  const response = log?.response
-  const method = log?.method
-  const status = log?.status_code
+const FunctionInvocationSelectionRender = ({ log }: { log: PreviewLogData }) => {
+  const metadata = log.metadata?.[0]
+  const request = metadata?.request?.[0]
+  const response = metadata?.response?.[0]
+  const method = request?.method
+  const status = response?.status_code
   const requestUrl = new URL(request?.url)
-  const executionTimeMs = log?.execution_time_ms
+  const executionTimeMs = metadata.execution_time_ms
+  const deploymentId = metadata.deployment_id
   const timestamp = dayjs(log.timestamp / 1000)
 
   const DetailedRow = ({
@@ -42,7 +45,7 @@ const FunctionInvocationSelectionRender = ({ log }: any) => {
         <DetailedRow label="Method" value={method} />
         <DetailedRow label="Timestamp" value={dayjs(timestamp).format('DD MMM, YYYY HH:mm')} />
         <DetailedRow label="Execution Time" value={`${executionTimeMs}ms`} />
-        <DetailedRow label="Deployment ID" value={log.deployment_id} />
+        <DetailedRow label="Deployment ID" value={deploymentId} />
         <DetailedRow label="Log ID" value={log.id} />
         <DetailedRow label="Request Path" value={requestUrl.pathname + requestUrl.search} />
       </div>

--- a/studio/components/interfaces/Settings/Logs/LogSelectionRenderers/FunctionLogsSelectionRender.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogSelectionRenderers/FunctionLogsSelectionRender.tsx
@@ -4,6 +4,7 @@ import { jsonSyntaxHighlight, SeverityFormatter } from '../LogsFormatters'
 
 const FunctionLogsSelectionRender = ({ log }: any) => {
   const timestamp = dayjs(log.timestamp / 1000)
+  const metadata = log.metadata[0]
 
   const DetailedRow = ({
     label,
@@ -38,12 +39,12 @@ const FunctionLogsSelectionRender = ({ log }: any) => {
       </div>
       <div className="h-px w-full bg-panel-border-interior-light dark:bg-panel-border-interior-dark"></div>
       <div className={`${LOGS_TAILWIND_CLASSES.log_selection_x_padding} space-y-2`}>
-        <DetailedRow label="Severity" value={<SeverityFormatter value={log.metadata.level} />} />
-        <DetailedRow label="Log ID" value={log.id} />
-        <DetailedRow label="Deployment version" value={log?.metadata?.version} />
+        {console.log(log)}
+        <DetailedRow label="Severity" value={<SeverityFormatter value={metadata.level} />} />
+        <DetailedRow label="Deployment version" value={metadata.version} />
         <DetailedRow label="Timestamp" value={timestamp.format('DD MMM, YYYY HH:mm')} />
-        <DetailedRow label="Execution ID" value={log.metadata.execution_id} />
-        <DetailedRow label="Deployment ID" value={log.metadata.deployment_id} />
+        <DetailedRow label="Execution ID" value={metadata.execution_id} />
+        <DetailedRow label="Deployment ID" value={metadata.deployment_id} />
       </div>
       <div className={`${LOGS_TAILWIND_CLASSES.log_selection_x_padding}`}>
         <h3 className="text-lg text-scale-1200 mb-4">Metadata</h3>
@@ -51,7 +52,7 @@ const FunctionLogsSelectionRender = ({ log }: any) => {
           <div
             className="text-wrap"
             dangerouslySetInnerHTML={{
-              __html: log.metadata ? jsonSyntaxHighlight(log.metadata) : '',
+              __html: metadata ? jsonSyntaxHighlight(metadata) : '',
             }}
           />
         </pre>

--- a/studio/components/interfaces/Settings/Logs/LogTable.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogTable.tsx
@@ -21,6 +21,7 @@ interface Props {
   isLoading?: boolean
   error?: any
   showDownload?: boolean
+  projectRef: string
 }
 type LogMap = { [id: string]: LogData }
 
@@ -55,6 +56,7 @@ const LogTable = ({
   isLoading,
   showDownload,
   error,
+  projectRef,
 }: Props) => {
   const [focusedLog, setFocusedLog] = useState<LogData | null>(null)
   const firstRow: LogData | undefined = data?.[0] as LogData
@@ -390,7 +392,7 @@ const LogTable = ({
               }
             >
               <LogSelection
-                isLoading={isLoading}
+                projectRef={projectRef}
                 onClose={() => setFocusedLog(null)}
                 log={focusedLog}
                 queryType={queryType}

--- a/studio/components/interfaces/Settings/Logs/Logs.types.ts
+++ b/studio/components/interfaces/Settings/Logs/Logs.types.ts
@@ -1,7 +1,7 @@
 import React from 'react'
 
 interface Metadata {
-  [key: string]: string | number | Object | Object[]
+  [key: string]: string | number | Object | Object[] | any
 }
 
 export type DatePickerToFrom = { to: string | null; from: string | null }

--- a/studio/components/interfaces/Settings/Logs/Logs.types.ts
+++ b/studio/components/interfaces/Settings/Logs/Logs.types.ts
@@ -32,7 +32,7 @@ export interface PreviewLogData extends CustomLogData {
   id: string
   timestamp: number
   event_message: string
-  metadata: Metadata
+  metadata?: Metadata
 }
 export type LogData = CustomLogData & PreviewLogData
 

--- a/studio/components/interfaces/Settings/Logs/Logs.utils.ts
+++ b/studio/components/interfaces/Settings/Logs/Logs.utils.ts
@@ -125,7 +125,7 @@ export const genDefaultQuery = (table: LogsTableName, filters: Filters) => {
 
   switch (table) {
     case 'edge_logs':
-      return `select id, timestamp, event_message, metadata, request, response, request.method, request.path, response.status_code
+      return `select id, timestamp, event_message, request, response, request.method, request.path, response.status_code
   from ${table}
   cross join unnest(metadata) as m
   cross join unnest(m.request) as request
@@ -133,24 +133,21 @@ export const genDefaultQuery = (table: LogsTableName, filters: Filters) => {
   ${where}
   limit 100
   `
-      break
 
     case 'postgres_logs':
-      return `select postgres_logs.timestamp, id, event_message, metadata, metadataparsed.error_severity from ${table} 
+      return `select postgres_logs.timestamp, id, event_message, parsed.error_severity from ${table} 
   cross join unnest(metadata) as m 
-  cross join unnest(m.parsed) as metadataparsed 
+  cross join unnest(m.parsed) as parsed 
   ${where} 
   limit 100
   `
-      break
 
     case 'function_logs':
-      return `select id, ${table}.timestamp, event_message, metadata.event_type, metadata.function_id, metadata.level, metadata from ${table}
+      return `select id, ${table}.timestamp, event_message, metadata.event_type, metadata.function_id, metadata.level from ${table}
   cross join unnest(metadata) as metadata
   ${where}
   limit 100
     `
-      break
 
     case 'function_edge_logs':
       return `select id, ${table}.timestamp, event_message, response.status_code, response, request, request.method, m.function_id, m.execution_time_ms, m.deployment_id, m.version from ${table} 
@@ -162,10 +159,14 @@ export const genDefaultQuery = (table: LogsTableName, filters: Filters) => {
   `
 
     default:
-      return `select id, ${table}.timestamp, event_message, metadata from ${table}
+      return `select id, ${table}.timestamp, event_message from ${table}
   ${where}
   limit 100          
   `
-      break
   }
 }
+
+/**
+ * SQL query to retrieve only one log
+ */
+export const genSingleLogQuery = (table: LogsTableName, id: string) => `select id, timestamp, event_message, metadata from ${table} where id = '${id}'' limit 1`

--- a/studio/components/interfaces/Settings/Logs/Logs.utils.ts
+++ b/studio/components/interfaces/Settings/Logs/Logs.utils.ts
@@ -169,4 +169,4 @@ export const genDefaultQuery = (table: LogsTableName, filters: Filters) => {
 /**
  * SQL query to retrieve only one log
  */
-export const genSingleLogQuery = (table: LogsTableName, id: string) => `select id, timestamp, event_message, metadata from ${table} where id = '${id}'' limit 1`
+export const genSingleLogQuery = (table: LogsTableName, id: string) => `select id, timestamp, event_message, metadata from ${table} where id = '${id}' limit 1`

--- a/studio/components/interfaces/Settings/Logs/LogsPreviewer.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogsPreviewer.tsx
@@ -156,6 +156,7 @@ export const LogsPreviewer: React.FC<Props> = ({
         <ShimmerLine active={isLoading} />
         <LoadingOpacity active={isLoading}>
           <LogTable
+            projectRef={projectRef}
             isLoading={isLoading}
             data={logData}
             queryType={queryType}

--- a/studio/hooks/analytics/useLogsPreview.tsx
+++ b/studio/hooks/analytics/useLogsPreview.tsx
@@ -145,6 +145,7 @@ function useLogsPreview(
       setFilters((prev) => ({ ...prev, ...newFilters, ...filterOverride }))
     }
   }
+  console.log(logData)
   return [
     {
       newCount,

--- a/studio/hooks/analytics/useLogsPreview.tsx
+++ b/studio/hooks/analytics/useLogsPreview.tsx
@@ -145,7 +145,6 @@ function useLogsPreview(
       setFilters((prev) => ({ ...prev, ...newFilters, ...filterOverride }))
     }
   }
-  console.log(logData)
   return [
     {
       newCount,

--- a/studio/hooks/analytics/useSingleLog.tsx
+++ b/studio/hooks/analytics/useSingleLog.tsx
@@ -1,0 +1,56 @@
+import {
+  genQueryParams,
+  genSingleLogQuery,
+  LogData,
+  Logs,
+  LogsEndpointParams,
+  LOGS_TABLES,
+  QueryType,
+} from 'components/interfaces/Settings/Logs'
+import useSWR from 'swr'
+import { API_URL } from 'lib/constants'
+import { get } from 'lib/common/fetch'
+
+interface Data {
+  logData: LogData | undefined
+  error: string | Object | null
+  isLoading: boolean
+}
+interface Handlers {
+  refresh: () => void
+}
+function useSingleLog(
+  project: string,
+  queryType?: QueryType,
+  id?: string | null
+): [Data, Handlers] {
+  const table = queryType ? LOGS_TABLES[queryType] : undefined
+  const sql = id && table ? genSingleLogQuery(table, id) : ''
+  const params: LogsEndpointParams = { project, sql }
+  const endpointUrl = `${API_URL}/projects/${project}/analytics/endpoints/logs.all?${genQueryParams(
+    params as any
+  )}`
+  const {
+    data,
+    error: swrError,
+    isValidating,
+    mutate,
+  } = useSWR<Logs>(id && table ? endpointUrl : null, get, {
+    revalidateOnFocus: false,
+    dedupingInterval: 3000,
+  })
+
+  let error: null | string | object = swrError ? swrError.message : null
+
+  return [
+    {
+      logData: data ? data.result[0] : undefined,
+      isLoading: isValidating,
+      error,
+    },
+    {
+      refresh: () => mutate(),
+    },
+  ]
+}
+export default useSingleLog

--- a/studio/hooks/analytics/useSingleLog.tsx
+++ b/studio/hooks/analytics/useSingleLog.tsx
@@ -37,14 +37,15 @@ function useSingleLog(
     mutate,
   } = useSWR<Logs>(id && table ? endpointUrl : null, get, {
     revalidateOnFocus: false,
-    dedupingInterval: 3000,
+    revalidateIfStale: false,
+    revalidateOnReconnect: false,
+    dedupingInterval: 5000,
   })
 
   let error: null | string | object = swrError ? swrError.message : null
-
   return [
     {
-      logData: data ? data.result[0] : undefined,
+      logData: data?.result ? data.result[0] : undefined,
       isLoading: isValidating,
       error,
     },

--- a/studio/pages/project/[ref]/logs-explorer/index.tsx
+++ b/studio/pages/project/[ref]/logs-explorer/index.tsx
@@ -150,7 +150,7 @@ export const LogsExplorerPage: NextPageWithLayout = () => {
         <div className="relative flex flex-grow flex-col">
           <LoadingOpacity active={isLoading}>
             <div className="flex h-full flex-grow">
-              <LogTable data={logData} error={error} />
+              <LogTable data={logData} error={error} projectRef={ref as string} />
             </div>
           </LoadingOpacity>
           <div className="mt-2 flex flex-row justify-end">

--- a/studio/tests/fixtures.ts
+++ b/studio/tests/fixtures.ts
@@ -4,6 +4,5 @@ export const logDataFixture = (attrs: Partial<LogData>): LogData => ({
   id: `some-uuid-${new Date().getTime()}`,
   timestamp: new Date().getTime() * 1000,
   event_message: 'first event',
-  metadata: {},
   ...attrs,
 })

--- a/studio/tests/pages/projects/LogTable.test.js
+++ b/studio/tests/pages/projects/LogTable.test.js
@@ -1,6 +1,7 @@
 import LogTable from 'components/interfaces/Settings/Logs/LogTable'
 import { render, waitFor, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+
 test('can display log data', async () => {
   render(
     <LogTable
@@ -19,8 +20,8 @@ test('can display log data', async () => {
 
   const row = await screen.findByText(/some-uuid/)
   userEvent.click(row)
-  await waitFor(() => screen.getByText(/my_key/))
-  await waitFor(() => screen.getByText(/something_value/))
+  await screen.findByText(/my_key/)
+  await screen.findByText(/something_value/)
 })
 
 test('dedupes log lines with exact id', async () => {

--- a/studio/tests/pages/projects/LogsPreviewer.test.js
+++ b/studio/tests/pages/projects/LogsPreviewer.test.js
@@ -108,20 +108,30 @@ test('can display log data and metadata', async () => {
 test('Refresh page', async () => {
   get.mockImplementation((url) => {
     if (url.includes('count')) return { result: { count: 0 } }
+    if (url.includes('where+id')) {
+      return {
+        result: [
+          {
+            id: 'some-id',
+            metadata: [{ request: [{ method: 'POST' }] }],
+          },
+        ],
+      }
+    }
     return {
       result: [
         logDataFixture({
-          id: 'some-event-id',
-          metadata: { my_key: 'something_value' },
+          id: 'some-id',
+          request: { path: 'some-event' },
         }),
       ],
     }
   })
-  render(<LogsPreviewer projectRef="123" tableName={LogsTableName.EDGE} />)
+  render(<LogsPreviewer projectRef="123" queryType="api" tableName={LogsTableName.EDGE} />)
 
-  const row = await screen.findByText(/some-event-id/)
+  const row = await screen.findByText(/some-event/)
   fireEvent.click(row)
-  await screen.findByText(/my_key/)
+  await screen.findAllByText(/POST/)
 })
 
 test('Search will trigger a log refresh', async () => {


### PR DESCRIPTION
Delays the fetching of log metadata, to reduce selected columns & rows in the default generated query.

Removes the metadata column from the default generated query. Thereafter, on log selection, the log metadata is lazy loaded, reducing query memory required.

This PR also includes some UI fixes for functions, which we were not able to have a working dev env until now.

Todo:
- [x] test on dev
- [x] loading state 
- [x] test functions logs ui in dev
- [x] ui tests

https://user-images.githubusercontent.com/22714384/180422137-98e03548-e87b-41ff-b94e-a9ace8aeafec.mov


https://user-images.githubusercontent.com/22714384/180422145-bec6bc36-0e8b-455b-ba1c-da0b53067753.mov


https://user-images.githubusercontent.com/22714384/180701662-fb3bb010-4ffc-4ab3-91d3-e753d9104bde.mov


https://user-images.githubusercontent.com/22714384/180701673-61b132c2-edfa-4352-8364-26d6f6f43c91.mov


