### PR TITLE
feat: improved auth logs interface

### DIFF
--- a/studio/components/interfaces/Settings/Logs/LogColumnRenderers/AuthColumnRenderer.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogColumnRenderers/AuthColumnRenderer.tsx
@@ -1,3 +1,4 @@
+import { tryParseJson } from 'lib/helpers'
 import { PreviewLogData } from '..'
 import { AuthEventParsed } from '../LogSelectionRenderers/AuthSelectionRenderer'
 import {
@@ -10,18 +11,18 @@ import {
 export default [
   {
     formatter: (data: { row: PreviewLogData }) => {
-      let parsed: AuthEventParsed | undefined
-      try {
-        parsed = JSON.parse(data.row.event_message.trim())
-      } catch (_e) {
-        // do nothing
-      }
+      const parsed: AuthEventParsed | undefined = tryParseJson(data.row.event_message.trim())
 
       return (
         <RowLayout>
           <TimestampLocalFormatter value={data.row.timestamp!} />
           {parsed?.level && <SeverityFormatter value={parsed?.level} />}
-          <TextFormatter className="w-full" value={`${parsed?.path? parsed?.path + " | ": ""}${parsed?.msg.trim() || data.row.event_message}`} />
+          <TextFormatter
+            className="w-full"
+            value={`${parsed?.path ? parsed?.path + ' | ' : ''}${
+              parsed?.msg.trim() || data.row.event_message
+            }`}
+          />
         </RowLayout>
       )
     },

--- a/studio/components/interfaces/Settings/Logs/LogColumnRenderers/AuthColumnRenderer.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogColumnRenderers/AuthColumnRenderer.tsx
@@ -1,0 +1,29 @@
+import { PreviewLogData } from '..'
+import { AuthEventParsed } from '../LogSelectionRenderers/AuthSelectionRenderer'
+import {
+  RowLayout,
+  SeverityFormatter,
+  TextFormatter,
+  TimestampLocalFormatter,
+} from '../LogsFormatters'
+
+export default [
+  {
+    formatter: (data: { row: PreviewLogData }) => {
+      let parsed: AuthEventParsed | undefined
+      try {
+        parsed = JSON.parse(data.row.event_message.trim())
+      } catch (_e) {
+        // do nothing
+      }
+
+      return (
+        <RowLayout>
+          <TimestampLocalFormatter value={data.row.timestamp!} />
+          {parsed?.level && <SeverityFormatter value={parsed?.level} />}
+          <TextFormatter className="w-full" value={`${parsed?.path? parsed?.path + " | ": ""}${parsed?.msg.trim() || data.row.event_message}`} />
+        </RowLayout>
+      )
+    },
+  },
+]

--- a/studio/components/interfaces/Settings/Logs/LogSelection.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogSelection.tsx
@@ -18,6 +18,7 @@ import {
 import useSingleLog from 'hooks/analytics/useSingleLog'
 import Connecting from 'components/ui/Loading/Loading'
 import CopyButton from 'components/ui/CopyButton'
+import AuthSelectionRenderer from './LogSelectionRenderers/AuthSelectionRenderer'
 
 export interface LogSelectionProps {
   log: LogData | null
@@ -57,6 +58,10 @@ const LogSelection: FC<LogSelectionProps> = ({
       case 'functions':
         if (!fullLog) return null
         return <FunctionLogsSelectionRender log={fullLog} />
+
+      case 'auth':
+        if (!fullLog) return null
+        return <AuthSelectionRenderer log={fullLog} />
 
       default:
         if (queryType && fullLog && isDefaultLogPreviewFormat(fullLog)) {

--- a/studio/components/interfaces/Settings/Logs/LogSelectionRenderers/AuthSelectionRenderer.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogSelectionRenderers/AuthSelectionRenderer.tsx
@@ -1,0 +1,74 @@
+import { parse } from 'crypto-js/enc-utf8'
+import { isUnixMicro, PreviewLogData, unixMicroToIsoTimestamp } from '..'
+import { LOGS_TAILWIND_CLASSES } from '../Logs.constants'
+import {
+  jsonSyntaxHighlight,
+  ResponseCodeFormatter,
+  SelectionDetailedRow,
+  SeverityFormatter,
+} from '../LogsFormatters'
+
+export interface AuthEventParsed extends Record<string, string | number> {
+  component: string
+  error: string
+  method: string
+  level: string
+  msg: string
+  path: string
+  status: number
+}
+const AuthSelectionRenderer = ({ log }: { log: PreviewLogData }) => {
+  let parsed: AuthEventParsed | undefined
+  try {
+    parsed = JSON.parse(log.event_message.trim())
+  } catch (_e) {
+    // do nothing
+  }
+  return (
+    <div className={`${LOGS_TAILWIND_CLASSES.log_selection_x_padding} space-y-6`}>
+      <div className="flex flex-col gap-3">
+        <h3 className="text-scale-900 text-sm">Event Message</h3>
+        <div className="text-xs text-wrap font-mono text-scale-1200 whitespace-pre-wrap overflow-x-auto">
+          {parsed?.msg || log.event_message}
+        </div>
+      </div>
+
+      <SelectionDetailedRow
+        label="ISO Timestamp"
+        value={
+          isUnixMicro(log.timestamp)
+            ? unixMicroToIsoTimestamp(log.timestamp)
+            : String(log.timestamp)
+        }
+      />
+      {parsed?.status && (
+        <SelectionDetailedRow
+          label="Status"
+          value={String(parsed.status)}
+          valueRender={<ResponseCodeFormatter value={parsed.status} />}
+        />
+      )}
+      {parsed?.level && (
+        <SelectionDetailedRow
+          label="Severity"
+          value={parsed.level}
+          valueRender={<SeverityFormatter value={parsed.level} />}
+        />
+      )}
+      {parsed?.path && <SelectionDetailedRow label="Request Path" value={parsed.path} />}
+      {parsed?.error && <SelectionDetailedRow label="Error Message" value={parsed.error} />}
+
+      <div className="flex flex-col gap-3">
+        <h3 className="text-scale-900 text-sm">Metadata</h3>
+        <pre
+          className=" className={`text-scale-1200 text-sm col-span-8 overflow-x-auto text-xs font-mono`}"
+          dangerouslySetInnerHTML={{
+            __html: jsonSyntaxHighlight(parsed || log.metadata!),
+          }}
+        />
+      </div>
+    </div>
+  )
+}
+
+export default AuthSelectionRenderer

--- a/studio/components/interfaces/Settings/Logs/LogSelectionRenderers/AuthSelectionRenderer.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogSelectionRenderers/AuthSelectionRenderer.tsx
@@ -1,4 +1,5 @@
 import { parse } from 'crypto-js/enc-utf8'
+import { tryParseJson } from 'lib/helpers'
 import { isUnixMicro, PreviewLogData, unixMicroToIsoTimestamp } from '..'
 import { LOGS_TAILWIND_CLASSES } from '../Logs.constants'
 import {
@@ -18,12 +19,8 @@ export interface AuthEventParsed extends Record<string, string | number> {
   status: number
 }
 const AuthSelectionRenderer = ({ log }: { log: PreviewLogData }) => {
-  let parsed: AuthEventParsed | undefined
-  try {
-    parsed = JSON.parse(log.event_message.trim())
-  } catch (_e) {
-    // do nothing
-  }
+  const parsed: AuthEventParsed | undefined = tryParseJson(log.event_message.trim())
+
   return (
     <div className={`${LOGS_TAILWIND_CLASSES.log_selection_x_padding} space-y-6`}>
       <div className="flex flex-col gap-3">

--- a/studio/components/interfaces/Settings/Logs/LogTable.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogTable.tsx
@@ -14,7 +14,7 @@ import ResourcesExceededErrorRenderer from './LogsErrorRenderers/ResourcesExceed
 import DefaultErrorRenderer from './LogsErrorRenderers/DefaultErrorRenderer'
 import FunctionsLogsColumnRender from './LogColumnRenderers/FunctionsLogsColumnRender'
 import FunctionsEdgeColumnRender from './LogColumnRenderers/FunctionsEdgeColumnRender'
-import Divider from 'components/ui/Divider'
+import AuthColumnRenderer from './LogColumnRenderers/AuthColumnRenderer'
 
 interface Props {
   data?: Array<LogData | Object>
@@ -111,6 +111,10 @@ const LogTable = ({
         break
       case 'functions':
         columns = FunctionsLogsColumnRender
+        break
+
+      case 'auth':
+        columns = AuthColumnRenderer
         break
 
       default:

--- a/studio/tests/pages/projects/LogTable.test.js
+++ b/studio/tests/pages/projects/LogTable.test.js
@@ -113,6 +113,18 @@ test.each([
     includes: [/POST/, 'this-is-some-path'],
     excludes: [],
   },
+  {
+    queryType: 'auth',
+    data: [
+      {
+        event_message: JSON.stringify({msg: "some message", path: "/auth-path", level: "info"}),
+        timestamp: 1659545029083869,
+        id: '4475cf6f-2929-4296-ab44-ce2c17069937',
+      },
+    ],
+    includes: [/auth\-path/, /some message/, /INFO/],
+    excludes: [/\{/, /\}/],
+  },
 ])('table col renderer for $queryType', async ({ queryType, data, includes, excludes }) => {
   render(<LogTable queryType={queryType} data={data} />)
 

--- a/studio/tests/pages/projects/LogsPreviewer.test.js
+++ b/studio/tests/pages/projects/LogsPreviewer.test.js
@@ -102,6 +102,35 @@ test.each([
     selectionTexts: [/POST/],
   },
   // TODO: add more tests for each type of ui
+
+  {
+    queryType: 'auth',
+    tableName: undefined,
+    tableLog: logDataFixture({
+      id: 'some-id',
+      event_message: JSON.stringify({
+        msg: 'some message',
+        path: '/auth-path',
+        level: 'info',
+        status: 300,
+      }),
+      timestamp: 1659545029083869,
+      id: '4475cf6f-2929-4296-ab44-ce2c17069937',
+    }),
+    selectionLog: logDataFixture({
+      id: 'some-id',
+      event_message: JSON.stringify({
+        msg: 'some message',
+        path: '/auth-path',
+        level: 'info',
+        status: 300,
+      }),
+      timestamp: 1659545029083869,
+      id: '4475cf6f-2929-4296-ab44-ce2c17069937',
+    }),
+    tableTexts: [/auth\-path/, /some message/, /INFO/],
+    selectionTexts: [/auth\-path/, /some message/, /INFO/, /300/],
+  },
 ])(
   'selection $queryType $tableName , can display log data and metadata',
   async ({ queryType, tableName, tableLog, selectionLog, tableTexts, selectionTexts }) => {


### PR DESCRIPTION
Improved selection renderers and column renderers, for auth logs. Includes workarounds for metadata parsing on client side, based on event message.

Depends on #9713 

https://user-images.githubusercontent.com/22714384/197183569-eca83fd0-de99-4815-bc89-35751a5e4754.mov

