### PR TITLE
Restore alpha sorting to sql snippet list

### DIFF
--- a/studio/components/layouts/SQLEditorLayout/QueryItem.tsx
+++ b/studio/components/layouts/SQLEditorLayout/QueryItem.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useParams } from 'common'
 import ConfirmationModal from 'components/ui/ConfirmationModal'
 import { useContentDeleteMutation } from 'data/content/content-delete-mutation'
@@ -21,14 +21,26 @@ const QueryItem = ({ tabInfo }: QueryItemProps) => {
   const { ref, id: activeId } = useParams()
   const { id, name } = tabInfo || {}
   const isActive = id === activeId
+  const activeItemRef = useRef<HTMLElement | null>(null)
+
+  useEffect(() => {
+    // scroll to active item
+    if (isActive && activeItemRef.current) {
+      // race condition hack
+      setTimeout(() => {
+        activeItemRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+      }, 0)
+    }
+  })
 
   return (
     <div
       key={id}
       className={clsx(
         'flex items-center justify-between rounded-md group',
-        isActive && 'text-scale-1200 bg-scale-300'
+        isActive && 'text-scale-1200 bg-scale-400 dark:bg-scale-300 -active'
       )}
+      ref={isActive ? (activeItemRef as React.RefObject<HTMLDivElement>) : null}
     >
       <Link href={`/project/${ref}/sql/${id}`}>
         <a className="py-1 px-3 w-full">
@@ -127,14 +139,12 @@ const QueryItemActions = observer(({ tabInfo }: { tabInfo: SqlSnippet }) => {
       ) : (
         <Button as="span" type="text" style={{ padding: '3px' }} />
       )}
-
       <RenameQueryModal
         snippet={tabInfo}
         visible={renameModalOpen}
         onCancel={onCloseRenameModal}
         onComplete={onCloseRenameModal}
       />
-
       <ConfirmationModal
         header="Confirm to delete"
         buttonLabel="Delete query"

--- a/studio/components/layouts/SQLEditorLayout/SQLEditorMenu.tsx
+++ b/studio/components/layouts/SQLEditorLayout/SQLEditorMenu.tsx
@@ -111,6 +111,8 @@ const SideBarContent = observer(() => {
                 <Dropdown
                   align="end"
                   side="bottom"
+                  sideOffset={3}
+                  className="max-w-[210px]"
                   overlay={[
                     <Dropdown.Item
                       key="new-ai-query"

--- a/studio/components/layouts/SQLEditorLayout/SQLEditorMenu.tsx
+++ b/studio/components/layouts/SQLEditorLayout/SQLEditorMenu.tsx
@@ -61,7 +61,6 @@ const SideBarContent = observer(() => {
     filterString.length === 0
       ? queries
       : queries.filter((tab) => tab.name.toLowerCase().includes(filterString.toLowerCase()))
-
   const canCreateSQLSnippet = checkPermissions(PermissionAction.CREATE, 'user_content', {
     resource: { type: 'sql', owner_id: profile?.id },
     subject: { id: profile?.id },
@@ -180,21 +179,25 @@ const SideBarContent = observer(() => {
                 <div className="editor-product-menu">
                   <Menu.Group title="Favorites" />
                   <div className="space-y-1">
-                    {favouriteTabs.map((tabInfo) => {
-                      const { id } = tabInfo || {}
-                      return <QueryItem key={id} tabInfo={tabInfo} />
-                    })}
+                    {favouriteTabs
+                      .sort((a, b) => a.name?.localeCompare(b.name)) // first alphabetical
+                      .map((tabInfo) => {
+                        const { id } = tabInfo || {}
+                        return <QueryItem key={id} tabInfo={tabInfo} />
+                      })}
                   </div>
                 </div>
               )}
               {queryTabs.length >= 1 && (
                 <div className="editor-product-menu">
                   <Menu.Group title="SQL snippets" />
-                  <div className="space-y-1">
-                    {queryTabs.map((tabInfo) => {
-                      const { id } = tabInfo || {}
-                      return <QueryItem key={id} tabInfo={tabInfo} />
-                    })}
+                  <div className="space-y-1 pb-8">
+                    {queryTabs
+                      .sort((a, b) => a.name?.localeCompare(b.name)) // first alphabetical
+                      .map((tabInfo) => {
+                        const { id } = tabInfo || {}
+                        return <QueryItem key={id} tabInfo={tabInfo} />
+                      })}
                   </div>
                 </div>
               )}


### PR DESCRIPTION
Previously, the SQL Snippets were sorted in alphabetical order. 
A recent refactor to how these are fetched had the unintended consequence of changing this to date created order instead. 

This change, though small, has caused considerable dismay. 

This PR restores the sorting order to alphabetical, as before. 
It also scrolls the sidebar pane to the currently active item when the item is renamed. 

Please consider this additional, small feature as an act of penance.

