### PR TITLE
fix: add dropdown option to delete all factors for a user

### DIFF
--- a/studio/components/interfaces/Auth/Users/UserDropdown.tsx
+++ b/studio/components/interfaces/Auth/Users/UserDropdown.tsx
@@ -180,6 +180,10 @@ const UserDropdown: FC<Props> = ({ user, canRemoveUser }) => {
                   Remove MFA factors
                 </Dropdown.Item>
               </Tooltip.Trigger>
+              {/* 
+                [Joshen] Deleting MFA factors should be different ABAC perms i think
+                 need to double check with KM / anyone familiar with ABAC 
+              */}
               {!canRemoveUser && (
                 <Tooltip.Content side="bottom">
                   <Tooltip.Arrow className="radix-tooltip-arrow" />

--- a/studio/components/interfaces/Auth/Users/UserDropdown.tsx
+++ b/studio/components/interfaces/Auth/Users/UserDropdown.tsx
@@ -3,7 +3,7 @@ import { observer } from 'mobx-react-lite'
 import * as Tooltip from '@radix-ui/react-tooltip'
 import { Button, Dropdown, Divider, IconTrash, IconMail, IconMoreHorizontal } from 'ui'
 
-import { useStore } from 'hooks'
+import { useFlag, useStore } from 'hooks'
 import { timeout } from 'lib/helpers'
 import { post, delete_ } from 'lib/common/fetch'
 import { API_URL } from 'lib/constants'
@@ -17,6 +17,7 @@ interface Props {
 }
 
 const UserDropdown: FC<Props> = ({ user, canRemoveUser }) => {
+  const showDeleteFactorsDropdown = useFlag('mfaSso')
   const PageState: any = useContext(PageContext)
   const { ui } = useStore()
   const [loading, setLoading] = useState<boolean>(false)
@@ -194,32 +195,34 @@ const UserDropdown: FC<Props> = ({ user, canRemoveUser }) => {
               </Tooltip.Content>
             )}
           </Tooltip.Root>
-          <Tooltip.Root delayDuration={0}>
-            <Tooltip.Trigger className="w-full">
-              <Dropdown.Item
-                onClick={handleDeleteFactors}
-                icon={<IconTrash size="tiny" />}
-                disabled={!canRemoveUser}
-              >
-                Delete factors
-              </Dropdown.Item>
-            </Tooltip.Trigger>
-            {!canRemoveUser && (
-              <Tooltip.Content side="bottom">
-                <Tooltip.Arrow className="radix-tooltip-arrow" />
-                <div
-                  className={[
-                    'rounded bg-scale-100 py-1 px-2 leading-none shadow',
-                    'border border-scale-200',
-                  ].join(' ')}
+          {showDeleteFactorsDropdown && (
+            <Tooltip.Root delayDuration={0}>
+              <Tooltip.Trigger className="w-full">
+                <Dropdown.Item
+                  onClick={handleDeleteFactors}
+                  icon={<IconTrash size="tiny" />}
+                  disabled={!canRemoveUser}
                 >
-                  <span className="text-xs text-scale-1200">
-                    You need additional permissions to remove a user's authentication factors.
-                  </span>
-                </div>
-              </Tooltip.Content>
-            )}
-          </Tooltip.Root>
+                  Delete factors
+                </Dropdown.Item>
+              </Tooltip.Trigger>
+              {!canRemoveUser && (
+                <Tooltip.Content side="bottom">
+                  <Tooltip.Arrow className="radix-tooltip-arrow" />
+                  <div
+                    className={[
+                      'rounded bg-scale-100 py-1 px-2 leading-none shadow',
+                      'border border-scale-200',
+                    ].join(' ')}
+                  >
+                    <span className="text-xs text-scale-1200">
+                      You need additional permissions to remove a user's authentication factors.
+                    </span>
+                  </div>
+                </Tooltip.Content>
+              )}
+            </Tooltip.Root>
+          )}
         </>
       }
     >

--- a/studio/components/interfaces/Auth/Users/UserDropdown.tsx
+++ b/studio/components/interfaces/Auth/Users/UserDropdown.tsx
@@ -120,6 +120,33 @@ const UserDropdown: FC<Props> = ({ user, canRemoveUser }) => {
     })
   }
 
