### PR TITLE
fix: correct request/response heading text

### DIFF
--- a/studio/components/interfaces/Settings/Logs/LogSelectionRenderers/DatabaseApiSelectionRender.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogSelectionRenderers/DatabaseApiSelectionRender.tsx
@@ -37,7 +37,7 @@ const DatabaseApiSelectionRender = ({ log }: any) => {
       </div>
       <LogsDivider />
       <div className={`${LOGS_TAILWIND_CLASSES.log_selection_x_padding}`}>
-        <h3 className="text-lg text-scale-1200 mb-4">Request body</h3>
+        <h3 className="text-lg text-scale-1200 mb-4">Request Metadata</h3>
         <pre className="text-sm syntax-highlight overflow-x-auto">
           <div
             className="text-wrap"
@@ -49,9 +49,7 @@ const DatabaseApiSelectionRender = ({ log }: any) => {
       </div>
       <LogsDivider />
       <div className={`${LOGS_TAILWIND_CLASSES.log_selection_x_padding}`}>
-        <h3 className="text-lg text-scale-1200 mb-4">
-          Response{method ? ` ${method}` : null} body
-        </h3>
+        <h3 className="text-lg text-scale-1200 mb-4">Response Metadata</h3>
         <pre className="text-sm syntax-highlight overflow-x-auto">
           <div
             dangerouslySetInnerHTML={{


### PR DESCRIPTION
This PR fixes the heading text for API logs for the Request/Response section, as the data shown does not actually include the request/response body.

https://user-images.githubusercontent.com/22714384/189702764-968b9a9c-74da-4764-a74f-a910490678f8.mov

