### PR TITLE
Fix/functions metrics truncation

### DIFF
--- a/studio/components/interfaces/Reports/ReportWidget.tsx
+++ b/studio/components/interfaces/Reports/ReportWidget.tsx
@@ -1,10 +1,9 @@
 import { NextRouter, useRouter } from 'next/router'
 import * as Tooltip from '@radix-ui/react-tooltip'
-import { Button, IconExternalLink, IconHelpCircle } from 'ui'
+import { Button, IconExternalLink, IconHelpCircle, Loading } from 'ui'
 import { BaseReportParams } from './Reports.types'
 import { LogsEndpointParams } from '../Settings/Logs'
 import Panel from 'components/ui/Panel'
-import LoadingOpacity from 'components/ui/LoadingOpacity'
 
 export interface ReportWidgetProps<T = any> {
   data: T[]
@@ -102,9 +101,9 @@ const ReportWidget: React.FC<ReportWidgetProps> = (props) => {
           )}
         </div>
 
-        <LoadingOpacity className="w-full" active={props.isLoading}>
+        <Loading active={props.isLoading}>
           {props.data === undefined ? null : props.renderer({ ...props, router, projectRef })}
-        </LoadingOpacity>
+        </Loading>
 
         {props.append &&
           props.append({ ...props, ...(props.appendProps || {}), router, projectRef })}

