### PR TITLE
feat: support deletion actions for foreign keys in table editor

### DIFF
--- a/studio/components/grid/SupabaseGrid.utils.ts
+++ b/studio/components/grid/SupabaseGrid.utils.ts
@@ -215,9 +215,12 @@ export function parseSupaTable(
       isEncrypted: encryptedColumns.includes(column.name),
       enum: column.enums,
       comment: column.comment,
-      targetTableSchema: null,
-      targetTableName: null,
-      targetColumnName: null,
+      foreignKey: {
+        targetTableSchema: null,
+        targetTableName: null,
+        targetColumnName: null,
+        deletionAction: undefined,
+      },
     }
     const primaryKey = primaryKeys.find((pk) => pk.name == column.name)
     temp.isPrimaryKey = !!primaryKey
@@ -230,9 +233,10 @@ export function parseSupaTable(
       )
     })
     if (relationship) {
-      temp.targetTableSchema = relationship.target_table_schema
-      temp.targetTableName = relationship.target_table_name
-      temp.targetColumnName = relationship.target_column_name
+      temp.foreignKey.targetTableSchema = relationship.target_table_schema
+      temp.foreignKey.targetTableName = relationship.target_table_name
+      temp.foreignKey.targetColumnName = relationship.target_column_name
+      temp.foreignKey.deletionAction = relationship.deletion_action
     }
     return temp
   })

