### PR TITLE
Add SidePanel to create custom roles

### DIFF
--- a/studio/components/interfaces/Database/Roles/RoleCreate.tsx
+++ b/studio/components/interfaces/Database/Roles/RoleCreate.tsx
@@ -1,0 +1,85 @@
+import { useState } from 'react'
+import type { FC } from 'react'
+
+import { observer } from 'mobx-react-lite'
+
+import { Input, SidePanel, Toggle } from 'ui'
+import { FormSection, FormSectionContent, FormSectionLabel } from 'components/ui/Forms'
+import { useStore } from 'hooks'
+
+interface Props {
+  visible: boolean
+  onClose: () => void
+}
+
+interface RoleCreateFields {
+  name: string
+  api_access: boolean
+}
+
+const RoleCreate: FC<Props> = ({ visible, onClose }: Props) => {
+  // Loading state when calling Roles API
+  const [isCreatingRole, setIsCreatingRole] = useState<boolean>()
+  // Form fields
+  const [fields, setFields] = useState<RoleCreateFields>({ name: '', api_access: false })
+
+  const { meta } = useStore()
+
+  const onUpdateField = (update: Partial<RoleCreateFields>) => {
+    setFields({ ...fields, ...update })
+  }
+
+  const tryCreateRole = async () => {
+    setIsCreatingRole(true)
+    const payload = { name: fields.name, members: '' }
+    if (fields.api_access) {
+      payload.members = 'authenticator'
+    }
+    await meta.roles
+      .create(payload)
+      .then((r) => {
+        if (r.error) throw r.error
+        onClose()
+      })
+      // TODO: handle error logic
+      .catch(() => false)
+      .finally(() => setIsCreatingRole(false))
+  }
+
+  return (
+    <SidePanel
+      key="RoleCreator"
+      visible={visible}
+      loading={isCreatingRole}
+      onCancel={onClose}
+      onConfirm={tryCreateRole}
+    >
+      <FormSection header={<FormSectionLabel className="lg:!col-span-4">General</FormSectionLabel>}>
+        <FormSectionContent loading={false}>
+          <Input
+            label="Name of the role"
+            type="text"
+            placeholder="postgres"
+            value={fields.name}
+            onChange={(event) => {
+              onUpdateField({ name: event.target.value })
+            }}
+          />
+          <Toggle
+            label="Allow access to API?"
+            checked={fields.api_access}
+            onChange={() => {
+              onUpdateField({ api_access: !fields.api_access })
+            }}
+          />
+          <small>
+            If access allowed, then you will be able to use this role when calling API, like REST
+            for example
+          </small>
+        </FormSectionContent>
+      </FormSection>
+    </SidePanel>
+  )
+}
+
+export default observer(RoleCreate)

--- a/studio/components/interfaces/Database/index.ts
+++ b/studio/components/interfaces/Database/index.ts
@@ -1,6 +1,7 @@
 import TableList from './Tables/TableList'
 import ColumnList from './Tables/ColumnList'
 
+import RoleCreate from './Roles/RoleCreate'
 import RolesList from './Roles/RolesList'
 import RolesSettings from './Roles/RolesSettings'
 
@@ -26,6 +27,7 @@ import DeleteFunction from './Functions/DeleteFunction'
 export {
   TableList,
   ColumnList,
+  RoleCreate,
   RolesList,
   RolesSettings,
   Extensions,

--- a/studio/pages/_app.tsx
+++ b/studio/pages/_app.tsx
@@ -50,6 +50,12 @@ function MyApp({ Component, pageProps }: AppPropsWithLayout) {
   const [rootStore] = useState(() => new RootStore())
 
   useEffect(() => {
+    if (process.env.NODE_ENV !== "development") return;
+    // @ts-ignore
+    window.rootStore = rootStore
+  }, [])
+
+  useEffect(() => {
     async function handleEmailVerificationError() {
       const { error } = await auth.initialize()
 

--- a/studio/pages/api/pg-meta/[ref]/roles.ts
+++ b/studio/pages/api/pg-meta/[ref]/roles.ts
@@ -1,7 +1,7 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
 import apiWrapper from 'lib/api/apiWrapper'
-import { get } from 'lib/common/fetch'
+import { get, post} from 'lib/common/fetch'
 import { constructHeaders } from 'lib/api/apiHelpers'
 import { PG_META_URL } from 'lib/constants'
 
@@ -14,8 +14,10 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
   switch (method) {
     case 'GET':
       return handleGetAll(req, res)
+    case 'POST':
+      return handlePost(req, res)
     default:
-      res.setHeader('Allow', ['GET'])
+      res.setHeader('Allow', ['GET', 'POST'])
       res.status(405).json({ error: { message: `Method ${method} Not Allowed` } })
   }
 }
@@ -28,5 +30,19 @@ const handleGetAll = async (req: NextApiRequest, res: NextApiResponse) => {
   if (response.error) {
     return res.status(400).json({ error: response.error })
   }
+  return res.status(200).json(response)
+}
+
+const handlePost = async (req: NextApiRequest, res: NextApiResponse) => {
+  const headers = constructHeaders(req.headers)
+  const payload = req.body
+  const response = await post(`${PG_META_URL}/roles`, payload, {
+    headers,
+  })
+  if (response.error) {
+    console.error('Roles POST:', response.error)
+    return res.status(400).json({ error: response.error })
+  }
+
   return res.status(200).json(response)
 }

--- a/studio/pages/project/[ref]/database/roles.tsx
+++ b/studio/pages/project/[ref]/database/roles.tsx
@@ -5,12 +5,29 @@ import { isUndefined } from 'lodash'
 import { DatabaseLayout } from 'components/layouts'
 import { RolesList, RolesSettings } from 'components/interfaces/Database'
 import { NextPageWithLayout } from 'types'
+import { Button, IconPlus } from 'ui'
+import { RoleCreate } from 'components/interfaces/Database'
 
 const DatabaseRoles: NextPageWithLayout = () => {
   const [selectedRole, setSelectedRole] = useState<any>()
+  const [isCreatingRole, setIsCreatingRole] = useState<boolean>(false)
+
+  const onCreateRole = () => {
+    setIsCreatingRole(true)
+  }
+
+  const onClose = () => {
+    setIsCreatingRole(false)
+  }
 
   return (
     <div className="p-4">
+      <div className="mb-4 flex justify-end">
+        <Button size="tiny" icon={<IconPlus size={14} strokeWidth={2} />} onClick={onCreateRole}>
+          Create new role
+        </Button>
+      </div>
+      <RoleCreate visible={isCreatingRole} onClose={onClose}></RoleCreate>
       {isUndefined(selectedRole) ? (
         <RolesList onSelectRole={setSelectedRole} />
       ) : (


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature.
Add a new SidePanel to create a new Custom Role from Database -> Roles
Modified `roles` studio API to handle POST requests
Current fields are `name` and `api_access`. `api_access` means the new created role is granted to `authenticator` so you can do REST calls with that role.
Styles, design and phrases to be discussed and updated.

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
