### PR TITLE
Fix overflow issue if message is too long with progress

### DIFF
--- a/studio/components/ui/SparkBar.tsx
+++ b/studio/components/ui/SparkBar.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx'
 import { FC } from 'react'
 
 interface Props {
@@ -30,10 +31,15 @@ const SparkBar: FC<Props> = ({
       <div className="flex flex-col w-full">
         {hasLabels && (
           <div className="flex align-baseline justify-between pb-1 space-x-8">
-            <span className="text-scale-1200 text-sm truncate capitalize-sentence">
+            <p
+              className={clsx(
+                'text-scale-1200 text-sm truncate capitalize-sentence',
+                labelTop.length > 0 && 'max-w-[75%]'
+              )}
+            >
               {labelBottom}
-            </span>
-            <span className="text-scale-1100 text-sm tabular-nums">{labelTop}</span>
+            </p>
+            <p className="text-scale-1100 text-sm tabular-nums">{labelTop}</p>
           </div>
         )}
         <div


### PR DESCRIPTION
Before:
<img src="https://user-images.githubusercontent.com/19742402/223374423-79280bcd-fad5-47bd-bd1c-703be53f6c8b.png" width="400" />

After:
![image](https://user-images.githubusercontent.com/19742402/223374391-220afa12-a15d-44e3-9503-013ec0ab97fa.png)
