### PR TITLE
Show storage explorer row checkbox when row is hovered over, instead of just showing when hovering over icon

### DIFF
--- a/studio/components/to-be-cleaned/Storage/StorageExplorer/FileExplorerColumn.js
+++ b/studio/components/to-be-cleaned/Storage/StorageExplorer/FileExplorerColumn.js
@@ -121,6 +121,7 @@ const FileExplorerColumn = ({
   const SelectAllCheckbox = () => (
     <Checkbox
       label=""
+      className="-mt-0.5"
       checked={columnFiles.length !== 0 && selectedFilesFromColumn.length === columnFiles.length}
       disabled={columnFiles.length === 0}
       onChange={() => onSelectAllItemsInColumn(index)}
@@ -176,23 +177,14 @@ const FileExplorerColumn = ({
           border-b border-panel-border-light dark:border-panel-border-dark
         "
         >
-          <SelectAllCheckbox />
-          <p className="text-sm" style={{ width: '33%', minWidth: '250px' }}>
-            Name
-          </p>
-          <p className="text-sm" style={{ width: '12%', minWidth: '100px' }}>
-            Size
-          </p>
-          <p className="text-sm" style={{ width: '15%', minWidth: '100px' }}>
-            Type
-          </p>
-          <p className="text-sm" style={{ width: '20%', minWidth: '180px' }}>
-            Created at
-          </p>
-          <p className="text-sm" style={{ width: '20%', minWidth: '180px' }}>
-            Last modified at
-          </p>
-          <div className="w-3" />
+          <div className="flex items-center w-[40%] min-w-[250px]">
+            <SelectAllCheckbox />
+            <p className="text-sm">Name</p>
+          </div>
+          <p className="text-sm w-[11%] min-w-[100px]">Size</p>
+          <p className="text-sm w-[14%] min-w-[100px]">Type</p>
+          <p className="text-sm w-[15%] min-w-[160px]">Created at</p>
+          <p className="text-sm w-[15%] min-w-[160px]">Last modified at</p>
         </div>
       )}
 

--- a/studio/components/to-be-cleaned/Storage/StorageExplorer/FileExplorerColumn.js
+++ b/studio/components/to-be-cleaned/Storage/StorageExplorer/FileExplorerColumn.js
@@ -177,10 +177,10 @@ const FileExplorerColumn = ({
         "
         >
           <SelectAllCheckbox />
-          <p className="text-sm" style={{ width: '30%', minWidth: '250px' }}>
+          <p className="text-sm" style={{ width: '33%', minWidth: '250px' }}>
             Name
           </p>
-          <p className="text-sm" style={{ width: '15%', minWidth: '100px' }}>
+          <p className="text-sm" style={{ width: '12%', minWidth: '100px' }}>
             Size
           </p>
           <p className="text-sm" style={{ width: '15%', minWidth: '100px' }}>

--- a/studio/components/to-be-cleaned/Storage/StorageExplorer/FileExplorerHeader.js
+++ b/studio/components/to-be-cleaned/Storage/StorageExplorer/FileExplorerHeader.js
@@ -200,13 +200,13 @@ const FileExplorerHeader = ({
       className="
     bg-panel-header-light dark:bg-panel-header-dark
     border-panel-border-light dark:border-panel-border-dark
-    flex h-[40px] items-center justify-between rounded-t-md border-b px-3"
+    flex h-[40px] items-center justify-between rounded-t-md border-b px-2"
     >
       {/* Navigation */}
       <div className={`flex items-center ${isEditingPath ? 'w-1/2' : ''}`}>
         {breadcrumbs.length > 0 && (
           <Button
-            icon={<IconChevronLeft size={16} strokeWidth={1} />}
+            icon={<IconChevronLeft size={16} strokeWidth={2} />}
             size="tiny"
             type="text"
             className={breadcrumbs.length > 1 ? 'opacity-100' : 'opacity-25'}
@@ -377,8 +377,8 @@ const FileExplorerHeader = ({
                   actions={[
                     <IconX
                       key="close"
-                      className="mx-2 cursor-pointer text-white"
-                      size={'tiny'}
+                      className="mx-2 cursor-pointer text-scale-1200"
+                      size="tiny"
                       strokeWidth={2}
                       onClick={onCancelSearch}
                     />,

--- a/studio/components/to-be-cleaned/Storage/StorageExplorer/FileExplorerHeaderSelection.js
+++ b/studio/components/to-be-cleaned/Storage/StorageExplorer/FileExplorerHeaderSelection.js
@@ -8,7 +8,7 @@ const FileExplorerHeaderSelection = ({
   onUnselectAllItems = () => {},
 }) => {
   return (
-    <div className="px-1 py-1 rounded-t-md bg-green-600 flex items-center shadow z-10 h-[40px]">
+    <div className="px-2 py-1 rounded-t-md bg-brand-700 dark:bg-brand-600 flex items-center shadow z-10 h-[40px]">
       <Button
         icon={<IconX size={16} strokeWidth={2} />}
         type="text"
@@ -16,7 +16,7 @@ const FileExplorerHeaderSelection = ({
         onClick={onUnselectAllItems}
       />
       <div className="flex items-center space-x-3 ml-4">
-        <p className="text-sm text-white mb-0">
+        <p className="text-sm text-scale-1200 mb-0">
           <span style={{ fontVariantNumeric: 'tabular-nums' }}>{selectedItems.length}</span> items
           selected
         </p>

--- a/studio/components/to-be-cleaned/Storage/StorageExplorer/FileExplorerRow.js
+++ b/studio/components/to-be-cleaned/Storage/StorageExplorer/FileExplorerRow.js
@@ -220,11 +220,7 @@ const FileExplorerRow = ({
       >
         <div className="w-full flex flex-grow items-center">
           {/* Row Checkbox / Row Icon */}
-          <div
-            className="relative"
-            style={{ minWidth: view === STORAGE_VIEWS.COLUMNS ? '10%' : 'auto' }}
-            onClick={(event) => event.stopPropagation()}
-          >
+          <div className="relative w-[30px]" onClick={(event) => event.stopPropagation()}>
             {!isSelected && (
               <div
                 className={`absolute ${
@@ -252,7 +248,7 @@ const FileExplorerRow = ({
 
           {/* Row Text */}
           <div
-            className="flex items-center h-full py-2"
+            className="flex items-center h-full py-2 flex-grow"
             style={{ width: view === STORAGE_VIEWS.COLUMNS ? '80%' : '100%' }}
             onClick={(event) => {
               event.stopPropagation()
@@ -273,8 +269,8 @@ const FileExplorerRow = ({
               </div>
             ) : (
               <>
-                <p className="text-sm truncate w-[30%] min-w-[250px]">{item.name}</p>
-                <p className="text-sm truncate w-[15%] min-w-[100px]">{size}</p>
+                <p className="text-sm truncate w-[33%] min-w-[250px]">{item.name}</p>
+                <p className="text-sm truncate w-[12%] min-w-[100px]">{size}</p>
                 <p className="text-sm truncate w-[15%] min-w-[100px]">{mimeType}</p>
                 <p className="text-sm truncate w-[20%] min-w-[180px]">{createdAt}</p>
                 <p className="text-sm truncate w-[20%] min-w-[175px]">{updatedAt}</p>

--- a/studio/components/to-be-cleaned/Storage/StorageExplorer/FileExplorerRow.js
+++ b/studio/components/to-be-cleaned/Storage/StorageExplorer/FileExplorerRow.js
@@ -209,18 +209,19 @@ const FileExplorerRow = ({
       }}
     >
       <div
-        className={`
-        storage-row px-2.5 flex items-center justify-between hover:bg-panel-footer-light dark:hover:bg-panel-footer-dark
-        ${isOpened ? 'bg-scale-400' : ''} ${
-          isPreviewed ? 'bg-green-500 hover:bg-green-500 dark:hover:bg-green-500' : ''
-        } ${view === STORAGE_VIEWS.LIST ? 'min-w-min' : ''}
-        ${item.status !== STORAGE_ROW_STATUS.LOADING ? 'cursor-pointer' : ''}
-      `}
+        className={[
+          'storage-row px-2.5 flex items-center justify-between group',
+          'hover:bg-panel-footer-light dark:hover:bg-panel-footer-dark',
+          `${isOpened ? 'bg-scale-400' : ''}`,
+          `${isPreviewed ? 'bg-green-500 hover:bg-green-500 dark:hover:bg-green-500' : ''}`,
+          `${view === STORAGE_VIEWS.LIST ? 'min-w-min' : ''}`,
+          `${item.status !== STORAGE_ROW_STATUS.LOADING ? 'cursor-pointer' : ''}`,
+        ].join(' ')}
       >
         <div className="w-full flex flex-grow items-center">
           {/* Row Checkbox / Row Icon */}
           <div
-            className="relative group"
+            className="relative"
             style={{ minWidth: view === STORAGE_VIEWS.COLUMNS ? '10%' : 'auto' }}
             onClick={(event) => event.stopPropagation()}
           >


### PR DESCRIPTION
Also fixes some rendering issue for files with long names in list view

Before:
<img width="1118" alt="image" src="https://user-images.githubusercontent.com/19742402/187651337-17ba4106-b3a7-4a4c-9074-70f16e4628d2.png">

After: 
<img width="1112" alt="image" src="https://user-images.githubusercontent.com/19742402/187651378-533f8c04-5d22-4185-aa21-9ca000280370.png">
