### PR TITLE
chore: differentiate cpu usage metrics and use avg_cpu_usage

### DIFF
--- a/studio/components/interfaces/BillingV2/Usage/Infrastructure.tsx
+++ b/studio/components/interfaces/BillingV2/Usage/Infrastructure.tsx
@@ -60,7 +60,7 @@ const Infrastructure = ({
 
   const { data: cpuUsageData, isLoading: isLoadingCpuUsageData } = useInfraMonitoringQuery({
     projectRef,
-    attribute: 'cpu_usage',
+    attribute: 'avg_cpu_usage',
     interval,
     startDate,
     endDate,
@@ -91,7 +91,7 @@ const Infrastructure = ({
   )
 
   const chartMeta: { [key: string]: { data: DataPoint[]; isLoading: boolean } } = {
-    cpu_usage: {
+    avg_cpu_usage: {
       isLoading: isLoadingCpuUsageData,
       data: cpuUsageData?.data ?? [],
     },

--- a/studio/components/interfaces/BillingV2/Usage/Infrastructure.tsx
+++ b/studio/components/interfaces/BillingV2/Usage/Infrastructure.tsx
@@ -226,7 +226,7 @@ const Infrastructure = ({
                   </div>
                 )}
 
-                {attribute.key === 'cpu_usage' && (
+                {attribute.key === 'max_cpu_usage' && (
                   <p className="text-sm text-scale-1000">
                     Your compute instance has {currentComputeInstanceSpecs.cpu_cores} CPU cores.
                   </p>

--- a/studio/components/interfaces/BillingV2/Usage/Infrastructure.tsx
+++ b/studio/components/interfaces/BillingV2/Usage/Infrastructure.tsx
@@ -91,7 +91,7 @@ const Infrastructure = ({
   )
 
   const chartMeta: { [key: string]: { data: DataPoint[]; isLoading: boolean } } = {
-    avg_cpu_usage: {
+    max_cpu_usage: {
       isLoading: isLoadingCpuUsageData,
       data: cpuUsageData?.data ?? [],
     },

--- a/studio/components/interfaces/BillingV2/Usage/Infrastructure.tsx
+++ b/studio/components/interfaces/BillingV2/Usage/Infrastructure.tsx
@@ -60,7 +60,7 @@ const Infrastructure = ({
 
   const { data: cpuUsageData, isLoading: isLoadingCpuUsageData } = useInfraMonitoringQuery({
     projectRef,
-    attribute: 'avg_cpu_usage',
+    attribute: 'max_cpu_usage',
     interval,
     startDate,
     endDate,

--- a/studio/components/interfaces/BillingV2/Usage/Usage.constants.tsx
+++ b/studio/components/interfaces/BillingV2/Usage/Usage.constants.tsx
@@ -49,7 +49,7 @@ export const USAGE_CATEGORIES: CategoryMeta[] = [
     attributes: [
       {
         anchor: 'cpu',
-        key: 'cpu_usage',
+        key: 'max_cpu_usage',
         attribute: 'max_cpu_usage',
         name: 'CPU',
         unit: 'percentage',

--- a/studio/components/interfaces/BillingV2/Usage/Usage.constants.tsx
+++ b/studio/components/interfaces/BillingV2/Usage/Usage.constants.tsx
@@ -50,7 +50,7 @@ export const USAGE_CATEGORIES: CategoryMeta[] = [
       {
         anchor: 'cpu',
         key: 'cpu_usage',
-        attribute: 'avg_cpu_usage',
+        attribute: 'max_cpu_usage',
         name: 'CPU',
         unit: 'percentage',
         description: 'Max CPU usage of your server',

--- a/studio/components/interfaces/BillingV2/Usage/Usage.constants.tsx
+++ b/studio/components/interfaces/BillingV2/Usage/Usage.constants.tsx
@@ -53,7 +53,7 @@ export const USAGE_CATEGORIES: CategoryMeta[] = [
         attribute: 'avg_cpu_usage',
         name: 'CPU',
         unit: 'percentage',
-        description: 'Average CPU usage of your server',
+        description: 'Max CPU usage of your server',
         chartDescription: '',
         links: [
           {

--- a/studio/components/interfaces/BillingV2/Usage/Usage.constants.tsx
+++ b/studio/components/interfaces/BillingV2/Usage/Usage.constants.tsx
@@ -50,10 +50,10 @@ export const USAGE_CATEGORIES: CategoryMeta[] = [
       {
         anchor: 'cpu',
         key: 'cpu_usage',
-        attribute: 'cpu_usage',
+        attribute: 'avg_cpu_usage',
         name: 'CPU',
         unit: 'percentage',
-        description: 'CPU usage of your server',
+        description: 'Average CPU usage of your server',
         chartDescription: '',
         links: [
           {

--- a/studio/data/analytics/infra-monitoring-query.ts
+++ b/studio/data/analytics/infra-monitoring-query.ts
@@ -8,7 +8,13 @@ import { analyticsKeys } from './keys'
 
 export type InfraMonitoringVariables = {
   projectRef?: string
-  attribute: 'cpu_usage' | 'disk_io_budget' | 'ram_usage' | 'disk_io_consumption' | 'swap_usage'
+  attribute:
+    | 'max_cpu_usage'
+    | 'avg_cpu_usage'
+    | 'disk_io_budget'
+    | 'ram_usage'
+    | 'disk_io_consumption'
+    | 'swap_usage'
   startDate?: string
   endDate?: string
   interval?: '1m' | '5m' | '10m' | '30m' | '1h' | '1d'

--- a/studio/lib/constants/metrics.tsx
+++ b/studio/lib/constants/metrics.tsx
@@ -40,8 +40,14 @@ export const METRIC_CATEGORIES = {
 
 export const METRICS = [
   {
-    key: 'cpu_usage',
-    label: 'CPU % usage',
+    key: 'avg_cpu_usage',
+    label: 'Average CPU % usage',
+    provider: 'infra-monitoring',
+    category: METRIC_CATEGORIES.INSTANCE,
+  },
+  {
+    key: 'max_cpu_usage',
+    label: 'Max CPU % usage',
     provider: 'infra-monitoring',
     category: METRIC_CATEGORIES.INSTANCE,
   },

--- a/studio/tests/pages/projects/billing/Infrastructure.test.tsx
+++ b/studio/tests/pages/projects/billing/Infrastructure.test.tsx
@@ -1,0 +1,26 @@
+import { get } from 'lib/common/fetch'
+import { render } from '../../../helpers'
+import { screen } from '@testing-library/react'
+import Infrastructure from 'components/interfaces/BillingV2/Usage/Infrastructure'
+beforeEach(() => {
+  // reset mocks between tests
+  ;(get as jest.Mock).mockReset()
+  ;(get as jest.Mock).mockImplementation(async (_url: string) => {
+    console.log('url', _url)
+
+    return [{ result: [] }]
+  })
+})
+
+test(`renders category attributes static elements`, async () => {
+  render(
+    <Infrastructure
+      projectRef={'someref'}
+      startDate={new Date().toISOString()}
+      endDate={new Date().toISOString()}
+      currentBillingCycleSelected={false}
+    />
+  )
+  // renders usage categories info
+  await screen.findByText('Max CPU usage of your server')
+})

--- a/studio/tests/pages/projects/billing/Infrastructure.test.tsx
+++ b/studio/tests/pages/projects/billing/Infrastructure.test.tsx
@@ -6,8 +6,6 @@ beforeEach(() => {
   // reset mocks between tests
   ;(get as jest.Mock).mockReset()
   ;(get as jest.Mock).mockImplementation(async (_url: string) => {
-    console.log('url', _url)
-
     return [{ result: [] }]
   })
 })


### PR DESCRIPTION
Adjusts the attribute to use `avg_cpu_usage`, which is clearer which cpu usage metric is in use. 
This change is backwards compatible and does not require a companion migration to be merged, as data is stored as is when saved.
Migration will only be needed when removing support for `cpu_usage` metric on platform  api.
<img width="1110" alt="Screenshot 2023-06-24 at 3 35 47 AM" src="https://github.com/supabase/supabase/assets/22714384/59c50096-850c-4601-b69a-1df7c3597be7">
