### PR TITLE
fix: docs getting started links

### DIFF
--- a/apps/docs/pages/guides/getting-started.mdx
+++ b/apps/docs/pages/guides/getting-started.mdx
@@ -150,13 +150,13 @@ export const resources = [
   {
     title: 'Features',
     hasLightIcon: true,
-    href: '/features',
+    href: '/guides/getting-started/features',
     description: 'A non-exhaustive list of features that Supabase provides for every project.',
   },
   {
     title: 'Architecture',
     hasLightIcon: true,
-    href: '/architecture',
+    href: '/guides/getting-started/architecture',
     description: "An overview of Supabase's architecture and product principles.",
   },
 ]


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase docs - [Getting Started](https://supabase.com/docs/guides/getting-started)

## What is the current behavior?

Both the Features and Architecture cards go to a 404 page.

## What is the new behavior?

Both the cards now show the correct page.

## Additional context

Closes #11053
