### PR TITLE
fix: improve pgvector example code

### DIFF
--- a/apps/www/_blog/2023-02-03-openai-embeddings-postgres-vector.mdx
+++ b/apps/www/_blog/2023-02-03-openai-embeddings-postgres-vector.mdx
@@ -119,9 +119,9 @@ begin
   select
     id,
     content,
-    (documents.embedding <=> query_embedding) as similarity
+    1 - (documents.embedding <=> query_embedding) as similarity
   from documents
-  where (documents.embedding <=> query_embedding) > similarity_threshold
+  where 1 - (documents.embedding <=> query_embedding) > similarity_threshold
   order by documents.embedding <=> query_embedding
   limit match_count;
 end;


### PR DESCRIPTION
## What kind of change does this PR introduce?

https://github.com/supabase/supabase/issues/12244

## What is the current behavior?

In the example code in the [pgvector blog post](https://supabase.com/blog/openai-embeddings-postgres-vector#what-are-embeddings), the use of cosine distance and cosine similarity are mixed.

## What is the new behavior?

The correct formula is: `Cosine Distance = 1 — Cosine Similarity`

## Additional context

N/A
