### PR TITLE
feat: add logs explorer template for auth logs

### DIFF
--- a/studio/components/interfaces/Settings/Logs/Logs.constants.ts
+++ b/studio/components/interfaces/Settings/Logs/Logs.constants.ts
@@ -183,6 +183,21 @@ limit 100
 `,
     for: ['database'],
   },
+  {
+    label: 'Auth Endpoint Events',
+    description: 'Endpoint events filtered by path',
+    mode: 'custom',
+    searchString: `select
+  t.timestamp,
+  event_message
+from auth_logs as t
+where
+  regexp_contains(event_message,"level.{3}(info|warning||error|fatal)")
+  -- and regexp_contains(event_message,"path.{3}(/token|/recover|/signup|/otp)")
+limit 100
+`,
+    for: ['database'],
+  },
 ]
 
 export const LOG_TYPE_LABEL_MAPPING: { [k: string]: string } = {


### PR DESCRIPTION
Adds in log explorer templates for auth logs

<img width="1408" alt="Screenshot 2022-10-21 at 7 30 48 PM" src="https://user-images.githubusercontent.com/22714384/197186207-b1db02e4-4dbc-4802-9951-1eee57b6fc40.png">
