### PR TITLE
public/global.css in the sveltekit tutorial is named wrong and told to be placed in the wrong place.

### DIFF
--- a/apps/docs/pages/guides/getting-started/tutorials/with-sveltekit.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-sveltekit.mdx
@@ -56,8 +56,7 @@ import { env } from '$env/dynamic/public'
 export const supabase = createClient(env.PUBLIC_SUPABASE_URL, env.PUBLIC_SUPABASE_ANON_KEY)
 ```
 
-And one optional step is to update the CSS file `src/routes/style.css` to make the app look nice.
-You can find the full contents of this file [here](https://raw.githubusercontent.com/supabase/supabase/master/examples/user-management/svelte-user-management/src/app.css).
+Optionally, update `src/routes/style.css` with the [CSS from the example](https://raw.githubusercontent.com/supabase/supabase/master/examples/user-management/svelte-user-management/src/app.css).
 If you don't add this file, you will need to remove the import statement in `src/routes/+layout.svelte` (created later).
 
 ### Supabase Auth Helpers

--- a/apps/docs/pages/guides/getting-started/tutorials/with-sveltekit.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-sveltekit.mdx
@@ -56,8 +56,9 @@ import { env } from '$env/dynamic/public'
 export const supabase = createClient(env.PUBLIC_SUPABASE_URL, env.PUBLIC_SUPABASE_ANON_KEY)
 ```
 
-And one optional step is to update the CSS file `public/global.css` to make the app look nice.
+And one optional step is to update the CSS file `src/routes/style.css` to make the app look nice.
 You can find the full contents of this file [here](https://raw.githubusercontent.com/supabase/supabase/master/examples/user-management/svelte-user-management/src/app.css).
+If you don't add this file, you will need to remove the import statement in `src/routes/+layout.svelte` (created later).
 
 ### Supabase Auth Helpers
 

--- a/apps/docs/pages/guides/getting-started/tutorials/with-sveltekit.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-sveltekit.mdx
@@ -57,7 +57,6 @@ export const supabase = createClient(env.PUBLIC_SUPABASE_URL, env.PUBLIC_SUPABAS
 ```
 
 Optionally, update `src/routes/style.css` with the [CSS from the example](https://raw.githubusercontent.com/supabase/supabase/master/examples/user-management/svelte-user-management/src/app.css).
-If you don't add this file, you will need to remove the import statement in `src/routes/+layout.svelte` (created later).
 
 ### Supabase Auth Helpers
 


### PR DESCRIPTION
This needs to be put in `src/routes` and called `styles.css`

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
