### PR TITLE
docs: clarify Azure provider scopes requirement

### DIFF
--- a/apps/reference/docs/guides/auth/auth-azure.mdx
+++ b/apps/reference/docs/guides/auth/auth-azure.mdx
@@ -65,6 +65,10 @@ This will allow your users to use your custom Azure login page when logging in.
 
 ## Add login code to your client app
 
+:::tip
+Supabase Auth requires that Azure returns a valid email address. Therefore you must request the `email` scope in the `signIn` method above.
+:::
+
 When your user signs in, call [signInWithOAuth()](/docs/reference/javascript/auth-signinwithoauth) with `azure` as the `provider`:
 
 ```js


### PR DESCRIPTION
Users are not passing the `scopes: 'email'` option to `signIn` when using Azure, which [leads to confusing behavior](https://github.com/supabase/gotrue/issues/550).