### PR TITLE
fix: only show exceeded usage if above 100%

### DIFF
--- a/studio/components/ui/OveragesBanner/OveragesBanner.utils.ts
+++ b/studio/components/ui/OveragesBanner/OveragesBanner.utils.ts
@@ -22,7 +22,7 @@ export const getResourcesExceededLimits = (usages: any) => {
       .filter((resourceName) => usages[resourceName] !== null)
       .map((resourceName) => {
         const resource = usages[resourceName]
-        if (resource.usage / resource.limit >= 1) return resourceName
+        if (resource.usage / resource.limit > 1) return resourceName
       })
   )
 }


### PR DESCRIPTION
We shouldn't show usage exceeded banner and red bars if you're still within fair usage (100%).

I.e. using 10/10 functions