### PR TITLE
Docs: Adds redirect from root to /docs

### DIFF
--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -80,6 +80,16 @@ const nextConfig = {
       },
     ]
   },
+  async redirects() {
+    return [
+      {
+        source: '/',
+        destination: '/docs',
+        basePath: false,
+        permanent: false,
+      },
+    ]
+  },
 }
 
 // next.config.js


### PR DESCRIPTION
For local dev and preview builds, this will automatically redirect `/` to `/docs` on the docs site (no more 404's). Try it out:
https://docs-o4dwvxi5u-supabase.vercel.app/

This change is to the `./apps/docs` project, so Next.js rewrites in `./apps/www` should be unaffected:
https://zone-www-dot-com-git-chore-redirect-docs-root-supabase.vercel.app/