### PR TITLE
Docs update - Expand guide for generating types from the CLI

### DIFF
--- a/apps/reference/_supabase_js/working-with-types.md
+++ b/apps/reference/_supabase_js/working-with-types.md
@@ -10,7 +10,7 @@ id: typescript-support
 
 You can use the [Supabase CLI](/docs/guides/cli) to generate types directly from your Postgres database’s schema:
 
-### For databases hosted in the Supabase Cloud
+### Generate types from a remote database
 
 Install the [Supabase CLI](/docs/guides/cli#installation) locally, and then run:
 
@@ -20,7 +20,7 @@ supabase projects list
 supabase gen types typescript --project-id <project_id> > lib/database.types.ts
 ```
 
-### For databases running in a Supabase local development environment
+### Generate types from a local database
 
 Set up your [local development environment](/docs/guides/cli/local-development), and then run:
 
@@ -29,7 +29,7 @@ supabase start
 supabase gen types typescript --local > lib/database.types.ts
 ```
 
-For additional ways to generate types, see the [CLI Reference Docs](/docs/reference/cli/usage#supabase-gen-types).
+For additional methods, see the [CLI Reference Docs](/docs/reference/cli/usage#supabase-gen-types).
 
 These types are generated directly from your database. Given a table `public.movies`, the definition will provide the following data:
 

--- a/apps/reference/_supabase_js/working-with-types.md
+++ b/apps/reference/_supabase_js/working-with-types.md
@@ -11,7 +11,9 @@ id: typescript-support
 You can use the [Supabase CLI](/docs/guides/cli) to generate types directly from your Postgres database’s schema:
 
 ### For databases hosted in the Supabase Cloud
+
 Install the [Supabase CLI](/docs/guides/cli#installation) locally, and then run:
+
 ```bash
 supabase login
 supabase projects list
@@ -19,7 +21,9 @@ supabase gen types typescript --project-id <project_id> > lib/database.types.ts
 ```
 
 ### For databases running in a Supabase local development environment
+
 Set up your [local development environment](/docs/guides/cli/local-development), and then run:
+
 ```bash
 supabase start
 supabase gen types typescript --local > lib/database.types.ts

--- a/apps/reference/_supabase_js/working-with-types.md
+++ b/apps/reference/_supabase_js/working-with-types.md
@@ -8,12 +8,24 @@ id: typescript-support
 
 ## Generating types
 
-You can use our CLI to generate types:
+You can use the [Supabase CLI](/docs/guides/cli) to generate types directly from your Postgres database’s schema:
 
+### For databases hosted in the Supabase Cloud
+Install the [Supabase CLI](/docs/guides/cli#installation) locally, and then run:
+```bash
+supabase login
+supabase projects list
+supabase gen types typescript --project-id <project_id> > lib/database.types.ts
+```
+
+### For databases running in a Supabase local development environment
+Set up your [local development environment](/docs/guides/cli/local-development), and then run:
 ```bash
 supabase start
 supabase gen types typescript --local > lib/database.types.ts
 ```
+
+For additional ways to generate types, see the [CLI Reference Docs](/docs/reference/cli/usage#supabase-gen-types).
 
 These types are generated directly from your database. Given a table `public.movies`, the definition will provide the following data:
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
Docs update - javascript/typescript-support

## What is the current behavior?
The reference docs for javascript/typescript-support currently provide an instruction for generating types, but it only applies to users running a local development environment.

## What is the new behavior?
- Added an instruction for generating types for those hosting their project on the Supabase Platform.  (thank you [soedirgo](https://github.com/soedirgo) for providing this [guidance](https://github.com/supabase/cli/issues/327#issuecomment-1289606191) in issue supabase/cli#327
- Also added clarification to existing type gen instructions, such that the reader knows they apply for those with a local development running Supabase in a Docker container. 
- Also linked to the full list of type gen options in the reference docs.
