### PR TITLE
fix: disable logs explorer gracefully

### DIFF
--- a/studio/components/interfaces/Settings/Logs/Logs.constants.ts
+++ b/studio/components/interfaces/Settings/Logs/Logs.constants.ts
@@ -1,5 +1,4 @@
 import dayjs from 'dayjs'
-import { IS_PLATFORM } from 'lib/constants'
 import { DatetimeHelper, FilterTableSet, LogTemplate } from '.'
 
 export const LOGS_EXPLORER_DOCS_URL =
@@ -666,5 +665,3 @@ export const TIER_QUERY_LIMITS: {
   TEAM: { text: '28 days', value: 28, unit: 'day', promptUpgrade: true },
   ENTERPRISE: { text: '90 days', value: 90, unit: 'day', promptUpgrade: false },
 }
-
-export const SHOW_O11Y = IS_PLATFORM || process.env.NEXT_PUBLIC_ENABLE_LOGS == 'true'

--- a/studio/components/layouts/ProjectLayout/NavigationBar/NavigationBar.utils.tsx
+++ b/studio/components/layouts/ProjectLayout/NavigationBar/NavigationBar.utils.tsx
@@ -13,7 +13,6 @@ import SVG from 'react-inlinesvg'
 import { ProjectBase } from 'types'
 import { Route } from 'components/ui/ui.types'
 import { BASE_PATH, IS_PLATFORM, PROJECT_STATUS } from 'lib/constants'
-import { SHOW_O11Y } from 'components/interfaces/Settings/Logs'
 
 export const generateToolRoutes = (ref?: string, project?: ProjectBase): Route[] => {
   const isProjectBuilding = project?.status === PROJECT_STATUS.COMING_UP
@@ -97,16 +96,12 @@ export const generateOtherRoutes = (ref?: string, project?: ProjectBase): Route[
           },
         ]
       : []),
-    ...(SHOW_O11Y
-      ? [
-          {
-            key: 'logs',
-            label: 'Logs',
-            icon: <IconList size={18} strokeWidth={2} />,
-            link: ref && (isProjectBuilding ? buildingUrl : `/project/${ref}/logs/explorer`),
-          },
-        ]
-      : []),
+    {
+      key: 'logs',
+      label: 'Logs',
+      icon: <IconList size={18} strokeWidth={2} />,
+      link: ref && (isProjectBuilding ? buildingUrl : `/project/${ref}/logs/explorer`),
+    },
     {
       key: 'api',
       label: 'API Docs',

--- a/studio/pages/api/projects/[ref]/analytics/endpoints/[name].ts
+++ b/studio/pages/api/projects/[ref]/analytics/endpoints/[name].ts
@@ -10,6 +10,11 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
 
   switch (method) {
     case 'GET':
+      if (process.env.NEXT_PUBLIC_ENABLE_LOGS !== 'true') {
+        return res
+          .status(400)
+          .json({ error: { message: '[analytics] is not enabled in supabase/config.toml' } })
+      }
       const missingEnvVars = [
         process.env.LOGFLARE_API_KEY ? null : 'LOGFLARE_API_KEY',
         process.env.LOGFLARE_URL ? null : 'LOGFLARE_URL',


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Always show log explorer page in local studio. When analytics is disabled, shows clearly which config needs to change.

## Additional context

![Screenshot 2023-06-01 at 5 06 03 PM](https://github.com/supabase/supabase/assets/1639722/7695a5b0-9bca-43c8-8be2-684403cd1874)

