### PR TITLE
fix: studio toast outside interaction

### DIFF
--- a/studio/components/interfaces/Database/Functions/CreateFunction.tsx
+++ b/studio/components/interfaces/Database/Functions/CreateFunction.tsx
@@ -363,6 +363,12 @@ const CreateFunction: FC<CreateFunctionProps> = ({ func, visible, setVisible }) 
         className="hooks-sidepanel mr-0 transform transition-all duration-300 ease-in-out"
         loading={_localState.loading}
         onConfirm={handleSubmit}
+        onInteractOutside={(event) => {
+          const isToast = (event.target as Element)?.closest('#toast')
+          if (isToast) {
+            event.preventDefault()
+          }
+        }}
       >
         <CreateFunctionContext.Provider value={_localState}>
           <div className="mt-4 space-y-10">

--- a/studio/components/interfaces/Database/Roles/CreateRolePanel.tsx
+++ b/studio/components/interfaces/Database/Roles/CreateRolePanel.tsx
@@ -81,6 +81,12 @@ const CreateRolePanel: FC<Props> = ({ visible, onClose }) => {
           </Button>
         </div>
       }
+      onInteractOutside={(event) => {
+        const isToast = (event.target as Element)?.closest('#toast')
+        if (isToast) {
+          event.preventDefault()
+        }
+      }}
     >
       <Form
         validateOnBlur

--- a/studio/components/interfaces/Database/Triggers/CreateTrigger.tsx
+++ b/studio/components/interfaces/Database/Triggers/CreateTrigger.tsx
@@ -336,6 +336,12 @@ const CreateTrigger: FC<CreateTriggerProps> = ({ trigger, visible, setVisible })
         }
         loading={_localState.loading}
         onConfirm={handleSubmit}
+        onInteractOutside={(event) => {
+          const isToast = (event.target as Element)?.closest('#toast')
+          if (isToast) {
+            event.preventDefault()
+          }
+        }}
       >
         {hasPublicTables ? (
           <div className="">


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase Studio > Database > Functions|Roles|Triggers

## What is the current behavior?

When you interact with a toast from the side panel you will get the on cancel confirmation appear.

## What is the new behavior?

When you now interact with the toast the on cancel confirmation will not appear and you can continue to edit:


https://user-images.githubusercontent.com/22655069/233738799-331af960-bccf-47e2-b44b-ed1688d4d951.mov

Also found this on both Roles and Triggers as well.

## Additional context

Closes #13713 
