### PR TITLE
Fix permission load on self-host

### DIFF
--- a/studio/data/permissions/permissions-query.ts
+++ b/studio/data/permissions/permissions-query.ts
@@ -21,10 +21,9 @@ export async function getPermissions(signal?: AbortSignal) {
 export type PermissionsData = Awaited<ReturnType<typeof getPermissions>>
 export type PermissionsError = unknown
 
-export const usePermissionsQuery = <TData = PermissionsData>({
-  enabled = true,
-  ...options
-}: UseQueryOptions<PermissionsData, PermissionsError, TData> = {}) =>
+export const usePermissionsQuery = <TData = PermissionsData>(
+  options: UseQueryOptions<PermissionsData, PermissionsError, TData> = {}
+) =>
   useQuery<PermissionsData, PermissionsError, TData>(
     permissionKeys.list(),
     ({ signal }) => getPermissions(signal),


### PR DESCRIPTION
## What kind of change does this PR introduce?

Follow up to #12365 .
No need to extract `enabled` from options of `useQuery.`
`enabled` is always true from docs.

cc @sweatybridge 

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
