### PR TITLE
Update links to the JS reference docs

### DIFF
--- a/apps/docs/pages/guides/database/api.mdx
+++ b/apps/docs/pages/guides/database/api.mdx
@@ -209,12 +209,12 @@ curl '<SUPABASE_URL>/rest/v1/todos' \
 </TabPanel>
 </Tabs>
 
-JS Reference: [select()](/reference/javascript/select),
-[insert()](/reference/javascript/insert),
-[update()](/reference/javascript/update),
-[upsert()](/reference/javascript/upsert),
-[delete()](/reference/javascript/delete),
-[rpc()](/reference/javascript/rpc) (call Postgres functions).
+JS Reference: [select()](/docs/reference/javascript/select),
+[insert()](/docs/reference/javascript/insert),
+[update()](/docs/reference/javascript/update),
+[upsert()](/docs/reference/javascript/upsert),
+[delete()](/docs/reference/javascript/delete),
+[rpc()](/docs/reference/javascript/rpc) (call Postgres functions).
 
 ### GraphQL API
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

Incorrect links pointing to the JS reference docs

## What is the new behavior?

Links now pointing to the JS docs correctly

## Additional context

Add any other context or screenshots.
