### PR TITLE
feat: update SSR docs

### DIFF
--- a/apps/docs/pages/guides/auth/server-side-rendering.mdx
+++ b/apps/docs/pages/guides/auth/server-side-rendering.mdx
@@ -111,6 +111,10 @@ approach also avoids leaking credentials in request or access logs. If you wish 
         https://yourapp.com/...?code=<...>
         ```
         The `code` parameter is commonly known as the Auth Code. The Auth Code can then be exchanged for an access token by calling `exchangeCodeForSession(code)` method.
+        <Admonition type="info">
+          For security purposes, the code has a validity of 5 minutes and can only be exchanged for an access token once. You
+          will need to initiate the authentication flow again if you wish to obtain a new access token.
+        </Admonition>
 
         As the flow is run server side,  `localStorage` may not be available. You may configure the client library to use a custom storage adapter an alternate backing storage such as cookies
         by setting the `storage` option to an object with the following methods:
@@ -303,8 +307,3 @@ export const Page = ({ children }) => <Layout meta={meta} children={children} />
 
 export default Page
 
-### In the PKCE Flow, can I re-use the authorization code?
-
-An Auth Code can only be exchanged for an access token once. If you need a new Auth Code, you will need to restart the flow. For instance, in the case
-of a magic link flow you will need to call `signInWithOtp()` and `verifyOTP()` again in order to get a new Auth Code. The Auth Code
-is valid until a successful exchange for an access token or until a new authentication flow is initiated.

--- a/apps/docs/pages/guides/auth/server-side-rendering.mdx
+++ b/apps/docs/pages/guides/auth/server-side-rendering.mdx
@@ -1,4 +1,6 @@
 import Layout from '~/layouts/DefaultGuideLayout'
+import { Accordion } from 'ui'
+import ReactMarkdown from 'react-markdown'
 
 export const meta = {
   id: 'server-side-rendering',
@@ -55,8 +57,24 @@ like `*` and `**` to allow redirects to different forms of URLs.
 
 </Admonition>
 
-These redirect URLs have the following structure:
+Users can choose between one of two flows:
 
+<Accordion
+  type="default"
+  openBehaviour="multiple"
+  chevronAlign="right"
+  justified
+  size="medium"
+  className="text-scale-900 dark:text-white"
+  >
+    <div className="border-b pb-3">
+
+<Accordion.Item
+                          header={<span className="text-scale-1200">Implicit</span>}
+                          id={`implicit-flow`}
+                        >
+
+These redirect URLs have the following structure:
 ```
 https://yourapp.com/...#access_token=<...>&refresh_token=<...>&...
 ```
@@ -78,8 +96,22 @@ providers), we want to prevent hosting services from getting access to your
 user's authorization credentials by default. Even if the server is under your
 direct control, `GET` requests and their full URLs are often logged. This
 approach also avoids leaking credentials in request or access logs.
-
 </Admonition>
+
+  </Accordion.Item>
+  </div>
+    <div className="border-b pb-3">
+
+<Accordion.Item
+                          header={<span className="text-scale-1200">PKCE</span>}
+                          id={`pkce-flow`}
+                        >
+
+  Test
+  </Accordion.Item>
+    </div>
+
+</Accordion>
 
 ## Bringing it together
 

--- a/apps/docs/pages/guides/auth/server-side-rendering.mdx
+++ b/apps/docs/pages/guides/auth/server-side-rendering.mdx
@@ -110,26 +110,29 @@ approach also avoids leaking credentials in request or access logs. If you wish 
         ```
         https://yourapp.com/...?code=<...>
         ```
-        The `code` can then be exchanged for an access token by calling `exchangeCodeForSession(code)` method.
+        The `code` parameter is commonly known as the Auth Code. The Auth Code can then be exchanged for an access token by calling `exchangeCodeForSession(code)` method.
 
-        As the flow is run server side,  `localStorage` may not be available. You may configure the client library to use a custom storage adapter
+        As the flow is run server side,  `localStorage` may not be available. You may configure the client library to use a custom storage adapter an alternate backing storage such as cookies
         by setting the `storage` option to an object with the following methods:
         ```js
         const customStorageAdapter: SupportedStorage = {
           getItem: (key) => {
             if (!supportsLocalStorage()) {
+              // Configure alternate storage
               return null
             }
             return globalThis.localStorage.getItem(key)
           },
           setItem: (key, value) => {
             if (!supportsLocalStorage()) {
+              // Configure alternate storage here
               return
             }
             globalThis.localStorage.setItem(key, value)
           },
           removeItem: (key) => {
             if (!supportsLocalStorage()) {
+              // Configure alternate storage here
               return
             }
             globalThis.localStorage.removeItem(key)
@@ -299,3 +302,9 @@ cache keys every hour or less.
 export const Page = ({ children }) => <Layout meta={meta} children={children} />
 
 export default Page
+
+### In the PKCE Flow, can I re-use the authorization code?
+
+An Auth Code can only be exchanged for an access token once. If you need a new Auth Code, you will need to restart the flow. For instance, in the case
+of a magic link flow you will need to call `signInWithOtp()` and `verifyOTP()` again in order to get a new Auth Code. The Auth Code
+is valid until a successful exchange for an access token or until a new authentication flow is initiated.

--- a/apps/docs/pages/guides/auth/server-side-rendering.mdx
+++ b/apps/docs/pages/guides/auth/server-side-rendering.mdx
@@ -1,6 +1,5 @@
 import Layout from '~/layouts/DefaultGuideLayout'
 import { Accordion } from 'ui'
-import ReactMarkdown from 'react-markdown'
 
 export const meta = {
   id: 'server-side-rendering',

--- a/apps/docs/pages/guides/auth/server-side-rendering.mdx
+++ b/apps/docs/pages/guides/auth/server-side-rendering.mdx
@@ -57,7 +57,9 @@ like `*` and `**` to allow redirects to different forms of URLs.
 
 </Admonition>
 
-Users can choose between one of two flows:
+Supabase Auth supports two authentication flows: **Implicit** and **PKCE**. The **PKCE** flow is generally preferred when on the server.
+It introduces a few additional steps which guard a against replay and URL capture attacks. Unlike the implicit flow, it also allows users to access the
+`access_token` and `refresh_token` on the server.
 
 <Accordion
   type="default"
@@ -68,13 +70,12 @@ Users can choose between one of two flows:
   className="text-scale-900 dark:text-white"
   >
     <div className="border-b pb-3">
+      <Accordion.Item
+        header={<span className="text-scale-1200">Implicit</span>}
+        id={`ssr-implicit-flow`}
+      >
 
-<Accordion.Item
-                          header={<span className="text-scale-1200">Implicit</span>}
-                          id={`implicit-flow`}
-                        >
-
-These redirect URLs have the following structure:
+When using the implicit flow, a redirect URL will be returned with the following structure:
 ```
 https://yourapp.com/...#access_token=<...>&refresh_token=<...>&...
 ```
@@ -95,22 +96,68 @@ your direct control (such as on GitHub Pages or other freemium hosting
 providers), we want to prevent hosting services from getting access to your
 user's authorization credentials by default. Even if the server is under your
 direct control, `GET` requests and their full URLs are often logged. This
-approach also avoids leaking credentials in request or access logs.
+approach also avoids leaking credentials in request or access logs. If you wish to obtain the
+`access_token` and `refresh_token` on a server, please consider using the PKCE flow.
 </Admonition>
-
-  </Accordion.Item>
-  </div>
-    <div className="border-b pb-3">
-
-<Accordion.Item
-                          header={<span className="text-scale-1200">PKCE</span>}
-                          id={`pkce-flow`}
-                        >
-
-  Test
-  </Accordion.Item>
+      </Accordion.Item>
     </div>
+    <div className="border-b pb-3">
+      <Accordion.Item
+        header={<span className="text-scale-1200">PKCE</span>}
+        id={`ssr-pkce-flow`}
+      >
+        When using the PKCE flow, a redirect URL will be returned with the following structure:
+        ```
+        https://yourapp.com/...?code=<...>
+        ```
+        The `code` can then be exchanged for an access token by calling `exchangeCodeForSession(code)` method.
 
+        As the flow is run server side,  `localStorage` may not be available. You may configure the client library to use a custom storage adapter
+        by setting the `storage` option to an object with the following methods:
+        ```js
+        const customStorageAdapter: SupportedStorage = {
+          getItem: (key) => {
+            if (!supportsLocalStorage()) {
+              return null
+            }
+            return globalThis.localStorage.getItem(key)
+          },
+          setItem: (key, value) => {
+            if (!supportsLocalStorage()) {
+              return
+            }
+            globalThis.localStorage.setItem(key, value)
+          },
+          removeItem: (key) => {
+            if (!supportsLocalStorage()) {
+              return
+            }
+            globalThis.localStorage.removeItem(key)
+          },
+        }
+        ```
+        You may also configure the client library to automatically exchange it for a session after a successful redirect. This can be done by setting the `detectSessionInUrl` option to `true`.
+
+        Putting it all together, your client library initialization may look like this:
+        ```js
+        const supabase = createClient(
+             'https://xyzcompany.supabase.co',
+             'public-anon-key',
+             options: {
+               ...
+               auth: {
+                 ...
+                 detectSessionInUrl: true,
+                 flowType: 'pkce',
+                 storage: customStorageAdapter,
+               }
+               ...
+             }
+        )
+        ```
+        You can read more about the PKCE flow [here](https://oauth.net/2/pkce/)
+      </Accordion.Item>
+    </div>
 </Accordion>
 
 ## Bringing it together

--- a/apps/docs/pages/guides/auth/server-side-rendering.mdx
+++ b/apps/docs/pages/guides/auth/server-side-rendering.mdx
@@ -71,7 +71,7 @@ It introduces a few additional steps which guard a against replay and URL captur
   >
     <div className="border-b pb-3">
       <Accordion.Item
-        header={<span className="text-scale-1200">Implicit</span>}
+        header={<span className="text-scale-1200 font-bold">Implicit</span>}
         id={`ssr-implicit-flow`}
       >
 
@@ -103,17 +103,17 @@ approach also avoids leaking credentials in request or access logs. If you wish 
     </div>
     <div className="border-b pb-3">
       <Accordion.Item
-        header={<span className="text-scale-1200">PKCE</span>}
+        header={<span className="text-scale-1200 font-bold">PKCE</span>}
         id={`ssr-pkce-flow`}
       >
         When using the PKCE flow, a redirect URL will be returned with the following structure:
         ```
         https://yourapp.com/...?code=<...>
         ```
-        The `code` parameter is commonly known as the Auth Code. The Auth Code can then be exchanged for an access token by calling `exchangeCodeForSession(code)` method.
+        The `code` parameter is commonly known as the Auth Code and can be exchanged for an access token by calling `exchangeCodeForSession(code)`.
         <Admonition type="info">
           For security purposes, the code has a validity of 5 minutes and can only be exchanged for an access token once. You
-          will need to initiate the authentication flow again if you wish to obtain a new access token.
+          will need to restart the authentication flow from scratch if you wish to obtain a new access token.
         </Admonition>
 
         As the flow is run server side,  `localStorage` may not be available. You may configure the client library to use a custom storage adapter an alternate backing storage such as cookies


### PR DESCRIPTION
Update the server side rendering documentation to take into account the PKCE flow. The documentation intentionally sidesteps explanation of the protocol details as it might overwhelm the user.

The hope is that users can move over from the implicit flow, and the client library will handle the intricacies of the flow without the user needing to understand what is going on under the hood. Interested  users can, of course, dive into the spec to read further.