### PR TITLE
Docs: broken link fix in docs 

### DIFF
--- a/apps/docs/pages/guides/auth/auth-helpers/nextjs.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/nextjs.mdx
@@ -170,7 +170,7 @@ export async function GET(request: NextRequest) {
 
 ## Authentication
 
-Authentication can be initiated [client](/docs/guides/auth/auth-helpers/nextjs#client-side) or [server-side](/docs/guides/auth/auth-helpers/nextjs#server-side). All of the [supabase-js authentication strategies](http://localhost:3001/docs/reference/javascript/auth-api) are supported with the Auth Helpers client.
+Authentication can be initiated [client](/docs/guides/auth/auth-helpers/nextjs#client-side) or [server-side](/docs/guides/auth/auth-helpers/nextjs#server-side). All of the [supabase-js authentication strategies](/docs/reference/javascript/auth-api) are supported with the Auth Helpers client.
 
 > Note: The authentication flow requires the [Code Exchange Route](/docs/guides/auth/auth-helpers/nextjs#code-exchange-route) to exchange a `code` for the user's `session`.
 


### PR DESCRIPTION
fixes this issue: #14614 

After this change: 
1. Documentation [here](https://supabase.com/docs/guides/auth/auth-helpers/nextjs#authentication) 
2. Click on <ins>supabase-js authentication strategies</ins>
3. It should redirect you to the correct URL now.