### PR TITLE
docs: sveltekit typescript

### DIFF
--- a/apps/docs/pages/guides/getting-started/tutorials/with-sveltekit.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-sveltekit.mdx
@@ -24,7 +24,7 @@ Let's start building the Svelte app from scratch.
 ### Initialize a Svelte app
 
 We can use the [SvelteKit Skeleton Project](https://kit.svelte.dev/docs) to initialize
-an app called `supabase-sveltekit` (for this tutorial you do not need TypeScript, ESLint, Prettier, or Playwright):
+an app called `supabase-sveltekit` (for this tutorial we will be using TypeScript):
 
 ```bash
 npm init svelte@next supabase-sveltekit


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase Docs - [SvelteKit](https://supabase.com/docs/guides/getting-started/tutorials/with-sveltekit#initialize-a-svelte-app)

## What is the current behavior?

Docs say that Typescript is now used when it is.

## What is the new behavior?

Changed to say Typescript is used.

## Additional context

Closes #12014
