### PR TITLE
docs: add mfa methods to the reference docs

### DIFF
--- a/apps/docs/data/nav/supabase-js/v2.ts
+++ b/apps/docs/data/nav/supabase-js/v2.ts
@@ -42,6 +42,11 @@ const Nav = [
         url: '/reference/javascript/auth-resetpasswordforemail',
         items: [],
       },
+      {
+        name: 'enroll()',
+        url: '/reference/javascript/auth-mfa-enroll',
+        items: [],
+      },
     ],
   },
   {

--- a/apps/docs/data/nav/supabase-js/v2.ts
+++ b/apps/docs/data/nav/supabase-js/v2.ts
@@ -43,8 +43,28 @@ const Nav = [
         items: [],
       },
       {
-        name: 'enroll()',
+        name: 'mfa.enroll()',
         url: '/reference/javascript/auth-mfa-enroll',
+        items: [],
+      },
+      {
+        name: 'mfa.challenge()',
+        url: '/reference/javascript/auth-mfa-challenge',
+        items: [],
+      },
+      {
+        name: 'mfa.verify()',
+        url: '/reference/javascript/auth-mfa-verify',
+        items: [],
+      },
+      {
+        name: 'mfa.challengeAndVerify()',
+        url: '/reference/javascript/auth-mfa-challengeandverify',
+        items: [],
+      },
+      {
+        name: 'mfa.getAuthenticatorAssuranceLevel()',
+        url: '/reference/javascript/auth-mfa-getauthenticatorassuranceLevel',
         items: [],
       },
     ],
@@ -66,6 +86,16 @@ const Nav = [
       {
         name: 'updateUserById()',
         url: '/reference/javascript/auth-admin-updateuserbyid',
+        items: [],
+      },
+      {
+        name: 'mfa.listFactors()',
+        url: '/reference/javascript/auth-admin-mfa-listfactors',
+        items: [],
+      },
+      {
+        name: 'mfa.deleteFactor()',
+        url: '/reference/javascript/auth-admin-mfa-deletefactor',
         items: [],
       },
     ],

--- a/spec/supabase_js_v2.yml
+++ b/spec/supabase_js_v2.yml
@@ -422,16 +422,78 @@ pages:
           })
           ```
   auth.mfa.enroll():
-    title: 'enroll()'
+    title: 'mfa.enroll()'
     $ref: '@supabase/gotrue-js.GoTrueMFAApi.enroll'
     notes: |
-      - Enrolls a factor. To verify the factor, see `auth.mfa.challengeAndVerify()`.
+      - Currently, `totp` is the only supported `factorType`.
+      - To generate a QR code containing the `totp` secret, 
+      - To verify the factor next, see `auth.mfa.challengeAndVerify()`.
+      - To generate a QR code for the `totp` secret in nextjs, you can do the following:
+      ```html
+      <Image src={data.totp.qr_code} alt={data.totp.uri} layout="fill"></Image>
+      ```
     examples:
       - name: Enroll a TOTP factor
         isSpotlight: true
         js: |
           ```js
