### PR TITLE
Add section on managing metadata

### DIFF
--- a/apps/docs/pages/guides/auth/managing-user-data.mdx
+++ b/apps/docs/pages/guides/auth/managing-user-data.mdx
@@ -89,8 +89,6 @@ Make sure you _NEVER_ expose this publicly. But it can be used on the server-sid
 
 ## Accessing User Metadata
 
-Users can pass in metadata on sign up. User metadata is stored on the `raw_user_meta_data` column of the `auth.users` table.
-
 You can assign metadata to users on sign up:
 
 ```js

--- a/apps/docs/pages/guides/auth/managing-user-data.mdx
+++ b/apps/docs/pages/guides/auth/managing-user-data.mdx
@@ -91,7 +91,7 @@ Make sure you _NEVER_ expose this publicly. But it can be used on the server-sid
 
 Users can pass in metadata on sign up. User metadata is stored on the `raw_user_meta_data` column of the `auth.users` table.
 
-Here's an example of how to add metadata fields on signup:
+You can assign metadata to users on sign up:
 
 ```js
 const { data, error } = await supabase.auth.signUp(

--- a/apps/docs/pages/guides/auth/managing-user-data.mdx
+++ b/apps/docs/pages/guides/auth/managing-user-data.mdx
@@ -92,18 +92,16 @@ Make sure you _NEVER_ expose this publicly. But it can be used on the server-sid
 You can assign metadata to users on sign up:
 
 ```js
-const { data, error } = await supabase.auth.signUp(
-  {
-    email: 'example@email.com',
-    password: 'example-password',
-    options: {
-      data: {
-        first_name: 'John',
-        age: 27,
-      }
-    }
-  }
-)
+const { data, error } = await supabase.auth.signUp({
+  email: 'example@email.com',
+  password: 'example-password',
+  options: {
+    data: {
+      first_name: 'John',
+      age: 27,
+    },
+  },
+})
 ```
 
 User metadata is stored on the `raw_user_meta_data` column of the `auth.users` table. To view the metadata:

--- a/apps/docs/pages/guides/auth/managing-user-data.mdx
+++ b/apps/docs/pages/guides/auth/managing-user-data.mdx
@@ -87,6 +87,34 @@ If you need to fetch a full list of user profiles, we supply a `service_key` whi
 
 Make sure you _NEVER_ expose this publicly. But it can be used on the server-side to fetch all of the profiles.
 
+## Accessing User Metadata
+
+Users can pass in metadata on sign up. User metadata is stored on the `raw_user_meta_data` column of the `auth.users` table.
+
+Here's an example of how to add metadata fields on signup: 
+
+```
+const { data, error } = await supabase.auth.signUp(
+  {
+    email: 'example@email.com',
+    password: 'example-password',
+    options: {
+      data: {
+        first_name: 'John',
+        age: 27,
+      }
+    }
+  }
+)
+```
+
+To view the metadata:
+
+```js
+const { data: { user } } = await supabase.auth.getUser()
+let metadata = user.user_metadata
+```
+
 ## Advanced techniques
 
 ### Using triggers

--- a/apps/docs/pages/guides/auth/managing-user-data.mdx
+++ b/apps/docs/pages/guides/auth/managing-user-data.mdx
@@ -93,7 +93,7 @@ Users can pass in metadata on sign up. User metadata is stored on the `raw_user_
 
 Here's an example of how to add metadata fields on signup:
 
-```
+```js
 const { data, error } = await supabase.auth.signUp(
   {
     email: 'example@email.com',
@@ -108,7 +108,7 @@ const { data, error } = await supabase.auth.signUp(
 )
 ```
 
-To view the metadata:
+User metadata is stored on the `raw_user_meta_data` column of the `auth.users` table. To view the metadata:
 
 ```js
 const {

--- a/apps/docs/pages/guides/auth/managing-user-data.mdx
+++ b/apps/docs/pages/guides/auth/managing-user-data.mdx
@@ -91,7 +91,7 @@ Make sure you _NEVER_ expose this publicly. But it can be used on the server-sid
 
 Users can pass in metadata on sign up. User metadata is stored on the `raw_user_meta_data` column of the `auth.users` table.
 
-Here's an example of how to add metadata fields on signup: 
+Here's an example of how to add metadata fields on signup:
 
 ```
 const { data, error } = await supabase.auth.signUp(
@@ -111,7 +111,9 @@ const { data, error } = await supabase.auth.signUp(
 To view the metadata:
 
 ```js
-const { data: { user } } = await supabase.auth.getUser()
+const {
+  data: { user },
+} = await supabase.auth.getUser()
 let metadata = user.user_metadata
 ```
 


### PR DESCRIPTION
There have been many queries about metadata management which suggests that it's probably worth adding a section about it. 


Some issues about it - 

[How to get Metadata](https://github.com/supabase/gotrue-js/issues/576)
[OAuth User metadata](https://github.com/supabase/gotrue-js/issues/457) -> This is still [not merged yet](https://github.com/supabase/gotrue-js/pull/611) but it falls under the same category of metadata management
[Discord metadata](https://github.com/supabase/gotrue-js/issues/453)
[Security definer metadata](https://github.com/supabase/gotrue/issues/975) -> Needs verification