### PR TITLE
fix: functions log event chart not showing data

### DIFF
--- a/studio/components/interfaces/Settings/Logs/Logs.utils.ts
+++ b/studio/components/interfaces/Settings/Logs/Logs.utils.ts
@@ -234,7 +234,7 @@ export const genChartQuery = (
   const where = _genWhereStatement(table, filters)
 
   let joins = 'cross join unnest(t.metadata) as metadata'
-  if (table === LogsTableName.EDGE) {
+  if (table === LogsTableName.EDGE || table === LogsTableName.FN_EDGE) {
     joins += ' \n  cross join unnest(metadata.request) as request'
     joins += ' \n  cross join unnest(metadata.response) as response'
   } else if (table === LogsTableName.POSTGRES) {


### PR DESCRIPTION
Functions edge logs with filters enable was not showing data due to missing cross joins in sql generated.
<img width="1453" alt="Screenshot 2023-06-28 at 3 48 50 AM" src="https://github.com/supabase/supabase/assets/22714384/7652588b-e2be-4246-a83e-e1a15463a9e6">
https://www.notion.so/supabase/Function-log-summary-chart-display-error-b775c8a30c4a4e349d3444b4c04c22dd?pvs=4