### PR TITLE
chore: improve org-billing infos

### DIFF
--- a/studio/components/interfaces/Organization/BillingSettingsV2/PaymentMethods/ChangePaymentMethodModal.tsx
+++ b/studio/components/interfaces/Organization/BillingSettingsV2/PaymentMethods/ChangePaymentMethodModal.tsx
@@ -1,10 +1,8 @@
 import { useParams } from 'common'
 import { OrganizationPaymentMethod } from 'data/organizations/organization-payment-methods-query'
 import { useOrgSubscriptionQuery } from 'data/subscriptions/org-subscription-query'
-import {
-  SubscriptionTier,
-  useOrgSubscriptionUpdateMutation,
-} from 'data/subscriptions/org-subscription-update-mutation'
+import { useOrgSubscriptionUpdateMutation } from 'data/subscriptions/org-subscription-update-mutation'
+import { SubscriptionTier } from 'data/subscriptions/types'
 import { useStore } from 'hooks'
 import { Button, Modal } from 'ui'
 

--- a/studio/components/interfaces/Organization/BillingSettingsV2/Subscription/PlanUpdateSidePanel.tsx
+++ b/studio/components/interfaces/Organization/BillingSettingsV2/Subscription/PlanUpdateSidePanel.tsx
@@ -7,10 +7,7 @@ import { useEffect, useState } from 'react'
 import ShimmeringLoader from 'components/ui/ShimmeringLoader'
 import { useOrgPlansQuery } from 'data/subscriptions/org-plans-query'
 import { useOrgSubscriptionQuery } from 'data/subscriptions/org-subscription-query'
-import {
-  SubscriptionTier,
-  useOrgSubscriptionUpdateMutation,
-} from 'data/subscriptions/org-subscription-update-mutation'
+import { useOrgSubscriptionUpdateMutation } from 'data/subscriptions/org-subscription-update-mutation'
 import { useCheckPermissions, useSelectedOrganization, useStore } from 'hooks'
 import { PRICING_TIER_PRODUCT_IDS } from 'lib/constants'
 import Telemetry from 'lib/telemetry'
@@ -27,6 +24,7 @@ import { useFreeProjectLimitCheckQuery } from 'data/organizations/free-project-l
 import { useOrganizationBillingSubscriptionPreview } from 'data/organizations/organization-billing-subscription-preview'
 import InformationBox from 'components/ui/InformationBox'
 import AlertError from 'components/ui/AlertError'
+import { SubscriptionTier } from 'data/subscriptions/types'
 
 // [Joshen TODO] Need to remove all contexts of "projects"
 
