### PR TITLE
fix: Studio function argument/s overflow

### DIFF
--- a/studio/pages/project/[ref]/database/functions.tsx
+++ b/studio/pages/project/[ref]/database/functions.tsx
@@ -253,7 +253,7 @@ const FunctionList: FC<FunctionListProps> = observer(
             <Table.td>
               <Typography.Text>{x.name}</Typography.Text>
             </Table.td>
-            <Table.td className="hidden md:table-cell">
+            <Table.td className="hidden md:table-cell md:overflow-auto">
               <Typography.Text>{x.argument_types}</Typography.Text>
             </Table.td>
             <Table.td className="hidden lg:table-cell">


### PR DESCRIPTION
## What kind of change does this PR introduce?

Studio Database > Functions

## What is the current behavior?

The column for the arguments for functions overflows and is unreadable:

<img width="1081" alt="Screenshot 2022-08-17 at 09 11 12" src="https://user-images.githubusercontent.com/22655069/185068535-552aa278-63ef-48d1-9369-7308ce54b55b.png">

## What is the new behavior?

Overflow has been added:


https://user-images.githubusercontent.com/22655069/185068782-0f990702-1a88-4acd-a3de-f62a4d5982b3.mov



## Additional context

This will close #8406
