### PR TITLE
Updating queries on the homepage

### DIFF
--- a/apps/www/data/home/api-examples.js
+++ b/apps/www/data/home/api-examples.js
@@ -60,7 +60,7 @@ const { data, error } = await supabase
   },
   {
     lang: 'js',
-    title: 'Invoke function',
+    title: 'Invoke Edge Function',
     description: 'Invoke a Supabase Function',
     code: `import { createClient } from '@supabase/supabase-js'
     

--- a/apps/www/data/home/api-examples.js
+++ b/apps/www/data/home/api-examples.js
@@ -61,7 +61,7 @@ const { data, error } = await supabase
   {
     lang: 'js',
     title: 'Invoke Edge Function',
-    description: 'Invoke a Supabase Function',
+    description: 'Invoke a Supabase Edge Function',
     code: `import { createClient } from '@supabase/supabase-js'
     
 // Initialize 

--- a/apps/www/data/home/api-examples.js
+++ b/apps/www/data/home/api-examples.js
@@ -39,15 +39,58 @@ const realtime = supabase
   },
   {
     lang: 'js',
-    title: 'Read a record',
-    description: 'Get all public rooms and their messages',
-    code: `import '@supabase/supabase-js'
-
+    title: 'Create bucket',
+    description: 'Creates a new Storage bucket',
+    code: `import { createClient } from '@supabase/supabase-js'
+    
 // Initialize 
 const supabaseUrl = 'https://chat-room.supabase.co'
 const supabaseKey = 'public-anon-key'
 const supabase = createClient(supabaseUrl, supabaseKey)
 
+// Create a new bucket
+const { data, error } = await supabase
+  .storage
+  .createBucket('avatars', {
+    public: false,
+    allowedMimeTypes: ['image/png'],
+    fileSizeLimit: 1024
+  })
+    `,
+  },
+  {
+    lang: 'js',
+    title: 'Invoke function',
+    description: 'Invoke a Supabase Function',
+    code: `import { createClient } from '@supabase/supabase-js'
+    
+// Initialize 
+const supabaseUrl = 'https://chat-room.supabase.co'
+const supabaseKey = 'public-anon-key'
+const supabase = createClient(supabaseUrl, supabaseKey)
+
+// Invoke a function
+const { data, error } = await supabase.functions.invoke('hello', {
+  body: { foo: 'bar' }
+})
+    `,
+  },
+  {
+    lang: 'js',
+    title: 'CRUD a record',
+    description: 'Create, Read, Update and Delete all public rooms and their messages',
+    code: `import { createClient } from '@supabase/supabase-js'
+    
+// Initialize 
+const supabaseUrl = 'https://chat-room.supabase.co'
+const supabaseKey = 'public-anon-key'
+const supabase = createClient(supabaseUrl, supabaseKey)
+  
+// Create a new chat room
+const newRoom = await supabase
+  .from('rooms')
+  .insert({ name: 'Supabase Fan Club', public: true })
+    
 // Get public rooms and their messages
 const publicRooms = await supabase
   .from('rooms')
@@ -56,41 +99,12 @@ const publicRooms = await supabase
     messages ( text )
   \`)
   .eq('public', true)
-    `,
-  },
-  {
-    lang: 'js',
-    title: 'Create a record',
-    description: 'Create a new chat room',
-    code: `import { createClient } from '@supabase/supabase-js'
-
-// Initialize 
-const supabaseUrl = 'https://chat-room.supabase.co'
-const supabaseKey = 'public-anon-key'
-const supabase = createClient(supabaseUrl, supabaseKey)
-
-// Create a new chat room
-const newRoom = await supabase
-  .from('rooms')
-  .insert({ name: 'Supabase Fan Club', public: true })
-  `,
-  },
-  {
-    lang: 'js',
-    title: 'Update a record',
-    description: 'Update a user',
-    code: `import { createClient } from '@supabase/supabase-js'
-    
-// Initialize 
-const supabaseUrl = 'https://chat-room.supabase.co'
-const supabaseKey = 'public-anon-key'
-const supabase = createClient(supabaseUrl, supabaseKey)
-
+  
 // Update multiple users
 const updatedUsers = await supabase
   .from('users')
   .eq('account_type', 'paid')
   .update({ highlight_color: 'gold' })
-`,
+    `,
   },
 ]


### PR DESCRIPTION
## What kind of change does this PR introduce?

Live Preview: https://zone-www-dot-com-git-updating-queries-on-the-homepage-supabase.vercel.app/

Updating queries on the homepage

## What is the current behavior?

On the homepage, we have 3 separate queries for postgrest-js, 1 for realtime-js, and 1 for gotrue-js.

<img width="711" alt="CleanShot 2023-06-07 at 16 25 29@2x" src="https://github.com/supabase/supabase/assets/70828596/72595ab1-c575-4fdd-a8f7-78ab7e8d58b9">

## What is the new behavior?

On the homepage, we have 3 queries combined for 1 postgrest-js, 1 for realtime-js, 1 for gotrue-js, 1 for storage-js, and 1 for functions-js.


<img width="711" alt="CleanShot 2023-06-07 at 16 25 29@2x" src="https://github.com/supabase/supabase/assets/70828596/cfb3ef6b-1d6b-4c44-afd5-9eb59bc9227e">

## Additional context

https://www.notion.so/supabase/Updating-queries-on-the-homepage-3df795c0340749c9a096a211f9753945