### PR TITLE
fix/dart-docs-order-ascending

### DIFF
--- a/spec/supabase_dart_v1.yml
+++ b/spec/supabase_dart_v1.yml
@@ -907,7 +907,7 @@ functions:
           ```dart
           supabase.from('countries')
             .stream(primaryKey: ['id'])
-            .order('name', ascending: true)
+            .order('name', { ascending: true })
             .listen((List<Map<String, dynamic>> data) {
             // Do something awesome with the data
           });
@@ -918,7 +918,7 @@ functions:
           ```dart
           supabase.from('countries')
             .stream(primaryKey: ['id'])
-            .order('name', ascending: true)
+            .order('name', { ascending: true })
             .limit(10)
             .listen((List<Map<String, dynamic>> data) {
             // Do something awesome with the data
@@ -1334,7 +1334,7 @@ functions:
           final data = await supabase
             .from('cities')
             .select('name, country_id')
-            .order('id',  ascending: false );
+            .order('id',  { ascending: false });
           ```
       - id: with-embedded-resources
         name: With embedded resources


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update, ...

## What is the current behavior?

closes #12222

## What is the new behavior?

Add curly brackets to all `.order` examples that use `ascending`.

## Additional context

Add any other context or screenshots.
