### PR TITLE
docs(functions): fix broken link to 'connect to postgres'

### DIFF
--- a/apps/docs/pages/guides/functions.mdx
+++ b/apps/docs/pages/guides/functions.mdx
@@ -94,7 +94,7 @@ export const examples = [
   {
     name: 'Connect to Postgres',
     description: `Connecting to Postgres from Edge Functions.`,
-    href: '/guides/functions/examples/connect-to-postgres',
+    href: '/guides/functions/connect-to-postgres',
   },
   {
     name: 'Github Actions',


### PR DESCRIPTION
Fixes https://github.com/supabase/supabase/issues/13830
