### PR TITLE
Update docs landing page and sidebar

### DIFF
--- a/web/docs/about.mdx
+++ b/web/docs/about.mdx
@@ -71,12 +71,12 @@ It provides all the backend services you need to build a product. You can use it
         </div>
       </Link>
     </div>
-    {/* Auth */}
+    {/* API */}
     <div class="col col--6">
-      <Link class="card" to="/docs/guides/auth" style={{ height: '100%' }}>
+      <Link class="card" to="/docs/guides/api" style={{ height: '100%' }}>
         <div class="card__body">
-          <h4>Auth</h4>
-          <p>User management with Row Level Security.</p>
+          <h4>Auto-generated APIs</h4>
+          <p>Instantly generate APIs for your database.</p>
         </div>
       </Link>
     </div>
@@ -89,21 +89,21 @@ It provides all the backend services you need to build a product. You can use it
         </div>
       </Link>
     </div>
+    {/* Auth */}
+    <div class="col col--6">
+      <Link class="card" to="/docs/guides/auth" style={{ height: '100%' }}>
+        <div class="card__body">
+          <h4>Auth</h4>
+          <p>User management with Row Level Security.</p>
+        </div>
+      </Link>
+    </div>
     {/* Storage */}
     <div class="col col--6">
       <Link class="card" to="/docs/guides/storage" style={{ height: '100%' }}>
         <div class="card__body">
           <h4>File Storage</h4>
           <p>Store, organize, and serve large files.</p>
-        </div>
-      </Link>
-    </div>
-    {/* API */}
-    <div class="col col--6">
-      <Link class="card" to="/docs/guides/api" style={{ height: '100%' }}>
-        <div class="card__body">
-          <h4>Auto-generated APIs</h4>
-          <p>Instantly generate APIs for your database.</p>
         </div>
       </Link>
     </div>
@@ -150,32 +150,5 @@ Supabase is just Postgres, which makes it compatible with a large number of tool
         </Link>
       </div>
     ))}
-  </div>
-</div>
-
-## How to use these docs
-
-The documentation is divided into 2 sections.
-
-<div class="container" style={{ padding: 0 }}>
-  <div class="row is-multiline">
-    {/* Auth */}
-    <div class="col col--6">
-      <Link class="card" to="/docs/" style={{ height: '100%' }}>
-        <div class="card__body">
-          <h4>Guides</h4>
-          <p>In-depth explanations for each tool.</p>
-        </div>
-      </Link>
-    </div>
-    {/* Ref */}
-    <div class="col col--6">
-      <Link class="card" to="/docs/reference" style={{ height: '100%' }}>
-        <div class="card__body">
-          <h4>Reference Docs</h4>
-          <p>Technical documentation for Client Libraries and Systems.</p>
-        </div>
-      </Link>
-    </div>
   </div>
 </div>

--- a/web/docusaurus.config.js
+++ b/web/docusaurus.config.js
@@ -15,6 +15,11 @@ module.exports = {
   onBrokenLinks: 'ignore',
   themes: ['docusaurus-theme-search-typesense'],
   themeConfig: {
+    docs: {
+      sidebar: {
+        autoCollapseCategories: true,
+      },
+    },
     colorMode: {
       // "light" | "dark"
       defaultMode: 'dark',
@@ -191,6 +196,7 @@ module.exports = {
           routeBasePath: '/',
           sidebarPath: require.resolve('./sidebars.js'),
           editUrl: 'https://github.com/supabase/supabase/edit/master/web',
+          breadcrumbs: false,
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),

--- a/web/sidebars.js
+++ b/web/sidebars.js
@@ -54,12 +54,12 @@ module.exports = {
         'guides/local-development',
         'guides/examples',
       ],
-      collapsed: false,
+      collapsed: true,
     },
     {
       type: 'category',
       label: 'Quickstarts',
-      collapsed: false,
+      collapsed: true,
       items: [
         'guides/with-angular',
         'guides/with-expo',
@@ -80,7 +80,7 @@ module.exports = {
     {
       type: 'category',
       label: 'Database',
-      collapsed: false,
+      collapsed: true,
       items: [
         'guides/database',
         'guides/database/connecting-to-postgres',
@@ -118,19 +118,19 @@ module.exports = {
     {
       type: 'category',
       label: 'APIs',
-      collapsed: false,
+      collapsed: true,
       items: ['guides/api', 'guides/api/generating-types'],
     },
     {
       type: 'category',
       label: 'Functions',
-      collapsed: false,
+      collapsed: true,
       items: ['guides/functions'],
     },
     {
       type: 'category',
       label: 'Auth',
-      collapsed: false,
+      collapsed: true,
       items: [
         'guides/auth',
         {
@@ -185,13 +185,13 @@ module.exports = {
     {
       type: 'category',
       label: 'Storage',
-      collapsed: false,
+      collapsed: true,
       items: ['guides/storage'],
     },
     {
       type: 'category',
       label: 'Platform',
-      collapsed: false,
+      collapsed: true,
       items: [
         'guides/platform/logs',
         'guides/platform/metrics',
@@ -203,13 +203,13 @@ module.exports = {
     {
       type: 'category',
       label: 'Self Hosting',
-      collapsed: false,
+      collapsed: true,
       items: ['guides/hosting/overview', 'guides/hosting/docker'],
     },
     {
       type: 'category',
       label: 'Integrations',
-      collapsed: false,
+      collapsed: true,
       items: [
         'guides/integrations/appsmith',
         'guides/integrations/auth0',
@@ -228,7 +228,7 @@ module.exports = {
     {
       type: 'category',
       label: 'See Also',
-      collapsed: false,
+      collapsed: true,
       items: [
         'faq',
         'handbook/contributing',


### PR DESCRIPTION
## What kind of change does this PR introduce?
- Remove breadcrumbs
- **Landing page**
  - Update ordering of services to match sidebar
  - Remove "How to use these docs" section
- **Sidebar**
  - Collapse categories by default
  - Collapse current category when expanding another category

## What is the current behavior?

Sidebar is fully expanded (difficult to skim the top level categories)

## What is the new behavior?
![landing-page](https://user-images.githubusercontent.com/7026076/182531653-b32ce42e-953f-4393-bfbd-9a96225bd7c5.png)