### PR TITLE
fix: add back sql editor context copy item

### DIFF
--- a/studio/components/interfaces/SQLEditor/UtilityPanel/Results.tsx
+++ b/studio/components/interfaces/SQLEditor/UtilityPanel/Results.tsx
@@ -1,10 +1,25 @@
-import DataGrid from '@supabase/react-data-grid'
+import DataGrid, { Column } from '@supabase/react-data-grid'
 import { useKeyboardShortcuts } from 'hooks'
 import { copyToClipboard } from 'lib/helpers'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
+import { Item, Menu, useContextMenu } from 'react-contexify'
+import { createPortal } from 'react-dom'
+import { IconClipboard } from 'ui'
 
-const Results = ({ rows }: { rows: readonly any[] }) => {
+const Results = ({ id, rows }: { id: string; rows: readonly any[] }) => {
+  const SQL_CONTEXT_EDITOR_ID = 'sql-context-menu-' + id
+
   const [cellPosition, setCellPosition] = useState<any>(undefined)
+
+  function onCopyCell() {
+    if (columns && cellPosition) {
+      const { idx, rowIdx } = cellPosition
+      const colKey = columns[idx].key
+      const cellValue = rows[rowIdx]?.[colKey] ?? ''
+      const value = formatClipboardValue(cellValue)
+      copyToClipboard(value)
+    }
+  }
 
   useKeyboardShortcuts(
     {
@@ -20,6 +35,8 @@ const Results = ({ rows }: { rows: readonly any[] }) => {
     ['INPUT', 'TEXTAREA'] as any
   )
 
+  const { show: showContextMenu } = useContextMenu()
+
   if (rows.length <= 0) {
     return (
       <div className="bg-table-header-light dark:bg-table-header-dark">
@@ -29,12 +46,23 @@ const Results = ({ rows }: { rows: readonly any[] }) => {
   }
 
   const formatter = (column: any, row: any) => {
-    return <span className="font-mono text-xs">{JSON.stringify(row[column])}</span>
+    return (
+      <span
+        className="font-mono text-xs w-full"
+        onContextMenu={(e) =>
+          showContextMenu(e, {
+            id: SQL_CONTEXT_EDITOR_ID,
+          })
+        }
+      >
+        {JSON.stringify(row[column])}
+      </span>
+    )
   }
   const columnRender = (name: string) => {
     return <div className="flex h-full items-center justify-center font-mono">{name}</div>
   }
-  const columns = Object.keys(rows[0]).map((key) => ({
+  const columns: Column<any, unknown>[] = Object.keys(rows[0]).map((key) => ({
     key,
     name: key,
     formatter: ({ row }: any) => formatter(key, row),
@@ -47,23 +75,34 @@ const Results = ({ rows }: { rows: readonly any[] }) => {
     setCellPosition(position)
   }
 
-  function onCopyCell() {
-    if (columns && cellPosition) {
-      const { idx, rowIdx } = cellPosition
-      const colKey = columns[idx].key
-      const cellValue = rows[rowIdx]?.[colKey] ?? ''
-      const value = formatClipboardValue(cellValue)
-      copyToClipboard(value)
-    }
-  }
+  const [mounted, setMounted] = useState(false)
+  useEffect(() => {
+    if (!mounted) setMounted(true)
+  }, [])
 
   return (
-    <DataGrid
-      columns={columns}
-      rows={rows}
-      style={{ height: '100%' }}
-      onSelectedCellChange={onSelectedCellChange}
-    />
+    <>
+      <DataGrid
+        columns={columns}
+        rows={rows}
+        style={{ height: '100%' }}
+        onSelectedCellChange={onSelectedCellChange}
+      />
+      {mounted &&
+        createPortal(
+          <Menu
+            id={SQL_CONTEXT_EDITOR_ID}
+            animation={false}
+            className="!bg-scale-300 border border-scale-500"
+          >
+            <Item onClick={onCopyCell}>
+              <IconClipboard size="tiny" />
+              <span className="ml-2 text-xs">Copy cell content</span>
+            </Item>
+          </Menu>,
+          document.body
+        )}
+    </>
   )
 }
 

--- a/studio/components/interfaces/SQLEditor/UtilityPanel/Results.tsx
+++ b/studio/components/interfaces/SQLEditor/UtilityPanel/Results.tsx
@@ -40,7 +40,9 @@ const Results = ({ id, rows }: { id: string; rows: readonly any[] }) => {
   if (rows.length <= 0) {
     return (
       <div className="bg-table-header-light dark:bg-table-header-dark">
-        <p className="m-0 border-0 px-6 py-4 font-mono text-sm">Success. No rows returned</p>
+        <p className="m-0 border-0 px-6 py-4 font-mono text-sm">
+          Success. No rows returned
+        </p>
       </div>
     )
   }
@@ -60,7 +62,11 @@ const Results = ({ id, rows }: { id: string; rows: readonly any[] }) => {
     )
   }
   const columnRender = (name: string) => {
-    return <div className="flex h-full items-center justify-center font-mono">{name}</div>
+    return (
+      <div className="flex h-full items-center justify-center font-mono">
+        {name}
+      </div>
+    )
   }
   const columns: Column<any, unknown>[] = Object.keys(rows[0]).map((key) => ({
     key,
@@ -90,11 +96,7 @@ const Results = ({ id, rows }: { id: string; rows: readonly any[] }) => {
       />
       {mounted &&
         createPortal(
-          <Menu
-            id={SQL_CONTEXT_EDITOR_ID}
-            animation={false}
-            className="!bg-scale-300 border border-scale-500"
-          >
+          <Menu id={SQL_CONTEXT_EDITOR_ID} animation={false}>
             <Item onClick={onCopyCell}>
               <IconClipboard size="tiny" />
               <span className="ml-2 text-xs">Copy cell content</span>

--- a/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityTabResults.tsx
+++ b/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityTabResults.tsx
@@ -38,7 +38,7 @@ const UtilityTabResults = ({ id, isExecuting }: UtilityTabResultsProps) => {
 
   return (
     <div className="h-full">
-      <Results rows={result.rows} />
+      <Results id={id} rows={result.rows} />
     </div>
   )
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix/core

## What is the new behaviour?

Adds back the copy context menu:
<img width="574" alt="Screenshot 2023-04-18 at 11 06 13 pm" src="https://user-images.githubusercontent.com/10985857/232786642-d708fb7a-a324-46df-b1fa-2c945b10a856.png">
