### PR TITLE
Update many-to-many table structure

### DIFF
--- a/apps/docs/pages/guides/api/joins-and-nesting.mdx
+++ b/apps/docs/pages/guides/api/joins-and-nesting.mdx
@@ -138,9 +138,9 @@ create table
 
 create table
   members (
-    "id" serial primary key,
     "user_id" int references users,
-    "team_id" int references teams
+    "team_id" int references teams,
+    primary key(user_id, team_id)
   );
 ```
 


### PR DESCRIPTION
Closes https://github.com/supabase/supabase-js/issues/765

This was a change done way back on postgREST v10. See https://postgrest.org/en/stable/api.html#many-to-many-relationships.

It was done to prevent cases where undesired many-to-many relationship were detected.

Additionally, the `members` table structure is better without serial `id` and just a composite key. The prior structure indicates that a user can have many memberships to the same team, which doesn't make sense.