### PR TITLE
fix: hcaptcha remains clickable in modal

### DIFF
--- a/studio/components/interfaces/BillingV2/AddNewPaymentMethodModal/AddNewPaymentMethodModal.tsx
+++ b/studio/components/interfaces/BillingV2/AddNewPaymentMethodModal/AddNewPaymentMethodModal.tsx
@@ -111,10 +111,18 @@ const AddNewPaymentMethodModal = ({
         ref={captchaRefCallback}
         sitekey={process.env.NEXT_PUBLIC_HCAPTCHA_SITE_KEY!}
         size="invisible"
+        onOpen={() => {
+          // [Joshen] This is to ensure that hCaptcha popup remains clickable
+          if (document !== undefined) document.body.classList.add('!pointer-events-auto')
+        }}
+        onClose={() => {
+          onLocalCancel()
+          if (document !== undefined) document.body.classList.remove('!pointer-events-auto')
+        }}
         onVerify={(token) => {
           setCaptchaToken(token)
+          if (document !== undefined) document.body.classList.remove('!pointer-events-auto')
         }}
-        onClose={onLocalCancel}
         onExpire={() => {
           setCaptchaToken(null)
         }}


### PR DESCRIPTION
When clicking HCaptcha in the modal, the captcha currently closes the entire modal and it's impossible to complete. We already have this fix in several other modals.