### PR TITLE
Fix the introductory video in the integration page

### DIFF
--- a/apps/www/pages/partners/integrations/[slug].tsx
+++ b/apps/www/pages/partners/integrations/[slug].tsx
@@ -183,9 +183,9 @@ function Partner({
                   {partner.video && (
                     <div className="mb-6">
                       <ExpandableVideo
-                        imgUrl=""
                         videoId={partner.video}
                         imgOverlayText="Watch an introductory video"
+                        triggerContainerClassName="w-full"
                       />
                     </div>
                   )}

--- a/apps/www/pages/partners/integrations/index.tsx
+++ b/apps/www/pages/partners/integrations/index.tsx
@@ -86,8 +86,6 @@ function IntegrationPartnersPage(props: Props) {
     })
   }, [debouncedSearchTerm, router])
 
-  console.log(partners)
-
   return (
     <>
       <NextSeo


### PR DESCRIPTION
This PR fixes the introductory video to show properly. The regression was caused by a refactor of the `ExpandableVideo` during the preparation for LaunchWeek.

An example [page](https://zone-www-dot-com-git-fix-integrations-video-supabase.vercel.app/partners/integrations/pgmustard) vs [what's on production](https://supabase.com/partners/integrations/pgmustard).