### PR TITLE
Fix incorrect name on nextjs router

### DIFF
--- a/apps/docs/pages/guides/auth/auth-helpers/nextjs-server-components.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/nextjs-server-components.mdx
@@ -222,7 +222,7 @@ export default function SupabaseListener({ accessToken }) {
   useEffect(() => {
     supabase.auth.onAuthStateChange((event, session) => {
       if (session?.access_token !== accessToken) {
-        router.refresh()
+        router.reload()
       }
     })
   }, [accessToken])


### PR DESCRIPTION
## What kind of change does this PR introduce?
Doc typo

## Additional context
As far as I can tell, the NextRouter only has a `reload` method and not a `refresh` method. This change fixes that.

https://nextjs.org/docs/api-reference/next/router#routerreload
