### PR TITLE
bug fix: text overflow in sql editor sidebar

### DIFF
--- a/studio/components/layouts/SQLEditorLayout/QueryItem.tsx
+++ b/studio/components/layouts/SQLEditorLayout/QueryItem.tsx
@@ -67,7 +67,7 @@ const QueryItem = ({ tabInfo }: QueryItemProps) => {
         <a className="py-1 px-3 w-full overflow-hidden">
           <p
             title={description || name}
-            className="text-sm text-scale-1100 group-hover:text-scale-1200 transition overflow-hidden overflow-hidden text-ellipsis"
+            className="text-sm text-scale-1100 group-hover:text-scale-1200 transition overflow-hidden text-ellipsis"
           >
             {name}
           </p>

--- a/studio/components/layouts/SQLEditorLayout/QueryItem.tsx
+++ b/studio/components/layouts/SQLEditorLayout/QueryItem.tsx
@@ -67,7 +67,7 @@ const QueryItem = ({ tabInfo }: QueryItemProps) => {
         <a className="py-1 px-3 w-full overflow-hidden">
           <p
             title={description || name}
-            className="text-sm text-scale-1100 group-hover:text-scale-1200 transition overflow-hidden overflow-hidden truncate"
+            className="text-sm text-scale-1100 group-hover:text-scale-1200 transition overflow-hidden overflow-hidden text-ellipsis"
           >
             {name}
           </p>

--- a/studio/components/layouts/SQLEditorLayout/QueryItem.tsx
+++ b/studio/components/layouts/SQLEditorLayout/QueryItem.tsx
@@ -64,10 +64,10 @@ const QueryItem = ({ tabInfo }: QueryItemProps) => {
       ref={isActive ? (activeItemRef as React.RefObject<HTMLDivElement>) : null}
     >
       <Link href={`/project/${ref}/sql/${id}`}>
-        <a className="py-1 px-3 w-full">
+        <a className="py-1 px-3 w-full overflow-hidden">
           <p
             title={description || name}
-            className="text-sm text-scale-1100 group-hover:text-scale-1200 transition"
+            className="text-sm text-scale-1100 group-hover:text-scale-1200 transition overflow-hidden overflow-hidden truncate"
           >
             {name}
           </p>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixies: #15819 

## What is the current behavior?

<img width="489" alt="Screenshot 2023-08-14 at 4 45 15 PM" src="https://github.com/supabase/supabase/assets/71591136/f6927b80-9335-4dff-ba26-15aacd3409f8">

## What is the new behavior?

<img width="465" alt="Screenshot 2023-08-14 at 4 46 38 PM" src="https://github.com/supabase/supabase/assets/71591136/dfeeddd6-68c1-40cb-b184-10641ac29545">

## Additional context

Text with no gaps is blocking the dropdown trigger.
To fix that I have added overflow hidden with text ellipsis.
