### PR TITLE
feat: allow manual sorting cols on update table modal 

### DIFF
--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/Column.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/Column.tsx
@@ -42,7 +42,6 @@ import { ColumnField } from '../SidePanelEditor.types'
 interface ColumnProps {
   column: ColumnField
   enumTypes: PostgresType[]
-  isNewRecord: boolean
   hasImportContent: boolean
   dragHandleProps?: any
   onEditRelation: (column: any) => void
@@ -53,7 +52,6 @@ interface ColumnProps {
 const Column = ({
   column = {} as ColumnField,
   enumTypes = [] as PostgresType[],
-  isNewRecord = false,
   hasImportContent = false,
   dragHandleProps = {},
   onEditRelation = noop,
@@ -71,7 +69,7 @@ const Column = ({
 
   return (
     <div className="flex w-full items-center">
-      <div className={`w-[5%] ${!isNewRecord ? 'hidden' : ''}`}>
+      <div className="w-[5%]">
         <div className="cursor-drag" {...dragHandleProps}>
           <IconMenu strokeWidth={1} size={15} />
         </div>
@@ -156,7 +154,7 @@ const Column = ({
           />
         </div>
       </div>
-      <div className={`${isNewRecord ? 'w-[25%]' : 'w-[30%]'}`}>
+      <div className="w-[25%]">
         <div className="w-[95%]">
           <InputWithSuggestions
             placeholder={

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/ColumnManagement.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/ColumnManagement.tsx
@@ -118,7 +118,7 @@ const ColumnManagement = ({
     if (!result.destination) {
       return
     }
-
+    
     if (type === 'pks') {
       const updatedPrimaryKeyColumns = primaryKeyColumns.slice()
       const [removed] = updatedPrimaryKeyColumns.splice(result.source.index, 1)
@@ -190,7 +190,7 @@ const ColumnManagement = ({
           {/* Headers */}
           <div className="flex w-full px-3">
             {/* Drag handle */}
-            {isNewRecord && <div className="w-[5%]" />}
+            <div className="w-[5%]" />
             <div className="w-[25%] flex items-center space-x-2">
               <h5 className="text-xs text-scale-900">Name</h5>
               <Tooltip.Root delayDuration={0}>
@@ -220,7 +220,7 @@ const ColumnManagement = ({
             <div className="w-[25%]">
               <h5 className="text-xs text-scale-900">Type</h5>
             </div>
-            <div className={`${isNewRecord ? 'w-[25%]' : 'w-[30%]'} flex items-center space-x-2`}>
+            <div className="w-[25%] flex items-center space-x-2">
               <h5 className="text-xs text-scale-900">Default Value</h5>
 
               <Tooltip.Root delayDuration={0}>
@@ -264,9 +264,7 @@ const ColumnManagement = ({
                 {(droppableProvided: DroppableProvided) => (
                   <div
                     ref={droppableProvided.innerRef}
-                    className={`space-y-2 rounded-md bg-gray-400 px-3 py-2 ${
-                      isNewRecord ? '' : '-mx-3'
-                    }`}
+                    className="space-y-2 rounded-md bg-gray-400 px-3 py-2"
                   >
                     {primaryKeyColumns.map((column: ColumnField, index: number) => (
                       <Draggable key={column.id} draggableId={column.id} index={index}>
@@ -278,7 +276,6 @@ const ColumnManagement = ({
                             <Column
                               column={column}
                               enumTypes={enumTypes}
-                              isNewRecord={isNewRecord}
                               hasImportContent={hasImportContent}
                               dragHandleProps={draggableProvided.dragHandleProps}
                               onEditRelation={() => {
@@ -303,7 +300,7 @@ const ColumnManagement = ({
               {(droppableProvided: DroppableProvided) => (
                 <div
                   ref={droppableProvided.innerRef}
-                  className={`space-y-2 py-2 ${isNewRecord ? 'px-3 ' : ''}`}
+                  className="space-y-2 py-2 px-3"
                 >
                   {otherColumns.map((column: ColumnField, index: number) => (
                     <Draggable key={column.id} draggableId={column.id} index={index}>
@@ -312,7 +309,6 @@ const ColumnManagement = ({
                           <Column
                             column={column}
                             enumTypes={enumTypes}
-                            isNewRecord={isNewRecord}
                             hasImportContent={hasImportContent}
                             dragHandleProps={draggableProvided.dragHandleProps}
                             onEditRelation={() => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

fixes: #16509 
this will allow manual sorting columns on the update table modal 

## What is the current behavior?

<img width="693" alt="Screenshot 2023-08-14 at 8 58 25 PM" src="https://github.com/supabase/supabase/assets/71591136/8492d92b-3bc2-407d-a54a-4529d03f658d">

## What is the new behavior?



## Additional context

Showing drag handles, originally hidden for new table
