### PR TITLE
feat: edge functions setup buttons

### DIFF
--- a/studio/components/interfaces/Functions/FunctionsEmptyState.tsx
+++ b/studio/components/interfaces/Functions/FunctionsEmptyState.tsx
@@ -17,17 +17,21 @@ const FunctionsEmptyState = () => {
           </p>
           <div className="flex gap-2">
             <Link passHref href="https://supabase.com/docs/guides/functions">
-              <Button as="a" type="default" iconRight={<IconBookOpen />}>
-                Documentation
-              </Button>
+              <a target="_blank" rel="noreferrer">
+                <Button type="default" iconRight={<IconBookOpen />}>
+                  Documentation
+                </Button>
+              </a>
             </Link>
             <Link
               passHref
               href="https://github.com/supabase/supabase/tree/chore/stripe-issue/examples/edge-functions/supabase/functions"
             >
-              <Button as="a" type="default" iconRight={<IconCode />}>
-                Examples
-              </Button>
+              <a target="_blank" rel="noreferrer">
+                <Button type="default" iconRight={<IconCode />}>
+                  Examples
+                </Button>
+              </a>
             </Link>
           </div>
         </div>

--- a/studio/components/interfaces/Functions/TerminalInstructions.tsx
+++ b/studio/components/interfaces/Functions/TerminalInstructions.tsx
@@ -133,17 +133,21 @@ const TerminalInstructions: FC<Props> = ({ closable = false }) => {
           </div>
           <div className="flex gap-2">
             <Link passHref href="https://supabase.com/docs/guides/functions">
-              <Button as="a" type="default" iconRight={<IconBookOpen />}>
-                Documentation
-              </Button>
+              <a target="_blank" rel="noreferrer">
+                <Button type="default" iconRight={<IconBookOpen />}>
+                  Documentation
+                </Button>
+              </a>
             </Link>
             <Link
               passHref
               href="https://github.com/supabase/supabase/tree/chore/stripe-issue/examples/edge-functions/supabase/functions"
             >
-              <Button as="a" type="default" iconRight={<IconCode />}>
-                Examples
-              </Button>
+              <a target="_blank" rel="noreferrer">
+                <Button as="a" type="default" iconRight={<IconCode />}>
+                  Examples
+                </Button>
+              </a>
             </Link>
           </div>
         </div>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Studio Edge Functions

## What is the current behavior?

Currently when you have no edge functions set up the following is displayed:

<img width="471" alt="Screenshot 2022-10-26 at 23 13 42" src="https://user-images.githubusercontent.com/22655069/198127665-2022e5f1-0b88-4cb7-bbe8-84f5fcfd4f0a.png">

When you click on the buttons the links open in the same tab.

## What is the new behavior?

When you click on the buttons now a new tab is opened so you can have the edge functions page still open whilst you look at documentation. 

