### PR TITLE
[typo]: nextjs-server-components.mdx

### DIFF
--- a/apps/docs/pages/guides/auth/auth-helpers/nextjs-server-components.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/nextjs-server-components.mdx
@@ -210,7 +210,7 @@ Create a `/components/supabase-listener.jsx` file and add the following:
 
 import { useRouter } from 'next/navigation'
 import { useEffect } from 'react'
-import supabase from '../utils/supabase'
+import supabase from '../utils/supabase-browser'
 
 export default function SupabaseListener({ accessToken }) {
   const router = useRouter()


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update: typo

## What is the current behavior?

With the typo in the import statement, it is unclear which supabase client users should import (server vs client vs middleware)

## What is the new behavior?

Utilize the `createBrowserSupabaseClient()` from auth-helpers to ensure that the supabase client that is run on the client is using the browser client.

