### PR TITLE
remove execute() from dart code

### DIFF
--- a/apps/docs/pages/guides/database/functions.mdx
+++ b/apps/docs/pages/guides/database/functions.mdx
@@ -88,9 +88,8 @@ Reference: [rpc()](../../reference/javascript/rpc)
 <TabPanel id="dart" label="Dart">
 
 ```dart
-final res = await supabase
-  .rpc('hello_world')
-  .execute();
+final data = await supabase
+  .rpc('hello_world');
 ```
 
 Reference: [rpc()](../../reference/dart/rpc)
@@ -199,10 +198,9 @@ const { data, error } = supabase.rpc('get_planets').eq('id', 1)
 <TabPanel id="dart" label="Dart">
 
 ```dart
-final res = await supabase
+final data = await supabase
   .rpc('get_planets')
-  .eq('id', 1)
-  .execute();
+  .eq('id', 1);
 ```
 
 </TabPanel>
@@ -254,9 +252,8 @@ const { data, error } = await supabase.rpc('add_planet', { name: 'Jakku' })
 <TabPanel id="dart" label="Dart">
 
 ```dart
-final res = await supabase
-  .rpc('add_planet', params: { 'name': 'Jakku' })
-  .execute();
+final data = await supabase
+  .rpc('add_planet', params: { 'name': 'Jakku' });
 ```
 
 </TabPanel>

--- a/apps/docs/pages/guides/database/tables.mdx
+++ b/apps/docs/pages/guides/database/tables.mdx
@@ -206,7 +206,7 @@ const { data, error } = await supabase
 <TabPanel id="dart" label="Dart">
 
 ```sql
-final res = await supabase
+await supabase
   .from('movies')
   .insert([{
     name: 'The Empire Strikes Back',
@@ -214,7 +214,7 @@ final res = await supabase
   }, {
     name: 'Return of the Jedi',
     description: 'After a daring mission to rescue Han Solo from Jabba the Hutt, the Rebels dispatch to Endor to destroy the second Death Star.'
-  }]).execute();
+  }]);
 ```
 
 </TabPanel>


### PR DESCRIPTION
## What kind of change does this PR introduce?

There were some old syntax of the Flutter SDK left in few spots. This PR fixes them to use the new syntax.