### PR TITLE
feat: bump gotrue-js to v2.24.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -695,7 +695,6 @@
         "parse-numeric-range": "^1.3.0",
         "react": "^17.0.2",
         "react-copy-to-clipboard": "^5.0.2",
-        "react-countdown": "^2.3.5",
         "react-dom": "^17.0.2",
         "react-ga": "^3.3.0",
         "react-markdown": "^8.0.3",
@@ -9567,9 +9566,9 @@
       }
     },
     "node_modules/@supabase/gotrue-js": {
-      "version": "2.18.1",
-      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.18.1.tgz",
-      "integrity": "sha512-nXTQPbV1t1WRmdAfUeed0uIXiTwNplCGVEnHbbymyx0V7YZShlzgayuB5WZDRZLau5jg616NIRWf6/9VNF3hlg==",
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.24.0.tgz",
+      "integrity": "sha512-ZsH4K5cbMTjfMytXaDYVYs9l9igmlZFxiwXn7J2IP/CklWR5qmLCma+dvat5rccPLITVkN6oAZbKxDzW+pEgCg==",
       "dependencies": {
         "cross-fetch": "^3.1.5"
       }
@@ -38910,7 +38909,7 @@
       "license": "MIT",
       "dependencies": {
         "@headlessui/react": "^1.5.0",
-        "@supabase/gotrue-js": "^2.16.0",
+        "@supabase/gotrue-js": "2.24.0",
         "@supabase/ui": "^0.37.0-alpha.50",
         "react-use": "^17.4.0"
       },
@@ -39025,6 +39024,7 @@
         "postcss": "^8.4.5",
         "prop-types": "^15.7.2",
         "react-copy-to-clipboard": "^5.1.0",
+        "react-countdown": "^2.3.5",
         "react-feather": "^2.0.10",
         "react-markdown": "^8.0.3",
         "react-syntax-highlighter": "^15.5.0",
@@ -46266,9 +46266,9 @@
       }
     },
     "@supabase/gotrue-js": {
-      "version": "2.18.1",
-      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.18.1.tgz",
-      "integrity": "sha512-nXTQPbV1t1WRmdAfUeed0uIXiTwNplCGVEnHbbymyx0V7YZShlzgayuB5WZDRZLau5jg616NIRWf6/9VNF3hlg==",
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.24.0.tgz",
+      "integrity": "sha512-ZsH4K5cbMTjfMytXaDYVYs9l9igmlZFxiwXn7J2IP/CklWR5qmLCma+dvat5rccPLITVkN6oAZbKxDzW+pEgCg==",
       "requires": {
         "cross-fetch": "^3.1.5"
       }
@@ -49811,7 +49811,7 @@
       "version": "file:packages/common",
       "requires": {
         "@headlessui/react": "^1.5.0",
-        "@supabase/gotrue-js": "^2.16.0",
+        "@supabase/gotrue-js": "2.24.0",
         "@supabase/ui": "^0.37.0-alpha.50",
         "@types/react": "^17.0.37",
         "@types/react-dom": "^17.0.11",
@@ -68095,7 +68095,7 @@
         "@tailwindcss/typography": "^0.5.0",
         "@types/common-tags": "^1.8.1",
         "@types/react": "^17.0.37",
-        "@types/react-copy-to-clipboard": "*",
+        "@types/react-copy-to-clipboard": "^5.0.4",
         "@types/react-dom": "^17.0.11",
         "autoprefixer": "^10.4.2",
         "clsx": "^1.2.1",
@@ -68109,6 +68109,7 @@
         "postcss": "^8.4.5",
         "prop-types": "^15.7.2",
         "react-copy-to-clipboard": "^5.1.0",
+        "react-countdown": "^2.3.5",
         "react-feather": "^2.0.10",
         "react-markdown": "^8.0.3",
         "react-syntax-highlighter": "^15.5.0",
@@ -69877,7 +69878,6 @@
         "postcss-preset-env": "^6.7.0",
         "react": "^17.0.2",
         "react-copy-to-clipboard": "^5.0.2",
-        "react-countdown": "^2.3.5",
         "react-dom": "^17.0.2",
         "react-ga": "^3.3.0",
         "react-markdown": "^8.0.3",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "dependencies": {
     "@headlessui/react": "^1.5.0",
-    "@supabase/gotrue-js": "^2.16.0",
+    "@supabase/gotrue-js": "2.24.0",
     "@supabase/ui": "^0.37.0-alpha.50",
     "react-use": "^17.4.0"
   },


### PR DESCRIPTION
Bumps Studio's gotrue-js to v2.24.0.