### PR TITLE
fix: fetching single self-hosted views

### DIFF
--- a/studio/pages/api/pg-meta/[ref]/materialized-views.ts
+++ b/studio/pages/api/pg-meta/[ref]/materialized-views.ts
@@ -13,6 +13,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
 
   switch (method) {
     case 'GET':
+      if (req.query.id) return handleGetOne(req, res)
       return handleGetAll(req, res)
     default:
       res.setHeader('Allow', ['GET'])
@@ -23,6 +24,17 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
 const handleGetAll = async (req: NextApiRequest, res: NextApiResponse) => {
   const headers = constructHeaders(req.headers)
   let response = await get(`${PG_META_URL}/materialized-views`, {
+    headers,
+  })
+  if (response.error) {
+    return res.status(400).json({ error: response.error })
+  }
+  return res.status(200).json(response)
+}
+
+const handleGetOne = async (req: NextApiRequest, res: NextApiResponse) => {
+  const headers = constructHeaders(req.headers)
+  let response = await get(`${PG_META_URL}/materialized-views/${req.query.id}`, {
     headers,
   })
   if (response.error) {

--- a/studio/pages/api/pg-meta/[ref]/views.ts
+++ b/studio/pages/api/pg-meta/[ref]/views.ts
@@ -13,6 +13,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
 
   switch (method) {
     case 'GET':
+      if (req.query.id) return handleGetOne(req, res)
       return handleGetAll(req, res)
     default:
       res.setHeader('Allow', ['GET'])
@@ -23,6 +24,17 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
 const handleGetAll = async (req: NextApiRequest, res: NextApiResponse) => {
   const headers = constructHeaders(req.headers)
   let response = await get(`${PG_META_URL}/views`, {
+    headers,
+  })
+  if (response.error) {
+    return res.status(400).json({ error: response.error })
+  }
+  return res.status(200).json(response)
+}
+
+const handleGetOne = async (req: NextApiRequest, res: NextApiResponse) => {
+  const headers = constructHeaders(req.headers)
+  let response = await get(`${PG_META_URL}/views/${req.query.id}`, {
     headers,
   })
   if (response.error) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behaviour?

Self-hosted view routes don't support `?id=xxx` for fetching single views.

## What is the new behaviour?

fixes that ^


