### PR TITLE
feat: use v2 suffix for sign-in clicks counter

### DIFF
--- a/studio/lib/local-storage.ts
+++ b/studio/lib/local-storage.ts
@@ -4,7 +4,7 @@ export const LOCAL_STORAGE_KEYS_ALLOWLIST = [
   'graphiql:theme',
   'theme',
   'supabaseDarkMode',
-  'supabase.dashboard.sign_in_clicks',
+  'supabase.dashboard.sign_in_clicks_v2',
   'supabase.dashboard.auth.debug',
   'supabase.dashboard.auth.navigatorLock.enabled',
   'supabase.dashboard.auth.ff.threshold.navigatorLock',
@@ -19,12 +19,12 @@ export function clearLocalStorage() {
 }
 
 function inferSignInClicks() {
-  if (localStorage.getItem('supabase.dashboard.sign_in_clicks')) {
+  if (localStorage.getItem('supabase.dashboard.sign_in_clicks_v2')) {
     return
   }
 
   localStorage.setItem(
-    'supabase.dashboard.sign_in_clicks',
+    'supabase.dashboard.sign_in_clicks_v2',
     localStorage.getItem('supabase.dashboard.auth.token') ? '1' : '0'
   )
 }
@@ -33,7 +33,7 @@ export function getSignInClicks(): number {
   let count: number | null = null
 
   try {
-    count = JSON.parse(localStorage.getItem('supabase.dashboard.sign_in_clicks') || '0')
+    count = JSON.parse(localStorage.getItem('supabase.dashboard.sign_in_clicks_v2') || '0')
   } catch (e: any) {
     // do nothing
   }
@@ -44,7 +44,7 @@ export function getSignInClicks(): number {
 export function incrementSignInClicks(): number {
   const clicks = getSignInClicks()
 
-  localStorage.setItem('supabase.dashboard.sign_in_clicks', JSON.stringify(clicks + 1))
+  localStorage.setItem('supabase.dashboard.sign_in_clicks_v2', JSON.stringify(clicks + 1))
 
   return clicks + 1
 }
@@ -52,7 +52,7 @@ export function incrementSignInClicks(): number {
 export function resetSignInClicks(): number {
   const clicks = getSignInClicks()
 
-  localStorage.setItem('supabase.dashboard.sign_in_clicks', '0')
+  localStorage.setItem('supabase.dashboard.sign_in_clicks_v2', '0')
 
   return clicks
 }


### PR DESCRIPTION
The existing counter will not actually count any fixes / improvements made against random logouts. By using it suffixed with `v2` we can see if the numbers have improved.