### PR TITLE
chore(usage): fix typos, z-index for preview toggle

### DIFF
--- a/studio/components/interfaces/BillingV2/Usage/Usage.constants.tsx
+++ b/studio/components/interfaces/BillingV2/Usage/Usage.constants.tsx
@@ -170,7 +170,7 @@ export const USAGE_CATEGORIES: CategoryMeta[] = [
         chartPrefix: 'Max ',
         unit: 'bytes',
         description:
-          'Sum of all objects in your storage buckets.\nBilling is based on the average size in GB throughout your billing period.',
+          'Sum of all objects in your storage buckets.\nBilling is based on the average daily size in GB throughout your billing period.',
         chartDescription: 'The data refreshes every 24 hours.',
       },
       {
@@ -220,7 +220,7 @@ export const USAGE_CATEGORIES: CategoryMeta[] = [
         name: 'Storage Image Transformations',
         unit: 'absolute',
         description:
-          'We count all images that were transformed in the billing period, ignoring any transformations.\nUsage example: You transform one image with four different size transformations and another image with just a single transformations. It counts as two, as only two images were transformed.\nBilling is based on the count of (origin) images that used transformations throughout the billing period. Resets every billing cycle.',
+          'We count all images that were transformed in the billing period, ignoring any transformations.\nUsage example: You transform one image with four different size transformations and another image with just a single transformation. It counts as two, as only two images were transformed.\nBilling is based on the count of (origin) images that used transformations throughout the billing period. Resets every billing cycle.',
         chartDescription:
           'The data refreshes every 24 hours.\nThe data points are relative to the beginning of your billing period.',
       },

--- a/studio/pages/project/[ref]/settings/billing/subscription.tsx
+++ b/studio/pages/project/[ref]/settings/billing/subscription.tsx
@@ -18,7 +18,7 @@ const ProjectBilling: NextPageWithLayout = () => {
   return (
     <div className="relative">
       {enableSubscriptionV2 && (
-        <div className="absolute top-[1.9rem] right-16 xl:right-32 flex items-center space-x-3">
+        <div className="absolute top-[1.9rem] right-16 xl:right-32 flex items-center space-x-3 z-10">
           <Toggle
             size="tiny"
             checked={showNewSubscriptionUI}

--- a/studio/pages/project/[ref]/settings/billing/usage.tsx
+++ b/studio/pages/project/[ref]/settings/billing/usage.tsx
@@ -21,7 +21,7 @@ const ProjectBillingUsage: NextPageWithLayout = () => {
   return (
     <div className="relative">
       {enableUsageV2 && (
-        <div className="absolute top-[1.9rem] right-16 xl:right-32 flex items-center space-x-3">
+        <div className="absolute top-[1.9rem] right-16 xl:right-32 flex items-center space-x-3 z-10">
           <Toggle
             size="tiny"
             checked={showNewUsageUI}


### PR DESCRIPTION
- Fixed a typo
- Clarified storage size being daily average (same as database size)
- Added z-index for preview toggle as a user reported issues on smaller resolutions

Toggle will get removed in a week or two, so we don't need to make this super pretty on all resolutions now

Before:

![image](https://github.com/supabase/supabase/assets/14073399/6342e9f3-c68d-4b10-b63e-fdddc32dd2f1)

