### PR TITLE
fix: rename max enrolled factors to mfa max enrolled factors

### DIFF
--- a/studio/components/interfaces/Auth/AutoSchemaForm.tsx
+++ b/studio/components/interfaces/Auth/AutoSchemaForm.tsx
@@ -31,7 +31,7 @@ const AutoSchemaForm = observer(() => {
     SECURITY_CAPTCHA_ENABLED: authConfig.config.SECURITY_CAPTCHA_ENABLED || false,
     SECURITY_CAPTCHA_SECRET: authConfig.config.SECURITY_CAPTCHA_SECRET || '',
     SECURITY_CAPTCHA_PROVIDER: authConfig.config.SECURITY_CAPTCHA_PROVIDER || 'hcaptcha',
-    MAX_ENROLLED_FACTORS: authConfig.config.MAX_ENROLLED_FACTORS,
+    MFA_MAX_ENROLLED_FACTORS: authConfig.config.MFA_MAX_ENROLLED_FACTORS || 10,
   }
 
   const schema = object({
@@ -55,7 +55,7 @@ const AutoSchemaForm = observer(() => {
         .oneOf(['hcaptcha', 'turnstile'])
         .required('Captcha provider must be either hcaptcha or turnstile'),
     }),
-    MAX_ENROLLED_FACTORS: number()
+    MFA_MAX_ENROLLED_FACTORS: number()
       .min(0, 'Must be be a value more than 0')
       .max(30, 'Must be a value less than 30'),
   })
@@ -215,7 +215,7 @@ const AutoSchemaForm = observer(() => {
               >
                 <FormSectionContent loading={!isLoaded}>
                   <InputNumber
-                    id="MAX_ENROLLED_FACTORS"
+                    id="MFA_MAX_ENROLLED_FACTORS"
                     size="small"
                     label="Maximum number of enrolled factors"
                     disabled={!canUpdateConfig}

--- a/studio/stores/jsonSchema/auth_gotrue_config.json
+++ b/studio/stores/jsonSchema/auth_gotrue_config.json
@@ -443,6 +443,10 @@
       "title": "Body",
       "type": "string"
     },
+    "MFA_MAX_ENROLLED_FACTORS": {
+      "title": "Maximum enrolled factors",
+      "type": "integer"
+    }
     "PASSWORD_MIN_LENGTH": {
       "title": "Minimum password length",
       "type": "integer"


### PR DESCRIPTION
Companion PR to https://github.com/supabase/infrastructure/pull/13375

`MAX_ENROLLED_FACTORS` was misnamed and should be `MFA_MAX_ENROLLED_FACTORS` in order for the setting to update properly

Should only be merged after the infra prod deploy on 22nd June (to revisit then)