### PR TITLE
fix: Revert "feat: bump to gotrue-js v2.45.0 and bring back `navigatorLock`"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39912,7 +39912,7 @@
       "license": "MIT",
       "dependencies": {
         "@headlessui/react": "^1.7.14",
-        "@supabase/gotrue-js": "^2.45.0",
+        "@supabase/gotrue-js": "2.42.0",
         "@supabase/ui": "^0.37.0-alpha.50",
         "react-use": "^17.4.0"
       },
@@ -39925,9 +39925,9 @@
       }
     },
     "packages/common/node_modules/@supabase/gotrue-js": {
-      "version": "2.45.0",
-      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.45.0.tgz",
-      "integrity": "sha512-ctHQqk9foMHvU9pyGXbSbyalmyJ4dkpK/72jIytH5DbXxawqPIjUmJ+Ww9yyJLFP6wCsjPdeYBI+NW070WESvg==",
+      "version": "2.42.0",
+      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.42.0.tgz",
+      "integrity": "sha512-qYyTD+WVP9gjE7Hzw/ywoL9f+1kuUxeKJbb9JSsxV4wZHdKKPFHczfna8ecbmapH7423OXp0lgQAUDX97M39qw==",
       "dependencies": {
         "cross-fetch": "^3.1.5"
       }

--- a/packages/common/gotrue.ts
+++ b/packages/common/gotrue.ts
@@ -1,23 +1,16 @@
-import { GoTrueClient, navigatorLock } from '@supabase/gotrue-js'
+import { GoTrueClient } from '@supabase/gotrue-js'
 
 export const STORAGE_KEY = process.env.NEXT_PUBLIC_STORAGE_KEY || 'supabase.dashboard.auth.token'
 export const AUTH_DEBUG_KEY =
   process.env.NEXT_PUBLIC_AUTH_DEBUG_KEY || 'supabase.dashboard.auth.debug'
-export const AUTH_NAVIGATOR_LOCK_KEY =
-  process.env.NEXT_PUBLIC_AUTH_NAVIGATOR_LOCK_KEY || 'supabase.dashboard.auth.navigatorLock.enabled'
 
 const debug =
   process.env.NEXT_PUBLIC_IS_PLATFORM === 'true' &&
   globalThis?.localStorage?.getItem(AUTH_DEBUG_KEY) === 'true'
-
-const navigatorLockEnabled =
-  process.env.NEXT_PUBLIC_IS_PLATFORM === 'true' &&
-  globalThis?.localStorage?.getItem(AUTH_NAVIGATOR_LOCK_KEY) === 'true'
 
 export const gotrueClient = new GoTrueClient({
   url: process.env.NEXT_PUBLIC_GOTRUE_URL,
   storageKey: STORAGE_KEY,
   detectSessionInUrl: true,
   debug,
-  lock: navigatorLockEnabled ? navigatorLock : undefined,
 })

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "dependencies": {
     "@headlessui/react": "^1.7.14",
-    "@supabase/gotrue-js": "^2.45.0",
+    "@supabase/gotrue-js": "2.42.0",
     "@supabase/ui": "^0.37.0-alpha.50",
     "react-use": "^17.4.0"
   },


### PR DESCRIPTION
This reverts commit 3dc2788d52de562ef8ffff6fc56da48e2c126085.
