### PR TITLE
chore: fix typo for status code filter description

### DIFF
--- a/studio/components/interfaces/Settings/Logs/Logs.constants.ts
+++ b/studio/components/interfaces/Settings/Logs/Logs.constants.ts
@@ -537,7 +537,7 @@ export const FILTER_OPTIONS: FilterTableSet = {
         {
           key: 'success',
           label: 'Success',
-          description: 'Show all requests that have 2xx status code',
+          description: 'Show all requests that have 2XX status code',
         },
       ],
     },


### PR DESCRIPTION
Fixes typo, should be capitalized `2XX`