### PR TITLE
fix: prevent filter operator change

### DIFF
--- a/studio/components/grid/components/header/filter/FilterRow.tsx
+++ b/studio/components/grid/components/header/filter/FilterRow.tsx
@@ -16,7 +16,7 @@ interface Props {
 // [Area of improvement] Input field loses focus after the debounce (because of useUrlState?)
 const FilterRow: FC<Props> = ({ filter, filterIdx }) => {
   const state = useTrackedState()
-  const [_, setParams] = useUrlState({ arrayKeys: ['filter'] })
+  const [{ filter: filters }, setParams] = useUrlState({ arrayKeys: ['filter'] })
 
   const column = state.table?.columns.find((x) => x.name === filter.column)
   const columnOptions =
@@ -107,7 +107,7 @@ const FilterRow: FC<Props> = ({ filter, filterIdx }) => {
       }
     })
   }
-  const debounceHandler = useCallback(debounce(updateFilterValue, 600), [])
+  const debounceHandler = useCallback(debounce(updateFilterValue, 600), [filters])
 
   const placeholder =
     column?.format === 'timestamptz'


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix for resetting operator after setting filter value
 
## What is the current behavior?

Current behavior is described in #10334 

## What is the new behavior?

Filter operator remains unchanged after setting filter value

## Additional context

Closes #10334 
