### PR TITLE
Make nuxt quickstart visible

### DIFF
--- a/apps/docs/components/HomePageCover.tsx
+++ b/apps/docs/components/HomePageCover.tsx
@@ -73,8 +73,8 @@ const HomePageCover = (props) => {
           </p>
         </div>
         <div className="flex flex-wrap md:grid md:grid-cols-4 2xl:grid-cols-7 gap-2 sm:gap-3">
-          {frameworks.map((framework) => (
-            <Link href={framework.href} passHref>
+          {frameworks.map((framework, i) => (
+            <Link key={i} href={framework.href} passHref>
               <a className="no-underline">
                 <IconPanel
                   iconSize={iconSize}

--- a/apps/docs/components/HomePageCover.tsx
+++ b/apps/docs/components/HomePageCover.tsx
@@ -83,7 +83,7 @@ const HomePageCover = (props) => {
                   icon={framework.icon}
                 />
               </a>
-          </Link>
+            </Link>
           ))}
         </div>
       </div>

--- a/apps/docs/components/HomePageCover.tsx
+++ b/apps/docs/components/HomePageCover.tsx
@@ -7,6 +7,49 @@ const HomePageCover = (props) => {
   const isXs = useBreakpoint(639)
   const iconSize = isXs ? 'sm' : 'lg'
 
+  const frameworks = [
+    {
+      tooltip: 'ReactJS',
+      icon: '/docs/img/icons/react-icon',
+      href: '/guides/getting-started/quickstarts/reactjs',
+    },
+    {
+      tooltip: 'NextJS',
+      icon: '/docs/img/icons/nextjs-icon',
+      href: '/guides/getting-started/quickstarts/nextjs',
+    },
+    {
+      tooltip: 'RedwoodJS',
+      icon: '/docs/img/icons/redwoodjs-icon',
+      href: '/guides/getting-started/quickstarts/redwoodjs',
+    },
+    {
+      tooltip: 'Flutter',
+      icon: '/docs/img/icons/flutter-icon',
+      href: '/guides/getting-started/quickstarts/flutter',
+    },
+    {
+      tooltip: 'SvelteKit',
+      icon: '/docs/img/icons/svelte-icon',
+      href: '/guides/getting-started/quickstarts/sveltekit',
+    },
+    {
+      tooltip: 'SolidJS',
+      icon: '/docs/img/icons/solidjs-icon',
+      href: '/guides/getting-started/quickstarts/solidjs',
+    },
+    {
+      tooltip: 'Vue',
+      icon: '/docs/img/icons/vuejs-icon',
+      href: '/guides/getting-started/quickstarts/vue',
+    },
+    {
+      tooltip: 'NuxtJS',
+      icon: '/docs/img/icons/nuxt-icon',
+      href: '/guides/getting-started/quickstarts/nuxtjs',
+    },
+  ]
+
   const GettingStarted = () => (
     <div
       className="
@@ -30,76 +73,18 @@ const HomePageCover = (props) => {
           </p>
         </div>
         <div className="flex flex-wrap md:grid md:grid-cols-4 2xl:grid-cols-7 gap-2 sm:gap-3">
-          <Link href={`/guides/getting-started/quickstarts/reactjs`} passHref>
-            <a className="no-underline">
-              <IconPanel
-                iconSize={iconSize}
-                hideArrow
-                tooltip="ReactJS"
-                icon="/docs/img/icons/react-icon"
-              />
-            </a>
+          {frameworks.map((framework) => (
+            <Link href={framework.href} passHref>
+              <a className="no-underline">
+                <IconPanel
+                  iconSize={iconSize}
+                  hideArrow
+                  tooltip={framework.tooltip}
+                  icon={framework.icon}
+                />
+              </a>
           </Link>
-          <Link href={`/guides/getting-started/quickstarts/nextjs`} passHref>
-            <a className="no-underline">
-              <IconPanel
-                iconSize={iconSize}
-                hideArrow
-                tooltip="NextJS"
-                icon="/docs/img/icons/nextjs-icon"
-              />
-            </a>
-          </Link>
-          <Link href={`/guides/getting-started/quickstarts/redwoodjs`} passHref>
-            <a className="no-underline">
-              <IconPanel
-                iconSize={iconSize}
-                hideArrow
-                tooltip="RedwoodJS"
-                icon="/docs/img/icons/redwoodjs-icon"
-              />
-            </a>
-          </Link>
-          <Link href={`/guides/getting-started/quickstarts/flutter`} passHref>
-            <a className="no-underline">
-              <IconPanel
-                iconSize={iconSize}
-                hideArrow
-                tooltip="Flutter"
-                icon="/docs/img/icons/flutter-icon"
-              />
-            </a>
-          </Link>
-          <Link href={`/guides/getting-started/quickstarts/sveltekit`} passHref>
-            <a className="no-underline">
-              <IconPanel
-                iconSize={iconSize}
-                hideArrow
-                tooltip="SvelteKit"
-                icon="/docs/img/icons/svelte-icon"
-              />
-            </a>
-          </Link>
-          <Link href={`/guides/getting-started/quickstarts/solidjs`} passHref>
-            <a className="no-underline">
-              <IconPanel
-                iconSize={iconSize}
-                hideArrow
-                tooltip="SolidJS"
-                icon="/docs/img/icons/solidjs-icon"
-              />
-            </a>
-          </Link>
-          <Link href={`/guides/getting-started/quickstarts/vue`} passHref>
-            <a className="no-underline">
-              <IconPanel
-                iconSize={iconSize}
-                hideArrow
-                tooltip="Vue"
-                icon="/docs/img/icons/vuejs-icon"
-              />
-            </a>
-          </Link>
+          ))}
         </div>
       </div>
     </div>

--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
@@ -212,6 +212,7 @@ export const gettingstarted: NavMenuConstant = {
       items: [
         { name: 'React', url: '/guides/getting-started/quickstarts/reactjs' },
         { name: 'NextJS', url: '/guides/getting-started/quickstarts/nextjs' },
+        { name: 'NuxtJS', url: '/guides/getting-started/quickstarts/nuxtjs' },
         { name: 'RedwoodJS', url: '/guides/getting-started/quickstarts/redwoodjs' },
         { name: 'Flutter', url: '/guides/getting-started/quickstarts/flutter' },
         { name: 'SvelteKit', url: '/guides/getting-started/quickstarts/sveltekit' },

--- a/apps/docs/pages/guides/getting-started.mdx
+++ b/apps/docs/pages/guides/getting-started.mdx
@@ -137,6 +137,13 @@ export const quickstarts = [
     icon: '/docs/img/icons/nextjs-icon',
   },
   {
+    title: 'NuxtJS',
+    href: '/guides/getting-started/quickstarts/nuxtjs',
+    description:
+      'Learn how to create a Supabase project, add some sample data to your database, and query the data from a NuxtJS app.',
+    icon: '/docs/img/icons/nuxt-icon',
+  },
+  {
     title: 'RedwoodJS',
     href: '/guides/getting-started/quickstarts/redwoodjs',
     description:

--- a/packages/ui/src/components/Command/utils/shared-nav-items.json
+++ b/packages/ui/src/components/Command/utils/shared-nav-items.json
@@ -205,6 +205,10 @@
       "url": "https://supabase.com/docs/guides/getting-started/quickstarts/nextjs"
     },
     {
+      "label": "Nuxt.js",
+      "url": "https://supabase.com/docs/guides/getting-started/quickstarts/nuxtjs"
+    },
+    {
       "label": "Flutter",
       "url": "https://supabase.com/docs/guides/getting-started/quickstarts/flutter"
     },


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR makes the nuxt quickstart visible.

## What is the current behavior?

couldn't see in sidebar or homepage

![CleanShot 2023-06-14 at 22 00 26@2x](https://github.com/supabase/supabase/assets/70828596/8baf05d5-9f05-438d-8704-a74e8113f3e3)

## What is the new behavior?

can see in sidebar and homepage

![CleanShot 2023-06-14 at 22 00 43@2x](https://github.com/supabase/supabase/assets/70828596/64f6f9e8-7502-4686-939f-bac257de4c2a)

## Additional context

Also cleaned up some of the `GettingStarted` code