### PR TITLE
docs: add callout against using non-pks as fk references

### DIFF
--- a/apps/docs/pages/guides/auth/managing-user-data.mdx
+++ b/apps/docs/pages/guides/auth/managing-user-data.mdx
@@ -34,6 +34,14 @@ Make sure to specify the `on delete cascade` clause when referencing `auth.users
 
 </Admonition>
 
+<Admonition type="caution">
+
+Only use primary keys as [foreign key references](https://www.postgresql.org/docs/current/tutorial-fk.html) to schemas and tables like `auth.users` which are managed by Supabase. 
+
+PostgreSQL lets you specify a foreign key reference to columns which are backed by a unique index (not necessarily primary keys). Be aware that **primary keys are guaranteed not to change.** Columns, indices, constraints or other database objects managed by Supabase **may change at any time** and you should be careful when referencing them directly.
+
+</Admonition>
+
 ## Deleting Users
 
 You may delete users directly or via the management console at Authentication > Users. Note that deleting a user from the `auth.users` table does not automatically sign out a user. As Supabase makes use of JSON Web Tokens (JWT), a user's JWT will remain "valid" until it has expired. Should you wish to immediately revoke access for a user, do considering making use of a Row Level Security policy as described below.

--- a/apps/docs/pages/guides/auth/managing-user-data.mdx
+++ b/apps/docs/pages/guides/auth/managing-user-data.mdx
@@ -12,9 +12,7 @@ Even though Supabase provides an `auth.users` table, it can be helpful to create
 
 ## Creating user tables
 
-When you create tables to store user data, it's helpful to reference the `auth.users` table in the primary key. This ensures data integrity.
-
-For example, a `public.profiles` table might look like this:
+When you create tables to store user data, it's helpful to reference the `auth.users` table in the primary key to ensure data integrity. Also specify the `on delete cascade` clause when referencing `auth.users`. Omitting it may cause problems when deleting users. For example, a `public.profiles` table might look like this:
 
 ```sql
 create table public.profiles (
@@ -28,17 +26,11 @@ create table public.profiles (
 alter table public.profiles enable row level security;
 ```
 
-<Admonition type="note">
-
-Make sure to specify the `on delete cascade` clause when referencing `auth.users`. Omitting it may cause problems when deleting users.
-
-</Admonition>
-
 <Admonition type="caution">
 
-Only use primary keys as [foreign key references](https://www.postgresql.org/docs/current/tutorial-fk.html) to schemas and tables like `auth.users` which are managed by Supabase. 
+Only use primary keys as [foreign key references](https://www.postgresql.org/docs/current/tutorial-fk.html) for schemas and tables like `auth.users` which are managed by Supabase. PostgreSQL lets you specify a foreign key reference for columns backed by a unique index (not necessarily primary keys).
 
-PostgreSQL lets you specify a foreign key reference to columns which are backed by a unique index (not necessarily primary keys). Be aware that **primary keys are guaranteed not to change.** Columns, indices, constraints or other database objects managed by Supabase **may change at any time** and you should be careful when referencing them directly.
+Primary keys are **guaranteed not to change**. Columns, indices, constraints or other database objects managed by Supabase **may change at any time** and you should be careful when referencing them directly.
 
 </Admonition>
 


### PR DESCRIPTION
Recently a pattern has started appearing where projects place foreign key references on `email` in `auth.users`, which creates problems with upgrading to the latest Supabase Auth version. Furthermore, if not careful such foreign key references can break Supabase Auth functionality in subtle ways.

For example, unless you specify `references auth(email) on update cascade` Supabase Auth would never be able to update the user's email address correctly.

In the latest version of Supabase Auth the email column no longer is backed by a total unique index, which means that it is no longer possible to accidentally make this mistake. However, there could be other unforeseen situations and thus this callout to warn users only to reference primary keys as they are guaranteed not to change.
