### PR TITLE
Wrong name for Prisma datasource property

### DIFF
--- a/apps/docs/pages/guides/integrations/prisma.mdx
+++ b/apps/docs/pages/guides/integrations/prisma.mdx
@@ -162,7 +162,7 @@ Update your Prisma schema by setting the `directUrl` in the datasource block:
 datasource db {
   provider          = "postgresql"
   url               = env("DATABASE_URL")
-  directURL         = env("DIRECT_URL")
+  directUrl         = env("DIRECT_URL")
 }
 ```
 


### PR DESCRIPTION
This might be a duplicate PR of #12675 but somehow it's not updated in the live docs? The correct name in the Prisma schema API is `directUrl`, and not `directURL`.

<img width="687" alt="image" src="https://user-images.githubusercontent.com/25929147/226120671-547d81ef-24c7-44b2-89a4-55fef7c7f844.png">

See [here](https://supabase.com/docs/guides/integrations/prisma).