### PR TITLE
fix: React warnings / alert layout downgrade modal

### DIFF
--- a/studio/components/interfaces/BillingV2/Subscription/Tier/ExitSurveyModal.tsx
+++ b/studio/components/interfaces/BillingV2/Subscription/Tier/ExitSurveyModal.tsx
@@ -118,6 +118,8 @@ const ExitSurveyModal = ({ visible, onClose }: ExitSurveyModalProps) => {
     window.scrollTo({ top: 0, left: 0, behavior: 'smooth' })
   }
 
+  if (!visible) return null
+
   return (
     <>
       <div className="self-center">

--- a/studio/components/interfaces/Organization/BillingSettingsV2/PaymentMethods/PaymentMethods.tsx
+++ b/studio/components/interfaces/Organization/BillingSettingsV2/PaymentMethods/PaymentMethods.tsx
@@ -185,10 +185,13 @@ const PaymentMethods = () => {
                                       ]}
                                     >
                                       <Button
+                                        asChild
                                         type="outline"
                                         icon={<IconMoreHorizontal />}
                                         className="hover:border-gray-500 px-1"
-                                      />
+                                      >
+                                        <span />
+                                      </Button>
                                     </Dropdown>
                                   ) : null}
                                 </div>

--- a/studio/components/interfaces/Organization/BillingSettingsV2/Subscription/DowngradeModal.tsx
+++ b/studio/components/interfaces/Organization/BillingSettingsV2/Subscription/DowngradeModal.tsx
@@ -51,16 +51,32 @@ const DowngradeModal = ({
     >
       <Modal.Content>
         <div className="py-6">
-          <Alert
-            withIcon
-            variant="warning"
-            title="Downgrading to the free plan will lead to reductions in your organization's quota"
-          >
-            <p>
-              If you're already past the limits of the free plan, your projects could become
-              unresponsive or enter read only mode.
-            </p>
-          </Alert>
+          <div className="space-y-2">
+            <Alert
+              withIcon
+              variant="warning"
+              title="Downgrading to the free plan will lead to reductions in your organization's quota"
+            >
+              <p>
+                If you're already past the limits of the free plan, your projects could become
+                unresponsive or enter read only mode.
+              </p>
+            </Alert>
+
+            {(subscription?.project_addons.length ?? 0) > 0 && (
+              <Alert
+                title={`A total of ${subscription?.project_addons.length} project(s) will be affected from the downgrade`}
+                variant="warning"
+                withIcon
+              >
+                <ul className="space-y-1 max-h-[100px] overflow-y-auto">
+                  {subscription?.project_addons.map((project) => (
+                    <ProjectDowngradeListItem key={project.ref} projectAddon={project} />
+                  ))}
+                </ul>
+              </Alert>
+            )}
+          </div>
 
           <ul className="mt-4 space-y-5 text-sm">
             <li className="flex gap-3">
@@ -77,19 +93,6 @@ const DowngradeModal = ({
                 </div>
                 <span>Add ons from all projects under this organization will be removed.</span>
               </div>
-              {(subscription?.project_addons.length ?? 0) > 0 && (
-                <Alert
-                  title={`A total of ${subscription?.project_addons.length} project(s) will be affected from the downgrade`}
-                  variant="warning"
-                  withIcon
-                >
-                  <ul className="space-y-1 max-h-[100px] overflow-y-auto">
-                    {subscription?.project_addons.map((project) => (
-                      <ProjectDowngradeListItem key={project.ref} projectAddon={project} />
-                    ))}
-                  </ul>
-                </Alert>
-              )}
             </li>
 
             <li className="flex gap-3">


### PR DESCRIPTION
Fixes two React warnings regarding invalid HTML and groups the alerts in the exit survey modal (downgrade to free with org level billing)