### PR TITLE
feat: add unenroll documentation to mfa docs

### DIFF
--- a/apps/docs/pages/guides/auth/auth-mfa.mdx
+++ b/apps/docs/pages/guides/auth/auth-mfa.mdx
@@ -152,6 +152,10 @@ Enrolling a factor for use with MFA takes three steps:
 Below is an example that creates a new `EnrollMFA` component that illustrates
 the important pieces of the MFA enrollment flow.
 
+<Admonition type="note">
+A user can only unenroll a factor after completing the enrollment flow and obtaining
+an `aal2` JWT claim.
+</Admonition>
 - When the component appears on screen, the `supabase.auth.mfa.enroll()` API is
   called once to start the process of enrolling a new factor for the current
   user.
@@ -259,7 +263,8 @@ For example, to unenroll the nil UUID we would call: `supabase.auth.mfa.unenroll
 #### Example: React
 
 Below is an example that creates a new `UnenrollMFA` component that illustrates
-the important pieces of the MFA enrollment flow.
+the important pieces of the MFA enrollment flow. Note that a user can only unenroll a
+
 
 - When the component appears on screen, the `supabase.auth.mfa.listFactors()` API is
   called once to fetch all existing factors together with their details.

--- a/apps/docs/pages/guides/auth/auth-mfa.mdx
+++ b/apps/docs/pages/guides/auth/auth-mfa.mdx
@@ -94,20 +94,24 @@ for your application. JWTs without an `aal` claim are at the `aal1` level.
 
 ## Adding to your app
 
-Adding MFA to your app involves these three steps:
+Adding MFA to your app involves these four steps:
 
 1. **Add enrollment flow.**
    You need to provide a UI within your app that your users will be able to set-up
    MFA in. You can add this right after sign-up, or as part of a separate flow in
    the settings portion of your app.
-2. **Add challenge step to login.**
+2. **Add unenrollment flow.**
+   You need to support a UI through which users can see existing devices and unenroll
+   devices which are no longer relevant.
+3. **Add challenge step to login.**
    If a user has set-up MFA, your app's login flow needs to present a challenge
    screen to the user asking them to prove they have access to the additional
    factor.
-3. **Enforce rules for MFA logins.**
+4. **Enforce rules for MFA logins.**
    Once your users have a way to enroll and log in with MFA, you need to enforce
    authorization rules across your app: on the frontend, backend, API servers or
    Row-Level Security policies.
+
 
 ### Add enrollment flow
 
@@ -140,6 +144,8 @@ Enrolling a factor for use with MFA takes three steps:
    their app and is working correctly. If the verification succeeds, the factor
    immediately becomes active for the user account. If not, you should repeat
    steps 2 and 3.
+
+
 
 #### Example: React
 
@@ -236,6 +242,126 @@ export function EnrollMFA({
       />
       <input type="button" value="Enable" onClick={onEnableClicked} />
       <input type="button" value="Cancel" onClick={onCancelled} />
+    </>
+  )
+}
+```
+
+### Add unenrollment flow
+
+An Unenrollment flow provides a UI for users to manage and unenroll factors linked to their accounts.
+Most applications do so via a factor management page where users can view and unlink selected factors.
+
+To unenroll a factor, a user simply needs to call `supabase.auth.mfa.unenroll()` with the id of the factor they wish to unenroll.
+For example, to unenroll the nil UUID we would call: `supabase.auth.mfa.unenroll({factorId: "00000000-0000-0000-0000-000000000000"})`.
+
+
+#### Example: React
+
+Below is an example that creates a new `UnenrollMFA` component that illustrates
+the important pieces of the MFA enrollment flow.
+
+- When the component appears on screen, the `supabase.auth.mfa.listFactors()` API is
+  called once to fetch all existing factors together with their details.
+- The existing factors for a user are displayed together with the option to unenroll
+- Once the user has selected a factor to unenroll they can hit the `Unenroll` button
+  which creates a confirmation modal. We use `react-modal` for this modal.
+- `onUnenrolled` is a callback that notifies the other components that Unenrollment
+  has completed.
+- `onCancelled` is a callback that notifies the other components that the user
+  has clicked the `Cancel` button.
+
+```tsx
+import React from 'react';
+import ReactDOM from 'react-dom';
+import Modal from 'react-modal';
+
+...
+
+/**
+ * UnenrollMFA shows a simple table with the list of factors together with a button to unenroll.
+ * When a user selects a factor and clicks the unenroll button it displays a
+ * confirmation popup with the option to unenroll or to cancel. If the user opts
+ * to continue, it calls `onUnenroll`. Otherwise, if the user clicks cancel the
+ * `onCancelled` callback is called.
+ */
+export function UnenrollMFA({
+  onEnrolled,
+  onCancelled,
+}: {
+  onUnenrolled: () => void
+  onCancelled: () => void
+}) {
+  const [factorIds, setFactorIds] = useState('')
+  // TODO(Joel) - write the corresponding example
+  const [modalIsOpen, setIsOpen] = React.useState(false);
+  function closeModal() {
+    setIsOpen(false);
+    onCancelled();
+  }
+
+  function openModal() {
+    setIsOpen(true);
+  }
+
+  const [error, setError] = useState('') // holds an error message
+
+  const onEnableClicked = () => {
+    setError('')
+    ;(async () => {
+      const challenge = await supabase.auth.mfa.challenge({ factorId })
+      if (challenge.error) {
+        setError(challenge.error.message)
+        throw challenge.error
+      }
+
+      const challengeId = challenge.data.id
+
+      const verify = await supabase.auth.mfa.verify({
+        factorId,
+        challengeId,
+        code: verifyCode,
+      })
+      if (verify.error) {
+        setError(verify.error.message)
+        throw verify.error
+      }
+
+      onEnrolled()
+    })()
+  }
+
+  useEffect(() => {
+    ;(async () => {
+      const { data, error } = await supabase.auth.mfa.listFactors({
+        userId: <to-be-filled>
+      })
+      if (error) {
+        throw error
+      }
+
+      setFactorIds(data.id)
+    })()
+  }, [])
+
+  return (
+    <>
+      {error && <div className="error">{error}</div>}
+      <button onClick={openModal}>Open Modal</button>
+      <Modal
+        isOpen={modalIsOpen}
+        onAfterOpen={afterOpenModal}
+        onRequestClose={closeModal}
+        contentLabel="Unenrollment confirmation modal"
+      >
+        <h2 ref={(_subtitle) => (subtitle = _subtitle)}>Confirm Unenrollment</h2>
+        <div>Do you wish to proceed to unenroll: (todo: fetch-factor-name-here)?</div>
+        <form>
+          <button onClick={()=> supabase.auth.mfa.unenroll()}>Unenroll</button>
+          <button onClick={closeModal}>Cancel</button>
+        </form>
+      </Modal>
+    </div>
     </>
   )
 }
@@ -589,7 +715,7 @@ seconds later. The entries are ordered most recent method first!
 {
   "amr": [
     {
-      "method": "mfa/totp",
+      "method": "totp",
       "timestamp": 1666086056
     },
     {
@@ -625,7 +751,7 @@ Currently recognized methods are:
 - `otp` - any one-time password based sign in (email code, SMS code, magic
   link).
 - `oauth` - any OAuth based sign in (social login).
-- `mfa/totp` - a TOTP additional factor.
+- `totp` - a TOTP additional factor.
 
 This list will expand in the future.
 

--- a/apps/docs/pages/guides/auth/auth-mfa.mdx
+++ b/apps/docs/pages/guides/auth/auth-mfa.mdx
@@ -112,7 +112,6 @@ Adding MFA to your app involves these four steps:
    authorization rules across your app: on the frontend, backend, API servers or
    Row-Level Security policies.
 
-
 ### Add enrollment flow
 
 An enrollment flow provides a UI for users to set up additional authentication factors.
@@ -146,16 +145,11 @@ Enrolling a factor for use with MFA takes three steps:
    steps 2 and 3.
 
 
-
 #### Example: React
 
 Below is an example that creates a new `EnrollMFA` component that illustrates
 the important pieces of the MFA enrollment flow.
 
-<Admonition type="note">
-A user can only unenroll a factor after completing the enrollment flow and obtaining
-an `aal2` JWT claim.
-</Admonition>
 - When the component appears on screen, the `supabase.auth.mfa.enroll()` API is
   called once to start the process of enrolling a new factor for the current
   user.
@@ -253,7 +247,7 @@ export function EnrollMFA({
 
 ### Add unenrollment flow
 
-An Unenrollment flow provides a UI for users to manage and unenroll factors linked to their accounts.
+An unenrollment flow provides a UI for users to manage and unenroll factors linked to their accounts.
 Most applications do so via a factor management page where users can view and unlink selected factors.
 
 To unenroll a factor, a user simply needs to call `supabase.auth.mfa.unenroll()` with the id of the factor they wish to unenroll.
@@ -272,10 +266,12 @@ first going through the MFA process and attaining the `aal2` level. Here are som
 - Once the user has selected a factor to unenroll they can type in the factorId and hit the `Unenroll` button
   which creates a confirmation modal.
 
-```tsx
-import React from 'react';
-import ReactDOM from 'react-dom';
+<Admonition type="note">
+A user can only unenroll a factor after completing the enrollment flow and obtaining
+an `aal2` JWT claim.
+</Admonition>
 
