### PR TITLE
docs: postgres link updated

### DIFF
--- a/apps/docs/pages/guides/database.mdx
+++ b/apps/docs/pages/guides/database.mdx
@@ -85,7 +85,7 @@ Read about resetting your database password [here](/docs/guides/database/managin
 
 ## Next steps
 
-- Read more about [Postgres](/docs/postgres/server/about)
+- Read more about [Postgres](https://www.postgresql.org/about/)
 - Sign in: [app.supabase.com](https://app.supabase.com)
 
 export const Page = ({ children }) => <Layout meta={meta} children={children} />


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase Docs - [Database Next Steps](https://supabase.com/docs/guides/database#next-steps)

## What is the current behavior?

The `Read more about Postgres`link goes to a page not found

## What is the new behavior?

Was not sure to remove the link completely or link to an external link on the Postgres docs, But I have linked to the Postgres docs on the about section.

## Additional context

Closes #10547
