### PR TITLE
fix: Pin recharts to exact version

### DIFF
--- a/studio/package.json
+++ b/studio/package.json
@@ -70,7 +70,7 @@
     "react-virtualized-auto-sizer": "^1.0.6",
     "react-window": "^1.8.6",
     "react-window-infinite-loader": "^1.0.7",
-    "recharts": "^2.1.6",
+    "recharts": "2.1.6",
     "sass": "^1.43.4",
     "scheduler": "^0.20.2",
     "semver": "^6.3.0",


### PR DESCRIPTION
## What kind of change does this PR introduce?

It sets exact 2.1.6 version for recharts dependency (currently pinned on minor).

## What is the current behavior?

Cloning the repo and installing dependencies with yarn will install a patch version of recharts more recent than 2.1.6, which causes an exception to be thrown when trying to run the app.
See  #8491 for a detailed explanation.

## What is the new behavior?

Installing deps with yarn installs the proper 2.1.6 version which works, instead of installing last patch (2.1.13) which causes studio app to crash.

## Additional context

Using npm allows one not to have this issue because of the lock, but the risk remains of having a surprise upon upgrade of packages.

Refer to #8491 
