### PR TITLE
fix: add nginx env variables for kong

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -38,6 +38,8 @@ services:
       # https://github.com/supabase/cli/issues/14
       KONG_DNS_ORDER: LAST,A,CNAME
       KONG_PLUGINS: request-transformer,cors,key-auth,acl
+      KONG_NGINX_PROXY_PROXY_BUFFER_SIZE: 160k
+      KONG_NGINX_PROXY_PROXY_BUFFERS: 64 160k
     volumes:
       - ./volumes/api:/var/lib/kong
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix, for docker compose file

## What is the current behavior?
it gives this error for very long sql query

example: http://localhost:8000/rest/v1/shn_xxcxxexxs?select=*,createdByDetail:shn_users!shn_xxcxxexxs_created_by_fkey(*),patient:shn_patients!shn_xxcxxexxs_patient_id_fkey(*),xxcxxexx_type_details:shn_xxcxxexx_types(*),staff_id_all:shn_xxcxxexx_staff_involved(staff_id,staff_users:shn_users(first_name,last_name),xxx_employees:shn_xxx_employees(first_name,last_name)),post_feeding:shn_xxcxxexx_post_feeding(*),injury_violence:shn_xxcxxexx_injury_violence(*),statutory:shn_xxcxxexx_individual_statutory(*),notifications:shn_xxcxxexx_emergency_notifications(*),riddor:shn_xxcxxexxs_riddor(*),first_aid:shn_xxcxxexx_first_aid(*),hospital:shn_xxcxxexx_hospital(*),police:shn_xxcxxexx_police(*),patient_absent:shn_xxcxxexx_patient_absent(*),intexxxxxion:shn_xxcxxexx_intexxxxxion(*),status_details:shn_xxcxxexx_status(*),moving_patient:shn_xxcxxexx_moving_patient(*,children:shn_xxcxxexx_moving_patient_details(*,staff_users:shn_users(first_name,last_name),xxx_employees:shn_xxx_employees(first_name,last_name))),ng_feed:shn_xxcxxexx_ng_feed(*,intexxxxxion_types_details:shn_intexxxxxion_types!shn_xxcxxexx_ng_feed_intexxxxxion_type_fkey(id,name,mhsds_code),children:shn_xxcxxexx_ng_feed_details(*,staff_users:shn_users(first_name,last_name),xxx_employees:shn_xxx_employees(first_name,last_name)),xxxxxxxx:shn_xxcxxexx_ng_feed_xxxxxxxx(*,intexxxxxion_types_details:shn_intexxxxxion_types!shn_xxcxxexx_ng_feed_xxxxxxxx_type_fkey(id,name,mhsds_code),prescribed_by_details:shn_users!shn_xxcxxexx_ng_feed_xxxxxxxx_prescribed_by_fkey(first_name,last_name),administered_by_details:shn_users!shn_xxcxxexx_ng_feed_xxxxxxxx_administered_by_fkey(first_name,last_name))),post_feed:shn_xxcxxexx_post_feed(*,intexxxxxion_types_details:shn_intexxxxxion_types!shn_xxcxxexx_post_feed_intexxxxxion_type_fkey(id,name,mhsds_code),children:shn_xxcxxexx_post_feed_details(*,staff_users:shn_users(first_name,last_name),xxx_employees:shn_xxx_employees(first_name,last_name)),xxxxxxxx:shn_xxcxxexx_post_feed_xxxxxxxx(*,intexxxxxion_types_details:shn_intexxxxxion_types!shn_xxcxxexx_post_feed_xxxxxxxx_type_fkey(id,name,mhsds_code),prescribed_by_details:shn_users!shn_xxcxxexx_post_feed_xxxxxxxx_prescribed_by_fkey(first_name,last_name),administered_by_details:shn_users!shn_xxcxxexx_post_feed_xxxxxxxx_administered_by_fkey(first_name,last_name))),intexxxxxion_step:shn_xxcxxexx_intexxxxxion_steps(*,intexxxxxion_types_details:shn_intexxxxxion_types!shn_xxcxxexx_intexxxxxion_steps_intexxxxxion_type_fkey(id,name,mhsds_code),children:shn_xxcxxexx_intexxxxxion_steps_details(*,staff_users:shn_users(first_name,last_name),xxx_employees:shn_xxx_employees(first_name,last_name)),xxxxxxxx:shn_xxcxxexx_intexxxxxion_steps_xxxxxxxx(*,intexxxxxion_types_details:shn_intexxxxxion_types!shn_xxcxxexx_intexxxxxion_steps_xxxxxxxx_type_fkey(id,name,mhsds_code),prescribed_by_details:shn_users!shn_xxcxxexx_intexxxxxion_steps_xxxxxxxx_prescribed_by_fkey(first_name,last_name),administered_by_details:shn_users!shn_xxcxxexx_intexxxxxion_steps_xxxxxxxx_administered_by_fkey(first_name,last_name))),injury_details:shn_xxcxxexx_injuries_details(*,staff_users:shn_users(first_name,last_name),injury_severity:shn_severity(name)),xxcxxexx_logs:shn_xxcxxexx_logs(*,status_details:shn_xxcxxexx_status(*),created_by_user:shn_users(id,first_name,last_name,teams:shn_users_teams(team:shn_teams(name,initials))))&xxcxxexx_code=eq.EMXXXXPT8



502 Bad Gateway - Upstream sent too big header when reading response header from upstream  

## What is the new behavior?

fix the issue and get 200 response 

## Additional context
https://github.com/Kong/kong/issues/3974#issuecomment-482105126 => found fix here on kong repo discussion 

