### PR TITLE
Improve experience for unrecommended data types

### DIFF
--- a/packages/ui/src/components/Alert/Alert.tsx
+++ b/packages/ui/src/components/Alert/Alert.tsx
@@ -13,7 +13,7 @@ import { IconCheckCircle } from '../Icon/icons/IconCheckCircle'
 interface Props {
   variant?: 'success' | 'danger' | 'warning' | 'info' | 'neutral'
   className?: string
-  title: string
+  title: string | React.ReactNode
   withIcon?: boolean
   closable?: boolean
   children?: React.ReactNode
@@ -21,10 +21,7 @@ interface Props {
   actions?: React.ReactNode
 }
 
-const icons: Record<
-  'success' | 'danger' | 'warning' | 'info' | 'neutral',
-  React.ReactElement
-> = {
+const icons: Record<'success' | 'danger' | 'warning' | 'info' | 'neutral', React.ReactElement> = {
   danger: <IconAlertOctagon strokeWidth={1.5} size={18} />,
   success: <IconCheckCircle strokeWidth={1.5} size={18} />,
   warning: <IconAlertTriangle strokeWidth={1.5} size={18} />,
@@ -51,10 +48,7 @@ function Alert({
 
   if (className) containerClasses.push(className)
 
-  let descriptionClasses = [
-    __styles.description,
-    __styles.variant[variant].description,
-  ]
+  let descriptionClasses = [__styles.description, __styles.variant[variant].description]
   let closeButtonClasses = [__styles.close]
 
   return (
@@ -62,19 +56,12 @@ function Alert({
       {visible && (
         <div className={containerClasses.join(' ')}>
           {withIcon ? (
-            <div className={__styles.variant[variant].icon}>
-              {withIcon && icons[variant]}
-            </div>
+            <div className={__styles.variant[variant].icon}>{withIcon && icons[variant]}</div>
           ) : null}
           {icon && icon}
           <div className="flex flex-1 items-center justify-between">
             <div>
-              <h3
-                className={[
-                  __styles.variant[variant].header,
-                  __styles.header,
-                ].join(' ')}
-              >
+              <h3 className={[__styles.variant[variant].header, __styles.header].join(' ')}>
                 {title}
               </h3>
               <div className={descriptionClasses.join(' ')}>{children}</div>

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.tsx
@@ -191,7 +191,7 @@ const ColumnEditor: FC<Props> = ({
             label="Name"
             type="text"
             descriptionText="Recommended to use lowercase and use an underscore to separate words e.g. column_name"
-            placeholder='column_name'
+            placeholder="column_name"
             error={errors.name}
             value={columnFields?.name ?? ''}
             onChange={(event: any) => onUpdateField({ name: event.target.value })}
@@ -224,7 +224,28 @@ const ColumnEditor: FC<Props> = ({
       </FormSection>
       <SidePanel.Separator />
       <FormSection
-        header={<FormSectionLabel className="lg:!col-span-4">Data Type</FormSectionLabel>}
+        header={
+          <FormSectionLabel
+            className="lg:!col-span-4"
+            description={
+              <Link href="https://supabase.com/docs/guides/database/tables#data-types">
+                <a target="_blank" rel="noreferrer">
+                  <Button
+                    as="span"
+                    type="default"
+                    size="tiny"
+                    // className="text-scale-1000 hover:text-scale-1200"
+                    icon={<IconExternalLink size={14} strokeWidth={2} />}
+                  >
+                    About data types
+                  </Button>
+                </a>
+              </Link>
+            }
+          >
+            Data Type
+          </FormSectionLabel>
+        }
       >
         <FormSectionContent loading={false} className="lg:!col-span-8">
           <ColumnType
@@ -233,21 +254,6 @@ const ColumnEditor: FC<Props> = ({
             enumTypes={enumTypes}
             error={errors.format}
             disabled={!isUndefined(columnFields?.foreignKey)}
-            description={
-              <Link href="https://supabase.com/docs/guides/database/tables#data-types">
-                <a target="_blank" rel="noreferrer">
-                  <Button
-                    as="span"
-                    type="text"
-                    size="small"
-                    className="text-scale-1000 hover:text-scale-1200"
-                    icon={<IconExternalLink size={14} strokeWidth={2} />}
-                  >
-                    Learn more about data types
-                  </Button>
-                </a>
-              </Link>
-            }
             onOptionSelect={(format: string) => onUpdateField({ format, defaultValue: null })}
           />
           {isUndefined(columnFields.foreignKey) && (

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnType.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnType.tsx
@@ -1,8 +1,25 @@
 import React, { FC, ReactNode } from 'react'
-import { IconCalendar, IconType, IconHash, Listbox, IconToggleRight, Input } from 'ui'
+import {
+  IconCalendar,
+  IconType,
+  IconHash,
+  Listbox,
+  IconToggleRight,
+  Input,
+  Alert,
+  IconAlertCircle,
+  Button,
+  IconExternalLink,
+} from 'ui'
 import type { PostgresType } from '@supabase/postgres-meta'
-import { POSTGRES_DATA_TYPES, POSTGRES_DATA_TYPE_OPTIONS } from '../SidePanelEditor.constants'
+import {
+  POSTGRES_DATA_TYPES,
+  POSTGRES_DATA_TYPE_OPTIONS,
+  RECOMMENDED_ALTERNATIVE_DATA_TYPE,
+} from '../SidePanelEditor.constants'
 import { PostgresDataTypeOption } from '../SidePanelEditor.types'
+import InformationBox from 'components/ui/InformationBox'
+import Link from 'next/link'
 
 interface Props {
   value: string
@@ -32,6 +49,7 @@ const ColumnType: FC<Props> = ({
   // @ts-ignore
   const availableTypes = POSTGRES_DATA_TYPES.concat(enumTypes.map((type) => type.name))
   const isAvailableType = value ? availableTypes.includes(value) : true
+  const recommendation = RECOMMENDED_ALTERNATIVE_DATA_TYPE[value]
 
   if (!isAvailableType) {
     return (
@@ -74,75 +92,106 @@ const ColumnType: FC<Props> = ({
   }
 
   return (
-    <Listbox
-      label={showLabel ? 'Type' : ''}
-      layout={layout || (showLabel ? 'horizontal' : 'vertical')}
-      value={value}
-      size={size}
-      error={error}
-      disabled={disabled}
-      // @ts-ignore
-      descriptionText={description}
-      className={`${className} ${disabled ? 'column-type-disabled' : ''} rounded-md`}
-      onChange={(value: string) => onOptionSelect(value)}
-      optionsWidth={480}
-    >
-      <Listbox.Option key="empty" value="" label="---">
-        ---
-      </Listbox.Option>
+    <div className="space-y-2">
+      <Listbox
+        label={showLabel ? 'Type' : ''}
+        layout={layout || (showLabel ? 'horizontal' : 'vertical')}
+        value={value}
+        size={size}
+        error={error}
+        disabled={disabled}
+        // @ts-ignore
+        descriptionText={description}
+        className={`${className} ${disabled ? 'column-type-disabled' : ''} rounded-md`}
+        onChange={(value: string) => onOptionSelect(value)}
+        optionsWidth={480}
+      >
+        <Listbox.Option key="empty" value="" label="---">
+          ---
+        </Listbox.Option>
 
-      {/*
+        {/*
           Weird issue with Listbox here
           1. Can't do render conditionally (&&) within Listbox hence why using Fragment
           2. Can't wrap these 2 components within a Fragment conditional (enumTypes.length)
             as selecting the enumType option will not render it in the Listbox component
         */}
-      {enumTypes.length > 0 ? (
-        <Listbox.Option disabled key="header-1" value="header-1" label="header-1">
-          User-defined Enumerated Types
-        </Listbox.Option>
-      ) : (
-        <></>
-      )}
+        {enumTypes.length > 0 ? (
+          <Listbox.Option disabled key="header-1" value="header-1" label="header-1">
+            User-defined Enumerated Types
+          </Listbox.Option>
+        ) : (
+          <></>
+        )}
 
-      {enumTypes.length > 0 ? (
-        // @ts-ignore
-        enumTypes.map((enumType: PostgresType) => (
+        {enumTypes.length > 0 ? (
+          // @ts-ignore
+          enumTypes.map((enumType: PostgresType) => (
+            <Listbox.Option
+              key={enumType.name}
+              value={enumType.name}
+              label={enumType.name}
+              addOnBefore={() => {
+                return <div className="mx-1 h-2 w-2 rounded-full bg-scale-1200" />
+              }}
+            >
+              <div className="flex items-center space-x-4">
+                <p>{enumType.name}</p>
+              </div>
+            </Listbox.Option>
+          ))
+        ) : (
+          <></>
+        )}
+
+        <Listbox.Option disabled value="header-2" label="header-2">
+          PostgreSQL Data Types
+        </Listbox.Option>
+
+        {POSTGRES_DATA_TYPE_OPTIONS.map((option: PostgresDataTypeOption) => (
           <Listbox.Option
-            key={enumType.name}
-            value={enumType.name}
-            label={enumType.name}
-            addOnBefore={() => {
-              return <div className="mx-1 h-2 w-2 rounded-full bg-scale-1200" />
-            }}
+            key={option.name}
+            value={option.name}
+            label={option.name}
+            addOnBefore={() => inferIcon(option.type)}
           >
             <div className="flex items-center space-x-4">
-              <p>{enumType.name}</p>
+              <span className="text-scale-1200">{option.name}</span>
+              <span className="text-scale-900">{option.description}</span>
             </div>
           </Listbox.Option>
-        ))
-      ) : (
-        <></>
-      )}
-
-      <Listbox.Option disabled value="header-2" label="header-2">
-        PostgreSQL Data Types
-      </Listbox.Option>
-
-      {POSTGRES_DATA_TYPE_OPTIONS.map((option: PostgresDataTypeOption) => (
-        <Listbox.Option
-          key={option.name}
-          value={option.name}
-          label={option.name}
-          addOnBefore={() => inferIcon(option.type)}
+        ))}
+      </Listbox>
+      {recommendation !== undefined && (
+        <Alert
+          withIcon
+          variant="warning"
+          title={
+            <>
+              It is recommended to use <code className="text-xs">{recommendation.alternative}</code>{' '}
+              instead
+            </>
+          }
         >
-          <div className="flex items-center space-x-4">
-            <span className="text-scale-1200">{option.name}</span>
-            <span className="text-scale-900">{option.description}</span>
+          <p>
+            Postgres recommends against using the data type <code className="text-xs">{value}</code>{' '}
+            unless you have a very specific use case.
+          </p>
+          <div className="flex items-center space-x-2 mt-3">
+            <Link href={recommendation.reference}>
+              <a target="_blank">
+                <Button type="default" icon={<IconExternalLink />}>
+                  Read more
+                </Button>
+              </a>
+            </Link>
+            <Button type="primary" onClick={() => onOptionSelect(recommendation.alternative)}>
+              Use {recommendation.alternative}
+            </Button>
           </div>
-        </Listbox.Option>
-      ))}
-    </Listbox>
+        </Alert>
+      )}
+    </div>
   )
 }
 

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.constants.ts
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.constants.ts
@@ -16,6 +16,29 @@ export const POSTGRES_DATA_TYPES = sortBy(
   concat(NUMERICAL_TYPES, JSON_TYPES, TEXT_TYPES, DATETIME_TYPES, OTHER_DATA_TYPES)
 )
 
+export const RECOMMENDED_ALTERNATIVE_DATA_TYPE: {
+  [key: string]: { alternative: string; reference: string }
+} = {
+  varchar: {
+    alternative: 'text',
+    reference:
+      "https://wiki.postgresql.org/wiki/Don't_Do_This#Don.27t_use_varchar.28n.29_by_default",
+  },
+  json: {
+    alternative: 'jsonb',
+    reference: 'https://www.postgresql.org/docs/current/datatype-json.html',
+  },
+  timetz: {
+    alternative: 'timestamptz',
+    reference: "https://wiki.postgresql.org/wiki/Don't_Do_This#Don.27t_use_timetz",
+  },
+  timestamp: {
+    alternative: 'timestamptz',
+    reference:
+      "https://wiki.postgresql.org/wiki/Don't_Do_This#Don.27t_use_timestamp_.28without_time_zone.29",
+  },
+}
+
 export const POSTGRES_DATA_TYPE_OPTIONS: PostgresDataTypeOption[] = [
   {
     name: 'int2',
@@ -48,12 +71,22 @@ export const POSTGRES_DATA_TYPE_OPTIONS: PostgresDataTypeOption[] = [
     type: 'number',
   },
   {
+    name: 'json',
+    description: 'Textual JSON data',
+    type: 'json',
+  },
+  {
     name: 'jsonb',
     description: 'Binary JSON data, decomposed',
     type: 'json',
   },
   {
     name: 'text',
+    description: 'Variable-length character string',
+    type: 'text',
+  },
+  {
+    name: 'varchar',
     description: 'Variable-length character string',
     type: 'text',
   },
@@ -70,6 +103,16 @@ export const POSTGRES_DATA_TYPE_OPTIONS: PostgresDataTypeOption[] = [
   {
     name: 'time',
     description: 'Time of day (no time zone)',
+    type: 'time',
+  },
+  {
+    name: 'timetz',
+    description: 'Time of day, including time zone',
+    type: 'time',
+  },
+  {
+    name: 'timestamp',
+    description: 'Date and time (no time zone)',
     type: 'time',
   },
   {

--- a/studio/components/ui/Forms/FormSection.tsx
+++ b/studio/components/ui/Forms/FormSection.tsx
@@ -29,17 +29,28 @@ const FormSection = ({
 }
 
 const FormSectionLabel = ({
-  className = '',
   children,
+  className = '',
+  description,
 }: {
-  className?: string
   children: React.ReactNode | string
+  className?: string
+  description?: React.ReactNode
 }) => {
-  return (
-    <label className={`text-scale-1200 col-span-12 text-sm lg:col-span-5 ${className}`}>
-      {children}
-    </label>
-  )
+  if (description !== undefined) {
+    return (
+      <div className={`flex flex-col space-y-4 col-span-12 lg:col-span-5 ${className}`}>
+        <label className="text-scale-1200 text-sm">{children}</label>
+        {description}
+      </div>
+    )
+  } else {
+    return (
+      <label className={`text-scale-1200 col-span-12 text-sm lg:col-span-5 ${className}`}>
+        {children}
+      </label>
+    )
+  }
 }
 
 const Shimmer = () => (


### PR DESCRIPTION
Postgres recommends against using `varchar`, `json`, `timetz` and `timestamp` types

[Previously](https://github.com/supabase/supabase/pull/11294/files), we tried to enforce this recommendation by removing the data types from the dashboard but this resulted in quite a bit of confusion for why those data types are missing + UI errors. 

Former is definitely valid - the dashboard shouldn't be explicitly stopping users from trying to do what they normally can do.

Decided to put them back in and opt for the following UX instead:
![image](https://user-images.githubusercontent.com/19742402/216017790-77e9e199-7b9d-4ee5-9b08-1a027fea503c.png)

Read more will link to the documentation which explains why the data type is not recommended