### PR TITLE
fix(docs): update broken oauth examples

### DIFF
--- a/apps/docs/pages/guides/auth.mdx
+++ b/apps/docs/pages/guides/auth.mdx
@@ -100,7 +100,7 @@ const getURL = () => {
 };
 
 const { data, error } = await supabase.auth.signInWithOAuth({
-  provider: 'github'
+  provider: 'github',
   options: {
     redirectTo: getURL()
   }

--- a/spec/examples/examples.yml
+++ b/spec/examples/examples.yml
@@ -240,7 +240,7 @@ functions:
         js: |
           ```js
           const { data, error } = await supabase.auth.signInWithOAuth({
-            provider: 'github'
+            provider: 'github',
             options: {
               redirectTo: 'https://example.com/welcome'
             }
@@ -255,7 +255,7 @@ functions:
         js: |
           ```js
           const { data, error } = await supabase.auth.signInWithOAuth({
-            provider: 'github'
+            provider: 'github',
             options: {
               scopes: 'repo gist notifications'
             }

--- a/spec/supabase_js_v2.yml
+++ b/spec/supabase_js_v2.yml
@@ -297,7 +297,7 @@ functions:
         code: |
           ```js
           const { data, error } = await supabase.auth.signInWithOAuth({
-            provider: 'github'
+            provider: 'github',
             options: {
               redirectTo: 'https://example.com/welcome'
             }
@@ -312,7 +312,7 @@ functions:
         code: |
           ```js
           const { data, error } = await supabase.auth.signInWithOAuth({
-            provider: 'github'
+            provider: 'github',
             options: {
               scopes: 'repo gist notifications'
             }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes broken oauth examples 

## What is the current behavior?

The current example is as follows:

```javascript
const { data, error } = await supabase.auth.signInWithOAuth({
  provider: 'github'
  options: {
    redirectTo: 'https://example.com/welcome'
  }
})
```

Please link any relevant issues here.

## What is the new behavior?

```javascript
const { data, error } = await supabase.auth.signInWithOAuth({
  provider: 'github',
  options: {
    redirectTo: 'https://example.com/welcome'
  }
})
```

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
