### PR TITLE
added warning for RootLayout

### DIFF
--- a/apps/docs/pages/guides/auth/auth-helpers/nextjs-server-components.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/nextjs-server-components.mdx
@@ -399,6 +399,9 @@ export default async function RootLayout({ children }: { children: React.ReactNo
 </TabPanel>
 </Tabs>
 
+> Remember: With this RootLayout, you will get problems when using static site generation (SSG) somewhere in your project because in "dev" mode, NextJS will complain about the usage of header/cookie methods in the supebase client creation.
+
+  
 And now create our Supabase listener component that uses the singleton Supabase instance to listen for auth changes.
 
 <Tabs


### PR DESCRIPTION
Added warning for RootLayout that its not usable in dev mode when having pages with SSG enabled because of the access of headers/cookies of the supabase server client.

## What kind of change does this PR introduce?

Doc update / refinement

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
