### PR TITLE
Remove trimming in filterLiteral

### DIFF
--- a/studio/components/grid/query/Query.utils.ts
+++ b/studio/components/grid/query/Query.utils.ts
@@ -203,11 +203,10 @@ function isFilterSql(filter: Filter) {
 
 function filterLiteral(value: any) {
   if (typeof value === 'string') {
-    const temp = value.trim()
-    if (temp?.startsWith('ARRAY[') && temp?.endsWith(']')) {
-      return temp
+    if (value?.startsWith('ARRAY[') && value?.endsWith(']')) {
+      return value
     } else {
-      return literal(temp)
+      return literal(value)
     }
   }
   return value


### PR DESCRIPTION
Ran into an edge case whereby if i'm trying to update a row, and the primary key is of text type, and the primary key value has a new line character at the end, the trimming would incorrectly remove the new line and the update statement would not be able to target the row correctly

filterLiteral is only used in the Query.utils file and its used for column names which aren't user inputs. so the trimming should be safe to remove here