### PR TITLE
fix: col-span for invoice loading/error state

### DIFF
--- a/studio/components/interfaces/Billing/Invoices.tsx
+++ b/studio/components/interfaces/Billing/Invoices.tsx
@@ -97,7 +97,7 @@ const Invoices: FC<Props> = ({ projectRef }) => {
           body={
             invoices.length === 0 ? (
               <Table.tr>
-                <Table.td colSpan={5} className="p-3 py-12 text-center">
+                <Table.td colSpan={6} className="p-3 py-12 text-center">
                   <p className="text-scale-1000">
                     {loading ? 'Checking for invoices' : 'No invoices for this project yet'}
                   </p>

--- a/studio/components/interfaces/Organization/InvoicesSettings/InvoicesSettings.tsx
+++ b/studio/components/interfaces/Organization/InvoicesSettings/InvoicesSettings.tsx
@@ -107,7 +107,7 @@ const InvoicesSettings = () => {
           body={
             invoices.length === 0 ? (
               <Table.tr>
-                <Table.td colSpan={5} className="p-3 py-12 text-center">
+                <Table.td colSpan={6} className="p-3 py-12 text-center">
                   <p className="text-scale-1000">
                     {loading ? 'Checking for invoices' : 'No invoices for this organization yet'}
                   </p>


### PR DESCRIPTION
Fixes this:

<img width="983" alt="Screenshot 2023-06-19 at 01 02 18" src="https://github.com/supabase/supabase/assets/14073399/1aac87cb-ef41-48a9-9a02-4a64bf0e714b">
