### PR TITLE
chore: Fix spelling on v0.5 Migration Instructions

### DIFF
--- a/apps/docs/pages/guides/auth/auth-helpers/nextjs.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/nextjs.mdx
@@ -594,7 +594,7 @@ export const config = {
 
 To make these helpers more flexible as well as more maintainable and easier to upgrade for new versions of Next.js, we're stripping them down to the most useful part which is managing the cookies and giving you an authenticated supabase-js client in any environment (client, server, middleware/edge).
 
-Therefore we're marking the `withApiAuth`, `withPageAuth`, and `withMiddlewareAuth` higher order functions as deprectaed and they will be removed in the next **minor** release (v0.6.X).
+Therefore we're marking the `withApiAuth`, `withPageAuth`, and `withMiddlewareAuth` higher order functions as deprecated and they will be removed in the next **minor** release (v0.6.X).
 
 Please follow the steps below to update your API routes, pages, and middleware handlers. Thanks!
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs: Fixes spelling mistake on the `auth-helpers-nextjs` instructions page

deprectaed -> deprecated