### PR TITLE
docs: update section on user metadata to reflect that createUser will create certain fields by doing an Update instead of insert

### DIFF
--- a/apps/docs/pages/guides/auth/managing-user-data.mdx
+++ b/apps/docs/pages/guides/auth/managing-user-data.mdx
@@ -147,6 +147,14 @@ create trigger on_auth_user_created
   after insert on auth.users
   for each row execute procedure public.handle_new_user();
 ```
+**Note**: The admin `createUser` SDK method modifies the following fields via an update rather than an insert statement.
+1. `raw_app_meta_data`
+2. `confirmation_token`
+3. `email_confirmed_at`
+4. `phone_confirmed_at`
+5. `banned_until`
+
+Please initialize a trigger which runs after update if you wish to capture any of these fields.
 
 export const Page = ({ children }) => <Layout meta={meta} children={children} />
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Triggers on insert might not capture `raw_app_meta_data` and other related fields. This is because when a user calls `createUser` an insert call is made to create a user and an identity under the hood. Thereafter, a follow up call is then made to update user metadata - https://github.com/supabase/gotrue/issues/975

Relevant [section of code in GoTrue](https://github.com/supabase/gotrue/blob/master/internal/api/admin.go#L408)

This PR highlights fields that a trigger which runs after insert might not be able to capture

<img width="705" alt="CleanShot 2023-03-20 at 16 46 26@2x" src="https://user-images.githubusercontent.com/8011761/226289300-39089b8e-1e8a-44a4-a582-b03ae282feb8.png">


## Additional context

FLUP to #12933 
