### PR TITLE
Adjust array index for og-image page type

### DIFF
--- a/apps/docs/layouts/guides/index.tsx
+++ b/apps/docs/layouts/guides/index.tsx
@@ -65,7 +65,7 @@ const Layout: FC<Props> = (props) => {
   const hasTableOfContents = tocList.length > 0
 
   // page type, ie, Auth, Database, Storage etc
-  const ogPageType = asPath.split('/')[2]
+  const ogPageType = asPath.split('/')[1]
   // open graph image url constructor
   const ogImageUrl = encodeURI(
     `https://obuldanrptloktxcffvn.functions.supabase.co/og-images?site=docs${


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug Fix

## What is the current behavior?

Under the `guides` URL, the OG image is showing the wrong text for the og-image pre-header:

<img width="509" alt="Screenshot - Slack on 2023-04-04 at 15 43 52@2x" src="https://user-images.githubusercontent.com/28504852/229902996-454b833a-2b43-42f8-9ddc-363919eea5f9.png">

In the above, it should have "STORAGE" rather than "STORAGE CDN"

<img width="604" alt="Screenshot - Slack on 2023-04-04 at 15 47 11@2x" src="https://user-images.githubusercontent.com/28504852/229903350-809bde93-ca06-46ea-a3ac-d813a9ec9c0f.png">

In the above, it should say "REALTIME" rather than "RUBSCRIBING TO DATABASE CHANGES"

## What is the new behavior?

This should fix the index check to make sure the edge function returns the right pre-header