### PR TITLE
fixed: width of search card in docs on the mobile view

### DIFF
--- a/packages/ui/src/components/Command/CommandMenu.tsx
+++ b/packages/ui/src/components/Command/CommandMenu.tsx
@@ -97,7 +97,7 @@ const CommandMenu = ({ projectRef }: CommandMenuProps) => {
             onValueChange={handleInputChange}
           />
         )}
-        <CommandList className={['my-2', showCommandInput && 'max-h-[300px]'].join(' ')}>
+        <CommandList className={['my-2', showCommandInput && 'max-h-[300px] max-w-[350px]'].join(' ')}>
           {!currentPage && (
             <>
               <CommandGroup heading="Documentation" forceMount>


### PR DESCRIPTION


https://github.com/supabase/supabase/assets/112644558/9daa36ea-c188-4de4-a9fd-d02dd7b6200b


https://github.com/supabase/supabase/assets/112644558/1b32705e-1b51-4388-9f57-d3b6006c6a2f


## What is the current behavior?

when we write a long query on the search card in the docs on the mobile view the width of the card increases and goes out of the screen

## What is the new behavior?

added max width to the card now its not going out of the screen and working perfectly :)

## Additional context

Add any other context or screenshots.
