### PR TITLE
chore(storage): align wording for asset transformations

### DIFF
--- a/apps/docs/pages/guides/platform/spend-cap.mdx
+++ b/apps/docs/pages/guides/platform/spend-cap.mdx
@@ -17,7 +17,7 @@ Supabase charges for certain usage line items in your project. Those line items 
 - Database Size
 - Storage Size
 - Egress
-- Asset transformations
+- Storage Image Transformations
 - Realtime concurrent peak connections
 - Realtime messages
 - Edge function invocations

--- a/apps/www/data/Pricing.json
+++ b/apps/www/data/Pricing.json
@@ -217,7 +217,7 @@
         }
       },
       {
-        "title": "Asset transformations",
+        "title": "Image Transformations",
         "tooltips": {
           "main": "Distinct count of all images that were transformed in the billing period, ignoring any transformations."
         },

--- a/studio/components/interfaces/Billing/Billing.constants.tsx
+++ b/studio/components/interfaces/Billing/Billing.constants.tsx
@@ -81,8 +81,8 @@ export const USAGE_BASED_PRODUCTS = [
         costPerUnit: 0.015,
         tooltip: (
           <span>
-            The amount of distinct Single Sign-On users requesting your API throughout the billing period. Resets
-            at the beginning of every billing period.
+            The amount of distinct Single Sign-On users requesting your API throughout the billing
+            period. Resets at the beginning of every billing period.
           </span>
         ),
       },
@@ -123,15 +123,15 @@ export const USAGE_BASED_PRODUCTS = [
       {
         key: 'storage_image_render_count',
         attribute: 'total_storage_image_render_count',
-        title: 'Storage Images Transformed',
+        title: 'Storage Image Transformations',
         units: 'absolute',
         costPerUnit: 0.005,
         tooltip: (
           <span>
-            We distinctly count all images that were transformed in the billing period, ignoring any
-            transformations. If you transform one image with different transformations (i.e. once
-            with height=50 and once with height=150), it only counts as one. We only count the
-            unique (origin) images being transformed.
+            We distinctly count all images transformed in the billing period, ignoring any
+            transformations. Transforming one image with different transformations (i.e. once with
+            height=50 and once with height=150), only counts as one. Resets at the beginning of
+            every billing period.
           </span>
         ),
       },

--- a/studio/components/interfaces/Billing/SpendCapModal.tsx
+++ b/studio/components/interfaces/Billing/SpendCapModal.tsx
@@ -127,7 +127,7 @@ const SpendCapModal: FC<Props> = ({ visible, onHide }) => {
                   <p className="w-[25%] text-sm">$0.09/GB</p>
                 </div>
                 <div className="flex items-center px-4 py-1">
-                  <p className="w-[50%] text-sm">Asset transformations</p>
+                  <p className="w-[50%] text-sm">Storage Image Transformations</p>
                   <p className="w-[25%] text-sm">100 origin images</p>
                   <p className="w-[25%] text-sm">$5 per 1000 origin images</p>
                 </div>

--- a/studio/lib/constants/metrics.tsx
+++ b/studio/lib/constants/metrics.tsx
@@ -217,7 +217,7 @@ export const METRICS = [
   },
   {
     key: 'total_storage_image_render_count',
-    label: 'Storage Images Transformed',
+    label: 'Storage Image Transformations',
     provider: 'daily-stats',
     category: METRIC_CATEGORIES.API_STORAGE,
   },


### PR DESCRIPTION
We use "Asset Transformations" on the pricing page and "Storage Image Transformations" elsewhere.

PR aligns the wording and clarifies the copy for the usage billing a bit.