### PR TITLE
doc: missing closing bracket in auth example code

### DIFF
--- a/spec/examples/examples.yml
+++ b/spec/examples/examples.yml
@@ -244,7 +244,7 @@ functions:
             options: {
               redirectTo: 'https://example.com/welcome'
             }
-          }
+          })
           ```
       - id: sign-in-with-scopes
         name: Sign in with scopes

--- a/spec/supabase_js_v2.yml
+++ b/spec/supabase_js_v2.yml
@@ -287,7 +287,7 @@ functions:
             options: {
               redirectTo: 'https://example.com/welcome'
             }
-          }
+          })
           ```
       - id: sign-in-with-scopes
         name: Sign in with scopes


### PR DESCRIPTION
## What kind of change does this PR introduce?

[Docs code example error](https://github.com/supabase/supabase/issues/12356)

## What is the current behavior?

There are missing closing brackets in auth example code.

## What is the new behavior?

There auth example code should be correct.

## Additional context

N/A
