### PR TITLE
Fix: table cell selection

### DIFF
--- a/studio/styles/grid.scss
+++ b/studio/styles/grid.scss
@@ -32,7 +32,7 @@
   @apply border-scale-400 dark:border-scale-500 border-r-4 shadow-none;
 }
 
-.rdg-cell-selected {
+.rdg-cell[aria-selected='true'] {
   box-shadow: inset 0 0 0 1px #24b47e;
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix table cell selection to match supabase color scheme

## What is the current behavior?

Table cell selection do not match supabase color scheme

![CleanShot 2023-02-01 at 22 32 15@2x](https://user-images.githubusercontent.com/70828596/216225260-5b5fce83-d47c-4fca-a200-f3ed83759881.png)

## What is the new behavior?

Table cell selection match supabase color scheme

![CleanShot 2023-02-01 at 22 32 19@2x](https://user-images.githubusercontent.com/70828596/216225271-0df578eb-bfcb-4949-82c9-d6095c6578bb.png)