### PR TITLE
chore: improve subscription and usage pages

### DIFF
--- a/studio/components/interfaces/BillingV2/Subscription/BillingBreakdown.tsx
+++ b/studio/components/interfaces/BillingV2/Subscription/BillingBreakdown.tsx
@@ -234,17 +234,53 @@ const BillingBreakdown = ({}: BillingBreakdownProps) => {
                           </Tooltip.Portal>
                         </Tooltip.Root>
                       )}
-                      {isExceededLimit && !isUsageBillingEnabled ? (
-                        <div className="flex items-center space-x-2 min-w-[115px]">
-                          <IconAlertTriangle size={14} strokeWidth={2} className="text-red-900" />
-                          <p className="text-sm text-red-900">Exceeded limit</p>
-                        </div>
-                      ) : isApproachingLimit && !isUsageBillingEnabled ? (
-                        <div className="flex items-center space-x-2 min-w-[115px]">
-                          <IconAlertTriangle size={14} strokeWidth={2} className="text-amber-900" />
-                          <p className="text-sm text-amber-900">Reaching limit</p>
-                        </div>
-                      ) : null}
+                      {isUsageBillingEnabled === false &&
+                        usageRatio >= USAGE_APPROACHING_THRESHOLD && (
+                          <Tooltip.Root delayDuration={0}>
+                            <Tooltip.Trigger asChild>
+                              {isExceededLimit && !isUsageBillingEnabled ? (
+                                <div className="flex items-center space-x-2 min-w-[115px] cursor-help">
+                                  <IconAlertTriangle
+                                    size={14}
+                                    strokeWidth={2}
+                                    className="text-red-900"
+                                  />
+                                  <p className="text-sm text-red-900">Exceeded limit</p>
+                                </div>
+                              ) : isApproachingLimit && !isUsageBillingEnabled ? (
+                                <div className="flex items-center space-x-2 min-w-[115px] cursor-help">
+                                  <IconAlertTriangle
+                                    size={14}
+                                    strokeWidth={2}
+                                    className="text-amber-900"
+                                  />
+                                  <p className="text-sm text-amber-900">Approaching limit</p>
+                                </div>
+                              ) : null}
+                            </Tooltip.Trigger>
+
+                            <Tooltip.Portal>
+                              <Tooltip.Content side="bottom">
+                                <Tooltip.Arrow className="radix-tooltip-arrow" />
+                                <div
+                                  className={[
+                                    'rounded bg-scale-100 py-1 px-2 leading-none shadow',
+                                    'border border-scale-200',
+                                  ].join(' ')}
+                                >
+                                  <p className="text-xs text-scale-1200">
+                                    Exceeding your plans included usage will lead to restrictions to
+                                    your project.
+                                  </p>
+                                  <p className="text-xs text-scale-1200">
+                                    Upgrade to a usage-based plan or disable the spend cap to avoid
+                                    restrictions.
+                                  </p>
+                                </div>
+                              </Tooltip.Content>
+                            </Tooltip.Portal>
+                          </Tooltip.Root>
+                        )}
                     </div>
                     {usageMeta.available_in_plan ? (
                       <SparkBar
@@ -272,7 +308,7 @@ const BillingBreakdown = ({}: BillingBreakdownProps) => {
                             ? ''
                             : isExceededLimit && !isUsageBillingEnabled
                             ? '!text-red-900'
-                            : isApproachingLimit
+                            : isApproachingLimit && !isUsageBillingEnabled
                             ? '!text-amber-900'
                             : ''
                         }

--- a/studio/components/interfaces/BillingV2/Usage/Infrastructure.tsx
+++ b/studio/components/interfaces/BillingV2/Usage/Infrastructure.tsx
@@ -199,7 +199,7 @@ const Infrastructure = ({
                       <span className={attribute.key === 'ram_usage' ? 'lowercase' : ''}>
                         {attribute.name}
                       </span>{' '}
-                      per {interval === '1d' ? 'day' : 'hour'}
+                      utilization per {interval === '1d' ? 'day' : 'hour'}
                     </p>
                   )}
                 </div>

--- a/studio/components/interfaces/BillingV2/Usage/Usage.constants.tsx
+++ b/studio/components/interfaces/BillingV2/Usage/Usage.constants.tsx
@@ -1,7 +1,8 @@
 import { ProjectSubscriptionResponse } from 'data/subscriptions/project-subscription-v2-query'
 import { ProjectUsageData } from 'data/usage/project-usage-query'
 import Link from 'next/link'
-import { Badge, Button, IconExternalLink } from 'ui'
+import { Alert, Badge, Button, IconExternalLink } from 'ui'
+import { USAGE_APPROACHING_THRESHOLD } from '../Billing.constants'
 
 export const Y_DOMAIN_CEILING_MULTIPLIER = 4 / 3
 
@@ -25,6 +26,7 @@ export interface CategoryAttribute {
   description: string
   chartDescription: string
   additionalInfo?: (
+    ref: string,
     subscription?: ProjectSubscriptionResponse,
     usage?: ProjectUsageData
   ) => JSX.Element | null
@@ -84,7 +86,7 @@ export const USAGE_CATEGORIES: CategoryMeta[] = [
         unit: 'percentage',
         links: [
           {
-            name: 'Documentation',
+            name: 'Disk Throughput and IOPS',
             url: 'https://supabase.com/docs/guides/platform/compute-add-ons#disk-throughput-and-iops',
           },
         ],
@@ -134,7 +136,7 @@ export const USAGE_CATEGORIES: CategoryMeta[] = [
         chartPrefix: 'Average ',
         unit: 'bytes',
         description:
-          'Billing is based on the average daily database size in GB throughout the billing period.',
+          'Database size refers to the monthly average storage usage, as reported by Postgres. Paid plans use auto-scaling disks.\nBilling is based on the average daily database size used in GB throughout the billing period. Billing is independent of the provisioned disk size.',
         links: [
           {
             name: 'Documentation',
@@ -142,25 +144,72 @@ export const USAGE_CATEGORIES: CategoryMeta[] = [
           },
         ],
         chartDescription: 'The data refreshes every 24 hours.',
-        additionalInfo: (subscription?: ProjectSubscriptionResponse, usage?: ProjectUsageData) =>
-          subscription?.plan?.id !== 'free' ? (
-            <div className="flex items-center justify-between">
-              <div className="flex items-center space-x-2">
-                <p className="text-sm">Disk size:</p>
-                <p className="text-sm">{usage?.disk_volume_size_gb} GB</p>
-                <Badge color="green" size="small">
-                  Auto-scaling
-                </Badge>
+        additionalInfo: (
+          ref: string,
+          subscription?: ProjectSubscriptionResponse,
+          usage?: ProjectUsageData
+        ) => {
+          const usageMeta = usage?.['db_size'] ?? undefined
+          const usageRatio =
+            typeof usageMeta !== 'number' ? (usageMeta?.usage ?? 0) / (usageMeta?.limit ?? 0) : 0
+          const hasLimit = usageMeta && usageMeta.limit > 0
+
+          const isApproachingLimit = hasLimit && usageRatio >= USAGE_APPROACHING_THRESHOLD
+          const isExceededLimit = hasLimit && usageRatio >= 1
+          console.log({ usageMeta, isApproachingLimit, isExceededLimit })
+
+          return subscription?.plan?.id !== 'free' ? (
+            <div>
+              <div className="flex items-center justify-between">
+                <div className="flex items-center space-x-2">
+                  <p className="text-sm">Disk size:</p>
+                  <p className="text-sm">{usage?.disk_volume_size_gb} GB</p>
+                  <Badge color="green" size="small">
+                    Auto-scaling
+                  </Badge>
+                </div>
+                <Link href="https://supabase.com/docs/guides/platform/database-usage#disk-management">
+                  <a>
+                    <Button size="tiny" type="default" icon={<IconExternalLink size={14} />}>
+                      What is disk size?
+                    </Button>
+                  </a>
+                </Link>
               </div>
-              <Link href="https://supabase.com/docs/guides/platform/database-usage#disk-management">
-                <a>
-                  <Button size="tiny" type="default" icon={<IconExternalLink size={14} />}>
-                    What is disk size?
-                  </Button>
-                </a>
-              </Link>
+              <p className="text-sm text-scale-1000 mt-3">
+                Your disk storage expands automatically when the database reaches 90% of the disk
+                size. The disk is expanded to be 50% larger. Auto-scaling can only take place once
+                every 6 hours. If you reach 95% of the disk space, your project will enter read-only
+                mode. You can also{' '}
+                <Link passHref href={`/project/${ref}/settings/database#diskManagement`}>
+                  <a className="text-brand-900 transition hover:text-brand-1000">preprovision</a>
+                </Link>{' '}
+                disk for loading larger amounts of data.
+              </p>
             </div>
-          ) : null,
+          ) : (
+            <div>
+              {(isApproachingLimit || isExceededLimit) && (
+                <Alert
+                  withIcon
+                  variant={isExceededLimit ? 'danger' : 'warning'}
+                  title={
+                    isExceededLimit
+                      ? 'Exceeding database size limit'
+                      : 'Nearing database size limit'
+                  }
+                >
+                  <div className="flex w-full items-center flex-col justify-center space-y-2 md:flex-row md:justify-between">
+                    <div>
+                      When you reach your database size limit, your project can go into read-only
+                      mode. Please upgrade your plan.
+                    </div>
+                  </div>
+                </Alert>
+              )}
+            </div>
+          )
+        },
       },
       {
         anchor: 'storageSize',
@@ -172,6 +221,12 @@ export const USAGE_CATEGORIES: CategoryMeta[] = [
         description:
           'Sum of all objects in your storage buckets.\nBilling is based on the average daily size in GB throughout your billing period.',
         chartDescription: 'The data refreshes every 24 hours.',
+        links: [
+          {
+            name: 'Storage',
+            url: 'https://supabase.com/docs/guides/storage',
+          },
+        ],
       },
       {
         anchor: 'funcCount',
@@ -201,6 +256,12 @@ export const USAGE_CATEGORIES: CategoryMeta[] = [
           'Users who log in or refresh their token count towards MAU.\nBilling is based on the sum of distinct users requesting your API throughout the billing period. Resets every billing cycle.',
         chartDescription:
           'The data is refreshed over a period of 24 hours and resets at the beginning of every billing period.\nThe data points are relative to the beginning of your billing period.',
+        links: [
+          {
+            name: 'Auth',
+            url: 'https://supabase.com/docs/guides/auth',
+          },
+        ],
       },
       {
         anchor: 'mauSso',
@@ -212,6 +273,12 @@ export const USAGE_CATEGORIES: CategoryMeta[] = [
           'SSO users who log in or refresh their token count towards SSO MAU.\nBilling is based on the sum of distinct Single Sign-On users requesting your API throughout the billing period. Resets every billing cycle.',
         chartDescription:
           'The data refreshes over a period of 24 hours and resets at the beginning of every billing period.\nThe data points are relative to the beginning of your billing period.',
+        links: [
+          {
+            name: 'SSO with SAML 2.0',
+            url: 'https://supabase.com/docs/guides/auth/sso/auth-sso-saml',
+          },
+        ],
       },
       {
         anchor: 'storageImageTransformations',
@@ -223,6 +290,12 @@ export const USAGE_CATEGORIES: CategoryMeta[] = [
           'We count all images that were transformed in the billing period, ignoring any transformations.\nUsage example: You transform one image with four different size transformations and another image with just a single transformation. It counts as two, as only two images were transformed.\nBilling is based on the count of (origin) images that used transformations throughout the billing period. Resets every billing cycle.',
         chartDescription:
           'The data refreshes every 24 hours.\nThe data points are relative to the beginning of your billing period.',
+        links: [
+          {
+            name: 'Documentation',
+            url: 'https://supabase.com/docs/guides/storage/image-transformations',
+          },
+        ],
       },
       {
         anchor: 'functionInvocations',
@@ -233,6 +306,12 @@ export const USAGE_CATEGORIES: CategoryMeta[] = [
         description:
           'Every serverless function invocation independent of response status is counted.\nBilling is based on the sum of all invocations throughout your billing period.',
         chartDescription: 'The data refreshes every 24 hours.',
+        links: [
+          {
+            name: 'Edge Functions',
+            url: 'https://supabase.com/docs/guides/functions',
+          },
+        ],
       },
       {
         anchor: 'realtimeMessageCount',

--- a/studio/components/interfaces/BillingV2/Usage/UsageSection.tsx
+++ b/studio/components/interfaces/BillingV2/Usage/UsageSection.tsx
@@ -148,7 +148,7 @@ const UsageSection = ({
                         barClass={clsx(
                           usageRatio >= 1
                             ? usageBasedBilling
-                              ? 'bg-amber-900'
+                              ? 'bg-scale-1100'
                               : 'bg-red-900'
                             : usageBasedBilling === false &&
                               usageRatio >= USAGE_APPROACHING_THRESHOLD
@@ -204,7 +204,7 @@ const UsageSection = ({
                     </div>
                   </div>
 
-                  {attribute.additionalInfo?.(subscription, usage)}
+                  {attribute.additionalInfo?.(projectRef, subscription, usage)}
 
                   <div className="space-y-1">
                     <p>

--- a/studio/components/interfaces/Settings/Database/DiskSizeConfiguration.tsx
+++ b/studio/components/interfaces/Settings/Database/DiskSizeConfiguration.tsx
@@ -71,7 +71,7 @@ const DiskSizeConfiguration = ({ disabled = false }: DiskSizeConfigurationProps)
   })
 
   return (
-    <div>
+    <div id="diskManagement">
       <FormHeader title="Disk management" />
       {projectSubscriptionData?.tier.supabase_prod_id != 'tier_free' ? (
         <div className="flex flex-col gap-3">


### PR DESCRIPTION
- Few more links to docs
- More copy around disk and database size
  - Link to manual disk size provisioning
- Approaching or exceeding limit on a usage-based plan is no longer amber, as there is no action required and it signals that something might need attention
- Added tooltips to subscription page warnings
- Adjusted copy for CPU/memory usage