### PR TITLE
feat: enable `navigatorLock` completely, track random logouts

### DIFF
--- a/packages/common/gotrue.ts
+++ b/packages/common/gotrue.ts
@@ -3,8 +3,8 @@ import { GoTrueClient, navigatorLock } from '@supabase/gotrue-js'
 export const STORAGE_KEY = process.env.NEXT_PUBLIC_STORAGE_KEY || 'supabase.dashboard.auth.token'
 export const AUTH_DEBUG_KEY =
   process.env.NEXT_PUBLIC_AUTH_DEBUG_KEY || 'supabase.dashboard.auth.debug'
-export const AUTH_NAVIGATOR_LOCK_KEY =
-  process.env.NEXT_PUBLIC_AUTH_NAVIGATOR_LOCK_KEY || 'supabase.dashboard.auth.navigatorLock.enabled'
+export const AUTH_NAVIGATOR_LOCK_DISABLED_KEY =
+  process.env.NEXT_PUBLIC_AUTH_NAVIGATOR_LOCK_KEY || 'supabase.dashboard.auth.navigatorLock.disabled'
 
 const debug =
   process.env.NEXT_PUBLIC_IS_PLATFORM === 'true' &&
@@ -12,9 +12,13 @@ const debug =
 
 const navigatorLockEnabled = !!(
   process.env.NEXT_PUBLIC_IS_PLATFORM === 'true' &&
-  globalThis?.localStorage?.getItem(AUTH_NAVIGATOR_LOCK_KEY) === 'true' &&
+  !(globalThis?.localStorage?.getItem(AUTH_NAVIGATOR_LOCK_DISABLED_KEY) === 'true') &&
   globalThis?.navigator?.locks
 )
+
+if (!globalThis?.navigator?.locks) {
+  console.warn('This browser does not support the Navigator Locks API. Please update it.')
+}
 
 export const gotrueClient = new GoTrueClient({
   url: process.env.NEXT_PUBLIC_GOTRUE_URL,

--- a/studio/lib/gotrue.ts
+++ b/studio/lib/gotrue.ts
@@ -1,51 +1,21 @@
 import { IS_PLATFORM } from './constants'
 import { User, Session } from '@supabase/gotrue-js'
 import { gotrueClient } from 'common'
+
 import { getFlags } from './configcat'
-import { getNavigatorLockFeatureFlagThreshold, setNavigatorLockEnabled } from './local-storage'
-
-// The first time this file is imported, ConfigCat will be asked for all
-// available feature flags. The client that this is running in will have
-// determined and saved a random number [0, 100) under
-// `supabase.dashboard.ff.threshold.navigatorLock`. If there is a number-valued
-// feature flag `navigatorLockThreshold`, the
-// `supabase.dashboard.auth.navigatorLock.enabled` localStorage key will be set
-// to true if the value chosen by the browser is <= the value in the feature
-// flag.On the _following_ refresh of the page, `packages/common/gotrue.ts`
-// will read this value and enable the GoTrueClient navigatorLock.
-// ConfigCat does not have a native way to do this, as percent-based rollouts
-// are only available when ConfigCat has a user ID, and not without one, which
-// can be the case here (GoTrue is used when not authenticated too).
-async function determineNavigatorLockFeatureFlag() {
-  const flags = await getFlags()
-  const value = flags.find((flag) => flag.settingKey === 'navigatorLockThreshold')?.settingValue
-
-  if (typeof value === 'number' && value > 0) {
-    const threshold = getNavigatorLockFeatureFlagThreshold()
-
-    if (typeof threshold === 'number') {
-      setNavigatorLockEnabled(threshold <= value)
-    } else {
-      setNavigatorLockEnabled(false)
-    }
-  } else {
-    setNavigatorLockEnabled(false)
-  }
-}
 
 export { STORAGE_KEY } from 'common'
 
 export const auth = gotrueClient
 
 let currentSession: Session | null = null
-let getAccessTokenPromise: Promise<string | undefined | null> | null = null
 
 auth.onAuthStateChange((event, session) => {
   currentSession = session
 })
 
 /**
- * Grabs the currently available access token, or starts a single getSession call.
+ * Grabs the currently available access token, or calls getSession.
  */
 export async function getAccessToken() {
   // ignore if server-side
@@ -56,29 +26,15 @@ export async function getAccessToken() {
     : false
 
   if (!currentSession || aboutToExpire) {
-    if (!getAccessTokenPromise) {
-      const promise = (async () => {
-        try {
-          const {
-            data: { session },
-            error,
-          } = await auth.getSession()
-          if (error) {
-            throw error
-          }
-
-          return session?.access_token
-        } finally {
-          getAccessTokenPromise = null
-        }
-      })()
-
-      getAccessTokenPromise = promise
-
-      return await promise
+    const {
+      data: { session },
+      error,
+    } = await auth.getSession()
+    if (error) {
+      throw error
     }
 
-    return await getAccessTokenPromise
+    return session?.access_token
   }
 
   return currentSession.access_token
@@ -141,8 +97,4 @@ export const getReturnToPath = (fallback = '/projects') => {
   }
 
   return validReturnTo + (remainingSearchParams ? `?${remainingSearchParams}` : '')
-}
-
-if (IS_PLATFORM && globalThis.window) {
-  determineNavigatorLockFeatureFlag()
 }


### PR DESCRIPTION
Enables `navigatorLock` completely, which can be disabled per-browser by setting the `supabase.dashboard.auth.navigatorLock.disabled` flag to `true`.

Yet another prefix is added to track random logouts using the sign-in clicks counter.