### PR TITLE
Use CDN to load Monaco editor files

### DIFF
--- a/studio/pages/_app.tsx
+++ b/studio/pages/_app.tsx
@@ -64,8 +64,11 @@ loader.config({
   // while using monaco). If we end up facing more effort trying to maintain this, probably to either
   // use cloudflare or find some way to pull all the files from a CDN via a CLI, rather than tracking individual files
   // The alternative was to import * as monaco from 'monaco-editor' but i couldn't get it working
-  paths: { vs: `${BASE_PATH}/monaco-editor` },
-  // paths: { vs: 'https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.37.0/min/vs' },
+  paths: {
+    vs: IS_PLATFORM
+      ? 'https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.37.0/min/vs'
+      : `${BASE_PATH}/monaco-editor`,
+  },
 })
 
 // [Joshen TODO] Once we settle on the new nav layout - we'll need a lot of clean up in terms of our layout components

--- a/studio/pages/_document.tsx
+++ b/studio/pages/_document.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @next/next/no-css-tags */
-import { BASE_PATH } from 'lib/constants'
-import Document, { DocumentContext, Html, Head, Main, NextScript } from 'next/document'
+import { BASE_PATH, IS_PLATFORM } from 'lib/constants'
+import Document, { DocumentContext, Head, Html, Main, NextScript } from 'next/document'
 
 class MyDocument extends Document {
   static async getInitialProps(ctx: DocumentContext) {
@@ -18,7 +18,11 @@ class MyDocument extends Document {
             rel="stylesheet"
             type="text/css"
             data-name="vs/editor/editor.main"
-            href={`${BASE_PATH}/monaco-editor/editor/editor.main.css`}
+            href={
+              IS_PLATFORM
+                ? 'https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.37.0/min/vs/editor/editor.main.css'
+                : `${BASE_PATH}/monaco-editor/editor/editor.main.css`
+            }
           />
           <link rel="stylesheet" type="text/css" href="/css/fonts.css" />
         </Head>


### PR DESCRIPTION
This PR changes the studio app to use Monaco editor files from CDN (Cloudflare, specifically) for platform use. When selfhosting, it will use the files from the `public` folder.

To test this PR, check whether:
- the SQL editor is fully functional
- the `editor.main.css` and `editor.main.js` (and other minor JS files) are loaded from Cloudflare.