### PR TITLE
fix: announcement banner destination

### DIFF
--- a/packages/ui/src/layout/banners/Announcement.Countdown.tsx
+++ b/packages/ui/src/layout/banners/Announcement.Countdown.tsx
@@ -27,7 +27,6 @@ function CountdownBanner() {
   const { pathname } = useRouter()
   const isLaunchWeekPage = pathname === '/launch-week'
   const isLaunchWeekSection = pathname.includes('launch-week')
-  const basePath = typeof window !== 'undefined' ? window.location.origin : ''
 
   const renderer = ({ days, hours, minutes, seconds, completed }: any) => {
     if (completed) {
@@ -36,11 +35,9 @@ function CountdownBanner() {
         <div className="w-full flex gap-3 md:gap-6 items-center justify-center">
           <p>Supabase Launch Week 7</p>
           <div>
-            <Link href={`${basePath}/launch-week`}>
-              <a className="bg-white text-xs px-1.5 md:px-2.5 py-1 rounded-full text-[#9E44EF] shadow-none hover:shadow-mg cursor-pointer">
-                Explore
-              </a>
-            </Link>
+            <div className="bg-white text-xs px-1.5 md:px-2.5 py-1 rounded-full text-[#9E44EF] shadow-none hover:shadow-mg cursor-pointer">
+              Explore
+            </div>
           </div>
         </div>
       )
@@ -64,11 +61,9 @@ function CountdownBanner() {
           </div>
           {!isLaunchWeekPage && (
             <div className="hidden md:block">
-              <Link href={`${basePath}/launch-week`}>
-                <a className="bg-white text-xs px-1.5 md:px-2.5 py-1 rounded-full text-[#9E44EF] shadow-none hover:shadow-mg cursor-pointer">
-                  Get your ticket
-                </a>
-              </Link>
+              <div className="bg-white text-xs px-1.5 md:px-2.5 py-1 rounded-full text-[#9E44EF] shadow-none hover:shadow-mg cursor-pointer">
+                Get your ticket
+              </div>
             </div>
           )}
         </div>

--- a/packages/ui/src/layout/banners/data/Announcement.json
+++ b/packages/ui/src/layout/banners/data/Announcement.json
@@ -2,6 +2,6 @@
   "show": true,
   "text": "Supabase Launch Week 7",
   "launchDate": "2023-04-10T07:00:00.000-07:00",
-  "link": "/launch-week",
+  "link": "https://supabase.com/launch-week",
   "badge": "Get your ticket"
 }


### PR DESCRIPTION
Fixes Announcement banner destination url.

## What is the current behavior?

Wrong `basePath` skews navigation.
