### PR TITLE
Fix: Added the supabase developers guide link.

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -35,7 +35,7 @@ We are in the process of migrating this repository to monorepo, using [Turborepo
 
 Eventually, all the apps will be run using [Turborepo](https://turborepo.org/docs), which will significantly improve the developer workflow.
 
-If you are working on the ([docs site](https://supabase.com/docs)), please refer to this [developers guide](https://github.com/supabase/supabase/tree/master/apps/reference/DEVELOPERS.md).
+If you are working on the ([docs site](https://supabase.com/docs)), please refer to this developers guide.(https://supabase.com/docs/guides/cli/local-development).
 
 ### Fork the repository
 


### PR DESCRIPTION
Added supabase developers guide for the local development (https://supabase.com/docs/guides/cli/local-development).

## What kind of change does this PR introduce?

Bug fix, 

## What is the current behavior?

[Issue#10748](https://github.com/supabase/supabase/issues/10748), gives 404 page not found when clicked on the developers guide under the local development section.

## What is the new behavior?

Added the Developers guide [link](https://supabase.com/docs/guides/cli/local-development) from the supabase documentations website, so that reader may get the complete information. 

## Additional context

Add any other context or screenshots.
