### PR TITLE
Added set duration to some toasts

### DIFF
--- a/studio/components/grid/components/header/Header.tsx
+++ b/studio/components/grid/components/header/Header.tsx
@@ -366,6 +366,7 @@ const RowHeader = ({ table, sorts, filters }: RowHeaderProps) => {
       ui.setNotification({
         category: 'error',
         message: `Sorry! We're unable to support exporting of CSV for row counts larger than ${MAX_EXPORT_ROW_COUNT.toLocaleString()} at the moment.`,
+        duration: 4000
       })
       return setIsExporting(false)
     }

--- a/studio/components/interfaces/Account/TOTPFactors/AddNewFactorModal.tsx
+++ b/studio/components/interfaces/Account/TOTPFactors/AddNewFactorModal.tsx
@@ -126,6 +126,7 @@ const SecondStep = ({
       ui.setNotification({
         category: 'error',
         message: `Failed to add a second factor authentication:  ${error?.message}`,
+        duration: 4000
       })
     },
     onSuccess: () => {

--- a/studio/components/interfaces/App/CommandMenuWrapper.tsx
+++ b/studio/components/interfaces/App/CommandMenuWrapper.tsx
@@ -92,6 +92,7 @@ const CommandMenuWrapper = ({ children }: PropsWithChildren<{}>) => {
       ui.setNotification({
         category: 'error',
         message: `Failed to create new query: ${error.message}`,
+        duration: 4000
       })
     }
   }

--- a/studio/components/interfaces/Auth/Policies/Policies.tsx
+++ b/studio/components/interfaces/Auth/Policies/Policies.tsx
@@ -75,6 +75,7 @@ const Policies = ({ tables, hasTables, isLocked }: PoliciesProps) => {
       ui.setNotification({
         category: 'error',
         message: `Failed to toggle RLS: ${res.error.message}`,
+        duration: 4000
       })
     }
     closeConfirmModal()
@@ -86,6 +87,7 @@ const Policies = ({ tables, hasTables, isLocked }: PoliciesProps) => {
       ui.setNotification({
         category: 'error',
         message: `Error adding policy: ${res.error.message}`,
+        duration: 4000
       })
       return true
     }
@@ -98,6 +100,7 @@ const Policies = ({ tables, hasTables, isLocked }: PoliciesProps) => {
       ui.setNotification({
         category: 'error',
         message: `Error updating policy: ${res.error.message}`,
+        duration: 4000
       })
       return true
     }
@@ -110,6 +113,7 @@ const Policies = ({ tables, hasTables, isLocked }: PoliciesProps) => {
       ui.setNotification({
         category: 'error',
         message: `Error deleting policy: ${res.error.message}`,
+        duration: 4000
       })
     } else {
       ui.setNotification({ category: 'success', message: 'Successfully deleted policy!' })

--- a/studio/components/interfaces/Auth/Users/CreateUserModal.tsx
+++ b/studio/components/interfaces/Auth/Users/CreateUserModal.tsx
@@ -57,6 +57,7 @@ const CreateUserModal = ({ visible, setVisible }: CreateUserModalProps) => {
       return ui.setNotification({
         category: 'error',
         message: `Failed to create user: Error loading project config`,
+        duration: 4000
       })
     }
 

--- a/studio/components/interfaces/BillingV2/AddNewPaymentMethodModal/AddNewPaymentMethodModal.tsx
+++ b/studio/components/interfaces/BillingV2/AddNewPaymentMethodModal/AddNewPaymentMethodModal.tsx
@@ -44,6 +44,7 @@ const AddNewPaymentMethodModal = ({
         category: 'error',
         error: intent.error,
         message: `Failed to setup intent: ${error.message}`,
+        duration: 4000
       })
     },
   })

