### PR TITLE
feat: Add an alert if the user is using the built-in email server

### DIFF
--- a/packages/ui/src/components/shadcn/ui/alert.tsx
+++ b/packages/ui/src/components/shadcn/ui/alert.tsx
@@ -3,9 +3,10 @@ import { cva, type VariantProps } from 'class-variance-authority'
 
 import { cn } from '@ui/lib/utils'
 
+// Ivan: replaced [&:has(svg)]:pl-14 with [&>svg~*]:pl-10 cause of github.com/shadcn-ui/ui/issues/998
 const alertVariants = cva(
   cn(
-    'relative w-full rounded-lg border p-4 [&:has(svg)]:pl-14 [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground',
+    'relative w-full rounded-lg border p-4 [&>svg~*]:pl-10 [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground',
     '[&>svg]:w-[23px] [&>svg]:h-[23px] [&>svg]:p-1 [&>svg]:flex [&>svg]:rounded'
   ),
   {

--- a/packages/ui/src/components/shadcn/ui/alert.tsx
+++ b/packages/ui/src/components/shadcn/ui/alert.tsx
@@ -6,7 +6,7 @@ import { cn } from '@ui/lib/utils'
 // Ivan: replaced [&:has(svg)]:pl-14 with [&>svg~*]:pl-10 cause of github.com/shadcn-ui/ui/issues/998
 const alertVariants = cva(
   cn(
-    'relative w-full rounded-lg border p-4 [&>svg~*]:pl-10 [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground',
+    'relative w-full text-sm rounded-lg border p-4 [&>svg~*]:pl-10 [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground',
     '[&>svg]:w-[23px] [&>svg]:h-[23px] [&>svg]:p-1 [&>svg]:flex [&>svg]:rounded'
   ),
   {
@@ -17,7 +17,7 @@ const alertVariants = cva(
         destructive:
           'text border-destructive-400 bg-destructive-200 [&>svg]:text-destructive-200 [&>svg]:bg-destructive-600',
         warning:
-          'text-warning-100 dark:text-warning border-warning-400 bg-warning-200 [&>svg]:text-warning-200 [&>svg]:bg-warning-600',
+          'border-warning-400 bg-warning-200 [&>svg]:text-warning-200 [&>svg]:bg-warning-600',
       },
     },
     defaultVariants: {

--- a/studio/components/interfaces/Auth/SmtpForm/SmtpForm.tsx
+++ b/studio/components/interfaces/Auth/SmtpForm/SmtpForm.tsx
@@ -1,8 +1,8 @@
+import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { observer } from 'mobx-react-lite'
 import { useEffect, useState } from 'react'
+import { Alert, Button, Form, IconEye, IconEyeOff, Input, InputNumber, Toggle } from 'ui'
 import { number, object, string } from 'yup'
-import { PermissionAction } from '@supabase/shared-types/out/constants'
-import { Alert, Button, Form, Input, InputNumber, Toggle, IconEye, IconEyeOff } from 'ui'
 
 import {
   FormActions,
@@ -12,7 +12,7 @@ import {
   FormSectionContent,
   FormSectionLabel,
 } from 'components/ui/Forms'
-import { useStore, useCheckPermissions } from 'hooks'
+import { useCheckPermissions, useStore } from 'hooks'
 import { urlRegex } from './../Auth.constants'
 import { defaultDisabledSmtpFormValues } from './SmtpForm.constants'
 import { generateFormValues, isSmtpEnabled } from './SmtpForm.utils'
@@ -180,10 +180,27 @@ const SmtpForm = () => {
                 </FormSectionContent>
               </FormSection>
 
-              {enableSmtp && !isValidSmtpConfig && (
+              {enableSmtp ? (
+                !isValidSmtpConfig && (
+                  <div className="mx-8 mb-8 -mt-4">
+                    <Alert withIcon variant="warning" title="All fields below must be filled">
+                      The following fields must be filled before custom SMTP can be properly enabled
+                    </Alert>
+                  </div>
+                )
+              ) : (
                 <div className="mx-8 mb-8 -mt-4">
-                  <Alert withIcon variant="warning" title="All fields below must be filled">
-                    The following fields must be filled before custom SMTP can be properly enabled
+                  <Alert withIcon variant="warning" title="Built-in email service is rate-limited!">
+                    You're using the built-in email service. The service has rate limits and it's
+                    not meant to be used for production apps. Check the{' '}
+                    <a
+                      href="https://supabase.com/docs/guides/platform/going-into-prod#auth-rate-limits"
+                      className="underline"
+                    >
+                      documentation
+                    </a>{' '}
+                    for an up-to-date information on the current rate limits. Please use a custom
+                    SMTP server if you're planning on having large number of users.
                   </Alert>
                 </div>
               )}

--- a/studio/components/interfaces/Auth/SmtpForm/SmtpForm.tsx
+++ b/studio/components/interfaces/Auth/SmtpForm/SmtpForm.tsx
@@ -1,7 +1,20 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { observer } from 'mobx-react-lite'
 import { useEffect, useState } from 'react'
-import { Alert, Button, Form, IconEye, IconEyeOff, Input, InputNumber, Toggle } from 'ui'
+
+import {
+  AlertDescription_Shadcn_,
+  AlertTitle_Shadcn_,
+  Alert_Shadcn_,
+  Button,
+  Form,
+  IconAlertTriangle,
+  IconEye,
+  IconEyeOff,
+  Input,
+  InputNumber,
+  Toggle,
+} from 'ui'
 import { number, object, string } from 'yup'
 
 import {
@@ -183,25 +196,34 @@ const SmtpForm = () => {
               {enableSmtp ? (
                 !isValidSmtpConfig && (
                   <div className="mx-8 mb-8 -mt-4">
-                    <Alert withIcon variant="warning" title="All fields below must be filled">
-                      The following fields must be filled before custom SMTP can be properly enabled
-                    </Alert>
+                    <Alert_Shadcn_ variant="warning">
+                      <IconAlertTriangle strokeWidth={2} />
+                      <AlertTitle_Shadcn_>All fields below must be filled</AlertTitle_Shadcn_>
+                      <AlertDescription_Shadcn_>
+                        The following fields must be filled before custom SMTP can be properly
+                        enabled
+                      </AlertDescription_Shadcn_>
+                    </Alert_Shadcn_>
                   </div>
                 )
               ) : (
                 <div className="mx-8 mb-8 -mt-4">
-                  <Alert withIcon variant="warning" title="Built-in email service is rate-limited!">
-                    You're using the built-in email service. The service has rate limits and it's
-                    not meant to be used for production apps. Check the{' '}
-                    <a
-                      href="https://supabase.com/docs/guides/platform/going-into-prod#auth-rate-limits"
-                      className="underline"
-                    >
-                      documentation
-                    </a>{' '}
-                    for an up-to-date information on the current rate limits. Please use a custom
-                    SMTP server if you're planning on having large number of users.
-                  </Alert>
+                  <Alert_Shadcn_ variant="warning">
+                    <IconAlertTriangle strokeWidth={2} />
+                    <AlertTitle_Shadcn_>Built-in email service is rate-limited!</AlertTitle_Shadcn_>
+                    <AlertDescription_Shadcn_>
+                      You're using the built-in email service. The service has rate limits and it's
+                      not meant to be used for production apps. Check the{' '}
+                      <a
+                        href="https://supabase.com/docs/guides/platform/going-into-prod#auth-rate-limits"
+                        className="underline"
+                      >
+                        documentation
+                      </a>{' '}
+                      for an up-to-date information on the current rate limits. Please use a custom
+                      SMTP server if you're planning on having large number of users.
+                    </AlertDescription_Shadcn_>
+                  </Alert_Shadcn_>
                 </div>
               )}
 

--- a/studio/components/interfaces/Auth/SmtpForm/SmtpForm.tsx
+++ b/studio/components/interfaces/Auth/SmtpForm/SmtpForm.tsx
@@ -217,6 +217,7 @@ const SmtpForm = () => {
                       <a
                         href="https://supabase.com/docs/guides/platform/going-into-prod#auth-rate-limits"
                         className="underline"
+                        target="_blank"                 
                       >
                         documentation
                       </a>{' '}


### PR DESCRIPTION
This PR adds an alert to the SMTP section in the Auth Settings page.

Screenshots of enabled and disabled custom SMTP server.

<img width="1041" alt="Screenshot 2023-07-27 at 13 11 11" src="https://github.com/supabase/supabase/assets/568291/935d8c0a-b5c8-49d0-88eb-8e1413dedc83">
<img width="990" alt="Screenshot 2023-07-27 at 13 11 07" src="https://github.com/supabase/supabase/assets/568291/d540a731-e69d-42be-ae96-54d8b56cfb8e">



Open to suggestions about the message. The link is to https://supabase.com/docs/guides/platform/going-into-prod#auth-rate-limits.
```
Built-in email service is rate-limited!
You're using the built-in email service. The service has rate limits and it's not meant to be used for 
production apps. Check the documentation for an up-to-date information on the current rate limits. Please 
use a custom SMTP server if you're planning on having large number of users.
```

