### PR TITLE
Dashboard: link to client lib docs from API keys section

### DIFF
--- a/studio/components/ui/ProjectSettings/DisplayApiSettings.tsx
+++ b/studio/components/ui/ProjectSettings/DisplayApiSettings.tsx
@@ -1,12 +1,12 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { JwtSecretUpdateStatus } from '@supabase/shared-types/out/events'
-import { IconAlertCircle, IconLoader, Input } from 'ui'
+import { Button, IconAlertCircle, IconBookOpen, IconLoader, Input } from 'ui'
 
-import Panel from 'components/ui/Panel'
-import { useProjectSettingsQuery } from 'data/config/project-settings-query'
-import { useJwtSecretUpdatingStatusQuery } from 'data/config/jwt-secret-updating-status-query'
-import { checkPermissions } from 'hooks'
 import { useParams } from 'common/hooks'
+import Panel from 'components/ui/Panel'
+import { useJwtSecretUpdatingStatusQuery } from 'data/config/jwt-secret-updating-status-query'
+import { useProjectSettingsQuery } from 'data/config/project-settings-query'
+import { checkPermissions } from 'hooks'
 import { DEFAULT_PROJECT_API_SERVICE_ID } from 'lib/constants'
 
 const DisplayApiSettings = () => {
@@ -44,7 +44,14 @@ const DisplayApiSettings = () => {
           <p className="text-sm text-scale-1000">
             Your API is secured behind an API gateway which requires an API Key for every request.
             <br />
-            You can use the keys below to use Supabase client libraries.
+            You can use the keys below in the Supabase client libraries.
+            <br />
+            <a href="https://supabase.com/docs#client-libraries" target="_blank" rel="noreferrer">
+              <Button icon={<IconBookOpen />} type="default" className="mt-4">
+                Client Docs
+              </Button>
+            </a>
+            .
           </p>
         </div>
       }


### PR DESCRIPTION
Based on feedback from a customer - add link to documentation from API keys section:

![image](https://github.com/supabase/supabase/assets/4133076/afb5d727-02ec-4cc7-ac1c-e86079912b6e)
