### PR TITLE
fixed mobile documentation site menu

### DIFF
--- a/apps/docs/layouts/SiteLayout.tsx
+++ b/apps/docs/layouts/SiteLayout.tsx
@@ -244,7 +244,7 @@ const Container = memo(function Container(props) {
       className={[
         // 'overflow-x-auto',
         'w-full h-screen transition-all ease-out',
-        // 'absolute lg:relative', 
+        // 'absolute lg:relative',
         mobileMenuOpen
           ? '!w-auto ml-[75%] sm:ml-[50%] md:ml-[33%] overflow-hidden'
           : 'overflow-auto',

--- a/apps/docs/layouts/SiteLayout.tsx
+++ b/apps/docs/layouts/SiteLayout.tsx
@@ -244,7 +244,7 @@ const Container = memo(function Container(props) {
       className={[
         // 'overflow-x-auto',
         'w-full h-screen transition-all ease-out',
-        'absolute lg:relative',
+        // 'absolute lg:relative', 
         mobileMenuOpen
           ? '!w-auto ml-[75%] sm:ml-[50%] md:ml-[33%] overflow-hidden'
           : 'overflow-auto',


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix, feature, docs update, ... 



https://github.com/supabase/supabase/assets/112644558/39fe779d-7821-4f85-8375-f00bbca62cab 





https://github.com/supabase/supabase/assets/112644558/3def0fe8-b972-48a3-b631-c55b20927232


#what is the current behaviour? 

currently when the mobile menu of docs opened and when we scroll down in the menu the scroll gets out of the screen and the right side of the screen is also scrollable.

#what is the new behaviour? 
the scroll in the menu is fixed now its working perfectly.
