### PR TITLE
fix: docs - order by example

### DIFF
--- a/spec/supabase_js_v2.yml
+++ b/spec/supabase_js_v2.yml
@@ -3429,8 +3429,8 @@ functions:
         code: |
           ```ts
           const { data, error } = await supabase
-            .from('cities')
-            .select('name', 'country_id')
+            .from('countries')
+            .select('id', 'name')
             .order('id', { ascending: false })
           ```
         data:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase Docs - [Order the query](https://supabase.com/docs/reference/javascript/order)

## What is the current behavior?

The SQL example does not match with the `Data Response` and `Response`:

<img width="512" alt="Screenshot 2023-01-16 at 09 43 54" src="https://user-images.githubusercontent.com/22655069/212648115-6e467ded-29b8-4955-9829-43f480f3f43d.png">


## What is the new behavior?

Example changed to use `countries`:

<img width="512" alt="Screenshot 2023-01-16 at 09 45 24" src="https://user-images.githubusercontent.com/22655069/212648199-b9411c03-fbce-4130-843e-f9e65312d8c2.png">


## Additional context

Add any other context or screenshots.

Closes #11671
