### PR TITLE
Update recharts@2.3.0

### DIFF
--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -46,7 +46,7 @@
     "react-syntax-highlighter": "^15.5.0",
     "react-tooltip": "^4.2.17",
     "react-transition-group": "^4.4.1",
-    "recharts": "^2.1.15",
+    "recharts": "^2.3.0",
     "rehype-slug": "^5.0.1",
     "remark": "^13.0.0",
     "remark-gfm": "^3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -910,7 +910,7 @@
         "react-syntax-highlighter": "^15.5.0",
         "react-tooltip": "^4.2.17",
         "react-transition-group": "^4.4.1",
-        "recharts": "^2.1.15",
+        "recharts": "^2.3.0",
         "rehype-slug": "^5.0.1",
         "remark": "^13.0.0",
         "remark-gfm": "^3.0.1",
@@ -1050,6 +1050,30 @@
       },
       "engines": {
         "node": ">= 8.3"
+      }
+    },
+    "apps/www/node_modules/recharts": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.3.2.tgz",
+      "integrity": "sha512-2II30fGzKaypHfHNQNUhCfiLMxrOS/gF0WFahDIEFgXtJkVEe2DpZWFfEfAn+RU3B7/h2V/B05Bwmqq3rTXwLw==",
+      "dependencies": {
+        "classnames": "^2.2.5",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.19",
+        "react-is": "^16.10.2",
+        "react-resize-detector": "^7.1.2",
+        "react-smooth": "^2.0.1",
+        "recharts-scale": "^0.4.4",
+        "reduce-css-calc": "^2.1.8",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "prop-types": "^15.6.0",
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "apps/www/node_modules/remark": {
@@ -10325,32 +10349,25 @@
         "classnames": "*"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.0.4.tgz",
+      "integrity": "sha512-nwvEkG9vYOc0Ic7G7kwgviY4AQlTfYGIZ0fqB7CQHXGyYM6nO7kJh5EguSNA3jfh4rq7Sb7eMVq8isuvg2/miQ=="
+    },
     "node_modules/@types/d3-color": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-2.0.3.tgz",
       "integrity": "sha512-+0EtEjBfKEDtH9Rk3u3kLOUXM5F+iZK+WvASPb0MhIZl8J8NUvGeZRwKCXl+P3HkYx5TdU4YtcibpqHkSR9n7w=="
     },
-    "node_modules/@types/d3-interpolate": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-2.0.2.tgz",
-      "integrity": "sha512-lElyqlUfIPyWG/cD475vl6msPL4aMU7eJvx1//Q177L8mdXoVPFl1djIESF2FKnc0NyaHvQlJpWwKJYwAhUoCw==",
-      "dependencies": {
-        "@types/d3-color": "^2"
-      }
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.0.tgz",
+      "integrity": "sha512-aMo4eaAOijJjA6uU+GIeW018dvy9+oH5Y2VPPzjjfxevvGQ/oRDs+tfYC9b50Q4BygRR8yE2QCLsrT0WtAVseA=="
     },
     "node_modules/@types/d3-path": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-1.0.9.tgz",
-      "integrity": "sha512-NaIeSIBiFgSC6IGUBjZWcscUJEq7vpVu7KthHN8eieTV9d9MqkSOZLH4chq1PmcKy06PNe3axLeKmRIyxJ+PZQ==",
-      "dev": true
-    },
-    "node_modules/@types/d3-scale": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-3.3.2.tgz",
-      "integrity": "sha512-gGqr7x1ost9px3FvIfUMi5XA/F/yAf4UkUDtdQhpH92XCT0Oa7zkkRzY61gPVJq+DxpHn/btouw5ohWkbBsCzQ==",
-      "dependencies": {
-        "@types/d3-time": "^2"
-      }
+      "integrity": "sha512-NaIeSIBiFgSC6IGUBjZWcscUJEq7vpVu7KthHN8eieTV9d9MqkSOZLH4chq1PmcKy06PNe3axLeKmRIyxJ+PZQ=="
     },
     "node_modules/@types/d3-shape": {
       "version": "1.3.8",
@@ -10361,10 +10378,10 @@
         "@types/d3-path": "^1"
       }
     },
-    "node_modules/@types/d3-time": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-2.1.1.tgz",
-      "integrity": "sha512-9MVYlmIgmRR31C5b4FVSWtuMmBHh2mOWQYfl7XAYOa8dsnb7iEmUmRSWSFgXFtkjxO65d7hTUHQC+RhR/9IWFg=="
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.0.tgz",
+      "integrity": "sha512-HNB/9GHqu7Fo8AQiugyJbv6ZxYz58wef0esl4Mv828w1ZKpAshw/uFWVDUcIB9KKFeFKoxS3cHY07FFgtTRZ1g=="
     },
     "node_modules/@types/debounce-promise": {
       "version": "3.1.5",
@@ -10789,11 +10806,6 @@
         "@types/d3-shape": "^1",
         "@types/react": "*"
       }
