### PR TITLE
Docs: Update video link for Next.js Auth Helpers

### DIFF
--- a/apps/docs/pages/guides/auth/auth-helpers/nextjs.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/nextjs.mdx
@@ -12,7 +12,7 @@ The [Next.js Auth Helpers package](https://github.com/supabase/auth-helpers) con
 
 <div className="video-container">
   <iframe
-    src="https://www.youtube-nocookie.com/embed/MVYhyGZGLuo"
+    src="https://www.youtube-nocookie.com/embed/w3LD0Z73vgU"
     frameBorder="1"
     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
     allowFullScreen


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

Next.js Auth Helpers docs contain `unlisted` YouTube link

## What is the new behavior?

Next.js Auth Helpers docs contain `public` YouTube link
