### PR TITLE
docs(belong typo) in Many-to-many joins example

### DIFF
--- a/apps/docs/pages/guides/api/joins-and-nesting.mdx
+++ b/apps/docs/pages/guides/api/joins-and-nesting.mdx
@@ -127,7 +127,7 @@ GET https://[REF].supabase.co/rest/v1/countries?select=id,name,cities(id,name)
 
 ## Many-to-many joins
 
-The Serverless APIs will detect many-to-many joins. For example, if you have a database which stored teams of users (where each user could below to many teams):
+The Serverless APIs will detect many-to-many joins. For example, if you have a database which stored teams of users (where each user could belong to many teams):
 
 ```sql
 create table


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs typo fix - on the Querying Joins and Nested Tables page there was a type (below should be belong) - https://supabase.com/docs/guides/api/joins-and-nesting

## What is the current behavior?

N/A

## What is the new behavior?

Typo fixed

## Additional context

N/A
