### PR TITLE
Removed duplicated json data.

### DIFF
--- a/spec/common-self-hosting-auth-sections.json
+++ b/spec/common-self-hosting-auth-sections.json
@@ -128,12 +128,6 @@
         "slug": "verifies-a-sign-up",
         "title": "Verifies a sign up",
         "type": "operation"
-      },
-      {
-        "id": "verifies-a-sign-up",
-        "slug": "verifies-a-sign-up",
-        "title": "Verifies a sign up",
-        "type": "operation"
       }
     ]
   }


### PR DESCRIPTION
There was a duplicated json object for verified-a-sign-up field. So, I removed it. It was making the same button appear twice on the website.

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

A docs object is replicated leading to rendering the same thing twice on the website.

## What is the new behavior?

Now the object is rendered only once on the website.

## Additional context

![Screenshot_20221216_173032](https://user-images.githubusercontent.com/82873939/208093797-1904c0f1-e844-421e-8dca-9295eba00626.png)
