### PR TITLE
Note for accessing services across docker containers

### DIFF
--- a/apps/reference/docs/guides/cli/local-development.mdx
+++ b/apps/reference/docs/guides/cli/local-development.mdx
@@ -108,7 +108,7 @@ http://localhost:54321/auth/v1/           # Auth (GoTrue)
 </Tabs>
 
 :::note
-If you are looking to access, for example, your database from an edge function within your local Supabase setup, you will need to replace `localhost` with `host.docker.internal` in any URLs.
+To access the database from an edge function in your local Supabase setup, replace `localhost` with `host.docker.internal`.
 :::
 	
 ## Database migrations

--- a/apps/reference/docs/guides/cli/local-development.mdx
+++ b/apps/reference/docs/guides/cli/local-development.mdx
@@ -107,6 +107,10 @@ http://localhost:54321/auth/v1/           # Auth (GoTrue)
 </TabItem>
 </Tabs>
 
+:::note
+If you are looking to access, for example, your database from an edge function within your local Supabase setup, you will need to replace `localhost` with `host.docker.internal` in any URLs.
+:::
+	
 ## Database migrations
 
 Database changes are managed through "migrations." Database migrations are a common way of tracking changes to your database over time.


### PR DESCRIPTION
I spent a few hours today trying to work out why I couldn't connect to my local Supabase DB from a local Supabase function. It dawned on me that the `SUPABASE_DB_URL` included the `localhost` string, which would attempt to connect to the DB on the same container as the functions are hosted.

Swapping out `localhost` for `host.docker.internal` fixed the issue. Thought it would be worth documenting. Happy to amend or move to a more appropriate place if needs be.

## What kind of change does this PR introduce?

Docs update