### PR TITLE
docs: added in true and false for is reference

### DIFF
--- a/spec/supabase_js_v2.yml
+++ b/spec/supabase_js_v2.yml
@@ -2711,7 +2711,7 @@ pages:
     examples:
       - name: Checking nullness
         description: |
-          Using the `eq()` filter doesn't work when filtering for `null`:
+          Using the `eq()` filter doesn't work when filtering for `null`, `true` or `false`:
 
           <Tabs>
           <TabItem value="schema" label="Schema">

--- a/spec/supabase_js_v2.yml
+++ b/spec/supabase_js_v2.yml
@@ -2711,7 +2711,7 @@ pages:
     examples:
       - name: Checking nullness
         description: |
-          Using the `eq()` filter doesn't work when filtering for `null`, `true` or `false`:
+          Using the `eq()` filter doesn't work when filtering for `null`, `true`, or `false`:
 
           <Tabs>
           <TabItem value="schema" label="Schema">


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs - [is()](https://supabase.com/docs/reference/javascript/is)

## What is the current behavior?

On v2 of the docs missing reference for `true` and `false`

## What is the new behavior?

Added in the references

## Additional context

Closes #10160 
