### PR TITLE
Chore/remove some data types from dashboard

### DIFF
--- a/apps/docs/pages/guides/database/tables.mdx
+++ b/apps/docs/pages/guides/database/tables.mdx
@@ -77,7 +77,7 @@ You must define the "data type" when you create a column.
 ### Data types
 
 Every column is a predefined type. PostgreSQL provides many [default types](https://www.postgresql.org/docs/current/datatype.html), and you can even design your own (or use extensions)
-if the default types don't fit your needs.
+if the default types don't fit your needs. You can use any data type that Postgres supports via the SQL editor. We only support a subset of these in the Table Editor in an effort to keep the experience simple for people with less experience with databases.
 
 <details>
 <summary>Show/Hide default data types</summary>

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.constants.ts
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.constants.ts
@@ -3,12 +3,12 @@ import { PostgresDataTypeOption } from './SidePanelEditor.types'
 
 export const DATE_FORMAT = 'YYYY-MM-DDTHH:mm:ssZ'
 export const NUMERICAL_TYPES = ['int2', 'int4', 'int8', 'float4', 'float8', 'numeric']
-export const JSON_TYPES = ['jsonb']
-export const TEXT_TYPES = ['text']
+export const JSON_TYPES = ['json', 'jsonb']
+export const TEXT_TYPES = ['text', 'varchar']
 
-export const TIMESTAMP_TYPES = ['timestamptz']
+export const TIMESTAMP_TYPES = ['timestamp', 'timestamptz']
 export const DATE_TYPES = ['date']
-export const TIME_TYPES = ['time']
+export const TIME_TYPES = ['time', 'timetz']
 export const DATETIME_TYPES = concat(TIMESTAMP_TYPES, DATE_TYPES, TIME_TYPES)
 
 export const OTHER_DATA_TYPES = ['uuid', 'bool']
@@ -48,22 +48,12 @@ export const POSTGRES_DATA_TYPE_OPTIONS: PostgresDataTypeOption[] = [
     type: 'number',
   },
   {
-    name: 'json',
-    description: 'Textual JSON data',
-    type: 'json',
-  },
-  {
     name: 'jsonb',
     description: 'Binary JSON data, decomposed',
     type: 'json',
   },
   {
     name: 'text',
-    description: 'Variable-length character string',
-    type: 'text',
-  },
-  {
-    name: 'varchar',
     description: 'Variable-length character string',
     type: 'text',
   },
@@ -80,16 +70,6 @@ export const POSTGRES_DATA_TYPE_OPTIONS: PostgresDataTypeOption[] = [
   {
     name: 'time',
     description: 'Time of day (no time zone)',
-    type: 'time',
-  },
-  {
-    name: 'timetz',
-    description: 'Time of day, including time zone',
-    type: 'time',
-  },
-  {
-    name: 'timestamp',
-    description: 'Date and time (no time zone)',
     type: 'time',
   },
   {

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.constants.ts
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.constants.ts
@@ -3,12 +3,12 @@ import { PostgresDataTypeOption } from './SidePanelEditor.types'
 
 export const DATE_FORMAT = 'YYYY-MM-DDTHH:mm:ssZ'
 export const NUMERICAL_TYPES = ['int2', 'int4', 'int8', 'float4', 'float8', 'numeric']
-export const JSON_TYPES = ['json', 'jsonb']
-export const TEXT_TYPES = ['text', 'varchar']
+export const JSON_TYPES = ['jsonb']
+export const TEXT_TYPES = ['text']
 
-export const TIMESTAMP_TYPES = ['timestamp', 'timestamptz']
+export const TIMESTAMP_TYPES = ['timestamptz']
 export const DATE_TYPES = ['date']
-export const TIME_TYPES = ['time', 'timetz']
+export const TIME_TYPES = ['time']
 export const DATETIME_TYPES = concat(TIMESTAMP_TYPES, DATE_TYPES, TIME_TYPES)
 
 export const OTHER_DATA_TYPES = ['uuid', 'bool']


### PR DESCRIPTION
Removes varchar, timetz, timestamp and json from being able to be selected from the table editor (still can render accordingly in columns were created via SQL)

Mainly to avoid confusion + based on recommendations in postgres wiki