### PR TITLE
fix: remove POSTGRES_USER in .env.example

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -15,9 +15,8 @@ SERVICE_ROLE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJzZX
 
 POSTGRES_HOST=db
 POSTGRES_DB=postgres
-POSTGRES_USER=postgres
 POSTGRES_PORT=5432
-
+# default user is postgres
 
 ############
 # API Proxy - Configuration for the Kong Reverse proxy.


### PR DESCRIPTION
Can't change the database user, because POSTGRES_USER is not used in the docker-compose file or anywhere.

