### PR TITLE
chore: humongous improvements for org-billing

### DIFF
--- a/studio/components/interfaces/Home/ProjectList/ProjectList.tsx
+++ b/studio/components/interfaces/Home/ProjectList/ProjectList.tsx
@@ -99,10 +99,7 @@ const OrganizationProjects = ({
   return (
     <div className="space-y-3" key={makeRandomString(5)}>
       <div className="flex space-x-4 items-center">
-        <h4 className="text-lg flex items-center">
-          {name}
-          {subscription_id ? <Badge className="ml-3">V2</Badge> : <></>}
-        </h4>
+        <h4 className="text-lg flex items-center">{name}</h4>
 
         {!!overdueInvoices.length && (
           <div>

--- a/studio/components/interfaces/Organization/GeneralSettings/MigrateOrganizationBillingButton.tsx
+++ b/studio/components/interfaces/Organization/GeneralSettings/MigrateOrganizationBillingButton.tsx
@@ -23,6 +23,7 @@ import { useOrganizationBillingMigrationPreview } from 'data/organizations/organ
 import { useCheckPermissions, useSelectedOrganization, useStore } from 'hooks'
 import { PRICING_TIER_LABELS_ORG } from 'lib/constants'
 import PaymentMethodSelection from '../BillingSettingsV2/Subscription/PaymentMethodSelection'
+import InformationBox from 'components/ui/InformationBox'
 
 const MigrateOrganizationBillingButton = observer(() => {
   const { ui } = useStore()
@@ -114,7 +115,7 @@ const MigrateOrganizationBillingButton = observer(() => {
       <Modal
         closable
         hideFooter
-        size="large"
+        size="xlarge"
         visible={isOpen}
         onCancel={toggle}
         header={
@@ -173,7 +174,7 @@ const MigrateOrganizationBillingButton = observer(() => {
 
               <p>
                 For a detailed breakdown of changes, see{' '}
-                <Link href="https://www.notion.so/supabase/Organization-Level-Billing-9c159d69375b4af095f0b67881276582?pvs=4">
+                <Link href="https://www.notion.so/supabase/Org-Level-Billing-Public-Docs-f059a154beb743a19199d05bab4acb08">
                   <a target="_blank" rel="noreferrer" className="underline">
                     Billing Migration Docs
                   </a>
@@ -229,7 +230,7 @@ const MigrateOrganizationBillingButton = observer(() => {
                 <p className="text-sm text-scale-1000">
                   Paid plans come with one compute instance included. Additional projects will at
                   least cost the compute instance hours used (min $7/month). See{' '}
-                  <Link href="https://www.notion.so/supabase/Organization-Level-Billing-9c159d69375b4af095f0b67881276582?pvs=4">
+                  <Link href="https://www.notion.so/supabase/Organization-Level-Billing-707638e35c92489995dc3ac991a324d1">
                     <a target="_blank" rel="noreferrer" className="underline">
                       Compute Instance Usage Billing
                     </a>
@@ -318,6 +319,75 @@ const MigrateOrganizationBillingButton = observer(() => {
               </Alert_Shadcn_>
             )}
           </Modal.Content>
+
+          {!migrationPreviewIsLoading && migrationPreviewData && dbTier !== 'tier_free' && (
+            <Modal.Content>
+              <InformationBox
+                defaultVisibility={false}
+                title={
+                  <span>
+                    Estimated monthly price is $
+                    {migrationPreviewData.monthly_invoice_breakdown.reduce(
+                      (prev, cur) => prev + cur.total_price,
+                      0
+                    )}{' '}
+                    + usage
+                  </span>
+                }
+                hideCollapse={false}
+                description={
+                  <div>
+                    <table className="w-full">
+                      <thead>
+                        <tr className="border-b">
+                          <th className="py-2 font-normal text-left text-sm text-scale-1000 w-1/2">
+                            Item
+                          </th>
+                          <th className="py-2 font-normal text-left text-sm text-scale-1000">
+                            Count
+                          </th>
+                          <th className="py-2 font-normal text-left text-sm text-scale-1000">
+                            Unit price
+                          </th>
+                          <th className="py-2 font-normal text-right text-sm text-scale-1000">
+                            Price
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {migrationPreviewData.monthly_invoice_breakdown.map((item) => (
+                          <tr key={item.description} className="border-b">
+                            <td className="py-2 text-sm">{item.description ?? 'Unknown'}</td>
+                            <td className="py-2 text-sm">{item.quantity}</td>
+                            <td className="py-2 text-sm">
+                              {item.unit_price === 0 ? 'FREE' : `$${item.unit_price}`}
+                            </td>
+                            <td className="py-2 text-sm text-right">${item.total_price}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+
+                      <tbody>
+                        <tr>
+                          <td className="py-2 text-sm">Total</td>
+                          <td className="py-2 text-sm" />
+                          <td className="py-2 text-sm" />
+                          <td className="py-2 text-sm text-right">
+                            $
+                            {migrationPreviewData.monthly_invoice_breakdown.reduce(
+                              (prev, cur) => prev + cur.total_price,
+                              0
+                            ) ?? 0}
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div>
+                }
+              />
+            </Modal.Content>
+          )}
+
           <Modal.Content>
             <Button
               block

--- a/studio/components/interfaces/Organization/GeneralSettings/OrganizationBillingMigrationPanel.tsx
+++ b/studio/components/interfaces/Organization/GeneralSettings/OrganizationBillingMigrationPanel.tsx
@@ -30,7 +30,7 @@ const OrganizationBillingMigrationPanel = observer(() => {
               </p>
             </div>
             <div className="flex items-center gap-4 ml-12">
-              <Link href="https://www.notion.so/supabase/Organization-Level-Billing-9c159d69375b4af095f0b67881276582?pvs=4">
+              <Link href="https://www.notion.so/supabase/Org-Level-Billing-Public-Docs-f059a154beb743a19199d05bab4acb08">
                 <a target="_blank" rel="noreferrer">
                   <Button type="default" icon={<IconExternalLink strokeWidth={1.5} />}>
                     Documentation

--- a/studio/components/interfaces/Organization/NewOrg/NewOrgForm.tsx
+++ b/studio/components/interfaces/Organization/NewOrg/NewOrgForm.tsx
@@ -384,7 +384,7 @@ const NewOrgForm = ({ onPaymentMethodReset }: NewOrgFormProps) => {
                     subscriptions per project.{' '}
                   </p>
                   <div>
-                    <Link href="https://www.notion.so/supabase/Organization-Level-Billing-9c159d69375b4af095f0b67881276582?pvs=4">
+                    <Link href="https://www.notion.so/supabase/Org-Level-Billing-Public-Docs-f059a154beb743a19199d05bab4acb08">
                       <a target="_blank" rel="noreferrer">
                         <Button type="default" icon={<IconExternalLink strokeWidth={1.5} />}>
                           Documentation

--- a/studio/components/interfaces/Organization/Usage/Usage.tsx
+++ b/studio/components/interfaces/Organization/Usage/Usage.tsx
@@ -171,7 +171,7 @@ const Usage = () => {
                   "All Projects".
                 </p>
                 <div>
-                  <Link href="https://www.notion.so/supabase/Organization-Level-Billing-9c159d69375b4af095f0b67881276582?pvs=4">
+                  <Link href="https://www.notion.so/supabase/Org-Level-Billing-Public-Docs-f059a154beb743a19199d05bab4acb08">
                     <a target="_blank" rel="noreferrer">
                       <Button type="default" icon={<IconExternalLink strokeWidth={1.5} />}>
                         Documentation

--- a/studio/components/interfaces/Settings/Addons/ComputeInstanceSidePanel.tsx
+++ b/studio/components/interfaces/Settings/Addons/ComputeInstanceSidePanel.tsx
@@ -385,7 +385,7 @@ const ComputeInstanceSidePanel = () => {
                   There are no immediate charges when changing compute. Compute Hours are a
                   usage-based item and you're billed at the end of your billing cycle based on your
                   compute usage. Read more about{' '}
-                  <Link href="https://www.notion.so/supabase/Organization-Level-Billing-9c159d69375b4af095f0b67881276582?pvs=4">
+                  <Link href="https://www.notion.so/supabase/Org-Level-Billing-Public-Docs-f059a154beb743a19199d05bab4acb08">
                     <a target="_blank" rel="noreferrer" className="underline">
                       Compute Billing
                     </a>

--- a/studio/components/interfaces/Settings/General/TransferProjectPanel/TransferProjectButton.tsx
+++ b/studio/components/interfaces/Settings/General/TransferProjectPanel/TransferProjectButton.tsx
@@ -214,7 +214,7 @@ const TransferProjectButton = () => {
 
                 <p className="text-scale-1000 text-sm">
                   The target organization needs to use{' '}
-                  <Link href="https://www.notion.so/supabase/Organization-Level-Billing-9c159d69375b4af095f0b67881276582?pvs=4">
+                  <Link href="https://www.notion.so/supabase/Org-Level-Billing-Public-Docs-f059a154beb743a19199d05bab4acb08">
                     <a target="_blank" rel="noreferrer" className="underline">
                       organization-level-billing
                     </a>

--- a/studio/components/layouts/ProjectLayout/ProjectPausedState.tsx
+++ b/studio/components/layouts/ProjectLayout/ProjectPausedState.tsx
@@ -84,7 +84,7 @@ const ProjectPausedState = ({ product }: ProjectPausedStateProps) => {
                 <IconPauseCircle className="text-scale-1100" size={50} strokeWidth={1.5} />
               </div>
 
-              <div className="space-y-1">
+              <div className="space-y-2">
                 <p className="text-center">
                   The project "{project?.name ?? ''}" is currently paused.
                 </p>
@@ -103,6 +103,18 @@ const ProjectPausedState = ({ product }: ProjectPausedStateProps) => {
                 {isFreePlan && (
                   <p className="text-sm text-scale-1100 text-center">
                     You can also prevent project pausing in the future by upgrading to Pro.
+                  </p>
+                )}
+                {!isFreePlan && (
+                  <p className="text-sm text-scale-1100 text-center">
+                    Unpaused projects count towards compute usage. For every hour your instance is
+                    active, we'll bill you based on the instance size of your project. See{' '}
+                    <Link href="https://www.notion.so/supabase/Organization-Level-Billing-707638e35c92489995dc3ac991a324d1">
+                      <a target="_blank" rel="noreferrer" className="underline">
+                        Compute Instance Usage Billing
+                      </a>
+                    </Link>{' '}
+                    for more details.
                   </p>
                 )}
               </div>

--- a/studio/data/organizations/organization-migrate-billing-preview-query.ts
+++ b/studio/data/organizations/organization-migrate-billing-preview-query.ts
@@ -10,12 +10,12 @@ export type OrganizationBillingMigrationPreviewVariables = {
 
 export type OrganizationBillingMigrationPreviewResponse = {
   added_credits: number
-  addons_to_be_removed?: {
+  addons_to_be_removed: {
     projectRef: string
     projectName: string
     addons: { variant: string; name: string; type: string }[]
   }[]
-  monthly_invoice_breakdown?: {
+  monthly_invoice_breakdown: {
     description: string
     unit_price: number
     quantity: number

--- a/studio/pages/new/[slug].tsx
+++ b/studio/pages/new/[slug].tsx
@@ -467,20 +467,26 @@ const Wizard: NextPageWithLayout = () => {
                   description={
                     <div className="space-y-3">
                       <p className="text-sm leading-normal">
-                        This organization uses the new organization-level billing and is on the{' '}
+                        This organization uses the new organization-level-billing and is on the{' '}
                         <span className="text-brand">{orgSubscription?.plan?.name} plan</span>.
                       </p>
 
                       {/* Show info when launching a new project in a paid org that already has at least one project */}
                       {orgSubscription?.plan?.id !== 'free' && orgProjectCount > 0 && (
-                        <p>
-                          Launching another project incurs additional compute costs (starting at $10
-                          per month).
-                        </p>
+                        <div>
+                          <p>
+                            Launching another project incurs additional compute costs, starting at
+                            $0.01344 per hour (~$10/month).
+                          </p>
+                          <p>
+                            You can also create a new organization under the free plan (unless you
+                            have exceeded your 2 free project limit).
+                          </p>
+                        </div>
                       )}
 
                       <div>
-                        <Link href="https://www.notion.so/supabase/Organization-Level-Billing-9c159d69375b4af095f0b67881276582?pvs=4">
+                        <Link href="https://www.notion.so/supabase/Org-Level-Billing-Public-Docs-f059a154beb743a19199d05bab4acb08">
                           <a target="_blank" rel="noreferrer">
                             <Button type="default" icon={<IconExternalLink strokeWidth={1.5} />}>
                               Documentation


### PR DESCRIPTION
- Removed V2 label on overview
- Replaced Notion links
- Added estimated monthly costs + invoice breakdown on migration modal
- Extended size of migration modal
- Added info about compute hours on unpause screen

<img width="772" alt="Screenshot 2023-08-16 at 23 19 24" src="https://github.com/supabase/supabase/assets/14073399/fbcd041b-cda2-47a1-9794-60df163b68dc">
