### PR TITLE
fix: adjustment for project home bar chart click timestamp filtering

### DIFF
--- a/studio/components/interfaces/Home/ProjectUsage.tsx
+++ b/studio/components/interfaces/Home/ProjectUsage.tsx
@@ -67,8 +67,12 @@ const ProjectUsage = () => {
     // TODO (ziinc): link to edge logs with correct filter applied
     _type: 'rest' | 'realtime' | 'storage' | 'auth'
   ) => {
-    const selected = dayjs(value?.timestamp).toISOString()
-    router.push(`/project/${projectRef}/logs/edge-logs?ite=${encodeURIComponent(selected)}`)
+    const unit = selectedInterval.startUnit
+    const selectedStart = dayjs(value?.timestamp)
+    const selectedEnd = selectedStart.add(1, unit)
+    router.push(
+      `/project/${projectRef}/logs/edge-logs?ite=${encodeURIComponent(selectedEnd.toISOString())}`
+    )
   }
 
   return (


### PR DESCRIPTION
This PR adjusts the timestamp filtering value for the bar chart click from the project home page.

The values displayed in the bar chart is the interval start, so if user clicks on 2pm, they would expect to see logs up 3pm (assuming a 1 hour interval).
The interval calculation accounts for the selected time interval.