### PR TITLE
feat: invoice status and ability to pay

### DIFF
--- a/studio/components/interfaces/Billing/InvoiceStatusBadge.tsx
+++ b/studio/components/interfaces/Billing/InvoiceStatusBadge.tsx
@@ -1,0 +1,90 @@
+import { FC } from 'react'
+import * as Tooltip from '@radix-ui/react-tooltip'
+import { Badge } from 'ui'
+import { InvoiceStatus } from './Invoices.types'
+
+interface Props {
+  status: InvoiceStatus
+}
+
+export const invoiceStatusMapping: Record<InvoiceStatus, { label: string; badgeColor: string }> = {
+  [InvoiceStatus.DRAFT]: {
+    label: 'Upcoming',
+    badgeColor: 'yellow',
+  },
+  [InvoiceStatus.PAID]: {
+    label: 'Paid',
+    badgeColor: 'green',
+  },
+  [InvoiceStatus.VOID]: {
+    label: 'Forgiven',
+    badgeColor: 'green',
+  },
+
+  // We do not want to overcomplicate it for the user, so we'll treat uncollectible/open the same from a user perspective
+  // it's an outstanding invoice
+  [InvoiceStatus.UNCOLLECTIBLE]: {
+    label: 'Outstanding',
+    badgeColor: 'red',
+  },
+  [InvoiceStatus.OPEN]: {
+    label: 'Outstanding',
+    badgeColor: 'red',
+  },
+}
+
+const InvoiceStatusBadge: FC<Props> = ({ status }) => {
+  const statusMapping = invoiceStatusMapping[status]
+
+  return (
+    <Tooltip.Root delayDuration={0}>
+      <Tooltip.Trigger>
+        <Badge
+          size="small"
+          className="capitalize"
+          // @ts-ignore
+          color={statusMapping?.badgeColor || 'gray'}
+        >
+          {statusMapping?.label || status}
+        </Badge>
+      </Tooltip.Trigger>
+      <Tooltip.Content side="bottom">
+        <Tooltip.Arrow className="radix-tooltip-arrow" />
+        <div
+          className={[
+            'rounded bg-scale-100 py-1 px-2 leading-none shadow',
+            'w-[300px] space-y-2 border border-scale-200',
+          ].join(' ')}
+        >
+          {[InvoiceStatus.OPEN, InvoiceStatus.UNCOLLECTIBLE].includes(status) && (
+            <p className="text-xs text-scale-1200">
+              We were not able to collect the money. Make sure you have a valid payment method and
+              enough funds. Outstanding invoices may cause restrictions. You can manually pay the
+              using the "Pay Now" button.
+            </p>
+          )}
+
+          {status === InvoiceStatus.DRAFT && (
+            <p className="text-xs text-scale-1200">
+              The invoice will soon be finalized and charged for.
+            </p>
+          )}
+
+          {status === InvoiceStatus.PAID && (
+            <p className="text-xs text-scale-1200">
+              The invoice has been paid successfully. No action is required on your side.
+            </p>
+          )}
+
+          {status === InvoiceStatus.VOID && (
+            <p className="text-xs text-scale-1200">
+              This invoice has been forgiven. No action is required on your side.
+            </p>
+          )}
+        </div>
+      </Tooltip.Content>
+    </Tooltip.Root>
+  )
+}
+
+export default InvoiceStatusBadge

--- a/studio/components/interfaces/Billing/Invoices.tsx
+++ b/studio/components/interfaces/Billing/Invoices.tsx
@@ -1,10 +1,14 @@
 import { FC, useState, useEffect } from 'react'
 import { Button, Loading, IconFileText, IconDownload, IconChevronLeft, IconChevronRight } from 'ui'
+import Link from 'next/link'
 
 import { useStore } from 'hooks'
 import { API_URL } from 'lib/constants'
 import { get, head } from 'lib/common/fetch'
 import Table from 'components/to-be-cleaned/Table'
+
+import InvoiceStatusBadge from './InvoiceStatusBadge'
+import { Invoice, InvoiceStatus } from './Invoices.types'
 
 const PAGE_LIMIT = 10
 
