### PR TITLE
fix: table content overflow

### DIFF
--- a/studio/components/interfaces/Database/Functions/FunctionsList/FunctionList.tsx
+++ b/studio/components/interfaces/Database/Functions/FunctionsList/FunctionList.tsx
@@ -50,7 +50,7 @@ const FunctionList = ({
     <>
       {_functions.map((x) => (
         <Table.tr key={x.id}>
-          <Table.td>
+          <Table.td className="break-words">
             <p>{x.name}</p>
           </Table.td>
           <Table.td className="hidden md:table-cell md:overflow-auto">


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix. Closes #16454 

## What is the current behavior?

Long function names overflow into other table cells.

## What is the new behavior?

Long function names are broken and wrap onto the next line. [See here](https://i.gyazo.com/6cedc0cf99626212dd2d34994acb095f.png).

