### PR TITLE
feat: studio checkbox boolean outline colour

### DIFF
--- a/studio/styles/grid.scss
+++ b/studio/styles/grid.scss
@@ -346,7 +346,9 @@
 
 .sb-grid-checkbox-editor__input {
   @apply h-4 w-4;
+  outline: 5px auto -webkit-focus-ring-color;
 }
+
 
 /*
   DateEditor

--- a/studio/styles/grid.scss
+++ b/studio/styles/grid.scss
@@ -346,9 +346,8 @@
 
 .sb-grid-checkbox-editor__input {
   @apply h-4 w-4;
-  outline: 5px auto -webkit-focus-ring-color;
+  outline: 4px auto -webkit-focus-ring-color;
 }
-
 
 /*
   DateEditor


### PR DESCRIPTION
## What kind of change does this PR introduce?

Studio Feature - Table Editor

## What is the current behavior?

This was highlighted on [Discord](https://discord.com/channels/839993398554656828/1022823708072628246) where the boolean in line editor checkbox is unreadable sometimes.

## What is the new behavior?

The checkbox is changed to use the browsers default outline for the checkbox to become easier to see:
<img width="575" alt="Screenshot 2022-09-26 at 13 05 56" src="https://user-images.githubusercontent.com/22655069/192272775-871019d3-296c-4bfb-b0ef-d0b83ed1e9a2.png">

