### PR TITLE
Docs: Remember scroll position on reload/back/forward

### DIFF
--- a/apps/docs/pages/_app.tsx
+++ b/apps/docs/pages/_app.tsx
@@ -68,6 +68,42 @@ function MyApp({ Component, pageProps }: AppPropsWithLayout) {
     }
   }, [router, handlePageTelemetry])
 
+  /**
+   * Save/restore scroll position when reloading or navigating back/forward.
+   *
+   * Required since scroll happens within a sub-container, not the page root.
+   */
+  useEffect(() => {
+    const storageKey = 'scroll-position'
+
+    const container = document.getElementById('docs-content-container')
+    if (!container) {
+      return
+    }
+
+    const previousScroll = Number(sessionStorage.getItem(storageKey))
+    const [entry] = window.performance.getEntriesByType('navigation')
+
+    // Only restore scroll position on reload and back/forward events
+    if (
+      previousScroll &&
+      entry &&
+      isPerformanceNavigationTiming(entry) &&
+      ['reload', 'back_forward'].includes(entry.type)
+    ) {
+      container.scrollTop = previousScroll
+    }
+
+    const handler = () => {
+      // Scroll stored in session storage, so only persisted per tab
+      sessionStorage.setItem(storageKey, container.scrollTop.toString())
+    }
+
+    window.addEventListener('beforeunload', handler)
+
+    return () => window.removeEventListener('beforeunload', handler)
+  }, [router])
+
   useEffect(() => {
     /**
      * Send page telemetry on first page load
@@ -122,6 +158,16 @@ function MyApp({ Component, pageProps }: AppPropsWithLayout) {
       </AuthContainer>
     </>
   )
+}
+
+/**
+ * Type guard that checks if a performance entry is a
+ * `PerformanceNavigationTiming`.
+ */
+function isPerformanceNavigationTiming(
+  entry: PerformanceEntry
+): entry is PerformanceNavigationTiming {
+  return entry.entryType === 'navigation'
 }
 
 export default MyApp


### PR DESCRIPTION
When reloading a page, or navigating forward/back on a page, remember the scroll position and restore it.

This extra logic was required since scroll happens within a sub-container, not the page root.

## To test

### Back button
1. Go to https://docs-git-feat-remember-scroll-position-supabase.vercel.app/docs/guides/platform/database-size
2. Scroll down to **Vacuum operations**
3. Click on one of the external links, eg. **vacuum operation**
4. Click the back button in your browser
5. Should restore to the previous scroll position prior to clicking the link

### Reload button
1. Go to https://docs-git-feat-remember-scroll-position-supabase.vercel.app/docs/guides/platform/database-size
2. Scroll down anywhere on the page, remember approximately where you were
3. Click reload
4. Your scroll position should remain where it was