### PR TITLE
fix: Update deprecation warning comments of auth.email()

### DIFF
--- a/web/docs/guides/auth/row-level-security.mdx
+++ b/web/docs/guides/auth/row-level-security.mdx
@@ -80,7 +80,7 @@ using (
 
 :::caution
 
-Deprecated. Use `auth.role -> 'email'` instead.
+Deprecated. Use `jwt() ->> 'email'` instead.
 
 :::
 

--- a/web/docs/guides/auth/row-level-security.mdx
+++ b/web/docs/guides/auth/row-level-security.mdx
@@ -80,7 +80,7 @@ using (
 
 :::caution
 
-Deprecated. Use `jwt() ->> 'email'` instead.
+Deprecated. Use `auth.jwt() ->> 'email'` instead.
 
 :::
 


### PR DESCRIPTION
According to this PR https://github.com/supabase/gotrue/pull/484, `auth.email()` should now be replaced with `auth.jwt() ->> 'email'`. 