-    },
-    "node_modules/@types/resize-observer-browser": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@types/resize-observer-browser/-/resize-observer-browser-0.1.7.tgz",
-      "integrity": "sha512-G9eN0Sn0ii9PWQ3Vl72jDPgeJwRWhv2Qk/nQkJuWmRmOB4HX3/BhD5SE1dZs/hzPZL/WKnvF0RHdTSG54QJFyg=="
     },
     "node_modules/@types/scheduler": {
       "version": "0.16.2",
@@ -31928,35 +31940,6 @@
         "node": ">=8.10.0"
       }
     },
-    "node_modules/recharts": {
-      "version": "2.1.16",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.1.16.tgz",
-      "integrity": "sha512-aYn1plTjYzRCo3UGxtWsduslwYd+Cuww3h/YAAEoRdGe0LRnBgYgaXSlVrNFkWOOSXrBavpmnli9h7pvRuk5wg==",
-      "dependencies": {
-        "@types/d3-interpolate": "^2.0.0",
-        "@types/d3-scale": "^3.0.0",
-        "@types/d3-shape": "^2.0.0",
-        "classnames": "^2.2.5",
-        "d3-interpolate": "^2.0.0",
-        "d3-scale": "^3.0.0",
-        "d3-shape": "^2.0.0",
-        "eventemitter3": "^4.0.1",
-        "lodash": "^4.17.19",
-        "react-is": "^16.10.2",
-        "react-resize-detector": "^7.1.2",
-        "react-smooth": "^2.0.1",
-        "recharts-scale": "^0.4.4",
-        "reduce-css-calc": "^2.1.8"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "prop-types": "^15.6.0",
-        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
     "node_modules/recharts-scale": {
       "version": "0.4.5",
       "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
@@ -31964,91 +31947,6 @@
       "dependencies": {
         "decimal.js-light": "^2.4.1"
       }
-    },
-    "node_modules/recharts/node_modules/@types/d3-path": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-2.0.2.tgz",
-      "integrity": "sha512-3YHpvDw9LzONaJzejXLOwZ3LqwwkoXb9LI2YN7Hbd6pkGo5nIlJ09ul4bQhBN4hQZJKmUpX8HkVqbzgUKY48cg=="
-    },
-    "node_modules/recharts/node_modules/@types/d3-shape": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-2.1.3.tgz",
-      "integrity": "sha512-HAhCel3wP93kh4/rq+7atLdybcESZ5bRHDEZUojClyZWsRuEMo3A52NGYJSh48SxfxEU6RZIVbZL2YFZ2OAlzQ==",
-      "dependencies": {
-        "@types/d3-path": "^2"
-      }
-    },
-    "node_modules/recharts/node_modules/d3-array": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
-      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
-      "dependencies": {
-        "internmap": "^1.0.0"
-      }
-    },
-    "node_modules/recharts/node_modules/d3-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
-      "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ=="
-    },
-    "node_modules/recharts/node_modules/d3-format": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-2.0.0.tgz",
-      "integrity": "sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA=="
-    },
-    "node_modules/recharts/node_modules/d3-interpolate": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-2.0.1.tgz",
-      "integrity": "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==",
-      "dependencies": {
-        "d3-color": "1 - 2"
-      }
-    },
-    "node_modules/recharts/node_modules/d3-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-2.0.0.tgz",
-      "integrity": "sha512-ZwZQxKhBnv9yHaiWd6ZU4x5BtCQ7pXszEV9CU6kRgwIQVQGLMv1oiL4M+MK/n79sYzsj+gcgpPQSctJUsLN7fA=="
-    },
-    "node_modules/recharts/node_modules/d3-scale": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.3.0.tgz",
-      "integrity": "sha512-1JGp44NQCt5d1g+Yy+GeOnZP7xHo0ii8zsQp6PGzd+C1/dl0KGsp9A7Mxwp+1D1o4unbTTxVdU/ZOIEBoeZPbQ==",
-      "dependencies": {
-        "d3-array": "^2.3.0",
-        "d3-format": "1 - 2",
-        "d3-interpolate": "1.2.0 - 2",
-        "d3-time": "^2.1.1",
-        "d3-time-format": "2 - 3"
-      }
-    },
-    "node_modules/recharts/node_modules/d3-shape": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-2.1.0.tgz",
-      "integrity": "sha512-PnjUqfM2PpskbSLTJvAzp2Wv4CZsnAgTfcVRTwW03QR3MkXF8Uo7B1y/lWkAsmbKwuecto++4NlsYcvYpXpTHA==",
-      "dependencies": {
-        "d3-path": "1 - 2"
-      }
-    },
-    "node_modules/recharts/node_modules/d3-time": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
-      "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
-      "dependencies": {
-        "d3-array": "2"
-      }
-    },
-    "node_modules/recharts/node_modules/d3-time-format": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-3.0.0.tgz",
-      "integrity": "sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==",
-      "dependencies": {
-        "d3-time": "1 - 2"
-      }
-    },
-    "node_modules/recharts/node_modules/internmap": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
-      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
     },
     "node_modules/redent": {
       "version": "1.0.0",
@@ -33253,11 +33151,6 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "dev": true
-    },
-    "node_modules/resize-observer-polyfill": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
-      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "node_modules/resolve": {
       "version": "1.22.1",
@@ -37190,6 +37083,56 @@
         "node": ">=4"
       }
     },
