### PR TITLE
Bug Fix:Restricts opening chrome bar with search function #13339

### DIFF
--- a/packages/ui/src/components/Command/CommandMenuProvider.tsx
+++ b/packages/ui/src/components/Command/CommandMenuProvider.tsx
@@ -104,6 +104,7 @@ function useKeyboardEvents({
           return
         case 'k':
         case '/':
+          event.preventDefault()
           if (event.metaKey || event.ctrlKey) {
             setIsOpen(true)
           }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix of the default behavior of Shortcut for search (ctrl/k) opens Chrome search bar along with desired search function

## What is the current behavior?

shortcut Ctrl+k opens both Chrome search and search function in the documentation

## What is the new behavior?

It does not open Chrome search but only the search function.

## Additional context

N/A
