### PR TITLE
docs: remove dead link

### DIFF
--- a/apps/docs/docs/ref/self-hosting-analytics/introduction.mdx
+++ b/apps/docs/docs/ref/self-hosting-analytics/introduction.mdx
@@ -159,7 +159,6 @@ The self-hosted example is only used as a minimal example on running the entire 
     ### Additional links
 
     - [Source code](https://github.com/logflare/logflare)
-    - [Analytics guides](/docs/guides/analytics) - TODO
     - [OpenAPI docs](https://logflare.app/api/openapi)
     - [Supabase Acquires Logflare](https://supabase.com/blog/supabase-acquires-logflare)
     - [Logflare self-hosting docs](https://docs.logflare.app/self-hosting)


### PR DESCRIPTION
removes analytics guides link