### PR TITLE
docs: fix 404 link

### DIFF
--- a/apps/reference/docs/guides/api.mdx
+++ b/apps/reference/docs/guides/api.mdx
@@ -394,7 +394,7 @@ alter table todos enable row level security;
 
 Never expose the `service_role` key in a browser or anywhere where a user can see it. This Key is designed to bypass Row Level Security - so it should only be used on a private server.
 
-We have [partnered with GitHub](https://supabase.com/blog/2022/03/28/community-day#supabase-is-now-a-github-secret-scanning-partner) to scan for Supabase `service_role` keys pushed to public repositories.
+We have [partnered with GitHub](https://github.blog/changelog/2022-03-28-supabase-is-now-a-github-secret-scanning-partner/) to scan for Supabase `service_role` keys pushed to public repositories.
 If they detect any keys with service_role privileges being pushed to GitHub, they will forward the API key to us, so that we can automatically revoke the detected secrets and notify you, protecting your data against malicious actors.
 
 ### Safeguards towards accidental deletes and updates


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

the current link ("We have partnered with GitHub ...") in the docs is 404.

See: https://supabase.com/docs/guides/api#the-service_role-key

The incorrect link right now points to https://supabase.com/blog/2022/03/28/community-day#supabase-is-now-a-github-secret-scanning-partner

## What is the new behavior?

the link works

## Additional context

I tried fixing the link by pointing it to 

https://supabase.com/blog/beta-update-march-2022#github-secret-scanning

instead (which should be a direct link to the paragraph announcing this on Supabase's blog), but that link/hash/anchor would not work. I decided to link to the GitHub blog instead. Happy to change this to something else if that's preferable. Cheers!