### PR TITLE
Doc correction: Use host.docker.internal in local development

### DIFF
--- a/apps/docs/pages/guides/functions/local-development.mdx
+++ b/apps/docs/pages/guides/functions/local-development.mdx
@@ -66,7 +66,7 @@ The `functions serve` command has hot-reloading capabilities. It will watch for 
 While serving your local Edge Function, you can invoke it using curl:
 
 ```bash
-curl --request POST 'http://localhost:54321/functions/v1/function-name' \
+curl --request POST 'http://host.docker.internal:54321/functions/v1/function-name' \
   --header 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24ifQ.625_WdcF3KHqz5amU0x2X5WWHP-OEs_4qj0ssLNHzTs' \
   --header 'Content-Type: application/json' \
   --data '{ "name":"Functions" }'
@@ -97,7 +97,7 @@ Modify the `--data '{"name":"Functions"}'` line to `--data '{"name":"World"}'` a
 
 - Edge Functions don't serve HTML content (`GET` requests that return `text/html` are rewritten to `text/plain`).
 - The `Authorization` header is required. You can use either the `ANON` key, the `SERVICE_ROLE` key, or a logged-in user's JWT.
-- The Function is proxied through the local API (`http://localhost:54321`)
+- The Function is proxied through the local API (`http://host.docker.internal:54321`)
 
 </Admonition>
 


### PR DESCRIPTION
Using localhost leads to an error:
```
FetchError: error sending request for url (http://localhost:54321/rest/v1/rpc/insert_items_dynamic): error trying to connect: tcp connect error: Cannot assign requested address (os error 99)
```

## What kind of change does this PR introduce?

Doc fix

## What is the current behavior?

Errors using current instructions, encountered by multiple people.

## What is the new behavior?

Edge function successfully connects.

## Additional context

See [discussion](https://github.com/orgs/supabase/discussions/14169#discussioncomment-6303936).