### PR TITLE
chore: unused imports removed

### DIFF
--- a/studio/components/interfaces/Database/Tables/ColumnList.tsx
+++ b/studio/components/interfaces/Database/Tables/ColumnList.tsx
@@ -11,8 +11,6 @@ import {
   IconTrash,
 } from '@supabase/ui'
 
-import { useStore } from 'hooks'
-import { confirmAlert } from '../../../to-be-cleaned/ModalsDeprecated/ConfirmModal'
 import Table from '../../../to-be-cleaned/Table'
 import NoSearchResults from 'components/to-be-cleaned/NoSearchResults'
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Studio - Cleanup

## What is the current behavior?

Un-used imports are not being used in the ColumnList component

## What is the new behavior?

The un-used imports have been removed.
