### PR TITLE
Fix typo in column-encryption.mdx

### DIFF
--- a/apps/docs/pages/guides/database/column-encryption.mdx
+++ b/apps/docs/pages/guides/database/column-encryption.mdx
@@ -11,7 +11,7 @@ export const meta = {
 
 Supabase provides a secure method for encrypting data using [Vault](/docs/guides/database/vault), our Postgres secrets manager. Vault is a Postgres extension with an [integrated UI](https://app.supabase.com/project/_/settings/vault/secrets) intended to act as a secure global secrets management for your project.
 
-In addition to the Vault secret storage table, Supabase also enables an advanced feature called Transparent Column Encryption (TCE) which provides a safe way to encrypt columns in your own tables so that they doesn't leak into logs and backups. It can also provide row-level authenticated encryption.
+In addition to the Vault secret storage table, Supabase also enables an advanced feature called Transparent Column Encryption (TCE) which provides a safe way to encrypt columns in your own tables so that they don't leak into logs and backups. It can also provide row-level authenticated encryption.
 
 Column Encryption comes with tradeoffs that need to be considered before using it.
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes a typo in the second paragraph at https://supabase.com/docs/guides/database/column-encryption

"so that they doesn't" replaced by "so that they don't"

## What is the current behavior?

<img width="820" alt="Screenshot 2023-08-27 at 21 04 34" src="https://github.com/supabase/supabase/assets/45327819/120f9c17-9d1f-42c7-b549-209e36dcfb2a">
