### PR TITLE
Fix Self-Hosting Realtime docs intro

### DIFF
--- a/apps/docs/docs/ref/self-hosting-realtime/introduction.mdx
+++ b/apps/docs/docs/ref/self-hosting-realtime/introduction.mdx
@@ -20,16 +20,16 @@ hideTitle: true
 
     `Realtime` server works by:
 
-    1. listening to PostgreSQL's replication functionality (using PostgreSQL's logical decoding)
-    2. converting the byte stream into JSON
-    3. broadcasting to all connected clients over WebSockets
+    1. Listening to PostgreSQL's replication functionality (using PostgreSQL's logical decoding)
+    2. Converting the byte stream into JSON
+    3. Broadcasting to all connected clients over WebSockets
 
     `Realtime RLS` server works by:
 
-    1. polling PostgreSQL's replication functionality (using PostgreSQL's logical decoding and [wal2json](https://github.com/eulerto/wal2json) output plugin)
-    2. passing database changes to a [Write Ahead Log Realtime Unified Security (WALRUS)](https://github.com/supabase/walrus) PostgresSQL function and receiving a list of authorized subscribers depending on Row Level Security (RLS) policies
-    3. converting the changes into JSON
-    4. broadcasting to authorized subscribers over WebSockets
+    1. Polling PostgreSQL's replication functionality (using PostgreSQL's logical decoding and [wal2json](https://github.com/eulerto/wal2json) output plugin)
+    2. Passing database changes to a [Write Ahead Log Realtime Unified Security (WALRUS)](https://github.com/supabase/walrus) PostgresSQL function and receiving a list of authorized subscribers depending on Row Level Security (RLS) policies
+    3. Converting the changes into JSON
+    4. Broadcasting to authorized subscribers over WebSockets
 
     ## Why not just use PostgreSQL's `NOTIFY`?
 

--- a/apps/docs/pages/reference/self-hosting-realtime/[...slug].tsx
+++ b/apps/docs/pages/reference/self-hosting-realtime/[...slug].tsx
@@ -13,7 +13,7 @@ export default function JSReference(props) {
 }
 
 export async function getStaticProps({ params }: { params: { slug: string[] } }) {
-  return handleRefStaticProps(sections, params, '/self-hosting-auth', '/self-hosting-auth')
+  return handleRefStaticProps(sections, params, '/self-hosting-realtime', '/self-hosting-realtime')
 }
 
 export function getStaticPaths() {

--- a/spec/common-self-hosting-realtime-sections.json
+++ b/spec/common-self-hosting-realtime-sections.json
@@ -5,5 +5,24 @@
     "slug": "introduction",
     "summary": "Introduction",
     "type": "markdown"
+  },
+  {
+    "title": "Configuration",
+    "items": [
+      {
+        "id": "port",
+        "title": "Port",
+        "slug": "port",
+        "summary": "The port to connect your client/listeners.",
+        "type": "operation"
+      },
+      {
+        "id": "replication-mode",
+        "title": "Replication Mode",
+        "slug": "replication_mode",
+        "summary": "Connect to the database either through IPv4 or IPv6. Disregarded if database host is an IP address (e.g., `127.0.0.1`) and recommended if database host is a name (e.g., `db.abcd.supabase.co`) to prevent potential non-existent domain (NXDOMAIN) errors.",
+        "type": "operation"
+      }
+    ]
   }
 ]

--- a/spec/common-self-hosting-realtime-sections.json
+++ b/spec/common-self-hosting-realtime-sections.json
@@ -5,24 +5,5 @@
     "slug": "introduction",
     "summary": "Introduction",
     "type": "markdown"
-  },
-  {
-    "title": "Configuration",
-    "items": [
-      {
-        "id": "port",
-        "title": "Port",
-        "slug": "port",
-        "summary": "The port to connect your client/listeners.",
-        "type": "operation"
-      },
-      {
-        "id": "replication-mode",
-        "title": "Replication Mode",
-        "slug": "replication_mode",
-        "summary": "Connect to the database either through IPv4 or IPv6. Disregarded if database host is an IP address (e.g., `127.0.0.1`) and recommended if database host is a name (e.g., `db.abcd.supabase.co`) to prevent potential non-existent domain (NXDOMAIN) errors.",
-        "type": "operation"
-      }
-    ]
   }
 ]


### PR DESCRIPTION
## What kind of change does this PR introduce?
Fix Self-Hosting Realtime docs intro: https://docs-git-docs-realtime-server-supabase.vercel.app/docs/reference/self-hosting-realtime/introduction

## What is the current behavior?
https://supabase.com/docs/reference/self-hosting-realtime/introduction is showing the Self-Hosting Auth intro

![Screen Shot 2022-12-12 at 6 12 30 PM](https://user-images.githubusercontent.com/7026076/207209177-1df7515b-4965-4a2d-b71d-d8ba2e1087cb.png)