### PR TITLE
docs: update list of MFA Authentication Methods

### DIFF
--- a/apps/docs/pages/guides/auth/auth-mfa.mdx
+++ b/apps/docs/pages/guides/auth/auth-mfa.mdx
@@ -687,7 +687,7 @@ json_query_path(auth.jwt(), '$.amr[0]')
   authentication method in the JWT.
 
 Once you have extracted the most recent entry in the array, you can compare the
-`method` and `timestamp` to enforce stricter rules.
+`method` and `timestamp` to enforce stricter rules. For instance, you can mandate that access will be only be granted on a table to users who have recently signed in with a password.
 
 Currently recognized authentication methods are:
 
@@ -702,7 +702,7 @@ Currently recognized authentication methods are:
 - `email/signup` - any login resulting from an email signup.
 - `email_change` - any login resulting from a change in email.
 
-This list will expand in the future.
+More authentication methods will be added over time as we increase the number of authentication methods supported by Supabase.
 
 export const Page = ({ children }) => <Layout meta={meta} children={children} />
 

--- a/apps/docs/pages/guides/auth/auth-mfa.mdx
+++ b/apps/docs/pages/guides/auth/auth-mfa.mdx
@@ -698,11 +698,11 @@ Currently recognized authentication methods are:
 - `totp` - a TOTP additional factor.
 - `sso/saml` - any Single Sign On (SAML) method.
 
-The following additional claims are available only when using PKCE flow:
-- `invite` - any sign in via an invitation. Only available with PKCE.
+The following additional claims are available when using PKCE flow:
+- `invite` - any sign in via an invitation.
 - `magiclink` - any sign in via magic link. Excludes logins resulting from invocation of `signUp`.
-- `email/signup` - any login resulting from an email signup. Only available with PKCE.
-- `email_change` - any login resulting from a change in email. Only available with PKCE
+- `email/signup` - any login resulting from an email signup.
+- `email_change` - any login resulting from a change in email.
 
 More authentication methods will be added over time as we increase the number of authentication methods supported by Supabase.
 

--- a/apps/docs/pages/guides/auth/auth-mfa.mdx
+++ b/apps/docs/pages/guides/auth/auth-mfa.mdx
@@ -689,13 +689,18 @@ json_query_path(auth.jwt(), '$.amr[0]')
 Once you have extracted the most recent entry in the array, you can compare the
 `method` and `timestamp` to enforce stricter rules.
 
-Currently recognized methods are:
+Currently recognized authentication methods are:
 
+- `oauth` - any OAuth based sign in (social login).
 - `password` - any password based sign in.
 - `otp` - any one-time password based sign in (email code, SMS code, magic
   link).
-- `oauth` - any OAuth based sign in (social login).
 - `totp` - a TOTP additional factor.
+- `sso/saml` - any Single Sign On (SAML) method.
+- `invite` - any sign in via an invitation.
+- `magiclink` - any sign in via magic link. Excludes logins resulting from invocation of `signUp`.
+- `email/signup` - any login resulting from an email signup.
+- `email_change` - any login resulting from a change in email.
 
 This list will expand in the future.
 

--- a/apps/docs/pages/guides/auth/auth-mfa.mdx
+++ b/apps/docs/pages/guides/auth/auth-mfa.mdx
@@ -697,10 +697,12 @@ Currently recognized authentication methods are:
   link).
 - `totp` - a TOTP additional factor.
 - `sso/saml` - any Single Sign On (SAML) method.
-- `invite` - any sign in via an invitation.
+
+The following additional claims are available only when using PKCE flow:
+- `invite` - any sign in via an invitation. Only available with PKCE.
 - `magiclink` - any sign in via magic link. Excludes logins resulting from invocation of `signUp`.
-- `email/signup` - any login resulting from an email signup.
-- `email_change` - any login resulting from a change in email.
+- `email/signup` - any login resulting from an email signup. Only available with PKCE.
+- `email_change` - any login resulting from a change in email. Only available with PKCE
 
 More authentication methods will be added over time as we increase the number of authentication methods supported by Supabase.
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

As we now support SSO and PKCE the list of authentication methods has expanded.  

See [the Authentication Methods file](https://github.com/supabase/gotrue/blob/master/internal/models/factor.go#L49) and [PKCE token grant for more details](https://github.com/supabase/gotrue/blob/master/internal/api/token.go#L226)