### PR TITLE
feat: Improved LogEventChart

### DIFF
--- a/studio/components/interfaces/Settings/Logs/LogEventChart.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogEventChart.tsx
@@ -1,99 +1,116 @@
 import { BarChart } from 'components/to-be-cleaned/Charts/ChartRenderer'
 import dayjs from 'dayjs'
-import { LogData } from '.'
+import { EventChartData, isUnixMicro, LogData, unixMicroToIsoTimestamp } from '.'
 import { useMemo } from 'react'
 
 interface Props {
-  data?: LogData[]
-  onBarClick: (timestamp: number) => void
+  data?: EventChartData[]
+  onBarClick: (isoTimestamp: string) => void
 }
 
-type TimestampMap = { [timestamp: number]: number }
 const LogEventChart: React.FC<Props> = ({ data, onBarClick }) => {
   if (!data) return null
-  const aggregated = useAggregated(data)
+  // TODO: remove once endpoint returns iso timestamp directly
+  const transformedData = useMemo(() => {
+    return data.map((d) => {
+      const iso = isUnixMicro(d.timestamp)
+        ? unixMicroToIsoTimestamp(d.timestamp)
+        : dayjs(d.timestamp).toISOString()
+
+      return {
+        ...d,
+        timestamp: iso,
+        // needed for bar chart
+        // TODO: remove once bar chart is refactored
+        period_start: iso,
+      }
+    })
+  }, [JSON.stringify(data)])
 
   return (
     <BarChart
       minimalHeader
       chartSize="tiny"
-      data={aggregated}
+      data={transformedData}
       attribute="count"
       label="Events"
       onBarClick={(v?: { activePayload?: { payload: any }[] }) => {
         if (!v || !v?.activePayload?.[0]?.payload) return
-        const timestamp = v.activePayload[0].payload.timestamp
+        const unixOrIsoTimestamp = v.activePayload[0].payload.timestamp
+        const isoTimestamp = isUnixMicro(unixOrIsoTimestamp)
+          ? unixMicroToIsoTimestamp(unixOrIsoTimestamp)
+          : unixOrIsoTimestamp
         // 60s before
-        onBarClick((Number(timestamp) + 60) * 1000 * 1000)
+        onBarClick(isoTimestamp)
       }}
-      customDateFormat="MMM D, HH:mm"
+      customDateFormat="MMM D, HH:mm:s"
       noDataMessage={''}
     />
   )
 }
 
