### PR TITLE
Updated NextJS "Client-side data fetching with RLS" Documentation

### DIFF
--- a/apps/docs/pages/guides/auth/auth-helpers/nextjs.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/nextjs.mdx
@@ -185,7 +185,8 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
 For [row level security](/docs/learn/auth-deep-dive/auth-row-level-security) to work properly when fetching data client-side, you need to make sure to use the `supabaseClient` from the `useSupabaseClient` hook and only run your query once the user is defined client-side in the `useUser()` hook:
 
 ```jsx lines=10-17
-import { Auth, ThemeSupa } from '@supabase/auth-ui-react'
+import { Auth } from '@supabase/auth-ui-react'
+import { ThemeSupa } from '@supabase/auth-ui-shared'
 import { useUser, useSupabaseClient } from '@supabase/auth-helpers-react'
 import { useEffect, useState } from 'react'
 


### PR DESCRIPTION


## What kind of change does this PR introduce?

Documentation Update, updated the [Client-side data fetching with RLS Documentation](https://supabase.com/docs/guides/auth/auth-helpers/nextjs#client-side-data-fetching-with-rls) since `ThemeSupa` is not imported from `auth-ui-react` anymore but imported in `auth-ui-shared`

## What is the current behavior?

Currently ThemeSupa is imported from `auth-ui-react`
```
import { Auth, ThemeSupa } from '@supabase/auth-ui-react'
```
This will cause this error `Module '"@supabase/auth-ui-react"' has no exported member 'ThemeSupa'` to be shown.

I opened up a issue here
[Issue #12923 ](https://github.com/supabase/supabase/issues/12923)

## What is the new behavior?

After this [Commit](https://github.com/supabase/auth-ui/commit/1349aa6da943a259483bb4bba1f8482402089c06#diff-57ee89fa013f81ed2a2557c238340d66f870476fb722742aa7182903fc2aed30) I found that it was now imported from `auth-ui-shared`

