### PR TITLE
chore: update PolyScale integration info

### DIFF
--- a/apps/docs/pages/guides/integrations/polyscale.mdx
+++ b/apps/docs/pages/guides/integrations/polyscale.mdx
@@ -25,7 +25,7 @@ The video below illustrates how to get connected. Or you can read the steps belo
 </div>
 
 <Admonition type="note">
-PolyScale presently provides caching for TCP connections to Supabase. If you wish to make an http connection to Supabase, you can use GraphQL, for which PolyScale also provides support. Support for caching with the Supabase client is coming soon. For more information, please [contact PolyScale](https://www.polyscale.ai/contact/).
+PolyScale provides caching for TCP connections and GraphQL. Support for caching with the Supabase client is coming soon. 
 </Admonition>
 
 ## Step 0: Create a PolyScale account

--- a/apps/docs/pages/guides/integrations/polyscale.mdx
+++ b/apps/docs/pages/guides/integrations/polyscale.mdx
@@ -24,6 +24,10 @@ The video below illustrates how to get connected. Or you can read the steps belo
   ></iframe>
 </div>
 
+<Admonition type="note">
+PolyScale presently provides caching for TCP connections to Supabase. If you wish to make an http connection to Supabase, you can use GraphQL, for which PolyScale also provides support. Support for caching with the Supabase client is coming soon. For more information, please [contact PolyScale](https://www.polyscale.ai/contact/).
+</Admonition>
+
 ## Step 0: Create a PolyScale account
 
 If you do not already have a PolyScale account, you can create an account [here](https://app.polyscale.ai/signup). PolyScale offers a free tier and no credit card is required.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Addresses fact that PolyScale does not yet support caching with Supabase client

## What is the current behavior?

Customers think they can cache with Supabase client

## What is the new behavior?

Customers are warned they cannot cache with Supabase client

## Additional context


