### PR TITLE
Allows producthunt as an image source, dangerously-Allows-SVG

### DIFF
--- a/apps/www/next.config.js
+++ b/apps/www/next.config.js
@@ -6,6 +6,7 @@ module.exports = withMDX({
 
   trailingSlash: false,
   images: {
+    dangerouslyAllowSVG: true,
     domains: [
       'avatars.githubusercontent.com',
       'github.com',
@@ -16,6 +17,7 @@ module.exports = withMDX({
       'obuldanrptloktxcffvn.supabase.co',
       'avatars.githubusercontent.com',
       'colab.research.google.com',
+      'api.producthunt.com',
     ],
   },
   async headers() {


### PR DESCRIPTION
## What kind of change does this PR introduce?

ProductHunt embeds are broken:
https://supabase.com/blog/product-hunt-golden-kitty-awards-2021
https://supabase.com/blog/supabase-studio

Need to add PH as an image source and allow adding SVGs.