### PR TITLE
fix: Incorrect example in python documentation for setting session data

### DIFF
--- a/spec/supabase_py_v2.yml
+++ b/spec/supabase_py_v2.yml
@@ -257,7 +257,7 @@ functions:
         description: Sets the session data from refresh_token and returns current session or an error if the refresh_token is invalid.
         code: |
           ```
-          res = supabase.auth.set_session({"access_token": access_token, "refresh_token": refresh_token})
+          res = supabase.auth.set_session(access_token, refresh_token)
           ```
   - id: refresh-session
     title: 'refresh_session()'

--- a/spec/supabase_py_v2.yml
+++ b/spec/supabase_py_v2.yml
@@ -257,7 +257,7 @@ functions:
         description: Sets the session data from refresh_token and returns current session or an error if the refresh_token is invalid.
         code: |
           ```
-          res = supabase.auth.set_session({"access_token": access_token, "refresh_token": refresh_token)
+          res = supabase.auth.set_session({"access_token": access_token, "refresh_token": refresh_token})
           ```
   - id: refresh-session
     title: 'refresh_session()'


### PR DESCRIPTION
## What kind of change does this PR introduce?

Documentation update

## What is the current behavior?

The example given in the documentation contains a syntax error as defined in #16159. However even when this is fixed this error occurs:
```
res = supabase.auth.set_session({"access_token": access_token, "refresh_token": refresh_token})        
TypeError: SyncGoTrueClient.set_session() missing 1 required positional argument: 'refresh_token'
```

## What is the new behavior?

I have updated the example for one that has been tested and functions as expected:
```
res = supabase.auth.set_session(access_token, refresh_token)    
```
