### PR TITLE
chore: show/elaborate disk size

### DIFF
--- a/apps/docs/pages/guides/platform/database-usage.mdx
+++ b/apps/docs/pages/guides/platform/database-usage.mdx
@@ -12,8 +12,10 @@ Database size is the total size of used storage from your database, whereas disk
 For an instantaneous live view of the DB size, you can execute in Postgres:
 
 ```sql
-select sum(pg_database_size(pg_database.datname)) / (1024 * 1024) as db_size_mb
-from pg_database;
+select
+  sum(pg_database_size (pg_database.datname)) / (1024 * 1024) as db_size_mb
+from
+  pg_database;
 ```
 
 This value is also reported in the [database settings page](https://app.supabase.com/project/_/settings/database).
@@ -37,15 +39,16 @@ If you need more than 1024TB of disk size or require multiple storage expansions
 2. Delete data from your project's database to lower its disk usage. If your database is already in read-only mode, run the following command to change the transaction mode to read-write for your session:
 
    ```sql
-   SET default_transaction_read_only = 'off';
+   SET
+     default_transaction_read_only = 'off';
    ```
 
    This allows you to delete data from within the session.
 
 ### Preoccupied Space
 
-When launching a new project, several extensions will be installed to your project.
-This uses ~40-60mb and will be included in your database size.
+When launching a new project, your database size will be roughly ~40-60mb.
+The space is used up by preinstalled extensions, schema/data used by our services that are offered with each project and default Postgres data.
 
 When installing additional extensions, even if you don't actively use them, additional database size is used.
 

--- a/apps/docs/pages/guides/platform/database-usage.mdx
+++ b/apps/docs/pages/guides/platform/database-usage.mdx
@@ -18,8 +18,6 @@ from pg_database;
 
 This value is also reported in the [database settings page](https://app.supabase.com/project/_/settings/database).
 
-
-
 ## Database storage management
 
 Supabase uses network-attached storage to balance performance with scalability.

--- a/apps/docs/pages/guides/platform/database-usage.mdx
+++ b/apps/docs/pages/guides/platform/database-usage.mdx
@@ -17,6 +17,8 @@ from pg_database;
 
 This value is also reported in the [database settings page](https://app.supabase.com/project/_/settings/database).
 
+Disk size describes the size of the underlying storage, whereas database size is the total size of used storage from your database.
+
 ## Database storage management
 
 Supabase uses network-attached storage to balance performance with scalability. For Pro and Enterprise projects, database storage expands ~1.5x automatically (e.g., 8GB -> 12GB) when you reach 90% of the database storage quota. Automatic database storage expansion can only occur once every six hours. Pro projects can store up to 1024TB.
@@ -36,6 +38,13 @@ If you need more than 1024TB of database storage or require multiple storage exp
    ```
 
    This allows you to delete data from within the session.
+
+### Preoccupied Space
+
+When launching a new project, several extensions will be installed to your project.
+This uses ~40-60mb and will be included in your database size.
+
+When installing additional extensions, even if you don't actively use them, additional database size is used.
 
 ## Vacuum operations
 

--- a/apps/docs/pages/guides/platform/database-usage.mdx
+++ b/apps/docs/pages/guides/platform/database-usage.mdx
@@ -6,9 +6,10 @@ export const meta = {
   description: 'Understanding how database usage applies to your subscription.',
 }
 
-Database storage refers to the _monthly average storage usage_, as reported by Postgres. This metric is reported in your project's [billing usage](https://app.supabase.com/project/_/settings/billing/usage) and is updated daily.
+Database size refers to the _monthly average storage usage_, as reported by Postgres. This metric is reported in your project's [billing usage](https://app.supabase.com/project/_/settings/billing/usage) and is updated daily.
+Database size is the total size of used storage from your database, whereas disk size describes the size of the underlying available storage.
 
-For an instantaneous live view of the DB storage usage, you can execute in Postgres:
+For an instantaneous live view of the DB size, you can execute in Postgres:
 
 ```sql
 select sum(pg_database_size(pg_database.datname)) / (1024 * 1024) as db_size_mb
@@ -17,19 +18,23 @@ from pg_database;
 
 This value is also reported in the [database settings page](https://app.supabase.com/project/_/settings/database).
 
-Disk size describes the size of the underlying storage, whereas database size is the total size of used storage from your database.
+
 
 ## Database storage management
 
-Supabase uses network-attached storage to balance performance with scalability. For Pro and Enterprise projects, database storage expands ~1.5x automatically (e.g., 8GB -> 12GB) when you reach 90% of the database storage quota. Automatic database storage expansion can only occur once every six hours. Pro projects can store up to 1024TB.
+Supabase uses network-attached storage to balance performance with scalability.
+For Pro and Enterprise projects, disk size expands ~1.5x automatically (e.g., 8GB -> 12GB) when you reach 90% of the disk size.
+Automatic disk size expansion can only occur once every six hours.
+Pro projects can store up to 1024TB.
 
-All projects enter read-only mode when you reach 95% of the database storage quota. In read-only mode, clients will encounter errors such as `cannot execute INSERT in a read-only transaction`. Regular operation (read-write mode) is automatically re-enabled once usage is below 95% of the database storage quota.
+All projects enter read-only mode when you reach 95% of the disk size. In read-only mode, clients will encounter errors such as `cannot execute INSERT in a read-only transaction`.
+Regular operation (read-write mode) is automatically re-enabled once usage is below 95% of the disk size.
 
-If you need more than 1024TB of database storage or require multiple storage expansions in a short period of time, [contact us](https://app.supabase.com/support/new) to learn more about the Enterprise plan.
+If you need more than 1024TB of disk size or require multiple storage expansions in a short period of time, [contact us](https://app.supabase.com/support/new) to learn more about the Enterprise plan.
 
-### Increasing available database storage
+### Increasing available disk size
 
-1. [Upgrade to the Pro or Enterprise plan](https://app.supabase.com/project/_/settings/billing/subscription) to increase your storage quota.
+1. [Upgrade to the Pro or Enterprise plan](https://app.supabase.com/project/_/settings/billing/subscription) to increase your quota and expand your disk size automatically.
 
 2. Delete data from your project's database to lower its disk usage. If your database is already in read-only mode, run the following command to change the transaction mode to read-write for your session:
 

--- a/apps/www/data/Pricing.json
+++ b/apps/www/data/Pricing.json
@@ -22,7 +22,7 @@
       },
       {
         "title": "Database space",
-        "tooltip": "Billing is based on the average database size in GB throughout the billing period.",
+        "tooltip": "Billing is based on the average daily database size in GB throughout the billing period.",
         "tiers": {
           "free": "Up to 500 MB",
           "pro": "8 GB included, then $0.125 per GB",

--- a/apps/www/data/Pricing.json
+++ b/apps/www/data/Pricing.json
@@ -21,7 +21,7 @@
         }
       },
       {
-        "title": "Database space",
+        "title": "Database size",
         "tooltip": "Billing is based on the average daily database size in GB throughout the billing period.",
         "tiers": {
           "free": "Up to 500 MB",

--- a/studio/components/interfaces/Billing/Billing.constants.tsx
+++ b/studio/components/interfaces/Billing/Billing.constants.tsx
@@ -1,4 +1,4 @@
-import { IconArchive, IconCode, IconDatabase, IconKey } from 'ui'
+import { Badge, IconArchive, IconCode, IconDatabase, IconKey } from 'ui'
 
 export const CANCELLATION_REASONS = [
   'Pricing',
@@ -30,8 +30,10 @@ export const USAGE_BASED_PRODUCTS = [
         costPerUnit: 0.125,
         tooltip: (
           <span>
-            We continuously monitor the total size of your database. Billing is based on the average
-            database size in GB throughout the billing period.
+            Billing is based on the average daily database size in GB throughout the billing period.{' '}
+            <a href="https://supabase.com/docs/guides/platform/database-usage" target="_blank">
+              Docs
+            </a>
           </span>
         ),
       },

--- a/studio/components/interfaces/Billing/Billing.constants.tsx
+++ b/studio/components/interfaces/Billing/Billing.constants.tsx
@@ -25,7 +25,7 @@ export const USAGE_BASED_PRODUCTS = [
       {
         key: 'db_size',
         attribute: 'total_db_size_bytes',
-        title: 'Database space',
+        title: 'Database size',
         units: 'bytes',
         costPerUnit: 0.125,
         tooltip: (

--- a/studio/components/interfaces/Billing/ProUpgrade.tsx
+++ b/studio/components/interfaces/Billing/ProUpgrade.tsx
@@ -394,7 +394,7 @@ const ProUpgrade: FC<Props> = ({
                 </div>
                 <div className="py-1">
                   <div className="flex items-center px-4 py-1">
-                    <p className="w-[50%] text-sm">Database space</p>
+                    <p className="w-[50%] text-sm">Database size</p>
                     <p className="w-[25%] text-sm">8GB</p>
                     <p className="w-[25%] text-sm">$0.125/GB</p>
                   </div>

--- a/studio/components/interfaces/Billing/Subscription/Subscription.tsx
+++ b/studio/components/interfaces/Billing/Subscription/Subscription.tsx
@@ -14,7 +14,7 @@ import CostBreakdownRow from './CostBreakdownRow'
 import { StripeSubscription } from './Subscription.types'
 import NoPermission from 'components/ui/NoPermission'
 import { USAGE_BASED_PRODUCTS } from 'components/interfaces/Billing/Billing.constants'
-import { ProjectUsageResponse, useProjectUsageQuery } from 'data/usage/project-usage-query'
+import { ProjectUsagResponseUsageKeys, useProjectUsageQuery } from 'data/usage/project-usage-query'
 
 interface Props {
   project: any
@@ -62,7 +62,7 @@ const Subscription: FC<Props> = ({
         ? 0
         : Object.keys(usage)
             .map((productKey) => {
-              return usage[productKey as keyof ProjectUsageResponse].cost ?? 0
+              return usage[productKey as ProjectUsagResponseUsageKeys].cost ?? 0
             })
             .reduce((prev, current) => prev + current, 0)
 
@@ -183,10 +183,10 @@ const Subscription: FC<Props> = ({
               {isPayg &&
                 USAGE_BASED_PRODUCTS.map((product) => {
                   return product.features.map((feature) => {
-                    const amount = usage?.[feature.key as keyof ProjectUsageResponse]?.usage ?? 0
-                    const limit = usage?.[feature.key as keyof ProjectUsageResponse]?.limit ?? 0
+                    const amount = usage?.[feature.key as ProjectUsagResponseUsageKeys]?.usage ?? 0
+                    const limit = usage?.[feature.key as ProjectUsagResponseUsageKeys]?.limit ?? 0
                     const cost = (
-                      usage?.[feature.key as keyof ProjectUsageResponse]?.cost ?? 0
+                      usage?.[feature.key as ProjectUsagResponseUsageKeys]?.cost ?? 0
                     ).toFixed(2)
 
                     return (

--- a/studio/components/interfaces/Home/ProjectUsageSection.tsx
+++ b/studio/components/interfaces/Home/ProjectUsageSection.tsx
@@ -5,7 +5,7 @@ import { IconLoader, IconAlertCircle } from 'ui'
 import { useParams } from 'hooks'
 import { ProjectUsage, NewProjectPanel } from 'components/interfaces/Home'
 import InformationBox from 'components/ui/InformationBox'
-import { ProjectUsageResponse, useProjectUsageQuery } from 'data/usage/project-usage-query'
+import { ProjectUsagResponseUsageKeys, useProjectUsageQuery } from 'data/usage/project-usage-query'
 
 const ProjectUsageSection: FC = observer(({}) => {
   const { ref: projectRef } = useParams()
@@ -24,7 +24,7 @@ const ProjectUsageSection: FC = observer(({}) => {
 
   const hasProjectData = usage
     ? Object.keys(usage)
-        .map((key) => usage[key as keyof ProjectUsageResponse].usage)
+        .map((key) => usage[key as ProjectUsagResponseUsageKeys].usage)
         .some((usage) => (usage ?? 0) > 0)
     : false
 

--- a/studio/components/interfaces/Settings/ProjectUsageBars/ProjectUsageBars.tsx
+++ b/studio/components/interfaces/Settings/ProjectUsageBars/ProjectUsageBars.tsx
@@ -1,5 +1,5 @@
 import { FC, useEffect } from 'react'
-import { Badge, Button, IconAlertCircle, IconInfo, Loading } from 'ui'
+import { Badge, Button, IconAlertCircle, IconInfo, Loading, IconExternalLink } from 'ui'
 
 import { useStore } from 'hooks'
 import { formatBytes } from 'lib/helpers'
@@ -40,6 +40,8 @@ const ProjectUsage: FC<Props> = ({ projectRef }) => {
 
   const planName = subscriptionTier ? planNames[subscriptionTier] || 'current' : 'current'
 
+  console.log({ subscriptionTier })
+
   useEffect(() => {
     if (error) {
       ui.setNotification({
@@ -58,6 +60,26 @@ const ProjectUsage: FC<Props> = ({ projectRef }) => {
         title="There was an issue loading the usage details of your project"
       />
     )
+  }
+
+  const isPaidTier = subscriptionTier !== PRICING_TIER_PRODUCT_IDS.FREE
+
+  const featureFootnotes: Record<string, JSX.Element> = {
+    db_size: (
+      <div className="flex justify-between items-center">
+        <div className="flex flex-row space-x-4 text-scale-1000">
+          {usage?.disk_volume_size_gb && <span>Disk Size: {usage.disk_volume_size_gb} GB</span>}
+
+          {isPaidTier && <Badge>Auto-Scaling</Badge>}
+        </div>
+
+        <Button type="default" icon={<IconExternalLink size={14} strokeWidth={1.5} />}>
+          <a target="_blank" href="https://supabase.com/docs/guides/platform/database-usage">
+            What is disk size?
+          </a>
+        </Button>
+      </div>
+    ),
   }
 
   return (
@@ -171,7 +193,7 @@ const ProjectUsage: FC<Props> = ({ projectRef }) => {
                           )
                         }
 
-                        return (
+                        return [
                           <tr
                             key={feature.title}
                             className="border-t border-panel-border-light dark:border-panel-border-dark"
@@ -217,8 +239,18 @@ const ProjectUsage: FC<Props> = ({ projectRef }) => {
                                 </td>
                               </>
                             )}
-                          </tr>
-                        )
+                          </tr>,
+                          featureFootnotes[feature.key] && (
+                            <tr>
+                              <td
+                                className="whitespace-nowrap px-6 py-3 text-sm text-scale-1200"
+                                colSpan={3}
+                              >
+                                {featureFootnotes[feature.key]}
+                              </td>
+                            </tr>
+                          ),
+                        ]
                       })}
                     </tbody>
                   )}

--- a/studio/components/interfaces/Settings/ProjectUsageBars/ProjectUsageBars.tsx
+++ b/studio/components/interfaces/Settings/ProjectUsageBars/ProjectUsageBars.tsx
@@ -8,7 +8,7 @@ import SparkBar from 'components/ui/SparkBar'
 import ShimmeringLoader from 'components/ui/ShimmeringLoader'
 import InformationBox from 'components/ui/InformationBox'
 import { USAGE_BASED_PRODUCTS } from 'components/interfaces/Billing/Billing.constants'
-import { ProjectUsageResponse, useProjectUsageQuery } from 'data/usage/project-usage-query'
+import { ProjectUsagResponseUsageKeys, useProjectUsageQuery } from 'data/usage/project-usage-query'
 import { useRouter } from 'next/router'
 import * as Tooltip from '@radix-ui/react-tooltip'
 
@@ -89,7 +89,7 @@ const ProjectUsage: FC<Props> = ({ projectRef }) => {
               showUsageExceedMessage &&
               product.features
                 .map((feature) => {
-                  const featureUsage = usage[feature.key as keyof ProjectUsageResponse]
+                  const featureUsage = usage[feature.key as ProjectUsagResponseUsageKeys]
                   return (featureUsage.usage ?? 0) / featureUsage.limit > 1
                 })
                 .some((x) => x === true)
@@ -136,7 +136,7 @@ const ProjectUsage: FC<Props> = ({ projectRef }) => {
                   ) : (
                     <tbody>
                       {product.features.map((feature) => {
-                        const featureUsage = usage[feature.key as keyof ProjectUsageResponse]
+                        const featureUsage = usage[feature.key as ProjectUsagResponseUsageKeys]
                         const usageValue = featureUsage.usage || 0
                         const usageRatio = usageValue / featureUsage.limit
                         const isApproaching = usageRatio >= USAGE_APPROACHING_THRESHOLD

--- a/studio/components/interfaces/Settings/ProjectUsageBars/ProjectUsageBars.tsx
+++ b/studio/components/interfaces/Settings/ProjectUsageBars/ProjectUsageBars.tsx
@@ -239,7 +239,7 @@ const ProjectUsage: FC<Props> = ({ projectRef }) => {
                             )}
                           </tr>,
                           featureFootnotes[feature.key] && (
-                            <tr>
+                            <tr key={`${feature.title}-footnote`}>
                               <td
                                 className="whitespace-nowrap px-6 py-3 text-sm text-scale-1200"
                                 colSpan={3}

--- a/studio/components/interfaces/Settings/ProjectUsageBars/ProjectUsageBars.tsx
+++ b/studio/components/interfaces/Settings/ProjectUsageBars/ProjectUsageBars.tsx
@@ -40,8 +40,6 @@ const ProjectUsage: FC<Props> = ({ projectRef }) => {
 
   const planName = subscriptionTier ? planNames[subscriptionTier] || 'current' : 'current'
 
-  console.log({ subscriptionTier })
-
   useEffect(() => {
     if (error) {
       ui.setNotification({

--- a/studio/components/interfaces/Settings/ProjectUsageBars/ProjectUsageMinimal.tsx
+++ b/studio/components/interfaces/Settings/ProjectUsageBars/ProjectUsageMinimal.tsx
@@ -1,7 +1,7 @@
 import { FC } from 'react'
 import { Loading } from 'ui'
 
-import { ProjectUsageResponse, useProjectUsageQuery } from 'data/usage/project-usage-query'
+import { ProjectUsagResponseUsageKeys, useProjectUsageQuery } from 'data/usage/project-usage-query'
 import { useProjectSubscriptionQuery } from 'data/subscriptions/project-subscription-query'
 import { formatBytes } from 'lib/helpers'
 import { PRICING_TIER_PRODUCT_IDS, USAGE_APPROACHING_THRESHOLD } from 'lib/constants'
@@ -41,7 +41,7 @@ const ProjectUsageMinimal: FC<ProjectUsageMinimalProps> = ({ projectRef, filter 
       {usage && (
         <div className="space-y-8">
           {product.features.map((feature) => {
-            const featureUsage = usage[feature.key as keyof ProjectUsageResponse]
+            const featureUsage = usage[feature.key as ProjectUsagResponseUsageKeys]
             const usageRatio = (featureUsage.usage ?? 0) / featureUsage.limit
             const isApproaching = usageRatio >= USAGE_APPROACHING_THRESHOLD
             const isExceeded = usageRatio >= 1

--- a/studio/data/usage/project-usage-query.ts
+++ b/studio/data/usage/project-usage-query.ts
@@ -51,6 +51,7 @@ export type ProjectUsageResponse = {
   storage_size: StorageSize
   storage_egress: StorageEgress
   monthly_active_users: MonthlyActiveUsers
+  disk_volume_size_gb: number
 }
 
 export async function getProjectUsage({ projectRef }: ProjectUsageVariables, signal?: AbortSignal) {

--- a/studio/data/usage/project-usage-query.ts
+++ b/studio/data/usage/project-usage-query.ts
@@ -54,6 +54,8 @@ export type ProjectUsageResponse = {
   disk_volume_size_gb: number
 }
 
+export type ProjectUsagResponseUsageKeys = keyof Omit<ProjectUsageResponse, 'disk_volume_size_gb'>
+
 export async function getProjectUsage({ projectRef }: ProjectUsageVariables, signal?: AbortSignal) {
   if (!projectRef) {
     throw new Error('projectRef is required')


### PR DESCRIPTION
- Emphasize that billing is based on **daily** average database size
- Add a few notes in the docs regarding preoccupied space and disk size vs database size
- Added link to docs on usage page and an info about current disk size / auto scaling
- Streamlined wording (disk size instead of database storage, database size instead of database space)

<img width="1087" alt="Screenshot 2023-02-02 at 10 02 05" src="https://user-images.githubusercontent.com/14073399/216286017-22d6d38d-fe63-482f-88a5-31cecd8c304c.png">

<img width="1089" alt="Screenshot 2023-02-02 at 09 59 29" src="https://user-images.githubusercontent.com/14073399/216286027-671e0f46-4782-4eae-98ef-a65769e8df80.png">
