### PR TITLE
fix: remove common pkg button import

### DIFF
--- a/packages/common/index.tsx
+++ b/packages/common/index.tsx
@@ -1,6 +1,5 @@
 import SidebarLayout from './layouts/SidebarLayout'
 
-export * from './Button'
 export * from './Providers'
 export * from './hooks'
 export * from './gotrue'


### PR DESCRIPTION
https://github.com/supabase/supabase/pull/13306 missed an export of the deleted button component, causing all builds to break.