### PR TITLE
Replace link that points to achieved Nextjs Tod examples with correct link

### DIFF
--- a/apps/docs/pages/guides/resources/examples.mdx
+++ b/apps/docs/pages/guides/resources/examples.mdx
@@ -59,7 +59,7 @@ By [Fireship](https://www.youtube.com/watch?v=WiwfiVdfRIc).
 Build a basic Todo List with Supabase and your favorite frontend framework:
 
 - [Expo Todo List.](https://github.com/supabase/examples/tree/main/supabase-js-v1/todo-list/expo-todo-list)
-- [Next.js Todo List.](https://github.com/supabase/examples/tree/main/supabase-js-v1/todo-list/nextjs-todo-list)
+- [Next.js Todo List.](https://github.com/supabase/supabase/tree/master/examples/todo-list/nextjs-todo-list)
 - [React Todo List.](https://github.com/supabase/examples/tree/main/supabase-js-v1/todo-list/react-todo-list)
 - [Svelte Todo List.](https://github.com/supabase/supabase/tree/master/examples/todo-list/sveltejs-todo-list)
 - [Vue 3 Todo List (Typescript).](https://github.com/supabase/examples/tree/main/supabase-js-v1/todo-list/vue3-ts-todo-list)


### PR DESCRIPTION
The Next.js Todo link points to the archived example.

Link should point to > 
https://github.com/supabase/supabase/tree/master/examples/todo-list/nextjs-todo-list

but it was the old one: https://github.com/supabase/examples-archive/tree/main/supabase-js-v1/todo-list/nextjs-todo-list

This commit fixes that.

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
