### PR TITLE
Fix/json column boolean

### DIFF
--- a/studio/components/grid/components/editor/JsonEditor.tsx
+++ b/studio/components/grid/components/editor/JsonEditor.tsx
@@ -6,7 +6,7 @@ import { EditorProps } from '@supabase/react-data-grid'
 import { useTrackedState } from 'components/grid/store'
 import { BlockKeys, MonacoEditor, NullValue } from 'components/grid/components/common'
 import { tryParseJson } from 'lib/helpers'
-import { isNil } from "lodash";
+import { isNil } from 'lodash'
 
 interface JsonEditorProps<TRow, TSummaryRow = unknown> extends EditorProps<TRow, TSummaryRow> {
   onExpandEditor: (column: string, row: TRow) => void

--- a/studio/components/grid/components/editor/JsonEditor.tsx
+++ b/studio/components/grid/components/editor/JsonEditor.tsx
@@ -6,6 +6,7 @@ import { EditorProps } from '@supabase/react-data-grid'
 import { useTrackedState } from 'components/grid/store'
 import { BlockKeys, MonacoEditor, NullValue } from 'components/grid/components/common'
 import { tryParseJson } from 'lib/helpers'
+import { isNil } from "lodash";
 
 interface JsonEditorProps<TRow, TSummaryRow = unknown> extends EditorProps<TRow, TSummaryRow> {
   onExpandEditor: (column: string, row: TRow) => void
@@ -21,7 +22,7 @@ export function JsonEditor<TRow, TSummaryRow = unknown>({
 
   const gridColumn = state.gridColumns.find((x) => x.name == column.key)
   const initialValue = row[column.key as keyof TRow] as unknown
-  const jsonString = prettifyJSON(initialValue ? JSON.stringify(initialValue) : '')
+  const jsonString = prettifyJSON(!isNil(initialValue) ? JSON.stringify(initialValue) : '')
 
   const [isPopoverOpen, setIsPopoverOpen] = useState(true)
   const [value, setValue] = useState<string | null>(jsonString)

--- a/studio/components/grid/components/formatter/JsonFormatter.tsx
+++ b/studio/components/grid/components/formatter/JsonFormatter.tsx
@@ -1,16 +1,16 @@
-import * as React from "react";
-import { FormatterProps } from "@supabase/react-data-grid";
-import { SupaRow } from "../../types";
-import { EmptyValue, NullValue } from "../common";
+import * as React from 'react'
+import { FormatterProps } from '@supabase/react-data-grid'
+import { SupaRow } from '../../types'
+import { EmptyValue, NullValue } from '../common'
 
 export const JsonFormatter = (p: React.PropsWithChildren<FormatterProps<SupaRow, unknown>>) => {
-	let value = p.row[p.column.key]
+  let value = p.row[p.column.key]
 
-	if (value === null) return <NullValue />
-	if (value === '') return <EmptyValue />
-	try {
-		value = JSON.stringify(value)
-	} catch (err) {}
+  if (value === null) return <NullValue />
+  if (value === '') return <EmptyValue />
+  try {
+    value = JSON.stringify(value)
+  } catch (err) {}
 
-	return <>{value}</>
+  return <>{value}</>
 }

--- a/studio/components/grid/components/formatter/JsonFormatter.tsx
+++ b/studio/components/grid/components/formatter/JsonFormatter.tsx
@@ -1,0 +1,16 @@
+import * as React from "react";
+import { FormatterProps } from "@supabase/react-data-grid";
+import { SupaRow } from "../../types";
+import { EmptyValue, NullValue } from "../common";
+
+export const JsonFormatter = (p: React.PropsWithChildren<FormatterProps<SupaRow, unknown>>) => {
+	let value = p.row[p.column.key]
+
+	if (value === null) return <NullValue />
+	if (value === '') return <EmptyValue />
+	try {
+		value = JSON.stringify(value)
+	} catch (err) {}
+
+	return <>{value}</>
+}

--- a/studio/components/grid/components/formatter/index.ts
+++ b/studio/components/grid/components/formatter/index.ts
@@ -1,4 +1,4 @@
 export * from './BooleanFormatter'
 export * from './DefaultFormatter'
 export * from './ForeignKeyFormatter'
-export * from './JsonFormatter';
+export * from './JsonFormatter'

--- a/studio/components/grid/components/formatter/index.ts
+++ b/studio/components/grid/components/formatter/index.ts
@@ -1,3 +1,4 @@
 export * from './BooleanFormatter'
 export * from './DefaultFormatter'
 export * from './ForeignKeyFormatter'
+export * from './JsonFormatter';

--- a/studio/components/grid/utils/gridColumns.tsx
+++ b/studio/components/grid/utils/gridColumns.tsx
@@ -31,6 +31,7 @@ import {
   BooleanFormatter,
   DefaultFormatter,
   ForeignKeyFormatter,
+  JsonFormatter,
 } from 'components/grid/components/formatter'
 
 export const ESTIMATED_CHARACTER_PIXEL_WIDTH = 9
@@ -148,6 +149,9 @@ function getColumnFormatter(columnDef: SupaColumn, columnType: ColumnType) {
       } else {
         return ForeignKeyFormatter
       }
+    }
+    case 'json': {
+      return JsonFormatter
     }
     default: {
       return DefaultFormatter


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Fixes #14537

## What is the new behavior?

- False can be entered into the JSON editor for JSON and JSONB columns now.
- JSON formatter now shows true/false correctly.

## Additional context

Old UI
<img width="878" alt="old-ui" src="https://github.com/supabase/supabase/assets/52075362/a231a5e8-09f1-4f91-b142-96c166cddbbe">

New UI
<img width="879" alt="new-ui" src="https://github.com/supabase/supabase/assets/52075362/a8269b23-9d8a-4035-bdf0-72906b83533d">

