### PR TITLE
docs: add note about using a service key with rls

### DIFF
--- a/apps/docs/pages/guides/auth/row-level-security.mdx
+++ b/apps/docs/pages/guides/auth/row-level-security.mdx
@@ -328,6 +328,9 @@ Tip: Make sure to enable RLS for all your tables, so that your tables are inacce
 
 Supabase provides special "Service" keys, which can be used to bypass all RLS.
 These should never be used in the browser or exposed to customers, but they are useful for administrative tasks.
+<Admonition type="caution">
+Initializing a client with a Service Key will not override RLS if a user token is set. If a user is signed in with a client, Supabase will adhere to the RLS policy of the user.
+</Admonition>
 
 ### Testing policies
 


### PR DESCRIPTION
We wish to make clear the difference between the service role and user token (e.g. a user cannot use the service role in place of a user token). When a user token is used with the service role, the service role takes precedence -  https://github.com/supabase/gotrue/issues/965

<img width="714" alt="CleanShot 2023-03-20 at 16 12 13@2x" src="https://user-images.githubusercontent.com/8011761/226282227-17c150d5-6f14-49cb-a59b-20eec74761b4.png">
