### PR TITLE
fix: Edit this page on GitHub link width

### DIFF
--- a/apps/docs/layouts/guides/index.tsx
+++ b/apps/docs/layouts/guides/index.tsx
@@ -139,7 +139,7 @@ const Layout: FC<Props> = (props) => {
                   <div>
                     <a
                       href={`https://github.com/supabase/supabase/edit/master/apps/docs/pages${router.asPath}.mdx`}
-                      className="text-sm transition flex items-center gap-1 text-scale-1000 hover:text-scale-1200"
+                      className="text-sm transition flex items-center gap-1 text-scale-1000 hover:text-scale-1200 w-fit"
                     >
                       Edit this page on GitHub <IconExternalLink size={14} strokeWidth={1.5} />
                     </a>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes the width on the `Edit this page on GitHub` link. The width would stretch across the whole page.