### PR TITLE
chore: Move logging into Docker logs only

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -94,12 +94,10 @@ FUNCTIONS_VERIFY_JWT=false
 LOGFLARE_LOGGER_BACKEND_API_KEY=your-super-secret-and-long-logflare-key
 
 # Change vector.toml sinks to reflect this change
-LOGFLARE_HTTP_PORT=4001
 LOGFLARE_API_KEY=your-super-secret-and-long-logflare-key
 
-# Change vector.toml sources.docker_syslog to reflect this change
-VECTOR_PORT=9000
-VECTOR_API_PORT=9001
+# Docker socket location - this value will differ depending on your OS
+DOCKER_SOCKET_LOCATION=/var/run/docker.sock
 
 # Google Cloud Project details
 GOOGLE_PROJECT_ID=GOOGLE_PROJECT_ID

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -23,11 +23,6 @@ services:
       timeout: 5s
       interval: 5s
       retries: 3
-    logging:
-      driver: syslog
-      options:
-        syslog-address: "tcp://localhost:${VECTOR_PORT}"
-        tag: studio
     depends_on:
       analytics:
         condition: service_healthy
@@ -60,11 +55,6 @@ services:
     ports:
       - ${KONG_HTTP_PORT}:8000/tcp
       - ${KONG_HTTPS_PORT}:8443/tcp
-    logging:
-      driver: syslog
-      options:
-        syslog-address: "tcp://localhost:${VECTOR_PORT}"
-        tag: kong
     depends_on:
       analytics:
         condition: service_healthy
@@ -107,11 +97,6 @@ services:
       interval: 5s
       retries: 3
     restart: unless-stopped
-    logging:
-      driver: syslog
-      options:
-        syslog-address: "tcp://localhost:${VECTOR_PORT}"
-        tag: auth
     environment:
       GOTRUE_API_HOST: 0.0.0.0
       GOTRUE_API_PORT: 9999
@@ -159,11 +144,6 @@ services:
       analytics:
         condition: service_healthy
     restart: unless-stopped
-    logging:
-      driver: syslog
-      options:
-        syslog-address: "tcp://localhost:${VECTOR_PORT}"
-        tag: rest
     environment:
       PGRST_DB_URI: postgres://authenticator:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
       PGRST_DB_SCHEMAS: ${PGRST_DB_SCHEMAS}
@@ -194,11 +174,6 @@ services:
       interval: 5s
       retries: 3
     restart: unless-stopped
-    logging:
-      driver: syslog
-      options:
-        syslog-address: "tcp://localhost:${VECTOR_PORT}"
-        tag: realtime
     environment:
       PORT: 4000
       DB_HOST: ${POSTGRES_HOST}
@@ -287,11 +262,6 @@ services:
       analytics:
         condition: service_healthy
     restart: unless-stopped
-    logging:
-      driver: syslog
-      options:
-        syslog-address: "tcp://localhost:${VECTOR_PORT}"
-        tag: meta
     environment:
       PG_META_PORT: 8080
       PG_META_DB_HOST: ${POSTGRES_HOST}
@@ -307,11 +277,6 @@ services:
     depends_on:
       analytics:
         condition: service_healthy
-    logging:
-      driver: syslog
-      options:
-        syslog-address: "tcp://localhost:${VECTOR_PORT}"
-        tag: functions
     environment:
       JWT_SECRET: ${JWT_SECRET}
       SUPABASE_URL: http://kong:8000
@@ -368,6 +333,8 @@ services:
       # Uncomment to use Big Query backend for analytics
       # GOOGLE_PROJECT_ID: ${GOOGLE_PROJECT_ID}
       # GOOGLE_PROJECT_NUMBER: ${GOOGLE_PROJECT_NUMBER}
