### PR TITLE
chore: change log message length to 10k

### DIFF
--- a/apps/docs/pages/guides/platform/logs.mdx
+++ b/apps/docs/pages/guides/platform/logs.mdx
@@ -80,7 +80,7 @@ The Logs tab displays logs emitted during function execution.
 
 **Log Message Length**
 
-Edge Function log messages have a max length of 1000 characters. If you try to log a message longer than that it will be truncated.
+Edge Function log messages have a max length of 10,000 characters. If you try to log a message longer than that it will be truncated.
 
 </TabPanel>
 </Tabs>


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## Additional context

We've changed this limit from 1k to 10k
