### PR TITLE
chore: document service role use case and grants

### DIFF
--- a/apps/docs/docs/guides/api.mdx
+++ b/apps/docs/docs/guides/api.mdx
@@ -349,6 +349,12 @@ alter table todos enable row level security;
 
 Never expose the `service_role` key in a browser or anywhere where a user can see it. This Key is designed to bypass Row Level Security - so it should only be used on a private server.
 
+A common use case for the `service_role` key is to run data analytics jobs on the backend. To support joins on user id, it is often useful to grant the service role read access to `auth.users` table.
+
+```sql
+grant select on table auth.users to service_role;
+```
+
 We have [partnered with GitHub](https://github.blog/changelog/2022-03-28-supabase-is-now-a-github-secret-scanning-partner/) to scan for Supabase `service_role` keys pushed to public repositories.
 If they detect any keys with service_role privileges being pushed to GitHub, they will forward the API key to us, so that we can automatically revoke the detected secrets and notify you, protecting your data against malicious actors.
 

--- a/apps/reference/docs/guides/api.mdx
+++ b/apps/reference/docs/guides/api.mdx
@@ -385,6 +385,12 @@ alter table todos enable row level security;
 
 Never expose the `service_role` key in a browser or anywhere where a user can see it. This Key is designed to bypass Row Level Security - so it should only be used on a private server.
 
+A common use case for the `service_role` key is to run data analytics jobs on the backend. To support joins on user id, it is often useful to grant the service role read access to `auth.users` table.
+
+```sql
+grant select on table auth.users to service_role;
+```
+
 We have [partnered with GitHub](https://github.blog/changelog/2022-03-28-supabase-is-now-a-github-secret-scanning-partner/) to scan for Supabase `service_role` keys pushed to public repositories.
 If they detect any keys with service_role privileges being pushed to GitHub, they will forward the API key to us, so that we can automatically revoke the detected secrets and notify you, protecting your data against malicious actors.
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

many users are asking for an easy way to access `auth.users` table https://github.com/supabase/supabase/discussions/9314#discussioncomment-4105780

## What is the new behavior?

document the manual grants needed to execute joins 

## Additional context

Add any other context or screenshots.
