### PR TITLE
feat: use es2017 target for studio

### DIFF
--- a/studio/tsconfig.json
+++ b/studio/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
It was using ES5, which is from 2009.