### PR TITLE
feat: folder name creation

### DIFF
--- a/studio/localStores/storageExplorer/StorageExplorerStore.js
+++ b/studio/localStores/storageExplorer/StorageExplorerStore.js
@@ -317,6 +317,13 @@ class StorageExplorerStore {
     const formattedName = this.sanitizeNameForDuplicateInColumn(folderName, autofix, columnIndex)
     if (formattedName === null) return
 
+    if (!/^[a-zA-Z0-9_-]*$/.test(formattedName)) {
+      return this.ui.setNotification({
+        message: 'Folder name contains invalid special characters',
+        category: 'error',
+        duration: 8000,
+      })
+    }
     /**
      * todo: move this to a util file, as renameFolder() uses same logic
      */


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase Studio > Storage > Create Folder

## What is the current behavior?

You can create a folder with special characters but once create the folder become invalid.

## What is the new behavior?

Added in a check when the folder is first created so that the user knows that the name of the folder invalid:


https://user-images.githubusercontent.com/22655069/215477443-d4cb3301-4057-456f-a341-b8c8d624f84f.mov


## Additional context

Maybe worth adding in a toast when the folder is created so that the user knows that a folder has been created?

Closes #12021
