### PR TITLE
fix(studio): jsonb parse error in spreadsheet import

### DIFF
--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadsheetImport.utils.ts
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadsheetImport.utils.ts
@@ -9,6 +9,7 @@ const CHUNK_SIZE = 1024 * 1024 * 0.25 // 0.25MB
 export const parseSpreadsheetText: any = (text: string) => {
   const columnTypeMap: any = {}
   let previewRows: any[] = []
+  text = text.replaceAll(/(?<=,|^)[{[].+[}\]](?=,|\n|$)/g, (res) => `"${res.replaceAll('"', '""')}"`)
   return new Promise((resolve) => {
     Papa.parse(text, {
       header: true,


### PR DESCRIPTION
## What kind of change does this PR introduce?

When importing data from spreadsheet, jsonb values now aren't required to be properly formatted (quoted and quote-escaped). Fixes [#15552](https://github.com/supabase/supabase/issues/15552).

## What is the current behavior?
Currently, `abc123,offline,[ { "age": 23, "name": "Jane" }, { "age": 25, "name": "John" } ]` will be read as `abc123`, `offline`, and `[ { "age": 23` because there is no quotes surrounding the json object. This results in the csv parser parsing 6 columns instead of 3, hence the error message. 

To fix this, we can either ask the user to format their data to satisfy the parser, which would look like `abc123,offline,"[ { ""age"": 23, ""name"": ""Jane"" }, { ""age"": 25, ""name"": ""John"" } ]"`, or support the format as seen in the issue. Looking for thoughts on this issue!

## What is the new behavior?
### Current:
![image](https://github.com/supabase/supabase/assets/51780559/12babb87-cf6a-4b1d-9af1-a97f64adb3d8)
### New:
![image](https://github.com/supabase/supabase/assets/51780559/2bba2b36-01c4-4d89-951b-c845ce27bdf7)


## Additional context

Add any other context or screenshots.
