### PR TITLE
docs(auth): add note for RLS policies required for upsert

### DIFF
--- a/apps/docs/pages/guides/auth/row-level-security.mdx
+++ b/apps/docs/pages/guides/auth/row-level-security.mdx
@@ -104,6 +104,8 @@ create policy "Users can update their own profiles."
 2. Enables RLS.
 3. Creates a policy which allows logged in users to update their own data.
 
+**Note:** If you want to use upsert operations, the user needs to have `INSERT`, `UPDATE`, and `SELECT` permissions.
+
 ### Only anon or authenticated access
 
 You can add a Postgres role


### PR DESCRIPTION
Adds a short note that UPSERT operations require update, insert, and select permissions which can trip people up (https://github.com/orgs/supabase/discussions/6765)

## What kind of change does this PR introduce?

docs