### PR TITLE
fix: improve pgmeta tables fetchData

### DIFF
--- a/studio/stores/pgmeta/ForeignTableStore.ts
+++ b/studio/stores/pgmeta/ForeignTableStore.ts
@@ -37,9 +37,15 @@ export default class ForeignTableStore extends PostgresMetaInterface<Partial<Pos
     if (columnsResponse.error) throw columnsResponse.error
 
     // merge 2 response to create the final array
+    const columnsByTableId = (columnsResponse as PostgresColumn[])
+      .reduce((acc, curr) => {
+        acc[curr.table_id] ??= []
+        acc[curr.table_id].push(curr)
+        return acc
+      }, {} as Record<string, PostgresColumn[]>)
     const foreignTables: PostgresTable[] = []
     foreignTablesResponse.forEach((foreignTable: PostgresTable) => {
-      const columns = columnsResponse.filter((x: PostgresColumn) => x.table_id === foreignTable.id)
+      const columns = columnsByTableId[foreignTable.id]
       foreignTables.push({ ...foreignTable, columns })
     })
 

--- a/studio/stores/pgmeta/MaterializedViewStore.ts
+++ b/studio/stores/pgmeta/MaterializedViewStore.ts
@@ -39,9 +39,15 @@ export default class MaterializedViewStore extends PostgresMetaInterface<Postgre
     if (columnsResponse.error) throw columnsResponse.error
 
     // merge 2 response to create the final array
+    const columnsByTableId = (columnsResponse as PostgresColumn[])
+      .reduce((acc, curr) => {
+        acc[curr.table_id] ??= []
+        acc[curr.table_id].push(curr)
+        return acc
+      }, {} as Record<string, PostgresColumn[]>)
     const materializedViews: PostgresMaterializedView[] = []
     materializedViewsResponse.forEach((materializedView: PostgresMaterializedView) => {
-      const columns = columnsResponse.filter((x: PostgresColumn) => x.table_id === materializedView.id)
+      const columns = columnsByTableId[materializedView.id]
       materializedViews.push({ ...materializedView, columns })
     })
 

--- a/studio/stores/pgmeta/TableStore.ts
+++ b/studio/stores/pgmeta/TableStore.ts
@@ -42,10 +42,15 @@ export default class TableStore extends PostgresMetaInterface<PostgresTable> {
     if (columnsResponse.error) throw columnsResponse.error
 
     // merge 2 response to create the final array
+    const columnsByTableId = (columnsResponse as PostgresColumn[])
+      .reduce((acc, curr) => {
+        acc[curr.table_id] ??= []
+        acc[curr.table_id].push(curr)
+        return acc
+      }, {} as Record<string, PostgresColumn[]>)
     const tables: PostgresTable[] = []
     tablesResponse.forEach((table: PostgresTable) => {
-      const tableId = table.id
-      const columns = columnsResponse.filter((x: PostgresColumn) => x.table_id === tableId)
+      const columns = columnsByTableId[table.id]
       tables.push({ ...table, columns })
     })
 

--- a/studio/stores/pgmeta/TableStore.ts
+++ b/studio/stores/pgmeta/TableStore.ts
@@ -45,7 +45,7 @@ export default class TableStore extends PostgresMetaInterface<PostgresTable> {
     const tables: PostgresTable[] = []
     tablesResponse.forEach((table: PostgresTable) => {
       const tableId = table.id
-      const columns = columnsResponse.find((x: PostgresColumn) => x.table_id === tableId)
+      const columns = columnsResponse.filter((x: PostgresColumn) => x.table_id === tableId)
       tables.push({ ...table, columns })
     })
 

--- a/studio/stores/pgmeta/TableStore.ts
+++ b/studio/stores/pgmeta/TableStore.ts
@@ -1,5 +1,5 @@
 import { action, makeObservable } from 'mobx'
-import type { PostgresTable } from '@supabase/postgres-meta'
+import type { PostgresColumn, PostgresTable } from '@supabase/postgres-meta'
 
 import PostgresMetaInterface, { IPostgresMetaInterface } from '../common/PostgresMetaInterface'
 import { IRootStore } from '../RootStore'
@@ -23,6 +23,34 @@ export default class TableStore extends PostgresMetaInterface<PostgresTable> {
     makeObservable(this, {
       loadById: action,
     })
+  }
+
+  // Customize TableStore fetchData method to improve request performance
+  async fetchData() {
+    const headers = { 'Content-Type': 'application/json', ...this.headers }
+    // load all tables w/o columns info
+    const urlTables = this.url.includes('?')
+      ? `${this.url}&include_columns=false`
+      : `${this.url}?include_columns=false`
+    // load all columns
+    const urlColumns = this.url.replace('/tables', '/columns')
+    const [tablesResponse, columnsResponse] = await Promise.all([
+      get(urlTables, { headers }),
+      get(urlColumns, { headers }),
+    ])
+    if (tablesResponse.error) throw tablesResponse.error
+    if (columnsResponse.error) throw columnsResponse.error
+
+    // merge 2 response to create the final array
+    const tables: PostgresTable[] = []
+    tablesResponse.forEach((table: PostgresTable) => {
+      const tableId = table.id
+      const columns = columnsResponse.find((x: PostgresColumn) => x.table_id === tableId)
+      tables.push({ ...table, columns })
+    })
+
+    this.setDataArray(tables)
+    return tables as any
   }
 
   async loadById(id: number | string) {

--- a/studio/stores/pgmeta/ViewStore.ts
+++ b/studio/stores/pgmeta/ViewStore.ts
@@ -37,9 +37,15 @@ export default class ViewStore extends PostgresMetaInterface<SchemaView> {
     if (columnsResponse.error) throw columnsResponse.error
 
     // merge 2 response to create the final array
+    const columnsByTableId = (columnsResponse as PostgresColumn[])
+      .reduce((acc, curr) => {
+        acc[curr.table_id] ??= []
+        acc[curr.table_id].push(curr)
+        return acc
+      }, {} as Record<string, PostgresColumn[]>)
     const views: PostgresView[] = []
     viewsResponse.forEach((view: PostgresView) => {
-      const columns = columnsResponse.filter((x: PostgresColumn) => x.table_id === view.id)
+      const columns = columnsByTableId[view.id]
       views.push({ ...view, columns })
     })
 


### PR DESCRIPTION
When querying `/tables`-like endpoints on pg-meta, omit `columns` and fetch them separately on `/columns`. This is because atm the way pg-meta fetches the columns is very inefficient and easily hits the 15s timeout.

There's a bunch of support tickets related to this that should be resolved once this is released.