### PR TITLE
Feat: Add telemetry to billing

### DIFF
--- a/studio/components/interfaces/BillingV2/Subscription/AddOns/ComputeInstanceSidePanel.tsx
+++ b/studio/components/interfaces/BillingV2/Subscription/AddOns/ComputeInstanceSidePanel.tsx
@@ -12,6 +12,7 @@ import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
 import { useSubscriptionPageStateSnapshot } from 'state/subscription-page'
 import { Alert, Button, IconExternalLink, Modal, Radio, SidePanel } from 'ui'
+import Telemetry from 'lib/telemetry'
 
 const COMPUTE_CATEGORY_OPTIONS: {
   id: 'micro' | 'optimized'
@@ -79,6 +80,17 @@ const ComputeInstanceSidePanel = () => {
         setSelectedCategory('micro')
         setSelectedOption('ci_micro')
       }
+      Telemetry.sendActivity(
+        {
+          activity: 'Side Panel Viewed',
+          source: 'Dashboard',
+          data: {
+            title: 'Change project compute size',
+            section: 'Add ons',
+          },
+        },
+        router
+      )
     }
   }, [visible, isLoading])
 
@@ -169,6 +181,18 @@ const ComputeInstanceSidePanel = () => {
                       onClick={() => {
                         setSelectedCategory(option.id)
                         if (option.id === 'micro') setSelectedOption('ci_micro')
+                        Telemetry.sendActivity(
+                          {
+                            activity: 'Option Selected',
+                            source: 'Dashboard',
+                            data: {
+                              title: 'Change project compute size',
+                              section: 'Add ons',
+                              option: option.name,
+                            },
+                          },
+                          router
+                        )
                       }}
                     >
                       <img

--- a/studio/components/interfaces/BillingV2/Subscription/AddOns/CustomDomainSidePanel.tsx
+++ b/studio/components/interfaces/BillingV2/Subscription/AddOns/CustomDomainSidePanel.tsx
@@ -10,9 +10,12 @@ import Link from 'next/link'
 import { useEffect, useState } from 'react'
 import { useSubscriptionPageStateSnapshot } from 'state/subscription-page'
 import { Alert, Button, IconExternalLink, Radio, SidePanel } from 'ui'
+import Telemetry from 'lib/telemetry'
+import { useRouter } from 'next/router'
 
 const CustomDomainSidePanel = () => {
   const { ui } = useStore()
+  const router = useRouter()
   const { ref: projectRef } = useParams()
 
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false)
@@ -51,6 +54,17 @@ const CustomDomainSidePanel = () => {
       } else {
         setSelectedOption('cd_none')
       }
+      Telemetry.sendActivity(
+        {
+          activity: 'Side Panel Viewed',
+          source: 'Dashboard',
+          data: {
+            title: 'Custom domains',
+            section: 'Add ons',
+          },
+        },
+        router
+      )
     }
   }, [visible, isLoading])
 

