### PR TITLE
fix(docs): home page resources link

### DIFF
--- a/apps/docs/pages/index.mdx
+++ b/apps/docs/pages/index.mdx
@@ -88,7 +88,7 @@ export const meta = {
 
         <TextLink
           label="Explore more resources"
-          url="/docs/guides/resources"
+          url="/guides/resources"
           className="no-underline text-brand-900 text-sm"
         />
       </div>


### PR DESCRIPTION
This link on the docs home page
https://supabase.com/docs
![image](https://github.com/supabase/supabase/assets/4133076/8fef38a5-8a53-4f28-8c15-4eb449c3cb6c)

currently takes us to: https://supabase.com/docs/docs/guides/resources (double `/docs`)

instead of: https://supabase.com/docs/guides/resources 