### PR TITLE
docs: fix typo supabase-js install script for workers example

### DIFF
--- a/examples/with-cloudflare-workers/README.md
+++ b/examples/with-cloudflare-workers/README.md
@@ -17,7 +17,7 @@ In order to send a JSON response, we first stringify the object we get back from
 **Install Supabase JS**
 
 ```bash
-npm i @supabase-supabase-js
+npm i @supabase/supabase-js
 ```
 
 **Create a Cloudflare secret**


### PR DESCRIPTION


## What kind of change does this PR introduce?

Documentation typo fix

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Change from `@supabase-supabase-js` to `@supabase/supabase-js`