+    "node_modules/victory-vendor": {
+      "version": "36.6.8",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.6.8.tgz",
+      "integrity": "sha512-H3kyQ+2zgjMPvbPqAl7Vwm2FD5dU7/4bCTQakFQnpIsfDljeOMDojRsrmJfwh4oAlNnWhpAf+mbAoLh8u7dwyQ==",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
+    },
+    "node_modules/victory-vendor/node_modules/@types/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-jx5leotSeac3jr0RePOH1KdR9rISG91QIE4Q2PYTu4OymLTZfA3SrnURSLzKH48HmXVUru50b8nje4E79oQSQw==",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/victory-vendor/node_modules/@types/d3-scale": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.3.tgz",
+      "integrity": "sha512-PATBiMCpvHJSMtZAMEhc2WyL+hnzarKzI6wAHYjhsonjWJYGq5BXTzQjv4l8m2jO183/4wZ90rKvSeT7o72xNQ==",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/victory-vendor/node_modules/@types/d3-shape": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.1.tgz",
+      "integrity": "sha512-6Uh86YFF7LGg4PQkuO2oG6EMBRLuW9cbavUW46zkIO5kuS2PfTqo2o9SkgtQzguBHbLgNnU90UNsITpsX1My+A==",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/victory-vendor/node_modules/@types/d3-time": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.0.tgz",
+      "integrity": "sha512-sZLCdHvBUcNby1cB6Fd3ZBrABbjz3v1Vm90nysCQ6Vt7vd6e/h9Lt7SiJUoEX0l4Dzc7P5llKyhqSi1ycSf1Hg=="
+    },
     "node_modules/vm-browserify": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
@@ -38956,7 +38899,7 @@
         "react-virtualized-auto-sizer": "^1.0.6",
         "react-window": "^1.8.6",
         "react-window-infinite-loader": "^1.0.7",
-        "recharts": "2.1.6",
+        "recharts": "^2.3.0",
         "sass": "^1.43.4",
         "scheduler": "^0.20.2",
         "semver": "^6.3.0",
@@ -39112,19 +39055,6 @@
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
-    "studio/node_modules/@types/d3-path": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-2.0.2.tgz",
-      "integrity": "sha512-3YHpvDw9LzONaJzejXLOwZ3LqwwkoXb9LI2YN7Hbd6pkGo5nIlJ09ul4bQhBN4hQZJKmUpX8HkVqbzgUKY48cg=="
-    },
-    "studio/node_modules/@types/d3-shape": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-2.1.3.tgz",
-      "integrity": "sha512-HAhCel3wP93kh4/rq+7atLdybcESZ5bRHDEZUojClyZWsRuEMo3A52NGYJSh48SxfxEU6RZIVbZL2YFZ2OAlzQ==",
-      "dependencies": {
-        "@types/d3-path": "^2"
-      }
-    },
     "studio/node_modules/@types/react": {
       "version": "17.0.11",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.11.tgz",
@@ -39199,78 +39129,6 @@
         "tslib": "^2.4.1"
       }
     },
