### PR TITLE
Move client lib upgrade guides to /docs/guides/resources

### DIFF
--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
@@ -530,6 +530,21 @@ export const resources = {
     // { name: 'Examples', url: '/guides/resources/examples', items: [] },
     { name: 'Glossary', url: '/guides/resources/glossary', items: [] },
     {
+      name: 'Upgrade client library',
+      items: [
+        {
+          name: 'Javascript v2',
+          url: '/guides/resources/upgrade/supabase-js-v2',
+          items: [],
+        },
+        {
+          name: 'Flutter v1',
+          url: '/guides/resources/upgrade/flutter-v1',
+          items: [],
+        },
+      ],
+    },
+    {
       name: 'Migrate to Supabase',
       url: '/guides/resources/migrating-to-supabase',
       items: [
@@ -747,13 +762,13 @@ export const reference_javascript_v2 = {
 
 export const reference_dart_v0 = {
   icon: 'reference-dart',
-  title: 'dart',
+  title: 'Flutter',
   url: '/guides/reference/dart',
   parent: '/reference',
 }
 export const reference_dart_v1 = {
   icon: 'reference-dart',
-  title: 'dart',
+  title: 'Flutter',
   url: '/guides/reference/dart',
   parent: '/reference',
 }

--- a/apps/docs/docs/ref/dart/v0/introduction.mdx
+++ b/apps/docs/docs/ref/dart/v0/introduction.mdx
@@ -14,9 +14,14 @@ hideTitle: true
 
 <div className="max-w-xl">
 
-This reference documents every object and method available in Supabase's Flutter
-library, [supabase-flutter](https://pub.dev/packages/supabase_flutter). You can
-use supabase-flutter to interact with your Postgres database, listen to database changes, invoke
+<Admonition type="caution">
+  You're viewing the docs for an older version of the `supabase-flutter` library. View the [latest
+  version](/docs/reference/dart/introduction) or follow the [supabase-flutter v1
+  guide](/docs/guides/resources/upgrade/flutter-v1) to upgrade to the latest version.
+</Admonition>
+
+This reference documents every object and method available in Supabase's Flutter library, [supabase-flutter](https://pub.dev/packages/supabase_flutter).
+You can use supabase-flutter to interact with your Postgres database, listen to database changes, invoke
 Deno Edge Functions, build login and user management functionality, and manage large files.
 
 We also provide a [supabase](https://pub.dev/packages/supabase) package for non-Flutter projects.

--- a/apps/docs/docs/ref/javascript/v1/introduction.mdx
+++ b/apps/docs/docs/ref/javascript/v1/introduction.mdx
@@ -13,8 +13,16 @@ hideTitle: true
 </div>
 
 <div className="max-w-xl">
-  This reference documents every object and method available in Supabase's isomorphic JavaScript
-  library, supabase-js. You can use supabase-js to interact with your Postgres database, listen to
-  database changes, invoke Deno Edge Functions, build login and user management functionality, and
-  manage large files.
+
+<Admonition type="caution">
+  You're viewing the docs for an older version of the `supabase-js` library. View the [latest
+  version](/docs/reference/javascript/introduction) or follow the [supabase-js v2
+  guide](/docs/guides/resources/upgrade/supabase-js-v2) to upgrade to the latest version.
+</Admonition>
+
+This reference documents every object and method available in Supabase's isomorphic JavaScript
+library, supabase-js. You can use supabase-js to interact with your Postgres database, listen to
+database changes, invoke Deno Edge Functions, build login and user management functionality, and
+manage large files.
+
 </div>

--- a/apps/docs/docs/reference/dart/upgrade-guide.mdx
+++ b/apps/docs/docs/reference/dart/upgrade-guide.mdx
@@ -56,7 +56,7 @@ try {
 
 ### Usage of `SupabaseAuthState` and `SupabaseAuthRequiredState` classes
 
-In v0, `SupabaseAuthState` and `SupabaseAuthRequiredState` were required to handle automatic token refresh and to listen to auth state change. In v1, `SupabaseAuthState` and `SupabaseAuthRequiredState` are deprecated, and token refresh will happen automatically just by initializing Supabase. [`onAuthStateChange`](/docs/reference/dart/upgrade-guide#listening-to-auth-state-change) can be used to action on auth state change.
+In v0, `SupabaseAuthState` and `SupabaseAuthRequiredState` were required to handle automatic token refresh and to listen to auth state change. In v1, `SupabaseAuthState` and `SupabaseAuthRequiredState` are deprecated, and token refresh will happen automatically just by initializing Supabase. [`onAuthStateChange`](#listening-to-auth-state-change) can be used to action on auth state change.
 
 <Tabs
   scrollable

--- a/apps/docs/pages/guides/auth/auth-helpers/nextjs.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/nextjs.mdx
@@ -782,7 +782,7 @@ export const config = {
 
 ### Migrating to v0.4.X and supabase-js v2
 
-With the update to `supabase-js` v2 the `auth` API routes are no longer required, therefore you can go ahead and delete your `auth` directory under the `/pages/api/` directory. Please refer to the [v2 migration guide](/docs/reference/javascript/upgrade-guide) for the full set of changes within supabase-js.
+With the update to `supabase-js` v2 the `auth` API routes are no longer required, therefore you can go ahead and delete your `auth` directory under the `/pages/api/` directory. Refer to the [v2 migration guide](/docs/guides/resources/upgrade/supabase-js-v2) for the full set of changes within supabase-js.
 
 The `/api/auth/logout` API route has been removed, please use the `signout` method instead:
 

--- a/apps/docs/pages/guides/resources.mdx
+++ b/apps/docs/pages/guides/resources.mdx
@@ -6,7 +6,6 @@ export const meta = {
   id: 'resources',
   title: 'Resources',
   description: 'Resources for getting started building with Supabase.',
-  sidebar_label: 'Overview',
 }
 
 <div className="flex flex-col gap-12 my-12">
@@ -22,7 +21,7 @@ export const meta = {
           passHref
         >
           <a className={'col-span-12 md:col-span-4'}>
-            <GlassPanel {...resource} background={false} showIconBg={true}>
+            <GlassPanel {...resource} background={false}>
               {resource.description}
             </GlassPanel>
           </a>
@@ -96,6 +95,20 @@ export const resources = [
     href: '/guides/resources/glossary',
     description: 'Definitions for terminology and acronyms used in the Supabase documentation.',
   },
+  {
+    title: 'Upgrade to supabase-js v2',
+    icon: '/docs/img/icons/menu/reference-javascript',
+    hasLightIcon: true,
+    href: '/guides/resources/upgrade/supabase-js-v2',
+    description: 'Learn how to upgrade the Javascript client library to supabase-js v2.',
+  },
+  {
+    title: 'Upgrade to supabase-flutter v1',
+    icon: '/docs/img/icons/menu/reference-dart',
+    hasLightIcon: true,
+    href: '/guides/resources/upgrade/flutter-v1',
+    description: 'Learn how to upgrade the Flutter client library to supabase-flutter v1.',
+  },
 ]
 
 export const migrationGuides = [
@@ -109,7 +122,7 @@ export const migrationGuides = [
     title: 'Firestore Data',
     icon: '/docs/img/icons/firebase-icon',
     href: '/guides/resources/migrating-to-supabase/firestore-data',
-    description: 'Migrate the contents of a Firestore collection to a single PostgreSQL table.',
+    description: 'Migrate the contents of a Firestore collection to a PostgreSQL table.',
   },
   {
     title: 'Firebase Storage',

--- a/apps/docs/pages/guides/resources/upgrade/flutter-v1.mdx
+++ b/apps/docs/pages/guides/resources/upgrade/flutter-v1.mdx
@@ -54,7 +54,7 @@ try {
 
 ### Usage of `SupabaseAuthState` and `SupabaseAuthRequiredState` classes
 
-In v0, `SupabaseAuthState` and `SupabaseAuthRequiredState` were required to handle automatic token refresh and to listen to auth state change. In v1, `SupabaseAuthState` and `SupabaseAuthRequiredState` are deprecated, and token refresh will happen automatically just by initializing Supabase. [`onAuthStateChange`](/docs/reference/dart/upgrade-guide#listening-to-auth-state-change) can be used to action on auth state change.
+In v0, `SupabaseAuthState` and `SupabaseAuthRequiredState` were required to handle automatic token refresh and to listen to auth state change. In v1, `SupabaseAuthState` and `SupabaseAuthRequiredState` are deprecated, and token refresh will happen automatically just by initializing Supabase. [`onAuthStateChange`](#listening-to-auth-state-change) can be used to action on auth state change.
 
 <Tabs
   scrollable

--- a/apps/docs/pages/guides/resources/upgrade/flutter-v1.mdx
+++ b/apps/docs/pages/guides/resources/upgrade/flutter-v1.mdx
@@ -1,0 +1,549 @@
+import Layout from '~/layouts/DefaultGuideLayout'
+
+export const meta = {
+  title: 'Upgrade to supabase-flutter v1',
+  description: 'Learn how to upgrade to supabase-flutter v1.',
+}
+
+supabase-flutter focuses on improving the developer experience and making it easier to use. This guide helps you upgrade from supabase-flutter v0 to v1.
+
+## Upgrade the client library
+
+Update the package in your `pubspec.yaml` file.
+
+```yaml
+supabase_flutter: ^1.0.0
+```
+
+## Error handling
+
+The way supabase-flutter throws error has changed in v1. In v0, errors were returned as a response. In v1, errors are thrown as exceptions. This makes it more intuitive as a Flutter developer to handle errors.
+
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  defaultActiveId="0.x"
+>
+<TabPanel id="0.x" label="Before">
+
+```dart
+final res = await supabase.from('my_table').select().execute();
+final error = res.error;
+if (error != null) {
+  // handle error
+}
+final data = res.data;
+```
+
+</TabPanel>
+<TabPanel id="1.0x" label="After">
+
+```dart
+try {
+    final data = supabase.from('my_table').select();
+} catch (error) {
+    // handle error
+}
+```
+
+</TabPanel>
+</Tabs>
+
+## Auth classes and methods
+
+### Usage of `SupabaseAuthState` and `SupabaseAuthRequiredState` classes
+
+In v0, `SupabaseAuthState` and `SupabaseAuthRequiredState` were required to handle automatic token refresh and to listen to auth state change. In v1, `SupabaseAuthState` and `SupabaseAuthRequiredState` are deprecated, and token refresh will happen automatically just by initializing Supabase. [`onAuthStateChange`](/docs/reference/dart/upgrade-guide#listening-to-auth-state-change) can be used to action on auth state change.
+
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  defaultActiveId="0.x"
+>
+<TabPanel id="0.x" label="Before">
+
+```dart
+await Supabase.initialize(
+  url: 'SUPABASE_URL',
+  anonKey: 'SUPABASE_ANON_KEY',
+);
+...
+
+class AuthState<T extends StatefulWidget> extends SupabaseAuthState<T> {
+  ...
+}
+
+...
+
+class AuthRequiredState<T extends StatefulWidget> extends SupabaseAuthState<T> {
+  ...
+}
+```
+
+</TabPanel>
+<TabPanel id="1.0x" label="After">
+
+```dart
+await Supabase.initialize(
+  url: 'SUPABASE_URL',
+  anonKey: 'SUPABASE_ANON_KEY',
+);
+```
+
+</TabPanel>
+</Tabs>
+
+### Listening to auth state change
+
+`onAuthStateChange` now returns a `Stream`.
+
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  defaultActiveId="0.x"
+>
+<TabPanel id="0.x" label="Before">
+
+```dart
+final authSubscription = supabase.auth.onAuthStateChange((event, session) {
+  // handle auth state change
+});
+
+// Unsubscribe when no longer needed
+authSubscription.data?.unsubscribe();
+```
+
+</TabPanel>
+<TabPanel id="1.0x" label="After">
+
+```dart
+final authSubscription = supabase.auth.onAuthStateChange.listen((data) {
+      final AuthChangeEvent event = data.event;
+      final Session? session = data.session;
+      // handle auth state change
+    });
+
+// Unsubscribe when no longer needed
+authSubscription.cancel();
+```
+
+</TabPanel>
+</Tabs>
+
+### Sign in with email and password
+
+The signIn() method has been deprecated in favor of more explicit method signatures to help with type hinting. Previously it was difficult for developers to know what they were missing (e.g., a lot of developers didn't realize they could use passwordless magic links).
+
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  defaultActiveId="0.x"
+>
+<TabPanel id="0.x" label="Before">
+
+```dart
+await supabase.auth.signIn(email: email, password: password);
+```
+
+</TabPanel>
+<TabPanel id="1.0x" label="After">
+
+```dart
+await supabase.auth.signInWithPassword(email: email, password: password);
+```
+
+</TabPanel>
+</Tabs>
+
+### Sign in with magic link
+
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  defaultActiveId="0.x"
+>
+<TabPanel id="0.x" label="Before">
+
+```dart
+await supabase.auth.signIn(email: email);
+```
+
+</TabPanel>
+<TabPanel id="1.0x" label="After">
+
+```dart
+await supabase.auth.signInWithOtp(email: email);
+```
+
+</TabPanel>
+</Tabs>
+
+### Sign in with a third-party OAuth provider
+
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  defaultActiveId="0.x"
+>
+<TabPanel id="0.x" label="Before">
+
+```dart
+await supabase.auth.signInWithProvider(
+  Provider.github,
+  options: AuthOptions(
+      redirectTo: kIsWeb
+          ? null
+          : 'io.supabase.flutter://reset-callback/'),
+);
+```
+
+</TabPanel>
+<TabPanel id="1.0x" label="After">
+
+```dart
+await supabase.auth.signInWithOAuth(
+  Provider.github,
+  redirectTo: kIsWeb ? null : 'io.supabase.flutter://reset-callback/',
+);
+```
+
+</TabPanel>
+</Tabs>
+
+### Sign in with phone
+
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  defaultActiveId="0.x"
+>
+<TabPanel id="0.x" label="Before">
+
+```dart
+await supabase.auth.signIn(
+  phone: '+13334445555',
+  password: 'example-password',
+);
+```
+
+</TabPanel>
+<TabPanel id="1.0x" label="After">
+
+```dart
+await supabase.auth.signInWithPassword(
+  phone: '+13334445555',
+  password: 'example-password',
+);
+```
+
+</TabPanel>
+</Tabs>
+
+### Sign in with phone using OTP
+
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  defaultActiveId="0.x"
+>
+<TabPanel id="0.x" label="Before">
+
+```dart
+final res = await supabase.auth.signIn(phone: phone);
+```
+
+</TabPanel>
+<TabPanel id="1.0x" label="After">
+
+```dart
+await supabase.auth.signInWithOtp(
+  phone: phone,
+);
+
+// After receiving a SMS with a OTP.
+await supabase.auth.verifyOTP(
+  type: OtpType.sms,
+  token: token,
+  phone: phone,
+);
+```
+
+</TabPanel>
+</Tabs>
+
+### Reset password for email
+
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  defaultActiveId="0.x"
+>
+<TabPanel id="0.x" label="Before">
+
+```dart
+await supabase.auth.api.resetPasswordForEmail(
+  email,
+  options:
+      AuthOptions(redirectTo: 'io.supabase.flutter://reset-callback/'),
+);
+```
+
+</TabPanel>
+<TabPanel id="1.0x" label="After">
+
+```dart
+await supabase.auth.resetPasswordForEmail(
+  email,
+  redirectTo: kIsWeb ? null : 'io.supabase.flutter://reset-callback/',
+);
+```
+
+</TabPanel>
+</Tabs>
+
+### Get the user's current session
+
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  defaultActiveId="0.x"
+>
+<TabPanel id="0.x" label="Before">
+
+```dart
+final session = supabase.auth.session();
+```
+
+</TabPanel>
+<TabPanel id="1.0x" label="After">
+
+```dart
+final Session? session = supabase.auth.currentSession;
+```
+
+</TabPanel>
+</Tabs>
+
+### Get the logged-in user
+
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  defaultActiveId="0.x"
+>
+<TabPanel id="0.x" label="Before">
+
+```dart
+final user = supabase.auth.user();
+```
+
+</TabPanel>
+<TabPanel id="1.0x" label="After">
+
+```dart
+final User? user = supabase.auth.currentUser;
+```
+
+</TabPanel>
+</Tabs>
+
+### Update user data for a logged-in user
+
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  defaultActiveId="0.x"
+>
+<TabPanel id="0.x" label="Before">
+
+```dart
+await supabase.auth.update(
+  UserAttributes(data: {'hello': 'world'})
+);
+```
+
+</TabPanel>
+<TabPanel id="1.0x" label="After">
+
+```dart
+await supabase.updateUser(
+  UserAttributes(
+    data: { 'hello': 'world' },
+  ),
+);
+```
+
+</TabPanel>
+</Tabs>
+
+## Data methods
+
+`.insert()` / `.upsert()` / `.update()` / `.delete()` don't return rows by default.
+
+Previously, these methods return inserted/updated/deleted rows by default (which caused [some confusion](https://github.com/supabase/supabase/discussions/1548)), and you can opt to not return it by specifying `returning: 'minimal'`. Now the default behavior is to not return rows. To return inserted/updated/deleted rows, add a `.select()` call at the end.
+
+Also, calling `.execute()` at the end of the query was a requirement in v0, but in v1 `.execute` is deperecated.
+
+### Insert without returning inserted data
+
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  defaultActiveId="0.x"
+>
+<TabPanel id="0.x" label="Before">
+
+```dart
+await supabase
+  .from('my_table')
+  .insert(data, returning: ReturningOption.minimal)
+  .execute();
+
+```
+
+</TabPanel>
+<TabPanel id="1.0x" label="After">
+
+```dart
+await supabase.from('my_table').insert(data);
+```
+
+</TabPanel>
+</Tabs>
+
+### Insert with returning inserted data
+
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  defaultActiveId="0.x"
+>
+<TabPanel id="0.x" label="Before">
+
+```dart
+final res = await supabase
+  .from('my_table')
+  .insert(data)
+  .execute();
+```
+
+</TabPanel>
+<TabPanel id="1.0x" label="After">
+
+```dart
+final insertedData = await supabase.from('my_table').insert(data).select();
+```
+
+</TabPanel>
+</Tabs>
+
+## Realtime methods
+
+### Stream
+
+`.stream()` no longer needs the `.execute()` at the end. Also, filtering by `eq` is a lot easier now. `primaryKey` is now a named parameter to make it more obvious what to pass.
+
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  defaultActiveId="0.x"
+>
+<TabPanel id="0.x" label="Before">
+
+```dart
+supabase.from('my_table:id=eq.120')
+  .stream(['id'])
+  .listen();
+```
+
+</TabPanel>
+<TabPanel id="1.0x" label="After">
+
+```dart
+supabase.from('my_table')
+  .stream(primaryKey: ['id'])
+  .eq('id', '120')
+  .listen();
+```
+
+</TabPanel>
+</Tabs>
+
+### Subscribe
+
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  defaultActiveId="0.x"
+>
+<TabPanel id="0.x" label="Before">
+
+```dart
+final subscription = supabase
+  .from('countries')
+  .on(SupabaseEventTypes.all, (payload) {
+    // Handle realtime payload
+  })
+  .subscribe();
+```
+
+</TabPanel>
+<TabPanel id="1.0x" label="After">
+
+```dart
+final channel = supabase.channel('*');
+channel.on(
+  RealtimeListenTypes.postgresChanges,
+  ChannelFilter(event: '*', schema: '*'),
+  (payload, [ref]) {
+    // Handle realtime payload
+  },
+).subscribe();
+```
+
+</TabPanel>
+</Tabs>
+
+### Unsubscribe
+
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  defaultActiveId="0.x"
+>
+<TabPanel id="0.x" label="Before">
+
+```dart
+supabase.removeSubscription(subscription);
+```
+
+</TabPanel>
+<TabPanel id="1.0x" label="After">
+
+```dart
+await supabase.removeChannel(channel);
+```
+
+</TabPanel>
+</Tabs>
+
+export const Page = ({ children }) => <Layout meta={meta} children={children} />
+
+export default Page

--- a/apps/docs/pages/guides/resources/upgrade/supabase-js-v2.mdx
+++ b/apps/docs/pages/guides/resources/upgrade/supabase-js-v2.mdx
@@ -1,8 +1,9 @@
----
-id: upgrade-guide
-title: Upgrade to supabase-js v2
-description: 'Learn how to upgrade to supabase-js v2.'
----
+import Layout from '~/layouts/DefaultGuideLayout'
+
+export const meta = {
+  title: 'Upgrade to supabase-js v2',
+  description: 'Learn how to upgrade to supabase-js v2.',
+}
 
 supabase-js v2 focuses on "quality-of-life" improvements for developers and addresses some of the largest pain points in v1. v2 includes type support, a rebuilt Auth library with async methods, improved errors, and more.
 
@@ -10,28 +11,11 @@ No new features will be added to supabase-js v1 , but we'll continuing merging s
 
 ## Upgrade the client library
 
-<RefSubLayout.EducationRow>
-  <RefSubLayout.Details>
-
-    Install the latest version
-
-  </RefSubLayout.Details>
-  <RefSubLayout.Examples>
-
 ```sh
 npm install @supabase/supabase-js@2
 ```
 
-  </RefSubLayout.Examples>
-</RefSubLayout.EducationRow>
-
-<RefSubLayout.EducationRow>
-  <RefSubLayout.Details>
-
 _Optionally_ if you are using custom configuration with `createClient` then follow below:
-
-  </RefSubLayout.Details>
-  <RefSubLayout.Examples>
 
 <Tabs
   scrollable
@@ -65,98 +49,40 @@ const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
 </TabPanel>
 </Tabs>
 
-  </RefSubLayout.Examples>
-</RefSubLayout.EducationRow>
-
 Read more about the [constructor options](/docs/reference/javascript/release-notes#explicit-constructor-options).
 
-### Auth methods
+## Auth methods
 
 The signIn() method has been deprecated in favor of more explicit method signatures to help with type hinting. Previously it was difficult for developers to know what they were missing (e.g., a lot of developers didn't realize they could use passwordless magic links).
 
-<RefSubLayout.EducationRow>
-  <RefSubLayout.Details>
+### Sign in with email and password
 
-#### Sign in with email and password
-
-  </RefSubLayout.Details>
-  <RefSubLayout.Examples>
-
- <Tabs
+<Tabs
   scrollable
   size="small"
   type="underlined"
   defaultActiveId="1.0x"
 >
 <TabPanel id="1.0x" label="Before">
-{/* prettier-ignore */}
+
 ```ts
-const { user, error } = await supabase
-  .auth
-  .signIn({ email, password })
+const { user, error } = await supabase.auth.signIn({ email, password })
 ```
 
 </TabPanel>
 <TabPanel id="2.0x" label="After">
-{/* prettier-ignore */}
+
 ```ts
 const {
   data: { user },
   error,
-} = await supabase
-  .auth
-  .signInWithPassword({ email, password })
+} = await supabase.auth.signInWithPassword({ email, password })
 ```
 
 </TabPanel>
 </Tabs>
 
-  </RefSubLayout.Examples>
-</RefSubLayout.EducationRow>
-
-<RefSubLayout.EducationRow>
-  <RefSubLayout.Details>
-
-#### Sign in with magic link
-
-  </RefSubLayout.Details>
-  <RefSubLayout.Examples>
- <Tabs
-  scrollable
-  size="small"
-  type="underlined"
-  defaultActiveId="1.0x"
->
-<TabPanel id="1.0x" label="Before">
-{/* prettier-ignore */}
-```ts
-const { error } = await supabase
-  .auth
-  .signIn({ email })
-```
-
-</TabPanel>
-<TabPanel id="2.0x" label="After">
-{/* prettier-ignore */}
-```ts
-const { error } = await supabase
-  .auth
-  .signInWithOtp({ email })
-```
-
-</TabPanel>
-</Tabs>
-
-  </RefSubLayout.Examples>
-</RefSubLayout.EducationRow>
-
-<RefSubLayout.EducationRow>
-  <RefSubLayout.Details>
-
-#### Sign in with a third-party provider
-
-  </RefSubLayout.Details>
-  <RefSubLayout.Examples>
+### Sign in with magic link
 
 <Tabs
   scrollable
@@ -165,71 +91,22 @@ const { error } = await supabase
   defaultActiveId="1.0x"
 >
 <TabPanel id="1.0x" label="Before">
-{/* prettier-ignore */}
+
 ```ts
-const { error } = await supabase
-  .auth
-  .signIn({ provider })
+const { error } = await supabase.auth.signIn({ email })
 ```
 
 </TabPanel>
 <TabPanel id="2.0x" label="After">
-{/* prettier-ignore */}
+
 ```ts
-const { error } = await supabase
-  .auth
-  .signInWithOAuth({ provider })
+const { error } = await supabase.auth.signInWithOtp({ email })
 ```
 
 </TabPanel>
 </Tabs>
 
-  </RefSubLayout.Examples>
-</RefSubLayout.EducationRow>
-
-<RefSubLayout.EducationRow>
-  <RefSubLayout.Details>
-
-#### Sign in with phone
-
-  </RefSubLayout.Details>
-  <RefSubLayout.Examples>
- <Tabs
-  scrollable
-  size="small"
-  type="underlined"
-  defaultActiveId="1.0x"
->
-<TabPanel id="1.0x" label="Before">
-{/* prettier-ignore */}
-```ts
-const { error } = await supabase
-  .auth
-  .signIn({ phone, password })
-```
-
-</TabPanel>
-<TabPanel id="2.0x" label="After">
-{/* prettier-ignore */}
-```ts
-const { error } = await supabase
-  .auth
-  .signInWithPassword({ phone, password })
-```
-
-</TabPanel>
-</Tabs>
-
-  </RefSubLayout.Examples>
-</RefSubLayout.EducationRow>
-
-<RefSubLayout.EducationRow>
-  <RefSubLayout.Details>
-
-#### Sign in with phone using OTP
-
-  </RefSubLayout.Details>
-  <RefSubLayout.Examples>
+### Sign in with a third-party provider
 
 <Tabs
   scrollable
@@ -238,41 +115,73 @@ const { error } = await supabase
   defaultActiveId="1.0x"
 >
 <TabPanel id="1.0x" label="Before">
-{/* prettier-ignore */}
+
 ```ts
-const { error } = await supabase
-  .auth
-  .api
-  .sendMobileOTP(phone)
+const { error } = await supabase.auth.signIn({ provider })
 ```
 
 </TabPanel>
 <TabPanel id="2.0x" label="After">
-{/* prettier-ignore */}
+
 ```ts
-const { data, error } = await supabase
-  .auth
-  .signInWithOtp({ phone })
+const { error } = await supabase.auth.signInWithOAuth({ provider })
+```
+
+</TabPanel>
+</Tabs>
+
+### Sign in with phone
+
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  defaultActiveId="1.0x"
+>
+<TabPanel id="1.0x" label="Before">
+
+```ts
+const { error } = await supabase.auth.signIn({ phone, password })
+```
+
+</TabPanel>
+<TabPanel id="2.0x" label="After">
+
+```ts
+const { error } = await supabase.auth.signInWithPassword({ phone, password })
+```
+
+</TabPanel>
+</Tabs>
+
+### Sign in with phone using OTP
+
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  defaultActiveId="1.0x"
+>
+<TabPanel id="1.0x" label="Before">
+
+```ts
+const { error } = await supabase.auth.api.sendMobileOTP(phone)
+```
+
+</TabPanel>
+<TabPanel id="2.0x" label="After">
+
+```ts
+const { data, error } = await supabase.auth.signInWithOtp({ phone })
 
 // After receiving a SMS with a OTP.
-const { data, error } = await supabase
-.auth
-.verifyOtp({ phone, token })
+const { data, error } = await supabase.auth.verifyOtp({ phone, token })
 ```
 
 </TabPanel>
 </Tabs>
 
-  </RefSubLayout.Examples>
-</RefSubLayout.EducationRow>
-
-<RefSubLayout.EducationRow>
-  <RefSubLayout.Details>
-
-#### Reset password for email
-
-  </RefSubLayout.Details>
-  <RefSubLayout.Examples>
+### Reset password for email
 
 <Tabs
   scrollable
@@ -281,36 +190,22 @@ const { data, error } = await supabase
   defaultActiveId="1.0x"
 >
 <TabPanel id="1.0x" label="Before">
-{/* prettier-ignore */}
+
 ```ts
-const { data, error } = await supabase
-  .auth
-  .api
-  .resetPasswordForEmail(email)
+const { data, error } = await supabase.auth.api.resetPasswordForEmail(email)
 ```
 
 </TabPanel>
 <TabPanel id="2.0x" label="After">
-{/* prettier-ignore */}
+
 ```ts
-const { data, error } = await supabase
-  .auth
-  .resetPasswordForEmail(email)
+const { data, error } = await supabase.auth.resetPasswordForEmail(email)
 ```
 
 </TabPanel>
 </Tabs>
 
-  </RefSubLayout.Examples>
-</RefSubLayout.EducationRow>
-
-<RefSubLayout.EducationRow>
-  <RefSubLayout.Details>
-
-#### Get the user's current session
-
-  </RefSubLayout.Details>
-  <RefSubLayout.Examples>
+### Get the user's current session
 
 <Tabs
   scrollable
@@ -336,16 +231,7 @@ const {
 </TabPanel>
 </Tabs>
 
-  </RefSubLayout.Examples>
-</RefSubLayout.EducationRow>
-
-<RefSubLayout.EducationRow>
-  <RefSubLayout.Details>
-
-#### Get the logged-in user
-
-  </RefSubLayout.Details>
-  <RefSubLayout.Examples>
+### Get the logged-in user
 
 <Tabs
   scrollable
@@ -372,16 +258,7 @@ const { user } = session
 </TabPanel>
 </Tabs>
 
-  </RefSubLayout.Examples>
-</RefSubLayout.EducationRow>
-
-<RefSubLayout.EducationRow>
-  <RefSubLayout.Details>
-
-#### Update user data for a logged-in user
-
-  </RefSubLayout.Details>
-  <RefSubLayout.Examples>
+### Update user data for a logged-in user
 
 <Tabs
   scrollable
@@ -390,11 +267,9 @@ const { user } = session
   defaultActiveId="1.0x"
 >
 <TabPanel id="1.0x" label="Before">
-{/* prettier-ignore */}
+
 ```ts
-const { user, error } = await supabase
-  .auth
-  .update({ attributes })
+const { user, error } = await supabase.auth.update({ attributes })
 ```
 
 </TabPanel>
@@ -410,16 +285,7 @@ const {
 </TabPanel>
 </Tabs>
 
-  </RefSubLayout.Examples>
-</RefSubLayout.EducationRow>
-
-<RefSubLayout.EducationRow>
-  <RefSubLayout.Details>
-
-#### Use a custom `access_token` JWT with Supabase
-
-  </RefSubLayout.Details>
-  <RefSubLayout.Examples>
+### Use a custom `access_token` JWT with Supabase
 
 <Tabs
   scrollable
@@ -435,26 +301,19 @@ const { user, error } = supabase.auth.setAuth(access_token)
 
 </TabPanel>
 <TabPanel id="2.0x" label="After">
-{/* prettier-ignore */}
+
 ```ts
-const supabase = createClient(
-  SUPABASE_URL,
-  SUPABASE_ANON_KEY,
-  {
-    global: {
-      headers: {
-        Authorization: `Bearer ${access_token}`,
-      },
+const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+  global: {
+    headers: {
+      Authorization: `Bearer ${access_token}`,
     },
-  }
-)
+  },
+})
 ```
 
 </TabPanel>
 </Tabs>
-
-  </RefSubLayout.Examples>
-</RefSubLayout.EducationRow>
 
 ### Cookie methods
 
@@ -465,19 +324,13 @@ If you can't use the Auth Helpers, you can use [server-side rendering](https://s
 
 Some the [PR](https://github.com/supabase/gotrue-js/pull/340) for additional background information.
 
-### Data methods
+## Data methods
 
 `.insert()` / `.upsert()` / `.update()` / `.delete()` don't return rows by default: [PR](https://github.com/supabase/postgrest-js/pull/276).
 
 Previously, these methods return inserted/updated/deleted rows by default (which caused [some confusion](https://github.com/supabase/supabase/discussions/1548)), and you can opt to not return it by specifying `returning: 'minimal'`. Now the default behavior is to not return rows. To return inserted/updated/deleted rows, add a `.select()` call at the end.
 
-<RefSubLayout.EducationRow>
-  <RefSubLayout.Details>
-
-#### Insert and return data
-
-  </RefSubLayout.Details>
-  <RefSubLayout.Examples>
+### Insert and return data
 
 <Tabs
   scrollable
@@ -486,36 +339,22 @@ Previously, these methods return inserted/updated/deleted rows by default (which
   defaultActiveId="1.0x"
 >
 <TabPanel id="1.0x" label="Before">
-{/* prettier-ignore */}
+
 ```ts
-const { data, error } = await supabase
-  .from('my_table')
-  .insert({ new_data })
+const { data, error } = await supabase.auth.insert({ new_data })
 ```
 
 </TabPanel>
 <TabPanel id="2.0x" label="After">
-{/* prettier-ignore */}
+
 ```ts
-const { data, error } = await supabase
-  .from('my_table')
-  .insert({ new_data })
-  .select()
+const { data, error } = await supabase.auth.insert({ new_data }).select()
 ```
 
 </TabPanel>
 </Tabs>
 
-  </RefSubLayout.Examples>
-</RefSubLayout.EducationRow>
-
-<RefSubLayout.EducationRow>
-  <RefSubLayout.Details>
-
-#### Update and return data
-
-  </RefSubLayout.Details>
-  <RefSubLayout.Examples>
+### Update and return data
 
 <Tabs
   scrollable
@@ -524,38 +363,22 @@ const { data, error } = await supabase
   defaultActiveId="1.0x"
 >
 <TabPanel id="1.0x" label="Before">
-{/* prettier-ignore */}
+
 ```ts
-const { data, error } = await supabase
-  .from('my_table')
-  .update({ new_data })
-  .eq('id', id)
+const { data, error } = await supabase.auth.update({ new_data }).eq('id', id)
 ```
 
 </TabPanel>
 <TabPanel id="2.0x" label="After">
-{/* prettier-ignore */}
+
 ```ts
-const { data, error } = await supabase
-  .from('my_table')
-  .update({ new_data })
-  .eq('id', id)
-  .select()
+const { data, error } = await supabase.auth.update({ new_data }).eq('id', id).select()
 ```
 
 </TabPanel>
 </Tabs>
 
-  </RefSubLayout.Examples>
-</RefSubLayout.EducationRow>
-
-<RefSubLayout.EducationRow>
-  <RefSubLayout.Details>
-
-#### Upsert and return data
-
-  </RefSubLayout.Details>
-  <RefSubLayout.Examples>
+### Upsert and return data
 
 <Tabs
   scrollable
@@ -564,36 +387,22 @@ const { data, error } = await supabase
   defaultActiveId="1.0x"
 >
 <TabPanel id="1.0x" label="Before">
-{/* prettier-ignore */}
+
 ```ts
-const { data, error } = await supabase
-  .from('my_table')
-  .upsert({ new_data })
+const { data, error } = await supabase.from('my_table').upsert({ new_data })
 ```
 
 </TabPanel>
 <TabPanel id="2.0x" label="After">
-{/* prettier-ignore */}
+
 ```ts
-const { data, error } = await supabase
-  .from('my_table')
-  .upsert({ new_data })
-  .select()
+const { data, error } = await supabase.from('my_table').upsert({ new_data }).select()
 ```
 
 </TabPanel>
 </Tabs>
 
-  </RefSubLayout.Examples>
-</RefSubLayout.EducationRow>
-
-<RefSubLayout.EducationRow>
-  <RefSubLayout.Details>
-
-#### Delete and return data
-
-  </RefSubLayout.Details>
-  <RefSubLayout.Examples>
+### Delete and return data
 
 <Tabs
   scrollable
@@ -602,40 +411,24 @@ const { data, error } = await supabase
   defaultActiveId="1.0x"
 >
 <TabPanel id="1.0x" label="Before">
-{/* prettier-ignore */}
+
 ```ts
-const { data, error } = await supabase
-  .from('my_table')
-  .delete()
-  .eq('id', id)
+const { data, error } = await supabase.from('my_table').delete().eq('id', id)
 ```
 
 </TabPanel>
 <TabPanel id="2.0x" label="After">
-{/* prettier-ignore */}
+
 ```ts
-const { data, error } = await supabase
-  .from('my_table')
-  .delete()
-  .eq('id', id)
-  .select()
+const { data, error } = await supabase.from('my_table').delete().eq('id', id).select()
 ```
 
 </TabPanel>
 </Tabs>
 
-  </RefSubLayout.Examples>
-</RefSubLayout.EducationRow>
+## Realtime methods
 
-### Realtime methods
-
-<RefSubLayout.EducationRow>
-  <RefSubLayout.Details>
-
-#### Subscribe
-
-  </RefSubLayout.Details>
-  <RefSubLayout.Examples>
+### Subscribe
 
 <Tabs
   scrollable
@@ -667,16 +460,7 @@ const userListener = supabase
 </TabPanel>
 </Tabs>
 
-  </RefSubLayout.Examples>
-</RefSubLayout.EducationRow>
-
-<RefSubLayout.EducationRow>
-  <RefSubLayout.Details>
-
-#### Unsubscribe
-
-  </RefSubLayout.Details>
-  <RefSubLayout.Examples>
+### Unsubscribe
 
 <Tabs
   scrollable
@@ -700,5 +484,6 @@ supabase.removeChannel(userListener)
 </TabPanel>
 </Tabs>
 
-  </RefSubLayout.Examples>
-</RefSubLayout.EducationRow>
+export const Page = ({ children }) => <Layout meta={meta} children={children} />
+
+export default Page

--- a/apps/www/_blog/2022-08-16-supabase-js-v2.mdx
+++ b/apps/www/_blog/2022-08-16-supabase-js-v2.mdx
@@ -13,10 +13,7 @@ toc_depth: 3
 <div className="bg-gray-300 rounded-lg p-6 italic">
 <br /> ⚠️ UPDATED 20/10: supabase-js v2 is fully released 🥳<br />
 
-<a href="https://supabase.com/docs/reference/javascript">Check the updated docs</a> and <a href="https://supabase.com/docs/guides/resources/upgrade/supabase-js-v2">
-  migration guide
-</a>
-.
+<a href="https://supabase.com/docs/reference/javascript">Check the updated docs</a> and <a href="https://supabase.com/docs/guides/resources/upgrade/supabase-js-v2">migration guide</a>.
 
 </div>
 

--- a/apps/www/_blog/2022-08-16-supabase-js-v2.mdx
+++ b/apps/www/_blog/2022-08-16-supabase-js-v2.mdx
@@ -13,7 +13,10 @@ toc_depth: 3
 <div className="bg-gray-300 rounded-lg p-6 italic">
 <br /> ⚠️ UPDATED 20/10: supabase-js v2 is fully released 🥳<br />
 
-<a href="https://supabase.com/docs/reference/javascript">Check the updated docs</a> and <a href="https://supabase.com/docs/reference/javascript/upgrade-guide">migration guide</a>.
+<a href="https://supabase.com/docs/reference/javascript">Check the updated docs</a> and <a href="https://supabase.com/docs/guides/resources/upgrade/supabase-js-v2">
+  migration guide
+</a>
+.
 
 </div>
 
@@ -309,7 +312,7 @@ Update today by running:
 npm i @supabase/supabase-js@2
 ```
 
-[Migration guide](https://supabase.com/docs/reference/javascript/upgrade-guide)
+[Migration guide](https://supabase.com/docs/guides/resources/upgrade/supabase-js-v2)
 
 We'll continuing merging security fixes to v1, with maintenance patches for the next three months.
 
@@ -329,6 +332,6 @@ We'll continuing merging security fixes to v1, with maintenance patches for the 
 ## supabase-js v2 resources
 
 - [v2 Documentation](https://supabase.com/docs/reference/javascript)
-- [Migration guide](https://supabase.com/docs/reference/javascript/upgrade-guide)
+- [Migration guide](https://supabase.com/docs/guides/resources/upgrade/supabase-js-v2)
 - [Next.js quickstart guide](/docs/guides/with-nextjs)
 - [Examples](https://github.com/supabase/supabase/tree/master/examples)

--- a/apps/www/_blog/2022-10-20-supabase-js-v2-released.mdx
+++ b/apps/www/_blog/2022-10-20-supabase-js-v2-released.mdx
@@ -2,7 +2,7 @@
 title: 'supabase-js v2 Released'
 description: We've released supabase-js v2. Updated examples, quickstarts, and an improved experience.
 author: thor_schaeff
-image: supabase-js-v2-release/supabase-js.jpg 
+image: supabase-js-v2-release/supabase-js.jpg
 thumb: supabase-js-v2-release/supabase-js.jpg
 tags:
   - launch-week
@@ -10,17 +10,17 @@ date: '2022-10-20'
 toc_depth: 3
 ---
 
-During our [last Launch Week](/launch-week) we presented the [release candidate for supabase-js v2](/blog/supabase-js-v2). Since then we've been busy incorporating your feedback, [updating the docs](/docs/reference/javascript/), [examples](https://github.com/supabase/supabase/tree/master/examples), [quickstart guides](/docs/guides/with-nextjs), and putting a [migration guide](/docs/reference/javascript/upgrade-guide) together.
+During our [last Launch Week](/launch-week) we presented the [release candidate for supabase-js v2](/blog/supabase-js-v2). Since then we've been busy incorporating your feedback, [updating the docs](/docs/reference/javascript/), [examples](https://github.com/supabase/supabase/tree/master/examples), [quickstart guides](/docs/guides/with-nextjs), and putting a [migration guide](https://supabase.com/docs/guides/resources/upgrade/supabase-js-v2) together.
 
 ## What is new in v2?
 
-Enhanced TypeScript support built right in was the big one! Now you can use the CLI to generate types, directly from your database. 
+Enhanced TypeScript support built right in was the big one! Now you can use the CLI to generate types, directly from your database.
 
-Plus v2 comes with lots of improvements that solved some of the largest pain-points highlighted by our users. Your feedback help us improve: you speak, we listen. 
+Plus v2 comes with lots of improvements that solved some of the largest pain-points highlighted by our users. Your feedback help us improve: you speak, we listen.
 
 Read all the updates and the differences with v1 on the [announcement blog post](/blog/supabase-js-v2)
 
-## Acknowledgements  
+## Acknowledgements
 
 It truly takes a village, well, in this case an entire community, and we want to thank you all for your feedback, and contributions!
 
@@ -40,7 +40,7 @@ Special shout outs to: [@vejja](https://github.com/vejja), [@pixtron](https://gi
 ## Links
 
 - [Documentation](/docs/reference/javascript)
-- [Migration Guide](/docs/reference/javascript/upgrade-guide)
+- [Migration guide](https://supabase.com/docs/guides/resources/upgrade/supabase-js-v2)
 - [Quickstart Guides](/docs/guides/with-nextjs)
 - [Examples (GitHub)](https://github.com/supabase/supabase/tree/master/examples)
 - [Release Notes](/docs/reference/javascript/release-notes)

--- a/apps/www/_blog/2022-10-21-supabase-flutter-sdk-v1-released.mdx
+++ b/apps/www/_blog/2022-10-21-supabase-flutter-sdk-v1-released.mdx
@@ -2,7 +2,7 @@
 title: 'supabase-flutter v1 Released'
 description: We've released supabase-flutter v1. More intuitive way of accessing Supabase from your Flutter application.
 author: tyler_shukert
-image:  flutter-v1-release/flutter_v1_official_release.jpeg
+image: flutter-v1-release/flutter_v1_official_release.jpeg
 thumb: flutter-v1-release/flutter_v1_official_release.jpeg
 tags:
   - flutter
@@ -11,7 +11,7 @@ date: '2022-10-21'
 toc_depth: 3
 ---
 
-A few months ago, we announced a [developer preview version of supabase-flutter SDK](https://supabase.com/blog/supabase-flutter-sdk-1-developer-preview). Since then, we have heard a lot of amazing feedback from the community, and have been improving it. Today, we are happy to announce the stable v1 of [supabase-flutter](https://pub.dev/packages/supabase_flutter). You can also find the updated [quick start guide](https://supabase.com/docs/guides/with-flutter), [documentation](https://supabase.com/docs/reference/dart) and a [migration guide from v0](https://supabase.com/docs/reference/dart/upgrade-guide).
+A few months ago, we announced a [developer preview version of supabase-flutter SDK](https://supabase.com/blog/supabase-flutter-sdk-1-developer-preview). Since then, we have heard a lot of amazing feedback from the community, and have been improving it. Today, we are happy to announce the stable v1 of [supabase-flutter](https://pub.dev/packages/supabase_flutter). You can also find the updated [quick start guide](https://supabase.com/docs/guides/with-flutter), [documentation](https://supabase.com/docs/reference/dart) and a [migration guide from v0](https://supabase.com/docs/guides/resources/upgrade/flutter-v1).
 
 ## What is new in v1?
 
@@ -97,7 +97,7 @@ It required massive support from the community to bring the supabase-flutter to 
 
 - [Install supabase-flutter v1.0](https://pub.dev/packages/supabase_flutter)
 - [supabase-flutter documentation](https://supabase.com/docs/reference/dart/)
-- [v0 to v1 migration guide](https://supabase.com/docs/reference/dart/upgrade-guide)
+- [v0 to v1 migration guide](https://supabase.com/docs/guides/resources/upgrade/flutter-v1)
 - [Flutter Tutorial: building a Flutter chat app](https://supabase.com/blog/flutter-tutorial-building-a-chat-app)
 - [Flutter Tutorial - Part 2: Authentication and Authorization with RLS](https://supabase.com/blog/flutter-authentication-and-authorization-with-rls)
 - [Build a Flutter app with Very Good CLI and Supabase](https://verygood.ventures/blog/flutter-app-very-good-cli-supabase)

--- a/apps/www/lib/redirects.js
+++ b/apps/www/lib/redirects.js
@@ -1901,4 +1901,14 @@ module.exports = [
     source: '/legal/soc2',
     destination: 'https://forms.supabase.com/soc2',
   },
+  {
+    permanent: true,
+    source: '/docs/reference/javascript/upgrade-guide',
+    destination: '/docs/guides/resources/upgrade/supabase-js-v2',
+  },
+  {
+    permanent: true,
+    source: '/docs/reference/dart/upgrade-guide',
+    destination: '/docs/guides/resources/upgrade/flutter-v1',
+  },
 ]

--- a/spec/common-client-libs-sections.json
+++ b/spec/common-client-libs-sections.json
@@ -27,13 +27,6 @@
     "libs": ["js", "js_v1"]
   },
   {
-    "title": "Upgrade guide",
-    "id": "upgrade-guide",
-    "slug": "upgrade-guide",
-    "type": "markdown",
-    "libs": ["js"]
-  },
-  {
     "title": "Database",
     "libs": ["js", "js_v1", "dart", "dart_v0"],
     "items": [


### PR DESCRIPTION
## Preview URLs

- https://docs-git-docs-lib-upgrade-guides-supabase.vercel.app/docs/guides/resources
- https://docs-git-docs-lib-upgrade-guides-supabase.vercel.app/docs/guides/resources/upgrade/supabase-js-v2
- https://docs-git-docs-lib-upgrade-guides-supabase.vercel.app/docs/guides/resources/upgrade/flutter-v1
- https://docs-git-docs-lib-upgrade-guides-supabase.vercel.app/docs/reference/javascript/v1/start
- https://docs-git-docs-lib-upgrade-guides-supabase.vercel.app/docs/reference/dart/v0/start

## What kind of change does this PR introduce?

- Move client library upgrade guides to Resources
![Screenshot 2023-01-06 at 6 02 46 PM](https://user-images.githubusercontent.com/7026076/211126498-37c62236-c5df-4b3a-b95b-f2953877d0a0.png)

- Update Resources landing page
![Screenshot 2023-01-06 at 6 06 40 PM](https://user-images.githubusercontent.com/7026076/211126687-0c3baa5e-e881-4e3f-b15e-3926310ea985.png)

- Add callouts to supabase-js v1 and flutter v0 reference docs
![Screenshot 2023-01-06 at 6 04 36 PM](https://user-images.githubusercontent.com/7026076/211126578-1c190084-1d3c-4797-9654-33df9f8b8616.png)

- Add redirects and update links