### PR TITLE
Docs: Update links in exhaust cpu 

### DIFF
--- a/apps/docs/pages/guides/platform/exhaust-cpu.mdx
+++ b/apps/docs/pages/guides/platform/exhaust-cpu.mdx
@@ -23,7 +23,7 @@ Moreover, your instance might not be able to handle future traffic spikes if it 
 
 ## Monitor your CPU
 
-You can check your CPU usage directly on the Supabase Platform. For this go to database health in the reports section or [click here](https://app.supabase.com/project/_/reports/database) and select your project.
+You can check your CPU usage directly on the Supabase Platform. For this go to database health in the reports section or [click here](https://supabase.com/dashboard/project/_/reports/database) and select your project.
 
 ![CPU usage reported on Supabase dashboard](/docs/img/guides/platform/exhaust-cpu-report.png)
 
@@ -42,7 +42,7 @@ Everything you do with your Supabase project requires compute. Hence, there can 
 There are two ways to solve high CPU:
 
 1. **Optimize performance:** Get more out of your instance's resources by optimizing your usage. Have a look at our [performance tuning guide](https://supabase.com/docs/guides/platform/performance#examining-query-performance) and our [production readiness guide](https://supabase.com/docs/guides/platform/going-into-prod#performance).
-2. **Upgrade your compute:** You can get a Compute Add-on for your project. Follow [this link](https://app.supabase.com/project/_/settings/billing/subscription?panel=computeInstance) and select your project to see your upgrade options.
+2. **Upgrade your compute:** You can get a Compute Add-on for your project. Follow [this link](https://supabase.com/dashboard/project/_/settings/billing/subscription?panel=computeInstance) and select your project to see your upgrade options.
 
 export const Page = ({ children }) => <Layout meta={meta} children={children} />
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

Links were pointing to: [app.supabase.com](url)

## What is the new behavior?

Updated links to: [supabase.com/dashboard](url)


