### PR TITLE
Chore/update customers and blog post meta

### DIFF
--- a/apps/www/_customers/epsilon3.mdx
+++ b/apps/www/_customers/epsilon3.mdx
@@ -1,7 +1,9 @@
 ---
-title: Epsilon3 digitize paper-based procedures in the space industry using telemetry data, simplifying testing and operations.
 name: Epsilon3
+title: Epsilon3 digitize paper-based procedures in the space industry using telemetry data, simplifying testing and operations.
+meta_title: Epsilon3 digitize paper-based procedures in the space industry using telemetry data, simplifying testing and operations.
 description: Epsilon3 uses Supabase to help teams execute secure and reliable operations in an industry where project spend runs into the billions.
+meta_description: Epsilon3 uses Supabase to help teams execute secure and reliable operations in an industry where project spend runs into the billions.
 author: rory_wilding
 author_title: Supabase
 author_url: https://github.com/kiwicopple

--- a/apps/www/_customers/epsilon3.mdx
+++ b/apps/www/_customers/epsilon3.mdx
@@ -1,8 +1,10 @@
 ---
 name: Epsilon3
 title: Epsilon3 digitize paper-based procedures in the space industry using telemetry data, simplifying testing and operations.
-meta_title: Epsilon3 digitize paper-based procedures in the space industry using telemetry data, simplifying testing and operations.
+# Use meta_title to add a custom meta title. Otherwise it defaults to '{name} | Supabase Customer Stories':
+# meta_title:
 description: Epsilon3 uses Supabase to help teams execute secure and reliable operations in an industry where project spend runs into the billions.
+# Use meta_description to add a custom meta description. Otherwise it defaults to {description}:
 meta_description: Epsilon3 uses Supabase to help teams execute secure and reliable operations in an industry where project spend runs into the billions.
 author: rory_wilding
 author_title: Supabase

--- a/apps/www/_customers/happyteams.mdx
+++ b/apps/www/_customers/happyteams.mdx
@@ -1,8 +1,10 @@
 ---
 name: HappyTeams
 title: HappyTeams unlocks better performance and reduces cost with Supabase.
-meta_title: HappyTeams unlocks better performance and reduces cost with Supabase.
+# Use meta_title to add a custom meta title. Otherwise it defaults to '{name} | Supabase Customer Stories':
+# meta_title:
 description: How a bootstrapped startup migrated from Heroku to Supabase in 30 minutes and never looked back.
+# Use meta_description to add a custom meta description. Otherwise it defaults to {description}:
 meta_description: How a bootstrapped startup migrated from Heroku to Supabase in 30 minutes and never looked back.
 author: rory_wilding
 author_title: Supabase

--- a/apps/www/_customers/happyteams.mdx
+++ b/apps/www/_customers/happyteams.mdx
@@ -1,7 +1,9 @@
 ---
-title: HappyTeams unlocks better performance and reduces cost with Supabase.
 name: HappyTeams
+title: HappyTeams unlocks better performance and reduces cost with Supabase.
+meta_title: HappyTeams unlocks better performance and reduces cost with Supabase.
 description: How a bootstrapped startup migrated from Heroku to Supabase in 30 minutes and never looked back.
+meta_description: How a bootstrapped startup migrated from Heroku to Supabase in 30 minutes and never looked back.
 author: rory_wilding
 author_title: Supabase
 author_url: https://github.com/kiwicopple

--- a/apps/www/_customers/mendableai.mdx
+++ b/apps/www/_customers/mendableai.mdx
@@ -1,7 +1,9 @@
 ---
-title: Mendable switches from Pinecone to Supabase for PostgreSQL vector embeddings.
 name: Mendable
+title: Mendable switches from Pinecone to Supabase for PostgreSQL vector embeddings.
+meta_title: Mendable switches from Pinecone to Supabase for PostgreSQL vector embeddings.
 description: How Mendable boosts efficiency and accuracy of chat powered search for documentation using Supabase with pgvector.
+meta_description: How Mendable boosts efficiency and accuracy of chat powered search for documentation using Supabase with pgvector.
 author: paul_copplestone
 author_title: Supabase
 author_url: https://github.com/kiwicopple

--- a/apps/www/_customers/mendableai.mdx
+++ b/apps/www/_customers/mendableai.mdx
@@ -1,8 +1,10 @@
 ---
 name: Mendable
 title: Mendable switches from Pinecone to Supabase for PostgreSQL vector embeddings.
