### PR TITLE
Fix: Small typo in realtime quick start example

### DIFF
--- a/apps/reference/docs/guides/realtime/quickstart.mdx
+++ b/apps/reference/docs/guides/realtime/quickstart.mdx
@@ -103,7 +103,7 @@ const channel = supabase.channel('calc-latency', {
 })
 
 channel.subscribe(async (status) => {
-    if (status === 'SUBSCRIBED) {
+    if (status === 'SUBSCRIBED') {
       const begin = performance.now()
 
       await channel.send({


### PR DESCRIPTION
## What kind of change does this PR introduce?

A small doc update to fix a missing closing `'` in the real time quick start example
