### PR TITLE
feat: tell users which email supabase support will respond to

### DIFF
--- a/studio/components/interfaces/Support/SupportForm.tsx
+++ b/studio/components/interfaces/Support/SupportForm.tsx
@@ -22,6 +22,7 @@ import { useStore, useFlag } from 'hooks'
 import { post, get } from 'lib/common/fetch'
 import { detectBrowser } from 'lib/helpers'
 import { API_URL, PRICING_TIER_PRODUCT_IDS } from 'lib/constants'
+import { useProfileQuery } from 'data/profile/profile-query'
 
 import Divider from 'components/ui/Divider'
 import Connecting from 'components/ui/Loading'
@@ -76,11 +77,11 @@ const SupportForm: FC<Props> = ({ setSentCategory }) => {
     }
   }, [uploadedFiles])
 
-  useEffect(() => {
-    get(`${API_URL}/profile`).then((data) => {
-      setRespondToEmail(data.primary_email)
-    })
-  }, [respondToEmail])
+  useProfileQuery({
+    onSuccess(profile) {
+      setRespondToEmail(profile.primary_email)
+    },
+  })
 
   if (!isInitialized) {
     return (

--- a/studio/components/interfaces/Support/SupportForm.tsx
+++ b/studio/components/interfaces/Support/SupportForm.tsx
@@ -48,7 +48,6 @@ const SupportForm: FC<Props> = ({ setSentCategory }) => {
   const [uploadedFiles, setUploadedFiles] = useState<File[]>([])
   const [uploadedDataUrls, setUploadedDataUrls] = useState<string[]>([])
   const [selectedServices, setSelectedServices] = useState<string[]>([])
-  const [respondToEmail, setRespondToEmail] = useState<string>('')
 
   // Get all orgs and projects from global store
   const sortedOrganizations = app.organizations.list()
@@ -77,11 +76,8 @@ const SupportForm: FC<Props> = ({ setSentCategory }) => {
     }
   }, [uploadedFiles])
 
-  useProfileQuery({
-    onSuccess(profile) {
-      setRespondToEmail(profile.primary_email)
-    },
-  })
+  const { data: profile } = useProfileQuery()
+  const respondToEmail = profile?.primary_email ?? 'your email'
 
   if (!isInitialized) {
     return (

--- a/studio/components/interfaces/Support/SupportForm.tsx
+++ b/studio/components/interfaces/Support/SupportForm.tsx
@@ -47,6 +47,7 @@ const SupportForm: FC<Props> = ({ setSentCategory }) => {
   const [uploadedFiles, setUploadedFiles] = useState<File[]>([])
   const [uploadedDataUrls, setUploadedDataUrls] = useState<string[]>([])
   const [selectedServices, setSelectedServices] = useState<string[]>([])
+  const [respondToEmail, setRespondToEmail] = useState<string>('')
 
   // Get all orgs and projects from global store
   const sortedOrganizations = app.organizations.list()
@@ -74,6 +75,12 @@ const SupportForm: FC<Props> = ({ setSentCategory }) => {
       objectUrls.forEach((url: any) => URL.revokeObjectURL(url))
     }
   }, [uploadedFiles])
+
+  useEffect(() => {
+    get(`${API_URL}/profile`).then((data) => {
+      setRespondToEmail(data.primary_email)
+    })
+  }, [respondToEmail])
 
   if (!isInitialized) {
     return (
@@ -576,6 +583,11 @@ const SupportForm: FC<Props> = ({ setSentCategory }) => {
                       </div>
                     </div>
                     <div className="px-6">
+                      <div className="flex justify-end">
+                        <p className="block text-sm text-scale-1000 mt-0 mb-2">
+                          We will contact you at {respondToEmail}.
+                        </p>
+                      </div>
                       <div className="flex justify-end">
                         <Button
                           htmlType="submit"


### PR DESCRIPTION
## What is the current behavior?

Currently, it's not visible where users will receive responses from support. It can cause some confusion, especially for those who login with github and not using their github email anymore.

## What is the new behavior?

Showing a short notice that we will email them. Also lets user know to which email we will send responses to.

<img width="689" alt="Screenshot 2023-05-03 at 6 52 31 PM" src="https://user-images.githubusercontent.com/1732217/235896849-d937e168-5045-4869-8f8d-71fe45033802.png">

