### PR TITLE
Add docs redirect

### DIFF
--- a/apps/www/lib/redirects.js
+++ b/apps/www/lib/redirects.js
@@ -1842,4 +1842,9 @@ module.exports = [
     source: '/docs/guides/examples',
     destination: '/docs/guides/resources/examples',
   },
+  {
+    permanent: true,
+    source: '/docs/reference/javascript/v0/rpc',
+    destination: '/docs/reference/javascript/rpc',
+  },
 ]


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add a docs redirect for `/docs/reference/javascript/v0/rpc`

## What is the current behavior?

Googling for `supabase setsession` leads to a nonexistent page

## What is the new behavior?

[/docs/reference/javascript/v0/rpc](https://zone-www-dot-6qj40arc0-supabase.vercel.app/docs/reference/javascript/v0/rpc) redirects to [/docs/reference/javascript/rpc](https://zone-www-dot-6qj40arc0-supabase.vercel.app/docs/reference/javascript/rpc)