### PR TITLE
docs(ai): adds llamaindex integration to nav

### DIFF
--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
@@ -942,6 +942,10 @@ export const ai: NavMenuConstant = {
           name: 'Google Colab',
           url: '/guides/ai/google-colab',
         },
+        {
+          name: 'LlamaIndex',
+          url: '/guides/ai/integrations/llamaindex',
+        },
       ],
     },
   ],

--- a/apps/docs/pages/guides/ai.mdx
+++ b/apps/docs/pages/guides/ai.mdx
@@ -88,19 +88,24 @@ export const integrations = [
     name: 'OpenAI',
     description:
       'OpenAI is an AI research and deployment company. Supabase provides a simple way to use OpenAI in your applications.',
-    href: '/docs/guides/ai/examples/building-chatgpt-plugins',
+    href: '/guides/ai/examples/building-chatgpt-plugins',
   },
   {
     name: 'Hugging Face',
     description:
       "Hugging Face is an open-source provider of NLP technologies. Supabase provides a simple way to use Hugging Face's models in your applications.",
-    href: '/docs/guides/ai/hugging-face',
+    href: '/guides/ai/hugging-face',
   },
   {
     name: 'LangChain',
     description:
       'LangChain is a language-agnostic, open-source, and self-hosted API for text translation, summarization, and sentiment analysis.',
-    href: '/docs/guides/ai/langchain',
+    href: '/guides/ai/langchain',
+  },
+  {
+    name: 'LlamaIndex',
+    description: 'LlamaIndex is a data framework for your LLM applications.',
+    href: '/guides/ai/integrations/llamaindex',
   },
 ]
 


### PR DESCRIPTION
LlamaIndex integration guide + colab has been tested successfully off of master. Adding nav links to it.

https://supabase.com/docs/guides/ai/integrations/llamaindex