### PR TITLE
Update domain regex to accept chrome extension urls

### DIFF
--- a/studio/components/interfaces/Auth/Auth.constants.ts
+++ b/studio/components/interfaces/Auth/Auth.constants.ts
@@ -5,10 +5,11 @@
 //  "www.vercel.com"
 //  "uptime-monitor-fe.vercel.app"
 //  "https://uptime-monitor-fe.vercel.app/"
+//  "chrome-extension://<extension-id>"
 
 // Supports wildcards, port numbers at the end, paths at the end and query params
 const baseDomainRegex =
-  /^((ftp|http|https):\/\/)?(www.)?(?!.*(ftp|http|https|www.))[a-zA-Z0-9_*-]+(\.[a-zA-Z0-9_*-]+)+((\/)[\w#]+)*(\/\w+\?[a-zA-Z0-9_]+=\w+(&[a-zA-Z0-9_]+=\w+)*)+(?:\.[a-z]+)*(?::\d+)?(?![^<]*(?:<\/\w+>|\/?>))(.*)?\/?(.)*?$/gm
+  /^((ftp|http|https|chrome-extension):\/\/)?(www.)?(?!.*(ftp|http|https|www.))[a-zA-Z0-9_*-]+(\.[a-zA-Z0-9_*-]+)+((\/)[\w#]+)*(\/\w+\?[a-zA-Z0-9_]+=\w+(&[a-zA-Z0-9_]+=\w+)*)+(?:\.[a-z]+)*(?::\d+)?(?![^<]*(?:<\/\w+>|\/?>))(.*)?\/?(.)*?$/gm
 
 // iOS deep linking scheme https://benoitpasquier.com/deep-linking-url-scheme-ios/
 const appRegex =


### PR DESCRIPTION
Issue #8338

## What kind of change does this PR introduce?

Bug fix - input validation for redirect domain urls in Authentication settings

## What is the current behavior?
Chrome extension urls are not allowed when entered in dashboard, but gets accepted using curl

Please link any relevant issues here.
#8338 

## What is the new behavior?
Chrome extension urls may be added through Authentication settings in dashboard 
Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
