### PR TITLE
Add missing link to Kotlin Quickstart and cleanup code

### DIFF
--- a/apps/docs/components/HomePageCover.tsx
+++ b/apps/docs/components/HomePageCover.tsx
@@ -29,6 +29,11 @@ const HomePageCover = (props) => {
       href: '/guides/getting-started/quickstarts/flutter',
     },
     {
+      tooltip: 'Android Kotlin',
+      icon: '/docs/img/icons/kotlin-icon',
+      href: '/guides/getting-started/quickstarts/kotlin',
+    },
+    {
       tooltip: 'SvelteKit',
       icon: '/docs/img/icons/svelte-icon',
       href: '/guides/getting-started/quickstarts/sveltekit',

--- a/apps/docs/pages/guides/getting-started/quickstarts/kotlin.mdx
+++ b/apps/docs/pages/guides/getting-started/quickstarts/kotlin.mdx
@@ -102,10 +102,10 @@ export const meta = {
           supabaseUrl = "https://xyzcompany.supabase.co",
           supabaseKey = "public-anon-key"
         ) {
-              install(GoTrue)
-              install(Postgrest)
-              install(Storage)
-          }
+          install(GoTrue)
+          install(Postgrest)
+          install(Storage)
+      }
       ```
 
     </StepHikeCompact.Code>

--- a/apps/docs/pages/guides/getting-started/quickstarts/kotlin.mdx
+++ b/apps/docs/pages/guides/getting-started/quickstarts/kotlin.mdx
@@ -62,8 +62,6 @@ export const meta = {
       ```kotlin
         implementation "io.github.jan-tennert.supabase:postgrest-kt:$supabase_version"
         implementation "io.ktor:ktor-client-android:$ktor_version"
-        implementation "io.ktor:ktor-client-core:$ktor_version"
-        implementation "io.ktor:ktor-utils:$ktor_version"
       ```
 
     </StepHikeCompact.Code>
@@ -102,9 +100,7 @@ export const meta = {
           supabaseUrl = "https://xyzcompany.supabase.co",
           supabaseKey = "public-anon-key"
         ) {
-          install(GoTrue)
           install(Postgrest)
-          install(Storage)
       }
       ```
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

No icon to the Kotlin Quickstart here
![image](https://github.com/supabase/supabase/assets/26686035/7e61c51f-aee3-40eb-a531-bf9f212bef53)

## What is the new behavior?

The icon is now there and redirects to the Kotlin Quickstart
![image](https://github.com/supabase/supabase/assets/26686035/48e8798f-02f6-4b57-b989-0ef801a60d86)

On top of that, I also cleaned up the Kotlin code a little bit.
