### PR TITLE
fix: POSTGRES_PASSWORD key

### DIFF
--- a/docker/volumes/db/roles.sql
+++ b/docker/volumes/db/roles.sql
@@ -1,5 +1,5 @@
 -- NOTE: change to your own passwords for production environments
-\set pgpass `echo "$PGPASSWORD"`
+\set pgpass `echo "$POSTGRES_PASSWORD"`
 
 ALTER USER authenticator WITH PASSWORD :'pgpass';
 ALTER USER pgbouncer WITH PASSWORD :'pgpass';


### PR DESCRIPTION
Fix POSTGRES_PASSWORD key, consistent with /docker/.env.example POSTGRES_PASSWORD

## What kind of change does this PR introduce?

fix POSTGRES_PASSWORD key

## What is the current behavior?

When I self-hosted to the public server, when I opened `https://exmaple.com/project/default`, the /rest/v1 response code was 502.

## What is the new behavior?

It can work normally

## Additional context

Add any other context or screenshots.
