### PR TITLE
fix: remove authorized app id from ui

### DIFF
--- a/studio/components/interfaces/Organization/OAuthApps/AuthorizedAppRow.tsx
+++ b/studio/components/interfaces/Organization/OAuthApps/AuthorizedAppRow.tsx
@@ -1,9 +1,7 @@
 import Table from 'components/to-be-cleaned/Table'
 import { AuthorizedApp } from 'data/oauth/authorized-apps-query'
 import dayjs from 'dayjs'
-import { copyToClipboard } from 'lib/helpers'
-import { useState } from 'react'
-import { Button, IconCheck, IconClipboard, IconTrash } from 'ui'
+import { Button, IconTrash } from 'ui'
 
 export interface AuthorizedAppRowProps {
   app: AuthorizedApp
@@ -11,8 +9,6 @@ export interface AuthorizedAppRowProps {
 }
 
 const AuthorizedAppRow = ({ app, onSelectRevoke }: AuthorizedAppRowProps) => {
-  const [isCopied, setIsCopied] = useState(false)
-
   return (
     <Table.tr>
       <Table.td>
@@ -24,21 +20,6 @@ const AuthorizedAppRow = ({ app, onSelectRevoke }: AuthorizedAppRowProps) => {
         </div>
       </Table.td>
       <Table.td>{app.name}</Table.td>
-      <Table.td>
-        <span className="font-mono truncate">{app.id}</span>
-        <Button
-          type="default"
-          icon={isCopied ? <IconCheck className="text-brand" strokeWidth={3} /> : <IconClipboard />}
-          className="ml-2 px-1"
-          onClick={() => {
-            copyToClipboard(app.id)
-            setIsCopied(true)
-            setTimeout(() => {
-              setIsCopied(false)
-            }, 3000)
-          }}
-        />
-      </Table.td>
       <Table.td>{dayjs(app.authorized_at).format('DD/MM/YYYY, HH:mm:ss')}</Table.td>
       <Table.td align="right">
         <Button

--- a/studio/components/interfaces/Organization/OAuthApps/OAuthApps.tsx
+++ b/studio/components/interfaces/Organization/OAuthApps/OAuthApps.tsx
@@ -185,8 +185,7 @@ const OAuthApps = () => {
                     head={[
                       <Table.th key="icon" className="w-[30px]"></Table.th>,
                       <Table.th key="name">Name</Table.th>,
-                      <Table.th key="id">ID</Table.th>,
-                      <Table.th key="client-secret">Authorized at</Table.th>,
+                      <Table.th key="authorized-at">Authorized at</Table.th>,
                       <Table.th key="delete-action"></Table.th>,
                     ]}
                     body={


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Remove the authorized app id from the UI since it's not necessary to display it

<img width="1987" alt="image" src="https://github.com/supabase/supabase/assets/28647601/45b7bbcd-8636-4a26-ae86-18d12c00d5ff">

