### PR TITLE
When user isn't using Big Query adapter, we warn the user that they c…

### DIFF
--- a/apps/docs/docs/ref/self-hosting-analytics/introduction.mdx
+++ b/apps/docs/docs/ref/self-hosting-analytics/introduction.mdx
@@ -103,6 +103,8 @@ docker compose -f docker-compose.yml up
 
 > ⚠️ WARNING: Please be aware of the heavy consumption of analytics. For heavy usage you might want to consider the usage of a different database for analytics only by updating the `POSTGRES_BACKEND_URL` in the `analytics` service on the `docker-compose.yml` file.
 
+Also be aware that you won't be able to use [Log Explorer](https://supabase.com/docs/guides/platform/logs#logs-explorer) when using the Postgres Backend as some of the querying features are still not supported by our translation layer.
+
 #### Using the Big Query Backend
 
 Using the example [self-hosting stack based on docker-compose](https://github.com/supabase/supabase/tree/master/docker), you include the logging related services using the following command
@@ -113,7 +115,6 @@ Using the example [self-hosting stack based on docker-compose](https://github.co
 - `GOOGLE_PROJECT_NUMBER`
 
 2. Place your Service Account key in your present working directory with the filename `gcloud.json`.
-
 3. On `docker-compose.yml`, uncomment the block section below the commentary `# Uncomment to use Big Query backend for analytics`
 4. On `docker-compose.yml`, comment the block section below the commentary `# Comment variables to use Big Query backend for analytics`
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       # Comment to use Big Query backend for analytics
       NEXT_ANALYTICS_BACKEND_PROVIDER: postgres
       # Uncomment to use Big Query backend for analytics
-      # NEXT_ANALYTICS_BACKEND_PROVIDER: big_query
+      # NEXT_ANALYTICS_BACKEND_PROVIDER: bigquery
 
   kong:
     container_name: supabase-kong

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -46,6 +46,10 @@ services:
       LOGFLARE_API_KEY: ${LOGFLARE_API_KEY}
       LOGFLARE_URL: http://analytics:4000
       NEXT_PUBLIC_ENABLE_LOGS: true
+      # Comment to use Big Query backend for analytics
+      NEXT_ANALYTICS_BACKEND_PROVIDER: postgres
+      # Uncomment to use Big Query backend for analytics
+      # NEXT_ANALYTICS_BACKEND_PROVIDER: big_query
 
   kong:
     container_name: supabase-kong

--- a/studio/pages/api/projects/[ref]/analytics/endpoints/[name].ts
+++ b/studio/pages/api/projects/[ref]/analytics/endpoints/[name].ts
@@ -15,10 +15,10 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
           .status(400)
           .json({ error: { message: '[analytics] is not enabled in supabase/config.toml' } })
       }
-      if (process.env.NEXT_ANALYTICS_BACKEND_PROVIDER !== 'big_query') {
+      if (process.env.NEXT_ANALYTICS_BACKEND_PROVIDER !== 'bigquery') {
         return res
           .status(400)
-          .json({ error: { message: 'Log Explorer is only supported by the [analytics] Big Query backend, please refer to the documentation to set it up' } })
+          .json({ error: { message: 'Log Explorer is only supported by the [analytics] Big Query backend. Please refer to https://supabase.com/docs/reference/self-hosting-analytics/introduction for more information' } })
       }
       const missingEnvVars = [
         process.env.LOGFLARE_API_KEY ? null : 'LOGFLARE_API_KEY',

--- a/studio/pages/api/projects/[ref]/analytics/endpoints/[name].ts
+++ b/studio/pages/api/projects/[ref]/analytics/endpoints/[name].ts
@@ -15,6 +15,11 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
           .status(400)
           .json({ error: { message: '[analytics] is not enabled in supabase/config.toml' } })
       }
+      if (process.env.NEXT_ANALYTICS_BACKEND_PROVIDER !== 'big_query') {
+        return res
+          .status(400)
+          .json({ error: { message: 'Log Explorer is only supported by the [analytics] Big Query backend, please refer to the documentation to set it up' } })
+      }
       const missingEnvVars = [
         process.env.LOGFLARE_API_KEY ? null : 'LOGFLARE_API_KEY',
         process.env.LOGFLARE_URL ? null : 'LOGFLARE_URL',


### PR DESCRIPTION
## What kind of change does this PR introduce?

When the user isn't using Big Query as the backend adapter for analytics, we warn the user that currently they are unable to use Log Explorer as it doesn't offer the best experience at the moment.

## Additional context
<img width="2024" alt="Screenshot 2023-08-04 at 12 16 55" src="https://github.com/supabase/supabase/assets/1697301/744a9e94-612c-4a5f-97b5-aa83ef132ce0">
