### PR TITLE
fix: studio sign-in overflow

### DIFF
--- a/studio/components/layouts/SignInLayout/SignInLayout.tsx
+++ b/studio/components/layouts/SignInLayout/SignInLayout.tsx
@@ -118,7 +118,7 @@ const SignInLayout = ({
 
         <div className="flex flex-1">
           <main className="flex flex-col items-center flex-1 flex-shrink-0 px-5 pt-16 pb-8 border-r shadow-lg bg-scale-200 border-scale-500">
-            <div className="flex-1 flex flex-col justify-center w-[384px]">
+            <div className="flex-1 flex flex-col justify-center w-[350px] sm:w-[384px]">
               <div className="mb-10">
                 <h1 className="mt-8 mb-2 text-2xl lg:text-3xl">{heading}</h1>
                 <h2 className="text-sm text-scale-1100">{subheading}</h2>

--- a/studio/components/layouts/SignInLayout/SignInLayout.tsx
+++ b/studio/components/layouts/SignInLayout/SignInLayout.tsx
@@ -118,7 +118,7 @@ const SignInLayout = ({
 
         <div className="flex flex-1">
           <main className="flex flex-col items-center flex-1 flex-shrink-0 px-5 pt-16 pb-8 border-r shadow-lg bg-scale-200 border-scale-500">
-            <div className="flex-1 flex flex-col justify-center w-[350px] sm:w-[384px]">
+            <div className="flex-1 flex flex-col justify-center w-[330px] sm:w-[384px]">
               <div className="mb-10">
                 <h1 className="mt-8 mb-2 text-2xl lg:text-3xl">{heading}</h1>
                 <h2 className="text-sm text-scale-1100">{subheading}</h2>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase Studio > [Sign in](https://app.supabase.com/sign-in)

## What is the current behavior?

On a mobile device their is a slight overflow:

<img width="300" alt="Screenshot 2023-02-24 at 10 47 53" src="https://user-images.githubusercontent.com/22655069/221160684-98dd52be-0c8d-40c8-8640-0fc637b1fb33.png">


## What is the new behavior?

Width has been changed and added breakpoint:

<img width="300" alt="Screenshot 2023-02-24 at 10 48 28" src="https://user-images.githubusercontent.com/22655069/221160740-0fb752cd-e955-43cc-a22f-325240bbf2eb.png">

