### PR TITLE
docs(guides/database/full-text-search) update searching multiple columns

### DIFF
--- a/apps/docs/pages/guides/database/full-text-search.mdx
+++ b/apps/docs/pages/guides/database/full-text-search.mdx
@@ -227,8 +227,7 @@ final result = await client
 
 ### Search multiple columns
 
-Right now there is no direct way to use JavaScript or Dart to search through multiple columns. A workaround exist where using SQL is required.
-The method involves creating [computed virtual columns](https://postgrest.org/en/stable/api.html#computed-virtual-columns).
+Right now there is no direct way to use JavaScript or Dart to search through multiple columns but you can do it by creating [computed columns](https://postgrest.org/en/stable/api.html#computed-virtual-columns) on the database.
 
 To find all `books` where `description` or `title` contain the word `little`:
 
@@ -256,7 +255,7 @@ where
 ```sql
 create function title_description(books) returns text as $$
   select $1.title || ' ' || $1.description;
-$$ language sql;
+$$ language sql immutable;
 ```
 
 ```js
@@ -272,7 +271,7 @@ const { data, error } = await supabase
 ```sql
 create function title_description(books) returns text as $$
   select $1.title || ' ' || $1.description;
-$$ language sql;
+$$ language sql immutable;
 ```
 
 ```dart

--- a/apps/docs/pages/guides/database/full-text-search.mdx
+++ b/apps/docs/pages/guides/database/full-text-search.mdx
@@ -227,7 +227,7 @@ final result = await client
 
 ### Search multiple columns
 
-Right now there is no direct way to use Javascript or Dart to search through multiple columns. A workaround exist where using SQL is required.
+Right now there is no direct way to use JavaScript or Dart to search through multiple columns. A workaround exist where using SQL is required.
 The method involves creating [computed virtual columns](https://postgrest.org/en/stable/api.html#computed-virtual-columns).
 
 To find all `books` where `description` or `title` contain the word `little`:
@@ -254,9 +254,9 @@ where
 <TabPanel id="js" label="JavaScript">
 
 ```sql
-CREATE FUNCTION title_description(books) RETURNS text AS $$
-  SELECT $1.title || ' ' || $1.description;
-$$ LANGUAGE SQL;
+create function title_description(books) returns text as $$
+  select $1.title || ' ' || $1.description;
+$$ language sql;
 ```
 
 ```js
@@ -270,9 +270,9 @@ const { data, error } = await supabase
 <TabPanel id="dart" label="Dart">
 
 ```sql
-CREATE FUNCTION title_description(books) RETURNS text AS $$
-  SELECT $1.title || ' ' || $1.description;
-$$ LANGUAGE SQL;
+create function title_description(books) returns text as $$
+  select $1.title || ' ' || $1.description;
+$$ language sql;
 ```
 
 ```dart

--- a/apps/docs/pages/guides/database/full-text-search.mdx
+++ b/apps/docs/pages/guides/database/full-text-search.mdx
@@ -227,6 +227,9 @@ final result = await client
 
 ### Search multiple columns
 
+Right now there is no direct way to use Javascript or Dart to search through multiple columns. A workaround exist where using SQL is required.
+The method involves creating [computed virtual columns](https://postgrest.org/en/stable/api.html#computed-virtual-columns).
+
 To find all `books` where `description` or `title` contain the word `little`:
 
 <Tabs
@@ -245,6 +248,38 @@ from
 where
   to_tsvector(description || ' ' || title) -- concat columns, but be sure to include a space to separate them!
   @@ to_tsquery('little');
+```
+
+</TabPanel>
+<TabPanel id="js" label="JavaScript">
+
+```sql
+CREATE FUNCTION title_description(books) RETURNS text AS $$
+  SELECT $1.title || ' ' || $1.description;
+$$ LANGUAGE SQL;
+```
+
+```js
+const { data, error } = await supabase
+  .from('books')
+  .select()
+  .textSearch('title_description', `little`)
+```
+
+</TabPanel>
+<TabPanel id="dart" label="Dart">
+
+```sql
+CREATE FUNCTION title_description(books) RETURNS text AS $$
+  SELECT $1.title || ' ' || $1.description;
+$$ LANGUAGE SQL;
+```
+
+```dart
+final result = await client
+  .from('books')
+  .select()
+  .textSearch('title_description', "little")
 ```
 
 </TabPanel>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Update searching multiple columns guide (js and dart) with a workaround involving computed virtual columns

Solution by @steve-chahez from this https://github.com/supabase/postgrest-js/issues/289

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

https://github.com/supabase/supabase/pull/12508
https://github.com/supabase/postgrest-js/issues/289

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