--- a/studio/components/interfaces/BillingV2/AddNewPaymentMethodModal/AddPaymentMethodForm.tsx
+++ b/studio/components/interfaces/BillingV2/AddNewPaymentMethodModal/AddPaymentMethodForm.tsx
@@ -47,6 +47,7 @@ const AddPaymentMethodForm = ({ returnUrl, onCancel, onConfirm }: AddPaymentMeth
       ui.setNotification({
         category: 'error',
         message: error?.message ?? ' Failed to save card details',
+        duration: 4000
       })
     } else {
       setIsSaving(false)

--- a/studio/components/interfaces/BillingV2/Subscription/Tier/ExitSurveyModal.tsx
+++ b/studio/components/interfaces/BillingV2/Subscription/Tier/ExitSurveyModal.tsx
@@ -69,6 +69,7 @@ const ExitSurveyModal = ({ visible, onClose }: ExitSurveyModalProps) => {
       return ui.setNotification({
         category: 'error',
         message: 'Please select at least one reason for canceling your subscription',
+        duration: 4000
       })
     }
 

--- a/studio/components/interfaces/Database/Functions/CreateFunction.tsx
+++ b/studio/components/interfaces/Database/Functions/CreateFunction.tsx
@@ -353,6 +353,7 @@ const CreateFunction = ({ func, visible, setVisible }: CreateFunctionProps) => {
       ui.setNotification({
         category: 'error',
         message: `Failed to create function: ${error.message}`,
+        duration: 4000
       })
       _localState.setLoading(false)
     }

--- a/studio/components/interfaces/Database/Functions/DeleteFunction.tsx
+++ b/studio/components/interfaces/Database/Functions/DeleteFunction.tsx
@@ -36,6 +36,7 @@ const DeleteFunction = ({ func, visible, setVisible }: DeleteFunctionProps) => {
       ui.setNotification({
         category: 'error',
         message: `Failed to delete ${name}: ${error.message}`,
+        duration: 4000
       })
     } finally {
       setLoading(false)

--- a/studio/components/interfaces/Database/Publications/PublicationsTableItem.tsx
+++ b/studio/components/interfaces/Database/Publications/PublicationsTableItem.tsx
@@ -54,6 +54,7 @@ const PublicationsTableItem = ({ table, selectedPublication }: PublicationsTable
       ui.setNotification({
         category: 'error',
         message: `Failed to toggle replication for ${table.name}: ${error.message}`,
+        duration: 4000
       })
       setChecked(originalChecked)
       setLoading(false)

--- a/studio/components/interfaces/Database/Roles/CreateRolePanel.tsx
+++ b/studio/components/interfaces/Database/Roles/CreateRolePanel.tsx
@@ -42,11 +42,13 @@ const CreateRolePanel = ({ visible, onClose }: CreateRolePanelProps) => {
       return ui.setNotification({
         category: 'error',
         message: `Failed to create role: ${res.error.message}`,
+        duration: 4000
       })
     } else {
       ui.setNotification({
         category: 'success',
         message: `Successfully created new role: ${res.name}`,
+        duration: 4000
       })
       onClose()
     }

--- a/studio/components/interfaces/Database/Roles/DeleteRoleModal.tsx
+++ b/studio/components/interfaces/Database/Roles/DeleteRoleModal.tsx
@@ -24,11 +24,13 @@ const DeleteRoleModal = ({ role, visible, onClose }: DeleteRoleModalProps) => {
       return ui.setNotification({
         category: 'error',
         message: `Failed to delete role: ${res.error.message}`,
+        duration: 4000
       })
     } else {
       ui.setNotification({
         category: 'success',
         message: `Successfully deleted role: "${role.name}"`,
+        duration: 4000
       })
       onClose()
     }

--- a/studio/components/interfaces/Database/Roles/RoleRow.tsx
+++ b/studio/components/interfaces/Database/Roles/RoleRow.tsx
@@ -45,11 +45,13 @@ const RoleRow = ({ role, disabled = false, onSelectDelete }: RoleRowProps) => {
       ui.setNotification({
         category: 'error',
         message: `Failed to update role "${role.name}": ${res.error.message}`,
+        duration: 4000
       })
     } else {
       ui.setNotification({
         category: 'success',
         message: `Successfully updated role "${role.name}"`,
+        duration: 4000
       })
       resetForm({ values: { ...values }, initialValues: { ...values } })
     }

--- a/studio/components/interfaces/Database/Triggers/CreateTrigger.tsx
+++ b/studio/components/interfaces/Database/Triggers/CreateTrigger.tsx
@@ -330,6 +330,7 @@ const CreateTrigger = ({ trigger, visible, setVisible }: CreateTriggerProps) => 
       ui.setNotification({
         category: 'error',
         message: `Filed to create trigger: ${error.message}`,
+        duration: 4000
       })
       _localState.setLoading(false)
     }

--- a/studio/components/interfaces/Database/Triggers/DeleteTrigger.tsx
+++ b/studio/components/interfaces/Database/Triggers/DeleteTrigger.tsx
@@ -33,6 +33,7 @@ const DeleteTrigger = ({ trigger, visible, setVisible }: DeleteTriggerProps) => 
       ui.setNotification({
         category: 'error',
         message: `Failed to delete ${name}: ${error.message}`,
+        duration: 4000
       })
     } finally {
       setLoading(false)

--- a/studio/components/interfaces/Organization/BillingSettings/BillingEmail.tsx
+++ b/studio/components/interfaces/Organization/BillingSettings/BillingEmail.tsx
@@ -34,6 +34,7 @@ const BillingEmail = () => {
       return ui.setNotification({
         category: 'error',
         message: 'You do not have the required permissions to update this organization',
+        duration: 4000
       })
     }
 

--- a/studio/components/interfaces/Organization/BillingSettings/ProjectsSummary.tsx
+++ b/studio/components/interfaces/Organization/BillingSettings/ProjectsSummary.tsx
@@ -27,6 +27,7 @@ const ProjectSummary = ({ project }: ProjectSummaryProps) => {
       ui.setNotification({
         category: 'error',
         message: `Failed to get project subscription: ${(error as any)?.message ?? 'unknown'}`,
+        duration: 4000
       })
     }
   }, [error])

