### PR TITLE
docs: search docs placeholder

### DIFF
--- a/apps/docs/components/Navigation/NavBar.tsx
+++ b/apps/docs/components/Navigation/NavBar.tsx
@@ -197,7 +197,7 @@ const NavBar: FC<Props> = ({ currentPage }) => {
           <div className="flex items-center justify-between space-x-6 bg-scale-300 border border-scale-700 pl-3 pr-1.5 py-1.5 rounded">
             <div className="flex items-center space-x-2">
               <IconSearch className="text-scale-1100" size={18} strokeWidth={2} />
-              <p className="text-scale-800 text-sm">Search docs</p>
+              <p className="text-scale-800 text-sm">Search</p>
             </div>
             <div className="flex items-center space-x-1">
               <div className="hidden text-scale-1200 md:flex items-center justify-center h-6 w-6 rounded bg-scale-500">


### PR DESCRIPTION
## What kind of change does this PR introduce?

[Supabase Reference Docs](https://supabase.com/docs/reference/javascript)

## What is the current behavior?

On a mobile device the search button in the header/nav does not look right:

<img width="335" alt="Screenshot 2022-11-08 at 16 47 03" src="https://user-images.githubusercontent.com/22655069/200625759-fa5db35a-ee03-4cca-828c-418f07673655.png">


## What is the new behavior?

Wording on the placeholder has been changed and now looks correct:

<img width="389" alt="Screenshot 2022-11-08 at 16 46 38" src="https://user-images.githubusercontent.com/22655069/200625824-73846003-b6bf-4a59-9e85-1a80faadddab.png">
