### PR TITLE
fix: increased contrast for log row icon in  dark mode

### DIFF
--- a/studio/components/interfaces/Settings/Logs/LogTable.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogTable.tsx
@@ -306,8 +306,8 @@ const LogTable = ({
                       >
                         <>
                           <div className="flex flex-col gap-1">
-                            <div className="relative border border-scale-600 border-dashed dark:border-scale-400 w-32 h-4 rounded px-2 flex items-center"></div>
-                            <div className="relative border border-scale-600 border-dashed dark:border-scale-400 w-32 h-4 rounded px-2 flex items-center">
+                            <div className="relative border border-scale-600 border-dashed dark:border-scale-900 w-32 h-4 rounded px-2 flex items-center"></div>
+                            <div className="relative border border-scale-600 border-dashed dark:border-scale-900 w-32 h-4 rounded px-2 flex items-center">
                               <div className="absolute right-1 -bottom-4">
                                 <svg
                                   xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
before:

<img width="634" alt="Screenshot 2022-07-28 at 6 39 21 PM" src="https://user-images.githubusercontent.com/22714384/181464153-fa029218-4e4c-4601-88cc-6410f33d54d8.png">

afteR:
<img width="684" alt="Screenshot 2022-07-28 at 6 38 41 PM" src="https://user-images.githubusercontent.com/22714384/181464168-6aefdc14-f2e5-49d7-b844-537eee016894.png">

