### PR TITLE
docs: add sign in with token hash

### DIFF
--- a/spec/examples/examples.yml
+++ b/spec/examples/examples.yml
@@ -296,6 +296,13 @@ functions:
           ```js
           const { data, error } = await supabase.auth.verifyOtp({ email, token, type: 'signup'})
           ```
+      - id: verify-email-auth(tokenhash)
+        name: Verify Email Auth (Token Hash)
+        isSpotlight: false
+        code: |
+          ```js
+          const { data, error } = await supabase.auth.verifyOtp({ token_hash: tokenHash, type: 'email'})
+          ```
   - id: auth.getSession()
     title: 'getSession()'
     $ref: '@supabase/gotrue-js.GoTrueClient.getSession'

--- a/spec/supabase_js_v2.yml
+++ b/spec/supabase_js_v2.yml
@@ -415,6 +415,7 @@ functions:
     notes: |
       - The `verifyOtp` method takes in different verification types. If a phone number is used, the type can either be `sms` or `phone_change`. If an email address is used, the type can be one of the following: `email`, `recovery`, `invite` or `email_change` (`signup` and `magiclink` types are deprecated).
       - The verification type used should be determined based on the corresponding auth method called before `verifyOtp` to sign up / sign-in a user.
+      - It is also possible to use the `TokenHash` found in the [email templates](/docs/guides/auth/auth-email-templates) as a sign in method
     examples:
       - id: verify-sms-one-time-password(otp)
         name: Verify Sms One-Time Password (OTP)
@@ -429,6 +430,13 @@ functions:
         code: |
           ```js
           const { data, error } = await supabase.auth.verifyOtp({ email, token, type: 'email'})
+          ```
+     - id: verify-signup-one-time-password(otp)
+        name: Verify Signup One-Time Password (OTP)
+        isSpotlight: false
+        code: |
+          ```js
+          const { data, error } = await supabase.auth.verifyOtp({ tokenHash, type: 'email'})
           ```
   - id: get-session
     title: 'getSession()'

--- a/spec/supabase_js_v2.yml
+++ b/spec/supabase_js_v2.yml
@@ -415,7 +415,7 @@ functions:
     notes: |
       - The `verifyOtp` method takes in different verification types. If a phone number is used, the type can either be `sms` or `phone_change`. If an email address is used, the type can be one of the following: `email`, `recovery`, `invite` or `email_change` (`signup` and `magiclink` types are deprecated).
       - The verification type used should be determined based on the corresponding auth method called before `verifyOtp` to sign up / sign-in a user.
-      - It is also possible to use the `TokenHash` found in the [email templates](/docs/guides/auth/auth-email-templates) as a sign in method
+      - The `TokenHash` is contained in the [email templates](/docs/guides/auth/auth-email-templates) and can be used to sign in. You may wish to use the hash with Magic Links for the PKCE flow for Server Side Auth. See [this guide](/docs/guides/auth/server-side/email-based-auth-with-pkce-flow-for-ssr) for more details.
     examples:
       - id: verify-sms-one-time-password(otp)
         name: Verify Sms One-Time Password (OTP)

--- a/spec/supabase_js_v2.yml
+++ b/spec/supabase_js_v2.yml
@@ -431,12 +431,12 @@ functions:
           ```js
           const { data, error } = await supabase.auth.verifyOtp({ email, token, type: 'email'})
           ```
-     - id: verify-signup-one-time-password(otp)
-        name: Verify Signup One-Time Password (OTP)
+      - id: verify-email-auth(tokenhash)
+        name: Verify Email Auth (Token Hash)
         isSpotlight: false
         code: |
           ```js
-          const { data, error } = await supabase.auth.verifyOtp({ tokenHash, type: 'email'})
+          const { data, error } = await supabase.auth.verifyOtp({ token_hash: tokenHash, type: 'email'})
           ```
   - id: get-session
     title: 'getSession()'


### PR DESCRIPTION
## What kind of change does this PR introduce?

We recently allowed verification in with token hash [as well as guides for email SSR](https://supabase.com/docs/guides/auth/server-side/email-based-auth-with-pkce-flow-for-ssr)

This is the corresponding docs update.



