### PR TITLE
chore: improve project nav with org-billing

### DIFF
--- a/studio/components/interfaces/Organization/Usage/Usage.tsx
+++ b/studio/components/interfaces/Organization/Usage/Usage.tsx
@@ -11,10 +11,12 @@ import { useProjectsQuery } from 'data/projects/projects-query'
 import { useOrgSubscriptionQuery } from 'data/subscriptions/org-subscription-query'
 import { useSelectedOrganization } from 'hooks'
 import { TIME_PERIODS_BILLING, TIME_PERIODS_REPORTS } from 'lib/constants'
-import { Listbox } from 'ui'
+import { Button, IconExternalLink, IconInfo, Listbox } from 'ui'
 import Activity from './Activity'
 import Bandwidth from './Bandwidth'
 import SizeAndCounts from './SizeAndCounts'
+import InformationBox from 'components/ui/InformationBox'
+import Link from 'next/link'
 
 const Usage = () => {
   const { slug, projectRef } = useParams()
@@ -122,8 +124,8 @@ const Usage = () => {
                 <Listbox.Option
                   key="all-projects"
                   id="all-projects"
-                  value="all-projects"
                   label="All projects"
+                  value="all-projects"
                 >
                   All projects
                 </Listbox.Option>
@@ -152,6 +154,36 @@ const Usage = () => {
           )}
         </div>
       </ScaffoldContainer>
+
+      {selectedProjectRef && (
+        <ScaffoldContainer className="mt-5">
+          <InformationBox
+            title="Usage filtered by project"
+            description={
+              <div className="space-y-3">
+                <p>
+                  You are currently viewing usage for a specific project. Since your organization is
+                  using the new organization-level-billing, the included quota is for your whole
+                  organization and not per-project. For billing purposes, we sum up usage from all
+                  your projects. To view your usage quota, remove the project filter.
+                </p>
+                <div>
+                  <Link href="https://www.notion.so/supabase/Organization-Level-Billing-9c159d69375b4af095f0b67881276582?pvs=4">
+                    <a target="_blank" rel="noreferrer">
+                      <Button type="default" icon={<IconExternalLink strokeWidth={1.5} />}>
+                        Documentation
+                      </Button>
+                    </a>
+                  </Link>
+                </div>
+              </div>
+            }
+            defaultVisibility
+            hideCollapse
+            icon={<IconInfo />}
+          />
+        </ScaffoldContainer>
+      )}
 
       <Bandwidth
         orgSlug={slug as string}

--- a/studio/components/interfaces/Organization/Usage/Usage.tsx
+++ b/studio/components/interfaces/Organization/Usage/Usage.tsx
@@ -163,7 +163,7 @@ const Usage = () => {
               <div className="space-y-3">
                 <p>
                   You are currently viewing usage for a specific project. Since your organization is
-                  using the new organization-level-billing, the included quota is for your whole
+                  using the new organization-level billing, the included quota is for your whole
                   organization and not per-project. For billing purposes, we sum up usage from all
                   your projects. To view your usage quota, remove the project filter.
                 </p>

--- a/studio/components/interfaces/Organization/Usage/Usage.tsx
+++ b/studio/components/interfaces/Organization/Usage/Usage.tsx
@@ -164,7 +164,7 @@ const Usage = () => {
                 <p>
                   You are currently viewing usage for a specific project. Since your organization is
                   using the new organization-level billing, the included quota is for your whole
-                  organization and not per-project. For billing purposes, we sum up usage from all
+                  organization and not just this project. For billing purposes, we sum up usage from all
                   your projects. To view your usage quota, remove the project filter.
                 </p>
                 <div>

--- a/studio/components/interfaces/Organization/Usage/Usage.tsx
+++ b/studio/components/interfaces/Organization/Usage/Usage.tsx
@@ -84,6 +84,10 @@ const Usage = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dateRange, subscription])
 
+  const selectedProject = selectedProjectRef
+    ? orgProjects?.find((it) => it.ref === selectedProjectRef)
+    : undefined
+
   return (
     <>
       <ScaffoldContainer className="sticky top-0 border-b bg-scale-200 z-10 overflow-hidden">
@@ -162,10 +166,12 @@ const Usage = () => {
             description={
               <div className="space-y-3">
                 <p>
-                  You are currently viewing usage for a specific project. Since your organization is
+                  You are currently viewing usage for the "
+                  {selectedProject?.name || selectedProjectRef}" project. Since your organization is
                   using the new organization-level billing, the included quota is for your whole
-                  organization and not just this project. For billing purposes, we sum up usage from all
-                  your projects. To view your usage quota, remove the project filter.
+                  organization and not just this project. For billing purposes, we sum up usage from
+                  all your projects. To view your usage quota, set the project filter above back to
+                  "All Projects".
                 </p>
                 <div>
                   <Link href="https://www.notion.so/supabase/Organization-Level-Billing-9c159d69375b4af095f0b67881276582?pvs=4">

--- a/studio/components/layouts/ProjectSettingsLayout/SettingsLayout.tsx
+++ b/studio/components/layouts/ProjectSettingsLayout/SettingsLayout.tsx
@@ -18,7 +18,7 @@ const SettingsLayout = ({ title, children }: PropsWithChildren<SettingsLayoutPro
   const { ui, meta } = useStore()
   const project = useSelectedProject()
   const organization = useSelectedOrganization()
-  const isOrgBilling = !!organization?.subscription_id
+  
 
   // billing pages live under /billing/invoices and /billing/subscription, etc
   // so we need to pass the [5]th part of the url to the menu
@@ -27,7 +27,7 @@ const SettingsLayout = ({ title, children }: PropsWithChildren<SettingsLayoutPro
     : router.pathname.split('/')[4]
 
   const isVaultEnabled = useFlag('vaultExtension')
-  const menuRoutes = generateSettingsMenu(ref, project, isVaultEnabled, isOrgBilling)
+  const menuRoutes = generateSettingsMenu(ref, project, organization, isVaultEnabled)
 
   useEffect(() => {
     if (ui.selectedProjectRef) {

--- a/studio/components/layouts/ProjectSettingsLayout/SettingsMenu.utils.ts
+++ b/studio/components/layouts/ProjectSettingsLayout/SettingsMenu.utils.ts
@@ -1,15 +1,17 @@
-import { ProjectBase } from 'types'
+import { Organization, ProjectBase } from 'types'
 import { IS_PLATFORM, PROJECT_STATUS } from 'lib/constants'
 import { ProductMenuGroup } from 'components/ui/ProductMenu/ProductMenu.types'
 
 export const generateSettingsMenu = (
   ref?: string,
   project?: ProjectBase,
-  isVaultEnabled: boolean = false,
-  isOrgBilling: boolean = false
+  organization?: Organization,
+  isVaultEnabled: boolean = false
 ): ProductMenuGroup[] => {
   const isProjectBuilding = project?.status === PROJECT_STATUS.COMING_UP
   const buildingUrl = `/project/${ref}/building`
+
+  const isOrgBilling = !!organization?.subscription_id
 
   if (isOrgBilling) {
     return [
@@ -82,6 +84,24 @@ export const generateSettingsMenu = (
                 },
               ]
             : []),
+        ],
+      },
+
+      {
+        title: 'Billing',
+        items: [
+          {
+            name: 'Subscription',
+            key: 'subscription',
+            url: `/org/${organization?.slug}/billing`,
+            items: [],
+          },
+          {
+            name: 'Usage',
+            key: 'usage',
+            url: `/org/${organization?.slug}/usage?projectRef=${ref}`,
+            items: [],
+          },
         ],
       },
     ]


### PR DESCRIPTION
Adds back the subscription/usage nav items for confused users that are not yet used to the new organization billing. Links however lead to the organization pages.

Also adds a hint on the new org usage page, when filtering for a specific project.

![Screenshot 2023-08-04 at 13 48 06](https://github.com/supabase/supabase/assets/14073399/fa0bcd5c-7115-47f0-8423-0e8abdda5eef)

![Screenshot 2023-08-04 at 13 47 22](https://github.com/supabase/supabase/assets/14073399/2205ad17-ca98-4021-a2cd-bf009ccadcbd)
