### PR TITLE
docs(react-auth-ui) fix typo in documentation

### DIFF
--- a/apps/docs/pages/guides/auth/auth-helpers/auth-ui.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/auth-ui.mdx
@@ -41,7 +41,7 @@ const App = () => <Auth supabaseClient={supabase} />
 
 This renders the Auth component without any styling.
 We recommend using one of the predefined themes to style the UI.
-Import the theme you want to use and pass it to the `appearence.theme` prop.
+Import the theme you want to use and pass it to the `appearance.theme` prop.
 
 ```js lines=4,16 title=/src/index.js
 import { Auth } from '@supabase/auth-ui-react'
@@ -109,7 +109,7 @@ There are several ways to customize Auth UI:
 
 ### Predefined themes
 
-Auth UI comes with several themes to customize the appearance. Each predefined theme comes with at least two variations, a `default` variation, and a `dark` variation. You can switch between these themes using the `theme` prop. Import the theme you want to use and pass it to the `appearence.theme` prop.
+Auth UI comes with several themes to customize the appearance. Each predefined theme comes with at least two variations, a `default` variation, and a `dark` variation. You can switch between these themes using the `theme` prop. Import the theme you want to use and pass it to the `appearance.theme` prop.
 
 ```js lines=2,13 title=/src/index.js
 import { createClient } from '@supabase/supabase-js'


### PR DESCRIPTION
## What kind of change does this PR introduce?
Fixed a typo in the documentation for the React Auth UI documentation page


## What is the current behavior?
`appearence` should be spelled `appearance`

Please link any relevant issues here.

## What is the new behavior?
The React Auth UI documentation page will have the correct spelling of `appearance` instead of `appearence`

## Additional context
[Link to Issue](https://github.com/supabase/supabase/issues/13747)

