### PR TITLE
Chore/warn about empty array returns

### DIFF
--- a/studio/components/grid/components/header/Header.tsx
+++ b/studio/components/grid/components/header/Header.tsx
@@ -17,6 +17,7 @@ import { useTableRowDeleteAllMutation } from 'data/table-rows/table-row-delete-a
 import { useTableRowTruncateMutation } from 'data/table-rows/table-row-truncate-mutation'
 import { useTableRowsCountQuery } from 'data/table-rows/table-rows-count-query'
 import { useTableRowsQuery } from 'data/table-rows/table-rows-query'
+import RLSBannerWarning from './RLSBannerWarning'
 
 // [Joshen] CSV exports require this guard as a fail-safe if the table is
 // just too large for a browser to keep all the rows in memory before
@@ -37,13 +38,16 @@ const Header = ({ table, sorts, filters, onAddColumn, onAddRow, headerActions }:
   const { selectedRows } = state
 
   return (
-    <div className="flex h-10 items-center justify-between bg-scale-100 px-5 py-1.5 dark:bg-scale-300">
-      {selectedRows.size > 0 ? (
-        <RowHeader table={table} sorts={sorts} filters={filters} />
-      ) : (
-        <DefaultHeader table={table} onAddColumn={onAddColumn} onAddRow={onAddRow} />
-      )}
-      <div className="sb-grid-header__inner">{headerActions}</div>
+    <div>
+      <div className="flex h-10 items-center justify-between bg-scale-100 px-5 py-1.5 dark:bg-scale-300">
+        {selectedRows.size > 0 ? (
+          <RowHeader table={table} sorts={sorts} filters={filters} />
+        ) : (
+          <DefaultHeader table={table} onAddColumn={onAddColumn} onAddRow={onAddRow} />
+        )}
+        <div className="sb-grid-header__inner">{headerActions}</div>
+      </div>
+      <RLSBannerWarning />
     </div>
   )
 }

--- a/studio/components/grid/components/header/RLSBannerWarning.tsx
+++ b/studio/components/grid/components/header/RLSBannerWarning.tsx
@@ -1,0 +1,90 @@
+import React, { useState } from 'react'
+import { Button, IconAlertCircle, IconBookOpen, Modal } from 'ui'
+import Link from 'next/link'
+import { useParams, useStore } from 'hooks'
+import ConfirmationModal from 'components/ui/ConfirmationModal'
+import type { PostgresTable } from '@supabase/postgres-meta'
+
+const RLS_ACKNOWLEDGED_KEY = 'supabase-acknowledge-rls-warning'
+
+export default function RLSBannerWarning() {
+  const { meta } = useStore()
+  const { ref: projectRef, id: tableID } = useParams()
+
+  const isAcknowledged = localStorage.getItem(`${RLS_ACKNOWLEDGED_KEY}-${tableID}`) === 'true'
+
+  const [isOpen, setIsOpen] = useState(false)
+
+  const tables: PostgresTable[] = meta.tables.list()
+  const currentTable = tables.find((table) => table.id.toString() === tableID)
+  const rlsEnabled = currentTable?.rls_enabled
+  const isPublicTable = currentTable?.schema === 'public'
+
+  function handleDismissWarning() {
+    localStorage.setItem(`${RLS_ACKNOWLEDGED_KEY}-${tableID}`, 'true')
+    setIsOpen(false)
+  }
+
+  return (
+    <>
+      {!isAcknowledged && !rlsEnabled && isPublicTable ? (
+        <div>
+          <div className="text-center bg-red-900 text-white text-xs py-2 flex items-center justify-center">
+            <IconAlertCircle />
+            <span className="uppercase font-bold ml-2">Warning</span>: this table is publicly
+            readable and writable.{' '}
+            <Link href={`/project/${projectRef}/auth/policies#${tableID}`}>
+              <a className="underline ml-2">Enable Row Level Security</a>
+            </Link>
+            <div className="ml-20">
+              <Button
+                type="text"
+                className="text-white hover:text-scale-1200"
+                onClick={() => setIsOpen(true)}
+              >
+                Dismiss
+              </Button>
+            </div>
+          </div>
+
+          <ConfirmationModal
+            visible={isOpen}
+            danger={true}
+            header="Confirm"
+            buttonLabel="I understand, dismiss this warning"
+            onSelectCancel={() => setIsOpen(false)}
+            onSelectConfirm={handleDismissWarning}
+            children={
+              <Modal.Content>
+                <div className="grid gap-3 mt-4 mb-6">
+                  <h4 className="text-base">Warning: your data is public</h4>
+                  <p className="text-sm text-scale-1100">
+                    Data in this table is publicly <u>readable and writable</u> by anyone with the
+                    anon key. We strongly recommend creating RLS (Row-Level Security) policies to
+                    allow access to this table.
+                  </p>
+                  <div className="grid gap-3 pt-4">
+                    <p className="text-sm text-scale-1100">
+                      Read more about setting up RLS Policies:
+                    </p>
+                    <p>
+                      <Link href="https://supabase.com/docs/guides/auth/row-level-security">
+                        <a target="_blank">
+                          <Button type="default" icon={<IconBookOpen strokeWidth={1.5} />}>
+                            Documentation
+                          </Button>
+                        </a>
+                      </Link>
+                    </p>
+                  </div>
+                </div>
+              </Modal.Content>
+            }
+          />
+        </div>
+      ) : (
+        <></>
+      )}
+    </>
+  )
+}

