### PR TITLE
fix: omit `columns` when listing all tables

### DIFF
--- a/studio/components/interfaces/Database/Tables/ColumnList.tsx
+++ b/studio/components/interfaces/Database/Tables/ColumnList.tsx
@@ -1,8 +1,8 @@
-import { FC, useState } from 'react'
+import { FC, useEffect, useState } from 'react'
 import { observer } from 'mobx-react-lite'
 import * as Tooltip from '@radix-ui/react-tooltip'
 import { Input, Button, IconSearch, IconPlus, IconChevronLeft, IconEdit3, IconTrash } from 'ui'
-import type { PostgresTable } from '@supabase/postgres-meta'
+import type { PostgresColumn, PostgresTable } from '@supabase/postgres-meta'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 
 import { useStore, checkPermissions } from 'hooks'
@@ -26,11 +26,19 @@ const ColumnList: FC<Props> = ({
 }) => {
   const { meta } = useStore()
   const [filterString, setFilterString] = useState<string>('')
+  const [selectedTableColumns, setSelectedTableColumns] = useState<PostgresColumn[]>([])
+
+  useEffect(() => {
+    (async () => {
+      const res = await meta.tables.loadById(selectedTable.id) as { columns: PostgresColumn[] }
+      setSelectedTableColumns(res.columns)
+    })()
+  }, [selectedTable])
+
   const columns =
     (filterString.length === 0
-      ? selectedTable.columns
-      : selectedTable.columns?.filter((column: any) => column.name.includes(filterString))) ?? []
-
+      ? selectedTableColumns
+      : selectedTableColumns?.filter((column: any) => column.name.includes(filterString))) ?? []
   const isLocked = meta.excludedSchemas.includes(selectedTable.schema ?? '')
   const canUpdateColumns = checkPermissions(PermissionAction.TENANT_SQL_ADMIN_WRITE, 'columns')
 

