### PR TITLE
docs: consolidate database Realtime tips with Postgres Changes guide

### DIFF
--- a/apps/reference/docs/guides/database.mdx
+++ b/apps/reference/docs/guides/database.mdx
@@ -85,43 +85,6 @@ You can enable Postgres extensions with the click of a button within the Supabas
 
 ## Tips
 
-### Realtime
-
-Supabase provides a realtime engine on top of Postgres, so that you can listen to changes as they happen.
-Our realtime engine uses the built-in replication functionality of Postgres.
-
-Realtime server broadcasts database changes to authorized users depending on your Row Level Security (RLS) policies.
-We recommend that you enable row level security and set row security policies on tables that you add to the publication.
-However, you may choose to disable RLS on a table and have changes broadcast to all connected clients.
-
-You can manage the realtime system, simply by
-[updating](/docs/guides/database/replication) the `supabase_realtime` publication.
-
-For example to enable realtime only for individual tables:
-
-```sql
-begin;
-  -- remove the realtime publication
-  drop publication if exists supabase_realtime;
-
-  -- re-create the publication but don't enable it for any tables
-  create publication supabase_realtime;
-commit;
-
--- add a table to the publication
-alter publication supabase_realtime add table products;
-
--- add other tables to the publication
-alter publication supabase_realtime add table posts;
-```
-
-By default only "new" values are sent, but if you want to receive the old record (previous values) whenever you `update` or `delete` a record,
-you can update the replica identity of your tables, setting it to `full`:
-
-```sql
-alter table your_table replica identity full;
-```
-
 Read about resetting your database password [here](/docs/guides/database/managing-passwords) and changing the timezone of your server [here](/docs/guides/database/managing-timezones).
 
 ## Next steps

--- a/apps/reference/docs/guides/realtime/postgres-changes.mdx
+++ b/apps/reference/docs/guides/realtime/postgres-changes.mdx
@@ -4,15 +4,35 @@ title: Postgres Changes
 description: Getting started with Realtime's Postgres Changes feature
 ---
 
-Supabase Postgres Changes enable clients to listen to Postgres database events, specifically INSERT, UPDATE, and DELETE events.
+Supabase Postgres Changes listen for database changes and sends them to clients. Clients are required to subscribe with a JWT dictating which changes they are allowed to receive based on the database's [Row Level Security](/docs/guides/auth/row-level-security).
 
-Clients can elect to get changes for all tables in the public schema, a specific table, or a specific column's value. Replication is not enabled by default—enable it for the entities you are interested in the [Dashboard](https://app.supabase.com/project/_/database/replication). 
+:::caution
+Anyone with access to a valid JWT signed with the project's JWT secret is able to listen to your database's changes, unless tables have [Row Level Security](/docs/guides/auth/row-level-security) enabled and policies in place.
+:::
 
-Anyone with access to a valid JWT signed with the project's JWT secret is able to listen to database changes, unless the tables enabled for replication are protected with [Row Level Security](/docs/guides/auth/row-level-security). 
+Clients can choose to receive `INSERT`, `UPDATE`, `DELETE`, or `*` (all) changes for all changes in a schema, a table in a schema, or a column's value in a table.Your clients can only listen to tables in the `public` schema and you must first enable the tables you want your clients to listen to. You can do this in the [Replication](https://app.supabase.com/project/_/database/replication) section in the Dashboard or with the [SQL editor](https://app.supabase.com/project/_/sql):
 
-The postgres changes functionality is supported by supabase-js v2 release candidate.
+```sql
+begin;
+  -- remove the supabase_realtime publication
+  drop publication if exists supabase_realtime;
 
-To listen to all events on all tables in the public schema:
+  -- re-create the supabase_realtime publication with no tables
+  create publication supabase_realtime;
+commit;
+
+-- add a table to the publication
+alter publication supabase_realtime add table messages;
+```
+
+By default, only `new` record changes are sent but if you want to receive the `old` record (previous values) whenever you `UPDATE` or `DELETE` a record,
+you can set the `replica identity` of your table to `full`:
+
+```sql
+alter table messages replica identity full;
+```
+
+To listen to all changes in the `public` schema:
 
 ```js
 const { createClient } = require('@supabase/supabase-js')
@@ -23,24 +43,28 @@ const supabase = createClient(
 )
 
 /*
-  The name of the channel can be set to any string.
-  Event can be either INSERT, UPDATE, DELETE, or * for all events.
+  Channel name can be any string.
+  Event name can can be one of:
+    - INSERT
+    - UPDATE
+    - DELETE
+    - *
 */
 const channel = supabase
-  .channel('db-changes')
-  .on('postgres_changes', { event: '*', schema: '*' }, (payload) =>
+  .channel('schema-db-changes')
+  .on('postgres_changes', { event: '*', schema: 'public' }, (payload) =>
     console.log(payload)
   )
   .subscribe()
 ```
 
-To listen to INSERT events on the messages table in the public schema:
+To listen to changes on a table in the `public` schema:
 
 ```js
-// Setup
+// Supabase client setup
 
 const channel = supabase
-  .channel('db-changes')
+  .channel('table-db-changes')
   .on(
     'postgres_changes',
     { event: 'INSERT', schema: 'public', table: 'messages' },
@@ -49,31 +73,36 @@ const channel = supabase
   .subscribe()
 ```
 
-To listen to UPDATE events only when a specific column matches a value:
+To listen to changes when a column's value in a table matches a client-specified value:
 
 ```js
-// Setup
+// Supabase client setup
 
 const channel = supabase
-  .channel('db-changes')
+  .channel('value-db-changes')
   .on(
     'postgres_changes',
-    { event: 'UPDATE', schema: 'public', table: 'messages', filter: 'id=eq.1' },
+    {
+      event: 'UPDATE',
+      schema: 'public',
+      table: 'messages',
+      filter: 'body=eq.hey',
+    },
     (payload) => console.log(payload)
   )
   .subscribe()
 ```
 
-Clients can also mix and match and listen to different events and schema/tables/filters:
+To listen to different events and schema/tables/filters combinations with the same channel:
 
 ```js
-// Setup
+// Supabase client setup
 
 const channel = supabase
   .channel('db-changes')
   .on(
     'postgres_changes',
-    { event: '*', schema: 'public', table: 'messages', filter: 'id=eq.23' },
+    { event: '*', schema: 'public', table: 'messages', filter: 'body=eq.bye' },
     (payload) => console.log(payload)
   )
   .on(


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the new behavior?

Move the Realtime tips in the Database section to Realtime Postgres Changes guide.
