### PR TITLE
Update the installation instruction in the guide.

### DIFF
--- a/apps/reference/docs/guides/with-nextjs.mdx
+++ b/apps/reference/docs/guides/with-nextjs.mdx
@@ -171,7 +171,7 @@ cd supabase-nextjs
 Then let's install the only additional dependency: [supabase-js](https://github.com/supabase/supabase-js)
 
 ```bash
-npm install @supabase/supabase-js
+npm install @supabase/supabase-js@rc
 ```
 
 And finally we want to save the environment variables in a `.env.local`.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Documentation update

## What is the current behavior?

Installation instructions are incorrectly showing the v1 of the supabase-js library.

## What is the new behavior?

Installation instructions are now showing the v2 of the supabase-js library.

## Additional context

