### PR TITLE
Fix getStaticPaths() slug for ref docs

### DIFF
--- a/apps/docs/lib/mdx/handleRefStaticPaths.tsx
+++ b/apps/docs/lib/mdx/handleRefStaticPaths.tsx
@@ -1,14 +1,11 @@
 import { ICommonSection } from '~/components/reference/Reference.types'
 
-async function handleRefGetStaticPaths(sections: ICommonSection[], libraryPath: string) {
+async function handleRefGetStaticPaths(sections: ICommonSection[]) {
   return {
     paths: sections.map((section) => {
       return {
         params: {
-          slug: libraryPath
-            .split('/')
-            .filter((dir) => !!dir)
-            .concat(section.slug),
+          slug: [section.slug],
         },
       }
     }),

--- a/apps/docs/pages/reference/api/[...slug].tsx
+++ b/apps/docs/pages/reference/api/[...slug].tsx
@@ -20,5 +20,5 @@ export async function getStaticProps() {
 }
 
 export async function getStaticPaths() {
-  return handleRefGetStaticPaths(sections, libraryPath)
+  return handleRefGetStaticPaths(sections)
 }

--- a/apps/docs/pages/reference/cli/[...slug].tsx
+++ b/apps/docs/pages/reference/cli/[...slug].tsx
@@ -19,5 +19,5 @@ export async function getStaticProps() {
 }
 
 export async function getStaticPaths() {
-  return handleRefGetStaticPaths(sections, libraryPath)
+  return handleRefGetStaticPaths(sections)
 }

--- a/apps/docs/pages/reference/csharp/[...slug].tsx
+++ b/apps/docs/pages/reference/csharp/[...slug].tsx
@@ -17,5 +17,5 @@ export async function getStaticProps() {
 }
 
 export async function getStaticPaths() {
-  return handleRefGetStaticPaths(sections, libraryPath)
+  return handleRefGetStaticPaths(sections)
 }

--- a/apps/docs/pages/reference/csharp/crawlers/[...slug].tsx
+++ b/apps/docs/pages/reference/csharp/crawlers/[...slug].tsx
@@ -40,5 +40,5 @@ export async function getStaticProps() {
 }
 
 export async function getStaticPaths() {
-  return handleRefGetStaticPaths(sections, libraryPath)
+  return handleRefGetStaticPaths(sections)
 }

--- a/apps/docs/pages/reference/csharp/v0/[...slug].tsx
+++ b/apps/docs/pages/reference/csharp/v0/[...slug].tsx
@@ -17,5 +17,5 @@ export async function getStaticProps() {
 }
 
 export async function getStaticPaths() {
-  return handleRefGetStaticPaths(sections, libraryPath)
+  return handleRefGetStaticPaths(sections)
 }

--- a/apps/docs/pages/reference/csharp/v0/crawlers/[...slug].tsx
+++ b/apps/docs/pages/reference/csharp/v0/crawlers/[...slug].tsx
@@ -39,5 +39,5 @@ export async function getStaticProps() {
 }
 
 export async function getStaticPaths() {
-  return handleRefGetStaticPaths(sections, libraryPath)
+  return handleRefGetStaticPaths(sections)
 }

--- a/apps/docs/pages/reference/dart/[...slug].tsx
+++ b/apps/docs/pages/reference/dart/[...slug].tsx
@@ -17,5 +17,5 @@ export async function getStaticProps() {
 }
 
 export async function getStaticPaths() {
-  return handleRefGetStaticPaths(sections, libraryPath)
+  return handleRefGetStaticPaths(sections)
 }

--- a/apps/docs/pages/reference/dart/crawlers/[...slug].tsx
+++ b/apps/docs/pages/reference/dart/crawlers/[...slug].tsx
@@ -40,5 +40,5 @@ export async function getStaticProps() {
 }
 
 export async function getStaticPaths() {
-  return handleRefGetStaticPaths(sections, libraryPath)
+  return handleRefGetStaticPaths(sections)
 }

--- a/apps/docs/pages/reference/dart/v0/[...slug].tsx
+++ b/apps/docs/pages/reference/dart/v0/[...slug].tsx
@@ -17,5 +17,5 @@ export async function getStaticProps() {
 }
 
 export async function getStaticPaths() {
-  return handleRefGetStaticPaths(sections, libraryPath)
+  return handleRefGetStaticPaths(sections)
 }

--- a/apps/docs/pages/reference/dart/v0/crawlers/[...slug].tsx
+++ b/apps/docs/pages/reference/dart/v0/crawlers/[...slug].tsx
@@ -39,5 +39,5 @@ export async function getStaticProps() {
 }
 
 export async function getStaticPaths() {
-  return handleRefGetStaticPaths(sections, libraryPath)
+  return handleRefGetStaticPaths(sections)
 }

--- a/apps/docs/pages/reference/javascript/[...slug].tsx
+++ b/apps/docs/pages/reference/javascript/[...slug].tsx
@@ -1,4 +1,3 @@
-import { inspect } from 'util'
 import clientLibsCommonSections from '~/../../spec/common-client-libs-sections.json'
 import typeSpec from '~/../../spec/enrichments/tsdoc_v2/combined.json'
 import spec from '~/../../spec/supabase_js_v2.yml' assert { type: 'yml' }
@@ -27,5 +26,5 @@ export async function getStaticProps() {
 }
 
 export async function getStaticPaths() {
-  return handleRefGetStaticPaths(sections, libraryPath)
+  return handleRefGetStaticPaths(sections)
 }

--- a/apps/docs/pages/reference/javascript/crawlers/[...slug].tsx
+++ b/apps/docs/pages/reference/javascript/crawlers/[...slug].tsx
@@ -40,5 +40,5 @@ export async function getStaticProps() {
 }
 
 export async function getStaticPaths() {
-  return handleRefGetStaticPaths(sections, libraryPath)
+  return handleRefGetStaticPaths(sections)
 }

--- a/apps/docs/pages/reference/javascript/v1/[...slug].tsx
+++ b/apps/docs/pages/reference/javascript/v1/[...slug].tsx
@@ -27,5 +27,5 @@ export async function getStaticProps() {
 }
 
 export async function getStaticPaths() {
-  return handleRefGetStaticPaths(sections, libraryPath)
+  return handleRefGetStaticPaths(sections)
 }

--- a/apps/docs/pages/reference/javascript/v1/crawlers/[...slug].tsx
+++ b/apps/docs/pages/reference/javascript/v1/crawlers/[...slug].tsx
@@ -40,5 +40,5 @@ export async function getStaticProps() {
 }
 
 export async function getStaticPaths() {
-  return handleRefGetStaticPaths(sections, libraryPath)
+  return handleRefGetStaticPaths(sections)
 }

--- a/apps/docs/pages/reference/python/[...slug].tsx
+++ b/apps/docs/pages/reference/python/[...slug].tsx
@@ -26,5 +26,5 @@ export async function getStaticProps() {
 }
 
 export async function getStaticPaths() {
-  return handleRefGetStaticPaths(sections, libraryPath)
+  return handleRefGetStaticPaths(sections)
 }

--- a/apps/docs/pages/reference/python/crawlers/[...slug].tsx
+++ b/apps/docs/pages/reference/python/crawlers/[...slug].tsx
@@ -40,5 +40,5 @@ export async function getStaticProps() {
 }
 
 export async function getStaticPaths() {
-  return handleRefGetStaticPaths(sections, libraryPath)
+  return handleRefGetStaticPaths(sections)
 }

--- a/apps/docs/pages/reference/self-hosting-analytics/[...slug].tsx
+++ b/apps/docs/pages/reference/self-hosting-analytics/[...slug].tsx
@@ -21,5 +21,5 @@ export async function getStaticProps() {
 }
 
 export async function getStaticPaths() {
-  return handleRefGetStaticPaths(sections, libraryPath)
+  return handleRefGetStaticPaths(sections)
 }

--- a/apps/docs/pages/reference/self-hosting-auth/[...slug].tsx
+++ b/apps/docs/pages/reference/self-hosting-auth/[...slug].tsx
@@ -21,5 +21,5 @@ export async function getStaticProps() {
 }
 
 export async function getStaticPaths() {
-  return handleRefGetStaticPaths(sections, libraryPath)
+  return handleRefGetStaticPaths(sections)
 }

--- a/apps/docs/pages/reference/self-hosting-functions/[...slug].tsx
+++ b/apps/docs/pages/reference/self-hosting-functions/[...slug].tsx
@@ -18,5 +18,5 @@ export async function getStaticProps() {
 }
 
 export async function getStaticPaths() {
-  return handleRefGetStaticPaths(sections, libraryPath)
+  return handleRefGetStaticPaths(sections)
 }

--- a/apps/docs/pages/reference/self-hosting-realtime/[...slug].tsx
+++ b/apps/docs/pages/reference/self-hosting-realtime/[...slug].tsx
@@ -17,5 +17,5 @@ export async function getStaticProps() {
 }
 
 export async function getStaticPaths() {
-  return handleRefGetStaticPaths(sections, libraryPath)
+  return handleRefGetStaticPaths(sections)
 }

--- a/apps/docs/pages/reference/self-hosting-storage/[...slug].tsx
+++ b/apps/docs/pages/reference/self-hosting-storage/[...slug].tsx
@@ -21,5 +21,5 @@ export async function getStaticProps() {
 }
 
 export async function getStaticPaths() {
-  return handleRefGetStaticPaths(sections, libraryPath)
+  return handleRefGetStaticPaths(sections)
 }

--- a/apps/docs/pages/reference/swift/[...slug].tsx
+++ b/apps/docs/pages/reference/swift/[...slug].tsx
@@ -17,5 +17,5 @@ export async function getStaticProps() {
 }
 
 export async function getStaticPaths() {
-  return handleRefGetStaticPaths(sections, libraryPath)
+  return handleRefGetStaticPaths(sections)
 }

--- a/apps/docs/pages/reference/swift/crawlers/[...slug].tsx
+++ b/apps/docs/pages/reference/swift/crawlers/[...slug].tsx
@@ -40,5 +40,5 @@ export async function getStaticProps() {
 }
 
 export async function getStaticPaths() {
-  return handleRefGetStaticPaths(sections, libraryPath)
+  return handleRefGetStaticPaths(sections)
 }

--- a/apps/docs/pages/reference/swift/v0/[...slug].tsx
+++ b/apps/docs/pages/reference/swift/v0/[...slug].tsx
@@ -17,5 +17,5 @@ export async function getStaticProps() {
 }
 
 export async function getStaticPaths() {
-  return handleRefGetStaticPaths(sections, libraryPath)
+  return handleRefGetStaticPaths(sections)
 }

--- a/apps/docs/pages/reference/swift/v0/crawlers/[...slug].tsx
+++ b/apps/docs/pages/reference/swift/v0/crawlers/[...slug].tsx
@@ -39,5 +39,5 @@ export async function getStaticProps() {
 }
 
 export async function getStaticPaths() {
-  return handleRefGetStaticPaths(sections, libraryPath)
+  return handleRefGetStaticPaths(sections)
 }


### PR DESCRIPTION
New `getStaticPaths()` implementation for ref docs was producing the wrong slug.