### PR TITLE
Added redirectTo option to generateLink example with type recovery

### DIFF
--- a/spec/examples/examples.yml
+++ b/spec/examples/examples.yml
@@ -654,6 +654,9 @@ functions:
           const { data, error } = await supabase.auth.admin.generateLink({
             type: 'recovery',
             email: 'email@example.com'
+            options: {
+              redirectTo: 'https://example.com/update-password',
+            },
           })
           ```
       - id: generate-links-to-change-current-email-address


### PR DESCRIPTION
Added redirectTo option in the generateLink with type recovery

## What kind of change does this PR introduce?

Docs update regarding generateLink function example

## What is the current behavior?

Currently there is no reference to the redirectTo option

## What is the new behavior?

Added the same redirectTo example that we already have in the client version
