### PR TITLE
chore: removed an unnecessary semicolon in ui sass file

### DIFF
--- a/studio/styles/ui.scss
+++ b/studio/styles/ui.scss
@@ -419,7 +419,7 @@
     @apply fill-blue-500 stroke-blue-500;
   }
   path, circle {
-    @apply stroke-blue-900 fill-blue-500;;
+    @apply stroke-blue-900 fill-blue-500;
   }
 }
 


### PR DESCRIPTION
I only removed an unnecessary semicolon in the `ui.scss`.