### PR TITLE
Clarification on Team Id for Apple auth

### DIFF
--- a/apps/docs/pages/guides/auth/social-login/auth-apple.mdx
+++ b/apps/docs/pages/guides/auth/social-login/auth-apple.mdx
@@ -138,7 +138,7 @@ puts token
 1. Edit the `secret_gen.rb` file:
 
 - `key_file` = "Path to the private key you downloaded from Apple". It should look like this: `AuthKey_XXXXXXXXXX.p8`.
-- `team_id` = "Your Team ID". This is found at the top right of the Apple Developer site (next to your name).
+- `team_id` = "Your Team ID". This is found at the Apple Developer website, under Membership details. This is a 10-character alphanumeric string called "Team ID". Alternatively, this can be seen next to your name in the upper right when viewing your Certificates, Identifiers & Profiles.
 - `client_id` = "The Service ID of the service you created". This is the `Services ID` you created in the above step `Obtain a Services ID`. If you've lost this ID, you can find it in the Apple Developer Site:
   - Go to `Certificates, Identifiers & Profiles`.
   - Click `Identifiers` at the left.


### PR DESCRIPTION
The previous descriptor for Team Id was a little ambiguous, as the default Apple developer page doesn't have Team ID in the location noted, but rather Team Name. I think that being a little more specific, and offering an alternative location to find it could help future developers.

## What kind of change does this PR introduce?

Documentation update

## What is the current behavior?

Default location for developer website has a different value in the location noted, Team Name.

## What is the new behavior?

More specific about what Team ID is, and two different locations to find it.

## Additional context

N/A
