### PR TITLE
fix: link typo

### DIFF
--- a/apps/www/pages/realtime/Realtime.tsx
+++ b/apps/www/pages/realtime/Realtime.tsx
@@ -238,7 +238,7 @@ function RealtimePage() {
               </p>,
             ]}
             // [TODO] Point to the correct docs URL
-            documentation_link={'/docs/guides//docs/guides/realtime/broadcast'}
+            documentation_link={'/docs/guides/realtime/broadcast'}
           />
         </SectionContainer>
 

--- a/apps/www/pages/realtime/Realtime.tsx
+++ b/apps/www/pages/realtime/Realtime.tsx
@@ -238,7 +238,7 @@ function RealtimePage() {
               </p>,
             ]}
             // [TODO] Point to the correct docs URL
-            documentation_link={'/docs/guides/realtime/broadcast'}
+            documentation_link={'/docs/guides/realtime#broadcast'}
           />
         </SectionContainer>
 


### PR DESCRIPTION
Spotted a malformed link to the realtime docs which this PR fixes 🙂 

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
