### PR TITLE
fix: build studio docker as standalone app

### DIFF
--- a/studio/Dockerfile
+++ b/studio/Dockerfile
@@ -14,52 +14,37 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     && rm -rf /var/lib/apt/lists/*
 RUN npm i -g turbo
-
-# Calculate if dependencies are outdated
-FROM base as turbo
 WORKDIR /app
-COPY . .
+
 # Prune unneeded dependencies with turbo (from apps/ for example)
+FROM base as turbo
+COPY . .
 RUN turbo prune --scope=studio --docker
 
 # Install dev dependencies (only if needed)
 FROM base as deps
-WORKDIR /app
-COPY --from=turbo /app/out/json/ .
+COPY --from=turbo /app/out/json ./
 COPY --from=turbo /app/out/package-lock.json ./
-RUN npm clean-install && npm cache clean --force
+RUN npm clean-install
 
-FROM deps as deps-prod
-RUN npm prune --production
-# Remove packages dependencies (not needed in production)
-RUN rm -rf /app/packages
-
-# builder contains dependencies and source code not compiled
-FROM deps as builder
-WORKDIR /app
+# dev contains dependencies and source code not compiled
+FROM deps as dev
 COPY --from=turbo /app/out/full ./
 ENTRYPOINT ["docker-entrypoint.sh"]
-
-FROM builder as dev
 EXPOSE 8082
-CMD ["npx", "turbo", "run", "dev", "--filter=studio"]
+CMD ["npm", "run", "dev:studio"]
 
 # Compile NextJS
-FROM builder as productionprep
-WORKDIR /app
-RUN npx turbo run build --scope=studio --include-dependencies --no-deps \
-    && rm -rf ./studio/.next/cache/webpack
+FROM dev as builder
+RUN npx turbo run build --scope=studio --include-dependencies --no-deps
 
 # Copy only compiled code and dependencies
 FROM node:16-slim as production
-# Copy package(s).json and package-lock.json
-COPY --from=turbo /app/out/json /app
-# Copy all dependencies for production
-COPY --from=deps-prod /app /app
-# Copy necessary files
-COPY --from=turbo /app/out/full/studio /app/studio
-COPY --from=productionprep /app/studio/.next /app/studio/.next
-WORKDIR /app/studio
+WORKDIR /app
+COPY --from=builder /app/studio/public ./studio/public
+COPY --from=builder /app/studio/.next/standalone/app ./
+COPY --from=builder /app/studio/.next/static ./studio/.next/static
 EXPOSE 3000
+ENTRYPOINT ["docker-entrypoint.sh"]
 HEALTHCHECK --interval=5s --timeout=5s --retries=3 CMD node -e "require('http').get('http://localhost:3000/api/profile', (r) => {if (r.statusCode !== 200) throw new Error(r.statusCode)})"
-CMD ["npm", "run", "start"]
+CMD ["node", "studio/server.js"]

--- a/studio/Dockerfile
+++ b/studio/Dockerfile
@@ -9,22 +9,20 @@
 #    docker builder prune
 
 FROM node:16-slim as base
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    python3 \
-    build-essential \
-    && rm -rf /var/lib/apt/lists/*
-RUN npm i -g turbo
+
 WORKDIR /app
 
 # Prune unneeded dependencies with turbo (from apps/ for example)
 FROM base as turbo
 COPY . .
-RUN turbo prune --scope=studio --docker
+# Upstream bug: https://github.com/vercel/turbo/issues/3570
+RUN npx turbo@1.7.0 prune --scope=studio --docker
 
 # Install dev dependencies (only if needed)
 FROM base as deps
 COPY --from=turbo /app/out/json ./
 COPY --from=turbo /app/out/package-lock.json ./
+# No need to clean cache because production uses standalone build
 RUN npm clean-install
 
 # dev contains dependencies and source code not compiled

--- a/studio/Dockerfile
+++ b/studio/Dockerfile
@@ -37,8 +37,7 @@ FROM dev as builder
 RUN npx turbo run build --scope=studio --include-dependencies --no-deps
 
 # Copy only compiled code and dependencies
-FROM node:16-slim as production
-WORKDIR /app
+FROM base as production
 COPY --from=builder /app/studio/public ./studio/public
 COPY --from=builder /app/studio/.next/standalone/app ./
 COPY --from=builder /app/studio/.next/static ./studio/.next/static

--- a/studio/next.config.js
+++ b/studio/next.config.js
@@ -7,6 +7,9 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
 // this is required to use shared packages in the packages directory
 const withTM = require('next-transpile-modules')(['ui', 'common'])
 
+// Required for nextjs standalone build
+const path = require('path')
+
 // This file sets a custom webpack configuration to use your Next.js app
 // with Sentry.
 // https://nextjs.org/docs/api-reference/next.config.js/introduction
@@ -165,6 +168,11 @@ const nextConfig = {
   },
   images: {
     domains: ['github.com'],
+  },
+  // Ref: https://nextjs.org/docs/advanced-features/output-file-tracing#caveats
+  experimental: {
+    outputStandalone: true,
+    outputFileTracingRoot: path.join(__dirname, '../../'),
   },
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

chore

## What is the current behavior?

- studio source code is copied into production container
- build fails due to upstream turbo bug https://github.com/vercel/turbo/issues/3570

## What is the new behavior?

- build nextjs as standalone app for production docker
- pins turbo version to 1.7.0

## Additional context

current build error https://github.com/supabase/supabase/actions/runs/4072304964/jobs/7033349577
- [x] tested locally