### PR TITLE
fix: Stripe card form on light-mode

### DIFF
--- a/studio/components/interfaces/Billing/AddNewPaymentMethodModal/AddNewPaymentMethodModal.tsx
+++ b/studio/components/interfaces/Billing/AddNewPaymentMethodModal/AddNewPaymentMethodModal.tsx
@@ -9,6 +9,7 @@ import { useIsHCaptchaLoaded } from 'stores/hcaptcha-loaded-store'
 import { post } from 'lib/common/fetch'
 import { API_URL, STRIPE_PUBLIC_KEY } from 'lib/constants'
 import AddPaymentMethodForm from './AddPaymentMethodForm'
+import { useTheme } from 'common'
 
 interface Props {
   visible: boolean
@@ -78,9 +79,11 @@ const AddNewPaymentMethodModal: FC<Props> = ({ visible, returnUrl, onCancel, onC
     }
   }
 
+  const { isDarkMode } = useTheme()
+
   const options = {
     clientSecret: intent ? intent.client_secret : '',
-    appearance: { theme: 'night', labels: 'floating' },
+    appearance: { theme: isDarkMode ? 'night' : 'flat', labels: 'floating' },
   } as any
 
   const onLocalCancel = () => {

--- a/studio/components/interfaces/BillingV2/Subscription/Tier/AddNewPaymentMethodModal.tsx
+++ b/studio/components/interfaces/BillingV2/Subscription/Tier/AddNewPaymentMethodModal.tsx
@@ -9,6 +9,7 @@ import { useCallback, useEffect, useState } from 'react'
 import { useIsHCaptchaLoaded } from 'stores/hcaptcha-loaded-store'
 import { Modal } from 'ui'
 import AddNewPaymentMethodForm from './AddNewPaymentMethodForm'
+import { useTheme } from 'common'
 
 // [Joshen] Directly brought over from old Billing folder, so we can deprecate that folder easily next time
 
@@ -84,9 +85,11 @@ const AddNewPaymentMethodModal = ({
     }
   }
 
+  const { isDarkMode } = useTheme()
+
   const options = {
     clientSecret: intent ? intent.client_secret : '',
-    appearance: { theme: 'night', labels: 'floating' },
+    appearance: { theme: isDarkMode ? 'night' : 'flat', labels: 'floating' },
   } as any
 
   const onLocalCancel = () => {

--- a/studio/components/interfaces/Organization/NewProject/EmptyPaymentMethodWarning.tsx
+++ b/studio/components/interfaces/Organization/NewProject/EmptyPaymentMethodWarning.tsx
@@ -23,7 +23,7 @@ const EmptyPaymentMethodWarning = observer(
     return (
       <div className="mt-4">
         <InformationBox
-          icon={<IconAlertCircle className="text-white" size="large" strokeWidth={1.5} />}
+          icon={<IconAlertCircle size="large" strokeWidth={1.5} />}
           defaultVisibility={true}
           hideCollapse
           title="Your organization has no payment methods"


### PR DESCRIPTION
Before

![Screenshot 2023-05-26 at 20 39 21](https://github.com/supabase/supabase/assets/14073399/ab7d824e-c84d-4398-97df-599bcd41ce69)



After

![Screenshot 2023-05-26 at 20 38 13](https://github.com/supabase/supabase/assets/14073399/33f58126-e1df-4193-8061-8b370b6cf187)


![Screenshot 2023-05-26 at 20 37 51](https://github.com/supabase/supabase/assets/14073399/57474e01-5d40-453d-9037-aff628d60e60)




Also fixed the icon display from the empty payment method warning on light mode (wasn't visible)