### PR TITLE
chore: remove storageImageResize flag

### DIFF
--- a/studio/components/interfaces/Reports/Reports.tsx
+++ b/studio/components/interfaces/Reports/Reports.tsx
@@ -17,7 +17,7 @@ import {
 } from 'ui'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 
-import { checkPermissions, useFlag, useStore } from 'hooks'
+import { checkPermissions, useStore } from 'hooks'
 import { uuidv4 } from 'lib/helpers'
 import { METRIC_CATEGORIES, METRICS, TIME_PERIODS_REPORTS } from 'lib/constants'
 import { useProjectContentStore } from 'stores/projectContentStore'
@@ -263,10 +263,6 @@ const Reports = () => {
     })
   }
 
-  // Filter out total_storage_image_render_count if feature flag is not enabled
-  const storageImageResizeEnabled = useFlag('storageImageResize')
-  let metrics = METRICS.filter(it => it.key !== 'total_storage_image_render_count' || storageImageResizeEnabled);
-
   const MetricOptions = () => {
     return (
       <>
@@ -277,7 +273,7 @@ const Reports = () => {
                 isNested
                 overlay={
                   <>
-                    {metrics.filter((metric) => metric?.category?.key === cat.key).map((metric) => {
+                    {METRICS.filter((metric) => metric?.category?.key === cat.key).map((metric) => {
                       return (
                         <Dropdown.Checkbox
                           key={metric.key}

--- a/studio/components/interfaces/Settings/ProjectUsageBars/ProjectUsageBars.tsx
+++ b/studio/components/interfaces/Settings/ProjectUsageBars/ProjectUsageBars.tsx
@@ -1,7 +1,7 @@
 import { FC, useEffect } from 'react'
 import { Badge, Button, IconAlertCircle, Loading } from 'ui'
 
-import { useStore, useProjectUsage, useFlag } from 'hooks'
+import { useStore, useProjectUsage } from 'hooks'
 import { formatBytes } from 'lib/helpers'
 import { PRICING_TIER_PRODUCT_IDS, USAGE_APPROACHING_THRESHOLD } from 'lib/constants'
 import SparkBar from 'components/ui/SparkBar'
@@ -56,21 +56,11 @@ const ProjectUsage: FC<Props> = ({ projectRef }) => {
     )
   }
 
-  const storageImageResizeEnabled = useFlag('storageImageResize')
-
-  // Filter out storage_image_render_count if feature flag is not enabled
-  const usageBasedProducts = USAGE_BASED_PRODUCTS.map((usageBasedProduct) => ({
-    ...usageBasedProduct,
-    features: usageBasedProduct.features.filter(
-      (it) => it.key !== 'storage_image_render_count' || storageImageResizeEnabled
-    ),
-  }))
-
   return (
     <Loading active={isLoading}>
       {usage && (
         <div>
-          {usageBasedProducts.map((product) => {
+          {USAGE_BASED_PRODUCTS.map((product) => {
             const isExceededUsage =
               showUsageExceedMessage &&
               product.features


### PR DESCRIPTION
Flag is no longer needed, as storage image resizing has been released to GA.