### PR TITLE
Update with-expo.mdx

### DIFF
--- a/apps/docs/pages/guides/getting-started/tutorials/with-expo.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-expo.mdx
@@ -50,15 +50,17 @@ These variables will be exposed on the browser, and that's completely fine since
 import * as SecureStore from "expo-secure-store";
 import { createClient } from '@supabase/supabase-js'
 
-const ExpoSecureStoreAdapter = {
+const ExpoSecureStorageAdapter = {
   getItem: async (key: string) => {
-    return await SecureStore.getItemAsync(key);
+    const value = (await SecureStore.getItemAsync(key)) as string;
+
+    return JSON.parse(value);
   },
-  setItem: async (key: string, value: string) => {
+  setItem: (key: string, value: string) => {
     SecureStore.setItemAsync(key, JSON.stringify(value));
   },
-  removeItem: async (key: string) => {
-    await SecureStore.deleteItemAsync(key);
+  removeItem: (key: string) => {
+    SecureStore.deleteItemAsync(key);
   },
 };
 

--- a/apps/docs/pages/guides/getting-started/tutorials/with-expo.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-expo.mdx
@@ -51,13 +51,11 @@ import * as SecureStore from "expo-secure-store";
 import { createClient } from '@supabase/supabase-js'
 
 const ExpoSecureStorageAdapter = {
-  getItem: async (key: string) => {
-    const value = (await SecureStore.getItemAsync(key)) as string;
-
-    return JSON.parse(value);
+  getItem: (key: string) => {
+    return SecureStore.getItemAsync(key);
   },
   setItem: (key: string, value: string) => {
-    SecureStore.setItemAsync(key, JSON.stringify(value));
+    SecureStore.setItemAsync(key, value);
   },
   removeItem: (key: string) => {
     SecureStore.deleteItemAsync(key);

--- a/apps/docs/pages/guides/getting-started/tutorials/with-expo.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-expo.mdx
@@ -38,6 +38,7 @@ Then let's install the additional dependencies: [supabase-js](https://github.com
 ```bash
 npm install @supabase/supabase-js
 npm install react-native-elements @react-native-async-storage/async-storage react-native-url-polyfill
+npx expo install expo-secure-store
 ```
 
 Now let's create a helper file to initialize the Supabase client.
@@ -46,15 +47,27 @@ These variables will be exposed on the browser, and that's completely fine since
 [Row Level Security](/docs/guides/auth#row-level-security) enabled on our Database.
 
 ```ts title=lib/supabase.ts
-import AsyncStorage from '@react-native-async-storage/async-storage'
+import * as SecureStore from "expo-secure-store";
 import { createClient } from '@supabase/supabase-js'
+
+const ExpoSecureStoreAdapter = {
+  getItem: async (key: string) => {
+    return await SecureStore.getItemAsync(key);
+  },
+  setItem: async (key: string, value: string) => {
+    SecureStore.setItemAsync(key, JSON.stringify(value));
+  },
+  removeItem: async (key: string) => {
+    await SecureStore.deleteItemAsync(key);
+  },
+};
 
 const supabaseUrl = YOUR_REACT_NATIVE_SUPABASE_URL
 const supabaseAnonKey = YOUR_REACT_NATIVE_SUPABASE_ANON_KEY
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
   auth: {
-    storage: AsyncStorage as any,
+    storage: ExpoSecureStoreAdapter as any,
     autoRefreshToken: true,
     persistSession: true,
     detectSessionInUrl: false,

--- a/apps/docs/pages/guides/getting-started/tutorials/with-expo.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-expo.mdx
@@ -50,6 +50,7 @@ These variables will be exposed on the browser, and that's completely fine since
 import * as SecureStore from "expo-secure-store";
 import { createClient } from '@supabase/supabase-js'
 
+
 const ExpoSecureStoreAdapter = {
   getItem: (key: string) => {
     return SecureStore.getItemAsync(key);

--- a/apps/docs/pages/guides/getting-started/tutorials/with-expo.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-expo.mdx
@@ -50,7 +50,7 @@ These variables will be exposed on the browser, and that's completely fine since
 import * as SecureStore from "expo-secure-store";
 import { createClient } from '@supabase/supabase-js'
 
-const ExpoSecureStorageAdapter = {
+const ExpoSecureStoreAdapter = {
   getItem: (key: string) => {
     return SecureStore.getItemAsync(key);
   },


### PR DESCRIPTION
Instead of AsyncStorage use expos SecureStorage API. This is the recommended place to store sensitive information such as public client auth details. The storage key in the auth config of the supabase client expects: setItem, getItem and removeItem so a simple adapter can be written for SecureStore.

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

N/A

## What is the new behavior?

N/A

## Additional context

N/A
