### PR TITLE
fix: spend cap side panel costs

### DIFF
--- a/studio/components/interfaces/BillingV2/Subscription/CostControl/SpendCapSidePanel.tsx
+++ b/studio/components/interfaces/BillingV2/Subscription/CostControl/SpendCapSidePanel.tsx
@@ -187,7 +187,7 @@ const SpendCapSidePanel = () => {
                             </Table.td>
                             <Table.td>
                               <p className="text-xs pl-4">
-                                {item.plans[subscription?.plan?.id || 'pro']}
+                                {item.plans['pro']}
                               </p>
                             </Table.td>
                           </Table.tr>

--- a/studio/components/interfaces/Organization/BillingSettingsV2/CostControl/SpendCapSidePanel.tsx
+++ b/studio/components/interfaces/Organization/BillingSettingsV2/CostControl/SpendCapSidePanel.tsx
@@ -187,9 +187,7 @@ const SpendCapSidePanel = () => {
                               <p className="text-xs pl-4">{item.title}</p>
                             </Table.td>
                             <Table.td>
-                              <p className="text-xs pl-4">
-                                {item.plans[subscription?.plan?.id || 'pro']}
-                              </p>
+                              <p className="text-xs pl-4">{item.plans['pro']}</p>
                             </Table.td>
                           </Table.tr>
                         )


### PR DESCRIPTION
Spend cap is only relevant for Pro plan, so this should always should the numbers from the pro plan. Previously, this showed free plan limits on the free plan, which does not make sense.