### PR TITLE
Fix dead link to Kong documentation

### DIFF
--- a/apps/docs/pages/guides/hosting/overview.mdx
+++ b/apps/docs/pages/guides/hosting/overview.mdx
@@ -39,7 +39,7 @@ Each system has a number of configuration options which can be found in the rele
 - [Realtime](https://github.com/supabase/realtime#server)
 - [GoTrue](https://github.com/supabase/gotrue)
 - [Storage](https://github.com/supabase/storage-api)
-- [Kong](https://docs.konghq.com/install/docker/)
+- [Kong](https://docs.konghq.com/mesh/latest/installation/docker/)
 
 ## Managing your database
 

--- a/apps/docs/pages/guides/hosting/overview.mdx
+++ b/apps/docs/pages/guides/hosting/overview.mdx
@@ -39,7 +39,7 @@ Each system has a number of configuration options which can be found in the rele
 - [Realtime](https://github.com/supabase/realtime#server)
 - [GoTrue](https://github.com/supabase/gotrue)
 - [Storage](https://github.com/supabase/storage-api)
-- [Kong](https://docs.konghq.com/mesh/latest/installation/docker/)
+- [Kong](https://docs.konghq.com/gateway/latest/install/docker/)
 
 ## Managing your database
 


### PR DESCRIPTION
In the [Configuration section of the Self Hosting guide](https://supabase.com/docs/guides/hosting/overview#configuration), there is a link to the Kong docs which has been moved. This PR updates this link to the new location.