### PR TITLE
MAILER_SECURE_EMAIL_CHANGE_ENABLED env variable

### DIFF
--- a/web/docs/gotrue/server/about.md
+++ b/web/docs/gotrue/server/about.md
@@ -205,6 +205,10 @@ Controls the minimum amount of time that must pass before sending another signup
 
 If you do not require email confirmation, you may set this to `true`. Defaults to `false`.
 
+`MAILER_SECURE_EMAIL_CHANGE_ENABLED` - `bool`
+
+If `true`, send an email to both the user's current and new email with a confirmation link, otherwise send an email with confirmation link only to new email. Defaults to `true`.
+
 `MAILER_URLPATHS_INVITE` - `string`
 
 URL path to use in the user invite email. Defaults to `/`.

--- a/web/docs/reference/tools/auth.mdx
+++ b/web/docs/reference/tools/auth.mdx
@@ -108,6 +108,7 @@ These options control the emails sent from GoTrue.
 | Parameter | Type     | Description                |
 | :-------- | :------- | :------------------------- |
 | <span id="mailer_autoconfirm">`MAILER_AUTOCONFIRM`</span> | `bool` | If you do not require email confirmation, you may set this to `true`. Defaults to `false`. |
+| <span id="mailer_secure_email_change_enabled">`MAILER_SECURE_EMAIL_CHANGE_ENABLED`</span> | `bool` | If `true`, send an email to both the user's current and new email with a confirmation link, otherwise send an email with confirmation link only to new email. Defaults to `true`. |
 | <span id="mailer_otp_exp">`MAILER_OTP_EXP`</span> | `string` | Controls the duration an email link or otp is valid for. Defaults to 24 hrs. |
 | <span id="mailer_urlpaths_invite">`MAILER_URLPATHS_INVITE`</span> | `string` | URL path to use in the user invite email. Defaults to `/`. |
 | <span id="mailer_urlpaths_confirmation">`MAILER_URLPATHS_CONFIRMATION`</span> | `string` | URL path to use in the signup confirmation email. Defaults to `/`. |


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

`MAILER_SECURE_EMAIL_CHANGE_ENABLED` environment variable is not well documented. If `true`, email updates will send an email to both the user's current and new email with a confirmation link, otherwise will send an email only to new email address. Defaults to `true`.

**It's not documented at https://github.com/supabase/gotrue either. It can only be found at https://github.com/supabase/gotrue/blob/master/example.env#L38**

## What is the new behavior?

`MAILER_SECURE_EMAIL_CHANGE_ENABLED` environment variable is now documented.

Setting this variable to `false` is useful when we want to add to the user data, signed up with phone number or other providers (**not** with email/password), also an email address for recovery / notifications / newsletter purposes for example. 

