### PR TITLE
fix(typo): Commands are using two differents project name

### DIFF
--- a/apps/docs/pages/guides/getting-started/quickstarts/sveltekit.mdx
+++ b/apps/docs/pages/guides/getting-started/quickstarts/sveltekit.mdx
@@ -67,7 +67,7 @@ export const meta = {
     <StepHikeCompact.Code>
 
       ```bash Terminal
-      cd my-app && npm install @supabase/supabase-js
+      cd myapp && npm install @supabase/supabase-js
       ```
 
     </StepHikeCompact.Code>


### PR DESCRIPTION
project name is different between two commands examples

## What kind of change does this PR introduce?

Typo fix

## What is the current behavior?

## What is the new behavior?

## Additional context
