### PR TITLE
docs: fix broken link in todo list example, fix #11807

### DIFF
--- a/studio/components/interfaces/SQLEditor/SQLEditor.constants.ts
+++ b/studio/components/interfaces/SQLEditor/SQLEditor.constants.ts
@@ -613,10 +613,8 @@ values
     sql: `
 --
 -- For use with:
--- https://github.com/supabase/supabase/tree/master/examples/todo-list/nextjs-todo-list or
--- https://github.com/supabase/supabase/tree/master/examples/todo-list/react-todo-list or
 -- https://github.com/supabase/supabase/tree/master/examples/todo-list/sveltejs-todo-list or
--- https://github.com/supabase/supabase/tree/master/examples/todo-list/vue3-ts-todo-list
+-- https://github.com/supabase/examples-archive/tree/main/supabase-js-v1/todo-list
 --
 
 create table todos (


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to fix broken links in todo list example's comments, as described in #11807 .

## What is the current behavior?

Some of the todo list example links are broken.

## What is the new behavior?

Those links should be correct.

## Additional context

N/A
