### PR TITLE
fix(cmdk): Firefox cmk+k focusing address bar

### DIFF
--- a/packages/ui/src/components/Command/CommandMenuProvider.tsx
+++ b/packages/ui/src/components/Command/CommandMenuProvider.tsx
@@ -105,6 +105,9 @@ function useKeyboardEvents({
         case 'k':
         case '/':
           if (event.metaKey || event.ctrlKey) {
+            // Some browsers (ie. firefox) will focus the address bar by default
+            event.preventDefault()
+
             setIsOpen(true)
           }
           return


### PR DESCRIPTION
Prevent's Firefox's default `cmd`+`k` behaviour of focusing address bar instead of opening our menu.

fixes #13472