### PR TITLE
docs: platform nav item 404

### DIFF
--- a/apps/docs/components/Navigation/NavigationMenu/HomeMenu.tsx
+++ b/apps/docs/components/Navigation/NavigationMenu/HomeMenu.tsx
@@ -55,7 +55,7 @@ const home = [
     {
       label: 'Platform',
       icon: '/img/icons/menu/platform',
-      href: '/guides/hosting/platform',
+      href: '/guides/platform',
       level: 'platform',
     },
     {


### PR DESCRIPTION
## What kind of change does this PR introduce?

[Supabase docs](https://supabase.com/docs/)

## What is the current behavior?

When you click on the platform link on the nav you go to a 404 page:


https://user-images.githubusercontent.com/22655069/207367456-a35d4b2d-7178-43ea-adfb-4bb5cc6e07c8.mov



## What is the new behavior?

Changed the href and page appears.

