### PR TITLE
fix: correct the link of dart edge guide

### DIFF
--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
@@ -578,7 +578,7 @@ export const functions = {
           name: 'Connecting directly to Postgres',
           url: '/guides/functions/connect-to-postgres',
         },
-        { name: 'Dart Edge on Supabase', url: '/guides/functions/examples/dart-edge' },
+        { name: 'Dart Edge on Supabase', url: '/guides/functions/dart-edge' },
       ],
     },
     {

--- a/apps/docs/pages/guides/functions/dart-edge.mdx
+++ b/apps/docs/pages/guides/functions/dart-edge.mdx
@@ -8,7 +8,7 @@ export const meta = {
 
 [Dart Edge](https://docs.dartedge.dev/), a project built and maintained by [Invertase](https://invertase.io/), enables Dart code to be run on different edge environments. This guide will walk you through how you can start using Dart Edge to write your backend code using Dart and run it on Supabase.
 
-> ⚠️ WARNING: Dart Edge is an experimental project - it's probably not ready for production usage unless you're okay with living on the 'edge'. Open issues on [Dart Edge repo](https://github.com/invertase/dart_edge) if you find any issues.
+> ⚠️ WARNING: Dart Edge is an experimental project - it's probably not ready for production usage unless you're okay with living on the 'edge'. Open issues on [Dart Edge repo](https://github.com/invertase/dart_edge) if you encounter any issues.
 
 ## **Pre requirements**
 

--- a/apps/docs/pages/guides/functions/dart-edge.mdx
+++ b/apps/docs/pages/guides/functions/dart-edge.mdx
@@ -1,7 +1,7 @@
 import Layout from '~/layouts/DefaultGuideLayout'
 
 export const meta = {
-  id: 'examples-dart-edge',
+  id: 'functions-dart-edge',
   title: 'Dart Edge',
   description: 'Write your functions using Dart.',
 }

--- a/apps/docs/pages/guides/functions/dart-edge.mdx
+++ b/apps/docs/pages/guides/functions/dart-edge.mdx
@@ -6,9 +6,9 @@ export const meta = {
   description: 'Write your functions using Dart.',
 }
 
-[Dart Edge](https://docs.dartedge.dev/) is a project that enables Dart code to be run on different edge environments built by [Invertase](https://invertase.io/). This guide will walk you through how you can start using Dart Edge to write your backend code using Dart and run it on Supabase.
+[Dart Edge](https://docs.dartedge.dev/), a project built and maintained by [Invertase](https://invertase.io/), enables Dart code to be run on different edge environments. This guide will walk you through how you can start using Dart Edge to write your backend code using Dart and run it on Supabase.
 
-> ⚠️ WARNING: Dart Edge is an experimental project - it's probably not ready for production usage unless you're okay with living on the 'edge'.
+> ⚠️ WARNING: Dart Edge is an experimental project - it's probably not ready for production usage unless you're okay with living on the 'edge'. Open issues on [Dart Edge repo](https://github.com/invertase/dart_edge) if you find any issues.
 
 ## **Pre requirements**
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

The URL of Dart Edge guide should have been https://supabase.com/docs/guides/functions/dart-edge, but it is https://supabase.com/docs/guides/functions/examples/dart-edge right now. This PR fixes it. 

No need to add any rewrites for the URL as this guide was just added and there are no external links pointing to the original URL yet.

Also added some notes to make it clear which repo to open issues with when issues occur.

https://docs-c96aky16v-supabase.vercel.app/docs/guides/functions/dart-edge