### PR TITLE
fix: payment method selection when adding first card

### DIFF
--- a/studio/components/interfaces/BillingV2/Subscription/Tier/PaymentMethodSelection.tsx
+++ b/studio/components/interfaces/BillingV2/Subscription/Tier/PaymentMethodSelection.tsx
@@ -147,7 +147,10 @@ const PaymentMethodSelection = ({
             category: 'success',
             message: 'Successfully added new payment method',
           })
-          await refetchPaymentMethods()
+          const { data } = await refetchPaymentMethods()
+          if (!selectedPaymentMethod && data?.length) {
+            onSelectPaymentMethod(data[0].id)
+          }
         }}
       />
     </>


### PR DESCRIPTION
On the new subscription v2 page, when you're adding the very first card, it's selected visually in the dropdown, but not in the React state, so when you confirm the change, no payment method is selected.