### PR TITLE
example: use reverse client ID to perform Google login for Flutter Google auth example

### DIFF
--- a/examples/auth/flutter-native-google-auth/android/app/build.gradle
+++ b/examples/auth/flutter-native-google-auth/android/app/build.gradle
@@ -53,7 +53,7 @@ android {
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         manifestPlaceholders += [
-                'appAuthRedirectScheme': applicationId
+                'appAuthRedirectScheme': 'com.googleusercontent.apps.*account_id*'
         ]
 
     }

--- a/examples/auth/flutter-native-google-auth/android/app/build.gradle
+++ b/examples/auth/flutter-native-google-auth/android/app/build.gradle
@@ -53,6 +53,7 @@ android {
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         manifestPlaceholders += [
+                // *account_id* will be unique for every single app
                 'appAuthRedirectScheme': 'com.googleusercontent.apps.*account_id*'
         ]
 

--- a/examples/auth/flutter-native-google-auth/lib/screens/login_screen.dart
+++ b/examples/auth/flutter-native-google-auth/lib/screens/login_screen.dart
@@ -65,13 +65,8 @@ class _LoginScreenState extends State<LoginScreen> {
             final clientId =
                 Platform.isIOS ? 'IOS_CLIENT_ID' : 'ANDROID_CLIENT_ID';
 
-            /// Application ID or Bundle ID for your app.
-            /// If the application ID and Bundle ID is different for Android and iOS,
-            /// make sure the value here matches the platform you are running on.
-            const applicationId = 'com.example.myauthapp';
-
-            /// Fixed value for google login
-            const redirectUrl = '$applicationId:/google_auth';
+            /// Set as reversed DNS form of Google Client ID + `:/` for Google login
+            final redirectUrl = '${clientId.split('.').reversed.join('.')}:/';
 
             /// Fixed value for google login
             const discoveryUrl =


### PR DESCRIPTION
## What kind of change does this PR introduce?

Following up with the [Flutter native Google auth example](https://github.com/supabase/supabase/pull/15663), there is a small tweak that I wanted to make to fix the issue where Google Login on Android fails if the app's Application Name contains underscores. 