### PR TITLE
fix: only save truthy values on wrapper table options

### DIFF
--- a/studio/data/fdw/fdw-create-mutation.ts
+++ b/studio/data/fdw/fdw-create-mutation.ts
@@ -101,11 +101,13 @@ export function getCreateFDWSql({
         options (
           ${Object.entries(newTable)
             .filter(
-              ([key]) =>
+              ([key, value]) =>
                 key !== 'table_name' &&
                 key !== 'schema_name' &&
                 key !== 'columns' &&
-                key !== 'index'
+                key !== 'index' &&
+                key !== 'is_new_schema' &&
+                Boolean(value)
             )
             .map(([key, value]) => `${key} '${value}'`)
             .join(',\n          ')}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes #16599

## What is the new behaviour?

This PR also includes filtering out the `is_new_schema` value from the table options as it is only used for the UI and not the internal wrapper