### PR TITLE
Fixed typo in Realtime app examples

### DIFF
--- a/apps/www/data/products/realtime/app-examples.js
+++ b/apps/www/data/products/realtime/app-examples.js
@@ -41,7 +41,7 @@ export default [
     img: 'whiteboard.svg',
     title: 'Shared whiteboard',
     description:
-      'Allow users to collaorate on a shared whiteboard, sharing positions and states of any kind of object in Realtime.',
+      'Allow users to collaborate on a shared whiteboard, sharing positions and states of any kind of object in Realtime.',
   },
   {
     img: 'location.svg',


### PR DESCRIPTION
Changed collaorate to collaborate

## What kind of change does this PR introduce?

This PR fixes a single typo which can be viewed on the website on the [https://supabase.com/realtime](https://supabase.com/realtime) page

## What is the current behavior?

In the app examples, in the description of the 'shared whiteboard' app example, a typo was made in the word 'collaborate', making it 'collaorate'.

## What is the new behavior?

I changed it to 'collaborate'.

## Additional context

N/A
