### PR TITLE
Add Healthchecks to docker-compose for self-hosting

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -106,7 +106,7 @@ services:
       db: # Disable this if you are using an external Postgres database
         condition: service_healthy
     healthcheck:
-      test: [ "CMD", "printf", "\\0", ">", "/dev/tcp/localhost/4000" ]
+      test: [ "CMD", "bash", "-c", "printf \\0 > /dev/tcp/localhost/3000" ]
       timeout: 5s
       interval: 5s
       retries: 3
@@ -125,7 +125,7 @@ services:
       db: # Disable this if you are using an external Postgres database
         condition: service_healthy
     healthcheck:
-      test: [ "CMD", "printf", "\\0", ">", "/dev/tcp/localhost/4000" ]
+      test: [ "CMD", "bash", "-c", "printf \\0 > /dev/tcp/localhost/4000" ]
       timeout: 5s
       interval: 5s
       retries: 3

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -105,11 +105,6 @@ services:
     depends_on:
       db: # Disable this if you are using an external Postgres database
         condition: service_healthy
-    healthcheck:
-      test: [ "CMD", "bash", "-c", "printf \\0 > /dev/tcp/localhost/3000" ]
-      timeout: 5s
-      interval: 5s
-      retries: 3
     restart: unless-stopped
     environment:
       PGRST_DB_URI: postgres://authenticator:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -11,6 +11,11 @@ services:
     container_name: supabase-studio
     image: supabase/studio:20221214-4eecc99
     restart: unless-stopped
+    healthcheck:
+      test: [ "CMD", "node", "-e", "require('http').get('http://localhost:3000/api/profile', (r) => {if (r.statusCode !== 200) throw new Error(r.statusCode)})" ]
+      timeout: 5s
+      interval: 5s
+      retries: 3
     ports:
       - ${STUDIO_PORT}:3000/tcp
     environment:
@@ -51,6 +56,11 @@ services:
     depends_on:
       db: # Disable this if you are using an external Postgres database
         condition: service_healthy
+    healthcheck:
+      test: [ "CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:9999/health" ]
+      timeout: 5s
+      interval: 5s
+      retries: 3
     restart: unless-stopped
     environment:
       GOTRUE_API_HOST: 0.0.0.0
@@ -95,6 +105,11 @@ services:
     depends_on:
       db: # Disable this if you are using an external Postgres database
         condition: service_healthy
+    healthcheck:
+      test: [ "CMD", "printf", "\\0", ">", "/dev/tcp/localhost/4000" ]
+      timeout: 5s
+      interval: 5s
+      retries: 3
     restart: unless-stopped
     environment:
       PGRST_DB_URI: postgres://authenticator:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
@@ -109,6 +124,11 @@ services:
     depends_on:
       db: # Disable this if you are using an external Postgres database
         condition: service_healthy
+    healthcheck:
+      test: [ "CMD", "printf", "\\0", ">", "/dev/tcp/localhost/4000" ]
+      timeout: 5s
+      interval: 5s
+      retries: 3
     restart: unless-stopped
     environment:
       PORT: 4000
@@ -139,6 +159,11 @@ services:
         condition: service_started
       imgproxy:
         condition: service_started
+    healthcheck:
+      test: [ "CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:5000/status" ]
+      timeout: 5s
+      interval: 5s
+      retries: 3
     restart: unless-stopped
     environment:
       ANON_KEY: ${ANON_KEY}
@@ -161,6 +186,11 @@ services:
   imgproxy:
     container_name: supabase-imgproxy
     image: darthsim/imgproxy:v3.11
+    healthcheck:
+      test: [ "CMD", "imgproxy", "health" ]
+      timeout: 5s
+      interval: 5s
+      retries: 3
     environment:
       IMGPROXY_BIND: ":5001"
       IMGPROXY_LOCAL_FILESYSTEM_ROOT: /


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature. Add Healthchecks also to docker-compose (copied from supabase-cli).
One day maybe docker compose will be entirely replaced by supabase-cli (why not?).
Till that day try to match supabase-cli and docker-compose

## What is the current behavior?

No issue

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
