### PR TITLE
chore: move auth-helper docs to guides.

### DIFF
--- a/apps/reference/docs/guides/auth.mdx
+++ b/apps/reference/docs/guides/auth.mdx
@@ -44,7 +44,7 @@ You can authenticate your users in several ways:
 
 ### Providers
 
-We provide a suite of Providers and login methods, as well as [Auth helpers](/docs/guides/auth/auth-helpers/auth-ui).
+We provide a suite of Providers and login methods, as well as [Auth helpers](/docs/guides/auth/auth-helpers/).
 
 <div class="container" style={{ padding: 0 }}>
   <div class="row is-multiline">

--- a/apps/reference/docs/guides/auth/auth-helpers/index.mdx
+++ b/apps/reference/docs/guides/auth/auth-helpers/index.mdx
@@ -1,12 +1,49 @@
 ---
 id: index
-title: Overview
-description: A collection of framework specific Auth utilities for working with Supabase.
+title: Auth Helpers
+description: A collection of framework-specific Auth utilities for working with Supabase.
+sidebar_label: Overview
 ---
 
-# Auth Helpers
+import useBaseUrl from '@docusaurus/useBaseUrl'
+import ButtonCard from '@site/src/components/ButtonCard'
 
-A collection of framework specific Auth utilities for working with Supabase.
+A collection of framework-specific Auth utilities for working with Supabase.
+
+<div class="container" style={{ padding: 0 }}>
+  <div class="row is-multiline">
+    {/* Auth UI */}
+    <div class="col col--4">
+      <ButtonCard
+        class="card"
+        to={useBaseUrl('/guides/auth/auth-helpers/auth-ui')}
+        title={'Auth UI'}
+        description={'A pre-built React component for authenticating users.'}
+        style={{ height: '100%' }}
+      />
+    </div>    
+    {/* Next.js */}
+    <div class="col col--4">
+      <ButtonCard
+        class="card"
+        to={useBaseUrl('/guides/auth/auth-helpers/nextjs')}
+        title={'Next.js'}
+        description={'Helpers for authenticating users in Next.js applications.'}
+        style={{ height: '100%' }}
+      />
+    </div>
+    {/* SvelteKit */}
+    <div class="col col--4">
+      <ButtonCard
+        class="card"
+        to={useBaseUrl('/guides/auth/auth-helpers/sveltekit')}
+        title={'SvelteKit'}
+        description={'Helpers for authenticating users in SvelteKit applications.'}
+        style={{ height: '100%' }}
+      />
+    </div>
+  </div>
+</div>
 
 ## Status
 

