### PR TITLE
chore: filter out empty egress breakdown items

### DIFF
--- a/studio/components/interfaces/Organization/Usage/UsageChartTooltips.tsx
+++ b/studio/components/interfaces/Organization/Usage/UsageChartTooltips.tsx
@@ -81,15 +81,22 @@ export const MultiAttributeTooltipContent = ({
         <p className="text-scale-1000 text-lg">No data yet</p>
       ) : (
         <div className="space-y-1 pb-1">
-          {attributes.map((attr) => (
-            <AttributeContent
-              key={attr.name}
-              attribute={attr}
-              attributeMeta={values.find((x) => x.dataKey === attr.key)}
-              sumValue={sumValue}
-              tooltipFormatter={tooltipFormatter}
-            />
-          ))}
+          {attributes.flatMap((attr) => {
+            const attributeMeta = values.find((x) => x.dataKey === attr.key)
+
+            // Filter out empty attributes
+            if (Number(attributeMeta?.value ?? 0) === 0) return []
+
+            return (
+              <AttributeContent
+                key={attr.name}
+                attribute={attr}
+                attributeMeta={attributeMeta}
+                sumValue={sumValue}
+                tooltipFormatter={tooltipFormatter}
+              />
+            )
+          })}
         </div>
       )}
     </>


### PR DESCRIPTION
![image](https://github.com/supabase/supabase/assets/14073399/d2172583-9541-48d5-8703-95857021a179)

We currently show 0 values in the tooltip, this PR filters them out.