### PR TITLE
Update nextjs-server-components.mdx

### DIFF
--- a/apps/docs/pages/guides/auth/auth-helpers/nextjs-server-components.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/nextjs-server-components.mdx
@@ -140,7 +140,7 @@ export async function middleware(req) {
 
 <TabPanel id="ts" label="TypeScript">
 
-Create a new `/app/middleware.js` file and populate with the following:
+Create a new `/app/middleware.ts` file and populate with the following:
 
 ```tsx title="middleware.ts"
 import { createMiddlewareSupabaseClient } from '@supabase/auth-helpers-nextjs'


### PR DESCRIPTION
middleware file name for TypeScript had `.js` extension.

## What kind of change does this PR introduce?
Doc update

## What is the current behavior?
Instructs user to create a `.js` file for TypeScript

## What is the new behavior?
Lets the user know the correct file type

