### PR TITLE
fix: add align-items: center style to CreateFunction input rows

### DIFF
--- a/studio/components/interfaces/Database/Functions/CreateFunction.tsx
+++ b/studio/components/interfaces/Database/Functions/CreateFunction.tsx
@@ -577,7 +577,7 @@ const InputArgument: FC<InputArgumentProps> = observer(({ idx, name, type, error
   }
 
   return (
-    <div className="flex flex-row space-x-1">
+    <div className="flex flex-row space-x-1 items-center">
       <Input
         id={`name-${idx}`}
         className="flex-1 flex-grow"
@@ -699,7 +699,7 @@ const InputConfigParam: FC<InputConfigParamProps> = observer(({ idx, name, value
   }
 
   return (
-    <div className="flex space-x-1">
+    <div className="flex space-x-1 items-center">
       <Input
         id={`name-${idx}`}
         className="flex-1"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (resolves #12484)

## What is the current behavior?

Currently, the inputs & delete button are not aligned. See the screenshots in #12484

## What is the new behavior?

The delete button is aligned with the inputs.

<img width="641" alt="image" src="https://user-images.githubusercontent.com/11774799/219465046-b4d400c8-8b0c-4974-9422-4ed2b581633b.png">
<img width="645" alt="image" src="https://user-images.githubusercontent.com/11774799/219465071-4635d760-f4e5-4f2b-b25f-fa142c1227d4.png">

## Additional context

N/A
