### PR TITLE
feat: auth docs logo

### DIFF
--- a/apps/docs/components/AuthProviders.tsx
+++ b/apps/docs/components/AuthProviders.tsx
@@ -1,7 +1,28 @@
+import Image from 'next/image'
 import providers from '../data/authProviders'
 import ButtonCard from './ButtonCard'
 
 export default function AuthProviders() {
+  const IconContainer: React.FC = (props) => {
+    return (
+      <div
+        className={[
+          'relative',
+          'flex items-center justify-center shrink-0',
+          'h-10 w-10 rounded-lg',
+          'group',
+          'cursor-pointer',
+          'overflow-hidden',
+          'border-scale-500 hover:border-scale-700 bg-white dark:bg-scale-300',
+          'border rounded-full',
+          'transition',
+        ].join(' ')}
+      >
+        {props.children}
+      </div>
+    )
+  }
+
   return (
     <div className="grid md:grid-cols-12 gap-4">
       {providers.map((x) => (
@@ -9,7 +30,12 @@ export default function AuthProviders() {
           <ButtonCard to={x.href} title={x.name}>
             <div className="px-6 py-4">
               <div className="flex justify-between">
-                <p className="mt-0">{x.name}</p>
+                <div className="flex gap-3">
+                  <IconContainer>
+                    <Image width={20} height={20} src={`${x.logo}.svg`} alt={x.name} />
+                  </IconContainer>
+                  <p className="mt-0">{x.name}</p>
+                </div>
                 <p className="mt-0">
                   {x.official ? (
                     <span className={`badge badge--official`}>Official</span>

--- a/apps/docs/components/AuthProviders.tsx
+++ b/apps/docs/components/AuthProviders.tsx
@@ -1,78 +1,16 @@
-import Image from 'next/image'
 import providers from '../data/authProviders'
-import ButtonCard from './ButtonCard'
+import { IconPanel } from 'ui'
+import Link from 'next/link'
 
 export default function AuthProviders() {
-  const IconContainer: React.FC = (props) => {
-    return (
-      <div
-        className={[
-          'relative',
-          'flex items-center justify-center shrink-0',
-          'h-10 w-10 rounded-lg',
-          'group',
-          'cursor-pointer',
-          'overflow-hidden',
-          'border-scale-500 hover:border-scale-700 bg-white dark:bg-scale-300',
-          'border rounded-full',
-          'transition',
-        ].join(' ')}
-      >
-        {props.children}
-      </div>
-    )
-  }
-
   return (
-    <div className="grid md:grid-cols-12 gap-4">
+    <div className="grid grid-cols-12 gap-10 not-prose py-8">
       {providers.map((x) => (
-        <div key={x.name} className="col-span-6">
-          <ButtonCard to={x.href} title={x.name}>
-            <div className="px-6 py-4">
-              <div className="flex justify-between">
-                <div className="flex gap-3">
-                  <IconContainer>
-                    <Image width={20} height={20} src={`${x.logo}.svg`} alt={x.name} />
-                  </IconContainer>
-                  <p className="mt-0">{x.name}</p>
-                </div>
-                <p className="mt-0">
-                  {x.official ? (
-                    <span className={`badge badge--official`}>Official</span>
-                  ) : (
-                    <span className={`badge badge--unofficial`}>Unofficial</span>
-                  )}
-                </p>
-              </div>
-              <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
-                <div
-                  className="code-block"
-                  style={{
-                    width: '100%',
-                    display: 'flex',
-                    justifyContent: 'space-between',
-                    fontSize: '0.7rem',
-                  }}
-                >
-                  <span>Platform:</span>
-                  <span>{x.platform.toString()}</span>
-                </div>
-                <div
-                  className="code-block"
-                  style={{
-                    width: '100%',
-                    display: 'flex',
-                    justifyContent: 'space-between',
-                    fontSize: '0.7rem',
-                  }}
-                >
-                  <span>Self-Hosted:</span>
-                  <span>{x.selfHosted.toString()}</span>
-                </div>
-              </div>
-            </div>
-          </ButtonCard>
-        </div>
+        <Link href={`${x.href}`} key={x.name} passHref>
+          <a className="col-span-6 lg:col-span-4 xl:col-span-3">
+            <IconPanel title={x.name} icon={x.logo} />
+          </a>
+        </Link>
       ))}
     </div>
   )

--- a/apps/docs/components/AuthProviders.tsx
+++ b/apps/docs/components/AuthProviders.tsx
@@ -2,16 +2,20 @@ import providers from '../data/authProviders'
 import { IconPanel } from 'ui'
 import Link from 'next/link'
 
-export default function AuthProviders() {
+export default function AuthProviders({ type }: { type: string }) {
+  const filterProviders = providers.filter((item) => item.authType === type)
+
   return (
-    <div className="grid grid-cols-12 gap-10 not-prose py-8">
-      {providers.map((x) => (
-        <Link href={`${x.href}`} key={x.name} passHref>
-          <a className="col-span-6 lg:col-span-4 xl:col-span-3">
-            <IconPanel title={x.name} icon={x.logo} />
-          </a>
-        </Link>
-      ))}
-    </div>
+    <>
+      <div className="grid grid-cols-12 gap-10 not-prose py-8">
+        {filterProviders.map((x) => (
+          <Link href={`${x.href}`} key={x.name} passHref>
+            <a className="col-span-6 lg:col-span-4 xl:col-span-3">
+              <IconPanel title={x.name} icon={x.logo} />
+            </a>
+          </Link>
+        ))}
+      </div>
+    </>
   )
 }

--- a/apps/docs/data/authProviders.ts
+++ b/apps/docs/data/authProviders.ts
@@ -7,6 +7,7 @@ const authProviders = [
     supporter: 'Supabase',
     platform: true,
     selfHosted: true,
+    authType: 'social',
   },
   {
     name: 'Azure',
@@ -16,6 +17,7 @@ const authProviders = [
     supporter: 'TBD',
     platform: true,
     selfHosted: true,
+    authType: 'social',
   },
   {
     name: 'Bitbucket',
@@ -25,6 +27,7 @@ const authProviders = [
     supporter: 'Supabase',
     platform: true,
     selfHosted: true,
+    authType: 'social',
   },
   {
     name: 'Discord',
@@ -34,6 +37,7 @@ const authProviders = [
     supporter: 'Supabase',
     platform: true,
     selfHosted: true,
+    authType: 'social',
   },
   {
     name: 'Facebook',
@@ -43,6 +47,7 @@ const authProviders = [
     supporter: 'Supabase',
     platform: true,
     selfHosted: true,
+    authType: 'social',
   },
   {
     name: 'GitHub',
@@ -52,6 +57,7 @@ const authProviders = [
     supporter: 'Supabase',
     platform: true,
     selfHosted: true,
+    authType: 'social',
   },
   {
     name: 'GitLab',
@@ -61,6 +67,7 @@ const authProviders = [
     supporter: 'Supabase',
     platform: true,
     selfHosted: true,
+    authType: 'social',
   },
   {
     name: 'Google',
@@ -70,6 +77,7 @@ const authProviders = [
     supporter: 'Supabase',
     platform: true,
     selfHosted: true,
+    authType: 'social',
   },
   {
     name: 'Keycloak',
@@ -79,6 +87,7 @@ const authProviders = [
     supporter: 'Supabase',
     platform: true,
     selfHosted: true,
+    authType: 'social',
   },
   {
     name: 'LinkedIn',
@@ -88,6 +97,7 @@ const authProviders = [
     supporter: 'Supabase',
     platform: true,
     selfHosted: true,
+    authType: 'social',
   },
   {
     name: 'MessageBird',
@@ -97,6 +107,7 @@ const authProviders = [
     supporter: 'MessageBird',
     platform: true,
     selfHosted: true,
+    authType: 'phone'
   },
   {
     name: 'Notion',
@@ -106,6 +117,7 @@ const authProviders = [
     supporter: 'Supabase',
     platform: true,
     selfHosted: true,
+    authType: 'social',
   },
   {
     name: 'Slack',
@@ -115,6 +127,7 @@ const authProviders = [
     supporter: 'Supabase',
     platform: true,
     selfHosted: true,
+    authType: 'social',
   },
   {
     name: 'Spotify',
@@ -124,6 +137,7 @@ const authProviders = [
     supporter: 'Supabase',
     platform: true,
     selfHosted: true,
+    authType: 'social',
   },
   {
     name: 'Twitter',
@@ -133,6 +147,7 @@ const authProviders = [
     supporter: 'Supabase',
     platform: true,
     selfHosted: true,
+    authType: 'social',
   },
   {
     name: 'Twitch',
@@ -142,6 +157,7 @@ const authProviders = [
     supporter: 'Supabase',
     platform: true,
     selfHosted: true,
+    authType: 'social',
   },
   {
     name: 'Zoom',
@@ -151,6 +167,7 @@ const authProviders = [
     supporter: 'Supabase',
     platform: true,
     selfHosted: true,
+    authType: 'social',
   },
   {
     name: 'Twilio',
@@ -160,6 +177,7 @@ const authProviders = [
     supporter: 'Supabase',
     platform: true,
     selfHosted: true,
+    authType: 'phone',
   },
   {
     name: 'Vonage',
@@ -169,6 +187,7 @@ const authProviders = [
     supporter: 'Supabase',
     platform: true,
     selfHosted: true,
+    authType: 'phone',
   },
 ]
 

--- a/apps/docs/data/authProviders.ts
+++ b/apps/docs/data/authProviders.ts
@@ -1,7 +1,7 @@
 const authProviders = [
   {
     name: 'Apple',
-    // logo: '/img/libraries/dart-icon.svg',
+    logo: '/docs/img/icons/apple-icon',
     href: '/guides/auth/social-login/auth-apple',
     official: true,
     supporter: 'Supabase',
@@ -10,7 +10,7 @@ const authProviders = [
   },
   {
     name: 'Azure',
-    // logo: '/img/libraries/dart-icon.svg',
+    logo: '/docs/img/icons/microsoft-icon',
     href: '/guides/auth/social-login/auth-azure',
     official: false,
     supporter: 'TBD',
@@ -19,7 +19,7 @@ const authProviders = [
   },
   {
     name: 'Bitbucket',
-    // logo: '/img/libraries/dart-icon.svg',
+    logo: '/docs/img/icons/bitbucket-icon',
     href: '/guides/auth/social-login/auth-bitbucket',
     official: true,
     supporter: 'Supabase',
@@ -28,7 +28,7 @@ const authProviders = [
   },
   {
     name: 'Discord',
-    // logo: '/img/libraries/dart-icon.svg',
+    logo: '/docs/img/icons/discord-icon',
     href: '/guides/auth/social-login/auth-discord',
     official: true,
     supporter: 'Supabase',
@@ -37,7 +37,7 @@ const authProviders = [
   },
   {
     name: 'Facebook',
-    // logo: '/img/libraries/dart-icon.svg',
+    logo: '/docs/img/icons/facebook-icon',
     href: '/guides/auth/social-login/auth-facebook',
     official: true,
     supporter: 'Supabase',
@@ -46,7 +46,7 @@ const authProviders = [
   },
   {
     name: 'GitHub',
-    // logo: '/img/libraries/dart-icon.svg',
+    logo: '/docs/img/icons/github-icon',
     href: '/guides/auth/social-login/auth-github',
     official: true,
     supporter: 'Supabase',
@@ -55,7 +55,7 @@ const authProviders = [
   },
   {
     name: 'GitLab',
-    // logo: '/img/libraries/dart-icon.svg',
+    logo: '/docs/img/icons/gitlab-icon',
     href: '/guides/auth/social-login/auth-gitlab',
     official: true,
     supporter: 'Supabase',
@@ -64,7 +64,7 @@ const authProviders = [
   },
   {
     name: 'Google',
-    // logo: '/img/libraries/dart-icon.svg',
+    logo: '/docs/img/icons/google-icon',
     href: '/guides/auth/social-login/auth-google',
     official: true,
     supporter: 'Supabase',
@@ -73,6 +73,7 @@ const authProviders = [
   },
   {
     name: 'Keycloak',
+    logo: '/docs/img/icons/keycloak-icon',
     href: '/guides/auth/social-login/auth-keycloak',
     official: true,
     supporter: 'Supabase',
@@ -81,7 +82,7 @@ const authProviders = [
   },
   {
     name: 'LinkedIn',
-    // logo: '/img/libraries/dart-icon.svg',
+    logo: '/docs/img/icons/linkedin-icon',
     href: '/guides/auth/social-login/auth-linkedin',
     official: true,
     supporter: 'Supabase',
@@ -90,7 +91,7 @@ const authProviders = [
   },
   {
     name: 'MessageBird',
-    // logo: '/img/libraries/dart-icon.svg',
+    logo: '/docs/img/icons/messagebird-icon',
     href: '/guides/auth/phone-login/messagebird',
     official: false,
     supporter: 'MessageBird',
@@ -99,7 +100,7 @@ const authProviders = [
   },
   {
     name: 'Notion',
-    // logo: '/img/libraries/notion-icon.svg',
+    logo: '/docs/img/icons/notion-icon',
     href: '/guides/auth/social-login/auth-notion',
     official: true,
     supporter: 'Supabase',
@@ -108,7 +109,7 @@ const authProviders = [
   },
   {
     name: 'Slack',
-    // logo: '/img/libraries/dart-icon.svg',
+    logo: '/docs/img/icons/slack-icon',
     href: '/guides/auth/social-login/auth-slack',
     official: true,
     supporter: 'Supabase',
@@ -117,7 +118,7 @@ const authProviders = [
   },
   {
     name: 'Spotify',
-    // logo: '/img/libraries/dart-icon.svg',
+    logo: '/docs/img/icons/spotify-icon',
     href: '/guides/auth/social-login/auth-spotify',
     official: true,
     supporter: 'Supabase',
@@ -126,7 +127,7 @@ const authProviders = [
   },
   {
     name: 'Twitter',
-    // logo: '/img/libraries/dart-icon.svg',
+    logo: '/docs/img/icons/twitter-icon',
     href: '/guides/auth/social-login/auth-twitter',
     official: true,
     supporter: 'Supabase',
@@ -135,7 +136,7 @@ const authProviders = [
   },
   {
     name: 'Twitch',
-    // logo: '/img/libraries/dart-icon.svg',
+    logo: '/docs/img/icons/twitch-icon',
     href: '/guides/auth/social-login/auth-twitch',
     official: true,
     supporter: 'Supabase',
@@ -144,7 +145,7 @@ const authProviders = [
   },
   {
     name: 'Zoom',
-    // logo: '/img/libraries/dart-icon.svg',
+    logo: '/docs/img/icons/zoom-icon',
     href: '/guides/auth/social-login/auth-zoom',
     official: true,
     supporter: 'Supabase',
@@ -153,7 +154,7 @@ const authProviders = [
   },
   {
     name: 'Twilio',
-    // logo: '/img/libraries/dart-icon.svg',
+    logo: '/docs/img/icons/twilio-icon',
     href: '/guides/auth/phone-login/twilio',
     official: true,
     supporter: 'Supabase',
@@ -162,6 +163,7 @@ const authProviders = [
   },
   {
     name: 'Vonage',
+    logo: '/docs/img/icons/vonage-icon',
     href: '/guides/auth/phone-login/vonage',
     official: false,
     supporter: 'Supabase',

--- a/apps/docs/pages/guides/auth/overview.mdx
+++ b/apps/docs/pages/guides/auth/overview.mdx
@@ -44,8 +44,16 @@ You can authenticate your users in several ways:
 
 We provide a suite of Providers and login methods, as well as [Auth helpers](/docs/guides/auth/auth-helpers/).
 
+#### Social Auth
+
 <div className="container" style={{ padding: 0 }}>
-  <AuthProviders />
+  <AuthProviders type="social" />
+</div>
+
+#### Phone Auth
+
+<div className="container" style={{ padding: 0 }}>
+  <AuthProviders type="phone" />
 </div>
 
 ### Configure third-party providers


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase Docs - [Auth Providers](https://supabase.com/docs/guides/auth/overview#providers)

## What is the current behavior?

The auth cards currently show no logos.

## What is the new behavior?

Logos have been added to the cards:

<img width="863" alt="Screenshot 2023-02-09 at 18 30 45" src="https://user-images.githubusercontent.com/22655069/217906648-3c627618-2c19-4bca-949f-812abd2e552a.png">


## Additional context

Closes #12294

@MildTomato - I feel like more can be done e.g. styling with the other sections of the card, what do you think?
