### PR TITLE
fix: api reports styling

### DIFF
--- a/studio/components/interfaces/Reports/ReportWidget.tsx
+++ b/studio/components/interfaces/Reports/ReportWidget.tsx
@@ -108,10 +108,13 @@ const ReportWidget: React.FC<ReportWidgetProps> = (props) => {
         <Loading active={props.isLoading}>
           {props.data === undefined ? null : props.renderer({ ...props, router, projectRef })}
         </Loading>
-
-        {props.append &&
-          props.append({ ...props, ...(props.appendProps || {}), router, projectRef })}
       </Panel.Content>
+
+      {props.append && (
+        <div className="p-px">
+          {props.append({ ...props, ...(props.appendProps || {}), router, projectRef })}
+        </div>
+      )}
     </Panel>
   )
 }

--- a/studio/components/interfaces/Reports/ReportWidget.tsx
+++ b/studio/components/interfaces/Reports/ReportWidget.tsx
@@ -111,9 +111,9 @@ const ReportWidget: React.FC<ReportWidgetProps> = (props) => {
       </Panel.Content>
 
       {props.append && (
-        <div className="p-px">
+        <>
           {props.append({ ...props, ...(props.appendProps || {}), router, projectRef })}
-        </div>
+        </>
       )}
     </Panel>
   )

--- a/studio/components/interfaces/Reports/ReportWidget.tsx
+++ b/studio/components/interfaces/Reports/ReportWidget.tsx
@@ -111,9 +111,7 @@ const ReportWidget: React.FC<ReportWidgetProps> = (props) => {
       </Panel.Content>
 
       {props.append && (
-        <>
-          {props.append({ ...props, ...(props.appendProps || {}), router, projectRef })}
-        </>
+        <>{props.append({ ...props, ...(props.appendProps || {}), router, projectRef })}</>
       )}
     </Panel>
   )

