### PR TITLE
fix: name of the link in blog post

### DIFF
--- a/apps/www/_blog/2022-12-15-postgres-foreign-data-wrappers-rust.mdx
+++ b/apps/www/_blog/2022-12-15-postgres-foreign-data-wrappers-rust.mdx
@@ -240,7 +240,7 @@ We're not "officially" releasing Wrappers onto the platform yet, although the br
 We're excited to see what the community does with Wrappers. We're hoping that Wrappers will help to accelerate the adoption of Postgres as a data hub.
 If you're interested in getting involved or building your own Wrapper, don't hesitage to jump into the code and start developing with us.
 
-- Star & Watch the GitHub repo: [thub.com/supabase/wrapper](https://github.com/supabase/wrappers)
+- Star & Watch the GitHub repo: [github.com/supabase/wrappers](https://github.com/supabase/wrappers)
 - View the documentation: [supabase.github.io/wrappers](https://supabase.github.io/wrappers/)
 - Supabase Launch Week: [supabase.com/launch-week](https://supabase.com/launch-week)
 


### PR DESCRIPTION
Sorry for opening 3 seperate PRs, saw it too late, there was an error in the link name in the last blog post