### PR TITLE
docs: add Realtime instruction for private schema

### DIFF
--- a/apps/reference/docs/guides/realtime/postgres-cdc.mdx
+++ b/apps/reference/docs/guides/realtime/postgres-cdc.mdx
@@ -10,8 +10,14 @@ Anyone with access to a valid JWT signed with the project's JWT secret is able t
 
 Clients can choose to receive `INSERT`, `UPDATE`, `DELETE`, or `*` (all) changes for all changes in a schema, a table in a schema, or a column's value in a table. Your clients should only listen to tables in the `public` schema and you must first enable the tables you want your clients to listen to.
 
+Postgres CDC works out of the box for tables in the `public` schema. You can listen to tables in your private schemas by granting table SELECT permissions to the database role found in your access token. You can run a query similar to the following:
+
+```sql
+GRANT SELECT ON "private_schema"."table" TO authenticated;
+```
+
 :::caution
-Postgres CDC works out of the box for tables in the `public` schema. We do not yet recommend attempting to listen to tables in private schemas due to security concerns and additional permission requirements.
+We strongly encourage you to enable RLS and create policies for tables in private schemas. Otherwise, any role you grant access to will have unfettered read access to the table.
 :::
 
 You can do this in the [Replication](https://app.supabase.com/project/_/database/replication) section in the Dashboard or with the [SQL editor](https://app.supabase.com/project/_/sql):


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the new behavior?

More and more devs are asking about listening to tables in private schemas using Realtime.