### PR TITLE
Update LangChain guide with metadata filtering examples

### DIFF
--- a/apps/docs/pages/guides/ai/langchain.mdx
+++ b/apps/docs/pages/guides/ai/langchain.mdx
@@ -29,7 +29,7 @@ create table documents (
 -- Create a function to search for documents
 create function match_documents (
   query_embedding vector(1536),
-  match_count int,
+  match_count int DEFAULT null,
   filter jsonb DEFAULT '{}'
 ) returns table (
   id bigint,
@@ -88,6 +88,117 @@ export const run = async () => {
 
   console.log(resultOne)
 }
+```
+
+### Simple Metadata Filtering
+
+Given the above match_documents Postgres function, you can also pass a filter parameter to only return documents with a specific metadata field value. This filter parameter is a JSON object, and the `match_documents` function will use the Postgres JSONB Containment operator `@>` to filter documents by the metadata field values you specify. See details on the [Postgres JSONB Containment operator](https://www.postgresql.org/docs/current/datatype-json.html#JSON-CONTAINMENT) for more information.
+
+```js
+import { SupabaseVectorStore } from "langchain/vectorstores/supabase";
+import { OpenAIEmbeddings } from "langchain/embeddings/openai";
+import { createClient } from "@supabase/supabase-js";
+
+// First, follow set-up instructions above
+
+const privateKey = process.env.SUPABASE_PRIVATE_KEY;
+if (!privateKey) throw new Error(`Expected env var SUPABASE_PRIVATE_KEY`);
+
+const url = process.env.SUPABASE_URL;
+if (!url) throw new Error(`Expected env var SUPABASE_URL`);
+
+export const run = async () => {
+  const client = createClient(url, privateKey);
+
+  const vectorStore = await SupabaseVectorStore.fromTexts(
+    ["Hello world", "Hello world", "Hello world"],
+    [{ user_id: 2 }, { user_id: 1 }, { user_id: 3 }],
+    new OpenAIEmbeddings(),
+    {
+      client,
+      tableName: "documents",
+      queryName: "match_documents",
+    }
+  );
+
+  const result = await vectorStore.similaritySearch("Hello world", 1, {
+    user_id: 3,
+  });
+
+  console.log(result);
+};
+```
+
+### Advanced Metadata Filtering
+
+You can also use query builder-style filtering ([similar to how the Supabase JavaScript library works](https://supabase.com/docs/reference/javascript/using-filters)) instead of passing an object. Note that since the filter properties will be in the metadata column, you need to use arrow operators (`->` for integer or `->>` for text) as defined in [Postgrest API documentation](https://postgrest.org/en/stable/references/api/tables_views.html?highlight=operators#json-columns) and specify the data type of the property (e.g. the column should look something like `metadata->some_int_value::int`).
+
+```js
+import {
+  SupabaseFilterRPCCall,
+  SupabaseVectorStore,
+} from "langchain/vectorstores/supabase";
+import { OpenAIEmbeddings } from "langchain/embeddings/openai";
+import { createClient } from "@supabase/supabase-js";
+
+// First, follow set-up instructions above
+
+const privateKey = process.env.SUPABASE_PRIVATE_KEY;
+if (!privateKey) throw new Error(`Expected env var SUPABASE_PRIVATE_KEY`);
+
+const url = process.env.SUPABASE_URL;
+if (!url) throw new Error(`Expected env var SUPABASE_URL`);
+
+export const run = async () => {
+  const client = createClient(url, privateKey);
+
+  const embeddings = new OpenAIEmbeddings();
+
+  const store = new SupabaseVectorStore(embeddings, {
+    client,
+    tableName: "documents",
+  });
+
+  const docs = [
+    {
+      pageContent:
+        "This is a long text, but it actually means something because vector database does not understand Lorem Ipsum. So I would need to expand upon the notion of quantum fluff, a theorectical concept where subatomic particles coalesce to form transient multidimensional spaces. Yet, this abstraction holds no real-world application or comprehensible meaning, reflecting a cosmic puzzle.",
+      metadata: { b: 1, c: 10, stuff: "right" },
+    },
+    {
+      pageContent:
+        "This is a long text, but it actually means something because vector database does not understand Lorem Ipsum. So I would need to proceed by discussing the echo of virtual tweets in the binary corridors of the digital universe. Each tweet, like a pixelated canary, hums in an unseen frequency, a fascinatingly perplexing phenomenon that, while conjuring vivid imagery, lacks any concrete implication or real-world relevance, portraying a paradox of multidimensional spaces in the age of cyber folklore.",
+      metadata: { b: 2, c: 9, stuff: "right" },
+    },
+    { pageContent: "hello", metadata: { b: 1, c: 9, stuff: "right" } },
+    { pageContent: "hello", metadata: { b: 1, c: 9, stuff: "wrong" } },
+    { pageContent: "hi", metadata: { b: 2, c: 8, stuff: "right" } },
+    { pageContent: "bye", metadata: { b: 3, c: 7, stuff: "right" } },
+    { pageContent: "what's this", metadata: { b: 4, c: 6, stuff: "right" } },
+  ];
+
+  await store.addDocuments(docs);
+
+  const funcFilterA: SupabaseFilterRPCCall = (rpc) =>
+    rpc
+      .filter("metadata->b::int", "lt", 3)
+      .filter("metadata->c::int", "gt", 7)
+      .textSearch("content", `'multidimensional' & 'spaces'`, {
+        config: "english",
+      });
+
+  const resultA = await store.similaritySearch("quantum", 4, funcFilterA);
+
+  const funcFilterB: SupabaseFilterRPCCall = (rpc) =>
+    rpc
+      .filter("metadata->b::int", "lt", 3)
+      .filter("metadata->c::int", "gt", 7)
+      .filter("metadata->>stuff", "eq", "right");
+
+  const resultB = await store.similaritySearch("hello", 2, funcFilterB);
+
+  console.log(resultA, resultB);
+};
 ```
 
 ## Hybrid search

--- a/apps/docs/pages/guides/ai/langchain.mdx
+++ b/apps/docs/pages/guides/ai/langchain.mdx
@@ -95,38 +95,38 @@ export const run = async () => {
 Given the above `match_documents` Postgres function, you can also pass a filter parameter to only return documents with a specific metadata field value. This filter parameter is a JSON object, and the `match_documents` function will use the Postgres JSONB Containment operator `@>` to filter documents by the metadata field values you specify. See details on the [Postgres JSONB Containment operator](https://www.postgresql.org/docs/current/datatype-json.html#JSON-CONTAINMENT) for more information.
 
 ```js
-import { SupabaseVectorStore } from "langchain/vectorstores/supabase";
-import { OpenAIEmbeddings } from "langchain/embeddings/openai";
-import { createClient } from "@supabase/supabase-js";
+import { SupabaseVectorStore } from 'langchain/vectorstores/supabase'
+import { OpenAIEmbeddings } from 'langchain/embeddings/openai'
+import { createClient } from '@supabase/supabase-js'
 
 // First, follow set-up instructions above
 
-const privateKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
-if (!privateKey) throw new Error(`Expected env var SUPABASE_SERVICE_ROLE_KEY`);
+const privateKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+if (!privateKey) throw new Error(`Expected env var SUPABASE_SERVICE_ROLE_KEY`)
 
-const url = process.env.SUPABASE_URL;
-if (!url) throw new Error(`Expected env var SUPABASE_URL`);
+const url = process.env.SUPABASE_URL
+if (!url) throw new Error(`Expected env var SUPABASE_URL`)
 
 export const run = async () => {
-  const client = createClient(url, privateKey);
+  const client = createClient(url, privateKey)
 
   const vectorStore = await SupabaseVectorStore.fromTexts(
-    ["Hello world", "Hello world", "Hello world"],
+    ['Hello world', 'Hello world', 'Hello world'],
     [{ user_id: 2 }, { user_id: 1 }, { user_id: 3 }],
     new OpenAIEmbeddings(),
     {
       client,
-      tableName: "documents",
-      queryName: "match_documents",
+      tableName: 'documents',
+      queryName: 'match_documents',
     }
-  );
+  )
 
-  const result = await vectorStore.similaritySearch("Hello world", 1, {
+  const result = await vectorStore.similaritySearch('Hello world', 1, {
     user_id: 3,
-  });
+  })
 
-  console.log(result);
-};
+  console.log(result)
+}
 ```
 
 ### Advanced Metadata Filtering
@@ -134,71 +134,68 @@ export const run = async () => {
 You can also use query builder-style filtering ([similar to how the Supabase JavaScript library works](https://supabase.com/docs/reference/javascript/using-filters)) instead of passing an object. Note that since the filter properties will be in the metadata column, you need to use arrow operators (`->` for integer or `->>` for text) as defined in [Postgrest API documentation](https://postgrest.org/en/stable/references/api/tables_views.html?highlight=operators#json-columns) and specify the data type of the property (e.g. the column should look something like `metadata->some_int_value::int`).
 
 ```js
