### PR TITLE
fix: update links for getting started tutorials

### DIFF
--- a/apps/docs/pages/guides/getting-started.mdx
+++ b/apps/docs/pages/guides/getting-started.mdx
@@ -55,91 +55,91 @@ export const meta = {
 export const webapps = [
   {
     title: 'NextJS',
-    href: '/guides/tutorials/with-nextjs',
+    href: '/guides/getting-started/tutorials/with-nextjs',
     description:
       'Learn how to build a user management app with NextJS and Supabase Database, Auth, and Storage functionality.',
     icon: '/docs/img/icons/nextjs-icon',
   },
   {
     title: 'React',
-    href: '/guides/tutorials/with-react',
+    href: '/guides/getting-started/tutorials/with-react',
     description:
       'Learn how to build a user management app with React and Supabase Database, Auth, and Storage functionality.',
     icon: '/docs/img/icons/react-icon',
   },
   {
     title: 'Vue 3',
-    href: '/guides/tutorials/with-vue-3',
+    href: '/guides/getting-started/tutorials/with-vue-3',
     description:
       'Learn how to build a user management app with Vue 3 and Supabase Database, Auth, and Storage functionality.',
     icon: '/docs/img/icons/vuejs-icon',
   },
   {
     title: 'Nuxt 3',
-    href: '/guides/tutorials/with-nuxt-3',
+    href: '/guides/getting-started/tutorials/with-nuxt-3',
     description:
       'Learn how to build a user management app with Nuxt 3 and Supabase Database, Auth, and Storage functionality.',
     icon: '/docs/img/icons/nuxt-icon',
   },
   {
     title: 'Anglular',
-    href: '/guides/tutorials/with-angular',
+    href: '/guides/getting-started/tutorials/with-angular',
     description:
       'Learn how to build a user management app with Nuxt 3 and Supabase Database, Auth, and Storage functionality.',
     icon: '/docs/img/icons/angular-icon',
   },
   {
     title: 'RedwoodJS',
-    href: '/guides/tutorials/with-redwoodjs',
+    href: '/guides/getting-started/tutorials/with-redwoodjs',
     description:
       'Learn how to build a user management app with Nuxt 3 and Supabase Database, Auth, and Storage functionality.',
     icon: '/docs/img/icons/redwood-icon',
   },
   {
     title: 'Svelte',
-    href: '/guides/tutorials/with-svelte',
+    href: '/guides/getting-started/tutorials/with-svelte',
     description:
       'Learn how to build a user management app with Nuxt 3 and Supabase Database, Auth, and Storage functionality.',
     icon: '/docs/img/icons/svelte-icon',
   },
   {
     title: 'SvelteKit',
-    href: '/guides/tutorials/with-sveltekit',
+    href: '/guides/getting-started/tutorials/with-sveltekit',
     description:
       'Learn how to build a user management app with Nuxt 3 and Supabase Database, Auth, and Storage functionality.',
     icon: '/docs/img/icons/svelte-icon',
   },
   {
     title: 'Flutter',
-    href: '/guides/tutorials/with-flutter',
+    href: '/guides/getting-started/tutorials/with-flutter',
     description:
       'Learn how to build a user management app with Flutter and Supabase Database, Auth, and Storage functionality.',
     icon: '/docs/img/icons/flutter-icon',
   },
   {
     title: 'Expo',
-    href: '/guides/tutorials/with-expo',
+    href: '/guides/getting-started/tutorials/with-expo',
     description:
       'Learn how to build a user management app with React and Supabase Database, Auth, and Storage functionality.',
     icon: '/docs/img/icons/expo-icon',
   },
   {
     title: 'Ionic React',
-    href: '/guides/tutorials/with-ionic-react',
+    href: '/guides/getting-started/tutorials/with-ionic-react',
     description:
       'Learn how to build a user management app with React and Supabase Database, Auth, and Storage functionality.',
     icon: '/docs/img/icons/ionic-icon',
   },
   {
     title: 'Ionic Vue',
-    href: '/guides/tutorials/with-ionic-vue',
+    href: '/guides/getting-started/tutorials/with-ionic-vue',
     description:
       'Learn how to build a user management app with Flutter and Supabase Database, Auth, and Storage functionality.',
     icon: '/docs/img/icons/ionic-icon',
   },
   {
     title: 'Ionic Angular',
-    href: '/guides/tutorials/with-ionic-angular',
+    href: '/guides/getting-started/tutorials/with-ionic-angular',
     description:
       'Learn how to build a user management app with NextJS and Supabase Database, Auth, and Storage functionality.',
     icon: '/docs/img/icons/ionic-icon',

--- a/apps/docs/pages/guides/tutorials.mdx
+++ b/apps/docs/pages/guides/tutorials.mdx
@@ -57,56 +57,56 @@ export const meta = {
 export const webapps = [
   {
     title: 'NextJS',
-    href: '/guides/tutorials/with-nextjs',
+    href: '/guides/getting-started/tutorials/with-nextjs',
     description:
       'Learn how to build a user management app with NextJS and Supabase Database, Auth, and Storage functionality.',
     icon: '/docs/img/icons/nextjs-icon',
   },
   {
     title: 'React',
-    href: '/guides/tutorials/with-react',
+    href: '/guides/getting-started/tutorials/with-react',
     description:
       'Learn how to build a user management app with React and Supabase Database, Auth, and Storage functionality.',
     icon: '/docs/img/icons/react-icon',
   },
   {
     title: 'Vue 3',
-    href: '/guides/tutorials/with-vue-3',
+    href: '/guides/getting-started/tutorials/with-vue-3',
     description:
       'Learn how to build a user management app with Vue 3 and Supabase Database, Auth, and Storage functionality.',
     icon: '/docs/img/icons/vuejs-icon',
   },
   {
     title: 'Nuxt 3',
-    href: '/guides/tutorials/with-nuxt-3',
+    href: '/guides/getting-started/tutorials/with-nuxt-3',
     description:
       'Learn how to build a user management app with Nuxt 3 and Supabase Database, Auth, and Storage functionality.',
     icon: '/docs/img/icons/nuxt-icon',
   },
   {
     title: 'Anglular',
-    href: '/guides/tutorials/with-angular',
+    href: '/guides/getting-started/tutorials/with-angular',
     description:
       'Learn how to build a user management app with Nuxt 3 and Supabase Database, Auth, and Storage functionality.',
     icon: '/docs/img/icons/angular-icon',
   },
   {
     title: 'RedwoodJS',
-    href: '/guides/tutorials/with-redwoodjs',
+    href: '/guides/getting-started/tutorials/with-redwoodjs',
     description:
       'Learn how to build a user management app with Nuxt 3 and Supabase Database, Auth, and Storage functionality.',
     icon: '/docs/img/icons/redwood-icon',
   },
   {
     title: 'Svelte',
-    href: '/guides/tutorials/with-svelte',
+    href: '/guides/getting-started/tutorials/with-svelte',
     description:
       'Learn how to build a user management app with Nuxt 3 and Supabase Database, Auth, and Storage functionality.',
     icon: '/docs/img/icons/svelte-icon',
   },
   {
     title: 'SvelteKit',
-    href: '/guides/tutorials/with-sveltekit',
+    href: '/guides/getting-started/tutorials/with-sveltekit',
     description:
       'Learn how to build a user management app with Nuxt 3 and Supabase Database, Auth, and Storage functionality.',
     icon: '/docs/img/icons/svelte-icon',
@@ -116,14 +116,14 @@ export const webapps = [
 export const mobile = [
   {
     title: 'Flutter',
-    href: '/guides/tutorials/with-flutter',
+    href: '/guides/getting-started/tutorials/with-flutter',
     description:
       'Learn how to build a user management app with Flutter and Supabase Database, Auth, and Storage functionality.',
     icon: '/docs/img/icons/flutter-icon',
   },
   {
     title: 'Expo',
-    href: '/guides/tutorials/with-expo',
+    href: '/guides/getting-started/tutorials/with-expo',
     description:
       'Learn how to build a user management app with React and Supabase Database, Auth, and Storage functionality.',
     icon: '/docs/img/icons/expo-icon',
@@ -133,21 +133,21 @@ export const mobile = [
 export const lowCode = [
   {
     title: 'Ionic React',
-    href: '/guides/tutorials/with-ionic-react',
+    href: '/guides/getting-started/tutorials/with-ionic-react',
     description:
       'Learn how to build a user management app with React and Supabase Database, Auth, and Storage functionality.',
     icon: '/docs/img/icons/ionic-icon',
   },
   {
     title: 'Ionic Vue',
-    href: '/guides/tutorials/with-ionic-vue',
+    href: '/guides/getting-started/tutorials/with-ionic-vue',
     description:
       'Learn how to build a user management app with Flutter and Supabase Database, Auth, and Storage functionality.',
     icon: '/docs/img/icons/ionic-icon',
   },
   {
     title: 'Ionic Angular',
-    href: '/guides/tutorials/with-ionic-angular',
+    href: '/guides/getting-started/tutorials/with-ionic-angular',
     description:
       'Learn how to build a user management app with NextJS and Supabase Database, Auth, and Storage functionality.',
     icon: '/docs/img/icons/ionic-icon',


### PR DESCRIPTION
Hi 👋 congrats on Docs v2! I was just exploring them and found these broken links. I grepped to find the references to the old URL, so please let me know if I changed the wrong files.

## What kind of change does this PR introduce?

replaced '/guides/tutorials/' with '/guides/getting-started/tutorials/' using sed

`:%s /\/guides\/tutorials\//\/guides\/getting-started\/tutorials\//g`

## What is the current behavior?

Click on the links on the Getting Started page: https://supabase.com/docs/guides/getting-started

The current links take you to a 404 page: https://supabase.com/docs/guides/tutorials/with-nextjs

## What is the new behavior?

Links to the correct page: https://supabase.com/docs/guides/getting-started/tutorials/with-nextjs

## Additional context

Add any other context or screenshots.
