### PR TITLE
feat: preview costs for Pro/Team plan change

### DIFF
--- a/studio/data/api.d.ts
+++ b/studio/data/api.d.ts
@@ -214,8 +214,12 @@ export interface paths {
   "/platform/organizations/{slug}/billing/subscription": {
     /** Gets the current subscription */
     get: operations["SubscriptionController_getSubscription"];
-    /** Updates subscription */
+    /** Previews subscription change */
     put: operations["SubscriptionController_updateSubscription"];
+  };
+  "/platform/organizations/{slug}/billing/subscription/preview": {
+    /** Updates subscription */
+    post: operations["SubscriptionController_previewSubscriptionChange"];
   };
   "/platform/organizations/{slug}/billing/plans": {
     /** Gets subscription plans */
@@ -1818,6 +1822,8 @@ export interface components {
       SMS_PROVIDER?: string;
       SMS_MESSAGEBIRD_ACCESS_KEY?: string;
       SMS_MESSAGEBIRD_ORIGINATOR?: string;
+      SMS_TEST_OTP?: string;
+      SMS_TEST_OTP_VALID_UNTIL?: string;
       SMS_TEXTLOCAL_API_KEY?: string;
       SMS_TEXTLOCAL_SENDER?: string;
       SMS_TWILIO_ACCOUNT_SID?: string;
@@ -5458,6 +5464,26 @@ export interface operations {
     };
     responses: {
       200: never;
+      403: never;
+      /** @description Failed to update subscription */
+      500: never;
+    };
+  };
+  /** Updates subscription */
+  SubscriptionController_previewSubscriptionChange: {
+    parameters: {
+      path: {
+        /** @description Organization slug */
+        slug: string;
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["UpdateSubscriptionBody"];
+      };
+    };
+    responses: {
+      201: never;
       403: never;
       /** @description Failed to update subscription */
       500: never;

--- a/studio/data/organizations/keys.ts
+++ b/studio/data/organizations/keys.ts
@@ -14,6 +14,8 @@ export const organizationKeys = {
   migrateBilling: (slug: string | undefined) => ['organizations', slug, 'migrate-billing'] as const,
   migrateBillingPreview: (slug: string | undefined) =>
     ['organizations', slug, 'migrate-billing', 'preview'] as const,
+  subscriptionPreview: (slug: string | undefined, tier: string | undefined) =>
+    ['organizations', slug, 'subscription', 'preview', tier] as const,
   taxIds: (slug: string | undefined) => ['organizations', slug, 'tax-ids'] as const,
   tokenValidation: (slug: string | undefined, token: string | undefined) =>
     ['organizations', slug, 'validate-token', token] as const,

--- a/studio/data/organizations/organization-billing-subscription-preview.ts
+++ b/studio/data/organizations/organization-billing-subscription-preview.ts
@@ -1,0 +1,80 @@
+import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { post } from 'data/fetchers'
+import { organizationKeys } from './keys'
+import { ResponseError } from 'types'
+
+export type OrganizationBillingSubscriptionPreviewVariables = {
+  organizationSlug?: string
+  tier?: 'tier_payg' | 'tier_pro' | 'tier_free' | 'tier_team' | 'tier_enterprise'
+}
+
+export type OrganizationBillingSubscriptionPreviewResponse = {
+  breakdown: {
+    description: string
+    unit_price: number
+    quantity: number
+    total_price: number
+  }[]
+}
+
+export async function previewOrganizationBillingSubscription({
+  organizationSlug,
+  tier,
+}: OrganizationBillingSubscriptionPreviewVariables) {
+  if (!organizationSlug) throw new Error('organizationSlug is required')
+  if (!tier) throw new Error('tier is required')
+
+  const { data, error } = await post(
+    `/platform/organizations/{slug}/billing/subscription/preview`,
+    {
+      params: { path: { slug: organizationSlug } },
+      body: {
+        tier,
+      },
+    }
+  )
+
+  if (error) throw error
+
+  return data as OrganizationBillingSubscriptionPreviewResponse
+}
+
+export type OrganizationBillingSubscriptionPreviewData = Awaited<
+  ReturnType<typeof previewOrganizationBillingSubscription>
+>
+
+export const useOrganizationBillingSubscriptionPreview = <
+  TData = OrganizationBillingSubscriptionPreviewData
+>(
+  { organizationSlug, tier }: OrganizationBillingSubscriptionPreviewVariables,
+  {
+    enabled = true,
+    ...options
+  }: UseQueryOptions<OrganizationBillingSubscriptionPreviewData, ResponseError, TData> = {}
+) =>
+  useQuery<OrganizationBillingSubscriptionPreviewData, ResponseError, TData>(
+    organizationKeys.subscriptionPreview(organizationSlug, tier),
+    () => previewOrganizationBillingSubscription({ organizationSlug, tier }),
+    {
+      enabled: enabled && typeof organizationSlug !== 'undefined' && typeof tier !== 'undefined',
+      ...options,
+
+      retry: (failureCount, error) => {
+        // Don't retry on 400s
+        if (
+          typeof error === 'object' &&
+          error !== null &&
+          'code' in error &&
+          (error as any).code === 400
+        ) {
+          return false
+        }
+
+        if (failureCount < 3) {
+          return true
+        }
+
+        return false
+      },
+    }
+  )


### PR DESCRIPTION
https://github.com/supabase/infrastructure/pull/14439 needs to be merged first.

PR adds a preview when up/downgrading to Pro/Team plan to be transparent about costs.

![Screenshot 2023-08-27 at 17 50 51](https://github.com/supabase/supabase/assets/14073399/245836ca-ddea-4dc0-80b6-2d37f567d102)

![Screenshot 2023-08-27 at 17 50 40](https://github.com/supabase/supabase/assets/14073399/4f5dd73e-aaf5-46d1-894e-a153a805c58c)
