### PR TITLE
Fix Vector Example in Python Notebook 

### DIFF
--- a/examples/ai/vector_hello_world.ipynb
+++ b/examples/ai/vector_hello_world.ipynb
@@ -141,7 +141,7 @@
       "source": [
         "# add records to the collection\n",
         "docs.upsert(\n",
-        "    vectors=[\n",
+        "    records=[\n",
         "        (\n",
         "         \"vec0\",           # the vector's identifier\n",
         "         [0.1, 0.2, 0.3],  # the vector. list or np.array\n",
@@ -273,7 +273,7 @@
       ],
       "source": [
         "docs.query(\n",
-        "    query_vector=[0.4,0.5,0.6],  # required\n",
+        "    data=[0.4,0.5,0.6],  # required\n",
         "    limit=5,                     # number of records to return\n",
         "    filters={},                  # metadata filters\n",
         "    measure=\"cosine_distance\",   # distance measure to use\n",


### PR DESCRIPTION
## What kind of change does this PR introduce?

This fixes `vecs` updates in https://supabase.github.io/vecs/api/ within this python notebook.

## What is the current behavior?

The updated changes in `vecs` results in errors when running this notebook. Specifically that `query_vector` cannot be found as it has been replaced with updates in https://supabase.github.io/vecs/api/. 

## What is the new behavior?

This PR adds changes to add `records` to `docs.upsert`

```
docs.upsert(
    records=[
        (
         "vec0",           # the vector's identifier
         [0.1, 0.2, 0.3],  # the vector. list or np.array
         {"year": 1973}    # associated  metadata
        ),
        (
         "vec1",
         [0.7, 0.8, 0.9],
         {"year": 2012}
        )
    ]
)
```

and `data` to the method `docs.query`

```
docs.query(
    data=[0.4,0.5,0.6],  # required
    limit=5,                     # number of records to return
    filters={},                  # metadata filters
    measure="cosine_distance",   # distance measure to use
    include_value=False,         # should distance measure values be returned?
    include_metadata=False,      # should record metadata be returned?
)```
