### PR TITLE
Add missing import to component

### DIFF
--- a/apps/docs/pages/guides/getting-started/tutorials/with-nextjs.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-nextjs.mdx
@@ -125,6 +125,7 @@ export default MyApp
 Wrap your `pages/_app.tsx` component with the `SessionContextProvider` component:
 
 ```jsx lines=2,8 title=pages/_app.tsx
+import { useState } from 'react'
 import { createBrowserSupabaseClient } from '@supabase/auth-helpers-nextjs'
 import { SessionContextProvider, Session } from '@supabase/auth-helpers-react'
 


### PR DESCRIPTION
On line 138 the component is using a `useState` function call which is a react hook, however no react hook is imported causing an error.

## What kind of change does this PR introduce?

docs updates

## What is the current behavior?

## What is the new behavior?

All functions in the code are defined with next.js

## Additional context

Add any other context or screenshots.
