### PR TITLE
docs: adds import statement to main.dart

### DIFF
--- a/apps/docs/pages/guides/getting-started/tutorials/with-flutter.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-flutter.mdx
@@ -130,6 +130,8 @@ These variables will be exposed on the app, and that's completely fine since we 
 [Row Level Security](/docs/guides/auth#row-level-security) enabled on our Database.
 
 ```dart lib/main.dart
+import 'package:supabase_flutter/supabase_flutter.dart';
+
 Future<void> main() async {
   await Supabase.initialize(
     url: 'YOUR_SUPABASE_URL',


### PR DESCRIPTION
## What kind of change does this PR introduce?

Documentation improvement for getting started with flutter tutorial.

## What is the current behavior?

There is no import statement in the docs, so I needed to try and find it. Android Studio also offered `'package:supabase/supabase.dart'` (which is wrong) as the first choice for auto-completion.

