### PR TITLE
fix: only add upgrade-insecure-requests in production

### DIFF
--- a/studio/next.config.js
+++ b/studio/next.config.js
@@ -17,7 +17,7 @@ const path = require('path')
 const csp = [
   "frame-ancestors 'none';",
   // IS_PLATFORM
-  process.env.NEXT_PUBLIC_IS_PLATFORM === 'true' && process.env.NODE_ENV === 'production'
+  process.env.NEXT_PUBLIC_IS_PLATFORM === 'true' && process.env.NEXT_PUBLIC_ENVIRONMENT === 'prod'
     ? 'upgrade-insecure-requests;'
     : '',
 ]

--- a/studio/next.config.js
+++ b/studio/next.config.js
@@ -17,7 +17,9 @@ const path = require('path')
 const csp = [
   "frame-ancestors 'none';",
   // IS_PLATFORM
-  process.env.NEXT_PUBLIC_IS_PLATFORM === 'true' ? 'upgrade-insecure-requests;' : '',
+  process.env.NEXT_PUBLIC_IS_PLATFORM === 'true' && process.env.NODE_ENV === 'production'
+    ? 'upgrade-insecure-requests;'
+    : '',
 ]
   .filter(Boolean)
   .join(' ')


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behaviour?

Studio can now be tested in Safari locally