### PR TITLE
Fix next month billing amount in subscription payment panel

### DIFF
--- a/studio/components/interfaces/Billing/PaymentSummaryPanel/PaymentSummaryPanel.tsx
+++ b/studio/components/interfaces/Billing/PaymentSummaryPanel/PaymentSummaryPanel.tsx
@@ -88,7 +88,11 @@ const PaymentSummaryPanel: FC<Props> = ({
 
   const [showConfirmModal, setShowConfirmModal] = useState(false)
 
-  const totalMonthlyCost = Object.keys(selectedAddons)
+  const selectedPlanCost =
+    selectedPlan.prices.find(
+      (price: AddonPrice) => price.id === selectedPlan.metadata.default_price_id
+    )?.unit_amount ?? 0
+  const totalSelectedAddonCost = Object.keys(selectedAddons)
     .map((productName) => {
       const product = (selectedAddons as any)[productName]
       const price = product.prices.find(
@@ -97,6 +101,7 @@ const PaymentSummaryPanel: FC<Props> = ({
       return price
     })
     .reduce((a, b) => a + b.unit_amount, 0)
+  const totalMonthlyCost = selectedPlanCost + totalSelectedAddonCost
 
   const currentPITRDays =
     currentAddons.pitrDuration !== undefined ? getPITRDays(currentAddons.pitrDuration) : 0

--- a/studio/components/interfaces/Billing/PaymentSummaryPanel/PaymentSummaryPanel.tsx
+++ b/studio/components/interfaces/Billing/PaymentSummaryPanel/PaymentSummaryPanel.tsx
@@ -103,6 +103,8 @@ const PaymentSummaryPanel: FC<Props> = ({
     .reduce((a, b) => a + b.unit_amount, 0)
   const totalMonthlyCost = selectedPlanCost + totalSelectedAddonCost
 
+  console.log({ selectedPlanCost, totalSelectedAddonCost })
+
   const currentPITRDays =
     currentAddons.pitrDuration !== undefined ? getPITRDays(currentAddons.pitrDuration) : 0
   const selectedPITRDays =

--- a/studio/components/interfaces/Billing/PaymentSummaryPanel/PaymentSummaryPanel.tsx
+++ b/studio/components/interfaces/Billing/PaymentSummaryPanel/PaymentSummaryPanel.tsx
@@ -103,8 +103,6 @@ const PaymentSummaryPanel: FC<Props> = ({
     .reduce((a, b) => a + b.unit_amount, 0)
   const totalMonthlyCost = selectedPlanCost + totalSelectedAddonCost
 
-  console.log({ selectedPlanCost, totalSelectedAddonCost })
-
   const currentPITRDays =
     currentAddons.pitrDuration !== undefined ? getPITRDays(currentAddons.pitrDuration) : 0
   const selectedPITRDays =

--- a/studio/components/interfaces/Billing/PaymentSummaryPanel/PaymentSummaryPanel.tsx
+++ b/studio/components/interfaces/Billing/PaymentSummaryPanel/PaymentSummaryPanel.tsx
@@ -1,4 +1,4 @@
-import { FC, useRef, useState } from 'react'
+import { FC, useState } from 'react'
 import * as Tooltip from '@radix-ui/react-tooltip'
 import { Listbox, IconLoader, Button, IconPlus, IconAlertCircle, IconCreditCard } from 'ui'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
@@ -9,7 +9,7 @@ import { SubscriptionPreview } from '../Billing.types'
 import { getProductPrice, validateSubscriptionUpdatePayload } from '../Billing.utils'
 import PaymentTotal from './PaymentTotal'
 import InformationBox from 'components/ui/InformationBox'
-import { SubscriptionAddon } from '../AddOns/AddOns.types'
+import { AddonPrice, SubscriptionAddon } from '../AddOns/AddOns.types'
 import { getPITRDays } from './PaymentSummaryPanel.utils'
 import ConfirmPaymentModal from './ConfirmPaymentModal'
 import { StripeSubscription } from '../Subscription/Subscription.types'
@@ -87,6 +87,16 @@ const PaymentSummaryPanel: FC<Props> = ({
   )
 
   const [showConfirmModal, setShowConfirmModal] = useState(false)
+
+  const totalMonthlyCost = Object.keys(selectedAddons)
+    .map((productName) => {
+      const product = (selectedAddons as any)[productName]
+      const price = product.prices.find(
+        (price: AddonPrice) => price.id === product.metadata.default_price_id
+      )
+      return price
+    })
+    .reduce((a, b) => a + b.unit_amount, 0)
 
   const currentPITRDays =
     currentAddons.pitrDuration !== undefined ? getPITRDays(currentAddons.pitrDuration) : 0
@@ -308,6 +318,7 @@ const PaymentSummaryPanel: FC<Props> = ({
         <div className="w-full h-px bg-scale-600" />
 
         <PaymentTotal
+          totalMonthlyCost={totalMonthlyCost / 100}
           subscriptionPreview={subscriptionPreview}
           isRefreshingPreview={isRefreshingPreview}
           isSpendCapEnabled={isSpendCapEnabled}

--- a/studio/components/interfaces/Billing/PaymentSummaryPanel/PaymentTotal.tsx
+++ b/studio/components/interfaces/Billing/PaymentSummaryPanel/PaymentTotal.tsx
@@ -5,18 +5,20 @@ import { SubscriptionPreview } from '../Billing.types'
 import CostBreakdownModal from './CostBreakdownModal'
 
 interface Props {
+  totalMonthlyCost: number
   subscriptionPreview?: SubscriptionPreview
   isRefreshingPreview: boolean
   isSpendCapEnabled: boolean
 }
 
 const PaymentTotal: FC<Props> = ({
+  totalMonthlyCost,
   subscriptionPreview,
   isRefreshingPreview,
   isSpendCapEnabled,
 }) => {
   const hasChanges = subscriptionPreview?.has_changes ?? false
-  const totalMonthlyCost = (subscriptionPreview?.base_amount_due_next_billing_cycle ?? 0) / 100
+  // const totalMonthlyCost = (subscriptionPreview?.base_amount_due_next_billing_cycle ?? 0) / 100
   const amountDueImmediately = (subscriptionPreview?.amount_due_immediately ?? 0) / 100
   const billingDate = new Date((subscriptionPreview?.bill_on ?? 0) * 1000)
   const isBillingToday =


### PR DESCRIPTION
FE to calculate the subsequent month's billing charge by summation of selected tier and addons, instead of API