### PR TITLE
Add option to show 7 days worth of report metrics

### DIFF
--- a/studio/lib/constants/metrics.tsx
+++ b/studio/lib/constants/metrics.tsx
@@ -416,16 +416,17 @@ export const TIME_PERIODS_INFRA = [
   {
     key: '1h',
     label: 'Last hour',
-    interval: '1m',
   },
   {
     key: '3h',
     label: 'Last 3 hours',
-    interval: '5m',
   },
   {
     key: '1d',
     label: 'Last 24 hours',
-    interval: '30m',
+  },
+  {
+    key: '7d',
+    label: 'Last 7 days',
   },
 ]

--- a/studio/pages/project/[ref]/reports/database.tsx
+++ b/studio/pages/project/[ref]/reports/database.tsx
@@ -151,7 +151,7 @@ const DatabaseUsage: FC<any> = () => {
               <div className="mb-4 flex items-center space-x-3">
                 <DateRangePicker
                   loading={false}
-                  value={'3h'}
+                  value={'7d'}
                   options={TIME_PERIODS_INFRA}
                   currentBillingPeriodStart={undefined}
                   onChange={setDateRange}


### PR DESCRIPTION
We should allow all users to see more than 1 day of health metrics no matter if they have upgraded their plan or not. This will help all users to see whats going on with their instances no matter which plan they are on.

![image](https://github.com/supabase/supabase/assets/1732217/3f8f3ccb-5fb8-4788-97d0-81c3d3288545)