### PR TITLE
Remove .babelrc from studio app

### DIFF
--- a/studio/.babelrc
+++ b/studio/.babelrc
@@ -1,4 +1,0 @@
-{
-  "presets": ["next/babel"],
-  "plugins": []
-}


### PR DESCRIPTION
This PR removes .babelrc from the studio app since it blocks nextjs from using SWC. Everything should work as before.