### PR TITLE
fix: LogEventChart - fixes timestamp truncation filtering logic

### DIFF
--- a/studio/components/interfaces/Settings/Logs/Logs.utils.ts
+++ b/studio/components/interfaces/Settings/Logs/Logs.utils.ts
@@ -177,7 +177,7 @@ export const calcChartStart = (params: Partial<LogsEndpointParams>): [Dayjs, str
   let extendValue = 60 * 6
   const minuteDiff = ite.diff(its, 'minute')
   const hourDiff = ite.diff(its, 'hour')
-  if (minuteDiff > (60 * 12)) {
+  if (minuteDiff > 60 * 12) {
     trunc = 'hour'
     extendValue = 24 * 5
   } else if (hourDiff > 24 * 3) {
@@ -198,7 +198,6 @@ export const genChartQuery = (
 ) => {
   const [startOffset, trunc] = calcChartStart(params)
   const where = _genWhereStatement(table, filters)
-  console.log('where', where)
   return `
 SELECT
   timestamp_trunc(t.timestamp, ${trunc}) as timestamp,
@@ -206,7 +205,11 @@ SELECT
 FROM
   ${table} t
   cross join unnest(t.metadata) as metadata
-  ${where ? where + ` and t.timestamp > '${startOffset.toISOString()}'` : `where t.timestamp > '${startOffset.toISOString()}'`}
+  ${
+    where
+      ? where + ` and t.timestamp > '${startOffset.toISOString()}'`
+      : `where t.timestamp > '${startOffset.toISOString()}'`
+  }
 GROUP BY
 timestamp
 ORDER BY
@@ -214,18 +217,18 @@ ORDER BY
   `
 }
 
-
 type TsPair = [string | '', string | '']
-export const ensureNoTimestampConflict = ([initialStart, initialEnd]: TsPair, [nextStart, nextEnd]: TsPair): TsPair => {
+export const ensureNoTimestampConflict = (
+  [initialStart, initialEnd]: TsPair,
+  [nextStart, nextEnd]: TsPair
+): TsPair => {
   if (initialStart && initialEnd && nextEnd && !nextStart) {
     const resolvedDiff = dayjs(nextEnd).diff(dayjs(initialStart))
     let start = dayjs(initialStart)
 
     if (resolvedDiff <= 0) {
       // start ts is definitely before end ts
-      const currDiff = Math.abs(
-        dayjs(initialEnd).diff(start, 'minute')
-      )
+      const currDiff = Math.abs(dayjs(initialEnd).diff(start, 'minute'))
       // shift start ts backwards by the current ts difference
       start = dayjs(nextEnd).subtract(currDiff, 'minute')
     }
@@ -235,5 +238,4 @@ export const ensureNoTimestampConflict = ([initialStart, initialEnd]: TsPair, [n
   } else {
     return [nextStart, nextEnd]
   }
-
 }

--- a/studio/components/interfaces/Settings/Logs/Logs.utils.ts
+++ b/studio/components/interfaces/Settings/Logs/Logs.utils.ts
@@ -174,12 +174,12 @@ export const calcChartStart = (params: Partial<LogsEndpointParams>): [Dayjs, str
   const ite = params.iso_timestamp_end ? dayjs(params.iso_timestamp_end) : dayjs()
   const its = params.iso_timestamp_start ? dayjs(params.iso_timestamp_start) : dayjs()
   let trunc = 'minute'
-  let extendValue = 60 * 1
+  let extendValue = 60 * 6
   const minuteDiff = ite.diff(its, 'minute')
   const hourDiff = ite.diff(its, 'hour')
-  if (minuteDiff > (60 * 8)) {
+  if (minuteDiff > (60 * 12)) {
     trunc = 'hour'
-    extendValue = 24 * 3
+    extendValue = 24 * 5
   } else if (hourDiff > 24 * 3) {
     trunc = 'day'
     extendValue = 7

--- a/studio/components/interfaces/Settings/Logs/Logs.utils.ts
+++ b/studio/components/interfaces/Settings/Logs/Logs.utils.ts
@@ -174,13 +174,13 @@ export const calcChartStart = (params: Partial<LogsEndpointParams>): [Dayjs, str
   const ite = params.iso_timestamp_end ? dayjs(params.iso_timestamp_end) : dayjs()
   const its = params.iso_timestamp_start ? dayjs(params.iso_timestamp_start) : dayjs()
   let trunc = 'minute'
-  let extendValue = 60 * 6
+  let extendValue = 60 * 1
   const minuteDiff = ite.diff(its, 'minute')
   const hourDiff = ite.diff(its, 'hour')
-  if (minuteDiff > (60 * 12)) {
+  if (minuteDiff > (60 * 8)) {
     trunc = 'hour'
     extendValue = 24 * 3
-  } else if (hourDiff > 24 * 5) {
+  } else if (hourDiff > 24 * 3) {
     trunc = 'day'
     extendValue = 7
   }
@@ -198,13 +198,15 @@ export const genChartQuery = (
 ) => {
   const [startOffset, trunc] = calcChartStart(params)
   const where = _genWhereStatement(table, filters)
+  console.log('where', where)
   return `
 SELECT
   timestamp_trunc(t.timestamp, ${trunc}) as timestamp,
-  count(timestamp) as count
+  count(t.timestamp) as count
 FROM
   ${table} t
-${where ? where + ` and t.timestamp > '${startOffset.toISOString()}'` : ""}
+  cross join unnest(t.metadata) as metadata
+  ${where ? where + ` and t.timestamp > '${startOffset.toISOString()}'` : `where t.timestamp > '${startOffset.toISOString()}'`}
 GROUP BY
 timestamp
 ORDER BY


### PR DESCRIPTION
This PR fixes the log event chart truncation logic, where the event chart was disappearing.

The issue was two-fold:
- long query times due to a bug in the timestamp filtering for the chart sql generated
- no metadata cross join for when there is an override filter in the previewer

Long query times resulted in queries taking >10s, degrading user experience.

Cross join filtering issue was affecting edge function logs.

Reference ticket: https://www.notion.so/supabase/LogEventChart-sometimes-does-not-show-all-events-9d829bcd64474147a0482d8fac136f0b
