### PR TITLE
add warn severity filter

### DIFF
--- a/studio/components/interfaces/Settings/Logs/Logs.constants.ts
+++ b/studio/components/interfaces/Settings/Logs/Logs.constants.ts
@@ -250,6 +250,7 @@ export const SQL_FILTER_TEMPLATES: any = {
     'severity.log': `metadata.level = 'log'`,
     'severity.info': `metadata.level = 'info'`,
     'severity.debug': `metadata.level = 'debug'`,
+    'severity.warn': `metadata.level = 'warn'`,
   },
   auth_logs: {
     ..._SQL_FILTER_COMMON,
@@ -473,22 +474,27 @@ export const FILTER_OPTIONS: FilterTableSet = {
         {
           key: 'error',
           label: 'Error',
-          description: 'Show all events that have error severity',
+          description: 'Show all events that are "error" severity',
+        },
+        {
+          key: 'warn',
+          label: 'Warning',
+          description: 'Show all events that are "warn" severity',
         },
         {
           key: 'info',
           label: 'Info',
-          description: 'Show all events that have error severity',
+          description: 'Show all events that are "info" severity',
         },
         {
           key: 'debug',
           label: 'Debug',
-          description: 'Show all events that have error severity',
+          description: 'Show all events that are "debug" severity',
         },
         {
           key: 'log',
           label: 'Log',
-          description: 'Show all events that are log severity',
+          description: 'Show all events that are "log" severity',
         },
       ],
     },


### PR DESCRIPTION
## What kind of change does this PR introduce?
fix/feature
allows user to also filter function logs for "warn" severity ie:`console.warn()`

## What is the current behavior?
currently missing the option to show only warnings:
<img width="620" alt="Screenshot 2023-01-14 at 9 15 11 PM" src="https://user-images.githubusercontent.com/2755958/212519578-bcd08e32-f880-472f-91cc-1d9f699deb69.png">

## What is the new behavior?

adds the warn filter into the constants (which i believe [controls the filters component](https://github.com/supabase/supabase/blob/78a426621bef5c7f2cd7accfcb4e04552815d1bd/studio/components/interfaces/Settings/Logs/PreviewFilterPanel.tsx#L148))