### PR TITLE
fix(studio dockerfile): the destination of the COPY command is change…

### DIFF
--- a/studio/Dockerfile
+++ b/studio/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 FROM base as builder
 WORKDIR /usr/src/app
-COPY package*.json .
+COPY package*.json ./
 COPY turbo.json .
 COPY packages packages
 COPY studio studio


### PR DESCRIPTION
The destination of the COPY command is changed to a directory: `./`

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?
When you execute `docker build --target production -t supabase/studio:latest .` in **studio** sub directory or execute `docker build -f ./studio/Dockerfile --target production --no-cache -t supabase/studio:latest .` in repo root directory, you will receive error message: **When using COPY with more than one source file, the destination must be a directory and end with a /**, and docker build process will terminate.

## What is the new behavior?
You can build docker image correctly.

## Additional context
Error Message Screenshot
![image](https://user-images.githubusercontent.com/66654074/202985636-02cfb4a3-b515-4d2d-9736-332e19327322.png)

