### PR TITLE
Change button to link tag

### DIFF
--- a/apps/docs/components/Navigation/NavigationMenu/TopNavBarRef.tsx
+++ b/apps/docs/components/Navigation/NavigationMenu/TopNavBarRef.tsx
@@ -141,7 +141,7 @@ const TopNavBarRef: FC = () => {
               target="_blank"
               rel="noreferrer noopener"
             >
-              <a class="px-2.5 py-1" target="_blank">
+              <a className="px-2.5 py-1" target="_blank">
                 <IconGitHub size={16} />
               </a>
             </Link>

--- a/apps/docs/components/Navigation/NavigationMenu/TopNavBarRef.tsx
+++ b/apps/docs/components/Navigation/NavigationMenu/TopNavBarRef.tsx
@@ -136,16 +136,15 @@ const TopNavBarRef: FC = () => {
             Dashboard
           </Button>
           <ul className="flex items-center">
-            <Button
-              type="text"
-              as="a"
-              // @ts-ignore
+            <Link
               href="https://github.com/supabase/supabase"
               target="_blank"
               rel="noreferrer noopener"
             >
-              <IconGitHub size={16} />
-            </Button>
+              <a class="px-2.5 py-1" target="_blank">
+                <IconGitHub size={16} />
+              </a>
+            </Link>
           </ul>
           <ul className="flex items-center">
             <li className="px-4">


### PR DESCRIPTION
## What kind of change does this PR introduce?

Change button to link tag because when hovering over button it behaves like a text button instead of a icon link.

## What is the current behavior?

<img width="417" alt="CleanShot 2023-03-13 at 17 57 07@2x" src="https://user-images.githubusercontent.com/70828596/224841259-4ce76fba-8dfa-468f-987e-60af66a6ddf4.png">

## What is the new behavior?

<img width="417" alt="CleanShot 2023-03-13 at 17 57 07@2x" src="https://user-images.githubusercontent.com/70828596/224841277-ee15b775-5af4-4107-952f-747c9ecdfdfd.png">