### PR TITLE
feat: add replication status as a report within the dashboard's SQL snippets

### DIFF
--- a/studio/components/interfaces/SQLEditor/SQLEditor.constants.ts
+++ b/studio/components/interfaces/SQLEditor/SQLEditor.constants.ts
@@ -1158,6 +1158,23 @@ as $$
 $$;
 `.trim(),
   },
+  {
+    id: 21,
+    type: 'template',
+    title: 'Replication status report',
+    description: 'See the status of your replication slots and replication lag.',
+    sql: `-- Replication status report
+
+SELECT
+  s.slot_name,
+  s.active,
+  COALESCE(r.state, 'N/A') as state,
+  COALESCE(r.client_addr, null) as replication_client_address,
+  GREATEST(0, ROUND((redo_lsn-restart_lsn)/1024/1024/1024, 2)) as replication_lag_gb
+FROM pg_control_checkpoint(), pg_replication_slots s
+LEFT JOIN pg_stat_replication r ON (r.pid = s.active_pid);
+`,
+  },
 ]
 
 export const SQL_SNIPPET_SCHEMA_VERSION = '1.0'


### PR DESCRIPTION
* Helps users debug the status of their own replication slots and setups

Context: https://supabase.slack.com/archives/C055J62DHH6/p1685968115096609?thread_ts=1685708088.569879&cid=C055J62DHH6

This brings up decently intuitive results results such as

```
 slot_name  | active |   state   | replication_client_address | replication_lag_gb
------------+--------+-----------+----------------------------+-----------
 datastream | t      | catchup   | 10.101.10.101              |      0.09
```
```
 slot_name  | active |   state   | replication_client_address | replication_lag_gb
------------+--------+-----------+----------------------------+-----------
 datastream | t      | streaming | 10.101.10.101              |     -0.01
```