### PR TITLE
fix: add maxBarSize for chart renderer, fixes for LogEventChart

### DIFF
--- a/studio/components/to-be-cleaned/Charts/ChartRenderer.tsx
+++ b/studio/components/to-be-cleaned/Charts/ChartRenderer.tsx
@@ -256,6 +256,8 @@ export function BarChart({
                     fill={CHART_COLORS.GREEN_1}
                     // barSize={2}
                     animationDuration={300}
+                    // max bar size required for LogEventChart, prevents bars from expanding to max width.
+                    maxBarSize={48}
                   >
                     {data?.map((entry: any, index: any) => (
                       <Cell


### PR DESCRIPTION
This adds a maxBarSize to all charts, ensuring that the bar width of the horizontal bar chart does not expand beyond a certain size (hardcoded to 48px)


<img width="1228" alt="Screenshot 2022-07-28 at 6 10 02 PM" src="https://user-images.githubusercontent.com/22714384/181456584-b034bd77-f964-42dd-95ad-ee5ca0133d79.png">

