### PR TITLE
docs: twitter elevated access information on twitter auth page

### DIFF
--- a/apps/docs/pages/guides/auth/social-login/auth-twitter.mdx
+++ b/apps/docs/pages/guides/auth/social-login/auth-twitter.mdx
@@ -6,7 +6,7 @@ export const meta = {
   description: 'Add Twitter OAuth to your Supabase project',
 }
 
-To enable Twitter Auth for your project, you need to set up a Twitter OAuth application and add the application credentials to your Supabase Dashboard.
+To enable Twitter Auth for your project, you need to set up a Twitter OAuth application and add the application credentials to your Supabase Dashboard. You will also need an [elevated access](https://developer.twitter.com/en/portal/products/elevated) from Twitter.
 
 ## Overview
 

--- a/apps/docs/pages/guides/auth/social-login/auth-twitter.mdx
+++ b/apps/docs/pages/guides/auth/social-login/auth-twitter.mdx
@@ -6,7 +6,7 @@ export const meta = {
   description: 'Add Twitter OAuth to your Supabase project',
 }
 
-To enable Twitter Auth for your project, you need to set up a Twitter OAuth application and add the application credentials to your Supabase Dashboard. You will also need an [elevated access](https://developer.twitter.com/en/portal/products/elevated) from Twitter.
+To enable Twitter Auth for your project, you need to set up a Twitter OAuth application with [elevated access](https://developer.twitter.com/en/portal/products/elevated)and add the application credentials in the Supabase Dashboard.
 
 ## Overview
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Solves the problem at `login with twitter documentation` specified about elevated access which is needed in order to login with twitter.

## What is the current behavior?

There is no such information about elevated access.
Issue: https://github.com/supabase/supabase/issues/8127

## What is the new behavior?

Lets the user know that elevated access would be need in order to login with twitter.


