### PR TITLE
docs: add doc links for bq and s3 fdw

### DIFF
--- a/apps/docs/pages/guides/database/extensions/wrappers.mdx
+++ b/apps/docs/pages/guides/database/extensions/wrappers.mdx
@@ -62,8 +62,9 @@ A web interface for connecting to external data is coming to Supabase Studio in 
 
 - [Firebase](https://supabase.github.io/wrappers/firebase/)
 - [Stripe](https://supabase.github.io/wrappers/stripe/)
+- [BigQuery](https://supabase.github.io/wrappers/bigquery/)
+- [AWS S3](https://supabase.github.io/wrappers/s3/)
 - Airtable - Coming Soon
-- BigQuery - Coming Soon
 - Clickhouse - Coming Soon
 
 ## Resources


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to add doc links for newly added BigQuery and S3 FDW.

## What is the current behavior?

Those 2 FDWs aren't released yet.

## What is the new behavior?

Those 2 FDWs are released for LW7.

## Additional context

N/A
