### PR TITLE
docs: auth helpers - added links to examples for both nextjs and sveltekit

### DIFF
--- a/apps/reference/docs/guides/auth/auth-helpers/nextjs.mdx
+++ b/apps/reference/docs/guides/auth/auth-helpers/nextjs.mdx
@@ -312,3 +312,8 @@ This is a step by step guide on migrating away from the `@supabase/supabase-auth
 4. Replace all instances of `withAuthRequired` in any of your NextJS pages with `withPageAuth`.
 5. Replace all instances of `withAuthRequired` in any of your NextJS API endpoints with `withApiAuth`.
 6. Uninstall `@supabase/supabase-auth-helpers`.
+
+## Additional Links
+
+- [Auth Helpers Source code](https://github.com/supabase/auth-helpers)
+- [Next.js example](https://github.com/supabase/auth-helpers/tree/main/examples/nextjs)

--- a/apps/reference/docs/guides/auth/auth-helpers/sveltekit.mdx
+++ b/apps/reference/docs/guides/auth/auth-helpers/sveltekit.mdx
@@ -300,3 +300,10 @@ export const GET: RequestHandler<GetOutput> = async ({ locals, request }) =>
 ```
 
 If you visit `/api/protected-route` without a valid session cookie, you will get a 303 response.
+
+## Additional Links
+
+- [Auth Helpers Source code](https://github.com/supabase/auth-helpers)
+- [SvelteKit example](https://github.com/supabase/auth-helpers/tree/main/examples/sveltekit)
+- [SvelteKit Email/Password example](https://github.com/supabase/auth-helpers/tree/main/examples/sveltekit-email-password)
+- [SvelteKit Magiclink example](https://github.com/supabase/auth-helpers/tree/main/examples/sveltekit-magic-link)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs - [Auth Helpers](https://supabase.com/docs/guides/auth/auth-helpers/)

## What is the new behavior?

Links have been added to access examples and source code for both Next.js and. SvelteKit for the Auth Helpers

