### PR TITLE
docs: generate types link change

### DIFF
--- a/apps/reference/docs/guides/auth/auth-helpers/nextjs.mdx
+++ b/apps/reference/docs/guides/auth/auth-helpers/nextjs.mdx
@@ -104,7 +104,7 @@ You can now determine if a user is authenticated by checking that the `user` obj
 
 ## Usage with TypeScript
 
-You can pass types that were [generated with the Supabase CLI](https://supabase.com/docs/reference/javascript/typescript-support#generating-types) to the Supabase Client to get enhanced type safety and auto completion:
+You can pass types that were [generated with the Supabase CLI](/docs/reference/javascript/typescript-support#generating-types) to the Supabase Client to get enhanced type safety and auto completion:
 
 ```js
 // Creating a new supabase client object:
@@ -375,7 +375,7 @@ export const config = {
   ```
 - The `UserProvider` has been replaced by the `SessionContextProvider`. Make sure to wrap your `pages/_app.js` componenent with the `SessionContextProvider`. Then, throughout your application you can use the `useSessionContext` hook to get the `session` and the `useSupabaseClient` hook to get an authenticated `supabaseClient`.
 - The `useUser` hook now returns the `user` object or `null`.
-- Usage with TypeScript: You can pass types that were [generated with the Supabase CLI](https://supabase.com/docs/reference/javascript/typescript-support#generating-types) to the Supabase Client to get enhanced type safety and auto completion:
+- Usage with TypeScript: You can pass types that were [generated with the Supabase CLI](/docs/reference/javascript/typescript-support#generating-types) to the Supabase Client to get enhanced type safety and auto completion:
   ```js
   // Creating a new supabase client object:
   import { Database } from '../db_types';

--- a/apps/reference/docs/guides/auth/auth-helpers/nextjs.mdx
+++ b/apps/reference/docs/guides/auth/auth-helpers/nextjs.mdx
@@ -104,7 +104,7 @@ You can now determine if a user is authenticated by checking that the `user` obj
 
 ## Usage with TypeScript
 
-You can pass types that were [generated with the Supabase CLI](https://supabase.com/docs/reference/javascript/next/typescript-support#generating-types) to the Supabase Client to get enhanced type safety and auto completion:
+You can pass types that were [generated with the Supabase CLI](https://supabase.com/docs/reference/javascript/typescript-support#generating-types) to the Supabase Client to get enhanced type safety and auto completion:
 
 ```js
 // Creating a new supabase client object:
@@ -375,7 +375,7 @@ export const config = {
   ```
 - The `UserProvider` has been replaced by the `SessionContextProvider`. Make sure to wrap your `pages/_app.js` componenent with the `SessionContextProvider`. Then, throughout your application you can use the `useSessionContext` hook to get the `session` and the `useSupabaseClient` hook to get an authenticated `supabaseClient`.
 - The `useUser` hook now returns the `user` object or `null`.
-- Usage with TypeScript: You can pass types that were [generated with the Supabase CLI](https://supabase.com/docs/reference/javascript/next/typescript-support#generating-types) to the Supabase Client to get enhanced type safety and auto completion:
+- Usage with TypeScript: You can pass types that were [generated with the Supabase CLI](https://supabase.com/docs/reference/javascript/typescript-support#generating-types) to the Supabase Client to get enhanced type safety and auto completion:
   ```js
   // Creating a new supabase client object:
   import { Database } from '../db_types';


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs -> [Auth Helpers](https://supabase.com/docs/guides/auth/auth-helpers/nextjs#usage-with-typescript)

## What is the current behavior?

The generated with the Supabase CL link goes to a 404.

## What is the new behavior?

The link has been changed

## Additional context

Link changed in the Supabase repo but needs changing in the [auth-helpers](https://github.com/supabase/auth-helpers/tree/main/packages/nextjs) README.MD

Linked with #9508
