### PR TITLE
fix: switches the default previewer datetime range to 1 hr

### DIFF
--- a/studio/components/interfaces/Settings/Logs/Logs.constants.ts
+++ b/studio/components/interfaces/Settings/Logs/Logs.constants.ts
@@ -435,6 +435,7 @@ export const PREVIEWER_DATEPICKER_HELPERS: DatetimeHelper[] = [
     text: 'Last hour',
     calcFrom: () => dayjs().subtract(1, 'hour').startOf('hour').toISOString(),
     calcTo: () => '',
+    default: true,
   },
   {
     text: 'Last 3 hours',
@@ -445,7 +446,6 @@ export const PREVIEWER_DATEPICKER_HELPERS: DatetimeHelper[] = [
     text: 'Last day',
     calcFrom: () => dayjs().subtract(1, 'day').startOf('day').toISOString(),
     calcTo: () => '',
-    default: true,
   },
 ]
 export const EXPLORER_DATEPICKER_HELPERS: DatetimeHelper[] = [

--- a/studio/tests/pages/projects/PreviewFilterPanel.test.js
+++ b/studio/tests/pages/projects/PreviewFilterPanel.test.js
@@ -50,10 +50,10 @@ test('Manual refresh', async () => {
 })
 test('Datepicker dropdown', async () => {
   render(<PreviewFilterPanel />)
-  clickDropdown(await screen.findByText(/Last day/))
+  clickDropdown(await screen.findByText(/Last hour/))
   userEvent.click(await screen.findByText(/Last 3 hours/))
   await screen.findByText(/Last 3 hours/)
-  await expect(screen.findByText(/Last day/)).rejects.toThrow()
+  await expect(screen.findByText(/Last hour/)).rejects.toThrow()
 })
 
 test.todo('timestamp to/from filter default value')


### PR DESCRIPTION
Adjusts the log previewer's default datetime range to 1 hour, to reduce chance of out-of-memory errors.

todos:
- [x] test on dev