### PR TITLE
docs: auth ui changes

### DIFF
--- a/apps/docs/pages/guides/auth/auth-helpers/auth-ui.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/auth-ui.mdx
@@ -34,7 +34,10 @@ Pass `supabaseClient` from `@supabase/supabase-js` as a prop to the component.
 import { createClient } from '@supabase/supabase-js'
 import { Auth } from '@supabase/auth-ui-react'
 
-const supabase = createClient('<INSERT PROJECT URL>', '<INSERT PROJECT ANON API KEY>')
+const supabase = createClient(
+  '<INSERT PROJECT URL>',
+  '<INSERT PROJECT ANON API KEY>'
+)
 
 const App = () => <Auth supabaseClient={supabase} />
 ```
@@ -43,14 +46,17 @@ This renders the Auth component without any styling.
 We recommend using one of the predefined themes to style the UI.
 Import the theme you want to use and pass it to the `appearence.theme` prop.
 
-```js lines=4,13 title=/src/index.js
+```js lines=4,16 title=/src/index.js
 import {
   Auth,
   // Import predefined theme
   ThemeSupa,
 } from '@supabase/auth-ui-react'
 
-const supabase = createClient('<INSERT PROJECT URL>', '<INSERT PROJECT ANON API KEY>')
+const supabase = createClient(
+  '<INSERT PROJECT URL>',
+  '<INSERT PROJECT ANON API KEY>'
+)
 
 const App = () => (
   <Auth
@@ -65,11 +71,14 @@ const App = () => (
 
 The Auth component also supports login with [offical social providers](../../auth#providers).
 
-```js lines=10 title=/src/index.js
+```js lines=13 title=/src/index.js
 import { createClient } from '@supabase/supabase-js'
 import { Auth, ThemeSupa } from '@supabase/auth-ui-react'
 
-const supabase = createClient('<INSERT PROJECT URL>', '<INSERT PROJECT ANON API KEY>')
+const supabase = createClient(
+  '<INSERT PROJECT URL>',
+  '<INSERT PROJECT ANON API KEY>'
+)
 
 const App = () => (
   <Auth
@@ -95,11 +104,14 @@ There are several ways to customize Auth UI:
 
 Auth UI comes with several themes to customize the appearance. Each predefined theme comes with at least two variations, a `default` variation, and a `dark` variation. You can switch between these themes using the `theme` prop. Import the theme you want to use and pass it to the `appearence.theme` prop.
 
-```js lines=2,10 title=/src/index.js
+```js lines=2,13 title=/src/index.js
 import { createClient } from '@supabase/supabase-js'
 import { Auth, ThemeSupa } from '@supabase/auth-ui-react'
 
-const supabase = createClient('<INSERT PROJECT URL>', '<INSERT PROJECT ANON API KEY>')
+const supabase = createClient(
+  '<INSERT PROJECT URL>',
+  '<INSERT PROJECT ANON API KEY>'
+)
 
 const App = () => (
   <Auth
@@ -120,11 +132,14 @@ Currently there is only one predefined theme available, but we plan to add more.
 
 Auth UI comes with two theme variations: `default` and `dark`. You can switch between these themes with the `theme` prop.
 
-```js lines=11 title=/src/index.js
+```js lines=14 title=/src/index.js
 import { createClient } from '@supabase/supabase-js'
 import { Auth, ThemeSupa } from '@supabase/auth-ui-react'
 
-const supabase = createClient('<INSERT PROJECT URL>', '<INSERT PROJECT ANON API KEY>')
+const supabase = createClient(
+  '<INSERT PROJECT URL>',
+  '<INSERT PROJECT ANON API KEY>'
+)
 
 const App = () => (
   <Auth
@@ -142,11 +157,14 @@ If you don't pass a value to `theme` it uses the `"default"` theme. You can pass
 
 Auth UI themes can be overridden using variable tokens. See the [list of variable tokens](https://github.com/supabase-community/auth-ui/blob/main/packages/react/common/theming/Themes.tsx).
 
-```js lines=11-18 title=/src/index.js
+```js lines=14-21 title=/src/index.js
 import { createClient } from '@supabase/supabase-js'
 import { Auth, ThemeSupa } from '@supabase/auth-ui-react'
 
-const supabase = createClient('<INSERT PROJECT URL>', '<INSERT PROJECT ANON API KEY>')
+const supabase = createClient(
+  '<INSERT PROJECT URL>',
+  '<INSERT PROJECT ANON API KEY>'
+)
 
 const App = () => (
   <Auth
@@ -229,7 +247,10 @@ You can use custom CSS classes for the following elements:
 import { createClient } from '@supabase/supabase-js'
 import { Auth } from '@supabase/auth-ui-react'
 
-const supabase = createClient('<INSERT PROJECT URL>', '<INSERT PROJECT ANON API KEY>')
+const supabase = createClient(
+  '<INSERT PROJECT URL>',
+  '<INSERT PROJECT ANON API KEY>'
+)
 
 const App = () => (
   <Auth
@@ -254,7 +275,10 @@ You can use custom CSS inline styles for the following elements:
 import { createClient } from '@supabase/supabase-js'
 import { Auth } from '@supabase/auth-ui-react'
 
-const supabase = createClient('<INSERT PROJECT URL>', '<INSERT PROJECT ANON API KEY>')
+const supabase = createClient(
+  '<INSERT PROJECT URL>',
+  '<INSERT PROJECT ANON API KEY>'
+)
 
 const App = () => (
   <Auth
@@ -278,7 +302,10 @@ You can use custom labels with `localization.variables`. See the [list of labels
 import { createClient } from '@supabase/supabase-js'
 import { Auth } from '@supabase/auth-ui-react'
 
-const supabase = createClient('<INSERT PROJECT URL>', '<INSERT PROJECT ANON API KEY>')
+const supabase = createClient(
+  '<INSERT PROJECT URL>',
+  '<INSERT PROJECT ANON API KEY>'
+)
 
 const App = () => (
   <Auth

--- a/apps/docs/pages/guides/auth/auth-helpers/auth-ui.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/auth-ui.mdx
@@ -43,12 +43,14 @@ This renders the Auth component without any styling.
 We recommend using one of the predefined themes to style the UI.
 Import the theme you want to use and pass it to the `appearence.theme` prop.
 
-```js lines=4,11 title=/src/index.js
+```js lines=4,13 title=/src/index.js
 import {
   Auth,
   // Import predefined theme
   ThemeSupa,
 } from '@supabase/auth-ui-react'
+
+const supabase = createClient('<INSERT PROJECT URL>', '<INSERT PROJECT ANON API KEY>')
 
 const App = () => (
   <Auth

--- a/apps/docs/pages/guides/auth/auth-helpers/auth-ui.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/auth-ui.mdx
@@ -59,6 +59,25 @@ const App = () => (
 )
 ```
 
