### PR TITLE
Fix/members owner leave team action

### DIFF
--- a/apps/docs/pages/guides/platform/access-control.mdx
+++ b/apps/docs/pages/guides/platform/access-control.mdx
@@ -39,12 +39,10 @@ You can invite your team members into your organizations to collaborate on proje
 
 ### Transferring ownership of an organization
 
-An organization can have multiple owners, so a Supabase organization can either have 1 owner, or several owners.
+Each Supabase organization can have one or more owners. If you no longer want be an owner of an organization, click **Leave team** in the members view (`https://app.supabase.com/org/<org-slug>/settings#team`) of your organization.
+However, you can only leave an organization when there is _at least one other owner_.
 
-If you would like to no longer be an owner of an organization you can simply click 'Leave team' in the members view (`https://app.supabase.com/org/<org-slug>/settings#team`) of your organization.
-However, you can only leave an organization when there is _at least 1 other owner_.
-
-If you are transferring ownership of your organization to someone else, then you will need to invite the new member with the role `"Owner"`. Once they've accepted the invitation, you can then leave your organization.
+If you are transferring ownership of your organization to someone else, you will need to invite the new member with the **Owner** role. You can leave the organization after they've accepted the invitation.
 
 ### Permissions across roles [#permission-across-roles]
 

--- a/apps/docs/pages/guides/platform/access-control.mdx
+++ b/apps/docs/pages/guides/platform/access-control.mdx
@@ -44,7 +44,7 @@ An organization can have multiple owners, so a Supabase organization can either 
 If you would like to no longer be an owner of an organization you can simply click 'Leave team' in the members view (`https://app.supabase.com/org/<org-slug>/settings#team`) of your organization.
 However, you can only leave an organization when there is _at least 1 other owner_.
 
-If you are transferring ownership of your organization to someone else, then you will need to invite the new member with the role `"Owner"`, and then once they've accpeted the invitation, you can then leave your organization.
+If you are transferring ownership of your organization to someone else, then you will need to invite the new member with the role `"Owner"`. Once they've accepted the invitation, you can then leave your organization.
 
 ### Permissions across roles [#permission-across-roles]
 

--- a/apps/docs/pages/guides/platform/access-control.mdx
+++ b/apps/docs/pages/guides/platform/access-control.mdx
@@ -37,6 +37,15 @@ You can invite your team members into your organizations to collaborate on proje
   <source src="/docs/videos/invite-team.mp4" type="video/mp4" muted playsInline />
 </video>
 
+### Transferring ownership of an organization
+
+An organization can have multiple owners, so a Supabase organization can either have 1 owner, or several owners.
+
+If you would like to no longer be an owner of an organization you can simply click 'Leave team' in the members view (`https://app.supabase.com/org/<org-slug>/settings#team`) of your organization.
+However, you can only leave an organization when there is _at least 1 other owner_.
+
+If you are transferring ownership of your organization to someone else, then you will need to invite the new member with the role `"Owner"`, and then once they've accpeted the invitation, you can then leave your organization.
+
 ### Permissions across roles [#permission-across-roles]
 
 The table below shows the corresponding permissions for each available role you can assign a team member in the Dashboard.

--- a/studio/components/interfaces/Organization/TeamSettings/MemberActions.tsx
+++ b/studio/components/interfaces/Organization/TeamSettings/MemberActions.tsx
@@ -1,18 +1,17 @@
-import { FC, useState, useContext } from 'react'
-import { observer } from 'mobx-react-lite'
 import * as Tooltip from '@radix-ui/react-tooltip'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
-import { Button, Dropdown, IconTrash, IconMoreHorizontal } from 'ui'
+import { observer } from 'mobx-react-lite'
+import { FC, useContext, useState } from 'react'
+import { Button, Dropdown, IconMoreHorizontal, IconTrash } from 'ui'
 
-import { Member, Role } from 'types'
-import { useStore, useOrganizationDetail, checkPermissions } from 'hooks'
+import { confirmAlert } from 'components/to-be-cleaned/ModalsDeprecated/ConfirmModal'
+import { checkPermissions, useOrganizationDetail, useStore } from 'hooks'
 import { delete_, post } from 'lib/common/fetch'
 import { API_URL } from 'lib/constants'
