### PR TITLE
chore: do not send captcha token for subscription endpoint

### DIFF
--- a/studio/components/interfaces/Billing/Billing.utils.ts
+++ b/studio/components/interfaces/Billing/Billing.utils.ts
@@ -52,8 +52,7 @@ export const formSubscriptionUpdatePayload = (
   },
   nonChangeableAddons: SubscriptionAddon[],
   selectedPaymentMethod: string,
-  region: string,
-  hcaptchaToken: string | undefined
+  region: string
 ) => {
   const { computeSize, pitrDuration, customDomains } = selectedAddons
 
@@ -78,8 +77,7 @@ export const formSubscriptionUpdatePayload = (
     ...(tierPriceId && { tier: tierPriceId.id }),
     addons,
     proration_date,
-    payment_method: selectedPaymentMethod,
-    hcaptchaToken
+    payment_method: selectedPaymentMethod
   }
 }
 

--- a/studio/components/interfaces/Billing/EnterpriseUpdate.tsx
+++ b/studio/components/interfaces/Billing/EnterpriseUpdate.tsx
@@ -114,8 +114,7 @@ const EnterpriseUpdate: FC<Props> = ({
         selectedAddons,
         nonChangeableAddons,
         selectedPaymentMethodId,
-        projectRegion,
-        undefined
+        projectRegion
       ),
       tier: currentSubscription.tier.price_id,
     }
@@ -178,8 +177,7 @@ const EnterpriseUpdate: FC<Props> = ({
         selectedAddons,
         nonChangeableAddons,
         selectedPaymentMethodId,
-        projectRegion,
-        token ?? undefined
+        projectRegion
       ),
       tier: currentSubscription.tier.price_id,
     }

--- a/studio/components/interfaces/Billing/ExitSurvey/ExitSurvey.tsx
+++ b/studio/components/interfaces/Billing/ExitSurvey/ExitSurvey.tsx
@@ -109,7 +109,7 @@ const ExitSurvey: FC<Props> = ({ freeTier, subscription, onSelectBack }) => {
       setMessage(values.message)
       return setShowConfirmModal(true)
     } else {
-      downgradeProject(values, token as string)
+      downgradeProject(values)
     }
   }
 
@@ -118,7 +118,7 @@ const ExitSurvey: FC<Props> = ({ freeTier, subscription, onSelectBack }) => {
     captchaRef.current?.resetCaptcha()
   }
 
-  const downgradeProject = async (values?: any, hcaptchaToken?: string) => {
+  const downgradeProject = async (values?: any) => {
     const downgradeMessage = values?.message ?? message
 
     try {
@@ -132,7 +132,6 @@ const ExitSurvey: FC<Props> = ({ freeTier, subscription, onSelectBack }) => {
         tier,
         addons,
         proration_date,
-        hcaptchaToken: captchaToken ?? hcaptchaToken,
       })
 
       resetCaptcha()

--- a/studio/components/interfaces/Billing/ProUpgrade.tsx
+++ b/studio/components/interfaces/Billing/ProUpgrade.tsx
@@ -137,8 +137,7 @@ const ProUpgrade: FC<Props> = ({
       selectedAddons,
       nonChangeableAddons,
       selectedPaymentMethodId,
-      projectRegion,
-      undefined
+      projectRegion
     )
 
     setIsRefreshingPreview(true)
@@ -184,8 +183,7 @@ const ProUpgrade: FC<Props> = ({
       selectedAddons,
       nonChangeableAddons,
       selectedPaymentMethodId,
-      projectRegion,
-      captchaToken ?? undefined
+      projectRegion
     )
     const res = await patch(`${API_URL}/projects/${projectRef}/subscription`, payload)
     resetCaptcha()


### PR DESCRIPTION
As some of our users want to automate subscription changes (specifically compute sizes), we can't enforce hCaptchaToken on the backend for the subscription endpoint.

- We will still trigger hCaptcha on the frontend, just not send it to the backend for subscription changes
- We will still validate hCaptcha on the backend for setting up an intent (start of adding a payment method)