### PR TITLE
fix: get user info code snippet

### DIFF
--- a/studio/components/to-be-cleaned/Docs/Snippets.js
+++ b/studio/components/to-be-cleaned/Docs/Snippets.js
@@ -660,7 +660,7 @@ curl -X GET '${endpoint}/auth/v1/user' \\
     js: {
       language: 'js',
       code: `
-const user = supabase.auth.user()
+const { data: { user } } = await supabase.auth.getUser()
 `,
     },
   }),


### PR DESCRIPTION
## What kind of change does this PR introduce?

Studio > API > User Management > User

## What is the current behavior?

Currently the code snippet uses the v1 call:

<img width="986" alt="Screenshot 2022-11-15 at 16 06 35" src="https://user-images.githubusercontent.com/22655069/201970385-9862df1d-0e84-4f91-b0a5-207a58cad338.png">


## What is the new behavior?

Changed to use the v2 call:

<img width="1103" alt="Screenshot 2022-11-15 at 16 14 21" src="https://user-images.githubusercontent.com/22655069/201970434-c8aa54af-1334-44fc-a0d4-814826c5ceeb.png">


## Additional context

Closes #10300
