### PR TITLE
feat: Add text area for integration description in the oAuth apps sidebar

### DIFF
--- a/packages/ui/index.tsx
+++ b/packages/ui/index.tsx
@@ -164,6 +164,8 @@ export {
 
 export { ScrollArea, ScrollBar } from './src/components/shadcn/ui/scroll-area'
 
+export { Textarea } from './src/components/shadcn/ui/textarea'
+
 // links
 
 export * from './src/components/TextLink'

--- a/studio/components/interfaces/Organization/OAuthApps/PublishAppSidePanel/droppableTextArea.tsx
+++ b/studio/components/interfaces/Organization/OAuthApps/PublishAppSidePanel/droppableTextArea.tsx
@@ -1,4 +1,5 @@
 import { useParams } from 'common'
+import { uuidv4 } from 'lib/helpers'
 import { uploadAttachment } from 'lib/upload'
 import { Dispatch, DragEventHandler, SetStateAction, useState } from 'react'
 import { cn, Textarea } from 'ui'
@@ -61,13 +62,15 @@ export const DroppableTextArea = ({ value, onChange }: DroppableTextAreaProps) =
       const files = await getFilesDataTransferItems(items)
 
       files.forEach((file) => {
+        const generatedId = uuidv4()
         onChange((v) => {
           return v + `\n![Uploading ${file.name}…]()\n`
         })
-        uploadAttachment('temp-for-testing-integrations', `${slug}/${file.name}`, file).then(
+
+        uploadAttachment('temp-for-testing-integrations', `${slug}/${generatedId}`, file).then(
           (url) => {
             onChange((v) => {
-              return v.replace(`![Uploading ${file.name}…]()`, `![${file.name}(${url})`)
+              return v.replace(`![Uploading ${file.name}…]()`, `![${file.name}](${url})`)
             })
           }
         )

--- a/studio/components/interfaces/Organization/OAuthApps/PublishAppSidePanel/droppableTextArea.tsx
+++ b/studio/components/interfaces/Organization/OAuthApps/PublishAppSidePanel/droppableTextArea.tsx
@@ -1,0 +1,117 @@
+import { useParams } from 'common'
+import { uploadAttachment } from 'lib/upload'
+import { Dispatch, DragEventHandler, SetStateAction, useState } from 'react'
+import { cn, Textarea } from 'ui'
+
+const VALID_FILE_EXTENSIONS = ['image/jpeg', 'image/png']
+
+interface DroppableTextAreaProps {
+  value: string
+  onChange: Dispatch<SetStateAction<string>>
+}
+
+export const DroppableTextArea = ({ value, onChange }: DroppableTextAreaProps) => {
+  const { slug } = useParams()
+  const [areFilesValid, setAreFilesValid] = useState<'none' | 'valid' | 'invalid'>('none')
+
+  const onDragOver = (event: any) => {
+    if (event) {
+      event.stopPropagation()
+      event.preventDefault()
+    }
+  }
+
+  const getFile = async (fileEntry: FileSystemFileEntry) => {
+    try {
+      return await new Promise<File>((resolve, reject) => fileEntry.file(resolve, reject))
+    } catch (err) {
+      console.error('getFile error:', err)
+      return undefined
+    }
+  }
+
+  // https://stackoverflow.com/a/53058574
+  const getFilesDataTransferItems = async (items: DataTransferItemList) => {
+    const files = []
+    const queue: FileSystemEntry[] = []
+    for (const item of items) {
+      const entry = item.webkitGetAsEntry()
+      if (entry) {
+        queue.push(entry)
+      }
+    }
+    while (queue.length > 0) {
+      const entry = queue.shift()
+      if (entry && entry.isFile) {
+        const file = await getFile(entry as FileSystemFileEntry)
+        if (file !== undefined) {
+          // file.path = entry.fullPath.slice(1)
+          files.push(file)
+        }
+      }
+    }
+    return files
+  }
+
+  const onDrop: DragEventHandler<HTMLTextAreaElement> = async (event) => {
+    onDragOver(event)
+
+    if (areFilesValid === 'valid') {
+      const items = (event as any).target.files || (event as any).dataTransfer.items
+      const files = await getFilesDataTransferItems(items)
+
+      files.forEach((file) => {
+        onChange((v) => {
+          return v + `\n![Uploading ${file.name}…]()\n`
+        })
+        uploadAttachment('temp-for-testing-integrations', `${slug}/${file.name}`, file).then(
+          (url) => {
+            onChange((v) => {
+              return v.replace(`![Uploading ${file.name}…]()`, `![${file.name}(${url})`)
+            })
+          }
+        )
+      })
+      // onChange(description)
+    }
+  }
+
+  const checkFiles: DragEventHandler<HTMLTextAreaElement> = (event) => {
+    const items = event.dataTransfer.items || []
+    if (items.length === 0) {
+      setAreFilesValid('none')
+    }
+    for (const item of items) {
+      if (!VALID_FILE_EXTENSIONS.includes(item.type)) {
+        setAreFilesValid('invalid')
+        return
+      }
+    }
+    setAreFilesValid('valid')
+  }
+
+  return (
+    <div>
+      <Textarea
+        onDragEnter={(e) => checkFiles(e)}
+        onDragExit={() => setAreFilesValid('none')}
+        onDragOver={onDragOver}
+        onDrop={onDrop}
+        className={cn(
+          areFilesValid === 'valid'
+            ? 'border-green-700'
+            : areFilesValid === 'invalid'
+            ? 'border-red-700'
+            : ''
+        )}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      />
+      <div className="px-1 pt-2">
+        <span className="text-sm text-scale-1000">
+          Attach files by dragging &amp; dropping them.
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/studio/components/interfaces/Organization/OAuthApps/PublishAppSidePanel/index.tsx
+++ b/studio/components/interfaces/Organization/OAuthApps/PublishAppSidePanel/index.tsx
@@ -2,6 +2,7 @@ import clsx from 'clsx'
 import { ChangeEvent, useEffect, useRef, useState } from 'react'
 
 import { useParams } from 'common'
+import { Markdown } from 'components/interfaces/Markdown'
 import {
   OAuthAppCreateResponse,
   useOAuthAppCreateMutation,
@@ -10,9 +11,21 @@ import { useOAuthAppUpdateMutation } from 'data/oauth/oauth-app-update-mutation'
 import { OAuthApp } from 'data/oauth/oauth-apps-query'
 import { useStore } from 'hooks'
 import { isValidHttpUrl, uuidv4 } from 'lib/helpers'
-import { Badge, Button, Dropdown, Form, IconEdit, IconUpload, Input, Modal, SidePanel } from 'ui'
 import { uploadAttachment } from 'lib/upload'
-import AuthorizeRequesterDetails from './AuthorizeRequesterDetails'
+import {
+  Badge,
+  Button,
+  Dropdown,
+  Form,
+  IconEdit,
+  IconUpload,
+  Input,
+  Modal,
+  SidePanel,
+  Tabs,
+} from 'ui'
+import AuthorizeRequesterDetails from '../AuthorizeRequesterDetails'
+import { DroppableTextArea } from './droppableTextArea'
 
 export interface PublishAppSidePanelProps {
   visible: boolean
@@ -75,6 +88,7 @@ const PublishAppSidePanel = ({
   const [iconUrl, setIconUrl] = useState<string>()
   const [errors, setErrors] = useState<{ [key: string]: string }>({})
   const [urls, setUrls] = useState<{ id: string; value: string }[]>([{ id: uuidv4(), value: '' }])
+  const [descriptionText, setDescriptionText] = useState('')
 
   useEffect(() => {
     if (visible) {
@@ -111,7 +125,6 @@ const PublishAppSidePanel = ({
   }
 
   const onFileUpload = async (event: ChangeEvent<HTMLInputElement>) => {
-    event.persist()
     const [file] = event.target.files || (event as any).dataTransfer.items
     setIconFile(file)
     setIconUrl(URL.createObjectURL(file))
@@ -321,6 +334,19 @@ const PublishAppSidePanel = ({
                       </div>
                     </SidePanel.Content>
                     <SidePanel.Separator />
+                    <SidePanel.Content className="py-4">
+                      <Tabs type="underlined" size="small">
+                        <Tabs.Panel id="write" label="Write">
+                          <DroppableTextArea
+                            value={descriptionText}
+                            onChange={setDescriptionText}
+                          />
+                        </Tabs.Panel>
+                        <Tabs.Panel id="preview" label="Preview">
+                          <Markdown content={descriptionText} />
+                        </Tabs.Panel>
+                      </Tabs>
+                    </SidePanel.Content>
                   </div>
 
                   <SidePanel.Separator />


### PR DESCRIPTION
This PR adds a text area, which should be used to edit the integration description on the [Integrations page](https://supabase.com/partners/integrations). The text area is similar to the Github PR description, it can be used to edit markdown (with a preview tab) and images can be drag and dropped in the text area which are then automatically uploaded and inserted as an image in the markdown.