### PR TITLE
AI SQL Editor: add more log information for AI requests

### DIFF
--- a/studio/pages/api/ai/sql/debug.ts
+++ b/studio/pages/api/ai/sql/debug.ts
@@ -178,7 +178,9 @@ export async function handlePost(req: NextApiRequest, res: NextApiResponse) {
     return res.json(debugSqlResult)
   } catch (error) {
     console.error(
-      `AI SQL editing failed: ${isError(error) ? error.message : 'An unknown error occurred'}`
+      `AI SQL editing failed: ${
+        isError(error) ? error.message : 'An unknown error occurred'
+      }, sqlResponseString: ${sqlResponseString}`
     )
 
     return res.status(500).json({

--- a/studio/pages/api/ai/sql/edit.ts
+++ b/studio/pages/api/ai/sql/edit.ts
@@ -170,7 +170,9 @@ export async function handlePost(req: NextApiRequest, res: NextApiResponse) {
     return res.json(editSqlResult)
   } catch (error) {
     console.error(
-      `AI SQL editing failed: ${isError(error) ? error.message : 'An unknown error occurred'}`
+      `AI SQL editing failed: ${
+        isError(error) ? error.message : 'An unknown error occurred'
+      }, sqlResponseString: ${sqlResponseString}`
     )
 
     return res.status(500).json({

--- a/studio/pages/api/ai/sql/generate.ts
+++ b/studio/pages/api/ai/sql/generate.ts
@@ -158,7 +158,9 @@ export async function handlePost(req: NextApiRequest, res: NextApiResponse) {
     return res.json(generateSqlResult)
   } catch (error) {
     console.error(
-      `AI SQL editing failed: ${isError(error) ? error.message : 'An unknown error occurred'}`
+      `AI SQL editing failed: ${
+        isError(error) ? error.message : 'An unknown error occurred'
+      }, sqlResponseString: ${sqlResponseString}`
     )
 
     return res.status(500).json({

--- a/studio/pages/api/ai/sql/title.ts
+++ b/studio/pages/api/ai/sql/title.ts
@@ -136,7 +136,9 @@ export async function handlePost(req: NextApiRequest, res: NextApiResponse) {
     return res.json(generateTitleResult)
   } catch (error) {
     console.error(
-      `AI SQL editing failed: ${isError(error) ? error.message : 'An unknown error occurred'}`
+      `AI SQL editing failed: ${
+        isError(error) ? error.message : 'An unknown error occurred'
+      }, titleResponseString: ${titleResponseString}`
     )
 
     return res.status(500).json({


### PR DESCRIPTION
When users get `There was an unknown error editing the SQL snippet. Please try again.`, this adds more information to server side logs to help debug the error. So far these seem to be JSON parsing errors, but this will confirm and help us debug exactly what part of the JSON is incorrect (OpenAI LLM itself returns bad JSON).