### PR TITLE
Add environment variables substitution for kong.yml

### DIFF
--- a/apps/docs/pages/guides/self-hosting/docker.mdx
+++ b/apps/docs/pages/guides/self-hosting/docker.mdx
@@ -48,14 +48,10 @@ We can use your JWT Secret to generate new `anon` and `service` API keys using t
 
 ### Update API Keys
 
-Replace the values in these files:
+Replace the values the `.env` file:
 
-- `.env`:
   - `ANON_KEY` - replace with an `anon` key
   - `SERVICE_ROLE_KEY` - replace with a `service` key
-- `volumes/api/kong.yml`
-  - `anon` - replace with an `anon` key
-  - `service_role` - replace with a `service` key
 
 ### Update Secrets
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -40,20 +40,24 @@ services:
     container_name: supabase-kong
     image: kong:2.8.1
     restart: unless-stopped
+    # https://unix.stackexchange.com/a/294837
+    entrypoint: bash -c 'eval "echo \"$(cat ~/temp.yml)\"" > ~/kong.yml && /docker-entrypoint.sh kong docker-start'
     ports:
       - ${KONG_HTTP_PORT}:8000/tcp
       - ${KONG_HTTPS_PORT}:8443/tcp
     environment:
       KONG_DATABASE: "off"
-      KONG_DECLARATIVE_CONFIG: /var/lib/kong/kong.yml
+      KONG_DECLARATIVE_CONFIG: /home/kong/kong.yml
       # https://github.com/supabase/cli/issues/14
       KONG_DNS_ORDER: LAST,A,CNAME
       KONG_PLUGINS: request-transformer,cors,key-auth,acl
       KONG_NGINX_PROXY_PROXY_BUFFER_SIZE: 160k
       KONG_NGINX_PROXY_PROXY_BUFFERS: 64 160k
+      SUPABASE_ANON_KEY: ${ANON_KEY}
+      SUPABASE_SERVICE_KEY: ${SERVICE_ROLE_KEY}
     volumes:
       # https://github.com/supabase/supabase/issues/12661
-      - ./volumes/api/kong.yml:/var/lib/kong/kong.yml:ro
+      - ./volumes/api/kong.yml:/home/kong/temp.yml:ro
 
   auth:
     container_name: supabase-auth

--- a/docker/volumes/api/kong.yml
+++ b/docker/volumes/api/kong.yml
@@ -6,10 +6,10 @@ _format_version: '1.1'
 consumers:
   - username: anon
     keyauth_credentials:
-      - key: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJhbm9uIiwKICAgICJpc3MiOiAic3VwYWJhc2UtZGVtbyIsCiAgICAiaWF0IjogMTY0MTc2OTIwMCwKICAgICJleHAiOiAxNzk5NTM1NjAwCn0.dc_X5iR_VP_qT0zsiyj_I_OZ2T9FtRU2BBNWN8Bu4GE
+      - key: $SUPABASE_ANON_KEY
   - username: service_role
     keyauth_credentials:
-      - key: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJzZXJ2aWNlX3JvbGUiLAogICAgImlzcyI6ICJzdXBhYmFzZS1kZW1vIiwKICAgICJpYXQiOiAxNjQxNzY5MjAwLAogICAgImV4cCI6IDE3OTk1MzU2MDAKfQ.DaYlNEoUrrEn2Ig7tqibS-PHK5vgusbcbo7X36XVt4Q
+      - key: $SUPABASE_SERVICE_KEY
 
 ###
 ### Access Control List


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix #12416

## What is the current behavior?
As mentioned in [Self Hosting Page](https://supabase.com/docs/guides/self-hosting/docker#update-api-keys)
Replace the values in both files `.env` and `volumes/api/kong.yml` with the anon and service key

## What is the new behavior?
Changes in `.env` file will now reflect in `kong.yml` inside the container.

## Additional context
**Note** that `volumes/api/kong.yml` is not included in the `.gitignore` which is a **bad practice** since configuration files should not be tracked in git.

I did some investigation on the matter and it turns out that `kong.yml` is passed as a `KONG_DECLARATIVE_CONFIG` file.
Unfortunately Kong Declarative Config files [does not support environment variables](https://discuss.konghq.com/t/using-environment-variables-in-kong-configuration-file-in-db-less-mode/7653/2)
There is a hint in the link above for the solution using `envsubst` command but unfortunately it's not supported in the official docker image for Kong.
There is an [image](https://github.com/carnei-ro/kong-interpolation) that can do just that, but it's older and this is too much changes for my taste anyway.

The simpler workaround I used for this is to use this little [hack](https://unix.stackexchange.com/a/294837):
`eval "echo \"$(cat ~/temp.yml)\"" > ~/kong.yml`
executing it before the entry point for Kong substitute the environment variables in the file.
Also `kong.yml` should reference the environment variables and we should pass them in the `docker-compose.yml` file as well.
