### PR TITLE
docs: fix issue #13025 by removing empty space character while signing in to prevent snackbar error "Unable to validate email address: invalid format"

### DIFF
--- a/apps/docs/pages/guides/getting-started/tutorials/with-flutter.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-flutter.mdx
@@ -237,7 +237,7 @@ class _LoginPageState extends State<LoginPage> {
     });
     try {
       await supabase.auth.signInWithOtp(
-        email: _emailController.text,
+        email: _emailController.text.trim(),
         emailRedirectTo:
             kIsWeb ? null : 'io.supabase.flutterquickstart://login-callback/',
       );
@@ -358,8 +358,8 @@ class _AccountPageState extends State<AccountPage> {
     setState(() {
       _loading = true;
     });
-    final userName = _usernameController.text;
-    final website = _websiteController.text;
+    final userName = _usernameController.text.trim();
+    final website = _websiteController.text.trim();
     final user = supabase.auth.currentUser;
     final updates = {
       'id': user!.id,
@@ -682,8 +682,8 @@ class _AccountPageState extends State<AccountPage> {
     setState(() {
       _loading = true;
     });
-    final userName = _usernameController.text;
-    final website = _websiteController.text;
+    final userName = _usernameController.text.trim();
+    final website = _websiteController.text.trim();
     final user = supabase.auth.currentUser;
     final updates = {
       'id': user!.id,

--- a/examples/user-management/flutter-user-management/lib/pages/account_page.dart
+++ b/examples/user-management/flutter-user-management/lib/pages/account_page.dart
@@ -48,8 +48,8 @@ class _AccountPageState extends State<AccountPage> {
     setState(() {
       _loading = true;
     });
-    final userName = _usernameController.text;
-    final website = _websiteController.text;
+    final userName = _usernameController.text.trim();
+    final website = _websiteController.text.trim();
     final user = supabase.auth.currentUser;
     final updates = {
       'id': user!.id,

--- a/examples/user-management/flutter-user-management/lib/pages/login_page.dart
+++ b/examples/user-management/flutter-user-management/lib/pages/login_page.dart
@@ -25,7 +25,7 @@ class _LoginPageState extends State<LoginPage> {
     });
     try {
       await supabase.auth.signInWithOtp(
-        email: _emailController.text,
+        email: _emailController.text.trim(),
         emailRedirectTo:
             kIsWeb ? null : 'io.supabase.flutterquickstart://login-callback/',
       );


### PR DESCRIPTION
fix issue #13025 by removing empty space character while signing in to prevent snackbar error `Unable to validate email address: invalid format`