### PR TITLE
chore: sql run button only runs selected sql

### DIFF
--- a/studio/components/interfaces/SQLEditor/SQLEditor.tsx
+++ b/studio/components/interfaces/SQLEditor/SQLEditor.tsx
@@ -1,14 +1,12 @@
 import { useParams } from 'common'
 import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
-import { useCallback } from 'react'
+import { useCallback, useRef } from 'react'
 import Split from 'react-split'
 import { getSqlEditorStateSnapshot, useSqlEditorStateSnapshot } from 'state/sql-editor'
-import useLatest from 'hooks/misc/useLatest'
-import MonacoEditor from './MonacoEditor'
-import UtilityPanel from './UtilityPanel/UtilityPanel'
 import { useExecuteSqlMutation } from 'data/sql/execute-sql-mutation'
-
-export interface SQLEditorProps {}
+import useLatest from 'hooks/misc/useLatest'
+import MonacoEditor, { IStandaloneCodeEditor } from './MonacoEditor'
+import UtilityPanel from './UtilityPanel/UtilityPanel'
 
 const SQLEditor = () => {
   const { ref, id } = useParams()
@@ -38,22 +36,26 @@ const SQLEditor = () => {
     if (id) snap.setSplitSizes(id, sizes)
   }, [])
 
-  const executeQuery = useCallback(
-    (overrideSql?: string) => {
-      // use the latest state
-      const state = getSqlEditorStateSnapshot()
-      const snippet = idRef.current && state.snippets[idRef.current]
+  const editorRef = useRef<IStandaloneCodeEditor | null>(null)
 
-      if (project && snippet && !isExecuting) {
-        execute?.({
-          projectRef: project.ref,
-          connectionString: project.connectionString,
-          sql: overrideSql ?? snippet.snippet.content.sql,
-        })
-      }
-    },
-    [isExecuting, project]
-  )
+  const executeQuery = useCallback(() => {
+    // use the latest state
+    const state = getSqlEditorStateSnapshot()
+    const snippet = idRef.current && state.snippets[idRef.current]
+
+    if (project && snippet && !isExecuting && editorRef.current !== null) {
+      const editor = editorRef.current
+      const selection = editor.getSelection()
+      const selectedValue = selection ? editor.getModel()?.getValueInRange(selection) : undefined
+      const overrideSql = selectedValue || editorRef.current?.getValue()
+
+      execute({
+        projectRef: project.ref,
+        connectionString: project.connectionString,
+        sql: overrideSql ?? snippet.snippet.content.sql,
+      })
+    }
+  }, [isExecuting, project])
 
   return (
     <div className="flex h-full flex-col">
@@ -72,7 +74,12 @@ const SQLEditor = () => {
           {isLoading ? (
             <div className="flex h-full w-full items-center justify-center">Loading...</div>
           ) : (
-            <MonacoEditor id={id!} isExecuting={isExecuting} executeQuery={executeQuery} />
+            <MonacoEditor
+              id={id}
+              editorRef={editorRef}
+              isExecuting={isExecuting}
+              executeQuery={executeQuery}
+            />
           )}
         </div>
 
@@ -80,7 +87,7 @@ const SQLEditor = () => {
           {isLoading ? (
             <div className="flex h-full w-full items-center justify-center">Loading...</div>
           ) : (
-            <UtilityPanel id={id!} isExecuting={isExecuting} executeQuery={executeQuery} />
+            <UtilityPanel id={id} isExecuting={isExecuting} executeQuery={executeQuery} />
           )}
         </div>
       </Split>

--- a/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityActions.tsx
+++ b/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityActions.tsx
@@ -8,7 +8,7 @@ import { detectOS } from 'lib/helpers'
 export type UtilityActionsProps = {
   id: string
   isExecuting?: boolean
-  executeQuery?: (overrideSql?: string) => void
+  executeQuery: () => void
 }
 
 const UtilityActions = ({ id, isExecuting = false, executeQuery }: UtilityActionsProps) => {
@@ -20,7 +20,7 @@ const UtilityActions = ({ id, isExecuting = false, executeQuery }: UtilityAction
       {IS_PLATFORM && <FavoriteButton id={id} />}
       <SizeToggleButton id={id} />
       <Button
-        onClick={() => executeQuery?.()}
+        onClick={() => executeQuery()}
         disabled={isExecuting}
         loading={isExecuting}
         type="default"

--- a/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityPanel.tsx
+++ b/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityPanel.tsx
@@ -5,7 +5,7 @@ import UtilityTabResults from './UtilityTabResults'
 export type UtilityPanelProps = {
   id: string
   isExecuting?: boolean
-  executeQuery?: (overrideSql?: string) => void
+  executeQuery: () => void
 }
 
 const UtilityPanel = ({ id, isExecuting, executeQuery }: UtilityPanelProps) => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix/feature?

## Changes

You can execute the currently selected SQL using CMD+Enter, but this functionality did not extend to the Run button. Now the run button works exactly the same as the shortcut for a more consistent experience.