### PR TITLE
docs: fixed typo in variables for change email template

### DIFF
--- a/studio/stores/authConfig/schema/AuthProviders/AuthTemplatesValidation.tsx
+++ b/studio/stores/authConfig/schema/AuthProviders/AuthTemplatesValidation.tsx
@@ -122,7 +122,7 @@ export const EMAIL_CHANGE: FormSchema = {
 - \`{{ .TokenHash }}\` : The hashed token used in the URL
 - \`{{ .SiteURL }}\` : The URL of the site
 - \`{{ .Email }}\` : The original users email address
-- \`{{ .NewEmail }\` : The users new email address
+- \`{{ .NewEmail }}\` : The users new email address
 `,
     },
   },


### PR DESCRIPTION
While working on my hobby project I noticed a small typo in the documentation page, this change should fix it. Really like supabase so keep up the good work!

## What kind of change does this PR introduce?

Small typo fix in the studio project

## What is the current behavior?

![image](https://user-images.githubusercontent.com/23300110/228826733-f49f122c-8893-45ae-b26f-f6e676f98264.png)

## What is the new behavior?

![image](https://user-images.githubusercontent.com/23300110/228826859-1f7e1047-84d0-435f-899e-c796522a592c.png)
