### PR TITLE
feat(hCaptcha): captcha for subscription/payment method changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63417,7 +63417,7 @@
         "uniforms-bootstrap4": "^3.6.2",
         "uniforms-bridge-json-schema": "^3.6.2",
         "uuid": "^8.3.2",
-        "valtio": "*",
+        "valtio": "^1.7.6",
         "yup": "^0.32.11",
         "yup-password": "^0.2.2",
         "zxcvbn": "^4.4.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -37607,6 +37607,7 @@
         "uniforms-bootstrap4": "^3.6.2",
         "uniforms-bridge-json-schema": "^3.6.2",
         "uuid": "^8.3.2",
+        "valtio": "^1.7.6",
         "yup": "^0.32.11",
         "yup-password": "^0.2.2",
         "zxcvbn": "^4.4.2"
@@ -37829,6 +37830,11 @@
       "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-9.3.1.tgz",
       "integrity": "sha512-/Yvsd2D7miYB4HLJ3hOOS0+vnowQpaT75FsHzr/y5M9P4q9bwa7RcbW2YdH6KZBn8ceLbKGnHxMZ1CHliGHUFw=="
     },
+    "studio/node_modules/proxy-compare": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-2.3.0.tgz",
+      "integrity": "sha512-c3L2CcAi7f7pvlD0D7xsF+2CQIW8C3HaYx2Pfgq8eA4HAl3GAH6/dVYsyBbYF/0XJs2ziGLrzmz5fmzPm6A0pQ=="
+    },
     "studio/node_modules/react-resize-detector": {
       "version": "6.7.8",
       "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-6.7.8.tgz",
@@ -37887,6 +37893,46 @@
       },
       "engines": {
         "node": ">=4.2.0"
+      }
+    },
+    "studio/node_modules/valtio": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/valtio/-/valtio-1.7.6.tgz",
+      "integrity": "sha512-zsGrCCYOIpy8egQxftduFyJusF/BMu3CganhHKUOE/I6t6V6yA1MDfZZkrYoWYCGkC3rSBYcIHEEsoYQM9lV2w==",
+      "dependencies": {
+        "proxy-compare": "2.3.0",
+        "use-sync-external-store": "1.2.0"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@babel/helper-module-imports": ">=7.12",
+        "@babel/types": ">=7.13",
+        "aslemammad-vite-plugin-macro": ">=1.0.0-alpha.1",
+        "babel-plugin-macros": ">=3.0",
+        "react": ">=16.8",
+        "vite": ">=2.8.6"
+      },
+      "peerDependenciesMeta": {
+        "@babel/helper-module-imports": {
+          "optional": true
+        },
+        "@babel/types": {
+          "optional": true
+        },
+        "aslemammad-vite-plugin-macro": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
       }
     },
     "studio/node_modules/webpack-bundle-analyzer": {
@@ -63371,6 +63417,7 @@
         "uniforms-bootstrap4": "^3.6.2",
         "uniforms-bridge-json-schema": "^3.6.2",
         "uuid": "^8.3.2",
+        "valtio": "*",
         "yup": "^0.32.11",
         "yup-password": "^0.2.2",
         "zxcvbn": "^4.4.2"
@@ -63521,6 +63568,11 @@
           "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-9.3.1.tgz",
           "integrity": "sha512-/Yvsd2D7miYB4HLJ3hOOS0+vnowQpaT75FsHzr/y5M9P4q9bwa7RcbW2YdH6KZBn8ceLbKGnHxMZ1CHliGHUFw=="
         },
+        "proxy-compare": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-2.3.0.tgz",
+          "integrity": "sha512-c3L2CcAi7f7pvlD0D7xsF+2CQIW8C3HaYx2Pfgq8eA4HAl3GAH6/dVYsyBbYF/0XJs2ziGLrzmz5fmzPm6A0pQ=="
+        },
         "react-resize-detector": {
           "version": "6.7.8",
           "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-6.7.8.tgz",
@@ -63563,6 +63615,15 @@
           "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
           "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
           "dev": true
+        },
+        "valtio": {
+          "version": "1.7.6",
+          "resolved": "https://registry.npmjs.org/valtio/-/valtio-1.7.6.tgz",
+          "integrity": "sha512-zsGrCCYOIpy8egQxftduFyJusF/BMu3CganhHKUOE/I6t6V6yA1MDfZZkrYoWYCGkC3rSBYcIHEEsoYQM9lV2w==",
+          "requires": {
+            "proxy-compare": "2.3.0",
+            "use-sync-external-store": "1.2.0"
+          }
         },
         "webpack-bundle-analyzer": {
           "version": "4.3.0",

--- a/studio/components/interfaces/Billing/AddNewPaymentMethodModal/AddNewPaymentMethodModal.tsx
+++ b/studio/components/interfaces/Billing/AddNewPaymentMethodModal/AddNewPaymentMethodModal.tsx
@@ -36,6 +36,7 @@ const AddNewPaymentMethodModal: FC<Props> = ({ visible, returnUrl, onCancel }) =
         }
 
         await setupIntent(token ?? undefined)
+        resetCaptcha()
       }
     }
 
@@ -59,17 +60,15 @@ const AddNewPaymentMethodModal: FC<Props> = ({ visible, returnUrl, onCancel }) =
       hcaptchaToken,
     })
 
