### PR TITLE
feat: Add Schema Visualizer to Supabase Studio

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2813,6 +2813,22 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/@dagrejs/dagre": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@dagrejs/dagre/-/dagre-1.0.2.tgz",
+      "integrity": "sha512-7N7vEZDlcU4uRHWuL/9RyI8IgM/d4ULR7z2exJALshh7BHF3tFjYL2pW6bQ4mmlDzd2Tr49KJMIY87Be1L6J0w==",
+      "dependencies": {
+        "@dagrejs/graphlib": "2.1.13"
+      }
+    },
+    "node_modules/@dagrejs/graphlib": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/@dagrejs/graphlib/-/graphlib-2.1.13.tgz",
+      "integrity": "sha512-calbMa7Gcyo+/t23XBaqQqon8LlgE9regey4UVoikoenKBXvUnCUL3s9RP6USCxttfr0XWVICtYUuKMdehKqMw==",
+      "engines": {
+        "node": ">17.0.0"
+      }
+    },
     "node_modules/@devtools-ds/object-inspector": {
       "version": "1.2.1",
       "dev": true,
@@ -6802,6 +6818,240 @@
       },
       "peerDependenciesMeta": {
         "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reactflow/background": {
+      "version": "11.2.4",
+      "resolved": "https://registry.npmjs.org/@reactflow/background/-/background-11.2.4.tgz",
+      "integrity": "sha512-SYQbCRCU0GuxT/40Tm7ZK+l5wByGnNJSLtZhbL9C/Hl7JhsJXV3UGXr0vrlhVZUBEtkWA7XhZM/5S9XEA5XSFA==",
+      "dependencies": {
+        "@reactflow/core": "11.7.4",
+        "classcat": "^5.0.3",
+        "zustand": "^4.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/background/node_modules/zustand": {
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.3.9.tgz",
+      "integrity": "sha512-Tat5r8jOMG1Vcsj8uldMyqYKC5IZvQif8zetmLHs9WoZlntTHmIoNM8TpLRY31ExncuUvUOXehd0kvahkuHjDw==",
+      "dependencies": {
+        "use-sync-external-store": "1.2.0"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "immer": ">=9.0",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reactflow/controls": {
+      "version": "11.1.15",
+      "resolved": "https://registry.npmjs.org/@reactflow/controls/-/controls-11.1.15.tgz",
+      "integrity": "sha512-//33XfBYu8vQ6brfmlZwKrDoh+8hh93xO2d88XiqfIbrPEEb32SYjsb9mS9VuHKNlSIW+eB27fBA1Gt00mEj5w==",
+      "dependencies": {
+        "@reactflow/core": "11.7.4",
+        "classcat": "^5.0.3",
+        "zustand": "^4.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/controls/node_modules/zustand": {
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.3.9.tgz",
+      "integrity": "sha512-Tat5r8jOMG1Vcsj8uldMyqYKC5IZvQif8zetmLHs9WoZlntTHmIoNM8TpLRY31ExncuUvUOXehd0kvahkuHjDw==",
+      "dependencies": {
+        "use-sync-external-store": "1.2.0"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "immer": ">=9.0",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reactflow/core": {
+      "version": "11.7.4",
+      "resolved": "https://registry.npmjs.org/@reactflow/core/-/core-11.7.4.tgz",
+      "integrity": "sha512-nt0T8ERp8TE7YCDQViaoEY9lb0StDPrWHVx3zBjhStFYET3wc88t8QRasZdf99xRTmyNtI3U3M40M5EBLNUpMw==",
+      "dependencies": {
+        "@types/d3": "^7.4.0",
+        "@types/d3-drag": "^3.0.1",
+        "@types/d3-selection": "^3.0.3",
+        "@types/d3-zoom": "^3.0.1",
+        "classcat": "^5.0.3",
+        "d3-drag": "^3.0.0",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0",
+        "zustand": "^4.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/core/node_modules/zustand": {
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.3.9.tgz",
+      "integrity": "sha512-Tat5r8jOMG1Vcsj8uldMyqYKC5IZvQif8zetmLHs9WoZlntTHmIoNM8TpLRY31ExncuUvUOXehd0kvahkuHjDw==",
+      "dependencies": {
+        "use-sync-external-store": "1.2.0"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "immer": ">=9.0",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reactflow/minimap": {
+      "version": "11.5.4",
+      "resolved": "https://registry.npmjs.org/@reactflow/minimap/-/minimap-11.5.4.tgz",
+      "integrity": "sha512-1tDBj2zX2gxu2oHU6qvH5RGNrOWRfRxu8369KhDotuuBN5yJrGXJzWIKikwhzjsNsQJYOB+B0cS44yWAfwSwzw==",
+      "dependencies": {
+        "@reactflow/core": "11.7.4",
+        "@types/d3-selection": "^3.0.3",
+        "@types/d3-zoom": "^3.0.1",
+        "classcat": "^5.0.3",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0",
+        "zustand": "^4.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/minimap/node_modules/zustand": {
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.3.9.tgz",
+      "integrity": "sha512-Tat5r8jOMG1Vcsj8uldMyqYKC5IZvQif8zetmLHs9WoZlntTHmIoNM8TpLRY31ExncuUvUOXehd0kvahkuHjDw==",
+      "dependencies": {
+        "use-sync-external-store": "1.2.0"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "immer": ">=9.0",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reactflow/node-resizer": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@reactflow/node-resizer/-/node-resizer-2.1.1.tgz",
+      "integrity": "sha512-5Q+IBmZfpp/bYsw3+KRVJB1nUbj6W3XAp5ycx4uNWH+K98vbssymyQsW0vvKkIhxEPg6tkiMzO4UWRWvwBwt1g==",
+      "dependencies": {
+        "@reactflow/core": "^11.6.0",
+        "classcat": "^5.0.4",
+        "d3-drag": "^3.0.0",
+        "d3-selection": "^3.0.0",
+        "zustand": "^4.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/node-resizer/node_modules/zustand": {
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.3.9.tgz",
+      "integrity": "sha512-Tat5r8jOMG1Vcsj8uldMyqYKC5IZvQif8zetmLHs9WoZlntTHmIoNM8TpLRY31ExncuUvUOXehd0kvahkuHjDw==",
+      "dependencies": {
+        "use-sync-external-store": "1.2.0"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "immer": ">=9.0",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reactflow/node-toolbar": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@reactflow/node-toolbar/-/node-toolbar-1.2.3.tgz",
+      "integrity": "sha512-uFQy9xpog92s0G1wsPLniwV9nyH4i/MmL7QoMsWdnKaOi7XMhd8SJcCzUdHC3imR21HltsuQITff/XQ51ApMbg==",
+      "dependencies": {
+        "@reactflow/core": "11.7.4",
+        "classcat": "^5.0.3",
+        "zustand": "^4.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/node-toolbar/node_modules/zustand": {
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.3.9.tgz",
+      "integrity": "sha512-Tat5r8jOMG1Vcsj8uldMyqYKC5IZvQif8zetmLHs9WoZlntTHmIoNM8TpLRY31ExncuUvUOXehd0kvahkuHjDw==",
+      "dependencies": {
+        "use-sync-external-store": "1.2.0"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "immer": ">=9.0",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "immer": {
+          "optional": true
+        },
+        "react": {
           "optional": true
         }
       }
@@ -14204,17 +14454,138 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/d3": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.0.tgz",
+      "integrity": "sha512-jIfNVK0ZlxcuRDKtRS/SypEyOQ6UHaFQBKv032X45VvxSJ6Yi5G9behy9h6tNTHTDGh5Vq+KbmBjUWLgY4meCA==",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
     "node_modules/@types/d3-array": {
       "version": "3.0.5",
       "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.2.tgz",
+      "integrity": "sha512-uGC7DBh0TZrU/LY43Fd8Qr+2ja1FKmH07q2FoZFHo1eYl8aj87GhfVoY1saJVJiq24rp1+wpI6BvQJMKgQm8oA==",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.2.tgz",
+      "integrity": "sha512-2TEm8KzUG3N7z0TrSKPmbxByBx54M+S9lHoP2J55QuLU0VSQ9mE96EJSAOVNEqd1bbynMjeTS9VHmz8/bSw8rA==",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.2.tgz",
+      "integrity": "sha512-abT/iLHD3sGZwqMTX1TYCMEulr+wBd0SzyOQnjYNLp7sngdOHYtNkMRI5v3w5thoN+BWtlHVDx2Osvq6fxhZWw=="
     },
     "node_modules/@types/d3-color": {
       "version": "3.1.0",
       "license": "MIT"
     },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.2.tgz",
+      "integrity": "sha512-k6/bGDoAGJZnZWaKzeB+9glgXCYGvh6YlluxzBREiVo8f/X2vpTEdgPy9DN7Z2i42PZOZ4JDhVdlTSTSkLDPlQ==",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.1.tgz",
+      "integrity": "sha512-tLxQ2sfT0p6sxdG75c6f/ekqxjyYR0+LwPrsO1mbC9YDBzPJhs2HbJJRrn8Ez1DBoHRo2yx7YEATI+8V1nGMnQ=="
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.2.tgz",
+      "integrity": "sha512-rxN6sHUXEZYCKV05MEh4z4WpPSqIw+aP7n9ZN6WYAAvZoEAghEK1WeVZMZcHRBwyaKflU43PCUAJNjFxCzPDjg=="
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.2.tgz",
+      "integrity": "sha512-qmODKEDvyKWVHcWWCOVcuVcOwikLVsyc4q4EBJMREsoQnR2Qoc2cZQUyFUPgO9q4S3qdSqJKBsuefv+h0Qy+tw==",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-76pBHCMTvPLt44wFOieouXcGXWOF0AJCceUvaFkxSZEu4VDUdv93JfpMa6VGNFs01FHfuP4a5Ou68eRG1KBfTw=="
+    },
     "node_modules/@types/d3-ease": {
       "version": "3.0.0",
       "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.2.tgz",
+      "integrity": "sha512-gllwYWozWfbep16N9fByNBDTkJW/SyhH6SGRlXloR7WdtAaBui4plTP+gbUgiEot7vGw/ZZop1yDZlgXXSuzjA==",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.4.tgz",
+      "integrity": "sha512-q7xbVLrWcXvSBBEoadowIUJ7sRpS1yvgMWnzHJggFy5cUZBq2HZL5k/pBSm0GdYWS1vs5/EDwMjSKF55PDY4Aw=="
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.1.tgz",
+      "integrity": "sha512-5KY70ifCCzorkLuIkDe0Z9YTf9RR2CjBX1iaJG+rgM/cPP+sO+q9YdQ9WdhQcgPj1EQiJ2/0+yUkkziTG6Lubg=="
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.0.3.tgz",
+      "integrity": "sha512-bK9uZJS3vuDCNeeXQ4z3u0E7OeJZXjUgzFdSOtNtMCJCLvDtWDwfpRVWlyt3y8EvRzI0ccOu9xlMVirawolSCw==",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-9hjRTVoZjRFR6xo8igAJyNXQyPX6Aq++Nhb5ebrUF414dv4jr2MitM2fWiOY475wa3Za7TOS2Gh9fmqEhLTt0A=="
     },
     "node_modules/@types/d3-interpolate": {
       "version": "3.0.1",
@@ -14227,6 +14598,21 @@
       "version": "1.0.9",
       "license": "MIT"
     },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.0.tgz",
+      "integrity": "sha512-D49z4DyzTKXM0sGKVqiTDTYr+DHg/uxsiWDAkNrwXYuiZVd9o9wXZIo+YsHkifOiyBkmSWlEngHCQme54/hnHw=="
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.2.tgz",
+      "integrity": "sha512-QNcK8Jguvc8lU+4OfeNx+qnVy7c0VrDJ+CCVFS9srBo2GL9Y18CnIxBdTF3v38flrGy5s1YggcoAiu6s4fLQIw=="
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-IIE6YTekGczpLYo/HehAy3JGF1ty7+usI97LqraNa8IiDur+L44d0VOjAvFQWJVdZOJHukUJw+ZdZBlgeUsHOQ=="
+    },
     "node_modules/@types/d3-scale": {
       "version": "4.0.3",
       "license": "MIT",
@@ -14234,9 +14620,18 @@
         "@types/d3-time": "*"
       }
     },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.0.0.tgz",
+      "integrity": "sha512-dsoJGEIShosKVRBZB0Vo3C8nqSDqVGujJU6tPznsBJxNJNwMF8utmS83nvCBKQYPpjCzaaHcrf66iTRpZosLPw=="
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.5.tgz",
+      "integrity": "sha512-xCB0z3Hi8eFIqyja3vW8iV01+OHGYR2di/+e+AiOcXIOrY82lcvWW8Ke1DYE/EUVMsBl4Db9RppSBS3X1U6J0w=="
+    },
     "node_modules/@types/d3-shape": {
       "version": "1.3.8",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/d3-path": "^1"
@@ -14246,9 +14641,31 @@
       "version": "3.0.0",
       "license": "MIT"
     },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.0.tgz",
+      "integrity": "sha512-yjfBUe6DJBsDin2BMIulhSHmr5qNR5Pxs17+oW4DoVPyVIXZ+m6bs7j1UVKP08Emv6jRmYrYqxYzO63mQxy1rw=="
+    },
     "node_modules/@types/d3-timer": {
       "version": "3.0.0",
       "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.3.tgz",
+      "integrity": "sha512-/S90Od8Id1wgQNvIA8iFv9jRhCiZcGhPd2qX0bKF/PS+y0W5CrXKgIiELd2CvG1mlQrWK/qlYh3VxicqG1ZvgA==",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.3.tgz",
+      "integrity": "sha512-OWk1yYIIWcZ07+igN6BeoG6rqhnJ/pYe+R1qWFM2DtW49zsoSjgb9G5xB0ZXA8hh2jAzey1XuRmMSoXdKw8MDA==",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
     },
     "node_modules/@types/dat.gui": {
       "version": "0.7.10",
@@ -14352,6 +14769,11 @@
       "version": "3.2.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.10",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.10.tgz",
+      "integrity": "sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA=="
     },
     "node_modules/@types/glob": {
       "version": "8.1.0",
@@ -17662,6 +18084,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/classcat": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.4.tgz",
+      "integrity": "sha512-sbpkOw6z413p+HDGcBENe498WM9woqWHiJxCq7nvmxe9WmrUmqfAcxpIwAiMtM5Q3AhYkzXcNQHqsWq0mND51g=="
     },
     "node_modules/classnames": {
       "version": "2.3.2",
@@ -34019,6 +34446,23 @@
         "react-dom": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/reactflow": {
+      "version": "11.7.4",
+      "resolved": "https://registry.npmjs.org/reactflow/-/reactflow-11.7.4.tgz",
+      "integrity": "sha512-QI6+oc1Ft6oFeLSdHlp+SmgymbI5Tm49wj5JyE84O4A54yN/ImfYaBhLit9Cmfzxn9Tz6tDqmGMGbk4bdtB8/w==",
+      "dependencies": {
+        "@reactflow/background": "11.2.4",
+        "@reactflow/controls": "11.1.15",
+        "@reactflow/core": "11.7.4",
+        "@reactflow/minimap": "11.5.4",
+        "@reactflow/node-resizer": "2.1.1",
+        "@reactflow/node-toolbar": "1.2.3"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "license": "MIT",
@@ -42109,6 +42553,7 @@
     "studio": {
       "version": "0.0.9",
       "dependencies": {
+        "@dagrejs/dagre": "^1.0.2",
         "@graphiql/react": "^0.15.0",
         "@graphiql/toolkit": "^0.8.0",
         "@hcaptcha/react-hcaptcha": "^1.4.4",
@@ -42183,6 +42628,7 @@
         "react-virtualized-auto-sizer": "^1.0.6",
         "react-window": "^1.8.6",
         "react-window-infinite-loader": "^1.0.7",
+        "reactflow": "^11.7.4",
         "recharts": "^2.1.15",
         "sass": "^1.55.0",
         "scheduler": "^0.20.2",

--- a/studio/components/interfaces/Database/Schemas/SchemaGraph.tsx
+++ b/studio/components/interfaces/Database/Schemas/SchemaGraph.tsx
@@ -1,7 +1,8 @@
 import dagre from '@dagrejs/dagre'
+import clsx from 'clsx'
 import { observer } from 'mobx-react-lite'
 import { uniqBy } from 'lodash'
-import { FC, useEffect, useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
 import ReactFlow, {
   Background,
   BackgroundVariant,
@@ -15,6 +16,7 @@ import ReactFlow, {
 } from 'reactflow'
 
 import { PostgresTable } from '@supabase/postgres-meta'
+import { useTheme } from 'common/Providers'
 import { useStore } from 'hooks'
 import { IconLoader } from 'ui'
 
@@ -203,20 +205,20 @@ function TableNode({ data, targetPosition, sourcePosition }: NodeProps<TableNode
     <>
       {data.isForeign ? (
         <div className="rounded-lg overflow-hidden">
-          <header className="text-[0.5rem] leading-5 font-bold px-2 text-center bg-yellow-900 text-gray-300">
+          <header className="text-[0.5rem] leading-5 font-bold px-2 text-center bg-brand-900 text-gray-300">
             {data.name}
             {targetPosition && (
               <Handle
                 type="target"
                 id={data.name}
                 position={targetPosition}
-                className={`${hiddenNodeConnector} !left-0`}
+                className={clsx(hiddenNodeConnector, '!left-0')}
               />
             )}
           </header>
         </div>
       ) : (
-        <div className={`w-[${NODE_WIDTH / 2}px] rounded-lg overflow-hidden`}>
+        <div className="rounded-lg overflow-hidden" style={{ width: NODE_WIDTH / 2 }}>
           <header className="text-[0.5rem] leading-5 font-bold px-2 text-center bg-brand-900 text-gray-300">
             {data.name}
           </header>
@@ -227,9 +229,10 @@ function TableNode({ data, targetPosition, sourcePosition }: NodeProps<TableNode
               key={column.id}
             >
               <span
-                className={`${
-                  column.isPrimary ? 'border-l-2 border-l-brand-900 pl-[6px] pr-2' : 'px-2'
-                } text-ellipsis overflow-hidden whitespace-nowrap`}
+                className={clsx(
+                  column.isPrimary ? 'border-l-2 border-l-brand-900 pl-[6px] pr-2' : 'px-2',
+                  'text-ellipsis overflow-hidden whitespace-nowrap'
+                )}
               >
                 {column.name}
               </span>
@@ -239,7 +242,7 @@ function TableNode({ data, targetPosition, sourcePosition }: NodeProps<TableNode
                   type="target"
                   id={column.id}
                   position={targetPosition}
-                  className={`${hiddenNodeConnector} !left-0`}
+                  className={clsx(hiddenNodeConnector, '!left-0')}
                 />
               )}
               {sourcePosition && (
@@ -247,7 +250,7 @@ function TableNode({ data, targetPosition, sourcePosition }: NodeProps<TableNode
                   type="source"
                   id={column.id}
                   position={sourcePosition}
-                  className={`${hiddenNodeConnector} !right-0`}
+                  className={clsx(hiddenNodeConnector, '!right-0')}
                 />
               )}
             </div>
@@ -258,7 +261,11 @@ function TableNode({ data, targetPosition, sourcePosition }: NodeProps<TableNode
   )
 }
 
-const TablesGraph: FC<{ tables: PostgresTable[] }> = ({ tables }) => {
+const TablesGraph = ({ tables }: { tables: PostgresTable[] }) => {
+  const { isDarkMode } = useTheme()
+  const backgroundPatternColor = isDarkMode ? '#2e2e2e' : '#e6e8eb'
+  const edgeStrokeColor = isDarkMode ? '#ededed' : '#111318'
+
   const reactFlowInstance = useReactFlow()
   const nodeTypes = useMemo(
     () => ({
@@ -273,11 +280,11 @@ const TablesGraph: FC<{ tables: PostgresTable[] }> = ({ tables }) => {
       reactFlowInstance.setEdges(edges)
       setTimeout(() => reactFlowInstance.fitView({})) // it needs to happen during next event tick
     })
-  }, [tables])
+  }, [tables, isDarkMode])
 
   return (
     <>
-      <div style={{ width: '100%', height: '100%' }}>
+      <div className="w-full h-full">
         <ReactFlow
           defaultNodes={[]}
           defaultEdges={[]}
@@ -286,7 +293,7 @@ const TablesGraph: FC<{ tables: PostgresTable[] }> = ({ tables }) => {
             animated: true,
             deletable: false,
             style: {
-              stroke: '#ededed',
+              stroke: edgeStrokeColor,
             },
           }}
           nodeTypes={nodeTypes}
@@ -295,21 +302,14 @@ const TablesGraph: FC<{ tables: PostgresTable[] }> = ({ tables }) => {
             hideAttribution: true,
           }}
         >
-          <Background id="1" gap={10} color="#262626" variant={BackgroundVariant.Lines} />
-          <Background
-            id="2"
-            gap={100}
-            offset={1}
-            color="#2c2c2c"
-            variant={BackgroundVariant.Lines}
-          />
+          <Background gap={16} color={backgroundPatternColor} variant={BackgroundVariant.Lines} />
         </ReactFlow>
       </div>
     </>
   )
 }
 
-const SchemaGraph: FC<{ schema: string }> = ({ schema }) => {
+const SchemaGraph = ({ schema }: { schema: string }) => {
   const { meta } = useStore()
   const tables = meta.tables.list((table: { schema: string }) => table.schema === schema)
 

--- a/studio/components/interfaces/Database/Schemas/SchemaGraph.tsx
+++ b/studio/components/interfaces/Database/Schemas/SchemaGraph.tsx
@@ -298,8 +298,13 @@ const TablesGraph = ({ tables }: { tables: PostgresTable[] }) => {
           }}
           nodeTypes={nodeTypes}
           fitView
+          maxZoom={1.5}
           proOptions={{
-            hideAttribution: true,
+            /**
+             * TODO: Sponsor Reactflow before using it in production! 😇
+             * https://pro.reactflow.dev/
+             */
+            hideAttribution: false,
           }}
         >
           <Background gap={16} color={backgroundPatternColor} variant={BackgroundVariant.Lines} />

--- a/studio/components/interfaces/Database/Schemas/SchemaGraph.tsx
+++ b/studio/components/interfaces/Database/Schemas/SchemaGraph.tsx
@@ -1,0 +1,341 @@
+import dagre from '@dagrejs/dagre'
+import { observer } from 'mobx-react-lite'
+import { uniqBy } from 'lodash'
+import { FC, useEffect, useMemo } from 'react'
+import ReactFlow, {
+  Background,
+  BackgroundVariant,
+  Edge,
+  Handle,
+  Node,
+  NodeProps,
+  Position,
+  ReactFlowProvider,
+  useReactFlow,
+} from 'reactflow'
+
+import { PostgresTable } from '@supabase/postgres-meta'
+import { useStore } from 'hooks'
+import { IconLoader } from 'ui'
+
+import 'reactflow/dist/style.css'
+
+type TableNodeData = {
+  name: string
+  isForeign: boolean
+  columns: {
+    id: string
+    isPrimary: boolean
+    name: string
+    format: string
+  }[]
+}
+
+async function getGraphDataFromTables(tables: PostgresTable[]): Promise<{
+  nodes: Node<TableNodeData>[]
+  edges: Edge[]
+}> {
+  if (!tables.length) {
+    return { nodes: [], edges: [] }
+  }
+
+  const nodes = tables.map((table) => {
+    const columns = (table.columns || []).map((column) => {
+      return {
+        id: column.id,
+        isPrimary: table.primary_keys.some((pk) => pk.name === column.name),
+        name: column.name,
+        format: column.format,
+      }
+    })
+
+    return {
+      id: `${table.id}`,
+      type: 'table',
+      data: {
+        name: table.name,
+        isForeign: false,
+        columns,
+      },
+      position: { x: 0, y: 0 },
+    }
+  })
+
+  const edges: Edge[] = []
+  const currentSchema = tables[0].schema
+  const uniqueRelationships = uniqBy(
+    tables.flatMap((t) => t.relationships),
+    'id'
+  )
+
+  for (const rel of uniqueRelationships) {
+    // TODO: Support [external->this] relationship?
+    if (rel.source_schema !== currentSchema) {
+      continue
+    }
+
+    // Create additional [this->foreign] node that we can point to on the graph.
+    if (rel.target_table_schema !== currentSchema) {
+      nodes.push({
+        id: rel.constraint_name,
+        type: 'table',
+        data: {
+          name: `${rel.target_table_schema}.${rel.target_table_name}.${rel.target_column_name}`,
+          isForeign: true,
+          columns: [],
+        },
+        position: { x: 0, y: 0 },
+      })
+
+      const [source, sourceHandle] = findTablesHandleIds(
+        tables,
+        rel.source_table_name,
+        rel.source_column_name
+      )
+
+      if (source) {
+        edges.push({
+          id: String(rel.id),
+          source,
+          sourceHandle,
+          target: rel.constraint_name,
+          targetHandle: rel.constraint_name,
+        })
+      }
+
+      continue
+    }
+
+    const [source, sourceHandle] = findTablesHandleIds(
+      tables,
+      rel.source_table_name,
+      rel.source_column_name
+    )
+    const [target, targetHandle] = findTablesHandleIds(
+      tables,
+      rel.target_table_name,
+      rel.target_column_name
+    )
+
+    // We do not support [external->this] flow currently.
+    if (source && target) {
+      edges.push({
+        id: String(rel.id),
+        source,
+        sourceHandle,
+        target,
+        targetHandle,
+      })
+    }
+  }
+
+  return getLayoutedElements(nodes, edges)
+}
+
+function findTablesHandleIds(
+  tables: PostgresTable[],
+  table_name: string,
+  column_name: string
+): [string?, string?] {
+  for (const table of tables) {
+    if (table_name !== table.name) continue
+
+    for (const column of table.columns || []) {
+      if (column_name !== column.name) continue
+
+      return [String(table.id), column.id]
+    }
+  }
+
+  return []
+}
+
+const getLayoutedElements = (nodes: Node[], edges: Edge[]) => {
+  const dagreGraph = new dagre.graphlib.Graph()
+  dagreGraph.setDefaultEdgeLabel(() => ({}))
+  dagreGraph.setGraph({
+    rankdir: 'LR',
+    align: 'UR',
+    nodesep: 25,
+    ranksep: 50,
+  })
+
+  nodes.forEach((node) => {
+    dagreGraph.setNode(node.id, {
+      width: NODE_WIDTH / 2,
+      height: (NODE_ROW_HEIGHT / 2) * (node.data.columns.length + 1), // columns + header
+    })
+  })
+
+  edges.forEach((edge) => {
+    dagreGraph.setEdge(edge.source, edge.target)
+  })
+
+  dagre.layout(dagreGraph)
+
+  nodes.forEach((node) => {
+    const nodeWithPosition = dagreGraph.node(node.id)
+    node.targetPosition = Position.Left
+    node.sourcePosition = Position.Right
+    // We are shifting the dagre node position (anchor=center center) to the top left
+    // so it matches the React Flow node anchor point (top left).
+    node.position = {
+      x: nodeWithPosition.x - nodeWithPosition.width / 2,
+      y: nodeWithPosition.y - nodeWithPosition.height / 2,
+    }
+
+    return node
+  })
+
+  return { nodes, edges }
+}
+
+// ReactFlow is scaling everything by the factor of 2
+const NODE_WIDTH = 320
+const NODE_ROW_HEIGHT = 40
+
+function TableNode({ data, targetPosition, sourcePosition }: NodeProps<TableNodeData>) {
+  // Important styles is a nasty hack to use Handles (required for edges calculations), but do not show them in the UI.
+  // ref: https://github.com/wbkd/react-flow/discussions/2698
+  const hiddenNodeConnector = '!h-px !w-px !min-w-0 !min-h-0 !cursor-grab !border-0 !opacity-0'
+
+  return (
+    <>
+      {data.isForeign ? (
+        <div className="rounded-lg overflow-hidden">
+          <header className="text-[0.5rem] leading-5 font-bold px-2 text-center bg-yellow-900 text-gray-300">
+            {data.name}
+            {targetPosition && (
+              <Handle
+                type="target"
+                id={data.name}
+                position={targetPosition}
+                className={`${hiddenNodeConnector} !left-0`}
+              />
+            )}
+          </header>
+        </div>
+      ) : (
+        <div className={`w-[${NODE_WIDTH / 2}px] rounded-lg overflow-hidden`}>
+          <header className="text-[0.5rem] leading-5 font-bold px-2 text-center bg-brand-900 text-gray-300">
+            {data.name}
+          </header>
+
+          {data.columns.map((column) => (
+            <div
+              className="text-[8px] leading-5 relative flex justify-between odd:bg-scale-300 even:bg-scale-400"
+              key={column.id}
+            >
+              <span
+                className={`${
+                  column.isPrimary ? 'border-l-2 border-l-brand-900 pl-[6px] pr-2' : 'px-2'
+                } text-ellipsis overflow-hidden whitespace-nowrap`}
+              >
+                {column.name}
+              </span>
+              <span className="px-2">{column.format}</span>
+              {targetPosition && (
+                <Handle
+                  type="target"
+                  id={column.id}
+                  position={targetPosition}
+                  className={`${hiddenNodeConnector} !left-0`}
+                />
+              )}
+              {sourcePosition && (
+                <Handle
+                  type="source"
+                  id={column.id}
+                  position={sourcePosition}
+                  className={`${hiddenNodeConnector} !right-0`}
+                />
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </>
+  )
+}
+
+const TablesGraph: FC<{ tables: PostgresTable[] }> = ({ tables }) => {
+  const reactFlowInstance = useReactFlow()
+  const nodeTypes = useMemo(
+    () => ({
+      table: TableNode,
+    }),
+    []
+  )
+
+  useEffect(() => {
+    getGraphDataFromTables(tables).then(({ nodes, edges }) => {
+      reactFlowInstance.setNodes(nodes)
+      reactFlowInstance.setEdges(edges)
+      setTimeout(() => reactFlowInstance.fitView({})) // it needs to happen during next event tick
+    })
+  }, [tables])
+
+  return (
+    <>
+      <div style={{ width: '100%', height: '100%' }}>
+        <ReactFlow
+          defaultNodes={[]}
+          defaultEdges={[]}
+          defaultEdgeOptions={{
+            type: 'smoothstep',
+            animated: true,
+            deletable: false,
+            style: {
+              stroke: '#ededed',
+            },
+          }}
+          nodeTypes={nodeTypes}
+          fitView
+          proOptions={{
+            hideAttribution: true,
+          }}
+        >
+          <Background id="1" gap={10} color="#262626" variant={BackgroundVariant.Lines} />
+          <Background
+            id="2"
+            gap={100}
+            offset={1}
+            color="#2c2c2c"
+            variant={BackgroundVariant.Lines}
+          />
+        </ReactFlow>
+      </div>
+    </>
+  )
+}
+
+const SchemaGraph: FC<{ schema: string }> = ({ schema }) => {
+  const { meta } = useStore()
+  const tables = meta.tables.list((table: { schema: string }) => table.schema === schema)
+
+  if (meta.tables.isLoading) {
+    return (
+      <div className="flex h-full w-full items-center justify-center space-x-2">
+        <IconLoader className="animate-spin" size={14} />
+        <p className="text-sm text-scale-1000">Loading schemas...</p>
+      </div>
+    )
+  }
+
+  if (meta.tables.hasError) {
+    return (
+      <div className="px-6 py-4 text-scale-1000">
+        <p>Error connecting to API</p>
+        <p>{`${meta.tables.error?.message ?? 'Unknown error'}`}</p>
+      </div>
+    )
+  }
+
+  return (
+    <ReactFlowProvider>
+      <TablesGraph tables={tables} />
+    </ReactFlowProvider>
+  )
+}
+
+export default observer(SchemaGraph)

--- a/studio/components/interfaces/Database/Schemas/SchemaGraph.tsx
+++ b/studio/components/interfaces/Database/Schemas/SchemaGraph.tsx
@@ -230,8 +230,16 @@ function TableNode({ data, targetPosition, sourcePosition }: NodeProps<TableNode
             >
               <span
                 className={clsx(
-                  column.isPrimary ? 'border-l-2 border-l-brand-900 pl-[6px] pr-2' : 'px-2',
-                  'text-ellipsis overflow-hidden whitespace-nowrap'
+                  column.isPrimary && 'border-l-2 border-l-brand-900 pl-[6px] pr-2',
+                  'pl-2 text-ellipsis overflow-hidden whitespace-nowrap'
+                )}
+              >
+                {column.name}
+              </span>
+              <span
+                className={clsx(
+                  column.isPrimary && 'ml-[2px] pl-[6px]',
+                  'absolute top-0 left-0 right-0 pl-2 bg-scale-500 text-ellipsis overflow-hidden whitespace-nowrap opacity-0 hover:opacity-100'
                 )}
               >
                 {column.name}

--- a/studio/components/layouts/DatabaseLayout/DatabaseMenu.utils.ts
+++ b/studio/components/layouts/DatabaseLayout/DatabaseMenu.utils.ts
@@ -21,6 +21,12 @@ export const generateDatabaseMenu = (
           items: [],
         },
         {
+          name: 'Schemas',
+          key: 'schemas',
+          url: `/project/${ref}/database/schemas`,
+          items: [],
+        },
+        {
           name: 'Functions',
           key: 'functions',
           url: `/project/${ref}/database/functions`,

--- a/studio/components/layouts/DatabaseLayout/DatabaseMenu.utils.ts
+++ b/studio/components/layouts/DatabaseLayout/DatabaseMenu.utils.ts
@@ -15,15 +15,15 @@ export const generateDatabaseMenu = (
       items: [
         { name: 'Tables', key: 'tables', url: `/project/${ref}/database/tables`, items: [] },
         {
-          name: 'Triggers',
-          key: 'triggers',
-          url: `/project/${ref}/database/triggers`,
+          name: 'Schema Visualizer',
+          key: 'schemas',
+          url: `/project/${ref}/database/schemas`,
           items: [],
         },
         {
-          name: 'Schemas',
-          key: 'schemas',
-          url: `/project/${ref}/database/schemas`,
+          name: 'Triggers',
+          key: 'triggers',
+          url: `/project/${ref}/database/triggers`,
           items: [],
         },
         {

--- a/studio/package.json
+++ b/studio/package.json
@@ -17,6 +17,7 @@
     "codegen": "openapi-typescript http://localhost:8080/api-json -o ./data/api.d.ts"
   },
   "dependencies": {
+    "@dagrejs/dagre": "^1.0.2",
     "@graphiql/react": "^0.15.0",
     "@graphiql/toolkit": "^0.8.0",
     "@hcaptcha/react-hcaptcha": "^1.4.4",
@@ -91,6 +92,7 @@
     "react-virtualized-auto-sizer": "^1.0.6",
     "react-window": "^1.8.6",
     "react-window-infinite-loader": "^1.0.7",
+    "reactflow": "^11.7.4",
     "recharts": "^2.1.15",
     "sass": "^1.55.0",
     "scheduler": "^0.20.2",

--- a/studio/pages/project/[ref]/database/schemas.tsx
+++ b/studio/pages/project/[ref]/database/schemas.tsx
@@ -8,12 +8,6 @@ import { useStore } from 'hooks'
 import { NextPageWithLayout } from 'types'
 import { IconLock, Listbox } from 'ui'
 
-/**
- * TODO: Sponsor Reactflow before using it in production! 😇
- *
- * https://pro.reactflow.dev/
- */
-
 const SchemasPage: NextPageWithLayout = () => {
   const { meta } = useStore()
   const schemas = meta.schemas.list()

--- a/studio/pages/project/[ref]/database/schemas.tsx
+++ b/studio/pages/project/[ref]/database/schemas.tsx
@@ -27,7 +27,7 @@ const SchemasPage: NextPageWithLayout = () => {
   return (
     <>
       <div className="flex w-full h-full flex-col">
-        <div className="p-4">
+        <div className="p-4 border-b border-scale-500">
           <Listbox
             className="w-[260px]"
             size="small"

--- a/studio/pages/project/[ref]/database/schemas.tsx
+++ b/studio/pages/project/[ref]/database/schemas.tsx
@@ -1,0 +1,80 @@
+import { observer } from 'mobx-react-lite'
+import { partition } from 'lodash'
+import { useState } from 'react'
+
+import SchemaGraph from 'components/interfaces/Database/Schemas/SchemaGraph'
+import { DatabaseLayout } from 'components/layouts'
+import { useStore } from 'hooks'
+import { NextPageWithLayout } from 'types'
+import { IconLock, Listbox } from 'ui'
+
+/**
+ * TODO: Sponsor Reactflow before using it in production! 😇
+ *
+ * https://pro.reactflow.dev/
+ */
+
+const SchemasPage: NextPageWithLayout = () => {
+  const { meta } = useStore()
+  const schemas = meta.schemas.list()
+  const [selectedSchema, setSelectedSchema] = useState<string>('public')
+  const [protectedSchemas, openSchemas] = partition(schemas, (schema) =>
+    meta.excludedSchemas.includes(schema?.name ?? '')
+  )
+  const schema = schemas.find((schema) => schema.name === selectedSchema)
+  const isLocked = protectedSchemas.some((s) => s.id === schema?.id)
+
+  return (
+    <>
+      <div className="flex w-full h-full flex-col">
+        <div className="p-4">
+          <Listbox
+            className="w-[260px]"
+            size="small"
+            value={selectedSchema}
+            onChange={setSelectedSchema}
+            icon={isLocked && <IconLock size={14} strokeWidth={2} />}
+          >
+            <Listbox.Option disabled key="normal-schemas" value="normal-schemas" label="Schemas">
+              <p className="text-sm">Schemas</p>
+            </Listbox.Option>
+            {openSchemas.map((schema) => (
+              <Listbox.Option
+                key={schema.id}
+                value={schema.name}
+                label={schema.name}
+                addOnBefore={() => <span className="text-scale-900">schema</span>}
+              >
+                <span className="text-scale-1200 text-sm">{schema.name}</span>
+              </Listbox.Option>
+            ))}
+            <Listbox.Option
+              disabled
+              key="protected-schemas"
+              value="protected-schemas"
+              label="Protected schemas"
+            >
+              <p className="text-sm">Protected schemas</p>
+            </Listbox.Option>
+            {protectedSchemas.map((schema) => (
+              <Listbox.Option
+                key={schema.id}
+                value={schema.name}
+                label={schema.name}
+                addOnBefore={() => <span className="text-scale-900">schema</span>}
+              >
+                <span className="text-scale-1200 text-sm">{schema.name}</span>
+              </Listbox.Option>
+            ))}
+          </Listbox>
+        </div>
+
+        <SchemaGraph schema={selectedSchema}></SchemaGraph>
+      </div>
+    </>
+  )
+}
+
+SchemasPage.getLayout = (page) => <DatabaseLayout title="Database">{page}</DatabaseLayout>
+
+export default observer(SchemasPage)


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR introduces a new sub-page called `Schemas` to the `Database` page.
It visualizes the selected schema (`public` by default) as an interactive graph.

## What is the new behavior?

![image](https://github.com/supabase/supabase/assets/1523305/55ba50d5-8ca8-40df-8582-9d9cb76e6c98)

## Additional context

There are some improvements and features that can be added (and better styling!), but for the rest of the community to jump in, the main functionality has to be in place.

Would appreciate some other folks testing it out locally, as due to its generative nature, the graph might be rendered in a funky way in case someone has a very complex schema in place.

Please note that I'm gone until Monday 17th starting tomorrow, so won't be able to respond to the feedback or help with setting things up till then.

## Possible improvements

- [ ] better styling overall
- [x] adding indicators
  - [x] primary key (right now its just a colored border)
  - [x] foreign key
  - [x] is nullable
  - [x] is identity
  - [x] unique
- [x] show truncated column names on hover (right now it shows as a native title attribute but would be nice to make it instant as a "floating" label
- [ ] a more complex addition would be to render a foreign table as a full node (although not sure if it's a good idea tbh, maybe just upgrade that node to be shown as a 3-line node with schema/table/column rows + column type and same indicators as above
- [ ] adding <Controls /> component with matching styles - https://reactflow.dev/docs/api/plugin-components/controls/; I had it in the initial implementation but didn't find it that useful tbh, but maybe with just a custom "force layout" button and "center" it might be actually helpful, it'd have to be a design UX decision

Closes https://github.com/supabase/supabase/issues/15585