### PR TITLE
feat: use `st_asgeojson` for `geometry` columns

### DIFF
--- a/studio/components/grid/query/QueryAction.ts
+++ b/studio/components/grid/query/QueryAction.ts
@@ -25,7 +25,11 @@ export class QueryAction implements IQueryAction {
    *
    * @param options.returning  If `true`, return the deleted row(s) in the response.
    */
-  delete(options?: { returning: boolean; enumArrayColumns?: string[] }) {
+  delete(options?: {
+    returning: boolean
+    enumArrayColumns?: string[]
+    geometryColumns?: string[]
+  }) {
     return new QueryFilter(this.table, 'delete', undefined, options)
   }
 
@@ -35,7 +39,10 @@ export class QueryAction implements IQueryAction {
    * @param values             The values to insert.
    * @param options.returning  If `true`, return the inserted row(s) in the response.
    */
-  insert(values: Dictionary<any>[], options?: { returning: boolean; enumArrayColumns?: string[] }) {
+  insert(
+    values: Dictionary<any>[],
+    options?: { returning: boolean; enumArrayColumns?: string[]; geometryColumns?: string[] }
+  ) {
     return new QueryFilter(this.table, 'insert', values, options)
   }
 
@@ -54,14 +61,21 @@ export class QueryAction implements IQueryAction {
    * @param value  The value to update.
    * @param options.returning  If `true`, return the updated row(s) in the response.
    */
-  update(value: Dictionary<any>, options?: { returning: boolean; enumArrayColumns?: string[] }) {
+  update(
+    value: Dictionary<any>,
+    options?: { returning: boolean; enumArrayColumns?: string[]; geometryColumns?: string[] }
+  ) {
     return new QueryFilter(this.table, 'update', value, options)
   }
 
   /**
    * Performs a TRUNCATE on the table
    */
-  truncate(options?: { returning: boolean; enumArrayColumns?: string[] }) {
+  truncate(options?: {
+    returning: boolean
+    enumArrayColumns?: string[]
+    geometryColumns?: string[]
+  }) {
     return new QueryFilter(this.table, 'truncate', undefined, options)
   }
 }

--- a/studio/components/grid/query/QueryModifier.ts
+++ b/studio/components/grid/query/QueryModifier.ts
@@ -21,7 +21,12 @@ export class QueryModifier implements IQueryModifier {
     protected action: 'count' | 'delete' | 'insert' | 'select' | 'update' | 'truncate',
     protected options?: {
       actionValue?: string | string[] | Dictionary<any> | Dictionary<any>[]
-      actionOptions?: { returning?: boolean; cascade?: boolean; enumArrayColumns?: string[] }
+      actionOptions?: {
+        returning?: boolean
+        cascade?: boolean
+        enumArrayColumns?: string[]
+        geometryColumns?: string[]
+      }
       filters?: Filter[]
       sorts?: Sort[]
     }
@@ -52,12 +57,14 @@ export class QueryModifier implements IQueryModifier {
           return deleteQuery(this.table, filters, {
             returning: actionOptions?.returning,
             enumArrayColumns: actionOptions?.enumArrayColumns,
+            geometryColumns: actionOptions?.geometryColumns,
           })
         }
         case 'insert': {
           return insertQuery(this.table, actionValue as Dictionary<any>[], {
             returning: actionOptions?.returning,
             enumArrayColumns: actionOptions?.enumArrayColumns,
+            geometryColumns: actionOptions?.geometryColumns,
           })
         }
         case 'select': {
@@ -72,6 +79,7 @@ export class QueryModifier implements IQueryModifier {
             filters,
             returning: actionOptions?.returning,
             enumArrayColumns: actionOptions?.enumArrayColumns,
+            geometryColumns: actionOptions?.geometryColumns,
           })
         }
         case 'truncate': {

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
@@ -65,10 +65,16 @@ const SidePanelEditor: FC<Props> = ({
       })
       .map((column) => column.name)
 
+    const geometryColumns = selectedTable.columns
+      .filter((column) => {
+        return column.data_type.toLowerCase() === 'geometry'
+      })
+      .map((column) => column.name)
+
     if (isNewRecord) {
       const insertQuery = new Query()
         .from(selectedTable.name, selectedTable.schema)
-        .insert([payload], { returning: true, enumArrayColumns })
+        .insert([payload], { returning: true, enumArrayColumns, geometryColumns })
         .toSql()
 
       const res: any = await meta.query(insertQuery)
@@ -84,7 +90,7 @@ const SidePanelEditor: FC<Props> = ({
         if (selectedTable.primary_keys.length > 0) {
           const updateQuery = new Query()
             .from(selectedTable.name, selectedTable.schema)
-            .update(payload, { returning: true, enumArrayColumns })
+            .update(payload, { returning: true, enumArrayColumns, geometryColumns })
             .match(configuration.identifiers)
             .toSql()
 


### PR DESCRIPTION
The table view does not format `geometry` tables with a human readable format. This change uses the [`st_asgeojson()`](https://postgis.net/docs/ST_AsGeoJSON.html) function to format `geometry` columns to JSON which is somewhat more readable.

Fixes: #3788 