### PR TITLE
Fix code wrapping in paragraphs

### DIFF
--- a/apps/docs/components/CustomHTMLElements/InlineCode.tsx
+++ b/apps/docs/components/CustomHTMLElements/InlineCode.tsx
@@ -1,0 +1,11 @@
+const InlineCodeTag = ({ children }) => {
+  // If children isn't a string, just return it as is, just in case
+  if (typeof children !== 'string') return children
+
+  // check the length of the string inside the <code> tag
+  // if it's fewer than 70 characters, add a white-space: pre so it doesn't wrap
+  const classes = children.length < 70 ? 'short-inline-codeblock' : ''
+
+  return <code className={classes}>{children}</code>
+}
+export default InlineCodeTag

--- a/apps/docs/components/index.tsx
+++ b/apps/docs/components/index.tsx
@@ -18,6 +18,7 @@ import { Heading } from './CustomHTMLElements'
 import QuickstartIntro from './MDX/quickstart_intro.mdx'
 import ProjectSetup from './MDX/project_setup.mdx'
 import { Mermaid } from 'mdx-mermaid/lib/Mermaid'
+import InlineCodeTag from './CustomHTMLElements/InlineCode'
 
 const components = {
   Admonition,
@@ -55,6 +56,7 @@ const components = {
     return <CodeBlock {...props} linesToHighlight={linesToHighlight} />
   },
   mono: (props: any) => <code className="text-sm">{props.children}</code>,
+  inlineCode: (props: any) => <InlineCodeTag>{props.children}</InlineCodeTag>,
 }
 
 export default components

--- a/apps/docs/styles/main.scss
+++ b/apps/docs/styles/main.scss
@@ -220,7 +220,9 @@ article p code {
   &::after {
     display: none !important;
   }
+}
 
+.short-inline-codeblock {
   @media screen and (min-width: 769px) {
     white-space: pre !important;
   }

--- a/apps/docs/styles/main.scss
+++ b/apps/docs/styles/main.scss
@@ -213,14 +213,27 @@ a:has(code) {
   box-shadow: none !important;
 }
 
+// fix code line wrapping
+// need to set this to happen from medium onwards, otherwise the would cause horizontal scroll
+article p code {
+  &::before,
+  &::after {
+    display: none !important;
+  }
+
+  @media screen and (min-width: 769px) {
+    white-space: pre !important;
+  }
+}
+
 // fix firefox issue with li wrapping
 .doc-content-container ul li div.relative {
   display: inline-block;
 }
 
-.doc-content-container ul li a {
-  box-shadow: none !important;
-}
+// .doc-content-container ul li a {
+//   box-shadow: none !important;
+// }
 
 // fix ToC links when they have <code> inside
 .toc-menu li a code {

--- a/apps/docs/styles/main.scss
+++ b/apps/docs/styles/main.scss
@@ -231,10 +231,6 @@ article p code {
   display: inline-block;
 }
 
-// .doc-content-container ul li a {
-//   box-shadow: none !important;
-// }
-
 // fix ToC links when they have <code> inside
 .toc-menu li a code {
   background: none;


### PR DESCRIPTION
Before:
<img width="698" alt="CleanShot 2022-11-18 at 15 23 21@2x" src="https://user-images.githubusercontent.com/105593/202781113-2be9acae-2a6f-4b2e-a87c-daf8dfced4ee.png">

After:
<img width="692" alt="CleanShot 2022-11-18 at 16 51 47@2x" src="https://user-images.githubusercontent.com/105593/202795468-c2c6111a-a9da-4653-828e-980b2a2acfd6.png">



On mobile, both line break:
<img width="384" alt="CleanShot 2022-11-18 at 16 50 51@2x" src="https://user-images.githubusercontent.com/105593/202795352-263c6f95-41e9-4d40-922a-423f80c6b9a9.png">

