### PR TITLE
Fix: pricing faq alignment

### DIFF
--- a/apps/www/pages/pricing/index.tsx
+++ b/apps/www/pages/pricing/index.tsx
@@ -929,7 +929,7 @@ export default function IndexPage() {
                 >
                   {pricingFaq.map((faq, i) => {
                     return (
-                      <div className="border-b pb-3" key={i}>
+                      <div className="border-b py-2" key={i}>
                         <Accordion.Item
                           header={<span className="text-scale-1200">{faq.question}</span>}
                           id={`faq--${i.toString()}`}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Small but the pricing faq questions are slightly off center.

## What is the current behavior?

![CleanShot 2023-06-15 at 00 32 42@2x](https://github.com/supabase/supabase/assets/70828596/19a7a3bd-a755-40e9-83c2-3f7c0dd8e73f)

## What is the new behavior?

![CleanShot 2023-06-15 at 00 32 24@2x](https://github.com/supabase/supabase/assets/70828596/819f9830-e983-47e9-9dfd-9394c4dc99de)