-import TextConfirmModal from 'components/ui/Modals/TextConfirmModal'
-import { confirmAlert } from 'components/to-be-cleaned/ModalsDeprecated/ConfirmModal'
+import { Member, Role } from 'types'
 
 import { PageContext } from 'pages/org/[slug]/settings'
-import { getUserDisplayName, isInviteExpired } from '../Organization.utils'
+import { isInviteExpired } from '../Organization.utils'
 import { getRolesManagementPermissions } from './TeamSettings.utils'
 
 interface Props {
@@ -30,7 +29,6 @@ const MemberActions: FC<Props> = ({ members, member, roles }) => {
   const { mutateOrgMembers } = useOrganizationDetail(ui.selectedOrganization?.slug || '')
 
   const [loading, setLoading] = useState(false)
-  const [ownerTransferIsVisible, setOwnerTransferIsVisible] = useState(false)
 
   const isExpired = isInviteExpired(member?.invited_at ?? '')
   const isPendingInviteAcceptance = member.invited_id
@@ -96,7 +94,7 @@ const MemberActions: FC<Props> = ({ members, member, roles }) => {
       })
 
       mutateOrgMembers(updatedMembers)
-      setOwnerTransferIsVisible(false)
+
       ui.setNotification({ category: 'success', message: 'Successfully transferred organization' })
     }
 
