### PR TITLE
fix: telemetry url asPath

### DIFF
--- a/apps/docs/pages/_app.tsx
+++ b/apps/docs/pages/_app.tsx
@@ -64,7 +64,7 @@ function MyApp({ Component, pageProps }: AppPropsWithLayout) {
      * Send page telemetry on first page load
      */
     if (router.isReady) {
-      handlePageTelemetry(router.route)
+      handlePageTelemetry(router.asPath)
     }
   }, [router.isReady])
 

--- a/apps/www/pages/_app.tsx
+++ b/apps/www/pages/_app.tsx
@@ -37,7 +37,7 @@ export default function MyApp({ Component, pageProps }: AppProps) {
      * Send page telemetry on first page load
      */
     if (router.isReady) {
-      handlePageTelemetry(router.route)
+      handlePageTelemetry(router.asPath)
     }
   }, [router.isReady])
 

--- a/studio/components/ui/PageTelemetry.tsx
+++ b/studio/components/ui/PageTelemetry.tsx
@@ -27,7 +27,7 @@ const PageTelemetry: FC = ({ children }) => {
      * if the route is not ready. Don't need to send it will be picked up by router.event above
      */
     if (router.isReady) {
-      handlePageTelemetry(router.route)
+      handlePageTelemetry(router.asPath)
     }
   }, [])
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes the route injected to telemetry by the next/router.

## What is the current behavior?

It was injecting routes like `/blog/[slug]`

## What is the new behavior?

Now it injects `/blog/correct-slug`

## Additional context

<img width="1025" alt="Screenshot 2023-04-12 at 17 40 10" src="https://user-images.githubusercontent.com/25671831/231510027-ee34f608-f65d-4b5d-8b9d-be3934cf5a20.png">
