### PR TITLE
docs: update flutter sdk repo links to the new monorepo

### DIFF
--- a/apps/docs/pages/guides/api/rest/client-libs.mdx
+++ b/apps/docs/pages/guides/api/rest/client-libs.mdx
@@ -11,9 +11,9 @@ Supabase provides client libraries for the REST and Realtime APIs. Some librarie
 
 ## Official Libraries
 
-| `Language`            | `Source Code`                                              | `Documentation`                                                     |
-| --------------------- | ---------------------------------------------------------- | ------------------------------------------------------------------- |
-| Javascript/Typescript | [supabase-js](https://github.com/supabase/supabase-js)     | [Docs](https://supabase.com/docs/reference/javascript/introduction) |
+| `Language`            | `Source Code`                                                                                        | `Documentation`                                                     |
+| --------------------- | ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| Javascript/Typescript | [supabase-js](https://github.com/supabase/supabase-js)                                               | [Docs](https://supabase.com/docs/reference/javascript/introduction) |
 | Dart/Flutter          | [supabase-flutter](https://github.com/supabase/supabase-flutter/tree/main/packages/supabase_flutter) | [Docs](https://supabase.com/docs/reference/dart/introduction)       |
 
 ## Community Libraries

--- a/apps/docs/pages/guides/api/rest/client-libs.mdx
+++ b/apps/docs/pages/guides/api/rest/client-libs.mdx
@@ -14,7 +14,7 @@ Supabase provides client libraries for the REST and Realtime APIs. Some librarie
 | `Language`            | `Source Code`                                              | `Documentation`                                                     |
 | --------------------- | ---------------------------------------------------------- | ------------------------------------------------------------------- |
 | Javascript/Typescript | [supabase-js](https://github.com/supabase/supabase-js)     | [Docs](https://supabase.com/docs/reference/javascript/introduction) |
-| Dart/Flutter          | [supabase-dart](https://github.com/supabase/supabase-dart) | [Docs](https://supabase.com/docs/reference/dart/introduction)       |
+| Dart/Flutter          | [supabase-flutter](https://github.com/supabase/supabase-flutter/tree/main/packages/supabase_flutter) | [Docs](https://supabase.com/docs/reference/dart/introduction)       |
 
 ## Community Libraries
 

--- a/apps/www/_blog/2021-07-26-supabase-community-day.mdx
+++ b/apps/www/_blog/2021-07-26-supabase-community-day.mdx
@@ -105,14 +105,14 @@ Today the Community are releasing both the Flutter and Dart libraries in Beta (w
 
 - Check out the [Flutter Quickstart Guide](/docs/guides/with-flutter)
 - Check out the code:
-  - Supabase Flutter: [GitHub](https://github.com/supabase/supabase-flutter/) | [Release](https://pub.dev/packages/supabase_flutter)
-  - Supabase Dart: [GitHub](https://github.com/supabase/supabase-dart/) | [Release](https://pub.dev/packages/supabase)
+  - Supabase Flutter: [GitHub](https://github.com/supabase/supabase-flutter/tree/main/packages/supabase_flutter) | [Release](https://pub.dev/packages/supabase_flutter)
+  - Supabase Dart: [GitHub](https://github.com/supabase/supabase-flutter/tree/main/packages/supabase) | [Release](https://pub.dev/packages/supabase)
 
 ### Get involved
 
 - Help [write](/supasquad#author) the Flutter Docs.
-- Help [maintain](/supasquad#maintainer) the [Flutter](https://github.com/supabase/supabase-flutter/)
-  and [Dart](https://github.com/supabase/supabase-dart/) libraries.
+- Help [maintain](/supasquad#maintainer) the [Flutter](https://github.com/supabase/supabase-flutter/tree/main/packages/supabase_flutter)
+  and [Dart](https://github.com/supabase/supabase-flutter/tree/main/packages/supabase) libraries.
 
 ## Supabase Discord
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

All of the supabase-flutter library and its sub-libraries were merged into a [supabase-flutter monorepo](https://github.com/supabase/supabase-flutter). This PR updates the links to point to the new monorepo. 