### PR TITLE
fix: relax isSmtpEnabled criteria

### DIFF
--- a/studio/components/interfaces/Auth/SmtpForm/SmtpForm.utils.ts
+++ b/studio/components/interfaces/Auth/SmtpForm/SmtpForm.utils.ts
@@ -12,7 +12,7 @@ export const isSmtpEnabled = (config?: Partial<AuthConfig>): boolean => {
     config?.SMTP_HOST &&
     config?.SMTP_PASS &&
     config?.SMTP_PORT &&
-    (config?.SMTP_MAX_FREQUENCY ?? 0) > 0
+    (config?.SMTP_MAX_FREQUENCY ?? 0) >= 0
   )
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Show custom SMTP even if max frequency is set to 0