### PR TITLE
Update docs on disk size limitation for Pro plan with improved gp3 disks

### DIFF
--- a/apps/docs/pages/guides/platform/database-size.mdx
+++ b/apps/docs/pages/guides/platform/database-size.mdx
@@ -70,7 +70,7 @@ Due to provider restrictions, disk expansions can occur only once every six hour
 
 </Admonition>
 
-The maximum Disk Storage Size for the Pro plan is 64TB. If you need more than this, [contact us](https://forms.supabase.com/enterprise) to learn more about the Enterprise plan.
+The maximum Disk Storage Size for the Pro plan is 16TB. If you need more than this, [contact us](https://forms.supabase.com/enterprise) to learn more about the Enterprise plan.
 
 ### Free Plan Behavior
 

--- a/apps/docs/pages/guides/platform/database-size.mdx
+++ b/apps/docs/pages/guides/platform/database-size.mdx
@@ -74,7 +74,7 @@ The maximum Disk Storage Size for the Pro plan is 16TB. If you need more than th
 
 ### Free Plan Behavior
 
-Free Plan projects enter [read-only](#read-only-mode) mode when you exceed the 500mb limit. Once in read-only mode, you have several options:
+Free Plan projects enter [read-only](#read-only-mode) mode when you exceed the 500MB limit. Once in read-only mode, you have several options:
 
 - [Upgrade to the Pro plan or above](https://supabase.com/dashboard/project/_/settings/billing/subscription) to enable auto-scaling and expand beyond the 500mb database size limit.
 - [Disable read-only mode](#disabling-read-only-mode) and reduce your database size.

--- a/apps/docs/pages/guides/platform/database-size.mdx
+++ b/apps/docs/pages/guides/platform/database-size.mdx
@@ -57,13 +57,11 @@ Supabase uses network-attached storage to balance performance with scalability. 
 
 ### Paid Plan Behavior
 
-Pro and Enterprise projects have auto-scaling Disk Storage.
+Projects on the Pro plan and above have auto-scaling Disk Storage.
 
 Disk Storage expands automatically when the database reaches 90% of the disk size. The disk is expanded to be 50% larger (e.g., 8GB -> 12GB). Auto-scaling can only take place once every 6 hours. If within those 6 hours you reach 95% of the disk space, your project will enter read-only mode.
 
-The maximum Disk Storage Size for Pro plan is 64TB. If you need more than this, [contact us](https://supabase.com/dashboard/support/new) to learn more about the Enterprise plan.
-
-The Disk Storage Size can also be manually expanded in [Database settings page](https://supabase.com/dashboard/project/_/settings/database). The maximum default you can expand the Disk Storage to is 200GB. If you wish to manually expand it any more than 200GB, please [contact us](https://supabase.com/dashboard/support/new) to discuss expanding the 200GB limit.
+The Disk Storage Size can also be manually expanded on the [Database settings page](https://supabase.com/dashboard/project/_/settings/database). The maximum default you can expand the Disk Storage to is 200GB. If you wish to manually expand it to any more than 200GB, please [contact us](https://supabase.com/dashboard/support/new) to discuss expanding the 200GB limit.
 
 <Admonition type="info">
 You may want to import a lot of data into your database which requires multiple disk expansions; for example, uploading more than 1.5x the current size of your database storage will put your database into [read-only mode](#read-only-mode). If so, it is highly recommended you increase the Disk Storage Size manually on the [Database settings page](https://supabase.com/dashboard/project/_/settings/database).
@@ -72,11 +70,13 @@ Due to provider restrictions, disk expansions can occur only once every six hour
 
 </Admonition>
 
+The maximum Disk Storage Size for the Pro plan is 64TB. If you need more than this, [contact us](https://forms.supabase.com/enterprise) to learn more about the Enterprise plan.
+
 ### Free Plan Behavior
 
 Free Plan projects enter [read-only](#read-only-mode) mode when you exceed the 500mb limit. Once in read-only mode, you have several options:
 
-- [Upgrade to the Pro or Enterprise plan](https://supabase.com/dashboard/project/_/settings/billing/subscription) to enable auto-scaling and expand beyond the 500mb database size limit.
+- [Upgrade to the Pro plan or above](https://supabase.com/dashboard/project/_/settings/billing/subscription) to enable auto-scaling and expand beyond the 500mb database size limit.
 - [Disable read-only mode](#disabling-read-only-mode) and reduce your database size.
 
 ### Read-only mode

--- a/apps/docs/pages/guides/platform/database-size.mdx
+++ b/apps/docs/pages/guides/platform/database-size.mdx
@@ -76,7 +76,7 @@ The maximum Disk Storage Size for the Pro plan is 16TB. If you need more than th
 
 Free Plan projects enter [read-only](#read-only-mode) mode when you exceed the 500MB limit. Once in read-only mode, you have several options:
 
-- [Upgrade to the Pro plan or above](https://supabase.com/dashboard/project/_/settings/billing/subscription) to enable auto-scaling and expand beyond the 500mb database size limit.
+- [Upgrade to the Pro plan or above](https://supabase.com/dashboard/project/_/settings/billing/subscription) to enable auto-scaling and expand beyond the 500MB database size limit.
 - [Disable read-only mode](#disabling-read-only-mode) and reduce your database size.
 
 ### Read-only mode


### PR DESCRIPTION
We are using gp3 disks for everyone now. This means faster and more reliable performance. gp3 disks have a platform limitation of 16TB

In addition:

* changed some wordings to make the difference between auto-scaling and manual disk increases clearer
* make it clear auto-scaling is available to all paid plans not only Pro and Enterprise