### PR TITLE
Fix the CSV download in the SQL editor to escape newlines.

### DIFF
--- a/studio/components/interfaces/SQLEditor/UtilityPanel/ResultsDropdown.tsx
+++ b/studio/components/interfaces/SQLEditor/UtilityPanel/ResultsDropdown.tsx
@@ -43,6 +43,18 @@ const ResultsDropdown = ({ id }: ResultsDropdownProps) => {
     return ''
   }, [result])
 
+  const headers = useMemo(() => {
+    if (result?.rows) {
+      const firstRow = Array.from(result.rows || [])[0]
+      if (firstRow) {
+        return Object.keys(firstRow)
+      }
+    }
+    // if undefined is returned no headers will be set. In this case, no headers would be better
+    // than malformed headers.
+    return undefined
+  }, [result])
+
   function onDownloadCSV() {
     csvRef.current?.link.click()
     Telemetry.sendEvent(
@@ -99,6 +111,7 @@ const ResultsDropdown = ({ id }: ResultsDropdownProps) => {
       <CSVLink
         ref={csvRef}
         className="hidden"
+        headers={headers}
         data={csvData}
         filename={`supabase_${project?.ref}_${snap.snippets[id]?.snippet.name}`}
       />

--- a/studio/components/interfaces/SQLEditor/UtilityPanel/ResultsDropdown.tsx
+++ b/studio/components/interfaces/SQLEditor/UtilityPanel/ResultsDropdown.tsx
@@ -31,7 +31,8 @@ const ResultsDropdown = ({ id }: ResultsDropdownProps) => {
         return map(row, (v, k) => {
           if (isString(v)) {
             // replace all newlines with the character \n
-            return v.replaceAll(/\n/g, '\\n')
+            // escape all quotation marks
+            return v.replaceAll(/\n/g, '\\n').replaceAll(/"/g, '""')
           }
           return v
         })


### PR DESCRIPTION
If one of the results in the SQL editor contains a newline it breaks the CSV file when exported. This fix will replace the newline with `\n` which should be obvious to the user that it's a new line when seen in the CSV file.