### PR TITLE
Fix: Remove .api from reset password for email snippet

### DIFF
--- a/studio/components/to-be-cleaned/Docs/Snippets.js
+++ b/studio/components/to-be-cleaned/Docs/Snippets.js
@@ -680,7 +680,7 @@ const { data: { user } } = await supabase.auth.getUser()
     js: {
       language: 'js',
       code: `
-let { data, error } = await supabase.auth.api.resetPasswordForEmail(email)
+let { data, error } = await supabase.auth.resetPasswordForEmail(email)
 `,
     },
   }),


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix typo

## What is the current behavior?

Code snippet contains typo for `supabase.auth.api.resetPasswordForEmail`

## What is the new behavior?

Code snippet no longer contains typo - `supabase.auth.resetPasswordForEmail`

## Additional context

<img width="2320" alt="Screenshot 2023-01-19 at 12 00 14 pm" src="https://user-images.githubusercontent.com/13792200/213331007-50d1b1ad-88f1-449a-b288-2dba2601a93a.png">

