### PR TITLE
add discord audio channel link to lw7 hackathon article

### DIFF
--- a/apps/www/_blog/2023-04-07-launch-week-7-hackathon.mdx
+++ b/apps/www/_blog/2023-04-07-launch-week-7-hackathon.mdx
@@ -89,6 +89,7 @@ We will be looking for:
 The Supabase Team will be taking part in the Hackathon and you'll find us live to build in our discord all week. Please join us by building in public:
 
 - Text channel: [#hackathon](https://discord.gg/UYyweApy)
+- Audio channel: [#hackathon](https://discord.gg/Vj3mTPwH)
 
 If you need help or advice when building, find other people to join your team, or if you just want to chill and watch people build, come and join us!
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds the link to the audio hackathon discord channel 