### PR TITLE
Fix: minimist import in generating embedding script

### DIFF
--- a/apps/docs/generator/index.ts
+++ b/apps/docs/generator/index.ts
@@ -10,6 +10,7 @@ const main = (command: string[], options: any) => {
 }
 
 // Run everything
+/* @ts-ignore - required for Next.js build */
 const argv = minimist(process.argv.slice(2))
 main(argv['_'], argv)
 

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -84,8 +84,8 @@
     "react-markdown": "^8.0.3",
     "rehype-slug": "^5.1.0",
     "remark": "^14.0.2",
-    "remark-gfm": "^3.0.1",
     "remark-emoji": "^3.1.2",
+    "remark-gfm": "^3.0.1",
     "ui": "*",
     "unist-builder": "^3.0.1",
     "unist-util-filter": "^4.0.1",
@@ -96,6 +96,7 @@
   "devDependencies": {
     "@aws-sdk/client-secrets-manager": "^3.410.0",
     "@types/hast": "^2.3.4",
+    "@types/minimist": "^1.2.2",
     "@types/node": "^17.0.24",
     "@types/react": "17.0.39",
     "@types/unist": "^2.0.6",
@@ -103,6 +104,7 @@
     "dotenv": "^16.0.3",
     "ejs": "^3.1.8",
     "globby": "^13.2.2",
+    "jest-environment-jsdom": "^29.7.0",
     "minimist": "^1.2.8",
     "next-transpile-modules": "^9.0.0",
     "npm-run-all": "^4.1.5",
@@ -111,7 +113,6 @@
     "ts-node": "^10.9.1",
     "tsconfig": "*",
     "tsx": "^3.12.2",
-    "typescript": "^5.0.4",
-    "jest-environment-jsdom": "^29.7.0"
+    "typescript": "^5.0.4"
   }
 }

--- a/apps/docs/scripts/search/generate-embeddings.ts
+++ b/apps/docs/scripts/search/generate-embeddings.ts
@@ -1,11 +1,11 @@
 import { createClient } from '@supabase/supabase-js'
 import dotenv from 'dotenv'
+import minimist from 'minimist'
 import 'openai'
 import { Configuration, OpenAIApi } from 'openai'
 import { inspect } from 'util'
 import { v4 as uuidv4 } from 'uuid'
 import { fetchSources } from './sources'
-import * as minimist from 'minimist'
 
 dotenv.config()
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,6 +84,7 @@
       "devDependencies": {
         "@aws-sdk/client-secrets-manager": "^3.410.0",
         "@types/hast": "^2.3.4",
+        "@types/minimist": "^1.2.2",
         "@types/node": "^17.0.24",
         "@types/react": "17.0.39",
         "@types/unist": "^2.0.6",
@@ -16151,6 +16152,12 @@
       "version": "5.1.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/minimist": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
+      "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
+      "dev": true
     },
     "node_modules/@types/ms": {
       "version": "0.7.31",


### PR DESCRIPTION
The `minimist` import in the `apps/docs/scripts/search/generate-embeddings.ts` script is causing [embedding generation CI](https://github.com/supabase/supabase/actions/runs/6232522738/job/16915864789?pr=17546) to fail.

Problem was that
```ts
import * as minimist from 'minimist'
```
returns an object that is one level too high containing `minimist` as the default export, despite the fact that `minimist` has no default export. The reason why `minimist` is getting a default export is because we have `esModuleInterop: true` (for good reason).

Fixed by removing `* as`:
```ts
import minimist from 'minimist'
```
