### PR TITLE
feat: Move table filters and sorting to an "Apply" workflow

### DIFF
--- a/studio/components/grid/components/header/filter/FilterRow.tsx
+++ b/studio/components/grid/components/header/filter/FilterRow.tsx
@@ -1,113 +1,26 @@
-import { debounce } from 'lodash'
-import { FC, memo, useState, useEffect, ChangeEvent, useCallback } from 'react'
+import { FC, memo } from 'react'
 import { Button, Input, IconChevronDown, IconX } from 'ui'
 
-import { useUrlState } from 'hooks'
-import { Filter } from 'components/grid/types'
+import { Filter, FilterOperator } from 'components/grid/types'
 import { DropdownControl } from 'components/grid/components/common'
 import { useTrackedState } from 'components/grid/store'
 import { FilterOperatorOptions } from './Filter.constants'
 
 interface Props {
-  filter: Filter
   filterIdx: number
+  filter: Filter
+  onChange: (index: number, filter: Filter) => void
+  onDelete: (index: number) => void
 }
 
-// [Area of improvement] Input field loses focus after the debounce (because of useUrlState?)
-const FilterRow: FC<Props> = ({ filter, filterIdx }) => {
+const FilterRow: FC<Props> = ({ filter, filterIdx, onChange, onDelete }) => {
   const state = useTrackedState()
-  const [{ filter: filters }, setParams] = useUrlState({ arrayKeys: ['filter'] })
 
   const column = state.table?.columns.find((x) => x.name === filter.column)
   const columnOptions =
     state.table?.columns?.map((x) => {
       return { value: x.name, label: x.name, postLabel: x.dataType }
     }) || []
-  const [filterValue, setFilterValue] = useState(filter.value)
-
-  useEffect(() => {
-    setFilterValue(filter.value)
-  }, [filterIdx])
-
-  function onRemoveFilter() {
-    setParams((prevParams) => {
-      const existingFilters = (prevParams?.filter ?? []) as string[]
-      const updatedFilters = existingFilters.filter((filter: string, idx: number) => {
-        if (idx !== filterIdx) return filter
-      })
-      return {
-        ...prevParams,
-        filter: updatedFilters,
-      }
-    })
-  }
-
-  function onColumnChange(column: string | number) {
-    setParams((prevParams) => {
-      const existingFilters = (prevParams?.filter ?? []) as string[]
-      const updatedFilters = existingFilters.map((filter: string, idx: number) => {
-        if (idx === filterIdx) {
-          const [_, operator, ...value] = filter.split(':')
-          const formattedValue = value.join(':')
-          return `${column}:${operator}:${formattedValue}`
-        } else {
-          return filter
-        }
-      })
-      return {
-        ...prevParams,
-        filter: updatedFilters,
-      }
-    })
-  }
-
-  function onOperatorChange(operator: string | number) {
-    setParams((prevParams) => {
-      const existingFilters = (prevParams?.filter ?? []) as string[]
-      const updatedFilters = existingFilters.map((filter: string, idx: number) => {
-        if (idx === filterIdx) {
-          const [column, _, ...value] = filter.split(':')
-          const formattedValue = value.join(':')
-          const selectedOperator = FilterOperatorOptions.find((option) => option.value === operator)
-          return `${column}:${selectedOperator?.abbrev}:${formattedValue}`
-        } else {
-          return filter
-        }
-      })
-      return {
-        ...prevParams,
-        filter: updatedFilters,
-      }
-    })
-  }
-
-  function onValueChange(event: ChangeEvent<HTMLInputElement>) {
-    const value = event.target.value
-    setFilterValue(value)
-    debounceHandler({
-      filterIdx,
-      value: { ...filter, value: value },
-    })
-  }
-
-  const updateFilterValue = (payload: { filterIdx: number; value: Filter }) => {
-    setParams((prevParams) => {
-      const existingFilters = (prevParams?.filter ?? []) as string[]
-      const updatedFilters = existingFilters.map((filter: string, idx: number) => {
-        if (idx === filterIdx) {
-          const [column, operator] = filter.split(':')
-          return `${column}:${operator}:${payload.value.value}`
-        } else {
-          return filter
-        }
-      })
-      return {
-        ...prevParams,
-        filter: updatedFilters,
-      }
-    })
-  }
-  const debounceHandler = useCallback(debounce(updateFilterValue, 600), [filters])
 
   const placeholder =
     column?.format === 'timestamptz'
@@ -118,7 +31,11 @@ const FilterRow: FC<Props> = ({ filter, filterIdx }) => {
 
   return (
     <div className="sb-grid-filter-row px-3">
-      <DropdownControl align="start" options={columnOptions} onSelect={onColumnChange}>
+      <DropdownControl
+        align="start"
+        options={columnOptions}
+        onSelect={(nextColumn) => onChange(filterIdx, { ...filter, column: nextColumn as string })}
+      >
         <Button
           as="span"
           type="outline"
@@ -129,10 +46,19 @@ const FilterRow: FC<Props> = ({ filter, filterIdx }) => {
           }
           className="w-32"
         >
-          {column?.name || ''}
+          {column?.name ?? ''}
         </Button>
       </DropdownControl>
-      <DropdownControl align="start" options={FilterOperatorOptions} onSelect={onOperatorChange}>
+      <DropdownControl
+        align="start"
+        options={FilterOperatorOptions}
+        onSelect={(nextOperator) =>
+          onChange(filterIdx, {
+            ...filter,
+            operator: nextOperator as FilterOperator,
+          })
+        }
+      >
         <Button
           as="span"
           type="outline"
@@ -149,14 +75,19 @@ const FilterRow: FC<Props> = ({ filter, filterIdx }) => {
         size="tiny"
         className="w-full"
         placeholder={placeholder}
-        value={filterValue}
-        onChange={onValueChange}
+        value={filter.value}
+        onChange={(event) =>
+          onChange(filterIdx, {
+            ...filter,
+            value: event.target.value,
+          })
+        }
       />
       <Button
         icon={<IconX strokeWidth={1.5} size={14} />}
         size="tiny"
         type="text"
-        onClick={onRemoveFilter}
+        onClick={() => onDelete(filterIdx)}
       />
     </div>
   )


### PR DESCRIPTION
## What kind of change does this PR introduce?
 
Fixes https://github.com/supabase/supabase/issues/9301

## What is the current behavior?

When a value is changed in table filter/sort then the table filter/sort is applied instantaneously 

## What is the new behavior?

-  Table filters and sorting are move to "Apply" workflow i.e. when value is changed in table filter/sort then the table filter/sort is not applied instantaneously but is applied when `Apply` Button is clicked
- The Apply Filters / Apply Sorting is always showing, but is only active when the state is "dirty" (ie: when there are changes to apply)

## Demo

https://www.loom.com/share/5652560def3446588cef9b442ce3b1dd