### PR TITLE
Docs: Fix edge function rate limit link to GitHub

### DIFF
--- a/apps/docs/pages/guides/functions/examples/rate-limiting.mdx
+++ b/apps/docs/pages/guides/functions/examples/rate-limiting.mdx
@@ -18,7 +18,7 @@ export const meta = {
 
 [Upstash](https://upstash.com/) provides an HTTP/REST based Redis client which is ideal for serverless use-cases and therefore works well with Supabase Edge Functions.
 
-Find the code on [GitHub](https://github.com/supabase/supabase/tree/master/examples/edge-functions/supabase/functions/upstash-redis-ratelimit).
+Find the code on [GitHub](https://github.com/supabase/supabase/tree/master/examples/edge-functions/supabase/functions/upstash-redis-counter).
 
 export const Page = ({ children }) => <Layout meta={meta} children={children} />
 


### PR DESCRIPTION
Updates the GitHub link found on this page:

https://supabase.com/docs/guides/functions/examples/rate-limiting

From:
https://github.com/supabase/supabase/tree/master/examples/edge-functions/supabase/functions/upstash-redis-ratelimit

To:
https://github.com/supabase/supabase/tree/master/examples/edge-functions/supabase/functions/upstash-redis-counter