### PR TITLE
Update NextJS-13 Sever Components doc for the Typescript Listener

### DIFF
--- a/apps/docs/pages/guides/auth/auth-helpers/nextjs-server-components.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/nextjs-server-components.mdx
@@ -322,7 +322,7 @@ Create a `/components/supabase-listener.tsx` file and add the following:
 
 import { useRouter } from 'next/navigation'
 import { useEffect } from 'react'
-import supabase from '../utils/supabase'
+import supabase from '../utils/supabase-browser'
 
 export default function SupabaseListener({ accessToken }: { accessToken?: string }) {
   const router = useRouter()


### PR DESCRIPTION
As it is currently written, `import supabase from '../utils/supabase'` is not a valid statement. Since this is client side, I changed it to `supabase-browser`.

## What kind of change does this PR introduce?

Doc update. 

## What is the current behavior?
Import error.

## What is the new behavior?
Correct import.
