### PR TITLE
Add package-lock.json to studio workflows

### DIFF
--- a/.github/workflows/studio-build.yml
+++ b/.github/workflows/studio-build.yml
@@ -7,6 +7,7 @@ on:
       - studio
     paths:
       - 'studio/**'
+      - 'package-lock.json'
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/studio-tests.yml
+++ b/.github/workflows/studio-tests.yml
@@ -8,10 +8,12 @@ on:
     branches: [master]
     paths:
       - 'studio/**'
+      - 'package-lock.json'
   pull_request:
     branches: [master]
     paths:
       - 'studio/**'
+      - 'package-lock.json'
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix?
Build studio and run tests also when `package-lock.json` is modified.
Catch errors when upgrading a dependency that studio might depend on

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
