### PR TITLE
move arguments to their own lines for ease of reading and consistency

### DIFF
--- a/apps/docs/pages/guides/realtime/postgres-changes.mdx
+++ b/apps/docs/pages/guides/realtime/postgres-changes.mdx
@@ -63,7 +63,14 @@ const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_KEY
 */
 const channel = supabase
   .channel('schema-db-changes')
-  .on('postgres_changes', { event: '*', schema: 'public' }, (payload) => console.log(payload))
+  .on(
+    'postgres_changes',
+    {
+      event: '*',
+      schema: 'public',
+    },
+    (payload) => console.log(payload)
+  )
   .subscribe()
 ```
 
@@ -74,8 +81,14 @@ To listen to changes on a table in the `public` schema:
 
 const channel = supabase
   .channel('table-db-changes')
-  .on('postgres_changes', { event: 'INSERT', schema: 'public', table: 'messages' }, (payload) =>
-    console.log(payload)
+  .on(
+    'postgres_changes',
+    {
+      event: 'INSERT',
+      schema: 'public',
+      table: 'messages',
+    },
+    (payload) => console.log(payload)
   )
   .subscribe()
 ```
@@ -109,11 +122,21 @@ const channel = supabase
   .channel('db-changes')
   .on(
     'postgres_changes',
-    { event: '*', schema: 'public', table: 'messages', filter: 'body=eq.bye' },
+    {
+      event: '*',
+      schema: 'public',
+      table: 'messages',
+      filter: 'body=eq.bye',
+    },
     (payload) => console.log(payload)
   )
-  .on('postgres_changes', { event: 'INSERT', schema: 'public', table: 'users' }, (payload) =>
-    console.log(payload)
+  .on('postgres_changes',
+    {
+      event: 'INSERT',
+      schema: 'public',
+      table: 'users',
+    },
+    (payload) => console.log(payload)
   )
   .subscribe()
 ```


### PR DESCRIPTION
## What kind of change does this PR introduce?
docs update

## What is the current behavior?
There are multiple code examples in this 1 document which all use different interpretations of how to format code in terms of line breaks. As someone new to Supabase, trying to understand the API & conventions, I found this distracting.

## What is the new behavior?
I adopted the code style from 1 existing example, which I found easiest to read and quickly digest the various arguments, then applied this style to the other code examples on the page.
