### PR TITLE
build: use larger runner for build/tests

### DIFF
--- a/.github/workflows/studio-tests.yml
+++ b/.github/workflows/studio-tests.yml
@@ -22,7 +22,8 @@ concurrency:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    # Uses larger hosted runner as it significantly decreases build times
+    runs-on: [larger-runner-4cpu]
 
     strategy:
       matrix:


### PR DESCRIPTION
Dependency installs were ~25% faster

Full studio build was 3m30 instead of 5m (30% faster)
Studio Test run took 40s instead of 1m34 (58% faster)

The hourly costs for that instance is double of what the default instance size costs, if we save roughly ~50% of time, we basically have the same costs but way less waiting time. If we save a little less time, we pay a few bucks on top, but still have a lot less waiting time.