### PR TITLE
fix for og image undefined description issue.

### DIFF
--- a/supabase/functions/og-images/handler.tsx
+++ b/supabase/functions/og-images/handler.tsx
@@ -30,7 +30,7 @@ export async function handler(req: Request) {
 
   switch (site) {
     case 'docs':
-      return new ImageResponse(( <Docs title={title} description={(description !=='undefined')? description:''} type={type} icon={icon} /> ),
+      return new ImageResponse(( <Docs title={title} description={description !== 'undefined' ? description : ''} type={type} icon={icon} /> ),
         {
           width: 1200,
           height: 630,

--- a/supabase/functions/og-images/handler.tsx
+++ b/supabase/functions/og-images/handler.tsx
@@ -30,7 +30,7 @@ export async function handler(req: Request) {
 
   switch (site) {
     case 'docs':
-      return new ImageResponse(( <Docs title={title} description={description} type={type} icon={icon} /> ),
+      return new ImageResponse(( <Docs title={title} description={(description !=='undefined')? description:''} type={type} icon={icon} /> ),
         {
           width: 1200,
           height: 630,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix for _og image description undefined #14229_

## What is the current behavior?

When a Docs og images has a description that is undefined the og image generator displays the undefined description.

## What is the new behavior?

It now doesn't render the description if its undefined.

<img width="1512" alt="Screenshot 2023-05-09 at 11 17 36 PM" src="https://github.com/supabase/supabase/assets/73219529/a1c99da0-4ed4-4218-94c6-ae321f528438">
