### PR TITLE
fix: Action toggle icon disappears on focus in dashboard storage table

### DIFF
--- a/studio/styles/storage.scss
+++ b/studio/styles/storage.scss
@@ -40,7 +40,9 @@
 // scroll-behavior: smooth;
 // }
 
-.storage-row:hover {
+.storage-row:hover,
+button[aria-haspopup='menu'][data-state='open'],
+button[aria-haspopup='menu']:focus-visible {
   .storage-row-menu {
     @apply opacity-100;
   }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes https://github.com/supabase/supabase/issues/10524

## What is the current behavior?

Action toggle icon disappears when the Dropdown menu in dashboard storage table is open.

## What is the new behavior?

VerticalMore Icon remains visible when the Dropdown Menu is open.

## Steps to test

Steps to reproduce the behavior, please provide code snippets or a repository:

1. Go to the storage on dashboard
2. Upload a few items
4. On the action column (last column), focus on the 3 dot action icon.
5. Notice that the `verticalMore Icon` doesn't disappear anymore when the Dropdown menu is open.
6. Notice that the `verticalMore icon` remains visible when the dropdown is closed, but the focus is on it.

## Demo


https://user-images.githubusercontent.com/7220167/204736580-a0f4ecec-d729-4a74-b190-b6d231de6558.mov


