### PR TITLE
chore: update swift labelling in site layout

### DIFF
--- a/apps/docs/layouts/SiteLayout.tsx
+++ b/apps/docs/layouts/SiteLayout.tsx
@@ -96,7 +96,7 @@ const levelsData = {
   },
   reference_swift_v0: {
     icon: '/docs/img/icons/menu/reference-swift',
-    name: 'Swift Reference v1.0',
+    name: 'Swift Reference v0.0',
   },
   reference_kotlin_v0: {
     icon: '/docs/img/icons/menu/reference-kotlin',


### PR DESCRIPTION
should be v0.0 and not v1.0