+```tsx
 /**
  * UnenrollMFA shows a simple table with the list of factors together with a button to unenroll.
  * When a user types in the factorId of the factor that they wish to unenroll
@@ -283,7 +279,6 @@ import ReactDOM from 'react-dom';
 export function UnenrollMFA() {
   const [factorId, setFactorId] = useState('')
   const [factors, setFactors] = useState([])
-  const [modalIsOpen, setIsOpen] = React.useState(false);
   const [error, setError] = useState('') // holds an error message
 
   useEffect(() => {

--- a/apps/docs/pages/guides/auth/auth-mfa.mdx
+++ b/apps/docs/pages/guides/auth/auth-mfa.mdx
@@ -263,110 +263,64 @@ For example, to unenroll the nil UUID we would call: `supabase.auth.mfa.unenroll
 #### Example: React
 
 Below is an example that creates a new `UnenrollMFA` component that illustrates
-the important pieces of the MFA enrollment flow. Note that a user can only unenroll a
-
+the important pieces of the MFA enrollment flow. Note that a user can only unenroll factors they own and they can only unenroll factors after
+first going through the MFA process and attaining the `aal2` level. Here are some points of note:
 
 - When the component appears on screen, the `supabase.auth.mfa.listFactors()` API is
   called once to fetch all existing factors together with their details.
