### PR TITLE
feat/add security page to footer

### DIFF
--- a/apps/www/data/Footer.json
+++ b/apps/www/data/Footer.json
@@ -64,6 +64,10 @@
         "url": "/brand-assets"
       },
       {
+        "text": "Security and Compliance",
+        "url": "/security"
+      },
+      {
         "text": "DPA",
         "url": "/legal/dpa"
       },


### PR DESCRIPTION
## What kind of change does this PR introduce?

Small change to add security page to footer. Allow 'Security at Supabase' [supabase.com/security](url) page to be searchable from our main website