### PR TITLE
Add spacing to docs sidebar

### DIFF
--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenuGuideListItems.tsx
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenuGuideListItems.tsx
@@ -147,7 +147,7 @@ const Content = (props) => {
   const { menu, id } = props
 
   return (
-    <ul className={['relative w-full flex flex-col gap-0'].join(' ')}>
+    <ul className={['relative w-full flex flex-col gap-0 pb-5'].join(' ')}>
       <Link href={`${menu.parent ?? '/'}`} passHref>
         <a
           className={[


### PR DESCRIPTION
## What kind of change does this PR introduce?

Forgot about the sub section of the docs sidebar. Same as last PR https://github.com/supabase/supabase/pull/14305.

## What is the current behavior?

<img src="https://github.com/supabase/supabase/assets/70828596/4ee0492b-d2c4-48bf-93ff-1b1c2a11f790" height="500" />

## What is the new behavior?

<img src="https://github.com/supabase/supabase/assets/70828596/0ae2bd1a-744d-4b78-9e86-f018f8c67afe" height="500" />