### PR TITLE
fix: Bump up Logflare version

### DIFF
--- a/docker/docker-compose-logging.yml
+++ b/docker/docker-compose-logging.yml
@@ -83,7 +83,7 @@ services:
 
   analytics:
     container_name: supabase-analytics
-    image: supabase/logflare:1.0.1
+    image: supabase/logflare:1.0.2
     healthcheck:
       test: [ "CMD", "curl", "http://localhost:4000/health" ]
       timeout: 5s


### PR DESCRIPTION
## What kind of change does this PR introduce?

New Logflare version was released, bumping up from version 1.0.1 to 1.0.2