-const useAggregated = (data: LogData[]) => {
-  const truncateToMinute = (micro: number) => Math.floor(micro / 1000 / 1000 / 60) * 60
-  const truncateToHour = (micro: number) => Math.floor(micro / 1000 / 1000 / 60 / 60) * 60 * 60
-  const getDiffMinute = (currentTimestamp: number, olderTimestamp: number) =>
-    Math.round((currentTimestamp - olderTimestamp) / 1000 / 60)
-  const getDiffHour = (currentTimestamp: number, olderTimestamp: number) =>
-    Math.round((currentTimestamp - olderTimestamp) / 1000 / 60 / 60)
-  const diffMultiplierMinute = (v: number) => v * 60
-  const diffMultiplierHour = (v: number) => v * 60 * 60
-  return useMemo(() => {
-    const oldest = data[data.length - 1]
-    if (!oldest) return
-    const latest = data[0]
-    const oldestDayjs = dayjs(oldest.timestamp / 1000)
-    const latestDayjs = dayjs(latest.timestamp / 1000)
-    let truncFunc = truncateToMinute
-    let getDiff = getDiffMinute
-    let diffMultiplier = diffMultiplierMinute
-    if (Math.abs(oldestDayjs.diff(latestDayjs, 'day', true)) > 0.25) {
-      truncFunc = truncateToHour
-      getDiff = getDiffHour
-      diffMultiplier = diffMultiplierHour
-    }
+// const useAggregated = (data: LogData[]) => {
+//   const truncateToMinute = (micro: number) => Math.floor(micro / 1000 / 1000 / 60) * 60
+//   const truncateToHour = (micro: number) => Math.floor(micro / 1000 / 1000 / 60 / 60) * 60 * 60
+//   const getDiffMinute = (currentTimestamp: number, olderTimestamp: number) =>
+//     Math.round((currentTimestamp - olderTimestamp) / 1000 / 60)
+//   const getDiffHour = (currentTimestamp: number, olderTimestamp: number) =>
+//     Math.round((currentTimestamp - olderTimestamp) / 1000 / 60 / 60)
+//   const diffMultiplierMinute = (v: number) => v * 60
+//   const diffMultiplierHour = (v: number) => v * 60 * 60
+//   return useMemo(() => {
+//     const oldest = data[data.length - 1]
+//     if (!oldest) return
+//     const latest = data[0]
+//     const oldestDayjs = dayjs(oldest.timestamp / 1000)
+//     const latestDayjs = dayjs(latest.timestamp / 1000)
+//     let truncFunc = truncateToMinute
+//     let getDiff = getDiffMinute
+//     let diffMultiplier = diffMultiplierMinute
+//     if (Math.abs(oldestDayjs.diff(latestDayjs, 'day', true)) > 0.25) {
+//       truncFunc = truncateToHour
+//       getDiff = getDiffHour
+//       diffMultiplier = diffMultiplierHour
+//     }
 
-    const countMap = data
-      .map((d) => {
-        //   truncate to per-minute
-        return { ...d, timestamp: truncateToMinute(d.timestamp) }
-      })
-      .reduce((acc, d) => {
-        if (acc[d.timestamp]) {
-          acc[d.timestamp] = acc[d.timestamp] + 1
-        } else {
-          acc[d.timestamp] = 1
-        }
-        return acc
-      }, {} as TimestampMap)
+//     const countMap = data
+//       .map((d) => {
+//         //   truncate to per-minute
+//         return { ...d, timestamp: truncateToMinute(d.timestamp) }
+//       })
+//       .reduce((acc, d) => {
+//         if (acc[d.timestamp]) {
+//           acc[d.timestamp] = acc[d.timestamp] + 1
+//         } else {
+//           acc[d.timestamp] = 1
+//         }
+//         return acc
+//       }, {} as TimestampMap)
 
-    // Add in additional data points for empty minutes
-    const oldestEvent = data[data.length - 1]
-    if (!oldestEvent) return []
-    const currentTimestamp = new Date().getTime()
-    const oldestTimestampMicro = oldestEvent.timestamp
-    const latestTimestamp = truncFunc(data[0]['timestamp'])
-    const diff = getDiff(currentTimestamp, oldestTimestampMicro / 1000)
-    for (const toAdd of Array.from(Array(diff).keys())) {
-      const tsToCheck = truncFunc(oldestTimestampMicro) + diffMultiplier(toAdd)
-      if (!(tsToCheck in countMap) && tsToCheck <= latestTimestamp) {
-        countMap[tsToCheck] = 0
-      }
-    }
+//     // Add in additional data points for empty minutes
+//     const oldestEvent = data[data.length - 1]
+//     if (!oldestEvent) return []
+//     const currentTimestamp = new Date().getTime()
+//     const oldestTimestampMicro = oldestEvent.timestamp
+//     const latestTimestamp = truncFunc(data[0]['timestamp'])
+//     const diff = getDiff(currentTimestamp, oldestTimestampMicro / 1000)
+//     for (const toAdd of Array.from(Array(diff).keys())) {
+//       const tsToCheck = truncFunc(oldestTimestampMicro) + diffMultiplier(toAdd)
+//       if (!(tsToCheck in countMap) && tsToCheck <= latestTimestamp) {
+//         countMap[tsToCheck] = 0
+//       }
+//     }
 
-    let aggregated = []
-    for (const [key, value] of Object.entries(countMap)) {
-      const v: number = Number(key)
-      aggregated.push({
-        timestamp: key,
-        timestampMicro: v * 1000 * 1000,
-        count: value,
-      })
-    }
-    return aggregated.sort((a, b) => a.timestampMicro - b.timestampMicro)
-  }, [JSON.stringify(data)])
-}
+//     let aggregated = []
+//     for (const [key, value] of Object.entries(countMap)) {
+//       const v: number = Number(key)
+//       aggregated.push({
+//         timestamp: key,
+//         timestampMicro: v * 1000 * 1000,
+//         count: value,
+//       })
+//     }
+//     return aggregated.sort((a, b) => a.timestampMicro - b.timestampMicro)
+//   }, [JSON.stringify(data)])
+// }
 export default LogEventChart

