### PR TITLE
fix(billing): storage size should be avg not max

### DIFF
--- a/studio/components/interfaces/BillingV2/Usage/Usage.constants.tsx
+++ b/studio/components/interfaces/BillingV2/Usage/Usage.constants.tsx
@@ -229,7 +229,7 @@ export const USAGE_CATEGORIES: CategoryMeta[] = [
         key: 'storage_size',
         attribute: 'total_storage_size_bytes',
         name: 'Storage Size',
-        chartPrefix: 'Max ',
+        chartPrefix: 'Average ',
         unit: 'bytes',
         description:
           'Sum of all objects in your storage buckets.\nBilling is based on the average daily size in GB throughout your billing period.',

--- a/studio/components/interfaces/Organization/Usage/Usage.constants.tsx
+++ b/studio/components/interfaces/Organization/Usage/Usage.constants.tsx
@@ -134,7 +134,7 @@ export const USAGE_CATEGORIES: CategoryMeta[] = [
         key: PricingMetric.STORAGE_SIZE,
         attributes: [{ key: PricingMetric.STORAGE_SIZE.toLowerCase(), color: 'white' }],
         name: 'Storage Size',
-        chartPrefix: 'Max',
+        chartPrefix: 'Average',
         unit: 'bytes',
         description:
           'Sum of all objects in your storage buckets.\nBilling is based on the average daily size in GB throughout your billing period.',


### PR DESCRIPTION
We falsely displayed "Max in period", whereas the storage size billing is based on the average size (correct in backend)