### PR TITLE
docs: document react native polyfill workaround

### DIFF
--- a/spec/supabase_js_v2.yml
+++ b/spec/supabase_js_v2.yml
@@ -337,6 +337,7 @@ pages:
       - The refresh token can only be used once to obtain a new session.
       - [Refresh token rotation](/docs/reference/auth/config#refresh_token_rotation_enabled) is enabled by default on all projects to guard against replay attacks.
       - You can configure the [`REFRESH_TOKEN_REUSE_INTERVAL`](https://supabase.com/docs/reference/auth/config#refresh_token_reuse_interval) which provides a short window in which the same refresh token can be used multiple times in the event of concurrency or offline issues.
+      - If you are using React Native, you will need to install a Buffer polyfill via a library such as [rn-nodeify](https://github.com/tradle/rn-nodeify) to properly use the library.
     examples:
       - name: Refresh the session
         description: Sets the session data from refresh_token and returns current session or an error if the refresh_token is invalid.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Describes the workaround needed to use `setSession` with react native as per [this issue](https://github.com/supabase/gotrue-js/issues/476)

## What is the current behavior?

No docs

## What is the new behavior?

Docs in the reference spec

## Additional context

None