### PR TITLE
Remove LW8 announcements

### DIFF
--- a/apps/docs/layouts/SiteLayout.tsx
+++ b/apps/docs/layouts/SiteLayout.tsx
@@ -8,7 +8,6 @@ import Head from 'next/head'
 import { PropsWithChildren, memo } from 'react'
 import Footer from '~/components/Navigation/Footer'
 import { menuState, useMenuLevelId, useMenuMobileOpen } from '~/hooks/useMenuState'
-import { Announcement, LW8CountdownBanner } from 'ui'
 
 const levelsData = {
   home: {
@@ -327,9 +326,6 @@ const SiteLayout = ({ children }: PropsWithChildren<{}>) => {
         <title>Supabase Docs</title>
       </Head>
       <main>
-        <Announcement>
-          <LW8CountdownBanner />
-        </Announcement>
         <div className="flex flex-row h-screen">
           <NavContainer />
           <Container>

--- a/apps/www/components/Announcement/Badge.tsx
+++ b/apps/www/components/Announcement/Badge.tsx
@@ -3,10 +3,17 @@ import Link from 'next/link'
 import { Badge } from 'ui'
 import { ArrowNarrowRightIcon } from '@heroicons/react/outline'
 
-const AnnouncementBadge = () => (
+interface Props {
+  url: string
+  announcement: string
+  badge?: string
+  target?: '_self' | '_blank'
+}
+const AnnouncementBadge = ({ url, announcement, badge, target = '_self' }: Props) => (
   <div className="w-full max-w-xl flex justify-center opacity-0 !animate-[fadeIn_0.5s_cubic-bezier(0.25,0.25,0,1)_0.5s_both]">
-    <Link href="/launch-week">
+    <Link href={url}>
       <a
+        target={target}
         className="
           group
           relative
@@ -26,10 +33,12 @@ const AnnouncementBadge = () => (
           focus:outline-none focus:ring-brand-600 focus:ring-2 focus:rounded-full
           "
       >
-        <Badge color="brand" size="large" className="py-1">
-          Explore
-        </Badge>
-        <span className="text-foreground">Launch Week 8 announcements</span>
+        {badge && (
+          <Badge color="brand" size="large" className="py-1">
+            {badge}
+          </Badge>
+        )}
+        <span className="text-foreground">{announcement}</span>
         <ArrowNarrowRightIcon className="h-4 ml-2 -translate-x-1 transition-transform group-hover:translate-x-0" />
         <div
           className="absolute inset-0 -z-10 bg-gradient-to-br

--- a/apps/www/components/Hero/Hero.tsx
+++ b/apps/www/components/Hero/Hero.tsx
@@ -8,7 +8,7 @@ import SectionContainer from '~/components/Layouts/SectionContainer'
 import HeroFrameworks from './HeroFrameworks'
 import styles from './hero.module.css'
 import Image from 'next/image'
-import AnnouncementBadge from '../Announcement/Badge'
+// import AnnouncementBadge from '../Announcement/Badge'
 
 const Hero = () => {
   const router = useRouter()
@@ -19,7 +19,7 @@ const Hero = () => {
 
   return (
     <div className="relative -mt-[65px]">
-      <SectionContainer className="pt-8 md:pt-16 lg:pt-24 overflow-hidden">
+      <SectionContainer className="pt-8 md:pt-16 overflow-hidden">
         <div className="relative">
           <div className="mx-auto">
             <div className="mx-auto max-w-2xl lg:col-span-6 lg:flex lg:items-center justify-center text-center">
@@ -30,9 +30,9 @@ const Hero = () => {
                 ].join(' ')}
               >
                 <div className="flex flex-col items-center">
-                  <div className="z-40 w-full flex justify-center mb-8 lg:mb-8">
+                  {/* <div className="z-40 w-full flex justify-center mb-8 lg:mb-8">
                     <AnnouncementBadge />
-                  </div>
+                  </div> */}
                   <h1 className="text-scale-1200 text-4xl sm:text-5xl sm:leading-none lg:text-7xl">
                     <span className="block text-[#F4FFFA00] bg-clip-text bg-gradient-to-b from-scale-1200 to-scale-1200 dark:to-scale-1100">
                       Build in a weekend
@@ -80,32 +80,7 @@ const Hero = () => {
             </div>
           </div>
         </div>
-        <div className="absolute -top-2 md:top-0 -left-10 -right-10 md:left-0 md:right-0 h-[500px] lg:h-[550px] z-0 flex items-center justify-center">
-          <span className="absolute inset-0">
-            <Image
-              src="/images/launchweek/8/stars.svg"
-              alt="stars background"
-              layout="fill"
-              objectFit="cover"
-              className="opacity-70"
-              draggable={false}
-            />
-          </span>
-        </div>
       </SectionContainer>
-      <div className="absolute w-full max-w-[1600px] mx-auto h-[500px] lg:h-[750px] inset-0 z-0 flex items-center justify-center">
-        <Image
-          src="/images/launchweek/8/LW8-gradient.png"
-          alt="Launch Week 8 purple background gradient"
-          className="not-sr-only"
-          layout="fill"
-          objectFit="cover"
-          objectPosition="top"
-          priority
-          draggable={false}
-        />
-      </div>
-      <div className="absolute top-0 left-0 right-0 h-screen bg-gradient-to-b from-[#020405] to-transparent -z-10" />
     </div>
   )
 }

--- a/apps/www/components/Nav/Developers.tsx
+++ b/apps/www/components/Nav/Developers.tsx
@@ -32,7 +32,7 @@ const Developers = () => {
             stroke="currentColor"
             aria-hidden="true"
           >
-            <path stroke-linecap="round" strokeLinejoin="round" strokeWidth="1.5" d={icon} />
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5" d={icon} />
           </svg>
         )}
         {Svg && <Svg />}

--- a/apps/www/components/Nav/index.tsx
+++ b/apps/www/components/Nav/index.tsx
@@ -2,8 +2,7 @@ import React, { useState } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 
-import Announcement from '~/components/Announcement/Announcement'
-import { Button, Badge, IconStar, IconChevronDown, LW8CountdownBanner } from 'ui'
+import { Button, Badge, IconStar, IconChevronDown } from 'ui'
 import FlyOut from '~/components/UI/FlyOut'
 import Transition from 'lib/Transition'
 
@@ -198,9 +197,6 @@ const Nav = () => {
 
   return (
     <>
-      <Announcement link="/launch-week">
-        <LW8CountdownBanner />
-      </Announcement>
       <div className="sticky top-0 z-40 transform" style={{ transform: 'translate3d(0,0,999px)' }}>
         <div
           className={[

--- a/apps/www/data/Announcements.json
+++ b/apps/www/data/Announcements.json
@@ -1,6 +1,21 @@
 [
   {
     "type": "Announcement",
+    "title": "Supabase Beta August 2023",
+    "description": "Launch Week 8 review and more things we shipped 🚀",
+    "imgUrl": "/images/blog/2023-09-07-beta-update-august-2023/monthly-update-august-2023.jpg",
+    "logoUrl": "/images/blog/2023-09-07-beta-update-august-2023/monthly-update-august-2023.jpg",
+    "organization": "Supabase",
+    "url": "/blog/beta-update-august-2023",
+    "postMeta": {
+      "name": "Ant Wilson",
+      "publishDate": "Sep 08, 2023",
+      "readLength": 5
+    },
+    "ctaText": "Learn more"
+  },
+  {
+    "type": "Announcement",
     "title": "Launch Week 8 Hackathon Winners",
     "description": "Announcing the winners of the Launch Week 8 Hackathon!",
     "imgUrl": "/images/blog/lw8-hackathon-winners/hackathon-winners.png",
@@ -13,20 +28,5 @@
       "readLength": 3
     },
     "ctaText": "See the winners"
-  },
-  {
-    "type": "Announcement",
-    "title": "Supabase Launch Week 8",
-    "description": "One new feature (or more) every day during a week.",
-    "imgUrl": "/images/launchweek/8/lw8-og.jpg",
-    "logoUrl": "/images/launchweek/8/lw8-og.jpg",
-    "organization": "Supabase",
-    "url": "/launch-week",
-    "postMeta": {
-      "name": "Paul Copplestone",
-      "publishDate": "Aug 07, 2023",
-      "readLength": 5
-    },
-    "ctaText": "Learn more"
   }
 ]

--- a/apps/www/pages/partners/index.tsx
+++ b/apps/www/pages/partners/index.tsx
@@ -51,8 +51,8 @@ const Partners = () => {
                   <path
                     d="M91 1C120.005 1 145.841 14.5702 162.505 35.708"
                     stroke="url(#paint0_linear_4766_6117)"
-                    stroke-width="2"
-                    stroke-linecap="round"
+                    strokeWidth="2"
+                    strokeLinecap="round"
                   />
                   <defs>
                     <linearGradient
@@ -63,9 +63,9 @@ const Partners = () => {
                       y2="21.5"
                       gradientUnits="userSpaceOnUse"
                     >
-                      <stop stop-color="#1CF7C3" stop-opacity="0" />
-                      <stop offset="0.510417" stop-color="#1CF7C3" />
-                      <stop offset="1" stop-color="#1CF7C3" stop-opacity="0" />
+                      <stop stopColor="#1CF7C3" stopOpacity="0" />
+                      <stop offset="0.510417" stopColor="#1CF7C3" />
+                      <stop offset="1" stopColor="#1CF7C3" stopOpacity="0" />
                     </linearGradient>
                   </defs>
                 </svg>

--- a/apps/www/pages/pricing/index.tsx
+++ b/apps/www/pages/pricing/index.tsx
@@ -14,6 +14,7 @@ import { useTheme } from 'common/Providers'
 import ComputePricingModal from '~/components/Pricing/ComputePricingModal'
 import { plans } from 'shared-data/plans'
 import { ArrowNarrowRightIcon } from '@heroicons/react/outline'
+import AnnouncementBadge from '../../components/Announcement/Badge'
 
 export default function IndexPage() {
   const router = useRouter()
@@ -151,7 +152,7 @@ export default function IndexPage() {
       />
 
       <div>
-        <div className="relative z-10 py-16 lg:py-28">
+        <div className="relative z-10 py-16 lg:py-20">
           <div className="mx-auto max-w-7xl px-4 text-center sm:px-6 lg:px-8">
             <div className="mx-auto max-w-3xl space-y-2 lg:max-w-none">
               <h1 className="text-brand text-base">Pricing</h1>
@@ -159,45 +160,13 @@ export default function IndexPage() {
               <p className="p text-lg">
                 Start building for free, collaborate with a team, then scale to millions of users.
               </p>
-              <div className="w-full flex justify-center items-center opacity-0 !animate-[fadeIn_0.5s_cubic-bezier(0.25,0.25,0,1)_0.5s_both]">
-                <Link href="/blog/organization-based-billing" passHref>
-                  <a
-                    target="_blank"
-                    className="
-          group
-          relative
-          flex flex-row
-          items-center
-          pr-3 p-1
-          text-sm
-          w-auto
-          gap-2
-          text-left
-          rounded-full
-          bg-opacity-20
-          border
-          border-background-surface-100
-          hover:border-background-surface-300
-          overflow-hidden
-          focus:outline-none focus:ring-brand-600 focus:ring-2 focus:rounded-full
-          "
-                  >
-                    <Badge color="brand" size="large" className="py-1">
-                      Update
-                    </Badge>
-                    <span className="text-foreground">Changes to how we bill</span>
-                    <ArrowNarrowRightIcon className="h-4 ml-2 -translate-x-1 transition-transform group-hover:translate-x-0" />
-                    <div
-                      className="absolute inset-0 -z-10 bg-gradient-to-br
-            opacity-70
-            overflow-hidden rounded-full
-            from-background-surface-100
-            to-background-surface-300
-            backdrop-blur-md
-            "
-                    />
-                  </a>
-                </Link>
+              <div className="w-full inline-flex justify-center items-center pt-3 pb-6">
+                <AnnouncementBadge
+                  url="/blog/organization-based-billing"
+                  badge="Update"
+                  announcement="Changes to how we bill"
+                  target="_blank"
+                />
               </div>
             </div>
           </div>


### PR DESCRIPTION
Removed LW8 promotional components in www and docs.

## Before

<img width="1589" alt="Screenshot 2023-09-12 at 18 55 56" src="https://github.com/supabase/supabase/assets/25671831/6ee80f7c-1803-4778-a628-78535c9ea8f7">

<img width="1862" alt="Screenshot 2023-09-12 at 18 56 00" src="https://github.com/supabase/supabase/assets/25671831/3bdd62b6-dbb3-4ac9-9ec3-1318c03804a5">

## After

<img width="1746" alt="Screenshot 2023-09-12 at 18 57 38" src="https://github.com/supabase/supabase/assets/25671831/ddb3b32e-7ede-484c-bcbe-8d3d3225fd7a">
