### PR TITLE
CUD operations cases added for 'Roles' in self hosted environment

### DIFF
--- a/studio/pages/api/pg-meta/[ref]/roles.ts
+++ b/studio/pages/api/pg-meta/[ref]/roles.ts
@@ -1,7 +1,7 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
 import apiWrapper from 'lib/api/apiWrapper'
-import { get } from 'lib/common/fetch'
+import { get, post, delete_, patch } from 'lib/common/fetch'
 import { constructHeaders } from 'lib/api/apiHelpers'
 import { PG_META_URL } from 'lib/constants'
 
@@ -14,6 +14,12 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
   switch (method) {
     case 'GET':
       return handleGetAll(req, res)
+    case 'POST':
+      return handlePost(req, res)  
+    case 'PATCH':
+      return handlePatch(req, res)  
+    case 'DELETE':
+      return handleDelete(req, res)  
     default:
       res.setHeader('Allow', ['GET'])
       res.status(405).json({ error: { message: `Method ${method} Not Allowed` } })
@@ -25,6 +31,37 @@ const handleGetAll = async (req: NextApiRequest, res: NextApiResponse) => {
   let response = await get(`${PG_META_URL}/roles`, {
     headers,
   })
+  if (response.error) {
+    return res.status(400).json({ error: response.error })
+  }
+  return res.status(200).json(response)
+}
+
+const handlePost = async (req: NextApiRequest, res: NextApiResponse) => {
+  const headers = constructHeaders(req.headers)
+  const payload = req.body
+  let response = await post(`${PG_META_URL}/roles`, payload, {
+    headers,
+  })
+  if (response.error) {
+    return res.status(400).json({ error: response.error })
+  }
+  return res.status(200).json(response)
+}
+
+const handlePatch = async (req: NextApiRequest, res: NextApiResponse) => {
+  const headers = constructHeaders(req.headers)
+  const roleId = req.query.id
+  let response = await patch(`${PG_META_URL}/roles/${roleId}`, req.body, {headers})
+  if (response.error) {
+    return res.status(400).json({ error: response.error })
+  }
+  return res.status(200).json(response)
+}
+const handleDelete = async (req: NextApiRequest, res: NextApiResponse) => {
+  const headers = constructHeaders(req.headers)
+  const roleId = req.query.id
+  let response = await delete_(`${PG_META_URL}/roles/${roleId}`, {headers})
   if (response.error) {
     return res.status(400).json({ error: response.error })
   }


### PR DESCRIPTION
## What kind of change does this PR introduce?
The pull request aims to fix [16723](https://github.com/supabase/supabase/issues/16723)

## What is the current behavior?
The following is currently disabled for Database Roles in the self-hosted envirnonment:
1. Addition of new Roles
2. Updation of exisitng Roles
3. Deletion of Roles

## What is the new behavior?

The changes aims to add in cases for 

<table>
    <tr>
        <th>S No.</th>
        <th>Update</th>
        <th>Screenshot</th>
    </tr>
<tr>
<td>1.</td>
<td>Add New Roles</td>
<td>
<img src="https://github.com/supabase/supabase/assets/34278282/2bb15ee3-c738-498e-bfbf-f911afca3129"/>
</td>
</tr>
<tr>
<td>2.</td>
<td>Update Existing Roles</td>
<td><img src="https://github.com/supabase/supabase/assets/34278282/15a6a8c7-e606-47a3-85e3-97aea2fe7ef0"/></td>
</tr><tr>
<td>3.</td>
<td>Delete Exisiting Roles</td>
<td><img src="https://github.com/supabase/supabase/assets/34278282/6e6639f3-8ba3-4454-8c14-d8743cdea0cc"/></td>
</tr>
</table>

## Additional context

