### PR TITLE
docs: fix - set session missing bracket

### DIFF
--- a/spec/supabase_js_v2.yml
+++ b/spec/supabase_js_v2.yml
@@ -404,7 +404,7 @@ functions:
             const { data, error } = supabase.auth.setSession({
               access_token,
               refresh_token
-            )
+            })
           ```
   - id: refresh-session
     title: 'refreshSession()'


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase Docs - [Set session](https://supabase.com/docs/reference/javascript/auth-setsession)

## What is the current behavior?

In the code example their is a missing bracket:

<img width="533" alt="Screenshot 2023-01-02 at 16 30 20" src="https://user-images.githubusercontent.com/22655069/210257945-c7f7ffa8-1e0b-4079-b334-440725a4c165.png">


## What is the new behavior?

Bracket has been added.

## Additional context

This was raised on [Discord](https://discord.com/channels/839993398554656828/839993398554656831/1058426686741417984)
