### PR TITLE
Check if value is an object before returning it

### DIFF
--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.utils.ts
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.utils.ts
@@ -84,7 +84,7 @@ export const validateFields = (fields: RowField[]) => {
 
 const parseValue = (originalValue: any, format: string) => {
   try {
-    if (originalValue === null || originalValue.length === 0) {
+    if ((originalValue === null || originalValue.length === 0) && typeof originalValue !== 'object') {
       return originalValue
     } else if (typeof originalValue === 'number' || !format) {
       return originalValue


### PR DESCRIPTION
To test, note the difference between handling of these two json objects: 

```
 {
  "width": 0,
  "height": 0,
  "length": 0,
  "weight": 0
}
```


```
{
  "glossary": {
    "title": "parent title",
    "subItem": {
      "title": "subItem title"
    }
  }
}
```

The first one has .length of 0 and so gets returned right away, the second one has length undefined (yay javascript!) and moves on to get stringified. 

This PR lets objects move on to that step to be stringified. 