### PR TITLE
feat: add loading indicator to `Sign in with Github` button

### DIFF
--- a/studio/components/interfaces/SignIn/SignInWithGitHub.tsx
+++ b/studio/components/interfaces/SignIn/SignInWithGitHub.tsx
@@ -1,9 +1,14 @@
+import { useState } from 'react'
 import { BASE_PATH } from 'lib/constants'
 import { auth, getReturnToPath } from 'lib/gotrue'
 import { Button, IconGitHub } from 'ui'
 
 const SignInWithGitHub = () => {
+  const [loading, setLoading] = useState(false)
+
   async function handleGithubSignIn() {
+    setLoading(true)
+
     try {
       const { error } = await auth.signInWithOAuth({
         provider: 'github',
@@ -18,6 +23,8 @@ const SignInWithGitHub = () => {
       if (error) throw error
     } catch (error) {
       console.error(error)
+    } finally {
+      setLoading(false)
     }
   }
 
@@ -28,6 +35,7 @@ const SignInWithGitHub = () => {
       icon={<IconGitHub width={18} height={18} />}
       size="large"
       type="default"
+      loading={loading}
     >
       Continue with GitHub
     </Button>


### PR DESCRIPTION
Given that primary region for supabase.com is not in EU/US, this button sometimes takes multiple seconds to take you to the GitHub consent screen.