### PR TITLE
Fix typo - Line 29 - 'your' > 'you''

### DIFF
--- a/apps/reference/docs/guides/api/generating-types.mdx
+++ b/apps/reference/docs/guides/api/generating-types.mdx
@@ -26,7 +26,7 @@ Important notes:
 
 - Since the generator uses JSON API, there is no way to determine if a column is an Array. It will generate array types as `string`, even though Supabase handles this automatically and returns arrays.
   You can fix this manually in the files by changing the type, e.g. `names: string` -> `names: string[]`
-- The types won't automatically stay in sync with your database, so make sure to regenerate your types after your make changes to your database.
+- The types won't automatically stay in sync with your database, so make sure to regenerate your types after you make changes to your database.
 
 After you have generated your types, you can use them in your TypeScript projects:
 


### PR DESCRIPTION
make sure to regenerate your types after your (change to 'you') make changes to your database.

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
