### PR TITLE
feat: use a persisted auth debug log if `supabase.dashboard.auth.debug.persist` is true

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14121,17 +14121,17 @@
       }
     },
     "node_modules/@supabase/gotrue-js": {
-      "version": "2.48.0",
-      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.48.0.tgz",
-      "integrity": "sha512-+6g5aFL6+iaZC6mFVpRLauSkU5MrQ52QZA1TlY0/evvz9Rmhqc315tIeUfUK87ZLeX7sOL6XYVGkI6ZxgeyAUA==",
+      "version": "2.52.0",
+      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.52.0.tgz",
+      "integrity": "sha512-UFCbydMYFn/LhPW08aeZ9sgFDA3kOQCjA2ieFj/sccye9m8Tv0pimMfnXh3A9TqBJ0/0utpkaGSad3XdpJ+Mbw==",
       "dependencies": {
-        "@supabase/node-fetch": "^2.6.13"
+        "@supabase/node-fetch": "^2.6.14"
       }
     },
     "node_modules/@supabase/node-fetch": {
-      "version": "2.6.13",
-      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.13.tgz",
-      "integrity": "sha512-rEHQaDVzxLZMCK3p+JW2nzEsK4AJpOQhetppaqAzrFum0Ub8wcnoM/8f1dWRZSulY5fRDP6rJaWT/8X3VleCzg==",
+      "version": "2.6.14",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.14.tgz",
+      "integrity": "sha512-w/Tsd22e/5fAeoxqQ4P2MX6EyF+iM6rc9kmlMVFkHuG0rAltt2TLhFbDJfemnHbtvnazWaRfy5KnFU/SYT37dQ==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -40754,7 +40754,7 @@
       "license": "MIT",
       "dependencies": {
         "@headlessui/react": "^1.7.14",
-        "@supabase/gotrue-js": "^2.48.0",
+        "@supabase/gotrue-js": "^2.52.0",
         "@supabase/ui": "^0.37.0-alpha.50",
         "@types/react": "^17.0.39",
         "react-use": "^17.4.0"

--- a/packages/common/gotrue.ts
+++ b/packages/common/gotrue.ts
@@ -3,12 +3,19 @@ import { GoTrueClient, navigatorLock } from '@supabase/gotrue-js'
 export const STORAGE_KEY = process.env.NEXT_PUBLIC_STORAGE_KEY || 'supabase.dashboard.auth.token'
 export const AUTH_DEBUG_KEY =
   process.env.NEXT_PUBLIC_AUTH_DEBUG_KEY || 'supabase.dashboard.auth.debug'
+export const AUTH_DEBUG_PERSISTED_KEY =
+  process.env.NEXT_PUBLIC_AUTH_DEBUG_PERSISTED_KEY || 'supabase.dashboard.auth.debug.persist'
 export const AUTH_NAVIGATOR_LOCK_DISABLED_KEY =
-  process.env.NEXT_PUBLIC_AUTH_NAVIGATOR_LOCK_KEY || 'supabase.dashboard.auth.navigatorLock.disabled'
+  process.env.NEXT_PUBLIC_AUTH_NAVIGATOR_LOCK_KEY ||
+  'supabase.dashboard.auth.navigatorLock.disabled'
 
 const debug =
   process.env.NEXT_PUBLIC_IS_PLATFORM === 'true' &&
   globalThis?.localStorage?.getItem(AUTH_DEBUG_KEY) === 'true'
+
+const persistedDebug =
+  process.env.NEXT_PUBLIC_IS_PLATFORM === 'true' &&
+  globalThis?.localStorage?.getItem(AUTH_DEBUG_PERSISTED_KEY) === 'true'
 
 const navigatorLockEnabled = !!(
   process.env.NEXT_PUBLIC_IS_PLATFORM === 'true' &&
@@ -20,10 +27,83 @@ if (!globalThis?.navigator?.locks) {
   console.warn('This browser does not support the Navigator Locks API. Please update it.')
 }
 
+const tabId = Math.random().toString(16).substring(2)
+
+let dbHandle = new Promise<IDBDatabase | null>((accept, _) => {
+  if (!persistedDebug) {
+    accept(null)
+    return
+  }
+
+  const request = indexedDB.open('auth-debug-log', 1)
+
+  request.onupgradeneeded = (event: any) => {
+    const db = event?.target?.result
+
+    if (!db) {
+      return
+    }
+
+    db.createObjectStore('events', { autoIncrement: true })
+  }
+
+  request.onsuccess = (event: any) => {
+    console.log('Opened persisted auth debug log IndexedDB database', tabId)
+    accept(event.target.result)
+  }
+
+  request.onerror = (event: any) => {
+    console.error('Failed to open persisted auth debug log IndexedDB database', event)
+    accept(null)
+  }
+})
+
+const logIndexedDB = (message: string, ...args: any[]) => {
+  console.log(message, ...args)
+
+  const copyArgs = structuredClone(args)
+
+  copyArgs.forEach((value) => {
+    if (typeof value === 'object' && value !== null) {
+      delete value.user
+      delete value.access_token
+      delete value.token_type
+      delete value.provider_token
+    }
+  })
+  ;(async () => {
+    try {
+      const db = await dbHandle
+
+      if (!db) {
+        return
+      }
+
+      const tx = db.transaction(['events'], 'readwrite')
+      tx.onerror = (event: any) => {
+        console.error('Failed to write to persisted auth debug log IndexedDB database', event)
+        dbHandle = Promise.resolve(null)
+      }
+
+      const events = tx.objectStore('events')
+
+      events.add({
+        m: message.replace(/^GoTrueClient@/i, ''),
+        a: copyArgs,
+        l: window.location.pathname,
+        t: tabId,
+      })
+    } catch (e: any) {
+      console.error('Failed to log to persisted auth debug log IndexedDB database', e)
+      dbHandle = Promise.resolve(null)
+    }
+  })()
+}
+
 export const gotrueClient = new GoTrueClient({
   url: process.env.NEXT_PUBLIC_GOTRUE_URL,
   storageKey: STORAGE_KEY,
   detectSessionInUrl: true,
-  debug,
+  debug: debug ? (persistedDebug ? logIndexedDB : true) : false,
   lock: navigatorLockEnabled ? navigatorLock : undefined,
 })

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "dependencies": {
     "@headlessui/react": "^1.7.14",
-    "@supabase/gotrue-js": "^2.48.0",
+    "@supabase/gotrue-js": "^2.52.0",
     "@supabase/ui": "^0.37.0-alpha.50",
     "@types/react": "^17.0.39",
     "react-use": "^17.4.0"


### PR DESCRIPTION
Bumps `@supabase/gotrue-js` to the latest version which allows a custom debug function to be set. If the local storage key `supabase.dashboard.auth.debug.persist` is set to `true`, then a `auth-debug-log` indexed DB will be opened and all debug messages will be persisted in the `events` object store. This can be used to inspect the behavior of multi-tab and multi-window scenarios.