### PR TITLE
Fix formatter of cell in sql result

### DIFF
--- a/studio/components/to-be-cleaned/SqlEditor/TabSqlQuery.js
+++ b/studio/components/to-be-cleaned/SqlEditor/TabSqlQuery.js
@@ -383,7 +383,7 @@ const Results = ({ results }) => {
       <div className="group sb-grid-select-cell__formatter overflow-hidden">
         <span className="font-mono text-xs truncate">{JSON.stringify(row[column])}</span>
 
-        {row[column] && (
+        {row[column] != undefined && (
           <Button
             type="outline"
             icon={isCopied ? <IconCheck size="tiny" /> : <IconClipboard size="tiny" />}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.
If value is 0 copying doesn't work and the result is rendered twice instead.
```sql
SELECT 0;
```
in SQL editor to see.

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
