### PR TITLE
rename next to 2.0 RC

### DIFF
--- a/apps/reference/docusaurus.config.js
+++ b/apps/reference/docusaurus.config.js
@@ -102,11 +102,14 @@ const config = {
         breadcrumbs: false,
         editUrl:
           'https://github.com/supabase/supabase/edit/master/apps/reference/',
-        lastVersion: 'current',
+        lastVersion: 'v1',
         versions: {
           current: {
             label: '2.0 RC',
-            path: 'next',
+            path: '/next',
+          },
+          v1: {
+            label: 'v1',
           },
         },
       },

--- a/apps/reference/docusaurus.config.js
+++ b/apps/reference/docusaurus.config.js
@@ -102,13 +102,13 @@ const config = {
         breadcrumbs: false,
         editUrl:
           'https://github.com/supabase/supabase/edit/master/apps/reference/',
-        // lastVersion: 'current',
-        // versions: {
-        //   current: {
-        //     label: 'v2',
-        //     // path: 'v2',
-        //   },
-        // },
+        lastVersion: 'current',
+        versions: {
+          current: {
+            label: '2.0 RC',
+            path: 'next',
+          },
+        },
       },
     ],
     [

--- a/apps/reference/docusaurus.config.js
+++ b/apps/reference/docusaurus.config.js
@@ -105,7 +105,7 @@ const config = {
         lastVersion: 'v1',
         versions: {
           current: {
-            label: '2.0 RC',
+            label: 'v2 RC',
             path: '/next',
           },
           v1: {

--- a/apps/reference/nav/_referenceSidebars.js
+++ b/apps/reference/nav/_referenceSidebars.js
@@ -249,7 +249,7 @@ const sidebars = {
         {
           type: 'link',
           label: 'Supabase JavaScript Library',
-          href: '/reference/javascript/next',
+          href: '/reference/javascript/',
         },
         {
           type: 'link',

--- a/apps/reference/nav/_referenceSidebars.js
+++ b/apps/reference/nav/_referenceSidebars.js
@@ -249,7 +249,7 @@ const sidebars = {
         {
           type: 'link',
           label: 'Supabase JavaScript Library',
-          href: '/reference/javascript',
+          href: '/reference/javascript/next',
         },
         {
           type: 'link',


### PR DESCRIPTION
URL remains as next, but label changed to 2.0 RC.

<img width="499" alt="CleanShot 2022-08-30@2x" src="https://user-images.githubusercontent.com/2155545/187353955-2e4643ab-b833-4c9f-8448-c922c7221396.png">