### PR TITLE
fix : Filtering by a bigint id column in studio doesn't work for large ints

### DIFF
--- a/studio/data/table-rows/utils.ts
+++ b/studio/data/table-rows/utils.ts
@@ -10,7 +10,8 @@ export function formatFilterValue(table: SupaTable, filter: Filter) {
   const column = table.columns.find((x) => x.name == filter.column)
   if (column && isNumericalColumn(column.format)) {
     const numberValue = Number(filter.value)
-    if (Number.isNaN(numberValue)) return filter.value
+    // Supports BigInt filter values
+    if (Number.isNaN(numberValue) || numberValue > Number.MAX_SAFE_INTEGER) return filter.value
     else return Number(filter.value)
   }
   return filter.value


### PR DESCRIPTION
Fixes https://github.com/supabase/supabase/issues/13612

## What kind of change does this PR introduce?

## What is the current behavior?
Filtering by a bigint id column in table doesn't work for large ints which is greater than Number.MAX_SAFE_INTEGER

## What is the new behavior?
Filtering by bigint id column works well

## Demo video

https://github.com/GitStartHQ/client-supabase/assets/51731962/c17f8c20-eca1-440c-8735-074c6195f536


---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time. 