### PR TITLE
Update C# reference docs nav menu

### DIFF
--- a/apps/docs/docs/ref/csharp/introduction.mdx
+++ b/apps/docs/docs/ref/csharp/introduction.mdx
@@ -8,13 +8,14 @@ hideTitle: true
   <img src="/docs/img/icons/menu/reference-csharp.svg" className="w-8 h-8 rounded" />
   <div className="flex flex-col gap-2">
     <h1 className="text-3xl text-scale-1200 m-0">C# Client Library</h1>
-    <h2 className="text-base font-mono text-scale-1100">supabase-csharp</h2>
+    <h2 className="text-base font-mono text-scale-1100">@supabase-community/supabase-csharp</h2>
   </div>
 </div>
 
 <div className="max-w-xl">
-  This reference documents every object and method available in Supabase's C#
-  library, [supabase-csharp](https://www.nuget.org/packages/supabase-csharp). You can
-  use supabase-csharp to interact with your Postgres database, listen to database changes, invoke
-  Deno Edge Functions, build login and user management functionality, and manage large files.
+  This reference documents every object and method available in the
+  [supabase-csharp](https://www.nuget.org/packages/supabase-csharp) library from the Supabase
+  community. You can use `supabase-csharp` to interact with your Postgres database, listen to
+  database changes, invoke Deno Edge Functions, build login and user management functionality, and
+  manage large files.
 </div>

--- a/spec/common-client-libs-sections.json
+++ b/spec/common-client-libs-sections.json
@@ -28,7 +28,8 @@
       "reference_javascript_v1",
       "reference_dart_v0",
       "reference_dart_v1",
-      "reference_python_v2"
+      "reference_python_v2",
+      "reference_csharp_v0"
     ]
   },
   {
@@ -36,7 +37,12 @@
     "id": "upgrade-guide",
     "slug": "upgrade-guide",
     "type": "markdown",
-    "excludes": ["reference_javascript_v2", "reference_dart_v1", "reference_python_v2"]
+    "excludes": [
+      "reference_javascript_v2",
+      "reference_dart_v1",
+      "reference_python_v2",
+      "reference_csharp_v0"
+    ]
   },
   {
     "title": "Database",
@@ -842,7 +848,6 @@
   {
     "title": "Misc",
     "excludes": ["reference_dart_v1", "reference_dart_v0"],
-
     "items": [
       {
         "title": "Release Notes",


### PR DESCRIPTION
## Preview URL

https://docs-ksjqy8rly-supabase.vercel.app/docs/reference/csharp/introduction

## What kind of change does this PR introduce?

- Remove "TypeScript Support" and "Upgrade guide"
- Update introduction

## What is the current behavior?

![Screenshot 2023-01-30 at 5 04 22 PM](https://user-images.githubusercontent.com/7026076/215632562-a213c91f-6836-41df-b7b3-e3b653d165a7.png)

## What is the new behavior?

![Screenshot 2023-01-30 at 5 04 31 PM](https://user-images.githubusercontent.com/7026076/215632580-19c78896-b3bd-4e45-8a1b-9e3c357432ca.png)