### PR TITLE
docs: case issue in Typescript support sample code

### DIFF
--- a/apps/docs/docs/ref/javascript/typescript-support.mdx
+++ b/apps/docs/docs/ref/javascript/typescript-support.mdx
@@ -116,7 +116,7 @@ title: Typescript Support
         return await supabase.from('movies').select('id, title, actors(\*)')
       }
 
-      type Actors = Database['public']['tables']['actors']['row']
+      type Actors = Database['public']['Tables']['actors']['Row']
       type MoviesResponse = Awaited<ReturnType<typeof getMovies>>
       type MoviesResponseSuccess = MoviesResponse['data'] & {
       actors: Actors[]


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix for a typo (case issue) in the Typescript support section.

I might have missed something, but it seems that we need to use `Tables` and `Row` as keys in the `Database` interface (and not the lowercase `tables` and `row` keys).

## What is the current behavior?

The example code does not (seem to) work.

## What is the new behavior?

The sample code works.