-    "studio/node_modules/d3-array": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
-      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
-      "dependencies": {
-        "internmap": "^1.0.0"
-      }
-    },
-    "studio/node_modules/d3-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
-      "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ=="
-    },
-    "studio/node_modules/d3-format": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-2.0.0.tgz",
-      "integrity": "sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA=="
-    },
-    "studio/node_modules/d3-interpolate": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-2.0.1.tgz",
-      "integrity": "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==",
-      "dependencies": {
-        "d3-color": "1 - 2"
-      }
-    },
-    "studio/node_modules/d3-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-2.0.0.tgz",
-      "integrity": "sha512-ZwZQxKhBnv9yHaiWd6ZU4x5BtCQ7pXszEV9CU6kRgwIQVQGLMv1oiL4M+MK/n79sYzsj+gcgpPQSctJUsLN7fA=="
-    },
-    "studio/node_modules/d3-scale": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.3.0.tgz",
-      "integrity": "sha512-1JGp44NQCt5d1g+Yy+GeOnZP7xHo0ii8zsQp6PGzd+C1/dl0KGsp9A7Mxwp+1D1o4unbTTxVdU/ZOIEBoeZPbQ==",
-      "dependencies": {
-        "d3-array": "^2.3.0",
-        "d3-format": "1 - 2",
-        "d3-interpolate": "1.2.0 - 2",
-        "d3-time": "^2.1.1",
-        "d3-time-format": "2 - 3"
-      }
-    },
-    "studio/node_modules/d3-shape": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-2.1.0.tgz",
-      "integrity": "sha512-PnjUqfM2PpskbSLTJvAzp2Wv4CZsnAgTfcVRTwW03QR3MkXF8Uo7B1y/lWkAsmbKwuecto++4NlsYcvYpXpTHA==",
-      "dependencies": {
-        "d3-path": "1 - 2"
-      }
-    },
-    "studio/node_modules/d3-time": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
-      "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
-      "dependencies": {
-        "d3-array": "2"
-      }
-    },
-    "studio/node_modules/d3-time-format": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-3.0.0.tgz",
-      "integrity": "sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==",
-      "dependencies": {
-        "d3-time": "1 - 2"
-      }
-    },
-    "studio/node_modules/internmap": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
-      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
-    },
     "studio/node_modules/openapi-types": {
       "version": "9.3.1",
       "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-9.3.1.tgz",
@@ -39281,43 +39139,28 @@
       "resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-2.3.0.tgz",
       "integrity": "sha512-c3L2CcAi7f7pvlD0D7xsF+2CQIW8C3HaYx2Pfgq8eA4HAl3GAH6/dVYsyBbYF/0XJs2ziGLrzmz5fmzPm6A0pQ=="
     },
-    "studio/node_modules/react-resize-detector": {
-      "version": "6.7.8",
-      "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-6.7.8.tgz",
-      "integrity": "sha512-0FaEcUBAbn+pq3PT5a9hHRebUfuS1SRLGLpIw8LydU7zX429I6XJgKerKAMPsJH0qWAl6o5bVKNqFJqr6tGPYw==",
-      "dependencies": {
-        "@types/resize-observer-browser": "^0.1.6",
-        "lodash": "^4.17.21",
-        "resize-observer-polyfill": "^1.5.1"
-      },
-      "peerDependencies": {
-        "react": "^16.0.0 || ^17.0.0",
-        "react-dom": "^16.0.0 || ^17.0.0"
-      }
-    },
     "studio/node_modules/recharts": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.1.6.tgz",
-      "integrity": "sha512-KnRNnCum1hL27DYhUfcdcKUEQkYnda6G+KDN4n/nCiTKp7UzJSgHfFHQvCkBujPi/U98dGd430DA2/8RJpkPlg==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.3.2.tgz",
+      "integrity": "sha512-2II30fGzKaypHfHNQNUhCfiLMxrOS/gF0WFahDIEFgXtJkVEe2DpZWFfEfAn+RU3B7/h2V/B05Bwmqq3rTXwLw==",
       "dependencies": {
-        "@types/d3-interpolate": "^2.0.0",
-        "@types/d3-scale": "^3.0.0",
-        "@types/d3-shape": "^2.0.0",
         "classnames": "^2.2.5",
-        "d3-interpolate": "^2.0.0",
-        "d3-scale": "^3.0.0",
-        "d3-shape": "^2.0.0",
         "eventemitter3": "^4.0.1",
         "lodash": "^4.17.19",
         "react-is": "^16.10.2",
-        "react-resize-detector": "^6.6.3",
-        "react-smooth": "^2.0.0",
+        "react-resize-detector": "^7.1.2",
+        "react-smooth": "^2.0.1",
         "recharts-scale": "^0.4.4",
-        "reduce-css-calc": "^2.1.8"
+        "reduce-css-calc": "^2.1.8",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=12"
       },
       "peerDependencies": {
-        "react": "^16.0.0 || ^17.0.0",
-        "react-dom": "^16.0.0 || ^17.0.0"
+        "prop-types": "^15.6.0",
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "studio/node_modules/typescript": {
@@ -46452,32 +46295,25 @@
         "classnames": "*"
       }
     },