@@ -266,7 +264,7 @@ const PlanUpdateSidePanel = () => {
                     <div className="border-t my-6" />
 
                     <ul role="list">
-                      {(plan.features).map((feature) => (
+                      {plan.features.map((feature) => (
                         <li key={feature} className="flex py-2">
                           <div className="w-[12px]">
                             <IconCheck
@@ -304,7 +302,7 @@ const PlanUpdateSidePanel = () => {
       <Modal
         loading={isUpdating}
         alignFooter="right"
-        className="!w-[550px]"
+        size="large"
         visible={selectedTier !== undefined && selectedTier !== 'tier_free'}
         onCancel={() => setSelectedTier(undefined)}
         onConfirm={onUpdateSubscription}

--- a/studio/components/interfaces/Settings/General/TransferProjectPanel/TransferProjectButton.tsx
+++ b/studio/components/interfaces/Settings/General/TransferProjectPanel/TransferProjectButton.tsx
@@ -144,7 +144,13 @@ const TransferProjectButton = () => {
           <Modal.Content>
             <p className="text-sm">
               To transfer projects, the owner must be a member of both the source and target
-              organizations.
+              organizations. For further information see our{' '}
+              <Link href="https://supabase.com/docs/guides/platform/project-transfer">
+                <a className="text-brand hover:underline" target="_blank" rel="noreferrer">
+                  Documentation
+                </a>
+              </Link>
+              .
             </p>
 
             <p className="font-bold mt-6 text-sm">Transferring considerations:</p>

--- a/studio/components/layouts/ProjectLayout/LayoutHeader/LayoutHeader.tsx
+++ b/studio/components/layouts/ProjectLayout/LayoutHeader/LayoutHeader.tsx
@@ -38,7 +38,7 @@ const LayoutHeader = ({ customHeaderComponents, breadcrumbs = [], headerBorder =
     { enabled: selectedOrganization && !selectedOrganization.subscription_id }
   )
 
-  const projectHasNoLimits = subscription?.usage_billing_enabled === false
+  const projectHasNoLimits = subscription?.usage_billing_enabled === true
 
   const showOverUsageBadge =
     useFlag('overusageBadge') &&

--- a/studio/data/organizations/organization-billing-subscription-preview.ts
+++ b/studio/data/organizations/organization-billing-subscription-preview.ts
@@ -2,10 +2,11 @@ import { useQuery, UseQueryOptions } from '@tanstack/react-query'
 import { post } from 'data/fetchers'
 import { organizationKeys } from './keys'
 import { ResponseError } from 'types'
+import { SubscriptionTier } from 'data/subscriptions/types'
 
 export type OrganizationBillingSubscriptionPreviewVariables = {
   organizationSlug?: string
-  tier?: 'tier_payg' | 'tier_pro' | 'tier_free' | 'tier_team' | 'tier_enterprise'
+  tier?: SubscriptionTier
 }
 
 export type OrganizationBillingSubscriptionPreviewResponse = {

--- a/studio/data/organizations/organization-migrate-billing-preview-query.ts
+++ b/studio/data/organizations/organization-migrate-billing-preview-query.ts
@@ -2,6 +2,7 @@ import { useQuery, UseQueryOptions } from '@tanstack/react-query'
 import { post } from 'lib/common/fetch'
 import { API_URL } from 'lib/constants'
 import { organizationKeys } from './keys'
+import { SubscriptionTier } from 'data/subscriptions/types'
 
 export type OrganizationBillingMigrationPreviewVariables = {
   organizationSlug?: string
@@ -21,6 +22,7 @@ export type OrganizationBillingMigrationPreviewResponse = {
     quantity: number
     total_price: number
   }[]
+  old_tiers: SubscriptionTier[]
 }
 
 export async function previewOrganizationBillingMigration(

--- a/studio/data/subscriptions/org-subscription-update-mutation.ts
+++ b/studio/data/subscriptions/org-subscription-update-mutation.ts
@@ -5,13 +5,7 @@ import { toast } from 'react-hot-toast'
 import { ResponseError } from 'types/base'
 import { subscriptionKeys } from './keys'
 import { usageKeys } from 'data/usage/keys'
-
-export type SubscriptionTier =
-  | 'tier_free'
-  | 'tier_pro'
-  | 'tier_payg'
-  | 'tier_team'
-  | 'tier_enterprise'
+import { SubscriptionTier } from './types'
 
 export type OrgSubscriptionUpdateVariables = {
   slug: string

--- a/studio/data/subscriptions/types.ts
+++ b/studio/data/subscriptions/types.ts
@@ -1,0 +1,6 @@
+export type SubscriptionTier =
+  | 'tier_free'
+  | 'tier_pro'
+  | 'tier_payg'
+  | 'tier_team'
+  | 'tier_enterprise'

--- a/studio/pages/new/[slug].tsx
+++ b/studio/pages/new/[slug].tsx
@@ -496,7 +496,14 @@ const Wizard: NextPageWithLayout = () => {
                         </div>
                       )}
 
-                      <div>
+                      <div className="space-x-3">
+                        <Link href="https://supabase.com/blog/organization-based-billing">
+                          <a target="_blank" rel="noreferrer">
+                            <Button type="default" icon={<IconExternalLink strokeWidth={1.5} />}>
+                              Announcement
+                            </Button>
+                          </a>
+                        </Link>
                         <Link href="https://supabase.com/docs/guides/platform/org-based-billing">
                           <a target="_blank" rel="noreferrer">
                             <Button type="default" icon={<IconExternalLink strokeWidth={1.5} />}>
@@ -570,6 +577,51 @@ const Wizard: NextPageWithLayout = () => {
                 {!billedViaOrg && !isSelectFreeTier && isEmptyPaymentMethod && (
                   <EmptyPaymentMethodWarning onPaymentMethodAdded={() => refetchPaymentMethods()} />
                 )}
+              </Panel.Content>
+            )}
+
+            {!billedViaOrg && (
+              <Panel.Content>
+                <InformationBox
+                  icon={<IconInfo size="large" strokeWidth={1.5} />}
+                  defaultVisibility={true}
+                  hideCollapse
+                  title="Legacy Billing"
+                  description={
+                    <div className="space-y-3">
+                      <p className="text-sm leading-normal">
+                        This organization uses the legacy project-based billing. We’ve recently made
+                        some big improvements to our billing system. To opt-in to the new
+                        organization-based billing, head over to your{' '}
+                        <Link href={`/org/${slug}/billing`}>
+                          <a>
+                            <span className="text-sm text-green-900 transition hover:text-green-1000">
+                              organization billing settings
+                            </span>
+                          </a>
+                        </Link>
+                        .
+                      </p>
+
+                      <div className="space-x-3">
+                        <Link href="https://supabase.com/blog/organization-based-billing">
+                          <a target="_blank" rel="noreferrer">
+                            <Button type="default" icon={<IconExternalLink strokeWidth={1.5} />}>
+                              Announcement
+                            </Button>
+                          </a>
+                        </Link>
+                        <Link href="https://supabase.com/docs/guides/platform/org-based-billing">
+                          <a target="_blank" rel="noreferrer">
+                            <Button type="default" icon={<IconExternalLink strokeWidth={1.5} />}>
+                              Documentation
+                            </Button>
+                          </a>
+                        </Link>
+                      </div>
+                    </div>
+                  }
+                />
               </Panel.Content>
             )}
 


### PR DESCRIPTION
- Adds an info box to inform about the usage of legacy billing when launching a new project
- Add warnings for spend cap in billing migration modal
  - Switched spend cap to off by default for the migration, as this could lead to serious restrictions
- Added link to docs in project transfer modal
- Fixed display criteria of over-usage banner