### PR TITLE
Fix: Missing null check for realtime publication tables in studio database/tables page

### DIFF
--- a/studio/components/interfaces/Database/Tables/TableList.tsx
+++ b/studio/components/interfaces/Database/Tables/TableList.tsx
@@ -166,7 +166,7 @@ const TableList: FC<Props> = ({
                   <code className="text-sm">{x.size}</code>
                 </Table.td>
                 <Table.td className="hidden xl:table-cell text-center">
-                  {realtimePublication.tables.find((table: any) => table.id === x.id) && (
+                  {realtimePublication.tables?.find((table: any) => table.id === x.id) && (
                     <div className="flex justify-center">
                       <IconCheck strokeWidth={2} />
                     </div>


### PR DESCRIPTION
This issue is happening on my production project and prevents me to see the database page:

```
TypeError: Cannot read properties of null (reading 'find')
    at TableList.tsx:169:47
```
![image](https://user-images.githubusercontent.com/10697451/215360747-8dd4ff13-68a3-47a0-95c5-9a08c587ed31.png)

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

[Link to my projec database/tables page](https://app.supabase.com/project/wubgwbmxkgvibuhlvhil/database/tables)

## What is the new behavior?

Hopefully I'd be able to see the page!

## Additional context

Sorry I did not test the fix on a local installation or something!
