### PR TITLE
docs(cli): clarify npx usage when installing via npm

### DIFF
--- a/apps/docs/pages/guides/cli.mdx
+++ b/apps/docs/pages/guides/cli.mdx
@@ -25,6 +25,12 @@ Install the CLI as dev dependency via [npm](https://www.npmjs.com/package/supaba
 npm install supabase --save-dev
 ```
 
+Run the CLI by prefixing each command with `npx` (only applicable when installing through `npm`):
+
+```sh
+npx supabase <command>
+```
+
 </TabPanel>
 <TabPanel id="macos" label="macOS">
 


### PR DESCRIPTION
Adds clarity around prefixing `supabase` CLI with `npx` when installing via `npm`:
![image](https://user-images.githubusercontent.com/4133076/232548778-6ef96f6c-2602-42fc-bbd0-8e46dd482c3a.png)

Will help new users facing `supabase: command not found` issues.