### PR TITLE
small fix: line break in docs

### DIFF
--- a/apps/docs/pages/guides/getting-started/architecture.mdx
+++ b/apps/docs/pages/guides/getting-started/architecture.mdx
@@ -156,8 +156,7 @@ As the profile of a developer changes over time, Supabase will continue to evolv
 
 ### Support existing tools
 
-Supabase supports existing tools and communities wherever possible. Supabase is more like a "community of communities" - each tool typically has its own community
-which we work with.
+Supabase supports existing tools and communities wherever possible. Supabase is more like a "community of communities" - each tool typically has its own community which we work with.
 Open source is something we approach [collaboratively](https://supabase.com/blog/supabase-series-b#giving-back): we employ maintainers, sponsor projects, invest in businesses, and develop our own open source tools.
 
 export const Page = ({ children }) => <Layout meta={meta} children={children} />


### PR DESCRIPTION
Removes an unnecessary line break.

## What kind of change does this PR introduce?

Docs update, minor change.

## What is the current behavior?

There is an extra line break.

![image](https://github.com/supabase/supabase/assets/12992271/b66c5447-5ca5-484a-8b45-ea1db99c5940)

## What is the new behavior?

Removes the extra line break.
