### PR TITLE
Update extension register

### DIFF
--- a/apps/docs/data/extensions.json
+++ b/apps/docs/data/extensions.json
@@ -1,499 +1,286 @@
 [
   {
     "name": "address_standardizer",
-    "schema": null,
-    "default_version": "3.1.1",
-    "installed_version": null,
     "comment": "Used to parse an address into constituent elements. Generally used to support geocoding address normalization step."
   },
   {
     "name": "address_standardizer-3",
-    "schema": null,
-    "default_version": "3.1.1",
-    "installed_version": null,
     "comment": "Used to parse an address into constituent elements. Generally used to support geocoding address normalization step."
   },
   {
     "name": "address_standardizer_data_us",
-    "schema": null,
-    "default_version": "3.1.1",
-    "installed_version": null,
     "comment": "Address Standardizer US dataset example"
   },
   {
     "name": "address_standardizer_data_us-3",
-    "schema": null,
-    "default_version": "3.1.1",
-    "installed_version": null,
     "comment": "Address Standardizer US dataset example"
   },
   {
     "name": "adminpack",
-    "schema": null,
-    "default_version": "2.0",
-    "installed_version": null,
     "comment": "administrative functions for PostgreSQL"
   },
   {
     "name": "amcheck",
-    "schema": null,
-    "default_version": "1.2",
-    "installed_version": null,
     "comment": "functions for verifying relation integrity"
   },
   {
     "name": "autoinc",
-    "schema": null,
-    "default_version": "1.0",
-    "installed_version": null,
     "comment": "functions for autoincrementing fields"
   },
   {
     "name": "bloom",
-    "schema": null,
-    "default_version": "1.0",
-    "installed_version": null,
     "comment": "bloom access method - signature file based index"
   },
   {
     "name": "btree_gin",
-    "schema": null,
-    "default_version": "1.3",
-    "installed_version": null,
     "comment": "support for indexing common datatypes in GIN"
   },
   {
     "name": "btree_gist",
-    "schema": null,
-    "default_version": "1.5",
-    "installed_version": null,
     "comment": "support for indexing common datatypes in GiST"
   },
   {
     "name": "citext",
-    "schema": null,
-    "default_version": "1.6",
-    "installed_version": null,
     "comment": "data type for case-insensitive character strings"
   },
   {
     "name": "cube",
-    "schema": null,
-    "default_version": "1.4",
-    "installed_version": null,
     "comment": "data type for multidimensional cubes"
   },
   {
     "name": "dblink",
-    "schema": null,
-    "default_version": "1.2",
-    "installed_version": null,
     "comment": "connect to other PostgreSQL databases from within a database"
   },
   {
     "name": "dict_int",
-    "schema": null,
-    "default_version": "1.0",
-    "installed_version": null,
     "comment": "text search dictionary template for integers"
   },
   {
     "name": "dict_xsyn",
-    "schema": null,
-    "default_version": "1.0",
-    "installed_version": null,
     "comment": "text search dictionary template for extended synonym processing"
   },
   {
     "name": "earthdistance",
-    "schema": null,
-    "default_version": "1.1",
-    "installed_version": null,
     "comment": "calculate great-circle distances on the surface of the Earth"
   },
   {
     "name": "file_fdw",
-    "schema": null,
-    "default_version": "1.0",
-    "installed_version": null,
     "comment": "foreign-data wrapper for flat file access"
   },
   {
     "name": "fuzzystrmatch",
-    "schema": null,
-    "default_version": "1.1",
-    "installed_version": null,
     "comment": "determine similarities and distance between strings"
   },
   {
     "name": "hstore",
-    "schema": null,
-    "default_version": "1.6",
-    "installed_version": null,
     "comment": "data type for storing sets of (key, value) pairs"
   },
   {
     "name": "http",
-    "schema": "extensions",
-    "default_version": "1.3",
-    "installed_version": "1.3",
     "comment": "HTTP client for PostgreSQL, allows web page retrieval inside the database."
   },
   {
     "name": "insert_username",
-    "schema": null,
-    "default_version": "1.0",
-    "installed_version": null,
     "comment": "functions for tracking who changed a table"
   },
   {
     "name": "intagg",
-    "schema": null,
-    "default_version": "1.1",
-    "installed_version": null,
     "comment": "integer aggregator and enumerator (obsolete)"
   },
   {
     "name": "intarray",
-    "schema": null,
-    "default_version": "1.2",
-    "installed_version": null,
     "comment": "functions, operators, and index support for 1-D arrays of integers"
   },
   {
     "name": "isn",
-    "schema": null,
-    "default_version": "1.2",
-    "installed_version": null,
     "comment": "data types for international product numbering standards"
   },
   {
     "name": "lo",
-    "schema": null,
-    "default_version": "1.1",
-    "installed_version": null,
     "comment": "Large Object maintenance"
   },
   {
     "name": "ltree",
-    "schema": null,
-    "default_version": "1.1",
-    "installed_version": null,
     "comment": "data type for hierarchical tree-like structures"
   },
   {
     "name": "moddatetime",
-    "schema": null,
-    "default_version": "1.0",
-    "installed_version": null,
     "comment": "functions for tracking last modification time"
   },
   {
     "name": "pageinspect",
-    "schema": null,
-    "default_version": "1.7",
-    "installed_version": null,
     "comment": "inspect the contents of database pages at a low level"
   },
   {
     "name": "pg_buffercache",
-    "schema": null,
-    "default_version": "1.3",
-    "installed_version": null,
     "comment": "examine the shared buffer cache"
   },
   {
     "name": "pg_cron",
-    "schema": "extensions",
-    "default_version": "1.3",
-    "installed_version": "1.3",
     "comment": "Job scheduler for PostgreSQL"
   },
   {
     "name": "pg_freespacemap",
-    "schema": null,
-    "default_version": "1.2",
-    "installed_version": null,
     "comment": "examine the free space map (FSM)"
   },
   {
     "name": "pg_prewarm",
-    "schema": null,
-    "default_version": "1.2",
-    "installed_version": null,
     "comment": "prewarm relation data"
   },
   {
     "name": "pg_stat_statements",
-    "schema": null,
-    "default_version": "1.7",
-    "installed_version": null,
     "comment": "track execution statistics of all SQL statements executed"
   },
   {
     "name": "pg_trgm",
-    "schema": null,
-    "default_version": "1.4",
-    "installed_version": null,
     "comment": "text similarity measurement and index searching based on trigrams"
   },
   {
     "name": "pg_visibility",
-    "schema": null,
-    "default_version": "1.2",
-    "installed_version": null,
     "comment": "examine the visibility map (VM) and page-level visibility info"
   },
   {
     "name": "pgaudit",
-    "schema": null,
-    "default_version": "1.4",
-    "installed_version": null,
     "comment": "provides auditing functionality"
   },
   {
     "name": "pgcrypto",
-    "schema": "extensions",
-    "default_version": "1.3",
-    "installed_version": "1.3",
     "comment": "cryptographic functions"
   },
   {
     "name": "pgjwt",
-    "schema": "extensions",
-    "default_version": "0.1.0",
-    "installed_version": "0.1.0",
     "comment": "JSON Web Token API for Postgresql"
   },
   {
     "name": "pgrowlocks",
-    "schema": null,
-    "default_version": "1.2",
-    "installed_version": null,
     "comment": "show row-level locking information"
   },
   {
     "name": "pgstattuple",
-    "schema": null,
-    "default_version": "1.5",
-    "installed_version": null,
     "comment": "show tuple-level statistics"
   },
   {
     "name": "pgtap",
-    "schema": null,
-    "default_version": "1.1.0",
-    "installed_version": null,
     "comment": "Unit testing for PostgreSQL"
   },
   {
     "name": "plcoffee",
-    "schema": null,
-    "default_version": "3.0alpha",
-    "installed_version": null,
     "comment": "PL/CoffeeScript (v8) trusted procedural language"
   },
   {
     "name": "pljava",
-    "schema": null,
-    "default_version": "1.6.0",
-    "installed_version": null,
     "comment": "PL/Java procedural language (https://tada.github.io/pljava/)"
   },
   {
     "name": "plls",
-    "schema": null,
-    "default_version": "3.0alpha",
-    "installed_version": null,
     "comment": "PL/LiveScript (v8) trusted procedural language"
   },
   {
     "name": "plpgsql",
-    "schema": "pg_catalog",
-    "default_version": "1.0",
-    "installed_version": "1.0",
     "comment": "PL/pgSQL procedural language"
   },
   {
     "name": "plpgsql_check",
-    "schema": null,
-    "default_version": "1.11",
-    "installed_version": null,
     "comment": "extended check for plpgsql functions"
   },
   {
     "name": "plv8",
-    "schema": null,
-    "default_version": "3.0alpha",
-    "installed_version": null,
     "comment": "PL/JavaScript (v8) trusted procedural language"
   },
   {
     "name": "postgis",
-    "schema": null,
-    "default_version": "3.1.1",
-    "installed_version": null,
     "comment": "PostGIS geometry and geography spatial types and functions"
   },
   {
     "name": "postgis-3",
-    "schema": null,
-    "default_version": "3.1.1",
-    "installed_version": null,
     "comment": "PostGIS geometry and geography spatial types and functions"
   },
   {
     "name": "postgis_raster",
-    "schema": null,
-    "default_version": "3.1.1",
-    "installed_version": null,
     "comment": "PostGIS raster types and functions"
   },
   {
     "name": "postgis_raster-3",
-    "schema": null,
-    "default_version": "3.1.1",
-    "installed_version": null,
     "comment": "PostGIS raster types and functions"
   },
   {
     "name": "postgis_sfcgal",
-    "schema": null,
-    "default_version": "3.1.1",
-    "installed_version": null,
     "comment": "PostGIS SFCGAL functions"
   },
   {
     "name": "postgis_sfcgal-3",
-    "schema": null,
-    "default_version": "3.1.1",
-    "installed_version": null,
     "comment": "PostGIS SFCGAL functions"
   },
   {
     "name": "postgis_tiger_geocoder",
-    "schema": null,
-    "default_version": "3.1.1",
-    "installed_version": null,
     "comment": "PostGIS tiger geocoder and reverse geocoder"
   },
   {
     "name": "postgis_tiger_geocoder-3",
-    "schema": null,
-    "default_version": "3.1.1",
-    "installed_version": null,
     "comment": "PostGIS tiger geocoder and reverse geocoder"
   },
   {
     "name": "postgis_topology",
-    "schema": null,
-    "default_version": "3.1.1",
-    "installed_version": null,
     "comment": "PostGIS topology spatial types and functions"
   },
   {
     "name": "postgis_topology-3",
-    "schema": null,
-    "default_version": "3.1.1",
-    "installed_version": null,
     "comment": "PostGIS topology spatial types and functions"
   },
   {
     "name": "postgres_fdw",
-    "schema": null,
-    "default_version": "1.0",
-    "installed_version": null,
     "comment": "foreign-data wrapper for remote PostgreSQL servers"
   },
   {
     "name": "refint",
-    "schema": null,
-    "default_version": "1.0",
-    "installed_version": null,
     "comment": "functions for implementing referential integrity (obsolete)"
   },
   {
     "name": "seg",
-    "schema": null,
-    "default_version": "1.3",
-    "installed_version": null,
     "comment": "data type for representing line segments or floating-point intervals"
   },
   {
     "name": "sslinfo",
-    "schema": null,
-    "default_version": "1.2",
-    "installed_version": null,
     "comment": "information about SSL certificates"
   },
   {
     "name": "tablefunc",
-    "schema": null,
-    "default_version": "1.0",
-    "installed_version": null,
     "comment": "functions that manipulate whole tables, including crosstab"
   },
   {
     "name": "tcn",
-    "schema": null,
-    "default_version": "1.0",
-    "installed_version": null,
     "comment": "Triggered change notifications"
   },
   {
     "name": "tsm_system_rows",
-    "schema": null,
-    "default_version": "1.0",
-    "installed_version": null,
     "comment": "TABLESAMPLE method which accepts number of rows as a limit"
   },
   {
     "name": "tsm_system_time",
-    "schema": null,
-    "default_version": "1.0",
-    "installed_version": null,
     "comment": "TABLESAMPLE method which accepts time in milliseconds as a limit"
   },
   {
     "name": "unaccent",
-    "schema": null,
-    "default_version": "1.1",
-    "installed_version": null,
     "comment": "text search dictionary that removes accents"
   },
   {
     "name": "uuid-ossp",
-    "schema": "extensions",
-    "default_version": "1.1",
-    "installed_version": "1.1",
     "comment": "generate universally unique identifiers (UUIDs)"
   },
   {
     "name": "vector",
-    "schema": "extensions",
-    "default_version": "0.4.0",
-    "installed_version": null,
     "comment": "vector data type with similarity search"
   },
   {
     "name": "xml2",
-    "schema": null,
-    "default_version": "1.1",
-    "installed_version": null,
     "comment": "XPath querying and XSLT"
   },
   {
     "name": "rum",
-    "schema": "extensions",
-    "default_version": "1.3.13",
-    "installed_version": "1.3.13",
     "comment": "GIN-like index for text search"
   },
   {
     "name": "pg_repack",
-    "schema": "extensions",
-    "default_version": "1.4.8",
-    "installed_version": "1.4.8",
     "comment": "optimize physical storage and remove bloat from tables and indexes"
   }
 ]

