### PR TITLE
update confirmation template to use GoTrue's template

### DIFF
--- a/studio/pages/api/auth/[ref]/config.ts
+++ b/studio/pages/api/auth/[ref]/config.ts
@@ -114,7 +114,7 @@ const handleGetAll = async (req: NextApiRequest, res: NextApiResponse) => {
       '<h2>You have been invited</h2>\n\n<p>You have been invited to create a user on {{ .SiteURL }}. Follow this link to accept the invite:</p>\n<p><a href="{{ .ConfirmationURL }}">Accept the invite</a></p>',
     MAILER_TEMPLATES_CONFIRMATION: null,
     MAILER_TEMPLATES_CONFIRMATION_CONTENT:
-      '<h2>Confirm your signup</h2>\n\n<p>Follow this link to confirm your user:</p>\n<p><a href="{{ .ConfirmationURL }}">Confirm your mail</a></p>',
+      '<h2>Confirm your email</h2>\n\n<p>Follow this link to confirm your email:</p>\n\n<p><a href="{{ .ConfirmationURL }}">Confirm your email address</a></p>\n\n<p>Alternatively, enter the code: {{ .Token }}</p>',
     MAILER_TEMPLATES_RECOVERY: null,
     MAILER_TEMPLATES_RECOVERY_CONTENT:
       '<h2>Reset Password</h2>\n\n<p>Follow this link to reset the password for your user:</p>\n<p><a href="{{ .ConfirmationURL }}">Reset Password</a></p>',

--- a/studio/pages/api/auth/[ref]/config.ts
+++ b/studio/pages/api/auth/[ref]/config.ts
@@ -114,7 +114,7 @@ const handleGetAll = async (req: NextApiRequest, res: NextApiResponse) => {
       '<h2>You have been invited</h2>\n\n<p>You have been invited to create a user on {{ .SiteURL }}. Follow this link to accept the invite:</p>\n<p><a href="{{ .ConfirmationURL }}">Accept the invite</a></p>',
     MAILER_TEMPLATES_CONFIRMATION: null,
     MAILER_TEMPLATES_CONFIRMATION_CONTENT:
-      '<h2>Confirm your email</h2>\n\n<p>Follow this link to confirm your email:</p>\n\n<p><a href="{{ .ConfirmationURL }}">Confirm your email address</a></p>\n\n<p>Alternatively, enter the code: {{ .Token }}</p>',
+      '<h2>Confirm your email</h2>\n\n<p>Follow this link to confirm your email:</p>\n\n<p><a href="{{ .ConfirmationURL }}">Confirm your email address</a></p>',
     MAILER_TEMPLATES_RECOVERY: null,
     MAILER_TEMPLATES_RECOVERY_CONTENT:
       '<h2>Reset Password</h2>\n\n<p>Follow this link to reset the password for your user:</p>\n<p><a href="{{ .ConfirmationURL }}">Reset Password</a></p>',


### PR DESCRIPTION
## What kind of change does this PR introduce?
The default template in the dashboard says confirm mail instead of email. 

I've replaced with GoTrue's default template: https://github.com/supabase/gotrue/blob/ed08260df22811b5b78b3eb6a2af9f1f2b368de7/mailer/template.go#L48

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
