### PR TITLE
fix: LogTable formatting fixes

### DIFF
--- a/studio/components/interfaces/Settings/Logs/LogColumnRenderers/DatabaseApiColumnRender.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogColumnRenderers/DatabaseApiColumnRender.tsx
@@ -1,20 +1,14 @@
-import dayjs from 'dayjs'
-import { ResponseCodeFormatter } from '../LogsFormatters'
+import { ResponseCodeFormatter, TimestampLocalFormatter } from '../LogsFormatters'
 
 export default [
   {
     formatter: (data: any) => (
       <div className="flex h-full w-full items-center justify-between gap-3">
+        <TimestampLocalFormatter value={data.row.timestamp!} />
         <div className="flex h-full w-full items-center gap-4">
           <ResponseCodeFormatter row={data} value={data.row.status_code} />
           <span className="text-xs w-14">{data.row.request.method}</span>
           <span className="font-mono text-xs">{data.row.request.path}</span>
-        </div>
-        <div>
-          <span className="flex w-full h-full items-center gap-1">
-            <span className="text-xs">{dayjs(data?.row?.timestamp / 1000).format('DD MMM')}</span>
-            <span className="text-xs">{dayjs(data?.row?.timestamp / 1000).format('HH:mm:ss')}</span>
-          </span>
         </div>
       </div>
     ),

--- a/studio/components/interfaces/Settings/Logs/LogColumnRenderers/DatabasePostgresColumnRender.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogColumnRenderers/DatabasePostgresColumnRender.tsx
@@ -1,15 +1,11 @@
-import dayjs from 'dayjs'
-import { SeverityFormatter } from '../LogsFormatters'
+import { SeverityFormatter, TimestampLocalFormatter } from '../LogsFormatters'
 
 export default [
   {
     formatter: (data: any) => (
       <div className="flex w-full items-center gap-2 h-full">
         <div className="flex items-center gap-2 h-full">
-          <span className="w-24 flex items-center gap-1">
-            <span className="text-xs">{dayjs(data?.row?.timestamp / 1000).format('DD MMM')}</span>
-            <span className="text-xs">{dayjs(data?.row?.timestamp / 1000).format('HH:mm:ss')}</span>
-          </span>
+          <TimestampLocalFormatter className="w-24" value={data.row.timestamp!} />
           <div className="w-16 flex items-center">
             <SeverityFormatter value={data.row.error_severity} />
           </div>

--- a/studio/components/interfaces/Settings/Logs/LogColumnRenderers/DefaultPreviewColumnRenderer.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogColumnRenderers/DefaultPreviewColumnRenderer.tsx
@@ -6,10 +6,7 @@ const DefaultPreviewColumnRenderer = [
     formatter: (data: { row: PreviewLogData }) => {
       return (
         <div className="flex w-full items-center gap-4 h-full">
-          <span className="w-24 flex items-center gap-1">
-            <TimestampLocalFormatter value={data.row.timestamp!} />
-          </span>
-
+          <TimestampLocalFormatter value={data.row.timestamp!} className="w-24" />
           <span className="font-mono text-xs truncate">{data.row.event_message}</span>
         </div>
       )

--- a/studio/components/interfaces/Settings/Logs/LogColumnRenderers/DefaultPreviewColumnRenderer.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogColumnRenderers/DefaultPreviewColumnRenderer.tsx
@@ -1,17 +1,19 @@
-import { isUnixMicro, PreviewLogData, unixMicroToIsoTimestamp } from '..'
+import { PreviewLogData } from '..'
+import { TimestampLocalFormatter } from '../LogsFormatters'
 
 const DefaultPreviewColumnRenderer = [
   {
-    formatter: (data: { row: PreviewLogData }) => (
-      <div className="flex w-full items-center gap-4 h-full">
-        <span className="flex items-center text-xs pr-2">
-          {isUnixMicro(data?.row?.timestamp)
-            ? unixMicroToIsoTimestamp(data?.row?.timestamp)
-            : data?.row?.timestamp}
-        </span>
-        <span className="font-mono text-xs truncate">{data.row.event_message}</span>
-      </div>
-    ),
+    formatter: (data: { row: PreviewLogData }) => {
+      return (
+        <div className="flex w-full items-center gap-4 h-full">
+          <span className="w-24 flex items-center gap-1">
+            <TimestampLocalFormatter value={data.row.timestamp!} />
+          </span>
+
+          <span className="font-mono text-xs truncate">{data.row.event_message}</span>
+        </div>
+      )
+    },
   },
 ]
 export default DefaultPreviewColumnRenderer

--- a/studio/components/interfaces/Settings/Logs/LogColumnRenderers/DefaultPreviewColumnRenderer.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogColumnRenderers/DefaultPreviewColumnRenderer.tsx
@@ -5,8 +5,8 @@ const DefaultPreviewColumnRenderer = [
   {
     formatter: (data: { row: PreviewLogData }) => {
       return (
-        <div className="flex w-full items-center gap-4 h-full">
-          <TimestampLocalFormatter value={data.row.timestamp!} className="w-24" />
+        <div className="flex w-full justify-start items-center gap-4 h-full">
+          <TimestampLocalFormatter value={data.row.timestamp!} />
           <span className="font-mono text-xs truncate">{data.row.event_message}</span>
         </div>
       )

--- a/studio/components/interfaces/Settings/Logs/LogColumnRenderers/FunctionsEdgeColumnRender.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogColumnRenderers/FunctionsEdgeColumnRender.tsx
@@ -1,5 +1,4 @@
-import dayjs from 'dayjs'
-import { HeaderFormmater, ResponseCodeFormatter } from '../LogsFormatters'
+import { HeaderFormmater, ResponseCodeFormatter, TimestampLocalFormatter } from '../LogsFormatters'
 
 export default [
   {
@@ -10,13 +9,7 @@ export default [
       </div>
     ),
     name: 'timestamp',
-    formatter: (data: any) => (
-      <span className="flex w-full h-full items-center gap-1">
-        <span className="text-xs">{dayjs(data?.row?.timestamp / 1000).format('DD MMM')}</span>
-        <span className="text-xs">{dayjs(data?.row?.timestamp / 1000).format('HH:mm:ss')}</span>
-        {/* {data?.row?.timestamp} */}
-      </span>
-    ),
+    formatter: (data: any) => <TimestampLocalFormatter value={data.row.timestamp!} />,
     width: 128,
   },
   {

--- a/studio/components/interfaces/Settings/Logs/LogColumnRenderers/FunctionsLogsColumnRender.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogColumnRenderers/FunctionsLogsColumnRender.tsx
@@ -1,5 +1,4 @@
-import dayjs from 'dayjs'
-import { HeaderFormmater, SeverityFormatter } from '../LogsFormatters'
+import { HeaderFormmater, SeverityFormatter, TimestampLocalFormatter } from '../LogsFormatters'
 
 export default [
   {
@@ -11,15 +10,7 @@ export default [
     ),
     name: 'timestamp',
     formatter: (data: any) => (
-      <span className="flex w-full h-full items-center gap-1">
-        <span className="text-xs !text-scale-1100">
-          {dayjs(data?.row?.timestamp / 1000).format('DD MMM')}
-        </span>
-        <span className="text-xs !text-scale-1100">
-          {dayjs(data?.row?.timestamp / 1000).format('HH:mm:ss')}
-        </span>
-        {/* {data?.row?.timestamp} */}
-      </span>
+      <TimestampLocalFormatter className="!text-scale-1100" value={data.row.timestamp!} />
     ),
     width: 128,
     resizable: true,

--- a/studio/components/interfaces/Settings/Logs/LogEventChart.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogEventChart.tsx
@@ -27,7 +27,6 @@ const LogEventChart: React.FC<Props> = ({ data, onBarClick }) => {
         onBarClick((Number(timestamp) + 60) * 1000 * 1000)
       }}
       customDateFormat="MMM D, HH:mm"
-      displayDateInUtc
       noDataMessage={''}
     />
   )
@@ -89,7 +88,6 @@ const useAggregated = (data: LogData[]) => {
     for (const [key, value] of Object.entries(countMap)) {
       const v: number = Number(key)
       aggregated.push({
-        period_start: dayjs.unix(v).utc().format(),
         timestamp: key,
         timestampMicro: v * 1000 * 1000,
         count: value,

--- a/studio/components/interfaces/Settings/Logs/LogSelectionRenderers/DatabaseApiSelectionRender.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogSelectionRenderers/DatabaseApiSelectionRender.tsx
@@ -17,7 +17,9 @@ const DatabaseApiSelectionRender = ({ log }: any) => {
     return (
       <div className="grid grid-cols-12">
         <span className="text-scale-900 text-sm col-span-4 whitespace-pre-wrap">{label}</span>
-        <span className="text-scale-1200 text-base col-span-8 whitespace-pre-wrap">{value}</span>
+        <span className="text-scale-1200 text-sm col-span-8 whitespace-pre-wrap break-all">
+          {value}
+        </span>
       </div>
     )
   }

--- a/studio/components/interfaces/Settings/Logs/LogSelectionRenderers/DefaultPreviewSelectionRenderer.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogSelectionRenderers/DefaultPreviewSelectionRenderer.tsx
@@ -36,7 +36,7 @@ const DefaultPreviewSelectionRenderer = ({ log }: any) => {
       </div>
 
       <DetailedRow
-        label="Timestamp"
+        label="ISO Timestamp"
         value={isUnixMicro(log.timestamp) ? unixMicroToIsoTimestamp(log.timestamp) : log.timestamp}
       />
       <div className="flex flex-col gap-3">

--- a/studio/components/interfaces/Settings/Logs/Logs.utils.ts
+++ b/studio/components/interfaces/Settings/Logs/Logs.utils.ts
@@ -16,12 +16,7 @@ export const isUnixMicro = (unix: string | number): boolean => {
 }
 
 export const isDefaultLogPreviewFormat = (log: LogData) =>
-  log &&
-  log.timestamp &&
-  log.metadata &&
-  log.event_message &&
-  log.id &&
-  Object.keys(log).length === 4
+  log && log.timestamp && log.event_message && log.id
 
 /**
  * Recursively retrieve all nested object key paths.

--- a/studio/components/interfaces/Settings/Logs/LogsFormatters.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogsFormatters.tsx
@@ -5,6 +5,8 @@
  */
 
 import { IconAlertCircle, IconInfo } from '@supabase/ui'
+import dayjs from 'dayjs'
+import { isUnixMicro, unixMicroToIsoTimestamp } from '.'
 
 export const ResponseCodeFormatter = ({ value }: any) => {
   if (!value) {
@@ -164,6 +166,23 @@ export const SeverityFormatter = ({ value }: { value: string }) => {
       )
       break
   }
+}
+
+/**
+ * Formats a timestamp into a local timestamp display
+ *
+ * Accepts either unix microsecond or iso timestamp.
+ * For LogTable column rendering
+ */
+export const TimestampLocalFormatter = ({
+  value,
+}: {
+  className?: string
+  value: string | number
+}) => {
+  const timestamp = isUnixMicro(value) ? unixMicroToIsoTimestamp(value) : value
+  const formattedTimestamp = dayjs(timestamp).format('DD MMM, HH:mm:ss')
+  return <span className={'text-xs'}>{formattedTimestamp}</span>
 }
 
 /*

--- a/studio/components/interfaces/Settings/Logs/LogsFormatters.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogsFormatters.tsx
@@ -29,8 +29,7 @@ export const ResponseCodeFormatter = ({ value }: any) => {
         <div className="flex items-center h-full">
           <div
             className="relative rounded px-2 py-1 text-center h-6 flex justify-center items-center
-            bg-scale-300 dark:bg-scale-600
-            
+            bg-scale-500 dark:bg-scale-400 border
             "
           >
             <label className="block font-mono text-sm text-scale-900">{value}</label>
@@ -45,7 +44,7 @@ export const ResponseCodeFormatter = ({ value }: any) => {
           <div
             className="relative rounded px-2 py-1 text-center h-6 flex justify-center items-center
             bg-red-400
-            
+
             "
           >
             <label className="block font-mono text-sm text-red-1100">{value}</label>
@@ -61,7 +60,7 @@ export const ResponseCodeFormatter = ({ value }: any) => {
           <div
             className="relative rounded px-2 py-1 text-center h-6 flex justify-center items-center
             bg-amber-400
-            
+
             "
           >
             <label className="block font-mono text-sm text-amber-1100 dark:text-amber-900">
@@ -78,7 +77,7 @@ export const ResponseCodeFormatter = ({ value }: any) => {
           <div
             className="relative rounded px-2 py-1 text-center h-6 flex justify-center items-center
             bg-scale-300
-            
+
             "
           >
             <label className="block font-mono text-sm text-scale-900">{value}</label>

--- a/studio/components/interfaces/Settings/Logs/LogsFormatters.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogsFormatters.tsx
@@ -176,13 +176,14 @@ export const SeverityFormatter = ({ value }: { value: string }) => {
  */
 export const TimestampLocalFormatter = ({
   value,
+  className,
 }: {
   className?: string
   value: string | number
 }) => {
   const timestamp = isUnixMicro(value) ? unixMicroToIsoTimestamp(value) : value
   const formattedTimestamp = dayjs(timestamp).format('DD MMM, HH:mm:ss')
-  return <span className={'text-xs'}>{formattedTimestamp}</span>
+  return <span className={`text-xs ${className}`}>{formattedTimestamp}</span>
 }
 
 /*

--- a/studio/tests/pages/projects/LogTable.test.js
+++ b/studio/tests/pages/projects/LogTable.test.js
@@ -1,6 +1,7 @@
 import LogTable from 'components/interfaces/Settings/Logs/LogTable'
 import { render, waitFor, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import dayjs from 'dayjs'
 
 test('can display log data', async () => {
   render(
@@ -49,6 +50,18 @@ test('dedupes log lines with exact id', async () => {
   await screen.findByText(/some-uuid/)
 })
 
+test('can display standard preview table columns', async () => {
+  const fakeMicroTimestamp = dayjs().unix() * 1000
+  render(
+    <LogTable
+      queryType="auth"
+      data={[{ id: '12345', event_message: 'some event message', timestamp: fakeMicroTimestamp }]}
+    />
+  )
+  await waitFor(() => screen.getByText(/some event message/))
+  await expect(screen.findByText(/12345/)).rejects.toThrow()
+  await expect(screen.findByText(fakeMicroTimestamp)).rejects.toThrow()
+})
 test('can display custom columns and headers based on data input', async () => {
   render(<LogTable data={[{ some_header: 'some_data', kinda: 123456 }]} />)
   await waitFor(() => screen.getByText(/some_header/))


### PR DESCRIPTION
Fixes default previewer column display, affects Auth logs and Realtime logs, which currently blocks the release of Realtime logs page.

Also adds in some timestamp placement and formatting standardization, affects API logs as timestamp position is now shifted to the front of the row.

Auth logs example:
<img width="1195" alt="Screenshot 2022-07-28 at 6 01 23 PM" src="https://user-images.githubusercontent.com/22714384/181454517-e4c3308b-82cf-42ec-a0fb-709aa459706b.png">
.