### PR TITLE
Fix Code Hike components not rendering correctly inside <details> tag on Firefox

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@algolia/autocomplete-js": "^1.7.2",
     "@algolia/autocomplete-plugin-recent-searches": "^1.7.2",
-    "@code-hike/mdx": "^0.8.3",
+    "@code-hike/mdx": "^0.9.0",
     "@docsearch/react": "^3.3.0",
     "@mdx-js/loader": "^2.1.5",
     "@mdx-js/react": "^2.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
       "dependencies": {
         "@algolia/autocomplete-js": "^1.7.2",
         "@algolia/autocomplete-plugin-recent-searches": "^1.7.2",
-        "@code-hike/mdx": "^0.8.3",
+        "@code-hike/mdx": "^0.9.0",
         "@docsearch/react": "^3.3.0",
         "@mdx-js/loader": "^2.1.5",
         "@mdx-js/react": "^2.1.5",
@@ -122,6 +122,30 @@
         "typescript": "^5.0.4"
       }
     },
+    "apps/docs/node_modules/@code-hike/lighter": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@code-hike/lighter/-/lighter-0.7.0.tgz",
+      "integrity": "sha512-64O07rIORKQLB+5T/GKAmKcD9sC0N9yHFJXa0Hs+0Aee1G+I4bSXxTccuDFP6c/G/3h5Pk7yv7PoX9/SpzaeiQ==",
+      "funding": {
+        "url": "https://github.com/code-hike/lighter?sponsor=1"
+      }
+    },
+    "apps/docs/node_modules/@code-hike/mdx": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@code-hike/mdx/-/mdx-0.9.0.tgz",
+      "integrity": "sha512-0wg68ZCjVWAkWT4gBUZJ8Mwktjen/XeWyqBQCrhA2IZSbZZnMYsEI6JJEFb/nZoNI3comB3JdxPLykZRq3qT2A==",
+      "dependencies": {
+        "@code-hike/lighter": "0.7.0",
+        "node-fetch": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/code-hike"
+      },
+      "peerDependencies": {
+        "react": "^16.8.3 || ^17 || ^18"
+      }
+    },
     "apps/docs/node_modules/@mdx-js/react": {
       "version": "2.3.0",
       "license": "MIT",
@@ -135,6 +159,26 @@
       },
       "peerDependencies": {
         "react": ">=16"
+      }
+    },
+    "apps/docs/node_modules/@next/mdx": {
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/mdx/-/mdx-13.4.19.tgz",
+      "integrity": "sha512-EaWA30YxAqFcyQYNxCoL9/TCcZP1Nk6pvW0vf1M54qDAkAGiloWQqyttVKVbRz+qOYk92he6mBB4ej/7pmEinQ==",
+      "dependencies": {
+        "source-map": "^0.7.0"
+      },
+      "peerDependencies": {
+        "@mdx-js/loader": ">=0.15.0",
+        "@mdx-js/react": ">=0.15.0"
+      },
+      "peerDependenciesMeta": {
+        "@mdx-js/loader": {
+          "optional": true
+        },
+        "@mdx-js/react": {
+          "optional": true
+        }
       }
     },
     "apps/docs/node_modules/@types/yargs": {
@@ -4186,7 +4230,8 @@
     },
     "node_modules/@mdx-js/loader": {
       "version": "2.3.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@mdx-js/loader/-/loader-2.3.0.tgz",
+      "integrity": "sha512-IqsscXh7Q3Rzb+f5DXYk0HU71PK+WuFsEhf+mSV3fOhpLcEpgsHvTQ2h0T6TlZ5gHOaBeFjkXwB52by7ypMyNg==",
       "dependencies": {
         "@mdx-js/mdx": "^2.0.0",
         "source-map": "^0.7.0"
@@ -40944,13 +40989,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "packages/config/node_modules/semver": {
-      "version": "6.3.0",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "packages/config/node_modules/slash": {
       "version": "4.0.0",
       "license": "MIT",
@@ -43089,13 +43127,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "studio/node_modules/semver": {
-      "version": "6.3.0",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "studio/node_modules/slash": {

--- a/package.json
+++ b/package.json
@@ -33,11 +33,6 @@
     "perf:meta": "ab -t 5 -c 20 -T application/json http://localhost:5555/tables",
     "generate:types": "supabase gen types typescript --local > ./supabase/functions/common/database-types.ts"
   },
-  "overrides": {
-    "@code-hike/mdx": {
-      "@code-hike/lighter": "^0.6.7"
-    }
-  },
   "devDependencies": {
     "@types/json-stringify-safe": "^5.0.0",
     "aws-sdk": "^2.1354.0",

--- a/packages/config/code-hike.scss
+++ b/packages/config/code-hike.scss
@@ -66,9 +66,8 @@
   color: #fafafa;
   overflow: hidden;
   padding: 0 8px 8px;
-  font-family: 'Courier New', Courier, monospace;
-  //   font-family: Ubuntu, Droid Sans, -apple-system, BlinkMacSystemFont, Segoe WPC, Segoe UI,
-  // sans-serif;
+  font-family: Ubuntu, Droid Sans, -apple-system, BlinkMacSystemFont, Segoe WPC, Segoe UI,
+    sans-serif;
 }
 .ch-terminal-container .ch-frame-content {
   background-color: inherit;
@@ -77,7 +76,6 @@
   color: #8fa2db;
   -webkit-user-select: none;
   -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
 }
 .ch-terminal-content {
@@ -89,13 +87,13 @@
 .ch-code-line-number {
   -webkit-user-select: none;
   -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   text-align: right;
   display: inline-block;
   box-sizing: border-box;
   padding-right: 1.5ch;
   font-variant-numeric: tabular-nums;
+  color: var(--ch-t-editorLineNumber-foreground);
 }
 .ch-code-scroll-parent {
   display: block;
@@ -111,20 +109,47 @@
   border: none;
 }
 .ch-code-scroll-parent ::-moz-selection {
-  background-color: var(--ch-selection-background);
+  background-color: var(--ch-t-editor-selectionBackground);
   color: inherit;
 }
 .ch-code-scroll-parent ::selection {
-  background-color: var(--ch-selection-background);
+  background-color: var(--ch-t-editor-selectionBackground);
   color: inherit;
 }
 .ch-code-button {
+  -webkit-appearance: button;
+  background-color: transparent;
+  background-image: none;
+  cursor: pointer;
+  color: inherit;
+  margin: 0;
+  padding: 0;
+  border: none;
+  font-size: inherit;
   position: absolute;
   top: 10px;
   right: 10px;
   width: 1.1em;
   height: 1.1em;
-  cursor: pointer;
+}
+.ch-code-button:focus-visible {
+  outline-color: currentColor;
+}
+.ch-code-wrapper {
+  background-color: var(--ch-t-background);
+  color: var(--ch-t-foreground);
+  color-scheme: var(--ch-t-colorScheme);
+  margin: 0;
+  padding: 0;
+  position: relative;
+  white-space: pre;
+  box-sizing: content-box;
+}
+.ch-code-wrapper[data-ch-measured='false'] {
+  overflow: auto;
+}
+.ch-code-wrapper[data-ch-measured='false'] > * {
+  opacity: 0;
 }
 .ch-no-scroll {
   overflow: hidden;
@@ -136,20 +161,28 @@
   border: 0;
   background-color: transparent;
 }
-.ch-expand-dialog::-webkit-backdrop {
-  background-color: rgba(0, 0, 0, 0.8);
-}
 .ch-expand-dialog::backdrop {
   background-color: rgba(0, 0, 0, 0.8);
 }
 .ch-expand-close {
+  -webkit-appearance: button;
+  background-color: transparent;
+  background-image: none;
+  cursor: pointer;
+  color: inherit;
+  margin: 0;
+  padding: 0;
+  border: none;
+  font-size: inherit;
   position: absolute;
   top: 10px;
   right: 10px;
-  cursor: pointer;
   color: #fff;
   width: 26px;
   height: 26px;
+}
+.ch-expand-close:focus-visible {
+  outline-color: currentColor;
 }
 .ch-expand-dialog-content {
   color: #fff;
@@ -158,18 +191,26 @@
   overflow: hidden;
   border-radius: 8px;
   border: 1px solid;
+  border-color: var(--ch-t-sideBar-border);
 }
 .ch-code-browser {
+  color: var(--ch-t-editor-foreground);
   display: flex;
   height: 100%;
-  //   font-family: 'Courier New', Courier, monospace;
-  //   font-family: Ubuntu, Droid Sans, -apple-system;
+  font-family: Ubuntu, Droid Sans, -apple-system, BlinkMacSystemFont, Segoe WPC, Segoe UI,
+    sans-serif;
 }
 .ch-code-browser-sidebar {
-  border-right: 1px solid;
   min-width: 100px;
   padding: 1em 0;
   font-size: 0.95rem;
+  border-left-color: var(--ch-t-sideBar-border);
+  border-bottom-color: var(--ch-t-sideBar-border);
+  border-right: 1px solid;
+  border-right-color: var(--ch-t-sideBar-border);
+  border-top-color: var(--ch-t-sideBar-border);
+  background: var(--ch-t-sideBar-background);
+  color: var(--ch-t-sideBar-foreground);
 }
 .ch-code-browser-content {
   overflow: auto;
@@ -182,13 +223,16 @@
   line-height: 1.2rem;
   letter-spacing: 0;
   position: relative;
+  background: var(--ch-t-background);
+  color: var(--ch-t-foreground);
+  color-scheme: var(--ch-t-colorScheme);
 }
 .ch-code-browser-content ::-moz-selection {
-  background-color: var(--ch-selection-background);
+  background-color: var(--ch-t-editor-selectionBackground);
   color: inherit;
 }
 .ch-code-browser-content ::selection {
-  background-color: var(--ch-selection-background);
+  background-color: var(--ch-t-editor-selectionBackground);
   color: inherit;
 }
 .ch-code-browser-sidebar-file,
@@ -198,23 +242,36 @@
 .ch-code-browser-sidebar-file {
   cursor: pointer;
 }
+.ch-code-browser-sidebar-file[data-selected='true'] {
+  background: var(--ch-t-list-activeSelectionBackground);
+  color: var(--ch-t-list-activeSelectionForeground);
+}
 .ch-code-browser-sidebar-file:hover {
-  background-color: var(--ch-hover-background);
-  color: var(--ch-hover-foreground);
+  background-color: var(--ch-t-list-hoverBackground);
+  color: var(--ch-t-list-hoverForeground);
 }
 .ch-code-browser-button {
+  -webkit-appearance: button;
+  background-color: transparent;
+  background-image: none;
+  cursor: pointer;
+  color: inherit;
+  margin: 0;
+  padding: 0;
+  border: none;
+  font-size: inherit;
   width: 1.5em;
   height: 1.5em;
-  cursor: pointer;
   min-width: 1.5em;
   min-height: 1.5em;
   position: absolute;
   right: 0.8em;
   top: 0.8em;
 }
+.ch-code-browser-button:focus-visible {
+  outline-color: currentColor;
+}
 .ch-editor-tab {
-  border-right: 1px solid #252526;
-  min-width: -webkit-fit-content;
   min-width: -moz-fit-content;
   min-width: fit-content;
   flex-shrink: 1;
@@ -226,17 +283,20 @@
   box-sizing: border-box;
   padding-left: 15px;
   padding-right: 15px;
-  background-color: #2d2d2d;
-  color: hsla(0, 0%, 100%, 0.5);
   min-width: 0;
+  background: var(--ch-t-tab-inactiveBackground);
+  color: var(--ch-t-tab-inactiveForeground);
+  border-right: 1px solid #252526;
+  border-right-color: var(--ch-t-tab-border);
   border-bottom: 1px solid;
+  border-bottom-color: var(--ch-t-tab-inactiveBackground);
 }
-.ch-editor-tab-active {
-  background-color: red;
-  color: #fff;
+.ch-editor-tab[data-active='true'] {
+  background: var(--ch-t-tab-activeBackground);
+  color: var(--ch-t-tab-activeForeground);
+  border-bottom-color: var(--ch-t-tab-activeBorder);
   min-width: unset;
 }
-
 .ch-editor-tab > div {
   margin-top: auto;
   margin-bottom: auto;
@@ -244,6 +304,14 @@
   line-height: 1.4em;
   text-overflow: ellipsis;
   overflow: hidden;
+}
+.ch-editor-group-border {
+  position: absolute;
+  top: 0;
+  height: 1px;
+  width: 100%;
+  z-index: 1;
+  background: var(--ch-t-editorGroup-border);
 }
 .ch-editor-frame {
   display: flex;
@@ -254,12 +322,14 @@
     sans-serif;
   -moz-column-break-inside: avoid;
   break-inside: avoid;
-  --ch-title-bar-height: 40px;
+  --ch-title-bar-height: 30px;
   height: 100%;
-  //   border: 1px solid red;
+  background: var(--ch-t-editor-background);
 }
 .ch-editor-frame .ch-frame-title-bar {
   background: none;
+  color: var(--ch-t-icon-foreground);
+  background: var(--ch-t-editorGroupHeader-tabsBackground);
 }
 .ch-editor-terminal {
   position: absolute;
@@ -292,12 +362,22 @@
   margin: 0;
 }
 .ch-editor-button {
+  -webkit-appearance: button;
+  background-color: transparent;
+  background-image: none;
+  cursor: pointer;
+  color: inherit;
+  padding: 0;
+  border: none;
+  font-size: inherit;
   width: 1.5em;
   height: 1.5em;
-  cursor: pointer;
   min-width: 1.5em;
   min-height: 1.5em;
-  margin-right: 0.8em;
+  margin: 0 0.8em 0 0;
+}
+.ch-editor-button:focus-visible {
+  outline-color: currentColor;
 }
 .ch-frame {
   height: 100%;
@@ -360,7 +440,6 @@
   height: 100%;
   display: flex;
   align-items: center;
-  width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
 }
@@ -369,8 +448,7 @@
   flex-shrink: 0;
   height: 1em;
   width: 4.16em;
-  //   display: flex;
-  display: none; // @mildtomato
+  display: none;
 }
 .ch-frame-button {
   width: 1em;
@@ -409,13 +487,15 @@
   height: 1.4em;
   font-size: 1em;
   border-radius: 0.5em;
-  border: none;
   box-shadow: none;
   flex: 1;
   padding: 0 10px;
   color: #544;
   min-width: 5px;
   width: 5px;
+  background: var(--ch-t-input-background);
+  color: var(--ch-t-input-foreground);
+  border: 1px solid var(--ch-t-input-border);
 }
 .ch-browser-button {
   margin: 0 1em;
@@ -428,7 +508,7 @@
   margin-left: 0;
 }
 .ch-browser-open-button {
-  color: inherit;
+  color: var(--ch-t-icon-foreground);
 }
 .ch-browser-open-icon {
   display: block;
@@ -452,13 +532,12 @@
   border: 1px solid #e3e3e3;
 }
 .ch-spotlight-tab:hover {
-  border-color: red;
+  border-color: #222;
 }
 .ch-spotlight-tab[data-selected] {
-  border-color: red;
+  border-color: #0070f3;
 }
 .ch-spotlight-sticker {
-  position: -webkit-sticky;
   position: sticky;
   top: 10vh;
   display: flex;
@@ -518,7 +597,6 @@
   margin-bottom: 0;
 }
 .ch-scrollycoding-sticker {
-  position: -webkit-sticky;
   position: sticky;
   top: 10vh;
   display: flex;
@@ -598,12 +676,10 @@
 .ch-preview {
   border-radius: 6px;
   overflow: hidden;
-  height: -webkit-max-content;
   height: -moz-max-content;
   height: max-content;
   // box-shadow: 0 13px 27px -5px rgba(50, 50, 93, 0.25), 0 8px 16px -8px rgba(0, 0, 0, 0.3),
   //   0 -6px 16px -6px rgba(0, 0, 0, 0.025);
-  -webkit-print-color-adjust: exact;
   print-color-adjust: exact;
 }
 .ch-codeblock > *,
@@ -617,13 +693,19 @@
 .ch-codegroup {
   margin-top: 1.25em;
   margin-bottom: 1.25em;
-  border: 1px solid var(--colors-scale5); // @mildtomato
 }
 .ch-inline-code > code {
   padding: 0.2em 0.15em;
   margin: 0.1em -0.05em;
   border-radius: 0.25em;
   font-size: 0.9rem;
+  color: var(--ch-t-foreground);
+  background: var(--ch-t-lighter-inlineBackground);
+}
+.ch-inline-code .ch-section-link,
+.ch-inline-code .ch-section-link * {
+  -webkit-text-decoration-color: var(--ch-t-foreground);
+  text-decoration-color: var(--ch-t-foreground);
 }
 .ch-section-link,
 .ch-section-link * {
@@ -631,8 +713,8 @@
   -webkit-text-decoration-style: dotted;
   text-decoration-style: dotted;
   text-decoration-thickness: 1px;
-  -webkit-text-decoration-color: var(--ch-code-foreground, currentColor);
-  text-decoration-color: var(--ch-code-foreground, currentColor);
+  -webkit-text-decoration-color: currentColor;
+  text-decoration-color: currentColor;
 }
 .ch-section-link[data-active='true'] {
   background-color: rgba(186, 230, 253, 0.4);
@@ -646,17 +728,49 @@
   padding: 0.2rem 0.15rem 0.1rem;
   margin: 0 -0.15rem;
 }
+.ch-code-inline-mark,
+.ch-code-multiline-mark {
+  background: var(--ch-t-editor-rangeHighlightBackground);
+}
 .ch-code-multiline-mark-border {
-  background: var(--colors-scale12) !important;
   width: 3px;
   height: 100%;
   position: absolute;
   left: 0;
+  background: var(--ch-t-editor-infoForeground);
 }
-.ch-code-inline-link,
+.ch-code-multiline-mark .ch-code-button {
+  font-size: 1.2em;
+  position: absolute;
+  right: 10px;
+  top: 1px;
+  display: none;
+}
+.ch-code-inline-link {
+  text-decoration: underline;
+  -webkit-text-decoration-style: dotted;
+  text-decoration-style: dotted;
+  color: inherit;
+}
 .ch-code-link :not(span) > span {
   text-decoration: underline;
   -webkit-text-decoration-style: dotted;
   text-decoration-style: dotted;
   color: inherit;
+}
+.ch-code-box-annotation {
+  outline: 2px solid var(--ch-t-editor-infoForeground);
+}
+.ch-code-label-annotation:hover {
+  background: var(--ch-t-editor-lineHighlightBackground);
+}
+.ch-code-label-annotation:hover .ch-code-label-annotation-text {
+  display: block;
+}
+.ch-code-label-annotation-text {
+  position: absolute;
+  right: 0;
+  padding-right: 16px;
+  opacity: 0.7;
+  display: none;
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Fixes #14850 

The original issue was that Code Hike components were not rendering correctly inside the <detail> tag on Firefox. This was addressed by the Code Hike team in their [v0.9.0 release](https://github.com/code-hike/codehike/pull/373).

After upgrading to v0.9.0 which solved the above issue. But the text started to overlap each other, below is the screenshot for your reference.

![Screenshot from 2023-08-22 14-02-27](https://github.com/supabase/supabase/assets/71846487/8a88bcb7-e2b3-44b8-95da-c6cb832a237e)


## What is the new behavior?

To fix the overlapping issue, I copied Code Hike's CSS properties and made some changes like removing the `box-shadow` property in `code-hike.scss`. Below is the screenshot using Firefox for the same.

![Screenshot from 2023-08-22 14-09-57](https://github.com/supabase/supabase/assets/71846487/6624b676-73d6-41c9-9caa-608b3e1db1bc)

I check the new changes on other pages as well which are working as required:
http://localhost:3001/docs/guides/getting-started/tutorials/with-kotlin
http://localhost:3001/docs/guides/getting-started/tutorials/with-ionic-react
http://localhost:3001/docs/guides/getting-started/tutorials/with-refine

Tested on Browser: Firefox and Chrome