### PR TITLE
Zero downtime embeddings refresh + auto refresh via CI

### DIFF
--- a/.github/workflows/og_images.yml
+++ b/.github/workflows/og_images.yml
@@ -14,7 +14,7 @@ jobs:
 
     env:
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-      PROJECT_ID: ${{ secrets.PROJECT_ID }}
+      PROJECT_ID: ${{ secrets.OG_IMAGE_SUPABASE_PROJECT_ID }}
 
     steps:
       - name: Check out repo

--- a/.github/workflows/search.yml
+++ b/.github/workflows/search.yml
@@ -6,9 +6,10 @@ on:
       - master
       - feat/zero-downtime-embeddings-refresh
     paths:
+      - '.github/workflows/search.yml'
+      - 'supabase/migrations/**'
       - 'apps/docs/**'
       - 'spec/**'
-      - '.github/workflows/search.yml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/search.yml
+++ b/.github/workflows/search.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - feat/zero-downtime-embeddings-refresh
     paths:
       - '.github/workflows/search.yml'
       - 'supabase/migrations/**'

--- a/.github/workflows/search.yml
+++ b/.github/workflows/search.yml
@@ -1,0 +1,37 @@
+name: Generate Embeddings for Search
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'apps/docs/**'
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    env:
+      OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+      PROJECT_ID: ${{ secrets.SEARCH_SUPABASE_PROJECT_ID }}
+      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SEARCH_SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SEARCH_SUPABASE_SERVICE_ROLE_KEY }}
+
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v3
+
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Download dependencies
+        working-directory: ./apps/docs
+        run: npm ci
+
+      - name: Refresh embeddings
+        working-directory: ./apps/docs
+        run: npx run embeddings

--- a/.github/workflows/search.yml
+++ b/.github/workflows/search.yml
@@ -4,8 +4,10 @@ on:
   push:
     branches:
       - master
+      - feat/zero-downtime-embeddings-refresh
     paths:
       - 'apps/docs/**'
+      - 'spec/**'
   workflow_dispatch:
 
 jobs:
@@ -29,8 +31,10 @@ jobs:
           node-version: 18
 
       - name: Download dependencies
-        working-directory: ./apps/docs
         run: npm ci
+
+      - name: Run migrations
+        run: npx supabase db push --project-ref $PROJECT_ID
 
       - name: Refresh embeddings
         working-directory: ./apps/docs

--- a/.github/workflows/search.yml
+++ b/.github/workflows/search.yml
@@ -21,6 +21,7 @@ jobs:
       PROJECT_ID: ${{ secrets.SEARCH_SUPABASE_PROJECT_ID }}
       NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SEARCH_SUPABASE_URL }}
       SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SEARCH_SUPABASE_SERVICE_ROLE_KEY }}
+      SUPABASE_DB_PASSWORD: ${{ secrets.SEARCH_SUPABASE_DB_PASSWORD }}
 
     steps:
       - name: Check out repo

--- a/.github/workflows/search.yml
+++ b/.github/workflows/search.yml
@@ -43,4 +43,4 @@ jobs:
 
       - name: Refresh embeddings
         working-directory: ./apps/docs
-        run: npx run embeddings
+        run: npm run embeddings

--- a/.github/workflows/search.yml
+++ b/.github/workflows/search.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - 'apps/docs/**'
       - 'spec/**'
+      - '.github/workflows/search.yml'
   workflow_dispatch:
 
 jobs:
@@ -33,8 +34,11 @@ jobs:
       - name: Download dependencies
         run: npm ci
 
+      - name: Link Supabase project
+        run: npx supabase link --project-ref $PROJECT_ID
+
       - name: Run migrations
-        run: npx supabase db push --project-ref $PROJECT_ID
+        run: npx supabase db push
 
       - name: Refresh embeddings
         working-directory: ./apps/docs

--- a/apps/docs/.gitignore
+++ b/apps/docs/.gitignore
@@ -12,6 +12,7 @@
 .env.local
 .env.development.local
 .env.test.local
+.env.staging.local
 .env.production.local
 
 npm-debug.log*

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -94,6 +94,7 @@
     "ui": "*",
     "unist-builder": "^3.0.1",
     "unist-util-filter": "^4.0.1",
