### PR TITLE
Fix: error msg of NoSearchResults

### DIFF
--- a/studio/components/to-be-cleaned/NoSearchResults.tsx
+++ b/studio/components/to-be-cleaned/NoSearchResults.tsx
@@ -13,7 +13,7 @@ export const NoSearchResults = () => {
         }
       />
       <p className="w-64 text-center text-sm opacity-50">
-        Hmm, we couldn't find any results that matches your query. Try another?
+        Hmm, we couldn't find any results that match your query.
       </p>
     </div>
   )


### PR DESCRIPTION
## What kind of change does this PR introduce?

Error msg fix

## What is the current behavior?

Previous error message:  `Hmm, we couldn't find any results that matches your query. Try another?`

## What is the new behavior?

Current error message: `Hmm, we couldn't find any results that match your query.`


