### PR TITLE
update generate link supabase-js docs

### DIFF
--- a/spec/supabase_js_v2.yml
+++ b/spec/supabase_js_v2.yml
@@ -583,13 +583,21 @@ pages:
             email: 'email@example.com'
           })
           ```
-      - name: Generate a link to change email addresses
+      - name: Generate links to change current email address
         isSpotlight: false
         js: |
           ```js
           const { data, error } = await supabase.auth.admin.generateLink({
             type: 'email_change_current',
-            email: 'old.email@example.com',
+            email: 'current.email@example.com',
+            newEmail: 'new.email@example.com'
+          })
+          ```
+        js: |
+          ```js
+          const { data, error } = await supabase.auth.admin.generateLink({
+            type: 'email_change_new',
+            email: 'current.email@example.com',
             newEmail: 'new.email@example.com'
           })
           ```


### PR DESCRIPTION
## What kind of change does this PR introduce?
 `docs update`

## What is the current behavior?
### Generate a link to change email addresses

```js
const { data, error } = await supabase.auth.admin.generateLink({
  type: 'email_change_current',
  email: 'old.email@example.com',
  newEmail: 'new.email@example.com'
})
```


## What is the new behavior?
### Generate  links to change current email address

```js
const { data, error } = await supabase.auth.admin.generateLink({
  type: 'email_change_current',
  email: 'current.email@example.com',
  newEmail: 'new.email@example.com'
})
```
```js
const { data, error } = await supabase.auth.admin.generateLink({
  type: 'email_change_new',
  email: 'current.email@example.com',
  newEmail: 'new.email@example.com'
})
```

The documentation is not clear as to what type of link you need to generate for the email change to take effect. The confirmation links need to be generated for both the current email and the new one. I also changed the old@example.com address to current@example.com address in order to avoid confusion over which email should be provided.
