### PR TITLE
feat(usage): show image transformations

### DIFF
--- a/studio/components/interfaces/Billing/Billing.constants.tsx
+++ b/studio/components/interfaces/Billing/Billing.constants.tsx
@@ -69,6 +69,13 @@ export const USAGE_BASED_PRODUCTS = [
         units: 'bytes',
         costPerUnit: 0.09,
       },
+      {
+        key: 'storage_image_render_count',
+        attribute: 'total_storage_image_render_count',
+        title: 'Storage Image Renders',
+        units: 'absolute',
+        costPerUnit: 0.005,
+      },
     ],
   },
   {

--- a/studio/components/interfaces/Billing/Billing.constants.tsx
+++ b/studio/components/interfaces/Billing/Billing.constants.tsx
@@ -72,7 +72,7 @@ export const USAGE_BASED_PRODUCTS = [
       {
         key: 'storage_image_render_count',
         attribute: 'total_storage_image_render_count',
-        title: 'Storage Image Renders',
+        title: 'Storage Images Transformed',
         units: 'absolute',
         costPerUnit: 0.005,
       },

--- a/studio/components/interfaces/Reports/Reports.tsx
+++ b/studio/components/interfaces/Reports/Reports.tsx
@@ -17,7 +17,7 @@ import {
 } from 'ui'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 
-import { checkPermissions, useStore } from 'hooks'
+import { checkPermissions, useFlag, useStore } from 'hooks'
 import { uuidv4 } from 'lib/helpers'
 import { METRIC_CATEGORIES, METRICS, TIME_PERIODS_REPORTS } from 'lib/constants'
 import { useProjectContentStore } from 'stores/projectContentStore'
@@ -263,6 +263,10 @@ const Reports = () => {
     })
   }
 
