### PR TITLE
Remove the list from the code block

### DIFF
--- a/apps/reference/docs/guides/with-flutter.mdx
+++ b/apps/reference/docs/guides/with-flutter.mdx
@@ -47,12 +47,10 @@ Run `flutter pub get` to install the dependencies.
 
 Now that we have the dependencies installed let's setup deep links so users who have logged in via magic link or OAuth can come back to the app.
 
-```sh
 1. Go to the "Authentication" section.
 2. Click "Settings" in the sidebar.
 3. Type `io.supabase.flutterquickstart://login-callback/` in the Additional Redirect URLs input field.
 4. Hit save.
-```
 
 ![Supabase console deep link setting](/img/deeplink-setting.png)
 

--- a/apps/reference/docs/guides/with-flutter.mdx
+++ b/apps/reference/docs/guides/with-flutter.mdx
@@ -47,10 +47,8 @@ Run `flutter pub get` to install the dependencies.
 
 Now that we have the dependencies installed let's setup deep links so users who have logged in via magic link or OAuth can come back to the app.
 
-1. Go to the "Authentication" section.
-2. Click "Settings" in the sidebar.
-3. Type `io.supabase.flutterquickstart://login-callback/` in the Additional Redirect URLs input field.
-4. Hit save.
+1. Go to [Authentication Settings](https://app.supabase.com/project/_/auth/settings) in the Dashboard.
+1. In **Redirect URLs**, add `io.supabase.flutterquickstart://login-callback/` as a new domain.
 
 ![Supabase console deep link setting](/img/deeplink-setting.png)
 


### PR DESCRIPTION
Setup deep links contain the list of actions inside the code block. It doesn't seem correct according to the other pages of docs.

## What kind of change does this PR introduce?

Docs update.

## What is the current behavior?

The list of actions inside `Setup deep links` sits inside the code block which seems incorrect.

## What is the new behavior?

Code block formatting was removed, therefore the list of actions is displayed as the other lists in docs.

## Additional context

As an example you can compare two sections:
- https://supabase.com/docs/guides/with-flutter#get-the-api-keys
- https://supabase.com/docs/guides/with-flutter#setup-deep-links
