### PR TITLE
docs: document use of {{ .Data }} field in email template

### DIFF
--- a/apps/docs/pages/guides/auth/auth-email-templates.mdx
+++ b/apps/docs/pages/guides/auth/auth-email-templates.mdx
@@ -25,6 +25,7 @@ The templating system provides the following variables for use:
 | `{{ .TokenHash }}`       | Contains a hashed version of the `{{ .Token }}`. This is useful for constructing your own email link in the email template.                                                                                       |
 | `{{ .SiteURL }}`         | Contains your application's Site URL. This can be configured in your project's [authentication settings](/dashboard/project/_/auth/url-configuration).                                                                                                           |
 | `{{ .RedirectTo }}`      | Contains the redirect URL passed when `signUp`, `signInWithOtp`, `signInWithOAuth`, `resetPasswordForEmail` or `inviteUserByEmail` is called. The redirect URL allow list can be configured in your project's [authentication settings](/dashboard/project/_/auth/url-configuration).                                                                                                           |
+| `{{ .Data }}`            | Contains Metadata linked to a user. This can be used to provide customize the email message on a per user basis.
 
 ## Limitations
 
@@ -72,6 +73,39 @@ const { data: { session }, error } = await supabase.auth.verifyOtp({ token_hash,
 // ...
 
 ```
+
+## Customization
+
+Supabase Auth makes use of [Go Templates](https://pkg.go.dev/text/template). This means it is possible to conditionally render information based on template properties.You may wish to checkout this [guide by Hugo](https://gohugo.io/templates/introduction/) for a guide on the templating language.
+
+Let's demonstrate some ways of using the templating system below:
+
+### Different Email Based on Signup Domain
+
+Send users different emails based on the domain that they signed up for your service with.
+
+```
+{{ if eq .Data.Domain "http://www.example.com" }}
+<insert content for Pro Tier users>
+{{ else if eq .Data.Domain "http://www.specialsite.com" }}
+<insert content for Free Tier users>
+{{end }}
+```
+
+
+### Custom Email Content For Secure Email Change Flow
+
+Send two distinct emails: one customized for the new email account and another for the email the user is currently using.
+```
+{{ if eq .Email .SendingTo }}
+<insert content which will be received by current email>
+{{ else }}
+<insert content which will be received by new email>
+{{end}}
+
+```
+
+
 
 export const Page = ({ children }) => <Layout meta={meta} children={children} />
 

--- a/apps/docs/pages/guides/auth/auth-email-templates.mdx
+++ b/apps/docs/pages/guides/auth/auth-email-templates.mdx
@@ -25,7 +25,7 @@ The templating system provides the following variables for use:
 | `{{ .TokenHash }}`       | Contains a hashed version of the `{{ .Token }}`. This is useful for constructing your own email link in the email template.                                                                                       |
 | `{{ .SiteURL }}`         | Contains your application's Site URL. This can be configured in your project's [authentication settings](/dashboard/project/_/auth/url-configuration).                                                                                                           |
 | `{{ .RedirectTo }}`      | Contains the redirect URL passed when `signUp`, `signInWithOtp`, `signInWithOAuth`, `resetPasswordForEmail` or `inviteUserByEmail` is called. The redirect URL allow list can be configured in your project's [authentication settings](/dashboard/project/_/auth/url-configuration).                                                                                                           |
-| `{{ .Data }}`            | Contains Metadata linked to a user. This can be used to provide customize the email message on a per user basis.
+| `{{ .Data }}`            | Contains metadata from `auth.users.user_metadata`. Use this to personalize the email message.
 
 ## Limitations
 

--- a/apps/docs/pages/guides/auth/auth-email-templates.mdx
+++ b/apps/docs/pages/guides/auth/auth-email-templates.mdx
@@ -96,7 +96,7 @@ Billy Team</p>
   <p> As an early access member, you have access to select features like Point To Space Restoration.</p>
   <p>Best Regards,<br>
 Billy Team</p>
-{{end }}
+{{ end }}
 ```
 
 export const Page = ({ children }) => <Layout meta={meta} children={children} />

--- a/apps/docs/pages/guides/auth/auth-email-templates.mdx
+++ b/apps/docs/pages/guides/auth/auth-email-templates.mdx
@@ -78,23 +78,22 @@ const { data: { session }, error } = await supabase.auth.verifyOtp({ token_hash,
 
 Supabase Auth makes use of [Go Templates](https://pkg.go.dev/text/template). This means it is possible to conditionally render information based on template properties.You may wish to checkout this [guide by Hugo](https://gohugo.io/templates/introduction/) for a guide on the templating language.
 
+### Send different email to early access users
 
-### Different Email Based on Signup Domain
-
-Send users different emails based on the domain that they signed up for your service with.
+Send a different email to users who signed up via an early access domain (`https://www.earlyaccess.trial.com`).
 
 ```
-{{ if eq .Data.Domain "http://www.example.com" }}
+{{ if eq .Data.Domain "https://www.example.com" }}
 <h1>Welcome to Our Database Service!</h1>
   <p>Dear Developer,</p>
   <p>Welcome to Billy, the scalable developer platform!</p>
   <p>Best Regards,<br>
 Billy Team</p>
-{{ else if eq .Data.Domain "http://www.specialsite.com" }}
+{{ else if eq .Data.Domain "https://www.earlyaccess.trial.com" }}
 <h1>Welcome to Our Database Service!</h1>
   <p>Dear Developer,</p>
-  <p>Welcome to Pro Plan of Billy, the scalable developer platform!</p>
-  <p> As a Pro Plan member of Billy, you have access to select features like Point In Time Restoration.</p>
+  <p>Welcome Billy, the scalable developer platform!</p>
+  <p> As an early access member, you have access to select features like Point To Space Restoration.</p>
   <p>Best Regards,<br>
 Billy Team</p>
 {{end }}

--- a/apps/docs/pages/guides/auth/auth-email-templates.mdx
+++ b/apps/docs/pages/guides/auth/auth-email-templates.mdx
@@ -78,7 +78,6 @@ const { data: { session }, error } = await supabase.auth.verifyOtp({ token_hash,
 
 Supabase Auth makes use of [Go Templates](https://pkg.go.dev/text/template). This means it is possible to conditionally render information based on template properties.You may wish to checkout this [guide by Hugo](https://gohugo.io/templates/introduction/) for a guide on the templating language.
 
-Let's demonstrate some ways of using the templating system below:
 
 ### Different Email Based on Signup Domain
 

--- a/apps/docs/pages/guides/auth/auth-email-templates.mdx
+++ b/apps/docs/pages/guides/auth/auth-email-templates.mdx
@@ -86,26 +86,20 @@ Send users different emails based on the domain that they signed up for your ser
 
 ```
 {{ if eq .Data.Domain "http://www.example.com" }}
-<insert content for Pro Tier users>
+<h1>Welcome to Our Database Service!</h1>
+  <p>Dear Developer,</p>
+  <p>Welcome to Billy, the scalable developer platform!</p>
+  <p>Best Regards,<br>
+Billy Team</p>
 {{ else if eq .Data.Domain "http://www.specialsite.com" }}
-<insert content for Free Tier users>
+<h1>Welcome to Our Database Service!</h1>
+  <p>Dear Developer,</p>
+  <p>Welcome to Pro Plan of Billy, the scalable developer platform!</p>
+  <p> As a Pro Plan member of Billy, you have access to select features like Point In Time Restoration.</p>
+  <p>Best Regards,<br>
+Billy Team</p>
 {{end }}
 ```
-
-
-### Custom Email Content For Secure Email Change Flow
-
-Send two distinct emails: one customized for the new email account and another for the email the user is currently using.
-```
-{{ if eq .Email .SendingTo }}
-<insert content which will be received by current email>
-{{ else }}
-<insert content which will be received by new email>
-{{end}}
-
-```
-
-
 
 export const Page = ({ children }) => <Layout meta={meta} children={children} />
 

--- a/apps/studio/stores/authConfig/schema/AuthProviders/AuthTemplatesValidation.tsx
+++ b/apps/studio/stores/authConfig/schema/AuthProviders/AuthTemplatesValidation.tsx
@@ -127,7 +127,7 @@ export const EMAIL_CHANGE: FormSchema = {
 - \`{{ .Email }}\` : The original user's email address
 - \`{{ .NewEmail }}\` : The user's new email address
 - \`{{ .Data }}\` : The user's \`user_metadata\`
-- \`{{ .SendingTo }}\: The recepient of the email. Relevant for Secure Email Change.`
+- \`{{ .SendingTo }}\: The recipient of the email. Relevant for Secure Email Change.`
 `,
     },
   },

--- a/apps/studio/stores/authConfig/schema/AuthProviders/AuthTemplatesValidation.tsx
+++ b/apps/studio/stores/authConfig/schema/AuthProviders/AuthTemplatesValidation.tsx
@@ -127,7 +127,6 @@ export const EMAIL_CHANGE: FormSchema = {
 - \`{{ .Email }}\` : The original user's email address
 - \`{{ .NewEmail }}\` : The user's new email address
 - \`{{ .Data }}\` : The user's \`user_metadata\`
-- \`{{ .SendingTo }}\: The recipient of the email. Relevant for Secure Email Change.`
 `,
     },
   },

--- a/apps/studio/stores/authConfig/schema/AuthProviders/AuthTemplatesValidation.tsx
+++ b/apps/studio/stores/authConfig/schema/AuthProviders/AuthTemplatesValidation.tsx
@@ -127,6 +127,7 @@ export const EMAIL_CHANGE: FormSchema = {
 - \`{{ .Email }}\` : The original user's email address
 - \`{{ .NewEmail }}\` : The user's new email address
 - \`{{ .Data }}\` : The user's \`user_metadata\`
+- \`{{ .SendingTo }}\: The recepient of the email. Relevant for Secure Email Change.`
 `,
     },
   },


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR documents the `{{ .Data }}` field for which allows developer to include data from the `User.Metadata` field. 

Initially, this was also intended to document the `{{ .SendingTo }}` field but that has been removed  and will be addressed in a separate PR.