### PR TITLE
fix: studio api users verifyotp

### DIFF
--- a/studio/components/to-be-cleaned/Docs/Snippets.js
+++ b/studio/components/to-be-cleaned/Docs/Snippets.js
@@ -634,7 +634,7 @@ let { data, error } = await supabase.auth.api.inviteUserByEmail('someone@email.c
     },
   }),
   authThirdPartyLogin: (endpoint, apiKey) => ({
-    title: '',
+    title: 'Third Party Login',
     bash: {
       language: 'bash',
       code: ``,

--- a/studio/components/to-be-cleaned/Docs/Snippets.js
+++ b/studio/components/to-be-cleaned/Docs/Snippets.js
@@ -604,9 +604,10 @@ curl -X POST '${endpoint}/auth/v1/verify' \\
     js: {
       language: 'js',
       code: `
-let { data, error } = await supabase.auth.verifyOTP({
+let { data, error } = await supabase.auth.verifyOtp({
   phone: '+13334445555',
-  token: '123456'
+  token: '123456',
+  type: 'sms'
 })
 `,
     },


### PR DESCRIPTION
## What kind of change does this PR introduce?

Studio > API Docs > User Management > Verify An SMS OTP

## What is the current behavior?

The example in `Verify An SMS OTP` is not correct and outdated:

<img width="1101" alt="Screenshot 2023-01-10 at 15 09 52" src="https://user-images.githubusercontent.com/22655069/211590444-2e286a29-e2c6-446f-9b2b-131532f84bb4.png">


## What is the new behavior?

Example has been changed to use `v2` code:

<img width="1101" alt="Screenshot 2023-01-10 at 15 15 53" src="https://user-images.githubusercontent.com/22655069/211590529-28d91366-da3a-42c0-a30f-1d11f1b448c7.png">


## Additional context

I've also also a title to `Log In With Third Party OAuth`.

This was highlighted on [Discord](https://discord.com/channels/839993398554656828/839993398554656831/1062198489888591984)
