### PR TITLE
fix: Set the default value for boolean fields when creating a new row

### DIFF
--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.utils.ts
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.utils.ts
@@ -25,7 +25,7 @@ export const generateRowFields = (
       isUndefined(row) && TEXT_TYPES.includes(column.format)
         ? null
         : isUndefined(row) && column.format === 'bool' && !column.is_nullable
-        ? 'true'
+        ? column.default_value
         : isUndefined(row) && column.format === 'bool' && column.is_nullable
         ? 'null'
         : isUndefined(row)

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.utils.ts
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.utils.ts
@@ -188,7 +188,17 @@ export const generateRowObjectFromFields = (
       rowObject[field.name] = value
     }
   })
-  return includeNullProperties ? rowObject : omitBy(rowObject, isNull)
+  if (includeNullProperties) {
+    return rowObject
+  } else {
+    return omitBy(rowObject, (v, k) => {
+      const field = fields.find((f) => f.name === k)
+      if (field && field.isNullable) {
+        return false
+      }
+      return isNull(v)
+    })
+  }
 }
 
 export const generateUpdateRowPayload = (originalRow: any, field: RowField[]) => {


### PR DESCRIPTION
This PR fixes two issues:
- The `default_value` for non-null booleans was ignored when inserting a new row via the side panel editor. It always defaulted to `true` even though it can also be `false` or `null`. To replicate this bug on production:
  1. Add a new table with non-null boolean field, with default set to `false`
  2. Try to insert new row
  3. See that the value is set to `true` instead of `false` (fixed in this PR)

- When inserting a new row, if a field has a default value, but then you delete that value and make it `null`, the `null` is not respected and the field is set to the default value when you save the new row. To replicate this bug on production:
  1. Add a new table with nullable boolean field, with default set to `false`
  2. Try to insert new row
  3. Set the value to `null`
  4. Save the new row
  5. See in the table that the new row has `false` value instead of `null` (fixed in this PR)

