### PR TITLE
fix(docs/sitelayout): not responsive on mobile view and not scrollable on resize from mobile to web view

### DIFF
--- a/apps/docs/layouts/SiteLayout.tsx
+++ b/apps/docs/layouts/SiteLayout.tsx
@@ -224,9 +224,7 @@ const Container = memo(function Container(props) {
         // 'overflow-x-auto',
         'w-full h-screen transition-all ease-out',
         'absolute lg:relative',
-        mobileMenuOpen
-          ? '!w-auto ml-[75%] sm:ml-[50%] md:ml-[33%] overflow-hidden'
-          : 'overflow-auto',
+        mobileMenuOpen ? '!w-auto ml-[75%] sm:ml-[50%] md:ml-[33%]' : 'overflow-auto',
         // desktop override any margin styles
         'lg:ml-0',
       ].join(' ')}
@@ -287,7 +285,7 @@ const NavContainer = memo(function NavContainer() {
 })
 
 const SiteLayout = ({ children }) => {
-  // const mobileMenuOpen = useMenuMobileOpen()
+  const mobileMenuOpen = useMenuMobileOpen()
 
   useEffect(() => {
     const key = localStorage.getItem('supabaseDarkMode')
@@ -299,9 +297,26 @@ const SiteLayout = ({ children }) => {
     }
   }, [])
 
+  useEffect(() => {
+    window.addEventListener('resize', (e: UIEvent) => {
+      const w = e.target as Window
+      if (mobileMenuOpen && w.innerWidth >= 640) {
+        menuState.setMenuMobileOpen(!mobileMenuOpen)
+      }
+    })
+    return () => {
+      window.removeEventListener('resize', () => {})
+    }
+  }, [])
+
   return (
     <main>
-      <div className="flex flex-row h-screen">
+      <div
+        className={[
+          'flex flex-row h-screen',
+          mobileMenuOpen ? 'relative overflow-hidden' : '',
+        ].join(' ')}
+      >
         <NavContainer />
         <Container>
           <div className={['lg:sticky top-0 z-10 overflow-hidden'].join(' ')}>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## reproduce
there are two things here:

1. Page is not responsive on mobile view when open side menu.
You can check by visiting this https://supabase.com/docs on a mobile view and open side menu and try to scroll. You will see the UI is broken.

2. Page overflow hidden and user can not scroll through content.
To reproduce, you can visit https://supabase.com/docs and resize window to mobile view and open side menu. After that you resize the screen back to the desktop view. You will see that you won't be able to scroll the content because we haven't close the side menu yet.

## What is the current behavior?

- site layout is not responsive on mobile view when open mobile menu
![Screen Shot 2022-12-22 at 6 28 04 PM](https://user-images.githubusercontent.com/52232579/209124812-75547341-3072-4323-9737-f05cff78e1f3.png)

- after open mobile menu and resize the screen to desktop view. The page is not scrollable  



## What is the new behavior?

Fix the two issues above
- make it responsive
- automatically close mobileMenu when resize to desktop view so we can scroll the content 


