### PR TITLE
updated link from auth-apple to auth-google

### DIFF
--- a/studio/stores/authConfig/schema/AuthProviders/AuthProvidersFormValidation.tsx
+++ b/studio/stores/authConfig/schema/AuthProviders/AuthProvidersFormValidation.tsx
@@ -884,7 +884,7 @@ const EXTERNAL_PROVIDER_GOOGLE = {
     iconKey: 'google-icon',
     requiresRedirect: true,
     helper: `Register this callback URL when using Sign-in with Google on the web using OAuth.
-            [Learn more](https://supabase.com/docs/guides/auth/social-login/auth-apple#configure-your-services-id)`,
+            [Learn more](https://supabase.com/docs/guides/auth/social-login/auth-google#configure-your-services-id)`,
   },
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
Editing the link in documentation for google auth provider
Route to link - studio/stores/authConfig/schema/AuthProviders/AuthProvidersFormValidation.tsx

## What is the current behavior?
Currently text has the input links to https://supabase.com/docs/guides/auth/social-login/auth-apple#configure-your-services-id

## What is the new behavior?
After fixing the link from - studio/stores/authConfig/schema/AuthProviders/AuthProvidersFormValidation.tsx  it currently links to - https://supabase.com/docs/guides/auth/social-login/auth-google#configure-your-services-id

Thankyou for giving this opportunity @gregnr @neiled @laktek
