### PR TITLE
Fixed : Typo issue in docs guides (Docs) 

### DIFF
--- a/apps/docs/pages/guides/cli/getting-started.mdx
+++ b/apps/docs/pages/guides/cli/getting-started.mdx
@@ -161,7 +161,7 @@ The CLI provides a number of commands to help you develop your project locally a
 - [Project](/docs/reference/cli/supabase-projects) and [Organization](/docs/reference/cli/supabase-orgs) management
 - [Database management](/docs/reference/cli/supabase-db)
 - [Database migrations](/docs/reference/cli/supabase-migration) and [Database Branching](/docs/reference/cli/supabase-branches)
-- [Database debugigng tools](/docs/reference/cli/supabase-inspect-db-calls)
+- [Database debugging tools](/docs/reference/cli/supabase-inspect-db-calls)
 - [Edge Function management](/docs/reference/cli/supabase-functions)
 - [Auth management](/docs/reference/cli/supabase-functions)
 - [Types Generators](/docs/reference/cli/supabase-gen)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug Fix

## What is the current behavior?

Typo in the documentation https://github.com/supabase/supabase/issues/16657#issue-1859401800

## What is the new behavior?

Fixed Typo error in docs
![Screenshot from 2023-08-21 20-45-44](https://github.com/supabase/supabase/assets/50178043/150e15f6-001d-4383-bb8e-088d242bfe23)

