### PR TITLE
fix: Update path to the SMTP settings page in the guides

### DIFF
--- a/apps/docs/pages/guides/platform/going-into-prod.mdx
+++ b/apps/docs/pages/guides/platform/going-into-prod.mdx
@@ -21,7 +21,7 @@ After developing your project and deciding it's Production Ready, you should run
   - Go to the Authentication > Policies page in the Supabase Dashboard to enable RLS and create security policies.
   - Go to the Database > Replication page in the Supabase Dashboard to manage replication tables.
 - Enable 2FA on GitHub. Since your GitHub account gives you administrative rights to your Supabase project, you should protect it with a strong password and 2FA using a U2F key or a TOTP app.
-- Ensure email confirmations are enabled in the `Auth > Settings` page.
+- Ensure email confirmations are enabled in the `Project Settings > Auth` page.
 - Use a custom SMTP server for auth emails so that your users can see that the mails are coming from a trusted domain (preferably the same domain that your app is hosted on). Grab SMTP credentials from any major email provider such as SendGrid, AWS SES, etc.
 - Think hard about how _you_ would abuse your service as an attacker, and mitigate.
 - Review these [common cybersecurity threats](https://auth0.com/docs/security/prevent-threats).
@@ -39,7 +39,7 @@ After developing your project and deciding it's Production Ready, you should run
 
 ## Availability
 
-- Use your own SMTP credentials so that you have full control over the deliverability of your transactional auth emails (see Auth > Settings)
+- Use your own SMTP credentials so that you have full control over the deliverability of your transactional auth emails (see Project Settings > Auth)
   - you can grab SMTP credentials from any major email provider such as SendGrid, AWS SES, etc.
   - The default rate limit for auth emails provided by Supabase is 30 new users per hour, if doing a major public announcement you will likely require more than this.
 - If your application is on the free plan and is **not** expected to be queried at least once every 7 days, then it may be paused by Supabase to save on server resources.

--- a/apps/docs/pages/guides/platform/going-into-prod.mdx
+++ b/apps/docs/pages/guides/platform/going-into-prod.mdx
@@ -21,7 +21,7 @@ After developing your project and deciding it's Production Ready, you should run
   - Go to the Authentication > Policies page in the Supabase Dashboard to enable RLS and create security policies.
   - Go to the Database > Replication page in the Supabase Dashboard to manage replication tables.
 - Enable 2FA on GitHub. Since your GitHub account gives you administrative rights to your Supabase project, you should protect it with a strong password and 2FA using a U2F key or a TOTP app.
-- Ensure email confirmations are enabled in the `Project Settings > Auth` page.
+- Ensure email confirmations are enabled in the `Settings > Auth` page.
 - Use a custom SMTP server for auth emails so that your users can see that the mails are coming from a trusted domain (preferably the same domain that your app is hosted on). Grab SMTP credentials from any major email provider such as SendGrid, AWS SES, etc.
 - Think hard about how _you_ would abuse your service as an attacker, and mitigate.
 - Review these [common cybersecurity threats](https://auth0.com/docs/security/prevent-threats).
@@ -39,7 +39,7 @@ After developing your project and deciding it's Production Ready, you should run
 
 ## Availability
 
-- Use your own SMTP credentials so that you have full control over the deliverability of your transactional auth emails (see Project Settings > Auth)
+- Use your own SMTP credentials so that you have full control over the deliverability of your transactional auth emails (see Settings > Auth)
   - you can grab SMTP credentials from any major email provider such as SendGrid, AWS SES, etc.
   - The default rate limit for auth emails provided by Supabase is 30 new users per hour, if doing a major public announcement you will likely require more than this.
 - If your application is on the free plan and is **not** expected to be queried at least once every 7 days, then it may be paused by Supabase to save on server resources.

--- a/apps/docs/pages/learn/auth-deep-dive/auth-gotrue.mdx
+++ b/apps/docs/pages/learn/auth-deep-dive/auth-gotrue.mdx
@@ -40,7 +40,7 @@ curl -X POST 'https://<project-ref>.supabase.co/auth/v1/magiclink' \
 }'
 ```
 
-Gotrue is responsible for issuing access tokens for your users, sends confirmation, magic-link, and password recovery emails (by default we send these from a Supabase SMTP server, but you can easily plug in your own inside the dashboard at Auth > Settings) and also transacting with third party OAuth providers to get basic user data.
+Gotrue is responsible for issuing access tokens for your users, sends confirmation, magic-link, and password recovery emails (by default we send these from a Supabase SMTP server, but you can easily plug in your own inside the dashboard at Project Project Settings > Auth) and also transacting with third party OAuth providers to get basic user data.
 
 The community even recently built in the functionality to request custom OAuth scopes, if your users need to interact more closely with the provider. See the scopes parameter here: [https://github.com/supabase/gotrue#get-authorize](https://github.com/supabase/gotrue#get-authorize).
 

--- a/apps/docs/pages/learn/auth-deep-dive/auth-gotrue.mdx
+++ b/apps/docs/pages/learn/auth-deep-dive/auth-gotrue.mdx
@@ -40,7 +40,7 @@ curl -X POST 'https://<project-ref>.supabase.co/auth/v1/magiclink' \
 }'
 ```
 
-Gotrue is responsible for issuing access tokens for your users, sends confirmation, magic-link, and password recovery emails (by default we send these from a Supabase SMTP server, but you can easily plug in your own inside the dashboard at Project Project Settings > Auth) and also transacting with third party OAuth providers to get basic user data.
+Gotrue is responsible for issuing access tokens for your users, sends confirmation, magic-link, and password recovery emails (by default we send these from a Supabase SMTP server, but you can easily plug in your own inside the dashboard at Project Settings > Auth) and also transacting with third party OAuth providers to get basic user data.
 
 The community even recently built in the functionality to request custom OAuth scopes, if your users need to interact more closely with the provider. See the scopes parameter here: [https://github.com/supabase/gotrue#get-authorize](https://github.com/supabase/gotrue#get-authorize).
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

The custom SMTP settings used to be in `Auth > Settings`, but it was moved to `Settings > Auth`. I noticed it when I was looking up some things related to the [new email rate limits](https://github.com/orgs/supabase/discussions/15896), and thought we should guide everyone to the correct page.