### PR TITLE
docs: fix property names when acquiring counts

### DIFF
--- a/apps/docs/pages/guides/database/sql-to-api.mdx
+++ b/apps/docs/pages/guides/database/sql-to-api.mdx
@@ -71,7 +71,7 @@ where team_id = 'NYM';
 ```
 
 ```js
-const { data, error } = await supabase
+const { count, error } = await supabase
   .from('players')
   .select('*', { count: 'exact', head: true }) // exact, planned, or executed
   .eq('team_id', 'NYM')


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

If you get `data` as documented, you get `data = null` because `head: true`. To get the count, you need to retrieve the `count` property.

## What is the new behavior?

Users will know how to obtain a count.

