### PR TITLE
fix(docs js): upsert true in replace example

### DIFF
--- a/spec/supabase_js_v2.yml
+++ b/spec/supabase_js_v2.yml
@@ -4421,7 +4421,7 @@ functions:
             .from('avatars')
             .update('public/avatar1.png', avatarFile, {
               cacheControl: '3600',
-              upsert: false
+              upsert: true
             })
           ```
       - id: update-file-using-arraybuffer-from-base64-file-data

--- a/spec/supabase_js_v2.yml
+++ b/spec/supabase_js_v2.yml
@@ -4421,6 +4421,7 @@ functions:
             .from('avatars')
             .update('public/avatar1.png', avatarFile, {
               cacheControl: '3600',
+              // Overwrite file if it exists
               upsert: true
             })
           ```


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

#11300

## What is the new behavior?

`upsert: true` in example
