### PR TITLE
fix: issue because of is_super_admin being null

### DIFF
--- a/docker/volumes/db/init/01-auth-schema.sql
+++ b/docker/volumes/db/init/01-auth-schema.sql
@@ -22,7 +22,7 @@ CREATE TABLE auth.users (
 	last_sign_in_at timestamptz NULL,
 	raw_app_meta_data jsonb NULL,
 	raw_user_meta_data jsonb NULL,
-	is_super_admin bool NULL,
+	is_super_admin bool NOT NULL DEFAULT FALSE,
 	created_at timestamptz NULL,
 	updated_at timestamptz NULL,
 	CONSTRAINT users_pkey PRIMARY KEY (id)


### PR DESCRIPTION
## Bug fix
## What is the current behavior?
I am running local docker instance. imported my database as per supabase documentation. using pg_dump & psql.

now some users had **is_super_admin** column as **null** in **auth.users** table after I was done with import in my local instance.

so when I tried to send password recovery link to user from http://localhost:3000/project/default/auth/users it was giving this error in logs.

`supabase-auth      | {"component":"api","error":"error finding user: sql: Scan error on column index 17, name \"is_super_admin\": sql/driver: couldn't convert \u003cnil\u003e (\u003cnil\u003e) into type bool","level":"error","method":"POST","msg":"500: Unable to process request","path":"/recover","referer":"","remote_addr":"172.21.0.4:35012","timestamp":"2022-10-21T12:12:38Z"}
`
## What is the new behavior?

after setting false value where is_super_admin was null using,
`update auth.users set is_super_admin=true where is_super_admin is null
`
it fixed the issue locally, however with this pr change we can fix it globally.

## Additional context

also was not able to login in my app because of this issue.. (built using js sdk in nextjs).