### PR TITLE
fix: onSuccess prop in Turnstile captcha docs

### DIFF
--- a/apps/docs/pages/guides/auth/auth-captcha.mdx
+++ b/apps/docs/pages/guides/auth/auth-captcha.mdx
@@ -165,18 +165,18 @@ Let's create an empty state to store our `captchaToken`
 const [captchaToken, setCaptchaToken] = useState()
 ```
 
-Now lets add the Cloudflare Turnstile component to the JSX section of our code
+Now lets add the Cloudflare Turnstile component to the JSX section of our code:
 
 ```html
 <Turnstile />
 ```
 
-We will pass it the sitekey we copied from the Cloudflare website as a property along with a `onVerify` property which takes a callback function. This callback function will have a token as one of its properties. Let's set the token in the state using `setCaptchaToken`
+We will pass it the sitekey we copied from the Cloudflare website as a property along with a `onSuccess` property which takes a callback function. This callback function will have a token as one of its properties. Let's set the token in the state using `setCaptchaToken`:
 
 ```jsx
 <Turnstile
   sitekey="your-sitekey"
-  onVerify={(token) => { setCaptchaToken(token) }
+  onSuccess={(token) => { setCaptchaToken(token) }
 />
 ```
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

This is a documentation fix for issue #15517.

## What is the current behavior?

The prop `onVerify` does not exist.
See https://docs.page/marsidev/react-turnstile/props

## What is the new behavior?

The prop `onSuccess` should be used.
