### PR TITLE
fix: docs - getting started mobile cards

### DIFF
--- a/apps/docs/pages/guides/getting-started.mdx
+++ b/apps/docs/pages/guides/getting-started.mdx
@@ -38,7 +38,7 @@ export const meta = {
 
 ### Tutorials
 
-<div className="grid grid-cols-12 gap-6 not-prose">
+<div className="grid lg:grid-cols-12 gap-6 not-prose">
   {webapps.map((item) => {
     return (
       <Link href={`/${item.href}`} key={item.title} passHref>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase docs - [Getting Started](https://supabase.com/docs/guides/getting-started)

## What is the current behavior?

On a mobile device the example cards are too small and bunched up:


https://user-images.githubusercontent.com/22655069/208140464-3bdfa288-c5dc-41bc-bd80-5e9b56072260.mov


## What is the new behavior?

Now the cards take up a whole row:


https://user-images.githubusercontent.com/22655069/208140537-9ea21561-e7e1-49a5-a466-12cee7656a35.mov

