### PR TITLE
Fix example code markdown replacement

### DIFF
--- a/apps/docs/components/reference/RefFunctionSection.tsx
+++ b/apps/docs/components/reference/RefFunctionSection.tsx
@@ -119,7 +119,7 @@ const RefFunctionSection: React.FC<IRefFunctionSection> = (props) => {
                         (example.code &&
                           example.code
                             .trim()
-                            .replace(/^```(js|ts|dart|c#|kotlin)/, '')
+                            .replace(/^```.*/, '')
                             .replace(/```$/, ''))
 
                       const codeBlockLang = example?.code?.startsWith('```js')

--- a/apps/docs/components/reference/RefFunctionSection.tsx
+++ b/apps/docs/components/reference/RefFunctionSection.tsx
@@ -114,7 +114,13 @@ const RefFunctionSection: React.FC<IRefFunctionSection> = (props) => {
                 >
                   {item.examples &&
                     item.examples.map((example, exampleIndex) => {
-                      const exampleString = ''
+                      const exampleString =
+                        '' +
+                        (example.code &&
+                          example.code
+                            .trim()
+                            .replace(/^```(js|ts|dart|c#|kotlin)/, '')
+                            .replace(/```$/, ''))
 
                       const codeBlockLang = example?.code?.startsWith('```js')
                         ? 'js'
@@ -133,7 +139,6 @@ const RefFunctionSection: React.FC<IRefFunctionSection> = (props) => {
                       // // Create a single supabase client for interacting with your database
                       // const supabase = createClient('https://xyzcompany.supabase.co', 'public-anon-key')
                       // `
-                      const currentExampleId = example.id
                       const staticExample = item.examples[exampleIndex]
 
                       const response = staticExample.response
@@ -152,15 +157,7 @@ const RefFunctionSection: React.FC<IRefFunctionSection> = (props) => {
                             language={codeBlockLang}
                             hideLineNumbers={true}
                           >
-                            {exampleString +
-                              (example.code &&
-                                example.code
-                                  .replace(/```/g, '')
-                                  .replace('js', '')
-                                  .replace('ts', '')
-                                  .replace('dart', '')
-                                  .replace('c#', '')
-                                  .replace('kotlin', ''))}
+                            {exampleString}
                           </CodeBlock>
 
                           {((tables && tables.length > 0) || sql) && (


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Fixes #14270

## What is the new behavior?

Only replace text at the start and end of the example code instead of globally.

## Additional context

Old UI
<img width="615" alt="old-ui" src="https://github.com/supabase/supabase/assets/52075362/5089ffc8-17e0-4fed-84e7-dccb54eeb943">

New UI
<img width="624" alt="new-ui" src="https://github.com/supabase/supabase/assets/52075362/9995baea-9131-4641-8c6d-9774edc9668e">
