### PR TITLE
Remove duplicate versions of `@supabase/gotrue-js`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14121,8 +14121,9 @@
       }
     },
     "node_modules/@supabase/gotrue-js": {
-      "version": "2.27.2",
-      "license": "MIT",
+      "version": "2.47.0",
+      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.47.0.tgz",
+      "integrity": "sha512-3e34/vsKH/DoSZCpB85UZpFWSJ2p4GRUUlqgAgeTPagPlx4xS+Nc5v7g7ic7vp3gK0J5PsYVCn9Qu2JQUp4vXg==",
       "dependencies": {
         "cross-fetch": "^3.1.5"
       }
@@ -40762,14 +40763,6 @@
         "config": "*",
         "tsconfig": "*",
         "typescript": "^5.0.4"
-      }
-    },
-    "packages/common/node_modules/@supabase/gotrue-js": {
-      "version": "2.47.0",
-      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.47.0.tgz",
-      "integrity": "sha512-3e34/vsKH/DoSZCpB85UZpFWSJ2p4GRUUlqgAgeTPagPlx4xS+Nc5v7g7ic7vp3gK0J5PsYVCn9Qu2JQUp4vXg==",
-      "dependencies": {
-        "cross-fetch": "^3.1.5"
       }
     },
     "packages/common/node_modules/@types/react": {


### PR DESCRIPTION
The `studio` app included the `@supabase/gotrue-js` library twice (once as its own dependency, once as a dependency of `packages/common`). There's a warning in a browser console for this: `Multiple GoTrueClient instances detected in the same browser context. It is not an error, but this should be avoided as it may produce undefined behavior when used concurrently under the same storage key.`

This PR deduplicates them and leaves the newer library to be used.