### PR TITLE
docs: remove -ts- from next user management repo names and url throughout the docs

### DIFF
--- a/apps/docs/pages/guides/getting-started/tutorials/with-nextjs.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-nextjs.mdx
@@ -978,7 +978,7 @@ At this stage you have a fully functional application!
 
 ## See also
 
-- See the complete [example on GitHub](https://github.com/supabase/supabase/tree/master/examples/user-management/nextjs-ts-user-management) and deploy it to Vercel
+- See the complete [example on GitHub](https://github.com/supabase/supabase/tree/master/examples/user-management/nextjs-user-management) and deploy it to Vercel
 - Explore the [pre-built Auth UI for React](/docs/guides/auth/auth-helpers/auth-ui)
 - Explore the [Auth Helpers for Next.js](/docs/guides/auth/auth-helpers/nextjs)
 - Explore the [Supabase Cache Helpers](https://github.com/psteinroe/supabase-cache-helpers)

--- a/apps/docs/pages/guides/resources/examples.mdx
+++ b/apps/docs/pages/guides/resources/examples.mdx
@@ -69,7 +69,7 @@ Build a basic Todo List with Supabase and your favorite frontend framework:
 ### Auth examples
 
 - [Supabase Auth with vanilla JavaScript.](https://github.com/supabase/examples/tree/main/supabase-js-v1/auth/javascript-auth). Use Supabase without any frontend frameworks.
-- [Supabase Auth with Next.js](https://github.com/supabase/supabase/tree/master/examples/user-management/nextjs-ts-user-management).
+- [Supabase Auth with Next.js](https://github.com/supabase/supabase/tree/master/examples/user-management/nextjs-user-management).
 - [Supabase Auth with RedwoodJS.](https://redwood-playground-auth.netlify.app/supabase) Try out Supabase authentication in the [RedwoodJS](https://redwoodjs.com) Authentication Playground complete with OAuth support and code samples.
 
 ### Collaborative

--- a/apps/www/pages/storage/Storage.tsx
+++ b/apps/www/pages/storage/Storage.tsx
@@ -153,9 +153,9 @@ function StoragePage() {
                   author={'supabase'}
                   author_url={'https://github.com/supabase'}
                   author_img={'https://avatars.githubusercontent.com/u/54469796'}
-                  repo_name={'nextjs-ts-user-management'}
+                  repo_name={'nextjs-user-management'}
                   repo_url={
-                    'https://github.com/supabase/supabase/tree/master/examples/user-management/nextjs-ts-user-management'
+                    'https://github.com/supabase/supabase/tree/master/examples/user-management/nextjs-user-management'
                   }
                   vercel_deploy_url={
                     'https://vercel.com/new/git/external?repository-url=https%3A%2F%2Fgithub.com%2Fsupabase%2Fsupabase%2Ftree%2Fmaster%2Fexamples%2Fuser-mangement%2Fnextjs-ts-user-management&project-name=supabase-user-management&repository-name=supabase-user-management&demo-title=Supabase%20User%20Management&demo-description=An%20example%20web%20app%20using%20Supabase%20and%20Next.js&demo-url=https%3A%2F%2Fsupabase-nextjs-ts-user-management.vercel.app&demo-image=https%3A%2F%2Fi.imgur.com%2FZ3HkQqe.png&integration-ids=oac_jUduyjQgOyzev1fjrW83NYOv&external-id=nextjs-user-management'


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix url and repo name for Next.js authentication/user management example

## What is the current behavior?

navigates to https://github.com/supabase/supabase/tree/master/examples/user-management/nextjs-ts-user-management which is 404

## What is the new behavior?
navigates to https://github.com/supabase/supabase/tree/master/examples/user-management/nextjs-user-management


## Additional context

Fix issue #15543 