### PR TITLE
Specify outdated  guide and refer readers to helpful workarounds

### DIFF
--- a/apps/reference/_auth_helpers/svelte-kit.md
+++ b/apps/reference/_auth_helpers/svelte-kit.md
@@ -6,7 +6,11 @@ sidebar_label: With SvelteKit
 
 # Supabase Auth with SvelteKit
 
-This submodule provides convenience helpers for implementing user authentication in [SvelteKit](https://kit.svelte.dev/) applications.
+This submodule provides convenience helpers for implementing user authentication in [SvelteKit](https://kit.svelte.dev/) applications. 
+
+Note that this guide is outdated and won't work on a new sveltekit proyect.
+Refer to [#230](https://github.com/supabase/auth-helpers/issues/230) for a workaround. 
+Refer to [Sveltekit discussion #5883](https://github.com/sveltejs/kit/discussions/5883#discussion-4302953) for more info.
 
 ## Installation
 


### PR DESCRIPTION
Specify outdated  guide and refer readers to helpful workarounds

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

SvelteKit auth-helpers don't work after changes with SvelteKit's $session, redirects handling, cookies and more.

Refer to: https://github.com/sveltejs/kit/discussions/5774
And refer to: https://github.com/sveltejs/kit/discussions/5883

## What is the new behavior?
Just an update to refer users to workarounds discussed in: https://github.com/supabase/auth-helpers/issues/230 

## Additional context
Following instructions provided in the guide entirely breaks the app. 
