### PR TITLE
fix: shrinking of ProductIcon

### DIFF
--- a/apps/www/components/ProductIcon.tsx
+++ b/apps/www/components/ProductIcon.tsx
@@ -7,7 +7,7 @@ function ProductIcon({ icon, color }: ProductIcon) {
   return (
     <div
       className={[
-        'inline-flex h-8 w-8 items-center justify-center rounded-md',
+        'inline-flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-md',
         !color || color === 'black' ? 'bg-scale-1200 text-scale-100' : '',
         color && color === 'green' ? 'bg-brand-800 dark:bg-brand-600 text-brand-100' : '',
       ].join(' ')}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix flex-shrink for ProductIcon to maintain size

## What is the current behavior?

![image](https://github.com/supabase/supabase/assets/69892552/557a2ee0-f4c2-4bc4-ae84-db7ec2038089)
If `category.title` is two lines, the icon is reduced.

## What is the new behavior?

![image](https://github.com/supabase/supabase/assets/69892552/42136c06-0cff-4b4b-ae12-83c41467a733)
Maintain icon size

## Additional context

Fixed using `flex-shrink-0` from existing codebase utilization.
