### PR TITLE
Task: Update Policy template to avoid deprecated function

### DIFF
--- a/studio/components/interfaces/Auth/Policies/PolicyEditorModal/PolicyEditorModal.constants.ts
+++ b/studio/components/interfaces/Auth/Policies/PolicyEditorModal/PolicyEditorModal.constants.ts
@@ -57,13 +57,13 @@ WITH CHECK (true);`.trim(),
 CREATE POLICY "policy_name"
 ON ${schema}.${table}
 FOR UPDATE USING (
-  auth.email() = email
+  auth.jwt() ->> 'email' = email
 ) WITH CHECK (
-  auth.email() = email
+  auth.jwt() ->> 'email' = email
 );`.trim(),
     name: 'Enable update for users based on email',
-    definition: 'auth.email() = email',
-    check: 'auth.email() = email',
+    definition: `auth.jwt() ->> 'email' = email`,
+    check: `auth.jwt() ->> 'email' = email`,
     command: 'UPDATE',
     roles: [],
   },


### PR DESCRIPTION
## What kind of change does this PR introduce?

The deprecated function `auth.email()` was in the RLS templates:
https://supabase.com/docs/guides/auth/row-level-security#deprecated-features

I am updating this to use the current suggestion i.e `auth.jwt() ->> 'email'`
## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
