### PR TITLE
typo fix in 2022-12-15 wrappers blog post

### DIFF
--- a/apps/www/_blog/2022-12-15-postgres-foreign-data-wrappers-rust.mdx
+++ b/apps/www/_blog/2022-12-15-postgres-foreign-data-wrappers-rust.mdx
@@ -231,7 +231,7 @@ Wrappers [supports](https://github.com/supabase/wrappers/blob/83887dcc2ddcf972ca
 
 Foreign Data Wrappers have a concept of "push down". This means that the FDW runs the query on _remote_ data source. This is useful for performance reasons, as the remote data source can often perform the query more efficiently than Postgres. Push down is also useful for security reasons, as the remote data source can enforce access control. Limited push-down support has been added as a Proof of Concept, but this will be a key focus of Wrappers.
 
-You can follow development off all Wrappers in the offiical [GitHub Repo](https://github.com/supabase/wrappers).
+You can follow development off all Wrappers in the official [GitHub Repo](https://github.com/supabase/wrappers).
 
 ## Next Steps
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

1 typo fix in recent blog post - `offiical` -> `official`