### PR TITLE
Update getting-started.mdx because of dangerous default

### DIFF
--- a/apps/docs/pages/guides/cli/getting-started.mdx
+++ b/apps/docs/pages/guides/cli/getting-started.mdx
@@ -120,7 +120,7 @@ brew upgrade supabase
 If you have any Supabase containers running locally, remember to restart them after upgrading to use the new features.
 
 ```bash
-supabase stop --no-backup
+supabase stop
 supabase start
 ```
 


### PR DESCRIPTION
I somehow cannot relate why the default to stop containers would be `--no-backup` . Many people copy paste scripts from the official docs.

## What kind of change does this PR introduce?

Docs Update
