### PR TITLE
Chore/storage explorer custom domain

### DIFF
--- a/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
+++ b/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
@@ -158,7 +158,7 @@ const ProviderForm: FC<Props> = ({ provider }) => {
                         disabled
                         label="Redirect URL"
                         value={
-                          customDomainData?.customDomain
+                          customDomainData?.customDomain?.status === 'active'
                             ? `https://${customDomainData.customDomain?.hostname}/auth/v1/callback`
                             : `https://${ui.selectedProjectRef}.supabase.co/auth/v1/callback`
                         }

--- a/studio/components/layouts/StorageLayout/StorageBucketsError.tsx
+++ b/studio/components/layouts/StorageLayout/StorageBucketsError.tsx
@@ -1,0 +1,43 @@
+import { useParams } from 'common'
+import Link from 'next/link'
+import { ResponseError } from 'types'
+import { Alert, Button } from 'ui'
+
+export interface StorageBucketsErrorProps {
+  error: ResponseError
+}
+
+const StorageBucketsError = ({ error }: StorageBucketsErrorProps) => {
+  const { ref } = useParams()
+
+  return (
+    <div className="storage-container flex flex items-center justify-center flex-grow">
+      <div>
+        <Alert
+          withIcon
+          variant="warning"
+          title="Failed to fetch buckets"
+          actions={[
+            <Link
+              key="contact-support"
+              href={`/support/new?ref=${ref}&category=dashboard_bug&subject=Unable%20to%20fetch%20storage%20buckets`}
+            >
+              <a>
+                <Button type="default" className="ml-4">
+                  Contact support
+                </Button>
+              </a>
+            </Link>,
+          ]}
+        >
+          <p className="mb-1">
+            Please try refreshing your browser, or contact support if the issue persists
+          </p>
+          <p>Error: {(error as any)?.message ?? 'Unknown'}</p>
+        </Alert>
+      </div>
+    </div>
+  )
+}
+
+export default StorageBucketsError

--- a/studio/components/layouts/StorageLayout/StorageLayout.tsx
+++ b/studio/components/layouts/StorageLayout/StorageLayout.tsx
@@ -30,7 +30,7 @@ const StorageLayout = ({ title, children }: StorageLayoutProps) => {
 
   useEffect(() => {
     if (!isLoading && apiService) initializeStorageStore(apiService)
-  }, [isLoading])
+  }, [isLoading, projectRef])
 
   const initializeStorageStore = async (apiService: AutoApiService) => {
     if (isPaused) return

--- a/studio/components/layouts/StorageLayout/StorageMenu.tsx
+++ b/studio/components/layouts/StorageLayout/StorageMenu.tsx
@@ -31,12 +31,10 @@ const StorageMenu = () => {
     | 'logs'
 
   const storageExplorerStore = useStorageStore()
-  const { data, isLoading, isError } = useBucketsQuery({ projectRef: ref })
+  const { data, isLoading, isError, isSuccess } = useBucketsQuery({ projectRef: ref })
   const { openDeleteBucketModal } = storageExplorerStore || {}
 
   const buckets = data ?? []
-
-  console.log({ isError })
 
   return (
     <>
@@ -82,13 +80,24 @@ const StorageMenu = () => {
           <div className="">
             <div>
               <Menu.Group title="All buckets" />
-              {isLoading ? (
+
+              {isLoading && (
                 <div className="space-y-2 mx-2">
                   <ShimmeringLoader className="!py-2.5" />
                   <ShimmeringLoader className="!py-2.5" />
                   <ShimmeringLoader className="!py-2.5" />
                 </div>
-              ) : (
+              )}
+
+              {isError && (
+                <div className="px-2">
+                  <Alert variant="warning" title="Failed to fetch buckets">
+                    Please refresh to try again.
+                  </Alert>
+                </div>
+              )}
+
+              {isSuccess && (
                 <>
                   {buckets.length === 0 && (
                     <div className="px-2">

--- a/studio/components/layouts/StorageLayout/StorageMenu.tsx
+++ b/studio/components/layouts/StorageLayout/StorageMenu.tsx
@@ -31,10 +31,12 @@ const StorageMenu = () => {
     | 'logs'
 
   const storageExplorerStore = useStorageStore()
-  const { data, isLoading } = useBucketsQuery({ projectRef: ref })
+  const { data, isLoading, isError } = useBucketsQuery({ projectRef: ref })
   const { openDeleteBucketModal } = storageExplorerStore || {}
 
   const buckets = data ?? []
+
+  console.log({ isError })
 
   return (
     <>

--- a/studio/components/to-be-cleaned/Storage/Storage.types.ts
+++ b/studio/components/to-be-cleaned/Storage/Storage.types.ts
@@ -1,0 +1,30 @@
+export interface StorageColumn {
+  id: string
+  name: string
+  status: string
+  items: StorageItem[]
+  hasMoreItems: boolean
+  isLoadingMoreItems: boolean
+}
+
+export interface StorageItem {
+  id: string | null
+  name: string
+  type: string
+  status: string
+  metadata: StorageItemMetadata | null
+  isCorrupted: boolean
+  created_at: string | null
+  updated_at: string | null
+  last_accessed_at: string | null
+}
+
+export interface StorageItemMetadata {
+  cacheControl: string
+  contentLength: number
+  size: number
+  httpStatusCode: number
+  eTag: string
+  lastModified: string
+  mimetype: string
+}

--- a/studio/components/to-be-cleaned/Storage/StorageExplorer/CustomExpiryModal.tsx
+++ b/studio/components/to-be-cleaned/Storage/StorageExplorer/CustomExpiryModal.tsx
@@ -1,14 +1,14 @@
-import { FC } from 'react'
 import { Form, Modal, Input, Button } from 'ui'
 import { observer } from 'mobx-react-lite'
 import { useStorageStore } from 'localStores/storageExplorer/StorageExplorerStore'
 
-interface Props {}
+export interface CustomExpiryModalProps {
+  onCopyUrl: (name: string, url: string) => void
+}
 
-const CustomExpiryModal: FC<Props> = () => {
+const CustomExpiryModal = ({ onCopyUrl }: CustomExpiryModalProps) => {
   const storageExplorerStore = useStorageStore()
-  const { selectedFileCustomExpiry, setSelectedFileCustomExpiry, copyFileURLToClipboard } =
-    storageExplorerStore
+  const { getFileUrl, selectedFileCustomExpiry, setSelectedFileCustomExpiry } = storageExplorerStore
 
   const visible = selectedFileCustomExpiry !== undefined
   const onClose = () => setSelectedFileCustomExpiry(undefined)
@@ -28,7 +28,10 @@ const CustomExpiryModal: FC<Props> = () => {
         initialValues={{ expiresIn: '' }}
         onSubmit={async (values: any, { setSubmitting }: any) => {
           setSubmitting(true)
-          await copyFileURLToClipboard(selectedFileCustomExpiry, values.expiresIn)
+          onCopyUrl(
+            selectedFileCustomExpiry.name,
+            await getFileUrl(selectedFileCustomExpiry, values.expiresIn)
+          )
           setSubmitting(false)
           onClose()
         }}

--- a/studio/components/to-be-cleaned/Storage/StorageExplorer/FileExplorer.tsx
+++ b/studio/components/to-be-cleaned/Storage/StorageExplorer/FileExplorer.tsx
@@ -6,6 +6,21 @@ import ItemContextMenu from './ItemContextMenu'
 import FolderContextMenu from './FolderContextMenu'
 import ColumnContextMenu from './ColumnContextMenu'
 import FileExplorerColumn from './FileExplorerColumn'
+import { noop } from 'lodash'
+import { StorageColumn } from '../Storage.types'
+
+export interface FileExplorerProps {
+  view: string
+  columns: any[]
+  openedFolders: any[]
+  selectedItems: any[]
+  selectedFilePreview: any
+  onFilesUpload: (event: any, index: number) => void
+  onSelectAllItemsInColumn: (index: number) => void
+  onSelectColumnEmptySpace: (index: number) => void
+  onColumnLoadMore: (index: number, column: StorageColumn) => void
+  onCopyUrl: (name: string, url: string) => void
+}
 
 const FileExplorer = ({
   view = STORAGE_VIEWS.COLUMNS,
@@ -13,12 +28,13 @@ const FileExplorer = ({
   openedFolders = [],
   selectedItems = [],
   selectedFilePreview = {},
-  onFilesUpload = () => {},
-  onSelectAllItemsInColumn = () => {},
-  onSelectColumnEmptySpace = () => {},
-  onColumnLoadMore = () => {},
-}) => {
-  const fileExplorerRef = useRef(null)
+  onFilesUpload = noop,
+  onSelectAllItemsInColumn = noop,
+  onSelectColumnEmptySpace = noop,
+  onColumnLoadMore = noop,
+  onCopyUrl = noop,
+}: FileExplorerProps) => {
+  const fileExplorerRef = useRef<any>(null)
 
   useEffect(() => {
     if (fileExplorerRef) {
@@ -35,7 +51,7 @@ const FileExplorer = ({
       className="file-explorer flex flex-grow overflow-x-auto justify-between h-full w-full"
     >
       <ColumnContextMenu id={CONTEXT_MENU_KEYS.STORAGE_COLUMN} />
-      <ItemContextMenu id={CONTEXT_MENU_KEYS.STORAGE_ITEM} />
+      <ItemContextMenu id={CONTEXT_MENU_KEYS.STORAGE_ITEM} onCopyUrl={onCopyUrl} />
       <FolderContextMenu id={CONTEXT_MENU_KEYS.STORAGE_FOLDER} />
       {view === STORAGE_VIEWS.COLUMNS ? (
         <div className="flex">
@@ -52,6 +68,7 @@ const FileExplorer = ({
               onSelectAllItemsInColumn={onSelectAllItemsInColumn}
               onSelectColumnEmptySpace={onSelectColumnEmptySpace}
               onColumnLoadMore={onColumnLoadMore}
+              onCopyUrl={onCopyUrl}
             />
           ))}
         </div>
@@ -69,6 +86,7 @@ const FileExplorer = ({
               onSelectAllItemsInColumn={onSelectAllItemsInColumn}
               onSelectColumnEmptySpace={onSelectColumnEmptySpace}
               onColumnLoadMore={onColumnLoadMore}
+              onCopyUrl={onCopyUrl}
             />
           )}
         </>

--- a/studio/components/to-be-cleaned/Storage/StorageExplorer/FileExplorerColumn.tsx
+++ b/studio/components/to-be-cleaned/Storage/StorageExplorer/FileExplorerColumn.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from 'react'
-import { get, sum } from 'lodash'
+import { get, noop, sum } from 'lodash'
 import { Checkbox, IconUpload } from 'ui'
 import { Transition } from '@headlessui/react'
 import { useContextMenu } from 'react-contexify'
@@ -15,8 +15,9 @@ import {
 } from '../Storage.constants'
 import { formatBytes } from 'lib/helpers'
 import { BASE_PATH } from 'lib/constants'
+import { StorageColumn } from '../Storage.types'
 
-const DragOverOverlay = ({ isOpen, onDragLeave, onDrop, folderIsEmpty }) => {
+const DragOverOverlay = ({ isOpen, onDragLeave, onDrop, folderIsEmpty }: any) => {
   return (
     <Transition
       show={isOpen}
@@ -50,21 +51,37 @@ const DragOverOverlay = ({ isOpen, onDragLeave, onDrop, folderIsEmpty }) => {
   )
 }
 
+export interface FileExplorerColumnProps {
+  index: number
+  view: string
+  column: StorageColumn
+  fullWidth?: boolean
+  openedFolders?: any[]
+  selectedItems: any[]
+  selectedFilePreview: any
+  onFilesUpload: (event: any, index: number) => void
+  onSelectAllItemsInColumn: (index: number) => void
+  onSelectColumnEmptySpace: (index: number) => void
+  onColumnLoadMore: (index: number, column: StorageColumn) => void
+  onCopyUrl: (name: string, url: string) => void
+}
+
 const FileExplorerColumn = ({
   index = 0,
   view = STORAGE_VIEWS.COLUMNS,
-  column = {},
+  column,
   fullWidth = false,
   openedFolders = [],
   selectedItems = [],
   selectedFilePreview = {},
-  onFilesUpload = () => {},
-  onSelectAllItemsInColumn = () => {},
-  onSelectColumnEmptySpace = () => {},
-  onColumnLoadMore = () => {},
-}) => {
+  onFilesUpload = noop,
+  onSelectAllItemsInColumn = noop,
+  onSelectColumnEmptySpace = noop,
+  onColumnLoadMore = noop,
+  onCopyUrl = noop,
+}: FileExplorerColumnProps) => {
   const [isDraggedOver, setIsDraggedOver] = useState(false)
-  const fileExplorerColumnRef = useRef(null)
+  const fileExplorerColumnRef = useRef<any>(null)
 
   useEffect(() => {
     if (fileExplorerColumnRef) {
@@ -87,14 +104,14 @@ const FileExplorerColumn = ({
   const columnItemsSize = sum(columnItems.map((item) => get(item, ['metadata', 'size'], 0)))
 
   const { show } = useContextMenu()
-  const displayMenu = (event) => {
+  const displayMenu = (event: any) => {
     show(event, {
       id: CONTEXT_MENU_KEYS.STORAGE_COLUMN,
       props: { index },
     })
   }
 
-  const onDragOver = (event) => {
+  const onDragOver = (event: any) => {
     if (event) {
       event.stopPropagation()
       event.preventDefault()
@@ -104,7 +121,7 @@ const FileExplorerColumn = ({
     }
   }
 
-  const onDrop = (event) => {
+  const onDrop = (event: any) => {
     onDragOver(event)
     onFilesUpload(event, index)
   }
@@ -144,7 +161,7 @@ const FileExplorerColumn = ({
       {view === STORAGE_VIEWS.COLUMNS && (
         <div
           className={`sticky top-0 z-10 mb-0 flex items-center bg-table-header-light px-2.5 dark:bg-table-header-dark ${
-            haveSelectedItems > 0 ? 'h-10 py-3 opacity-100' : 'h-0 py-0 opacity-0'
+            haveSelectedItems ? 'h-10 py-3 opacity-100' : 'h-0 py-0 opacity-0'
           } transition-all duration-200`}
           onClick={(event) => event.stopPropagation()}
         >
@@ -202,15 +219,7 @@ const FileExplorerColumn = ({
           selectedItems,
           openedFolders,
           selectedFilePreview,
-          // onCheckItem,
-          // onRenameFile,
-          // onCopyFileURL,
-          // onDownloadFile,
-          // onRenameFolder,
-          // onCreateFolder,
-          // onSelectItemDelete,
-          // onSelectItemRename,
-          // onSelectItemMove,
+          onCopyUrl,
         }}
         ItemComponent={FileExplorerRow}
         getItemSize={(index) => (index !== 0 && index === columnItems.length ? 85 : 37)}

--- a/studio/components/to-be-cleaned/Storage/StorageExplorer/FileExplorerRow.tsx
+++ b/studio/components/to-be-cleaned/Storage/StorageExplorer/FileExplorerRow.tsx
@@ -71,7 +71,7 @@ export const RowIcon = ({ view, status, fileType, mimeType }: any) => {
   return <IconFile size={16} strokeWidth={2} />
 }
 
-interface FileExplorerRowProps {
+export interface FileExplorerRowProps {
   index: number
   item: any
   view: string
@@ -79,6 +79,7 @@ interface FileExplorerRowProps {
   selectedItems: any[]
   openedFolders: any[]
   selectedFilePreview: any
+  onCopyUrl: (name: string, url: string) => void
 }
 
 const FileExplorerRow = ({
@@ -89,9 +90,11 @@ const FileExplorerRow = ({
   selectedItems = [],
   openedFolders = [],
   selectedFilePreview = {},
+  onCopyUrl,
 }: FileExplorerRowProps) => {
   const storageExplorerStore = useStorageStore()
   const {
+    getFileUrl,
     popColumnAtIndex,
     pushOpenedFolderAtIndex,
     popOpenedFoldersAtIndex,
@@ -107,7 +110,6 @@ const FileExplorerRow = ({
     fetchFolderContents,
     downloadFile,
     downloadFolder,
-    copyFileURLToClipboard,
     selectRangeItems,
   } = storageExplorerStore
 
@@ -188,7 +190,11 @@ const FileExplorerRow = ({
                       {
                         name: 'Get URL',
                         icon: <IconClipboard size="tiny" />,
-                        onClick: async () => await copyFileURLToClipboard(itemWithColumnIndex),
+                        onClick: async () =>
+                          onCopyUrl(
+                            itemWithColumnIndex.name,
+                            await getFileUrl(itemWithColumnIndex)
+                          ),
                       },
                     ]
                   : [
@@ -199,25 +205,25 @@ const FileExplorerRow = ({
                           {
                             name: 'Expire in 1 week',
                             onClick: async () =>
-                              await copyFileURLToClipboard(
-                                itemWithColumnIndex,
-                                URL_EXPIRY_DURATION.WEEK
+                              onCopyUrl(
+                                itemWithColumnIndex.name,
+                                await getFileUrl(itemWithColumnIndex, URL_EXPIRY_DURATION.WEEK)
                               ),
                           },
                           {
                             name: 'Expire in 1 month',
                             onClick: async () =>
-                              await copyFileURLToClipboard(
-                                itemWithColumnIndex,
-                                URL_EXPIRY_DURATION.MONTH
+                              onCopyUrl(
+                                itemWithColumnIndex.name,
+                                await getFileUrl(itemWithColumnIndex, URL_EXPIRY_DURATION.MONTH)
                               ),
                           },
                           {
                             name: 'Expire in 1 year',
                             onClick: async () =>
-                              await copyFileURLToClipboard(
-                                itemWithColumnIndex,
-                                URL_EXPIRY_DURATION.YEAR
+                              onCopyUrl(
+                                itemWithColumnIndex.name,
+                                await getFileUrl(itemWithColumnIndex, URL_EXPIRY_DURATION.YEAR)
                               ),
                           },
                           {

--- a/studio/components/to-be-cleaned/Storage/StorageExplorer/ItemContextMenu.tsx
+++ b/studio/components/to-be-cleaned/Storage/StorageExplorer/ItemContextMenu.tsx
@@ -1,4 +1,3 @@
-import { FC } from 'react'
 import { observer } from 'mobx-react-lite'
 import { Menu, Item, Separator, Submenu } from 'react-contexify'
 import 'react-contexify/dist/ReactContexify.css'
@@ -8,21 +7,23 @@ import { IconClipboard, IconEdit, IconMove, IconDownload, IconTrash2, IconChevro
 import { checkPermissions } from 'hooks'
 import { URL_EXPIRY_DURATION } from '../Storage.constants'
 import { useStorageStore } from 'localStores/storageExplorer/StorageExplorerStore'
+import { noop } from 'lodash'
 
-interface Props {
+interface ItemContextMenuProps {
   id: string
+  onCopyUrl: (name: string, url: string) => void
 }
 
-const ItemContextMenu: FC<Props> = ({ id = '' }) => {
+const ItemContextMenu = ({ id = '', onCopyUrl = noop }: ItemContextMenuProps) => {
   const storageExplorerStore = useStorageStore()
   const {
+    getFileUrl,
     downloadFile,
     selectedBucket,
     setSelectedItemsToDelete,
     setSelectedItemToRename,
     setSelectedItemsToMove,
     setSelectedFileCustomExpiry,
-    copyFileURLToClipboard,
   } = storageExplorerStore
   const isPublic = selectedBucket.public
   const canUpdateFiles = checkPermissions(PermissionAction.STORAGE_ADMIN_WRITE, '*')
@@ -32,7 +33,7 @@ const ItemContextMenu: FC<Props> = ({ id = '' }) => {
     switch (event) {
       case 'copy':
         if (expiresIn !== undefined && expiresIn < 0) return setSelectedFileCustomExpiry(item)
-        else return await copyFileURLToClipboard(item, expiresIn)
+        else return onCopyUrl(item.name, await getFileUrl(item, expiresIn))
       case 'rename':
         return setSelectedItemToRename(item)
       case 'move':

--- a/studio/components/to-be-cleaned/Storage/StorageExplorer/PreviewPane.tsx
+++ b/studio/components/to-be-cleaned/Storage/StorageExplorer/PreviewPane.tsx
@@ -94,13 +94,17 @@ const PreviewFile = ({ mimeType, previewUrl }: { mimeType: string; previewUrl: s
   )
 }
 
-const PreviewPane = () => {
+export interface PreviewPaneProps {
+  onCopyUrl: (name: string, url: string) => void
+}
+
+const PreviewPane = ({ onCopyUrl }: PreviewPaneProps) => {
   const storageExplorerStore = useStorageStore()
   const {
+    getFileUrl,
     downloadFile,
     selectedBucket,
     selectedFilePreview: file,
-    copyFileURLToClipboard,
     closeFilePreview,
     setSelectedItemsToDelete,
     setSelectedFileCustomExpiry,
@@ -194,7 +198,7 @@ const PreviewPane = () => {
                 <Button
                   type="outline"
                   icon={<IconClipboard size={16} strokeWidth={2} />}
-                  onClick={async () => await copyFileURLToClipboard(file)}
+                  onClick={async () => onCopyUrl(file.name, await getFileUrl(file))}
                   disabled={file.isCorrupted}
                 >
                   Get URL
@@ -207,7 +211,7 @@ const PreviewPane = () => {
                     <Dropdown.Item
                       key="expires-one-week"
                       onClick={async () =>
-                        await copyFileURLToClipboard(file, URL_EXPIRY_DURATION.WEEK)
+                        onCopyUrl(file.name, await getFileUrl(file, URL_EXPIRY_DURATION.WEEK))
                       }
                     >
                       Expire in 1 week
@@ -215,7 +219,7 @@ const PreviewPane = () => {
                     <Dropdown.Item
                       key="expires-one-month"
                       onClick={async () =>
-                        await copyFileURLToClipboard(file, URL_EXPIRY_DURATION.MONTH)
+                        onCopyUrl(file.name, await getFileUrl(file, URL_EXPIRY_DURATION.MONTH))
                       }
                     >
                       Expire in 1 month
@@ -223,7 +227,7 @@ const PreviewPane = () => {
                     <Dropdown.Item
                       key="expires-one-year"
                       onClick={async () =>
-                        await copyFileURLToClipboard(file, URL_EXPIRY_DURATION.YEAR)
+                        onCopyUrl(file.name, await getFileUrl(file, URL_EXPIRY_DURATION.YEAR))
                       }
                     >
                       Expire in 1 year

--- a/studio/components/to-be-cleaned/Storage/StorageExplorer/StorageExplorer.js
+++ b/studio/components/to-be-cleaned/Storage/StorageExplorer/StorageExplorer.js
@@ -166,9 +166,10 @@ const StorageExplorer = observer(({ bucket }) => {
   }
 
   const onCopyUrl = (name, url) => {
-    const formattedUrl = customDomainData?.customDomain
-      ? url.replace(apiUrl, `https://${customDomainData.customDomain.hostname}`)
-      : url
+    const formattedUrl =
+      customDomainData?.customDomain.status === 'active'
+        ? url.replace(apiUrl, `https://${customDomainData.customDomain.hostname}`)
+        : url
     copyToClipboard(formattedUrl, () => {
       ui.setNotification({
         category: 'success',

--- a/studio/components/to-be-cleaned/Storage/StorageExplorer/StorageExplorer.js
+++ b/studio/components/to-be-cleaned/Storage/StorageExplorer/StorageExplorer.js
@@ -1,17 +1,22 @@
-import { useEffect, useState, useRef } from 'react'
+import { compact, get, isEmpty, uniqBy } from 'lodash'
 import { observer } from 'mobx-react-lite'
-import { compact, isEmpty, uniqBy, get } from 'lodash'
+import { useEffect, useRef, useState } from 'react'
 
+import { useParams } from 'common'
 import { useStorageStore } from 'localStores/storageExplorer/StorageExplorerStore'
 import { STORAGE_ROW_TYPES } from '../Storage.constants'
-
+import ConfirmDeleteModal from './ConfirmDeleteModal'
+import CustomExpiryModal from './CustomExpiryModal'
 import FileExplorer from './FileExplorer'
 import FileExplorerHeader from './FileExplorerHeader'
 import FileExplorerHeaderSelection from './FileExplorerHeaderSelection'
-import ConfirmDeleteModal from './ConfirmDeleteModal'
 import MoveItemsModal from './MoveItemsModal'
 import PreviewPane from './PreviewPane'
-import CustomExpiryModal from './CustomExpiryModal'
+import { useCustomDomainsQuery } from 'data/custom-domains/custom-domains-query'
+import { useProjectSettingsQuery } from 'data/config/project-settings-query'
+import { DEFAULT_PROJECT_API_SERVICE_ID } from 'lib/constants'
+import { copyToClipboard } from 'lib/helpers'
+import { useStore } from 'hooks'
 
 const StorageExplorer = observer(({ bucket }) => {
   const storageExplorerStore = useStorageStore()
@@ -43,6 +48,16 @@ const StorageExplorer = observer(({ bucket }) => {
   } = storageExplorerStore
 
   const storageExplorerRef = useRef(null)
+
+  const { ui } = useStore()
+  const { ref } = useParams()
+  const { data: customDomainData } = useCustomDomainsQuery({ projectRef: ref })
+  const { data: projectSettings } = useProjectSettingsQuery({ projectRef: ref })
+  const apiService = (projectSettings?.services ?? []).find(
+    (x) => x.app.id == DEFAULT_PROJECT_API_SERVICE_ID
+  )
+  const apiConfig = apiService?.app_config
+  const apiUrl = `${apiConfig?.protocol ?? 'https'}://${apiConfig?.endpoint ?? '-'}`
 
   // This state exists outside of the header because FileExplorerColumn needs to listen to these as well
   // I'm keeping them outside of the mobx store as I feel that the store should contain persistent data
@@ -150,6 +165,19 @@ const StorageExplorer = observer(({ bucket }) => {
     clearSelectedItems()
   }
 
+  const onCopyUrl = (name, url) => {
+    const formattedUrl = customDomainData?.customDomain
+      ? url.replace(apiUrl, `https://${customDomainData.customDomain.hostname}`)
+      : url
+    copyToClipboard(formattedUrl, () => {
+      ui.setNotification({
+        category: 'success',
+        message: `Copied URL for ${name} to clipboard.`,
+        duration: 4000,
+      })
+    })
+  }
+
   return (
     <div
       ref={storageExplorerRef}
@@ -180,8 +208,9 @@ const StorageExplorer = observer(({ bucket }) => {
           onColumnLoadMore={(index, column) =>
             fetchMoreFolderContents(index, column, itemSearchString)
           }
+          onCopyUrl={onCopyUrl}
         />
-        <PreviewPane />
+        <PreviewPane onCopyUrl={onCopyUrl} />
       </div>
       <ConfirmDeleteModal
         visible={selectedItemsToDelete.length > 0}
@@ -196,7 +225,7 @@ const StorageExplorer = observer(({ bucket }) => {
         onSelectCancel={clearSelectedItemsToMove}
         onSelectMove={onMoveSelectedFiles}
       />
-      <CustomExpiryModal />
+      <CustomExpiryModal onCopyUrl={onCopyUrl} />
     </div>
   )
 })

--- a/studio/data/storage/buckets-query.ts
+++ b/studio/data/storage/buckets-query.ts
@@ -21,6 +21,8 @@ export async function getBuckets({ projectRef }: BucketsVariables, signal?: Abor
   if (!projectRef) throw new Error('projectRef is required')
 
   const response = await get(`${API_URL}/storage/${projectRef}/buckets`, { signal })
+  throw new Error('test')
+
   if (response.error) throw response.error
   return response as Bucket[]
 }

--- a/studio/data/storage/buckets-query.ts
+++ b/studio/data/storage/buckets-query.ts
@@ -21,8 +21,6 @@ export async function getBuckets({ projectRef }: BucketsVariables, signal?: Abor
   if (!projectRef) throw new Error('projectRef is required')
 
   const response = await get(`${API_URL}/storage/${projectRef}/buckets`, { signal })
-  throw new Error('test')
-
   if (response.error) throw response.error
   return response as Bucket[]
 }

--- a/studio/localStores/storageExplorer/StorageExplorerStore.js
+++ b/studio/localStores/storageExplorer/StorageExplorerStore.js
@@ -8,7 +8,7 @@ import { createClient } from '@supabase/supabase-js'
 import { useStore } from 'hooks'
 import { copyToClipboard } from 'lib/helpers'
 import { API_URL, IS_PLATFORM } from 'lib/constants'
-import { get, patch, post, delete_ } from 'lib/common/fetch'
+import { post, delete_ } from 'lib/common/fetch'
 import { PROJECT_ENDPOINT_PROTOCOL } from 'pages/api/constants'
 import {
   STORAGE_VIEWS,
@@ -407,15 +407,12 @@ class StorageExplorerStore {
       })
     } else {
       // Need to generate signed URL, and might as well save it to cache as well
-      const signedUrlAsync = this.fetchFilePreview(file.name, expiresIn).then((signedUrl) => {
-        const formattedUrl = new URL(signedUrl)
-        formattedUrl.searchParams.set('t', new Date().toISOString())
-
-        return formattedUrl.toString()
-      })
+      const signedUrl = await this.fetchFilePreview(file.name, expiresIn)
+      const formattedUrl = new URL(signedUrl)
+      formattedUrl.searchParams.set('t', new Date().toISOString())
 
       try {
-        copyToClipboard(signedUrlAsync, () => {
+        copyToClipboard(formattedUrl.toString(), () => {
           this.ui.setNotification({
             category: 'success',
             message: `Copied URL for ${file.name} to clipboard.`,
@@ -424,7 +421,7 @@ class StorageExplorerStore {
         })
         const fileCache = {
           id: file.id,
-          url: await signedUrlAsync,
+          url: formattedUrl.toString(),
           expiresIn: DEFAULT_EXPIRY,
           fetchedAt: Date.now(),
         }

--- a/studio/pages/project/[ref]/storage/buckets/[bucketId].tsx
+++ b/studio/pages/project/[ref]/storage/buckets/[bucketId].tsx
@@ -4,6 +4,7 @@ import { useEffect } from 'react'
 
 import { useParams } from 'common'
 import { StorageLayout } from 'components/layouts'
+import StorageBucketsError from 'components/layouts/StorageLayout/StorageBucketsError'
 import { StorageExplorer } from 'components/to-be-cleaned/Storage'
 import { useBucketsQuery } from 'data/storage/buckets-query'
 import { useFlag, useStore } from 'hooks'
@@ -17,7 +18,7 @@ const PageLayout: NextPageWithLayout = () => {
   const { ui } = useStore()
   const project = ui.selectedProject
 
-  const { data, isSuccess } = useBucketsQuery({ projectRef: ref })
+  const { data, isSuccess, isError, error } = useBucketsQuery({ projectRef: ref })
   const buckets = data ?? []
 
   const kpsEnabled = useFlag('initWithKps')
@@ -34,6 +35,8 @@ const PageLayout: NextPageWithLayout = () => {
 
   return (
     <div className="storage-container flex flex-grow p-4">
+      {isError && <StorageBucketsError error={error as any} />}
+
       {isSuccess ? (
         !bucket ? (
           <div className="flex h-full w-full items-center justify-center">

--- a/studio/pages/project/[ref]/storage/buckets/index.tsx
+++ b/studio/pages/project/[ref]/storage/buckets/index.tsx
@@ -1,11 +1,14 @@
+import { observer } from 'mobx-react-lite'
+import { useEffect } from 'react'
+
 import { useParams } from 'common/hooks'
 import { StorageLayout } from 'components/layouts'
+import StorageBucketsError from 'components/layouts/StorageLayout/StorageBucketsError'
 import ProductEmptyState from 'components/to-be-cleaned/ProductEmptyState'
+import { useBucketsQuery } from 'data/storage/buckets-query'
 import { useFlag, useStore } from 'hooks'
 import { post } from 'lib/common/fetch'
 import { API_URL, PROJECT_STATUS } from 'lib/constants'
-import { observer } from 'mobx-react-lite'
-import { useEffect } from 'react'
 import { NextPageWithLayout } from 'types'
 
 const PageLayout: NextPageWithLayout = ({}) => {
@@ -14,6 +17,8 @@ const PageLayout: NextPageWithLayout = ({}) => {
   const project = ui.selectedProject
   const kpsEnabled = useFlag('initWithKps')
 
+  const { error, isError } = useBucketsQuery({ projectRef: ref })
+
   useEffect(() => {
     if (project && project.status === PROJECT_STATUS.INACTIVE) {
       post(`${API_URL}/projects/${ref}/restore`, { kps_enabled: kpsEnabled })
@@ -21,6 +26,8 @@ const PageLayout: NextPageWithLayout = ({}) => {
   }, [project])
 
   if (!project) return <div></div>
+
+  if (isError) <StorageBucketsError error={error as any} />
 
   return (
     <div className="storage-container flex flex-grow">

--- a/studio/types/base.ts
+++ b/studio/types/base.ts
@@ -88,3 +88,9 @@ export interface ResponseFailure {
 }
 
 export type SupaResponse<T> = T & ResponseFailure
+
+export interface ResponseError {
+  code: number
+  message: string
+  requestId: string
+}


### PR DESCRIPTION
- Deprecate copyFileURLToClipboard method in StorageExplorerStore
- onCopyUrl will be used instead to replace URL from sign request with custom domain if available
- Fix changing projects not updating endpoint in StorageExplorerStore