### PR TITLE
Added missing import createServerSupabaseClient

### DIFF
--- a/apps/docs/pages/guides/auth/auth-helpers/nextjs.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/nextjs.mdx
@@ -162,6 +162,7 @@ const supabaseClient = useSupabaseClient<Database>()
 
 ```tsx
 // Creating a new supabase server client object (e.g. in API route):
+import { createServerSupabaseClient } from '@supabase/auth-helpers-nextjs'
 import type { NextApiRequest, NextApiResponse } from 'next'
 import type { Database } from 'types_db'
 


### PR DESCRIPTION
Added missing import for createServerSupabaseClient on "Server client" example for Supabase Auth with Next.js page

## What kind of change does this PR introduce?
Update to docs, Supabase Auth with Next.js page

## What is the current behavior?
No import for createServerSupabaseClient 
![image](https://user-images.githubusercontent.com/10702083/207908056-cdab41b4-212f-4e4e-bebb-4a0339a7dbbd.png)

## What is the new behavior?
import { createServerSupabaseClient } from '@supabase/auth-helpers-nextjs'
