### PR TITLE
chore(ci): update ci regarding forked repos

### DIFF
--- a/.github/workflows/avoid-typos.yml
+++ b/.github/workflows/avoid-typos.yml
@@ -7,6 +7,9 @@ jobs:
   misspell:
     name: runner / misspell
     runs-on: ubuntu-latest
+    permissions:
+       contents: read
+       pull-requests: write 
     steps:
       - name: Check out code.
         uses: actions/checkout@v1


### PR DESCRIPTION
## What kind of change does this PR introduce?

Updating CI regarding forked repos as discussed [here](https://github.com/supabase/supabase/pull/11373#issuecomment-1407188822)

## What is the current behavior?

As mentioned by the team, this might not be working correctly for contributions from forks.