--- a/studio/components/interfaces/Reports/Reports.constants.ts
+++ b/studio/components/interfaces/Reports/Reports.constants.ts
@@ -93,8 +93,7 @@ export const PRESET_CONFIG: Record<Presets, PresetConfig> = {
           request.path, request.method, request.search, response.status_code
         order by
           count desc
-        limit
-        3
+        limit 10
         `,
       },
       errorCounts: {
@@ -138,8 +137,7 @@ export const PRESET_CONFIG: Record<Presets, PresetConfig> = {
           request.path, request.method, request.search, response.status_code
         order by
           count desc
-        limit
-        3
+        limit 10
         `,
       },
       responseSpeed: {
@@ -181,8 +179,7 @@ export const PRESET_CONFIG: Record<Presets, PresetConfig> = {
           request.path, request.method, request.search, response.status_code
         order by
           avg desc
-        limit
-        3
+        limit 10
         `,
       },
       networkTraffic: {

--- a/studio/components/interfaces/Reports/renderers/ApiRenderers.tsx
+++ b/studio/components/interfaces/Reports/renderers/ApiRenderers.tsx
@@ -167,7 +167,7 @@ export const TopApiRoutesRenderer = (
               'transition',
               showMore ? 'text-foreground' : 'text-foreground-lighter',
               props.data.length <= 3 ? 'hidden' : '',
-            ].join(" ")}
+            ].join(' ')}
           >
             {!showMore ? 'Show more' : 'Show less'}
           </Button>

--- a/studio/components/interfaces/Reports/renderers/ApiRenderers.tsx
+++ b/studio/components/interfaces/Reports/renderers/ApiRenderers.tsx
@@ -159,7 +159,7 @@ export const TopApiRoutesRenderer = (
         }
       />
       <Collapsible.Trigger asChild>
-        <div className="flex flex-row justify-end w-full gap-2 pt-1">
+        <div className="flex flex-row justify-end w-full gap-2 p-1">
           <Button
             type="text"
             onClick={() => setShowMore(!showMore)}

--- a/studio/components/interfaces/Reports/renderers/ApiRenderers.tsx
+++ b/studio/components/interfaces/Reports/renderers/ApiRenderers.tsx
@@ -6,10 +6,12 @@ import Table from 'components/to-be-cleaned/Table'
 import BarChart from 'components/ui/Charts/BarChart'
 import useFillTimeseriesSorted from 'hooks/analytics/useFillTimeseriesSorted'
 import sumBy from 'lodash/sumBy'
-import { Fragment } from 'react'
+import { Fragment, useState } from 'react'
 import { Button, Collapsible, IconChevronRight } from 'ui'
 import { queryParamsToObject } from '../Reports.utils'
 import { ReportWidgetProps, ReportWidgetRendererProps } from '../ReportWidget'
+import Link from 'next/link'
+import { useParams } from 'common/hooks'
 
 export const NetworkTrafficRenderer = (
   props: ReportWidgetProps<{
@@ -105,42 +107,89 @@ export const TopApiRoutesRenderer = (
     avg?: number
   }>
 ) => {
+  const { ref: projectRef } = useParams()
+
+  const [showMore, setShowMore] = useState(false)
   if (props.data.length === 0) return null
   const headerClasses = '!text-xs !py-2 p-0 font-bold !bg-scale-400'
   const cellClasses = '!text-xs !py-2'
+
   return (
-    <Table
-      head={
-        <>
-          <Table.th className={headerClasses}>Request</Table.th>
-          <Table.th className={headerClasses + ' text-right'}>Count</Table.th>
-          {props.data[0].avg !== undefined && (
-            <Table.th className={headerClasses + ' text-right'}>Avg</Table.th>
-          )}
-        </>
-      }
-      body={
-        <>
-          {props.data.map((datum) => (
-            <Fragment key={datum.path + (datum.search || '')}>
-              <Table.tr className="p-0">
-                <Table.td className={[cellClasses].join(' ')}>
-                  <RouteTdContent {...datum} />
-                </Table.td>
-                <Table.td className={[cellClasses, 'text-right align-top'].join(' ')}>
-                  {datum.count}
-                </Table.td>
-                {props.data[0].avg !== undefined && (
-                  <Table.td className={[cellClasses, 'text-right align-top'].join(' ')}>
-                    {Number(datum.avg).toFixed(2)}ms
-                  </Table.td>
-                )}
-              </Table.tr>
-            </Fragment>
-          ))}
-        </>
-      }
-    />
+    <Collapsible>
+      <Table
+        head={
+          <>
+            <Table.th className={headerClasses}>Request</Table.th>
+            <Table.th className={headerClasses + ' text-right'}>Count</Table.th>
+            {props.data[0].avg !== undefined && (
+              <Table.th className={headerClasses + ' text-right'}>Avg</Table.th>
+            )}
+          </>
+        }
+        body={
+          <>
+            {props.data.map((datum, index) => (
+              <Fragment key={datum.path + (datum.search || '')}>
+                <Table.tr
+                  className={[
+                    'p-0 transition transform duration-700',
+                    showMore && index >= 3 ? 'w-full h-full opacity-100' : '',
+                    !showMore && index >= 3 ? ' w-0 h-0 translate-y-10 opacity-0' : '',
+                  ].join(' ')}
+                >
+                  {(!showMore && index < 3) || showMore ? (
+                    <>
+                      <Table.td className={[cellClasses].join(' ')}>
+                        <RouteTdContent {...datum} />
+                      </Table.td>
+                      <Table.td className={[cellClasses, 'text-right align-top'].join(' ')}>
+                        {datum.count}
+                      </Table.td>
+                      {props.data[0].avg !== undefined && (
+                        <Table.td className={[cellClasses, 'text-right align-top'].join(' ')}>
+                          {Number(datum.avg).toFixed(2)}ms
+                        </Table.td>
+                      )}
+                    </>
+                  ) : null}
+                </Table.tr>
+              </Fragment>
+            ))}
+          </>
+        }
+      />
+      <Collapsible.Trigger asChild>
+        <div className="flex flex-row justify-end w-full gap-2 pt-1">
+          <Button
+            type="text"
+            onClick={() => setShowMore(!showMore)}
+            className={[
+              'transition',
+              showMore ? 'text-foreground' : 'text-foreground-lighter',
+              props.data.length <= 3 ? 'hidden' : '',
+            ].join(" ")}
+          >
+            {!showMore ? 'Show more' : 'Show less'}
+          </Button>
+          <Button
+            type="text"
+            className="text-foreground-lighter"
+            onClick={() => {
+              props.router.push({
+                pathname: `/project/${projectRef}/logs/explorer`,
+                query: {
+                  q: props.params?.sql,
+                  its: props.params!.iso_timestamp_start,
+                  ite: props.params!.iso_timestamp_end,
+                },
+              })
+            }}
+          >
+            Open in Logs Explorer
+          </Button>
+        </div>
+      </Collapsible.Trigger>
+    </Collapsible>
   )
 }
 

--- a/studio/pages/project/[ref]/reports/api-overview.tsx
+++ b/studio/pages/project/[ref]/reports/api-overview.tsx
@@ -67,7 +67,7 @@ export const ApiReport: NextPageWithLayout = () => {
         data={report.data.totalRequests || []}
         renderer={TotalRequestsChartRenderer}
         append={TopApiRoutesRenderer}
-        appendProps={{ data: report.data.topRoutes || [] }}
+        appendProps={{ data: report.data.topRoutes || [], params: report.params.topRoutes }}
       />
       <ReportWidget
         isLoading={report.isLoading}
@@ -76,7 +76,10 @@ export const ApiReport: NextPageWithLayout = () => {
         tooltip="Error responses with 4XX or 5XX status codes"
         data={report.data.errorCounts || []}
         renderer={ErrorCountsChartRenderer}
-        appendProps={{ data: report.data.topErrorRoutes || [] }}
+        appendProps={{
+          data: report.data.topErrorRoutes || [],
+          params: report.params.topErrorRoutes,
+        }}
         append={TopApiRoutesRenderer}
       />
       <ReportWidget
@@ -86,7 +89,7 @@ export const ApiReport: NextPageWithLayout = () => {
         tooltip="Average response speed (in miliseconds) of a request"
         data={report.data.responseSpeed || []}
         renderer={ResponseSpeedChartRenderer}
-        appendProps={{ data: report.data.topSlowRoutes || [] }}
+        appendProps={{ data: report.data.topSlowRoutes || [], params: report.params.topSlowRoutes }}
         append={TopApiRoutesRenderer}
       />
 


### PR DESCRIPTION
This PR adds in the following changes:
- reduced x,b padding for routes tables
- add collapsible toggle
- add "Open in Logs Explorer" button

https://github.com/supabase/supabase/assets/22714384/9ea49cbe-e216-4c9c-91d2-d33250b7cf9d

