### PR TITLE
fix: studio api docs stored procedures/functions

### DIFF
--- a/studio/components/interfaces/Docs/RpcContent.tsx
+++ b/studio/components/interfaces/Docs/RpcContent.tsx
@@ -42,6 +42,7 @@ const RpcContent = ({
 
       <div className="doc-section">
         <article className="text ">
+          <label className="font-mono text-xs uppercase text-scale-900">Description</label>
           <Description content={summary} metadata={{ rpc: rpcId }} onChange={refreshDocs} />
         </article>
         <article className="code">


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase Studio > API Docs > Stored Procedures

## What is the current behavior?

Currently the 'Click to edit' textarea does not show what you are editing, This textarea is used to edit a description

## What is the new behavior?

Added in a description label:

<img width="1124" alt="Screenshot 2023-01-18 at 13 52 04" src="https://user-images.githubusercontent.com/22655069/213188926-ba28d140-3d7b-49e8-826e-338ac0c90507.png">


## Additional context

Closes #11713 
