### PR TITLE
fix: hides recharts ticks properly

### DIFF
--- a/studio/components/to-be-cleaned/Charts/ChartRenderer.tsx
+++ b/studio/components/to-be-cleaned/Charts/ChartRenderer.tsx
@@ -214,7 +214,7 @@ export function BarChart({
                     interval={data ? data.length - 2 : 0}
                     angle={0}
                     // stroke="#4B5563"
-                    tick={{ fontSize: '0px', color: CHART_COLORS.TICK }}
+                    tick={false}
                     axisLine={{ stroke: CHART_COLORS.AXIS }}
                     tickLine={{ stroke: CHART_COLORS.AXIS }}
                   />

--- a/studio/components/ui/Charts/AreaChart.tsx
+++ b/studio/components/ui/Charts/AreaChart.tsx
@@ -97,7 +97,7 @@ const AreaChart: React.FC<AreaChartProps> = ({
             interval={data.length - 2}
             angle={0}
             // hide the tick
-            tick={{ fontSize: '0px' }}
+            tick={false}
             // color the axis
             axisLine={{ stroke: CHART_COLORS.AXIS }}
             tickLine={{ stroke: CHART_COLORS.AXIS }}

--- a/studio/components/ui/Charts/BarChart.tsx
+++ b/studio/components/ui/Charts/BarChart.tsx
@@ -92,7 +92,7 @@ const BarChart: React.FC<BarChartProps> = ({
             interval={data.length - 2}
             angle={0}
             // hide the tick
-            tick={{ fontSize: '0px' }}
+            tick={false}
             // color the axis
             axisLine={{ stroke: CHART_COLORS.AXIS }}
             tickLine={{ stroke: CHART_COLORS.AXIS }}

--- a/studio/components/ui/Charts/StackedBarChart.tsx
+++ b/studio/components/ui/Charts/StackedBarChart.tsx
@@ -84,7 +84,7 @@ const StackedBarChart: React.FC<Props> = ({
             dataKey={xAxisKey}
             interval={data.length - 2}
             angle={0}
-            tick={{ fontSize: '0px' }}
+            tick={false}
             axisLine={{ stroke: CHART_COLORS.AXIS }}
             tickLine={{ stroke: CHART_COLORS.AXIS }}
           />


### PR DESCRIPTION
This PR fixes the ticks hiding for recharts, where the 0px hack broke when they patched tick rendering in a [minor version](https://github.com/recharts/recharts/blob/master/CHANGELOG.md#2114-sep-7-2022).

recent package-lock update should have bumped up the minor version resulting in this break.
<img width="1260" alt="Screenshot 2023-05-17 at 6 21 22 PM" src="https://github.com/supabase/supabase/assets/22714384/0dec0179-3271-4b62-9ae5-87e821c412dc">
