### PR TITLE
fix: use `bigint` for db size report

### DIFF
--- a/studio/pages/project/[ref]/reports/database.tsx
+++ b/studio/pages/project/[ref]/reports/database.tsx
@@ -50,7 +50,7 @@ const DatabaseUsage: FC<any> = () => {
     let cancel = false
     const getDatabaseSize = async () => {
       const res = await meta.query(
-        'select sum(pg_database_size(pg_database.datname))::integer as db_size from pg_database;'
+        'select sum(pg_database_size(pg_database.datname))::bigint as db_size from pg_database;'
       )
       if (!res.error && !cancel) {
         setDatabaseSize(res[0].db_size)


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to fix the `Failed to retrieve database size` error when database size is greater than 2GB.

## What is the current behavior?

Currently the query sent to backend pg-meta to get db size is using `integer` which cannot hold number greater than 2GB, thus caused `Failed to retrieve database size` error when db size is large.

## What is the new behavior?

Use `bigint` for db size to avoid `Failed to retrieve database size` error.

## Additional context

N/A
