### PR TITLE
Docs: Add additional mutually exclusive note on backups docs

### DIFF
--- a/apps/docs/pages/guides/platform/backups.mdx
+++ b/apps/docs/pages/guides/platform/backups.mdx
@@ -8,7 +8,8 @@ export const meta = {
 
 export const mutuallyExclusiveNote = (
   <Admonition type="note">
-    If you enable PITR, Daily Backups will no longer be taken. PITR provides a finer granularity than Daily Backups, so it's unnecessary to run both.
+    If you enable PITR, Daily Backups will no longer be taken. PITR provides a finer granularity
+    than Daily Backups, so it's unnecessary to run both.
   </Admonition>
 )
 
@@ -76,7 +77,7 @@ By default, WAL files are backed up at two minute intervals. If these files cros
 
 ![PITR dashboard](/docs/img/backups-pitr-dashboard.png)
 
-You can access PITR in the [Point in Time](https://app.supabase.com/project/_/database/backups/pitr) settings in the Dashboard. The recovery period of a project is indicated by the earliest and latest points of recoveries displayed in one's preferred timezone. If need be, the maximum amount of this recovery period can be modified accordingly.
+You can access PITR in the [Point in Time](https://app.supabase.com/project/_/database/backups/pitr) settings in the Dashboard. The recovery period of a project is indicated by the earliest and latest points of recoveries displayed in your preferred timezone. If need be, the maximum amount of this recovery period can be modified accordingly.
 
 Note that the latest restore point of the project could be significantly far from the current time. This occurs when there has not been any recent activity in the database, and therefore no WAL file backups have been made recently. This is perfectly fine as the state of the database at the latest point of recovery would still be indicative of the state of the database at the current time given that no transactions have been made in between.
 

--- a/apps/docs/pages/guides/platform/backups.mdx
+++ b/apps/docs/pages/guides/platform/backups.mdx
@@ -1,9 +1,18 @@
 import Layout from '~/layouts/DefaultGuideLayout'
+import Admonition from '~/components/Admonition'
 
 export const meta = {
   title: 'Database Backups',
   description: 'Learn about the available backup methods for your Supabase project.',
 }
+
+export const mutuallyExclusiveNote = (
+  <Admonition type="note">
+    Daily Backups and PITR are mutually exclusive. If your project opts into using PITR, Daily
+    Backups will no longer be taken. They're also unnecessary, as PITR supports a superset of
+    functionality, in terms of the granular recovery that can be performed.
+  </Admonition>
+)
 
 Database backups are an integral part of any disaster recovery plan. Disasters come in many shapes and sizes. It could be as simple as accidentally deleting a table column, the database crashing, or even a natural calamity wiping out the underlying hardware a database is running on. The risks and impact brought by these scenarios can never be fully eliminated, but only minimized or even mitigated. Having database backups is a form of insurance policy. They are essentially snapshots of the database at various points in time. When disaster strikes, database backups allow the project to be brought back to any of these points in time, therefore averting the crisis.
 
@@ -11,7 +20,7 @@ Database backups are an integral part of any disaster recovery plan. Disasters c
 
 When deciding how often a database should be backed up, the key business metric Recovery Point Objective (RPO) should be considered. RPO is the threshold for how much data, measured in time, a business could lose when disaster strikes. This amount is fully dependent on a business and its underlying requirements. A low RPO would mean that database backups would have to be taken at an increased cadence throughout the day. Each Supabase project has access to two forms of backups, Daily Backups and Point-in-Time Recovery (PITR). The agreed upon RPO would be a deciding factor in choosing which solution best fits a project.
 
-Daily Backups and PITR are mutually exclusive. If your project opts into using PITR, Daily Backups will no longer be taken. They're also unnecessary, as PITR supports a superset of functionality, in terms of the granular recovery that can be performed.
+{mutuallyExclusiveNote}
 
 <Admonition type="note">
 
@@ -56,6 +65,8 @@ Point-in-Time Recovery (PITR) allows a project to be backed up at much shorter i
 This feature is available to all Enterprise plan projects. Pro plan projects can enable PITR as an add-on.
 
 </Admonition>
+
+{mutuallyExclusiveNote}
 
 ### Backup Process [#pitr-backup-process]
 

--- a/apps/docs/pages/guides/platform/backups.mdx
+++ b/apps/docs/pages/guides/platform/backups.mdx
@@ -14,9 +14,9 @@ When deciding how often a database should be backed up, the key business metric 
 Daily Backups and PITR are mutually exclusive. If your project opts into using PITR, Daily Backups will no longer be taken. They're also unnecessary, as PITR supports a superset of functionality, in terms of the granular recovery that can be performed.
 
 <Admonition type="note">
-  Database backups do not include objects stored via the Storage API, as the database only includes
-  metadata about these objects. Restoring an old backup does not restore objects that have been
-  deleted since then.
+
+Database backups do not include objects stored via the Storage API, as the database only includes metadata about these objects. Restoring an old backup does not restore objects that have been deleted since then.
+
 </Admonition>
 
 ## Daily Backups
@@ -24,9 +24,9 @@ Daily Backups and PITR are mutually exclusive. If your project opts into using P
 All Pro and Enterprise plan Supabase projects are backed up automatically on a daily basis. In terms of Recovery Point Objective (RPO), Daily Backups would be suitable for projects willing to lose up to 24 hours worth of data if disaster hits at the most inopportune time. If a lower RPO is required, enabling Point-in-Time Recovery should be considered.
 
 <Admonition type="note">
-  For security purposes, passwords for custom roles are not stored in daily backups, and will not be
-  found in downloadable files. As such, if you are restoring from a daily backup and are using
-  custom roles, you will need to set their passwords once more following a completed restoration.
+
+For security purposes, passwords for custom roles are not stored in daily backups, and will not be found in downloadable files. As such, if you are restoring from a daily backup and are using custom roles, you will need to set their passwords once more following a completed restoration.
+
 </Admonition>
 
 ### Backup Process [#daily-backups-process]
@@ -35,11 +35,11 @@ The PostgreSQL utility [pg_dumpall](https://www.postgresql.org/docs/current/app-
 
 ![Scheduled backups dashboard](/docs/img/backups-daily-dashboard.png)
 
-You can access daily backups in the [Scheduled backups](https://app.supabase.com/project/_/database/backups/scheduled) settings in the Dashboard. Pro plan projects can access the last 7 days’ worth of daily backups while Enterprise plan projects can access up to 30 days’ worth of daily backups. Users can restore their project to any one of the backups or download them as a zipped SQL file.
+You can access daily backups in the [Scheduled backups](https://app.supabase.com/project/_/database/backups/scheduled) settings in the Dashboard. Pro plan projects can access the last 7 days' worth of daily backups while Enterprise plan projects can access up to 30 days' worth of daily backups. Users can restore their project to any one of the backups or download them as a zipped SQL file.
 
 ### Restoration Process [#daily-backups-restoration-process]
 
-When selecting a backup to restore to, select the closest available one made before the desired point in time to restore to. Earlier backups can always be chosen too but do consider the number of days’ worth of data that could be lost.
+When selecting a backup to restore to, select the closest available one made before the desired point in time to restore to. Earlier backups can always be chosen too but do consider the number of days' worth of data that could be lost.
 
 ![Scheduled backups: Confirmation modal](/docs/img/backups-daily-confirmation-modal.png)
 
@@ -49,11 +49,12 @@ The Dashboard will then prompt for a confirmation before proceeding with the res
 
 ## Point-in-Time Recovery
 
-Point-in-Time Recovery (PITR) allows a project to be backed up at much shorter intervals. This provides users an option to restore to any chosen point of up to seconds in granularity. Even with daily backups, a day’s worth of data could still be lost. With PITR, backups could be performed up to the point of disaster.
+Point-in-Time Recovery (PITR) allows a project to be backed up at much shorter intervals. This provides users an option to restore to any chosen point of up to seconds in granularity. Even with daily backups, a day's worth of data could still be lost. With PITR, backups could be performed up to the point of disaster.
 
 <Admonition type="note">
-  This feature is available to all Enterprise plan projects. Pro plan projects can enable PITR as an
-  add-on.
+
+This feature is available to all Enterprise plan projects. Pro plan projects can enable PITR as an add-on.
+
 </Admonition>
 
 ### Backup Process [#pitr-backup-process]
@@ -66,7 +67,7 @@ By default, WAL files are backed up at two minute intervals. If these files cros
 
 ![PITR dashboard](/docs/img/backups-pitr-dashboard.png)
 
-You can access PITR in the [Point in Time](https://app.supabase.com/project/_/database/backups/pitr) settings in the Dashboard. The recovery period of a project is indicated by the earliest and latest points of recoveries displayed in one’s preferred timezone. If need be, the maximum amount of this recovery period can be modified accordingly.
+You can access PITR in the [Point in Time](https://app.supabase.com/project/_/database/backups/pitr) settings in the Dashboard. The recovery period of a project is indicated by the earliest and latest points of recoveries displayed in one's preferred timezone. If need be, the maximum amount of this recovery period can be modified accordingly.
 
 Note that the latest restore point of the project could be significantly far from the current time. This occurs when there has not been any recent activity in the database, and therefore no WAL file backups have been made recently. This is perfectly fine as the state of the database at the latest point of recovery would still be indicative of the state of the database at the current time given that no transactions have been made in between.
 

--- a/apps/docs/pages/guides/platform/backups.mdx
+++ b/apps/docs/pages/guides/platform/backups.mdx
@@ -8,9 +8,7 @@ export const meta = {
 
 export const mutuallyExclusiveNote = (
   <Admonition type="note">
-    Daily Backups and PITR are mutually exclusive. If your project opts into using PITR, Daily
-    Backups will no longer be taken. They're also unnecessary, as PITR supports a superset of
-    functionality, in terms of the granular recovery that can be performed.
+    If you enable PITR, Daily Backups will no longer be taken. PITR provides a finer granularity than Daily Backups, so it's unnecessary to run both.
   </Admonition>
 )
 


### PR DESCRIPTION
Moves the "Daily Backups and PITR are mutually exclusive" note to an admonition and duplicates it under the PITR section for visibility.