### PR TITLE
fix: Get Url in Storage doesn't work in Safari

### DIFF
--- a/studio/lib/helpers.ts
+++ b/studio/lib/helpers.ts
@@ -153,10 +153,26 @@ export const snakeToCamel = (str: string) =>
     group.toUpperCase().replace('-', '').replace('_', '')
   )
 
-export const copyToClipboard = (str: string, callback = () => {}) => {
+/**
+ * Copy text content (string or Promise<string>) into Clipboard.
+ * Safari doesn't support write text into clipboard async, so if you need to load
+ * text content async before coping, please use Promise<string> for the 1st arg.
+ */
+export const copyToClipboard = (str: string | Promise<string>, callback = () => {}) => {
   const focused = window.document.hasFocus()
   if (focused) {
-    window.navigator?.clipboard?.writeText(str).then(callback)
+    if (window.ClipboardItem) {
+      const text = new ClipboardItem({
+        'text/plain': Promise.resolve(str).then((text) => new Blob([text], { type: 'text/plain' })),
+      })
+      window.navigator?.clipboard?.write([text]).then(callback)
+
+      return
+    }
+
+    Promise.resolve(str)
+      .then((text) => window.navigator?.clipboard?.writeText(text))
+      .then(callback)
   } else {
     console.warn('Unable to copy to clipboard')
   }

--- a/studio/localStores/storageExplorer/StorageExplorerStore.js
+++ b/studio/localStores/storageExplorer/StorageExplorerStore.js
@@ -425,13 +425,15 @@ class StorageExplorerStore {
       })
     } else {
       // Need to generate signed URL, and might as well save it to cache as well
-      const signedUrl = await this.fetchFilePreview(file.name, expiresIn)
-
-      try {
-        let formattedUrl = new URL(signedUrl)
+      const signedUrlAsync = this.fetchFilePreview(file.name, expiresIn).then((signedUrl) => {
+        const formattedUrl = new URL(signedUrl)
         formattedUrl.searchParams.set('t', new Date().toISOString())
 
-        copyToClipboard(formattedUrl.toString(), () => {
+        return formattedUrl.toString()
+      })
+
+      try {
+        copyToClipboard(signedUrlAsync, () => {
           this.ui.setNotification({
             category: 'success',
             message: `Copied URL for ${file.name} to clipboard.`,
@@ -440,7 +442,7 @@ class StorageExplorerStore {
         })
         const fileCache = {
           id: file.id,
-          url: formattedUrl.toString(),
+          url: await signedUrlAsync,
           expiresIn: DEFAULT_EXPIRY,
           fetchedAt: Date.now(),
         }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes https://github.com/supabase/supabase/issues/11983
## What is the current behavior?

On Safari when we click on `Get Url` in storage, url is not copied

## What is the new behavior?

When we click on `Get Url` in storage, url is copied in safari too

## Steps to test

Steps to reproduce the behavior, please provide code snippets or a repository:

- Go to Storage
- Click on a file
- Click on Get Url button
- Verify that url get copies

---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.
 