+    "uuid": "^9.0.0",
     "valtio": "^1.7.6"
   },
   "devDependencies": {

--- a/apps/docs/pages/guides/auth/phone-login/twilio.mdx
+++ b/apps/docs/pages/guides/auth/phone-login/twilio.mdx
@@ -1,4 +1,5 @@
 import Layout from '~/layouts/DefaultGuideLayout'
+
 export const meta = {
   id: 'auth-twilio',
   title: 'Phone Auth with Twilio',
@@ -308,33 +309,35 @@ To make use of WhatsApp OTP, please complete the following steps:
 - Submit a template via the [Twilio Guide For Submitting WhatsApp templates](https://www.twilio.com/docs/whatsapp/tutorial/send-whatsapp-notification-messages-templates#creating-message-templates-and-submitting-them-for-approval)
 
 <Admonition type="caution">
-The message template submitted to Twilio must exactly match the SMS Body entered on the Supabase dashboard.
+  The message template submitted to Twilio must exactly match the SMS Body entered on the Supabase
+  dashboard.
 </Admonition>
 
 The sign in process with WhatsApp is similar to the sign in process for SMS. Do note the additional `whatsapp` parameter added:
 
 ```js
-const {data, error } = await supabase.auth.signInWithOtp({
-    phone: '+57336567365',
-    options: {
-      channel:'whatsapp'
-    }
- })
+const { data, error } = await supabase.auth.signInWithOtp({
+  phone: '+57336567365',
+  options: {
+    channel: 'whatsapp',
+  },
+})
 ```
 
 You can also sign up with `whatsapp` as a channel:
 
 ```js
-const {data, error }= await supabase.auth.signUp({
-   phone: '+57336567365',
-   password: 'testsupabasenow',
-   options: {
-     channel:'whatsapp',
-   }
+const { data, error } = await supabase.auth.signUp({
+  phone: '+57336567365',
+  password: 'testsupabasenow',
+  options: {
+    channel: 'whatsapp',
+  },
 })
 ```
 
 There is no change in the verification process, you should continue to use the `sms` type for verification
+
 ```js
 // After receiving a WhatsApp OTP
 let { data, error } = await supabase.auth.verifyOtp({

--- a/apps/docs/scripts/search/generate-embeddings.ts
+++ b/apps/docs/scripts/search/generate-embeddings.ts
@@ -242,6 +242,8 @@ async function generateEmbeddings() {
     }
   }
 
+  console.log(`Removing old pages and their sections`)
+
   // Delete pages that have been removed (and their sections via cascade)
   const { error: deletePageError } = await supabaseClient
     .from('page')

--- a/apps/docs/scripts/search/generate-embeddings.ts
+++ b/apps/docs/scripts/search/generate-embeddings.ts
@@ -100,11 +100,17 @@ async function generateEmbeddings() {
           }
         }
 
-        // No content update required
-        // Update this page to the latest refresh version & timestamp
+        // No content/embedding update required on this page
+        // Update other meta info
         const { error: updatePageError } = await supabaseClient
           .from('page')
-          .update({ version: refreshVersion, last_refresh: refreshDate })
+          .update({
+            type,
+            source,
+            meta,
+            version: refreshVersion,
+            last_refresh: refreshDate,
+          })
           .filter('id', 'eq', existingPage.id)
 
         if (updatePageError) {
@@ -156,6 +162,8 @@ async function generateEmbeddings() {
             source,
             meta,
             parent_page_id: parentPage?.id,
+            version: refreshVersion,
+            last_refresh: refreshDate,
           },
           { onConflict: 'path' }
         )

--- a/apps/docs/scripts/search/sources/markdown.ts
+++ b/apps/docs/scripts/search/sources/markdown.ts
@@ -110,7 +110,8 @@ export function processMdxForSearch(content: string): ProcessedMdx {
   })
 
   const meta = extractMetaExport(mdxTree)
-  const serializableMeta: Json = JSON.parse(JSON.stringify(meta))
+
+  const serializableMeta: Json = meta && JSON.parse(JSON.stringify(meta))
 
   // Remove all MDX elements from markdown
   const mdTree = filter(

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,6 +89,7 @@
         "ui": "*",
         "unist-builder": "^3.0.1",
         "unist-util-filter": "^4.0.1",
+        "uuid": "^9.0.0",
         "valtio": "^1.7.6"
       },
       "devDependencies": {
@@ -591,6 +592,14 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "apps/docs/node_modules/uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "apps/docs/node_modules/valtio": {
@@ -49780,7 +49789,7 @@
         "@types/react": "^17.0.37",
         "@types/react-dom": "^17.0.11",
         "config": "*",
-        "react-use": "*",
+        "react-use": "^17.4.0",
         "tsconfig": "*",
         "typescript": "^4.5.3"
       },
@@ -51542,6 +51551,7 @@
         "ui": "*",
         "unist-builder": "^3.0.1",
         "unist-util-filter": "^4.0.1",
+        "uuid": "^9.0.0",
         "valtio": "^1.7.6"
       },
       "dependencies": {
@@ -51876,6 +51886,11 @@
             "@types/unist": "^2.0.0",
             "unist-util-is": "^4.0.0"
           }
+        },
+        "uuid": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+          "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
         },
         "valtio": {
           "version": "1.7.6",
@@ -66373,7 +66388,7 @@
         "config": "*",
         "configcat-js": "^7.0.0",
         "dayjs": "^1.11.0",
-        "eslint-config-next": "*",
+        "eslint-config-next": "^13.3.0",
         "file-saver": "^2.0.5",
         "generate-password": "^1.7.0",
         "graphql": "^16.6.0",

--- a/supabase/migrations/20230421193603_page_version.sql
+++ b/supabase/migrations/20230421193603_page_version.sql
@@ -1,0 +1,3 @@
+alter table "public"."page"
+add "version" uuid,
+add "last_refresh" timestamptz;


### PR DESCRIPTION
Refresh our search embeddings without causing downtime.

The missing piece was accounting for deletions. Adds a `version` `uuid` column to track which pages have been added/updated so that we know which old pages need to be removed.

Adds a GitHub Actions config to:
- run migrations
- re-run embeddings when docs change in `master`

Tested and runs successfully:
https://github.com/supabase/supabase/actions/runs/4790561456/jobs/8519847395