### PR TITLE
Fix: Telemetry has no routes

### DIFF
--- a/apps/www/lib/fetchWrapper.ts
+++ b/apps/www/lib/fetchWrapper.ts
@@ -1,6 +1,7 @@
 interface DataProps {
   referrer?: string
   title: string
+  route?: string
 }
 
 export const post = (url: string, data: DataProps, options = {}) => {

--- a/apps/www/pages/_app.tsx
+++ b/apps/www/pages/_app.tsx
@@ -11,16 +11,17 @@ import { ThemeProvider } from '~/components/Providers'
 export default function MyApp({ Component, pageProps }: AppProps) {
   const router = useRouter()
 
-  function telemetry() {
+  function telemetry(route) {
     return post(`https://api.supabase.io/platform/telemetry/page`, {
       referrer: document.referrer,
       title: document.title,
+      route,
     })
   }
 
   useEffect(() => {
-    function handleRouteChange() {
-      telemetry()
+    function handleRouteChange(url) {
+      telemetry(url)
     }
 
     // Listen for page changes after a navigation or when the query changes

--- a/apps/www/pages/_app.tsx
+++ b/apps/www/pages/_app.tsx
@@ -11,7 +11,7 @@ import { ThemeProvider } from '~/components/Providers'
 export default function MyApp({ Component, pageProps }: AppProps) {
   const router = useRouter()
 
-  function telemetry(route) {
+  function telemetry(route: string) {
     return post(`https://api.supabase.io/platform/telemetry/page`, {
       referrer: document.referrer,
       title: document.title,
@@ -20,7 +20,7 @@ export default function MyApp({ Component, pageProps }: AppProps) {
   }
 
   useEffect(() => {
-    function handleRouteChange(url) {
+    function handleRouteChange(url: string) {
       telemetry(url)
     }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Path references were broken all this time, will take routes from Next router instead.