### PR TITLE
Chore: use stable version of auth-helpers-nextjs package

### DIFF
--- a/examples/auth/nextjs/package.json
+++ b/examples/auth/nextjs/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@supabase/auth-helpers-nextjs": "^0.7.0-next.8",
+    "@supabase/auth-helpers-nextjs": "^0.7.0",
     "@types/node": "^20.2.3",
     "@types/react": "^18.2.6",
     "@types/react-dom": "^18.2.4",


### PR DESCRIPTION
## What kind of change does this PR introduce?

Version bump

## What is the current behavior?

Next.js Auth example uses `next` version of `auth-helpers-nextjs` package.

## What is the new behavior?

Next.js Auth example uses stable version of `auth-helpers-nextjs` package.
