### PR TITLE
Redirect /docs/reference to /docs

### DIFF
--- a/apps/www/data/Footer.json
+++ b/apps/www/data/Footer.json
@@ -73,10 +73,6 @@
         "url": "/docs"
       },
       {
-        "text": "API Reference",
-        "url": "/docs/reference"
-      },
-      {
         "text": "Changelog",
         "url": "/changelog"
       },

--- a/apps/www/lib/redirects.js
+++ b/apps/www/lib/redirects.js
@@ -599,7 +599,7 @@ module.exports = [
   {
     permanent: true,
     source: '/docs/reference/javascript/supabase-client',
-    destination: '/docs',
+    destination: '/docs#reference-documentation',
   },
   {
     permanent: true,
@@ -1331,7 +1331,7 @@ module.exports = [
   {
     permanent: true,
     source: '/docs/guides/client-libraries',
-    destination: '/docs',
+    destination: '/docs#reference-documentation',
   },
   {
     permanent: true,
@@ -1598,6 +1598,6 @@ module.exports = [
   {
     permanent: true,
     source: '/docs/reference',
-    destination: '/docs',
+    destination: '/docs#reference-documentation',
   },
 ]

--- a/apps/www/lib/redirects.js
+++ b/apps/www/lib/redirects.js
@@ -599,7 +599,7 @@ module.exports = [
   {
     permanent: true,
     source: '/docs/reference/javascript/supabase-client',
-    destination: '/docs/reference',
+    destination: '/docs',
   },
   {
     permanent: true,
@@ -1331,7 +1331,7 @@ module.exports = [
   {
     permanent: true,
     source: '/docs/guides/client-libraries',
-    destination: '/docs/reference',
+    destination: '/docs',
   },
   {
     permanent: true,
@@ -1594,5 +1594,10 @@ module.exports = [
     permanent: true,
     source: '/docs/company/sla',
     destination: '/sla',
+  },
+  {
+    permanent: true,
+    source: '/docs/reference',
+    destination: '/docs',
   },
 ]


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Add a redirect for `/docs/reference` to `/docs#reference-documentation` as we don't have a reference docs landing page anymore
- Remove API Reference link in footer