-- The existing factors for a user are displayed together with the option to unenroll
-- Once the user has selected a factor to unenroll they can hit the `Unenroll` button
-  which creates a confirmation modal. We use `react-modal` for this modal.
-- `onUnenrolled` is a callback that notifies the other components that Unenrollment
-  has completed.
-- `onCancelled` is a callback that notifies the other components that the user
-  has clicked the `Cancel` button.
+- The existing factors for a user are displayed in a table.
+- Once the user has selected a factor to unenroll they can type in the factorId and hit the `Unenroll` button
+  which creates a confirmation modal.
 
 ```tsx
 import React from 'react';
 import ReactDOM from 'react-dom';
-import Modal from 'react-modal';
-
-...
 
 /**
  * UnenrollMFA shows a simple table with the list of factors together with a button to unenroll.
- * When a user selects a factor and clicks the unenroll button it displays a
- * confirmation popup with the option to unenroll or to cancel. If the user opts
- * to continue, it calls `onUnenroll`. Otherwise, if the user clicks cancel the
- * `onCancelled` callback is called.
+ * When a user types in the factorId of the factor that they wish to unenroll
  */
-export function UnenrollMFA({
-  onEnrolled,
-  onCancelled,
-}: {
-  onUnenrolled: () => void
-  onCancelled: () => void
-}) {
-  const [factorIds, setFactorIds] = useState('')
-  // TODO(Joel) - write the corresponding example
+export function UnenrollMFA() {
+  const [factorId, setFactorId] = useState('')
+  const [factors, setFactors] = useState([])
   const [modalIsOpen, setIsOpen] = React.useState(false);
-  function closeModal() {
-    setIsOpen(false);
-    onCancelled();
-  }
-
-  function openModal() {
-    setIsOpen(true);
-  }
-
   const [error, setError] = useState('') // holds an error message
-
-  const onEnableClicked = () => {
-    setError('')
-    ;(async () => {
-      const challenge = await supabase.auth.mfa.challenge({ factorId })
-      if (challenge.error) {
-        setError(challenge.error.message)
-        throw challenge.error
-      }
-
-      const challengeId = challenge.data.id
-
-      const verify = await supabase.auth.mfa.verify({
-        factorId,
-        challengeId,
-        code: verifyCode,
-      })
-      if (verify.error) {
-        setError(verify.error.message)
-        throw verify.error
-      }
-
-      onEnrolled()
-    })()
-  }
 
   useEffect(() => {
     ;(async () => {
-      const { data, error } = await supabase.auth.mfa.listFactors({
-        userId: <to-be-filled>
-      })
+      const { data, error } = await supabase.auth.mfa.listFactors()
       if (error) {
         throw error
       }
 
-      setFactorIds(data.id)
+      setFactors(data.totp)
     })()
   }, [])
 
   return (
     <>
       {error && <div className="error">{error}</div>}
-      <button onClick={openModal}>Open Modal</button>
-      <Modal
-        isOpen={modalIsOpen}
-        onAfterOpen={afterOpenModal}
-        onRequestClose={closeModal}
-        contentLabel="Unenrollment confirmation modal"
-      >
-        <h2 ref={(_subtitle) => (subtitle = _subtitle)}>Confirm Unenrollment</h2>
-        <div>Do you wish to proceed to unenroll: (todo: fetch-factor-name-here)?</div>
-        <form>
-          <button onClick={()=> supabase.auth.mfa.unenroll()}>Unenroll</button>
-          <button onClick={closeModal}>Cancel</button>
-        </form>
-      </Modal>
-    </div>
+      <tbody>
+       <tr>
+         <td>Factor ID</td>
+         <td>Friendly Name</td>
+         <td>Factor Status</td>
+       </tr>
+       {factors.map(factor => (
+        <tr>
+          <td>{factor.id}</td>
+          <td>{factor.friendly_name}</td>
+          <td>{factor.factor_type}</td>
+          <td>{factor.status}</td>
+        </tr>
+      ))}
+      </tbody>
+      <input
+        type="text"
+        value={verifyCode}
+        onChange={(e) => setFactorId(e.target.value.trim())}
+      />
+      <button onClick={()=> supabase.auth.mfa.unenroll({factorId})}>Unenroll</button>
     </>
   )
 }

--- a/apps/docs/pages/guides/auth/auth-mfa.mdx
+++ b/apps/docs/pages/guides/auth/auth-mfa.mdx
@@ -7,13 +7,6 @@ export const meta = {
     'Add an additional layer of security to your apps with Supabase Auth multi-factor authentication.',
 }
 
-<Admonition type="note">
-
-Multi-Factor Authentication is in early access preview only. Although we
-believe it is production ready, APIs and some behavior may change based on
-feedback we receive in the preview period.
-
-</Admonition>
 
 Multi-factor authentication (MFA), sometimes called two-factor
 authentication (2FA), adds an additional layer of security to your
@@ -257,8 +250,8 @@ For example, to unenroll the nil UUID we would call: `supabase.auth.mfa.unenroll
 #### Example: React
 
 Below is an example that creates a new `UnenrollMFA` component that illustrates