--- a/studio/components/grid/components/common/ForeignTableModal/index.tsx
+++ b/studio/components/grid/components/common/ForeignTableModal/index.tsx
@@ -31,7 +31,7 @@ export const ForeignTableModal: React.FC<ForeignTableModalProps> = ({
 
     if (defaultValue && columnDefinition) {
       fetchData({
-        column: columnDefinition.targetColumnName!,
+        column: columnDefinition?.foreignKey?.targetColumnName!,
         operator: '=',
         value: defaultValue,
       })
@@ -43,14 +43,14 @@ export const ForeignTableModal: React.FC<ForeignTableModalProps> = ({
   async function fetchColumns() {
     if (
       !state.metaService ||
-      !columnDefinition?.targetTableName ||
-      !columnDefinition?.targetTableSchema
+      !columnDefinition?.foreignKey?.targetTableName ||
+      !columnDefinition?.foreignKey?.targetTableSchema
     )
       return
 
     const { data } = await state.metaService.fetchColumns(
-      columnDefinition?.targetTableName,
-      columnDefinition?.targetTableSchema
+      columnDefinition?.foreignKey?.targetTableName,
+      columnDefinition?.foreignKey?.targetTableSchema
     )
     if (data && data.length > 0) {
       const columnNames = data.map((x) => x.name)
@@ -59,11 +59,14 @@ export const ForeignTableModal: React.FC<ForeignTableModalProps> = ({
   }
 
   async function fetchData(filter?: Filter) {
-    if (!state.onSqlQuery || !columnDefinition?.targetTableName) return
+    if (!state.onSqlQuery || !columnDefinition?.foreignKey?.targetTableName) return
 
     const query = new Query()
     let queryChains = query
-      .from(columnDefinition?.targetTableName, columnDefinition?.targetTableSchema ?? undefined)
+      .from(
+        columnDefinition?.foreignKey?.targetTableName,
+        columnDefinition?.foreignKey?.targetTableSchema ?? undefined
+      )
       .select()
 
     if (filter && filter.value && filter.value != '') {
@@ -88,8 +91,8 @@ export const ForeignTableModal: React.FC<ForeignTableModalProps> = ({
   }
 
   function onItemSelect(item: Dictionary<any>) {
-    if (item && columnDefinition && columnDefinition.targetColumnName) {
-      const value = item[columnDefinition.targetColumnName]
+    if (item && columnDefinition && columnDefinition.foreignKey?.targetColumnName) {
+      const value = item[columnDefinition.foreignKey?.targetColumnName]
       onChange(value)
     }
 
@@ -140,7 +143,7 @@ export const ForeignTableModal: React.FC<ForeignTableModalProps> = ({
       >
         <Modal.Content>
           <FilterHeader
-            defaultColumnName={columnDefinition?.targetColumnName ?? undefined}
+            defaultColumnName={columnDefinition?.foreignKey?.targetColumnName ?? undefined}
             defaultValue={defaultValue}
             foreignColumnNames={foreignColumnNames}
             onChange={onFilterChange}

--- a/studio/components/grid/types/base.ts
+++ b/studio/components/grid/types/base.ts
@@ -55,9 +55,17 @@ export type ColumnType =
   | 'time'
   | 'unknown'
 
+export interface GridForeignKey {
+  targetTableSchema?: string | null
+  targetTableName?: string | null
+  targetColumnName?: string | null
+  deletionAction?: string
+}
+
 export interface ColumnHeaderProps<R> extends HeaderRendererProps<R> {
   columnType: ColumnType
   isPrimaryKey: boolean | undefined
   isEncrypted: boolean | undefined
   format: string
+  foreignKey?: GridForeignKey
 }

--- a/studio/components/grid/types/table.ts
+++ b/studio/components/grid/types/table.ts
@@ -1,4 +1,4 @@
-import { Dictionary } from './base'
+import { Dictionary, GridForeignKey } from './base'
 
 export interface SupaColumn {
   readonly dataType: string
@@ -13,9 +13,7 @@ export interface SupaColumn {
   readonly isNullable?: boolean
   readonly isUpdatable?: boolean
   readonly isEncrypted?: boolean
-  readonly targetTableSchema?: string | null
-  readonly targetTableName?: string | null
-  readonly targetColumnName?: string | null
+  readonly foreignKey?: GridForeignKey
   position: number
 }
 

--- a/studio/components/grid/utils/gridColumns.tsx
+++ b/studio/components/grid/utils/gridColumns.tsx
@@ -47,7 +47,6 @@ export function getGridColumns(
 ): any[] {
   const columns = table.columns.map((x, idx) => {
     const columnType = getColumnType(x)
-
     const columnDefaultWidth = getColumnDefaultWidth(x)
     const columnWidthBasedOnName =
       (x.name.length + x.format.length) * ESTIMATED_CHARACTER_PIXEL_WIDTH
@@ -75,6 +74,7 @@ export function getGridColumns(
           isPrimaryKey={x.isPrimaryKey}
           isEncrypted={x.isEncrypted}
           format={x.format}
+          foreignKey={x.foreignKey}
         />
       ),
       editor: options?.editable

--- a/studio/components/grid/utils/types.ts
+++ b/studio/components/grid/utils/types.ts
@@ -65,6 +65,6 @@ export function isEnumColumn(type: string) {
 }
 
 export function isForeignKeyColumn(columnDef: SupaColumn) {
-  const { targetTableSchema, targetTableName, targetColumnName } = columnDef
+  const { targetTableSchema, targetTableName, targetColumnName } = columnDef?.foreignKey ?? {}
   return !!targetTableSchema && !!targetTableName && !!targetColumnName
 }

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.tsx
@@ -1,12 +1,11 @@
 import Link from 'next/link'
 import { FC, useEffect, useState } from 'react'
-import { isUndefined, isEmpty } from 'lodash'
+import { isEmpty } from 'lodash'
 import { Dictionary } from 'components/grid'
 import { Checkbox, SidePanel, Input, Button, IconExternalLink, Toggle } from 'ui'
 import type {
   PostgresColumn,
   PostgresExtension,
-  PostgresRelationship,
   PostgresTable,
   PostgresType,
 } from '@supabase/postgres-meta'
@@ -27,19 +26,26 @@ import {
   generateUpdateColumnPayload,
 } from './ColumnEditor.utils'
 import { TEXT_TYPES } from '../SidePanelEditor.constants'
-import { ColumnField, CreateColumnPayload, UpdateColumnPayload } from '../SidePanelEditor.types'
+import {
+  ColumnField,
+  CreateColumnPayload,
+  ExtendedPostgresRelationship,
+  UpdateColumnPayload,
+} from '../SidePanelEditor.types'
 import { FormSection, FormSectionContent, FormSectionLabel } from 'components/ui/Forms'
 import { EncryptionKeySelector } from 'components/interfaces/Settings/Vault'
+
+import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
+import { useForeignKeyConstraintsQuery } from 'data/database/foreign-key-constraints-query'
 
 interface Props {
   column?: PostgresColumn
   selectedTable: PostgresTable
-  tables: PostgresTable[]
   visible: boolean
   closePanel: () => void
   saveChanges: (
     payload: CreateColumnPayload | UpdateColumnPayload,
-    foreignKey: Partial<PostgresRelationship> | undefined,
+    foreignKey: ExtendedPostgresRelationship | undefined,
     isNewRecord: boolean,
     configuration: {
       columnId: string | undefined
@@ -55,7 +61,6 @@ interface Props {
 const ColumnEditor: FC<Props> = ({
   column,
   selectedTable,
-  tables = [],
   visible = false,
   closePanel = () => {},
   saveChanges = () => {},
@@ -63,31 +68,41 @@ const ColumnEditor: FC<Props> = ({
 }) => {
   const { ref } = useParams()
   const { meta, vault } = useStore()
+  const { project } = useProjectContext()
   const isTCEEnabled = useFlag('transparentColumnEncryption')
 
-  const isNewRecord = isUndefined(column)
-  const originalForeignKey = column ? getColumnForeignKey(column, selectedTable) : undefined
+  const [errors, setErrors] = useState<Dictionary<any>>({})
+  const [columnFields, setColumnFields] = useState<ColumnField>()
+  const [isEditingRelation, setIsEditingRelation] = useState<boolean>(false)
+
+  const { data, isLoading } = useForeignKeyConstraintsQuery({
+    projectRef: project?.ref,
+    connectionString: project?.connectionString,
+    schema: selectedTable?.schema,
+  })
+  const foreignKeyMeta = data?.result ?? []
 
   const keys = vault.listKeys()
   const enumTypes = meta.types.list(
     (type: PostgresType) => !meta.excludedSchemas.includes(type.schema)
   )
 
-  const [errors, setErrors] = useState<Dictionary<any>>({})
-  const [columnFields, setColumnFields] = useState<ColumnField>()
-  const [isEditingRelation, setIsEditingRelation] = useState<boolean>(false)
-
   const [pgsodiumExtension] = meta.extensions.list(
     (ext: PostgresExtension) => ext.name.toLowerCase() === 'pgsodium'
   )
   const isPgSodiumInstalled = pgsodiumExtension?.installed_version !== null
+
+  const isNewRecord = column === undefined
+  const originalForeignKey = column
+    ? getColumnForeignKey(column, selectedTable, foreignKeyMeta)
+    : undefined
 
   useEffect(() => {
     if (visible) {
       setErrors({})
       const columnFields = isNewRecord
         ? { ...generateColumnField(), keyId: keys.length > 0 ? keys[0].id : 'create-new' }
-        : generateColumnFieldFromPostgresColumn(column!, selectedTable)
+        : generateColumnFieldFromPostgresColumn(column!, selectedTable, foreignKeyMeta)
       setColumnFields(columnFields)
     }
   }, [visible])
@@ -111,23 +126,27 @@ const ColumnEditor: FC<Props> = ({
     setErrors(updatedErrors)
   }
 
-  const saveColumnForeignKey = (
-    foreignKeyConfiguration: { table: PostgresTable; column: PostgresColumn } | undefined
-  ) => {
+  const saveColumnForeignKey = (foreignKeyConfiguration?: {
+    table: PostgresTable
+    column: PostgresColumn
+    deletionAction: string
+  }) => {
     onUpdateField({
-      foreignKey: !isUndefined(foreignKeyConfiguration)
-        ? {
-            id: 0,
-            constraint_name: '',
-            source_schema: selectedTable.schema,
-            source_table_name: selectedTable.name,
-            source_column_name: columnFields?.name || column?.name || '',
-            target_table_schema: foreignKeyConfiguration.table.schema,
-            target_table_name: foreignKeyConfiguration.table.name,
-            target_column_name: foreignKeyConfiguration.column.name,
-          }
-        : undefined,
-      ...(!isUndefined(foreignKeyConfiguration) && {
+      foreignKey:
+        foreignKeyConfiguration !== undefined
+          ? {
+              id: 0,
+              constraint_name: '',
+              source_schema: selectedTable.schema,
+              source_table_name: selectedTable.name,
+              source_column_name: columnFields?.name || column?.name || '',
+              target_table_schema: foreignKeyConfiguration.table.schema,
+              target_table_name: foreignKeyConfiguration.table.name,
+              target_column_name: foreignKeyConfiguration.column.name,
+              deletion_action: foreignKeyConfiguration.deletionAction,
+            }
+          : undefined,
+      ...(foreignKeyConfiguration !== undefined && {
         format: foreignKeyConfiguration.column.format,
         defaultValue: null,
       }),
@@ -218,6 +237,7 @@ const ColumnEditor: FC<Props> = ({
               originalForeignKey={originalForeignKey}
               onSelectEditRelation={() => setIsEditingRelation(true)}
               onSelectRemoveRelation={() => onUpdateField({ foreignKey: undefined })}
+              onSelectCancelRemoveRelation={() => onUpdateField({ foreignKey: originalForeignKey })}
             />
           </div>
         </FormSectionContent>
@@ -254,10 +274,10 @@ const ColumnEditor: FC<Props> = ({
             layout="vertical"
             enumTypes={enumTypes}
             error={errors.format}
-            disabled={!isUndefined(columnFields?.foreignKey)}
+            disabled={columnFields?.foreignKey !== undefined}
             onOptionSelect={(format: string) => onUpdateField({ format, defaultValue: null })}
           />
-          {isUndefined(columnFields.foreignKey) && (
+          {columnFields.foreignKey === undefined && (
             <div className="space-y-4">
               {columnFields.format.includes('int') && (
                 <div className="w-full">

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.tsx
@@ -80,7 +80,7 @@ const ColumnEditor: FC<Props> = ({
     connectionString: project?.connectionString,
     schema: selectedTable?.schema,
   })
-  const foreignKeyMeta = data?.result ?? []
+  const foreignKeyMeta = data || []
 
   const keys = vault.listKeys()
   const enumTypes = meta.types.list(

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.tsx
@@ -75,7 +75,7 @@ const ColumnEditor: FC<Props> = ({
   const [columnFields, setColumnFields] = useState<ColumnField>()
   const [isEditingRelation, setIsEditingRelation] = useState<boolean>(false)
 
-  const { data, isLoading } = useForeignKeyConstraintsQuery({
+  const { data } = useForeignKeyConstraintsQuery({
     projectRef: project?.ref,
     connectionString: project?.connectionString,
     schema: selectedTable?.schema,

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.utils.ts
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.utils.ts
@@ -221,7 +221,7 @@ export const getColumnForeignKey = (
   })
   if (foreignKey === undefined) return foreignKey
   else {
-    const foreignKeyMeta = foreignKeys.find((fk) => fk.id === foreignKey?.id)
+    const foreignKeyMeta = foreignKeys.find((fk) => fk.id === foreignKey.id)
     return { ...foreignKey, deletion_action: foreignKeyMeta?.deletion_action ?? 'a' }
   }
 }

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.utils.ts
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.utils.ts
@@ -222,7 +222,10 @@ export const getColumnForeignKey = (
   if (foreignKey === undefined) return foreignKey
   else {
     const foreignKeyMeta = foreignKeys.find((fk) => fk.id === foreignKey.id)
-    return { ...foreignKey, deletion_action: foreignKeyMeta?.deletion_action ?? 'a' }
+    return {
+      ...foreignKey,
+      deletion_action: foreignKeyMeta?.deletion_action ?? FOREIGN_KEY_DELETION_ACTION.NO_ACTION,
+    }
   }
 }
 

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.utils.ts
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.utils.ts
@@ -244,7 +244,7 @@ export const getForeignKeyDeletionAction = (deletionAction?: string) => {
     case FOREIGN_KEY_DELETION_ACTION.SET_DEFAULT:
       return 'Set default'
     case FOREIGN_KEY_DELETION_ACTION.SET_NULL:
-      return 'Set null'
+      return 'Set NULL'
     default:
       return undefined
   }

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.utils.ts
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.utils.ts
@@ -8,7 +8,14 @@ import type {
 } from '@supabase/postgres-meta'
 
 import { uuidv4 } from 'lib/helpers'
-import { ColumnField, CreateColumnPayload, UpdateColumnPayload } from '../SidePanelEditor.types'
+import {
+  ColumnField,
+  CreateColumnPayload,
+  ExtendedPostgresRelationship,
+  UpdateColumnPayload,
+} from '../SidePanelEditor.types'
+import { FOREIGN_KEY_DELETION_ACTION } from 'data/database/database-query-constants'
+import { ForeignKeyConstraint } from 'data/database/foreign-key-constraints-query'
 
 const isSQLExpression = (input: string) => {
   if (['CURRENT_DATE'].includes(input)) return true
@@ -49,12 +56,13 @@ export const generateColumnField = (field: any = {}): ColumnField => {
 
 export const generateColumnFieldFromPostgresColumn = (
   column: PostgresColumn,
-  table: PostgresTable
+  table: PostgresTable,
+  foreignKeys: ForeignKeyConstraint[]
 ): ColumnField => {
   const { primary_keys } = table
   // @ts-ignore
   const primaryKeyColumns = primary_keys.map((key) => key.name)
-  const foreignKey = getColumnForeignKey(column, table)
+  const foreignKey = getColumnForeignKey(column, table, foreignKeys)
   const isArray = column?.data_type === 'ARRAY'
 
   return {
@@ -175,8 +183,8 @@ export const validateFields = (field: ColumnField) => {
 }
 
 export const getForeignKeyUIState = (
-  originalConfig: PostgresRelationship | undefined,
-  updatedConfig: PostgresRelationship | undefined
+  originalConfig: ExtendedPostgresRelationship | undefined,
+  updatedConfig: ExtendedPostgresRelationship | undefined
 ): 'Info' | 'Add' | 'Remove' | 'Update' => {
   if (isUndefined(originalConfig) && !isUndefined(updatedConfig)) {
     return 'Add'
@@ -189,7 +197,8 @@ export const getForeignKeyUIState = (
   if (
     !isEqual(originalConfig?.target_table_schema, updatedConfig?.target_table_schema) ||
     !isEqual(originalConfig?.target_table_name, updatedConfig?.target_table_name) ||
-    !isEqual(originalConfig?.target_column_name, updatedConfig?.target_column_name)
+    !isEqual(originalConfig?.target_column_name, updatedConfig?.target_column_name) ||
+    originalConfig?.deletion_action !== updatedConfig?.deletion_action
   ) {
     return 'Update'
   }
@@ -197,19 +206,43 @@ export const getForeignKeyUIState = (
   return 'Info'
 }
 
-export const getColumnForeignKey = (column: PostgresColumn, table: PostgresTable) => {
+export const getColumnForeignKey = (
+  column: PostgresColumn,
+  table: PostgresTable,
+  foreignKeys: ForeignKeyConstraint[]
+) => {
   const { relationships } = table
-  return find(relationships, (relationship) => {
+  const foreignKey = find(relationships, (relationship) => {
     return (
       relationship.source_schema === column.schema &&
       relationship.source_table_name === column.table &&
       relationship.source_column_name === column.name
     )
   })
+  if (foreignKey === undefined) return foreignKey
+  else {
+    const foreignKeyMeta = foreignKeys.find((fk) => fk.id === foreignKey?.id)
+    return { ...foreignKey, deletion_action: foreignKeyMeta?.deletion_action ?? 'a' }
+  }
 }
 
 // Assumes arrayString is a stringified array (e.g "[1, 2, 3]")
 const formatArrayToPostgresArray = (arrayString: string) => {
   if (!arrayString) return null
   return arrayString.replaceAll('[', '{').replaceAll(']', '}')
+}
+
+export const getForeignKeyDeletionAction = (deletionAction?: string) => {
+  switch (deletionAction) {
+    case FOREIGN_KEY_DELETION_ACTION.CASCADE:
+      return 'Cascade'
+    case FOREIGN_KEY_DELETION_ACTION.RESTRICT:
+      return 'Restrict'
+    case FOREIGN_KEY_DELETION_ACTION.SET_DEFAULT:
+      return 'Set default'
+    case FOREIGN_KEY_DELETION_ACTION.SET_NULL:
+      return 'Set null'
+    default:
+      return undefined
+  }
 }

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnForeignKey.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnForeignKey.tsx
@@ -101,7 +101,9 @@ const ColumnForeignKeyInformation: FC<{
                 {foreignKey?.target_table_schema}.{foreignKey?.target_table_name}.
                 {foreignKey?.target_column_name}
               </span>
-              {deletionAction !== undefined && <Badge color="gray">Delete: {deletionAction}</Badge>}
+              {deletionAction !== undefined && (
+                <Badge color="gray">On delete: {deletionAction}</Badge>
+              )}
             </div>
           </div>
           <div className="flex items-center space-x-2">
@@ -148,7 +150,9 @@ const ColumnForeignKeyAdded: FC<{
                 {foreignKey?.target_table_schema}.{foreignKey?.target_table_name}.
                 {foreignKey?.target_column_name}
               </span>
-              {deletionAction !== undefined && <Badge color="gray">Delete: {deletionAction}</Badge>}
+              {deletionAction !== undefined && (
+                <Badge color="gray">On delete: {deletionAction}</Badge>
+              )}
             </div>
           </div>
           <div className="flex items-center space-x-2">
@@ -248,11 +252,11 @@ const ColumnForeignKeyUpdated: FC<{
                 {originalDeletionAction !== undefined &&
                   originalDeletionAction !== updatedDeletionAction && (
                     <Badge color="gray" className="line-through">
-                      Delete: {originalDeletionAction}
+                      On delete: {originalDeletionAction}
                     </Badge>
                   )}
                 {updatedDeletionAction !== undefined && (
-                  <Badge color="green">Delete: {updatedDeletionAction}</Badge>
+                  <Badge color="green">On delete: {updatedDeletionAction}</Badge>
                 )}
               </div>
             </div>

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnForeignKey.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnForeignKey.tsx
@@ -256,7 +256,9 @@ const ColumnForeignKeyUpdated: FC<{
                     </Badge>
                   )}
                 {updatedDeletionAction !== undefined && (
-                  <Badge color="green">On delete: {updatedDeletionAction}</Badge>
+                  <div>
+                    <Badge color="green">On delete: {updatedDeletionAction}</Badge>
+                  </div>
                 )}
               </div>
             </div>

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnForeignKey.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnForeignKey.tsx
@@ -1,17 +1,18 @@
 import { FC } from 'react'
 import { isUndefined } from 'lodash'
-import { Button, IconArrowRight } from 'ui'
+import { Badge, Button, IconArrowRight } from 'ui'
 
 import { ColumnField } from '../SidePanelEditor.types'
 import InformationBox from 'components/ui/InformationBox'
-import { getForeignKeyUIState } from './ColumnEditor.utils'
-import type { PostgresRelationship } from '@supabase/postgres-meta'
+import { getForeignKeyDeletionAction, getForeignKeyUIState } from './ColumnEditor.utils'
+import type { ExtendedPostgresRelationship } from '../SidePanelEditor.types'
 
 interface Props {
   column: ColumnField
-  originalForeignKey: PostgresRelationship | undefined
+  originalForeignKey: ExtendedPostgresRelationship | undefined
   onSelectEditRelation: () => void
   onSelectRemoveRelation: () => void
+  onSelectCancelRemoveRelation: () => void
 }
 
 const ColumnForeignKey: FC<Props> = ({
@@ -19,6 +20,7 @@ const ColumnForeignKey: FC<Props> = ({
   originalForeignKey,
   onSelectEditRelation = () => {},
   onSelectRemoveRelation = () => {},
+  onSelectCancelRemoveRelation,
 }) => {
   const hasNoForeignKey = isUndefined(originalForeignKey) && isUndefined(column?.foreignKey)
   if (hasNoForeignKey) {
@@ -47,6 +49,7 @@ const ColumnForeignKey: FC<Props> = ({
           columnName={column.name}
           originalForeignKey={originalForeignKey}
           onSelectEditRelation={onSelectEditRelation}
+          onSelectCancelRemoveRelation={onSelectCancelRemoveRelation}
         />
       )
     case 'Update':
@@ -79,24 +82,26 @@ export default ColumnForeignKey
 
 const ColumnForeignKeyInformation: FC<{
   columnName: string
-  foreignKey?: PostgresRelationship
+  foreignKey?: ExtendedPostgresRelationship
   onSelectEditRelation: () => void
   onSelectRemoveRelation: () => void
 }> = ({ columnName, foreignKey, onSelectEditRelation, onSelectRemoveRelation }) => {
+  const deletionAction = getForeignKeyDeletionAction(foreignKey?.deletion_action)
   return (
     <InformationBox
       block
       title={
-        <div className="flex flex-col space-y-4 text-scale-900">
+        <div className="flex flex-col space-y-4">
           <div className="space-y-2">
-            <span>This column has the following foreign key relation:</span>
-            <div className="flex items-center space-x-2">
-              <span className="text-code">{columnName}</span>
+            <p className="text-scale-1100">This column has the following foreign key relation:</p>
+            <div className="flex items-center space-x-2 text-scale-1200">
+              <span className="text-xs text-code font-mono">{columnName}</span>
               <IconArrowRight size={14} strokeWidth={2} />
-              <span className="text-code">
+              <span className="text-xs text-code font-mono">
                 {foreignKey?.target_table_schema}.{foreignKey?.target_table_name}.
                 {foreignKey?.target_column_name}
               </span>
+              {deletionAction !== undefined && <Badge color="gray">Delete: {deletionAction}</Badge>}
             </div>
           </div>
           <div className="flex items-center space-x-2">
@@ -115,10 +120,11 @@ const ColumnForeignKeyInformation: FC<{
 
 const ColumnForeignKeyAdded: FC<{
   columnName: string
-  foreignKey?: PostgresRelationship
+  foreignKey?: ExtendedPostgresRelationship
   onSelectEditRelation: () => void
   onSelectRemoveRelation: () => void
 }> = ({ columnName, foreignKey, onSelectEditRelation, onSelectRemoveRelation }) => {
+  const deletionAction = getForeignKeyDeletionAction(foreignKey?.deletion_action)
   return (
     <InformationBox
       block
@@ -142,6 +148,7 @@ const ColumnForeignKeyAdded: FC<{
                 {foreignKey?.target_table_schema}.{foreignKey?.target_table_name}.
                 {foreignKey?.target_column_name}
               </span>
+              {deletionAction !== undefined && <Badge color="gray">Delete: {deletionAction}</Badge>}
             </div>
           </div>
           <div className="flex items-center space-x-2">
@@ -160,23 +167,24 @@ const ColumnForeignKeyAdded: FC<{
 
 const ColumnForeignKeyRemoved: FC<{
   columnName: string
-  originalForeignKey?: PostgresRelationship
+  originalForeignKey?: ExtendedPostgresRelationship
   onSelectEditRelation: () => void
-}> = ({ columnName, originalForeignKey, onSelectEditRelation }) => {
+  onSelectCancelRemoveRelation: () => void
+}> = ({ columnName, originalForeignKey, onSelectEditRelation, onSelectCancelRemoveRelation }) => {
   return (
     <InformationBox
       block
       title={
         <div className="flex flex-col space-y-4">
           <div className="space-y-2">
-            <p>
+            <p className="text-scale-1100">
               The following foreign key relation will be{' '}
-              <span className="text-amber-900">removed</span> from this column:
+              <span className="text-amber-900">removed</span>:
             </p>
             <div className="flex items-center space-x-2">
-              <code className="text-sm">{columnName}</code>
+              <code className="text-xs font-mono">{columnName}</code>
               <IconArrowRight size={14} strokeWidth={2} />
-              <code className="text-sm">
+              <code className="text-xs font-mono">
                 {originalForeignKey?.target_table_schema}.{originalForeignKey?.target_table_name}.
                 {originalForeignKey?.target_column_name}
               </code>
@@ -185,6 +193,9 @@ const ColumnForeignKeyRemoved: FC<{
           <div className="flex items-center space-x-2">
             <Button type="outline" onClick={onSelectEditRelation}>
               Edit relation
+            </Button>
+            <Button type="outline" onClick={onSelectCancelRemoveRelation}>
+              Cancel remove
             </Button>
           </div>
         </div>
@@ -195,8 +206,8 @@ const ColumnForeignKeyRemoved: FC<{
 
 const ColumnForeignKeyUpdated: FC<{
   columnName: string
-  originalForeignKey?: PostgresRelationship
-  updatedForeignKey?: PostgresRelationship
+  originalForeignKey?: ExtendedPostgresRelationship
+  updatedForeignKey?: ExtendedPostgresRelationship
   onSelectEditRelation: () => void
   onSelectRemoveRelation: () => void
 }> = ({
@@ -206,6 +217,12 @@ const ColumnForeignKeyUpdated: FC<{
   onSelectEditRelation,
   onSelectRemoveRelation,
 }) => {
+  const originalKey = `${originalForeignKey?.target_table_schema}.${originalForeignKey?.target_table_name}.${originalForeignKey?.target_column_name}`
+  const updatedKey = `${updatedForeignKey?.target_table_schema}.${updatedForeignKey?.target_table_name}.${updatedForeignKey?.target_column_name}`
+
+  const originalDeletionAction = getForeignKeyDeletionAction(originalForeignKey?.deletion_action)
+  const updatedDeletionAction = getForeignKeyDeletionAction(updatedForeignKey?.deletion_action)
+
   return (
     <InformationBox
       block
@@ -217,19 +234,25 @@ const ColumnForeignKeyUpdated: FC<{
               such:
             </p>
             <div className="flex items-start space-x-2">
-              <code className="text-sm">{columnName}</code>
+              <code className="text-xs font-mono">{columnName}</code>
               <IconArrowRight className="mt-1" size={14} strokeWidth={2} />
               <div className="flex flex-col space-y-2">
-                <p className="line-through">
-                  <code className="text-sm">
-                    {originalForeignKey?.target_table_schema}.
-                    {originalForeignKey?.target_table_name}.{originalForeignKey?.target_column_name}
-                  </code>
-                </p>
-                <code className="text-sm">
-                  {updatedForeignKey?.target_table_schema}.{updatedForeignKey?.target_table_name}.
-                  {updatedForeignKey?.target_column_name}
-                </code>
+                {originalKey !== updatedKey && (
+                  <p className="line-through">
+                    <code className="text-xs font-mono">{originalKey}</code>
+                  </p>
+                )}
+                <code className="text-xs font-mono">{updatedKey}</code>
+              </div>
+              <div className="flex flex-col space-y-2">
+                {originalDeletionAction !== updatedDeletionAction && (
+                  <Badge color="gray" className="line-through">
+                    Delete: {originalDeletionAction}
+                  </Badge>
+                )}
+                {updatedDeletionAction !== undefined && (
+                  <Badge color="green">Delete: {updatedDeletionAction}</Badge>
+                )}
               </div>
             </div>
           </div>

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnForeignKey.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnForeignKey.tsx
@@ -245,11 +245,12 @@ const ColumnForeignKeyUpdated: FC<{
                 <code className="text-xs font-mono">{updatedKey}</code>
               </div>
               <div className="flex flex-col space-y-2">
-                {originalDeletionAction !== updatedDeletionAction && (
-                  <Badge color="gray" className="line-through">
-                    Delete: {originalDeletionAction}
-                  </Badge>
-                )}
+                {originalDeletionAction !== undefined &&
+                  originalDeletionAction !== updatedDeletionAction && (
+                    <Badge color="gray" className="line-through">
+                      Delete: {originalDeletionAction}
+                    </Badge>
+                  )}
                 {updatedDeletionAction !== undefined && (
                   <Badge color="green">Delete: {updatedDeletionAction}</Badge>
                 )}

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.constants.ts
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.constants.ts
@@ -1,0 +1,9 @@
+import { FOREIGN_KEY_DELETION_ACTION } from 'data/database/database-query-constants'
+
+export const FOREIGN_KEY_DELETION_OPTIONS = [
+  { key: 'no-action', label: 'No action', value: FOREIGN_KEY_DELETION_ACTION.NO_ACTION },
+  { key: 'cascade', label: 'Cascade', value: FOREIGN_KEY_DELETION_ACTION.CASCADE },
+  { key: 'restrict', label: 'Restrict', value: FOREIGN_KEY_DELETION_ACTION.RESTRICT },
+  { key: 'set-default', label: 'Set default', value: FOREIGN_KEY_DELETION_ACTION.SET_DEFAULT },
+  { key: 'set-null', label: 'Set NULL', value: FOREIGN_KEY_DELETION_ACTION.SET_NULL },
+]

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.tsx
@@ -276,7 +276,7 @@ const ForeignKeySelector: FC<Props> = ({ column, visible = false, closePanel, sa
               <Listbox
                 id="deletionAction"
                 value={selectedForeignKey.deletionAction}
-                label="Deletion action if referenced row is removed"
+                label="Delete action if referenced row is removed"
                 // @ts-ignore
                 descriptionText={generateDeletionActionDescription(
                   selectedForeignKey.deletionAction,

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.tsx
@@ -273,10 +273,45 @@ const ForeignKeySelector: FC<Props> = ({ column, visible = false, closePanel, sa
                 </Listbox>
               )}
               <SidePanel.Separator />
+              <InformationBox
+                icon={<IconHelpCircle size="large" strokeWidth={1.5} />}
+                title="Which action is most appropriate?"
+                description={
+                  <>
+                    <p>
+                      The choice of the action depends on what kinds of objects the related tables
+                      represent:
+                    </p>
+                    <ul className="mt-2 list-disc pl-4 space-y-1">
+                      <li>
+                        <code className="text-xs">Cascade</code>: if the referencing table
+                        represents something that is a component of what is represented by the
+                        referenced table and cannot exist independently
+                      </li>
+                      <li>
+                        <code className="text-xs">Restrict</code> or{' '}
+                        <code className="text-xs">No action</code>: if the two tables represent
+                        independent objects
+                      </li>
+                      <li>
+                        <code className="text-xs">Set NULL</code> or{' '}
+                        <code className="text-xs">Set default</code>: if a foreign-key relationship
+                        represents optional information
+                      </li>
+                    </ul>
+                    <p className="mt-2">
+                      Typically, restricting and cascading deletes are the most common options, but
+                      the default behaviour is no action
+                    </p>
+                  </>
+                }
+                url="https://www.postgresql.org/docs/current/ddl-constraints.html#DDL-CONSTRAINTS-FK"
+                urlLabel="More information"
+              />
               <Listbox
                 id="deletionAction"
                 value={selectedForeignKey.deletionAction}
-                label="Delete action if referenced row is removed"
+                label="Action if referenced row is removed"
                 // @ts-ignore
                 descriptionText={generateDeletionActionDescription(
                   selectedForeignKey.deletionAction,

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.tsx
@@ -301,7 +301,7 @@ const ForeignKeySelector: FC<Props> = ({ column, visible = false, closePanel, sa
                     </ul>
                     <p className="mt-2">
                       Typically, restricting and cascading deletes are the most common options, but
-                      the default behaviour is no action
+                      the default behavior is no action
                     </p>
                   </>
                 }

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.types.ts
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.types.ts
@@ -2,5 +2,5 @@ export interface ForeignKey {
   schema: string
   table: string
   column?: string
-  enableCascadeDelete: boolean
+  deletionAction: string
 }

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.types.ts
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.types.ts
@@ -2,4 +2,5 @@ export interface ForeignKey {
   schema: string
   table: string
   column?: string
+  enableCascadeDelete: boolean
 }

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.utils.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.utils.tsx
@@ -1,4 +1,6 @@
+import * as Tooltip from '@radix-ui/react-tooltip'
 import { FOREIGN_KEY_DELETION_ACTION } from 'data/database/database-query-constants'
+import { IconHelpCircle } from 'ui'
 import { getForeignKeyDeletionAction } from '../ColumnEditor/ColumnEditor.utils'
 
 export const generateDeletionActionDescription = (deletionAction: string, reference: string) => {
@@ -29,7 +31,26 @@ export const generateDeletionActionDescription = (deletionAction: string, refere
           <span className="text-scale-1100">{actionName}</span>: Deleting a record from{' '}
           <code className="text-xs text-scale-1100">{reference}</code> will{' '}
           <span className="text-amber-900 opacity-75">prevent deletion</span> of existing
-          referencing rows from this table
+          referencing rows from this table.
+          <Tooltip.Root delayDuration={0}>
+            <Tooltip.Trigger className="translate-y-[2px] ml-1">
+              <IconHelpCircle className="text-scale-1100" size={16} strokeWidth={1.5} />
+            </Tooltip.Trigger>
+            <Tooltip.Content side="bottom">
+              <Tooltip.Arrow className="radix-tooltip-arrow" />
+              <div
+                className={[
+                  'rounded bg-scale-100 py-1 px-2 leading-none shadow',
+                  'w-[300px] space-y-2 border border-scale-200',
+                ].join(' ')}
+              >
+                <p className="text-xs text-scale-1200">
+                  This is similar to no action, but the restrict check cannot be deferred till later
+                  in the transaction
+                </p>
+              </div>
+            </Tooltip.Content>
+          </Tooltip.Root>
         </>
       )
     case FOREIGN_KEY_DELETION_ACTION.SET_DEFAULT:
@@ -37,7 +58,7 @@ export const generateDeletionActionDescription = (deletionAction: string, refere
         <>
           <span className="text-scale-1100">{actionName}</span>: Deleting a record from{' '}
           <code className="text-xs text-scale-1100">{reference}</code> will set the value of any
-          existing records in this table referencing it back to their{' '}
+          existing records in this table referencing it to their{' '}
           <span className="text-amber-900 opacity-75">default value</span>
         </>
       )

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.utils.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.utils.tsx
@@ -1,45 +1,53 @@
 import { FOREIGN_KEY_DELETION_ACTION } from 'data/database/database-query-constants'
+import { getForeignKeyDeletionAction } from '../ColumnEditor/ColumnEditor.utils'
 
 export const generateDeletionActionDescription = (deletionAction: string, reference: string) => {
+  const actionName = getForeignKeyDeletionAction(deletionAction) ?? 'No action'
+
   switch (deletionAction) {
     case FOREIGN_KEY_DELETION_ACTION.NO_ACTION:
       return (
         <>
-          Deleting a record from <code className="text-xs text-scale-1100">{reference}</code> will{' '}
-          <span className="text-brand-900 opacity-75">raise an error</span> if there exists
-          referencing rows from this table
+          <span className="text-scale-1100">{actionName}</span>: Deleting a record from{' '}
+          <code className="text-xs text-scale-1100">{reference}</code> will{' '}
+          <span className="text-amber-900 opacity-75">raise an error</span> if there are records
+          existing in this table that reference it
         </>
       )
     case FOREIGN_KEY_DELETION_ACTION.CASCADE:
       return (
         <>
-          Deleting a record from <code className="text-xs text-scale-1100">{reference}</code> will{' '}
-          <span className="text-brand-900 opacity-75">also delete</span> the referencing records
-          from this table
+          <span className="text-scale-1100">{actionName}</span>: Deleting a record from{' '}
+          <code className="text-xs text-scale-1100">{reference}</code> will{' '}
+          <span className="text-amber-900 opacity-75">also delete</span> any records that reference
+          it in this table
         </>
       )
     case FOREIGN_KEY_DELETION_ACTION.RESTRICT:
       return (
         <>
-          Deleting a record from <code className="text-xs text-scale-1100">{reference}</code> will{' '}
-          <span className="text-brand-900 opacity-75">prevent deletion</span> of existing
+          <span className="text-scale-1100">{actionName}</span>: Deleting a record from{' '}
+          <code className="text-xs text-scale-1100">{reference}</code> will{' '}
+          <span className="text-amber-900 opacity-75">prevent deletion</span> of existing
           referencing rows from this table
         </>
       )
     case FOREIGN_KEY_DELETION_ACTION.SET_DEFAULT:
       return (
         <>
-          Deleting a record from <code className="text-xs text-scale-1100">{reference}</code> will{' '}
-          set the values of existing referencing rows to their{' '}
-          <span className="text-brand-900 opacity-75">default value</span> from this table
+          <span className="text-scale-1100">{actionName}</span>: Deleting a record from{' '}
+          <code className="text-xs text-scale-1100">{reference}</code> will set the value of any
+          existing records in this table referencing it back to their{' '}
+          <span className="text-amber-900 opacity-75">default value</span>
         </>
       )
     case FOREIGN_KEY_DELETION_ACTION.SET_NULL:
       return (
         <>
-          Deleting a record from <code className="text-xs text-scale-1100">{reference}</code> will{' '}
-          set the values of existing referencing rows{' '}
-          <span className="text-brand-900 opacity-75">to NULL</span> from this table
+          <span className="text-scale-1100">{actionName}</span>: Deleting a record from{' '}
+          <code className="text-xs text-scale-1100">{reference}</code> will set the value of any
+          existing records in this table referencing it{' '}
+          <span className="text-amber-900 opacity-75">to NULL</span>
         </>
       )
   }

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.utils.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.utils.tsx
@@ -22,7 +22,7 @@ export const generateDeletionActionDescription = (deletionAction: string, refere
       return (
         <>
           Deleting a record from <code className="text-xs text-scale-1100">{reference}</code> will{' '}
-          <span className="text-brand-900 opacity-75">raise an error</span> if there exists
+          <span className="text-brand-900 opacity-75">prevent deletion</span> of existing
           referencing rows from this table
         </>
       )

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.utils.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.utils.tsx
@@ -28,12 +28,9 @@ export const generateDeletionActionDescription = (deletionAction: string, refere
     case FOREIGN_KEY_DELETION_ACTION.RESTRICT:
       return (
         <>
-          <span className="text-scale-1100">{actionName}</span>: Deleting a record from{' '}
-          <code className="text-xs text-scale-1100">{reference}</code> will{' '}
-          <span className="text-amber-900 opacity-75">prevent deletion</span> of existing
-          referencing rows from this table.
+          <span className="text-scale-1100">{actionName}</span>
           <Tooltip.Root delayDuration={0}>
-            <Tooltip.Trigger className="translate-y-[2px] ml-1">
+            <Tooltip.Trigger className="translate-y-[3px] mx-1">
               <IconHelpCircle className="text-scale-1100" size={16} strokeWidth={1.5} />
             </Tooltip.Trigger>
             <Tooltip.Content side="bottom">
@@ -51,6 +48,9 @@ export const generateDeletionActionDescription = (deletionAction: string, refere
               </div>
             </Tooltip.Content>
           </Tooltip.Root>
+          : Deleting a record from <code className="text-xs text-scale-1100">{reference}</code> will{' '}
+          <span className="text-amber-900 opacity-75">prevent deletion</span> of existing
+          referencing rows from this table.
         </>
       )
     case FOREIGN_KEY_DELETION_ACTION.SET_DEFAULT:

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.utils.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.utils.tsx
@@ -1,0 +1,46 @@
+import { FOREIGN_KEY_DELETION_ACTION } from 'data/database/database-query-constants'
+
+export const generateDeletionActionDescription = (deletionAction: string, reference: string) => {
+  switch (deletionAction) {
+    case FOREIGN_KEY_DELETION_ACTION.NO_ACTION:
+      return (
+        <>
+          Deleting a record from <code className="text-xs text-scale-1100">{reference}</code> will{' '}
+          <span className="text-brand-900 opacity-75">raise an error</span> if there exists
+          referencing rows from this table
+        </>
+      )
+    case FOREIGN_KEY_DELETION_ACTION.CASCADE:
+      return (
+        <>
+          Deleting a record from <code className="text-xs text-scale-1100">{reference}</code> will{' '}
+          <span className="text-brand-900 opacity-75">also delete</span> the referencing records
+          from this table
+        </>
+      )
+    case FOREIGN_KEY_DELETION_ACTION.RESTRICT:
+      return (
+        <>
+          Deleting a record from <code className="text-xs text-scale-1100">{reference}</code> will{' '}
+          <span className="text-brand-900 opacity-75">raise an error</span> if there exists
+          referencing rows from this table
+        </>
+      )
+    case FOREIGN_KEY_DELETION_ACTION.SET_DEFAULT:
+      return (
+        <>
+          Deleting a record from <code className="text-xs text-scale-1100">{reference}</code> will{' '}
+          set the values of existing referencing rows to their{' '}
+          <span className="text-brand-900 opacity-75">default value</span> from this table
+        </>
+      )
+    case FOREIGN_KEY_DELETION_ACTION.SET_NULL:
+      return (
+        <>
+          Deleting a record from <code className="text-xs text-scale-1100">{reference}</code> will{' '}
+          set the values of existing referencing rows{' '}
+          <span className="text-brand-900 opacity-75">to NULL</span> from this table
+        </>
+      )
+  }
+}

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
@@ -1,15 +1,20 @@
 import { FC, useState } from 'react'
 import { find, isEmpty, isUndefined } from 'lodash'
-import { Query, Dictionary } from 'components/grid'
+import { Dictionary } from 'components/grid'
 import { Modal } from 'ui'
-import type { PostgresRelationship, PostgresTable, PostgresColumn } from '@supabase/postgres-meta'
+import type { PostgresTable, PostgresColumn } from '@supabase/postgres-meta'
 
 import { useStore } from 'hooks'
 import { useTableRowCreateMutation } from 'data/table-rows/table-row-create-mutation'
 import { useTableRowUpdateMutation } from 'data/table-rows/table-row-update-mutation'
 import { RowEditor, ColumnEditor, TableEditor } from '.'
 import { ImportContent } from './TableEditor/TableEditor.types'
-import { ColumnField, CreateColumnPayload, UpdateColumnPayload } from './SidePanelEditor.types'
+import {
+  ColumnField,
+  CreateColumnPayload,
+  ExtendedPostgresRelationship,
+  UpdateColumnPayload,
+} from './SidePanelEditor.types'
 import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
 import ConfirmationModal from 'components/ui/ConfirmationModal'
 import JsonEdit from './RowEditor/JsonEditor/JsonEditor'
@@ -150,7 +155,7 @@ const SidePanelEditor: FC<Props> = ({
 
   const saveColumn = async (
     payload: CreateColumnPayload | UpdateColumnPayload,
-    foreignKey: Partial<PostgresRelationship> | undefined,
+    foreignKey: ExtendedPostgresRelationship | undefined,
     isNewRecord: boolean,
     configuration: { columnId?: string; isEncrypted: boolean; keyId?: string; keyName?: string },
     resolve: any
@@ -304,7 +309,6 @@ const SidePanelEditor: FC<Props> = ({
       )}
       {!isUndefined(selectedTable) && (
         <ColumnEditor
-          tables={tables}
           column={selectedColumnToEdit}
           selectedTable={selectedTable}
           visible={sidePanelKey === 'column'}

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
@@ -181,10 +181,6 @@ const SidePanelEditor: FC<Props> = ({
     if (response?.error) {
       ui.setNotification({ category: 'error', message: response.error.message })
     } else {
-      ui.setNotification({
-        category: 'success',
-        message: isNewRecord ? `Successfully created column` : `Successfully updated column`,
-      })
       await meta.tables.loadById(selectedTable!.id)
       queryClient.invalidateQueries(sqlKeys.query(project?.ref, ['foreignKeyConstraints']))
       onColumnSaved(configuration.isEncrypted)

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.types.ts
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.types.ts
@@ -56,13 +56,17 @@ export interface Field {
   foreignKey?: { table: string; column: string }
 }
 
+export interface ExtendedPostgresRelationship extends PostgresRelationship {
+  deletion_action: string
+}
+
 export interface ColumnField {
   id: string
   name: string
   comment?: string
   format: string
   defaultValue: string | null
-  foreignKey: PostgresRelationship | undefined
+  foreignKey: ExtendedPostgresRelationship | undefined
   isNullable: boolean
   isUnique: boolean
   isArray: boolean

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/ColumnManagement.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/ColumnManagement.tsx
@@ -1,14 +1,9 @@
 import Link from 'next/link'
-import React, { FC, useState } from 'react'
-import { partition, isEmpty, isUndefined } from 'lodash'
+import { FC, useState } from 'react'
+import { partition, isEmpty } from 'lodash'
 import { Alert, Button, IconEdit, IconHelpCircle, IconKey, IconTrash, IconExternalLink } from 'ui'
 
-import type {
-  PostgresTable,
-  PostgresColumn,
-  PostgresRelationship,
-  PostgresType,
-} from '@supabase/postgres-meta'
+import type { PostgresTable, PostgresColumn, PostgresType } from '@supabase/postgres-meta'
 import {
   DragDropContext,
   Droppable,
@@ -60,7 +55,7 @@ const ColumnManagement: FC<Props> = ({
     column: PostgresColumn
     deletionAction: string
   }) => {
-    if (!isUndefined(selectedColumnToEditRelation)) {
+    if (selectedColumnToEditRelation !== undefined) {
       onUpdateColumn(selectedColumnToEditRelation, {
         foreignKey:
           foreignKeyConfiguration !== undefined
@@ -356,7 +351,7 @@ const ColumnManagement: FC<Props> = ({
       </div>
       <ForeignKeySelector
         column={selectedColumnToEditRelation as ColumnField}
-        visible={!isUndefined(selectedColumnToEditRelation)}
+        visible={selectedColumnToEditRelation !== undefined}
         closePanel={() => setSelectedColumnToEditRelation(undefined)}
         saveChanges={saveColumnForeignKey}
       />

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.tsx
@@ -263,7 +263,6 @@ const TableEditor: FC<Props> = ({
             {!isDuplicating && (
               <ColumnManagement
                 table={{ name: tableFields.name, schema: selectedSchema }}
-                tables={tables}
                 columns={tableFields?.columns}
                 enumTypes={enumTypes}
                 isNewRecord={isNewRecord}

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.tsx
@@ -80,7 +80,7 @@ const TableEditor: FC<Props> = ({
     connectionString: project?.connectionString,
     schema: table?.schema,
   })
-  const foreignKeyMeta = data?.result ?? []
+  const foreignKeyMeta = data || []
 
   useEffect(() => {
     if (visible) {

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.tsx
@@ -17,7 +17,8 @@ import {
   generateTableFieldFromPostgresTable,
   formatImportedContentToColumnFields,
 } from './TableEditor.utils'
-import InformationBox from 'components/ui/InformationBox'
+import { useForeignKeyConstraintsQuery } from 'data/database/foreign-key-constraints-query'
+import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
 
 interface Props {
   table?: PostgresTable
@@ -51,6 +52,7 @@ const TableEditor: FC<Props> = ({
   updateEditorDirty = () => {},
 }) => {
   const { ui, meta } = useStore()
+  const { project } = useProjectContext()
   const isNewRecord = isUndefined(table)
 
   const tables = meta.tables.list()
@@ -73,6 +75,13 @@ const TableEditor: FC<Props> = ({
   const [importContent, setImportContent] = useState<ImportContent>()
   const [isImportingSpreadsheet, setIsImportingSpreadsheet] = useState<boolean>(false)
 
+  const { data } = useForeignKeyConstraintsQuery({
+    projectRef: project?.ref,
+    connectionString: project?.connectionString,
+    schema: table?.schema,
+  })
+  const foreignKeyMeta = data?.result ?? []
+
   useEffect(() => {
     if (visible) {
       setErrors({})
@@ -84,6 +93,7 @@ const TableEditor: FC<Props> = ({
       } else {
         const tableFields = generateTableFieldFromPostgresTable(
           table!,
+          foreignKeyMeta,
           isDuplicating,
           isRealtimeEnabled
         )

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.utils.ts
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.utils.ts
@@ -8,6 +8,7 @@ import {
   generateColumnField,
   generateColumnFieldFromPostgresColumn,
 } from '../ColumnEditor/ColumnEditor.utils'
+import { ForeignKeyConstraint } from 'data/database/foreign-key-constraints-query'
 
 export const validateFields = (field: TableField) => {
   const errors = {} as any
@@ -36,6 +37,7 @@ export const generateTableField = (): TableField => {
 
 export const generateTableFieldFromPostgresTable = (
   table: PostgresTable,
+  foreignKeys: ForeignKeyConstraint[],
   isDuplicating = false,
   isRealtimeEnabled = false
 ): TableField => {
@@ -45,7 +47,7 @@ export const generateTableFieldFromPostgresTable = (
     comment: isDuplicating ? `This is a duplicate of ${table.name}` : table?.comment ?? '',
     // @ts-ignore
     columns: table.columns.map((column: PostgresColumn) => {
-      return generateColumnFieldFromPostgresColumn(column, table)
+      return generateColumnFieldFromPostgresColumn(column, table, foreignKeys)
     }),
     isRLSEnabled: table.rls_enabled,
     isRealtimeEnabled,

--- a/studio/components/interfaces/TableGridEditor/TableGridEditor.tsx
+++ b/studio/components/interfaces/TableGridEditor/TableGridEditor.tsx
@@ -2,7 +2,7 @@ import { FC, useRef, useEffect, useState } from 'react'
 import { observer } from 'mobx-react-lite'
 import { useRouter } from 'next/router'
 import { find, isUndefined } from 'lodash'
-import type { PostgresColumn, PostgresTable } from '@supabase/postgres-meta'
+import type { PostgresColumn, PostgresRelationship, PostgresTable } from '@supabase/postgres-meta'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { QueryKey, useQueryClient } from '@tanstack/react-query'
 
@@ -30,6 +30,11 @@ import { JsonEditValue } from './SidePanelEditor/RowEditor/RowEditor.types'
 import LangSelector from '../Docs/LangSelector'
 import GeneratingTypes from '../Docs/GeneratingTypes'
 import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
+import {
+  ForeignKeyConstraint,
+  useForeignKeyConstraintsQuery,
+} from 'data/database/foreign-key-constraints-query'
+import { FOREIGN_KEY_DELETION_ACTION } from 'data/database/database-query-constants'
 
 interface Props {
   /** Theme for the editor */
@@ -198,14 +203,17 @@ const TableGridEditor: FC<Props> = ({
     error: jsonSchemaError,
     refetch,
   } = useProjectJsonSchemaQuery({ projectRef })
-
-  if (jsonSchemaError) console.log('jsonSchemaError', jsonSchemaError)
+  if (jsonSchemaError) console.error('jsonSchemaError', jsonSchemaError)
 
   const resources = getResourcesFromJsonSchema(jsonSchema)
+  const refreshDocs = async () => await refetch()
 
-  const refreshDocs = async () => {
-    await refetch()
-  }
+  const { data } = useForeignKeyConstraintsQuery({
+    projectRef: project?.ref,
+    connectionString: project?.connectionString,
+    schema: selectedTable?.schema,
+  })
+  const foreignKeyMeta = data?.result ?? []
 
   useEffect(() => {
     if (selectedTable !== undefined && selectedTable.id !== undefined && isVaultEnabled) {
@@ -228,6 +236,20 @@ const TableGridEditor: FC<Props> = ({
   const canUpdateTables = checkPermissions(PermissionAction.TENANT_SQL_ADMIN_WRITE, 'tables')
   const canEditViaTableEditor = !isViewSelected && !isForeignTableSelected && !isLocked
 
+  // [Joshen] We can tweak below to eventually support composite keys as the data
+  // returned from foreignKeyMeta should be easy to deal with, rather than pg-meta
+  const formattedRelationships = (selectedTable?.relationships ?? []).map(
+    (relationship: PostgresRelationship) => {
+      const relationshipMeta = foreignKeyMeta.find(
+        (fk: ForeignKeyConstraint) => fk.id === relationship.id
+      )
+      return {
+        ...relationship,
+        deletion_action: relationshipMeta?.deletion_action ?? FOREIGN_KEY_DELETION_ACTION.NO_ACTION,
+      }
+    }
+  )
+
   const gridTable =
     !isViewSelected && !isForeignTableSelected
       ? parseSupaTable(
@@ -235,7 +257,7 @@ const TableGridEditor: FC<Props> = ({
             table: selectedTable as PostgresTable,
             columns: (selectedTable as PostgresTable).columns ?? [],
             primaryKeys: (selectedTable as PostgresTable).primary_keys,
-            relationships: (selectedTable as PostgresTable).relationships,
+            relationships: formattedRelationships,
           },
           encryptedColumns
         )

--- a/studio/components/interfaces/TableGridEditor/TableGridEditor.tsx
+++ b/studio/components/interfaces/TableGridEditor/TableGridEditor.tsx
@@ -213,7 +213,7 @@ const TableGridEditor: FC<Props> = ({
     connectionString: project?.connectionString,
     schema: selectedTable?.schema,
   })
-  const foreignKeyMeta = data?.result ?? []
+  const foreignKeyMeta = data || []
 
   useEffect(() => {
     if (selectedTable !== undefined && selectedTable.id !== undefined && isVaultEnabled) {

--- a/studio/data/database/database-query-constants.ts
+++ b/studio/data/database/database-query-constants.ts
@@ -4,7 +4,7 @@ export enum FOREIGN_KEY_DELETION_ACTION {
   NO_ACTION = 'a',
   RESTRICT = 'r',
   CASCADE = 'c',
-  SET_NULL = 's',
+  SET_NULL = 'n',
   SET_DEFAULT = 'd',
 }
 

--- a/studio/data/database/database-query-constants.ts
+++ b/studio/data/database/database-query-constants.ts
@@ -1,0 +1,18 @@
+// https://www.postgresql.org/docs/current/catalog-pg-constraint.html
+
+export enum FOREIGN_KEY_DELETION_ACTION {
+  NO_ACTION = 'a',
+  RESTRICT = 'r',
+  CASCADE = 'c',
+  SET_NULL = 's',
+  SET_DEFAULT = 'd',
+}
+
+export enum CONSTRAINT_TYPE {
+  CHECK_CONSTRAINT = 'c',
+  FOREIGN_KEY_CONSTRAINT = 'f',
+  PRIMARY_KEY_CONSTRAINT = 'p',
+  UNIQUE_CONSTRAINT = 'u',
+  CONSTRAINT_TRIGGER = 't',
+  EXCLUSION_CONSTRAINT = 'x',
+}

--- a/studio/data/database/foreign-key-constraints-query.ts
+++ b/studio/data/database/foreign-key-constraints-query.ts
@@ -81,29 +81,26 @@ export const useForeignKeyConstraintsQuery = <
   { projectRef, connectionString, schema }: ForeignKeyConstraintsVariables,
   options: UseQueryOptions<ExecuteSqlData, ForeignKeyConstraintsError, TData> = {}
 ) => {
-  const response = useExecuteSqlQuery(
+  return useExecuteSqlQuery(
     {
       projectRef,
       connectionString,
       sql: getForeignKeyConstraintsQuery({ schema }),
       queryKey: ['foreignKeyConstraints'],
     },
-    options
-  )
-
-  // [Joshen] Convert target/source_columns into a string array
-  // This should be safe as the returned data is rather scoped
-  const formattedResults = ((response?.data as any)?.result ?? []).map(
-    (foreignKey: ForeignKeyConstraint) => {
-      return {
-        ...foreignKey,
-        source_columns: foreignKey.source_columns.replace('{', '').replace('}', '').split(','),
-        target_columns: foreignKey.target_columns.replace('{', '').replace('}', '').split(','),
-      }
+    {
+      select(data) {
+        return ((data as any)?.result ?? []).map((foreignKey: ForeignKeyConstraint) => {
+          return {
+            ...foreignKey,
+            source_columns: foreignKey.source_columns.replace('{', '').replace('}', '').split(','),
+            target_columns: foreignKey.target_columns.replace('{', '').replace('}', '').split(','),
+          }
+        })
+      },
+      ...options,
     }
   )
-
-  return { ...response, data: { ...response.data, result: formattedResults } }
 }
 
 export const useForeignKeyConstraintsPrefetch = ({

--- a/studio/data/database/foreign-key-constraints-query.ts
+++ b/studio/data/database/foreign-key-constraints-query.ts
@@ -1,0 +1,120 @@
+import { UseQueryOptions } from '@tanstack/react-query'
+import { ExecuteSqlData, useExecuteSqlPrefetch, useExecuteSqlQuery } from '../sql/execute-sql-query'
+
+type getForeignKeyConstraintsVariables = {
+  schema?: string
+}
+
+export type ForeignKeyConstraint = {
+  id: number
+  constraint_name: string
+  deletion_action: string
+  source_schema: string
+  source_table: string
+  source_columns: string
+  target_schema: string
+  target_table: string
+  target_columns: string
+}
+
+export const getForeignKeyConstraintsQuery = ({ schema }: getForeignKeyConstraintsVariables) => {
+  const sql = `
+SELECT 
+  con.oid as id, 
+  con.conname as constraint_name, 
+  con.confdeltype as deletion_action, 
+  nsp.nspname as source_schema, 
+  rel.relname as source_table, 
+  (
+    SELECT 
+      array_agg(
+        att.attname 
+        ORDER BY 
+          un.ord
+      ) 
+    FROM 
+      unnest(con.conkey) WITH ORDINALITY un (attnum, ord) 
+      INNER JOIN pg_attribute att ON att.attnum = un.attnum 
+    WHERE 
+      att.attrelid = rel.oid
+  ) source_columns, 
+  fnsp.nspname as target_schema, 
+  frel.relname as target_table, 
+  (
+    SELECT 
+      array_agg(
+        att.attname 
+        ORDER BY 
+          un.ord
+      ) 
+    FROM 
+      unnest(con.confkey) WITH ORDINALITY un (attnum, ord) 
+      INNER JOIN pg_attribute att ON att.attnum = un.attnum 
+    WHERE 
+      att.attrelid = frel.oid
+  ) target_columns 
+FROM 
+  pg_constraint con 
+  INNER JOIN pg_class rel ON rel.oid = con.conrelid 
+  INNER JOIN pg_namespace nsp ON nsp.oid = rel.relnamespace 
+  INNER JOIN pg_class frel ON frel.oid = con.confrelid 
+  INNER JOIN pg_namespace fnsp ON fnsp.oid = frel.relnamespace 
+WHERE 
+  con.contype = 'f'
+  ${schema !== undefined ? `AND nsp.nspname = '${schema}'` : ''};
+`.trim()
+
+  return sql
+}
+
+export type ForeignKeyConstraintsVariables = getForeignKeyConstraintsVariables & {
+  projectRef?: string
+  connectionString?: string
+}
+
+export type ForeignKeyConstraintsData = ForeignKeyConstraint[]
+export type ForeignKeyConstraintsError = unknown
+
+export const useForeignKeyConstraintsQuery = <
+  TData extends ForeignKeyConstraintsData = ForeignKeyConstraintsData
+>(
+  { projectRef, connectionString, schema }: ForeignKeyConstraintsVariables,
+  options: UseQueryOptions<ExecuteSqlData, ForeignKeyConstraintsError, TData> = {}
+) => {
+  const response = useExecuteSqlQuery(
+    {
+      projectRef,
+      connectionString,
+      sql: getForeignKeyConstraintsQuery({ schema }),
+      queryKey: ['foreignKeyConstraints'],
+    },
+    options
+  )
+
+  // [Joshen] Convert target/source_columns into a string array
+  // This should be safe as the returned data is rather scoped
+  const formattedResults = ((response?.data as any)?.result ?? []).map(
+    (foreignKey: ForeignKeyConstraint) => {
+      return {
+        ...foreignKey,
+        source_columns: foreignKey.source_columns.replace('{', '').replace('}', '').split(','),
+        target_columns: foreignKey.target_columns.replace('{', '').replace('}', '').split(','),
+      }
+    }
+  )
+
+  return { ...response, data: { ...response.data, result: formattedResults } }
+}
+
+export const useForeignKeyConstraintsPrefetch = ({
+  projectRef,
+  connectionString,
+  schema,
+}: ForeignKeyConstraintsVariables) => {
+  return useExecuteSqlPrefetch({
+    projectRef,
+    connectionString,
+    sql: getForeignKeyConstraintsQuery({ schema }),
+    queryKey: ['foreignKeyConstraints'],
+  })
+}

--- a/studio/stores/pgmeta/MetaStore.ts
+++ b/studio/stores/pgmeta/MetaStore.ts
@@ -498,6 +498,10 @@ export default class MetaStore implements IMetaStore {
         const relation: any = await this.addForeignKey(foreignKey)
         if (relation.error) throw relation.error
       }
+      this.rootStore.ui.setNotification({
+        category: 'success',
+        message: `Successfully updated column "${column.name}"`,
+      })
     } catch (error: any) {
       return { error }
     }
@@ -631,6 +635,7 @@ export default class MetaStore implements IMetaStore {
       // Then add the foreign key constraints here
       for (const column of columns) {
         if (!isUndefined(column.foreignKey)) {
+          console.log('Add foreign key', column)
           const relationship = await this.addForeignKey(column.foreignKey)
           if (relationship.error) throw relationship.error
         }

--- a/studio/stores/pgmeta/MetaStore.ts
+++ b/studio/stores/pgmeta/MetaStore.ts
@@ -635,7 +635,6 @@ export default class MetaStore implements IMetaStore {
       // Then add the foreign key constraints here
       for (const column of columns) {
         if (!isUndefined(column.foreignKey)) {
-          console.log('Add foreign key', column)
           const relationship = await this.addForeignKey(column.foreignKey)
           if (relationship.error) throw relationship.error
         }


### PR DESCRIPTION
- Support deletion action for foreign keys in table editor
  - You can now set a deletion action when setting a foreign key
  <img src="https://user-images.githubusercontent.com/19742402/223298894-3d266317-b56d-4857-bb6b-c1d3b04a06b8.png" width="400" />
  <img src="https://user-images.githubusercontent.com/19742402/223298995-74463dae-2193-44a2-ac8e-c2a439c66c2f.png" width="400" />

- Misc UI improvements:
  - Tooltip added in table side panel editor
![image](https://user-images.githubusercontent.com/19742402/223299236-c4676f1d-75e1-4831-9923-722475a09b2a.png)
![image](https://user-images.githubusercontent.com/19742402/223299263-fcebf110-afae-4eaa-abc5-19a1e7b19df5.png)
  - Tooltip added in grid column for foreign keys
![image](https://user-images.githubusercontent.com/19742402/223299326-39932942-abe0-48ae-9de5-45744d4947c7.png)
  - Added a cancel button if trying to remove foreign key
![image](https://user-images.githubusercontent.com/19742402/223299755-456c0588-aee8-4ca6-8baf-a00400b9543a.png)



