### PR TITLE
[Supabase Studio] Fix web manifest unauthorized fetch

### DIFF
--- a/studio/components/head/Favicons.tsx
+++ b/studio/components/head/Favicons.tsx
@@ -42,7 +42,11 @@ const Favicons = () => {
       <link rel="shortcut icon" href={`${basePath}/favicon/favicon.ico`} />
       <link rel="icon" type="image/png" href={`${basePath}/favicon/favicon.ico`} />
       {/* misc */}
-      <link rel="manifest" href={`${basePath}/favicon/site.webmanifest`} crossorigin="use-credentials" />
+      <link
+        rel="manifest"
+        href={`${basePath}/favicon/site.webmanifest`}
+        crossOrigin="use-credentials"
+      />
       <link rel="alternate" type="application/rss+xml" href={`${basePath}/feed.xml`} />
       <link rel="apple-touch-icon" href={`${basePath}/favicon/favicon.ico`} />
       <meta name="msapplication-config" content={`${basePath}/favicon/browserconfig.xml`} />

--- a/studio/components/head/Favicons.tsx
+++ b/studio/components/head/Favicons.tsx
@@ -42,7 +42,7 @@ const Favicons = () => {
       <link rel="shortcut icon" href={`${basePath}/favicon/favicon.ico`} />
       <link rel="icon" type="image/png" href={`${basePath}/favicon/favicon.ico`} />
       {/* misc */}
-      <link rel="manifest" href={`${basePath}/favicon/site.webmanifest`} />
+      <link rel="manifest" href={`${basePath}/favicon/site.webmanifest`} crossorigin="use-credentials" />
       <link rel="alternate" type="application/rss+xml" href={`${basePath}/feed.xml`} />
       <link rel="apple-touch-icon" href={`${basePath}/favicon/favicon.ico`} />
       <meta name="msapplication-config" content={`${basePath}/favicon/browserconfig.xml`} />


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix
## What is the current behavior?

Fetching Web Manifest fails when using Supabase studio behind basic authorization gateways.
According to [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin#example_web_manifest_with_credentials) we should use `crossorigin="use-credentials"` in the web manifest link tag.

## What is the new behavior?

Credentials are passed to the web manifest fetch. and the fetch is successful. 

## Additional context
Fetching Fails with 401 Unauthorized.

![image](https://github.com/supabase/supabase/assets/13420623/bea8135e-f2e1-45f5-8c2b-86abde8e2e41)
