### PR TITLE
Fix: install `supabase-js` as dependency in Auth Helpers docs and example apps

### DIFF
--- a/apps/docs/pages/guides/auth/auth-helpers/nextjs-pages.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/nextjs-pages.mdx
@@ -23,7 +23,7 @@ This submodule provides convenience helpers for implementing user authentication
 <TabPanel id="npm" label="npm">
 
 ```sh
-npm install @supabase/auth-helpers-nextjs
+npm install @supabase/auth-helpers-nextjs @supabase/supabase-js
 ```
 
 This library supports the following tooling versions:
@@ -41,7 +41,7 @@ npm install @supabase/auth-helpers-react
 <TabPanel id="yarn" label="Yarn">
 
 ```sh
-yarn add @supabase/auth-helpers-nextjs
+yarn add @supabase/auth-helpers-nextjs @supabase/supabase-js
 ```
 
 This library supports the following tooling versions:

--- a/apps/docs/pages/guides/auth/auth-helpers/nextjs-pages.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/nextjs-pages.mdx
@@ -14,7 +14,7 @@ This submodule provides convenience helpers for implementing user authentication
 
 ## Install the Next.js helper library
 
-```bash
+```sh Terminal
 npm install @supabase/auth-helpers-nextjs @supabase/supabase-js
 ```
 
@@ -25,7 +25,7 @@ This library supports the following tooling versions:
 
 Additionally, install the **React Auth Helpers** for components and hooks that can be used across all React-based frameworks.
 
-```bash
+```sh Terminal
 npm install @supabase/auth-helpers-react
 ```
 

--- a/apps/docs/pages/guides/auth/auth-helpers/nextjs-pages.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/nextjs-pages.mdx
@@ -14,15 +14,7 @@ This submodule provides convenience helpers for implementing user authentication
 
 ## Install the Next.js helper library
 
-<Tabs
-  scrollable
-  size="small"
-  type="underlined"
-  defaultActiveId="npm"
->
-<TabPanel id="npm" label="npm">
-
-```sh
+```bash
 npm install @supabase/auth-helpers-nextjs @supabase/supabase-js
 ```
 
@@ -33,30 +25,9 @@ This library supports the following tooling versions:
 
 Additionally, install the **React Auth Helpers** for components and hooks that can be used across all React-based frameworks.
 
-```sh
+```bash
 npm install @supabase/auth-helpers-react
 ```
-
-</TabPanel>
-<TabPanel id="yarn" label="Yarn">
-
-```sh
-yarn add @supabase/auth-helpers-nextjs @supabase/supabase-js
-```
-
-This library supports the following tooling versions:
-
-- Node.js: `^10.13.0 || >=12.0.0`
-- Next.js: `>=10`
-
-Additionally, install the **React Auth Helpers** for components and hooks that can be used across all React-based frameworks.
-
-```sh
-yarn add @supabase/auth-helpers-react
-```
-
-</TabPanel>
-</Tabs>
 
 ## Set up environment variables
 

--- a/apps/docs/pages/guides/auth/auth-helpers/nextjs.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/nextjs.mdx
@@ -62,28 +62,9 @@ npm run dev
 
 ### Install Next.js Auth Helpers library
 
-<Tabs
-  scrollable
-  size="small"
-  type="underlined"
-  defaultActiveId="npm"
->
-
-<TabPanel id="npm" label="npm">
-
-```sh
+```bash
 npm install @supabase/auth-helpers-nextjs @supabase/supabase-js
 ```
-
-</TabPanel>
-<TabPanel id="yarn" label="Yarn">
-
-```sh
-yarn add @supabase/auth-helpers-nextjs @supabase/supabase-js
-```
-
-</TabPanel>
-</Tabs>
 
 ### Declare Environment Variables
 

--- a/apps/docs/pages/guides/auth/auth-helpers/nextjs.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/nextjs.mdx
@@ -72,14 +72,14 @@ npm run dev
 <TabPanel id="npm" label="npm">
 
 ```sh
-npm install @supabase/auth-helpers-nextjs
+npm install @supabase/auth-helpers-nextjs @supabase/supabase-js
 ```
 
 </TabPanel>
 <TabPanel id="yarn" label="Yarn">
 
 ```sh
-yarn add @supabase/auth-helpers-nextjs
+yarn add @supabase/auth-helpers-nextjs @supabase/supabase-js
 ```
 
 </TabPanel>

--- a/apps/docs/pages/guides/auth/auth-helpers/nextjs.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/nextjs.mdx
@@ -29,7 +29,7 @@ If you are using the `pages` directory, check out [Auth Helpers in Next.js Pages
 
 Use the `create-next-app` command and the `with-supabase` template to automate the configuration of cookie-based auth with the Next.js Auth Helpers.
 
-```sh
+```sh Terminal
 npx create-next-app -e with-supabase
 ```
 
@@ -54,7 +54,7 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
 
 Run the development server and navigate to http://localhost:3000.
 
-```bash
+```sh Terminal
 npm run dev
 ```
 
@@ -62,7 +62,7 @@ npm run dev
 
 ### Install Next.js Auth Helpers library
 
-```bash
+```sh Terminal
 npm install @supabase/auth-helpers-nextjs @supabase/supabase-js
 ```
 

--- a/apps/docs/pages/guides/auth/auth-helpers/remix.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/remix.mdx
@@ -31,7 +31,7 @@ This submodule provides convenience helpers for implementing user authentication
 <TabPanel id="npm" label="npm">
 
 ```sh
-npm install @supabase/auth-helpers-remix
+npm install @supabase/auth-helpers-remix @supabase/supabase-js
 ```
 
 This library supports the following tooling versions:
@@ -42,7 +42,7 @@ This library supports the following tooling versions:
 <TabPanel id="yarn" label="Yarn">
 
 ```sh
-yarn add @supabase/auth-helpers-remix
+yarn add @supabase/auth-helpers-remix @supabase/supabase-js
 ```
 
 This library supports the following tooling versions:

--- a/apps/docs/pages/guides/auth/auth-helpers/remix.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/remix.mdx
@@ -22,7 +22,7 @@ This submodule provides convenience helpers for implementing user authentication
 
 ## Install the Remix helper library
 
-```bash
+```sh Terminal
 npm install @supabase/auth-helpers-remix @supabase/supabase-js
 ```
 

--- a/apps/docs/pages/guides/auth/auth-helpers/remix.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/remix.mdx
@@ -22,35 +22,13 @@ This submodule provides convenience helpers for implementing user authentication
 
 ## Install the Remix helper library
 
-<Tabs
-  scrollable
-  size="small"
-  type="underlined"
-  defaultActiveId="npm"
->
-<TabPanel id="npm" label="npm">
-
-```sh
+```bash
 npm install @supabase/auth-helpers-remix @supabase/supabase-js
 ```
 
 This library supports the following tooling versions:
 
 - Remix: `>=1.7.2`
