### PR TITLE
Add reading time to blog list items

### DIFF
--- a/apps/www/components/Blog/BlogListItem.tsx
+++ b/apps/www/components/Blog/BlogListItem.tsx
@@ -48,8 +48,18 @@ const BlogListItem = ({ post }: Props) => {
               </div>
 
               <h3 className="text-scale-1200 max-w-sm text-xl">{post.title}</h3>
-              {post.date && <p className="text-scale-1100 text-xs">{post.date}</p>}
               <p className="text-scale-1100 max-w-sm text-base">{post.description}</p>
+              {post.date && (
+                <div className="text-scale-900 flex items-center space-x-1.5 text-sm">
+                  <p>{post.date}</p>
+                  {post.readingTime && (
+                    <>
+                      <p>•</p>
+                      <p>{post.readingTime}</p>
+                    </>
+                  )}
+                </div>
+              )}
             </div>
             <div className="flex items-center -space-x-2">
               {author.map((author: any, i: number) => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

rearranges the date and description, also adds reading time.

## What is the current behavior?

<img width="440" alt="CleanShot 2023-06-17 at 20 27 21@2x" src="https://github.com/supabase/supabase/assets/70828596/c502846b-8927-49cd-be5d-c75c3130412d">

## What is the new behavior?

<img width="440" alt="CleanShot 2023-06-17 at 20 27 40@2x" src="https://github.com/supabase/supabase/assets/70828596/09e00a3a-b5f6-4baf-8135-c88c5ca67977">