### PR TITLE
fix: log explorer copy button not working

### DIFF
--- a/studio/components/interfaces/Settings/Logs/LogSelection.tsx
+++ b/studio/components/interfaces/Settings/Logs/LogSelection.tsx
@@ -17,6 +17,7 @@ import DefaultPreviewSelectionRenderer from './LogSelectionRenderers/DefaultPrev
 import FunctionInvocationSelectionRender from './LogSelectionRenderers/FunctionInvocationSelectionRender'
 import FunctionLogsSelectionRender from './LogSelectionRenderers/FunctionLogsSelectionRender'
 import { LogData, QueryType } from './Logs.types'
+import { useMemo } from 'react'
 
 export interface LogSelectionProps {
   log: LogData | null
@@ -73,9 +74,8 @@ const LogSelection = ({
     }
   }
 
-  const selectionText = () => {
-    if (!fullLog) return ''
-    if (queryType) {
+  const selectionText = useMemo(() => {
+    if (fullLog && queryType) {
       return `Log ID
 ${fullLog.id}\n
 Log Timestamp (UTC)
@@ -87,8 +87,8 @@ ${JSON.stringify(fullLog.metadata, null, 2)}
 `
     }
 
-    return JSON.stringify(fullLog, null, 2)
-  }
+    return JSON.stringify(fullLog || partialLog, null, 2)
+  }, [fullLog])
 
   return (
     <div
@@ -153,7 +153,7 @@ ${JSON.stringify(fullLog.metadata, null, 2)}
         <div className="pt-4 px-4 flex flex-col gap-4">
           <div className="flex flex-row justify-between items-center">
             <div className={`transition ${!isLoading ? 'opacity-100' : 'opacity-0'}`}>
-              <CopyButton text={selectionText()} type="default" title="Copy log to clipboard" />
+              <CopyButton text={selectionText} type="default" title="Copy log to clipboard" />
             </div>
             <Button
               type="text"


### PR DESCRIPTION
This PR fixes a bug where a custom log explorer result is not set as the selection text to be copied.


https://github.com/supabase/supabase/assets/22714384/13a349e6-7f36-4688-a2f3-594674d2dbac

