### PR TITLE
Make UpgradeToPro CTA for pitr and custom domains more nuanced based on the project's plan

### DIFF
--- a/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainConfig.tsx
+++ b/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainConfig.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link'
 import { observer } from 'mobx-react-lite'
 import { IconAlertCircle } from 'ui'
 
-import { useParams } from 'hooks'
+import { useParams, useStore } from 'hooks'
 import { useProjectSettingsQuery } from 'data/config/project-settings-query'
 import { useCustomDomainsQuery } from 'data/custom-domains/custom-domains-query'
 import Panel from 'components/ui/Panel'
@@ -13,10 +13,13 @@ import CustomDomainVerify from './CustomDomainVerify'
 import CustomDomainActivate from './CustomDomainActivate'
 import CustomDomainsConfigureHostname from './CustomDomainsConfigureHostname'
 import CustomDomainsShimmerLoader from './CustomDomainsShimmerLoader'
+import { PRICING_TIER_PRODUCT_IDS } from 'lib/constants'
 
 const CustomDomainConfig = () => {
+  const { ui } = useStore()
   const { ref } = useParams()
 
+  const tier = ui.selectedProject?.subscription_tier
   const { isLoading: isSettingsLoading, data: settings } = useProjectSettingsQuery({
     projectRef: ref,
   })
@@ -49,7 +52,11 @@ const CustomDomainConfig = () => {
                 icon={<IconAlertCircle size={18} strokeWidth={1.5} />}
                 primaryText="Custom domains are a Pro plan add-on"
                 projectRef={ref as string}
-                secondaryText="To configure a custom domain for your project, please upgrade to a Pro plan"
+                secondaryText={
+                  tier === PRICING_TIER_PRODUCT_IDS.FREE
+                    ? 'To configure a custom domain for your project, please upgrade to the Pro plan and purchase the add-on'
+                    : 'To configure a custom domain for your project, please purchase the add-on'
+                }
               />
             </Panel.Content>
           )}

