### PR TITLE
Chore/migrate studio turbo

### DIFF
--- a/.github/workflows/studio-build.yml
+++ b/.github/workflows/studio-build.yml
@@ -9,24 +9,23 @@ on:
       - 'studio/**'
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ matrix.node-version }}
-        cache: 'npm'
-    - name: Install deps
-      run: npm i
-      working-directory: ./studio
-    - name: Run build
-      run: npm run build
-      working-directory: ./studio
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+      - name: Install deps
+        run: npm i
+        working-directory: ./studio
+      - name: Run build
+        run: npm run build
+        working-directory: ./studio

--- a/.github/workflows/studio-tests.yml
+++ b/.github/workflows/studio-tests.yml
@@ -5,31 +5,30 @@ name: Studio Unit Tests
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
     paths:
       - 'studio/**'
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ matrix.node-version }}
-        cache: 'npm'
-    - name: Install deps
-      run: npm i
-      working-directory: ./studio
-    - name: Run tests
-      run: npm test
-      working-directory: ./studio
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+      - name: Install deps
+        run: npm i
+        working-directory: ./studio
+      - name: Run tests
+        run: npm test
+        working-directory: ./studio

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "apps/temp-community-tutorials",
     "apps/temp-docs",
     "apps/www",
-    "packages/*"
+    "packages/*",
+    "studio"
   ],
   "scripts": {
     "build": "turbo run build",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -5,11 +5,11 @@
   "types": "./index.tsx",
   "license": "MIT",
   "dependencies": {
-    "@headlessui/react": "^1.5.0",
-    "@supabase/ui": "^0.37.0-alpha.50"
+    "@headlessui/react": "^1.4.1",
+    "@supabase/ui": "0.37.0-alpha.80"
   },
   "devDependencies": {
-    "@types/react": "^17.0.37",
+    "@types/react": "17.0.11",
     "@types/react-dom": "^17.0.11",
     "config": "*",
     "tsconfig": "*",

--- a/studio/components/interfaces/Settings/Logs/Logs.utils.ts
+++ b/studio/components/interfaces/Settings/Logs/Logs.utils.ts
@@ -184,6 +184,7 @@ export const calcChartStart = (params: Partial<LogsEndpointParams>): [Dayjs, str
     trunc = 'day'
     extendValue = 7
   }
+  // @ts-ignore
   return [its.add(-extendValue, trunc), trunc]
 }
 

--- a/studio/lib/api/apiWrapper.ts
+++ b/studio/lib/api/apiWrapper.ts
@@ -30,6 +30,7 @@ export default async function apiWrapper(
     }
 
     const func = withSentry(handler)
+    // @ts-ignore
     return await func(req, res)
   } catch (error) {
     return res.status(500).json({ error })

--- a/studio/next.config.js
+++ b/studio/next.config.js
@@ -1,3 +1,6 @@
+// this is required to use shared packages in the packages directory
+const withTM = require('next-transpile-modules')(['common'])
+
 const { withSentryConfig } = require('@sentry/nextjs')
 const withPlugins = require('next-compose-plugins')
 const withBundleAnalyzer = require('@next/bundle-analyzer')({
@@ -65,7 +68,9 @@ const nextConfig = {
 }
 
 // Export all config
-const moduleExports = withPlugins([[withBundleAnalyzer({})]], nextConfig)
+const plugins = [[withBundleAnalyzer({})], withTM()]
+
+const moduleExports = withPlugins(plugins, nextConfig)
 
 const sentryWebpackPluginOptions = {
   // Additional config options for the Sentry Webpack plugin. Keep in mind that
@@ -85,4 +90,4 @@ const sentryWebpackPluginOptions = {
 module.exports =
   process.env.NEXT_PUBLIC_IS_PLATFORM === 'true'
     ? withSentryConfig(moduleExports, sentryWebpackPluginOptions)
-    : nextConfig
+    : withPlugins([withTM()], nextConfig)

--- a/studio/package-lock.json
+++ b/studio/package-lock.json
@@ -41,6 +41,7 @@
         "mobx-react-lite": "^3.2.0",
         "next": "12.0.9",
         "next-compose-plugins": "^2.2.1",
+        "next-transpile-modules": "^9.0.0",
         "openapi-types": "^9.1.0",
         "p-queue": "^6.6.2",
         "papaparse": "^5.3.1",
@@ -64,7 +65,7 @@
         "react-virtualized-auto-sizer": "^1.0.6",
         "react-window": "^1.8.6",
         "react-window-infinite-loader": "^1.0.7",
-        "recharts": "^2.1.6",
+        "recharts": "2.1.6",
         "sass": "^1.43.4",
         "scheduler": "^0.20.2",
         "semver": "^6.3.0",
@@ -109,6 +110,7 @@
         "@types/zxcvbn": "^4.4.1",
         "autoprefixer": "^10.4.2",
         "babel-loader": "^8.2.3",
+        "common": "*",
         "jest": "^27.4.0",
         "jest-canvas-mock": "^2.3.1",
         "postcss": "^8.4.6",
@@ -11870,6 +11872,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/common": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/common/-/common-0.2.5.tgz",
+      "integrity": "sha512-bjuztiY8Wcz2V9dPpa0XdF0unGWqAGsnyKDGV7g6xDcaZfpufRrxV35qhuhjwv1h0jEPeiCHWKAQFLj702jGnA==",
+      "dev": true
+    },
     "node_modules/common-path-prefix": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-3.0.0.tgz",
@@ -15374,8 +15382,7 @@
     "node_modules/graceful-fs": {
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
-      "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
-      "devOptional": true
+      "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
     },
     "node_modules/gzip-size": {
       "version": "6.0.0",
@@ -20870,6 +20877,35 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
       "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
+    },
+    "node_modules/next-transpile-modules": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/next-transpile-modules/-/next-transpile-modules-9.0.0.tgz",
+      "integrity": "sha512-VCNFOazIAnXn1hvgYYSTYMnoWgKgwlYh4lm1pKbSfiB3kj5ZYLcKVhfh3jkPOg1cnd9DP+pte9yCUocdPEUBTQ==",
+      "dependencies": {
+        "enhanced-resolve": "^5.7.0",
+        "escalade": "^3.1.1"
+      }
+    },
+    "node_modules/next-transpile-modules/node_modules/enhanced-resolve": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.10.0.tgz",
+      "integrity": "sha512-T0yTFjdpldGY8PmuXXR0PyQ1ufZpEGiHVrp7zHKB7jdR4qlmZHhONVM5AQOAWXuF/w3dnHbEQVrNptJgt7F+cQ==",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/next-transpile-modules/node_modules/tapable": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.5",
@@ -38660,6 +38696,12 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
       "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="
     },
+    "common": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/common/-/common-0.2.5.tgz",
+      "integrity": "sha512-bjuztiY8Wcz2V9dPpa0XdF0unGWqAGsnyKDGV7g6xDcaZfpufRrxV35qhuhjwv1h0jEPeiCHWKAQFLj702jGnA==",
+      "dev": true
+    },
     "common-path-prefix": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-3.0.0.tgz",
@@ -41528,8 +41570,7 @@
     "graceful-fs": {
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
-      "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
-      "devOptional": true
+      "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
     },
     "gzip-size": {
       "version": "6.0.0",
@@ -45602,6 +45643,31 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
       "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
+    },
+    "next-transpile-modules": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/next-transpile-modules/-/next-transpile-modules-9.0.0.tgz",
+      "integrity": "sha512-VCNFOazIAnXn1hvgYYSTYMnoWgKgwlYh4lm1pKbSfiB3kj5ZYLcKVhfh3jkPOg1cnd9DP+pte9yCUocdPEUBTQ==",
+      "requires": {
+        "enhanced-resolve": "^5.7.0",
+        "escalade": "^3.1.1"
+      },
+      "dependencies": {
+        "enhanced-resolve": {
+          "version": "5.10.0",
+          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.10.0.tgz",
+          "integrity": "sha512-T0yTFjdpldGY8PmuXXR0PyQ1ufZpEGiHVrp7zHKB7jdR4qlmZHhONVM5AQOAWXuF/w3dnHbEQVrNptJgt7F+cQ==",
+          "requires": {
+            "graceful-fs": "^4.2.4",
+            "tapable": "^2.2.0"
+          }
+        },
+        "tapable": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+          "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ=="
+        }
+      }
     },
     "nice-try": {
       "version": "1.0.5",

--- a/studio/package.json
+++ b/studio/package.json
@@ -47,6 +47,7 @@
     "mobx-react-lite": "^3.2.0",
     "next": "12.0.9",
     "next-compose-plugins": "^2.2.1",
+    "next-transpile-modules": "^9.0.0",
     "openapi-types": "^9.1.0",
     "p-queue": "^6.6.2",
     "papaparse": "^5.3.1",
@@ -70,7 +71,7 @@
     "react-virtualized-auto-sizer": "^1.0.6",
     "react-window": "^1.8.6",
     "react-window-infinite-loader": "^1.0.7",
-    "recharts": "^2.1.6",
+    "recharts": "2.1.6",
     "sass": "^1.43.4",
     "scheduler": "^0.20.2",
     "semver": "^6.3.0",
@@ -83,6 +84,7 @@
     "zxcvbn": "^4.4.2"
   },
   "devDependencies": {
+    "common": "*",
     "@babel/core": "^7.17.5",
     "@storybook/addon-actions": "^6.4.19",
     "@storybook/addon-essentials": "^6.4.19",


### PR DESCRIPTION
Based off from https://github.com/supabase/supabase/pull/9082, trying to fix some local issues

— Studio now uses turbo repo, under the scope name studio
We have not moved the directory though to apps/ as that would break existing PRs

— Studio now runs under the global turborepo command npm run dev
```
# in root of repo
$ npm i
$ npm run dev
```