### PR TITLE
chore: Refactor for LogEventChart, chart empty value auto-fill

### DIFF
--- a/studio/components/interfaces/Settings/Logs/LogEventChart.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogEventChart.tsx
@@ -1,111 +1,29 @@
-import BarChart from 'components/ui/Charts/BarChart'
+import BarChart, { BarChartProps } from 'components/ui/Charts/BarChart'
 import { EventChartData, isUnixMicro, LogData, unixMicroToIsoTimestamp } from '.'
-import { useMemo } from 'react'
 
 interface Props {
-  data?: EventChartData[]
+  data: EventChartData[]
   onBarClick: (isoTimestamp: string) => void
 }
 
-const LogEventChart: React.FC<Props> = ({ data, onBarClick }) => {
-  // TODO: remove once endpoint returns iso timestamp directly
-  const transformedData = useMemo(() => {
-    return data?.map((d) => {
-      const iso = isUnixMicro(d.timestamp) ? unixMicroToIsoTimestamp(d.timestamp) : d.timestamp
-
-      return {
-        ...d,
-        timestamp: iso,
-      }
-    })
-  }, [JSON.stringify(data)])
-
-  if (!transformedData) return null
-
-  return (
-    <BarChart
-      minimalHeader
-      size="tiny"
-      yAxisKey="count"
-      xAxisKey="timestamp"
-      data={transformedData}
-      title="Logs / Time"
-      onBarClick={(v?: { activePayload?: { payload: any }[] }) => {
-        if (!v || !v?.activePayload?.[0]?.payload) return
-        const unixOrIsoTimestamp = v.activePayload[0].payload.timestamp
-        const isoTimestamp = isUnixMicro(unixOrIsoTimestamp)
-          ? unixMicroToIsoTimestamp(unixOrIsoTimestamp)
-          : unixOrIsoTimestamp
-        // 60s before
-        onBarClick(isoTimestamp)
-      }}
-      customDateFormat="MMM D, HH:mm:s"
-    />
-  )
-}
-
-// const useAggregated = (data: LogData[]) => {
-//   const truncateToMinute = (micro: number) => Math.floor(micro / 1000 / 1000 / 60) * 60
-//   const truncateToHour = (micro: number) => Math.floor(micro / 1000 / 1000 / 60 / 60) * 60 * 60
-//   const getDiffMinute = (currentTimestamp: number, olderTimestamp: number) =>
-//     Math.round((currentTimestamp - olderTimestamp) / 1000 / 60)
-//   const getDiffHour = (currentTimestamp: number, olderTimestamp: number) =>
-//     Math.round((currentTimestamp - olderTimestamp) / 1000 / 60 / 60)
-//   const diffMultiplierMinute = (v: number) => v * 60
-//   const diffMultiplierHour = (v: number) => v * 60 * 60
-//   return useMemo(() => {
-//     const oldest = data[data.length - 1]
-//     if (!oldest) return
-//     const latest = data[0]
-//     const oldestDayjs = dayjs(oldest.timestamp / 1000)
-//     const latestDayjs = dayjs(latest.timestamp / 1000)
-//     let truncFunc = truncateToMinute
-//     let getDiff = getDiffMinute
-//     let diffMultiplier = diffMultiplierMinute
-//     if (Math.abs(oldestDayjs.diff(latestDayjs, 'day', true)) > 0.25) {
-//       truncFunc = truncateToHour
-//       getDiff = getDiffHour
-//       diffMultiplier = diffMultiplierHour
-//     }
-
-//     const countMap = data
-//       .map((d) => {
-//         //   truncate to per-minute
-//         return { ...d, timestamp: truncateToMinute(d.timestamp) }
-//       })
-//       .reduce((acc, d) => {
-//         if (acc[d.timestamp]) {
-//           acc[d.timestamp] = acc[d.timestamp] + 1
-//         } else {
-//           acc[d.timestamp] = 1
-//         }
-//         return acc
-//       }, {} as TimestampMap)
-
-//     // Add in additional data points for empty minutes
-//     const oldestEvent = data[data.length - 1]
-//     if (!oldestEvent) return []
-//     const currentTimestamp = new Date().getTime()
-//     const oldestTimestampMicro = oldestEvent.timestamp
-//     const latestTimestamp = truncFunc(data[0]['timestamp'])
-//     const diff = getDiff(currentTimestamp, oldestTimestampMicro / 1000)
-//     for (const toAdd of Array.from(Array(diff).keys())) {
-//       const tsToCheck = truncFunc(oldestTimestampMicro) + diffMultiplier(toAdd)
-//       if (!(tsToCheck in countMap) && tsToCheck <= latestTimestamp) {
-//         countMap[tsToCheck] = 0
-//       }
-//     }
-
-//     let aggregated = []
-//     for (const [key, value] of Object.entries(countMap)) {
-//       const v: number = Number(key)
-//       aggregated.push({
-//         timestamp: key,
-//         timestampMicro: v * 1000 * 1000,
-//         count: value,
-//       })
-//     }
-//     return aggregated.sort((a, b) => a.timestampMicro - b.timestampMicro)
-//   }, [JSON.stringify(data)])
-// }
+const LogEventChart: React.FC<Props> = ({ data, onBarClick }) => (
+  <BarChart
+    minimalHeader
+    size="tiny"
+    yAxisKey="count"
+    xAxisKey="timestamp"
+    data={data as unknown as BarChartProps['data']}
+    title="Logs / Time"
+    onBarClick={(v?: { activePayload?: { payload: any }[] }) => {
+      if (!v || !v?.activePayload?.[0]?.payload) return
+      const unixOrIsoTimestamp = v.activePayload[0].payload.timestamp
+      const isoTimestamp = isUnixMicro(unixOrIsoTimestamp)
+        ? unixMicroToIsoTimestamp(unixOrIsoTimestamp)
+        : unixOrIsoTimestamp
+      // 60s before
+      onBarClick(isoTimestamp)
+    }}
+    customDateFormat="MMM D, HH:mm:s"
+  />
+)
 export default LogEventChart

