### PR TITLE
fix: add a note on flutter guide about running it on macOS

### DIFF
--- a/apps/docs/pages/guides/getting-started/quickstarts/flutter.mdx
+++ b/apps/docs/pages/guides/getting-started/quickstarts/flutter.mdx
@@ -176,6 +176,7 @@ export const meta = {
     Run your app on a platform of your choosing! By default an app should launch in your web browser.
 
     Note that `supabase_flutter` is compatible with web, iOS, Android, macOS, and Windows apps.
+    Running the app on MacOS requires additional configuration to [set the entitlements](https://docs.flutter.dev/development/platform-integration/macos/building#setting-up-entitlements).
 
     </StepHikeCompact.Details>
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds a one-line comment about running Flutter apps on macOS. 

Fixes https://github.com/supabase/supabase/issues/12541