### PR TITLE
fix: Remove unnecessary whitespace in header name

### DIFF
--- a/studio/components/interfaces/Database/Hooks/HTTPRequestFields.tsx
+++ b/studio/components/interfaces/Database/Hooks/HTTPRequestFields.tsx
@@ -165,7 +165,7 @@ const HTTPRequestFields = ({
                       onClick={() =>
                         onAddHeader({
                           id: uuidv4(),
-                          name: ' Authorization',
+                          name: 'Authorization',
                           value: `Bearer ${anonKey}`,
                         })
                       }
@@ -183,7 +183,7 @@ const HTTPRequestFields = ({
                       onClick={() =>
                         onAddHeader({
                           id: uuidv4(),
-                          name: ' x-supabase-webhook-source',
+                          name: 'x-supabase-webhook-source',
                           value: `[Use a secret value]`,
                         })
                       }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Currently webhooks don't trigger the Edge Functions when adding the header with the UI.

## What is the new behavior?

Currently webhooks trigger the Edge Functions when adding the header with the UI.

## Additional context

Add any other context or screenshots.
