### PR TITLE
feat: delete organisation error value

### DIFF
--- a/studio/components/interfaces/Organization/GeneralSettings/DeleteOrganizationButton.tsx
+++ b/studio/components/interfaces/Organization/GeneralSettings/DeleteOrganizationButton.tsx
@@ -27,7 +27,7 @@ const DeleteOrganizationButton = observer(() => {
       errors.orgName = 'Enter the name of the organization.'
     }
     if (values.orgName !== orgSlug) {
-      errors.orgName = 'Value entered does not match name of the organization.'
+      errors.orgName = 'Value entered does not match the value above.'
     }
     return errors
   }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Studio Feat

## What is the current behavior?

The current error value is `'Value entered does not match name of the organization.'`

## What is the new behavior?

The error now reads `'Value entered does not match the value above.'`

## Additional context

This is linked to and will close #8686

I was thinking about this and we could go extra by disabling the button if the value entered does not match the value generated, If people think this is a good option I can push a commit for it.
