### PR TITLE
issue-16454 _Long function names overlap in list issue fixed

### DIFF
--- a/studio/components/interfaces/Database/Functions/FunctionsList/FunctionList.tsx
+++ b/studio/components/interfaces/Database/Functions/FunctionsList/FunctionList.tsx
@@ -50,7 +50,7 @@ const FunctionList = ({
     <>
       {_functions.map((x) => (
         <Table.tr key={x.id}>
-          <Table.td>
+          <Table.td className='w-28 overflow-x-scroll'>
             <p>{x.name}</p>
           </Table.td>
           <Table.td className="hidden md:table-cell md:overflow-auto">


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix ...

## What is the current behavior?
Function name too long, overlapping neighboring cell.
Long function name in delete function confirmation Modal overflowing the modal.

Issue https://github.com/supabase/supabase/issues/16454

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.
Adding word break for long function name in Delete function Modal
