### PR TITLE
fix: $ in front of column name causes issue with definition tab

### DIFF
--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.utils.ts
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.utils.ts
@@ -177,6 +177,9 @@ export const validateFields = (field: ColumnField) => {
   if (field.name.length === 0) {
     errors['name'] = `Please assign a name for your column`
   }
+  if (field.name.startsWith('$')) {
+    errors['name'] = `Column name must not begin with $`
+  }
   if (field.format.length === 0) {
     errors['format'] = `Please select a type for your column`
   }

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/ColumnManagement.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/ColumnManagement.tsx
@@ -209,7 +209,7 @@ const ColumnManagement = ({
                       ].join(' ')}
                     >
                       <span className="text-xs text-scale-1200">
-                        Recommended to use lowercase and use an underscore to separate words e.g.
+                        Recommended to use lowercase (must not begin with $)  and use an underscore to separate words e.g.
                         column_name
                       </span>
                     </div>

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/ColumnManagement.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/ColumnManagement.tsx
@@ -209,7 +209,7 @@ const ColumnManagement = ({
                       ].join(' ')}
                     >
                       <span className="text-xs text-scale-1200">
-                        Recommended to use lowercase (must not begin with $)  and use an underscore to separate words e.g.
+                        Recommended to use only lowercase letters, with an underscore to separate words e.g.
                         column_name
                       </span>
                     </div>

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.utils.ts
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.utils.ts
@@ -21,6 +21,9 @@ export const validateFields = (field: TableField) => {
   if (some(field.columns, (column: ColumnField) => column.name.length === 0)) {
     errors['columns'] = 'Ensure that all your columns are named'
   }
+  if (some(field.columns, (column: ColumnField) => column.name.startsWith('$'))) {
+    errors['columns'] = 'Ensure that a column name doesn\'t begin with $'
+  }
   return errors
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes [#17013](https://github.com/supabase/supabase/issues/17013). The given PR brings about **client-side validation** on column's `name` field for a given table's definition made using the `Table Editor.`  

## What is the current behavior?

The current behavior allows for naming columns of a given table without any validation for special characters `(case in point being column names beginning with'$')` which cause a syntax error with the supabase-meta container running the postgres-meta service.


> <img src="https://github.com/supabase/supabase/assets/34278282/bc3dbbcb-4608-4aef-8c57-57e7d7cc2cef" width="500" height="320"/>


###  **Replicating the error**

> ![ezgif com-video-to-gif (11)](https://github.com/supabase/supabase/assets/34278282/bb7faa3f-0daa-427c-aaad-ef798037c756)

###  **Error from Postgres-meta container's logs**

> ```shell
> "request":{"method":"POST","url":"/query","pg":"db","opt":""}}
> {"level":"error","time":"2023-08-31T11:31:36.849Z","pid":19,"hostname":"a26f486d93cb","reqId":"req-2st","error":{"message":"syntax error at or near \"$\""}," \"$\""}
> ``` 

## What is the new behavior?

The changes in validation allow for users to not create a table until the said column name within that table does not begin with a '$'. Additionally, any previously created column names are also validated on any subsequent updation to them.

### **Table Creation**

> ![ezgif com-video-to-gif (13)](https://github.com/supabase/supabase/assets/34278282/f316b3ef-8377-4ec7-bd2c-62ebe91bf572)


### **Table Updation**

> ![ezgif com-video-to-gif (12)](https://github.com/supabase/supabase/assets/34278282/40f5d456-5515-4b82-9110-b9432f2b4536)

### **Accessing Table Definition**

> ![ezgif com-video-to-gif (14)](https://github.com/supabase/supabase/assets/34278282/fd2401e1-691f-42da-8746-cbfc2c80bd26)


This also solves the problem of `Application error` that was earlier caused by column names beginning with '$' on accessing the Table Definition tab inside the Table Editor.