### PR TITLE
Fix default value of boolean column not respecting

### DIFF
--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/InputField.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/InputField.tsx
@@ -202,7 +202,7 @@ const InputField = ({
       ...(field.isNullable ? [{ value: 'null', label: 'NULL' }] : []),
     ]
 
-    const defaultValue = field.value === null ? 'null' : field.value
+    const defaultValue = field.defaultValue === null ? 'null' : field.defaultValue
 
     return (
       <Listbox

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/InputField.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/InputField.tsx
@@ -202,7 +202,7 @@ const InputField = ({
       ...(field.isNullable ? [{ value: 'null', label: 'NULL' }] : []),
     ]
 
-    const defaultValue = field.defaultValue === null ? 'null' : field.defaultValue
+const defaultValue = field.defaultValue !== null ? field.defaultValue : 'null'
 
     return (
       <Listbox


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

Changed `field.value` to `field.defaultValue` because when the user clicks on the save button, we change the defaultValue inside the "Add new column to `database_name`" page.

## What is the current behavior?
Setting true or false for a boolean column isn't respected. Always resets to null.

Fixes #17284 

## What is the new behavior?
Works with true/false/TRUE/FALSE

[Screencast.webm](https://github.com/supabase/supabase/assets/71846487/f2386beb-cfd2-4f1b-a322-87dd04f68c12)
