### PR TITLE
fix: typo in `realtime` page

### DIFF
--- a/apps/www/data/products/realtime/app-examples.js
+++ b/apps/www/data/products/realtime/app-examples.js
@@ -52,7 +52,7 @@ export default [
     img: 'multiplayer-game.svg',
     title: 'Multiplayer games',
     description:
-      "Keep track of how long a player has been playing, who's turn it is and even share to other clients what the pllayer is doing.",
+      "Keep track of how long a player has been playing, who's turn it is and even share to other clients what the player is doing.",
   },
   {
     img: 'form-presence.svg',


### PR DESCRIPTION
Fix Typo. Change `pllayer` to `player` in the Multiplayer games example

## What kind of change does this PR introduce?

Fix Typo

## What is the current behavior?

Multiplayer games example on Supabase Realtime page mentions `pllayer`

## What is the new behavior?

Multiplayer games example on Supabase Realtime page now uses the correct spelling `player`

## Additional context

<img width="392" alt="image" src="https://user-images.githubusercontent.com/53081208/224116098-049a814b-8ff0-4cba-ac50-3aaf715986a5.png">

