### PR TITLE
Remove wrapping quotes from blockquote element

### DIFF
--- a/packages/config/tailwind.config.js
+++ b/packages/config/tailwind.config.js
@@ -251,6 +251,8 @@ const uiConfig = ui({
             'figure.quote-figure p:last-child': {
               marginBottom: '0 !important',
             },
+            'blockquote p:first-of-type::before': { content: 'none' },
+            'blockquote p:first-of-type::after': { content: 'none' },
           },
         },
 


### PR DESCRIPTION
From:
![image](https://github.com/supabase/supabase/assets/4133076/203d9f0b-81a1-460a-b902-0c8749bb4474)

To:
![image](https://github.com/supabase/supabase/assets/4133076/0a938719-6af8-4f67-bce6-82d38780f752)

When using blockquotes:
```markdown
> For a complete implementation example, check out [this free egghead course](https://egghead.io/courses/build-a-realtime-chat-app-with-remix-and-supabase-d36e2618) or [this GitHub repo](https://github.com/supabase/auth-helpers/tree/main/examples/remix).
```