### PR TITLE
feat: policy placeholder text changed

### DIFF
--- a/studio/components/interfaces/Auth/Policies/PolicyEditor/PolicyRoles.tsx
+++ b/studio/components/interfaces/Auth/Policies/PolicyEditor/PolicyRoles.tsx
@@ -32,7 +32,7 @@ const PolicyRoles: FC<Props> = ({ roles, selectedRoles, onUpdateSelectedRoles })
         <MultiSelect
           options={formattedRoles}
           value={selectedRoles}
-          placeholder="Defaults to all roles if none selected"
+          placeholder="Defaults to all (public) roles if none selected"
           searchPlaceholder="Search for a role"
           onChange={onUpdateSelectedRoles}
         />


### PR DESCRIPTION
## What kind of change does this PR introduce?

Studio > Auth > Policies

## What is the current behavior?

Highlighted in #10196

## What is the new behavior?

Changed the placeholder to add in reference to the `public` role:

<img width="1156" alt="Screenshot 2022-11-09 at 15 57 55" src="https://user-images.githubusercontent.com/22655069/200879278-885c1778-1d19-4922-88a7-3ff77b2a9e9a.png">


## Additional context

Closes #10196