-import {
-  SupabaseFilterRPCCall,
-  SupabaseVectorStore,
-} from "langchain/vectorstores/supabase";
-import { OpenAIEmbeddings } from "langchain/embeddings/openai";
-import { createClient } from "@supabase/supabase-js";
+import { SupabaseFilterRPCCall, SupabaseVectorStore } from 'langchain/vectorstores/supabase'
+import { OpenAIEmbeddings } from 'langchain/embeddings/openai'
+import { createClient } from '@supabase/supabase-js'
 
 // First, follow set-up instructions above
 
-const privateKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
-if (!privateKey) throw new Error(`Expected env var SUPABASE_SERVICE_ROLE_KEY`);
+const privateKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+if (!privateKey) throw new Error(`Expected env var SUPABASE_SERVICE_ROLE_KEY`)
 
-const url = process.env.SUPABASE_URL;
-if (!url) throw new Error(`Expected env var SUPABASE_URL`);
+const url = process.env.SUPABASE_URL
+if (!url) throw new Error(`Expected env var SUPABASE_URL`)
 
 export const run = async () => {
-  const client = createClient(url, privateKey);
+  const client = createClient(url, privateKey)
 
-  const embeddings = new OpenAIEmbeddings();
+  const embeddings = new OpenAIEmbeddings()
 
   const store = new SupabaseVectorStore(embeddings, {
     client,
-    tableName: "documents",
-  });
+    tableName: 'documents',
+  })
 
   const docs = [
     {
       pageContent:
-        "This is a long text, but it actually means something because vector database does not understand Lorem Ipsum. So I would need to expand upon the notion of quantum fluff, a theorectical concept where subatomic particles coalesce to form transient multidimensional spaces. Yet, this abstraction holds no real-world application or comprehensible meaning, reflecting a cosmic puzzle.",
-      metadata: { b: 1, c: 10, stuff: "right" },
+        'This is a long text, but it actually means something because vector database does not understand Lorem Ipsum. So I would need to expand upon the notion of quantum fluff, a theorectical concept where subatomic particles coalesce to form transient multidimensional spaces. Yet, this abstraction holds no real-world application or comprehensible meaning, reflecting a cosmic puzzle.',
+      metadata: { b: 1, c: 10, stuff: 'right' },
     },
     {
       pageContent:
-        "This is a long text, but it actually means something because vector database does not understand Lorem Ipsum. So I would need to proceed by discussing the echo of virtual tweets in the binary corridors of the digital universe. Each tweet, like a pixelated canary, hums in an unseen frequency, a fascinatingly perplexing phenomenon that, while conjuring vivid imagery, lacks any concrete implication or real-world relevance, portraying a paradox of multidimensional spaces in the age of cyber folklore.",
-      metadata: { b: 2, c: 9, stuff: "right" },
+        'This is a long text, but it actually means something because vector database does not understand Lorem Ipsum. So I would need to proceed by discussing the echo of virtual tweets in the binary corridors of the digital universe. Each tweet, like a pixelated canary, hums in an unseen frequency, a fascinatingly perplexing phenomenon that, while conjuring vivid imagery, lacks any concrete implication or real-world relevance, portraying a paradox of multidimensional spaces in the age of cyber folklore.',
+      metadata: { b: 2, c: 9, stuff: 'right' },
     },
-    { pageContent: "hello", metadata: { b: 1, c: 9, stuff: "right" } },
-    { pageContent: "hello", metadata: { b: 1, c: 9, stuff: "wrong" } },
-    { pageContent: "hi", metadata: { b: 2, c: 8, stuff: "right" } },
-    { pageContent: "bye", metadata: { b: 3, c: 7, stuff: "right" } },
-    { pageContent: "what's this", metadata: { b: 4, c: 6, stuff: "right" } },
-  ];
+    { pageContent: 'hello', metadata: { b: 1, c: 9, stuff: 'right' } },
+    { pageContent: 'hello', metadata: { b: 1, c: 9, stuff: 'wrong' } },
+    { pageContent: 'hi', metadata: { b: 2, c: 8, stuff: 'right' } },
+    { pageContent: 'bye', metadata: { b: 3, c: 7, stuff: 'right' } },
+    { pageContent: "what's this", metadata: { b: 4, c: 6, stuff: 'right' } },
+  ]
 
