### PR TITLE
chore: only allow org-level-billing orgs when toggled

### DIFF
--- a/studio/components/layouts/AccountLayout/AccountLayout.tsx
+++ b/studio/components/layouts/AccountLayout/AccountLayout.tsx
@@ -36,7 +36,7 @@ const AccountLayout = ({ children, title, breadcrumbs }: PropsWithChildren<Accou
     .map((organization) => ({
       isActive:
         router.pathname.startsWith('/org/') && selectedOrganization?.slug === organization.slug,
-      label: organization.name + (organization.subscription_id ? ' (V2)' : ''),
+      label: organization.name,
       href: `/org/${organization.slug}/general`,
       key: organization.slug,
     }))

--- a/studio/components/layouts/ProjectLayout/LayoutHeader/OrgDropdown.tsx
+++ b/studio/components/layouts/ProjectLayout/LayoutHeader/OrgDropdown.tsx
@@ -53,17 +53,13 @@ const OrgDropdown = () => {
               )
             })}
           <Dropdown.Separator />
-          <Dropdown.Item icon={<IconPlus size="tiny" />} onClick={() => router.push(`/new`)}>
+
+          <Dropdown.Item
+            icon={<IconPlus size="tiny" />}
+            onClick={() => router.push(orgCreationV2 ? `/new-with-subscription` : `/new`)}
+          >
             New organization
           </Dropdown.Item>
-          {orgCreationV2 && (
-            <Dropdown.Item
-              icon={<IconPlus size="tiny" />}
-              onClick={() => router.push(`/new-with-subscription`)}
-            >
-              New organization V2
-            </Dropdown.Item>
-          )}
         </>
       }
     >

--- a/studio/components/to-be-cleaned/Dropdown/OrganizationDropdown.js
+++ b/studio/components/to-be-cleaned/Dropdown/OrganizationDropdown.js
@@ -27,17 +27,12 @@ const OrganizationDropdown = ({ organizations }) => {
               </Dropdown.Item>
             ))}
           <Dropdown.Separator />
-          <Dropdown.Item icon={<IconPlus size="tiny" />} onClick={() => router.push(`/new`)}>
+          <Dropdown.Item
+            icon={<IconPlus size="tiny" />}
+            onClick={() => router.push(orgCreationV2 ? `/new-with-subscription` : `/new`)}
+          >
             New organization
           </Dropdown.Item>
-          {orgCreationV2 && (
-            <Dropdown.Item
-              icon={<IconPlus size="tiny" />}
-              onClick={() => router.push(`/new-with-subscription`)}
-            >
-              New organization V2
-            </Dropdown.Item>
-          )}
         </>
       }
     >


### PR DESCRIPTION
To speed up internal adoption, if the feature toggle for the new orgCreationV2 (uses org-level-billing), we only allow creating new organizations with org-level-billing and not both.