### PR TITLE
Chore/update grid behaviour on esc

### DIFF
--- a/studio/components/grid/components/common/BlockKeys.tsx
+++ b/studio/components/grid/components/common/BlockKeys.tsx
@@ -1,9 +1,10 @@
-import * as React from 'react'
+import { FC, useCallback, KeyboardEvent, ReactNode } from 'react'
 
-type BlockKeysProps = {
+interface BlockKeysProps {
+  value: string | null
+  children: ReactNode
   onEscape?: (value: string | null) => void
   onEnter?: (value: string | null) => void
-  value: string | null
 }
 
 /**
@@ -11,9 +12,9 @@ type BlockKeysProps = {
  * We use this with cell editor to allow editor component to handle keys.
  * Example: press enter to add newline on textEditor
  */
-export const BlockKeys: React.FC<BlockKeysProps> = ({ onEscape, onEnter, value, children }) => {
-  const handleKeyDown = React.useCallback(
-    (ev: React.KeyboardEvent<HTMLDivElement>) => {
+export const BlockKeys: FC<BlockKeysProps> = ({ value, children, onEscape, onEnter }) => {
+  const handleKeyDown = useCallback(
+    (ev: KeyboardEvent<HTMLDivElement>) => {
       switch (ev.key) {
         case 'Escape':
           ev.stopPropagation()
@@ -32,7 +33,7 @@ export const BlockKeys: React.FC<BlockKeysProps> = ({ onEscape, onEnter, value, 
   )
 
   function onBlur() {
-    if (onEscape) onEscape(value)
+    if (onEnter) onEnter(value)
   }
 
   return (

--- a/studio/components/grid/components/common/BlockKeys.tsx
+++ b/studio/components/grid/components/common/BlockKeys.tsx
@@ -21,7 +21,7 @@ export const BlockKeys: React.FC<BlockKeysProps> = ({ onEscape, onEnter, value, 
           break
         case 'Enter':
           ev.stopPropagation()
-          if (onEnter) onEnter(value)
+          if (!ev.shiftKey && onEnter) onEnter(value)
           break
       }
     },

--- a/studio/components/grid/components/common/BlockKeys.tsx
+++ b/studio/components/grid/components/common/BlockKeys.tsx
@@ -21,7 +21,10 @@ export const BlockKeys: React.FC<BlockKeysProps> = ({ onEscape, onEnter, value, 
           break
         case 'Enter':
           ev.stopPropagation()
-          if (!ev.shiftKey && onEnter) onEnter(value)
+          if (!ev.shiftKey && onEnter) {
+            ev.preventDefault()
+            onEnter(value)
+          }
           break
       }
     },

--- a/studio/components/grid/components/editor/TextEditor.tsx
+++ b/studio/components/grid/components/editor/TextEditor.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import { useState, useCallback } from 'react'
 import { EditorProps } from '@supabase/react-data-grid'
 import { useTrackedState } from '../../store'
 import { BlockKeys, MonacoEditor, NullValue, EmptyValue } from '../common'
@@ -10,12 +10,17 @@ export function TextEditor<TRow, TSummaryRow = unknown>({
   onRowChange,
 }: EditorProps<TRow, TSummaryRow>) {
   const state = useTrackedState()
-  const [isPopoverOpen, setIsPopoverOpen] = React.useState(true)
+  const [isPopoverOpen, setIsPopoverOpen] = useState(true)
   const gridColumn = state.gridColumns.find((x) => x.name == column.key)
   const initialValue = row[column.key as keyof TRow] as unknown as string
-  const [value, setValue] = React.useState<string | null>(initialValue)
+  const [value, setValue] = useState<string | null>(initialValue)
 
-  const onEscape = React.useCallback((newValue: string | null) => {
+  const cancelChanges = useCallback(() => {
+    onRowChange(row, true)
+    setIsPopoverOpen(false)
+  }, [])
+
+  const saveChanges = useCallback((newValue: string | null) => {
     onRowChange({ ...row, [column.key]: newValue }, true)
     setIsPopoverOpen(false)
   }, [])
@@ -33,7 +38,7 @@ export function TextEditor<TRow, TSummaryRow = unknown>({
       sideOffset={-35}
       className="rounded-none"
       overlay={
-        <BlockKeys value={value} onEscape={onEscape}>
+        <BlockKeys value={value} onEscape={cancelChanges} onEnter={saveChanges}>
           <MonacoEditor
             width={`${gridColumn?.width || column.width}px`}
             value={value ?? ''}

--- a/studio/components/grid/components/editor/TextEditor.tsx
+++ b/studio/components/grid/components/editor/TextEditor.tsx
@@ -44,6 +44,10 @@ export function TextEditor<TRow, TSummaryRow = unknown>({
             value={value ?? ''}
             onChange={onChange}
           />
+          <div className="flex items-center justify-end p-2 bg-scale-400 space-x-2">
+            <p className="text-xs text-scale-1100">Save changes</p>
+            <code className="text-xs">⏎</code>
+          </div>
         </BlockKeys>
       }
     >

--- a/studio/components/to-be-cleaned/SqlEditor/TabSqlQuery.js
+++ b/studio/components/to-be-cleaned/SqlEditor/TabSqlQuery.js
@@ -290,7 +290,7 @@ const UtilityTabResults = observer(() => {
       <div className="bg-table-header-light dark:bg-table-header-dark">
         <p className="m-0 border-0 px-6 py-4 text-sm text-scale-1000">
           Click <code>RUN</code> or hit{' '}
-          <code>{window.navigator.platform.match(/^Mac/) ? 'cmd' : 'ctrl'} + ⏎</code> to execute
+          <code>{window.navigator.platform.match(/^Mac/) ? '⌘' : 'Ctrl'} + Enter</code> to execute
           your query.
         </p>
       </div>


### PR DESCRIPTION
Resolves https://github.com/supabase/supabase/issues/8634

This only affects the grid which involves using monaco editor (TextEditor and JsonEditor)
Hitting `Enter` will save + commit the changes in the cell
If the user hits `Esc` or clicks out of the cell -> changes will be lost

This also resolves an issue i found while fixing this, whereby for TextEditor you can't actually discard your changes once you're in the editing state i think

Also added a helper below to communicate that
![image](https://user-images.githubusercontent.com/19742402/192480679-6db65c2e-db7a-485b-a216-4b3b3b76d71d.png)
