### PR TITLE
Fix missing card title on docs landing page

### DIFF
--- a/apps/reference/docs/about.mdx
+++ b/apps/reference/docs/about.mdx
@@ -149,6 +149,7 @@ You can use it completely, or just the features you need.
       <ButtonCard
         class="card"
         to={useBaseUrl('/guides/platform/logs')}
+        title={'Observability'}
         description={'Monitor and debug your infrastucture.'}
         style={{ height: '100%' }}
       >

--- a/apps/reference/docs/guides/integrations/vercel.mdx
+++ b/apps/reference/docs/guides/integrations/vercel.mdx
@@ -89,7 +89,7 @@ From the Supabase popup, select your new Vercel Project and Supabase project fro
 
 ![Supabase integration](/img/guides/integrations/vercel/link-vercel-to-supabase.png)
 
-## Step 4: Clone GitHub repo
+## Step 3: Clone GitHub repo
 
 The fastest way to get this project running locally is to clone the repo that Vercel created for us.
 


### PR DESCRIPTION
- https://reference-docs-git-dng-docs-card-title-supabase.vercel.app/new-docs
- https://reference-docs-git-dng-docs-card-title-supabase.vercel.app/new-docs/guides/integrations/vercel

## What kind of change does this PR introduce?

- Fix missing card title on docs landing page
- Fix step numbering in Vercel integration guide

## What is the current behavior?

<img width="915" alt="Screen Shot 2022-08-14 at 6 29 32 PM" src="https://user-images.githubusercontent.com/7026076/184563381-67b032ae-2bf6-4e49-bf77-0d18063ff3e5.png">
<img width="186" alt="Screen Shot 2022-08-14 at 3 57 31 PM" src="https://user-images.githubusercontent.com/7026076/184563378-7ba123fd-e836-4115-9243-ee151b3502e0.png">

## What is the new behavior?

<img width="908" alt="Screen Shot 2022-08-14 at 6 30 17 PM" src="https://user-images.githubusercontent.com/7026076/184563418-3128133a-ae06-472a-bce7-df1a21112bf7.png">
<img width="197" alt="Screen Shot 2022-08-14 at 6 30 08 PM" src="https://user-images.githubusercontent.com/7026076/184563431-91830b97-217b-42a5-88d9-56c5b181b970.png">