--- a/apps/reference/docs/guides/auth/auth-helpers/index.mdx
+++ b/apps/reference/docs/guides/auth/auth-helpers/index.mdx
@@ -1,0 +1,18 @@
+---
+id: index
+title: Overview
+description: A collection of framework specific Auth utilities for working with Supabase.
+---
+
+# Auth Helpers
+
+A collection of framework specific Auth utilities for working with Supabase.
+
+## Status
+
+The Auth Helpers are in `beta`. They are usable in their current state, but it's likely that there will be breaking changes.
+
+## Additional Links
+
+- [Source code](https://github.com/supabase/auth-helpers)
+- [Known bugs and issues](https://github.com/supabase/auth-helpers/issues)

--- a/apps/reference/docs/guides/auth/auth-helpers/nextjs.mdx
+++ b/apps/reference/docs/guides/auth/auth-helpers/nextjs.mdx
@@ -1,10 +1,9 @@
 ---
 id: nextjs
-title: Next.js Auth Helpers
+title: Supabase Auth with Next.js
 description: Authentication helpers for Next.js API routes, middleware, and SSR.
+sidebar_label: "Next.js"
 ---
-
-# Supabase Auth with Next.js
 
 This submodule provides convenience helpers for implementing user authentication in Next.js applications.
 

--- a/apps/reference/docs/guides/auth/auth-helpers/nextjs.mdx
+++ b/apps/reference/docs/guides/auth/auth-helpers/nextjs.mdx
@@ -1,0 +1,315 @@
+---
+id: nextjs
+title: Next.js Auth Helpers
+description: Authentication helpers for Next.js API routes, middleware, and SSR.
+---
+
+# Supabase Auth with Next.js
+
+This submodule provides convenience helpers for implementing user authentication in Next.js applications.
+
+## Installation
+
+Using [npm](https://npmjs.org):
+
+```sh
+npm install @supabase/auth-helpers-nextjs
+
+# Main components and hooks for React based frameworks (optional)
+npm install @supabase/auth-helpers-react
+```
+
+Using [yarn](https://yarnpkg.com/):
+
+```sh
+yarn add @supabase/auth-helpers-nextjs
+
+# Main components and hooks for React based frameworks (optional)
+yarn add @supabase/auth-helpers-react
+```
+
+This library supports the following tooling versions:
+
+- Node.js: `^10.13.0 || >=12.0.0`
+
+- Next.js: `>=10`
+
+## Getting Started
+
+### Configuration
+
+Set up the following env vars. For local development you can set them in a `.env.local` file. See an [example](https://github.com/supabase/auth-helpers/blob/main/examples/nextjs/.env.local.example).
+
+```bash
+# Find these in your Supabase project settings > API
+NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+```
+
+### Basic Setup
+
+- Create an `auth` directory under the `/pages/api/` directory.
+
+- Create a `[...supabase].js` file under the newly created `auth` directory.
+
+The path to your dynamic API route file would be `/pages/api/auth/[...supabase].js`. Populate that file as follows:
+
+```js
+import { handleAuth } from '@supabase/auth-helpers-nextjs'
+
+export default handleAuth({ logout: { returnTo: '/' } })
+```
+
+Executing `handleAuth()` creates the following route handlers under the hood that perform different parts of the authentication flow:
+
+- `/api/auth/callback`: The `UserProvider` forwards the session details here every time `onAuthStateChange` fires on the client side. This is needed to set up the cookies for your application so that SSR works seamlessly.
+
+- `/api/auth/user`: You can fetch user profile information in JSON format.
+
+- `/api/auth/logout`: Your Next.js application logs out the user. You can optionally pass a `returnTo` parameter to return to a custom relative URL after logout, eg `/api/auth/logout?returnTo=/login`. This will overwrite the logout `returnTo` option specified `handleAuth()`
+
+Wrap your `pages/_app.js` component with the `UserProvider` component:
+
+```jsx
+// pages/_app.js
+import React from 'react'
+import { UserProvider } from '@supabase/auth-helpers-react'
+import { supabaseClient } from '@supabase/auth-helpers-nextjs'
+
+export default function App({ Component, pageProps }) {
+  return (
+    <UserProvider supabaseClient={supabaseClient}>
+      <Component {...pageProps} />
+    </UserProvider>
+  )
+}
+```
+
+You can now determine if a user is authenticated by checking that the `user` object returned by the `useUser()` hook is defined.
+
+## Client-side data fetching with RLS
+
+For [row level security](https://supabase.com/docs/learn/auth-deep-dive/auth-row-level-security) to work properly when fetching data client-side, you need to make sure to import the `{ supabaseClient }` from `# @supabase/auth-helpers-nextjs` and only run your query once the user is defined client-side in the `useUser()` hook:
+
+```js
+import { Auth } from '@supabase/ui'
+import { useUser } from '@supabase/auth-helpers-react'
+import { supabaseClient } from '@supabase/auth-helpers-nextjs'
+import { useEffect, useState } from 'react'
+
+const LoginPage = () => {
+  const { user, error } = useUser()
+  const [data, setData] = useState()
+
+  useEffect(() => {
+    async function loadData() {
+      const { data } = await supabaseClient.from('test').select('*')
+      setData(data)
+    }
+    // Only run query once user is logged in.
+    if (user) loadData()
+  }, [user])
+
+  if (!user)
+    return (
+      <>
+        {error && <p>{error.message}</p>}
+        <Auth
+          supabaseClient={supabaseClient}
+          providers={['google', 'github']}
+          socialLayout="horizontal"
+          socialButtonSize="xlarge"
+        />
+      </>
+    )
+
+  return (
+    <>
+      <button onClick={() => supabaseClient.auth.signOut()}>Sign out</button>
+      <p>user:</p>
+      <pre>{JSON.stringify(user, null, 2)}</pre>
+      <p>client-side data fetching with RLS</p>
+      <pre>{JSON.stringify(data, null, 2)}</pre>
+    </>
+  )
+}
+
+export default LoginPage
+```
+
+### Server-side rendering (SSR) - withPageAuth
+
+If you wrap your `getServerSideProps` with `withPageAuth` your props object will be augmented with the user object.
+
+```js
+// pages/profile.js
+import { withPageAuth } from '@supabase/auth-helpers-nextjs'
+
+export default function Profile({ user }) {
+  return <div>Hello {user.name}</div>
+}
+
+export const getServerSideProps = withPageAuth({ redirectTo: '/login' })
+```
+
+If there is no authenticated user, they will be redirect to your home page, unless you specify the `redirectTo` option.
+
+You can pass in your own `getServerSideProps` method, the props returned from this will be merged with the
+user props. You can also access the user session data by calling `getUser` inside of this method, eg:
+
+```js
+// pages/protected-page.js
+import { withPageAuth, getUser } from '@supabase/auth-helpers-nextjs'
+
+export default function ProtectedPage({ user, customProp }) {
+  return <div>Protected content</div>
+}
+
+export const getServerSideProps = withPageAuth({
+  redirectTo: '/foo',
+  async getServerSideProps(ctx) {
+    // Access the user object
+    const { user, accessToken } = await getUser(ctx)
+    return { props: { email: user?.email } }
+  },
+})
+```
+
+### Server-side data fetching with RLS
+
+For [row level security](https://supabase.com/docs/learn/auth-deep-dive/auth-row-level-security) to work in a server environment, you need to inject the request context into the supabase client:
+
+```js
+import {
+  User,
+  withPageAuth,
+  supabaseServerClient,
+} from '@supabase/auth-helpers-nextjs'
+
+export default function ProtectedPage({
+  user,
+  data,
+}: {
+  user: User,
+  data: any,
+}) {
+  return (
+    <>
+      <div>Protected content for {user.email}</div>
+      <pre>{JSON.stringify(data, null, 2)}</pre>
+      <pre>{JSON.stringify(user, null, 2)}</pre>
+    </>
+  )
+}
+
+export const getServerSideProps = withPageAuth({
+  redirectTo: '/',
+  async getServerSideProps(ctx) {
+    // Run queries with RLS on the server
+    const { data } = await supabaseServerClient(ctx).from('test').select('*')
+    return { props: { data } }
+  },
+})
+```
+
+### Server-side data fetching to OAuth APIs using `provider_token`
+
+When using third-party auth providers, sessions are initiated with an additional `provider_token` field which is persisted as an HTTPOnly cookie upon logging in to enabled usage on the server side. The `provider_token` can be used to make API requests to the OAuth provider's API endpoints on behalf of the logged-in user. In the following example, we fetch the user's full profile from the third-party API during SSR using their id and auth token:
+
+```js
+import { User, withPageAuth, getUser } from '@supabase/auth-helpers-nextjs'
+
+interface Profile {
+  /* ... */
+}
+
+export default function ProtectedPage({
+  user,
+  data,
+}: {
+  user: User,
+  profile: Profile,
+}) {
+  return <div>Protected content</div>
+}
+
+export const getServerSideProps = withPageAuth({
+  redirectTo: '/',
+  async getServerSideProps(ctx) {
+    // Retrieve provider_token from cookies
+    const provider_token = ctx.req.cookies['sb-provider-token']
+    // Get logged in user's third-party id from metadata
+    const { user } = await getUser(ctx)
+    const userId = user?.user_metadata.provider_id
+    const profile: Profile = await (
+      await fetch(`https://api.example.com/users/${userId}`, {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${provider_token}`,
+        },
+      })
+    ).json()
+    return { props: { profile } }
+  },
+})
+```
+
+## Protecting API routes
+
+Wrap an API Route to check that the user has a valid session. If they're not logged in the handler will return a
+401 Unauthorized.
+
+```js
+// pages/api/protected-route.js
+import {
+  withApiAuth,
+  supabaseServerClient,
+} from '@supabase/auth-helpers-nextjs'
+
+export default withApiAuth(async function ProtectedRoute(req, res) {
+  // Run queries with RLS on the server
+  const { data } = await supabaseServerClient({ req, res })
+    .from('test')
+    .select('*')
+  res.json(data)
+})
+```
+
+If you visit `/api/protected-route` without a valid session cookie, you will get a 401 response.
+
+## Protecting routes with [Nextjs Middleware](https://nextjs.org/docs/middleware)
+
+As an alternative to protecting individual pages using `getServerSideProps` with `withPageAuth`, `withMiddlewareAuth` can be used from inside a `_middleware` file to protect an entire directory. In the following example, all requests to `/protected/*` will check whether a user is signed in, if successful the request will be forwarded to the destination route, otherwise the user will be redirected to `/login` (defaults to: `/`) with a 307 Temporary Redirect response status:
+
+```ts
+// pages/protected/_middleware.ts
+import { withMiddlewareAuth } from '@supabase/auth-helpers-nextjs/middleware'
+
+export const middleware = withMiddlewareAuth({ redirectTo: '/login' })
+```
+
+It is also possible to add finer granularity based on the user logged in. I.e. you can specify a promise to determine if a specific user has permission or not.
+
+```ts
+// pages/protected/_middleware.ts
+import { withMiddlewareAuth } from '@supabase/auth-helpers-nextjs/dist/middleware'
+
+export const middleware = withMiddlewareAuth({
+  redirectTo: '/login',
+  authGuard: {
+    isPermitted: async (user) => user.email?.endsWith('@example.com') ?? false,
+    redirectTo: '/insufficient-permissions',
+  },
+})
+```
+
+## Migrating from @supabase/supabase-auth-helpers to @supabase/auth-helpers
+
+This is a step by step guide on migrating away from the `@supabase/supabase-auth-helpers` to the newly released `@supabase/auth-helpers`.
+
+1. Install `@supabase/supabase-js`, `@supabase/auth-helpers-nextjs` and `@supabase/auth-helpers-react` libraries from npm.
+2. Replace all imports of `@supabase/supabase-auth-helpers/nextjs` in your project with `@supabase/auth-helpers-nextjs`.
+3. Replace all imports of `@supabase/supabase-auth-helpers/react` in your project with `@supabase/auth-helpers-react`.
+4. Replace all instances of `withAuthRequired` in any of your NextJS pages with `withPageAuth`.
+5. Replace all instances of `withAuthRequired` in any of your NextJS API endpoints with `withApiAuth`.
+6. Uninstall `@supabase/supabase-auth-helpers`.

--- a/apps/reference/docs/guides/auth/auth-helpers/sveltekit.mdx
+++ b/apps/reference/docs/guides/auth/auth-helpers/sveltekit.mdx
@@ -1,0 +1,303 @@
+---
+id: sveltekit
+title: SvelteKit Auth Helpers
+description: Convenience helpers for implementing user authentication in SvelteKit.
+---
+
+# Supabase Auth with SvelteKit
+
+This submodule provides convenience helpers for implementing user authentication in [SvelteKit](https://kit.svelte.dev/) applications.
+
+## Installation
+
+Using [npm](https://npmjs.org):
+
+```sh
+npm install @supabase/auth-helpers-sveltekit
+
+# Main component for Svelte based frameworks (optional but recommended)
+npm install @supabase/auth-helpers-svelte
+```
+
+Using [yarn](https://yarnpkg.com/):
+
+```sh
+yarn add @supabase/auth-helpers-sveltekit
+
+# Main component for Svelte based frameworks (optional but recommended)
+yarn add @supabase/auth-helpers-svelte
+```
+
+This library supports the following tooling versions:
+
+- Node.js: `^16.15.0`
+
+## Getting Started
+
+### Configuration
+
+Set up the fillowing env vars. For local development you can set them in a `.env` file. See an [example](https://github.com/supabase/auth-helpers/blob/main/examples/sveltekit/.env.example).
+
+```bash
+# Find these in your Supabase project settings > API
+VITE_SUPABASE_URL=https://your-project.supabase.co
+VITE_SUPABASE_ANON_KEY=your-anon-key
+```
+
+### SupabaseClient and SupaAuthHelper component setup
+
+We will start off by creating a `db.ts` file inside of our `src/lib` directory. Now lets instantiate our `supabaseClient` by using our `createSupabaseClient` function from the `@supabase/auth-helpers-sveltekit` library.
+
+```ts
+// src/lib/db.ts
+import { createSupabaseClient } from '@supabase/auth-helpers-sveltekit'
+
+const { supabaseClient } = createSupabaseClient(
+  import.meta.env.VITE_SUPABASE_URL as string,
+  import.meta.env.VITE_SUPABASE_ANON_KEY as string
+)
+
+export { supabaseClient }
+```
+
+Edit your `__layout.svelte` file and add import the `SupaAuthHelper` component, the `supabaseClient` we just instantiated and the `session` store.
+
+```html
+// src/routes/__layout.svelte
+<script>
+  import { session } from '$app/stores'
+  import { supabaseClient } from '$lib/db'
+  import { SupaAuthHelper } from '@supabase/auth-helpers-svelte'
+</script>
+
+<SupaAuthHelper {supabaseClient} {session}>
+  <slot />
+</SupaAuthHelper>
+```
+
+### Hooks setup
+
+Our `hooks.ts` file is where the heavy lifting of this library happens, we need to import our function to handle the sign in, signing out and cookie creation phase. we can import all the hooks using `handleAuth` function and destructure its returned data.
+
+```ts
+// src/hooks.ts
+import { handleAuth } from '@supabase/auth-helpers-sveltekit'
+import type { GetSession, Handle } from '@sveltejs/kit'
+import { sequence } from '@sveltejs/kit/hooks'
+
+export const handle: Handle = sequence(...handleAuth())
+
+export const getSession: GetSession = async (event) => {
+  const { user, accessToken, error } = event.locals
+  return {
+    user,
+    accessToken,
+    error,
+  }
+}
+```
+
+These will create the handlers under the hood that perform different parts of the authentication flow:
+
+- `/api/auth/callback`: The `UserHelper` forwards the session details here every time `onAuthStateChange` fires on the client side. This is needed to set up the cookies for your application so that SSR works seamlessly.
+- `/api/auth/user`: You can fetch user profile information in JSON format.
+- `/api/auth/logout`: You can logout the user.
+
+### Typings
+
+In order to get the most out of TypeScript and its intellisense, you should import our types into the `app.d.ts` type definition file that comes with your SvelteKit project.
+
+```ts
+// src/app.d.ts
+/// <reference types="@sveltejs/kit" />
+// See https://kit.svelte.dev/docs/types#app
+// for information about these interfaces
+declare namespace App {
+  interface UserSession {
+    user: import('@supabase/supabase-js').User
+    accessToken?: string
+  }
+  interface Locals extends UserSession {
+    error: import('@supabase/supabase-js').ApiError
+  }
+
+  interface Session extends UserSession {} // interface Platform {} // interface Stuff {}
+}
+```
+
+### Signing out
+
+This library has provided a dedicated endpoint for you to use to sign a user out. This endpoint will sign the user out of the Gotrue server, clear the cookies that were set when the user logged in and redirect the user to a configurable path.
+
+The logout handler endpoint is `/api/auth/logout`, this will take a `GET` request which means it can be used as the href for a normal `a` tag in your html.
+
+```html
+<a href="/api/auth/logout">Sign out</a>
+```
+
+### Logout handler configuration
+
+In your `src/hooks.ts` file the logout handler is already setup and you can configure the redirect path from here.
+
+> By default the redirect path after logging out will be `/`.
+
+```ts
+export const handle = sequence(
+  ...handleAuth({
+    logout: { returnTo: '/auth/signin' },
+  })
+)
+```
+
+### Basic Setup
+
+You can now determine if a user is authenticated on the client-side by checking that the `user` object returned by the `$session` store is defined.
+
+```html
+// example
+<script>
+  import { session } from '$app/stores'
+</script>
+
+{#if !$session.user}
+<h1>I am not logged in</h1>
+{:else}
+<h1>Welcome {$session.user.email}</h1>
+<p>I am logged in!</p>
+{/if}
+```
+
+## Client-side data fetching with RLS
+
+For [row level security](https://supabase.com/docs/learn/auth-deep-dive/auth-row-level-security) to work properly when fetching data client-side, you need to make sure to import the `{ supabaseClient }` from `@supabase/auth-helpers-sveltekit` and only run your query once the user is defined client-side in the `$session`:
+
+```html
+<script>
+import Auth from 'supabase-ui-svelte';
+import { error, isLoading } from '@supabase/auth-helpers-svelte';
+import { supabaseClient } from '$lib/db';
+import { session } from '$app/stores';
+
+let loadedData = [];
+async function loadData() {
+  const { data } = await supabaseClient.from('test').select('*').single();
+  loadedData = data
+}
+
+$: {
+  if ($session.user && $session.user.id) {
+    loadData();
+  }
+}
+</script>
+
+{#if !$session.user}
+  {#if $error}
+    <p>{$error.message}</p>
+  {/if}
+  <h1>{$isLoading ? `Loading...` : `Loaded!`}</h1>
+  <Auth
+    supabaseClient={supabaseClient}
+    providers={['google', 'github']}
+  />
+{:else}
+  <a href=="/api/auth/logout">Sign out</a>
+  <p>user:</p>
+  <pre>{JSON.stringify($session.user, null, 2)}</pre>
+  <p>client-side data fetching with RLS</p>
+  <pre>{JSON.stringify(loadedData, null, 2)}</pre>
+{/if}
+```
+
+### Server-side data fetching with RLS
+
+For [row level security](https://supabase.com/docs/learn/auth-deep-dive/auth-row-level-security) to work in a server environment, you need to inject the request context into the supabase client:
+
+```html
+<!-- src/routes/profile.svelte -->
+<script>
+  export let user
+  export let data
+</script>
+
+<div>Protected content for {user.email}</div>
+<pre>{JSON.stringify(data, null, 2)}</pre>
+<pre>{JSON.stringify(user, null, 2)}</pre>
+```
+
+```ts
+// src/routes/profile.ts
+import {
+  supabaseServerClient,
+  withApiAuth,
+} from '@supabase/auth-helpers-sveltekit'
+import type { RequestHandler } from './__types/profile'
+
+interface TestTable {
+  id: string
+  created_at: string
+}
+
+interface GetOutput {
+  user: User
+  data: TestTable[]
+}
+
+export const GET: RequestHandler<GetOutput> = async ({ locals }) =>
+  withApiAuth(
+    {
+      redirectTo: '/',
+      user: locals.user,
+    },
+    async () => {
+      const { data } = await supabaseServerClient(session.accessToken)
+        .from<TestTable>('test')
+        .select('*')
+
+      return {
+        body: {
+          user: locals.user,
+          data,
+        },
+      }
+    }
+  )
+```
+
+## Protecting API routes
+
+Wrap an API Route to check that the user has a valid session. If they're not logged in the handler will return a
+303 and redirect header.
+
+```ts
+// src/routes/api/protected-route.ts
+import {
+  supabaseServerClient,
+  withApiAuth,
+} from '@supabase/auth-helpers-sveltekit'
+import type { RequestHandler } from './__types/protected-route'
+
+interface TestTable {
+  id: string
+  created_at: string
+}
+
+interface GetOutput {
+  data: TestTable[]
+}
+
+export const GET: RequestHandler<GetOutput> = async ({ locals, request }) =>
+  withApiAuth({ user: locals.user }, async () => {
+    // Run queries with RLS on the server
+    const { data } = await supabaseServerClient(request)
+      .from('test')
+      .select('*')
+
+    return {
+      status: 200,
+      body: { data },
+    }
+  })
+```
+
+If you visit `/api/protected-route` without a valid session cookie, you will get a 303 response.

--- a/apps/reference/docs/guides/auth/auth-helpers/sveltekit.mdx
+++ b/apps/reference/docs/guides/auth/auth-helpers/sveltekit.mdx
@@ -1,10 +1,9 @@
 ---
 id: sveltekit
-title: SvelteKit Auth Helpers
+title: Supabase Auth with SvelteKit
 description: Convenience helpers for implementing user authentication in SvelteKit.
+sidebar_label: SvelteKit
 ---
-
-# Supabase Auth with SvelteKit
 
 This submodule provides convenience helpers for implementing user authentication in [SvelteKit](https://kit.svelte.dev/) applications.
 

--- a/apps/reference/nav/_referenceSidebars.js
+++ b/apps/reference/nav/_referenceSidebars.js
@@ -101,7 +101,12 @@ const sidebars = {
           type: 'category',
           label: 'Auth Helpers',
           collapsed: true,
-          items: ['guides/auth/auth-helpers/auth-ui'],
+          items: [
+            'guides/auth/auth-helpers/index',
+            'guides/auth/auth-helpers/auth-ui',
+            'guides/auth/auth-helpers/nextjs',
+            'guides/auth/auth-helpers/sveltekit',
+          ],
         },
         {
           type: 'category',


### PR DESCRIPTION
- [x] Quick win: make auth helper guides available at `/docs/guides/auth/auth-helpers/`
- [ ] Fix typedoc generation in `auth-helpers`
- [ ] Replace https://supabase.com/docs/reference/auth-helpers with the typedoc generated reference
- [ ] Add redirects for the Next.js and SvelteKit guides

<img width="1165" alt="image" src="https://user-images.githubusercontent.com/5748289/190985843-d3fe18fc-e0f2-424d-b078-59701f88a4cf.png">
