### PR TITLE
feat: description added and templates not in alphabetical order

### DIFF
--- a/studio/components/interfaces/Settings/Logs/Logs.constants.ts
+++ b/studio/components/interfaces/Settings/Logs/Logs.constants.ts
@@ -163,6 +163,7 @@ limit 100
   },
   {
     label: 'Error Count by User',
+    description: 'Count of errors by users',
     mode: 'custom',
     searchString: `select
   count(t.timestamp) as count,

--- a/studio/pages/project/[ref]/logs-explorer/templates.tsx
+++ b/studio/pages/project/[ref]/logs-explorer/templates.tsx
@@ -14,59 +14,61 @@ export const LogsTemplatesPage: NextPageWithLayout = () => {
   return (
     <div>
       <div className="grid grid-cols-3 gap-6">
-        {TEMPLATES.filter((template) => template.mode === 'custom').map((template, i) => {
-          const [showPreview, setShowPreview] = useState(false)
-          return (
-            <CardButton
-              key={i}
-              title={template.label}
-              icon={
-                <div
-                  className="duration-400 flex h-6 w-6 items-center justify-center rounded
+        {TEMPLATES.sort((a, b) => a.label!.localeCompare(b.label!))
+          .filter((template) => template.mode === 'custom')
+          .map((template, i) => {
+            const [showPreview, setShowPreview] = useState(false)
+            return (
+              <CardButton
+                key={i}
+                title={template.label}
+                icon={
+                  <div
+                    className="duration-400 flex h-6 w-6 items-center justify-center rounded
                     bg-scale-1200
                     text-scale-100
                     transition-colors
                     group-hover:bg-brand-900
                     group-hover:text-brand-1200
                   "
-                >
-                  <div className="scale-100 group-hover:scale-110">
-                    <IconCode size={12} strokeWidth={2} />
-                  </div>
-                </div>
-              }
-              containerHeightClassName="h-40"
-              linkHref={`/project/${ref}/logs-explorer?q=${encodeURI(template.searchString)}`}
-              description={template.description}
-              footer={
-                <div className="flex flex-row justify-end">
-                  <Popover
-                    onOpenChange={setShowPreview}
-                    open={showPreview}
-                    className="rounded-lg bg-scale-100"
-                    size="content"
-                    overlay={
-                      <pre className="whitespace-pre-line break-words rounded-lg bg-scale-100 p-4 text-sm">
-                        {template.searchString}
-                      </pre>
-                    }
                   >
-                    <Button
-                      type="default"
-                      as="span"
-                      onClick={(e) => {
-                        e.preventDefault()
-                        setShowPreview(!showPreview)
-                      }}
+                    <div className="scale-100 group-hover:scale-110">
+                      <IconCode size={12} strokeWidth={2} />
+                    </div>
+                  </div>
+                }
+                containerHeightClassName="h-40"
+                linkHref={`/project/${ref}/logs-explorer?q=${encodeURI(template.searchString)}`}
+                description={template.description}
+                footer={
+                  <div className="flex flex-row justify-end">
+                    <Popover
+                      onOpenChange={setShowPreview}
+                      open={showPreview}
+                      className="rounded-lg bg-scale-100"
+                      size="content"
+                      overlay={
+                        <pre className="whitespace-pre-line break-words rounded-lg bg-scale-100 p-4 text-sm">
+                          {template.searchString}
+                        </pre>
+                      }
                     >
-                      Preview
-                    </Button>
-                  </Popover>
-                </div>
-              }
-            />
-          )
-        })}
+                      <Button
+                        type="default"
+                        as="span"
+                        onClick={(e) => {
+                          e.preventDefault()
+                          setShowPreview(!showPreview)
+                        }}
+                      >
+                        Preview
+                      </Button>
+                    </Popover>
+                  </div>
+                }
+              />
+            )
+          })}
       </div>
     </div>
   )


### PR DESCRIPTION
## What kind of change does this PR introduce?

Studio > Log Explorer Templates

## What is the current behavior?

The current log explorer templates are not in order and the Error Count by User template has no description

## What is the new behavior?

The templates are now in order and a description has been added to Error Count by User:

<img width="1311" alt="Screenshot 2022-10-14 at 14 16 50" src="https://user-images.githubusercontent.com/22655069/195856477-d880caf7-98fe-4ea0-b410-6b253efd5048.png">


## Additional context

New pull due to conflict on #9194
