### PR TITLE
Prevent app crash on auth events

### DIFF
--- a/apps/docs/pages/guides/auth/auth-helpers/remix.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/remix.mdx
@@ -493,7 +493,7 @@ useEffect(() => {
   const {
     data: { subscription },
   } = supabase.auth.onAuthStateChange((event, session) => {
-    if (session?.access_token !== serverAccessToken) {
+    if (event !== "INITIAL_SESSION" && session?.access_token !== serverAccessToken) {
       // server and client are out of sync.
       // Remix recalls active loaders after actions complete
       fetcher.submit(null, {


### PR DESCRIPTION
As of @supabase/gotrue-js  v2.16.0 https://github.com/supabase/gotrue-js/releases/tag/v2.16.0, an INITIAL_SESSION event is emitted whenever a new listener is registered which happens a lot. The result is that with that code example, the HTTP POST request to /handle-supabase-auth is made continuously when signing in or out  which causes the application to stop responding. I found that only submitting that request when the event is different than "INITIAL_SESSION" solves the issue.

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The application stops responding when signing in or out with implementing the code example.

## What is the new behavior?

The application behaves correctly, we can sign in or out of the application without any issue.

## Additional context

Add any other context or screenshots.
