### PR TITLE
hotfix: storage list abort toast error

### DIFF
--- a/studio/localStores/storageExplorer/StorageExplorerStore.js
+++ b/studio/localStores/storageExplorer/StorageExplorerStore.js
@@ -1123,7 +1123,10 @@ class StorageExplorerStore {
         },
         index
       )
-    } else if (!res.error.message.includes('The user aborted a request')) {
+    } else if (
+      !res.error.message.includes('The user aborted a request') ||
+      !res.error.message.includes('Request signal is aborted')
+    ) {
       this.ui.setNotification({
         error: res.error,
         category: 'error',

--- a/studio/localStores/storageExplorer/StorageExplorerStore.js
+++ b/studio/localStores/storageExplorer/StorageExplorerStore.js
@@ -1124,7 +1124,7 @@ class StorageExplorerStore {
         index
       )
     } else if (
-      !res.error.message.includes('The user aborted a request') ||
+      !res.error.message.includes('The user aborted a request') &&
       !res.error.message.includes('Request signal is aborted')
     ) {
       this.ui.setNotification({

--- a/studio/localStores/storageExplorer/StorageExplorerStore.js
+++ b/studio/localStores/storageExplorer/StorageExplorerStore.js
@@ -1166,7 +1166,10 @@ class StorageExplorerStore {
         }
         return col
       })
-    } else if (!res.error.message.includes('The user aborted a request')) {
+    } else if (
+      !res.error.message.includes('The user aborted a request') &&
+      !res.error.message.includes('Request signal is aborted')
+    ) {
       this.ui.setNotification({
         error: res.error,
         category: 'error',


### PR DESCRIPTION
In browsers that are not Chrome an error toast is displayed when trying to list a buckets contents:

<img width="374" alt="Screenshot 2023-08-15 at 5 01 18 pm" src="https://github.com/supabase/supabase/assets/10985857/b3ad9a75-11b2-48ce-aebd-6aa09ee29344">
