### PR TITLE
Docs: Move scrollbar to content area

### DIFF
--- a/apps/docs/layouts/DefaultLayout.tsx
+++ b/apps/docs/layouts/DefaultLayout.tsx
@@ -83,7 +83,7 @@ const Layout: FC<Props> = (props: Props) => {
 }
 
 export const LayoutMainContent: FC<{ className?: string }> = ({ className, children }) => (
-  <div className={['max-w-7xl px-5 mx-auto py-16', className].join(' ')}>{children}</div>
+  <div className={['max-w-7xl mx-auto', className].join(' ')}>{children}</div>
 )
 
 export default Layout

--- a/apps/docs/layouts/SiteLayout.tsx
+++ b/apps/docs/layouts/SiteLayout.tsx
@@ -242,7 +242,7 @@ const Container = memo(function Container(props) {
       id="docs-content-container"
       className={[
         // 'overflow-x-auto',
-        'w-full h-screen transition-all ease-out',
+        'w-full transition-all ease-out',
         'absolute lg:relative',
         mobileMenuOpen
           ? '!w-auto ml-[75%] sm:ml-[50%] md:ml-[33%] overflow-hidden'
@@ -251,7 +251,7 @@ const Container = memo(function Container(props) {
         'lg:ml-0',
       ].join(' ')}
     >
-      <div className="flex flex-col relative">{props.children}</div>
+      <div className="flex flex-col relative h-screen">{props.children}</div>
     </div>
   )
 })
@@ -329,7 +329,7 @@ const SiteLayout = ({ children }: PropsWithChildren<{}>) => {
         <div className="flex flex-row h-screen">
           <NavContainer />
           <Container>
-            <div className={['lg:sticky top-0 z-10 overflow-hidden'].join(' ')}>
+            <div className={['z-10'].join(' ')}>
               <TopNavBarRef />
             </div>
             <div
@@ -343,10 +343,7 @@ const SiteLayout = ({ children }: PropsWithChildren<{}>) => {
                 <MobileHeader />
               </div>
             </div>
-            <div className="grow">
-              {children}
-              <Footer />
-            </div>
+            <div className="grow overflow-y-auto">{children}</div>
             <MobileMenuBackdrop />
           </Container>
         </div>

--- a/apps/docs/layouts/guides/index.tsx
+++ b/apps/docs/layouts/guides/index.tsx
@@ -12,6 +12,7 @@ import GuidesTableOfContents from '~/components/GuidesTableOfContents'
 import useHash from '~/hooks/useHash'
 import { LayoutMainContent } from '../DefaultLayout'
 import ExpandableVideo from 'ui/src/components/ExpandableVideo/ExpandableVideo'
+import Footer from '~/components/Navigation/Footer'
 
 interface Props {
   meta: {
@@ -106,14 +107,16 @@ const Layout: FC<Props> = (props) => {
           },
         }}
       />
-      <LayoutMainContent className="pb-0">
-        <div className={['grid grid-cols-12 relative gap-4'].join(' ')}>
+      <LayoutMainContent className="pb-0 h-full">
+        <div className={['grid grid-cols-12 relative gap-4 h-full'].join(' ')}>
           <div
             className={[
               'relative',
               !props.hideToc ? 'col-span-12 md:col-span-9' : 'col-span-12',
               'transition-all ease-out',
               'duration-100',
+              'h-full',
+              'overflow-y-auto',
             ].join(' ')}
           >
             {props.meta.breadcrumb && (
@@ -123,7 +126,7 @@ const Layout: FC<Props> = (props) => {
               ref={articleRef}
               className={`${
                 props.meta?.hide_table_of_contents || !hasTableOfContents ? '' : ''
-              } prose dark:prose-dark max-w-none`}
+              } prose dark:prose-dark max-w-none h-full overflow-y-auto px-10 py-16`}
             >
               <h1 className="mb-0">{props.meta.title}</h1>
               {props.meta.subtitle && (
@@ -146,6 +149,8 @@ const Layout: FC<Props> = (props) => {
                   </div>
                 </div>
               )}
+
+              <Footer />
             </article>
           </div>
           {!props.hideToc && hasTableOfContents && !props.meta?.hide_table_of_contents && (
@@ -158,17 +163,15 @@ const Layout: FC<Props> = (props) => {
                 'duration-100',
               ].join(' ')}
             >
-              <div className="border-l">
-                {props.meta?.tocVideo && !!tocVideoPreview && (
-                  <div className="relative mb-6 pl-5">
-                    <ExpandableVideo imgUrl={tocVideoPreview} videoId={props.meta.tocVideo} />
-                  </div>
-                )}
-                <span className="block font-mono text-xs uppercase text-scale-1200 px-5 mb-6">
-                  On this page
-                </span>
-                <GuidesTableOfContents list={tocList} />
-              </div>
+              {props.meta?.tocVideo && !!tocVideoPreview && (
+                <div className="relative mb-6 pl-5">
+                  <ExpandableVideo imgUrl={tocVideoPreview} videoId={props.meta.tocVideo} />
+                </div>
+              )}
+              <span className="block font-mono text-xs uppercase text-scale-1200 px-5 mb-6">
+                On this page
+              </span>
+              <GuidesTableOfContents list={tocList} />
             </div>
           )}
         </div>

--- a/studio/README.md
+++ b/studio/README.md
@@ -1,7 +1,5 @@
 # Supabase Studio
 
-test
-
 A dashboard for managing your self-hosted Supabase project, and used on our [hosted platform](https://supabase.com/dashboard). Built with:
 
 - [Next.js](https://nextjs.org/)

--- a/studio/README.md
+++ b/studio/README.md
@@ -1,5 +1,7 @@
 # Supabase Studio
 
+test
+
 A dashboard for managing your self-hosted Supabase project, and used on our [hosted platform](https://supabase.com/dashboard). Built with:
 
 - [Next.js](https://nextjs.org/)


### PR DESCRIPTION
Moves the scrollbar in docs from far right side to right-side of the content.

## Preview
https://docs-git-feat-docs-content-scrollbar-supabase.vercel.app/docs/guides/getting-started/local-development

### Old
![image](https://github.com/supabase/supabase/assets/4133076/1c3a2cd5-05ea-4c52-a0e6-4b3fbe7ccf45)

### New
![image](https://github.com/supabase/supabase/assets/4133076/c91a84b8-2d48-4f38-b86b-71e3a77e9fbb)

This is WIP. Still need to:
- [ ] Fix footer styling
- [ ] Fix home page padding
- [ ] Fix reference doc padding
- [ ] Regression test (mobile & desktop)