### PR TITLE
fix(blog): broken links in pgvector post

### DIFF
--- a/apps/www/_blog/2023-02-03-openai-embeddings-postgres-vector.mdx
+++ b/apps/www/_blog/2023-02-03-openai-embeddings-postgres-vector.mdx
@@ -12,10 +12,16 @@ date: '2023-02-06'
 toc_depth: 3
 ---
 
-A new PostgreSQL extension is now available in Supabase: [`pgvector`](https://supabase.com/docs/guides/getting-started/openai/vector-search), an open-source vector similarity search.
+A new PostgreSQL extension is now available in Supabase: [`pgvector`](https://github.com/pgvector/pgvector), an open-source vector similarity search.
 
 The exponential progress of AI functionality over the past year has inspired many new real world applications. One specific challenge has been the ability to store and query _embeddings_ at scale.
 In this post we'll explain what embeddings are, why we might want to use them, and how we can store and query them in PostgreSQL using `pgvector`.
+
+<div className="bg-gray-300 rounded-lg px-6 py-2 bold">
+
+🆕 Supabase has now released an open source toolkit for developing AI applications using Postgres and pgvector. Learn more in the [AI & Vectors docs](https://supabase.com/docs/guides/ai).
+
+</div>
 
 ## What are embeddings?
 
@@ -370,7 +376,7 @@ The OpenAI API supports [completion streaming](https://platform.openai.com/docs/
 
 Storing embeddings in Postgres opens a world of possibilities. You can combine your search function with telemetry functions, add an user-provided feedback (thumbs up/down), and make your search feel more integrated with your products.
 
-The [pgvector extension](https://supabase.com/docs/guides/getting-started/openai/vector-search) is available on all new Supabase projects today. If you want to try it out, launch a new Postgres database today: [database.new](https://database.new)
+The [pgvector extension](https://supabase.com/docs/guides/ai/vector-columns) is available on all new Supabase projects today. If you want to try it out, launch a new Postgres database today: [database.new](https://database.new)
 
 ## More pgvector and ChatGPT resources
 


### PR DESCRIPTION
Fixes broken links referencing `pgvector` + adds callout with internal link to AI & Vector docs.


![image](https://github.com/supabase/supabase/assets/4133076/fd0cc035-75cd-4de1-a60e-c083331a19d6)
![image](https://github.com/supabase/supabase/assets/4133076/3ad7498a-b610-400d-a5ae-e1e743cecf99)
