### PR TITLE
chore: add info about cookie methods in v2 upgrade guide

### DIFF
--- a/apps/reference/_supabase_js/upgrade-guide.mdx
+++ b/apps/reference/_supabase_js/upgrade-guide.mdx
@@ -441,3 +441,12 @@ supabase.channel('any')
 ```
 </TabItem>
 </Tabs>
+
+### Cookie methods
+
+The cookie related methods like `setAuthCookie` and `getUserByCookie` have been removed.
+
+For Next.js you can use the [Auth Helpers](https://supabase.com/docs/guides/auth/auth-helpers/nextjs) to help you manage cookies.
+If you prefer not to use the auth helpers package you can follow [this approach](https://supabase.com/docs/guides/auth/server-side-rendering) for server-side-rendering.
+
+Some more background information about the reasoning can be obtained [here](https://github.com/supabase/gotrue-js/pull/340).

--- a/apps/reference/_supabase_js/upgrade-guide.mdx
+++ b/apps/reference/_supabase_js/upgrade-guide.mdx
@@ -304,7 +304,7 @@ const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
 The cookie related methods like `setAuthCookie` and `getUserByCookie` have been removed.
 
 For Next.js you can use the [Auth Helpers](https://supabase.com/docs/guides/auth/auth-helpers/nextjs) to help you manage cookies.
-If you prefer not to use the auth helpers package you can follow [this approach](https://supabase.com/docs/guides/auth/server-side-rendering) for server-side-rendering.
+If you can't use the Auth Helpers, you can follow [this approach](https://supabase.com/docs/guides/auth/server-side-rendering) for server-side-rendering.
 
 Some more background information about the reasoning can be obtained [here](https://github.com/supabase/gotrue-js/pull/340).
 

--- a/apps/reference/_supabase_js/upgrade-guide.mdx
+++ b/apps/reference/_supabase_js/upgrade-guide.mdx
@@ -304,7 +304,7 @@ const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
 The cookie related methods like `setAuthCookie` and `getUserByCookie` have been removed.
 
 For Next.js you can use the [Auth Helpers](https://supabase.com/docs/guides/auth/auth-helpers/nextjs) to help you manage cookies.
-If you can't use the Auth Helpers, you can follow [this approach](https://supabase.com/docs/guides/auth/server-side-rendering) for server-side-rendering.
+If you can't use the Auth Helpers, you can follow [this approach](https://supabase.com/docs/guides/auth/server-side-rendering) for server-side rendering.
 
 Some more background information about the reasoning can be obtained [here](https://github.com/supabase/gotrue-js/pull/340).
 

--- a/apps/reference/_supabase_js/upgrade-guide.mdx
+++ b/apps/reference/_supabase_js/upgrade-guide.mdx
@@ -299,6 +299,15 @@ const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
 </TabItem>
 </Tabs>
 
+#### Cookie methods
+
+The cookie related methods like `setAuthCookie` and `getUserByCookie` have been removed.
+
+For Next.js you can use the [Auth Helpers](https://supabase.com/docs/guides/auth/auth-helpers/nextjs) to help you manage cookies.
+If you prefer not to use the auth helpers package you can follow [this approach](https://supabase.com/docs/guides/auth/server-side-rendering) for server-side-rendering.
+
+Some more background information about the reasoning can be obtained [here](https://github.com/supabase/gotrue-js/pull/340).
+
 ### Data methods
 
 `.insert()` / `.upsert()` / `.update()` / `.delete()` don't return rows by default: [PR](https://github.com/supabase/postgrest-js/pull/276).
@@ -441,12 +450,3 @@ supabase.channel('any')
 ```
 </TabItem>
 </Tabs>
-
-### Cookie methods
-
-The cookie related methods like `setAuthCookie` and `getUserByCookie` have been removed.
-
-For Next.js you can use the [Auth Helpers](https://supabase.com/docs/guides/auth/auth-helpers/nextjs) to help you manage cookies.
-If you prefer not to use the auth helpers package you can follow [this approach](https://supabase.com/docs/guides/auth/server-side-rendering) for server-side-rendering.
-
-Some more background information about the reasoning can be obtained [here](https://github.com/supabase/gotrue-js/pull/340).


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

While the cookie related methods have been removed, there is no hint in the upgrade guide on how to deal with this. As I've run into this myself and also seen multiple other users asking questions about it, I thought it would be great to add a small section about it.

Related

https://github.com/supabase/supabase/issues/8751
https://github.com/supabase/gotrue-js/issues/492
https://github.com/supabase/gotrue-js/pull/340
https://github.com/supabase/supabase/discussions/10051
