### PR TITLE
docs: extensions search background

### DIFF
--- a/apps/docs/components/Extensions.js
+++ b/apps/docs/components/Extensions.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import { IconSearch, Input } from '~/../../packages/ui'
 import extensions from '../data/extensions.json'
 
 export default function Extensions() {
@@ -7,13 +8,11 @@ export default function Extensions() {
     <>
       <div className="mb-8 grid">
         <label className="text-xs mb-2">Filter extensions</label>
-        <input
+        <Input
           type="text"
-          className="border bg-gray-200
-          transition
-          hover:border-scale-600
-          border-scale-500 rounded"
-          placeholder="Extension name"
+          className="border text-scale-900"
+          placeholder="Search extension names..."
+          icon={<IconSearch size="small" />}
           onChange={(e) => setFilter(e.target.value)}
         />
       </div>

--- a/apps/docs/components/Extensions.js
+++ b/apps/docs/components/Extensions.js
@@ -9,7 +9,10 @@ export default function Extensions() {
         <label className="text-xs mb-2">Filter extensions</label>
         <input
           type="text"
-          className="border text-gray-200"
+          className="border bg-gray-200
+          transition
+          hover:border-scale-600
+          border-scale-500 rounded"
           placeholder="Extension name"
           onChange={(e) => setFilter(e.target.value)}
         />


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase docs - [Extensions](https://supabase.com/docs/guides/database/extensions#full-list-of-extensions)

## What is the current behavior?

The search does not look right with the theming on the docs:

<img width="843" alt="Screenshot 2022-12-22 at 10 06 59" src="https://user-images.githubusercontent.com/22655069/209110717-ceb8548b-bb19-4fb2-9fa7-86227a369552.png">


## What is the new behavior?

Background has been changed to match in with site theme:

<img width="843" alt="Screenshot 2022-12-22 at 10 06 27" src="https://user-images.githubusercontent.com/22655069/209110776-fdfb8abd-9f2c-4b05-a040-e452163a72bb.png">

