### PR TITLE
fix: add warning on unsaved content changes

### DIFF
--- a/studio/components/to-be-cleaned/SqlEditor/TabSqlQuery.js
+++ b/studio/components/to-be-cleaned/SqlEditor/TabSqlQuery.js
@@ -78,6 +78,7 @@ const TabSqlQuery = observer(() => {
         <MonacoEditor
           error={sqlEditorStore.activeTab.sqlQueryError}
           updateSqlSnippet={updateSqlSnippet}
+          setUpdatingRequired={contentStore.setUpdatingRequired.bind(contentStore)}
         />
         <div>
           <UtilityPanel updateSqlSnippet={updateSqlSnippet} />
@@ -88,7 +89,7 @@ const TabSqlQuery = observer(() => {
 })
 export default TabSqlQuery
 
-const MonacoEditor = ({ error, updateSqlSnippet }) => {
+const MonacoEditor = ({ error, updateSqlSnippet, setUpdatingRequired }) => {
   const sqlEditorStore = useSqlStore()
   const editorRef = useRef(null)
   const monacoRef = useRef(null)
@@ -172,6 +173,10 @@ const MonacoEditor = ({ error, updateSqlSnippet }) => {
     // update sqlEditorStore with new value immediately
     // this is so any SQL run will be whatever is currently in monaco editor
     sqlEditorStore.activeTab.setQuery(value)
+
+    // inform the content store that the SQL has changed and needs to be persisted
+    // this is so we can block the tab being closed if an update is required
+    setUpdatingRequired?.()
 
     // debounce changes
     debounceUpdateSqlSnippet(value)

--- a/studio/pages/_app.tsx
+++ b/studio/pages/_app.tsx
@@ -52,6 +52,37 @@ function MyApp({ Component, pageProps }: AppPropsWithLayout) {
     handleEmailVerificationError()
   }, [])
 
+  const getSavingState = () => rootStore.content.savingState
+
+  // prompt the user if they try and leave with unsaved content store changes
+  useEffect(() => {
+    const warningText = 'You have unsaved changes - are you sure you wish to leave this page?'
+
+    const handleWindowClose = (e: BeforeUnloadEvent) => {
+      const savingState = getSavingState()
+
+      const unsavedChanges =
+        savingState === 'UPDATING_REQUIRED' ||
+        savingState === 'UPDATING' ||
+        savingState === 'UPDATING_FAILED'
+
+      if (!unsavedChanges) {
+        return
+      }
+
+      e.preventDefault()
+
+      return (e.returnValue = warningText)
+    }
+
+    window.addEventListener('beforeunload', handleWindowClose)
+
+    return () => {
+      window.removeEventListener('beforeunload', handleWindowClose)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
   const getLayout = Component.getLayout ?? ((page) => page)
 
   return (

--- a/studio/stores/project/ProjectContentStore.ts
+++ b/studio/stores/project/ProjectContentStore.ts
@@ -15,7 +15,13 @@ export interface IProjectContentStore {
   isLoading: boolean
   isInitialized: boolean
   isLoaded: boolean
-  savingState: 'IDLE' | 'CREATING' | 'CREATING_FAILED' | 'UPDATING' | 'UPDATING_FAILED'
+  savingState:
+    | 'IDLE'
+    | 'CREATING'
+    | 'CREATING_FAILED'
+    | 'UPDATING_REQUIRED'
+    | 'UPDATING'
+    | 'UPDATING_FAILED'
   error: any
   recentLogSqlSnippets: LogSqlSnippets.Content[]
 
@@ -81,6 +87,7 @@ export interface IProjectContentStore {
 
   del(id: any): Promise<{ data: boolean; error: unknown }>
   delOptimistically(id: string): { data: boolean; error: null }
+  setUpdatingRequired(): void
 }
 
 export default class ProjectContentStore implements IProjectContentStore {
@@ -102,7 +109,13 @@ export default class ProjectContentStore implements IProjectContentStore {
   recentLogSqlSnippets: LogSqlSnippets.Content[] = []
 
   state = this.STATES.INITIAL
-  savingState: 'IDLE' | 'CREATING' | 'CREATING_FAILED' | 'UPDATING' | 'UPDATING_FAILED'
+  savingState:
+    | 'IDLE'
+    | 'CREATING'
+    | 'CREATING_FAILED'
+    | 'UPDATING_REQUIRED'
+    | 'UPDATING'
+    | 'UPDATING_FAILED'
   error = null
 
   constructor(rootStore: IRootStore, options: { projectRef: string }) {
@@ -352,6 +365,12 @@ export default class ProjectContentStore implements IProjectContentStore {
   delOptimistically(id: string) {
     delete this.data[id]
     return { data: true, error: null }
+  }
+
+  setUpdatingRequired() {
+    if (this.savingState === 'IDLE' || this.savingState === 'UPDATING_FAILED') {
+      this.savingState = 'UPDATING_REQUIRED'
+    }
   }
 
   setProjectRef(ref?: string) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behaviour?

If a user closes their browser while an SQL snippet is saving, the changes will be lost.

## What is the new behaviour?

Adds a standard browser prompt to warn the user that the changes they have made will be lost if they close the window.

<img width="385" alt="Screen Shot 2022-09-22 at 4 49 33 pm" src="https://user-images.githubusercontent.com/10985857/191677663-f32ae9fd-f0f4-4ae4-8931-75601e4b0734.png">


