### PR TITLE
hotfix: SmtpForm not showing saved values

### DIFF
--- a/studio/components/interfaces/Auth/SmtpForm/SmtpForm.tsx
+++ b/studio/components/interfaces/Auth/SmtpForm/SmtpForm.tsx
@@ -32,7 +32,7 @@ const SmtpForm = () => {
     if (isLoaded && isSmtpEnabled(config)) {
       setEnableSmtp(true)
     }
-  }, [isLoaded])
+  }, [isLoaded, config])
 
   const schema = object({
     SMTP_ADMIN_EMAIL: string().when([], {
@@ -133,7 +133,7 @@ const SmtpForm = () => {
             const formValues = generateFormValues(config)
             resetForm({ values: formValues, initialValues: formValues })
           }
-        }, [isLoaded])
+        }, [isLoaded, config])
 
         const onResetForm = () => {
           setEnableSmtp(isSmtpEnabled(initialValues))

--- a/studio/pages/project/[ref]/settings/auth.tsx
+++ b/studio/pages/project/[ref]/settings/auth.tsx
@@ -2,7 +2,6 @@ import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { observer } from 'mobx-react-lite'
 import { useEffect } from 'react'
 
-import { useParams } from 'common'
 import { AutoSchemaForm, SmtpForm } from 'components/interfaces/Auth'
 import { SettingsLayout } from 'components/layouts'
 import NoPermission from 'components/ui/NoPermission'
@@ -10,12 +9,11 @@ import { useCheckPermissions, useStore } from 'hooks'
 import { NextPageWithLayout } from 'types'
 
 const PageLayout: NextPageWithLayout = () => {
-  const { authConfig } = useStore()
-  const { ref: projectRef } = useParams()
+  const { authConfig, ui } = useStore()
 
   useEffect(() => {
     authConfig.load()
-  }, [projectRef])
+  }, [ui.selectedProjectRef])
 
   const canReadAuthSettings = useCheckPermissions(PermissionAction.READ, 'custom_config_gotrue')
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behaviour?

Values are being saved correctly, but upon refresh, the form is not showing those saved values.

## What is the new behaviour?

The form correctly shows the saved values after a refresh.
