### PR TITLE
docs(nextjs13) updated documentation for stable app dir and server components

### DIFF
--- a/apps/docs/pages/guides/auth/auth-helpers/nextjs-server-components.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/nextjs-server-components.mdx
@@ -10,7 +10,7 @@ export const meta = {
 
 The Next.js Auth Helpers package configures Supabase Auth to store the user's session in a cookie, rather than `localStorage`. This makes the users's session available server-side - in Server Components and Route Handlers - and is automatically sent along with any requests to Supabase.
 
-> The `app` directory in Next.js is still in beta and expected to change. For examples using the `pages` directory check out [Auth Helpers in Next.js](/docs/guides/auth/auth-helpers/nextjs).
+> Note: If you are using the `pages` directory, check out [Auth Helpers in Next.js](/docs/guides/auth/auth-helpers/nextjs).
 
 <div className="video-container">
   <iframe
@@ -38,16 +38,12 @@ The Next.js Auth Helpers package configures Supabase Auth to store the user's se
 npm install @supabase/auth-helpers-nextjs
 ```
 
-> [Next.js Server Components](https://beta.nextjs.org/docs) and the `app` directory are experimental and likely to change.
-
 </TabPanel>
 <TabPanel id="yarn" label="Yarn">
 
 ```sh
 yarn add @supabase/auth-helpers-nextjs
 ```
-
-> [Next.js Server Components](https://beta.nextjs.org/docs) and the `app` directory are experimental and likely to change.
 
 </TabPanel>
 </Tabs>

--- a/apps/docs/pages/guides/auth/auth-helpers/nextjs.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/nextjs.mdx
@@ -28,7 +28,7 @@ This library supports the following tooling versions:
 - Node.js: `^10.13.0 || >=12.0.0`
 - Next.js: `>=10`
 
-> Note: In [Next.js 13.4](https://nextjs.org/blog/next-13-4), The `app` directory and Server Components have reached stable status. Therefore, the new features are no longer in beta. You can refer to our experimental guide on utilizing [Auth Helpers with Next.js Server Components](/docs/guides/auth/auth-helpers/nextjs-server-components).
+> Note: As of [Next.js 13.4](https://nextjs.org/blog/next-13-4), the `app` directory and Server Components have reached stable status. Check out our guide on using [Auth Helpers with Next.js Server Components](/docs/guides/auth/auth-helpers/nextjs-server-components).
 
 Additionally, install the **React Auth Helpers** for components and hooks that can be used across all React-based frameworks.
 

--- a/apps/docs/pages/guides/auth/auth-helpers/nextjs.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/nextjs.mdx
@@ -28,7 +28,7 @@ This library supports the following tooling versions:
 - Node.js: `^10.13.0 || >=12.0.0`
 - Next.js: `>=10`
 
-> Note: Next.js 13 is stable, however, the new `app` directory and Server Components are still in beta. Check out our experimental guide on [using Auth Helpers with Next.js Server Components](/docs/guides/auth/auth-helpers/nextjs-server-components).
+> Note: In [Next.js 13.4](https://nextjs.org/blog/next-13-4), The `app` directory and Server Components have reached stable status. Therefore, the new features are no longer in beta. You can refer to our experimental guide on utilizing [Auth Helpers with Next.js Server Components](/docs/guides/auth/auth-helpers/nextjs-server-components).
 
 Additionally, install the **React Auth Helpers** for components and hooks that can be used across all React-based frameworks.
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

This pull request introduces an update regarding the stable status of the `app` directory and Server Components in Next.js 13.4.

## What is the current behavior?

Currently, Next.js 13 is stable, but the `app` directory and Server Components are still in beta.

## What is the new behavior?

With this update, I've confirmed that both the `app` directory and Server Components have reached a stable status in Next.js 13.4.

## Additional context

This change is important as it ensures that developers are aware of the stable nature of the app directory and Server Components in Next.js 13. It eliminates any confusion and provides clarity for users of these features.
