### PR TITLE
feat: bump gotrue-js to 2.48.0 which fixes race condition with visibility callback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14128,6 +14128,36 @@
         "cross-fetch": "^3.1.5"
       }
     },
+    "node_modules/@supabase/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-rEHQaDVzxLZMCK3p+JW2nzEsK4AJpOQhetppaqAzrFum0Ub8wcnoM/8f1dWRZSulY5fRDP6rJaWT/8X3VleCzg==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/@supabase/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/@supabase/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/@supabase/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/@supabase/postgres-meta": {
       "version": "0.64.6",
       "dev": true,
@@ -40753,7 +40783,7 @@
       "license": "MIT",
       "dependencies": {
         "@headlessui/react": "^1.7.14",
-        "@supabase/gotrue-js": "^2.47.0",
+        "@supabase/gotrue-js": "^2.48.0",
         "@supabase/ui": "^0.37.0-alpha.50",
         "@types/react": "^17.0.39",
         "react-use": "^17.4.0"
@@ -40763,6 +40793,14 @@
         "config": "*",
         "tsconfig": "*",
         "typescript": "^5.0.4"
+      }
+    },
+    "packages/common/node_modules/@supabase/gotrue-js": {
+      "version": "2.48.0",
+      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.48.0.tgz",
+      "integrity": "sha512-+6g5aFL6+iaZC6mFVpRLauSkU5MrQ52QZA1TlY0/evvz9Rmhqc315tIeUfUK87ZLeX7sOL6XYVGkI6ZxgeyAUA==",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.13"
       }
     },
     "packages/common/node_modules/@types/react": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14121,11 +14121,11 @@
       }
     },
     "node_modules/@supabase/gotrue-js": {
-      "version": "2.47.0",
-      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.47.0.tgz",
-      "integrity": "sha512-3e34/vsKH/DoSZCpB85UZpFWSJ2p4GRUUlqgAgeTPagPlx4xS+Nc5v7g7ic7vp3gK0J5PsYVCn9Qu2JQUp4vXg==",
+      "version": "2.48.0",
+      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.48.0.tgz",
+      "integrity": "sha512-+6g5aFL6+iaZC6mFVpRLauSkU5MrQ52QZA1TlY0/evvz9Rmhqc315tIeUfUK87ZLeX7sOL6XYVGkI6ZxgeyAUA==",
       "dependencies": {
-        "cross-fetch": "^3.1.5"
+        "@supabase/node-fetch": "^2.6.13"
       }
     },
     "node_modules/@supabase/node-fetch": {
@@ -40793,14 +40793,6 @@
         "config": "*",
         "tsconfig": "*",
         "typescript": "^5.0.4"
-      }
-    },
-    "packages/common/node_modules/@supabase/gotrue-js": {
-      "version": "2.48.0",
-      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.48.0.tgz",
-      "integrity": "sha512-+6g5aFL6+iaZC6mFVpRLauSkU5MrQ52QZA1TlY0/evvz9Rmhqc315tIeUfUK87ZLeX7sOL6XYVGkI6ZxgeyAUA==",
-      "dependencies": {
-        "@supabase/node-fetch": "^2.6.13"
       }
     },
     "packages/common/node_modules/@types/react": {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "dependencies": {
     "@headlessui/react": "^1.7.14",
-    "@supabase/gotrue-js": "^2.47.0",
+    "@supabase/gotrue-js": "^2.48.0",
     "@supabase/ui": "^0.37.0-alpha.50",
     "@types/react": "^17.0.39",
     "react-use": "^17.4.0"


### PR DESCRIPTION
Bumps gotrue-js to v2.48.0 which addresses a race condition that occurs when the computer comes back from sleep / locked state, with multiple windows open, which all try to refresh the token at once.