### PR TITLE
fix: add shoutout to python maintainers

### DIFF
--- a/apps/docs/docs/ref/python/introduction.mdx
+++ b/apps/docs/docs/ref/python/introduction.mdx
@@ -19,3 +19,14 @@ hideTitle: true
   changes, invoke Deno Edge Functions, build login and user management functionality, and manage
   large files.
 </div>
+
+<div className="max-w-xl bg-slate-300 px-4 py-2 rounded-md">
+  <p>The Python client library is created and maintained by the Supabase community, and is not an official library. Please be tolerant of areas where the library is still being developed, and — as with all the libraries — feel free to contribute wherever you find issues.</p>
+
+<p>
+  Huge thanks to official maintainers, [anand2312](https://github.com/anand2312/), [dreinon](https://github.com/dreinon), [J0](https://github.com/j0), and [Leynier](https://github.com/leynier).
+</p>
+<p>
+  Shoutout to [timkpaine](https://github.com/timkpaine) for maintaining our Conda libraries as well.
+</p>
+</div>


### PR DESCRIPTION
## What kind of change does this PR introduce?
Adds shoutout to the Python maintainers. 




Visual:
<img width="568" alt="CleanShot 2023-04-12 at 00 30 07@2x" src="https://user-images.githubusercontent.com/8011761/231228664-3b28a8f6-e2e4-4e81-b3dd-8cef5d04ee42.png">

I'm not sure if I should be including myself,since I am on the team atm - will decide tomorrow once wake up
