### PR TITLE
Fix Studio tests memory issue

### DIFF
--- a/studio/__mocks__/hooks/analytics/useFillTimeseriesSorted.ts
+++ b/studio/__mocks__/hooks/analytics/useFillTimeseriesSorted.ts
@@ -1,0 +1,2 @@
+const useFillTimeseriesSorted = jest.fn().mockReturnValue([])
+export default useFillTimeseriesSorted

--- a/studio/tests/components/Home/ProjectUsage.test.js
+++ b/studio/tests/components/Home/ProjectUsage.test.js
@@ -3,6 +3,7 @@ import { clickDropdown, render } from '../../helpers'
 import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { get } from 'lib/common/fetch'
+import useFillTimeseriesSorted from 'hooks/analytics/useFillTimeseriesSorted'
 
 // TODO: abstract out to global setup
 const ProjectUsage = jest.fn()
@@ -51,8 +52,12 @@ const MOCK_CHART_DATA = {
       total_rest_requests: 333,
       timestamp: new Date().toISOString(),
     },
-  ]
+  ],
 }
+
+// This hook is globally mocked, so you don't need to call `jest.mock` first - but the tests
+// for this component need this mock data returned
+useFillTimeseriesSorted.mockReturnValue(MOCK_CHART_DATA.result)
 
 test('mounts correctly', async () => {
   get.mockImplementation((url) => {

--- a/studio/tests/pages/projects/logs-query.test.js
+++ b/studio/tests/pages/projects/logs-query.test.js
@@ -2,7 +2,7 @@ import { get } from 'lib/common/fetch'
 import { useRouter } from 'next/router'
 import { LogsExplorerPage } from 'pages/project/[ref]/logs/explorer/index'
 import { render } from 'tests/helpers'
-import { waitFor, screen } from '@testing-library/react'
+import { waitFor, screen, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { logDataFixture } from '../../fixtures'
 import { clickDropdown } from 'tests/helpers'
@@ -131,7 +131,10 @@ test('custom sql querying', async () => {
       expect(get).toHaveBeenCalledWith(expect.stringContaining('sql='), expect.anything())
       expect(get).toHaveBeenCalledWith(expect.stringContaining('select'), expect.anything())
       expect(get).toHaveBeenCalledWith(expect.stringContaining('edge_logs'), expect.anything())
-      expect(get).toHaveBeenCalledWith(expect.stringContaining(encodeURIComponent("my_count")), expect.anything())
+      expect(get).toHaveBeenCalledWith(
+        expect.stringContaining(encodeURIComponent('my_count')),
+        expect.anything()
+      )
       expect(get).toHaveBeenCalledWith(
         expect.stringContaining('iso_timestamp_start'),
         expect.anything()
@@ -160,11 +163,11 @@ test('custom sql querying', async () => {
   await expect(screen.findByText(/Load older/)).rejects.toThrow()
 })
 
-test("bug: can edit query after selecting a log", async ()=>{
+test('bug: can edit query after selecting a log', async () => {
   get.mockImplementation((url) => {
-    if (url.includes('sql=') && url.includes('select') && !url.includes("limit 222")) {
+    if (url.includes('sql=') && url.includes('select') && !url.includes('limit 222')) {
       return {
-        result: [ { my_count: 12345 }],
+        result: [{ my_count: 12345 }],
       }
     }
     return { result: [] }
@@ -186,7 +189,10 @@ test("bug: can edit query after selecting a log", async ()=>{
 
   await waitFor(
     () => {
-      expect(get).toHaveBeenCalledWith(expect.stringContaining(encodeURIComponent("something")), expect.anything())
+      expect(get).toHaveBeenCalledWith(
+        expect.stringContaining(encodeURIComponent('something')),
+        expect.anything()
+      )
     },
     { timeout: 1000 }
   )
@@ -241,9 +247,12 @@ describe.each(['FREE', 'PRO', 'TEAM', 'ENTERPRISE'])('upgrade modal for %s', (ke
 
   test('based on datepicker helpers', async () => {
     render(<LogsExplorerPage />)
-    // click on the dropdown
-    clickDropdown(await screen.findByText('Last 24 hours'))
-    userEvent.click(await screen.findByText('Last 3 days'))
+
+    clickDropdown(screen.getByText('Last 24 hours'))
+    await waitFor(async () => {
+      const option = await screen.findByText('Last 3 days')
+      fireEvent.click(option)
+    })
 
     // only free tier will show modal
     if (key === 'FREE') {

--- a/studio/tests/pages/projects/reports/api-report.test.js
+++ b/studio/tests/pages/projects/reports/api-report.test.js
@@ -3,8 +3,12 @@ import { render } from '../../../helpers'
 import { waitFor, screen } from '@testing-library/react'
 import { ApiReport } from 'pages/project/[ref]/reports/api-overview'
 import userEvent from '@testing-library/user-event'
+import * as useFillTimeseriesSortedModule from 'hooks/analytics/useFillTimeseriesSorted'
 
 beforeEach(() => {
+  // This hook can result in a huge amount of data being loaded into memory (array of 130k+ objects)
+  jest.spyOn(useFillTimeseriesSortedModule, 'default').mockReturnValue([])
+
   // reset mocks between tests
   get.mockReset()
   get.mockImplementation(async (_url) => [{ result: [] }])
@@ -29,8 +33,12 @@ test('refresh button', async () => {
 
 test('append - api request routes', async () => {
   get.mockImplementation(async (url) => {
-    if (decodeURIComponent(url).includes("request.path")) {
-      return { result: [{ path: 'mypath', method: 'GET', status_code: 200, search: 'some-query', count: 22 }] }
+    if (decodeURIComponent(url).includes('request.path')) {
+      return {
+        result: [
+          { path: 'mypath', method: 'GET', status_code: 200, search: 'some-query', count: 22 },
+        ],
+      }
     }
     return { result: [{ timestamp: new Date().toISOString(), count: 123 }] }
   })
@@ -43,12 +51,15 @@ test('append - api request routes', async () => {
   await screen.findAllByText(/22/)
 })
 
-
 test('append - error routes', async () => {
   get.mockImplementation(async (url) => {
     const uri = decodeURIComponent(url)
-    if (uri.includes("400")) {
-      return { result: [{ path: 'mypath', method: 'GET', status_code: 200, search: 'some-query', count: 22 }] }
+    if (uri.includes('400')) {
+      return {
+        result: [
+          { path: 'mypath', method: 'GET', status_code: 200, search: 'some-query', count: 22 },
+        ],
+      }
     }
     return { result: [{ timestamp: new Date().toISOString(), count: 123 }] }
   })
@@ -61,12 +72,22 @@ test('append - error routes', async () => {
   await screen.findAllByText(/22/)
 })
 
-
 test('append - error routes', async () => {
   get.mockImplementation(async (url) => {
     const uri = decodeURIComponent(url)
-    if (uri.includes("avg") && uri.includes("request.path")) {
-      return { result: [{ path: 'mypath', method: 'GET', status_code: 200, avg: 534, search: 'some-query', count: 22 }] }
+    if (uri.includes('avg') && uri.includes('request.path')) {
+      return {
+        result: [
+          {
+            path: 'mypath',
+            method: 'GET',
+            status_code: 200,
+            avg: 534,
+            search: 'some-query',
+            count: 22,
+          },
+        ],
+      }
     }
     return { result: [{ timestamp: new Date().toISOString(), count: 123 }] }
   })
@@ -79,8 +100,6 @@ test('append - error routes', async () => {
   await screen.findAllByText(/22/)
   await screen.findAllByText(/534\.00ms/)
 })
-
-
 
 // test('expandable error routes', async () => {
 //   get.mockImplementation(async (url) => {

--- a/studio/tests/pages/projects/reports/api-report.test.js
+++ b/studio/tests/pages/projects/reports/api-report.test.js
@@ -3,12 +3,8 @@ import { render } from '../../../helpers'
 import { waitFor, screen } from '@testing-library/react'
 import { ApiReport } from 'pages/project/[ref]/reports/api-overview'
 import userEvent from '@testing-library/user-event'
-import * as useFillTimeseriesSortedModule from 'hooks/analytics/useFillTimeseriesSorted'
 
 beforeEach(() => {
-  // This hook can result in a huge amount of data being loaded into memory (array of 130k+ objects)
-  jest.spyOn(useFillTimeseriesSortedModule, 'default').mockReturnValue([])
-
   // reset mocks between tests
   get.mockReset()
   get.mockImplementation(async (_url) => [{ result: [] }])
@@ -33,12 +29,8 @@ test('refresh button', async () => {
 
 test('append - api request routes', async () => {
   get.mockImplementation(async (url) => {
-    if (decodeURIComponent(url).includes('request.path')) {
-      return {
-        result: [
-          { path: 'mypath', method: 'GET', status_code: 200, search: 'some-query', count: 22 },
-        ],
-      }
+    if (decodeURIComponent(url).includes("request.path")) {
+      return { result: [{ path: 'mypath', method: 'GET', status_code: 200, search: 'some-query', count: 22 }] }
     }
     return { result: [{ timestamp: new Date().toISOString(), count: 123 }] }
   })
@@ -51,15 +43,12 @@ test('append - api request routes', async () => {
   await screen.findAllByText(/22/)
 })
 
+
 test('append - error routes', async () => {
   get.mockImplementation(async (url) => {
     const uri = decodeURIComponent(url)
-    if (uri.includes('400')) {
-      return {
-        result: [
-          { path: 'mypath', method: 'GET', status_code: 200, search: 'some-query', count: 22 },
-        ],
-      }
+    if (uri.includes("400")) {
+      return { result: [{ path: 'mypath', method: 'GET', status_code: 200, search: 'some-query', count: 22 }] }
     }
     return { result: [{ timestamp: new Date().toISOString(), count: 123 }] }
   })
@@ -72,22 +61,12 @@ test('append - error routes', async () => {
   await screen.findAllByText(/22/)
 })
 
+
 test('append - error routes', async () => {
   get.mockImplementation(async (url) => {
     const uri = decodeURIComponent(url)
-    if (uri.includes('avg') && uri.includes('request.path')) {
-      return {
-        result: [
-          {
-            path: 'mypath',
-            method: 'GET',
-            status_code: 200,
-            avg: 534,
-            search: 'some-query',
-            count: 22,
-          },
-        ],
-      }
+    if (uri.includes("avg") && uri.includes("request.path")) {
+      return { result: [{ path: 'mypath', method: 'GET', status_code: 200, avg: 534, search: 'some-query', count: 22 }] }
     }
     return { result: [{ timestamp: new Date().toISOString(), count: 123 }] }
   })
@@ -100,6 +79,8 @@ test('append - error routes', async () => {
   await screen.findAllByText(/22/)
   await screen.findAllByText(/534\.00ms/)
 })
+
+
 
 // test('expandable error routes', async () => {
 //   get.mockImplementation(async (url) => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

fixes #14463 - Tests were intermittently failing in Github Actions due to heap limits  

## What is the current behavior?

Using the `--expose-gc` node flag and `--logHeapUsage` jest flag, we noticed the `api-report.test.js` suite was the largest offender, allocating ~2GB of memory, compared to ~1GB for the other suites.

Using the Chrome Inspector & breakpoints, and capping the heap to 768 MB locally, I had a run that paused on the `BarChart` component before an OOM exception when it was mapping over `data`. Upon further inspection, this `data` array was huge - over 130k objects:

<details>
<summary>Console log of BarChart.props.data</summary>

```tsx
studio:test:   console.log
studio:test:     data [
studio:test:       { timestamp: '2023-05-18T04:00:00.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:01.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:02.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:03.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:04.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:05.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:06.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:07.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:08.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:09.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:10.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:11.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:12.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:13.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:14.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:15.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:16.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:17.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:18.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:19.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:20.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:21.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:22.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:23.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:24.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:25.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:26.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:27.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:28.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:29.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:30.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:31.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:32.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:33.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:34.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:35.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:36.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:37.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:38.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:39.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:40.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:41.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:42.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:43.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:44.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:45.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:46.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:47.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:48.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:49.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:50.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:51.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:52.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:53.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:54.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:55.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:56.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:57.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:58.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:00:59.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:01:00.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:01:01.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:01:02.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:01:03.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:01:04.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:01:05.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:01:06.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:01:07.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:01:08.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:01:09.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:01:10.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:01:11.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:01:12.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:01:13.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:01:14.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:01:15.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:01:16.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:01:17.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:01:18.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:01:19.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:01:20.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:01:21.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:01:22.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:01:23.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:01:24.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:01:25.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:01:26.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:01:27.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:01:28.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:01:29.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:01:30.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:01:31.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:01:32.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:01:33.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:01:34.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:01:35.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:01:36.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:01:37.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:01:38.000Z', avg: 0 },
studio:test:       { timestamp: '2023-05-18T04:01:39.000Z', avg: 0 },
studio:test:       ... 134435 more items
studio:test:     ]
studio:test: 
studio:test:       at BarChart (components/ui/Charts/BarChart.tsx:37:11)
```
</details>

I don't think this data is necessary for this test, so I mocked out the return value of the hook, which greatly reduces memory usage (and time, for that matter)

```tsx
studio:test: PASS tests/pages/projects/reports/api-report.test.js (23.371 s, 1814 MB heap size)
studio:test:   ✓ static elements (336 ms)
studio:test:   ✓ refresh button (414 ms)
studio:test:   ✓ append - api request routes (3031 ms)
studio:test:   ✓ append - error routes (2007 ms)
studio:test:   ✓ append - error routes (2903 ms)
```


## What is the new behavior?

```
studio:test: PASS tests/pages/projects/reports/api-report.test.js (11.925 s, 588 MB heap size)
studio:test:   ✓ static elements (303 ms)
studio:test:   ✓ refresh button (211 ms)
studio:test:   ✓ append - api request routes (165 ms)
studio:test:   ✓ append - error routes (176 ms)
studio:test:   ✓ append - error routes (123 ms)
```

## Additional context

Additionally, the `logs-query.test.js` suite was always failing for me locally, so I updated the assertions in there to be more resilient using `waitFor`.
