### PR TITLE
feat: uuid default

### DIFF
--- a/apps/docs/pages/guides/resources/migrating-to-supabase/firestore-data.mdx
+++ b/apps/docs/pages/guides/resources/migrating-to-supabase/firestore-data.mdx
@@ -89,7 +89,7 @@ And split it into two files (one table for users and one table for items):
   - `smallserial` Creates a key using `(id SMALLSERIAL PRIMARY KEY)` (autoincrementing 2-byte integer).
   - `serial` Creates a key using `(id SERIAL PRIMARY KEY)` (autoincrementing 4-byte integer).
   - `bigserial` Creates a key using `(id BIGSERIAL PRIMARY KEY)` (autoincrementing 8-byte integer).
-  - `uuid` Creates a key using `(id UUID PRIMARY KEY DEFAULT uuid_generate_v4())` (randomly generated UUID).
+  - `uuid` Creates a key using `(id UUID PRIMARY KEY DEFAULT gen_random_uuid())` (randomly generated UUID).
   - `firestore_id` Creates a key using `(id TEXT PRIMARY KEY)` (uses existing `firestore_id` random text as key).
 - `[<primary_key_name>]` (optional) Name of primary key. Defaults to "id".
 

--- a/apps/www/_blog/2022-03-08-audit.mdx
+++ b/apps/www/_blog/2022-03-08-audit.mdx
@@ -206,7 +206,7 @@ as $$
         case
             when rec is null then null
 						-- if no primary key exists, use a random uuid
