### PR TITLE
docs: enabling pgnet extension

### DIFF
--- a/apps/docs/pages/guides/database/extensions/pgnet.mdx
+++ b/apps/docs/pages/guides/database/extensions/pgnet.mdx
@@ -40,7 +40,7 @@ It differs from the `http` extension in that it is asynchronous by default. This
 create extension pg_net;
 -- Note: The extension creates its own schema/namespace named "net" to avoid naming conflicts.
 
--- Example: disable the "plv8" extension
+-- Example: disable the "pg_net" extension
 drop extension if exists pg_net;
 drop schema net;
 ```

--- a/apps/docs/pages/guides/database/extensions/pgnet.mdx
+++ b/apps/docs/pages/guides/database/extensions/pgnet.mdx
@@ -36,9 +36,9 @@ It differs from the `http` extension in that it is asynchronous by default. This
 <TabPanel id="sql" label="SQL">
 
 ```sql
--- Example: enable the "pg_net" extension
-create schema if not exists net;
-create extension pg_net with schema net;
+-- Example: enable the "pg_net" extension.
+create extension pg_net;
+-- Note: The extension creates its own schema/namespace named "net" to avoid naming conflicts.
 
 -- Example: disable the "plv8" extension
 drop extension if exists pg_net;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase docs - [pgnet](https://supabase.com/docs/guides/database/extensions/pgnet#enable-the-extension)

## What is the current behavior?

The example in the SQL tab is incorrect and comes back with an error when exected:

<img width="844" alt="Screenshot 2022-12-15 at 08 58 54" src="https://user-images.githubusercontent.com/22655069/207817799-43cca0e9-5203-459f-baf2-4a90bad76ba9.png">


## What is the new behavior?

Changed the example and added a note about schema creation:

<img width="835" alt="Screenshot 2022-12-15 at 09 05 21" src="https://user-images.githubusercontent.com/22655069/207818040-35af998f-1c04-418d-949d-d24d2b080a72.png">



## Additional context

Closes #10986 
