### PR TITLE
docs: removed redirects

### DIFF
--- a/apps/www/lib/redirects.js
+++ b/apps/www/lib/redirects.js
@@ -1219,22 +1219,7 @@ module.exports = [
   },
   {
     permanent: true,
-    source: '/docs/reference/cli/supabase-db-reset',
-    destination: '/docs/reference/cli/usage',
-  },
-  {
-    permanent: true,
     source: '/docs/reference/cli/supabase-db-remote-set',
-    destination: '/docs/reference/cli/usage',
-  },
-  {
-    permanent: true,
-    source: '/docs/reference/cli/supabase-db-remote-commit',
-    destination: '/docs/reference/cli/usage',
-  },
-  {
-    permanent: true,
-    source: '/docs/reference/cli/supabase-db-push',
     destination: '/docs/reference/cli/usage',
   },
   {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase Docs - [Database Referencee](https://supabase.com/docs/reference/cli/supabase-db)

## What is the current behavior?

The following links when navigated to redirect to `/docs/reference/cli/usage`:
```
db push
db reset
db remote commit
```

## What is the new behavior?

Removed redirects

## Additional context

Linked to #11461 
