### PR TITLE
Fix/billing subscription page

### DIFF
--- a/studio/components/interfaces/Billing/AddOns/AddOns.types.ts
+++ b/studio/components/interfaces/Billing/AddOns/AddOns.types.ts
@@ -8,6 +8,8 @@ export interface DatabaseAddon {
     default_price_id?: string
     supabase_prod_id: string
   }
+  // UI specific, do not allow changes if add on has a $0 price to it
+  isLocked?: boolean
 }
 
 export interface AddonPrice {

--- a/studio/components/interfaces/Billing/AddOns/AddOns.types.ts
+++ b/studio/components/interfaces/Billing/AddOns/AddOns.types.ts
@@ -1,4 +1,4 @@
-export interface DatabaseAddon {
+export interface SubscriptionAddon {
   id?: string
   name: string
   description?: string | null

--- a/studio/components/interfaces/Billing/AddOns/AddOns.utils.ts
+++ b/studio/components/interfaces/Billing/AddOns/AddOns.utils.ts
@@ -1,4 +1,4 @@
-import { DatabaseAddon } from './AddOns.types'
+import { SubscriptionAddon } from './AddOns.types'
 
 export const getSemanticVersion = (version: string) => {
   if (!version) return 0
@@ -14,7 +14,7 @@ export const getSemanticVersion = (version: string) => {
   return Number(formattedSemver.split('.').join(''))
 }
 
-export const formatComputeSizes = (addons: DatabaseAddon[]) => {
+export const formatComputeSizes = (addons: SubscriptionAddon[]) => {
   const addonsOrder = [
     'addon_instance_small',
     'addon_instance_medium',
@@ -27,7 +27,7 @@ export const formatComputeSizes = (addons: DatabaseAddon[]) => {
     'addon_instance_16xlarge',
   ]
 
-  const microOption: DatabaseAddon = {
+  const microOption: SubscriptionAddon = {
     id: undefined,
     name: 'Micro Add-on',
     metadata: {
@@ -55,15 +55,15 @@ export const formatComputeSizes = (addons: DatabaseAddon[]) => {
     .concat(
       addonsOrder.map((id: string) => {
         return addons.find((option) => option.metadata.supabase_prod_id === id)
-      }) as DatabaseAddon[]
+      }) as SubscriptionAddon[]
     )
     .filter((option) => option !== undefined)
 }
 
-export const formatPITROptions = (addons: DatabaseAddon[]) => {
+export const formatPITROptions = (addons: SubscriptionAddon[]) => {
   const pitrOrder = ['addon_pitr_7days', 'addon_pitr_14days', 'addon_pitr_28days']
 
-  const noPITROption: DatabaseAddon = {
+  const noPITROption: SubscriptionAddon = {
     id: undefined,
     name: 'Disable PITR',
     metadata: {
@@ -91,15 +91,15 @@ export const formatPITROptions = (addons: DatabaseAddon[]) => {
     .map((id: string) => {
       return addons.find((option) => option.metadata.supabase_prod_id === id)
     })
-    .filter((option) => option !== undefined) as DatabaseAddon[]
+    .filter((option) => option !== undefined) as SubscriptionAddon[]
 
   if (pitrOptions.length === 0) return []
   else return [noPITROption].concat(pitrOptions)
 }
 
-export const formatCustomDomainOptions = (addons: DatabaseAddon[]) => {
+export const formatCustomDomainOptions = (addons: SubscriptionAddon[]) => {
   const customDomainOrder = ['addon_custom_domains']
-  const noCustomDomainOption: DatabaseAddon = {
+  const noCustomDomainOption: SubscriptionAddon = {
     id: undefined,
     name: 'Disable Custom Domains',
     metadata: {
@@ -127,7 +127,7 @@ export const formatCustomDomainOptions = (addons: DatabaseAddon[]) => {
     .map((id: string) => {
       return addons.find((option) => option.metadata.supabase_prod_id === id)
     })
-    .filter((option) => option !== undefined) as DatabaseAddon[]
+    .filter((option) => option !== undefined) as SubscriptionAddon[]
 
   if (customDomainOptions.length === 0) return []
   else return [noCustomDomainOption].concat(customDomainOptions)

--- a/studio/components/interfaces/Billing/AddOns/ComputeSizeSelection.tsx
+++ b/studio/components/interfaces/Billing/AddOns/ComputeSizeSelection.tsx
@@ -75,7 +75,9 @@ const ComputeSizeSelection: FC<Props> = ({
             label="Need a larger add on?"
             description="Reach out to us - we've got you covered!"
             optionalLabel={
-              <Link href={`/support/new?ref=${projectRef}&category=sales`}>
+              <Link
+                href={`/support/new?ref=${projectRef}&category=sales&subject=Enquiry%20for%20larger%20compute%20size`}
+              >
                 <a>
                   <Button>Contact us</Button>
                 </a>

--- a/studio/components/interfaces/Billing/AddOns/ComputeSizeSelection.tsx
+++ b/studio/components/interfaces/Billing/AddOns/ComputeSizeSelection.tsx
@@ -45,7 +45,7 @@ const ComputeSizeSelection: FC<Props> = ({
         >
           <div className="space-y-3">
             <h5 className="text-sm text-scale-1200">
-              Your project currently has the {currentComputeSize.name}
+              Your project currently has the {currentComputeSize.name} included
             </h5>
             <p className="text-sm text-scale-1100">
               If you would like to change your compute size, do reach out to us

--- a/studio/components/interfaces/Billing/AddOns/ComputeSizeSelection.tsx
+++ b/studio/components/interfaces/Billing/AddOns/ComputeSizeSelection.tsx
@@ -5,12 +5,12 @@ import { Badge, Button, Radio } from 'ui'
 import { useFlag, useParams } from 'hooks'
 import { getProductPrice } from '../Billing.utils'
 import DisabledWarningDueToIncident from 'components/ui/DisabledWarningDueToIncident'
-import { DatabaseAddon } from './AddOns.types'
+import { SubscriptionAddon } from './AddOns.types'
 
 interface Props {
-  computeSizes: DatabaseAddon[]
-  currentComputeSize?: DatabaseAddon
-  selectedComputeSize: DatabaseAddon
+  computeSizes: SubscriptionAddon[]
+  currentComputeSize?: SubscriptionAddon
+  selectedComputeSize: SubscriptionAddon
   onSelectOption: (option: any) => void
 }
 

--- a/studio/components/interfaces/Billing/AddOns/ComputeSizeSelection.tsx
+++ b/studio/components/interfaces/Billing/AddOns/ComputeSizeSelection.tsx
@@ -2,14 +2,15 @@ import { FC } from 'react'
 import Link from 'next/link'
 import { Badge, Button, Radio } from 'ui'
 
-import { useStore, useFlag } from 'hooks'
+import { useFlag, useParams } from 'hooks'
 import { getProductPrice } from '../Billing.utils'
 import DisabledWarningDueToIncident from 'components/ui/DisabledWarningDueToIncident'
+import { DatabaseAddon } from './AddOns.types'
 
 interface Props {
-  computeSizes: any[]
-  currentComputeSize?: any
-  selectedComputeSize: any
+  computeSizes: DatabaseAddon[]
+  currentComputeSize?: DatabaseAddon
+  selectedComputeSize: DatabaseAddon
   onSelectOption: (option: any) => void
 }
 
@@ -19,8 +20,7 @@ const ComputeSizeSelection: FC<Props> = ({
   selectedComputeSize,
   onSelectOption,
 }) => {
-  const { ui } = useStore()
-  const projectRef = ui.selectedProjectRef
+  const { ref } = useParams()
   const addonUpdateDisabled = useFlag('disableProjectCreationAndUpdate')
 
   return (
@@ -36,6 +36,31 @@ const ComputeSizeSelection: FC<Props> = ({
       </div>
       {addonUpdateDisabled ? (
         <DisabledWarningDueToIncident title="Updating database add-ons is currently disabled" />
+      ) : currentComputeSize?.isLocked ? (
+        <div
+          className={[
+            'flex items-center justify-between block w-full rounded px-4 py-3',
+            'border border-scale-600 bg-scale-100 dark:border-scale-500 dark:bg-scale-400',
+          ].join(' ')}
+        >
+          <div className="space-y-3">
+            <h5 className="text-sm text-scale-1200">
+              Your project currently has the {currentComputeSize.name}
+            </h5>
+            <p className="text-sm text-scale-1100">
+              If you would like to change your compute size, do reach out to us
+            </p>
+          </div>
+          <div className="">
+            <Link
+              href={`/support/new?ref=${ref}&category=sales&subject=Disable%20custom%20domains%20`}
+            >
+              <a>
+                <Button>Contact us</Button>
+              </a>
+            </Link>
+          </div>
+        </div>
       ) : (
         <Radio.Group type="cards" className="billing-compute-radio">
           {computeSizes.map((option: any) => {
@@ -76,7 +101,7 @@ const ComputeSizeSelection: FC<Props> = ({
             description="Reach out to us - we've got you covered!"
             optionalLabel={
               <Link
-                href={`/support/new?ref=${projectRef}&category=sales&subject=Enquiry%20for%20larger%20compute%20size`}
+                href={`/support/new?ref=${ref}&category=sales&subject=Enquiry%20for%20larger%20compute%20size`}
               >
                 <a>
                   <Button>Contact us</Button>

--- a/studio/components/interfaces/Billing/AddOns/CustomDomainSelection.tsx
+++ b/studio/components/interfaces/Billing/AddOns/CustomDomainSelection.tsx
@@ -43,7 +43,7 @@ const CustomDomainSelection: FC<Props> = ({
         >
           <div className="space-y-3">
             <h5 className="text-sm text-scale-1200">
-              Your project currently has custom domains enabled
+              Your project currently has custom domains included
             </h5>
             <p className="text-sm text-scale-1100">
               If you would like to disable custom domains, do reach out to us

--- a/studio/components/interfaces/Billing/AddOns/CustomDomainSelection.tsx
+++ b/studio/components/interfaces/Billing/AddOns/CustomDomainSelection.tsx
@@ -1,14 +1,16 @@
+import Link from 'next/link'
 import { FC } from 'react'
-import { Badge, Radio } from 'ui'
+import { Badge, Button, Radio } from 'ui'
 
-import { useStore, useFlag } from 'hooks'
+import { useFlag, useParams } from 'hooks'
 import { getProductPrice } from '../Billing.utils'
 import DisabledWarningDueToIncident from 'components/ui/DisabledWarningDueToIncident'
+import { DatabaseAddon } from './AddOns.types'
 
 interface Props {
-  options: any[]
-  currentOption?: any
-  selectedOption: any
+  options: DatabaseAddon[]
+  currentOption?: DatabaseAddon
+  selectedOption: DatabaseAddon
   onSelectOption: (option: any) => void
 }
 
@@ -18,7 +20,9 @@ const CustomDomainSelection: FC<Props> = ({
   selectedOption,
   onSelectOption,
 }) => {
+  const { ref } = useParams()
   const addonUpdateDisabled = useFlag('disableProjectCreationAndUpdate')
+
   return (
     <div className="space-y-4">
       <div>
@@ -30,6 +34,31 @@ const CustomDomainSelection: FC<Props> = ({
       </div>
       {addonUpdateDisabled ? (
         <DisabledWarningDueToIncident title="Updating database add-ons is currently disabled" />
+      ) : currentOption?.isLocked ? (
+        <div
+          className={[
+            'flex items-center justify-between block w-full rounded px-4 py-3',
+            'border border-scale-600 bg-scale-100 dark:border-scale-500 dark:bg-scale-400',
+          ].join(' ')}
+        >
+          <div className="space-y-3">
+            <h5 className="text-sm text-scale-1200">
+              Your project currently has custom domains enabled
+            </h5>
+            <p className="text-sm text-scale-1100">
+              If you would like to disable custom domains, do reach out to us
+            </p>
+          </div>
+          <div className="">
+            <Link
+              href={`/support/new?ref=${ref}&category=sales&subject=Disable%20custom%20domains%20`}
+            >
+              <a>
+                <Button>Contact us</Button>
+              </a>
+            </Link>
+          </div>
+        </div>
       ) : (
         <Radio.Group type="cards" className="billing-compute-radio">
           {options.map((option: any) => {

--- a/studio/components/interfaces/Billing/AddOns/CustomDomainSelection.tsx
+++ b/studio/components/interfaces/Billing/AddOns/CustomDomainSelection.tsx
@@ -5,12 +5,12 @@ import { Badge, Button, Radio } from 'ui'
 import { useFlag, useParams } from 'hooks'
 import { getProductPrice } from '../Billing.utils'
 import DisabledWarningDueToIncident from 'components/ui/DisabledWarningDueToIncident'
-import { DatabaseAddon } from './AddOns.types'
+import { SubscriptionAddon } from './AddOns.types'
 
 interface Props {
-  options: DatabaseAddon[]
-  currentOption?: DatabaseAddon
-  selectedOption: DatabaseAddon
+  options: SubscriptionAddon[]
+  currentOption?: SubscriptionAddon
+  selectedOption: SubscriptionAddon
   onSelectOption: (option: any) => void
 }
 

--- a/studio/components/interfaces/Billing/AddOns/PITRDurationSelection.tsx
+++ b/studio/components/interfaces/Billing/AddOns/PITRDurationSelection.tsx
@@ -81,7 +81,7 @@ const PITRDurationSelection: FC<Props> = ({
         >
           <div className="space-y-3">
             <h5 className="text-sm text-scale-1200">
-              Your project currently has {currentPitrDuration.name}
+              Your project currently has {currentPitrDuration.name} included
             </h5>
             <p className="text-sm text-scale-1100">
               If you would like to change your PITR duration, do reach out to us

--- a/studio/components/interfaces/Billing/AddOns/PITRDurationSelection.tsx
+++ b/studio/components/interfaces/Billing/AddOns/PITRDurationSelection.tsx
@@ -41,7 +41,7 @@ const PITRDurationSelection: FC<Props> = ({
         <p className="text-sm text-scale-1100">
           Restore your database from a specific point in time
         </p>
-        {canUsePITR && (
+        {canUsePITR && !currentPitrDuration?.isLocked && (
           <div className="mt-2">
             <InformationBox
               icon={<IconAlertCircle strokeWidth={2} />}
@@ -72,6 +72,29 @@ const PITRDurationSelection: FC<Props> = ({
           }
           icon={<IconAlertCircle strokeWidth={2} />}
         />
+      ) : currentPitrDuration?.isLocked ? (
+        <div
+          className={[
+            'flex items-center justify-between block w-full rounded px-4 py-3',
+            'border border-scale-600 bg-scale-100 dark:border-scale-500 dark:bg-scale-400',
+          ].join(' ')}
+        >
+          <div className="space-y-3">
+            <h5 className="text-sm text-scale-1200">
+              Your project currently has {currentPitrDuration.name}
+            </h5>
+            <p className="text-sm text-scale-1100">
+              If you would like to change your PITR duration, do reach out to us
+            </p>
+          </div>
+          <div className="">
+            <Link href={`/support/new?ref=${ref}&category=sales&subject=Change%20PITR%20duration`}>
+              <a>
+                <Button>Contact us</Button>
+              </a>
+            </Link>
+          </div>
+        </div>
       ) : (
         <Radio.Group type="cards" className="billing-compute-radio">
           {pitrDurationOptions.map((option: any) => {

--- a/studio/components/interfaces/Billing/AddOns/PITRDurationSelection.tsx
+++ b/studio/components/interfaces/Billing/AddOns/PITRDurationSelection.tsx
@@ -3,7 +3,7 @@ import { useRouter } from 'next/router'
 import { Badge, IconAlertCircle, Radio, Button } from 'ui'
 
 import { useFlag, useStore } from 'hooks'
-import { DatabaseAddon } from './AddOns.types'
+import { SubscriptionAddon } from './AddOns.types'
 import { getProductPrice } from '../Billing.utils'
 import DisabledWarningDueToIncident from 'components/ui/DisabledWarningDueToIncident'
 import InformationBox from 'components/ui/InformationBox'
@@ -11,9 +11,9 @@ import { getSemanticVersion } from './AddOns.utils'
 import Link from 'next/link'
 
 interface Props {
-  pitrDurationOptions: DatabaseAddon[]
-  currentPitrDuration?: DatabaseAddon
-  selectedPitrDuration?: DatabaseAddon
+  pitrDurationOptions: SubscriptionAddon[]
+  currentPitrDuration?: SubscriptionAddon
+  selectedPitrDuration?: SubscriptionAddon
   onSelectOption: (option: any) => void
 }
 

--- a/studio/components/interfaces/Billing/AddOns/SupportPlan.tsx
+++ b/studio/components/interfaces/Billing/AddOns/SupportPlan.tsx
@@ -1,0 +1,48 @@
+import { FC } from 'react'
+import Link from 'next/link'
+import { Button } from 'ui'
+import { useParams } from 'hooks'
+
+interface Props {
+  currentOption?: any
+}
+
+const SupportPlan: FC<Props> = ({ currentOption }) => {
+  const { ref } = useParams()
+  return (
+    <div className="space-y-4">
+      <div>
+        <div className="flex items-center space-x-2">
+          <h4 className="text-lg">Support Plan</h4>
+        </div>
+        <p className="text-sm text-scale-1100">Designated support with guaranteed response times</p>
+      </div>
+      {currentOption !== undefined && (
+        <div
+          className={[
+            'flex items-center justify-between block w-full rounded px-4 py-3',
+            'border border-scale-600 bg-scale-100 dark:border-scale-500 dark:bg-scale-400',
+          ].join(' ')}
+        >
+          <div className="space-y-3">
+            <h5 className="text-sm text-scale-1200">
+              Your project is currently on {currentOption.name}
+            </h5>
+            <p className="text-sm text-scale-1100">
+              If you would like to change your support plan, do reach out to us
+            </p>
+          </div>
+          <div className="">
+            <Link href={`/support/new?ref=${ref}&category=sales&subject=Change%20support%20plan`}>
+              <a>
+                <Button>Contact us</Button>
+              </a>
+            </Link>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default SupportPlan

--- a/studio/components/interfaces/Billing/AddOns/SupportPlan.tsx
+++ b/studio/components/interfaces/Billing/AddOns/SupportPlan.tsx
@@ -17,30 +17,28 @@ const SupportPlan: FC<Props> = ({ currentOption }) => {
         </div>
         <p className="text-sm text-scale-1100">Designated support with guaranteed response times</p>
       </div>
-      {currentOption !== undefined && (
-        <div
-          className={[
-            'flex items-center justify-between block w-full rounded px-4 py-3',
-            'border border-scale-600 bg-scale-100 dark:border-scale-500 dark:bg-scale-400',
-          ].join(' ')}
-        >
-          <div className="space-y-3">
-            <h5 className="text-sm text-scale-1200">
-              Your project is currently on {currentOption.name}
-            </h5>
-            <p className="text-sm text-scale-1100">
-              If you would like to change your support plan, do reach out to us
-            </p>
-          </div>
-          <div className="">
-            <Link href={`/support/new?ref=${ref}&category=sales&subject=Change%20support%20plan`}>
-              <a>
-                <Button>Contact us</Button>
-              </a>
-            </Link>
-          </div>
+      <div
+        className={[
+          'flex items-center justify-between block w-full rounded px-4 py-3',
+          'border border-scale-600 bg-scale-100 dark:border-scale-500 dark:bg-scale-400',
+        ].join(' ')}
+      >
+        <div className="space-y-3">
+          <h5 className="text-sm text-scale-1200">
+            Your project is currently on {currentOption.name}
+          </h5>
+          <p className="text-sm text-scale-1100">
+            If you would like to change your support plan, do reach out to us
+          </p>
         </div>
-      )}
+        <div className="">
+          <Link href={`/support/new?ref=${ref}&category=sales&subject=Change%20support%20plan`}>
+            <a>
+              <Button>Contact us</Button>
+            </a>
+          </Link>
+        </div>
+      </div>
     </div>
   )
 }

--- a/studio/components/interfaces/Billing/Billing.utils.ts
+++ b/studio/components/interfaces/Billing/Billing.utils.ts
@@ -1,5 +1,4 @@
-import { add } from 'lodash'
-import { DatabaseAddon } from './AddOns/AddOns.types'
+import { SubscriptionAddon } from './AddOns/AddOns.types'
 import {
   formatComputeSizes,
   formatCustomDomainOptions,
@@ -30,9 +29,9 @@ const getProductPriceId = (
 }
 
 export const validateSubscriptionUpdatePayload = (selectedAddons: {
-  computeSize: DatabaseAddon
-  pitrDuration: DatabaseAddon
-  customDomains: DatabaseAddon
+  computeSize: SubscriptionAddon
+  pitrDuration: SubscriptionAddon
+  customDomains: SubscriptionAddon
 }) => {
   if (
     selectedAddons.pitrDuration?.id !== undefined &&
@@ -47,11 +46,11 @@ export const formSubscriptionUpdatePayload = (
   currentSubscription: StripeSubscription,
   selectedTier: any,
   selectedAddons: {
-    computeSize: DatabaseAddon
-    pitrDuration: DatabaseAddon
-    customDomains: DatabaseAddon
+    computeSize: SubscriptionAddon
+    pitrDuration: SubscriptionAddon
+    customDomains: SubscriptionAddon
   },
-  nonChangeableAddons: DatabaseAddon[],
+  nonChangeableAddons: SubscriptionAddon[],
   selectedPaymentMethod: string,
   region: string
 ) => {
@@ -84,10 +83,10 @@ export const formSubscriptionUpdatePayload = (
 
 const findAddon = (
   subscription: StripeSubscription,
-  addons: DatabaseAddon[],
+  addons: SubscriptionAddon[],
   key: string,
   defaultKey: string
-): DatabaseAddon => {
+): SubscriptionAddon => {
   const product = addons.find((option) => {
     const subscriptionAddon = subscription.addons.find((addon) =>
       addon.supabase_prod_id.includes(key)
@@ -95,7 +94,9 @@ const findAddon = (
     return option.id === subscriptionAddon?.prod_id
   })
   if (product === undefined) {
-    return addons.find((addon) => addon.metadata.supabase_prod_id === defaultKey) as DatabaseAddon
+    return addons.find(
+      (addon) => addon.metadata.supabase_prod_id === defaultKey
+    ) as SubscriptionAddon
   } else {
     const subscriptionAddon = subscription.addons.find((addon) => addon.prod_id === product.id)
     return { ...product, isLocked: subscriptionAddon?.unit_amount === 0 }
@@ -104,12 +105,12 @@ const findAddon = (
 
 export const getCurrentAddons = (
   currentSubscription: StripeSubscription,
-  addons: DatabaseAddon[]
+  addons: SubscriptionAddon[]
 ): {
-  computeSize: DatabaseAddon
-  pitrDuration: DatabaseAddon
-  customDomains: DatabaseAddon
-  supportPlan?: DatabaseAddon
+  computeSize: SubscriptionAddon
+  pitrDuration: SubscriptionAddon
+  customDomains: SubscriptionAddon
+  supportPlan?: SubscriptionAddon
 } => {
   const computeSizes = formatComputeSizes(addons)
   const pitrDurationOptions = formatPITROptions(addons)

--- a/studio/components/interfaces/Billing/Billing.utils.ts
+++ b/studio/components/interfaces/Billing/Billing.utils.ts
@@ -46,9 +46,12 @@ export const formSubscriptionUpdatePayload = (
     region === 'af-south-1'
       ? []
       : [
-          computeSize.prices[0].id,
-          pitrDuration?.prices?.[0].id,
-          customDomains?.prices?.[0].id,
+          computeSize.prices.find((price) => price.id === computeSize.metadata.default_price_id)
+            ?.id,
+          pitrDuration.prices.find((price) => price.id === pitrDuration.metadata.default_price_id)
+            ?.id,
+          customDomains.prices.find((price) => price.id === customDomains.metadata.default_price_id)
+            ?.id,
         ].filter((x) => x !== undefined)
   const proration_date = Math.floor(Date.now() / 1000)
   return {

--- a/studio/components/interfaces/Billing/Billing.utils.ts
+++ b/studio/components/interfaces/Billing/Billing.utils.ts
@@ -61,10 +61,17 @@ export const formSubscriptionUpdatePayload = (
 export const getCurrentAddons = (
   currentSubscription: StripeSubscription,
   addons: DatabaseAddon[]
-) => {
+): {
+  computeSize: DatabaseAddon
+  pitrDuration: DatabaseAddon
+  customDomains: DatabaseAddon
+  supportPlan?: DatabaseAddon
+} => {
   const computeSizes = formatComputeSizes(addons)
   const pitrDurationOptions = formatPITROptions(addons)
   const customDomainOptions = formatCustomDomainOptions(addons)
+
+  console.log({ currentSubscription })
 
   const computeSize =
     computeSizes.find((option: any) => {
@@ -79,10 +86,10 @@ export const getCurrentAddons = (
 
   const pitrDuration =
     pitrDurationOptions.find((option: any) => {
-      const subscriptionComputeSize = currentSubscription?.addons.find((addon) =>
+      const subscriptionPitrDuration = currentSubscription?.addons.find((addon) =>
         addon.supabase_prod_id.includes('_pitr_')
       )
-      return option.id === subscriptionComputeSize?.prod_id
+      return option.id === subscriptionPitrDuration?.prod_id
     }) ||
     (pitrDurationOptions.find(
       (option: any) => option.metadata.supabase_prod_id === 'addon_pitr_0days'
@@ -90,14 +97,21 @@ export const getCurrentAddons = (
 
   const customDomains =
     customDomainOptions.find((option: any) => {
-      const subscriptionComputeSize = currentSubscription?.addons.find((addon) =>
+      const subscriptionCustomDomain = currentSubscription?.addons.find((addon) =>
         addon.supabase_prod_id.includes('_custom_domains')
       )
-      return option.id === subscriptionComputeSize?.prod_id
+      return option.id === subscriptionCustomDomain?.prod_id
     }) ||
     (customDomainOptions.find(
-      (option: any) => option.metadata.supabase_prod_id === 'addon__custom_domains_disabled'
+      (option: any) => option.metadata.supabase_prod_id === 'addon_custom_domains_disabled'
     ) as DatabaseAddon)
 
-  return { computeSize, pitrDuration, customDomains }
+  const supportPlan = addons.find((option: any) => {
+    const subscriptionSupportPlan = currentSubscription?.addons.find((addon) =>
+      addon.supabase_prod_id.includes('_support_')
+    )
+    return option.id === subscriptionSupportPlan?.prod_id
+  })
+
+  return { computeSize, pitrDuration, customDomains, supportPlan }
 }

--- a/studio/components/interfaces/Billing/EnterpriseUpdate.tsx
+++ b/studio/components/interfaces/Billing/EnterpriseUpdate.tsx
@@ -25,6 +25,7 @@ import {
 } from './'
 import { PaymentMethod, SubscriptionPreview } from './Billing.types'
 import { formSubscriptionUpdatePayload, getCurrentAddons } from './Billing.utils'
+import SupportPlan from './AddOns/SupportPlan'
 
 interface Props {
   products: { tiers: any[]; addons: DatabaseAddon[] }
@@ -53,6 +54,8 @@ const EnterpriseUpdate: FC<Props> = ({
   const pitrDurationOptions = formatPITROptions(addons)
   const customDomainOptions = formatCustomDomainOptions(addons)
   const currentAddons = getCurrentAddons(currentSubscription, addons)
+
+  console.log({ currentAddons })
 
   // [Joshen TODO] Ideally we just have a state to hold all the add ons selection, rather than individual
   // Even better if we can just use the <Form> component to handle all of these. Mainly to reduce the amount
@@ -199,6 +202,12 @@ const EnterpriseUpdate: FC<Props> = ({
                 </div>
                 {projectRegion !== 'af-south-1' && (
                   <>
+                    {currentAddons.supportPlan !== undefined && (
+                      <>
+                        <Divider light />
+                        <SupportPlan currentOption={currentAddons.supportPlan} />
+                      </>
+                    )}
                     {isCustomDomainsEnabled && customDomainOptions.length > 0 && (
                       <>
                         <Divider light />

--- a/studio/components/interfaces/Billing/EnterpriseUpdate.tsx
+++ b/studio/components/interfaces/Billing/EnterpriseUpdate.tsx
@@ -8,7 +8,7 @@ import { post, patch } from 'lib/common/fetch'
 import { API_URL, PROJECT_STATUS } from 'lib/constants'
 
 import Divider from 'components/ui/Divider'
-import { DatabaseAddon } from './AddOns/AddOns.types'
+import { SubscriptionAddon } from './AddOns/AddOns.types'
 import {
   formatComputeSizes,
   formatCustomDomainOptions,
@@ -28,7 +28,7 @@ import { formSubscriptionUpdatePayload, getCurrentAddons } from './Billing.utils
 import SupportPlan from './AddOns/SupportPlan'
 
 interface Props {
-  products: { tiers: any[]; addons: DatabaseAddon[] }
+  products: { tiers: any[]; addons: SubscriptionAddon[] }
   paymentMethods?: PaymentMethod[]
   currentSubscription: StripeSubscription
   isLoadingPaymentMethods: boolean
@@ -58,20 +58,20 @@ const EnterpriseUpdate: FC<Props> = ({
   // [Joshen TODO] Ideally we just have a state to hold all the add ons selection, rather than individual
   // Even better if we can just use the <Form> component to handle all of these. Mainly to reduce the amount
   // of unnecessary state management on this complex page.
-  const [selectedComputeSize, setSelectedComputeSize] = useState<DatabaseAddon>(
+  const [selectedComputeSize, setSelectedComputeSize] = useState<SubscriptionAddon>(
     currentAddons.computeSize
   )
-  const [selectedPITRDuration, setSelectedPITRDuration] = useState<DatabaseAddon>(
+  const [selectedPITRDuration, setSelectedPITRDuration] = useState<SubscriptionAddon>(
     currentAddons.pitrDuration
   )
-  const [selectedCustomDomainOption, setSelectedCustomDomainOption] = useState<DatabaseAddon>(
+  const [selectedCustomDomainOption, setSelectedCustomDomainOption] = useState<SubscriptionAddon>(
     currentAddons.customDomains
   )
   // [Joshen TODO] Future - We may need to also include any add ons outside of
   // compute size, pitr, custom domain and support plan, although we dont have any now
   const nonChangeableAddons = [currentAddons.supportPlan].filter(
     (x) => x !== undefined
-  ) as DatabaseAddon[]
+  ) as SubscriptionAddon[]
 
   // [Joshen] Scaffolded here
   const selectedAddons = {

--- a/studio/components/interfaces/Billing/EnterpriseUpdate.tsx
+++ b/studio/components/interfaces/Billing/EnterpriseUpdate.tsx
@@ -67,6 +67,11 @@ const EnterpriseUpdate: FC<Props> = ({
   const [selectedCustomDomainOption, setSelectedCustomDomainOption] = useState<DatabaseAddon>(
     currentAddons.customDomains
   )
+  // [Joshen TODO] Future - We may need to also include any add ons outside of
+  // compute size, pitr, custom domain and support plan, although we dont have any now
+  const nonChangeableAddons = [currentAddons.supportPlan].filter(
+    (x) => x !== undefined
+  ) as DatabaseAddon[]
 
   // [Joshen] Scaffolded here
   const selectedAddons = {
@@ -87,7 +92,7 @@ const EnterpriseUpdate: FC<Props> = ({
 
   useEffect(() => {
     getSubscriptionPreview()
-  }, [selectedComputeSize, selectedPITRDuration])
+  }, [selectedComputeSize, selectedPITRDuration, selectedCustomDomainOption])
 
   useEffect(() => {
     if (!isLoadingPaymentMethods && paymentMethods && paymentMethods.length > 0) {
@@ -100,8 +105,10 @@ const EnterpriseUpdate: FC<Props> = ({
     // Only allow add-ons changing
     const payload = {
       ...formSubscriptionUpdatePayload(
+        currentSubscription,
         null,
         selectedAddons,
+        nonChangeableAddons,
         selectedPaymentMethodId,
         projectRegion
       ),
@@ -124,8 +131,10 @@ const EnterpriseUpdate: FC<Props> = ({
   const onConfirmPayment = async () => {
     const payload = {
       ...formSubscriptionUpdatePayload(
+        currentSubscription,
         null,
         selectedAddons,
+        nonChangeableAddons,
         selectedPaymentMethodId,
         projectRegion
       ),

--- a/studio/components/interfaces/Billing/EnterpriseUpdate.tsx
+++ b/studio/components/interfaces/Billing/EnterpriseUpdate.tsx
@@ -55,8 +55,6 @@ const EnterpriseUpdate: FC<Props> = ({
   const customDomainOptions = formatCustomDomainOptions(addons)
   const currentAddons = getCurrentAddons(currentSubscription, addons)
 
-  console.log({ currentAddons })
-
   // [Joshen TODO] Ideally we just have a state to hold all the add ons selection, rather than individual
   // Even better if we can just use the <Form> component to handle all of these. Mainly to reduce the amount
   // of unnecessary state management on this complex page.
@@ -248,6 +246,7 @@ const EnterpriseUpdate: FC<Props> = ({
             isSpendCapEnabled={true}
             isSubmitting={isSubmitting}
             isRefreshingPreview={isRefreshingPreview}
+            currentSubscription={currentSubscription}
             subscriptionPreview={subscriptionPreview}
             // Current subscription configuration based on DB
             currentPlan={currentSubscription.tier}

--- a/studio/components/interfaces/Billing/PaymentSummaryPanel/PaymentSummaryPanel.tsx
+++ b/studio/components/interfaces/Billing/PaymentSummaryPanel/PaymentSummaryPanel.tsx
@@ -111,6 +111,15 @@ const PaymentSummaryPanel: FC<Props> = ({
     } else return plan.name
   }
 
+  const getAddonPriceFromSubscription = (
+    key: 'computeSize' | 'pitrDuration' | 'customDomains' | 'supportPlan'
+  ) => {
+    return (
+      ((currentSubscription?.addons ?? []).find((addon) => addon.prod_id === currentAddons[key]?.id)
+        ?.unit_amount ?? 0) / 100
+    ).toFixed(2)
+  }
+
   const validateOrder = () => {
     const error = validateSubscriptionUpdatePayload(selectedAddons)
     if (error) {
@@ -170,12 +179,7 @@ const PaymentSummaryPanel: FC<Props> = ({
               <p
                 className={`${isChangingComputeSize ? 'text-scale-1100 line-through' : ''} text-sm`}
               >
-                $
-                {(
-                  ((currentSubscription?.addons ?? []).find(
-                    (addon) => addon.prod_id === currentAddons.computeSize.id
-                  )?.unit_amount ?? 0) / 100
-                ).toFixed(2)}
+                ${getAddonPriceFromSubscription('computeSize')}
               </p>
             </div>
             {isChangingComputeSize && (
@@ -202,12 +206,7 @@ const PaymentSummaryPanel: FC<Props> = ({
                     isChangingPITRDuration ? 'text-scale-1100 line-through' : ''
                   } text-sm`}
                 >
-                  $
-                  {(
-                    ((currentSubscription?.addons ?? []).find(
-                      (addon) => addon.prod_id === currentAddons.pitrDuration.id
-                    )?.unit_amount ?? 0) / 100
-                  ).toFixed(2)}
+                  ${getAddonPriceFromSubscription('pitrDuration')}
                 </p>
               </div>
             )}
@@ -235,12 +234,7 @@ const PaymentSummaryPanel: FC<Props> = ({
                     isChangingCustomDomains ? 'text-scale-1100 line-through' : ''
                   } text-sm`}
                 >
-                  $
-                  {(
-                    ((currentSubscription?.addons ?? []).find(
-                      (addon) => addon.prod_id === currentAddons.customDomains.id
-                    )?.unit_amount ?? 0) / 100
-                  ).toFixed(2)}
+                  ${getAddonPriceFromSubscription('customDomains')}
                 </p>
               </div>
             )}
@@ -257,14 +251,7 @@ const PaymentSummaryPanel: FC<Props> = ({
             {currentAddons.supportPlan !== undefined && (
               <div className="flex items-center justify-between">
                 <p className="text-sm">{currentAddons.supportPlan?.name}</p>
-                <p className="text-sm">
-                  $
-                  {(
-                    ((currentSubscription?.addons ?? []).find(
-                      (addon) => addon.prod_id === currentAddons.supportPlan?.id
-                    )?.unit_amount ?? 0) / 100
-                  ).toFixed(2)}
-                </p>
+                <p className="text-sm">${getAddonPriceFromSubscription('supportPlan')}</p>
               </div>
             )}
 

--- a/studio/components/interfaces/Billing/PaymentSummaryPanel/PaymentSummaryPanel.tsx
+++ b/studio/components/interfaces/Billing/PaymentSummaryPanel/PaymentSummaryPanel.tsx
@@ -9,7 +9,7 @@ import { SubscriptionPreview } from '../Billing.types'
 import { getProductPrice, validateSubscriptionUpdatePayload } from '../Billing.utils'
 import PaymentTotal from './PaymentTotal'
 import InformationBox from 'components/ui/InformationBox'
-import { DatabaseAddon } from '../AddOns/AddOns.types'
+import { SubscriptionAddon } from '../AddOns/AddOns.types'
 import { getPITRDays } from './PaymentSummaryPanel.utils'
 import ConfirmPaymentModal from './ConfirmPaymentModal'
 import { StripeSubscription } from '../Subscription/Subscription.types'
@@ -23,17 +23,17 @@ interface Props {
 
   currentPlan: any
   currentAddons: {
-    computeSize: DatabaseAddon
-    pitrDuration: DatabaseAddon
-    customDomains: DatabaseAddon
-    supportPlan?: DatabaseAddon
+    computeSize: SubscriptionAddon
+    pitrDuration: SubscriptionAddon
+    customDomains: SubscriptionAddon
+    supportPlan?: SubscriptionAddon
   }
 
   selectedPlan?: any
   selectedAddons: {
-    computeSize: DatabaseAddon
-    pitrDuration: DatabaseAddon
-    customDomains: DatabaseAddon
+    computeSize: SubscriptionAddon
+    pitrDuration: SubscriptionAddon
+    customDomains: SubscriptionAddon
   }
 
   isSpendCapEnabled: boolean

--- a/studio/components/interfaces/Billing/PaymentSummaryPanel/PaymentSummaryPanel.tsx
+++ b/studio/components/interfaces/Billing/PaymentSummaryPanel/PaymentSummaryPanel.tsx
@@ -3,7 +3,7 @@ import * as Tooltip from '@radix-ui/react-tooltip'
 import { Listbox, IconLoader, Button, IconPlus, IconAlertCircle, IconCreditCard } from 'ui'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 
-import { checkPermissions, useFlag, useStore } from 'hooks'
+import { checkPermissions, useStore } from 'hooks'
 import { PRICING_TIER_PRODUCT_IDS, STRIPE_PRODUCT_IDS } from 'lib/constants'
 import { SubscriptionPreview } from '../Billing.types'
 import { getProductPrice, validateSubscriptionUpdatePayload } from '../Billing.utils'
@@ -12,11 +12,13 @@ import InformationBox from 'components/ui/InformationBox'
 import { DatabaseAddon } from '../AddOns/AddOns.types'
 import { getPITRDays } from './PaymentSummaryPanel.utils'
 import ConfirmPaymentModal from './ConfirmPaymentModal'
+import { StripeSubscription } from '../Subscription/Subscription.types'
 
 // [Joshen] PITR stuff can be undefined for now until we officially launch PITR self serve
 
 interface Props {
   isRefreshingPreview: boolean
+  currentSubscription?: StripeSubscription
   subscriptionPreview?: SubscriptionPreview
 
   currentPlan: any
@@ -24,6 +26,7 @@ interface Props {
     computeSize: DatabaseAddon
     pitrDuration: DatabaseAddon
     customDomains: DatabaseAddon
+    supportPlan?: DatabaseAddon
   }
 
   selectedPlan?: any
@@ -53,6 +56,7 @@ interface Props {
 const PaymentSummaryPanel: FC<Props> = ({
   isRefreshingPreview,
   isSpendCapEnabled,
+  currentSubscription,
   subscriptionPreview,
 
   currentPlan,
@@ -154,7 +158,9 @@ const PaymentSummaryPanel: FC<Props> = ({
         {/* Add on details */}
         {projectRegion !== 'af-south-1' && (
           <div className="space-y-1">
-            <p className="text-sm">Selected add-ons</p>
+            <p className="text-sm text-scale-1100">Selected add-ons</p>
+
+            {/* Compute size */}
             <div className="flex items-center justify-between">
               <p
                 className={`${isChangingComputeSize ? 'text-scale-1100 line-through' : ''} text-sm`}
@@ -164,7 +170,12 @@ const PaymentSummaryPanel: FC<Props> = ({
               <p
                 className={`${isChangingComputeSize ? 'text-scale-1100 line-through' : ''} text-sm`}
               >
-                ${(getProductPrice(currentAddons.computeSize).unit_amount / 100).toFixed(2)}
+                $
+                {(
+                  ((currentSubscription?.addons ?? []).find(
+                    (addon) => addon.prod_id === currentAddons.computeSize.id
+                  )?.unit_amount ?? 0) / 100
+                ).toFixed(2)}
               </p>
             </div>
             {isChangingComputeSize && (
@@ -175,6 +186,8 @@ const PaymentSummaryPanel: FC<Props> = ({
                 </p>
               </div>
             )}
+
+            {/* PITR Duration */}
             {currentAddons.pitrDuration?.id !== undefined && (
               <div className="flex items-center justify-between">
                 <p
@@ -189,7 +202,12 @@ const PaymentSummaryPanel: FC<Props> = ({
                     isChangingPITRDuration ? 'text-scale-1100 line-through' : ''
                   } text-sm`}
                 >
-                  ${(getProductPrice(currentAddons.pitrDuration).unit_amount / 100).toFixed(2)}
+                  $
+                  {(
+                    ((currentSubscription?.addons ?? []).find(
+                      (addon) => addon.prod_id === currentAddons.pitrDuration.id
+                    )?.unit_amount ?? 0) / 100
+                  ).toFixed(2)}
                 </p>
               </div>
             )}
@@ -201,6 +219,8 @@ const PaymentSummaryPanel: FC<Props> = ({
                 </p>
               </div>
             )}
+
+            {/* Custom Domains */}
             {currentAddons.customDomains?.id !== undefined && (
               <div className="flex items-center justify-between">
                 <p
@@ -215,7 +235,12 @@ const PaymentSummaryPanel: FC<Props> = ({
                     isChangingCustomDomains ? 'text-scale-1100 line-through' : ''
                   } text-sm`}
                 >
-                  ${(getProductPrice(currentAddons.customDomains).unit_amount / 100).toFixed(2)}
+                  $
+                  {(
+                    ((currentSubscription?.addons ?? []).find(
+                      (addon) => addon.prod_id === currentAddons.customDomains.id
+                    )?.unit_amount ?? 0) / 100
+                  ).toFixed(2)}
                 </p>
               </div>
             )}
@@ -224,6 +249,21 @@ const PaymentSummaryPanel: FC<Props> = ({
                 <p className="text-sm">{selectedAddons.customDomains?.name}</p>
                 <p className="text-sm">
                   ${(getProductPrice(selectedAddons.customDomains).unit_amount / 100).toFixed(2)}
+                </p>
+              </div>
+            )}
+
+            {/* Support Plan */}
+            {currentAddons.supportPlan !== undefined && (
+              <div className="flex items-center justify-between">
+                <p className="text-sm">{currentAddons.supportPlan?.name}</p>
+                <p className="text-sm">
+                  $
+                  {(
+                    ((currentSubscription?.addons ?? []).find(
+                      (addon) => addon.prod_id === currentAddons.supportPlan?.id
+                    )?.unit_amount ?? 0) / 100
+                  ).toFixed(2)}
                 </p>
               </div>
             )}

--- a/studio/components/interfaces/Billing/PaymentSummaryPanel/PaymentSummaryPanel.utils.ts
+++ b/studio/components/interfaces/Billing/PaymentSummaryPanel/PaymentSummaryPanel.utils.ts
@@ -1,6 +1,6 @@
-import { DatabaseAddon } from '../AddOns/AddOns.types'
+import { SubscriptionAddon } from '../AddOns/AddOns.types'
 
-export const getPITRDays = (pitrAddon: DatabaseAddon) => {
+export const getPITRDays = (pitrAddon: SubscriptionAddon) => {
   const prodId = pitrAddon.metadata.supabase_prod_id
   const daysString = prodId.split('_')[2]
   return Number(daysString.split('days')[0])

--- a/studio/components/interfaces/Billing/ProUpgrade.tsx
+++ b/studio/components/interfaces/Billing/ProUpgrade.tsx
@@ -28,6 +28,7 @@ import {
   formatPITROptions,
 } from './AddOns/AddOns.utils'
 import BackButton from 'components/ui/BackButton'
+import SupportPlan from './AddOns/SupportPlan'
 
 // Do not allow compute size changes for af-south-1
 
@@ -242,6 +243,12 @@ const ProUpgrade: FC<Props> = ({
                 </div>
                 {projectRegion !== 'af-south-1' && (
                   <>
+                    {currentAddons.supportPlan !== undefined && (
+                      <>
+                        <Divider light />
+                        <SupportPlan currentOption={currentAddons.supportPlan} />
+                      </>
+                    )}
                     {isCustomDomainsEnabled && customDomainOptions.length > 0 && (
                       <>
                         <Divider light />

--- a/studio/components/interfaces/Billing/ProUpgrade.tsx
+++ b/studio/components/interfaces/Billing/ProUpgrade.tsx
@@ -306,6 +306,7 @@ const ProUpgrade: FC<Props> = ({
             // Current subscription configuration based on DB
             currentPlan={currentSubscription.tier}
             currentAddons={currentAddons}
+            currentSubscription={currentSubscription}
             // Selected subscription configuration based on UI
             selectedPlan={selectedTier}
             selectedAddons={selectedAddons}

--- a/studio/components/interfaces/Billing/ProUpgrade.tsx
+++ b/studio/components/interfaces/Billing/ProUpgrade.tsx
@@ -88,6 +88,12 @@ const ProUpgrade: FC<Props> = ({
     currentAddons.customDomains
   )
 
+  // [Joshen TODO] Future - We may need to also include any add ons outside of
+  // compute size, pitr, custom domain and support plan, although we dont have any now
+  const nonChangeableAddons = [currentAddons.supportPlan].filter(
+    (x) => x !== undefined
+  ) as DatabaseAddon[]
+
   // [Joshen] Scaffolded here
   const selectedAddons = {
     computeSize: selectedComputeSize,
@@ -122,8 +128,10 @@ const ProUpgrade: FC<Props> = ({
     if (!selectedTier) return
 
     const payload = formSubscriptionUpdatePayload(
+      currentSubscription,
       selectedTier,
       selectedAddons,
+      nonChangeableAddons,
       selectedPaymentMethodId,
       projectRegion
     )
@@ -142,8 +150,10 @@ const ProUpgrade: FC<Props> = ({
 
   const onConfirmPayment = async () => {
     const payload = formSubscriptionUpdatePayload(
+      currentSubscription,
       selectedTier,
       selectedAddons,
+      nonChangeableAddons,
       selectedPaymentMethodId,
       projectRegion
     )

--- a/studio/components/interfaces/Billing/ProUpgrade.tsx
+++ b/studio/components/interfaces/Billing/ProUpgrade.tsx
@@ -21,7 +21,7 @@ import { STRIPE_PRODUCT_IDS } from 'lib/constants'
 import UpdateSuccess from './UpdateSuccess'
 import { PaymentMethod, SubscriptionPreview } from './Billing.types'
 import { formSubscriptionUpdatePayload, getCurrentAddons } from './Billing.utils'
-import { DatabaseAddon } from './AddOns/AddOns.types'
+import { SubscriptionAddon } from './AddOns/AddOns.types'
 import {
   formatComputeSizes,
   formatCustomDomainOptions,
@@ -33,7 +33,7 @@ import SupportPlan from './AddOns/SupportPlan'
 // Do not allow compute size changes for af-south-1
 
 interface Props {
-  products: { tiers: any[]; addons: DatabaseAddon[] }
+  products: { tiers: any[]; addons: SubscriptionAddon[] }
   paymentMethods?: PaymentMethod[]
   currentSubscription: StripeSubscription
   isLoadingPaymentMethods: boolean
@@ -78,13 +78,13 @@ const ProUpgrade: FC<Props> = ({
   // [Joshen TODO] Ideally we just have a state to hold all the add ons selection, rather than individual
   // Even better if we can just use the <Form> component to handle all of these. Mainly to reduce the amount
   // of unnecessary state management on this complex page.
-  const [selectedComputeSize, setSelectedComputeSize] = useState<DatabaseAddon>(
+  const [selectedComputeSize, setSelectedComputeSize] = useState<SubscriptionAddon>(
     currentAddons.computeSize
   )
-  const [selectedPITRDuration, setSelectedPITRDuration] = useState<DatabaseAddon>(
+  const [selectedPITRDuration, setSelectedPITRDuration] = useState<SubscriptionAddon>(
     currentAddons.pitrDuration
   )
-  const [selectedCustomDomainOption, setSelectedCustomDomainOption] = useState<DatabaseAddon>(
+  const [selectedCustomDomainOption, setSelectedCustomDomainOption] = useState<SubscriptionAddon>(
     currentAddons.customDomains
   )
 
@@ -92,7 +92,7 @@ const ProUpgrade: FC<Props> = ({
   // compute size, pitr, custom domain and support plan, although we dont have any now
   const nonChangeableAddons = [currentAddons.supportPlan].filter(
     (x) => x !== undefined
-  ) as DatabaseAddon[]
+  ) as SubscriptionAddon[]
 
   // [Joshen] Scaffolded here
   const selectedAddons = {

--- a/studio/components/to-be-cleaned/forms/SchemaFormPanel.js
+++ b/studio/components/to-be-cleaned/forms/SchemaFormPanel.js
@@ -32,7 +32,7 @@ export default function SchemaFormPanel({
         setSubmitButtonLoading(true)
       })
       .catch((error) => {
-        console.log('Error on submitting', error)
+        console.error('Error on submitting', error)
       })
   }
 

--- a/studio/components/ui/DatePicker/TimeSplitInput.tsx
+++ b/studio/components/ui/DatePicker/TimeSplitInput.tsx
@@ -38,13 +38,10 @@ const TimeSplitInput = ({
     // Only run time conflicts if
     // startDate and endDate are the same date
 
-    // console.log(startDate)
-    // console.log(endDate)
     if (format(new Date(startDate), 'dd/mm/yyyy') == format(new Date(endDate), 'dd/mm/yyyy')) {
       // checks if start time is ahead of end time
 
       if (type === 'start') {
-        // console.log('HH in start switch')
         if (_time.HH && Number(_time.HH) > Number(endTime.HH)) {
           endTimePayload.HH = _time.HH
           endTimeChanges = true
@@ -79,8 +76,6 @@ const TimeSplitInput = ({
       }
 
       if (type === 'end') {
-        // console.log('HH in start switch')
-
         if (_time.HH && Number(_time.HH) < Number(startTime.HH)) {
           startTimePayload.HH = _time.HH
           startTimeChanges = true
@@ -128,8 +123,6 @@ const TimeSplitInput = ({
   }
 
   function handleOnChange(value: string, valueType: TimeType) {
-    // console.log('handleOnChange')
-
     const payload = {
       HH: time.HH,
       mm: time.mm,
@@ -151,14 +144,8 @@ const TimeSplitInput = ({
         break
     }
 
-    // console.log('got here')
-
     payload[valueType] = value
     setTime({ ...payload })
-
-    // if (endTimeChanges) {
-    //   setEndTime(endTimePayload)
-    // }
   }
 
   const handleFocus = (event: React.FocusEvent<HTMLInputElement>) => {

--- a/studio/lib/gotrue.ts
+++ b/studio/lib/gotrue.ts
@@ -18,7 +18,7 @@ export const getAuthUser = async (token: String): Promise<any> => {
 
     return { user, error: null }
   } catch (err) {
-    console.log(err)
+    console.error(err)
     return { user: null, error: err }
   }
 }

--- a/studio/pages/project/[ref]/settings/billing/update/pro.tsx
+++ b/studio/pages/project/[ref]/settings/billing/update/pro.tsx
@@ -12,7 +12,7 @@ import Connecting from 'components/ui/Loading/Loading'
 import { StripeSubscription } from 'components/interfaces/Billing'
 import { ProUpgrade } from 'components/interfaces/Billing'
 import { PaymentMethod } from 'components/interfaces/Billing/Billing.types'
-import { DatabaseAddon } from 'components/interfaces/Billing/AddOns/AddOns.types'
+import { SubscriptionAddon } from 'components/interfaces/Billing/AddOns/AddOns.types'
 
 const BillingUpdatePro: NextPageWithLayout = () => {
   const { ui } = useStore()
@@ -24,7 +24,7 @@ const BillingUpdatePro: NextPageWithLayout = () => {
   const projectUpdateDisabled = useFlag('disableProjectCreationAndUpdate')
 
   const [subscription, setSubscription] = useState<StripeSubscription>()
-  const [products, setProducts] = useState<{ tiers: any[]; addons: DatabaseAddon[] }>()
+  const [products, setProducts] = useState<{ tiers: any[]; addons: SubscriptionAddon[] }>()
   const [paymentMethods, setPaymentMethods] = useState<PaymentMethod[]>()
   const [isLoadingPaymentMethods, setIsLoadingPaymentMethods] = useState(false)
 


### PR DESCRIPTION
- Show support plan add on in subscription update page if project has a support plan add on
- Prevent changing of addons if addons have no price tag on it (implicitly included in the plan purchased)
- Ensure that payment summary panel is showing the correct price (some products have multiple prices, we were only using the default price previously)
- Ensure that the correct price ids are being used to create the subscription update payload (some products have multiple prices, we were only using the default price id previously)