### PR TITLE
Replace `createMiddlewareClient` with `createMiddlewareSupabaseClient` in Next.js docs

### DIFF
--- a/apps/docs/pages/guides/auth/auth-helpers/nextjs.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/nextjs.mdx
@@ -82,12 +82,12 @@ Next.js [Middleware](https://nextjs.org/docs/app/building-your-application/routi
 Create a new `middleware.js` file in the root of your project and populate with the following:
 
 ```js middleware.js
-import { createMiddlewareClient } from '@supabase/auth-helpers-nextjs'
+import { createMiddlewareSupabaseClient } from '@supabase/auth-helpers-nextjs'
 import { NextResponse } from 'next/server'
 
 export async function middleware(req) {
   const res = NextResponse.next()
-  const supabase = createMiddlewareClient({ req, res })
+  const supabase = createMiddlewareSupabaseClient({ req, res })
   await supabase.auth.getSession()
   return res
 }
@@ -100,7 +100,7 @@ export async function middleware(req) {
 Create a new `middleware.ts` file in the root of your project and populate with the following:
 
 ```ts middleware.ts
-import { createMiddlewareClient } from '@supabase/auth-helpers-nextjs'
+import { createMiddlewareSupabaseClient } from '@supabase/auth-helpers-nextjs'
 import { NextResponse } from 'next/server'
 
 import type { NextRequest } from 'next/server'
@@ -108,7 +108,7 @@ import type { Database } from '@/lib/database.types'
 
 export async function middleware(req: NextRequest) {
   const res = NextResponse.next()
-  const supabase = createMiddlewareClient<Database>({ req, res })
+  const supabase = createMiddlewareSupabaseClient<Database>({ req, res })
   await supabase.auth.getSession()
   return res
 }
@@ -116,7 +116,7 @@ export async function middleware(req: NextRequest) {
 
 <Admonition type="note">
 
-TypeScript types can be [generated with the Supabase CLI](/docs/reference/javascript/typescript-support) and passed to `createMiddlewareClient` to add type support to the Supabase client.
+TypeScript types can be [generated with the Supabase CLI](/docs/reference/javascript/typescript-support) and passed to `createMiddlewareSupabaseClient` to add type support to the Supabase client.
 
 </Admonition>
 
@@ -508,7 +508,7 @@ There are 5 ways to access the Supabase client with the Next.js Auth Helpers:
 - [Server Components](/docs/guides/auth/auth-helpers/nextjs#server-components) — `createServerComponentClient` in Server Components
 - [Server Actions](/docs/guides/auth/auth-helpers/nextjs#server-actions) — `createServerActionClient` in Server Actions
 - [Route Handlers](/docs/guides/auth/auth-helpers/nextjs#route-handlers) — `createRouteHandlerClient` in Route Handlers
-- [Middleware](/docs/guides/auth/auth-helpers/nextjs#middleware) — `createMiddlewareClient` in Middleware
+- [Middleware](/docs/guides/auth/auth-helpers/nextjs#middleware) — `createMiddlewareSupabaseClient` in Middleware
 
 This allows for the Supabase client to be easily instantiated in the correct context. All you need to change is the context in the middle `create[ClientComponent|ServerComponent|ServerAction|RouteHandler|Middleware]Client` and the Auth Helpers will take care of the rest.
 
@@ -870,7 +870,7 @@ supabase.auth.signUp({
 
 With v0.7.x of the Next.js Auth Helpers a new naming convention has been implemented for createClient functions. The `createMiddlewareSupabaseClient`, `createBrowserSupabaseClient`, `createServerComponentSupabaseClient` and `createRouteHandlerSupabaseClient` functions have been marked as deprecated, and will be removed in a future version of the Auth Helpers.
 
-- `createMiddlewareSupabaseClient` has been replaced with `createMiddlewareClient`
+- `createMiddlewareSupabaseClient` has been replaced with `createMiddlewareSupabaseClient`
 - `createBrowserSupabaseClient` has been replaced with `createClientComponentClient`
 - `createServerComponentSupabaseClient` has been replaced with `createServerComponentClient`
 - `createRouteHandlerSupabaseClient` has been replaced with `createRouteHandlerClient`


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

Code example is referencing what I assume is an older version of the function, which is no longer exported.

## What is the new behavior?

Updated to reference the new function name :) 

## Additional context

Add any other context or screenshots.
