### PR TITLE
chore: Use cache in integration-tests.yml

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -28,9 +28,10 @@ jobs:
           java-version: 1.8
 
       - name: Set up Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
+          cache: 'npm'
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## What kind of change does this PR introduce?

Updated `integration-tests.yml` to cache dependencies using [actions/setup-node](https://github.com/actions/setup-node#caching-global-packages-data).

**AS-IS**

```yml
- name: Set up Node
  uses: actions/setup-node@v1
  with:
    node-version: ${{ matrix.node }}
```

**TO-BE**

```yml
- name: Set up Node
  uses: actions/setup-node@v3
  with:
    node-version: ${{ matrix.node }}
    cache: 'npm'
```