### PR TITLE
feat: scroll to element on pricing page

### DIFF
--- a/apps/www/components/Pricing/PricingTableRow.tsx
+++ b/apps/www/components/Pricing/PricingTableRow.tsx
@@ -12,6 +12,7 @@ export const PricingTableRowDesktop = (props: any) => {
       <tr
         className="divide-scale-600 dark:divide-scale-400 bg-scale-200"
         style={{ borderTop: 'none' }}
+        id={`${props.sectionId}-desktop`}
       >
         <th
           className="border-b border-scale-600 bg-scale-200 bg-scale-50 dark:bg-scale-200 text-scale-1200 sticky top-[62px] z-10 py-3 pl-6 text-left text-sm font-medium dark:text-white"
@@ -99,7 +100,7 @@ export const PricingTableRowMobile = (props: any) => {
 
   return (
     <>
-      <table className="mt-8 w-full">
+      <table className="mt-8 w-full" id={`${props.sectionId}-mobile`}>
         <caption className="bg-scale-50 dark:bg-dark-900 border-scale-400 border-t px-4 py-3 text-left text-sm font-medium dark:text-white">
           <div className="flex items-center gap-2">
             {category.icon ? <ProductIcon icon={props.icon} /> : null}

--- a/apps/www/pages/pricing/index.tsx
+++ b/apps/www/pages/pricing/index.tsx
@@ -3,7 +3,7 @@ import Solutions from 'data/Solutions.json'
 import { NextSeo } from 'next-seo'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 import CTABanner from '~/components/CTABanner'
 import DefaultLayout from '~/components/Layouts/Default'
@@ -15,7 +15,7 @@ import ComputePricingModal from '~/components/Pricing/ComputePricingModal'
 
 export default function IndexPage() {
   const router = useRouter()
-  const { basePath } = useRouter()
+  const { basePath, asPath } = useRouter()
   const { isDarkMode } = useTheme()
   const [showComputeModal, setShowComputeModal] = useState(false)
   const [activeMobileTier, setActiveMobileTier] = useState('Free')
@@ -23,6 +23,27 @@ export default function IndexPage() {
   const meta_title = 'Pricing & fees | Supabase'
   const meta_description =
     'Explore Supabase fees and pricing information. Find our competitive pricing tiers, with no hidden pricing. We have generous free tiers for those getting started, and Pay As You Go for those scaling up.'
+
+  // Ability to scroll into pricing sections like storage
+  useEffect(() => {
+    /**
+     * As we render a mobile and a desktop row for each item and just display based on screen size, we cannot navigate by simple id hash
+     * on both mobile and desktop. To handle both cases, we actually need to check screen size
+     */
+
+    const hash = asPath.split('#')[1]
+    if (!hash) return
+
+    let device = 'desktop'
+    if (window.matchMedia('screen and (max-width: 1024px)').matches) {
+      device = 'mobile'
+    }
+
+    const element = document.querySelector(`#${hash}-${device}`)
+    if (element) {
+      element.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    }
+  }, [asPath])
 
   /**
    * @mildtomato same plan metadata is also in /studio dashboard
@@ -510,41 +531,49 @@ export default function IndexPage() {
                     category={pricing.database}
                     tier={'free'}
                     icon={Solutions['database'].icon}
+                    sectionId="database"
                   />
                   <PricingTableRowMobile
                     category={pricing.auth}
                     tier={'free'}
                     icon={Solutions['authentication'].icon}
+                    sectionId="auth"
                   />
                   <PricingTableRowMobile
                     category={pricing.storage}
                     tier={'free'}
                     icon={Solutions['storage'].icon}
+                    sectionId="storage"
                   />
                   <PricingTableRowMobile
                     category={pricing.realtime}
                     tier={'free'}
                     icon={Solutions['realtime'].icon}
+                    sectionId="realtime"
                   />
                   <PricingTableRowMobile
                     category={pricing['edge-functions']}
                     tier={'free'}
                     icon={Solutions['edge-functions'].icon}
+                    sectionId="edge-functions"
                   />
                   <PricingTableRowMobile
                     category={pricing.dashboard}
                     tier={'free'}
                     icon={pricing.dashboard.icon}
+                    sectionId="dashboard"
                   />
                   <PricingTableRowMobile
                     category={pricing.security}
                     tier={'free'}
                     icon={pricing.security.icon}
+                    sectionId="security"
                   />
                   <PricingTableRowMobile
                     category={pricing.support}
                     tier={'free'}
                     icon={pricing.support.icon}
+                    sectionId="support"
                   />
                 </>
               )}
@@ -765,32 +794,43 @@ export default function IndexPage() {
                   <PricingTableRowDesktop
                     category={pricing.database}
                     icon={Solutions['database'].icon}
+                    sectionId="database"
                   />
                   <PricingTableRowDesktop
                     category={pricing.auth}
                     icon={Solutions['authentication'].icon}
+                    sectionId="auth"
                   />
                   <PricingTableRowDesktop
                     category={pricing.storage}
                     icon={Solutions['storage'].icon}
+                    sectionId="storage"
                   />
                   <PricingTableRowDesktop
                     category={pricing.realtime}
                     icon={Solutions['realtime'].icon}
+                    sectionId="realtime"
                   />
                   <PricingTableRowDesktop
                     category={pricing['edge-functions']}
                     icon={Solutions['edge-functions'].icon}
+                    sectionId="edge-functions"
                   />
                   <PricingTableRowDesktop
                     category={pricing.dashboard}
                     icon={pricing.dashboard.icon}
+                    sectionId="dashboard"
                   />
                   <PricingTableRowDesktop
                     category={pricing.security}
                     icon={pricing.security.icon}
+                    sectionId="security"
                   />
-                  <PricingTableRowDesktop category={pricing.support} icon={pricing.support.icon} />
+                  <PricingTableRowDesktop
+                    category={pricing.support}
+                    icon={pricing.support.icon}
+                    sectionId="support"
+                  />
                 </tbody>
                 <tfoot>
                   <tr className="border-scale-200 dark:border-scale-600 border-t">


### PR DESCRIPTION
Requested by the support team, talked to @joshenlim about the approach - unfortunately we couldn't just use ids and rely on the browser because of the layout (both mobile and desktop get rendered, just hidden through CSS)