### PR TITLE
Fix Jest errors with react markdown for cmdk

### DIFF
--- a/apps/docs/pages/_app.tsx
+++ b/apps/docs/pages/_app.tsx
@@ -85,12 +85,7 @@ function MyApp({ Component, pageProps }: AppPropsWithLayout) {
       <Favicons />
       <AuthContainer>
         <ThemeProvider>
-          <CommandMenuProvider
-            site="docs"
-            MarkdownHandler={(props) => (
-              <ReactMarkdown remarkPlugins={[remarkGfm]} components={components} {...props} />
-            )}
-          >
+          <CommandMenuProvider site="docs">
             <SiteLayout>
               <Component {...pageProps} />
             </SiteLayout>

--- a/packages/ui/src/components/Command/AiCommand.tsx
+++ b/packages/ui/src/components/Command/AiCommand.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import type {
   ChatCompletionResponseMessage,
   CreateChatCompletionResponse,
@@ -16,14 +15,23 @@ import {
 
 import { SSE } from 'sse.js'
 
-import { Alert, Button, IconAlertTriangle, IconCornerDownLeft, IconUser, Input } from 'ui'
+import {
+  Button,
+  IconAlertTriangle,
+  IconCornerDownLeft,
+  IconUser,
+  Input,
+  markdownComponents,
+} from 'ui'
 import { AiIcon, AiIconChat } from './Command.icons'
 import { CommandGroup, CommandItem, useAutoInputFocus, useHistoryKeys } from './Command.utils'
 
-import { useCommandMenu } from './CommandMenuProvider'
 import { AiWarning } from './Command.alerts'
+import { useCommandMenu } from './CommandMenuProvider'
 
+import ReactMarkdown from 'react-markdown'
 import { cn } from './../../utils/cn'
+import remarkGfm from 'remark-gfm'
 
 const questions = [
   'How do I get started with Supabase?',
@@ -339,7 +347,7 @@ export function queryAi(messages: Message[], timeout = 0) {
 }
 
 const AiCommand = () => {
-  const { isLoading, setIsLoading, search, setSearch, MarkdownHandler } = useCommandMenu()
+  const { isLoading, setIsLoading, search, setSearch } = useCommandMenu()
 
   const { submit, reset, messages, isResponding, hasError } = useAiChat({
     setIsLoading,
@@ -404,7 +412,9 @@ const AiCommand = () => {
                       {message.status === MessageStatus.Pending ? (
                         <div className="bg-scale-700 h-[21px] w-[13px] mt-1 animate-pulse animate-bounce"></div>
                       ) : (
-                        <MarkdownHandler
+                        <ReactMarkdown
+                          remarkPlugins={[remarkGfm]}
+                          components={markdownComponents}
                           linkTarget="_blank"
                           className="prose dark:prose-dark"
                           transformLinkUri={(href) => {
@@ -419,7 +429,7 @@ const AiCommand = () => {
                           }}
                         >
                           {message.content}
-                        </MarkdownHandler>
+                        </ReactMarkdown>
                       )}
                     </>
                   </div>

--- a/packages/ui/src/components/Command/CommandMenuProvider.tsx
+++ b/packages/ui/src/components/Command/CommandMenuProvider.tsx
@@ -1,7 +1,6 @@
 import { useTheme, UseThemeProps } from 'common'
 import { createContext, PropsWithChildren, useContext, useEffect, useState } from 'react'
 import CommandMenu from './CommandMenu'
-import { ReactMarkdownOptions } from 'react-markdown/lib/react-markdown'
 
 export interface CommandMenuContextValue {
   isOpen: boolean
@@ -28,10 +27,6 @@ export interface CommandMenuContextValue {
    * Opt in flag to use additional metadata in AI prompts
    */
   isOptedInToAI: boolean
-
-  // to do: remove this prop
-  // this is a temporary hack as ReactMarkdown fails our jest tests if we import the package within this UI package
-  MarkdownHandler: (props: ReactMarkdownOptions) => JSX.Element
 
   // Optional callback to save a generated SQL output
   saveGeneratedSQL?: (answer: string, title: string) => Promise<void>
@@ -67,11 +62,6 @@ export interface CommandMenuProviderProps {
    */
   metadata?: { definitions?: string; flags?: { [key: string]: string } }
   /**
-   * TODO: remove this prop, temporary hack as ReactMarkdown fails our jest tests
-   * if we import the package directly within this UI package
-   */
-  MarkdownHandler: (props: ReactMarkdownOptions) => JSX.Element
-  /**
    * Call back when save SQL snippet button is selected
    */
   saveGeneratedSQL?: (answer: string, title: string) => Promise<void>
@@ -84,7 +74,6 @@ const CommandMenuProvider = ({
   apiKeys,
   metadata,
   isOptedInToAI = false,
-  MarkdownHandler,
   saveGeneratedSQL,
 }: PropsWithChildren<CommandMenuProviderProps>) => {
   const [isOpen, setIsOpen] = useState(false)
@@ -116,7 +105,6 @@ const CommandMenuProvider = ({
         project,
         metadata,
         isOptedInToAI,
-        MarkdownHandler,
         saveGeneratedSQL,
       }}
     >

--- a/studio/__mocks__/react-markdown.js
+++ b/studio/__mocks__/react-markdown.js
@@ -1,0 +1,9 @@
+/**
+ * Opting for option 1 as described here:
+ * https://github.com/remarkjs/react-markdown/issues/635#issuecomment-956158474
+ */
+function ReactMarkdown({ children }) {
+  return <>{children}</>
+}
+
+export default ReactMarkdown

--- a/studio/__mocks__/remark-gfm.js
+++ b/studio/__mocks__/remark-gfm.js
@@ -1,0 +1,1 @@
+export default function remarkGfm() {}

--- a/studio/components/interfaces/App/CommandMenuWrapper.tsx
+++ b/studio/components/interfaces/App/CommandMenuWrapper.tsx
@@ -98,9 +98,6 @@ const CommandMenuWrapper = observer(({ children }: PropsWithChildren<{}>) => {
       site="studio"
       projectRef={ref}
       apiKeys={apiKeys}
-      MarkdownHandler={(props) => (
-        <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents} {...props} />
-      )}
       metadata={cmdkMetadata}
       isOptedInToAI={allowCMDKDataOptIn && isOptedInToAI}
       saveGeneratedSQL={onSaveGeneratedSQL}


### PR DESCRIPTION
Currently for `cmdk` we have to define our markdown handler outside of the `ui` packages in order for `studio` tests to pass:
https://github.com/supabase/supabase/blob/cb3fa4b2ce3b7d010e1759b8cfeff52a31a53d05/apps/docs/pages/_app.tsx#L90-L92

The issue is that the `react-markdown` package is an ESM module which Jest doesn't fully support yet.

## Solution
Mock out `react-markdown` so that it's ESM dependency is never imported. The downside is that we can't test `react-markdown` functionality, though we aren't doing that right now anyway.

## Alternatives
Alternatively, we could have manually told Jest to transform `markdown-react` and all of its sub-dependencies (a lot) in order for Jest to import them properly. This approach is slow, tedious, and prone to breaking anytime `react-markdown` changes any of its sub-dependencies.