--- a/studio/components/interfaces/Organization/BillingSettingsV2/BillingEmail.tsx
+++ b/studio/components/interfaces/Organization/BillingSettingsV2/BillingEmail.tsx
@@ -33,6 +33,7 @@ const BillingEmail = () => {
       return ui.setNotification({
         category: 'error',
         message: 'You do not have the required permissions to update this organization',
+        duration: 4000
       })
     }
     if (!slug) return console.error('Slug is required')

--- a/studio/components/interfaces/Organization/BillingSettingsV2/Subscription/ExitSurveyModal.tsx
+++ b/studio/components/interfaces/Organization/BillingSettingsV2/Subscription/ExitSurveyModal.tsx
@@ -65,6 +65,7 @@ const ExitSurveyModal = ({ visible, subscription, onClose }: ExitSurveyModalProp
       return ui.setNotification({
         category: 'error',
         message: 'Please select at least one reason for canceling your subscription',
+        duration: 4000
       })
     }
 

--- a/studio/components/interfaces/Organization/GeneralSettings/DeleteOrganizationButton.tsx
+++ b/studio/components/interfaces/Organization/GeneralSettings/DeleteOrganizationButton.tsx
@@ -35,6 +35,7 @@ const DeleteOrganizationButton = () => {
       return ui.setNotification({
         category: 'error',
         message: 'You do not have the required permissions to delete this organization',
+        duration: 4000
       })
     }
     if (!orgSlug) return console.error('Org slug is required')

--- a/studio/components/interfaces/Organization/GeneralSettings/GeneralSettings.tsx
+++ b/studio/components/interfaces/Organization/GeneralSettings/GeneralSettings.tsx
@@ -43,6 +43,7 @@ const GeneralSettings = () => {
       return ui.setNotification({
         category: 'error',
         message: 'You do not have the required permissions to update this organization',
+        duration: 4000
       })
     }
 

