### PR TITLE
Update discord-bot.mdx

### DIFF
--- a/apps/docs/pages/guides/functions/examples/discord-bot.mdx
+++ b/apps/docs/pages/guides/functions/examples/discord-bot.mdx
@@ -50,7 +50,7 @@ This will register a Slash Command named `hello` that accepts a parameter named 
 import { json, serve, validateRequest } from 'sift'
 // TweetNaCl is a cryptography library that we use to verify requests
 // from Discord.
-import nacl from 'nacl'
+import nacl from 'tweetnacl'
 
 enum DiscordCommandType {
   Ping = 1,


### PR DESCRIPTION
I tried using `nacl` and it just doesn't work. The comment above the import mentions TweetNaCl and when I switched to that, it worked.

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

I was following the Discord bot guide (https://supabase.com/docs/guides/functions/examples/discord-bot) and the import doesn't work. There is a package called `nacl` but it is very old.

## What is the new behavior?

Import the intended package `tweetnacl` which actually works.

## Additional context

I am using Deno for the first time and I strugged to import tweetnacl until I made my import map point to esm.sh - maybe the docs page should mention this? My support thread: https://discord.com/channels/839993398554656828/1085872843218235513