### PR TITLE
Fix/log event chart on click

### DIFF
--- a/studio/components/interfaces/Settings/Logs/LogEventChart.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogEventChart.tsx
@@ -1,4 +1,5 @@
 import BarChart, { BarChartProps } from 'components/ui/Charts/BarChart'
+import { Datum } from 'components/ui/Charts/Charts.types'
 import { EventChartData, isUnixMicro, LogData, unixMicroToIsoTimestamp } from '.'
 
 export interface LogEventChartProps {
@@ -12,16 +13,11 @@ const LogEventChart = ({ data, onBarClick }: LogEventChartProps) => (
     size="tiny"
     yAxisKey="count"
     xAxisKey="timestamp"
-    data={data as unknown as BarChartProps['data']}
+    data={data}
     title="Logs / Time"
-    onBarClick={(v?: { activePayload?: { payload: any }[] }) => {
-      if (!v || !v?.activePayload?.[0]?.payload) return
-      const unixOrIsoTimestamp = v.activePayload[0].payload.timestamp
-      const isoTimestamp = isUnixMicro(unixOrIsoTimestamp)
-        ? unixMicroToIsoTimestamp(unixOrIsoTimestamp)
-        : unixOrIsoTimestamp
-      // 60s before
-      onBarClick(isoTimestamp)
+    onBarClick={(datum: Datum | EventChartData) => {
+      if (!datum.timestamp) return
+      onBarClick(datum.timestamp as string)
     }}
     customDateFormat="MMM D, HH:mm:s"
   />

--- a/studio/components/interfaces/Settings/Logs/Logs.types.ts
+++ b/studio/components/interfaces/Settings/Logs/Logs.types.ts
@@ -1,3 +1,4 @@
+import { Datum } from 'components/ui/Charts/Charts.types'
 import React from 'react'
 
 interface Metadata {
@@ -49,9 +50,9 @@ export interface CountData {
   count: number
 }
 
-export interface EventChartData {
+export interface EventChartData extends Datum {
   count: number
-  timestamp: string | number
+  timestamp: string
 }
 
 type LFResponse<T> = {

--- a/studio/components/ui/Charts/BarChart.tsx
+++ b/studio/components/ui/Charts/BarChart.tsx
@@ -122,8 +122,8 @@ const BarChart = ({
       </Container>
       {data && (
         <div className="text-scale-900 -mt-9 flex items-center justify-between text-xs">
-          <span>{dayjs(data[0][xAxisKey]).format(customDateFormat)}</span>
-          <span>{dayjs(data[data?.length - 1]?.[xAxisKey]).format(customDateFormat)}</span>
+          <span>{day(data[0][xAxisKey]).format(customDateFormat)}</span>
+          <span>{day(data[data?.length - 1]?.[xAxisKey]).format(customDateFormat)}</span>
         </div>
       )}
     </div>

--- a/studio/components/ui/Charts/Charts.types.tsx
+++ b/studio/components/ui/Charts/Charts.types.tsx
@@ -28,7 +28,7 @@ export interface StackedChartProps<D> extends CommonChartProps<D> {
 export type HeaderType<D> = {
   attribute: string
   focus: number | null
-  format?: string | ((value: unknown) => string);
+  format?: string | ((value: unknown) => string)
   highlightedValue?: number | string
   highlightedLabel?: string
   data: D[]
@@ -38,9 +38,7 @@ export type HeaderType<D> = {
   displayDateInUtc?: boolean
 }
 
-export interface Datum {
-  [attribute: string]: number | string
-}
+export type Datum = Record<string, string | number>
 
 export interface TimeseriesDatum extends Datum {
   timestamp: string


### PR DESCRIPTION
Fixes 2 bugs
- log event chart should on click, was not firing due to bug in if logic
- bar chart ticks should display in utc based on prop flag.