### PR TITLE
feat: help popover status button

### DIFF
--- a/studio/components/layouts/ProjectLayout/LayoutHeader/HelpPopover.tsx
+++ b/studio/components/layouts/ProjectLayout/LayoutHeader/HelpPopover.tsx
@@ -5,6 +5,7 @@ import {
   IconMessageCircle,
   Popover,
   IconBookOpen,
+  IconActivity
 } from '@supabase/ui'
 import { useRouter } from 'next/router'
 import { FC } from 'react'
@@ -46,6 +47,13 @@ const HelpPopover: FC<Props> = () => {
                 <a>
                   <Button type="secondary" size="tiny" icon={<IconBookOpen />}>
                     Docs
+                  </Button>
+                </a>
+              </Link>
+              <Link href="https://status.supabase.com/">
+                <a>
+                  <Button type="secondary" size="tiny" icon={<IconActivity />}>
+                    Status
                   </Button>
                 </a>
               </Link>

--- a/studio/components/layouts/ProjectLayout/LayoutHeader/HelpPopover.tsx
+++ b/studio/components/layouts/ProjectLayout/LayoutHeader/HelpPopover.tsx
@@ -5,7 +5,7 @@ import {
   IconMessageCircle,
   Popover,
   IconBookOpen,
-  IconActivity
+  IconActivity,
 } from '@supabase/ui'
 import { useRouter } from 'next/router'
 import { FC } from 'react'

--- a/studio/components/layouts/ProjectLayout/LayoutHeader/HelpPopover.tsx
+++ b/studio/components/layouts/ProjectLayout/LayoutHeader/HelpPopover.tsx
@@ -35,11 +35,11 @@ const HelpPopover: FC<Props> = () => {
               For issues with your project hosted on supabase.com, or other inquiries about our
               hosted services.
             </p>
-            <div className="space-x-2">
+            <div className="space-x-1">
               <Link href={supportUrl}>
                 <a>
                   <Button type="default" icon={<IconMail />}>
-                    Contact support team
+                    Contact Support
                   </Button>
                 </a>
               </Link>
@@ -53,7 +53,7 @@ const HelpPopover: FC<Props> = () => {
               <Link href="https://status.supabase.com/">
                 <a>
                   <Button type="secondary" size="tiny" icon={<IconActivity />}>
-                    Status
+                    Supabase Status
                   </Button>
                 </a>
               </Link>

--- a/studio/components/layouts/ProjectLayout/LayoutHeader/HelpPopover.tsx
+++ b/studio/components/layouts/ProjectLayout/LayoutHeader/HelpPopover.tsx
@@ -36,17 +36,17 @@ const HelpPopover: FC<Props> = () => {
               hosted services.
             </p>
             <div className="space-x-1">
-              <Link href={supportUrl}>
+              <Link passHref href={supportUrl}>
                 <Button type="default" icon={<IconMail />} as="a">
                   Contact Support
                 </Button>
               </Link>
-              <Link href="https://supabase.com/docs/">
+              <Link passHref href="https://supabase.com/docs/">
                 <Button type="text" size="tiny" icon={<IconBookOpen />} as="a">
                   Docs
                 </Button>
               </Link>
-              <Link href="https://status.supabase.com/">
+              <Link passHref href="https://status.supabase.com/">
                 <Button type="text" size="tiny" icon={<IconActivity />} as="a">
                   Supabase Status
                 </Button>

--- a/studio/components/layouts/ProjectLayout/LayoutHeader/HelpPopover.tsx
+++ b/studio/components/layouts/ProjectLayout/LayoutHeader/HelpPopover.tsx
@@ -42,12 +42,12 @@ const HelpPopover: FC<Props> = () => {
                 </Button>
               </Link>
               <Link href="https://supabase.com/docs/">
-                <Button type="secondary" size="tiny" icon={<IconBookOpen />}>
+                <Button type="text" size="tiny" icon={<IconBookOpen />}>
                   Docs
                 </Button>
               </Link>
               <Link href="https://status.supabase.com/">
-                <Button type="secondary" size="tiny" icon={<IconActivity />}>
+                <Button type="text" size="tiny" icon={<IconActivity />}>
                   Supabase Status
                 </Button>
               </Link>

--- a/studio/components/layouts/ProjectLayout/LayoutHeader/HelpPopover.tsx
+++ b/studio/components/layouts/ProjectLayout/LayoutHeader/HelpPopover.tsx
@@ -37,17 +37,17 @@ const HelpPopover: FC<Props> = () => {
             </p>
             <div className="space-x-1">
               <Link href={supportUrl}>
-                <Button type="default" icon={<IconMail />}>
+                <Button type="default" icon={<IconMail />} as="a">
                   Contact Support
                 </Button>
               </Link>
               <Link href="https://supabase.com/docs/">
-                <Button type="text" size="tiny" icon={<IconBookOpen />}>
+                <Button type="text" size="tiny" icon={<IconBookOpen />} as="a">
                   Docs
                 </Button>
               </Link>
               <Link href="https://status.supabase.com/">
-                <Button type="text" size="tiny" icon={<IconActivity />}>
+                <Button type="text" size="tiny" icon={<IconActivity />} as="a">
                   Supabase Status
                 </Button>
               </Link>

--- a/studio/components/layouts/ProjectLayout/LayoutHeader/HelpPopover.tsx
+++ b/studio/components/layouts/ProjectLayout/LayoutHeader/HelpPopover.tsx
@@ -37,25 +37,19 @@ const HelpPopover: FC<Props> = () => {
             </p>
             <div className="space-x-1">
               <Link href={supportUrl}>
-                <a>
-                  <Button type="default" icon={<IconMail />}>
-                    Contact Support
-                  </Button>
-                </a>
+                <Button type="default" icon={<IconMail />}>
+                  Contact Support
+                </Button>
               </Link>
               <Link href="https://supabase.com/docs/">
-                <a>
-                  <Button type="secondary" size="tiny" icon={<IconBookOpen />}>
-                    Docs
-                  </Button>
-                </a>
+                <Button type="secondary" size="tiny" icon={<IconBookOpen />}>
+                  Docs
+                </Button>
               </Link>
               <Link href="https://status.supabase.com/">
-                <a>
-                  <Button type="secondary" size="tiny" icon={<IconActivity />}>
-                    Supabase Status
-                  </Button>
-                </a>
+                <Button type="secondary" size="tiny" icon={<IconActivity />}>
+                  Supabase Status
+                </Button>
               </Link>
             </div>
             <p className="text-sm text-scale-900">


### PR DESCRIPTION
## What kind of change does this PR introduce?

Studio Feature

## What is the current behavior?

On the Supabase Discord recently I've see seen some message to see if Supabase is down or issues with connectivity and links have been made to the [status](https://status.supabase.com/) website.

## What is the new behavior?

A button on the help overlay has been added so that users can just click on the button and see the status of Supabase easier.

