### PR TITLE
Recommend Docker Desktop alternatives

### DIFF
--- a/apps/docs/pages/guides/cli/local-development.mdx
+++ b/apps/docs/pages/guides/cli/local-development.mdx
@@ -62,7 +62,19 @@ git init
 supabase init
 ```
 
-Make sure Docker is running. On Mac, we recommend [OrbStack](https://orbstack.dev) to run docker on your machine. On other operating systems, install [Docker Desktop](https://www.docker.com/products/docker-desktop/). The [start](/docs/reference/cli/usage#supabase-start) command uses Docker to start the Supabase [services](/docs/guides/getting-started/architecture).
+Make sure Docker is running.
+
+<Admonition type="note">
+
+Docker is available via
+- [Docker Desktop](https://docs.docker.com/get-docker/) (macOS, Windows, Linux)
+- [Rancher Desktop](https://rancherdesktop.io/) (macOS, Windows, Linux)
+- [OrbStack](https://orbstack.dev/) (macOS)
+- [colima](https://github.com/abiosoft/colima) (macOS)
+
+</Admonition>
+
+The [start](/docs/reference/cli/usage#supabase-start) command uses Docker to start the Supabase [services](/docs/guides/getting-started/architecture).
 This command may take a while to run if this is the first time using the CLI.
 
 ```bash

--- a/apps/docs/pages/guides/cli/local-development.mdx
+++ b/apps/docs/pages/guides/cli/local-development.mdx
@@ -66,7 +66,7 @@ Make sure Docker is running.
 
 <Admonition type="note">
 
-Docker is available via
+There are a number of different projects available to download Docker from:
 - [Docker Desktop](https://docs.docker.com/get-docker/) (macOS, Windows, Linux)
 - [Rancher Desktop](https://rancherdesktop.io/) (macOS, Windows, Linux)
 - [OrbStack](https://orbstack.dev/) (macOS)

--- a/apps/docs/pages/guides/cli/local-development.mdx
+++ b/apps/docs/pages/guides/cli/local-development.mdx
@@ -62,7 +62,7 @@ git init
 supabase init
 ```
 
-Make sure Docker is running. The [start](/docs/reference/cli/usage#supabase-start) command uses Docker to start the Supabase [services](/docs/guides/getting-started/architecture).
+Make sure Docker is running. On Mac, we recommend [OrbStack](https://orbstack.dev) to run docker on your machine. On other operating systems, install [Docker Desktop](https://www.docker.com/products/docker-desktop/). The [start](/docs/reference/cli/usage#supabase-start) command uses Docker to start the Supabase [services](/docs/guides/getting-started/architecture).
 This command may take a while to run if this is the first time using the CLI.
 
 ```bash

--- a/apps/docs/pages/guides/cli/local-development.mdx
+++ b/apps/docs/pages/guides/cli/local-development.mdx
@@ -67,6 +67,7 @@ Make sure Docker is running.
 <Admonition type="note">
 
 There are a number of different projects available to download Docker from:
+
 - [Docker Desktop](https://docs.docker.com/get-docker/) (macOS, Windows, Linux)
 - [Rancher Desktop](https://rancherdesktop.io/) (macOS, Windows, Linux)
 - [OrbStack](https://orbstack.dev/) (macOS)


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

no information on how to use docker 

## What is the new behavior?

since OrbStack has been a life-changer for me as a avid cli user, and I keep recommending it to people, it might be a good addition to the docs. not sure if supabase wants to recommend other software here, and, if so, whether this is the right place for it though. 

