### PR TITLE
docs: feat - admin list users

### DIFF
--- a/spec/supabase_js_v2.yml
+++ b/spec/supabase_js_v2.yml
@@ -643,7 +643,7 @@ functions:
       - Defaults to return 50 users per page.
     examples:
       - id: get-a-full-list-of-users
-        name: Get a full list of users
+        name: Get a page of users
         isSpotlight: true
         code: |
           ```js


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase Docs > [Auth Admin List Users](https://supabase.com/docs/reference/javascript/auth-admin-listusers)

## What is the current behavior?

The title of the example says `Get a full list of users` when their is a default of 50 per page

## What is the new behavior?

Changed the title to show `Get a page of users`

## Additional context

Closes #11463
