### PR TITLE
Remove errant line break in docs

### DIFF
--- a/apps/docs/pages/guides/auth/row-level-security.mdx
+++ b/apps/docs/pages/guides/auth/row-level-security.mdx
@@ -22,8 +22,7 @@ When you need granular authorization rules, nothing beats PostgreSQL's [Row Leve
 
 ## Policies
 
-Policies are easy to understand once you get the hang of them. Each policy is attached to a table, and the policy is executed
-every time a table is accessed.
+Policies are easy to understand once you get the hang of them. Each policy is attached to a table, and the policy is executed every time a table is accessed.
 You can just think of them as adding a `WHERE` clause to every query. For example a policy like this ...
 
 ```sql


### PR DESCRIPTION
## What kind of change does this PR introduce?

Tiny docs update - there was a mid-sentence line break.

## What is the current behavior?

N/A

## What is the new behavior?

N/A

## Additional context

N/A