### PR TITLE
Update image-search-openai-clip.mdx to fix syntax error 

### DIFF
--- a/apps/docs/pages/guides/ai/examples/image-search-openai-clip.mdx
+++ b/apps/docs/pages/guides/ai/examples/image-search-openai-clip.mdx
@@ -97,7 +97,7 @@ def seed():
 
     # add records to the *images* collection
     images.upsert(
-        vectors=[
+        records=[
             (
                 "one.jpg",        # the vector's identifier
                 img_emb1,          # the vector. list or np.array


### PR DESCRIPTION

## What kind of change does this PR introduce?

# Doc update

The docs used .upsert(vectors=[]) instead of of .upsert(records=[])

## What is the current behavior?

When using vectors in .upsert instead of records you get: "TypeError: Collection.upsert() got an unexpected keyword argument 'vectors'"

## What is the new behavior?

.upsert works as expected and add records in vector db.

