### PR TITLE
docs: extensions 404

### DIFF
--- a/apps/docs/components/Extensions.tsx
+++ b/apps/docs/components/Extensions.tsx
@@ -94,8 +94,15 @@ export default function Extensions() {
                 filters.length === 0 ? x : x.tags.some((item) => filters.includes(item))
               )
               .map((extension) => (
-                <Link passHref href={`/guides/database/extensions/${extension.name}`}>
-                  <a target="_blank" className="no-underline">
+                <Link
+                  passHref
+                  href={`${
+                    extension.link
+                      ? `/guides/database/extensions/${extension.name}`
+                      : '/guides/database/extensions#full-list-of-extensions'
+                  }`}
+                >
+                  <a target={`${extension.link ? '_blank' : '_self'}`} className="no-underline">
                     <GlassPanel title={extension.name} background={false} key={extension.name}>
                       <p className="mt-4">
                         {extension.comment.charAt(0).toUpperCase() + extension.comment.slice(1)}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase Docs - [Extensions](https://supabase.com/docs/guides/database/extensions#full-list-of-extensions)

## What is the current behavior?

If you go to an extension which does not have a guide you will get a 404 error.

## What is the new behavior?

If an extension has no guide you will get redirected to the full list and no 404.

