### PR TITLE
docs: telegram edge function URL example

### DIFF
--- a/examples/edge-functions/supabase/functions/telegram-bot/README.md
+++ b/examples/edge-functions/supabase/functions/telegram-bot/README.md
@@ -9,5 +9,5 @@ Try it out: https://t.me/supabase_example_bot
 1. Run `supabase functions deploy --no-verify-jwt telegram-bot`
 2. Get your Telegram token from https://t.me/BotFather
 3. Run `supabase secrets set TELEGRAM_BOT_TOKEN=your_token FUNCTION_SECRET=random_secret`
-4. Set your bot's webhook url to `https://<PROJECT_NAME>.functions.supabase.co/telegram-bot` (Replacing `<...>` with respective values). In order to do that, run this url (in your browser, for example): `https://api.telegram.org/bot<TELEGRAM_BOT_TOKEN>/setWebhook?url=https://<PROJECT_NAME>.functions.supabase.co/telegram-bot?secret=<FUNCTION_SECRET>`
+4. Set your bot's webhook url to `https://<PROJECT_REFERENCE>.functions.supabase.co/telegram-bot` (Replacing `<...>` with respective values). In order to do that, run this url (in your browser, for example): `https://api.telegram.org/bot<TELEGRAM_BOT_TOKEN>/setWebhook?url=https://<PROJECT_REFERENCE>.functions.supabase.co/telegram-bot?secret=<FUNCTION_SECRET>`
 5. That's it, go ahead and chat with your bot 🤖💬


### PR DESCRIPTION
## What kind of change does this PR introduce?

[Edge Functions - Telegram Bot](https://github.com/supabase/supabase/tree/master/examples/edge-functions/supabase/functions/telegram-bot/)

## What is the new behavior?

As picked up in #9685 changed from `<PROJECT_NAME>` to `<PROJECT_REFERENCE>` in the url.

Closes #9685


