### PR TITLE
add warning to the flutterflow guide indicating that the integration is in alpha

### DIFF
--- a/apps/docs/pages/guides/integrations/flutterflow.mdx
+++ b/apps/docs/pages/guides/integrations/flutterflow.mdx
@@ -10,6 +10,11 @@ export const meta = {
 
 [FlutterFlow](https://flutterflow.io/) is a low-code builder for developing native mobile applications using Flutter. You can use the simple drag-and-drop interface to build your app faster than traditional development.
 
+This guide gives you a quick overview of implementing basic CRUD operations using FlutterFlow and Supabase. You can find the full docs on FlutterFlow and Supabase [here](https://docs.flutterflow.io/actions/actions/backend-database/supabase).
+
+> **Warning**
+> FlutterFlow and Supabase integration is currently in alpha, and supported features may be limited. 
+
 <div className="video-container">
   <iframe
     src="https://www.youtube-nocookie.com/embed/hw9Q-NjASbU"
@@ -19,7 +24,6 @@ export const meta = {
   ></iframe>
 </div>
 
-This guide gives you a quick overview of implementing basic CRUD operations using FlutterFlow and Supabase. You can find the full docs on FlutterFlow and Supabase [here](https://docs.flutterflow.io/actions/actions/backend-database/supabase).
 
 ## Step 1: Connect FlutterFlow to Supabase
 

--- a/apps/docs/pages/guides/integrations/flutterflow.mdx
+++ b/apps/docs/pages/guides/integrations/flutterflow.mdx
@@ -13,7 +13,7 @@ export const meta = {
 This guide gives you a quick overview of implementing basic CRUD operations using FlutterFlow and Supabase. You can find the full docs on FlutterFlow and Supabase [here](https://docs.flutterflow.io/actions/actions/backend-database/supabase).
 
 > **Warning**
-> FlutterFlow and Supabase integration is currently in alpha, and supported features may be limited. 
+> FlutterFlow and Supabase integration is currently in alpha, and supported features may be limited.
 
 <div className="video-container">
   <iframe

--- a/apps/docs/pages/guides/integrations/flutterflow.mdx
+++ b/apps/docs/pages/guides/integrations/flutterflow.mdx
@@ -8,12 +8,13 @@ export const meta = {
   canonical: 'https://docs.flutterflow.io/actions/actions/backend-database/supabase',
 }
 
+<Admonition type="caution">
+  FlutterFlow and Supabase integration is currently in alpha, and supported features may be limited.
+</Admonition>
+
 [FlutterFlow](https://flutterflow.io/) is a low-code builder for developing native mobile applications using Flutter. You can use the simple drag-and-drop interface to build your app faster than traditional development.
 
 This guide gives you a quick overview of implementing basic CRUD operations using FlutterFlow and Supabase. You can find the full docs on FlutterFlow and Supabase [here](https://docs.flutterflow.io/actions/actions/backend-database/supabase).
-
-> **Warning**
-> FlutterFlow and Supabase integration is currently in alpha, and supported features may be limited. 
 
 <div className="video-container">
   <iframe


### PR DESCRIPTION
## What kind of change does this PR introduce?

Users seem to expect that FlutterFlow integration supports all the features, so adding a waiting label indicating that the integration is currently in alpha. 