### PR TITLE
Fix 404 in blog link

### DIFF
--- a/apps/www/_blog/2022-07-18-seen-by-in-postgresql.mdx
+++ b/apps/www/_blog/2022-07-18-seen-by-in-postgresql.mdx
@@ -732,7 +732,7 @@ As usual, Postgres has the tools to solve the problem _reasonably_ well (if not 
 [pg-gin]: https://www.postgresql.org/docs/14/indexes-types.html#INDEXES-TYPES-GIN
 [wiki-muri]: https://en.wikipedia.org/wiki/Muri_(Japanese_term)
 [lz4]: https://github.com/lz4/lz4
-[clickhouse]: clickhouse.tech/
+[clickhouse]: https://clickhouse.com/
 [wiki-bloom-filter]: https://en.wikipedia.org/wiki/Bloom_filter
 [wiki-hll]: https://en.wikipedia.org/wiki/HyperLogLog
 [pg-cron]: https://github.com/citusdata/pg_cron

--- a/apps/www/_blog/2022-07-18-seen-by-in-postgresql.mdx
+++ b/apps/www/_blog/2022-07-18-seen-by-in-postgresql.mdx
@@ -732,7 +732,7 @@ As usual, Postgres has the tools to solve the problem _reasonably_ well (if not 
 [pg-gin]: https://www.postgresql.org/docs/14/indexes-types.html#INDEXES-TYPES-GIN
 [wiki-muri]: https://en.wikipedia.org/wiki/Muri_(Japanese_term)
 [lz4]: https://github.com/lz4/lz4
-[clickhouse]: https://clickhouse.com/
+[clickhouse]: https://clickhouse.com
 [wiki-bloom-filter]: https://en.wikipedia.org/wiki/Bloom_filter
 [wiki-hll]: https://en.wikipedia.org/wiki/HyperLogLog
 [pg-cron]: https://github.com/citusdata/pg_cron


### PR DESCRIPTION
The URL was leading to 404 page due to relative location

## What kind of change does this PR introduce?

Minor blog post link update

## What is the current behavior?

https://github.com/supabase/supabase/issues/9785

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
