### PR TITLE
Add a new warning about not having RLS policies in place

### DIFF
--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.tsx
@@ -1,6 +1,6 @@
 import { FC, useEffect, useState } from 'react'
 import { isUndefined, isEmpty } from 'lodash'
-import { Badge, Checkbox, SidePanel, Input, Alert } from 'ui'
+import { Badge, Checkbox, SidePanel, Input, Alert, IconBookOpen, Button } from 'ui'
 import type { PostgresTable, PostgresType } from '@supabase/postgres-meta'
 
 import { useStore } from 'hooks'
@@ -19,6 +19,7 @@ import {
 } from './TableEditor.utils'
 import { useForeignKeyConstraintsQuery } from 'data/database/foreign-key-constraints-query'
 import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
+import Link from 'next/link'
 
 interface Props {
   table?: PostgresTable
@@ -226,18 +227,46 @@ const TableEditor: FC<Props> = ({
                   <p>
                     Restrict access to your table by enabling RLS and writing Postgres policies.
                   </p>
-                  <p>
-                    RLS is secure by default - all normal access to this table must be allowed by a
-                    policy.
-                  </p>
-                  {!tableFields.isRLSEnabled && (
+
+                  {tableFields.isRLSEnabled ? (
                     <Alert
                       withIcon
                       variant="warning"
                       className="!px-4 !py-3 mt-3"
+                      title="RLS policies are required to query data"
+                    >
+                      <p>
+                        You need to write a policy before you can query data from this table.
+                        Without a policy, querying this table will result in an <u>empty array</u>{' '}
+                        of results.
+                      </p>
+                      <p className="mt-4">
+                        <Link href="https://supabase.com/docs/guides/auth/row-level-security">
+                          <a target="_blank">
+                            <Button type="default" icon={<IconBookOpen strokeWidth={1.5} />}>
+                              RLS Documentation
+                            </Button>
+                          </a>
+                        </Link>
+                      </p>
+                    </Alert>
+                  ) : (
+                    <Alert
+                      withIcon
+                      variant="danger"
+                      className="!px-4 !py-3 mt-3"
                       title="Turning off RLS means that you are allowing anonymous access to your table"
                     >
-                      As such, anyone with the anonymous key can modify or delete your data.
+                      <p>As such, anyone with the anonymous key can modify or delete your data.</p>
+                      <p className="mt-4">
+                        <Link href="https://supabase.com/docs/guides/auth/row-level-security">
+                          <a target="_blank">
+                            <Button type="default" icon={<IconBookOpen strokeWidth={1.5} />}>
+                              RLS Documentation
+                            </Button>
+                          </a>
+                        </Link>
+                      </p>
                     </Alert>
                   )}
                 </>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds a new warning telling people that having RLS enabled, but no policies set will mean they'll get an empty array returned when they query the table. 

<img width="640" alt="CleanShot 2023-03-21 at 17 28 18@2x" src="https://user-images.githubusercontent.com/105593/226726684-9da7bb87-42b9-4ea6-b510-532d2fe47b95.png">

Previously we just had this warning when RLS was turned off: 
<img width="632" alt="CleanShot 2023-03-21 at 17 28 49@2x" src="https://user-images.githubusercontent.com/105593/226726804-7d73c427-8436-4a43-9be6-94516507bf61.png">

