### PR TITLE
fix: remove icon from Edge Functions layout

### DIFF
--- a/studio/components/layouts/FunctionsLayout.tsx
+++ b/studio/components/layouts/FunctionsLayout.tsx
@@ -53,14 +53,6 @@ const FunctionsLayout: FC<Props> = ({ title, children }) => {
             xl:flex-row"
             >
               <div className="flex items-center gap-3">
-                <div
-                  className={[
-                    'h-6 w-6 rounded border border-brand-600 bg-brand-300',
-                    'flex items-center justify-center text-brand-900',
-                  ].join(' ')}
-                >
-                  <IconCode size={14} strokeWidth={3} />
-                </div>
                 <div className="flex items-center space-x-4">
                   <h1 className="text-2xl text-scale-1200">Edge Functions</h1>
                 </div>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Removes the old icon used in the Edge Functions layout. Fixed #15776 

## What is the current behavior?

Currently Edge Functions page layout uses an icon which is inconsistent with rest of the sidebar icons.

## What is the new behavior?

No more icon in Edge Functions page layout.

## Additional context

Add any other context or screenshots.
