### PR TITLE
Passing JWT_SECRET and JWT_EXPIRY to postgrest APP_SETTINGS

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -168,6 +168,8 @@ services:
       PGRST_DB_ANON_ROLE: anon
       PGRST_JWT_SECRET: ${JWT_SECRET}
       PGRST_DB_USE_LEGACY_GUCS: "false"
+      PGRST_APP_SETTINGS_JWT_SECRET: ${JWT_SECRET}
+      PGRST_APP_SETTINGS_JWT_EXP: ${JWT_EXPIRY}
 
   realtime:
     container_name: realtime-dev.supabase-realtime


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR allow the user to get the JWT Secret and expiry inside postgres using `current_setting('app.settings.jwt_secret')` and `current_setting('app.settings.jwt_expiry')`

## What is the current behavior?

Supabase managed instances can get the JWT_SECRET through executing the query `current_setting('app.settings.jwt_secret')` , But Self-hosted instances can't do that because the these values are not passed in the application setting for postgrest.

## What is the new behavior?

Passing the Values as environment variables to postgrest services as mentioned [here](https://postgrest.org/en/stable/references/configuration.html#app-settings) align the behavior of self-hosted services with supabase managed instances.

