### PR TITLE
docs: add Realtime upgrade guide for onOpen

### DIFF
--- a/apps/reference/_supabase_js/upgrade-guide.mdx
+++ b/apps/reference/_supabase_js/upgrade-guide.mdx
@@ -378,7 +378,7 @@ const userListener = supabase.from('users')
 <TabItem value="2.x">
 
 ```ts
-const userListener = supabase.channel('public:user')
+const userListener = supabase.channel('all-users-changes')
   .on(
     'postgres_changes',
     { event: '*', schema: 'public', table: 'user' },
@@ -409,6 +409,35 @@ userListener.unsubscribe()
 
 ```ts
 supabase.removeChannel(userListener)
+```
+</TabItem>
+</Tabs>
+
+#### onOpen
+
+<Tabs
+  groupId="version"
+  values={[
+    {label: 'Before', value: '1.x'},
+    {label: 'After', value: '2.x'},
+  ]}>
+
+<TabItem value="1.x">
+
+```ts
+supabase.realtime.onOpen(() => console.log('Connected to socket'))
+```
+</TabItem>
+
+<TabItem value="2.x">
+
+```ts
+supabase.channel('any')
+  .subscribe((status) => {
+    if (status === 'SUBSCRIBED') {
+      console.log('Connected to channel')
+    }
+  })
 ```
 </TabItem>
 </Tabs>


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

Unclear what the replacement for Realtime's `onOpen` method.

## What is the new behavior?

Clarity on how to achieve the same effect on the channel when calling `subscribe`.

## Additional context

https://github.com/supabase/realtime-js/issues/203

<img width="860" alt="Screen Shot 2022-10-26 at 15 53 03" src="https://user-images.githubusercontent.com/5532241/198153985-a1bb77ee-0bb7-42f0-a62f-920432aa6251.png">
<img width="860" alt="Screen Shot 2022-10-26 at 15 53 11" src="https://user-images.githubusercontent.com/5532241/198153984-081c942a-ae50-4b65-af27-43decf913943.png">