### PR TITLE
chore: properly handle permissions on new subscription page

### DIFF
--- a/studio/components/interfaces/BillingV2/Subscription/AddOns/CustomDomainSidePanel.tsx
+++ b/studio/components/interfaces/BillingV2/Subscription/AddOns/CustomDomainSidePanel.tsx
@@ -1,10 +1,11 @@
+import { PermissionAction } from '@supabase/shared-types/out/constants'
 import clsx from 'clsx'
 import { useParams } from 'common'
 import { useProjectAddonRemoveMutation } from 'data/subscriptions/project-addon-remove-mutation'
 import { useProjectAddonUpdateMutation } from 'data/subscriptions/project-addon-update-mutation'
 import { useProjectAddonsQuery } from 'data/subscriptions/project-addons-query'
 import { useProjectSubscriptionV2Query } from 'data/subscriptions/project-subscription-v2-query'
-import { useStore } from 'hooks'
+import { checkPermissions, useStore } from 'hooks'
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
 import { useSubscriptionPageStateSnapshot } from 'state/subscription-page'
@@ -16,6 +17,11 @@ const CustomDomainSidePanel = () => {
 
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false)
   const [selectedOption, setSelectedOption] = useState<string>('cd_none')
+
+  const canUpdateCustomDomain = checkPermissions(
+    PermissionAction.BILLING_WRITE,
+    'stripe.subscriptions'
+  )
 
   const snap = useSubscriptionPageStateSnapshot()
   const visible = snap.panelKey === 'customDomain'