--- a/studio/components/interfaces/Settings/Logs/LogEventChart.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogEventChart.tsx
@@ -1,12 +1,12 @@
 import BarChart, { BarChartProps } from 'components/ui/Charts/BarChart'
 import { EventChartData, isUnixMicro, LogData, unixMicroToIsoTimestamp } from '.'
 
-interface Props {
+export interface LogEventChartProps {
   data: EventChartData[]
   onBarClick: (isoTimestamp: string) => void
 }
 
-const LogEventChart: React.FC<Props> = ({ data, onBarClick }) => (
+const LogEventChart = ({ data, onBarClick }: LogEventChartProps) => (
   <BarChart
     minimalHeader
     size="tiny"

--- a/studio/components/interfaces/Settings/Logs/LogEventChart.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogEventChart.tsx
@@ -1,5 +1,4 @@
-import { BarChart } from 'components/to-be-cleaned/Charts/ChartRenderer'
-import dayjs from 'dayjs'
+import BarChart from 'components/ui/Charts/BarChart'
 import { EventChartData, isUnixMicro, LogData, unixMicroToIsoTimestamp } from '.'
 import { useMemo } from 'react'
 
@@ -12,29 +11,25 @@ const LogEventChart: React.FC<Props> = ({ data, onBarClick }) => {
   // TODO: remove once endpoint returns iso timestamp directly
   const transformedData = useMemo(() => {
     return data?.map((d) => {
-      const iso = isUnixMicro(d.timestamp)
-        ? unixMicroToIsoTimestamp(d.timestamp)
-        : dayjs(d.timestamp).toISOString()
+      const iso = isUnixMicro(d.timestamp) ? unixMicroToIsoTimestamp(d.timestamp) : d.timestamp
 
       return {
         ...d,
         timestamp: iso,
-        // needed for bar chart
-        // TODO: remove once bar chart is refactored
-        period_start: iso,
       }
     })
   }, [JSON.stringify(data)])
 
-  if (!data) return null
+  if (!transformedData) return null
 
   return (
     <BarChart
       minimalHeader
-      chartSize="tiny"
+      size="tiny"
+      yAxisKey="count"
+      xAxisKey="timestamp"
       data={transformedData}
-      attribute="count"
-      label="Logs / Time"
+      title="Logs / Time"
       onBarClick={(v?: { activePayload?: { payload: any }[] }) => {
         if (!v || !v?.activePayload?.[0]?.payload) return
         const unixOrIsoTimestamp = v.activePayload[0].payload.timestamp
@@ -45,7 +40,6 @@ const LogEventChart: React.FC<Props> = ({ data, onBarClick }) => {
         onBarClick(isoTimestamp)
       }}
       customDateFormat="MMM D, HH:mm:s"
-      noDataMessage={''}
     />
   )
 }

--- a/studio/components/interfaces/Settings/Logs/Logs.utils.ts
+++ b/studio/components/interfaces/Settings/Logs/Logs.utils.ts
@@ -1,12 +1,14 @@
 import { Filters, LogData, LogsEndpointParams, LogsTableName, SQL_FILTER_TEMPLATES } from '.'
 import dayjs, { Dayjs } from 'dayjs'
-import { get } from 'lodash'
+import { get, isEqual } from 'lodash'
 import { StripeSubscription } from 'components/interfaces/Billing'
 import { useMonaco } from '@monaco-editor/react'
 import logConstants from 'shared-data/logConstants'
 import BackwardIterator from 'components/ui/CodeEditor/Providers/BackwardIterator'
-import { uniqBy } from 'lodash'
+import uniqBy from 'lodash/uniqBy'
 import { useEffect } from 'react'
+import utc from 'dayjs/plugin/utc'
+dayjs.extend(utc)
 
 /**
  * Convert a micro timestamp from number/string to iso timestamp
@@ -228,13 +230,22 @@ export const genChartQuery = (
 ) => {
   const [startOffset, trunc] = calcChartStart(params)
   const where = _genWhereStatement(table, filters)
+
+  let joins = 'cross join unnest(t.metadata) as metadata'
+  if (table === LogsTableName.EDGE) {
+    joins += ' \n  cross join unnest(metadata.request) as request'
+    joins += ' \n  cross join unnest(metadata.response) as response'
+  } else if (table === LogsTableName.POSTGRES) {
+    joins += ' \n  cross join unnest(metadata.parsed) as parsed'
+  }
+
   return `
 SELECT
   timestamp_trunc(t.timestamp, ${trunc}) as timestamp,
   count(t.timestamp) as count
 FROM
   ${table} t
-  cross join unnest(t.metadata) as metadata
+  ${joins}
   ${
     where
       ? where + ` and t.timestamp > '${startOffset.toISOString()}'`
@@ -348,4 +359,65 @@ export const useEditorHints = () => {
       }
     }
   }, [monaco])
+}
+
+/**
+ * Assumes that all timestamps are in ISO-8601 UTC timezone.
+ *
+ * min/max are the datetime strings that extend beyond the given timeseries data.
+ */
+export const fillTimeseries = (
+  timeseriesData: any[],
+  timestampKey: string,
+  valueKey: string,
+  defaultValue: number,
+  min?: string,
+  max?: string
+) => {
+  if (timeseriesData.length <= 1 && !(min || max)) return timeseriesData
+  const dates: unknown[] = timeseriesData.map((datum) => dayjs.utc(datum[timestampKey]))
+
+  const maxDate = max ? dayjs.utc(max) : dayjs.utc(Math.max.apply(null, dates as number[]))
+  const minDate = min ? dayjs.utc(min) : dayjs.utc(Math.min.apply(null, dates as number[]))
+
+  const truncationSample = timeseriesData.length > 0 ? timeseriesData[0][timestampKey] : min || max
+  const truncation = getTimestampTruncation(truncationSample)
+
+  let newData = timeseriesData.map((datum) => {
+    const iso = dayjs.utc(datum[timestampKey]).toISOString()
+    datum[timestampKey] = iso
+    return datum
+  })
+
+  const diff = maxDate.diff(minDate, truncation as dayjs.UnitType)
+  for (let i = 0; i <= diff; i++) {
+    const dateToMaybeAdd = minDate.add(i, truncation as dayjs.ManipulateType)
+    if (!dates.find((d) => isEqual(d, dateToMaybeAdd))) {
+      newData.push({
+        [timestampKey]: dateToMaybeAdd.toISOString(),
+        [valueKey]: defaultValue,
+      })
+    }
+  }
+
+  return newData
+}
+
+export const getTimestampTruncation = (datetime: string): 'second' | 'minute' | 'hour' | 'day' => {
+  const values = ['second', 'minute', 'hour', 'day'].map((key) =>
+    dayjs(datetime).get(key as dayjs.UnitType)
+  )
+  const zeroCount = values.reduce((acc, value) => {
+    if (value === 0) {
+      acc += 1
+    }
+    return acc
+  }, 0)
+  let truncation = {
+    0: 'second' as const,
+    1: 'minute' as const,
+    2: 'hour' as const,
+    3: 'day' as const,
+  }[zeroCount]!
+  return truncation
 }

--- a/studio/components/interfaces/Settings/Logs/Logs.utils.ts
+++ b/studio/components/interfaces/Settings/Logs/Logs.utils.ts
@@ -7,8 +7,6 @@ import logConstants from 'shared-data/logConstants'
 import BackwardIterator from 'components/ui/CodeEditor/Providers/BackwardIterator'
 import uniqBy from 'lodash/uniqBy'
 import { useEffect } from 'react'
-import utc from 'dayjs/plugin/utc'
-dayjs.extend(utc)
 
 /**
  * Convert a micro timestamp from number/string to iso timestamp
@@ -383,7 +381,7 @@ export const fillTimeseries = (
   const truncationSample = timeseriesData.length > 0 ? timeseriesData[0][timestampKey] : min || max
   const truncation = getTimestampTruncation(truncationSample)
 
-  let newData = timeseriesData.map((datum) => {
+  const newData = timeseriesData.map((datum) => {
     const iso = dayjs.utc(datum[timestampKey]).toISOString()
     datum[timestampKey] = iso
     return datum
@@ -413,7 +411,7 @@ export const getTimestampTruncation = (datetime: string): 'second' | 'minute' | 
     }
     return acc
   }, 0)
-  let truncation = {
+  const truncation = {
     0: 'second' as const,
     1: 'minute' as const,
     2: 'hour' as const,

--- a/studio/components/interfaces/Settings/Logs/LogsPreviewer.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogsPreviewer.tsx
@@ -191,9 +191,9 @@ export const LogsPreviewer: React.FC<Props> = ({
         }
       >
         <div className={condensedLayout ? 'px-4' : ''}>
-          {showChart && (
+          {!isLoading && showChart && (
             <LogEventChart
-              data={!isLoading && eventChartData ? eventChartData : undefined}
+              data={ eventChartData }
               onBarClick={(isoTimestamp) => {
                 handleSearch('event-chart-bar-click', {
                   query: filters.search_query as string,

--- a/studio/components/interfaces/Settings/Logs/LogsPreviewer.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogsPreviewer.tsx
@@ -193,7 +193,7 @@ export const LogsPreviewer: React.FC<Props> = ({
         <div className={condensedLayout ? 'px-4' : ''}>
           {!isLoading && showChart && (
             <LogEventChart
-              data={ eventChartData }
+              data={eventChartData}
               onBarClick={(isoTimestamp) => {
                 handleSearch('event-chart-bar-click', {
                   query: filters.search_query as string,

--- a/studio/hooks/analytics/useFillTimeseriesSorted.ts
+++ b/studio/hooks/analytics/useFillTimeseriesSorted.ts
@@ -10,6 +10,6 @@ const useFillTimeseriesSorted = (...args: Parameters<typeof fillTimeseries>) => 
     return filled.sort((a, b) => {
       return (new Date(a[args[1]]) as any) - (new Date(b[args[1]]) as any)
     })
-  }, [JSON.stringify(args[0])])
+  }, [JSON.stringify(args[0]), ...args])
 }
 export default useFillTimeseriesSorted

--- a/studio/hooks/analytics/useFillTimeseriesSorted.ts
+++ b/studio/hooks/analytics/useFillTimeseriesSorted.ts
@@ -1,0 +1,15 @@
+import { fillTimeseries } from 'components/interfaces/Settings/Logs'
+import { useMemo } from 'react'
+
+/**
+ * Convenience hook for memoized filling of timeseries data.
+ */
+const useFillTimeseriesSorted = (...args: Parameters<typeof fillTimeseries>) => {
+  return useMemo(() => {
+    const filled = fillTimeseries(...args)
+    return filled.sort((a, b) => {
+      return (new Date(a[args[1]]) as any) - (new Date(b[args[1]]) as any)
+    })
+  }, [JSON.stringify(args[0])])
+}
+export default useFillTimeseriesSorted

--- a/studio/hooks/analytics/useFillTimeseriesSorted.ts
+++ b/studio/hooks/analytics/useFillTimeseriesSorted.ts
@@ -6,6 +6,9 @@ import { useMemo } from 'react'
  */
 const useFillTimeseriesSorted = (...args: Parameters<typeof fillTimeseries>) => {
   return useMemo(() => {
+    const [data, timestampKey] = args
+    if (!data[0]?.[timestampKey]) return data;
+
     const filled = fillTimeseries(...args)
     return filled.sort((a, b) => {
       return (new Date(a[args[1]]) as any) - (new Date(b[args[1]]) as any)

--- a/studio/hooks/analytics/useLogsPreview.tsx
+++ b/studio/hooks/analytics/useLogsPreview.tsx
@@ -189,8 +189,9 @@ function useLogsPreview(
     'timestamp',
     'count',
     0,
-    params.iso_timestamp_start,
-    params.iso_timestamp_end
+    params.iso_timestamp_start ,
+    // default to current time if not set
+    params.iso_timestamp_end || new Date().toISOString()
   )
 
   return [

--- a/studio/hooks/analytics/useTimeseriesUnixToIso.ts
+++ b/studio/hooks/analytics/useTimeseriesUnixToIso.ts
@@ -1,0 +1,21 @@
+import { isUnixMicro, unixMicroToIsoTimestamp } from 'components/interfaces/Settings/Logs'
+import { useMemo } from 'react'
+
+/**
+ * Convenience hook for converting timeseries timestamp from unix microsecond to iso
+ *
+ * memoized
+ */
+const useTimeseriesUnixToIso = (data: any[], timestampKey: string) => {
+  return useMemo(() => {
+    // check if need to convert or not
+    if (data.length === 0) return data
+    if (!isUnixMicro(data[0][timestampKey])) return data
+
+    return data?.map((d) => {
+      d[timestampKey] = unixMicroToIsoTimestamp(d[timestampKey])
+      return d
+    })
+  }, [JSON.stringify(data)])
+}
+export default useTimeseriesUnixToIso

--- a/studio/tests/pages/projects/Logs.utils.test.js
+++ b/studio/tests/pages/projects/Logs.utils.test.js
@@ -1,11 +1,13 @@
 import {
   ensureNoTimestampConflict,
+  fillTimeseries,
   genChartQuery,
   genDefaultQuery,
   LogsTableName,
   SQL_FILTER_TEMPLATES,
 } from 'components/interfaces/Settings/Logs'
 import dayjs from 'dayjs'
+import { isEqual } from 'lodash'
 
 describe.each(Object.values(LogsTableName))('%s', (table) => {
   const templates = SQL_FILTER_TEMPLATES[table]
@@ -98,3 +100,57 @@ test.each([
   expect(result[0]).toEqual(expected[0])
   expect(result[1]).toEqual(expected[1])
 })
+
+// test for log trunc filling
+test.each([
+  {
+    // truncate timestamp string from bigquery
+    case: 'bq utc timestamp, truncated minutely',
+    data: [
+      { timestamp: '2023-04-26T17:18:00', count: 123 },
+      { timestamp: '2023-04-26T17:20:00', count: 123 },
+    ],
+    // expected
+    len: 3,
+    includes: [{ timestamp: '2023-04-26T17:19:00.000Z', count: 0 }],
+  },
+  // hourly truncation
+  {
+    case: 'bq timestamp truncated hourly, different options',
+    data: [
+      { period: '2023-04-26T17:00:00.000Z', value: 123 },
+      { period: '2023-04-26T20:00:00.000Z', value: 123 },
+    ],
+    // expected
+    len: 4,
+    defaultVal: 1,
+    valKey: 'value',
+    tsKey: 'period',
+    includes: [
+      { period: '2023-04-26T18:00:00.000Z', value: 1 },
+      { period: '2023-04-26T19:00:00.000Z', value: 1 },
+    ],
+  },
+  // fill beyong data min/max
+  {
+    case: 'fill beyond min/max',
+    data: [],
+    len: 3,
+    min: '2023-04-26T18:00:00.000Z',
+    max: '2023-04-26T20:00:00.000Z',
+    includes: [
+      { timestamp: '2023-04-26T18:00:00.000Z', count: 0 },
+      { timestamp: '2023-04-26T19:00:00.000Z', count: 0 },
+      { timestamp: '2023-04-26T20:00:00.000Z', count: 0 },
+    ],
+  },
+])(
+  'fillTimeseries : $case',
+  ({ data, len, includes, min, max, tsKey = 'timestamp', valKey = 'count', defaultVal = 0 }) => {
+    const result = fillTimeseries(data, tsKey, valKey, defaultVal, min, max)
+    expect(result.length).toEqual(len)
+    for (const inc of includes) {
+      expect(result.find((d) => isEqual(d, inc))).toBeTruthy()
+    }
+  }
+)

--- a/studio/tests/pages/projects/LogsPreviewer.test.js
+++ b/studio/tests/pages/projects/LogsPreviewer.test.js
@@ -347,7 +347,7 @@ test('log event chart hide', async () => {
     return { result: [] }
   })
   render(<LogsPreviewer projectRef="123" tableName={LogsTableName.EDGE} />)
-  await screen.findByText(/Logs \/ Time/)
+  await screen.findByText(/No data/)
   const toggle = await screen.findByText(/Chart/)
   userEvent.click(toggle)
   await expect(screen.findByText('Events')).rejects.toThrow()


### PR DESCRIPTION
This PR focuses on refactoring the LogEventChart and cleaning it up, as well as client-side timestamp filling for timeseries data. The utility functions in this PR will then be used throughout the app for timeseries display consistency. As empty values are usually not returned as 0 in our queries, this ensures that each datapoint on each truncated timestamp is appropriately set at 0.

I have also added logic to allow for min/max date filling, so this means that the bar chart widths will no longer vary and will be fixed width based on the given intervals.

This PR is needed for adding logic for ensuring self-hosted charts will be able to display charts correctly without regressions, where the ProjectUsage charts and the function metrics charts are affected.

- [x] refactor and clean up log event chart
- add in chart empty timestamp auto-fill
  - [x] LogEventChart

This PR also fixes a filtering bug in the logs editor for request filtering. [ticket](https://www.notion.so/supabase/Function-log-summary-chart-display-error-b775c8a30c4a4e349d3444b4c04c22dd?pvs=4) here.


https://user-images.githubusercontent.com/22714384/234835542-49a1793a-a461-4bd4-b143-575e4b2814b7.mov


Ticket: [main](https://www.notion.so/supabase/autofill-charts-data-with-empty-values-with-auto-timestamp-truncation-changing-d0ac1b1368b74deaa0e5e987813562aa?pvs=4), [related self-hosted tickets](https://www.notion.so/supabase/ProjectUsage-function-metrics-charts-for-local-self-hosted-42905924ce03481eb9331f53bfb3b3fe?pvs=4)

Other charts refactor, (other PRs)
  - ProjectUsage charts
  -  Functions charts
  - API Report