--- a/studio/components/interfaces/Database/Tables/TableList.tsx
+++ b/studio/components/interfaces/Database/Tables/TableList.tsx
@@ -216,7 +216,7 @@ const TableList: FC<Props> = ({
                       style={{ paddingTop: 3, paddingBottom: 3 }}
                       onClick={() => onOpenTable(x)}
                     >
-                      {x.columns.length} columns
+                      Columns
                     </Button>
 
                     <Tooltip.Root delayDuration={0}>

--- a/studio/components/interfaces/TableGridEditor/TableGridEditor.tsx
+++ b/studio/components/interfaces/TableGridEditor/TableGridEditor.tsx
@@ -200,13 +200,17 @@ const TableGridEditor = ({
   useEffect(() => {
     (async () => {
       if (entityType?.type === ENTITY_TYPE.TABLE) {
-        setSelectedTableColumns((await meta.tables.loadById(selectedTable.id) as any).columns)
+        const { columns } = await meta.tables.loadById(selectedTable.id) as { columns: PostgresColumn[] }
+        setSelectedTableColumns(columns)
       } else if (entityType?.type === ENTITY_TYPE.VIEW) {
-        setSelectedTableColumns((await meta.views.loadById(selectedTable.id) as any).columns)
+        const { columns } = await meta.views.loadById(selectedTable.id) as { columns: PostgresColumn[] }
+        setSelectedTableColumns(columns)
       } else if (entityType?.type === ENTITY_TYPE.MATERIALIZED_VIEW) {
-        setSelectedTableColumns((await meta.materializedViews.loadById(selectedTable.id) as any).columns)
+        const { columns } = await meta.materializedViews.loadById(selectedTable.id) as { columns: PostgresColumn[] }
+        setSelectedTableColumns(columns)
       } else if (entityType?.type === ENTITY_TYPE.FOREIGN_TABLE) {
-        setSelectedTableColumns((await meta.foreignTables.loadById(selectedTable.id) as any).columns)
+        const { columns } = await meta.foreignTables.loadById(selectedTable.id) as { columns: PostgresColumn[] }
+        setSelectedTableColumns(columns)
       }
     })()
     if (selectedTable !== undefined && selectedTable.id !== undefined && isVaultEnabled) {
@@ -291,8 +295,8 @@ const TableGridEditor = ({
   const onSelectEditColumn = async (name: string) => {
     // For some reason, selectedTable here is stale after adding a table
     // temporary workaround is to list grab the selected table again
-    const table: any = await meta.tables.loadById(tableId)
-    const column = find(table.columns, { name }) as PostgresColumn
+    const table = await meta.tables.loadById(tableId) as { name: string; columns: PostgresColumn[] }
+    const column = find(table.columns, { name })
     if (column) {
       onEditColumn(column)
     } else {
@@ -303,8 +307,8 @@ const TableGridEditor = ({
   const onSelectDeleteColumn = async (name: string) => {
     // For some reason, selectedTable here is stale after adding a table
     // temporary workaround is to list grab the selected table again
-    const table: any = await meta.tables.loadById(tableId)
-    const column = find(table.columns, { name }) as PostgresColumn
+    const table = await meta.tables.loadById(tableId) as { name: string; columns: PostgresColumn[] }
+    const column = find(table.columns, { name })
     onDeleteColumn(column)
   }
 

--- a/studio/pages/api/pg-meta/[ref]/tables.ts
+++ b/studio/pages/api/pg-meta/[ref]/tables.ts
@@ -35,7 +35,7 @@ const handleGetAll = async (req: NextApiRequest, res: NextApiResponse) => {
   const includeAuthSchema = true // req.query['auth-schema'] === 'true'
   const includeStorageSchema = true // req.query['storage-schema'] === 'true'
 
-  const response = await get(`${PG_META_URL}/tables`, { headers })
+  const response = await get(`${PG_META_URL}/tables?include_columns=false`, { headers })
   if (response.error) {
     return res.status(400).json({ error: response.error })
   }

--- a/studio/stores/common/PostgresMetaInterface.ts
+++ b/studio/stores/common/PostgresMetaInterface.ts
@@ -225,7 +225,13 @@ export default class PostgresMetaInterface<T> implements IPostgresMetaInterface<
   async del(id: number | string, cascade: boolean = false) {
     try {
       const headers = { 'Content-Type': 'application/json', ...this.headers }
-      const url = cascade ? `${this.url}?id=${id}&cascade=${cascade}` : `${this.url}?id=${id}`
+
+      const _url = new URL(this.url)
+      _url.searchParams.set('id', `${id}`)
+      if (cascade) {
+        _url.searchParams.set('cascade', 'true')
+      }
+      const url = _url.toString()
       const response = await delete_<T>(url, {}, { headers })
       if (response.error) throw response.error
 

--- a/studio/stores/pgmeta/MetaStore.ts
+++ b/studio/stores/pgmeta/MetaStore.ts
@@ -204,18 +204,18 @@ export default class MetaStore implements IMetaStore {
       this.rootStore,
       `${API_URL}/projects/${this.projectRef}/api/rest`
     )
-    this.tables = new TableStore(this.rootStore, `${this.baseUrl}/tables`, this.headers)
+    this.tables = new TableStore(this.rootStore, `${this.baseUrl}/tables?include_columns=false`, this.headers)
     this.columns = new ColumnStore(this.rootStore, `${this.baseUrl}/columns`, this.headers)
     this.schemas = new SchemaStore(this.rootStore, `${this.baseUrl}/schemas`, this.headers)
-    this.views = new ViewStore(this.rootStore, `${this.baseUrl}/views`, this.headers)
+    this.views = new ViewStore(this.rootStore, `${this.baseUrl}/views?include_columns=false`, this.headers)
     this.materializedViews = new MaterializedViewStore(
       this.rootStore,
-      `${this.baseUrl}/materialized-views`,
+      `${this.baseUrl}/materialized-views?include_columns=false`,
       this.headers
     )
     this.foreignTables = new ForeignTableStore(
       this.rootStore,
-      `${this.baseUrl}/foreign-tables`,
+      `${this.baseUrl}/foreign-tables?include_columns=false`,
       this.headers
     )
 
@@ -985,7 +985,7 @@ export default class MetaStore implements IMetaStore {
     this.openApi.setUrl(`${API_URL}/projects/${this.projectRef}/api/rest`)
     this.openApi.setHeaders(this.headers)
 
-    this.tables.setUrl(`${this.baseUrl}/tables`)
+    this.tables.setUrl(`${this.baseUrl}/tables?include_columns=false`)
     this.tables.setHeaders(this.headers)
 
     this.columns.setUrl(`${this.baseUrl}/columns`)
@@ -994,10 +994,10 @@ export default class MetaStore implements IMetaStore {
     this.schemas.setUrl(`${this.baseUrl}/schemas`)
     this.schemas.setHeaders(this.headers)
 
-    this.views.setUrl(`${this.baseUrl}/views`)
+    this.views.setUrl(`${this.baseUrl}/views?include_columns=false`)
     this.views.setHeaders(this.headers)
 
-    this.materializedViews.setUrl(`${this.baseUrl}/materialized-views`)
+    this.materializedViews.setUrl(`${this.baseUrl}/materialized-views?include_columns=false`)
     this.materializedViews.setHeaders(this.headers)
 
     this.foreignTables.setUrl(`${this.baseUrl}/foreign-tables`)

--- a/studio/stores/pgmeta/ViewStore.ts
+++ b/studio/stores/pgmeta/ViewStore.ts
@@ -21,7 +21,7 @@ export default class ViewStore extends PostgresMetaInterface<SchemaView> {
 
   async loadById(id: number | string) {
     try {
-      const url = `${this.url}?id=${id}`
+      const url = this.url.includes('?') ? `${this.url}&id=${id}` : `${this.url}?id=${id}`
       const response = await get(url, { headers: this.headers })
       if (response.error) throw response.error
 


### PR DESCRIPTION
Omit `columns` when listing all tables, views, matviews, foreign tables. `columns` is not omitted when querying individual tables.

This was causing `544: upstream request timeout` on projects with a lot of tables & columns.