### PR TITLE
fix: adds versions to cdn supabase-js installations

### DIFF
--- a/apps/reference/_supabase_js/installing.mdx
+++ b/apps/reference/_supabase_js/installing.mdx
@@ -31,7 +31,7 @@ Find the source code on [GitHub](https://github.com/supabase/supabase-js).
 Or via CDN
 
 ```js
-<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
 //or
-<script src="https://unpkg.com/@supabase/supabase-js"></script>
+<script src="https://unpkg.com/@supabase/supabase-js@2"></script>
 ```

--- a/apps/reference/_supabase_js_versioned_docs/version-v1/installing.mdx
+++ b/apps/reference/_supabase_js_versioned_docs/version-v1/installing.mdx
@@ -31,7 +31,7 @@ Find the source code on [GitHub](https://github.com/supabase/supabase-js).
 Or via CDN
 
 ```js
-<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@1"></script>
 //or
-<script src="https://unpkg.com/@supabase/supabase-js"></script>
+<script src="https://unpkg.com/@supabase/supabase-js@1"></script>
 ```

--- a/apps/temp-docs/docs/javascript/installing.mdx
+++ b/apps/temp-docs/docs/javascript/installing.mdx
@@ -28,9 +28,9 @@ Find the source code on [GitHub](https://github.com/supabase/supabase-js).
 
 Or via CDN
 ```js
-<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
 //or
-<script src="https://unpkg.com/@supabase/supabase-js"></script>
+<script src="https://unpkg.com/@supabase/supabase-js@2"></script>
 ```
 
 ## Python

--- a/apps/temp-docs/docs/reference/javascript/installing.mdx
+++ b/apps/temp-docs/docs/reference/javascript/installing.mdx
@@ -28,9 +28,9 @@ Find the source code on [GitHub](https://github.com/supabase/supabase-js).
 
 Or via CDN
 ```js
-<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
 //or
-<script src="https://unpkg.com/@supabase/supabase-js"></script>
+<script src="https://unpkg.com/@supabase/supabase-js@2"></script>
 ```
 
 ## Python

--- a/examples/auth/javascript-auth/index.html
+++ b/examples/auth/javascript-auth/index.html
@@ -2,7 +2,7 @@
 
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@1"></script>
     <script src="./index.js"></script>
     <link rel="stylesheet" type="text/css" href="./index.css">
 </head>


### PR DESCRIPTION
adds versions to cdn imports of supabase-js to avoid breaking older apps when new major versions with breaking changes are published