### PR TITLE
fix: docs - integration icons

### DIFF
--- a/apps/docs/pages/guides/integrations.mdx
+++ b/apps/docs/pages/guides/integrations.mdx
@@ -1,5 +1,6 @@
 import Layout from '~/layouts/DefaultLayout'
 import Link from 'next/link'
+import Image from 'next/image'
 import { GlassPanel } from 'ui'
 import { integrations } from '~/components/Navigation/NavigationMenu/NavigationMenu.constants'
 
@@ -20,7 +21,7 @@ Explore a variety of integrations from Supabase partners. Need a different integ
             <GlassPanel
               title={integration.name}
               background={false}
-              icon={<img className="w-10 h-10 rounded" src={`/docs/img/integrations/logos/${integration.name.toLowerCase()}_logo.png`}/>}
+              icon={<Image height={40} width={40} className="rounded" src={`/docs/img/integrations/logos/${integration.name.toLowerCase()}_logo.png`}/>}
             >
               {integration.description}
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase docs - [Integrations](https://supabase.com/docs/guides/integrations)

## What is the current behavior?

The icons seem to be all different sizes:

<img width="1106" alt="Screenshot 2022-12-20 at 10 58 10" src="https://user-images.githubusercontent.com/22655069/208652075-80f1c010-7932-4687-9c01-8baf19449746.png">


## What is the new behavior?

Changed over to `Next/Image` and using static values:

<img width="1106" alt="Screenshot 2022-12-20 at 11 01 35" src="https://user-images.githubusercontent.com/22655069/208652134-d4c5a6f9-e1ec-4825-aba1-10b549bc05c5.png">


## Additional context

Closes #11109 
