### PR TITLE
Install `@supabase/auth-ui-shared` before using it

### DIFF
--- a/apps/docs/pages/guides/auth/quickstarts/react.mdx
+++ b/apps/docs/pages/guides/auth/quickstarts/react.mdx
@@ -58,7 +58,7 @@ export const meta = {
     <StepHikeCompact.Code>
 
       ```bash Terminal
-      cd my-app && npm install @supabase/supabase-js @supabase/auth-ui-react
+      cd my-app && npm install @supabase/supabase-js @supabase/auth-ui-react @supabase/auth-ui-shared
       ```
 
     </StepHikeCompact.Code>


### PR DESCRIPTION
## docs update
Based on the example provided, @supabase/auth-ui-shared package is also needed to be installed. However, it is not mentioned in the previous section.

