### PR TITLE
fix: docs cli text

### DIFF
--- a/apps/docs/layouts/ref/RefSubLayout.tsx
+++ b/apps/docs/layouts/ref/RefSubLayout.tsx
@@ -132,7 +132,7 @@ const StickyHeader: FC<StickyHeader> = ({ icon, ...props }) => {
 }
 
 const Details: FC<ISectionDetails> = (props) => {
-  return <div className="relative overflow-hidden w-full">{props.children}</div>
+  return <div className="relative w-full">{props.children}</div>
 }
 
 const Examples: FC<ISectionExamples> = (props) => {

--- a/apps/docs/styles/main.scss
+++ b/apps/docs/styles/main.scss
@@ -80,6 +80,10 @@ article h1 {
   @apply text-scale-900 text-xs;
 }
 
+.prose :where(p):not(:where([class~='not-prose'] *)) {
+  white-space: pre-line;
+}
+
 code[class*='language-'],
 pre[class*='language-'] {
   text-shadow: none !important;

--- a/package-lock.json
+++ b/package-lock.json
@@ -51547,7 +51547,7 @@
         "dotenv": "^16.0.3",
         "ejs": "^3.1.8",
         "eslint": "8.9.0",
-        "framer-motion": "6.5.1",
+        "framer-motion": "^6.5.1",
         "github-slugger": "^2.0.0",
         "globby": "^12.0.2",
         "gray-matter": "^4.0.3",


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes issue #13795 

## What is the current behavior?

Text doesn't wrap and doesn't have enough overflow.

<img width="1413" alt="Schermata 2023-05-15 alle 11 29 58" src="https://github.com/supabase/supabase/assets/25671831/d9223065-9132-4dec-8743-2d86a12d06f0">


## What is the new behavior?

<img width="1435" alt="Schermata 2023-05-15 alle 11 29 28" src="https://github.com/supabase/supabase/assets/25671831/40295ec2-a9e2-4dc7-af0f-c914c6ab5d55">

