### PR TITLE
:scroll: typo fix : queries -> queried

### DIFF
--- a/apps/docs/pages/guides/database/extensions/pg_graphql.mdx
+++ b/apps/docs/pages/guides/database/extensions/pg_graphql.mdx
@@ -62,7 +62,7 @@ insert into "Blog"(name)
 values ('My Blog');
 ```
 
-The reflected GraphQL schema can be queries immediately as
+The reflected GraphQL schema can be queried immediately as
 
 {/* prettier-ignore */}
 ```sql


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

docs say "queries" but I think it should say "queried":

[affected docs](https://supabase.com/docs/guides/database/extensions/pg_graphql#:~:text=schema%20can%20be-,queries,-immediately%20as)

## What is the new behavior?

Fixed typo: 'can be queries' to 'can be queried'

## Additional context

Please accept my humble pull request 🍀 