### PR TITLE
Fix build error in nextjs-todo-list

### DIFF
--- a/examples/todo-list/nextjs-todo-list/lib/initSupabase.ts
+++ b/examples/todo-list/nextjs-todo-list/lib/initSupabase.ts
@@ -1,7 +1,6 @@
 import { createClient } from '@supabase/supabase-js'
-import { Database } from './schema'
 
 export const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  process.env.NEXT_PUBLIC_SUPABASE_URL ?? '',
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? ''
 )


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix, resolves `yarn build` issue:

## What is the current behavior?

```
yarn build
yarn run v1.22.19
$ next build
info  - Loaded env from /home/thomas/src/todo-supabase-nextjs/.env.local
info  - Linting and checking validity of types ..Failed to compile.

./lib/initSupabase.ts:5:3
Type error: Argument of type 'string | undefined' is not assignable to parameter of type 'string'.
  Type 'undefined' is not assignable to type 'string'.

  3 | 
  4 | export const supabase = createClient(
> 5 |   process.env.NEXT_PUBLIC_SUPABASE_URL,
    |   ^
  6 |   process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
  7 | )
  8 | 
error Command failed with exit code 1.
```

## What is the new behavior?

Build succeeds

## Additional context


