### PR TITLE
fix: bind meta store to this context

### DIFF
--- a/studio/components/layouts/ProjectLayout/LayoutHeader/NotificationsPopover/index.tsx
+++ b/studio/components/layouts/ProjectLayout/LayoutHeader/NotificationsPopover/index.tsx
@@ -99,7 +99,7 @@ const NotificationsPopover: FC<Props> = () => {
     if (!projectToApplyMigration) return
     const res = await post(`${API_URL}/database/${projectToApplyMigration.ref}/owner-reassign`, {})
     if (!res.error) {
-      await app.projects.fetchDetail(projectToApplyMigration.ref, meta.setProjectDetails)
+      await app.projects.fetchDetail(projectToApplyMigration.ref, (project) => meta.setProjectDetails(project))
       ui.setNotification({
         category: 'success',
         message: `Succesfully applied migration for project "${projectToApplyMigration.name}"`,
@@ -121,7 +121,7 @@ const NotificationsPopover: FC<Props> = () => {
       {}
     )
     if (!res.error) {
-      await app.projects.fetchDetail(projectToRollbackMigration.ref, meta.setProjectDetails)
+      await app.projects.fetchDetail(projectToRollbackMigration.ref, (project) => meta.setProjectDetails(project))
       ui.setNotification({
         category: 'success',
         message: `Succesfully rolled back migration for project "${projectToRollbackMigration.name}"`,
@@ -143,7 +143,7 @@ const NotificationsPopover: FC<Props> = () => {
       {}
     )
     if (!res.error) {
-      await app.projects.fetchDetail(projectToFinalizeMigration.ref, meta.setProjectDetails)
+      await app.projects.fetchDetail(projectToFinalizeMigration.ref, (project) => meta.setProjectDetails(project))
       ui.setNotification({
         category: 'success',
         message: `Succesfully finalized migration for project "${projectToFinalizeMigration.name}"`,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix #9229 

## What is the current behavior?

gives `this` context is undefined error locally

## Additional context

```
Unhandled Runtime Error
TypeError: Cannot set properties of undefined (setting 'projectRef')

Source
stores/pgmeta/MetaStore.ts (823:4) @ setProjectDetails

  821 | 
  822 |   setProjectDetails({ ref, connectionString }: { ref: string; connectionString?: string }) {
> 823 |     this.projectRef = ref
      |    ^
  824 |     this.baseUrl = `${API_URL}/pg-meta/${ref}`
  825 |     if (connectionString) {
  826 |       this.connectionString = connectionString

```
