### PR TITLE
feat: add Sentry events to monitor random logouts

### DIFF
--- a/studio/components/interfaces/SignIn/SignInForm.tsx
+++ b/studio/components/interfaces/SignIn/SignInForm.tsx
@@ -3,10 +3,12 @@ import { useQueryClient } from '@tanstack/react-query'
 import { useStore } from 'hooks'
 import { usePushNext } from 'hooks/misc/useAutoAuthRedirect'
 import { auth } from 'lib/gotrue'
+import { incrementSignInClicks } from 'lib/local-storage'
 import Link from 'next/link'
 import { useRef, useState } from 'react'
 import { Button, Form, Input } from 'ui'
 import { object, string } from 'yup'
+import * as Sentry from '@sentry/nextjs'
 
 const signInSchema = object({
   email: string().email('Must be a valid email').required('Email is required'),
@@ -31,6 +33,11 @@ const SignInForm = () => {
     if (!token) {
       const captchaResponse = await captchaRef.current?.execute({ async: true })
       token = captchaResponse?.response ?? null
+    }
+
+    const signInClicks = incrementSignInClicks()
+    if (signInClicks > 1) {
+      Sentry.captureMessage('Sign in without previous sing out detected')
     }
 
     const { error } = await auth.signInWithPassword({

--- a/studio/components/interfaces/SignIn/SignInWithGitHub.tsx
+++ b/studio/components/interfaces/SignIn/SignInWithGitHub.tsx
@@ -1,7 +1,9 @@
 import { useState } from 'react'
 import { BASE_PATH } from 'lib/constants'
 import { auth, getReturnToPath } from 'lib/gotrue'
+import { incrementSignInClicks } from 'lib/local-storage'
 import { Button, IconGitHub } from 'ui'
+import * as Sentry from '@sentry/nextjs'
 
 const SignInWithGitHub = () => {
   const [loading, setLoading] = useState(false)
@@ -10,6 +12,11 @@ const SignInWithGitHub = () => {
     setLoading(true)
 
     try {
+      const signInClicks = incrementSignInClicks()
+      if (signInClicks > 1) {
+        Sentry.captureMessage('Sign in without previous sign out detected')
+      }
+
       const { error } = await auth.signInWithOAuth({
         provider: 'github',
         options: {

--- a/studio/components/interfaces/SignIn/SignUpForm.tsx
+++ b/studio/components/interfaces/SignIn/SignUpForm.tsx
@@ -7,6 +7,7 @@ import { useStore } from 'hooks'
 import { post } from 'lib/common/fetch'
 import { API_URL, BASE_PATH } from 'lib/constants'
 import { passwordSchema } from 'lib/schemas'
+import { resetSignInClicks } from 'lib/local-storage'
 import PasswordConditionsHelper from './PasswordConditionsHelper'
 
 const signUpSchema = passwordSchema.shape({
@@ -32,6 +33,8 @@ const SignUpForm = () => {
       const captchaResponse = await captchaRef.current?.execute({ async: true })
       token = captchaResponse?.response ?? null
     }
+
+    resetSignInClicks()
 
     const response = await post(`${API_URL}/signup`, {
       email,

--- a/studio/lib/auth.tsx
+++ b/studio/lib/auth.tsx
@@ -12,7 +12,7 @@ import { useProfileQuery } from 'data/profile/profile-query'
 import { useStore } from 'hooks'
 import Telemetry from 'lib/telemetry'
 import { GOTRUE_ERRORS, IS_PLATFORM } from './constants'
-import { clearLocalStorage } from './local-storage'
+import { clearLocalStorage, resetSignInClicks } from './local-storage'
 import { useProfileCreateMutation } from 'data/profile/profile-create-mutation'
 
 export const AuthContext = AuthContextInternal
@@ -99,6 +99,8 @@ export function useSignOut() {
   const queryClient = useQueryClient()
 
   return useCallback(async () => {
+    resetSignInClicks()
+
     const result = await gotrueClient.signOut()
     clearLocalStorage()
     await queryClient.resetQueries()

--- a/studio/lib/local-storage.ts
+++ b/studio/lib/local-storage.ts
@@ -1,4 +1,11 @@
-export const LOCAL_STORAGE_KEYS_ALLOWLIST = ['graphiql:theme', 'theme', 'supabaseDarkMode']
+import { IS_PLATFORM } from './constants'
+
+export const LOCAL_STORAGE_KEYS_ALLOWLIST = [
+  'graphiql:theme',
+  'theme',
+  'supabaseDarkMode',
+  'supabase.dashboard.sign_in_clicks',
+]
 
 export function clearLocalStorage() {
   for (const key in localStorage) {
@@ -6,4 +13,48 @@ export function clearLocalStorage() {
       localStorage.removeItem(key)
     }
   }
+}
+
+function inferSignInClicks() {
+  if (localStorage.getItem('supabase.dashboard.sign_in_clicks')) {
+    return
+  }
+
+  localStorage.setItem(
+    'supabase.dashboard.sign_in_clicks',
+    localStorage.getItem('supabase.dashboard.auth.token') ? '1' : '0'
+  )
+}
+
+export function getSignInClicks(): number {
+  let count: number | null = null
+
+  try {
+    count = JSON.parse(localStorage.getItem('supabase.dashboard.sign_in_clicks') || '0')
+  } catch (e: any) {
+    // do nothing
+  }
+
+  return count || 0
+}
+
+export function incrementSignInClicks(): number {
+  const clicks = getSignInClicks()
+
+  localStorage.setItem('supabase.dashboard.sign_in_clicks', JSON.stringify(clicks + 1))
+
+  return clicks + 1
+}
+
+export function resetSignInClicks(): number {
+  const clicks = getSignInClicks()
+
+  localStorage.setItem('supabase.dashboard.sign_in_clicks', '0')
+
+  return clicks
+}
+
+if (globalThis && globalThis.localStorage && IS_PLATFORM) {
+  // populate the value based on the current local storage state
+  inferSignInClicks()
 }


### PR DESCRIPTION
Attempts to send a Sentry message/event when a Sign In button is clicked twice in a row without a Log Out in-between. Should help us identify the rate of occurrence of the random logouts problem.