### PR TITLE
feat: Autofill `gen_random_uuid()` when selecting `uuid` as column type

### DIFF
--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/Column.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/Column.tsx
@@ -1,25 +1,24 @@
-import { FC } from 'react'
 import * as Tooltip from '@radix-ui/react-tooltip'
-import {
-  Checkbox,
-  Input,
-  IconX,
-  IconMenu,
-  Popover,
-  IconLink,
-  IconSettings,
-  Button,
-  IconArrowRight,
-} from 'ui'
 import type { PostgresType } from '@supabase/postgres-meta'
+import {
+  Button,
+  Checkbox,
+  IconArrowRight,
+  IconLink,
+  IconMenu,
+  IconSettings,
+  IconX,
+  Input,
+  Popover,
+} from 'ui'
 
-import { ColumnField } from '../SidePanelEditor.types'
+import { FOREIGN_KEY_DELETION_ACTION } from 'data/database/database-query-constants'
+import { typeExpressionSuggestions } from '../ColumnEditor/ColumnEditor.constants'
+import { Suggestion } from '../ColumnEditor/ColumnEditor.types'
+import { getForeignKeyDeletionAction } from '../ColumnEditor/ColumnEditor.utils'
 import ColumnType from '../ColumnEditor/ColumnType'
 import InputWithSuggestions from '../ColumnEditor/InputWithSuggestions'
-import { Suggestion } from '../ColumnEditor/ColumnEditor.types'
-import { typeExpressionSuggestions } from '../ColumnEditor/ColumnEditor.constants'
-import { FOREIGN_KEY_DELETION_ACTION } from 'data/database/database-query-constants'
-import { getForeignKeyDeletionAction } from '../ColumnEditor/ColumnEditor.utils'
+import { ColumnField } from '../SidePanelEditor.types'
 
 /**
  * [Joshen] For context:
@@ -50,7 +49,7 @@ interface Props {
   onRemoveColumn: () => void
 }
 
-const Column: FC<Props> = ({
+const Column = ({
   column = {} as ColumnField,
   enumTypes = [] as PostgresType[],
   isNewRecord = false,
@@ -59,7 +58,7 @@ const Column: FC<Props> = ({
   onEditRelation = () => {},
   onUpdateColumn = () => {},
   onRemoveColumn = () => {},
-}) => {
+}: Props) => {
   const suggestions: Suggestion[] = typeExpressionSuggestions?.[column.format] ?? []
 
   const settingsCount = [
@@ -150,7 +149,11 @@ const Column: FC<Props> = ({
             className="table-editor-column-type lg:gap-0 "
             disabled={column.foreignKey !== undefined}
             onOptionSelect={(format: string) => {
-              onUpdateColumn({ format, defaultValue: null })
+              let defaultValue = null
+              if (format === 'uuid') {
+                defaultValue = 'gen_random_uuid()'
+              }
+              onUpdateColumn({ format, defaultValue })
             }}
           />
         </div>

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/Column.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/Column.tsx
@@ -13,6 +13,7 @@ import {
 } from 'ui'
 
 import { FOREIGN_KEY_DELETION_ACTION } from 'data/database/database-query-constants'
+import { noop } from 'lodash'
 import { typeExpressionSuggestions } from '../ColumnEditor/ColumnEditor.constants'
 import { Suggestion } from '../ColumnEditor/ColumnEditor.types'
 import { getForeignKeyDeletionAction } from '../ColumnEditor/ColumnEditor.utils'
@@ -38,7 +39,7 @@ import { ColumnField } from '../SidePanelEditor.types'
  * - Cannot be both identity AND array, still checkboxes as they can be toggled off
  */
 
-interface Props {
+interface ColumnProps {
   column: ColumnField
   enumTypes: PostgresType[]
   isNewRecord: boolean
@@ -55,10 +56,10 @@ const Column = ({
   isNewRecord = false,
   hasImportContent = false,
   dragHandleProps = {},
-  onEditRelation = () => {},
-  onUpdateColumn = () => {},
-  onRemoveColumn = () => {},
-}: Props) => {
+  onEditRelation = noop,
+  onUpdateColumn = noop,
+  onRemoveColumn = noop,
+}: ColumnProps) => {
   const suggestions: Suggestion[] = typeExpressionSuggestions?.[column.format] ?? []
 
   const settingsCount = [
@@ -149,10 +150,7 @@ const Column = ({
             className="table-editor-column-type lg:gap-0 "
             disabled={column.foreignKey !== undefined}
             onOptionSelect={(format: string) => {
-              let defaultValue = null
-              if (format === 'uuid') {
-                defaultValue = 'gen_random_uuid()'
-              }
+              const defaultValue = format === 'uuid' ? 'gen_random_uuid()' : null
               onUpdateColumn({ format, defaultValue })
             }}
           />


### PR DESCRIPTION
This PR adds an improvement to automatically select `gen_random_uuid()` when the user selects `uuid` as column type in the Edit table side panel.