### PR TITLE
fix: auth policy names truncate

### DIFF
--- a/studio/components/interfaces/Auth/Policies/PolicyTableRow/PolicyRow.tsx
+++ b/studio/components/interfaces/Auth/Policies/PolicyTableRow/PolicyRow.tsx
@@ -27,10 +27,10 @@ const PolicyRow: FC<Props> = ({
         'w-full space-x-4 border-b py-4 lg:items-center',
       ].join(' ')}
     >
-      <div className="flex grow flex-col space-y-1 truncate">
+      <div className="flex grow flex-col space-y-1">
         <div className="flex items-center space-x-4">
           <p className="font-mono text-xs text-scale-1000">{policy.command}</p>
-          <p className="max-w-xs truncate text-sm text-scale-1200">{policy.name}</p>
+          <p className="text-sm text-scale-1200">{policy.name}</p>
         </div>
         <div className="flex items-center space-x-2">
           <p className="text-scale-1000 text-sm">Applied to:</p>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Studio -> Auth -> Policies

## What is the current behavior?

The current policy name gets truncated when this is not needed

## What is the new behavior?

As their is a limit of 63 characters on the policy name the whole name can be shown:

<img width="1124" alt="Screenshot 2022-10-04 at 15 50 16" src="https://user-images.githubusercontent.com/22655069/193851840-7e926e6a-cb15-4405-9b91-c1792dc07db6.png">


## Additional context

New pull due to conflict.

Closes #9302
