### PR TITLE
fix: yml syntax changed to be compatible with yml 1.1 parsers

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -251,7 +251,7 @@ services:
       SUPABASE_ANON_KEY: ${ANON_KEY}
       SUPABASE_SERVICE_ROLE_KEY: ${SERVICE_ROLE_KEY}
       SUPABASE_DB_URL: postgresql://postgres:${POSTGRES_PASSWORD}@{POSTGRES_DB}:${POSTGRES_PORT}/${POSTGRES_DB}"
-      VERIFY_JWT: false
+      VERIFY_JWT: 'false'
     ports:
       - ${FUNCTIONS_HTTP_PORT}:9000/tcp
     volumes:


### PR DESCRIPTION
## What kind of change does this PR introduce?

I am trying to fix the issue i am pointing to in #13991 issue



## What is the current behavior?


Currently, the docker-compose stack, after following the official supabase [documentation](https://supabase.com/docs/guides/self-hosting), doesn't work as intended, After fresh clone, copying of `.env` files and running of `docker-compose up`, it prompts up the syntaxing error as shown in the screenshot provided

![image](https://user-images.githubusercontent.com/88193583/234739752-88d201a8-5976-43e3-9cbd-a0b8ce478ba3.png)

Docker compose file fails to start up after being freshly cloned from the repository due to yml parsers not being able to read boolean as proper value.


## What is the new behavior?

The docker compose stack fires up as it normally would (I used supabase's self hosted version for quite a bit and i had no issues with self hosting it out of the box within a minute or two).

![image](https://user-images.githubusercontent.com/88193583/234740672-2fe280d6-261b-4be1-9f83-39e02712c599.png)

The Error that came in with the fresh clone of the supabase master branch is removed.


## Additional Context

This [SO discussion](https://stackoverflow.com/questions/53648244/specifying-the-string-value-yes-in-a-yaml-property) explains nicely how to deal with booleans that would be backwards compatible in YML



