### PR TITLE
chore: use next/image for images in articles

### DIFF
--- a/apps/docs/components/index.tsx
+++ b/apps/docs/components/index.tsx
@@ -29,6 +29,7 @@ import CliGlobalFlagsHandler from '~/components/reference/enrichments/cli/CliGlo
 
 import Options from '~/components/Options'
 import Param from '~/components/Params'
+import Image from 'next/image'
 
 const components = {
   Admonition,
@@ -73,6 +74,13 @@ const components = {
   CliGlobalFlagsHandler: () => <CliGlobalFlagsHandler />,
   Options,
   Param,
+  img: (props: any) => {
+    return (
+      <span className={['next-image--dynamic-fill'].join(' ')}>
+        <Image {...props} className={['rounded-md border'].join(' ')} layout="fill" />
+      </span>
+    )
+  },
 }
 
 export default components

--- a/apps/docs/styles/main.scss
+++ b/apps/docs/styles/main.scss
@@ -272,10 +272,3 @@ div[role='tablist'] {
   position: relative !important;
   height: unset !important;
 }
-
-.line-clamp {
-  display: -webkit-box;
-  margin: 0 auto;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-}

--- a/apps/docs/styles/main.scss
+++ b/apps/docs/styles/main.scss
@@ -253,3 +253,29 @@ div[role='tablist'] {
     max-width: 620px;
   }
 }
+
+/*
+* sets the image in @Next/Image components
+* to respect the height of the content
+*
+*/
+.next-image--dynamic-fill {
+  width: 100%;
+  grid-column: 1 / -1;
+}
+.next-image--dynamic-fill > span {
+  position: relative !important;
+}
+.next-image--dynamic-fill img {
+  object-fit: contain;
+  width: 100% !important;
+  position: relative !important;
+  height: unset !important;
+}
+
+.line-clamp {
+  display: -webkit-box;
+  margin: 0 auto;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Now using Next/Image for images in guides

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Less bandwidth used on images

## Additional context

Add any other context or screenshots.
