### PR TITLE
Add section in project settings menu for compute and pitr add-ons

### DIFF
--- a/studio/components/interfaces/Billing/AddOns/ComputeSizeSelection.tsx
+++ b/studio/components/interfaces/Billing/AddOns/ComputeSizeSelection.tsx
@@ -1,6 +1,5 @@
 import Link from 'next/link'
-import { FC, useEffect } from 'react'
-import { useRouter } from 'next/router'
+import { FC } from 'react'
 import { Badge, Button, IconExternalLink, Radio } from 'ui'
 
 import { useFlag } from 'hooks'
@@ -23,14 +22,6 @@ const ComputeSizeSelection: FC<Props> = ({
   onSelectOption,
 }) => {
   const { ref } = useParams()
-  const { asPath } = useRouter()
-  useEffect(() => {
-    const hash = asPath.split('#')[1]
-    if (hash !== undefined) {
-      window.location.hash = ''
-      window.location.hash = hash
-    }
-  }, [asPath])
   const addonUpdateDisabled = useFlag('disableProjectCreationAndUpdate')
   return (
     <div className="space-y-4">

--- a/studio/components/interfaces/Billing/AddOns/CustomDomainSelection.tsx
+++ b/studio/components/interfaces/Billing/AddOns/CustomDomainSelection.tsx
@@ -1,6 +1,5 @@
 import Link from 'next/link'
-import { FC, useEffect } from 'react'
-import { useRouter } from 'next/router'
+import { FC } from 'react'
 import { Badge, Button, Radio } from 'ui'
 
 import { useFlag } from 'hooks'
@@ -24,14 +23,6 @@ const CustomDomainSelection: FC<Props> = ({
 }) => {
   const { ref } = useParams()
   const addonUpdateDisabled = useFlag('disableProjectCreationAndUpdate')
-  const { asPath } = useRouter()
-  useEffect(() => {
-    const hash = asPath.split('#')[1]
-    if (hash !== undefined) {
-      window.location.hash = ''
-      window.location.hash = hash
-    }
-  }, [asPath])
   return (
     <div className="space-y-4">
       <div>

--- a/studio/components/interfaces/Billing/AddOns/PITRDurationSelection.tsx
+++ b/studio/components/interfaces/Billing/AddOns/PITRDurationSelection.tsx
@@ -1,6 +1,5 @@
 import Link from 'next/link'
-import { FC, useEffect } from 'react'
-import { useRouter } from 'next/router'
+import { FC } from 'react'
 import { Badge, IconAlertCircle, Radio, Button } from 'ui'
 
 import { useFlag, useStore } from 'hooks'
@@ -33,14 +32,6 @@ const PITRDurationSelection: FC<Props> = ({
   // Only projects of version greater than supabase-postgrest-14.1.0.44 can use PITR
   const sufficientPgVersion = getSemanticVersion(ui.selectedProject?.dbVersion ?? '') >= 141044
   const isDisabledForRegion = ['ap-northeast-2'].includes(projectRegion)
-  const { asPath } = useRouter()
-  useEffect(() => {
-    const hash = asPath.split('#')[1]
-    if (hash !== undefined) {
-      window.location.hash = ''
-      window.location.hash = hash
-    }
-  }, [asPath])
   return (
     <div className="space-y-4">
       <div>

--- a/studio/components/interfaces/Billing/AddOns/SupportPlan.tsx
+++ b/studio/components/interfaces/Billing/AddOns/SupportPlan.tsx
@@ -1,6 +1,5 @@
 import Link from 'next/link'
-import { FC, useEffect } from 'react'
-import { useRouter } from 'next/router'
+import { FC } from 'react'
 import { Button } from 'ui'
 import { useParams } from 'common/hooks'
 
@@ -10,14 +9,6 @@ interface Props {
 
 const SupportPlan: FC<Props> = ({ currentOption }) => {
   const { ref } = useParams()
-  const { asPath } = useRouter()
-  useEffect(() => {
-    const hash = asPath.split('#')[1]
-    if (hash !== undefined) {
-      window.location.hash = ''
-      window.location.hash = hash
-    }
-  }, [asPath])
   return (
     <div className="space-y-4">
       <div>

--- a/studio/components/interfaces/Billing/ProUpgrade.tsx
+++ b/studio/components/interfaces/Billing/ProUpgrade.tsx
@@ -138,7 +138,7 @@ const ProUpgrade: FC<Props> = ({
     if (router.isReady) {
       const hash = router.asPath.split('#')[1]
       if (hash !== undefined) {
-        router.replace({ hash }, null, { shallow: true })
+        router.replace({ hash })
       }
     }
   }, [router.asPath])

--- a/studio/components/interfaces/Billing/ProUpgrade.tsx
+++ b/studio/components/interfaces/Billing/ProUpgrade.tsx
@@ -133,6 +133,16 @@ const ProUpgrade: FC<Props> = ({
     getSubscriptionPreview()
   }, [selectedComputeSize, selectedPITRDuration, selectedCustomDomainOption, isSpendCapEnabled])
 
+  // this is used to navigate to addon hash anchors on first load, allows us to directly link subscription addons
+  useEffect(() => {
+    if (router.isReady) {
+      const hash = router.asPath.split('#')[1]
+      if (hash !== undefined) {
+        router.replace({ hash }, null, { shallow: true })
+      }
+    }
+  }, [router.asPath])
+
   const getSubscriptionPreview = async () => {
     if (!selectedTier) return
 

--- a/studio/components/layouts/SettingsLayout/SettingsMenu.utils.ts
+++ b/studio/components/layouts/SettingsLayout/SettingsMenu.utils.ts
@@ -68,20 +68,41 @@ export const generateSettingsMenu = (
     ...(IS_PLATFORM
       ? [
           {
+            title: 'Addons',
+            items: [
+              {
+                name: 'Compute',
+                key: 'compute-addon',
+                url: isProjectBuilding
+                  ? buildingUrl
+                  : `/project/${ref}/settings/billing/update/pro#compute-addon`,
+                items: [],
+              },
+              {
+                name: 'PITR',
+                key: 'pitr-addon',
+                url: isProjectBuilding
+                  ? buildingUrl
+                  : `/project/${ref}/settings/billing/update/pro#pitr-addon`,
+                items: [],
+              },
+            ],
+          },
+          {
             title: 'Billing',
             items: [
+              {
+                name: 'Usage',
+                key: 'usage',
+                url: isProjectBuilding ? buildingUrl : `/project/${ref}/settings/billing/usage`,
+                items: [],
+              },
               {
                 name: 'Subscription',
                 key: 'subscription',
                 url: isProjectBuilding
                   ? buildingUrl
                   : `/project/${ref}/settings/billing/subscription`,
-                items: [],
-              },
-              {
-                name: 'Usage',
-                key: 'usage',
-                url: isProjectBuilding ? buildingUrl : `/project/${ref}/settings/billing/usage`,
                 items: [],
               },
               {


### PR DESCRIPTION
Many users have trouble finding the add-on sections. In fact, you need 6 clicks before you can see that there are add-ons available to every Pro project.

With https://github.com/supabase/supabase/pull/14392 we can link to these options directly. We can make them more visible by including them in the settings menu.

<img width="641" alt="Screenshot 2023-05-22 at 2 08 05 PM" src="https://github.com/supabase/supabase/assets/1732217/60b8c7b8-55a8-4031-b491-87a8064f97f4">
