### PR TITLE
fix: removed auth redirect

### DIFF
--- a/apps/www/lib/redirects.js
+++ b/apps/www/lib/redirects.js
@@ -1531,7 +1531,6 @@ module.exports = [
     source: '/docs/guides/auth/passwordless-login/phone-sms-otp-messagebird',
     destination: '/docs/guides/auth/phone-login/messagebird',
   },
-  { permanent: true, source: '/docs/guides/auth', destination: '/docs/guides/auth/overview' },
   {
     permanent: true,
     source: '/docs/guides/auth/auth-messagebird',


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase Docs

## What is the current behavior?

When you got to [Auth](https://supabase.com/docs/guides/auth/) you get a redirect to `overview` but this returns a 404.

## What is the new behavior?

Removed the redirect.

## Additional context

Closes #13262
