### PR TITLE
docs: add log level docs for pg_audit

### DIFF
--- a/apps/docs/pages/guides/platform/logs.mdx
+++ b/apps/docs/pages/guides/platform/logs.mdx
@@ -112,7 +112,7 @@ To _permanently_ set a logging configuration (beyond a single session), execute 
 alter role postgres set pgaudit.log to 'function, write, ddl';
 ```
 
-It is advised to adjust the scope of the logs to only relevant statements to aid in your debugging, as having too wide of a scope would result in a lot of noise in your Postgres logs.
+To help with debugging, we recommend adjusting the log scope to only relevant statements as having too wide of a scope would result in a lot of noise in your Postgres logs.
 
 Note that in the above example, the role is set to `postgres`. To log user-traffic flowing through the [HTTP APIs](../../guides/database/api#rest-api-overview) powered by PostgREST, set your configuration values for the roles `anon` and `authenticated`. For traffic using the `service_role` key, set the configuration values for the role `service_role`.
 

--- a/apps/docs/pages/guides/platform/logs.mdx
+++ b/apps/docs/pages/guides/platform/logs.mdx
@@ -112,7 +112,27 @@ To _permanently_ set a logging configuration (beyond a single session), execute 
 alter role postgres set pgaudit.log to 'function, write, ddl';
 ```
 
-For user-traffic flowing through the [HTTP APIs](../../guides/database/api#rest-api-overview) powered by PostgREST, set your configuration values for the roles `anon` and `authenticated`. For traffic using the `service_role` key, set the configuration values for the role `service_role`.
+It is advised to adjust the scope of the logs to only relevant statements to aid in your debugging, as having too wide of a scope would result in a lot of noise in your Postgres logs.
+
+Note that in the above example, the role is set to `postgres`. To log user-traffic flowing through the [HTTP APIs](../../guides/database/api#rest-api-overview) powered by PostgREST, set your configuration values for the roles `anon` and `authenticated`. For traffic using the `service_role` key, set the configuration values for the role `service_role`.
+
+
+```sql
+-- for API-related logs
+alter role anon set pgaudit.log to 'write';
+alter role authenticated set pgaudit.log to 'write';
+
+-- for service role logs
+alter role service_role set pgaudit.log to 'write';
+```
+
+By default, the log level will be set to `log`. To view other levels, run the following:
+```sql
+-- adjust log level
+alter role postgres set pgaudit.log_level to 'info';
+alter role postgres set pgaudit.log_level to 'debug5';
+```
+Note that as per the `pg_audit` [log_level documentation](https://github.com/pgaudit/pgaudit/blob/master/README.md#pgauditlog_level), `error`, `fatal`, and `panic` are not allowed.
 
 To reset system-wide settings, execute the following, then perform a fast reboot:
 

--- a/apps/docs/pages/guides/platform/logs.mdx
+++ b/apps/docs/pages/guides/platform/logs.mdx
@@ -132,7 +132,7 @@ By default, the log level will be set to `log`. To view other levels, run the fo
 alter role postgres set pgaudit.log_level to 'info';
 alter role postgres set pgaudit.log_level to 'debug5';
 ```
-Note that as per the `pg_audit` [log_level documentation](https://github.com/pgaudit/pgaudit/blob/master/README.md#pgauditlog_level), `error`, `fatal`, and `panic` are not allowed.
+Note that as per the pgAudit [log_level documentation](https://github.com/pgaudit/pgaudit/blob/master/README.md#pgauditlog_level), `error`, `fatal`, and `panic` are not allowed.
 
 To reset system-wide settings, execute the following, then perform a fast reboot:
 

--- a/apps/docs/pages/guides/platform/logs.mdx
+++ b/apps/docs/pages/guides/platform/logs.mdx
@@ -116,7 +116,6 @@ It is advised to adjust the scope of the logs to only relevant statements to aid
 
 Note that in the above example, the role is set to `postgres`. To log user-traffic flowing through the [HTTP APIs](../../guides/database/api#rest-api-overview) powered by PostgREST, set your configuration values for the roles `anon` and `authenticated`. For traffic using the `service_role` key, set the configuration values for the role `service_role`.
 
-
 ```sql
 -- for API-related logs
 alter role anon set pgaudit.log to 'write';
@@ -127,11 +126,13 @@ alter role service_role set pgaudit.log to 'write';
 ```
 
 By default, the log level will be set to `log`. To view other levels, run the following:
+
 ```sql
 -- adjust log level
 alter role postgres set pgaudit.log_level to 'info';
 alter role postgres set pgaudit.log_level to 'debug5';
 ```
+
 Note that as per the pgAudit [log_level documentation](https://github.com/pgaudit/pgaudit/blob/master/README.md#pgauditlog_level), `error`, `fatal`, and `panic` are not allowed.
 
 To reset system-wide settings, execute the following, then perform a fast reboot:


### PR DESCRIPTION
Add documentation on pg_audit log-level
<img width="964" alt="Screenshot 2023-05-17 at 3 47 31 PM" src="https://github.com/supabase/supabase/assets/22714384/aafb0675-24cd-42eb-8ff7-955ccd6f39a1">

note: adjusted name of pgaudit to `pgAudit`