### PR TITLE
fix: blog image showing instead of link

### DIFF
--- a/apps/www/_blog/2022-08-25-launch-week-5-hackathon-winners.mdx
+++ b/apps/www/_blog/2022-08-25-launch-week-5-hackathon-winners.mdx
@@ -141,9 +141,9 @@ To celebrate the massive success of the Hackathon, we are hosting a Twitter Spac
 
 And if you want to be part of the community and build with us, find other people using Supabase, or if you just want to chill and watch people build, come and join us in Discord!
 
-**[Join our Discord](https://discord.supabase.com/)**
+![Join Supabase Discord Channel](/images/blog/hackathon/community.png)
 
-[Join Supabase Discord Channel](/images/blog/hackathon/community.png)
+**[Join our Discord](https://discord.supabase.com/)**
 
 ### Get Started Guides
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Blog Fix

## What is the current behavior?

On the [Launch Week 5 Hackathon Winners](https://supabase.com/blog/launch-week-5-hackathon-winners) blog their is a link which directs the user to an image:


<img width="609" alt="Screenshot 2022-08-26 at 14 08 27" src="https://user-images.githubusercontent.com/22655069/186911016-1a7cd1ce-8052-452c-9443-34b5122612a6.png">


## What is the new behavior?

The image is now showing without having to click the link:

<img width="609" alt="Screenshot 2022-08-26 at 14 08 17" src="https://user-images.githubusercontent.com/22655069/186911079-b74d8ca5-2ee9-4116-b5e8-12502e178d45.png">
