### PR TITLE
Update Managing Environment Docs - Use latest cli version for Github Action

### DIFF
--- a/apps/docs/pages/guides/resources/supabase-cli/managing-environments.mdx
+++ b/apps/docs/pages/guides/resources/supabase-cli/managing-environments.mdx
@@ -215,8 +215,6 @@ jobs:
       - uses: actions/checkout@v3
 
       - uses: supabase/setup-cli@v1
-        with:
-          version: 1.0.0
 
       - name: Start Supabase local development setup
         run: supabase start
@@ -256,8 +254,6 @@ jobs:
       - uses: actions/checkout@v3
 
       - uses: supabase/setup-cli@v1
-        with:
-          version: 1.0.0
 
       - run: |
           supabase link --project-ref $STAGING_PROJECT_ID
@@ -289,8 +285,6 @@ jobs:
       - uses: actions/checkout@v3
 
       - uses: supabase/setup-cli@v1
-        with:
-          version: 1.0.0
 
       - run: |
           supabase link --project-ref $PRODUCTION_PROJECT_ID


### PR DESCRIPTION
The Supabase Github Action used in the workflows was set to use an outdated version of the supabase cli which causes issues when running the workflow.

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The docs currently tell you to set the Supabase cli used with the Supabase Github Action as v1.0.0. This is outdated and causes issues when trying to run.

## What is the new behavior?

By removing the hardcoded version, it'll use the latest Supabase cli version.

## Additional context

Add any other context or screenshots.
