### PR TITLE
fix: fallback for log renders for log events that are missing data

### DIFF
--- a/studio/components/interfaces/Settings/Logs/LogColumnRenderers/AuthColumnRenderer.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogColumnRenderers/AuthColumnRenderer.tsx
@@ -5,12 +5,17 @@ import {
   TextFormatter,
   TimestampLocalFormatter,
 } from '../LogsFormatters'
+import DefaultPreviewColumnRenderer from './DefaultPreviewColumnRenderer'
 
 export default [
   {
     formatter: (data: {
       row: PreviewLogData & { level: string; msg: string | null; status: number; path: string }
     }) => {
+      if (!data.row.level) {
+        return DefaultPreviewColumnRenderer[0].formatter(data)
+      }
+
       return (
         <RowLayout>
           <TimestampLocalFormatter value={data.row.timestamp!} />

--- a/studio/components/interfaces/Settings/Logs/LogColumnRenderers/DatabaseApiColumnRender.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogColumnRenderers/DatabaseApiColumnRender.tsx
@@ -4,16 +4,22 @@ import {
   TextFormatter,
   TimestampLocalFormatter,
 } from '../LogsFormatters'
+import DefaultPreviewColumnRenderer from './DefaultPreviewColumnRenderer'
 
 export default [
   {
-    formatter: (data: any) => (
-      <RowLayout>
-        <TimestampLocalFormatter value={data.row.timestamp!} />
-        <ResponseCodeFormatter row={data} value={data.row.status_code} />
-        <TextFormatter className="w-20" value={data.row.method} />
-        <TextFormatter className="w-full" value={data.row.path} />
-      </RowLayout>
-    ),
+    formatter: (data: any) => {
+      if (!data.row.status_code && !data.row.method && !data.row.path) {
+        return DefaultPreviewColumnRenderer[0].formatter(data)
+      }
+      return (
+        <RowLayout>
+          <TimestampLocalFormatter value={data.row.timestamp!} />
+          <ResponseCodeFormatter row={data} value={data.row.status_code} />
+          <TextFormatter className="w-20" value={data.row.method} />
+          <TextFormatter className="w-full" value={data.row.path} />
+        </RowLayout>
+      )
+    },
   },
 ]

--- a/studio/components/interfaces/Settings/Logs/LogColumnRenderers/DatabasePostgresColumnRender.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogColumnRenderers/DatabasePostgresColumnRender.tsx
@@ -4,15 +4,21 @@ import {
   TextFormatter,
   TimestampLocalFormatter,
 } from '../LogsFormatters'
+import DefaultPreviewColumnRenderer from './DefaultPreviewColumnRenderer'
 
 export default [
   {
-    formatter: (data: any) => (
-      <RowLayout>
-        <TimestampLocalFormatter value={data.row.timestamp!} />
-        <SeverityFormatter value={data.row.error_severity} />
-        <TextFormatter className="w-full" value={data.row.event_message} />
-      </RowLayout>
-    ),
+    formatter: (data: any) => {
+      if (!data.row.error_severity) {
+        return DefaultPreviewColumnRenderer[0].formatter(data)
+      }
+      return (
+        <RowLayout>
+          <TimestampLocalFormatter value={data.row.timestamp!} />
+          <SeverityFormatter value={data.row.error_severity} />
+          <TextFormatter className="w-full" value={data.row.event_message} />
+        </RowLayout>
+      )
+    },
   },
 ]

--- a/studio/components/interfaces/Settings/Logs/LogColumnRenderers/FunctionsEdgeColumnRender.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogColumnRenderers/FunctionsEdgeColumnRender.tsx
@@ -4,16 +4,22 @@ import {
   TextFormatter,
   TimestampLocalFormatter,
 } from '../LogsFormatters'
+import DefaultPreviewColumnRenderer from './DefaultPreviewColumnRenderer'
 
 export default [
   {
-    formatter: (data: any) => (
-      <RowLayout>
-        <TimestampLocalFormatter value={data.row.timestamp!} />
-        <ResponseCodeFormatter row={data} value={data.row.status_code} />
-        <TextFormatter value={data.row.method} />
-        <TextFormatter value={data.row.id} />
-      </RowLayout>
-    ),
+    formatter: (data: any) => {
+      if (!data.row.status_code && !data.row.method) {
+        return DefaultPreviewColumnRenderer[0].formatter(data)
+      }
+      return (
+        <RowLayout>
+          <TimestampLocalFormatter value={data.row.timestamp!} />
+          <ResponseCodeFormatter row={data} value={data.row.status_code} />
+          <TextFormatter value={data.row.method} />
+          <TextFormatter value={data.row.id} />
+        </RowLayout>
+      )
+    },
   },
 ]

--- a/studio/components/interfaces/Settings/Logs/LogColumnRenderers/FunctionsLogsColumnRender.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogColumnRenderers/FunctionsLogsColumnRender.tsx
@@ -4,19 +4,25 @@ import {
   TextFormatter,
   TimestampLocalFormatter,
 } from '../LogsFormatters'
+import DefaultPreviewColumnRenderer from './DefaultPreviewColumnRenderer'
 
 export default [
   {
-    formatter: (data: any) => (
-      <RowLayout>
-        <TimestampLocalFormatter value={data.row.timestamp!} />
-        {data.row.event_type === 'uncaughtException' ? (
-          <SeverityFormatter value={data.row.event_type} uppercase={false} />
-        ) : (
-          <SeverityFormatter value={data.row.level} />
-        )}
-        <TextFormatter className="w-full" value={data.row.event_message} />
-      </RowLayout>
-    ),
+    formatter: (data: any) => {
+      if (!data.row.event_type && !data.row.level) {
+        return DefaultPreviewColumnRenderer[0].formatter(data)
+      }
+      return (
+        <RowLayout>
+          <TimestampLocalFormatter value={data.row.timestamp!} />
+          {data.row.event_type === 'uncaughtException' ? (
+            <SeverityFormatter value={data.row.event_type} uppercase={false} />
+          ) : (
+            <SeverityFormatter value={data.row.level} />
+          )}
+          <TextFormatter className="w-full" value={data.row.event_message} />
+        </RowLayout>
+      )
+    },
   },
 ]

--- a/studio/components/interfaces/Settings/Logs/LogSelection.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogSelection.tsx
@@ -40,25 +40,31 @@ const LogSelection = ({
     partialLog?.id
   )
   const Formatter = () => {
+    
     switch (queryType) {
       case 'api':
         if (!fullLog) return null
+        if (!fullLog.metadata) return <DefaultPreviewSelectionRenderer log={fullLog} />;
         return <DatabaseApiSelectionRender log={fullLog} />
 
       case 'database':
         if (!fullLog) return null
+        if (!fullLog.metadata) return <DefaultPreviewSelectionRenderer log={fullLog} />;
         return <DatabasePostgresSelectionRender log={fullLog} />
 
       case 'fn_edge':
         if (!fullLog) return null
+        if (!fullLog.metadata) return <DefaultPreviewSelectionRenderer log={fullLog} />;
         return <FunctionInvocationSelectionRender log={fullLog} />
 
       case 'functions':
         if (!fullLog) return null
+        if (!fullLog.metadata) return <DefaultPreviewSelectionRenderer log={fullLog} />;
         return <FunctionLogsSelectionRender log={fullLog} />
 
       case 'auth':
         if (!fullLog) return null
+        if (!fullLog.metadata) return <DefaultPreviewSelectionRenderer log={fullLog} />;
         return <AuthSelectionRenderer log={fullLog} />
 
       default:

--- a/studio/components/interfaces/Settings/Logs/LogSelectionRenderers/DefaultPreviewSelectionRenderer.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogSelectionRenderers/DefaultPreviewSelectionRenderer.tsx
@@ -16,7 +16,7 @@ const DefaultPreviewSelectionRenderer = ({ log }: { log: PreviewLogData }) => (
       <pre
         className=" className={`text-scale-1200 text-sm col-span-8 overflow-x-auto text-xs font-mono`}"
         dangerouslySetInnerHTML={{
-          __html: jsonSyntaxHighlight(log.metadata!),
+          __html: jsonSyntaxHighlight(log.metadata || {}),
         }}
       />
     </div>

--- a/studio/tests/pages/projects/LogsPreviewer.test.js
+++ b/studio/tests/pages/projects/LogsPreviewer.test.js
@@ -37,6 +37,25 @@ beforeEach(() => {
   useParams.mockReturnValue(routerReturnValue.query)
 })
 
+// in the event that log metadata is not available, fall back to default renderer
+// generate test cases for each query type
+const defaultRendererFallbacksCases = [
+  'api', 'database', 'auth', 'pgbouncer', 'postgrest', 'storage', 'realtime'
+].map((queryType) => ({
+  testName: "fallback to default render",
+  queryType,
+  tableName: undefined,
+  tableLog: logDataFixture({
+    event_message: 'some message',
+    metadata: undefined,
+  }),
+  selectionLog: logDataFixture({
+    metadata: undefined,
+  }),
+  tableTexts: [/some message/],
+  selectionTexts: [/some message/],
+}))
+
 test.each([
   {
     queryType: 'api',
@@ -53,6 +72,7 @@ test.each([
     tableTexts: [/POST/, /some\-path/, /400/],
     selectionTexts: [/POST/, /Timestamp/, RegExp(`${new Date().getFullYear()}.+`, 'g')],
   },
+
   {
     queryType: 'database',
     tableName: undefined,
@@ -84,6 +104,7 @@ test.each([
     ],
   },
   {
+
     queryType: 'auth',
     tableName: undefined,
     tableLog: logDataFixture({
@@ -114,6 +135,7 @@ test.each([
       RegExp(`${new Date().getFullYear()}.+`, 'g'),
     ],
   },
+  ...defaultRendererFallbacksCases,
   // these all use teh default selection/table renderers
   ...['pgbouncer', 'postgrest', 'storage', 'realtime'].map((queryType) => ({
     queryType,
@@ -129,7 +151,7 @@ test.each([
     selectionTexts: [/some/, /nested/, /value/, RegExp(`${new Date().getFullYear()}.+`, 'g')],
   })),
 ])(
-  'selection $queryType $tableName , can display log data and metadata',
+  'selection $queryType $queryType, $tableName , can display log data and metadata $testName',
   async ({ queryType, tableName, tableLog, selectionLog, tableTexts, selectionTexts }) => {
     get.mockImplementation((url) => {
       // counts


### PR DESCRIPTION
This PR adjust the renderers for log events to handle instances where metadata is missing.

This situation occurs for CLI when we parse data from syslog and metadata is missing for certain service logs.

[ticket](https://www.notion.so/supabase/supabase-cli-bug-postgres-logs-seem-to-have-empty-No-Data-log-lines-that-result-in-studio-error-29b7c7e84a264cd0b677605fee5b9e90?pvs=4)