### PR TITLE
fixed image url in blog post

### DIFF
--- a/apps/www/_blog/2023-02-17-type-constraints-in-65-lines-of-sql.mdx
+++ b/apps/www/_blog/2023-02-17-type-constraints-in-65-lines-of-sql.mdx
@@ -28,7 +28,7 @@ A (very) loose primer on SemVer:
 
 SemVer is a specification for representing software versions that communicate information about backwards compatibility. The type is typically represented as a string with 5 components.
 
-![image](/images/blog/2023-jan/semver-spec.jpg)
+![image](/public/images/blog/2023-jan/semver-spec.jpg)
 
 Where `pre-release` and `metadata` are optional.
 


### PR DESCRIPTION
I fixed the URL of the image in the last blog post. Now it should be rendered correctly.