### PR TITLE
fix: trim leading and trailing spaces from project name

### DIFF
--- a/studio/components/interfaces/Settings/General/General.tsx
+++ b/studio/components/interfaces/Settings/General/General.tsx
@@ -25,7 +25,9 @@ const General: FC<Props> = ({}) => {
   const canUpdateProject = checkPermissions(PermissionAction.UPDATE, 'projects')
 
   const onSubmit = async (values: any, { resetForm }: any) => {
-    const response = await post(`${API_URL}/projects/${project?.ref}/update`, { name: values.name })
+    const response = await post(`${API_URL}/projects/${project?.ref}/update`, {
+      name: values.name.trim(),
+    })
     if (response.error) {
       ui.setNotification({
         category: 'error',

--- a/studio/pages/new/[slug].tsx
+++ b/studio/pages/new/[slug].tsx
@@ -162,7 +162,7 @@ const Wizard: NextPageWithLayout = () => {
     const data: Record<string, any> = {
       cloud_provider: PROVIDERS.AWS.id, // hardcoded for DB instances to be under AWS
       org_id: currentOrg?.id,
-      name: projectName,
+      name: projectName.trim(),
       db_pass: dbPass,
       db_region: dbRegion,
       db_pricing_tier_id: (PRICING_TIER_PRODUCT_IDS as any)[dbTier],

--- a/studio/pages/new/index.tsx
+++ b/studio/pages/new/index.tsx
@@ -42,8 +42,7 @@ const Wizard: NextPageWithLayout = () => {
   const [newOrgLoading, setNewOrgLoading] = useState(false)
 
   function validateOrgName(name: any) {
-    const value = name ? name.trim() : ''
-    return value.length >= 1
+    return name.length >= 1
   }
 
   function onOrgNameChange(e: any) {
@@ -60,7 +59,8 @@ const Wizard: NextPageWithLayout = () => {
 
   async function onClickSubmit(e: any) {
     e.preventDefault()
-    const isOrgNameValid = validateOrgName(orgName)
+    const trimmedOrgName = orgName ? orgName.trim() : ''
+    const isOrgNameValid = validateOrgName(trimmedOrgName)
     if (!isOrgNameValid) {
       ui.setNotification({ category: 'error', message: 'Organization name is empty' })
       return
@@ -68,7 +68,7 @@ const Wizard: NextPageWithLayout = () => {
 
     setNewOrgLoading(true)
     const response = await post(`${API_URL}/organizations`, {
-      name: orgName,
+      name: trimmedOrgName,
       kind: orgKind,
       ...(orgKind == 'COMPANY' ? { size: orgSize } : {}),
     })


### PR DESCRIPTION
## What kind of change does this PR introduce?

This fixes issue #14057

This fix ensures that any leading or trailing whitespace is removed from the project name when creating a new project or changing the name of an existing project in the settings.