### PR TITLE
fix(www): className on Img components

### DIFF
--- a/apps/www/lib/mdx/mdxComponents.tsx
+++ b/apps/www/lib/mdx/mdxComponents.tsx
@@ -12,6 +12,7 @@ import {
   CollapsibleTrigger_Shadcn_,
   CollapsibleContent_Shadcn_,
   IconTriangle,
+  cn,
 } from 'ui'
 import ImageFadeStack from '~/components/ImageFadeStack'
 import ZoomableImg from '~/components/ZoomableImg/ZoomableImg'
@@ -91,8 +92,8 @@ export default function mdxComponents(type?: 'blog' | 'lp' | undefined) {
       }
       return <img {...props} />
     },
-    Img: ({ zoomable = true, ...props }: any) => (
-      <figure className="m-0">
+    Img: ({ zoomable = true, className, ...props }: any) => (
+      <figure className={cn('m-0', className)}>
         <ZoomableImg zoomable={zoomable}>
           <span
             className={[


### PR DESCRIPTION
For `<Img />` components, some classes in the `className` prop are getting overwritten by styles in the `style` attribute (maybe coming from `react-medium-image-zoom`?). Specifically in blog posts we are unable to show/hide images based on light/dark mode (via tailwind `className`).

Eg.
```jsx
<div>
  <Img
    alt="my light mode image"
    className="dark:hidden"
    src="/images/blog/my-image--light.png"
  />
  <Img
    alt="my dark mode image"
    className="hidden dark:block"
    src="/images/blog/my-image--dark.png"
  />
</div>
```

This change applies the `<Img />` `className` prop to the top level `<figure />` instead of the Next.js `<Image />`.