### PR TITLE
docs: improve Fetcher snippet

### DIFF
--- a/apps/docs/pages/guides/auth/auth-helpers/remix.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/remix.mdx
@@ -440,8 +440,8 @@ And then use a `fetcher` to simulate submitting a form to our action, inside the
 const { env, session } = useLoaderData()
 const fetcher = useFetcher()
 
-const [supabase] = useState(
-  () => createBrowserClient(env.SUPABASE_URL, env.SUPABASE_ANON_KEY)
+const [supabase] = useState(() =>
+  createBrowserClient(env.SUPABASE_URL, env.SUPABASE_ANON_KEY)
 )
 
 const serverAccessToken = session?.access_token
@@ -451,6 +451,8 @@ useEffect(() => {
     data: { subscription },
   } = supabase.auth.onAuthStateChange((event, session) => {
     if (session?.access_token !== serverAccessToken) {
+      // server and client are out of sync.
+      // Remix recalls active loaders after actions complete
       fetcher.submit(null, {
         method: 'post',
         action: '/handle-supabase-auth',

--- a/apps/docs/pages/guides/auth/auth-helpers/remix.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/remix.mdx
@@ -441,7 +441,7 @@ const { env, session } = useLoaderData()
 const fetcher = useFetcher()
 
 const [supabase] = useState(
-  () => createBrowserClient < Database > (env.SUPABASE_URL, env.SUPABASE_ANON_KEY)
+  () => createBrowserClient(env.SUPABASE_URL, env.SUPABASE_ANON_KEY)
 )
 
 const serverAccessToken = session?.access_token


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Align content between JavaScript and TypeScript snippets
- Remove TypeScript leftovers in JavaScript snippet

## What is the current behavior?

Currently the snippets are not aligned and there is a leftover from TypeScript snippet inside JavaScript one

Link to website: https://supabase.com/docs/guides/auth/auth-helpers/remix#syncing-server-and-client-state

## What is the new behavior?

JavaScript and TypeScript snippets for Fetcher have the same contents, except for language differences

## Additional context

Before Video:

https://user-images.githubusercontent.com/24693481/210079276-119a831a-ad15-42b2-afbf-6168e5934486.mp4
