### PR TITLE
fix several issues with nextjs-slack-clone:

### DIFF
--- a/examples/slack-clone/nextjs-slack-clone/lib/Store.js
+++ b/examples/slack-clone/nextjs-slack-clone/lib/Store.js
@@ -62,9 +62,9 @@ export const useStore = (props) => {
       .subscribe()
     // Cleanup on unmount
     return () => {
-      supabase.removeChannel(supabase.channel('public:messages'))
-      supabase.removeChannel(supabase.channel('public:users'))
-      supabase.removeChannel(supabase.channel('public:channels'))
+      supabase.removeChannel(supabase.channel(messageListener))
+      supabase.removeChannel(supabase.channel(userListener))
+      supabase.removeChannel(supabase.channel(channelListener))
     }
   }, [])
 

--- a/examples/slack-clone/nextjs-slack-clone/lib/Store.js
+++ b/examples/slack-clone/nextjs-slack-clone/lib/Store.js
@@ -62,9 +62,9 @@ export const useStore = (props) => {
       .subscribe()
     // Cleanup on unmount
     return () => {
-      supabase.removeChannel('public:messages')
-      supabase.removeChannel('public:users')
-      supabase.removeChannel('public:channels')
+      supabase.removeChannel(supabase.channel('public:messages'))
+      supabase.removeChannel(supabase.channel('public:users'))
+      supabase.removeChannel(supabase.channel('public:channels'))
     }
   }, [])
 
@@ -179,7 +179,7 @@ export const fetchMessages = async (channelId, setState) => {
       .from('messages')
       .select(`*, author:user_id(*)`)
       .eq('channel_id', channelId)
-      .order('inserted_at', true)
+      .order('inserted_at', { ascending: true })
     if (setState) setState(data)
     return data
   } catch (error) {

--- a/examples/slack-clone/nextjs-slack-clone/pages/_app.js
+++ b/examples/slack-clone/nextjs-slack-clone/pages/_app.js
@@ -12,17 +12,10 @@ export default function SupabaseSlackClone({ Component, pageProps }) {
   const router = useRouter()
 
   useEffect(() => {
-    supabase.auth.getSession().then(({ data: { session }}) => {
-      setSession(session)
-      setUserLoaded(session ? true : false)
-      if (session?.user) {
-        signIn()
-        router.push('/channels/[id]', '/channels/1')
-      }
-    })
-
-
-    const { subscription: authListener } = supabase.auth.onAuthStateChange(async (event, session) => {
+    function saveSession(
+      /** @type {Awaited<ReturnType<typeof supabase.auth.getSession>>['data']['session']} */
+      session
+    ) {
       setSession(session)
       const currentUser = session?.user
       setUser(currentUser ?? null)
@@ -31,7 +24,11 @@ export default function SupabaseSlackClone({ Component, pageProps }) {
         signIn(currentUser.id, currentUser.email)
         router.push('/channels/[id]', '/channels/1')
       }
-    })
+    }
+
+    supabase.auth.getSession().then(({ data: { session }}) => saveSession(session))
+
+    const { subscription: authListener } = supabase.auth.onAuthStateChange(async (event, session) => saveSession(session))
 
     return () => {
       authListener.unsubscribe()


### PR DESCRIPTION
- fix session restoration in nextjs-slack-clone (setUser needs to be called from not only onAuthStateChange but also getSession)

- fix message listener unmounting (supabase.removeChannel expects a RealtimeChannel, not a string)

- fix fetchMessages order (ascending option must be provided within an options object)