### PR TITLE
feat: new project header

### DIFF
--- a/studio/components/layouts/WizardLayout.tsx
+++ b/studio/components/layouts/WizardLayout.tsx
@@ -59,7 +59,7 @@ const Header: FC<any> = ({ organization, project }) => {
               </p>
             </div>
           </div>
-          <div className="flex">{/* End */}</div>
+          <div className="flex">{/* The End */}</div>
           <div className="flex items-center space-x-2">
             <HelpPopover />
             <FeedbackDropdown />

--- a/studio/components/layouts/WizardLayout.tsx
+++ b/studio/components/layouts/WizardLayout.tsx
@@ -4,6 +4,8 @@ import { IconChevronRight } from 'ui'
 import { withAuth, useFlag } from 'hooks'
 import { observer } from 'mobx-react-lite'
 import { BASE_PATH } from 'lib/constants'
+import HelpPopover from './ProjectLayout/LayoutHeader/HelpPopover'
+import FeedbackDropdown from './ProjectLayout/LayoutHeader/FeedbackDropdown'
 
 const WizardLayout: FC<any> = ({ organization, project, children }) => {
   const ongoingIncident = useFlag('ongoingIncident')
@@ -58,6 +60,10 @@ const Header: FC<any> = ({ organization, project }) => {
             </div>
           </div>
           <div className="flex">{/* End */}</div>
+          <div className="flex items-center space-x-2">
+            <HelpPopover />
+            <FeedbackDropdown />
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase Studio > New Project

## What is the current behavior?

The header on the New Project page does not have the Feedback or Help buttons.

## What is the new behavior?

Both of the buttons have now been added:

<img width="1308" alt="Screenshot 2023-06-28 at 19 30 24" src="https://github.com/supabase/supabase/assets/22655069/33943536-eb07-4bce-8e04-386e710c2a6a">


## Additional context

Closes #15426
