### PR TITLE
fix: payment method preselection

### DIFF
--- a/studio/components/interfaces/BillingV2/Subscription/CostControl/SpendCapSidePanel.tsx
+++ b/studio/components/interfaces/BillingV2/Subscription/CostControl/SpendCapSidePanel.tsx
@@ -163,7 +163,7 @@ const SpendCapSidePanel = () => {
                       </Table.tr>
                       {usageItems.map((item: any) => {
                         return (
-                          <Table.tr key={item.name}>
+                          <Table.tr key={item.title}>
                             <Table.td>
                               <p className="text-xs pl-4">{item.title}</p>
                             </Table.td>

--- a/studio/components/interfaces/BillingV2/Subscription/Tier/SubscriptionPaymentMethod.tsx
+++ b/studio/components/interfaces/BillingV2/Subscription/Tier/SubscriptionPaymentMethod.tsx
@@ -201,7 +201,7 @@ const SubscriptionPaymentMethod = ({
               To remove unused or expired payment methods, head to your{' '}
               <Link href={`/org/${currentOrgSlug || '_'}/billing`} passHref>
                 <a target="_blank" className="text-green-900 transition hover:text-green-1000">
-                  org billing settings
+                  organization's billing settings
                 </a>
               </Link>
               .

--- a/studio/components/interfaces/BillingV2/Subscription/Tier/SubscriptionPaymentMethod.tsx
+++ b/studio/components/interfaces/BillingV2/Subscription/Tier/SubscriptionPaymentMethod.tsx
@@ -12,6 +12,7 @@ import {
 import { checkPermissions, useStore } from 'hooks'
 import { BASE_PATH } from 'lib/constants'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
+import Link from 'next/link'
 
 export interface SubscriptionTierProps {
   subscription: ProjectSubscriptionResponse
@@ -24,6 +25,8 @@ const SubscriptionPaymentMethod = ({
 }: SubscriptionTierProps) => {
   const { ref: projectRef } = useParams()
   const { ui } = useStore()
+
+  const currentOrgSlug = ui.selectedOrganization?.slug
 
   const canUpdatePaymentMethod = checkPermissions(
     PermissionAction.BILLING_WRITE,
@@ -191,7 +194,17 @@ const SubscriptionPaymentMethod = ({
           <div className="py-6 space-y-2">
             <p className="text-sm">
               Upon clicking confirm, all future charges will be deducted from the selected payment
-              method. There are no immediate charges.
+              method. There are no immediate charges. Changing the payment method for this project
+              does not affect the payment method for other projects.
+            </p>
+            <p className="text-sm text-scale-1000">
+              To remove unused or expired payment methods, head to your{' '}
+              <Link href={`/org/${currentOrgSlug || '_'}/billing`} passHref>
+                <a target="_blank" className="text-green-900 transition hover:text-green-1000">
+                  org billing settings
+                </a>
+              </Link>
+              .
             </p>
             <div className="!mt-6">
               <PaymentMethodSelection

--- a/studio/components/interfaces/BillingV2/Subscription/Tier/SubscriptionTier.tsx
+++ b/studio/components/interfaces/BillingV2/Subscription/Tier/SubscriptionTier.tsx
@@ -139,15 +139,15 @@ const SubscriptionTier = ({}: SubscriptionTierProps) => {
                   </Link>
                   , it may become unresponsive.{' '}
                   {currentPlan?.id === 'free' ? (
-                    <span>
+                    <p className="pr-4">
                       If you wish to exceed the included usage, you should upgrade to a paid plan.
-                    </span>
+                    </p>
                   ) : (
-                    <span>
+                    <p className="pr-4">
                       You currently have Spend Cap enabled - when you exceed your plan's limit, you
                       will experience restrictions. To scale seamlessly and pay for over-usage, you
                       can adjust your Cost Control settings.
-                    </span>
+                    </p>
                   )}
                 </p>
               </Alert>

--- a/studio/components/interfaces/BillingV2/Subscription/Tier/TierUpdateSidePanel.tsx
+++ b/studio/components/interfaces/BillingV2/Subscription/Tier/TierUpdateSidePanel.tsx
@@ -129,7 +129,7 @@ const TierUpdateSidePanel = () => {
               const tierMeta = subscriptionsPlans.find((it) => it.id === plan.id)
               const price = planMeta?.price ?? 0
               const isDowngradeOption = planMeta?.change_type === 'downgrade'
-              const isCurrentPlan = planMeta?.is_current ?? false
+              const isCurrentPlan = planMeta?.id === subscription?.plan?.id
 
               if (plan.id === 'tier_enterprise') {
                 return <EnterpriseCard key={plan.id} plan={plan} isCurrentPlan={isCurrentPlan} />


### PR DESCRIPTION
- We now correctly preselect the current payment method instead of using the default customer payment method
- We now preselect the new card, when a new card gets added
- Small styling/padding fixes
- Slight copy adjustments
- Fixed an invalidation issue (the plans were not invalidated and they are used to determine the current plan)
- Fixed missing `key` for an iterated element