### PR TITLE
Readd VECTOR_API_PORT in .env.example

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -96,6 +96,7 @@ LOGFLARE_LOGGER_BACKEND_API_KEY=your-super-secret-and-long-logflare-key
 # Change vector.toml sinks to reflect this change
 LOGFLARE_API_KEY=your-super-secret-and-long-logflare-key
 
+VECTOR_API_PORT=9001
 # Docker socket location - this value will differ depending on your OS
 DOCKER_SOCKET_LOCATION=/var/run/docker.sock
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix for self-hosting docker deployment

## What is the current behavior?

Vector container cannot start, blocking the rest of the stack

## What is the new behavior?

Vector container and other containers start

## Additional context

the line `VECTOR_API_PORT=9001` was removed by another PR, but it seems it is still necessary for the vector container to start correctly. Discussed in issue #16777
