### PR TITLE
Minor fixes to the Partner Integrations site

### DIFF
--- a/apps/www/components/Footer/index.tsx
+++ b/apps/www/components/Footer/index.tsx
@@ -132,7 +132,11 @@ const Footer = (props: Props) => {
 
                         return (
                           <li key={`${segment.title}_link_${idx}`}>
-                            {link.url.startsWith('https') ? <Fragment>{children}</Fragment> : <Link href={link.url}>{children}</Link>}
+                            {link.url.startsWith('https') ? (
+                              <Fragment>{children}</Fragment>
+                            ) : (
+                              <Link href={link.url}>{children}</Link>
+                            )}
                           </li>
                         )
                       })}

--- a/apps/www/components/Footer/index.tsx
+++ b/apps/www/components/Footer/index.tsx
@@ -109,30 +109,30 @@ const Footer = (props: Props) => {
                     <h6 className="text-scale-1200 overwrite text-base">{segment.title}</h6>
                     <ul className="mt-4 space-y-2">
                       {segment.links.map((link, idx) => {
-                        const LinkTag = link.url.startsWith('https') ? Fragment : Link
+                        const children = (
+                          <a
+                            // only add href key if link is external
+                            {...(link.url.startsWith('https') && { href: link.url })}
+                            className={`text-sm transition-colors ${
+                              link.url
+                                ? 'text-scale-1100 hover:text-scale-1200 '
+                                : 'text-scale-900 hover:text-scale-900'
+                            } `}
+                          >
+                            {link.text}
+                            {!link.url && (
+                              <div className="ml-2 inline text-xs xl:ml-0 xl:block 2xl:ml-2 2xl:inline">
+                                <Badge color="scale" size="small">
+                                  Coming soon
+                                </Badge>
+                              </div>
+                            )}
+                          </a>
+                        )
 
                         return (
                           <li key={`${segment.title}_link_${idx}`}>
-                            <LinkTag href={link.url}>
-                              <a
-                                // only add href key if link is external
-                                {...(link.url.startsWith('https') && { href: link.url })}
-                                className={`text-sm transition-colors ${
-                                  link.url
-                                    ? 'text-scale-1100 hover:text-scale-1200 '
-                                    : 'text-scale-900 hover:text-scale-900'
-                                } `}
-                              >
-                                {link.text}
-                                {!link.url && (
-                                  <div className="ml-2 inline text-xs xl:ml-0 xl:block 2xl:ml-2 2xl:inline">
-                                    <Badge color="scale" size="small">
-                                      Coming soon
-                                    </Badge>
-                                  </div>
-                                )}
-                              </a>
-                            </LinkTag>
+                            {link.url.startsWith('https') ? <Fragment>{children}</Fragment> : <Link href={link.url}>{children}</Link>}
                           </li>
                         )
                       })}

--- a/apps/www/components/ImageModal.tsx
+++ b/apps/www/components/ImageModal.tsx
@@ -1,4 +1,4 @@
-import  { useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import * as Dialog from '@radix-ui/react-dialog'
 

--- a/apps/www/components/ImageModal.tsx
+++ b/apps/www/components/ImageModal.tsx
@@ -1,0 +1,80 @@
+import React, { useEffect } from 'react'
+
+import * as Dialog from '@radix-ui/react-dialog'
+
+import styleHandler from 'ui/src/lib/theme/styleHandler'
+
+export type ImageModalProps = RadixProps & Props
+
+interface RadixProps
+  extends Dialog.DialogProps,
+    Pick<
+      Dialog.DialogContentProps,
+      | 'onOpenAutoFocus'
+      | 'onCloseAutoFocus'
+      | 'onEscapeKeyDown'
+      | 'onPointerDownOutside'
+      | 'onInteractOutside'
+    > {}
+
+interface Props {
+  children?: React.ReactNode
+  onCancel?: any
+  visible: boolean
+  size?: 'tiny' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge'
+  className?: string
+}
+
+/**
+ * Similar to ui/Modal component but with an unstyled dialog content component. 
+ * Mainly used to show images in a overlay.
+ */
+const ImageModal = ({
+  children,
+  onCancel = () => {},
+  visible = false,
+  size = 'large',
+  className = '',
+}: ImageModalProps) => {
+  const [open, setOpen] = React.useState(visible ? visible : false)
+
+  const __styles = styleHandler('modal')
+
+  useEffect(() => {
+    setOpen(visible)
+  }, [visible])
+
+  function handleOpenChange(open: boolean) {
+    if (visible !== undefined && !open) {
+      // controlled component behaviour
+      onCancel()
+    } else {
+      // un-controlled component behaviour
+      setOpen(open)
+    }
+  }
+
+  const contentClasses =
+    'relative data-open:animate-overlay-show data-closed:animate-overlay-hide'
+
+  return (
+    <Dialog.Root open={open} onOpenChange={handleOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className={__styles.overlay} />
+        <Dialog.Overlay className={__styles.scroll_overlay}>
+          <Dialog.Content className={[contentClasses, __styles.size[size], className].join(' ')}>
+            {children}
+          </Dialog.Content>
+        </Dialog.Overlay>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}
+
+function Content({ children }: { children: React.ReactNode }) {
+  const __styles = styleHandler('modal')
+  return <div className={__styles.content}>{children}</div>
+}
+
+ImageModal.Content = Content
+export default ImageModal

--- a/apps/www/components/ImageModal.tsx
+++ b/apps/www/components/ImageModal.tsx
@@ -1,4 +1,4 @@
-import  { useEffect } from 'react'
+import  { useEffect, useState } from 'react'
 
 import * as Dialog from '@radix-ui/react-dialog'
 
@@ -36,7 +36,7 @@ const ImageModal = ({
   size = 'large',
   className = '',
 }: ImageModalProps) => {
-  const [open, setOpen] = React.useState(visible ? visible : false)
+  const [open, setOpen] = useState(visible ? visible : false)
 
   const __styles = styleHandler('modal')
 

--- a/apps/www/components/ImageModal.tsx
+++ b/apps/www/components/ImageModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import  { useEffect } from 'react'
 
 import * as Dialog from '@radix-ui/react-dialog'
 

--- a/apps/www/components/ImageModal.tsx
+++ b/apps/www/components/ImageModal.tsx
@@ -26,7 +26,7 @@ interface Props {
 }
 
 /**
- * Similar to ui/Modal component but with an unstyled dialog content component. 
+ * Similar to ui/Modal component but with an unstyled dialog content component.
  * Mainly used to show images in a overlay.
  */
 const ImageModal = ({
@@ -46,16 +46,15 @@ const ImageModal = ({
 
   function handleOpenChange(open: boolean) {
     if (visible !== undefined && !open) {
-      // controlled component behaviour
+      // controlled component behavior
       onCancel()
     } else {
-      // un-controlled component behaviour
+      // un-controlled component behavior
       setOpen(open)
     }
   }
 
-  const contentClasses =
-    'relative data-open:animate-overlay-show data-closed:animate-overlay-hide'
+  const contentClasses = 'relative data-open:animate-overlay-show data-closed:animate-overlay-hide'
 
   return (
     <Dialog.Root open={open} onOpenChange={handleOpenChange}>

--- a/apps/www/pages/partners/integrations/[slug].tsx
+++ b/apps/www/pages/partners/integrations/[slug].tsx
@@ -41,7 +41,6 @@ function Partner({ partner }: { partner: Partner }) {
           onCancel={() => setFocusedImage(null)}
           size="xxlarge"
           className="w-full outline-none"
-          // hideFooter
         >
           <Image
             layout="responsive"

--- a/apps/www/pages/partners/integrations/[slug].tsx
+++ b/apps/www/pages/partners/integrations/[slug].tsx
@@ -5,14 +5,18 @@ import Image from 'next/image'
 import Link from 'next/link'
 import { Swiper, SwiperSlide } from 'swiper/react'
 import 'swiper/swiper.min.css'
-import { IconChevronLeft, IconExternalLink } from 'ui'
+import { IconChevronLeft, IconExternalLink, Modal } from 'ui'
 import DefaultLayout from '~/components/Layouts/Default'
 import SectionContainer from '~/components/Layouts/SectionContainer'
 import supabase from '~/lib/supabase'
 import { Partner } from '~/types/partners'
 import Error404 from '../../404'
+import { useState } from 'react'
+import ImageModal from '~/components/ImageModal'
 
 function Partner({ partner }: { partner: Partner }) {
+  const [focusedImage, setFocusedImage] = useState<string | null>(null)
+
   if (!partner) return <Error404 />
   return (
     <>
@@ -31,6 +35,24 @@ function Partner({ partner }: { partner: Partner }) {
         }}
       />
 
+      {focusedImage ? (
+        <ImageModal
+          visible
+          onCancel={() => setFocusedImage(null)}
+          size="xxlarge"
+          className="w-full outline-none"
+          // hideFooter
+        >
+          <Image
+            layout="responsive"
+            objectFit="contain"
+            width={1152}
+            height={766}
+            src={focusedImage!}
+            alt={partner.title}
+          />
+        </ImageModal>
+      ) : null}
       <DefaultLayout>
         <SectionContainer>
           <div className="col-span-12 mx-auto mb-2 max-w-5xl space-y-12 lg:col-span-2">
@@ -80,7 +102,7 @@ function Partner({ partner }: { partner: Partner }) {
                   1024: {
                     slidesPerView: 4,
                   },
-                  1208: {
+                  1280: {
                     slidesPerView: 5,
                   },
                 }}
@@ -96,6 +118,7 @@ function Partner({ partner }: { partner: Partner }) {
                           height={960}
                           src={image}
                           alt={partner.title}
+                          onClick={() => setFocusedImage(image)}
                         />
                       </div>
                     </SwiperSlide>

--- a/apps/www/pages/partners/integrations/index.tsx
+++ b/apps/www/pages/partners/integrations/index.tsx
@@ -164,11 +164,11 @@ function IntegrationPartnersPage(props: Props) {
                           fill="none"
                           viewBox="0 0 24 24"
                           stroke="currentColor"
-                          stroke-width="1"
+                          strokeWidth="1"
                         >
                           <path
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
                             d="M21 13.255A23.931 23.931 0 0112 15c-3.183 0-6.22-.62-9-1.745M16 6V4a2 2 0 00-2-2h-4a2 2 0 00-2 2v2m4 6h.01M5 20h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
                           />
                         </svg>
@@ -187,11 +187,11 @@ function IntegrationPartnersPage(props: Props) {
                           fill="none"
                           viewBox="0 0 24 24"
                           stroke="currentColor"
-                          stroke-width="1"
+                          strokeWidth="1"
                         >
                           <path
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
                             d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"
                           />
                         </svg>


### PR DESCRIPTION
This PR fixes several minor points related to the Integrations site on supabase.com:
- Add a modal which zooms in a specific image from a specific partner page (try clicking on an image [here](https://zone-www-dot-com-git-feat-integrations-v2-supabase.vercel.app/partners/integrations/sequin_io)).
- Fix a warning about adding a `href` prop on React Fragment.
- Fix a warning about SVG props not being properly cased.