### PR TITLE
docs: update sveltekit tutorial

### DIFF
--- a/apps/docs/pages/guides/getting-started/tutorials/with-sveltekit.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-sveltekit.mdx
@@ -50,9 +50,9 @@ These variables will be exposed on the browser, and that's completely fine since
 
 ```js title=src/lib/supabaseClient.ts
 import { createClient } from '@supabase/auth-helpers-sveltekit'
-import { env } from '$env/dynamic/public'
+import { PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY } from '$env/static/public'
 
-export const supabase = createClient(env.PUBLIC_SUPABASE_URL, env.PUBLIC_SUPABASE_ANON_KEY)
+export const supabase = createClient(PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY)
 ```
 
 Optionally, update `src/routes/styles.css` with the [CSS from the example](https://raw.githubusercontent.com/supabase/supabase/master/examples/user-management/svelte-user-management/src/app.css).


### PR DESCRIPTION
- This small change from dynamic public env var to static allows the env vars to be used for deployment, particularly in Vercel.
- For some reason, when deploying to Vercel and using `$env/dynamic/public`, the env vars will return `undefined` and you'll get an error when the Supabase client attempts to startup: `supaBase url is required`
- This change makes a successful client connection to Supabase

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

- issue #12556 
