### PR TITLE
fix: calculating estimated cost

### DIFF
--- a/studio/components/interfaces/Billing/Subscription/Subscription.tsx
+++ b/studio/components/interfaces/Billing/Subscription/Subscription.tsx
@@ -62,7 +62,7 @@ const Subscription: FC<Props> = ({
         ? 0
         : Object.keys(usage)
             .map((productKey) => {
-              return usage[productKey].cost
+              return usage[productKey].cost ?? 0
             })
             .reduce((prev, current) => prev + current, 0)
 


### PR DESCRIPTION
Not every object inside the usage response has a `.cost` property (i.e. newly introduced `disk_volume_gb`), so we need to ensure that these properties don't result in calculation errors (NaN).

![image](https://user-images.githubusercontent.com/14073399/216102047-690e0163-d418-4816-b5f3-a4e4c8a3051f.png)
