### PR TITLE
feat: auth email templates link

### DIFF
--- a/studio/components/interfaces/Auth/EmailTemplates/EmailTemplates.tsx
+++ b/studio/components/interfaces/Auth/EmailTemplates/EmailTemplates.tsx
@@ -1,4 +1,4 @@
-import { Tabs } from 'ui'
+import { Button, IconExternalLink, Tabs } from 'ui'
 import { observer } from 'mobx-react-lite'
 
 import { TEMPLATES_SCHEMAS } from 'stores/authConfig/schema'
@@ -8,10 +8,20 @@ import TemplateEditor from './TemplateEditor'
 const EmailTemplates = observer(() => {
   return (
     <div>
-      <FormHeader
-        title="Email Templates"
-        description="Customize the emails that will be sent out to your users."
-      />
+      <div className='flex justify-between items-center'>
+        <FormHeader
+          title="Email Templates"
+          description="Customize the emails that will be sent out to your users."
+        />
+        <Button type="link" icon={<IconExternalLink size={14} strokeWidth={1.5} />}>
+          <a
+            target="_blank"
+            href="https://supabase.com/docs/guides/auth/auth-email-templates"
+          >
+            Email Templates Documentation
+          </a>
+        </Button>
+      </div>
       <FormPanel>
         <Tabs
           scrollable


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase Studio > Auth > Email Templates

## What is the current behavior?

At the moment their is no link for email templates for easy access to docs

## What is the new behavior?

Added in a button to link to the docs:

<img width="1292" alt="Screenshot 2023-01-09 at 14 50 09" src="https://user-images.githubusercontent.com/22655069/211336955-58ea5e2c-0805-456a-9561-27bec0512aca.png">
