### PR TITLE
fix: reference doc redirects

### DIFF
--- a/apps/www/lib/redirects.js
+++ b/apps/www/lib/redirects.js
@@ -1799,6 +1799,26 @@ module.exports = [
   },
   {
     permanent: true,
+    source: '/docs/reference/python',
+    destination: '/docs/reference/python/start',
+  },
+  {
+    permanent: true,
+    source: '/docs/reference/csharp',
+    destination: '/docs/reference/csharp/start',
+  },
+  {
+    permanent: true,
+    source: '/docs/reference/swift',
+    destination: '/docs/reference/swift/start',
+  },
+  {
+    permanent: true,
+    source: '/docs/reference/kotlin',
+    destination: '/docs/reference/kotlin/start',
+  },
+  {
+    permanent: true,
     source: '/docs/reference/cli',
     destination: '/docs/reference/cli/start',
   },


### PR DESCRIPTION
Adds missing redirects for `python`, `csharp`, `swift`, and `kotlin` ref docs for situations where you link directly to their root path, eg. https://supabase.com/docs/reference/python/

Fixed version:
https://zone-www-dot-com-git-fix-ref-doc-redirects-supabase.vercel.app/docs/reference/python/