### PR TITLE
feat(usage): show functions usage

### DIFF
--- a/studio/components/interfaces/Billing/Billing.constants.tsx
+++ b/studio/components/interfaces/Billing/Billing.constants.tsx
@@ -1,4 +1,4 @@
-import { IconArchive, IconDatabase, IconKey } from 'ui'
+import { IconArchive, IconCode, IconDatabase, IconKey } from 'ui'
 
 export const CANCELLATION_REASONS = [
   'Pricing',
@@ -69,6 +69,27 @@ export const USAGE_BASED_PRODUCTS = [
         units: 'bytes',
         costPerUnit: 0.09,
       },
+    ],
+  },
+  {
+    title: 'Functions',
+    icon: <IconCode className="dark:text-scale-100" size={16} strokeWidth={2} />,
+    features: [
+      {
+        key: 'func_count',
+        attribute: 'func_count',
+        title: 'Function Count',
+        units: 'absolute',
+        costPerUnit: 0.1,
+      },
+     
+      {
+        key: 'func_invocations',
+        attribute: 'func_invocations',
+        title: 'Function Invocations',
+        units: 'absolute',
+        costPerUnit: 0.000002,
+      }
     ],
   },
 ]


### PR DESCRIPTION
## What kind of change does this PR introduce?

Show functions count/invocations on the usage page.

## What is the current behavior?

We currently show no info regarding functions.

## What is the new behavior?

<img width="926" alt="Screenshot 2022-11-28 at 11 07 51" src="https://user-images.githubusercontent.com/14073399/204251074-e5b0951f-457e-4291-a34a-4d434f42520c.png">

## Additional context

Function Egress and Function Time Spent are currently not billed, so I did not include them yet.

API PR has been merged and released to production

https://github.com/supabase/infrastructure/pull/10324

