### PR TITLE
fix: add a custom storage key

### DIFF
--- a/studio/lib/gotrue.ts
+++ b/studio/lib/gotrue.ts
@@ -3,9 +3,11 @@ import { GoTrueClient, User } from '@supabase/gotrue-js'
 export const GOTRUE_URL =
   process.env.NEXT_PUBLIC_GOTRUE_URL || `${process.env.SUPABASE_URL}/auth/v1`
 
+export const STORAGE_KEY = process.env.NEXT_PUBLIC_STORAGE_KEY || 'supabase.dashboard.auth.token'
+
 export const auth = new GoTrueClient({
   url: GOTRUE_URL,
-  autoRefreshToken: true,
+  storageKey: STORAGE_KEY,
 })
 
 export const getAuthUser = async (token: String): Promise<any> => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behaviour?

We're using `gotrue-js` default storage key, which can cause issues for some previously logged-in users after the upgrade to `rc`.

## What is the new behaviour?

Custom storage key

## Additional context

This will log out all currently logged-in users upon their next refresh/site load, which preferable to not being able to log in at all.
