### PR TITLE
Use custom domain in provider list, if we have one

### DIFF
--- a/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
+++ b/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
@@ -9,6 +9,8 @@ import { BASE_PATH } from 'lib/constants'
 import { Provider } from './AuthProvidersForm.types'
 import { ProviderCollapsibleClasses } from './AuthProvidersForm.constants'
 import FormField from './FormField'
+import { useCustomDomainsQuery } from 'data/custom-domains/custom-domains-query'
+import { useParams } from 'common'
 
 interface Props {
   provider: Provider
@@ -17,9 +19,11 @@ interface Props {
 const ProviderForm: FC<Props> = ({ provider }) => {
   const [open, setOpen] = useState(false)
   const { authConfig, ui } = useStore()
-
+  const { ref } = useParams()
   const doubleNegativeKeys = ['MAILER_AUTOCONFIRM', 'SMS_AUTOCONFIRM']
   const canUpdateConfig = checkPermissions(PermissionAction.UPDATE, 'custom_config_gotrue')
+
+  const { data: customDomainData } = useCustomDomainsQuery({ projectRef: ref })
 
   const generateInitialValues = () => {
     const initialValues: { [x: string]: string } = {}
@@ -153,7 +157,11 @@ const ProviderForm: FC<Props> = ({ provider }) => {
                         readOnly
                         disabled
                         label="Redirect URL"
-                        value={`https://${ui.selectedProjectRef}.supabase.co/auth/v1/callback`}
+                        value={
+                          customDomainData?.customDomain
+                            ? `https://${customDomainData.customDomain?.hostname}/auth/v1/callback`
+                            : `https://${ui.selectedProjectRef}.supabase.co/auth/v1/callback`
+                        }
                       />
                     </>
                   )}


### PR DESCRIPTION
We don't currently map custom domains to the auth providers redirect urls. 
If a user has a custom domain set, they should set that in the redirect url for their auth providers.
![CleanShot 2023-06-16 at 14 14 34@2x](https://github.com/supabase/supabase/assets/105593/ad5cdd19-662a-4998-9d52-428c710a5c4a)
![CleanShot 2023-06-16 at 14 13 20@2x](https://github.com/supabase/supabase/assets/105593/1716cbc2-7240-4521-a2d1-9f4ad0f28131)
