### PR TITLE
fix: use the term Edge Functions in titles

### DIFF
--- a/apps/docs/layouts/SiteLayout.tsx
+++ b/apps/docs/layouts/SiteLayout.tsx
@@ -29,7 +29,7 @@ const levelsData = {
   },
   functions: {
     icon: '/docs/img/icons/menu/functions',
-    name: 'Functions',
+    name: 'Edge Functions',
   },
   realtime: {
     icon: '/docs/img/icons/menu/realtime',

--- a/apps/docs/pages/guides/functions/cors.mdx
+++ b/apps/docs/pages/guides/functions/cors.mdx
@@ -3,10 +3,10 @@ import Layout from '~/layouts/DefaultGuideLayout'
 export const meta = {
   id: 'functions-cors',
   title: 'CORS (Cross-Origin Resource Sharing)',
-  description: 'Add CORS headers to invoke functions from the browser.',
+  description: 'Add CORS headers to invoke Edge Functions from the browser.',
 }
 
-To invoke the functions from the browser, you need to handle [CORS Preflight](https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request) requests.
+To invoke edge functions from the browser, you need to handle [CORS Preflight](https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request) requests.
 
 See the [example on GitHub](https://github.com/supabase/supabase/blob/master/examples/edge-functions/supabase/functions/browser-with-cors/index.ts).
 

--- a/apps/docs/pages/guides/functions/debugging.mdx
+++ b/apps/docs/pages/guides/functions/debugging.mdx
@@ -2,8 +2,8 @@ import Layout from '~/layouts/DefaultGuideLayout'
 
 export const meta = {
   id: 'functions-debugging',
-  title: 'Debugging Functions',
-  description: 'Debug functions in production.',
+  title: 'Debugging Edge Functions',
+  description: 'Debug Edge Functions in production.',
 }
 
 You can debug your deployed Edge Functions using the ["Functions" section](https://app.supabase.com/project/_/functions) of the Dashboard. There are two debugging tools available:

--- a/apps/docs/pages/guides/functions/local-development.mdx
+++ b/apps/docs/pages/guides/functions/local-development.mdx
@@ -3,7 +3,7 @@ import Layout from '~/layouts/DefaultGuideLayout'
 export const meta = {
   id: 'functions-local-development',
   title: 'Local Development',
-  description: 'Run your functions locally.',
+  description: 'Run your Edge Functions locally.',
 }
 
 You can run your Edge Function locally using [`supabase functions serve`](/docs/reference/cli/usage#supabase-functions-serve):
@@ -15,9 +15,9 @@ supabase functions serve hello-world # start the Function watcher
 
 The `functions serve` command has hot-reloading capabilities. It will watch for any changes to your files and restart the Deno server.
 
-### Invoking functions locally
+### Invoking Edge Functions locally
 
-While serving your local Function, you can invoke it using curl:
+While serving your local Edge Function, you can invoke it using curl:
 
 ```bash
 curl --request POST 'http://localhost:54321/functions/v1/hello-world' \
@@ -44,7 +44,7 @@ const { data, error } = await supabase.functions.invoke('hello-world', {
 
 You should see the response `{ "message":"Hello Functions!" }`.
 
-If you execute Function with a different payload the response will change. <br />
+If you execute the function with a different payload the response will change. <br />
 Modify the `--data '{"name":"Functions"}'` line to `--data '{"name":"World"}'` and try invoking the command again!
 
 <Admonition type="note">

--- a/apps/docs/pages/guides/functions/quickstart.mdx
+++ b/apps/docs/pages/guides/functions/quickstart.mdx
@@ -28,7 +28,7 @@ Follow the steps to prepare your Supabase project on your local machine.
 - Link to your Remote Project using the command `supabase link --project-ref your-project-ref`. [Docs](/docs/reference/cli/usage#supabase-link).
 - Optional: Setup your environment: Follow [this setup guide](https://deno.land/manual/getting_started/setup_your_environment) to integrate the Deno language server with your editor.
 
-## Create a function
+## Create an Edge Function
 
 Let's create a new Edge Function called `hello-world` inside your project:
 

--- a/apps/docs/pages/guides/functions/schedule-functions.mdx
+++ b/apps/docs/pages/guides/functions/schedule-functions.mdx
@@ -2,17 +2,17 @@ import Layout from '~/layouts/DefaultGuideLayout'
 
 export const meta = {
   id: 'schedule-functions',
-  title: 'Schedule Functions',
-  description: 'Schedule Functions with pg_cron.',
+  title: 'Schedule Edge Functions',
+  description: 'Schedule Edge Functions with pg_cron.',
 }
 
 The hosted Supabase Platform supports the [`pg_cron` extension](/docs/guides/database/extensions/pgcron), a simple cron-based job scheduler for PostgreSQL that runs inside the database.
 
-In combination with the [`pg_net` extension](/docs/guides/database/extensions/pgnet), this allows us to invoke functions periodically on a set schedule.
+In combination with the [`pg_net` extension](/docs/guides/database/extensions/pgnet), this allows us to invoke Edge Functions periodically on a set schedule.
 
 ## Examples
 
-### Invoke Function every minute
+### Invoke an Edge Function every minute
 
 Make a POST request to a Supabase Edge Function every minute:
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Based on feedback in this Slack thread - https://supabase.slack.com/archives/C023E4L60R3/p1674833300072199. This PR will change Edge Functions docs to use a consistent title.
