### PR TITLE
Change farsi README page direction to rtl

### DIFF
--- a/i18n/README.fa.md
+++ b/i18n/README.fa.md
@@ -1,3 +1,5 @@
+<div style="direction: rtl;" dir="rtl">
+
 <p align="center">
 <img width="300" src="https://raw.githubusercontent.com/supabase/supabase/master/apps/www/public/images/supabase-logo-wordmark--light.svg?sanitize=true#gh-light-mode-only">
 <img width="300" src="https://raw.githubusercontent.com/supabase/supabase/master/apps/www/public/images/supabase-logo-wordmark--dark.svg?sanitize=true#gh-dark-mode-only">
@@ -87,3 +89,5 @@
 [![New Sponsor](https://user-images.githubusercontent.com/10214025/90518111-e74bbb00-e198-11ea-8f88-c9e3c1aa4b5b.png)](https://github.com/sponsors/supabase)
 
 </p>
+
+</div>


### PR DESCRIPTION
Fix RTL in Farsi README

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

for changing page direction to Right to Left was added this line
<div style="direction: rtl;" dir="rtl">


## What is the new behavior?

it helps text reading easiness for farsi native.

## Additional context

Add any other context or screenshots.
