### PR TITLE
add docs for supabase CLI completion

### DIFF
--- a/apps/reference/_cli/intro.mdx
+++ b/apps/reference/_cli/intro.mdx
@@ -16,9 +16,9 @@ The CLI is still under development, but it contains all the functionality for wo
 - CI/CD for releasing to production: [`supabase db push`](https://supabase.com/docs/reference/cli/usage#supabase-db-push)
 - Manage your Supabase projects: [`supabase projects`](https://supabase.com/docs/reference/cli/usage#supabase-projects)
 - Generate types directly from your database schema: [`supabase gen types`](https://supabase.com/docs/reference/cli/usage#supabase-gen)
-    - A [community-supported GitHub Action to generate Supabase DB types](https://github.com/lyqht/generate-supabase-db-types-github-action) also uses this command
-- Shell Autocomplete: [`supabase completion`](https://supabase.com/docs/reference/cli/usage#supabase-completion)
-    - A [community Fig autocomplete spec for supabase](https://fig.io/manual/supabase) is also available
+    - A [community-supported GitHub Action to generate TypeScript types](https://github.com/lyqht/generate-supabase-db-types-github-action) using this command
+- Shell autocomplete: [`supabase completion`](https://supabase.com/docs/reference/cli/usage#supabase-completion)
+    - A [community-supported Fig autocomplete spec for Supabase](https://fig.io/manual/supabase) is also available
 
 ## Additional Links
 

--- a/apps/reference/_cli/intro.mdx
+++ b/apps/reference/_cli/intro.mdx
@@ -16,6 +16,9 @@ The CLI is still under development, but it contains all the functionality for wo
 - CI/CD for releasing to production: [`supabase db push`](https://supabase.com/docs/reference/cli/usage#supabase-db-push)
 - Manage your Supabase projects: [`supabase projects`](https://supabase.com/docs/reference/cli/usage#supabase-projects)
 - Generate types directly from your database schema: [`supabase gen types`](https://supabase.com/docs/reference/cli/usage#supabase-gen)
+    - A [community-supported GitHub Action to generate Supabase DB types](https://github.com/lyqht/generate-supabase-db-types-github-action) also uses this command
+- Shell Autocomplete: [`supabase completion`](https://supabase.com/docs/reference/cli/usage#supabase-completion)
+    - A community Fig autocomplete spec for supabase is also available
 
 ## Additional Links
 

--- a/apps/reference/_cli/intro.mdx
+++ b/apps/reference/_cli/intro.mdx
@@ -16,9 +16,9 @@ The CLI is still under development, but it contains all the functionality for wo
 - CI/CD for releasing to production: [`supabase db push`](https://supabase.com/docs/reference/cli/usage#supabase-db-push)
 - Manage your Supabase projects: [`supabase projects`](https://supabase.com/docs/reference/cli/usage#supabase-projects)
 - Generate types directly from your database schema: [`supabase gen types`](https://supabase.com/docs/reference/cli/usage#supabase-gen)
-    - A community-supported [GitHub Action](https://github.com/lyqht/generate-supabase-db-types-github-action) to generate TypeScript types
+    - A [community-supported GitHub Action](https://github.com/lyqht/generate-supabase-db-types-github-action) to generate TypeScript types
 - Shell autocomplete: [`supabase completion`](https://supabase.com/docs/reference/cli/usage#supabase-completion)
-    - A community-supported [Fig autocomplete spec](https://fig.io/manual/supabase) for macOS terminal
+    - A [community-supported Fig autocomplete spec](https://fig.io/manual/supabase) for macOS terminal
 
 ## Additional Links
 

--- a/apps/reference/_cli/intro.mdx
+++ b/apps/reference/_cli/intro.mdx
@@ -18,7 +18,7 @@ The CLI is still under development, but it contains all the functionality for wo
 - Generate types directly from your database schema: [`supabase gen types`](https://supabase.com/docs/reference/cli/usage#supabase-gen)
     - A [community-supported GitHub Action to generate Supabase DB types](https://github.com/lyqht/generate-supabase-db-types-github-action) also uses this command
 - Shell Autocomplete: [`supabase completion`](https://supabase.com/docs/reference/cli/usage#supabase-completion)
-    - A community Fig autocomplete spec for supabase is also available
+    - A [community Fig autocomplete spec for supabase](https://fig.io/manual/supabase) is also available
 
 ## Additional Links
 

--- a/apps/reference/_cli/intro.mdx
+++ b/apps/reference/_cli/intro.mdx
@@ -16,9 +16,9 @@ The CLI is still under development, but it contains all the functionality for wo
 - CI/CD for releasing to production: [`supabase db push`](https://supabase.com/docs/reference/cli/usage#supabase-db-push)
 - Manage your Supabase projects: [`supabase projects`](https://supabase.com/docs/reference/cli/usage#supabase-projects)
 - Generate types directly from your database schema: [`supabase gen types`](https://supabase.com/docs/reference/cli/usage#supabase-gen)
-    - A community-supported [GitHub Action to generate TypeScript types](https://github.com/lyqht/generate-supabase-db-types-github-action)
+    - A community-supported [GitHub Action](https://github.com/lyqht/generate-supabase-db-types-github-action) to generate TypeScript types
 - Shell autocomplete: [`supabase completion`](https://supabase.com/docs/reference/cli/usage#supabase-completion)
-    - A community-supported [Fig autocomplete spec for macOS terminal](https://fig.io/manual/supabase)
+    - A community-supported [Fig autocomplete spec](https://fig.io/manual/supabase) for macOS terminal
 
 ## Additional Links
 

--- a/apps/reference/_cli/intro.mdx
+++ b/apps/reference/_cli/intro.mdx
@@ -16,9 +16,9 @@ The CLI is still under development, but it contains all the functionality for wo
 - CI/CD for releasing to production: [`supabase db push`](https://supabase.com/docs/reference/cli/usage#supabase-db-push)
 - Manage your Supabase projects: [`supabase projects`](https://supabase.com/docs/reference/cli/usage#supabase-projects)
 - Generate types directly from your database schema: [`supabase gen types`](https://supabase.com/docs/reference/cli/usage#supabase-gen)
-    - A [community-supported GitHub Action to generate TypeScript types](https://github.com/lyqht/generate-supabase-db-types-github-action) using this command
+    - A community-supported [GitHub Action to generate TypeScript types](https://github.com/lyqht/generate-supabase-db-types-github-action)
 - Shell autocomplete: [`supabase completion`](https://supabase.com/docs/reference/cli/usage#supabase-completion)
-    - A [community-supported Fig autocomplete spec for Supabase](https://fig.io/manual/supabase) is also available
+    - A community-supported [Fig autocomplete spec for macOS terminal](https://fig.io/manual/supabase)
 
 ## Additional Links
 

--- a/spec/cli_v1_commands.yaml
+++ b/spec/cli_v1_commands.yaml
@@ -567,3 +567,17 @@ commands:
       ```sh
         -h, --help   help for create
       ```
+  - id: supabase-completion
+    title: supabase completion
+    summary: Generate shell script for completion. Available for bash, zsh and fish.
+    tags: []
+    links: []
+    usage: |-
+      ```sh
+      supabase completion <shell name> [flags]
+      ```
+    subcommands: []
+    options: |-
+      ```sh
+        -h, --help   help for completion
+      ```


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## Additional context

I have added [a Fig autocomplete spec for Supabase CLI](https://github.com/withfig/autocomplete/pull/1557), and initially thought to add it to supabase CLI's README, but since its not automated to keep to date to the supabase CLI's updates yet, @sweatybridge suggested to add it here in the docs.