### PR TITLE
Documentation: Add section about testing row-level-security

### DIFF
--- a/apps/docs/pages/guides/auth/row-level-security.mdx
+++ b/apps/docs/pages/guides/auth/row-level-security.mdx
@@ -328,6 +328,64 @@ Tip: Make sure to enable RLS for all your tables, so that your tables are inacce
 Supabase provides special "Service" keys, which can be used to bypass all RLS.
 These should never be used in the browser or exposed to customers, but they are useful for administrative tasks.
 
+### Testing policies
+
+In order to test policies on the database itself, i.e. from the SQL editor or from `psql` without switching to your frontend and logging in as different users, you can utilize the following helper SQL procedures ([credits](https://github.com/supabase/supabase/issues/7311#issuecomment-1398648114)):
+
+```sql
+GRANT anon, authenticated TO postgres;
+
+CREATE OR REPLACE PROCEDURE auth.login_as_user (user_email text)
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    auth_user auth.users;
+BEGIN
+    SELECT
+        * INTO auth_user
+    FROM
+        auth.users
+    WHERE
+        email = user_email;
+    EXECUTE format('SET request.jwt.claim.sub=%L', (auth_user).id::text);
+    EXECUTE format('SET request.jwt.claim.role=%I', (auth_user).ROLE);
+    EXECUTE format('SET request.jwt.claim.email=%L', (auth_user).email);
+    EXECUTE format('SET request.jwt.claims=%L', json_strip_nulls(json_build_object('app_metadata', (auth_user).raw_app_meta_data))::text);
+
+    RAISE NOTICE '%', format( 'SET ROLE %I; -- Logging in as %L (%L)', (auth_user).ROLE, (auth_user).id, (auth_user).email);
+    EXECUTE format('SET ROLE %I', (auth_user).ROLE);
+END;
+$$;
+
+CREATE OR REPLACE PROCEDURE auth.login_as_anon ()
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    SET request.jwt.claim.sub='';
+    SET request.jwt.claim.role='';
+    SET request.jwt.claim.email='';
+    SET request.jwt.claims='';
+    SET ROLE anon;
+END;
+$$;
+
+CREATE OR REPLACE PROCEDURE auth.logout ()
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    SET request.jwt.claim.sub='';
+    SET request.jwt.claim.role='';
+    SET request.jwt.claim.email='';
+    SET request.jwt.claims='';
+    SET ROLE postgres;
+END;
+$$;
+```
+
+In order to switch to a given user (by email), use `CALL auth.login_as_user('my@email.com');`. You can also switch to the `anon` role using `CALL auth.login_as_anon();`. When you are done, use `CALL auth.logout();` which will return yourself to the powerful `postgres` role.
+
+These procedures are also very handy for writing [pgTAP](/docs/guides/database/extensions/pgtap) unit-tests for policies.
+
 ## Deprecated features
 
 We have deprecate some functions to ensure better performance and extensibilty of RLS policies.

--- a/apps/docs/pages/guides/auth/row-level-security.mdx
+++ b/apps/docs/pages/guides/auth/row-level-security.mdx
@@ -330,7 +330,7 @@ These should never be used in the browser or exposed to customers, but they are 
 
 ### Testing policies
 
-In order to test policies on the database itself, i.e. from the SQL editor or from `psql` without switching to your frontend and logging in as different users, you can utilize the following helper SQL procedures ([credits](https://github.com/supabase/supabase/issues/7311#issuecomment-1398648114)):
+To test policies on the database itself (i.e., from the [SQL Editor](https://app.supabase.com/project/_/sql) or from `psql`) without switching to your frontend and logging in as different users, you can utilize the following helper SQL procedures ([credits](https://github.com/supabase/supabase/issues/7311#issuecomment-1398648114)):
 
 ```sql
 GRANT anon, authenticated TO postgres;
@@ -382,9 +382,9 @@ END;
 $$;
 ```
 
-In order to switch to a given user (by email), use `CALL auth.login_as_user('my@email.com');`. You can also switch to the `anon` role using `CALL auth.login_as_anon();`. When you are done, use `CALL auth.logout();` which will return yourself to the powerful `postgres` role.
+To switch to a given user (by email), use `CALL auth.login_as_user('my@email.com');`. You can also switch to the `anon` role using `CALL auth.login_as_anon();`. When you are done, use `CALL auth.logout();` to return yourself to the `postgres` role.
 
-These procedures are also very handy for writing [pgTAP](/docs/guides/database/extensions/pgtap) unit-tests for policies.
+These procedures can also be used for writing [pgTAP](/docs/guides/database/extensions/pgtap) unit tests for policies.
 
 ## Deprecated features
 

--- a/apps/docs/pages/guides/auth/row-level-security.mdx
+++ b/apps/docs/pages/guides/auth/row-level-security.mdx
@@ -333,58 +333,123 @@ These should never be used in the browser or exposed to customers, but they are 
 To test policies on the database itself (i.e., from the [SQL Editor](https://app.supabase.com/project/_/sql) or from `psql`) without switching to your frontend and logging in as different users, you can utilize the following helper SQL procedures ([credits](https://github.com/supabase/supabase/issues/7311#issuecomment-1398648114)):
 
 ```sql
-GRANT anon, authenticated TO postgres;
+grant anon, authenticated to postgres;
 
-CREATE OR REPLACE PROCEDURE auth.login_as_user (user_email text)
-    LANGUAGE plpgsql
-    AS $$
-DECLARE
+create or replace procedure auth.login_as_user (user_email text)
+    language plpgsql
+    as $$
+declare
     auth_user auth.users;
-BEGIN
-    SELECT
-        * INTO auth_user
-    FROM
+begin
+    select
+        * into auth_user
+    from
         auth.users
-    WHERE
+    where
         email = user_email;
-    EXECUTE format('SET request.jwt.claim.sub=%L', (auth_user).id::text);
-    EXECUTE format('SET request.jwt.claim.role=%I', (auth_user).ROLE);
-    EXECUTE format('SET request.jwt.claim.email=%L', (auth_user).email);
-    EXECUTE format('SET request.jwt.claims=%L', json_strip_nulls(json_build_object('app_metadata', (auth_user).raw_app_meta_data))::text);
+    execute format('set request.jwt.claim.sub=%L', (auth_user).id::text);
+    execute format('set request.jwt.claim.role=%I', (auth_user).role);
+    execute format('set request.jwt.claim.email=%L', (auth_user).email);
+    execute format('set request.jwt.claims=%L', json_strip_nulls(json_build_object('app_metadata', (auth_user).raw_app_meta_data))::text);
 
-    RAISE NOTICE '%', format( 'SET ROLE %I; -- Logging in as %L (%L)', (auth_user).ROLE, (auth_user).id, (auth_user).email);
-    EXECUTE format('SET ROLE %I', (auth_user).ROLE);
-END;
+    raise notice '%', format( 'set role %I; -- logging in as %L (%L)', (auth_user).role, (auth_user).id, (auth_user).email);
+    execute format('set role %I', (auth_user).role);
+end;
 $$;
 
-CREATE OR REPLACE PROCEDURE auth.login_as_anon ()
-    LANGUAGE plpgsql
-    AS $$
-BEGIN
-    SET request.jwt.claim.sub='';
-    SET request.jwt.claim.role='';
-    SET request.jwt.claim.email='';
-    SET request.jwt.claims='';
-    SET ROLE anon;
-END;
+create or replace procedure auth.login_as_anon ()
+    language plpgsql
+    as $$
+begin
+    set request.jwt.claim.sub='';
+    set request.jwt.claim.role='';
+    set request.jwt.claim.email='';
+    set request.jwt.claims='';
+    set role anon;
+end;
 $$;
 
-CREATE OR REPLACE PROCEDURE auth.logout ()
-    LANGUAGE plpgsql
-    AS $$
-BEGIN
-    SET request.jwt.claim.sub='';
-    SET request.jwt.claim.role='';
-    SET request.jwt.claim.email='';
-    SET request.jwt.claims='';
-    SET ROLE postgres;
-END;
+create or replace procedure auth.logout ()
+    language plpgsql
+    as $$
+begin
+    set request.jwt.claim.sub='';
+    set request.jwt.claim.role='';
+    set request.jwt.claim.email='';
+    set request.jwt.claims='';
+    set role postgres;
+end;
 $$;
 ```
 
-To switch to a given user (by email), use `CALL auth.login_as_user('my@email.com');`. You can also switch to the `anon` role using `CALL auth.login_as_anon();`. When you are done, use `CALL auth.logout();` to return yourself to the `postgres` role.
+To switch to a given user (by email), use `call auth.login_as_user('my@email.com');`. You can also switch to the `anon` role using `call auth.login_as_anon();`. When you are done, use `call auth.logout();` to return yourself to the `postgres` role.
 
 These procedures can also be used for writing [pgTAP](/docs/guides/database/extensions/pgtap) unit tests for policies.
+
+<details>
+  <summary>Click here to see an example `psql` interaction using this.</summary>
+
+This example shows that the `public.profiles` table from the tutorial example can indeed be updated by the `postgres` role and the owner of the row but not from `anon` connections:
+
+```shell
+postgres=> select id, email from auth.users;
+                  id                  |       email
+--------------------------------------+-------------------
+ d4f0aa86-e6f6-41d1-bd32-391f077cf1b9 | user1@example.com
+ 15d6811a-16ee-4fa2-9b18-b63085688be4 | user2@example.com
+ 4e1010bb-eb37-4a4d-a05a-b0ee315c9d56 | user3@example.com
+(3 rows)
+
+postgres=> table public.profiles;
+                  id                  | updated_at | username | full_name | avatar_url | website
+--------------------------------------+------------+----------+-----------+------------+---------
+ d4f0aa86-e6f6-41d1-bd32-391f077cf1b9 |            | user1    | User 1    |            |
+ 15d6811a-16ee-4fa2-9b18-b63085688be4 |            | user2    | User 2    |            |
+ 4e1010bb-eb37-4a4d-a05a-b0ee315c9d56 |            | user3    | User 3    |            |
+(3 rows)
+
+postgres=> call auth.login_as_anon();
+CALL
+postgres=> update public.profiles set updated_at=now();
+UPDATE 0 -- anon users cannot update any profile but see all of them
+postgres=> table public.profiles;
+                  id                  | updated_at | username | full_name | avatar_url | website
+--------------------------------------+------------+----------+-----------+------------+---------
+ d4f0aa86-e6f6-41d1-bd32-391f077cf1b9 |            | user1    | User 1    |            |
+ 15d6811a-16ee-4fa2-9b18-b63085688be4 |            | user2    | User 2    |            |
+ 4e1010bb-eb37-4a4d-a05a-b0ee315c9d56 |            | user3    | User 3    |            |
+(3 rows)
+
+postgres=> call auth.logout();
+CALL
+postgres=> call auth.login_as_user('user1@example.com');
+NOTICE:  set role authenticated; -- logging in as 'd4f0aa86-e6f6-41d1-bd32-391f077cf1b9' ('user1@example.com')
+CALL
+postgres=> update public.profiles set updated_at=now();
+UPDATE 1 -- authenticated users can update their own profile and see all of them
+postgres=> table public.profiles;
+                  id                  |          updated_at           | username | full_name | avatar_url | website
+--------------------------------------+-------------------------------+----------+-----------+------------+---------
+ 15d6811a-16ee-4fa2-9b18-b63085688be4 |                               | user1    | User 1    |            |
+ 4e1010bb-eb37-4a4d-a05a-b0ee315c9d56 |                               | user2    | User 2    |            |
+ d4f0aa86-e6f6-41d1-bd32-391f077cf1b9 | 2023-02-18 21:39:16.204612+00 | user3    | User 3    |            |
+(3 rows)
+
+postgres=> call auth.logout();
+CALL
+postgres=> update public.profiles set updated_at=now();
+UPDATE 3 -- the 'postgres' role can update and see all profiles
+postgres=> table public.profiles;
+                  id                  |          updated_at           | username | full_name | avatar_url | website
+--------------------------------------+-------------------------------+----------+-----------+------------+---------
+ 15d6811a-16ee-4fa2-9b18-b63085688be4 | 2023-02-18 21:40:08.216324+00 | user1    | User 1    |            |
+ 4e1010bb-eb37-4a4d-a05a-b0ee315c9d56 | 2023-02-18 21:40:08.216324+00 | user2    | User 2    |            |
+ d4f0aa86-e6f6-41d1-bd32-391f077cf1b9 | 2023-02-18 21:40:08.216324+00 | user3    | User 3    |            |
+(3 rows)
+
+```
+
+</details>
 
 ## Deprecated features
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Documentation update to get started with testing RLS policies.

## What is the current behavior?

You need to google to find hints on how to switch roles (and JWT context).

## What is the new behavior?

When reading about supabase RLS, you'll immediately get pointed to testing your policies.

## Additional context

I think, it would be a good idea having those `login_*/logout()` procedures included in the `auth` schema by default because they seem to be of general interest (unless when not using RLS at all). The use of the internal `auth` schema might be a point of argument?
