### PR TITLE
feat: enable read-only/billing-only role

### DIFF
--- a/studio/components/interfaces/Organization/TeamSettings/RolesHelperModal/RolesHelperModal.tsx
+++ b/studio/components/interfaces/Organization/TeamSettings/RolesHelperModal/RolesHelperModal.tsx
@@ -12,7 +12,7 @@ const RolesHelperModal: FC<Props> = ({}) => {
   const roleColumnClassName =
     'w-[12%] text-sm h-8 flex items-center justify-center border-l border-scale-600 font-bold'
 
-  const enterpriseTooltip = (
+  const accessTooltip = (
     <Tooltip.Root delayDuration={0}>
       <Tooltip.Trigger>
         <IconInfo size={14} strokeWidth={2} />
@@ -20,7 +20,7 @@ const RolesHelperModal: FC<Props> = ({}) => {
       <Tooltip.Content side="top">
         <Tooltip.Arrow className="radix-tooltip-arrow" />
 
-        <span className="text-xs text-scale-1200">Only available in Enterprise plan.</span>
+        <span className="text-xs text-scale-1200">Only available in Team/Enterprise plan.</span>
       </Tooltip.Content>
     </Tooltip.Root>
   )
@@ -55,8 +55,8 @@ const RolesHelperModal: FC<Props> = ({}) => {
                 <div className={roleColumnClassName}>Owner</div>
                 <div className={roleColumnClassName}>Adminstrator</div>
                 <div className={roleColumnClassName}>Developer</div>
-                <div className={roleColumnClassName}>Read-only&nbsp;{enterpriseTooltip}</div>
-                <div className={roleColumnClassName}>Billing-only&nbsp;{enterpriseTooltip}</div>
+                <div className={roleColumnClassName}>Read-only&nbsp;{accessTooltip}</div>
+                <div className={roleColumnClassName}>Billing-only&nbsp;{accessTooltip}</div>
               </div>
 
               <div className="max-h-[425px] overflow-y-auto">

--- a/studio/components/interfaces/Organization/TeamSettings/RolesHelperModal/RolesHelperModal.tsx
+++ b/studio/components/interfaces/Organization/TeamSettings/RolesHelperModal/RolesHelperModal.tsx
@@ -1,22 +1,29 @@
 import { FC, Fragment, useState } from 'react'
-import { IconCheck, IconHelpCircle, Modal } from 'ui'
-import { useFlag } from 'hooks'
+import { IconCheck, IconHelpCircle, IconInfo, Modal } from 'ui'
 import { PERMISSIONS_MAPPING } from './RolesHelperModal.constants'
+import * as Tooltip from '@radix-ui/react-tooltip'
 
 interface Props {}
 
 const RolesHelperModal: FC<Props> = ({}) => {
   const [showModal, setShowModal] = useState(false)
-  const enableBillingOnlyReadOnlyRoles = useFlag('enableBillingOnlyReadOnlyRoles')
 
-  const permissionColumnClassName = [
-    `${enableBillingOnlyReadOnlyRoles ? 'w-[40%]' : 'w-[49%]'}`,
-    'text-sm pl-4 font-bold',
-  ].join(' ')
-  const roleColumnClassName = [
-    `${enableBillingOnlyReadOnlyRoles ? 'w-[12%]' : 'w-[17%]'}`,
-    'text-sm h-8 flex items-center justify-center border-l border-scale-600 font-bold',
-  ].join(' ')
+  const permissionColumnClassName = 'w-[40%] text-sm pl-4 font-bold'
+  const roleColumnClassName =
+    'w-[12%] text-sm h-8 flex items-center justify-center border-l border-scale-600 font-bold'
+
+  const enterpriseTooltip = (
+    <Tooltip.Root delayDuration={0}>
+      <Tooltip.Trigger>
+        <IconInfo size={14} strokeWidth={2} />
+      </Tooltip.Trigger>
+      <Tooltip.Content side="top">
+        <Tooltip.Arrow className="radix-tooltip-arrow" />
+
+        <span className="text-xs text-scale-1200">Only available in Enterprise plan.</span>
+      </Tooltip.Content>
+    </Tooltip.Root>
+  )
 
   return (
     <>
@@ -30,7 +37,7 @@ const RolesHelperModal: FC<Props> = ({}) => {
         closable
         hideFooter
         visible={showModal}
-        size={enableBillingOnlyReadOnlyRoles ? 'xxlarge' : 'xlarge'}
+        size={'xxlarge'}
         header="Permissions for each role"
         onCancel={() => setShowModal(!showModal)}
       >
@@ -48,12 +55,8 @@ const RolesHelperModal: FC<Props> = ({}) => {
                 <div className={roleColumnClassName}>Owner</div>
                 <div className={roleColumnClassName}>Adminstrator</div>
                 <div className={roleColumnClassName}>Developer</div>
-                {enableBillingOnlyReadOnlyRoles && (
-                  <div className={roleColumnClassName}>Read-only</div>
-                )}
-                {enableBillingOnlyReadOnlyRoles && (
-                  <div className={roleColumnClassName}>Billing-only</div>
-                )}
+                <div className={roleColumnClassName}>Read-only&nbsp;{enterpriseTooltip}</div>
+                <div className={roleColumnClassName}>Billing-only&nbsp;{enterpriseTooltip}</div>
               </div>
 
               <div className="max-h-[425px] overflow-y-auto">
@@ -77,20 +80,14 @@ const RolesHelperModal: FC<Props> = ({}) => {
                         <div className={roleColumnClassName}>
                           {action.permissions.developer && <IconCheck size={14} strokeWidth={2} />}
                         </div>
-                        {enableBillingOnlyReadOnlyRoles && (
-                          <div className={roleColumnClassName}>
-                            {action.permissions.read_only && (
-                              <IconCheck size={14} strokeWidth={2} />
-                            )}
-                          </div>
-                        )}
-                        {enableBillingOnlyReadOnlyRoles && (
-                          <div className={roleColumnClassName}>
-                            {action.permissions.billing_only && (
-                              <IconCheck size={14} strokeWidth={2} />
-                            )}
-                          </div>
-                        )}
+                        <div className={roleColumnClassName}>
+                          {action.permissions.read_only && <IconCheck size={14} strokeWidth={2} />}
+                        </div>
+                        <div className={roleColumnClassName}>
+                          {action.permissions.billing_only && (
+                            <IconCheck size={14} strokeWidth={2} />
+                          )}
+                        </div>
                       </div>
                     ))}
                   </Fragment>

--- a/studio/components/interfaces/Organization/TeamSettings/RolesHelperModal/RolesHelperModal.tsx
+++ b/studio/components/interfaces/Organization/TeamSettings/RolesHelperModal/RolesHelperModal.tsx
@@ -19,8 +19,14 @@ const RolesHelperModal: FC<Props> = ({}) => {
       </Tooltip.Trigger>
       <Tooltip.Content side="top">
         <Tooltip.Arrow className="radix-tooltip-arrow" />
-
-        <span className="text-xs text-scale-1200">Only available in Team/Enterprise plan.</span>
+        <div
+          className={[
+            'rounded bg-scale-100 py-1 px-2 leading-none shadow', // background
+            'border border-scale-200 ', //border
+          ].join(' ')}
+        >
+          <span className="text-xs text-scale-1200">Only available in Team/Enterprise plan.</span>
+        </div>
       </Tooltip.Content>
     </Tooltip.Root>
   )

--- a/studio/components/interfaces/Organization/TeamSettings/TeamSettings.tsx
+++ b/studio/components/interfaces/Organization/TeamSettings/TeamSettings.tsx
@@ -19,12 +19,8 @@ const TeamSettings = () => {
   const isOwner = ui.selectedOrganization?.is_owner
 
   const { members } = useOrganizationDetail(slug || '')
-  const { roles: allRoles } = useOrganizationRoles(slug)
+  const { roles } = useOrganizationRoles(slug)
 
-  const enableBillingOnlyReadOnly = useFlag('enableBillingOnlyReadOnlyRoles')
-  const roles = enableBillingOnlyReadOnly
-    ? allRoles
-    : (allRoles ?? []).filter((role) => ['Owner', 'Administrator', 'Developer'].includes(role.name))
   const { rolesAddable } = getRolesManagementPermissions(roles)
 
   const [isLeaving, setIsLeaving] = useState(false)


### PR DESCRIPTION
The filtering of roles is now done in the backend, so there is no need for a feature flag in the dashboard.

In the modal for explaining the roles, I decided to show ALL available roles (even if they are not accessible), but include a tooltip to let the user know, that these new roles are only available for the Enterprise tier (soon Team tier, too).

![Screenshot 2023-01-06 at 12 34 06](https://user-images.githubusercontent.com/14073399/211004719-233e1553-3b85-4b6d-8bb4-d158e4afa40d.png)

Can only be merged after next backend prod deploy.
