### PR TITLE
Fix guide doc links

### DIFF
--- a/studio/components/layouts/AccountLayout/AccountLayout.tsx
+++ b/studio/components/layouts/AccountLayout/AccountLayout.tsx
@@ -99,7 +99,7 @@ const AccountLayout: FC<Props> = ({ children, title, breadcrumbs }) => {
           key: 'ext-guides',
           icon: `${router.basePath}/img/book.svg`,
           label: 'Guides',
-          href: 'https://supabase.com/docs',
+          href: 'https://supabase.com/docs/guides/platform',
           isExternal: true,
         },
         {

--- a/studio/components/layouts/DocsLayout/DocsLayout.utils.tsx
+++ b/studio/components/layouts/DocsLayout/DocsLayout.utils.tsx
@@ -85,7 +85,7 @@ export const generateDocsMenu = (
         {
           name: 'Guides',
           key: 'guides',
-          url: `https://supabase.com/docs`,
+          url: `https://supabase.com/docs/guides/platform`,
           icon: <IconBook size={14} strokeWidth={2} />,
           items: [],
           isExternal: true,


### PR DESCRIPTION
## What is the current behavior?

Currently, clicking on the guides link from studio will direct users to the docs front page and not to the platform guides page.
<img width="237" alt="image" src="https://user-images.githubusercontent.com/1732217/229565508-3f0e651f-81f2-4d67-91a4-eac8ccb9f551.png">

## What is the new behavior?

Link will now direct the user to this page:
https://supabase.com/docs/guides/platform
