### PR TITLE
Add docker-compose-override.yml to .gitignore

### DIFF
--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -2,3 +2,4 @@ volumes/db/data
 volumes/storage
 .env
 test.http
+docker-compose.override.yml


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature.
Adds `docker-compose.override.yml` in `.gitignore` to allow me and others to update containers without having the file tracked by git.
Also docker compose picks up this file automatically: https://docs.docker.com/compose/extends/#understanding-multiple-compose-files

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
