### PR TITLE
docs(`/integrations/auth0`): fix module '@auth0/nextjs-auth0' has no exported member for `UserProvider`

### DIFF
--- a/apps/docs/pages/guides/integrations/auth0.mdx
+++ b/apps/docs/pages/guides/integrations/auth0.mdx
@@ -162,7 +162,7 @@ Open `pages/_app.js` and wrap our `Component` with the `UserProvider` from Auth0
 // pages/_app.js
 
 import React from 'react'
-import { UserProvider } from '@auth0/nextjs-auth0'
+import { UserProvider } from '@auth0/nextjs-auth0/client'
 
 const App = ({ Component, pageProps }) => {
   return (


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix: Module '@auth0/nextjs-auth0' has no exported member for `UserProvider`

## What is the current behavior?

Error: Module '@auth0/nextjs-auth0' has no exported member for `UserProvider`

## What is the new behavior?

Proper import path

## Additional context

Add any other context or screenshots.
