### PR TITLE
chore: LogTable - removes typo for focused, from focussed

### DIFF
--- a/studio/components/interfaces/Settings/Logs/LogTable.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogTable.tsx
@@ -296,16 +296,9 @@ const LogTable = ({
               ) : null
             }
             columns={columns as any}
-            rowClass={(r) => {
-              const row = r as LogData
-
-              let classes = []
-              classes.push(
-                `${row.id === focusedLog?.id ? '!bg-scale-400 rdg-row--focused' : 'cursor-pointer'}`
-              )
-
-              return classes.join(' ')
-            }}
+            rowClass={(row: LogData) =>
+              row.id === focusedLog?.id ? '!bg-scale-400 rdg-row--focused' : 'cursor-pointer'
+            }
             rows={logDataRows}
             rowKeyGetter={(r) => {
               if (!hasId) return Object.keys(r)[0]

--- a/studio/components/interfaces/Settings/Logs/LogTable.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogTable.tsx
@@ -301,9 +301,7 @@ const LogTable = ({
 
               let classes = []
               classes.push(
-                `${
-                  row.id === focusedLog?.id ? '!bg-scale-400 rdg-row--focussed' : 'cursor-pointer'
-                }`
+                `${row.id === focusedLog?.id ? '!bg-scale-400 rdg-row--focused' : 'cursor-pointer'}`
               )
 
               return classes.join(' ')

--- a/studio/styles/react-data-grid-logs.scss
+++ b/studio/styles/react-data-grid-logs.scss
@@ -14,13 +14,13 @@
   }
 
   .rdg-row {
-    &.rdg-row--focussed {
+    &.rdg-row--focused {
       @apply border-r border-brand-900;
       border-right-width: 4px;
     }
 
-    &.rdg-row--focussed .rdg-cell,
-    &.rdg-row--focussed .rdg-cell span {
+    &.rdg-row--focused .rdg-cell,
+    &.rdg-row--focused .rdg-cell span {
       @apply text-scale-1200 font-semibold #{!important};
     }
   }
@@ -42,13 +42,13 @@
   }
 
   .rdg-row {
-    &.rdg-row--focussed {
+    &.rdg-row--focused {
       @apply border-r border-brand-900;
       border-right-width: 4px;
     }
 
-    &.rdg-row--focussed .rdg-cell,
-    &.rdg-row--focussed .rdg-cell span {
+    &.rdg-row--focused .rdg-cell,
+    &.rdg-row--focused .rdg-cell span {
       @apply text-scale-1200 font-semibold #{!important};
     }
   }


### PR DESCRIPTION
Fixes a typo, changes class from `focussed` to `focused`

it also does some slight refactoring for the rowClass building