### PR TITLE
fix: usage fees on Enterprise plan

### DIFF
--- a/studio/components/interfaces/BillingV2/Subscription/BillingBreakdown.tsx
+++ b/studio/components/interfaces/BillingV2/Subscription/BillingBreakdown.tsx
@@ -177,7 +177,7 @@ const BillingBreakdown = ({}: BillingBreakdownProps) => {
                           </div>
                         </a>
                       </Link>
-                      {isUsageBillingEnabled && usageFee && (
+                      {isUsageBillingEnabled && hasLimit && usageFee && (
                         <Tooltip.Root delayDuration={0}>
                           <Tooltip.Trigger>
                             <div className="flex items-center">

--- a/studio/components/interfaces/Organization/BillingSettingsV2/BillingBreakdown/BillingMetric.tsx
+++ b/studio/components/interfaces/Organization/BillingSettingsV2/BillingBreakdown/BillingMetric.tsx
@@ -67,7 +67,7 @@ const BillingMetric = ({ idx, slug, metric, usage, subscription }: BillingMetric
           </a>
         </Link>
 
-        {isUsageBillingEnabled && usageFee && (
+        {isUsageBillingEnabled && hasLimit && usageFee && (
           <Tooltip.Root delayDuration={0}>
             <Tooltip.Trigger>
               <div className="flex items-center">


### PR DESCRIPTION
There were empty tooltips for metrics with unlimited quota.

![image](https://github.com/supabase/supabase/assets/14073399/4c8e5d96-a324-466a-9a11-8c65725bee6e)

PR fixes it to only display metrics that have a limited quota.

<img width="858" alt="Screenshot 2023-07-18 at 00 40 48" src="https://github.com/supabase/supabase/assets/14073399/a889acad-a46c-488d-95a7-19300aa251bb">
