### PR TITLE
chore: improve usage page x time label

### DIFF
--- a/studio/components/interfaces/BillingV2/Usage/Infrastructure.tsx
+++ b/studio/components/interfaces/BillingV2/Usage/Infrastructure.tsx
@@ -47,7 +47,7 @@ const Infrastructure = ({
 
     if (diffInHours <= 48) {
       interval = '1h'
-      dateFormat = 'HH a'
+      dateFormat = 'h a'
     }
   }
 

--- a/studio/components/interfaces/BillingV2/Usage/UsageBarChart.tsx
+++ b/studio/components/interfaces/BillingV2/Usage/UsageBarChart.tsx
@@ -9,7 +9,6 @@ import {
   XAxis,
   YAxis,
 } from 'recharts'
-import { Y_DOMAIN_CEILING_MULTIPLIER } from './Usage.constants'
 import dayjs from 'dayjs'
 
 // [Joshen] This BarChart is specifically for usage, hence not a reusable component, and not


### PR DESCRIPTION
![Screenshot 2023-06-08 at 17 02 25](https://github.com/supabase/supabase/assets/14073399/6f7506b3-a6ef-42f7-8a3d-3f130451a816)

Previously it showed "17 pm" instead of "5 pm"