### PR TITLE
fix: add missing form data for partner form submission

### DIFF
--- a/apps/www/supabase/functions/hubspot-notification/index.ts
+++ b/apps/www/supabase/functions/hubspot-notification/index.ts
@@ -40,7 +40,6 @@ serve(async (req) => {
         form_note,
         company,
         company_size,
-        email,
         phone,
         lastName,
         firstName,

--- a/apps/www/supabase/functions/hubspot-notification/index.ts
+++ b/apps/www/supabase/functions/hubspot-notification/index.ts
@@ -33,7 +33,21 @@ serve(async (req) => {
 
   switch (input.table) {
     case 'partner_contacts':
-      formData = { ...formData, jobtitle, website, partner_gallery_type }
+      formData = {
+        ...formData,
+        supabase_table_id,
+        country,
+        form_note,
+        company,
+        company_size,
+        email,
+        phone,
+        lastName,
+        firstName,
+        jobtitle,
+        website,
+        partner_gallery_type,
+      }
       break
     case 'soc2_requests':
     case 'enterprise_contacts':


### PR DESCRIPTION
When someone submits the [become a partner form](https://supabase.com/partners/integrations), some of the fields such as company name are not being send to HubSpot. This PR adds those fields to be sent over.