### PR TITLE
fix(ResourceContent): add null coalesce on resourceDefinition, add types and tests

### DIFF
--- a/studio/components/interfaces/Docs/Docs.types.ts
+++ b/studio/components/interfaces/Docs/Docs.types.ts
@@ -1,4 +1,4 @@
-export type showApiKey = {
+export type ShowApiKey = {
   key: string
   name: string
 }

--- a/studio/components/interfaces/Docs/LangSelector.tsx
+++ b/studio/components/interfaces/Docs/LangSelector.tsx
@@ -3,15 +3,15 @@ import { Button, Dropdown, IconKey } from 'ui'
 import { checkPermissions } from 'hooks'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 
-import { showApiKey } from 'components/interfaces/Docs/Docs.types'
+import { ShowApiKey } from 'components/interfaces/Docs/Docs.types'
 
 const DEFAULT_KEY = { name: 'hide', key: 'SUPABASE_KEY' }
 
 interface Props {
   selectedLang: string
   setSelectedLang: (selectedLang: string) => void
-  showApiKey: showApiKey
-  setShowApiKey: (showApiKey: showApiKey) => void
+  showApiKey: ShowApiKey
+  setShowApiKey: (showApiKey: ShowApiKey) => void
   apiKey: string | undefined
   autoApiService: any
 }

--- a/studio/components/interfaces/Docs/ResourceContent.test.tsx
+++ b/studio/components/interfaces/Docs/ResourceContent.test.tsx
@@ -62,6 +62,21 @@ describe('ResourceContent', () => {
     expect(() => render(<ResourceContent {...props} />)).not.toThrow()
   })
 
+  it.each([undefined, null])(
+    "should not throw when 'paths./{resourceId}' is %p",
+    (value: undefined | null) => {
+      // Arbitrary value, but we are intentionally nulling out `/resourceId` in the paths object
+      const resourceId = 'resourceId'
+      const props = buildProps({
+        paths: {
+          [`/${resourceId}`]: value,
+        },
+      })
+
+      expect(() => render(<ResourceContent {...props} />)).not.toThrow()
+    }
+  )
+
   it('should render', () => {
     const props = buildProps()
 

--- a/studio/components/interfaces/Docs/ResourceContent.test.tsx
+++ b/studio/components/interfaces/Docs/ResourceContent.test.tsx
@@ -1,0 +1,72 @@
+import ResourceContent, { ResourceContentProps } from 'components/interfaces/Docs/ResourceContent'
+import { render } from 'tests/helpers'
+import { screen } from '@testing-library/react'
+
+describe('ResourceContent', () => {
+  const defaultResourceId = 'foo'
+
+  const buildProps = (overrides?: Partial<ResourceContentProps>): ResourceContentProps => {
+    const resourceId = overrides?.resourceId ?? defaultResourceId
+    return {
+      autoApiService: {},
+      resourceId,
+      resources: {},
+      definitions: {
+        [resourceId]: {
+          description: 'bar',
+        },
+      },
+      paths: {
+        [`/${resourceId}`]: {},
+      },
+      selectedLang: 'js',
+      apiKey: '4e06c649-fe79-514e-95dd-81aff148c258',
+      refreshDocs: () => {},
+      ...overrides,
+    }
+  }
+
+  it.each([undefined, null])('should not render when paths is %p', (paths: undefined | null) => {
+    const props = buildProps({ paths })
+
+    const { container } = render(<ResourceContent {...props} />)
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it.each([undefined, null, ''])(
+    'should not render when resourceId is %p',
+    (resourceId: undefined | null | string) => {
+      const props = buildProps({ resourceId: resourceId as string | undefined })
+
+      const { container } = render(<ResourceContent {...props} />)
+
+      expect(container).toBeEmptyDOMElement()
+    }
+  )
+
+  it.each([undefined, null])(
+    'should not render when definitions is is %p',
+    (definitions: undefined | null) => {
+      const props = buildProps({ definitions })
+
+      const { container } = render(<ResourceContent {...props} />)
+
+      expect(container).toBeEmptyDOMElement()
+    }
+  )
+
+  it.each([undefined, null])("should not throw when 'definitions.resourceId' is %p", () => {
+    const props = buildProps({ definitions: {} })
+
+    expect(() => render(<ResourceContent {...props} />)).not.toThrow()
+  })
+
+  it('should render', () => {
+    const props = buildProps()
+
+    render(<ResourceContent {...props} />)
+
+    expect(() => screen.getByText('Description')).not.toThrow()
+  })
+})

--- a/studio/components/interfaces/Docs/ResourceContent.tsx
+++ b/studio/components/interfaces/Docs/ResourceContent.tsx
@@ -4,6 +4,17 @@ import Param from 'components/to-be-cleaned/Docs/Param'
 import Description from 'components/to-be-cleaned/Docs/Description'
 import { IconTable } from 'ui'
 
+export interface ResourceContentProps {
+  autoApiService: any
+  resourceId: string | undefined
+  resources: any
+  definitions: any
+  paths: any
+  selectedLang: string
+  apiKey: string
+  refreshDocs: () => void
+}
+
 const ResourceContent = ({
   autoApiService,
   resourceId,
@@ -11,18 +22,20 @@ const ResourceContent = ({
   definitions,
   paths,
   selectedLang,
-  showApiKey,
+  apiKey,
   refreshDocs,
-}: any) => {
-  if (!paths || !definitions) return null
+}: ResourceContentProps) => {
+  if (!paths || !definitions || !resourceId) {
+    return null
+  }
 
-  const keyToShow = !!showApiKey ? showApiKey : 'SUPABASE_KEY'
+  const keyToShow = !!apiKey ? apiKey : 'SUPABASE_KEY'
   const resourcePaths = paths[`/${resourceId}`]
   const resourceDefinition = definitions[resourceId]
   const resourceMeta = resources[resourceId]
-  const description = resourceDefinition.description || null
+  const description = resourceDefinition?.description || null
   const methods = Object.keys(resourcePaths).map((x) => x.toUpperCase())
-  const properties = Object.entries(resourceDefinition.properties || []).map(([id, val]: any) => ({
+  const properties = Object.entries(resourceDefinition?.properties || []).map(([id, val]: any) => ({
     ...val,
     id,
     required: resourceDefinition?.required?.includes(id),

--- a/studio/components/interfaces/Docs/ResourceContent.tsx
+++ b/studio/components/interfaces/Docs/ResourceContent.tsx
@@ -30,7 +30,7 @@ const ResourceContent = ({
   }
 
   const keyToShow = !!apiKey ? apiKey : 'SUPABASE_KEY'
-  const resourcePaths = paths[`/${resourceId}`]
+  const resourcePaths = paths[`/${resourceId}`] || {}
   const resourceDefinition = definitions[resourceId]
   const resourceMeta = resources[resourceId]
   const description = resourceDefinition?.description || null

--- a/studio/components/interfaces/TableGridEditor/APIDocumentationPanel.tsx
+++ b/studio/components/interfaces/TableGridEditor/APIDocumentationPanel.tsx
@@ -10,6 +10,7 @@ import ActionBar from './SidePanelEditor/ActionBar'
 import { useProjectApiQuery } from 'data/config/project-api-query'
 import { useProjectJsonSchemaQuery } from 'data/docs/project-json-schema-query'
 import { snakeToCamel } from 'lib/helpers'
+import { ShowApiKey } from 'components/interfaces/Docs/Docs.types'
 
 interface APIDocumentationPanelProps {
   visible: boolean
@@ -27,8 +28,8 @@ const APIDocumentationPanel = ({ visible, onClose }: APIDocumentationPanelProps)
   const { data: settings } = useProjectApiQuery({ projectRef: ref })
 
   const DEFAULT_KEY = { name: 'hide', key: 'SUPABASE_KEY' }
-  const [selectedLang, setSelectedLang] = useState<any>('js')
-  const [showApiKey, setShowApiKey] = useState<any>(DEFAULT_KEY)
+  const [selectedLang, setSelectedLang] = useState<string>('js')
+  const [showApiKey, setShowApiKey] = useState<ShowApiKey>(DEFAULT_KEY)
 
   const tables = meta.tables.list()
   const autoApiService = {
@@ -41,6 +42,7 @@ const APIDocumentationPanel = ({ visible, onClose }: APIDocumentationPanelProps)
   const anonKey = apiService?.service_api_keys.find((x) => x.name === 'anon key')
     ? apiService.defaultApiKey
     : undefined
+
   const resources = getResourcesFromJsonSchema(jsonSchema)
 
   function getResourcesFromJsonSchema(value: any) {
@@ -114,7 +116,7 @@ const APIDocumentationPanel = ({ visible, onClose }: APIDocumentationPanelProps)
                       resources={resources}
                       definitions={jsonSchema.definitions}
                       paths={jsonSchema.paths}
-                      showApiKey={showApiKey.key}
+                      apiKey={showApiKey.key}
                       refreshDocs={async () => await refetch()}
                     />
                   )}

--- a/studio/jest.config.js
+++ b/studio/jest.config.js
@@ -2,6 +2,7 @@ module.exports = {
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   moduleDirectories: ['<rootDir>', 'node_modules'],
   setupFiles: ['jest-canvas-mock', './tests/setup/radix'],
+  setupFilesAfterEnv: ['@testing-library/jest-dom/extend-expect'],
   testEnvironment: 'jsdom',
   testTimeout: 10000,
   testRegex: '(.*\\.test.(js|jsx|ts|tsx)$)',

--- a/studio/pages/project/[ref]/api/index.tsx
+++ b/studio/pages/project/[ref]/api/index.tsx
@@ -140,7 +140,7 @@ const DocView: FC<any> = observer(({}) => {
               resources={PageState.resources}
               definitions={definitions}
               paths={paths}
-              showApiKey={showApiKey.key}
+              apiKey={showApiKey.key}
               refreshDocs={refreshDocs}
             />
           ) : rpc ? (


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes #14766

## What is the current behavior?

The current behavior causes a runtime exception when the `resourceDefinition` object in `ResourceContent.tsx` is accessed w/o properly null checking it first. It seems like this was just an oversight, since there's a null check for this object later on in the `ResourceContent` component.

## What is the new behavior?

I added some types to this component and null coalescing on the `resourceDefinition` object since it might not be present in a custom schema it seems. Additionally, the `resourceId` seems like it should be a required prop, but based on existing usage, is nullable:

https://github.com/supabase/supabase/blob/1d5a53e8fd2671f64f75c69e334e0e85e3ca5a9c/studio/components/interfaces/TableGridEditor/APIDocumentationPanel.tsx#L113

I typed it as `string | undefined` so consumers must pass a value to it, but added a falsy check since you can't index into an object with `undefined`. Let me know if you think we should change this back to the previous behavior and add a `@ts-ignore` or some other behavior.

## Additional context

N/A
