### PR TITLE
Fix broken link for "Edge Functions -> Connect to Postgres" example 

### DIFF
--- a/apps/docs/pages/guides/functions.mdx
+++ b/apps/docs/pages/guides/functions.mdx
@@ -94,7 +94,7 @@ export const examples = [
   {
     name: 'Connect to Postgres',
     description: `Connecting to Postgres from Edge Functions.`,
-    href: '/guides/functions/examples/connect-to-postgres',
+    href: '/guides/functions/connect-to-postgres',
   },
   {
     name: 'Github Actions',

--- a/packages/ui/src/components/Command/CommandMenuProvider.tsx
+++ b/packages/ui/src/components/Command/CommandMenuProvider.tsx
@@ -104,6 +104,7 @@ function useKeyboardEvents({
           return
         case 'k':
         case '/':
+          event.preventDefault()
           if (event.metaKey || event.ctrlKey) {
             setIsOpen(true)
           }

--- a/packages/ui/src/components/Command/CommandMenuProvider.tsx
+++ b/packages/ui/src/components/Command/CommandMenuProvider.tsx
@@ -104,7 +104,6 @@ function useKeyboardEvents({
           return
         case 'k':
         case '/':
-          event.preventDefault()
           if (event.metaKey || event.ctrlKey) {
             setIsOpen(true)
           }


### PR DESCRIPTION
## What kind of change does this PR introduce?
This commit fixes the broken link issue #13328. The link was updated to the correct one. 

## What is the current behavior?

issue #13328
![image](https://user-images.githubusercontent.com/43529945/229048642-2534bd26-38e7-4443-8d6c-d582e251d057.png)

## What is the new behavior?

![image](https://user-images.githubusercontent.com/43529945/229048808-2046957b-b001-4eb8-99e4-9f823bedcbb0.png)

Add any other context or screenshots.
N/A