@@ -18,7 +22,7 @@ const Invoices: FC<Props> = ({ projectRef }) => {
 
   const [page, setPage] = useState(1)
   const [count, setCount] = useState(0)
-  const [invoices, setInvoices] = useState<any>([])
+  const [invoices, setInvoices] = useState<Invoice[]>([])
 
   const offset = (page - 1) * PAGE_LIMIT
 
@@ -85,6 +89,9 @@ const Invoices: FC<Props> = ({ projectRef }) => {
             <Table.th key="header-date">Date</Table.th>,
             <Table.th key="header-amount">Amount due</Table.th>,
             <Table.th key="header-invoice">Invoice number</Table.th>,
+            <Table.th key="header-invoice" className="flex items-center">
+              Status
+            </Table.th>,
             <Table.th key="header-download" className="text-right"></Table.th>,
           ]}
           body={
@@ -98,7 +105,7 @@ const Invoices: FC<Props> = ({ projectRef }) => {
               </Table.tr>
             ) : (
               <>
-                {invoices.map((x: any) => {
+                {invoices.map((x) => {
                   return (
                     <Table.tr key={x.id}>
                       <Table.td>
@@ -117,11 +124,22 @@ const Invoices: FC<Props> = ({ projectRef }) => {
                       <Table.td>
                         <p>{x.number}</p>
                       </Table.td>
+                      <Table.td>
+                        <InvoiceStatusBadge status={x.status} />
+                      </Table.td>
                       <Table.td className="align-right">
                         <div className="flex items-center justify-end space-x-2">
+                          {[InvoiceStatus.UNCOLLECTIBLE, InvoiceStatus.OPEN].includes(x.status) && (
+                            <Link href={`https://redirect.revops.supabase.com/pay-invoice/${x.id}`}>
+                              <a target="_blank">
+                                <Button>Pay Now</Button>
+                              </a>
+                            </Link>
+                          )}
+
                           <Button
                             type="outline"
-                            icon={<IconDownload />}
+                            icon={<IconDownload size={16} strokeWidth={1.5} />}
                             onClick={() => fetchInvoice(x.id)}
                           />
                         </div>
@@ -130,7 +148,7 @@ const Invoices: FC<Props> = ({ projectRef }) => {
                   )
                 })}
                 <Table.tr key="navigation">
-                  <Table.td colSpan={5}>
+                  <Table.td colSpan={6}>
                     <div className="flex items-center justify-between">
                       <p className="text-sm opacity-50">
                         Showing {offset + 1} to {offset + invoices.length} out of {count} invoices

--- a/studio/components/interfaces/Billing/Invoices.types.ts
+++ b/studio/components/interfaces/Billing/Invoices.types.ts
@@ -1,0 +1,15 @@
+export enum InvoiceStatus {
+  DRAFT = 'draft',
+  PAID = 'paid',
+  VOID = 'void',
+  UNCOLLECTIBLE = 'uncollectible',
+  OPEN = 'open',
+}
+
+export type Invoice = {
+  id: string
+  number: string
+  period_end: number
+  subtotal: number
+  status: InvoiceStatus
+}

--- a/studio/components/interfaces/Organization/InvoicesSettings/InvoicesSettings.tsx
+++ b/studio/components/interfaces/Organization/InvoicesSettings/InvoicesSettings.tsx
@@ -1,12 +1,15 @@
 import { useState, useEffect } from 'react'
 import { Button, Loading, IconFileText, IconDownload, IconChevronLeft, IconChevronRight } from 'ui'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
+import Link from 'next/link'
 
 import { checkPermissions, useStore } from 'hooks'
 import { API_URL } from 'lib/constants'
 import { get, head } from 'lib/common/fetch'
 import Table from 'components/to-be-cleaned/Table'
 import NoPermission from 'components/ui/NoPermission'
+import InvoiceStatusBadge from 'components/interfaces/Billing/InvoiceStatusBadge'
+import { Invoice, InvoiceStatus } from 'components/interfaces/Billing/Invoices.types'
 
 const PAGE_LIMIT = 10
 
@@ -18,7 +21,7 @@ const InvoicesSettings = () => {
 
   const [page, setPage] = useState(1)
   const [count, setCount] = useState(0)
-  const [invoices, setInvoices] = useState<any>([])
+  const [invoices, setInvoices] = useState<Invoice[]>([])
 
   const { stripe_customer_id } = ui.selectedOrganization ?? {}
   const offset = (page - 1) * PAGE_LIMIT
@@ -96,6 +99,9 @@ const InvoicesSettings = () => {
             <Table.th key="header-date">Date</Table.th>,
             <Table.th key="header-amount">Amount due</Table.th>,
             <Table.th key="header-invoice">Invoice number</Table.th>,
+            <Table.th key="header-invoice" className="flex items-center">
+              Status
+            </Table.th>,
             <Table.th key="header-download" className="text-right"></Table.th>,
           ]}
           body={
@@ -109,7 +115,7 @@ const InvoicesSettings = () => {
               </Table.tr>
             ) : (
               <>
-                {invoices.map((x: any) => {
+                {invoices.map((x) => {
                   return (
                     <Table.tr key={x.id}>
                       <Table.td>
@@ -124,11 +130,22 @@ const InvoicesSettings = () => {
                       <Table.td>
                         <p>{x.number}</p>
                       </Table.td>
+                      <Table.td>
+                        <InvoiceStatusBadge status={x.status} />
+                      </Table.td>
                       <Table.td className="align-right">
                         <div className="flex items-center justify-end space-x-2">
+                          {[InvoiceStatus.UNCOLLECTIBLE, InvoiceStatus.OPEN].includes(x.status) && (
+                            <Link href={`https://redirect.revops.supabase.com/pay-invoice/${x.id}`}>
+                              <a target="_blank">
+                                <Button>Pay Now</Button>
+                              </a>
+                            </Link>
+                          )}
+
                           <Button
                             type="outline"
-                            icon={<IconDownload />}
+                            icon={<IconDownload size={16} strokeWidth={1.5} />}
                             onClick={() => fetchInvoice(x.id)}
                           />
                         </div>
@@ -137,7 +154,7 @@ const InvoicesSettings = () => {
                   )
                 })}
                 <Table.tr key="navigation">
-                  <Table.td colSpan={5}>
+                  <Table.td colSpan={6}>
                     <div className="flex items-center justify-between">
                       <p className="text-sm opacity-50">
                         Showing {offset + 1} to {offset + invoices.length} out of {count} invoices


### PR DESCRIPTION
Adds the invoice status to the invoice tables and an option to pay the outstanding invoices (using the revops invoice payment link).

Keeping this draft as the API needs another prod deployment before this can be merged.

Seemed like they could be a single invoice table component, but I didn't want to refactor all of that in this PR.

<img width="924" alt="Screenshot 2023-03-09 at 06 57 24" src="https://user-images.githubusercontent.com/14073399/223933401-69f16cb1-4a7f-4a2c-80c7-ef456eeb0cf0.png">

<img width="380" alt="Screenshot 2023-03-07 at 10 03 52" src="https://user-images.githubusercontent.com/14073399/223376672-e512e9d4-04b0-4fb2-8620-84e2fb40ffde.png">

