### PR TITLE
Add disabled cursor style

### DIFF
--- a/packages/ui/src/components/ThemeProvider/ThemeToggle.tsx
+++ b/packages/ui/src/components/ThemeProvider/ThemeToggle.tsx
@@ -27,7 +27,7 @@ const ThemeToggle = ({ forceDark = false }: ThemeToggleProps) => {
       <DropdownMenuTrigger_Shadcn_ asChild disabled={forceDark}>
         <button
           id="user-settings-dropdown"
-          className="flex items-center justify-center h-7 w-7 text"
+          className={`${forceDark ? "cursor-not-allowed":"cursor-pointer" } flex items-center justify-center h-7 w-7 text`}
         >
           <IconSun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
           <IconMoon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />


### PR DESCRIPTION
Add cursor: not-allowed style to the theme toggle when it's disabled on the home and launch week pages

![image](https://github.com/supabase/supabase/assets/20722868/5a1c6c36-4acb-475b-8e99-02cf6fbd8481)

