### PR TITLE
Fix: wrappers link in the dashboard

### DIFF
--- a/studio/components/interfaces/Database/Wrappers/WrappersDisabledState.tsx
+++ b/studio/components/interfaces/Database/Wrappers/WrappersDisabledState.tsx
@@ -107,7 +107,7 @@ const WrappersDisabledState = () => {
                 </div>
               </div>
               <div className="flex items-center space-x-2 my-1 ml-[1px]">
-                <Link href="https://supabase.com/docs/guides/database/extensions/wrappers">
+                <Link href="https://supabase.com/docs/guides/database/extensions/wrappers/overview">
                   <a target="_blank" rel="noreferrer">
                     <Button type="default" icon={<IconExternalLink />}>
                       About Wrappers
@@ -118,7 +118,7 @@ const WrappersDisabledState = () => {
             </div>
           ) : (
             <div className="flex items-center space-x-2">
-              <Link href="https://supabase.com/docs/guides/database/extensions/wrappers">
+              <Link href="https://supabase.com/docs/guides/database/extensions/wrappers/overview">
                 <a target="_blank" rel="noreferrer">
                   <Button type="default" icon={<IconExternalLink />}>
                     About Wrappers


### PR DESCRIPTION
## What kind of change does this PR introduce?

Link fix

## What is the current behavior?

`About Wrappers` in the dashboard was returning 404 error code. 

## What is the new behavior?

Fixed the link to '`https://supabase.com/docs/guides/database/extensions/wrappers/overview`'

## Additional context

<img width="954" alt="image" src="https://github.com/supabase/supabase/assets/99693443/96bf09ee-9f50-4caa-8dca-ec6bf7d50709">

