### PR TITLE
docs: update `setSession` docs for auth

### DIFF
--- a/apps/reference/nav/supabase_js_sidebars.js
+++ b/apps/reference/nav/supabase_js_sidebars.js
@@ -40,9 +40,9 @@ const sidebars = {
         'generated/auth-signout',
         'generated/auth-verifyotp',
         'generated/auth-getsession',
+        'generated/auth-setsession',
         'generated/auth-getuser',
         'generated/auth-updateuser',
-        'generated/auth-setsession',
         'generated/auth-onauthstatechange',
         'generated/auth-resetpasswordforemail',
       ],
@@ -50,7 +50,7 @@ const sidebars = {
     },
     {
       type: 'category',
-      label: 'Auth (Server Only)',
+      label: 'Auth (Admin Server Only)',
       items: [
         'generated/supabase-auth-admin-api',
         'generated/auth-admin-listusers',

--- a/spec/supabase_js_v1_legacy.yml
+++ b/spec/supabase_js_v1_legacy.yml
@@ -195,11 +195,11 @@ pages:
     $ref: '@supabase/gotrue-js.GoTrueClient.setSession'
     notes: |
       - `setSession()` takes in a refresh token and uses it to refresh the session.
-      - Typically a refresh token can be used only once to obtain a new access token, however in practice each refresh token can be used multiple times within a time window that can be configured via the [`REFRESH_TOKEN_REUSE_INTERVAL`](/docs/reference/auth/config#refresh_token_reuse_interval) configuration variable. You can disable this by configuring [`REFRESH_TOKEN_ROTATION_ENABLED`](/docs/reference/auth/config#refresh_token_rotation_enabled)).
-      - When used in a server-side rendering context this method will generate a new refresh and access token on the server which will not match new ones issued in the browser. It is thus important that the `REFRESH_TOKEN_REUSE_INTERVAL` is sufficiently long to allow the browser to successfully reuse a refresh token in the browser context too.
+      - Typically, a refresh token can only be used once to obtain a new access token. However, each refresh token can be used multiple times within a time interval that can be configured with the [`REFRESH_TOKEN_REUSE_INTERVAL`](/docs/reference/auth/config#refresh_token_reuse_interval) variable. You can disable this by configuring [`REFRESH_TOKEN_ROTATION_ENABLED`](/docs/reference/auth/config#refresh_token_rotation_enabled)).
+      - When used in a server-side rendering context, this method generates a new refresh and access token on the server which will not match new ones issued in the browser. The `REFRESH_TOKEN_REUSE_INTERVAL` must be sufficiently long to allow the browser to successfully reuse a refresh token in the browser context.
     examples:
       - name: Refresh the session
-        description: Sets the session data from refresh_token and returns current session or an error if the refresh_token is invalid.
+        description: Sets the session data from refresh_token and returns the current session or an error if the refresh_token is invalid.
         isSpotlight: true
         js: |
           ```js

--- a/spec/supabase_js_v1_legacy.yml
+++ b/spec/supabase_js_v1_legacy.yml
@@ -190,6 +190,29 @@ pages:
           const session = supabase.auth.session()
           ```
 
+  auth.setSession():
+    title: 'setSession()'
+    $ref: '@supabase/gotrue-js.GoTrueClient.setSession'
+    notes: |
+      - `setSession()` takes in a refresh token and uses it to refresh the session.
+      - Typically a refresh token can be used only once to obtain a new access token, however in practice each refresh token can be used multiple times within a time window that can be configured via the [`REFRESH_TOKEN_REUSE_INTERVAL`](/docs/reference/auth/config#refresh_token_reuse_interval) configuration variable. You can disable this by configuring [`REFRESH_TOKEN_ROTATION_ENABLED`](/docs/reference/auth/config#refresh_token_rotation_enabled)).
+      - When used in a server-side rendering context this method will generate a new refresh and access token on the server which will not match new ones issued in the browser. It is thus important that the `REFRESH_TOKEN_REUSE_INTERVAL` is sufficiently long to allow the browser to successfully reuse a refresh token in the browser context too.
+    examples:
+      - name: Refresh the session
+        description: Sets the session data from refresh_token and returns current session or an error if the refresh_token is invalid.
+        isSpotlight: true
+        js: |
+          ```js
+            const { data, error } = await supabase.auth.setSession(refresh_token)
+          ```
+      - name: Use in a server-side rendering context
+        description: Sets the session of the client library in a server-side rendered context.
+        js: |
+          ```js
+            const refresh_token = req.cookies['my-refresh-token']
+            const { data, error } = await supabase.auth.setSession(refresh_token)
+          ```
+
   auth.user():
     title: 'user()'
     $ref: '@supabase/gotrue-js.GoTrueClient.user'

--- a/spec/supabase_js_v2_legacy.yml
+++ b/spec/supabase_js_v2_legacy.yml
@@ -316,17 +316,23 @@ pages:
     title: 'setSession()'
     $ref: '@supabase/gotrue-js.GoTrueClient.setSession'
     notes: |
-      - `setSession()` takes in a refresh token and uses it to get a new session.
-      - The refresh token can only be used once to obtain a new session.
-      - Refresh token rotation (see [`REFRESH_TOKEN_ROTATION_ENABLED`](https://supabase.com/docs/reference/auth/config#refresh_token_rotation_enabled)) is enabled by default on all projects to guard against replay attacks. 
-      - You can configure the [`REFRESH_TOKEN_REUSE_INTERVAL`](https://supabase.com/docs/reference/auth/config#refresh_token_reuse_interval) which provides a short window in which the same refresh token can be used multiple times in the event of concurrency or offline issues.
+      - `setSession()` takes in a refresh token and uses it to refresh the session.
+      - Typically a refresh token can be used only once to obtain a new access token, however in practice each refresh token can be used multiple times within a time window that can be configured via the [`REFRESH_TOKEN_REUSE_INTERVAL`](/docs/reference/auth/config#refresh_token_reuse_interval) configuration variable. You can disable this by configuring [`REFRESH_TOKEN_ROTATION_ENABLED`](/docs/reference/auth/config#refresh_token_rotation_enabled).
+      - When used in a server-side rendering context this method will generate a new refresh and access token on the server which will not match new ones issued in the browser. It is thus important that the `REFRESH_TOKEN_REUSE_INTERVAL` is sufficiently long to allow the browser to successfully reuse a refresh token in the browser context too.
     examples:
       - name: Refresh the session
         description: Sets the session data from refresh_token and returns current session or an error if the refresh_token is invalid.
         isSpotlight: true
         js: |
           ```js
-            const { data, error } = supabase.auth.setSession(refresh_token)
+            const { data, error } = await supabase.auth.setSession(refresh_token)
+          ```
+      - name: Use in a server-side rendering context
+        description: Sets the session of the client library in a server-side rendered context.
+        js: |
+          ```js
+            const refresh_token = req.cookies['my-refresh-token']
+            const { data, error } = await supabase.auth.setSession(refresh_token)
           ```
   auth.onAuthStateChange():
     title: 'onAuthStateChange()'

--- a/spec/supabase_js_v2_legacy.yml
+++ b/spec/supabase_js_v2_legacy.yml
@@ -317,8 +317,8 @@ pages:
     $ref: '@supabase/gotrue-js.GoTrueClient.setSession'
     notes: |
       - `setSession()` takes in a refresh token and uses it to refresh the session.
-      - Typically a refresh token can be used only once to obtain a new access token, however in practice each refresh token can be used multiple times within a time window that can be configured via the [`REFRESH_TOKEN_REUSE_INTERVAL`](/docs/reference/auth/config#refresh_token_reuse_interval) configuration variable. You can disable this by configuring [`REFRESH_TOKEN_ROTATION_ENABLED`](/docs/reference/auth/config#refresh_token_rotation_enabled).
-      - When used in a server-side rendering context this method will generate a new refresh and access token on the server which will not match new ones issued in the browser. It is thus important that the `REFRESH_TOKEN_REUSE_INTERVAL` is sufficiently long to allow the browser to successfully reuse a refresh token in the browser context too.
+      - Typically, a refresh token can only be used once to obtain a new access token. However, each refresh token can be used multiple times within a time internal that can be configured with the [`REFRESH_TOKEN_REUSE_INTERVAL`](/docs/reference/auth/config#refresh_token_reuse_interval) variable. You can disable this by configuring [`REFRESH_TOKEN_ROTATION_ENABLED`](/docs/reference/auth/config#refresh_token_rotation_enabled).
+      - When used in a server-side rendering context, this method generates a new refresh and access token on the server which will not match new ones issued in the browser. The `REFRESH_TOKEN_REUSE_INTERVAL` must be sufficiently long to allow the browser to successfully reuse a refresh token in the browser context.
     examples:
       - name: Refresh the session
         description: Sets the session data from refresh_token and returns current session or an error if the refresh_token is invalid.


### PR DESCRIPTION
The `setSession` method was missing from the v1 auth reference. Also updated the docs with clarifications on what the method does especially in a SSR context.