### PR TITLE
feat: add route information to API report

### DIFF
--- a/studio/components/interfaces/Reports/ReportFilterBar.tsx
+++ b/studio/components/interfaces/Reports/ReportFilterBar.tsx
@@ -12,7 +12,7 @@ import {
   IconBox,
   IconCode,
   IconDatabase,
-  IconZapOff,
+  IconZap,
 } from 'ui'
 import DatePickers from '../Settings/Logs/Logs.DatePickers'
 import { REPORTS_DATEPICKER_HELPERS } from './Reports.constants'
@@ -59,7 +59,7 @@ const PRODUCT_FILTERS = [
     filterValue: '/realtime',
     label: 'Realtime',
     description: 'Realtime connection requests',
-    icon: IconZapOff,
+    icon: IconZap,
   },
   // TODO: support functions once union parsing is fixed
   // {

--- a/studio/components/interfaces/Reports/ReportPadding.tsx
+++ b/studio/components/interfaces/Reports/ReportPadding.tsx
@@ -2,7 +2,7 @@
  * Standardized padding and width layout for non-custom reports
  */
 const ReportPadding: React.FC = ({ children }) => (
-  <div className="flex flex-col gap-4 px-5 py-6 h-full mx-auto 1xl:px-28 lg:px-16 xl:px-24 2xl:px-32">
+  <div className="flex flex-col gap-4 px-5 py-6 mx-auto 1xl:px-28 lg:px-16 xl:px-24 2xl:px-32">
     {children}
   </div>
 )

--- a/studio/components/interfaces/Reports/ReportWidget.tsx
+++ b/studio/components/interfaces/Reports/ReportWidget.tsx
@@ -15,14 +15,15 @@ export interface ReportWidgetProps<T = any> {
   tooltip?: string
   className?: string
   renderer: (props: ReportWidgetRendererProps) => React.ReactNode
-  expandable?: (props: ReportWidgetRendererProps) => React.ReactNode
-  expandableText?: string
+  append?: (props: ReportWidgetRendererProps) => React.ReactNode
+  // for overriding props, such as data
+  appendProps?: Partial<ReportWidgetRendererProps>
   // omitting params will hide the "View in logs explorer" button
   params?: BaseReportParams | LogsEndpointParams
   isLoading: boolean
 }
 
-export interface ReportWidgetRendererProps extends ReportWidgetProps {
+export interface ReportWidgetRendererProps<T = any> extends ReportWidgetProps<T> {
   router: NextRouter
   projectRef: string
 }
@@ -99,7 +100,7 @@ const ReportWidget: React.FC<ReportWidgetProps> = (props) => {
                   </div>
                 </Tooltip.Content>
               </Tooltip.Portal>
-            </Tooltip.Root>
+          </Tooltip.Root>
           )}
         </div>
 
@@ -107,16 +108,8 @@ const ReportWidget: React.FC<ReportWidgetProps> = (props) => {
           {props.data === undefined ? null : props.renderer({ ...props, router, projectRef })}
         </LoadingOpacity>
 
-        {props.expandable && (
-          <Collapsible>
-            <Collapsible.Trigger asChild>
-              <Button>{props.expandableText || 'Expand'}</Button>
-            </Collapsible.Trigger>
-            <Collapsible.Content>
-              {props.expandable && props.expandable({ ...props, router, projectRef })}
-            </Collapsible.Content>
-          </Collapsible>
-        )}
+        {props.append &&
+          props.append({ ...props, ...(props.appendProps || {}), router, projectRef })}
       </Panel.Content>
     </Panel>
   )

--- a/studio/components/interfaces/Reports/ReportWidget.tsx
+++ b/studio/components/interfaces/Reports/ReportWidget.tsx
@@ -1,12 +1,10 @@
 import { NextRouter, useRouter } from 'next/router'
 import * as Tooltip from '@radix-ui/react-tooltip'
-import { Button, Collapsible, IconExternalLink, IconHelpCircle } from 'ui'
-
+import { Button, IconExternalLink, IconHelpCircle } from 'ui'
 import { BaseReportParams } from './Reports.types'
 import { LogsEndpointParams } from '../Settings/Logs'
 import Panel from 'components/ui/Panel'
 import LoadingOpacity from 'components/ui/LoadingOpacity'
-import { useState } from 'react'
 
 export interface ReportWidgetProps<T = any> {
   data: T[]
@@ -100,7 +98,7 @@ const ReportWidget: React.FC<ReportWidgetProps> = (props) => {
                   </div>
                 </Tooltip.Content>
               </Tooltip.Portal>
-          </Tooltip.Root>
+            </Tooltip.Root>
           )}
         </div>
 

--- a/studio/components/interfaces/Reports/ReportWidget.tsx
+++ b/studio/components/interfaces/Reports/ReportWidget.tsx
@@ -1,11 +1,12 @@
 import { NextRouter, useRouter } from 'next/router'
 import * as Tooltip from '@radix-ui/react-tooltip'
-import { Button, IconExternalLink, IconHelpCircle } from 'ui'
+import { Button, Collapsible, IconExternalLink, IconHelpCircle } from 'ui'
 
 import { BaseReportParams } from './Reports.types'
 import { LogsEndpointParams } from '../Settings/Logs'
 import Panel from 'components/ui/Panel'
 import LoadingOpacity from 'components/ui/LoadingOpacity'
