### PR TITLE
Update Estee Tey github login for career page

### DIFF
--- a/apps/www/pages/careers/index.tsx
+++ b/apps/www/pages/careers/index.tsx
@@ -48,7 +48,7 @@ export async function getStaticProps() {
       html_url: 'https://github.com/marijanasimag',
     },
     {
-      login: 'estee_tey',
+      login: 'lyqht',
       avatar_url: 'https://pbs.twimg.com/profile_images/1589662526941253632/s1cu3vuD_400x400.jpg',
       html_url: 'https://twitter.com/estee_tey',
     },


### PR DESCRIPTION
## What kind of change does this PR introduce?

Updates Estee Tey github login from `estee_tey` to `lyqht` for career page

## What is the current behavior?

`estee_tey`

![CleanShot 2023-06-17 at 16 41 00@2x](https://github.com/supabase/supabase/assets/70828596/e5c2efca-36ee-4c1a-a26c-74bfb84ef441)

## What is the new behavior?

`lyqht`

![CleanShot 2023-06-17 at 16 41 58@2x](https://github.com/supabase/supabase/assets/70828596/130ecd63-e1f4-46ce-8894-959d2a9e26ea)