### PR TITLE
fix: `Connecting to default project`

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -74,4 +74,5 @@ STUDIO_DEFAULT_ORGANIZATION=Default Organization
 STUDIO_DEFAULT_PROJECT=Default Project
 
 STUDIO_PORT=3000
-SUPABASE_PUBLIC_URL=http://localhost:8000 # replace if you intend to use Studio outside of localhost
+# replace if you intend to use Studio outside of localhost
+SUPABASE_PUBLIC_URL=http://localhost:8000 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix

## What is the current behavior?
```
Your project might be facing resource constraints and hence is having trouble connecting. You can verify this by checking your 
database's health or your remaining daily disk IO budget via a customizable project report.

If your project is facing resource constraints, you can upgrade your project's subscription to a Pro for access to larger compute
 sizes.

However, if your project still fails to connect thereafter, you can open a support ticket here.
```

## What is the new behavior?

Now it doesn't show any `Connecting to default project`

## Additional context

The end after `/v1/ #`. The space between / and #. The space was being read as a part of the variable as mentioned [here](https://github.com/supabase/supabase/discussions/11228#discussioncomment-4484872).

Add any other context or screenshots.
