### PR TITLE
Fix/cardbutton classes

### DIFF
--- a/studio/components/interfaces/Home/ProjectList/ProjectCard.tsx
+++ b/studio/components/interfaces/Home/ProjectList/ProjectCard.tsx
@@ -36,7 +36,7 @@ const ProjectCard = ({
     <li className="col-span-1 list-none">
       <CardButton
         linkHref={rewriteHref ? rewriteHref : `/project/${projectRef}`}
-        containerHeightClassName="h-44"
+        className="h-44 !px-0"
         title={
           <div className="w-full justify-between space-y-1.5 px-6">
             <p className="flex-shrink truncate text-base">{name}</p>

--- a/studio/components/interfaces/SQLEditor/SQLTemplates/SQLCard.tsx
+++ b/studio/components/interfaces/SQLEditor/SQLTemplates/SQLCard.tsx
@@ -20,6 +20,7 @@ const SQLCard = ({ title, description, sql, onClick }: SQLCardProps) => {
       title={title}
       loading={loading}
       onClick={() => handleOnClick()}
+      className="px-6"
       footer={<span className="text-scale-1100 text-sm">{description}</span>}
     />
   )

--- a/studio/components/interfaces/SQLEditor/SQLTemplates/SQLCard.tsx
+++ b/studio/components/interfaces/SQLEditor/SQLTemplates/SQLCard.tsx
@@ -20,7 +20,6 @@ const SQLCard = ({ title, description, sql, onClick }: SQLCardProps) => {
       title={title}
       loading={loading}
       onClick={() => handleOnClick()}
-      className="px-6"
       footer={<span className="text-scale-1100 text-sm">{description}</span>}
     />
   )

--- a/studio/components/ui/CardButton.tsx
+++ b/studio/components/ui/CardButton.tsx
@@ -12,8 +12,8 @@ interface CardButtonProps {
   imgAlt?: string
   onClick?: () => void
   icon?: React.ReactNode
-  containerHeightClassName?: string
   loading?: boolean
+  className?: string
 }
 
 const CardButton = ({
@@ -27,7 +27,7 @@ const CardButton = ({
   imgAlt,
   onClick,
   icon,
-  containerHeightClassName = '',
+  className,
   loading = false,
 }: PropsWithChildren<CardButtonProps>) => {
   const LinkContainer = ({ children }: { children: React.ReactNode }) => (
@@ -44,12 +44,12 @@ const CardButton = ({
   const isLink = url || linkHref || onClick
 
   let containerClasses = [
+    className,
     'group relative text-left',
     'bg-panel-header-light dark:bg-panel-header-dark',
     'border border-panel-border-light dark:border-panel-border-dark',
-    'rounded-md py-4 flex flex-row',
+    'rounded-md py-4 px-4 flex flex-row h-32',
     'transition ease-in-out duration-150',
-    containerHeightClassName,
   ]
 
   if (isLink) {

--- a/studio/components/ui/CardButton.tsx
+++ b/studio/components/ui/CardButton.tsx
@@ -48,7 +48,7 @@ const CardButton = ({
     'group relative text-left',
     'bg-panel-header-light dark:bg-panel-header-dark',
     'border border-panel-border-light dark:border-panel-border-dark',
-    'rounded-md py-4 px-4 flex flex-row h-32',
+    'rounded-md py-4 px-6 flex flex-row h-32',
     'transition ease-in-out duration-150',
   ]
 

--- a/studio/pages/project/[ref]/logs/explorer/templates.tsx
+++ b/studio/pages/project/[ref]/logs/explorer/templates.tsx
@@ -50,7 +50,7 @@ const Template = ({ projectRef, template }: { projectRef?: string; template: Log
           </div>
         </div>
       }
-      containerHeightClassName="h-40"
+      className="h-40 px-6"
       linkHref={`/project/${projectRef}/logs/explorer?q=${encodeURI(template.searchString)}`}
       description={template.description}
       footer={

--- a/studio/pages/project/[ref]/logs/explorer/templates.tsx
+++ b/studio/pages/project/[ref]/logs/explorer/templates.tsx
@@ -50,7 +50,7 @@ const Template = ({ projectRef, template }: { projectRef?: string; template: Log
           </div>
         </div>
       }
-      className="h-40 px-6"
+      className="h-40"
       linkHref={`/project/${projectRef}/logs/explorer?q=${encodeURI(template.searchString)}`}
       description={template.description}
       footer={


### PR DESCRIPTION
We removed the px-6 class from the CardButton component here: 

https://github.com/supabase/supabase/commit/17d4445ce70cd2a4870d12fa1b88ca90de707fc5#diff-bae01e5bc89aa196bcefbcb38b044c9de7499680f467bd6dfae1523b2efb7476L50

But we still need this, conditionally on some instances. 

This PR passes className down to the CardButton component to handle this. 
Since we were using someting similar (containerHeightClassName) I changed it to just use className.

**Places to check:** 

/dashboard/project/_/sql/quickstarts
/dashboard/project/_/logs/explorer/templates
/dashboard/org/_/general