### PR TITLE
chore: add hackernews link and small tweaks

### DIFF
--- a/apps/www/components/LaunchWeek/7/BlogLinks.tsx
+++ b/apps/www/components/LaunchWeek/7/BlogLinks.tsx
@@ -36,8 +36,8 @@ const BlogLinks = () => {
                 <div className="relative z-10 flex items-center text-lg flex-col-reverse lg:flex-row lg:justify-start gap-2 text-black dark:text-white">
                   <div
                     className={[
-                      'text-transparent bg-clip-text bg-gradient-to-r from-[#F4FFFA] to-[#B7B2C9] drop-shadow-lg',
-                      step.break_thumb_title && 'max-w-[270px]',
+                      'text-transparent bg-clip-text bg-gradient-to-r text-base from-[#F4FFFA] to-[#B7B2C9] drop-shadow-lg',
+                      step.break_thumb_title && 'max-w-[240px]',
                     ].join(' ')}
                   >
                     {step.title}

--- a/apps/www/components/LaunchWeek/Releases/LW7/LW7Releases.tsx
+++ b/apps/www/components/LaunchWeek/Releases/LW7/LW7Releases.tsx
@@ -277,7 +277,7 @@ export default function LW7Releases() {
                         background: `radial-gradient(90% 130px at 80% 0px, #4635A7, transparent)`,
                       }}
                     />
-                    <div className="flex items-center text-center lg:text-left lg: justify-between flex-col-reverse lg:flex-row lg:justify-start gap-2 text-white">
+                    <div className="flex items-center text-center lg:text-left justify-between flex-col-reverse lg:flex-row lg:justify-start gap-2 text-white">
                       <CartTitle>{preRelease.steps[0].title}</CartTitle>
                       <StyledArticleBadge className="lg:ml-2">Guide</StyledArticleBadge>
                     </div>
