### PR TITLE
chore: remove duplicate pricing item in pro plan

### DIFF
--- a/apps/www/pages/pricing/index.tsx
+++ b/apps/www/pages/pricing/index.tsx
@@ -69,7 +69,6 @@ export default function IndexPage() {
         '8GB database & 100GB file storage',
         '50GB bandwidth',
         '5GB file uploads',
-        'Social OAuth providers',
         '100,000 monthly active users',
         '2M Edge Function invocations',
         'Daily backups',

--- a/studio/components/interfaces/Billing/PlanSelection/Plans/Plans.Constants.ts
+++ b/studio/components/interfaces/Billing/PlanSelection/Plans/Plans.Constants.ts
@@ -39,7 +39,6 @@ export const PRICING_META = {
       '8GB database & 100GB file storage',
       '50GB bandwidth',
       '5GB file uploads',
-      'Social OAuth providers',
       '100,000 monthly active users',
       '2M Edge Function invocations',
       'Daily backups',


### PR DESCRIPTION
Mini issue with the copy I noticed. The free plan has an item "Social OAuth providers". Pro plan is  "Everything in the Free plan, plus:" and then mentions "Social OAuth providers" again.

![image](https://user-images.githubusercontent.com/14073399/235303286-d2597e66-0481-48d0-9df1-9dd1d2c89344.png)
