### PR TITLE
Fix: typo in cors documentation

### DIFF
--- a/apps/docs/pages/guides/functions/cors.mdx
+++ b/apps/docs/pages/guides/functions/cors.mdx
@@ -12,7 +12,7 @@ See the [example on GitHub](https://github.com/supabase/supabase/blob/master/exa
 
 ### Recommended setup
 
-We recommend adding a `corst.ts` file within a [`_shared` folder](/docs/guides/functions/quickstart#organizing-your-edge-functions) which makes it easy to reuse the CORS headers across functions:
+We recommend adding a `cors.ts` file within a [`_shared` folder](/docs/guides/functions/quickstart#organizing-your-edge-functions) which makes it easy to reuse the CORS headers across functions:
 
 ```ts cors.ts
 export const corsHeaders = {


### PR DESCRIPTION
Fixed an error in the name of a file in the CORS (Cross-Origin Resource Sharing) documentation.

## What kind of change does this PR introduce?

docs update

