### PR TITLE
Remove root dependencies not needed

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -62,6 +62,7 @@
     "mdast-util-to-markdown": "^1.5.0",
     "mdx-mermaid": "2.0.0-rc3",
     "micromark-extension-mdxjs": "^1.0.0",
+    "mermaid": "^9.2.2",
     "next": "12.3.2",
     "next-compose-plugins": "^2.2.1",
     "next-mdx-remote": "^4.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "packages/*"
       ],
       "dependencies": {
-        "@mdx-js/react": "^2.1.1",
         "mdx-mermaid": "^1.3.2",
         "mermaid": "^9.2.2",
         "mini-svg-data-uri": "^1.4.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,6 @@
         "packages/*"
       ],
       "dependencies": {
-        "mdx-mermaid": "^1.3.2",
-        "mermaid": "^9.2.2",
         "mini-svg-data-uri": "^1.4.4"
       },
       "devDependencies": {
@@ -64,6 +62,7 @@
         "mdast-util-to-markdown": "^1.5.0",
         "mdx-mermaid": "2.0.0-rc3",
         "micromark-extension-mdxjs": "^1.0.0",
+        "mermaid": "^9.2.2",
         "next": "12.3.2",
         "next-compose-plugins": "^2.2.1",
         "next-mdx-remote": "^4.1.0",
@@ -24850,16 +24849,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
       "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g=="
-    },
-    "node_modules/mdx-mermaid": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/mdx-mermaid/-/mdx-mermaid-1.3.2.tgz",
-      "integrity": "sha512-8kw0tg3isKKBFzFwoe2DhIaEgKYtVeJXQtxZCCrdTPO0CTpXHnTHT0atDqsp7YkXi5iUCp/zAZPZu1cmr68T3w==",
-      "peerDependencies": {
-        "mermaid": ">=8.11.0",
-        "react": "^16.8.4 || ^17.0.0 || ^18.0.0",
-        "unist-util-visit": "^2.0.0"
-      }
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -51157,6 +51146,7 @@
         "mdast-util-to-markdown": "^1.5.0",
         "mdx-mermaid": "2.0.0-rc3",
         "micromark-extension-mdxjs": "^1.0.0",
+        "mermaid": "^9.2.2",
         "minimist": "^1.2.6",
         "next": "12.3.2",
         "next-compose-plugins": "^2.2.1",
@@ -58216,12 +58206,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
       "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g=="
-    },
-    "mdx-mermaid": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/mdx-mermaid/-/mdx-mermaid-1.3.2.tgz",
-      "integrity": "sha512-8kw0tg3isKKBFzFwoe2DhIaEgKYtVeJXQtxZCCrdTPO0CTpXHnTHT0atDqsp7YkXi5iUCp/zAZPZu1cmr68T3w==",
-      "requires": {}
     },
     "media-typer": {
       "version": "0.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "packages/*"
       ],
       "dependencies": {
-        "@code-hike/mdx": "^0.7.4",
         "@mdx-js/react": "^2.1.1",
         "mdx-mermaid": "^1.3.2",
         "mermaid": "^9.2.2",
@@ -3147,28 +3146,6 @@
       },
       "engines": {
         "node": ">=0.1.95"
-      }
-    },
-    "node_modules/@code-hike/mdx": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/@code-hike/mdx/-/mdx-0.7.4.tgz",
-      "integrity": "sha512-MHnoSJ7wxJ2LJfJ/x+18jh6JOBCPwk1EMQRgVINj3yyejqsYgOQx2ChE+/n+n3AdP7J5RLKfQ6qm/jiNxD8+Lg==",
-      "dependencies": {
-        "hast-util-to-estree": "^1.4.0",
-        "is-plain-obj": "^3.0.0",
-        "node-fetch": "^2.0.0",
-        "remark-rehype": "^8.1.0",
-        "shiki": "^0.10.1",
-        "unified": "^9.2.2",
-        "unist-util-visit": "^2.0.0",
-        "unist-util-visit-parents": "^3.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/code-hike"
-      },
-      "peerDependencies": {
-        "react": "^16.8.3 || ^17 || ^18"
       }
     },
     "node_modules/@colors/colors": {
@@ -17930,6 +17907,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/estree-util-attach-comments/-/estree-util-attach-comments-1.0.0.tgz",
       "integrity": "sha512-sL7dTwFGqzelPlB56lRZY1CC/yDxCe365WQpxNd49ispL40Yv8Tv4SmteGbvZeFwShOOVKfMlo4jrVvwoaMosA==",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -20049,6 +20027,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/hast-util-to-estree/-/hast-util-to-estree-1.4.0.tgz",
       "integrity": "sha512-CiOAIESUKkSOcYbvTth9+yM28z5ArpsYqxWc7LWJxOx975WRUBDjvVuuzZR2o09BNlkf7bp8G2GlOHepBRKJ8Q==",
+      "peer": true,
       "dependencies": {
         "comma-separated-tokens": "^1.0.0",
         "estree-util-attach-comments": "^1.0.0",
@@ -20069,6 +20048,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-1.1.0.tgz",
       "integrity": "sha512-OVJZ3fGGt9By77Ix9NhaRbzfbDV/2rx9EP7YIDJTmsZSEc5kYn2vWcNccYyahJL2uAQZK2a5Or2i0wtIKTPoRQ==",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -20181,6 +20161,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-1.0.4.tgz",
       "integrity": "sha512-I5GTdSfhYfAPNztx2xJRQpG8cuDSNt599/7YUn7Gx/WxNMsG+a835k97TDkFgk123cwjfwINaZknkKkphx/f2A==",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
@@ -21165,17 +21146,6 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-plain-obj": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
-      "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-plain-object": {
@@ -32802,55 +32772,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/remark-rehype": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-8.1.0.tgz",
-      "integrity": "sha512-EbCu9kHgAxKmW1yEYjx3QafMyGY3q8noUbNUI5xyKbaFP89wbhDrKxyIQNukNYthzjNHZu6J7hwFg7hRm1svYA==",
-      "dependencies": {
-        "mdast-util-to-hast": "^10.2.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remark-rehype/node_modules/mdast-util-to-hast": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-10.2.0.tgz",
-      "integrity": "sha512-JoPBfJ3gBnHZ18icCwHR50orC9kNH81tiR1gs01D8Q5YpV6adHNO9nKNuFBCJQ941/32PT1a63UF/DitmS3amQ==",
-      "dependencies": {
-        "@types/mdast": "^3.0.0",
-        "@types/unist": "^2.0.0",
-        "mdast-util-definitions": "^4.0.0",
-        "mdurl": "^1.0.0",
-        "unist-builder": "^2.0.0",
-        "unist-util-generated": "^1.0.0",
-        "unist-util-position": "^3.0.0",
-        "unist-util-visit": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remark-rehype/node_modules/unist-builder": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-2.0.3.tgz",
-      "integrity": "sha512-f98yt5pnlMWlzP539tPc4grGMsFaQQlP/vM396b00jngsiINumNmsY8rkXjfoi1c6QaM8nQ3vaGDuoKWbe/1Uw==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remark-rehype/node_modules/unist-util-generated": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-1.1.6.tgz",
-      "integrity": "sha512-cln2Mm1/CZzN5ttGK7vkoGw+RZ8VcUH6BtGbq98DDtRGquAAOXig1mrBQYelOwMXYS8rK+vZDyyojSjp7JX+Lg==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/remark-slug": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/remark-slug/-/remark-slug-7.0.1.tgz",
@@ -34025,16 +33946,6 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/shiki": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.10.1.tgz",
-      "integrity": "sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==",
-      "dependencies": {
-        "jsonc-parser": "^3.0.0",
-        "vscode-oniguruma": "^1.6.1",
-        "vscode-textmate": "5.2.0"
       }
     },
     "node_modules/side-channel": {
@@ -37199,11 +37110,6 @@
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
       "integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA=="
-    },
-    "node_modules/vscode-textmate": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
-      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ=="
     },
     "node_modules/w3c-hr-time": {
       "version": "1.0.2",
@@ -41003,21 +40909,6 @@
       "requires": {
         "exec-sh": "^0.3.2",
         "minimist": "^1.2.0"
-      }
-    },
-    "@code-hike/mdx": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/@code-hike/mdx/-/mdx-0.7.4.tgz",
-      "integrity": "sha512-MHnoSJ7wxJ2LJfJ/x+18jh6JOBCPwk1EMQRgVINj3yyejqsYgOQx2ChE+/n+n3AdP7J5RLKfQ6qm/jiNxD8+Lg==",
-      "requires": {
-        "hast-util-to-estree": "^1.4.0",
-        "is-plain-obj": "^3.0.0",
-        "node-fetch": "^2.0.0",
-        "remark-rehype": "^8.1.0",
-        "shiki": "^0.10.1",
-        "unified": "^9.2.2",
-        "unist-util-visit": "^2.0.0",
-        "unist-util-visit-parents": "^3.0.0"
       }
     },
     "@colors/colors": {
@@ -52970,7 +52861,8 @@
     "estree-util-attach-comments": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/estree-util-attach-comments/-/estree-util-attach-comments-1.0.0.tgz",
-      "integrity": "sha512-sL7dTwFGqzelPlB56lRZY1CC/yDxCe365WQpxNd49ispL40Yv8Tv4SmteGbvZeFwShOOVKfMlo4jrVvwoaMosA=="
+      "integrity": "sha512-sL7dTwFGqzelPlB56lRZY1CC/yDxCe365WQpxNd49ispL40Yv8Tv4SmteGbvZeFwShOOVKfMlo4jrVvwoaMosA==",
+      "peer": true
     },
     "estree-util-build-jsx": {
       "version": "2.2.0",
@@ -54568,9 +54460,9 @@
       }
     },
     "hast-util-to-estree": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/hast-util-to-estree/-/hast-util-to-estree-1.4.0.tgz",
+      "version": "https://registry.npmjs.org/hast-util-to-estree/-/hast-util-to-estree-1.4.0.tgz",
       "integrity": "sha512-CiOAIESUKkSOcYbvTth9+yM28z5ArpsYqxWc7LWJxOx975WRUBDjvVuuzZR2o09BNlkf7bp8G2GlOHepBRKJ8Q==",
+      "peer": true,
       "requires": {
         "comma-separated-tokens": "^1.0.0",
         "estree-util-attach-comments": "^1.0.0",
@@ -54586,7 +54478,8 @@
         "estree-util-is-identifier-name": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-1.1.0.tgz",
-          "integrity": "sha512-OVJZ3fGGt9By77Ix9NhaRbzfbDV/2rx9EP7YIDJTmsZSEc5kYn2vWcNccYyahJL2uAQZK2a5Or2i0wtIKTPoRQ=="
+          "integrity": "sha512-OVJZ3fGGt9By77Ix9NhaRbzfbDV/2rx9EP7YIDJTmsZSEc5kYn2vWcNccYyahJL2uAQZK2a5Or2i0wtIKTPoRQ==",
+          "peer": true
         }
       }
     },
@@ -54662,7 +54555,8 @@
     "hast-util-whitespace": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-1.0.4.tgz",
-      "integrity": "sha512-I5GTdSfhYfAPNztx2xJRQpG8cuDSNt599/7YUn7Gx/WxNMsG+a835k97TDkFgk123cwjfwINaZknkKkphx/f2A=="
+      "integrity": "sha512-I5GTdSfhYfAPNztx2xJRQpG8cuDSNt599/7YUn7Gx/WxNMsG+a835k97TDkFgk123cwjfwINaZknkKkphx/f2A==",
+      "peer": true
     },
     "hastscript": {
       "version": "6.0.0",
@@ -55383,11 +55277,6 @@
       "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.2.tgz",
       "integrity": "sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==",
       "dev": true
-    },
-    "is-plain-obj": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
-      "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA=="
     },
     "is-plain-object": {
       "version": "2.0.4",
@@ -64155,41 +64044,6 @@
         }
       }
     },
-    "remark-rehype": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-8.1.0.tgz",
-      "integrity": "sha512-EbCu9kHgAxKmW1yEYjx3QafMyGY3q8noUbNUI5xyKbaFP89wbhDrKxyIQNukNYthzjNHZu6J7hwFg7hRm1svYA==",
-      "requires": {
-        "mdast-util-to-hast": "^10.2.0"
-      },
-      "dependencies": {
-        "mdast-util-to-hast": {
-          "version": "10.2.0",
-          "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-10.2.0.tgz",
-          "integrity": "sha512-JoPBfJ3gBnHZ18icCwHR50orC9kNH81tiR1gs01D8Q5YpV6adHNO9nKNuFBCJQ941/32PT1a63UF/DitmS3amQ==",
-          "requires": {
-            "@types/mdast": "^3.0.0",
-            "@types/unist": "^2.0.0",
-            "mdast-util-definitions": "^4.0.0",
-            "mdurl": "^1.0.0",
-            "unist-builder": "^2.0.0",
-            "unist-util-generated": "^1.0.0",
-            "unist-util-position": "^3.0.0",
-            "unist-util-visit": "^2.0.0"
-          }
-        },
-        "unist-builder": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-2.0.3.tgz",
-          "integrity": "sha512-f98yt5pnlMWlzP539tPc4grGMsFaQQlP/vM396b00jngsiINumNmsY8rkXjfoi1c6QaM8nQ3vaGDuoKWbe/1Uw=="
-        },
-        "unist-util-generated": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-1.1.6.tgz",
-          "integrity": "sha512-cln2Mm1/CZzN5ttGK7vkoGw+RZ8VcUH6BtGbq98DDtRGquAAOXig1mrBQYelOwMXYS8rK+vZDyyojSjp7JX+Lg=="
-        }
-      }
-    },
     "remark-slug": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/remark-slug/-/remark-slug-7.0.1.tgz",
@@ -65016,16 +64870,6 @@
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.4.tgz",
       "integrity": "sha512-8o/QEhSSRb1a5i7TFR0iM4G16Z0vYB2OQVs4G3aAFXjn3T6yEx8AZxy1PgDF7I00LZHYA3WxaSYIf5e5sAX8Rw==",
       "dev": true
-    },
-    "shiki": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.10.1.tgz",
-      "integrity": "sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==",
-      "requires": {
-        "jsonc-parser": "^3.0.0",
-        "vscode-oniguruma": "^1.6.1",
-        "vscode-textmate": "5.2.0"
-      }
     },
     "side-channel": {
       "version": "1.0.4",
@@ -68069,11 +67913,6 @@
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
       "integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA=="
-    },
-    "vscode-textmate": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
-      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ=="
     },
     "w3c-hr-time": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,9 +16,6 @@
         "tests",
         "packages/*"
       ],
-      "dependencies": {
-        "mini-svg-data-uri": "^1.4.4"
-      },
       "devDependencies": {
         "@types/json-stringify-safe": "^5.0.0",
         "eslint": "^7.32.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "auth"
   ],
   "dependencies": {
-    "@mdx-js/react": "^2.1.1",
     "mdx-mermaid": "^1.3.2",
     "mermaid": "^9.2.2",
     "mini-svg-data-uri": "^1.4.4"

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "auth"
   ],
   "dependencies": {
-    "mermaid": "^9.2.2",
     "mini-svg-data-uri": "^1.4.4"
   },
   "overrides": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "auth"
   ],
   "dependencies": {
-    "mdx-mermaid": "^1.3.2",
     "mermaid": "^9.2.2",
     "mini-svg-data-uri": "^1.4.4"
   },

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "auth"
   ],
   "dependencies": {
-    "@code-hike/mdx": "^0.7.4",
     "@mdx-js/react": "^2.1.1",
     "mdx-mermaid": "^1.3.2",
     "mermaid": "^9.2.2",

--- a/package.json
+++ b/package.json
@@ -56,9 +56,6 @@
     "database",
     "auth"
   ],
-  "dependencies": {
-    "mini-svg-data-uri": "^1.4.4"
-  },
   "overrides": {
     "pgsql-parser": "13.4.0"
   }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature.
Remove 5 dependencies from root `package.json`. They are not needed at root level
Remove:
- `@code-hike/mdx`. Not used. Was used in past but it's all commented
- `@mdx-js/react`. Used in `apps/docs` and `apps/www`. It is present in both `package.json`
- `mdx-mermaid`. Used in `apps/docs`. Present in respective `package.json`
- `mermaid`. Not used as a direct dependency (is a peer dep of `mdx-mermaid`). Transferred to relative `package.json`
- `mini-svg-data-uri`. Used in `packages/config`. Present in respective `package.json`

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
