### PR TITLE
chore: remove replace feature flags logs reports

### DIFF
--- a/studio/components/layouts/DatabaseLayout/DatabaseMenu.utils.ts
+++ b/studio/components/layouts/DatabaseLayout/DatabaseMenu.utils.ts
@@ -5,7 +5,7 @@ import { useFlag } from 'hooks'
 
 export const generateDatabaseMenu = (project?: Project): ProductMenuGroup[] => {
   const ref = project?.ref ?? 'default'
-  const reportsOverview = useFlag('reportsOverview')
+  const productReports = useFlag('productReports')
 
   const HOOKS_RELEASED = '2021-07-30T15:33:54.383Z'
   const showHooksRoute = project?.inserted_at ? project.inserted_at > HOOKS_RELEASED : false
@@ -47,7 +47,7 @@ export const generateDatabaseMenu = (project?: Project): ProductMenuGroup[] => {
                 url: `/project/${ref}/database/api-logs`,
                 items: [],
               },
-              ...(reportsOverview
+              ...(productReports
                 ? [
                     {
                       name: 'API usage',

--- a/studio/components/layouts/DatabaseLayout/DatabaseMenu.utils.ts
+++ b/studio/components/layouts/DatabaseLayout/DatabaseMenu.utils.ts
@@ -5,7 +5,6 @@ import { useFlag } from 'hooks'
 
 export const generateDatabaseMenu = (project?: Project): ProductMenuGroup[] => {
   const ref = project?.ref ?? 'default'
-  const logsRealtime = useFlag('logsRealtime')
   const reportsOverview = useFlag('reportsOverview')
 
   const HOOKS_RELEASED = '2021-07-30T15:33:54.383Z'
@@ -64,16 +63,12 @@ export const generateDatabaseMenu = (project?: Project): ProductMenuGroup[] => {
                 url: `/project/${ref}/database/postgres-logs`,
                 items: [],
               },
-              ...(logsRealtime
-                ? [
-                    {
-                      name: 'Realtime logs',
-                      key: 'realtime-logs',
-                      url: `/project/${ref}/database/realtime-logs`,
-                      items: [],
-                    },
-                  ]
-                : []),
+              {
+                name: 'Realtime logs',
+                key: 'realtime-logs',
+                url: `/project/${ref}/database/realtime-logs`,
+                items: [],
+              },
             ],
           },
         ]

--- a/studio/components/layouts/StorageLayout/StorageMenu.tsx
+++ b/studio/components/layouts/StorageLayout/StorageMenu.tsx
@@ -18,7 +18,6 @@ import {
 import ProductMenuItem from 'components/ui/ProductMenu/ProductMenuItem'
 import { STORAGE_ROW_STATUS } from 'components/to-be-cleaned/Storage/Storage.constants'
 import { useStorageStore } from 'localStores/storageExplorer/StorageExplorerStore'
-import Flag from 'components/ui/Flag/Flag'
 
 interface Props {}
 
@@ -109,13 +108,11 @@ const StorageMenu: FC<Props> = () => {
               <p className="truncate">Policies</p>
             </Menu.Item>
           </Link>
-          <Flag name="logsStorage">
-            <Link href={`/project/${projectRef}/storage/logs`}>
-              <Menu.Item rounded active={page === 'logs'}>
-                <p className="truncate">Logs</p>
-              </Menu.Item>
-            </Link>
-          </Flag>
+          <Link href={`/project/${projectRef}/storage/logs`}>
+            <Menu.Item rounded active={page === 'logs'}>
+              <p className="truncate">Logs</p>
+            </Menu.Item>
+          </Link>
         </div>
       </div>
     </Menu>


### PR DESCRIPTION
Removes `logsRealtime` and `logsStorage`, and replaces `reportsOverview` with `productReports`