### PR TITLE
chore: allow more memory consumption on tests

### DIFF
--- a/.github/workflows/studio-tests.yml
+++ b/.github/workflows/studio-tests.yml
@@ -34,5 +34,8 @@ jobs:
         run: npm ci
         working-directory: ./
       - name: Run tests
+        env:
+          # Default is 2 GB, increase to have less frequent OOM errors
+          NODE_OPTIONS: "--max_old_space_size=3072"
         run: npm run test:studio
         working-directory: ./


### PR DESCRIPTION
We regularly run into OOM errors. By default, Node will crash when hitting 2 GB. While the long-term fix is decreasing actual memory usage, a short term relief is increasing max-old-space-size, so avoid such frequent OOM errors.