### PR TITLE
Update generateLink() reference docs copy

### DIFF
--- a/apps/reference/_supabase_js/generated/auth-admin-generatelink.mdx
+++ b/apps/reference/_supabase_js/generated/auth-admin-generatelink.mdx
@@ -8,7 +8,7 @@ custom_edit_url: https://github.com/supabase/supabase/edit/master/spec/supabase_
 import Tabs from '@theme/Tabs'
 import TabItem from '@theme/TabItem'
 
-Generates email links and OTPs to be sent via a custom email provider.
+Generates email links and OTPs to send via a custom email provider.
 
 ```js
 const { data, error } = await supabase.auth.admin.generateLink(
@@ -133,7 +133,7 @@ No description provided.
 
 ## Examples
 
-### Generate a signup link.
+### Generate a signup link
 
 ```js
 const { data, error } = await supabase.auth.admin.generateLink(
@@ -145,7 +145,7 @@ const { data, error } = await supabase.auth.admin.generateLink(
 )
 ```
 
-### Generate an invite link.
+### Generate an invite link
 
 ```js
 const { data, error } = await supabase.auth.admin.generateLink(

--- a/apps/reference/_supabase_js_versioned_docs/version-v1/auth-api-generatelink.mdx
+++ b/apps/reference/_supabase_js_versioned_docs/version-v1/auth-api-generatelink.mdx
@@ -8,7 +8,7 @@ custom_edit_url: https://github.com/supabase/supabase/edit/master/spec/supabase_
 import Tabs from '@theme/Tabs'
 import TabItem from '@theme/TabItem'
 
-Generates links to be sent via email or other.
+Generates authentication links to send via email.
 
 ## Parameters
 
@@ -148,7 +148,7 @@ No description provided.
 
 ## Examples
 
-### Generate invite link.
+### Generate an invite link
 
 ```js
 const { data: user, error } = await supabase.auth.api.generateLink(

--- a/spec/enrichments/tsdoc_v1/combined.json
+++ b/spec/enrichments/tsdoc_v1/combined.json
@@ -2215,7 +2215,7 @@
                         "isExternal": true
                       },
                       "comment": {
-                        "shortText": "Generates links to be sent via email or other."
+                        "shortText": "Generates authentication links to send via email."
                       },
                       "parameters": [
                         {

--- a/spec/enrichments/tsdoc_v2/supabase_dereferenced.json
+++ b/spec/enrichments/tsdoc_v2/supabase_dereferenced.json
@@ -6615,7 +6615,7 @@
                     "isExternal": true
                   },
                   "comment": {
-                    "shortText": "Generates links to be sent via email or other."
+                    "shortText": "Generates authenticaion links to send via email."
                   },
                   "parameters": [
                     {

--- a/spec/supabase_js_v1_legacy.yml
+++ b/spec/supabase_js_v1_legacy.yml
@@ -621,7 +621,7 @@ pages:
       - Requires a `service_role` key.
       - This function should only be called on a server. Never expose your `service_role` key in the browser.
     examples:
-      - name: Generate invite link.
+      - name: Generate an invite link
         isSpotlight: false
         js: |
           ```js

--- a/spec/supabase_js_v2_legacy.yml
+++ b/spec/supabase_js_v2_legacy.yml
@@ -505,7 +505,7 @@ pages:
     title: 'generateLink()'
     $ref: '@supabase/gotrue-js.GoTrueAdminApi.generateLink'
     examples:
-      - name: Generate a signup link.
+      - name: Generate a signup link
         isSpotlight: true
         js: |
           ```js
@@ -517,7 +517,7 @@ pages:
             }
           )
           ```
-      - name: Generate an invite link.
+      - name: Generate an invite link
         isSpotlight: false
         js: |
           ```js


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Update copy for GenerateLink()
- Remove periods from headings

## What is the current behavior?

- https://supabase.com/docs/reference/javascript/auth-api-generatelink#examples
- https://supabase.com/docs/reference/javascript/next/auth-admin-generatelink#examples

## What is the new behavior?

supabase-js v1
![Screen Shot 2022-09-13 at 5 08 46 PM](https://user-images.githubusercontent.com/7026076/190030826-de2a6b9d-5735-4e89-af56-a665a8e2ac1b.png)

supabase-js v2 RC
![Screen Shot 2022-09-13 at 5 09 10 PM](https://user-images.githubusercontent.com/7026076/190030838-eb5d824b-7e9c-4089-89f0-6489ce31d6a4.png)