### PR TITLE
Update docs for auth.getUser() to add reference to auth.getSession() as a faster alternative

### DIFF
--- a/spec/supabase_js_v2.yml
+++ b/spec/supabase_js_v2.yml
@@ -356,6 +356,7 @@ functions:
     notes: |
       - This method gets the user object from the current session.
       - Fetches the user object from the database instead of local session.
+      - Should be used only when you require the most current user data. For faster results, `getSession().session.user` is recommended.
     examples:
       - id: get-the-logged-in-user-with-the-current-existing-session
         name: Get the logged in user with the current existing session


### PR DESCRIPTION
When using Supabase, you're nudged towards using `auth.getUser()` to retrieve the current user. 

While this is correct, the docs don't particularly highlight the fact that this is a slower retrieval as it refetches the user object from the `/user` endpoint. Instead in performance sensitive contexts we should use `auth.getSession().session.user` as it will simply return the user data contained within the JWT.

This latency can be seen in the video below:


https://user-images.githubusercontent.com/13398220/218340538-394503d2-13a9-45e4-a7b4-fd138c1c1db4.mov