### PR TITLE
Show disk io consumed instead of disk io remaining

### DIFF
--- a/studio/lib/constants/metrics.tsx
+++ b/studio/lib/constants/metrics.tsx
@@ -46,8 +46,8 @@ export const METRICS = [
     category: METRIC_CATEGORIES.INSTANCE,
   },
   {
-    key: 'disk_io_budget',
-    label: 'Daily Disk IO Budget % Remaining',
+    key: 'disk_io_consumption',
+    label: 'Disk IO % Consumed',
     provider: 'infra-monitoring',
     category: METRIC_CATEGORIES.INSTANCE,
   },

--- a/studio/lib/constants/metrics.tsx
+++ b/studio/lib/constants/metrics.tsx
@@ -52,6 +52,12 @@ export const METRICS = [
     category: METRIC_CATEGORIES.INSTANCE,
   },
   {
+    key: 'disk_io_budget',
+    label: 'Disk IO % Remaining',
+    provider: 'infra-monitoring',
+    category: METRIC_CATEGORIES.INSTANCE,
+  },
+  {
     key: 'ram_usage',
     label: 'Memory % usage',
     provider: 'infra-monitoring',

--- a/studio/pages/project/[ref]/reports/database.tsx
+++ b/studio/pages/project/[ref]/reports/database.tsx
@@ -208,8 +208,8 @@ const DatabaseUsage: FC<any> = () => {
                   <ChartHandler
                     startDate={dateRange?.period_start?.date}
                     endDate={dateRange?.period_end?.date}
-                    attribute={'disk_io_budget'}
-                    label={'Daily Disk IO Budget remaining'}
+                    attribute={'disk_io_consumption'}
+                    label={'Disk IO consumed'}
                     interval={dateRange.interval}
                     provider={'infra-monitoring'}
                   />


### PR DESCRIPTION
Lots of confusion from users as high disk io budget is good as it indicates the remaining budget.

Flipping this metric to show consumption instead of balance to be more aligned with all other charts where high = bad, low = good.

## Screenshots

![image](https://github.com/supabase/supabase/assets/1732217/033b1fac-f3ba-44c9-a494-5b74e3bd5944)
Database Health 👆

![image](https://github.com/supabase/supabase/assets/1732217/8465d6d0-5254-4042-8aab-3828686d2ae9)
Custom Report 👆