### PR TITLE
fix: support buttons layout

### DIFF
--- a/apps/www/pages/support.tsx
+++ b/apps/www/pages/support.tsx
@@ -134,7 +134,7 @@ const Index = ({}: Props) => {
                     >
                       <a target="_blank">
                         <Button size="medium" type="default" iconRight={<IconMessageCircle />}>
-                          Join The Discussion
+                          Join the discussion
                         </Button>
                       </a>
                     </Link>

--- a/apps/www/pages/support.tsx
+++ b/apps/www/pages/support.tsx
@@ -122,8 +122,8 @@ const Index = ({}: Props) => {
                 <div>
                   <div
                     className="
-                    dark:bg-scale-400 justify-space-evenly
-                    flex flex-row gap-2 rounded rounded-t-none border-b
+                    dark:bg-scale-400 lg:justify-evenly gap-2
+                    flex flex-row rounded rounded-t-none border-b
                     border-r border-l
                     border-gray-100 bg-white p-5
                     pt-14 dark:border-gray-600"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase site fix

## What is the current behavior?

On the [Support Page](https://supabase.com/support) on the Github Discussions/Discord section the spacing seems off:

<img width="370" alt="Screenshot 2022-08-16 at 19 11 53" src="https://user-images.githubusercontent.com/22655069/184950057-2d2e9928-3edd-4508-b121-0c40522e0e8c.png">

## What is the new behavior?

Layout is now more even and made a tweak for other screen sizes:

<img width="370" alt="Screenshot 2022-08-16 at 19 11 40" src="https://user-images.githubusercontent.com/22655069/184950158-1829eede-f5c4-4f68-a9a2-bbe06d889550.png">

