### PR TITLE
fix: adjust logflare endpoints query route

### DIFF
--- a/studio/pages/api/projects/[ref]/analytics/endpoints/[name].ts
+++ b/studio/pages/api/projects/[ref]/analytics/endpoints/[name].ts
@@ -44,7 +44,7 @@ const proxyRequest = async (req: NextApiRequest) => {
   const payload = { ...toForward, project_tier: 'ENTERPRISE' }
   const search = '?' + new URLSearchParams(payload as any).toString()
   const apiKey = process.env.LOGFLARE_API_KEY
-  const url = `${PROJECT_ANALYTICS_URL}endpoints/query/name/${name}${search}`
+  const url = `${PROJECT_ANALYTICS_URL}endpoints/query/${name}${search}`
   const result = await get(url, {
     headers: {
       'x-api-key': apiKey,


### PR DESCRIPTION
This PR adjusts the querying route to match the new standardized Logflare endpoints query route.

https://docs.logflare.app/concepts/endpoints#api-endpoints

This PR will require a subsequent Logflare image version bump for CLI of at least v1.3.16 cc @sweatybridge 

[ticket](https://www.notion.so/supabase/Remove-deprecated-usage-of-api-endpoints-query-name-name-99f00e97969d4948ae333607a27bfd8d?pvs=4)