### PR TITLE
feat: add centralized, cached access to the access token

### DIFF
--- a/studio/data/fetchers.ts
+++ b/studio/data/fetchers.ts
@@ -1,5 +1,5 @@
 import { API_URL } from 'lib/constants'
-import { auth } from 'lib/gotrue'
+import { getAccessToken } from 'lib/gotrue'
 import { uuidv4 } from 'lib/helpers'
 import createClient from 'openapi-fetch'
 import { paths } from './api' // generated from openapi-typescript
@@ -26,17 +26,6 @@ const {
   referrerPolicy: 'no-referrer-when-downgrade',
   headers: DEFAULT_HEADERS,
 })
-
-export async function getAccessToken() {
-  // ignore if server-side
-  if (typeof window === 'undefined') return undefined
-
-  const {
-    data: { session },
-  } = await auth.getSession()
-
-  return session?.access_token
-}
 
 export async function constructHeaders(headersInit?: HeadersInit | undefined) {
   const requestId = uuidv4()

--- a/studio/lib/common/fetch/base.ts
+++ b/studio/lib/common/fetch/base.ts
@@ -1,4 +1,4 @@
-import { auth } from 'lib/gotrue'
+import { getAccessToken } from 'lib/gotrue'
 import { isUndefined } from 'lodash'
 import { SupaResponse } from 'types/base'
 import { Session } from '@supabase/gotrue-js'
@@ -85,34 +85,6 @@ export async function handleResponseError<T = unknown>(
     const error = { code: response.status, message, requestId }
     return { error } as unknown as SupaResponse<T>
   }
-}
-
-let currentSession: Session | null = null
-
-auth.onAuthStateChange((event, session) => {
-  currentSession = session
-})
-
-export async function getAccessToken() {
-  // ignore if server-side
-  if (typeof window === 'undefined') return ''
-
-  const aboutToExpire = currentSession?.expires_at
-    ? currentSession.expires_at - Math.ceil(Date.now() / 1000) < 60
-    : false
-
-  if (!currentSession || aboutToExpire) {
-    const {
-      data: { session },
-    } = await auth.getSession()
-
-    currentSession = session
-  }
-
-  // using memory version as gotrue-js can be a bit slow when using
-  // #getSession() as it has to read directly from local storage
-
-  return currentSession?.access_token
 }
 
 export async function constructHeaders(requestId: string, optionHeaders?: { [prop: string]: any }) {


### PR DESCRIPTION
Similar to #15933 except it replaces all unnecessary `getSession()` calls with a singular `getAccessToken()` call, that fetches the access token from the last observed session or by fetching a new one using `getSession()`. It also makes sure there's only one `getSession()` call even if `getAccessToken()` is called concurrently.