### PR TITLE
Specify the place of "Credentials"

### DIFF
--- a/apps/reference/docs/guides/auth/auth-google.mdx
+++ b/apps/reference/docs/guides/auth/auth-google.mdx
@@ -70,7 +70,7 @@ The next step requires a callback URL, which looks like this:
   />
 </video>
 
-### Create your credentials
+### Create your Google credentials
 
 - Click `Credentials` at the left to go to the `Credentials` page on the Google Cloud Platform console.
 - Click `Create Credentials` near the top then select `OAuth client ID`

--- a/apps/reference/docs/guides/auth/auth-google.mdx
+++ b/apps/reference/docs/guides/auth/auth-google.mdx
@@ -72,7 +72,7 @@ The next step requires a callback URL, which looks like this:
 
 ### Create your credentials
 
-- Click `Credentials` at the left to go to the `Credentials` page
+- Click `Credentials` at the left to go to the `Credentials` page on the Google Cloud Platform console.
 - Click `Create Credentials` near the top then select `OAuth client ID`
 - On the `Create OAuth client ID` page, select your application type. If you're not sure, choose `Web application`.
 - Fill in your app name.


### PR DESCRIPTION
I could not tell that the description "Click `Credentials` at the left to go to the `Credentials` page" was indicating on Google Cloud Platform.

I added "on the Google Cloud Platform console"

## What kind of change does this PR introduce?

Document update.

## What is the current behavior?

"Click `Credentials` at the left to go to the `Credentials` page" was confusing.

## What is the new behavior?

I can tell that `Credentials` is on the GCP Console.


