### PR TITLE
fix(studio): invalid sql in table definitions

### DIFF
--- a/studio/data/database/database-query-constants.ts
+++ b/studio/data/database/database-query-constants.ts
@@ -298,8 +298,8 @@ export const CREATE_PG_GET_TABLEDEF_SQL = minify(
             END IF;
             
             --v17 put double-quotes around case-sensitive column names
-            SELECT COUNT(*) INTO v_cnt FROM information_schema.columns t WHERE EXISTS (SELECT REGEXP_MATCHES(s.column_name, '([A-Z]+)','g') FROM information_schema.columns s 
-            WHERE t.table_schema=s.table_schema and t.table_name=s.table_name and t.column_name=s.column_name AND t.table_schema = quote_ident(in_schema) AND column_name = v_colrec.column_name);         
+            SELECT COUNT(*) INTO v_cnt FROM information_schema.columns t WHERE EXISTS (SELECT s.column_name FROM information_schema.columns s
+            WHERE t.table_schema=s.table_schema and t.table_name=s.table_name and t.column_name=s.column_name AND t.table_schema = quote_ident(in_schema) AND column_name = v_colrec.column_name AND (s.column_name ~ '[A-Z]+' OR s.column_name IN (SELECT word FROM pg_get_keywords() WHERE catdesc = 'reserved')));
             IF v_cnt > 0 THEN
               v_table_ddl := v_table_ddl || '  "' || v_colrec.column_name || '" ';
             ELSE


### PR DESCRIPTION
## What kind of change does this PR introduce?
Fixed invalid SQL in table definitions when columns are named as reserved identifiers in postgres, mentioned in [#13869](https://github.com/supabase/supabase/issues/13869)

## What is the current behavior?
Currently, columns with the same names as reserved keywords (e.g. desc, and, or) are not quoted, unlike columns with capital letters in them are (e.g. productId).

## What is the new behavior?
Now these columns are quoted just like camelCase ones. The reserved keywords are fetched using the `pg_get_keywords()` function.
### Old
![image](https://github.com/supabase/supabase/assets/51780559/687834eb-e32c-4eab-a408-6e415b361b9e)

### New
![image](https://github.com/supabase/supabase/assets/51780559/152b7e16-8554-4006-94b3-0abc3b32d468)


## Additional context
I couldn't reproduce a related issue: `If the definition is copied and pasted into the SQL Editor to create a table any camelCase columns are converted to lowercase`. Also, the `pg_get_tabledef` is really large, so I'm not sure if I missed some parts to change. I'd love to get some feedback on this!
