### PR TITLE
Fix/log event chart rq memoized keys

### DIFF
--- a/studio/hooks/analytics/useLogsPreview.tsx
+++ b/studio/hooks/analytics/useLogsPreview.tsx
@@ -15,7 +15,7 @@ import {
   LogsTableName,
   PREVIEWER_DATEPICKER_HELPERS,
 } from 'components/interfaces/Settings/Logs'
-import { Dispatch, SetStateAction, useEffect, useRef, useState } from 'react'
+import { Dispatch, SetStateAction, useEffect, useMemo, useRef, useState } from 'react'
 import { API_URL } from 'lib/constants'
 import { get, isResponseOk } from 'lib/common/fetch'
 import dayjs from 'dayjs'
@@ -125,14 +125,14 @@ function useLogsPreview(
 
   // chart data
 
-  const chartQuery = genChartQuery(table, params, filters)
-  const chartUrl = () => {
+  const chartQuery = useMemo(()=> genChartQuery(table, params, filters) , [params, filters])
+  const chartUrl = useMemo(() => {
     return `${API_URL}/projects/${projectRef}/analytics/endpoints/logs.all?${genQueryParams({
       iso_timestamp_end: params.iso_timestamp_end,
       project: params.project,
       sql: chartQuery,
     } as any)}`
-  }
+  }, [params, chartQuery])
 
   const { data: eventChartResponse, refetch: refreshEventChart } = useQuery(
     [
@@ -141,7 +141,7 @@ function useLogsPreview(
       'logs-chart',
       { iso_timestamp_end: params.iso_timestamp_end, project: params.project, sql: chartQuery },
     ],
-    ({ signal }) => get<EventChart>(chartUrl(), { signal }),
+    ({ signal }) => get<EventChart>(chartUrl, { signal }),
     { refetchOnWindowFocus: false }
   )
 


### PR DESCRIPTION
This PR fixes a refresh loop for the log event chart data loading. Conversion to react query did not use memoized keys, resulting in keys changing on each render. This resulted in one api call succeeding and the next getting cancelled, and the stored data of the successful api call getting cleared as it was seen as stale.

Before:

https://github.com/supabase/supabase/assets/22714384/01ecda24-bd3e-4946-a7b4-423048892f20


After:

https://github.com/supabase/supabase/assets/22714384/5a1e0b50-17af-4668-bfd0-014b4f2696a4

