### PR TITLE
Increase stroke width on nav icons

### DIFF
--- a/studio/components/layouts/ProjectLayout/NavigationBar/NavigationBar.utils.tsx
+++ b/studio/components/layouts/ProjectLayout/NavigationBar/NavigationBar.utils.tsx
@@ -33,7 +33,7 @@ export const generateToolRoutes = (
       icon: (
         <SVG
           src={`${BASE_PATH}/img/sql-editor.svg`}
-          style={{ width: `${18}px`, height: `${18}px` }}
+          style={{ width: `${18}px`, height: `${18}px`, strokeWidth: `4` }}
           preProcessor={(code) => code.replace(/svg/, 'svg class="m-auto text-color-inherit"')}
         />
       ),
@@ -162,7 +162,7 @@ export const generateOtherRoutes = (ref?: string, project?: ProjectBase): Route[
           {
             key: 'reports',
             label: 'Reports',
-            icon: <IconBarChart size={18} strokeWidth={2} />,
+            icon: <IconBarChart size={18} strokeWidth={2.5} />,
             link: ref && (isProjectBuilding ? buildingUrl : `/project/${ref}/reports`),
           },
         ]
@@ -170,7 +170,7 @@ export const generateOtherRoutes = (ref?: string, project?: ProjectBase): Route[
     {
       key: 'logs',
       label: 'Logs',
-      icon: <IconList size={18} strokeWidth={2} />,
+      icon: <IconList size={18} strokeWidth={2.5} />,
       link: ref && (isProjectBuilding ? buildingUrl : `/project/${ref}/logs/explorer`),
     },
     {
@@ -184,7 +184,7 @@ export const generateOtherRoutes = (ref?: string, project?: ProjectBase): Route[
           {
             key: 'settings',
             label: 'Project Settings',
-            icon: <IconSettings size={18} strokeWidth={2} />,
+            icon: <IconSettings size={18} strokeWidth={2.5} />,
             link: ref && `/project/${ref}/settings/general`,
           },
         ]

--- a/studio/public/img/sql-editor.svg
+++ b/studio/public/img/sql-editor.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="22px" height="19px" viewBox="0 0 22 19" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
-        <g id="Artboard" transform="translate(-964.000000, -2867.000000)" stroke="currentColor" stroke-width="2">
+    <g id="Page-1" stroke="none" stroke-width="2.5" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
+        <g id="Artboard" transform="translate(-964.000000, -2867.000000)" stroke="currentColor" stroke-width="2.5">
             <path d="M970.7,2873.47 L973.9,2876.67 L970.7,2879.87 M985,2883 L985,2870.06801 C985,2868.96639 984.109168,2868.07219 983.007556,2868.06803 L967.007556,2868.00758 C965.902994,2868.00341 965.004187,2868.89545 965.000014,2870.00001 C965.000005,2870.00253 965,2870.00505 965,2870.00757 L965,2883 C965,2884.10457 965.895431,2885 967,2885 L983,2885 C984.104569,2885 985,2884.10457 985,2883 Z M976.033333,2879.97 L979.233333,2879.97" id="Shape"></path>
         </g>
     </g>


### PR DESCRIPTION
Attempts to bring make all of the nav icons have consistent strokeWidth.

<img width="133" alt="screenshot-2023-09-18-at-17 04 53" src="https://github.com/supabase/supabase/assets/105593/7e7b6020-b6a2-4c17-9386-4d91e039edb9">
