### PR TITLE
Fix docs getting started icon grid

### DIFF
--- a/apps/docs/components/HomePageCover.tsx
+++ b/apps/docs/components/HomePageCover.tsx
@@ -63,7 +63,7 @@ const HomePageCover = (props) => {
   const GettingStarted = () => (
     <div
       className="
-        border border-scale-400 bg-scale-200
+        border bg-scale-200
         relative overflow-hidden
         grid grid-cols-12
         rounded-lg
@@ -71,7 +71,7 @@ const HomePageCover = (props) => {
         "
     >
       <div className="col-span-full flex flex-col md:flex-row xl:flex-col justify-between gap-1 md:gap-3">
-        <div className="md:max-w-xs xl:max-w-none">
+        <div className="md:max-w-xs shrink w-fit xl:max-w-none">
           <div className="flex items-center gap-3 mb-3">
             <IconBackground>
               <IconPlay className="text-brand-600 dark:text-brand w-4" strokeWidth={2} />
@@ -82,7 +82,7 @@ const HomePageCover = (props) => {
             Discover how to set up a database to an app making queries in just a few minutes.
           </p>
         </div>
-        <div className="flex flex-wrap md:grid md:grid-cols-4 md:gap-6 2xl:grid-cols-8 gap-2 sm:gap-3">
+        <div className="flex shrink-0 flex-wrap md:grid md:grid-cols-5 gap-2 sm:gap-3">
           {frameworks.map((framework, i) => (
             <Link key={i} href={framework.href} passHref>
               <a className="no-underline">
@@ -113,7 +113,7 @@ const HomePageCover = (props) => {
             </p>
           </div>
         </div>
-        <div className="w-full xl:max-w-[375px] 2xl:max-w-[620px] -mb-40">
+        <div className="w-full xl:max-w-[440px] -mb-40">
           <GettingStarted />
         </div>
       </div>

--- a/apps/docs/pages/index.mdx
+++ b/apps/docs/pages/index.mdx
@@ -9,7 +9,6 @@ import {
   IconPlay,
   TextLink,
 } from 'ui'
-import { LWAnnouncement } from 'ui'
 
 import HomeMenuIconPicker from '~/components/Navigation/NavigationMenu/HomeMenuIconPicker'
 
@@ -21,10 +20,6 @@ export const meta = {
 }
 
 <div className="flex flex-col">
-
-  <div className="mt-8 sm:mt-0 md:mt-4 xl:mt-16">
-    <LWAnnouncement />
-  </div>
   <div>
     <div className="max-w-xl">
       ## Products


### PR DESCRIPTION
## What kind of change does this PR introduce?

Improve the "Getting Started" icons layout.

## What is the current behavior?

<img width="1871" alt="Screenshot 2023-09-18 at 16 26 23" src="https://github.com/supabase/supabase/assets/25671831/a7c4a2cc-0391-49f8-b9bb-c47adef5d781">

## What is the new behavior?

<img width="1864" alt="Screenshot 2023-09-18 at 16 29 15" src="https://github.com/supabase/supabase/assets/25671831/3611c344-986d-4641-9512-d93f00fa5796">
