### PR TITLE
Dashboard: Update button text on modal warnings

### DIFF
--- a/studio/components/interfaces/Auth/Policies/PolicyEditorModal/index.tsx
+++ b/studio/components/interfaces/Auth/Policies/PolicyEditorModal/index.tsx
@@ -194,7 +194,7 @@ const PolicyEditorModal = ({
       <div className="">
         <ConfirmationModal
           visible={isClosingPolicyEditorModal}
-          header="Confirm to close"
+          header="Discard changes"
           buttonLabel="Discard"
           onSelectCancel={() => setIsClosingPolicyEditorModal(false)}
           onSelectConfirm={() => {

--- a/studio/components/interfaces/Auth/Policies/PolicyEditorModal/index.tsx
+++ b/studio/components/interfaces/Auth/Policies/PolicyEditorModal/index.tsx
@@ -195,7 +195,7 @@ const PolicyEditorModal = ({
         <ConfirmationModal
           visible={isClosingPolicyEditorModal}
           header="Confirm to close"
-          buttonLabel="Confirm"
+          buttonLabel="Discard"
           onSelectCancel={() => setIsClosingPolicyEditorModal(false)}
           onSelectConfirm={() => {
             onSelectCancel()

--- a/studio/components/interfaces/Database/Functions/CreateFunction.tsx
+++ b/studio/components/interfaces/Database/Functions/CreateFunction.tsx
@@ -452,7 +452,7 @@ const CreateFunction = ({ func, visible, setVisible }: CreateFunctionProps) => {
         </CreateFunctionContext.Provider>
         <ConfirmationModal
           visible={isClosingPanel}
-          header="Confirm to close"
+          header="Discard changes"
           buttonLabel="Discard"
           onSelectCancel={() => setIsClosingPanel(false)}
           onSelectConfirm={() => {

--- a/studio/components/interfaces/Database/Functions/CreateFunction.tsx
+++ b/studio/components/interfaces/Database/Functions/CreateFunction.tsx
@@ -453,7 +453,7 @@ const CreateFunction = ({ func, visible, setVisible }: CreateFunctionProps) => {
         <ConfirmationModal
           visible={isClosingPanel}
           header="Confirm to close"
-          buttonLabel="Confirm"
+          buttonLabel="Discard"
           onSelectCancel={() => setIsClosingPanel(false)}
           onSelectConfirm={() => {
             setIsClosingPanel(false)

--- a/studio/components/interfaces/Database/Hooks/EditHookPanel.tsx
+++ b/studio/components/interfaces/Database/Hooks/EditHookPanel.tsx
@@ -316,7 +316,7 @@ const EditHookPanel = ({ visible, selectedHook, onClose }: EditHookPanelProps) =
       </SidePanel>
       <ConfirmationModal
         visible={isClosingPanel}
-        header="Confirm to close"
+        header="Discard changes"
         buttonLabel="Discard"
         onSelectCancel={() => setIsClosingPanel(false)}
         onSelectConfirm={() => {

--- a/studio/components/interfaces/Database/Hooks/EditHookPanel.tsx
+++ b/studio/components/interfaces/Database/Hooks/EditHookPanel.tsx
@@ -317,7 +317,7 @@ const EditHookPanel = ({ visible, selectedHook, onClose }: EditHookPanelProps) =
       <ConfirmationModal
         visible={isClosingPanel}
         header="Confirm to close"
-        buttonLabel="Confirm"
+        buttonLabel="Discard"
         onSelectCancel={() => setIsClosingPanel(false)}
         onSelectConfirm={() => {
           setIsClosingPanel(false)

--- a/studio/components/interfaces/Database/Triggers/CreateTrigger.tsx
+++ b/studio/components/interfaces/Database/Triggers/CreateTrigger.tsx
@@ -394,7 +394,7 @@ const CreateTrigger = ({ trigger, visible, setVisible }: CreateTriggerProps) => 
             <ConfirmationModal
               visible={isClosingPanel}
               header="Confirm to close"
-              buttonLabel="Confirm"
+              buttonLabel="Discard"
               onSelectCancel={() => setIsClosingPanel(false)}
               onSelectConfirm={() => {
                 setIsClosingPanel(false)

--- a/studio/components/interfaces/Database/Triggers/CreateTrigger.tsx
+++ b/studio/components/interfaces/Database/Triggers/CreateTrigger.tsx
@@ -393,7 +393,7 @@ const CreateTrigger = ({ trigger, visible, setVisible }: CreateTriggerProps) => 
             </CreateTriggerContext.Provider>
             <ConfirmationModal
               visible={isClosingPanel}
-              header="Confirm to close"
+              header="Discard changes"
               buttonLabel="Discard"
               onSelectCancel={() => setIsClosingPanel(false)}
               onSelectConfirm={() => {

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
@@ -586,7 +586,7 @@ const SidePanelEditor = ({
       <ConfirmationModal
         visible={isClosingPanel}
         header="Confirm to close"
-        buttonLabel="Confirm"
+        buttonLabel="Discard"
         onSelectCancel={() => setIsClosingPanel(false)}
         onSelectConfirm={() => {
           setIsClosingPanel(false)

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
@@ -585,7 +585,7 @@ const SidePanelEditor = ({
       />
       <ConfirmationModal
         visible={isClosingPanel}
-        header="Confirm to close"
+        header="Discard changes"
         buttonLabel="Discard"
         onSelectCancel={() => setIsClosingPanel(false)}
         onSelectConfirm={() => {


### PR DESCRIPTION
## What is the current behavior?

Warning modals that pop up when you are about to lose changes (eg. RLS policy changes) look like this:
![image](https://github.com/supabase/supabase/assets/4133076/2c08cc0b-a786-486d-ae22-0676c598c22e)

If you're in a hurry, the wording "Confirm" on the button almost feels like your changes will be saved vs. discarded.

## What is the new behavior?

Update wording on header to "Discard changes" and button to "Discard" which indicates what the button is really doing and reduces ambiguity.

![image](https://github.com/supabase/supabase/assets/4133076/06769f65-804d-4a12-9770-2317d5bf63ef)
