### PR TITLE
Fix 14130 reduce rls warning clutter

### DIFF
--- a/studio/components/interfaces/TableGridEditor/GridHeaderActions.tsx
+++ b/studio/components/interfaces/TableGridEditor/GridHeaderActions.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react'
 import Link from 'next/link'
-import { Button, IconAlertCircle, IconCode, IconLock } from 'ui'
+import { Button, IconCode, IconLock } from 'ui'
 import * as Tooltip from '@radix-ui/react-tooltip'
 import type { PostgresPolicy, PostgresTable } from '@supabase/postgres-meta'
 
@@ -73,26 +73,17 @@ const GridHeaderActions: FC<Props> = ({
         </Tooltip.Root>
       )}
 
-      <Link href={`/project/${projectRef}/auth/policies?search=${table.id}`}>
+      {table.rls_enabled && <Link href={`/project/${projectRef}/auth/policies?search=${table.id}`}>
         <a>
           <Button
-            type={table.rls_enabled ? 'link' : 'warning'}
-            icon={
-              table.rls_enabled ? (
-                <IconLock strokeWidth={2} size={14} />
-              ) : (
-                <IconAlertCircle strokeWidth={2} size={14} />
-              )
-            }
+            type="link"
+            icon={<IconLock strokeWidth={2} size={14} />}
           >
-            {!table.rls_enabled
-              ? 'RLS is not enabled'
-              : `${policies.length == 0 ? 'No' : policies.length} active RLS polic${
-                  policies.length > 1 || policies.length == 0 ? 'ies' : 'y'
-                }`}
+            {`${policies.length == 0 ? 'No' : policies.length} active RLS polic${policies.length > 1 || policies.length == 0 ? 'ies' : 'y'
+              }`}
           </Button>
         </a>
-      </Link>
+      </Link>}
       <div className="mt-[1px]">
         <RenderAPIPreviewToggle />
       </div>

--- a/studio/components/interfaces/TableGridEditor/GridHeaderActions.tsx
+++ b/studio/components/interfaces/TableGridEditor/GridHeaderActions.tsx
@@ -73,26 +73,17 @@ const GridHeaderActions: FC<Props> = ({
         </Tooltip.Root>
       )}
 
-      <Link href={`/project/${projectRef}/auth/policies?search=${table.id}`}>
+      {table.rls_enabled && <Link href={`/project/${projectRef}/auth/policies?search=${table.id}`}>
         <a>
           <Button
-            type={table.rls_enabled ? 'link' : 'warning'}
-            icon={
-              table.rls_enabled ? (
-                <IconLock strokeWidth={2} size={14} />
-              ) : (
-                <IconAlertCircle strokeWidth={2} size={14} />
-              )
-            }
+            type="link"
+            icon={<IconLock strokeWidth={2} size={14} />}
           >
-            {!table.rls_enabled
-              ? 'RLS is not enabled'
-              : `${policies.length == 0 ? 'No' : policies.length} active RLS polic${
-                  policies.length > 1 || policies.length == 0 ? 'ies' : 'y'
-                }`}
+            {`${policies.length == 0 ? 'No' : policies.length} active RLS polic${policies.length > 1 || policies.length == 0 ? 'ies' : 'y'
+              }`}
           </Button>
         </a>
-      </Link>
+      </Link>}
       <div className="mt-[1px]">
         <RenderAPIPreviewToggle />
       </div>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix
https://github.com/supabase/supabase/issues/14130


## What is the current behavior?

In the Table Editor, if you have RLS disabled, you'll see both of these warnings — a badge and a banner:
In this case, the banner is sufficient. To reduce clutter there, we shouldn't show the badge.

## What is the new behavior?
To reduce clutter there, I hide the badge.

