### PR TITLE
Update signUp with phone

### DIFF
--- a/web/spec/supabase.yml
+++ b/web/spec/supabase.yml
@@ -282,7 +282,7 @@ pages:
           Supabase supports Phone Auth. After a user has verified their number, they can use the [`signIn()`](/docs/reference/javascript/auth-signin#sign-in-using-phone) method.
         js: |
           ```js
-          const { user, session, error } = await supabase.auth.signIn({
+          const { user, session, error } = await supabase.auth.signUp({
             phone: '+13334445555',
             password: 'some-password',
           })


### PR DESCRIPTION
Register user with phone using `signIn` results in an `Invalid Credentials` error. Update the documentation to make use of the `signUp` option when registering user with their phone number.

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
