### PR TITLE
remove extra parentesis

### DIFF
--- a/apps/docs/pages/guides/storage/access-control.mdx
+++ b/apps/docs/pages/guides/storage/access-control.mdx
@@ -82,7 +82,7 @@ on storage.objects
 for select
 to public
 using (
-  storage.filename(name)) = 'favicon.ico'
+  storage.filename(name) = 'favicon.ico'
 );
 ```
 
@@ -100,7 +100,7 @@ on storage.objects
 for insert
 to authenticated
 with check (
-  storage.foldername(name))[1] = 'private'
+  storage.foldername(name)[1] = 'private'
 );
 ```
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Previously 

`storage.foldername(name))` and  `storage.foldername(name))[1] = 'private`' has extra parenthesis now it is  `storage.foldername(name)` ,  `storage.foldername(name)[1] = 'private'`

## What is the new behavior?

Removed the extra parenthesis.

## Additional context

Issue Link : https://github.com/supabase/supabase/issues/17035
