### PR TITLE
Only allow numbers in input field

### DIFF
--- a/studio/pages/new/[slug].tsx
+++ b/studio/pages/new/[slug].tsx
@@ -363,7 +363,7 @@ const Wizard: NextPageWithLayout = () => {
                           This is only applicable for local/staging projects
                         </p>
                       }
-                      type="text"
+                      type="number"
                       placeholder="Postgres Version"
                       value={postgresVersion}
                       onChange={(event: any) => setPostgresVersion(event.target.value)}


### PR DESCRIPTION
Currently, this input type is string. 
For some reason, the browser autofills my email address into this field. 
Having to manually remove my email from this field multiple times a day is slowly driving me crazy. 
Changing the input type to number solves this issue. 

![CleanShot 2023-08-25 at 13 13 30@2x](https://github.com/supabase/supabase/assets/105593/f99c2e8a-4c27-4f0c-9d98-ef4f5ea404e1)
