### PR TITLE
Docs: Remove unused import statement

### DIFF
--- a/apps/docs/pages/guides/auth/auth-helpers/sveltekit.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/sveltekit.mdx
@@ -385,7 +385,6 @@ protect multiple routes at once.
 ```ts
 // src/hooks.server.ts
 import type { RequestHandler } from './$types';
-import { getSupabase } from '@supabase/auth-helpers-sveltekit';
 import { redirect, error } from '@sveltejs/kit';
 
 export const handle: Handle = async ({ event, resolve }) => {


### PR DESCRIPTION
Removes the unused import `getSupabase` in the "Protecting multiple routes" passage of the sveltekit auth helper docs.

## What kind of change does this PR introduce?

Docs update

## Additional context

Prevent confusion 😊 
