### PR TITLE
fix: pricing table firebox bug

### DIFF
--- a/apps/www/pages/pricing/index.tsx
+++ b/apps/www/pages/pricing/index.tsx
@@ -770,7 +770,7 @@ export default function IndexPage() {
 
                     {plans.map((plan) => (
                       <td className="h-full px-6 py-2 align-top" key={`price-${plan.name}`}>
-                        <div className="relative table h-full w-full">
+                        <div className="relative h-full w-full">
                           <div className="flex flex-col justify-between h-full">
                             <>
                               <span


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix pricing table bug. (Firefox)

## Before

<img width="1528" alt="Schermata 2023-06-19 alle 12 40 45" src="https://github.com/supabase/supabase/assets/25671831/9cc72f0b-94f3-4d47-b402-01dbf58bcc4f">

## After

<img width="1500" alt="Schermata 2023-06-19 alle 12 40 35" src="https://github.com/supabase/supabase/assets/25671831/cb6401dc-8f0d-4b57-b96d-c45e82afb686">
