### PR TITLE
feat: show tables using realtime

### DIFF
--- a/studio/components/interfaces/Database/Tables/TableList.tsx
+++ b/studio/components/interfaces/Database/Tables/TableList.tsx
@@ -10,6 +10,7 @@ import {
   IconColumns,
   Listbox,
   IconLock,
+  IconCheck,
 } from 'ui'
 
 import { partition } from 'lodash'
@@ -54,6 +55,10 @@ const TableList: FC<Props> = ({
       : // @ts-ignore
         allTables.filter((table: PostgresTable) => table.name.includes(filterString))
 
+  const publications = meta.publications.list()
+  const realtimePublication = publications.find(
+    (publication) => publication.name === 'supabase_realtime'
+  )
   // @ts-ignore
   const schema = schemas.find((schema) => schema.name === selectedSchema)
   const isLocked = protectedSchemas.some((s) => s.id === schema?.id)
@@ -137,6 +142,9 @@ const TableList: FC<Props> = ({
               <Table.th key="size" className="hidden xl:table-cell">
                 Size (Estimated)
               </Table.th>,
+              <Table.th key="realtime" className="hidden xl:table-cell text-center">
+                Realtime Enabled
+              </Table.th>,
               <Table.th key="buttons"></Table.th>,
             ]}
             body={tables.map((x: any, i: any) => (
@@ -156,6 +164,13 @@ const TableList: FC<Props> = ({
                 </Table.td>
                 <Table.td className="hidden xl:table-cell">
                   <code className="text-sm">{x.size}</code>
+                </Table.td>
+                <Table.td className="hidden xl:table-cell text-center">
+                  {realtimePublication.tables.find((table: any) => table.id === x.id) && (
+                    <div className="flex justify-center">
+                      <IconCheck strokeWidth={2} />
+                    </div>
+                  )}
                 </Table.td>
                 <Table.td>
                   <div className="flex justify-end gap-2">


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase Studio > Database > Tables

## What is the current behavior?

The table currently does not show a table has realtime enabled

## What is the new behavior?

Added in a column to show if a table has realtime enabled:

<img width="1117" alt="Screenshot 2023-01-13 at 17 19 30" src="https://user-images.githubusercontent.com/22655069/212380667-a9f4c06a-d040-4fd8-9dbe-92972f3f1b41.png">


## Additional context

Closes #11647 
