### PR TITLE
fix: edge functions beta text

### DIFF
--- a/studio/components/layouts/FunctionsLayout.tsx
+++ b/studio/components/layouts/FunctionsLayout.tsx
@@ -63,7 +63,6 @@ const FunctionsLayout: FC<Props> = ({ title, children }) => {
                 </div>
                 <div className="flex items-center space-x-4">
                   <h1 className="text-2xl text-scale-1200">Edge Functions</h1>
-                  <p className="mt-1 text-scale-1000">Beta</p>
                 </div>
               </div>
             </div>
@@ -97,7 +96,6 @@ const FunctionsLayout: FC<Props> = ({ title, children }) => {
                         Edge Functions
                       </h1>
                     </Link>
-                    <p className="mt-1 text-scale-1000">Beta</p>
                     {name && (
                       <div className="mt-1.5 flex items-center space-x-4">
                         <span className="text-scale-1000">


### PR DESCRIPTION
## What kind of change does this PR introduce?

Studio > Edge Functions

## What is the current behavior?

'Beta' appear next to Edge Functions title

## What is the new behavior?
<img width="733" alt="Screenshot 2023-06-28 at 15 20 16" src="https://github.com/supabase/supabase/assets/22655069/50d8b0dc-a7d7-4bca-aece-dcf22b709dee">

Feel free to include screenshots if it includes visual changes.

## Additional context

Closes #15411
