### PR TITLE
add step using "shadow databases" to prisma guide

### DIFF
--- a/apps/docs/pages/guides/integrations/prisma.mdx
+++ b/apps/docs/pages/guides/integrations/prisma.mdx
@@ -63,21 +63,38 @@ This project comes with TypeScript configured and has the following structure.
 
 ### Configuring the project to use PostgreSQL
 
-Go ahead and delete the `prisma/dev.db` file because we will be switching to PostgreSQL.
-Next, inside the `prisma/.env` file, update the value of the `DATABASE_URL` variable to the connection string you got in **step 1**. The URL might look as follows:
+Prisma init migrations will try to drop `postgres` database by default, and this may lead to conflicts with Supabase initial migrations that are critically needed for the correct functioning of our managed databases. For such cases Prisma has a feature called [Shadow Databases](https://www.prisma.io/docs/concepts/components/prisma-migrate/shadow-database#cloud-hosted-shadow-databases-must-be-created-manually).
 
-```env
-# prisma/.env
-postgres://postgres:[YOUR-PASSWORD]@db.vdbnhqozmlzdsaejdxwr.supabase.co:5432/postgres
+To make it work we need to create shadow database, it can be the local database, or you can create another database in your PostgreSQL server right inside the same supabase project. Here is how you may do this, you will need `psql` CLI and the `DATABASE_URL` from previous steps.
+
+```bash
+psql postgresql://postgres:[YOUR-PASSWORD]@db.vdbnhqozmlzdsaejdxwr.supabase.red:5432
 ```
 
-Finally, inside your `schema.prisma` file, change the `provider` from “sqlite” to `“postgresql”`.
+After you connect to your project's PostgreSQL instance, you should create another databasee and name it for example `postgres_shadow`
+
+```bash
+postgres=> CREATE DATABASE postgres_shadow;
+postgres=> exit
+```
+
+Go ahead and delete the `prisma/dev.db` file because we will be switching to PostgreSQL.
+Next, inside the `.env` file, update the value of the `DATABASE_URL` and `SHADOW_DATABASE_URL` variables to the connection string you got in **step 1**. The `.env` file might look as follows:
+
+```env
+# .env
+DATABASE_URL="postgres://postgres:[YOUR-PASSWORD]@db.vdbnhqozmlzdsaejdxwr.supabase.co:5432/postgres"
+SHADOW_DATABASE_URL="postgres://postgres:[YOUR-PASSWORD]@db.vdbnhqozmlzdsaejdxwr.supabase.co:5432/postgres_shadow"
+```
+
+Finally, inside your `schema.prisma` file, change the `provider` from “sqlite” to `“postgresql”` and add `shadowDatabaseUrl` property.
 This is what your `schema.prisma` file should look like:
 
 ```go
 datasource db {
   provider = “postgresql”
   url      = env(“DATABASE_URL”)
+  shadowDatabaseUrl = env("SHADOW_DATABASE_URL")
 }
 generator client {
   provider = “prisma-client-js”
@@ -124,11 +141,12 @@ This will create a `prisma/migrations` folder inside your `prisma` directory and
 If you’re working in a serverless environment (for example Node.js functions hosted on AWS Lambda, Vercel or Netlify Functions), you need to set up [connection pooling](https://www.prisma.io/docs/guides/performance-and-optimization/connection-management#serverless-environments-faas) using a tool like [PgBouncer](https://www.pgbouncer.org/). That’s because every function invocation may result in a [new connection to the database](https://www.prisma.io/docs/guides/performance-and-optimization/connection-management#the-serverless-challenge). Supabase [supports connection management using PgBouncer](https://supabase.io/blog/2021/04/02/supabase-pgbouncer#what-is-connection-pooling) and are enabled by default.
 Go to the **Database** page from the sidebar in the Supabase dashboard and navigate to **connection pool** settings
 ![Connection pool settings](/docs/img/guides/integrations/prisma/w0oowg8vq435ob5c3gf0.png)
-When running migrations you need to use the non pooled connection URL (like the one we used in **step 1**). However, when deploying your app, you’ll use the pooled connection URL and add the `?pgbouncer=true` flag to the PostgreSQL connection URL. To minimize the number of concurrent connections, setting the `connection_limit` to `1` is also recommended. So the URL might look as follows:
+When running migrations you need to use the non pooled connection URL (like the one we used in **step 1**). However, when deploying your app, you’ll use the pooled connection URL and add the `?pgbouncer=true` flag to the PostgreSQL connection URL. To minimize the number of concurrent connections, setting the `connection_limit` to `1` is also recommended. So the `.env` file might look as follows:
 
 ```env
-# prisma/.env
-postgres://postgres:[YOUR-PASSWORD]@db.vdbnhqozmlzdsaejdxwr.supabase.co:6543/postgres?pgbouncer=true&connection_limit=1
+# .env
+DATABASE_URL="postgres://postgres:[YOUR-PASSWORD]@db.vdbnhqozmlzdsaejdxwr.supabase.co:6543/postgres?pgbouncer=true&connection_limit=1"
+SHADOW_DATABASE_URL="postgres://postgres:[YOUR-PASSWORD]@db.vdbnhqozmlzdsaejdxwr.supabase.co:5432/postgres_shadow"
 ```
 
 Prisma Migrate uses database transactions to check out the current state of the database and the migrations table. However, the Migration Engine is designed to use a single connection to the database, and does not support connection pooling with PgBouncer. If you attempt to run Prisma Migrate commands in any environment that uses PgBouncer for connection pooling, you might see the following error:

--- a/apps/docs/pages/guides/integrations/prisma.mdx
+++ b/apps/docs/pages/guides/integrations/prisma.mdx
@@ -63,7 +63,7 @@ This project comes with TypeScript configured and has the following structure.
 
 ### Configuring the project to use PostgreSQL
 
-Prisma init migrations will try to drop `postgres` database by default, and this may lead to conflicts with Supabase initial migrations that are critically needed for the correct functioning of our managed databases. For such cases Prisma has a feature called [Shadow Databases](https://www.prisma.io/docs/concepts/components/prisma-migrate/shadow-database#cloud-hosted-shadow-databases-must-be-created-manually).
+By default, Prisma migrations will try to drop the `postgres` database, which can lead to conflicts with Supabase databases. For this scenario, use [Prisma Shadow Databases](https://www.prisma.io/docs/concepts/components/prisma-migrate/shadow-database#cloud-hosted-shadow-databases-must-be-created-manually).
 
 Create a shadow database with the local database (or create another database in your PostgreSQL server with the same Supabase project) using the `psql` CLI and the `DATABASE_URL` from the previous steps.
 

--- a/apps/docs/pages/guides/integrations/prisma.mdx
+++ b/apps/docs/pages/guides/integrations/prisma.mdx
@@ -65,13 +65,13 @@ This project comes with TypeScript configured and has the following structure.
 
 Prisma init migrations will try to drop `postgres` database by default, and this may lead to conflicts with Supabase initial migrations that are critically needed for the correct functioning of our managed databases. For such cases Prisma has a feature called [Shadow Databases](https://www.prisma.io/docs/concepts/components/prisma-migrate/shadow-database#cloud-hosted-shadow-databases-must-be-created-manually).
 
-To make it work we need to create shadow database, it can be the local database, or you can create another database in your PostgreSQL server right inside the same supabase project. Here is how you may do this, you will need `psql` CLI and the `DATABASE_URL` from previous steps.
+Create a shadow database with the local database (or create another database in your PostgreSQL server with the same Supabase project) using the `psql` CLI and the `DATABASE_URL` from the previous steps.
 
 ```bash
 psql postgresql://postgres:[YOUR-PASSWORD]@db.vdbnhqozmlzdsaejdxwr.supabase.red:5432
 ```
 
-After you connect to your project's PostgreSQL instance, you should create another databasee and name it for example `postgres_shadow`
+After you connect to your project's PostgreSQL instance, create another database (e.g., `postgres_shadow`):
 
 ```bash
 postgres=> CREATE DATABASE postgres_shadow;
@@ -79,7 +79,7 @@ postgres=> exit
 ```
 
 Go ahead and delete the `prisma/dev.db` file because we will be switching to PostgreSQL.
-Next, inside the `.env` file, update the value of the `DATABASE_URL` and `SHADOW_DATABASE_URL` variables to the connection string you got in **step 1**. The `.env` file might look as follows:
+In the `.env` file, update `DATABASE_URL` and `SHADOW_DATABASE_URL` to the connection string from **step 1**. The `.env` file should look like:
 
 ```env
 # .env
@@ -87,7 +87,7 @@ DATABASE_URL="postgres://postgres:[YOUR-PASSWORD]@db.vdbnhqozmlzdsaejdxwr.supaba
 SHADOW_DATABASE_URL="postgres://postgres:[YOUR-PASSWORD]@db.vdbnhqozmlzdsaejdxwr.supabase.co:5432/postgres_shadow"
 ```
 
-Finally, inside your `schema.prisma` file, change the `provider` from “sqlite” to `“postgresql”` and add `shadowDatabaseUrl` property.
+In the `schema.prisma` file, change the `provider` from "sqlite" to `"postgresql"` and add the `shadowDatabaseUrl` property.
 This is what your `schema.prisma` file should look like:
 
 ```go
@@ -141,7 +141,7 @@ This will create a `prisma/migrations` folder inside your `prisma` directory and
 If you’re working in a serverless environment (for example Node.js functions hosted on AWS Lambda, Vercel or Netlify Functions), you need to set up [connection pooling](https://www.prisma.io/docs/guides/performance-and-optimization/connection-management#serverless-environments-faas) using a tool like [PgBouncer](https://www.pgbouncer.org/). That’s because every function invocation may result in a [new connection to the database](https://www.prisma.io/docs/guides/performance-and-optimization/connection-management#the-serverless-challenge). Supabase [supports connection management using PgBouncer](https://supabase.io/blog/2021/04/02/supabase-pgbouncer#what-is-connection-pooling) and are enabled by default.
 Go to the **Database** page from the sidebar in the Supabase dashboard and navigate to **connection pool** settings
 ![Connection pool settings](/docs/img/guides/integrations/prisma/w0oowg8vq435ob5c3gf0.png)
-When running migrations you need to use the non pooled connection URL (like the one we used in **step 1**). However, when deploying your app, you’ll use the pooled connection URL and add the `?pgbouncer=true` flag to the PostgreSQL connection URL. To minimize the number of concurrent connections, setting the `connection_limit` to `1` is also recommended. So the `.env` file might look as follows:
+When migrating, you need to use the non-pooled connection URL (like the one used in **step 1**). However, when deploying your app, use the pooled connection URL and add the `?pgbouncer=true` flag to the PostgreSQL connection URL. It's also recommended to minimize the number of concurrent connections by setting the `connection_limit` to `1`. The `.env` file should look like:
 
 ```env
 # .env

--- a/apps/docs/pages/guides/integrations/prisma.mdx
+++ b/apps/docs/pages/guides/integrations/prisma.mdx
@@ -65,7 +65,7 @@ This project comes with TypeScript configured and has the following structure.
 
 By default, Prisma migrations will try to drop the `postgres` database, which can lead to conflicts with Supabase databases. For this scenario, use [Prisma Shadow Databases](https://www.prisma.io/docs/concepts/components/prisma-migrate/shadow-database#cloud-hosted-shadow-databases-must-be-created-manually).
 
-Create a shadow database with the local database (or create another database in your PostgreSQL server with the same Supabase project) using the `psql` CLI and the `DATABASE_URL` from the previous steps.
+Create a shadow database in your PostgreSQL server within the same Supabase project using the `psql` CLI and the `DATABASE_URL` from the previous steps (or use the local database).
 
 ```bash
 psql postgresql://postgres:[YOUR-PASSWORD]@db.vdbnhqozmlzdsaejdxwr.supabase.red:5432


### PR DESCRIPTION
## What kind of change does this PR introduce?

- fix for prisma docs with new init workflow using ["shadow databases"](https://www.prisma.io/docs/concepts/components/prisma-migrate/shadow-database#cloud-hosted-shadow-databases-must-be-created-manually)

## Additional context

We got a lot of support tickets about failing prisma migrations with supabase projects. This should help to see less of them as this is up-to-date with current prisma behaviour.
