### PR TITLE
fix(self-hosted): platform routes with codegen

### DIFF
--- a/studio/data/fetchers.ts
+++ b/studio/data/fetchers.ts
@@ -1,4 +1,4 @@
-import { API_URL } from 'lib/constants'
+import { API_URL, IS_PLATFORM } from 'lib/constants'
 import { getAccessToken } from 'lib/gotrue'
 import { uuidv4 } from 'lib/helpers'
 import createClient from 'openapi-fetch'
@@ -44,6 +44,12 @@ export async function constructHeaders(headersInit?: HeadersInit | undefined) {
 export const get: typeof _get = async (url, init) => {
   const headers = await constructHeaders(init?.headers)
 
+  // on self-hosted, we don't have a /platform prefix
+  if (!IS_PLATFORM && url.startsWith('/platform')) {
+    // @ts-ignore
+    url = url.replace('/platform', '')
+  }
+
   return await _get(url, {
     ...init,
     headers,
@@ -52,6 +58,12 @@ export const get: typeof _get = async (url, init) => {
 
 export const post: typeof _post = async (url, init) => {
   const headers = await constructHeaders(init?.headers)
+
+  // on self-hosted, we don't have a /platform prefix
+  if (!IS_PLATFORM && url.startsWith('/platform')) {
+    // @ts-ignore
+    url = url.replace('/platform', '')
+  }
 
   return await _post(url, {
     ...init,
@@ -62,6 +74,12 @@ export const post: typeof _post = async (url, init) => {
 export const put: typeof _put = async (url, init) => {
   const headers = await constructHeaders(init?.headers)
 
+  // on self-hosted, we don't have a /platform prefix
+  if (!IS_PLATFORM && url.startsWith('/platform')) {
+    // @ts-ignore
+    url = url.replace('/platform', '')
+  }
+
   return await _put(url, {
     ...init,
     headers,
@@ -70,6 +88,12 @@ export const put: typeof _put = async (url, init) => {
 
 export const patch: typeof _patch = async (url, init) => {
   const headers = await constructHeaders(init?.headers)
+
+  // on self-hosted, we don't have a /platform prefix
+  if (!IS_PLATFORM && url.startsWith('/platform')) {
+    // @ts-ignore
+    url = url.replace('/platform', '')
+  }
 
   return await _patch(url, {
     ...init,
@@ -80,6 +104,12 @@ export const patch: typeof _patch = async (url, init) => {
 export const del: typeof _del = async (url, init) => {
   const headers = await constructHeaders(init?.headers)
 
+  // on self-hosted, we don't have a /platform prefix
+  if (!IS_PLATFORM && url.startsWith('/platform')) {
+    // @ts-ignore
+    url = url.replace('/platform', '')
+  }
+
   return await _del(url, {
     ...init,
     headers,
@@ -88,6 +118,12 @@ export const del: typeof _del = async (url, init) => {
 
 export const head: typeof _head = async (url, init) => {
   const headers = await constructHeaders(init?.headers)
+
+  // on self-hosted, we don't have a /platform prefix
+  if (!IS_PLATFORM && url.startsWith('/platform')) {
+    // @ts-ignore
+    url = url.replace('/platform', '')
+  }
 
   return await _head(url, {
     ...init,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behaviour?

`/platform` routes correctly get sent to `/api` on self-hosted