### PR TITLE
fix: hide copy about Advanced Settings when editing Database Function

### DIFF
--- a/studio/components/interfaces/Database/Functions/CreateFunction.tsx
+++ b/studio/components/interfaces/Database/Functions/CreateFunction.tsx
@@ -120,6 +120,7 @@ interface ICreateFunctionStore {
   formState: CreateFunctionFormState
   meta: any
   schemas: Dictionary<any>[]
+  isEditing: boolean
   onFormChange: (value: { key: string; value: any }) => void
   onFormArrayChange: (value: {
     operation: 'add' | 'delete' | 'update'
@@ -732,7 +733,7 @@ const InputConfigParam: FC<InputConfigParamProps> = observer(({ idx, name, value
 })
 
 const InputDefinition: FC = observer(({}) => {
-  const _localState = useContext(CreateFunctionContext) as CreateFunctionStore
+  const _localState = useContext(CreateFunctionContext)
   return (
     <div className="space-y-4">
       <div className="flex flex-col">
@@ -740,7 +741,7 @@ const InputDefinition: FC = observer(({}) => {
         <p className="text-sm text-scale-1100">
           The language below should be written in `{_localState!.formState.language.value}`.
         </p>
-        {!_localState.isEditing && (
+        {!_localState?.isEditing && (
           <p className="text-sm text-scale-1100">
             Change the language in the Advanced Settings below.
           </p>

--- a/studio/components/interfaces/Database/Functions/CreateFunction.tsx
+++ b/studio/components/interfaces/Database/Functions/CreateFunction.tsx
@@ -732,7 +732,7 @@ const InputConfigParam: FC<InputConfigParamProps> = observer(({ idx, name, value
 })
 
 const InputDefinition: FC = observer(({}) => {
-  const _localState = useContext(CreateFunctionContext)
+  const _localState = useContext(CreateFunctionContext) as CreateFunctionStore
   return (
     <div className="space-y-4">
       <div className="flex flex-col">
@@ -740,9 +740,11 @@ const InputDefinition: FC = observer(({}) => {
         <p className="text-sm text-scale-1100">
           The language below should be written in `{_localState!.formState.language.value}`.
         </p>
-        <p className="text-sm text-scale-1100">
-          Change the language in the Advanced Settings below.
-        </p>
+        {!_localState.isEditing && (
+          <p className="text-sm text-scale-1100">
+            Change the language in the Advanced Settings below.
+          </p>
+        )}
       </div>
       <div className="h-40 border dark:border-dark">
         <SqlEditor


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix/UX update

## What is the current behavior?

See #12243 - since certain data around a database function can't really be changed once created (it needs to be dropped and recreated), most of the form is read-only while editing. However, there's still some instruction in the UI to show Advanced Settings, which isn't allowed.

## What is the new behavior?

Since the Advanced Settings section isn't allowed to be toggled on/edited once the function is created, I conditionally rendered the copy while the computed `isEditing` function returns true.

## Additional context

New function (unchanged):
<img width="672" alt="image" src="https://user-images.githubusercontent.com/11774799/219522639-d2d613f7-5b45-41b4-be1d-2ef6f359ff2c.png">

While editing (Copy about Advanced Settings no longer shows):
<img width="676" alt="image" src="https://user-images.githubusercontent.com/11774799/219522572-27b6cb2c-bf23-4c9a-94da-2e1f375f0060.png">

I changed the minimum amount of code to make this work, but these components could probably use a refactoring pass. There's a lot going on in this file - some of these components could be broken out into their own files, and I'm not sure the use of context/mobx is really necessary here. Let me know!
