### PR TITLE
Fix duplicate client lib section

### DIFF
--- a/spec/common-client-libs-sections.json
+++ b/spec/common-client-libs-sections.json
@@ -554,19 +554,11 @@
         "type": "function"
       },
       {
-        "id": "reset-password-for-email",
-        "title": "Send a password reset request",
-        "slug": "auth-resetpasswordforemail",
+        "id": "exchange-code-for-session",
+        "title": "Exchange an auth code for a session",
+        "slug": "auth-exchangecodeforsession",
         "product": "auth",
         "type": "function"
-      },
-      {
-          "id": "exchange-code-for-session",
-          "title": "Exchange an auth code for a session",
-          "slug": "auth-exchangecodeforsession",
-          "product": "auth",
-          "type": "function"
-
       },
       {
         "id": "mfa-enroll",


### PR DESCRIPTION
Removes duplicate client lib entry for "Send a password reset request":

![image](https://github.com/supabase/supabase/assets/4133076/10dc8383-62a2-4af1-b147-1d9db328b81f)
