### PR TITLE
Fixes kenneth cassel's tweet grammar for testimonial

### DIFF
--- a/apps/www/data/tweets/Tweets.json
+++ b/apps/www/data/tweets/Tweets.json
@@ -78,7 +78,7 @@
     "img_url": "/images/twitter-profiles/_ki30kYo_400x400.jpg"
   },
   {
-    "text": "Badass Supabase is amazing, literally saves our small team a while engineer’s worth of work constantly Founders and everyone I’ve chatted with at supabase are just awesome people as well :)",
+    "text": "Badass! Supabase is amazing. literally saves our small team a whole engineer’s worth of work constantly. The founders and everyone I’ve chatted with at supabase are just awesome people as well :)",
     "url": "https://twitter.com/KennethCassel/status/1524359528619384834",
     "handle": "KennethCassel",
     "img_url": "/images/twitter-profiles/pmQj3TX-_400x400.jpg"

--- a/packages/shared-data/tweets.ts
+++ b/packages/shared-data/tweets.ts
@@ -78,7 +78,7 @@ const tweets = [
     img_url: '/images/twitter-profiles/_ki30kYo_400x400.jpg',
   },
   {
-    text: "Badass! Supabase is amazing. literally saves our small team a whole engineer’s worth of work constantly. The founders and everyone I’ve chatted with at supabase are just awesome people as well :)",
+    text: 'Badass! Supabase is amazing. literally saves our small team a whole engineer’s worth of work constantly. The founders and everyone I’ve chatted with at supabase are just awesome people as well :)',
     url: 'https://twitter.com/KennethCassel/status/1524359528619384834',
     handle: 'KennethCassel',
     img_url: '/images/twitter-profiles/pmQj3TX-_400x400.jpg',

--- a/packages/shared-data/tweets.ts
+++ b/packages/shared-data/tweets.ts
@@ -78,7 +78,7 @@ const tweets = [
     img_url: '/images/twitter-profiles/_ki30kYo_400x400.jpg',
   },
   {
-    text: 'Badass Supabase is amazing, literally saves our small team a while engineer’s worth of work constantly Founders and everyone I’ve chatted with at supabase are just awesome people as well :)',
+    text: "Badass! Supabase is amazing. literally saves our small team a whole engineer’s worth of work constantly. The founders and everyone I’ve chatted with at supabase are just awesome people as well :)",
     url: 'https://twitter.com/KennethCassel/status/1524359528619384834',
     handle: 'KennethCassel',
     img_url: '/images/twitter-profiles/pmQj3TX-_400x400.jpg',


### PR DESCRIPTION
## What kind of change does this PR introduce?

Copy update on testimonial for sign-in page.

## What is the current behavior?
Testimonial text on sign-in page (https://app.supabase.com/sign-in) shows poorly written testimonial from me. 

Previous text: "Badass Supabase is amazing, literally saves our small team a while engineer’s worth of work constantly Founders and everyone I’ve chatted with at supabase are just awesome people as well :)"

<img width="799" alt="image" src="https://user-images.githubusercontent.com/22961671/209718572-c71fefa6-997e-4410-9120-92fe1fbe88f9.png">



## What is the new behavior?
The testimonial text on sign-in page is now readable for humans :) 

New text: "Badass! Supabase is amazing. literally saves our small team a whole engineer’s worth of work constantly. The founders and everyone I’ve chatted with at supabase are just awesome people as well :)"

<img width="799" alt="image" src="https://user-images.githubusercontent.com/22961671/209718645-1b83cf52-b826-4141-8d70-d0a10cefa91c.png">

