### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -337,12 +337,16 @@ services:
     ports:
       - 4000:4000
     entrypoint: |
-                  sh -c `cat <<'EOF' > run.sh && sh run.sh
-                  ./logflare eval Logflare.Release.migrate
-                  ./logflare start --sname logflare
-                  EOF
-                  `
-
+                # Not working  
+                #  sh -c `cat <<'EOF' > run.sh && sh run.sh
+                #  ./logflare eval Logflare.Release.migrate
+                #  ./logflare start --sname logflare
+                #  EOF
+                #  `
+                
+                # Workaround
+                 sh run.sh && sh -c "./logflare eval 'Logflare.Release.migrate(Logflare.Repo)' &&  ./logflare start --sname logflare"
+                 
   # Comment out everything below this point if you are using an external Postgres database
   db:
     container_name: supabase-db


### PR DESCRIPTION
logflare run cmd not able to find run.sh and issues with parsing EOF method - workaround

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

analytics container will not start 

Please link any relevant issues here.

[#16097](https://github.com/supabase/supabase/pull/16097)

## What is the new behavior?

container is running successfully supabase/analytics (other dependent containers are also starting now, still an issue with supabase/auth) 

Feel free to include screenshots if it includes visual changes.

## Additional context

This was blocking most of the other containers from starting via docker-compose up as they depend_on this container. 

Add any other context or screenshots.
