### PR TITLE
Docs: update supabase_js_v2.yml to add example on using `!inner`

### DIFF
--- a/spec/supabase_js_v2.yml
+++ b/spec/supabase_js_v2.yml
@@ -1517,7 +1517,9 @@ functions:
         description: |
           If the filter on a foreign table's column is not satisfied, the foreign
           table returns `[]` or `null` but the parent table is not filtered out.
-          If you want to filter out the parent table rows, use the `!inner` hint
+          If you want to filter out the parent table rows, use the `!inner` hint.
+          For the example above, change `countries(*)` to `countries!inner(*)`. 
+          See also: The `Filter Foreign Tables` example under `Using filters`.
         hideCodeBlock: true
       - id: querying-foreign-table-with-count
         name: Querying foreign table with count


### PR DESCRIPTION
## What kind of change does this PR introduce?

Minor update to the `supabase_js_v2.yml` documentation

## What is the current behavior?

In the `Filtering through foreign tables` example under `Fetch data` in the `Database` section, there was a note to use the `!inner` hint to filter out the parent table rows, but no example or info on how to use it. 

If a user finds the note on using the `!inner` hint, it may not be obvious how to use it or where to find more info about it.

![inner](https://github.com/supabase/supabase/assets/14029543/b55b0089-60f7-4187-9c90-3768a2f2af53)

## What is the new behavior?

Added an example on how to use the `!inner` hint and made a reference to the `Filter Foreign Tables` example under `Using filters`.

## Additional context

