### PR TITLE
docs: fix usage of router in Server Components instructions

### DIFF
--- a/apps/docs/pages/guides/auth/auth-helpers/nextjs-server-components.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/nextjs-server-components.mdx
@@ -222,7 +222,7 @@ export default function SupabaseListener({ accessToken }) {
   useEffect(() => {
     supabase.auth.onAuthStateChange((event, session) => {
       if (session?.access_token !== accessToken) {
-        router.reload()
+        router.refresh()
       }
     })
   }, [accessToken])


### PR DESCRIPTION
## What kind of change does this PR introduce?

Updating docs for Next.js Server Components to use the correct method

## What is the current behavior?

Current docs for [Server Components](https://supabase.com/docs/guides/auth/auth-helpers/nextjs-server-components#supabase-listener) say to use `router.reload()` in the Supabase Listener, which is incorrect. It should be `router.refresh()` according to the latest Next.js [Beta Docs](https://beta.nextjs.org/docs/api-reference/use-router).

## What is the new behavior?

Docs say to use `router.refresh()`

## Additional context

Current docs:

<img width="899" alt="Screenshot 2023-01-08 at 11 33 03 AM" src="https://user-images.githubusercontent.com/5657181/211208194-88785511-b29c-4f90-9a49-aba98b8665ab.png">

Next.js Beta Docs:

<img width="733" alt="Screenshot 2023-01-08 at 11 33 53 AM" src="https://user-images.githubusercontent.com/5657181/211208200-1b0dc4c6-3c00-4df6-90fc-3a951b47f8c2.png">

