### PR TITLE
Fix typos in realtime/postgres-changes.mdx

### DIFF
--- a/apps/docs/pages/guides/realtime/postgres-changes.mdx
+++ b/apps/docs/pages/guides/realtime/postgres-changes.mdx
@@ -349,7 +349,7 @@ const changes = client
 
 ## Available filters
 
-Realtime offers filters so you can specify the data your client ves at a more granular level.
+Realtime offers filters so you can specify the data your client receives at a more granular level.
 
 ### Equal to (eq)
 

--- a/apps/docs/pages/guides/realtime/postgres-changes.mdx
+++ b/apps/docs/pages/guides/realtime/postgres-changes.mdx
@@ -197,7 +197,7 @@ In this example we'll set up a database table, secure it with Row Level Security
 
 You can use the Supabase client libraries to subscribe to database changes.
 
-### Listeniing to specific schemas
+### Listening to specific schemas
 
 Subscribe to specific schema events using the `schema` parameter:
 

--- a/apps/docs/pages/guides/realtime/postgres-changes.mdx
+++ b/apps/docs/pages/guides/realtime/postgres-changes.mdx
@@ -349,7 +349,7 @@ const changes = client
 
 ## Available filters
 
-Realtime offers filters so you can specify the data your client receives at a more granular level.
+Realtime offers filters so you can specify the data your client ves at a more granular level.
 
 ### Equal to (eq)
 
@@ -505,7 +505,7 @@ const channel = supabase
 
 This filter uses Postgres's `= ANY`. Realtime allows a maximum of 100 values for this filter.
 
-## Receiveing `old` records
+## Receiving `old` records
 
 By default, only `new` record changes are sent but if you want to receive the `old` record (previous values) whenever you `UPDATE` or `DELETE` a record, you can set the `replica identity` of your table to `full`:
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Docs update

## What is the current behavior?

- Has a typo `Listeniing`
- Has a typo `Receiveing`

## What is the new behavior?

- Uses correct spelling of `Listening`
- Uses correct spelling of `Receiving`
