### PR TITLE
fix: made the sql editor resizable

### DIFF
--- a/studio/components/interfaces/Database/Functions/CreateFunction.tsx
+++ b/studio/components/interfaces/Database/Functions/CreateFunction.tsx
@@ -733,7 +733,7 @@ const InputDefinition = observer(({}) => {
           </p>
         )}
       </div>
-      <div className="h-40 border dark:border-dark">
+      <div className="h-60 resize-y border dark:border-dark">
         <SqlEditor
           defaultValue={_localState!.formState.definition.value}
           onInputChange={(value: string | undefined) => {


### PR DESCRIPTION
issue #16444

## What kind of change does this PR introduce?
Increase the initial sql editor size and made it resizeable in y direction.
