### PR TITLE
fix: broken more link on blog post

### DIFF
--- a/apps/www/_blog/2022-06-29-visualizing-supabase-data-using-metabase.mdx
+++ b/apps/www/_blog/2022-06-29-visualizing-supabase-data-using-metabase.mdx
@@ -136,5 +136,5 @@ If you have any questions please reach out via [Twitter](https://twitter.com/sup
 
 ## More Python and Supabase resources
 - [supabase-py](https://github.com/supabase-community/supabase-py)
-- [Slack Consolidate: a slackbot built with Python and Supabase](blog/slack-consolidate-slackbot-to-consolidate-messages)
+- [Slack Consolidate: a slackbot built with Python and Supabase](slack-consolidate-slackbot-to-consolidate-messages)
 - [Supabase-py (Database) on Replit](https://replit.com/@Supabase/Supabase-py-Database?v=1)


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to fix a broken link on blog page. Fix #8298.

## What is the current behavior?

Currently the link `Slack Consolidate: a slackbot built with Python and Supabase` is broken. 

## What is the new behavior?

The link should work.

## Additional context

N/A
