### PR TITLE
fix: lib prop for Real-time NavigationMenuRefList should be self-hosting-realtime instead of self-hosting-auth

### DIFF
--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.tsx
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.tsx
@@ -298,7 +298,7 @@ const NavigationMenu = () => {
         id={'reference_self_hosting_realtime'}
         active={isReference_Self_Hosting_Realtime}
         commonSections={realtimeServerCommonSections}
-        lib="self-hosting-auth"
+        lib="self-hosting-realtime"
       />
     </div>
   )


### PR DESCRIPTION

## What kind of change does this PR introduce?

Bug fix (resolves #12483)

## What is the current behavior?

See #12483 - the **Introduction** link at https://supabase.com/docs/reference/self-hosting-realtime/introduction points to https://supabase.com/docs/reference/self-hosting-auth/introduction instead of https://supabase.com/docs/reference/self-hosting-realtime/introduction

## What is the new behavior?

The **Introduction** link correctly points to `/docs/reference/self-hosting-realtime/introduction` 

![image](https://user-images.githubusercontent.com/11774799/219508604-71bbd142-34d1-40a4-8abf-ddfe6cd1ce94.png)

## Additional context

N/A
