### PR TITLE
updating to match @supabase/auth-helpers-sveltekit docs

### DIFF
--- a/apps/docs/pages/guides/getting-started/tutorials/with-sveltekit.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-sveltekit.mdx
@@ -117,11 +117,14 @@ Create a new `src/routes/+layout.server.ts` file to handle the session on the se
 
 ```ts src/routes/+layout.server.ts
 // src/routes/+layout.server.ts
-export const load = async ({ locals: { getSession } }) => {
+
+import type { LayoutServerLoad } from './$types';
+
+export const load: LayoutServerLoad = async ({ locals: { getSession } }) => {
   return {
-    session: await getSession(),
-  }
-}
+    session: getSession()
+  };
+};
 ```
 
 > Start your dev server (`npm run dev`) in order to generate the `./$types` files we are referencing in our project.


### PR DESCRIPTION
## What kind of change does this PR introduce?
Fixes type issues and catches up this documentation to match https://github.com/supabase/auth-helpers/blob/main/examples/sveltekit/src/routes/%2Blayout.server.ts

## What is the current behavior?
If a user currently follows the svelte-kit guide the following lines of code will produce errors and stop their progression:
```// +layout.svelte
let { supabase, session } = data;
$: ({ supabase, session } = data);
```
Please link any relevant issues here.

## What is the new behavior?
It works