### PR TITLE
fix: query subscription for plan

### DIFF
--- a/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainConfig.tsx
+++ b/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainConfig.tsx
@@ -1,25 +1,25 @@
 import Link from 'next/link'
 
 import { useParams } from 'common/hooks'
-import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
 import { FormHeader } from 'components/ui/Forms'
 import Panel from 'components/ui/Panel'
 import UpgradeToPro from 'components/ui/UpgradeToPro'
 import { useProjectApiQuery } from 'data/config/project-api-query'
 import { useCustomDomainsQuery } from 'data/custom-domains/custom-domains-query'
-import { PRICING_TIER_PRODUCT_IDS } from 'lib/constants'
 import { IconAlertCircle } from 'ui'
 import CustomDomainActivate from './CustomDomainActivate'
 import CustomDomainDelete from './CustomDomainDelete'
 import CustomDomainVerify from './CustomDomainVerify'
 import CustomDomainsConfigureHostname from './CustomDomainsConfigureHostname'
 import CustomDomainsShimmerLoader from './CustomDomainsShimmerLoader'
+import { useProjectSubscriptionV2Query } from 'data/subscriptions/project-subscription-v2-query'
 
 const CustomDomainConfig = () => {
-  const { project } = useProjectContext()
   const { ref } = useParams()
 
-  const tier = project?.subscription_tier
+  const { data: subscription } = useProjectSubscriptionV2Query({ projectRef: ref })
+
+  const plan = subscription?.plan?.id
   const { isLoading: isSettingsLoading, data: settings } = useProjectApiQuery({
     projectRef: ref,
   })
@@ -65,7 +65,7 @@ const CustomDomainConfig = () => {
           primaryText="Custom domains are a Pro plan add-on"
           projectRef={ref as string}
           secondaryText={
-            tier === PRICING_TIER_PRODUCT_IDS.FREE
+            plan === 'free'
               ? 'To configure a custom domain for your project, please upgrade to the Pro plan with the custom domains add-on selected'
               : 'To configure a custom domain for your project, please enable the add-on'
           }

--- a/studio/components/interfaces/Settings/General/DeleteProjectPanel/DeleteProjectButton.tsx
+++ b/studio/components/interfaces/Settings/General/DeleteProjectPanel/DeleteProjectButton.tsx
@@ -12,6 +12,7 @@ import { invalidateProjectsQuery } from 'data/projects/projects-query'
 import { useCheckPermissions, useStore } from 'hooks'
 import { delete_, post } from 'lib/common/fetch'
 import { API_URL, PRICING_TIER_PRODUCT_IDS } from 'lib/constants'
+import { useProjectSubscriptionV2Query } from 'data/subscriptions/project-subscription-v2-query'
 
 export interface DeleteProjectButtonProps {
   type?: 'danger' | 'default'
@@ -24,8 +25,9 @@ const DeleteProjectButton = ({ type = 'danger' }: DeleteProjectButtonProps) => {
 
   const { project } = useProjectContext()
   const projectRef = project?.ref
-  const projectTier = project?.subscription_tier ?? PRICING_TIER_PRODUCT_IDS.FREE
-  const isFree = projectTier === PRICING_TIER_PRODUCT_IDS.FREE
+  const { data: subscription } = useProjectSubscriptionV2Query({ projectRef })
+  const projectPlan = subscription?.plan?.id ?? 'free'
+  const isFree = projectPlan === PRICING_TIER_PRODUCT_IDS.FREE
 
   const [isOpen, setIsOpen] = useState(false)
   const [loading, setLoading] = useState(false)

--- a/studio/components/layouts/ProjectLayout/LayoutHeader/LayoutHeader.tsx
+++ b/studio/components/layouts/ProjectLayout/LayoutHeader/LayoutHeader.tsx
@@ -6,13 +6,14 @@ import { getResourcesExceededLimits } from 'components/ui/OveragesBanner/Overage
 import { useProjectReadOnlyQuery } from 'data/config/project-read-only-query'
 import { useProjectUsageQuery } from 'data/usage/project-usage-query'
 import { useFlag, useSelectedOrganization, useSelectedProject } from 'hooks'
-import { IS_PLATFORM, PRICING_TIER_PRODUCT_IDS } from 'lib/constants'
+import { IS_PLATFORM } from 'lib/constants'
 import BreadcrumbsView from './BreadcrumbsView'
 import FeedbackDropdown from './FeedbackDropdown'
 import HelpPopover from './HelpPopover'
 import NotificationsPopover from './NotificationsPopover'
 import OrgDropdown from './OrgDropdown'
 import ProjectDropdown from './ProjectDropdown'
+import { useProjectSubscriptionV2Query } from 'data/subscriptions/project-subscription-v2-query'
 
 const LayoutHeader = ({ customHeaderComponents, breadcrumbs = [], headerBorder = true }: any) => {
   const selectedOrganization = useSelectedOrganization()
@@ -27,14 +28,13 @@ const LayoutHeader = ({ customHeaderComponents, breadcrumbs = [], headerBorder =
   const { data: usage } = useProjectUsageQuery({ projectRef })
   const resourcesExceededLimits = getResourcesExceededLimits(usage)
 
-  const projectHasNoLimits =
-    selectedProject?.subscription_tier === PRICING_TIER_PRODUCT_IDS.PAYG ||
-    selectedProject?.subscription_tier === PRICING_TIER_PRODUCT_IDS.ENTERPRISE ||
-    selectedProject?.subscription_tier === PRICING_TIER_PRODUCT_IDS.TEAM
+  const { data: subscription } = useProjectSubscriptionV2Query({ projectRef })
+
+  const projectHasNoLimits = subscription?.usage_billing_enabled === false
 
   const showOverUsageBadge =
     useFlag('overusageBadge') &&
-    selectedProject?.subscription_tier !== undefined &&
+    subscription !== undefined &&
     !projectHasNoLimits &&
     resourcesExceededLimits.length > 0
 

--- a/studio/components/ui/UpgradeToPro.tsx
+++ b/studio/components/ui/UpgradeToPro.tsx
@@ -3,11 +3,9 @@ import { PermissionAction } from '@supabase/shared-types/out/constants'
 import Link from 'next/link'
 import { FC, ReactNode } from 'react'
 
-import { useParams } from 'common/hooks'
-import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
 import { useCheckPermissions, useFlag } from 'hooks'
-import { PRICING_TIER_PRODUCT_IDS } from 'lib/constants'
 import { Button } from 'ui'
+import { useProjectSubscriptionV2Query } from 'data/subscriptions/project-subscription-v2-query'
 
 interface Props {
   icon?: ReactNode
@@ -17,9 +15,8 @@ interface Props {
 }
 
 const UpgradeToPro: FC<Props> = ({ icon, primaryText, projectRef, secondaryText }) => {
-  const { ref } = useParams()
-  const { project } = useProjectContext()
-  const tier = project?.subscription_tier
+  const { data: subscription } = useProjectSubscriptionV2Query({ projectRef })
+  const plan = subscription?.plan?.id
 
   const canUpdateSubscription = useCheckPermissions(
     PermissionAction.BILLING_WRITE,
@@ -48,13 +45,11 @@ const UpgradeToPro: FC<Props> = ({ icon, primaryText, projectRef, secondaryText 
             <Tooltip.Trigger>
               <Button type="primary" disabled={!canUpdateSubscription || projectUpdateDisabled}>
                 <Link
-                  href={`/project/${ref}/settings/billing/subscription${
-                    tier === PRICING_TIER_PRODUCT_IDS.FREE ? '?panel=subscriptionPlan' : ''
+                  href={`/project/${projectRef}/settings/billing/subscription${
+                    plan === 'free' ? '?panel=subscriptionPlan' : ''
                   }`}
                 >
-                  <a>
-                    {tier === PRICING_TIER_PRODUCT_IDS.FREE ? 'Upgrade to Pro' : 'Enable Addon'}
-                  </a>
+                  <a>{plan === 'free' ? 'Upgrade to Pro' : 'Enable Addon'}</a>
                 </Link>
               </Button>
             </Tooltip.Trigger>

--- a/studio/pages/project/[ref]/database/backups/pitr.tsx
+++ b/studio/pages/project/[ref]/database/backups/pitr.tsx
@@ -12,8 +12,8 @@ import Loading from 'components/ui/Loading'
 import NoPermission from 'components/ui/NoPermission'
 import UpgradeToPro from 'components/ui/UpgradeToPro'
 import { useCheckPermissions, useStore } from 'hooks'
-import { PRICING_TIER_PRODUCT_IDS } from 'lib/constants'
 import { NextPageWithLayout } from 'types'
+import { useProjectSubscriptionV2Query } from 'data/subscriptions/project-subscription-v2-query'
 
 const DatabasePhysicalBackups: NextPageWithLayout = () => {
   const router = useRouter()
@@ -59,8 +59,13 @@ const PITR = observer(() => {
   const { project } = useProjectContext()
   const { configuration, error, isLoading } = backups
 
+  const { data: subscription } = useProjectSubscriptionV2Query(
+    { projectRef: project?.ref },
+    { enabled: project?.ref !== undefined }
+  )
+
   const ref = project?.ref ?? 'default'
-  const tier = project?.subscription_tier
+  const plan = subscription?.plan?.id
   const isEnabled = configuration.walg_enabled
 
   const canReadPhysicalBackups = useCheckPermissions(PermissionAction.READ, 'physical_backups')
@@ -74,7 +79,7 @@ const PITR = observer(() => {
         projectRef={ref}
         primaryText="Point in time recovery is a Pro plan add-on."
         secondaryText={
-          tier === PRICING_TIER_PRODUCT_IDS.FREE
+          plan === 'free'
             ? 'Upgrade to the Pro plan with the PITR add-on selected to enable point in time recovery for your project.'
             : 'Please enable the add-on to enable point in time recovery for your project.'
         }

--- a/studio/pages/project/[ref]/index.tsx
+++ b/studio/pages/project/[ref]/index.tsx
@@ -10,7 +10,6 @@ import { NextPageWithLayout } from 'types'
 
 const Home: NextPageWithLayout = () => {
   const { project } = useProjectContext()
-  const projectTier = project?.subscription_tier
 
   const projectName =
     project?.ref !== 'default' && project?.name !== undefined

--- a/studio/pages/project/[ref]/reports/database.tsx
+++ b/studio/pages/project/[ref]/reports/database.tsx
@@ -4,11 +4,7 @@ import { useEffect, useState } from 'react'
 
 import { useParams } from 'common/hooks'
 import { useStore } from 'hooks'
-import {
-  PRICING_TIER_PRODUCT_IDS,
-  TIME_PERIODS_INFRA,
-  USAGE_APPROACHING_THRESHOLD,
-} from 'lib/constants'
+import { TIME_PERIODS_INFRA, USAGE_APPROACHING_THRESHOLD } from 'lib/constants'
 import { formatBytes } from 'lib/helpers'
 import { NextPageWithLayout } from 'types'
 import { Badge, Button, IconArrowRight, IconExternalLink } from 'ui'
@@ -20,6 +16,7 @@ import DateRangePicker from 'components/to-be-cleaned/DateRangePicker'
 import Panel from 'components/ui/Panel'
 import SparkBar from 'components/ui/SparkBar'
 import { useProjectUsageQuery } from 'data/usage/project-usage-query'
+import { useProjectSubscriptionV2Query } from 'data/subscriptions/project-subscription-v2-query'
 
 const DatabaseReport: NextPageWithLayout = () => {
   return (
@@ -45,6 +42,7 @@ const DatabaseUsage = observer(() => {
 
   const { ref: projectRef } = useParams()
   const { data: usage } = useProjectUsageQuery({ projectRef })
+  const { data: subscription } = useProjectSubscriptionV2Query({ projectRef })
 
   const databaseSizeLimit = usage?.db_size?.limit ?? 0
   const databaseEgressLimit = usage?.db_egress?.limit ?? 0
@@ -75,9 +73,9 @@ const DatabaseUsage = observer(() => {
   const egressIsApproaching = databaseSizeUsageRatio >= USAGE_APPROACHING_THRESHOLD
   const egressIsExceeded = databaseSizeUsageRatio >= 1
 
-  const subscriptionTier = project?.subscription_tier
+  const subscriptionPlan = subscription?.plan?.id
 
-  const isPaidTier = subscriptionTier !== PRICING_TIER_PRODUCT_IDS.FREE
+  const isPaidTier = subscriptionPlan !== 'free'
 
   return (
     <>

--- a/studio/types/base.ts
+++ b/studio/types/base.ts
@@ -30,8 +30,6 @@ export interface Project extends ProjectBase {
   dbVersion?: string
   kpsVersion?: string
   restUrl?: string
-  // store subscription tier products.metadata.supabase_prod_id
-  subscription_tier?: string
 
   /**
    * postgrestStatus is available on client side only.


### PR DESCRIPTION
With the recent MOBX refactoring, we no longer have `subscription_tier` property in the project store. This PR replaces the calls with actual react-query calls to get the subscription