### PR TITLE
fix: prevent default behavior on the search bar

### DIFF
--- a/packages/ui/src/components/Command/CommandMenuProvider.tsx
+++ b/packages/ui/src/components/Command/CommandMenuProvider.tsx
@@ -105,6 +105,7 @@ function useKeyboardEvents({
         case 'k':
         case '/':
           if (event.metaKey || event.ctrlKey) {
+            event.preventDefault()
             setIsOpen(true)
           }
           return


### PR DESCRIPTION
## What kind of change does this PR introduce?
The change is to prevent web browsers from performing their default behavior when press search bars shortcut.  
`Bug fix`

## What is the current behavior?
Using the search shortcut (ctrl/k) works correctly, but it also opens the search bar of your browser, which can be confuse the user. [link issues](https://github.com/supabase/supabase/issues/13339)

## What is the new behavior?
The new behavior only opens the Supabase search bar.
