### PR TITLE
chore: clean humans.txt

### DIFF
--- a/apps/docs/public/humans.txt
+++ b/apps/docs/public/humans.txt
@@ -46,7 +46,6 @@ Qiao Han
 Ramiro Nuñez Dosio
 Rodrigo Mansueli Nunes
 Rory Wilding
-Shane Rice
 Stanislav M
 Steve Chavez
 Stojan Dimitrovski

--- a/apps/reference/static/humans.txt
+++ b/apps/reference/static/humans.txt
@@ -46,7 +46,6 @@ Qiao Han
 Ramiro Nuñez Dosio
 Rodrigo Mansueli Nunes
 Rory Wilding
-Shane Rice
 Stanislav M
 Steve Chavez
 Stojan Dimitrovski


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to remove Shane Rice from humans.txt as he is not in Supabase now.

## What is the current behavior?

Shane Rice is still in humans.txt but he is not a Supabase member anymore.

## What is the new behavior?

Shane Rice should not in humans.txt.

## Additional context

N/A
