### PR TITLE
docs: fix space required after elevated access information on twitter auth

### DIFF
--- a/apps/docs/pages/guides/auth/social-login/auth-twitter.mdx
+++ b/apps/docs/pages/guides/auth/social-login/auth-twitter.mdx
@@ -6,7 +6,7 @@ export const meta = {
   description: 'Add Twitter OAuth to your Supabase project',
 }
 
-To enable Twitter Auth for your project, you need to set up a Twitter OAuth application with [elevated access](https://developer.twitter.com/en/portal/products/elevated)and add the application credentials in the Supabase Dashboard.
+To enable Twitter Auth for your project, you need to set up a Twitter OAuth application with [elevated access](https://developer.twitter.com/en/portal/products/elevated) and add the application credentials in the Supabase Dashboard.
 
 ## Overview
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Space required after elevated access information on twitter auth docs

## What is the current behavior?

There is no space
<img width="850" alt="Screenshot 2022-12-24 at 12 40 09 PM" src="https://user-images.githubusercontent.com/64960569/209425495-38834cdf-b567-40d5-b72f-2a4125d6157a.png">


