### PR TITLE
Update nextjs-server-components.mdx

### DIFF
--- a/apps/docs/pages/guides/auth/auth-helpers/nextjs-server-components.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/nextjs-server-components.mdx
@@ -226,7 +226,7 @@ export default function SupabaseListener({ accessToken }) {
       }
     })
   
-    return () => subscription.unsubscribe();
+    return () => subscription.unsubscribe()
   }, [accessToken])
 
   return null

--- a/apps/docs/pages/guides/auth/auth-helpers/nextjs-server-components.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/nextjs-server-components.mdx
@@ -220,13 +220,13 @@ export default function SupabaseListener({ accessToken }) {
   const router = useRouter()
 
   useEffect(() => {
-    const event = supabase.auth.onAuthStateChange((event, session) => {
+    const { data: subscription } = supabase.auth.onAuthStateChange((event, session) => {
       if (session?.access_token !== accessToken) {
         router.refresh()
       }
     })
   
-    return () => event.data.subscription.unsubscribe();
+    return () => subscription.unsubscribe();
   }, [accessToken])
 
   return null

--- a/apps/docs/pages/guides/auth/auth-helpers/nextjs-server-components.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/nextjs-server-components.mdx
@@ -220,11 +220,13 @@ export default function SupabaseListener({ accessToken }) {
   const router = useRouter()
 
   useEffect(() => {
-    supabase.auth.onAuthStateChange((event, session) => {
+    const event = supabase.auth.onAuthStateChange((event, session) => {
       if (session?.access_token !== accessToken) {
         router.refresh()
       }
     })
+  
+    return () => event.data.subscription.unsubscribe();
   }, [accessToken])
 
   return null


### PR DESCRIPTION
## What kind of change does this PR 
docs update.

## What is the current behavior?
The `SupabaseListener` doesn't have a cleanup function. In this way, several auth listeners are created and the page refreshes several times - the number of callbacks running is proportional to the number of auth changes. 

## What is the new behavior?

Add cleanup function to `useEffect`

## Additional context

Faced this issue in my app. This was the fix - I hope this help the community.
