### PR TITLE
docs: fix ts middleware path

### DIFF
--- a/apps/docs/pages/guides/auth/auth-helpers/nextjs-server-components.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/nextjs-server-components.mdx
@@ -158,7 +158,7 @@ import { createMiddlewareSupabaseClient } from '@supabase/auth-helpers-nextjs'
 import { NextResponse } from 'next/server'
 
 import type { NextRequest } from 'next/server'
-import type { Database } from '../lib/database.types'
+import type { Database } from './lib/database.types'
 
 export async function middleware(req: NextRequest) {
   const res = NextResponse.next()


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs typo.

Middlewares are now at the root path in Next 13.
