### PR TITLE
Fix: beta page performance bar

### DIFF
--- a/apps/www/pages/beta.tsx
+++ b/apps/www/pages/beta.tsx
@@ -315,7 +315,7 @@ const Performance = () => {
                         color={
                           stat.name === 'Supabase'
                             ? 'bg-brand-900 dark:bg-brand-800'
-                            : 'bg-dark-300 dark:bg-dark-400'
+                            : 'bg-brand-300 dark:bg-brand-400'
                         }
                         finalPercentage={Math.ceil((stat.value / maxValue) * 100)}
                       />


### PR DESCRIPTION
## What kind of change does this PR introduce?

fixes the performance bar on the beta page

## What is the current behavior?

![CleanShot 2023-06-15 at 00 30 48@2x](https://github.com/supabase/supabase/assets/70828596/f66bc02f-55f9-4c8a-994e-2395608744a6)

## What is the new behavior?

![CleanShot 2023-06-15 at 00 31 02@2x](https://github.com/supabase/supabase/assets/70828596/92237852-7257-4e3a-b1e7-b5d14335f2ce)