### PR TITLE
feat: add docs for deploy all edge functions.

### DIFF
--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
@@ -727,7 +727,7 @@ export const functions: NavMenuConstant = {
       url: undefined,
       items: [
         { name: 'Developing Functions locally', url: '/guides/functions/local-development' },
-        { name: 'Deploying with Git', url: '/guides/functions/cicd-workflow' },
+        { name: 'Deploying with GitHub', url: '/guides/functions/cicd-workflow' },
         { name: 'Managing Secrets and Environment Variables', url: '/guides/functions/secrets' },
         { name: 'Integrating With Supabase Auth', url: '/guides/functions/auth' },
         {

--- a/apps/docs/pages/guides/functions/cicd-workflow.mdx
+++ b/apps/docs/pages/guides/functions/cicd-workflow.mdx
@@ -24,7 +24,7 @@ jobs:
 
     env:
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-      PROJECT_ID: zdtdtxajzydjqzuktnqx
+      PROJECT_ID: your-project-id
 
     steps:
       - uses: actions/checkout@v3
@@ -33,7 +33,16 @@ jobs:
         with:
           version: 1.0.0
 
-      - run: supabase functions deploy your-function-name --project-ref $PROJECT_ID
+      - run: supabase functions deploy --project-ref $PROJECT_ID
+```
+
+Since Supabase CLI [v1.62.0](https://github.com/supabase/cli/releases/tag/v1.62.0) you can deploy all functions with a single command.
+
+Individual function configuration like [JWT verification](/docs/reference/cli/config#functions.function_name.verify_jwt) and [import map location](/docs/reference/cli/config#functions.function_name.import_map) can be set via the `config.toml` file.
+
+```toml
+[functions.hello-world]
+verify_jwt = false
 ```
 
 <div class="video-container">

--- a/apps/docs/pages/guides/functions/cicd-workflow.mdx
+++ b/apps/docs/pages/guides/functions/cicd-workflow.mdx
@@ -31,7 +31,7 @@ jobs:
 
       - uses: supabase/setup-cli@v1
         with:
-          version: 1.0.0
+          version: latest
 
       - run: supabase functions deploy --project-ref $PROJECT_ID
 ```

--- a/apps/docs/pages/guides/functions/examples/github-actions.mdx
+++ b/apps/docs/pages/guides/functions/examples/github-actions.mdx
@@ -40,9 +40,18 @@ jobs:
 
       - uses: supabase/setup-cli@v1
         with:
-          version: 1.0.0
+          version: latest
 
-      - run: supabase functions deploy github-action-deploy --project-ref $PROJECT_ID
+      - run: supabase functions deploy --project-ref $PROJECT_ID
+```
+
+Since Supabase CLI [v1.62.0](https://github.com/supabase/cli/releases/tag/v1.62.0) you can deploy all functions with a single command.
+
+Individual function configuration like [JWT verification](/docs/reference/cli/config#functions.function_name.verify_jwt) and [import map location](/docs/reference/cli/config#functions.function_name.import_map) can be set via the `config.toml` file.
+
+```toml
+[functions.hello-world]
+verify_jwt = false
 ```
 
 export const Page = ({ children }) => <Layout meta={meta} children={children} />

--- a/apps/docs/pages/guides/functions/quickstart.mdx
+++ b/apps/docs/pages/guides/functions/quickstart.mdx
@@ -41,6 +41,8 @@ This creates a function stub in your `supabase` folder at `./functions/hello-wor
 
 ## Deploy to production
 
+### Deploy a specific function
+
 ```bash
 supabase functions deploy hello-world
 ```
@@ -55,6 +57,21 @@ By default, Edge Functions require a valid JWT in the authorization header. This
 If you want to use Edge Functions to handle webhooks (e.g. [Stripe payment webhooks](https://github.com/supabase/supabase/tree/master/examples/edge-functions/supabase/functions/stripe-webhooks) etc.), you need to pass the `--no-verify-jwt` flag when deploying your function.
 
 </Admonition>
+
+### Deploy all functions
+
+```bash
+supabase functions deploy
+```
+
+Since Supabase CLI [v1.62.0](https://github.com/supabase/cli/releases/tag/v1.62.0) you can deploy all functions with a single command. This is useful for example when [deploying with GitHub Actions](/docs/guides/functions/cicd-workflow).
+
+Individual function configuration like [JWT verification](/docs/reference/cli/config#functions.function_name.verify_jwt) and [import map location](/docs/reference/cli/config#functions.function_name.import_map) can be set via the `config.toml` file.
+
+```toml
+[functions.hello-world]
+verify_jwt = false
+```
 
 ## Invoking remote functions
 

--- a/examples/edge-functions/.github/workflows/deploy.yaml
+++ b/examples/edge-functions/.github/workflows/deploy.yaml
@@ -19,6 +19,6 @@ jobs:
 
       - uses: supabase/setup-cli@v1
         with:
-          version: 1.0.0
+          version: latest
 
       - run: supabase functions deploy github-action-deploy --project-ref $PROJECT_ID

--- a/examples/edge-functions/README.md
+++ b/examples/edge-functions/README.md
@@ -81,7 +81,7 @@ jobs:
 
     env:
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-      PROJECT_ID: zdtdtxajzydjqzuktnqx
+      PROJECT_ID: your-project-id
 
     steps:
       - uses: actions/checkout@v3
@@ -90,7 +90,16 @@ jobs:
         with:
           version: 1.0.0
 
-      - run: supabase functions deploy your-function-name --project-ref $PROJECT_ID
+      - run: supabase functions deploy --project-ref $PROJECT_ID
+```
+
+Since Supabase CLI [v1.62.0](https://github.com/supabase/cli/releases/tag/v1.62.0) you can deploy all functions with a single command.
+
+Individual function configuration like [JWT verification](/docs/reference/cli/config#functions.function_name.verify_jwt) and [import map location](/docs/reference/cli/config#functions.function_name.import_map) can be set via the `config.toml` file.
+
+```toml
+[functions.hello-world]
+verify_jwt = false
 ```
 
 ## 👁⚡️👁

--- a/examples/edge-functions/README.md
+++ b/examples/edge-functions/README.md
@@ -88,7 +88,7 @@ jobs:
 
       - uses: supabase/setup-cli@v1
         with:
-          version: 1.0.0
+          version: latest
 
       - run: supabase functions deploy --project-ref $PROJECT_ID
 ```

--- a/examples/edge-functions/supabase/functions/github-action-deploy/README.md
+++ b/examples/edge-functions/supabase/functions/github-action-deploy/README.md
@@ -26,7 +26,7 @@ jobs:
 
       - uses: supabase/setup-cli@v1
         with:
-          version: 1.0.0
+          version: latest
 
       - run: supabase functions deploy github-action-deploy --project-ref $PROJECT_ID
 ```


### PR DESCRIPTION
### Deploy all functions

```bash
supabase functions deploy
```

Since Supabase CLI [v1.62.0](https://github.com/supabase/cli/releases/tag/v1.62.0) you can deploy all functions with a single command. This is useful for example when [deploying with GitHub Actions](/docs/guides/functions/cicd-workflow).

Individual function configuration like [JWT verification](/docs/reference/cli/config#functions.function_name.verify_jwt) and [import map location](/docs/reference/cli/config#functions.function_name.import_map) can be set via the `config.toml` file.

```toml
[functions.hello-world]
verify_jwt = false
```