### PR TITLE
constraint pgbouncer settings update

### DIFF
--- a/studio/components/interfaces/Settings/Database/ConnectionPooling.tsx
+++ b/studio/components/interfaces/Settings/Database/ConnectionPooling.tsx
@@ -134,7 +134,6 @@ export const PgbouncerConfig: FC<ConfigProps> = observer(
     )
 
     const [updates, setUpdates] = useState<any>({
-      pgbouncer_enabled: bouncerInfo.pgbouncer_enabled,
       pool_mode: bouncerInfo.pool_mode || 'transaction',
       default_pool_size: bouncerInfo.default_pool_size || '',
       ignore_startup_parameters: bouncerInfo.ignore_startup_parameters || '',
@@ -199,7 +198,7 @@ export const PgbouncerConfig: FC<ConfigProps> = observer(
           disabledMessage="You need additional permissions to update connection pooling settings"
         >
           <div className="space-y-6 py-4">
-            {updates.pgbouncer_enabled && (
+            {bouncerInfo.pgbouncer_enabled && (
               <>
                 <AutoField
                   name="pool_mode"

--- a/studio/components/interfaces/Settings/Database/ConnectionPooling.tsx
+++ b/studio/components/interfaces/Settings/Database/ConnectionPooling.tsx
@@ -204,7 +204,7 @@ export const PgbouncerConfig: FC<ConfigProps> = observer(
                 <AutoField
                   name="pool_mode"
                   showInlineError
-                  errorMessage="You must select one of the three options"
+                  errorMessage="You must select one of the two options"
                 />
                 <div className="!mt-1 flex" style={{ marginLeft: 'calc(33% + 0.5rem)' }}>
                   <p className="text-sm text-scale-900">

--- a/studio/components/interfaces/Settings/Database/ConnectionPooling.tsx
+++ b/studio/components/interfaces/Settings/Database/ConnectionPooling.tsx
@@ -159,11 +159,6 @@ export const PgbouncerConfig: FC<ConfigProps> = observer(
 
     const formSchema = {
       properties: {
-        pgbouncer_enabled: {
-          title: 'Enabled',
-          type: 'boolean',
-          help: 'Activates / deactivates Connection Pooling.',
-        },
         pool_mode: {
           title: 'Pool Mode',
           type: 'string',
@@ -175,10 +170,6 @@ export const PgbouncerConfig: FC<ConfigProps> = observer(
             {
               label: 'Session',
               value: 'session',
-            },
-            {
-              label: 'Statement',
-              value: 'statement',
             },
           ],
         },
@@ -208,10 +199,6 @@ export const PgbouncerConfig: FC<ConfigProps> = observer(
           disabledMessage="You need additional permissions to update connection pooling settings"
         >
           <div className="space-y-6 py-4">
-            <ToggleField name="pgbouncer_enabled" />
-
-            <Divider light />
-
             {updates.pgbouncer_enabled && (
               <>
                 <AutoField


### PR DESCRIPTION
dont let users disable pgbouncer and set statement transaction mode. Since Storage now requires pgbouncer to always be enabled. 

Before
<img width="943" alt="CleanShot 2023-03-24@2x" src="https://user-images.githubusercontent.com/2155545/227433735-a08792f1-52e6-4f72-9050-ca45a877cc8f.png">

After
<img width="934" alt="CleanShot 2023-03-24@2x" src="https://user-images.githubusercontent.com/2155545/227433755-9a78d2ec-111f-460e-a08d-5949f8e9ad13.png">
