### PR TITLE
chore: document extensions schema

### DIFF
--- a/apps/docs/pages/guides/database/extensions.mdx
+++ b/apps/docs/pages/guides/database/extensions.mdx
@@ -49,7 +49,7 @@ Most extensions are installed under the `extensions` schema, which is accessible
 
 If you need to restrict user access to tables managed by extensions, we recommend creating a separate schema for installing that specific extension.
 
-Some extensions can only be created under a specific schema, for eg. `tiger` schema for `postgis_tiger_geocoder` extension. Before enabling such extensions, make sure you have not created a conflicting schema with the same name.
+Some extensions can only be created under a specific schema, for eg. `postgis_tiger_geocoder` extension creates a schema named `tiger`. Before enabling such extensions, make sure you have not created a conflicting schema with the same name.
 
 </Admonition>
 

--- a/apps/docs/pages/guides/database/extensions.mdx
+++ b/apps/docs/pages/guides/database/extensions.mdx
@@ -40,14 +40,18 @@ drop
 Even though the SQL code is `create extension`, this is the equivalent of "enabling the extension".
 To disable an extension call `drop extension`.
 
-<Admonition type="caution">
-
-Enabling some extensions with `create extension <extension-name> with schema extensions` may lead to permission issues (e.g., `dblink`, `http`, `pg_cron`).
-
-</Admonition>
-
 </TabPanel>
 </Tabs>
+
+<Admonition type="note">
+
+Most extensions are installed under the `extensions` schema, which is accessible to public by default. To avoid namespace pollution, we do not recommend creating other entities in the `extensions` schema.
+
+If you need to restrict user access to tables managed by extensions, we recommend creating a separate schema for installing that specific extension.
+
+Some extensions can only be created under a specific schema, for eg. `tiger` schema for `postgis_tiger_geocoder` extension. Before enabling such extensions, make sure you have not created a conflicting schema with the same name.
+
+</Admonition>
 
 ### Full list of extensions
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the new behavior?

- removes warning about enabling extension via psql as supautils are handling them now
- adds a note about the supported use cases of `extensions` schema

## Additional context

Add any other context or screenshots.