+    "@types/d3-array": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.0.4.tgz",
+      "integrity": "sha512-nwvEkG9vYOc0Ic7G7kwgviY4AQlTfYGIZ0fqB7CQHXGyYM6nO7kJh5EguSNA3jfh4rq7Sb7eMVq8isuvg2/miQ=="
+    },
     "@types/d3-color": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-2.0.3.tgz",
       "integrity": "sha512-+0EtEjBfKEDtH9Rk3u3kLOUXM5F+iZK+WvASPb0MhIZl8J8NUvGeZRwKCXl+P3HkYx5TdU4YtcibpqHkSR9n7w=="
     },
-    "@types/d3-interpolate": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-2.0.2.tgz",
-      "integrity": "sha512-lElyqlUfIPyWG/cD475vl6msPL4aMU7eJvx1//Q177L8mdXoVPFl1djIESF2FKnc0NyaHvQlJpWwKJYwAhUoCw==",
-      "requires": {
-        "@types/d3-color": "^2"
-      }
+    "@types/d3-ease": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.0.tgz",
+      "integrity": "sha512-aMo4eaAOijJjA6uU+GIeW018dvy9+oH5Y2VPPzjjfxevvGQ/oRDs+tfYC9b50Q4BygRR8yE2QCLsrT0WtAVseA=="
     },
     "@types/d3-path": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-1.0.9.tgz",
-      "integrity": "sha512-NaIeSIBiFgSC6IGUBjZWcscUJEq7vpVu7KthHN8eieTV9d9MqkSOZLH4chq1PmcKy06PNe3axLeKmRIyxJ+PZQ==",
-      "dev": true
-    },
-    "@types/d3-scale": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-3.3.2.tgz",
-      "integrity": "sha512-gGqr7x1ost9px3FvIfUMi5XA/F/yAf4UkUDtdQhpH92XCT0Oa7zkkRzY61gPVJq+DxpHn/btouw5ohWkbBsCzQ==",
-      "requires": {
-        "@types/d3-time": "^2"
-      }
+      "integrity": "sha512-NaIeSIBiFgSC6IGUBjZWcscUJEq7vpVu7KthHN8eieTV9d9MqkSOZLH4chq1PmcKy06PNe3axLeKmRIyxJ+PZQ=="
     },
     "@types/d3-shape": {
       "version": "1.3.8",
@@ -46488,10 +46324,10 @@
         "@types/d3-path": "^1"
       }
     },
-    "@types/d3-time": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-2.1.1.tgz",
-      "integrity": "sha512-9MVYlmIgmRR31C5b4FVSWtuMmBHh2mOWQYfl7XAYOa8dsnb7iEmUmRSWSFgXFtkjxO65d7hTUHQC+RhR/9IWFg=="
+    "@types/d3-timer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.0.tgz",
+      "integrity": "sha512-HNB/9GHqu7Fo8AQiugyJbv6ZxYz58wef0esl4Mv828w1ZKpAshw/uFWVDUcIB9KKFeFKoxS3cHY07FFgtTRZ1g=="
     },
     "@types/debounce-promise": {
       "version": "3.1.5",
@@ -46915,11 +46751,6 @@
         "@types/d3-shape": "^1",
         "@types/react": "*"
       }
-    },
-    "@types/resize-observer-browser": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@types/resize-observer-browser/-/resize-observer-browser-0.1.7.tgz",
-      "integrity": "sha512-G9eN0Sn0ii9PWQ3Vl72jDPgeJwRWhv2Qk/nQkJuWmRmOB4HX3/BhD5SE1dZs/hzPZL/WKnvF0RHdTSG54QJFyg=="
     },
     "@types/scheduler": {
       "version": "0.16.2",
@@ -63471,114 +63302,6 @@
         "picomatch": "^2.2.1"
       }
     },
