### PR TITLE
Point to android manifest and plist files

### DIFF
--- a/apps/docs/pages/guides/getting-started/tutorials/with-flutter.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-flutter.mdx
@@ -50,7 +50,9 @@ Add `io.supabase.flutterquickstart://login-callback/` as a new [redirect URL](ht
 
 That is it on Supabase's end and the rest are platform specific settings:
 
-For Android, add an intent-filter to enable deep linking:
+For Android, edit the android/app/src/main/AndroidManifest.xml file.
+
+Add an intent-filter to enable deep linking:
 
 ```xml title=android/app/src/main/AndroidManifest.xml
 <manifest ...>
@@ -75,7 +77,9 @@ For Android, add an intent-filter to enable deep linking:
 </manifest>
 ```
 
-For iOS add CFBundleURLTypes to enable deep linking:
+For iOS, edit the ios/Runner/Info.plist file. 
+
+Add CFBundleURLTypes to enable deep linking:
 
 ```xml title=ios/Runner/Info.plist"
 <!-- ... other tags -->

--- a/apps/docs/pages/guides/getting-started/tutorials/with-flutter.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-flutter.mdx
@@ -50,7 +50,7 @@ Add `io.supabase.flutterquickstart://login-callback/` as a new [redirect URL](ht
 
 That is it on Supabase's end and the rest are platform specific settings:
 
-For Android, edit the android/app/src/main/AndroidManifest.xml file.
+For Android, edit the `android/app/src/main/AndroidManifest.xml` file.
 
 Add an intent-filter to enable deep linking:
 


### PR DESCRIPTION
Point users to location of files to be edited.

## What kind of change does this PR introduce?

Flutter tutorial docs update

## What is the current behavior?

Naive users may not know location of the files to be edited.

## What is the new behavior?

Users can follow the path to the files for edtiing

## Additional context

Add any other context or screenshots.
