### PR TITLE
fix: update the max disk io bandwidth

### DIFF
--- a/studio/components/interfaces/Billing/AddOns/AddOns.utils.ts
+++ b/studio/components/interfaces/Billing/AddOns/AddOns.utils.ts
@@ -33,7 +33,7 @@ export const formatComputeSizes = (addons: SubscriptionAddon[]) => {
     metadata: {
       default_price_id: undefined,
       supabase_prod_id: 'addon_instance_micro',
-      features: '2-core ARM (shared) • 1GB memory • 2,085Mbps Disk IO',
+      features: '2-core ARM (shared) • 1GB memory • 2,606Mbps Disk IO',
     },
     prices: [
       {


### PR DESCRIPTION
https://github.com/supabase/supabase/pull/11288 missed a spot.

I also updated the product features in Stripe, to match the adjusted max bandwidth.