### PR TITLE
Update auth-gotrue.mdx to use signInWithPassword and not signIn

### DIFF
--- a/apps/docs/pages/learn/auth-deep-dive/auth-gotrue.mdx
+++ b/apps/docs/pages/learn/auth-deep-dive/auth-gotrue.mdx
@@ -57,7 +57,7 @@ You'll have to make sure your google app is verified of course in order to reque
 But all the functionality of gotrue-js is also available in supabase-js, which uses gotrue-js internally when you do things like:
 
 ```jsx
-const { user, session, error } = await supabase.auth.signIn({
+const { user, session, error } = await supabase.auth.signInWithPassword({
   email: 'example@email.com',
   password: 'example-password',
 })


### PR DESCRIPTION
## What kind of change does this PR introduce?

Doc Update

## What is the current behavior?

Showed using signIn in the supabase-js call.  

## What is the new behavior?

Shows using signInWithPassword instead.

