### PR TITLE
Fix 404 when opening the Docker self-hosting guide in a new tab

### DIFF
--- a/apps/docs/pages/guides/self-hosting.mdx
+++ b/apps/docs/pages/guides/self-hosting.mdx
@@ -26,7 +26,7 @@ export const official = [
   {
     name: 'Docker',
     description: 'Deploy Supabase within your own infrastructure using Docker Compose.',
-    href: '/docs/guides/self-hosting/docker',
+    href: '/guides/self-hosting/docker',
   },
   {
     name: 'BYO Cloud',


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix / docs update.

## What is the current behavior?

On the "Self-Hosting" page, right-clicking the "Docker" link in Firefox and asking it to open a new tab opens a "404 not found" page in the new tab.

## What is the new behavior?

Right-clicking the "Docker" link in Firefox and asking it to open a new tab opens the "Self-Hosting with Docker" page in the new tab.

## Additional context

(copied from commit message) Relative to /docs, the Next.js root, /docs resolves as /docs/docs, doing a 404 when opening a new tab or refreshing the page that the client-side router manages to open on an ordinary click.