### PR TITLE
Avoid error on signOut when using some frameworks

### DIFF
--- a/web/docs/guides/with-svelte.mdx
+++ b/web/docs/guides/with-svelte.mdx
@@ -405,8 +405,8 @@ Now that we have all the components in place, let's update `App.svelte`:
 
 	user.set(supabase.auth.user())
 
-	supabase.auth.onAuthStateChange((_, session) => {
-		user.set(session.user)
+	supabase.auth.onAuthStateChange((state, session) => {
+		user.set(state === 'SIGNED_IN' && session.user)
 	})
 </script>
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

A small fix to the source code in the Svelte Quickstart guide. This was needed for me, when using Astro and for others when using SvelteKit.

This change is already merged into the source code repo, see https://github.com/yustarandomname/svelte-supabase-quickstart/pull/3.

## What is the current behavior?

Error on signOut when using some frameworks. See also https://github.com/supabase/supabase/discussions/3468#discussioncomment-2742352 for nullart2 discussing SvelteKit.

## What is the new behavior?

The error is no longer thrown, and the guide works as expected, also when using these frameworks.