-
-</TabPanel>
-<TabPanel id="yarn" label="Yarn">
-
-```sh
-yarn add @supabase/auth-helpers-remix @supabase/supabase-js
-```
-
-This library supports the following tooling versions:
-
-- Remix: `>=1.7.2`
-
-</TabPanel>
-</Tabs>
 
 ## Set up environment variables
 

--- a/apps/docs/pages/guides/auth/auth-helpers/sveltekit.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/sveltekit.mdx
@@ -16,7 +16,7 @@ This submodule provides convenience helpers for implementing user authentication
 This library supports Node.js `^16.15.0`.
 
 ```sh Terminal
-npm install @supabase/auth-helpers-sveltekit
+npm install @supabase/auth-helpers-sveltekit @supabase/supabase-js
 ```
 
 ### Declare Environment Variables

--- a/apps/docs/pages/guides/getting-started/tutorials/with-nextjs.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-nextjs.mdx
@@ -74,7 +74,7 @@ It can be challenging to authenticate your users in all these different environm
 Install the auth helpers for Next.js
 
 ```bash
-npm install @supabase/auth-helpers-nextjs
+npm install @supabase/auth-helpers-nextjs @supabase/supabase-js
 ```
 
 ### NextJS Middleware
@@ -241,7 +241,7 @@ export default function AuthForm() {
 
 </TabPanel>
 </Tabs>
-  
+
 <Admonition type="note">
 
 If you are using TypeScript for this project, see [generating types](/docs/guides/api/rest/generating-types) to automatically generate types from your database tables.

--- a/apps/docs/pages/guides/getting-started/tutorials/with-sveltekit.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-sveltekit.mdx
@@ -55,7 +55,7 @@ It can be challenging to authenticate your users in all these different environm
 Install the auth helpers for SvelteKit:
 
 ```bash
-npm install @supabase/auth-helpers-sveltekit
+npm install @supabase/auth-helpers-sveltekit @supabase/supabase-js
 ```
 
 Add the code below to your `src/hooks.server.ts` to initialize the client on the server:

--- a/examples/auth/nextjs/package-lock.json
+++ b/examples/auth/nextjs/package-lock.json
@@ -8,19 +8,19 @@
       "name": "full-nextjs-auth-helpers",
       "version": "0.1.0",
       "dependencies": {
-        "@supabase/auth-helpers-nextjs": "latest",
-        "@supabase/supabase-js": "latest",
+        "@supabase/auth-helpers-nextjs": "^0.7.1",
+        "@supabase/supabase-js": "^2.26.0",
         "@types/node": "^20.2.3",
         "@types/react": "^18.2.6",
         "@types/react-dom": "^18.2.4",
         "eslint": "^8.41.0",
-        "next": "latest",
+        "next": "^13.4.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "typescript": "^5.0.4"
       },
       "devDependencies": {
-        "eslint-config-next": "latest"
+        "eslint-config-next": "^13.4.3"
       }
     },
     "node_modules/@babel/runtime": {
@@ -325,11 +325,11 @@
       "dev": true
     },
     "node_modules/@supabase/auth-helpers-nextjs": {
-      "version": "0.7.0-next.8",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-helpers-nextjs/-/auth-helpers-nextjs-0.7.0-next.8.tgz",
-      "integrity": "sha512-7pCbdnyAQo+D4qYQCvfg4B3OHIPtrILy/4LNwmF+1uheDeK7B6pxfN2SVeOR2TU3lolxMwEKUP6Q0h1qiCXbQg==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-helpers-nextjs/-/auth-helpers-nextjs-0.7.2.tgz",
+      "integrity": "sha512-n5IyGBYJV/WiR5Rgw4CUaiJYiOv9yW2of4ZP4EyzKt2O6/6rztt7PcGE4AoK2vERw+fb5F2QtJBdt6J5eOYCCw==",
       "dependencies": {
-        "@supabase/auth-helpers-shared": "0.4.0-next.3",
+        "@supabase/auth-helpers-shared": "0.4.1",
         "set-cookie-parser": "^2.6.0"
       },
       "peerDependencies": {
@@ -337,9 +337,9 @@
       }
     },
     "node_modules/@supabase/auth-helpers-shared": {
-      "version": "0.4.0-next.3",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-helpers-shared/-/auth-helpers-shared-0.4.0-next.3.tgz",
-      "integrity": "sha512-ELvEbYPJdTlwvqXsHkRN8ADcRe1IQxHt+UNqxbV2SKIpJCieQ4BMsgUVI/w+e3gMQHRbydk0PaJpOa9aStzMyg==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-helpers-shared/-/auth-helpers-shared-0.4.1.tgz",
+      "integrity": "sha512-IEDX9JzWkIjQiLUaP4Qy5YDiG0jFQatWfS+jw8cCQs6QfbNdEPd2Y3qonwGHnM90CZom9SvjuylBv2pFVAL7Lw==",
       "dependencies": {
         "jose": "^4.14.3"
       },
@@ -348,33 +348,33 @@
       }
     },
     "node_modules/@supabase/functions-js": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.1.1.tgz",
-      "integrity": "sha512-bIR1Puae6W+1/MzPfYBWOG/SCWGo4B5CB7c0ZZksvliNEAzhxNBJ0UFKYINcGdGtxG8ZC+1xr3utWpNZNwnoRw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.1.2.tgz",
+      "integrity": "sha512-QCR6pwJs9exCl37bmpMisUd6mf+0SUBJ6mUpiAjEkSJ/+xW8TCuO14bvkWHADd5hElJK9MxNlMQXxSA4DRz9nQ==",
       "dependencies": {
         "cross-fetch": "^3.1.5"
       }
     },
     "node_modules/@supabase/gotrue-js": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.27.1.tgz",
-      "integrity": "sha512-rewbfKTC9DZNnPy4rRpr5ViBXre55wEXPWOueh/ZgwunR1TGmntRcraIM6SDKrP6iRD6ucx325a467uZ5U+KWg==",
+      "version": "2.31.0",
+      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.31.0.tgz",
+      "integrity": "sha512-YcwlbbNfedlue/HVIXtYBb4fuOrs29gNOTl6AmyxPp4zryRxzFvslVN9kmLDBRUAVU9fnPJh2bgOR3chRjJX5w==",
       "dependencies": {
         "cross-fetch": "^3.1.5"
       }
     },
     "node_modules/@supabase/postgrest-js": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.6.1.tgz",
-      "integrity": "sha512-WDBUPOCOwcZonaCwEodwdA8hwWYOiXroDF9vWGxZxKAnuSVE2Ieci/kvhR4EsWvgGST2h90LRowgO+msXe8+fA==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.7.1.tgz",
+      "integrity": "sha512-xPRYLaZrkLbXNlzmHW6Wtf9hmcBLjjI5xUz2zj8oE2hgXGaYoZBBkpN9bmW9i17Z1f6Ujxa942AqK439XOA36A==",
       "dependencies": {
         "cross-fetch": "^3.1.5"
       }
     },
     "node_modules/@supabase/realtime-js": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.7.2.tgz",
