### PR TITLE
chore: add cli guides to getting started for discoverability

### DIFF
--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
@@ -48,6 +48,7 @@ export const gettingstarted = {
   items: [
     { name: 'Features', url: '/guides/getting-started/features' },
     { name: 'Architecture', url: '/guides/getting-started/architecture' },
+    { name: 'Local Development', url: '/guides/cli/local-development' },
     {
       name: 'Framework Quickstarts',
       items: [

--- a/apps/docs/pages/guides/getting-started.mdx
+++ b/apps/docs/pages/guides/getting-started.mdx
@@ -218,6 +218,12 @@ export const resources = [
     href: '/guides/getting-started/architecture',
     description: "An overview of Supabase's architecture and product principles.",
   },
+  {
+    title: 'Local Development',
+    hasLightIcon: true,
+    href: '/guides/cli/local-development',
+    description: 'Use the Supabase CLI to develop locally and collaborate between teams.',
+  },
 ]
 
 export const Page = ({ children }) => <Layout meta={meta} children={children} />


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

local development guide isn't very discoverable because it's under cli section

## What is the new behavior?

add them to getting started section as discussed

## Additional context

<img width="1440" alt="Screenshot 2023-03-29 at 12 21 44 PM" src="https://user-images.githubusercontent.com/1639722/228426095-7136ecf4-6f11-4479-a763-e905456b79db.png">


