### PR TITLE
fix: disallow self-serve downgrade from Enterprise

### DIFF
--- a/studio/components/interfaces/Organization/BillingSettingsV2/Subscription/PlanUpdateSidePanel.tsx
+++ b/studio/components/interfaces/Organization/BillingSettingsV2/Subscription/PlanUpdateSidePanel.tsx
@@ -201,10 +201,8 @@ const PlanUpdateSidePanel = () => {
                             <Button
                               block
                               disabled={
-                                // no self-serve downgrades from team plan right now
-                                (plan.id !== PRICING_TIER_PRODUCT_IDS.TEAM &&
-                                  ['enterprise'].includes(subscription?.plan?.id || '')) ||
-                                !canUpdateSubscription
+                                // No self-serve downgrades from Enterprise
+                                subscription?.plan?.id === 'enterprise' || !canUpdateSubscription
                               }
                               type={isDowngradeOption ? 'default' : 'primary'}
                               onClick={() => {


### PR DESCRIPTION
It was possibly to downgrade from Enterprise -> Teams as self-serve by using the panel query param. This PR ensures downgrade to from enterprise -> team is not self-serve.