### PR TITLE
feat: table column title hover

### DIFF
--- a/studio/components/grid/components/grid/ColumnHeader.tsx
+++ b/studio/components/grid/components/grid/ColumnHeader.tsx
@@ -19,6 +19,7 @@ export function ColumnHeader<R>({
   const columnKey = column.key
   const columnFormat = getColumnFormat(columnType, format)
   const state = useTrackedState()
+  const hoverValue = column.name as string
 
   // keep state.gridColumns' order in sync with data grid component
   if (state.gridColumns[columnIdx].key != columnKey) {
@@ -122,7 +123,9 @@ export function ColumnHeader<R>({
               <IconKey size="tiny" strokeWidth={2} />
             </div>
           )}
-          <span className="sb-grid-column-header__inner__name">{column.name}</span>
+          <span className="sb-grid-column-header__inner__name" title={hoverValue}>
+            {column.name}
+          </span>
           <span className="sb-grid-column-header__inner__format">{columnFormat}</span>
         </div>
         <ColumnMenu column={column} />


### PR DESCRIPTION
## What kind of change does this PR introduce?

Studio Feature

## What is the current behavior?

This was brought up in discussion #8246 as a request. Currently when in the table view, long column names are truncated and you can not see the column name

## What is the new behavior?

When you have a long column name and you hover over the column name you will see a popover of the column name:

https://user-images.githubusercontent.com/22655069/184423762-e1685141-acf5-48dc-aeed-9af4ce781f5e.mov
