### PR TITLE
Update auth.mdx

### DIFF
--- a/apps/docs/pages/guides/auth.mdx
+++ b/apps/docs/pages/guides/auth.mdx
@@ -84,7 +84,7 @@ For deployments with Vercel, set the `SITE_URL` to your official site URL. Add t
 - `http://localhost:3000/**`
 - `https://*-username.vercel.app/**`
 
-Vercel provides an environment variable for the URL of the deployment called `NEXT_PUBLIC_VERCEL_URL`. See the [Vercel docs](https://vercel.com/docs/concepts/projects/environment-variables#system-environment-variables) for more details. You can use this variable to dynamically redirect depending on the environment:
+Vercel provides an environment variable for the URL of the deployment called `NEXT_PUBLIC_VERCEL_URL`. See the [Vercel docs](https://vercel.com/docs/concepts/projects/environment-variables#system-environment-variables) for more details. You can use this variable to dynamically redirect depending on the environment. You should also set the value of the environment variable called NEXT_PUBLIC_SITE_URL, this should be set to your site URL in production environment to ensure that redirects function correctly.
 
 ```js
 const getURL = () => {


### PR DESCRIPTION
Include description of the NEXT_PUBLIC_SITE_URL environment variable for completeness

## What kind of change does this PR introduce?

Docs update for redirect URLs and wildcards

## What is the current behavior?

Current docs omit reference to NEXT_PUBLIC_SITE_URL environment variable (mentioned only as a comment in the included code snippet)

## What is the new behavior?

Explanation of NEXT_PUBLIC_SITE_URL is proposed to be included in the docs text

## Additional context

The only reference to the variable is gleaned from the code comments: 
![image](https://github.com/supabase/supabase/assets/4340080/0e902330-cefb-4ba7-9c78-76631212d471)