-    "recharts": {
-      "version": "2.1.16",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.1.16.tgz",
-      "integrity": "sha512-aYn1plTjYzRCo3UGxtWsduslwYd+Cuww3h/YAAEoRdGe0LRnBgYgaXSlVrNFkWOOSXrBavpmnli9h7pvRuk5wg==",
-      "requires": {
-        "@types/d3-interpolate": "^2.0.0",
-        "@types/d3-scale": "^3.0.0",
-        "@types/d3-shape": "^2.0.0",
-        "classnames": "^2.2.5",
-        "d3-interpolate": "^2.0.0",
-        "d3-scale": "^3.0.0",
-        "d3-shape": "^2.0.0",
-        "eventemitter3": "^4.0.1",
-        "lodash": "^4.17.19",
-        "react-is": "^16.10.2",
-        "react-resize-detector": "^7.1.2",
-        "react-smooth": "^2.0.1",
-        "recharts-scale": "^0.4.4",
-        "reduce-css-calc": "^2.1.8"
-      },
-      "dependencies": {
-        "@types/d3-path": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-2.0.2.tgz",
-          "integrity": "sha512-3YHpvDw9LzONaJzejXLOwZ3LqwwkoXb9LI2YN7Hbd6pkGo5nIlJ09ul4bQhBN4hQZJKmUpX8HkVqbzgUKY48cg=="
-        },
-        "@types/d3-shape": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-2.1.3.tgz",
-          "integrity": "sha512-HAhCel3wP93kh4/rq+7atLdybcESZ5bRHDEZUojClyZWsRuEMo3A52NGYJSh48SxfxEU6RZIVbZL2YFZ2OAlzQ==",
-          "requires": {
-            "@types/d3-path": "^2"
-          }
-        },
-        "d3-array": {
-          "version": "2.12.1",
-          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
-          "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
-          "requires": {
-            "internmap": "^1.0.0"
-          }
-        },
-        "d3-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
-          "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ=="
-        },
-        "d3-format": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-2.0.0.tgz",
-          "integrity": "sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA=="
-        },
-        "d3-interpolate": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-2.0.1.tgz",
-          "integrity": "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==",
-          "requires": {
-            "d3-color": "1 - 2"
-          }
-        },
-        "d3-path": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-2.0.0.tgz",
-          "integrity": "sha512-ZwZQxKhBnv9yHaiWd6ZU4x5BtCQ7pXszEV9CU6kRgwIQVQGLMv1oiL4M+MK/n79sYzsj+gcgpPQSctJUsLN7fA=="
-        },
-        "d3-scale": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.3.0.tgz",
-          "integrity": "sha512-1JGp44NQCt5d1g+Yy+GeOnZP7xHo0ii8zsQp6PGzd+C1/dl0KGsp9A7Mxwp+1D1o4unbTTxVdU/ZOIEBoeZPbQ==",
-          "requires": {
-            "d3-array": "^2.3.0",
-            "d3-format": "1 - 2",
-            "d3-interpolate": "1.2.0 - 2",
-            "d3-time": "^2.1.1",
-            "d3-time-format": "2 - 3"
-          }
-        },
-        "d3-shape": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-2.1.0.tgz",
-          "integrity": "sha512-PnjUqfM2PpskbSLTJvAzp2Wv4CZsnAgTfcVRTwW03QR3MkXF8Uo7B1y/lWkAsmbKwuecto++4NlsYcvYpXpTHA==",
-          "requires": {
-            "d3-path": "1 - 2"
-          }
-        },
-        "d3-time": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
-          "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
-          "requires": {
-            "d3-array": "2"
-          }
-        },
-        "d3-time-format": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-3.0.0.tgz",
-          "integrity": "sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==",
-          "requires": {
-            "d3-time": "1 - 2"
-          }
-        },
-        "internmap": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
-          "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
-        }
-      }
-    },
     "recharts-scale": {
       "version": "0.4.5",
       "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
@@ -64405,11 +64128,6 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "dev": true
-    },
-    "resize-observer-polyfill": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
-      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "resolve": {
       "version": "1.22.1",
@@ -65830,7 +65548,7 @@
         "react-virtualized-auto-sizer": "^1.0.6",
         "react-window": "^1.8.6",
         "react-window-infinite-loader": "^1.0.7",
-        "recharts": "2.1.6",
+        "recharts": "^2.3.0",
         "sass": "^1.43.4",
         "scheduler": "^0.20.2",
         "semver": "^6.3.0",
@@ -65902,19 +65620,6 @@
             "use-sync-external-store": "^1.2.0"
           }
         },
-        "@types/d3-path": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-2.0.2.tgz",
-          "integrity": "sha512-3YHpvDw9LzONaJzejXLOwZ3LqwwkoXb9LI2YN7Hbd6pkGo5nIlJ09ul4bQhBN4hQZJKmUpX8HkVqbzgUKY48cg=="
-        },
-        "@types/d3-shape": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-2.1.3.tgz",
-          "integrity": "sha512-HAhCel3wP93kh4/rq+7atLdybcESZ5bRHDEZUojClyZWsRuEMo3A52NGYJSh48SxfxEU6RZIVbZL2YFZ2OAlzQ==",
-          "requires": {
-            "@types/d3-path": "^2"
-          }
-        },
         "@types/react": {
           "version": "17.0.11",
           "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.11.tgz",
@@ -65967,78 +65672,6 @@
             "tslib": "^2.4.1"
           }
         },
