### PR TITLE
Improve database guide overview copy

### DIFF
--- a/apps/docs/pages/guides/database/overview.mdx
+++ b/apps/docs/pages/guides/database/overview.mdx
@@ -10,17 +10,6 @@ export const meta = {
 Every Supabase project comes with a full [Postgres](https://www.postgresql.org/) database, a free and open source
 database which is considered one of the world's most stable and advanced databases.
 
-## Postgres or PostgreSQL?
-
-PostgreSQL the database was derived from the POSTGRES Project, a package written at the University of California at Berkeley in 1986.
-This package included a query language called "PostQUEL".
-
-In 1994, Postgres95 was built on top of POSTGRES code, adding an SQL language interpreter as a replacement for PostQUEL.
-Eventually, Postgres95 was renamed to PostgreSQL to reflect the SQL query capability.
-
-After this, many people referred to it as Postgres since it's less prone to confusion. Supabase is all about
-simplicity, so we also refer to it as Postgres.
-
 ## Features
 
 ### Table View
@@ -96,6 +85,19 @@ You can enable Postgres extensions with the click of a button within the Supabas
 </video>
 
 [Learn more](/docs/guides/database/extensions) about all the extensions provided on Supabase.
+
+## Terminology
+
+### Postgres or PostgreSQL?
+
+PostgreSQL the database was derived from the POSTGRES Project, a package written at the University of California at Berkeley in 1986.
+This package included a query language called "PostQUEL".
+
+In 1994, Postgres95 was built on top of POSTGRES code, adding an SQL language interpreter as a replacement for PostQUEL.
+Eventually, Postgres95 was renamed to PostgreSQL to reflect the SQL query capability.
+
+After this, many people referred to it as Postgres since it's less prone to confusion. Supabase is all about
+simplicity, so we also refer to it as Postgres.
 
 ## Tips
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

A section titled "Postgres or PostgreSQL?", is at the start of the guide. This is not what readers are likely to be most interested in on this page, as it's just explaining a decision made about the terminology.

## What is the new behavior?

- The section is moved to near the bottom of the page, so it's still available but doesn't delay important context.
- A new heading of "Terminology" is added to clarify the purpose of the section

## Additional context

-