@@ -401,13 +401,13 @@ export default function LW7Releases() {
                   <motion.div
                     className={`
                       relative overflow-hidden group/2 flex-1 flex flex-col items-center gap-5 lg:items-start justify-between
-                      w-full border border-[#232323] rounded-xl h-full px-8 lg:px-14 py-14 xs:text-2xl text-xl text-center shadow-lg
+                      w-full border border-[#232323] rounded-xl h-full px-4 sm:px-8 lg:px-14 py-14 xs:text-2xl text-xl text-center shadow-lg
                     `}
                     initial="default"
                     animate="default"
                     whileHover="hover"
                   >
-                    <div className="flex items-center text-center lg:text-left lg: justify-between flex-col-reverse lg:flex-row lg:justify-start gap-2 text-white">
+                    <div className="flex items-center text-center lg:text-left justify-between flex-col-reverse lg:flex-row lg:justify-start gap-2 text-white">
                       <CartTitle>{day1.steps[0].title}</CartTitle>
                       <StyledArticleBadge className="lg:ml-2">New</StyledArticleBadge>
                     </div>
@@ -489,13 +489,13 @@ export default function LW7Releases() {
                   <motion.div
                     className={`
                       relative overflow-hidden group/2 flex-1 flex flex-col items-center gap-5 lg:items-start justify-between
-                      w-full border rounded-xl h-full px-8 lg:px-14 py-14 xs:text-2xl text-xl text-center shadow-lg
+                      w-full border rounded-xl h-full px-4 sm:px-8 lg:px-14 py-14 xs:text-2xl text-xl text-center shadow-lg
                     `}
                     initial="default"
                     animate="default"
                     whileHover="hover"
                   >
-                    <div className="flex items-center text-center lg:text-left lg: justify-between flex-col-reverse lg:flex-row lg:justify-start gap-2 text-black dark:text-white">
+                    <div className="flex items-center text-center lg:text-left justify-between flex-col-reverse lg:flex-row lg:justify-start gap-2 text-black dark:text-white">
                       <CartTitle>{day2.steps[0].title}</CartTitle>
                       <StyledArticleBadge className="lg:ml-2">New</StyledArticleBadge>
                     </div>
@@ -577,13 +577,13 @@ export default function LW7Releases() {
                   <motion.div
                     className={`
                       relative overflow-hidden group/2 flex-1 flex flex-col items-center gap-5 lg:items-start justify-between
-                      w-full border rounded-xl h-full px-8 lg:px-14 py-14 xs:text-2xl text-xl text-center shadow-lg
+                      w-full border rounded-xl h-full px-4 sm:px-8 lg:px-14 py-14 xs:text-2xl text-xl text-center shadow-lg
                     `}
                     initial="default"
                     animate="default"
                     whileHover="hover"
                   >
-                    <div className="flex items-center text-center lg:text-left lg: justify-between flex-col-reverse lg:flex-row lg:justify-start gap-2 text-black dark:text-white">
+                    <div className="flex items-center text-center lg:text-left justify-between flex-col-reverse lg:flex-row lg:justify-start gap-2 text-black dark:text-white">
                       <CartTitle>{day3.steps[0].title}</CartTitle>
                       <StyledArticleBadge className="lg:ml-2">Updated</StyledArticleBadge>
                     </div>
@@ -664,13 +664,13 @@ export default function LW7Releases() {
                   <motion.div
                     className={`
                       relative overflow-hidden group/2 flex-1 flex flex-col items-center gap-5 lg:items-start justify-between
-                      w-full border rounded-xl h-full px-8 lg:px-14 py-14 xs:text-2xl text-xl text-center shadow-lg
+                      w-full border rounded-xl h-full px-4 sm:px-8 lg:px-14 py-14 xs:text-2xl text-xl text-center shadow-lg
                     `}
                     initial="default"
                     animate="default"
                     whileHover="hover"
                   >
-                    <div className="flex items-center text-center lg:text-left lg: justify-between flex-col-reverse lg:flex-row lg:justify-start gap-2 text-black dark:text-white">
+                    <div className="flex items-center text-center lg:text-left justify-between flex-col-reverse lg:flex-row lg:justify-start gap-2 text-black dark:text-white">
                       <CartTitle>{day4.steps[0].title}</CartTitle>
                       <StyledArticleBadge className="lg:ml-2">New</StyledArticleBadge>
                     </div>
@@ -678,6 +678,8 @@ export default function LW7Releases() {
                       docs={day4.steps[0].docs}
                       blog={day4.steps[0].blog}
                       video={day4.steps[0].video}
+                      hackernews={day4.steps[0].hackernews}
+                      mobileGrid
                     />
                     {day4.steps[0].bg_layers &&
                       day4.steps[0].bg_layers?.map((layer, i) =>

--- a/apps/www/components/LaunchWeek/Releases/LW7/components/index.tsx
+++ b/apps/www/components/LaunchWeek/Releases/LW7/components/index.tsx
@@ -175,6 +175,7 @@ export const SectionButtons = ({
   github,
   url,
   hackernews,
+  mobileGrid,
 }: {
   blog?: string
   docs?: string
@@ -182,9 +183,15 @@ export const SectionButtons = ({
   github?: string
   url?: string
   hackernews?: string
+  mobileGrid?: boolean
 }) => {
   return (
-    <div className="flex w-full md:w-auto justify-center gap-2 z-10">
+    <div
+      className={[
+        'flex w-full md:w-auto justify-center gap-2 z-10',
+        mobileGrid && 'grid grid-cols-2 gap-2 sm:flex',
+      ].join(' ')}
+    >
       {!!blog && (
         <ChipLink href={blog}>
           Blog post

--- a/apps/www/components/LaunchWeek/lw7_days.ts
+++ b/apps/www/components/LaunchWeek/lw7_days.ts
@@ -222,6 +222,7 @@ const days: WeekDayProps[] = [
         thumb: images['04-sso-thumb'],
         video: 'https://www.youtube.com/watch?v=hAwJeR6mhB0',
         docs: '/docs/guides/auth/sso/auth-sso-saml',
+        hackernews: 'https://news.ycombinator.com/item?id=35555263',
         bg_layers: [
           {
             img: images['04-sso-01'],


### PR DESCRIPTION
## What kind of change does this PR introduce?

Added relevant hackernews link to LW7 SSO card.
Improved some edge-case layouts.

If there are 4 links in the card, it stacks in a grid in mobile:
<img width="499" alt="Screenshot 2023-04-13 at 17 12 45" src="https://user-images.githubusercontent.com/25671831/231805058-ce54c21a-eb56-48cf-a1e3-a54e5b35ed8f.png">
