### PR TITLE
Chore: close hackathon

### DIFF
--- a/apps/www/components/LaunchWeek/HackathonSection.tsx
+++ b/apps/www/components/LaunchWeek/HackathonSection.tsx
@@ -11,7 +11,7 @@ export default function LaunchHero() {
           <div className="flex flex-col gap-3">
             <h3 className="text-scale-1200 text-4xl tracking-tight">Launch Week Hackathon</h3>
             <div>
-              <Badge>In progress</Badge>
+              <Badge color="red">Closed</Badge>
             </div>
             <h4 className="text-scale-1100 text-xl">
               Submissions close Sunday 21st Aug 23:59 (PT).
@@ -19,9 +19,9 @@ export default function LaunchHero() {
           </div>
 
           <div className="flex gap-3">
-            <Link href="https://www.madewithsupabase.com/launch-week-5">
+            <Link href="https://www.madewithsupabase.com/tag/Launch%20Week%205">
               <Button type="primary" size="small" className="text-white">
-                Submit your project
+                view projects
               </Button>
             </Link>
             <Link href="/blog/launch-week-5-hackathon">


### PR DESCRIPTION
## What kind of change does this PR introduce?

Close hackathon

## What is the current behavior?

Shows `In progress` and takes them to times up page

<img width="619" alt="CleanShot 2022-08-25 at 18 00 50@2x" src="https://user-images.githubusercontent.com/70828596/186776692-091e1d18-dea5-4675-ac88-ce09cbe119b5.png">

## What is the new behavior?

Shows `Closed` and takes them to submitted projects

<img width="619" alt="CleanShot 2022-08-25 at 18 00 50@2x" src="https://user-images.githubusercontent.com/70828596/186776954-0a9160fe-8879-4e5f-bbf0-69c369d9ed74.png">