### PR TITLE
fix: wrong link

### DIFF
--- a/apps/www/_blog/2023-08-04-interactive-constellation-threejs-react-three-fiber.mdx
+++ b/apps/www/_blog/2023-08-04-interactive-constellation-threejs-react-three-fiber.mdx
@@ -39,7 +39,7 @@ If you want to dive a little deeper, here are a few good resources we found to g
     target="_blank"
     children="I wish I knew this before using React Three Fiber"
   /> - from our very own <Link href="https://twitter.com/ggrdson" target="_blank" children="Greg" />
-- <Link href="https://Ts-journey.com/" target="_blank" children="ThreeJs Journey" /> - by <Link
+- <Link href="https://threejs-journey.com/" target="_blank" children="Three.js Journey" /> - by <Link
     href="https://bruno-simon.com/"
     target="_blank"
     children="Bruno Simon"


### PR DESCRIPTION
## What kind of change does this PR introduce?

fix wrong link of three.js journey

## What is the current behavior?

wrong link

## What is the new behavior?

correct link of [three.js journey](https://threejs-journey.com/)

## Additional context

Add any other context or screenshots.
