### PR TITLE
fix: docs - made ilike change

### DIFF
--- a/spec/supabase_js_v2.yml
+++ b/spec/supabase_js_v2.yml
@@ -3704,7 +3704,7 @@ functions:
           const { data, error } = await supabase
             .from('countries')
             .select()
-            .like('name', '%alba%')
+            .ilike('name', '%alba%')
           ```
         data:
           sql: |


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs Fix - [ilike docs](https://supabase.com/docs/reference/javascript/ilike)

## What is the current behavior?

The ilike example is missing a character.

## What is the new behavior?

Added in a missing character:

<img width="1106" alt="Screenshot 2022-12-20 at 09 34 03" src="https://user-images.githubusercontent.com/22655069/208634299-faf569a7-1fff-40cb-9dab-9bc92e1ba724.png">


## Additional context

Closes #11106
