### PR TITLE
Update github actions docs

### DIFF
--- a/apps/docs/pages/guides/functions/examples/github-actions.mdx
+++ b/apps/docs/pages/guides/functions/examples/github-actions.mdx
@@ -31,8 +31,8 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-      PROJECT_ID: zdtdtxajzydjqzuktnqx
+      SUPABASE_ACCESS_TOKEN: YOUR_SUPABASE_ACCESS_TOKEN
+      PROJECT_ID: YOUR_SUPABASE_PROJECT_ID
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## What kind of change does this PR introduce?

Updates the [github actions docs](https://supabase.com/docs/guides/functions/examples/github-actions) to hide the project id and to make it easier for people to know where to put their `project ID` and `access token`

## What is the current behavior?

random project id

## What is the new behavior?

no random project id and easier to find where to put your `project ID` and `access token`