### PR TITLE
docs: fix broken self-host/docker link in documentation

### DIFF
--- a/apps/docs/pages/guides/self-hosting.mdx
+++ b/apps/docs/pages/guides/self-hosting.mdx
@@ -149,7 +149,7 @@ We realize that database migrations are difficult, and this is one of the proble
 
 While Supabase officially supports Docker, we have several other deployment strategies managed by the community:
 
-- [supabase-docker](./docker) (Official)
+- [supabase-docker](/docs/guides/self-hosting/docker) (Official)
 - [supabase-kubernetes](https://github.com/supabase-community/supabase-kubernetes) (Unofficial)
 - [supabase-terraform](https://github.com/supabase-community/supabase-terraform) (Unofficial)
 - [supabase-traefik](https://github.com/supabase-community/supabase-traefik) (Unofficial)

--- a/apps/docs/pages/guides/self-hosting.mdx
+++ b/apps/docs/pages/guides/self-hosting.mdx
@@ -149,7 +149,7 @@ We realize that database migrations are difficult, and this is one of the proble
 
 While Supabase officially supports Docker, we have several other deployment strategies managed by the community:
 
-- [supabase-docker](../../guides/hosting/docker) (Official)
+- [supabase-docker](./docker) (Official)
 - [supabase-kubernetes](https://github.com/supabase-community/supabase-kubernetes) (Unofficial)
 - [supabase-terraform](https://github.com/supabase-community/supabase-terraform) (Unofficial)
 - [supabase-traefik](https://github.com/supabase-community/supabase-traefik) (Unofficial)


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

404 on click at link in docs.

## What is the new behavior?

should now open the expected docs page.