### PR TITLE
Fix: tables input

### DIFF
--- a/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
+++ b/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
@@ -179,7 +179,7 @@ const TableEditorMenu: FC<Props> = ({
         {/* Table search input */}
         <div className="mb-2 block px-3">
           <Input
-            className="border-none"
+            className={`border-none transition ease-in-out ${searchText == '' ? '' : 'custom-input-width'}`}
             icon={
               <div className="text-scale-900">
                 <IconSearch size={12} strokeWidth={1.5} />

--- a/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
+++ b/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
@@ -179,7 +179,7 @@ const TableEditorMenu: FC<Props> = ({
         {/* Table search input */}
         <div className="mb-2 block px-3">
           <Input
-            className={`border-none transition ease-in-out ${searchText == '' ? '' : 'custom-input-width'}`}
+            className={`border-none transition ease-in-out ${searchText.length > 0 ? 'custom-input-width' : ''}`}
             icon={
               <div className="text-scale-900">
                 <IconSearch size={12} strokeWidth={1.5} />

--- a/studio/styles/main.scss
+++ b/studio/styles/main.scss
@@ -211,3 +211,7 @@ div.fixed.inset-0 {
     @apply text-sm;
   }
 }
+
+.custom-input-width div div div input {
+  width: 80%;
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

fix table input `X` not show because of text.

## What is the current behavior?

Fix #8196

https://user-images.githubusercontent.com/70828596/184279920-d7794c12-9063-4d4a-bf7e-802c916a33ce.mp4

## What is the new behavior?

https://user-images.githubusercontent.com/70828596/184279905-9eaf0295-463d-460c-926e-fbb37b1248ea.mp4

## Additional context

This is the only idea that I could come up with. giving the icon any type of background blocks the text, so this was the next best thing.