### PR TITLE
docs: Clean up sidebar titles

### DIFF
--- a/web/docs/guides/api.mdx
+++ b/web/docs/guides/api.mdx
@@ -2,6 +2,7 @@
 id: api
 title: APIs
 description: Auto-generating and Realtime APIs.
+sidebar_label: Overview
 ---
 
 import Tabs from '@theme/Tabs';

--- a/web/docs/guides/auth.mdx
+++ b/web/docs/guides/auth.mdx
@@ -2,6 +2,7 @@
 id: auth
 title: Auth
 description: Use Supabase to Authenticate and Authorize your users.
+sidebar_label: Overview
 ---
 
 import Link from '@docusaurus/Link'

--- a/web/docs/guides/database.mdx
+++ b/web/docs/guides/database.mdx
@@ -2,6 +2,7 @@
 id: database
 title: Database
 description: Use Supabase to manage your data.
+sidebar_label: Overview
 ---
 
 Every Supabase project comes with a full [Postgres](https://www.postgresql.org/) database, a free and open source

--- a/web/docs/guides/database/connecting-to-postgres.mdx
+++ b/web/docs/guides/database/connecting-to-postgres.mdx
@@ -1,6 +1,6 @@
 ---
 id: connecting-to-postgres
-title: 'Connecting'
+title: 'Database Connections'
 description: There are various ways to connect to your Postgres database.
 ---
 

--- a/web/docs/guides/hosting/docker.mdx
+++ b/web/docs/guides/hosting/docker.mdx
@@ -1,7 +1,8 @@
 ---
 id: docker
-title: With Docker
-description: How to use configure and deploy Supabase.
+title: Self-hosting with Docker
+description: How to configure and deploy Supabase.
+sidebar_label: Docker
 ---
 
 Docker is the easiest way to get started with self-hosted Supabase.

--- a/web/docs/guides/storage.mdx
+++ b/web/docs/guides/storage.mdx
@@ -2,6 +2,7 @@
 id: storage
 title: Storage
 description: Use Supabase to store and serve files.
+sidebar_label: Overview
 ---
 
 import Tabs from '@theme/Tabs'

--- a/web/docs/guides/with-angular.mdx
+++ b/web/docs/guides/with-angular.mdx
@@ -2,6 +2,7 @@
 id: with-angular
 title: "Quickstart: Angular"
 description: Learn how to use Supabase in your Angular App.
+sidebar_label: Angular
 ---
 
 import Tabs from '@theme/Tabs';

--- a/web/docs/guides/with-expo.mdx
+++ b/web/docs/guides/with-expo.mdx
@@ -2,6 +2,7 @@
 id: with-expo
 title: 'Quickstart: Expo'
 description: Learn how to use Supabase in your React Native App.
+sidebar_label: Expo
 ---
 
 import Tabs from '@theme/Tabs'

--- a/web/docs/guides/with-flutter.mdx
+++ b/web/docs/guides/with-flutter.mdx
@@ -2,6 +2,7 @@
 id: with-flutter
 title: 'Quickstart: Flutter'
 description: Learn how to use Supabase in your Flutter App.
+sidebar_label: Flutter
 ---
 
 import Tabs from '@theme/Tabs'

--- a/web/docs/guides/with-ionic-angular.mdx
+++ b/web/docs/guides/with-ionic-angular.mdx
@@ -2,6 +2,7 @@
 id: with-ionic-angular
 title: "Quickstart: Ionic Angular"
 description: Learn how to use Supabase in your Ionic Angular App.
+sidebar_label: Ionic Angular
 ---
 
 import Tabs from '@theme/Tabs';

--- a/web/docs/guides/with-ionic-react.mdx
+++ b/web/docs/guides/with-ionic-react.mdx
@@ -2,6 +2,7 @@
 id: with-ionic-react
 title: "Quickstart: Ionic React"
 description: Learn how to use Supabase in your Ionic React App.
+sidebar_label: Ionic React
 ---
 
 import Tabs from '@theme/Tabs';

--- a/web/docs/guides/with-ionic-vue.mdx
+++ b/web/docs/guides/with-ionic-vue.mdx
@@ -2,6 +2,7 @@
 id: with-ionic-vue
 title: "Quickstart: Ionic Vue"
 description: Learn how to use Supabase in your Ionic Vue App.
+sidebar_label: Ionic Vue
 ---
 
 import Tabs from '@theme/Tabs';

--- a/web/docs/guides/with-nextjs.mdx
+++ b/web/docs/guides/with-nextjs.mdx
@@ -2,6 +2,7 @@
 id: with-nextjs
 title: "Quickstart: Next.js"
 description: Learn how to use Supabase in your Next App.
+sidebar_label: "Next.js"
 ---
 
 import Tabs from '@theme/Tabs';

--- a/web/docs/guides/with-nuxt-3.mdx
+++ b/web/docs/guides/with-nuxt-3.mdx
@@ -2,6 +2,7 @@
 id: with-nuxt-3
 title: 'Quickstart: Nuxt 3'
 description: Learn how to use Supabase in your Nuxt 3 App.
+sidebar_label: Nuxt 3
 ---
 
 # Quickstart: Nuxt

--- a/web/docs/guides/with-react.mdx
+++ b/web/docs/guides/with-react.mdx
@@ -2,6 +2,7 @@
 id: with-react
 title: 'Quickstart: React'
 description: Learn how to use Supabase in your React App.
+sidebar_label: React
 ---
 
 import Tabs from '@theme/Tabs'

--- a/web/docs/guides/with-redwoodjs.mdx
+++ b/web/docs/guides/with-redwoodjs.mdx
@@ -2,6 +2,7 @@
 id: with-redwoodjs
 title: 'Quickstart: RedwoodJS'
 description: Learn how to use Supabase in your RedwoodJS App.
+sidebar_label: RedwoodJS
 ---
 
 import Tabs from '@theme/Tabs'

--- a/web/docs/guides/with-solidjs.mdx
+++ b/web/docs/guides/with-solidjs.mdx
@@ -2,6 +2,7 @@
 id: with-solidjs
 title: 'Quickstart: SolidJS'
 description: Learn how to use Supabase in your SolidJS App.
+sidebar_label: SolidJS
 ---
 
 import Tabs from '@theme/Tabs'

--- a/web/docs/guides/with-svelte.mdx
+++ b/web/docs/guides/with-svelte.mdx
@@ -2,6 +2,7 @@
 id: with-svelte
 title: "Quickstart: Svelte"
 description: Learn how to use Supabase in your Svelte App.
+sidebar_label: Svelte
 ---
 
 import Tabs from '@theme/Tabs';

--- a/web/docs/guides/with-sveltekit.mdx
+++ b/web/docs/guides/with-sveltekit.mdx
@@ -2,6 +2,7 @@
 id: with-sveltekit
 title: "Quickstart: SvelteKit"
 description: Learn how to use Supabase in your SvelteKit App.
+sidebar_label: SvelteKit
 ---
 
 import Tabs from '@theme/Tabs';

--- a/web/docs/guides/with-vue-3.mdx
+++ b/web/docs/guides/with-vue-3.mdx
@@ -2,6 +2,7 @@
 id: with-vue-3
 title: "Quickstart: Vue 3"
 description: Learn how to use Supabase in your Vue 3 App.
+sidebar_label: "Vue 3"
 ---
 
 import Tabs from '@theme/Tabs';


### PR DESCRIPTION
## What kind of change does this PR introduce?

Make sidebar titles consistent and not have the same text as the category they reside under

## What is the current behavior?

https://supabase.com/docs

## What is the new behavior?

![Screen Shot 2022-08-11 at 5 45 22 PM](https://user-images.githubusercontent.com/7026076/184265198-01521078-d80d-4f51-9dfc-1657c7cdb51d.png)
![Screen Shot 2022-08-11 at 5 45 32 PM](https://user-images.githubusercontent.com/7026076/184265200-888e0b5c-af93-455a-ba4a-d69402802385.png)
![Screen Shot 2022-08-11 at 5 45 46 PM](https://user-images.githubusercontent.com/7026076/184265202-2f9ed57b-c326-4a73-8ee2-f7a4bdf62fde.png)
![Screen Shot 2022-08-11 at 5 46 01 PM](https://user-images.githubusercontent.com/7026076/184265203-5a881fdf-543e-4e52-89b5-58945a4e71c4.png)

