### PR TITLE
Update broadcast.mdx to include channel creation

### DIFF
--- a/apps/docs/pages/guides/realtime/extensions/broadcast.mdx
+++ b/apps/docs/pages/guides/realtime/extensions/broadcast.mdx
@@ -23,9 +23,9 @@ const { createClient } = require('@supabase/supabase-js')
 
 const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_KEY)
 
-supabase
-  .channel('test')
-  .on('broadcast', { event: 'supa' }, (payload) => console.log(payload))
+const channel = supabase.channel('test')
+
+channel.on('broadcast', { event: 'supa' }, (payload) => console.log(payload))
   .subscribe()
 ```
 
@@ -38,7 +38,9 @@ const { createClient } = require('@supabase/supabase-js')
 
 const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_KEY)
 
-supabase.channel('test').subscribe((status) => {
+const channel = supabase.channel('test')
+
+channel.subscribe((status) => {
   if (status === 'SUBSCRIBED') {
     channel.send({
       type: 'broadcast',
@@ -59,16 +61,15 @@ You can also choose for a client to receive messages that it sent:
 
 ```js
 // Supabase client setup
-
-supabase
-  .channel('test', {
-    config: {
-      broadcast: {
-        self: true,
-      },
+const channel = supabase.channel('test', {
+  config: {
+    broadcast: {
+      self: true,
     },
-  })
-  .on('broadcast', { event: 'supa' }, (payload) => console.log(payload))
+  },
+})
+
+channel.on('broadcast', { event: 'supa' }, (payload) => console.log(payload))
   .subscribe((status) => {
     if (status === 'SUBSCRIBED') {
       channel.send({


### PR DESCRIPTION
If you were to use the doc snippets as currently shown `channel.send` would throw with `channel` not being defined I believe.

## What kind of change does this PR introduce?
Teeny docs update

## What is the current behavior?
Current snippets could introduce errors for people if doing copy/pasta.

## What is the new behavior?
Shows users the line for instantiating a channel.

