### PR TITLE
fix(studio): auto docs js examples to include select()

### DIFF
--- a/studio/components/to-be-cleaned/Docs/Snippets.js
+++ b/studio/components/to-be-cleaned/Docs/Snippets.js
@@ -378,6 +378,7 @@ const { data, error } = await supabase
   .insert([
     { some_column: 'someValue', other_column: 'otherValue' },
   ])
+  .select()
 `,
     },
   }),
@@ -402,6 +403,7 @@ const { data, error } = await supabase
     { some_column: 'someValue' },
     { some_column: 'otherValue' },
   ])
+  .select()
 `,
     },
   }),
@@ -423,7 +425,8 @@ curl -X POST '${endpoint}/rest/v1/${resourceId}' \\
       code: `
 const { data, error } = await supabase
   .from('${resourceId}')
-  .upsert({ some_column: 'someValue' }).select()
+  .upsert({ some_column: 'someValue' })
+  .select()
 `,
     },
   }),
@@ -447,6 +450,7 @@ const { data, error } = await supabase
   .from('${resourceId}')
   .update({ other_column: 'otherValue' })
   .eq('some_column', 'someValue')
+  .select()
 `,
     },
   }),
@@ -463,7 +467,7 @@ curl -X DELETE '${endpoint}/rest/v1/${resourceId}?some_column=eq.someValue' \\
     js: {
       language: 'js',
       code: `
-const { data, error } = await supabase
+const { error } = await supabase
   .from('${resourceId}')
   .delete()
   .eq('some_column', 'someValue')


### PR DESCRIPTION
In the studio auto generated docs, we should include a chained `select()` call at the end of our `insert/upsert/update` JS examples if we are going to return `{ data }`:

![image](https://github.com/supabase/supabase/assets/4133076/5d85a132-8cac-4d3a-8a2c-4d718ed261c3)
