### PR TITLE
Fixed TS17004 and fixed TS2686

### DIFF
--- a/examples/user-management/expo-user-management/App.tsx
+++ b/examples/user-management/expo-user-management/App.tsx
@@ -5,6 +5,7 @@ import Auth from './components/Auth'
 import Account from './components/Account'
 import { View } from 'react-native'
 import { Session } from '@supabase/supabase-js'
+import React = require('react')
 
 export default function App() {
   const [session, setSession] = useState<Session | null>(null)

--- a/examples/user-management/expo-user-management/components/Account.tsx
+++ b/examples/user-management/expo-user-management/components/Account.tsx
@@ -4,6 +4,7 @@ import { StyleSheet, View, Alert } from 'react-native'
 import { Button, Input } from 'react-native-elements'
 import { Session } from '@supabase/supabase-js'
 import Avatar from './Avatar'
+import React = require('react')
 
 export default function Account({ session }: { session: Session }) {
   const [loading, setLoading] = useState(true)

--- a/examples/user-management/expo-user-management/components/Avatar.tsx
+++ b/examples/user-management/expo-user-management/components/Avatar.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import { supabase } from '../lib/supabase'
 import { StyleSheet, View, Alert, Image, Button } from 'react-native'
 import DocumentPicker, { isCancel, isInProgress, types } from 'react-native-document-picker'
+import React = require('react')
 
 interface Props {
   size: number

--- a/examples/user-management/expo-user-management/tsconfig.json
+++ b/examples/user-management/expo-user-management/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
+    "jsx": "react",
     "strict": true
   }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

fixed ts17004 by specifying type of jsx code to tsconfig 
fixed ts2686 by importing react to our module

## What is the current behavior?

TypeScript gives you an error when writing tsx on a module without requiring react
TypeScript gives you an error when you haven't specified jsx code on compiler options

## What is the new behavior?
fixed ts17004
fixed ts2686

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
