### PR TITLE
Remove client side validation for non null columns in row editor

### DIFF
--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/InputField.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/InputField.tsx
@@ -72,7 +72,13 @@ const InputField: FC<Props> = ({
         error={errors[field.name]}
         onChange={(event: any) => onUpdateField({ [field.name]: event.target.value })}
         actions={
-          <Button type="default" htmlType="button" onClick={onViewForeignKey} icon={<IconLink />}>
+          <Button
+            disabled={field.value.length === 0}
+            type="default"
+            htmlType="button"
+            onClick={onViewForeignKey}
+            icon={<IconLink />}
+          >
             View data
           </Button>
         }

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.utils.ts
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.utils.ts
@@ -75,14 +75,6 @@ export const validateFields = (fields: RowField[]) => {
       }
     }
     if (field.isIdentity || field.defaultValue) return
-    if (
-      !field.isNullable &&
-      typeof field.value === 'string' &&
-      field.value.length === 0 &&
-      field.defaultValue === null
-    ) {
-      errors[field.name] = `Please assign a value for this field`
-    }
   })
   return errors
 }


### PR DESCRIPTION
Resolves https://github.com/supabase/supabase/issues/5707

Instead, let the BE handle the validation and return any errors that come back

Resolves https://github.com/supabase/supabase/issues/7452 too

Disables View Data button for a field in the row editor if it has a foreign key, if the field is empty