### PR TITLE
Bulk data upload: Use `\copy` instead of `copy` to upload data with the `postgres` role

### DIFF
--- a/apps/docs/pages/guides/database/tables.mdx
+++ b/apps/docs/pages/guides/database/tables.mdx
@@ -243,6 +243,14 @@ You would [connect](../../guides/database/connecting-to-postgres#direct-connecti
 ```bash
 psql -h DATABASE_URL -p 5432 -d postgres -U postgres \
   -c "\COPY movies FROM './movies.csv';"
+```
+Additionally use the `DELIMITER`, `HEADER` and `FORMAT` options as defined in the PostgreSQL [COPY](https://www.postgresql.org/docs/current/sql-copy.html) docs.
+```bash
+psql -h DATABASE_URL -p 5432 -d postgres -U postgres \
+  -c "\COPY movies FROM './movies.csv' WITH DELIMITER ',' CSV HEADER"
+```
+
+Tip: If you get a `FATAL:  password authentication failed for user "postgres"` error, reset the password in your Database settings and try again.
 
 ## Joining tables with Foreign Keys
 

--- a/apps/docs/pages/guides/database/tables.mdx
+++ b/apps/docs/pages/guides/database/tables.mdx
@@ -244,6 +244,7 @@ You would [connect](../../guides/database/connecting-to-postgres#direct-connecti
 psql -h DATABASE_URL -p 5432 -d postgres -U postgres \
   -c "\COPY movies FROM './movies.csv';"
 ```
+
 Additionally use the `DELIMITER`, `HEADER` and `FORMAT` options as defined in the PostgreSQL [COPY](https://www.postgresql.org/docs/current/sql-copy.html) docs.
 
 ```bash

--- a/apps/docs/pages/guides/database/tables.mdx
+++ b/apps/docs/pages/guides/database/tables.mdx
@@ -252,7 +252,7 @@ psql -h DATABASE_URL -p 5432 -d postgres -U postgres \
   -c "\COPY movies FROM './movies.csv' WITH DELIMITER ',' CSV HEADER"
 ```
 
-Tip: If you get a `FATAL:  password authentication failed for user "postgres"` error, reset the password in your Database settings and try again.
+If you receive an error `FATAL:  password authentication failed for user "postgres"`, reset your database password in the Database Settings and try again.
 
 ## Joining tables with Foreign Keys
 

--- a/apps/docs/pages/guides/database/tables.mdx
+++ b/apps/docs/pages/guides/database/tables.mdx
@@ -243,14 +243,6 @@ You would [connect](../../guides/database/connecting-to-postgres#direct-connecti
 ```bash
 psql -h DATABASE_URL -p 5432 -d postgres -U postgres \
   -c "\COPY movies FROM './movies.csv';"
-```
-Additionally use the `DELIMITER`, `HEADER` and `FORMAT` options as defined in the PostgreSQL [COPY](https://www.postgresql.org/docs/current/sql-copy.html) docs.
-```bash
-psql -h DATABASE_URL -p 5432 -d postgres -U postgres \
-  -c "\COPY movies FROM './movies.csv' WITH DELIMITER ',' CSV HEADER"
-```
-
-Tip: If you get a `FATAL:  password authentication failed for user "postgres"` error, reset the password in your Database settings and try again.
 
 ## Joining tables with Foreign Keys
 

--- a/apps/docs/pages/guides/database/tables.mdx
+++ b/apps/docs/pages/guides/database/tables.mdx
@@ -245,6 +245,7 @@ psql -h DATABASE_URL -p 5432 -d postgres -U postgres \
   -c "\COPY movies FROM './movies.csv';"
 ```
 Additionally use the `DELIMITER`, `HEADER` and `FORMAT` options as defined in the PostgreSQL [COPY](https://www.postgresql.org/docs/current/sql-copy.html) docs.
+
 ```bash
 psql -h DATABASE_URL -p 5432 -d postgres -U postgres \
   -c "\COPY movies FROM './movies.csv' WITH DELIMITER ',' CSV HEADER"

--- a/apps/docs/pages/guides/database/tables.mdx
+++ b/apps/docs/pages/guides/database/tables.mdx
@@ -242,8 +242,15 @@ You would [connect](../../guides/database/connecting-to-postgres#direct-connecti
 
 ```bash
 psql -h DATABASE_URL -p 5432 -d postgres -U postgres \
-  -c "COPY movies FROM './movies.csv';"
+  -c "\COPY movies FROM './movies.csv';"
 ```
+Additionally use the `DELIMITER`, `HEADER` and `FORMAT` options as defined in the PostgreSQL [COPY](https://www.postgresql.org/docs/current/sql-copy.html) docs.
+```bash
+psql -h DATABASE_URL -p 5432 -d postgres -U postgres \
+  -c "\COPY movies FROM './movies.csv' WITH DELIMITER ',' CSV HEADER"
+```
+
+Tip: If you get a `FATAL:  password authentication failed for user "postgres"` error, reset the password in your Database settings and try again.
 
 ## Joining tables with Foreign Keys
 


### PR DESCRIPTION
With the recent Supabase migration, where the `postgres` role is no longer a `superuser`, the "COPY" commands throws an error 
```
ERROR:  must be superuser or a member of the pg_read_server_files role to COPY from a file
HINT:  Anyone can COPY to stdout or from stdin. psql's \copy command also works for anyone.
```

## What kind of change does this PR introduce?

docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
