### PR TITLE
Docs: Update Next.js quickstarts to use new `create-next-app` starter

### DIFF
--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
@@ -210,8 +210,8 @@ export const gettingstarted: NavMenuConstant = {
     {
       name: 'Framework Quickstarts',
       items: [
+        { name: 'Next.js', url: '/guides/getting-started/quickstarts/nextjs' },
         { name: 'React', url: '/guides/getting-started/quickstarts/reactjs' },
-        { name: 'NextJS', url: '/guides/getting-started/quickstarts/nextjs' },
         { name: 'NuxtJS', url: '/guides/getting-started/quickstarts/nuxtjs' },
         { name: 'RedwoodJS', url: '/guides/getting-started/quickstarts/redwoodjs' },
         { name: 'Flutter', url: '/guides/getting-started/quickstarts/flutter' },
@@ -224,7 +224,7 @@ export const gettingstarted: NavMenuConstant = {
       name: 'Web app tutorials',
       items: [
         {
-          name: 'NextJS',
+          name: 'Next.js',
           url: '/guides/getting-started/tutorials/with-nextjs',
         },
         {
@@ -424,7 +424,10 @@ export const auth = {
     },
     {
       name: 'Quickstarts',
-      items: [{ name: 'Auth with React', url: '/guides/auth/quickstarts/react', items: [] }],
+      items: [
+        { name: 'Next.js', url: '/guides/auth/quickstarts/nextjs', items: [] },
+        { name: 'React', url: '/guides/auth/quickstarts/react', items: [] },
+      ],
     },
     {
       name: 'Authentication',

--- a/apps/docs/pages/guides/auth/auth-helpers/nextjs.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/nextjs.mdx
@@ -25,7 +25,40 @@ If you are using the `pages` directory, check out [Auth Helpers in Next.js Pages
 
 </Admonition>
 
-## Configuration
+## Automatic Configuration (recommended)
+
+Use the `create-next-app` command and the `with-supabase` template to automate the configuration of cookie-based auth with the Next.js Auth Helpers.
+
+```sh
+npx create-next-app -e with-supabase
+```
+
+This creates a new Next.js app configured with:
+
+- [Cookie-based Auth](/docs/guides/auth/auth-helpers/nextjs#authentication)
+- [Middleware to refresh user's session](/docs/guides/auth/auth-helpers/nextjs#managing-session-with-middleware)
+- [Code Exchange Route](/docs/guides/auth/auth-helpers/nextjs#Managing-sign-in-with-code-exchange)
+- [TypeScript](https://www.typescriptlang.org/)
+- [Tailwind CSS](https://tailwindcss.com/)
+
+### Declare Environment Variables
+
+Retrieve your project's URL and anon key from your [API settings](https://app.supabase.com/project/_/settings/api), and create a `.env.local` file with the following environment variables:
+
+```bash .env.local
+NEXT_PUBLIC_SUPABASE_URL=your-supabase-url
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
+```
+
+### Run Next.js App
+
+Run the development server and navigate to http://localhost:3000.
+
+```bash
+npm run dev
+```
+
+## Manual Configuration
 
 ### Install Next.js Auth Helpers library
 
@@ -60,8 +93,6 @@ Retrieve your project's URL and anon key from your [API settings](https://app.su
 NEXT_PUBLIC_SUPABASE_URL=your-supabase-url
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
 ```
-
-Make sure you name these variables exactly as seen here, since these are picked up by the auth helpers library — you no longer have to explicitly pass them to a `createClient()` function as before.
 
 ### Managing session with Middleware
 

--- a/apps/docs/pages/guides/auth/quickstarts/nextjs.mdx
+++ b/apps/docs/pages/guides/auth/quickstarts/nextjs.mdx
@@ -1,0 +1,94 @@
+import Layout from '~/layouts/DefaultGuideLayout'
+import StepHikeCompact from '~/components/StepHikeCompact'
+
+export const meta = {
+  title: 'Use Supabase Auth with Next.js',
+  subtitle: 'Learn how to configure Supabase Auth for the Next.js App Router.',
+  breadcrumb: 'Auth Quickstarts',
+}
+
+<StepHikeCompact>
+
+  <StepHikeCompact.Step step={1}>
+    <StepHikeCompact.Details title="Create a new Supabase project">
+
+    [Launch a new project](https://app.supabase.com) in the Supabase Dashboard.
+
+    Your new database has a table for storing your users. You can see that this table is currently empty by running some SQL in the [SQL Editor](https://app.supabase.com/project/_/sql).
+
+    </StepHikeCompact.Details>
+
+    <StepHikeCompact.Code>
+
+     ```sql SQL_EDITOR
+      select * from auth.users;
+      ````
+
+    </StepHikeCompact.Code>
+
+  </StepHikeCompact.Step>
+
+  <StepHikeCompact.Step step={2}>
+
+    <StepHikeCompact.Details title="Create a Next.js app">
+
+    Use the `create-next-app` command and the `with-supabase` template, to create a Next.js app pre-configured with:
+    - [Supabase Auth](https://supabase.com/docs/guides/auth/auth-helpers/nextjs)
+    - [TypeScript](https://www.typescriptlang.org/)
+    - [Tailwind CSS](https://tailwindcss.com/)
+
+    </StepHikeCompact.Details>
+
+    <StepHikeCompact.Code>
+
+      ```bash Terminal
+      npx create-next-app -e with-supabase my-app && cd my-app
+      ```
+
+    </StepHikeCompact.Code>
+
+  </StepHikeCompact.Step>
+
+  <StepHikeCompact.Step step={3}>
+    <StepHikeCompact.Details title="Declare Supabase Environment Variables">
+
+    Rename `.env.local.example` to `.env.local` and populate with [your project's URL and Anon Key](https://app.supabase.com/project/_/settings/api).
+
+    </StepHikeCompact.Details>
+
+    <StepHikeCompact.Code>
+
+      ```text .env.local
+        NEXT_PUBLIC_SUPABASE_URL=your-project-url
+        NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+      ```
+
+    </StepHikeCompact.Code>
+
+  </StepHikeCompact.Step>
+
+  <StepHikeCompact.Step step={4}>
+    <StepHikeCompact.Details title="Start the app">
+
+    Start the development server, go to http://localhost:3000 in a browser, and you should see the contents of `app/page.tsx`.
+
+    To Sign Up a new user, navigate to http://localhost:3000/login, and click `Sign Up Now`.
+
+    Check out the [Supabase Auth docs](https://supabase.com/docs/guides/auth#authentication) for more authentication methods.
+
+    </StepHikeCompact.Details>
+
+    <StepHikeCompact.Code>
+
+      ```bash Terminal
+      npm run dev
+      ```
+
+    </StepHikeCompact.Code>
+
+  </StepHikeCompact.Step>
+</StepHikeCompact>
+
+export const Page = ({ children }) => <Layout meta={meta} children={children} hideToc={true} />
+
+export default Page

--- a/apps/docs/pages/guides/auth/quickstarts/react.mdx
+++ b/apps/docs/pages/guides/auth/quickstarts/react.mdx
@@ -3,7 +3,7 @@ import StepHikeCompact from '~/components/StepHikeCompact'
 
 export const meta = {
   title: 'Use Supabase Auth with React',
-  subtitle: 'Learn how to Supabase Auth with React.js.',
+  subtitle: 'Learn how to use Supabase Auth with React.js.',
   breadcrumb: 'Auth Quickstarts',
 }
 

--- a/apps/docs/pages/guides/getting-started/quickstarts/nextjs.mdx
+++ b/apps/docs/pages/guides/getting-started/quickstarts/nextjs.mdx
@@ -2,9 +2,9 @@ import Layout from '~/layouts/DefaultGuideLayout'
 import StepHikeCompact from '~/components/StepHikeCompact'
 
 export const meta = {
-  title: 'Use Supabase with NextJS',
+  title: 'Use Supabase with Next.js',
   subtitle:
-    'Learn how to create a Supabase project, add some sample data to your database, and query the data from a NextJS app.',
+    'Learn how to create a Supabase project, add some sample data to your database, and query the data from a Next.js app.',
   breadcrumb: 'Framework Quickstarts',
 }
 
@@ -15,17 +15,19 @@ export const meta = {
 
     [Create a new project](https://app.supabase.com) in the Supabase Dashboard.
 
-    After your project is ready, create a table in your Supabase database using the [SQL Editor](https://app.supabase.com/project/_/sql) in the Dashboard. Use the following SQL statement to create a `countries` table with some sample data.
+    After your project is ready, create a table in your Supabase database using the [SQL Editor](https://app.supabase.com/project/_/sql) in the Dashboard.
+
+    Use the following SQL statement to create a `countries` table with some sample data.
 
     </StepHikeCompact.Details>
 
     <StepHikeCompact.Code>
 
-     ```sql Editor
+     ```sql SQL_EDITOR
       -- Create the table
       create table countries (
         id serial primary key,
-        name varchar(255) not null
+        name text not null
       );
 
       -- Insert some sample data into the table
@@ -40,16 +42,19 @@ export const meta = {
 
   <StepHikeCompact.Step step={2}>
 
-    <StepHikeCompact.Details title="Create a NextJS app">
+    <StepHikeCompact.Details title="Create a Next.js app">
 
-    Create a Next.js app using the `create-next-app` command.
+    Use the `create-next-app` command and the `with-supabase` template, to create a Next.js app pre-configured with:
+    - [Supabase Auth](https://supabase.com/docs/guides/auth/auth-helpers/nextjs)
+    - [TypeScript](https://www.typescriptlang.org/)
+    - [Tailwind CSS](https://tailwindcss.com/)
 
     </StepHikeCompact.Details>
 
     <StepHikeCompact.Code>
 
       ```bash Terminal
-      npx create-next-app my-app
+      npx create-next-app -e with-supabase my-app && cd my-app
       ```
 
     </StepHikeCompact.Code>
@@ -57,18 +62,17 @@ export const meta = {
   </StepHikeCompact.Step>
 
   <StepHikeCompact.Step step={3}>
-    <StepHikeCompact.Details title="Install the Supabase client library">
+    <StepHikeCompact.Details title="Declare Supabase Environment Variables">
 
-      The fastest way to get started is to use the `supabase-js` client library which provides a convenient interface for working with Supabase from a NextJS app.
-
-      Navigate to the NextJS app and install `supabase-js`.
+    Rename `.env.local.example` to `.env.local` and populate with [your project's URL and Anon Key](https://app.supabase.com/project/_/settings/api).
 
     </StepHikeCompact.Details>
 
     <StepHikeCompact.Code>
 
-      ```bash Terminal
-      cd my-app && npm install @supabase/supabase-js
+      ```text .env.local
+        NEXT_PUBLIC_SUPABASE_URL=your-project-url
+        NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
       ```
 
     </StepHikeCompact.Code>
@@ -76,18 +80,33 @@ export const meta = {
   </StepHikeCompact.Step>
 
   <StepHikeCompact.Step step={4}>
-    <StepHikeCompact.Details title="Create the Supabase client">
+    <StepHikeCompact.Details title="Query Supabase data from Next.js">
 
-    In the `/lib` directory of your Next.js app, create a file called `supabaseClient.js` and add the following code to initialize the Supabase client with your [project URL and public API (anon) key](https://app.supabase.com/project/_/settings/api).
+    Create a new file at `app/countries/page.tsx` and populate with the following.
+
+    This will select all the rows from the `countries` table in Supabase and render them on the page.
 
     </StepHikeCompact.Details>
 
     <StepHikeCompact.Code>
 
-      ```js lib/supabaseClient.js
-        import { createClient } from '@supabase/supabase-js'
+      ```ts app/countries/page.tsx
+        import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
+        import { cookies } from "next/headers";
 
-        export const supabase = createClient('https://<project>.supabase.co', '<your-anon-key>')
+        export default async function Index() {
+          const supabase = createServerComponentClient({ cookies });
+
+          const { data: countries } = await supabase.from("countries").select();
+
+          return (
+            <ul className="my-auto">
+              {countries?.map((country) => (
+                <li key={country.id}>{country.name}</li>
+              ))}
+            </ul>
+          );
+        }
       ```
 
     </StepHikeCompact.Code>
@@ -95,50 +114,9 @@ export const meta = {
   </StepHikeCompact.Step>
 
   <StepHikeCompact.Step step={5}>
-    <StepHikeCompact.Details title="Query data from the app">
-
-    Use the `getServerSideProps` method to fetch the data server-side and display the query result as a simple list.
-
-    Replace the existing function in your index file in the `pages` directory with the following code.
-
-    </StepHikeCompact.Details>
-
-    <StepHikeCompact.Code>
-
-      ```js app/index.js
-        import { supabase } from './../lib/supabaseClient';
-
-        function Page({ countries }) {
-          return (
-            <ul>
-              {countries.map((country) => (
-                <li key={country.id}>{country.name}</li>
-              ))}
-            </ul>
-          );
-        }
-
-        export async function getServerSideProps() {
-          let { data } = await supabase.from('countries').select()
-
-          return {
-            props: {
-             countries: data
-            },
-          }
-        }
-
-        export default Page;
-      ```
-
-    </StepHikeCompact.Code>
-
-  </StepHikeCompact.Step>
-
-  <StepHikeCompact.Step step={6}>
     <StepHikeCompact.Details title="Start the app">
 
-    Start the app and go to http://localhost:3000 in a browser and you should see the list of countries.
+    Run the development server, go to http://localhost:3000/countries in a browser and you should see the list of countries.
 
     </StepHikeCompact.Details>
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

- Next.js Auth Helpers only contain Manual Configuration steps
- Next.js Quickstart does not use cookies
- There is no Next.js Auth Quickstart

## What is the new behavior?

- Next.js Auth Helpers contain Automatic Configuration steps
- Next.js Quickstarts use the new Supabase Starter template for `create-next-app`

```
$ npx create-next-app -e with-supabase
```

## Additional context

Initial template: https://github.com/vercel/next.js/pull/51335

Improved template: https://github.com/vercel/next.js/pull/51442