### PR TITLE
Fix product menu items truncate

### DIFF
--- a/studio/components/ui/ProductMenu/ProductMenuItem.tsx
+++ b/studio/components/ui/ProductMenu/ProductMenuItem.tsx
@@ -34,11 +34,11 @@ const ProductMenuItem: FC<Props> = ({
       <div className="flex w-full items-center justify-between gap-1">
         <div
           title={hoverText ? hoverText : typeof name === 'string' ? name : ''}
-          className={'flex items-center gap-2 truncate w-full ' + textClassName}
+          className={'flex items-center gap-2 w-full' + textClassName}
         >
-          {name}{' '}
+          <span className="truncate">{name}{' '}</span>
           {label !== undefined && (
-            <span className="text-orange-800 text-xs font-normal">{label}</span>
+            <span className="text-orange-800 text-xs font-normal truncate">{label}</span>
           )}
         </div>
         {action}


### PR DESCRIPTION
## What kind of change does this PR introduce?

fix truncate for product menu item

## What is the current behavior?

<img width="241" src="https://user-images.githubusercontent.com/70828596/218331265-499d5c97-5615-4196-8f00-24954cf41b7c.png">

## What is the new behavior?

<img width="241" src="https://user-images.githubusercontent.com/70828596/218331269-fd9ceb90-c82a-4f0c-90c7-bae122c790f5.png">

## Additional context

I haven't checked if this works everywhere