--- a/studio/components/interfaces/Organization/GeneralSettings/MigrateOrganizationBillingButton.tsx
+++ b/studio/components/interfaces/Organization/GeneralSettings/MigrateOrganizationBillingButton.tsx
@@ -120,6 +120,7 @@ const MigrateOrganizationBillingButton = observer(() => {
       return ui.setNotification({
         category: 'error',
         message: 'You do not have the required permissions to migrate this organization',
+        duration: 4000
       })
     }
     migrateBilling({ organizationSlug: organization?.slug, tier: dbTier, paymentMethodId })

--- a/studio/components/interfaces/Organization/TeamSettings/MemberActions.tsx
+++ b/studio/components/interfaces/Organization/TeamSettings/MemberActions.tsx
@@ -63,6 +63,7 @@ const MemberActions = ({ member, roles }: MemberActionsProps) => {
       ui.setNotification({
         category: 'error',
         message: `Failed to resend invitation: ${error.message}`,
+        duration: 4000
       })
     },
   })

--- a/studio/components/interfaces/Organization/TeamSettings/MembersView.tsx
+++ b/studio/components/interfaces/Organization/TeamSettings/MembersView.tsx
@@ -63,6 +63,7 @@ const MembersView = ({ searchString }: MembersViewProps) => {
         message: `Failed to update role for ${getUserDisplayName(selectedMember)}: ${
           error.message
         }`,
+        duration: 4000
       })
     },
   })

--- a/studio/components/interfaces/Organization/TeamSettings/TeamSettings.tsx
+++ b/studio/components/interfaces/Organization/TeamSettings/TeamSettings.tsx
@@ -71,6 +71,7 @@ const TeamSettings = () => {
       ui.setNotification({
         category: 'error',
         message: `Failed to leave organization: ${error?.message}`,
+        duration: 4000
       })
     } finally {
       setIsLeaving(false)

--- a/studio/components/interfaces/SQLEditor/SQLTemplates/SQLQuickstarts.tsx
+++ b/studio/components/interfaces/SQLEditor/SQLTemplates/SQLQuickstarts.tsx
@@ -53,6 +53,7 @@ const SQLQuickstarts = observer(() => {
       ui.setNotification({
         category: 'error',
         message: `Failed to create new query: ${error.message}`,
+        duration: 4000
       })
     }
   }

--- a/studio/components/interfaces/SQLEditor/SQLTemplates/SQLTemplates.tsx
+++ b/studio/components/interfaces/SQLEditor/SQLTemplates/SQLTemplates.tsx
@@ -55,6 +55,7 @@ const SQLTemplates = observer(() => {
       ui.setNotification({
         category: 'error',
         message: `Failed to create new query: ${error.message}`,
+        duration: 4000
       })
     }
   }

--- a/studio/components/interfaces/Settings/General/Infrastructure/RestartServerButton.tsx
+++ b/studio/components/interfaces/Settings/General/Infrastructure/RestartServerButton.tsx
@@ -54,6 +54,7 @@ const RestartServerButton = () => {
       return ui.setNotification({
         category: 'error',
         message: 'You do not have the required permissions to restart this project',
+        duration: 4000
       })
     }
     restartProject({ ref: projectRef })
@@ -64,6 +65,7 @@ const RestartServerButton = () => {
       return ui.setNotification({
         category: 'error',
         message: 'You do not have the required permissions to restart this project',
+        duration: 4000
       })
     }
     restartProjectServices({ ref: projectRef, region: projectRegion, services: ['postgresql'] })

--- a/studio/components/interfaces/SignIn/ForgotPasswordForm.tsx
+++ b/studio/components/interfaces/SignIn/ForgotPasswordForm.tsx
@@ -34,6 +34,7 @@ const ForgotPasswordForm = () => {
       ui.setNotification({
         category: 'error',
         message: `Failed to send reset email: ${error.message}`,
+        duration: 4000
       })
     },
   })

--- a/studio/components/interfaces/SignIn/SignUpForm.tsx
+++ b/studio/components/interfaces/SignIn/SignUpForm.tsx
@@ -36,6 +36,7 @@ const SignUpForm = () => {
       ui.setNotification({
         category: 'error',
         message: `Failed to sign up: ${error.message}`,
+        duration: 4000
       })
     },
   })

