### PR TITLE
fix: Update imports in Auth UI guide

### DIFF
--- a/apps/docs/pages/guides/auth/auth-helpers/auth-ui.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/auth-ui.mdx
@@ -44,11 +44,11 @@ We recommend using one of the predefined themes to style the UI.
 Import the theme you want to use and pass it to the `appearence.theme` prop.
 
 ```js lines=4,16 title=/src/index.js
+import { Auth } from '@supabase/auth-ui-react'
 import {
-  Auth,
   // Import predefined theme
   ThemeSupa,
-} from '@supabase/auth-ui-react'
+} from '@supabase/auth-ui-shared'
 
 const supabase = createClient(
   '<INSERT PROJECT URL>',
@@ -70,7 +70,8 @@ The Auth component also supports login with [offical social providers](../../aut
 
 ```js lines=13 title=/src/index.js
 import { createClient } from '@supabase/supabase-js'
-import { Auth, ThemeSupa } from '@supabase/auth-ui-react'
+import { Auth } from '@supabase/auth-ui-react'
+import { ThemeSupa } from '@supabase/auth-ui-shared'
 
 const supabase = createClient('<INSERT PROJECT URL>', '<INSERT PROJECT ANON API KEY>')
 
@@ -112,7 +113,8 @@ Auth UI comes with several themes to customize the appearance. Each predefined t
 
 ```js lines=2,13 title=/src/index.js
 import { createClient } from '@supabase/supabase-js'
-import { Auth, ThemeSupa } from '@supabase/auth-ui-react'
+import { Auth } from '@supabase/auth-ui-react'
+import { ThemeSupa } from '@supabase/auth-ui-shared'
 
 const supabase = createClient(
   '<INSERT PROJECT URL>',
@@ -140,7 +142,8 @@ Auth UI comes with two theme variations: `default` and `dark`. You can switch be
 
 ```js lines=14 title=/src/index.js
 import { createClient } from '@supabase/supabase-js'
-import { Auth, ThemeSupa } from '@supabase/auth-ui-react'
+import { Auth } from '@supabase/auth-ui-react'
+import { ThemeSupa } from '@supabase/auth-ui-shared'
 
 const supabase = createClient(
   '<INSERT PROJECT URL>',
@@ -165,7 +168,8 @@ Auth UI themes can be overridden using variable tokens. See the [list of variabl
 
 ```js lines=14-21 title=/src/index.js
 import { createClient } from '@supabase/supabase-js'
-import { Auth, ThemeSupa } from '@supabase/auth-ui-react'
+import { Auth } from '@supabase/auth-ui-react'
+import { ThemeSupa } from '@supabase/auth-ui-shared'
 
 const supabase = createClient('<INSERT PROJECT URL>', '<INSERT PROJECT ANON API KEY>')
 
@@ -197,6 +201,7 @@ See the list of [tokens within a theme](https://github.com/supabase-community/au
 ```js title=/src/index.js
 import { createClient } from '@supabase/supabase-js'
 import { Auth } from '@supabase/auth-ui-react'
+import { ThemeSupa } from '@supabase/auth-ui-shared'
 
 const supabase = createClient(
   '<INSERT PROJECT URL>',
@@ -249,6 +254,7 @@ You can use custom CSS classes for the following elements:
 ```js title=/src/index.js
 import { createClient } from '@supabase/supabase-js'
 import { Auth } from '@supabase/auth-ui-react'
+import { ThemeSupa } from '@supabase/auth-ui-shared'
 
 const supabase = createClient('<INSERT PROJECT URL>', '<INSERT PROJECT ANON API KEY>')
 
@@ -274,6 +280,7 @@ You can use custom CSS inline styles for the following elements:
 ```js title=/src/index.js
 import { createClient } from '@supabase/supabase-js'
 import { Auth } from '@supabase/auth-ui-react'
+import { ThemeSupa } from '@supabase/auth-ui-shared'
 
 const supabase = createClient('<INSERT PROJECT URL>', '<INSERT PROJECT ANON API KEY>')
 

--- a/apps/docs/pages/guides/auth/auth-helpers/auth-ui.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/auth-ui.mdx
@@ -201,7 +201,6 @@ See the list of [tokens within a theme](https://github.com/supabase-community/au
 ```js title=/src/index.js
 import { createClient } from '@supabase/supabase-js'
 import { Auth } from '@supabase/auth-ui-react'
-import { ThemeSupa } from '@supabase/auth-ui-shared'
 
 const supabase = createClient(
   '<INSERT PROJECT URL>',
@@ -254,7 +253,6 @@ You can use custom CSS classes for the following elements:
 ```js title=/src/index.js
 import { createClient } from '@supabase/supabase-js'
 import { Auth } from '@supabase/auth-ui-react'
-import { ThemeSupa } from '@supabase/auth-ui-shared'
 
 const supabase = createClient('<INSERT PROJECT URL>', '<INSERT PROJECT ANON API KEY>')
 
@@ -280,7 +278,6 @@ You can use custom CSS inline styles for the following elements:
 ```js title=/src/index.js
 import { createClient } from '@supabase/supabase-js'
 import { Auth } from '@supabase/auth-ui-react'
-import { ThemeSupa } from '@supabase/auth-ui-shared'
 
 const supabase = createClient('<INSERT PROJECT URL>', '<INSERT PROJECT ANON API KEY>')
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

`ThemeSupa` was moved to `shared` package, but the guide hadn't been updated with the new imports. This PR fixes it.