--- a/studio/components/interfaces/Auth/Policies/PolicyTableRow/index.tsx
+++ b/studio/components/interfaces/Auth/Policies/PolicyTableRow/index.tsx
@@ -53,9 +53,10 @@ const PolicyTableRow: FC<Props> = ({
               withIcon
               variant="warning"
               className="!px-4 !py-3 !mt-3"
-              title="Warning: RLS is disabled"
+              title="Warning: RLS is disabled. Your table is publicly readable and writable."
             >
-              Anonymous access is allowed to this table
+              Anyone with the anon. key can modify or delete your data. You should turn on RLS and
+              create access policies to keep your data secure.
             </Alert>
           )}
         </div>

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.tsx
@@ -1,6 +1,6 @@
 import { FC, useEffect, useState } from 'react'
 import { isUndefined, isEmpty } from 'lodash'
-import { Badge, Checkbox, SidePanel, Input, Alert } from 'ui'
+import { Badge, Checkbox, SidePanel, Input, Alert, IconBookOpen, Button } from 'ui'
 import type { PostgresTable, PostgresType } from '@supabase/postgres-meta'
 
 import { useStore } from 'hooks'
@@ -19,6 +19,7 @@ import {
 } from './TableEditor.utils'
 import { useForeignKeyConstraintsQuery } from 'data/database/foreign-key-constraints-query'
 import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
+import Link from 'next/link'
 
 interface Props {
   table?: PostgresTable
@@ -226,18 +227,46 @@ const TableEditor: FC<Props> = ({
                   <p>
                     Restrict access to your table by enabling RLS and writing Postgres policies.
                   </p>
-                  <p>
-                    RLS is secure by default - all normal access to this table must be allowed by a
-                    policy.
-                  </p>
-                  {!tableFields.isRLSEnabled && (
+
+                  {tableFields.isRLSEnabled ? (
                     <Alert
                       withIcon
                       variant="warning"
                       className="!px-4 !py-3 mt-3"
+                      title="RLS policies are required to query data"
+                    >
+                      <p>
+                        You need to write a policy before you can query data from this table.
+                        Without a policy, querying this table will result in an <u>empty array</u>{' '}
+                        of results.
+                      </p>
+                      <p className="mt-4">
+                        <Link href="https://supabase.com/docs/guides/auth/row-level-security">
+                          <a target="_blank">
+                            <Button type="default" icon={<IconBookOpen strokeWidth={1.5} />}>
+                              RLS Documentation
+                            </Button>
+                          </a>
+                        </Link>
+                      </p>
+                    </Alert>
+                  ) : (
+                    <Alert
+                      withIcon
+                      variant="danger"
+                      className="!px-4 !py-3 mt-3"
                       title="Turning off RLS means that you are allowing anonymous access to your table"
                     >
-                      As such, anyone with the anonymous key can modify or delete your data.
+                      <p>As such, anyone with the anonymous key can modify or delete your data.</p>
+                      <p className="mt-4">
+                        <Link href="https://supabase.com/docs/guides/auth/row-level-security">
+                          <a target="_blank">
+                            <Button type="default" icon={<IconBookOpen strokeWidth={1.5} />}>
+                              RLS Documentation
+                            </Button>
+                          </a>
+                        </Link>
+                      </p>
                     </Alert>
                   )}
                 </>

--- a/studio/pages/project/[ref]/editor/[id].tsx
+++ b/studio/pages/project/[ref]/editor/[id].tsx
@@ -15,6 +15,7 @@ import { NextPageWithLayout, SchemaView } from 'types'
 import { JsonEditValue } from 'components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.types'
 import { ProjectContextFromParamsProvider } from 'components/layouts/ProjectLayout/ProjectContext'
 import { ForeignRowSelectorProps } from 'components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/ForeignRowSelector/ForeignRowSelector'
+import { toJS } from 'mobx'
 
 const TableEditorPage: NextPageWithLayout = () => {
   const router = useRouter()
@@ -57,7 +58,7 @@ const TableEditorPage: NextPageWithLayout = () => {
         .concat(foreignTables)
         .find((table) => table.id === Number(id))
     : undefined
-
+  console.log('selectedTable', toJS(selectedTable))
   useEffect(() => {
     if (selectedTable && 'schema' in selectedTable) {
       setSelectedSchema(selectedTable.schema)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds a new warning telling people that having RLS enabled, but no policies set will mean they'll get an empty array returned when they query the table. 

<img width="640" alt="CleanShot 2023-03-21 at 17 28 18@2x" src="https://user-images.githubusercontent.com/105593/226726684-9da7bb87-42b9-4ea6-b510-532d2fe47b95.png">

Previously we just had this warning when RLS was turned off: 
<img width="632" alt="CleanShot 2023-03-21 at 17 28 49@2x" src="https://user-images.githubusercontent.com/105593/226726804-7d73c427-8436-4a43-9be6-94516507bf61.png">

