### PR TITLE
Update expo documentation

### DIFF
--- a/apps/docs/pages/guides/getting-started/tutorials/with-expo.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-expo.mdx
@@ -45,21 +45,21 @@ These variables will be exposed on the browser, and that's completely fine since
 [Row Level Security](/docs/guides/auth#row-level-security) enabled on our Database.
 
 ```ts title=lib/supabase.ts
-import * as SecureStore from "expo-secure-store";
+import 'react-native-url-polyfill/auto'
+import * as SecureStore from 'expo-secure-store'
 import { createClient } from '@supabase/supabase-js'
-
 
 const ExpoSecureStoreAdapter = {
   getItem: (key: string) => {
-    return SecureStore.getItemAsync(key);
+    return SecureStore.getItemAsync(key)
   },
   setItem: (key: string, value: string) => {
-    SecureStore.setItemAsync(key, value);
+    SecureStore.setItemAsync(key, value)
   },
   removeItem: (key: string) => {
-    SecureStore.deleteItemAsync(key);
+    SecureStore.deleteItemAsync(key)
   },
-};
+}
 
 const supabaseUrl = YOUR_REACT_NATIVE_SUPABASE_URL
 const supabaseAnonKey = YOUR_REACT_NATIVE_SUPABASE_ANON_KEY

--- a/package-lock.json
+++ b/package-lock.json
@@ -68107,7 +68107,7 @@
         "@types/react": "^17.0.37",
         "@types/react-copy-to-clipboard": "^5.0.4",
         "@types/react-dom": "^17.0.11",
-        "@types/react-syntax-highlighter": "*",
+        "@types/react-syntax-highlighter": "^15.5.6",
         "autoprefixer": "^10.4.2",
         "clsx": "^1.2.1",
         "cmdk-supabase": "^0.2.2",


### PR DESCRIPTION
## What kind of change does this PR introduce?

Issue described in [Issue 14185](https://github.com/supabase/supabase/issues/14185) is as follows:

The documentation has a error that not includes a import in section building the app where when using react native >= 0.70 and expo version compatible an error is thrown in initialization of app. To fix this is just necessary to add the import of 'react-native-url-polyfill/auto' before all imports once.

## What is the current behavior?

<img width="1512" alt="Screenshot 2023-05-08 at 10 50 40 AM" src="https://user-images.githubusercontent.com/59986120/236856508-9e721b68-5134-43b7-b335-997409090657.png">

## What is the new behavior?

![image](https://user-images.githubusercontent.com/59986120/236856700-40d4aa29-7ab5-4b4b-8096-d83719a0684c.png)
