### PR TITLE
feat: expose control over additional pooler parameters

### DIFF
--- a/apps/docs/pages/guides/platform/custom-postgres-config.mdx
+++ b/apps/docs/pages/guides/platform/custom-postgres-config.mdx
@@ -73,3 +73,15 @@ max_parallel_workers    |3        |
 export const Page = ({ children }) => <Layout meta={meta} children={children} />
 
 export default Page
+
+## Pooler Config
+
+You can also [customize some parameters](https://app.supabase.com/project/_/settings/database) for the Connection Pooler:
+
+1. [Pooling Mode](https://devcenter.heroku.com/articles/best-practices-pgbouncer-configuration#pgbouncer-s-connection-pooling-modes)
+1. [Default Pool Size](https://www.pgbouncer.org/config.html)
+1. [Max Client Connections](https://www.pgbouncer.org/config.html)
+
+The default pool size, and the maximum number of clients allowed to connect concurrently is automatically optimized based on the compute add-on being used. At the moment, the Dashboard only reflects any custom configuration being used, and does not include the default optimized numbers used for your project.
+
+Custom Pooler Config may also require manual updates to any relevant overrides when changing compute add-ons.

--- a/apps/docs/pages/guides/platform/custom-postgres-config.mdx
+++ b/apps/docs/pages/guides/platform/custom-postgres-config.mdx
@@ -76,7 +76,7 @@ export default Page
 
 ## Pooler Config
 
-You can also [customize some parameters](https://app.supabase.com/project/_/settings/database) for the Connection Pooler:
+You can also [customize some parameters](https://supabase.com/dashboard/project/_/settings/database) for the Connection Pooler:
 
 1. [Pooling Mode](https://devcenter.heroku.com/articles/best-practices-pgbouncer-configuration#pgbouncer-s-connection-pooling-modes)
 1. [Default Pool Size](https://www.pgbouncer.org/config.html)

--- a/studio/components/interfaces/Settings/Database/ConnectionPooling.tsx
+++ b/studio/components/interfaces/Settings/Database/ConnectionPooling.tsx
@@ -34,6 +34,7 @@ const ConnectionPooling = () => {
     'ignore_startup_parameters',
     'pool_mode',
     'pgbouncer_enabled',
+    'max_client_conn',
   ]
   const bouncerInfo = isSuccess ? pluckObjectFields(formModel, BOUNCER_FIELDS) : {}
 
@@ -124,7 +125,7 @@ export const PgbouncerConfig: FC<ConfigProps> = ({ projectRef, bouncerInfo, conn
     'projects'
   )
 
-  const [updates, setUpdates] = useState<any>({
+  const [updates, setUpdates] = useState({
     pool_mode: bouncerInfo.pool_mode || 'transaction',
     default_pool_size: bouncerInfo.default_pool_size || undefined,
     ignore_startup_parameters: bouncerInfo.ignore_startup_parameters || '',

--- a/studio/components/interfaces/Settings/Database/ConnectionPooling.tsx
+++ b/studio/components/interfaces/Settings/Database/ConnectionPooling.tsx
@@ -35,6 +35,7 @@ const ConnectionPooling = () => {
     'pool_mode',
     'pgbouncer_enabled',
     'max_client_conn',
+    'connectionString',
   ]
   const bouncerInfo = isSuccess ? pluckObjectFields(formModel, BOUNCER_FIELDS) : {}
 
@@ -107,6 +108,7 @@ interface ConfigProps {
     pool_mode: string
     pgbouncer_enabled: boolean
     max_client_conn: number
+    connectionString: string
   }
   connectionInfo: {
     db_host: string
@@ -256,11 +258,7 @@ export const PgbouncerConfig: FC<ConfigProps> = ({ projectRef, bouncerInfo, conn
             copy
             disabled
             label="Connection string"
-            value={
-              `postgres://${connectionInfo.db_user}:[YOUR-PASSWORD]@` +
-              `${connectionInfo.db_host}:${connectionInfo.db_port}` +
-              `/${connectionInfo.db_name}`
-            }
+            value={bouncerInfo.connectionString}
           />
         </div>
       </SchemaFormPanel>

--- a/studio/components/interfaces/Settings/Database/ConnectionPooling.tsx
+++ b/studio/components/interfaces/Settings/Database/ConnectionPooling.tsx
@@ -178,14 +178,14 @@ export const PgbouncerConfig: FC<ConfigProps> = ({ projectRef, bouncerInfo, conn
       },
       max_client_conn: {
         title: 'Max Client Connections',
-        type: 'integer',
+        oneOf: [{ type: 'integer' }, { type: 'null' }],
         help: 'The maximum number of concurrent client connections allowed. Overrides default optimizations; refer to https://supabase.com/docs/guides/platform/custom-postgres-config#pooler-config',
       },
       default_pool_size: {
         title: 'Default Pool Size',
-        type: 'integer',
+        oneOf: [{ type: 'integer' }, { type: 'null' }],
         help: 'The maximum number of connections made to the underlying Postgres cluster, per user+db combination. Overrides default optimizations; refer to https://supabase.com/docs/guides/platform/custom-postgres-config#pooler-config',
-      }
+      },
     },
     required: ['pool_mode'],
     type: 'object',

--- a/studio/components/interfaces/Settings/Database/ConnectionPooling.tsx
+++ b/studio/components/interfaces/Settings/Database/ConnectionPooling.tsx
@@ -105,6 +105,7 @@ interface ConfigProps {
     ignore_startup_parameters: 'string'
     pool_mode: string
     pgbouncer_enabled: boolean
+    max_client_conn: number
   }
   connectionInfo: {
     db_host: string
@@ -128,6 +129,7 @@ export const PgbouncerConfig: FC<ConfigProps> = ({ projectRef, bouncerInfo, conn
     default_pool_size: bouncerInfo.default_pool_size || undefined,
     ignore_startup_parameters: bouncerInfo.ignore_startup_parameters || '',
     pgbouncer_enabled: bouncerInfo.pgbouncer_enabled,
+    max_client_conn: bouncerInfo.max_client_conn || undefined,
   })
 
   const updateConfig = async (updatedConfig: any) => {
@@ -174,6 +176,16 @@ export const PgbouncerConfig: FC<ConfigProps> = ({ projectRef, bouncerInfo, conn
         type: 'string',
         help: 'Defaults are either blank or "extra_float_digits"',
       },
+      max_client_conn: {
+        title: 'Max Client Connections',
+        type: 'integer',
+        help: 'The maximum number of concurrent client connections allowed. Overrides default optimizations; refer to https://supabase.com/docs/guides/platform/custom-postgres-config#pooler-config',
+      },
+      default_pool_size: {
+        title: 'Default Pool Size',
+        type: 'integer',
+        help: 'The maximum number of connections made to the underlying Postgres cluster, per user+db combination. Overrides default optimizations; refer to https://supabase.com/docs/guides/platform/custom-postgres-config#pooler-config',
+      }
     },
     required: ['pool_mode'],
     type: 'object',
@@ -182,7 +194,7 @@ export const PgbouncerConfig: FC<ConfigProps> = ({ projectRef, bouncerInfo, conn
   return (
     <div>
       <SchemaFormPanel
-        title="Connection Pooling"
+        title="Connection Pooling Custom Configuration"
         schema={formSchema}
         model={updates}
         submitLabel="Save"
@@ -219,6 +231,10 @@ export const PgbouncerConfig: FC<ConfigProps> = ({ projectRef, bouncerInfo, conn
               </div>
               <Divider light />
               <AutoField name="ignore_startup_parameters" />
+              <Divider light />
+              <AutoField name="max_client_conn" />
+              <Divider light />
+              <AutoField name="default_pool_size" />
             </>
           )}
           <Divider light />

--- a/studio/data/database/pooling-configuration-query.ts
+++ b/studio/data/database/pooling-configuration-query.ts
@@ -2,8 +2,8 @@ import { useQuery, useQueryClient, UseQueryOptions } from '@tanstack/react-query
 import { get } from 'lib/common/fetch'
 import { API_URL } from 'lib/constants'
 import { useCallback } from 'react'
-import { databaseKeys } from './keys'
 import { ResponseError } from 'types'
+import { databaseKeys } from './keys'
 
 export type PoolingConfigurationVariables = {
   projectRef: string
@@ -23,6 +23,7 @@ export type PoolingConfiguration = {
   pgbouncer_enabled: boolean
   pgbouncer_status: string
   pool_mode: string
+  connectionString: string
 }
 
 export async function getPoolingConfiguration(


### PR DESCRIPTION
This PR enables the frontend to control two additional Postgres parameters: maximum connections and pool size. Frontend also now uses the connection string, which is now constructed on the API server.