### PR TITLE
docs: add supabase/functions/.env info

### DIFF
--- a/apps/docs/pages/guides/functions/secrets.mdx
+++ b/apps/docs/pages/guides/functions/secrets.mdx
@@ -12,6 +12,14 @@ It's common that you will need to use sensitive information or environment-speci
 Deno.env.get(MY_SECRET_NAME)
 ```
 
+### Local Development
+When developing functions locally, you be able to load environment variables two ways:
+
+1. Through a default `.env` file placed at `supabase/functions/.env`, which will get loaded on `supabase start`
+2. Through the `--env-file` option for `supabase functions serve`, for example: `supabase functions serve --env-file ./path/to/.env-file`
+
+To perform a one-time setup of your local development secrets, use the first option to create the `.env` file that will apply to all functions.
+
 ### Default secrets
 
 By default, Edge Functions have access to these secrets:

--- a/apps/docs/pages/guides/functions/secrets.mdx
+++ b/apps/docs/pages/guides/functions/secrets.mdx
@@ -13,6 +13,7 @@ Deno.env.get(MY_SECRET_NAME)
 ```
 
 ### Local Development
+
 When developing functions locally, you be able to load environment variables two ways:
 
 1. Through a default `.env` file placed at `supabase/functions/.env`, which will get loaded on `supabase start`


### PR DESCRIPTION
This PR adds documentation for functions env var setup.

This was discussed on [this feedback](https://www.notion.so/supabase/functions-served-by-cli-supabaise-start-does-not-have-a-way-to-load-env-var-files-for-edge-runtime-a1c99759ec654a8fa05299bb2c760d97?pvs=4)

