### PR TITLE
SQL editor: Generate AI SQL when editor is empty

### DIFF
--- a/studio/components/interfaces/SQLEditor/MonacoEditor.tsx
+++ b/studio/components/interfaces/SQLEditor/MonacoEditor.tsx
@@ -70,7 +70,9 @@ const MonacoEditor = ({
   }
 
   function handleEditorChange(value: string | undefined) {
-    if (id && value) snap.setSql(id, value)
+    if (id && value !== undefined) {
+      snap.setSql(id, value)
+    }
   }
 
   return (

--- a/studio/components/interfaces/SQLEditor/SQLEditor.tsx
+++ b/studio/components/interfaces/SQLEditor/SQLEditor.tsx
@@ -530,7 +530,13 @@ const SQLEditor = () => {
                           'focus-visible:ring-0 focus-visible:ring-offset-0',
                           'appearance-none outline-none'
                         )}
-                        placeholder={!debugSolution ? 'Ask Supabase AI to modify your query' : ''}
+                        placeholder={
+                          !debugSolution
+                            ? !snippet?.snippet.content.sql.trim()
+                              ? 'Ask Supabase AI to build a query'
+                              : 'Ask Supabase AI to modify your query'
+                            : ''
+                        }
                         onKeyDown={(e) => {
                           if (e.key === 'Escape' && !aiInput) {
                             setIsAiOpen(false)


### PR DESCRIPTION
Currently the AI input on the SQL editor only edits queries. This changes logic to generate SQL (`/api/ai/sql/generate`) when the editor is empty, or otherwise edit SQL (`/api/ai/sql/edit`) when existing SQL is present.

Also changes AI input placeholder text accordingly.

![image](https://github.com/supabase/supabase/assets/4133076/c2552ea6-602d-48dc-98bd-a41e3e3df407)
![image](https://github.com/supabase/supabase/assets/4133076/1df70021-7130-40e2-bc0c-b40a2f276816)
