### PR TITLE
Update "Connect to Postgres" example with correct env variable for Postgres DB

### DIFF
--- a/apps/docs/pages/guides/functions/examples/connect-to-postgres.mdx
+++ b/apps/docs/pages/guides/functions/examples/connect-to-postgres.mdx
@@ -22,8 +22,8 @@ Supabase Edge Functions allow you to go beyond HTTP and can connect to your Post
 import * as postgres from 'https://deno.land/x/postgres@v0.14.2/mod.ts'
 import { serve } from 'https://deno.land/std@0.177.0/http/server.ts'
 
-// Get the connection string from the environment variable "DATABASE_URL"
-const databaseUrl = Deno.env.get('DATABASE_URL')!
+// Get the connection string from the environment variable "SUPABASE_DB_URL"
+const databaseUrl = Deno.env.get('SUPABASE_DB_URL')!
 
 // Create a database pool with three connections that are lazily established
 const pool = new postgres.Pool(databaseUrl, 3, true)


### PR DESCRIPTION
See https://supabase.com/docs/guides/functions/secrets

## What kind of change does this PR introduce?

Docs update.

## What is the current behavior?

Wrong environment variable can confuse anyone copying the code. (As I was)

## What is the new behavior?

Use the correct environement variable to avoid confusion.
