### PR TITLE
Docs suggestion - Update database-usage.mdx for clarity on free tier and paid tier behaviour and read only for both free and paid

### DIFF
--- a/apps/docs/pages/guides/platform/database-usage.mdx
+++ b/apps/docs/pages/guides/platform/database-usage.mdx
@@ -40,7 +40,11 @@ For [disk auto-scaling](paid-tier-disk-auto-scaling), and avoid your database en
 Pro and Enterprise have disk auto-scaling. Storage expands automatically when the database reaches 90% of the disk size. The disk is expanded to be 50% larger (e.g., 8GB -> 12GB).
 Auto-scaling can only take place once every 6 hours.
 
+<Admonition type="caution">
+
 If you intend to import a lot of data into your database that would require multiple storage expansions then [reach out to our team](https://app.supabase.com/support/new), otherwise your project might enter a ['read-only' mode](#paid-tier-project-read-only-mode).
+
+</Admonition>
 
 If you need more than 1024TB of disk size or require multiple storage expansions in a short period of time, [contact us](https://app.supabase.com/support/new) to learn more about the Enterprise plan.
 

--- a/apps/docs/pages/guides/platform/database-usage.mdx
+++ b/apps/docs/pages/guides/platform/database-usage.mdx
@@ -57,17 +57,18 @@ Regular operation (read-write mode) is automatically re-enabled once usage is be
 
 ### Increasing available disk size
 
-1. [Upgrade to the Pro or Enterprise plan](https://app.supabase.com/project/_/settings/billing/subscription) to increase your quota and expand your disk size automatically.
+If your project is on the free tier, you can [Upgrade to the Pro or Enterprise tier](https://app.supabase.com/project/_/settings/billing/subscription) so that your disk size can start to [auto scale](#paid-tier-disk-auto-scaling) beyond 8GB.
 
-2. Delete data from your project's database to lower its disk usage.
-   If your database is already in read-only mode, run the following command to change the transaction mode to read-write for your session:
+For Free tier projects that do not wish to upgrade, or Pro tier projects that are nearing their disk size limit, you can increase available disk size by deleting data from your project's database to lower its disk usage.
 
-   ```sql
-   SET
-     default_transaction_read_only = 'off';
-   ```
+If your free tier project database is already in read-only mode, run the following command to change the transaction mode to read-write for your session:
 
-   This allows you to delete data from within the session.
+```sql
+SET
+  default_transaction_read_only = 'off';
+```
+
+This allows you to delete data from within the session.
 
 ### Preoccupied Space
 

--- a/apps/docs/pages/guides/platform/database-usage.mdx
+++ b/apps/docs/pages/guides/platform/database-usage.mdx
@@ -23,11 +23,14 @@ This value is also reported in the [database settings page](https://app.supabase
 ## Database storage management
 
 Supabase uses network-attached storage to balance performance with scalability.
-For Pro and Enterprise projects, disk size expands ~1.5x automatically (e.g., 8GB -> 12GB) when you reach 90% of the disk size.
-Disk size expansion can only occur once every six hours.
-Pro projects can store up to 1024TB.
 
-### Free tier project 'read-only' mode at 95% disk size use
+For Pro and Enterprise tier projects, [disk size expands ~1.5x automatically](#paid-tier-automatic-disk-resizing) (e.g., 8GB -> 12GB) when you reach 90% of the disk size. Disk size expansion can only occur once every six hours.
+
+For Free tier projects, the database will enter ['read only' mode when you reach 95% disk space](#free-tier-project-read-only-mode).
+
+Pro and enterprise tier projects can store up to 1024TB.
+
+### Free tier project 'read-only' mode
 
 Free tier projects enter read-only mode when you reach 95% of the disk size.
 In read-only mode, clients will encounter errors such as `cannot execute INSERT in a read-only transaction`.
@@ -37,11 +40,9 @@ For automatic disk resizing, and avoid your database entering read-only mode, yo
 
 ### Paid tier automatic disk resizing
 
-If you are on Pro or Enterprise, database storage expands automatically. Usually the disk is expanded to be 50% larger.
+If you are on Pro or Enterprise, database storage expands automatically. Usually the disk is expanded to be 50% larger. For every automatic database storage expansion, it will not auto expand for another 6 hours.
 
-However, you may also encounter this error if you fill the database faster than it can expand. For every automatic database storage expansion, it will not auto expand for another 6 hours.
-
-During this 6 hour period, if you reach 95% of the disk space, your project may enter read-only mode. In read-only mode, clients will encounter errors such as `cannot execute INSERT in a read-only transaction`.
+During this 6 hour period, if you reach 95% of the disk space, your project will enter read-only mode. In read-only mode, clients will encounter errors such as `cannot execute INSERT in a read-only transaction`.
 Regular operation (read-write mode) is automatically re-enabled once usage is below 95% of the disk size.
 
 If you intend to import a lot of data into your database that would require multiple storage expansions then [reach out to our team](https://app.supabase.com/support/new).

--- a/apps/docs/pages/guides/platform/database-usage.mdx
+++ b/apps/docs/pages/guides/platform/database-usage.mdx
@@ -24,9 +24,8 @@ This value is also reported in the [database settings page](https://app.supabase
 
 Supabase uses network-attached storage to balance performance with scalability.
 
-For Free tier projects, the database will enter ['read only' mode when you reach 95% disk space](#free-tier-project-read-only-mode).
-
-For Pro and Enterprise tier projects, your [disk size expands automatically](#paid-tier-disk-auto-scaling).
+- For **Free tier projects**, the database will enter ['read only' mode when you reach 95% disk space](#free-tier-project-read-only-mode).
+- For **Pro and Enterprise tier projects**, your [disk size expands automatically](#paid-tier-disk-auto-scaling).
 
 ### Free tier project 'read-only' mode
 

--- a/apps/docs/pages/guides/platform/database-usage.mdx
+++ b/apps/docs/pages/guides/platform/database-usage.mdx
@@ -27,8 +27,24 @@ For Pro and Enterprise projects, disk size expands ~1.5x automatically (e.g., 8G
 Disk size expansion can only occur once every six hours.
 Pro projects can store up to 1024TB.
 
-All projects enter read-only mode when you reach 95% of the disk size. In read-only mode, clients will encounter errors such as `cannot execute INSERT in a read-only transaction`.
+### Free tier project 'read-only' mode at 95% disk size use
+
+Free tier projects enter read-only mode when you reach 95% of the disk size.
+In read-only mode, clients will encounter errors such as `cannot execute INSERT in a read-only transaction`.
 Regular operation (read-write mode) is automatically re-enabled once usage is below 95% of the disk size.
+
+For automatic disk resizing, and avoid your database entering read-only mode, you can [upgrade to the Pro or Enterprise plan](https://app.supabase.com/project/_/settings/billing/subscription).
+
+### Paid tier automatic disk resizing
+
+If you are on Pro or Enterprise, database storage expands automatically. Usually the disk is expanded to be 50% larger.
+
+However, you may also encounter this error if you fill the database faster than it can expand. For every automatic database storage expansion, it will not auto expand for another 6 hours.
+
+During this 6 hour period, if you reach 95% of the disk space, your project may enter read-only mode. In read-only mode, clients will encounter errors such as `cannot execute INSERT in a read-only transaction`.
+Regular operation (read-write mode) is automatically re-enabled once usage is below 95% of the disk size.
+
+If you intend to import a lot of data into your database that would require multiple storage expansions then [reach out to our team](https://app.supabase.com/support/new).
 
 If you need more than 1024TB of disk size or require multiple storage expansions in a short period of time, [contact us](https://app.supabase.com/support/new) to learn more about the Enterprise plan.
 
@@ -36,7 +52,8 @@ If you need more than 1024TB of disk size or require multiple storage expansions
 
 1. [Upgrade to the Pro or Enterprise plan](https://app.supabase.com/project/_/settings/billing/subscription) to increase your quota and expand your disk size automatically.
 
-2. Delete data from your project's database to lower its disk usage. If your database is already in read-only mode, run the following command to change the transaction mode to read-write for your session:
+2. Delete data from your project's database to lower its disk usage.
+   If your database is already in read-only mode, run the following command to change the transaction mode to read-write for your session:
 
    ```sql
    SET

--- a/apps/docs/pages/guides/platform/database-usage.mdx
+++ b/apps/docs/pages/guides/platform/database-usage.mdx
@@ -24,20 +24,21 @@ This value is also reported in the [database settings page](https://app.supabase
 
 Supabase uses network-attached storage to balance performance with scalability.
 
-- For **Free tier projects**, the database will enter ['read only' mode when you reach 95% disk space](#free-tier-project-read-only-mode).
+- For **Free tier projects**, the database can enter ['read only' mode when you exceed the 500mb limit](#free-tier-project-read-only-mode).
 - For **Pro and Enterprise tier projects**, your [disk size expands automatically](#paid-tier-disk-auto-scaling).
 
 ### Free tier project 'read-only' mode
 
-Free tier projects enter read-only mode when you reach 95% of the disk size.
-In read-only mode, clients will encounter errors such as `cannot execute INSERT in a read-only transaction`.
-Regular operation (read-write mode) is automatically re-enabled once usage is below 95% of the disk size.
+Free tier projects can enter read-only mode when exceeding the 500mb database size limit.
 
-For [disk auto-scaling](paid-tier-disk-auto-scaling), and avoid your database entering read-only mode, you can [upgrade to the Pro or Enterprise plan](https://app.supabase.com/project/_/settings/billing/subscription).
+In read-only mode, clients will encounter errors such as `cannot execute INSERT in a read-only transaction`.
+Regular operation (read-write mode) is automatically re-enabled once database storage is below the 500mb database size limit.
+
+For more database storage and avoid your database entering read-only mode when exceeding the limit, you can [upgrade to the Pro or Enterprise plan](https://app.supabase.com/project/_/settings/billing/subscription).
 
 ### Paid tier disk auto-scaling
 
-Pro and Enterprise have disk auto-scaling. Storage expands automatically when the database reaches 90% of the disk size. The disk is expanded to be 50% larger (e.g., 8GB -> 12GB).
+Pro and Enterprise have disk auto-scaling. Database storage expands automatically when the database reaches 90% of the disk size. The disk is expanded to be 50% larger (e.g., 8GB -> 12GB).
 Auto-scaling can only take place once every 6 hours.
 
 <Admonition type="caution">
@@ -48,9 +49,9 @@ If you intend to import a lot of data into your database that would require mult
 
 You may require multiple storage expansions in a short period of time. For example, you need to upload more than 1.5x the current size of your database storage. This will lead to your database entering a [read-only mode](#paid-tier-project-read-only-mode). You can avoid this by [contacting the support team](https://app.supabase.com/support/new) so that your database can be resized to a sufficient amount before you start uploading to it.
 
-If you need more than 1024TB of disk size, you can [contact us](https://app.supabase.com/support/new) to learn more about the Enterprise plan. 
+If you need more than 1024TB of disk size, you can [contact us](https://app.supabase.com/support/new) to learn more about the Enterprise plan.
 
-#### Paid tier project 'read-only' mode
+### Paid tier project 'read-only' mode
 
 Database storage expands, at most, once every 6 hours.
 If within those 6 hours you reach 95% of the disk space, your project will enter read-only mode.
@@ -58,13 +59,13 @@ If within those 6 hours you reach 95% of the disk space, your project will enter
 In read-only mode, clients will encounter errors such as `cannot execute INSERT in a read-only transaction`.
 Regular operation (read-write mode) is automatically re-enabled once usage is below 95% of the disk size, or when the database automatically resizes after the 6 hour period.
 
-### Increasing available disk size
+### Increasing available database space
 
-If your project is on the free tier, you can [Upgrade to the Pro or Enterprise tier](https://app.supabase.com/project/_/settings/billing/subscription) so that your disk size can start to [auto scale](#paid-tier-disk-auto-scaling) beyond 8GB.
+If your project is on the free tier, you can [Upgrade to the Pro or Enterprise tier](https://app.supabase.com/project/_/settings/billing/subscription) so that you can start to use more than 500mb.
 
-For Free tier projects that do not wish to upgrade, or Pro tier projects that are nearing their disk size limit, you can increase available disk size by deleting data from your project's database to lower its disk usage.
+For Pro and Enterprise tier projects that are [nearing their disk size limit](#paid-tier-project-read-only-mode), you can increase available disk size by deleting data from your project's database to lower its disk usage.
 
-If your free tier project database is already in read-only mode, run the following command to change the transaction mode to read-write for your session:
+If your project database is already in read-only mode, run the following command to change the transaction mode to read-write for your session:
 
 ```sql
 SET

--- a/apps/docs/pages/guides/platform/database-usage.mdx
+++ b/apps/docs/pages/guides/platform/database-usage.mdx
@@ -42,12 +42,17 @@ For automatic disk resizing, and avoid your database entering read-only mode, yo
 
 If you are on Pro or Enterprise, database storage expands automatically. Usually the disk is expanded to be 50% larger. For every automatic database storage expansion, it will not auto expand for another 6 hours.
 
-During this 6 hour period, if you reach 95% of the disk space, your project will enter read-only mode. In read-only mode, clients will encounter errors such as `cannot execute INSERT in a read-only transaction`.
-Regular operation (read-write mode) is automatically re-enabled once usage is below 95% of the disk size.
-
-If you intend to import a lot of data into your database that would require multiple storage expansions then [reach out to our team](https://app.supabase.com/support/new).
+If you intend to import a lot of data into your database that would require multiple storage expansions then [reach out to our team](https://app.supabase.com/support/new), otherwise your project might enter a ['read-only' mode](#paid-tier-project-read-only-mode).
 
 If you need more than 1024TB of disk size or require multiple storage expansions in a short period of time, [contact us](https://app.supabase.com/support/new) to learn more about the Enterprise plan.
+
+#### Paid tier project 'read-only' mode
+
+During the 6 hour period after an automatic resize, your database will not automatically resize until after 6 hours.
+If within those 6 hours you reach 95% of the disk space, your project will enter read-only mode.
+
+In read-only mode, clients will encounter errors such as `cannot execute INSERT in a read-only transaction`.
+Regular operation (read-write mode) is automatically re-enabled once usage is below 95% of the disk size.
 
 ### Increasing available disk size
 

--- a/apps/docs/pages/guides/platform/database-usage.mdx
+++ b/apps/docs/pages/guides/platform/database-usage.mdx
@@ -24,7 +24,7 @@ This value is also reported in the [database settings page](https://app.supabase
 
 Supabase uses network-attached storage to balance performance with scalability.
 
-For Pro and Enterprise tier projects, [disk size expands ~1.5x automatically](#paid-tier-automatic-disk-resizing) when you reach 90% of the disk size. Disk size expansion can only occur once every six hours.
+For Pro and Enterprise tier projects, [disk size expands ~1.5x automatically](#paid-tier-disk-auto-scaling) when you reach 90% of the disk size. Disk size expansion can only occur once every six hours.
 
 For Free tier projects, the database will enter ['read only' mode when you reach 95% disk space](#free-tier-project-read-only-mode).
 
@@ -36,12 +36,12 @@ Free tier projects enter read-only mode when you reach 95% of the disk size.
 In read-only mode, clients will encounter errors such as `cannot execute INSERT in a read-only transaction`.
 Regular operation (read-write mode) is automatically re-enabled once usage is below 95% of the disk size.
 
-For [automatic disk resizing](paid-tier-automatic-disk-resizing), and avoid your database entering read-only mode, you can [upgrade to the Pro or Enterprise plan](https://app.supabase.com/project/_/settings/billing/subscription).
+For [disk auto-scaling](paid-tier-disk-auto-scaling), and avoid your database entering read-only mode, you can [upgrade to the Pro or Enterprise plan](https://app.supabase.com/project/_/settings/billing/subscription).
 
-### Paid tier automatic disk resizing
+### Paid tier disk auto-scaling
 
-If you are on Pro or Enterprise, database storage expands automatically when you reach 90% of the disk size. Usually the disk is expanded to be 50% larger (e.g., 8GB -> 12GB).
-For every automatic database storage expansion, it will not auto expand for another 6 hours.
+Pro and Enterprise have disk auto-scaling. Storage expands automatically when the database reaches 90% of the disk size. The disk is expanded to be 50% larger (e.g., 8GB -> 12GB).
+Auto-scaling can only take place once every 6 hours.
 
 If you intend to import a lot of data into your database that would require multiple storage expansions then [reach out to our team](https://app.supabase.com/support/new), otherwise your project might enter a ['read-only' mode](#paid-tier-project-read-only-mode).
 
@@ -49,7 +49,7 @@ If you need more than 1024TB of disk size or require multiple storage expansions
 
 #### Paid tier project 'read-only' mode
 
-During the 6 hour period after an automatic resize, your database will not automatically resize until after 6 hours.
+Database storage expands, at most, once every 6 hours.
 If within those 6 hours you reach 95% of the disk space, your project will enter read-only mode.
 
 In read-only mode, clients will encounter errors such as `cannot execute INSERT in a read-only transaction`.

--- a/apps/docs/pages/guides/platform/database-usage.mdx
+++ b/apps/docs/pages/guides/platform/database-usage.mdx
@@ -46,7 +46,9 @@ If you intend to import a lot of data into your database that would require mult
 
 </Admonition>
 
-If you need more than 1024TB of disk size or require multiple storage expansions in a short period of time, [contact us](https://app.supabase.com/support/new) to learn more about the Enterprise plan.
+You may require multiple storage expansions in a short period of time. For example, you need to upload more than 1.5x the current size of your database storage. This will lead to your database entering a [read-only mode](#paid-tier-project-read-only-mode). You can avoid this by [contacting the support team](https://app.supabase.com/support/new) so that your database can be resized to a sufficient amount before you start uploading to it.
+
+If you need more than 1024TB of disk size, you can [contact us](https://app.supabase.com/support/new) to learn more about the Enterprise plan. 
 
 #### Paid tier project 'read-only' mode
 

--- a/apps/docs/pages/guides/platform/database-usage.mdx
+++ b/apps/docs/pages/guides/platform/database-usage.mdx
@@ -24,7 +24,7 @@ This value is also reported in the [database settings page](https://app.supabase
 
 Supabase uses network-attached storage to balance performance with scalability.
 
-For Pro and Enterprise tier projects, [disk size expands ~1.5x automatically](#paid-tier-automatic-disk-resizing) (e.g., 8GB -> 12GB) when you reach 90% of the disk size. Disk size expansion can only occur once every six hours.
+For Pro and Enterprise tier projects, [disk size expands ~1.5x automatically](#paid-tier-automatic-disk-resizing) when you reach 90% of the disk size. Disk size expansion can only occur once every six hours.
 
 For Free tier projects, the database will enter ['read only' mode when you reach 95% disk space](#free-tier-project-read-only-mode).
 
@@ -36,11 +36,12 @@ Free tier projects enter read-only mode when you reach 95% of the disk size.
 In read-only mode, clients will encounter errors such as `cannot execute INSERT in a read-only transaction`.
 Regular operation (read-write mode) is automatically re-enabled once usage is below 95% of the disk size.
 
-For automatic disk resizing, and avoid your database entering read-only mode, you can [upgrade to the Pro or Enterprise plan](https://app.supabase.com/project/_/settings/billing/subscription).
+For [automatic disk resizing](paid-tier-automatic-disk-resizing), and avoid your database entering read-only mode, you can [upgrade to the Pro or Enterprise plan](https://app.supabase.com/project/_/settings/billing/subscription).
 
 ### Paid tier automatic disk resizing
 
-If you are on Pro or Enterprise, database storage expands automatically. Usually the disk is expanded to be 50% larger. For every automatic database storage expansion, it will not auto expand for another 6 hours.
+If you are on Pro or Enterprise, database storage expands automatically when you reach 90% of the disk size. Usually the disk is expanded to be 50% larger (e.g., 8GB -> 12GB).
+For every automatic database storage expansion, it will not auto expand for another 6 hours.
 
 If you intend to import a lot of data into your database that would require multiple storage expansions then [reach out to our team](https://app.supabase.com/support/new), otherwise your project might enter a ['read-only' mode](#paid-tier-project-read-only-mode).
 
@@ -52,7 +53,7 @@ During the 6 hour period after an automatic resize, your database will not autom
 If within those 6 hours you reach 95% of the disk space, your project will enter read-only mode.
 
 In read-only mode, clients will encounter errors such as `cannot execute INSERT in a read-only transaction`.
-Regular operation (read-write mode) is automatically re-enabled once usage is below 95% of the disk size.
+Regular operation (read-write mode) is automatically re-enabled once usage is below 95% of the disk size, or when the database automatically resizes after the 6 hour period.
 
 ### Increasing available disk size
 

--- a/apps/docs/pages/guides/platform/database-usage.mdx
+++ b/apps/docs/pages/guides/platform/database-usage.mdx
@@ -24,11 +24,9 @@ This value is also reported in the [database settings page](https://app.supabase
 
 Supabase uses network-attached storage to balance performance with scalability.
 
-For Pro and Enterprise tier projects, [disk size expands ~1.5x automatically](#paid-tier-disk-auto-scaling) when you reach 90% of the disk size. Disk size expansion can only occur once every six hours.
-
 For Free tier projects, the database will enter ['read only' mode when you reach 95% disk space](#free-tier-project-read-only-mode).
 
-Pro and enterprise tier projects can store up to 1024TB.
+For Pro and Enterprise tier projects, your [disk size expands automatically](#paid-tier-disk-auto-scaling).
 
 ### Free tier project 'read-only' mode
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

- updated for clarity of DB resize/read only behavior between paid and free tiers
- sub headers for easier linking from the dashboard and CLI
- clarify DB behavior for paid tier when reaching 95% disk space within 6 hour resize period.
- more anchor links 