### PR TITLE
Delete folder in right-click context menu not working

### DIFF
--- a/studio/components/to-be-cleaned/Storage/StorageExplorer/FileExplorer.js
+++ b/studio/components/to-be-cleaned/Storage/StorageExplorer/FileExplorer.js
@@ -26,7 +26,7 @@ const FileExplorer = ({
   const fileExplorerRef = useRef(null)
   const storageExplorerStore = useStorageStore()
 
-  const { setSelectedItemToRename } = storageExplorerStore
+  const { setSelectedItemToRename, setSelectedItemsToDelete } = storageExplorerStore
 
   useEffect(() => {
     if (fileExplorerRef) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes https://github.com/supabase/supabase/issues/11835

## What is the current behavior?

When we right click on the folder and then click on delete then the folder do not get deleted

## What is the new behavior?
When we right click on the folder and then click on delete then the folder get deleted

## Steps to test

Steps to reproduce the behavior, please provide code snippets or a repository:

- Go to Storage
- Create a folder
- Right click on the folder and click on delete
- Verify that folder get deleted

## Demo

https://user-images.githubusercontent.com/45232708/215025557-2ccb4a2f-aec0-45f6-bb02-6f582720f12d.mov

