### PR TITLE
chore: add info about memory usage

### DIFF
--- a/studio/components/interfaces/BillingV2/Usage/Infrastructure.tsx
+++ b/studio/components/interfaces/BillingV2/Usage/Infrastructure.tsx
@@ -205,9 +205,17 @@ const Infrastructure = ({
                 </div>
 
                 {attribute.key === 'ram_usage' && (
-                  <p className="text-sm text-scale-1000">
-                    Your compute instance has {currentComputeInstanceSpecs.memoryGb} GB memory.
-                  </p>
+                  <div className="text-sm text-scale-1000">
+                    <p>
+                      Your compute instance has {currentComputeInstanceSpecs.memoryGb} GB memory.
+                    </p>
+                    {currentComputeInstanceSpecs.memoryGb === 1 && (
+                      <p>
+                        As your project is running on the smallest compute instance, it is not
+                        unusual for your project to have a base memory usage of ~50%.
+                      </p>
+                    )}
+                  </div>
                 )}
 
                 {attribute.key === 'cpu_usage' && (

--- a/studio/components/interfaces/BillingV2/Usage/Infrastructure.tsx
+++ b/studio/components/interfaces/BillingV2/Usage/Infrastructure.tsx
@@ -207,7 +207,7 @@ const Infrastructure = ({
                 {attribute.key === 'ram_usage' && (
                   <div className="text-sm text-scale-1000">
                     <p>
-                      Your compute instance has {currentComputeInstanceSpecs.memoryGb} GB memory.
+                      Your compute instance has {currentComputeInstanceSpecs.memoryGb} GB of memory.
                     </p>
                     {currentComputeInstanceSpecs.memoryGb === 1 && (
                       <p>

--- a/studio/components/interfaces/BillingV2/Usage/Usage.constants.tsx
+++ b/studio/components/interfaces/BillingV2/Usage/Usage.constants.tsx
@@ -61,6 +61,10 @@ export const USAGE_CATEGORIES: CategoryMeta[] = [
             url: 'https://supabase.com/docs/guides/platform/compute-add-ons',
           },
           { name: 'High CPU Usage', url: 'https://supabase.com/docs/guides/platform/exhaust-cpu' },
+          {
+            name: 'Metrics',
+            url: 'https://supabase.com/docs/guides/platform/metrics',
+          },
         ],
       },
       {
@@ -69,12 +73,17 @@ export const USAGE_CATEGORIES: CategoryMeta[] = [
         attribute: 'ram_usage',
         name: 'Memory',
         unit: 'percentage',
-        description: 'Memory usage of your server',
+        description:
+          'Memory usage of your server.\nEven with little to no load, you might observe elevated memory usage. Besides Postgres, a wide range of services is running under the hood resulting in an elevated base memory usage.',
         chartDescription: '',
         links: [
           {
             name: 'Compute Add-Ons',
             url: 'https://supabase.com/docs/guides/platform/compute-add-ons',
+          },
+          {
+            name: 'Metrics',
+            url: 'https://supabase.com/docs/guides/platform/metrics',
           },
         ],
       },
@@ -88,6 +97,10 @@ export const USAGE_CATEGORIES: CategoryMeta[] = [
           {
             name: 'Disk Throughput and IOPS',
             url: 'https://supabase.com/docs/guides/platform/compute-add-ons#disk-throughput-and-iops',
+          },
+          {
+            name: 'Metrics',
+            url: 'https://supabase.com/docs/guides/platform/metrics',
           },
         ],
         description:

--- a/studio/components/interfaces/BillingV2/Usage/Usage.constants.tsx
+++ b/studio/components/interfaces/BillingV2/Usage/Usage.constants.tsx
@@ -74,7 +74,7 @@ export const USAGE_CATEGORIES: CategoryMeta[] = [
         name: 'Memory',
         unit: 'percentage',
         description:
-          'Memory usage of your server.\nEven with little to no load, you might observe elevated memory usage. Besides Postgres, a wide range of services is running under the hood resulting in an elevated base memory usage.',
+          'Memory usage of your server.\nYou might observe elevated memory usage, even with little to no load. Besides Postgres, a wide range of services is running under the hood resulting in an elevated base memory usage.',
         chartDescription: '',
         links: [
           {


### PR DESCRIPTION
- Added links to Metrics docs (Prometheus access)
- Added general info about base memory usage
- Added specific info about base memory usage on smallest compute

![Screenshot 2023-06-14 at 12 53 44](https://github.com/supabase/supabase/assets/14073399/02242554-8acc-4b63-b559-6bea81ffdd5e)
