### PR TITLE
feat: add `navigatorLock` to `GoTrueClient`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39928,7 +39928,7 @@
       "license": "MIT",
       "dependencies": {
         "@headlessui/react": "^1.7.14",
-        "@supabase/gotrue-js": "^2.43.0",
+        "@supabase/gotrue-js": "^2.44.0",
         "@supabase/ui": "^0.37.0-alpha.50",
         "react-use": "^17.4.0"
       },
@@ -39941,9 +39941,9 @@
       }
     },
     "packages/common/node_modules/@supabase/gotrue-js": {
-      "version": "2.43.0",
-      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.43.0.tgz",
-      "integrity": "sha512-bIgE5pJFTQulFIhI1h/ASzfqQa/ukeL0NOTGVk78Tk2vXDU0a03npiz2KhgHekFi2COYndRHYkAsFOwiY8y2Pg==",
+      "version": "2.44.0",
+      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.44.0.tgz",
+      "integrity": "sha512-Et7/UVYsEvMTMEA+F26Vxsqvnq79dG1H5bq31WkyQXH3hY0JUA0+BUixlVinG5Uy/2SRk5eZOs4xxDmQQEJAFw==",
       "dependencies": {
         "cross-fetch": "^3.1.5"
       }

--- a/packages/common/gotrue.ts
+++ b/packages/common/gotrue.ts
@@ -1,42 +1,26 @@
-import { GoTrueClient } from '@supabase/gotrue-js'
+import { GoTrueClient, navigatorLock } from '@supabase/gotrue-js'
 
 export const STORAGE_KEY = process.env.NEXT_PUBLIC_STORAGE_KEY || 'supabase.dashboard.auth.token'
 export const AUTH_DEBUG_KEY =
   process.env.NEXT_PUBLIC_AUTH_DEBUG_KEY || 'supabase.dashboard.auth.debug'
+export const AUTH_NAVIGATOR_LOCK_KEY =
+  process.env.NEXT_PUBLIC_AUTH_NAVIGATOR_LOCK_KEY || 'supabase.dashboard.auth.navigatorLock.enabled'
 
 const debug =
   process.env.NEXT_PUBLIC_IS_PLATFORM === 'true' &&
-  globalThis &&
-  globalThis.localStorage &&
-  globalThis.localStorage.getItem(AUTH_DEBUG_KEY) === 'true'
+  globalThis?.localStorage?.getItem(AUTH_DEBUG_KEY) === 'true'
 
-let customFetch = globalThis.fetch
-
-if (debug) {
-  customFetch = async (a, b) => {
-    const el = (event: any) => {
-      event.preventDefault()
-      console.log('GoTrue fetch in progress detected in beforeunload!', a, b)
-    }
-
-    try {
-      if (document) {
-        document.addEventListener('beforeunload', el, { capture: true })
-      }
-
-      return await globalThis.fetch(a, b)
-    } finally {
-      if (document) {
-        document.removeEventListener('beforeunload', el, { capture: true })
-      }
-    }
-  }
-}
+const navigatorLockEnabled =
+  process.env.NEXT_PUBLIC_IS_PLATFORM === 'true' &&
+  globalThis?.localStorage?.getItem(AUTH_NAVIGATOR_LOCK_KEY) === 'true'
 
 export const gotrueClient = new GoTrueClient({
   url: process.env.NEXT_PUBLIC_GOTRUE_URL,
   storageKey: STORAGE_KEY,
   detectSessionInUrl: true,
   debug,
-  fetch: customFetch,
+  lock:
+    (debug || navigatorLockEnabled) && globalThis.navigator && globalThis.navigator.locks
+      ? navigatorLock
+      : undefined,
 })

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "dependencies": {
     "@headlessui/react": "^1.7.14",
-    "@supabase/gotrue-js": "^2.43.0",
+    "@supabase/gotrue-js": "^2.44.0",
     "@supabase/ui": "^0.37.0-alpha.50",
     "react-use": "^17.4.0"
   },


### PR DESCRIPTION
Uses the experimental `navigatorLock` with `GoTrueClient` which serializes access across tabs. It should make random logouts due to races impossible.

Only active if `supabase.dashboard.auth.debug` or `supabase.dashboard.auth.navigatorLock.enabled` is `true`.