### PR TITLE
fix: filter out empty redirect domains

### DIFF
--- a/studio/components/interfaces/Auth/RedirectDomains/RedirectDomains.tsx
+++ b/studio/components/interfaces/Auth/RedirectDomains/RedirectDomains.tsx
@@ -14,7 +14,7 @@ const RedirectDomains = () => {
   const { authConfig, ui } = useStore()
 
   const URI_ALLOW_LIST_ARRAY = authConfig.config.URI_ALLOW_LIST
-    ? authConfig.config.URI_ALLOW_LIST.split(',')
+    ? authConfig.config.URI_ALLOW_LIST.split(/\s*[,]+\s*/).filter((url) => url)
     : []
 
   const [open, setOpen] = useState(false)
@@ -28,6 +28,10 @@ const RedirectDomains = () => {
   })
 
   const onAddNewDomain = async (values: any, { setSubmitting }: any) => {
+    if (!values.domain) {
+      return
+    }
+
     setSubmitting(true)
     const payload = URI_ALLOW_LIST_ARRAY
     payload.push(values.domain)


### PR DESCRIPTION
Empty redirect domains can't be added any more and won't be shown in the list if they exist on the server.

Fixes #11639.