-      "integrity": "sha512-Fi6xAl5PUkqnjl3wo4rdcQIbMG3+yTRX1aUZe/yfvTG84RMvmCXJ1yN6MmafVLeZpU1xkaz5Vx4L0tnHcLiy6w==",
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.7.3.tgz",
+      "integrity": "sha512-c7TzL81sx2kqyxsxcDduJcHL9KJdCOoKimGP6lQSqiZKX42ATlBZpWbyy9KFGFBjAP4nyopMf5JhPi2ZH9jyNw==",
       "dependencies": {
         "@types/phoenix": "^1.5.4",
         "@types/websocket": "^1.0.3",
@@ -390,14 +390,14 @@
       }
     },
     "node_modules/@supabase/supabase-js": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.22.0.tgz",
-      "integrity": "sha512-omkgSWL1HwnpXZZy+yshFLx/qqxwk9kx9jbRM6IHNEylKrH/sz6JX7rGyIOmN9niDxMRjsCu1nwuBhD6IiF2xg==",
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.26.0.tgz",
+      "integrity": "sha512-RXmTPTobaYAwkSobadHZmEVLmzX3SGrtRZIGfLWnLv92VzBRrjuXn0a+bJqKl50GUzsyqPA+j5pod7EwMkcH5A==",
       "dependencies": {
         "@supabase/functions-js": "^2.1.0",
-        "@supabase/gotrue-js": "^2.26.0",
-        "@supabase/postgrest-js": "^1.1.1",
-        "@supabase/realtime-js": "^2.7.2",
+        "@supabase/gotrue-js": "^2.31.0",
+        "@supabase/postgrest-js": "^1.7.0",
+        "@supabase/realtime-js": "^2.7.3",
         "@supabase/storage-js": "^2.5.1",
         "cross-fetch": "^3.1.5"
       }
@@ -422,9 +422,9 @@
       "integrity": "sha512-pg9d0yC4rVNWQzX8U7xb4olIOFuuVL9za3bzMT2pu2SU0SNEi66i2qrvhE2qt0HvkhuCaWJu7pLNOt/Pj8BIrw=="
     },
     "node_modules/@types/phoenix": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.5.6.tgz",
-      "integrity": "sha512-e7jZ6I9uyRGsg7MNwQcarmBvRlbGb9DibbocE9crVnxqsy6C23RMxLWbJ2CQ3vgCW7taoL1L+F02EcjA6ld7XA=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.0.tgz",
+      "integrity": "sha512-qwfpsHmFuhAS/dVd4uBIraMxRd56vwBUYQGZ6GpXnFuM2XMRFJbIyruFKKlW2daQliuYZwe0qfn/UjFCDKic5g=="
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
@@ -3925,50 +3925,50 @@
       "dev": true
     },
     "@supabase/auth-helpers-nextjs": {
-      "version": "0.7.0-next.8",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-helpers-nextjs/-/auth-helpers-nextjs-0.7.0-next.8.tgz",
-      "integrity": "sha512-7pCbdnyAQo+D4qYQCvfg4B3OHIPtrILy/4LNwmF+1uheDeK7B6pxfN2SVeOR2TU3lolxMwEKUP6Q0h1qiCXbQg==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-helpers-nextjs/-/auth-helpers-nextjs-0.7.2.tgz",
+      "integrity": "sha512-n5IyGBYJV/WiR5Rgw4CUaiJYiOv9yW2of4ZP4EyzKt2O6/6rztt7PcGE4AoK2vERw+fb5F2QtJBdt6J5eOYCCw==",
       "requires": {
-        "@supabase/auth-helpers-shared": "0.4.0-next.3",
+        "@supabase/auth-helpers-shared": "0.4.1",
         "set-cookie-parser": "^2.6.0"
       }
     },
     "@supabase/auth-helpers-shared": {
-      "version": "0.4.0-next.3",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-helpers-shared/-/auth-helpers-shared-0.4.0-next.3.tgz",
-      "integrity": "sha512-ELvEbYPJdTlwvqXsHkRN8ADcRe1IQxHt+UNqxbV2SKIpJCieQ4BMsgUVI/w+e3gMQHRbydk0PaJpOa9aStzMyg==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-helpers-shared/-/auth-helpers-shared-0.4.1.tgz",
+      "integrity": "sha512-IEDX9JzWkIjQiLUaP4Qy5YDiG0jFQatWfS+jw8cCQs6QfbNdEPd2Y3qonwGHnM90CZom9SvjuylBv2pFVAL7Lw==",
       "requires": {
         "jose": "^4.14.3"
       }
     },
     "@supabase/functions-js": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.1.1.tgz",
-      "integrity": "sha512-bIR1Puae6W+1/MzPfYBWOG/SCWGo4B5CB7c0ZZksvliNEAzhxNBJ0UFKYINcGdGtxG8ZC+1xr3utWpNZNwnoRw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.1.2.tgz",
+      "integrity": "sha512-QCR6pwJs9exCl37bmpMisUd6mf+0SUBJ6mUpiAjEkSJ/+xW8TCuO14bvkWHADd5hElJK9MxNlMQXxSA4DRz9nQ==",
       "requires": {
         "cross-fetch": "^3.1.5"
       }
     },
     "@supabase/gotrue-js": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.27.1.tgz",
-      "integrity": "sha512-rewbfKTC9DZNnPy4rRpr5ViBXre55wEXPWOueh/ZgwunR1TGmntRcraIM6SDKrP6iRD6ucx325a467uZ5U+KWg==",
+      "version": "2.31.0",
+      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.31.0.tgz",
+      "integrity": "sha512-YcwlbbNfedlue/HVIXtYBb4fuOrs29gNOTl6AmyxPp4zryRxzFvslVN9kmLDBRUAVU9fnPJh2bgOR3chRjJX5w==",
       "requires": {
         "cross-fetch": "^3.1.5"
       }
     },
     "@supabase/postgrest-js": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.6.1.tgz",
-      "integrity": "sha512-WDBUPOCOwcZonaCwEodwdA8hwWYOiXroDF9vWGxZxKAnuSVE2Ieci/kvhR4EsWvgGST2h90LRowgO+msXe8+fA==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.7.1.tgz",
+      "integrity": "sha512-xPRYLaZrkLbXNlzmHW6Wtf9hmcBLjjI5xUz2zj8oE2hgXGaYoZBBkpN9bmW9i17Z1f6Ujxa942AqK439XOA36A==",
       "requires": {
         "cross-fetch": "^3.1.5"
       }
     },
     "@supabase/realtime-js": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.7.2.tgz",
-      "integrity": "sha512-Fi6xAl5PUkqnjl3wo4rdcQIbMG3+yTRX1aUZe/yfvTG84RMvmCXJ1yN6MmafVLeZpU1xkaz5Vx4L0tnHcLiy6w==",
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.7.3.tgz",
+      "integrity": "sha512-c7TzL81sx2kqyxsxcDduJcHL9KJdCOoKimGP6lQSqiZKX42ATlBZpWbyy9KFGFBjAP4nyopMf5JhPi2ZH9jyNw==",
       "requires": {
         "@types/phoenix": "^1.5.4",
         "@types/websocket": "^1.0.3",
@@ -3984,14 +3984,14 @@
       }
     },
     "@supabase/supabase-js": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.22.0.tgz",
