### PR TITLE
feat: secondary nav show and hide

### DIFF
--- a/studio/components/layouts/ProjectLayout/ProductMenuBar.tsx
+++ b/studio/components/layouts/ProjectLayout/ProductMenuBar.tsx
@@ -1,5 +1,6 @@
-import { FC, ReactNode } from 'react'
+import { FC, ReactNode, useState } from 'react'
 import { useFlag } from 'hooks'
+import { IconArrowLeft, IconArrowRight } from '@supabase/ui'
 
 interface Props {
   title: string
@@ -9,23 +10,40 @@ interface Props {
 const ProductMenuBar: FC<Props> = ({ title, children }) => {
   const ongoingIncident = useFlag('ongoingIncident')
   const maxHeight = ongoingIncident ? 'calc(100vh - 44px)' : '100vh'
+  const [isOpen, setIsOpen] = useState(true)
 
   return (
     <div
       style={{ height: maxHeight, maxHeight }}
       className={[
-        'hide-scrollbar flex w-64 flex-col border-r', // Layout
+        'hide-scrollbar flex w-64 flex-col border-r transition-all ease-out duration-500', // Layout
         'bg-sidebar-linkbar-light', // Light mode
         'dark:bg-sidebar-linkbar-dark dark:border-dark ', // Dark mode
+        `${!isOpen ? 'w-16' : ''}`,
       ].join(' ')}
     >
       <div
-        className="dark:border-dark flex max-h-12 items-center border-b px-6"
+        className="dark:border-dark flex max-h-12 items-center border-b px-6 justify-between"
         style={{ minHeight: '3rem' }}
       >
-        <h4 className="text-lg">{title}</h4>
+        <h4 className={`text-lg ${!isOpen ? 'hidden' : ''}`}>{title}</h4>
+        {isOpen ? (
+          <IconArrowLeft
+            class="cursor-pointer"
+            size={18}
+            strokeWidth={2}
+            onClick={() => setIsOpen(!isOpen)}
+          />
+        ) : (
+          <IconArrowRight
+            class="cursor-pointer"
+            size={18}
+            strokeWidth={2}
+            onClick={() => setIsOpen(!isOpen)}
+          />
+        )}
       </div>
-      <div className="flex-grow overflow-y-auto">{children}</div>
+      <div className={`flex-grow overflow-y-auto ${!isOpen ? 'hidden' : ''}`}>{children}</div>
     </div>
   )
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Studio Feature

## What is the current behavior?

This is linked to #9018 - It seems that the secondary menu makes it hard for the studio to be used on a mobile device and is restricted

## What is the new behavior?

A button has been added on the secondary nav so that you can show and hide the menu:


https://user-images.githubusercontent.com/22655069/191943823-e2a6973a-4229-402b-88cd-660186b27885.mov

## Additional context

Not sure if the button should only be shown on smaller devices?

Closes #9018
