### PR TITLE
Remove python

### DIFF
--- a/studio/components/interfaces/Home/NewProjectPanel/APIKeys.tsx
+++ b/studio/components/interfaces/Home/NewProjectPanel/APIKeys.tsx
@@ -17,7 +17,6 @@ const APIKeys = () => {
 
   const availableLanguages = [
     { name: 'Javascript', key: 'js' },
-    { name: 'Python', key: 'python' },
     { name: 'Dart', key: 'dart' },
   ]
   const [selectedLanguage, setSelectedLanguage] = useState(availableLanguages[0])


### PR DESCRIPTION
Python client library isn't officially supported at the moment, so we'll just keep js and dart