### PR TITLE
fix: docs stylesheet links

### DIFF
--- a/apps/reference/docs/guides/with-nextjs.mdx
+++ b/apps/reference/docs/guides/with-nextjs.mdx
@@ -202,7 +202,7 @@ export const supabase = createClient(supabaseUrl, supabaseAnonKey)
 ```
 
 And one optional step is to update the CSS file `styles/globals.css` to make the app look nice.
-You can find the full contents of this file [here](https://raw.githubusercontent.com/supabase/supabase/master/examples/user-management/nextjs-ts-user-management/styles/globals.css).
+You can find the full contents of this file [here](https://raw.githubusercontent.com/supabase/examples/main/supabase-js-v2/user-management/nextjs-ts-user-management/styles/globals.css).
 
 ### Set up a Login component
 

--- a/apps/reference/docs/guides/with-redwoodjs.mdx
+++ b/apps/reference/docs/guides/with-redwoodjs.mdx
@@ -324,7 +324,7 @@ export default App
 ```
 
 And one optional step is to update the CSS file `web/src/index.css` to make the app look nice.
-You can find the full contents of this file [here](https://raw.githubusercontent.com/supabase/supabase/master/examples/user-management/react-user-management/src/index.css).
+You can find the full contents of this file [here](https://raw.githubusercontent.com/supabase/examples/main/supabase-js-v2/user-management/react-user-management/src/index.css).
 
 ### Start RedwoodJS and your first Page
 

--- a/apps/reference/docs/guides/with-solidjs.mdx
+++ b/apps/reference/docs/guides/with-solidjs.mdx
@@ -200,7 +200,7 @@ export const supabase = createClient(supabaseUrl, supabaseAnonKey)
 ```
 
 And one optional step is to update the CSS file `src/index.css` to make the app look nice.
-You can find the full contents of this file [here](https://raw.githubusercontent.com/supabase/supabase/master/examples/user-management/react-user-management/src/index.css).
+You can find the full contents of this file [here](https://raw.githubusercontent.com/supabase/examples/main/supabase-js-v2/user-management/solid-user-management/src/index.css).
 
 ### Set up a Login component
 

--- a/apps/reference/docs/guides/with-svelte.mdx
+++ b/apps/reference/docs/guides/with-svelte.mdx
@@ -184,7 +184,7 @@ export const supabase = createClient(supabaseUrl, supabaseAnonKey)
 ```
 
 And one optional step is to update the CSS file `src/app.css` to make the app look nice.
-You can find the full contents of this file [here](https://raw.githubusercontent.com/supabase/supabase/master/examples/user-management/react-user-management/src/index.css).
+You can find the full contents of this file [here](https://raw.githubusercontent.com/supabase/examples/main/supabase-js-v2/user-management/svelte-user-management/src/app.css).
 
 ### Set up a Login component
 

--- a/apps/reference/docs/guides/with-sveltekit.mdx
+++ b/apps/reference/docs/guides/with-sveltekit.mdx
@@ -179,7 +179,7 @@ export const supabase = createClient(supabaseUrl, supabaseAnonKey)
 ```
 
 And one optional step is to update the CSS file `public/global.css` to make the app look nice.
-You can find the full contents of this file [here](https://raw.githubusercontent.com/supabase/supabase/master/examples/user-management/react-user-management/src/index.css).
+You can find the full contents of this file [here](https://raw.githubusercontent.com/supabase/examples/main/supabase-js-v2/user-management/svelte-user-management/src/app.css).
 
 ### Set up a Login component
 

--- a/apps/reference/docs/guides/with-vue-3.mdx
+++ b/apps/reference/docs/guides/with-vue-3.mdx
@@ -183,7 +183,7 @@ export const supabase = createClient(supabaseUrl, supabaseAnonKey)
 ```
 
 And one optional step is to update the CSS file `src/assets/main.css` to make the app look nice.
-You can find the full contents of this file [here](https://raw.githubusercontent.com/supabase/supabase/master/examples/user-management/react-user-management/src/index.css).
+You can find the full contents of this file [here](https://raw.githubusercontent.com/supabase/examples/main/supabase-js-v2/user-management/react-user-management/src/index.css).
 
 ```javascript title="src/main.js"
 import { createApp } from 'vue'


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs fix

## What is the current behavior?

On some of the guides the link to view the main stylesheets of the applications are broken.

## What is the new behavior?

Links are now in place and looking at the [examples repo](https://github.com/supabase/examples)

## Additional context

Closes #8927 
