### PR TITLE
docs: release notes should use signInWithOtp

### DIFF
--- a/apps/reference/_supabase_js/release-notes.md
+++ b/apps/reference/_supabase_js/release-notes.md
@@ -106,7 +106,7 @@ interface Session {
 ### New Auth methods
 
 We're removing the `signIn()` method in favor of more explicit function signatures:
-`signInWithPassword()`, `signInWithPasswordless()`, and `signInWithOtp()`.
+`signInWithPassword()`, `signInWithOtp()`, and `signInWithOtp()`.
 
 ```ts
 // v2
@@ -170,7 +170,7 @@ Deprecated and removed `setAuth()` . To set a custom `access_token` jwt instead,
     - client-level `throwOnError`
 - `gotrue-js`
   - `supabase-js` client allows passing a `storageKey` param which will allow the user to set the key used in local storage for storing the session. By default, this will be namespace-d with the supabase project ref. ([PR](https://github.com/supabase/supabase-js/pull/460))
-  - `signIn` method is now split into `signInWithPassword` , `signInWithPasswordless` , `signInWithOAuth` ([PR](https://github.com/supabase/gotrue-js/pull/304))
+  - `signIn` method is now split into `signInWithPassword` , `signInWithOtp` , `signInWithOAuth` ([PR](https://github.com/supabase/gotrue-js/pull/304))
   - Deprecated and removed `session()` , `user()` in favour of using `getSession()` instead. `getSession()` will always return a valid session if a user is already logged in, meaning no more random logouts. ([PR](https://github.com/supabase/gotrue-js/pull/299))
   - Deprecated and removed setting for `multitab` support because `getSession()` and gotrue’s reuse interval setting takes care of session management across multiple tabs ([PR](https://github.com/supabase/gotrue-js/pull/366))
   - No more throwing of random errors, gotrue-js v2 always returns a custom error type: ([PR](https://github.com/supabase/gotrue-js/pull/341))

--- a/apps/temp-docs/_supabase_js/release-notes.md
+++ b/apps/temp-docs/_supabase_js/release-notes.md
@@ -104,7 +104,7 @@ interface Session {
 ### New Auth methods
 
 We're removing the `signIn()` method in favor of more explicit function signatures:
-`signInWithPassword()`, `signInWithPasswordless()`, and `signInWithOtp()`.
+`signInWithPassword()`, `signInWithOtp()`, and `signInWithOtp()`.
 
 ```ts
 // v2
@@ -168,7 +168,7 @@ Deprecated and removed `setAuth()` . To set a custom `access_token` jwt instead,
     - client-level `throwOnError`
 - `gotrue-js`
   - `supabase-js` client allows passing a `storageKey` param which will allow the user to set the key used in local storage for storing the session. By default, this will be namespace-d with the supabase project ref. ([PR](https://github.com/supabase/supabase-js/pull/460))
-  - `signIn` method is now split into `signInWithPassword` , `signInWithPasswordless` , `signInWithOAuth` ([PR](https://github.com/supabase/gotrue-js/pull/304))
+  - `signIn` method is now split into `signInWithPassword` , `signInWithOtp` , `signInWithOAuth` ([PR](https://github.com/supabase/gotrue-js/pull/304))
   - Deprecated and removed `session()` , `user()` in favour of using `getSession()` instead. `getSession()` will always return a valid session if a user is already logged in, meaning no more random logouts. ([PR](https://github.com/supabase/gotrue-js/pull/299))
   - Deprecated and removed setting for `multitab` support because `getSession()` and gotrue’s reuse interval setting takes care of session management across multiple tabs ([PR](https://github.com/supabase/gotrue-js/pull/366))
   - No more throwing of random errors, gotrue-js v2 always returns a custom error type: ([PR](https://github.com/supabase/gotrue-js/pull/341))

--- a/apps/temp-docs/docs/reference/javascript/release-notes.mdx
+++ b/apps/temp-docs/docs/reference/javascript/release-notes.mdx
@@ -104,7 +104,7 @@ interface Session {
 ### New Auth methods
 
 We're removing the `signIn()` method in favor of more explicit function signatures:
-`signInWithPassword()`, `signInWithPasswordless()`, and `signInWithOtp()`.
+`signInWithPassword()`, `signInWithOtp()`, and `signInWithOtp()`.
 
 ```ts
 // v2
@@ -168,7 +168,7 @@ Deprecated and removed `setAuth()` . To set a custom `access_token` jwt instead,
     - client-level `throwOnError`
 - `gotrue-js`
   - `supabase-js` client allows passing a `storageKey` param which will allow the user to set the key used in local storage for storing the session. By default, this will be namespace-d with the supabase project ref. ([PR](https://github.com/supabase/supabase-js/pull/460))
-  - `signIn` method is now split into `signInWithPassword` , `signInWithPasswordless` , `signInWithOAuth` ([PR](https://github.com/supabase/gotrue-js/pull/304))
+  - `signIn` method is now split into `signInWithPassword` , `signInWithOtp` , `signInWithOAuth` ([PR](https://github.com/supabase/gotrue-js/pull/304))
   - Deprecated and removed `session()` , `user()` in favour of using `getSession()` instead. `getSession()` will always return a valid session if a user is already logged in, meaning no more random logouts. ([PR](https://github.com/supabase/gotrue-js/pull/299))
   - Deprecated and removed setting for `multitab` support because `getSession()` and gotrue’s reuse interval setting takes care of session management across multiple tabs ([PR](https://github.com/supabase/gotrue-js/pull/366))
   - No more throwing of random errors, gotrue-js v2 always returns a custom error type: ([PR](https://github.com/supabase/gotrue-js/pull/341))

--- a/apps/www/lib/redirects.js
+++ b/apps/www/lib/redirects.js
@@ -1442,7 +1442,7 @@ module.exports = [
     source: '/docs/reference/javascript/auth-api-updateuserbyid',
     destination: '/docs/reference/javascript/v1/auth-api-updateuserbyid',
   },
-  // signIn method is now split into signInWithPassword ,signInWithPasswordless ,signInWithOAuth
+  // signIn method is now split into signInWithPassword ,signInWithOtp ,signInWithOAuth
   // send traffic to v1 docs instead
   {
     permanent: true,
@@ -1501,7 +1501,7 @@ module.exports = [
     source: '/docs/reference/dart/reset-password-email',
     destination: '/docs/reference/dart/auth-resetpasswordforemail',
   },
-  // signIn method is now split into signInWithPassword ,signInWithPasswordless ,signInWithOAuth
+  // signIn method is now split into signInWithPassword ,signInWithOtp ,signInWithOAuth
   // send traffic to v0 docs instead
   {
     permanent: true,


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Release notes mentioned `signInWithPasswordless` as a method when it should be `signInWithOtp` 
* Shoutout to @GaryAustin1 for catching this! (https://github.com/supabase/gotrue-js/pull/304#issuecomment-1290518032)