### PR TITLE
docs: fix broken link to tutorial repo

### DIFF
--- a/apps/docs/pages/guides/getting-started/tutorials/with-nextjs.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-nextjs.mdx
@@ -978,7 +978,7 @@ At this stage you have a fully functional application!
 
 ## See also
 
-- See the complete [example on GitHub](https://github.com/supabase/supabase/tree/master/examples/user-management/nextjs-ts-user-management) and deploy it to Vercel
+- See the complete [example on GitHub](https://github.com/supabase/supabase/tree/master/examples/user-management/nextjs-user-management) and deploy it to Vercel
 - Explore the [pre-built Auth UI for React](/docs/guides/auth/auth-helpers/auth-ui)
 - Explore the [Auth Helpers for Next.js](/docs/guides/auth/auth-helpers/nextjs)
 - Explore the [Supabase Cache Helpers](https://github.com/psteinroe/supabase-cache-helpers)


### PR DESCRIPTION
## What kind of change does this PR introduce?
The name of the example seems to have changed, this fixes the Github link