--- a/studio/components/interfaces/BillingV2/Subscription/AddOns/CustomDomainSidePanel.tsx
+++ b/studio/components/interfaces/BillingV2/Subscription/AddOns/CustomDomainSidePanel.tsx
@@ -142,7 +142,21 @@ const CustomDomainSidePanel = () => {
               type="large-cards"
               size="tiny"
               id="custom-domain"
-              onChange={(event: any) => setSelectedOption(event.target.value)}
+              onChange={(event: any) => {
+                setSelectedOption(event.target.value)
+                Telemetry.sendActivity(
+                  {
+                    activity: 'Option Selected',
+                    source: 'Dashboard',
+                    data: {
+                      title: 'Custom domains',
+                      section: 'Add ons',
+                      option: event.target.label,
+                    },
+                  },
+                  router
+                )
+              }}
             >
               <Radio
                 name="custom-domain"

--- a/studio/components/interfaces/BillingV2/Subscription/AddOns/PITRSidePanel.tsx
+++ b/studio/components/interfaces/BillingV2/Subscription/AddOns/PITRSidePanel.tsx
@@ -11,6 +11,8 @@ import Link from 'next/link'
 import { useEffect, useState } from 'react'
 import { useSubscriptionPageStateSnapshot } from 'state/subscription-page'
 import { Alert, Button, IconExternalLink, Radio, SidePanel } from 'ui'
+import Telemetry from 'lib/telemetry'
+import { useRouter } from 'next/router'
 
 const PITR_CATEGORY_OPTIONS: {
   id: 'off' | 'on'
@@ -34,6 +36,7 @@ const PITR_CATEGORY_OPTIONS: {
 
 const PITRSidePanel = () => {
   const { ui } = useStore()
+  const router = useRouter()
   const { ref: projectRef } = useParams()
   const { isDarkMode } = useTheme()
 
@@ -72,6 +75,17 @@ const PITRSidePanel = () => {
         setSelectedCategory('off')
         setSelectedOption('pitr_0')
       }
+      Telemetry.sendActivity(
+        {
+          activity: 'Side Panel Viewed',
+          source: 'Dashboard',
+          data: {
+            title: 'Point in Time Recovery',
+            section: 'Add ons',
+          },
+        },
+        router
+      )
     }
   }, [visible, isLoading])
 
@@ -152,6 +166,18 @@ const PITRSidePanel = () => {
                     onClick={() => {
                       setSelectedCategory(option.id)
                       if (option.id === 'off') setSelectedOption('pitr_0')
+                      Telemetry.sendActivity(
+                        {
+                          activity: 'Option Selected',
+                          source: 'Dashboard',
+                          data: {
+                            title: 'Point in Time Recovery',
+                            section: 'Add ons',
+                            option: option.name,
+                          },
+                        },
+                        router
+                      )
                     }}
                   >
                     <img

--- a/studio/components/interfaces/BillingV2/Subscription/CostControl/SpendCapSidePanel.tsx
+++ b/studio/components/interfaces/BillingV2/Subscription/CostControl/SpendCapSidePanel.tsx
@@ -11,6 +11,8 @@ import { useSubscriptionPageStateSnapshot } from 'state/subscription-page'
 import { Alert, Button, Collapsible, IconChevronRight, IconExternalLink, SidePanel } from 'ui'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { pricing } from 'shared-data/pricing'
+import Telemetry from 'lib/telemetry'
+import { useRouter } from 'next/router'
 
 const SPEND_CAP_OPTIONS: {
   name: string
@@ -34,6 +36,7 @@ const SPEND_CAP_OPTIONS: {
 
 const SpendCapSidePanel = () => {
   const { ui } = useStore()
+  const router = useRouter()
   const { ref: projectRef } = useParams()
   const { isDarkMode } = useTheme()
 
@@ -58,6 +61,17 @@ const SpendCapSidePanel = () => {
   useEffect(() => {
     if (visible && subscription !== undefined) {
       setSelectedOption(isSpendCapOn ? 'on' : 'off')
+      Telemetry.sendActivity(
+        {
+          activity: 'Side Panel Viewed',
+          source: 'Dashboard',
+          data: {
+            title: 'Spend cap',
+            section: 'Cost Control',
+          },
+        },
+        router
+      )
     }
   }, [visible, isLoading, subscription, isSpendCapOn])
 

--- a/studio/components/interfaces/BillingV2/Subscription/CostControl/SpendCapSidePanel.tsx
+++ b/studio/components/interfaces/BillingV2/Subscription/CostControl/SpendCapSidePanel.tsx
@@ -220,7 +220,21 @@ const SpendCapSidePanel = () => {
                   <div
                     key={option.value}
                     className={clsx('col-span-4 group space-y-1', isFreePlan && 'opacity-75')}
-                    onClick={() => !isFreePlan && setSelectedOption(option.value)}
+                    onClick={() => {
+                      !isFreePlan && setSelectedOption(option.value)
+                      Telemetry.sendActivity(
+                        {
+                          activity: 'Option Selected',
+                          source: 'Dashboard',
+                          data: {
+                            title: 'Spend cap',
+                            section: 'Cost Control',
+                            option: option.name,
+                          },
+                        },
+                        router
+                      )
+                    }}
                   >
                     <img
                       alt="Spend Cap"

--- a/studio/components/interfaces/BillingV2/Subscription/Tier/TierUpdateSidePanel.tsx
+++ b/studio/components/interfaces/BillingV2/Subscription/Tier/TierUpdateSidePanel.tsx
@@ -19,9 +19,12 @@ import { useProjectSubscriptionV2Query } from 'data/subscriptions/project-subscr
 import { PRICING_TIER_PRODUCT_IDS } from 'lib/constants'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import * as Tooltip from '@radix-ui/react-tooltip'
+import Telemetry from 'lib/telemetry'
+import { useRouter } from 'next/router'
 
 const TierUpdateSidePanel = () => {
   const { ui } = useStore()
+  const router = useRouter()
   const slug = ui.selectedOrganization?.slug
   const { ref: projectRef } = useParams()
 
@@ -58,6 +61,16 @@ const TierUpdateSidePanel = () => {
   useEffect(() => {
     if (visible) {
       setSelectedTier(undefined)
+      Telemetry.sendActivity(
+        {
+          activity: 'Side Panel Viewed',
+          source: 'Dashboard',
+          data: {
+            side_panel_title: 'Change Subscription Plan',
+          },
+        },
+        router
+      )
     }
   }, [visible])
 

--- a/studio/components/interfaces/BillingV2/Subscription/Tier/TierUpdateSidePanel.tsx
+++ b/studio/components/interfaces/BillingV2/Subscription/Tier/TierUpdateSidePanel.tsx
@@ -66,7 +66,8 @@ const TierUpdateSidePanel = () => {
           activity: 'Side Panel Viewed',
           source: 'Dashboard',
           data: {
-            side_panel_title: 'Change Subscription Plan',
+            title: 'Change Subscription Plan',
+            section: 'Subscription plan',
           },
         },
         router
@@ -205,7 +206,22 @@ const TierUpdateSidePanel = () => {
                                 !canUpdateSubscription
                               }
                               type={isDowngradeOption ? 'default' : 'primary'}
-                              onClick={() => setSelectedTier(plan.id as any)}
+                              onClick={() => {
+                                setSelectedTier(plan.id as any)
+                                Telemetry.sendActivity(
+                                  {
+                                    activity: 'Popup Viewed',
+                                    source: 'Dashboard',
+                                    data: {
+                                      title: isDowngradeOption
+                                        ? 'Downgrade'
+                                        : 'Upgrade' + ' to ' + plan.name,
+                                      section: 'Subscription plan',
+                                    },
+                                  },
+                                  router
+                                )
+                              }}
                             >
                               {isDowngradeOption ? 'Downgrade' : 'Upgrade'} to {plan.name}
                             </Button>

--- a/studio/lib/telemetry.ts
+++ b/studio/lib/telemetry.ts
@@ -81,11 +81,11 @@ const sendActivity = (
     ...(projectRef && { projectRef }),
     ...(router.route.includes('/project/') &&
       !projectRef && {
-        projectRef: router.route.split('/project/')[1].split('/')[0],
+        projectRef: router.asPath.split('/project/')[1].split('/')[0],
       }),
     ...(orgId && { orgId }),
     ...(router.route.includes('/org/') &&
-      !orgId && { orgId: router.route.split('/org/')[1].split('/')[0] }),
+      !orgId && { orgId: router.asPath.split('/org/')[1].split('/')[0] }),
   }
   return post(`${API_URL}/telemetry/activity`, properties)
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Now we can see in mixpanel (for billing related stuff only) when a user opens side panel and selects options. Focus mainly on free and pro users because we want to understand before-upgrade behaviour 