-  await store.addDocuments(docs);
+  await store.addDocuments(docs)
 
   const funcFilterA: SupabaseFilterRPCCall = (rpc) =>
     rpc
-      .filter("metadata->b::int", "lt", 3)
-      .filter("metadata->c::int", "gt", 7)
-      .textSearch("content", `'multidimensional' & 'spaces'`, {
-        config: "english",
-      });
+      .filter('metadata->b::int', 'lt', 3)
+      .filter('metadata->c::int', 'gt', 7)
+      .textSearch('content', `'multidimensional' & 'spaces'`, {
+        config: 'english',
+      })
 
-  const resultA = await store.similaritySearch("quantum", 4, funcFilterA);
+  const resultA = await store.similaritySearch('quantum', 4, funcFilterA)
 
   const funcFilterB: SupabaseFilterRPCCall = (rpc) =>
     rpc
-      .filter("metadata->b::int", "lt", 3)
-      .filter("metadata->c::int", "gt", 7)
-      .filter("metadata->>stuff", "eq", "right");
+      .filter('metadata->b::int', 'lt', 3)
+      .filter('metadata->c::int', 'gt', 7)
+      .filter('metadata->>stuff', 'eq', 'right')
 
-  const resultB = await store.similaritySearch("hello", 2, funcFilterB);
+  const resultB = await store.similaritySearch('hello', 2, funcFilterB)
 
