### PR TITLE
Fix: docs navbar

### DIFF
--- a/web/docusaurus.config.js
+++ b/web/docusaurus.config.js
@@ -67,8 +67,7 @@ module.exports = {
         {
           label: 'Guides',
           to: '/',
-          activeBaseRegex:
-            '.*.docs/$|^/docs/architecture|(^/docs/guides/(database|auth|storage|api|examples!))|(^/docs/guides/(examples|with-angular|with-flutter|with-nextjs|with-nuxt-3|with-react|with-redwoodjs|with-svelte|with-vue-3)|^/docs/faq|^/docs/going-into-prod|^/docs/handbook|^/docs/company)',
+          activeBasePath: '/docs/guides/',
           position: 'left',
         },
         {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix navbar links `Guides` and `Reference` are both highlighted at the same time

## What is the current behavior?

`Guides` and `Reference` are both highlighted at the same time

![CleanShot 2022-08-12 at 15 11 44@2x](https://user-images.githubusercontent.com/70828596/184427449-68c7353f-58f2-45aa-9f47-7eb76c92d091.png)

## What is the new behavior?

Only link highlighted

![CleanShot 2022-08-12 at 15 11 32@2x](https://user-images.githubusercontent.com/70828596/184427476-1184b06b-47f6-4c0f-99ed-56e9d291c1b5.png)

## Additional context

Fix: #7530