### PR TITLE
fix: correct the syntax for ordering query in Flutter docs

### DIFF
--- a/spec/supabase_dart_v1.yml
+++ b/spec/supabase_dart_v1.yml
@@ -1382,7 +1382,7 @@ functions:
           final data = await supabase
             .from('cities')
             .select('name, country_id')
-            .order('id',  { ascending: false });
+            .order('id', ascending: true);
           ```
       - id: with-embedded-resources
         name: With embedded resources


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixing a syntax error reported on Twitter [here](https://twitter.com/_Ideagarage/status/1659093855793184770). Corrects the order syntax for Flutter SDK. 