### PR TITLE
fix: update LW7 auth blog post rollout section

### DIFF
--- a/apps/www/_blog/2023-04-13-supabase-auth-sso-pkce.mdx
+++ b/apps/www/_blog/2023-04-13-supabase-auth-sso-pkce.mdx
@@ -221,6 +221,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 }
 ```
 
+### Roll out
+
+Since this is a major update that touches many of the authentication routes, we will roll it out gradually over the next few weeks. You will receive a notification in your dashboard when the feature is available for your project. Reach out to us if you want early access to this feature.
+
+**Update**: Server-Side Auth (PKCE) is now available on all projects. Please refer to our [Server Side Auth Guide](https://supabase.com/docs/guides/auth/server-side-rendering) for further details on how to add PKCE to your project.
+
 ## Native Apple login on iOS
 
 While PKCE support is great, that is not the only news for you mobile app developers out there.

--- a/apps/www/_blog/2023-04-13-supabase-auth-sso-pkce.mdx
+++ b/apps/www/_blog/2023-04-13-supabase-auth-sso-pkce.mdx
@@ -221,10 +221,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 }
 ```
 
-### Roll out
-
-Since this is a major update that touches many of the authentication routes, we will roll it out gradually over the next few weeks. You will receive a notification in your dashboard when the feature is available for your project. Reach out to us if you want early access to this feature.
-
 ## Native Apple login on iOS
 
 While PKCE support is great, that is not the only news for you mobile app developers out there.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Now that PKCE has been enabled on all projects, we add a note stating that PKCE has been rolled out so as not to confuse users  who may wish to contact us to get PKCE enabled.