### PR TITLE
return found or undefined selectedproject after set

### DIFF
--- a/studio/stores/RootStore.ts
+++ b/studio/stores/RootStore.ts
@@ -83,7 +83,7 @@ export class RootStore implements IRootStore {
     // - project not found yet. projectStore is loading
     // - connectionString is not available. projectStore loaded
     const found = this.app.projects.find((x: Project) => x.ref === value)
-    if (!found || !found.connectionString) {
+    if (found?.connectionString === undefined) {
       this.app.projects.fetchDetail(value, (project) => {
         setProjectRefs(project)
       })

--- a/studio/stores/UiStore.ts
+++ b/studio/stores/UiStore.ts
@@ -59,7 +59,7 @@ export default class UiStore implements IUiStore {
       const found = this.rootStore.app.projects.find(
         (x: Project) => x.ref === this.selectedProjectRef
       )
-      return !!found?.connectionString ? found : undefined
+      return found
     }
     return undefined
   }

--- a/studio/stores/UiStore.ts
+++ b/studio/stores/UiStore.ts
@@ -59,7 +59,8 @@ export default class UiStore implements IUiStore {
       const found = this.rootStore.app.projects.find(
         (x: Project) => x.ref === this.selectedProjectRef
       )
-      return found
+      // Self-hosted project details has connectionString set to empty string
+      return found?.connectionString !== undefined ? found : undefined
     }
     return undefined
   }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix for self-hosted

## What is the current behavior?

Users can't get into the default project page, infinite loading spinner since the projectRef isn't being set

## What is the new behavior?

The projectRef is set correctly and the users can access their project

## Additional context

Add any other context or screenshots.
