### PR TITLE
default active tab to first panel if present, otherwise uses url hash

### DIFF
--- a/packages/ui/src/components/Tabs/Tabs.tsx
+++ b/packages/ui/src/components/Tabs/Tabs.tsx
@@ -55,8 +55,8 @@ function Tabs({
   let __styles = styleHandler('tabs')
 
   // activeId state can be overriden externally with `active`
-  // defaults to use a url #hash if we have one or activeTab if not
-  const active = activeId ? activeId : hash ? hash : activeTab
+  // defaults to the first panelif we have one or url hash if not
+  const active = activeId ? activeId : activeTab ? activeTab : hash
 
   function onTabClick(id: string) {
     const newTabSelected = id !== active


### PR DESCRIPTION
## What kind of change does this PR introduce?

Tabs component behaviour

## What is the current behavior?

If you land on a page with the tabs component from an external link and there is a url hash present users aren't able to change tabs.

## What is the new behavior?

Default tabs to first panel, only use url hash if there are no other options present

## Additional context
Reproduce by following this [link](https://supabase.com/docs/guides/api#rest-api) while navigating to that page works since the router isn't adding the # to the router path.
