### PR TITLE
Changed "Email Support" link to point to create ticket form

### DIFF
--- a/apps/www/pages/support.tsx
+++ b/apps/www/pages/support.tsx
@@ -199,7 +199,7 @@ const Index = ({}: Props) => {
                     border-gray-100 bg-white p-5
                     pt-14 dark:border-gray-600"
                   >
-                    <a href="mailto:support@supabase.io">
+                    <a href="https://app.supabase.com/support/new">
                       <Button size="medium" type="default" iconRight={<IconMail />}>
                         Email Support
                       </Button>


### PR DESCRIPTION
## What kind of change does this PR introduce?

This updates the /support page "Email Support" link to point to our create ticket form, rather than a mailto: link that emails support.

## Additional context

Using the create ticket form allows us to gather more relevant information about a problem, such as the affected project, which can help us resolve issues faster.