--- a/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainConfig.tsx
+++ b/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainConfig.tsx
@@ -54,7 +54,7 @@ const CustomDomainConfig = () => {
                 projectRef={ref as string}
                 secondaryText={
                   tier === PRICING_TIER_PRODUCT_IDS.FREE
-                    ? 'To configure a custom domain for your project, please upgrade to the Pro plan and purchase the add-on'
+                    ? 'To configure a custom domain for your project, please upgrade to the Pro plan with the custom domains add-on selected'
                     : 'To configure a custom domain for your project, please purchase the add-on'
                 }
               />

--- a/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainConfig.tsx
+++ b/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainConfig.tsx
@@ -55,7 +55,7 @@ const CustomDomainConfig = () => {
                 secondaryText={
                   tier === PRICING_TIER_PRODUCT_IDS.FREE
                     ? 'To configure a custom domain for your project, please upgrade to the Pro plan with the custom domains add-on selected'
-                    : 'To configure a custom domain for your project, please purchase the add-on'
+                    : 'To configure a custom domain for your project, please enable the add-on'
                 }
               />
             </Panel.Content>

--- a/studio/components/ui/UpgradeToPro.tsx
+++ b/studio/components/ui/UpgradeToPro.tsx
@@ -1,6 +1,9 @@
-import { Button, IconClock } from 'ui'
+import { Button } from 'ui'
+import { observer } from 'mobx-react-lite'
 import Link from 'next/link'
 import { FC, ReactNode } from 'react'
+import { useStore } from 'hooks'
+import { PRICING_TIER_PRODUCT_IDS } from 'lib/constants'
 
 interface Props {
   icon?: ReactNode
@@ -9,29 +12,38 @@ interface Props {
   secondaryText: string
 }
 
-const UpgradeToPro: FC<Props> = ({ icon, primaryText, projectRef, secondaryText }) => (
-  <div
-    className={[
-      'block w-full rounded border border-opacity-20 py-4 px-6',
-      'border-gray-600 bg-gray-100',
-      'dark:border-gray-300 dark:bg-gray-400',
-    ].join(' ')}
-  >
-    <div className="flex space-x-3">
-      {icon && <div className="mt-1">{icon}</div>}
-      <div className="flex w-full items-center justify-between">
-        <div className="space-y-1">
-          <p className="text-sm">{primaryText}</p>
-          <div>
-            <p className="text-sm text-scale-1100">{secondaryText}</p>
+const UpgradeToPro: FC<Props> = ({ icon, primaryText, projectRef, secondaryText }) => {
+  const { ui } = useStore()
+  const tier = ui.selectedProject?.subscription_tier
+
+  return (
+    <div
+      className={[
+        'block w-full rounded border border-opacity-20 py-4 px-6',
+        'border-gray-600 bg-gray-100',
+        'dark:border-gray-300 dark:bg-gray-400',
+      ].join(' ')}
+    >
+      <div className="flex space-x-3">
+        {icon && <div className="mt-1">{icon}</div>}
+        <div className="flex w-full items-center justify-between">
+          <div className="space-y-1">
+            <p className="text-sm">{primaryText}</p>
+            <div>
+              <p className="text-sm text-scale-1100">{secondaryText}</p>
+            </div>
           </div>
+          <Link href={`/project/${projectRef}/settings/billing/update`}>
+            <a>
+              <Button type="primary">
+                {tier === PRICING_TIER_PRODUCT_IDS.FREE ? 'Upgrade to Pro' : 'Purchase Add-on'}
+              </Button>
+            </a>
+          </Link>
         </div>
-        <Link href={`/project/${projectRef}/settings/billing/update`}>
-          <Button type="primary">Upgrade to Pro</Button>
-        </Link>
       </div>
     </div>
-  </div>
-)
+  )
+}
 
-export default UpgradeToPro
+export default observer(UpgradeToPro)

--- a/studio/components/ui/UpgradeToPro.tsx
+++ b/studio/components/ui/UpgradeToPro.tsx
@@ -36,7 +36,7 @@ const UpgradeToPro: FC<Props> = ({ icon, primaryText, projectRef, secondaryText 
           <Link href={`/project/${projectRef}/settings/billing/update`}>
             <a>
               <Button type="primary">
-                {tier === PRICING_TIER_PRODUCT_IDS.FREE ? 'Upgrade to Pro' : 'Purchase Add-on'}
+                {tier === PRICING_TIER_PRODUCT_IDS.FREE ? 'Upgrade to Pro' : 'Modify subscription'}
               </Button>
             </a>
           </Link>

--- a/studio/pages/project/[ref]/database/backups/pitr.tsx
+++ b/studio/pages/project/[ref]/database/backups/pitr.tsx
@@ -68,7 +68,7 @@ const PITR = () => {
         primaryText="Point in time recovery is a Pro plan add-on."
         secondaryText={
           tier === PRICING_TIER_PRODUCT_IDS.FREE
-            ? 'Please upgrade to the Pro plan and purchase the add-on to enable point in time recovery for your project.'
+            ? 'Please upgrade to the Pro plan with the PITR add-on selected to enable point in time recovery for your project.'
             : 'Please purchase the add-on to enable point in time recovery for your project.'
         }
       />

--- a/studio/pages/project/[ref]/database/backups/pitr.tsx
+++ b/studio/pages/project/[ref]/database/backups/pitr.tsx
@@ -13,6 +13,7 @@ import InformationBox from 'components/ui/InformationBox'
 import UpgradeToPro from 'components/ui/UpgradeToPro'
 import { PITRNotice, PITRSelection } from 'components/interfaces/Database/Backups/PITR'
 import BackupsError from 'components/interfaces/Database/Backups/BackupsError'
+import { PRICING_TIER_PRODUCT_IDS } from 'lib/constants'
 
 const DatabasePhysicalBackups: NextPageWithLayout = () => {
   const { ui } = useStore()
@@ -51,6 +52,7 @@ const PITR = () => {
   const { configuration, error, isLoading } = backups
 
   const ref = ui.selectedProject?.ref ?? 'default'
+  const tier = ui.selectedProject?.subscription_tier
   const isEnabled = configuration.walg_enabled
 
   const isPITRSelfServeEnabled = useFlag('pitrSelfServe')
@@ -63,8 +65,12 @@ const PITR = () => {
     return isPITRSelfServeEnabled ? (
       <UpgradeToPro
         projectRef={ref}
-        primaryText="Free Plan does not include point in time recovery."
-        secondaryText="Please upgrade to the Pro plan to enable point in time recovery for your project."
+        primaryText="Point in time recovery is a Pro plan add-on."
+        secondaryText={
+          tier === PRICING_TIER_PRODUCT_IDS.FREE
+            ? 'Please upgrade to the Pro plan and purchase the add-on to enable point in time recovery for your project.'
+            : 'Please purchase the add-on to enable point in time recovery for your project.'
+        }
       />
     ) : (
       <InformationBox

--- a/studio/pages/project/[ref]/database/backups/pitr.tsx
+++ b/studio/pages/project/[ref]/database/backups/pitr.tsx
@@ -69,7 +69,7 @@ const PITR = () => {
         secondaryText={
           tier === PRICING_TIER_PRODUCT_IDS.FREE
             ? 'Please upgrade to the Pro plan with the PITR add-on selected to enable point in time recovery for your project.'
-            : 'Please purchase the add-on to enable point in time recovery for your project.'
+            : 'Please enable the add-on to enable point in time recovery for your project.'
         }
       />
     ) : (


### PR DESCRIPTION
If on free plan
<img width="994" alt="image" src="https://user-images.githubusercontent.com/19742402/203914374-57b52fc0-3508-4967-a639-3fe88e652cfd.png">

If already on paid plan
<img width="969" alt="image" src="https://user-images.githubusercontent.com/19742402/203915440-14b68582-979f-40ef-a902-7951b013eec6.png">
