### PR TITLE
fix: log explorer bugfixes relating to selection panel

### DIFF
--- a/studio/components/interfaces/Settings/Logs/LogTable.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogTable.tsx
@@ -161,14 +161,21 @@ const LogTable = ({
     }
   }, [stringData])
 
-  const RowRenderer = (props: RowRendererProps<any>) => {
-    return (
+  const RowRenderer = useMemo(() => {
+    return (props: RowRendererProps<any>) => (
       <Row
         {...props}
-        className="font-mono tracking-tight cursor-pointer !bg-scale-200 hover:!bg-scale-300"
+        isRowSelected={false}
+        selectedCellIdx={undefined}
+        className={[
+          'font-mono tracking-tight cursor-pointer',
+          props.selectedCellIdx !== undefined
+            ? '!bg-scale-800'
+            : '!bg-scale-200 hover:!bg-scale-300',
+        ].join(' ')}
       />
     )
-  }
+  }, [])
 
   const LogsExplorerTableHeader = () => (
     <div className="flex w-full items-center justify-between rounded-tl rounded-tr border-t border-l border-r bg-scale-100 px-5 py-2 dark:bg-scale-300">
@@ -268,10 +275,11 @@ const LogTable = ({
           `}
             rowHeight={40}
             headerRowHeight={queryType ? 0 : 28}
-            onSelectedCellChange={({ idx, rowIdx }) => {
+            onSelectedCellChange={({ rowIdx }) => {
               if (!hasId) return
               setFocusedLog(data[rowIdx] as LogData)
             }}
+            selectedRows={new Set([])}
             noRowsFallback={
               !isLoading ? (
                 <div className="mx-auto flex h-full w-full items-center justify-center space-y-12 py-4 transition-all delay-200 duration-500">
@@ -286,11 +294,11 @@ const LogTable = ({
             }
             rows={logDataRows}
             rowKeyGetter={(r) => {
-              if (!hasId) return Object.keys(r)[0]
+              if (!hasId) return JSON.stringify(r)
               const row = r as LogData
               return row.id
             }}
-            onRowClick={(r) => setFocusedLog(r)}
+            onRowClick={setFocusedLog}
             rowRenderer={RowRenderer}
           />
           {logDataRows.length > 0 ? (

--- a/studio/components/interfaces/Settings/Logs/LogTable.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogTable.tsx
@@ -15,6 +15,7 @@ import DefaultErrorRenderer from './LogsErrorRenderers/DefaultErrorRenderer'
 import FunctionsLogsColumnRender from './LogColumnRenderers/FunctionsLogsColumnRender'
 import FunctionsEdgeColumnRender from './LogColumnRenderers/FunctionsEdgeColumnRender'
 import AuthColumnRenderer from './LogColumnRenderers/AuthColumnRenderer'
+import { isEqual } from 'lodash'
 
 interface Props {
   data?: Array<LogData | Object>
@@ -59,7 +60,6 @@ const LogTable = ({
   onHistogramToggle,
   isHistogramShowing,
   isLoading,
-  showDownload,
   error,
   projectRef,
   params,
@@ -144,8 +144,10 @@ const LogTable = ({
   }, [stringData])
 
   useEffect(() => {
-    if (!hasId || data === null) return
-    if (focusedLog && !(focusedLog.id in logMap)) {
+    if (!data) return
+    const found = data.find((datum) => isEqual(datum, focusedLog))
+    if (!found) {
+      // close selection panel if not found in dataset
       setFocusedLog(null)
     }
   }, [stringData])
@@ -163,17 +165,7 @@ const LogTable = ({
 
   const RowRenderer = useMemo(() => {
     return (props: RowRendererProps<any>) => (
-      <Row
-        {...props}
-        isRowSelected={false}
-        selectedCellIdx={undefined}
-        className={[
-          'font-mono tracking-tight cursor-pointer',
-          props.selectedCellIdx !== undefined
-            ? '!bg-scale-800'
-            : '!bg-scale-200 hover:!bg-scale-300',
-        ].join(' ')}
-      />
+      <Row {...props} isRowSelected={false} selectedCellIdx={undefined} />
     )
   }, [])
 
@@ -290,7 +282,12 @@ const LogTable = ({
             }
             columns={columns as any}
             rowClass={(row: LogData) =>
-              row.id === focusedLog?.id ? '!bg-scale-400 rdg-row--focused' : 'cursor-pointer'
+              [
+                'font-mono tracking-tight',
+                isEqual(row, focusedLog)
+                  ? '!bg-scale-800 rdg-row--focused'
+                  : ' !bg-scale-200 hover:!bg-scale-300 cursor-pointer',
+              ].join(' ')
             }
             rows={logDataRows}
             rowKeyGetter={(r) => {

--- a/studio/components/interfaces/Settings/Logs/LogTable.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogTable.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo } from 'react'
+import { useEffect, useState, useMemo, useCallback } from 'react'
 import { Alert, Button, IconEye, IconEyeOff } from 'ui'
 import DataGrid, { Row, RowRendererProps } from '@supabase/react-data-grid'
 
@@ -163,11 +163,12 @@ const LogTable = ({
     }
   }, [stringData])
 
-  const RowRenderer = useMemo(() => {
-    return (props: RowRendererProps<any>) => (
+  const RowRenderer = useCallback(
+    (props: RowRendererProps<any>) => (
       <Row {...props} isRowSelected={false} selectedCellIdx={undefined} />
-    )
-  }, [])
+    ),
+    []
+  )
 
   const LogsExplorerTableHeader = () => (
     <div className="flex w-full items-center justify-between rounded-tl rounded-tr border-t border-l border-r bg-scale-100 px-5 py-2 dark:bg-scale-300">

--- a/studio/tests/pages/projects/LogTable.test.js
+++ b/studio/tests/pages/projects/LogTable.test.js
@@ -68,6 +68,18 @@ test('can display standard preview table columns', async () => {
   await expect(screen.findByText(fakeMicroTimestamp)).rejects.toThrow()
 })
 
+test("closes the selection if the selected row's data changes", async () => {
+  const { rerender } = render(
+    <LogTable queryType="auth" data={[{ id: '12345', event_message: 'some event message' }]} />
+  )
+  const text = await screen.findByText(/some event message/)
+  userEvent.click(text)
+  await screen.findByText('Copy')
+  rerender(<LogTable data={[{ id: '12346', event_message: 'some other message' }]} />)
+  await expect(screen.findByText(/some event message/)).rejects.toThrow()
+  await screen.findByText(/some other message/)
+})
+
 test.each([
   {
     queryType: 'functions',

--- a/studio/tests/pages/projects/logs-query.test.js
+++ b/studio/tests/pages/projects/logs-query.test.js
@@ -131,6 +131,7 @@ test('custom sql querying', async () => {
       expect(get).toHaveBeenCalledWith(expect.stringContaining('sql='), expect.anything())
       expect(get).toHaveBeenCalledWith(expect.stringContaining('select'), expect.anything())
       expect(get).toHaveBeenCalledWith(expect.stringContaining('edge_logs'), expect.anything())
+      expect(get).toHaveBeenCalledWith(expect.stringContaining(encodeURIComponent("my_count")), expect.anything())
       expect(get).toHaveBeenCalledWith(
         expect.stringContaining('iso_timestamp_start'),
         expect.anything()
@@ -157,6 +158,40 @@ test('custom sql querying', async () => {
 
   // should not see chronological features
   await expect(screen.findByText(/Load older/)).rejects.toThrow()
+})
+
+test("bug: can edit query after selecting a log", async ()=>{
+  get.mockImplementation((url) => {
+    if (url.includes('sql=') && url.includes('select') && !url.includes("limit 222")) {
+      return {
+        result: [ { my_count: 12345 }],
+      }
+    }
+    return { result: [] }
+  })
+  const { container } = render(<LogsExplorerPage />)
+  // run default query
+  userEvent.click(await screen.findByText('Run'))
+  const rowValue = await screen.findByText(/12345/) // row value
+  // open up an show selection panel
+  await userEvent.click(rowValue)
+  await screen.findByText(/Copy/)
+
+  // change the query
+  let editor = container.querySelector('.monaco-editor')
+  // type new query
+  userEvent.click(editor)
+  userEvent.type(editor, ' something')
+  userEvent.click(await screen.findByText('Run'))
+
+  await waitFor(
+    () => {
+      expect(get).toHaveBeenCalledWith(expect.stringContaining(encodeURIComponent("something")), expect.anything())
+    },
+    { timeout: 1000 }
+  )
+  // closes the selection panel
+  await expect(screen.findByText(/Copy/)).rejects.toThrow()
 })
 
 test('query warnings', async () => {


### PR DESCRIPTION
Fixes a bug where react-data-grid hijacks the typing focus of the monaco editor if a cell is selected. Instead of relying on react-data-grid to handle row selection highlighting, I have switched it to use a background change instead (inset/border styling doesn't work due to virtualization).

https://user-images.githubusercontent.com/22714384/236474039-b68e85cb-5056-4314-b732-acde8c9846d7.mov

If there is stale data, the selection panel will now auto-close, instead of leaving the panel with stale data open.

https://user-images.githubusercontent.com/22714384/236493860-2fb51b47-ac55-436f-a35a-3f561d80f8f0.mov



Tickets:
- [editor hijacking](https://www.notion.so/supabase/Logs-Explorer-when-LogPanel-is-open-user-cannot-type-in-monaco-editor-023c1c653fff40ccae597112d1e48cd7?pvs=4)
- [auto-close selection panel if data is stale](https://www.notion.so/supabase/Logs-Explorer-selecting-a-row-shows-wrong-data-previously-selected-data-does-not-auto-close-if-q-78eb59471ff84295afd4424a89ceb5ac?pvs=4)