### PR TITLE
docs(reference/v2): fix options argument in auth.resetPasswordForEmail

### DIFF
--- a/spec/supabase_js_v2_legacy.yml
+++ b/spec/supabase_js_v2_legacy.yml
@@ -496,7 +496,7 @@ pages:
         isSpotlight: true
         js: |
           ```js
-          const { error, data } = await supabase.auth.resetPasswordForEmail(email, options: {
+          const { error, data } = await supabase.auth.resetPasswordForEmail(email, {
             redirectTo: 'https://example.com/update-password',
           })
           ```


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to fix a docs example issue for `auth.resetPasswordForEmail`, which is described in #8903 .

## What is the current behavior?

The current example code is,

```
const { error, data } = await supabase.auth.resetPasswordForEmail(email, options: {
  redirectTo: 'https://example.com/update-password',
})
```

## What is the new behavior?

The new example is,

```
const { error, data } = await supabase.auth.resetPasswordForEmail(email, {
  redirectTo: 'https://example.com/update-password',
})
```

## Additional context

N/A
