### PR TITLE
chore: add right margins for token message

### DIFF
--- a/studio/components/ui/Forms/FormHeader.tsx
+++ b/studio/components/ui/Forms/FormHeader.tsx
@@ -1,8 +1,16 @@
 import ReactMarkdown from 'react-markdown'
 
-const FormHeader = ({ title, description }: { title: string; description?: string }) => {
+const FormHeader = ({
+  title,
+  description,
+  className,
+}: {
+  title: string
+  description?: string
+  className?: string
+}) => {
   return (
-    <div className="mb-6">
+    <div className={`mb-6 ${className}`}>
       <h3 className="text-scale-1200 mb-2 text-xl">
         <ReactMarkdown unwrapDisallowed disallowedElements={['p']}>
           {title}

--- a/studio/pages/account/tokens.tsx
+++ b/studio/pages/account/tokens.tsx
@@ -20,7 +20,8 @@ const UserAccessTokens: NextPageWithLayout = () => {
       <div className="flex items-center justify-between">
         <FormHeader
           title="Access Tokens"
-          description="Personal access tokens can be used with our management API or the Supabase CLI. These tokens will have the same permissions as you have."
+          description="Personal access tokens can be used with our management API or the Supabase CLI. These tokens will have the same permissions as your user account."
+          className="mr-4"
         />
         <div className="flex items-center space-x-4 mb-6">
           <div className="flex items-center space-x-2">


### PR DESCRIPTION
## What kind of change does this PR introduce?

follow up https://github.com/supabase/supabase/pull/15263

## What is the new behavior?

Add right margin to wrap lines nicely on small screens.

## Additional context

Before:
<img width="888" alt="Screenshot 2023-06-26 at 1 52 13 AM" src="https://github.com/supabase/supabase/assets/1639722/ea03c8c5-8367-4b47-a07d-45827405809f">

After:
<img width="888" alt="Screenshot 2023-06-26 at 1 52 46 AM" src="https://github.com/supabase/supabase/assets/1639722/de626ca4-b1f2-413f-af4d-192c0d21246a">
