### PR TITLE
fix: assign storage port from public url

### DIFF
--- a/studio/pages/api/storage/[ref]/buckets/[id]/objects/sign.ts
+++ b/studio/pages/api/storage/[ref]/buckets/[id]/objects/sign.ts
@@ -29,7 +29,7 @@ const handlePost = async (req: NextApiRequest, res: NextApiResponse) => {
 
   // change the domain name to the SUPABASE_PUBLIC_URL since SUPABASE_URL is not accessible from the client
   const signedUrl = new URL(data.signedUrl)
-  signedUrl.hostname = new URL(process.env.SUPABASE_PUBLIC_URL!).hostname
+  signedUrl.host = new URL(process.env.SUPABASE_PUBLIC_URL!).host
   data.signedUrl = signedUrl.href
 
   return res.status(200).json(data)


### PR DESCRIPTION
## What kind of change does this PR introduce?

follow up https://github.com/supabase/supabase/pull/14250

## What is the new behavior?

Pass in port from public url.

## Additional context

Add any other context or screenshots.
