### PR TITLE
Fix package name for ui component

### DIFF
--- a/apps/reference/docs/guides/auth/auth-helpers/auth-ui-overview.mdx
+++ b/apps/reference/docs/guides/auth/auth-helpers/auth-ui-overview.mdx
@@ -14,7 +14,7 @@ Auth UI relies on [@supabase/supabase-js](/docs/reference/javascript/next/). You
 
 ### Install via NPM
 
-Install the NPM package from @supabase/react-ui-react
+Install the NPM package from @supabase/ui
 
 ```bash
 npm install @supabase/react-ui-react @supabase/supabase-js@rc


### PR DESCRIPTION
The package `@supabase/react-ui-react` does not exist on the NPM registry.

## What kind of change does this PR introduce?

Docs update.
