### PR TITLE
chore: Update auth-mfa.mdx

### DIFF
--- a/apps/reference/docs/guides/auth/auth-mfa.mdx
+++ b/apps/reference/docs/guides/auth/auth-mfa.mdx
@@ -619,7 +619,7 @@ Currently recognized methods are:
 - `otp` - any one-time password based sign in (email code, SMS code, magic
   link).
 - `oauth` - any OAuth based sign in (social login).
-- `mfa/totp` - a TOTP additional factor.
+- `totp` - a TOTP additional factor.
 
 This list will expand in the future.
 


### PR DESCRIPTION
we dropped the `mfa/` prefix so it's now just `totp`