### PR TITLE
docs: setsession link

### DIFF
--- a/apps/docs/data/nav/supabase-js/v2.ts
+++ b/apps/docs/data/nav/supabase-js/v2.ts
@@ -30,7 +30,7 @@ const Nav = [
       { name: 'getSession()', url: '/reference/javascript/auth-getsession', items: [] },
       { name: 'getUser()', url: '/reference/javascript/auth-getuser', items: [] },
       { name: 'updateUser()', url: '/reference/javascript/auth-updateuser', items: [] },
-      { name: 'setSession()', url: '/reference/javascript/auth-setSession', items: [] },
+      { name: 'setSession()', url: '/reference/javascript/auth-setsession', items: [] },
       {
         name: 'resetPasswordForEmail()',
         url: '/reference/javascript/auth-resetpasswordforemail',


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase Docs Javascript

## What is the current behavior?

The setsession nav goes to a 404

## What is the new behavior?

Changed the URL path to `setsession`

## Additional context

Closes #10076 
