### PR TITLE
fix: typo in docs chapter Typescript Support

### DIFF
--- a/apps/reference/_supabase_js/working-with-types.md
+++ b/apps/reference/_supabase_js/working-with-types.md
@@ -31,7 +31,7 @@ interface Database {
 }
 ```
 
-There is a different between `selects`, `inserts`, and `updates`, because often you will set default values in your database for specific columns.
+There is a difference between `selects`, `inserts`, and `updates`, because often you will set default values in your database for specific columns.
 With default values you do not need to send any data over the network, even if that column is a "required" field. Our type system is granular
 enough to handle these situations.
 


### PR DESCRIPTION
- Just a small typo under "Getting Started - Typescript Support"

## What kind of change does this PR introduce?

Just fixing small typo in the docs for v2