### PR TITLE
fix: typo in supabase db dump description

### DIFF
--- a/spec/cli_v1_commands.yaml
+++ b/spec/cli_v1_commands.yaml
@@ -1990,7 +1990,7 @@ commands:
 
       Requires your local project to be linked to a remote database by running `supabase link`. For self-hosted databases, you can pass in the connection parameters using `--db-url` flag.
 
-      Runs `pg_dump` in a container with additional flags to exclude Supabase managed schemas. The ignored schemas include auth, stroage, and those created by extensions.
+      Runs `pg_dump` in a container with additional flags to exclude Supabase managed schemas. The ignored schemas include auth, storage, and those created by extensions.
 
       The default dump does not contain any data or custom roles. To dump those contents explicitly, specify either the `--data-only` and `--role-only` flag.
     examples:


### PR DESCRIPTION
## What kind of change does this PR introduce?

A small typo fix in the command description.

## What is the current behavior?

There is a typo.

## What is the new behavior?

One less typo!
