### PR TITLE
Remove "nodescription"

### DIFF
--- a/apps/docs/components/Options.tsx
+++ b/apps/docs/components/Options.tsx
@@ -70,7 +70,7 @@ const Option: FC<IOption> = (props) => {
         </span>
         <span className="text-scale-900 text-xs">{props.type ?? 'no type'}</span>
       </div>
-      <p className="text-sm text-scale-1000 m-0">{props.description ?? 'nodescription'}</p>
+      <p className="text-sm text-scale-1000 m-0">{props.description}</p>
       {props.children}
     </div>
   )

--- a/apps/docs/components/Params.tsx
+++ b/apps/docs/components/Params.tsx
@@ -20,7 +20,7 @@ const Param: FC<IParamProps> = (paramItem) => {
         </span>
         <span className="text-scale-900 text-xs">{paramItem.type ?? 'no type'}</span>
       </div>
-      <p className="text-sm text-scale-1000 m-0">{paramItem.description ?? 'nodescription'}</p>
+      <p className="text-sm text-scale-1000 m-0">{paramItem.description}</p>
       {paramItem.children}
     </li>
   )


### PR DESCRIPTION
## Preview URL

https://docs-git-docs-ref-nodescription-supabase.vercel.app/docs/reference/javascript/initializing

## What kind of change does this PR introduce?

Remove `nodescription` text if a parameter doesn't have a description. This is redundant for parameters with additional nested values.

## What is the current behavior?

![Screenshot 2023-01-10 at 3 41 40 PM](https://user-images.githubusercontent.com/7026076/211685001-478351a1-60e2-453b-b40f-c4a5167fc9fe.png)

## What is the new behavior?

![Screenshot 2023-01-10 at 3 41 24 PM](https://user-images.githubusercontent.com/7026076/211685024-4f332fb9-3d3a-4179-af79-f1ee689538b3.png)