### PR TITLE
fix: Org invite listbox

### DIFF
--- a/studio/components/interfaces/Organization/TeamSettings/InviteMemberButton.tsx
+++ b/studio/components/interfaces/Organization/TeamSettings/InviteMemberButton.tsx
@@ -2,7 +2,7 @@ import { isNil } from 'lodash'
 import { useEffect, useState } from 'react'
 import { object, string } from 'yup'
 import * as Tooltip from '@radix-ui/react-tooltip'
-import { Button, Form, IconMail, Input, Modal, Select } from 'ui'
+import { Button, Form, IconMail, Input, Listbox, Modal } from 'ui'
 
 import { Member, Role } from 'types'
 import { checkPermissions, useParams, useStore } from 'hooks'
@@ -153,7 +153,7 @@ const InviteMemberButton = ({
                     <div className="space-y-4">
                       <div className="space-y-2">
                         {roles && (
-                          <Select
+                          <Listbox
                             id="role"
                             name="role"
                             label="Member role"
@@ -164,13 +164,14 @@ const InviteMemberButton = ({
                             }
                           >
                             {roles.map((role: any) => (
-                              <Select.Option key={role.id} value={role.id}>
+                              <Listbox.Option key={role.id} value={role.id} label={role.name}>
                                 {role.name}
-                              </Select.Option>
+                              </Listbox.Option>
                             ))}
-                          </Select>
+                          </Listbox>
                         )}
                       </div>
+
 
                       <Input
                         autoFocus

--- a/studio/components/interfaces/Organization/TeamSettings/InviteMemberButton.tsx
+++ b/studio/components/interfaces/Organization/TeamSettings/InviteMemberButton.tsx
@@ -172,7 +172,6 @@ const InviteMemberButton = ({
                         )}
                       </div>
 
-
                       <Input
                         autoFocus
                         id="email"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Studio > Organisations > Team > Invite

## What is the current behavior?

The form is currently using a `Select` component.

## What is the new behavior?

Changed to use a `Listbox` component:

<img width="518" alt="Screenshot 2023-03-23 at 16 48 52" src="https://user-images.githubusercontent.com/22655069/227277443-ed3c2efa-1ecc-4c7e-837b-cc118ff04482.png">


## Additional context

Closes #12780
