### PR TITLE
fix: usage page crash after creating project

### DIFF
--- a/studio/components/interfaces/BillingV2/Usage/Infrastructure.tsx
+++ b/studio/components/interfaces/BillingV2/Usage/Infrastructure.tsx
@@ -88,7 +88,7 @@ const Infrastructure = ({
   const hasLatest = dayjs(endDate!).isAfter(dayjs().startOf('day'))
 
   const latestIoBudgetConsumption =
-    hasLatest && ioBudgetData?.data?.slice(-1)
+    hasLatest && ioBudgetData?.data?.slice(-1)?.[0]
       ? Number(ioBudgetData.data.slice(-1)[0].disk_io_consumption)
       : 0
 


### PR DESCRIPTION
Usage page crashed on local after launching new project