### PR TITLE
Fix/project usage chart bugfixes

### DIFF
--- a/studio/components/interfaces/Home/ProjectUsage.tsx
+++ b/studio/components/interfaces/Home/ProjectUsage.tsx
@@ -2,7 +2,16 @@ import dayjs from 'dayjs'
 import Link from 'next/link'
 import { FC, useState } from 'react'
 import { useRouter } from 'next/router'
-import { Button, Dropdown, IconArchive, IconChevronDown, IconDatabase, IconKey, IconZap } from 'ui'
+import {
+  Button,
+  Dropdown,
+  IconArchive,
+  IconChevronDown,
+  IconDatabase,
+  IconKey,
+  IconZap,
+  Loading,
+} from 'ui'
 import Panel from 'components/ui/Panel'
 import { ChartIntervals } from 'types'
 import { useParams } from 'common/hooks'
@@ -99,16 +108,17 @@ const ProjectUsage: FC<Props> = ({}) => {
               href={`/project/${projectRef}/editor`}
             />
 
-            <BarChart
-              title="REST Requests"
-              data={charts}
-              xAxisKey="timestamp"
-              yAxisKey="total_rest_requests"
-              isLoading={isLoading}
-              onBarClick={(v: unknown) => handleBarClick(v as UsageApiCounts, 'rest')}
-              customDateFormat={datetimeFormat}
-              highlightedValue={sumBy(charts, 'total_rest_requests')}
-            />
+            <Loading active={isLoading}>
+              <BarChart
+                title="REST Requests"
+                data={charts}
+                xAxisKey="timestamp"
+                yAxisKey="total_rest_requests"
+                onBarClick={(v: unknown) => handleBarClick(v as UsageApiCounts, 'rest')}
+                customDateFormat={datetimeFormat}
+                highlightedValue={sumBy(charts, 'total_rest_requests')}
+              />
+            </Loading>
           </Panel.Content>
         </Panel>
         <Panel>
@@ -122,16 +132,17 @@ const ProjectUsage: FC<Props> = ({}) => {
               title="Auth"
               href={`/project/${projectRef}/auth/users`}
             />
-            <BarChart
-              title="Auth Requests"
-              data={charts}
-              xAxisKey="timestamp"
-              yAxisKey="total_auth_requests"
-              isLoading={!charts && !error ? true : false}
-              onBarClick={(v: unknown) => handleBarClick(v as UsageApiCounts, 'auth')}
-              customDateFormat={datetimeFormat}
-              highlightedValue={sumBy(charts || [], 'total_auth_requests')}
-            />
+            <Loading active={isLoading}>
+              <BarChart
+                title="Auth Requests"
+                data={charts}
+                xAxisKey="timestamp"
+                yAxisKey="total_auth_requests"
+                onBarClick={(v: unknown) => handleBarClick(v as UsageApiCounts, 'auth')}
+                customDateFormat={datetimeFormat}
+                highlightedValue={sumBy(charts || [], 'total_auth_requests')}
+              />
+            </Loading>
           </Panel.Content>
         </Panel>
         <Panel>
@@ -146,16 +157,17 @@ const ProjectUsage: FC<Props> = ({}) => {
               href={`/project/${projectRef}/storage/buckets`}
             />
 
-            <BarChart
-              title="Storage Requests"
-              data={charts}
-              xAxisKey="timestamp"
-              yAxisKey="total_storage_requests"
-              isLoading={isLoading}
-              onBarClick={(v: unknown) => handleBarClick(v as UsageApiCounts, 'storage')}
-              customDateFormat={datetimeFormat}
-              highlightedValue={sumBy(charts, 'total_storage_requests')}
-            />
+            <Loading active={isLoading}>
+              <BarChart
+                title="Storage Requests"
+                data={charts}
+                xAxisKey="timestamp"
+                yAxisKey="total_storage_requests"
+                onBarClick={(v: unknown) => handleBarClick(v as UsageApiCounts, 'storage')}
+                customDateFormat={datetimeFormat}
+                highlightedValue={sumBy(charts, 'total_storage_requests')}
+              />
+            </Loading>
           </Panel.Content>
         </Panel>
         <Panel>
@@ -169,16 +181,17 @@ const ProjectUsage: FC<Props> = ({}) => {
               title="Realtime"
             />
 
-            <BarChart
-              title="Realtime Requests"
-              data={charts}
-              xAxisKey="timestamp"
-              yAxisKey="total_realtime_requests"
-              isLoading={isLoading}
-              onBarClick={(v: unknown) => handleBarClick(v as UsageApiCounts, 'realtime')}
-              customDateFormat={datetimeFormat}
-              highlightedValue={sumBy(charts, 'total_realtime_requests')}
-            />
+            <Loading active={isLoading}>
+              <BarChart
+                title="Realtime Requests"
+                data={charts}
+                xAxisKey="timestamp"
+                yAxisKey="total_realtime_requests"
+                onBarClick={(v: unknown) => handleBarClick(v as UsageApiCounts, 'realtime')}
+                customDateFormat={datetimeFormat}
+                highlightedValue={sumBy(charts, 'total_realtime_requests')}
+              />
+            </Loading>
           </Panel.Content>
         </Panel>
       </div>

--- a/studio/components/interfaces/Settings/Logs/Logs.utils.ts
+++ b/studio/components/interfaces/Settings/Logs/Logs.utils.ts
@@ -449,6 +449,7 @@ const _getTruncation = (date: Dayjs) => {
     1: 'minute' as const,
     2: 'hour' as const,
     3: 'day' as const,
+    4: 'day' as const,
   }[zeroCount]!
   return truncation
 }

--- a/studio/components/interfaces/Settings/Logs/Logs.utils.ts
+++ b/studio/components/interfaces/Settings/Logs/Logs.utils.ts
@@ -437,7 +437,7 @@ export const getTimestampTruncation = (samples: Dayjs[]): 'second' | 'minute' | 
 }
 
 const _getTruncation = (date: Dayjs) => {
-  const values = ['second', 'minute', 'hour', 'day'].map((key) => date.get(key as dayjs.UnitType))
+  const values = ['second', 'minute', 'hour'].map((key) => date.get(key as dayjs.UnitType))
   const zeroCount = values.reduce((acc, value) => {
     if (value === 0) {
       acc += 1
@@ -449,7 +449,6 @@ const _getTruncation = (date: Dayjs) => {
     1: 'minute' as const,
     2: 'hour' as const,
     3: 'day' as const,
-    4: 'day' as const,
   }[zeroCount]!
   return truncation
 }

--- a/studio/components/ui/Charts/Charts.types.tsx
+++ b/studio/components/ui/Charts/Charts.types.tsx
@@ -13,7 +13,6 @@ export interface CommonChartProps<D>
   > {
   title?: string
   className?: string
-  isLoading?: boolean
   size?: 'tiny' | 'small' | 'normal' | 'large'
 }
 

--- a/studio/tests/pages/projects/Logs.utils.test.js
+++ b/studio/tests/pages/projects/Logs.utils.test.js
@@ -144,9 +144,9 @@ test.each([
       { timestamp: '2023-04-26T20:00:00.000Z', count: 0 },
     ],
   },
-   // fill multiple keys in one go
-   {
-    case: 'fill beyond min/max',
+  // fill multiple keys in one go
+  {
+    case: 'fill multiple keys when both not given',
     data: [],
     len: 2,
     min: '2023-04-26T18:00:00.000Z',
@@ -155,6 +155,74 @@ test.each([
     includes: [
       { timestamp: '2023-04-26T18:00:00.000Z', count: 0, other: 0 },
       { timestamp: '2023-04-26T19:00:00.000Z', count: 0, other: 0 },
+    ],
+  },
+
+  {
+    case: 'truncation detection should check underlying data',
+    data: [
+      {
+        timestamp: '2023-05-18T00:00:00',
+        total_auth_requests: 4,
+        total_realtime_requests: 0,
+        total_rest_requests: 0,
+        total_storage_requests: 0,
+      },
+      {
+        timestamp: '2023-05-18T03:00:00',
+        total_auth_requests: 4,
+        total_realtime_requests: 0,
+        total_rest_requests: 0,
+        total_storage_requests: 0,
+      },
+      {
+        timestamp: '2023-05-18T07:00:00',
+        total_auth_requests: 4,
+        total_realtime_requests: 0,
+        total_rest_requests: 0,
+        total_storage_requests: 0,
+      },
+      {
+        timestamp: '2023-05-18T08:00:00',
+        total_auth_requests: 2,
+        total_realtime_requests: 0,
+        total_rest_requests: 0,
+        total_storage_requests: 0,
+      },
+      {
+        timestamp: '2023-05-18T09:00:00',
+        total_auth_requests: 2,
+        total_realtime_requests: 0,
+        total_rest_requests: 0,
+        total_storage_requests: 0,
+      },
+      {
+        timestamp: '2023-05-18T13:00:00',
+        total_auth_requests: 0,
+        total_realtime_requests: 0,
+        total_rest_requests: 0,
+        total_storage_requests: 0,
+      },
+      {
+        timestamp: '2023-05-18T16:00:00',
+        total_auth_requests: 0,
+        total_realtime_requests: 0,
+        total_rest_requests: 1,
+        total_storage_requests: 0,
+      },
+    ],
+    len: 24,
+    min: '2023-05-18T00:00:00',
+    max: '2023-05-18T23:00:00',
+    valKey: ['total_auth_requests', 'total_realtime_requests', 'total_rest_requests', 'total_storage_requests'],
+    includes: [   {
+      // timestamp format is with higher precision and with tz
+      timestamp: '2023-05-18T14:00:00.000Z',
+      total_auth_requests: 0,
+      total_realtime_requests: 0,
+      total_rest_requests: 0,
+      total_storage_requests: 0,
+    },
     ],
   },
 ])(


### PR DESCRIPTION
Fixes the truncation logic to check the underlying data instead of just the first datapoint, which is especially important if the timestamp ends with 00 values, for example at midnight it would be `00:00:00` and it would assume that truncation should be daily, when it should in fact be hourly if other values are used.

The new truncation logic takes the most likely truncation based on truncation occurrence.

This PR also add back the loading state, and removes the `isLoading` prop from charts, as loading state should not be handled by the charting component.
