### PR TITLE
remove preselected aws region for new project

### DIFF
--- a/studio/pages/new/[slug].tsx
+++ b/studio/pages/new/[slug].tsx
@@ -47,7 +47,7 @@ const Wizard: NextPageWithLayout = () => {
 
   const [projectName, setProjectName] = useState('')
   const [dbPass, setDbPass] = useState('')
-  const [dbRegion, setDbRegion] = useState(REGIONS_DEFAULT)
+  const [dbRegion, setDbRegion] = useState<string | undefined>(undefined)
   const [dbPricingTierKey, setDbPricingTierKey] = useState(PRICING_TIER_DEFAULT_KEY)
   const [newProjectedLoading, setNewProjectLoading] = useState(false)
   const [passwordStrengthMessage, setPasswordStrengthMessage] = useState('')
@@ -78,7 +78,7 @@ const Wizard: NextPageWithLayout = () => {
   const canSubmit =
     projectName != '' &&
     passwordStrengthScore >= DEFAULT_MINIMUM_PASSWORD_STRENGTH &&
-    dbRegion != '' &&
+    dbRegion &&
     dbPricingTierKey != '' &&
     (isSelectFreeTier || (!isSelectFreeTier && !isEmptyPaymentMethod))
 
@@ -301,6 +301,14 @@ const Wizard: NextPageWithLayout = () => {
                     onChange={(value: string) => onDbRegionChange(value)}
                     descriptionText="Select a region close to you for the best performance."
                   >
+                    <Listbox.Option
+                      key={'empty-label'}
+                      label={'Please choose a region'}
+                      value={''}
+                      disabled
+                    >
+                      <span className="text-scale-1200">{'Please choose a region'}</span>
+                    </Listbox.Option>
                     {Object.keys(REGIONS).map((option: string, i) => {
                       const label = Object.values(REGIONS)[i]
                       return (


### PR DESCRIPTION
## What kind of change does this PR introduce?
Users will need to choose a region before creating a new project

## What is the current behavior?
West US AWS region is preselected because its the first one on the REGIONS object

## What is the new behavior?
There is no pre selected region, the users are presented with the dropdown that says 'Please choose a region'

Feel free to include screenshots if it includes visual changes.

![Screen Shot 2022-07-27 at 14 24 02](https://user-images.githubusercontent.com/1002620/181310486-f5e9c305-f08d-429f-acb7-07bb4050a3a5.png)

