### PR TITLE
feat: studio - table editor column tooltip and description

### DIFF
--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.tsx
@@ -190,7 +190,7 @@ const ColumnEditor: FC<Props> = ({
           <Input
             label="Name"
             type="text"
-            descriptionText="Recommended to use lowercase and use an underscore to seperate words e.g. column_name"
+            descriptionText="Recommended to use lowercase and use an underscore to separate words e.g. column_name"
             placeholder='column_name'
             error={errors.name}
             value={columnFields?.name ?? ''}

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.tsx
@@ -190,6 +190,8 @@ const ColumnEditor: FC<Props> = ({
           <Input
             label="Name"
             type="text"
+            descriptionText="Recommended to use lowercase and use an underscore to seperate words e.g. column_name"
+            placeholder='column_name'
             error={errors.name}
             value={columnFields?.name ?? ''}
             onChange={(event: any) => onUpdateField({ name: event.target.value })}

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/Column.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/Column.tsx
@@ -71,7 +71,7 @@ const Column: FC<Props> = ({
             size="small"
             title={column.name}
             disabled={hasImportContent}
-            placeholder="Column name"
+            placeholder="column_name"
             className={`table-editor-columns-input bg-white dark:bg-transparent lg:gap-0 ${
               hasImportContent ? 'opacity-50' : ''
             } rounded-md`}

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/ColumnManagement.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/ColumnManagement.tsx
@@ -197,8 +197,29 @@ const ColumnManagement: FC<Props> = ({
           <div className="flex w-full px-3">
             {/* Drag handle */}
             {isNewRecord && <div className="w-[5%]" />}
-            <div className="w-[25%]">
+            <div className="w-[25%] flex items-center space-x-2">
               <h5 className="text-xs text-scale-900">Name</h5>
+              <Tooltip.Root delayDuration={0}>
+                <Tooltip.Trigger>
+                  <h5 className="text-xs text-scale-900">
+                    <IconHelpCircle size={15} strokeWidth={1.5} />
+                  </h5>
+                </Tooltip.Trigger>
+                <Tooltip.Content side="bottom">
+                  <Tooltip.Arrow className="radix-tooltip-arrow" />
+                  <div
+                    className={[
+                      'rounded bg-scale-100 py-1 px-2 leading-none shadow', // background
+                      'border border-scale-200 ', //border
+                    ].join(' ')}
+                  >
+                    <span className="text-xs text-scale-1200">
+                      Recommended to use lowercase and use an underscore to seperate words e.g.
+                      column_name
+                    </span>
+                  </div>
+                </Tooltip.Content>
+              </Tooltip.Root>
             </div>
             <div className="w-[25%]">
               <h5 className="text-xs text-scale-900">Type</h5>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Studio Feature - Adding a new table/editing a column name

## What is the current behavior?

Highlighted in #10121 - When adding a column into a table it may be a good idea to advice on naming conventions e.g. using lowercase or underscores.

## What is the new behavior?

A tooltip has been added on the table editor section next to column name:


https://user-images.githubusercontent.com/22655069/200368745-0aaac692-a23a-46c7-b948-0e7ddb322b1f.mov

A field description has been added when adding a single column in the table editor:

<img width="677" alt="Screenshot 2022-11-07 at 16 51 33" src="https://user-images.githubusercontent.com/22655069/200368851-14f5b9ac-2bb2-4755-a624-6df63ede71cf.png">


## Additional context

Closes #10121

Recreation of #10148