### PR TITLE
Fix broken links

### DIFF
--- a/apps/docs/pages/guides/database/api.mdx
+++ b/apps/docs/pages/guides/database/api.mdx
@@ -209,12 +209,12 @@ curl '<SUPABASE_URL>/rest/v1/todos' \
 </TabPanel>
 </Tabs>
 
-JS Reference: [select()](../reference/javascript/select),
-[insert()](../reference/javascript/insert),
-[update()](../reference/javascript/update),
-[upsert()](../reference/javascript/upsert),
-[delete()](../reference/javascript/delete),
-[rpc()](../reference/javascript/rpc) (call Postgres functions).
+JS Reference: [select()](/reference/javascript/select),
+[insert()](/reference/javascript/insert),
+[update()](/reference/javascript/update),
+[upsert()](/reference/javascript/upsert),
+[delete()](/reference/javascript/delete),
+[rpc()](/reference/javascript/rpc) (call Postgres functions).
 
 ### GraphQL API
 


### PR DESCRIPTION
## Preview URL

https://docs-ijtuwjxmr-supabase.vercel.app/docs/guides/database/api#rest-api

## What kind of change does this PR introduce?

Fix these broken docs links:
![Screenshot 2023-02-10 at 2 08 08 PM](https://user-images.githubusercontent.com/7026076/218208094-462c6517-0c4b-444a-9fe2-13e68e9c8db7.png)