### PR TITLE
Add missing export let data in example

### DIFF
--- a/apps/docs/pages/guides/auth/auth-helpers/sveltekit.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/sveltekit.mdx
@@ -363,6 +363,7 @@ We can access the supabase instance in our `+page.svelte` file through the data 
 ```svelte src/routes/auth/+page.svelte
 <!-- // src/routes/auth/+page.svelte -->
 <script>
+  export let data
   let { supabase } = data
   $: ({ supabase } = data)
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

The example doesn't work if you copyp/paste.

## What is the new behavior?

Now it does.

## Additional context

Hi, if you blindly follow the sveltekit auth helpers examples in this great guide, one of them fails because of a little missing `export let data`. This PR adds that line.

Thanks!
