### PR TITLE
Update supabase_js_v2.yml to mention the unified type of verification for emails `email`

### DIFF
--- a/spec/supabase_js_v2.yml
+++ b/spec/supabase_js_v2.yml
@@ -380,7 +380,7 @@ functions:
     title: 'verifyOtp()'
     $ref: '@supabase/gotrue-js.GoTrueClient.verifyOtp'
     notes: |
-      - The `verifyOtp` method takes in different verification types. If a phone number is used, the type can either be `sms` or `phone_change`. If an email address is used, the type can be one of the following: `signup`, `magiclink`, `recovery`, `invite` or `email_change`.
+      - The `verifyOtp` method takes in different verification types. If a phone number is used, the type can either be `sms` or `phone_change`. If an email address is used, the type can be one of the following: `email`, `recovery`, `invite` or `email_change` (`signup` and `magiclink` types are deprecated).
       - The verification type used should be determined based on the corresponding auth method called before `verifyOtp` to sign up / sign-in a user.
     examples:
       - id: verify-sms-one-time-password(otp)
@@ -395,7 +395,7 @@ functions:
         isSpotlight: false
         code: |
           ```js
-          const { data, error } = await supabase.auth.verifyOtp({ email, token, type: 'signup'})
+          const { data, error } = await supabase.auth.verifyOtp({ email, token, type: 'email'})
           ```
   - id: get-session
     title: 'getSession()'


### PR DESCRIPTION
Fixes #14089 https://github.com/supabase/supabase/issues/14089 

Specifies that `email` is the right type for OTP verification and adds `signup` and `magiclink` to be deprecated per https://github.com/supabase/gotrue/pull/885 and https://github.com/supabase/gotrue-js/pull/642

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

https://github.com/supabase/supabase/issues/14089  

## What is the new behavior?

This adds the missing `email` type to the /verify call as introduced in [gotrue v2.40](https://github.com/supabase/gotrue/pull/885)  and [gotrue-js v2.19](https://github.com/supabase/gotrue-js/pull/642)


## Additional context

This fixes a bug for users who read the documentation and assumed (like me) that using `magiclink` as the type of verification would work for new and returning users. Which was not the case. New users would have needed the `signup` type or the OTP would throw a 401. 
