### PR TITLE
fix: remove auto sign in

### DIFF
--- a/studio/pages/join/index.tsx
+++ b/studio/pages/join/index.tsx
@@ -32,7 +32,7 @@ const JoinOrganizationPage = () => {
   const { token_does_not_exist, email_match, expired_token, organization_name, invite_id } =
     tokenValidationInfo || {}
 
-  const loginRedirectLink = `/?next=${encodeURIComponent(`/join?token=${token}&slug=${slug}`)}`
+  const loginRedirectLink = `/?returnTo=${encodeURIComponent(`/join?token=${token}&slug=${slug}`)}`
 
   useEffect(() => {
     const fetchTokenInfo = async () => {

--- a/studio/pages/sign-in.tsx
+++ b/studio/pages/sign-in.tsx
@@ -1,42 +1,11 @@
 import SignInForm from 'components/interfaces/SignIn/SignInForm'
 import SignInWithGitHub from 'components/interfaces/SignIn/SignInWithGitHub'
 import { SignInLayout } from 'components/layouts'
-import Connecting from 'components/ui/Loading'
-import { auth } from 'lib/gotrue'
 import Link from 'next/link'
-import { NextRouter, useRouter } from 'next/router'
-import { useEffect } from 'react'
 import { NextPageWithLayout } from 'types'
 
-// detect for redirect from 3rd party service like vercel, aws...
-const isRedirectFromThirdPartyService = (router: NextRouter) => router.query.next !== undefined
-
 const SignInPage: NextPageWithLayout = () => {
-  const router = useRouter()
-  const autoSignIn = isRedirectFromThirdPartyService(router)
-
-  useEffect(() => {
-    if (autoSignIn) {
-      const queryParams = (router.query as any) || {}
-      const params = new URLSearchParams(queryParams)
-
-      // trigger github signIn
-      auth.signInWithOAuth({
-        provider: 'github',
-        options: {
-          redirectTo: `${
-            process.env.NEXT_PUBLIC_VERCEL_ENV === 'preview'
-              ? process.env.NEXT_PUBLIC_VERCEL_URL
-              : process.env.NEXT_PUBLIC_SITE_URL
-          }?${params.toString()}`,
-        },
-      })
-    }
-  }, [])
-
-  return autoSignIn ? (
-    <Connecting />
-  ) : (
+  return (
     <>
       <div className="flex flex-col gap-5">
         <SignInWithGitHub />


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behaviour?

The connecting screen gets stuck when there is a next query param on the login screen.

## What is the new behaviour?

`autoSignIn` is now handled by the `returnTo` parameter
