### PR TITLE
Docs: Add sitemap.ts to Next.js Auth Helpers example

### DIFF
--- a/examples/auth/nextjs/app/sitemap.ts
+++ b/examples/auth/nextjs/app/sitemap.ts
@@ -1,0 +1,14 @@
+import { createServerComponentClient } from '@supabase/auth-helpers-nextjs'
+import { cookies } from 'next/headers'
+
+export default async function sitemap() {
+  const supabase = createServerComponentClient({ cookies })
+  const { data: posts } = await supabase.from('posts').select()
+
+  return (
+    posts?.map(({ id }) => ({
+      url: `https://example.com/${id}`,
+      lastModified: new Date(),
+    })) ?? []
+  )
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

Next.js Auth Helpers **does not have** an example for generating a sitemap.xml from Supabase data

## What is the new behavior?

Next.js Auth Helpers **has** an example for generating a sitemap.xml from Supabase data

## Additional context

https://twitter.com/KyleRummens/status/1668650559602319360?s=20
