### PR TITLE
fix: docs - next js loader

### DIFF
--- a/apps/docs/pages/guides/storage/image-transformations.mdx
+++ b/apps/docs/pages/guides/storage/image-transformations.mdx
@@ -103,10 +103,8 @@ To get started, create a `supabase-image-loader.js` file in your NextJS project 
 ```ts
 const projectId = '' // your supabase project id
 
-export default function supabaseLoader({ src, width, height, quality }) {
-  return `https://${projectId}.supabase.co/storage/v1/render/image/public/${src}?width=${width}&height=${
-    height || 0
-  }&quality=${quality || 75}`
+export default function supabaseLoader({ src, width, quality }) {
+  return `https://${projectId}.supabase.co/storage/v1/render/image/public/${src}?width=${width}&quality=${quality || 75}`
 }
 ```
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase Docs - [NextJS Loader](docs/guides/storage/image-transformations#nextjs-loader)

## What is the current behavior?

In the examples the `height` prop is being used in the loader which is not in the Next JS documentation.

## What is the new behavior?

Removed the `height` prop:

<img width="818" alt="Screenshot 2023-01-27 at 10 17 56" src="https://user-images.githubusercontent.com/22655069/215062577-94c1a0a6-a99d-4dc5-a06a-dc6f54cd0ff4.png">


## Additional context

Closes #11960 
