### PR TITLE
fix: Remove 'upgrade-insecure-requests' for self-host

### DIFF
--- a/studio/next.config.js
+++ b/studio/next.config.js
@@ -12,6 +12,14 @@ const withTM = require('next-transpile-modules')(['ui', 'common'])
 // https://nextjs.org/docs/api-reference/next.config.js/introduction
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
+const csp = [
+  "frame-ancestors 'none';",
+  // IS_PLATFORM
+  process.env.NEXT_PUBLIC_IS_PLATFORM === 'true' ? 'upgrade-insecure-requests;' : '',
+]
+  .filter(Boolean)
+  .join(' ')
+
 const nextConfig = {
   async redirects() {
     return [
@@ -137,12 +145,7 @@ const nextConfig = {
           },
           {
             key: 'Content-Security-Policy',
-            value: `
-            frame-ancestors 'none';
-            upgrade-insecure-requests;
-            `
-              .replace(/\s{2,}/g, ' ')
-              .trim(),
+            value: csp,
           },
           {
             key: 'Referrer-Policy',


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.
Remove 'upgrade-insecure-requests' for self-hosting

Bug introduced in #11932 

Fixes #12003 

Needs a new build of studio image and a change in `docker-compose.yml`

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
