### PR TITLE
Docs: Avoid mixing Yarn & NPM

### DIFF
--- a/web/docs/guides/with-nextjs.mdx
+++ b/web/docs/guides/with-nextjs.mdx
@@ -171,7 +171,7 @@ We can use [`create-next-app`](https://nextjs.org/docs/getting-started) to initi
 an app called `supabase-nextjs`:
 
 ```bash
-npx create-next-app supabase-nextjs
+npx create-next-app supabase-nextjs --use-npm
 cd supabase-nextjs
 ```
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
Docs update - guide for Supabase with Next.js

## What is the current behavior?
The guide for Supabase with Next.js mixes package managers.
`create-next-app` installs dependencies with Yarn by default, but the guide then installs Supabase using npm. It does install Supabase properly, but it would be better to avoid using two package managers to manage the same packages. 

## What is the new behavior?
Guide specifies `create-next-app` with flag to install using npm.
