### PR TITLE
Update joins-and-nesting.mdx

### DIFF
--- a/apps/docs/pages/guides/api/joins-and-nesting.mdx
+++ b/apps/docs/pages/guides/api/joins-and-nesting.mdx
@@ -82,7 +82,7 @@ The APIs will automatically detect relationships based on the foreign keys:
 const { data, error } = await supabase.from('countries').select(`
   id, 
   name, 
-  cities ( id, name )
+  cities:id ( id, name )
 `)
 ```
 


### PR DESCRIPTION
I have experienced that when I write a join sql, I need to write a foreign key. The former syntax doesn't work.

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

The current query return response with null.

## What is the new behavior?

I've updated the query so that it contains foreign key.

## Additional context

Add any other context or screenshots.
