### PR TITLE
Fix: selection color on selected code

### DIFF
--- a/apps/docs/styles/main.scss
+++ b/apps/docs/styles/main.scss
@@ -32,7 +32,7 @@ body {
 }
 
 ::selection {
-  background-color: #6ee7b7;
+  background-color: #6ee7b7 !important;
   color: #333 !important;
 }
 

--- a/apps/www/styles/index.css
+++ b/apps/www/styles/index.css
@@ -148,7 +148,7 @@ h6:not(.overwrite) {
 }
 
 ::selection {
-  background-color: #6ee7b7;
+  background-color: #6ee7b7 !important;
   color: #333 !important;
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes selection color on selected code

## What is the current behavior?

<img width="515" height="275" src="https://github.com/supabase/supabase/assets/1911623/97473613-ca63-4a47-88a8-5860af5cd056">

## What is the new behavior?
<img width="515" height="275" src="https://github.com/supabase/supabase/assets/70828596/a95f2c70-7509-41cb-a6c6-6d1586f011a2">

## Additional context

Fixes https://github.com/supabase/supabase/issues/14900