### PR TITLE
chore: purge apt cache to reduce image size

### DIFF
--- a/studio/Dockerfile
+++ b/studio/Dockerfile
@@ -13,6 +13,7 @@ FROM node:18-slim as base
 # Fixes issues with Sentry CLI and SSL certificates during build
 RUN apt-get update -qq && \
     apt-get install -y ca-certificates && \
+    rm -rf /var/lib/apt/lists/* && \
     update-ca-certificates
 
 WORKDIR /app


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Somewhere between [these commits](https://github.com/supabase/supabase/compare/c876cea...528052e), our studio image size jumped by 90MB. I suspect it's due to apt cache being shipped in production image.
```
public.ecr.aws/supabase/studio                                   20230616-528052e   88c382c7e947   7 weeks ago     355MB
public.ecr.aws/supabase/studio                                   20230605-c876cea   1d334599d83c   2 months ago    265MB
```

## What is the new behavior?

Purge apt cache after updating ca certs.

## Additional context

