### PR TITLE
docs: fixed small typo error in tables.mdx

### DIFF
--- a/apps/docs/pages/guides/database/tables.mdx
+++ b/apps/docs/pages/guides/database/tables.mdx
@@ -265,7 +265,7 @@ For example if you had the following situations:
 
 - You have a list of `movies`.
 - A movie can have several `actors`.
-- An `actor` can perfom in several movies.
+- An `actor` can perform in several movies.
 
 <Tabs
   scrollable


### PR DESCRIPTION
I fixed another typo error in the docs.