### PR TITLE
feat: api docs copy codeblock on click

### DIFF
--- a/studio/components/to-be-cleaned/SimpleCodeBlock.tsx
+++ b/studio/components/to-be-cleaned/SimpleCodeBlock.tsx
@@ -80,7 +80,10 @@ const SimpleCodeBlock: FC<any> = ({ children, className: languageClassName, meta
     >
       {({ className, style, tokens, getLineProps, getTokenProps }) => {
         return (
-          <div className="Code codeBlockWrapper group cursor-pointer" onClick={() => handleCopyCode(children)}>
+          <div
+            className="Code codeBlockWrapper group cursor-pointer"
+            onClick={() => handleCopyCode(children)}
+          >
             <pre ref={target} className={`codeBlock ${className}`}>
               {tokens.map((line, i) => {
                 const lineProps = getLineProps({ line, key: i })

--- a/studio/components/to-be-cleaned/SimpleCodeBlock.tsx
+++ b/studio/components/to-be-cleaned/SimpleCodeBlock.tsx
@@ -12,6 +12,7 @@ import Clipboard from 'clipboard'
 import rangeParser from 'parse-numeric-range'
 import { Button } from 'ui'
 import { copyToClipboard } from 'lib/helpers'
+import { useStore } from 'hooks'
 
 const highlightLinesRangeRegex = /{([\d,-]+)}/
 const prism = {
@@ -21,6 +22,7 @@ const prism = {
 
 const SimpleCodeBlock: FC<any> = ({ children, className: languageClassName, metastring }) => {
   const [showCopied, setShowCopied] = useState(false)
+  const { ui } = useStore()
   const target = useRef(null)
   const button = useRef(null)
   let highlightLines: any = []
@@ -63,6 +65,10 @@ const SimpleCodeBlock: FC<any> = ({ children, className: languageClassName, meta
 
   const handleCopyCode = (code: any) => {
     copyToClipboard(code, () => setShowCopied(true))
+    ui.setNotification({
+      category: 'success',
+      message: 'Sample code has been copied',
+    })
   }
 
   return (
@@ -74,7 +80,7 @@ const SimpleCodeBlock: FC<any> = ({ children, className: languageClassName, meta
     >
       {({ className, style, tokens, getLineProps, getTokenProps }) => {
         return (
-          <div className="Code codeBlockWrapper group">
+          <div className="Code codeBlockWrapper group cursor-pointer" onClick={() => handleCopyCode(children)}>
             <pre ref={target} className={`codeBlock ${className}`}>
               {tokens.map((line, i) => {
                 const lineProps = getLineProps({ line, key: i })


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase Studio > API Docs > Codeblocks

## What is the current behavior?

The was highlighted on [Twitter](https://twitter.com/blackevilgoblin/status/1633512086314655748?s=46&t=tLKfO7YE1D93n5ce5Pshuw)

## What is the new behavior?

When you hover over the code block you are now able to click on the code block and copy the code straight to your clipboard:


https://user-images.githubusercontent.com/22655069/232578758-362cec02-6445-414d-8747-1d5acbbe5456.mov