--- a/studio/components/ui/Charts/AreaChart.tsx
+++ b/studio/components/ui/Charts/AreaChart.tsx
@@ -47,7 +47,7 @@ const AreaChart: React.FC<AreaChartProps> = ({
   const resolvedHighlightedLabel =
     (focusDataIndex !== null &&
       data &&
-      data[focusDataIndex] &&
+      data[focusDataIndex] !== undefined &&
       day(data[focusDataIndex][xAxisKey]).format(customDateFormat)) ||
     highlightedLabel
 

--- a/studio/components/ui/Charts/AreaChart.tsx
+++ b/studio/components/ui/Charts/AreaChart.tsx
@@ -52,7 +52,7 @@ const AreaChart: React.FC<AreaChartProps> = ({
     highlightedLabel
 
   const resolvedHighlightedValue =
-    (focusDataIndex !== null ? data[focusDataIndex]?.[yAxisKey] : null) || highlightedValue
+    focusDataIndex !== null ? data[focusDataIndex]?.[yAxisKey] : highlightedValue
 
   return (
     <div className={['flex flex-col gap-3', className].join(' ')}>

--- a/studio/pages/project/[ref]/functions/[functionSlug]/index.tsx
+++ b/studio/pages/project/[ref]/functions/[functionSlug]/index.tsx
@@ -1,4 +1,4 @@
-import dayjs from 'dayjs'
+import dayjs, { Dayjs } from 'dayjs'
 import { useMemo, useState } from 'react'
 import { useRouter } from 'next/router'
 import { Button } from 'ui'
@@ -27,10 +27,10 @@ const CHART_INTERVALS: ChartIntervals[] = [
     startUnit: 'minute',
     format: 'MMM D, h:mm:ssa',
   },
-  { key: '15min', label: '15 min', startValue: 15, startUnit: 'minute' },
-  { key: '1hr', label: '1 hour', startValue: 1, startUnit: 'hour' },
-  { key: '1day', label: '1 day', startValue: 1, startUnit: 'day' },
-  { key: '7day', label: '7 days', startValue: 7, startUnit: 'day' },
+  { key: '15min', label: '15 min', startValue: 15, startUnit: 'minute', format: 'MMM D, h:mma' },
+  { key: '1hr', label: '1 hour', startValue: 1, startUnit: 'hour', format: 'MMM D, h:mma' },
+  { key: '1day', label: '1 day', startValue: 1, startUnit: 'hour', format: 'MMM D, h:mma' },
+  { key: '7day', label: '7 days', startValue: 7, startUnit: 'day', format: 'MMM D' },
 ]
 
 const PageLayout: NextPageWithLayout = () => {
@@ -54,18 +54,24 @@ const PageLayout: NextPageWithLayout = () => {
     }))
   }, [data?.result])
 
-  const startDate = dayjs().subtract(
-    selectedInterval.startValue,
-    selectedInterval.startUnit as dayjs.ManipulateType
-  )
+  console.log(data)
 
+  const [startDate, endDate]: [Dayjs, Dayjs] = useMemo(() => {
+    const start = dayjs()
+      .subtract(selectedInterval.startValue, selectedInterval.startUnit as dayjs.ManipulateType)
+      .startOf(selectedInterval.startUnit as dayjs.ManipulateType)
+
+    const end = dayjs().startOf(selectedInterval.startUnit as dayjs.ManipulateType)
+    return [start, end]
+  }, [selectedInterval])
+  console.log(startDate.toISOString(), endDate.toISOString())
   const chartData = useFillTimeseriesSorted(
     normalizedData,
     'timestamp',
     ['avg_execution_time', 'count'],
     0,
     startDate.toISOString(),
-    dayjs().toISOString()
+    endDate.toISOString()
   )
 
   const canReadFunction = checkPermissions(PermissionAction.FUNCTIONS_READ, functionSlug as string)
@@ -111,17 +117,24 @@ const PageLayout: NextPageWithLayout = () => {
             tooltip="Average execution time of function invocations"
             data={chartData}
             isLoading={isChartLoading}
-            renderer={(props) => (
-              <AreaChart
-                className="w-full"
-                xAxisKey="timestamp"
-                customDateFormat={selectedInterval.format}
-                yAxisKey="avg_execution_time"
-                data={props.data}
-                format="ms"
-                highlightedValue={meanBy(props.data, 'avg_execution_time')}
-              />
-            )}
+            renderer={(props) => {
+              const latest = normalizedData[normalizedData.length - 1]
+              let highlightedValue
+              if (latest) {
+                highlightedValue = latest['avg_execution_time']
+              }
+              return (
+                <AreaChart
+                  className="w-full"
+                  xAxisKey="timestamp"
+                  customDateFormat={selectedInterval.format}
+                  yAxisKey="avg_execution_time"
+                  data={props.data}
+                  format="ms"
+                  highlightedValue={highlightedValue}
+                />
+              )
+            }}
           />
           <ReportWidget
             title="Invocations"

--- a/studio/pages/project/[ref]/functions/[functionSlug]/index.tsx
+++ b/studio/pages/project/[ref]/functions/[functionSlug]/index.tsx
@@ -64,7 +64,6 @@ const PageLayout: NextPageWithLayout = () => {
     const end = dayjs().startOf(selectedInterval.startUnit as dayjs.ManipulateType)
     return [start, end]
   }, [selectedInterval])
-  console.log(startDate.toISOString(), endDate.toISOString())
   const chartData = useFillTimeseriesSorted(
     normalizedData,
     'timestamp',

--- a/studio/pages/project/[ref]/functions/[functionSlug]/index.tsx
+++ b/studio/pages/project/[ref]/functions/[functionSlug]/index.tsx
@@ -54,7 +54,6 @@ const PageLayout: NextPageWithLayout = () => {
     }))
   }, [data?.result])
 
-  console.log(data)
 
   const [startDate, endDate]: [Dayjs, Dayjs] = useMemo(() => {
     const start = dayjs()


### PR DESCRIPTION
fix for functions metrics charts which has broken truncation logic, due to lack of rounding of the start/end datetimes used for generating filled in timeseries data.

This PR also:
- fixes a bug relating to hovering of area chart values
- fixes loading state of report widget, to make it much more obvious that it is loading.


https://github.com/supabase/supabase/assets/22714384/99a30bb7-94df-4fdd-b2d0-258ec23ec28e

