### PR TITLE
fix: blog post overflow

### DIFF
--- a/apps/www/_blog/2022-08-09-slack-consolidate-slackbot-to-consolidate-messages.mdx
+++ b/apps/www/_blog/2022-08-09-slack-consolidate-slackbot-to-consolidate-messages.mdx
@@ -157,7 +157,7 @@ After right-clicking a message in Slack, you can see the option to select the li
 
 Slack links have the following format:
 
-<span>
+<span className="break-words">
   https://<span className="text-scale-1200">ORGANIZATION</span>.slack.com/archives/
   <span className="text-scale-1200">channel_id</span>/p<span className="text-scale-1200">message_id</span>
 </span>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase Blog fix

## What is the current behavior?

Their seems to be a long span which is causing an overflow issue on [this](https://supabase.com/blog/slack-consolidate-slackbot-to-consolidate-messages) blog post:

<img width="415" alt="Screenshot 2022-08-09 at 22 17 28" src="https://user-images.githubusercontent.com/22655069/183763332-ed46e935-6566-4846-a8ba-dadfa878a443.png">


## What is the new behavior?

I've added a `className` of `break-words` which wraps the element and no overflow issue:

<img width="415" alt="Screenshot 2022-08-09 at 22 17 16" src="https://user-images.githubusercontent.com/22655069/183763432-37f273d0-f0a1-465e-b0f8-ad0ecedd8dc0.png">


## Additional context

This should resolve #8181
