### PR TITLE
Chore/move storage item toggles

### DIFF
--- a/studio/components/to-be-cleaned/Storage/StorageExplorer/FileExplorerHeaderSelection.js
+++ b/studio/components/to-be-cleaned/Storage/StorageExplorer/FileExplorerHeaderSelection.js
@@ -8,9 +8,10 @@ const FileExplorerHeaderSelection = ({
   onUnselectAllItems = () => {},
 }) => {
   return (
-    <div className="px-1 py-1 rounded-t-md bg-green-600 flex items-center shadow z-10 h-[40px]">
+    <div className="px-1 py-1 rounded-t-md bg-green-700 flex items-center shadow z-10 h-[40px]">
       <Button
-        icon={<IconX size={16} strokeWidth={2} />}
+        className="hover:bg-green-600"
+        icon={<IconX size={16} strokeWidth={2} className="text-white" />}
         type="text"
         shadow={false}
         onClick={onUnselectAllItems}

--- a/studio/components/to-be-cleaned/Storage/StorageExplorer/FileExplorerRow.js
+++ b/studio/components/to-be-cleaned/Storage/StorageExplorer/FileExplorerRow.js
@@ -218,35 +218,27 @@ const FileExplorerRow = ({
       `}
       >
         <div className="w-full flex flex-grow items-center">
-          {/* Row Checkbox / Row Icon */}
+          <Checkbox
+            label={''}
+            className={`w-full ${item.type !== STORAGE_ROW_TYPES.FILE ? 'invisible' : ''} ${
+              isSelected ? 'opacity-100' : 'opacity-70 group-hover:opacity-100'
+            }`}
+            checked={isSelected}
+            onChange={() => onCheckItem(itemWithColumnIndex)}
+          />
           <div
-            className="relative group"
+            className="relative group flex items-center"
             style={{ minWidth: view === STORAGE_VIEWS.COLUMNS ? '10%' : 'auto' }}
             onClick={(event) => event.stopPropagation()}
           >
-            {!isSelected && (
-              <div
-                className={`absolute ${
-                  item.type === STORAGE_ROW_TYPES.FILE ? 'group-hover:hidden' : ''
-                }`}
-                style={{ top: '2px' }}
-              >
-                <RowIcon
-                  view={view}
-                  status={item.status}
-                  fileType={item.type}
-                  mimeType={item.metadata?.mimetype}
-                />
-              </div>
-            )}
-            <Checkbox
-              label={''}
-              className={`w-full ${item.type !== STORAGE_ROW_TYPES.FILE ? 'invisible' : ''} ${
-                isSelected ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
-              }`}
-              checked={isSelected}
-              onChange={() => onCheckItem(itemWithColumnIndex)}
-            />
+            <div>
+              <RowIcon
+                view={view}
+                status={item.status}
+                fileType={item.type}
+                mimeType={item.metadata?.mimetype}
+              />
+            </div>
           </div>
 
           {/* Row Text */}


### PR DESCRIPTION
Makes Storage items selectable without hovering on the icon. 

**Currently:** 
<img width="235" alt="CleanShot 2022-08-22 at 10 11 53@2x" src="https://user-images.githubusercontent.com/105593/185923662-cc74d412-ecd5-44a3-a53d-07f8be37b4ff.png">


**Proposed:**
<img width="223" alt="CleanShot 2022-08-22 at 10 12 30@2x" src="https://user-images.githubusercontent.com/105593/185923726-610eb5a5-e23e-4ce9-ba76-0e0ae5e314dd.png">
