### PR TITLE
hotfix: use ui store to listen to project ref changes

### DIFF
--- a/studio/pages/project/[ref]/auth/providers.tsx
+++ b/studio/pages/project/[ref]/auth/providers.tsx
@@ -11,12 +11,11 @@ import { useCheckPermissions, useStore } from 'hooks'
 import { NextPageWithLayout } from 'types'
 
 const PageLayout: NextPageWithLayout = () => {
-  const { authConfig } = useStore()
-  const { project } = useProjectContext()
+  const { authConfig, ui } = useStore()
 
   useEffect(() => {
     authConfig.load()
-  }, [project?.ref])
+  }, [ui.selectedProjectRef])
 
   const canReadAuthSettings = useCheckPermissions(PermissionAction.READ, 'custom_config_gotrue')
 

--- a/studio/pages/project/[ref]/auth/templates.tsx
+++ b/studio/pages/project/[ref]/auth/templates.tsx
@@ -11,12 +11,11 @@ import { useCheckPermissions, useStore } from 'hooks'
 import { NextPageWithLayout } from 'types'
 
 const PageLayout: NextPageWithLayout = () => {
-  const { authConfig } = useStore()
-  const { project } = useProjectContext()
+  const { authConfig, ui } = useStore()
 
   useEffect(() => {
     authConfig.load()
-  }, [project?.ref])
+  }, [ui.selectedProjectRef])
 
   const canReadAuthSettings = useCheckPermissions(PermissionAction.READ, 'custom_config_gotrue')
 

--- a/studio/pages/project/[ref]/auth/url-configuration.tsx
+++ b/studio/pages/project/[ref]/auth/url-configuration.tsx
@@ -12,12 +12,11 @@ import { useCheckPermissions, useStore } from 'hooks'
 import { NextPageWithLayout } from 'types'
 
 const URLConfiguration: NextPageWithLayout = () => {
-  const { authConfig } = useStore()
-  const { project } = useProjectContext()
+  const { authConfig, ui } = useStore()
 
   useEffect(() => {
     authConfig.load()
-  }, [project?.ref])
+  }, [ui.selectedProjectRef])
 
   const canReadAuthSettings = useCheckPermissions(PermissionAction.READ, 'custom_config_gotrue')
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

- uses UI store instead on auth config pages as useProjectContext() doesn't seem to respect project ref changes

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
