### PR TITLE
Update with-sveltekit.mdx

### DIFF
--- a/apps/docs/pages/guides/getting-started/tutorials/with-sveltekit.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-sveltekit.mdx
@@ -311,9 +311,9 @@ Create a new `src/routes/account/+page.svelte` file with the content below.
 	export let data: PageData;
 	export let form: ActionData;
 
-	let { session, profile } = data;
+	let { session, profile, supabase } = data;
 
-  let profileForm: any;
+	let profileForm: any;
 	let loading = false;
 	let fullName: string | null = profile?.full_name;
 	let username: string | null = profile?.username;


### PR DESCRIPTION
Including `supabase` here fixes an issue further in the tutorial in, "Add the new widget"

## What kind of change does this PR introduce?

Bug fix, and minor formatting

## What is the current behavior?

`supabase` variable nulrefs after student attempts to add the new widget

## What is the new behavior?

Following the instructions to add a new widget will work properly

## Additional context

N/A
