### PR TITLE
feat: allow self-serve subscription changes for team tier

### DIFF
--- a/studio/components/interfaces/Billing/PlanSelection/Plans/PlanCard.tsx
+++ b/studio/components/interfaces/Billing/PlanSelection/Plans/PlanCard.tsx
@@ -1,4 +1,4 @@
-import { STRIPE_PRODUCT_IDS } from 'lib/constants'
+import { PRICING_TIER_PRODUCT_IDS, STRIPE_PRODUCT_IDS } from 'lib/constants'
 import { FC } from 'react'
 import { IconCheck } from 'ui'
 
@@ -13,7 +13,8 @@ interface Props {
 }
 
 const PlanCard: FC<Props> = ({ plan, currentPlan, onSelectPlan }) => {
-  const teamTierEnabled = useFlag('teamTier')
+  // Team tier is enabled when the flag is turned on OR the user is already on the team tier (manually assigned by us)
+  const teamTierEnabled = currentPlan?.supabase_prod_id === PRICING_TIER_PRODUCT_IDS.TEAM || useFlag('teamTier')
 
   const planMeta = PRICING_META[plan.id]
   const isEnterprise = plan.id === 'Enterprise'

--- a/studio/components/interfaces/Billing/TeamUpgrade.tsx
+++ b/studio/components/interfaces/Billing/TeamUpgrade.tsx
@@ -48,7 +48,11 @@ const TeamUpgrade: FC<Props> = ({
 }) => {
   const { app, ui } = useStore()
   const router = useRouter()
-  const teamTierEnabled = useFlag('teamTier')
+
+  // Team tier is enabled when the flag is turned on OR the user is already on the team tier (manually assigned by us)
+  const userIsOnTeamTier =
+    currentSubscription?.tier?.supabase_prod_id === PRICING_TIER_PRODUCT_IDS.TEAM
+  const teamTierEnabled = userIsOnTeamTier || useFlag('teamTier')
 
   const [captchaToken, setCaptchaToken] = useState<string | null>(null)
   const captchaRef = useRef<HCaptcha>(null)
@@ -158,11 +162,6 @@ const TeamUpgrade: FC<Props> = ({
     setIsSubmitting(false)
     return true
   }
-
-  // Team tier is enabled when the flag is turned on OR the user is already on the team tier (manually assigned by us)
-  const userIsOnTeamTier =
-    currentSubscription?.tier?.supabase_prod_id === PRICING_TIER_PRODUCT_IDS.TEAM
-  const teamTierEnabled = userIsOnTeamTier || useFlag('teamTier')
 
   const onConfirmPayment = async () => {
     if (!teamTierEnabled) {

--- a/studio/components/interfaces/Billing/TeamUpgrade.tsx
+++ b/studio/components/interfaces/Billing/TeamUpgrade.tsx
@@ -4,7 +4,7 @@ import { useRouter } from 'next/router'
 
 import { useStore, useFlag } from 'hooks'
 import { post, patch } from 'lib/common/fetch'
-import { API_URL, PROJECT_STATUS } from 'lib/constants'
+import { API_URL, PRICING_TIER_PRODUCT_IDS, PROJECT_STATUS } from 'lib/constants'
 import { getURL } from 'lib/helpers'
 import Divider from 'components/ui/Divider'
 import {
@@ -158,6 +158,11 @@ const TeamUpgrade: FC<Props> = ({
     setIsSubmitting(false)
     return true
   }
+
+  // Team tier is enabled when the flag is turned on OR the user is already on the team tier (manually assigned by us)
+  const userIsOnTeamTier =
+    currentSubscription?.tier?.supabase_prod_id === PRICING_TIER_PRODUCT_IDS.TEAM
+  const teamTierEnabled = userIsOnTeamTier || useFlag('teamTier')
 
   const onConfirmPayment = async () => {
     if (!teamTierEnabled) {

--- a/studio/pages/project/[ref]/settings/billing/update/index.tsx
+++ b/studio/pages/project/[ref]/settings/billing/update/index.tsx
@@ -111,7 +111,9 @@ const BillingUpdate: NextPageWithLayout = () => {
     )
   }
 
-  const teamTierEnabled = useFlag('teamTier')
+  // Team tier is enabled when the flag is turned on OR the user is already on the team tier (manually assigned by us)
+  const userIsOnTeamTier = subscription?.tier?.supabase_prod_id === PRICING_TIER_PRODUCT_IDS.TEAM
+  const teamTierEnabled = userIsOnTeamTier || useFlag('teamTier')
 
   const productTiers = (products?.tiers ?? []).filter(
     (tier) => teamTierEnabled || tier.id !== STRIPE_PRODUCT_IDS.TEAM


### PR DESCRIPTION
Previously, subscription changes and downgrades were only available when the feature toggle is turned on. We are holding back with self-serving the upgrade to Team tier. However, we want users that we manually put on the Team tier to be able to change their subscription, i.e. adding a custom domain, without having to reach out.
