### PR TITLE
Fix: Resolved 'null.length' TypeError in WrapperRow.tsx

### DIFF
--- a/studio/components/interfaces/Database/Wrappers/WrapperRow.tsx
+++ b/studio/components/interfaces/Database/Wrappers/WrapperRow.tsx
@@ -114,10 +114,11 @@ const WrapperRow = ({
                     ))}
                     <div className="!mt-3 space-y-1">
                       <p className="text-sm text-scale-1100">
-                        Foreign tables: ({wrapper.tables.length})
+                        Foreign tables: {wrapper.tables ? `(${wrapper.tables.length})` : ''}
                       </p>
                       <div className="flex flex-wrap gap-2">
-                        {wrapper.tables.map((table: any) => (
+                      {wrapper.tables ? (
+                        wrapper.tables.map((table: any) => (
                           <Link key={table.id} href={`/project/${ref}/editor/${table.id}`}>
                             <a>
                               <div
@@ -128,9 +129,12 @@ const WrapperRow = ({
                               </div>
                             </a>
                           </Link>
-                        ))}
+                        ))
+                      ) : (
+                        <p className="text-sm text-scale-1100">No tables available</p>
+                      )}
                       </div>
-                    </div>
+                    </div>  
                   </div>
                   <div className="flex items-center space-x-2">
                     {canManageWrappers ? (

--- a/studio/components/interfaces/Settings/Database/BannedIPs.tsx
+++ b/studio/components/interfaces/Settings/Database/BannedIPs.tsx
@@ -1,0 +1,136 @@
+import * as Tooltip from '@radix-ui/react-tooltip'
+import Link from 'next/link'
+import { useEffect, useState } from 'react'
+import { Button, IconExternalLink } from 'ui'
+import { useParams } from 'common/hooks'
+import {
+  FormHeader,
+  FormPanel,
+  FormSection,
+  FormSectionContent,
+  FormSectionLabel,
+} from 'components/ui/Forms'
+import { useProjectSettingsQuery } from 'data/config/project-settings-query'
+import { useBannedIPsQuery } from 'data/banned-ips/banned-ips-query'
+
+const BannedIPs = () => {
+  const { ref } = useParams()
+  const [selectedIPs, setSelectedIPs] = useState<string[]>([]) // Explicitly define the type as string[]
+  const { data: projectSettings } = useProjectSettingsQuery({ projectRef: ref })
+  const {
+    data: IPlist,
+    isLoading,
+    isSuccess,
+  } = useBannedIPsQuery({
+    projectRef: ref,
+  })
+
+   // Log the data from useProjectSettingsQuery
+   console.log('Project Settings Data:', projectSettings);
+
+   // Log the data from useBannedIPsQuery only when it's available
+   useEffect(() => {
+    if (isSuccess) {
+      console.log('Banned IPs Data:', IPlist);
+    }
+  }, [isSuccess, IPlist]);
+
+  const handleToggleIP = (ip: string) => {
+    // Toggle the selection state of an IP address
+    setSelectedIPs((prevSelectedIPs) =>
+      prevSelectedIPs.includes(ip)
+        ? prevSelectedIPs.filter((selectedIP) => selectedIP !== ip)
+        : [...prevSelectedIPs, ip]
+    )
+  }
+
+  const handleUnbanIPs = () => {
+    // Perform the unban action for selected IPs here
+    // I can use the `selectedIPs` array to unban the selected IPs
+  }
+
+  return (
+    <div>
+      <div className="flex items-center justify-between">
+        <FormHeader title="Banned IPs" description="" />
+        <div className="flex items-center space-x-2 mb-6">
+          <Link href="https://supabase.com/docs/guides/platform/network-restrictions">
+            <a target="_blank">
+              <Button type="default" icon={<IconExternalLink />}>
+                Documentation
+              </Button>
+            </a>
+          </Link>
+        </div>
+      </div>
+      <FormPanel>
+        <div className="grid grid-cols-1 items-center lg:grid-cols-2 p-8">
+          <div className="space-y-2">
+            <div style={{ maxWidth: '420px' }}>
+              <p className="text-sm opacity-50"></p>
+            </div>
+            {/* Display the list of banned IPs */}
+            <table>
+              <thead>
+                <tr>
+                  <th>Select</th>
+                  <th>IP Address</th>
+                  <th>Action</th>
+                </tr>
+              </thead>
+              <tbody>
+                {IPlist && IPlist.banned_ipv4_addresses.map((ip) => ( 
+                    <tr key={ip}>
+                      <td>
+                        <input
+                          type="checkbox"
+                          checked={selectedIPs.includes(ip)}
+                          onChange={() => handleToggleIP(ip)}
+                        />
+                      </td>
+                      <td>{ip}</td>
+                      <td>
+                        {/* I can any action buttons here */}
+                        <button
+                          type="button"
+                          onClick={() => {
+                            // Implement the unban logic here for a single IP
+                            // I can use the `ip` variable to unban this specific IP
+                          }}
+                        >
+                          Unban IP
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+              </tbody>
+            </table>
+          </div>
+          <div className="flex items-end justify-end">
+            <Tooltip.Root delayDuration={0}>
+              <Tooltip.Trigger>
+                <Button
+                  type="default"
+                  disabled={!selectedIPs.length}
+                  onClick={handleUnbanIPs}
+                >
+                  Unban IPs
+                </Button>
+              </Tooltip.Trigger>
+              {!selectedIPs.length && (
+                <Tooltip.Portal>
+                  <Tooltip.Content align="center" side="bottom">
+                    <Tooltip.Arrow className="radix-tooltip-arrow" />
+                    <div></div>
+                  </Tooltip.Content>
+                </Tooltip.Portal>
+              )}
+            </Tooltip.Root>
+          </div>
+        </div>
+      </FormPanel>
+    </div>
+  )
+}
+
+export default BannedIPs

--- a/studio/data/banned-ips/banned-ips-delete-mutation.ts
+++ b/studio/data/banned-ips/banned-ips-delete-mutation.ts
@@ -1,0 +1,62 @@
+import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { post } from 'data/fetchers'
+import { ResponseError } from 'types'
+import { BannedIPKeys } from './keys'
+
+import toast from 'react-hot-toast'
+import { patch } from 'data/fetchers'
+
+export type IPDeleteVariables = {
+  projectRef: string
+  ip: number
+  updatedParam: string
+}
+
+export async function deleteBannedIPs({ projectRef, ip }: IPDeleteVariables) {
+  // @ts-ignore Just sample, TS lint will validate if the endpoint is valid
+  const { data, error } = await del(`/v1/projects/{ref}/network-bans`, {
+    params: { 
+      path: { ref: projectRef } 
+    },
+    data: { ip }
+  })
+
+  if (error) throw error
+  return data
+}
+
+type IPDeleteData = Awaited<ReturnType<typeof deleteBannedIPs>>
+
+export const useBannedIPsDeleteMutation = ({
+  onSuccess,
+  onError,
+  ...options
+}: Omit<
+  UseMutationOptions<IPDeleteData, ResponseError, IPDeleteVariables>,
+  'mutationFn'
+> = {}) => {
+  const queryClient = useQueryClient()
+  return useMutation<IPDeleteData, ResponseError, IPDeleteVariables>(
+    (vars) => deleteBannedIPs(vars),
+    {
+      async onSuccess(data, variables, context) {
+        const { projectRef, ip } = variables
+
+        await Promise.all([
+          queryClient.invalidateQueries(BannedIPKeys.list(projectRef)),
+          queryClient.invalidateQueries(BannedIPKeys.detail(ip)),
+        ])
+
+        await onSuccess?.(data, variables, context)
+      },
+      async onError(data, variables, context) {
+        if (onError === undefined) {
+          toast.error(`Failed to delete ip: ${data.message}`)
+        } else {
+          onError(data, variables, context)
+        }
+      },
+      ...options,
+    }
+  )
+}

--- a/studio/data/banned-ips/banned-ips-query.ts
+++ b/studio/data/banned-ips/banned-ips-query.ts
@@ -1,0 +1,53 @@
+import { useQuery, useQueryClient, UseQueryOptions } from '@tanstack/react-query'
+import { post } from 'data/fetchers'
+import { ResponseError } from 'types'
+import { BannedIPKeys } from './keys'
+
+export type BannedIPVariables = {
+  projectRef?: string
+  ip?: string
+};
+
+export type BannedIPsData = BannedIPVariables[];
+export type BannedIPsError = ResponseError;
+
+export async function getBannedIPs({ projectRef }: BannedIPVariables, signal?: AbortSignal) {
+  if (!projectRef) throw new Error('projectRef is required')
+
+  // @ts-ignore Just a sample here, TS lint will validate if the endpoint is valid
+  const { data, error } = await post(`/v1/projects/{ref}/network-bans/retrieve`, {
+    params: { 
+      path: { ref: projectRef } 
+    },
+    signal,
+  })
+  // Log the error message if an error occurred
+  if (error) {
+    console.error('Error fetching banned IPs:', error);
+    throw error;
+  }
+
+  // Log the data if it's available
+  if (data) {
+    console.log('Banned IPs Data:', data);
+  }
+  return data
+}
+
+export type IPData = Awaited<ReturnType<typeof getBannedIPs>>
+export type IPError = ResponseError
+
+export const useBannedIPsQuery = <TData = IPData>(
+  { projectRef }: BannedIPVariables,
+  { enabled = true, ...options }: UseQueryOptions<IPData, IPError, TData> = {}
+) =>
+  useQuery<IPData, IPError, TData>(
+    BannedIPKeys.list(projectRef),
+    ({ signal }) => getBannedIPs({ projectRef }, signal),
+    {
+      enabled: enabled && typeof projectRef !== 'undefined',
+      ...options,
+    }
+  )
+
+

--- a/studio/data/banned-ips/keys.ts
+++ b/studio/data/banned-ips/keys.ts
@@ -1,0 +1,4 @@
+export const BannedIPKeys = {
+    list: (projectRef: string | undefined) => ['projects', projectRef, 'banned-ips'] as const,
+    detail: (ip: string | undefined) => ['banned-ips', ip] as const,
+  }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The issue is caused by an attempt to access the 'length' property of a null value in the `WrapperRow.tsx` file at line 117 when we don't have any foreign tables available:
![image](https://github.com/supabase/supabase/assets/99693443/59ef7943-09fe-453f-8017-889d9eb6ffff)

## What is the new behavior?

![image](https://github.com/supabase/supabase/assets/99693443/cd9260f8-3325-4d6f-a416-c4768443cac1)

