### PR TITLE
Update `unlisted` link to `public` link for Realtime video

### DIFF
--- a/apps/docs/pages/guides/auth/auth-helpers/nextjs.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/nextjs.mdx
@@ -528,7 +528,7 @@ This allows for the Supabase client to be easily instantiated in the correct con
 
 <div className="video-container">
   <iframe
-    src="https://www.youtube-nocookie.com/embed/f4yAnVgcJqI"
+    src="https://www.youtube-nocookie.com/embed/6Sb8R1PYhTY"
     frameBorder="1"
     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
     allowFullScreen


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

Auth Helpers Next.js Realtime video contains `unlisted` link

## What is the new behavior?

Auth Helpers Next.js Realtime video contains `public` link
