### PR TITLE
feat(self-host): use `<API_URL>/functions/v1` for Edge Functions

### DIFF
--- a/apps/docs/pages/guides/self-hosting/docker.mdx
+++ b/apps/docs/pages/guides/self-hosting/docker.mdx
@@ -68,6 +68,10 @@ Update the `.env` file with your own secrets. In particular, these are required:
 
 The Docker setup doesn't include a management database for managing users and logins. If you plan to deploy the Studio to the web we suggest you put it behind a web proxy with Basic Auth or hide it behind a VPN.
 
+## Setting up Edge Functions
+
+Your Functions are stored in `volumes/functions`. The default setup has a `hello` Function that you can invoke on `http://localhost:8000/functions/v1/hello`. You can add new Functions as `volumes/functions/<Function name>/index.ts`.
+
 ## Configuration
 
 Each system can be [configured](../self-hosting#configuration) to suit your particular use-case.

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -82,7 +82,8 @@ IMGPROXY_ENABLE_WEBP_DETECTION=true
 ############
 # Functions - Configuration for Functions
 ############
-FUNCTIONS_HTTP_PORT=9002
+# NOTE: VERIFY_JWT applies to all functions. Per-function VERIFY_JWT is not supported yet.
+FUNCTIONS_VERIFY_JWT=false
 
 ############
 # Logs - Configuration for Logflare

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -250,10 +250,9 @@ services:
       SUPABASE_URL: http://kong:8000
       SUPABASE_ANON_KEY: ${ANON_KEY}
       SUPABASE_SERVICE_ROLE_KEY: ${SERVICE_ROLE_KEY}
-      SUPABASE_DB_URL: postgresql://postgres:${POSTGRES_PASSWORD}@{POSTGRES_DB}:${POSTGRES_PORT}/${POSTGRES_DB}"
-      VERIFY_JWT: "false"
-    ports:
-      - ${FUNCTIONS_HTTP_PORT}:9000/tcp
+      SUPABASE_DB_URL: postgresql://postgres:${POSTGRES_PASSWORD}@{POSTGRES_DB}:${POSTGRES_PORT}/${POSTGRES_DB}
+      # TODO: Allow configuring VERIFY_JWT per function. This PR might help: https://github.com/supabase/cli/pull/786
+      VERIFY_JWT: "${FUNCTIONS_VERIFY_JWT}"
     volumes:
       - ./volumes/functions:/home/deno/functions:Z
     command:

--- a/docker/volumes/api/kong.yml
+++ b/docker/volumes/api/kong.yml
@@ -153,6 +153,19 @@ services:
           - /storage/v1/
     plugins:
       - name: cors
+
+  ## Edge Functions routes
+  - name: functions-v1
+    _comment: 'Edge Functions: /functions/v1/* -> http://functions:9000/*'
+    url: http://functions:9000/
+    routes:
+      - name: functions-v1-all
+        strip_path: true
+        paths:
+          - /functions/v1/
+    plugins:
+      - name: cors
+
   ## Analytics routes
   - name: analytics-v1
     _comment: 'Analytics: /analytics/v1/* -> http://logflare:4000/*'

--- a/docker/volumes/functions/hello/index.ts
+++ b/docker/volumes/functions/hello/index.ts
@@ -1,0 +1,16 @@
+// Follow this setup guide to integrate the Deno language server with your editor:
+// https://deno.land/manual/getting_started/setup_your_environment
+// This enables autocomplete, go to definition, etc.
+
+import { serve } from "https://deno.land/std@0.177.1/http/server.ts"
+
+serve(async () => {
+  return new Response(
+    `"Hello from Edge Functions!"`,
+    { headers: { "Content-Type": "application/json" } },
+  )
+})
+
+// To invoke:
+// curl 'http://localhost:<KONG_HTTP_PORT>/functions/v1/hello' \
+//   --header 'Authorization: Bearer <anon/service_role API key>'


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

Edge Functions doesn't work OOtB with supabase-js because the `url` for functions-js needs to be customized to be `FUNCTIONS_HTTP_PORT`.

## What is the new behavior?

- Edge Functions works OOtB with supabase-js
- Removes `FUNCTIONS_HTTP_PORT` from `.env.example` - one less thing to have to configure
- Adds `FUNCTIONS_VERIFY_JWT` to `.env.example`
- Adds an example `hello` function

## Additional context

Addresses https://github.com/orgs/supabase/discussions/12079, https://github.com/orgs/supabase/discussions/12954