### PR TITLE
docs: fix issue #13537

### DIFF
--- a/apps/docs/pages/guides/auth/auth-helpers/sveltekit.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/sveltekit.mdx
@@ -199,8 +199,8 @@ For [row level security](https://supabase.com/docs/guides/auth/row-level-securit
 
   let loadedData = [];
   async function loadData() {
-    const { data } = await data.supabase.from('test').select('*').limit(20);
-    loadedData = data;
+    const { data: result } = await data.supabase.from('test').select('*').limit(20);
+    loadedData = result;
   }
 
   $: if (data.session) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixing a little issue in the docs, that i mentioned in #13537

## What is the current behavior?

Currently there are conflicts using the example from [auth-helpers-sveltekit docs](https://supabase.com/docs/guides/auth/auth-helpers/sveltekit#client-side-data-fetching-with-rls).

Destructuring a query response with `{ data }` doesn't work while using `await data.supabase.*` right after.

`Block-scoped variable 'data' used before its declaration. ts(2448)`

## What is the new behavior?

Changed the statement in the example to:
```ts
// ...
const { data: result } = await data.supabase.from('test').select('*').limit(20);
loadedData = result;
// ...
```