### PR TITLE
Fix Enter not-working in filter popup

### DIFF
--- a/studio/components/grid/components/header/filter/FilterPopover.tsx
+++ b/studio/components/grid/components/header/filter/FilterPopover.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback } from 'react'
+import { useState, useMemo, useCallback, KeyboardEvent } from 'react'
 import { isEqual } from 'lodash'
 import { Button, IconPlus, IconFilter, Popover } from 'ui'
 import update from 'immutability-helper'
@@ -102,6 +102,12 @@ const FilterOverlay = ({ table, filters: filtersFromUrl, setParams }: FilterOver
     })
   }
 
+  function handleEnterKeyDown(event: KeyboardEvent<HTMLInputElement>) {
+    if (event.key === 'Enter') {
+      onApplyFilter()
+    }
+  }
+
   return (
     <div className="space-y-2 py-2">
       <div className="space-y-2">
@@ -113,6 +119,7 @@ const FilterOverlay = ({ table, filters: filtersFromUrl, setParams }: FilterOver
             filterIdx={index}
             onChange={onChangeFilter}
             onDelete={onDeleteFilter}
+            onKeyDown={handleEnterKeyDown}
           />
         ))}
         {filters.length == 0 && (

--- a/studio/components/grid/components/header/filter/FilterRow.tsx
+++ b/studio/components/grid/components/header/filter/FilterRow.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react'
+import { memo, KeyboardEvent } from 'react'
 import { Button, Input, IconChevronDown, IconX } from 'ui'
 
 import { Filter, FilterOperator, SupaTable } from 'components/grid/types'
@@ -11,9 +11,10 @@ export interface FilterRowProps {
   filter: Filter
   onChange: (index: number, filter: Filter) => void
   onDelete: (index: number) => void
+  onKeyDown: (event: KeyboardEvent<HTMLInputElement>) => void
 }
 
-const FilterRow = ({ table, filter, filterIdx, onChange, onDelete }: FilterRowProps) => {
+const FilterRow = ({ table, filter, filterIdx, onChange, onDelete, onKeyDown }: FilterRowProps) => {
   const column = table.columns.find((x) => x.name === filter.column)
   const columnOptions =
     table.columns?.map((x) => {
@@ -80,6 +81,7 @@ const FilterRow = ({ table, filter, filterIdx, onChange, onDelete }: FilterRowPr
             value: event.target.value,
           })
         }
+        onKeyDown={onKeyDown}
       />
       <Button
         icon={<IconX strokeWidth={1.5} size={14} />}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix, feature
Fixes #17025 

Added an Enter key down handler to the filter input field, allowing users to save their filter by pressing the `Enter` button.

## What is the current behavior?
Not able to save filter by pressing the `Enter` button.

## What is the new behavior?
[screencast.webm](https://github.com/supabase/supabase/assets/71846487/08d8bcce-42b0-419d-988b-9c1f83b5989c)
