### PR TITLE
fix: terminal problem

### DIFF
--- a/studio/components/interfaces/Billing/ProUpgrade.tsx
+++ b/studio/components/interfaces/Billing/ProUpgrade.tsx
@@ -260,7 +260,7 @@ const ProUpgrade: FC<Props> = ({
                   </>
                 )}
               </div>
-              <div className="flex items-center justify-between gap-16 px-6 py-4 border rounded border-panel-border-light border-panel-border-dark bg-panel-body-light drop-shadow-sm dark:bg-panel-body-dark">
+              <div className="flex items-center justify-between gap-16 px-6 py-4 border rounded border-panel-border-light dark:border-panel-border-dark bg-panel-body-light drop-shadow-sm dark:bg-panel-body-dark">
                 <div>
                   <div className="flex items-center space-x-2">
                     <p>Spend cap</p>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase Studio - Pro Upgrade

## What is the current behavior?

Noticed a problem in the terminal in vscode:

<img width="821" alt="Screenshot 2023-04-03 at 20 58 29" src="https://user-images.githubusercontent.com/22655069/229615183-2aa42593-9c20-4bf7-9bec-544426eb3f53.png">


## What is the new behavior?

Problem resolved by adding `dark:`

