### PR TITLE
docs: remove overview & oauth apps

### DIFF
--- a/apps/docs/pages/guides/integrations.mdx
+++ b/apps/docs/pages/guides/integrations.mdx
@@ -11,29 +11,33 @@ export const meta = {
 Explore a variety of integrations from Supabase partners. Need a different integration? Find a [Supabase expert](https://supabase.com/partners/experts) to help build your next idea.
 
 <div>
-  {integrations.items.map((item) => (
-  <div key={item.name}>
-    <h2>{item.name}</h2>
-    <div className="grid grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 not-prose">
-      {item.items?.map((integration) => (
-        <Link href={`${integration.url}`} key={integration.name} >
-          <a>
-            <GlassPanel
-              title={integration.name}
-              background={false}
-              icon={<Image height={40} width={40} className="rounded" alt="" src={`/docs/img/integrations/logos/${integration.name.toLowerCase().replace(/ /g,"_")}_logo.png`}/>}
-            >
-              {integration.description}
+  {integrations.items.map((item) => {
+    return ['Overview', 'OAuth Apps (Beta)'].includes(item.name) ? null :
+    (
+      <div key={item.name}>
+        <h2>{item.name}</h2>
+        <div className="grid grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 not-prose">
+          {item.items?.map((integration) => (
+            <Link href={`${integration.url}`} key={integration.name} >
+              <a>
+                <GlassPanel
+                  title={integration.name}
+                  background={false}
+                  icon={<Image height={40} width={40} className="rounded" alt="" src={`/docs/img/integrations/logos/${integration.name.toLowerCase().replace(/ /g,"_")}_logo.png`}/>}
+                >
+                  {integration.description}
 
-            </GlassPanel>
-          </a>
-        </Link>
-      ))}
+                </GlassPanel>
+              </a>
+            </Link>
+          ))}
 
-    </div>
+        </div>
 
-  </div>
-  ))}
+      </div>
+
+)})}
+
 </div>
 
 export const Page = ({ children }) => <Layout meta={meta} children={children} />


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Very hacky, but just removing the overview and oauth app guides from the integrations homepage until we find a better place for both of them to live

Current:
<img width="1398" alt="image" src="https://github.com/supabase/supabase/assets/28647601/7206810b-44d2-4e9e-b054-4a4a07649d33">

Fixed: 
<img width="1391" alt="image" src="https://github.com/supabase/supabase/assets/28647601/d170c4ab-56cd-4f3d-8c4c-5528106df003">
