### PR TITLE
Skip static page generation for reference docs on preview builds

### DIFF
--- a/apps/docs/lib/mdx/handleRefStaticPaths.tsx
+++ b/apps/docs/lib/mdx/handleRefStaticPaths.tsx
@@ -1,6 +1,15 @@
 import { ICommonSection } from '~/components/reference/Reference.types'
 
 async function handleRefGetStaticPaths(sections: ICommonSection[]) {
+  // In preview environments, don't generate static pages (faster builds)
+  if (process.env.SKIP_BUILD_STATIC_GENERATION) {
+    return {
+      paths: [],
+      fallback: 'blocking',
+    }
+  }
+
+  // In production, generate static pages for every sub-section (better SEO)
   return {
     paths: sections.map((section) => {
       return {


### PR DESCRIPTION
Improve docs build times (> 50%) by skipping static page generation on reference docs for preview builds (there were a lot of pages).

### Before
![image](https://github.com/supabase/supabase/assets/4133076/43d25a4d-050c-4492-bc63-a30745a1cd94)

### After
![image](https://github.com/supabase/supabase/assets/4133076/9e66ab0b-39ff-4b1f-bc04-663501c2cdb7)

## ⚠️ Consequence
Reference docs will be slow to load in preview environments.