### PR TITLE
fix: disallow self-serve downgrades from Enterprise/Team

### DIFF
--- a/studio/pages/project/[ref]/settings/billing/update/enterprise.tsx
+++ b/studio/pages/project/[ref]/settings/billing/update/enterprise.tsx
@@ -41,10 +41,20 @@ const BillingUpdateEnterprise: NextPageWithLayout = () => {
   }, [orgSlug])
 
   useEffect(() => {
-    if (subscription !== undefined && !isEnterprise) {
-      router.push(`/project/${projectRef}/settings/billing/update`)
+    if (subscription && !isEnterprise) {
+      if (subscription.tier.supabase_prod_id === PRICING_TIER_PRODUCT_IDS.TEAM) {
+        router.push(`/project/${projectRef}/settings/billing/update/team`)
+      } else if (
+        [PRICING_TIER_PRODUCT_IDS.PAYG, PRICING_TIER_PRODUCT_IDS.PRO].includes(
+          subscription.tier.supabase_prod_id
+        )
+      ) {
+        router.push(`/project/${projectRef}/settings/billing/update/pro`)
+      } else {
+        router.push(`/project/${projectRef}/settings/billing/update`)
+      }
     }
-  }, [subscription])
+  }, [subscription, isEnterprise, projectRef, router])
 
   const getStripeProducts = async () => {
     try {

--- a/studio/pages/project/[ref]/settings/billing/update/free.tsx
+++ b/studio/pages/project/[ref]/settings/billing/update/free.tsx
@@ -30,10 +30,17 @@ const BillingUpdateFree: NextPageWithLayout = () => {
   }, [projectRef])
 
   useEffect(() => {
-    if (isEnterprise) {
+    if (subscription?.tier?.supabase_prod_id === PRICING_TIER_PRODUCT_IDS.ENTERPRISE) {
+      // no self-serve downgrade from Enterprise
       router.push(`/project/${projectRef}/settings/billing/update/enterprise`)
+    } else if (subscription?.tier?.supabase_prod_id === PRICING_TIER_PRODUCT_IDS.TEAM) {
+      // no self-serve downgrade from Team
+      router.push(`/project/${projectRef}/settings/billing/update/team`)
+    } else if (subscription?.tier?.supabase_prod_id === PRICING_TIER_PRODUCT_IDS.FREE) {
+      // Downgrade from free to free is not possible, so let's redirect
+      router.push(`/project/${projectRef}/settings/billing/update`)
     }
-  }, [subscription])
+  }, [subscription, projectRef, router])
 
   const getStripeProducts = async () => {
     try {

--- a/studio/pages/project/[ref]/settings/billing/update/pro.tsx
+++ b/studio/pages/project/[ref]/settings/billing/update/pro.tsx
@@ -37,6 +37,21 @@ const BillingUpdatePro: NextPageWithLayout = () => {
   }, [])
 
   useEffect(() => {
+    if (
+      subscription &&
+      ![PRICING_TIER_PRODUCT_IDS.PAYG, PRICING_TIER_PRODUCT_IDS.PRO].includes(
+        subscription.tier.supabase_prod_id
+      )
+    ) {
+      if (subscription.tier.supabase_prod_id === PRICING_TIER_PRODUCT_IDS.ENTERPRISE) {
+        router.push(`/project/${projectRef}/settings/billing/update/enterprise`)
+      } else if (subscription.tier.supabase_prod_id === PRICING_TIER_PRODUCT_IDS.TEAM) {
+        router.push(`/project/${projectRef}/settings/billing/update/team`)
+      }
+    }
+  }, [subscription, projectRef, router])
+
+  useEffect(() => {
     if (projectRef) {
       getStripeProducts()
       getSubscription()

--- a/studio/pages/project/[ref]/settings/billing/update/team.tsx
+++ b/studio/pages/project/[ref]/settings/billing/update/team.tsx
@@ -50,10 +50,22 @@ const BillingUpdateTeam: NextPageWithLayout = () => {
   }, [orgSlug])
 
   useEffect(() => {
-    if (isEnterprise) {
+    if (subscription?.tier?.supabase_prod_id === PRICING_TIER_PRODUCT_IDS.ENTERPRISE) {
       router.push(`/project/${projectRef}/settings/billing/update/enterprise`)
+    } else if (
+      subscription &&
+      [PRICING_TIER_PRODUCT_IDS.PAYG, PRICING_TIER_PRODUCT_IDS.PRO].includes(
+        subscription.tier.supabase_prod_id
+      )
+    ) {
+      router.push(`/project/${projectRef}/settings/billing/update/pro`)
+    } else if (
+      subscription &&
+      subscription.tier.supabase_prod_id !== PRICING_TIER_PRODUCT_IDS.TEAM
+    ) {
+      router.push(`/project/${projectRef}/settings/billing/update`)
     }
-  }, [subscription])
+  }, [subscription, projectRef, router])
 
   const getStripeProducts = async () => {
     try {


### PR DESCRIPTION
When a customer directly navigates to `/project/_/settings/billing/update/pro`, they could initiate a downgrade from Enterprise/Team.

This accidentally happened for one of our Team plan customers.

This PR makes sure we redirect the customer to the appropriate plan.