### PR TITLE
docs: generateLink() examples 

### DIFF
--- a/apps/reference/_supabase_js/generated/auth-admin-generatelink.mdx
+++ b/apps/reference/_supabase_js/generated/auth-admin-generatelink.mdx
@@ -11,13 +11,13 @@ import TabItem from '@theme/TabItem'
 Generates email links and OTPs to be sent via a custom email provider.
 
 ```js
-const { data, error } = await supabase.auth.admin.generateLink(
-  'email@example.com'
-  'signup',
-  {
-    'password': 'secret'
-  }
-)
+const { data, error } = await supabase.auth.admin.generateLink({
+  type: 'signup',
+  email: 'email@example.com',
+  options: {
+    password: 'secret',
+  },
+})
 ```
 
 ## Parameters
@@ -133,23 +133,51 @@ No description provided.
 
 ## Examples
 
-### Generate a signup link.
+### Generate a signup link
 
 ```js
-const { data, error } = await supabase.auth.admin.generateLink(
-  'email@example.com'
-  'signup',
-  {
-    'password': 'secret'
-  }
-)
+const { data, error } = await supabase.auth.admin.generateLink({
+  type: 'signup',
+  email: 'email@example.com',
+  options: {
+    password: 'secret',
+  },
+})
 ```
 
-### Generate an invite link.
+### Generate an invite link
 
 ```js
-const { data, error } = await supabase.auth.admin.generateLink(
-  'email@example.com'
-  'invite',
-)
+const { data, error } = await supabase.auth.admin.generateLink({
+  type: 'invite',
+  email: 'email@example.com',
+})
+```
+
+### Generate a magic link
+
+```js
+const { data, error } = await supabase.auth.admin.generateLink({
+  type: 'magiclink',
+  email: 'email@example.com',
+})
+```
+
+### Generate a recovery link
+
+```js
+const { data, error } = await supabase.auth.admin.generateLink({
+  type: 'recovery',
+  email: 'email@example.com',
+})
+```
+
+### Generate a link to change email addresses
+
+```js
+const { data, error } = await supabase.auth.admin.generateLink({
+  type: 'email_change_current',
+  email: 'old.email@example.com',
+  newEmail: 'new.email@example.com',
+})
 ```

--- a/spec/supabase_js_v2_legacy.yml
+++ b/spec/supabase_js_v2_legacy.yml
@@ -505,7 +505,7 @@ pages:
     title: 'generateLink()'
     $ref: '@supabase/gotrue-js.GoTrueAdminApi.generateLink'
     examples:
-      - name: Generate a signups link.
+      - name: Generate a signup link.
         isSpotlight: true
         js: |
           ```js

--- a/spec/supabase_js_v2_legacy.yml
+++ b/spec/supabase_js_v2_legacy.yml
@@ -505,27 +505,55 @@ pages:
     title: 'generateLink()'
     $ref: '@supabase/gotrue-js.GoTrueAdminApi.generateLink'
     examples:
-      - name: Generate a signup link.
+      - name: Generate a signups link.
         isSpotlight: true
         js: |
           ```js
-          const { data, error } = await supabase.auth.admin.generateLink(
-            'email@example.com'
-            'signup',
-            {
+          const { data, error } = await supabase.auth.admin.generateLink({
+            type: 'signup',
+            email: 'email@example.com'
+            options: {
               'password': 'secret'
             }
-          )
+          })
           ```
       - name: Generate an invite link.
         isSpotlight: false
         js: |
           ```js
-          const { data, error } = await supabase.auth.admin.generateLink(
-            'email@example.com'
-            'invite',
-          )
+          const { data, error } = await supabase.auth.admin.generateLink({
+            type: 'invite',
+            email: 'email@example.com'
+          })
           ```
+      - name: Generate an Magic link.
+        isSpotlight: false
+        js: |
+          ```js
+          const { data, error } = await supabase.auth.admin.generateLink({
+            type: 'magiclink',
+            email: 'email@example.com'
+          })
+          ```
+      - name: Generate an recovery link.
+        isSpotlight: false
+        js: |
+          ```js
+          const { data, error } = await supabase.auth.admin.generateLink({
+            type: 'recovery',
+            email: 'email@example.com'
+          })
+          ``` 
+      - name: Generate link to change email address.
+        isSpotlight: false
+        js: |
+          ```js
+          const { data, error } = await supabase.auth.admin.generateLink({
+            type: 'email_change_current',
+            email: 'old.email@example.com',
+            newEmail: 'new.email@example.com'
+          })
+          ```           
 
   auth.admin.updateUserById():
     title: 'updateUserById()'

--- a/spec/supabase_js_v2_legacy.yml
+++ b/spec/supabase_js_v2_legacy.yml
@@ -505,19 +505,19 @@ pages:
     title: 'generateLink()'
     $ref: '@supabase/gotrue-js.GoTrueAdminApi.generateLink'
     examples:
-      - name: Generate a signup link.
+      - name: Generate a signup link
         isSpotlight: true
         js: |
           ```js
           const { data, error } = await supabase.auth.admin.generateLink({
             type: 'signup',
-            email: 'email@example.com'
+            email: 'email@example.com',
             options: {
               'password': 'secret'
             }
           })
           ```
-      - name: Generate an invite link.
+      - name: Generate an invite link
         isSpotlight: false
         js: |
           ```js
@@ -526,7 +526,7 @@ pages:
             email: 'email@example.com'
           })
           ```
-      - name: Generate an Magic link.
+      - name: Generate an Magic link
         isSpotlight: false
         js: |
           ```js
@@ -535,7 +535,7 @@ pages:
             email: 'email@example.com'
           })
           ```
-      - name: Generate an recovery link.
+      - name: Generate an recovery link
         isSpotlight: false
         js: |
           ```js
@@ -544,7 +544,7 @@ pages:
             email: 'email@example.com'
           })
           ``` 
-      - name: Generate link to change email address.
+      - name: Generate link to change email address
         isSpotlight: false
         js: |
           ```js

--- a/spec/supabase_js_v2_legacy.yml
+++ b/spec/supabase_js_v2_legacy.yml
@@ -526,7 +526,7 @@ pages:
             email: 'email@example.com'
           })
           ```
-      - name: Generate an Magic link
+      - name: Generate a magic link
         isSpotlight: false
         js: |
           ```js
@@ -535,7 +535,7 @@ pages:
             email: 'email@example.com'
           })
           ```
-      - name: Generate an recovery link
+      - name: Generate a recovery link
         isSpotlight: false
         js: |
           ```js
@@ -544,7 +544,7 @@ pages:
             email: 'email@example.com'
           })
           ``` 
-      - name: Generate link to change email address
+      - name: Generate a link to change email addresses
         isSpotlight: false
         js: |
           ```js


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs Update

## What is the current behavior?

The [generateLink()](https://supabase.com/docs/reference/javascript/next/auth-admin-generatelink) next/v2 docs not match whats on the gotrue spec.

## What is the new behavior?

Examples have been updated and also added some new examples as well

## Additional context

This closes #8636 
