### PR TITLE
Additional info about creating new custom schema

### DIFF
--- a/apps/docs/docs/reference/javascript/v1/initializing.mdx
+++ b/apps/docs/docs/reference/javascript/v1/initializing.mdx
@@ -117,7 +117,7 @@ const supabase = createClient('https://xyzcompany.supabase.co', 'public-anon-key
 ```
 
 By default the API server points to the `public` schema. You can enable other database schemas within the Dashboard.
-Go to `Settings > API > Schema` and add the schema which you want to expose to the API.
+Go to `Settings > API > Schema` and add the schema which you want to expose to the API. You also need to grant `USAGE`on your new schema and your desire grant such as `SELECT, INSERT, UPDATE, DELETE` on objects those will be created in your new schema. 
 
 Note: each client connection can only access a single schema, so the code above can access the `other_schema` schema but cannot access the `public` schema.
 

--- a/apps/docs/docs/reference/javascript/v1/initializing.mdx
+++ b/apps/docs/docs/reference/javascript/v1/initializing.mdx
@@ -117,7 +117,7 @@ const supabase = createClient('https://xyzcompany.supabase.co', 'public-anon-key
 ```
 
 By default the API server points to the `public` schema. You can enable other database schemas within the Dashboard.
-Go to `Settings > API > Schema` and add the schema which you want to expose to the API. You also need to grant `USAGE`on your new schema and your desire grant such as `SELECT, INSERT, UPDATE, DELETE` on objects those will be created in your new schema. 
+Go to `Settings > API > Schema` and add the schema which you want to expose to the API. You also need to grant `USAGE` on your new schema with the grants you desire, such as `SELECT, INSERT, UPDATE, DELETE`. 
 
 Note: each client connection can only access a single schema, so the code above can access the `other_schema` schema but cannot access the `public` schema.
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?
Not enough information to start using new custom schema via API. 
When we create new schema by following the docs, we still can't access those new schema without giving necessary permissions to it. It took me hours to figure it out.

Please link any relevant issues here.

## What is the new behavior?
Add additional information about giving necessary permission to newly created schema.

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
