### PR TITLE
chore: update typo on json method docs

### DIFF
--- a/apps/docs/pages/guides/auth/auth-mfa.mdx
+++ b/apps/docs/pages/guides/auth/auth-mfa.mdx
@@ -605,10 +605,10 @@ Use the `supabase.auth.getAuthenticatorAssuranceLevel()` method to get easy acce
 You can use this PostgreSQL snippet in RLS policies, too:
 
 ```sql
-json_query_path(auth.jwt(), '$.amr[0]')
+jsonb_path_query(auth.jwt(), '$.amr[0]')
 ```
 
-- [`json_query_path(json, path)`](https://www.postgresql.org/docs/current/functions-json.html#FUNCTIONS-JSON-PROCESSING-TABLE)
+- [`jsonb_path_query(json, path)`](https://www.postgresql.org/docs/current/functions-json.html#FUNCTIONS-JSON-PROCESSING-TABLE)
   is a function that allows access to elements in a JSON object according to a
   [SQL/JSON
   path](https://www.postgresql.org/docs/current/functions-json.html#FUNCTIONS-SQLJSON-PATH).


### PR DESCRIPTION

## What kind of change does this PR introduce?

Update typo on method name - method name should be `jsonb_path_query`


Docs: https://www.postgresql.org/docs/current/functions-json.html (Ctrl-f jsonb_path_query)

Tested by running: 
```
select * from jsonb_path_query('{
  "amr": [
    {
      "method": "totp",
      "timestamp": 1666086056
    },
    {
      "method": "password",
      "timestamp": 1666085924
    }
  ]
}', '$.amr[0].method') 
```
