### PR TITLE
Fix: Missing import in pgvector blog example codeblock

### DIFF
--- a/apps/www/_blog/2023-02-03-openai-embeddings-postgres-vector.mdx
+++ b/apps/www/_blog/2023-02-03-openai-embeddings-postgres-vector.mdx
@@ -265,7 +265,7 @@ import 'https://deno.land/x/xhr@0.2.1/mod.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.5.0'
 import GPT3Tokenizer from 'https://esm.sh/gpt3-tokenizer@1.1.5'
 import { Configuration, OpenAIApi } from 'https://esm.sh/openai@3.1.0'
-import { stripIndent } from 'https://esm.sh/common-tags@1.8.2'
+import { oneLine, stripIndent } from 'https://esm.sh/common-tags@1.8.2'
 import { supabaseClient } from './lib/supabase'
 
 export const corsHeaders = {


### PR DESCRIPTION
Missing import for `oneLine` template tag in pgvector blog post.