### PR TITLE
Import supabase env vars

### DIFF
--- a/apps/docs/pages/guides/auth/auth-helpers/sveltekit.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/sveltekit.mdx
@@ -261,6 +261,7 @@ To utilize Supabase in shared load functions and within pages, it is essential t
 // src/routes/+layout.js
 import { PUBLIC_SUPABASE_ANON_KEY, PUBLIC_SUPABASE_URL } from '$env/static/public'
 import { createSupabaseLoadClient } from '@supabase/auth-helpers-sveltekit'
+import { PUBLIC_SUPABASE_ANON_KEY, PUBLIC_SUPABASE_URL } from '$env/static/public';
 
 export const load = async ({ fetch, data, depends }) => {
   depends('supabase:auth')


### PR DESCRIPTION
Env var imports are missing for `PUBLIC_SUPABASE_ANON_KEY`, `PUBLIC_SUPABASE_URL`

## What kind of change does this PR introduce?

Docs

## What is the current behavior?

na

## What is the new behavior?

Imports for all env vars

## Additional context

Add any other context or screenshots.
