### PR TITLE
Update with-nextjs.mdx

### DIFF
--- a/apps/reference/docs/guides/with-nextjs.mdx
+++ b/apps/reference/docs/guides/with-nextjs.mdx
@@ -214,7 +214,9 @@ export default function Auth() {
   const handleLogin = async (email) => {
     try {
       setLoading(true)
-      const { error } = await supabase.auth.signInWithOtp({ email })
+      const { user, error } = await supabase.auth.signIn({
+        email: email,
+      })
       if (error) throw error
       alert('Check your email for the login link!')
     } catch (error) {
@@ -279,14 +281,7 @@ export default function Account({ session }) {
   }, [session])
 
   async function getCurrentUser() {
-    const {
-      data: { session },
-      error,
-    } = await supabase.auth.getSession()
-
-    if (error) {
-      throw error
-    }
+    const session = supabase.auth.session()
 
     if (!session?.user) {
       throw new Error('User not logged in')
@@ -413,9 +408,7 @@ export default function Home() {
     let mounted = true
 
     async function getInitialSession() {
-      const {
-        data: { session },
-      } = await supabase.auth.getSession()
+      const data = supabase.auth.session()
 
       // only update the react state if the component is still mounted
       if (mounted) {


### PR DESCRIPTION
Updating to use new references

const { error } = await supabase.auth.signInWithOtp({ email })  ->   const { user, error } = await supabase.auth.signIn({ email: email,})
const {data: { session }, error,} = await supabase.auth.getSession()   ->   const session = supabase.auth.session()
const {data: { session },} = await supabase.auth.getSession()   ->    const session = supabase.auth.session()

## What kind of change does this PR introduce?

When I tried to copy the *[Quickstart: Next.js](https://supabase.com/docs/guides/with-nextjs)* guide in the docs I was not able to get it working, then looking through the updated Auth docs I found they didn't exist anymore.

## What is the current behavior?

Currently NextJS will error and say `supabase.auth.getSession()` does not exist

## What is the new behavior?

Now following the docs it will hopefully work.

## Additional context

This is my first pull request, so I apologize if I have done anything incorrectly 
