### PR TITLE
docs: add init command to cli intro

### DIFF
--- a/apps/docs/docs/ref/cli/introduction.mdx
+++ b/apps/docs/docs/ref/cli/introduction.mdx
@@ -17,7 +17,7 @@ hideTitle: true
     The Supabase CLI provides tools to develop your project locally and deploy to the Supabase Platform.
     The CLI is still under development, but it contains all the functionality for working with your Supabase projects and the Supabase Platform.
 
-    - Run Supabase locally: [`supabase start`](/docs/reference/cli/usage#supabase-start)
+    - Run Supabase locally: [`supabase init`](/docs/reference/cli/usage#supabase-init) and [`supabase start`](/docs/reference/cli/usage#supabase-start)
     - Manage database migrations: [`supabase migration`](/docs/reference/cli/usage#supabase-migration)
     - CI/CD for releasing to production: [`supabase db push`](/docs/reference/cli/usage#supabase-db-push)
     - Manage your Supabase projects: [`supabase projects`](/docs/reference/cli/usage#supabase-projects)


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to add `supabase init` command to CLI intro page, as that command should be the first command to use for the beginners.

## What is the current behavior?

Currently, the `supabase start` is the 1st command on CLI intro page, but it depends on `supabase init` command to run before it.

## What is the new behavior?

`supabase init` command should be the very first command for a beginner.

## Additional context

N/A