-the important pieces of the MFA enrollment flow. Note that a user can only unenroll factors they own and they can only unenroll factors after
-first going through the MFA process and attaining the `aal2` level. Here are some points of note:
+the important pieces of the MFA enrollment flow. Note that users can only unenroll a factor after completing the enrollment flow and obtaining
+an `aal2` JWT claim.Here are some points of note:
 
 - When the component appears on screen, the `supabase.auth.mfa.listFactors()` API is
   called once to fetch all existing factors together with their details.
@@ -267,14 +260,15 @@ first going through the MFA process and attaining the `aal2` level. Here are som
   which creates a confirmation modal.
 
 <Admonition type="note">
-A user can only unenroll a factor after completing the enrollment flow and obtaining
-an `aal2` JWT claim.
+Unenrolling a factor will downgrade the assurance level from `aal2` to `aal1` only after the refresh interval has lapsed.
+For an immediate downgrade from `aal2` to `aal1` after enrolling one will need to manually call `refreshSession()`
 </Admonition>
 
 ```tsx
 /**
  * UnenrollMFA shows a simple table with the list of factors together with a button to unenroll.
- * When a user types in the factorId of the factor that they wish to unenroll
+ * When a user types in the factorId of the factor that they wish to unenroll and clicks unenroll
+ * the corresponding factor will be unenrolled.
  */
 export function UnenrollMFA() {
   const [factorId, setFactorId] = useState('')

--- a/apps/docs/pages/guides/auth/auth-mfa.mdx
+++ b/apps/docs/pages/guides/auth/auth-mfa.mdx
@@ -244,7 +244,7 @@ An unenrollment flow provides a UI for users to manage and unenroll factors link
 Most applications do so via a factor management page where users can view and unlink selected factors.
 
 To unenroll a factor, a user simply needs to call `supabase.auth.mfa.unenroll()` with the id of the factor they wish to unenroll.
-For example, to unenroll the nil UUID we would call: `supabase.auth.mfa.unenroll({factorId: "00000000-0000-0000-0000-000000000000"})`.
+For example, we would call: `supabase.auth.mfa.unenroll({factorId: "d30fd651-184e-4748-a928-0a4b9be1d429"})` to unenroll a factor with ID `d30fd651-184e-4748-a928-0a4b9be1d429`.
 
 
 #### Example: React
@@ -534,7 +534,7 @@ create policy "Policy name."
        select
          case
            when created_at >= '2022-12-12T00:00:00Z' then array['aal2']
-           else array['aal1', 'aal2', NULL]
+           else array['aal1', 'aal2']
          end as aal
        from auth.users
        where auth.uid() = id));
@@ -545,8 +545,6 @@ create policy "Policy name."
   `aal2` for all other timestamps.
 - The `<@` operator is PostgreSQL's ["contained in"
   operator.](https://www.postgresql.org/docs/current/functions-array.html)
-- `NULL` appears because some JWTs originating from prior to the introduction
-  of MFA in Supabase Auth will not contain an `aal` claim.
 - **Using `as restrictive` ensures this policy will restrict all commands on the
   table regardless of other policies!**
 
@@ -565,7 +563,7 @@ create policy "Policy name."
       select
           case
             when count(id) > 0 then array['aal2']
-            else array['aal1', 'aal2', NULL]
+            else array['aal1', 'aal2']
           end as aal
         from auth.mfa_factors
         where auth.uid() = user_id and status = 'verified'
@@ -577,8 +575,6 @@ create policy "Policy name."
 - Otherwise, it will accept both `aal1` and `aal2`.
 - The `<@` operator is PostgreSQL's ["contained in"
   operator.](https://www.postgresql.org/docs/current/functions-array.html)
-- `NULL` appears because some JWTs originating from prior to the introduction
-  of MFA in Supabase Auth will not contain an `aal` claim.
 - **Using `as restrictive` ensures this policy will restrict all commands on the
   table regardless of other policies!**
 

--- a/apps/docs/pages/guides/auth/auth-mfa.mdx
+++ b/apps/docs/pages/guides/auth/auth-mfa.mdx
@@ -260,10 +260,10 @@ Below is an example that creates a new `UnenrollMFA` component that illustrates
 the important pieces of the MFA enrollment flow. Note that a user can only unenroll factors they own and they can only unenroll factors after
 first going through the MFA process and attaining the `aal2` level. Here are some points of note:
 
-- When the component appears on screen, the `supabase.auth.mfa.listFactors()` API is
-  called once to fetch all existing factors together with their details.
+- When the component appears on screen, the `supabase.auth.mfa.listFactors()` endpoint
+  fetches all existing factors together with their details.
 - The existing factors for a user are displayed in a table.
-- Once the user has selected a factor to unenroll they can type in the factorId and hit the `Unenroll` button
+- Once the user has selected a factor to unenroll, they can type in the factorId and click **Unenroll**
   which creates a confirmation modal.
 
 <Admonition type="note">

--- a/apps/docs/pages/guides/auth/auth-mfa.mdx
+++ b/apps/docs/pages/guides/auth/auth-mfa.mdx
@@ -243,8 +243,8 @@ export function EnrollMFA({
 An unenrollment flow provides a UI for users to manage and unenroll factors linked to their accounts.
 Most applications do so via a factor management page where users can view and unlink selected factors.
 
-To unenroll a factor, a user simply needs to call `supabase.auth.mfa.unenroll()` with the id of the factor they wish to unenroll.
-For example, to unenroll the nil UUID we would call: `supabase.auth.mfa.unenroll({factorId: "00000000-0000-0000-0000-000000000000"})`.
+When a user unenrolls a factor, call `supabase.auth.mfa.unenroll()` with the ID of the factor.
+For example, to unenroll the nil UUID, call `supabase.auth.mfa.unenroll({factorId: "00000000-0000-0000-0000-000000000000"})`.
 
 
 #### Example: React

--- a/apps/docs/pages/guides/auth/auth-mfa.mdx
+++ b/apps/docs/pages/guides/auth/auth-mfa.mdx
@@ -243,8 +243,8 @@ export function EnrollMFA({
 An unenrollment flow provides a UI for users to manage and unenroll factors linked to their accounts.
 Most applications do so via a factor management page where users can view and unlink selected factors.
 
-To unenroll a factor, a user simply needs to call `supabase.auth.mfa.unenroll()` with the id of the factor they wish to unenroll.
-For example, we would call: `supabase.auth.mfa.unenroll({factorId: "d30fd651-184e-4748-a928-0a4b9be1d429"})` to unenroll a factor with ID `d30fd651-184e-4748-a928-0a4b9be1d429`.
+When a user unenrolls a factor, call `supabase.auth.mfa.unenroll()` with the ID of the factor.
+For example, call `supabase.auth.mfa.unenroll({factorId: "d30fd651-184e-4748-a928-0a4b9be1d429"})` to unenroll a factor with ID `d30fd651-184e-4748-a928-0a4b9be1d429`.
 
 
 #### Example: React


### PR DESCRIPTION
## What kind of change does this PR introduce?

The MFA documentation previously did not describe the steps needed to unenroll a device. We add a section with a react example which describes how to build a management page through which a use can view factors and unenroll selected factors (if user has completed mfa login)

Was initially going to go with an example with a modal and a dropdown via `react-modal` and `react-select` However, I realise that an input text field would suffice as an example  and that introducing two additional packages might cause both bloat and confusion.

## What is the current behavior?

No docs

## What is the new behavior?

An example in react  + jsaround unenrollment

## Additional context

Note: there's a separate task to remove the early access flag etc + callouts which say beta - they'll be dropped in a separate PR