### PR TITLE
Fix: Refetch entity definitions after SQL execution

### DIFF
--- a/studio/components/interfaces/SQLEditor/SQLEditor.tsx
+++ b/studio/components/interfaces/SQLEditor/SQLEditor.tsx
@@ -96,10 +96,12 @@ const SQLEditor = () => {
   const { profile } = useProfile()
   const project = useSelectedProject()
   const snap = useSqlEditorStateSnapshot()
+
   const { mutateAsync: generateSql, isLoading: isGenerateSqlLoading } = useSqlGenerateMutation()
   const { mutateAsync: editSql, isLoading: isEditSqlLoading } = useSqlEditMutation()
   const { mutateAsync: titleSql } = useSqlTitleGenerateMutation()
   const { mutateAsync: generateSqlTitle } = useSqlTitleGenerateMutation()
+
   const [aiInput, setAiInput] = useState('')
   const [debugSolution, setDebugSolution] = useState<string>()
   const [sqlDiff, setSqlDiff] = useState<ContentDiff>()
@@ -141,7 +143,7 @@ const SQLEditor = () => {
     setIsFirstRender(false)
   }, [])
 
-  const { data } = useEntityDefinitionsQuery(
+  const { data, refetch: refetchEntityDefinitions } = useEntityDefinitionsQuery(
     {
       projectRef: selectedProject?.ref,
       connectionString: selectedProject?.connectionString,
@@ -163,6 +165,9 @@ const SQLEditor = () => {
   const { mutate: execute, isLoading: isExecuting } = useExecuteSqlMutation({
     onSuccess(data) {
       if (id) snap.addResult(id, data.result)
+
+      // Refetching instead of invalidating since invalidate doesn't work with `enabled` flag
+      refetchEntityDefinitions()
     },
     onError(error) {
       if (id) snap.addResultError(id, error)


### PR DESCRIPTION
Currently after executing a query in the SQL editor, entity definitions (table, view, etc schema) are not refetched. The causes Supabase AI to have a stale copy of database metadata when performing AI requests.

Example flow:
1. Ask Supabase AI to create countries table with a column called "primary_language"
2. AI generates SQL, you accept, you execute, new countries table is created
3. You ask Supabase AI to group countries by language
4. Supabase is unaware of the countries table and `primary_language` column, since it has a stale version of the DB schemas

This PR fixes this by refetching entity definitions after each successful SQL execution.