### PR TITLE
Update testing.mdx fixing incorrect command 

### DIFF
--- a/apps/reference/docs/guides/database/testing.mdx
+++ b/apps/reference/docs/guides/database/testing.mdx
@@ -51,13 +51,13 @@ rollback;
 To run the test, you can use:
 
 ```bash
-supabase test db
+supabase db test
 ```
 
 This will produce the following output:
 
 ```bash
-$ supabase test db
+$ supabase db test
 supabase/tests/database/hello_world.test.sql .. ok
 All tests successful.
 Files=1, Tests=1,  1 wallclock secs ( 0.01 usr  0.00 sys +  0.04 cusr  0.02 csys =  0.07 CPU)


### PR DESCRIPTION
the db test command is `supabase db test` not `supabase test db` also the path appears to be incorrect (doesn't find the test there). Debugging that now.