-  console.log(resultA, resultB);
-};
+  console.log(resultA, resultB)
+}
 ```
 
 ## Hybrid search

--- a/apps/docs/pages/guides/ai/langchain.mdx
+++ b/apps/docs/pages/guides/ai/langchain.mdx
@@ -101,8 +101,8 @@ import { createClient } from "@supabase/supabase-js";
 
 // First, follow set-up instructions above
 
-const privateKey = process.env.SUPABASE_PRIVATE_KEY;
-if (!privateKey) throw new Error(`Expected env var SUPABASE_PRIVATE_KEY`);
+const privateKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!privateKey) throw new Error(`Expected env var SUPABASE_SERVICE_ROLE_KEY`);
 
 const url = process.env.SUPABASE_URL;
 if (!url) throw new Error(`Expected env var SUPABASE_URL`);
@@ -143,8 +143,8 @@ import { createClient } from "@supabase/supabase-js";
 
 // First, follow set-up instructions above
 
-const privateKey = process.env.SUPABASE_PRIVATE_KEY;
-if (!privateKey) throw new Error(`Expected env var SUPABASE_PRIVATE_KEY`);
+const privateKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!privateKey) throw new Error(`Expected env var SUPABASE_SERVICE_ROLE_KEY`);
 
 const url = process.env.SUPABASE_URL;
 if (!url) throw new Error(`Expected env var SUPABASE_URL`);

--- a/apps/docs/pages/guides/ai/langchain.mdx
+++ b/apps/docs/pages/guides/ai/langchain.mdx
@@ -29,7 +29,7 @@ create table documents (
 -- Create a function to search for documents
 create function match_documents (
   query_embedding vector(1536),
-  match_count int DEFAULT null,
+  match_count int default null,
   filter jsonb DEFAULT '{}'
 ) returns table (
   id bigint,

--- a/apps/docs/pages/guides/ai/langchain.mdx
+++ b/apps/docs/pages/guides/ai/langchain.mdx
@@ -92,7 +92,7 @@ export const run = async () => {
 
 ### Simple Metadata Filtering
 
-Given the above match_documents Postgres function, you can also pass a filter parameter to only return documents with a specific metadata field value. This filter parameter is a JSON object, and the `match_documents` function will use the Postgres JSONB Containment operator `@>` to filter documents by the metadata field values you specify. See details on the [Postgres JSONB Containment operator](https://www.postgresql.org/docs/current/datatype-json.html#JSON-CONTAINMENT) for more information.
+Given the above `match_documents` Postgres function, you can also pass a filter parameter to only return documents with a specific metadata field value. This filter parameter is a JSON object, and the `match_documents` function will use the Postgres JSONB Containment operator `@>` to filter documents by the metadata field values you specify. See details on the [Postgres JSONB Containment operator](https://www.postgresql.org/docs/current/datatype-json.html#JSON-CONTAINMENT) for more information.
 
 ```js
 import { SupabaseVectorStore } from "langchain/vectorstores/supabase";


### PR DESCRIPTION
## What kind of change does this PR introduce?

Updates the Postgres function in the docs, which allows for more advanced metadata filtering:
https://github.com/hwchase17/langchainjs/pull/1418

Should mirror the current content in the LangChainJS docs:
https://js.langchain.com/docs/modules/indexes/vector_stores/integrations/supabase