### PR TITLE
Fix formatting and inline CORS headers

### DIFF
--- a/apps/reference/docs/guides/functions.mdx
+++ b/apps/reference/docs/guides/functions.mdx
@@ -290,12 +290,18 @@ We recommend using hyphens to name functions because hyphens are the most URL-fr
 We recommend adding a check to handle [CORS Preflight](https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request) requests in your edge function to be able to invoke the function from browsers.
 
 ```ts
+export const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey',
+}
+
 serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response('ok', { headers: corsHeaders })
   }
   ...
 })
+```
 
 ## Limitations
 


### PR DESCRIPTION
This fixes a formatting issue in the page and inlines CORS headers in the example.