### PR TITLE
fix: add filtering to counts query generation

### DIFF
--- a/studio/components/interfaces/Settings/Logs/Logs.utils.ts
+++ b/studio/components/interfaces/Settings/Logs/Logs.utils.ts
@@ -180,7 +180,9 @@ export const maybeShowUpgradePrompt = (
   return (day > 1 && tierKey === 'FREE') || (day > 7 && tierKey === 'PRO') || day > 90 && tierKey === 'ENTERPRISE'
 }
 
-export const genCountQuery = (table: string): string => `SELECT count(*) as count FROM ${table}`
+export const genCountQuery = (table: LogsTableName, filters: Filters): string => {
+  const where = _genWhereStatement(table, filters)
+  return `SELECT count(*) as count FROM ${table} ${where}`}
 
 /** calculates how much the chart start datetime should be offset given the current datetime filter params */
 export const calcChartStart = (params: Partial<LogsEndpointParams>): [Dayjs, string] => {

--- a/studio/hooks/analytics/useLogsPreview.tsx
+++ b/studio/hooks/analytics/useLogsPreview.tsx
@@ -111,7 +111,7 @@ function useLogsPreview(
 
     return `${API_URL}/projects/${projectRef}/analytics/endpoints/logs.all?${genQueryParams({
       ...params,
-      sql: genCountQuery(table),
+      sql: genCountQuery(table, filters),
       iso_timestamp_start: latestRefresh,
     } as any)}`
   }

--- a/studio/tests/pages/projects/LogsPreviewer.test.js
+++ b/studio/tests/pages/projects/LogsPreviewer.test.js
@@ -380,6 +380,9 @@ test('filters alter generated query', async () => {
   userEvent.click(await screen.findByText(/Save/))
 
   await waitFor(() => {
+    // counts are adjusted
+    expect(get).toHaveBeenCalledWith(expect.stringMatching(/count.+\*.+as.count.+where.+500.+599/))
+
     expect(get).toHaveBeenCalledWith(expect.stringContaining('500'))
     expect(get).toHaveBeenCalledWith(expect.stringContaining('599'))
     expect(get).toHaveBeenCalledWith(expect.stringContaining('200'))
@@ -398,6 +401,11 @@ test('filters alter generated query', async () => {
   userEvent.click(await screen.findByText(/Save/))
 
   await waitFor(() => {
+    // counts are adjusted
+    expect(get).not.toHaveBeenCalledWith(expect.stringMatching(/count.+\*.+as.count.+where.+500.+599/))
+    expect(get).toHaveBeenCalledWith(expect.stringMatching(/count.+\*.+as.count.+where.+400.+499/))
+
+
     expect(get).not.toHaveBeenCalledWith(expect.stringContaining('500'))
     expect(get).not.toHaveBeenCalledWith(expect.stringContaining('599'))
     expect(get).not.toHaveBeenCalledWith(expect.stringContaining('200'))


### PR DESCRIPTION
Adds where filter generation to logs counts query. This fixes issues where users were receiving indicator of new logs even when filters are active (e.g. logs from different functions)

reference [ticket](https://www.notion.so/supabase/Logs-Previewer-refresh-counter-does-not-consider-active-filters-12d67418423a49d7ab89555fac5a35e6)