### PR TITLE
Update Supabase-JS to @latest, remove JWT from the example

### DIFF
--- a/examples/edge-functions/supabase/functions/select-from-table-with-auth-rls/index.ts
+++ b/examples/edge-functions/supabase/functions/select-from-table-with-auth-rls/index.ts
@@ -3,7 +3,7 @@
 // This enables autocomplete, go to definition, etc.
 
 import { serve } from 'https://deno.land/std@0.131.0/http/server.ts'
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.0.0'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@latest'
 import { corsHeaders } from '../_shared/cors.ts'
 
 console.log(`Function "select-from-table-with-auth-rls" up and running!`)
@@ -48,6 +48,6 @@ serve(async (req: Request) => {
 
 // To invoke:
 // curl -i --location --request POST 'http://localhost:54321/functions/v1/select-from-table-with-auth-rls' \
-//   --header 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24ifQ.625_WdcF3KHqz5amU0x2X5WWHP-OEs_4qj0ssLNHzTs' \
+//   --header 'Authorization: Bearer <token> \
 //   --header 'Content-Type: application/json' \
 //   --data '{"name":"Functions"}'


### PR DESCRIPTION
the example on the website is showing a pre-release version  tag which even work, I spent 30 minutes trying debugging this.

https://supabase.com/docs/guides/functions/auth

## What kind of change does this PR introduce?

Improve docs

## What is the current behavior?

The example is using an old version of the library and includes a JWT for some reasons