### PR TITLE
Fix/infra monitoring queries negative value

### DIFF
--- a/studio/components/to-be-cleaned/DateRangePicker.tsx
+++ b/studio/components/to-be-cleaned/DateRangePicker.tsx
@@ -110,7 +110,7 @@ const DateRangePicker = ({
             date: today,
             time_period: 'today',
           },
-          interval: '5m',
+          interval: '4m',
         })
         break
       case '1h':
@@ -123,7 +123,7 @@ const DateRangePicker = ({
             date: today,
             time_period: 'today',
           },
-          interval: '5m',
+          interval: '2m',
         })
         break
       case '7d':


### PR DESCRIPTION
This PR adjusts the infra monitoring queries to correctly apply averaging based the collected intervals.

Uses `2m` and `4m` intervals.

Premerge checklist:
- merge in accompanying infra PR https://github.com/supabase/infrastructure/pull/14291