### PR TITLE
Import missing "fail" import

### DIFF
--- a/apps/docs/pages/guides/auth/auth-helpers/sveltekit.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/sveltekit.mdx
@@ -416,6 +416,8 @@ We can access the supabase instance in our `+page.svelte` file through the data 
 
 ```js src/routes/login/+page.server.js
 // src/routes/login/+page.server.js
+import { fail } from '@sveltejs/kit'
+
 export const actions = {
   default: async ({ request, url, locals: { supabase } }) => {
     const formData = await request.formData()


### PR DESCRIPTION
Must import `fail` method from SvelteKit in the +page.server example

## What kind of change does this PR introduce?

Docs

## What is the current behavior?

na

## What is the new behavior?

Makes copy/pasting error free

## Additional context

Add any other context or screenshots.
