### PR TITLE
chore/removed signInWithPasswordless mention from the blogpost

### DIFF
--- a/apps/www/_blog/2022-08-16-supabase-js-v2.mdx
+++ b/apps/www/_blog/2022-08-16-supabase-js-v2.mdx
@@ -63,7 +63,7 @@ supabase.from<Database['Message']>('messages').select('*')
 ### New Auth methods
 
 We're removing the `signIn()` method in favor of more explicit method signatures:
-`signInWithPassword()`, `signInWithPasswordless()`, and `signInWithOtp()`.
+`signInWithPassword()`, and `signInWithOtp()`.
 
 ```ts
 // v2


### PR DESCRIPTION
There is no signInWithPasswordless() method. Context:

https://github.com/supabase/gotrue-js/pull/304

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
