### PR TITLE
doc(read-only): database

### DIFF
--- a/apps/docs/pages/guides/platform/database-size.mdx
+++ b/apps/docs/pages/guides/platform/database-size.mdx
@@ -90,8 +90,7 @@ In read-only mode, clients will encounter errors such as `cannot execute INSERT 
 You can manually override read-only mode to reduce disk size. To do this, run the following in the [SQL Editor](https://supabase.com/dashboard/project/_/sql):
 
 ```sql
-SET
-  default_transaction_read_only = 'off';
+SET TRANSACTION READ WRITE;
 ```
 
 This allows you to delete data from within the session. After deleting data, you should run a vacuum to reclaim as much space as possible.


### PR DESCRIPTION
Database read only unlock command

## What kind of change does this PR introduce?

 docs update

## What is the current behavior?

https://twitter.com/_StanGirard/status/1679513720106491906?s=20

Old behavior it doesn't allow to run commands

## What is the new behavior?

New behavior it does.

## Additional context

I was read-only locked. I couldn't unlock myself with the command. I asked chatGPT and it gave me this answer

<img width="901" alt="image" src="https://github.com/supabase/supabase/assets/19614572/b9a39bda-1f48-4460-b522-4873e49df704">

