### PR TITLE
fix: Upgrade studio image to 20230330-99fed3d

### DIFF
--- a/apps/www/README.md
+++ b/apps/www/README.md
@@ -1,4 +1,4 @@
-# supabase.io - test
+# supabase.io
 
 ## Overview
 

--- a/apps/www/README.md
+++ b/apps/www/README.md
@@ -1,4 +1,4 @@
-# supabase.io
+# supabase.io - test
 
 ## Overview
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,7 +9,7 @@ version: "3.8"
 services:
   studio:
     container_name: supabase-studio
-    image: supabase/studio:20230216-e731b77
+    image: supabase/studio:20230330-99fed3d
     restart: unless-stopped
     healthcheck:
       test: [ "CMD", "node", "-e", "require('http').get('http://localhost:3000/api/profile', (r) => {if (r.statusCode !== 200) throw new Error(r.statusCode)})" ]


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Using the studio image version 20230216-e731b77, the studio received error 404 from any request to /profile/permissions and even trying to create a new user via SDK was impossible.

## What is the new behavior?

The studio image version has been replaced with the latest one from Docker-Hub (20230330-99fed3d) this image version resolved any issue with the /profile/permissions endpoint.

## Additional context

![image](https://user-images.githubusercontent.com/30237552/229547657-eb2d9254-be59-49b6-b9ec-ddd46633dd4b.png)