-      "integrity": "sha512-omkgSWL1HwnpXZZy+yshFLx/qqxwk9kx9jbRM6IHNEylKrH/sz6JX7rGyIOmN9niDxMRjsCu1nwuBhD6IiF2xg==",
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.26.0.tgz",
+      "integrity": "sha512-RXmTPTobaYAwkSobadHZmEVLmzX3SGrtRZIGfLWnLv92VzBRrjuXn0a+bJqKl50GUzsyqPA+j5pod7EwMkcH5A==",
       "requires": {
         "@supabase/functions-js": "^2.1.0",
-        "@supabase/gotrue-js": "^2.26.0",
-        "@supabase/postgrest-js": "^1.1.1",
-        "@supabase/realtime-js": "^2.7.2",
+        "@supabase/gotrue-js": "^2.31.0",
+        "@supabase/postgrest-js": "^1.7.0",
+        "@supabase/realtime-js": "^2.7.3",
         "@supabase/storage-js": "^2.5.1",
         "cross-fetch": "^3.1.5"
       }
@@ -4016,9 +4016,9 @@
       "integrity": "sha512-pg9d0yC4rVNWQzX8U7xb4olIOFuuVL9za3bzMT2pu2SU0SNEi66i2qrvhE2qt0HvkhuCaWJu7pLNOt/Pj8BIrw=="
     },
     "@types/phoenix": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.5.6.tgz",
