### PR TITLE
Update: Vonage docs

### DIFF
--- a/apps/docs/pages/guides/auth/phone-login/vonage.mdx
+++ b/apps/docs/pages/guides/auth/phone-login/vonage.mdx
@@ -53,7 +53,7 @@ Now go to the Auth > Settings page in the Supabase dashboard (https://supabase.c
 
 You should see an option to enable Phone Signup.
 
-Toggle it on, and copy the api key, api secret and optionally phone number values over from the Vonage dashboard. Click save.
+Toggle it on, and copy the api key, api secret and phone number values over from the Vonage dashboard. Click save.
 
 Now the backend should be setup, we can proceed to add our client-side code!
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

`Vonage from` field was mentioned as optional in the vonage doc. 
![image](https://github.com/supabase/supabase/assets/99693443/90f6d151-97f6-4e66-b1dd-4e6fb597eb42)
![image](https://github.com/supabase/supabase/assets/99693443/48958dae-794f-4495-aeeb-a1f91abf0877)

## What is the new behavior?

Since `Vonage from` field is required in Phone Auth Provider Setup, we've updated the docs to reflect this info. 

## Additional context