@@ -85,8 +91,14 @@ const CustomDomainSidePanel = () => {
       onCancel={onClose}
       onConfirm={onConfirm}
       loading={isLoading || isSubmitting}
-      disabled={isFreePlan || isLoading || !hasChanges || isSubmitting}
-      tooltip={isFreePlan ? 'Unable to enable custom domain on a free plan' : undefined}
+      disabled={isFreePlan || isLoading || !hasChanges || isSubmitting || !canUpdateCustomDomain}
+      tooltip={
+        isFreePlan
+          ? 'Unable to enable custom domain on a free plan'
+          : !canUpdateCustomDomain
+          ? 'You do not have permission to update custom domain'
+          : undefined
+      }
       header={
         <div className="flex items-center justify-between">
           <h4>Custom domains</h4>

--- a/studio/components/interfaces/BillingV2/Subscription/AddOns/PITRSidePanel.tsx
+++ b/studio/components/interfaces/BillingV2/Subscription/AddOns/PITRSidePanel.tsx
@@ -1,10 +1,11 @@
+import { PermissionAction } from '@supabase/shared-types/out/constants'
 import clsx from 'clsx'
 import { useParams, useTheme } from 'common'
 import { useProjectAddonRemoveMutation } from 'data/subscriptions/project-addon-remove-mutation'
 import { useProjectAddonUpdateMutation } from 'data/subscriptions/project-addon-update-mutation'
 import { useProjectAddonsQuery } from 'data/subscriptions/project-addons-query'
 import { useProjectSubscriptionV2Query } from 'data/subscriptions/project-subscription-v2-query'
-import { useStore } from 'hooks'
+import { checkPermissions, useStore } from 'hooks'
 import { BASE_PATH } from 'lib/constants'
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
@@ -39,6 +40,8 @@ const PITRSidePanel = () => {
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [selectedCategory, setSelectedCategory] = useState<'on' | 'off'>('off')
   const [selectedOption, setSelectedOption] = useState<string>('pitr_0')
+
+  const canUpdatePitr = checkPermissions(PermissionAction.BILLING_WRITE, 'stripe.subscriptions')
 
   const snap = useSubscriptionPageStateSnapshot()
   const visible = snap.panelKey === 'pitr'
@@ -109,8 +112,14 @@ const PITRSidePanel = () => {
       onCancel={onClose}
       onConfirm={onConfirm}
       loading={isLoading || isSubmitting}
-      disabled={isFreePlan || isLoading || !hasChanges || isSubmitting}
-      tooltip={isFreePlan ? 'Unable to enable point in time recovery on a free plan' : undefined}
+      disabled={isFreePlan || isLoading || !hasChanges || isSubmitting || !canUpdatePitr}
+      tooltip={
+        isFreePlan
+          ? 'Unable to enable point in time recovery on a free plan'
+          : !canUpdatePitr
+          ? 'You do not have permission to update PITR'
+          : undefined
+      }
       header={
         <div className="flex items-center justify-between">
           <h4>Point in Time Recovery</h4>

--- a/studio/components/interfaces/BillingV2/Subscription/CostControl/SpendCapSidePanel.tsx
+++ b/studio/components/interfaces/BillingV2/Subscription/CostControl/SpendCapSidePanel.tsx
@@ -3,13 +3,14 @@ import { useParams, useTheme } from 'common'
 import Table from 'components/to-be-cleaned/Table'
 import { useProjectSubscriptionUpdateMutation } from 'data/subscriptions/project-subscription-update-mutation'
 import { useProjectSubscriptionV2Query } from 'data/subscriptions/project-subscription-v2-query'
-import { useStore } from 'hooks'
+import { checkPermissions, useStore } from 'hooks'
 import { BASE_PATH, PRICING_TIER_PRODUCT_IDS } from 'lib/constants'
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
 import { useSubscriptionPageStateSnapshot } from 'state/subscription-page'
 import { Alert, Button, Collapsible, IconChevronRight, IconExternalLink, SidePanel } from 'ui'
 import { BILLING_BREAKDOWN_METRICS } from '../Subscription.constants'
+import { PermissionAction } from '@supabase/shared-types/out/constants'
 
 const SPEND_CAP_OPTIONS: {
   name: string
@@ -39,6 +40,8 @@ const SpendCapSidePanel = () => {
   const [showUsageCosts, setShowUsageCosts] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false)
   const [selectedOption, setSelectedOption] = useState<'on' | 'off'>()
+
+  const canUpdateSpendCap = checkPermissions(PermissionAction.BILLING_WRITE, 'stripe.subscriptions')
 
   const snap = useSubscriptionPageStateSnapshot()
   const visible = snap.panelKey === 'costControl'
@@ -93,7 +96,7 @@ const SpendCapSidePanel = () => {
     <SidePanel
       size="large"
       loading={isLoading || isSubmitting}
-      disabled={isFreePlan || isLoading || !hasChanges || isSubmitting}
+      disabled={isFreePlan || isLoading || !hasChanges || isSubmitting || !canUpdateSpendCap}
       visible={visible}
       onCancel={onClose}
       onConfirm={onConfirm}
@@ -109,6 +112,7 @@ const SpendCapSidePanel = () => {
           </Link>
         </div>
       }
+      tooltip={!canUpdateSpendCap ? 'You do not have permission to update spend cap' : undefined}
     >
       <SidePanel.Content>
         <div className="py-6 space-y-4">

--- a/studio/components/interfaces/BillingV2/Subscription/Tier/SubscriptionTier.tsx
+++ b/studio/components/interfaces/BillingV2/Subscription/Tier/SubscriptionTier.tsx
@@ -114,7 +114,22 @@ const SubscriptionTier = ({}: SubscriptionTierProps) => {
                 </Alert>
               ))}
             {!subscription?.usage_billing_enabled && (
-              <Alert withIcon variant="info" title="This project is limited by the included usage">
+              <Alert
+                withIcon
+                variant="info"
+                title="This project is limited by the included usage"
+                actions={
+                  currentPlan?.id === 'free' ? (
+                    <Button type="default" onClick={() => snap.setPanelKey('subscriptionPlan')}>
+                      Uprade Plan
+                    </Button>
+                  ) : (
+                    <Button type="default" onClick={() => snap.setPanelKey('costControl')}>
+                      Adjust Spend Cap
+                    </Button>
+                  )
+                }
+              >
                 <p className="text-sm text-scale-1000">
                   When this project exceeds its{' '}
                   <Link href="#breakdown">
@@ -129,8 +144,9 @@ const SubscriptionTier = ({}: SubscriptionTierProps) => {
                     </span>
                   ) : (
                     <span>
-                      You can change the Cost Control settings if you plan on exceeding the included
-                      usage quotas.
+                      You currently have Spend Cap enabled - when you exceed your plan's limit, you
+                      will experience restrictions. To scale seamlessly and pay for over-usage, you
+                      can adjust your Cost Control settings.
                     </span>
                   )}
                 </p>

--- a/studio/components/interfaces/BillingV2/Subscription/Tier/TierUpdateSidePanel.tsx
+++ b/studio/components/interfaces/BillingV2/Subscription/Tier/TierUpdateSidePanel.tsx
@@ -5,7 +5,7 @@ import { useFreeProjectLimitCheckQuery } from 'data/organizations/free-project-l
 import { useProjectAddonsQuery } from 'data/subscriptions/project-addons-query'
 import { useProjectPlansQuery } from 'data/subscriptions/project-plans-query'
 import { useProjectSubscriptionUpdateMutation } from 'data/subscriptions/project-subscription-update-mutation'
-import { useStore } from 'hooks'
+import { checkPermissions, useStore } from 'hooks'
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
 import { useSubscriptionPageStateSnapshot } from 'state/subscription-page'
@@ -17,6 +17,8 @@ import PaymentMethodSelection from './PaymentMethodSelection'
 import { plans as subscriptionsPlans } from 'shared-data/plans'
 import { useProjectSubscriptionV2Query } from 'data/subscriptions/project-subscription-v2-query'
 import { PRICING_TIER_PRODUCT_IDS } from 'lib/constants'
+import { PermissionAction } from '@supabase/shared-types/out/constants'
+import * as Tooltip from '@radix-ui/react-tooltip'
 
 const TierUpdateSidePanel = () => {
   const { ui } = useStore()
@@ -28,6 +30,11 @@ const TierUpdateSidePanel = () => {
   const [selectedPaymentMethod, setSelectedPaymentMethod] = useState<string>()
   const [showDowngradeError, setShowDowngradeError] = useState(false)
   const [selectedTier, setSelectedTier] = useState<'tier_free' | 'tier_pro' | 'tier_team'>()
+
+  const canUpdateSubscription = checkPermissions(
+    PermissionAction.BILLING_WRITE,
+    'stripe.subscriptions'
+  )
 
   const snap = useSubscriptionPageStateSnapshot()
   const visible = snap.panelKey === 'subscriptionPlan'
@@ -173,18 +180,42 @@ const TierUpdateSidePanel = () => {
                         Current plan
                       </Button>
                     ) : plan.id !== PRICING_TIER_PRODUCT_IDS.TEAM ? (
-                      <Button
-                        block
-                        // no self-serve downgrades from team plan right now
-                        disabled={
-                          plan.id !== PRICING_TIER_PRODUCT_IDS.TEAM &&
-                          ['team', 'enterprise'].includes(subscription?.plan?.id || '')
-                        }
-                        type={isDowngradeOption ? 'default' : 'primary'}
-                        onClick={() => setSelectedTier(plan.id as any)}
-                      >
-                        {isDowngradeOption ? 'Downgrade' : 'Upgrade'} to {plan.name}
-                      </Button>
+                      <Tooltip.Root delayDuration={0}>
+                        <Tooltip.Trigger asChild>
+                          <div>
+                            <Button
+                              block
+                              disabled={
+                                // no self-serve downgrades from team plan right now
+                                (plan.id !== PRICING_TIER_PRODUCT_IDS.TEAM &&
+                                  ['team', 'enterprise'].includes(subscription?.plan?.id || '')) ||
+                                !canUpdateSubscription
+                              }
+                              type={isDowngradeOption ? 'default' : 'primary'}
+                              onClick={() => setSelectedTier(plan.id as any)}
+                            >
+                              {isDowngradeOption ? 'Downgrade' : 'Upgrade'} to {plan.name}
+                            </Button>
+                          </div>
+                        </Tooltip.Trigger>
+                        {!canUpdateSubscription ? (
+                          <Tooltip.Portal>
+                            <Tooltip.Content side="bottom">
+                              <Tooltip.Arrow className="radix-tooltip-arrow" />
+                              <div
+                                className={[
+                                  'rounded bg-scale-100 py-1 px-2 leading-none shadow',
+                                  'border border-scale-200',
+                                ].join(' ')}
+                              >
+                                <span className="text-xs text-scale-1200">
+                                  You do not have permission to change the subscription plan.
+                                </span>
+                              </div>
+                            </Tooltip.Content>
+                          </Tooltip.Portal>
+                        ) : null}
+                      </Tooltip.Root>
                     ) : (
                       <Link href={plan.href} passHref className="hidden md:block">
                         <a target="_blank">


### PR DESCRIPTION
Instead of letting the user run into API "Forbidden resource" errors, we should properly display a tooltip/disable buttons, when a user lacks permissions to do changes.

Also adjusted copy & implemented upsell for spend cap/upgrade to paid plan

![Screenshot 2023-06-15 at 18 00 26](https://github.com/supabase/supabase/assets/14073399/c392c0b7-f6cf-4bf7-a15d-d41785613908)
