### PR TITLE
Fix vercel previews to auth redirect reliably 

### DIFF
--- a/studio/components/interfaces/SignIn/ForgotPasswordForm.tsx
+++ b/studio/components/interfaces/SignIn/ForgotPasswordForm.tsx
@@ -35,7 +35,7 @@ const ForgotPasswordForm = () => {
       hcaptchaToken: token ?? undefined,
       redirectTo: `${
         process.env.NEXT_PUBLIC_VERCEL_ENV === 'preview'
-          ? `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`
+          ? location.origin
           : process.env.NEXT_PUBLIC_SITE_URL
       }${BASE_PATH}/reset-password`,
     })

--- a/studio/components/interfaces/SignIn/SignInSSOForm.tsx
+++ b/studio/components/interfaces/SignIn/SignInSSOForm.tsx
@@ -36,7 +36,7 @@ const SignInSSOForm = () => {
         captchaToken: token ?? undefined,
         redirectTo: `${
           process.env.NEXT_PUBLIC_VERCEL_ENV === 'preview'
-            ? `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`
+            ? location.origin
             : process.env.NEXT_PUBLIC_SITE_URL
         }${BASE_PATH}${getReturnToPath()}`,
       },

--- a/studio/components/interfaces/SignIn/SignInWithGitHub.tsx
+++ b/studio/components/interfaces/SignIn/SignInWithGitHub.tsx
@@ -22,7 +22,7 @@ const SignInWithGitHub = () => {
         options: {
           redirectTo: `${
             process.env.NEXT_PUBLIC_VERCEL_ENV === 'preview'
-              ? `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`
+              ? location.origin
               : process.env.NEXT_PUBLIC_SITE_URL
           }${BASE_PATH}${getReturnToPath()}`,
         },

--- a/studio/components/interfaces/SignIn/SignUpForm.tsx
+++ b/studio/components/interfaces/SignIn/SignUpForm.tsx
@@ -42,7 +42,7 @@ const SignUpForm = () => {
       hcaptchaToken: token ?? null,
       redirectTo: `${
         process.env.NEXT_PUBLIC_VERCEL_ENV === 'preview'
-          ? `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`
+          ? location.origin
           : process.env.NEXT_PUBLIC_SITE_URL
       }${BASE_PATH}/sign-in`,
     })

--- a/turbo.json
+++ b/turbo.json
@@ -37,7 +37,9 @@
         "SENTRY_URL",
         "SESSION_COOKIE_SECRET",
         "SUPABASE_ENCRYPTION_KEY",
-        "PLATFORM_PG_META_URL"
+        "PLATFORM_PG_META_URL",
+        "NEXT_PUBLIC_VERCEL_URL",
+        "NEXT_PUBLIC_VERCEL_ENV"
       ],
       "outputs": [".next/**", "!.next/cache/**"]
     },

--- a/turbo.json
+++ b/turbo.json
@@ -38,8 +38,8 @@
         "SESSION_COOKIE_SECRET",
         "SUPABASE_ENCRYPTION_KEY",
         "PLATFORM_PG_META_URL",
-        "NEXT_PUBLIC_VERCEL_URL",
-        "NEXT_PUBLIC_VERCEL_ENV"
+        "NEXT_PUBLIC_VERCEL_ENV",
+        "NEXT_PUBLIC_SITE_URL"
       ],
       "outputs": [".next/**", "!.next/cache/**"]
     },


### PR DESCRIPTION
## What kind of change does this PR introduce?

- issue with Vercel preview urls in env vars perhaps being wrongly cached
- opted to use location.origin rather than relying on NEXT_PUBLIC_VERCEL_URL which doesn't cover the latest branch based preview url.

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
