### PR TITLE
fix: pass avatar_url updateProfile directly

### DIFF
--- a/apps/docs/pages/guides/getting-started/tutorials/with-react.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-react.mdx
@@ -168,7 +168,7 @@ export default function Account({ session }) {
       id: user.id,
       username,
       website,
-      avatarUrl ?? avatar_url,
+      avatarUrl,
       updated_at: new Date(),
     }
 

--- a/apps/docs/pages/guides/getting-started/tutorials/with-react.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-react.mdx
@@ -176,6 +176,8 @@ export default function Account({ session }) {
 
     if (error) {
       alert(error.message)
+    } else {
+      setAvatarUrl(avatarUrl)
     }
     setLoading(false)
   }

--- a/apps/docs/pages/guides/getting-started/tutorials/with-react.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-react.mdx
@@ -158,7 +158,7 @@ export default function Account({ session }) {
     getProfile()
   }, [session])
 
-  async function updateProfile(event) {
+  async function updateProfile(event, avatarUrl) {
     event.preventDefault()
 
     setLoading(true)
@@ -168,7 +168,7 @@ export default function Account({ session }) {
       id: user.id,
       username,
       website,
-      avatar_url,
+      avatarUrl ?? avatar_url,
       updated_at: new Date(),
     }
 
@@ -378,8 +378,7 @@ return (
       url={avatar_url}
       size={150}
       onUpload={(event, url) => {
-        setAvatarUrl(url)
-        updateProfile(event)
+        updateProfile(event, url)
       }}
     />
     {/* ... */}

--- a/examples/user-management/react-user-management/src/Account.jsx
+++ b/examples/user-management/react-user-management/src/Account.jsx
@@ -51,6 +51,8 @@ export default function Account({ session }) {
 
     if (error) {
       alert(error.message)
+    } else {
+      setAvatarUrl(avatarUrl)
     }
     setLoading(false)
   }

--- a/examples/user-management/react-user-management/src/Account.jsx
+++ b/examples/user-management/react-user-management/src/Account.jsx
@@ -33,7 +33,7 @@ export default function Account({ session }) {
     getProfile()
   }, [session])
 
-  async function updateProfile(event) {
+  async function updateProfile(event, avatarUrl) {
     event.preventDefault()
 
     setLoading(true)
@@ -43,7 +43,7 @@ export default function Account({ session }) {
       id: user.id,
       username,
       website,
-      avatar_url,
+      avatarUrl,
       updated_at: new Date(),
     }
 
@@ -61,8 +61,7 @@ export default function Account({ session }) {
         url={avatar_url}
         size={150}
         onUpload={(event, url) => {
-          setAvatarUrl(url)
-          updateProfile(event)
+          updateProfile(event, url)
         }}
       />
       <div>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix in the docs

## What is the current behavior?

In the [Build a User Management App with React](https://supabase.com/docs/guides/getting-started/tutorials/with-react) tutorial [Accounts.jsx](https://github.com/supabase/supabase/blob/master/examples/user-management/react-user-management/src/Account.jsx), when you upload a avatar picture, the picture is uploaded to storage as expected however `onUpload` also calls `updateProfile` and the profile is updated before `setAvatarUrl` state is set so updateProfile updates the user profile with a null `avatar_url`

#15225 

## What is the new behavior?

The `avatar_url` is directly passed to the `updateProfile` handler, instead of setting it in state first.
