### PR TITLE
Updated Markdown on using native sign in section auth-google.mdx

### DIFF
--- a/apps/docs/pages/guides/auth/social-login/auth-google.mdx
+++ b/apps/docs/pages/guides/auth/social-login/auth-google.mdx
@@ -152,11 +152,11 @@ Future<AuthResponse> signInWithGoogle() {
     nonce: rawNonce,
   );
 }
-```
+````
 
 In the Supabase JavaScript library, which you can use with web-based native frameworks like React Native or Expo, you can invoke this functionality like so:
 
-```ts
+````ts
 await supabase.auth.signInWithIdToken({
   provider: 'google',
   token: '<identity token received from the OS>',


### PR DESCRIPTION

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

The line 81 of the markdown was not closed, missing a backtick to close and open 2 lines below

## What is the new behavior?

Updated Markdown on Using native sign in Section

## Additional context

None.
