### PR TITLE
added small gaps in between the framework icons on the docs get started page

### DIFF
--- a/apps/docs/components/HomePageCover.tsx
+++ b/apps/docs/components/HomePageCover.tsx
@@ -82,7 +82,7 @@ const HomePageCover = (props) => {
             Discover how to set up a database to an app making queries in just a few minutes.
           </p>
         </div>
-        <div className="flex flex-wrap md:grid md:grid-cols-4 2xl:grid-cols-8 gap-2 sm:gap-3">
+        <div className="flex flex-wrap md:grid md:grid-cols-4 2xl:grid-cols-7 gap-2 sm:gap-3"> 
           {frameworks.map((framework, i) => (
             <Link key={i} href={framework.href} passHref>
               <a className="no-underline">

--- a/packages/ui/src/components/Command/CommandMenu.tsx
+++ b/packages/ui/src/components/Command/CommandMenu.tsx
@@ -100,7 +100,7 @@ const CommandMenu = ({ projectRef }: CommandMenuProps) => {
             onValueChange={handleInputChange}
           />
         )}
-        <CommandList className={['my-2', showCommandInput && 'max-h-[300px]'].join(' ')}>
+        <CommandList className={['my-2', showCommandInput && 'max-h-[300px] max-w-[350px]'].join(' ')}>
           {!currentPage && (
             <>
               <CommandGroup heading="Documentation" forceMount>


### PR DESCRIPTION
#17491
current behaviour : there is no gaps between the framework icons on pc screen 

![current_behaviour](https://github.com/supabase/supabase/assets/144774379/4f5164b0-b74f-4b72-94b4-371503a64062) 

new behaviour : added small gaps in between the framework icons now its look perfect 

![new_behaviour](https://github.com/supabase/supabase/assets/144774379/ae436daf-85e7-4f05-b66a-963269c2d08b)