### PR TITLE
Update auth-password-reset.mdx

### DIFF
--- a/apps/docs/pages/guides/auth/auth-password-reset.mdx
+++ b/apps/docs/pages/guides/auth/auth-password-reset.mdx
@@ -65,7 +65,7 @@ We are using `next` as our query parameter, but this can name whatever you like.
 The email link you receive will behave like a magic link. When the link is clicked you will be sent to the `redirectTo` URL you specified that points to the path with the exchange code.
 
 ### Exchange authorization code
-After redirecting to the server page, we need to retrieve the code from the query parameter called `code` and pass it to the `.exchangeAuthCodeForSession` function.
+After redirecting to the server page, we need to retrieve the code from the query parameter called `code` and pass it to the `.exchangeCodeForSession` function.
 ```ts
 // api/auth/callback.ts
 


### PR DESCRIPTION
Update name of `.exchangeCodeForSession` method.

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

Docs mention an outdated (or wrong) method `.exchangeAuthCodeForSession`, which is confusing. The code example below it shows that the method is called `.exchangeCodeForSession`.
