### PR TITLE
Revert badge global color change

### DIFF
--- a/apps/docs/components/Navigation/NavigationMenu/HomeMenu.tsx
+++ b/apps/docs/components/Navigation/NavigationMenu/HomeMenu.tsx
@@ -50,7 +50,11 @@ const NavigationMenuHome = () => {
                             >
                               {link?.icon && <HomeMenuIconPicker icon={link.icon} />}
                               {link.label}
-                              {link.community && <Badge size="small">Community</Badge>}
+                              {link.community && (
+                                <Badge size="small" color="scale">
+                                  Community
+                                </Badge>
+                              )}
                             </li>
                           </a>
                         </Link>

--- a/packages/ui/src/lib/theme/defaultTheme.ts
+++ b/packages/ui/src/lib/theme/defaultTheme.ts
@@ -216,8 +216,7 @@ export default {
     },
     dot: '-ml-0.5 mr-1.5 h-2 w-2 rounded-full',
     color: {
-      brand: 'bg-brand bg-opacity-100 text-background border border-brand-400',
-      alt: 'bg-brand-500 text-brand-600 border border-brand-400',
+      brand: 'bg-brand-500 text-brand-600 border border-brand-400',
       scale: 'bg-scale-200 text-scale-1100 border border-scale-700',
       tomato: `bg-tomato-200 text-tomato-1100 border border-tomato-700`,
       red: `bg-red-200 text-red-1100 border border-red-700`,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Badge default brand color is now as before this PR #16901.

## What is the current behavior?

<img width="308" alt="Screenshot 2023-08-30 at 11 52 43" src="https://github.com/supabase/supabase/assets/25671831/cfd1a182-e0d2-487a-9a78-b90540bf20ae">

## What is the new behavior?

<img width="294" alt="Screenshot 2023-08-30 at 11 53 02" src="https://github.com/supabase/supabase/assets/25671831/97b9802e-adb7-43fe-8c4e-db16aeb65db7">


## Additional context

Before the bug, the badges were dark green.

<img width="305" alt="Screenshot 2023-08-30 at 11 53 51" src="https://github.com/supabase/supabase/assets/25671831/e2fb42c4-ceac-490a-ae2b-4e53a52cc5b2">
