### PR TITLE
Fix typo

### DIFF
--- a/apps/docs/pages/guides/cli/getting-started.mdx
+++ b/apps/docs/pages/guides/cli/getting-started.mdx
@@ -161,7 +161,7 @@ The CLI provides a number of commands to help you develop your project locally a
 - [Project](/docs/reference/cli/supabase-projects) and [Organization](/docs/reference/cli/supabase-orgs) management
 - [Database management](/docs/reference/cli/supabase-db)
 - [Database migrations](/docs/reference/cli/supabase-migration) and [Database Branching](/docs/reference/cli/supabase-branches)
-- [Database debugigng tools](/docs/reference/cli/supabase-inspect-db-calls)
+- [Database debugging tools](/docs/reference/cli/supabase-inspect-db-calls)
 - [Edge Function management](/docs/reference/cli/supabase-functions)
 - [Auth management](/docs/reference/cli/supabase-functions)
 - [Types Generators](/docs/reference/cli/supabase-gen)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixed the typo under the [getting started page](https://supabase.com/docs/guides/cli/getting-started).

## What is the current behavior?

At the moment, the resource looks like this:

![image](https://github.com/supabase/supabase/assets/71621723/2fc9a18c-d8d7-4c7d-9dcf-b348454addb6)

## Issue

#16657 Typo in the documentation
