### PR TITLE
Fix the Expo logo in dark mode

### DIFF
--- a/studio/components/interfaces/Home/ExampleProject.tsx
+++ b/studio/components/interfaces/Home/ExampleProject.tsx
@@ -30,7 +30,7 @@ const ExampleProject: FC<Props> = ({ framework, title, description, url }) => {
             <img
               className="transition-all group-hover:scale-110"
               src={`/img/libraries/${framework.toLowerCase()}${
-                framework.toLowerCase() == 'nextjs' ? (isDarkTheme ? '-dark' : '') : ''
+                ['expo', 'nextjs'].includes(framework.toLowerCase()) ? (isDarkTheme ? '-dark' : '') : ''
               }-icon.svg`}
               alt={`${framework} logo`}
               width={26}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

![image](https://user-images.githubusercontent.com/1203991/193147745-af95bc54-e89f-42b6-908e-bcd79866a3d2.png)
> See [this tweet](https://twitter.com/cedricvanputten/status/1575599482628341762)

<details><summary>Maybe the logo type A might make more sense here though?</summary>

type | logo
--- | ---
Type A | ![logo-type-a](https://user-images.githubusercontent.com/1203991/193148190-ab9727bf-285d-431c-8097-1e368679e382.png)
Type A - Light | ![logo-type-a-light](https://user-images.githubusercontent.com/1203991/193148191-efe9d3ed-8c3e-4ac1-a3bf-9417afbef36d.png)

From our [branding pack](https://expo.dev/brand)

</details>

## What is the new behavior?

This should enable the light icon version on dark mode for Expo, which is already inside this project.
> https://github.com/supabase/supabase/blob/master/studio/public/img/icons/expo-dark-icon.svg

## Additional context

![image](https://user-images.githubusercontent.com/1203991/193147974-1f9c6ab6-488e-40c1-8532-fe116295e80b.png)
