### PR TITLE
Remove alpha warning

### DIFF
--- a/studio/components/interfaces/Database/Functions/FunctionsList/FunctionsList.tsx
+++ b/studio/components/interfaces/Database/Functions/FunctionsList/FunctionsList.tsx
@@ -63,7 +63,6 @@ const FunctionsList: FC<Props> = ({
             disabled={!canCreateFunctions}
             disabledMessage="You need additional permissions to create functions"
           >
-            <AlphaPreview />
             <p className="text-sm text-scale-1100">
               PostgreSQL functions, also known as stored procedures, is a set of SQL and procedural
               commands such as declarations, assignments, loops, flow-of-control, etc.


### PR DESCRIPTION
We removed the ALPHA badge from the menu item, but this Alert is still there. 

<img width="940" alt="CleanShot 2023-04-24 at 21 46 34@2x" src="https://user-images.githubusercontent.com/105593/234143138-3829741d-6645-4031-a1ef-7ebfcc3b8c18.png">
