### PR TITLE
Docs: Fix local developement variables naming

### DIFF
--- a/apps/docs/pages/guides/getting-started/local-development.mdx
+++ b/apps/docs/pages/guides/getting-started/local-development.mdx
@@ -426,8 +426,8 @@ redirect_uri = "http://localhost:54321/auth/v1/callback"
 As a best practice, any secret values should be loaded from environment variables. You can add them to `supabase/.env` for the CLI to automatically substitute them.
 
 ```bash supabase/.env
-SUPABASE_AUTH_GITHUB_CLIENT_ID="redacted"
-SUPABASE_AUTH_GITHUB_SECRET="redacted"
+GITHUB_CLIENT_ID="redacted"
+GITHUB_SECRET="redacted"
 ```
 
 For these changes to take effect, you need to run `supabase stop` and `supabase start` again.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Update docs with correct file example.

## What is the current behavior?

Local developement guide includes incorrect .env file, after copying config to local machine, `supabase start` throws error about unset env vars.

## What is the new behavior?

According to [this](https://supabase.com/docs/guides/cli/using-environment-variables-in-config) page, the .env variables are named correctly. After update the local developement is working correctly.