### PR TITLE
chore: fix layout ui for unsupported type

### DIFF
--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnType.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnType.tsx
@@ -37,7 +37,9 @@ const ColumnType: FC<Props> = ({
         readOnly
         disabled
         label={showLabel ? 'Type' : ''}
-        layout="horizontal"
+        layout={showLabel ? 'horizontal' : undefined}
+        className="md:gap-x-0"
+        size="small"
         value={value}
         descriptionText={
           showLabel


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes https://github.com/supabase/supabase/issues/10207

## What is the current behavior?

UI for unsupported column types in `ColumnManagement` is rendered unexpectedly

## What is the new behavior?

UI for unsupported column types in `ColumnManagement` is rendered correctly

## Demo

Before
<img width="665" alt="Screenshot at Nov 21 22-50-48" src="https://user-images.githubusercontent.com/51897872/203099095-824c9f31-28a9-4fc4-bffa-286947d24824.png">


After

<img width="664" alt="Screenshot at Nov 21 22-51-26" src="https://user-images.githubusercontent.com/51897872/203099067-e87a6815-2e25-4783-b862-72b1304a7808.png">


