### PR TITLE
Project ID to Project Reference ID

### DIFF
--- a/apps/docs/pages/guides/api/rest/generating-types.mdx
+++ b/apps/docs/pages/guides/api/rest/generating-types.mdx
@@ -37,7 +37,7 @@ npx supabase login
 Generate types for your project to produce the `types/supabase.ts` file:
 
 ```bash
-npx supabase gen types typescript --project-id "$PROJECT_ID" --schema public > types/supabase.ts
+npx supabase gen types typescript --project-id "$PROJECT_REFERENCE_ID" --schema public > types/supabase.ts
 ```
 
 After you have generated your types, you can use them in `src/index.ts`

--- a/apps/docs/pages/guides/api/rest/generating-types.mdx
+++ b/apps/docs/pages/guides/api/rest/generating-types.mdx
@@ -37,7 +37,7 @@ npx supabase login
 Generate types for your project to produce the `types/supabase.ts` file:
 
 ```bash
-npx supabase gen types typescript --project-id "$PROJECT_REFERENCE_ID" --schema public > types/supabase.ts
+npx supabase gen types typescript --project-id "$PROJECT_REF" --schema public > types/supabase.ts
 ```
 
 After you have generated your types, you can use them in `src/index.ts`
@@ -65,7 +65,7 @@ One way to keep your type definitions in sync with your database is to set up a 
 Add the script above to your `package.json` to run it using `npm run update-types`
 
 ```json
-"update-types": "npx supabase gen types typescript --project-id \"$PROJECT_ID\" > types/supabase.ts"
+"update-types": "npx supabase gen types typescript --project-id \"$PROJECT_REF\" > types/supabase.ts"
 ```
 
 Create a file `.github/workflows/update-types.yml` with the following snippet to define the action along with the environment variables. This script will commit new type changes to your repo every night.
@@ -83,7 +83,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SUPABASE_ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-      PROJECT_ID: <your-project-id>
+      PROJECT_REF: <your-project-id>
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
In the docs, the term "Project ID" is used, but in the app, it's called a "Reference ID". This makes a bit of a compromise and refers to it as "Project reference ID". 