@@ -180,19 +178,9 @@ const MemberActions: FC<Props> = ({ members, member, roles }) => {
       <Dropdown
         side="bottom"
         align="end"
+        size="small"
         overlay={
           <>
-            {!isPendingInviteAcceptance && (
-              <>
-                <Dropdown.Item onClick={() => setOwnerTransferIsVisible(!ownerTransferIsVisible)}>
-                  <div className="flex flex-col">
-                    <p>Make owner</p>
-                    <p className="block opacity-50">Transfer ownership of "{orgName}"</p>
-                  </div>
-                </Dropdown.Item>
-                <Dropdown.Separator />
-              </>
-            )}
             {isPendingInviteAcceptance ? (
               <>
                 {canRevokeInvite && (
@@ -231,25 +219,6 @@ const MemberActions: FC<Props> = ({ members, member, roles }) => {
           icon={<IconMoreHorizontal />}
         />
       </Dropdown>
-
-      <TextConfirmModal
-        title="Transfer organization"
-        visible={ownerTransferIsVisible}
-        confirmString={slug}
-        loading={loading}
-        confirmLabel="I understand, transfer ownership"
-        confirmPlaceholder="Type in name of orgnization"
-        onCancel={() => setOwnerTransferIsVisible(!ownerTransferIsVisible)}
-        onConfirm={handleTransferOwnership}
-        alert="Payment methods such as credit cards will also be transferred. You may want to delete credit card information first before transferring."
-        text={
-          <span>
-            By transferring this organization, it will be solely owned by{' '}
-            <span className="font-medium dark:text-white">{getUserDisplayName(member)}</span>, they
-            will also be able to remove you from the organization as a member
-          </span>
-        }
-      />
     </div>
   )
 }

--- a/studio/components/interfaces/Organization/TeamSettings/MembersView.tsx
+++ b/studio/components/interfaces/Organization/TeamSettings/MembersView.tsx
@@ -95,6 +95,7 @@ const MembersView = () => {
                 const memberIsPendingInvite = !!x.invited_id
                 const canRemoveRole = rolesRemovable.includes(memberRoleId)
                 const disableRoleEdit = !canRemoveRole || memberIsUser || memberIsPendingInvite
+                const isEmailUser = x.username === x.primary_email
 
                 const validateSelectedRoleToChange = (roleId: any) => {
                   if (!role || role.id === roleId) return
@@ -126,17 +127,17 @@ const MembersView = () => {
                               <span className="flex rounded-full border-2 border-border-secondary-light p-2 dark:border-border-secondary-dark">
                                 <IconUser size={20} strokeWidth={2} />
                               </span>
-                            ) : !x?.username?.includes('@') ? (
+                            ) : isEmailUser ? (
+                              <div className="w-[40px] h-[40px] bg-scale-300 border border-scale-400 rounded-full text-scale-900 flex items-center justify-center">
+                                <IconUser strokeWidth={1.5} />
+                              </div>
+                            ) : (
                               <Image
                                 src={`https://github.com/${x.username}.png?size=80`}
                                 width="40"
                                 height="40"
                                 className="rounded-full border"
                               />
-                            ) : (
-                              <div className="w-[40px] h-[40px] bg-scale-300 border border-scale-400 rounded-full text-scale-900 flex items-center justify-center">
-                                <IconUser strokeWidth={1.5} />
-                              </div>
                             )}
                           </div>
                           <div>

--- a/studio/components/interfaces/Organization/TeamSettings/MembersView.tsx
+++ b/studio/components/interfaces/Organization/TeamSettings/MembersView.tsx
@@ -126,13 +126,17 @@ const MembersView = () => {
                               <span className="flex rounded-full border-2 border-border-secondary-light p-2 dark:border-border-secondary-dark">
                                 <IconUser size={20} strokeWidth={2} />
                               </span>
-                            ) : (
+                            ) : !x?.username?.includes('@') ? (
                               <Image
                                 src={`https://github.com/${x.username}.png?size=80`}
                                 width="40"
                                 height="40"
                                 className="rounded-full border"
                               />
+                            ) : (
+                              <div className="w-[40px] h-[40px] bg-scale-300 border border-scale-400 rounded-full text-scale-900 flex items-center justify-center">
+                                <IconUser strokeWidth={1.5} />
+                              </div>
                             )}
                           </div>
                           <div>

--- a/studio/components/interfaces/Organization/TeamSettings/TeamSettings.tsx
+++ b/studio/components/interfaces/Organization/TeamSettings/TeamSettings.tsx
@@ -8,7 +8,7 @@ import { post } from 'lib/common/fetch'
 import { API_URL } from 'lib/constants'
 import InviteMemberButton from './InviteMemberButton'
 import MembersView from './MembersView'
-import { getRolesManagementPermissions } from './TeamSettings.utils'
+import { getRolesManagementPermissions, hasMultipleOwners } from './TeamSettings.utils'
 import { confirmAlert } from 'components/to-be-cleaned/ModalsDeprecated/ConfirmModal'
 
 import { PageContext } from 'pages/org/[slug]/settings'
@@ -25,7 +25,7 @@ const TeamSettings = observer(() => {
   const [isLeaving, setIsLeaving] = useState(false)
   const canAddMembers = rolesAddable.length > 0
 
-  const canLeave = !isOwner || ui.isOwnerAndCanLeaveOrg(members)
+  const canLeave = !isOwner || (isOwner && hasMultipleOwners(members, roles))
 
   function onFilterMemberChange(e: any) {
     PageState.membersFilterString = e.target.value

--- a/studio/components/interfaces/Organization/TeamSettings/TeamSettings.tsx
+++ b/studio/components/interfaces/Organization/TeamSettings/TeamSettings.tsx
@@ -1,6 +1,7 @@
 import { useState, useContext } from 'react'
 import { observer } from 'mobx-react-lite'
 import { Button, Input, IconSearch } from 'ui'
+import * as Tooltip from '@radix-ui/react-tooltip'
 
 import { useStore } from 'hooks'
 import { post } from 'lib/common/fetch'
@@ -24,10 +25,7 @@ const TeamSettings = observer(() => {
   const [isLeaving, setIsLeaving] = useState(false)
   const canAddMembers = rolesAddable.length > 0
 
-  const canLeave = (isOwner && ui.isOwnerAndCanLeaveOrg(members)) || !isOwner
-
-  console.log(rolesAddable)
-  console.log(PageState)
+  const canLeave = !isOwner || ui.isOwnerAndCanLeaveOrg(members)
 
   function onFilterMemberChange(e: any) {
     PageState.membersFilterString = e.target.value
@@ -82,13 +80,35 @@ const TeamSettings = observer(() => {
                 />
               </div>
             )}
-            {canLeave && (
-              <div>
-                <Button type="default" onClick={() => leaveTeam()} loading={isLeaving}>
-                  Leave team
-                </Button>
-              </div>
-            )}
+            <div>
+              <Tooltip.Root delayDuration={0}>
+                <Tooltip.Trigger>
+                  <Button
+                    type="default"
+                    disabled={!canLeave}
+                    onClick={() => leaveTeam()}
+                    loading={isLeaving}
+                  >
+                    Leave team
+                  </Button>
+                </Tooltip.Trigger>
+                {!canLeave && (
+                  <Tooltip.Content side="bottom">
+                    <Tooltip.Arrow className="radix-tooltip-arrow" />
+                    <div
+                      className={[
+                        'rounded bg-scale-100 py-1 px-2 leading-none shadow',
+                        'border border-scale-200',
+                      ].join(' ')}
+                    >
+                      <span className="text-xs text-scale-1200">
+                        An organization requires at least 1 owner
+                      </span>
+                    </div>
+                  </Tooltip.Content>
+                )}
+              </Tooltip.Root>
+            </div>
           </div>
         </div>
       </div>

--- a/studio/components/interfaces/Organization/TeamSettings/TeamSettings.tsx
+++ b/studio/components/interfaces/Organization/TeamSettings/TeamSettings.tsx
@@ -24,6 +24,11 @@ const TeamSettings = observer(() => {
   const [isLeaving, setIsLeaving] = useState(false)
   const canAddMembers = rolesAddable.length > 0
 
+  const canLeave = (isOwner && ui.isOwnerAndCanLeaveOrg(members)) || !isOwner
+
+  console.log(rolesAddable)
+  console.log(PageState)
+
   function onFilterMemberChange(e: any) {
     PageState.membersFilterString = e.target.value
   }
@@ -77,7 +82,7 @@ const TeamSettings = observer(() => {
                 />
               </div>
             )}
-            {!isOwner && (
+            {canLeave && (
               <div>
                 <Button type="default" onClick={() => leaveTeam()} loading={isLeaving}>
                   Leave team

--- a/studio/components/interfaces/Organization/TeamSettings/TeamSettings.utils.ts
+++ b/studio/components/interfaces/Organization/TeamSettings/TeamSettings.utils.ts
@@ -1,4 +1,4 @@
-import { Role } from 'types'
+import { Member, Role } from 'types'
 import { checkPermissions } from 'hooks'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 
@@ -22,4 +22,13 @@ export const getRolesManagementPermissions = (
   })
 
   return { rolesAddable, rolesRemovable }
+}
+
+export const hasMultipleOwners = (members: Member[], roles: Role[]) => {
+  const membersWhoAreOwners = members.filter((member) => {
+    const [memberRoleId] = member.role_ids ?? []
+    const role = roles.find((role: Role) => role.id === memberRoleId)
+    return role?.name === 'Owner' && !member.invited_at
+  })
+  return membersWhoAreOwners.length > 1
 }

--- a/studio/components/interfaces/Organization/TeamSettings/TeamSettings.utils.ts
+++ b/studio/components/interfaces/Organization/TeamSettings/TeamSettings.utils.ts
@@ -24,7 +24,7 @@ export const getRolesManagementPermissions = (
   return { rolesAddable, rolesRemovable }
 }
 
-export const hasMultipleOwners = (members: Member[], roles: Role[]) => {
+export const hasMultipleOwners = (members: Member[] = [], roles: Role[] = []) => {
   const membersWhoAreOwners = members.filter((member) => {
     const [memberRoleId] = member.role_ids ?? []
     const role = roles.find((role: Role) => role.id === memberRoleId)

--- a/studio/stores/UiStore.ts
+++ b/studio/stores/UiStore.ts
@@ -184,7 +184,7 @@ export default class UiStore implements IUiStore {
       // dangerous use of string here
       // to do, refactor so that changing the role name does not fail this check
       // if role name does change, then user will simply not be able to leave project as a 'owner' regardless
-      return role && role.name === 'Owner'
+      return role && role.name === 'Owner' && !member.invited_at
     })
 
     console.log('membersWhoAreOwners', membersWhoAreOwners)

--- a/studio/stores/UiStore.ts
+++ b/studio/stores/UiStore.ts
@@ -1,8 +1,18 @@
 import { uuidv4 } from 'lib/helpers'
 import { action, makeAutoObservable } from 'mobx'
-import { Project, Notification, User, Organization, ProjectBase, Permission } from 'types'
+import {
+  Project,
+  Notification,
+  User,
+  Organization,
+  ProjectBase,
+  Permission,
+  Member,
+  Role,
+} from 'types'
 import { IRootStore } from './RootStore'
 import Telemetry from 'lib/telemetry'
+import { useOrganizationRoles } from 'hooks'
 
 export interface IUiStore {
   language: 'en_US'
@@ -26,6 +36,7 @@ export interface IUiStore {
   setNotification: (notification: Notification) => string
   setProfile: (value?: User) => void
   setPermissions: (permissions?: Permission[]) => void
+  isOwnerAndCanLeaveOrg: (members: Member[]) => void
 }
 export default class UiStore implements IUiStore {
   rootStore: IRootStore
@@ -156,5 +167,30 @@ export default class UiStore implements IUiStore {
 
   setPermissions(permissions?: any) {
     this.permissions = permissions
+  }
+
+  /*
+   * Check wether the owner is allowed to leave a project
+   * the conditions for this is that they are an owner, and there is also 1 other owner in the org.
+   */
+  isOwnerAndCanLeaveOrg(members: Member[]) {
+    const selectedOrg = this.selectedOrganization
+
+    const roles: { roles: Role[] } = useOrganizationRoles(this.selectedOrganization?.slug)
+
+    const membersWhoAreOwners = members.filter((member) => {
+      const [memberRoleId] = member.role_ids ?? []
+      const role = (roles.roles || []).find((role: Role) => role.id === memberRoleId)
+      // dangerous use of string here
+      // to do, refactor so that changing the role name does not fail this check
+      // if role name does change, then user will simply not be able to leave project as a 'owner' regardless
+      return role && role.name === 'Owner'
+    })
+
+    console.log('membersWhoAreOwners', membersWhoAreOwners)
+
+    return selectedOrg?.is_owner && membersWhoAreOwners && membersWhoAreOwners.length > 1
+      ? true
+      : false
   }
 }

--- a/studio/stores/UiStore.ts
+++ b/studio/stores/UiStore.ts
@@ -1,18 +1,8 @@
 import { uuidv4 } from 'lib/helpers'
 import { action, makeAutoObservable } from 'mobx'
-import {
-  Project,
-  Notification,
-  User,
-  Organization,
-  ProjectBase,
-  Permission,
-  Member,
-  Role,
-} from 'types'
+import { Project, Notification, User, Organization, ProjectBase, Permission } from 'types'
 import { IRootStore } from './RootStore'
 import Telemetry from 'lib/telemetry'
-import { useOrganizationRoles } from 'hooks'
 
 export interface IUiStore {
   language: 'en_US'
@@ -36,7 +26,6 @@ export interface IUiStore {
   setNotification: (notification: Notification) => string
   setProfile: (value?: User) => void
   setPermissions: (permissions?: Permission[]) => void
-  isOwnerAndCanLeaveOrg: (members: Member[]) => boolean
 }
 export default class UiStore implements IUiStore {
   rootStore: IRootStore
@@ -167,24 +156,5 @@ export default class UiStore implements IUiStore {
 
   setPermissions(permissions?: any) {
     this.permissions = permissions
-  }
-
-  /*
-   * Check whether the owner is allowed to leave a project
-   * the conditions for this is that they are an owner, and there is also 1 other owner in the org.
-   */
-  isOwnerAndCanLeaveOrg(members: Member[]) {
-    const selectedOrg = this.selectedOrganization
-    if (!selectedOrg?.is_owner) return false
-
-    const roles: { roles: Role[] } = useOrganizationRoles(this.selectedOrganization?.slug)
-
-    const membersWhoAreOwners = members.filter((member) => {
-      const [memberRoleId] = member.role_ids ?? []
-      const role = (roles.roles || []).find((role: Role) => role.id === memberRoleId)
-      return role?.name === 'Owner' && !member.invited_at
-    })
-
-    return membersWhoAreOwners.length > 1
   }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Members who are owners can now leave their own organization.
**but** only if 1 other owner is in the organization, so the org does not become an orphan.

## What is the current behavior?

Owners cannot leave their own org, even with multiple other owners.
Although Owners can delete other owners.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Also removed the old 'transfer ownership' actions and code
