### PR TITLE
Rename Azure to Azure (Mircosoft)

### DIFF
--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
@@ -321,7 +321,7 @@ export const SocialLoginItems = [
     url: '/guides/auth/social-login/auth-apple',
   },
   {
-    name: 'Azure',
+    name: 'Azure (Microsoft)',
     icon: '/docs/img/icons/microsoft-icon',
     url: '/guides/auth/social-login/auth-azure',
   },

--- a/apps/docs/data/authProviders.ts
+++ b/apps/docs/data/authProviders.ts
@@ -10,7 +10,7 @@ const authProviders = [
     authType: 'social',
   },
   {
-    name: 'Azure',
+    name: 'Azure (Microsoft)',
     logo: '/docs/img/icons/microsoft-icon',
     href: '/guides/auth/social-login/auth-azure',
     official: false,

--- a/apps/docs/pages/guides/auth/social-login/auth-azure.mdx
+++ b/apps/docs/pages/guides/auth/social-login/auth-azure.mdx
@@ -2,11 +2,11 @@ import Layout from '~/layouts/DefaultGuideLayout'
 
 export const meta = {
   id: 'auth-azure',
-  title: 'Login with Azure',
-  description: 'Add Azure OAuth to your Supabase project',
+  title: 'Login with Azure (Microsoft)',
+  description: 'Add Azure (Microsoft) OAuth to your Supabase project',
 }
 
-To enable Azure Auth for your project, you need to set up an Azure OAuth application and add the application credentials to your Supabase Dashboard.
+To enable Azure (Microsoft) Auth for your project, you need to set up an Azure OAuth application and add the application credentials to your Supabase Dashboard.
 
 ## Overview
 

--- a/apps/docs/pages/guides/self-hosting.mdx
+++ b/apps/docs/pages/guides/self-hosting.mdx
@@ -134,7 +134,7 @@ secrets manager when deploying to production. Plain text files like dotenv lead 
 Some suggested systems include:
 
 - [Doppler](https://www.doppler.com/)
-- [Key Vault](https://docs.microsoft.com/en-us/azure/key-vault/general/overview) by Azure
+- [Key Vault](https://docs.microsoft.com/en-us/azure/key-vault/general/overview) by Azure (Microsoft)
 - [Secrets Manager](https://aws.amazon.com/secrets-manager/) by AWS
 - [Secrets Manager](https://cloud.google.com/secret-manager) by GCP
 - [Vault](https://www.hashicorp.com/products/vault) by Hashicorp

--- a/apps/docs/pages/learn/auth-deep-dive/auth-google-oauth.mdx
+++ b/apps/docs/pages/learn/auth-deep-dive/auth-google-oauth.mdx
@@ -24,7 +24,7 @@ How to add Google OAuth Logins to your Supabase Application.
 
 ### Logging in with external OAuth providers
 
-Connecting social logins such as Google, GitHub, or Facebook couldn't be easier. In this guide we'll walk you through the process of connecting Google, but the process is basically the same for all of the providers which includes: azure, bitbucket, github, gitlab, facebook, and google.
+Connecting social logins such as Google, GitHub, or Facebook couldn't be easier. In this guide we'll walk you through the process of connecting Google, but the process is basically the same for all of the providers which includes: azure (Microsoft), bitbucket, github, gitlab, facebook, and google.
 
 First you'll need to create a google project inside their [cloud console](https://console.cloud.google.com/home/dashboard), in other providers they may refer to this as an "app" and is usually available on the company's developer portal.
 

--- a/apps/docs/pages/learn/auth-deep-dive/auth-google-oauth.mdx
+++ b/apps/docs/pages/learn/auth-deep-dive/auth-google-oauth.mdx
@@ -24,7 +24,7 @@ How to add Google OAuth Logins to your Supabase Application.
 
 ### Logging in with external OAuth providers
 
-Connecting social logins such as Google, GitHub, or Facebook couldn't be easier. In this guide we'll walk you through the process of connecting Google, but the process is basically the same for all of the providers which includes: azure (Microsoft), bitbucket, github, gitlab, facebook, and google.
+Connecting social logins such as Google, GitHub, or Facebook couldn't be easier. In this guide we'll walk you through the process of connecting Google, but the process is basically the same for all of the providers which includes: azure, bitbucket, github, gitlab, facebook, and google.
 
 First you'll need to create a google project inside their [cloud console](https://console.cloud.google.com/home/dashboard), in other providers they may refer to this as an "app" and is usually available on the company's developer portal.
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Renames Azure to Azure (Mircosoft) in the docs for better understanding.

## What is the current behavior?

Named Azure

## What is the new behavior?

Named Azure (Mircosoft)

## Additional context

- [notion task](https://www.notion.so/Rename-Sign-In-with-Azure-to-Sign-In-With-Microsoft-on-the-Docs-de54d2d9aa524abc967370fe5cf2d95b?pvs=5)
- [github comment](https://github.com/supabase/gotrue/pull/1107#issuecomment-1550698804)