### PR TITLE
Fix punctuation in Pricing FAQ

### DIFF
--- a/apps/www/data/PricingFAQ.json
+++ b/apps/www/data/PricingFAQ.json
@@ -1,6 +1,6 @@
 [
   {
-    "question": "Can I cap my usage so my bill doesn't run over.",
+    "question": "Can I cap my usage so my bill doesn't run over?",
     "answer": "Yes. Spend caps are on by default on the pro tier. You can turn spend caps off for usage beyond the tier limits to pay as you grow."
   },
   {
@@ -20,7 +20,7 @@
     "answer": "Our pricing is in Beta. You can read more about our decisions in our blog on pricing [here](/blog/2021/03/29/pricing). Pricing may change in the future, however as a team of developers we are committed to pricing being as developer friendly as possible."
   },
   {
-    "question": "What happens if I cancel my subscription",
+    "question": "What happens if I cancel my subscription?",
     "answer": "The organization is allocated credits for unused time during the billing month. Those credits can be used for other projects."
   },
   {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix punctuation in Pricing FAQ: https://zone-www-dot-730hm3wek-supabase.vercel.app/pricing

## What is the current behavior?
![Screen Shot 2022-08-01 at 1 51 49 PM](https://user-images.githubusercontent.com/7026076/182244578-dce48d91-5c6b-4a01-b1a5-5a73ca1b6129.png)

## What is the new behavior?
![Screen Shot 2022-08-01 at 1 52 29 PM](https://user-images.githubusercontent.com/7026076/182244697-f3d6b061-65dc-4a5b-8df6-9811979a5bee.png)