### PR TITLE
chore: LogTable extracts out the LogsExplorer table header for better organiza…

### DIFF
--- a/studio/components/interfaces/Settings/Logs/LogTable.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogTable.tsx
@@ -151,6 +151,33 @@ const LogTable = ({
     }
   }, [stringData])
 
+  const LogsExplorerTableHeader = () => (
+    <div className="w-full bg-scale-100 dark:bg-scale-300 rounded-tl rounded-tr border-t border-l border-r flex items-center justify-between px-5 py-2">
+      <div className="flex items-center gap-2">
+        {data && data.length ? (
+          <>
+            <span className="text-sm text-scale-1200">Query results</span>
+            <span className="text-sm text-scale-1100">{data && data.length}</span>
+          </>
+        ) : (
+          <span className="text-xs text-scale-1200">Results will be shown below</span>
+        )}
+      </div>
+      <div className="flex items-center gap-2">
+        {onHistogramToggle && (
+          <Button
+            type="default"
+            icon={isHistogramShowing ? <IconEye /> : <IconEyeOff />}
+            onClick={onHistogramToggle}
+          >
+            Histogram
+          </Button>
+        )}
+        <CSVButton data={data}>Download</CSVButton>
+      </div>
+    </div>
+  )
+
   const renderErrorAlert = () => {
     if (!error) return null
     const childProps = {
@@ -185,44 +212,7 @@ const LogTable = ({
         className={'flex flex-col w-full ' + (!queryType ? 'shadow-lg' : '')}
         style={{ maxHeight }}
       >
-        {!queryType && (
-          <div>
-            <div
-              className="
-            w-full bg-scale-100 dark:bg-scale-300 
-            rounded-tl rounded-tr
-            border-t
-            border-l
-            border-r
-            flex items-center justify-between
-            px-5 py-2
-      "
-            >
-              <div className="flex items-center gap-2">
-                {data && data.length ? (
-                  <>
-                    <span className="text-sm text-scale-1200">Query results</span>
-                    <span className="text-sm text-scale-1100">{data && data.length}</span>
-                  </>
-                ) : (
-                  <span className="text-xs text-scale-1200">Results will be shown below</span>
-                )}
-              </div>
-              <div className="flex items-center gap-2">
-                {onHistogramToggle && (
-                  <Button
-                    type="default"
-                    icon={isHistogramShowing ? <IconEye /> : <IconEyeOff />}
-                    onClick={onHistogramToggle}
-                  >
-                    Histogram
-                  </Button>
-                )}
-                {showDownload && <CSVButton data={data}>Download</CSVButton>}
-              </div>
-            </div>
-          </div>
-        )}
+        {!queryType && <LogsExplorerTableHeader />}
         <div className={`flex flex-row h-full ${!queryType ? 'border-l border-r' : ''}`}>
           <DataGrid
             style={{ height: '100%' }}


### PR DESCRIPTION
This PR does a small refactor to extract out the Logs Explorer table header, and can be further extracted to a separate component down the line.

It makes it much clearer in the render code. Some unnecessary wrapping divs were also removed. This is part of a general LogTable refactor, see below reference ticket.


reference issue: https://www.notion.so/supabase/LogTable-code-cleanup-and-stories-f1a554fdeb1f4337bc9f16fc076401c9