### PR TITLE
Skip updating latest tag when published from studio

### DIFF
--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -49,7 +49,7 @@ jobs:
       - uses: docker/build-push-action@v3
         with:
           push: true
-          context: studio
+          context: "{{defaultContext}}:studio"
           target: production
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -3,7 +3,7 @@ name: Publish to Image Registry
 on:
   push:
     tags:
-      - 'v*'
+      - '*'
   workflow_dispatch:
     inputs:
       version:
@@ -49,7 +49,7 @@ jobs:
       - uses: docker/build-push-action@v3
         with:
           push: true
-          context: "{{defaultContext}}:studio"
+          context: '{{defaultContext}}:studio'
           target: production
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -2,17 +2,18 @@ name: Publish to Image Registry
 
 on:
   push:
-    branches:
-      - studio
-    paths:
-      - 'studio/**'
     tags:
       - 'v*'
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Image tag'
+        required: true
+        type: string
 
 jobs:
   publish:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - id: meta
         uses: docker/metadata-action@v4
@@ -21,9 +22,10 @@ jobs:
             supabase/studio
             public.ecr.aws/t3w2s2c9/studio
           flavor: |
-            latest=true
+            latest=false
           tags: |
             type=ref,event=tag
+            type=raw,value=${{ inputs.version }},enable=${{ github.event_name != 'push' }}
 
       - uses: docker/setup-qemu-action@v2
         with:


### PR DESCRIPTION
## What kind of change does this PR introduce?

release workflow

1. support manual studio image releases via `workflow_dispatch` (allows bug fix releases for cli)
2. when new tag is pushed, release both studio and dashboard
3. stop pushing to latest tag as it's disabled on our ECR