### PR TITLE
fix: email provider wording clarification

### DIFF
--- a/studio/stores/authConfig/schema/AuthProviders/AuthProvidersFormValidation.tsx
+++ b/studio/stores/authConfig/schema/AuthProviders/AuthProvidersFormValidation.tsx
@@ -10,7 +10,7 @@ const PROVIDER_EMAIL = {
   properties: {
     EXTERNAL_EMAIL_ENABLED: {
       title: 'Enable Email provider',
-      description: 'This will enable Email based login for your application',
+      description: 'This will enable Email based signup and login for your application',
       type: 'boolean',
     },
     MAILER_AUTOCONFIRM: {


### PR DESCRIPTION
Users were somewhat confused that this only prevents logins but not sign-ups.