--- a/studio/components/interfaces/TableGridEditor/DeleteConfirmationDialogs.tsx
+++ b/studio/components/interfaces/TableGridEditor/DeleteConfirmationDialogs.tsx
@@ -98,6 +98,7 @@ const DeleteConfirmationDialogs = ({
       ui.setNotification({
         category: 'error',
         message: `Failed to delete ${selectedColumnToDelete!.name}: ${error.message}`,
+        duration: 4000
       })
     } finally {
       snap.closeConfirmationDialog()

--- a/studio/components/interfaces/TableGridEditor/GridHeaderActions.tsx
+++ b/studio/components/interfaces/TableGridEditor/GridHeaderActions.tsx
@@ -110,6 +110,7 @@ const GridHeaderActions = ({
       ui.setNotification({
         category: 'error',
         message: `Failed to toggle realtime for ${table.name}: ${error.message}`,
+        duration: 4000
       })
     } finally {
       setIsTogglingRealtime(false)

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadsheetImport.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadsheetImport.tsx
@@ -147,18 +147,21 @@ const SpreadsheetImport = ({
       ui.setNotification({
         category: 'error',
         message: 'Please upload a file to import your data with',
+        duration: 4000
       })
       resolve()
     } else if (selectedHeaders.length === 0) {
       ui.setNotification({
         category: 'error',
         message: 'Please select at least one header from your CSV',
+        duration: 4000
       })
       resolve()
     } else if (!isCompatible) {
       ui.setNotification({
         category: 'error',
         message: 'The data that you are trying to import is incompatible with your table structure',
+        duration: 4000
       })
       resolve()
     } else {

--- a/studio/components/interfaces/TableGridEditor/TableGridEditor.tsx
+++ b/studio/components/interfaces/TableGridEditor/TableGridEditor.tsx
@@ -246,6 +246,7 @@ const TableGridEditor = ({
       ui.setNotification({
         category: 'error',
         message: `Unable to find column ${name} in ${selectedTable?.name}`,
+        duration: 4000
       })
     }
   }
@@ -258,6 +259,7 @@ const TableGridEditor = ({
       ui.setNotification({
         category: 'error',
         message: `Unable to find column ${name} in ${selectedTable?.name}`,
+        duration: 4000
       })
     }
   }
@@ -266,6 +268,7 @@ const TableGridEditor = ({
     ui.setNotification({
       category: 'error',
       message: error?.details ?? error?.message ?? error,
+      duration: 4000
     })
   }
 
@@ -291,6 +294,7 @@ const TableGridEditor = ({
       return ui.setNotification({
         category: 'error',
         message: ERROR_PRIMARY_KEY_NOTFOUND,
+        duration: 4000
       })
     }
 

--- a/studio/components/layouts/ProjectLayout/ProjectPausedState.tsx
+++ b/studio/components/layouts/ProjectLayout/ProjectPausedState.tsx
@@ -53,6 +53,7 @@ const ProjectPausedState = ({ product }: ProjectPausedStateProps) => {
       ui.setNotification({
         category: 'error',
         message: 'You do not have the required permissions to restore this project',
+        duration: 4000
       })
     } else if (hasMembersExceedingFreeTierLimit) setShowFreeProjectLimitWarning(true)
     else setShowConfirmRestore(true)

--- a/studio/components/layouts/SQLEditorLayout/QueryItem.tsx
+++ b/studio/components/layouts/SQLEditorLayout/QueryItem.tsx
@@ -193,6 +193,7 @@ const QueryItemActions = observer(({ tabInfo, activeId }: QueryItemActionsProps)
       ui.setNotification({
         category: 'error',
         message: `Failed to create a personal copy of this query: ${error.message}`,
+        duration: 4000
       })
     }
   }

--- a/studio/components/layouts/SQLEditorLayout/SQLEditorMenu.tsx
+++ b/studio/components/layouts/SQLEditorLayout/SQLEditorMenu.tsx
@@ -118,6 +118,7 @@ const SideBarContent = observer(() => {
       ui.setNotification({
         category: 'error',
         message: `Failed to create new query: ${error.message}`,
+        duration: 4000
       })
     }
   }

--- a/studio/components/layouts/StorageLayout/StorageLayout.tsx
+++ b/studio/components/layouts/StorageLayout/StorageLayout.tsx
@@ -43,6 +43,7 @@ const StorageLayout = ({ title, children }: StorageLayoutProps) => {
         category: 'error',
         message:
           'Failed to fetch project configuration. Try refreshing your browser, or reach out to us at support@supabase.io',
+        duration: 4000,
       })
     }
     storageExplorerStore.setLoaded(true)

--- a/studio/components/to-be-cleaned/Storage/StoragePolicies/StoragePolicies.js
+++ b/studio/components/to-be-cleaned/Storage/StoragePolicies/StoragePolicies.js
@@ -116,6 +116,7 @@ const StoragePolicies = () => {
       ui.setNotification({
         category: 'error',
         message: `Error adding policy: ${res.error.message}`,
+        duration: 4000
       })
       return true
     }
@@ -128,6 +129,7 @@ const StoragePolicies = () => {
       ui.setNotification({
         category: 'error',
         message: `Error updating policy: ${res.error.message}`,
+        duration: 4000
       })
       return true
     }
@@ -140,6 +142,7 @@ const StoragePolicies = () => {
       ui.setNotification({
         category: 'error',
         message: `Failed to delete policy: ${res.error.message}`,
+        duration: 4000
       })
     } else {
       ui.setNotification({ category: 'success', message: 'Successfully deleted policy!' })

--- a/studio/components/to-be-cleaned/Storage/StorageSettings/StorageSettings.tsx
+++ b/studio/components/to-be-cleaned/Storage/StorageSettings/StorageSettings.tsx
@@ -87,6 +87,7 @@ const StorageConfig = ({ config, projectRef }: any) => {
       return ui.setNotification({
         category: 'error',
         message: `Upload file size limit must be up to 5GB (${formattedMaxSizeBytes})`,
+        duration: 4000
       })
     }
 

--- a/studio/lib/profile.tsx
+++ b/studio/lib/profile.tsx
@@ -45,6 +45,7 @@ export const ProfileProvider = ({ children }: PropsWithChildren<{}>) => {
       ui.setNotification({
         category: 'error',
         message: 'Failed to create your profile. Please refresh to try again.',
+        duration: 4000
       })
     },
   })

--- a/studio/pages/authorize.tsx
+++ b/studio/pages/authorize.tsx
@@ -53,12 +53,14 @@ const APIAuthorizationPage: NextPageWithLayout = () => {
       return ui.setNotification({
         category: 'error',
         message: 'Unable to approve request: auth_id is missing ',
+        duration: 4000
       })
     }
     if (!selectedOrg) {
       return ui.setNotification({
         category: 'error',
         message: 'Unable to approve request: No organization selected',
+        duration: 4000
       })
     }
 
@@ -70,6 +72,7 @@ const APIAuthorizationPage: NextPageWithLayout = () => {
       return ui.setNotification({
         category: 'error',
         message: 'Unable to decline request: auth_id is missing ',
+        duration: 4000
       })
 
     declineRequest({ id: auth_id })

--- a/studio/pages/integrations/vercel/install.tsx
+++ b/studio/pages/integrations/vercel/install.tsx
@@ -141,6 +141,7 @@ const VercelIntegration: NextPageWithLayout = () => {
       return ui.setNotification({
         category: 'error',
         message: 'Vercel Configuration source missing',
+        duration: 4000
       })
     }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR resolves https://github.com/supabase/supabase/issues/17687

## What is the current behavior?

Currently, majority of the toasts that appear to do not have a set duration, so they appear on the screen until a user dismisses them, a different page is navigated to etc.

## What is the new behavior?

I added durations of 4s to some of the error toasts.

## Additional context

Could a member of the supabase team please advise if this is something they would like? I can continue and set timeouts for the remainder of the toasts as well.
