### PR TITLE
Bump up script size in free plan to 2mb

### DIFF
--- a/apps/www/data/Pricing.json
+++ b/apps/www/data/Pricing.json
@@ -217,7 +217,7 @@
       {
         "title": "Script size",
         "tiers": {
-          "free": "1 mb",
+          "free": "2 mb",
           "pro": "10 mb",
           "enterprise": "Unlimited"
         }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump the free plan script size to 2mb as discussed internally.