### PR TITLE
Update docker-compose.yml to fix typo "false" /docker/docker-compose.yml

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -251,7 +251,7 @@ services:
       SUPABASE_ANON_KEY: ${ANON_KEY}
       SUPABASE_SERVICE_ROLE_KEY: ${SERVICE_ROLE_KEY}
       SUPABASE_DB_URL: postgresql://postgres:${POSTGRES_PASSWORD}@{POSTGRES_DB}:${POSTGRES_PORT}/${POSTGRES_DB}"
-      VERIFY_JWT: false
+      VERIFY_JWT: "false"
     ports:
       - ${FUNCTIONS_HTTP_PORT}:9000/tcp
     volumes:


### PR DESCRIPTION
## What kind of change does this PR introduce?

fix typo "false" /docker/docker-compose.yml

```
ERROR: The Compose file './docker-compose.yml' is invalid because:
services.functions.environment.VERIFY_JWT contains false, which is an invalid type, it should be a string, number, or a null
```

## What is the current behavior?

``docker-compose up -d`` fails until fixed

## What is the new behavior?

After the change, ``docker-compose up -d`` succeeds

## Additional context

![image](https://user-images.githubusercontent.com/11604783/233564978-c092778c-cbde-4cf2-88cd-a50c8175269d.png)
