### PR TITLE
feat: display rate limit alert on email templates page

### DIFF
--- a/studio/components/interfaces/Auth/EmailRateLimitsAlert/EmailRateLimitsAlert.tsx
+++ b/studio/components/interfaces/Auth/EmailRateLimitsAlert/EmailRateLimitsAlert.tsx
@@ -1,0 +1,23 @@
+import { AlertDescription_Shadcn_, AlertTitle_Shadcn_, Alert_Shadcn_, IconAlertTriangle } from 'ui'
+
+export function EmailRateLimitsAlert() {
+  return (
+    <Alert_Shadcn_ variant="warning">
+      <IconAlertTriangle strokeWidth={2} />
+      <AlertTitle_Shadcn_>Built-in email service is rate-limited!</AlertTitle_Shadcn_>
+      <AlertDescription_Shadcn_>
+        You're using the built-in email service. The service has rate limits and it's not meant to
+        be used for production apps. Check the{' '}
+        <a
+          href="https://supabase.com/docs/guides/platform/going-into-prod#auth-rate-limits"
+          className="underline"
+          target="_blank"
+        >
+          documentation
+        </a>{' '}
+        for an up-to-date information on the current rate limits. Please use a custom SMTP server if
+        you're planning on having large number of users.
+      </AlertDescription_Shadcn_>
+    </Alert_Shadcn_>
+  )
+}

--- a/studio/components/interfaces/Auth/EmailRateLimitsAlert/index.tsx
+++ b/studio/components/interfaces/Auth/EmailRateLimitsAlert/index.tsx
@@ -1,0 +1,3 @@
+import { EmailRateLimitsAlert } from './EmailRateLimitsAlert'
+
+export default EmailRateLimitsAlert

--- a/studio/components/interfaces/Auth/EmailTemplates/EmailTemplates.tsx
+++ b/studio/components/interfaces/Auth/EmailTemplates/EmailTemplates.tsx
@@ -14,6 +14,7 @@ import { GenericSkeletonLoader } from 'components/ui/ShimmeringLoader'
 import { useAuthConfigQuery } from 'data/auth/auth-config-query'
 import { TEMPLATES_SCHEMAS } from 'stores/authConfig/schema'
 import TemplateEditor from './TemplateEditor'
+import EmailRateLimitsAlert from '../EmailRateLimitsAlert'
 
 const EmailTemplates = () => {
   const { ref: projectRef } = useParams()
@@ -24,6 +25,11 @@ const EmailTemplates = () => {
     isError,
     isSuccess,
   } = useAuthConfigQuery({ projectRef })
+
+  const builtInSMTP =
+    isSuccess &&
+    authConfig &&
+    (!authConfig.SMTP_HOST || !authConfig.SMTP_USER || !authConfig.SMTP_PASS)
 
   return (
     <div>
@@ -65,6 +71,11 @@ const EmailTemplates = () => {
               const panelId = template.title.trim().replace(/\s+/g, '-')
               return (
                 <Tabs.Panel id={panelId} label={template.title} key={panelId}>
+                  {builtInSMTP ? (
+                    <div className="mx-8">
+                      <EmailRateLimitsAlert />
+                    </div>
+                  ) : null}
                   <TemplateEditor
                     key={template.title}
                     template={template}

--- a/studio/components/interfaces/Auth/SmtpForm/SmtpForm.tsx
+++ b/studio/components/interfaces/Auth/SmtpForm/SmtpForm.tsx
@@ -33,6 +33,7 @@ import { useCheckPermissions, useStore } from 'hooks'
 import { urlRegex } from './../Auth.constants'
 import { defaultDisabledSmtpFormValues } from './SmtpForm.constants'
 import { generateFormValues, isSmtpEnabled } from './SmtpForm.utils'
+import EmailRateLimitsAlert from '../EmailRateLimitsAlert'
 
 const SmtpForm = () => {
   const { ui } = useStore()
@@ -231,23 +232,7 @@ const SmtpForm = () => {
                 )
               ) : (
                 <div className="mx-8 mb-8 -mt-4">
-                  <Alert_Shadcn_ variant="warning">
-                    <IconAlertTriangle strokeWidth={2} />
-                    <AlertTitle_Shadcn_>Built-in email service is rate-limited!</AlertTitle_Shadcn_>
-                    <AlertDescription_Shadcn_>
-                      You're using the built-in email service. The service has rate limits and it's
-                      not meant to be used for production apps. Check the{' '}
-                      <a
-                        href="https://supabase.com/docs/guides/platform/going-into-prod#auth-rate-limits"
-                        className="underline"
-                        target="_blank"
-                      >
-                        documentation
-                      </a>{' '}
-                      for an up-to-date information on the current rate limits. Please use a custom
-                      SMTP server if you're planning on having large number of users.
-                    </AlertDescription_Shadcn_>
-                  </Alert_Shadcn_>
+                  <EmailRateLimitsAlert />
                 </div>
               )}
 


### PR DESCRIPTION
Displays the "Built-in email service is rate limited" alert on the Email Templates configuration page.