### PR TITLE
fix: vercel deploy button for slack clone

### DIFF
--- a/examples/slack-clone/nextjs-slack-clone/README.md
+++ b/examples/slack-clone/nextjs-slack-clone/README.md
@@ -39,7 +39,7 @@ The `anon` key is your client-side API key. It allows "anonymous access" to your
 
 ### 4. Deploy the Next.js client
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/git/external?repository-url=https%3A%2F%2Fgithub.com%2Fsupabase%2Fsupabase%2Ftree%2Fmaster%2Fexamples%2slack-clone%2Fnextjs-slack-clone&env=NEXT_PUBLIC_SUPABASE_URL,NEXT_PUBLIC_SUPABASE_KEY&envDescription=Find%20the%20Supabase%20URL%20and%20key%20in%20the%20your%20auto-generated%20docs%20at%20app.supabase.com&project-name=supabase-slack-clone&repo-name=supabase-slack-clone)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/git/external?repository-url=https%3A%2F%2Fgithub.com%2Fsupabase%2Fsupabase%2Ftree%2Fmaster%2Fexamples%2Fslack-clone%2Fnextjs-slack-clone&env=NEXT_PUBLIC_SUPABASE_URL,NEXT_PUBLIC_SUPABASE_KEY&envDescription=Find%20the%20Supabase%20URL%20and%20key%20in%20the%20your%20auto-generated%20docs%20at%20app.supabase.com&project-name=supabase-slack-clone&repo-name=supabase-slack-clone)
 
 Here, we recommend forking this repo so you can deploy through Vercel by clicking the button above. When you click the button, replace the repo URL with your fork's URL.
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix: the vercel deploy button in the readme had an invalid url so it was unable to clone the example

## What is the current behavior?
Slack clone repo is not cloned and results in an empty repo which causes the vercel deploy to fail

See here: [README](https://github.com/supabase/supabase/tree/master/examples/slack-clone/nextjs-slack-clone)

## What is the new behavior?
Vercel deploy button will now clone the expected example repo

### Before (malformed url)
![image](https://user-images.githubusercontent.com/3660667/181609212-f5919035-1d36-44c5-9f95-d90e527eb5b6.png)

### After (correct url)
![image](https://user-images.githubusercontent.com/3660667/181609141-1381b357-f0a5-4978-a07e-ebf0d85d172e.png)

