### PR TITLE
docs: added FE to list of providers

### DIFF
--- a/apps/docs/pages/guides/auth/auth-smtp.mdx
+++ b/apps/docs/pages/guides/auth/auth-smtp.mdx
@@ -31,6 +31,7 @@ Fill in fields below with the relevant details obtained from your custom SMTP pr
 
 You can use Supabase Auth with any major SMTP provider of your choosing. Some SMTP providers you could consider using are:
 
+- [Forward Email](https://forwardemail.net/en/guides/send-email-with-custom-domain-smtp) (100% open-source)
 - [Twilio SendGrid](https://docs.sendgrid.com/for-developers/sending-email/integrating-with-the-smtp-api)
 - [AWS SES](https://docs.aws.amazon.com/ses/latest/dg/send-email-smtp.html)
 - [Resend](https://resend.com/docs/dashboard/emails/introduction)


### PR DESCRIPTION
[Forward Email](https://forwardemail.net) is 100% open-source and on GitHub at https://github.com/forwardemail - it is the official recommended service of Nodemailer at https://nodemailer.com