### PR TITLE
Fix: Remove crawlers from canonical path

### DIFF
--- a/apps/docs/components/reference/RefSectionHandler.tsx
+++ b/apps/docs/components/reference/RefSectionHandler.tsx
@@ -60,6 +60,10 @@ const RefSectionHandler = (props: RefSectionHandlerProps) => {
   const pageTitle = getPageTitle()
   const section = props.sections.find((section) => section.slug === slug)
   const fullTitle = `${pageTitle}${section ? ` - ${section.title}` : ''}`
+  const path = router.asPath
+    .split('/')
+    .filter((segment) => segment !== 'crawlers')
+    .join('/')
 
   return (
     <>
@@ -72,7 +76,7 @@ const RefSectionHandler = (props: RefSectionHandlerProps) => {
           content={`https://supabase.com/docs/img/supabase-og-image.png`}
         />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <link rel="canonical" href={`https://supabase.com${router.basePath}${router.asPath}`} />
+        <link rel="canonical" href={`https://supabase.com${router.basePath}${path}`} />
       </Head>
       {props.isOldVersion && <OldVersionAlert sections={props.sections} />}
       <RefSubLayout>

--- a/apps/docs/components/reference/RefSectionHandler.tsx
+++ b/apps/docs/components/reference/RefSectionHandler.tsx
@@ -60,10 +60,7 @@ const RefSectionHandler = (props: RefSectionHandlerProps) => {
   const pageTitle = getPageTitle()
   const section = props.sections.find((section) => section.slug === slug)
   const fullTitle = `${pageTitle}${section ? ` - ${section.title}` : ''}`
-  const path = router.asPath
-    .split('/')
-    .filter((segment) => segment !== 'crawlers')
-    .join('/')
+  const path = router.asPath.replace('/crawlers', '')
 
   return (
     <>


### PR DESCRIPTION
We [added a canonical path](https://github.com/supabase/supabase/pull/15125) to each ref doc page in an attempt to get search engines to index sub-sections as if they are their own pages. Unfortunately though this is showing up with `/crawlers` in the URL when the page is requested by a crawler user agent:

```html
<link rel="canonical" href="https://supabase.com/docs/reference/javascript/crawlers/update"/>
```

This removes `/crawlers` from that `link` `href`.