### PR TITLE
docs(prisma): filled abruptly cut off sentence

### DIFF
--- a/apps/docs/pages/guides/integrations/prisma.mdx
+++ b/apps/docs/pages/guides/integrations/prisma.mdx
@@ -120,7 +120,7 @@ This will create a `prisma/migrations` folder inside your `prisma` directory and
 > **Note**: If you want to skip the process of creating a migration history, you can use the [`prisma db push`](https://www.prisma.io/docs/concepts/components/prisma-migrate/db-push) command instead of `prisma migrate dev`. However, we recommend using `prisma migrate dev` to evolve your database schema in development.
 > If you would like to get a conceptual overview of how Prisma Migrate works and which commands to use in what environment, refer to [this page in the Prisma documentation](https://www.prisma.io/docs/concepts/components/prisma-migrate/mental-model).
 
-If you go to your Supabase project, in the table editor, you should see that two tables have been created, a `Post`, `User`, and `_prisma_migrations` tables. The `_prisma_migrations` table is used to keep
+If you go to your Supabase project, in the table editor, you should see that two tables have been created, a `Post`, `User`, and `_prisma_migrations` tables. The `_prisma_migrations` table is used to keep track of the migration history and ensure that the database schema stays in sync with your Prisma schema.
 
 ![tables created in the UI](/docs/img/guides/integrations/prisma/7y4qq4wwvfrheti6r09u.png)
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update: continued the sentence  where it was abruptly cut off at 'The `_prisma_migrations` table is used to keep...'

## What is the current behavior?

The current sentence was abruptly cut off and not meaningful.

## What is the new behavior?

Filled and continued the sentence with the correct information.

## Additional context

<img width="1156" alt="Screenshot 2023-06-14 at 10 05 29 PM" src="https://github.com/supabase/supabase/assets/101852870/397dbcb7-ba97-4814-86fa-e30d697028b3">

