### PR TITLE
Fix Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@ node_modules/
 .env.production
 .env.dev
 .env.*
+.git

--- a/studio/Dockerfile
+++ b/studio/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 FROM base as builder
 WORKDIR /usr/src/app
-COPY package*.json .
+COPY package*.json ./
 COPY turbo.json .
 COPY packages packages
 COPY studio studio


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Closes #10424

## What is the new behavior?

When building with the latest Docker I get this error:

```
Step 5/23 : COPY package*.json .
When using COPY with more than one source file, the destination must be a directory and end with a /
```

The second commit resolves this issue.

Also .git directory is about `800M` and it's not needed to build images. Added in `.dockerignore`

![image](https://user-images.githubusercontent.com/25064808/213246613-e4306b40-8d0d-4c63-a8c6-845c55065ed4.png)


## Additional context

Add any other context or screenshots.
