### PR TITLE
fix: adds timestamp rendering standardization for log selection rende…

### DIFF
--- a/studio/components/interfaces/Settings/Logs/LogSelectionRenderers/AuthSelectionRenderer.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogSelectionRenderers/AuthSelectionRenderer.tsx
@@ -6,6 +6,7 @@ import {
   jsonSyntaxHighlight,
   ResponseCodeFormatter,
   SelectionDetailedRow,
+  SelectionDetailedTimestampRow,
   SeverityFormatter,
 } from '../LogsFormatters'
 
@@ -30,14 +31,7 @@ const AuthSelectionRenderer = ({ log }: { log: PreviewLogData }) => {
         </div>
       </div>
 
-      <SelectionDetailedRow
-        label="ISO Timestamp"
-        value={
-          isUnixMicro(log.timestamp)
-            ? unixMicroToIsoTimestamp(log.timestamp)
-            : String(log.timestamp)
-        }
-      />
+      <SelectionDetailedTimestampRow value={log.timestamp} />
       {parsed?.status && (
         <SelectionDetailedRow
           label="Status"

--- a/studio/components/interfaces/Settings/Logs/LogSelectionRenderers/DatabaseApiSelectionRender.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogSelectionRenderers/DatabaseApiSelectionRender.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { LOGS_TAILWIND_CLASSES } from '../Logs.constants'
 import LogsDivider from '../Logs.Divider'
-import { jsonSyntaxHighlight, ResponseCodeFormatter, SelectionDetailedRow } from '../LogsFormatters'
+import {
+  jsonSyntaxHighlight,
+  ResponseCodeFormatter,
+  SelectionDetailedRow,
+  SelectionDetailedTimestampRow,
+} from '../LogsFormatters'
 
 const DatabaseApiSelectionRender = ({ log }: any) => {
   const request = log?.metadata[0]?.request?.[0]
@@ -16,9 +21,13 @@ const DatabaseApiSelectionRender = ({ log }: any) => {
   return (
     <>
       <div className={`${LOGS_TAILWIND_CLASSES.log_selection_x_padding} space-y-2`}>
-        <SelectionDetailedRow label="Status" value={status} valueRender={<ResponseCodeFormatter value={status} />} />
+        <SelectionDetailedRow
+          label="Status"
+          value={status}
+          valueRender={<ResponseCodeFormatter value={status} />}
+        />
         <SelectionDetailedRow label="Method" value={method} />
-        <SelectionDetailedRow label="Timestamp" value={log.timestamp} />
+        <SelectionDetailedTimestampRow value={log.timestamp} />
         <SelectionDetailedRow label="IP Address" value={ipAddress} />
         <SelectionDetailedRow label="Origin Country" value={countryOrigin} />
         {clientInfo && <SelectionDetailedRow label="Client" value={clientInfo} />}

--- a/studio/components/interfaces/Settings/Logs/LogSelectionRenderers/DatabasePostgresSelectionRender.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogSelectionRenderers/DatabasePostgresSelectionRender.tsx
@@ -2,7 +2,12 @@ import { Alert } from 'ui'
 import React from 'react'
 import { LOGS_TAILWIND_CLASSES } from '../Logs.constants'
 import LogsDivider from '../Logs.Divider'
-import { jsonSyntaxHighlight, SelectionDetailedRow, SeverityFormatter } from '../LogsFormatters'
+import {
+  jsonSyntaxHighlight,
+  SelectionDetailedRow,
+  SelectionDetailedTimestampRow,
+  SeverityFormatter,
+} from '../LogsFormatters'
 
 const DatabasePostgresSelectionRender = ({ log }: any) => {
   const postgresUsername = log?.metadata[0]?.parsed[0]?.user_name
@@ -26,6 +31,7 @@ const DatabasePostgresSelectionRender = ({ log }: any) => {
           value={errorSeverity}
           valueRender={<SeverityFormatter value={errorSeverity} />}
         />
+        <SelectionDetailedTimestampRow value={log.timestamp} />
         <SelectionDetailedRow label="Postgres Username" value={postgresUsername} />
         <SelectionDetailedRow label="Session ID" value={sessionId} />
       </div>

--- a/studio/components/interfaces/Settings/Logs/LogSelectionRenderers/DefaultPreviewSelectionRenderer.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogSelectionRenderers/DefaultPreviewSelectionRenderer.tsx
@@ -1,6 +1,6 @@
-import { isUnixMicro, PreviewLogData, unixMicroToIsoTimestamp } from '..'
+import { PreviewLogData } from '..'
 import { LOGS_TAILWIND_CLASSES } from '../Logs.constants'
-import { jsonSyntaxHighlight, SelectionDetailedRow } from '../LogsFormatters'
+import { jsonSyntaxHighlight, SelectionDetailedTimestampRow } from '../LogsFormatters'
 
 const DefaultPreviewSelectionRenderer = ({ log }: { log: PreviewLogData }) => (
   <div className={`${LOGS_TAILWIND_CLASSES.log_selection_x_padding} space-y-6`}>
@@ -10,11 +10,7 @@ const DefaultPreviewSelectionRenderer = ({ log }: { log: PreviewLogData }) => (
         {log.event_message}
       </div>
     </div>
-
-    <SelectionDetailedRow
-      label="ISO Timestamp"
-      value={isUnixMicro(log.timestamp) ? unixMicroToIsoTimestamp(log.timestamp) : String(log.timestamp)}
-    />
+    <SelectionDetailedTimestampRow value={log.timestamp} />
     <div className="flex flex-col gap-3">
       <h3 className="text-scale-900 text-sm">Metadata</h3>
       <pre

--- a/studio/components/interfaces/Settings/Logs/LogSelectionRenderers/FunctionInvocationSelectionRender.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogSelectionRenderers/FunctionInvocationSelectionRender.tsx
@@ -2,7 +2,12 @@ import dayjs from 'dayjs'
 import { filterFunctionsRequestResponse } from 'lib/logs'
 import { PreviewLogData } from '..'
 import { LOGS_TAILWIND_CLASSES } from '../Logs.constants'
-import { jsonSyntaxHighlight, ResponseCodeFormatter, SelectionDetailedRow } from '../LogsFormatters'
+import {
+  jsonSyntaxHighlight,
+  ResponseCodeFormatter,
+  SelectionDetailedRow,
+  SelectionDetailedTimestampRow,
+} from '../LogsFormatters'
 
 const FunctionInvocationSelectionRender = ({ log }: { log: PreviewLogData }) => {
   const metadata = log.metadata?.[0]
@@ -13,17 +18,17 @@ const FunctionInvocationSelectionRender = ({ log }: { log: PreviewLogData }) => 
   const requestUrl = new URL(request?.url)
   const executionTimeMs = metadata.execution_time_ms
   const deploymentId = metadata.deployment_id
-  const timestamp = dayjs(log.timestamp / 1000)
 
   return (
     <>
       <div className={`${LOGS_TAILWIND_CLASSES.log_selection_x_padding} space-y-2`}>
-        <SelectionDetailedRow label="Status" value={status} valueRender={<ResponseCodeFormatter value={status} />} />
-        <SelectionDetailedRow label="Method" value={method} />
         <SelectionDetailedRow
-          label="Timestamp"
-          value={dayjs(timestamp).format('DD MMM, YYYY HH:mm')}
+          label="Status"
+          value={status}
+          valueRender={<ResponseCodeFormatter value={status} />}
         />
+        <SelectionDetailedRow label="Method" value={method} />
+        <SelectionDetailedTimestampRow value={log.timestamp} />
         <SelectionDetailedRow label="Execution Time" value={`${executionTimeMs}ms`} />
         <SelectionDetailedRow label="Deployment ID" value={deploymentId} />
         <SelectionDetailedRow label="Log ID" value={log.id} />

--- a/studio/components/interfaces/Settings/Logs/LogSelectionRenderers/FunctionLogsSelectionRender.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogSelectionRenderers/FunctionLogsSelectionRender.tsx
@@ -1,9 +1,13 @@
 import dayjs from 'dayjs'
 import { LOGS_TAILWIND_CLASSES } from '../Logs.constants'
-import { jsonSyntaxHighlight, SelectionDetailedRow, SeverityFormatter } from '../LogsFormatters'
+import {
+  jsonSyntaxHighlight,
+  SelectionDetailedRow,
+  SelectionDetailedTimestampRow,
+  SeverityFormatter,
+} from '../LogsFormatters'
 
 const FunctionLogsSelectionRender = ({ log }: any) => {
-  const timestamp = dayjs(log.timestamp / 1000)
   const metadata = log.metadata[0]
 
   return (
@@ -22,7 +26,7 @@ const FunctionLogsSelectionRender = ({ log }: any) => {
           valueRender={<SeverityFormatter value={metadata.level} />}
         />
         <SelectionDetailedRow label="Deployment version" value={metadata.version} />
-        <SelectionDetailedRow label="Timestamp" value={timestamp.format('DD MMM, YYYY HH:mm')} />
+        <SelectionDetailedTimestampRow value={log.timestamp} />
         <SelectionDetailedRow label="Execution ID" value={metadata.execution_id} />
         <SelectionDetailedRow label="Deployment ID" value={metadata.deployment_id} />
       </div>

--- a/studio/components/interfaces/Settings/Logs/LogsFormatters.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogsFormatters.tsx
@@ -13,7 +13,16 @@ import CopyButton from 'components/ui/CopyButton'
 export const RowLayout: React.FC = ({ children }) => (
   <div className="flex h-full w-full items-center gap-4">{children}</div>
 )
-
+// renders a timestamp (either unix microsecond or iso timestap)
+export const SelectionDetailedTimestampRow = ({ value }: { value: string | number }) => (
+  <>
+    <SelectionDetailedRow
+      label="Timestamp"
+      value={isUnixMicro(value) ? unixMicroToIsoTimestamp(value) : String(value)}
+    />
+    {console.log(isUnixMicro(value) ? unixMicroToIsoTimestamp(value) : String(value))}
+  </>
+)
 export const SelectionDetailedRow = ({
   label,
   value,

--- a/studio/components/interfaces/Settings/Logs/LogsFormatters.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogsFormatters.tsx
@@ -13,15 +13,12 @@ import CopyButton from 'components/ui/CopyButton'
 export const RowLayout: React.FC = ({ children }) => (
   <div className="flex h-full w-full items-center gap-4">{children}</div>
 )
-// renders a timestamp (either unix microsecond or iso timestap)
+// renders a timestamp (either unix microsecond or iso timestamp)
 export const SelectionDetailedTimestampRow = ({ value }: { value: string | number }) => (
-  <>
-    <SelectionDetailedRow
-      label="Timestamp"
-      value={isUnixMicro(value) ? unixMicroToIsoTimestamp(value) : String(value)}
-    />
-    {console.log(isUnixMicro(value) ? unixMicroToIsoTimestamp(value) : String(value))}
-  </>
+  <SelectionDetailedRow
+    label="Timestamp"
+    value={isUnixMicro(value) ? unixMicroToIsoTimestamp(value) : String(value)}
+  />
 )
 export const SelectionDetailedRow = ({
   label,

--- a/studio/tests/pages/projects/LogsPreviewer.test.js
+++ b/studio/tests/pages/projects/LogsPreviewer.test.js
@@ -47,7 +47,36 @@ test.each([
     tableTexts: [/POST/, /some\-path/, /400/],
     selectionTexts: [/POST/, /Timestamp/, RegExp(`${new Date().getFullYear()}.+`, 'g')],
   },
-  // TODO: add more tests for each type of ui
+  {
+    queryType: 'database',
+    tableName: undefined,
+    tableLog: logDataFixture({
+      error_severity: 'ERROR',
+      event_message: 'some db event',
+      metadata: undefined,
+    }),
+    selectionLog: logDataFixture({
+      metadata: [
+        {
+          parsed: [
+            {
+              application_type: 'client backend',
+              error_severity: 'ERROR',
+              hint: 'some pg hint',
+            },
+          ],
+        },
+      ],
+    }),
+    tableTexts: [/ERROR/, /some db event/],
+    selectionTexts: [
+      /client backend/,
+      /some pg hint/,
+      /ERROR/,
+      /Timestamp/,
+      RegExp(`${new Date().getFullYear()}.+`, 'g'),
+    ],
+  },
   {
     queryType: 'auth',
     tableName: undefined,
@@ -77,6 +106,20 @@ test.each([
       RegExp(`${new Date().getFullYear()}.+`, 'g'),
     ],
   },
+  // these all use teh default selection/table renderers
+  ...['pgbouncer', 'postgrest', 'storage', 'realtime'].map((queryType) => ({
+    queryType,
+    tableName: undefined,
+    tableLog: logDataFixture({
+      event_message: 'some message',
+      metadata: undefined,
+    }),
+    selectionLog: logDataFixture({
+      metadata: [{ some: [{ nested: 'value' }] }],
+    }),
+    tableTexts: [/some message/],
+    selectionTexts: [/some/, /nested/, /value/, RegExp(`${new Date().getFullYear()}.+`, 'g')],
+  })),
 ])(
   'selection $queryType $tableName , can display log data and metadata',
   async ({ queryType, tableName, tableLog, selectionLog, tableTexts, selectionTexts }) => {


### PR DESCRIPTION
Adds standardized timestamp rendering on all selection renderers

Pre-merge checklist:
- [x] test cases for each ui
- [x] demo

<img width="1274" alt="Screenshot 2022-11-11 at 12 06 35 AM" src="https://user-images.githubusercontent.com/22714384/201146705-4907c16e-f52e-488c-935f-aef14bc04b22.png">
<img width="1278" alt="Screenshot 2022-11-11 at 12 06 23 AM" src="https://user-images.githubusercontent.com/22714384/201146717-9b692fc5-a63d-4369-9e54-9dfd42830110.png">
<img width="1283" alt="Screenshot 2022-11-11 at 12 05 59 AM" src="https://user-images.githubusercontent.com/22714384/201146727-b08104f4-53dd-4538-8cd1-54273ac02946.png">
