### PR TITLE
docs: add Realtime pricing to pricing page

### DIFF
--- a/apps/www/data/Pricing.json
+++ b/apps/www/data/Pricing.json
@@ -21,7 +21,7 @@
         }
       },
       {
-        "title": "Realtime functionality",
+        "title": "Realtime Change Data Capture",
         "tiers": {
           "free": true,
           "pro": true,
@@ -376,6 +376,36 @@
           "free": false,
           "pro": false,
           "enterprise": true
+        }
+      }
+    ]
+  },
+  "realtime": {
+    "title": "Realtime",
+    "icon": "M18.87,12.07l-6,9.47A1,1,0,0,1,12,22a.9.9,0,0,1-.28,0A1,1,0,0,1,11,21V15H6.82a2,2,0,0,1-1.69-3.07l6-9.47A1,1,0,0,1,12.28,2,1,1,0,0,1,13,3V9h4.18a2,2,0,0,1,1.69,3.07Z",
+    "features": [
+      {
+        "title": "Max concurrent connections",
+        "tiers": {
+          "free": "200",
+          "pro": "500",
+          "enterprise": "Unlimited"
+        }
+      },
+      {
+        "title": "Total messages",
+        "tiers": {
+          "free": "2 million per month",
+          "pro": "5 million per month",
+          "enterprise": "Unlimited"
+        }
+      },
+      {
+        "title": "Max message payload",
+        "tiers": {
+          "free": "250 KB",
+          "pro": "1 MB",
+          "enterprise": "1 MB"
         }
       }
     ]

--- a/apps/www/data/PricingAddOn.json
+++ b/apps/www/data/PricingAddOn.json
@@ -5,7 +5,7 @@
       "Fully Managed PostgreSQL",
       "Dedicated Postgres Database",
       "Optimized Database Instances",
-      "Realtime Functionality"
+      "Realtime Change Data Capture"
     ],
     "rows": [
       {

--- a/apps/www/pages/pricing/CHANGELOG.txt
+++ b/apps/www/pages/pricing/CHANGELOG.txt
@@ -1,5 +1,10 @@
 Pricing Changelog
 
+### 24 October 2022
+----
+
+Realtime pricing announced
+
 ### 16 June 2022
 ----
 

--- a/apps/www/pages/pricing/index.tsx
+++ b/apps/www/pages/pricing/index.tsx
@@ -349,6 +349,11 @@ export default function IndexPage() {
                 icon={Solutions['edge-functions'].icon}
               />
               <PricingTableRowMobile
+                category={pricing.realtime}
+                tier={'free'}
+                icon={pricing.realtime.icon}
+              />
+              <PricingTableRowMobile
                 category={pricing.dashboard}
                 tier={'free'}
                 icon={pricing.dashboard.icon}
@@ -386,6 +391,11 @@ export default function IndexPage() {
                 category={pricing['edge-functions']}
                 tier={'pro'}
                 icon={Solutions['edge-functions'].icon}
+              />
+              <PricingTableRowMobile
+                category={pricing.realtime}
+                tier={'pro'}
+                icon={pricing.realtime.icon}
               />
               <PricingTableRowMobile
                 category={pricing.dashboard}
@@ -426,6 +436,11 @@ export default function IndexPage() {
                 category={pricing['edge-functions']}
                 tier={'enterprise'}
                 icon={Solutions['edge-functions'].icon}
+              />
+              <PricingTableRowMobile
+                category={pricing.realtime}
+                tier={'enterprise'}
+                icon={pricing.realtime.icon}
               />
               <PricingTableRowMobile
                 category={pricing.dashboard}
@@ -571,6 +586,10 @@ export default function IndexPage() {
                   <PricingTableRowDesktop
                     category={pricing['edge-functions']}
                     icon={Solutions['edge-functions'].icon}
+                  />
+                  <PricingTableRowDesktop
+                    category={pricing.realtime}
+                    icon={pricing.realtime.icon}
                   />
                   <PricingTableRowDesktop
                     category={pricing.dashboard}


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the new behavior?

Add Realtime pricing to Supabase pricing page.

## Additional context

<img width="1294" alt="Screen Shot 2022-10-24 at 22 30 54" src="https://user-images.githubusercontent.com/5532241/197690533-5ddd1d78-a2f8-4931-bd6d-3ab697cab136.png">
<img width="1267" alt="Screen Shot 2022-10-24 at 22 31 05" src="https://user-images.githubusercontent.com/5532241/197690530-c84c32ff-41d6-49f8-a3d3-7bf209f6e923.png">
<img width="1289" alt="Screen Shot 2022-10-24 at 22 21 48" src="https://user-images.githubusercontent.com/5532241/197690537-c14f29c2-f27b-4131-9465-c985122192f8.png">

### Mobile views

<img width="480" alt="Screen Shot 2022-10-24 at 22 27 26" src="https://user-images.githubusercontent.com/5532241/197690536-ca62ebde-1a75-4524-bca4-1500711407dd.png">
<img width="490" alt="Screen Shot 2022-10-24 at 22 27 40" src="https://user-images.githubusercontent.com/5532241/197690535-5b278fbe-7058-4982-8165-6b4feee7e487.png">
<img width="483" alt="Screen Shot 2022-10-24 at 22 28 16" src="https://user-images.githubusercontent.com/5532241/197690534-8aa77ff7-1354-4d68-8be4-fd428c9fcffb.png">