### PR TITLE
chore: do not query project usage with org-level-billing

### DIFF
--- a/studio/components/layouts/ProjectLayout/LayoutHeader/LayoutHeader.tsx
+++ b/studio/components/layouts/ProjectLayout/LayoutHeader/LayoutHeader.tsx
@@ -25,10 +25,18 @@ const LayoutHeader = ({ customHeaderComponents, breadcrumbs = [], headerBorder =
     connectionString: selectedProject?.connectionString,
   })
 
-  const { data: usage } = useProjectUsageQuery({ projectRef })
+  // Skip with org-level-billing, as quota is for the entire org
+  const { data: usage } = useProjectUsageQuery(
+    { projectRef },
+    { enabled: selectedOrganization && !selectedOrganization.subscription_id }
+  )
   const resourcesExceededLimits = getResourcesExceededLimits(usage)
 
-  const { data: subscription } = useProjectSubscriptionV2Query({ projectRef })
+  // Skip with org-level-billing, as quota is for the entire org
+  const { data: subscription } = useProjectSubscriptionV2Query(
+    { projectRef },
+    { enabled: selectedOrganization && !selectedOrganization.subscription_id }
+  )
 
   const projectHasNoLimits = subscription?.usage_billing_enabled === false
 


### PR DESCRIPTION
With org-level-billing, quotas are for the entire org, so it doesn't make sense to show an over-age banner based on the project limits. We'll eventually introduce new banners for org over-usage, this adjustments prevents confusing reports.