### PR TITLE
Load the public tables initially

### DIFF
--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.tsx
@@ -48,6 +48,11 @@ const ForeignKeySelector: FC<Props> = ({ column, visible = false, closePanel, sa
   })
 
   useEffect(() => {
+    // make sure the public schemas are loaded initially
+    meta.tables.loadBySchema('public')
+  }, [])
+
+  useEffect(() => {
     // Reset the state of the side panel
     if (visible) {
       setErrors({})


### PR DESCRIPTION
I have 4 tables and am trying to do a fk look up. 

**current behaviour:** 
I can only see this table3 because I've already loaded it. I can't see the other tables until I click on them and load them 

<img width="450" alt="CleanShot 2023-04-07 at 09 44 24@2x" src="https://user-images.githubusercontent.com/105593/230607029-c1301a5a-39b5-4b31-b292-67a2298a52ba.png">


**Expected behaviour:**
<img width="452" alt="CleanShot 2023-04-07 at 09 44 03@2x" src="https://user-images.githubusercontent.com/105593/230606963-93daea9f-561a-4a27-8c26-0bd2394e2d29.png">


Currently loading these in a useEffect — not sure if there's another way to load them when the page loads.

**To reproduce:**

- create 2-3 tables
- refresh the page 
- add a new column to a table and try and look up a fk 
- you won't be able to see your other tables until you actually click on them and load them