### PR TITLE
fix cli invocation

### DIFF
--- a/apps/reference/docs/guides/database/tables.mdx
+++ b/apps/reference/docs/guides/database/tables.mdx
@@ -245,7 +245,7 @@ For example, if you wanted to load a CSV file into your movies table:
 You would [connect](../../guides/database/connecting-to-postgres#direct-connections) to your database directly and load the file with the COPY command:
 
 ```bash
-psql -h DATABASE_URL -p 5432 postgres -U postgres \
+psql -h DATABASE_URL -p 5432 -d postgres -U postgres \
   -c "COPY movies FROM './movies.csv';"
 ```
 


### PR DESCRIPTION
Note that this also doesn't seem to work in practice, users will see this error:

```
ERROR:  must be superuser or a member of the pg_read_server_files role to COPY from a file
HINT:  Anyone can COPY to stdout or from stdin. psql's \copy command also works for anyone.
```