### PR TITLE
Docs: SvelteKit Auth Helpers: Add missing import to code example

### DIFF
--- a/apps/docs/pages/guides/auth/auth-helpers/sveltekit.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/sveltekit.mdx
@@ -295,6 +295,7 @@ If you try to submit a form with the action `?/createPost` without a valid sessi
 import type { Actions } from './$types'
 import { invalid, redirect } from '@sveltejs/kit'
 import { getSupabase } from '@supabase/auth-helpers-sveltekit'
+import { AuthApiError } from '@supabase/supabase-js'
 
 export const actions: Actions = {
   signin: async (event) => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update in [auth-helpers for SvelteKit](https://supabase.com/docs/guides/auth/auth-helpers/sveltekit#saving-and-deleting-the-session), add missing import `AuthApiError` to code example.

## What is the current behavior?

Import of error class is missing and throwing TS error.

## What is the new behavior?

Added import so everything to make the code example work is presented in the code to copy from the docs.
