### PR TITLE
fix: do not submit SQL generate submit prompt unless search is undefined

### DIFF
--- a/packages/ui/src/components/Command/GenerateSQL/GenerateSQL.tsx
+++ b/packages/ui/src/components/Command/GenerateSQL/GenerateSQL.tsx
@@ -200,7 +200,9 @@ const GenerateSQL = () => {
                         <CommandItem
                           type="command"
                           onSelect={() => {
-                            handleSubmit(query)
+                            if (!search) {
+                              handleSubmit(query)
+                            }
                           }}
                           onKeyDown={(e) => e.keyCode === 13 && handleSubmit(query)}
                           forceMount


### PR DESCRIPTION
## What kind of change does this PR introduce?

## What is the new behavior?

— sample generative SQL prompts will not submit if `search` is defined

## Additional context

Add any other context or screenshots.
