### PR TITLE
Fixes AI tag on www

### DIFF
--- a/apps/www/_blog/2023-08-09-supabase-studio-3-0.mdx
+++ b/apps/www/_blog/2023-08-09-supabase-studio-3-0.mdx
@@ -5,7 +5,7 @@ launchweek: 8
 tags:
   - launch-week
   - studio
-  - ai
+  - AI
 date: '2023-08-09'
 published_at: '2023-08-09T09:00:00.000-07:00'
 toc_depth: 3


### PR DESCRIPTION
Currently have two tags  for AI. Renaming this one properly.

![CleanShot 2023-08-11 at 10 10 45@2x](https://github.com/supabase/supabase/assets/105593/6667dc9a-ab3a-44ac-aa84-15483cff06ff)
