### PR TITLE
feat: avoid modifier keys and modifier key bindings to trigger input …

### DIFF
--- a/packages/ui/src/components/Command/Command.utils.tsx
+++ b/packages/ui/src/components/Command/Command.utils.tsx
@@ -408,8 +408,10 @@ export function useAutoInputFocus() {
 
   // Focus the input when typing from anywhere
   React.useEffect(() => {
-    function isModifierNotShift(event: KeyboardEvent) {
-      return event.key.length !== 1 && event.key !== 'Shift'
+    function isModifierKey(event: KeyboardEvent) {
+      const modifierKeys = ['Alt', 'Control', 'Meta', 'Tab']
+      const { key } = event
+      return modifierKeys.includes(key)
     }
 
     // Keep track of whether the modifier key (except shift) is pressed
@@ -417,7 +419,7 @@ export function useAutoInputFocus() {
 
     function onKeyDown(event: KeyboardEvent) {
       // If the user is typing a modifier key, don't focus the input and set the modifierPressed flag
-      if (isModifierNotShift(event)) {
+      if (isModifierKey(event)) {
         modifierPressed = true
       } else {
         if (!modifierPressed) {
@@ -428,7 +430,7 @@ export function useAutoInputFocus() {
     }
     function onKeyUp(event: KeyboardEvent) {
       console.log('keyup')
-      if (isModifierNotShift(event)) {
+      if (isModifierKey(event)) {
         // Reset the modifierPressed flag when the modifier key is released
         modifierPressed = false
       }

--- a/packages/ui/src/components/Command/Command.utils.tsx
+++ b/packages/ui/src/components/Command/Command.utils.tsx
@@ -408,40 +408,16 @@ export function useAutoInputFocus() {
 
   // Focus the input when typing from anywhere
   React.useEffect(() => {
-    function isModifierKey(event: KeyboardEvent) {
-      const modifierKeys = ['Alt', 'Control', 'Meta', 'Tab']
-      const { key } = event
-      return modifierKeys.includes(key)
-    }
-
-    // Keep track of whether the modifier key (except shift) is pressed
-    let modifierPressed = false
-
-    function onKeyDown(event: KeyboardEvent) {
-      // If the user is typing a modifier key, don't focus the input and set the modifierPressed flag
-      if (isModifierKey(event)) {
-        modifierPressed = true
-      } else {
-        if (!modifierPressed) {
-          // Focus the input if no modifier key is pressed (other than shift)
-          input?.focus()
-        }
-      }
-    }
-    function onKeyUp(event: KeyboardEvent) {
-      console.log('keyup')
-      if (isModifierKey(event)) {
-        // Reset the modifierPressed flag when the modifier key is released
-        modifierPressed = false
+    function onKeyDown(e: KeyboardEvent) {
+      if (!e.ctrlKey && !e.altKey && !e.metaKey && e.key !== 'Tab') {
+        input?.focus()
       }
     }
 
     window.addEventListener('keydown', onKeyDown)
-    window.addEventListener('keyup', onKeyUp)
 
     return () => {
       window.removeEventListener('keydown', onKeyDown)
-      window.removeEventListener('keyup', onKeyUp)
     }
   }, [input])
 

--- a/packages/ui/src/components/Command/Command.utils.tsx
+++ b/packages/ui/src/components/Command/Command.utils.tsx
@@ -408,14 +408,38 @@ export function useAutoInputFocus() {
 
   // Focus the input when typing from anywhere
   React.useEffect(() => {
-    function onKeyDown() {
-      input?.focus()
+    function isModifierNotShift(event: KeyboardEvent) {
+      return event.key.length !== 1 && event.key !== 'Shift'
+    }
+
+    // Keep track of whether the modifier key (except shift) is pressed
+    let modifierPressed = false
+
+    function onKeyDown(event: KeyboardEvent) {
+      // If the user is typing a modifier key, don't focus the input and set the modifierPressed flag
+      if (isModifierNotShift(event)) {
+        modifierPressed = true
+      } else {
+        if (!modifierPressed) {
+          // Focus the input if no modifier key is pressed (other than shift)
+          input?.focus()
+        }
+      }
+    }
+    function onKeyUp(event: KeyboardEvent) {
+      console.log('keyup')
+      if (isModifierNotShift(event)) {
+        // Reset the modifierPressed flag when the modifier key is released
+        modifierPressed = false
+      }
     }
 
     window.addEventListener('keydown', onKeyDown)
+    window.addEventListener('keyup', onKeyUp)
 
     return () => {
       window.removeEventListener('keydown', onKeyDown)
+      window.removeEventListener('keyup', onKeyUp)
     }
   }, [input])
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Changes the behavior of the keydown listener in the useAutoInputFocus hook. It nows checks if the key pressed is a modifier (except shift) or if a modifier is currently pressed and if it is, it does not trigger focus on the input.

## What is the current behavior?

Issue #15475 

Fixes bug where any key clicked will trigger focus on the AI assistant input. This avoids, for example, users from copying code from the AI output.


## What is the new behavior?

Now only shift, letter, number or symbols keys (and only in case no other modifier key is currently pressed) trigger the focus behavior.

## Additional context

I decided to use the hacky solution where you check if the event.key length is different than one - all letters, numbers and symbols are only one 'character' long. This avoids us having to create a long list of possibilities and miss any important modifier by chance.

I also left 'shift'  out of the modifier groups assuming some people (like me) always start phrases with capital letters.