### PR TITLE
Fix typo

### DIFF
--- a/apps/docs/pages/guides/integrations/zuplo.mdx
+++ b/apps/docs/pages/guides/integrations/zuplo.mdx
@@ -30,7 +30,7 @@ Manually enter a couple of rows of data, so that we have something to read from 
 
 ## The `Get all` reviews route in Zuplo
 
-Login to Zuplo at [portal.zuplo.com](https://portal.zuplo.com] and create a new project in Zuplo - I went with `supabase-ski-reviews`.
+Login to Zuplo at [portal.zuplo.com](https://portal.zuplo.com) and create a new project in Zuplo - I went with `supabase-ski-reviews`.
 
 Select the **File** tab and choose **Routes**. Add your first route with the following settings:
 


### PR DESCRIPTION
Fixing a typo within the Zuplo docs for Supabase. This fixes a broken link tag