### PR TITLE
fix: typo from chucks -> chunks

### DIFF
--- a/apps/www/_blog/2023-04-12-storage-v3-resumable-uploads.mdx
+++ b/apps/www/_blog/2023-04-12-storage-v3-resumable-uploads.mdx
@@ -15,7 +15,7 @@ Supabase Storage is receiving a major upgrade, implementing many of the most req
 
 The key feature: **Resumable Uploads**! With Resumable Uploads, you can continue uploading a file from where you left off, even if you lose internet connectivity or accidentally close your browser tab while uploading.
 
-Resumable uploads divides the file into chucks before uploading them, emitting progress events during upload.
+Resumable uploads divides the file into chunks before uploading them, emitting progress events during upload.
 
 <video width="100%" autoPlay="" loop="" muted="" playsInline="" controls="true">
   <source


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixed a typo in the new Launch Week blog post about storage updates

## What is the current behavior?

'chucks' is meant to be 'chunks' based on the rest of the article

## What is the new behavior?

`chunks`!

## Additional context

Add any other context or screenshots.
