### PR TITLE
fix: openai-pgvector embedding example function

### DIFF
--- a/apps/www/_blog/2023-02-03-openai-embeddings-postgres-vector.mdx
+++ b/apps/www/_blog/2023-02-03-openai-embeddings-postgres-vector.mdx
@@ -104,7 +104,7 @@ Soon we're going to need to perform a similarity search over these embeddings. L
 ```sql
 create or replace function match_documents (
   query_embedding vector(1536),
-  similarity_threshold float,
+  match_threshold float,
   match_count int
 )
 returns table (
@@ -117,12 +117,12 @@ as $$
 begin
   return query
   select
-    id,
-    content,
+    documents.id,
+    documents.content,
     1 - (documents.embedding <=> query_embedding) as similarity
   from documents
-  where 1 - (documents.embedding <=> query_embedding) > similarity_threshold
-  order by documents.embedding <=> query_embedding
+  where 1 - (documents.embedding <=> query_embedding) > match_threshold
+  order by similarity desc
   limit match_count;
 end;
 $$;


### PR DESCRIPTION
Fix the function argument names in the pgvector example from `similarity_threshold` to `match_threshold` to be consistent with the typescript example below.

Remove the ambiguity with the `id` and `content` row names by adding the prefix `documents`.

Clean up the order by using the `similarity` column instead of the raw expression.