### PR TITLE
Docs: add await to async function in code snippet

### DIFF
--- a/apps/docs/pages/guides/auth/auth-helpers/sveltekit.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/sveltekit.mdx
@@ -86,7 +86,7 @@ import type { LayoutServerLoad } from './$types';
 
 export const load: LayoutServerLoad = async ({ locals: { getSession } }) => {
   return {
-    session: getSession()
+    session: await getSession()
   };
 };
 ```


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs fix.

## What is the current behavior?

The `getSession` function defined in the hook is asynchronous and the server load of the layout is not awaiting it, therefore, it is sending a promise instead of the session.

## What is the new behavior?

Added `await` keyword.
