### PR TITLE
docs: fixed typo in with-expo.mdx

### DIFF
--- a/apps/reference/docs/guides/with-expo.mdx
+++ b/apps/reference/docs/guides/with-expo.mdx
@@ -423,7 +423,7 @@ import { View } from 'react-native'
 import { Session } from '@supabase/supabase-js'
 
 export default function App() {
-  const [session, setSession] = (useState < Session) | (null > null)
+  const [session, setSession] = useState<Session|null>(null);
 
   useEffect(() => {
     setSession(supabase.auth.session())


### PR DESCRIPTION
There was a typo in the tsx portion, see this StackOverflow post https://stackoverflow.com/a/73368981/12101554

## What kind of change does this PR introduce?

Docs typo fix

## What is the current behavior?

There was a typo that made it invalid code

## What is the new behavior?

The typo is fiex

## Additional context

Typo discussed here https://stackoverflow.com/a/73368981/12101554
