### PR TITLE
fix: pgbouncer/pgrest logs pages should use logs layout

### DIFF
--- a/studio/pages/project/[ref]/logs/pgbouncer-logs.tsx
+++ b/studio/pages/project/[ref]/logs/pgbouncer-logs.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { useRouter } from 'next/router'
 import { observer } from 'mobx-react-lite'
-import { DatabaseLayout } from 'components/layouts'
+import { LogsLayout } from 'components/layouts'
 import LogsPreviewer from 'components/interfaces/Settings/Logs/LogsPreviewer'
 import { NextPageWithLayout } from 'types'
 import { LogsTableName } from 'components/interfaces/Settings/Logs'
@@ -20,6 +20,6 @@ export const LogPage: NextPageWithLayout = () => {
   )
 }
 
-LogPage.getLayout = (page) => <DatabaseLayout title="Database">{page}</DatabaseLayout>
+LogPage.getLayout = (page) => <LogsLayout title="Database">{page}</LogsLayout>
 
 export default observer(LogPage)

--- a/studio/pages/project/[ref]/logs/postgrest-logs.tsx
+++ b/studio/pages/project/[ref]/logs/postgrest-logs.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { useRouter } from 'next/router'
 import { observer } from 'mobx-react-lite'
-import { DatabaseLayout } from 'components/layouts'
+import { LogsLayout } from 'components/layouts'
 import LogsPreviewer from 'components/interfaces/Settings/Logs/LogsPreviewer'
 import { NextPageWithLayout } from 'types'
 import { LogsTableName } from 'components/interfaces/Settings/Logs'
@@ -20,6 +20,6 @@ export const LogPage: NextPageWithLayout = () => {
   )
 }
 
-LogPage.getLayout = (page) => <DatabaseLayout title="Database">{page}</DatabaseLayout>
+LogPage.getLayout = (page) => <LogsLayout title="Database">{page}</LogsLayout>
 
 export default observer(LogPage)


### PR DESCRIPTION
uses the correct layout for pgbouncer and pgrest logs pages

demo:
https://user-images.githubusercontent.com/22714384/199436207-9ec25361-e174-4b64-80c0-9e50e87714e8.mov

