### PR TITLE
Update remix.mdx

### DIFF
--- a/apps/docs/pages/guides/auth/auth-helpers/remix.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/remix.mdx
@@ -441,7 +441,7 @@ useEffect(() => {
   return () => {
     subscription.unsubscribe()
   }
-}, [serverAccessToken, supabase, fetcher])
+}, [serverAccessToken, supabase, revalidate])
 ```
 
 </TabPanel>
@@ -471,7 +471,7 @@ useEffect(() => {
   return () => {
     subscription.unsubscribe()
   }
-}, [serverAccessToken, supabase, fetcher])
+}, [serverAccessToken, supabase, revalidate])
 ```
 
 </TabPanel>


### PR DESCRIPTION
`fetcher` doesn't exist anymore and we should replace the dependency array of useEffect with the new `revalidate`

## What kind of change does this PR introduce?

docs update

