### PR TITLE
feat: studio - changed styling of folder menu

### DIFF
--- a/studio/components/to-be-cleaned/Storage/StorageExplorer/FolderContextMenu.js
+++ b/studio/components/to-be-cleaned/Storage/StorageExplorer/FolderContextMenu.js
@@ -1,16 +1,27 @@
 import { useStorageStore } from 'localStores/storageExplorer/StorageExplorerStore'
-import { Menu, Item } from 'react-contexify'
+import { Menu, Item, Separator } from 'react-contexify'
 import 'react-contexify/dist/ReactContexify.css'
+import { IconEdit, IconDownload, IconTrash2 } from 'ui'
 
 const FolderContextMenu = ({ id = '', onRenameFolder = () => {}, onDeleteFolder = () => {} }) => {
   const storageExplorerStore = useStorageStore()
   const { downloadFolder } = storageExplorerStore
 
   return (
-    <Menu id={id} animation="fade">
-      <Item onClick={({ props }) => onRenameFolder(props.item)}>Rename</Item>
-      <Item onClick={({ props }) => downloadFolder(props.item)}>Download</Item>
-      <Item onClick={({ props }) => onDeleteFolder(props.item)}>Delete</Item>
+    <Menu id={id} animation="fade" className="!bg-scale-300 border border-scale-500">
+      <Item onClick={({ props }) => onRenameFolder(props.item)}>
+        <IconEdit size="tiny" />
+        <span className="ml-2 text-xs">Rename</span>
+      </Item>
+      <Item onClick={({ props }) => downloadFolder(props.item)}>
+        <IconDownload size="tiny" />
+        <span className="ml-2 text-xs">Download</span>
+      </Item>
+      <Separator />
+      <Item onClick={({ props }) => onDeleteFolder(props.item)}>
+        <IconTrash2 size="tiny" />
+        <span className="ml-2 text-xs">Delete</span>
+      </Item>
     </Menu>
   )
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase Studio > Storage > Folder (Right click)

## What is the current behavior?

The current menu has no styling:


https://user-images.githubusercontent.com/22655069/215084914-aa3d1b7c-3033-4a1e-ba53-0d4fa0a64fb1.mov



## What is the new behavior?

Styling has been added:


https://user-images.githubusercontent.com/22655069/215084957-73ef8aba-3280-4cc1-9ffc-7cbe817f7a26.mov



## Additional context

Linked with #11835 [comment](https://github.com/supabase/supabase/issues/11835#issuecomment-1403224375)
