### PR TITLE
rename from storage caching to storage cdn

### DIFF
--- a/apps/reference/docs/architecture.mdx
+++ b/apps/reference/docs/architecture.mdx
@@ -27,7 +27,7 @@ Most notably, we use Postgres rather than a NoSQL store. This choice was deliber
 | Realtime                   | Broadcast              | Alpha | [Link](/docs/guides/realtime/broadcast)          |
 | Realtime                   | Presence               | Alpha | [Link](/docs/guides/realtime/presence)           |
 | Storage                    |                        | Beta  | [Link](/docs/guides/storage)                     |
-| Storage                    | CDN                    | Beta  | [Link](/docs/guides/storage-caching)             |
+| Storage                    | CDN                    | Beta  | [Link](/docs/guides/storage-cdn)                 |
 | Edge Functions             |                        | Beta  | [Link](/docs/guides/functions)                   |
 | Auth                       | OAuth Providers        | Beta  | [Link](/docs/guides/auth/auth-apple)             |
 | Auth                       | Passwordless           | Beta  | [Link](/guides/auth/auth-magic-link)             |

--- a/apps/reference/docs/guides/storage-cdn.mdx
+++ b/apps/reference/docs/guides/storage-cdn.mdx
@@ -1,8 +1,8 @@
 ---
-id: storage-caching
-title: Storage Caching
-description: How Supabase Storage caches objects
-sidebar_label: Caching
+id: storage-cdn
+title: Storage CDN
+description: How Supabase Storage caches objects with a CDN
+sidebar_label: CDN
 ---
 
 ## CDN basics

--- a/apps/reference/docs/guides/storage-cdn.mdx
+++ b/apps/reference/docs/guides/storage-cdn.mdx
@@ -21,12 +21,14 @@ By default, assets are cached both in the CDN and in the user’s browser for 1 
 
 You can modify this cache time when you are [uploading](https://supabase.com/docs/reference/javascript/next/storage-from-upload) or [updating](https://supabase.com/docs/reference/javascript/next/storage-from-update) an object by modifying the `cacheControl` parameter.
 
-The cache status of a particular request is sent in the `cf-cache-status` header. A cache status of `MISS` indicates that the CDN node did not have the object in its cache and had to ping the origin to get it. A cache status of `HIT` indicates that the object was sent directly from the CDN.
-
-## Performance
-
 If you expect the object to not change at a given URL, setting a longer cache duration is preferable.
 
 If you need to update the version of the object stored in the CDN, there are various cache-busting techniques you can use. The most common way to do this is to add a version query parameter in the URL. For example, you can use a URL like `/storage/v1/object/sign/profile-pictures/cat.jpg?token=eyJh...&version=1` in your applications and set a long cache time of 1 year. When you want to update the cat picture, you can increment the version query parameter in the URL. The CDN will treat `/storage/v1/object/sign/profile-pictures/cat.jpg?token=eyJh...&version=2` as a new object and pings the origin for the updated version.
 
 Note that CDNs might still evict your object from their cache if it has not been requested for a while from a specific region. For example, if no user from United States requests your object, it will be removed from the CDN cache even if you set a very long cache control duration.
+
+The cache status of a particular request is sent in the `cf-cache-status` header. A cache status of `MISS` indicates that the CDN node did not have the object in its cache and had to ping the origin to get it. A cache status of `HIT` indicates that the object was sent directly from the CDN.
+
+## Public vs Private Buckets
+
+Objects in public buckets do not require any Authorization to access objects. This leads to a better cache hit rate compared to private buckets. For private buckets, permissions for accessing each object is checked on a per user level. For example, if two different users access the same object in a private bucket from the same region, it results in a cache miss for both the users since they might have different security policies attached to them. On the other hand, if two different users access the same object in a public bucket from the same region, it results in a cache hit for the second user.

--- a/apps/reference/docs/guides/storage.mdx
+++ b/apps/reference/docs/guides/storage.mdx
@@ -24,7 +24,7 @@ organize your files. You can store them in whichever folder structure suits your
 
 Buckets are distinct containers for files and folders. You can think of them like "super folders".
 Generally you would create distinct buckets for different Security and Access Rules. For example, you might
-keep all public files in a "public" bucket, and other files that require logged-in access in a "restricted" bucket.
+keep all video files in a "video" bucket, and profile pictures in an "avatar" bucket.
 
 <div class="video-container">
   <iframe
@@ -241,14 +241,18 @@ create policy "Public Access"
 </TabItem>
 </Tabs>
 
-## Accessing objects
+## Public and Private Buckets
+
+Storage buckets are private by default.
 
 For private buckets, you can access objects via the [download](/docs/reference/javascript/storage-from-download) method. This corresponds to `/object/auth/` API endpoint.
 Alternatively, you can create a publicly shareable URL with an expiry date using the [createSignedUrl](/docs/reference/javascript/storage-from-createsignedurl) method
 which calls the `/object/sign/` API.
 
 For public buckets, you can access the assets directly without a token or an Authorisation header. The [getPublicUrl](/docs/reference/javascript/storage-from-getpublicurl)
-helper method returns the full public URL for an asset. This calls the `/object/public/` API endpoint internally.
+helper method returns the full public URL for an asset. This calls the `/object/public/` API endpoint internally. While no authorization is required for accessing objects in a public bucket, proper [access control](#access-control) is required for other operations like uploading, deleting objects from public buckets as well.
+
+Public buckets also tend to have [better performance](/docs/guides/storage-cdn#public-vs-private-buckets).
 
 <details>
 <summary>Advanced: reverse proxy</summary>

--- a/apps/reference/nav/_referenceSidebars.js
+++ b/apps/reference/nav/_referenceSidebars.js
@@ -188,7 +188,7 @@ const sidebars = {
       type: 'category',
       label: 'Storage',
       collapsed: true,
-      items: ['guides/storage', 'guides/storage-caching'],
+      items: ['guides/storage', 'guides/storage-cdn'],
     },
     {
       type: 'category',

--- a/apps/www/next.config.js
+++ b/apps/www/next.config.js
@@ -132,6 +132,11 @@ module.exports = withMDX({
       },
       {
         permanent: true,
+        source: '/docs/guides/storage-caching',
+        destination: '/docs/guides/storage-cdn',
+      },
+      {
+        permanent: true,
         source: '/database/Database',
         destination: '/database',
       },


### PR DESCRIPTION
first commit renames storage caching to storage cdn (I think more people are searching for storage cdn than storage caching)

second commit adds performance implications of private and public buckets