### PR TITLE
POC: optional nextis template

### DIFF
--- a/apps/docs/pages/guides/getting-started/quickstarts/nextjs.mdx
+++ b/apps/docs/pages/guides/getting-started/quickstarts/nextjs.mdx
@@ -1,5 +1,6 @@
 import Layout from '~/layouts/DefaultGuideLayout'
 import StepHikeCompact from '~/components/StepHikeCompact'
+import Options from '~/components/Options'
 
 export const meta = {
   title: 'Use Supabase with Next.js',
@@ -44,36 +45,74 @@ export const meta = {
 
     <StepHikeCompact.Details title="Create a Next.js app">
 
-    Use the `create-next-app` command and the `with-supabase` template, to create a Next.js app pre-configured with:
-    - [Supabase Auth](https://supabase.com/docs/guides/auth/auth-helpers/nextjs)
-    - [TypeScript](https://www.typescriptlang.org/)
-    - [Tailwind CSS](https://tailwindcss.com/)
+      Create a Next.js app using the `create-next-app` command
+
+      <Options name="optional template">
+        <Options.Option type isOptional name="Use Supabase template">
+
+        <div className="[&_ul]:my-0 [&_p]:mb-0">
+        Use the `create-next-app` command and the `with-supabase` template, to create a Next.js app pre-configured with:
+        - [Supabase Auth](https://supabase.com/docs/guides/auth/auth-helpers/nextjs)
+        - [TypeScript](https://www.typescriptlang.org/)
+        - [Tailwind CSS](https://tailwindcss.com/)
+
+        To Follow the rest of the optional template guide, click and expand the optional tabs.
+        </div>
+        
+        </Options.Option>
+      </Options>
 
     </StepHikeCompact.Details>
 
     <StepHikeCompact.Code>
 
+      <CH.Code>
+
       ```bash Terminal
+      npx create-next-app
+      ```
+
+      ```bash Terminal-(Optional)
       npx create-next-app -e with-supabase my-app && cd my-app
       ```
+
+      </CH.Code>
 
     </StepHikeCompact.Code>
 
   </StepHikeCompact.Step>
 
   <StepHikeCompact.Step step={3}>
-    <StepHikeCompact.Details title="Declare Supabase Environment Variables">
+    <StepHikeCompact.Details title="Install the Supabase client library">
 
-    Rename `.env.local.example` to `.env.local` and populate with [your project's URL and Anon Key](https://app.supabase.com/project/_/settings/api).
+    The fastest way to get started is to use the `supabase-js` client library which provides a convenient interface for working with Supabase from a React app.
+
+    Navigate to the Next.js app and install `supabase-js`.
+
+    <Options name="optional template">
+      <Options.Option type isOptional name="Declare Supabase Environment Variables">
+
+      Rename `.env.local.example` to `.env.local` and populate with [your project's URL and Anon Key]().
+      
+      </Options.Option>
+    </Options>
 
     </StepHikeCompact.Details>
 
     <StepHikeCompact.Code>
 
-      ```text .env.local
+      <CH.Code>
+
+      ```bash Terminal
+      cd my-app && npm install @supabase/supabase-js
+      ```
+
+      ```bash .env.local-(Optional)
         NEXT_PUBLIC_SUPABASE_URL=your-project-url
         NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
       ```
+
+      </CH.Code>
 
     </StepHikeCompact.Code>
 
@@ -90,24 +129,58 @@ export const meta = {
 
     <StepHikeCompact.Code>
 
+      <CH.Code>
+
       ```ts app/countries/page.tsx
-        import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
-        import { cookies } from "next/headers";
+        import { useEffect, useState } from "react";
+        import { createClient } from "@supabase/supabase-js";
 
-        export default async function Index() {
-          const supabase = createServerComponentClient({ cookies });
+        const supabase = createClient("https://<project>.supabase.co", "<your-anon-key>");
 
-          const { data: countries } = await supabase.from("countries").select();
+        function App() {
+          const [countries, setCountries] = useState([]);
+
+          useEffect(() => {
+            getCountries();
+          }, []);
+
+          async function getCountries() {
+            const { data } = await supabase.from("countries").select();
+            setCountries(data);
+          }
 
           return (
-            <ul className="my-auto">
-              {countries?.map((country) => (
-                <li key={country.id}>{country.name}</li>
+            <ul>
+              {countries.map((country) => (
+                <li key={country.name}>{country.name}</li>
               ))}
             </ul>
           );
         }
+
+        export default App;
       ```
+
+      ```ts app/countries/page.tsx-(Optional)
+      import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
+      import { cookies } from "next/headers";
+
+      export default async function Index() {
+        const supabase = createServerComponentClient({ cookies });
+
+        const { data: countries } = await supabase.from("countries").select();
+
+        return (
+          <ul className="my-auto">
+            {countries?.map((country) => (
+              <li key={country.id}>{country.name}</li>
+            ))}
+          </ul>
+        );
+      }
+      ```
+
+      </CH.Code>
 
     </StepHikeCompact.Code>
 

--- a/apps/docs/pages/guides/getting-started/quickstarts/nextjs.mdx
+++ b/apps/docs/pages/guides/getting-started/quickstarts/nextjs.mdx
@@ -58,7 +58,7 @@ export const meta = {
 
         To Follow the rest of the optional template guide, click and expand the optional tabs.
         </div>
-        
+
         </Options.Option>
       </Options>
 
@@ -93,7 +93,7 @@ export const meta = {
       <Options.Option type isOptional name="Declare Supabase Environment Variables">
 
       Rename `.env.local.example` to `.env.local` and populate with [your project's URL and Anon Key]().
-      
+
       </Options.Option>
     </Options>
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Instead of making users use the supabase template for the nextjs quickstart. We make using the supabase template optional and hide it unless user wants to use the template.

## What is the current behavior?

![CleanShot 2023-06-22 at 20 13 25@2x](https://github.com/supabase/supabase/assets/70828596/dde7e8ee-976c-4510-8f7c-5d224e630143)

## What is the new behavior?

![CleanShot 2023-06-22 at 20 20 10@2x](https://github.com/supabase/supabase/assets/70828596/f1f3562e-c8f1-41cb-9ee0-a39d330ffa03)

## Additional context

This is just a POC and can definitely use some work.