### PR TITLE
Update prisma.mdx

### DIFF
--- a/apps/docs/pages/guides/integrations/prisma.mdx
+++ b/apps/docs/pages/guides/integrations/prisma.mdx
@@ -173,7 +173,7 @@ Update your Prisma schema by setting the `directUrl` in the datasource block:
 datasource db {
   provider          = "postgresql"
   url               = env("DATABASE_URL")
-  directURL         = env("DIRECT_URL")
+  directUrl         = env("DIRECT_URL")
   shadowDatabaseUrl = env("SHADOW_DATABASE_URL")
 }
 ```


### PR DESCRIPTION
Renames the falsely named property "directURL" to "directUrl"

## What kind of change does this PR introduce?

Documentation update of [this](https://supabase.com/docs/guides/integrations/prisma#connection-pooling-with-supabase) guide.

Solves #12674

