### PR TITLE
fix: docs foreign table example

### DIFF
--- a/spec/supabase_js_v2.yml
+++ b/spec/supabase_js_v2.yml
@@ -979,7 +979,7 @@ functions:
       - id: query-foreign-tables-through-a-join-table
         name: Query foreign tables through a join table
         code: |
-          ```js
+          ```ts
             const { data, error } = await supabase
               .from('users')
               .select(`

--- a/spec/supabase_js_v2.yml
+++ b/spec/supabase_js_v2.yml
@@ -965,10 +965,21 @@ functions:
         name: Query foreign tables
         description: |
           If your database has foreign key relationships, you can query related tables too.
+        code: |
+          ```js
+          const { data, error } = await supabase
+            .from('countries')
+            .select(`
+              name,
+              cities (
+                name
+              )
+            `)
+          ```
       - id: query-foreign-tables-through-a-join-table
         name: Query foreign tables through a join table
         code: |
-          ```ts
+          ```js
             const { data, error } = await supabase
               .from('users')
               .select(`


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase Docs - [Select > Query foreign tables](https://supabase.com/docs/reference/javascript/select)

## What is the current behavior?

As highlighted in issue #11051 the example is undefined

## What is the new behavior?

Taken the example from the v1 spec and now an example appears:

<img width="540" alt="Screenshot 2022-12-16 at 17 01 09" src="https://user-images.githubusercontent.com/22655069/208150349-274989fb-7cbe-4f39-95da-632ec885dc69.png">


## Additional context

Closes #11051
