### PR TITLE
Adds note to Local Development page and Reorganize notes

### DIFF
--- a/apps/docs/docs/guides/cli/local-development.mdx
+++ b/apps/docs/docs/guides/cli/local-development.mdx
@@ -82,6 +82,12 @@ For example:
 psql 'postgresql://postgres:postgres@localhost:54322/postgres'
 ```
 
+<Admonition type="note">
+
+To access the database from an edge function in your local Supabase setup, replace `localhost` with `host.docker.internal`.
+
+</Admonition>
+
 </TabPanel>
 <TabPanel id="kong" label="API Gateway">
 
@@ -104,14 +110,14 @@ http://localhost:54321/storage/v1/        # Storage
 http://localhost:54321/auth/v1/           # Auth (GoTrue)
 ```
 
-</TabPanel>
-</Tabs>
-
 <Admonition type="note">
 
-To access the database from an edge function in your local Supabase setup, replace `localhost` with `host.docker.internal`.
+`<anon key>` is provided when you run the command `supabase start`.
 
 </Admonition>
+
+</TabPanel>
+</Tabs>
 
 ## Database migrations
 


### PR DESCRIPTION
- Adds note to Local Development page.
- Reorganize notes between Tab Panels on the Local Development page.

## What kind of change does this PR introduce?
Docs update

## What is the current behavior?
No information about where to find the `<anon key>` while using `curl` to query information.

## What is the new behavior?
Adds `<anon key>` information and reorganize notes between panels.

## Additional context
The note about Postgres is out of place, and I searched about the ANON KEY for local development and didn't find any information anywhere. There is little mention of local keys in the `supabase start` command, but it is forgettable if you are not starting supabase manually every time.
