### PR TITLE
fix: usage v2 end date

### DIFF
--- a/studio/components/interfaces/BillingV2/Subscription/Tier/TierUpdateSidePanel.tsx
+++ b/studio/components/interfaces/BillingV2/Subscription/Tier/TierUpdateSidePanel.tsx
@@ -16,7 +16,7 @@ import MembersExceedLimitModal from './MembersExceedLimitModal'
 import PaymentMethodSelection from './PaymentMethodSelection'
 import { plans as subscriptionsPlans } from 'shared-data/plans'
 import { useProjectSubscriptionV2Query } from 'data/subscriptions/project-subscription-v2-query'
-import { PRICING_TIER_PRODUCT_IDS, STRIPE_PRODUCT_IDS } from 'lib/constants'
+import { PRICING_TIER_PRODUCT_IDS } from 'lib/constants'
 
 const TierUpdateSidePanel = () => {
   const { ui } = useStore()

--- a/studio/components/interfaces/BillingV2/Usage/Usage.tsx
+++ b/studio/components/interfaces/BillingV2/Usage/Usage.tsx
@@ -63,17 +63,17 @@ const Usage = () => {
   }, [dateRange, subscription])
 
   const endDate = useMemo(() => {
-    // If end date is in future, set end date to now
+    // If end date is in future, set end date to end of current day
     if (dateRange?.period_end?.date && dayjs(dateRange.period_end.date).isAfter(dayjs())) {
       // LF seems to have an issue with the milliseconds, causes infinite loading sometimes
-      return new Date().toISOString().slice(0, -5) + 'Z'
+      // In order to have full days from Prometheus metrics when using 1d interval,
+      // the time needs to be greater or equal than the time of the start date
+      return dayjs().endOf('day').toISOString().slice(0, -5) + 'Z'
     } else if (dateRange?.period_end?.date) {
       // LF seems to have an issue with the milliseconds, causes infinite loading sometimes
       return new Date(dateRange.period_end.date).toISOString().slice(0, -5) + 'Z'
     }
   }, [dateRange, subscription])
-
-  console.log({ startDate, endDate })
 
   const { data: ioBudgetData } = useInfraMonitoringQuery({
     projectRef: selectedProjectRef,

--- a/studio/data/analytics/daily-stats-query.ts
+++ b/studio/data/analytics/daily-stats-query.ts
@@ -131,7 +131,7 @@ export const useDailyStatsQuery = <TData = DailyStatsData>(
         typeof endDate !== 'undefined',
 
       select(data) {
-        const noDataYet = data.data[0].id === undefined
+        const noDataYet = data.data[0]?.id === undefined
 
         // [Joshen] Ideally handled by API, like infra-monitoring
         if (noDataYet) {


### PR DESCRIPTION
We currently set the requested end date to `now`, if the selected end date in the range picker is after the current time, which is always the case if you look at the current billing cycle.

When requesting Prometheus with interval "1d", we end date time should be equal or after the start date time, in order to get data for the current date. By using the end of day time for the requested end date, we ensure we get data for the current date as well (i.e. for CPU usage)