### PR TITLE
docs: update twitter auth guide with references to new elevated access policies

### DIFF
--- a/apps/docs/pages/guides/auth/auth-twitter.mdx
+++ b/apps/docs/pages/guides/auth/auth-twitter.mdx
@@ -18,6 +18,7 @@ Setting up Twitter logins for your application consists of 3 parts:
 
 ## Access your Twitter Developer account
 
+- Before proceeding further make sure your twitter account has [elevated access](https://developer.twitter.com/en/portal/petition/essential/basic-info)
 - Go to [developer.twitter.com](https://developer.twitter.com).
 - Click on `Sign in` at the top right to log in.
 

--- a/apps/docs/pages/guides/auth/auth-twitter.mdx
+++ b/apps/docs/pages/guides/auth/auth-twitter.mdx
@@ -18,9 +18,7 @@ Setting up Twitter logins for your application consists of 3 parts:
 
 ## Access your Twitter Developer account
 
-- Before proceeding further make sure your twitter account has [elevated access](https://developer.twitter.com/en/portal/petition/essential/basic-info)
-- Go to [developer.twitter.com](https://developer.twitter.com).
-- Click on `Sign in` at the top right to log in.
+Sign in to your [Twitter developer account](https://developer.twitter.com). Note that your account must have [elevated access](https://developer.twitter.com/en/portal/petition/essential/basic-info) to use Twitter as an OAuth provider.
 
 ![Twitter Developer Portal.](/docs/img/guides/auth-twitter/twitter-portal.png)
 

--- a/examples/user-management/expo-user-management/App.tsx
+++ b/examples/user-management/expo-user-management/App.tsx
@@ -5,6 +5,7 @@ import Auth from './components/Auth'
 import Account from './components/Account'
 import { View } from 'react-native'
 import { Session } from '@supabase/supabase-js'
+import React = require('react')
 
 export default function App() {
   const [session, setSession] = useState<Session | null>(null)

--- a/examples/user-management/expo-user-management/components/Account.tsx
+++ b/examples/user-management/expo-user-management/components/Account.tsx
@@ -4,6 +4,7 @@ import { StyleSheet, View, Alert } from 'react-native'
 import { Button, Input } from 'react-native-elements'
 import { Session } from '@supabase/supabase-js'
 import Avatar from './Avatar'
+import React = require('react')
 
 export default function Account({ session }: { session: Session }) {
   const [loading, setLoading] = useState(true)

--- a/examples/user-management/expo-user-management/components/Avatar.tsx
+++ b/examples/user-management/expo-user-management/components/Avatar.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import { supabase } from '../lib/supabase'
 import { StyleSheet, View, Alert, Image, Button } from 'react-native'
 import DocumentPicker, { isCancel, isInProgress, types } from 'react-native-document-picker'
+import React = require('react')
 
 interface Props {
   size: number

--- a/examples/user-management/expo-user-management/tsconfig.json
+++ b/examples/user-management/expo-user-management/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
+    "jsx": "react",
     "strict": true
   }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

clarified that an elevated access twitter account is necessary for twitter authentication as per requested in supabase/gotrue#867

## What is the current behavior?

the docs lack vital information on how to get twitter authentication

## What is the new behavior?

updated twitter docs To Clarify Need of Elevated Access

