### PR TITLE
Hide example projects inactive

### DIFF
--- a/studio/pages/project/[ref]/index.tsx
+++ b/studio/pages/project/[ref]/index.tsx
@@ -41,26 +41,30 @@ const Home: NextPageWithLayout = () => {
         {IS_PLATFORM && project?.status !== PROJECT_STATUS.INACTIVE && <ProjectUsageSection />}
       </div>
 
-      <div className="space-y-8">
-        <div className="mx-6">
-          <h4 className="text-lg">Client libraries</h4>
-        </div>
-        <div className="mx-6 mb-12 grid gap-12 md:grid-cols-3">
-          {CLIENT_LIBRARIES.map((library) => (
-            <ClientLibrary key={library.language} {...library} />
-          ))}
-        </div>
-      </div>
-      <div className="space-y-8">
-        <div className="mx-6">
-          <h4 className="text-lg">Example projects</h4>
-        </div>
-        <div className="mx-6 grid gap-8 md:grid-cols-2 lg:grid-cols-3">
-          {EXAMPLE_PROJECTS.sort((a, b) => a.title.localeCompare(b.title)).map((project) => (
-            <ExampleProject key={project.url} {...project} />
-          ))}
-        </div>
-      </div>
+      {project?.status !== PROJECT_STATUS.INACTIVE && (
+        <>
+          <div className="space-y-8">
+            <div className="mx-6">
+              <h4 className="text-lg">Client libraries</h4>
+            </div>
+            <div className="mx-6 mb-12 grid gap-12 md:grid-cols-3">
+              {CLIENT_LIBRARIES.map((library) => (
+                <ClientLibrary key={library.language} {...library} />
+              ))}
+            </div>
+          </div>
+          <div className="space-y-8">
+            <div className="mx-6">
+              <h4 className="text-lg">Example projects</h4>
+            </div>
+            <div className="mx-6 grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+              {EXAMPLE_PROJECTS.sort((a, b) => a.title.localeCompare(b.title)).map((project) => (
+                <ExampleProject key={project.url} {...project} />
+              ))}
+            </div>
+          </div>
+        </>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Hides example projects and client libraries when project is inactive.

## What is the current behavior?

Shows example projects and client libraries when project is inactive.

![CleanShot 2023-03-28 at 18 16 12@2x](https://user-images.githubusercontent.com/70828596/228378910-cbe4d849-b12b-42be-a413-0d7572ff1809.png)

## What is the new behavior?

Hides example projects and client libraries when project is inactive.

![CleanShot 2023-03-28 at 18 18 06@2x](https://user-images.githubusercontent.com/70828596/228379271-af2b4fbd-9fee-4d01-a7e9-0a88a3c4cddd.png)