### PR TITLE
bug fix: warning icon overlaps the increment buttons (firefox)

### DIFF
--- a/studio/styles/main.scss
+++ b/studio/styles/main.scss
@@ -165,6 +165,10 @@ input[type='radio'] {
   @apply p-0;
 }
 
+input[type='number'] {
+  -moz-appearance: textfield; /* Firefox, Not included in tailwind styles reset */
+}
+
 // TODO: It doesnt' work, need to check
 .hide-scrollbar {
   scrollbar-width: none; /* Firefox */


### PR DESCRIPTION
## What kind of change does this PR introduce?

fixes: #15308 

## What is the current behavior?

<img width="612" alt="Screenshot 2023-08-14 at 11 51 39 PM" src="https://github.com/supabase/supabase/assets/71591136/6cb96a1e-75b3-4486-ab97-71b06911d507">

## What is the new behavior?

<img width="563" alt="Screenshot 2023-08-14 at 11 52 10 PM" src="https://github.com/supabase/supabase/assets/71591136/b23c0973-0408-4e82-b3ad-bf692bd6ef94">

## Additional context

Tailwind global styles reset does not work for the input field in Firefox, so had to add it manually.