--- a/studio/components/interfaces/Settings/Logs/Logs.DatePickers.tsx
+++ b/studio/components/interfaces/Settings/Logs/Logs.DatePickers.tsx
@@ -24,8 +24,6 @@ const DatePickers: React.FC<Props> = ({ to, from, onChange, helpers }) => {
   const selectedHelper = helpers.find((helper) => {
     if (to === helper.calcTo() && from === helper.calcFrom()) {
       return true
-    } else if (helper.text === helperValue) {
-      return true
     } else {
       return false
     }
@@ -33,8 +31,10 @@ const DatePickers: React.FC<Props> = ({ to, from, onChange, helpers }) => {
   useEffect(() => {
     if (selectedHelper && helperValue !== selectedHelper.text) {
       setHelperValue(selectedHelper.text)
+    } else if (!selectedHelper) {
+      setHelperValue('')
     }
-  }, [selectedHelper])
+  }, [selectedHelper, to, from])
 
   return (
     <div className="flex items-center">

--- a/studio/components/interfaces/Settings/Logs/Logs.DatePickers.tsx
+++ b/studio/components/interfaces/Settings/Logs/Logs.DatePickers.tsx
@@ -31,7 +31,7 @@ const DatePickers: React.FC<Props> = ({ to, from, onChange, helpers }) => {
   useEffect(() => {
     if (selectedHelper && helperValue !== selectedHelper.text) {
       setHelperValue(selectedHelper.text)
-    } else if (!selectedHelper) {
+    } else if (!selectedHelper && (to || from)) {
       setHelperValue('')
     }
   }, [selectedHelper, to, from])
@@ -66,6 +66,7 @@ const DatePickers: React.FC<Props> = ({ to, from, onChange, helpers }) => {
       <DatePicker
         triggerButtonClassName="rounded-l-none"
         triggerButtonType={selectedHelper ? 'default' : 'secondary'}
+        triggerButtonTitle="Custom"
         onChange={(value) => {
           setHelperValue('')
           if (onChange) onChange(value)

--- a/studio/components/interfaces/Settings/Logs/Logs.constants.ts
+++ b/studio/components/interfaces/Settings/Logs/Logs.constants.ts
@@ -254,7 +254,7 @@ export const LOGS_TABLES = {
   functions: LogsTableName.FUNCTIONS,
   fn_edge: LogsTableName.FN_EDGE,
   auth: LogsTableName.AUTH,
-  realtime: LogsTableName.REALTIME
+  realtime: LogsTableName.REALTIME,
 }
 
 export const LOGS_SOURCE_DESCRIPTION = {
@@ -265,8 +265,6 @@ export const LOGS_SOURCE_DESCRIPTION = {
   [LogsTableName.AUTH]: 'Authentication logs from GoTrue',
   [LogsTableName.REALTIME]: 'Realtime server for Postgres logical replication broadcasting',
 }
-
-export const genCountQuery = (table: string): string => `SELECT count(*) as count FROM ${table}`
 
 export const genQueryParams = (params: { [k: string]: string }) => {
   // remove keys which are empty strings, null, or undefined

--- a/studio/components/interfaces/Settings/Logs/Logs.types.ts
+++ b/studio/components/interfaces/Settings/Logs/Logs.types.ts
@@ -7,9 +7,13 @@ interface Metadata {
 export type DatePickerToFrom = { to: string | null; from: string | null }
 
 export type LogSearchCallback = (
+  event:
+    | 'search-input-change'
+    | 'event-chart-bar-click'
+    | 'datepicker-change',
   filters: {
-    query: string
-  } & DatePickerToFrom
+    query?: string
+  } & Partial<DatePickerToFrom>
 ) => void
 
 export interface LogsWarning {
@@ -48,6 +52,11 @@ export interface CountData {
   count: number
 }
 
+export interface EventChartData {
+  count: number
+  timestamp: string | number
+}
+
 type LFResponse<T> = {
   result: T[]
   error?: {
@@ -63,9 +72,10 @@ type LFResponse<T> = {
 }
 type ApiError = string
 
-export type LogQueryError = Omit<LFResponse<unknown>, "result"> | ApiError
+export type LogQueryError = Omit<LFResponse<unknown>, 'result'> | ApiError
 
 export type Count = LFResponse<CountData>
+export type EventChart = LFResponse<EventChartData>
 
 export type Logs = LFResponse<LogData>
 

--- a/studio/components/interfaces/Settings/Logs/LogsPreviewer.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogsPreviewer.tsx
@@ -11,7 +11,7 @@ import {
   QueryType,
   LogEventChart,
   Filters,
-  unixMicroToIsoTimestamp,
+  ensureNoTimestampConflict,
 } from 'components/interfaces/Settings/Logs'
 import useLogsPreview from 'hooks/analytics/useLogsPreview'
 import PreviewFilterPanel from 'components/interfaces/Settings/Logs/PreviewFilterPanel'
@@ -52,7 +52,7 @@ export const LogsPreviewer: React.FC<Props> = ({
   const table = !tableName ? LOGS_TABLES[queryType] : tableName
 
   const [
-    { error, logData, params, newCount, filters, isLoading },
+    { error, logData, params, newCount, filters, isLoading, eventChartData },
     { loadOlder, setFilters, refresh, setParams },
   ] = useLogsPreview(projectRef as string, table, filterOverride)
 
@@ -83,24 +83,48 @@ export const LogsPreviewer: React.FC<Props> = ({
       },
     })
   }
-
-  const handleSearch: LogSearchCallback = async ({ query = '', to, from }) => {
-    setParams((prev) => ({
-      ...prev,
-      iso_timestamp_start: from || prev.iso_timestamp_start || '',
-      iso_timestamp_end: to || prev.iso_timestamp_end || '',
-    }))
-    setFilters((prev) => ({ ...prev, search_query: query }))
-    router.push({
-      pathname: router.pathname,
-      query: {
-        ...router.query,
-        s: query || '',
-        its: from || its || '',
-        ite: to || ite || '',
-      },
-    })
+  const handleSearch: LogSearchCallback = async (event, { query, to, from }) => {
+    if (event === 'search-input-change') {
+      setFilters((prev) => ({ ...prev, search_query: query }))
+      router.push({
+        pathname: router.pathname,
+        query: { ...router.query, s: query },
+      })
+    } else if (event === 'event-chart-bar-click') {
+      const [nextStart, nextEnd] = ensureNoTimestampConflict(
+        [params.iso_timestamp_start || '', params.iso_timestamp_end || ''],
+        [from || '', to || '']
+      )
+      setParams((prev) => ({
+        ...prev,
+        iso_timestamp_start: nextStart,
+        iso_timestamp_end: nextEnd,
+      }))
+      router.push({
+        pathname: router.pathname,
+        query: {
+          ...router.query,
+          its: nextStart,
+          ite: nextEnd,
+        },
+      })
+    } else if (event === 'datepicker-change') {
+      setParams((prev) => ({
+        ...prev,
+        iso_timestamp_start: from || '',
+        iso_timestamp_end: to || '',
+      }))
+      router.push({
+        pathname: router.pathname,
+        query: {
+          ...router.query,
+          its: from || '',
+          ite: to || '',
+        },
+      })
+    }
   }
+
   return (
     <div className="h-full flex flex-col flex-grow">
       <PreviewFilterPanel
@@ -143,10 +167,13 @@ export const LogsPreviewer: React.FC<Props> = ({
         <div className={condensedLayout ? 'px-4' : ''}>
           {showChart && (
             <LogEventChart
-              data={!isLoading ? logData : undefined}
-              onBarClick={(timestampMicro) => {
-                const to = unixMicroToIsoTimestamp(timestampMicro)
-                handleSearch({ query: filters.search_query as string, to, from: null })
+              data={!isLoading && eventChartData ? eventChartData : undefined}
+              onBarClick={(isoTimestamp) => {
+                handleSearch('event-chart-bar-click', {
+                  query: filters.search_query as string,
+                  to: isoTimestamp as string,
+                  from: null,
+                })
               }}
             />
           )}

--- a/studio/components/interfaces/Settings/Logs/PreviewFilterPanel.tsx
+++ b/studio/components/interfaces/Settings/Logs/PreviewFilterPanel.tsx
@@ -97,8 +97,10 @@ const PreviewFilterPanel: FC<Props> = ({
       Refresh
     </Button>
   )
-  const handleSearch = (partial: Partial<Parameters<LogSearchCallback>[0]>) =>
-    onSearch({ query: search, to: partial?.to || null, from: partial?.from || null })
+  const handleDatepickerChange = ({ to, from }: Partial<Parameters<LogSearchCallback>[1]>) => {
+    onSearch('datepicker-change', { to, from })
+  }
+  const handleInputSearch = (query: string) => onSearch('search-input-change', { query })
 
   return (
     <div
@@ -110,7 +112,7 @@ const PreviewFilterPanel: FC<Props> = ({
           onSubmit={(e) => {
             // prevent redirection
             e.preventDefault()
-            handleSearch({})
+            handleInputSearch(search)
           }}
         >
           <Input
@@ -120,7 +122,7 @@ const PreviewFilterPanel: FC<Props> = ({
             onChange={(e) => setSearch(e.target.value)}
             onBlur={(e: React.FocusEvent<HTMLInputElement>) => {
               setSearch(e.target.value)
-              handleSearch({ query: e.target.value })
+              handleInputSearch(e.target.value)
             }}
             icon={
               <div className="text-scale-900">
@@ -131,7 +133,7 @@ const PreviewFilterPanel: FC<Props> = ({
             actions={
               hasEdits && (
                 <button
-                  onClick={() => handleSearch({})}
+                  onClick={() => handleInputSearch(search)}
                   className="text-scale-1100 hover:text-scale-1200 mx-2"
                 >
                   {'↲'}
@@ -142,7 +144,7 @@ const PreviewFilterPanel: FC<Props> = ({
         </form>
 
         <DatePickers
-          onChange={handleSearch}
+          onChange={handleDatepickerChange}
           to={defaultToValue}
           from={defaultFromValue}
           helpers={PREVIEWER_DATEPICKER_HELPERS}

--- a/studio/components/ui/DatePicker/DatePicker.tsx
+++ b/studio/components/ui/DatePicker/DatePicker.tsx
@@ -21,6 +21,7 @@ export interface DatePickerProps {
   from?: string
   triggerButtonType?: ButtonProps['type']
   triggerButtonClassName?: string
+  triggerButtonTitle?: string
   renderFooter?: (args: DatePickerToFrom) => React.ReactNode | void
 }
 
@@ -36,6 +37,7 @@ function _DatePicker({
   onChange,
   triggerButtonType = 'default',
   triggerButtonClassName = '',
+  triggerButtonTitle,
   renderFooter = () => null,
 }: DatePickerProps) {
   const [open, setOpen] = useState<boolean>(false)
@@ -220,6 +222,7 @@ function _DatePicker({
       }
     >
       <Button
+        title={triggerButtonTitle}
         type={triggerButtonType}
         as="span"
         icon={<IconCalendar />}

--- a/studio/tests/pages/projects/Logs.utils.test.js
+++ b/studio/tests/pages/projects/Logs.utils.test.js
@@ -1,8 +1,11 @@
 import {
+  ensureNoTimestampConflict,
+  genChartQuery,
   genDefaultQuery,
   LogsTableName,
   SQL_FILTER_TEMPLATES,
 } from 'components/interfaces/Settings/Logs'
+import dayjs from 'dayjs'
 
 describe.each(Object.values(LogsTableName))('%s', (table) => {
   const templates = SQL_FILTER_TEMPLATES[table]
@@ -60,5 +63,38 @@ describe.each(Object.values(LogsTableName))('%s', (table) => {
       contains.forEach((str) => expect(generated).toContain(str))
       excludes.forEach((str) => expect(generated).not.toContain(str))
     })
+    test('generated chart query should include filters', () => {
+      const generated = genChartQuery(table, {}, { 'override.nested': 'something' })
+      expect(generated).toContain('override.nested')
+      expect(generated).toContain('something')
+      expect(generated).toContain('timestamp_trunc')
+    })
   })
+})
+
+const base = dayjs().subtract(2, 'day')
+const baseIso = base.toISOString()
+test.each([
+  {
+    case: 'next start is after initial start',
+    initial: [base.subtract(1, 'day').toISOString(), baseIso],
+    next: [base.subtract(2, 'day').toISOString(), null],
+    expected: [base.subtract(2, 'day').toISOString(), baseIso],
+  },
+  {
+    case: 'next end is before initial start',
+    initial: [base.subtract(1, 'day').toISOString(), baseIso],
+    next: [null, base.subtract(2, 'day').toISOString()],
+    expected: [base.subtract(3, 'day').toISOString(), base.subtract(2, 'day').toISOString()],
+  },
+  {
+    case: 'next end is not before initial start',
+    initial: [base.subtract(2, 'day').toISOString(), baseIso],
+    next: [null, base.subtract(1, 'day').toISOString()],
+    expected: [base.subtract(2, 'day').toISOString(), base.subtract(1, 'day').toISOString()],
+  },
+])('ensure no timestamp conflict: $case', ({ initial, next, expected }) => {
+  const result = ensureNoTimestampConflict(initial, next)
+  expect(result[0]).toEqual(expected[0])
+  expect(result[1]).toEqual(expected[1])
 })

--- a/studio/tests/pages/projects/LogsPreviewer.test.js
+++ b/studio/tests/pages/projects/LogsPreviewer.test.js
@@ -193,6 +193,21 @@ test('poll count for new messages', async () => {
   await waitFor(() => screen.queryByText(/125/) === null)
   await screen.findByText(/some-uuid123/)
 })
+test('log event chart', async () => {
+  get.mockImplementation((url) => {
+    // truncate
+    if (url.includes('trunc')) {
+      return { result: [{ timestamp: new Date().toISOString(), count: 125 }] }
+    }
+    return {
+      result: [logDataFixture({ id: 'some-uuid123' })],
+    }
+  })
+  render(<LogsPreviewer projectRef="123" tableName={LogsTableName.EDGE} />)
+
+  await waitFor(() => screen.queryByText(/some-uuid123/) === null)
+  expect(get).toBeCalledWith(expect.stringContaining('trunc'))
+})
 
 test('s= query param will populate the search bar', async () => {
   const router = defaultRouterMock()
@@ -289,6 +304,9 @@ test('bug: load older btn does not error out when previous page is empty', async
 })
 
 test('log event chart hide', async () => {
+  get.mockImplementation((url) => {
+    return { result: [] }
+  })
   render(<LogsPreviewer projectRef="123" tableName={LogsTableName.EDGE} />)
   await screen.findByText('Events')
   const toggle = await screen.findByText(/Chart/)

--- a/studio/tests/pages/projects/LogsPreviewer.test.js
+++ b/studio/tests/pages/projects/LogsPreviewer.test.js
@@ -234,7 +234,7 @@ test('te= query param will populate the timestamp to input', async () => {
       expect.stringContaining(`iso_timestamp_end=${encodeURIComponent(iso)}`)
     )
   })
-  userEvent.click(await screen.findByText('Custom'))
+  userEvent.click(await screen.findByTitle('Custom'))
 })
 test('ts= query param will populate the timestamp from input', async () => {
   // get time 20 mins before
@@ -251,7 +251,7 @@ test('ts= query param will populate the timestamp from input', async () => {
       expect.stringContaining(`iso_timestamp_start=${encodeURIComponent(iso)}`)
     )
   })
-  userEvent.click(await screen.findByText('Custom'))
+  userEvent.click(await screen.findByTitle('Custom'))
   await screen.findByText(new RegExp(newDate.getFullYear()))
 })
 

--- a/studio/tests/pages/projects/PreviewFilterPanel.test.js
+++ b/studio/tests/pages/projects/PreviewFilterPanel.test.js
@@ -49,11 +49,11 @@ test('Manual refresh', async () => {
   expect(mockFn).toBeCalled()
 })
 test('Datepicker dropdown', async () => {
-  render(<PreviewFilterPanel />)
+  const fn = jest.fn()
+  render(<PreviewFilterPanel onSearch={fn} />)
   clickDropdown(await screen.findByText(/Last hour/))
   userEvent.click(await screen.findByText(/Last 3 hours/))
-  await screen.findByText(/Last 3 hours/)
-  await expect(screen.findByText(/Last hour/)).rejects.toThrow()
+  expect(fn).toBeCalled()
 })
 
 test.todo('timestamp to/from filter default value')


### PR DESCRIPTION
This PR improves the log event chart, decoupling it from the actual query data. It fetches event counts beyond the current selected datetime range, allowing users to determine if there are interesting trends beyond their selected time frame.

The selection of the timestamp truncation is dynamic, switching between hourly, daily, and minutely, and is based on the selected datetime range.

https://user-images.githubusercontent.com/22714384/185618745-76d3dd3a-a275-434f-b9d8-a83b81fe4a38.mov



This PR also cleans up a lot of code and allows ISO timestamp interop, for the transition to purely iso timestamp handling by the logflare endpoint.

