### PR TITLE
fix(pricing): aligned pricing page with current state

### DIFF
--- a/apps/www/data/Pricing.json
+++ b/apps/www/data/Pricing.json
@@ -43,7 +43,7 @@
         "tooltip": "PITR cannot be applied retroactively, projects can only be rolled back to the point from which PITR has been applied.",
         "tiers": {
           "free": false,
-          "pro": "$100 per 7 day rollback period (if > 28 days contact enterprise)",
+          "pro": "$100 per 7 day rollback period (if > 28 days, contact enterprise)",
           "enterprise": true
         }
       },

--- a/apps/www/data/Pricing.json
+++ b/apps/www/data/Pricing.json
@@ -34,15 +34,16 @@
         "tooltip": "Backups are entire copies of your database that can be restored in the future.",
         "tiers": {
           "free": false,
-          "pro": "7 days of backup* (* if > 1TB, contact enterprise)",
+          "pro": "7 days of backup (if > 1TB, contact enterprise)",
           "enterprise": "Custom"
         }
       },
       {
         "title": "Point in time recovery",
+        "tooltip": "PITR cannot be applied retroactively, projects can only be rolled back to the point from which PITR has been applied.",
         "tiers": {
           "free": false,
-          "pro": false,
+          "pro": "$100 per 7 day rollback period (if > 28 days contact enterprise)",
           "enterprise": true
         }
       },
@@ -129,14 +130,6 @@
         }
       },
       {
-        "title": "Custom SMTP",
-        "tiers": {
-          "free": true,
-          "pro": true,
-          "enterprise": true
-        }
-      },
-      {
         "title": "Supabase Auth emails",
         "tooltip": "Rate limits do not apply to Custom SMTP",
         "tiers": {
@@ -199,7 +192,7 @@
         "tooltip": "Distinct count of all images that were transformed in the billing period, ignoring any transformations.",
         "tiers": {
           "free": false,
-          "pro": "Unlimited transformations for 100 origin images, then 5$ per 1000 origin images",
+          "pro": "Unlimited transformations for 100 origin images, then $5 per 1000 origin images",
           "enterprise": "Unlimited"
         }
       }
@@ -251,6 +244,7 @@
       },
       {
         "title": "Concurrent Peak Connections",
+        "tooltip": "We only charge for successful connections - not connection attempts!",
         "tiers": {
           "free": "Up to 200",
           "pro": "Up to 500, then $10 per 1000",
@@ -384,7 +378,6 @@
       },
       {
         "title": "Custom Domains",
-        "tooltip": "Contact us to access this feature",
         "tiers": {
           "free": false,
           "pro": "$10 per domain per month per project add on",


### PR DESCRIPTION
Just a few tiny fixes to align our pricing page with our actual pricing

- Removed duplicate Custom SMTP entry
- Removed custom domain tooltip that is no longer necessary, as custom domains are now self-serve
- Added a tooltip for PITR
- Fixed a "$" sign
- Clarified realtime peak connections