### PR TITLE
Fix: Resolve null.length TypeError in WrapperRow.tsx

### DIFF
--- a/studio/components/interfaces/Database/Wrappers/WrapperRow.tsx
+++ b/studio/components/interfaces/Database/Wrappers/WrapperRow.tsx
@@ -113,26 +113,26 @@ const WrapperRow = ({
                       </div>
                     ))}
                     <div className="!mt-3 space-y-1">
-                    <p className="text-sm text-scale-1100">
+                      <p className="text-sm text-scale-1100">
                         Foreign tables: {wrapper.tables ? `(${wrapper.tables.length})` : ''}
                       </p>
                       <div className="flex flex-wrap gap-2">
-                      {wrapper.tables ? (
-                        wrapper.tables.map((table: any) => (
-                          <Link key={table.id} href={`/project/${ref}/editor/${table.id}`}>
-                            <a>
-                              <div
-                                key={table.id}
-                                className="text-sm border rounded px-2 py-1 transition bg-scale-400 hover:bg-scale-500"
-                              >
-                                {table.name} 
-                              </div>
-                            </a>
-                          </Link>
-                        ))
-                      ) : (
-                        <p className="text-sm text-scale-1100">No tables available</p>
-                      )}
+                        {wrapper.tables ? (
+                          wrapper.tables.map((table: any) => (
+                            <Link key={table.id} href={`/project/${ref}/editor/${table.id}`}>
+                              <a>
+                                <div
+                                  key={table.id}
+                                  className="text-sm border rounded px-2 py-1 transition bg-scale-400 hover:bg-scale-500"
+                                >
+                                  {table.name}
+                                </div>
+                              </a>
+                            </Link>
+                          ))
+                        ) : (
+                          <p className="text-sm text-scale-1100">No tables available</p>
+                        )}
                       </div>
                     </div>
                   </div>

--- a/studio/components/interfaces/Database/Wrappers/WrapperRow.tsx
+++ b/studio/components/interfaces/Database/Wrappers/WrapperRow.tsx
@@ -114,7 +114,7 @@ const WrapperRow = ({
                     ))}
                     <div className="!mt-3 space-y-1">
                       <p className="text-sm text-scale-1100">
-                        Foreign tables: {wrapper.tables ? `(${wrapper.tables.length})` : ''}
+                        Foreign tables{wrapper.tables && `: (${wrapper.tables.length})`}
                       </p>
                       <div className="flex flex-wrap gap-2">
                         {wrapper.tables ? (

--- a/studio/components/interfaces/Database/Wrappers/WrapperRow.tsx
+++ b/studio/components/interfaces/Database/Wrappers/WrapperRow.tsx
@@ -113,22 +113,26 @@ const WrapperRow = ({
                       </div>
                     ))}
                     <div className="!mt-3 space-y-1">
-                      <p className="text-sm text-scale-1100">
-                        Foreign tables: ({wrapper.tables.length})
+                    <p className="text-sm text-scale-1100">
+                        Foreign tables: {wrapper.tables ? `(${wrapper.tables.length})` : ''}
                       </p>
                       <div className="flex flex-wrap gap-2">
-                        {wrapper.tables.map((table: any) => (
+                      {wrapper.tables ? (
+                        wrapper.tables.map((table: any) => (
                           <Link key={table.id} href={`/project/${ref}/editor/${table.id}`}>
                             <a>
                               <div
                                 key={table.id}
                                 className="text-sm border rounded px-2 py-1 transition bg-scale-400 hover:bg-scale-500"
                               >
-                                {table.name}
+                                {table.name} 
                               </div>
                             </a>
                           </Link>
-                        ))}
+                        ))
+                      ) : (
+                        <p className="text-sm text-scale-1100">No tables available</p>
+                      )}
                       </div>
                     </div>
                   </div>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The issue is caused by an attempt to access the 'length' property of a null value in the `WrapperRow.tsx` file at line 117 when we don't have any foreign tables available:
![image](https://github.com/supabase/supabase/assets/99693443/59ef7943-09fe-453f-8017-889d9eb6ffff)

## What is the new behavior?

![image](https://github.com/supabase/supabase/assets/99693443/cd9260f8-3325-4d6f-a416-c4768443cac1)

