### PR TITLE
fix: update API docs bash code sample to return=minimal

### DIFF
--- a/studio/components/to-be-cleaned/Docs/Snippets.js
+++ b/studio/components/to-be-cleaned/Docs/Snippets.js
@@ -366,7 +366,7 @@ curl -X POST '${endpoint}/rest/v1/${resourceId}' \\
 -H "apikey: ${apiKey}" \\
 -H "Authorization: Bearer ${apiKey}" \\
 -H "Content-Type: application/json" \\
--H "Prefer: return=representation" \\
+-H "Prefer: return=minimal" \\
 -d '{ "some_column": "someValue", "other_column": "otherValue" }'
 `,
     },
@@ -436,7 +436,7 @@ curl -X PATCH '${endpoint}/rest/v1/${resourceId}?some_column=eq.someValue' \\
 -H "apikey: ${apiKey}" \\
 -H "Authorization: Bearer ${apiKey}" \\
 -H "Content-Type: application/json" \\
--H "Prefer: return=representation" \\
+-H "Prefer: return=minimal" \\
 -d '{ "other_column": "otherValue" }'
 `,
     },


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently, the API docs in Supabase dashboard provides `return=representation` for inserting and updating data using bash. This may be confusing, because it requires select policy, and this is no longer the behavior in supabase-js and other client libraries when performing an insert. This PR changes them to `return=minimal`. One user on Twitter was stuck on this, because they could not insert with the bash code, and they only had insert policy on.

<img width="1426" alt="Screen Shot 2022-11-24 at 13 00 04" src="https://user-images.githubusercontent.com/18113850/203691098-0349af33-986b-460d-9fa8-2516863181e7.png">


## What is the current behavior?

`return=representation` is used for sample curl command in the dashboard API docs. 

## What is the new behavior?

`return=minimal` is used for sample curl command in the dashboard API docs. 