### PR TITLE
feat: Multi select dropdown icon

### DIFF
--- a/studio/components/ui/MultiSelect/index.tsx
+++ b/studio/components/ui/MultiSelect/index.tsx
@@ -6,7 +6,6 @@ import {
   IconAlertCircle,
   IconSearch,
   IconPlus,
-  IconArrowDown,
   IconChevronDown,
 } from 'ui'
 
@@ -259,7 +258,7 @@ export default function MultiSelect({
               }
             })}
             <div className="absolute inset-y-0 right-0 pl-3 pr-1 flex space-x-1 items-center cursor-pointer ">
-              <IconChevronDown className="text-scale-900"/>
+              <IconChevronDown className="text-scale-900" />
             </div>
           </div>
         </Popover>

--- a/studio/components/ui/MultiSelect/index.tsx
+++ b/studio/components/ui/MultiSelect/index.tsx
@@ -1,6 +1,14 @@
 import { useRef, useEffect, useState, FormEvent, KeyboardEvent, ReactNode } from 'react'
 import { orderBy, filter, without } from 'lodash'
-import { Popover, IconCheck, IconAlertCircle, IconSearch, IconPlus } from 'ui'
+import {
+  Popover,
+  IconCheck,
+  IconAlertCircle,
+  IconSearch,
+  IconPlus,
+  IconArrowDown,
+  IconChevronDown,
+} from 'ui'
 
 import { BadgeDisabled, BadgeSelected } from './Badges'
 
@@ -223,7 +231,7 @@ export default function MultiSelect({
         >
           <div
             className={[
-              'flex w-full flex-wrap items-start items-center gap-1.5 p-1.5',
+              'flex w-full flex-wrap items-start gap-1.5 p-1.5 cursor-default',
               `${selectedOptions.length === 0 ? 'h-9' : ''}`,
             ].join(' ')}
           >
@@ -250,6 +258,9 @@ export default function MultiSelect({
                 )
               }
             })}
+            <div className="absolute inset-y-0 right-0 pl-3 pr-1 flex space-x-1 items-center cursor-pointer ">
+              <IconChevronDown className="text-scale-900"/>
+            </div>
           </div>
         </Popover>
       </div>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Studio > Settings > API
Studio > Auth > Policies > Edit Policy

## What is the current behavior?

Currently the multi select does not indicate that you can multi select as the field looks like a normal input:

<img width="1161" alt="Screenshot 2022-10-17 at 12 03 43" src="https://user-images.githubusercontent.com/22655069/196165133-64e169dc-c6b3-494a-918f-c1b49d30fe28.png">


## What is the new behavior?

Added a chevron icon to indicate you can click on the multi select:

<img width="1161" alt="Screenshot 2022-10-17 at 12 18 04" src="https://user-images.githubusercontent.com/22655069/196165058-e74251e5-a574-45a8-97ee-679f92b6f6e5.png">


## Additional context

Closes #6630
