### PR TITLE
fix: nav org redirect

### DIFF
--- a/studio/components/layouts/AppLayout/OrganizationDropdown.tsx
+++ b/studio/components/layouts/AppLayout/OrganizationDropdown.tsx
@@ -102,7 +102,7 @@ const OrganizationDropdown = ({ isNewNav = false }: OrganizationDropdownProps) =
                 </ScrollArea>
               </CommandGroup_Shadcn_>
               <CommandGroup_Shadcn_ className="border-t">
-                <Link passHref href="new">
+                <Link passHref href="/new">
                   <CommandItem_Shadcn_
                     asChild
                     className="cursor-pointer flex items-center space-x-2 w-full"


### PR DESCRIPTION
User was redirected to `/projects/new` instead of `/new` so we tried to find a project with the ref `new`