### PR TITLE
fix: Correct typo in Auth Managing User data Documentation

### DIFF
--- a/apps/docs/pages/guides/auth/managing-user-data.mdx
+++ b/apps/docs/pages/guides/auth/managing-user-data.mdx
@@ -36,7 +36,7 @@ Primary keys are **guaranteed not to change**. Columns, indices, constraints or 
 
 ## Deleting Users
 
-You may delete users directly or via the management console at Authentication > Users. Note that deleting a user from the `auth.users` table does not automatically sign out a user. As Supabase makes use of JSON Web Tokens (JWT), a user's JWT will remain "valid" until it has expired. Should you wish to immediately revoke access for a user, do considering making use of a Row Level Security policy as described below.
+You may delete users directly or via the management console at Authentication > Users. Note that deleting a user from the `auth.users` table does not automatically sign out a user. As Supabase makes use of JSON Web Tokens (JWT), a user's JWT will remain "valid" until it has expired. Should you wish to immediately revoke access for a user, do consider making use of a Row Level Security policy as described below.
 
 <Admonition type="caution">
 You cannot delete a user if they are the owner of any objects in Supabase Storage.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixed a typo in the Auth Managing User Data documentation.

## What is the current behavior?

The documentation has this sentence ` Should you wish to immediately revoke access for a user, do considering making use of a Row Level Security policy as described below.`
## What is the new behavior?

The documentation will now display  Should you wish to immediately revoke access for a user, do consider making use of a Row Level Security policy as described below.`

## Additional context

[Link to issue](https://github.com/supabase/supabase/issues/13758)
