### PR TITLE
Implemented blob URL cache to prevent redownload

### DIFF
--- a/examples/user-management/nextjs-ts-user-management/components/Avatar.tsx
+++ b/examples/user-management/nextjs-ts-user-management/components/Avatar.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { useSupabaseClient } from '@supabase/auth-helpers-react'
 import { Database } from '../utils/database.types'
 type Profiles = Database['public']['Tables']['profiles']['Row']


### PR DESCRIPTION
## What kind of change does this PR introduce?

This code introduces BUG fix &  Caching logic for Next JS User Management Demo

## What is the current behavior?

Current behavior is that once the user logged in and uploads their image, the web page constantly tries to fetch the blob image from the server and it results in the high CPU usage as well as low performance ~500ms overhead. 

It also trashes the memory and GC has to clean up unused assets.

## What is the new behavior?

The new behavior introduces the caching of the blob image, unless the client hits refresh button.

## Additional context

Here are the screenshots of how Sources and Network pages are trashed 

![Screenshot_1](https://user-images.githubusercontent.com/105135724/225779523-509f1fd8-679b-4475-aed7-e231f52a5b08.png)
![Screenshot_2](https://user-images.githubusercontent.com/105135724/225779525-1642616c-6efe-446f-ace2-5592f6f47a1f.png)

And this is after, notice how blob only requested once.

![image](https://user-images.githubusercontent.com/105135724/225779681-ce3d83e5-8a0f-4fdd-ab9a-30bb5511514f.png)

