### PR TITLE
fix: word wrapping on doc intros

### DIFF
--- a/apps/docs/docs/ref/csharp/introduction.mdx
+++ b/apps/docs/docs/ref/csharp/introduction.mdx
@@ -12,10 +12,12 @@ hideTitle: true
   </div>
 </div>
 
+{/* prettier-ignore */}
 <div className="max-w-xl">
   This reference documents every object and method available in Supabase's C# library, [supabase-csharp](https://www.nuget.org/packages/supabase-csharp). You can use supabase-csharp to interact with your Postgres database, listen to database changes, invoke Deno Edge Functions, build login and user management functionality, and manage large files.
 </div>
 
+{/* prettier-ignore */}
 <div className="max-w-xl bg-slate-300 px-4 py-2 rounded-md">
   <p>
     The C# client library is created and maintained by the Supabase community, and is not an official library. Please be tolerant of areas where the library is still being developed, and — as with all the libraries — feel free to contribute wherever you find issues.

--- a/apps/docs/docs/ref/csharp/introduction.mdx
+++ b/apps/docs/docs/ref/csharp/introduction.mdx
@@ -13,19 +13,15 @@ hideTitle: true
 </div>
 
 <div className="max-w-xl">
-  This reference documents every object and method available in Supabase's C# library,
-  [supabase-csharp](https://www.nuget.org/packages/supabase-csharp). You can use supabase-csharp to
-  interact with your Postgres database, listen to database changes, invoke Deno Edge Functions,
-  build login and user management functionality, and manage large files.
+  This reference documents every object and method available in Supabase's C# library, [supabase-csharp](https://www.nuget.org/packages/supabase-csharp). You can use supabase-csharp to interact with your Postgres database, listen to database changes, invoke Deno Edge Functions, build login and user management functionality, and manage large files.
 </div>
 
 <div className="max-w-xl bg-slate-300 px-4 py-2 rounded-md">
-  <p>The C# client library is created and maintained by the Supabase community, and is not an official library. Please be tolerant of areas where the library is still being developed, and — as with all the libraries — feel free to contribute wherever you find issues.</p>
+  <p>
+    The C# client library is created and maintained by the Supabase community, and is not an official library. Please be tolerant of areas where the library is still being developed, and — as with all the libraries — feel free to contribute wherever you find issues.
+  </p>
 
-<p>
-  Huge thanks to official maintainer, [Joseph Schultz](https://github.com/acupofjose), and to [Ben
-  Randall](https://github.com/veleek) and [Rhuan Barros](https://github.com/rhuanbarros) for their
-  help.
-</p>
-
+  <p>
+    Huge thanks to official maintainer, [Joseph Schultz](https://github.com/acupofjose), and to [Ben Randall](https://github.com/veleek) and [Rhuan Barros](https://github.com/rhuanbarros) for their help.
+  </p>
 </div>

--- a/apps/docs/docs/ref/dart/introduction.mdx
+++ b/apps/docs/docs/ref/dart/introduction.mdx
@@ -13,12 +13,7 @@ hideTitle: true
 </div>
 
 <div className="max-w-xl">
-
-This reference documents every object and method available in Supabase's Flutter
-library, [supabase-flutter](https://pub.dev/packages/supabase_flutter). You can
-use supabase-flutter to interact with your Postgres database, listen to database changes, invoke
-Deno Edge Functions, build login and user management functionality, and manage large files.
-
-We also provide a [supabase](https://pub.dev/packages/supabase) package for non-Flutter projects.
-
+  This reference documents every object and method available in Supabase's Flutter library, [supabase-flutter](https://pub.dev/packages/supabase_flutter). You can use supabase-flutter to interact with your Postgres database, listen to database changes, invoke Deno Edge Functions, build login and user management functionality, and manage large files.
+  
+  We also provide a [supabase](https://pub.dev/packages/supabase) package for non-Flutter projects.
 </div>

--- a/apps/docs/docs/ref/dart/introduction.mdx
+++ b/apps/docs/docs/ref/dart/introduction.mdx
@@ -12,6 +12,7 @@ hideTitle: true
   </div>
 </div>
 
+{/* prettier-ignore */}
 <div className="max-w-xl">
   This reference documents every object and method available in Supabase's Flutter library, [supabase-flutter](https://pub.dev/packages/supabase_flutter). You can use supabase-flutter to interact with your Postgres database, listen to database changes, invoke Deno Edge Functions, build login and user management functionality, and manage large files.
   

--- a/apps/docs/docs/ref/dart/v0/introduction.mdx
+++ b/apps/docs/docs/ref/dart/v0/introduction.mdx
@@ -12,6 +12,7 @@ hideTitle: true
   </div>
 </div>
 
+{/* prettier-ignore */}
 <div className="max-w-xl">
   <Admonition type="caution">
     You're viewing the docs for an older version of the `supabase-flutter` library. Learn how to [upgrade to the latest version](/docs/reference/dart/v0/upgrade-guide).

--- a/apps/docs/docs/ref/dart/v0/introduction.mdx
+++ b/apps/docs/docs/ref/dart/v0/introduction.mdx
@@ -13,16 +13,10 @@ hideTitle: true
 </div>
 
 <div className="max-w-xl">
-
-<Admonition type="caution">
-  You're viewing the docs for an older version of the `supabase-flutter` library. Learn how to
-  [upgrade to the latest version](/docs/reference/dart/v0/upgrade-guide).
-</Admonition>
-
-This reference documents every object and method available in Supabase's Flutter library, [supabase-flutter](https://pub.dev/packages/supabase_flutter).
-You can use supabase-flutter to interact with your Postgres database, listen to database changes, invoke
-Deno Edge Functions, build login and user management functionality, and manage large files.
-
-We also provide a [supabase](https://pub.dev/packages/supabase) package for non-Flutter projects.
-
+  <Admonition type="caution">
+    You're viewing the docs for an older version of the `supabase-flutter` library. Learn how to [upgrade to the latest version](/docs/reference/dart/v0/upgrade-guide).
+  </Admonition>
+  This reference documents every object and method available in Supabase's Flutter library, [supabase-flutter](https://pub.dev/packages/supabase_flutter). You can use supabase-flutter to interact with your Postgres database, listen to database changes, invoke Deno Edge Functions, build login and user management functionality, and manage large files.
+  
+  We also provide a [supabase](https://pub.dev/packages/supabase) package for non-Flutter projects.
 </div>

--- a/apps/docs/docs/ref/javascript/introduction.mdx
+++ b/apps/docs/docs/ref/javascript/introduction.mdx
@@ -12,6 +12,6 @@ hideTitle: true
   </div>
 </div>
 
-<div className="max-w-xl whitespace-nowrap">
+<div className="max-w-xl">
   This reference documents every object and method available in Supabase's isomorphic JavaScript library, supabase-js. You can use supabase-js to interact with your Postgres database, listen to database changes, invoke Deno Edge Functions, build login and user management functionality, and manage large files.
 </div>

--- a/apps/docs/docs/ref/javascript/introduction.mdx
+++ b/apps/docs/docs/ref/javascript/introduction.mdx
@@ -7,14 +7,11 @@ hideTitle: true
 <div className="flex items-start gap-6 not-prose" id="introduction">
   <IconMenuJavascript width={35} height={35} />
   <div className="flex flex-col gap-2">
-    <h1 className="text-3xl text-scale-1200 m-0">Javascript Client Library</h1>
+    <h1 className="text-3xl text-scale-1200 m-0">JavaScript Client Library</h1>
     <h2 className="text-base font-mono text-scale-1100">@supabase/supabase-js</h2>
   </div>
 </div>
 
-<div className="max-w-xl">
-  This reference documents every object and method available in Supabase's isomorphic JavaScript
-  library, supabase-js. You can use supabase-js to interact with your Postgres database, listen to
-  database changes, invoke Deno Edge Functions, build login and user management functionality, and
-  manage large files.
+<div className="max-w-xl whitespace-nowrap">
+  This reference documents every object and method available in Supabase's isomorphic JavaScript library, supabase-js. You can use supabase-js to interact with your Postgres database, listen to database changes, invoke Deno Edge Functions, build login and user management functionality, and manage large files.
 </div>

--- a/apps/docs/docs/ref/javascript/introduction.mdx
+++ b/apps/docs/docs/ref/javascript/introduction.mdx
@@ -12,6 +12,7 @@ hideTitle: true
   </div>
 </div>
 
+{/* prettier-ignore */}
 <div className="max-w-xl">
   This reference documents every object and method available in Supabase's isomorphic JavaScript library, supabase-js. You can use supabase-js to interact with your Postgres database, listen to database changes, invoke Deno Edge Functions, build login and user management functionality, and manage large files.
 </div>

--- a/apps/docs/docs/ref/javascript/v1/introduction.mdx
+++ b/apps/docs/docs/ref/javascript/v1/introduction.mdx
@@ -12,10 +12,10 @@ hideTitle: true
   </div>
 </div>
 
+{/* prettier-ignore */}
 <div className="max-w-xl">
   <Admonition type="caution">
-    You're viewing the docs for an older version of the `supabase-js` library. Learn how to [upgrade
-    to the latest version](/docs/reference/javascript/v1/upgrade-guide).
+    You're viewing the docs for an older version of the `supabase-js` library. Learn how to [upgrade to the latest version](/docs/reference/javascript/v1/upgrade-guide).
   </Admonition>
 
   This reference documents every object and method available in Supabase's isomorphic JavaScript library, supabase-js. You can use supabase-js to interact with your Postgres database, listen to database changes, invoke Deno Edge Functions, build login and user management functionality, and manage large files.

--- a/apps/docs/docs/ref/javascript/v1/introduction.mdx
+++ b/apps/docs/docs/ref/javascript/v1/introduction.mdx
@@ -18,5 +18,7 @@ hideTitle: true
     You're viewing the docs for an older version of the `supabase-js` library. Learn how to [upgrade to the latest version](/docs/reference/javascript/v1/upgrade-guide).
   </Admonition>
 
-  This reference documents every object and method available in Supabase's isomorphic JavaScript library, supabase-js. You can use supabase-js to interact with your Postgres database, listen to database changes, invoke Deno Edge Functions, build login and user management functionality, and manage large files.
+  <p>
+    This reference documents every object and method available in Supabase's isomorphic JavaScript library, supabase-js. You can use supabase-js to interact with your Postgres database, listen to database changes, invoke Deno Edge Functions, build login and user management functionality, and manage large files.
+  </p>
 </div>

--- a/apps/docs/docs/ref/javascript/v1/introduction.mdx
+++ b/apps/docs/docs/ref/javascript/v1/introduction.mdx
@@ -7,21 +7,16 @@ hideTitle: true
 <div className="flex items-start gap-6 not-prose" id="introduction">
   <IconMenuJavascript width={35} height={35} />
   <div className="flex flex-col gap-2">
-    <h1 className="text-3xl text-scale-1200 m-0">Javascript Client Library</h1>
+    <h1 className="text-3xl text-scale-1200 m-0">JavaScript Client Library</h1>
     <h2 className="text-base font-mono text-scale-1100">@supabase/supabase-js</h2>
   </div>
 </div>
 
 <div className="max-w-xl">
+  <Admonition type="caution">
+    You're viewing the docs for an older version of the `supabase-js` library. Learn how to [upgrade
+    to the latest version](/docs/reference/javascript/v1/upgrade-guide).
+  </Admonition>
 
-<Admonition type="caution">
-  You're viewing the docs for an older version of the `supabase-js` library. Learn how to [upgrade
-  to the latest version](/docs/reference/javascript/v1/upgrade-guide).
-</Admonition>
-
-This reference documents every object and method available in Supabase's isomorphic JavaScript
-library, supabase-js. You can use supabase-js to interact with your Postgres database, listen to
-database changes, invoke Deno Edge Functions, build login and user management functionality, and
-manage large files.
-
+  This reference documents every object and method available in Supabase's isomorphic JavaScript library, supabase-js. You can use supabase-js to interact with your Postgres database, listen to database changes, invoke Deno Edge Functions, build login and user management functionality, and manage large files.
 </div>

--- a/apps/docs/docs/ref/swift/introduction.mdx
+++ b/apps/docs/docs/ref/swift/introduction.mdx
@@ -13,15 +13,13 @@ hideTitle: true
 </div>
 
 <div className="max-w-xl">
-This reference documents every object and method available in Supabase's Swift library, [supabase-swift](https://github.com/supabase-community/supabase-swift). You can use supabase-swift to interact with your Postgres database, listen to database changes, invoke Deno Edge Functions, build login and user management functionality, and manage large files.
+  This reference documents every object and method available in Supabase's Swift library, [supabase-swift](https://github.com/supabase-community/supabase-swift). You can use supabase-swift to interact with your Postgres database, listen to database changes, invoke Deno Edge Functions, build login and user management functionality, and manage large files.
 
-We also provide a [supabase](https://pub.dev/packages/supabase) package for non-Swift projects.
-
+  We also provide a [supabase](https://pub.dev/packages/supabase) package for non-Swift projects.
 </div>
 
 <div className="max-w-xl bg-slate-300 px-4 py-2 rounded-md">
   <p>The Swift client library is created and maintained by the Supabase community, and is not an official library. Please be tolerant of areas where the library is still being developed, and — as with all the libraries — feel free to contribute wherever you find issues.</p>
 
-<p>Huge thanks to official maintainer, [Maail](https://github.com/maail).</p>
-
+  <p>Huge thanks to official maintainer, [Maail](https://github.com/maail).</p>
 </div>

--- a/apps/docs/docs/ref/swift/introduction.mdx
+++ b/apps/docs/docs/ref/swift/introduction.mdx
@@ -14,9 +14,12 @@ hideTitle: true
 
 {/* prettier-ignore */}
 <div className="max-w-xl">
-  This reference documents every object and method available in Supabase's Swift library, [supabase-swift](https://github.com/supabase-community/supabase-swift). You can use supabase-swift to interact with your Postgres database, listen to database changes, invoke Deno Edge Functions, build login and user management functionality, and manage large files.
-
-  We also provide a [supabase](https://pub.dev/packages/supabase) package for non-Swift projects.
+  <p>
+    This reference documents every object and method available in Supabase's Swift library, [supabase-swift](https://github.com/supabase-community/supabase-swift). You can use supabase-swift to interact with your Postgres database, listen to database changes, invoke Deno Edge Functions, build login and user management functionality, and manage large files.
+  </p>
+  <p>
+    We also provide a [supabase](https://pub.dev/packages/supabase) package for non-Swift projects.
+  </p>
 </div>
 
 {/* prettier-ignore */}

--- a/apps/docs/docs/ref/swift/introduction.mdx
+++ b/apps/docs/docs/ref/swift/introduction.mdx
@@ -12,12 +12,14 @@ hideTitle: true
   </div>
 </div>
 
+{/* prettier-ignore */}
 <div className="max-w-xl">
   This reference documents every object and method available in Supabase's Swift library, [supabase-swift](https://github.com/supabase-community/supabase-swift). You can use supabase-swift to interact with your Postgres database, listen to database changes, invoke Deno Edge Functions, build login and user management functionality, and manage large files.
 
   We also provide a [supabase](https://pub.dev/packages/supabase) package for non-Swift projects.
 </div>
 
+{/* prettier-ignore */}
 <div className="max-w-xl bg-slate-300 px-4 py-2 rounded-md">
   <p>The Swift client library is created and maintained by the Supabase community, and is not an official library. Please be tolerant of areas where the library is still being developed, and — as with all the libraries — feel free to contribute wherever you find issues.</p>
 

--- a/apps/docs/docs/reference/csharp/introduction.mdx
+++ b/apps/docs/docs/reference/csharp/introduction.mdx
@@ -12,6 +12,7 @@ hideTitle: true
   </div>
 </div>
 
+{/* prettier-ignore */}
 <div className="max-w-xl">
   This reference documents every object and method available in Supabase's C# library, [supabase-csharp](https://www.nuget.org/packages/supabase-csharp). You can use supabase-csharp to interact with your Postgres database, listen to database changes, invoke Deno Edge Functions, build login and user management functionality, and manage large files.
 </div>

--- a/apps/docs/docs/reference/csharp/introduction.mdx
+++ b/apps/docs/docs/reference/csharp/introduction.mdx
@@ -13,8 +13,5 @@ hideTitle: true
 </div>
 
 <div className="max-w-xl">
-  This reference documents every object and method available in Supabase's C#
-  library, [supabase-csharp](https://www.nuget.org/packages/supabase-csharp). You can
-  use supabase-csharp to interact with your Postgres database, listen to database changes, invoke
-  Deno Edge Functions, build login and user management functionality, and manage large files.
+  This reference documents every object and method available in Supabase's C# library, [supabase-csharp](https://www.nuget.org/packages/supabase-csharp). You can use supabase-csharp to interact with your Postgres database, listen to database changes, invoke Deno Edge Functions, build login and user management functionality, and manage large files.
 </div>

--- a/apps/docs/docs/reference/dart.mdx
+++ b/apps/docs/docs/reference/dart.mdx
@@ -17,6 +17,7 @@ You can use the `supabase-flutter` library to:
 
 ## For non-Flutter projects
 
+{/* prettier-ignore */}
 We also have [supabase-dart](https://github.com/supabase-community/supabase-dart) for non-Flutter Dart projects, such as server-side Dart or Angular-Dart. supabase-dart shares most of the APIs with supabase-flutter without being dependent on Flutter so that you can use Supabase anywhere you can run Dart!
 
 ## Additional Links

--- a/apps/docs/docs/reference/dart.mdx
+++ b/apps/docs/docs/reference/dart.mdx
@@ -17,8 +17,7 @@ You can use the `supabase-flutter` library to:
 
 ## For non-Flutter projects
 
-We also have [supabase-dart](https://github.com/supabase-community/supabase-dart) for non-Flutter Dart projects, such as server-side Dart or Angular-Dart.
-supabase-dart shares most of the APIs with supabase-flutter without being dependent on Flutter so that you can use Supabase anywhere you can run Dart!
+We also have [supabase-dart](https://github.com/supabase-community/supabase-dart) for non-Flutter Dart projects, such as server-side Dart or Angular-Dart. supabase-dart shares most of the APIs with supabase-flutter without being dependent on Flutter so that you can use Supabase anywhere you can run Dart!
 
 ## Additional Links
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

Just some unexpected line breaks on some documentation introductions:

![image](https://github.com/supabase/supabase/assets/15347252/2ba19201-64fb-49fd-a2d7-be6142a7b011)

## What is the new behavior?

No more unexpected line breaks:

![image](https://github.com/supabase/supabase/assets/15347252/aaaac277-f730-41eb-b4fa-811ac0502581)

I changed that on a number of files, as you can see on the PR.

## Additional context

No content was changed on any of the files.
