### PR TITLE
Remove creating email function from guide

### DIFF
--- a/apps/reference/docs/guides/auth/row-level-security.mdx
+++ b/apps/reference/docs/guides/auth/row-level-security.mdx
@@ -238,7 +238,7 @@ alter table leaderboard
 create policy "Only Blizzard staff can update leaderboard"
   on leaderboard
   for update using (
-    right(auth.email(), 13) = '@blizzard.com'
+    right(auth.jwt() ->> 'email', 13) = '@blizzard.com'
   );
 ```
 

--- a/apps/reference/docs/learn/auth-deep-dive/policies.md
+++ b/apps/reference/docs/learn/auth-deep-dive/policies.md
@@ -141,7 +141,7 @@ Once you get the hang of policies you can start to get a little bit fancy. Let's
 create policy "Only Blizzard staff can update leaderboard"
   on my_scores
   for update using (
-    right(auth.jwt()->>'email', 13) = '@blizzard.com'
+    right(auth.jwt() ->> 'email', 13) = '@blizzard.com'
   );
 ```
 

--- a/apps/reference/docs/learn/auth-deep-dive/policies.md
+++ b/apps/reference/docs/learn/auth-deep-dive/policies.md
@@ -141,11 +141,11 @@ Once you get the hang of policies you can start to get a little bit fancy. Let's
 create policy "Only Blizzard staff can update leaderboard"
   on my_scores
   for update using (
-    right(auth.email(), 13) = '@blizzard.com'
+    right(auth.jwt()->>'email', 13) = '@blizzard.com'
   );
 ```
 
-Supabase comes with three built-in helper functions: `auth.email()`, `auth.uid()` and `auth.role()`.
+Supabase comes with two built-in helper functions: `auth.uid()` and `auth.jwt()`.
 
 See the full PostgreSQL policy docs here: [https://www.postgresql.org/docs/12/sql-createpolicy.html](https://www.postgresql.org/docs/12/sql-createpolicy.html)
 

--- a/apps/reference/docs/learn/auth-deep-dive/policies.md
+++ b/apps/reference/docs/learn/auth-deep-dive/policies.md
@@ -138,10 +138,6 @@ There are some more notes here on how to structure your schema to best integrate
 Once you get the hang of policies you can start to get a little bit fancy. Let's say I work at Blizzard and I only want Blizzard staff members to be able to update people's high scores, I can write something like:
 
 ```sql
-create or replace function auth.email() returns text as $$
-  select nullif(current_setting('request.jwt.claims', true)::json->>'email', '')::text;
-$$ language sql;
-
 create policy "Only Blizzard staff can update leaderboard"
   on my_scores
   for update using (


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

Showing the creation of the `auth.email` function

## What is the new behavior?

Doesn't show the creation of `auth.email` function as its now built in.
