### PR TITLE
chore: Add links explaining each param in the custom postgres docs

### DIFF
--- a/apps/docs/pages/guides/platform/custom-postgres-config.mdx
+++ b/apps/docs/pages/guides/platform/custom-postgres-config.mdx
@@ -24,17 +24,17 @@ From the perspective of Postgres, config overrides will show up in the global co
 
 The following parameters are available for overrides:
 
-1. `effective_cache_size`
-1. `maintenance_work_mem`
-1. `max_connections`
-1. `max_parallel_maintenance_workers`
-1. `max_parallel_workers_per_gather`
-1. `max_parallel_workers`
-1. `max_worker_processes`
-1. `session_replication_role`
-1. `shared_buffers`
-1. `statement_timeout`
-1. `work_mem`
+1. [effective_cache_size](https://postgresqlco.nf/doc/en/param/effective_cache_size/)
+1. [maintenance_work_mem](https://postgresqlco.nf/doc/en/param/maintenance_work_mem/)
+1. [max_connections](https://postgresqlco.nf/doc/en/param/max_connections/)
+1. [max_parallel_maintenance_workers](https://postgresqlco.nf/doc/en/param/max_parallel_maintenance_workers/)
+1. [max_parallel_workers_per_gather](https://postgresqlco.nf/doc/en/param/max_parallel_workers_per_gather/)
+1. [max_parallel_workers](https://postgresqlco.nf/doc/en/param/max_parallel_workers/)
+1. [max_worker_processes](https://postgresqlco.nf/doc/en/param/max_worker_processes/)
+1. [session_replication_role](https://postgresqlco.nf/doc/en/param/session_replication_role/)
+1. [shared_buffers](https://postgresqlco.nf/doc/en/param/shared_buffers/)
+1. [statement_timeout](https://postgresqlco.nf/doc/en/param/statement_timeout/)
+1. [work_mem](https://postgresqlco.nf/doc/en/param/work_mem/)
 
 ### Setting config using the CLI
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Includes links to each param in postgresqlco.nf, so users can understand what each does in more depth:
https://postgresqlco.nf/doc/en/param/statement_timeout/

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
