### PR TITLE
fix: set Realtime Docker DB_USER to supabase_admin

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -114,7 +114,7 @@ services:
       PORT: 4000
       DB_HOST: ${POSTGRES_HOST}
       DB_PORT: ${POSTGRES_PORT}
-      DB_USER: ${POSTGRES_USER}
+      DB_USER: supabase_admin
       DB_PASSWORD: ${POSTGRES_PASSWORD}
       DB_NAME: ${POSTGRES_DB}
       DB_AFTER_CONNECT_QUERY: 'SET search_path TO _realtime'


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Permissions issue b/c Realtime requires super user privileges but the server is connecting to database as `postgres` role without the proper permissions.

## What is the new behavior?

Realtime connects to the database as `supabase_admin` role and Realtime works without issue.

## Additional context

Issue: https://github.com/supabase/realtime/issues/432
