### PR TITLE
Update supabase-js setSession() example to reflect updated usage

### DIFF
--- a/spec/supabase_js_v2.yml
+++ b/spec/supabase_js_v2.yml
@@ -333,17 +333,17 @@ pages:
     title: 'setSession()'
     $ref: '@supabase/gotrue-js.GoTrueClient.setSession'
     notes: |
-      - `setSession()` takes in a refresh token and uses it to get a new session.
+      - `setSession()` takes in a refresh token and access token and uses it to get a new session.
       - The refresh token can only be used once to obtain a new session.
       - Refresh token rotation (see [`REFRESH_TOKEN_ROTATION_ENABLED`](https://supabase.com/docs/reference/auth/config#refresh_token_rotation_enabled)) is enabled by default on all projects to guard against replay attacks. 
       - You can configure the [`REFRESH_TOKEN_REUSE_INTERVAL`](https://supabase.com/docs/reference/auth/config#refresh_token_reuse_interval) which provides a short window in which the same refresh token can be used multiple times in the event of concurrency or offline issues.
     examples:
       - name: Refresh the session
-        description: Sets the session data from refresh_token and returns current session or an error if the refresh_token is invalid.
+        description: Sets the session data from a refresh_token and access_token and returns current session or an error if the tokens are invalid.
         isSpotlight: true
         js: |
           ```js
-            const { data, error } = supabase.auth.setSession(refresh_token)
+            const { data, error } = supabase.auth.setSession({refresh_token, access_token})
           ```
   auth.onAuthStateChange():
     title: 'onAuthStateChange()'

--- a/spec/supabase_js_v2.yml
+++ b/spec/supabase_js_v2.yml
@@ -338,7 +338,7 @@ pages:
       - Refresh token rotation (see [`REFRESH_TOKEN_ROTATION_ENABLED`](https://supabase.com/docs/reference/auth/config#refresh_token_rotation_enabled)) is enabled by default on all projects to guard against replay attacks. 
       - You can configure the [`REFRESH_TOKEN_REUSE_INTERVAL`](https://supabase.com/docs/reference/auth/config#refresh_token_reuse_interval) which provides a short window in which the same refresh token can be used multiple times in the event of concurrency or offline issues.
     examples:
-      - name: Refresh the session
+      - name: Set the session
         description: Sets the session data from a refresh_token and access_token and returns current session or an error if the tokens are invalid.
         isSpotlight: true
         js: |


### PR DESCRIPTION
## What kind of change does this PR introduce?

Update the setSession() example in the supabase-js vs docs.

Fixes supabase/supabase-js#633 

## What is the current behavior?

The docs show an incorrect usage example for the function.

## What is the new behavior?

The docs show a correct usage example of the function.

In a larger context, this usage is required for Expo and react-native. I plan to update the Expo example to reflect this in a separate issue.