-        "d3-array": {
-          "version": "2.12.1",
-          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
-          "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
-          "requires": {
-            "internmap": "^1.0.0"
-          }
-        },
-        "d3-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
-          "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ=="
-        },
-        "d3-format": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-2.0.0.tgz",
-          "integrity": "sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA=="
-        },
-        "d3-interpolate": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-2.0.1.tgz",
-          "integrity": "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==",
-          "requires": {
-            "d3-color": "1 - 2"
-          }
-        },
-        "d3-path": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-2.0.0.tgz",
-          "integrity": "sha512-ZwZQxKhBnv9yHaiWd6ZU4x5BtCQ7pXszEV9CU6kRgwIQVQGLMv1oiL4M+MK/n79sYzsj+gcgpPQSctJUsLN7fA=="
-        },
-        "d3-scale": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.3.0.tgz",
-          "integrity": "sha512-1JGp44NQCt5d1g+Yy+GeOnZP7xHo0ii8zsQp6PGzd+C1/dl0KGsp9A7Mxwp+1D1o4unbTTxVdU/ZOIEBoeZPbQ==",
-          "requires": {
-            "d3-array": "^2.3.0",
-            "d3-format": "1 - 2",
-            "d3-interpolate": "1.2.0 - 2",
-            "d3-time": "^2.1.1",
-            "d3-time-format": "2 - 3"
-          }
-        },
-        "d3-shape": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-2.1.0.tgz",
-          "integrity": "sha512-PnjUqfM2PpskbSLTJvAzp2Wv4CZsnAgTfcVRTwW03QR3MkXF8Uo7B1y/lWkAsmbKwuecto++4NlsYcvYpXpTHA==",
-          "requires": {
-            "d3-path": "1 - 2"
-          }
-        },
-        "d3-time": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
-          "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
-          "requires": {
-            "d3-array": "2"
-          }
-        },
-        "d3-time-format": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-3.0.0.tgz",
-          "integrity": "sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==",
-          "requires": {
-            "d3-time": "1 - 2"
-          }
-        },
-        "internmap": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
-          "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
-        },
         "openapi-types": {
           "version": "9.3.1",
           "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-9.3.1.tgz",
@@ -66049,35 +65682,20 @@
           "resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-2.3.0.tgz",
           "integrity": "sha512-c3L2CcAi7f7pvlD0D7xsF+2CQIW8C3HaYx2Pfgq8eA4HAl3GAH6/dVYsyBbYF/0XJs2ziGLrzmz5fmzPm6A0pQ=="
         },
-        "react-resize-detector": {
-          "version": "6.7.8",
-          "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-6.7.8.tgz",
-          "integrity": "sha512-0FaEcUBAbn+pq3PT5a9hHRebUfuS1SRLGLpIw8LydU7zX429I6XJgKerKAMPsJH0qWAl6o5bVKNqFJqr6tGPYw==",
-          "requires": {
-            "@types/resize-observer-browser": "^0.1.6",
-            "lodash": "^4.17.21",
-            "resize-observer-polyfill": "^1.5.1"
-          }
-        },
         "recharts": {
-          "version": "2.1.6",
-          "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.1.6.tgz",
-          "integrity": "sha512-KnRNnCum1hL27DYhUfcdcKUEQkYnda6G+KDN4n/nCiTKp7UzJSgHfFHQvCkBujPi/U98dGd430DA2/8RJpkPlg==",
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.3.2.tgz",
+          "integrity": "sha512-2II30fGzKaypHfHNQNUhCfiLMxrOS/gF0WFahDIEFgXtJkVEe2DpZWFfEfAn+RU3B7/h2V/B05Bwmqq3rTXwLw==",
           "requires": {
-            "@types/d3-interpolate": "^2.0.0",
-            "@types/d3-scale": "^3.0.0",
-            "@types/d3-shape": "^2.0.0",
             "classnames": "^2.2.5",
-            "d3-interpolate": "^2.0.0",
-            "d3-scale": "^3.0.0",
-            "d3-shape": "^2.0.0",
             "eventemitter3": "^4.0.1",
             "lodash": "^4.17.19",
             "react-is": "^16.10.2",
-            "react-resize-detector": "^6.6.3",
-            "react-smooth": "^2.0.0",
+            "react-resize-detector": "^7.1.2",
+            "react-smooth": "^2.0.1",
             "recharts-scale": "^0.4.4",
-            "reduce-css-calc": "^2.1.8"
+            "reduce-css-calc": "^2.1.8",
+            "victory-vendor": "^36.6.8"
           }
         },
         "typescript": {
@@ -68060,6 +67678,58 @@
         "unist-util-stringify-position": "^3.0.0"
       }
     },
