### PR TITLE
Facebook typo in auth-facebook.mdx

### DIFF
--- a/apps/docs/pages/guides/auth/social-login/auth-facebook.mdx
+++ b/apps/docs/pages/guides/auth/social-login/auth-facebook.mdx
@@ -33,7 +33,7 @@ Setting up Facebook logins for your application consists of 3 parts:
 
 <SocialProviderSetup provider="Facebook" />
 
-## Set up FaceBook Login for your Facebook App
+## Set up Facebook Login for your Facebook App
 
 From the `Add Products to your App` screen:
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

Mistyped `FaceBook`

## What is the new behavior?

Changed to `Facebook`

