### PR TITLE
Fix missing import in auth guide

### DIFF
--- a/apps/docs/pages/guides/auth/auth-helpers/nextjs-server-components.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/nextjs-server-components.mdx
@@ -178,7 +178,7 @@ Create a new file at `/app/supabase-provider.tsx` and populate with the followin
 'use client'
 
 import { createContext, useContext, useEffect, useState } from 'react'
-import { createBrowserSupabaseClient } from '@supabase/auth-helpers-nextjs'
+import { Session, createBrowserSupabaseClient } from '@supabase/auth-helpers-nextjs'
 import { useRouter } from 'next/navigation'
 
 import type { SupabaseClient } from '@supabase/auth-helpers-nextjs'


### PR DESCRIPTION
## What kind of change does this PR introduce?

Updated the docs for the Next.js app directory auth provider since it was missing the import for the `Session` type

## What is the current behavior?

The `Session` import is missing, so copying the SupabaseProvider from the docs would lead to an error

## What is the new behavior?

The `Session` import has been added, so users can now copy the SupabaseProvder from the docs without running into issues

## Additional context

Add any other context or screenshots.
