### PR TITLE
docs: reserved words filter

### DIFF
--- a/spec/supabase_js_v2.yml
+++ b/spec/supabase_js_v2.yml
@@ -2258,6 +2258,9 @@ functions:
           ```
         hideCodeBlock: true
         isSpotlight: true
+        description: |
+          When using [reserved words](https://www.postgresql.org/docs/current/sql-keywords-appendix.html) for column names you need
+          to add double quotes e.g. `.gt('"order"', 2)`
   - id: gte
     title: gte()
     $ref: '@supabase/postgrest-js.PostgrestFilterBuilder.gte'


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase Docs - [gt](https://supabase.com/docs/reference/javascript/gt)

## What is the current behavior?

When using a reserved word for a column name you need to use double quotes but this is not documented.

## What is the new behavior?

Added in a note on the `gt` section:

<img width="1093" alt="Screenshot 2023-02-20 at 11 03 55" src="https://user-images.githubusercontent.com/22655069/220088491-d09a6cfc-05d0-4277-8d6d-9f7ca96e7a55.png">


## Additional context

Linked with #12539 

Closes #12539 