### PR TITLE
hotfix: use correct endpoint to revoke authorized oauth app

### DIFF
--- a/studio/data/oauth/authorized-app-revoke-mutation.ts
+++ b/studio/data/oauth/authorized-app-revoke-mutation.ts
@@ -1,7 +1,7 @@
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'react-hot-toast'
 
-import { delete_ } from 'lib/common/fetch'
+import { post } from 'lib/common/fetch'
 import { API_ADMIN_URL } from 'lib/constants'
 import { ResponseError } from 'types'
 import { oauthAppKeys } from './keys'
@@ -15,9 +15,7 @@ export async function revokeAuthorizedApp({ id, slug }: AuthorizedAppRevokeVaria
   if (!id) throw new Error('App ID is required')
   if (!slug) throw new Error('Organization slug is required')
 
-  const response = await delete_(
-    `${API_ADMIN_URL}/organizations/${slug}/oauth/apps/${id}?type=authorized`
-  )
+  const response = await post(`${API_ADMIN_URL}/organizations/${slug}/oauth/apps/${id}/revoke`, {})
   if (response.error) throw response.error
   return response
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Users can't delete an authorized app in their org
<img width="1740" alt="image" src="https://github.com/supabase/supabase/assets/28647601/fd965ef3-3207-4764-9501-3a01d80a07bb">
* If the authorized app is in the same org as the published app, deleting the authorized app would delete the published app instead because the wrong endpoint is being used
