### PR TITLE
Fix: Regex for destructive operation detection in SQL editor

### DIFF
--- a/studio/components/interfaces/SQLEditor/SQLEditor.constants.ts
+++ b/studio/components/interfaces/SQLEditor/SQLEditor.constants.ts
@@ -1256,4 +1256,4 @@ export const sqlAiDisclaimerComment = stripIndent`
 
 export const untitledSnippetTitle = 'Untitled query'
 
-export const destructiveSqlRegex = [/(drop|delete|truncate) /i]
+export const destructiveSqlRegex = [/(drop|delete|truncate)\s/i]

--- a/studio/components/interfaces/SQLEditor/SQLEditor.constants.ts
+++ b/studio/components/interfaces/SQLEditor/SQLEditor.constants.ts
@@ -1256,4 +1256,4 @@ export const sqlAiDisclaimerComment = stripIndent`
 
 export const untitledSnippetTitle = 'Untitled query'
 
-export const destructiveSqlRegex = [/drop/i, /delete/i, /truncate/i]
+export const destructiveSqlRegex = [/(drop|delete|truncate) /i]


### PR DESCRIPTION
Improve the regex for destructive operation detection to reduce false positives.

eg. when you perform a select on a table with a column called `deleted` or `deleted_timestamp` - this shouldn't flag the warning:
![image](https://github.com/supabase/supabase/assets/4133076/9b9f7a89-94f6-40c7-90aa-5d4fc008b9dd)
