### PR TITLE
Fixing typo extenstions -> extensions

### DIFF
--- a/apps/docs/pages/guides/realtime.mdx
+++ b/apps/docs/pages/guides/realtime.mdx
@@ -15,7 +15,7 @@ Supabase provides a globally distributed cluster of [Realtime](https://github.co
 
 A [channel](https://hexdocs.pm/phoenix/channels.html) is the basic building block of Realtime and narrows the scope of data flow to subscribed clients. You can think of a channel as a chatroom where participants are able to see who's online and send and receive messages; similar to a Discord or Slack channel.
 
-All clients can connect to a channel and take advantage of the built-in features, Broadcast and Presence, while extenstions, like Postgres Changes, must be enabled prior to use.
+All clients can connect to a channel and take advantage of the built-in features, Broadcast and Presence, while extensions, like Postgres Changes, must be enabled prior to use.
 
 ## Broadcast
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixing a minor typo in "extenstions"

## What is the current behavior?

There is a typo in the doc

## What is the new behavior?

The typo went away!

## Additional context

N/A
