### PR TITLE
feat: help buttons new tab

### DIFF
--- a/studio/components/layouts/ProjectLayout/LayoutHeader/HelpPopover.tsx
+++ b/studio/components/layouts/ProjectLayout/LayoutHeader/HelpPopover.tsx
@@ -42,14 +42,18 @@ const HelpPopover: FC<Props> = () => {
                 </Button>
               </Link>
               <Link passHref href="https://supabase.com/docs/">
-                <Button type="text" size="tiny" icon={<IconBookOpen />} as="a">
-                  Docs
-                </Button>
+                <a target="_blank" rel="noreferrer">
+                  <Button type="text" size="tiny" icon={<IconBookOpen />}>
+                    Docs
+                  </Button>
+                </a>
               </Link>
               <Link passHref href="https://status.supabase.com/">
-                <Button type="text" size="tiny" icon={<IconActivity />} as="a">
-                  Supabase Status
-                </Button>
+                <a target="_blank" rel="noreferrer">
+                  <Button type="text" size="tiny" icon={<IconActivity />}>
+                    Supabase Status
+                  </Button>
+                </a>
               </Link>
             </div>
             <p className="text-sm text-scale-900">


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feat: Studio > Help popover

## What is the current behavior?

Currently if you click on 'Docs' or 'Supabase Status' you get redirected to a new page.

## What is the new behavior?

When you click on either of the buttons a new tab opens which makes it easier to have the studio open in one tab and then docs or status in an other.
