### PR TITLE
Update sitemap to only include latest lib versions

### DIFF
--- a/apps/docs/internals/files/reference-lib.mjs
+++ b/apps/docs/internals/files/reference-lib.mjs
@@ -8,10 +8,10 @@ const flatCommonLibSections = flattenSections(commonLibSections)
 
 const clientLibFiles = [
   { fileName: 'supabase_js_v2', label: 'javascript', version: 'v2', versionSlug: false },
-  { fileName: 'supabase_js_v1', label: 'javascript', version: 'v1', versionSlug: true },
   { fileName: 'supabase_dart_v1', label: 'dart', version: 'v1', versionSlug: false },
-  { fileName: 'supabase_dart_v0', label: 'dart', version: 'v0', versionSlug: true },
-  { fileName: 'supabase_dart_v0', label: 'dart', version: 'v0', versionSlug: true },
+  { fileName: 'supabase_py_v2', label: 'python', version: 'v2', versionSlug: false },
+  { fileName: 'supabase_csharp_v0', label: 'csharp', version: 'v0', versionSlug: false },
+  { fileName: 'supabase_swift_v0', label: 'swift', version: 'v0', versionSlug: false },
 ]
 
 export function generateReferencePages() {

--- a/apps/docs/scripts/search/sources/index.ts
+++ b/apps/docs/scripts/search/sources/index.ts
@@ -60,6 +60,14 @@ export async function fetchSources() {
     '../../spec/common-client-libs-sections.json'
   )
 
+  const swiftLibReferenceSource = new ClientLibReferenceSource(
+    'swift-lib',
+    '/reference/swift',
+    { title: 'Swift Reference' },
+    '../../spec/supabase_swift_v0.yml',
+    '../../spec/common-client-libs-sections.json'
+  )
+
   const cliReferenceSource = new CliReferenceSource(
     'cli',
     '/reference/cli',
@@ -87,6 +95,7 @@ export async function fetchSources() {
     dartLibReferenceSource,
     pythonLibReferenceSource,
     cSharpLibReferenceSource,
+    swiftLibReferenceSource,
     cliReferenceSource,
     ...githubDiscussionSources,
     ...guideSources,


### PR DESCRIPTION
Search engines are coming up with results to old versions of our libs (eg. JS v1). Remove all old lib versions from the sitemap and only include the latest.