### PR TITLE
feat: listen to multi-tab sign-in

### DIFF
--- a/studio/pages/sign-in.tsx
+++ b/studio/pages/sign-in.tsx
@@ -8,6 +8,7 @@ import { SignInLayout } from 'components/layouts'
 import { useEffect } from 'react'
 import { IS_PLATFORM } from 'lib/constants'
 import { useRouter } from 'next/router'
+import { auth } from 'lib/gotrue'
 
 const SignInPage: NextPageWithLayout = () => {
   const router = useRouter()
@@ -15,6 +16,20 @@ const SignInPage: NextPageWithLayout = () => {
     // if the dashboard is running locally, redirect straight to the projects page
     if (!IS_PLATFORM) {
       router.replace('/projects')
+      return
+    }
+
+    const {
+      data: { subscription },
+    } = auth.onAuthStateChange((event) => {
+      if (event === 'SIGNED_IN') {
+        // if user has signed in on another tab, take them to the home page
+        router.replace('/projects')
+      }
+    })
+
+    return () => {
+      subscription.unsubscribe()
     }
   }, [])
 


### PR DESCRIPTION
While trying to reproduce an issue connected to being logged out of the dashboard, I realized we can listen to the `SIGNED_IN` event on the sign-in page emitted from another tab and take the user to the `/projects` route.