### PR TITLE
better space to positions CTA

### DIFF
--- a/apps/www/pages/careers/index.tsx
+++ b/apps/www/pages/careers/index.tsx
@@ -111,7 +111,7 @@ const CareerPage: NextPage = ({ jobs, contributors }: any) => {
               Explore remote possibilities and join our team to help us achieve it.
             </p>
             <a href="#positions">
-              <Button className="text-white xl:text-sm">Open positions</Button>
+              <Button className="text-white xl:text-sm mt-4">Open positions</Button>
             </a>
           </div>
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
Minor change that gives some spacing to the main /careers CTA

Now: 
![image](https://user-images.githubusercontent.com/48492084/235363882-4fca900b-9987-49ba-8baf-eb5dd5542eca.png)


Before:
![image](https://user-images.githubusercontent.com/48492084/235363873-d7bb6dbe-3042-413b-86af-e3f5f88579bc.png)
