### PR TITLE
chore: usage/subscription page improvements

### DIFF
--- a/studio/components/interfaces/BillingV2/Subscription/BillingBreakdown.tsx
+++ b/studio/components/interfaces/BillingV2/Subscription/BillingBreakdown.tsx
@@ -42,7 +42,7 @@ const BillingBreakdown = ({}: BillingBreakdownProps) => {
   const currentPlan = subscription?.plan
   const isUsageBillingEnabled = subscription?.usage_billing_enabled
   const [usageFees, fixedFees] = partition(upcomingInvoice?.lines ?? [], (item) => item.usage_based)
-  const totalUsageFees = usageFees.reduce((a, b) => a + b.amount, 0)
+  const totalUsageFees = +usageFees.reduce((a, b) => a + b.amount, 0).toFixed(2)
 
   const hasExceededAnyLimits =
     isUsageBillingEnabled === false &&
@@ -77,13 +77,14 @@ const BillingBreakdown = ({}: BillingBreakdownProps) => {
           {isUsageBillingEnabled ? (
             <p className="text-sm text-scale-1000">
               Your plan includes a limited amount of included usage. If the usage on your project
-              exceeds these quotas, your subscription will be charged for the extra usage.
+              exceeds these quotas, your subscription will be charged for the overage. It may take
+              up to 24 hours for usage stats to update.
             </p>
           ) : (
             <p className="text-sm text-scale-1000">
               Your plan includes a limited amount of included usage. If the usage on your project
               exceeds these quotas, you may experience restrictions, as you are currently not billed
-              for overusage.
+              for overage. It may take up to 24 hours for usage stats to update.
             </p>
           )}
 
@@ -96,7 +97,7 @@ const BillingBreakdown = ({}: BillingBreakdownProps) => {
                 <Button
                   key="upgrade-button"
                   type="default"
-                  className="ml-4"
+                  className="ml-8"
                   onClick={() =>
                     snap.setPanelKey(
                       currentPlan?.id === 'free' ? 'subscriptionPlan' : 'costControl'
@@ -110,7 +111,7 @@ const BillingBreakdown = ({}: BillingBreakdownProps) => {
               Your project can become unresponsive or enter read only mode.{' '}
               {currentPlan?.id === 'free'
                 ? 'Please upgrade to the Pro plan to ensure that your project remains available.'
-                : 'Please disable spend caps to ensure that your project remains available.'}
+                : 'Please disable spend cap to ensure that your project remains available.'}
             </Alert>
           )}
 
@@ -149,8 +150,8 @@ const BillingBreakdown = ({}: BillingBreakdownProps) => {
                   <div
                     key={metric.key}
                     className={clsx(
-                      'col-span-6 space-y-4 py-4 border-scale-400',
-                      i % 2 === 0 ? 'border-r pr-4' : 'pl-4',
+                      'col-span-12 md:col-span-6 space-y-4 py-4 border-scale-400',
+                      i % 2 === 0 ? 'md:border-r md:pr-4' : 'md:pl-4',
                       i < BILLING_BREAKDOWN_METRICS.length - 2 && 'border-b'
                     )}
                   >

--- a/studio/components/interfaces/BillingV2/Subscription/BillingBreakdown.tsx
+++ b/studio/components/interfaces/BillingV2/Subscription/BillingBreakdown.tsx
@@ -42,7 +42,7 @@ const BillingBreakdown = ({}: BillingBreakdownProps) => {
   const currentPlan = subscription?.plan
   const isUsageBillingEnabled = subscription?.usage_billing_enabled
   const [usageFees, fixedFees] = partition(upcomingInvoice?.lines ?? [], (item) => item.usage_based)
-  const totalUsageFees = +usageFees.reduce((a, b) => a + b.amount, 0).toFixed(2)
+  const totalUsageFees = Number(usageFees.reduce((a, b) => a + b.amount, 0).toFixed(2))
 
   const hasExceededAnyLimits =
     isUsageBillingEnabled === false &&

--- a/studio/components/interfaces/BillingV2/Subscription/Tier/SubscriptionTier.tsx
+++ b/studio/components/interfaces/BillingV2/Subscription/Tier/SubscriptionTier.tsx
@@ -39,7 +39,7 @@ const SubscriptionTier = ({}: SubscriptionTierProps) => {
           <div className="sticky space-y-6 top-16">
             <p className="text-base">Subscription plan</p>
             <div className="text-sm text-scale-1000">
-              To manage your billing address, emails or tax IDs, head to your{' '}
+              To manage your billing address, emails or Tax ID, head to your{' '}
               <Link href={`/org/${orgSlug}/billing`}>
                 <a>
                   <span className="text-sm text-green-900 transition hover:text-green-1000">

--- a/studio/components/interfaces/BillingV2/Subscription/Tier/SubscriptionTier.tsx
+++ b/studio/components/interfaces/BillingV2/Subscription/Tier/SubscriptionTier.tsx
@@ -41,10 +41,10 @@ const SubscriptionTier = ({}: SubscriptionTierProps) => {
             <div className="text-sm text-scale-1000">
               To manage your billing address, emails or tax IDs, head to your{' '}
               <Link href={`/org/${orgSlug}/billing`}>
-                <a rel="noreferrer">
-                  <p className="text-sm text-green-900 transition hover:text-green-1000">
+                <a>
+                  <span className="text-sm text-green-900 transition hover:text-green-1000">
                     organization settings
-                  </p>
+                  </span>.
                 </a>
               </Link>
             </div>

--- a/studio/components/interfaces/BillingV2/Subscription/Tier/TierUpdateSidePanel.tsx
+++ b/studio/components/interfaces/BillingV2/Subscription/Tier/TierUpdateSidePanel.tsx
@@ -178,7 +178,7 @@ const TierUpdateSidePanel = () => {
                       )}
                     >
                       <div className="text-xs bg-brand-400 text-brand-900 rounded px-2 py-0.5">
-                        Usage based plan
+                        Usage-based plan
                       </div>
                     </div>
                     {isCurrentPlan ? (

--- a/studio/components/interfaces/BillingV2/Usage/Activity.tsx
+++ b/studio/components/interfaces/BillingV2/Usage/Activity.tsx
@@ -8,9 +8,16 @@ export interface ActivityProps {
   startDate: string | undefined
   endDate: string | undefined
   subscription: ProjectSubscriptionResponse | undefined
+  currentBillingCycleSelected: boolean
 }
 
-const Activity = ({ projectRef, subscription, startDate, endDate }: ActivityProps) => {
+const Activity = ({
+  projectRef,
+  subscription,
+  startDate,
+  endDate,
+  currentBillingCycleSelected,
+}: ActivityProps) => {
   const { data: mauData, isLoading: isLoadingMauData } = useDailyStatsQuery({
     projectRef,
     attribute: 'total_auth_billing_period_mau',
@@ -108,9 +115,10 @@ const Activity = ({ projectRef, subscription, startDate, endDate }: ActivityProp
   return (
     <UsageSection
       projectRef={projectRef}
-      categoryKey='activity'
+      categoryKey="activity"
       chartMeta={chartMeta}
       subscription={subscription}
+      currentBillingCycleSelected={currentBillingCycleSelected}
     />
   )
 }

--- a/studio/components/interfaces/BillingV2/Usage/Bandwidth.tsx
+++ b/studio/components/interfaces/BillingV2/Usage/Bandwidth.tsx
@@ -8,9 +8,16 @@ export interface BandwidthProps {
   startDate: string | undefined
   endDate: string | undefined
   subscription: ProjectSubscriptionResponse | undefined
+  currentBillingCycleSelected: boolean
 }
 
-const Bandwidth = ({ projectRef, subscription, startDate, endDate }: BandwidthProps) => {
+const Bandwidth = ({
+  projectRef,
+  subscription,
+  startDate,
+  endDate,
+  currentBillingCycleSelected,
+}: BandwidthProps) => {
   const { data: dbEgressData, isLoading: isLoadingDbEgressData } = useDailyStatsQuery({
     projectRef,
     attribute: 'total_egress_modified',
@@ -47,9 +54,10 @@ const Bandwidth = ({ projectRef, subscription, startDate, endDate }: BandwidthPr
   return (
     <UsageSection
       projectRef={projectRef}
-      categoryKey='bandwidth'
+      categoryKey="bandwidth"
       chartMeta={chartMeta}
       subscription={subscription}
+      currentBillingCycleSelected={currentBillingCycleSelected}
     />
   )
 }

--- a/studio/components/interfaces/BillingV2/Usage/Infrastructure.tsx
+++ b/studio/components/interfaces/BillingV2/Usage/Infrastructure.tsx
@@ -3,7 +3,7 @@ import { DataPoint } from 'data/analytics/constants'
 import { useInfraMonitoringQuery } from 'data/analytics/infra-monitoring-query'
 import dayjs from 'dayjs'
 import Link from 'next/link'
-import { Alert, Button } from 'ui'
+import { Alert, Button, IconBarChart2 } from 'ui'
 import SectionContent from './SectionContent'
 import SectionHeader from './SectionHeader'
 import { COMPUTE_INSTANCE_SPECS, USAGE_CATEGORIES } from './Usage.constants'
@@ -11,35 +11,27 @@ import { getUpgradeUrlFromV2Subscription } from './Usage.utils'
 import UsageBarChart from './UsageBarChart'
 import Panel from 'components/ui/Panel'
 import { useProjectSubscriptionV2Query } from 'data/subscriptions/project-subscription-v2-query'
-import { useMemo } from 'react'
+import { useFlag } from 'hooks'
 
 export interface InfrastructureProps {
   projectRef: string
+  startDate?: string
+  endDate?: string
+  currentBillingCycleSelected: boolean
 }
 
-// [Joshen] Need to update the IO budget chart to show burst mbps and duration next time
-
-const Infrastructure = ({ projectRef }: InfrastructureProps) => {
+const Infrastructure = ({
+  projectRef,
+  startDate,
+  endDate,
+  currentBillingCycleSelected,
+}: InfrastructureProps) => {
+  const enableSubscriptionV2 = useFlag('subscriptionV2')
   const { data: subscription } = useProjectSubscriptionV2Query({ projectRef })
-  const { current_period_start, current_period_end } = subscription ?? {}
-  const startDate = useMemo(() => {
-    return current_period_start ? new Date(current_period_start * 1000).toISOString() : undefined
-  }, [current_period_start])
-
-  const endDate = useMemo(() => {
-    const periodEndDate = current_period_end ? new Date(current_period_end * 1000) : undefined
-    // If end date is in future, set end date to now
-    if (periodEndDate && dayjs(periodEndDate).isAfter(dayjs())) {
-      // LF seems to have an issue with the milliseconds, causes infinite loading sometimes
-      return new Date().toISOString().slice(0, -5) + 'Z'
-    } else if (periodEndDate) {
-      return periodEndDate.toISOString()
-    }
-  }, [current_period_end])
 
   const categoryMeta = USAGE_CATEGORIES.find((category) => category.key === 'infra')
 
-  const upgradeUrl = getUpgradeUrlFromV2Subscription(projectRef, subscription)
+  const upgradeUrl = getUpgradeUrlFromV2Subscription(projectRef, subscription, enableSubscriptionV2)
   const isFreeTier = subscription?.plan?.id === 'free'
   const currentComputeInstance = subscription?.addons.find((addon) =>
     addon.supabase_prod_id.includes('_instance_')
@@ -119,7 +111,7 @@ const Infrastructure = ({ projectRef }: InfrastructureProps) => {
             <SectionContent section={attribute}>
               {attribute.key === 'disk_io_consumption' && (
                 <>
-                  {highestIoBudgetConsumption >= 100 ? (
+                  {currentBillingCycleSelected && highestIoBudgetConsumption >= 100 ? (
                     <Alert withIcon variant="danger" title="IO Budget for today has been used up">
                       <p className="mb-4">
                         Your workload has used up all the burst IO throughput minutes and ran at the
@@ -134,7 +126,7 @@ const Infrastructure = ({ projectRef }: InfrastructureProps) => {
                         </a>
                       </Link>
                     </Alert>
-                  ) : highestIoBudgetConsumption >= 80 ? (
+                  ) : currentBillingCycleSelected && highestIoBudgetConsumption >= 80 ? (
                     <Alert withIcon variant="warning" title="IO Budget for today is running out">
                       <p className="mb-4">
                         Your workload is about to use up all the burst IO throughput minutes during
@@ -153,10 +145,6 @@ const Infrastructure = ({ projectRef }: InfrastructureProps) => {
                   ) : null}
                   <div className="space-y-1">
                     <p>Disk IO Bandwidth</p>
-
-                    <p className="text-sm text-scale-1000">
-                      The disk performance of your workload is determined by the Disk IO bandwidth.
-                    </p>
 
                     {currentComputeInstanceSpecs.maxBandwidth ===
                     currentComputeInstanceSpecs.baseBandwidth ? (
@@ -191,17 +179,20 @@ const Infrastructure = ({ projectRef }: InfrastructureProps) => {
                         {currentComputeInstanceSpecs.baseBandwidth.toLocaleString()} Mbps
                       </p>
                     </div>
-                    <div className="flex items-center justify-between py-1">
-                      <p className="text-xs text-scale-1000">Daily burst time limit</p>
-                      <p className="text-xs">30 mins</p>
-                    </div>
+                    {currentComputeInstanceSpecs.maxBandwidth !==
+                      currentComputeInstanceSpecs.baseBandwidth && (
+                      <div className="flex items-center justify-between py-1">
+                        <p className="text-xs text-scale-1000">Daily burst time limit</p>
+                        <p className="text-xs">30 mins</p>
+                      </div>
+                    )}
                   </div>
                 </>
               )}
               <div className="space-y-1">
                 <div className="flex flex-row justify-between">
                   {attribute.key === 'disk_io_consumption' ? (
-                    <p>IO consumed per {interval === '1d' ? 'day' : 'hour'}</p>
+                    <p>Disk IO consumed per {interval === '1d' ? 'day' : 'hour'}</p>
                   ) : (
                     <p>
                       Max{' '}
@@ -250,8 +241,9 @@ const Infrastructure = ({ projectRef }: InfrastructureProps) => {
                 <Panel>
                   <Panel.Content>
                     <div className="flex flex-col items-center justify-center space-y-2">
-                      <p>No data</p>
-                      <p className="text-sm text-scale-1000">There is no data in period</p>
+                      <IconBarChart2 className="text-scale-1100 mb-2" />
+                      <p className="text-sm">No data in period</p>
+                      <p className="text-sm text-scale-1000">May take a few minutes to show</p>
                     </div>
                   </Panel.Content>
                 </Panel>

--- a/studio/components/interfaces/BillingV2/Usage/SizeAndCounts.tsx
+++ b/studio/components/interfaces/BillingV2/Usage/SizeAndCounts.tsx
@@ -8,9 +8,16 @@ export interface SizeAndCountsProps {
   startDate: string | undefined
   endDate: string | undefined
   subscription: ProjectSubscriptionResponse | undefined
+  currentBillingCycleSelected: boolean
 }
 
-const SizeAndCounts = ({ projectRef, startDate, endDate, subscription }: SizeAndCountsProps) => {
+const SizeAndCounts = ({
+  projectRef,
+  startDate,
+  endDate,
+  subscription,
+  currentBillingCycleSelected,
+}: SizeAndCountsProps) => {
   const { data: dbSizeData, isLoading: isLoadingDbSizeData } = useDailyStatsQuery({
     projectRef,
     attribute: 'total_db_size_bytes',
@@ -61,9 +68,10 @@ const SizeAndCounts = ({ projectRef, startDate, endDate, subscription }: SizeAnd
   return (
     <UsageSection
       projectRef={projectRef}
-      categoryKey='sizeCount'
+      categoryKey="sizeCount"
       chartMeta={chartMeta}
       subscription={subscription}
+      currentBillingCycleSelected={currentBillingCycleSelected}
     />
   )
 }

--- a/studio/components/interfaces/BillingV2/Usage/Usage.constants.tsx
+++ b/studio/components/interfaces/BillingV2/Usage/Usage.constants.tsx
@@ -80,7 +80,7 @@ export const USAGE_CATEGORIES: CategoryMeta[] = [
         anchor: 'disk_io',
         key: 'disk_io_consumption',
         attribute: 'disk_io_consumption',
-        name: 'Disk IO bandwidth',
+        name: 'Disk IO Bandwidth',
         unit: 'percentage',
         links: [
           {
@@ -89,7 +89,7 @@ export const USAGE_CATEGORIES: CategoryMeta[] = [
           },
         ],
         description:
-          'Smaller compute instances (below 4XL) can burst up to their largest throughput and IOPS for 30 minutes in a day. Beyond that, the performance reverts to the baseline. Your disk budget gets replenished throughout the day.',
+          'The disk performance of your workload is determined by the Disk IO bandwidth.\nSmaller compute instances (below 4XL) can burst up to their largest throughput and IOPS for 30 minutes in a day. Beyond that, the performance reverts to the baseline. Your disk budget gets replenished throughout the day.',
         chartDescription: '',
       },
     ],
@@ -103,7 +103,7 @@ export const USAGE_CATEGORIES: CategoryMeta[] = [
         anchor: 'dbEgress',
         key: 'db_egress',
         attribute: 'total_egress_modified',
-        name: 'Database egress',
+        name: 'Database Egress',
         unit: 'bytes',
         description:
           'Contains any outgoing traffic (egress) from your database.\nBilling is based on the total sum of egress in GB throughout your billing period.',
@@ -113,7 +113,7 @@ export const USAGE_CATEGORIES: CategoryMeta[] = [
         anchor: 'storageEgress',
         key: 'storage_egress',
         attribute: 'total_storage_egress',
-        name: 'Storage egress',
+        name: 'Storage Egress',
         unit: 'bytes',
         description:
           'All requests to view and download your storage items go through our CDN. We sum up all outgoing traffic (egress) for storage related requests through our CDN. We do not differentiate between cache and no cache hits.\nBilling is based on the total amount of egress in GB throughout your billing period.',
@@ -166,7 +166,7 @@ export const USAGE_CATEGORIES: CategoryMeta[] = [
         anchor: 'storageSize',
         key: 'storage_size',
         attribute: 'total_storage_size_bytes',
-        name: 'Storage size',
+        name: 'Storage Size',
         chartPrefix: 'Max ',
         unit: 'bytes',
         description:
@@ -177,7 +177,7 @@ export const USAGE_CATEGORIES: CategoryMeta[] = [
         anchor: 'funcCount',
         key: 'func_count',
         attribute: 'total_func_count',
-        name: 'Edge function count',
+        name: 'Edge Function Count',
         chartPrefix: 'Max ',
         unit: 'absolute',
         description:
@@ -217,7 +217,7 @@ export const USAGE_CATEGORIES: CategoryMeta[] = [
         anchor: 'storageImageTransformations',
         key: 'storage_image_render_count',
         attribute: 'total_storage_image_render_count',
-        name: 'Storage image transformations',
+        name: 'Storage Image Transformations',
         unit: 'absolute',
         description:
           'We count all images that were transformed in the billing period, ignoring any transformations.\nUsage example: You transform one image with four different size transformations and another image with just a single transformations. It counts as two, as only two images were transformed.\nBilling is based on the count of (origin) images that used transformations throughout the billing period. Resets every billing cycle.',
@@ -228,7 +228,7 @@ export const USAGE_CATEGORIES: CategoryMeta[] = [
         anchor: 'functionInvocations',
         key: 'func_invocations',
         attribute: 'total_func_invocations',
-        name: 'Edge function invocations',
+        name: 'Edge Function Invocations',
         unit: 'absolute',
         description:
           'Every serverless function invocation independent of response status is counted.\nBilling is based on the sum of all invocations throughout your billing period.',
@@ -238,7 +238,7 @@ export const USAGE_CATEGORIES: CategoryMeta[] = [
         anchor: 'realtimeMessageCount',
         key: 'realtime_message_count',
         attribute: 'total_realtime_message_count',
-        name: 'Realtime message count',
+        name: 'Realtime Message Count',
         unit: 'absolute',
         description:
           "Count of messages going through Realtime.\nUsage example: If you do a database change and 5 clients listen to that change via Realtime, that's 5 messages. If you broadcast a message and 4 clients listen to that, that's 5 messages (1 message sent, 4 received).\nBilling is based on the total amount of messages throughout your billing period.",
@@ -248,11 +248,11 @@ export const USAGE_CATEGORIES: CategoryMeta[] = [
         anchor: 'realtimePeakConnection',
         key: 'realtime_peak_connection',
         attribute: 'total_realtime_peak_connection',
-        name: 'Realtime peak connections',
+        name: 'Realtime Peak Connections',
         chartPrefix: 'Max ',
         unit: 'absolute',
         description:
-          'Total number of successful connections (not connection attempts).\nBilling is based on the maximum amount of concurrent peak connections throughout your billing period.',
+          'Total number of successful connections. Connections attempts are not counted towards usage.\nBilling is based on the maximum amount of concurrent peak connections throughout your billing period.',
         chartDescription: 'The data refreshes every 24 hours.',
       },
     ],

--- a/studio/components/interfaces/BillingV2/Usage/Usage.tsx
+++ b/studio/components/interfaces/BillingV2/Usage/Usage.tsx
@@ -4,10 +4,9 @@ import { useInfraMonitoringQuery } from 'data/analytics/infra-monitoring-query'
 import { useProjectSubscriptionV2Query } from 'data/subscriptions/project-subscription-v2-query'
 import { useProjectUsageQuery } from 'data/usage/project-usage-query'
 import dayjs from 'dayjs'
-import Link from 'next/link'
 import { useMemo, useRef, useState } from 'react'
 import { InView } from 'react-intersection-observer'
-import { Button, IconAlertCircle, IconLoader, Listbox } from 'ui'
+import { IconAlertCircle, IconLoader } from 'ui'
 import { cn } from 'ui/src/utils/cn'
 import Activity from './Activity'
 import Bandwidth from './Bandwidth'
@@ -15,6 +14,8 @@ import Infrastructure from './Infrastructure'
 import SizeAndCounts from './SizeAndCounts'
 import { USAGE_CATEGORIES, USAGE_STATUS } from './Usage.constants'
 import { getUsageStatus } from './Usage.utils'
+import DateRangePicker from 'components/to-be-cleaned/DateRangePicker'
+import { TIME_PERIODS_BILLING, TIME_PERIODS_REPORTS } from 'lib/constants'
 
 export type usageSectionIds = 'infra' | 'bandwidth' | 'sizeCount' | 'activity'
 
@@ -32,36 +33,54 @@ const Usage = () => {
 
   const [activeTab, setActiveTab] = useState<usageSectionIds>('infra')
 
+  const [dateRange, setDateRange] = useState<any>()
+
   const { data: usage } = useProjectUsageQuery({ projectRef: ref })
   const { data: subscription, isLoading: isLoadingSubscription } = useProjectSubscriptionV2Query({
     projectRef: selectedProjectRef,
   })
 
-  const { current_period_start, current_period_end } = subscription ?? {}
+  const currentBillingCycleSelected = useMemo(() => {
+    // Selected by default
+    if (!dateRange?.period_start || !dateRange?.period_end || !subscription) return true
+
+    const { current_period_start, current_period_end } = subscription
+
+    return (
+      dayjs(dateRange.period_start.date).isSame(new Date(current_period_start * 1000)) &&
+      dayjs(dateRange.period_end.date).isSame(new Date(current_period_end * 1000))
+    )
+  }, [dateRange, subscription])
 
   const startDate = useMemo(() => {
-    return current_period_start ? new Date(current_period_start * 1000).toISOString() : undefined
-  }, [current_period_start])
-
-  const endDate =
-    current_period_end !== undefined ? new Date(current_period_end * 1000).toISOString() : undefined
-
-  const dailyStatsEndDate = useMemo(() => {
     // If end date is in future, set end date to now
-    if (endDate && dayjs(endDate).isAfter(dayjs())) {
+    if (!dateRange?.period_start?.date) {
+      return undefined
+    } else {
+      // LF seems to have an issue with the milliseconds, causes infinite loading sometimes
+      return new Date(dateRange?.period_start?.date).toISOString().slice(0, -5) + 'Z'
+    }
+  }, [dateRange, subscription])
+
+  const endDate = useMemo(() => {
+    // If end date is in future, set end date to now
+    if (dateRange?.period_end?.date && dayjs(dateRange.period_end.date).isAfter(dayjs())) {
       // LF seems to have an issue with the milliseconds, causes infinite loading sometimes
       return new Date().toISOString().slice(0, -5) + 'Z'
-    } else if (endDate) {
-      return endDate
+    } else if (dateRange?.period_end?.date) {
+      // LF seems to have an issue with the milliseconds, causes infinite loading sometimes
+      return new Date(dateRange.period_end.date).toISOString().slice(0, -5) + 'Z'
     }
-  }, [endDate])
+  }, [dateRange, subscription])
+
+  console.log({ startDate, endDate })
 
   const { data: ioBudgetData } = useInfraMonitoringQuery({
     projectRef: selectedProjectRef,
     attribute: 'disk_io_budget',
     interval: '1d',
-    startDate,
-    endDate,
+    startDate: dateRange?.period_start?.date,
+    endDate: dateRange?.period_end?.date,
   })
   const currentDayIoBudget = Number(
     ioBudgetData?.data.find((x) => x.periodStartFormatted === dayjs().format('DD MMM'))?.[
@@ -117,7 +136,7 @@ const Usage = () => {
 
   return (
     <>
-      <div className="">
+      <div>
         <div className="1xl:px-28 mx-auto flex flex-col px-5 lg:px-16 2xl:px-32 pt-6 space-y-4">
           <h3 className="text-scale-1200 text-xl">Usage</h3>
         </div>
@@ -127,22 +146,19 @@ const Usage = () => {
           <div className="1xl:px-28 mx-auto px-5 lg:px-16 2xl:px-32 flex flex-col gap-2">
             <div className="flex items-center mt-4 justify-between">
               <div className="flex items-center space-x-4">
-                <Listbox
-                  disabled
-                  size="small"
-                  id="billingCycle"
-                  name="billingCycle"
-                  value={'current'}
-                  className="!w-[200px]"
-                  onChange={() => {}}
-                >
-                  <Listbox.Option label="Current billing cycle" value="current">
-                    Current billing cycle
-                  </Listbox.Option>
-                  <Listbox.Option label="Previous billing cycle" value="previous">
-                    Previous billing cycle
-                  </Listbox.Option>
-                </Listbox>
+                {!isLoadingSubscription && (
+                  <DateRangePicker
+                    id="billingCycle"
+                    name="billingCycle"
+                    onChange={setDateRange}
+                    value={TIME_PERIODS_BILLING[0].key}
+                    options={[...TIME_PERIODS_BILLING, ...TIME_PERIODS_REPORTS]}
+                    loading={isLoadingSubscription}
+                    currentBillingPeriodStart={subscription?.current_period_start}
+                    className="!w-[200px]"
+                  />
+                )}
+
                 {isLoadingSubscription ? (
                   <IconLoader className="animate-spin" size={14} />
                 ) : subscription !== undefined ? (
@@ -150,7 +166,7 @@ const Usage = () => {
                     <p
                       className={clsx('text-sm transition', isLoadingSubscription && 'opacity-50')}
                     >
-                      Project is on {subscription.plan.name}
+                      Project is on {subscription.plan.name} plan
                     </p>
                     <p className="text-sm text-scale-1000">
                       {billingCycleStart.format('DD MMM YYYY')} -{' '}
@@ -158,18 +174,6 @@ const Usage = () => {
                     </p>
                   </div>
                 ) : null}
-              </div>
-              <div className="items-center space-x-2 hidden lg:flex">
-                <Link href={`/project/${selectedProjectRef}/settings/billing/invoices`}>
-                  <a>
-                    <Button type="default">View invoices</Button>
-                  </a>
-                </Link>
-                <Link href={`/project/${selectedProjectRef}/settings/billing/subscription`}>
-                  <a>
-                    <Button type="default">View billing</Button>
-                  </a>
-                </Link>
               </div>
             </div>
             <div className="flex gap-6">
@@ -197,9 +201,13 @@ const Usage = () => {
                         : 'opacity-50'
                     )}
                   >
-                    {usageBillingEnabled === false && status === USAGE_STATUS.APPROACHING ? (
+                    {currentBillingCycleSelected &&
+                    usageBillingEnabled === false &&
+                    status === USAGE_STATUS.APPROACHING ? (
                       <IconAlertCircle size={15} strokeWidth={2} className="text-amber-900" />
-                    ) : usageBillingEnabled === false && status === USAGE_STATUS.EXCEEDED ? (
+                    ) : currentBillingCycleSelected &&
+                      usageBillingEnabled === false &&
+                      status === USAGE_STATUS.EXCEEDED ? (
                       <IconAlertCircle size={15} strokeWidth={2} className="text-red-900" />
                     ) : null}
                     <p className="text-sm">{category.name}</p>
@@ -212,7 +220,12 @@ const Usage = () => {
 
         <InView as="div" threshold={0.2} onChange={(inView) => inView && setActiveTab('infra')}>
           <div id="infrastructure" ref={infrastructureRef} style={{ scrollMarginTop: '100px' }}>
-            <Infrastructure projectRef={selectedProjectRef} />
+            <Infrastructure
+              projectRef={selectedProjectRef}
+              startDate={startDate}
+              endDate={endDate}
+              currentBillingCycleSelected={currentBillingCycleSelected}
+            />
           </div>
         </InView>
         <InView
@@ -225,7 +238,8 @@ const Usage = () => {
               projectRef={selectedProjectRef}
               subscription={subscription}
               startDate={startDate}
-              endDate={dailyStatsEndDate}
+              endDate={endDate}
+              currentBillingCycleSelected={currentBillingCycleSelected}
             />
           </div>
         </InView>
@@ -239,7 +253,8 @@ const Usage = () => {
               projectRef={selectedProjectRef}
               subscription={subscription}
               startDate={startDate}
-              endDate={dailyStatsEndDate}
+              endDate={endDate}
+              currentBillingCycleSelected={currentBillingCycleSelected}
             />
           </div>
         </InView>
@@ -253,7 +268,8 @@ const Usage = () => {
               projectRef={selectedProjectRef}
               subscription={subscription}
               startDate={startDate}
-              endDate={dailyStatsEndDate}
+              endDate={endDate}
+              currentBillingCycleSelected={currentBillingCycleSelected}
             />
           </div>
         </InView>

--- a/studio/components/interfaces/BillingV2/Usage/Usage.utils.ts
+++ b/studio/components/interfaces/BillingV2/Usage/Usage.utils.ts
@@ -51,17 +51,28 @@ export const getUpgradeUrl = (projectRef: string, subscription?: StripeSubscript
 
 export const getUpgradeUrlFromV2Subscription = (
   projectRef: string,
-  subscription?: ProjectSubscriptionResponse
+  subscription?: ProjectSubscriptionResponse,
+  newSubscriptionPage?: boolean
 ) => {
-  if (!subscription) return `/project/${projectRef}/settings/billing/update`
+  if (!subscription) {
+    return !newSubscriptionPage
+      ? `/project/${projectRef}/settings/billing/update`
+      : `/project/${projectRef}/settings/billing/subscription`
+  }
 
-  return subscription?.plan.id === 'enterprise'
-    ? `/project/${projectRef}/settings/billing/update/enterprise`
-    : subscription?.plan.id === 'team'
-    ? `/project/${projectRef}/settings/billing/update/team`
-    : subscription?.plan.id === 'free'
-    ? `/project/${projectRef}/settings/billing/update`
-    : `/project/${projectRef}/settings/billing/update/pro`
+  if (!newSubscriptionPage) {
+    return subscription?.plan.id === 'enterprise'
+      ? `/project/${projectRef}/settings/billing/update/enterprise`
+      : subscription?.plan.id === 'team'
+      ? `/project/${projectRef}/settings/billing/update/team`
+      : subscription?.plan.id === 'free'
+      ? `/project/${projectRef}/settings/billing/update`
+      : `/project/${projectRef}/settings/billing/update/pro`
+  } else {
+    return subscription?.plan?.id === 'pro' && subscription?.usage_billing_enabled === false
+      ? `/project/${projectRef}/settings/billing/subscription#cost-control`
+      : `/project/${projectRef}/settings/billing/subscription?panel=subscriptionPlan`
+  }
 }
 
 const compactNumberFormatter = new Intl.NumberFormat('en-US', {

--- a/studio/components/interfaces/BillingV2/Usage/UsageSection.tsx
+++ b/studio/components/interfaces/BillingV2/Usage/UsageSection.tsx
@@ -114,7 +114,7 @@ const UsageSection = ({
                                   your project.
                                 </p>
                                 <p className="text-xs text-scale-1200">
-                                  Upgrade to a usage based plan or disable the spend cap to avoid
+                                  Upgrade to a usage-based plan or disable the spend cap to avoid
                                   restrictions.
                                 </p>
                               </div>

--- a/studio/components/interfaces/BillingV2/Usage/UsageSection.tsx
+++ b/studio/components/interfaces/BillingV2/Usage/UsageSection.tsx
@@ -18,6 +18,8 @@ import { ChartYFormatterCompactNumber, getUpgradeUrlFromV2Subscription } from '.
 import { formatBytes } from 'lib/helpers'
 import UsageBarChart from './UsageBarChart'
 import Panel from 'components/ui/Panel'
+import * as Tooltip from '@radix-ui/react-tooltip'
+import { useFlag } from 'hooks'
 
 interface UsageSectionProps {
   projectRef: string
@@ -26,9 +28,17 @@ interface UsageSectionProps {
   chartMeta: {
     [key: string]: { data: DataPoint[]; margin: number; isLoading: boolean; hasNoData: boolean }
   }
+  currentBillingCycleSelected: boolean
 }
 
-const UsageSection = ({ projectRef, categoryKey, chartMeta, subscription }: UsageSectionProps) => {
+const UsageSection = ({
+  projectRef,
+  categoryKey,
+  chartMeta,
+  subscription,
+  currentBillingCycleSelected,
+}: UsageSectionProps) => {
+  const enableSubscriptionV2 = useFlag('subscriptionV2')
   const { data: usage } = useProjectUsageQuery({ projectRef })
   const categoryMeta = USAGE_CATEGORIES.find((category) => category.key === categoryKey)
 
@@ -37,7 +47,7 @@ const UsageSection = ({ projectRef, categoryKey, chartMeta, subscription }: Usag
   const usageBasedBilling = subscription?.usage_billing_enabled
   const exceededLimitStyle = !usageBasedBilling ? 'text-red-900' : 'text-amber-900'
 
-  const upgradeUrl = getUpgradeUrlFromV2Subscription(projectRef, subscription)
+  const upgradeUrl = getUpgradeUrlFromV2Subscription(projectRef, subscription, enableSubscriptionV2)
 
   return (
     <>
@@ -62,34 +72,73 @@ const UsageSection = ({ projectRef, categoryKey, chartMeta, subscription }: Usag
                 <div className="flex items-center justify-between">
                   <div className="flex items-center space-x-4">
                     <p className="text-sm">{attribute.name} usage</p>
-                    {!usageBasedBilling && usageRatio >= 1 ? (
-                      <div className="flex items-center space-x-2 min-w-[115px]">
-                        <IconAlertTriangle
-                          size={14}
-                          strokeWidth={2}
-                          className={exceededLimitStyle}
-                        />
-                        <p className={`text-sm ${exceededLimitStyle}`}>Exceeded limit</p>
-                      </div>
-                    ) : !usageBasedBilling && usageRatio >= USAGE_APPROACHING_THRESHOLD ? (
-                      <div className="flex items-center space-x-2 min-w-[115px]">
-                        <IconAlertTriangle size={14} strokeWidth={2} className="text-amber-900" />
-                        <p className="text-sm text-amber-900">Approaching limit</p>
-                      </div>
-                    ) : null}
+                    {currentBillingCycleSelected &&
+                      usageBasedBilling === false &&
+                      usageRatio >= USAGE_APPROACHING_THRESHOLD && (
+                        <Tooltip.Root delayDuration={0}>
+                          <Tooltip.Trigger asChild>
+                            {!usageBasedBilling && usageRatio >= 1 ? (
+                              <div className="flex items-center space-x-2 min-w-[115px] cursor-help">
+                                <IconAlertTriangle
+                                  size={14}
+                                  strokeWidth={2}
+                                  className={exceededLimitStyle}
+                                />
+                                <p className={`text-sm ${exceededLimitStyle}`}>Exceeded limit</p>
+                              </div>
+                            ) : (
+                              !usageBasedBilling &&
+                              usageRatio >= USAGE_APPROACHING_THRESHOLD && (
+                                <div className="flex items-center space-x-2 min-w-[115px] cursor-help">
+                                  <IconAlertTriangle
+                                    size={14}
+                                    strokeWidth={2}
+                                    className="text-amber-900"
+                                  />
+                                  <p className="text-sm text-amber-900">Approaching limit</p>
+                                </div>
+                              )
+                            )}
+                          </Tooltip.Trigger>
+                          <Tooltip.Portal>
+                            <Tooltip.Content side="bottom">
+                              <Tooltip.Arrow className="radix-tooltip-arrow" />
+                              <div
+                                className={[
+                                  'rounded bg-scale-100 py-1 px-2 leading-none shadow',
+                                  'border border-scale-200',
+                                ].join(' ')}
+                              >
+                                <p className="text-xs text-scale-1200">
+                                  Exceeding your plans included usage will lead to restrictions to
+                                  your project.
+                                </p>
+                                <p className="text-xs text-scale-1200">
+                                  Upgrade to a usage based plan or disable the spend cap to avoid
+                                  restrictions.
+                                </p>
+                              </div>
+                            </Tooltip.Content>
+                          </Tooltip.Portal>
+                        </Tooltip.Root>
+                      )}
                   </div>
 
-                  {!usageBasedBilling && usageRatio >= USAGE_APPROACHING_THRESHOLD && (
-                    <Link href={upgradeUrl}>
-                      <a>
-                        <Button type="default" size="tiny">
-                          Upgrade project
-                        </Button>
-                      </a>
-                    </Link>
-                  )}
+                  {currentBillingCycleSelected &&
+                    !usageBasedBilling &&
+                    usageRatio >= USAGE_APPROACHING_THRESHOLD && (
+                      <Link href={upgradeUrl}>
+                        <a className="pb-1">
+                          <Button type="default" size="tiny">
+                            {subscription?.plan?.id === 'free'
+                              ? 'Upgrade plan'
+                              : 'Change spend cap'}
+                          </Button>
+                        </a>
+                      </Link>
+                    )}
                 </div>
-                {usageMeta?.limit > 0 && (
+                {currentBillingCycleSelected && usageMeta?.limit > 0 && (
                   <SparkBar
                     type="horizontal"
                     barClass={clsx(
@@ -97,7 +146,7 @@ const UsageSection = ({ projectRef, categoryKey, chartMeta, subscription }: Usag
                         ? usageBasedBilling
                           ? 'bg-amber-900'
                           : 'bg-red-900'
-                        : usageRatio >= USAGE_APPROACHING_THRESHOLD
+                        : usageBasedBilling === false && usageRatio >= USAGE_APPROACHING_THRESHOLD
                         ? 'bg-amber-900'
                         : 'bg-scale-1100'
                     )}
@@ -127,7 +176,7 @@ const UsageSection = ({ projectRef, categoryKey, chartMeta, subscription }: Usag
                         : (usageMeta?.usage ?? 0).toLocaleString()}
                     </p>
                   </div>
-                  {usageMeta?.limit > 0 && (
+                  {currentBillingCycleSelected && usageMeta?.limit > 0 && (
                     <div className="flex items-center justify-between border-t py-1">
                       <p className="text-xs text-scale-1000">Overage in period</p>
                       <p className="text-xs">
@@ -163,7 +212,7 @@ const UsageSection = ({ projectRef, categoryKey, chartMeta, subscription }: Usag
                   <ShimmeringLoader className="w-3/4" />
                   <ShimmeringLoader className="w-1/2" />
                 </div>
-              ) : chartData.length > 1 && notAllValuesZero ? (
+              ) : chartData.length > 0 && notAllValuesZero ? (
                 <UsageBarChart
                   name={`${attribute.chartPrefix || ''}${attribute.name}`}
                   unit={attribute.unit}
@@ -177,10 +226,8 @@ const UsageSection = ({ projectRef, categoryKey, chartMeta, subscription }: Usag
                   <Panel.Content>
                     <div className="flex flex-col items-center justify-center">
                       <IconBarChart2 className="text-scale-1100 mb-2" />
-                      <p className='text-sm'>No data in period</p>
-                      <p className="text-sm text-scale-1000">
-                        May take up to 24 hours to show
-                      </p>
+                      <p className="text-sm">No data in period</p>
+                      <p className="text-sm text-scale-1000">May take up to 24 hours to show</p>
                     </div>
                   </Panel.Content>
                 </Panel>

--- a/studio/pages/project/[ref]/settings/billing/invoices.tsx
+++ b/studio/pages/project/[ref]/settings/billing/invoices.tsx
@@ -3,12 +3,12 @@ import { FC, useEffect } from 'react'
 
 import { SettingsLayout } from 'components/layouts'
 import LoadingUI from 'components/ui/Loading'
-import OveragesBanner from 'components/ui/OveragesBanner/OveragesBanner'
 import { useStore } from 'hooks'
 import { useProjectSubscriptionQuery } from 'data/subscriptions/project-subscription-query'
 import { NextPageWithLayout, Project } from 'types'
 
 import { Invoices } from 'components/interfaces/Billing'
+import Link from 'next/link'
 
 const ProjectBilling: NextPageWithLayout = () => {
   const { ui } = useStore()
@@ -35,7 +35,7 @@ interface SettingsProps {
 
 const Settings: FC<SettingsProps> = ({ project }) => {
   const { ui } = useStore()
-  const projectTier = ui.selectedProject?.subscription_tier
+  const orgSlug = ui.selectedOrganization?.slug ?? ''
 
   const { data: subscription, error } = useProjectSubscriptionQuery({
     projectRef: ui.selectedProject?.ref,
@@ -61,6 +61,19 @@ const Settings: FC<SettingsProps> = ({ project }) => {
 
       <div className="space-y-2">
         <h4 className="text-lg">Invoices</h4>
+
+        <div className="text-sm text-scale-1000">
+          To manage your billing address, emails or tax IDs, head to your{' '}
+          <Link href={`/org/${orgSlug}/billing`}>
+            <a>
+              <span className="text-sm text-green-900 transition hover:text-green-1000">
+                organization settings
+              </span>
+              .
+            </a>
+          </Link>
+        </div>
+
         <Invoices projectRef={ui.selectedProject?.ref ?? ''} />
       </div>
     </div>

--- a/studio/pages/project/[ref]/settings/billing/invoices.tsx
+++ b/studio/pages/project/[ref]/settings/billing/invoices.tsx
@@ -63,7 +63,7 @@ const Settings: FC<SettingsProps> = ({ project }) => {
         <h4 className="text-lg">Invoices</h4>
 
         <div className="text-sm text-scale-1000">
-          To manage your billing address, emails or tax IDs, head to your{' '}
+          To manage your billing address, emails or Tax ID, head to your{' '}
           <Link href={`/org/${orgSlug}/billing`}>
             <a>
               <span className="text-sm text-green-900 transition hover:text-green-1000">


### PR DESCRIPTION
- Added date range picker instead of having current billing cycle fixed
  - We hide upsell, progress bars and overage if the selected date range is not the current billing cycle
- Slight copy changes
- Round the total usage fees to avoid displaying something like "$128.23123123123"
- Smaller styling fixes and better layout on mobile for some components like the billing breakdown
- Fixed "organization settings" link breaking to new row
- Added "organization settings" link on project invoices page
- Tooltip for exceeded/approaching limit
- The upsell now links to the new subscription v2 page if the feature is toggled


<img width="475" alt="Screenshot 2023-06-07 at 00 49 24" src="https://github.com/supabase/supabase/assets/14073399/08dbba9c-2968-4b00-b2aa-4a3a578eb6f0">

<img width="568" alt="Screenshot 2023-06-07 at 00 50 47" src="https://github.com/supabase/supabase/assets/14073399/56509a99-f715-4e73-acfc-5d095dc645c1">
