### PR TITLE
fix(embeddings): custom heading slugs

### DIFF
--- a/.github/workflows/search.yml
+++ b/.github/workflows/search.yml
@@ -9,7 +9,12 @@ on:
       - 'supabase/migrations/**'
       - 'apps/docs/**'
       - 'spec/**'
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      refresh:
+        description: 'Refresh all pages'
+        required: false
+        type: boolean
   schedule:
     - cron: '0 0 * * *'
 
@@ -46,6 +51,12 @@ jobs:
       - name: Run migrations
         run: npx supabase db push
 
+      - name: Update embeddings
+        working-directory: ./apps/docs
+        if: ${{ !inputs.refresh }}
+        run: npm run embeddings
+
       - name: Refresh embeddings
         working-directory: ./apps/docs
-        run: npm run embeddings
+        if: ${{ inputs.refresh }}
+        run: npm run embeddings:refresh

--- a/apps/docs/scripts/search/sources/markdown.ts
+++ b/apps/docs/scripts/search/sources/markdown.ts
@@ -97,6 +97,23 @@ export function splitTreeBy(tree: Root, predicate: (node: Content) => boolean) {
 }
 
 /**
+ * Wrapped slug generator that also accounts for
+ * custom anchors in the format:
+ *
+ * ```markdown
+ * ### My Heading [#my-custom-anchor]
+ * ```
+ */
+export function generateSlug(slugger: GithubSlugger, heading: string) {
+  const match = heading.match(/\[#(.*)\]/)
+  if (match) {
+    const [, customAnchor] = match
+    return slugger.slug(customAnchor)
+  }
+  return slugger.slug(heading)
+}
+
+/**
  * Processes MDX content for search indexing.
  * It extracts metadata, strips it of all JSX,
  * and splits it into sub-sections based on criteria.
@@ -142,7 +159,7 @@ export function processMdxForSearch(content: string): ProcessedMdx {
     const [firstNode] = tree.children
 
     const heading = firstNode.type === 'heading' ? toString(firstNode) : undefined
-    const slug = heading ? slugger.slug(heading) : undefined
+    const slug = heading ? generateSlug(slugger, heading) : undefined
 
     return {
       content: toMarkdown(tree),


### PR DESCRIPTION
Markdown headings with custom slugs don't parse properly for embedding search:
![image](https://github.com/supabase/supabase/assets/4133076/25ea4fda-ab31-4ead-a400-d02b39494679)

Adds custom slug parsing logic.