### PR TITLE
chore: add hint about daily backups when PITR enabled

### DIFF
--- a/studio/components/interfaces/Database/Backups/BackupsList.tsx
+++ b/studio/components/interfaces/Database/Backups/BackupsList.tsx
@@ -23,6 +23,8 @@ const BackupsList: FC<Props> = ({}) => {
     'queue_job.restore.prepare'
   )
 
+  const isPitrEnabled = backups?.configuration?.walg_enabled
+
   if (backups.isLoading) return <Loading />
   if (backups.error) return <BackupsError />
 
@@ -43,7 +45,11 @@ const BackupsList: FC<Props> = ({}) => {
   return (
     <div className="space-y-6">
       {!sortedBackups?.length && tierKey !== 'FREE' ? (
-        <BackupsEmpty />
+        !isPitrEnabled ? (
+          <BackupsEmpty />
+        ) : (
+          <></>
+        )
       ) : (
         <>
           {!canTriggerScheduledBackups && (

--- a/studio/pages/project/[ref]/database/backups/scheduled.tsx
+++ b/studio/pages/project/[ref]/database/backups/scheduled.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from 'next/router'
 import { observer } from 'mobx-react-lite'
-import { Tabs } from 'ui'
+import { IconAlertCircle, IconHelpCircle, IconInfo, IconMessageCircle, Tabs } from 'ui'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 
 import { NextPageWithLayout } from 'types'
@@ -9,11 +9,14 @@ import { DatabaseLayout } from 'components/layouts'
 import { BackupsList } from 'components/interfaces/Database'
 import NoPermission from 'components/ui/NoPermission'
 import { FormsContainer } from 'components/ui/Forms'
+import InformationBox from 'components/ui/InformationBox'
 
 const DatabaseScheduledBackups: NextPageWithLayout = () => {
-  const { ui } = useStore()
+  const { ui, backups } = useStore()
   const router = useRouter()
   const ref = ui.selectedProject?.ref
+
+  const isPitrEnabled = backups?.configuration?.walg_enabled
 
   const canReadScheduledBackups = checkPermissions(PermissionAction.READ, 'back_ups')
 
@@ -35,10 +38,35 @@ const DatabaseScheduledBackups: NextPageWithLayout = () => {
         </Tabs>
 
         <div className="space-y-4">
-          <p className="text-sm text-scale-1100">
-            Projects are backed up daily around midnight of your project's region and can be
-            restored at any time.
-          </p>
+          {!isPitrEnabled && (
+            <p className="text-sm text-scale-1100">
+              Projects are backed up daily around midnight of your project's region and can be
+              restored at any time.
+            </p>
+          )}
+
+          {isPitrEnabled && (
+            <InformationBox
+              hideCollapse
+              defaultVisibility
+              icon={<IconInfo strokeWidth={2} />}
+              title="Point-In-Time-Recovery (PITR) enabled"
+              description={
+                <div>
+                  Your project uses PITR and full daily backups are no longer taken. They're not
+                  needed, as PITR supports a superset of functionality, in terms of the granular
+                  recovery that can be performed.{' '}
+                  <a
+                    className="text-brand-900 transition-colors hover:text-brand-1200"
+                    href="https://supabase.io/docs/guides/database/backups"
+                  >
+                    Learn more
+                  </a>
+                </div>
+              }
+            />
+          )}
+
           {canReadScheduledBackups ? (
             <BackupsList />
           ) : (


### PR DESCRIPTION
We occasionally get anxious support tickets about backups no longer working after enabling PITR - this is expected, so this PR adds a small hint that explains it

![image](https://user-images.githubusercontent.com/14073399/230579715-6cc9e78d-2e5c-4fd2-8ead-08e3d6f52f57.png)

![image](https://user-images.githubusercontent.com/14073399/230579740-71a68dcd-44ab-4269-9b16-07fd1f01a4f9.png)

