### PR TITLE
docs: code block example language

### DIFF
--- a/apps/docs/components/reference/RefFunctionSection.tsx
+++ b/apps/docs/components/reference/RefFunctionSection.tsx
@@ -204,7 +204,6 @@ const RefFunctionSection: React.FC<IRefFunctionSection> = (props) => {
                             </RefDetailCollapse>
                           )}
 
-
                           <CodeBlock
                             className="useless-code-block-class"
                             language={codeBlockLang}

--- a/apps/docs/components/reference/RefFunctionSection.tsx
+++ b/apps/docs/components/reference/RefFunctionSection.tsx
@@ -130,6 +130,14 @@ const RefFunctionSection: React.FC<IRefFunctionSection> = (props) => {
                   {item.examples &&
                     item.examples.map((example, exampleIndex) => {
                       const exampleString = ''
+
+                      const codeBlockLang = example?.code?.includes('```js')
+                        ? 'js'
+                        : example?.code?.includes('```ts')
+                        ? 'ts'
+                        : example?.code?.includes('```dart')
+                        ? 'dart'
+                        : 'js'
                       //                     `
                       // import { createClient } from '@supabase/supabase-js'
 
@@ -196,9 +204,10 @@ const RefFunctionSection: React.FC<IRefFunctionSection> = (props) => {
                             </RefDetailCollapse>
                           )}
 
+
                           <CodeBlock
                             className="useless-code-block-class"
-                            language="js"
+                            language={codeBlockLang}
                             hideLineNumbers={true}
                           >
                             {exampleString +
@@ -206,7 +215,8 @@ const RefFunctionSection: React.FC<IRefFunctionSection> = (props) => {
                                 example.code
                                   .replace(/```/g, '')
                                   .replace('js', '')
-                                  .replace('ts', ''))}
+                                  .replace('ts', '')
+                                  .replace('dart', ''))}
                           </CodeBlock>
 
                           {response && (
@@ -217,7 +227,7 @@ const RefFunctionSection: React.FC<IRefFunctionSection> = (props) => {
                             >
                               <CodeBlock
                                 className="useless-code-block-class"
-                                language="js"
+                                language={codeBlockLang}
                                 hideLineNumbers={true}
                               >
                                 {response.replace(/```/g, '').replace('json', '')}

--- a/apps/docs/components/reference/RefFunctionSection.tsx
+++ b/apps/docs/components/reference/RefFunctionSection.tsx
@@ -131,11 +131,11 @@ const RefFunctionSection: React.FC<IRefFunctionSection> = (props) => {
                     item.examples.map((example, exampleIndex) => {
                       const exampleString = ''
 
-                      const codeBlockLang = example?.code?.includes('```js')
+                      const codeBlockLang = example?.code?.startsWith('```js')
                         ? 'js'
-                        : example?.code?.includes('```ts')
+                        : example?.code?.startsWith('```ts')
                         ? 'ts'
-                        : example?.code?.includes('```dart')
+                        : example?.code?.startsWith('```dart')
                         ? 'dart'
                         : 'js'
                       //                     `


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase Docs - [Javascript](https://supabase.com/docs/reference/javascript/introduction) & [Dart](https://supabase.com/docs/reference/dart/introduction) references

## What is the current behavior?

Currently on the docs the code block examples are using `js` so some `dart` keywords do not get highlighted:

<img width="1097" alt="Screenshot 2022-12-23 at 16 47 46" src="https://user-images.githubusercontent.com/22655069/209371892-5affcb5d-7c33-4446-87d2-3e93885d9141.png">


## What is the new behavior?

Keywords are now highlighted:

<img width="1097" alt="Screenshot 2022-12-23 at 16 51 12" src="https://user-images.githubusercontent.com/22655069/209372404-97281d47-63c3-44a3-958a-e79ac78708a1.png">



Also `dart` at the top of the `dart` examples has been removed.

## Additional context

I've done this for `js` , `ts` and `dart` as these were the only examples I could see in the spec.


Closes #11225 
Closes #11226
