### PR TITLE
Remove JS logo from Auth Server ref docs

### DIFF
--- a/apps/reference/src/theme/DocSidebar/Desktop/Content/index.js
+++ b/apps/reference/src/theme/DocSidebar/Desktop/Content/index.js
@@ -25,7 +25,6 @@ const headerNames = {
   },
   auth: {
     name: 'Auth',
-    icon: 'javascript-icon',
   },
   storage: {
     name: 'Storage',


### PR DESCRIPTION
## What kind of change does this PR introduce?

Remove JS logo from Auth Server ref docs

## What is the current behavior?

![Screen Shot 2022-09-15 at 3 04 19 PM](https://user-images.githubusercontent.com/7026076/190516903-614fd607-456f-4318-989f-f91a4990791f.png)

## What is the new behavior?

![Screen Shot 2022-09-15 at 3 04 29 PM](https://user-images.githubusercontent.com/7026076/190516921-a3e89083-676e-4ff5-aa27-e6eee6d6d700.png)