### PR TITLE
Fixed docs for updating a user in Flutter

### DIFF
--- a/spec/supabase_dart_v1.yml
+++ b/spec/supabase_dart_v1.yml
@@ -223,7 +223,7 @@ pages:
         isSpotlight: true
         dart: |
           ```dart
-          final UserResponse res = await supabase.updateUser(
+          final UserResponse res = await supabase.auth.updateUser(
             UserAttributes(
               email: 'example@email.com',
             ),
@@ -234,7 +234,7 @@ pages:
         isSpotlight: false
         dart: |
           ```dart
-          final UserResponse res = await supabase.updateUser(
+          final UserResponse res = await supabase.auth.updateUser(
             UserAttributes(
               password: 'new password',
             ),
@@ -245,7 +245,7 @@ pages:
         isSpotlight: true
         dart: |
           ```dart
-          final UserResponse res = await supabase.updateUser(
+          final UserResponse res = await supabase.auth.updateUser(
             UserAttributes(
               data: { 'hello': 'world' },
             ),


### PR DESCRIPTION
## What kind of change does this PR introduce?

Seems this is a little oversight as all the other methods under the "Auth" tab has "supabase.auth" in front.  
I did confirm this is indeed a mistake in the docs and the correct code is "supabase.auth.updateUser".

Linked issue: #9941 
