### PR TITLE
chore: add tooltips for pricing metrics

### DIFF
--- a/apps/www/components/PricingTableRow.tsx
+++ b/apps/www/components/PricingTableRow.tsx
@@ -77,7 +77,7 @@ export const PricingTableRowDesktop = (props: any) => {
               <span>{feat.title}</span>
               {feat.tooltip && (
                 <span
-                  className="text-scale-900 hover:text-scale-1200 ml-2 cursor-pointer transition-color"
+                  className="text-scale-900 hover:text-scale-1200 ml-2 cursor-pointer transition-colors"
                   data-tip={feat.tooltip}
                 >
                   <IconHelpCircle size={14} strokeWidth={2} />

--- a/apps/www/components/PricingTableRow.tsx
+++ b/apps/www/components/PricingTableRow.tsx
@@ -77,7 +77,7 @@ export const PricingTableRowDesktop = (props: any) => {
               <span>{feat.title}</span>
               {feat.tooltip && (
                 <span
-                  className="text-scale-900 hover:text-scale-1200 ml-2 cursor-pointer transition-colors"
+                  className="text-scale-900 hover:text-scale-1200 ml-2 cursor-pointer transition-color"
                   data-tip={feat.tooltip}
                 >
                   <IconHelpCircle size={14} strokeWidth={2} />

--- a/apps/www/data/Pricing.json
+++ b/apps/www/data/Pricing.json
@@ -22,6 +22,7 @@
       },
       {
         "title": "Database space",
+        "tooltip": "Billing is based on the average database size in GB throughout the billing period.",
         "tiers": {
           "free": "Up to 500 MB",
           "pro": "8 GB included, then $0.125 per GB",
@@ -56,7 +57,7 @@
       },
       {
         "title": "Database egress",
-        "tooltip": "Good news, only download operations are counted towards the limit",
+        "tooltip": "Billing is based on the total sum of outgoing traffic of your database in GB throughout your billing period.",
         "tiers": {
           "free": "Up to 2GB",
           "pro": "50GB included per month, then $0.09 per GB",
@@ -80,7 +81,7 @@
       },
       {
         "title": "MAUs",
-        "tooltip": "Monthly Active Users; a user that has made an API request in the last month.",
+        "tooltip": "Distinct users requesting your API throughout the billing period.",
         "tiers": {
           "free": "Up to 50,000 MAUs",
           "pro": "100,000 included, then $0.00325 per MAU",
@@ -160,6 +161,7 @@
     "features": [
       {
         "title": "Storage",
+        "tooltip": "The sum of all objects' size in your storage buckets.",
         "tiers": {
           "free": "Up to 1 GB",
           "pro": "100 GB included, then $0.021 per GB",
@@ -168,7 +170,7 @@
       },
       {
         "title": "Storage egress",
-        "tooltip": "Good news, only download operations are counted towards the limit",
+        "tooltip": "Total sum of outgoing traffic (egress) from your storage buckets, only download operations are counted.",
         "tiers": {
           "free": "Up to 2 GB",
           "pro": "200 GB included, then $0.09 per GB",
@@ -194,7 +196,7 @@
       },
       {
         "title": "Asset transformations",
-        "tooltip": "Origin images are only relevant for image transformations. Images in the bucket which are not transformed do not count towards this limit.",
+        "tooltip": "Distinct count of all images that were transformed in the billing period, ignoring any transformations.",
         "tiers": {
           "free": false,
           "pro": "Unlimited transformations for 100 origin images, then 5$ per 1000 origin images",
@@ -209,6 +211,7 @@
     "features": [
       {
         "title": "Invocations",
+        "tooltip": "Billing is based on the sum of all invocations, independent of response status, throughout your billing period.",
         "tiers": {
           "free": "500K per month",
           "pro": "2 Million per month, then $2 per 1 million invocations",
@@ -225,6 +228,7 @@
       },
       {
         "title": "Number of functions",
+        "tooltip": "Billing is based on the maximum amount of functions at any point in time throughout your billing period.",
         "tiers": {
           "free": "10",
           "pro": "100, then $10 per additional 100 functions",

--- a/studio/components/interfaces/Billing/Billing.constants.tsx
+++ b/studio/components/interfaces/Billing/Billing.constants.tsx
@@ -28,6 +28,12 @@ export const USAGE_BASED_PRODUCTS = [
         title: 'Database space',
         units: 'bytes',
         costPerUnit: 0.125,
+        tooltip: (
+          <span>
+            We continuously monitor the total size of your database. Billing is based on the average
+            database size in GB throughout the billing period.
+          </span>
+        ),
       },
       {
         key: 'db_egress',
@@ -35,6 +41,12 @@ export const USAGE_BASED_PRODUCTS = [
         title: 'Database egress',
         units: 'bytes',
         costPerUnit: 0.09,
+        tooltip: (
+          <span>
+            Database egress contains any outgoing traffic (egress) from your database. Billing is
+            based on the total sum of egress in GB throughout your billing period.
+          </span>
+        ),
       },
     ],
   },
@@ -48,6 +60,12 @@ export const USAGE_BASED_PRODUCTS = [
         title: 'Monthly Active Users',
         units: 'absolute',
         costPerUnit: 0.00325,
+        tooltip: (
+          <span>
+            The amount of distinct users requesting your API throughout the billing period. Resets
+            at the beginning of every billing period.
+          </span>
+        ),
       },
     ],
   },
@@ -61,6 +79,12 @@ export const USAGE_BASED_PRODUCTS = [
         title: 'Storage space',
         units: 'bytes',
         costPerUnit: 0.021,
+        tooltip: (
+          <span>
+            The storage size is the sum of all objects in your storage buckets. Billing is based on
+            the average size in GB throughout your billing period.
+          </span>
+        ),
       },
       {
         key: 'storage_egress',
@@ -68,6 +92,14 @@ export const USAGE_BASED_PRODUCTS = [
         title: 'Storage egress',
         units: 'bytes',
         costPerUnit: 0.09,
+        tooltip: (
+          <span>
+            Storage egress contains any outgoing traffic (egress) from your storage buckets, only
+            download operations are counted. We currently do not differentiate between no-cache and
+            cache hits. Billing is based on the total amount of egress in GB throughout your billing
+            period.
+          </span>
+        ),
       },
       {
         key: 'storage_image_render_count',
@@ -75,6 +107,14 @@ export const USAGE_BASED_PRODUCTS = [
         title: 'Storage Images Transformed',
         units: 'absolute',
         costPerUnit: 0.005,
+        tooltip: (
+          <span>
+            We distinctly count all images that were transformed in the billing period, ignoring any
+            transformations. If you transform one image with different transformations (i.e. once
+            with height=50 and once with height=150), it only counts as one. We only count the
+            unique (origin) images being transformed.
+          </span>
+        ),
       },
     ],
   },
@@ -88,6 +128,12 @@ export const USAGE_BASED_PRODUCTS = [
         title: 'Function Count',
         units: 'absolute',
         costPerUnit: 0.1,
+        tooltip: (
+          <span>
+            Every single serverless function invocation independent of response status is counted.
+            Billing is based on the sum of all invocations throughout your billing period.
+          </span>
+        ),
       },
 
       {
@@ -96,6 +142,13 @@ export const USAGE_BASED_PRODUCTS = [
         title: 'Function Invocations',
         units: 'absolute',
         costPerUnit: 0.000002,
+        tooltip: (
+          <span>
+            We continuously monitor the amount of serverless functions in your project. Billing is
+            based on the maximum amount of functions at any point in time throughout your billing
+            period.
+          </span>
+        ),
       },
     ],
   },

--- a/studio/components/interfaces/Settings/ProjectUsageBars/ProjectUsageBars.tsx
+++ b/studio/components/interfaces/Settings/ProjectUsageBars/ProjectUsageBars.tsx
@@ -1,5 +1,5 @@
 import { FC, useEffect } from 'react'
-import { Badge, Button, IconAlertCircle, Loading } from 'ui'
+import { Badge, Button, IconAlertCircle, IconInfo, Loading } from 'ui'
 
 import { useStore, useProjectUsage } from 'hooks'
 import { formatBytes } from 'lib/helpers'
@@ -9,6 +9,7 @@ import ShimmeringLoader from 'components/ui/ShimmeringLoader'
 import InformationBox from 'components/ui/InformationBox'
 import { USAGE_BASED_PRODUCTS } from 'components/interfaces/Billing/Billing.constants'
 import { useRouter } from 'next/router'
+import * as Tooltip from '@radix-ui/react-tooltip'
 
 interface Props {
   projectRef?: string
@@ -176,6 +177,27 @@ const ProjectUsage: FC<Props> = ({ projectRef }) => {
                           >
                             <td className="whitespace-nowrap px-6 py-3 text-sm text-scale-1200">
                               {feature.title}
+                              {feature.tooltip && (
+                                <Tooltip.Root delayDuration={0}>
+                                  <Tooltip.Trigger>
+                                    <IconInfo className="ml-2" size={14} strokeWidth={2} />
+                                  </Tooltip.Trigger>
+                                  <Tooltip.Content side="top">
+                                    <Tooltip.Arrow className="radix-tooltip-arrow" />
+                                    <div
+                                      className={[
+                                        'max-w-md', // size
+                                        'rounded bg-scale-100 py-1 px-2 leading-none shadow', // background
+                                        'border border-scale-200 ', //border
+                                      ].join(' ')}
+                                    >
+                                      <span className="text-xs text-scale-1200">
+                                        {feature.tooltip}
+                                      </span>
+                                    </div>
+                                  </Tooltip.Content>
+                                </Tooltip.Root>
+                              )}
                             </td>
                             {ui.selectedProject?.subscription_tier !== undefined && (
                               <>

--- a/studio/components/interfaces/Settings/ProjectUsageBars/ProjectUsageBars.tsx
+++ b/studio/components/interfaces/Settings/ProjectUsageBars/ProjectUsageBars.tsx
@@ -182,16 +182,17 @@ const ProjectUsage: FC<Props> = ({ projectRef }) => {
                                   <Tooltip.Trigger>
                                     <IconInfo className="ml-2" size={14} strokeWidth={2} />
                                   </Tooltip.Trigger>
-                                  <Tooltip.Content side="top">
+                                  <Tooltip.Content side="bottom">
                                     <Tooltip.Arrow className="radix-tooltip-arrow" />
                                     <div
                                       className={[
                                         'max-w-md', // size
+                                        'flex items-center justify-center',
                                         'rounded bg-scale-100 py-1 px-2 leading-none shadow', // background
-                                        'border border-scale-200 ', //border
+                                        'border border-scale-200', //border
                                       ].join(' ')}
                                     >
-                                      <span className="text-xs text-scale-1200">
+                                      <span className="text-xs text-center text-scale-1200">
                                         {feature.tooltip}
                                       </span>
                                     </div>


### PR DESCRIPTION
Adds a couple of tooltips to help understand the billing metrics. 

Eventually, I want to add a full page that explains it more thoroughly with examples (possibly a pricing calculator, ...). However, this is out of scope for now, as we will also soon work on changing the entire usage page.