### PR TITLE
Add missing `type` param in `verifyOTP()` example

### DIFF
--- a/apps/reference/docs/guides/auth/auth-twilio.mdx
+++ b/apps/reference/docs/guides/auth/auth-twilio.mdx
@@ -145,7 +145,7 @@ values={[
 let { session, error } = await supabase.auth.verifyOTP({
   phone: '+13334445555',
   token: '123456',
-  type:"sms"
+  type: 'sms',
 })
 ```
 
@@ -261,6 +261,7 @@ values={[
 let { session, error } = await supabase.auth.verifyOTP({
   phone: '+13334445555',
   token: '123456',
+  type: 'sms',
 })
 ```
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Missing `type` param in `verifyOTP()`

## Additional context

Follow-up from https://github.com/supabase/supabase/pull/9795
