### PR TITLE
Fix/toggle styles

### DIFF
--- a/packages/ui/src/components/Toggle/Toggle.tsx
+++ b/packages/ui/src/components/Toggle/Toggle.tsx
@@ -128,7 +128,7 @@ function Toggle({
         type="button"
         id={id}
         name={name}
-        className={clsx(toggleClasses, disabled && 'opacity-50 cursor-default')}
+        className={clsx(...toggleClasses, disabled && 'opacity-50 cursor-default')}
         onClick={onClick}
         disabled={disabled}
         onBlur={handleBlurEvent}

--- a/packages/ui/src/lib/theme/defaultTheme.ts
+++ b/packages/ui/src/lib/theme/defaultTheme.ts
@@ -1061,8 +1061,8 @@ export default {
       hover:bg-scale-700
     `,
     active: `
-      bg-brand-900
-      hover:bg-brand-900
+      !bg-brand-900
+      !hover:bg-brand-900
     `,
     handle_container: {
       tiny: 'h-4 w-7',
@@ -1081,11 +1081,11 @@ export default {
         transition
         ease-in-out duration-200
       `,
-      tiny: 'h-3 w-3',
-      small: 'h-5 w-5',
-      medium: 'h-5 w-5',
-      large: 'h-6 w-6',
-      xlarge: 'h-6 w-6',
+      tiny: '!h-3 !w-3',
+      small: '!h-5 !w-5',
+      medium: '!h-5 !w-5',
+      large: '!h-6 !w-6',
+      xlarge: '!h-6 !w-6',
     },
     handle_active: {
       tiny: ' translate-x-3 dark:bg-white',

--- a/studio/components/interfaces/Database/Publications/PublicationsList.tsx
+++ b/studio/components/interfaces/Database/Publications/PublicationsList.tsx
@@ -92,18 +92,10 @@ const PublicationsList: FC<Props> = ({ onSelectPublication = () => {} }) => {
               <Table.th key="header.id" className="hidden lg:table-cell">
                 System ID
               </Table.th>,
-              <Table.th key="header.insert" className="text-center">
-                Insert
-              </Table.th>,
-              <Table.th key="header.update" className="text-center">
-                Update
-              </Table.th>,
-              <Table.th key="header.delete" className="text-center">
-                Delete
-              </Table.th>,
-              <Table.th key="header.truncate" className="text-center">
-                Truncate
-              </Table.th>,
+              <Table.th key="header.insert">Insert</Table.th>,
+              <Table.th key="header.update">Update</Table.th>,
+              <Table.th key="header.delete">Delete</Table.th>,
+              <Table.th key="header.truncate">Truncate</Table.th>,
               <Table.th key="header.source" className="text-right">
                 Source
               </Table.th>,
@@ -118,16 +110,12 @@ const PublicationsList: FC<Props> = ({ onSelectPublication = () => {} }) => {
                 </Table.td>
                 {publicationEvents.map((event) => (
                   <Table.td key={event.key}>
-                    <div className="flex justify-center">
-                      <Toggle
-                        size="tiny"
-                        checked={x[event.key]}
-                        disabled={!canUpdatePublications}
-                        onChange={() =>
-                          toggleListenEvent(x, event.event.toLowerCase(), x[event.key])
-                        }
-                      />
-                    </div>
+                    <Toggle
+                      size="tiny"
+                      checked={x[event.key]}
+                      disabled={!canUpdatePublications}
+                      onChange={() => toggleListenEvent(x, event.event.toLowerCase(), x[event.key])}
+                    />
                   </Table.td>
                 ))}
                 <Table.td className="px-4 py-3 pr-2">


### PR DESCRIPTION
## What kind of change does this PR introduce?

- updated toggle styles to work. probably broke in a tailwind update as classes were overriding each other
- adjusted replication table slightly so toggles sit a bit nicer

before:
![image](https://user-images.githubusercontent.com/8291514/230008211-c241dacd-a3b3-4a54-9ae2-a825da9411cd.png)

after:
<img width="1563" alt="Screenshot 2023-04-05 at 3 13 40 PM" src="https://user-images.githubusercontent.com/8291514/230007943-bdf650d3-9aa7-4e95-95f4-e46bd2866592.png">

