### PR TITLE
Fix row delete confirm modal not showing the right number of rows when all rows are selected

### DIFF
--- a/studio/components/grid/components/header/Header.tsx
+++ b/studio/components/grid/components/header/Header.tsx
@@ -112,12 +112,13 @@ const RowHeader: FC<RowHeaderProps> = ({ sorts, filters }) => {
   }
 
   const onRowsDelete = () => {
+    const numRows = allRowsSelected ? totalRows : selectedRows.size
     confirmAlert({
       title: 'Confirm to delete',
-      message: `Are you sure you want to delete the selected ${selectedRows.size} row${
-        selectedRows.size > 1 ? 's' : ''
+      message: `Are you sure you want to delete the selected ${numRows} row${
+        numRows > 1 ? 's' : ''
       }? This action cannot be undone.`,
-      confirmText: `Delete ${selectedRows.size} rows`,
+      confirmText: `Delete ${numRows} rows`,
       onAsyncConfirm: async () => {
         if (allRowsSelected) {
           const { error } =


### PR DESCRIPTION
Previously would show the number of rows selected on the page only

![image](https://user-images.githubusercontent.com/19742402/195300813-b318c226-6d26-4f22-a675-15185350dd71.png)
