### PR TITLE
docs: changed docs url

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -75,7 +75,7 @@ Then visit, and edit, any of the following sites:
 | ---------------------------------------------- | -------------- | ---------- | ------------------------------------ | ------------------------ |
 | [supabase.com](https://supabase.com)           | `/apps/www`    | www        | The main website                     | http://localhost:3000    |
 | [app.supabase.com](https://app.supabase.com)   | `/studio`      | studio     | Studio dashboard                     | http://localhost:8082    |
-| [supabase.com/docs](https://supabase.com/docs) | `/apps/docs`   | docs       | Guides and Reference (Next.js based) | http://localhost:3001    |
+| [supabase.com/docs](https://supabase.com/docs) | `/apps/docs`   | docs       | Guides and Reference (Next.js based) | http://localhost:3001/docs    |
 
 #### Running sites individually
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

DEVELOPERS.MD - [Local Dev Servers](https://github.com/supabase/supabase/blob/master/DEVELOPERS.md#running-turborepo)

## What is the current behavior?

The docs section links to http://localhost:3001/ but you get a page not found error

## What is the new behavior?

Changed URL to be http://localhost:3001/docs which shows the docs intro screen.

## Additional context

Closes #10711
