### PR TITLE
Chore: Update youtube link to live version of video

### DIFF
--- a/apps/docs/pages/guides/auth/auth-helpers/nextjs.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/nextjs.mdx
@@ -205,7 +205,7 @@ TypeScript types can be [generated with the Supabase CLI](/docs/reference/javasc
 
 <div className="video-container">
   <iframe
-    src="https://www.youtube-nocookie.com/embed/11zi7sUJFoU"
+    src="https://www.youtube-nocookie.com/embed/-7K6DRWfEGM"
     frameBorder="1"
     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
     allowFullScreen


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

Video link is `unlisted` version

## What is the new behavior?

Video link is `public` version
