### PR TITLE
Update nuxtjs.mdx, import line missing

### DIFF
--- a/apps/docs/pages/guides/getting-started/quickstarts/nuxtjs.mdx
+++ b/apps/docs/pages/guides/getting-started/quickstarts/nuxtjs.mdx
@@ -88,7 +88,7 @@ export const meta = {
 
       ```vue src/App.vue
       <script setup>
-      import {createClient} from '@supabase/supabase-js'
+      import { createClient } from '@supabase/supabase-js'
       const supabase = createClient('https://<project>.supabase.co', '<your-anon-key>')
       const countries = ref([])
 

--- a/apps/docs/pages/guides/getting-started/quickstarts/nuxtjs.mdx
+++ b/apps/docs/pages/guides/getting-started/quickstarts/nuxtjs.mdx
@@ -88,6 +88,7 @@ export const meta = {
 
       ```vue src/App.vue
       <script setup>
+      import {createClient} from '@supabase/supabase-js'
       const supabase = createClient('https://<project>.supabase.co', '<your-anon-key>')
       const countries = ref([])
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update, nuxt hello world

## What is the current behavior?

with the current example a just made nuxt 3 returns a 500 error, createClient is not defined so you need to import it from the library

## What is the new behavior?

Now the example works perfectly