### PR TITLE
Add missing client lib doc links to guide

### DIFF
--- a/apps/docs/pages/guides/api/rest/client-libs.mdx
+++ b/apps/docs/pages/guides/api/rest/client-libs.mdx
@@ -19,13 +19,13 @@ Supabase provides client libraries for the REST and Realtime APIs. Some librarie
 ## Community Libraries
 
 | `Language`              | `Source Code`                                                                    | `Documentation`                                                 |
-| ----------------------- | -------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+|-------------------------|----------------------------------------------------------------------------------|-----------------------------------------------------------------|
 | C#                      | [supabase-csharp](https://github.com/supabase-community/supabase-csharp)         | [Docs](https://supabase.com/docs/reference/csharp/introduction) |
 | Go                      | [supabase-go](https://github.com/supabase-community/supabase-go)                 |                                                                 |
-| Kotlin                  | [supabase-kt](https://github.com/supabase-community/supabase-kt)                 |                                                                 |
+| Kotlin                  | [supabase-kt](https://github.com/supabase-community/supabase-kt)                 | [Docs](https://supabase.com/docs/reference/kotlin/introduction) |
 | Python                  | [supabase-py](https://github.com/supabase-community/supabase-py)                 | [Docs](https://supabase.com/docs/reference/python/initializing) |
 | Ruby                    | [supabase-rb](https://github.com/supabase-community/supabase-rb)                 |                                                                 |
-| Swift                   | [supabase-swift](https://github.com/supabase-community/supabase-swift)           |                                                                 |
+| Swift                   | [supabase-swift](https://github.com/supabase-community/supabase-swift)           | [Docs](https://supabase.com/docs/reference/swift/introduction)  |
 | Godot Engine (GDScript) | [supabase-gdscript](https://github.com/supabase-community/godot-engine.supabase) |                                                                 |
 
 export const Page = ({ children }) => <Layout meta={meta} children={children} />

--- a/apps/docs/pages/guides/api/rest/client-libs.mdx
+++ b/apps/docs/pages/guides/api/rest/client-libs.mdx
@@ -19,7 +19,7 @@ Supabase provides client libraries for the REST and Realtime APIs. Some librarie
 ## Community Libraries
 
 | `Language`              | `Source Code`                                                                    | `Documentation`                                                 |
-|-------------------------|----------------------------------------------------------------------------------|-----------------------------------------------------------------|
+| ----------------------- | -------------------------------------------------------------------------------- | --------------------------------------------------------------- |
 | C#                      | [supabase-csharp](https://github.com/supabase-community/supabase-csharp)         | [Docs](https://supabase.com/docs/reference/csharp/introduction) |
 | Go                      | [supabase-go](https://github.com/supabase-community/supabase-go)                 |                                                                 |
 | Kotlin                  | [supabase-kt](https://github.com/supabase-community/supabase-kt)                 | [Docs](https://supabase.com/docs/reference/kotlin/introduction) |


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

Documentation link for Swift & Kotlin missing in https://supabase.com/docs/guides/api/rest/client-libs

![image](https://github.com/supabase/supabase/assets/26686035/cf4a1a32-084a-4748-ac20-38ddafd7d8cb)


## What is the new behavior?

Missing links added
