### PR TITLE
Add confirmation dialog for closing RLS Editor with unsaved changes

### DIFF
--- a/studio/components/interfaces/Auth/Policies/PolicyEditorModal/index.tsx
+++ b/studio/components/interfaces/Auth/Policies/PolicyEditorModal/index.tsx
@@ -23,6 +23,7 @@ import {
   PostgresPolicyUpdatePayload,
 } from '../Policies.types'
 import { PolicyTemplate } from '../PolicyTemplates/PolicyTemplates.constants'
+import ConfirmationModal from 'components/ui/ConfirmationModal'
 
 interface Props {
   visible: boolean
@@ -65,11 +66,12 @@ const PolicyEditorModal: FC<Props> = ({
   // Mainly to decide which view to show when back from templates
   const [previousView, setPreviousView] = useState('')
   const [view, setView] = useState(POLICY_MODAL_VIEWS.EDITOR)
-
   const [policyFormFields, setPolicyFormFields] = useState<PolicyFormField>(
     initializedPolicyFormFields
   )
   const [policyStatementForReview, setPolicyStatementForReview] = useState<any>('')
+  const [isDirty, setIsDirty] = useState(false)
+  const [isClosingPolicyEditorModal, setIsClosingPolicyEditorModal] = useState(false)
 
   useEffect(() => {
     if (visible) {
@@ -106,6 +108,7 @@ const PolicyEditorModal: FC<Props> = ({
   }
 
   const onUpdatePolicyFormFields = (field: Partial<PolicyFormField>) => {
+    setIsDirty(true)
     if (field.name && field.name.length > 63) return
     setPolicyFormFields({ ...policyFormFields, ...field })
   }
@@ -165,6 +168,12 @@ const PolicyEditorModal: FC<Props> = ({
     hasError ? onViewEditor() : onSaveSuccess()
   }
 
+  const isClosingPolicyEditor = () => {
+    isDirty ? setIsClosingPolicyEditorModal(true) : onSelectCancel()
+  }
+
+  console.log('form data', policyFormFields)
+
   return (
     <Modal
       size={view === POLICY_MODAL_VIEWS.SELECTION ? 'medium' : 'xxlarge'}
@@ -182,9 +191,27 @@ const PolicyEditorModal: FC<Props> = ({
           onSelectBackFromTemplates={onSelectBackFromTemplates}
         />,
       ]}
-      onCancel={onSelectCancel}
+      onCancel={isClosingPolicyEditor}
     >
       <div className="">
+        <ConfirmationModal
+          visible={isClosingPolicyEditorModal}
+          header="Confirm to close"
+          buttonLabel="Confirm"
+          onSelectCancel={() => setIsClosingPolicyEditorModal(false)}
+          onSelectConfirm={() => {
+            onSelectCancel()
+            setIsClosingPolicyEditorModal(false)
+            setIsDirty(false)
+          }}
+        >
+          <Modal.Content>
+            <p className="py-4 text-sm text-scale-1100">
+              There are unsaved changes. Are you sure you want to close the panel? Your changes will
+              be lost.
+            </p>
+          </Modal.Content>
+        </ConfirmationModal>
         {view === POLICY_MODAL_VIEWS.SELECTION ? (
           <PolicySelection
             description="Write rules with PostgreSQL's policies to fit your unique business needs."

--- a/studio/components/interfaces/Auth/Policies/PolicyEditorModal/index.tsx
+++ b/studio/components/interfaces/Auth/Policies/PolicyEditorModal/index.tsx
@@ -172,8 +172,6 @@ const PolicyEditorModal: FC<Props> = ({
     isDirty ? setIsClosingPolicyEditorModal(true) : onSelectCancel()
   }
 
-  console.log('form data', policyFormFields)
-
   return (
     <Modal
       size={view === POLICY_MODAL_VIEWS.SELECTION ? 'medium' : 'xxlarge'}
@@ -207,8 +205,8 @@ const PolicyEditorModal: FC<Props> = ({
         >
           <Modal.Content>
             <p className="py-4 text-sm text-scale-1100">
-              There are unsaved changes. Are you sure you want to close the panel? Your changes will
-              be lost.
+              There are unsaved changes. Are you sure you want to close the editor? Your changes
+              will be lost.
             </p>
           </Modal.Content>
         </ConfirmationModal>


### PR DESCRIPTION
## What kind of change does this PR introduce?

fixes #15091 
## What is the current behavior?
Currently, when the RLS Editor has unsaved changes, clicking outside the editor or pressing the Esc key will close the modal, resulting in the loss of all the changes. 

https://github.com/supabase/supabase/assets/41125658/d890d4f8-54e5-4b3d-bfc3-0d16cb0278b9

## What is the new behavior?

a confirmation dialog will be displayed when attempting to close the RLS Editor with unsaved changes. Users will be prompted to confirm their action

https://github.com/supabase/supabase/assets/41125658/a82bb487-dc5a-4a26-a67c-8b5b1617bd29
