### PR TITLE
feat: studio policies warning

### DIFF
--- a/studio/components/interfaces/Auth/Policies/PolicyTableRow/index.tsx
+++ b/studio/components/interfaces/Auth/Policies/PolicyTableRow/index.tsx
@@ -6,6 +6,7 @@ import { useStore } from 'hooks'
 import PolicyTableRowHeader from './PolicyTableRowHeader'
 import PolicyRow from './PolicyRow'
 import Panel from 'components/ui/Panel'
+import { Alert } from 'ui'
 
 interface Props {
   table: PostgresTable
@@ -46,9 +47,14 @@ const PolicyTableRow: FC<Props> = ({
               RLS is enabled - create a policy to allow access to this table.
             </p>
           ) : (
-            <p className="text-amber-900 text-sm opacity-50">
-              Warning: RLS is disabled - anonymous access is allowed to this table
-            </p>
+            <Alert
+              withIcon
+              variant="warning"
+              className="!px-4 !py-3 !mt-3"
+              title="Warning: RLS is disabled"
+            >
+              Anonymous access is allowed to this table
+            </Alert>
           )}
         </div>
       )}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase Studio > Authentication > Policies

## What is the current behavior?

The current warning if a table does not have RLS switched on is kind of hard to see:

<img width="1101" alt="Screenshot 2023-01-25 at 14 24 24" src="https://user-images.githubusercontent.com/22655069/214588764-b6963821-ac41-4d2a-b50b-745426cb73e2.png">


## What is the new behavior?

Added an `Alert` component to show the message:

<img width="1103" alt="Screenshot 2023-01-25 at 14 28 46" src="https://user-images.githubusercontent.com/22655069/214589762-8211e532-c90d-4714-9956-1a29d00f77c3.png">



## Additional context

At the moment if RLS is enabled but no policies the following is shown:

<img width="1101" alt="Screenshot 2023-01-25 at 14 26 03" src="https://user-images.githubusercontent.com/22655069/214589118-5e7fe8f5-c8ac-4891-a2e1-93455da676fb.png">

Is it worth adding an `Alert' component to the above as well?