### PR TITLE
Chore: Update performance doc with details about explain command

### DIFF
--- a/apps/docs/pages/guides/platform/performance.mdx
+++ b/apps/docs/pages/guides/platform/performance.mdx
@@ -151,6 +151,7 @@ Postgres has built in tooling to help you optimize poorly performing queries. Yo
 ```sql
 explain analyze <query-statement-here>;
 ```
+
 When you include `analyze` in the explain statement, the database attempts to execute the query and provides a detailed query plan along with actual execution times. So, be careful using `explain analyze` with `insert`/`update`/`delete` queries, because the query will actually run, and could have unintended side-effects.
 
 If you run just `explain` without the `analyze` keyword, the database will only perform query planning without actually executing the query. This approach can be beneficial when you want to inspect the query plan without affecting the database or if you encounter timeouts in your queries. 

--- a/apps/docs/pages/guides/platform/performance.mdx
+++ b/apps/docs/pages/guides/platform/performance.mdx
@@ -154,7 +154,7 @@ explain analyze <query-statement-here>;
 
 When you include `analyze` in the explain statement, the database attempts to execute the query and provides a detailed query plan along with actual execution times. So, be careful using `explain analyze` with `insert`/`update`/`delete` queries, because the query will actually run, and could have unintended side-effects.
 
-If you run just `explain` without the `analyze` keyword, the database will only perform query planning without actually executing the query. This approach can be beneficial when you want to inspect the query plan without affecting the database or if you encounter timeouts in your queries. 
+If you run just `explain` without the `analyze` keyword, the database will only perform query planning without actually executing the query. This approach can be beneficial when you want to inspect the query plan without affecting the database or if you encounter timeouts in your queries.
 
 Using the query plan analyzer to optimize your queries is a large topic, with a number of online resources available:
 

--- a/apps/docs/pages/guides/platform/performance.mdx
+++ b/apps/docs/pages/guides/platform/performance.mdx
@@ -151,8 +151,9 @@ Postgres has built in tooling to help you optimize poorly performing queries. Yo
 ```sql
 explain analyze <query-statement-here>;
 ```
+When you include `analyze` in the explain statement, the database attempts to execute the query and provides a detailed query plan along with actual execution times. So, be careful using `explain analyze` with `insert`/`update`/`delete` queries, because the query will actually run, and could have unintended side-effects.
 
-Be careful using `explain analyze` with `insert`/`update`/`delete` queries, because the query will actually run, and could have unintended side-effects.
+If you run just `explain` without the `analyze` keyword, the database will only perform query planning without actually executing the query. This approach can be beneficial when you want to inspect the query plan without affecting the database or if you encounter timeouts in your queries. 
 
 Using the query plan analyzer to optimize your queries is a large topic, with a number of online resources available:
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

Doesn't include information about using `EXPLAIN` without `ANALYZE` keyword.

## What is the new behavior?

Add more info to the `EXPLAIN ANALYZE` section.
