### PR TITLE
docs(storage): use 'to' field instead of 'auth.role()' in storage access control

### DIFF
--- a/apps/docs/pages/guides/storage/access-control.mdx
+++ b/apps/docs/pages/guides/storage/access-control.mdx
@@ -117,10 +117,8 @@ using ( bucket_id = 'public' );
 -- 1. Allow logged-in access to any files in the "restricted" bucket
 create policy "Restricted Access"
 on storage.objects for select
-using (
-  bucket_id = 'restricted'
-  and auth.role() = 'authenticated'
-);
+to authenticated
+using ( bucket_id = 'restricted' );
 ```
 
 ### Allow individual access to a file


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update: update the storage access control example to use the `to` field instead of the deprecated `auth.role()`