-            when pkey_cols = array[]::text[] then uuid_generate_v4()
+            when pkey_cols = array[]::text[] then gen_random_uuid()
             else (
                 select
                     uuid_generate_v5(

--- a/apps/www/_blog/2022-06-30-flutter-tutorial-building-a-chat-app.mdx
+++ b/apps/www/_blog/2022-06-30-flutter-tutorial-building-a-chat-app.mdx
@@ -109,7 +109,7 @@ create table if not exists public.profiles (
 comment on table public.profiles is 'Holds all of users profile information';
 
 create table if not exists public.messages (
-    id uuid not null primary key default uuid_generate_v4(),
+    id uuid not null primary key default gen_random_uuid(),
     profile_id uuid default auth.uid() references public.profiles(id) on delete cascade not null,
     content varchar(500) not null,
     created_at timestamp with time zone default timezone('utc' :: text, now()) not null

--- a/apps/www/_blog/2022-09-08-choosing-a-postgres-primary-key.mdx
+++ b/apps/www/_blog/2022-09-08-choosing-a-postgres-primary-key.mdx
@@ -266,7 +266,7 @@ These don't have a time component, but  they don't have in time they make up for
 We can generate them in Postgres like this (with `uuid-ossp`):
 
 ```sql
-SELECT uuid_generate_v4();
+SELECT gen_random_uuid();
 
            uuid_generate_v4
 --------------------------------------

--- a/apps/www/_blog/2022-11-17-fetching-and-caching-supabase-data-in-next-js-server-components.mdx
+++ b/apps/www/_blog/2022-11-17-fetching-and-caching-supabase-data-in-next-js-server-components.mdx
@@ -58,7 +58,7 @@ Once your instance is up and running, head over to the [SQL Editor](https://app.
 
 ```sql
 create table if not exists posts (
-  id uuid default uuid_generate_v4() primary key,
+  id uuid default gen_random_uuid() primary key,
   created_at timestamp with time zone default timezone('utc'::text, now()) not null,
   title text,
   content text

--- a/apps/www/_blog/2022-11-22-flutter-authentication-and-authorization-with-rls.mdx
+++ b/apps/www/_blog/2022-11-22-flutter-authentication-and-authorization-with-rls.mdx
@@ -58,7 +58,7 @@ We will also introduce a `create_new_room` function, which is a [database functi
 -- *** Table definitions ***
 
 create table if not exists public.rooms (
-    id uuid not null primary key default uuid_generate_v4(),
+    id uuid not null primary key default gen_random_uuid(),
     created_at timestamp with time zone default timezone('utc' :: text, now()) not null
 );
 comment on table public.rooms is 'Holds chat rooms';

--- a/apps/www/_blog/2022-11-24-sql-or-nosql-both-with-postgresql.mdx
+++ b/apps/www/_blog/2022-11-24-sql-or-nosql-both-with-postgresql.mdx
@@ -136,7 +136,7 @@ Let's see how we can use the power of SQL together with the ease-of-use of NoSQL
 
 ```sql
 CREATE TABLE calendar (
-    id uuid DEFAULT uuid_generate_v4() NOT NULL,
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
     date date,
     user_id uuid NOT NULL,
     weight numeric,

--- a/examples/caching/with-nextjs-13/supabase/migrations/20221028100232_init.sql
+++ b/examples/caching/with-nextjs-13/supabase/migrations/20221028100232_init.sql
@@ -1,5 +1,5 @@
 create table if not exists articles (
-  id uuid default uuid_generate_v4() primary key,
+  id uuid default gen_random_uuid() primary key,
   created_at timestamp with time zone default timezone('utc'::text, now()) not null,
   title text not null,
   content text not null,

--- a/studio/components/interfaces/SQLEditor/SQLEditor.constants.ts
+++ b/studio/components/interfaces/SQLEditor/SQLEditor.constants.ts
@@ -880,7 +880,7 @@ GRANT ALL ON SCHEMA next_auth TO postgres;
 --
 CREATE TABLE IF NOT EXISTS next_auth.users
 (
-    id uuid NOT NULL DEFAULT uuid_generate_v4(),
+    id uuid NOT NULL DEFAULT gen_random_uuid(),
     name text,
     email text,
     "emailVerified" timestamp with time zone,
@@ -908,7 +908,7 @@ $$;
 --
 CREATE TABLE IF NOT EXISTS  next_auth.sessions
 (
-    id uuid NOT NULL DEFAULT uuid_generate_v4(),
+    id uuid NOT NULL DEFAULT gen_random_uuid(),
     expires timestamp with time zone NOT NULL,
     "sessionToken" text NOT NULL,
     "userId" uuid,
@@ -928,7 +928,7 @@ GRANT ALL ON TABLE next_auth.sessions TO service_role;
 --
 CREATE TABLE IF NOT EXISTS  next_auth.accounts
 (
-    id uuid NOT NULL DEFAULT uuid_generate_v4(),
+    id uuid NOT NULL DEFAULT gen_random_uuid(),
     type text NOT NULL,
     provider text NOT NULL,
     "providerAccountId" text NOT NULL,

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnDefaultValue.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnDefaultValue.tsx
@@ -52,7 +52,7 @@ const ColumnDefaultValue: FC<Props> = ({
     <InputWithSuggestions
       label="Default Value"
       layout="vertical"
-      description="Can either be a literal or an expression. When using an expression wrap your expression in brackets, e.g. (uuid_generate_v4())"
+      description="Can either be a literal or an expression. When using an expression wrap your expression in brackets, e.g. (gen_random_uuid())"
       placeholder={
         typeof columnFields.defaultValue === 'string' && columnFields.defaultValue.length === 0
           ? 'EMPTY'

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.constants.ts
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.constants.ts
@@ -32,8 +32,8 @@ const defaultTextBasedValues: Suggestion[] = [
 export const typeExpressionSuggestions: Dictionary<Suggestion[]> = {
   uuid: [
     {
-      name: 'uuid_generate_v4()',
-      value: 'uuid_generate_v4()',
+      name: 'gen_random_uuid()',
+      value: 'gen_random_uuid()',
       description: 'Generates a version 4 UUID',
     },
   ],

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/ColumnManagement.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/ColumnManagement.tsx
@@ -241,7 +241,7 @@ const ColumnManagement: FC<Props> = ({
                     >
                       <span className="text-xs text-scale-1200">
                         Can either be a literal or an expression. When using an expression wrap your
-                        expression in brackets, e.g. (uuid_generate_v4())
+                        expression in brackets, e.g. (gen_random_uuid())
                       </span>
                     </div>
                   </Tooltip.Content>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase Studio Feature

## What is the current behavior?

Currently the `uuid` default uses `uuid_generate_v4()`

## What is the new behavior?

Default `uuid` is now using `gen_random_uuid()`:

<img width="665" alt="Screenshot 2023-05-01 at 20 10 57" src="https://user-images.githubusercontent.com/22655069/235515235-88e26656-1195-4803-a091-52991e1a8635.png">


## Additional context

Closes #13999 
