### PR TITLE
docs(Getting started) - Add warning for risk of accidentally committing auth secrets when used in local testing

### DIFF
--- a/apps/docs/pages/guides/getting-started/local-development.mdx
+++ b/apps/docs/pages/guides/getting-started/local-development.mdx
@@ -421,7 +421,7 @@ enabled = true
 client_id = "env(GITHUB_CLIENT_ID)"
 secret = "env(GITHUB_SECRET)"
 ```
-> ⚠️ WARNING: Make sure to not commit your secrets to your Git repository. To avoid the risk, follow [this guide](docs/guides/cli/using-environment-variables-in-config) for configuring the secrets using environment variables.
+> ⚠️ WARNING: Make sure to not commit your secrets to your Git repository. To avoid the risk, follow [this guide](/docs/guides/cli/using-environment-variables-in-config) for configuring the secrets using environment variables.
 
 For these changes to take effect, you need to run `supabase stop` and `supabase start` again.
 

--- a/apps/docs/pages/guides/getting-started/local-development.mdx
+++ b/apps/docs/pages/guides/getting-started/local-development.mdx
@@ -418,9 +418,10 @@ To use Auth locally, update your project's `supabase/config.toml` file that gets
 ```bash config.toml
 [auth.external.github]
 enabled = true
-client_id = ""
-secret = ""
+client_id = "env(GITHUB_CLIENT_ID)"
+secret = "env(GITHUB_SECRET)"
 ```
+> ⚠️ WARNING: Make sure to not commit your secrets to your Git repository. To avoid the risk, follow [this guide](docs/guides/cli/using-environment-variables-in-config) for configuring the secrets using environment variables.
 
 For these changes to take effect, you need to run `supabase stop` and `supabase start` again.
 

--- a/apps/docs/pages/guides/getting-started/local-development.mdx
+++ b/apps/docs/pages/guides/getting-started/local-development.mdx
@@ -421,7 +421,11 @@ enabled = true
 client_id = "env(GITHUB_CLIENT_ID)"
 secret = "env(GITHUB_SECRET)"
 ```
-> ⚠️ WARNING: Make sure to not commit your secrets to your Git repository. To avoid the risk, follow [this guide](/docs/guides/cli/using-environment-variables-in-config) for configuring the secrets using environment variables.
+<Admonition type="caution">
+  
+Make sure to not commit your secrets to your Git repository. To avoid the risk, follow [this guide](/docs/guides/cli/using-environment-variables-in-config) for configuring the secrets using environment variables.
+  
+</Admonition>
 
 For these changes to take effect, you need to run `supabase stop` and `supabase start` again.
 


### PR DESCRIPTION
Changes the example for using Auth locally to use environment variables by default and adds a note to warn users about the potential risk of committing their secrets to git.

I also added a link to the changes from #14216 where it gets explained. 

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

Currently users following the guide may forget to remove their auth secrets when developing locally. 

## What is the new behavior?

Changed the example to display using environment variables and added warning