### PR TITLE
Update testing procedures in row-level-security.mdx

### DIFF
--- a/apps/docs/pages/guides/auth/row-level-security.mdx
+++ b/apps/docs/pages/guides/auth/row-level-security.mdx
@@ -351,9 +351,7 @@ begin
         auth.users
     where
         email = user_email;
-    execute format('set request.jwt.claim.sub=%L', (auth_user).id::text);
-    execute format('set request.jwt.claim.role=%I', (auth_user).role);
-    execute format('set request.jwt.claim.email=%L', (auth_user).email);
+    execute format('set request.jwt.claim=%L', json_build_object('sub', (auth_user).id::text, 'role', (auth_user).role, 'email', (auth_user).email));
     execute format('set request.jwt.claims=%L', json_strip_nulls(json_build_object('app_metadata', (auth_user).raw_app_meta_data))::text);
 
     raise notice '%', format( 'set role %I; -- logging in as %L (%L)', (auth_user).role, (auth_user).id, (auth_user).email);
@@ -365,9 +363,7 @@ create or replace procedure auth.login_as_anon ()
     language plpgsql
     as $$
 begin
-    set request.jwt.claim.sub='';
-    set request.jwt.claim.role='';
-    set request.jwt.claim.email='';
+    set request.jwt.claim='';
     set request.jwt.claims='';
     set role anon;
 end;
@@ -377,9 +373,7 @@ create or replace procedure auth.logout ()
     language plpgsql
     as $$
 begin
-    set request.jwt.claim.sub='';
-    set request.jwt.claim.role='';
-    set request.jwt.claim.email='';
+    set request.jwt.claim='';
     set request.jwt.claims='';
     set role postgres;
 end;


### PR DESCRIPTION
As far as I can tell, these documents are out of date with how RLS is implemented in supabase.

When I tried running:

```
call auth.login_as_user('jamie@spirals.so');
select auth.jwt()
```

The result was (note that there is no "email" field)

```
jwt
{"app_metadata":{"providers":"google","providers":["google"]}}
```

To understand what as going on, I inspected the UDF:

```
SELECT proname, prosrc 
FROM pg_proc 
WHERE proname = 'jwt' 
  AND pronamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'auth');
```

```
  select 
    coalesce(
        nullif(current_setting('request.jwt.claim', true), ''),
        nullif(current_setting('request.jwt.claims', true), '')
    )::jsonb
 ```

Which seems to indicate that `claim` is now a single setting rather than several.

After updating the procedure as in this PR, `select auth.jwt()` behaves as I expect it to.

## What kind of change does this PR introduce?

Docs update