### PR TITLE
fix: logs custom error messages

### DIFF
--- a/studio/components/interfaces/Settings/Logs/LogTable.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogTable.tsx
@@ -22,7 +22,7 @@ interface Props {
   onHistogramToggle?: () => void
   isHistogramShowing?: boolean
   isLoading?: boolean
-  error?: LogQueryError
+  error?: LogQueryError | null
   showDownload?: boolean
   projectRef: string
 }

--- a/studio/components/interfaces/Settings/Logs/Logs.types.ts
+++ b/studio/components/interfaces/Settings/Logs/Logs.types.ts
@@ -51,9 +51,19 @@ export interface CountData {
 type LFResponse<T> = {
   result: T[]
   error?: {
+    code: number
+    errors: {
+      domain: string
+      message: string
+      reason: string | 'resourcesExceeded'
+    }[]
     message: string
+    status: string
   }
 }
+type ApiError = string
+
+export type LogQueryError = Omit<LFResponse<unknown>, "result"> | ApiError
 
 export type Count = LFResponse<CountData>
 

--- a/studio/components/interfaces/Settings/Logs/LogsErrorRenderers/DefaultErrorRenderer.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogsErrorRenderers/DefaultErrorRenderer.tsx
@@ -1,0 +1,19 @@
+import { Input } from '@supabase/ui'
+import { LogQueryError } from '..'
+
+export interface ErrorRendererProps {
+  error: LogQueryError
+  isCustomQuery: boolean
+}
+
+const DefaultErrorRenderer: React.FC<ErrorRendererProps> = ({ error }) => (
+  <Input.TextArea
+    size="tiny"
+    value={typeof error === 'string' ? error : JSON.stringify(error, null, 2)}
+    borderless
+    className="font-mono w-full mt-4"
+    copy
+    rows={7}
+  />
+)
+export default DefaultErrorRenderer

--- a/studio/components/interfaces/Settings/Logs/LogsErrorRenderers/LogsErrorRenderers.stories.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogsErrorRenderers/LogsErrorRenderers.stories.tsx
@@ -1,0 +1,65 @@
+import React, { useState } from 'react'
+
+import DefaultErrorRenderer from './DefaultErrorRenderer'
+import ResourcesExceededErrorRenderer from './ResourcesExceededErrorRenderer'
+import { Alert } from '@supabase/ui'
+
+export default {
+  title: 'Logs',
+}
+
+export const ErrorRenderers = () => (
+  <div
+    style={{
+      display: 'flex',
+      flexDirection: 'column',
+      gap: '10px',
+    }}
+  >
+    {[
+      <DefaultErrorRenderer isCustomQuery={false} error="some string error" />,
+      <DefaultErrorRenderer
+        isCustomQuery={false}
+        error={{
+          error: { code: 123, errors: [], status: 'something', message: 'some logflare error' },
+        }}
+      />,
+      <ResourcesExceededErrorRenderer
+        isCustomQuery
+        error={{
+          error: {
+            code: 123,
+            errors: [
+              { domain: 'global', message: 'Some very long message', reason: 'resourcesExceeded' },
+            ],
+            status: 'something',
+            message: 'some logflare error',
+          },
+        }}
+      />,
+
+      <ResourcesExceededErrorRenderer
+        isCustomQuery={false}
+        error={{
+          error: {
+            code: 123,
+            errors: [
+              { domain: 'global', message: 'Some very long message', reason: 'resourcesExceeded' },
+            ],
+            status: 'something',
+            message: 'some logflare error',
+          },
+        }}
+      />,
+    ].map((child) => (
+      <Alert
+        variant="danger"
+        title="Sorry! An error occured when fetching data."
+        withIcon
+        className="w-1/2"
+      >
+        {child}
+      </Alert>
+    ))}
+  </div>
+)

--- a/studio/components/interfaces/Settings/Logs/LogsErrorRenderers/ResourcesExceededErrorRenderer.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogsErrorRenderers/ResourcesExceededErrorRenderer.tsx
@@ -1,0 +1,39 @@
+import { Accordion, Input } from '@supabase/ui'
+import { ErrorRendererProps } from './DefaultErrorRenderer'
+
+const ResourcesExceededErrorRenderer: React.FC<ErrorRendererProps> = ({ error, isCustomQuery }) => (
+  <div className="text-scale-1100 flex flex-col gap-2">
+    <div className="text-sm flex flex-col gap-1">
+      <p>This query requires too much memory to be executed.</p>
+      <p>
+        {isCustomQuery
+          ? 'Avoid selecting entire objects and instead select specific keys using dot notation'
+          : 'Avoid querying across a large datetime range'}
+      </p>
+      {!isCustomQuery && <p>Please contact support if this error persists.</p>}
+    </div>
+    <Accordion
+      className="text-sm"
+      justified={false}
+      openBehaviour="multiple"
+      type="default"
+      chevronAlign="left"
+      size="small"
+      bordered={false}
+      iconPosition="left"
+    >
+      <Accordion.Item id="1" header="Full error message">
+        <Input.TextArea
+          size="tiny"
+          value={JSON.stringify(error, null, 2)}
+          borderless
+          className="font-mono w-full mt-4"
+          copy
+          rows={5}
+        />
+      </Accordion.Item>
+    </Accordion>
+  </div>
+)
+
+export default ResourcesExceededErrorRenderer

--- a/studio/components/interfaces/Settings/Logs/LogsErrorRenderers/ResourcesExceededErrorRenderer.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogsErrorRenderers/ResourcesExceededErrorRenderer.tsx
@@ -7,8 +7,8 @@ const ResourcesExceededErrorRenderer: React.FC<ErrorRendererProps> = ({ error, i
       <p>This query requires too much memory to be executed.</p>
       <p>
         {isCustomQuery
-          ? 'Avoid selecting entire objects and instead select specific keys using dot notation'
-          : 'Avoid querying across a large datetime range'}
+          ? 'Avoid selecting entire objects and instead select specific keys using dot notation.'
+          : 'Avoid querying across a large datetime range.'}
       </p>
       {!isCustomQuery && <p>Please contact support if this error persists.</p>}
     </div>

--- a/web/docs/guides/platform/logs.mdx
+++ b/web/docs/guides/platform/logs.mdx
@@ -61,8 +61,7 @@ In order to query any value that is an array, we would need to `UNNEST()` that f
 
 :::caution
 
-Large projects may run into a `400 ORDER BY` memory limit error when querying with many unnested rows across large date ranges. If experiencing this error, consider reducing the number of unnested joins, or by reducing the queried date range.
-
+Large projects may run into a `Resources Exceeded` memory limit error when selecting large objects with many nested keys. To avoid this error, select individual keys separately or reduce the queried date range.
 :::
 
 ### Functions


### PR DESCRIPTION
Adds custom error messages to logs explorer and previewers.

Allows us to handle specific errors and prompt users to self-serve & fix them.

<img width="772" alt="Screenshot 2022-08-03 at 3 07 49 AM" src="https://user-images.githubusercontent.com/22714384/182435595-ec7f599c-d7ba-4bd6-ac24-538b6ad44550.png">

punctuation has been fixed.

