### PR TITLE
Add link to youtube in docs footer

### DIFF
--- a/apps/docs/components/Navigation/Footer.tsx
+++ b/apps/docs/components/Navigation/Footer.tsx
@@ -1,6 +1,6 @@
 import Image from 'next/image'
 import Link from 'next/link'
-import { Button, IconGitHub, IconTwitter } from '~/../../packages/ui'
+import { Button, IconGitHub, IconTwitter, IconYoutube } from '~/../../packages/ui'
 import footerData from '~/data/footer.json'
 import { useTheme } from 'common/Providers'
 
@@ -20,6 +20,16 @@ const Footer = () => {
           ))}
         </div>
         <div className="flex items-center gap-2">
+          <Button
+            type="text"
+            as="a"
+            // @ts-ignore
+            href="https://youtube.com/c/supabase"
+            target="_blank"
+            rel="noreferrer noopener"
+          >
+            <IconYoutube size={16} />
+          </Button>
           <Button
             type="text"
             as="a"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add link to youtube in docs footer.

## What is the current behavior?

No link to youtube in docs footer.

## What is the new behavior?

link to youtube in docs footer

## Additional context

![CleanShot 2023-02-01 at 20 21 08@2x](https://user-images.githubusercontent.com/70828596/216207614-1703dfd0-82e4-44b6-98ce-b1d65b62bb19.png)