### PR TITLE
Add section about storage management

### DIFF
--- a/apps/docs/components/MDX/storage_management.mdx
+++ b/apps/docs/components/MDX/storage_management.mdx
@@ -1,15 +1,14 @@
-If you repeatedly upload profile photos, you will observe that all uploads will accumulate
+If you upload additional profile photos, they'll accumulate
 in the `avatars` bucket because of their random names with only the latest being referenced
-from `public.profiles` and the others getting orphaned.
+from `public.profiles` and the older versions getting orphaned.
 
-In order to automatically remove obsolete storage objects, we can extend the database
-triggers. It is important to note that it is not sufficient to delete the objects from the
+To automatically remove obsolete storage objects, extend the database
+triggers. Note that it is not sufficient to delete the objects from the
 `storage.objects` table because that would orphan and leak the actual storage objects in
-the S3 backend. Instead, we'll need to invoke the storage API itself from within Postgres
-via the `http` extension. So, enable that for the `extensions` schema in the
-Database/Extensions dashboard.
+the S3 backend. Instead, invoke the storage API within Postgres via the `http` extension. 
 
-Then, define the following SQL functions in the SQL Editor which allow to easily delete
+Enable the [http extension for the `extensions` schema](https://app.supabase.com/project/_/database/extensions) in the Dashboard.
+Then, define the following SQL functions in the SQL Editor to delete
 storage objects via the API:
 
 ```SQL
@@ -50,7 +49,7 @@ $$;
 
 ```
 
-The next step is to add a trigger that removes any obsolete avatar whenever the
+Next, add a trigger that removes any obsolete avatar whenever the
 profile is updated or deleted:
 
 ```SQL
@@ -86,9 +85,9 @@ create trigger before_profile_changes
 
 ```
 
-The final step is to delete the `public.profile` row ahead of time when a user
-is deleted. If this step is omitted, you won't be able to delete users without
-first manually deleting the avatar image owned by them.
+Finally, delete the `public.profile` row before a user is deleted.
+If this step is omitted, you won't be able to delete users without
+first manually deleting their avatar image.
 
 ```SQL
 create or replace function delete_old_profile()

--- a/apps/docs/components/MDX/storage_management.mdx
+++ b/apps/docs/components/MDX/storage_management.mdx
@@ -1,0 +1,109 @@
+If you repeatedly upload profile photos, you will observe that all uploads will accumulate
+in the `avatars` bucket because of their random names with only the latest being referenced
+from `public.profiles` and the others getting orphaned.
+
+In order to automatically remove obsolete storage objects, we can extend the database
+triggers. It is important to note that it is not sufficient to delete the objects from the
+`storage.objects` table because that would orphan and leak the actual storage objects in
+the S3 backend. Instead, we'll need to invoke the storage API itself from within Postgres
+via the `http` extension. So, enable that for the `extensions` schema in the
+Database/Extensions dashboard.
+
+Then, define the following SQL functions in the SQL Editor which allow to easily delete
+storage objects via the API:
+
+```SQL
+create or replace function delete_storage_object(bucket text, object text, out status int, out content varchar)
+returns record
+language 'plpgsql'
+security definer
+as $$
+declare
+  project_url varchar := '<YOURPROJECTURL>';
+  service_role_key varchar := '<YOURSERVICEROLEKEY>'; --  full access needed
+  url varchar := project_url||'/storage/v1/object/'||bucket||'/'||object;
+begin
+  select
+      into status, content
+           result.status::int, result.content::varchar
+      FROM extensions.http((
+    'DELETE',
+    url,
+    ARRAY[extensions.http_header('authorization','Bearer '||service_role_key)],
+    NULL,
+    NULL)::extensions.http_request) as result;
+end;
+$$;
+
+create or replace function delete_avatar(avatar_url text, out status int, out content varchar)
+returns record
+language 'plpgsql'
+security definer
+as $$
+begin
+  select
+      into status, content
+           result.status, result.content
+      from public.delete_storage_object('avatars', avatar_url) as result;
+end;
+$$;
+
+```
+
+The next step is to add a trigger that removes any obsolete avatar whenever the
+profile is updated or deleted:
+
+```SQL
+create or replace function delete_old_avatar()
+returns trigger
+language 'plpgsql'
+security definer
+as $$
+declare
+  status int;
+  content varchar;
+begin
+  if coalesce(old.avatar_url, '') <> ''
+      and (tg_op = 'DELETE' or (old.avatar_url <> new.avatar_url)) then
+    select
+      into status, content
+      result.status, result.content
+      from public.delete_avatar(old.avatar_url) as result;
+    if status <> 200 then
+      raise warning 'Could not delete avatar: % %', status, content;
+    end if;
+  end if;
+  if tg_op = 'DELETE' then
+    return old;
+  end if;
+  return new;
+end;
+$$;
+
+create trigger before_profile_changes
+  before update of avatar_url or delete on public.profiles
+  for each row execute function public.delete_old_avatar();
+
+```
+
+The final step is to delete the `public.profile` row ahead of time when a user
+is deleted. If this step is omitted, you won't be able to delete users without
+first manually deleting the avatar image owned by them.
+
+```SQL
+create or replace function delete_old_profile()
+returns trigger
+language 'plpgsql'
+security definer
+as $$
+begin
+  delete from public.profiles where id = old.id;
+  return old;
+end;
+$$;
+
+create trigger before_delete_user
+  before delete on auth.users
+  for each row execute function public.delete_old_profile();
+
+```

--- a/apps/docs/components/index.tsx
+++ b/apps/docs/components/index.tsx
@@ -20,6 +20,7 @@ import QuickstartIntro from './MDX/quickstart_intro.mdx'
 import ProjectSetup from './MDX/project_setup.mdx'
 import SocialProviderSetup from './MDX/social_provider_setup.mdx'
 import SocialProviderSettingsSupabase from './MDX/social_provider_settings_supabase.mdx'
+import StorageManagement from './MDX/storage_management.mdx'
 import { Mermaid } from 'mdx-mermaid/lib/Mermaid'
 import InlineCodeTag from './CustomHTMLElements/InlineCode'
 import React from 'react'
@@ -49,6 +50,7 @@ const components = {
   ProjectSetup,
   SocialProviderSetup,
   SocialProviderSettingsSupabase,
+  StorageManagement,
   Mermaid,
   Extensions,
   Alert: (props: any) => (

--- a/apps/docs/pages/guides/getting-started/tutorials/with-angular.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-angular.mdx
@@ -530,6 +530,10 @@ export class AccountComponent implements OnInit {
 }
 ```
 
+### Storage management
+
+<StorageManagement />
+
 ## Next steps
 
 At this stage you have a fully functional application!

--- a/apps/docs/pages/guides/getting-started/tutorials/with-expo.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-expo.mdx
@@ -500,6 +500,10 @@ Now you will need to run the prebuild command to get the application working on 
 expo prebuild
 ```
 
+### Storage management
+
+<StorageManagement />
+
 ## Next steps
 
 At this stage you have a fully functional application!

--- a/apps/docs/pages/guides/getting-started/tutorials/with-flutter.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-flutter.mdx
@@ -793,6 +793,10 @@ class _AccountPageState extends State<AccountPage> {
 }
 ```
 
+### Storage management
+
+<StorageManagement />
+
 Congratulations, that is it! You have now built a fully functional user management app using Flutter and Supabase!
 
 ## See also

--- a/apps/docs/pages/guides/getting-started/tutorials/with-ionic-angular.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-ionic-angular.mdx
@@ -522,6 +522,10 @@ template: `
 `
 ```
 
+### Storage management
+
+<StorageManagement />
+
 ## Next steps
 
 At this stage you have a fully functional application!

--- a/apps/docs/pages/guides/getting-started/tutorials/with-ionic-react.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-ionic-react.mdx
@@ -495,6 +495,10 @@ return (
       <Avatar url={profile.avatar_url} onUpload={updateProfile}></Avatar>
 ```
 
+### Storage management
+
+<StorageManagement />
+
 ## Next steps
 
 At this stage you have a fully functional application!

--- a/apps/docs/pages/guides/getting-started/tutorials/with-ionic-vue.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-ionic-vue.mdx
@@ -555,6 +555,10 @@ export default defineComponent({
 </script>
 ```
 
+### Storage management
+
+<StorageManagement />
+
 ## Next steps
 
 At this stage you have a fully functional application!

--- a/apps/docs/pages/guides/getting-started/tutorials/with-nextjs.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-nextjs.mdx
@@ -718,6 +718,10 @@ return (
 )
 ```
 
+### Storage management
+
+<StorageManagement />
+
 ## Next steps
 
 At this stage you have a fully functional application!

--- a/apps/docs/pages/guides/getting-started/tutorials/with-nuxt-3.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-nuxt-3.mdx
@@ -420,6 +420,10 @@ And then we can add the widget to the Account page:
 
 That is it! You should now be able to upload a profile photo to Supabase Storage.
 
+### Storage management
+
+<StorageManagement />
+
 ## Next steps
 
 At this stage you have a fully functional application!

--- a/apps/docs/pages/guides/getting-started/tutorials/with-react.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-react.mdx
@@ -397,6 +397,10 @@ return (
 )
 ```
 
+### Storage management
+
+<StorageManagement />
+
 ## Next steps
 
 At this stage you have a fully functional application!

--- a/apps/docs/pages/guides/getting-started/tutorials/with-redwoodjs.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-redwoodjs.mdx
@@ -771,6 +771,10 @@ return (
 )
 ```
 
+### Storage management
+
+<StorageManagement />
+
 ## Next steps
 
 At this stage you have a fully functional application!

--- a/apps/docs/pages/guides/getting-started/tutorials/with-solidjs.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-solidjs.mdx
@@ -415,6 +415,10 @@ return (
 )
 ```
 
+### Storage management
+
+<StorageManagement />
+
 ## Next steps
 
 At this stage you have a fully functional application!

--- a/apps/docs/pages/guides/getting-started/tutorials/with-svelte.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-svelte.mdx
@@ -368,6 +368,10 @@ And then we can add the widget to the Account page:
 </form>
 ```
 
+### Storage management
+
+<StorageManagement />
+
 ## Next steps
 
 At this stage you have a fully functional application!

--- a/apps/docs/pages/guides/getting-started/tutorials/with-sveltekit.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-sveltekit.mdx
@@ -434,6 +434,10 @@ And then we can add the widget to the Account page:
 </form>
 ```
 
+### Storage management
+
+<StorageManagement />
+
 ## Next steps
 
 At this stage you have a fully functional application!

--- a/apps/docs/pages/guides/getting-started/tutorials/with-vue-3.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-vue-3.mdx
@@ -379,6 +379,10 @@ And then we can add the widget to the Account page:
 </template>
 ```
 
+### Storage management
+
+<StorageManagement />
+
 ## Next steps
 
 At this stage you have a fully functional application!


### PR DESCRIPTION
This section fixes the quick-start project such that uploaded avatar images are not leaked and are cleaned up on user deletion, too.

For newbie such as me, such information would have been super helpful to get kicked off with consistent database/storage management.

## What kind of change does this PR introduce?

Docs extension

## What is the current behavior?

Docs donot mention problem and solution of leaking storage objects and inability to delete users with storage objects.

## What is the new behavior?

Docs give newbies an idea of how to deal consistently with storage objects referenced in the database.

## Additional context

Of course, this section pertains to all the quickstart guides. So, please feel free to move the content to a more suitable place, maybe even the SQL code to the "User Management Starter" SQL template.
