### PR TITLE
update google & azure oauth guide

### DIFF
--- a/apps/docs/pages/guides/auth/social-login/auth-azure.mdx
+++ b/apps/docs/pages/guides/auth/social-login/auth-azure.mdx
@@ -91,6 +91,21 @@ async function signout() {
 }
 ```
 
+## Obtain the provider refresh token
+
+Azure OAuth2.0 doesn't return the `provider_refresh_token` by default. If you need the `provider_refresh_token` returned, you will need to include the following scope:
+
+```js
+async function signInWithAzure() {
+  const { data, error } = await supabase.auth.signInWithOAuth({
+    provider: 'azure',
+    options: {
+      scopes: 'offline_access',
+    },
+  })
+}
+```
+
 ## Resources
 
 - [Azure Developer Account](https://portal.azure.com)

--- a/apps/docs/pages/guides/auth/social-login/auth-google.mdx
+++ b/apps/docs/pages/guides/auth/social-login/auth-google.mdx
@@ -83,6 +83,18 @@ async function signInWithGoogle() {
 }
 ```
 
+You can view the full list of query parameters and their descriptions [here](https://developers.google.com/identity/protocols/oauth2/web-server#creatingclient).
+
+When your user signs out, call [signOut()](/docs/reference/javascript/auth-signout) to remove them from the browser session and any objects from localStorage:
+
+```js
+async function signout() {
+  const { error } = await supabase.auth.signOut()
+}
+```
+
+## Obtain the provider refresh token
+
 Google OAuth2.0 doesn't return the `provider_refresh_token` by default. If you need the `provider_refresh_token` returned, you will need to add additional query parameters:
 
 ```js
@@ -96,16 +108,6 @@ async function signInWithGoogle() {
       },
     },
   })
-}
-```
-
-You can view the full list of query parameters and their descriptions [here](https://developers.google.com/identity/protocols/oauth2/web-server#creatingclient).
-
-When your user signs out, call [signOut()](/docs/reference/javascript/auth-signout) to remove them from the browser session and any objects from localStorage:
-
-```js
-async function signout() {
-  const { error } = await supabase.auth.signOut()
 }
 ```
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Add section on retrieving the `provider_refresh_token` for google and azure