+  async function handleDeleteFactors() {
+    await timeout(200)
+
+    confirmAlert({
+      title: 'Confirm to delete',
+      message: `This is permanent! Are you sure you want to delete the user's factors?`,
+      onAsyncConfirm: async () => {
+        setLoading(true)
+        const response = await delete_(
+          `${API_URL}/auth/${PageState.projectRef}/users/${user.id}/factors`
+        )
+        if (response.error) {
+          ui.setNotification({
+            category: 'error',
+            message: `Failed to delete factors: ${response.error.message}`,
+          })
+        } else {
+          ui.setNotification({
+            category: 'success',
+            message: "Successfully deleted the user's factors",
+          })
+        }
+        setLoading(false)
+      },
+    })
+  }
+
   return (
     <Dropdown
       size="medium"
@@ -162,6 +189,32 @@ const UserDropdown: FC<Props> = ({ user, canRemoveUser }) => {
                 >
                   <span className="text-xs text-scale-1200">
                     You need additional permissions to delete users
+                  </span>
+                </div>
+              </Tooltip.Content>
+            )}
+          </Tooltip.Root>
+          <Tooltip.Root delayDuration={0}>
+            <Tooltip.Trigger className="w-full">
+              <Dropdown.Item
+                onClick={handleDeleteFactors}
+                icon={<IconTrash size="tiny" />}
+                disabled={!canRemoveUser}
+              >
+                Delete factors
+              </Dropdown.Item>
+            </Tooltip.Trigger>
+            {!canRemoveUser && (
+              <Tooltip.Content side="bottom">
+                <Tooltip.Arrow className="radix-tooltip-arrow" />
+                <div
+                  className={[
+                    'rounded bg-scale-100 py-1 px-2 leading-none shadow',
+                    'border border-scale-200',
+                  ].join(' ')}
+                >
+                  <span className="text-xs text-scale-1200">
+                    You need additional permissions to remove a user's authentication factors.
                   </span>
                 </div>
               </Tooltip.Content>

--- a/studio/components/interfaces/Auth/Users/UserDropdown.tsx
+++ b/studio/components/interfaces/Auth/Users/UserDropdown.tsx
@@ -1,7 +1,7 @@
 import { FC, useContext, useState } from 'react'
 import { observer } from 'mobx-react-lite'
 import * as Tooltip from '@radix-ui/react-tooltip'
-import { Button, Dropdown, Divider, IconTrash, IconMail, IconMoreHorizontal } from 'ui'
+import { Button, Dropdown, IconTrash, IconMail, IconMoreHorizontal } from 'ui'
 
 import { useFlag, useStore } from 'hooks'
 import { timeout } from 'lib/helpers'
@@ -203,7 +203,7 @@ const UserDropdown: FC<Props> = ({ user, canRemoveUser }) => {
                   icon={<IconTrash size="tiny" />}
                   disabled={!canRemoveUser}
                 >
-                  Delete factors
+                  Remove MFA factors
                 </Dropdown.Item>
               </Tooltip.Trigger>
               {!canRemoveUser && (

--- a/studio/components/interfaces/Auth/Users/UserDropdown.tsx
+++ b/studio/components/interfaces/Auth/Users/UserDropdown.tsx
@@ -126,7 +126,7 @@ const UserDropdown: FC<Props> = ({ user, canRemoveUser }) => {
 
     confirmAlert({
       title: 'Confirm to delete',
-      message: `This is permanent! Are you sure you want to delete the user's factors?`,
+      message: `This is permanent! Are you sure you want to delete the user's MFA factors?`,
       onAsyncConfirm: async () => {
         setLoading(true)
         const response = await delete_(

--- a/studio/components/interfaces/Auth/Users/UserDropdown.tsx
+++ b/studio/components/interfaces/Auth/Users/UserDropdown.tsx
@@ -1,7 +1,7 @@
 import { FC, useContext, useState } from 'react'
 import { observer } from 'mobx-react-lite'
 import * as Tooltip from '@radix-ui/react-tooltip'
-import { Button, Dropdown, IconTrash, IconMail, IconMoreHorizontal } from 'ui'
+import { Button, Dropdown, IconTrash, IconMail, IconMoreHorizontal, IconShieldOff } from 'ui'
 
 import { useFlag, useStore } from 'hooks'
 import { timeout } from 'lib/helpers'
@@ -169,6 +169,34 @@ const UserDropdown: FC<Props> = ({ user, canRemoveUser }) => {
             </Dropdown.Item>
           ) : null}
           <Dropdown.Separator />
+          {showDeleteFactorsDropdown && (
+            <Tooltip.Root delayDuration={0}>
+              <Tooltip.Trigger className="w-full">
+                <Dropdown.Item
+                  onClick={handleDeleteFactors}
+                  icon={<IconShieldOff size="tiny" />}
+                  disabled={!canRemoveUser}
+                >
+                  Remove MFA factors
+                </Dropdown.Item>
+              </Tooltip.Trigger>
+              {!canRemoveUser && (
+                <Tooltip.Content side="bottom">
+                  <Tooltip.Arrow className="radix-tooltip-arrow" />
+                  <div
+                    className={[
+                      'rounded bg-scale-100 py-1 px-2 leading-none shadow',
+                      'border border-scale-200',
+                    ].join(' ')}
+                  >
+                    <span className="text-xs text-scale-1200">
+                      You need additional permissions to remove a user's authentication factors.
+                    </span>
+                  </div>
+                </Tooltip.Content>
+              )}
+            </Tooltip.Root>
+          )}
           <Tooltip.Root delayDuration={0}>
             <Tooltip.Trigger className="w-full">
               <Dropdown.Item
@@ -195,34 +223,6 @@ const UserDropdown: FC<Props> = ({ user, canRemoveUser }) => {
               </Tooltip.Content>
             )}
           </Tooltip.Root>
-          {showDeleteFactorsDropdown && (
-            <Tooltip.Root delayDuration={0}>
-              <Tooltip.Trigger className="w-full">
-                <Dropdown.Item
-                  onClick={handleDeleteFactors}
-                  icon={<IconTrash size="tiny" />}
-                  disabled={!canRemoveUser}
-                >
-                  Remove MFA factors
-                </Dropdown.Item>
-              </Tooltip.Trigger>
-              {!canRemoveUser && (
-                <Tooltip.Content side="bottom">
-                  <Tooltip.Arrow className="radix-tooltip-arrow" />
-                  <div
-                    className={[
-                      'rounded bg-scale-100 py-1 px-2 leading-none shadow',
-                      'border border-scale-200',
-                    ].join(' ')}
-                  >
-                    <span className="text-xs text-scale-1200">
-                      You need additional permissions to remove a user's authentication factors.
-                    </span>
-                  </div>
-                </Tooltip.Content>
-              )}
-            </Tooltip.Root>
-          )}
         </>
       }
     >


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Adds a dropdown option in the authentication tab to delete all factors for a user
* API changes for the delete factors endpoint has already been added and deployed to prod 

<img width="1526" alt="image" src="https://user-images.githubusercontent.com/28647601/207536990-9d800ca4-bb0f-4c62-977d-38f2a1d039d2.png">
<img width="1523" alt="image" src="https://user-images.githubusercontent.com/28647601/207537037-fd81c239-5202-4841-b443-1b72a48a4587.png">
