### PR TITLE
fix: studio table editor gap

### DIFF
--- a/packages/ui/src/lib/theme/defaultTheme.ts
+++ b/packages/ui/src/lib/theme/defaultTheme.ts
@@ -1112,7 +1112,7 @@ export default {
       },
     },
 
-    responsive: 'md:grid md:grid-cols-12 md:gap-x-4',
+    responsive: 'md:grid md:grid-cols-12',
     non_responsive: 'grid grid-cols-12 gap-2',
 
     labels_horizontal_layout: 'flex flex-row space-x-2 justify-between col-span-12',


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase Studio > Table Editor > Column Mangement

## What is the current behavior?

On smaller devices the columns overflow:

<img width="668" alt="Screenshot 2023-01-26 at 13 56 27" src="https://user-images.githubusercontent.com/22655069/214854323-70d84b40-60a1-485b-8707-eab765ee2c98.png">


## What is the new behavior?

Removed `md:gap-x-4` class:

<img width="668" alt="Screenshot 2023-01-26 at 13 56 55" src="https://user-images.githubusercontent.com/22655069/214854408-8ea67920-645a-4d15-a303-7ae302b3c0f0.png">


## Additional context

Closes #11927
