### PR TITLE
Add link to python docs in dashboard

### DIFF
--- a/studio/components/interfaces/Home/Home.constants.ts
+++ b/studio/components/interfaces/Home/Home.constants.ts
@@ -10,7 +10,7 @@ export const CLIENT_LIBRARIES = [
     language: 'Python',
     officialSupport: false,
     releaseState: 'Alpha',
-    docsUrl: undefined,
+    docsUrl: 'https://supabase.com/docs/reference/python/introduction',
     gitUrl: 'https://github.com/supabase/supabase-py',
   },
   {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add link to python docs in dashboard.

## What is the current behavior?

No link to python docs in dashboard.

## What is the new behavior?

link to python docs in dashboard.