### PR TITLE
fix: typo autoApiService in project/[ref]/api

### DIFF
--- a/studio/components/interfaces/Functions/TerminalInstructions.tsx
+++ b/studio/components/interfaces/Functions/TerminalInstructions.tsx
@@ -25,7 +25,7 @@ const TerminalInstructions: FC<Props> = ({ closable = false }) => {
   // Get the API service
   const apiService = settings?.autoApiService
   const anonKey = apiService?.service_api_keys.find((x: any) => x.name === 'anon key')
-    ? apiService?.defaultApiKey
+    ? apiService.defaultApiKey
     : undefined
 
   const endpoint = apiService?.endpoint ?? ''

--- a/studio/pages/project/[ref]/api/index.tsx
+++ b/studio/pages/project/[ref]/api/index.tsx
@@ -5,13 +5,13 @@ import { FC, createContext, useContext, useEffect, useState } from 'react'
 import { observer, useLocalObservable } from 'mobx-react-lite'
 
 import { NextPageWithLayout } from 'types'
-import { API_URL } from 'lib/constants'
 import { checkPermissions, useStore } from 'hooks'
 import { get } from 'lib/common/fetch'
 import { snakeToCamel } from 'lib/helpers'
 import { DocsLayout } from 'components/layouts'
 import { GeneralContent, ResourceContent, RpcContent } from 'components/interfaces/Docs'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
+import { useProjectSettingsQuery } from 'data/config/project-settings-query'
 
 const PageContext = createContext(null)
 
@@ -64,14 +64,14 @@ export default observer(PageConfig)
 
 const DEFAULT_KEY = { name: 'hide', key: 'SUPABASE_KEY' }
 
-const DocView: FC<any> = observer(({}) => {
+const DocView: FC<any> = observer(({ }) => {
   const PageState: any = useContext(PageContext)
   const router = useRouter()
   const [selectedLang, setSelectedLang] = useState<any>('js')
   const [showApiKey, setShowApiKey] = useState<any>(DEFAULT_KEY)
 
-  const { data, error }: any = useSWR(`${API_URL}/props/project/${PageState.projectRef}/api`, get)
-  const API_KEY = data?.autoApiService?.defaultApiKey
+  const { data, error } = useProjectSettingsQuery({ projectRef: PageState.projectRef as string })
+  const API_KEY = data?.autoApiService?.defaultApiKey ?? "-"
   const swaggerUrl = data?.autoApiService?.restUrl
   const headers: any = { apikey: API_KEY }
 
@@ -116,7 +116,7 @@ const DocView: FC<any> = observer(({}) => {
   // Data Loaded
   const autoApiService = {
     ...data.autoApiService,
-    endpoint: `${data.apiService.protocol ?? 'https'}://${data.apiService.endpoint ?? '-'}`,
+    endpoint: `${data.autoApiService.protocol ?? 'https'}://${data.autoApiService.endpoint ?? '-'}`,
   }
 
   const { query } = router
@@ -134,22 +134,20 @@ const DocView: FC<any> = observer(({}) => {
               <button
                 type="button"
                 onClick={() => setSelectedLang('js')}
-                className={`${
-                  selectedLang == 'js'
-                    ? 'bg-scale-300 font-medium text-scale-1200 dark:bg-scale-200'
-                    : 'bg-scale-100 text-scale-900 dark:bg-scale-100'
-                } relative inline-flex items-center border-r border-scale-200 p-1 px-2 text-sm transition hover:text-scale-1200 focus:outline-none`}
+                className={`${selectedLang == 'js'
+                  ? 'bg-scale-300 font-medium text-scale-1200 dark:bg-scale-200'
+                  : 'bg-scale-100 text-scale-900 dark:bg-scale-100'
+                  } relative inline-flex items-center border-r border-scale-200 p-1 px-2 text-sm transition hover:text-scale-1200 focus:outline-none`}
               >
                 JavaScript
               </button>
               <button
                 type="button"
                 onClick={() => setSelectedLang('bash')}
-                className={`${
-                  selectedLang == 'bash'
-                    ? 'bg-scale-300 font-medium text-scale-1200 dark:bg-scale-200'
-                    : 'bg-scale-100 text-scale-900 dark:bg-scale-100'
-                } relative inline-flex items-center border-r border-scale-200 p-1 px-2 text-sm transition hover:text-scale-1200 focus:outline-none`}
+                className={`${selectedLang == 'bash'
+                  ? 'bg-scale-300 font-medium text-scale-1200 dark:bg-scale-200'
+                  : 'bg-scale-100 text-scale-900 dark:bg-scale-100'
+                  } relative inline-flex items-center border-r border-scale-200 p-1 px-2 text-sm transition hover:text-scale-1200 focus:outline-none`}
               >
                 Bash
               </button>

--- a/studio/pages/project/[ref]/api/index.tsx
+++ b/studio/pages/project/[ref]/api/index.tsx
@@ -64,15 +64,17 @@ export default observer(PageConfig)
 
 const DEFAULT_KEY = { name: 'hide', key: 'SUPABASE_KEY' }
 
-const DocView: FC<any> = observer(({ }) => {
+const DocView: FC<any> = observer(({}) => {
   const PageState: any = useContext(PageContext)
   const router = useRouter()
   const [selectedLang, setSelectedLang] = useState<any>('js')
   const [showApiKey, setShowApiKey] = useState<any>(DEFAULT_KEY)
 
   const { data, error } = useProjectSettingsQuery({ projectRef: PageState.projectRef as string })
-  const API_KEY = data?.autoApiService?.defaultApiKey
-  const swaggerUrl = data?.autoApiService?.restUrl
+  const API_KEY = data?.autoApiService.service_api_keys.find((key: any) => key.tags === 'anon')
+    ? data?.autoApiService.defaultApiKey
+    : undefined
+  const swaggerUrl = data?.autoApiService.restUrl
   const headers: any = { apikey: API_KEY }
 
   const canReadServiceKey = checkPermissions(
@@ -80,7 +82,7 @@ const DocView: FC<any> = observer(({ }) => {
     'service_api_keys.service_role_key'
   )
 
-  if (API_KEY?.length > 40) headers['Authorization'] = `Bearer ${API_KEY}`
+  if (API_KEY) headers['Authorization'] = `Bearer ${API_KEY}`
 
   const { data: jsonSchema, error: jsonSchemaError } = useSWR(
     () => swaggerUrl,
@@ -134,20 +136,22 @@ const DocView: FC<any> = observer(({ }) => {
               <button
                 type="button"
                 onClick={() => setSelectedLang('js')}
-                className={`${selectedLang == 'js'
-                  ? 'bg-scale-300 font-medium text-scale-1200 dark:bg-scale-200'
-                  : 'bg-scale-100 text-scale-900 dark:bg-scale-100'
-                  } relative inline-flex items-center border-r border-scale-200 p-1 px-2 text-sm transition hover:text-scale-1200 focus:outline-none`}
+                className={`${
+                  selectedLang == 'js'
+                    ? 'bg-scale-300 font-medium text-scale-1200 dark:bg-scale-200'
+                    : 'bg-scale-100 text-scale-900 dark:bg-scale-100'
+                } relative inline-flex items-center border-r border-scale-200 p-1 px-2 text-sm transition hover:text-scale-1200 focus:outline-none`}
               >
                 JavaScript
               </button>
               <button
                 type="button"
                 onClick={() => setSelectedLang('bash')}
-                className={`${selectedLang == 'bash'
-                  ? 'bg-scale-300 font-medium text-scale-1200 dark:bg-scale-200'
-                  : 'bg-scale-100 text-scale-900 dark:bg-scale-100'
-                  } relative inline-flex items-center border-r border-scale-200 p-1 px-2 text-sm transition hover:text-scale-1200 focus:outline-none`}
+                className={`${
+                  selectedLang == 'bash'
+                    ? 'bg-scale-300 font-medium text-scale-1200 dark:bg-scale-200'
+                    : 'bg-scale-100 text-scale-900 dark:bg-scale-100'
+                } relative inline-flex items-center border-r border-scale-200 p-1 px-2 text-sm transition hover:text-scale-1200 focus:outline-none`}
               >
                 Bash
               </button>

--- a/studio/pages/project/[ref]/api/index.tsx
+++ b/studio/pages/project/[ref]/api/index.tsx
@@ -71,7 +71,7 @@ const DocView: FC<any> = observer(({ }) => {
   const [showApiKey, setShowApiKey] = useState<any>(DEFAULT_KEY)
 
   const { data, error } = useProjectSettingsQuery({ projectRef: PageState.projectRef as string })
-  const API_KEY = data?.autoApiService?.defaultApiKey ?? "-"
+  const API_KEY = data?.autoApiService?.defaultApiKey
   const swaggerUrl = data?.autoApiService?.restUrl
   const headers: any = { apikey: API_KEY }
 

--- a/studio/pages/project/[ref]/api/index.tsx
+++ b/studio/pages/project/[ref]/api/index.tsx
@@ -72,7 +72,7 @@ const DocView: FC<any> = observer(({}) => {
 
   const { data, error } = useProjectSettingsQuery({ projectRef: PageState.projectRef as string })
   const API_KEY = data?.autoApiService.service_api_keys.find((key: any) => key.tags === 'anon')
-    ? data?.autoApiService.defaultApiKey
+    ? data.autoApiService.defaultApiKey
     : undefined
   const swaggerUrl = data?.autoApiService.restUrl
   const headers: any = { apikey: API_KEY }
@@ -174,7 +174,7 @@ const DocView: FC<any> = observer(({}) => {
                           key="anon"
                           onClick={() =>
                             setShowApiKey({
-                              key: autoApiService?.defaultApiKey,
+                              key: API_KEY,
                               name: 'anon (public)',
                             })
                           }
@@ -186,7 +186,7 @@ const DocView: FC<any> = observer(({}) => {
                             key="service"
                             onClick={() =>
                               setShowApiKey({
-                                key: autoApiService?.serviceApiKey,
+                                key: autoApiService.serviceApiKey,
                                 name: 'service_role (secret)',
                               })
                             }

--- a/studio/pages/project/[ref]/functions/[id]/details.tsx
+++ b/studio/pages/project/[ref]/functions/[id]/details.tsx
@@ -99,9 +99,8 @@ const PageLayout: NextPageWithLayout = () => {
   // Get the API service
   const { data: settings } = useProjectSettingsQuery({ projectRef: ref as string })
   const apiService = settings?.autoApiService
-  const apiKeys = apiService?.service_api_keys ?? []
-  const anonKey = apiKeys.find((x: any) => x.name === 'anon key')
-    ? apiService?.defaultApiKey
+  const anonKey = apiService?.service_api_keys.find((x: any) => x.name === 'anon key')
+    ? apiService.defaultApiKey
     : undefined
 
   const endpoint = apiService?.endpoint ?? ''


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix, introduced in #11936 .
Page `project/[ref]/api` crashes with a `client-side expection` typical of NextJS
cc @sweatybridge 

Used `useProjectSettingsQuery` like elsewhere.

Will need a manual build of studio image again I think.

All other changes are from prettier automatic saving.
Tell me if they are good to go
(PS we should enable again prettier in the monorepo)

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
