### PR TITLE
docs: workos sign in example

### DIFF
--- a/apps/reference/docs/guides/auth/auth-workos.mdx
+++ b/apps/reference/docs/guides/auth/auth-workos.mdx
@@ -65,12 +65,14 @@ async function signInWithWorkOS() {
   const { data, error } = await supabase.auth.signInWithOAuth(
     {
       provider: 'workos',
+      options: {
+        queryParams: {
+          connection: '<your_connection>',
+          organization: '<your_organization',
+          provider: '<your_provider>',
+        }
+      }
     },
-    {
-      connection: '<your_connection>',
-      organization: '<your_organization',
-      provider: '<your_provider>',
-    }
   )
 }
 ```


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs - [Work OS Login Example](https://supabase.com/docs/guides/auth/auth-workos#add-login-code-to-your-client-app)

## What is the current behavior?

This was picked up in issue #9604 where the login example is incorrect.

## What is the new behavior?

Example has been changed to use new sign in method:

<img width="865" alt="Screenshot 2022-10-18 at 15 16 58" src="https://user-images.githubusercontent.com/22655069/196456749-1ff344bf-9d82-499b-8132-a4f19b9237e5.png">


## Additional context

Closes #9604
