### PR TITLE
fix(docs): use activate subcommand in vanity domain documentation

### DIFF
--- a/apps/docs/pages/guides/platform/custom-domains.mdx
+++ b/apps/docs/pages/guides/platform/custom-domains.mdx
@@ -138,7 +138,7 @@ As such, it is recommended that you schedule a downtime window of 20-30 minutes,
 The `activate` subcommand can be used to initiate the activation:
 
 ```bash
-supabase vanity-subdomains --project-ref fwmssjhjgszhnavvqxnt check-availability --desired-subdomain my-example-subdomain --experimental
+supabase vanity-subdomains --project-ref fwmssjhjgszhnavvqxnt activate --desired-subdomain my-example-subdomain --experimental
 ```
 
 ## Remove a Vanity Subdomain


### PR DESCRIPTION
## What kind of change does this PR introduce?

Update the documentation for activating a vanity subdomain

## What is the current behavior?

https://supabase.com/docs/guides/platform/custom-domains#activate-a-subdomain

## What is the new behavior?

Use the correct subcommand

