### PR TITLE
Docs: Update Edge Function URL format

### DIFF
--- a/apps/docs/layouts/guides/index.tsx
+++ b/apps/docs/layouts/guides/index.tsx
@@ -69,7 +69,7 @@ const Layout: FC<Props> = (props) => {
   const ogPageType = asPath.split('/')[2]
   // open graph image url constructor
   const ogImageUrl = encodeURI(
-    `https://obuldanrptloktxcffvn.functions.supabase.co/og-images?site=docs${
+    `https://obuldanrptloktxcffvn.supabase.co/functions/v1/og-images?site=docs${
       ogPageType ? `&type=${ogPageType}` : ''
     }&title=${props.meta?.title}&description=${props.meta?.description}`
   )

--- a/apps/docs/pages/guides/ai/examples/headless-vector-search.mdx
+++ b/apps/docs/pages/guides/ai/examples/headless-vector-search.mdx
@@ -87,7 +87,7 @@ const onSubmit = (e: Event) => {
   isLoading.value = true
 
   const query = new URLSearchParams({ query: inputRef.current!.value })
-  const projectUrl = `https://your-project-ref.functions.supabase.co`
+  const projectUrl = `https://your-project-ref.supabase.co/functions/v1`
   const queryURL = `${projectURL}/${query}`
   const eventSource = new EventSource(queryURL)
 

--- a/apps/docs/pages/guides/database/extensions/pg_cron.mdx
+++ b/apps/docs/pages/guides/database/extensions/pg_cron.mdx
@@ -99,7 +99,7 @@ select
     $$
     select
       net.http_post(
-          url:='https://project-ref.functions.supabase.co/function-name',
+          url:='https://project-ref.supabase.co/functions/v1/function-name',
           headers:='{"Content-Type": "application/json", "Authorization": "Bearer YOUR_ANON_KEY"}'::jsonb,
           body:=concat('{"time": "', now(), '"}')::jsonb
       ) as request_id;

--- a/apps/docs/pages/guides/database/extensions/pg_net.mdx
+++ b/apps/docs/pages/guides/database/extensions/pg_net.mdx
@@ -157,7 +157,7 @@ Make a POST request to a Supabase Edge Function with auth header and JSON body p
 ```sql
 select
     net.http_post(
-        url:='https://project-ref.functions.supabase.co/function-name',
+        url:='https://project-ref.supabase.co/functions/v1/function-name',
         headers:='{"Content-Type": "application/json", "Authorization": "Bearer YOUR_ANON_KEY"}'::jsonb,
         body:='{"name": "pg_net"}'::jsonb
     ) as request_id;

--- a/apps/docs/pages/guides/functions/quickstart.mdx
+++ b/apps/docs/pages/guides/functions/quickstart.mdx
@@ -78,7 +78,7 @@ verify_jwt = false
 You can invoke Edge Functions using curl:
 
 ```bash
-curl --request POST 'https://<project_ref>.functions.supabase.co/hello-world' \
+curl --request POST 'https://<project_ref>.supabase.co/functions/v1/hello-world' \
   --header 'Authorization: Bearer ANON_KEY' \
   --header 'Content-Type: application/json' \
   --data '{ "name":"Functions" }'

--- a/apps/docs/pages/guides/functions/schedule-functions.mdx
+++ b/apps/docs/pages/guides/functions/schedule-functions.mdx
@@ -33,7 +33,7 @@ select
     $$
     select
       net.http_post(
-          url:='https://project-ref.functions.supabase.co/function-name',
+          url:='https://project-ref.supabase.co/functions/v1/function-name',
           headers:='{"Content-Type": "application/json", "Authorization": "Bearer YOUR_ANON_KEY"}'::jsonb,
           body:=concat('{"time": "', now(), '"}')::jsonb
       ) as request_id;

--- a/apps/www/components/LaunchWeek/7/Ticket/TicketActions.tsx
+++ b/apps/www/components/LaunchWeek/7/Ticket/TicketActions.tsx
@@ -31,7 +31,7 @@ export default function TicketActions({
     'twitter'
   )}&via=supabase&text=${text}`
   const linkedInUrl = `https://www.linkedin.com/sharing/share-offsite/?url=${permalink('linkedin')}`
-  const downloadUrl = `https://obuldanrptloktxcffvn.functions.supabase.co/lw7-ticket-og?username=${encodeURIComponent(
+  const downloadUrl = `https://obuldanrptloktxcffvn.supabase.co/functions/v1/lw7-ticket-og?username=${encodeURIComponent(
     username
   )}`
   const params = useParams()

--- a/apps/www/components/LaunchWeek/7/Ticket/TicketForm.tsx
+++ b/apps/www/components/LaunchWeek/7/Ticket/TicketForm.tsx
@@ -60,7 +60,7 @@ export default function TicketForm({ defaultUsername = '', setTicketGenerationSt
           fetch(`/launch-week/tickets/${username}`).catch((_) => {})
           // Prefetch ticket og image.
           fetch(
-            `https://obuldanrptloktxcffvn.functions.supabase.co/lw7-ticket-og?username=${encodeURIComponent(
+            `https://obuldanrptloktxcffvn.supabase.co/functions/v1/lw7-ticket-og?username=${encodeURIComponent(
               username ?? ''
             )}`
           ).catch((_) => {})

