### PR TITLE
Fix the SupportForm crash

### DIFF
--- a/studio/components/interfaces/Support/SupportForm.tsx
+++ b/studio/components/interfaces/Support/SupportForm.tsx
@@ -278,10 +278,10 @@ const SupportForm = ({ setSentCategory }: SupportFormProps) => {
         useEffect(() => {
           if (isReady) {
             const updatedValues = {
-              projectRef: ref,
-              subject: subject ?? '',
-              category: selectedCategoryFromUrl?.value,
-              message: message ?? '',
+              projectRef: ref ?? initialValues.projectRef,
+              subject: subject ?? initialValues.subject,
+              category: selectedCategoryFromUrl?.value ?? initialValues.category,
+              message: message ?? initialValues.message,
             }
             resetForm({ values: updatedValues, initialValues: updatedValues })
           }

--- a/studio/components/interfaces/Support/SupportForm.tsx
+++ b/studio/components/interfaces/Support/SupportForm.tsx
@@ -279,9 +279,9 @@ const SupportForm = ({ setSentCategory }: SupportFormProps) => {
           if (isReady) {
             const updatedValues = {
               projectRef: ref,
-              subject,
+              subject: subject ?? '',
               category: selectedCategoryFromUrl?.value,
-              message,
+              message: message ?? '',
             }
             resetForm({ values: updatedValues, initialValues: updatedValues })
           }


### PR DESCRIPTION
The support page was broken in https://github.com/supabase/supabase/pull/17011. Two undefined values were passed and the form didn't expect them so it crashed.