### PR TITLE
docs: use `--attribute-mapping-file` in SSO setup

### DIFF
--- a/apps/docs/pages/guides/auth/sso/auth-sso-saml.mdx
+++ b/apps/docs/pages/guides/auth/sso/auth-sso-saml.mdx
@@ -219,13 +219,13 @@ For example, the following JSON structure configures attribute mapping for the `
 }
 ```
 
-When creating or updating an identity provider with the [Supabase CLI](/docs/guides/cli) you can include this JSON as a file with the `--attribute-mapping /path/to/attribute/mapping.json` flag.
+When creating or updating an identity provider with the [Supabase CLI](/docs/guides/cli) you can include this JSON as a file with the `--attribute-mapping-file /path/to/attribute/mapping.json` flag.
 
 For example, to change the attribute mappings to an existing provider you can use:
 
 ```bash
 supabase sso update <provider-uuid> --project-ref <your-project> \
-  --attribute-mapping /path/to/attribute/mapping.json
+  --attribute-mapping-file /path/to/attribute/mapping.json
 ```
 
 Given a SAML 2.0 assertion that includes these attributes:


### PR DESCRIPTION
Wrong argument was documented.