### PR TITLE
feat: over-usage banners for orgs

### DIFF
--- a/studio/components/interfaces/Organization/BillingSettingsV2/BillingBreakdown/BillingBreakdown.tsx
+++ b/studio/components/interfaces/Organization/BillingSettingsV2/BillingBreakdown/BillingBreakdown.tsx
@@ -14,8 +14,10 @@ import { Alert, Button } from 'ui'
 import { BILLING_BREAKDOWN_METRICS } from './BillingBreakdown.constants'
 import BillingMetric from './BillingMetric'
 import UpcomingInvoice from './UpcomingInvoice'
+import { useOrgSettingsPageStateSnapshot } from 'state/organization-settings'
 
 const BillingBreakdown = () => {
+  const snap = useOrgSettingsPageStateSnapshot()
   const { slug: orgSlug } = useParams()
   const {
     data: usage,
@@ -93,7 +95,16 @@ const BillingBreakdown = () => {
                 variant="danger"
                 title="Your organization's usage has exceeded its included quota"
                 actions={[
-                  <Button key="upgrade-button" type="default" className="ml-8" onClick={() => {}}>
+                  <Button
+                    key="upgrade-button"
+                    type="default"
+                    className="ml-8"
+                    onClick={() =>
+                      snap.setPanelKey(
+                        currentPlan?.id === 'free' ? 'subscriptionPlan' : 'costControl'
+                      )
+                    }
+                  >
                     {currentPlan?.id === 'free' ? 'Upgrade plan' : 'Change spend cap'}
                   </Button>,
                 ]}

--- a/studio/components/ui/OveragesBanner/OveragesBanner.utils.ts
+++ b/studio/components/ui/OveragesBanner/OveragesBanner.utils.ts
@@ -1,5 +1,6 @@
 import { compact } from 'lodash'
 import { USAGE_APPROACHING_THRESHOLD } from 'lib/constants'
+import { OrgUsageResponse, UsageMetric } from 'data/usage/org-usage-query'
 
 export const getResourcesApproachingLimits = (usages: any) => {
   if (!usages) return []
@@ -22,7 +23,21 @@ export const getResourcesExceededLimits = (usages: any) => {
       .filter((resourceName) => usages[resourceName] !== null)
       .map((resourceName) => {
         const resource = usages[resourceName]
-        if (resource.limit > 0 && (resource.usage / resource.limit) > 1) return resourceName
+        if (resource.limit > 0 && resource.usage / resource.limit > 1) return resourceName
       })
   )
+}
+
+export const getResourcesExceededLimitsOrg = (usageMetrics: UsageMetric[]): string[] => {
+  if (!usageMetrics.length) return []
+
+  return usageMetrics
+    .filter((usageMetric) => {
+      if (!usageMetric.capped || !usageMetric.available_in_plan || usageMetric.unlimited) return false
+
+      const freeUnits = usageMetric.pricing_free_units || 0
+
+      return usageMetric.usage > freeUnits
+    })
+    .map((it) => it.metric)
 }


### PR DESCRIPTION
- Fixes button for over-usage panel in billing breakdown
- Add over-usage alert on org usage page
- Add over-usage badge in the project nav (just like before) for orgs billed through the organization