### PR TITLE
Remove apps/new-docs from workspaces in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   "workspaces": [
     "apps/www",
     "apps/docs",
-    "apps/new-docs",
     "studio",
     "tests",
     "packages/*"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Remove `apps/new-docs` from workspaces in `package.json` since its no longer used.