### PR TITLE
Update search param in email-based-auth-with-pkce-flow-for-ssr.mdx

### DIFF
--- a/apps/docs/pages/guides/auth/server-side/email-based-auth-with-pkce-flow-for-ssr.mdx
+++ b/apps/docs/pages/guides/auth/server-side/email-based-auth-with-pkce-flow-for-ssr.mdx
@@ -168,7 +168,7 @@ export const GET = async (event) => {
 		url,
 		locals: { supabase }
 	} = event;
-	const token_hash = url.searchParams.get('token') as string;
+	const token_hash = url.searchParams.get('token_hash') as string;
 	const type = url.searchParams.get('type') as string;
 	const next = url.searchParams.get('next') ?? '/';
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

 #17170

## What is the new behavior?

Changes sveltekit search param from `token` to `token_hash` to follow rest of guide


fixes #17170
