### PR TITLE
fix: permission check for billing migration

### DIFF
--- a/studio/components/interfaces/Organization/BillingSettings/BillingSettings.tsx
+++ b/studio/components/interfaces/Organization/BillingSettings/BillingSettings.tsx
@@ -32,15 +32,12 @@ const BillingSettings = () => {
       : customerBalance
 
   const orgBillingMigrationEnabled = useFlag('orgBillingMigration')
-  const canMigrateOrganization = useCheckPermissions(PermissionAction.UPDATE, 'organizations')
   const selectedOrganization = useSelectedOrganization()
   const { subscription_id } = selectedOrganization ?? {}
 
   return (
     <ScaffoldContainerLegacy>
-      {orgBillingMigrationEnabled && canMigrateOrganization && !subscription_id && (
-        <OrganizationBillingMigrationPanel />
-      )}
+      {orgBillingMigrationEnabled && !subscription_id && <OrganizationBillingMigrationPanel />}
 
       <ProjectsSummary projects={projects} />
 

--- a/studio/components/interfaces/Organization/GeneralSettings/MigrateOrganizationBillingButton.tsx
+++ b/studio/components/interfaces/Organization/GeneralSettings/MigrateOrganizationBillingButton.tsx
@@ -32,7 +32,7 @@ const MigrateOrganizationBillingButton = observer(() => {
   const organization = useSelectedOrganization()
 
   const disableOrgBillingMigration = useFlag('disableOrgBillingMigration')
-  const canMigrateOrg = useCheckPermissions(PermissionAction.UPDATE, 'organizations')
+  const canMigrateOrg = useCheckPermissions(PermissionAction.BILLING_WRITE, 'stripe.subscriptions')
 
   const [isOpen, setIsOpen] = useState(false)
   const [tier, setTier] = useState('')
@@ -93,8 +93,6 @@ const MigrateOrganizationBillingButton = observer(() => {
     }
   }, [isOpen])
 
-  const canMigrateOrganization = useCheckPermissions(PermissionAction.UPDATE, 'organizations')
-
   const selectedLimitedUsage = useMemo(
     () => tier === 'PRO' && isSpendCapEnabled,
     [tier, isSpendCapEnabled]
@@ -118,7 +116,7 @@ const MigrateOrganizationBillingButton = observer(() => {
 
   const onConfirmMigrate = async () => {
     if (!tier) return
-    if (!canMigrateOrganization) {
+    if (!canMigrateOrg) {
       return ui.setNotification({
         category: 'error',
         message: 'You do not have the required permissions to migrate this organization',
@@ -136,7 +134,7 @@ const MigrateOrganizationBillingButton = observer(() => {
               loading={!organization?.slug}
               onClick={toggle}
               type="primary"
-              disabled={!canMigrateOrg || disableOrgBillingMigration}
+              disabled={disableOrgBillingMigration}
             >
               Migrate organization
             </Button>


### PR DESCRIPTION
- Anyone who has write access to billing should be able to initiate the migration (not just owners like before)
- Always show the migration panel, only deny at the very end when they want to do the actual migration