### PR TITLE
docs(storage) Storage Uploads docs typo

### DIFF
--- a/apps/docs/pages/guides/storage/uploads.mdx
+++ b/apps/docs/pages/guides/storage/uploads.mdx
@@ -10,7 +10,7 @@ export const meta = {
 Supabase Storage provides two methods for uploading files:
 
 - Standard Uploads
-- Resuamble Uploads
+- Resumable Uploads
 
 ## Standard Upload
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update for typo in storage uploads documentation.

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
