### PR TITLE
Show an info alert when selecting a foreign key

### DIFF
--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.tsx
@@ -318,26 +318,24 @@ const ForeignKeySelector = ({
               {!matchingColumnTypes && !column?.format && (
                 <Alert_Shadcn_ variant="default">
                   <IconAlertCircle className="h-4 w-4" />
-                  <AlertTitle_Shadcn_>The referenced column has no type</AlertTitle_Shadcn_>
+                  <AlertTitle_Shadcn_>
+                    The reference column's type will be updated to {selectedColumn?.data_type}
+                  </AlertTitle_Shadcn_>
                   <AlertDescription_Shadcn_ className="leading-6">
                     <span>The referenced column</span>
                     {column?.name && <span className="text-code">{column.name}</span>}
-                    <span> has no type</span>
-                    <span> while the selected foreign column </span>
-                    <span className="text-code">
-                      {selectedTable?.name}.{selectedColumn?.name}
+                    <span>
+                      {' '}
+                      must match the type of the selected foreign column when creating a foreign key
+                      relationship.
                     </span>
-                    <span> has </span>
-                    <span className="text-code">{selectedColumn?.data_type}</span>type. They must be
-                    of the same type, therefore the referenced column type will be set to{' '}
-                    <span className="text-code">{selectedColumn?.data_type}</span>type.
                   </AlertDescription_Shadcn_>
                 </Alert_Shadcn_>
               )}
               {!matchingColumnTypes && column?.format && (
                 <Alert_Shadcn_ variant="warning">
                   <IconAlertTriangle strokeWidth={2} />
-                  <AlertTitle_Shadcn_>The column types don't match</AlertTitle_Shadcn_>
+                  <AlertTitle_Shadcn_>Column types do not match</AlertTitle_Shadcn_>
                   <AlertDescription_Shadcn_ className="leading-6">
                     <span>The referenced column</span>
                     {column?.name && <span className="text-code">{column.name}</span>}

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.tsx
@@ -12,6 +12,7 @@ import {
   AlertDescription_Shadcn_,
   AlertTitle_Shadcn_,
   Alert_Shadcn_,
+  IconAlertCircle,
   IconAlertTriangle,
   IconDatabase,
   IconHelpCircle,
@@ -201,6 +202,7 @@ const ForeignKeySelector = ({
       customFooter={
         <ActionBar
           backButtonLabel="Cancel"
+          disableApply={!!column?.format && !matchingColumnTypes}
           applyButtonLabel="Save"
           closePanel={closePanel}
           applyFunction={onSaveChanges}
@@ -313,21 +315,34 @@ const ForeignKeySelector = ({
                   ))}
                 </Listbox>
               )}
-              {!matchingColumnTypes && (
+              {!matchingColumnTypes && !column?.format && (
+                <Alert_Shadcn_ variant="default">
+                  <IconAlertCircle className="h-4 w-4" />
+                  <AlertTitle_Shadcn_>The referenced column has no type</AlertTitle_Shadcn_>
+                  <AlertDescription_Shadcn_ className="leading-6">
+                    <span>The referenced column</span>
+                    {column?.name && <span className="text-code">{column.name}</span>}
+                    <span> has no type</span>
+                    <span> while the selected foreign column </span>
+                    <span className="text-code">
+                      {selectedTable?.name}.{selectedColumn?.name}
+                    </span>
+                    <span> has </span>
+                    <span className="text-code">{selectedColumn?.data_type}</span>type. They must be
+                    of the same type, therefore the referenced column type will be set to{' '}
+                    <span className="text-code">{selectedColumn?.data_type}</span>type.
+                  </AlertDescription_Shadcn_>
+                </Alert_Shadcn_>
+              )}
+              {!matchingColumnTypes && column?.format && (
                 <Alert_Shadcn_ variant="warning">
                   <IconAlertTriangle strokeWidth={2} />
                   <AlertTitle_Shadcn_>The column types don't match</AlertTitle_Shadcn_>
                   <AlertDescription_Shadcn_ className="leading-6">
                     <span>The referenced column</span>
                     {column?.name && <span className="text-code">{column.name}</span>}
-                    {column?.format ? (
-                      <>
-                        <span> is of type </span>
-                        <span className="text-code">{column.format}</span>
-                      </>
-                    ) : (
-                      <span> has no type</span>
-                    )}
+                    <span> is of type </span>
+                    <span className="text-code">{column.format}</span>
                     <span> while the selected foreign column </span>
                     <span className="text-code">
                       {selectedTable?.name}.{selectedColumn?.name}

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.tsx
@@ -319,7 +319,7 @@ const ForeignKeySelector = ({
                 <Alert_Shadcn_ variant="default">
                   <IconAlertCircle className="h-4 w-4" />
                   <AlertTitle_Shadcn_>
-                    The reference column's type will be updated to {selectedColumn?.data_type}
+                    The referenced column's type will be updated to {selectedColumn?.data_type}
                   </AlertTitle_Shadcn_>
                   <AlertDescription_Shadcn_ className="leading-6">
                     <span>The referenced column</span>


### PR DESCRIPTION
This PR adds another alert to the foreign key selector side panel. The alert explains to the user that the referenced column data type will be set to the foreign column data type. This alert only shows up if the referenced column has no data type selected.