### PR TITLE
docs: Replacing type="website" attributes on html inputs with type="url"

### DIFF
--- a/apps/docs/pages/guides/getting-started/tutorials/with-nextjs.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-nextjs.mdx
@@ -287,7 +287,7 @@ export default function Account({ session }) {
         <label htmlFor="website">Website</label>
         <input
           id="website"
-          type="website"
+          type="url"
           value={website || ''}
           onChange={(e) => setWebsite(e.target.value)}
         />
@@ -417,7 +417,7 @@ export default function Account({ session }: { session: Session }) {
         <label htmlFor="website">Website</label>
         <input
           id="website"
-          type="website"
+          type="url"
           value={website || ''}
           onChange={(e) => setWebsite(e.target.value)}
         />

--- a/apps/docs/pages/guides/getting-started/tutorials/with-nuxt-3.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-nuxt-3.mdx
@@ -192,7 +192,7 @@ async function signOut() {
     </div>
     <div>
       <label for="website">Website</label>
-      <input id="website" type="website" v-model="website" />
+      <input id="website" type="url" v-model="website" />
     </div>
 
     <div>
@@ -414,7 +414,7 @@ async function signOut() {
     </div>
     <div>
       <label for="website">Website</label>
-      <input id="website" type="website" v-model="website" />
+      <input id="website" type="url" v-model="website" />
     </div>
 
     <div>

--- a/apps/docs/pages/guides/getting-started/tutorials/with-react.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-react.mdx
@@ -200,7 +200,7 @@ export default function Account({ session }) {
         <label htmlFor="website">Website</label>
         <input
           id="website"
-          type="website"
+          type="url"
           value={website || ''}
           onChange={(e) => setWebsite(e.target.value)}
         />

--- a/apps/docs/pages/guides/getting-started/tutorials/with-redwoodjs.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-redwoodjs.mdx
@@ -415,7 +415,7 @@ const Account = () => {
             <label htmlFor="website">Website</label>
             <input
               id="website"
-              type="website"
+              type="url"
               value={website || ''}
               onChange={(e) => setWebsite(e.target.value)}
             />

--- a/apps/docs/pages/guides/getting-started/tutorials/with-sveltekit.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-sveltekit.mdx
@@ -176,7 +176,7 @@ Update your `src/routes/+layout.svelte`:
 	import { invalidate } from '$app/navigation'
 	import { onMount } from 'svelte'
 	import type { LayoutData } from './$types'
-	
+
 	export let data: LayoutData
 
 	$: ({ supabase, session } = data)
@@ -353,7 +353,7 @@ Create a new `src/routes/account/+page.svelte` file with the content below.
 
 		<div>
 			<label for="website">Website</label>
-			<input id="website" name="website" type="website" value={form?.website ?? website} />
+			<input id="website" name="website" type="url" value={form?.website ?? website} />
 		</div>
 
 		<div>

--- a/apps/docs/pages/guides/getting-started/tutorials/with-vue-3.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-vue-3.mdx
@@ -209,7 +209,7 @@ async function signOut() {
     </div>
     <div>
       <label for="website">Website</label>
-      <input id="website" type="website" v-model="website" />
+      <input id="website" type="url" v-model="website" />
     </div>
 
     <div>

--- a/examples/user-management/nextjs-ts-user-management/components/Account.tsx
+++ b/examples/user-management/nextjs-ts-user-management/components/Account.tsx
@@ -105,7 +105,7 @@ export default function Account({ session }: { session: Session }) {
         <label htmlFor="website">Website</label>
         <input
           id="website"
-          type="website"
+          type="url"
           value={website || ''}
           onChange={(e) => setWebsite(e.target.value)}
         />

--- a/examples/user-management/nuxt3-user-management/components/Account.vue
+++ b/examples/user-management/nuxt3-user-management/components/Account.vue
@@ -11,7 +11,7 @@
         </div>
         <div>
             <label for="website">Website</label>
-            <input id="website" type="website" v-model="website" />
+            <input id="website" type="url" v-model="website" />
         </div>
 
         <div>

--- a/examples/user-management/react-user-management/src/Account.jsx
+++ b/examples/user-management/react-user-management/src/Account.jsx
@@ -83,7 +83,7 @@ export default function Account({ session }) {
         <label htmlFor="website">Website</label>
         <input
           id="website"
-          type="website"
+          type="url"
           value={website || ''}
           onChange={(e) => setWebsite(e.target.value)}
         />

--- a/examples/user-management/sveltekit-user-management/src/routes/Account.svelte
+++ b/examples/user-management/sveltekit-user-management/src/routes/Account.svelte
@@ -94,7 +94,7 @@
 	</div>
 	<div>
 		<label for="website">Website</label>
-		<input id="website" type="website" bind:value={website} />
+		<input id="website" type="url" bind:value={website} />
 	</div>
 
 	<div>

--- a/examples/user-management/vue3-user-management/src/components/Account.vue
+++ b/examples/user-management/vue3-user-management/src/components/Account.vue
@@ -89,7 +89,7 @@ async function signOut() {
         </div>
         <div>
             <label for="website">Website</label>
-            <input id="website" type="website" v-model="website" />
+            <input id="website" type="url" v-model="website" />
         </div>
 
         <div>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

Currently some of the getting started docs contain HTML input elements with the type "website". This is not a valid html input type, and I believe this is meant to be the "url" type

## What is the current behavior?

In the getting started docs (I noticed it in the vue 3 tutorial [here](https://supabase.com/docs/guides/getting-started/tutorials/with-vue-3#account-page)) the resulting app doesn't perform validation on the user provided "website" field, allowing them to put in any string

## What is the new behavior?

Now when an invalid website is put in, it fails validation and gives a little pop up like this:
![image](https://user-images.githubusercontent.com/45305164/231604059-7421a0a6-0139-4cf8-8fbf-128819c05887.png)

Whereas previously the profile was just updated.

## Additional context

Add any other context or screenshots.
