### PR TITLE
docs: added link to Resend API docs and Forward Email example

### DIFF
--- a/apps/docs/pages/guides/functions/examples/send-emails.mdx
+++ b/apps/docs/pages/guides/functions/examples/send-emails.mdx
@@ -2,17 +2,17 @@ import Layout from '~/layouts/DefaultGuideLayout'
 
 export const meta = {
   title: 'Sending Emails',
-  description: 'Sending emails from Edge Functions using the Resend API.',
+  description: 'Sending emails from Edge Functions using either the Forward Email or Resend API's.',
 }
 
-Sending emails from Edge Functions using the [Resend API](https://resend.com/).
+Sending emails from Edge Functions using either the [Forward Email](https://forwardemail.net) (100% open-source) or [Resend](https://resend.com/) API's.
 
 ### Prerequisites
 
 To get the most out of this guide, you’ll need to:
 
-- [Create an API key](https://resend.com/api-keys)
-- [Verify your domain](https://resend.com/domains)
+- Create an API key using either [Forward Email](https://forwardemail.net/my-account/security) or [Resend](https://resend.com/api-keys)
+- Verify your domain using either [Forward Email](https://forwardemail.net/my-account/domains) or [Resend](https://resend.com/domains)
 
 Make sure you have the latest version of the [Supabase CLI](https://supabase.com/docs/guides/cli#installation) installed.
 
@@ -21,26 +21,63 @@ Make sure you have the latest version of the [Supabase CLI](https://supabase.co
 Create a new function locally:
 
 ```bash
-supabase functions new resend
+supabase functions new email
 ```
 
-Store the `RESEND_API_KEY` in your `.env` file.
+Store your provider's `EMAIL_API_KEY` in your `.env` file.
 
 ### 2. Edit the handler function
 
-Paste the following code into the `index.ts` file:
+**If using Forward Email**, then paste the following code into the `index.ts` file ([see complete API docs](https://forwardemail.net/en/email-api#create-email)):
 
 ```tsx
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 
-const RESEND_API_KEY = Deno.env.get('RESEND_API_KEY')
+const EMAIL_API_KEY = Deno.env.get('EMAIL_API_KEY')
 
 const handler = async (_request: Request): Promise<Response> => {
+  // <https://forwardemail.net/en/email-api#create-email>
+  const res = await fetch('https://api.forwardemail.net/v1/emails', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Basic ${Buffer.from(EMAIL_API_KEY).toString('base64')}:`,
+    },
+    body: JSON.stringify({
+      from: 'onboarding@example.com',
+      to: 'delivered@example.com',
+      subject: 'hello world',
+      html: '<strong>it works!</strong>',
+    }),
+  })
+
+  const data = await res.json()
+
+  return new Response(JSON.stringify(data), {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  })
+}
+
+serve(handler)
+```
+
+**If using Resend**, then paste the following code into the `index.ts` file ([see complete API docs](https://resend.com/docs/api-reference/emails/send-email)):
+
+```tsx
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
+
+const EMAIL_API_KEY = Deno.env.get('EMAIL_API_KEY')
+
+const handler = async (_request: Request): Promise<Response> => {
+  // <https://resend.com/docs/api-reference/emails/send-email>
   const res = await fetch('https://api.resend.com/emails', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      Authorization: `Bearer ${RESEND_API_KEY}`,
+      Authorization: `Bearer ${EMAIL_API_KEY}`,
     },
     body: JSON.stringify({
       from: 'onboarding@resend.dev',
@@ -72,19 +109,19 @@ supabase start
 supabase functions serve --no-verify-jwt --env-file .env
 ```
 
-Test it: http://localhost:54321/functions/v1/resend
+Test it: http://localhost:54321/functions/v1/email
 
 Deploy function to Supabase:
 
 ```bash
-supabase functions deploy resend --no-verify-jwt
+supabase functions deploy email --no-verify-jwt
 ```
 
 Open the endpoint URL to send an email:
 
 ### 4. Try it yourself
 
-Find the complete example on [GitHub](https://github.com/resendlabs/resend-supabase-edge-functions-example).
+See the complete [Forward Email](https://github.com/forwardemail/forwardemail.net/blob/master/app/views/docs/how-to-javascript-contact-forms-node-js/index.md) or [Resend](https://github.com/resendlabs/resend-supabase-edge-functions-example) examples on GitHub.
 
 export const Page = ({ children }) => <Layout meta={meta} children={children} />
 


### PR DESCRIPTION
Hi there - we're adding options for users to choose either Resend or Forward Email for sending emails with Supabase.  Forward Email is 100% open-source and is the official recommended Nodemailer service.

**We've updated the docs not only to include Forward Email but more accurately give references and links to Resend's API docs and simplified the code examples.**

Thanks! 🙏