### PR TITLE
docs: add uploadBinary func to flutter docs

### DIFF
--- a/spec/supabase_dart_v1.yml
+++ b/spec/supabase_dart_v1.yml
@@ -1129,6 +1129,17 @@ functions:
                 fileOptions: const FileOptions(cacheControl: '3600', upsert: false),
               );
           ```
+      - id: upload-file-on-web
+        name: Upload file on web
+        code: |
+          ```dart
+          final avatarFile = chosenFile.bytes;
+          final String path = await supabase.storage.from('avatars').uploadBinary(
+                'public/avatar1.png',
+                avatarFile,
+                fileOptions: const FileOptions(cacheControl: '3600', upsert: false),
+              );
+          ```
 
   - id: from-update
     description: |


### PR DESCRIPTION
## What kind of change does this PR introduce?

Enhance flutter reference docs to include uploadBinary function.

## What is the current behavior?

The function is not documented. Relevant issue: #14352. 

## What is the new behavior?

Add the fucntion to the upload file section of flutter docs:
<img width="1121" alt="screenshot" src="https://github.com/supabase/supabase/assets/67555014/3734f933-639a-4856-9af3-d02c0f809320">


## Additional context
Upload files through flutter web works differently.