### PR TITLE
Modified Vite command(init -> create)

### DIFF
--- a/web/docs/guides/with-vue-3.mdx
+++ b/web/docs/guides/with-vue-3.mdx
@@ -140,10 +140,10 @@ an app called `supabase-vue-3`:
 
 ```bash
 # npm 6.x
-npm init @vitejs/app supabase-vue-3 --template vue
+npm create @vitejs/app supabase-vue-3 --template vue
 
 # npm 7+, extra double-dash is needed:
-npm init @vitejs/app supabase-vue-3 -- --template vue
+npm create @vitejs/app supabase-vue-3 -- --template vue
 
 cd supabase-vue-3
 ```


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update.

Vite template command changed from init to create.

The following error occurred when using the init command.
```
@vitejs/create-app is deprecated, use npm init vite instead

internal/modules/cjs/loader.js:1102
      throw new ERR_REQUIRE_ESM(filename, parentPath, packageJsonPath);
      ^

Error [ERR_REQUIRE_ESM]: Must use import to load ES Module: /Users/star_nishi/.npm/_npx/96769/lib/node_modules/@vitejs/create-app/node_modules/create-vite/index.js
require() of ES modules is not supported.
require() of /Users/star_nishi/.npm/_npx/96769/lib/node_modules/@vitejs/create-app/node_modules/create-vite/index.js from /Users/star_nishi/.npm/_npx/96769/lib/node_modules/@vitejs/create-app/index.js is an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which defines all .js files in that package scope as ES modules.
Instead rename /Users/star_nishi/.npm/_npx/96769/lib/node_modules/@vitejs/create-app/node_modules/create-vite/index.js to end in .cjs, change the requiring code to use import(), or remove "type": "module" from /Users/star_nishi/.npm/_npx/96769/lib/node_modules/@vitejs/create-app/node_modules/create-vite/package.json.

    at new NodeError (internal/errors.js:322:7)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1102:13)
    at Module.load (internal/modules/cjs/loader.js:950:32)
    at Function.Module._load (internal/modules/cjs/loader.js:790:12)
    at Module.require (internal/modules/cjs/loader.js:974:19)
    at require (internal/modules/cjs/helpers.js:101:18)
    at Object.<anonymous> (/Users/star_nishi/.npm/_npx/96769/lib/node_modules/@vitejs/create-app/index.js:43:1)
    at Module._compile (internal/modules/cjs/loader.js:1085:14)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
    at Module.load (internal/modules/cjs/loader.js:950:32) {
  code: 'ERR_REQUIRE_ESM'
}
```

As a solution, the create command was used.

Reference Vite site:
```bash
# npm 6.x
npm create vite@latest my-vue-app --template vue

# npm 7+, extra double-dash is needed:
npm create vite@latest my-vue-app -- --template vue

# yarn
yarn create vite my-vue-app --template vue

# pnpm
pnpm create vite my-vue-app --template vue
```

## What is the current behavior?


## What is the new behavior?

## Additional context
