### PR TITLE
self hosting improvements

### DIFF
--- a/apps/docs/pages/guides/self-hosting.mdx
+++ b/apps/docs/pages/guides/self-hosting.mdx
@@ -9,7 +9,74 @@ There are several ways to use Supabase:
 
 - [Supabase Cloud](https://app.supabase.com): you don't need to deploy anything. We will manage and scale your infrastructure.
 - [Docker](/docs/guides/self-hosting/docker): deploy to your own infrastructure.
-- Kubernetes: coming soon.
+
+### Community
+
+There are several community-driven projects to help you deploy Supabase. We encourage you to try them out and contribute back to the community.
+
+<div className="grid md:grid-cols-12 gap-4 not-prose">
+  {community.map((x) => (
+    <div className="md:col-span-6 xl:col-span-3" key={x.href}>
+      <Link href={x.href} passHref>
+        <a>
+          <GlassPanel title={x.name}>{x.description}</GlassPanel>
+        </a>
+      </Link>
+    </div>
+  ))}
+</div>
+
+export const community = [
+  {
+    name: 'Kubernetes',
+    description: 'Helm charts to deploy a Supabase on Kubernetes.',
+    href: 'https://github.com/supabase-community/supabase-kubernetes',
+  },
+  {
+    name: 'Terraform',
+    description: 'A community-driven Terraform Provider for Supabase.',
+    href: 'https://github.com/supabase-community/supabase-terraform',
+  },
+  {
+    name: 'Traefik',
+    description: 'A self-hosted Supabase setup with Traefik as a reverse proxy.',
+    href: 'https://github.com/supabase-community/supabase-traefik',
+  },
+  {
+    name: 'AWS',
+    description: 'A CloudFormation template for Supabase.',
+    href: 'https://github.com/supabase-community/supabase-on-aws',
+  },
+]
+
+### Third-party
+
+The following third-party providers have shown consistent support for the self-hosted version of Supabase:.
+
+<div className="grid md:grid-cols-12 gap-4 not-prose">
+  {external.map((x) => (
+    <div className="md:col-span-6" key={x.href}>
+      <Link href={x.href} passHref>
+        <a>
+          <GlassPanel title={x.name}>{x.description}</GlassPanel>
+        </a>
+      </Link>
+    </div>
+  ))}
+</div>
+
+export const external = [
+  {
+    name: 'Digital Ocean',
+    description: 'Deploys using Terraform.',
+    href: 'https://supabase-on-do.product-docs.pages.dev/developer-center/hosting-supabase-on-digitalocean/',
+  },
+  {
+    name: 'StackGres',
+    description: 'Deploys using Kubernetes.',
+    href: 'https://stackgres.io/blog/running-supabase-on-top-of-stackgres/',
+  },
+]
 
 ## Architecture
 
@@ -53,8 +120,8 @@ to run automatically when starting the database container.
 We recommend installing all extensions into an `extensions` schema. This will keep your API clean,
 since all tables in the `public` schema are exposed via the API.
 
-```sql
 {/* prettier-ignore */}
+```sql
 create schema if not exists extensions;
 create extension if not exists "uuid-ossp" with schema extensions;
 create extension if not exists pgcrypto with schema extensions;
@@ -145,15 +212,6 @@ If you have decoupled your database from the middleware, then you should be able
 Supabase is evolving fast, and we'll continue to improve the migration strategy as part of our core offering.
 
 We realize that database migrations are difficult, and this is one of the problems we plan to make easy for developers.
-
-## Deployment options
-
-While Supabase officially supports Docker, we have several other deployment strategies managed by the community:
-
-- [supabase-docker](/docs/guides/self-hosting/docker) (Official)
-- [supabase-kubernetes](https://github.com/supabase-community/supabase-kubernetes) (Unofficial)
-- [supabase-terraform](https://github.com/supabase-community/supabase-terraform) (Unofficial)
-- [supabase-traefik](https://github.com/supabase-community/supabase-traefik) (Unofficial)
 
 export const Page = ({ children }) => <Layout meta={meta} children={children} />
 

--- a/apps/docs/pages/guides/self-hosting/docker.mdx
+++ b/apps/docs/pages/guides/self-hosting/docker.mdx
@@ -81,6 +81,8 @@ You can now access your services at the following URLs:
 - REST: `https://<your-domain>/proxy/rest/v1/`
 - Auth: `https://<your-domain>/proxy/auth/v1/`
 - Storage: `https://<your-domain>/proxy/storage/v1/`
+- Functions: `https://<your-domain>/proxy/functions/v1/`
+- Realtime: `https://<your-domain>/proxy/realtime/v1/`
 - Dashboard: `https://<your-domain>/` (if you uncommented the Dashboard section in the Caddyfile)
 
 ## Stop 

--- a/apps/docs/pages/guides/self-hosting/docker.mdx
+++ b/apps/docs/pages/guides/self-hosting/docker.mdx
@@ -5,20 +5,15 @@ export const meta = {
   description: 'Learn how to configure and deploy Supabase with Docker.',
 }
 
-Docker is the easiest way to get started with self-hosted Supabase.
+Docker is the easiest way to get started with self-hosted Supabase. This guide assumes you are running the command from the machine you intend to host from.
 
 ## Before you begin
 
-You need the following installed in your system:
+You need the following installed in your system: [Git](https://git-scm.com/downloads) and Docker ([Windows](https://docs.docker.com/desktop/install/windows-install/), [MacOS](https://docs.docker.com/desktop/install/mac-install/), or [Linux](https://docs.docker.com/desktop/install/linux-install/)).
 
-- [Docker](https://docs.docker.com/engine/install/) and [docker compose](https://docs.docker.com/compose/install/)
-- [Git](https://git-scm.com/downloads)
+## Running Supabase
 
-## Quick Start
-
-### Get the code
-
-Checkout the docker directory in the Supabase repo:
+Running a self-hosted Supabase project is simple. Follow the steps below:
 
 ```sh
 # Get the code
@@ -36,15 +31,21 @@ docker compose up
 
 Now visit [http://localhost:3000](http://localhost:3000) to start using Supabase Studio.
 
-## Securing your setup
+That's everything you need to get started. The rest of this guide will focus on customizing your setup.
+
+## Customizing your setup
 
 While we provided you with some example secrets for getting started, you should NEVER deploy your Supabase setup using the defaults we have provided.
 
-Follow these steps to secure your Docker setup. We strongly recommend using a [secrets manager](../self-hosting#managing-your-secrets) when deploying to production.
+We strongly recommend using a [secrets manager](../self-hosting#managing-your-secrets) when deploying to production, rather than using an `.env` file.
 
 ### Generate API Keys
 
-Use your `JWT_SECRET` to generate a `anon` and `service` API keys using the [JWT generator](../self-hosting#api-keys).
+Create a new `JWT_SECRET` and store it securely. 
+
+Now we can use it to generate a `anon` and `service` API keys by updating the "JWT Secret" and then running "Generate JWT" once for the `SERVICE_KEY` and once for the `ANON_KEY`:
+
+<JwtGenerator />
 
 Replace the values in these files:
 
@@ -64,23 +65,46 @@ Update the `.env` file with your own secrets. In particular, these are required:
 - `SITE_URL`: the base URL of your site.
 - `SMTP_*`: mail server credentials. You can use any SMTP server.
 
-### Securing the Dashboard
 
-The Docker setup doesn't include a management database for managing users and logins. If you plan to deploy the Studio to the web we suggest you put it behind a web proxy with Basic Auth or hide it behind a VPN.
+## Exposing services
 
-## Setting up Edge Functions
+The services running on the machine are not exposed to the internet by default. To do this, we recommend using a reverse proxy such as [NGINX](https://www.nginx.com/) or [Caddy](https://caddyserver.com/).
+
+We have provided an example Caddy configuration in the `docker` folder that you cloned. You can use this as a starting point for your own configuration.
+
+1. Install Caddy using the official [instructions](https://caddyserver.com/docs/install).
+2. Modify the `Caddyfile` at `./docker/deploy/caddy/Caddyfile`.
+  a. Replace `localhost` with your domain.
+  b. Uncomment the "Dashboard" section if you want to expose the Supabase Dashboard. You MUST set a password for this to be secure.
+3. Run `caddy run --config ./docker/deploy/caddy/Caddyfile` to start Caddy.
+
+You can now access your services at the following URLs:
+
+- Supabase Dashboard: `https://<your-domain>/`
+- REST: `https://<your-domain>/proxy/rest/v1/`
+- Auth: `https://<your-domain>/proxy/auth/v1/`
+- Storage: `https://<your-domain>/proxy/storage/v1/`
+
+## Stop 
+
+You can stop Supabase by running `docker compose stop` in same directory as your `docker-compose.yml` file.
+
+## Uninstall
+
+You can stop Supabase by running `docker compose down -v` in same directory as your `docker-compose.yml` file.
+
+## Advanced configuration
+
+Each system can be [configured](../self-hosting#configuration) independently. Some of the most important configuration options are:
+
+- Consider deploying the database to a different server than the rest of the services
+- Update Storage to use S3 instead of the filesystem backend
+- Configure Auth with a production-ready SMTP server
+
+### Setting up Edge Functions
 
 Your Functions are stored in `volumes/functions`. The default setup has a `hello` Function that you can invoke on `http://localhost:8000/functions/v1/hello`. You can add new Functions as `volumes/functions/<Function name>/index.ts`.
 
-## Configuration
-
-Each system can be [configured](../self-hosting#configuration) to suit your particular use-case.
-
-To keep the setup simple, we made some choices that may not be optimal for production:
-
-- the database is in the same machine as the servers
-- Storage uses the filesystem backend instead of S3
-- Auth should be configured with a production-ready SMTP server
 
 ### Using an external database
 
@@ -111,14 +135,6 @@ However, you might miss important log messages such as database errors. Configur
 ### File storage backend on macOS
 
 By default, Storage backend is set to `file`, which is to use local files as the storage backend. To make it work on macOS, you need to choose `VirtioFS` as the Docker container file sharing implementation (in Docker Desktop -> Preferences -> General).
-
-## Deploying
-
-See the following guides to deploy Docker Compose setup using your preferred tool and platform:
-
-- [Docker Swarm](https://docs.docker.com/engine/swarm/stack-deploy/)
-- [AWS Fargate](https://aws.amazon.com/blogs/containers/deploy-applications-on-amazon-ecs-using-docker-compose/)
-- [Using Kompose for Kubernetes](https://kubernetes.io/docs/tasks/configure-pod-container/translate-compose-kubernetes/)
 
 ## Next steps
 

--- a/apps/docs/pages/guides/self-hosting/docker.mdx
+++ b/apps/docs/pages/guides/self-hosting/docker.mdx
@@ -30,23 +30,23 @@ cp .env.example .env
 docker compose up
 ```
 
-Now visit [http://localhost:3000](http://localhost:3000) to start using Supabase Studio.
+Now visit [localhost:3000](http://localhost:3000) to start using Supabase Studio.
 
-That's everything you need to get started. The rest of this guide will focus on customizing your setup.
+That's everything you need to get started. The rest of this guide will help you to customize your setup.
 
-## Customizing your setup
+## Securing your setup
 
 While we provided you with some example secrets for getting started, you should NEVER deploy your Supabase setup using the defaults we have provided.
-
-We strongly recommend using a [secrets manager](../self-hosting#managing-your-secrets) when deploying to production, rather than using an `.env` file.
 
 ### Generate API Keys
 
 Create a new `JWT_SECRET` and store it securely. 
 
-Now we can use it to generate a `anon` and `service` API keys by updating the "JWT Secret" and then running "Generate JWT" once for the `SERVICE_KEY` and once for the `ANON_KEY`:
+We can use your JWT Secret to generate new `anon` and `service` API keys using the form below. Update the "JWT Secret" and then run "Generate JWT" once for the `SERVICE_KEY` and once for the `ANON_KEY`:
 
 <JwtGenerator />
+
+### Update API Keys
 
 Replace the values in these files:
 
@@ -65,7 +65,6 @@ Update the `.env` file with your own secrets. In particular, these are required:
 - `JWT_SECRET`: used by PostgREST and GoTrue, among others.
 - `SITE_URL`: the base URL of your site.
 - `SMTP_*`: mail server credentials. You can use any SMTP server.
-
 
 ## Exposing services
 
@@ -134,11 +133,6 @@ However, you might miss important log messages such as database errors. Configur
 ### File storage backend on macOS
 
 By default, Storage backend is set to `file`, which is to use local files as the storage backend. To make it work on macOS, you need to choose `VirtioFS` as the Docker container file sharing implementation (in Docker Desktop -> Preferences -> General).
-
-## Next steps
-
-- Got a question? [Ask here](https://github.com/supabase/supabase/discussions).
-- Sign in: [app.supabase.com](https://app.supabase.com)
 
 export const Page = ({ children }) => <Layout meta={meta} children={children} />
 

--- a/apps/docs/pages/guides/self-hosting/docker.mdx
+++ b/apps/docs/pages/guides/self-hosting/docker.mdx
@@ -74,8 +74,8 @@ We have provided an example Caddy configuration in the `docker` folder that you 
 
 1. Install Caddy using the official [instructions](https://caddyserver.com/docs/install).
 2. Modify the `Caddyfile` at `./docker/deploy/caddy/Caddyfile`.
-  a. Replace `localhost` with your domain.
-  b. Uncomment the "Dashboard" section if you want to expose the Supabase Dashboard. You MUST set a password for this to be secure.
+    1. Replace `localhost` with your domain.
+    2. Uncomment the "Dashboard" section if you want to expose the Supabase Dashboard. You **MUST** set a password for this to be secure.
 3. Run `caddy run --config ./docker/deploy/caddy/Caddyfile` to start Caddy.
 
 You can now access your services at the following URLs:

--- a/apps/docs/pages/guides/self-hosting/docker.mdx
+++ b/apps/docs/pages/guides/self-hosting/docker.mdx
@@ -3,6 +3,7 @@ import Layout from '~/layouts/DefaultGuideLayout'
 export const meta = {
   title: 'Self-Hosting with Docker',
   description: 'Learn how to configure and deploy Supabase with Docker.',
+  subtitle: 'Learn how to configure and deploy Supabase with Docker.',
 }
 
 Docker is the easiest way to get started with self-hosted Supabase. This guide assumes you are running the command from the machine you intend to host from.
@@ -68,9 +69,7 @@ Update the `.env` file with your own secrets. In particular, these are required:
 
 ## Exposing services
 
-The services running on the machine are not exposed to the internet by default. To do this, we recommend using a reverse proxy such as [NGINX](https://www.nginx.com/) or [Caddy](https://caddyserver.com/).
-
-We have provided an example Caddy configuration in the `docker` folder that you cloned. You can use this as a starting point for your own configuration.
+The services running on the machine are not exposed to the internet by default. We recommend using a reverse proxy such as [NGINX](https://www.nginx.com/) or [Caddy](https://caddyserver.com/) if you want to expose the services publicly:
 
 1. Install Caddy using the official [instructions](https://caddyserver.com/docs/install).
 2. Modify the `Caddyfile` at `./docker/deploy/caddy/Caddyfile`.
@@ -80,10 +79,10 @@ We have provided an example Caddy configuration in the `docker` folder that you 
 
 You can now access your services at the following URLs:
 
-- Supabase Dashboard: `https://<your-domain>/`
 - REST: `https://<your-domain>/proxy/rest/v1/`
 - Auth: `https://<your-domain>/proxy/auth/v1/`
 - Storage: `https://<your-domain>/proxy/storage/v1/`
+- Dashboard: `https://<your-domain>/` (if you uncommented the Dashboard section in the Caddyfile)
 
 ## Stop 
 

--- a/docker/deploy/caddy/Caddyfile
+++ b/docker/deploy/caddy/Caddyfile
@@ -1,0 +1,19 @@
+localhost
+
+## API Server
+##   You can change this route to anything, however if you use /api/ then you will have conflicts 
+##   with the NextJS API routes in the Dashboard
+handle_path /proxy/* {
+    uri replace /proxy/ /
+    reverse_proxy 127.0.0.1:8000
+}
+
+# ## Dashboard
+# ##   MAKE SURE YOU CHANGE THE PASSWORD BELOW BEFORE UNCOMMENTING THIS SECTION.
+# ##   You can create a new password by running `caddy hash-password`
+# handle_path /* {
+#     reverse_proxy 127.0.0.1:3000
+#     basicauth /* {
+#         supabase $2a$14$24w8H5T3D4hC74y6rdxgYOYqTna7K.zWbts/AheHuilnRrdPFGGhK ## IMPORTANT: CHANGE THIS PASSWORD
+#     }
+# }


### PR DESCRIPTION
- Self Hosted page: https://docs-git-docs-self-hosting-kaizen-supabase.vercel.app/docs/guides/self-hosting
- Docker guide: https://docs-git-docs-self-hosting-kaizen-supabase.vercel.app/docs/guides/self-hosting/docker
  - Cleans up page
  - Adds instructions on exposing services using Caddy