### PR TITLE
fix: experts page overflow

### DIFF
--- a/apps/www/pages/partners/experts/index.tsx
+++ b/apps/www/pages/partners/experts/index.tsx
@@ -62,7 +62,7 @@ function ExpertPartnersPage(props: Props) {
             <h1 className="h1">{meta_title}</h1>
             <h2 className="text-scale-900 text-xl">{meta_description}</h2>
           </div>
-          <div className="grid space-y-12 md:gap-8 lg:grid-cols-12 lg:gap-16 lg:space-y-0 xl:gap-32">
+          <div className="grid space-y-12 md:gap-8 lg:grid-cols-12 lg:gap-16 lg:space-y-0 xl:gap-16">
             <div className="lg:col-span-4 xl:col-span-3">
               {/* Horizontal link menu */}
               <div className="space-y-6">


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase website bug fix

## What is the current behavior?

On the [Experts](https://supabase.com/partners/experts) page their is an overflow issue with the cards:

<img width="1428" alt="Screenshot 2022-08-04 at 10 35 29" src="https://user-images.githubusercontent.com/22655069/182820889-7b360141-0400-4a6b-bb43-bad3e1f00d9f.png">


## What is the new behavior?

The gap size of the div has been changed so no overflow issues:

<img width="1428" alt="Screenshot 2022-08-04 at 10 56 15" src="https://user-images.githubusercontent.com/22655069/182820953-0241c002-fbce-4cc5-8483-9da2f3b2b67c.png">


## Additional context

Add any other context or screenshots.
