### PR TITLE
fix: stop dragging on storage image

### DIFF
--- a/studio/components/to-be-cleaned/Storage/StorageExplorer/FileExplorerColumn.js
+++ b/studio/components/to-be-cleaned/Storage/StorageExplorer/FileExplorerColumn.js
@@ -233,7 +233,7 @@ const FileExplorerColumn = ({
       {/* Drag drop upload CTA for when column is empty */}
       {column.items.length === 0 && column.status !== STORAGE_ROW_STATUS.LOADING && (
         <div className="h-full w-full flex flex-col items-center justify-center">
-          <img src="/img/storage-placeholder.svg" className="opacity-75" />
+          <img src="/img/storage-placeholder.svg" className="opacity-75 pointer-events-none" />
           <p className="my-3 opacity-75">Drop your files here</p>
           <p className="text-sm text-center w-40 text-scale-1100">
             Or upload them via the "Upload file" button above

--- a/studio/tsconfig.json
+++ b/studio/tsconfig.json
@@ -14,7 +14,8 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "baseUrl": ".",
-    "downlevelIteration": true
+    "downlevelIteration": true,
+    "incremental": true
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

You can drag the background image into the upload box of the storage explorer.

## What is the new behavior?

Adds pointer events none so you can no longer drag the image