### PR TITLE
docs: add info about no possibility to localize error messages in auth ui

### DIFF
--- a/apps/docs/pages/guides/auth/auth-helpers/auth-ui.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/auth-ui.mdx
@@ -322,6 +322,8 @@ const App = () => (
 )
 ```
 
+Currently, translating error messages (e.g. "Invalid credentials") is not supported. Check [related issue.](https://github.com/supabase/auth-ui/issues/86)
+
 export const Page = ({ children }) => <Layout meta={meta} children={children} />
 
 export default Page


### PR DESCRIPTION
The current Supabase Auth UI lacks the ability to translate error messages, which has been a widely expressed concern (refer to https://github.com/supabase/auth-ui/issues/86). This PR intends to highlight this issue and provide a solution to help developers avoid the need to search for answers online. Additionally, I suggest we provide a temporary workaround and ultimately address the root cause of the issue.