### PR TITLE
feat: studio logs explorer templates sort

### DIFF
--- a/studio/components/interfaces/Settings/Logs/Logs.constants.ts
+++ b/studio/components/interfaces/Settings/Logs/Logs.constants.ts
@@ -163,6 +163,7 @@ limit 100
   },
   {
     label: 'Error Count by User',
+    description: 'Count of errors by users',
     mode: 'custom',
     searchString: `select
   count(t.timestamp) as count,

--- a/studio/pages/project/[ref]/logs-explorer/templates.tsx
+++ b/studio/pages/project/[ref]/logs-explorer/templates.tsx
@@ -14,59 +14,61 @@ export const LogsTemplatesPage: NextPageWithLayout = () => {
   return (
     <div>
       <div className="grid grid-cols-3 gap-6">
-        {TEMPLATES.filter((template) => template.mode === 'custom').map((template, i) => {
-          const [showPreview, setShowPreview] = useState(false)
-          return (
-            <CardButton
-              key={i}
-              title={template.label}
-              icon={
-                <div
-                  className="text-scale-100 bg-scale-1200 duration-400 group-hover:bg-brand-900 group-hover:text-brand-1200 flex h-6
+        {TEMPLATES.sort((a, b) => a.label!.localeCompare(b.label!))
+          .filter((template) => template.mode === 'custom')
+          .map((template, i) => {
+            const [showPreview, setShowPreview] = useState(false)
+            return (
+              <CardButton
+                key={i}
+                title={template.label}
+                icon={
+                  <div
+                    className="text-scale-100 bg-scale-1200 duration-400 group-hover:bg-brand-900 group-hover:text-brand-1200 flex h-6
                     w-6
                     items-center
                     justify-center
                     rounded
                     transition-colors
                   "
-                >
-                  <div className="scale-100 group-hover:scale-110">
-                    <IconCode size={12} strokeWidth={2} />
-                  </div>
-                </div>
-              }
-              containerHeightClassName="h-40"
-              linkHref={`/project/${ref}/logs-explorer?q=${encodeURI(template.searchString)}`}
-              description={template.description}
-              footer={
-                <div className="flex flex-row justify-end">
-                  <Popover
-                    onOpenChange={setShowPreview}
-                    open={showPreview}
-                    className="bg-scale-100 rounded-lg"
-                    size="content"
-                    overlay={
-                      <pre className="bg-scale-100 whitespace-pre-line break-words rounded-lg p-4 text-sm">
-                        {template.searchString}
-                      </pre>
-                    }
                   >
-                    <Button
-                      type="default"
-                      as="span"
-                      onClick={(e) => {
-                        e.preventDefault()
-                        setShowPreview(!showPreview)
-                      }}
+                    <div className="scale-100 group-hover:scale-110">
+                      <IconCode size={12} strokeWidth={2} />
+                    </div>
+                  </div>
+                }
+                containerHeightClassName="h-40"
+                linkHref={`/project/${ref}/logs-explorer?q=${encodeURI(template.searchString)}`}
+                description={template.description}
+                footer={
+                  <div className="flex flex-row justify-end">
+                    <Popover
+                      onOpenChange={setShowPreview}
+                      open={showPreview}
+                      className="bg-scale-100 rounded-lg"
+                      size="content"
+                      overlay={
+                        <pre className="bg-scale-100 whitespace-pre-line break-words rounded-lg p-4 text-sm">
+                          {template.searchString}
+                        </pre>
+                      }
                     >
-                      Preview
-                    </Button>
-                  </Popover>
-                </div>
-              }
-            />
-          )
-        })}
+                      <Button
+                        type="default"
+                        as="span"
+                        onClick={(e) => {
+                          e.preventDefault()
+                          setShowPreview(!showPreview)
+                        }}
+                      >
+                        Preview
+                      </Button>
+                    </Popover>
+                  </div>
+                }
+              />
+            )
+          })}
       </div>
     </div>
   )

--- a/studio/pages/project/[ref]/logs-explorer/templates.tsx
+++ b/studio/pages/project/[ref]/logs-explorer/templates.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { useRouter } from 'next/router'
 import { observer, useStaticRendering } from 'mobx-react-lite'
-import { IconCode, Badge, Collapsible, Button, Popover } from '@supabase/ui'
+import { IconCode, Badge, Collapsible, Button, Popover } from 'ui'
 import { TEMPLATES } from 'components/interfaces/Settings/Logs'
 import LogsExplorerLayout from 'components/layouts/LogsExplorerLayout/LogsExplorerLayout'
 import CardButton from 'components/ui/CardButton'
@@ -24,12 +24,12 @@ export const LogsTemplatesPage: NextPageWithLayout = () => {
                 title={template.label}
                 icon={
                   <div
-                    className="text-scale-100 bg-scale-1200 duration-400 group-hover:bg-brand-900 group-hover:text-brand-1200 flex h-6
-                    w-6
-                    items-center
-                    justify-center
-                    rounded
+                    className="duration-400 flex h-6 w-6 items-center justify-center rounded
+                    bg-scale-1200
+                    text-scale-100
                     transition-colors
+                    group-hover:bg-brand-900
+                    group-hover:text-brand-1200
                   "
                   >
                     <div className="scale-100 group-hover:scale-110">
@@ -45,10 +45,10 @@ export const LogsTemplatesPage: NextPageWithLayout = () => {
                     <Popover
                       onOpenChange={setShowPreview}
                       open={showPreview}
-                      className="bg-scale-100 rounded-lg"
+                      className="rounded-lg bg-scale-100"
                       size="content"
                       overlay={
-                        <pre className="bg-scale-100 whitespace-pre-line break-words rounded-lg p-4 text-sm">
+                        <pre className="whitespace-pre-line break-words rounded-lg bg-scale-100 p-4 text-sm">
                           {template.searchString}
                         </pre>
                       }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Studio Logs Explorer - Templates

## What is the current behavior?

Minor change to the sort order of the templates:

<img width="1311" alt="Screenshot 2022-09-27 at 15 02 44" src="https://user-images.githubusercontent.com/22655069/192548693-17a60ea4-c390-4e1d-b19d-d8cc7740e193.png">


## What is the new behavior?

Template are now in order:

<img width="1311" alt="Screenshot 2022-09-27 at 15 03 05" src="https://user-images.githubusercontent.com/22655069/192548781-a2173b2c-9f03-45cf-b3ae-813f4eee398d.png">
