### PR TITLE
Clarify need for database type generation

### DIFF
--- a/apps/docs/pages/guides/getting-started/tutorials/with-nextjs.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-nextjs.mdx
@@ -317,6 +317,8 @@ export default function Account({ session }) {
 
 Let's create a new component for that called `Account.tsx` within a `components` folder.
 
+First, [generate type definitions from your database using the Supabase CLI](https://supabase.com/docs/guides/database/api/generating-types) to `../utils/database.types`.
+
 ```tsx title=components/Account.tsx
 import { useState, useEffect } from 'react'
 import { useUser, useSupabaseClient, Session } from '@supabase/auth-helpers-react'


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

When you start building the Account page, `Account.tsx` includes `import { Database } from '../utils/database.types'`, but that is not created in any of the previous steps and there's nothing telling you how to generate it.

## What is the new behavior?

The tutorial now includes an instruction to use the Supabase CLI to generate the necessary type definition file.
