### PR TITLE
Chore: update link to use public video instead of unlisted

### DIFF
--- a/apps/docs/pages/guides/auth/auth-helpers/nextjs.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/nextjs.mdx
@@ -696,7 +696,7 @@ Check out the [Next.js auth example repo](https://github.com/supabase/supabase/t
 
 <div className="video-container">
   <iframe
-    src="https://www.youtube-nocookie.com/embed/B5TUzTKO9CE"
+    src="https://www.youtube-nocookie.com/embed/4_epZIxqCho"
     frameBorder="1"
     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
     allowFullScreen


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

Server Actions link uses `unlisted` version of video

## What is the new behavior?

Server Actions link uses `public` version of video
