### PR TITLE
Issue 14872

### DIFF
--- a/packages/ui/src/components/Modal/Modal.tsx
+++ b/packages/ui/src/components/Modal/Modal.tsx
@@ -162,6 +162,7 @@ const Modal = ({
             className={[__styles.base, __styles.size[size], className].join(' ')}
             onInteractOutside={props.onInteractOutside}
             onEscapeKeyDown={props.onEscapeKeyDown}
+            onPointerDownOutside={(e) => e.preventDefault()}
           >
             {header && <div className={__styles.header}>{header}</div>}
             {/* <div

--- a/studio/components/interfaces/Auth/Policies/PolicyEditorModal/index.tsx
+++ b/studio/components/interfaces/Auth/Policies/PolicyEditorModal/index.tsx
@@ -114,7 +114,13 @@ const PolicyEditorModal: FC<Props> = ({
     const { name, definition, check, command } = policyFormFields
 
     if (name.length === 0) {
-      return ui.setNotification({ category: 'error', message: 'Do give your policy a name' })
+      return (
+          ui.setNotification({
+            category: 'error',
+            message: 'Do give your policy a name',
+            duration: 4000,
+          })
+      )
     }
     if (!command) {
       return ui.setNotification({

--- a/studio/components/interfaces/Auth/Policies/PolicyEditorModal/index.tsx
+++ b/studio/components/interfaces/Auth/Policies/PolicyEditorModal/index.tsx
@@ -114,13 +114,11 @@ const PolicyEditorModal: FC<Props> = ({
     const { name, definition, check, command } = policyFormFields
 
     if (name.length === 0) {
-      return (
-          ui.setNotification({
-            category: 'error',
-            message: 'Do give your policy a name',
-            duration: 4000,
-          })
-      )
+      return ui.setNotification({
+        category: 'error',
+        message: 'Do give your policy a name',
+        duration: 4000,
+      })
     }
     if (!command) {
       return ui.setNotification({


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is a bug fix for the bugs described in [Issue #14872](https://github.com/supabase/supabase/issues/14872)

## What is the current behavior?

Currently when no RLS policy name is given in the RLS policy editor and the user attempts to submit it, an error toast appears that has no time out. The other error is that when the user clicks to close a toast, the RLS policy editor also closes, this should not be the case.

https://github.com/supabase/supabase/assets/59986120/8304f017-a72f-4c5a-8727-40fdf2783724


## What is the new behavior?

The error toast times-out after 4000ms and the closing the toast will not exit the RLS policy editor.

https://github.com/supabase/supabase/assets/59986120/99124c4f-10d2-4976-a1f2-482279fd0dd6
