### PR TITLE
mantain route when changing projects

### DIFF
--- a/studio/components/layouts/ProjectLayout/LayoutHeader/ProjectDropdown.tsx
+++ b/studio/components/layouts/ProjectLayout/LayoutHeader/ProjectDropdown.tsx
@@ -1,9 +1,27 @@
 import Link from 'next/link'
 import { observer } from 'mobx-react-lite'
-import { Button, Dropdown, Divider, IconPlus, Popover } from '@supabase/ui'
+import { Button, Dropdown, IconPlus, Popover } from '@supabase/ui'
+import { useRouter } from 'next/router'
+import { ParsedUrlQuery } from 'querystring'
 
 import { useStore } from 'hooks'
 import { IS_PLATFORM, PROJECT_STATUS } from 'lib/constants'
+
+// [Fran] the idea is to let users change projects without losing the current page,
+// but at the same time we need to redirect correctly between urls that might be
+// unique to a project e.g. '/project/projectRef/editor/tableId'
+// Right now, I'm gonna assume that any router query after the projectId,
+// is a unique project id/marker so we'll redirect the user to the
+// highest common route with just projectRef in the router queries.
+
+const sanitizeRoute = (route: string, routerQueries: ParsedUrlQuery) => {
+  let queryArray = Object.entries(routerQueries)
+  if (queryArray.length > 1) {
+    return route.split('/').slice(0, 4).join('/')
+  } else {
+    return route
+  }
+}
 
 const ProjectDropdown = () => {
   const { app, ui } = useStore()
@@ -11,9 +29,8 @@ const ProjectDropdown = () => {
   const selectedOrganizationSlug = ui.selectedOrganization?.slug
   const selectedProject: any = ui.selectedProject
 
-  // [Joshen] If let's say we want to support changing projects to retain sub-route
-  // const currentSubRoute = router.route.split('/[ref]/')[1] || ''
-  // But need to ensure that pages update correctly when the project ref changes
+  const router = useRouter()
+  const sanitizedRoute = sanitizeRoute(router.route, router.query)
 
   return IS_PLATFORM ? (
     <Dropdown
@@ -25,7 +42,11 @@ const ProjectDropdown = () => {
             .filter((x: any) => x.status !== PROJECT_STATUS.INACTIVE)
             .sort((a: any, b: any) => a.name.localeCompare(b.name))
             .map((x: any) => (
-              <Link key={x.ref} href={`/project/${x.ref}`}>
+              <Link
+                key={x.ref}
+                href={sanitizedRoute?.replace('[ref]', x.ref) ?? `/project/${x.ref}`}
+                passHref
+              >
                 <a className="block">
                   <Dropdown.Item>{x.name}</Dropdown.Item>
                 </a>

--- a/studio/components/layouts/ProjectLayout/ProjectLayout.tsx
+++ b/studio/components/layouts/ProjectLayout/ProjectLayout.tsx
@@ -1,5 +1,5 @@
 import Head from 'next/head'
-import { FC, ReactNode, PropsWithChildren } from 'react'
+import { FC, ReactNode, PropsWithChildren, Fragment } from 'react'
 import { observer } from 'mobx-react-lite'
 import { useRouter } from 'next/router'
 import { useStore, withAuth, useFlag } from 'hooks'
@@ -130,7 +130,7 @@ const ContentWrapper: FC<ContentWrapperProps> = observer(({ isLoading, children 
       ) : requiresDbConnection && isProjectBuilding ? (
         <BuildingState project={ui.selectedProject} />
       ) : (
-        <>{children}</>
+        <Fragment key={ui.selectedProject.ref}>{children}</Fragment>
       )}
     </>
   )


### PR DESCRIPTION
## What kind of change does this PR introduce?
Fixes routing to the main project page when users change projects using the project dropdown
Bug fix https://github.com/supabase/supabase/issues/4327

## What is the current behavior?
User changes project and gets redirected to the project main page

## What is the new behavior?
Changing projects will not redirect as long as the current route is not unique to that particular project, in that case it will reroute to the nearest common route. e.g. if a user is on a table route on the editor, they will be sent to the editor page on the selected project.
