### PR TITLE
chore: adjust redirect after org deletion

### DIFF
--- a/studio/components/interfaces/Organization/GeneralSettings/DeleteOrganizationButton.tsx
+++ b/studio/components/interfaces/Organization/GeneralSettings/DeleteOrganizationButton.tsx
@@ -46,7 +46,7 @@ const DeleteOrganizationButton = () => {
         category: 'success',
         message: `Successfully deleted ${orgName}`,
       })
-      router.push('/')
+      router.push('/projects')
     }
   }
 


### PR DESCRIPTION
Redirecting to "/" causes the login screen to show up for a second before redirecting away. We can instead redirect to "/projects"