### PR TITLE
Add spacing to docs sidebar

### DIFF
--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenuRefListItems.tsx
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenuRefListItems.tsx
@@ -197,7 +197,7 @@ const NavigationMenuRefListItems = ({
         <HeaderLink title={menu.title} url={menu.url} id={id} />
         <RevVersionDropdown />
       </div>
-      <ul className="function-link-list flex flex-col gap-2">
+      <ul className="function-link-list flex flex-col gap-2 pb-5">
         {filteredSections.map((section) => {
           return (
             <Fragment key={section.title}>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Forgot about the sub section of the docs sidebar. Same as last PR https://github.com/supabase/supabase/pull/14320.

## What is the current behavior?

[supabase.com/docs/reference/javascript/introduction](https://supabase.com/docs/reference/javascript/introduction)

<img src="https://github.com/supabase/supabase/assets/70828596/85c8bd75-32ec-4dfd-a290-f573c1a85a70" height="500" />

## What is the new behavior?

<img src="https://github.com/supabase/supabase/assets/70828596/573fe017-bf27-40c5-bc55-0bf51599b3ef" height="500" />