### PR TITLE
Correct class names to match CSS

### DIFF
--- a/web/docs/guides/with-nextjs.mdx
+++ b/web/docs/guides/with-nextjs.mdx
@@ -219,7 +219,7 @@ export default function Auth() {
 
   return (
     <div className="row flex flex-center">
-      <div className="col-6 form-widget">
+      <div className="col-6 auth-widget">
         <h1 className="header">Supabase + Next.js</h1>
         <p className="description">Sign in via magic link with your email below</p>
         <div>
@@ -324,7 +324,7 @@ export default function Account({ session }) {
   }
 
   return (
-    <div className="form-widget">
+    <div className="account">
       <div>
         <label htmlFor="email">Email</label>
         <input id="email" type="text" value={session.user.email} disabled />
@@ -522,7 +522,7 @@ import Avatar from './Avatar'
 // ...
 
 return (
-  <div className="form-widget">
+  <div className="account">
     {/* Add to the body */}
     <Avatar
       url={avatar_url}


### PR DESCRIPTION
## What kind of change does this PR introduce?
Docs update (bug fix to the guide)

## What is the current behavior?
The tutorial provides React Component code that lists non-existent CSS classes. This results in improper spacing (see screenshot). It appears the class names & styles in the CSS file was refactored at some point and this .md guide was not updated. 

## What is the new behavior?
The proposed changes use the correct class names here in the markdown.

## Additional context
<img width="591" alt="Screen Shot 2022-08-11 at 7 17 10 PM" src="https://user-images.githubusercontent.com/89077432/184501650-cd2d3d3f-7978-4e88-b2b2-a28fd57bd23b.png">
<img width="590" alt="Screen Shot 2022-08-11 at 7 15 36 PM" src="https://user-images.githubusercontent.com/89077432/184501653-940f254f-6603-406b-ab8a-560de9a1d191.png">

