### PR TITLE
Update with-ionic-react.mdx

### DIFF
--- a/apps/docs/pages/guides/getting-started/tutorials/with-ionic-react.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-ionic-react.mdx
@@ -314,7 +314,7 @@ setupIonicReact()
 const App: React.FC = () => {
   const [session, setSession] = useState < Session > null
   useEffect(() => {
-    setSession(supabase.auth.session())
+    setSession(supabase.auth.getSession())
     supabase.auth.onAuthStateChange((_event, session) => {
       setSession(session)
     })


### PR DESCRIPTION
Updated call to supabase.auth.getSession() to match latest js-library version

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

Docs example uses an old method name for supabase.auth

## What is the new behavior?

Example now uses the new method name .getSession()

## Additional context

Add any other context or screenshots.
