### PR TITLE
Fix failing docs compilation check

### DIFF
--- a/web/sidebars.js
+++ b/web/sidebars.js
@@ -213,7 +213,6 @@ module.exports = {
       items: [
         'guides/integrations/appsmith',
         'guides/integrations/auth0',
-        'guides/integrations/authsignal',
         'guides/integrations/clerk',
         'guides/integrations/dashibase',
         'guides/integrations/directus',


### PR DESCRIPTION
## What kind of change does this PR introduce?

Remove sidebar reference to non-existing doc

Moved a doc in https://github.com/supabase/supabase/pull/8475 but missed removing it from the old sidebar causing the docs compilation check to fail.

https://github.com/supabase/supabase/runs/7904915471?check_suite_focus=true
