### PR TITLE
fix: studio editor enum

### DIFF
--- a/studio/components/grid/components/editor/SelectEditor.tsx
+++ b/studio/components/grid/components/editor/SelectEditor.tsx
@@ -1,4 +1,4 @@
-import { Listbox } from '@supabase/ui'
+import { Select } from '@supabase/ui'
 import { EditorProps } from '@supabase/react-data-grid'
 
 import { useTrackedState } from 'components/grid/store'
@@ -19,11 +19,11 @@ export function SelectEditor<TRow, TSummaryRow = unknown>({
 
   const value = row[column.key as keyof TRow] as unknown as string
 
-  function onChange(value: string) {
+  function onChange(value: any) {
     if (!value || value == '') {
       onRowChange({ ...row, [column.key]: null }, true)
     } else {
-      onRowChange({ ...row, [column.key]: value }, true)
+      onRowChange({ ...row, [column.key]: value.target.value }, true)
     }
   }
 
@@ -32,7 +32,7 @@ export function SelectEditor<TRow, TSummaryRow = unknown>({
   }
 
   return (
-    <Listbox
+    <Select
       autoFocus
       id="select-editor"
       name="select-editor"
@@ -44,14 +44,12 @@ export function SelectEditor<TRow, TSummaryRow = unknown>({
       onChange={onChange}
       onBlur={onBlur}
     >
-      <Listbox.Option id="NULL" label="NULL" value="">
-        NULL
-      </Listbox.Option>
+      <Select.Option value="">NULL</Select.Option>
       {options.map(({ label, value }) => (
-        <Listbox.Option key={value} label={label} value={value}>
+        <Select.Option key={value} value={value}>
           {label}
-        </Listbox.Option>
+        </Select.Option>
       ))}
-    </Listbox>
+    </Select>
   )
 }

--- a/studio/components/grid/components/editor/SelectEditor.tsx
+++ b/studio/components/grid/components/editor/SelectEditor.tsx
@@ -19,11 +19,11 @@ export function SelectEditor<TRow, TSummaryRow = unknown>({
 
   const value = row[column.key as keyof TRow] as unknown as string
 
-  function onChange(value: any) {
-    if (!value || value == '') {
+  function onChange(event: any) {
+    if (!event || event == '') {
       onRowChange({ ...row, [column.key]: null }, true)
     } else {
-      onRowChange({ ...row, [column.key]: value.target.value }, true)
+      onRowChange({ ...row, [column.key]: event.target.value }, true)
     }
   }
 

--- a/studio/components/grid/components/editor/SelectEditor.tsx
+++ b/studio/components/grid/components/editor/SelectEditor.tsx
@@ -21,7 +21,7 @@ export function SelectEditor<TRow, TSummaryRow = unknown>({
 
   function onChange(event: any) {
     debugger
-    if (!event.target.vaue || event.target.value == '') {
+    if (!event.target.value || event.target.value == '') {
       onRowChange({ ...row, [column.key]: null }, true)
     } else {
       onRowChange({ ...row, [column.key]: event.target.value }, true)

--- a/studio/components/grid/components/editor/SelectEditor.tsx
+++ b/studio/components/grid/components/editor/SelectEditor.tsx
@@ -1,10 +1,10 @@
-import { Select } from '@supabase/ui'
+import { Select } from 'ui'
 import { EditorProps } from '@supabase/react-data-grid'
 
 import { useTrackedState } from 'components/grid/store'
 
 interface SelectEditorProps<TRow, TSummaryRow = unknown> extends EditorProps<TRow, TSummaryRow> {
-  options: { label: string; value: string }[]
+  options: { label: string; _value: string }[]
 }
 
 export function SelectEditor<TRow, TSummaryRow = unknown>({
@@ -45,8 +45,8 @@ export function SelectEditor<TRow, TSummaryRow = unknown>({
       onBlur={onBlur}
     >
       <Select.Option value="">NULL</Select.Option>
-      {options.map(({ label, value }) => (
-        <Select.Option key={value} value={value}>
+      {options.map(({ label, _value }) => (
+        <Select.Option key={_value} value={_value} selected={_value === value}>
           {label}
         </Select.Option>
       ))}

--- a/studio/components/grid/components/editor/SelectEditor.tsx
+++ b/studio/components/grid/components/editor/SelectEditor.tsx
@@ -20,7 +20,8 @@ export function SelectEditor<TRow, TSummaryRow = unknown>({
   const value = row[column.key as keyof TRow] as unknown as string
 
   function onChange(event: any) {
-    if (!event || event == '') {
+    debugger
+    if (!event.target.vaue || event.target.value == '') {
       onRowChange({ ...row, [column.key]: null }, true)
     } else {
       onRowChange({ ...row, [column.key]: event.target.value }, true)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase Studio > Table Editor > Enum Select

## What is the current behavior?

Currently the `Listbox` does not show the dropdown values in the editor

## What is the new behavior?

Changed the `Listbox` to a `Select` and the enum values now appear:


https://user-images.githubusercontent.com/22655069/213496446-c8cb9632-b2e3-403e-a10b-31d678a3fe82.mov



## Additional context

Closes #11757 
