### PR TITLE
Update auth-email-templates.mdx

### DIFF
--- a/apps/docs/pages/guides/auth/auth-email-templates.mdx
+++ b/apps/docs/pages/guides/auth/auth-email-templates.mdx
@@ -44,6 +44,22 @@ To guard against this:
 
   The user should be brought to a page on your site where they can confirm the action by clicking a button.
   The button should contain the actual confirmation link which can be obtained from parsing the `confirmation_url={{ .ConfirmationURL }}` query parameter in the URL.
+  
+- Redirect users to a `password setup page`. When a user has clicked the link from the email invite, the user will be marked as `approved/confirmed`.
+  For example, you can simply add the redirect url in your email template:
+  ```html
+  <a
+    href="{{ .SiteURL }}/confirm-signup?confirmation_url={{ .ConfirmationURL }}/password-setup"
+    >Confirm your signup
+  </a>
+  ```
+
+    The flow will be: 
+    - User clicks the link from the email invite
+    - User will be redirected to the `password set up` page. For example: `https://example.com/auth/password-setup`.
+    - User will be able to set up their password and login to the app. You can use the `supabase.auth.updateUser` from `supabase js` to update the user's password.
+
+
 
 export const Page = ({ children }) => <Layout meta={meta} children={children} />
 


### PR DESCRIPTION
There wasn't a clear guide on `how to add redirect urls` when I want to send users to a different page rather than the site url. 

The confirmation url only redirects to the homepage (set up in supabase dashboar). 

Found this neat solution in this [github discussion](https://github.com/orgs/supabase/discussions/3208)

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

This shows another neat way to add email invites to new users. Helpful for building apps with `Join a waitlist` option

## What is the current behavior?

Currently it shows a way to add a button for the authentication. But the new method adds a short tweak which is easy to implement

## What is the new behavior?

Better docs for better developer expereince

## Additional context

