### PR TITLE
docs(auth): add scopes option to Keycloak login

### DIFF
--- a/apps/docs/pages/guides/auth/auth-keycloak.mdx
+++ b/apps/docs/pages/guides/auth/auth-keycloak.mdx
@@ -65,9 +65,10 @@ When your user signs in, call [signInWithOAuth()](/docs/reference/javascript/aut
 
 ```js
 async function signInWithKeycloak() {
-  const { data, error } = await supabase.auth.signInWithOAuth({
-    provider: 'keycloak',
-  })
+  const { data, error } = await supabase.auth.signInWithOAuth(
+    {provider: 'keycloak'},
+    {scopes: 'openid'},
+  )
 }
 ```
 

--- a/apps/docs/pages/guides/auth/auth-keycloak.mdx
+++ b/apps/docs/pages/guides/auth/auth-keycloak.mdx
@@ -65,10 +65,12 @@ When your user signs in, call [signInWithOAuth()](/docs/reference/javascript/aut
 
 ```js
 async function signInWithKeycloak() {
-  const { data, error } = await supabase.auth.signInWithOAuth(
-    {provider: 'keycloak'},
-    {scopes: 'openid'},
-  )
+  const { data, error } = await supabase.auth.signInWithOAuth({
+    provider: 'keycloak',
+    options: {
+      scopes: 'openid',
+    },
+  })
 }
 ```
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

Login with Keycloak needs the `scopes` option defined with at least the `openid` value specified, but it isn't documented.

If this option is not specified, the redirect URL back to the app (from Keycloak) returns with the following error message in the URL: 
`<YOUR_APP_URL>?error=server_error&error_description=Error+getting+user+email+from+external+provider`

There was a similar [issue #550](https://github.com/supabase/gotrue/issues/550) for the Azure integration too.

## What is the new behavior?

Adds `{scopes: 'openid'}` for the login example at [supabase.com/docs/guides/auth/auth-keycloak#add-login-code-to-your-client-app](https://supabase.com/docs/guides/auth/auth-keycloak#add-login-code-to-your-client-app), as the second parameter of the function.

## Additional context

None.
