### PR TITLE
fixed: width of search card in docs on the mobile view

### DIFF
--- a/packages/ui/src/components/Command/CommandMenu.tsx
+++ b/packages/ui/src/components/Command/CommandMenu.tsx
@@ -100,7 +100,7 @@ const CommandMenu = ({ projectRef }: CommandMenuProps) => {
             onValueChange={handleInputChange}
           />
         )}
-        <CommandList className={['my-2', showCommandInput && 'max-h-[300px]'].join(' ')}>
+        <CommandList className={['my-2', showCommandInput && 'max-h-[300px] max-w-[350px]'].join(' ')}>
           {!currentPage && (
             <>
               <CommandGroup heading="Documentation" forceMount>


### PR DESCRIPTION
fixed issue : #17437 

https://github.com/supabase/supabase/assets/144774379/b275e0b1-a196-4d4c-b37f-43e8569ef146 


https://github.com/supabase/supabase/assets/144774379/1fab84cd-62cc-4fa3-a81c-994e0d748d36 


## What is the current behavior?

when we write a long query on the search card in the docs on the mobile view the width of the card increases and goes out of the screen.

## What is the new behavior?

added max width to the card now its not going out of the screen and working perfectly :)

## Additional context

Add any other context or screenshots.
