### PR TITLE
fix: add dependencies for arm64 docker build

### DIFF
--- a/docker/dev/docker-compose.dev.yml
+++ b/docker/dev/docker-compose.dev.yml
@@ -1,6 +1,13 @@
 version: "3.8"
 
 services:
+  studio:
+    build:
+      context: ..
+      dockerfile: studio/Dockerfile
+      target: dev
+    ports:
+      - 8082:8082
   mail:
     container_name: supabase-mail
     image: inbucket/inbucket:3.0.3

--- a/studio/Dockerfile
+++ b/studio/Dockerfile
@@ -22,6 +22,13 @@ RUN npx turbo@1.7.0 prune --scope=studio --docker
 FROM base as deps
 COPY --from=turbo /app/out/json ./
 COPY --from=turbo /app/out/package-lock.json ./
+# Install additional dependencies for arm64 build (required by bufferutil)
+ARG TARGETARCH
+RUN if [ "$TARGETARCH" = "arm64" ]; then \
+    apt-get update && apt-get install -y --no-install-recommends \
+    python3 \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*; fi
 # No need to clean cache because production uses standalone build
 RUN npm clean-install
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

follow up #12140 

## What is the current behavior?

websockets/bufferutil does not distribute linux arm64 build

## What is the new behavior?

include python to build from source

## Additional context

Add any other context or screenshots.
