### PR TITLE
fix: deploy the og images only when changed and pushed to master

### DIFF
--- a/.github/workflows/og_images.yml
+++ b/.github/workflows/og_images.yml
@@ -6,7 +6,6 @@ on:
       - master
     paths:
       - 'supabase/functions/og-images/**'
-  workflow_dispatch:
 
 jobs:
   deploy:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ---
 
-# Supabase
+# Supabase test
 
 [Supabase](https://supabase.com) is an open source Firebase alternative. We're building the features of Firebase using enterprise-grade open source tools.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ---
 
-# Supabase test
+# Supabase
 
 [Supabase](https://supabase.com) is an open source Firebase alternative. We're building the features of Firebase using enterprise-grade open source tools.
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix https://github.com/supabase/supabase/issues/12870

## What is the new behavior?
With this change, the function will only be deployed when you edit og-images files and push them to the master branch.
