### PR TITLE
AICommand: remove superfluous message sent to server

### DIFF
--- a/packages/ui/src/components/Command/AiCommand.tsx
+++ b/packages/ui/src/components/Command/AiCommand.tsx
@@ -188,6 +188,7 @@ export function useAiChat({
           messages: messages
             .filter(({ status }) => status === MessageStatus.Complete)
             .map(({ role, content }) => ({ role, content }))
+            .slice(0, -1)
             .concat({ role: MessageRole.User, content: messageTemplate(query) }),
         }),
       })


### PR DESCRIPTION
Since in the last step we `concat` the `query` enhanced by `messageTemplate`, we don't need to additionally send the message without the engineered prompt, too.

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
