### PR TITLE
fix: Deleting a column with a filter still tries to filter by that column

### DIFF
--- a/studio/components/grid/SupabaseGrid.utils.ts
+++ b/studio/components/grid/SupabaseGrid.utils.ts
@@ -79,10 +79,20 @@ export function initTable(
       ? onLoadStorage(props.storageRef, table.name, table.schema)
       : undefined
 
-    // Load sort and filters via URL param only if given
+    // Check for saved state on initial load and also, load sort and filters via URL param only if given
     // Otherwise load from local storage to resume user session
-    if (sort === undefined && filter === undefined && (savedState?.sorts || savedState?.filters)) {
-      return { savedState: { sorts: savedState.sorts, filters: savedState.filters } }
+    if (
+      !state.isInitialComplete &&
+      sort === undefined &&
+      filter === undefined &&
+      (savedState?.sorts || savedState?.filters)
+    ) {
+      return {
+        savedState: {
+          sorts: savedState.sorts,
+          filters: savedState.filters,
+        },
+      }
     }
 
     const gridColumns = getGridColumns(table, {

--- a/studio/pages/project/[ref]/editor/[id].tsx
+++ b/studio/pages/project/[ref]/editor/[id].tsx
@@ -8,7 +8,7 @@ import { PostgresTable, PostgresColumn } from '@supabase/postgres-meta'
 
 import Base64 from 'lib/base64'
 import { tryParseJson } from 'lib/helpers'
-import { useStore, withAuth } from 'hooks'
+import { useStore, withAuth, useUrlState } from 'hooks'
 import { Dictionary } from 'components/grid'
 import { TableEditorLayout } from 'components/layouts'
 import { TableGridEditor } from 'components/interfaces'
@@ -17,6 +17,7 @@ import ConfirmationModal from 'components/ui/ConfirmationModal'
 const TableEditorPage: NextPage = () => {
   const router = useRouter()
   const { id }: any = router.query
+  const [_, setParams] = useUrlState({ arrayKeys: ['filter', 'sort'] })
 
   const { meta, ui } = useStore()
   const [selectedSchema, setSelectedSchema] = useState<string>()
@@ -98,10 +99,31 @@ const TableEditorPage: NextPage = () => {
     setSidePanelKey(undefined)
   }
 
+  const removeDeletedColumnFromFiltersAndSorts = (columnName: string) => {
+    setParams((prevParams) => {
+      const existingFilters = (prevParams?.filter ?? []) as string[]
+      const existingSorts = (prevParams?.sort ?? []) as string[]
+
+      return {
+        ...prevParams,
+        filter: existingFilters.filter((filter: string) => {
+          const [column] = filter.split(':')
+          if (column !== columnName) return filter
+        }),
+        sort: existingSorts.filter((sort: string) => {
+          const [column] = sort.split(':')
+          if (column !== columnName) return sort
+        }),
+      }
+    })
+  }
+
   const onConfirmDeleteColumn = async () => {
     try {
       const response: any = await meta.columns.del(selectedColumnToDelete!.id)
       if (response.error) throw response.error
+
+      removeDeletedColumnFromFiltersAndSorts(selectedColumnToDelete!.name)
 
       await meta.tables.loadById(selectedColumnToDelete!.table_id)
     } catch (error: any) {


### PR DESCRIPTION
- closes https://github.com/supabase/supabase/issues/8501

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

If a column has an existing filter or sort rule, and the column is deleted, the rules are not removed.
[Issue](https://github.com/GitStartHQ/client-supabase/issues/92)

## What is the new behavior?

- When a column has a filter rule, when column is deleted, the filter rule is removed
- When a column has a sort rule, when column is deleted, the sort rule is removed

https://www.loom.com/share/2f954bfb5fe64597b4a0314c32178f61

This PR was pushed through [Gitstart](https://www.gitstart.com/), with contributions from @Chiazokam, @raph941, @phunguyenmurcul
