### PR TITLE
Update database extensions modal

### DIFF
--- a/studio/components/interfaces/Database/Extensions/ExtensionCard.tsx
+++ b/studio/components/interfaces/Database/Extensions/ExtensionCard.tsx
@@ -19,40 +19,39 @@ const ExtensionCard: FC<Props> = ({ extension }) => {
   const [showConfirmEnableModal, setShowConfirmEnableModal] = useState(false)
 
   async function enableExtension() {
-    if (EXTENSIONS_IN_OWN_SCHEMA.includes(extension.name)) {
-      return setShowConfirmEnableModal(true)
-    }
+    return setShowConfirmEnableModal(true)
 
-    confirmAlert({
-      title: 'Confirm to enable extension',
-      message: `Are you sure you want to turn ON "${extension.name}" extension?`,
-      onAsyncConfirm: async () => {
-        try {
-          setLoading(true)
-          const response = await meta.extensions.create({
-            name: extension.name,
-            schema: 'extensions',
-            version: extension.default_version,
-            cascade: true,
-          })
-          if (response.error) {
-            throw response.error
-          } else {
-            ui.setNotification({
-              category: 'success',
-              message: `${extension.name.toUpperCase()} is on.`,
-            })
-          }
-        } catch (error: any) {
-          ui.setNotification({
-            category: 'error',
-            message: `Failed to toggle ${extension.name.toUpperCase()}: ${error.message}`,
-          })
-        } finally {
-          setLoading(false)
-        }
-      },
-    })
+    // [Joshen] Keeping this for now in case we need a reference
+    // confirmAlert({
+    //   title: 'Confirm to enable extension',
+    //   message: `Are you sure you want to turn ON "${extension.name}" extension?`,
+    //   onAsyncConfirm: async () => {
+    //     try {
+    //       setLoading(true)
+    //       const response = await meta.extensions.create({
+    //         name: extension.name,
+    //         schema: 'extensions',
+    //         version: extension.default_version,
+    //         cascade: true,
+    //       })
+    //       if (response.error) {
+    //         throw response.error
+    //       } else {
+    //         ui.setNotification({
+    //           category: 'success',
+    //           message: `${extension.name.toUpperCase()} is on.`,
+    //         })
+    //       }
+    //     } catch (error: any) {
+    //       ui.setNotification({
+    //         category: 'error',
+    //         message: `Failed to toggle ${extension.name.toUpperCase()}: ${error.message}`,
+    //       })
+    //     } finally {
+    //       setLoading(false)
+    //     }
+    //   },
+    // })
   }
 
   async function disableExtension() {

--- a/studio/components/interfaces/Database/Extensions/ExtensionCard.tsx
+++ b/studio/components/interfaces/Database/Extensions/ExtensionCard.tsx
@@ -4,7 +4,6 @@ import { Badge, IconLoader, Toggle } from '@supabase/ui'
 
 import { useStore } from 'hooks'
 import { confirmAlert } from 'components/to-be-cleaned/ModalsDeprecated/ConfirmModal'
-import { EXTENSIONS_IN_OWN_SCHEMA } from './Extensions.constants'
 import EnableExtensionModal from './EnableExtensionModal'
 
 interface Props {
@@ -20,38 +19,6 @@ const ExtensionCard: FC<Props> = ({ extension }) => {
 
   async function enableExtension() {
     return setShowConfirmEnableModal(true)
-
-    // [Joshen] Keeping this for now in case we need a reference
-    // confirmAlert({
-    //   title: 'Confirm to enable extension',
-    //   message: `Are you sure you want to turn ON "${extension.name}" extension?`,
-    //   onAsyncConfirm: async () => {
-    //     try {
-    //       setLoading(true)
-    //       const response = await meta.extensions.create({
-    //         name: extension.name,
-    //         schema: 'extensions',
-    //         version: extension.default_version,
-    //         cascade: true,
-    //       })
-    //       if (response.error) {
-    //         throw response.error
-    //       } else {
-    //         ui.setNotification({
-    //           category: 'success',
-    //           message: `${extension.name.toUpperCase()} is on.`,
-    //         })
-    //       }
-    //     } catch (error: any) {
-    //       ui.setNotification({
-    //         category: 'error',
-    //         message: `Failed to toggle ${extension.name.toUpperCase()}: ${error.message}`,
-    //       })
-    //     } finally {
-    //       setLoading(false)
-    //     }
-    //   },
-    // })
   }
 
   async function disableExtension() {

--- a/studio/components/interfaces/Database/Extensions/Extensions.constants.ts
+++ b/studio/components/interfaces/Database/Extensions/Extensions.constants.ts
@@ -12,5 +12,3 @@ export const HIDDEN_EXTENSIONS = [
   'pg_visibility',
   'pgstattuple',
 ]
-
-export const EXTENSIONS_IN_OWN_SCHEMA = ['postgis', 'pgsodium', 'vault']

--- a/studio/components/interfaces/Database/Extensions/Extensions.tsx
+++ b/studio/components/interfaces/Database/Extensions/Extensions.tsx
@@ -3,7 +3,7 @@ import { observer } from 'mobx-react-lite'
 import { partition, isNull } from 'lodash'
 import { Input, IconSearch } from '@supabase/ui'
 
-import { useStore } from 'hooks'
+import { useStore, useFlag } from 'hooks'
 import ExtensionCard from './ExtensionCard'
 import { HIDDEN_EXTENSIONS } from './Extensions.constants'
 import NoSearchResults from 'components/to-be-cleaned/NoSearchResults'
@@ -14,12 +14,17 @@ const Extensions: FC<Props> = ({}) => {
   const { meta } = useStore()
   const [filterString, setFilterString] = useState<string>('')
 
+  const enableVaultExtension = useFlag('vaultExtension')
+  const hiddenExtensions = enableVaultExtension
+    ? HIDDEN_EXTENSIONS
+    : HIDDEN_EXTENSIONS.concat(['vault'])
+
   const extensions =
     filterString.length === 0
       ? meta.extensions.list()
       : meta.extensions.list((ext: any) => ext.name.includes(filterString))
   const extensionsWithoutHidden = extensions.filter(
-    (ext: any) => !HIDDEN_EXTENSIONS.includes(ext.name)
+    (ext: any) => !hiddenExtensions.includes(ext.name)
   )
   const [enabledExtensions, disabledExtensions] = partition(
     extensionsWithoutHidden,


### PR DESCRIPTION
- Allow users to select which schema to install it to
- By default we select the schema extensions, but users can choose any other schema or even create another schema to install that extension to (example 1 in demo video)
- However, for extensions which have a specified schema in the `pg_available_extension_versions`, we'll enforce that (example 2 in demo video)

https://user-images.githubusercontent.com/19742402/185152833-3c1b9bba-47d1-4f4f-93e8-4100ff4fe633.mov

