### PR TITLE
Add missing tab select for npm to CLI install doc

### DIFF
--- a/apps/reference/docs/guides/cli.mdx
+++ b/apps/reference/docs/guides/cli.mdx
@@ -18,6 +18,7 @@ You can also use the CLI to manage your Supabase projects, handle database migra
   groupId="platform"
   defaultValue="macos"
   values={[
+    {label: 'npm', value: 'npm'},
     {label: 'macOS', value: 'macos'},
     {label: 'Windows', value: 'windows'},
     {label: 'Linux', value: 'linux'},


### PR DESCRIPTION
The CLI install docs contain information about installing with npm but it is not displayed since the tab for it is missing.