### PR TITLE
fix: minor ux changes 

### DIFF
--- a/studio/components/interfaces/Auth/Auth.constants.ts
+++ b/studio/components/interfaces/Auth/Auth.constants.ts
@@ -12,7 +12,7 @@ const baseDomainRegex =
 
 // iOS deep linking scheme https://benoitpasquier.com/deep-linking-url-scheme-ios/
 const appRegex =
-  /^[a-z0-9]+([.][a-z0-9]+)*:\/(\/[-a-z0-9._~!$&'()*+,;=:@%]+)+(?:\.[a-z]+)*(?::\d+)?(?![^<]*(?:<\/\w+>|\/?>))(.*)?\/?(.)*?$/i
+  /^[a-z0-9-]+([.][a-z0-9]+)*:\/(\/[-a-z0-9._~!$&'()*+,;=:@%]+)+(?:\.[a-z]+)*(?::\d+)?(?![^<]*(?:<\/\w+>|\/?>))(.*)?\/?(.)*?$/i
 
 // Regex from https://stackoverflow.com/a/18696953/4807782
 const localhostRegex = /^(?:^|\s)((https?:\/\/)?(?:localhost|[\w-]+(?:\.[\w-]+)+)(:\d+)?(\/\S*)?)/i

--- a/studio/components/interfaces/SignIn/ForgotPasswordForm.tsx
+++ b/studio/components/interfaces/SignIn/ForgotPasswordForm.tsx
@@ -45,7 +45,7 @@ const ForgotPasswordForm = () => {
       ui.setNotification({
         id: toastId,
         category: 'success',
-        message: `Password reset email sent successfully! Please check your email`,
+        message: `If you registered using your email and password, you should receive a password reset email.`,
       })
 
       await router.push('/sign-in')

--- a/studio/components/interfaces/SignIn/ForgotPasswordForm.tsx
+++ b/studio/components/interfaces/SignIn/ForgotPasswordForm.tsx
@@ -45,7 +45,7 @@ const ForgotPasswordForm = () => {
       ui.setNotification({
         id: toastId,
         category: 'success',
-        message: `If you registered using your email and password, you should receive a password reset email.`,
+        message: `If you registered using your email and password, you will receive a password reset email.`,
       })
 
       await router.push('/sign-in')


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Improve success message returned for password reset
* Allow mobile deeplinks to be included in the redirect allow list. Previously, if there was a "-" in the scheme (e.g. `foo-bar://auth/reset-password`), the regex pattern would reject it.