### PR TITLE
fixed

### DIFF
--- a/studio/pages/_document.tsx
+++ b/studio/pages/_document.tsx
@@ -9,7 +9,7 @@ class MyDocument extends Document {
 
   render() {
     return (
-      <Html lang="en">
+      <Html lang="en" className="dark">
         <Head>
           {/* Workaround for https://github.com/suren-atoyan/monaco-react/issues/272 */}
           <link


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixing the background color so it will show dark all the way even on mobile when you scroll down.

## What is the current behavior?

GIVEN You are logged in to your dashboard 
AND you have dark mode selected
WHEN you scroll down from to the bottom of the page
THEN you see white background (which is out of the viewport)

https://imgtr.ee/image/IMG-1C7C6A538103-1.BK7Js

## What is the new behavior?

The page has the background-color all the way down.

## Additional context
n/a
