### PR TITLE
Update JS V2 Upsert Docs With Specified Notes

### DIFF
--- a/spec/supabase_js_v2.yml
+++ b/spec/supabase_js_v2.yml
@@ -1558,6 +1558,8 @@ pages:
     $ref: '@supabase/postgrest-js.PostgrestQueryBuilder.upsert'
     notes: |
       - Primary keys must be included in `values` to use upsert.
+      - If you are using RLS, you might want to add some data to upsert.
+      - If the table is restricted to row `owners`, you need to include the column that the auth.id matches when doing bulk upsert request only when a select number of the columns are changing.
     examples:
       - name: Upsert your data
         description: |


### PR DESCRIPTION
Update JS V2 Upsert Docs with Specified Notes as per issue #9159

## What kind of change does this PR introduce?

Docs update for JS V2 Upsert

## What is the current behavior?

The current Notes section for the Upsert docs didn't include the notes as mentioned in issue #9159 

## What is the new behavior?

Added notes as per the requirement of the issue
