### PR TITLE
fix: Markdown url is not rendered in docs/guides/self-hosting/storage…

### DIFF
--- a/apps/docs/pages/guides/self-hosting/storage/config.mdx
+++ b/apps/docs/pages/guides/self-hosting/storage/config.mdx
@@ -9,6 +9,8 @@ export const meta = {
   description: 'How to configure and deploy Supabase.',
 }
 
+A sample `.env` file is located in the [storage repository](https://github.com/supabase/storage-api/blob/master/.env.sample).
+
 <div>{spec.info.description}</div>
 
 <div>

--- a/spec/storage_v0_config.yaml
+++ b/spec/storage_v0_config.yaml
@@ -9,8 +9,6 @@ info:
   bugs: 'https://github.com/supabase/storage-api/issues' # {string} Where developers can file bugs.
   spec: 'https://github.com/supabase/supabase/blob/master/spec/storage_v1_config.yml' # {string} Where developers can find this spec (to link directly in the docs).
   description: |
-    A sample `.env` file is located in the [storage repository](https://github.com/supabase/storage-api/blob/master/.env.sample).
-
     Use this file to configure your environment variables for your Storage server.
   tags:
     - id: general


### PR DESCRIPTION
…/config

## What kind of change does this PR introduce?

Bug fix, docs update, ...

## What is the current behavior?

Before:
![image](https://github.com/supabase/supabase/assets/71846487/035fefd4-a36d-4a2d-b65b-51c6392e9ea7)

## What is the new behavior?
After:
![image](https://github.com/supabase/supabase/assets/71846487/18e78e47-458d-4c07-b8f5-97493b2517f1)


## Additional context

Add any other context or screenshots.
