### PR TITLE
add `target="_blank" rel="noreferrer"` to external links

### DIFF
--- a/studio/components/interfaces/Home/NewProjectPanel/NewProjectPanel.tsx
+++ b/studio/components/interfaces/Home/NewProjectPanel/NewProjectPanel.tsx
@@ -78,7 +78,7 @@ const NewProjectPanel: FC<Props> = ({}) => {
                   </a>
                 </Link>
                 <Link href="https://supabase.com/docs/guides/database">
-                  <a>
+                  <a target="_blank" rel="noreferrer">
                     <Button type="default" icon={<IconExternalLink size={14} />}>
                       About Database
                     </Button>
@@ -120,7 +120,7 @@ const NewProjectPanel: FC<Props> = ({}) => {
                       </a>
                     </Link>
                     <Link href="https://supabase.com/docs/guides/auth">
-                      <a>
+                      <a target="_blank" rel="noreferrer">
                         <Button
                           className="translate-y-[1px]"
                           icon={<IconExternalLink size={14} />}
@@ -154,7 +154,7 @@ const NewProjectPanel: FC<Props> = ({}) => {
                       </a>
                     </Link>
                     <Link href="https://supabase.com/docs/guides/storage">
-                      <a>
+                      <a target="_blank" rel="noreferrer">
                         <Button
                           className="translate-y-[1px]"
                           icon={<IconExternalLink size={14} />}
@@ -189,7 +189,7 @@ const NewProjectPanel: FC<Props> = ({}) => {
                       </a>
                     </Link>
                     <Link href="https://supabase.com/docs/guides/functions">
-                      <a>
+                      <a target="_blank" rel="noreferrer">
                         <Button
                           className="translate-y-[1px]"
                           icon={<IconExternalLink size={14} />}
@@ -217,7 +217,7 @@ const NewProjectPanel: FC<Props> = ({}) => {
                   </div>
                   <div className="flex items-center space-x-2">
                     <Link href="https://supabase.com/docs/guides/realtime">
-                      <a>
+                      <a target="_blank" rel="noreferrer">
                         <Button
                           className="translate-y-[1px]"
                           icon={<IconExternalLink size={14} />}
@@ -258,7 +258,7 @@ const NewProjectPanel: FC<Props> = ({}) => {
               </a>
             </Link>
             <Link href="https://supabase.com/docs/guides/api">
-              <a>
+              <a target="_blank" rel="noreferrer">
                 <Button className="translate-y-[1px]" type="default" icon={<IconExternalLink />}>
                   About APIs
                 </Button>

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.tsx
@@ -212,7 +212,7 @@ const ColumnEditor: FC<Props> = ({
             disabled={!isUndefined(columnFields?.foreignKey)}
             description={
               <Link href="https://supabase.com/docs/guides/database/tables#data-types">
-                <a>
+                <a target="_blank" rel="noreferrer">
                   <Button
                     as="span"
                     type="text"

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/ColumnManagement.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/ColumnManagement.tsx
@@ -319,7 +319,7 @@ const ColumnManagement: FC<Props> = ({
             </Button>
           )}
           <Link href="https://supabase.com/docs/guides/database/tables#data-types">
-            <a>
+            <a target="_blank" rel="noreferrer">
               <Button
                 type="text"
                 className="text-scale-1000 hover:text-scale-1200"

--- a/studio/components/layouts/ProjectLayout/LayoutHeader/NotificationsPopover/NotificationActions.tsx
+++ b/studio/components/layouts/ProjectLayout/LayoutHeader/NotificationsPopover/NotificationActions.tsx
@@ -90,7 +90,7 @@ const NotificationActions: FC<Props> = ({
       })}
       {changelogLink && (
         <Link href={changelogLink}>
-          <a>
+          <a target="_blank" rel="noreferrer">
             <Button as="span" type="default" icon={<IconExternalLink size={12} strokeWidth={2} />}>
               More info
             </Button>

--- a/studio/components/layouts/ProjectLayout/LayoutHeader/NotificationsPopover/NotificationRows.utils.tsx
+++ b/studio/components/layouts/ProjectLayout/LayoutHeader/NotificationsPopover/NotificationRows.utils.tsx
@@ -129,7 +129,7 @@ export const formatNotificationText = (
                 {upgrade.changelog_link && (
                   <div className="!ml-4">
                     <Link href={upgrade.changelog_link}>
-                      <a>
+                      <a target="_blank" rel="noreferrer">
                         <IconExternalLink
                           className="cursor-pointer text-scale-1000 hover:text-scale-1200 transition"
                           size={12}


### PR DESCRIPTION
Bug fix, feature, docs update, ...

## What is the current behavior?

Clicking an external link opens it in the same tab, meaning you lose any chagnes which are in progress

## What is the new behavior?

External links open in a new tab
