### PR TITLE
docs: flutter quickstart - variable name

### DIFF
--- a/apps/reference/docs/guides/with-flutter.mdx
+++ b/apps/reference/docs/guides/with-flutter.mdx
@@ -171,7 +171,7 @@ class SplashPage extends StatefulWidget {
 }
 
 class _SplashPageState extends State<SplashPage> {
-  bool _redicrectCalled = false;
+  bool _redirectCalled = false;
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
@@ -180,11 +180,11 @@ class _SplashPageState extends State<SplashPage> {
 
   Future<void> _redirect() async {
     await Future.delayed(Duration.zero);
-    if (_redicrectCalled || !mounted) {
+    if (_redirectCalled || !mounted) {
       return;
     }
 
-    _redicrectCalled = true;
+    _redirectCalled = true;
     final session = supabase.auth.currentSession;
     if (session != null) {
       Navigator.of(context).pushReplacementNamed('/account');


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs - [Flutter quickstart splash screen](https://supabase.com/docs/guides/with-flutter#set-up-splash-screen)

## What is the current behavior?

Variable typo named `redicrectCalled` is used.

## What is the new behavior?

Variable has been renamed to `redirectCalled`.

## Additional context

Closes #9881
