### PR TITLE
chore: adds studio dir root-level module resolution

### DIFF
--- a/studio/.storybook/main.js
+++ b/studio/.storybook/main.js
@@ -1,3 +1,4 @@
+const path = require('path')
 module.exports = {
   stories: ['./*.stories.mdx', '../components/**/*.stories.@(js|jsx|ts|tsx)'],
   addons: [
@@ -6,4 +7,9 @@ module.exports = {
     '@storybook/addon-interactions',
     'storybook-dark-mode',
   ],
+
+  webpackFinal: async (config) => {
+    config.resolve.modules = [...(config.resolve.modules || []), path.resolve(__dirname, '../')]
+    return config
+  },
 }


### PR DESCRIPTION
adds root-level module resolution, for components that do stuff like
```
import Testing from `components/ui/Testing`
```