### PR TITLE
fix(docs): typo in architecture.mdx

### DIFF
--- a/apps/docs/pages/guides/getting-started/architecture.mdx
+++ b/apps/docs/pages/guides/getting-started/architecture.mdx
@@ -55,7 +55,7 @@ We use this with our [pg_graphql](https://github.com/supabase/pg_graphql) extens
 - Official Docs: [postgrest.org](https://postgrest.org/)
 - Source code: [github.com/PostgREST/postgrest](https://github.com/PostgREST/postgrest)
 - License: [MIT](https://github.com/PostgREST/postgrest/blob/main/LICENSE)
-- Language: Haskel
+- Language: Haskell
 
 ### Realtime (API & multiplayer)
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update, fixing a typo

## What is the current behavior?

[guides/getting-started/architecture](https://supabase.com/docs/guides/getting-started/architecture#postgrest-api) mentions `Haskel` as PostgREST API's language.

## What is the new behavior?

`Haskel` has been changed to `Haskell` ([haskell.org](https://www.haskell.org/))

## Additional context

![immagine](https://user-images.githubusercontent.com/121574880/226186326-c0028ef1-3688-4083-bcee-b1b574271db0.png) 