### PR TITLE
chore: reenable PITR for apne2 (Seoul)

### DIFF
--- a/studio/components/interfaces/Billing/AddOns/PITRDurationSelection.tsx
+++ b/studio/components/interfaces/Billing/AddOns/PITRDurationSelection.tsx
@@ -28,11 +28,8 @@ const PITRDurationSelection: FC<Props> = ({
   const { ref } = useParams()
   const addonUpdateDisabled = useFlag('disableProjectCreationAndUpdate')
 
-  const projectRegion = ui.selectedProject?.region ?? ''
-
   // Only projects of version greater than supabase-postgrest-14.1.0.44 can use PITR
   const sufficientPgVersion = getSemanticVersion(ui.selectedProject?.dbVersion ?? '') >= 141044
-  const isDisabledForRegion = ['ap-northeast-2'].includes(projectRegion)
   const { asPath } = useRouter()
   useEffect(() => {
     const hash = asPath.split('#')[1]
@@ -55,7 +52,7 @@ const PITRDurationSelection: FC<Props> = ({
         <p className="text-sm text-scale-1100">
           Restore your database from a specific point in time
         </p>
-        {sufficientPgVersion && !isDisabledForRegion && !currentPitrDuration?.isLocked && (
+        {sufficientPgVersion && !currentPitrDuration?.isLocked && (
           <div className="mt-2">
             <InformationBox
               icon={<IconAlertCircle strokeWidth={2} />}
@@ -109,27 +106,6 @@ const PITRDurationSelection: FC<Props> = ({
             </Link>
           </div>
         </div>
-      ) : isDisabledForRegion ? (
-        <InformationBox
-          hideCollapse
-          defaultVisibility
-          title={`PITR is not available for your project's region (${projectRegion})`}
-          description={
-            <div className="flex items-center justify-between m-1">
-              <p className="text-sm leading-normal">
-                Reach out to us if you're interested! We'll see what we can do for you.
-              </p>
-              <Link
-                href={`/support/new?ref=${ref}&category=sales&subject=Enquiry%20on%20PITR%20for%20project%20in%20${projectRegion}`}
-              >
-                <a>
-                  <Button type="default">Contact support</Button>
-                </a>
-              </Link>
-            </div>
-          }
-          icon={<IconAlertCircle strokeWidth={2} />}
-        />
       ) : (
         <Radio.Group type="cards" className="billing-compute-radio">
           {pitrDurationOptions.map((option: any) => {


### PR DESCRIPTION
* Allows PITR to be accessible for projects situated in the ap-northeast-2 region (Seoul).
* This PR reverses the changes made in: https://github.com/supabase/supabase/pull/10948.