### PR TITLE
fix: Clicking the action icon on storage UI, should not trigger the row click event

### DIFF
--- a/studio/components/to-be-cleaned/Storage/StorageExplorer/FileExplorerRow.js
+++ b/studio/components/to-be-cleaned/Storage/StorageExplorer/FileExplorerRow.js
@@ -307,6 +307,10 @@ const FileExplorerRow = ({
           className={`flex items-center justify-end ${
             view === STORAGE_VIEWS.LIST ? 'flex-grow' : 'w-[10%]'
           }`}
+          onClick={(event) =>
+            // Stops click event from this div, to resolve an issue with menu item's click event triggering unexpected row select
+            event.stopPropagation()
+          }
         >
           {item.status === STORAGE_ROW_STATUS.LOADING ? (
             <IconLoader

--- a/studio/localStores/storageExplorer/StorageExplorerStore.js
+++ b/studio/localStores/storageExplorer/StorageExplorerStore.js
@@ -1176,7 +1176,7 @@ class StorageExplorerStore {
     const files = await this.getAllItemsAlongFolder(folder)
     await this.deleteFiles(files, isDeleteFolder)
 
-    const isFolderOpen = this.openedFolders[this.openedFolders.length - 1].name === folder.name
+    const isFolderOpen = this.openedFolders[this.openedFolders.length - 1]?.name === folder.name
     if (isFolderOpen) {
       this.popColumnAtIndex(folder.columnIndex)
       this.popOpenedFoldersAtIndex(folder.columnIndex - 1)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes https://github.com/supabase/supabase/issues/10525

## What is the current behavior?

Clicking the action icon on the storage UI triggers the row-click event

## What is the new behavior?

When any action on the view more icon is clicked, the row-click event (select row event) is not triggered.
It also resolves  a bug that occurs when attempting to delete an un-opened folder.

## Steps to test

Steps to reproduce the behavior, please provide code snippets or a repository:

1. Go to the storage on the dashboard
2. Upload a few items
3. On the action column, click on the 3-dot action icon.
4. Then click on any action: `Copy URL, Rename, ...`
5. Notice that the click does not trigger the row-click event.

## Demo

https://user-images.githubusercontent.com/1501599/206129498-9910d43d-d69e-4d56-8347-b23d645f31a4.mov


