### PR TITLE
feat: go-live org-based billing

### DIFF
--- a/studio/components/interfaces/BillingV2/SpendCapModal.tsx
+++ b/studio/components/interfaces/BillingV2/SpendCapModal.tsx
@@ -34,12 +34,12 @@ const SpendCapModal = ({ visible, onHide }: SpendCapModalProps) => {
                 <div className="flex items-center px-4 py-1">
                   <p className="w-[50%] text-sm">Database size</p>
                   <p className="w-[25%] text-sm">8GB</p>
-                  <p className="w-[25%] text-sm">$0.125/GB</p>
+                  <p className="w-[25%] text-sm">$0.125 per GB</p>
                 </div>
                 <div className="flex items-center px-4 py-1">
-                  <p className="w-[50%] text-sm">Database egress</p>
-                  <p className="w-[25%] text-sm">50GB</p>
-                  <p className="w-[25%] text-sm">$0.09/GB</p>
+                  <p className="w-[50%] text-sm">Egress</p>
+                  <p className="w-[25%] text-sm">250GB</p>
+                  <p className="w-[25%] text-sm">$0.09 per GB</p>
                 </div>
               </div>
               <div className="py-2">
@@ -75,10 +75,8 @@ const SpendCapModal = ({ visible, onHide }: SpendCapModalProps) => {
                     </Tooltip.Root>
                   </div>
                   <p className="w-[25%] text-sm">100,000</p>
-                  <p className="w-[25%] text-sm">$0.00325/user</p>
+                  <p className="w-[25%] text-sm">$0.00325 per user</p>
                 </div>
-              </div>
-              <div className="py-2">
                 <div className="flex items-center px-4 py-1">
                   <div className="flex w-[50%] items-center space-x-2">
                     <p className="text-sm">Single Sign-On (SAML 2.0) MAUs</p>
@@ -111,19 +109,15 @@ const SpendCapModal = ({ visible, onHide }: SpendCapModalProps) => {
                     </Tooltip.Root>
                   </div>
                   <p className="w-[25%] text-sm">50</p>
-                  <p className="w-[25%] text-sm">$0.015/user</p>
+                  <p className="w-[25%] text-sm">$0.015 per user</p>
                 </div>
               </div>
+
               <div className="py-2">
                 <div className="flex items-center px-4 py-1">
                   <p className="w-[50%] text-sm">Storage size</p>
                   <p className="w-[25%] text-sm">100GB</p>
-                  <p className="w-[25%] text-sm">$0.021/GB</p>
-                </div>
-                <div className="flex items-center px-4 py-1">
-                  <p className="w-[50%] text-sm">Storage egress</p>
-                  <p className="w-[25%] text-sm">200GB</p>
-                  <p className="w-[25%] text-sm">$0.09/GB</p>
+                  <p className="w-[25%] text-sm">$0.021 per GB</p>
                 </div>
                 <div className="flex items-center px-4 py-1">
                   <p className="w-[50%] text-sm">Storage Image Transformations</p>
@@ -136,13 +130,13 @@ const SpendCapModal = ({ visible, onHide }: SpendCapModalProps) => {
                 <div className="flex items-center px-4 py-1">
                   <p className="w-[50%] text-sm">Realtime concurrent peak connections</p>
                   <p className="w-[25%] text-sm">500</p>
-                  <p className="w-[25%] text-sm">$10/1000</p>
+                  <p className="w-[25%] text-sm">$10 per 1000</p>
                 </div>
 
                 <div className="flex items-center px-4 py-1">
                   <p className="w-[50%] text-sm">Realtime messages</p>
                   <p className="w-[25%] text-sm">5 Million</p>
-                  <p className="w-[25%] text-sm">$2.50/Million</p>
+                  <p className="w-[25%] text-sm">$2.50 per Million</p>
                 </div>
               </div>
 
@@ -161,7 +155,7 @@ const SpendCapModal = ({ visible, onHide }: SpendCapModalProps) => {
               </div>
             </div>
 
-            <p>
+            <p className="text-sm">
               See{' '}
               <Link href="https://supabase.com/pricing" passHref>
                 <a className="text-brand" target="_blank" rel="noreferrer">

--- a/studio/components/interfaces/Organization/BillingSettingsV2/Subscription/PlanUpdateSidePanel.tsx
+++ b/studio/components/interfaces/Organization/BillingSettingsV2/Subscription/PlanUpdateSidePanel.tsx
@@ -266,7 +266,7 @@ const PlanUpdateSidePanel = () => {
                     <div className="border-t my-6" />
 
                     <ul role="list">
-                      {(plan.featuresOrg || plan.features).map((feature) => (
+                      {(plan.features).map((feature) => (
                         <li key={feature} className="flex py-2">
                           <div className="w-[12px]">
                             <IconCheck

--- a/studio/components/interfaces/Organization/GeneralSettings/OrganizationBillingMigrationPanel.tsx
+++ b/studio/components/interfaces/Organization/GeneralSettings/OrganizationBillingMigrationPanel.tsx
@@ -23,10 +23,8 @@ const OrganizationBillingMigrationPanel = observer(() => {
             <div className="space-y-2">
               <p className="text-sm text-scale-1100">
                 You will have a single subscription for all projects inside the organization, rather
-                than individual subscriptions per project.
-              </p>
-              <p className="text-sm text-scale-1100">
-                Migrating your organization billing is not reversible.
+                than individual subscriptions per project. Migrating to organization-based billing
+                is not reversible.
               </p>
             </div>
             <div className="flex items-center gap-4 ml-12">

--- a/studio/components/interfaces/Organization/NewOrg/NewOrgForm.tsx
+++ b/studio/components/interfaces/Organization/NewOrg/NewOrgForm.tsx
@@ -23,6 +23,7 @@ import { invalidateOrganizationsQuery } from 'data/organizations/organizations-q
 import { useStore } from 'hooks'
 import { BASE_PATH, PRICING_TIER_LABELS_ORG } from 'lib/constants'
 import { getURL } from 'lib/helpers'
+import { useParams } from 'common'
 
 const ORG_KIND_TYPES = {
   PERSONAL: 'Personal',
@@ -57,6 +58,8 @@ const NewOrgForm = ({ onPaymentMethodReset }: NewOrgFormProps) => {
   const stripe = useStripe()
   const elements = useElements()
 
+  const { plan } = useParams()
+
   const [orgName, setOrgName] = useState('')
   const [orgKind, setOrgKind] = useState(ORG_KIND_DEFAULT)
   const [orgSize, setOrgSize] = useState(ORG_SIZE_DEFAULT)
@@ -64,7 +67,10 @@ const NewOrgForm = ({ onPaymentMethodReset }: NewOrgFormProps) => {
   const [newOrgLoading, setNewOrgLoading] = useState(false)
   const [paymentMethod, setPaymentMethod] = useState<PaymentMethod>()
 
-  const [dbPricingTierKey, setDbPricingTierKey] = useState('FREE')
+  // URL param support for passing plan
+  const [dbPricingTierKey, setDbPricingTierKey] = useState(
+    plan && ['free', 'team', 'pro'].includes(plan) ? plan.toUpperCase() : 'FREE'
+  )
 
   const [showSpendCapHelperModal, setShowSpendCapHelperModal] = useState(false)
   const [isSpendCapEnabled, setIsSpendCapEnabled] = useState(true)
@@ -133,7 +139,7 @@ const NewOrgForm = ({ onPaymentMethodReset }: NewOrgFormProps) => {
         elements,
         redirect: 'if_required',
         confirmParams: {
-          return_url: `${getURL()}/new-with-subscription`,
+          return_url: `${getURL()}/new`,
           expand: ['payment_method'],
         },
       })

--- a/studio/components/interfaces/Settings/General/TransferProjectPanel/TransferProjectButton.tsx
+++ b/studio/components/interfaces/Settings/General/TransferProjectPanel/TransferProjectButton.tsx
@@ -18,7 +18,7 @@ import {
 import { useOrganizationsQuery } from 'data/organizations/organizations-query'
 import { useProjectTransferMutation } from 'data/projects/project-transfer-mutation'
 import { useProjectTransferPreviewQuery } from 'data/projects/project-transfer-preview-query'
-import { useCheckPermissions, useSelectedProject, useStore } from 'hooks'
+import { useCheckPermissions, useFlag, useSelectedProject, useStore } from 'hooks'
 
 const TransferProjectButton = () => {
   const { ui } = useStore()
@@ -27,6 +27,7 @@ const TransferProjectButton = () => {
   const projectRef = project?.ref
   const projectOrgId = project?.organization_id
   const { data: allOrganizations } = useOrganizationsQuery()
+  const disableProjectTransfer = useFlag('disableProjectTransfer')
 
   const organizations = (allOrganizations || [])
     .filter((it) => it.id !== projectOrgId)
@@ -87,11 +88,15 @@ const TransferProjectButton = () => {
     <>
       <Tooltip.Root delayDuration={0}>
         <Tooltip.Trigger>
-          <Button onClick={toggle} type="default" disabled={!canTransferProject}>
+          <Button
+            onClick={toggle}
+            type="default"
+            disabled={!canTransferProject || disableProjectTransfer}
+          >
             Transfer project
           </Button>
         </Tooltip.Trigger>
-        {!canTransferProject && (
+        {(!canTransferProject || disableProjectTransfer) && (
           <Tooltip.Portal>
             <Tooltip.Content side="bottom">
               <Tooltip.Arrow className="radix-tooltip-arrow" />
@@ -102,7 +107,9 @@ const TransferProjectButton = () => {
                 ].join(' ')}
               >
                 <span className="text-xs text-scale-1200">
-                  You need additional permissions to transfer this project
+                  {!canTransferProject
+                    ? 'You need additional permissions to transfer this project'
+                    : 'Project transfers are temporarily disabled, please try again later.'}
                 </span>
               </div>
             </Tooltip.Content>

--- a/studio/components/layouts/AppLayout/OrganizationDropdown.tsx
+++ b/studio/components/layouts/AppLayout/OrganizationDropdown.tsx
@@ -22,11 +22,10 @@ import {
 import ShimmeringLoader from 'components/ui/ShimmeringLoader'
 import { useOrganizationsQuery } from 'data/organizations/organizations-query'
 import { useOrgSubscriptionQuery } from 'data/subscriptions/org-subscription-query'
-import { useFlag, useSelectedOrganization } from 'hooks'
+import { useSelectedOrganization } from 'hooks'
 
 const OrganizationDropdown = () => {
   const router = useRouter()
-  const orgCreationV2 = useFlag('orgcreationv2')
   const selectedOrganization = useSelectedOrganization()
   const { data: organizations, isLoading: isLoadingOrganizations } = useOrganizationsQuery()
 
@@ -97,13 +96,13 @@ const OrganizationDropdown = () => {
                 </ScrollArea>
               </CommandGroup_Shadcn_>
               <CommandGroup_Shadcn_ className="border-t">
-                <Link passHref href={orgCreationV2 ? `/new-with-subscription` : `/new`}>
+                <Link passHref href="new">
                   <CommandItem_Shadcn_
                     asChild
                     className="cursor-pointer flex items-center space-x-2 w-full"
                     onSelect={(e) => {
                       setOpen(false)
-                      router.push(orgCreationV2 ? `/new-with-subscription` : `/new`)
+                      router.push(`/new`)
                     }}
                     onClick={() => setOpen(false)}
                   >

--- a/studio/components/layouts/ProjectLayout/LayoutHeader/OrgDropdown.tsx
+++ b/studio/components/layouts/ProjectLayout/LayoutHeader/OrgDropdown.tsx
@@ -2,7 +2,7 @@ import { toJS } from 'mobx'
 import { useRouter } from 'next/router'
 
 import { useOrganizationsQuery } from 'data/organizations/organizations-query'
-import { useFlag, useSelectedOrganization, useStore } from 'hooks'
+import { useSelectedOrganization, useStore } from 'hooks'
 import { IS_PLATFORM } from 'lib/constants'
 import { Button, Dropdown, IconPlus } from 'ui'
 
@@ -12,8 +12,6 @@ const OrgDropdown = () => {
 
   const { data: organizations } = useOrganizationsQuery()
   const selectedOrganization = useSelectedOrganization()
-
-  const orgCreationV2 = useFlag('orgcreationv2')
 
   return IS_PLATFORM ? (
     <Dropdown
@@ -54,10 +52,7 @@ const OrgDropdown = () => {
             })}
           <Dropdown.Separator />
 
-          <Dropdown.Item
-            icon={<IconPlus size="tiny" />}
-            onClick={() => router.push(orgCreationV2 ? `/new-with-subscription` : `/new`)}
-          >
+          <Dropdown.Item icon={<IconPlus size="tiny" />} onClick={() => router.push(`/new`)}>
             New organization
           </Dropdown.Item>
         </>

--- a/studio/components/to-be-cleaned/Dropdown/OrganizationDropdown.js
+++ b/studio/components/to-be-cleaned/Dropdown/OrganizationDropdown.js
@@ -1,12 +1,10 @@
 import { useRouter } from 'next/router'
 
-import { useFlag } from 'hooks'
 import { Button, Dropdown, IconPlus } from 'ui'
 import { EMPTY_ARR } from 'lib/void'
 
 const OrganizationDropdown = ({ organizations = EMPTY_ARR }) => {
   const router = useRouter()
-  const orgCreationV2 = useFlag('orgcreationv2')
 
   return (
     <Dropdown
@@ -29,7 +27,7 @@ const OrganizationDropdown = ({ organizations = EMPTY_ARR }) => {
           <Dropdown.Separator />
           <Dropdown.Item
             icon={<IconPlus size="tiny" />}
-            onClick={() => router.push(orgCreationV2 ? `/new-with-subscription` : `/new`)}
+            onClick={() => router.push(`/new`)}
           >
             New organization
           </Dropdown.Item>

--- a/studio/data/subscriptions/org-subscription-update-mutation.ts
+++ b/studio/data/subscriptions/org-subscription-update-mutation.ts
@@ -4,6 +4,7 @@ import { API_URL } from 'lib/constants'
 import { toast } from 'react-hot-toast'
 import { ResponseError } from 'types/base'
 import { subscriptionKeys } from './keys'
+import { usageKeys } from 'data/usage/keys'
 
 export type SubscriptionTier =
   | 'tier_free'
@@ -54,7 +55,17 @@ export const useOrgSubscriptionUpdateMutation = ({
     {
       async onSuccess(data, variables, context) {
         const { slug } = variables
-        await queryClient.invalidateQueries(subscriptionKeys.orgSubscription(slug))
+
+        // [Kevin] Backend can return stale data as it's waiting for the Stripe-sync to complete. Until that's solved in the backend
+        // we are going back to monkey here and delay the invalidation
+        await new Promise((resolve) => setTimeout(resolve, 2000))
+
+        await Promise.all([
+          queryClient.invalidateQueries(subscriptionKeys.orgSubscription(slug)),
+          queryClient.invalidateQueries(subscriptionKeys.orgPlans(slug)),
+          queryClient.invalidateQueries(usageKeys.orgUsage(slug)),
+        ])
+
         await onSuccess?.(data, variables, context)
       },
       async onError(data, variables, context) {

--- a/studio/pages/new/[slug].tsx
+++ b/studio/pages/new/[slug].tsx
@@ -474,16 +474,24 @@ const Wizard: NextPageWithLayout = () => {
                         <span className="text-brand">{orgSubscription?.plan?.name} plan</span>.
                       </p>
 
+                      {/* Show info when launching a new project in a paid org that has no project yet */}
+                      {orgSubscription?.plan?.id !== 'free' && orgProjectCount === 0 && (
+                        <div>
+                          <p>
+                            As this is the first project you're launching in this organization, it
+                            comes with no additional compute costs.
+                          </p>
+                        </div>
+                      )}
+
                       {/* Show info when launching a new project in a paid org that already has at least one project */}
                       {orgSubscription?.plan?.id !== 'free' && orgProjectCount > 0 && (
                         <div>
                           <p>
                             Launching another project incurs additional compute costs, starting at
-                            $0.01344 per hour (~$10/month).
-                          </p>
-                          <p>
-                            You can also create a new organization under the free plan (unless you
-                            have exceeded your 2 free project limit).
+                            $0.01344 per hour (~$10/month). You can also create a new organization
+                            under the free plan in case you have not exceeded your 2 free project
+                            limit.
                           </p>
                         </div>
                       )}

--- a/studio/pages/old-org.tsx
+++ b/studio/pages/old-org.tsx
@@ -1,0 +1,168 @@
+import { observer } from 'mobx-react-lite'
+import { useRouter } from 'next/router'
+import { useState } from 'react'
+import { Button, Input, Listbox } from 'ui'
+
+import { WizardLayout } from 'components/layouts'
+import Panel from 'components/ui/Panel'
+import { useOrganizationCreateMutation } from 'data/organizations/organization-create-mutation'
+import { useStore } from 'hooks'
+import { NextPageWithLayout } from 'types'
+
+const ORG_KIND_TYPES = {
+  PERSONAL: 'Personal',
+  EDUCATIONAL: 'Educational',
+  STARTUP: 'Startup',
+  AGENCY: 'Agency',
+  COMPANY: 'Company',
+  UNDISCLOSED: 'N/A',
+}
+const ORG_KIND_DEFAULT = 'PERSONAL'
+
+const ORG_SIZE_TYPES = {
+  '1': '1 - 10',
+  '10': '10 - 49',
+  '50': '50 - 99',
+  '100': '100 - 299',
+  '300': 'More than 300',
+}
+const ORG_SIZE_DEFAULT = '1'
+
+/**
+ * No org selected yet, create a new one
+ */
+const Wizard: NextPageWithLayout = () => {
+  const { ui } = useStore()
+  const router = useRouter()
+
+  const [orgName, setOrgName] = useState('')
+  const [orgKind, setOrgKind] = useState(ORG_KIND_DEFAULT)
+  const [orgSize, setOrgSize] = useState(ORG_SIZE_DEFAULT)
+
+  const { mutate: createOrganization, isLoading: newOrgLoading } = useOrganizationCreateMutation({
+    onSuccess: async (org: any) => {
+      // [Joshen] API spec is wrong? its returning org type as only having id and name
+      router.push(`/new/${org.slug}`)
+    },
+  })
+
+  function validateOrgName(name: any) {
+    return name.length >= 1
+  }
+
+  function onOrgNameChange(e: any) {
+    setOrgName(e.target.value)
+  }
+
+  function onOrgKindChange(value: any) {
+    setOrgKind(value)
+  }
+
+  function onOrgSizeChange(value: any) {
+    setOrgSize(value)
+  }
+
+  async function onClickSubmit(e: any) {
+    e.preventDefault()
+    const trimmedOrgName = orgName ? orgName.trim() : ''
+    const isOrgNameValid = validateOrgName(trimmedOrgName)
+    if (!isOrgNameValid) {
+      return ui.setNotification({ category: 'error', message: 'Organization name is empty' })
+    }
+
+    createOrganization({
+      name: trimmedOrgName,
+      kind: orgKind,
+      ...(orgKind == 'COMPANY' ? { size: orgSize } : {}),
+    })
+  }
+
+  return (
+    <Panel
+      hideHeaderStyling
+      title={
+        <div key="panel-title">
+          <h4>Create a new organization</h4>
+        </div>
+      }
+      footer={
+        <div key="panel-footer" className="flex w-full items-center justify-between">
+          <Button type="default" onClick={() => router.push('/projects')}>
+            Cancel
+          </Button>
+          <div className="flex items-center space-x-3">
+            <p className="text-xs text-scale-900">You can rename your organization later</p>
+            <Button onClick={onClickSubmit} loading={newOrgLoading} disabled={newOrgLoading}>
+              Create organization
+            </Button>
+          </div>
+        </div>
+      }
+    >
+      <Panel.Content className="pt-0">
+        <p className="text-sm">This is your organization within Supabase.</p>
+        <p className="text-sm text-scale-1100">
+          For example, you can use the name of your company or department.
+        </p>
+      </Panel.Content>
+      <Panel.Content className="Form section-block--body has-inputs-centered">
+        <Input
+          autoFocus
+          label="Name"
+          type="text"
+          layout="horizontal"
+          placeholder="Organization name"
+          descriptionText="What's the name of your company or team?"
+          value={orgName}
+          onChange={onOrgNameChange}
+        />
+      </Panel.Content>
+      <Panel.Content className="Form section-block--body has-inputs-centered">
+        <Listbox
+          label="Type of organization"
+          layout="horizontal"
+          value={orgKind}
+          onChange={onOrgKindChange}
+          descriptionText="What would best describe your organization?"
+        >
+          {Object.entries(ORG_KIND_TYPES).map(([k, v]) => {
+            return (
+              <Listbox.Option key={k} label={v} value={k}>
+                {v}
+              </Listbox.Option>
+            )
+          })}
+        </Listbox>
+      </Panel.Content>
+      {orgKind == 'COMPANY' ? (
+        <Panel.Content className="Form section-block--body has-inputs-centered">
+          <Listbox
+            label="Company size"
+            layout="horizontal"
+            value={orgSize}
+            onChange={onOrgSizeChange}
+            descriptionText="How many people are in your company?"
+          >
+            {Object.entries(ORG_SIZE_TYPES).map(([k, v]) => {
+              return (
+                <Listbox.Option key={k} label={v} value={k}>
+                  {v}
+                </Listbox.Option>
+              )
+            })}
+          </Listbox>
+        </Panel.Content>
+      ) : (
+        <></>
+      )}
+    </Panel>
+  )
+}
+
+Wizard.getLayout = (page) => (
+  <WizardLayout organization={null} project={null}>
+    {page}
+  </WizardLayout>
+)
+
+export default observer(Wizard)

--- a/studio/pages/org/_/[[...routeSlug]].tsx
+++ b/studio/pages/org/_/[[...routeSlug]].tsx
@@ -77,7 +77,7 @@ const GenericOrganizationPage: NextPage = () => {
                 </p>
               </div>
               <div>
-                <Link href={`/new`}>
+                <Link href="/new">
                   <a>
                     <Button icon={<IconPlus />}>New organization</Button>
                   </a>


### PR DESCRIPTION
- New org creation supports reading a plan from URL params
- Swap out old org creation with new one
- Adjusted spend cap modal
- Kill switches for project transfers and org billing creation
- Permission check for org billing migration
