### PR TITLE
fix: clear panel key state when changing compute addon

### DIFF
--- a/studio/components/interfaces/BillingV2/Subscription/AddOns/ComputeInstanceSidePanel.tsx
+++ b/studio/components/interfaces/BillingV2/Subscription/AddOns/ComputeInstanceSidePanel.tsx
@@ -82,6 +82,7 @@ const ComputeInstanceSidePanel = () => {
         message: `Successfully updated compute instance to ${selectedCompute?.name}. Your project is currently being restarted to update its instance`,
       })
       app.onProjectStatusUpdated(projectId, PROJECT_STATUS.RESTORING)
+      onClose()
       router.push(`/project/${projectRef}`)
     } catch (error: any) {
       ui.setNotification({


### PR DESCRIPTION
Not clearing the panel key sometimes lead to the panel randomly opening again when navigating to the page (as it was still in the state)