### PR TITLE
fix: functions auth schema

### DIFF
--- a/studio/components/interfaces/Database/Functions/FunctionsList/FunctionList.tsx
+++ b/studio/components/interfaces/Database/Functions/FunctionsList/FunctionList.tsx
@@ -24,11 +24,12 @@ const FunctionList: FC<Props> = ({
 }) => {
   const router = useRouter()
   const { ui, meta } = useStore()
-  const functions = meta.functions.list((fn: any) => !meta.excludedSchemas.includes(fn.schema))
+  const schemasToShow = ['public', 'auth']
+  const functions = meta.functions.list((fn: any) => schemasToShow.includes(fn.schema))
   const filteredFunctions = functions.filter((x: any) =>
     includes(x.name.toLowerCase(), filterString.toLowerCase())
   )
-  const _functions = filteredFunctions.filter((x) => x.schema == schema)
+  const _functions = filteredFunctions.filter((x: any) => x.schema == schema)
   const isApiDocumentAvailable = schema == 'public'
   const projectRef = ui.selectedProject?.ref
 

--- a/studio/components/interfaces/Database/Functions/FunctionsList/FunctionsList.tsx
+++ b/studio/components/interfaces/Database/Functions/FunctionsList/FunctionsList.tsx
@@ -24,10 +24,11 @@ const FunctionsList: FC<Props> = ({
 }) => {
   const { meta } = useStore()
   const [filterString, setFilterString] = useState<string>('')
-
+  const schemasToShow = ['public', 'auth']
   const functions = meta.functions.list(
-    (fn: PostgresFunction) => !meta.excludedSchemas.includes(fn.schema)
+    (fn: PostgresFunction) => schemasToShow.includes(fn.schema)
   )
+  console.log('functions: ', functions);
   const filteredFunctions = functions.filter((x: PostgresFunction) =>
     includes(x.name?.toLowerCase(), filterString.toLowerCase())
   )


### PR DESCRIPTION
## What kind of change does this PR introduce?

Studio > Database > Functions

## What is the current behavior?

The current functions list only shows functions which are in the `public` schema.

## What is the new behavior?

The view now shows both `public` and `auth`:

<img width="1440" alt="Screenshot 2023-04-20 at 18 52 52" src="https://user-images.githubusercontent.com/22655069/233448497-9ea6d25a-5ff0-40d8-865f-e3db7fac35f2.png">

## Additional context

The `auth` schema shows functions which are system related and I could not find any keys on the arrays to hide so not sure how this can be handled?

Closes #13854
