### PR TITLE
Clarify azure as microsoft auth provider

### DIFF
--- a/apps/www/pages/auth/Auth.tsx
+++ b/apps/www/pages/auth/Auth.tsx
@@ -122,8 +122,8 @@ function AuthPage() {
               </div>
               <h4 className="h4">All the social providers</h4>
               <p className="p text-base">
-                Enable social logins with the click of a button. Google, Facebook, GitHub, Azure (Microsoft),
-                Gitlab, Twitter, Discord, and many more.
+                Enable social logins with the click of a button. Google, Facebook, GitHub, Azure
+                (Microsoft), Gitlab, Twitter, Discord, and many more.
               </p>
             </div>
             <div className="col-span-12 mb-10 lg:col-span-3 lg:col-start-5 lg:mb-0">

--- a/apps/www/pages/auth/Auth.tsx
+++ b/apps/www/pages/auth/Auth.tsx
@@ -122,7 +122,7 @@ function AuthPage() {
               </div>
               <h4 className="h4">All the social providers</h4>
               <p className="p text-base">
-                Enable social logins with the click of a button. Google, Facebook, GitHub, Azure,
+                Enable social logins with the click of a button. Google, Facebook, GitHub, Azure (Microsoft),
                 Gitlab, Twitter, Discord, and many more.
               </p>
             </div>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Clarifies azure as the auth provider Microsoft.

## What is the current behavior?

<img width="300" src="https://github.com/supabase/supabase/assets/70828596/cf7252fc-ef74-49a6-a7ca-3572d663ec93" alt="CleanShot 2023-06-18 at 17 00 00@2x">

## What is the new behavior?

<img width="300" src="https://github.com/supabase/supabase/assets/70828596/731e053c-69a2-4c36-8223-997343dcf85a" alt="CleanShot 2023-06-18 at 17 00 31@2x">