### PR TITLE
Move function privileges info to database functions guide

### DIFF
--- a/apps/reference/docs/guides/database/functions.mdx
+++ b/apps/reference/docs/guides/database/functions.mdx
@@ -278,10 +278,10 @@ final res = await supabase
 
 ### Database Functions vs Edge Functions
 
-For data-intensive operations we recommend using [Database Functions](../../guides/database/functions), which are executed within your database
+For data-intensive operations, use Database Functions, which are executed within your database
 and can be called remotely using the [REST and GraphQL API](../api).
 
-For use-cases which require low-latency we recommend [Edge Functions](../../guides/functions), which are globally-distributed and can be written in Typescript.
+For use-cases which require low-latency, use [Edge Functions](../../guides/functions), which are globally-distributed and can be written in Typescript.
 
 ### Security `definer` vs `invoker`
 
@@ -301,6 +301,18 @@ $$;
 
 It is best practice to use `security invoker` (which is also the default). If you ever use `security definer`, you _must_ set the `search_path`.
 This limits the potential damage if you allow access to schemas which the user executing the function should not have.
+
+### Function privileges
+
+By default, database functions can be executed by any role. You can restrict this by altering the default privileges and then choosing which roles can execute functions.
+
+```sql
+ALTER DEFAULT PRIVILEGES REVOKE EXECUTE ON FUNCTIONS FROM PUBLIC;
+
+-- Choose which roles can execute functions
+GRANT EXECUTE ON FUNCTION hello_world TO authenticated;
+GRANT EXECUTE ON FUNCTION hello_world TO service_role;
+```
 
 ## Resources
 

--- a/spec/supabase_js_v1_legacy.yml
+++ b/spec/supabase_js_v1_legacy.yml
@@ -943,17 +943,6 @@ pages:
       $$ language sql;
       ```
     $ref: '@supabase/postgrest-js.PostgrestClient.rpc'
-    notes: |
-      By default, functions can be executed by any role.
-      You can restrict this by altering the default prvivileges and then choosing which roles can execute functions.
-
-      ```sql
-      ALTER DEFAULT PRIVILEGES REVOKE EXECUTE ON FUNCTIONS FROM PUBLIC;
-
-      -- Choose which roles can execute functions
-      GRANT EXECUTE ON FUNCTION hello_world TO authenticated;
-      GRANT EXECUTE ON FUNCTION hello_world TO service_role;
-      ```
     examples:
       - name: Call a Postgres function without arguments
         isSpotlight: true

--- a/spec/supabase_js_v2_legacy.yml
+++ b/spec/supabase_js_v2_legacy.yml
@@ -1847,17 +1847,6 @@ pages:
       $$ language sql;
       ```
     $ref: '@supabase/postgrest-js.PostgrestClient.rpc'
-    notes: |
-      By default, functions can be executed by any role.
-      You can restrict this by altering the default prvivileges and then choosing which roles can execute functions.
-
-      ```sql
-      ALTER DEFAULT PRIVILEGES REVOKE EXECUTE ON FUNCTIONS FROM PUBLIC;
-
-      -- Choose which roles can execute functions
-      GRANT EXECUTE ON FUNCTION hello_world TO authenticated;
-      GRANT EXECUTE ON FUNCTION hello_world TO service_role;
-      ```
     examples:
       - name: Call a Postgres function without arguments
         description: |


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Move function privileges info (currently in ref docs) to database functions guide
- Remove a self-referencing link in database functions guide

![Screen Shot 2022-10-04 at 4 16 52 PM](https://user-images.githubusercontent.com/7026076/193948020-adf98d47-cf46-48a9-bd97-24e66d140970.png)
