### PR TITLE
Add notice to guides that are using supabase-js v2

### DIFF
--- a/apps/reference/docs/guides/with-nextjs.mdx
+++ b/apps/reference/docs/guides/with-nextjs.mdx
@@ -8,6 +8,12 @@ sidebar_label: 'Next.js'
 import Tabs from '@theme/Tabs'
 import TabItem from '@theme/TabItem'
 
+:::note
+
+This guide uses supabase-js v2.0.0 Release Candidate (RC).
+
+:::
+
 ## Intro
 
 This example provides the steps to build a simple user management app (from scratch!) using Supabase and Next.js. It includes:

--- a/apps/reference/docs/guides/with-nuxt-3.mdx
+++ b/apps/reference/docs/guides/with-nuxt-3.mdx
@@ -8,12 +8,6 @@ sidebar_label: Nuxt 3
 import Tabs from '@theme/Tabs'
 import TabItem from '@theme/TabItem'
 
-:::caution
-
-This example uses Nuxt Supabase v0, that depends on outdated supabase-js v1. It will be updated when updated Nuxt Supabase is released.
-
-:::
-
 ## Intro
 
 This example provides the steps to build a simple user management app (from scratch!) using Supabase and Nuxt 3. It includes:

--- a/apps/reference/docs/guides/with-react.mdx
+++ b/apps/reference/docs/guides/with-react.mdx
@@ -8,6 +8,12 @@ sidebar_label: React
 import Tabs from '@theme/Tabs'
 import TabItem from '@theme/TabItem'
 
+:::note
+
+This guide uses supabase-js v2.0.0 Release Candidate (RC).
+
+:::
+
 ## Intro
 
 This example provides the steps to build a simple user management app (from scratch!) using Supabase and React. It includes:

--- a/apps/reference/docs/guides/with-solidjs.mdx
+++ b/apps/reference/docs/guides/with-solidjs.mdx
@@ -8,6 +8,12 @@ sidebar_label: SolidJS
 import Tabs from '@theme/Tabs'
 import TabItem from '@theme/TabItem'
 
+:::note
+
+This guide uses supabase-js v2.0.0 Release Candidate (RC).
+
+:::
+
 ## Intro
 
 This example provides the steps to build a simple user management app (from scratch!) using Supabase and Solid JS. It includes:

--- a/apps/reference/docs/guides/with-svelte.mdx
+++ b/apps/reference/docs/guides/with-svelte.mdx
@@ -8,6 +8,12 @@ sidebar_label: Svelte
 import Tabs from '@theme/Tabs'
 import TabItem from '@theme/TabItem'
 
+:::note
+
+This guide uses supabase-js v2.0.0 Release Candidate (RC).
+
+:::
+
 ## Intro
 
 This example provides the steps to build a simple user management app (from scratch!) using Supabase and Svelte. It includes:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

We aren't currently showing in the guides which ones currently use the latest v2 of the supabase-js library.

## What is the new behavior?

Add notice to show which guides are using supabase-js v2

## Additional context

<img width="898" alt="Screenshot 2022-08-25 at 16 36 13" src="https://user-images.githubusercontent.com/79497/186721976-42c0b824-0856-427c-a811-238569571a42.png">

