### PR TITLE
feat: add missing variables for email templates

### DIFF
--- a/studio/stores/authConfig/schema/AuthProviders/AuthTemplatesValidation.tsx
+++ b/studio/stores/authConfig/schema/AuthProviders/AuthTemplatesValidation.tsx
@@ -18,9 +18,11 @@ export const CONFIRMATION: FormSchema = {
       descriptionOptional: 'HTML body of your email',
       type: 'code',
       description: ` 
-- \`{{ .ConfirmationURL }}\` : URL to confirm the message
+- \`{{ .ConfirmationURL }}\` : URL to confirm the e-mail address for the new account
 - \`{{ .Token }}\` : The 6-digit numeric email OTP 
 - \`{{ .TokenHash }}\` : The hashed token used in the URL
+- \`{{ .SiteURL }}\` : The URL of the site
+- \`{{ .Email }}\` : The users email address
 `,
     },
   },
@@ -49,9 +51,11 @@ export const INVITE: FormSchema = {
       descriptionOptional: 'HTML body of your email',
       type: 'code',
       description: ` 
-- \`{{ .ConfirmationURL }}\` : URL to confirm the message
+- \`{{ .ConfirmationURL }}\` : URL to accept the invitation to create an account
 - \`{{ .Token }}\` : The 6-digit numeric email OTP 
 - \`{{ .TokenHash }}\` : The hashed token used in the URL
+- \`{{ .SiteURL }}\` : The URL of the site
+- \`{{ .Email }}\` : The users email address
 `,
     },
   },
@@ -80,9 +84,11 @@ export const MAGIC_LINK: FormSchema = {
       descriptionOptional: 'HTML body of your email',
       type: 'code',
       description: ` 
-- \`{{ .ConfirmationURL }}\` : URL to confirm the message
+- \`{{ .ConfirmationURL }}\` : URL for a one-time login to the user's account
 - \`{{ .Token }}\` : The 6-digit numeric email OTP 
 - \`{{ .TokenHash }}\` : The hashed token used in the URL
+- \`{{ .SiteURL }}\` : The URL of the site
+- \`{{ .Email }}\` : The users email address
 `,
     },
   },
@@ -114,6 +120,9 @@ export const EMAIL_CHANGE: FormSchema = {
 - \`{{ .ConfirmationURL }}\` : URL to confirm the email change
 - \`{{ .Token }}\` : The 6-digit numeric email OTP 
 - \`{{ .TokenHash }}\` : The hashed token used in the URL
+- \`{{ .SiteURL }}\` : The URL of the site
+- \`{{ .Email }}\` : The original users email address
+- \`{{ .NewEmail }\` : The users new email address
 `,
     },
   },
@@ -145,6 +154,8 @@ export const RECOVERY: FormSchema = {
 - \`{{ .ConfirmationURL }}\` : URL to confirm the password reset
 - \`{{ .Token }}\` : The 6-digit numeric email OTP 
 - \`{{ .TokenHash }}\` : The hashed token used in the URL
+- \`{{ .SiteURL }}\` : The URL of the site
+- \`{{ .Email }}\` : The users email address
 `,
     },
   },


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase Studio > Auth > Email Templates

## What is the current behavior?

The email template editor has missing variables.

## What is the new behavior?

Missing variables have been added.

## Additional context

Closes #12634 
