### PR TITLE
Chore: add missing partner pages to sitemap

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ---
 
-# Supabase
+# Supabase test
 
 [Supabase](https://supabase.com) is an open source Firebase alternative. We're building the features of Firebase using enterprise-grade open source tools.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ---
 
-# Supabase test
+# Supabase
 
 [Supabase](https://supabase.com) is an open source Firebase alternative. We're building the features of Firebase using enterprise-grade open source tools.
 

--- a/apps/www/internals/generate-sitemap.mjs
+++ b/apps/www/internals/generate-sitemap.mjs
@@ -22,6 +22,8 @@ async function generate() {
     '!pages/*/index.tsx',
     '!pages/api',
     '!pages/404.js',
+    //get the generated partner pages
+    '.next/server/pages/partners/*.html',
   ])
 
   const sitemap = `
@@ -31,12 +33,15 @@ async function generate() {
           .filter((page) => !page.includes('_document.tsx'))
           .map((page) => {
             const path = page
+              //replace the path for the generated partner pages
+              .replace('.next/server/pages/partners/', '/partners/')
               .replace('pages', '')
               // add a `/` for blog posts
               .replace('_blog', '/blog')
               .replace('_alternatives', '/alternatives')
               .replace('.tsx', '')
               .replace('.mdx', '')
+              .replace('.html', '')
               // replace the paths for nested 'index' based routes
               .replace('/auth/Auth', '/auth')
               .replace('/database/Database', '/database')


### PR DESCRIPTION
## What kind of change does this PR introduce?

Resolves  #12461 

## Additional context


Get the missing partner pages(individual and index) by looking in the `.next` directory that is generated after `next build` is run. 