### PR TITLE
Only show RLS warning badge if banner has been dismissed

### DIFF
--- a/studio/components/grid/components/header/RLSBannerWarning.tsx
+++ b/studio/components/grid/components/header/RLSBannerWarning.tsx
@@ -1,19 +1,19 @@
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 import { Button, IconAlertCircle, Modal } from 'ui'
 import Link from 'next/link'
 import { useStore } from 'hooks'
 import { useParams } from 'common/hooks'
 import ConfirmationModal from 'components/ui/ConfirmationModal'
 import type { PostgresTable } from '@supabase/postgres-meta'
-import { RLS_ACKNOWLEDGED_KEY } from 'components/grid/constants'
+import { rlsAcknowledgedKey } from 'components/grid/constants'
 import RLSDisableModalContent from 'components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/RLSDisableModal'
 
 export default function RLSBannerWarning() {
   const { meta } = useStore()
   const { ref: projectRef, id: tableID } = useParams()
 
-  const isAcknowledged =
-    localStorage?.getItem(`${RLS_ACKNOWLEDGED_KEY}-${tableID}`) === 'true' ?? false
+  const rlsKey = rlsAcknowledgedKey(tableID)
+  const isAcknowledged = localStorage?.getItem(rlsKey) === 'true' ?? false
 
   const [isOpen, setIsOpen] = useState(false)
 
@@ -22,10 +22,11 @@ export default function RLSBannerWarning() {
   const rlsEnabled = currentTable?.rls_enabled
   const isPublicTable = currentTable?.schema === 'public'
 
-  function handleDismissWarning() {
-    localStorage.setItem(`${RLS_ACKNOWLEDGED_KEY}-${tableID}`, 'true')
+  const handleDismissWarning = useCallback(() => {
+    new BroadcastChannel(rlsKey).postMessage({ type: 'dismiss' })
+    localStorage.setItem(rlsKey, 'true')
     setIsOpen(false)
-  }
+  }, [rlsKey])
 
   return (
     <>

--- a/studio/components/grid/constants.ts
+++ b/studio/components/grid/constants.ts
@@ -17,3 +17,5 @@ export const ERROR_PRIMARY_KEY_NOTFOUND =
   'Please add a primary key column to your table to update or delete rows'
 
 export const RLS_ACKNOWLEDGED_KEY = 'supabase-acknowledge-rls-warning'
+
+export const rlsAcknowledgedKey = (tableID?: string) => `${RLS_ACKNOWLEDGED_KEY}-${tableID}`


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

User is bombarded by RLS warnings in the form of both a banner and badge, when only one at a given time is sufficient.

## What is the new behavior?

Addresses #14130 by firing an event when the RLS warning banner is dismissed, which triggers the RLS warning badge to be visible. This works across browser tabs and without a page refresh by using the `BroadcastChannel` API.

### Demo

https://www.loom.com/share/4adc2461b081450ab69ad0ae82b2f24a

## Additional context

Add any other context or screenshots.
