### PR TITLE
Remove invalid TypeScript type syntax from starter file

### DIFF
--- a/apps/reference/docs/guides/with-sveltekit.mdx
+++ b/apps/reference/docs/guides/with-sveltekit.mdx
@@ -251,7 +251,7 @@ Let's create a new component for that called `Profile.svelte`.
   let website = null
   let avatar_url = null
 
-  function getProfile(node: HTMLElement) {
+  function getProfile(node) {
   try {
     loading = true;
     const user = supabase.auth.user();
@@ -269,7 +269,7 @@ Let's create a new component for that called `Profile.svelte`.
         }
         if (error && status !== 406) throw error;
       });
-    } catch (error: any) {
+    } catch (error) {
       alert(error.message);
     } finally {
       loading = false;


### PR DESCRIPTION
This code throws an error because it includes TypeScript types in two locations.

Adding `lang="ts"` to the `<script>` tag also fixes the issue, but since TS doesn't seem to be present anywhere else in this starter, for the sake of simplicity, I felt it was better to simply remove the TS syntax.

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
