### PR TITLE
fix: UX fix on ai query builder

### DIFF
--- a/packages/ui/src/components/Command/GenerateSQL/GenerateSQL.tsx
+++ b/packages/ui/src/components/Command/GenerateSQL/GenerateSQL.tsx
@@ -298,7 +298,7 @@ const GenerateSQL = () => {
                     search ? 'opacity-100' : 'opacity-0'
                   }`}
                 >
-                  <span className="text-scale-1100">Submit message</span>
+                  <span className={`text-scale-1100 transition-opacity ${search.length > 25 ? 'opacity-0' : 'opacity-100'}`}>Submit message</span>
                   <div className="hidden text-scale-1100 md:flex items-center justify-center h-6 w-6 rounded bg-scale-500">
                     <IconCornerDownLeft size={12} strokeWidth={1.5} />
                   </div>

--- a/packages/ui/src/components/Command/GenerateSQL/GenerateSQL.tsx
+++ b/packages/ui/src/components/Command/GenerateSQL/GenerateSQL.tsx
@@ -282,7 +282,7 @@ const GenerateSQL = () => {
         )}
         <Input
           inputRef={inputRef}
-          className="bg-scale-100 rounded mx-3 mb-4"
+          className="bg-scale-100 rounded mx-3 mb-4 [&_input]:pr-32 md:[&_input]:pr-40"
           autoFocus
           placeholder={
             isLoading || isResponding
@@ -298,7 +298,7 @@ const GenerateSQL = () => {
                     search ? 'opacity-100' : 'opacity-0'
                   }`}
                 >
-                  <span className={`text-scale-1100 transition-opacity ${search.length > 25 ? 'opacity-0' : 'opacity-100'}`}>Submit message</span>
+                  <span className="text-scale-1100">Submit message</span>
                   <div className="hidden text-scale-1100 md:flex items-center justify-center h-6 w-6 rounded bg-scale-500">
                     <IconCornerDownLeft size={12} strokeWidth={1.5} />
                   </div>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix: #13981 

## What is the new behavior?

![CPT2304261143-768x433](https://user-images.githubusercontent.com/49753983/234629770-39c1841a-cc7f-49a4-8406-33736002b798.gif)


I have set it to be hidden once the search string reaches a length of 25.

I chose the number 25 to ensure that the design is functional on all responsive devices. Please let me know if you believe that we should use different numbers for different devices.(ex. mobile - 25, tablet ~ 40, desktop ~ 75, etcs)

Let me know if you have any alternative desire fix.

.