### PR TITLE
feat: bump `@supabase/gotrue-js` to v2.54.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41205,7 +41205,7 @@
       "license": "MIT",
       "dependencies": {
         "@headlessui/react": "^1.7.14",
-        "@supabase/gotrue-js": "^2.52.0",
+        "@supabase/gotrue-js": "^2.54.0",
         "@supabase/ui": "^0.37.0-alpha.50",
         "@types/react": "^17.0.39",
         "react-use": "^17.4.0"
@@ -41215,6 +41215,14 @@
         "config": "*",
         "tsconfig": "*",
         "typescript": "^5.0.4"
+      }
+    },
+    "packages/common/node_modules/@supabase/gotrue-js": {
+      "version": "2.54.0",
+      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.54.0.tgz",
+      "integrity": "sha512-JjtbchtPbpgK0O8NIMIvKLk7HHv0kd23L3UO5a398nczCcBkI0IvmbPtbS4Xs5AUIuJ+JHtV6siOZR1ha5EzQw==",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
       }
     },
     "packages/common/node_modules/@types/react": {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "dependencies": {
     "@headlessui/react": "^1.7.14",
-    "@supabase/gotrue-js": "^2.52.0",
+    "@supabase/gotrue-js": "^2.54.0",
     "@supabase/ui": "^0.37.0-alpha.50",
     "@types/react": "^17.0.39",
     "react-use": "^17.4.0"


### PR DESCRIPTION
Bumps `@supabase/gotrue-js` to v2.54.0.