### PR TITLE
chore: increase support form character limit

### DIFF
--- a/studio/components/interfaces/Support/SupportForm.tsx
+++ b/studio/components/interfaces/Support/SupportForm.tsx
@@ -455,8 +455,8 @@ const SupportForm: FC<Props> = ({ setSentCategory }) => {
                     id="message"
                     label="Message"
                     placeholder="Describe the issue you're facing, along with any relevant information. Please be as detailed and specific as possible."
-                    limit={500}
-                    labelOptional="500 character limit"
+                    limit={5000}
+                    labelOptional="5000 character limit"
                   />
                 </div>
                 <div className="space-y-4 px-6">


### PR DESCRIPTION
As discussed in https://supabase.slack.com/archives/C03AP03JFDZ/p1669230644776199 based on user feedback.

> The issue with the dashboard is that I only get 500 characters, which is an unreasonably small amount of space to provide enough details for a problem or bug we see in Supabase

While this might not be the most future-proof solution, it's a quick win and unblocks our users.

If there are other limitations that I am not aware of or very good reasons not to increase the limit, please let me know.