### PR TITLE
chore: document min required cli version

### DIFF
--- a/apps/reference/docs/guides/api/generating-types.mdx
+++ b/apps/reference/docs/guides/api/generating-types.mdx
@@ -10,10 +10,10 @@ Supabase APIs are generated from your database, which means that we can use data
 
 The Supabase CLI is a single binary Go application that provides everything you need to setup a local development environment.
 
-You can [install the CLI](https://www.npmjs.com/package/supabase) via npm or other supported package managers.
+You can [install the CLI](https://www.npmjs.com/package/supabase) via npm or other supported package managers. The minimum required version of the CLI is [v1.8.1](https://github.com/supabase/cli/releases).
 
 ```bash
-npm i supabase --save-dev
+npm i supabase@">=1.8.1" --save-dev
 ```
 
 Login with your Personal Access Token


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

multiple users tripped up on min cli version

## What is the new behavior?

specify min required cli version in docs

## Additional context

Add any other context or screenshots.
