### PR TITLE
fix: replace publication recreate with update

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -155,7 +155,7 @@ services:
 
   meta:
     container_name: supabase-meta
-    image: supabase/postgres-meta:v0.50.2
+    image: supabase/postgres-meta:v0.52.1
     depends_on:
       db: # Disable this if you are using an external Postgres database
         condition: service_healthy

--- a/studio/stores/pgmeta/PublicationStore.ts
+++ b/studio/stores/pgmeta/PublicationStore.ts
@@ -1,10 +1,5 @@
-import { ResponseError } from 'types'
-import PostgresMetaInterface, { IPostgresMetaInterface } from '../common/PostgresMetaInterface'
+import PostgresMetaInterface from '../common/PostgresMetaInterface'
 import { IRootStore } from '../RootStore'
-
-export interface IPublicationStore extends IPostgresMetaInterface<any> {
-  recreate: (id: any) => Promise<Partial<any> | { error: ResponseError }>
-}
 
 export default class PublicationStore extends PostgresMetaInterface<any> {
   constructor(
@@ -16,29 +11,5 @@ export default class PublicationStore extends PostgresMetaInterface<any> {
     options?: { identifier: string }
   ) {
     super(rootStore, dataUrl, headers, options)
-  }
-
-  /**
-   * Will recreate a publication.
-   * This is required if switching from "ALL TABLES" to individual tables.
-   */
-  async recreate(id: any, tables: string[] = []) {
-    let currentPublication = this.byId(id)
-    let payload: any = {
-      name: currentPublication.name,
-      publish_insert: currentPublication.publish_insert,
-      publish_update: currentPublication.publish_update,
-      publish_delete: currentPublication.publish_delete,
-      publish_truncate: currentPublication.publish_truncate,
-    }
-    if (currentPublication.tables === null) {
-      // Previously was "ALL TABLES"
-      payload.tables = tables
-    }
-    const deleted: any = await this.del(id)
-    if (deleted.error) {
-      return deleted // return error
-    }
-    return await this.create(payload)
   }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Updating `supabase_realtime` publication with new tables means deleting and then creating publication but b/c it's a two step process there are times when publication is deleted but not created. This results in the case when Studio user ends up with no publication.

## What is the new behavior?

Updating `supabase_realtime` publication with new tables is all done in a single transaction to prevent the absence of a publication.
