### PR TITLE
Fix step numbering in Vercel integration guide

### DIFF
--- a/web/docs/guides/integrations/vercel.mdx
+++ b/web/docs/guides/integrations/vercel.mdx
@@ -89,7 +89,7 @@ From the Supabase popup, select your new Vercel Project and Supabase project fro
 
 ![Supabase integration](/img/guides/integrations/vercel/link-vercel-to-supabase.png)
 
-## Step 4: Clone GitHub repo
+## Step 3: Clone GitHub repo
 
 The fastest way to get this project running locally is to clone the repo that Vercel created for us.
 


### PR DESCRIPTION
## What is the current behavior?

https://supabase.com/docs/guides/integrations/vercel

<img width="186" alt="Screen Shot 2022-08-14 at 3 57 31 PM" src="https://user-images.githubusercontent.com/7026076/184557917-db90238b-27aa-4a54-ad47-1a86d5a405ea.png">

## What is the new behavior?

Steps are numbered correctly
