### PR TITLE
Fixing issue #13873, updating the delete bucket message

### DIFF
--- a/studio/components/to-be-cleaned/Storage/DeleteBucketModal.tsx
+++ b/studio/components/to-be-cleaned/Storage/DeleteBucketModal.tsx
@@ -37,7 +37,7 @@ const DeleteBucketModal: FC<Props> = ({
       confirmString={bucket.name}
       loading={deleting}
       text={`This will delete your bucket called ${bucket.name}.`}
-      alert="You cannot recover this bucket once it is deleted!"
+      alert="all the contents of the bucket will be deleted and can't be recovered!"
       confirmLabel={`Delete bucket ${bucket.name}`}
     />
   )


### PR DESCRIPTION
## What kind of change does this PR introduce?

changes the delete bucket message

## What is the current behavior?

Currently, it displays This will delete your bucket called {bucketName}

## What is the new behavior?

after the update it will display  This will delete your bucket called {bucketName} ,all it's content will be deleted and cannot be recovered

## Additional context
#13873

