### PR TITLE
fix broken link in pg_graphql release blog post

### DIFF
--- a/apps/www/_blog/2021-12-03-pg-graphql.mdx
+++ b/apps/www/_blog/2021-12-03-pg-graphql.mdx
@@ -133,7 +133,7 @@ type AccountConnection {
 
 Where `Query` type's `account` field selects a single account by its globally unique `ID` and `allAccounts` enables pagination via the [relay connections specification](https://relay.dev/graphql/connections.htm). Under the SQL hood, iterating through pages is handled using keyset pagination giving consistent retrieval times on every page.
 
-For a more complete examples with relationships, enums, and more exotic types check out the [reflection doc](https://supabase.github.io/pg_graphql/reflection).
+For a more complete examples with relationships, enums, and more exotic types check out the [API doc](https://supabase.github.io/pg_graphql/api).
 
 ### API
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
Fixes a broken link in the pg_graphql release blog post from 2021

resolves #9745 