### PR TITLE
Add redirect for database usage doc

### DIFF
--- a/apps/www/lib/redirects.js
+++ b/apps/www/lib/redirects.js
@@ -1540,4 +1540,9 @@ module.exports = [
     source: '/docs/going-into-prod',
     destination: '/docs/guides/platform/going-into-prod',
   },
+  {
+    permanent: true,
+    source: '/docs/guides/platform/disk-usage',
+    destination: '/docs/guides/platform/database-usage',
+  },
 ]


### PR DESCRIPTION
## What kind of change does this PR introduce?

[/docs/guides/platform/disk-usage](https://zone-www-dot-com-git-docs-database-usage-redirect-supabase.vercel.app/docs/guides/platform/disk-usage) should redirect to [/docs/guides/platform/database-usage](https://zone-www-dot-com-git-docs-database-usage-redirect-supabase.vercel.app/docs/guides/platform/database-usage)