### PR TITLE
Briefly simplify downloading of file in storage from preview pane

### DIFF
--- a/studio/components/to-be-cleaned/Storage/StorageExplorer/PreviewPane.js
+++ b/studio/components/to-be-cleaned/Storage/StorageExplorer/PreviewPane.js
@@ -10,6 +10,7 @@ import {
 import SVG from 'react-inlinesvg'
 import { formatBytes } from 'lib/helpers'
 import { Transition } from '@headlessui/react'
+import Link from 'next/link'
 
 const PreviewFile = ({ mimeType, previewUrl }) => {
   if (!mimeType || !previewUrl) {
@@ -92,7 +93,6 @@ const PreviewPane = ({
   file = {},
   width = 400,
   onCopyFileURL = () => {},
-  onDownloadFile = () => {},
   onSelectFileDelete = () => {},
   onClosePreviewPane = () => {},
 }) => {
@@ -168,14 +168,17 @@ const PreviewPane = ({
 
           {/* Actions */}
           <div className="flex space-x-2 border-b border-panel-border-light pb-4 dark:border-panel-border-dark">
-            <Button
-              type="default"
-              icon={<IconDownload size={16} strokeWidth={2} />}
-              onClick={() => onDownloadFile(file)}
-              disabled={file.isCorrupted}
-            >
-              Download
-            </Button>
+            <Link href={`${file.previewUrl}&download`}>
+              <a>
+                <Button
+                  type="default"
+                  icon={<IconDownload size={16} strokeWidth={2} />}
+                  disabled={file.isCorrupted}
+                >
+                  Download
+                </Button>
+              </a>
+            </Link>
             <Button
               type="outline"
               icon={<IconClipboard size={16} strokeWidth={2} />}

--- a/studio/components/to-be-cleaned/Storage/StorageExplorer/StorageExplorer.js
+++ b/studio/components/to-be-cleaned/Storage/StorageExplorer/StorageExplorer.js
@@ -353,7 +353,6 @@ const StorageExplorer = observer(({ bucket }) => {
           file={selectedFilePreview}
           width={previewPaneWidth}
           onCopyFileURL={onCopyFileURL}
-          onDownloadFile={onDownloadFile}
           onSelectFileDelete={onSelectItemDelete}
           onClosePreviewPane={closeFilePreview}
         />


### PR DESCRIPTION
The new storage-api allows downloading of files by appending `?download` to the end of the file's URL

Just a small improvement to the downloading of file from preview pane to skip downloading the file blob