### PR TITLE
Docs: realtime going into prod

### DIFF
--- a/apps/docs/pages/guides/platform/going-into-prod.mdx
+++ b/apps/docs/pages/guides/platform/going-into-prod.mdx
@@ -34,7 +34,7 @@ After developing your project and deciding it's Production Ready, you should run
 - Perform load testing (preferably on a staging env)
   - Tools like [k6](https://k6.io/) can simulate traffic from many different users.
 - Upgrade your database if you require more resources. If you need anything beyond what is listed, contact enterprise@supabase.io.
-- If you are expecting a surge in traffic (for a big launch), let the team know by sending your Project Ref to us (support@supabase.io) with more details about your launch. We'll keep an eye on your project.
+- If you are expecting a surge in traffic (for a big launch) [contact support](https://app.supabase.com/support/new) with more details about your launch. We'll keep an eye on your project.
 
 ## Availability
 
@@ -47,7 +47,7 @@ After developing your project and deciding it's Production Ready, you should run
 - Database backups are not available for download on the free tier.
   - You can set up your own backup systems using tools like [pg_dump](https://www.postgresqltutorial.com/postgresql-backup-database/) or [wal-g](https://github.com/wal-g/wal-g).
   - Nightly backups for Pro tier projects are available on the Supabase dashboard for up to 7 days.
-- Upgrading to the Supabase Pro Tier will give you access to email support on support@supabase.io
+- Upgrading to the Supabase Pro Tier will give you [access to our support team](https://app.supabase.com/support/new).
 
 ## Rate Limiting, Resource Allocation, & Abuse Prevention
 
@@ -72,7 +72,7 @@ After developing your project and deciding it's Production Ready, you should run
 ### Realtime Rate Limits
 
 - Review the [Realtime rate limits](/docs/guides/realtime/rate-limits).
-- If you need rate limits increased you can always reach out to us at support@supabase.io.
+- If you need rate limits increased you can always [contact support](https://app.supabase.com/support/new).
 
 ### Abuse Prevention
 

--- a/apps/docs/pages/guides/platform/going-into-prod.mdx
+++ b/apps/docs/pages/guides/platform/going-into-prod.mdx
@@ -54,7 +54,7 @@ After developing your project and deciding it's Production Ready, you should run
 - Supabase employs a number of safeguards against bursts of incoming traffic to prevent abuse and help maximize stability across the platform
   - If you're expecting high load events including production launches or heavy load testing, or prolonged high resource usage please give us at least 2 weeks notice. You can do this by opening a ticket via the [support form](https://app.supabase.com/support/new).
 
-### Rate Limits
+### Auth Rate Limits
 
 - The table below shows the rate limit quotas on the following authentication endpoints:
 

--- a/apps/docs/pages/guides/platform/going-into-prod.mdx
+++ b/apps/docs/pages/guides/platform/going-into-prod.mdx
@@ -69,6 +69,11 @@ After developing your project and deciding it's Production Ready, you should run
 | Token refresh requests                           | `/auth/v1/token`                                               | IP Address               | 360 requests per hour (with bursts up to 30 requests)                           |
 | Create or Verify an MFA challenge                | `/auth/v1/factors/:id/challenge` `/auth/v1/factors/:id/verify` | IP Address               | 15 requests per minute (with bursts up to 30 requests)                          |
 
+### Realtime Rate Limits
+
+- Review the [Realtime rate limits](/docs/guides/realtime/rate-limits).
+- If you need rate limits increased you can always reach out to us at support@supabase.io.
+
 ### Abuse Prevention
 
 - Supabase provides CAPTCHA protection on the signup, sign-in and password reset endpoints. Please refer to [our guide](/docs/guides/auth/auth-captcha) on how to protect against abuse using this method.

--- a/apps/docs/pages/guides/realtime/extensions.mdx
+++ b/apps/docs/pages/guides/realtime/extensions.mdx
@@ -8,7 +8,7 @@ export const meta = {
   sidebar_label: 'Extensions',
 }
 
-Supabase Realtime provides multiplayer features so that you can build real-time applications. The server is has several extensions which are built to solve a specific task.
+Supabase Realtime provides multiplayer features so that you can build real-time applications. The server has several built-in extensions to solve specific tasks.
 
 - [Broadcast](/docs/guides/realtime/broadcast): for sending rapid, ephemeral messages to other connected clients. A typical use-case is tracking mouse movements.
 - [Presence](/docs/guides/realtime/presence): for sending user state between connected clients. A typical use-case is simply an "online" status, which will disappear when a user is disconnected.


### PR DESCRIPTION
- [x] adds a "Realtime Rate Limits" section
- [x] specifies "Auth Rate Limits" because that table is all auth rate limits
- [x] links to Realtime rate limits section because all that info is there
- [x] reinforces that people can always contact support for help 
- [x] links to support form instead of support@ email