### PR TITLE
Fix: announcement on small screen

### DIFF
--- a/apps/www/components/Nav/Announcement.tsx
+++ b/apps/www/components/Nav/Announcement.tsx
@@ -69,9 +69,9 @@ const Announcement = () => {
           "
         >
           <span>{announcement.text}</span>
-          <span className="item-center flex gap-2 px-3">
+          <span className="item-center flex gap-2 pr-8 sm:px-3">
             {announcement.badge && (
-              <div className="bg-[#2E2E2E] text-white py-0.25 rounded-2xl px-3 py-1 border border-gray-1100	">
+              <div className="bg-[#2E2E2E] text-white py-0.25 rounded-2xl px-3 py-1 border border-gray-1100	whitespace-nowrap">
                 {announcement.badge}
               </div>
             )}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix announcement on small screen

## What is the current behavior?

<img width="406" alt="screenshot" src="https://user-images.githubusercontent.com/70828596/204975879-b0a9f9c0-69cd-442d-9884-bebb679123d1.png">

## What is the new behavior?
<img width="406" alt="screenshot" src="https://user-images.githubusercontent.com/70828596/204975833-6e0c343e-ea5a-4db2-83dd-0f4e1225a710.png">