-      "integrity": "sha512-e7jZ6I9uyRGsg7MNwQcarmBvRlbGb9DibbocE9crVnxqsy6C23RMxLWbJ2CQ3vgCW7taoL1L+F02EcjA6ld7XA=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.0.tgz",
+      "integrity": "sha512-qwfpsHmFuhAS/dVd4uBIraMxRd56vwBUYQGZ6GpXnFuM2XMRFJbIyruFKKlW2daQliuYZwe0qfn/UjFCDKic5g=="
     },
     "@types/prop-types": {
       "version": "15.7.5",

--- a/examples/auth/nextjs/package-lock.json
+++ b/examples/auth/nextjs/package-lock.json
@@ -8,18 +8,19 @@
       "name": "full-nextjs-auth-helpers",
       "version": "0.1.0",
       "dependencies": {
-        "@supabase/auth-helpers-nextjs": "^0.7.0-next.8",
+        "@supabase/auth-helpers-nextjs": "latest",
+        "@supabase/supabase-js": "latest",
         "@types/node": "^20.2.3",
         "@types/react": "^18.2.6",
         "@types/react-dom": "^18.2.4",
         "eslint": "^8.41.0",
-        "next": "^13.4.3",
+        "next": "latest",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "typescript": "^5.0.4"
       },
       "devDependencies": {
-        "eslint-config-next": "^13.4.3"
+        "eslint-config-next": "latest"
       }
     },
     "node_modules/@babel/runtime": {
@@ -350,7 +351,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.1.1.tgz",
       "integrity": "sha512-bIR1Puae6W+1/MzPfYBWOG/SCWGo4B5CB7c0ZZksvliNEAzhxNBJ0UFKYINcGdGtxG8ZC+1xr3utWpNZNwnoRw==",
-      "peer": true,
       "dependencies": {
         "cross-fetch": "^3.1.5"
       }
@@ -359,7 +359,6 @@
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.27.1.tgz",
       "integrity": "sha512-rewbfKTC9DZNnPy4rRpr5ViBXre55wEXPWOueh/ZgwunR1TGmntRcraIM6SDKrP6iRD6ucx325a467uZ5U+KWg==",
-      "peer": true,
       "dependencies": {
         "cross-fetch": "^3.1.5"
       }
@@ -368,7 +367,6 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.6.1.tgz",
       "integrity": "sha512-WDBUPOCOwcZonaCwEodwdA8hwWYOiXroDF9vWGxZxKAnuSVE2Ieci/kvhR4EsWvgGST2h90LRowgO+msXe8+fA==",
-      "peer": true,
       "dependencies": {
         "cross-fetch": "^3.1.5"
       }
@@ -377,7 +375,6 @@
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.7.2.tgz",
       "integrity": "sha512-Fi6xAl5PUkqnjl3wo4rdcQIbMG3+yTRX1aUZe/yfvTG84RMvmCXJ1yN6MmafVLeZpU1xkaz5Vx4L0tnHcLiy6w==",
-      "peer": true,
       "dependencies": {
         "@types/phoenix": "^1.5.4",
         "@types/websocket": "^1.0.3",
@@ -388,7 +385,6 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.5.1.tgz",
       "integrity": "sha512-nkR0fQA9ScAtIKA3vNoPEqbZv1k5B5HVRYEvRWdlP6mUpFphM9TwPL2jZ/ztNGMTG5xT6SrHr+H7Ykz8qzbhjw==",
-      "peer": true,
       "dependencies": {
         "cross-fetch": "^3.1.5"
       }
@@ -397,7 +393,6 @@
       "version": "2.22.0",
       "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.22.0.tgz",
       "integrity": "sha512-omkgSWL1HwnpXZZy+yshFLx/qqxwk9kx9jbRM6IHNEylKrH/sz6JX7rGyIOmN9niDxMRjsCu1nwuBhD6IiF2xg==",
-      "peer": true,
       "dependencies": {
         "@supabase/functions-js": "^2.1.0",
         "@supabase/gotrue-js": "^2.26.0",
@@ -429,8 +424,7 @@
     "node_modules/@types/phoenix": {
       "version": "1.5.6",
       "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.5.6.tgz",
-      "integrity": "sha512-e7jZ6I9uyRGsg7MNwQcarmBvRlbGb9DibbocE9crVnxqsy6C23RMxLWbJ2CQ3vgCW7taoL1L+F02EcjA6ld7XA==",
-      "peer": true
+      "integrity": "sha512-e7jZ6I9uyRGsg7MNwQcarmBvRlbGb9DibbocE9crVnxqsy6C23RMxLWbJ2CQ3vgCW7taoL1L+F02EcjA6ld7XA=="
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
@@ -464,7 +458,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/websocket/-/websocket-1.0.5.tgz",
       "integrity": "sha512-NbsqiNX9CnEfC1Z0Vf4mE1SgAJ07JnRYcNex7AJ9zAVzmiGHmjKFEk7O4TJIsgv2B1sLEb6owKFZrACwdYngsQ==",
-      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -797,7 +790,6 @@
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.7.tgz",
       "integrity": "sha512-kukuqc39WOHtdxtw4UScxF/WVnMFVSQVKhtx3AjZJzhd0RGZZldcrfSEbVsWWe6KNH253574cq5F+wpv0G9pJw==",
       "hasInstallScript": true,
-      "peer": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
       },
@@ -897,7 +889,6 @@
       "version": "3.1.6",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.6.tgz",
       "integrity": "sha512-riRvo06crlE8HiqOwIpQhxwdOk4fOeR7FVM/wXoxchFEqMNUjvbs3bfo4OTgMEMHzppd4DxFBDbyySj8Cv781g==",
-      "peer": true,
       "dependencies": {
         "node-fetch": "^2.6.11"
       }
@@ -924,7 +915,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
       "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
-      "peer": true,
       "dependencies": {
         "es5-ext": "^0.10.50",
         "type": "^1.0.1"
@@ -1165,7 +1155,6 @@
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
       "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
       "hasInstallScript": true,
-      "peer": true,
       "dependencies": {
         "es6-iterator": "^2.0.3",
         "es6-symbol": "^3.1.3",
@@ -1179,7 +1168,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
       "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
-      "peer": true,
       "dependencies": {
         "d": "1",
         "es5-ext": "^0.10.35",
@@ -1190,7 +1178,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
       "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
-      "peer": true,
       "dependencies": {
         "d": "^1.0.1",
         "ext": "^1.1.2"
@@ -1651,7 +1638,6 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
       "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
-      "peer": true,
       "dependencies": {
         "type": "^2.7.2"
       }
@@ -1659,8 +1645,7 @@
     "node_modules/ext/node_modules/type": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
-      "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw==",
-      "peer": true
+      "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -2380,8 +2365,7 @@
     "node_modules/is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
-      "peer": true
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
     },
     "node_modules/is-weakmap": {
       "version": "2.0.1",
@@ -2687,14 +2671,12 @@
     "node_modules/next-tick": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
-      "peer": true
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
     },
     "node_modules/node-fetch": {
       "version": "2.6.11",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
       "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
-      "peer": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -2714,7 +2696,6 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
       "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==",
-      "peer": true,
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -3477,8 +3458,7 @@
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "peer": true
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/tsconfig-paths": {
       "version": "3.14.2",
@@ -3521,8 +3501,7 @@
     "node_modules/type": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
-      "peer": true
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -3564,7 +3543,6 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
       "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-      "peer": true,
       "dependencies": {
         "is-typedarray": "^1.0.0"
       }
@@ -3609,7 +3587,6 @@
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
       "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
       "hasInstallScript": true,
-      "peer": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
       },
@@ -3620,14 +3597,12 @@
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "peer": true
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "node_modules/websocket": {
       "version": "1.0.34",
       "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.34.tgz",
       "integrity": "sha512-PRDso2sGwF6kM75QykIesBijKSVceR6jL2G8NGYyq2XrItNC2P5/qL5XeR056GhA+Ly7JMFvJb9I312mJfmqnQ==",
-      "peer": true,
       "dependencies": {
         "bufferutil": "^4.0.1",
         "debug": "^2.2.0",
@@ -3644,7 +3619,6 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "peer": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -3652,14 +3626,12 @@
     "node_modules/websocket/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "peer": true
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "peer": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -3747,7 +3719,6 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
       "integrity": "sha512-MvQa//+KcZCUkBTIC9blM+CU9J2GzuTytsOUwf2lidtvkx/6gnEp1QvJv34t9vdjhFmha/mUiNDbN0D0mJWdug==",
-      "peer": true,
       "engines": {
         "node": ">=0.10.32"
       }
@@ -3974,7 +3945,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.1.1.tgz",
       "integrity": "sha512-bIR1Puae6W+1/MzPfYBWOG/SCWGo4B5CB7c0ZZksvliNEAzhxNBJ0UFKYINcGdGtxG8ZC+1xr3utWpNZNwnoRw==",
-      "peer": true,
       "requires": {
         "cross-fetch": "^3.1.5"
       }
@@ -3983,7 +3953,6 @@
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.27.1.tgz",
       "integrity": "sha512-rewbfKTC9DZNnPy4rRpr5ViBXre55wEXPWOueh/ZgwunR1TGmntRcraIM6SDKrP6iRD6ucx325a467uZ5U+KWg==",
-      "peer": true,
       "requires": {
         "cross-fetch": "^3.1.5"
       }
@@ -3992,7 +3961,6 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.6.1.tgz",
       "integrity": "sha512-WDBUPOCOwcZonaCwEodwdA8hwWYOiXroDF9vWGxZxKAnuSVE2Ieci/kvhR4EsWvgGST2h90LRowgO+msXe8+fA==",
-      "peer": true,
       "requires": {
         "cross-fetch": "^3.1.5"
       }
@@ -4001,7 +3969,6 @@
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.7.2.tgz",
       "integrity": "sha512-Fi6xAl5PUkqnjl3wo4rdcQIbMG3+yTRX1aUZe/yfvTG84RMvmCXJ1yN6MmafVLeZpU1xkaz5Vx4L0tnHcLiy6w==",
-      "peer": true,
       "requires": {
         "@types/phoenix": "^1.5.4",
         "@types/websocket": "^1.0.3",
@@ -4012,7 +3979,6 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.5.1.tgz",
       "integrity": "sha512-nkR0fQA9ScAtIKA3vNoPEqbZv1k5B5HVRYEvRWdlP6mUpFphM9TwPL2jZ/ztNGMTG5xT6SrHr+H7Ykz8qzbhjw==",
-      "peer": true,
       "requires": {
         "cross-fetch": "^3.1.5"
       }
@@ -4021,7 +3987,6 @@
       "version": "2.22.0",
       "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.22.0.tgz",
       "integrity": "sha512-omkgSWL1HwnpXZZy+yshFLx/qqxwk9kx9jbRM6IHNEylKrH/sz6JX7rGyIOmN9niDxMRjsCu1nwuBhD6IiF2xg==",
-      "peer": true,
       "requires": {
         "@supabase/functions-js": "^2.1.0",
         "@supabase/gotrue-js": "^2.26.0",
@@ -4053,8 +4018,7 @@
     "@types/phoenix": {
       "version": "1.5.6",
       "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.5.6.tgz",
-      "integrity": "sha512-e7jZ6I9uyRGsg7MNwQcarmBvRlbGb9DibbocE9crVnxqsy6C23RMxLWbJ2CQ3vgCW7taoL1L+F02EcjA6ld7XA==",
-      "peer": true
+      "integrity": "sha512-e7jZ6I9uyRGsg7MNwQcarmBvRlbGb9DibbocE9crVnxqsy6C23RMxLWbJ2CQ3vgCW7taoL1L+F02EcjA6ld7XA=="
     },
     "@types/prop-types": {
       "version": "15.7.5",
@@ -4088,7 +4052,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/websocket/-/websocket-1.0.5.tgz",
       "integrity": "sha512-NbsqiNX9CnEfC1Z0Vf4mE1SgAJ07JnRYcNex7AJ9zAVzmiGHmjKFEk7O4TJIsgv2B1sLEb6owKFZrACwdYngsQ==",
-      "peer": true,
       "requires": {
         "@types/node": "*"
       }
@@ -4315,7 +4278,6 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.7.tgz",
       "integrity": "sha512-kukuqc39WOHtdxtw4UScxF/WVnMFVSQVKhtx3AjZJzhd0RGZZldcrfSEbVsWWe6KNH253574cq5F+wpv0G9pJw==",
-      "peer": true,
       "requires": {
         "node-gyp-build": "^4.3.0"
       }
@@ -4384,7 +4346,6 @@
       "version": "3.1.6",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.6.tgz",
       "integrity": "sha512-riRvo06crlE8HiqOwIpQhxwdOk4fOeR7FVM/wXoxchFEqMNUjvbs3bfo4OTgMEMHzppd4DxFBDbyySj8Cv781g==",
-      "peer": true,
       "requires": {
         "node-fetch": "^2.6.11"
       }
@@ -4408,7 +4369,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
       "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
-      "peer": true,
       "requires": {
         "es5-ext": "^0.10.50",
         "type": "^1.0.1"
@@ -4601,7 +4561,6 @@
       "version": "0.10.62",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
       "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
-      "peer": true,
       "requires": {
         "es6-iterator": "^2.0.3",
         "es6-symbol": "^3.1.3",
@@ -4612,7 +4571,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
       "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
-      "peer": true,
       "requires": {
         "d": "1",
         "es5-ext": "^0.10.35",
@@ -4623,7 +4581,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
       "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
-      "peer": true,
       "requires": {
         "d": "^1.0.1",
         "ext": "^1.1.2"
@@ -4968,7 +4925,6 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
       "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
-      "peer": true,
       "requires": {
         "type": "^2.7.2"
       },
@@ -4976,8 +4932,7 @@
         "type": {
           "version": "2.7.2",
           "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
-          "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw==",
-          "peer": true
+          "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
         }
       }
     },
@@ -5485,8 +5440,7 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
-      "peer": true
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
     },
     "is-weakmap": {
       "version": "2.0.1",
@@ -5705,14 +5659,12 @@
     "next-tick": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
-      "peer": true
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
     },
     "node-fetch": {
       "version": "2.6.11",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
       "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
-      "peer": true,
       "requires": {
         "whatwg-url": "^5.0.0"
       }
@@ -5720,8 +5672,7 @@
     "node-gyp-build": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
-      "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==",
-      "peer": true
+      "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ=="
     },
     "object-assign": {
       "version": "4.1.1",
@@ -6228,8 +6179,7 @@
     "tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "peer": true
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "tsconfig-paths": {
       "version": "3.14.2",
@@ -6268,8 +6218,7 @@
     "type": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
-      "peer": true
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
     },
     "type-check": {
       "version": "0.4.0",
@@ -6299,7 +6248,6 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
       "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-      "peer": true,
       "requires": {
         "is-typedarray": "^1.0.0"
       }
@@ -6333,7 +6281,6 @@
       "version": "5.0.10",
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
       "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "peer": true,
       "requires": {
         "node-gyp-build": "^4.3.0"
       }
@@ -6341,14 +6288,12 @@
     "webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "peer": true
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "websocket": {
       "version": "1.0.34",
       "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.34.tgz",
       "integrity": "sha512-PRDso2sGwF6kM75QykIesBijKSVceR6jL2G8NGYyq2XrItNC2P5/qL5XeR056GhA+Ly7JMFvJb9I312mJfmqnQ==",
-      "peer": true,
       "requires": {
         "bufferutil": "^4.0.1",
         "debug": "^2.2.0",
@@ -6362,7 +6307,6 @@
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "peer": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -6370,8 +6314,7 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-          "peer": true
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
         }
       }
     },
@@ -6379,7 +6322,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "peer": true,
       "requires": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -6445,8 +6387,7 @@
     "yaeti": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
-      "integrity": "sha512-MvQa//+KcZCUkBTIC9blM+CU9J2GzuTytsOUwf2lidtvkx/6gnEp1QvJv34t9vdjhFmha/mUiNDbN0D0mJWdug==",
-      "peer": true
+      "integrity": "sha512-MvQa//+KcZCUkBTIC9blM+CU9J2GzuTytsOUwf2lidtvkx/6gnEp1QvJv34t9vdjhFmha/mUiNDbN0D0mJWdug=="
     },
     "yallist": {
       "version": "4.0.0",

--- a/examples/auth/nextjs/package.json
+++ b/examples/auth/nextjs/package.json
@@ -9,17 +9,18 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@supabase/auth-helpers-nextjs": "^0.7.0",
+    "@supabase/auth-helpers-nextjs": "latest",
+    "@supabase/supabase-js": "latest",
     "@types/node": "^20.2.3",
     "@types/react": "^18.2.6",
     "@types/react-dom": "^18.2.4",
     "eslint": "^8.41.0",
-    "next": "^13.4.3",
+    "next": "latest",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "typescript": "^5.0.4"
   },
   "devDependencies": {
-    "eslint-config-next": "^13.4.3"
+    "eslint-config-next": "latest"
   }
 }

--- a/examples/auth/nextjs/package.json
+++ b/examples/auth/nextjs/package.json
@@ -9,18 +9,18 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@supabase/auth-helpers-nextjs": "latest",
-    "@supabase/supabase-js": "latest",
+    "@supabase/auth-helpers-nextjs": "^0.7.1",
+    "@supabase/supabase-js": "^2.26.0",
     "@types/node": "^20.2.3",
     "@types/react": "^18.2.6",
     "@types/react-dom": "^18.2.4",
     "eslint": "^8.41.0",
-    "next": "latest",
+    "next": "^13.4.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "typescript": "^5.0.4"
   },
   "devDependencies": {
-    "eslint-config-next": "latest"
+    "eslint-config-next": "^13.4.3"
   }
 }

--- a/examples/user-management/nextjs-user-management/package-lock.json
+++ b/examples/user-management/nextjs-user-management/package-lock.json
@@ -8,16 +8,17 @@
       "name": "nextjs-user-management",
       "version": "0.1.0",
       "dependencies": {
-        "@supabase/auth-helpers-nextjs": "^0.7.1",
+        "@supabase/auth-helpers-nextjs": "latest",
         "@supabase/auth-ui-react": "^0.4.2",
         "@supabase/auth-ui-shared": "^0.1.6",
+        "@supabase/supabase-js": "latest",
         "@types/node": "20.1.4",
         "@types/react": "18.2.6",
         "@types/react-dom": "18.2.4",
         "encoding": "^0.1.13",
         "eslint": "8.40.0",
-        "eslint-config-next": "13.4.2",
-        "next": "13.4.2",
+        "eslint-config-next": "latest",
+        "next": "latest",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "typescript": "5.0.4"
@@ -375,7 +376,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.1.1.tgz",
       "integrity": "sha512-bIR1Puae6W+1/MzPfYBWOG/SCWGo4B5CB7c0ZZksvliNEAzhxNBJ0UFKYINcGdGtxG8ZC+1xr3utWpNZNwnoRw==",
-      "peer": true,
       "dependencies": {
         "cross-fetch": "^3.1.5"
       }
@@ -384,7 +384,6 @@
       "version": "2.26.0",
       "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.26.0.tgz",
       "integrity": "sha512-orxz8nwaF5D1nY/9H5xxTfFSCTvYeDLx24UO/Mxsx83xFP0t5RNxQZ0lEHBOhHhXJ4vR/COv79AxoWCOTu/7Rg==",
-      "peer": true,
       "dependencies": {
         "cross-fetch": "^3.1.5"
       }
@@ -393,7 +392,6 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.6.1.tgz",
       "integrity": "sha512-WDBUPOCOwcZonaCwEodwdA8hwWYOiXroDF9vWGxZxKAnuSVE2Ieci/kvhR4EsWvgGST2h90LRowgO+msXe8+fA==",
-      "peer": true,
       "dependencies": {
         "cross-fetch": "^3.1.5"
       }
@@ -402,7 +400,6 @@
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.7.2.tgz",
       "integrity": "sha512-Fi6xAl5PUkqnjl3wo4rdcQIbMG3+yTRX1aUZe/yfvTG84RMvmCXJ1yN6MmafVLeZpU1xkaz5Vx4L0tnHcLiy6w==",
-      "peer": true,
       "dependencies": {
         "@types/phoenix": "^1.5.4",
         "@types/websocket": "^1.0.3",
@@ -413,7 +410,6 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.5.1.tgz",
       "integrity": "sha512-nkR0fQA9ScAtIKA3vNoPEqbZv1k5B5HVRYEvRWdlP6mUpFphM9TwPL2jZ/ztNGMTG5xT6SrHr+H7Ykz8qzbhjw==",
-      "peer": true,
       "dependencies": {
         "cross-fetch": "^3.1.5"
       }
@@ -422,7 +418,6 @@
       "version": "2.21.0",
       "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.21.0.tgz",
       "integrity": "sha512-FW3ZzBoc4orSgfX0dXrmJoXAcI/hiekmqXTkN64vjtUF2Urp3UjyAf71UTtV9Jl6ejHoe3K++e0+Rg9zKUJh5w==",
-      "peer": true,
       "dependencies": {
         "@supabase/functions-js": "^2.1.0",
         "@supabase/gotrue-js": "^2.23.0",
@@ -453,8 +448,7 @@
     "node_modules/@types/phoenix": {
       "version": "1.5.6",
       "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.5.6.tgz",
-      "integrity": "sha512-e7jZ6I9uyRGsg7MNwQcarmBvRlbGb9DibbocE9crVnxqsy6C23RMxLWbJ2CQ3vgCW7taoL1L+F02EcjA6ld7XA==",
-      "peer": true
+      "integrity": "sha512-e7jZ6I9uyRGsg7MNwQcarmBvRlbGb9DibbocE9crVnxqsy6C23RMxLWbJ2CQ3vgCW7taoL1L+F02EcjA6ld7XA=="
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
@@ -488,7 +482,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/websocket/-/websocket-1.0.5.tgz",
       "integrity": "sha512-NbsqiNX9CnEfC1Z0Vf4mE1SgAJ07JnRYcNex7AJ9zAVzmiGHmjKFEk7O4TJIsgv2B1sLEb6owKFZrACwdYngsQ==",
-      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -823,7 +816,6 @@
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.7.tgz",
       "integrity": "sha512-kukuqc39WOHtdxtw4UScxF/WVnMFVSQVKhtx3AjZJzhd0RGZZldcrfSEbVsWWe6KNH253574cq5F+wpv0G9pJw==",
       "hasInstallScript": true,
-      "peer": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
       },
@@ -940,7 +932,6 @@
       "version": "3.1.6",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.6.tgz",
       "integrity": "sha512-riRvo06crlE8HiqOwIpQhxwdOk4fOeR7FVM/wXoxchFEqMNUjvbs3bfo4OTgMEMHzppd4DxFBDbyySj8Cv781g==",
-      "peer": true,
       "dependencies": {
         "node-fetch": "^2.6.11"
       }
@@ -967,7 +958,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
       "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
-      "peer": true,
       "dependencies": {
         "es5-ext": "^0.10.50",
         "type": "^1.0.1"
@@ -1240,7 +1230,6 @@
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
       "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
       "hasInstallScript": true,
-      "peer": true,
       "dependencies": {
         "es6-iterator": "^2.0.3",
         "es6-symbol": "^3.1.3",
@@ -1254,7 +1243,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
       "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
-      "peer": true,
       "dependencies": {
         "d": "1",
         "es5-ext": "^0.10.35",
@@ -1265,7 +1253,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
       "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
-      "peer": true,
       "dependencies": {
         "d": "^1.0.1",
         "ext": "^1.1.2"
@@ -1731,7 +1718,6 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
       "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
-      "peer": true,
       "dependencies": {
         "type": "^2.7.2"
       }
@@ -1739,8 +1725,7 @@
     "node_modules/ext/node_modules/type": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
-      "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw==",
-      "peer": true
+      "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -2468,8 +2453,7 @@
     "node_modules/is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
-      "peer": true
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
     },
     "node_modules/is-weakmap": {
       "version": "2.0.1",
@@ -2807,14 +2791,12 @@
     "node_modules/next-tick": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
-      "peer": true
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
     },
     "node_modules/node-fetch": {
       "version": "2.6.11",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
       "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
-      "peer": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -2834,7 +2816,6 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
       "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==",
-      "peer": true,
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -3723,8 +3704,7 @@
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "peer": true
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/tsconfig-paths": {
       "version": "3.14.2",
@@ -3764,8 +3744,7 @@
     "node_modules/type": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
-      "peer": true
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -3806,7 +3785,6 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
       "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-      "peer": true,
       "dependencies": {
         "is-typedarray": "^1.0.0"
       }
@@ -3858,7 +3836,6 @@
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
       "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
       "hasInstallScript": true,
-      "peer": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
       },
@@ -3869,14 +3846,12 @@
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "peer": true
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "node_modules/websocket": {
       "version": "1.0.34",
       "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.34.tgz",
       "integrity": "sha512-PRDso2sGwF6kM75QykIesBijKSVceR6jL2G8NGYyq2XrItNC2P5/qL5XeR056GhA+Ly7JMFvJb9I312mJfmqnQ==",
-      "peer": true,
       "dependencies": {
         "bufferutil": "^4.0.1",
         "debug": "^2.2.0",
@@ -3893,7 +3868,6 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "peer": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -3901,14 +3875,12 @@
     "node_modules/websocket/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "peer": true
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "peer": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -3993,7 +3965,6 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
       "integrity": "sha512-MvQa//+KcZCUkBTIC9blM+CU9J2GzuTytsOUwf2lidtvkx/6gnEp1QvJv34t9vdjhFmha/mUiNDbN0D0mJWdug==",
-      "peer": true,
       "engines": {
         "node": ">=0.10.32"
       }

--- a/examples/user-management/nextjs-user-management/package-lock.json
+++ b/examples/user-management/nextjs-user-management/package-lock.json
@@ -8,17 +8,17 @@
       "name": "nextjs-user-management",
       "version": "0.1.0",
       "dependencies": {
-        "@supabase/auth-helpers-nextjs": "latest",
+        "@supabase/auth-helpers-nextjs": "^0.7.1",
         "@supabase/auth-ui-react": "^0.4.2",
         "@supabase/auth-ui-shared": "^0.1.6",
-        "@supabase/supabase-js": "latest",
+        "@supabase/supabase-js": "^2.26.0",
         "@types/node": "20.1.4",
         "@types/react": "18.2.6",
         "@types/react-dom": "18.2.4",
         "encoding": "^0.1.13",
         "eslint": "8.40.0",
-        "eslint-config-next": "latest",
-        "next": "latest",
+        "eslint-config-next": "13.4.2",
+        "next": "13.4.2",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "typescript": "5.0.4"
@@ -381,25 +381,25 @@
       }
     },
     "node_modules/@supabase/gotrue-js": {
-      "version": "2.26.0",
-      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.26.0.tgz",
-      "integrity": "sha512-orxz8nwaF5D1nY/9H5xxTfFSCTvYeDLx24UO/Mxsx83xFP0t5RNxQZ0lEHBOhHhXJ4vR/COv79AxoWCOTu/7Rg==",
+      "version": "2.31.0",
+      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.31.0.tgz",
+      "integrity": "sha512-YcwlbbNfedlue/HVIXtYBb4fuOrs29gNOTl6AmyxPp4zryRxzFvslVN9kmLDBRUAVU9fnPJh2bgOR3chRjJX5w==",
       "dependencies": {
         "cross-fetch": "^3.1.5"
       }
     },
     "node_modules/@supabase/postgrest-js": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.6.1.tgz",
-      "integrity": "sha512-WDBUPOCOwcZonaCwEodwdA8hwWYOiXroDF9vWGxZxKAnuSVE2Ieci/kvhR4EsWvgGST2h90LRowgO+msXe8+fA==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.7.1.tgz",
+      "integrity": "sha512-xPRYLaZrkLbXNlzmHW6Wtf9hmcBLjjI5xUz2zj8oE2hgXGaYoZBBkpN9bmW9i17Z1f6Ujxa942AqK439XOA36A==",
       "dependencies": {
         "cross-fetch": "^3.1.5"
       }
     },
     "node_modules/@supabase/realtime-js": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.7.2.tgz",
-      "integrity": "sha512-Fi6xAl5PUkqnjl3wo4rdcQIbMG3+yTRX1aUZe/yfvTG84RMvmCXJ1yN6MmafVLeZpU1xkaz5Vx4L0tnHcLiy6w==",
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.7.3.tgz",
+      "integrity": "sha512-c7TzL81sx2kqyxsxcDduJcHL9KJdCOoKimGP6lQSqiZKX42ATlBZpWbyy9KFGFBjAP4nyopMf5JhPi2ZH9jyNw==",
       "dependencies": {
         "@types/phoenix": "^1.5.4",
         "@types/websocket": "^1.0.3",
@@ -415,14 +415,14 @@
       }
     },
     "node_modules/@supabase/supabase-js": {
-      "version": "2.21.0",
-      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.21.0.tgz",
-      "integrity": "sha512-FW3ZzBoc4orSgfX0dXrmJoXAcI/hiekmqXTkN64vjtUF2Urp3UjyAf71UTtV9Jl6ejHoe3K++e0+Rg9zKUJh5w==",
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.26.0.tgz",
+      "integrity": "sha512-RXmTPTobaYAwkSobadHZmEVLmzX3SGrtRZIGfLWnLv92VzBRrjuXn0a+bJqKl50GUzsyqPA+j5pod7EwMkcH5A==",
       "dependencies": {
         "@supabase/functions-js": "^2.1.0",
-        "@supabase/gotrue-js": "^2.23.0",
-        "@supabase/postgrest-js": "^1.1.1",
-        "@supabase/realtime-js": "^2.7.2",
+        "@supabase/gotrue-js": "^2.31.0",
+        "@supabase/postgrest-js": "^1.7.0",
+        "@supabase/realtime-js": "^2.7.3",
         "@supabase/storage-js": "^2.5.1",
         "cross-fetch": "^3.1.5"
       }
@@ -446,9 +446,9 @@
       "integrity": "sha512-At4pvmIOki8yuwLtd7BNHl3CiWNbtclUbNtScGx4OHfBd4/oWoJC8KRCIxXwkdndzhxOsPXihrsOoydxBjlE9Q=="
     },
     "node_modules/@types/phoenix": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.5.6.tgz",
-      "integrity": "sha512-e7jZ6I9uyRGsg7MNwQcarmBvRlbGb9DibbocE9crVnxqsy6C23RMxLWbJ2CQ3vgCW7taoL1L+F02EcjA6ld7XA=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.0.tgz",
+      "integrity": "sha512-qwfpsHmFuhAS/dVd4uBIraMxRd56vwBUYQGZ6GpXnFuM2XMRFJbIyruFKKlW2daQliuYZwe0qfn/UjFCDKic5g=="
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.5",

--- a/examples/user-management/nextjs-user-management/package.json
+++ b/examples/user-management/nextjs-user-management/package.json
@@ -9,8 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@supabase/auth-helpers-nextjs": "latest",
-    "@supabase/supabase-js": "latest",
+    "@supabase/auth-helpers-nextjs": "^0.7.1",
+    "@supabase/supabase-js": "^2.26.0",
     "@supabase/auth-ui-react": "^0.4.2",
     "@supabase/auth-ui-shared": "^0.1.6",
     "@types/node": "20.1.4",
@@ -18,8 +18,8 @@
     "@types/react-dom": "18.2.4",
     "encoding": "^0.1.13",
     "eslint": "8.40.0",
-    "eslint-config-next": "latest",
-    "next": "latest",
+    "eslint-config-next": "13.4.2",
+    "next": "13.4.2",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "typescript": "5.0.4"

--- a/examples/user-management/nextjs-user-management/package.json
+++ b/examples/user-management/nextjs-user-management/package.json
@@ -9,7 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@supabase/auth-helpers-nextjs": "^0.7.1",
+    "@supabase/auth-helpers-nextjs": "latest",
+    "@supabase/supabase-js": "latest",
     "@supabase/auth-ui-react": "^0.4.2",
     "@supabase/auth-ui-shared": "^0.1.6",
     "@types/node": "20.1.4",
@@ -17,8 +18,8 @@
     "@types/react-dom": "18.2.4",
     "encoding": "^0.1.13",
     "eslint": "8.40.0",
-    "eslint-config-next": "13.4.2",
-    "next": "13.4.2",
+    "eslint-config-next": "latest",
+    "next": "latest",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "typescript": "5.0.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "workspaces": [
         "apps/www",
         "apps/docs",
-        "apps/new-docs",
         "studio",
         "tests",
         "packages/*"


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

Docs and examples for Auth Helpers do *not* install `supabase-js` as a dependency. It is required as it is a peer dependency of the Auth Helpers.

## What is the new behavior?

Docs and examples for Auth Helpers do install `supabase-js` as a dependency
