### PR TITLE
feat: fix default captcha reverting to hcaptcha when site url is changed

### DIFF
--- a/studio/components/interfaces/Auth/SiteUrl/SiteUrl.tsx
+++ b/studio/components/interfaces/Auth/SiteUrl/SiteUrl.tsx
@@ -30,6 +30,7 @@ const SiteUrl = observer(() => {
     REFRESH_TOKEN_ROTATION_ENABLED: authConfig.config.REFRESH_TOKEN_ROTATION_ENABLED || false,
     SECURITY_REFRESH_TOKEN_REUSE_INTERVAL: authConfig.config.SECURITY_REFRESH_TOKEN_REUSE_INTERVAL,
     SECURITY_CAPTCHA_ENABLED: authConfig.config.SECURITY_CAPTCHA_ENABLED || false,
+    SECURITY_CAPTCHA_PROVIDER: authConfig.config.SECURITY_CAPTCHA_PROVIDER || 'hcaptcha',
     SECURITY_CAPTCHA_SECRET: authConfig.config.SECURITY_CAPTCHA_SECRET || '',
   }
 
@@ -46,14 +47,13 @@ const SiteUrl = observer(() => {
     SECURITY_CAPTCHA_ENABLED: boolean().required(),
     SECURITY_CAPTCHA_SECRET: string().when('SECURITY_CAPTCHA_ENABLED', {
       is: true,
-      then: string().required('Must have a hCaptcha secret'),
+      then: string().required('Must have a Captcha secret'),
     }),
   })
 
   const onSubmit = async (values: any, { setSubmitting, resetForm }: any) => {
     const payload = { ...values }
     payload.DISABLE_SIGNUP = !values.DISABLE_SIGNUP
-    payload.SECURITY_CAPTCHA_PROVIDER = 'hcaptcha'
 
     setSubmitting(true)
     const { error } = await authConfig.update(payload)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently, changing site url reverts captcha setting to hcaptcha as a default.  Attempts to fix #15565 

## What is the new behaviour?

Modifying the site url should not affect the captcha setting.
