### PR TITLE
fix: update function limitations

### DIFF
--- a/apps/docs/pages/guides/functions/quickstart.mdx
+++ b/apps/docs/pages/guides/functions/quickstart.mdx
@@ -128,8 +128,8 @@ Edge Functions supports `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, and `OPTIONS`. 
 - Deno Deploy limitations
   - Deno does not support outgoing connections to ports `25`, `465`, and `587`.
   - Cannot read or write to File System
+  - NPM modules are not supported.
 - Edge Functions
-  - Local development - only one function at a time
   - Serving of HTML content is not supported (`GET` requests that return `text/html` will be rewritten to `text/plain`).
 
 export const Page = ({ children }) => <Layout meta={meta} children={children} />


### PR DESCRIPTION
## What kind of change does this PR introduce?

Updates the limitations listed under Quickstart for Edge Functions guide.
