### PR TITLE
Docs: remove (outdated) references to graphql.rebuild_schema

### DIFF
--- a/apps/docs/docs/guides/api.mdx
+++ b/apps/docs/docs/guides/api.mdx
@@ -199,13 +199,6 @@ JS Reference: [select()](../reference/javascript/select),
 
 ### GraphQL API
 
-<Admonition type='note'>
-
-To rebuild your GraphQL schema from the SQL schema, call `select graphql.rebuild_schema();`.
-Be sure to rebuild the GraphQL schema after altering the SQL schema.
-
-</Admonition>
-
 You can use any GraphQL client with the Supabase GraphQL API. For our GraphQL example we will use [urql](https://formidable.com/open-source/urql/docs/).
 
 <Tabs

--- a/apps/docs/docs/guides/migrations/heroku.mdx
+++ b/apps/docs/docs/guides/migrations/heroku.mdx
@@ -55,14 +55,6 @@ Use `psql` to import the Heroku database file to your Supabase project.
 psql -h $SUPABASE_HOST -U postgres -f heroku_dump.sql
 ```
 
-## (Optional) Post processing {#post-processing}
-
-If you're using GraphQL with your Supabase project, you may need to run the following SQL command in the Supabase Dashboard (SQL Editor) to make sure the new tables show up:
-
-```sql
-select graphql.rebuild_schema();
-```
-
 ## Additional options
 
 - To only migrate a single database schema, add the `--schema=PATTERN` parameter to your `pg_dump` command.

--- a/apps/reference/docs/guides/api.mdx
+++ b/apps/reference/docs/guides/api.mdx
@@ -221,13 +221,6 @@ JS Reference: [select()](../reference/javascript/select),
 
 ### GraphQL API
 
-:::note
-
-To rebuild your GraphQL schema from the SQL schema, call `select graphql.rebuild_schema();`.
-Be sure to rebuild the GraphQL schema after altering the SQL schema.
-
-:::
-
 You can use any GraphQL client with the Supabase GraphQL API. For our GraphQL example we will use [urql](https://formidable.com/open-source/urql/docs/).
 
 <Tabs

--- a/apps/reference/docs/guides/migrations/heroku.mdx
+++ b/apps/reference/docs/guides/migrations/heroku.mdx
@@ -55,14 +55,6 @@ Use `psql` to import the Heroku database file to your Supabase project.
 psql -h $SUPABASE_HOST -U postgres -f heroku_dump.sql
 ```
 
-## (Optional) Post processing {#post-processing}
-
-If you're using GraphQL with your Supabase project, you may need to run the following SQL command in the Supabase Dashboard (SQL Editor) to make sure the new tables show up:
-
-```sql
-select graphql.rebuild_schema();
-```
-
 ## Additional options
 
 - To only migrate a single database schema, add the `--schema=PATTERN` parameter to your `pg_dump` command.

--- a/apps/www/_blog/2022-03-29-graphql-now-available.mdx
+++ b/apps/www/_blog/2022-03-29-graphql-now-available.mdx
@@ -67,9 +67,6 @@ create table "Account"(
     "createdAt" timestamp not null,
     "updatedAt" timestamp not null
 );
-
--- Rebuild the GraphQL Schema Cache
-select graphql.rebuild_schema();
 ```
 
 Translates to the GraphQL base type


### PR DESCRIPTION
## What kind of change does this PR introduce?
Removes references to `graphql.rebuild_schema`.

This hasn't been necessary since 0.3.0 and the function was removed in 0.5.0 (live for new projects)