### PR TITLE
docs(performance-tuning): fix typo

### DIFF
--- a/apps/docs/pages/guides/platform/performance.mdx
+++ b/apps/docs/pages/guides/platform/performance.mdx
@@ -118,7 +118,7 @@ limit 100;
 
 This query will show you statistics about queries ordered by the cumulative total execution time. It shows the total time the query has spent running as well as the proportion of total execution time the query has taken up.
 
-Queries which are the most time consuming are not necessarily bad, you may have a very effiecient and frequently ran queries that end up taking a large total % time, but it can be useful to help spot queries that are taking up more time than they should.
+Queries which are the most time consuming are not necessarily bad, you may have a very efficient and frequently ran queries that end up taking a large total % time, but it can be useful to help spot queries that are taking up more time than they should.
 
 ### Hit rate
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes a typo at https://supabase.com/docs/guides/platform/performance from `effiecient` to `efficient`

## What is the current behavior?

https://supabase.com/docs/guides/platform/performance documentation link displays the incorrect spelling of `efficient`

## What is the new behavior?

https://supabase.com/docs/guides/platform/performance shows the correct spelling of `efficient`