-meta_title: Mendable switches from Pinecone to Supabase for PostgreSQL vector embeddings.
+# Use meta_title to add a custom meta title. Otherwise it defaults to '{name} | Supabase Customer Stories':
+# meta_title:
 description: How Mendable boosts efficiency and accuracy of chat powered search for documentation using Supabase with pgvector.
+# Use meta_description to add a custom meta description. Otherwise it defaults to {description}:
 meta_description: How Mendable boosts efficiency and accuracy of chat powered search for documentation using Supabase with pgvector.
 author: paul_copplestone
 author_title: Supabase

--- a/apps/www/_customers/mobbin.mdx
+++ b/apps/www/_customers/mobbin.mdx
@@ -1,8 +1,10 @@
 ---
 name: Mobbin
 title: How Mobbin migrated 200,000 users from Firebase for a better authentication experience.
-meta_title: How Mobbin migrated 200,000 users from Firebase for a better authentication experience.
+# Use meta_title to add a custom meta title. Otherwise it defaults to '{name} | Supabase Customer Stories':
+# meta_title:
 description: Mobbin helps over 200,000 creators globally search and view the latest design patterns from well-known apps.
+# Use meta_description to add a custom meta description. Otherwise it defaults to {description}:
 meta_description: Mobbin helps over 200,000 creators globally search and view the latest design patterns from well-known apps.
 author: rory_wilding
 author_title: Supabase

--- a/apps/www/_customers/mobbin.mdx
+++ b/apps/www/_customers/mobbin.mdx
@@ -1,7 +1,9 @@
 ---
-title: How Mobbin migrated 200,000 users from Firebase for a better authentication experience.
 name: Mobbin
+title: How Mobbin migrated 200,000 users from Firebase for a better authentication experience.
+meta_title: How Mobbin migrated 200,000 users from Firebase for a better authentication experience.
 description: Mobbin helps over 200,000 creators globally search and view the latest design patterns from well-known apps.
+meta_description: Mobbin helps over 200,000 creators globally search and view the latest design patterns from well-known apps.
 author: rory_wilding
 author_title: Supabase
 author_url: https://github.com/kiwicopple

--- a/apps/www/_customers/replenysh.mdx
+++ b/apps/www/_customers/replenysh.mdx
@@ -1,8 +1,10 @@
 ---
 name: Replenysh
 title: Replenysh uses Supabase to implement OTP in less than 24 hours.
-meta_title: Replenysh uses Supabase to implement OTP in less than 24 hours.
+# Use meta_title to add a custom meta title. Otherwise it defaults to '{name} | Supabase Customer Stories':
+# meta_title:
 description: With Supabase, Replenysh gets a slick auth experience, reduces DevOps overhead, and continues to scale with Postgres.
+# Use meta_description to add a custom meta description. Otherwise it defaults to {description}:
 meta_description: With Supabase, Replenysh gets a slick auth experience, reduces DevOps overhead, and continues to scale with Postgres.
 author: rory_wilding
 author_title: Supabase

--- a/apps/www/_customers/replenysh.mdx
+++ b/apps/www/_customers/replenysh.mdx
@@ -1,7 +1,9 @@
 ---
-title: Replenysh uses Supabase to implement OTP in less than 24 hours.
 name: Replenysh
+title: Replenysh uses Supabase to implement OTP in less than 24 hours.
+meta_title: Replenysh uses Supabase to implement OTP in less than 24 hours.
 description: With Supabase, Replenysh gets a slick auth experience, reduces DevOps overhead, and continues to scale with Postgres.
+meta_description: With Supabase, Replenysh gets a slick auth experience, reduces DevOps overhead, and continues to scale with Postgres.
 author: rory_wilding
 author_title: Supabase
 author_url: https://github.com/kiwicopple

--- a/apps/www/_customers/xendit.mdx
+++ b/apps/www/_customers/xendit.mdx
@@ -1,7 +1,9 @@
 ---
-title: Xendit use Supabase and create a full solution shipped to production in less than one week.
 name: Xendit
+title: Xendit use Supabase and create a full solution shipped to production in less than one week.
+meta_title: Xendit use Supabase and create a full solution shipped to production in less than one week.
 description: As a payment processor, Xendit are responsible for verifying that all transactions are legal.
+meta_description: As a payment processor, Xendit are responsible for verifying that all transactions are legal.
 author: rory_wilding
 author_title: Supabase
 author_url: https://github.com/kiwicopple
@@ -10,10 +12,10 @@ authorURL: https://github.com/kiwicopple
 logo: /images/customers/logos/xendit.png
 logo_inverse: /images/customers/logos/light/xendit.png
 og_image: /images/customers/og/xendit.jpg