--- a/apps/www/components/LaunchWeek/8/Ticket/TicketActions.tsx
+++ b/apps/www/components/LaunchWeek/8/Ticket/TicketActions.tsx
@@ -30,7 +30,7 @@ export default function TicketActions({
   const { userData, supabase } = useConfData()
   const tweetUrl = `https://twitter.com/intent/tweet?url=${permalink}&via=supabase&text=${encodedText}`
   const linkedInUrl = `https://www.linkedin.com/sharing/share-offsite/?url=${permalink}`
-  const downloadUrl = `https://obuldanrptloktxcffvn.functions.supabase.co/lw8-ticket?username=${encodeURIComponent(
+  const downloadUrl = `https://obuldanrptloktxcffvn.supabase.co/functions/v1/lw8-ticket?username=${encodeURIComponent(
     username
   )}`
   const params = useParams()

--- a/apps/www/pages/launch-week/7/tickets/[username].tsx
+++ b/apps/www/pages/launch-week/7/tickets/[username].tsx
@@ -132,7 +132,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
     golden = user?.golden ?? false
     bg_image_id = user?.bg_image_id ?? 1
     referrals = user?.referrals ?? 0
-    ogImageUrl = `https://obuldanrptloktxcffvn.functions.supabase.co/lw7-ticket-og?username=${encodeURIComponent(
+    ogImageUrl = `https://obuldanrptloktxcffvn.supabase.co/functions/v1/lw7-ticket-og?username=${encodeURIComponent(
       username ?? ''
     )}${golden ? '&golden=true' : ''}`
   }

