### PR TITLE
Update default-colors.js

### DIFF
--- a/packages/config/default-colors.js
+++ b/packages/config/default-colors.js
@@ -70,7 +70,7 @@ module.exports = {
     scale8: 'var(--colors-gray8)',
     scale9: 'var(--colors-gray9)',
     scale10: 'var(--colors-gray10)',
-    scale11: 'var(--colors-gray11)',
+    scale11: '#bbbbbb',
     scale12: 'var(--colors-gray12)',
   },
   scaleADark: {


### PR DESCRIPTION
manually adjust the step 11 gray for dark mode as we had some contrast issues on blog and docs