### PR TITLE
feat: use access token from ram instead of from `auth.getSession()`

### DIFF
--- a/studio/lib/common/fetch/base.ts
+++ b/studio/lib/common/fetch/base.ts
@@ -1,6 +1,7 @@
 import { auth } from 'lib/gotrue'
 import { isUndefined } from 'lodash'
 import { SupaResponse } from 'types/base'
+import { Session } from '@supabase/gotrue-js'
 
 export function handleError<T>(e: any, requestId: string): SupaResponse<T> {
   const message = e?.message ? `An error has occurred: ${e.message}` : 'An error has occurred'
@@ -86,15 +87,32 @@ export async function handleResponseError<T = unknown>(
   }
 }
 
+let currentSession: Session | null = null
+
+auth.onAuthStateChange((event, session) => {
+  currentSession = session
+})
+
 export async function getAccessToken() {
   // ignore if server-side
   if (typeof window === 'undefined') return ''
 
-  const {
-    data: { session },
-  } = await auth.getSession()
+  const aboutToExpire = currentSession?.expires_at
+    ? currentSession.expires_at - Math.ceil(Date.now() / 1000) < 60
+    : false
 
-  return session?.access_token
+  if (!currentSession || aboutToExpire) {
+    const {
+      data: { session },
+    } = await auth.getSession()
+
+    currentSession = session
+  }
+
+  // using memory version as gotrue-js can be a bit slow when using
+  // #getSession() as it has to read directly from local storage
+
+  return currentSession?.access_token
 }
 
 export async function constructHeaders(requestId: string, optionHeaders?: { [prop: string]: any }) {


### PR DESCRIPTION
`#getSession()` in gotrue-js can be a bit slow as it has to read from `localStorage` all the time to make sure it's returning consistent data. With some changes that are coming (see #15795) it's going to be even slower as there would only be a single such call per tab.

By storing and using the access token as seein in `onAuthStateChanged` notifications, issues of slowness or concurrent access will be significantly reduced. This is absolutely safe, as any tab that changes the session broadcasts the changes to other tabs. This might significantly reduce the reported occurrence of random logouts when using the SQL editor.