### PR TITLE
Add security compliance section

### DIFF
--- a/apps/www/components/Footer/index.tsx
+++ b/apps/www/components/Footer/index.tsx
@@ -2,13 +2,14 @@ import FooterLinks from 'data/Footer.json'
 import SectionContainer from '../Layouts/SectionContainer'
 import Link from 'next/link'
 import { useTheme } from 'next-themes'
-import { Badge } from 'ui'
+import { Badge, IconChevronRight, TextLink } from 'ui'
 import Image from 'next/image'
 import * as supabaseLogoWordmarkDark from 'common/assets/images/supabase-logo-wordmark--dark.png'
 import * as supabaseLogoWordmarkLight from 'common/assets/images/supabase-logo-wordmark--light.png'
 import { useRouter } from 'next/router'
 import { Fragment } from 'react'
 import ThemeToggle from '@ui/components/ThemeProvider/ThemeToggle'
+import { CheckIcon } from '@heroicons/react/outline'
 
 interface Props {
   className?: string
@@ -28,6 +29,27 @@ const Footer = (props: Props) => {
       <h2 id="footerHeading" className="sr-only">
         Footer
       </h2>
+      <div className="w-full !py-0 border-b">
+        <SectionContainer className="grid grid-cols-2 md:flex items-center justify-between md:justify-center gap-8 md:gap-10 !py-6 md:!py-10 text-sm">
+          <div className="flex flex-col md:flex-row gap-2 md:items-center">
+            We protect your data.
+            <Link href="/security">
+              <a className="text-brand hover:underline">More on Security</a>
+            </Link>
+          </div>
+          <span className="hidden md:block h-px w-8 bg-border" />
+          <ul className="flex flex-col md:flex-row gap-2 md:gap-8 justify-center md:items-center">
+            <li className="flex items-center gap-2">
+              <CheckIcon className="w-4 h-4" /> SOC2 Type 2{' '}
+              <span className="text-lighter">Certified</span>
+            </li>
+            <li className="flex items-center gap-2">
+              <CheckIcon className="w-4 h-4" /> HIPAA{' '}
+              <span className="text-lighter">Compliant</span>
+            </li>
+          </ul>
+        </SectionContainer>
+      </div>
       <SectionContainer>
         <div className="xl:grid xl:grid-cols-3 xl:gap-8">
           <div className="space-y-8 xl:col-span-1">


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add security compliance section before footer.

## What is the new behavior?

<img width="1374" alt="Screenshot 2023-09-27 at 10 03 31" src="https://github.com/supabase/supabase/assets/25671831/57ed1e74-d9d3-4b70-ba11-f492370cad25">
<img width="1647" alt="Screenshot 2023-09-27 at 10 04 50" src="https://github.com/supabase/supabase/assets/25671831/1704cb85-ed68-405e-ae4e-ddee4c52af5d">

<img width="497" alt="Screenshot 2023-09-27 at 10 03 39" src="https://github.com/supabase/supabase/assets/25671831/66c8551d-3844-4f31-ab59-7123fd35e92c">
<img width="496" alt="Screenshot 2023-09-27 at 10 04 55" src="https://github.com/supabase/supabase/assets/25671831/4cae16ed-2f8c-4196-9374-7c199bffe3d8">

