### PR TITLE
fix pagination input style, fix debouncing issues, add max input page…

### DIFF
--- a/studio/components/grid/components/footer/pagination/Pagination.tsx
+++ b/studio/components/grid/components/footer/pagination/Pagination.tsx
@@ -28,10 +28,6 @@ const Pagination: FC<PaginationProps> = () => {
   const maxPages = Math.ceil(state.totalRows / state.rowsPerPage)
   const totalPages = state.totalRows > 0 ? maxPages : 1
 
-  useEffect(() => {
-    if (state.page != page) setPage(state.page)
-  }, [state.page, page])
-
   // [Joshen] Oddly without this, state.selectedRows will be stale
   useEffect(() => {}, [state.selectedRows])
 
@@ -93,7 +89,7 @@ const Pagination: FC<PaginationProps> = () => {
 
   function onPageChange(event: React.ChangeEvent<HTMLInputElement>) {
     const value = event.target.value
-    const pageNum = Number(value)
+    const pageNum = Number(value) > maxPages ? maxPages : Number(value)
     setPage(pageNum)
     updatePageDebounced(pageNum, dispatch)
   }
@@ -120,7 +116,6 @@ const Pagination: FC<PaginationProps> = () => {
             <InputNumber
               value={page}
               onChange={onPageChange}
-              className="sb-grid-pagination-input"
               size="tiny"
               style={{
                 width: '3rem',


### PR DESCRIPTION
… control

## What kind of change does this PR introduce?
Bug fix for pagination input style and behavior. Added max page control to the input as well.

## What is the current behavior?
The input does not have the correct styling, and gets blocked until the fetch is debounced correctly

## What is the new behavior?
The input has the correct styles, input does not get blocked while it gets debounced, the input will go to the last page when users try to input more than the max pages available.

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
