### PR TITLE
Show file names in documentation

### DIFF
--- a/apps/docs/pages/guides/getting-started/tutorials/with-vue-3.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-vue-3.mdx
@@ -50,7 +50,7 @@ VITE_SUPABASE_URL=YOUR_SUPABASE_URL
 VITE_SUPABASE_ANON_KEY=YOUR_SUPABASE_ANON_KEY
 ```
 
-Now that we have the API credentials in place, let's create a helper file to initialize the Supabase client. These variables will be exposed
+Now that we have the API credentials in place, let's create a helper file (`src/supabase.js`) to initialize the Supabase client. These variables will be exposed
 on the browser, and that's completely fine since we have [Row Level Security](/docs/guides/auth#row-level-security) enabled on our Database.
 
 ```js title=src/supabase.js
@@ -66,7 +66,7 @@ Optionally, update [src/style.css](https://raw.githubusercontent.com/supabase/su
 
 ### Set up a Login component
 
-Let's set up a Vue component to manage logins and sign ups. We'll use Magic Links, so users can sign in with their email without using passwords.
+Let's set up a Vue component at `src/components/Auth.vue` to manage logins and sign ups. We'll use Magic Links, so users can sign in with their email without using passwords. 
 
 ```html title=/src/components/Auth.vue
 <script setup>
@@ -118,7 +118,7 @@ Let's set up a Vue component to manage logins and sign ups. We'll use Magic Link
 ### Account page
 
 After a user is signed in we can allow them to edit their profile details and manage their account.
-Let's create a new component for that called `Account.vue`.
+Let's create a new component for that in `src/components/Account.vue`.
 
 ```html title=src/components/Account.vue
 <script setup>
@@ -277,7 +277,7 @@ Every Supabase project is configured with [Storage](/docs/guides/storage) for ma
 
 ### Create an upload widget
 
-Let's create an avatar for the user so that they can upload a profile photo. We can start by creating a new component:
+Let's create an avatar for the user so that they can upload a profile photo. We can start by creating a new component at `src/components/Avatar.vue`:
 
 ```html title=src/components/Avatar.vue
 <script setup>
@@ -361,7 +361,7 @@ Let's create an avatar for the user so that they can upload a profile photo. We 
 
 ### Add the new widget
 
-And then we can add the widget to the Account page:
+And then we can add the widget to the Account page at `src/components/Account.vue`:
 
 ```html title=src/components/Account.vue
 <script>

--- a/apps/docs/pages/guides/getting-started/tutorials/with-vue-3.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-vue-3.mdx
@@ -50,7 +50,7 @@ VITE_SUPABASE_URL=YOUR_SUPABASE_URL
 VITE_SUPABASE_ANON_KEY=YOUR_SUPABASE_ANON_KEY
 ```
 
-Now that we have the API credentials in place, let's create a helper file (`src/supabase.js`) to initialize the Supabase client. These variables will be exposed
+With the API credentials in place, create an `src/supabase.js` helper file to initialize the Supabase client. These variables are exposed
 on the browser, and that's completely fine since we have [Row Level Security](/docs/guides/auth#row-level-security) enabled on our Database.
 
 ```js title=src/supabase.js
@@ -66,7 +66,7 @@ Optionally, update [src/style.css](https://raw.githubusercontent.com/supabase/su
 
 ### Set up a Login component
 
-Let's set up a Vue component at `src/components/Auth.vue` to manage logins and sign ups. We'll use Magic Links, so users can sign in with their email without using passwords. 
+Set up an `src/components/Auth.vue` component to manage logins and sign ups. We'll use Magic Links, so users can sign in with their email without using passwords. 
 
 ```html title=/src/components/Auth.vue
 <script setup>
@@ -118,7 +118,7 @@ Let's set up a Vue component at `src/components/Auth.vue` to manage logins and s
 ### Account page
 
 After a user is signed in we can allow them to edit their profile details and manage their account.
-Let's create a new component for that in `src/components/Account.vue`.
+Create a new `src/components/Account.vue` component to handle this.
 
 ```html title=src/components/Account.vue
 <script setup>
@@ -277,7 +277,7 @@ Every Supabase project is configured with [Storage](/docs/guides/storage) for ma
 
 ### Create an upload widget
 
-Let's create an avatar for the user so that they can upload a profile photo. We can start by creating a new component at `src/components/Avatar.vue`:
+Create a new `src/components/Avatar.vue` component that allows users to upload profile photos:
 
 ```html title=src/components/Avatar.vue
 <script setup>
@@ -361,7 +361,7 @@ Let's create an avatar for the user so that they can upload a profile photo. We 
 
 ### Add the new widget
 
-And then we can add the widget to the Account page at `src/components/Account.vue`:
+And then we can add the widget to the Account page in `src/components/Account.vue`:
 
 ```html title=src/components/Account.vue
 <script>


### PR DESCRIPTION
File names for snippets were not visible in generated documentation. Added this to text to make guide easier for new users.

## What kind of change does this PR introduce?

Documentation update

## What is the current behavior?

File names are not visible in generated documentation: 
<img width="744" alt="image" src="https://user-images.githubusercontent.com/26654/215346225-253d52a8-a46f-4334-916f-24155c3109c8.png">

## What is the new behavior?

Added explicit references to the file names.

