### PR TITLE
fix: remove duplicate error display in LogTable, only one alert at a time

### DIFF
--- a/studio/components/interfaces/Settings/Logs/LogTable.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogTable.tsx
@@ -14,6 +14,7 @@ import ResourcesExceededErrorRenderer from './LogsErrorRenderers/ResourcesExceed
 import DefaultErrorRenderer from './LogsErrorRenderers/DefaultErrorRenderer'
 import FunctionsLogsColumnRender from './LogColumnRenderers/FunctionsLogsColumnRender'
 import FunctionsEdgeColumnRender from './LogColumnRenderers/FunctionsEdgeColumnRender'
+import Divider from 'components/ui/Divider'
 
 interface Props {
   data?: Array<LogData | Object>
@@ -166,18 +167,43 @@ const LogTable = ({
     }
 
     return (
-      <div className="flex justify-center px-5">
-        <Alert
-          variant="danger"
-          title="Sorry! An error occured when fetching data."
-          withIcon
-          className="w-1/2"
-        >
+      <div className="flex justify-center px-5 w-1/2">
+        <Alert variant="danger" title="Sorry! An error occured when fetching data." withIcon>
           <Renderer {...childProps} />
         </Alert>
       </div>
     )
   }
+
+  const renderNoResultAlert = () => (
+    <div className="flex flex-col items-center gap-6 text-center mt-16 opacity-100 scale-100 justify-center">
+      <div className="flex flex-col gap-1">
+        <div className="relative border border-scale-600 border-dashed dark:border-scale-900 w-32 h-4 rounded px-2 flex items-center"></div>
+        <div className="relative border border-scale-600 border-dashed dark:border-scale-900 w-32 h-4 rounded px-2 flex items-center">
+          <div className="absolute right-1 -bottom-4">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="h-6 w-6"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth="2"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M9.172 16.172a4 4 0 015.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+      <div className="flex flex-col gap-1 px-5">
+        <h3 className="text-lg text-scale-1200">No results</h3>
+        <p className="text-sm text-scale-900">Try another search, or adjusting the filters</p>
+      </div>
+    </div>
+  )
 
   return (
     <>
@@ -238,61 +264,10 @@ const LogTable = ({
             }}
             noRowsFallback={
               !isLoading ? (
-                <>
-                  <div className="py-4 w-full h-full flex-col space-y-12">
-                    {!error && (
-                      <div
-                        className={`transition-all
-                      duration-500
-                      delay-200
-                      
-                      flex
-                      flex-col
-                      items-center
-                  
-                      gap-6
-                      text-center
-                      mt-16
-                      opacity-100 
-                      scale-100
-                      
-                      justify-center
-                    `}
-                      >
-                        <>
-                          <div className="flex flex-col gap-1">
-                            <div className="relative border border-scale-600 border-dashed dark:border-scale-900 w-32 h-4 rounded px-2 flex items-center"></div>
-                            <div className="relative border border-scale-600 border-dashed dark:border-scale-900 w-32 h-4 rounded px-2 flex items-center">
-                              <div className="absolute right-1 -bottom-4">
-                                <svg
-                                  xmlns="http://www.w3.org/2000/svg"
-                                  className="h-6 w-6"
-                                  fill="none"
-                                  viewBox="0 0 24 24"
-                                  stroke="currentColor"
-                                  strokeWidth="2"
-                                >
-                                  <path
-                                    strokeLinecap="round"
-                                    strokeLinejoin="round"
-                                    d="M9.172 16.172a4 4 0 015.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-                                  />
-                                </svg>
-                              </div>
-                            </div>
-                          </div>
-                          <div className="flex flex-col gap-1 px-5">
-                            <h3 className="text-lg text-scale-1200">No results</h3>
-                            <p className="text-sm text-scale-900">
-                              Try another search, or adjusting the filters
-                            </p>
-                          </div>
-                        </>
-                      </div>
-                    )}
-                    {error && renderErrorAlert()}
-                  </div>
-                </>
+                <div className="transition-all duration-500 delay-200 py-4 flex w-full h-full justify-center items-center mx-auto space-y-12">
+                  {!error && renderNoResultAlert()}
+                  {error && renderErrorAlert()}
+                </div>
               ) : null
             }
             columns={columns as any}

--- a/studio/components/interfaces/Settings/Logs/LogsPreviewer.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogsPreviewer.tsx
@@ -190,6 +190,7 @@ export const LogsPreviewer: React.FC<Props> = ({
             isHistogramShowing={showChart}
             onHistogramToggle={() => setShowChart(!showChart)}
             params={params}
+            error={error}
           />
         </LoadingOpacity>
         {!error && (
@@ -198,22 +199,6 @@ export const LogsPreviewer: React.FC<Props> = ({
               Load older
             </Button>
             <UpgradePrompt projectRef={projectRef} from={params.iso_timestamp_start || ''} />
-          </div>
-        )}
-        {error && (
-          <div className="flex w-full h-full justify-center items-center mx-auto">
-            <Card className="flex flex-col gap-y-2  w-2/5 bg-scale-400">
-              <div className="flex flex-row gap-x-2 py-2">
-                <IconAlertCircle size={16} />
-                <p className="text-scale-1000">Sorry! An error occured when fetching data.</p>
-              </div>
-              <Input.TextArea
-                label="Error Messages"
-                value={JSON.stringify(error, null, 2)}
-                borderless
-                className=" border-t-2 border-scale-800 pt-2 font-mono"
-              />
-            </Card>
           </div>
         )}
       </div>

--- a/studio/tests/pages/projects/LogTable.test.js
+++ b/studio/tests/pages/projects/LogTable.test.js
@@ -132,6 +132,12 @@ test('error message handling', async () => {
   await screen.findByText(/my_error/)
 })
 
+test('no results message handling', async () => {
+  render(<LogTable data={[]} />)
+  await screen.findByText(/No results/)
+  await screen.findByText(/Try another search/)
+})
+
 test('custom error message: Resources exceeded during query execution', async () => {
   const errorFromLogflare = {
     error: {


### PR DESCRIPTION
Fixes the bug where the a duplicate error alert display was being used (instead of our brand new custom error handler), as well as the bug where both the No Results message and the Error Alert was being shown at the same time.

LogTable tests have been extended to cover the no results message display.

![Screenshot 2022-09-13 at 2 08 00 AM](https://user-images.githubusercontent.com/22714384/189725640-012cc782-ef22-47f6-a20a-ac7d0578cf3c.png)
![Screenshot 2022-09-13 at 2 07 24 AM](https://user-images.githubusercontent.com/22714384/189725648-688ef4da-dbd8-4bdf-b31d-c8b3cb22e5a8.png)
