### PR TITLE
fix: update JWT regex for Apple secret key validation

### DIFF
--- a/studio/stores/authConfig/schema/AuthProviders/AuthProvidersFormValidation.tsx
+++ b/studio/stores/authConfig/schema/AuthProviders/AuthProvidersFormValidation.tsx
@@ -404,7 +404,7 @@ const EXTERNAL_PROVIDER_APPLE = {
         then: (schema) =>
           schema
             .required('Secret key is required when using the OAuth flow.')
-            .matches(/^[a-z0-9_-]+([.][a-z0-9_-]+){2}$/i, 'Secret key should be a JWT.')
+            .matches(/^[a-zA-Z0-9_-]+([.][a-zA-Z0-9_-]+){2}$/i, 'Secret key should be a JWT.')
             .test({
               message: 'Secret key is not a correctly generated JWT.',
               test: (value?: string): boolean => {

--- a/studio/stores/authConfig/schema/AuthProviders/AuthProvidersFormValidation.tsx
+++ b/studio/stores/authConfig/schema/AuthProviders/AuthProvidersFormValidation.tsx
@@ -404,7 +404,7 @@ const EXTERNAL_PROVIDER_APPLE = {
         then: (schema) =>
           schema
             .required('Secret key is required when using the OAuth flow.')
-            .matches(/^[a-zA-Z0-9_-]+([.][a-zA-Z0-9_-]+){2}$/i, 'Secret key should be a JWT.')
+            .matches(/^[a-z0-9_-]+([.][a-z0-9_-]+){2}$/i, 'Secret key should be a JWT.')
             .test({
               message: 'Secret key is not a correctly generated JWT.',
               test: (value?: string): boolean => {
@@ -420,7 +420,6 @@ const EXTERNAL_PROVIDER_APPLE = {
                     typeof body === 'object' &&
                     header &&
                     body &&
-                    header.typ === 'JWT' &&
                     header.alg === 'ES256' &&
                     body.aud === 'https://appleid.apple.com'
                   )


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently the Supabase dashboard doesn't allow secret key generated by Apple to be saved. By investigating, I discovered that the JWT does not contain a `typ` header. 

<img width="1225" alt="Screenshot 2023-08-24 at 15 46 12" src="https://github.com/supabase/supabase/assets/18113850/62f1228e-05bc-4676-a2e8-98e9188fb2e9">

This PR updates the validation logic to allow JWT without `typ` header to be saved. 