### PR TITLE
fix: hardcode vector api port

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -396,7 +396,7 @@ services:
           "--no-verbose",
           "--tries=1",
           "--spider",
-          "http://vector:${VECTOR_API_PORT}/health"
+          "http://vector:9001/health"
         ]
       timeout: 5s
       interval: 5s


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix: https://github.com/supabase/supabase/pull/17122

## What is the current behavior?

vector is always reported as unhealthy, causing docker compose to cancel

## What is the new behavior?

hardcode vector api port since the variable is removed

## Additional context

Add any other context or screenshots.
