### PR TITLE
docs: hide literal union variants

### DIFF
--- a/apps/reference/generator/legacy.ts
+++ b/apps/reference/generator/legacy.ts
@@ -130,8 +130,14 @@ function recurseThroughParams(paramDefinition: TsDoc.TypeDefinition) {
   if (param.type?.declaration?.children) {
     children = param.type?.declaration?.children
   } else if (isUnion(param)) {
-    // children = param.type.types
-    children = null // We don't want to show the union types
+    // We don't want to show the union types if it's a literal
+    const nonLiteralVariants = param.type.types.filter(({ type }) => type !== 'literal')
+
+    if (nonLiteralVariants.length === 0) {
+      children = null
+    } else {
+      children = nonLiteralVariants
+    }
   } else if (param.type === 'reflection') {
     children = param.declaration.children
   }


### PR DESCRIPTION
Only show union variant in `Properties` if it's not a literal, e.g. `"foo", 42, null`