### PR TITLE
Fix: Documentation link for Google auth provider fix

### DIFF
--- a/studio/stores/authConfig/schema/AuthProviders/AuthProvidersFormValidation.tsx
+++ b/studio/stores/authConfig/schema/AuthProviders/AuthProvidersFormValidation.tsx
@@ -884,7 +884,7 @@ const EXTERNAL_PROVIDER_GOOGLE = {
     iconKey: 'google-icon',
     requiresRedirect: true,
     helper: `Register this callback URL when using Sign-in with Google on the web using OAuth.
-            [Learn more](https://supabase.com/docs/guides/auth/social-login/auth-apple#configure-your-services-id)`,
+            [Learn more](https://supabase.com/docs/guides/auth/social-login/auth-google#configure-your-services-id)`,
   },
 }
 


### PR DESCRIPTION
What kind of change does this PR introduce?
Fixes #16437 

What is the current behavior?
Google learn more link points towards Apple documentation

What is the new behavior?
Google learn more link points towards Google documentation

Additional context
Add any other context or screenshots.

Let me know if there is anything else I can do to improve this PR :) Thanks