### PR TITLE
chore: add upgrade plan button on free project limit

### DIFF
--- a/studio/components/interfaces/Organization/NewProject/FreeProjectLimitWarning.tsx
+++ b/studio/components/interfaces/Organization/NewProject/FreeProjectLimitWarning.tsx
@@ -1,15 +1,18 @@
 import { FC } from 'react'
-import { IconAlertCircle } from 'ui'
+import { Button, IconAlertCircle } from 'ui'
 import InformationBox from 'components/ui/InformationBox'
 import { MemberWithFreeProjectLimit } from 'data/organizations/free-project-limit-check-query'
+import Link from 'next/link'
 
 interface Props {
   membersExceededLimit: MemberWithFreeProjectLimit[]
+  orgLevelBilling: boolean
+  orgSlug: string
 }
 
-const FreeProjectLimitWarning: FC<Props> = ({ membersExceededLimit }) => {
+const FreeProjectLimitWarning: FC<Props> = ({ membersExceededLimit, orgLevelBilling, orgSlug }) => {
   return (
-    <div className="mt-4">
+    <div>
       <InformationBox
         icon={<IconAlertCircle className="text-scale-1200" size="large" strokeWidth={1.5} />}
         defaultVisibility={true}
@@ -33,6 +36,16 @@ const FreeProjectLimitWarning: FC<Props> = ({ membersExceededLimit }) => {
               These members will need to either delete, pause, or upgrade one or more of these
               projects before you're able to create a free project within this organization.
             </p>
+
+            {orgLevelBilling && (
+              <div>
+                <Link href={`/org/${orgSlug}/billing?panel=subscriptionPlan`} passHref>
+                  <a target="_blank">
+                    <Button type="primary">Upgrade plan</Button>
+                  </a>
+                </Link>
+              </div>
+            )}
           </div>
         }
       />

--- a/studio/pages/new/[slug].tsx
+++ b/studio/pages/new/[slug].tsx
@@ -549,8 +549,14 @@ const Wizard: NextPageWithLayout = () => {
                   </Listbox>
                 )}
 
-                {freePlanWithExceedingLimits && (
-                  <FreeProjectLimitWarning membersExceededLimit={membersExceededLimit || []} />
+                {freePlanWithExceedingLimits && slug && (
+                  <div className={billedViaOrg ? '' : 'mt-4'}>
+                    <FreeProjectLimitWarning
+                      membersExceededLimit={membersExceededLimit || []}
+                      orgLevelBilling={billedViaOrg}
+                      orgSlug={slug}
+                    />
+                  </div>
                 )}
 
                 {!billedViaOrg && !isSelectFreeTier && isEmptyPaymentMethod && (


### PR DESCRIPTION
When launching another project with org-level-billing and the free project limit is reached, add a button to upgrade the org plan.

![Screenshot 2023-07-17 at 15 59 03](https://github.com/supabase/supabase/assets/14073399/ba2365f0-b617-4599-9ca3-8201fb6b5a4f)
