### PR TITLE
Improve reference doc SEO

### DIFF
--- a/apps/docs/components/reference/RefSectionHandler.tsx
+++ b/apps/docs/components/reference/RefSectionHandler.tsx
@@ -58,18 +58,21 @@ const RefSectionHandler = (props: RefSectionHandlerProps) => {
   }
 
   const pageTitle = getPageTitle()
+  const section = props.sections.find((section) => section.slug === slug)
+  const fullTitle = `${pageTitle}${section ? ` - ${section.title}` : ''}`
 
   return (
     <>
       <Head>
-        <title>{pageTitle}</title>
-        <meta name="description" content={pageTitle} />
+        <title>{fullTitle}</title>
+        <meta name="description" content={section?.title ?? pageTitle} />
         <meta property="og:image" content={`https://supabase.com/docs/img/supabase-og-image.png`} />
         <meta
           name="twitter:image"
           content={`https://supabase.com/docs/img/supabase-og-image.png`}
         />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <link rel="canonical" href={`https://supabase.com${router.basePath}${router.asPath}`} />
       </Head>
       {props.isOldVersion && <OldVersionAlert sections={props.sections} />}
       <RefSubLayout>


### PR DESCRIPTION
An attempt at improving SEO in our reference docs.

Reference docs are a special case since each "path" is really just a sub section within a single large page (similar to [Stripe API docs](https://stripe.com/docs/api))

Currently Google search points "sub" pages of a reference doc to the start/intro section:
![image](https://github.com/supabase/supabase/assets/4133076/620c3349-dc1b-4fb0-b076-ca13c099edc6)

## Changes
- Adds `<link rel="canonical" ... />` in hopes that search engines will identify each sub section as the primary/canonical page for each path.
- Updates page title & description to include the sub section title, eg. for `/docs/reference/cli/supabase-db-remote-commit`, "Supabase CLI reference" is now "Supabase CLI reference - Commit remote database changes"