### PR TITLE
chore: do not list out valid logical backups if PITR is already enabled

### DIFF
--- a/studio/components/interfaces/Database/Backups/BackupsList.tsx
+++ b/studio/components/interfaces/Database/Backups/BackupsList.tsx
@@ -42,7 +42,7 @@ const BackupsList = () => {
   }
 
   if (isPitrEnabled) {
-    return <></>
+    return null
   }
 
   return (

--- a/studio/components/interfaces/Database/Backups/BackupsList.tsx
+++ b/studio/components/interfaces/Database/Backups/BackupsList.tsx
@@ -41,14 +41,14 @@ const BackupsList = () => {
     )
   }
 
+  if (isPitrEnabled) {
+    return <></>
+  }
+
   return (
     <div className="space-y-6">
       {!sortedBackups?.length && tierKey !== 'FREE' ? (
-        !isPitrEnabled ? (
-          <BackupsEmpty />
-        ) : (
-          <></>
-        )
+        <BackupsEmpty />
       ) : (
         <>
           {!canTriggerScheduledBackups && (


### PR DESCRIPTION
* As long as PITR is already enabled for a project, daily backups should no longer be displayed on the dashboard.