### PR TITLE
Fix: tables with long names

### DIFF
--- a/studio/components/ui/ProductMenu/ProductMenuItem.tsx
+++ b/studio/components/ui/ProductMenu/ProductMenuItem.tsx
@@ -60,10 +60,12 @@ const ProductMenuItem: FC<Props> = ({
       <div className="flex w-full items-center justify-between gap-1">
         <div
           title={hoverText ? hoverText : typeof name === 'string' ? name : ''}
-          className={`flex items-center gap-2 w-full ${textClassName}`}
+          className={'flex items-center gap-2 truncate w-full ' + textClassName}
         >
-          <span className="truncate">{name} </span>
-          {label !== undefined && <Label label={label} />}
+          <span className="truncate">{name}{' '}</span>
+          {label !== undefined && (
+            <span className="text-orange-800 text-xs font-normal truncate">{label}</span>
+          )}
         </div>
         {action}
       </div>


### PR DESCRIPTION
## What kind of change does this PR introduce?

cant edit tables with long names.

## What is the current behavior?

cant edit tables with long names.
the commit 89e17f2fb1fd34dafd88d2b4b56aaa0cde0ed368

## What is the new behavior?

let people be able to edit tables with long names.

## Additional context

https://supabase.slack.com/archives/CSMGA08FP/p1677542180499259
https://supabase.slack.com/archives/CSMGA08FP/p1677320341991869