### PR TITLE
Fix/papaparse wrong chunk size

### DIFF
--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/SpreadsheetImport/SpreadsheetImport.utils.ts
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/SpreadsheetImport/SpreadsheetImport.utils.ts
@@ -51,7 +51,7 @@ export const parseSpreadsheet = (
   return new Promise((resolve) => {
     Papa.parse(file, {
       header: true,
-      dynamicTyping: true,
+      dynamicTyping: false,
       skipEmptyLines: true,
       worker: true,
       quoteChar: file.type === 'text/tab-separated-values' ? '' : '"',
@@ -140,8 +140,14 @@ export const inferColumnType = (column: string, rows: object[]) => {
   }
 
   // Infer datetime type
-  if (dayjs(columnData, 'YYYY-MM-DD hh:mm:ss').isValid() && Date.parse(columnData)) {
-    return 'timestamptz'
+  if (Date.parse(columnData)) {
+    const isAllTimestamptz = columnDataAcrossRows.every((item) =>
+      dayjs(item, 'YYYY-MM-DD hh:mm:ss').isValid()
+    )
+
+    if (isAllTimestamptz) {
+      return 'timestamptz'
+    }
   }
 
   return 'text'

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/SpreadsheetImport/SpreadsheetImport.utils.ts
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/SpreadsheetImport/SpreadsheetImport.utils.ts
@@ -127,7 +127,7 @@ export const inferColumnType = (column: string, rows: object[]) => {
       else return includes(['true', 'false'], item.toString().toLowerCase())
     })
     if (isAllBoolean) {
-      return 'boolean'
+      return 'bool'
     }
   }
 

--- a/studio/stores/pgmeta/MetaStore.ts
+++ b/studio/stores/pgmeta/MetaStore.ts
@@ -42,7 +42,7 @@ import ExtensionsStore from './ExtensionsStore'
 import TypesStore from './TypesStore'
 
 const BATCH_SIZE = 1000
-const CHUNK_SIZE = 1024 * 1024 * 0.25 // 0.25MB
+const CHUNK_SIZE = 1024 * 1024 * 0.1 // 0.1MB
 
 export interface IMetaStore {
   excludedSchemas: string[]

--- a/studio/tests/components/Editor/SpreadsheetImport.utils.test.js
+++ b/studio/tests/components/Editor/SpreadsheetImport.utils.test.js
@@ -29,11 +29,11 @@ describe('SpreadsheedImport.utils: inferColumnType', () => {
   test('should infer boolean types correctly', () => {
     const mockData1 = [{ name: 'bob', height: '161.72', isWorking: 'true' }]
     const type1 = inferColumnType('isWorking', mockData1)
-    expect(type1).toBe('boolean')
+    expect(type1).toBe('bool')
 
     const mockData2 = [{ name: 'bob', height: '161.72', isRetired: 'false' }]
     const type2 = inferColumnType('isRetired', mockData2)
-    expect(type2).toBe('boolean')
+    expect(type2).toBe('bool')
   })
   test('should infer boolean type for a supposed boolean column if one of the rows has a null value', () => {
     const mockData3 = [
@@ -42,11 +42,25 @@ describe('SpreadsheedImport.utils: inferColumnType', () => {
       { name: 'bob', height: '161.72', isRetired: null },
     ]
     const type3 = inferColumnType('isRetired', mockData3)
-    expect(type3).toBe('boolean')
+    expect(type3).toBe('bool')
   })
   test('should infer objects as jsonb types correctly', () => {
     const mockData = [{ name: 'bob', metadata: '{}' }]
     const type = inferColumnType('metadata', mockData)
     expect(type).toBe('jsonb')
+  })
+  test.only('should infer date type correctly', () => {
+    const mockData4 = [
+      { event: 'christmas', date: '2022-12-25 17:45:23 UTC' },
+      { event: 'christmas', date: '2022-12-25' },
+      { event: 'christmas', date: '2022-12-25T12:03:40Z' },
+      { event: 'christmas', date: new Date() },
+      { event: 'christmas', date: new Date().toISOString() },
+      { event: 'christmas', date: 1410715640579 },
+      { event: 'christmas', date: '25 Dec 2022' },
+      { event: 'christmas', date: 'Dec 25 2022' },
+    ]
+    const type4 = inferColumnType('date', mockData4)
+    expect(type4).toBe('timestamptz')
   })
 })

--- a/studio/tests/components/Editor/SpreadsheetImport.utils.test.js
+++ b/studio/tests/components/Editor/SpreadsheetImport.utils.test.js
@@ -29,11 +29,11 @@ describe('SpreadsheedImport.utils: inferColumnType', () => {
   test('should infer boolean types correctly', () => {
     const mockData1 = [{ name: 'bob', height: '161.72', isWorking: 'true' }]
     const type1 = inferColumnType('isWorking', mockData1)
-    expect(type1).toBe('boolean')
+    expect(type1).toBe('bool')
 
     const mockData2 = [{ name: 'bob', height: '161.72', isRetired: 'false' }]
     const type2 = inferColumnType('isRetired', mockData2)
-    expect(type2).toBe('boolean')
+    expect(type2).toBe('bool')
   })
   test('should infer boolean type for a supposed boolean column if one of the rows has a null value', () => {
     const mockData3 = [
@@ -42,7 +42,7 @@ describe('SpreadsheedImport.utils: inferColumnType', () => {
       { name: 'bob', height: '161.72', isRetired: null },
     ]
     const type3 = inferColumnType('isRetired', mockData3)
-    expect(type3).toBe('boolean')
+    expect(type3).toBe('bool')
   })
   test('should infer objects as jsonb types correctly', () => {
     const mockData = [{ name: 'bob', metadata: '{}' }]


### PR DESCRIPTION
## What kind of change does this PR introduce?

It looks like Papa Parse isn't calculating the chunk size properly during csv imports. When I reduce the allowable chunk size from 0.25MB to 0.1MB, all is well. 

Did some testing to make sure reducing this doesn't impact speed too much — looks like not. Takes me just 1s longer to import a 2MB csv with the smaller chunk size. 

— 

PR also addresses a misnaming of bool / boolean. The type expected is `bool`, and causes this issue in the column type preview. https://github.com/supabase/supabase/blob/master/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnType.tsx#L63
 
<img width="510" alt="CleanShot 2022-08-26 at 14 51 10@2x" src="https://user-images.githubusercontent.com/105593/186958714-947902fb-a97d-44a8-8fc5-3f05b56eaab7.png">
