### PR TITLE
Add import to apply global css to the app to Next.js guide

### DIFF
--- a/apps/reference/docs/guides/with-nextjs.mdx
+++ b/apps/reference/docs/guides/with-nextjs.mdx
@@ -240,6 +240,7 @@ npm install @supabase/auth-helpers-react @supabase/auth-helpers-nextjs
 Wrap your `pages/_app.js` component with the `SessionContextProvider` component:
 
 ```jsx title="pages/_app.js"
+import '../styles/globals.css'
 import { createBrowserSupabaseClient } from '@supabase/auth-helpers-nextjs'
 import { SessionContextProvider } from '@supabase/auth-helpers-react'
 


### PR DESCRIPTION
Currently, global CSS is not applied after following the guide. This PR fixes that. 