### PR TITLE
feat: use proper `redirectTo` with SSO

### DIFF
--- a/studio/components/interfaces/SignIn/SignInSSOForm.tsx
+++ b/studio/components/interfaces/SignIn/SignInSSOForm.tsx
@@ -1,6 +1,6 @@
 import HCaptcha from '@hcaptcha/react-hcaptcha'
 import { useStore } from 'hooks'
-import { auth } from 'lib/gotrue'
+import { auth, getReturnToPath } from 'lib/gotrue'
 import { useRef, useState } from 'react'
 import { useSWRConfig } from 'swr'
 import { Button, Form, Input } from 'ui'
@@ -31,7 +31,14 @@ const SignInSSOForm = () => {
 
     const { data, error } = await auth.signInWithSSO({
       domain: email.split('@')[1],
-      options: { captchaToken: token ?? undefined },
+      options: {
+        captchaToken: token ?? undefined,
+        redirectTo: `${
+          process.env.NEXT_PUBLIC_VERCEL_ENV === 'preview'
+            ? process.env.NEXT_PUBLIC_VERCEL_URL
+            : process.env.NEXT_PUBLIC_SITE_URL
+        }${getReturnToPath()}`,
+      },
     })
 
     if (!error) {


### PR DESCRIPTION
Sets the correct redirect URL when using SSO, so that users end up in the correct spot.