### PR TITLE
feat: enable gotrue debug flag via localstorage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42804,7 +42804,7 @@
       "license": "MIT",
       "dependencies": {
         "@headlessui/react": "^1.7.14",
-        "@supabase/gotrue-js": "^2.31.0",
+        "@supabase/gotrue-js": "^2.35.0",
         "@supabase/ui": "^0.37.0-alpha.50",
         "react-use": "^17.4.0"
       },
@@ -42817,9 +42817,9 @@
       }
     },
     "packages/common/node_modules/@supabase/gotrue-js": {
-      "version": "2.31.0",
-      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.31.0.tgz",
-      "integrity": "sha512-YcwlbbNfedlue/HVIXtYBb4fuOrs29gNOTl6AmyxPp4zryRxzFvslVN9kmLDBRUAVU9fnPJh2bgOR3chRjJX5w==",
+      "version": "2.35.0",
+      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.35.0.tgz",
+      "integrity": "sha512-bLNIrBzFNRR61qUN8VZ4iV7q+fPilWyYQi0CZlxuHBiPtVcNPTul02DbNvgvw76hNz+mB5maay/Y17lSHnSRmw==",
       "dependencies": {
         "cross-fetch": "^3.1.5"
       }

--- a/packages/common/gotrue.ts
+++ b/packages/common/gotrue.ts
@@ -1,9 +1,18 @@
 import { GoTrueClient } from '@supabase/gotrue-js'
 
 export const STORAGE_KEY = process.env.NEXT_PUBLIC_STORAGE_KEY || 'supabase.dashboard.auth.token'
+export const AUTH_DEBUG_KEY =
+  process.env.NEXT_PUBLIC_AUTH_DEBUG_KEY || 'supabase.dashboard.auth.debug'
+
+const debug =
+  process.env.NEXT_PUBLIC_IS_PLATFORM === 'true' &&
+  globalThis &&
+  globalThis.localStorage &&
+  globalThis.localStorage.getItem(AUTH_DEBUG_KEY) === 'true'
 
 export const gotrueClient = new GoTrueClient({
   url: process.env.NEXT_PUBLIC_GOTRUE_URL,
   storageKey: STORAGE_KEY,
   detectSessionInUrl: true,
+  debug,
 })

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "dependencies": {
     "@headlessui/react": "^1.7.14",
-    "@supabase/gotrue-js": "^2.31.0",
+    "@supabase/gotrue-js": "^2.35.0",
     "@supabase/ui": "^0.37.0-alpha.50",
     "react-use": "^17.4.0"
   },

--- a/studio/lib/local-storage.ts
+++ b/studio/lib/local-storage.ts
@@ -5,6 +5,7 @@ export const LOCAL_STORAGE_KEYS_ALLOWLIST = [
   'theme',
   'supabaseDarkMode',
   'supabase.dashboard.sign_in_clicks',
+  'supabase.dashboard.auth.debug',
 ]
 
 export function clearLocalStorage() {


### PR DESCRIPTION
Adds `supabase.dashboard.auth.debug` as a key to `localStorage` which if set to `true` will turn on the debug option in GoTrue. Useful for identifying difficult to debug errors like random logouts.