### PR TITLE
Update Developers links

### DIFF
--- a/apps/www/data/Developers.json
+++ b/apps/www/data/Developers.json
@@ -1,26 +1,20 @@
 [
   {
     "text": "Documentation",
-    "description": "Everything you need that makes it simple to get started.",
+    "description": "Everything you need to start building with Supabase.",
     "url": "/docs",
     "icon": "M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
   },
   {
-    "text": "API reference",
-    "description": "Examples and references for using API libraries.",
-    "url": "/docs/client/supabase-client",
-    "icon": "M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"
-  },
-  {
-    "text": "Guides",
-    "description": "Examples and references for using Supabase.",
-    "url": "/docs/",
+    "text": "Changelog",
+    "description": "See the latest updates and product improvements.",
+    "url": "/changelog",
     "icon": "M19.428 15.428a2 2 0 00-1.022-.547l-2.387-.477a6 6 0 00-3.86.517l-.318.158a6 6 0 01-3.86.517L6.05 15.21a2 2 0 00-1.806.547M8 4h8l-1 1v5.172a2 2 0 00.586 1.414l5 5c1.26 1.26.367 3.414-1.415 3.414H4.828c-1.782 0-2.674-2.154-1.414-3.414l5-5A2 2 0 009 10.172V5L8 4z"
   },
   {
     "text": "Careers",
     "description": "Join the Supabase team and get involved.",
-    "url": "https://supabase.com/careers",
+    "url": "/careers",
     "icon": "M21 13.255A23.931 23.931 0 0112 15c-3.183 0-6.22-.62-9-1.745M16 6V4a2 2 0 00-2-2h-4a2 2 0 00-2 2v2m4 6h.01M5 20h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
   }
 ]


### PR DESCRIPTION
## Preview URL

https://zone-www-dot-com-git-docs-www-links-supabase.vercel.app/

## What is the current behavior?

Three of these links point to `/docs`
![Screenshot 2022-12-20 at 4 54 42 PM](https://user-images.githubusercontent.com/7026076/208795525-6e341a17-4839-41b3-aeb3-a6a6fcb60fde.png)

## What is the new behavior?

![Screenshot 2022-12-20 at 4 54 56 PM](https://user-images.githubusercontent.com/7026076/208795569-c60377cf-3730-4027-a7b9-cc24df6747c2.png)