### PR TITLE
fix: flutter svg

### DIFF
--- a/studio/public/img/libraries/flutter-icon.svg
+++ b/studio/public/img/libraries/flutter-icon.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="317px" height="317px" viewBox="-30.5 0 317 317" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" preserveAspectRatio="xMidYMid">
+    <defs>
+        <linearGradient x1="3.9517088%" y1="26.9930287%" x2="75.8970734%" y2="52.9192657%" id="linearGradient-1">
+            <stop stop-color="#000000" offset="0%"></stop>
+            <stop stop-color="#000000" stop-opacity="0" offset="100%"></stop>
+        </linearGradient>
+    </defs>
+		<g>
+				<polygon fill="#47C5FB" points="157.665785 0.000549356223 0.000549356223 157.665785 48.8009614 206.466197 255.267708 0.000549356223"></polygon>
+				<polygon fill="#47C5FB" points="156.567183 145.396793 72.1487107 229.815265 121.132608 279.530905 169.842925 230.820587 255.267818 145.396793"></polygon>
+				<polygon fill="#00569E" points="121.133047 279.531124 158.214592 316.61267 255.267159 316.61267 169.842266 230.820807"></polygon>
+				<polygon fill="#00B5F8" points="71.5995742 230.364072 120.401085 181.562561 169.842046 230.821136 121.132827 279.531454"></polygon>
+				<polygon fill-opacity="0.8" fill="url(#linearGradient-1)" points="121.132827 279.531454 161.692896 266.072227 165.721875 234.941308"></polygon>
+		</g>
+</svg>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Studio Fix

## What is the current behavior?

On the project dashboard screen the flutter logo is broken:

<img width="1288" alt="Screenshot 2022-10-20 at 14 07 10" src="https://user-images.githubusercontent.com/22655069/196957217-c4d45d03-b98f-4fc5-b526-1908a40bb7cd.png">


## What is the new behavior?

Flutter svg has been added:

<img width="1288" alt="Screenshot 2022-10-20 at 14 06 59" src="https://user-images.githubusercontent.com/22655069/196957265-81621fec-5eb1-4c65-b01c-7c0f91b73dd5.png">