-    resetCaptcha()
-
     if (intent.error) {
       return ui.setNotification({
         category: 'error',
         message: intent.error.message,
         error: intent.error,
       })
+    } else {
+      setIntent(intent)
     }
-
-    captchaRef.current?.resetCaptcha()
   }
 
   const options = {
@@ -77,15 +76,9 @@ const AddNewPaymentMethodModal: FC<Props> = ({ visible, returnUrl, onCancel }) =
     appearance: { theme: 'night', labels: 'floating' },
   } as any
 
+  // Needs to be re-rendered properly for hCaptcha to work seamlessly
   return (
-    <Modal
-      hideFooter
-      size="medium"
-      visible={visible}
-      header="Add new payment method"
-      onCancel={onCancel}
-      className="PAYMENT"
-    >
+    <>
       <HCaptcha
         ref={captchaRef}
         sitekey={process.env.NEXT_PUBLIC_HCAPTCHA_SITE_KEY!}
@@ -98,18 +91,27 @@ const AddNewPaymentMethodModal: FC<Props> = ({ visible, returnUrl, onCancel }) =
           setCaptchaToken(null)
         }}
       />
-      <div className="space-y-4 py-4">
-        {intent !== undefined ? (
-          <Elements stripe={stripePromise} options={options}>
-            <AddPaymentMethodForm returnUrl={returnUrl} onCancel={onCancel} />
-          </Elements>
-        ) : (
-          <div className="flex w-full items-center justify-center py-20">
-            <IconLoader size={16} className="animate-spin" />
-          </div>
-        )}
-      </div>
-    </Modal>
+      <Modal
+        hideFooter
+        size="medium"
+        visible={visible}
+        header="Add new payment method"
+        onCancel={onCancel}
+        className="PAYMENT"
+      >
+        <div className="space-y-4 py-4">
+          {intent !== undefined ? (
+            <Elements stripe={stripePromise} options={options}>
+              <AddPaymentMethodForm returnUrl={returnUrl} onCancel={onCancel} />
+            </Elements>
+          ) : (
+            <div className="flex w-full items-center justify-center py-20">
+              <IconLoader size={16} className="animate-spin" />
+            </div>
+          )}
+        </div>
+      </Modal>
+    </>
   )
 }
 

--- a/studio/components/interfaces/Billing/AddNewPaymentMethodModal/AddNewPaymentMethodModal.tsx
+++ b/studio/components/interfaces/Billing/AddNewPaymentMethodModal/AddNewPaymentMethodModal.tsx
@@ -104,6 +104,8 @@ const AddNewPaymentMethodModal: FC<Props> = ({ visible, returnUrl, onCancel }) =
         onVerify={(token) => {
           setCaptchaToken(token)
         }}
+        onClose={() => console.log('onclose')}
+        onOpen={() => console.log('onopen')}
         onExpire={() => {
           setCaptchaToken(null)
         }}

--- a/studio/components/interfaces/Billing/AddNewPaymentMethodModal/AddNewPaymentMethodModal.tsx
+++ b/studio/components/interfaces/Billing/AddNewPaymentMethodModal/AddNewPaymentMethodModal.tsx
@@ -76,7 +76,6 @@ const AddNewPaymentMethodModal: FC<Props> = ({ visible, returnUrl, onCancel }) =
     appearance: { theme: 'night', labels: 'floating' },
   } as any
 
