### PR TITLE
Fix docs search modal cursor

### DIFF
--- a/apps/docs/styles/docsearch.scss
+++ b/apps/docs/styles/docsearch.scss
@@ -7,6 +7,7 @@
 .DocSearch-Container {
   background: rgba(0, 0, 0, 0.3);
   @apply fixed top-0 left-0 z-[200] flex h-screen w-screen flex-col p-4 backdrop-blur-sm sm:p-6 md:p-[10vh] lg:p-[12vh];
+  @apply cursor-auto #{!important};
 }
 
 .DocSearch-LoadingIndicator svg {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix docs search modal so the cursor is not always a pointer

## What is the current behavior?

<img width="609" alt="CleanShot 2023-02-08 at 18 27 59@2x" src="https://user-images.githubusercontent.com/70828596/217675166-0d3139d2-c9bd-4ecc-8284-f16c971fdabb.png">

## What is the new behavior?

<img width="603" alt="CleanShot 2023-02-08 at 18 29 06@2x" src="https://user-images.githubusercontent.com/70828596/217675181-738eb0a4-615f-45f1-8609-0c6089c5287b.png">