### PR TITLE
Fix Cypress vat code

### DIFF
--- a/studio/components/interfaces/Organization/BillingSettings/TaxID/TaxID.constants.ts
+++ b/studio/components/interfaces/Organization/BillingSettings/TaxID/TaxID.constants.ts
@@ -109,7 +109,7 @@ export const TAX_IDS: TaxId[] = [
   },
   {
     name: 'CY VAT',
-    code: 'cy_vat',
+    code: 'eu_vat',
     country: 'Cyprus',
     placeholder: 'CY12345678Z',
   },


### PR DESCRIPTION
Fixes Cyprus vat code, per:
https://stripe.com/docs/billing/customer/tax-ids#validation