### PR TITLE
feat: count only successful email+pw sign in clicks

### DIFF
--- a/studio/components/interfaces/SignIn/SignInForm.tsx
+++ b/studio/components/interfaces/SignIn/SignInForm.tsx
@@ -35,11 +35,6 @@ const SignInForm = () => {
       token = captchaResponse?.response ?? null
     }
 
-    const signInClicks = incrementSignInClicks()
-    if (signInClicks > 1) {
-      Sentry.captureMessage('Sign in without previous sign out detected')
-    }
-
     const { error } = await auth.signInWithPassword({
       email,
       password,
@@ -47,6 +42,11 @@ const SignInForm = () => {
     })
 
     if (!error) {
+      const signInClicks = incrementSignInClicks()
+      if (signInClicks > 1) {
+        Sentry.captureMessage('Sign in without previous sign out detected')
+      }
+
       ui.setNotification({
         id: toastId,
         category: 'success',


### PR DESCRIPTION
Previously sign in clicks tracker for random logouts emitted an event on wrong passwords too, skewing the results. Now it will only emit the event on correct email + password combination.