### PR TITLE
fix: remove credentials: 'include' from fetch requests

### DIFF
--- a/studio/lib/common/fetch/delete.ts
+++ b/studio/lib/common/fetch/delete.ts
@@ -14,7 +14,6 @@ export async function delete_<T = any>(
     const response = await fetch(url, {
       method: 'DELETE',
       body: JSON.stringify(data),
-      credentials: 'include',
       referrerPolicy: 'no-referrer-when-downgrade',
       headers,
       ...otherOptions,

--- a/studio/lib/common/fetch/get.ts
+++ b/studio/lib/common/fetch/get.ts
@@ -12,7 +12,6 @@ export async function get<T = any>(
     const headers = await constructHeaders(requestId, optionHeaders)
     const response = await fetch(url, {
       method: 'GET',
-      credentials: 'include',
       referrerPolicy: 'no-referrer-when-downgrade',
       headers,
       ...otherOptions,
@@ -37,7 +36,6 @@ export async function getWithTimeout<T = any>(
     const headers = await constructHeaders(requestId, optionHeaders)
     const response = await fetch(url, {
       method: 'GET',
-      credentials: 'include',
       referrerPolicy: 'no-referrer-when-downgrade',
       headers,
       ...otherOptions,

--- a/studio/lib/common/fetch/head.ts
+++ b/studio/lib/common/fetch/head.ts
@@ -13,7 +13,6 @@ export async function head<T = any>(
     const headers = await constructHeaders(requestId, optionHeaders)
     const response = await fetch(url, {
       method: 'HEAD',
-      credentials: 'include',
       referrerPolicy: 'no-referrer-when-downgrade',
       headers,
       ...otherOptions,
@@ -39,7 +38,6 @@ export async function headWithTimeout<T = any>(
     const headers = await constructHeaders(requestId, optionHeaders)
     const response = await fetch(url, {
       method: 'HEAD',
-      credentials: 'include',
       referrerPolicy: 'no-referrer-when-downgrade',
       headers,
       ...otherOptions,

--- a/studio/lib/common/fetch/patch.ts
+++ b/studio/lib/common/fetch/patch.ts
@@ -14,7 +14,6 @@ export async function patch<T = any>(
     const response = await fetch(url, {
       method: 'PATCH',
       body: JSON.stringify(data),
-      credentials: 'include',
       referrerPolicy: 'no-referrer-when-downgrade',
       headers,
       ...otherOptions,

--- a/studio/lib/common/fetch/post.ts
+++ b/studio/lib/common/fetch/post.ts
@@ -14,7 +14,6 @@ export async function post<T = any>(
     const response = await fetch(url, {
       method: 'POST',
       body: JSON.stringify(data),
-      credentials: 'include',
       referrerPolicy: 'no-referrer-when-downgrade',
       headers,
       ...otherOptions,


### PR DESCRIPTION
All our fetch requests are sent with `credentials: 'include'`. Some API routes seem to return `Access-Control-Allow-Origin: *`, which isn't allowed with `credentials: 'include'`.

Before this PR can be merged we need to confirm there aren't any cookies being used for cross-domain requests.