### PR TITLE
Update typo

### DIFF
--- a/examples/edge-functions/supabase/functions/oak-server/index.ts
+++ b/examples/edge-functions/supabase/functions/oak-server/index.ts
@@ -2,7 +2,7 @@ import { Application, Router } from 'https://deno.land/x/oak/mod.ts'
 
 const router = new Router()
 router
-  // Note: path will be prefixed with function name
+  // Note: path should be prefixed with function name
   .get('/oak-server', (context) => {
     context.response.body = 'This is an example Oak server running on Edge Functions!'
   })


### PR DESCRIPTION
When I fist read the comment I was thinking that I can remove /oak-server because "path will be prefixed with function name"
