### PR TITLE
Update supabase_js_v2_legacy.yml

### DIFF
--- a/spec/supabase_js_v2_legacy.yml
+++ b/spec/supabase_js_v2_legacy.yml
@@ -928,7 +928,7 @@ pages:
       - Row level security is not applied to delete statements.
       - If you want to receive the "previous" data for updates and deletes, you will need to set `REPLICA IDENTITY` to `FULL`, like this: `ALTER TABLE your_table REPLICA IDENTITY FULL;`
       - When a delete occurs, the contents of old_record will be broadcast to all subscribers to that table so ensure that each table's replica identity only contains information that is safe to expose publicly.
-      - The channel name must exactly match the schema/table/filter you want to listen to separated by semicolons. See below examples for additional context.
+      - The channel name must exactly match the schema/table/filter you want to listen to separated by colons. See below examples for additional context.
     examples:
       - name: Listen to all database changes
         isSpotlight: true


### PR DESCRIPTION
## What kind of change does this PR introduce?
docs update - apparent error

## What is the current behavior?
says channel names should be schema/table/filter separated by semicolon ';' but it should be a colon ':'

## What is the new behavior?
specify 'colon'
