### PR TITLE
chore: Remove typo error on BackupsList.tsx

### DIFF
--- a/studio/components/interfaces/Database/Backups/BackupsList.tsx
+++ b/studio/components/interfaces/Database/Backups/BackupsList.tsx
@@ -117,7 +117,7 @@ const BackupsList = () => {
         <Modal.Content>
           <div className="pt-6 pb-5">
             <p>
-              Are you sure you want to restore from  
+              Are you sure you want to restore from
               {dayjs(selectedBackup?.inserted_at).format('DD MMM YYYY')}? This will destroy any new
               data written since this backup was made.
             </p>

--- a/studio/components/interfaces/Database/Backups/BackupsList.tsx
+++ b/studio/components/interfaces/Database/Backups/BackupsList.tsx
@@ -117,7 +117,7 @@ const BackupsList = () => {
         <Modal.Content>
           <div className="pt-6 pb-5">
             <p>
-              Are you sure you want to restore from $
+              Are you sure you want to restore from  
               {dayjs(selectedBackup?.inserted_at).format('DD MMM YYYY')}? This will destroy any new
               data written since this backup was made.
             </p>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When you select a restore from the Scheduled backups from the Dashboard, the date has a `$` before the date.

![image](https://github.com/supabase/supabase/assets/119607551/621ffd59-f242-4a46-960b-0737b647e06b)

## What is the new behavior?

This will remove the `$` on the date.

## Additional context

Add any other context or screenshots.