+    ports:
+      - 4000:4000
     entrypoint: |
                   sh -c `cat <<'EOF' > run.sh && sh run.sh
                   ./logflare eval Logflare.Release.migrate
@@ -387,11 +354,6 @@ services:
     depends_on:
       vector:
         condition: service_healthy
-    logging:
-      driver: syslog
-      options:
-        syslog-address: "tcp://localhost:${VECTOR_PORT}"
-        tag: db
     command:
       - postgres
       - -c
@@ -433,14 +395,13 @@ services:
           "--no-verbose",
           "--tries=1",
           "--spider",
-          "http://localhost:${VECTOR_API_PORT}/health"
+          "http://vector:${VECTOR_API_PORT}/health"
         ]
       timeout: 5s
       interval: 5s
       retries: 3
-    ports:
-      - ${VECTOR_PORT}:${VECTOR_PORT}
-      - ${VECTOR_API_PORT}:${VECTOR_API_PORT}
     volumes:
       - ./volumes/logs/vector.yml:/etc/vector/vector.yml:ro
+      - ${DOCKER_SOCKET_LOCATION}:/var/run/docker.sock:ro
+
     command: [ "--config", "etc/vector/vector.yml" ]

--- a/docker/volumes/logs/vector.yml
+++ b/docker/volumes/logs/vector.yml
@@ -1,41 +1,43 @@
 api:
   enabled: true
-  address: '0.0.0.0:9001'
+  address: 0.0.0.0:9001
 
 sources:
-  docker_syslog:
-    type: 'syslog'
-    address: '0.0.0.0:9000'
-    mode: 'tcp'
-    path: '/tmp/socket'
+  docker_host:
+    type: docker_logs
+    exclude_containers:
+      - supabase-vector
 
 transforms:
   project_logs:
     type: remap
     inputs:
-      - docker_syslog
+      - docker_host
     source: |-
       .project = "default"
       .event_message = del(.message)
-      del(.procid)
-      del(.source_id)
+      .appname = del(.container_name)
+      del(.container_created_at)
+      del(.container_id)
       del(.source_type)
-      del(.facility)
+      del(.stream)
+      del(.label)
+      del(.image)
       del(.host)
-      del(.id)
+      del(.stream)
   router:
     type: route
     inputs:
       - project_logs
     route:
-      kong: '.appname == "kong"'
-      auth: '.appname == "auth"'
-      rest: '.appname == "rest"'
-      realtime: '.appname == "realtime"'
-      storage: '.appname == "storage"'
-      functions: '.appname == "functions"'
-      db: '.appname == "db"'
-  # Kong logs only include api requests
+      kong: '.appname == "supabase-kong"'
+      auth: '.appname == "supabase-auth"'
+      rest: '.appname == "supabase-rest"'
+      realtime: '.appname == "supabase-realtime"'
+      storage: '.appname == "supabase-storage"'
+      functions: '.appname == "supabase-functions"'
+      db: '.appname == "supabase-db"'
+  # Ignores non nginx errors since they are related with kong booting up
   kong_logs:
     type: remap
     inputs:
@@ -52,7 +54,10 @@ transforms:
           .metadata.request.protocol = req.protocol
           .metadata.response.status_code = req.status
       }
-  # TODO: create a separate page and filter for kong error logs
+      if err != null {
+        abort
+      }
+  # Ignores non nginx errors since they are related with kong booting up
   kong_err:
     type: remap
     inputs:
@@ -72,6 +77,9 @@ transforms:
               .metadata.request.path = url[1]
               .metadata.request.protocol = url[2]
           }
+      }
+      if err != null {
+        abort
       }
   # Gotrue logs are structured json strings which frontend parses directly. But we keep metadata for consistency.
   auth_logs:
@@ -126,7 +134,6 @@ transforms:
           .metadata.context[0].pid = parsed.pid
       }
   # Postgres logs some messages to stderr which we map to warning severity level
-  # TODO: parse raw postgres logs via regex
   db_logs:
     type: remap
     inputs:
@@ -134,7 +141,16 @@ transforms:
     source: |-
       .metadata.host = "db-default"
       .metadata.parsed.timestamp = .timestamp
-      .metadata.parsed.error_severity = replace!(.severity, r'^err$', "warning")
+      parsed, err = parse_regex(.event_message, r'.*(?P<level>INFO|NOTICE|WARNING|ERROR|LOG|FATAL|PANIC?):.*', numeric_groups: true)
+
+      if err != null || parsed == null {
+        .metadata.parsed.error_severity = "info"
+      }
+      if parsed != null {
+       .metadata.parsed.error_severity = parsed.level
+      }
+
+
 
 sinks:
   logflare_auth:
@@ -204,6 +220,7 @@ sinks:
     type: 'http'
     inputs:
       - kong_logs
+      - kong_err
     encoding:
       codec: 'json'
     method: 'post'

--- a/studio/.env
+++ b/studio/.env
@@ -3,6 +3,9 @@ POSTGRES_PASSWORD=your-super-secret-and-long-postgres-password
 
 DEFAULT_ORGANIZATION_NAME=Default Organization
 DEFAULT_PROJECT_NAME=Default Project
+DASHBOARD_USERNAME=supabase
+DASHBOARD_PASSWORD=this_password_is_insecure_and_should_be_updated
+
 
 SUPABASE_URL=http://localhost:8000
 SUPABASE_PUBLIC_URL=http://localhost:8000
@@ -20,3 +23,5 @@ NEXT_PUBLIC_HCAPTCHA_SITE_KEY=10000000-ffff-ffff-ffff-000000000001
 # CmdK / AI
 NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InhndWloeHV6cWlid3hqbmlteGV2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE2NzUwOTQ4MzUsImV4cCI6MTk5MDY3MDgzNX0.0PMlOxtKL4O9GGZuAP_Xl4f-Tut1qOnW4bNEmAtoB8w
 NEXT_PUBLIC_SUPABASE_URL=https://xguihxuzqibwxjnimxev.supabase.co
+
+DOCKER_SOCKET_LOCATION=/var/run/docker.sock


### PR DESCRIPTION
## What kind of change does this PR introduce?

Change the Vector ingestion to use docker logs directly from the docker socket instead of syslog via an open port

