### PR TITLE
Disk io warning to make clear what is happening now and what has happened in the past

### DIFF
--- a/studio/components/interfaces/BillingV2/Usage/Infrastructure.tsx
+++ b/studio/components/interfaces/BillingV2/Usage/Infrastructure.tsx
@@ -85,14 +85,17 @@ const Infrastructure = ({
     dateFormat,
   })
 
+  const hasLatest = dayjs(endDate!).isAfter(dayjs().startOf('day'))
+
+  const latestIoBudgetConsumption =
+    hasLatest && ioBudgetData?.data?.slice(-1)
+      ? Number(ioBudgetData.data.slice(-1)[0].disk_io_consumption)
+      : 0
+
   const highestIoBudgetConsumption = Math.max(
     ...(ioBudgetData?.data || []).map((x) => Number(x.disk_io_consumption) ?? 0),
     0
   )
-
-  const latestIoBudgetConsumption = ioBudgetData?.data.slice(-1)
-    ? Number(ioBudgetData?.data.slice(-1)[0].disk_io_consumption)
-    : 0
 
   const chartMeta: { [key: string]: { data: DataPoint[]; isLoading: boolean } } = {
     max_cpu_usage: {
@@ -122,7 +125,7 @@ const Infrastructure = ({
             <SectionContent section={attribute}>
               {attribute.key === 'disk_io_consumption' && (
                 <>
-                  {latestIoBudgetConsumption >= 100 ? (
+                  {hasLatest && latestIoBudgetConsumption >= 100 ? (
                     <Alert withIcon variant="danger" title="Your Disk IO Budget has been used up">
                       <p className="mb-4">
                         Your workload has used up all your Disk IO Budget and is now running at the

--- a/studio/components/interfaces/BillingV2/Usage/Infrastructure.tsx
+++ b/studio/components/interfaces/BillingV2/Usage/Infrastructure.tsx
@@ -91,7 +91,7 @@ const Infrastructure = ({
   )
 
   const latestIoBudgetConsumption = ioBudgetData?.data.slice(-1)
-    ? ioBudgetData?.data.slice(-1)[0].disk_io_consumption
+    ? Number(ioBudgetData?.data.slice(-1)[0].disk_io_consumption)
     : 0
 
   const chartMeta: { [key: string]: { data: DataPoint[]; isLoading: boolean } } = {

--- a/studio/components/interfaces/BillingV2/Usage/Infrastructure.tsx
+++ b/studio/components/interfaces/BillingV2/Usage/Infrastructure.tsx
@@ -140,6 +140,26 @@ const Infrastructure = ({
                         </a>
                       </Link>
                     </Alert>
+                  ) : hasLatest && latestIoBudgetConsumption >= 80 ? (
+                    <Alert
+                      withIcon
+                      variant="danger"
+                      title="You are close to running out of Disk IO Budget"
+                    >
+                      <p className="mb-4">
+                        Your workload has consumed {latestIoBudgetConsumption}% of your Disk IO
+                        Budget. If you use up all your Disk IO Budget, your instance will reverted
+                        to baseline performance. If you need consistent disk performance, consider
+                        upgrading to a larger compute add-on.
+                      </p>
+                      <Link href={upgradeUrl}>
+                        <a>
+                          <Button type="danger">
+                            {isFreeTier ? 'Upgrade project' : 'Change compute add-on'}
+                          </Button>
+                        </a>
+                      </Link>
+                    </Alert>
                   ) : currentBillingCycleSelected && highestIoBudgetConsumption >= 100 ? (
                     <Alert
                       withIcon
@@ -149,6 +169,26 @@ const Infrastructure = ({
                       <p className="mb-4">
                         Your workload has used up all your Disk IO Budget and reverted to baseline
                         performance at least once during this billing cycle. If you need consistent
+                        disk performance, consider upgrading to a larger compute add-on.
+                      </p>
+                      <Link href={upgradeUrl}>
+                        <a>
+                          <Button type="warning">
+                            {isFreeTier ? 'Upgrade project' : 'Change compute add-on'}
+                          </Button>
+                        </a>
+                      </Link>
+                    </Alert>
+                  ) : currentBillingCycleSelected && highestIoBudgetConsumption >= 80 ? (
+                    <Alert
+                      withIcon
+                      variant="warning"
+                      title="You were close to using all your IO Budget at least once"
+                    >
+                      <p className="mb-4">
+                        Your workload has consumed {highestIoBudgetConsumption}% of your Disk IO
+                        budget during this billing cycle. If you use up all your Disk IO Budget,
+                        your instance will reverted to baseline performance. If you need consistent
                         disk performance, consider upgrading to a larger compute add-on.
                       </p>
                       <Link href={upgradeUrl}>

--- a/studio/components/interfaces/BillingV2/Usage/Infrastructure.tsx
+++ b/studio/components/interfaces/BillingV2/Usage/Infrastructure.tsx
@@ -90,6 +90,10 @@ const Infrastructure = ({
     0
   )
 
+  const latestIoBudgetConsumption = ioBudgetData?.data.slice(-1)
+    ? ioBudgetData?.data.slice(-1)[0].disk_io_consumption
+    : 0
+
   const chartMeta: { [key: string]: { data: DataPoint[]; isLoading: boolean } } = {
     max_cpu_usage: {
       isLoading: isLoadingCpuUsageData,
@@ -118,10 +122,10 @@ const Infrastructure = ({
             <SectionContent section={attribute}>
               {attribute.key === 'disk_io_consumption' && (
                 <>
-                  {currentBillingCycleSelected && highestIoBudgetConsumption >= 100 ? (
-                    <Alert withIcon variant="danger" title="IO Budget for today has been used up">
+                  {latestIoBudgetConsumption >= 100 ? (
+                    <Alert withIcon variant="danger" title="Your Disk IO Budget has been used up">
                       <p className="mb-4">
-                        Your workload has used up all the burst IO throughput minutes and ran at the
+                        Your workload has used up all your Disk IO Budget and is now running at the
                         baseline performance. If you need consistent disk performance, consider
                         upgrading to a larger compute add-on.
                       </p>
@@ -133,13 +137,16 @@ const Infrastructure = ({
                         </a>
                       </Link>
                     </Alert>
-                  ) : currentBillingCycleSelected && highestIoBudgetConsumption >= 80 ? (
-                    <Alert withIcon variant="warning" title="IO Budget for today is running out">
+                  ) : currentBillingCycleSelected && highestIoBudgetConsumption >= 100 ? (
+                    <Alert
+                      withIcon
+                      variant="warning"
+                      title="You ran out of IO Budget at least once"
+                    >
                       <p className="mb-4">
-                        Your workload is about to use up all the burst IO throughput minutes during
-                        the day. Once this is completely used up, your workload will run at the
-                        baseline performance. If you need consistent disk performance, consider
-                        upgrading to a larger compute add-on.
+                        Your workload has used up all your Disk IO Budget and reverted to baseline
+                        performance at least once during this billing cycle. If you need consistent
+                        disk performance, consider upgrading to a larger compute add-on.
                       </p>
                       <Link href={upgradeUrl}>
                         <a>


### PR DESCRIPTION
Disk IO warning can be confusing now. Even when a Disk IO issue has been resolved (after optimizing queries or after upgrading compute), a few days later users will still be warned that the Disk IO budget is running low for _today_.

Changing the warning to make it more clear what is happening now and what has happened in the past.

Example: Running out of Disk IO right now

<img width="1002" alt="Screenshot 2023-07-05 18 06 34@2x" src="https://github.com/supabase/supabase/assets/1732217/2ecc8c60-61d6-4b2f-98eb-75248f69a9af">

Example: Running out of Disk IO in the past

<img width="1020" alt="Screenshot 2023-07-05 18 07 24@2x" src="https://github.com/supabase/supabase/assets/1732217/d2d658b7-a966-4e90-84fd-46beb6df1533">
