### PR TITLE
style: table td colspan 5 to 6

### DIFF
--- a/studio/components/interfaces/Organization/InvoicesSettings/InvoicesSettings.tsx
+++ b/studio/components/interfaces/Organization/InvoicesSettings/InvoicesSettings.tsx
@@ -107,7 +107,7 @@ const InvoicesSettings = () => {
           body={
             invoices.length === 0 ? (
               <Table.tr>
-                <Table.td colSpan={5} className="p-3 py-12 text-center">
+                <Table.td colSpan={6} className="p-3 py-12 text-center">
                   <p className="text-scale-1000">
                     {loading ? 'Checking for invoices' : 'No invoices for this organization yet'}
                   </p>


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR updates the colspan in use in the invoices table within organization settings to fix a misalignment as seen below:

## What is the current behavior?

**before**
<img width="976" alt="Screenshot 2023-06-14 at 18 53 38" src="https://github.com/antlio/supabase/assets/14966155/fc0d01f7-959f-4737-8796-5c1a26f5e8c2">

## What is the new behavior?

**after**
<img width="976" alt="Screenshot 2023-06-14 at 18 53 47" src="https://github.com/antlio/supabase/assets/14966155/82ae5a2b-f240-4f82-a288-f47d75a9d032">
