### PR TITLE
(docs): fix broken link

### DIFF
--- a/apps/docs/pages/guides/getting-started/tutorials/with-nuxt-3.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-nuxt-3.mdx
@@ -22,7 +22,7 @@ Let's start building the Vue 3 app from scratch.
 
 ### Initialize a Nuxt 3 app
 
-We can use [`nuxi init`](https://v3.nuxtjs.org/getting-started/quick-start/) to create an app called `nuxt-user-management`:
+We can use [`nuxi init`](https://nuxt.com/docs/getting-started/installation) to create an app called `nuxt-user-management`:
 
 ```bash
 npx nuxi init nuxt-user-management


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixing a broken link in the documentation.

## What is the current behavior?

The docs have a hyper link that goes to this broken link: https://v3.nuxtjs.org/getting-started/quick-start/

## What is the new behavior?

The hyperlink in the docs will go to this link now: https://nuxt.com/docs/getting-started/installation
