### PR TITLE
Fix conversion to NULL when importing CSV files

### DIFF
--- a/studio/stores/pgmeta/MetaStore.ts
+++ b/studio/stores/pgmeta/MetaStore.ts
@@ -15,8 +15,8 @@ import { API_URL, IS_PLATFORM } from 'lib/constants'
 import { timeout, tryParseJson } from 'lib/helpers'
 import { ResponseError } from 'types'
 
-import { IRootStore } from '../RootStore'
 import { IPostgresMetaInterface } from '../common/PostgresMetaInterface'
+import { IRootStore } from '../RootStore'
 import ColumnStore from './ColumnStore'
 import OpenApiStore, { IOpenApiStore } from './OpenApiStore'
 import TableStore, { ITableStore } from './TableStore'
@@ -904,6 +904,9 @@ export default class MetaStore implements IMetaStore {
                 (column?.format ?? '').includes('json')
               ) {
                 formattedRow[header] = tryParseJson(row[header])
+              } else if (row[header] === '') {
+                // if the cell is empty string, convert it to NULL
+                formattedRow[header] = null
               } else {
                 formattedRow[header] = row[header]
               }


### PR DESCRIPTION
When importing CSV, if a cell has empty string for a value, convert it to NULL value. This was the default behavior before, but it was changed when we set `dynamicTyping` to false. We set the flag to false because it was causing `0005` to be interpreted as `5`.

To test this:
1. add a new table
2. have some rows with NULL values in some cells
3. download it as CSV
4. change the unique ids of the rows so that you don't get id collision
5. try to upload it

It should be uploaded without an issue.