### PR TITLE
fix(reference): misaligned `ButtonCard` content

### DIFF
--- a/apps/reference/docs/about.mdx
+++ b/apps/reference/docs/about.mdx
@@ -150,7 +150,7 @@ Supabase is just Postgres, which makes it compatible with a large number of tool
 <div>
   <div class="row is-multiline">
     {frameworks.map((x) => (
-      <div key={x.name} class="col col--3">
+    <div key={x.name} class="col col--3">
         <ButtonCard
           layout="horizontal"
           icon={
@@ -158,11 +158,11 @@ Supabase is just Postgres, which makes it compatible with a large number of tool
               <x.logo
                 width="20"
                 alt={x.name}
-                style={{ display: 'block', maxHeight: 20 }}
+                style={{ display: 'block', maxHeight: 20, minWidth: 20 }}
               />
             ) : (
               <ThemedImage
-                style={{ display: 'block', maxHeight: 20 }}
+                style={{ display: 'block', maxHeight: 20, minWidth: 20, margin: 0 }}
                 alt={x.name}
                 width="20"
                 sources={{

--- a/apps/reference/src/components/ButtonCard.js
+++ b/apps/reference/src/components/ButtonCard.js
@@ -3,7 +3,6 @@ import Link from '@docusaurus/Link'
 
 export default function ButtonCard({
   children,
-  color,
   icon,
   title,
   description,

--- a/apps/reference/src/css/components/_button-card.scss
+++ b/apps/reference/src/css/components/_button-card.scss
@@ -20,6 +20,10 @@
     flex-direction: row;
     gap: var(--ifm-spacing-horizontal);
     align-items: center;
+
+    h3 {
+      margin-bottom: 0;
+    }
   }
 
   .button-card__inner {


### PR DESCRIPTION
## What kind of change does this PR introduce?

UI Bug fix

## What is the current behavior?

The icons passed to the `ButtonCard` component were shrinking on window resize due to not having enforced `minWidth` to the point where they become invisible. Also, unnecessary margins would make the content look off-centered.

## What is the new behavior?

![CleanShot 2022-09-07 at 13 27 32@2x](https://user-images.githubusercontent.com/32957606/188857527-71a9e352-accd-4d08-926a-01fe774e3991.png)

## Additional context

For best results, the `ButtonCard` wrapper should conditionally apply `col--3` or `col--4` based on the window size. Unfortunately, I did not find a way for quickly adding media queries to the current CSS utilities.