### PR TITLE
Update next-js.md's middleware section

### DIFF
--- a/apps/reference/_auth_helpers/next-js.md
+++ b/apps/reference/_auth_helpers/next-js.md
@@ -279,28 +279,36 @@ If you visit `/api/protected-route` without a valid session cookie, you will get
 
 ## Protecting routes with [Nextjs Middleware](https://nextjs.org/docs/middleware)
 
-As an alternative to protecting individual pages using `getServerSideProps` with `withPageAuth`, `withMiddlewareAuth` can be used from inside a `_middleware` file to protect an entire directory. In the following example, all requests to `/protected/*` will check whether a user is signed in, if successful the request will be forwarded to the destination route, otherwise the user will be redirected to `/login` (defaults to: `/`) with a 307 Temporary Redirect response status:
+As an alternative to protecting individual pages using `getServerSideProps` with `withPageAuth`, `withMiddlewareAuth` can be used from inside a `middleware` file to protect the entire directory or those that match the config object. In the following example, all requests to `/middleware-protected/*` will check whether a user is signed in, if successful the request will be forwarded to the destination route, otherwise the user will be redirected to `/login` (defaults to: `/`) with a 307 Temporary Redirect response status:
 
 ```ts
-// pages/protected/_middleware.ts
-import { withMiddlewareAuth } from '@supabase/auth-helpers-nextjs/middleware'
+// /middleware.ts
+import { withMiddlewareAuth } from '@supabase/auth-helpers-nextjs';
 
-export const middleware = withMiddlewareAuth({ redirectTo: '/login' })
+export const middleware = withMiddlewareAuth({ redirectTo: '/' });
+
+export const config = {
+  matcher: ['/middleware-protected/:path*']
+};
 ```
 
 It is also possible to add finer granularity based on the user logged in. I.e. you can specify a promise to determine if a specific user has permission or not.
 
 ```ts
-// pages/protected/_middleware.ts
-import { withMiddlewareAuth } from '@supabase/auth-helpers-nextjs/dist/middleware'
+// middlware.ts
+import { withMiddlewareAuth } from '@supabase/auth-helpers-nextjs/middleware';
 
 export const middleware = withMiddlewareAuth({
   redirectTo: '/login',
   authGuard: {
     isPermitted: async (user) => user.email?.endsWith('@example.com') ?? false,
-    redirectTo: '/insufficient-permissions',
-  },
-})
+    redirectTo: '/insufficient-permissions'
+  }
+});
+
+export const config = {
+  matcher: ['/middleware-protected/:path*']
+};
 ```
 
 ## Migrating from @supabase/supabase-auth-helpers to @supabase/auth-helpers

--- a/apps/reference/_auth_helpers/next-js.md
+++ b/apps/reference/_auth_helpers/next-js.md
@@ -281,34 +281,32 @@ If you visit `/api/protected-route` without a valid session cookie, you will get
 
 As an alternative to protecting individual pages using `getServerSideProps` with `withPageAuth`, `withMiddlewareAuth` can be used from inside a `middleware` file to protect the entire directory or those that match the config object. In the following example, all requests to `/middleware-protected/*` will check whether a user is signed in, if successful the request will be forwarded to the destination route, otherwise the user will be redirected to `/login` (defaults to: `/`) with a 307 Temporary Redirect response status:
 
-```ts
-// /middleware.ts
-import { withMiddlewareAuth } from '@supabase/auth-helpers-nextjs';
+```ts title="/middleware.ts"
+import { withMiddlewareAuth } from '@supabase/auth-helpers-nextjs'
 
-export const middleware = withMiddlewareAuth({ redirectTo: '/' });
+export const middleware = withMiddlewareAuth({ redirectTo: '/' })
 
 export const config = {
-  matcher: ['/middleware-protected/:path*']
-};
+  matcher: ['/middleware-protected/:path*'],
+}
 ```
 
 It is also possible to add finer granularity based on the user logged in. I.e. you can specify a promise to determine if a specific user has permission or not.
 
-```ts
-// middlware.ts
-import { withMiddlewareAuth } from '@supabase/auth-helpers-nextjs/middleware';
+```ts title="/middleware.ts"
+import { withMiddlewareAuth } from '@supabase/auth-helpers-nextjs/middleware'
 
 export const middleware = withMiddlewareAuth({
   redirectTo: '/login',
   authGuard: {
     isPermitted: async (user) => user.email?.endsWith('@example.com') ?? false,
-    redirectTo: '/insufficient-permissions'
-  }
-});
+    redirectTo: '/insufficient-permissions',
+  },
+})
 
 export const config = {
-  matcher: ['/middleware-protected/:path*']
-};
+  matcher: ['/middleware-protected/:path*'],
+}
 ```
 
 ## Migrating from @supabase/supabase-auth-helpers to @supabase/auth-helpers


### PR DESCRIPTION
## What kind of change does this PR introduce?

Just making sure the docs [over here](https://supabase.com/docs/reference/auth-helpers/next-js#protecting-routes-with-nextjs-middleware) actually reflect [from the auth-helpers repo](https://github.com/supabase/auth-helpers/blob/main/packages/nextjs/README.md).

## What is the current behavior?

Current docs are showing the deprecated way of using middleware in Next.js, by using nested configuration.

## What is the new behavior?

Correct way is to use a middleware.ts file in the root of the project.

## Additional context

[Nested Middleware deprecation notice](https://nextjs.org/docs/messages/nested-middleware)
