### PR TITLE
fix: double scroll on modal

### DIFF
--- a/studio/components/interfaces/Auth/Policies/PolicyEditor/index.tsx
+++ b/studio/components/interfaces/Auth/Policies/PolicyEditor/index.tsx
@@ -37,7 +37,7 @@ const PolicyEditor: FC<Props> = ({
 
   return (
     <div className="">
-      <div className="max-h-[600px] space-y-8 overflow-y-auto py-8">
+      <div className="space-y-8 py-8">
         <Modal.Content>
           <PolicyName
             name={policyFormFields.name}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix 🐞

## What is the current behavior?
Double scroll prevents from reaching buttons easily as 14' screens have no space for scrolling. 
I suggest keeping the modal scroll with the page by removing `max-h-600`.

## What is the new behavior?

Issue: https://user-images.githubusercontent.com/39779426/210115465-e3a84671-392e-4e5a-907a-5f3f5d65f489.mov

Fix: https://user-images.githubusercontent.com/39779426/210115452-1cfea01a-c2b5-4c00-9218-599d6988771b.mov

## Additional context
