### PR TITLE
Docs: Add link to new egghead course

### DIFF
--- a/apps/docs/pages/guides/auth/auth-helpers/nextjs.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/nextjs.mdx
@@ -848,6 +848,7 @@ See [refreshing session example](/docs/guides/auth/auth-helpers/nextjs#managing-
 
 ## More examples
 
+- [Build a Twitter Clone with the Next.js App Router and Supabase - free egghead course](https://egghead.io/courses/build-a-twitter-clone-with-the-next-js-app-router-and-supabase-19bebadb)
 - [Cookie-based Auth and the Next.js 13 App Router (free course)](https://youtube.com/playlist?list=PL5S4mPUpp4OtMhpnp93EFSo42iQ40XjbF)
 - [Full App Router example](https://github.com/supabase/supabase/tree/master/examples/auth/nextjs)
 - [Realtime Subscriptions](https://github.com/supabase/supabase/tree/master/examples/auth/nextjs/app/realtime-posts.tsx)

--- a/apps/docs/pages/guides/getting-started/tutorials/with-nextjs.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-nextjs.mdx
@@ -979,6 +979,7 @@ At this stage you have a fully functional application!
 ## See also
 
 - See the complete [example on GitHub](https://github.com/supabase/supabase/tree/master/examples/user-management/nextjs-user-management) and deploy it to Vercel
+- [Build a Twitter Clone with the Next.js App Router and Supabase - free egghead course](https://egghead.io/courses/build-a-twitter-clone-with-the-next-js-app-router-and-supabase-19bebadb)
 - Explore the [pre-built Auth UI for React](/docs/guides/auth/auth-helpers/auth-ui)
 - Explore the [Auth Helpers for Next.js](/docs/guides/auth/auth-helpers/nextjs)
 - Explore the [Supabase Cache Helpers](https://github.com/psteinroe/supabase-cache-helpers)

--- a/apps/docs/pages/guides/resources/examples.mdx
+++ b/apps/docs/pages/guides/resources/examples.mdx
@@ -13,6 +13,18 @@ We have a [set of examples](https://github.com/supabase/supabase/tree/master/exa
 
 ## Featured
 
+## Build a Twitter Clone with the Next.js App Router and Supabase
+
+By [Jon Meyers](https://twitter.com/jonmeyers_io)
+
+<a href="https://egghead.io/courses/build-a-twitter-clone-with-the-next-js-app-router-and-supabase-19bebadb">
+  <img
+    src="https://pbs.twimg.com/media/F2DEsxTaYAA1Coe?format=jpg&name=medium"
+    alt="Build a Twitter Clone with the Next.js App Router and Supabase"
+    width="100%"
+  />
+</a>
+
 ### Supabase Crash Course
 
 By [Traversy Media](https://www.youtube.com/watch?v=7uKQBl9uZ00).
@@ -80,6 +92,7 @@ Build a basic Todo List with Supabase and your favorite frontend framework:
 
 ### Courses
 
+- [Build a Twitter Clone with the Next.js App Router and Supabase - free egghead course](https://egghead.io/courses/build-a-twitter-clone-with-the-next-js-app-router-and-supabase-19bebadb)
 - Build a FullStack App with Next.js, Supabase & Prisma by [@gdangel0](https://twitter.com/gdangel0): [Free course](https://themodern.dev/courses/build-a-fullstack-app-with-nextjs-supabase-and-prisma-322389284337222224)
 
 ### Libraries


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

No links to egghead course

## What is the new behavior?

Links to egghead course to Next.js and examples pages
