### PR TITLE
Fix dead Wrappers documentation links

### DIFF
--- a/apps/docs/data/extensions.json
+++ b/apps/docs/data/extensions.json
@@ -411,6 +411,6 @@
     "name": "wrappers",
     "comment": "Foreign data wrappers developed by Supabase",
     "tags": ["Admin", "Utility"],
-    "link": "/guides/database/extensions/wrappers"
+    "link": "/guides/database/extensions/wrappers/overview"
   }
 ]

--- a/apps/docs/public/sitemap.xml
+++ b/apps/docs/public/sitemap.xml
@@ -1525,7 +1525,7 @@
   </url>
 
   <url>
-    <loc>https://supabase.com/docs/guides/database/extensions/wrappers</loc>
+    <loc>https://supabase.com/docs/guides/database/extensions/wrappers/overview</loc>
     <changefreq>weekly</changefreq>
     <changefreq>0.5</changefreq>
   </url>

--- a/studio/components/interfaces/Database/Wrappers/Wrappers.tsx
+++ b/studio/components/interfaces/Database/Wrappers/Wrappers.tsx
@@ -49,7 +49,7 @@ const Wrappers = () => {
             </div>
           </div>
           <div className="flex items-center space-x-2">
-            <Link href="https://supabase.com/docs/guides/database/extensions/wrappers">
+            <Link href="https://supabase.com/docs/guides/database/extensions/wrappers/overview">
               <a target="_blank" rel="noreferrer">
                 <Button type="default" icon={<IconExternalLink strokeWidth={1.5} />}>
                   Documentation


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

[Wrappers documentation links link to 404'd page.](https://github.com/supabase/supabase/issues/16425)

## What is the new behavior?

Wrappers documentation links link correctly.
