### PR TITLE
updated outdated and archived link for nextjs todo app example

### DIFF
--- a/apps/docs/pages/guides/resources/examples.mdx
+++ b/apps/docs/pages/guides/resources/examples.mdx
@@ -59,7 +59,7 @@ By [Fireship](https://www.youtube.com/watch?v=WiwfiVdfRIc).
 Build a basic Todo List with Supabase and your favorite frontend framework:
 
 - [Expo Todo List.](https://github.com/supabase/examples/tree/main/supabase-js-v1/todo-list/expo-todo-list)
-- [Next.js Todo List.](https://github.com/supabase/examples/tree/main/supabase-js-v1/todo-list/nextjs-todo-list)
+- [Next.js Todo List.](https://github.com/supabase/supabase/tree/master/examples/todo-list/nextjs-todo-list)
 - [React Todo List.](https://github.com/supabase/examples/tree/main/supabase-js-v1/todo-list/react-todo-list)
 - [Svelte Todo List.](https://github.com/supabase/supabase/tree/master/examples/todo-list/sveltejs-todo-list)
 - [Vue 3 Todo List (Typescript).](https://github.com/supabase/examples/tree/main/supabase-js-v1/todo-list/vue3-ts-todo-list)


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR updates the archived and outdated link for nextjs example todo list app.

## What is the current behavior?

For issue: https://github.com/supabase/supabase/issues/15483

## What is the new behavior?

After merge example will point to this repo https://github.com/supabase/supabase/tree/master/examples/todo-list/nextjs-todo-list

