### PR TITLE
fix: remove duplicate Realtime connection requests metric from Studio

### DIFF
--- a/studio/lib/constants/metrics.tsx
+++ b/studio/lib/constants/metrics.tsx
@@ -64,7 +64,7 @@ export const METRICS = [
     category: METRIC_CATEGORIES.API,
   },
   {
-    key: 'total_realtime_get_requests',
+    key: 'total_realtime_requests',
     label: 'Realtime Connection Requests',
     provider: 'daily-stats',
     category: METRIC_CATEGORIES.API_REALTIME,
@@ -81,12 +81,6 @@ export const METRICS = [
   //   provider: 'daily-stats',
   //   category: METRIC_CATEGORIES.API_REALTIME,
   // },
-  {
-    key: 'total_realtime_requests',
-    label: 'Connection Requests',
-    provider: 'daily-stats',
-    category: METRIC_CATEGORIES.API_REALTIME,
-  },
 
   /**
    * API


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

There are duplicate metrics for Realtime connection requests.

## What is the new behavior?

There is a single metrics option for Realtime connection requests.
