### PR TITLE
docs: change Remix loader and action function types to follow latest version

### DIFF
--- a/apps/docs/pages/guides/auth/auth-helpers/remix.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/remix.mdx
@@ -89,9 +89,9 @@ import { redirect } from '@remix-run/node'
 import { createServerClient } from '@supabase/auth-helpers-remix'
 
 import type { Database } from 'db_types'
-import type { LoaderArgs } from '@remix-run/node'
+import type { LoaderFunctionArgs } from '@remix-run/node'
 
-export const loader = async ({ request }: LoaderArgs) => {
+export const loader = async ({ request }: LoaderFunctionArgs) => {
   const response = new Response()
   const url = new URL(request.url)
   const code = url.searchParams.get('code')
@@ -170,9 +170,9 @@ export const loader = async ({ request }) => {
 import { json } from '@remix-run/node' // change this import to whatever runtime you are using
 import { createServerClient } from '@supabase/auth-helpers-remix'
 
-import type { LoaderArgs } from '@remix-run/node' // change this import to whatever runtime you are using
+import type { LoaderFunctionArgs } from '@remix-run/node' // change this import to whatever runtime you are using
 
-export const loader = async ({ request }: LoaderArgs) => {
+export const loader = async ({ request }: LoaderFunctionArgs) => {
   const response = new Response()
   const supabaseClient = createServerClient(
     process.env.SUPABASE_URL!,
@@ -242,9 +242,9 @@ export const action = async ({ request }) => {
 import { json } from '@remix-run/node' // change this import to whatever runtime you are using
 import { createServerClient } from '@supabase/auth-helpers-remix'
 
-import type { ActionArgs } from '@remix-run/node' // change this import to whatever runtime you are using
+import type { ActionFunctionArgs } from '@remix-run/node' // change this import to whatever runtime you are using
 
-export const action = async ({ request }: ActionArgs) => {
+export const action = async ({ request }: ActionFunctionArgs) => {
   const response = new Response()
 
   const supabaseClient = createServerClient(
@@ -345,7 +345,7 @@ And then we can share this instance across our application with Outlet Context.
 <TabPanel id="ts" label="TypeScript">
 
 ```tsx app/root.tsx
-export const loader = ({}: LoaderArgs) => {
+export const loader = ({}: LoaderFunctionArgs) => {
   const env = {
     SUPABASE_URL: process.env.SUPABASE_URL!,
     SUPABASE_ANON_KEY: process.env.SUPABASE_ANON_KEY!,
@@ -435,7 +435,7 @@ export const loader = async ({ request }) => {
 <TabPanel id="ts" label="TypeScript">
 
 ```tsx app/root.tsx
-export const loader = async ({ request }: LoaderArgs) => {
+export const loader = async ({ request }: LoaderFunctionArgs) => {
   const env = {
     SUPABASE_URL: process.env.SUPABASE_URL!,
     SUPABASE_ANON_KEY: process.env.SUPABASE_ANON_KEY!,
@@ -701,9 +701,9 @@ import type { Database } from 'db_types'
 
 type Post = Database['public']['Tables']['posts']['Row']
 
-import type { LoaderArgs } from '@remix-run/node'
+import type { LoaderFunctionArgs } from '@remix-run/node'
 
-export const loader = async ({ request }: LoaderArgs) => {
+export const loader = async ({ request }: LoaderFunctionArgs) => {
   const response = new Response()
   const supabase = createServerClient<Database>(
     process.env.SUPABASE_URL!,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Changing all references from **LoaderArgs** and **ActionArgs** to **LoaderFunctionArgs** and **ActionFunctionArgs** in the docs for the remix supabase auth helpers since these are the correct types in Remix V2
