### PR TITLE
fix: improve y-axis and tooltip values for usage chart

### DIFF
--- a/studio/components/interfaces/BillingV2/Usage/Infrastructure.tsx
+++ b/studio/components/interfaces/BillingV2/Usage/Infrastructure.tsx
@@ -240,7 +240,8 @@ const Infrastructure = ({
                   unit={attribute.unit}
                   attribute={attribute.attribute}
                   data={chartData}
-                  yFormatter={(value) => `${value}%`}
+                  yFormatter={(value) => `${Math.round(Number(value))}%`}
+                  tooltipFormatter={(value) => `${value}%`}
                   yLimit={100}
                 />
               ) : (

--- a/studio/components/interfaces/BillingV2/Usage/Usage.utils.ts
+++ b/studio/components/interfaces/BillingV2/Usage/Usage.utils.ts
@@ -2,7 +2,6 @@ import { DataPoint } from 'data/analytics/constants'
 import { ProjectUsageResponse } from 'data/usage/project-usage-query'
 import { USAGE_APPROACHING_THRESHOLD } from '../Billing.constants'
 import { CategoryAttribute, USAGE_STATUS } from './Usage.constants'
-import { formatBytes } from 'lib/helpers'
 import { ProjectSubscriptionResponse } from 'data/subscriptions/project-subscription-v2-query'
 
 // [Joshen] This is just for development to generate some test data for chart rendering
@@ -50,14 +49,63 @@ const compactNumberFormatter = new Intl.NumberFormat('en-US', {
   compactDisplay: 'short',
 })
 
+/**
+ * For the y-axis, we don't need to be as precise, to avoid showing 58.597MB.
+ */
 export const ChartYFormatterCompactNumber = (number: number | string, unit: string) => {
   if (typeof number === 'string') return number
 
   if (unit === 'bytes') {
-    const formattedBytes = formatBytes(number, 0).replace(/\s/g, '')
+    const formattedBytes = formatBytesCompact(number).replace(/\s/g, '')
 
     return formattedBytes === '0bytes' ? '0' : formattedBytes
   } else {
     return compactNumberFormatter.format(number)
   }
+}
+
+/**
+ * For the chart tooltip, we want to be more precise and show more decimals.
+ */
+export const ChartTooltipValueFormatter = (number: number | string, unit: string) => {
+  if (typeof number === 'string') return number
+
+  if (unit === 'bytes') {
+    const formattedBytes = formatBytesPrecision(number).replace(/\s/g, '')
+
+    return formattedBytes === '0bytes' ? '0' : formattedBytes
+  } else {
+    return compactNumberFormatter.format(number)
+  }
+}
+
+const sizes = ['bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
+
+export const formatBytesCompact = (bytes: number) => {
+  if (bytes === 0 || bytes === undefined) return '0 bytes'
+
+  const k = 1024
+  const i = Math.floor(Math.log(bytes) / Math.log(k))
+
+  const unit = sizes[i]
+
+  let dm = 2
+  if (['bytes', 'KB', 'MB'].includes(unit)) {
+    dm = 0
+  } else if (['GB'].includes(unit)) {
+    dm = 1
+  }
+
+  return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + unit
+}
+
+export const formatBytesPrecision = (bytes: any) => {
+  if (bytes === 0 || bytes === undefined) return '0 bytes'
+
+  const k = 1024
+  const i = Math.floor(Math.log(bytes) / Math.log(k))
+
+  const unit = sizes[i]
+
+  return parseFloat((bytes / Math.pow(k, i)).toFixed(3)) + ' ' + unit
 }

--- a/studio/components/interfaces/BillingV2/Usage/UsageBarChart.tsx
+++ b/studio/components/interfaces/BillingV2/Usage/UsageBarChart.tsx
@@ -22,6 +22,7 @@ export interface UsageBarChartProps {
   yLimit?: number
   yLeftMargin?: number
   yFormatter?: (value: number | string) => string
+  tooltipFormatter?: (value: number | string) => string
 }
 
 const UsageBarChart = ({
@@ -32,6 +33,7 @@ const UsageBarChart = ({
   yLimit,
   yLeftMargin = 10,
   yFormatter,
+  tooltipFormatter
 }: UsageBarChartProps) => {
   const yMin = 0 // We can consider passing this as a prop if there's a use case in the future
 
@@ -70,7 +72,7 @@ const UsageBarChart = ({
                       <p className="text-scale-1000 text-lg">No data yet</p>
                     ) : (
                       <p className="text-xl">
-                        {yFormatter !== undefined ? yFormatter(value) : value}
+                        {tooltipFormatter !== undefined ? tooltipFormatter(value) : value}
                       </p>
                     )}
                     <p className="text-xs text-scale-1100 mt-1">

--- a/studio/components/interfaces/BillingV2/Usage/UsageSection.tsx
+++ b/studio/components/interfaces/BillingV2/Usage/UsageSection.tsx
@@ -14,7 +14,7 @@ import Link from 'next/link'
 import SparkBar from 'components/ui/SparkBar'
 import clsx from 'clsx'
 import { ProjectSubscriptionResponse } from 'data/subscriptions/project-subscription-v2-query'
-import { ChartYFormatterCompactNumber, getUpgradeUrl } from './Usage.utils'
+import { ChartTooltipValueFormatter, ChartYFormatterCompactNumber, getUpgradeUrl } from './Usage.utils'
 import { formatBytes } from 'lib/helpers'
 import UsageBarChart from './UsageBarChart'
 import Panel from 'components/ui/Panel'
@@ -229,6 +229,7 @@ const UsageSection = ({
                       data={chartData}
                       yLeftMargin={chartMeta[attribute.key].margin}
                       yFormatter={(value) => ChartYFormatterCompactNumber(value, attribute.unit)}
+                      tooltipFormatter={(value) => ChartTooltipValueFormatter(value, attribute.unit)}
                     />
                   ) : (
                     <Panel>


### PR DESCRIPTION
It is currently very difficult to see the usage chart values for byte units. The y-axis just cuts off the entire decimals and the tooltip does not show the more precise value either, leading to users being confused about the chart values mismatching the total usage. The API returns the correct values, it's just an issue with our y-axis and tooltip value formatting.

PR introduces different formats for tooltip values and y-axis (compact and precise). While this is not 100% sophisticated, it at least stops misleading our users.

**Current:**

![Screenshot 2023-06-18 at 22 04 05](https://github.com/supabase/supabase/assets/14073399/3d6e39a3-6249-4632-a6d3-b000e2cc0e97)
![Screenshot 2023-06-18 at 22 04 03](https://github.com/supabase/supabase/assets/14073399/8f734175-27bb-4f8b-8b28-b4fd95ec249c)

**New:**

![Screenshot 2023-06-18 at 21 55 29](https://github.com/supabase/supabase/assets/14073399/186997b3-4377-4da4-b21a-ab59503f5a11)

![Screenshot 2023-06-18 at 21 55 35](https://github.com/supabase/supabase/assets/14073399/e964e4fa-26e1-4004-a19e-a1bd43e413e0)
