### PR TITLE
docs: fix wrong env variate usage

### DIFF
--- a/apps/docs/pages/guides/cli/local-development.mdx
+++ b/apps/docs/pages/guides/cli/local-development.mdx
@@ -403,8 +403,8 @@ To use Auth locally, update your project's `supabase/config.toml` file that gets
 ```bash supabase/config.toml
 [auth.external.github]
 enabled = true
-client_id = "env($SUPABASE_AUTH_GITHUB_CLIENT_ID)"
-secret = "env($SUPABASE_AUTH_GITHUB_SECRET)"
+client_id = "env(SUPABASE_AUTH_GITHUB_CLIENT_ID)"
+secret = "env(SUPABASE_AUTH_GITHUB_SECRET)"
 redirect_uri = "http://localhost:54321/auth/v1/callback"
 ```
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

`docs update`

## What is the current behavior?

using `env($SUPABASE_AUTH_GITHUB_CLIENT_ID)` when executing `supabase start` or `supabase stop`
```
Error: Error evaluating "env($SUPABASE_AUTH_GITHUB_CLIENT_ID)": environment variable $SUPABASE_AUTH_GITHUB_CLIENT_ID is unset.
```

## What is the new behavior?
```
"env($SUPABASE_AUTH_GITHUB_CLIENT_ID)" -> "env(SUPABASE_AUTH_GITHUB_CLIENT_ID)"
"env($SUPABASE_AUTH_GITHUB_SECRET)"  -> "env(SUPABASE_AUTH_GITHUB_SECRET)"
```
link: https://supabase.com/docs/guides/cli/local-development#use-auth-locally  

When I used this case, following the instructions, even though I added environment variables, I still couldn't find these two variables. Later, I saw that another env() didn't have $, so I removed it and tried it.
