### PR TITLE
Fix 404 URL by providing full address

### DIFF
--- a/apps/docs/pages/guides/database/extensions/index_advisor.mdx
+++ b/apps/docs/pages/guides/database/extensions/index_advisor.mdx
@@ -31,7 +31,7 @@ Features:
 
 ## Installation
 
-index_advisor is a trusted language extension, which means it is directly installable by users from the [database.dev](database.dev) SQL package repository.
+index_advisor is a trusted language extension, which means it is directly installable by users from the [database.dev](https://database.dev/) SQL package repository.
 
 To get started, enable the dbdev client by executing the [setup SQL script](https://database.dev/installer).
 


### PR DESCRIPTION
Fixing link went to https://supabase.com/docs/guides/database/extensions/database.dev Instead of https://database.dev/

## What kind of change does this PR introduce?

Docs update - fixing broken link

## What is the current behavior?

Link went to https://supabase.com/docs/guides/database/extensions/database.dev Instead of https://database.dev/

## What is the new behavior?

Link goes to https://database.dev/

## Additional context

-
