### PR TITLE
chore: remove new label from reports menu

### DIFF
--- a/studio/components/layouts/ReportsLayout/ReportsMenu.utils.ts
+++ b/studio/components/layouts/ReportsLayout/ReportsMenu.utils.ts
@@ -23,7 +23,6 @@ export const generateReportsMenu = (project?: Project): ProductMenuGroup[] => {
           key: 'api-overview',
           url: `/project/${ref}/reports/api-overview`,
           items: [],
-          label: 'NEW',
         },
         {
           name: 'Database',
@@ -36,7 +35,6 @@ export const generateReportsMenu = (project?: Project): ProductMenuGroup[] => {
           key: 'query-performance',
           url: `/project/${ref}/reports/query-performance`,
           items: [],
-          label: 'NEW',
         },
       ],
     },


### PR DESCRIPTION
Small tweak to remove the NEW label from reports menu items

<img width="367" alt="Screenshot 2023-09-09 at 2 56 20 AM" src="https://github.com/supabase/supabase/assets/22714384/8d321485-5007-49b0-82d4-091b41181b1b">
