### PR TITLE
fix: syntax error in python documentation for setting session data

### DIFF
--- a/spec/supabase_py_v2.yml
+++ b/spec/supabase_py_v2.yml
@@ -257,7 +257,7 @@ functions:
         description: Sets the session data from refresh_token and returns current session or an error if the refresh_token is invalid.
         code: |
           ```
-          res = supabase.auth.set_session({"access_token": access_token, "refresh_token": refresh_token)
+          res = supabase.auth.set_session({"access_token": access_token, "refresh_token": refresh_token})
           ```
   - id: refresh-session
     title: 'refresh_session()'


### PR DESCRIPTION
Resolves issue #16159

## What kind of change does this PR introduce?

A syntax typo fix in the example for setting session data with the python sdk

## What is the current behavior?

This issue is described here #16159

## What is the new behavior?

Fixes the missing curly brace in the code example
