### PR TITLE
chore: redirect project pausing button

### DIFF
--- a/studio/components/layouts/ProjectLayout/ProjectPausedState.tsx
+++ b/studio/components/layouts/ProjectLayout/ProjectPausedState.tsx
@@ -13,6 +13,7 @@ import { post } from 'lib/common/fetch'
 import { API_URL, PROJECT_STATUS } from 'lib/constants'
 import { Button, IconPauseCircle, Modal } from 'ui'
 import { useProjectContext } from './ProjectContext'
+import { useProjectSubscriptionV2Query } from 'data/subscriptions/project-subscription-v2-query'
 
 export interface ProjectPausedStateProps {
   product?: string
@@ -25,6 +26,8 @@ const ProjectPausedState = ({ product }: ProjectPausedStateProps) => {
   const selectedOrganization = useSelectedOrganization()
   const { project } = useProjectContext()
   const orgSlug = selectedOrganization?.slug
+  const { data: subscription } = useProjectSubscriptionV2Query({ projectRef: ref })
+  const isFreePlan = subscription?.plan.id === 'free'
 
   const { data: membersExceededLimit } = useFreeProjectLimitCheckQuery({ slug: orgSlug })
   const hasMembersExceedingFreeTierLimit = (membersExceededLimit || []).length > 0
@@ -96,6 +99,11 @@ const ProjectPausedState = ({ product }: ProjectPausedStateProps) => {
                     'Restore this project and get back to building the next big thing!'
                   )}
                 </p>
+                {isFreePlan && (
+                  <p className="text-sm text-scale-1100 text-center">
+                    You can also prevent project pausing in the future by upgrading to Pro.
+                  </p>
+                )}
               </div>
 
               <div className="flex items-center justify-center gap-4">
@@ -128,11 +136,21 @@ const ProjectPausedState = ({ product }: ProjectPausedStateProps) => {
                     </Tooltip.Portal>
                   )}
                 </Tooltip.Root>
-                <Link href={`/project/${ref}/settings/general`}>
-                  <a>
-                    <Button type="default">View project settings</Button>
-                  </a>
-                </Link>
+                {isFreePlan ? (
+                  <Link
+                    href={`/project/${ref}/settings/billing/subscription?panel=subscriptionPlan`}
+                  >
+                    <a>
+                      <Button type="default">Change Plan</Button>
+                    </a>
+                  </Link>
+                ) : (
+                  <Link href={`/project/${ref}/settings/general`}>
+                    <a>
+                      <Button type="default">View project settings</Button>
+                    </a>
+                  </Link>
+                )}
               </div>
             </div>
           </div>

--- a/studio/components/layouts/ProjectLayout/ProjectPausedState.tsx
+++ b/studio/components/layouts/ProjectLayout/ProjectPausedState.tsx
@@ -27,7 +27,7 @@ const ProjectPausedState = ({ product }: ProjectPausedStateProps) => {
   const { project } = useProjectContext()
   const orgSlug = selectedOrganization?.slug
   const { data: subscription } = useProjectSubscriptionV2Query({ projectRef: ref })
-  const isFreePlan = subscription?.plan.id === 'free'
+  const isFreePlan = subscription?.plan?.id === 'free'
 
   const { data: membersExceededLimit } = useFreeProjectLimitCheckQuery({ slug: orgSlug })
   const hasMembersExceedingFreeTierLimit = (membersExceededLimit || []).length > 0

--- a/studio/components/layouts/ProjectLayout/ProjectPausedState.tsx
+++ b/studio/components/layouts/ProjectLayout/ProjectPausedState.tsx
@@ -28,6 +28,7 @@ const ProjectPausedState = ({ product }: ProjectPausedStateProps) => {
   const orgSlug = selectedOrganization?.slug
   const { data: subscription } = useProjectSubscriptionV2Query({ projectRef: ref })
   const isFreePlan = subscription?.plan?.id === 'free'
+  const billedViaOrg = Boolean(selectedOrganization?.subscription_id)
 
   const { data: membersExceededLimit } = useFreeProjectLimitCheckQuery({ slug: orgSlug })
   const hasMembersExceedingFreeTierLimit = (membersExceededLimit || []).length > 0
@@ -138,10 +139,14 @@ const ProjectPausedState = ({ product }: ProjectPausedStateProps) => {
                 </Tooltip.Root>
                 {isFreePlan ? (
                   <Link
-                    href={`/project/${ref}/settings/billing/subscription?panel=subscriptionPlan`}
+                    href={
+                      billedViaOrg
+                        ? `/org/${orgSlug}/billing?panel=subscriptionPlan`
+                        : `/project/${ref}/settings/billing/subscription?panel=subscriptionPlan`
+                    }
                   >
                     <a>
-                      <Button type="default">Change Plan</Button>
+                      <Button type="default">Upgrade to Pro</Button>
                     </a>
                   </Link>
                 ) : (


### PR DESCRIPTION
## What kind of change does this PR introduce?

Explain to free plan users that they can avoid project pausing by upgrading to pro at the project paused page. Pro plan users button remains the same. 

<img width="1390" alt="Screenshot 2023-08-12 at 2 53 14 PM" src="https://github.com/supabase/supabase/assets/26612111/3b7c91e9-c51a-4b4f-9c9c-3ecbb3f9dcb4">
