### PR TITLE
docs: Add `supabase-js` documentation example for ordering a query with multiple columns

### DIFF
--- a/web/spec/supabase.yml
+++ b/web/spec/supabase.yml
@@ -1266,7 +1266,7 @@ pages:
           ```
       - name: Listening to row level changes
         description: You can listen to individual rows using the format `{table}:{col}=eq.{val}` - where `{col}` is the column name, and `{val}` is the value which you want to match.
-        notes: | 
+        notes: |
           - ``eq`` filter works with all database types as under the hood, it's casting both the filter value and the database value to the correct type and then comparing them.
         js: |
           ```js
@@ -1695,7 +1695,15 @@ pages:
             .eq('name', 'United States')
             .order('name', {foreignTable: 'cities'})
           ```
-
+      - name: Ordering multiple columns
+        js: |
+          ```js
+          const { data, error } = await supabase
+            .from('cities')
+            .select('name', 'country_id')
+            .order('country_id', { ascending: false })
+            .order('name', { ascending: false })
+          ```
   range():
     $ref: '@supabase/postgrest-js."lib/PostgrestFilterBuilder".PostgrestFilterBuilder.range'
     examples:


### PR DESCRIPTION
## What kind of change does this PR introduce?

This is a small documentation update to add an example for ordering a query with multiple columns.

## What is the current behavior?

N/A

## What is the new behavior?

N/A

## Additional context

The feature was implemented [here](https://github.com/supabase/postgrest-js/pull/162).
The documentation update was suggested [here](https://github.com/supabase/postgrest-js/issues/249#issuecomment-1211318051) and should close the issue.