### PR TITLE
chore: validation for postgres version

### DIFF
--- a/studio/pages/new/[slug].tsx
+++ b/studio/pages/new/[slug].tsx
@@ -169,6 +169,15 @@ const Wizard: NextPageWithLayout = () => {
       kps_enabled: kpsEnabled,
     }
     if (postgresVersion) {
+      if (!postgresVersion.match(/1[2-9]\..*/)) {
+        setNewProjectLoading(false)
+        ui.setNotification({
+          category: 'error',
+          message: `Invalid Postgres version, should start with a number between 12-19, a dot and additional characters, i.e. 15.2 or 15.2.0-3`,
+        })
+        return
+      }
+
       data['custom_supabase_internal_requests'] = {
         ami: { search_tags: { 'tag:postgresVersion': postgresVersion } },
       }
@@ -310,6 +319,7 @@ const Wizard: NextPageWithLayout = () => {
                       id="custom-postgres-version"
                       layout="horizontal"
                       label="Postgres Version"
+                      autoComplete="off"
                       descriptionText={
                         <p>
                           Specify a custom version of Postgres (Defaults to the latest)


### PR DESCRIPTION
Since at least two people ran into projects not launching and realizing that the browser autocompletion filled the Postgres Version input with non-sense (i.e. email address), this PR adds a simple validation to prevent creating projects with completely invalid Postgres versions.