### PR TITLE
fix: remove unnecessary env var checks in self-hosted studio

### DIFF
--- a/studio/pages/api/projects/[ref]/analytics/endpoints/[name].ts
+++ b/studio/pages/api/projects/[ref]/analytics/endpoints/[name].ts
@@ -10,16 +10,6 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
 
   switch (method) {
     case 'GET':
-      if (process.env.NEXT_PUBLIC_ENABLE_LOGS !== 'true') {
-        return res
-          .status(400)
-          .json({ error: { message: '[analytics] is not enabled in supabase/config.toml' } })
-      }
-      if (process.env.NEXT_ANALYTICS_BACKEND_PROVIDER !== 'bigquery') {
-        return res
-          .status(400)
-          .json({ error: { message: 'Log Explorer is only supported by the [analytics] Big Query backend. Please refer to https://supabase.com/docs/reference/self-hosting-analytics/introduction for more information' } })
-      }
       const missingEnvVars = [
         process.env.LOGFLARE_API_KEY ? null : 'LOGFLARE_API_KEY',
         process.env.LOGFLARE_URL ? null : 'LOGFLARE_URL',
@@ -44,7 +34,7 @@ const proxyRequest = async (req: NextApiRequest) => {
   const payload = { ...toForward, project_tier: 'ENTERPRISE' }
   const search = '?' + new URLSearchParams(payload as any).toString()
   const apiKey = process.env.LOGFLARE_API_KEY
-  const url = `${PROJECT_ANALYTICS_URL}endpoints/query/name/${name}${search}`
+  const url = `${PROJECT_ANALYTICS_URL}endpoints/query/${name}${search}`
   const result = await get(url, {
     headers: {
       'x-api-key': apiKey,


### PR DESCRIPTION
This PR removes some checks in the self-hosted studio, which are no longer required as logs are always enabled now, and the logs explorer is compatible with postgres backend (via translation)