### PR TITLE
feat: prevent document unload if gotrue is debugged and in a fetch

### DIFF
--- a/packages/common/gotrue.ts
+++ b/packages/common/gotrue.ts
@@ -10,9 +10,33 @@ const debug =
   globalThis.localStorage &&
   globalThis.localStorage.getItem(AUTH_DEBUG_KEY) === 'true'
 
+let customFetch = globalThis.fetch
+
+if (debug) {
+  customFetch = async (a, b) => {
+    const el = (event: any) => {
+      event.preventDefault()
+      console.log('GoTrue fetch in progress detected in beforeunload!', a, b)
+    }
+
+    try {
+      if (document) {
+        document.addEventListener('beforeunload', el, { capture: true })
+      }
+
+      return await globalThis.fetch(a, b)
+    } finally {
+      if (document) {
+        document.removeEventListener('beforeunload', el, { capture: true })
+      }
+    }
+  }
+}
+
 export const gotrueClient = new GoTrueClient({
   url: process.env.NEXT_PUBLIC_GOTRUE_URL,
   storageKey: STORAGE_KEY,
   detectSessionInUrl: true,
   debug,
+  fetch: customFetch,
 })


### PR DESCRIPTION
In an effort to validate a hypothesis about one potential cause of rare random logouts, I'm adding a custom fetch implementation to the GoTrue client which will ask the user about closing the browser. If team members encounter this, we'll know it's happening in correlation with the random logouts.