### PR TITLE
Update auth-row-level-security.mdx for wrong RLS impact on operation

### DIFF
--- a/apps/docs/pages/learn/auth-deep-dive/auth-row-level-security.mdx
+++ b/apps/docs/pages/learn/auth-deep-dive/auth-row-level-security.mdx
@@ -82,7 +82,7 @@ or via the Supabase Dashboard, by navigating to Auth > Policies, and clicking th
 
 ![Enable row level security in Supabase](/docs/img/auth-deep-dive-2.png)
 
-You'll notice that both reading and writing now fail with an error like:
+You'll notice that reading will return no rows and writing will now fail with an error like:
 
 ```jsx
 {


### PR DESCRIPTION
RLS does not error on reads, just writes.

Changed "You'll notice that both reading and writing now fail with an error like:"

To "You'll notice that reading will return no rows and writing will now fail with an error like:"

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
