### PR TITLE
fix: interpolate refs on links only when they exist

### DIFF
--- a/studio/components/layouts/ProjectLayout/NavigationBar/NavigationBar.tsx
+++ b/studio/components/layouts/ProjectLayout/NavigationBar/NavigationBar.tsx
@@ -9,13 +9,14 @@ import { useFlag, useStore } from 'hooks'
 import { IS_PLATFORM } from 'lib/constants'
 import { generateOtherRoutes, generateProductRoutes } from './NavigationBar.utils'
 import NavigationIconButton from './NavigationIconButton'
+import { useParams } from 'hooks/misc/useParams'
 
 interface Props {}
 
 const NavigationBar: FC<Props> = ({}) => {
   const router = useRouter()
-  const { selectedProjectRef, ui } = useStore()
-  const projectRef = selectedProjectRef ?? '[ref]'
+  const { ref: projectRef } = useParams()
+  const { ui } = useStore()
   const projectBaseInfo = ui.selectedProjectBaseInfo
 
   const ongoingIncident = useFlag('ongoingIncident')

--- a/studio/components/layouts/ProjectLayout/NavigationBar/NavigationBar.utils.tsx
+++ b/studio/components/layouts/ProjectLayout/NavigationBar/NavigationBar.utils.tsx
@@ -14,7 +14,7 @@ import { ProjectBase } from 'types'
 import { Route } from 'components/ui/ui.types'
 import { IS_PLATFORM, PROJECT_STATUS } from 'lib/constants'
 
-export const generateProductRoutes = (ref: string, project?: ProjectBase): Route[] => {
+export const generateProductRoutes = (ref?: string, project?: ProjectBase): Route[] => {
   const isProjectBuilding = project?.status !== PROJECT_STATUS.ACTIVE_HEALTHY
   const buildingUrl = `/project/${ref}/building`
 
@@ -29,13 +29,13 @@ export const generateProductRoutes = (ref: string, project?: ProjectBase): Route
           preProcessor={(code) => code.replace(/svg/, 'svg class="m-auto text-color-inherit"')}
         />
       ),
-      link: isProjectBuilding ? buildingUrl : `/project/${ref}/editor`,
+      link: ref && (isProjectBuilding ? buildingUrl : `/project/${ref}/editor`),
     },
     {
       key: 'auth',
       label: 'Authentication',
       icon: <IconUsers size={18} strokeWidth={2} />,
-      link: isProjectBuilding ? buildingUrl : `/project/${ref}/auth/users`,
+      link: ref && (isProjectBuilding ? buildingUrl : `/project/${ref}/auth/users`),
     },
     ...(IS_PLATFORM
       ? [
@@ -43,7 +43,7 @@ export const generateProductRoutes = (ref: string, project?: ProjectBase): Route
             key: 'storage',
             label: 'Storage',
             icon: <IconArchive size={18} strokeWidth={2} />,
-            link: isProjectBuilding ? buildingUrl : `/project/${ref}/storage/buckets`,
+            link: ref && (isProjectBuilding ? buildingUrl : `/project/${ref}/storage/buckets`),
           },
         ]
       : []),
@@ -57,13 +57,13 @@ export const generateProductRoutes = (ref: string, project?: ProjectBase): Route
           preProcessor={(code) => code.replace(/svg/, 'svg class="m-auto text-color-inherit"')}
         />
       ),
-      link: isProjectBuilding ? buildingUrl : `/project/${ref}/sql`,
+      link: ref && (isProjectBuilding ? buildingUrl : `/project/${ref}/sql`),
     },
     {
       key: 'database',
       label: 'Database',
       icon: <IconDatabase size={18} strokeWidth={2} />,
-      link: isProjectBuilding ? buildingUrl : `/project/${ref}/database/tables`,
+      link: ref && (isProjectBuilding ? buildingUrl : `/project/${ref}/database/tables`),
     },
     ...(IS_PLATFORM
       ? [
@@ -71,14 +71,14 @@ export const generateProductRoutes = (ref: string, project?: ProjectBase): Route
             key: 'functions',
             label: 'Edge Functions',
             icon: <IconCode size={18} strokeWidth={2} />,
-            link: isProjectBuilding ? buildingUrl : `/project/${ref}/functions`,
+            link: ref && (isProjectBuilding ? buildingUrl : `/project/${ref}/functions`),
           },
         ]
       : []),
   ]
 }
 
