### PR TITLE
(docs): update delete confirmation text

### DIFF
--- a/studio/components/to-be-cleaned/Storage/DeleteBucketModal.tsx
+++ b/studio/components/to-be-cleaned/Storage/DeleteBucketModal.tsx
@@ -36,7 +36,12 @@ const DeleteBucketModal: FC<Props> = ({
       onCancel={onSelectCancel}
       confirmString={bucket.name}
       loading={deleting}
-      text={`Your bucket named ${bucket.name} and all its contents will be deleted.`}
+      text={
+        <>
+          `Your bucket <span className="font-bold">{bucket.name}</span> and its contents will be
+          permanently deleted.`
+        </>
+      }
       alert="You cannot recover this bucket once it is deleted!"
       confirmLabel={`Delete bucket ${bucket.name}`}
     />

--- a/studio/components/to-be-cleaned/Storage/DeleteBucketModal.tsx
+++ b/studio/components/to-be-cleaned/Storage/DeleteBucketModal.tsx
@@ -36,7 +36,7 @@ const DeleteBucketModal: FC<Props> = ({
       onCancel={onSelectCancel}
       confirmString={bucket.name}
       loading={deleting}
-      text={`This will delete your bucket called ${bucket.name}.`}
+      text={`Your bucket named ${bucket.name} and all its contents will be deleted.`}
       alert="You cannot recover this bucket once it is deleted!"
       confirmLabel={`Delete bucket ${bucket.name}`}
     />


### PR DESCRIPTION
## What kind of change does this PR introduce?

Updates delete confirmation text.

## What is the current behavior?

Currently, it displays `This will delete your bucket called {bucketName}`

## What is the new behavior?

With my update, it will display `Your bucket named {bucketName} and all its contents will be deleted.`

## Additional context

[Linked issue](https://github.com/supabase/supabase/issues/13873)
