### PR TITLE
fix: reset captcha token on sso sign in error

### DIFF
--- a/studio/components/interfaces/SignIn/SignInSSOForm.tsx
+++ b/studio/components/interfaces/SignIn/SignInSSOForm.tsx
@@ -44,6 +44,7 @@ const SignInSSOForm = () => {
         window.location.href = data.url
       }
     } else {
+      setCaptchaToken(null)
       captchaRef.current?.resetCaptcha()
 
       ui.setNotification({


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behaviour?

Captcha token is not being fully reset when an error occurs when signing in with SSO.
