### PR TITLE
fix: add exchangeCodeForSession to spec

### DIFF
--- a/spec/common-client-libs-sections.json
+++ b/spec/common-client-libs-sections.json
@@ -559,6 +559,14 @@
         "type": "function"
       },
       {
+          "id": "exchange-code-for-session",
+          "title": "Exchange an auth code for a session",
+          "slug": "auth-exchangecodeforsession",
+          "product": "auth",
+          "type": "function"
+
+      },
+      {
         "id": "mfa-enroll",
         "title": "Enroll a factor",
         "slug": "auth-mfa-enroll",

--- a/spec/supabase_js_v2.yml
+++ b/spec/supabase_js_v2.yml
@@ -567,6 +567,20 @@ functions:
             if (event == 'USER_UPDATED') console.log('USER_UPDATED', session)
           })
           ```
+  - id: exchange-code-for-session
+    title: 'exchangeCodeForSession()'
+    $ref: '@supabase/gotrue-js.GoTrueClient.exchangeCodeForSession'
+    notes: |
+      - Used when `flowType` is set to True in client options.
+    examples:
+      - id: exchange-auth-code
+        name: Exchange Auth Code
+        isSpotlight: true
+        code: |
+          ```js
+          supabase.auth.exchangeCodeForSession('34e770dd-9ff9-416c-87fa-43b31d7ef225')
+          ```
+
   - id: mfa-enroll
     title: 'mfa.enroll()'
     $ref: '@supabase/gotrue-js.GoTrueMFAApi.enroll'

--- a/spec/supabase_js_v2.yml
+++ b/spec/supabase_js_v2.yml
@@ -571,7 +571,7 @@ functions:
     title: 'exchangeCodeForSession()'
     $ref: '@supabase/gotrue-js.GoTrueClient.exchangeCodeForSession'
     notes: |
-      - Used when `flowType` is set to True in client options.
+      - Used when `flowType` is set to `pkce` in client options.
     examples:
       - id: exchange-auth-code
         name: Exchange Auth Code


### PR DESCRIPTION
see title


Related PRs:

- PR to correct `exchangeCodeForSession` description: https://github.com/supabase/gotrue-js/pull/674