### PR TITLE
fix: add manual localstorage clearing

### DIFF
--- a/studio/components/layouts/AccountLayout/AccountLayout.tsx
+++ b/studio/components/layouts/AccountLayout/AccountLayout.tsx
@@ -27,6 +27,7 @@ const AccountLayout: FC<Props> = ({ children, title, breadcrumbs }) => {
 
   const onClickLogout = async () => {
     await auth.signOut()
+    localStorage.clear();
     router.reload()
   }
 


### PR DESCRIPTION
GoTrue client doesn't seem to be clearing local storage as intended. 

On local dev, local storage is still persisted even after clicking "Logout", resulting in always getting redirected by router to home page even though token has expired. This bandaid fix manually clears the cache.


cc @kangmingtay 