### PR TITLE
AI SQL editor: enable schema sending by default (after org level opt-in)

### DIFF
--- a/studio/components/interfaces/SQLEditor/AISettingsModal.tsx
+++ b/studio/components/interfaces/SQLEditor/AISettingsModal.tsx
@@ -12,12 +12,12 @@ const AISettingsModal = (props: ModalProps) => {
   const selectedOrganization = useSelectedOrganization()
   const isOptedInToAI =
     selectedOrganization?.opt_in_tags?.includes('AI_SQL_GENERATOR_OPT_IN') ?? false
-  const [isOptedInToAISchema, setIsOptedInToAISchema] = useLocalStorageQuery(
+  const [hasEnabledAISchema, setHasEnabledAISchema] = useLocalStorageQuery(
     'supabase_sql-editor-ai-schema-enabled',
-    false
+    true
   )
 
-  const includeSchemaMetadata = (isOptedInToAI || !IS_PLATFORM) && isOptedInToAISchema
+  const includeSchemaMetadata = (isOptedInToAI || !IS_PLATFORM) && hasEnabledAISchema
 
   return (
     <Modal header="SQL Editor AI Settings" hideFooter closable {...props}>
@@ -33,7 +33,7 @@ const AISettingsModal = (props: ModalProps) => {
           <Toggle
             disabled={IS_PLATFORM && !isOptedInToAI}
             checked={includeSchemaMetadata}
-            onChange={() => setIsOptedInToAISchema((prev) => !prev)}
+            onChange={() => setHasEnabledAISchema((prev) => !prev)}
           />
         </div>
         {IS_PLATFORM && !isOptedInToAI && selectedOrganization && (

--- a/studio/components/interfaces/SQLEditor/SQLEditor.tsx
+++ b/studio/components/interfaces/SQLEditor/SQLEditor.tsx
@@ -151,7 +151,7 @@ const SQLEditor = () => {
   const selectedProject = useSelectedProject()
   const isOptedInToAI =
     selectedOrganization?.opt_in_tags?.includes('AI_SQL_GENERATOR_OPT_IN') ?? false
-  const [isOptedInToAISchema] = useLocalStorageQuery('supabase_sql-editor-ai-schema-enabled', false)
+  const [hasEnabledAISchema] = useLocalStorageQuery('supabase_sql-editor-ai-schema-enabled', true)
   const [isAcceptDiffLoading, setIsAcceptDiffLoading] = useState(false)
   const [, setAiQueryCount] = useLocalStorageQuery('supabase_sql-editor-ai-query-count', 0)
   const [, setIsSchemaSuggestionDismissed] = useLocalStorageQuery(
@@ -159,7 +159,7 @@ const SQLEditor = () => {
     false
   )
 
-  const includeSchemaMetadata = (isOptedInToAI || !IS_PLATFORM) && isOptedInToAISchema
+  const includeSchemaMetadata = (isOptedInToAI || !IS_PLATFORM) && hasEnabledAISchema
 
   const [selectedDiffType, setSelectedDiffType] = useState(DiffType.Modification)
   const [isFirstRender, setIsFirstRender] = useState(true)

--- a/studio/components/interfaces/SQLEditor/SQLTemplates/SQLAI.tsx
+++ b/studio/components/interfaces/SQLEditor/SQLTemplates/SQLAI.tsx
@@ -37,7 +37,7 @@ const SQLAI = () => {
   const selectedProject = useSelectedProject()
   const isOptedInToAI =
     selectedOrganization?.opt_in_tags?.includes('AI_SQL_GENERATOR_OPT_IN') ?? false
-  const [isOptedInToAISchema] = useLocalStorageQuery('supabase_sql-editor-ai-schema-enabled', false)
+  const [hasEnabledAISchema] = useLocalStorageQuery('supabase_sql-editor-ai-schema-enabled', true)
   const [, setAiQueryCount] = useLocalStorageQuery('supabase_sql-editor-ai-query-count', 0)
   const [, setIsSchemaSuggestionDismissed] = useLocalStorageQuery(
     'supabase_sql-editor-ai-schema-suggestion-dismissed',
@@ -52,7 +52,7 @@ const SQLAI = () => {
     subject: { id: profile?.id },
   })
 
-  const includeSchemaMetadata = (isOptedInToAI || !IS_PLATFORM) && isOptedInToAISchema
+  const includeSchemaMetadata = (isOptedInToAI || !IS_PLATFORM) && hasEnabledAISchema
 
   const { data } = useEntityDefinitionsQuery(
     {

--- a/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityTabResults.tsx
+++ b/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityTabResults.tsx
@@ -24,9 +24,9 @@ const UtilityTabResults = ({ id, isExecuting }: UtilityTabResultsProps) => {
   const selectedProject = useSelectedProject()
   const isOptedInToAI =
     selectedOrganization?.opt_in_tags?.includes('AI_SQL_GENERATOR_OPT_IN') ?? false
-  const [isOptedInToAISchema] = useLocalStorageQuery('supabase_sql-editor-ai-schema-enabled', false)
+  const [hasEnabledAISchema] = useLocalStorageQuery('supabase_sql-editor-ai-schema-enabled', true)
 
-  const includeSchemaMetadata = (isOptedInToAI || !IS_PLATFORM) && isOptedInToAISchema
+  const includeSchemaMetadata = (isOptedInToAI || !IS_PLATFORM) && hasEnabledAISchema
 
   const { data } = useEntityDefinitionsQuery(
     {


### PR DESCRIPTION
Currently you need to enable 2 toggles to allow sending DB schema up with SQL editor AI requests:
1. Org level opt-in to send data to OpenAI
2. Toggle in sql editor settings (value stored in local storage)

This change enables the second toggle by default after the OpenAI opt-in has been enabled at the org level. This prevents the unnecessary extra step of toggling again after already toggling on the org level. We're keeping the second toggle available (vs removing altogether) so that users still have the option to disable within their specific session/query. They might want to do this because:
- prompt payload gets too big if your schema is too large, in this case you can’t send all your schema info
- the result returned has varied qualities for larger schemas too, sometimes the query returned doesn't always make sense