### PR TITLE
Added redirect from /documentation to /docs

### DIFF
--- a/apps/www/lib/redirects.js
+++ b/apps/www/lib/redirects.js
@@ -2298,4 +2298,9 @@ module.exports = [
     source: '/docs/guides/ai/managing-indexes',
     destination: '/docs/guides/ai/vector-indexes',
   },
+  {
+    permanent: true,
+    source: '/documentation',
+    destination: '/docs',
+  },
 ]


### PR DESCRIPTION
## What kind of change does this PR introduce?
Redirects from /documentation to /docs on the website.

## What is the current behavior?
/documentation path shows a 404 not found message

## What is the new behavior?
/documentation redirects to the documentation at /docs

## Additional context
This is my first PR for the project. I want to learn the codebase and make more useful contributions.
