### PR TITLE
Fix/safari table header height

### DIFF
--- a/studio/components/grid/components/header/Header.tsx
+++ b/studio/components/grid/components/header/Header.tsx
@@ -30,7 +30,7 @@ const Header: FC<HeaderProps> = ({ sorts, filters, onAddColumn, onAddRow, header
   const { selectedRows } = state
 
   return (
-    <div className="bg-scale-100 dark:bg-scale-300 flex h-10 items-center justify-between px-5">
+    <div className="bg-scale-100 dark:bg-scale-300 flex h-10 items-center justify-between px-5 py-1.5">
       {selectedRows.size > 0 ? (
         <RowHeader sorts={sorts} filters={filters} />
       ) : (


### PR DESCRIPTION
## What kind of change does this PR introduce?

The table editor header height was off in Safari.

**Before:** 
<img width="681" alt="CleanShot 2022-08-09 at 15 24 39@2x" src="https://user-images.githubusercontent.com/105593/183725655-7eba30a7-cd1d-4ec8-890c-c49b354fc43a.png">

**After:**
<img width="891" alt="CleanShot 2022-08-09 at 15 24 24@2x" src="https://user-images.githubusercontent.com/105593/183725681-84d68f3a-c68e-40ed-b726-5b9a29f532de.png">

Chrome remains the same as before due to the `h-10` being respected there.
