### PR TITLE
Fix references to environment variables in local dev docs

### DIFF
--- a/apps/docs/pages/guides/getting-started/local-development.mdx
+++ b/apps/docs/pages/guides/getting-started/local-development.mdx
@@ -418,8 +418,8 @@ To use Auth locally, update your project's `supabase/config.toml` file that gets
 ```bash supabase/config.toml
 [auth.external.github]
 enabled = true
-client_id = "env($SUPABASE_AUTH_GITHUB_CLIENT_ID)"
-secret = "env($SUPABASE_AUTH_GITHUB_SECRET)"
+client_id = "env(SUPABASE_AUTH_GITHUB_CLIENT_ID)"
+secret = "env(SUPABASE_AUTH_GITHUB_SECRET)"
 redirect_uri = "http://localhost:54321/auth/v1/callback"
 ```
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix docs

## What is the current behavior?

```
▶ npx supabase start
Error evaluating "env(env($SUPABASE_AUTH_GITHUB_CLIENT_ID))": environment variable $SUPABASE_AUTH_GITHUB_CLIENT_ID is unset.
Try rerunning the command with --debug to troubleshoot the error.
```

## What is the new behavior?

```
▶ npx supabase start
supabase start is already running.
Run supabase status to show status of local Supabase containers.
```

## Additional context

Add any other context or screenshots.