-  // Needs to be re-rendered properly for hCaptcha to work seamlessly
   return (
     <>
       <HCaptcha
@@ -84,6 +83,7 @@ const AddNewPaymentMethodModal: FC<Props> = ({ visible, returnUrl, onCancel }) =
         sitekey={process.env.NEXT_PUBLIC_HCAPTCHA_SITE_KEY!}
         size="invisible"
         onLoad={onCaptchaLoaded}
+        onError={(err) => console.error(err)}
         onVerify={(token) => {
           setCaptchaToken(token)
         }}

--- a/studio/components/interfaces/Billing/AddNewPaymentMethodModal/AddNewPaymentMethodModal.tsx
+++ b/studio/components/interfaces/Billing/AddNewPaymentMethodModal/AddNewPaymentMethodModal.tsx
@@ -34,7 +34,7 @@ const AddNewPaymentMethodModal: FC<Props> = ({ visible, returnUrl, onCancel }) =
   useEffect(() => {
     const loadPaymentForm = async () => {
       console.log('load payment form', { visible, captchaLoaded, captchaRef })
-      if (visible && captchaLoaded && captchaRef) {
+      if (visible && captchaRef && captchaLoaded) {
         let token = captchaToken
         if (!token) {
           const captchaResponse = await captchaRef.execute({ async: true })
@@ -49,7 +49,7 @@ const AddNewPaymentMethodModal: FC<Props> = ({ visible, returnUrl, onCancel }) =
     }
 
     loadPaymentForm()
-  }, [visible, captchaLoaded, captchaRef])
+  }, [visible, captchaRef, captchaLoaded])
 
   const onCaptchaLoaded = () => {
     console.log('on captcha loaded')
@@ -95,19 +95,21 @@ const AddNewPaymentMethodModal: FC<Props> = ({ visible, returnUrl, onCancel }) =
       onCancel={onCancel}
       className="PAYMENT"
     >
-      <HCaptcha
-        ref={captchaRefCallback}
-        sitekey={process.env.NEXT_PUBLIC_HCAPTCHA_SITE_KEY!}
-        size="invisible"
-        onLoad={onCaptchaLoaded}
-        onError={(err) => console.error(err)}
-        onVerify={(token) => {
-          setCaptchaToken(token)
-        }}
-        onExpire={() => {
-          setCaptchaToken(null)
-        }}
-      />
+      {visible && (
+        <HCaptcha
+          ref={captchaRefCallback}
+          sitekey={process.env.NEXT_PUBLIC_HCAPTCHA_SITE_KEY!}
+          size="invisible"
+          onError={(err) => console.error(err)}
+          onLoad={() => onCaptchaLoaded()}
+          onVerify={(token) => {
+            setCaptchaToken(token)
+          }}
+          onExpire={() => {
+            setCaptchaToken(null)
+          }}
+        />
+      )}
       <div className="space-y-4 py-4">
         {intent !== undefined ? (
           <Elements stripe={stripePromise} options={options}>

--- a/studio/components/interfaces/Billing/AddNewPaymentMethodModal/AddNewPaymentMethodModal.tsx
+++ b/studio/components/interfaces/Billing/AddNewPaymentMethodModal/AddNewPaymentMethodModal.tsx
@@ -1,13 +1,14 @@
-import { FC, useCallback, useEffect, useRef, useState } from 'react'
-import { IconLoader, Modal } from 'ui'
+import HCaptcha from '@hcaptcha/react-hcaptcha'
 import { loadStripe } from '@stripe/stripe-js'
 import { Elements } from '@stripe/react-stripe-js'
+import { FC, useCallback, useEffect, useState } from 'react'
 
+import { Modal } from 'ui'
 import { useStore } from 'hooks'
+import { useIsHCaptchaLoaded } from 'stores/hcaptcha-loaded-store'
 import { post } from 'lib/common/fetch'
 import { API_URL, STRIPE_PUBLIC_KEY } from 'lib/constants'
 import AddPaymentMethodForm from './AddPaymentMethodForm'
-import HCaptcha from '@hcaptcha/react-hcaptcha'
 
 interface Props {
   visible: boolean
@@ -21,7 +22,7 @@ const AddNewPaymentMethodModal: FC<Props> = ({ visible, returnUrl, onCancel }) =
   const { ui } = useStore()
   const [intent, setIntent] = useState<any>()
 
-  const [captchaLoaded, setCaptchaLoaded] = useState(false)
+  const captchaLoaded = useIsHCaptchaLoaded()
 
   const [captchaToken, setCaptchaToken] = useState<string | null>(null)
   const [captchaRef, setCaptchaRef] = useState<HCaptcha | null>(null)
@@ -29,18 +30,6 @@ const AddNewPaymentMethodModal: FC<Props> = ({ visible, returnUrl, onCancel }) =
   const captchaRefCallback = useCallback((node) => {
     setCaptchaRef(node)
   }, [])
-
-  /**
-   * We want to load the Stripe payment elements only after successfully verifying captcha.
-   * To execute hCaptcha when displaying the modal, we need to ensure hCaptcha is actually loaded.
-   * The `onLoad` method from hCaptcha is only executed ONCE for the entire application, so we cannot listen to it.
-   * One way to find out if hCaptcha has been initialized, is checking `window.hcaptcha`. When checking via window,
-   * we know if the hCaptcha has been initialized from a different part of the app or through this component.
-   */
-  useEffect(() => {
-    setCaptchaLoaded(true)
-    // @ts-ignore
-  }, [window.hcaptcha])
 
   useEffect(() => {
     const loadPaymentForm = async () => {
@@ -118,7 +107,7 @@ const AddNewPaymentMethodModal: FC<Props> = ({ visible, returnUrl, onCancel }) =
         onCancel={onLocalCancel}
         className="PAYMENT"
       >
-        <div className="space-y-4 py-4">
+        <div className="py-4 space-y-4">
           <Elements stripe={stripePromise} options={options}>
             <AddPaymentMethodForm returnUrl={returnUrl} onCancel={onLocalCancel} />
           </Elements>

--- a/studio/components/interfaces/Billing/AddNewPaymentMethodModal/AddNewPaymentMethodModal.tsx
+++ b/studio/components/interfaces/Billing/AddNewPaymentMethodModal/AddNewPaymentMethodModal.tsx
@@ -27,13 +27,14 @@ const AddNewPaymentMethodModal: FC<Props> = ({ visible, returnUrl, onCancel }) =
   const [captchaRef, setCaptchaRef] = useState<HCaptcha | null>(null)
 
   const captchaRefCallback = useCallback((node) => {
+    console.log({ node })
     setCaptchaRef(node)
   }, [])
 
   useEffect(() => {
     const loadPaymentForm = async () => {
+      console.log('load payment form', { visible, captchaLoaded, captchaRef })
       if (visible && captchaLoaded && captchaRef) {
-        console.log('load payment form', { visible, captchaLoaded })
         let token = captchaToken
         if (!token) {
           const captchaResponse = await captchaRef.execute({ async: true })

--- a/studio/components/interfaces/Billing/AddNewPaymentMethodModal/AddNewPaymentMethodModal.tsx
+++ b/studio/components/interfaces/Billing/AddNewPaymentMethodModal/AddNewPaymentMethodModal.tsx
@@ -104,8 +104,7 @@ const AddNewPaymentMethodModal: FC<Props> = ({ visible, returnUrl, onCancel }) =
         onVerify={(token) => {
           setCaptchaToken(token)
         }}
-        onClose={() => console.log('onclose')}
-        onOpen={() => console.log('onopen')}
+        onClose={onLocalCancel}
         onExpire={() => {
           setCaptchaToken(null)
         }}

--- a/studio/components/interfaces/Billing/AddNewPaymentMethodModal/AddNewPaymentMethodModal.tsx
+++ b/studio/components/interfaces/Billing/AddNewPaymentMethodModal/AddNewPaymentMethodModal.tsx
@@ -35,9 +35,14 @@ const AddNewPaymentMethodModal: FC<Props> = ({ visible, returnUrl, onCancel }) =
     const loadPaymentForm = async () => {
       if (visible && captchaRef && captchaLoaded) {
         let token = captchaToken
-        if (!token) {
-          const captchaResponse = await captchaRef.execute({ async: true })
-          token = captchaResponse?.response ?? null
+
+        try {
+          if (!token) {
+            const captchaResponse = await captchaRef.execute({ async: true })
+            token = captchaResponse?.response ?? null
+          }
+        } catch (error) {
+          return
         }
 
         await setupIntent(token ?? undefined)

--- a/studio/components/interfaces/Billing/AddNewPaymentMethodModal/AddNewPaymentMethodModal.tsx
+++ b/studio/components/interfaces/Billing/AddNewPaymentMethodModal/AddNewPaymentMethodModal.tsx
@@ -94,14 +94,9 @@ const AddNewPaymentMethodModal: FC<Props> = ({ visible, returnUrl, onCancel }) =
   }
 
   return (
-    <Modal
-      hideFooter
-      size="medium"
-      visible={visible}
-      header="Add new payment method"
-      onCancel={onLocalCancel}
-      className="PAYMENT"
-    >
+    // We cant display the hCaptcha in the modal, as the modal auto-closes when clicking the captcha
+    // So we only show the modal if the captcha has been executed successfully (intent loaded)
+    <>
       <HCaptcha
         ref={captchaRefCallback}
         sitekey={process.env.NEXT_PUBLIC_HCAPTCHA_SITE_KEY!}
@@ -113,18 +108,22 @@ const AddNewPaymentMethodModal: FC<Props> = ({ visible, returnUrl, onCancel }) =
           setCaptchaToken(null)
         }}
       />
-      <div className="space-y-4 py-4">
-        {intent !== undefined ? (
+
+      <Modal
+        hideFooter
+        size="medium"
+        visible={visible && intent !== undefined}
+        header="Add new payment method"
+        onCancel={onLocalCancel}
+        className="PAYMENT"
+      >
+        <div className="space-y-4 py-4">
           <Elements stripe={stripePromise} options={options}>
             <AddPaymentMethodForm returnUrl={returnUrl} onCancel={onLocalCancel} />
           </Elements>
-        ) : (
-          <div className="flex w-full items-center justify-center py-20">
-            <IconLoader size={16} className="animate-spin" />
-          </div>
-        )}
-      </div>
-    </Modal>
+        </div>
+      </Modal>
+    </>
   )
 }
 

--- a/studio/components/interfaces/Billing/AddNewPaymentMethodModal/AddNewPaymentMethodModal.tsx
+++ b/studio/components/interfaces/Billing/AddNewPaymentMethodModal/AddNewPaymentMethodModal.tsx
@@ -27,14 +27,19 @@ const AddNewPaymentMethodModal: FC<Props> = ({ visible, returnUrl, onCancel }) =
   const captchaRef = useRef<HCaptcha>(null)
 
   useEffect(() => {
-    if (visible && captchaLoaded) {
-      let token = captchaToken
-      if (!token) {
-        captchaRef.current?.execute({ async: true }).then((captchaResponse) => {
-          return setupIntent(captchaResponse?.response ?? undefined)
-        })
+    const loadPaymentForm = async () => {
+      if (visible && captchaLoaded) {
+        let token = captchaToken
+        if (!token) {
+          const captchaResponse = await captchaRef.current?.execute({ async: true })
+          token = captchaResponse?.response ?? null
+        }
+
+        await setupIntent(token ?? undefined)
       }
     }
+
+    loadPaymentForm()
   }, [visible, captchaLoaded])
 
   const onCaptchaLoaded = () => {

--- a/studio/components/interfaces/Billing/AddNewPaymentMethodModal/AddNewPaymentMethodModal.tsx
+++ b/studio/components/interfaces/Billing/AddNewPaymentMethodModal/AddNewPaymentMethodModal.tsx
@@ -27,9 +27,13 @@ const AddNewPaymentMethodModal: FC<Props> = ({ visible, returnUrl, onCancel }) =
   const [captchaRef, setCaptchaRef] = useState<HCaptcha | null>(null)
 
   const captchaRefCallback = useCallback((node) => {
-    console.log({ node })
     setCaptchaRef(node)
   }, [])
+
+  useEffect(() => {
+    setCaptchaLoaded(true)
+    // @ts-ignore
+  }, [window.hcaptcha])
 
   useEffect(() => {
     const loadPaymentForm = async () => {
@@ -50,11 +54,6 @@ const AddNewPaymentMethodModal: FC<Props> = ({ visible, returnUrl, onCancel }) =
 
     loadPaymentForm()
   }, [visible, captchaRef, captchaLoaded])
-
-  const onCaptchaLoaded = () => {
-    console.log('on captcha loaded')
-    setCaptchaLoaded(true)
-  }
 
   const resetCaptcha = () => {
     console.log('Resetting  captcha')
@@ -86,30 +85,31 @@ const AddNewPaymentMethodModal: FC<Props> = ({ visible, returnUrl, onCancel }) =
     appearance: { theme: 'night', labels: 'floating' },
   } as any
 
+  const onLocalCancel = () => {
+    setIntent(undefined)
+    return onCancel()
+  }
+
   return (
     <Modal
       hideFooter
       size="medium"
       visible={visible}
       header="Add new payment method"
-      onCancel={onCancel}
+      onCancel={onLocalCancel}
       className="PAYMENT"
     >
-      {visible && (
-        <HCaptcha
-          ref={captchaRefCallback}
-          sitekey={process.env.NEXT_PUBLIC_HCAPTCHA_SITE_KEY!}
-          size="invisible"
-          onError={(err) => console.error(err)}
-          onLoad={() => onCaptchaLoaded()}
-          onVerify={(token) => {
-            setCaptchaToken(token)
-          }}
-          onExpire={() => {
-            setCaptchaToken(null)
-          }}
-        />
-      )}
+      <HCaptcha
+        ref={captchaRefCallback}
+        sitekey={process.env.NEXT_PUBLIC_HCAPTCHA_SITE_KEY!}
+        size="invisible"
+        onVerify={(token) => {
+          setCaptchaToken(token)
+        }}
+        onExpire={() => {
+          setCaptchaToken(null)
+        }}
+      />
       <div className="space-y-4 py-4">
         {intent !== undefined ? (
           <Elements stripe={stripePromise} options={options}>

--- a/studio/components/interfaces/Billing/AddNewPaymentMethodModal/AddNewPaymentMethodModal.tsx
+++ b/studio/components/interfaces/Billing/AddNewPaymentMethodModal/AddNewPaymentMethodModal.tsx
@@ -46,6 +46,11 @@ const AddNewPaymentMethodModal: FC<Props> = ({ visible, returnUrl, onCancel }) =
     setCaptchaLoaded(true)
   }
 
+  const resetCaptcha = () => {
+    setCaptchaToken(null)
+    captchaRef.current?.resetCaptcha()
+  }
+
   const setupIntent = async (hcaptchaToken: string | undefined) => {
     setIntent(undefined)
 
@@ -54,10 +59,9 @@ const AddNewPaymentMethodModal: FC<Props> = ({ visible, returnUrl, onCancel }) =
       hcaptchaToken,
     })
 
-    if (intent.error) {
-      setCaptchaToken(null)
-      captchaRef.current?.resetCaptcha()
+    resetCaptcha()
 
+    if (intent.error) {
       return ui.setNotification({
         category: 'error',
         message: intent.error.message,
@@ -65,7 +69,7 @@ const AddNewPaymentMethodModal: FC<Props> = ({ visible, returnUrl, onCancel }) =
       })
     }
 
-    setIntent(intent)
+    captchaRef.current?.resetCaptcha()
   }
 
   const options = {

--- a/studio/components/interfaces/Billing/Billing.utils.ts
+++ b/studio/components/interfaces/Billing/Billing.utils.ts
@@ -52,7 +52,8 @@ export const formSubscriptionUpdatePayload = (
   },
   nonChangeableAddons: SubscriptionAddon[],
   selectedPaymentMethod: string,
-  region: string
+  region: string,
+  hcaptchaToken: string | undefined
 ) => {
   const { computeSize, pitrDuration, customDomains } = selectedAddons
 
@@ -78,6 +79,7 @@ export const formSubscriptionUpdatePayload = (
     addons,
     proration_date,
     payment_method: selectedPaymentMethod,
+    hcaptchaToken
   }
 }
 

--- a/studio/components/interfaces/Billing/EnterpriseUpdate.tsx
+++ b/studio/components/interfaces/Billing/EnterpriseUpdate.tsx
@@ -139,10 +139,14 @@ const EnterpriseUpdate: FC<Props> = ({
 
   // Last todo to support enterprise billing on dashboard + E2E test
   const onConfirmPayment = async () => {
-    let token = captchaToken
+    setIsSubmitting(true)
+
+    const token =
+      captchaToken ?? (await captchaRef.current?.execute({ async: true }))?.response ?? undefined
+
     if (!token) {
-      const captchaResponse = await captchaRef.current?.execute({ async: true })
-      token = captchaResponse?.response ?? null
+      setIsSubmitting(false)
+      return
     }
 
     const payload = {
@@ -157,8 +161,6 @@ const EnterpriseUpdate: FC<Props> = ({
       ),
       tier: currentSubscription.tier.price_id,
     }
-
-    setIsSubmitting(true)
     const res = await patch(`${API_URL}/projects/${projectRef}/subscription`, payload)
     resetCaptcha()
 

--- a/studio/components/interfaces/Billing/EnterpriseUpdate.tsx
+++ b/studio/components/interfaces/Billing/EnterpriseUpdate.tsx
@@ -132,6 +132,11 @@ const EnterpriseUpdate: FC<Props> = ({
     setIsRefreshingPreview(false)
   }
 
+  const resetCaptcha = () => {
+    setCaptchaToken(null)
+    captchaRef.current?.resetCaptcha()
+  }
+
   // Last todo to support enterprise billing on dashboard + E2E test
   const onConfirmPayment = async () => {
     let token = captchaToken
@@ -155,9 +160,9 @@ const EnterpriseUpdate: FC<Props> = ({
 
     setIsSubmitting(true)
     const res = await patch(`${API_URL}/projects/${projectRef}/subscription`, payload)
+    resetCaptcha()
+
     if (res?.error) {
-      setCaptchaToken(null)
-      captchaRef.current?.resetCaptcha()
       ui.setNotification({
         category: 'error',
         message: `Failed to update subscription: ${res?.error?.message}`,

--- a/studio/components/interfaces/Billing/EnterpriseUpdate.tsx
+++ b/studio/components/interfaces/Billing/EnterpriseUpdate.tsx
@@ -140,11 +140,14 @@ const EnterpriseUpdate: FC<Props> = ({
   // Last todo to support enterprise billing on dashboard + E2E test
   const onConfirmPayment = async () => {
     setIsSubmitting(true)
+    let token = captchaToken
 
-    const token =
-      captchaToken ?? (await captchaRef.current?.execute({ async: true }))?.response ?? undefined
-
-    if (!token) {
+    try {
+      if (!token) {
+        const captchaResponse = await captchaRef.current?.execute({ async: true })
+        token = captchaResponse?.response ?? null
+      }
+    } catch (error) {
       setIsSubmitting(false)
       return
     }

--- a/studio/components/interfaces/Billing/EnterpriseUpdate.tsx
+++ b/studio/components/interfaces/Billing/EnterpriseUpdate.tsx
@@ -156,6 +156,8 @@ const EnterpriseUpdate: FC<Props> = ({
     setIsSubmitting(true)
     const res = await patch(`${API_URL}/projects/${projectRef}/subscription`, payload)
     if (res?.error) {
+      setCaptchaToken(null)
+      captchaRef.current?.resetCaptcha()
       ui.setNotification({
         category: 'error',
         message: `Failed to update subscription: ${res?.error?.message}`,

--- a/studio/components/interfaces/Billing/ExitSurvey/ExitSurvey.tsx
+++ b/studio/components/interfaces/Billing/ExitSurvey/ExitSurvey.tsx
@@ -120,10 +120,12 @@ const ExitSurvey: FC<Props> = ({ freeTier, subscription, onSelectBack }) => {
         tier,
         addons,
         proration_date,
-        hcaptchaToken: token ?? undefined
+        hcaptchaToken: token ?? undefined,
       })
 
       if (res?.error) {
+        setCaptchaToken(null)
+        captchaRef.current?.resetCaptcha()
         return ui.setNotification({
           category: 'error',
           message: `Failed to cancel subscription: ${res?.error?.message}`,

--- a/studio/components/interfaces/Billing/ExitSurvey/ExitSurvey.tsx
+++ b/studio/components/interfaces/Billing/ExitSurvey/ExitSurvey.tsx
@@ -100,6 +100,11 @@ const ExitSurvey: FC<Props> = ({ freeTier, subscription, onSelectBack }) => {
     }
   }
 
+  const resetCaptcha = () => {
+    setCaptchaToken(null)
+    captchaRef.current?.resetCaptcha()
+  }
+
   const downgradeProject = async (values?: any) => {
     const downgradeMessage = values?.message ?? message
 
@@ -123,9 +128,9 @@ const ExitSurvey: FC<Props> = ({ freeTier, subscription, onSelectBack }) => {
         hcaptchaToken: token ?? undefined,
       })
 
+      resetCaptcha()
+
       if (res?.error) {
-        setCaptchaToken(null)
-        captchaRef.current?.resetCaptcha()
         return ui.setNotification({
           category: 'error',
           message: `Failed to cancel subscription: ${res?.error?.message}`,

--- a/studio/components/interfaces/Billing/ExitSurvey/ExitSurvey.tsx
+++ b/studio/components/interfaces/Billing/ExitSurvey/ExitSurvey.tsx
@@ -42,7 +42,7 @@ const ExitSurvey: FC<Props> = ({ freeTier, subscription, onSelectBack }) => {
   const [subscriptionPreview, setSubscriptionPreview] = useState<SubscriptionPreview>()
 
   // Anything above a micro instance size will involve a change in compute size
-  const willChangeComputeSize = (subscription?.addons ?? []).length > 0
+  // as downgrading back to free will bring the project back to micro
   const currentComputeSize = subscription?.addons.find((option) =>
     option.supabase_prod_id.includes('addon_instance')
   )
@@ -63,7 +63,7 @@ const ExitSurvey: FC<Props> = ({ freeTier, subscription, onSelectBack }) => {
     }
   }
 
-  const getDowngradeSuccessMessage = () => {
+  const getDowngradeRefundMessage = () => {
     return `A total of $${returnedAmount} will be refunded as credits on ${billingDate.toLocaleDateString(
       'en-US',
       {
@@ -105,7 +105,7 @@ const ExitSurvey: FC<Props> = ({ freeTier, subscription, onSelectBack }) => {
       return
     }
 
-    if (willChangeComputeSize) {
+    if (currentComputeSize !== undefined) {
       setMessage(values.message)
       return setShowConfirmModal(true)
     } else {
@@ -144,11 +144,11 @@ const ExitSurvey: FC<Props> = ({ freeTier, subscription, onSelectBack }) => {
           error: res.error,
         })
       } else {
-        if (willChangeComputeSize) {
+        if (currentComputeSize !== undefined) {
           app.onProjectStatusUpdated(projectId, PROJECT_STATUS.RESTORING)
           ui.setNotification({
             category: 'info',
-            message: getDowngradeSuccessMessage(),
+            message: getDowngradeRefundMessage(),
             duration: 8000,
           })
           ui.setNotification({
@@ -184,7 +184,7 @@ const ExitSurvey: FC<Props> = ({ freeTier, subscription, onSelectBack }) => {
       <UpdateSuccess
         projectRef={projectRef || ''}
         title="Your project has been updated"
-        message={getDowngradeSuccessMessage()}
+        message={getDowngradeRefundMessage()}
       />
     )
   }

--- a/studio/components/interfaces/Billing/PaymentSummaryPanel/PaymentSummaryPanel.tsx
+++ b/studio/components/interfaces/Billing/PaymentSummaryPanel/PaymentSummaryPanel.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from 'react'
+import { FC, useRef, useState } from 'react'
 import * as Tooltip from '@radix-ui/react-tooltip'
 import { Listbox, IconLoader, Button, IconPlus, IconAlertCircle, IconCreditCard } from 'ui'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
@@ -44,6 +44,8 @@ interface Props {
   onSelectAddNewPaymentMethod: () => void
   onConfirmPayment: () => void
   isSubmitting: boolean
+
+  captcha: React.ReactNode
 }
 
 // Use case of this panel is actually only for upgrading from Free to Pro
@@ -72,6 +74,7 @@ const PaymentSummaryPanel: FC<Props> = ({
   onSelectAddNewPaymentMethod,
   onConfirmPayment,
   isSubmitting,
+  captcha,
 }) => {
   const { ui } = useStore()
   const projectRegion = ui.selectedProject?.region
@@ -120,7 +123,7 @@ const PaymentSummaryPanel: FC<Props> = ({
     ).toFixed(2)
   }
 
-  const validateOrder = () => {
+  const validateOrder = async () => {
     const error = validateSubscriptionUpdatePayload(selectedAddons)
     if (error) {
       return ui.setNotification({
@@ -381,6 +384,8 @@ const PaymentSummaryPanel: FC<Props> = ({
             </Listbox>
           )}
         </div>
+
+        <div className="self-center">{captcha}</div>
 
         <div className="flex items-center justify-end">
           <Tooltip.Root delayDuration={0}>

--- a/studio/components/interfaces/Billing/ProUpgrade.tsx
+++ b/studio/components/interfaces/Billing/ProUpgrade.tsx
@@ -179,7 +179,6 @@ const ProUpgrade: FC<Props> = ({
       token ?? undefined
     )
     const res = await patch(`${API_URL}/projects/${projectRef}/subscription`, payload)
-
     resetCaptcha()
 
     if (res?.error) {

--- a/studio/components/interfaces/Billing/ProUpgrade.tsx
+++ b/studio/components/interfaces/Billing/ProUpgrade.tsx
@@ -153,6 +153,11 @@ const ProUpgrade: FC<Props> = ({
     setIsRefreshingPreview(false)
   }
 
+  const resetCaptcha = () => {
+    setCaptchaToken(null)
+    captchaRef.current?.resetCaptcha()
+  }
+
   const onConfirmPayment = async () => {
     let token = captchaToken
     if (!token) {
@@ -166,18 +171,19 @@ const ProUpgrade: FC<Props> = ({
       nonChangeableAddons,
       selectedPaymentMethodId,
       projectRegion,
-      token ?? undefined,
+      token ?? undefined
     )
 
     setIsSubmitting(true)
     const res = await patch(`${API_URL}/projects/${projectRef}/subscription`, payload)
+
+    resetCaptcha()
+
     if (res?.error) {
       ui.setNotification({
         category: 'error',
         message: `Failed to update subscription: ${res?.error?.message}`,
       })
-      setCaptchaToken(null)
-      captchaRef.current?.resetCaptcha()
     } else {
       if (isChangingComputeSize) {
         app.onProjectStatusUpdated(projectId, PROJECT_STATUS.RESTORING)

--- a/studio/components/interfaces/Billing/ProUpgrade.tsx
+++ b/studio/components/interfaces/Billing/ProUpgrade.tsx
@@ -168,12 +168,9 @@ const ProUpgrade: FC<Props> = ({
         token = captchaResponse?.response ?? null
       }
     } catch (error) {
-      console.log('ERRORR', error)
       setIsSubmitting(false)
       return
     }
-
-    console.log('TOKEN', { token })
 
     const payload = formSubscriptionUpdatePayload(
       currentSubscription,

--- a/studio/components/interfaces/Billing/ProUpgrade.tsx
+++ b/studio/components/interfaces/Billing/ProUpgrade.tsx
@@ -164,6 +164,8 @@ const ProUpgrade: FC<Props> = ({
     const token =
       captchaToken ?? (await captchaRef.current?.execute({ async: true }))?.response ?? undefined
 
+    console.log('confirm', { token })
+
     if (!token) {
       setIsSubmitting(false)
       return

--- a/studio/components/interfaces/Billing/ProUpgrade.tsx
+++ b/studio/components/interfaces/Billing/ProUpgrade.tsx
@@ -160,16 +160,20 @@ const ProUpgrade: FC<Props> = ({
 
   const onConfirmPayment = async () => {
     setIsSubmitting(true)
+    let token = captchaToken
 
-    const token =
-      captchaToken ?? (await captchaRef.current?.execute({ async: true }))?.response ?? undefined
-
-    console.log('confirm', { token })
-
-    if (!token) {
+    try {
+      if (!token) {
+        const captchaResponse = await captchaRef.current?.execute({ async: true })
+        token = captchaResponse?.response ?? null
+      }
+    } catch (error) {
+      console.log('ERRORR', error)
       setIsSubmitting(false)
       return
     }
+
+    console.log('TOKEN', { token })
 
     const payload = formSubscriptionUpdatePayload(
       currentSubscription,

--- a/studio/components/interfaces/Billing/ProUpgrade.tsx
+++ b/studio/components/interfaces/Billing/ProUpgrade.tsx
@@ -159,11 +159,16 @@ const ProUpgrade: FC<Props> = ({
   }
 
   const onConfirmPayment = async () => {
-    let token = captchaToken
+    setIsSubmitting(true)
+
+    const token =
+      captchaToken ?? (await captchaRef.current?.execute({ async: true }))?.response ?? undefined
+
     if (!token) {
-      const captchaResponse = await captchaRef.current?.execute({ async: true })
-      token = captchaResponse?.response ?? null
+      setIsSubmitting(false)
+      return
     }
+
     const payload = formSubscriptionUpdatePayload(
       currentSubscription,
       selectedTier,
@@ -173,8 +178,6 @@ const ProUpgrade: FC<Props> = ({
       projectRegion,
       token ?? undefined
     )
-
-    setIsSubmitting(true)
     const res = await patch(`${API_URL}/projects/${projectRef}/subscription`, payload)
 
     resetCaptcha()

--- a/studio/package.json
+++ b/studio/package.json
@@ -89,6 +89,7 @@
     "uniforms-bootstrap4": "^3.6.2",
     "uniforms-bridge-json-schema": "^3.6.2",
     "uuid": "^8.3.2",
+    "valtio": "^1.7.6",
     "yup": "^0.32.11",
     "yup-password": "^0.2.2",
     "zxcvbn": "^4.4.2"

--- a/studio/pages/_app.tsx
+++ b/studio/pages/_app.tsx
@@ -27,6 +27,7 @@ import { useEffect, useState } from 'react'
 import { Hydrate, QueryClientProvider } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import { RootStore } from 'stores'
+import HCaptchaLoadedStore from 'stores/hcaptcha-loaded-store'
 import { StoreProvider } from 'hooks'
 import { GOTRUE_ERRORS } from 'lib/constants'
 import { auth } from 'lib/gotrue'
@@ -115,6 +116,7 @@ function MyApp({ Component, pageProps }: AppPropsWithLayout) {
               </RouteValidationWrapper>
             </PageTelemetry>
 
+            <HCaptchaLoadedStore />
             <PortalToast />
             <ReactQueryDevtools initialIsOpen={false} position="bottom-right" />
           </FlagProvider>

--- a/studio/pages/project/[ref]/settings/billing/update/free.tsx
+++ b/studio/pages/project/[ref]/settings/billing/update/free.tsx
@@ -80,7 +80,7 @@ const BillingUpdateFree: NextPageWithLayout = () => {
     )
 
   return (
-    <div className="mx-auto my-10 max-w-5xl">
+    <div className="mx-auto my-10 max-w-5xl px-32 xl:px-0">
       <ExitSurvey
         freeTier={freeTier}
         subscription={subscription}

--- a/studio/stores/hcaptcha-loaded-store.tsx
+++ b/studio/stores/hcaptcha-loaded-store.tsx
@@ -1,0 +1,31 @@
+import HCaptcha from '@hcaptcha/react-hcaptcha'
+import { proxy, useSnapshot } from 'valtio'
+
+const hCaptchaLoadedStoreState = proxy({
+  loaded: false,
+  setLoaded() {
+    hCaptchaLoadedStoreState.loaded = true
+  },
+})
+
+export const useIsHCaptchaLoaded = () => {
+  const snap = useSnapshot(hCaptchaLoadedStoreState)
+
+  return snap.loaded
+}
+
+const HCaptchaLoadedStore = () => {
+  const onLoad = () => {
+    hCaptchaLoadedStoreState.setLoaded()
+  }
+
+  return (
+    <HCaptcha
+      sitekey={process.env.NEXT_PUBLIC_HCAPTCHA_SITE_KEY!}
+      size="invisible"
+      onLoad={onLoad}
+    />
+  )
+}
+
+export default HCaptchaLoadedStore


### PR DESCRIPTION
As a mitigation and increased friction for card testing (fraudulent activity for verifying that credit cards are valid), we will be using hCaptcha when changing the subscription and when adding payment methods.

API is already adjusted to accept the new `hcaptchaToken` parameters (without verifying them yet)
