### PR TITLE
Fix verifyOtp method name in the example snippets

### DIFF
--- a/apps/docs/pages/guides/auth/phone-login/messagebird.mdx
+++ b/apps/docs/pages/guides/auth/phone-login/messagebird.mdx
@@ -111,7 +111,7 @@ curl -X POST 'https://cvwawazfelidkloqmbma.supabase.co/auth/v1/signup' \
 
 The user will now receive an SMS with a 6-digit pin that you will need to receive from them within 60-seconds before they can login to their account.
 
-You should present a form to the user so they can input the 6 digit pin, then send it along with the phone number to `verifyOTP`:
+You should present a form to the user so they can input the 6 digit pin, then send it along with the phone number to `verifyOtp`:
 
 <Tabs
   scrollable
@@ -122,7 +122,7 @@ You should present a form to the user so they can input the 6 digit pin, then se
 <TabPanel id="js" label="JavaScript">
 
 ```js
-let { session, error } = await supabase.auth.verifyOTP({
+let { session, error } = await supabase.auth.verifyOtp({
   phone: '+13334445555',
   token: '123456',
 })
@@ -237,7 +237,7 @@ The second step is the same as the previous section, you need to collect the 6-d
 <TabPanel id="js" label="JavaScript">
 
 ```js
-let { session, error } = await supabase.auth.verifyOTP({
+let { session, error } = await supabase.auth.verifyOtp({
   phone: '+13334445555',
   token: '123456',
 })

--- a/apps/docs/pages/guides/auth/phone-login/twilio.mdx
+++ b/apps/docs/pages/guides/auth/phone-login/twilio.mdx
@@ -157,7 +157,7 @@ curl -X POST 'https://cvwawazfelidkloqmbma.supabase.co/auth/v1/signup' \
 
 The user will now receive an SMS with a 6-digit pin that you will need to receive from them within 60-seconds before they can login to their account.
 
-You should present a form to the user so they can input the 6 digit pin, then send it along with the phone number to `verifyOTP`:
+You should present a form to the user so they can input the 6 digit pin, then send it along with the phone number to `verifyOtp`:
 
 <Tabs
   scrollable

--- a/apps/docs/pages/guides/auth/phone-login/vonage.mdx
+++ b/apps/docs/pages/guides/auth/phone-login/vonage.mdx
@@ -104,7 +104,7 @@ curl -X POST 'https://xxx.supabase.co/auth/v1/signup' \
 
 The user will now receive an SMS with a 6-digit pin that you will need to receive from them within 60-seconds before they can login to their account.
 
-You should present a form to the user so they can input the 6 digit pin, then send it along with the phone number to `verifyOTP`:
+You should present a form to the user so they can input the 6 digit pin, then send it along with the phone number to `verifyOtp`:
 
 <Tabs
   scrollable
@@ -115,7 +115,7 @@ You should present a form to the user so they can input the 6 digit pin, then se
 <TabPanel id="js" label="JavaScript">
 
 ```js
-let { session, error } = await supabase.auth.verifyOTP({
+let { session, error } = await supabase.auth.verifyOtp({
   phone: '491512223334444',
   token: '123456',
 })
@@ -230,7 +230,7 @@ The second step is the same as the previous section, you need to collect the 6-d
 <TabPanel id="js" label="JavaScript">
 
 ```js
-let { session, error } = await supabase.auth.verifyOTP({
+let { session, error } = await supabase.auth.verifyOtp({
   phone: '491512223334444',
   token: '123456',
 })


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

The example code is making reference to `verifyOTP` which is an incorrect method name.

## What is the new behavior?

Update the example code with the correct `verifyOtp` method name.

## Additional context

Add any other context or screenshots.
