### PR TITLE
chore: allow creating paid project without payment method

### DIFF
--- a/studio/pages/new/[slug].tsx
+++ b/studio/pages/new/[slug].tsx
@@ -82,8 +82,7 @@ const Wizard: NextPageWithLayout = () => {
     projectName !== '' &&
     passwordStrengthScore >= DEFAULT_MINIMUM_PASSWORD_STRENGTH &&
     dbRegion !== '' &&
-    dbPricingTierKey !== '' &&
-    (isSelectFreeTier || (!isSelectFreeTier && !isEmptyPaymentMethod))
+    dbPricingTierKey !== ''
 
   const delayedCheckPasswordStrength = useRef(
     debounce((value) => checkPasswordStrength(value), 300)


### PR DESCRIPTION
This PR allows form submission, if you select a paid tier and have no payment method on file.

We have backend checks in place that validate whether the customer is allowed to actually do that - this just unblocks the customer by allowing them to even attempt it.