### PR TITLE
docs: fix typo and add clarity for Oauth glossary term

### DIFF
--- a/apps/docs/pages/guides/resources/glossary.mdx
+++ b/apps/docs/pages/guides/resources/glossary.mdx
@@ -54,7 +54,7 @@ Nonce means number used once. In reality though, it is a unique and difficult to
 
 ## OAuth
 
-OAuth is a protocol allowing third-party applications to request and receive authorization from their users. It is typically used to implement social login, and serves as a base for enterprise single-sign on in the OIDC protocol. Applications can request various level of access, and this includes some user identification information at least (name, email address, user identification number).
+OAuth is a protocol allowing third-party applications to request and receive authorization from their users. It is typically used to implement social login, and serves as a base for enterprise single-sign on in the OIDC protocol. Applications can request different levels of access, including basic user identification information such as name, email address, and user ID.
 
 ## OIDC
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

This fixes a typo and rewords a sentence for clarity at [Supabase Glossary](https://supabase.com/docs/guides/resources/glossary#oauth).

## What is the current behavior?

Currently, the sentence displays as `Applications can request various level of access, and this includes some user identification information at least (name, email address, user identification number).` 

## What is the new behavior?

With my change, I fix a typo (`various level of access...` to `various levels of access...`) and add more clarity to the sentence by changing it to `Applications can request different levels of access, including basic user identification information such as name, email address, and user ID.`
