### PR TITLE
docs: update self-hosted tutorial for self-hosting analytics server

### DIFF
--- a/apps/docs/pages/guides/self-hosting/docker.mdx
+++ b/apps/docs/pages/guides/self-hosting/docker.mdx
@@ -132,6 +132,11 @@ However, you might miss important log messages such as database errors. Configur
 
 By default, Storage backend is set to `file`, which is to use local files as the storage backend. To make it work on macOS, you need to choose `VirtioFS` as the Docker container file sharing implementation (in Docker Desktop -> Preferences -> General).
 
+### Setting up logging with the Analytics server
+
+Additional configuration is required for self-hosting the Analytics server. Full setup instructions can be found [here](https://supabase.com/docs/reference/self-hosting-analytics/introduction#getting-started).
+
+
 export const Page = ({ children }) => <Layout meta={meta} children={children} />
 
 export default Page

--- a/apps/docs/pages/guides/self-hosting/docker.mdx
+++ b/apps/docs/pages/guides/self-hosting/docker.mdx
@@ -134,7 +134,7 @@ By default, Storage backend is set to `file`, which is to use local files as the
 
 ### Setting up logging with the Analytics server
 
-Additional configuration is required for self-hosting the Analytics server. Full setup instructions can be found [here](https://supabase.com/docs/reference/self-hosting-analytics/introduction#getting-started).
+Additional configuration is required for self-hosting the Analytics server. For the full setup instructions, see [Self Hosting Analytics](https://supabase.com/docs/reference/self-hosting-analytics/introduction#getting-started).
 
 
 export const Page = ({ children }) => <Layout meta={meta} children={children} />


### PR DESCRIPTION
This PR updates the docker tutorial for self-hosting with additional information on the Analytics server.

https://github.com/supabase/supabase/issues/14222