### PR TITLE
Fix more docs links

### DIFF
--- a/apps/docs/pages/guides/integrations/estuary.mdx
+++ b/apps/docs/pages/guides/integrations/estuary.mdx
@@ -3,62 +3,64 @@ import Layout from '~/layouts/DefaultGuideLayout'
 export const meta = {
   id: 'estuary',
   title: 'Estuary',
-  description: 'Create a real-time data pipeline connecting Firestore and Supabase to make migration simple.',
+  description:
+    'Create a real-time data pipeline connecting Firestore and Supabase to make migration simple.',
 }
 
 Estuary Flow is a platform for creating [real-time data pipelines at scale](https://www.estuary.dev/).
-It combines the intuitive interface of an ELT service with an event-driven runtime and a variety of open-source connectors. 
+It combines the intuitive interface of an ELT service with an event-driven runtime and a variety of open-source connectors.
 
-You can use Flow to migrate your data from Firestore to the Postgres database in your Supabase project. 
+You can use Flow to migrate your data from Firestore to the Postgres database in your Supabase project.
 You do this by building a real-time pipeline that captures data from Firestore and materializes (loads) that data to Postgres.
-Once created, the pipeline backfills all your historical data from Firestore and continues to process new data events in real time. 
+Once created, the pipeline backfills all your historical data from Firestore and continues to process new data events in real time.
 
 ## Prerequisites
 
 Before you begin, you'll need:
 
-* An [Estuary account](go.estuary.dev/sign-up). 
+- An [Estuary account](https://go.estuary.dev/sign-up).
 
-* For your Firestore database:
-   * A Google service account with read access to your Firestore database, via [roles/datastore.viewer](https://cloud.google.com/datastore/docs/access/iam). You can assign this role when you [create the service account](https://cloud.google.com/iam/docs/creating-managing-service-accounts#creating), or [add it to an existing service account](https://cloud.google.com/iam/docs/granting-changing-revoking-access#single-role).
-   * A generated [JSON service account key](https://cloud.google.com/iam/docs/creating-managing-service-account-keys#creating) for the service account.
+- For your Firestore database:
 
-* A Supabase project
+  - A Google service account with read access to your Firestore database, via [roles/datastore.viewer](https://cloud.google.com/datastore/docs/access/iam). You can assign this role when you [create the service account](https://cloud.google.com/iam/docs/creating-managing-service-accounts#creating), or [add it to an existing service account](https://cloud.google.com/iam/docs/granting-changing-revoking-access#single-role).
+  - A generated [JSON service account key](https://cloud.google.com/iam/docs/creating-managing-service-account-keys#creating) for the service account.
+
+- A Supabase project
 
 ## Step 1: Capture your Firestore data
 
-You'll start by creating a **capture**, a task in Flow that connects to your data source system: in this case, Firestore. This process will create one or more data **collections**, backed by a real-time data lake. 
+You'll start by creating a **capture**, a task in Flow that connects to your data source system: in this case, Firestore. This process will create one or more data **collections**, backed by a real-time data lake.
 
 1. Go to the Flow web application at [dashboard.estuary.dev](http://dashboard.estuary.dev) and sign in using the credentials provided by your Estuary account manager.
 
 2. Click the **Captures** tab and choose **New Capture**.
 
-3. Locate and select the **Google Firestore** card. 
+3. Locate and select the **Google Firestore** card.
 
    A form appears with the properties required for a Firestore capture.
 
-4. Set a name for your capture. 
- 
+4. Set a name for your capture.
+
    Click inside the **Name** field to generate a drop-down menu of available **prefixes** and select one (likely, this will be the name of your organization). Append a unique capture name after the `/` to create the full name, for example, `acmeCo/myFirestoreCapture`.
 
 5. Fill out the required properties for Firestore.
 
-   * **Database**: Flow can autodetect the database name, but you may optionally specify it here. This is helpful if the service account used has access to multiple Firebase projects. Your database name usually follows the format `projects/$PROJECTID/databases/(default)`.
-   * **Credentials**: The JSON service account key created per the prerequisites.
+   - **Database**: Flow can autodetect the database name, but you may optionally specify it here. This is helpful if the service account used has access to multiple Firebase projects. Your database name usually follows the format `projects/$PROJECTID/databases/(default)`.
+   - **Credentials**: The JSON service account key created per the prerequisites.
 
 6. Click **Discover Endpoint**.
 
-  Flow uses the provided configuration to initiate a connection with Firestore. It generates a capture specification and details of the collections that it will create, once published.
+Flow uses the provided configuration to initiate a connection with Firestore. It generates a capture specification and details of the collections that it will create, once published.
 
-7. Use the **Specification Editor** to view the [JSON schemas](https://docs.estuary.dev/concepts/schemas/) for each collection and make sure they are formatted correctly for your needs. If they're not, you can edit them. 
+7. Use the **Specification Editor** to view the [JSON schemas](https://docs.estuary.dev/concepts/schemas/) for each collection and make sure they are formatted correctly for your needs. If they're not, you can edit them.
 
 8. Click **Save and publish**.
 
-  You'll see a notification when the capture publishes successfully.
+You'll see a notification when the capture publishes successfully.
 
-  The data currently in your Firestore database has been captured, and future updates to it will be captured continuously.
+The data currently in your Firestore database has been captured, and future updates to it will be captured continuously.
 
-  Click **Materialize Collections** to continue.
+Click **Materialize Collections** to continue.
 
 ## Step 2: Materialize your collections to Postgres
 
@@ -66,35 +68,35 @@ Next, you'll add a Postgres materialization to connect the captured collections 
 
 1. On the **Create Materialization** page, search for and select the **PostgreSQL** tile.
 
-  A form appears with the properties required for a Postgres materialization.
+A form appears with the properties required for a Postgres materialization.
 
 2. Choose a unique name for your materialization like you did when naming your capture; for example, `acmeCo/mySupabaseMaterialization`.
 
 3. Fill out the required properties for PostgreSQL. You can find most of these in Supabase by going to the **Settings** section and clicking **Database**.
 
-   * **Address**: Format at `<host>:<port>`.
-   * **User**: Usually, this is `postgres`.
-   * **Password**: The password you set when you created your Supabase project.
+   - **Address**: Format at `<host>:<port>`.
+   - **User**: Usually, this is `postgres`.
+   - **Password**: The password you set when you created your Supabase project.
 
 4. Scroll down to view the **Collection Selector** and fill in the **Table** field for each collection.
 
-  The collections you just created have already been selected, but you must provide names for the tables to which they'll be materialized.
+The collections you just created have already been selected, but you must provide names for the tables to which they'll be materialized.
 
-5. Click **Discover Endpoint**.  
-  
-  Flow uses the provided configuration to initiate a connection to your Supabase Postgres database and generate a specification.
+5. Click **Discover Endpoint**.
 
-6. Click **Save and Publish**. You'll see a notification when the full materialization publishes successfully.  
+Flow uses the provided configuration to initiate a connection to your Supabase Postgres database and generate a specification.
 
-Your Firestore collections are copied to tables in Supabase. As long as you leave the capture and materialation running, any changes to the Firestore data will be reflected in Supabase in milliseconds. 
+6. Click **Save and Publish**. You'll see a notification when the full materialization publishes successfully.
+
+Your Firestore collections are copied to tables in Supabase. As long as you leave the capture and materialation running, any changes to the Firestore data will be reflected in Supabase in milliseconds.
 
 ## Resources
 
 For more information, visit the [Flow docs](https://docs.estuary.dev/). In particular:
 
-   * [Guide to create a Data Flow](https://docs.estuary.dev/guides/create-dataflow/)
-   * [Firestore capture connector](https://docs.estuary.dev/reference/Connectors/capture-connectors/google-firestore/)
-   * [Postgres materializaiton connector](https://docs.estuary.dev/reference/Connectors/materialization-connectors/PostgreSQL/)
+- [Guide to create a Data Flow](https://docs.estuary.dev/guides/create-dataflow/)
+- [Firestore capture connector](https://docs.estuary.dev/reference/Connectors/capture-connectors/google-firestore/)
+- [Postgres materializaiton connector](https://docs.estuary.dev/reference/Connectors/materialization-connectors/PostgreSQL/)
 
 export const Page = ({ children }) => <Layout meta={meta} children={children} />
 

--- a/apps/docs/pages/guides/integrations/sequin.mdx
+++ b/apps/docs/pages/guides/integrations/sequin.mdx
@@ -82,7 +82,7 @@ You'll use this client to query for data in your synced schema.
 ## Resources
 
 - [Sequin](https://sequin.io) official website.
-- [Sequin Console](https://app.sequin.io*).
+- [Sequin Console](https://app.sequin.io).
 - [Sequin](https://docs.sequin.io/welcome) documentation.
 - [Sequin + Supabase + Stripe Tutorial](https://github.com/sequin-io/build-a-saas-with-next-js-supabase-stripe-and-sequin)
 

--- a/apps/docs/pages/guides/integrations/snaplet.mdx
+++ b/apps/docs/pages/guides/integrations/snaplet.mdx
@@ -51,7 +51,7 @@ The password is the same password you used when creating the Supabase project.
 
 ![supabase-connection-db-info](/docs/img/guides/integrations/snaplet/supabase-connection-db-info.png)
 
-You’ll have to confirm providing Snaplet access to your database. Snaplet will prompt you to only provide `read-only` access to your database. Snaplet has a guide in their documentation on how to do so [here](https://docs.snaplet.dev/postgresql/create-read-only-role).
+You’ll have to confirm providing Snaplet access to your database. Snaplet will prompt you to only provide `read-only` access to your database. Snaplet has a guide in their documentation on how to do so [here](https://docs.snaplet.dev/guides/postgresql/#create-read-only-role).
 
 > Note that whatever connection string you provide here will be that of your Data Source – essentially the production database in a real-life scenario
 

--- a/apps/docs/pages/guides/integrations/weweb.mdx
+++ b/apps/docs/pages/guides/integrations/weweb.mdx
@@ -103,7 +103,7 @@ If we only ask for the data from the `location` field of the `vehicles` table, S
 
 Assuming you were able to fetch data from Supabase in a WeWeb Collection, you'll be able to bind the data from that Collection on your WeWeb pages.
 
-In the example below, we chose to display the car model and mileage in the [Data Grid element](https://docs.weweb.io/data-grid/) that comes out-of-the-box in WeWeb:
+In the example below, we chose to display the car model and mileage in the [Data Grid element](https://docs.weweb.io/add-elements/elements/data-grid.html) that comes out-of-the-box in WeWeb:
 
 ![](https://weweb-changelog.ghost.io/content/images/2022/10/CleanShot-2022-10-21-at-12.31.05@2x.png)
 
@@ -111,7 +111,7 @@ We chose this element because it includes a built-in inline editing mode we'll w
 
 #### 🔥 Pro Tip 🔥
 
-> In WeWeb, you can [bind arrays of data to any Container](https://docs.weweb.io/display-collection-list/). Just bear in mind that the first child of the Container you bind the Collection to will be the repeated item. With that in mind, you might want the first child Element to be another Container with a number of items inside like a title, description, button or image.
+> In WeWeb, you can [bind arrays of data to any Container](https://docs.weweb.io/binding-filtering/display-data.html). Just bear in mind that the first child of the Container you bind the Collection to will be the repeated item. With that in mind, you might want the first child Element to be another Container with a number of items inside like a title, description, button or image.
 
 ## Step 4: Update a record in Supabase
 

--- a/apps/docs/pages/guides/platform/network-restrictions.mdx
+++ b/apps/docs/pages/guides/platform/network-restrictions.mdx
@@ -20,7 +20,7 @@ To get started:
 
 1. [Install](/docs/guides/cli) the Supabase CLI 1.22.0+.
 1. [Log in](/docs/guides/cli/local-development#log-in-to-the-supabase-cli) to your Supabase account using the CLI.
-1. Ensure that you have [Owner or Admin permissions](/docs/guides/hosting/platform/access-control#manage-team-members) for the project that you are enabling network restrictions.
+1. Ensure that you have [Owner or Admin permissions](/docs/guides/platform/access-control#manage-team-members) for the project that you are enabling network restrictions.
 
 ## Check restrictions
 

--- a/apps/docs/pages/guides/self-hosting.mdx
+++ b/apps/docs/pages/guides/self-hosting.mdx
@@ -72,7 +72,7 @@ For working with JWT and Auth functions.
 
 Supabase creates several default roles in your Postgres database. To restore defaults at any time you can run the commands inside the
 [schema initialization scripts](https://github.com/supabase/postgres/tree/develop/migrations/db/init-scripts). Remember to change your
-[role passwords](./docker#securing-your-setup) before deploying to production environments.
+[role passwords](/docs/guides/self-hosting/docker#securing-your-setup) before deploying to production environments.
 
 ##### `postgres`
 

--- a/apps/www/_blog/2021-05-03-supabase-beta-april-2021.mdx
+++ b/apps/www/_blog/2021-05-03-supabase-beta-april-2021.mdx
@@ -49,7 +49,7 @@ So today we're shipping Light Mode. Access it in the settings of your [Dashboard
 With the help of the community, we [started internationalizing](https://github.com/supabase/supabase/issues/1341) our main repository:
 
 - [Arabic | العربية](https://github.com/supabase/supabase/blob/master/i18n/README.ar.md)
-- [Chinese / 中文](https://github.com/supabase/supabase/blob/master/i18n/README.cn.md)
+- [Chinese / 中文](https://github.com/supabase/supabase/blob/master/i18n/README.zh-cn.md)
 - [Dutch / Nederlands](https://github.com/supabase/supabase/blob/master/i18n/README.nl.md)
 - [English](https://github.com/supabase/supabase)
 - [French / Français](https://github.com/supabase/supabase/blob/master/i18n/README.fr.md)

--- a/apps/www/lib/redirects.js
+++ b/apps/www/lib/redirects.js
@@ -1709,6 +1709,11 @@ module.exports = [
   },
   {
     permanent: true,
+    source: '/docs/guides/auth/auth-zoom',
+    destination: '/docs/guides/auth/social-login/auth-zoom',
+  },
+  {
+    permanent: true,
     source: '/docs/guides/database',
     destination: '/docs/guides/database/overview',
   },

--- a/apps/www/lib/redirects.js
+++ b/apps/www/lib/redirects.js
@@ -535,11 +535,15 @@ module.exports = [
     source: '/docs/reference/postgres/publications',
     destination: '/docs/guides/database/replication',
   },
-
   {
     permanent: true,
     source: '/docs/guides/hosting/platform',
     destination: '/docs/guides/platform',
+  },
+  {
+    permanent: true,
+    source: '/docs/guides/hosting/platform/access-control',
+    destination: '/docs/guides/platform/access-control',
   },
   {
     permanent: true,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix more broken links in the docs

## What is the current behavior?

Links go to 404s

## What is the new behavior?

- [/docs/guides/hosting/platform/access-control](https://zone-www-dot-com-git-docs-fix-links-supabase.vercel.app/docs/guides/hosting/platform/access-control) should redirect to [/docs/guides/platform/access-control](https://zone-www-dot-com-git-docs-fix-links-supabase.vercel.app/docs/guides/platform/access-control)
- [/docs/guides/auth/auth-zoom](https://zone-www-dot-com-git-docs-fix-links-supabase.vercel.app/docs/guides/auth/auth-zoom) should redirect to [/docs/guides/auth/social-login/auth-zoom](https://zone-www-dot-com-git-docs-fix-links-supabase.vercel.app/docs/guides/auth/social-login/auth-zoom)
