### PR TITLE
feat: Dashboard/Studio project switch

### DIFF
--- a/studio/components/layouts/ProjectLayout/LayoutHeader/OrgDropdown.tsx
+++ b/studio/components/layouts/ProjectLayout/LayoutHeader/OrgDropdown.tsx
@@ -1,6 +1,7 @@
 import { useRouter } from 'next/router'
 import { observer } from 'mobx-react-lite'
-import { Button, Dropdown, Divider, IconPlus } from '@supabase/ui'
+import { Button, Dropdown, Divider, IconPlus, IconSettings } from '@supabase/ui'
+import Link from 'next/link'
 
 import { useStore } from 'hooks'
 import { IS_PLATFORM } from 'lib/constants'
@@ -21,8 +22,16 @@ const OrgDropdown = () => {
           {sortedOrganizations
             .sort((a, b) => a.name.localeCompare(b.name))
             .map((x) => (
-              <Dropdown.Item key={x.slug} onClick={() => router.push(`/org/${x.slug}/settings`)}>
-                {x.name}
+              <Dropdown.Item key={x.slug}>
+                <div className='flex items-center justify-between w-56'>
+                  <Link href='/'>
+                    <Button type='text' className='truncate pl-0 text-xs text-scale-1100'> {x.name}</Button>
+                  </Link>
+                  <Link passHref href={`/org/${x.slug}/settings`}>
+                    <Button icon={<IconSettings />} type='text'/>
+                  </Link>
+                </div>
+
               </Dropdown.Item>
             ))}
           <Dropdown.Seperator />
@@ -36,11 +45,12 @@ const OrgDropdown = () => {
         {selectedOrganization.name}
       </Button>
     </Dropdown>
-  ) : (
-    <Button as="span" type="text" size="tiny">
-      {selectedOrganization.name}
-    </Button>
+    ) : (
+      <Button as="span" type="text" size="tiny">
+        {selectedOrganization.name}
+      </Button>
   )
 }
 
 export default observer(OrgDropdown)
+

--- a/studio/components/layouts/ProjectLayout/LayoutHeader/OrgDropdown.tsx
+++ b/studio/components/layouts/ProjectLayout/LayoutHeader/OrgDropdown.tsx
@@ -23,15 +23,16 @@ const OrgDropdown = () => {
             .sort((a, b) => a.name.localeCompare(b.name))
             .map((x) => (
               <Dropdown.Item key={x.slug}>
-                <div className='flex items-center justify-between w-56'>
-                  <Link href='/'>
-                    <Button type='text' className='truncate pl-0 text-xs text-scale-1100'> {x.name}</Button>
+                <div className="flex items-center justify-between w-56">
+                  <Link href="/">
+                    <Button type="text" className="truncate pl-0 text-xs text-scale-1100">
+                      {x.name}
+                    </Button>
                   </Link>
                   <Link passHref href={`/org/${x.slug}/settings`}>
-                    <Button icon={<IconSettings />} type='text'/>
+                    <Button icon={<IconSettings />} type="text" />
                   </Link>
                 </div>
-
               </Dropdown.Item>
             ))}
           <Dropdown.Seperator />
@@ -45,12 +46,11 @@ const OrgDropdown = () => {
         {selectedOrganization.name}
       </Button>
     </Dropdown>
-    ) : (
-      <Button as="span" type="text" size="tiny">
-        {selectedOrganization.name}
-      </Button>
+  ) : (
+    <Button as="span" type="text" size="tiny">
+      {selectedOrganization.name}
+    </Button>
   )
 }
 
 export default observer(OrgDropdown)
-

--- a/studio/components/layouts/ProjectLayout/LayoutHeader/OrgDropdown.tsx
+++ b/studio/components/layouts/ProjectLayout/LayoutHeader/OrgDropdown.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from 'next/router'
 import { observer } from 'mobx-react-lite'
-import { Button, Dropdown, Divider, IconPlus, IconSettings } from '@supabase/ui'
+import { Button, Dropdown, IconPlus, IconSettings } from '@supabase/ui'
 import Link from 'next/link'
 
 import { useStore } from 'hooks'


### PR DESCRIPTION
## What kind of change does this PR introduce?

Studio feature

## What is the current behavior?

Currently in the dashboard when you click on the organisation  name in the top header you get a dropdown appear where you can see all your organisations. When you click on a organisation you go to the settings page of the organisation.

## What is the new behavior?

A suggestion is that when you click on the project name you get redirected to the home page where you can see your whole list of organisations and projects. 

I've added this in but I have also added a settings icon on each organisation name so when you click on the icon you get sent to the settings page of the organisation:

<img width="349" alt="Screenshot 2022-08-11 at 12 17 00" src="https://user-images.githubusercontent.com/22655069/184124500-a8c4bfbc-2193-4030-8238-7cd6278a5d92.png">


## Additional context

This was suggested in #5491
