### PR TITLE
Update docs Generating types using Supabase CLI

### DIFF
--- a/apps/docs/pages/guides/api/rest/generating-types.mdx
+++ b/apps/docs/pages/guides/api/rest/generating-types.mdx
@@ -40,6 +40,12 @@ Generate types for your project to produce the `types/supabase.ts` file:
 npx supabase gen types typescript --project-id "$PROJECT_REF" --schema public > types/supabase.ts
 ```
 
+<Admonition type="note">
+
+You can download the types/supabase.ts file [from the dashboard](https://supabase.com/dashboard/project/_/api?page=tables-intro).
+
+</Admonition>
+
 After you have generated your types, you can use them in `src/index.ts`
 
 ```tsx


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

For point "Generate types for your project to produce the types/supabase.ts file:" 
I thought that maybe some users might need a reference to the supabase.ts file.

```bash
from this code:

Generate types for your project to produce the `types/supabase.ts` file:

npx supabase gen types typescript --project-id "$PROJECT_REF" --schema public > types/supabase.ts
```

[Reference link from live website](https://supabase.com/docs/guides/api/rest/generating-types#generating-types-using-supabase-cli)

## What is the new behavior?

So, I updated the docs and added a note there. I also gave a link to download supabase.ts from the dashboard.

```bash
Changed code:

Generate types for your project to produce the `types/supabase.ts` file:

npx supabase gen types typescript --project-id "$PROJECT_REF" --schema public > types/supabase.ts

<Admonition type="note">

You can download the types/supabase.ts file [from the dashboard](https://supabase.com/dashboard/project/_/api?page=tables-intro).

</Admonition>
```

Feel free to include screenshots if it includes visual changes.

## Additional context

![image](https://github.com/supabase/supabase/assets/110520844/6f2d25a9-ded0-47a6-adc9-780818794b26)