--- a/apps/docs/data/extensions.json
+++ b/apps/docs/data/extensions.json
@@ -4,15 +4,7 @@
     "comment": "Used to parse an address into constituent elements. Generally used to support geocoding address normalization step."
   },
   {
-    "name": "address_standardizer-3",
-    "comment": "Used to parse an address into constituent elements. Generally used to support geocoding address normalization step."
-  },
-  {
     "name": "address_standardizer_data_us",
-    "comment": "Address Standardizer US dataset example"
-  },
-  {
-    "name": "address_standardizer_data_us-3",
     "comment": "Address Standardizer US dataset example"
   },
   {
@@ -80,6 +72,10 @@
     "comment": "HTTP client for PostgreSQL, allows web page retrieval inside the database."
   },
   {
+    "name": "hypopg",
+    "comment": "Hypothetical indexes for PostgreSQL"
+  },
+  {
     "name": "insert_username",
     "comment": "functions for tracking who changed a table"
   },
@@ -108,6 +104,10 @@
     "comment": "functions for tracking last modification time"
   },
   {
+    "name": "old_snapshot",
+    "comment": "utilities in support of old_snapshot_threshold"
+  },
+  {
     "name": "pageinspect",
     "comment": "inspect the contents of database pages at a low level"
   },
@@ -124,12 +124,40 @@
     "comment": "examine the free space map (FSM)"
   },
   {
+    "name": "pg_graphql",
+    "comment": "pg_graphql: GraphQL support"
+  },
+  {
+    "name": "pg_hashids",
+    "comment": "pg_hashids"
+  },
+  {
+    "name": "pg_jsonschema",
+    "comment": "pg_jsonschema"
+  },
+  {
+    "name": "pg_net",
+    "comment": "Async HTTP"
+  },
+  {
     "name": "pg_prewarm",
     "comment": "prewarm relation data"
   },
   {
+    "name": "pg_repack",
+    "comment": "Reorganize tables in PostgreSQL databases with minimal locks"
+  },
+  {
+    "name": "pg_stat_monitor",
+    "comment": "The pg_stat_monitor is a PostgreSQL Query Performance Monitoring tool, based on PostgreSQL contrib module pg_stat_statements. pg_stat_monitor provides aggregated statistics, client information, plan details including plan, and histogram information."
+  },
+  {
     "name": "pg_stat_statements",
-    "comment": "track execution statistics of all SQL statements executed"
+    "comment": "track planning and execution statistics of all SQL statements executed"
+  },
+  {
+    "name": "pg_surgery",
+    "comment": "extension to perform surgery on a damaged relation"
   },
   {
     "name": "pg_trgm",
@@ -138,6 +166,10 @@
   {
     "name": "pg_visibility",
     "comment": "examine the visibility map (VM) and page-level visibility info"
+  },
+  {
+    "name": "pg_walinspect",
+    "comment": "functions to inspect contents of PostgreSQL Write-Ahead Log"
   },
   {
     "name": "pgaudit",
@@ -152,8 +184,24 @@
     "comment": "JSON Web Token API for Postgresql"
   },
   {
+    "name": "pgroonga",
+    "comment": "Super fast and all languages supported full text search index based on Groonga"
+  },
+  {
+    "name": "pgroonga_database",
+    "comment": "PGroonga database management module"
+  },
+  {
+    "name": "pgrouting",
+    "comment": "pgRouting Extension"
+  },
+  {
     "name": "pgrowlocks",
     "comment": "show row-level locking information"
+  },
+  {
+    "name": "pgsodium",
+    "comment": "Postgres extension for libsodium functions"
   },
   {
     "name": "pgstattuple",
@@ -192,15 +240,7 @@
     "comment": "PostGIS geometry and geography spatial types and functions"
   },
   {
-    "name": "postgis-3",
-    "comment": "PostGIS geometry and geography spatial types and functions"
-  },
-  {
     "name": "postgis_raster",
-    "comment": "PostGIS raster types and functions"
-  },
-  {
-    "name": "postgis_raster-3",
     "comment": "PostGIS raster types and functions"
   },
   {
@@ -208,23 +248,11 @@
     "comment": "PostGIS SFCGAL functions"
   },
   {
-    "name": "postgis_sfcgal-3",
-    "comment": "PostGIS SFCGAL functions"
-  },
-  {
     "name": "postgis_tiger_geocoder",
     "comment": "PostGIS tiger geocoder and reverse geocoder"
   },
   {
-    "name": "postgis_tiger_geocoder-3",
-    "comment": "PostGIS tiger geocoder and reverse geocoder"
-  },
-  {
     "name": "postgis_topology",
-    "comment": "PostGIS topology spatial types and functions"
-  },
-  {
-    "name": "postgis_topology-3",
     "comment": "PostGIS topology spatial types and functions"
   },
   {
@@ -236,6 +264,10 @@
     "comment": "functions for implementing referential integrity (obsolete)"
   },
   {
+    "name": "rum",
+    "comment": "RUM index access method"
+  },
+  {
     "name": "seg",
     "comment": "data type for representing line segments or floating-point intervals"
   },
@@ -244,12 +276,20 @@
     "comment": "information about SSL certificates"
   },
   {
+    "name": "supautils",
+    "comment": "Supabase standard library"
+  },
+  {
     "name": "tablefunc",
     "comment": "functions that manipulate whole tables, including crosstab"
   },
   {
     "name": "tcn",
     "comment": "Triggered change notifications"
+  },
+  {
+    "name": "timescaledb",
+    "comment": "Enables scalable inserts and complex queries for time-series data"
   },
   {
     "name": "tsm_system_rows",
@@ -269,18 +309,14 @@
   },
   {
     "name": "vector",
-    "comment": "vector data type with similarity search"
+    "comment": "vector data type and ivfflat access method"
+  },
+  {
+    "name": "wrappers",
+    "comment": "Foreign data wrappers developed by Supabase"
   },
   {
     "name": "xml2",
     "comment": "XPath querying and XSLT"
-  },
-  {
-    "name": "rum",
-    "comment": "GIN-like index for text search"
-  },
-  {
-    "name": "pg_repack",
-    "comment": "optimize physical storage and remove bloat from tables and indexes"
   }
 ]


### PR DESCRIPTION
## What kind of change does this PR introduce?
Update the extension register AO 2022-02-15 and removes unused keys from json objects

Can be refreshed with
```sql
select
  jsonb_pretty(
    jsonb_agg(
      jsonb_build_object(
        'name', name,
        'comment', comment
      )
      order by name asc
    )
    )
from
  pg_available_extensions;
```