### PR TITLE
feat: Studio show table name

### DIFF
--- a/studio/components/interfaces/Database/Tables/ColumnList.tsx
+++ b/studio/components/interfaces/Database/Tables/ColumnList.tsx
@@ -81,7 +81,7 @@ const ColumnList: FC<{
                 icon={<IconChevronLeft size="small" />}
                 style={{ padding: '5px' }}
               />
-              <Typography.Text code>{selectedTable.name}</Typography.Text>
+              <code>{selectedTable.name}</code>
             </div>
           }
           rightComponents={

--- a/studio/components/interfaces/Database/Tables/ColumnList.tsx
+++ b/studio/components/interfaces/Database/Tables/ColumnList.tsx
@@ -8,7 +8,7 @@ import {
   IconPlus,
   IconChevronLeft,
   IconEdit3,
-  IconTrash
+  IconTrash,
 } from '@supabase/ui'
 
 import { useStore } from 'hooks'
@@ -73,15 +73,15 @@ const ColumnList: FC<{
           filterString={filterString}
           setFilterString={setFilterString}
           leftComponents={
-            <div className='flex items-center mr-4'>
-            <Button
-              type="outline"
-              className="mr-4"
-              onClick={() => onSelectBack()}
-              icon={<IconChevronLeft size="small" />}
-              style={{ padding: '5px' }}
-            />
-             <Typography.Text code>{selectedTable.name}</Typography.Text>           
+            <div className="flex items-center mr-4">
+              <Button
+                type="outline"
+                className="mr-4"
+                onClick={() => onSelectBack()}
+                icon={<IconChevronLeft size="small" />}
+                style={{ padding: '5px' }}
+              />
+              <Typography.Text code>{selectedTable.name}</Typography.Text>
             </div>
           }
           rightComponents={

--- a/studio/components/interfaces/Database/Tables/ColumnList.tsx
+++ b/studio/components/interfaces/Database/Tables/ColumnList.tsx
@@ -8,7 +8,7 @@ import {
   IconPlus,
   IconChevronLeft,
   IconEdit3,
-  IconTrash,
+  IconTrash
 } from '@supabase/ui'
 
 import { useStore } from 'hooks'
@@ -73,6 +73,7 @@ const ColumnList: FC<{
           filterString={filterString}
           setFilterString={setFilterString}
           leftComponents={
+            <div className='flex items-center mr-4'>
             <Button
               type="outline"
               className="mr-4"
@@ -80,6 +81,8 @@ const ColumnList: FC<{
               icon={<IconChevronLeft size="small" />}
               style={{ padding: '5px' }}
             />
+             <Typography.Text code>{selectedTable.name}</Typography.Text>           
+            </div>
           }
           rightComponents={
             <Button icon={<IconPlus />} onClick={() => onAddColumn()}>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Studio: Database > Tables

## What is the current behavior?

At the moment when you click on the column count their is no indication of the table

## What is the new behavior?

The table name now appears when you are editing the columns:

<img width="1117" alt="Screenshot 2022-08-16 at 19 32 23" src="https://user-images.githubusercontent.com/22655069/184953796-7fb79a2a-054c-468d-ac1b-01aaae3b175a.png">


## Additional context

This is linked to #8381
