### PR TITLE
Updated method in `sveltekit.mdx` auth helper guide

### DIFF
--- a/apps/docs/pages/guides/auth/auth-helpers/sveltekit.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/sveltekit.mdx
@@ -257,7 +257,7 @@ Wrap an Action to check that the user has a valid session. If they're not logged
 ```ts title=src/routes/posts/+page.server.ts
 import type { Actions } from './$types'
 import { getSupabase } from '@supabase/auth-helpers-sveltekit'
-import { error, invalid } from '@sveltejs/kit'
+import { error, fail } from '@sveltejs/kit'
 
 export const actions: Actions = {
   createPost: async (event) => {
@@ -276,7 +276,7 @@ export const actions: Actions = {
       .insert({ content })
 
     if (createPostError) {
-      return invalid(500, {
+      return fail(500, {
         supabaseErrorMessage: createPostError.message,
       })
     }
@@ -293,7 +293,7 @@ If you try to submit a form with the action `?/createPost` without a valid sessi
 
 ```ts
 import type { Actions } from './$types'
-import { invalid, redirect } from '@sveltejs/kit'
+import { fail, redirect } from '@sveltejs/kit'
 import { getSupabase } from '@supabase/auth-helpers-sveltekit'
 import { AuthApiError } from '@supabase/supabase-js'
 
@@ -313,14 +313,14 @@ export const actions: Actions = {
 
     if (error) {
       if (error instanceof AuthApiError && error.status === 400) {
-        return invalid(400, {
+        return fail(400, {
           error: 'Invalid credentials.',
           values: {
             email,
           },
         })
       }
-      return invalid(500, {
+      return fail(500, {
         error: 'Server error. Try again later.',
         values: {
           email,


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

### Module '@sveltejs/kit' has no exported member 'invalid'

- `invalid` seems to be an invalid exported member of `@sveltejs/kit`
- The most similar and appropriate method to use is [fail]
- It may seem that `invalid` was the former name of `fail` method but was renamed after `SvelteKit`'s recent official major release. However I am not sure of that.

[fail]: https://kit.svelte.dev/docs/modules#sveltejs-kit-fail

## What is the new behavior?

`invalid()` renamed to `fail()`

## Additional context

- In the `Saving and Deleting the Session` section, some destructured properties in the `load()` method were not used. Was this intentional? I followed the guide and did not destructure those unused properties.
- Perhaps `cookies` from the `event` parameter were supposed to store the `session` destructured from `getSupabase()` helper, however it seems to work fine without that process and the session is persisted. I stand to be corrected by this conclusion.
- It seems like they are safe to remove. If so, then I would be glad to add another commit in this PR to remove them.

