### PR TITLE
docs(installation): update vite commands

### DIFF
--- a/apps/reference/docs/guides/with-vue-3.mdx
+++ b/apps/reference/docs/guides/with-vue-3.mdx
@@ -148,10 +148,10 @@ an app called `supabase-vue-3`:
 
 ```bash
 # npm 6.x
-npm init @vitejs/app supabase-vue-3 --template vue
+npm create vite@latest supabase-vue-3 --template vue
 
 # npm 7+, extra double-dash is needed:
-npm init @vitejs/app supabase-vue-3 -- --template vue
+npm create vite@latest supabase-vue-3 -- --template vue
 
 cd supabase-vue-3
 ```


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

```bash
$npm init @vitejs/app supabase-vue-3 -- --template vue

@vitejs/create-app is deprecated, use npm init vite instead
...
```

 `init @vitejs/ap` has been depricated and no longer works

You can view the `vite` docs [here](https://vitejs.dev/guide/#scaffolding-your-first-vite-project) for the new process, a screenshot from the official docs is shown below.


<img width="729" alt="Screenshot 2022-09-10 at 15 38 10" src="https://user-images.githubusercontent.com/11394050/189488262-83877824-e280-4f5d-a025-d8985f8dc587.png">


An example of `vuetify` updating their docs can be seen [here](https://github.com/vuetifyjs/vuetify/commit/32365b2bf5e625a2adf0f3010ca62057118107a2). 

## What is the new behavior?
```bash
$npm create vite@latest supabase-vue-3 -- --template vue

Scaffolding project in /Users/andrew/work/supabase-vue-3...

Done. Now run:

  cd supabase-vue-3
  npm install
  npm run dev
```