+    "victory-vendor": {
+      "version": "36.6.8",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.6.8.tgz",
+      "integrity": "sha512-H3kyQ+2zgjMPvbPqAl7Vwm2FD5dU7/4bCTQakFQnpIsfDljeOMDojRsrmJfwh4oAlNnWhpAf+mbAoLh8u7dwyQ==",
+      "requires": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      },
+      "dependencies": {
+        "@types/d3-interpolate": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+          "integrity": "sha512-jx5leotSeac3jr0RePOH1KdR9rISG91QIE4Q2PYTu4OymLTZfA3SrnURSLzKH48HmXVUru50b8nje4E79oQSQw==",
+          "requires": {
+            "@types/d3-color": "*"
+          }
+        },
+        "@types/d3-scale": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.3.tgz",
+          "integrity": "sha512-PATBiMCpvHJSMtZAMEhc2WyL+hnzarKzI6wAHYjhsonjWJYGq5BXTzQjv4l8m2jO183/4wZ90rKvSeT7o72xNQ==",
+          "requires": {
+            "@types/d3-time": "*"
+          }
+        },
+        "@types/d3-shape": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.1.tgz",
+          "integrity": "sha512-6Uh86YFF7LGg4PQkuO2oG6EMBRLuW9cbavUW46zkIO5kuS2PfTqo2o9SkgtQzguBHbLgNnU90UNsITpsX1My+A==",
+          "requires": {
+            "@types/d3-path": "*"
+          }
+        },
+        "@types/d3-time": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.0.tgz",
+          "integrity": "sha512-sZLCdHvBUcNby1cB6Fd3ZBrABbjz3v1Vm90nysCQ6Vt7vd6e/h9Lt7SiJUoEX0l4Dzc7P5llKyhqSi1ycSf1Hg=="
+        }
+      }
+    },
     "vm-browserify": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
@@ -69024,7 +68694,7 @@
         "react-syntax-highlighter": "^15.5.0",
         "react-tooltip": "^4.2.17",
         "react-transition-group": "^4.4.1",
-        "recharts": "^2.1.15",
+        "recharts": "^2.3.0",
         "rehype-slug": "^5.0.1",
         "remark": "^13.0.0",
         "remark-gfm": "^3.0.1",
@@ -69128,6 +68798,22 @@
             "ansi-regex": "^5.0.0",
             "ansi-styles": "^4.0.0",
             "react-is": "^16.12.0"
+          }
+        },
+        "recharts": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.3.2.tgz",
+          "integrity": "sha512-2II30fGzKaypHfHNQNUhCfiLMxrOS/gF0WFahDIEFgXtJkVEe2DpZWFfEfAn+RU3B7/h2V/B05Bwmqq3rTXwLw==",
+          "requires": {
+            "classnames": "^2.2.5",
+            "eventemitter3": "^4.0.1",
+            "lodash": "^4.17.19",
+            "react-is": "^16.10.2",
+            "react-resize-detector": "^7.1.2",
+            "react-smooth": "^2.0.1",
+            "recharts-scale": "^0.4.4",
+            "reduce-css-calc": "^2.1.8",
+            "victory-vendor": "^36.6.8"
           }
         },
         "remark": {

--- a/studio/components/ui/Charts/StackedBarChart.tsx
+++ b/studio/components/ui/Charts/StackedBarChart.tsx
@@ -115,6 +115,8 @@ const StackedBarChart: React.FC<Props> = ({
                 ? (label) => timestampFormatter(label, customDateFormat, displayDateInUtc)
                 : undefined
             }
+            // currently recharts@2.3.0 is broken in formatter type
+            // @ts-ignore
             formatter={(value: number, name: string, props: any) => {
               const suffix = format || ''
               if (variant === 'percentages' && percentagesStackedData) {

--- a/studio/package.json
+++ b/studio/package.json
@@ -78,7 +78,7 @@
     "react-virtualized-auto-sizer": "^1.0.6",
     "react-window": "^1.8.6",
     "react-window-infinite-loader": "^1.0.7",
-    "recharts": "2.1.6",
+    "recharts": "^2.3.0",
     "sass": "^1.43.4",
     "scheduler": "^0.20.2",
     "semver": "^6.3.0",


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature.
Update `recharts` to `^2.3.0` to resolve partially vulnerability in `d3-color@<3.1.0`
https://github.com/advisories/GHSA-36jr-mh4h-2g58

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