-company_url: https://xendit.co
 tags:
   - supabase
 date: '2023-02-14'
+company_url: https://xendit.co
 stats:
   [
     { stat: '120', label: Staff count },

--- a/apps/www/_customers/xendit.mdx
+++ b/apps/www/_customers/xendit.mdx
@@ -1,8 +1,10 @@
 ---
 name: Xendit
 title: Xendit use Supabase and create a full solution shipped to production in less than one week.
-meta_title: Xendit use Supabase and create a full solution shipped to production in less than one week.
+# Use meta_title to add a custom meta title. Otherwise it defaults to '{name} | Supabase Customer Stories':
+# meta_title:
 description: As a payment processor, Xendit are responsible for verifying that all transactions are legal.
+# Use meta_description to add a custom meta description. Otherwise it defaults to {description}:
 meta_description: As a payment processor, Xendit are responsible for verifying that all transactions are legal.
 author: rory_wilding
 author_title: Supabase

--- a/apps/www/pages/blog/[slug].tsx
+++ b/apps/www/pages/blog/[slug].tsx
@@ -130,15 +130,21 @@ function BlogPostPage(props: any) {
     </div>
   )
 
+  const meta = {
+    title: props.blog.meta_title ?? props.blog.title,
+    description: props.blog.meat_description ?? props.blog.description,
+    url: `https://supabase.com/blog/${props.blog.slug}`,
+  }
+
   return (
     <>
       <NextSeo
-        title={props.blog.title}
-        description={props.blog.description}
+        title={meta.title}
+        description={meta.description}
         openGraph={{
-          title: props.blog.title,
-          description: props.blog.description,
-          url: `https://supabase.com/blog/${props.blog.slug}`,
+          title: meta.title,
+          description: meta.description,
+          url: meta.url,
           type: 'article',
           videos: props.blog.video && [
             {

--- a/apps/www/pages/customers/[slug].tsx
+++ b/apps/www/pages/customers/[slug].tsx
@@ -62,8 +62,9 @@ function CaseStudyPage(props: any) {
   const { basePath } = useRouter()
 
   const meta = {
-    title: `${props.blog.name} | Supabase Customer Stories`,
-    description: props.blog.description,
+    title:
+      props.blog.meta_title ?? props.blog.title ?? `${props.blog.name} | Supabase Customer Stories`,
+    description: props.blog.meta_description ?? props.blog.description,
     image: props.blog.og_image ?? `${basePath}/images/customers/og/customer-stories.jpg`,
     url: `https://supabase.io/customers/${props.blog.slug}`,
   }

--- a/apps/www/pages/customers/[slug].tsx
+++ b/apps/www/pages/customers/[slug].tsx
@@ -62,8 +62,7 @@ function CaseStudyPage(props: any) {
   const { basePath } = useRouter()
 
   const meta = {
-    title:
-      props.blog.meta_title ?? props.blog.title ?? `${props.blog.name} | Supabase Customer Stories`,
+    title: props.blog.meta_title ?? `${props.blog.name} | Supabase Customer Stories`,
     description: props.blog.meta_description ?? props.blog.description,
     image: props.blog.og_image ?? `${basePath}/images/customers/og/customer-stories.jpg`,
     url: `https://supabase.io/customers/${props.blog.slug}`,

--- a/apps/www/public/customers-rss.xml
+++ b/apps/www/public/customers-rss.xml
@@ -9,9 +9,9 @@
       <atom:link href="https://supabase.com/rss.xml" rel="self" type="application/rss+xml"/>
       <item>
   <guid>https://supabase.com/customers/mendableai</guid>
-  <title>Mendable.ai switches from Pinecone to Supabase for PostgreSQL vector embeddings.</title>
+  <title>Mendable switches from Pinecone to Supabase for PostgreSQL vector embeddings.</title>
   <link>https://supabase.com/customers/mendableai</link>
-  <description>How Mendable.ai boosts efficiency and accuracy of chat powered search for documentation using Supabase with pg_vector.</description>
+  <description>How Mendable boosts efficiency and accuracy of chat powered search for documentation using Supabase with pgvector.</description>
   <pubDate>Thu, 04 May 2023 22:10:00 +0000</pubDate>
 </item>
 <item>

--- a/apps/www/public/rss.xml
+++ b/apps/www/public/rss.xml
@@ -11,7 +11,7 @@
   <guid>https://supabase.com/blog/building-chatgpt-plugins-template</guid>
   <title>Building ChatGPT Plugins with Supabase Edge Runtime</title>
   <link>https://supabase.com/blog/building-chatgpt-plugins-template</link>
-  <description>undefined</description>
+  <description>We're releasing a ChatGPT plugin template written in TypeScript and running on Deno!</description>
   <pubDate>Sun, 14 May 2023 22:10:00 +0000</pubDate>
 </item>
 <item>
@@ -60,7 +60,7 @@
   <guid>https://supabase.com/blog/supabase-studio-2.0</guid>
   <title>Supabase Studio 2.0: help when you need it most</title>
   <link>https://supabase.com/blog/supabase-studio-2.0</link>
-  <description>undefined</description>
+  <description>Supabase Studio now comes with ChatGPT, and GraphiQL built in, Cascade Deletes, and Foreign Key Selectors, and much more.</description>
   <pubDate>Thu, 13 Apr 2023 22:10:00 +0000</pubDate>
 </item>
 <item>
@@ -74,42 +74,42 @@
   <guid>https://supabase.com/blog/pg-tle</guid>
   <title>Trusted Language Extensions for Postgres</title>
   <link>https://supabase.com/blog/pg-tle</link>
-  <description>undefined</description>
+  <description>We're collaborating with AWS to bring Trusted Language Extensions to Postgres.</description>
   <pubDate>Thu, 13 Apr 2023 22:10:00 +0000</pubDate>
 </item>
 <item>
   <guid>https://supabase.com/blog/launch-week-7-community-highlights</guid>
   <title>Launch Week 7 Community Highlights</title>
   <link>https://supabase.com/blog/launch-week-7-community-highlights</link>
-  <description>undefined</description>
+  <description>We're honored to work with, sponsor, and support incredible people and tools. Here is a highlight of the last 3 months.</description>
   <pubDate>Thu, 13 Apr 2023 22:10:00 +0000</pubDate>
 </item>
 <item>
   <guid>https://supabase.com/blog/supabase-auth-sso-pkce</guid>
   <title>Supabase Auth: SSO,  Mobile, and Server-side support</title>
   <link>https://supabase.com/blog/supabase-auth-sso-pkce</link>
-  <description>undefined</description>
+  <description>Supacharging Supabase Auth with Sign in with Apple on iOS, Single-Sign-On support with SAML 2.0, and PKCE for server-side rendering and mobile auth.</description>
   <pubDate>Wed, 12 Apr 2023 22:10:00 +0000</pubDate>
 </item>
 <item>
   <guid>https://supabase.com/blog/storage-v3-resumable-uploads</guid>
   <title>Supabase Storage v3: Resumable Uploads with support for 50GB files</title>
   <link>https://supabase.com/blog/storage-v3-resumable-uploads</link>
-  <description>undefined</description>
+  <description>Storage V3 with lots of new features including resumable uploads, more image transformationsm a Next.js image loader and more.</description>
   <pubDate>Tue, 11 Apr 2023 22:10:00 +0000</pubDate>
 </item>
 <item>
   <guid>https://supabase.com/blog/edge-runtime-self-hosted-deno-functions</guid>
   <title>Supabase Edge Runtime: Self-hosted Deno Functions</title>
   <link>https://supabase.com/blog/edge-runtime-self-hosted-deno-functions</link>
-  <description>undefined</description>
+  <description>We are open-sourcing Supabase Edge Runtime allowing you to host your Edge Functions anywhere.</description>
   <pubDate>Mon, 10 Apr 2023 22:10:00 +0000</pubDate>
 </item>
 <item>
   <guid>https://supabase.com/blog/supabase-logs-self-hosted</guid>
   <title>Supabase Logs: open source logging server</title>
   <link>https://supabase.com/blog/supabase-logs-self-hosted</link>
-  <description>undefined</description>
+  <description>We're releasing Supabase Logs for both self-hosted users and CLI development.</description>
   <pubDate>Sun, 09 Apr 2023 22:10:00 +0000</pubDate>
 </item>
 <item>


### PR DESCRIPTION
## What kind of change does this PR introduce?

New properties for customer article:
- **`meta_title`**
  - if not present, it will fall back to _`${props.blog.name} | Supabase Customer Stories`_, as before
- **`meta_description`**
  - if not present, it will fall back to _`description`_, as before

New properties for blog post:
- **`meta_title`**
  - if not present, it will fall back to _`title`_ property, as before
- **`meta_description`**
  - if not present, it fall back to _`description`_ property, as before