### PR TITLE
Move LW6 link from menu to footer #11641

### DIFF
--- a/apps/www/components/Nav/index.tsx
+++ b/apps/www/components/Nav/index.tsx
@@ -234,19 +234,6 @@ const Nav = () => {
                       Blog
                     </a>
                   </Link>
-                  <div className="xl:block hidden">
-                    <Link href="/launch-week">
-                      <a
-                        className={`
-                        text-brand-900 hover:text-brand-900 hover:border-brand-1000 dark:text-dark-100 dark:hover:border-dark-100 inline-flex items-center
-                        border-b-2 border-transparent p-5 px-1
-                        text-sm font-medium
-                      `}
-                      >
-                        Launch Week 6
-                      </a>
-                    </Link>
-                  </div>
                 </div>
               </div>
               <div className="flex items-center gap-2">
@@ -374,14 +361,6 @@ const Nav = () => {
                       className="text-scale-900 dark:hover:bg-scale-600 block rounded-md py-2 pl-3 pr-4 text-base font-medium hover:border-gray-300 hover:bg-gray-50 dark:text-white"
                     >
                       Blog
-                    </a>
-                  </Link>
-                  <Link href="/launch-week">
-                    <a
-                      target="_blank"
-                      className="text-scale-900 dark:hover:bg-scale-600 block rounded-md py-2 pl-3 pr-4 text-base font-medium hover:border-gray-300 hover:bg-gray-50 dark:text-white"
-                    >
-                      Launch Week 6
                     </a>
                   </Link>
                 </div>

--- a/apps/www/data/Footer.json
+++ b/apps/www/data/Footer.json
@@ -27,8 +27,8 @@
         "url": "/pricing"
       },
       {
-        "text": "Beta",
-        "url": "/beta"
+        "text": "Launch Week 6",
+        "url": "/launch-week"
       }
     ]
   },


### PR DESCRIPTION
## What kind of change does this PR introduce?

This pull request solves issue for moving LW6 link from menu to footer. And the beta link is removed from footer. And solves issue for #11641 .

### Screenshot
![superbase1](https://user-images.githubusercontent.com/87536360/212710621-d2a10d88-fd82-4bea-b313-2ecc7a53183a.png)

