### PR TITLE
docs: added in redirect example

### DIFF
--- a/spec/supabase_js_v2.yml
+++ b/spec/supabase_js_v2.yml
@@ -174,9 +174,8 @@ functions:
             }
           )
           ```
-      - id: sign-up-with-redirect.
-        name: Sign up with a redirect
-        isSpotlight: false
+      - id: sign-up-with-redirect
+        name: Sign up with a redirect URL
         description: |         
           - See [redirect URLs and wildcards](/docs/guides/auth/overview#redirect-urls-and-wildcards) to add additional redirect URLs to your project.
         code: |

--- a/spec/supabase_js_v2.yml
+++ b/spec/supabase_js_v2.yml
@@ -174,6 +174,23 @@ functions:
             }
           )
           ```
+      - id: sign-up-with-redirect.
+        name: Sign up with a redirect
+        isSpotlight: false
+        description: |         
+          - See [redirect URLs and wildcards](/docs/guides/auth/overview#redirect-urls-and-wildcards) to add additional redirect URLs to your project.
+        code: |
+          ```js
+          const { data, error } = await supabase.auth.signUp(
+            {
+              email: 'example@email.com',
+              password: 'example-password',
+              options: {
+                redirectTo: 'https://example.com/welcome'
+              }
+            }
+          )
+          ```
   - id: sign-in-with-password
     title: 'signInWithPassword()'
     $ref: '@supabase/gotrue-js.GoTrueClient.signInWithPassword'


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase Docs > Javscript reference > [Create a new user](https://supabase.com/docs/reference/javascript/auth-signup)

## What is the current behavior?

The current `sign-up` examples do not show a `redirectTo` example.

## What is the new behavior?

Added a new example:

<img width="1112" alt="Screenshot 2023-01-23 at 14 37 03" src="https://user-images.githubusercontent.com/22655069/214066528-cbe08475-4e2b-45c5-920d-c6dae6645973.png">


## Additional context

Closes #11845