--- a/apps/www/pages/launch-week/7/tickets/index.tsx
+++ b/apps/www/pages/launch-week/7/tickets/index.tsx
@@ -27,7 +27,7 @@ const supabaseAdmin = createClient(
 
 const generateOgs = async (users: UserData[]) => {
   users?.map(async (user) => {
-    const ogImageUrl = `https://obuldanrptloktxcffvn.functions.supabase.co/lw7-ticket-og?username=${encodeURIComponent(
+    const ogImageUrl = `https://obuldanrptloktxcffvn.supabase.co/functions/v1/lw7-ticket-og?username=${encodeURIComponent(
       user.username ?? ''
     )}${!!user.golden ? '&golden=true' : ''}`
     return await fetch(ogImageUrl)

--- a/apps/www/pages/launch-week/tickets/[username].tsx
+++ b/apps/www/pages/launch-week/tickets/[username].tsx
@@ -144,7 +144,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
   const { data: users } = await supabaseAdmin!.from('lw8_tickets_golden').select().limit(17)
 
   fetch(
-    `https://obuldanrptloktxcffvn.functions.supabase.co/lw8-ticket?username=${encodeURIComponent(
+    `https://obuldanrptloktxcffvn.supabase.co/functions/v1/lw8-ticket?username=${encodeURIComponent(
       username ?? ''
     )}`
   ).catch((_) => {})

--- a/apps/www/pages/launch-week/tickets/index.tsx
+++ b/apps/www/pages/launch-week/tickets/index.tsx
@@ -28,7 +28,7 @@ const supabaseAdmin = createClient(
 
 const generateOgs = async (users: UserData[]) => {
   users?.map(async (user) => {
-    const ogImageUrl = `https://obuldanrptloktxcffvn.functions.supabase.co/lw8-ticket-og?username=${encodeURIComponent(
+    const ogImageUrl = `https://obuldanrptloktxcffvn.supabase.co/functions/v1/lw8-ticket-og?username=${encodeURIComponent(
       user.username ?? ''
     )}${!!user.golden ? '&golden=true' : ''}`
     return await fetch(ogImageUrl)

--- a/apps/www/supabase/functions/launchweek-ticket-og/README.md
+++ b/apps/www/supabase/functions/launchweek-ticket-og/README.md
@@ -4,7 +4,7 @@ Generate Open Graph images with Deno and Supabase Edge Functions and cache the g
 
 - Docs: https://deno.land/x/og_edge@0.0.2
 - Examples: https://vercel.com/docs/concepts/functions/edge-functions/og-image-examples
-- Demo: https://obuldanrptloktxcffvn.functions.supabase.co/launchweek-ticket-og?username=thorwebdev
+- Demo: https://obuldanrptloktxcffvn.supabase.co/functions/v1/launchweek-ticket-og?username=thorwebdev
 
 ## Run locally
 

--- a/apps/www/supabase/functions/lw7-ticket-og/README.md
+++ b/apps/www/supabase/functions/lw7-ticket-og/README.md
@@ -4,7 +4,7 @@ Generate Open Graph images with Deno and Supabase Edge Functions and cache the g
 
 - Docs: https://deno.land/x/og_edge@0.0.2
 - Examples: https://vercel.com/docs/concepts/functions/edge-functions/og-image-examples
-- Demo: https://obuldanrptloktxcffvn.functions.supabase.co/lw7-ticket-og?username=thorwebdev
+- Demo: https://obuldanrptloktxcffvn.supabase.co/functions/v1/lw7-ticket-og?username=thorwebdev
 
 ## Run locally
 

--- a/apps/www/supabase/functions/lw7-ticket-og/handler.tsx
+++ b/apps/www/supabase/functions/lw7-ticket-og/handler.tsx
@@ -256,7 +256,7 @@ export async function handler(req: Request) {
       )
     if (storageError) throw new Error(`storageError: ${storageError.message}`)
     // Generate image for gallery
-    fetch('https://obuldanrptloktxcffvn.functions.supabase.co/lw7-ticket-gallery', {
+    fetch('https://obuldanrptloktxcffvn.supabase.co/functions/v1/lw7-ticket-gallery', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/apps/www/supabase/functions/lw8-ticket/README.md
+++ b/apps/www/supabase/functions/lw8-ticket/README.md
@@ -4,7 +4,7 @@ Generate Open Graph images with Deno and Supabase Edge Functions and cache the g
 
 - Docs: https://deno.land/x/og_edge@0.0.2
 - Examples: https://vercel.com/docs/concepts/functions/edge-functions/og-image-examples
-- Demo: https://obuldanrptloktxcffvn.functions.supabase.co/lw8-ticket?username=thorwebdev
+- Demo: https://obuldanrptloktxcffvn.supabase.co/functions/v1/lw8-ticket?username=thorwebdev
 
 ## Run locally
 

--- a/apps/www/supabase/functions/lw8-ticket/handler.tsx
+++ b/apps/www/supabase/functions/lw8-ticket/handler.tsx
@@ -252,7 +252,7 @@ export async function handler(req: Request) {
     if (storageError) throw new Error(`storageError: ${storageError.message}`)
 
     // Generate og image
-    fetch('https://obuldanrptloktxcffvn.functions.supabase.co/lw8-ticket-og', {
+    fetch('https://obuldanrptloktxcffvn.supabase.co/functions/v1/lw8-ticket-og', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/examples/edge-functions/supabase/functions/get-tshirt-competition/README.md
+++ b/examples/edge-functions/supabase/functions/get-tshirt-competition/README.md
@@ -2,10 +2,10 @@
 
 To celebrate the support of GET requests in Supabase Edge Functions we're giving away some limited edition Functions Shirts!
 
-To win a Supabase Edge Functions T-Shirt, make a GET request to https://obuldanrptloktxcffvn.functions.supabase.co/get-tshirt-competition with your email address, your Twitter handle (optional), your t-shirt size (S-2XL) and the correct answer, e.g.
+To win a Supabase Edge Functions T-Shirt, make a GET request to https://obuldanrptloktxcffvn.supabase.co/functions/v1/get-tshirt-competition with your email address, your Twitter handle (optional), your t-shirt size (S-2XL) and the correct answer, e.g.
 
 ```text
-https://obuldanrptloktxcffvn.functions.supabase.co/get-tshirt-competition?email=testr@test.de&twitter=thorwebdev&size=2XL&answer=20
+https://obuldanrptloktxcffvn.supabase.co/functions/v1/get-tshirt-competition?email=testr@test.de&twitter=thorwebdev&size=2XL&answer=20
 ```
 
 You can read the functions source code to figure out the answer ;)

--- a/examples/edge-functions/supabase/functions/og-image-with-storage-cdn/README.md
+++ b/examples/edge-functions/supabase/functions/og-image-with-storage-cdn/README.md
@@ -4,7 +4,7 @@ Generate Open Graph images with Deno and Supabase Edge Functions and cache the g
 
 - Docs: https://deno.land/x/og_edge@0.0.2
 - Examples: https://vercel.com/docs/concepts/functions/edge-functions/og-image-examples
-- Demo: https://obuldanrptloktxcffvn.functions.supabase.co/launchweek-ticket-og?ticketNumber=1234&username=thorwebdev&name=Thor%20%E9%9B%B7%E7%A5%9E%20Schaeff
+- Demo: https://obuldanrptloktxcffvn.supabase.co/functions/v1/launchweek-ticket-og?ticketNumber=1234&username=thorwebdev&name=Thor%20%E9%9B%B7%E7%A5%9E%20Schaeff
 
 ## Run locally
 

--- a/examples/edge-functions/supabase/functions/telegram-bot/README.md
+++ b/examples/edge-functions/supabase/functions/telegram-bot/README.md
@@ -9,5 +9,5 @@ Try it out: https://t.me/supabase_example_bot
 1. Run `supabase functions deploy --no-verify-jwt telegram-bot`
 2. Get your Telegram token from https://t.me/BotFather
 3. Run `supabase secrets set TELEGRAM_BOT_TOKEN=your_token FUNCTION_SECRET=random_secret`
-4. Set your bot's webhook url to `https://<PROJECT_REFERENCE>.functions.supabase.co/telegram-bot` (Replacing `<...>` with respective values). In order to do that, run this url (in your browser, for example): `https://api.telegram.org/bot<TELEGRAM_BOT_TOKEN>/setWebhook?url=https://<PROJECT_REFERENCE>.functions.supabase.co/telegram-bot?secret=<FUNCTION_SECRET>`
+4. Set your bot's webhook url to `https://<PROJECT_REFERENCE>.functions.supabase.co/telegram-bot` (Replacing `<...>` with respective values). In order to do that, run this url (in your browser, for example): `https://api.telegram.org/bot<TELEGRAM_BOT_TOKEN>/setWebhook?url=https://<PROJECT_REFERENCE>.supabase.co/functions/v1/telegram-bot?secret=<FUNCTION_SECRET>`
 5. That's it, go ahead and chat with your bot 🤖💬

--- a/supabase/functions/og-images/README.md
+++ b/supabase/functions/og-images/README.md
@@ -1,6 +1,6 @@
 # Open Graph (OG) Image Generator
 
-Generate  OG Images for the sites at supabase.
+Generate OG Images for the sites at supabase.
 
 ## How to use
 
@@ -20,7 +20,7 @@ If any of the required parameters are missing, you will receive a 404 response w
 
 Here is an example link that you can use to test the website:
 
-https://obuldanrptloktxcffvn.functions.supabase.co/og-images?site=docs&title=Example%20Title&description=Example%20Description&type=Auth&icon=google
+https://obuldanrptloktxcffvn.supabase.co/functions/v1/og-images?site=docs&title=Example%20Title&description=Example%20Description&type=Auth&icon=google
 
 This link will generate an image for the docs site with the title "Example Title", the description "Example Description", the Auth type, and the Google icon.
 
@@ -33,6 +33,7 @@ supabase start
 ```
 
 Then run the function
+
 ```bash
 supabase functions serve og-images
 ```


### PR DESCRIPTION
For Edge Functions, we are now recommending users use the path-based URL format:

`https://project-ref.supabase.co/functions/v1`

instead the previous subdomain-based format:

`https://project-ref.functions.supabase.co`
