### PR TITLE
feat: references pgvector extension in docs extension list

### DIFF
--- a/apps/docs/data/extensions.json
+++ b/apps/docs/data/extensions.json
@@ -469,6 +469,13 @@
     "comment": "generate universally unique identifiers (UUIDs)"
   },
   {
+    "name": "vector",
+    "schema": "extensions",
+    "default_version": "0.4.0",
+    "installed_version": null,
+    "comment": "vector data type with similarity search"
+  },
+  {
     "name": "xml2",
     "schema": null,
     "default_version": "1.1",


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update.

## What is the current behavior?

No reference to new `pgvector` Postgres extension.

## What is the new behavior?

Adds reference to `pgvector` Postgres extension (now in prod).

## Additional context

https://github.com/supabase/postgres/pull/472

Note within Postgres, the extension is just called `vector`, ie:
```sql
create extension vector;
```