+### Social Providers
+
+The Auth component also supports login with [offical social providers](../../auth#providers).
+
+```js lines=10 title=/src/index.js
+import { createClient } from '@supabase/supabase-js'
+import { Auth, ThemeSupa } from '@supabase/auth-ui-react'
+
+const supabase = createClient('<INSERT PROJECT URL>', '<INSERT PROJECT ANON API KEY>')
+
+const App = () => (
+  <Auth
+    supabaseClient={supabase}
+    appearance={{ theme: ThemeSupa }}
+    providers={['google', 'facebook', 'twitter']} 
+  />
+)
+```
+
 ## Customization
 
 There are several ways to customize Auth UI:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs - [Auth UI](https://supabase.com/docs/guides/auth/auth-helpers/auth-ui)

## What is the current behavior?

This issue is currently highlighted [here](https://github.com/supabase/auth-ui/issues/80) in the auth-ui repository, Their does not seem to be any documentation on social providers for the auth ui component.

## What is the new behavior?

A new section named `Social Providers` has been added:

<img width="685" alt="Screenshot 2022-12-07 at 14 59 47" src="https://user-images.githubusercontent.com/22655069/206213583-751091d3-16ed-4593-b49e-19d4bd0405b9.png">

I've also done the following:

- Added a missing `supabase` variable in an example.
- Changed the format of `supabase` variable in the examples.
