### PR TITLE
chore: PITR and payment method improvements

### DIFF
--- a/studio/components/interfaces/BillingV2/Subscription/AddOns/ComputeInstanceSidePanel.tsx
+++ b/studio/components/interfaces/BillingV2/Subscription/AddOns/ComputeInstanceSidePanel.tsx
@@ -58,10 +58,14 @@ const ComputeInstanceSidePanel = () => {
 
   const isFreePlan = subscription?.plan.id === 'free'
   const subscriptionCompute = selectedAddons.find((addon) => addon.type === 'compute_instance')
+  const pitrAddon = selectedAddons.find((addon) => addon.type === 'pitr')
   const availableOptions =
     availableAddons.find((addon) => addon.type === 'compute_instance')?.variants ?? []
   const selectedCompute = availableOptions.find((option) => option.identifier === selectedOption)
   const hasChanges = selectedOption !== (subscriptionCompute?.variant.identifier ?? 'ci_micro')
+
+  const blockMicroDowngradeDueToPitr =
+    pitrAddon !== undefined && selectedOption === 'ci_micro' && hasChanges
 
   useEffect(() => {
     if (visible) {
@@ -115,7 +119,7 @@ const ComputeInstanceSidePanel = () => {
         onCancel={onClose}
         onConfirm={() => setShowConfirmationModal(true)}
         loading={isLoading}
-        disabled={isFreePlan || isLoading || !hasChanges}
+        disabled={isFreePlan || isLoading || !hasChanges || blockMicroDowngradeDueToPitr}
         tooltip={isFreePlan ? 'Unable to update compute instance on a free plan' : undefined}
         header={
           <div className="flex items-center justify-between">
@@ -225,7 +229,10 @@ const ComputeInstanceSidePanel = () => {
                             <p className="text-scale-1200 text-sm">
                               ${option.price.toLocaleString()}
                             </p>
-                            <p className="text-scale-1000 translate-y-[1px]"> / month</p>
+                            <p className="text-scale-1000 translate-y-[1px]">
+                              {' '}
+                              / {option.price_interval === 'monthly' ? 'month' : 'hour'}
+                            </p>
                           </div>
                         </div>
                       </div>
@@ -261,7 +268,7 @@ const ComputeInstanceSidePanel = () => {
                 </p>
               ))}
 
-            {hasChanges && (
+            {hasChanges && !blockMicroDowngradeDueToPitr && (
               <Alert
                 withIcon
                 variant="info"
@@ -269,6 +276,26 @@ const ComputeInstanceSidePanel = () => {
               >
                 It will take up to 2 minutes for changes to take place, in which your project will
                 be unavailable during that time.
+              </Alert>
+            )}
+
+            {blockMicroDowngradeDueToPitr && (
+              <Alert
+                withIcon
+                variant="info"
+                className="mb-4"
+                title="Disable PITR before downgrading to Micro Compute"
+                actions={
+                  <Button type="default" onClick={() => snap.setPanelKey('pitr')}>
+                    Change PITR
+                  </Button>
+                }
+              >
+                <p>
+                  You currently have PITR enabled. The minimum compute instance size for using PITR
+                  is the Small Compute.
+                </p>
+                <p>You need to disable PITR before downgrading to Micro Compute.</p>
               </Alert>
             )}
           </div>

--- a/studio/components/interfaces/BillingV2/Subscription/Tier/SubscriptionPaymentMethod.tsx
+++ b/studio/components/interfaces/BillingV2/Subscription/Tier/SubscriptionPaymentMethod.tsx
@@ -14,9 +14,10 @@ import { BASE_PATH } from 'lib/constants'
 
 export interface SubscriptionTierProps {
   subscription: ProjectSubscriptionResponse
+  onSubscriptionUpdated: () => void
 }
 
-const SubscriptionPaymentMethod = ({ subscription }: SubscriptionTierProps) => {
+const SubscriptionPaymentMethod = ({ subscription, onSubscriptionUpdated }: SubscriptionTierProps) => {
   const { ref: projectRef } = useParams()
   const { ui } = useStore()
 
@@ -54,6 +55,8 @@ const SubscriptionPaymentMethod = ({ subscription }: SubscriptionTierProps) => {
           category: 'success',
           message: `Successfully updated payment method!`,
         })
+
+        onSubscriptionUpdated()
       } catch (error: any) {
         ui.setNotification({
           error,

--- a/studio/components/interfaces/BillingV2/Subscription/Tier/SubscriptionTier.tsx
+++ b/studio/components/interfaces/BillingV2/Subscription/Tier/SubscriptionTier.tsx
@@ -19,7 +19,7 @@ const SubscriptionTier = ({}: SubscriptionTierProps) => {
   const orgSlug = ui.selectedOrganization?.slug ?? ''
   const snap = useSubscriptionPageStateSnapshot()
   const projectUpdateDisabled = useFlag('disableProjectCreationAndUpdate')
-  const { data: subscription, isLoading } = useProjectSubscriptionV2Query({ projectRef })
+  const { data: subscription, isLoading, refetch } = useProjectSubscriptionV2Query({ projectRef })
 
   const currentPlan = subscription?.plan
   const tierName = currentPlan?.name || 'Unknown'
@@ -149,7 +149,12 @@ const SubscriptionTier = ({}: SubscriptionTierProps) => {
               labelTop={`${daysToCycleEnd} Days left`}
             />
 
-            {subscription && <SubscriptionPaymentMethod subscription={subscription} />}
+            {subscription && (
+              <SubscriptionPaymentMethod
+                subscription={subscription}
+                onSubscriptionUpdated={() => refetch()}
+              />
+            )}
           </div>
         )}
       </div>


### PR DESCRIPTION
- Forcefully refresh subscription when updating payment method, as it's not fetched automatically (not like the side panel)
- Show a hint and disallow downgrading to Micro compute, if PITR is enabled

<img width="860" alt="Screenshot 2023-06-14 at 00 48 59" src="https://github.com/supabase/supabase/assets/14073399/9cf8ffc4-37ee-497c-a06a-38f1c34274b4">
