### PR TITLE
fix: display triggers in the `net` schema if they're not webhooks; hide triggers in webhooks if they don't have at least an URL and method specified

### DIFF
--- a/studio/components/interfaces/Database/Hooks/HooksList/HookList.tsx
+++ b/studio/components/interfaces/Database/Hooks/HooksList/HookList.tsx
@@ -38,7 +38,7 @@ const HookList: FC<Props> = ({
   const restUrlTld = new URL(restUrl as string).hostname.split('.').pop()
 
   const filteredHooks = (hooks ?? []).filter(
-    (x: any) => includes(x.name.toLowerCase(), filterString.toLowerCase()) && x.schema === schema
+    (x: any) => includes(x.name.toLowerCase(), filterString.toLowerCase()) && x.schema === schema && x.function_args.length >= 2
   )
   const canUpdateWebhook = checkPermissions(PermissionAction.TENANT_SQL_ADMIN_WRITE, 'triggers')
 

--- a/studio/data/database-triggers/database-triggers-query.ts
+++ b/studio/data/database-triggers/database-triggers-query.ts
@@ -45,7 +45,7 @@ export const useDatabaseHooks = <TData = DatabaseTriggersData>(
       // @ts-ignore
       select(data) {
         return (data as PostgresTrigger[]).filter(
-          (trigger) => trigger.function_schema === 'supabase_functions' && trigger.schema !== 'net'
+          (trigger) => trigger.function_schema === 'supabase_functions' && (trigger.schema !== 'net' || trigger.function_args.length === 0)
         )
       },
       enabled:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
