### PR TITLE
fix: function name overflow

### DIFF
--- a/studio/components/interfaces/Database/Functions/FunctionsList/FunctionList.tsx
+++ b/studio/components/interfaces/Database/Functions/FunctionsList/FunctionList.tsx
@@ -50,7 +50,7 @@ const FunctionList = ({
     <>
       {_functions.map((x) => (
         <Table.tr key={x.id}>
-          <Table.td>
+          <Table.td className="truncate">
             <p>{x.name}</p>
           </Table.td>
           <Table.td className="hidden md:table-cell md:overflow-auto">

--- a/studio/components/ui/Modals/TextConfirmModal.tsx
+++ b/studio/components/ui/Modals/TextConfirmModal.tsx
@@ -68,7 +68,7 @@ const TextConfirmModal = ({
               )}
               {text !== undefined && (
                 <Modal.Content>
-                  <p className="mb-2 block text-sm">{text}</p>
+                  <p className="mb-2 block text-sm break-all">{text}</p>
                 </Modal.Content>
               )}
               <Modal.Separator />
@@ -77,7 +77,7 @@ const TextConfirmModal = ({
                   id="confirmValue"
                   label={
                     <span>
-                      Type <span className="text-scale-1200">{confirmString}</span> to confirm.
+                      Type <span className="text-scale-1200 break-all">{confirmString}</span> to confirm.
                     </span>
                   }
                   placeholder={confirmPlaceholder}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

- Added truncate class in FunctionList function name table cell
- Added break-all to Modal.Content


## What is the current behavior?

Function name too long, overlapping neighboring cell.
Long function name in delete function confirmation Modal overflowing the modal.

Issue #16454

## What is the new behavior?

Truncating the long function name in table cell.
Adding word break for long function name in Delete function Modal
