### PR TITLE
chore: fixed file type for syntax highlighting

### DIFF
--- a/apps/docs/pages/guides/functions/secrets.mdx
+++ b/apps/docs/pages/guides/functions/secrets.mdx
@@ -25,7 +25,7 @@ By default, Edge Functions have access to these secrets:
 
 Let's create a local file for storing our secrets, and inside it we can store a secret `MY_NAME`:
 
-```jsx
+```bash
 echo "MY_NAME=Yoda" >> ./supabase/.env.local
 ```
 


### PR DESCRIPTION
I fixed file type for syntax highlighting