+import { useState } from 'react'
 
 export interface ReportWidgetProps<T = any> {
   data: T[]
@@ -14,6 +15,8 @@ export interface ReportWidgetProps<T = any> {
   tooltip?: string
   className?: string
   renderer: (props: ReportWidgetRendererProps) => React.ReactNode
+  expandable?: (props: ReportWidgetRendererProps) => React.ReactNode
+  expandableText?: string
   // omitting params will hide the "View in logs explorer" button
   params?: BaseReportParams | LogsEndpointParams
   isLoading: boolean
@@ -28,7 +31,6 @@ const ReportWidget: React.FC<ReportWidgetProps> = (props) => {
   const router = useRouter()
   const { ref } = router.query
   const projectRef = ref as string
-
   return (
     <Panel
       noMargin
@@ -104,6 +106,17 @@ const ReportWidget: React.FC<ReportWidgetProps> = (props) => {
         <LoadingOpacity className="w-full" active={props.isLoading}>
           {props.data === undefined ? null : props.renderer({ ...props, router, projectRef })}
         </LoadingOpacity>
+
+        {props.expandable && (
+          <Collapsible>
+            <Collapsible.Trigger asChild>
+              <Button>{props.expandableText || 'Expand'}</Button>
+            </Collapsible.Trigger>
+            <Collapsible.Content>
+              {props.expandable && props.expandable({ ...props, router, projectRef })}
+            </Collapsible.Content>
+          </Collapsible>
+        )}
       </Panel.Content>
     </Panel>
   )

--- a/studio/components/interfaces/Reports/Reports.constants.ts
+++ b/studio/components/interfaces/Reports/Reports.constants.ts
@@ -147,8 +147,7 @@ export const PRESET_CONFIG: Record<Presets, PresetConfig> = {
         sql: (filters) => `
         select
           cast(timestamp_trunc(t.timestamp, hour) as datetime) as timestamp,
-          avg(response.origin_time) as avg,
-          APPROX_QUANTILES(response.origin_time, 100) as quantiles
+          avg(response.origin_time) as avg
         FROM
           edge_logs t
           cross join unnest(metadata) as m

--- a/studio/components/interfaces/Reports/Reports.constants.ts
+++ b/studio/components/interfaces/Reports/Reports.constants.ts
@@ -81,6 +81,7 @@ export const PRESET_CONFIG: Record<Presets, PresetConfig> = {
           request.path as path,
           request.method as method,
           request.search as search,
+          response.status_code as status_code,
           count(t.id) as count
         from edge_logs t
           cross join unnest(metadata) as m
@@ -89,11 +90,11 @@ export const PRESET_CONFIG: Record<Presets, PresetConfig> = {
           cross join unnest(request.headers) as headers
           ${generateRexepWhere(filters)}
         group by
-          request.path, request.method, request.search
+          request.path, request.method, request.search, response.status_code
         order by
           count desc
         limit
-        5
+        3
         `
       },
       errorCounts: {
@@ -138,7 +139,7 @@ export const PRESET_CONFIG: Record<Presets, PresetConfig> = {
         order by
           count desc
         limit
-        5
+        3
         `
       },
       responseSpeed: {

--- a/studio/components/interfaces/Reports/Reports.constants.ts
+++ b/studio/components/interfaces/Reports/Reports.constants.ts
@@ -74,6 +74,28 @@ export const PRESET_CONFIG: Record<Presets, PresetConfig> = {
         ORDER BY
           timestamp ASC`,
       },
+      topRoutes: {
+        queryType: "logs",
+        sql: (filters)=> `
+        select
+          request.path as path,
+          request.method as method,
+          request.search as search,
+          count(t.id) as count
+        from edge_logs t
+          cross join unnest(metadata) as m
+          cross join unnest(m.response) as response
+          cross join unnest(m.request) as request
+          cross join unnest(request.headers) as headers
+          ${generateRexepWhere(filters)}
+        group by
+          request.path, request.method, request.search
+        order by
+          count desc
+        limit
+        5
+        `
+      },
       errorCounts: {
         queryType: 'logs',
         sql: (filters) => `

--- a/studio/components/interfaces/Reports/renderers/ApiRenderers.tsx
+++ b/studio/components/interfaces/Reports/renderers/ApiRenderers.tsx
@@ -3,14 +3,11 @@ import BarChart from 'components/ui/Charts/BarChart'
 import Table from 'components/to-be-cleaned/Table'
 import {
   jsonSyntaxHighlight,
-  ResponseCodeFormatter,
   TextFormatter,
 } from 'components/interfaces/Settings/Logs/LogsFormatters'
 import { Button, Collapsible, IconChevronRight } from 'ui'
 import { queryParamsToObject } from '../Reports.utils'
-import Loading from 'components/ui/Loading'
-import { LoadingLine } from 'ui/src/components/Command/LoadingLine'
-import LoadingOpacity from 'components/ui/LoadingOpacity'
+import { Fragment } from 'react'
 
 export const renderTotalRequests = (
   props: ReportWidgetProps<{
@@ -64,7 +61,7 @@ export const renderTopApiRoutes = (
       body={
         <>
           {props.data.map((datum) => (
-            <>
+            <Fragment key={datum.path + (datum.search || '')}>
               <Table.tr className="p-0">
                 <Table.td className={[cellClasses].join(' ')}>
                   <RouteTdContent {...datum} />
@@ -78,7 +75,7 @@ export const renderTopApiRoutes = (
                   </Table.td>
                 )}
               </Table.tr>
-            </>
+            </Fragment>
           ))}
         </>
       }
@@ -117,7 +114,7 @@ export const renderResponseSpeed = (
 ) => {
   const transformedData = props.data.map((datum) => ({
     timestamp: datum.timestamp,
-    avg: datum.avg
+    avg: datum.avg,
   }))
   const lastAvg = props.data[props.data.length - 1]?.avg
   return (
@@ -145,7 +142,7 @@ const RouteTdContent = (datum: RouteTdContentProps) => (
   <Collapsible>
     <Collapsible.Trigger asChild>
       <div className="flex gap-2">
-        <Button type="text" className=" !py-0 !p-1" title="Show more route details">
+        <Button as="span" type="text" className=" !py-0 !p-1" title="Show more route details">
           <IconChevronRight
             size={14}
             className="transition data-open-parent:rotate-90 data-closed-parent:rotate-0"

--- a/studio/components/interfaces/Reports/renderers/ApiRenderers.tsx
+++ b/studio/components/interfaces/Reports/renderers/ApiRenderers.tsx
@@ -10,7 +10,7 @@ import { queryParamsToObject } from '../Reports.utils'
 import { Fragment } from 'react'
 import useFillTimeseriesSorted from 'hooks/analytics/useFillTimeseriesSorted'
 
-export const renderTotalRequests = (
+export const TotalRequestsChartRenderer = (
   props: ReportWidgetProps<{
     timestamp: string
     count: number
@@ -41,7 +41,7 @@ export const renderTotalRequests = (
   )
 }
 
-export const renderTopApiRoutes = (
+export const TopApiRoutesRenderer = (
   props: ReportWidgetRendererProps<{
     method: string
     // shown for error table but not all requests table
@@ -92,7 +92,7 @@ export const renderTopApiRoutes = (
   )
 }
 
-export const renderErrorCounts = (
+export const ErrorCountsChartRenderer = (
   props: ReportWidgetProps<{
     timestamp: string
     count: number
@@ -125,7 +125,7 @@ export const renderErrorCounts = (
   )
 }
 
-export const renderResponseSpeed = (
+export const ResponseSpeedChartRenderer = (
   props: ReportWidgetProps<{
     timestamp: string
     avg: number

--- a/studio/components/interfaces/Reports/renderers/ApiRenderers.tsx
+++ b/studio/components/interfaces/Reports/renderers/ApiRenderers.tsx
@@ -210,7 +210,7 @@ const RouteTdContent = (datum: RouteTdContentProps) => (
           />
         </pre>
       ) : (
-        <p className="text-xs text-scale-900">No query paramters in this request</p>
+        <p className="text-xs text-scale-900">No query parameters in this request</p>
       )}
     </Collapsible.Content>
   </Collapsible>

--- a/studio/components/interfaces/Reports/renderers/ApiRenderers.tsx
+++ b/studio/components/interfaces/Reports/renderers/ApiRenderers.tsx
@@ -3,10 +3,14 @@ import BarChart from 'components/ui/Charts/BarChart'
 import Table from 'components/to-be-cleaned/Table'
 import {
   jsonSyntaxHighlight,
+  ResponseCodeFormatter,
   TextFormatter,
 } from 'components/interfaces/Settings/Logs/LogsFormatters'
 import { Button, Collapsible, IconChevronRight } from 'ui'
 import { queryParamsToObject } from '../Reports.utils'
+import Loading from 'components/ui/Loading'
+import { LoadingLine } from 'ui/src/components/Command/LoadingLine'
+import LoadingOpacity from 'components/ui/LoadingOpacity'
 
 export const renderTotalRequests = (
   props: ReportWidgetProps<{
@@ -34,40 +38,41 @@ export const renderTotalRequests = (
 export const renderTopApiRoutes = (
   props: ReportWidgetRendererProps<{
     method: string
+    // shown for error table but not all requests table
+    status_code?: number
     path: string
     search: string
     count: number
   }>
 ) => {
+  if (props.data.length === 0) return null
   const headerClasses = '!text-xs !py-2 p-0 font-bold !bg-scale-400'
-  const cellClasses = '!text-xs !py-2 truncate'
+  const cellClasses = '!text-xs !py-2'
   return (
-    <>
-      <Table
-        head={
-          <>
-            <Table.th className={headerClasses}>Request</Table.th>
-            <Table.th className={headerClasses + ' text-right'}>Count</Table.th>
-          </>
-        }
-        body={
-          <>
-            {props.data.map((datum) => (
-              <>
-                <Table.tr className="p-0">
-                  <Table.td className={[cellClasses].join(' ')}>
-                    <RouteTdContent {...datum} />
-                  </Table.td>
-                  <Table.td className={[cellClasses, 'text-right align-top'].join(' ')}>
-                    {datum.count}
-                  </Table.td>
-                </Table.tr>
-              </>
-            ))}
-          </>
-        }
-      />
-    </>
+    <Table
+      head={
+        <>
+          <Table.th className={headerClasses}>Request</Table.th>
+          <Table.th className={headerClasses + ' text-right'}>Count</Table.th>
+        </>
+      }
+      body={
+        <>
+          {props.data.map((datum) => (
+            <>
+              <Table.tr className="p-0">
+                <Table.td className={[cellClasses].join(' ')}>
+                  <RouteTdContent {...datum} />
+                </Table.td>
+                <Table.td className={[cellClasses, 'text-right align-top'].join(' ')}>
+                  {datum.count}
+                </Table.td>
+              </Table.tr>
+            </>
+          ))}
+        </>
+      }
+    />
   )
 }
 
@@ -124,6 +129,7 @@ export const renderResponseSpeed = (
 
 interface RouteTdContentProps {
   method: string
+  status_code?: number
   path: string
   search: string
 }
@@ -138,10 +144,22 @@ const RouteTdContent = (datum: RouteTdContentProps) => (
           />
         </Button>
         <TextFormatter className="w-10 h-4 text-center rounded bg-scale-500" value={datum.method} />
-        <div>
+        {datum.status_code && (
+          <TextFormatter
+            className={`w-10 h-4 text-center rounded ${
+              datum.status_code >= 400
+                ? 'bg-orange-500'
+                : datum.status_code >= 300
+                ? 'bg-yellow-500'
+                : 'bg-green-500'
+            }`}
+            value={String(datum.status_code)}
+          />
+        )}
+        <div className=" truncate max-w-sm lg:max-w-lg">
           <TextFormatter className="text-scale-1100" value={datum.path} />
           <TextFormatter
-            className="max-w-sm text-scale-900"
+            className="max-w-sm text-scale-900 truncate "
             value={decodeURIComponent(datum.search || '')}
           />
         </div>

--- a/studio/components/interfaces/Reports/renderers/ApiRenderers.tsx
+++ b/studio/components/interfaces/Reports/renderers/ApiRenderers.tsx
@@ -43,6 +43,8 @@ export const renderTopApiRoutes = (
     path: string
     search: string
     count: number
+    // used for response speed table only
+    avg?: number
   }>
 ) => {
   if (props.data.length === 0) return null
@@ -54,6 +56,9 @@ export const renderTopApiRoutes = (
         <>
           <Table.th className={headerClasses}>Request</Table.th>
           <Table.th className={headerClasses + ' text-right'}>Count</Table.th>
+          {props.data[0].avg !== undefined && (
+            <Table.th className={headerClasses + ' text-right'}>Avg</Table.th>
+          )}
         </>
       }
       body={
@@ -67,6 +72,11 @@ export const renderTopApiRoutes = (
                 <Table.td className={[cellClasses, 'text-right align-top'].join(' ')}>
                   {datum.count}
                 </Table.td>
+                {props.data[0].avg !== undefined && (
+                  <Table.td className={[cellClasses, 'text-right align-top'].join(' ')}>
+                    {Number(datum.avg).toFixed(2)}ms
+                  </Table.td>
+                )}
               </Table.tr>
             </>
           ))}

--- a/studio/components/interfaces/Reports/renderers/ApiRenderers.tsx
+++ b/studio/components/interfaces/Reports/renderers/ApiRenderers.tsx
@@ -113,13 +113,11 @@ export const renderResponseSpeed = (
   props: ReportWidgetProps<{
     timestamp: string
     avg: number
-    quantiles: number[]
   }>
 ) => {
   const transformedData = props.data.map((datum) => ({
     timestamp: datum.timestamp,
-    avg: datum.avg,
-    median: datum.quantiles[49],
+    avg: datum.avg
   }))
   const lastAvg = props.data[props.data.length - 1]?.avg
   return (

--- a/studio/components/interfaces/Reports/renderers/ApiRenderers.tsx
+++ b/studio/components/interfaces/Reports/renderers/ApiRenderers.tsx
@@ -8,6 +8,7 @@ import {
 import { Button, Collapsible, IconChevronRight } from 'ui'
 import { queryParamsToObject } from '../Reports.utils'
 import { Fragment } from 'react'
+import useFillTimeseriesSorted from 'hooks/analytics/useFillTimeseriesSorted'
 
 export const renderTotalRequests = (
   props: ReportWidgetProps<{
@@ -18,13 +19,21 @@ export const renderTotalRequests = (
   const total = props.data.reduce((acc, datum) => {
     return acc + datum.count
   }, 0)
+  const data = useFillTimeseriesSorted(
+    props.data,
+    'timestamp',
+    'count',
+    0,
+    props.params?.iso_timestamp_start,
+    props.params?.iso_timestamp_end
+  )
   return (
     <BarChart
       size="small"
       minimalHeader
       highlightedValue={total}
       className="w-full"
-      data={props.data}
+      data={data}
       yAxisKey="count"
       xAxisKey="timestamp"
       displayDateInUtc
@@ -92,13 +101,23 @@ export const renderErrorCounts = (
   const total = props.data.reduce((acc, datum) => {
     return acc + datum.count
   }, 0)
+
+  const data = useFillTimeseriesSorted(
+    props.data,
+    'timestamp',
+    'count',
+    0,
+    props.params?.iso_timestamp_start,
+    props.params?.iso_timestamp_end
+  )
+
   return (
     <BarChart
       size="small"
       minimalHeader
       className="w-full"
       highlightedValue={total}
-      data={props.data}
+      data={data}
       yAxisKey="count"
       xAxisKey="timestamp"
       displayDateInUtc
@@ -116,6 +135,16 @@ export const renderResponseSpeed = (
     timestamp: datum.timestamp,
     avg: datum.avg,
   }))
+
+  const data = useFillTimeseriesSorted(
+    transformedData,
+    'timestamp',
+    'avg',
+    0,
+    props.params?.iso_timestamp_start,
+    props.params?.iso_timestamp_end
+  )
+
   const lastAvg = props.data[props.data.length - 1]?.avg
   return (
     <BarChart
@@ -124,7 +153,7 @@ export const renderResponseSpeed = (
       format="ms"
       minimalHeader
       className="w-full"
-      data={transformedData}
+      data={data}
       yAxisKey="avg"
       xAxisKey="timestamp"
       displayDateInUtc
@@ -171,14 +200,18 @@ const RouteTdContent = (datum: RouteTdContentProps) => (
       </div>
     </Collapsible.Trigger>
     <Collapsible.Content className="pt-2">
-      <pre className={`syntax-highlight overflow-auto rounded bg-scale-300 p-2 !text-xs`}>
-        <div
-          className="text-wrap"
-          dangerouslySetInnerHTML={{
-            __html: jsonSyntaxHighlight(queryParamsToObject(datum.search)),
-          }}
-        />
-      </pre>
+      {datum.search ? (
+        <pre className={`syntax-highlight overflow-auto rounded bg-scale-300 p-2 !text-xs`}>
+          <div
+            className="text-wrap"
+            dangerouslySetInnerHTML={{
+              __html: jsonSyntaxHighlight(queryParamsToObject(datum.search)),
+            }}
+          />
+        </pre>
+      ) : (
+        <p className="text-xs text-scale-900">No query paramters in this request</p>
+      )}
     </Collapsible.Content>
   </Collapsible>
 )

--- a/studio/components/interfaces/Reports/renderers/ApiRenderers.tsx
+++ b/studio/components/interfaces/Reports/renderers/ApiRenderers.tsx
@@ -1,5 +1,12 @@
-import { ReportWidgetProps } from '../ReportWidget'
+import { ReportWidgetProps, ReportWidgetRendererProps } from '../ReportWidget'
 import BarChart from 'components/ui/Charts/BarChart'
+import Table from 'components/to-be-cleaned/Table'
+import {
+  jsonSyntaxHighlight,
+  TextFormatter,
+} from 'components/interfaces/Settings/Logs/LogsFormatters'
+import { Button, Collapsible, IconChevronRight } from 'ui'
+import { queryParamsToObject } from '../Reports.utils'
 
 export const renderTotalRequests = (
   props: ReportWidgetProps<{
@@ -21,6 +28,46 @@ export const renderTotalRequests = (
       xAxisKey="timestamp"
       displayDateInUtc
     />
+  )
+}
+
+export const renderTopApiRoutes = (
+  props: ReportWidgetRendererProps<{
+    method: string
+    path: string
+    search: string
+    count: number
+  }>
+) => {
+  const headerClasses = '!text-xs !py-2 p-0 font-bold !bg-scale-400'
+  const cellClasses = '!text-xs !py-2 truncate'
+  return (
+    <>
+      <Table
+        head={
+          <>
+            <Table.th className={headerClasses}>Request</Table.th>
+            <Table.th className={headerClasses + ' text-right'}>Count</Table.th>
+          </>
+        }
+        body={
+          <>
+            {props.data.map((datum) => (
+              <>
+                <Table.tr className="p-0">
+                  <Table.td className={[cellClasses].join(' ')}>
+                    <RouteTdContent {...datum} />
+                  </Table.td>
+                  <Table.td className={[cellClasses, 'text-right align-top'].join(' ')}>
+                    {datum.count}
+                  </Table.td>
+                </Table.tr>
+              </>
+            ))}
+          </>
+        }
+      />
+    </>
   )
 }
 
@@ -74,3 +121,41 @@ export const renderResponseSpeed = (
     />
   )
 }
+
+interface RouteTdContentProps {
+  method: string
+  path: string
+  search: string
+}
+const RouteTdContent = (datum: RouteTdContentProps) => (
+  <Collapsible>
+    <Collapsible.Trigger asChild>
+      <div className="flex gap-2">
+        <Button type="text" className=" !py-0 !p-1" title="Show more route details">
+          <IconChevronRight
+            size={14}
+            className="transition data-open-parent:rotate-90 data-closed-parent:rotate-0"
+          />
+        </Button>
+        <TextFormatter className="w-10 h-4 text-center rounded bg-scale-500" value={datum.method} />
+        <div>
+          <TextFormatter className="text-scale-1100" value={datum.path} />
+          <TextFormatter
+            className="max-w-sm text-scale-900"
+            value={decodeURIComponent(datum.search || '')}
+          />
+        </div>
+      </div>
+    </Collapsible.Trigger>
+    <Collapsible.Content className="pt-2">
+      <pre className={`syntax-highlight overflow-auto rounded bg-scale-300 p-2 !text-xs`}>
+        <div
+          className="text-wrap"
+          dangerouslySetInnerHTML={{
+            __html: jsonSyntaxHighlight(queryParamsToObject(datum.search)),
+          }}
+        />
+      </pre>
+    </Collapsible.Content>
+  </Collapsible>
+)

--- a/studio/components/ui/Charts/BarChart.tsx
+++ b/studio/components/ui/Charts/BarChart.tsx
@@ -43,12 +43,12 @@ const BarChart: React.FC<BarChartProps> = ({
   const resolvedHighlightedLabel =
     (focusDataIndex !== null &&
       data &&
-      data[focusDataIndex] &&
+      data[focusDataIndex] !== undefined &&
       day(data[focusDataIndex][xAxisKey]).format(customDateFormat)) ||
     highlightedLabel
 
   const resolvedHighlightedValue =
-    (focusDataIndex !== null ? data[focusDataIndex]?.[yAxisKey] : null) || highlightedValue
+    (focusDataIndex !== null ? data[focusDataIndex]?.[yAxisKey] : highlightedValue) 
 
   return (
     <div className={['flex flex-col gap-3', className].join(' ')}>

--- a/studio/pages/project/[ref]/reports/api-overview.tsx
+++ b/studio/pages/project/[ref]/reports/api-overview.tsx
@@ -75,6 +75,8 @@ export const ApiReport: NextPageWithLayout = () => {
         tooltip="Error responses with 4XX or 5XX status codes"
         data={report.data.errorCounts || []}
         renderer={renderErrorCounts}
+        appendProps={{data: report.data.topErrorRoutes || [] }}
+        append={renderTopApiRoutes}
       />
       <ReportWidget
         isLoading={report.isLoading}
@@ -99,6 +101,7 @@ const useApiReport = () => {
   const totalRequests = queryHooks.totalRequests()
   const topRoutes = queryHooks.topRoutes()
   const errorCounts = queryHooks.errorCounts()
+  const topErrorRoutes = queryHooks.topErrorRoutes()
   const responseSpeed = queryHooks.responseSpeed()
   const activeHooks = [totalRequests, topRoutes, errorCounts, responseSpeed]
   const [filters, setFilters] = useState<ReportFilterItem[]>([])
@@ -137,6 +140,10 @@ const useApiReport = () => {
     if (errorCounts[1].changeQuery) {
       errorCounts[1].changeQuery(PRESET_CONFIG.api.queries.errorCounts.sql(filters))
     }
+
+    if (topErrorRoutes[1].changeQuery) {
+      topErrorRoutes[1].changeQuery(PRESET_CONFIG.api.queries.topErrorRoutes.sql(filters))
+    }
     if (responseSpeed[1].changeQuery) {
       responseSpeed[1].changeQuery(PRESET_CONFIG.api.queries.responseSpeed.sql(filters))
     }
@@ -159,12 +166,14 @@ const useApiReport = () => {
       errorCounts: errorCounts[0].logData,
       responseSpeed: responseSpeed[0].logData,
       topRoutes: topRoutes[0].logData,
+      topErrorRoutes: topErrorRoutes[0].logData,
     },
     params: {
       totalRequests: totalRequests[0].params,
       errorCounts: errorCounts[0].params,
       responseSpeed: responseSpeed[0].params,
       topRoutes: topRoutes[0].params,
+      topErrorRoutes: topErrorRoutes[0].params,
     },
     mergeParams: handleSetParams,
     filters,

--- a/studio/pages/project/[ref]/reports/api-overview.tsx
+++ b/studio/pages/project/[ref]/reports/api-overview.tsx
@@ -66,7 +66,7 @@ export const ApiReport: NextPageWithLayout = () => {
         data={report.data.totalRequests || []}
         renderer={renderTotalRequests}
         append={renderTopApiRoutes}
-        appendProps={{data: report.data.topRoutes || [] }}
+        appendProps={{ data: report.data.topRoutes || [] }}
       />
       <ReportWidget
         isLoading={report.isLoading}
@@ -75,7 +75,7 @@ export const ApiReport: NextPageWithLayout = () => {
         tooltip="Error responses with 4XX or 5XX status codes"
         data={report.data.errorCounts || []}
         renderer={renderErrorCounts}
-        appendProps={{data: report.data.topErrorRoutes || [] }}
+        appendProps={{ data: report.data.topErrorRoutes || [] }}
         append={renderTopApiRoutes}
       />
       <ReportWidget
@@ -85,6 +85,8 @@ export const ApiReport: NextPageWithLayout = () => {
         tooltip="Average response speed (in miliseconds) of a request"
         data={report.data.responseSpeed || []}
         renderer={renderResponseSpeed}
+        appendProps={{ data: report.data.topSlowRoutes || [] }}
+        append={renderTopApiRoutes}
       />
     </ReportPadding>
   )
@@ -103,7 +105,15 @@ const useApiReport = () => {
   const errorCounts = queryHooks.errorCounts()
   const topErrorRoutes = queryHooks.topErrorRoutes()
   const responseSpeed = queryHooks.responseSpeed()
-  const activeHooks = [totalRequests, topRoutes, errorCounts, responseSpeed]
+  const topSlowRoutes = queryHooks.topSlowRoutes()
+  const activeHooks = [
+    totalRequests,
+    topRoutes,
+    errorCounts,
+    topErrorRoutes,
+    responseSpeed,
+    topSlowRoutes,
+  ]
   const [filters, setFilters] = useState<ReportFilterItem[]>([])
   const addFilter = (filter: ReportFilterItem) => {
     // use a deep equal when comparing objects.
@@ -147,6 +157,10 @@ const useApiReport = () => {
     if (responseSpeed[1].changeQuery) {
       responseSpeed[1].changeQuery(PRESET_CONFIG.api.queries.responseSpeed.sql(filters))
     }
+
+    if (topSlowRoutes[1].changeQuery) {
+      topSlowRoutes[1].changeQuery(PRESET_CONFIG.api.queries.topSlowRoutes.sql(filters))
+    }
   }, [JSON.stringify(filters)])
 
   const handleRefresh = async () => {
@@ -167,6 +181,7 @@ const useApiReport = () => {
       responseSpeed: responseSpeed[0].logData,
       topRoutes: topRoutes[0].logData,
       topErrorRoutes: topErrorRoutes[0].logData,
+      topSlowRoutes: topSlowRoutes[0].logData,
     },
     params: {
       totalRequests: totalRequests[0].params,
@@ -174,6 +189,7 @@ const useApiReport = () => {
       responseSpeed: responseSpeed[0].params,
       topRoutes: topRoutes[0].params,
       topErrorRoutes: topErrorRoutes[0].params,
+      topSlowRoutes: topSlowRoutes[0].params,
     },
     mergeParams: handleSetParams,
     filters,

--- a/studio/pages/project/[ref]/reports/api-overview.tsx
+++ b/studio/pages/project/[ref]/reports/api-overview.tsx
@@ -9,10 +9,10 @@ import {
 import ReportWidget from 'components/interfaces/Reports/ReportWidget'
 import { queriesFactory } from 'components/interfaces/Reports/Reports.utils'
 import {
-  renderTotalRequests,
-  renderErrorCounts,
-  renderResponseSpeed,
-  renderTopApiRoutes,
+  TotalRequestsChartRenderer,
+  ErrorCountsChartRenderer,
+  ResponseSpeedChartRenderer,
+  TopApiRoutesRenderer,
 } from 'components/interfaces/Reports/renderers/ApiRenderers'
 import { useState, useEffect } from 'react'
 import ReportHeader from 'components/interfaces/Reports/ReportHeader'
@@ -64,8 +64,8 @@ export const ApiReport: NextPageWithLayout = () => {
         params={report.params.totalRequests}
         title="Total Requests"
         data={report.data.totalRequests || []}
-        renderer={renderTotalRequests}
-        append={renderTopApiRoutes}
+        renderer={TotalRequestsChartRenderer}
+        append={TopApiRoutesRenderer}
         appendProps={{ data: report.data.topRoutes || [] }}
       />
       <ReportWidget
@@ -74,9 +74,9 @@ export const ApiReport: NextPageWithLayout = () => {
         title="Response Errors"
         tooltip="Error responses with 4XX or 5XX status codes"
         data={report.data.errorCounts || []}
-        renderer={renderErrorCounts}
+        renderer={ErrorCountsChartRenderer}
         appendProps={{ data: report.data.topErrorRoutes || [] }}
-        append={renderTopApiRoutes}
+        append={TopApiRoutesRenderer}
       />
       <ReportWidget
         isLoading={report.isLoading}
@@ -84,9 +84,9 @@ export const ApiReport: NextPageWithLayout = () => {
         title="Response Speed"
         tooltip="Average response speed (in miliseconds) of a request"
         data={report.data.responseSpeed || []}
-        renderer={renderResponseSpeed}
+        renderer={ResponseSpeedChartRenderer}
         appendProps={{ data: report.data.topSlowRoutes || [] }}
-        append={renderTopApiRoutes}
+        append={TopApiRoutesRenderer}
       />
     </ReportPadding>
   )

--- a/studio/pages/project/[ref]/reports/api-overview.tsx
+++ b/studio/pages/project/[ref]/reports/api-overview.tsx
@@ -12,6 +12,7 @@ import {
   renderTotalRequests,
   renderErrorCounts,
   renderResponseSpeed,
+  renderTopApiRoutes,
 } from 'components/interfaces/Reports/renderers/ApiRenderers'
 import { useState, useEffect } from 'react'
 import ReportHeader from 'components/interfaces/Reports/ReportHeader'
@@ -64,6 +65,8 @@ export const ApiReport: NextPageWithLayout = () => {
         title="Total Requests"
         data={report.data.totalRequests || []}
         renderer={renderTotalRequests}
+        append={renderTopApiRoutes}
+        appendProps={{data: report.data.topRoutes || [] }}
       />
       <ReportWidget
         isLoading={report.isLoading}
@@ -94,9 +97,10 @@ const useApiReport = () => {
     projectRef ?? 'default'
   )
   const totalRequests = queryHooks.totalRequests()
+  const topRoutes = queryHooks.topRoutes()
   const errorCounts = queryHooks.errorCounts()
   const responseSpeed = queryHooks.responseSpeed()
-  const activeHooks = [totalRequests, errorCounts, responseSpeed]
+  const activeHooks = [totalRequests, topRoutes, errorCounts, responseSpeed]
   const [filters, setFilters] = useState<ReportFilterItem[]>([])
   const addFilter = (filter: ReportFilterItem) => {
     // use a deep equal when comparing objects.
@@ -127,6 +131,9 @@ const useApiReport = () => {
     if (totalRequests[1].changeQuery) {
       totalRequests[1].changeQuery(PRESET_CONFIG.api.queries.totalRequests.sql(filters))
     }
+    if (topRoutes[1].changeQuery) {
+      topRoutes[1].changeQuery(PRESET_CONFIG.api.queries.topRoutes.sql(filters))
+    }
     if (errorCounts[1].changeQuery) {
       errorCounts[1].changeQuery(PRESET_CONFIG.api.queries.errorCounts.sql(filters))
     }
@@ -151,11 +158,13 @@ const useApiReport = () => {
       totalRequests: totalRequests[0].logData,
       errorCounts: errorCounts[0].logData,
       responseSpeed: responseSpeed[0].logData,
+      topRoutes: topRoutes[0].logData,
     },
     params: {
       totalRequests: totalRequests[0].params,
       errorCounts: errorCounts[0].params,
       responseSpeed: responseSpeed[0].params,
+      topRoutes: topRoutes[0].params,
     },
     mergeParams: handleSetParams,
     filters,

--- a/studio/tests/components/Reports/ReportWidget.test.js
+++ b/studio/tests/components/Reports/ReportWidget.test.js
@@ -3,11 +3,10 @@ import { useRouter } from 'next/router'
 import { screen } from '@testing-library/react'
 import { render } from '../../helpers'
 import ReportWidget from 'components/interfaces/Reports/ReportWidget'
+import userEvent from '@testing-library/user-event'
 beforeEach(() => {
   // reset mocks between tests
   get.mockReset()
-  useRouter.mockReset()
-  useRouter.mockReturnValue(defaultRouterMock())
 })
 
 test('static elements', async () => {
@@ -16,13 +15,8 @@ test('static elements', async () => {
   await screen.findByText(/something/)
 })
 
-test("lazy load component expandable", async ()=>{
-  const Expandable = ()=> "expanded"
-  render(<ReportWidget data={[]} renderer={() => null} expandable={Expandable} />)
-  await screen.findByText(/Expand/)
-})
-
-test("customize expandable text", async ()=>{
-  render(<ReportWidget data={[]} renderer={() => null} expandable={()=> null} expandableText="open_me"/>)
-  await screen.findByText(/open_me/)
+test("append", async ()=>{
+  const appendable = ()=> "some text"
+  render(<ReportWidget data={[]} renderer={() => null} append={appendable} />)
+  await screen.findByText(/some text/)
 })

--- a/studio/tests/components/Reports/ReportWidget.test.js
+++ b/studio/tests/components/Reports/ReportWidget.test.js
@@ -1,41 +1,8 @@
-// mock the fetch function
-jest.mock('lib/common/fetch')
 import { get } from 'lib/common/fetch'
-
-// mock mobx
-jest.mock('mobx-react-lite')
-import { observer } from 'mobx-react-lite'
-observer.mockImplementation((v) => v)
-
-// mock the router
-jest.mock('next/router')
 import { useRouter } from 'next/router'
-const defaultRouterMock = () => {
-  const router = jest.fn()
-  router.query = {}
-  router.push = jest.fn()
-  router.pathname = 'logs/path'
-  return router
-}
-useRouter.mockReturnValue(defaultRouterMock())
-
-// mock usage flags
-jest.mock('components/ui/Flag/Flag')
-import Flag from 'components/ui/Flag/Flag'
-Flag.mockImplementation(({ children }) => <>{children}</>)
-jest.mock('hooks')
-import { useFlag } from 'hooks'
-useFlag.mockReturnValue(true)
-
-import { fireEvent, waitFor, screen, act } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import { render } from '../../helpers'
-import userEvent from '@testing-library/user-event'
-import { wait } from '@testing-library/user-event/dist/utils'
-import { logDataFixture } from '../../fixtures'
-import { LogsTableName } from 'components/interfaces/Settings/Logs'
-import { Presets } from 'components/interfaces/Reports/Reports.types'
 import ReportWidget from 'components/interfaces/Reports/ReportWidget'
-import { clickDropdown } from 'tests/helpers'
 beforeEach(() => {
   // reset mocks between tests
   get.mockReset()
@@ -47,4 +14,15 @@ test('static elements', async () => {
   render(<ReportWidget data={[]} title="Some chart" sql="select" renderer={() => 'something'} />)
   await screen.findByText(/Some chart/)
   await screen.findByText(/something/)
+})
+
+test("lazy load component expandable", async ()=>{
+  const Expandable = ()=> "expanded"
+  render(<ReportWidget data={[]} renderer={() => null} expandable={Expandable} />)
+  await screen.findByText(/Expand/)
+})
+
+test("customize expandable text", async ()=>{
+  render(<ReportWidget data={[]} renderer={() => null} expandable={()=> null} expandableText="open_me"/>)
+  await screen.findByText(/open_me/)
 })

--- a/studio/tests/pages/projects/reports/api-report.test.js
+++ b/studio/tests/pages/projects/reports/api-report.test.js
@@ -26,3 +26,16 @@ test('refresh button', async () => {
   userEvent.click(await screen.findByText(/Refresh/))
   await waitFor(() => expect(get).toBeCalled())
 })
+
+test('expandable tables', async () => {
+  get.mockImplementation(async (_url) => [
+    { data: [{ timestamp: new Date().toISOString(), count: 123 }] },
+  ])
+  const expandables = await screen.findByText('View API requests')
+  const first = expandables[0]
+  get.mockImplementationOnce(async (_url) => [{ data: [{ path: '/my-path', count: 22 }] }])
+  userEvent.click(first)
+  await screen.findByText('Hide API Requests')
+  await screen.findByText(/\/my\-path/)
+  await screen.findByText(/22/)
+})

--- a/studio/tests/pages/projects/reports/api-report.test.js
+++ b/studio/tests/pages/projects/reports/api-report.test.js
@@ -7,7 +7,7 @@ import userEvent from '@testing-library/user-event'
 beforeEach(() => {
   // reset mocks between tests
   get.mockReset()
-  get.mockImplementation(async (_url) => [{ data: [] }])
+  get.mockImplementation(async (_url) => [{ result: [] }])
 })
 
 test(`static elements`, async () => {
@@ -27,15 +27,85 @@ test('refresh button', async () => {
   await waitFor(() => expect(get).toBeCalled())
 })
 
-test('expandable tables', async () => {
-  get.mockImplementation(async (_url) => [
-    { data: [{ timestamp: new Date().toISOString(), count: 123 }] },
-  ])
-  const expandables = await screen.findByText('View API requests')
-  const first = expandables[0]
-  get.mockImplementationOnce(async (_url) => [{ data: [{ path: '/my-path', count: 22 }] }])
-  userEvent.click(first)
-  await screen.findByText('Hide API Requests')
-  await screen.findByText(/\/my\-path/)
-  await screen.findByText(/22/)
+test('append - api request routes', async () => {
+  get.mockImplementation(async (url) => {
+    if (decodeURIComponent(url).includes("request.path")) {
+      return { result: [{ path: 'mypath', method: 'GET', status_code: 200, search: 'some-query', count: 22 }] }
+    }
+    return { result: [{ timestamp: new Date().toISOString(), count: 123 }] }
+  })
+  render(<ApiReport />)
+  await waitFor(() => expect(get).toBeCalled())
+  await screen.findAllByText(/mypath/)
+  await screen.findAllByText(/GET/)
+  await screen.findAllByText(/200/)
+  await screen.findAllByText(/some\-query/)
+  await screen.findAllByText(/22/)
 })
+
+
+test('append - error routes', async () => {
+  get.mockImplementation(async (url) => {
+    const uri = decodeURIComponent(url)
+    if (uri.includes("400")) {
+      return { result: [{ path: 'mypath', method: 'GET', status_code: 200, search: 'some-query', count: 22 }] }
+    }
+    return { result: [{ timestamp: new Date().toISOString(), count: 123 }] }
+  })
+  render(<ApiReport />)
+  await waitFor(() => expect(get).toBeCalled())
+  await screen.findAllByText(/mypath/)
+  await screen.findAllByText(/GET/)
+  await screen.findAllByText(/200/)
+  await screen.findAllByText(/some\-query/)
+  await screen.findAllByText(/22/)
+})
+
+
+test('append - error routes', async () => {
+  get.mockImplementation(async (url) => {
+    const uri = decodeURIComponent(url)
+    if (uri.includes("avg") && uri.includes("request.path")) {
+      return { result: [{ path: 'mypath', method: 'GET', status_code: 200, avg: 534, search: 'some-query', count: 22 }] }
+    }
+    return { result: [{ timestamp: new Date().toISOString(), count: 123 }] }
+  })
+  render(<ApiReport />)
+  await waitFor(() => expect(get).toBeCalled())
+  await screen.findAllByText(/mypath/)
+  await screen.findAllByText(/GET/)
+  await screen.findAllByText(/200/)
+  await screen.findAllByText(/some\-query/)
+  await screen.findAllByText(/22/)
+  await screen.findAllByText(/534\.00ms/)
+})
+
+
+
+// test('expandable error routes', async () => {
+//   get.mockImplementation(async (url) => {
+//     if (url.includes('path')) {
+//       return [{ data: [{ path: '/my-path', method: 'GET', search: '?=123', count: 22 }] }]
+//     }
+//     return [{ data: [{ timestamp: new Date().toISOString(), count: 123 }] }]
+//   })
+
+//   render(<ApiReport />)
+//   await screen.findByText(/\/my\-path/)
+//   await screen.findByText(/\?\=123/)
+//   await screen.findByText(/22/)
+// })
+
+// test('expandable high latency routes', async () => {
+//   get.mockImplementation(async (url) => {
+//     if (url.includes('path')) {
+//       return [{ data: [{ path: '/my-path', method: 'GET', search: '?=123', avg_ms: 55, count: 22 }] }]
+//     }
+//     return [{ data: [{ timestamp: new Date().toISOString(), avg_ms: 123  }] }]
+//   })
+//   render(<ApiReport />)
+//   await screen.findByText(/\/my\-path/)
+//   await screen.findByText(/\?\=123/)
+//   await screen.findByText(/22/)
+//   await screen.findByText(/55/)
+// })


### PR DESCRIPTION
This PR adds in route display information into the API report, and showcases the underlying top 3 routes for each chart.
This allows users to identify routes within the report.

Furthermore, this PR also adds in the timeseries filling, so that the charts are now of standardized width and are no longer jumping around wildly.

The useLogQuery hook needs a little refactoring so that the data and event handler callbacks are combined, in line with other hooks. This will come in a later PR.


- [x] expandable prop for ReportWidget
- [x] API top routes table
- [x] API top error routes table
- [x] API top slowest routes table

https://user-images.githubusercontent.com/22714384/235647096-cf6c3aa8-141e-43c8-89ae-4eb729b5cd06.mov

