### PR TITLE
docs: 404 links

### DIFF
--- a/apps/docs/pages/guides/integrations/stytch.mdx
+++ b/apps/docs/pages/guides/integrations/stytch.mdx
@@ -13,7 +13,7 @@ In this guide we will build a simple expense tracker web application using Stytc
 
 We will leverage Supabase to store and authorize access to user data. Supabase makes it simple to set up Row Level Security (RLS) policies which ensure users can only read and write data that they are authorized to do so. If you do not already have a Supabase account, you will need to create one.
 
-This guide will use [Next.js](https://nextjs.org/) which is a web application framework built on top of React. Stytch provides a [Node.js library](https://github.com/stytchauth/stytch-node) and a [React library](https://github.com/stytchauth/stytch-react) which makes building Next.js apps super easy.
+This guide will use [Next.js](https://nextjs.org/) which is a web application framework built on top of React. Stytch provides a [Node.js library](https://github.com/stytchauth/stytch-node) which makes building Next.js apps super easy.
 
 > Note: You can find a completed version of this project on [Github](https://github.com/stytchauth/stytch-nextjs-supabase).
 

--- a/apps/docs/pages/guides/platform/performance.mdx
+++ b/apps/docs/pages/guides/platform/performance.mdx
@@ -52,7 +52,7 @@ You can configure Postgres by executing the following statement, followed by a s
 alter system set max_connections = '<val-here>';
 ```
 
-Note that [the default configuration used by the Supabase platform](https://github.com/supabase/supabase-admin-api/blob/master/optimizations/postgres.go) optimizes the database to maximize resource utilization, and as a result, you might also need to configure other options (e.g. `work_mem`, `shared_buffers`, `maintenance_work_mem`) in order to tune them towards your use-case, and to avoid causing instability in your database.
+Note that the default configuration used by the Supabase platform optimizes the database to maximize resource utilization, and as a result, you might also need to configure other options (e.g. `work_mem`, `shared_buffers`, `maintenance_work_mem`) in order to tune them towards your use-case, and to avoid causing instability in your database.
 
 Once overridden, the Supabase platform will continue to respect your manually configured value (even if the add-on size is changed), unless the override is removed with the following statement, followed by a server restart:
 

--- a/apps/docs/pages/index.mdx
+++ b/apps/docs/pages/index.mdx
@@ -63,12 +63,12 @@ export const meta = {
           <Button size="small">Get started</Button>
           </div>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-3 md:gap-6">
-            <Link href={`/getting-started/quickstarts/reactjs`} passHref>
+            <Link href={`/guides/getting-started/tutorials/with-react`} passHref>
               <a className="no-underline">
                 <IconPanel title="ReactJS" icon="/docs/img/icons/react-icon" />
               </a>
             </Link>
-            <Link href={`/getting-started/quickstarts/nextjs`} passHref>
+            <Link href={`/guides/getting-started/tutorials/with-nextjs`} passHref>
               <a className="no-underline">
             <IconPanel title="NextJS" icon="/docs/img/icons/nextjs-icon" />
             </a>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase Docs - #11375

## What is the current behavior?

Some of the links in the docs are going to a 404 page

## What is the new behavior?

I've removed some text/links as I can not find any links that would replace the links.

## Additional context

Closes #11375
