### PR TITLE
provider: accessToken and router not defined

### DIFF
--- a/apps/docs/pages/guides/auth/auth-helpers/nextjs-server-components.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/nextjs-server-components.mdx
@@ -253,6 +253,8 @@ const Context = createContext()
 
 export default function SupabaseProvider({ children }) {
   const [supabase] = useState(() => createClient())
+  const router = useRouter()
+  const accessToken = supabase.accessToken
 
   useEffect(() => {
     const { data: { subscription } } = supabase.auth.onAuthStateChange((event, session) => {


### PR DESCRIPTION
The following lines were missing in the Provider Component

const router = useRouter()
const accessToken = supabase.accessToken

## What kind of change does this PR introduce?

Docs

## What is the current behavior?

Error messages were showing: "accessToken undefined" and "router undefined"

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

N/A
