### PR TITLE
Fix CSV import to not autocast strings into numbers

### DIFF
--- a/studio/stores/pgmeta/MetaStore.ts
+++ b/studio/stores/pgmeta/MetaStore.ts
@@ -871,7 +871,8 @@ export default class MetaStore implements IMetaStore {
     return new Promise((resolve) => {
       Papa.parse(file, {
         header: true,
-        dynamicTyping: true,
+        // dynamicTyping has to be disabled so that "00001" doesn't get parsed as 1.
+        dynamicTyping: false,
         skipEmptyLines: true,
         chunkSize: CHUNK_SIZE,
         quoteChar: file.type === 'text/tab-separated-values' ? '' : '"',


### PR DESCRIPTION
This PR fixes an issue where uploading a CSV with `"00001"` gets automatically casted to number and converted to `"1"`.