### PR TITLE
Capitalize Supabase and GitHub on homepage

### DIFF
--- a/apps/www/components/BuiltWithSupabase/index.tsx
+++ b/apps/www/components/BuiltWithSupabase/index.tsx
@@ -13,7 +13,7 @@ const BuiltExamples = () => {
     <SectionContainer className="xl:pt-32">
       <div className="text-center">
         <h3 className="h2">What can you build with Supabase?</h3>
-        <p className="p">There are many example apps and starter projects to get you started!</p>
+        <p className="p">There are many example apps and starter projects to get you started.</p>
         <div className="flex justify-center gap-2 py-4">
           <Link href="/docs/guides/examples" as="/docs/guides/examples" passHref>
             <a>

--- a/apps/www/components/BuiltWithSupabase/index.tsx
+++ b/apps/www/components/BuiltWithSupabase/index.tsx
@@ -12,8 +12,8 @@ const BuiltExamples = () => {
   return (
     <SectionContainer className="xl:pt-32">
       <div className="text-center">
-        <h3 className="h2">What can you build with supabase?</h3>
-        <p className="p">There are many example apps and starter projects to get going</p>
+        <h3 className="h2">What can you build with Supabase?</h3>
+        <p className="p">There are many example apps and starter projects to get you started!</p>
         <div className="flex justify-center gap-2 py-4">
           <Link href="/docs/guides/examples" as="/docs/guides/examples" passHref>
             <a>
@@ -29,7 +29,7 @@ const BuiltExamples = () => {
           >
             <a>
               <Button type="default" icon={<IconGitHub />} size="small">
-                Official github library
+                Official GitHub library
               </Button>
             </a>
           </Link>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Minor capitalization fix

## What is the current behavior?

<img width="534" alt="image" src="https://github.com/supabase/supabase/assets/1454517/2bb4f4b3-dd05-44a5-a96a-097dde91b270">

## What is the new behavior?

<img width="549" alt="image" src="https://github.com/supabase/supabase/assets/1454517/5c52c6d9-8630-4c8e-b442-478c9cc44786">

