### PR TITLE
docs: fix broken link on Self-Hosting page

### DIFF
--- a/apps/docs/pages/guides/self-hosting.mdx
+++ b/apps/docs/pages/guides/self-hosting.mdx
@@ -149,7 +149,7 @@ We realize that database migrations are difficult, and this is one of the proble
 
 While Supabase officially supports Docker, we have several other deployment strategies managed by the community:
 
-- [supabase-docker](../../guides/hosting/docker) (Official)
+- [supabase-docker](../../guides/self-hosting/docker) (Official)
 - [supabase-kubernetes](https://github.com/supabase-community/supabase-kubernetes) (Unofficial)
 - [supabase-terraform](https://github.com/supabase-community/supabase-terraform) (Unofficial)
 - [supabase-traefik](https://github.com/supabase-community/supabase-traefik) (Unofficial)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix broken link on https://supabase.com/docs/guides/self-hosting#deployment-options

## What is the current behavior?

Redirect to 404 page

## What is the new behavior?

Fixed broken link

## Additional context

N/A
