### PR TITLE
fix: typo in RC release notes

### DIFF
--- a/apps/reference/_supabase_js/release-notes.md
+++ b/apps/reference/_supabase_js/release-notes.md
@@ -78,7 +78,7 @@ Previously `nullsFirst` defaults to `false` , meaning `null`s are ordered last. 
 
 ### Cookies and localstorage namespace
 
-Storage key name in the Auth library has changed to include project reference which means that existing website that had their JWT expiry set to a longer time could find their user’s logged out with this upgrade.
+Storage key name in the Auth library has changed to include project reference which means that existing websites that had their JWT expiry set to a longer time could find their users logged out with this upgrade.
 
 ```jsx
 const defaultStorageKey = `sb-${


### PR DESCRIPTION
- Fix two small typos in Cookies and localstorage paragraph

## What kind of change does this PR introduce?

Just fixing small typo in the release notes for upcoming Supabase library. 