### PR TITLE
fix: studio - user management starter

### DIFF
--- a/studio/components/interfaces/SQLEditor/SQLEditor.constants.ts
+++ b/studio/components/interfaces/SQLEditor/SQLEditor.constants.ts
@@ -812,7 +812,7 @@ create publication supabase_realtime
     sql: `
 -- Create a table for public profiles
 create table profiles (
-  id uuid references auth.users not null primary key,
+  id uuid references auth.users on delete cascade not null primary key,
   updated_at timestamp with time zone,
   username text unique,
   full_name text,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase Studio - User Management Starter

## What is the current behavior?

When using the starter template you can got a conflict error message if you try to delete a user from the Authentication section due to data being in `public.profiles`.

## What is the new behavior?

Added a `on delete cascade` so that when the user gets deleted in Authentication the user then gets delete in `public.profiles`
