### PR TITLE
chore: add service dependency on imgproxy

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -137,6 +137,8 @@ services:
         condition: service_healthy
       rest:
         condition: service_started
+      imgproxy:
+        condition: service_started
     restart: unless-stopped
     environment:
       ANON_KEY: ${ANON_KEY}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Closes https://github.com/supabase/supabase/issues/11305

## What is the current behavior?

imgproxy may start after storage-api

## What is the new behavior?

wait for imgproxy to be up

## Additional context

Add any other context or screenshots.
