### PR TITLE
fix: fix path rewriting for local dev for docs pages

### DIFF
--- a/apps/www/.env
+++ b/apps/www/.env
@@ -5,7 +5,7 @@
 # Replace this URL with the URL of your blog app
 
 NEXT_PUBLIC_URL="https://localhost:3000"
-NEXT_PUBLIC_DOCS_URL="http://localhost:3005"
+NEXT_PUBLIC_DOCS_URL="http://localhost:3001"
 NEXT_PUBLIC_STUDIO_URL="https://localhost:8082"
 NEXT_PUBLIC_LAUNCHWEEKSITE_URL="https://localhost:3008"
 NEXT_PUBLIC_REFERENCE_DOCS_URL="https://localhost:3010"

--- a/apps/www/lib/rewrites.js
+++ b/apps/www/lib/rewrites.js
@@ -1,8 +1,4 @@
 module.exports = [
-  // {
-  //   source: '/:path*',
-  //   destination: `/:path*`,
-  // },
   {
     source: '/docs',
     destination: `${process.env.NEXT_PUBLIC_DOCS_URL}/docs`,

--- a/apps/www/lib/rewrites.js
+++ b/apps/www/lib/rewrites.js
@@ -1,21 +1,21 @@
 module.exports = [
-  {
-    source: '/:path*',
-    destination: `/:path*`,
-  },
+  // {
+  //   source: '/:path*',
+  //   destination: `/:path*`,
+  // },
   {
     source: '/docs',
-    destination: `${process.env.NEXT_PUBLIC_DOCS_URL}`,
+    destination: `${process.env.NEXT_PUBLIC_DOCS_URL}/docs`,
   },
   {
     // redirect /docs/
     // trailing slash caused by docusaurus issue with multizone
     source: '/docs/',
-    destination: `${process.env.NEXT_PUBLIC_DOCS_URL}`,
+    destination: `${process.env.NEXT_PUBLIC_DOCS_URL}/docs/`,
   },
   {
     source: '/docs/:path*',
-    destination: `${process.env.NEXT_PUBLIC_DOCS_URL}/:path*`,
+    destination: `${process.env.NEXT_PUBLIC_DOCS_URL}/docs/:path*`,
   },
   // rewrite to keep existing ticket urls working
   {


### PR DESCRIPTION
Fixes the local development path rewriting, to allow proper transitioning between www and docs in local dev.


https://user-images.githubusercontent.com/22714384/201086733-ce62d77e-3b6d-4d6e-bbfd-230d1651bbc9.mov


