### PR TITLE
useSupabase function doesn't work in Next 13 docs

### DIFF
--- a/apps/docs/pages/guides/auth/auth-helpers/nextjs-server-components.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/nextjs-server-components.mdx
@@ -295,11 +295,12 @@ export default function SupabaseProvider({ children }: { children: React.ReactNo
 }
 
 export const useSupabase = () => {
+  let context = useContext(Context);
   if (context === undefined) {
     throw new Error("useSupabase must be used inside SupabaseProvider");
+  } else {
+    return context;
   }
-
-  return useContext(Context)
 }
 ```
 


### PR DESCRIPTION
`context` is not even defined. Returning useContext(Context) directly also doesn't work because it could be undefined.

## What kind of change does this PR introduce?

This PR just updates the documents to something that works

## What is the current behavior?

The docs currently don't work for TypeScript

## What is the new behavior?

I first instantiate a local variable called `context` with `let context = useContext(Context)` and then do a conditional operation to throw an error if it's undefined.

## Additional context

Add any other context or screenshots.
