### PR TITLE
Add docs for email template in local supabase

### DIFF
--- a/apps/docs/components/CustomHTMLElements/Heading.tsx
+++ b/apps/docs/components/CustomHTMLElements/Heading.tsx
@@ -26,7 +26,7 @@ interface Props {
  *
  * In tsx files, we can generate this tocList directly. For these files, we don't
  * need to parse the <a> and generate anchors. Custom anchors are used in tsx files.
- * (see: /pages/reference/cli/config.tsx)
+ * (see: /pages/guides/cli/config.tsx)
  */
 const Heading: React.FC<Props> = ({ tag, customAnchor, children }) => {
   const HeadingTag = `${tag}` as any

--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
@@ -1037,6 +1037,10 @@ export const supabase_cli: NavMenuConstant = {
           name: 'Testing and linting',
           url: '/guides/cli/testing-and-linting',
         },
+        {
+          name: 'Customizing email templates',
+          url: '/guides/cli/customizing-email-templates',
+        },
       ],
     },
     {

--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.tsx
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.tsx
@@ -95,7 +95,7 @@ const menus: Menu[] = [
   },
   {
     id: 'supabase_cli',
-    // TODO: Add path '/reference/cli/config'
+    // TODO: Add path '/guides/cli/config'
     path: '/guides/cli',
     type: 'guide',
   },

--- a/apps/docs/data/nav/supabase-cli.ts
+++ b/apps/docs/data/nav/supabase-cli.ts
@@ -4,7 +4,7 @@ const Nav = [
     items: [
       { name: 'Supabase CLI', url: '/reference/cli', items: [] },
       { name: 'Usage', url: '/reference/cli/usage', items: [] },
-      { name: 'Configuration', url: '/reference/cli/config', items: [] },
+      { name: 'Configuration', url: '/guides/cli/config', items: [] },
       { name: 'Release Notes', url: '/reference/cli/release-notes', items: [] },
     ],
   },

--- a/apps/docs/pages/guides/cli/customizing-email-templates.mdx
+++ b/apps/docs/pages/guides/cli/customizing-email-templates.mdx
@@ -32,16 +32,16 @@ These settings are only for local development, if you want to use the same conte
 
 ### Email template variables
 
-The following template variables are available inside of your email template.
+The templating system provides the following variables for use:
 
-```
-{{ .ConfirmationURL }} : URL to confirm the email change
-{{ .Token }} : The 6-digit numeric email OTP
-{{ .TokenHash }} : The hashed token used in the URL
-{{ .SiteURL }} : The URL of the site
-{{ .Email }} : The original users email address
-{{ .NewEmail }} : The users new email address
-```
+| Name                     | Description                                                                                                                                                                                                       |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `{{ .ConfirmationURL }}` | Contains the confirmation URL. For example, a signup confirmation URL would look like: `https://project-ref.supabase.co/auth/v1/verify?token={{ .TokenHash }}&type=signup&redirect_to=https://example.com/path` . |
+| `{{ .Token }}`           | Contains a 6-digit One-Time-Password (OTP) that can be used instead of the `{{. ConfirmationURL }}` .                                                                                                             |
+| `{{ .TokenHash }}`       | Contains a hashed version of the `{{ .Token }}`. This is useful for constructing your own email link in the email template.                                                                                       |
+| `{{ .SiteURL }}`         | Contains your application's Site URL. This can be configured in your project's [authentication settings](https://supabase.com/dashboard/project/_/auth/url-configuration).                                        |
+| `{{ .Email }}`           | Contains the user's email address.                                                                                                                                                                                |
+| `{{ .NewEmail }}`        | Contains the new user's email address.                                                                                                                                                                            |
 
 <Admonition type="note">
 

--- a/apps/docs/pages/guides/cli/customizing-email-templates.mdx
+++ b/apps/docs/pages/guides/cli/customizing-email-templates.mdx
@@ -24,7 +24,30 @@ content_path = "./supabase/auth/email/invite.html"
 
 The `content_path` should contain the html file you are pointing to otherwise the CLI won't start the project.
 
-> Note: These settings are only for local development, if you want to use the same content for your hosted Supabase you will need to copy and paste these into the Supabase Dashboard
+<Admonition type="note">
+
+These settings are only for local development, if you want to use the same content for your hosted Supabase instance you will need to copy and paste these into the Supabase Dashboard
+
+</Admonition>
+
+### Email template variables
+
+The following template variables are available inside of your email template.
+
+```
+{{ .ConfirmationURL }} : URL to confirm the email change
+{{ .Token }} : The 6-digit numeric email OTP
+{{ .TokenHash }} : The hashed token used in the URL
+{{ .SiteURL }} : The URL of the site
+{{ .Email }} : The original users email address
+{{ .NewEmail }} : The users new email address
+```
+
+<Admonition type="note">
+
+`{{ .NewEmail }}` is only available in the email_change email template
+
+</Admonition>
 
 export const Page = ({ children }) => <Layout meta={meta} children={children} />
 

--- a/apps/docs/pages/guides/cli/customizing-email-templates.mdx
+++ b/apps/docs/pages/guides/cli/customizing-email-templates.mdx
@@ -1,0 +1,31 @@
+import Layout from '~/layouts/DefaultGuideLayout'
+
+export const meta = {
+  id: 'customizing-email-templates',
+  title: 'Customizing email teplates',
+  description: 'Customizing local email templates using config.toml.',
+}
+
+The Supabase CLI uses a `config.toml` file to manage local configuration. This file is located in the `supabase` directory of your project.
+
+## Config reference
+
+The `config.toml` file is automatically created when you run `supabase start`.
+
+There are a wide variety of options available, which can be found in the [CLI Config Reference](/docs/reference/cli/config).
+
+For example, to update the "Invite" email subject and content for local development, you can append the following information to `config.toml`:
+
+```toml
+[auth.email.template.invite]
+subject = "You are invited to Acme Inc"
+content_path = "./supabase/auth/email/invite.html"
+```
+
+The `content_path` should contain the html file you are pointing to otherwise the CLI won't start the project.
+
+> Note: These settings are only for local development, if you want to use the same content for your hosted Supabase you will need to copy and paste these into the Supabase Dashboard
+
+export const Page = ({ children }) => <Layout meta={meta} children={children} />
+
+export default Page

--- a/apps/docs/pages/guides/cli/customizing-email-templates.mdx
+++ b/apps/docs/pages/guides/cli/customizing-email-templates.mdx
@@ -2,7 +2,7 @@ import Layout from '~/layouts/DefaultGuideLayout'
 
 export const meta = {
   id: 'customizing-email-templates',
-  title: 'Customizing email teplates',
+  title: 'Customizing email templates',
   description: 'Customizing local email templates using config.toml.',
 }
 

--- a/apps/docs/pages/guides/cli/customizing-email-templates.mdx
+++ b/apps/docs/pages/guides/cli/customizing-email-templates.mdx
@@ -79,7 +79,9 @@ Contains a hashed version of the `Token`. This is useful for constructing your o
 ```html
 <p>Follow this link to confirm your user:</p>
 <p>
-  <a href="{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=email">Confirm your mail</a>
+  <a href="{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=email"
+    >Confirm your email</a
+  >
 </p>
 ```
 

--- a/apps/docs/pages/guides/cli/customizing-email-templates.mdx
+++ b/apps/docs/pages/guides/cli/customizing-email-templates.mdx
@@ -25,7 +25,7 @@ content_path = "./supabase/templates/invite.html"
 <html>
   <body>
     <h2>Confirm your signup</h2>
-    <p><a href="{{ .ConfirmationURL }}">Confirm your mail</a></p>
+    <p><a href="{{ .ConfirmationURL }}">Confirm your email</a></p>
   </body>
 </html>
 ```

--- a/apps/docs/pages/guides/cli/customizing-email-templates.mdx
+++ b/apps/docs/pages/guides/cli/customizing-email-templates.mdx
@@ -7,40 +7,108 @@ export const meta = {
   subtitle: 'Customizing local email templates using config.toml.',
 }
 
-You can customize the email templates for local development [using the `config.toml` settings](/docs/guides/cli/managing-config).
+You can customize the email templates for local development [using the `config.toml` settings](/docs/guides/cli/config#auth-config).
 
-## Auth Templates 
+## Configuring Templates
 
-There are several Auth templates which can be configured, detailed in the [CLI Config Reference](/docs/guides/cli/config#auth-config).
+You should provide a relative URL to the `content_path` parameter, pointing to an HTML file which contains the template. For example
 
-For example, to update the "Invite" email subject and content for local development, you can append the following information to `config.toml`:
+<CH.Code>
 
-```toml
+```toml supabase/config.toml
 [auth.email.template.invite]
 subject = "You are invited to Acme Inc"
-content_path = "./supabase/auth/email/invite.html"
+content_path = "./supabase/templates/invite.html"
 ```
 
-The `content_path` should contain the html file you are pointing to otherwise the CLI won't start the project.
+```html supabase/templates/invite.html
+<html>
+  <body>
+    <h2>Confirm your signup</h2>
+    <p><a href="{{ .ConfirmationURL }}">Confirm your mail</a></p>
+  </body>
+</html>
+```
 
-### Email template variables
+</CH.Code>
+
+## Available email templates
+
+There are several Auth email templates which can be configured:
+
+- `auth.email.template.invite`
+- `auth.email.template.confirmation`
+- `auth.email.template.recovery`
+- `auth.email.template.magic_link`
+- `auth.email.template.email_change`
+
+## Template variables
 
 The templating system provides the following variables for use:
 
-| Name                     | Description                                                                                                                                                                                                       |
-| ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `{{ .ConfirmationURL }}` | Contains the confirmation URL. For example, a signup confirmation URL would look like: `https://project-ref.supabase.co/auth/v1/verify?token={{ .TokenHash }}&type=signup&redirect_to=https://example.com/path` . |
-| `{{ .Token }}`           | Contains a 6-digit One-Time-Password (OTP) that can be used instead of the `{{. ConfirmationURL }}` .                                                                                                             |
-| `{{ .TokenHash }}`       | Contains a hashed version of the `{{ .Token }}`. This is useful for constructing your own email link in the email template.                                                                                       |
-| `{{ .SiteURL }}`         | Contains your application's Site URL. This can be configured in your project's [authentication settings](https://supabase.com/dashboard/project/_/auth/url-configuration).                                        |
-| `{{ .Email }}`           | Contains the user's email address.                                                                                                                                                                                |
-| `{{ .NewEmail }}`        | Contains the new user's email address.                                                                                                                                                                            |
+### ConfirmationURL
 
-<Admonition type="note">
+Contains the confirmation URL. For example, a signup confirmation URL would look like:
 
-`{{ .NewEmail }}` is only available in the email_change email template
+```
+https://project-ref.supabase.co/auth/v1/verify?token={{ .TokenHash }}&type=signup&redirect_to=https://example.com/path
+```
 
-</Admonition>
+**Usage**
+
+```html
+<p>Click here to confirm: {{ .ConfirmationURL }}</p>
+```
+
+### Token
+
+Contains a 6-digit One-Time-Password (OTP) that can be used instead of the `ConfirmationURL`.
+
+**Usage**
+
+```html
+<p>Here is your one time password: {{ .Token }}</p>
+```
+
+### TokenHash
+
+Contains a hashed version of the `Token`. This is useful for constructing your own email link in the email template.
+
+**Usage**
+
+```html
+<p>Click <a href="{{ .TokenHash }}">here</a> to confirm your login.</p>
+```
+
+### SiteURL
+
+Contains your application's Site URL. This can be configured in your project's [authentication settings](/dashboard/project/_/auth/url-configuration).
+
+**Usage**
+
+```html
+<p>Visit <a href="{{ .SiteURL }}">here</a> to log in.</p>
+```
+
+### Email
+
+Contains the user's email address.
+
+**Usage**
+
+```html
+<p>A recovery request was sent to {{ .Email }}.</p>
+```
+
+### NewEmail
+
+Contains the new user's email address. This is only available in the `email_change` email template.
+
+**Usage**
+
+```html
+<p>You are requesting to update your email address to {{ .NewEmail }}.</p>
+```
 
 ## Deploying email templates
 

--- a/apps/docs/pages/guides/cli/customizing-email-templates.mdx
+++ b/apps/docs/pages/guides/cli/customizing-email-templates.mdx
@@ -4,15 +4,14 @@ export const meta = {
   id: 'customizing-email-templates',
   title: 'Customizing email templates',
   description: 'Customizing local email templates using config.toml.',
+  subtitle: 'Customizing local email templates using config.toml.',
 }
 
-The Supabase CLI uses a `config.toml` file to manage local configuration. This file is located in the `supabase` directory of your project.
+You can customize the email templates for local development [using the `config.toml` settings](/docs/guides/cli/managing-config).
 
-## Config reference
+## Auth Templates 
 
-The `config.toml` file is automatically created when you run `supabase start`.
-
-There are a wide variety of options available, which can be found in the [CLI Config Reference](/docs/reference/cli/config).
+There are several Auth templates which can be configured, detailed in the [CLI Config Reference](/docs/guides/cli/config#auth-config).
 
 For example, to update the "Invite" email subject and content for local development, you can append the following information to `config.toml`:
 
@@ -23,12 +22,6 @@ content_path = "./supabase/auth/email/invite.html"
 ```
 
 The `content_path` should contain the html file you are pointing to otherwise the CLI won't start the project.
-
-<Admonition type="note">
-
-These settings are only for local development, if you want to use the same content for your hosted Supabase instance you will need to copy and paste these into the Supabase Dashboard
-
-</Admonition>
 
 ### Email template variables
 
@@ -48,6 +41,10 @@ The templating system provides the following variables for use:
 `{{ .NewEmail }}` is only available in the email_change email template
 
 </Admonition>
+
+## Deploying email templates
+
+These settings are only for local development. To update your hosted project, please copy the templates into the [Email Templates](/dashboard/project/_/auth/templates) section of the Dashboard.
 
 export const Page = ({ children }) => <Layout meta={meta} children={children} />
 

--- a/apps/docs/pages/guides/cli/customizing-email-templates.mdx
+++ b/apps/docs/pages/guides/cli/customizing-email-templates.mdx
@@ -77,7 +77,10 @@ Contains a hashed version of the `Token`. This is useful for constructing your o
 **Usage**
 
 ```html
-<p>Click <a href="{{ .TokenHash }}">here</a> to confirm your login.</p>
+<p>Follow this link to confirm your user:</p>
+<p>
+  <a href="{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=email">Confirm your mail</a>
+</p>
 ```
 
 ### SiteURL

--- a/apps/docs/pages/guides/cli/managing-config.mdx
+++ b/apps/docs/pages/guides/cli/managing-config.mdx
@@ -12,7 +12,7 @@ The Supabase CLI uses a `config.toml` file to manage local configuration. This f
 
 The `config.toml` file is automatically created when you run `supabase start`.
 
-There are a wide variety of options available, which can be found in the [CLI Config Reference](/docs/reference/cli/config).
+There are a wide variety of options available, which can be found in the [CLI Config Reference](/docs/guides/cli/config).
 
 For example, to enable the "Apple" OAuth provider for local development, you can append the following information to `config.toml`:
 

--- a/apps/docs/pages/guides/functions/cicd-workflow.mdx
+++ b/apps/docs/pages/guides/functions/cicd-workflow.mdx
@@ -38,7 +38,7 @@ jobs:
 
 Since Supabase CLI [v1.62.0](https://github.com/supabase/cli/releases/tag/v1.62.0) you can deploy all functions with a single command.
 
-Individual function configuration like [JWT verification](/docs/reference/cli/config#functions.function_name.verify_jwt) and [import map location](/docs/reference/cli/config#functions.function_name.import_map) can be set via the `config.toml` file.
+Individual function configuration like [JWT verification](/docs/guides/cli/config#functions.function_name.verify_jwt) and [import map location](/docs/guides/cli/config#functions.function_name.import_map) can be set via the `config.toml` file.
 
 ```toml
 [functions.hello-world]

--- a/apps/docs/pages/guides/functions/examples/github-actions.mdx
+++ b/apps/docs/pages/guides/functions/examples/github-actions.mdx
@@ -47,7 +47,7 @@ jobs:
 
 Since Supabase CLI [v1.62.0](https://github.com/supabase/cli/releases/tag/v1.62.0) you can deploy all functions with a single command.
 
-Individual function configuration like [JWT verification](/docs/reference/cli/config#functions.function_name.verify_jwt) and [import map location](/docs/reference/cli/config#functions.function_name.import_map) can be set via the `config.toml` file.
+Individual function configuration like [JWT verification](/docs/guides/cli/config#functions.function_name.verify_jwt) and [import map location](/docs/guides/cli/config#functions.function_name.import_map) can be set via the `config.toml` file.
 
 ```toml
 [functions.hello-world]

--- a/apps/docs/pages/guides/functions/quickstart.mdx
+++ b/apps/docs/pages/guides/functions/quickstart.mdx
@@ -66,7 +66,7 @@ supabase functions deploy
 
 Since Supabase CLI [v1.62.0](https://github.com/supabase/cli/releases/tag/v1.62.0) you can deploy all functions with a single command. This is useful for example when [deploying with GitHub Actions](/docs/guides/functions/cicd-workflow).
 
-Individual function configuration like [JWT verification](/docs/reference/cli/config#functions.function_name.verify_jwt) and [import map location](/docs/reference/cli/config#functions.function_name.import_map) can be set via the `config.toml` file.
+Individual function configuration like [JWT verification](/docs/guides/cli/config#functions.function_name.verify_jwt) and [import map location](/docs/guides/cli/config#functions.function_name.import_map) can be set via the `config.toml` file.
 
 ```toml
 [functions.hello-world]

--- a/spec/cli_v1_config.yaml
+++ b/spec/cli_v1_config.yaml
@@ -260,6 +260,38 @@ parameters:
     links:
       - name: 'Auth Server configuration'
         link: 'https://supabase.com/docs/reference/auth'
+  
+  - id: 'auth.email.template.type.subject'
+    title: 'auth.email.template.<type>.subject'
+    tags: ['auth']
+    required: false
+    description: |
+      The full list of email template types are:
+
+      - `invite`
+      - `confirmation`
+      - `recovery`
+      - `magic_link`
+      - `email_change`
+    links:
+      - name: 'Auth Server configuration'
+        link: 'https://supabase.com/docs/reference/auth'
+  
+  - id: 'auth.email.template.type.content_path'
+    title: 'auth.email.template.<type>.content_path'
+    tags: ['auth']
+    required: false
+    description: |
+      The full list of email template types are:
+
+      - `invite`
+      - `confirmation`
+      - `recovery`
+      - `magic_link`
+      - `email_change`
+    links:
+      - name: 'Auth Server configuration'
+        link: 'https://supabase.com/docs/reference/auth'
 
   - id: 'auth.external.provider.enabled'
     title: 'auth.external.<provider>.enabled'


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

There is currently no documentation for the CLI email template setup

## What is the new behavior?

There is now documentation for the CLI email template setup

## Additional context

Add any other context or screenshots.
