### PR TITLE
spec: fix missing dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,12 +16,13 @@
       ],
       "dependencies": {
         "@mdx-js/react": "^2.1.1",
-        "html-to-image": "^1.10.1",
         "mini-svg-data-uri": "^1.4.4"
       },
       "devDependencies": {
+        "@types/json-stringify-safe": "^5.0.0",
         "eslint": "^7.32.0",
         "eslint-config-custom": "*",
+        "json-stringify-safe": "^5.0.1",
         "prettier": "^2.5.1",
         "ts-jest": "^27.0.7",
         "turbo": "1.4.7"
@@ -9344,6 +9345,12 @@
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+      "dev": true
+    },
+    "node_modules/@types/json-stringify-safe": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz",
+      "integrity": "sha512-UUA1sH0RSRROdInuDOA1yoRzbi5xVFD1RHCoOvNRPTNwR8zBkJ/84PZ6NhKVDtKp0FTeIccJCdQz1X2aJPr4uw==",
       "dev": true
     },
     "node_modules/@types/json5": {
@@ -22584,6 +22591,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true
     },
     "node_modules/json5": {
       "version": "2.2.1",
@@ -43292,6 +43305,12 @@
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
       "dev": true
     },
+    "@types/json-stringify-safe": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz",
+      "integrity": "sha512-UUA1sH0RSRROdInuDOA1yoRzbi5xVFD1RHCoOvNRPTNwR8zBkJ/84PZ6NhKVDtKp0FTeIccJCdQz1X2aJPr4uw==",
+      "dev": true
+    },
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -53561,6 +53580,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true
     },
     "json5": {
       "version": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -28,11 +28,13 @@
     "perf:meta": "ab -t 5 -c 20 -T application/json http://localhost:5555/tables"
   },
   "devDependencies": {
+    "@types/json-stringify-safe": "^5.0.0",
     "eslint": "^7.32.0",
     "eslint-config-custom": "*",
+    "json-stringify-safe": "^5.0.1",
     "prettier": "^2.5.1",
-    "turbo": "1.4.7",
-    "ts-jest": "^27.0.7"
+    "ts-jest": "^27.0.7",
+    "turbo": "1.4.7"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
When running `make` under `spec` in isolation, these dependencies are missing.