### PR TITLE
chore: doc update on edge functions log message length

### DIFF
--- a/apps/docs/pages/guides/platform/logs.mdx
+++ b/apps/docs/pages/guides/platform/logs.mdx
@@ -78,6 +78,10 @@ The Logs tab displays logs emitted during function execution.
 
 ![Function Logs](/docs/img/guides/platform/logs/logs-functions.png)
 
+**Log Message Length**
+
+Edge Function log messages have a max length of 1000 characters. If you try to log a message longer than that it will be truncated.
+
 </TabPanel>
 </Tabs>
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs Update

Adds a note on max length for edge functions log messages
