### PR TITLE
Chore: lw mobile improvements

### DIFF
--- a/apps/www/components/LaunchWeek/LaunchSection/LaunchWeekPrizeSection.tsx
+++ b/apps/www/components/LaunchWeek/LaunchSection/LaunchWeekPrizeSection.tsx
@@ -11,7 +11,7 @@ export default function LaunchWeekPrizeSection({ className }: { className?: stri
       <div className="">
         <div className="text-center relative z-10 text-white">
           <motion.div
-            className="max-w-[38rem] mx-auto px-4 flex flex-col items-center gap-4"
+            className="max-w-[38rem] mx-auto flex flex-col items-center gap-4"
             initial={{ y: -20, opacity: 0 }}
             whileInView={finalAnimationState}
             viewport={{ once: true, margin: '-150px' }}
@@ -56,7 +56,7 @@ export default function LaunchWeekPrizeSection({ className }: { className?: stri
             </p>
           </motion.div>
         </div>
-        <div className="px-4 pt-24">
+        <div className="pt-24">
           <div className="grid grid-cols-1 md:grid-cols-2 col-span-2 lg:grid-cols-5 gap-4 max-w-7xl mx-auto text-white">
             <LaunchWeekPrizeCard
               imageUrl="/images/launchweek/seven/keyboard.jpg"

--- a/apps/www/components/LaunchWeek/Releases/LW7/LW7Releases.tsx
+++ b/apps/www/components/LaunchWeek/Releases/LW7/LW7Releases.tsx
@@ -185,7 +185,7 @@ export default function LW7Releases() {
                   <motion.div
                     className={`
                       relative overflow-hidden group/2 flex-1 flex flex-col items-center gap-5 lg:items-start justify-between
-                      basis-1/2 lg:basis-2/3 border rounded-xl h-full py-10 sm:py-14 px-4 sm:px-8 lg:px-10 xs:text-2xl text-xl text-center shadow-lg
+                      basis-1/2 lg:flex-shrink xl:basis-2/3 border rounded-xl h-full py-10 sm:py-14 px-4 sm:px-8 lg:px-10 xs:text-2xl text-xl text-center shadow-lg
                     `}
                     initial="default"
                     animate="default"

--- a/apps/www/components/LaunchWeek/Releases/LW7/LW7Releases.tsx
+++ b/apps/www/components/LaunchWeek/Releases/LW7/LW7Releases.tsx
@@ -72,7 +72,7 @@ export default function LW7Releases() {
 
   return (
     <>
-      <SectionContainer className="!py-0 w-full !px-0">
+      <SectionContainer className="!py-0 w-full !px-0 !max-w-none">
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 scroll-mt-[105px]" id="hackathon">
           <SmallCard
             bgGradient
@@ -106,7 +106,7 @@ export default function LW7Releases() {
                 </span>
               </div>
             </div>
-            <div className="flex gap-2 z-10">
+            <div className="flex w-full sm:w-auto justify-center gap-2 z-10">
               <ChipLink href={'/blog/launch-week-7-hackathon'}>
                 Blog post
                 <div className="bg-[#eeeeee] dark:bg-[#313131] rounded-full inline-block p-1 ml-2">
@@ -146,18 +146,15 @@ export default function LW7Releases() {
                 <span className="text-black dark:text-white mr-2">Join the prize draw</span>
               </div>
             </div>
-            <div className="flex gap-2 z-10">
-              <ChipLink href="#lw-7-prizes">
-                Learn more
-                <div className="bg-[#eeeeee] dark:bg-[#313131] rounded-full inline-block p-1 ml-2">
-                  <PencilSvg />
-                </div>
+            <div className="flex w-full sm:w-auto justify-center gap-2 z-10">
+              <ChipLink href="#lw-7-prizes" className="pr-3 !justify-center">
+                More info
               </ChipLink>
             </div>
           </SmallCard>
         </div>
       </SectionContainer>
-      <SectionContainer className="!pt-0 !w-full !px-0">
+      <SectionContainer className="!pt-0 !w-full !px-0 !max-w-none">
         <Accordion
           type="default"
           openBehaviour="multiple"
@@ -188,7 +185,7 @@ export default function LW7Releases() {
                   <motion.div
                     className={`
                       relative overflow-hidden group/2 flex-1 flex flex-col items-center gap-5 lg:items-start justify-between
-                      basis-1/2 lg:basis-2/3 border rounded-xl h-full p-14 xs:text-2xl text-xl text-center shadow-lg
+                      basis-1/2 lg:basis-2/3 border rounded-xl h-full py-10 sm:py-14 px-4 sm:px-8 lg:px-10 xs:text-2xl text-xl text-center shadow-lg
                     `}
                     initial="default"
                     animate="default"
@@ -253,7 +250,7 @@ export default function LW7Releases() {
                   <motion.div
                     className={`
                       relative overflow-hidden group/3 flex-1 flex flex-col items-center justify-between
-                      basis-1/2 lg:basis-1/3 border rounded-xl h-full bg-no-repeat py-14 lg:px-10 text-2xl bg-contain shadow-lg
+                      basis-1/2 lg:basis-1/3 border rounded-xl h-full bg-no-repeat py-10 sm:py-14 px-4 sm:px-8 lg:px-10 text-2xl bg-contain shadow-lg
                       `}
                     initial="default"
                     animate="default"

--- a/apps/www/components/LaunchWeek/Releases/LW7/LW7Releases.tsx
+++ b/apps/www/components/LaunchWeek/Releases/LW7/LW7Releases.tsx
@@ -72,7 +72,7 @@ export default function LW7Releases() {
 
   return (
     <>
-      <SectionContainer className="!py-0">
+      <SectionContainer className="!py-0 w-full !px-0">
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 scroll-mt-[105px]" id="hackathon">
           <SmallCard
             bgGradient
@@ -157,7 +157,7 @@ export default function LW7Releases() {
           </SmallCard>
         </div>
       </SectionContainer>
-      <SectionContainer className="!pt-0">
+      <SectionContainer className="!pt-0 !w-full !px-0">
         <Accordion
           type="default"
           openBehaviour="multiple"

--- a/apps/www/components/LaunchWeek/Releases/LW7/components/index.tsx
+++ b/apps/www/components/LaunchWeek/Releases/LW7/components/index.tsx
@@ -83,7 +83,7 @@ export const SmallCard = ({
   >
     <div
       className={[
-        'rounded-2xl text-sm px-6 py-4 flex flex-col sm:flex-row justify-between items-center backdrop-blur-md',
+        'rounded-2xl text-sm px-4 sm:px-8 lg:px-10 py-4 flex flex-col sm:flex-row justify-between items-center backdrop-blur-md',
         bgGradient ? styles['lw7-article-card-gradient'] : 'bg-[#1c1c1c99]',
       ].join(' ')}
     >
@@ -143,9 +143,22 @@ export const AccordionHeader = ({ date, day, title, shipped }: any) => {
   )
 }
 
-export const ChipLink = ({ href, children }: { href: string; children: any }) => (
+export const ChipLink = ({
+  href,
+  className,
+  children,
+}: {
+  href: string
+  className?: string
+  children: any
+}) => (
   <Link href={href} target="_blank" rel="noopener">
-    <a className="flex items-center border border-slate-400 bg-gradient-to-r text-black dark:text-white from-[#46444480] to-[#19191980] hover:from-[#4e4e4e80] hover:to-[#19191980] backdrop-blur-sm rounded-full text-sm py-2 pl-3 pr-2">
+    <a
+      className={[
+        'flex justify-between w-full min-h-[43px] sm:w-auto items-center border border-slate-400 bg-gradient-to-r text-black dark:text-white from-[#46444480] to-[#19191980] hover:from-[#4e4e4e80] hover:to-[#19191980] backdrop-blur-sm rounded-full text-sm py-2 pl-3 pr-2',
+        className,
+      ].join(' ')}
+    >
       {children}
     </a>
   </Link>
@@ -167,7 +180,7 @@ export const SectionButtons = ({
   hackernews?: string
 }) => {
   return (
-    <div className="flex gap-2 z-10">
+    <div className="flex w-full md:w-auto justify-center gap-2 z-10">
       {!!blog && (
         <ChipLink href={blog}>
           Blog post

--- a/apps/www/components/LaunchWeek/Releases/LW7/components/index.tsx
+++ b/apps/www/components/LaunchWeek/Releases/LW7/components/index.tsx
@@ -146,14 +146,18 @@ export const AccordionHeader = ({ date, day, title, shipped }: any) => {
 export const ChipLink = ({
   href,
   className,
+  target,
   children,
 }: {
   href: string
   className?: string
+  target?: '_blank' | '_self' | '_parent' | '_top' | 'framename'
   children: any
 }) => (
-  <Link href={href} target="_blank" rel="noopener">
+  <Link href={href}>
     <a
+      target={target ?? '_self'}
+      rel="noopener"
       className={[
         'flex justify-between w-full min-h-[43px] sm:w-auto items-center border border-slate-400 bg-gradient-to-r text-black dark:text-white from-[#46444480] to-[#19191980] hover:from-[#4e4e4e80] hover:to-[#19191980] backdrop-blur-sm rounded-full text-sm py-2 pl-3 pr-2',
         className,
@@ -206,7 +210,7 @@ export const SectionButtons = ({
         </ChipLink>
       )}
       {!!github && (
-        <ChipLink href={github}>
+        <ChipLink href={github} target="_blank">
           View on Github
           <div className="bg-[#eeeeee] dark:bg-[#313131] rounded-full inline-block p-1 ml-2">
             <GithubSvg />
@@ -222,7 +226,7 @@ export const SectionButtons = ({
         </ChipLink>
       )}
       {hackernews && (
-        <ChipLink href={hackernews}>
+        <ChipLink href={hackernews} target="_blank">
           Read more
           <div className="bg-[#eeeeee] dark:bg-[#313131] rounded-full inline-block p-1 ml-2">
             <HackernewsSvg />

--- a/apps/www/components/LaunchWeek/lw7_days.ts
+++ b/apps/www/components/LaunchWeek/lw7_days.ts
@@ -69,7 +69,7 @@ const days: WeekDayProps[] = [
       {
         title: 'Supavisor',
         github: 'https://github.com/supabase/supavisor',
-        // hackernews: 'hackernews_link',
+        hackernews: 'https://news.ycombinator.com/item?id=35501718',
         thumb: '/images/launchweek/seven/day0/supavisor/supavisor-thumb.png',
         bg_layers: [{ img: images['0-supavisor-01'] }, { img: images['0-supavisor-02'] }],
       },

--- a/apps/www/components/Nav/index.tsx
+++ b/apps/www/components/Nav/index.tsx
@@ -112,7 +112,7 @@ const Nav = () => {
 
   const HamburgerButton = (props: HamburgerButtonProps) => (
     <div
-      className="absolute inset-y-0 left-0 flex items-center px-2 lg:hidden"
+      className="absolute inset-y-0 left-0 flex items-center px-4 lg:hidden"
       onClick={() => props.toggleFlyOut()}
     >
       <button

--- a/apps/www/pages/launch-week/index.tsx
+++ b/apps/www/pages/launch-week/index.tsx
@@ -116,7 +116,7 @@ export default function TicketHome({ users }: Props) {
             />
           </div>
 
-          <SectionContainer className="relative !w-full !px-2 max-w-none lg:max-w-[1536px] -mt-48 md:mt-[-460px] z-20 flex flex-col justify-around items-center !py-4 md:!py-8 gap-2 md:gap-4 !mx-auto">
+          <div className="relative !w-full !px-2 sm:max-w-xl md:max-w-2xl lg:max-w-7xl -mt-48 md:mt-[-460px] z-20 flex flex-col justify-around items-center !py-4 md:!py-8 gap-2 md:gap-4 !mx-auto">
             <LW7Releases />
             <div className="w-full flex justify-center py-8 md:py-14 !px-2">
               {supabase && (
@@ -129,7 +129,7 @@ export default function TicketHome({ users }: Props) {
               )}
             </div>
             <LaunchWeekPrizeSection className="pt-10 md:pt-20" />
-          </SectionContainer>
+          </div>
           {users && <TicketBrickWall users={users} />}
         </div>
         <CTABanner />

--- a/apps/www/pages/launch-week/index.tsx
+++ b/apps/www/pages/launch-week/index.tsx
@@ -116,7 +116,7 @@ export default function TicketHome({ users }: Props) {
             />
           </div>
 
-          <div className="relative !w-full !px-2 sm:max-w-xl md:max-w-2xl lg:max-w-7xl -mt-48 md:mt-[-460px] z-20 flex flex-col justify-around items-center !py-4 md:!py-8 gap-2 md:gap-4 !mx-auto">
+          <div className="relative !w-full !px-4 sm:max-w-xl md:max-w-2xl lg:max-w-7xl -mt-48 md:mt-[-460px] z-20 flex flex-col justify-around items-center !py-4 md:!py-8 gap-2 md:gap-4 !mx-auto">
             <LW7Releases />
             <div className="w-full flex justify-center py-8 md:py-14 !px-2">
               {supabase && (

--- a/apps/www/pages/launch-week/index.tsx
+++ b/apps/www/pages/launch-week/index.tsx
@@ -116,7 +116,7 @@ export default function TicketHome({ users }: Props) {
             />
           </div>
 
-          <SectionContainer className="relative w-full -mt-48 md:mt-[-460px] z-20 flex flex-col justify-around items-center !py-4 md:!py-8 gap-2 md:gap-4 !mx-auto">
+          <SectionContainer className="relative !w-full !px-2 max-w-none lg:max-w-[1536px] -mt-48 md:mt-[-460px] z-20 flex flex-col justify-around items-center !py-4 md:!py-8 gap-2 md:gap-4 !mx-auto">
             <LW7Releases />
             <div className="w-full flex justify-center py-8 md:py-14 !px-2">
               {supabase && (

--- a/apps/www/pages/launch-week/tickets/[username].tsx
+++ b/apps/www/pages/launch-week/tickets/[username].tsx
@@ -95,7 +95,7 @@ export default function UsernamePage({ user, users, ogImageUrl }: Props) {
             </div>
             <div className={['bg-lw7-gradient absolute inset-0 z-0', golden && 'gold'].join(' ')} />
           </div>
-          <LaunchWeekPrizeSection className="-mt-20 md:-mt-60" />
+          <LaunchWeekPrizeSection className="-mt-20 md:-mt-60 px-4" />
           <TicketBrickWall users={users} />
         </div>
         <CTABanner />


### PR DESCRIPTION
## What kind of change does this PR introduce?

Launch week landing page changes:
- Less padding in mobile and other viewports in general
- Full width card buttons in mobile viewport
- Removed pencil icon on "more info" cta
- Added link to Supavisor Hackernews article

## What is the current behavior?

Too much padding in mobile

## Additional context

<img width="500" alt="Screenshot 2023-04-10 at 08 27 33" src="https://user-images.githubusercontent.com/25671831/230840980-cc74dcf3-b1a6-4073-bddf-ac5277f88ff0.png">
