### PR TITLE
docs: update uuid-ossp.mdx

### DIFF
--- a/web/docs/guides/database/extensions/uuid-ossp.mdx
+++ b/web/docs/guides/database/extensions/uuid-ossp.mdx
@@ -68,7 +68,7 @@ Creates a UUID value based on the combination of computer’s MAC address, curre
 
 ### `uuid_generate_v4()` 
 
-Creates UUID values based solely on random numbers. We can also use `gen_random_uuid ()`, which too generates a random UUID.
+Creates UUID values based solely on random numbers. We can also use Postgres's built-in [`gen_random_uuid()`](https://www.postgresql.org/docs/current/functions-uuid.html) function to generate a UUIDv4.
 
 ## Examples
 

--- a/web/docs/guides/database/extensions/uuid-ossp.mdx
+++ b/web/docs/guides/database/extensions/uuid-ossp.mdx
@@ -95,4 +95,5 @@ create table contacts (
 
 ## Resources 
 
+- [Choosing a Postgres Primary Key](https://supabase.com/blog/choosing-a-postgres-primary-key)
 - [The Basics Of PostgreSQL `UUID` Data Type](https://www.postgresqltutorial.com/postgresql-uuid/).

--- a/web/docs/guides/database/extensions/uuid-ossp.mdx
+++ b/web/docs/guides/database/extensions/uuid-ossp.mdx
@@ -64,7 +64,7 @@ Once the extension is enabled, you now have access to a `uuid` type.
 
 Creates a UUID value based on the combination of computer’s MAC address, current timestamp, and a random value.
 
-**Note**: UUIDs of this kind reveal the identity of the computer that created the identifier and the time at which it did so, which might make it unsuitable for certain security-sensitive applications.
+**Note**: UUIDv1 leaks identifiable details, which might make it unsuitable for certain security-sensitive applications.
 
 ### `uuid_generate_v4()` 
 

--- a/web/docs/guides/database/extensions/uuid-ossp.mdx
+++ b/web/docs/guides/database/extensions/uuid-ossp.mdx
@@ -64,9 +64,11 @@ Once the extension is enabled, you now have access to a `uuid` type.
 
 Creates a UUID value based on the combination of computer’s MAC address, current timestamp, and a random value.
 
+**Note**: UUIDs of this kind reveal the identity of the computer that created the identifier and the time at which it did so, which might make it unsuitable for certain security-sensitive applications.
+
 ### `uuid_generate_v4()` 
 
-Creates UUID values based solely on random numbers.
+Creates UUID values based solely on random numbers. We can also use `gen_random_uuid ()`, which too generates a random UUID.
 
 ## Examples
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
docs update

## What is the current behavior?
There's no note mentioning the possible vulnerability of version 1 UUID
Also, no mention of gen_random_uuid () which too generates a version 4 UUID

Please link any relevant issues here: #7870

## What is the new behavior?
Changes:
- **Note**: UUIDs of this kind reveal the identity of the computer that created the identifier and the time at which it did so, which might make it unsuitable for certain security-sensitive applications.
- We can also use `gen_random_uuid ()`, which too generates a random UUID.