### PR TITLE
docs: Fix grammar issues in README.fi.md

### DIFF
--- a/i18n/README.fi.md
+++ b/i18n/README.fi.md
@@ -31,10 +31,10 @@ Jos haluat nähdä, miten osallistuminen tapahtuu, käy osoitteessa [Getting Sta
 
 ## Yhteisö ja tuki
 
-- [Yhteisön foorumi](https://github.com/supabase/supabase/discussions). Paras: Apua rakentamiseen, keskustelua tietokannan parhaista käytännöistä.
-- [GitHub Issues](https://github.com/supabase/supabase/issues). Parasta: Supabasea käytettäessä kohdatut viat ja virheet.
-- [Sähköpostituki](https://supabase.com/docs/support#business-support). Paras: tietokantaan tai infrastruktuuriin liittyvät ongelmat.
-- [Discord](https://discord.supabase.com). Paras: sovellusten jakamiseen ja yhteisön kanssa hengailuun.
+- [Yhteisön foorumi](https://github.com/supabase/supabase/discussions). Sopii parhaiten: Apua rakentamiseen, keskustelua tietokannan parhaista käytännöistä.
+- [GitHub Issues](https://github.com/supabase/supabase/issues). Sopii parhaiten: Supabasea käytettäessä kohdatut viat ja virheet.
+- [Sähköpostituki](https://supabase.com/docs/support#business-support). Sopii parhaiten: Tietokantaan tai infrastruktuuriin liittyvät ongelmat.
+- [Discord](https://discord.supabase.com). Sopii parhaiten: Sovellusten jakamiseen ja yhteisön kanssa hengailuun.
 
 ## Status
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update. Made some changes to the lines in 'Yhteisö ja tuki' section in the Finnish translation of README.

'Paras' was replaced with 'Sopii parhaiten' to better convey the meaning of 'Best for'. The former can be directly translated as 'Best', but in the context of explaining for what purpose each support channel is best used, 'Sopii parhaiten' ('Best suited for') is a more appropriate and natural translation in Finnish. Using just 'Best' would not make sense in this case and would sound strange.