### PR TITLE
fix: add in timestamp filtering for single log query filtering

### DIFF
--- a/studio/components/interfaces/Settings/Logs/LogSelection.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogSelection.tsx
@@ -13,19 +13,31 @@ import FunctionInvocationSelectionRender, {
 import FunctionLogsSelectionRender from './LogSelectionRenderers/FunctionLogsSelectionRender'
 import DefaultExplorerSelectionRenderer from './LogSelectionRenderers/DefaultExplorerSelectionRenderer'
 import DefaultPreviewSelectionRenderer from './LogSelectionRenderers/DefaultPreviewSelectionRenderer'
-import { isDefaultLogPreviewFormat, LogsTableName } from '.'
+import { isDefaultLogPreviewFormat, LogsEndpointParams, LogsTableName } from '.'
 import useSingleLog from 'hooks/analytics/useSingleLog'
 import Connecting from 'components/ui/Loading/Loading'
 
-interface Props {
+export interface LogSelectionProps {
   log: LogData | null
   onClose: () => void
   queryType?: QueryType
   projectRef: string
+  params: Partial<LogsEndpointParams>
 }
 
-const LogSelection: FC<Props> = ({ projectRef, log: partialLog, onClose, queryType }) => {
-  const [{ logData: fullLog, isLoading }] = useSingleLog(projectRef, queryType, partialLog?.id)
+const LogSelection: FC<LogSelectionProps> = ({
+  projectRef,
+  log: partialLog,
+  onClose,
+  queryType,
+  params = {},
+}) => {
+  const [{ logData: fullLog, isLoading }] = useSingleLog(
+    projectRef,
+    queryType,
+    params,
+    partialLog?.id
+  )
   const Formatter = () => {
     switch (queryType) {
       case 'api':

--- a/studio/components/interfaces/Settings/Logs/LogTable.stories.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogTable.stories.tsx
@@ -1,0 +1,46 @@
+import React from 'react'
+
+import LogTable from './LogTable'
+
+export default {
+  title: 'Logs',
+}
+
+export const Functions = (args: any) => (
+  <div
+  // style={{
+  //   height: '600px',
+  //   display: 'flex',
+  //   flexDirection: 'column',
+  //   flexGrow: 1,
+  //   position: 'relative',
+  // }}
+  // className="
+  // flex flex-col flex-grow relative pt-4 flex h-full flex-grow transition-opacity
+  // "
+  >
+    <LogTable
+      params={{}}
+      queryType="functions"
+      projectRef="123"
+      data={[
+        {
+          event_message: 'This is a error log\n',
+          event_type: 'log',
+          function_id: '001b0b08-331c-403e-810c-a2004b03a019',
+          level: 'error',
+          timestamp: 1659545029083869,
+          id: '3475cf6f-2929-4296-ab44-ce2c17069937',
+        },
+        {
+          event_message: 'This is a uncaughtExceptop\n',
+          event_type: 'uncaughtException',
+          function_id: '001b0b08-331c-403e-810c-a2004b03a019',
+          timestamp: 1659545029083869,
+          id: '4475cf6f-2929-4296-ab44-ce2c17069937',
+          level: null,
+        },
+      ]}
+    />
+  </div>
+)

--- a/studio/components/interfaces/Settings/Logs/LogTable.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogTable.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState, useMemo } from 'react'
 import { Alert, Button, IconEye, IconEyeOff, Input } from '@supabase/ui'
 import DataGrid from '@supabase/react-data-grid'
 
-import LogSelection from './LogSelection'
+import LogSelection, { LogSelectionProps } from './LogSelection'
 import { LogData, QueryType } from './Logs.types'
 import { SeverityFormatter, ResponseCodeFormatter, HeaderFormmater } from './LogsFormatters'
 import { isDefaultLogPreviewFormat } from './Logs.utils'
@@ -15,13 +15,15 @@ import DefaultPreviewColumnRenderer from './LogColumnRenderers/DefaultPreviewCol
 
 interface Props {
   data?: Array<LogData | Object>
-  queryType?: QueryType
   onHistogramToggle?: () => void
   isHistogramShowing?: boolean
   isLoading?: boolean
   error?: any
   showDownload?: boolean
+  // TODO: move all common params to a context to avoid prop drilling
+  queryType?: QueryType
   projectRef: string
+  params: LogSelectionProps['params']
 }
 type LogMap = { [id: string]: LogData }
 
@@ -57,6 +59,7 @@ const LogTable = ({
   showDownload,
   error,
   projectRef,
+  params,
 }: Props) => {
   const [focusedLog, setFocusedLog] = useState<LogData | null>(null)
   const firstRow: LogData | undefined = data?.[0] as LogData
@@ -396,6 +399,7 @@ const LogTable = ({
                 onClose={() => setFocusedLog(null)}
                 log={focusedLog}
                 queryType={queryType}
+                params={params}
               />
             </div>
           ) : null}

--- a/studio/components/interfaces/Settings/Logs/LogsPreviewer.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogsPreviewer.tsx
@@ -162,6 +162,7 @@ export const LogsPreviewer: React.FC<Props> = ({
             queryType={queryType}
             isHistogramShowing={showChart}
             onHistogramToggle={() => setShowChart(!showChart)}
+            params={params}
           />
         </LoadingOpacity>
         {!error && (

--- a/studio/hooks/analytics/useSingleLog.tsx
+++ b/studio/hooks/analytics/useSingleLog.tsx
@@ -22,11 +22,12 @@ interface Handlers {
 function useSingleLog(
   project: string,
   queryType?: QueryType,
+  paramsToMerge?: Partial<LogsEndpointParams>,
   id?: string | null
 ): [Data, Handlers] {
   const table = queryType ? LOGS_TABLES[queryType] : undefined
   const sql = id && table ? genSingleLogQuery(table, id) : ''
-  const params: LogsEndpointParams = { project, sql }
+  const params: LogsEndpointParams = { ...paramsToMerge, project, sql }
   const endpointUrl = `${API_URL}/projects/${project}/analytics/endpoints/logs.all?${genQueryParams(
     params as any
   )}`

--- a/studio/pages/project/[ref]/logs-explorer/index.tsx
+++ b/studio/pages/project/[ref]/logs-explorer/index.tsx
@@ -150,7 +150,7 @@ export const LogsExplorerPage: NextPageWithLayout = () => {
         <div className="relative flex flex-grow flex-col">
           <LoadingOpacity active={isLoading}>
             <div className="flex h-full flex-grow">
-              <LogTable data={logData} error={error} projectRef={ref as string} />
+              <LogTable params={params} data={logData} error={error} projectRef={ref as string} />
             </div>
           </LoadingOpacity>
           <div className="mt-2 flex flex-row justify-end">

--- a/studio/tests/pages/projects/LogsPreviewer.test.js
+++ b/studio/tests/pages/projects/LogsPreviewer.test.js
@@ -122,12 +122,19 @@ test.each([
       expect(get).toHaveBeenCalledWith(expect.stringContaining('iso_timestamp_start'))
       expect(get).not.toHaveBeenCalledWith(expect.stringContaining('iso_timestamp_end'))
     })
+    // reset mock so that we can check for selection call
+    get.mockClear()
 
     for (const text of tableTexts) {
       await screen.findByText(text)
     }
     const row = await screen.findByText(tableTexts[0])
     fireEvent.click(row)
+
+    await waitFor(() => {
+      expect(get).toHaveBeenCalledWith(expect.stringContaining('iso_timestamp_start'))
+      expect(get).not.toHaveBeenCalledWith(expect.stringContaining('iso_timestamp_end'))
+    })
 
     for (const text of selectionTexts) {
       await screen.findAllByText(text)


### PR DESCRIPTION
Adds in datetime range to the single log query for when a single log is selected, vastly speeding up query times.

cc @pucho we're having to prop drill through 3 component levels, i think using context in the future would be good to avoid duplicate logic.


context: https://supabase.slack.com/archives/C02HE0AQPC6/p1660030350690969?thread_ts=1659725010.354139&cid=C02HE0AQPC6