+  // Filter out total_storage_image_render_count if feature flag is not enabled
+  const storageImageResizeEnabled = useFlag('storageImageResize')
+  let metrics = METRICS.filter(it => it.key !== 'total_storage_image_render_count' || storageImageResizeEnabled);
+
   const MetricOptions = () => {
     return (
       <>
@@ -273,7 +277,7 @@ const Reports = () => {
                 isNested
                 overlay={
                   <>
-                    {METRICS.filter((metric) => metric?.category?.key === cat.key).map((metric) => {
+                    {metrics.filter((metric) => metric?.category?.key === cat.key).map((metric) => {
                       return (
                         <Dropdown.Checkbox
                           key={metric.key}

--- a/studio/components/interfaces/Settings/ProjectUsageBars/ProjectUsageBars.tsx
+++ b/studio/components/interfaces/Settings/ProjectUsageBars/ProjectUsageBars.tsx
@@ -1,7 +1,7 @@
 import { FC, useEffect } from 'react'
 import { Badge, Button, IconAlertCircle, Loading } from 'ui'
 
-import { useStore, useProjectUsage } from 'hooks'
+import { useStore, useProjectUsage, useFlag } from 'hooks'
 import { formatBytes } from 'lib/helpers'
 import { PRICING_TIER_PRODUCT_IDS, USAGE_APPROACHING_THRESHOLD } from 'lib/constants'
 import SparkBar from 'components/ui/SparkBar'
@@ -56,11 +56,21 @@ const ProjectUsage: FC<Props> = ({ projectRef }) => {
     )
   }
 
+  const storageImageResizeEnabled = useFlag('storageImageResize')
+
+  // Filter out storage_image_render_count if feature flag is not enabled
+  const usageBasedProducts = USAGE_BASED_PRODUCTS.map((usageBasedProduct) => ({
+    ...usageBasedProduct,
+    features: usageBasedProduct.features.filter(
+      (it) => it.key !== 'storage_image_render_count' || storageImageResizeEnabled
+    ),
+  }))
+
   return (
     <Loading active={isLoading}>
       {usage && (
         <div>
-          {USAGE_BASED_PRODUCTS.map((product) => {
+          {usageBasedProducts.map((product) => {
             const isExceededUsage =
               showUsageExceedMessage &&
               product.features

--- a/studio/components/interfaces/Settings/ProjectUsageBars/ProjectUsageBars.tsx
+++ b/studio/components/interfaces/Settings/ProjectUsageBars/ProjectUsageBars.tsx
@@ -9,7 +9,6 @@ import ShimmeringLoader from 'components/ui/ShimmeringLoader'
 import InformationBox from 'components/ui/InformationBox'
 import { USAGE_BASED_PRODUCTS } from 'components/interfaces/Billing/Billing.constants'
 import { useRouter } from 'next/router'
-import Link from 'next/link'
 
 interface Props {
   projectRef?: string
@@ -20,12 +19,22 @@ const ProjectUsage: FC<Props> = ({ projectRef }) => {
   const { usage, error, isLoading } = useProjectUsage(projectRef)
   const router = useRouter()
 
-  const projectHasNoLimits =
-    ui.selectedProject?.subscription_tier === PRICING_TIER_PRODUCT_IDS.PAYG ||
-    ui.selectedProject?.subscription_tier === PRICING_TIER_PRODUCT_IDS.ENTERPRISE
+  const subscriptionTier = ui.selectedProject?.subscription_tier
 
-  const showUsageExceedMessage =
-    ui.selectedProject?.subscription_tier !== undefined && !projectHasNoLimits
+  const projectHasNoLimits =
+    subscriptionTier === PRICING_TIER_PRODUCT_IDS.PAYG ||
+    subscriptionTier === PRICING_TIER_PRODUCT_IDS.ENTERPRISE
+
+  const showUsageExceedMessage = subscriptionTier !== undefined && !projectHasNoLimits
+
+  const planNames = {
+    [PRICING_TIER_PRODUCT_IDS.FREE]: 'Free',
+    [PRICING_TIER_PRODUCT_IDS.PRO]: 'Pro',
+    [PRICING_TIER_PRODUCT_IDS.PAYG]: 'Pro',
+    [PRICING_TIER_PRODUCT_IDS.ENTERPRISE]: 'Enterprise',
+  }
+
+  const planName = subscriptionTier ? planNames[subscriptionTier] || 'current' : 'current'
 
   useEffect(() => {
     if (error) {
@@ -113,12 +122,16 @@ const ProjectUsage: FC<Props> = ({ projectRef }) => {
                         let usageElement
                         if (!isAvailableInPlan) {
                           usageElement = (
-                            <div>
-                              <Link href={`/project/${projectRef}/settings/billing/update`}>
-                                <a className="underline">
-                                  <span>Upgrade to unlock</span>
-                                </a>
-                              </Link>
+                            <div className="flex justify-between">
+                              <span>Not included in {planName} tier</span>
+                              <Button
+                                size="tiny"
+                                onClick={() =>
+                                  router.push(`/project/${projectRef}/settings/billing/update`)
+                                }
+                              >
+                                Upgrade to Pro
+                              </Button>
                             </div>
                           )
                         } else if (showUsageExceedMessage) {

--- a/studio/components/interfaces/Settings/ProjectUsageBars/ProjectUsageBars.tsx
+++ b/studio/components/interfaces/Settings/ProjectUsageBars/ProjectUsageBars.tsx
@@ -132,7 +132,7 @@ const ProjectUsage: FC<Props> = ({ projectRef }) => {
                         let usageElement
                         if (!isAvailableInPlan) {
                           usageElement = (
-                            <div className="flex justify-between">
+                            <div className="flex justify-between items-center">
                               <span>Not included in {planName} tier</span>
                               <Button
                                 size="tiny"

--- a/studio/components/interfaces/Settings/ProjectUsageBars/ProjectUsageBars.types.ts
+++ b/studio/components/interfaces/Settings/ProjectUsageBars/ProjectUsageBars.types.ts
@@ -2,6 +2,7 @@ export interface ResourceUsage {
   usage: number
   limit: number
   cost: number
+  available_in_plan: boolean
 }
 
 export interface UsageStats {

--- a/studio/lib/constants/metrics.tsx
+++ b/studio/lib/constants/metrics.tsx
@@ -210,6 +210,12 @@ export const METRICS = [
     category: METRIC_CATEGORIES.API_STORAGE,
   },
   {
+    key: 'total_storage_image_render_count',
+    label: 'Storage Image Renders',
+    provider: 'daily-stats',
+    category: METRIC_CATEGORIES.API_STORAGE,
+  },
+  {
     key: 'total_storage_requests',
     label: 'Storage Requests',
     provider: 'daily-stats',

--- a/studio/lib/constants/metrics.tsx
+++ b/studio/lib/constants/metrics.tsx
@@ -211,7 +211,7 @@ export const METRICS = [
   },
   {
     key: 'total_storage_image_render_count',
-    label: 'Storage Image Renders',
+    label: 'Storage Images Transformed',
     provider: 'daily-stats',
     category: METRIC_CATEGORIES.API_STORAGE,
   },


### PR DESCRIPTION
Based on this API PR https://github.com/supabase/infrastructure/pull/10702

- Adds the Image Transformation usage to the usage dashboard
- Adds upsell for the free tier
- Adds a new report for storage image transformations

<img width="903" alt="Screenshot 2022-12-11 at 14 20 10" src="https://user-images.githubusercontent.com/14073399/206906068-3abef2b2-a101-486f-947c-35e59b457bc5.png">

@frontend-team: Is there any other common styling for simple links (took this of pricing page)? A button would be too much, as the upsell could be in there multiple times