-          const { data, error } = supabase.auth.mfa.enroll({ factorType: 'totp' })
+          const { data, error } = await supabase.auth.mfa.enroll({ 
+            factorType: 'totp' 
+          })
+          ```
+  auth.mfa.challenge():
+    title: 'mfa.challenge()'
+    $ref: '@supabase/gotrue-js.GoTrueMFAApi.challenge'
+    examples:
+      - name: Creates a challenge for a factor
+        isSpotlight: true
+        js: |
+          ```js
+          const { data, error } = await supabase.auth.mfa.challenge({ 
+            factorId: '00000000-0000-0000-0000-000000000000' 
+          })
+          ```
+  auth.mfa.verify():
+    title: 'mfa.verify()'
+    $ref: '@supabase/gotrue-js.GoTrueMFAApi.verify'
+    examples:
+      - name: Verifies a challenge for a factor
+        isSpotlight: true
+        js: |
+          ```js
+          const { data, error } = await supabase.auth.mfa.verify({ 
+            factorId: '00000000-0000-0000-0000-000000000000', 
+            challengeId: '11111111-1111-1111-1111-111111111111', 
+            code: '123456'
+          })
+          ```
+  auth.mfa.challengeAndVerify():
+    title: 'mfa.challengeAndVerify()'
+    $ref: '@supabase/gotrue-js.GoTrueMFAApi.challengeAndVerify'
+    notes: |
+      - Combines `mfa.challenge()` and `mfa.verify()` in 1 step
+    examples:
+      - name: Creates and verifies a challenge for a factor
+        isSpotlight: true
+        js: |
+          ```js
+          const { data, error } = await supabase.auth.mfa.challengeAndVerify({
+            factorId: '00000000-0000-0000-0000-000000000000',
+            code: '123456'
+          })
+          ```
+  auth.mfa.getAuthenticatorAssuranceLevel():
+    title: 'mfa.getAuthenticatorAssuranceLevel()'
+    $ref: '@supabase/gotrue-js.GoTrueMFAApi.getAuthenticatorAssuranceLevel'
+    notes:
+      - Authenticator Assurance Level (AAL) is the measure of the strength of an authentication mechanism.
+      - In Supabase, having an AAL of `aal1` typically refers to having the 1st factor of authentication such as an email and password or oauth sign-in while `aal2` refers to the 2nd factor of authentication such as Time-based one-time-password (TOTP).
+    example:
+      - name: Get the AAL details of a session
+        js: |
+          ```js
+          const { data, error } = await supabase.auth.mfa.getAuthenticatorAssuranceLevel()
+          const { currentLevel, nextLevel, currentAuthenticationMethods } = data
           ```
   Supabase Auth Admin Api:
     title: 'Overview'
@@ -691,6 +753,31 @@ pages:
             '6aa5d0d4-2a9f-4483-b6c8-0cf4c6c98ac4',
             { phone_confirm: true }
           )
+          ```
+
+  auth.admin.mfa.listFactors():
+    title: 'mfa.listFactors()'
+    $ref: '@supabase/gotrue-js.GoTrueAdminMFAApi.listFactors'
+    examples:
+      - name: List all factors associated to a user
+        isSpotlight: true
+        js: |
+          ```js
+          const { data, error } = await supabase.auth.admin.mfa.listFactors()
+          ```
+
+  auth.admin.mfa.deleteFactor():
+    title: 'mfa.deleteFactor()'
+    $ref: '@supabase/gotrue-js.GoTrueAdminMFAApi.deleteFactor'
+    examples:
+      - name: Deletes a factor associated to a user
+        isSpotlight: true
+        js: |
+          ```js
+          const { data, error } = await supabase.auth.admin.mfa.deleteFactor({ 
+            id: '00000000-0000-0000-0000-000000000000', 
+            userId: '11111111-1111-1111-1111-111111111111'
+          })
           ```
 
   select():

--- a/spec/supabase_js_v2.yml
+++ b/spec/supabase_js_v2.yml
@@ -421,6 +421,18 @@ pages:
             if (event == 'PASSWORD_RECOVERY') console.log('PASSWORD_RECOVERY', session)
           })
           ```
+  auth.mfa.enroll():
+    title: 'enroll()'
+    $ref: '@supabase/gotrue-js.GoTrueMFAApi.enroll'
+    notes: |
+      - Enrolls a factor. To verify the factor, see `auth.mfa.challengeAndVerify()`.
+    examples:
+      - name: Enroll a TOTP factor
+        isSpotlight: true
+        js: |
+          ```js
+          const { data, error } = supabase.auth.mfa.enroll({ factorType: 'totp' })
+          ```
   Supabase Auth Admin Api:
     title: 'Overview'
     notes: |


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Adds the gotrue-js MFA methods to the reference guide