-export const generateOtherRoutes = (ref: string, project?: ProjectBase): Route[] => {
+export const generateOtherRoutes = (ref?: string, project?: ProjectBase): Route[] => {
   const isProjectBuilding = project?.status !== PROJECT_STATUS.ACTIVE_HEALTHY
   const buildingUrl = `/project/${ref}/building`
 
@@ -89,7 +89,7 @@ export const generateOtherRoutes = (ref: string, project?: ProjectBase): Route[]
             key: 'logs-explorer',
             label: 'Logs Explorer',
             icon: <IconList size={18} strokeWidth={2} />,
-            link: isProjectBuilding ? buildingUrl : `/project/${ref}/logs-explorer`,
+            link: ref && (isProjectBuilding ? buildingUrl : `/project/${ref}/logs-explorer`),
           },
         ]
       : []),
@@ -99,7 +99,7 @@ export const generateOtherRoutes = (ref: string, project?: ProjectBase): Route[]
             key: 'reports',
             label: 'Reports',
             icon: <IconBarChart size={18} strokeWidth={2} />,
-            link: isProjectBuilding ? buildingUrl : `/project/${ref}/reports`,
+            link: ref && (isProjectBuilding ? buildingUrl : `/project/${ref}/reports`),
           },
         ]
       : []),
@@ -107,7 +107,7 @@ export const generateOtherRoutes = (ref: string, project?: ProjectBase): Route[]
       key: 'api',
       label: 'API',
       icon: <IconFileText size={18} strokeWidth={2} />,
-      link: isProjectBuilding ? buildingUrl : `/project/${ref}/api`,
+      link: ref && (isProjectBuilding ? buildingUrl : `/project/${ref}/api`),
     },
     ...(IS_PLATFORM
       ? [
@@ -115,7 +115,7 @@ export const generateOtherRoutes = (ref: string, project?: ProjectBase): Route[]
             key: 'settings',
             label: 'Settings',
             icon: <IconSettings size={18} strokeWidth={2} />,
-            link: `/project/${ref}/settings/general`,
+            link: ref && `/project/${ref}/settings/general`,
           },
         ]
       : []),

--- a/studio/components/layouts/ProjectLayout/NavigationBar/NavigationIconButton.tsx
+++ b/studio/components/layouts/ProjectLayout/NavigationBar/NavigationIconButton.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import * as Tooltip from '@radix-ui/react-tooltip'
 
 import { Route } from 'components/ui/ui.types'
+import ConditionalWrap from 'components/ui/ConditionalWrap'
 
 interface Props {
   route: Route
@@ -13,7 +14,10 @@ const NavigationIconButton: FC<Props> = ({ route, isActive = false }) => {
   return (
     <Tooltip.Root delayDuration={0}>
       <Tooltip.Trigger>
-        <Link href={route.link}>
+        <ConditionalWrap
+          condition={route.link !== undefined}
+          wrap={(children) => <Link href={route.link!}>{children}</Link>}
+        >
           <a
             className={[
               'transition-colors duration-200',
@@ -25,7 +29,7 @@ const NavigationIconButton: FC<Props> = ({ route, isActive = false }) => {
           >
             {route.icon}
           </a>
-        </Link>
+        </ConditionalWrap>
       </Tooltip.Trigger>
       <Tooltip.Content side="right">
         <Tooltip.Arrow className="radix-tooltip-arrow" />

--- a/studio/components/ui/ConditionalWrap.tsx
+++ b/studio/components/ui/ConditionalWrap.tsx
@@ -1,0 +1,12 @@
+import { cloneElement } from 'react'
+
+type ConditionalWrapProps = {
+  condition: boolean
+  wrap: (children: JSX.Element | null) => JSX.Element
+  children: JSX.Element | null
+}
+
+const ConditionalWrap = ({ condition, children, wrap }: ConditionalWrapProps) =>
+  condition ? cloneElement(wrap(children)) : children
+
+export default ConditionalWrap

--- a/studio/components/ui/ui.types.ts
+++ b/studio/components/ui/ui.types.ts
@@ -4,6 +4,6 @@ export interface Route {
   key: string
   label: string
   icon: ReactNode
-  link: string
+  link?: string
   disabled?: boolean
 }

--- a/studio/hooks/misc/useParams.ts
+++ b/studio/hooks/misc/useParams.ts
@@ -1,0 +1,22 @@
+import { useRouter } from 'next/router'
+import { useMemo } from 'react'
+
+export function useParams(): {
+  [k: string]: string | undefined
+} {
+  const { query } = useRouter()
+
+  return useMemo(
+    () =>
+      Object.fromEntries(
+        Object.entries(query).map(([key, value]) => {
+          if (Array.isArray(value)) {
+            return [key, value[0]]
+          } else {
+            return [key, value]
+          }
+        })
+      ),
+    [query]
+  )
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behaviour?

`The provided href (/project/[ref]/building) value is missing query values (ref) to be interpolated properly`

## What is the new behaviour?

Links are only added once the ref is read from the url
