### PR TITLE
chore: only redirect when adding CC when needed

### DIFF
--- a/studio/components/interfaces/Billing/AddNewPaymentMethodModal/AddNewPaymentMethodModal.tsx
+++ b/studio/components/interfaces/Billing/AddNewPaymentMethodModal/AddNewPaymentMethodModal.tsx
@@ -14,11 +14,12 @@ interface Props {
   visible: boolean
   returnUrl: string
   onCancel: () => void
+  onConfirm: () => void
 }
 
 const stripePromise = loadStripe(STRIPE_PUBLIC_KEY)
 
-const AddNewPaymentMethodModal: FC<Props> = ({ visible, returnUrl, onCancel }) => {
+const AddNewPaymentMethodModal: FC<Props> = ({ visible, returnUrl, onCancel, onConfirm }) => {
   const { ui } = useStore()
   const [intent, setIntent] = useState<any>()
 
@@ -87,6 +88,11 @@ const AddNewPaymentMethodModal: FC<Props> = ({ visible, returnUrl, onCancel }) =
     return onCancel()
   }
 
+  const onLocalConfirm = () => {
+    setIntent(undefined)
+    return onConfirm()
+  }
+
   return (
     // We cant display the hCaptcha in the modal, as the modal auto-closes when clicking the captcha
     // So we only show the modal if the captcha has been executed successfully (intent loaded)
@@ -114,7 +120,11 @@ const AddNewPaymentMethodModal: FC<Props> = ({ visible, returnUrl, onCancel }) =
       >
         <div className="py-4 space-y-4">
           <Elements stripe={stripePromise} options={options}>
-            <AddPaymentMethodForm returnUrl={returnUrl} onCancel={onLocalCancel} />
+            <AddPaymentMethodForm
+              returnUrl={returnUrl}
+              onCancel={onLocalCancel}
+              onConfirm={onLocalConfirm}
+            />
           </Elements>
         </div>
       </Modal>

--- a/studio/components/interfaces/Billing/AddNewPaymentMethodModal/AddPaymentMethodForm.tsx
+++ b/studio/components/interfaces/Billing/AddNewPaymentMethodModal/AddPaymentMethodForm.tsx
@@ -6,13 +6,14 @@ import { useStore } from 'hooks'
 interface Props {
   returnUrl: string
   onCancel: () => void
+  onConfirm: () => void
 }
 
 // Stripe docs recommend to use the new SetupIntent flow over
 // manually creating and attaching payment methods via the API
 // Small UX annoyance here, that the page will be refreshed
 
-const AddPaymentMethodForm: FC<Props> = ({ returnUrl, onCancel }) => {
+const AddPaymentMethodForm: FC<Props> = ({ returnUrl, onCancel, onConfirm }) => {
   const { ui } = useStore()
   const stripe = useStripe()
   const elements = useElements()
@@ -36,6 +37,7 @@ const AddPaymentMethodForm: FC<Props> = ({ returnUrl, onCancel }) => {
 
     const { error } = await stripe.confirmSetup({
       elements,
+      redirect: 'if_required',
       confirmParams: { return_url: returnUrl },
     })
 
@@ -45,6 +47,9 @@ const AddPaymentMethodForm: FC<Props> = ({ returnUrl, onCancel }) => {
         category: 'error',
         message: error?.message ?? ' Failed to save card details',
       })
+    } else {
+      setIsSaving(false)
+      onConfirm()
     }
 
     if (document !== undefined) {

--- a/studio/components/interfaces/Billing/EnterpriseUpdate.tsx
+++ b/studio/components/interfaces/Billing/EnterpriseUpdate.tsx
@@ -33,6 +33,7 @@ interface Props {
   paymentMethods?: PaymentMethod[]
   currentSubscription: StripeSubscription
   isLoadingPaymentMethods: boolean
+  onPaymentMethodAdded: () => void
 }
 
 const EnterpriseUpdate: FC<Props> = ({
@@ -40,6 +41,7 @@ const EnterpriseUpdate: FC<Props> = ({
   paymentMethods,
   currentSubscription,
   isLoadingPaymentMethods,
+  onPaymentMethodAdded,
 }) => {
   const { app, ui } = useStore()
   const router = useRouter()
@@ -91,6 +93,11 @@ const EnterpriseUpdate: FC<Props> = ({
   const [showAddPaymentMethodModal, setShowAddPaymentMethodModal] = useState(false)
 
   const isChangingComputeSize = currentAddons.computeSize?.id !== selectedAddons.computeSize.id
+
+  const onLocalPaymentMethodAdded = () => {
+    setShowAddPaymentMethodModal(false)
+    return onPaymentMethodAdded()
+  }
 
   useEffect(() => {
     getSubscriptionPreview()
@@ -312,6 +319,7 @@ const EnterpriseUpdate: FC<Props> = ({
         visible={showAddPaymentMethodModal}
         returnUrl={`${getURL()}/project/${projectRef}/settings/billing/update/pro`}
         onCancel={() => setShowAddPaymentMethodModal(false)}
+        onConfirm={() => onLocalPaymentMethodAdded()}
       />
     </>
   )

--- a/studio/components/interfaces/Billing/ProUpgrade.tsx
+++ b/studio/components/interfaces/Billing/ProUpgrade.tsx
@@ -38,6 +38,7 @@ interface Props {
   paymentMethods?: PaymentMethod[]
   currentSubscription: StripeSubscription
   isLoadingPaymentMethods: boolean
+  onPaymentMethodAdded: () => void
   onSelectBack: () => void
 }
 
@@ -47,6 +48,7 @@ const ProUpgrade: FC<Props> = ({
   currentSubscription,
   isLoadingPaymentMethods,
   onSelectBack,
+  onPaymentMethodAdded,
 }) => {
   const { app, ui } = useStore()
   const router = useRouter()
@@ -115,6 +117,11 @@ const ProUpgrade: FC<Props> = ({
     currentSubscription.tier.prod_id === STRIPE_PRODUCT_IDS.PAYG
 
   const isChangingComputeSize = currentAddons.computeSize?.id !== selectedAddons.computeSize.id
+
+  const onLocalPaymentMethodAdded = () => {
+    setShowAddPaymentMethodModal(false)
+    return onPaymentMethodAdded()
+  }
 
   useEffect(() => {
     if (!isLoadingPaymentMethods && paymentMethods && paymentMethods.length > 0) {
@@ -362,6 +369,7 @@ const ProUpgrade: FC<Props> = ({
         visible={showAddPaymentMethodModal}
         returnUrl={`${getURL()}/project/${projectRef}/settings/billing/update/pro`}
         onCancel={() => setShowAddPaymentMethodModal(false)}
+        onConfirm={() => onLocalPaymentMethodAdded()}
       />
 
       {/* Spend caps helper modal */}

--- a/studio/components/interfaces/Billing/TeamUpgrade.tsx
+++ b/studio/components/interfaces/Billing/TeamUpgrade.tsx
@@ -35,6 +35,7 @@ interface TeamUpgradeProps {
   paymentMethods?: PaymentMethod[]
   currentSubscription: StripeSubscription
   isLoadingPaymentMethods: boolean
+  onPaymentMethodAdded: () => void
 }
 
 const TeamUpgrade = ({
@@ -42,6 +43,7 @@ const TeamUpgrade = ({
   paymentMethods,
   currentSubscription,
   isLoadingPaymentMethods,
+  onPaymentMethodAdded,
 }: TeamUpgradeProps) => {
   const { app, ui } = useStore()
   const router = useRouter()
@@ -158,6 +160,11 @@ const TeamUpgrade = ({
 
     setIsSubmitting(false)
     return true
+  }
+
+  const onLocalPaymentMethodAdded = () => {
+    setShowAddPaymentMethodModal(false)
+    return onPaymentMethodAdded()
   }
 
   const onConfirmPayment = async () => {
@@ -328,6 +335,7 @@ const TeamUpgrade = ({
         visible={showAddPaymentMethodModal}
         returnUrl={`${getURL()}/project/${projectRef}/settings/billing/update/team`}
         onCancel={() => setShowAddPaymentMethodModal(false)}
+        onConfirm={() => onLocalPaymentMethodAdded()}
       />
     </>
   )

--- a/studio/components/interfaces/Organization/BillingSettings/BillingSettings.tsx
+++ b/studio/components/interfaces/Organization/BillingSettings/BillingSettings.tsx
@@ -104,6 +104,7 @@ const BillingSettings = () => {
           paymentMethods={paymentMethods || []}
           onDefaultMethodUpdated={setCustomer}
           onPaymentMethodsDeleted={() => getPaymentMethods()}
+          onPaymentMethodAdded={() => getPaymentMethods()}
         />
 
         <BillingEmail />

--- a/studio/components/interfaces/Organization/BillingSettings/PaymentMethods.tsx
+++ b/studio/components/interfaces/Organization/BillingSettings/PaymentMethods.tsx
@@ -28,6 +28,7 @@ interface Props {
   paymentMethods: any[]
   onDefaultMethodUpdated: (updatedCustomer: any) => void
   onPaymentMethodsDeleted: () => void
+  onPaymentMethodAdded: () => void
 }
 
 const PaymentMethods: FC<Props> = ({
@@ -36,6 +37,7 @@ const PaymentMethods: FC<Props> = ({
   paymentMethods,
   onDefaultMethodUpdated,
   onPaymentMethodsDeleted,
+  onPaymentMethodAdded,
 }) => {
   const { ui } = useStore()
   const orgSlug = ui.selectedOrganization?.slug ?? ''
@@ -97,6 +99,11 @@ const PaymentMethods: FC<Props> = ({
     } finally {
       setIsUpdatingPaymentMethod(false)
     }
+  }
+
+  const onLocalPaymentMethodAdded = () => {
+    setShowAddPaymentMethodModal(false)
+    return onPaymentMethodAdded()
   }
 
   return (
@@ -252,6 +259,7 @@ const PaymentMethods: FC<Props> = ({
         visible={showAddPaymentMethodModal}
         returnUrl={`${getURL()}/org/${orgSlug}/billing`}
         onCancel={() => setShowAddPaymentMethodModal(false)}
+        onConfirm={() => onLocalPaymentMethodAdded()}
       />
 
       <Modal

--- a/studio/components/interfaces/Organization/NewProject/EmptyPaymentMethodWarning.tsx
+++ b/studio/components/interfaces/Organization/NewProject/EmptyPaymentMethodWarning.tsx
@@ -8,11 +8,17 @@ import InformationBox from 'components/ui/InformationBox'
 import { AddNewPaymentMethodModal } from 'components/interfaces/Billing'
 
 const EmptyPaymentMethodWarning = observer(
-  ({ stripeCustomerId }: { stripeCustomerId: string | undefined }) => {
+  ({ onPaymentMethodAdded }: { onPaymentMethodAdded: () => void }) => {
     const { ui } = useStore()
     const slug = ui.selectedOrganization?.slug
 
     const [showAddPaymentMethodModal, setShowAddPaymentMethodModal] = useState<boolean>(false)
+
+    const onLocalPaymentMethodAdded = () => {
+      setShowAddPaymentMethodModal(false)
+
+      return onPaymentMethodAdded()
+    }
 
     return (
       <div className="mt-4">
@@ -37,6 +43,7 @@ const EmptyPaymentMethodWarning = observer(
           visible={showAddPaymentMethodModal}
           returnUrl={`${getURL()}/new/${slug}`}
           onCancel={() => setShowAddPaymentMethodModal(false)}
+          onConfirm={() => onLocalPaymentMethodAdded()}
         />
       </div>
     )

--- a/studio/pages/new/[slug].tsx
+++ b/studio/pages/new/[slug].tsx
@@ -112,14 +112,14 @@ const Wizard: NextPageWithLayout = () => {
     }
   }, [])
 
-  useEffect(() => {
-    async function getPaymentMethods(slug: string) {
-      const { data: paymentMethods, error } = await get(`${API_URL}/organizations/${slug}/payments`)
-      if (!error) {
-        setPaymentMethods(paymentMethods)
-      }
+  async function getPaymentMethods(slug: string) {
+    const { data: paymentMethods, error } = await get(`${API_URL}/organizations/${slug}/payments`)
+    if (!error) {
+      setPaymentMethods(paymentMethods)
     }
+  }
 
+  useEffect(() => {
     if (slug) {
       getPaymentMethods(slug as string)
     }
@@ -145,6 +145,12 @@ const Wizard: NextPageWithLayout = () => {
 
   function onDbPricingPlanChange(value: string) {
     setDbPricingTierKey(value)
+  }
+
+  function onPaymentMethodAdded() {
+    if (slug) {
+      return getPaymentMethods(slug)
+    }
   }
 
   async function checkPasswordStrength(value: any) {
@@ -443,7 +449,7 @@ const Wizard: NextPageWithLayout = () => {
                 )}
 
                 {!isSelectFreeTier && isEmptyPaymentMethod && (
-                  <EmptyPaymentMethodWarning stripeCustomerId={stripeCustomerId} />
+                  <EmptyPaymentMethodWarning onPaymentMethodAdded={onPaymentMethodAdded} />
                 )}
               </Panel.Content>
             )}

--- a/studio/pages/project/[ref]/settings/billing/update/enterprise.tsx
+++ b/studio/pages/project/[ref]/settings/billing/update/enterprise.tsx
@@ -111,6 +111,7 @@ const BillingUpdateEnterprise: NextPageWithLayout = () => {
       currentSubscription={subscription}
       isLoadingPaymentMethods={isLoadingPaymentMethods}
       paymentMethods={paymentMethods || []}
+      onPaymentMethodAdded={() => getPaymentMethods()}
     />
   )
 }

--- a/studio/pages/project/[ref]/settings/billing/update/pro.tsx
+++ b/studio/pages/project/[ref]/settings/billing/update/pro.tsx
@@ -119,6 +119,7 @@ const BillingUpdatePro: NextPageWithLayout = () => {
       isLoadingPaymentMethods={isLoadingPaymentMethods}
       paymentMethods={paymentMethods || []}
       onSelectBack={() => router.push(`/project/${projectRef}/settings/billing/update`)}
+      onPaymentMethodAdded={() => getPaymentMethods()}
     />
   )
 }

--- a/studio/pages/project/[ref]/settings/billing/update/team.tsx
+++ b/studio/pages/project/[ref]/settings/billing/update/team.tsx
@@ -118,6 +118,7 @@ const BillingUpdateTeam: NextPageWithLayout = () => {
       currentSubscription={subscription}
       isLoadingPaymentMethods={isLoadingPaymentMethods}
       paymentMethods={paymentMethods || []}
+      onPaymentMethodAdded={() => getPaymentMethods()}
     />
   )
 }


### PR DESCRIPTION
When adding a new payment method via modal, we currently **always** redirect and possibly lose the state of the page (i.e. when creating a new project). By only redirecting if necessary, we stay on the page and do not not to reload everything, we just reload the payment methods.

While this generally speeds up the flow for the user and we avoid unnecessary requests, it also avoids some frustration when adding cards while setting up projects and losing the entire state (previously entered password, name, ...).


https://user-images.githubusercontent.com/14073399/235726913-4cb00a72-86e5-4aec-9cbe-2952078a5422.mov

