### PR TITLE
Updated plain text descriptions of file locations for sveltekit.

### DIFF
--- a/apps/docs/pages/guides/getting-started/tutorials/with-sveltekit.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-sveltekit.mdx
@@ -46,8 +46,8 @@ PUBLIC_SUPABASE_URL="YOUR_SUPABASE_URL"
 PUBLIC_SUPABASE_ANON_KEY="YOUR_SUPABASE_KEY"
 ```
 
-Now that we have the API credentials in place, let's create a helper file to initialize the Supabase client. These variables will be exposed
-on the browser, and that's completely fine since we have [Row Level Security](/docs/guides/auth#row-level-security) enabled on our Database.
+Now that we have the API credentials in place, let's create a helper file to initialize the Supabase client. Call it `src/lib/supabaseClient.ts`. 
+These variables will be exposed on the browser, and that's completely fine since we have [Row Level Security](/docs/guides/auth#row-level-security) enabled on our Database.
 
 ```js title=src/lib/supabaseClient.ts
 import { createClient } from '@supabase/auth-helpers-sveltekit'
@@ -136,6 +136,7 @@ import '$lib/supabaseClient'
 ### Set up a Login component
 
 Let's set up a Svelte component to manage logins and sign ups. We'll use Magic Links, so users can sign in with their email without using passwords.
+Create a new `Auth.svelte` component in the `src/routes` directory to handle this functionality.
 
 ```html title=src/routes/Auth.svelte
 <script lang="ts">
@@ -178,7 +179,7 @@ Let's set up a Svelte component to manage logins and sign ups. We'll use Magic L
 ### Account component
 
 After a user is signed in, they need to be able to edit their profile details and manage their account.
-Create a new `Account.svelte` component to handle this functionality.
+Create a new `Account.svelte` component in the `src/routes` directory to handle this functionality.
 
 ```html title=src/routes/Account.svelte
 <script lang="ts">
@@ -328,7 +329,7 @@ Every Supabase project is configured with [Storage](/docs/guides/storage) for ma
 
 ### Create an upload widget
 
-Let's create an avatar for the user so that they can upload a profile photo. We can start by creating a new component:
+Let's create an avatar for the user so that they can upload a profile photo. We can start by creating a new component called `Avatar.svelte` in the `src/routes` directory:
 
 ```html title=src/routes/Avatar.svelte
 <script lang="ts">

--- a/apps/docs/pages/guides/getting-started/tutorials/with-sveltekit.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-sveltekit.mdx
@@ -46,7 +46,7 @@ PUBLIC_SUPABASE_URL="YOUR_SUPABASE_URL"
 PUBLIC_SUPABASE_ANON_KEY="YOUR_SUPABASE_KEY"
 ```
 
-Now that we have the API credentials in place, let's create a helper file to initialize the Supabase client. Call it `src/lib/supabaseClient.ts`. 
+Now that we have the API credentials in place, create a `src/lib/supabaseClient.ts` helper file to initialize the Supabase client.
 These variables will be exposed on the browser, and that's completely fine since we have [Row Level Security](/docs/guides/auth#row-level-security) enabled on our Database.
 
 ```js title=src/lib/supabaseClient.ts


### PR DESCRIPTION
I struggled following this guide on the homepage because the site CSS does not show the title of the markdown code snippets in the plain text of the code. As such the path is hidden, and as a new user of the codebase, it's important to be clear about where the code should be located and what it should be called.

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
