### PR TITLE
Update auth-google.mdx

### DIFF
--- a/apps/docs/pages/guides/auth/social-login/auth-google.mdx
+++ b/apps/docs/pages/guides/auth/social-login/auth-google.mdx
@@ -58,7 +58,6 @@ From your project's dashboard screen:
 - Fill in your app name.
 - At the bottom, under `Authorized redirect URIs` click `Add URI`.
 - Enter your callback URI under `Authorized redirect URIs` at the bottom.
-- Enter your callback URI in the `Valid OAuth Redirect URIs` box.
 - Click `Save Changes` at the bottom right.
 - Click `Create`.
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Update Auth Guide for Google as there have been complaints that it has gone stale - just finished and it seems there's only one change. It appears that the valid URIs have been removed from UI

No longer need to configure valid redirect uri (for web at least):
<img width="563" alt="CleanShot 2023-02-26 at 17 02 27@2x" src="https://user-images.githubusercontent.com/8011761/221401561-91766225-9f27-4f76-b147-8aa256cb5412.png">
