### PR TITLE
fix: convert project read-only state to react query

### DIFF
--- a/studio/components/interfaces/Settings/ProjectUsageBars/ProjectUsageBars.tsx
+++ b/studio/components/interfaces/Settings/ProjectUsageBars/ProjectUsageBars.tsx
@@ -85,7 +85,7 @@ const ProjectUsage: FC<Props> = ({ projectRef }) => {
 
   const isPaidTier = subscriptionTier !== PRICING_TIER_PRODUCT_IDS.FREE
 
-  const featureFootnotes: Record<string, JSX.Element> = {
+  const featureFootnotes: Record<string, JSX.Element | null> = {
     db_size: isPaidTier ? (
       <div className="flex justify-between items-center">
         <div className="flex flex-row space-x-4 text-scale-1000">
@@ -99,9 +99,7 @@ const ProjectUsage: FC<Props> = ({ projectRef }) => {
           </a>
         </Button>
       </div>
-    ) : (
-      <></>
-    ),
+    ) : null,
   }
 
   return (

--- a/studio/components/interfaces/Settings/ProjectUsageBars/ProjectUsageBars.tsx
+++ b/studio/components/interfaces/Settings/ProjectUsageBars/ProjectUsageBars.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link'
-import { FC, useEffect, useState } from 'react'
+import { FC, useEffect } from 'react'
 import { useRouter } from 'next/router'
 import * as Tooltip from '@radix-ui/react-tooltip'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
@@ -22,7 +22,7 @@ import ShimmeringLoader from 'components/ui/ShimmeringLoader'
 import InformationBox from 'components/ui/InformationBox'
 import { USAGE_BASED_PRODUCTS } from 'components/interfaces/Billing/Billing.constants'
 import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
-import { executeSql } from 'data/sql/execute-sql-query'
+import { useProjectReadOnlyQuery } from 'data/config/project-read-only-query'
 import { ProjectUsageResponseUsageKeys, useProjectUsageQuery } from 'data/usage/project-usage-query'
 
 interface Props {
@@ -35,7 +35,11 @@ const ProjectUsage: FC<Props> = ({ projectRef }) => {
   const router = useRouter()
 
   const { project } = useProjectContext()
-  const [isReadOnlyMode, setIsReadOnlyMode] = useState(false)
+  const { data: isReadOnlyMode } = useProjectReadOnlyQuery({
+    projectRef: project?.ref,
+    connectionString: project?.connectionString,
+  })
+
   const canUpdateSubscription = checkPermissions(
     PermissionAction.BILLING_WRITE,
     'stripe.subscriptions'
@@ -78,20 +82,6 @@ const ProjectUsage: FC<Props> = ({ projectRef }) => {
       />
     )
   }
-  // [Terry]
-  // temporary solution to check if project is in read only mode
-  // until we get an api endpoint for this
-
-  async function checkForReadOnlyMode() {
-    const sql = `show default_transaction_read_only;`
-    const connectionString = project?.connectionString
-    const { result: readOnlyStatus } = await executeSql({ projectRef, connectionString, sql })
-    if (readOnlyStatus[0]?.default_transaction_read_only === 'on') setIsReadOnlyMode(true)
-  }
-
-  useEffect(() => {
-    if (projectRef) checkForReadOnlyMode()
-  }, [projectRef])
 
   const isPaidTier = subscriptionTier !== PRICING_TIER_PRODUCT_IDS.FREE
 

--- a/studio/components/layouts/ProjectLayout/LayoutHeader/LayoutHeader.tsx
+++ b/studio/components/layouts/ProjectLayout/LayoutHeader/LayoutHeader.tsx
@@ -11,11 +11,9 @@ import HelpPopover from './HelpPopover'
 import NotificationsPopover from './NotificationsPopover'
 import { getResourcesExceededLimits } from 'components/ui/OveragesBanner/OveragesBanner.utils'
 import { useProjectUsageQuery } from 'data/usage/project-usage-query'
+import { useProjectReadOnlyQuery } from 'data/config/project-read-only-query'
 import { Badge } from 'ui'
-import { executeSql } from 'data/sql/execute-sql-query'
 import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
-
-import { useEffect, useState } from 'react'
 
 const LayoutHeader = ({ customHeaderComponents, breadcrumbs = [], headerBorder = true }: any) => {
   const { ui } = useStore()
@@ -24,22 +22,10 @@ const LayoutHeader = ({ customHeaderComponents, breadcrumbs = [], headerBorder =
   const { ref: projectRef } = useParams()
   const { project } = useProjectContext()
 
-  const [isReadOnlyMode, setIsReadOnlyMode] = useState(false)
-
-  // [Terry]
-  // temporary solution to check if project is in read only mode
-  // until we get an api endpoint for this
-  async function checkForReadOnlyMode() {
-    const sql = `show default_transaction_read_only;`
-    const connectionString = project?.connectionString
-    const { result: readOnlyStatus } = await executeSql({ projectRef, connectionString, sql })
-    if (readOnlyStatus[0]?.default_transaction_read_only === 'on') setIsReadOnlyMode(true)
-  }
-
-  useEffect(() => {
-    if (projectRef) checkForReadOnlyMode()
-    else setIsReadOnlyMode(false)
-  }, [projectRef])
+  const { data: isReadOnlyMode } = useProjectReadOnlyQuery({
+    projectRef: project?.ref,
+    connectionString: project?.connectionString,
+  })
 
   const { data: usage } = useProjectUsageQuery({ projectRef })
   const resourcesExceededLimits = getResourcesExceededLimits(usage)

--- a/studio/data/config/project-read-only-query.ts
+++ b/studio/data/config/project-read-only-query.ts
@@ -1,0 +1,55 @@
+import { UseQueryOptions } from '@tanstack/react-query'
+import { ExecuteSqlData, useExecuteSqlPrefetch, useExecuteSqlQuery } from '../sql/execute-sql-query'
+
+// TODO: temporary solution to check if project is in read only mode
+// until we get an api endpoint for this
+
+export const getProjectReadOnlySql = () => {
+  const sql = /* SQL */ `
+    show default_transaction_read_only;
+  `
+
+  return sql
+}
+
+export type ProjectReadOnlyVariables = {
+  projectRef?: string
+  connectionString?: string
+}
+
+export type ProjectReadOnlyData = boolean
+export type ProjectReadOnlyError = unknown
+
+export const useProjectReadOnlyQuery = (
+  { projectRef, connectionString }: ProjectReadOnlyVariables,
+  options: Omit<
+    UseQueryOptions<ExecuteSqlData, ProjectReadOnlyError, ProjectReadOnlyData>,
+    'select'
+  > = {}
+) =>
+  useExecuteSqlQuery(
+    {
+      projectRef,
+      connectionString,
+      sql: getProjectReadOnlySql(),
+      queryKey: ['project-read-only'],
+    },
+    {
+      select(data) {
+        return data.result[0]?.default_transaction_read_only === 'on'
+      },
+      ...options,
+    }
+  )
+
+export const useProjectReadOnlyPrefetch = ({
+  projectRef,
+  connectionString,
+}: ProjectReadOnlyVariables) => {
+  return useExecuteSqlPrefetch({
+    projectRef,
+    connectionString,
+    sql: getProjectReadOnlySql(),
+    queryKey: ['project-read-only'],
+  })
+}

--- a/studio/data/config/project-read-only-query.ts
+++ b/studio/data/config/project-read-only-query.ts
@@ -38,6 +38,7 @@ export const useProjectReadOnlyQuery = (
       select(data) {
         return data.result[0]?.default_transaction_read_only === 'on'
       },
+      enabled: typeof projectRef !== 'undefined' && typeof connectionString !== 'undefined',
       ...options,
     }
   )

--- a/studio/stores/common/PostgresMetaInterface.ts
+++ b/studio/stores/common/PostgresMetaInterface.ts
@@ -117,6 +117,7 @@ export default class PostgresMetaInterface<T> implements IPostgresMetaInterface<
     }
   }
 
+  // [Joshen] Only used for tables and views for now
   async loadBySchema(schema: string) {
     let { LOADING, ERROR, LOADED } = this.STATES
     try {
@@ -132,7 +133,14 @@ export default class PostgresMetaInterface<T> implements IPostgresMetaInterface<
       const data = response as T[]
       const formattedData = keyBy(data, this.identifier)
 
-      this.data = { ...this.data, ...formattedData }
+      // Purge existing data that belongs to given schema, otherwise
+      // stale data will persist
+      const purgedData = Object.keys(this.data)
+        .map((identifier: any) => this.data[identifier])
+        .filter((item: any) => item.schema !== schema)
+      const formattedPurgedData = keyBy(purgedData, this.identifier)
+
+      this.data = { ...formattedPurgedData, ...formattedData }
       this.setState(LOADED)
 
       return data


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behaviour?

`useEffect` was loading the project read-only state before the database uri had loaded, resulting in `Failed to run sql query: connect ECONNREFUSED 127.0.0.1:5432`

## What is the new behaviour?

Project read-only state is loaded via a react-query query, which automatically waits for the connection string based on the `enabled:` option.