### PR TITLE
fix: allow writes to kong directory

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -46,7 +46,8 @@ services:
       KONG_NGINX_PROXY_PROXY_BUFFER_SIZE: 160k
       KONG_NGINX_PROXY_PROXY_BUFFERS: 64 160k
     volumes:
-      - ./volumes/api:/var/lib/kong:ro
+      # https://github.com/supabase/supabase/issues/12661
+      - ./volumes/api/kong.yml:/var/lib/kong/kong.yml:ro
 
   auth:
     container_name: supabase-auth


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/supabase/issues/12661

## What is the new behavior?

Mount `kong.yml` config file only so that the directory is writable by kong

## Additional context

Add any other context or screenshots.
