### PR TITLE
Chore: Update link to use public video instead of unlisted

### DIFF
--- a/apps/docs/pages/guides/auth/auth-helpers/nextjs.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/nextjs.mdx
@@ -626,7 +626,7 @@ const supabase = createClientComponentClient({ isSingleton: false })
 
 <div className="video-container">
   <iframe
-    src="https://www.youtube-nocookie.com/embed/SUS1t6Kq7-8"
+    src="https://www.youtube-nocookie.com/embed/ywvXGW6P4Gs"
     frameBorder="1"
     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
     allowFullScreen


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

Link points to `unlisted` video

## What is the new behavior?

Link points to `public` video
