### PR TITLE
Fix link to RLS docs

### DIFF
--- a/studio/pages/project/[ref]/auth/policies.tsx
+++ b/studio/pages/project/[ref]/auth/policies.tsx
@@ -138,14 +138,14 @@ const AuthPoliciesPage: NextPageWithLayout = () => {
               icon={<IconSearch size="tiny" />}
             />
           </div>
-          <Button type="link" icon={<IconExternalLink size={14} strokeWidth={1.5} />}>
-            <a
-              target="_blank"
-              href="https://supabase.com/docs/learn/auth-deep-dive/auth-row-level-security"
-            >
+          <a
+            target="_blank"
+            href="https://supabase.com/docs/learn/auth-deep-dive/auth-row-level-security"
+          >
+            <Button type="link" icon={<IconExternalLink size={14} strokeWidth={1.5} />}>
               What is RLS?
-            </a>
-          </Button>
+            </Button>
+          </a>
         </div>
       </div>
       <Policies tables={filteredTables} hasTables={tables.length > 0} isLocked={isLocked} />


### PR DESCRIPTION
## What kind of change does this PR introduce?

make it much easier to click button that takes you to RLS docs

## What is the current behavior?

https://user-images.githubusercontent.com/70828596/217973436-e6784d03-9584-4a85-9cdb-c2cd623400f8.mp4