### PR TITLE
Update SvelteKit auth helpers guide

### DIFF
--- a/apps/docs/pages/guides/auth/auth-helpers/sveltekit.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/sveltekit.mdx
@@ -257,7 +257,7 @@ Wrap an Action to check that the user has a valid session. If they're not logged
 ```ts title=src/routes/posts/+page.server.ts
 import type { Actions } from './$types'
 import { getSupabase } from '@supabase/auth-helpers-sveltekit'
-import { error, invalid } from '@sveltejs/kit'
+import { error, fail } from '@sveltejs/kit'
 
 export const actions: Actions = {
   createPost: async (event) => {
@@ -276,7 +276,7 @@ export const actions: Actions = {
       .insert({ content })
 
     if (createPostError) {
-      return invalid(500, {
+      return fail(500, {
         supabaseErrorMessage: createPostError.message,
       })
     }
@@ -293,7 +293,7 @@ If you try to submit a form with the action `?/createPost` without a valid sessi
 
 ```ts
 import type { Actions } from './$types'
-import { invalid, redirect } from '@sveltejs/kit'
+import { fail, redirect } from '@sveltejs/kit'
 import { getSupabase } from '@supabase/auth-helpers-sveltekit'
 import { AuthApiError } from '@supabase/supabase-js'
 
@@ -313,14 +313,14 @@ export const actions: Actions = {
 
     if (error) {
       if (error instanceof AuthApiError && error.status === 400) {
-        return invalid(400, {
+        return fail(400, {
           error: 'Invalid credentials.',
           values: {
             email,
           },
         })
       }
-      return invalid(500, {
+      return fail(500, {
         error: 'Server error. Try again later.',
         values: {
           email,

--- a/package-lock.json
+++ b/package-lock.json
@@ -46181,7 +46181,7 @@
         "@sinclair/typebox": "^0.25.1",
         "pg": "^8.7.1",
         "pg-format": "^1.0.4",
-        "pgsql-parser": "13.4.0",
+        "pgsql-parser": "^13.3.0",
         "postgres-array": "^3.0.1",
         "prettier": "^2.6.0",
         "prettier-plugin-sql": "^0.12.1"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The doc is using the `invalid` method which is no longer being used

## What is the new behavior?

The doc is now using the proper `fail` method

## Additional context

Add any other context or screenshots.
