### PR TITLE
fix(docs): fix middleware related info

### DIFF
--- a/apps/docs/pages/guides/auth/auth-helpers/nextjs-server-components.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/nextjs-server-components.mdx
@@ -108,7 +108,8 @@ export const createClient = () =>
 This will be used any time we need to create a Supabase client _server-side_ - in a Server Component, for example.
 
 Next, we need a middleware file to refresh the user's session on navigation.
-> If you were using Middleware prior to 12.2, please see the [upgrade guide](https://nextjs.org/docs/messages/middleware-upgrade-guide).
+
+> If you were using Middleware prior to 12.2, see the [upgrade guide](https://nextjs.org/docs/messages/middleware-upgrade-guide).
 
 <Tabs
   scrollable

--- a/apps/docs/pages/guides/auth/auth-helpers/nextjs-server-components.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/nextjs-server-components.mdx
@@ -108,6 +108,7 @@ export const createClient = () =>
 This will be used any time we need to create a Supabase client _server-side_ - in a Server Component, for example.
 
 Next, we need a middleware file to refresh the user's session on navigation.
+> If you were using Middleware prior to 12.2, please see the [upgrade guide](https://nextjs.org/docs/messages/middleware-upgrade-guide).
 
 <Tabs
   scrollable
@@ -117,7 +118,7 @@ Next, we need a middleware file to refresh the user's session on navigation.
 >
 <TabPanel id="js" label="JavaScript">
 
-Create a new `/app/middleware.js` file and populate with the following:
+Create a new `middleware.js` file at the same level as your `app` (in the root or `src` directory) and populate with the following:
 
 ```jsx title="middleware.js"
 import { createMiddlewareSupabaseClient } from '@supabase/auth-helpers-nextjs'
@@ -140,7 +141,7 @@ export async function middleware(req) {
 
 <TabPanel id="ts" label="TypeScript">
 
-Create a new `/app/middleware.ts` file and populate with the following:
+Create a new `middleware.ts` file at the same level as your `app` (in the root or `src` directory) and populate with the following:
 
 ```tsx title="middleware.ts"
 import { createMiddlewareSupabaseClient } from '@supabase/auth-helpers-nextjs'


### PR DESCRIPTION
## What kind of change does this PR introduce?
Fixes doc related to middleware. In the latest stable version they changed the behavior of middleware, it should go into root folder or into `src`. See the source here: https://nextjs.org/docs/advanced-features/middleware

## What is the current behavior?
Currently the doc says the `middleware.js` should go into `app` folder, but this isn't working.

## What is the new behavior?
It fixes the doc and adds a reference to upgrade guide.

## Additional context
\-
