### PR TITLE
Add type-safe hooks for Remix Auth utils

### DIFF
--- a/apps/docs/pages/guides/auth/auth-helpers/remix.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/remix.mdx
@@ -319,6 +319,23 @@ And then we can share this instance across our application with Outlet Context.
 <Outlet context={{ supabase }} />
 ```
 
+Optionally, you can create custom hooks for accessing the context in a type-safe way.
+
+```tsx
+import { useOutletContext } from "@remix-run/react";
+import type { Session, SupabaseClient } from "@supabase/supabase-js";
+
+export function useSupabase() {
+  const { supabase } = useOutletContext<{ supabase: SupabaseClient<Database> }>();
+  return supabase;
+}
+
+export function useSession() {
+  const { session } = useOutletContext<{ session: Session }>();
+  return session;
+}
+```
+
 </TabPanel>
 </Tabs>
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

I come from using `@supabase/auth-helpers-nextjs` and missed some hooks that are this library has and the Remix.run one does not. I added a small code snippet in de documentation to implement those hooks. I wonder if instead this should implemented in the package itself. If you want I can submit a PR with those hooks in the `@supabase/auth-helpers-remix`