### PR TITLE
chore: Add detail about deleting users from auth.users table

### DIFF
--- a/apps/docs/pages/guides/auth/managing-user-data.mdx
+++ b/apps/docs/pages/guides/auth/managing-user-data.mdx
@@ -34,7 +34,7 @@ Make sure to specify the `on delete cascade` clause when referencing `auth.users
 
 </Admonition>
 
-## Deleting Users 
+## Deleting Users
 
 Deleting a user from the `auth.users` table does not automatically sign out a user. As Supabase makes use of JSON Web Tokens (JWT), a user's JWT will remain "valid" until it has expired. Should you wish to immediately revoke access for a user, do considering making use of a Row Level Security policy as described below.
 

--- a/apps/docs/pages/guides/auth/managing-user-data.mdx
+++ b/apps/docs/pages/guides/auth/managing-user-data.mdx
@@ -34,6 +34,10 @@ Make sure to specify the `on delete cascade` clause when referencing `auth.users
 
 </Admonition>
 
+## Deleting Users 
+
+Deleting a user from the `auth.users` table does not automatically sign out a user. As Supabase makes use of JSON Web Tokens (JWT), a user's JWT will remain "valid" until it has expired. Should you wish to immediately revoke access for a user, do considering making use of a Row Level Security policy as described below.
+
 ## Public access
 
 Since Row Level Security is enabled, this table is accessible via the API but no data will be returned unless we set up some Policies.

--- a/apps/docs/pages/guides/auth/managing-user-data.mdx
+++ b/apps/docs/pages/guides/auth/managing-user-data.mdx
@@ -36,7 +36,7 @@ Make sure to specify the `on delete cascade` clause when referencing `auth.users
 
 ## Deleting Users
 
-Deleting a user from the `auth.users` table does not automatically sign out a user. As Supabase makes use of JSON Web Tokens (JWT), a user's JWT will remain "valid" until it has expired. Should you wish to immediately revoke access for a user, do considering making use of a Row Level Security policy as described below.
+You may delete users directly or via the management console at Authentication > Users. Note that deleting a user from the `auth.users` table does not automatically sign out a user. As Supabase makes use of JSON Web Tokens (JWT), a user's JWT will remain "valid" until it has expired. Should you wish to immediately revoke access for a user, do considering making use of a Row Level Security policy as described below.
 
 ## Public access
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

We wish to callout to users that [deleting a user from the users table does not automatically sign a user out from the frontend](https://github.com/supabase/supabase/issues/6702). The user is only logged out after the JWT that they are holding onto expires - see [slack thread](https://supabase.slack.com/archives/C022071RB2L/p1672729465640089) for details

## What is the current behavior?

No documentation.

## Additional Context

I'm not sure if this would do better as a callout - considered adding it as an Admonition but wasn't too sure where it'd best fit in so decided to add a new header for it

