### PR TITLE
Chore/nudge project cards

### DIFF
--- a/studio/components/interfaces/Home/ProjectList/ProjectCard.tsx
+++ b/studio/components/interfaces/Home/ProjectList/ProjectCard.tsx
@@ -36,10 +36,10 @@ const ProjectCard = ({
     <li className="col-span-1 list-none">
       <CardButton
         linkHref={rewriteHref ? rewriteHref : `/project/${projectRef}`}
-        className="h-44 !px-0 group"
+        className="h-44 !px-0 group pt-6 pb-0"
         title={
-          <div className="w-full justify-between space-y-1.5 px-6">
-            <p className="flex-shrink truncate text-base">{name}</p>
+          <div className="w-full justify-between space-y-1.5 px-4">
+            <p className="flex-shrink truncate text-sm">{name}</p>
             <span className="text-sm lowercase text-foreground-light">{desc}</span>
             <div className="flex items-center space-x-1.5">
               {isVercelIntegrated && (
@@ -68,7 +68,7 @@ const ProjectCard = ({
           </div>
         }
         footer={
-          <div className="mb-[-26px]">
+          <div className="mb-[-10px]">
             <ProjectCardStatus projectStatus={projectStatus} resourceWarnings={resourceWarnings} />
           </div>
         }

--- a/studio/components/interfaces/Home/ProjectList/ProjectCardStatus.tsx
+++ b/studio/components/interfaces/Home/ProjectList/ProjectCardStatus.tsx
@@ -2,14 +2,16 @@ import { RESOURCE_WARNING_MESSAGES } from 'components/ui/ResourceExhaustionWarni
 import { ResourceWarning } from 'data/usage/resource-warnings-query'
 import {
   Alert_Shadcn_,
-  AlertDescription_Shadcn_,
   AlertTitle_Shadcn_,
+  cn,
   IconAlertTriangle,
   IconPauseCircle,
   IconRefreshCw,
 } from 'ui'
 import { InferredProjectStatus } from './ProjectCard.utils'
 import { getWarningContent } from 'components/ui/ResourceExhaustionWarningBanner/ResourceExhaustionWarningBanner.utils'
+import * as Tooltip from '@radix-ui/react-tooltip'
+import { Info } from 'lucide-react'
 
 export interface ProjectCardWarningsProps {
   resourceWarnings?: ResourceWarning
@@ -84,7 +86,10 @@ export const ProjectCardStatus = ({
     <div>
       <Alert_Shadcn_
         variant={alertType}
-        className="border-0 rounded-none rounded-b-md my-2 mb-2.5 [&>svg]:w-[28px] [&>svg]:h-[28px] [&>svg]:mt-1 [&>svg]:p-1.5 [&>svg]:left-6 pl-6 group-hover:bg-destructive-300 transition-colors"
+        className={cn(
+          `border-0 rounded-none rounded-b-md my-2 mb-2.5 [&>svg]:top-2.5 [&>svg]:w-[24px] [&>svg]:h-[24px] [&>svg]:p-1.5 [&>svg]:left-4 pl-2 bg-transparent transition-colors flex items-center`,
+          !isCritical ? '[&>svg]:text-foreground [&>svg]:bg-scale-400' : ''
+        )}
       >
         {projectStatus === 'isPaused' || projectStatus === 'isPausing' ? (
           <IconPauseCircle strokeWidth={2} />
@@ -93,8 +98,27 @@ export const ProjectCardStatus = ({
         ) : (
           <IconAlertTriangle strokeWidth={2} />
         )}
-        <AlertTitle_Shadcn_ className="text-sm mb-0.5">{alertTitle}</AlertTitle_Shadcn_>
-        <AlertDescription_Shadcn_ className="text-xs">{alertDescription}</AlertDescription_Shadcn_>
+        <div className="flex justify-between items-center w-full pr-0.5">
+          <AlertTitle_Shadcn_ className="text-xs mb-0 mr-8">{alertTitle}</AlertTitle_Shadcn_>
+          <Tooltip.Root delayDuration={0}>
+            <Tooltip.Trigger>
+              <Info size={14} />
+            </Tooltip.Trigger>
+            <Tooltip.Portal>
+              <Tooltip.Content side="bottom">
+                <Tooltip.Arrow className="radix-tooltip-arrow" />
+                <div
+                  className={[
+                    'rounded bg-scale-100 py-1 px-2 leading-none shadow',
+                    'border border-scale-200',
+                  ].join(' ')}
+                >
+                  <span className="text-xs text-foreground">{alertDescription}</span>
+                </div>
+              </Tooltip.Content>
+            </Tooltip.Portal>
+          </Tooltip.Root>
+        </div>
       </Alert_Shadcn_>
     </div>
   )

--- a/studio/components/interfaces/Home/ProjectList/ProjectCardStatus.tsx
+++ b/studio/components/interfaces/Home/ProjectList/ProjectCardStatus.tsx
@@ -88,7 +88,9 @@ export const ProjectCardStatus = ({
         variant={alertType}
         className={cn(
           `border-0 rounded-none rounded-b-md my-2 mb-2.5 [&>svg]:top-2.5 [&>svg]:w-[24px] [&>svg]:h-[24px] [&>svg]:p-1.5 [&>svg]:left-4 pl-2 bg-transparent transition-colors flex items-center`,
-          !isCritical ? '[&>svg]:text-foreground [&>svg]:bg-scale-400' : ''
+          !isCritical
+            ? '[&>svg]:text-foreground [&>svg]:bg-scale-400 [&>svg]:dark:bg-scale-600'
+            : ''
         )}
       >
         {projectStatus === 'isPaused' || projectStatus === 'isPausing' ? (


### PR DESCRIPTION
Reduce visual weight of status badges on project cards 

**Testing notes:**

Only project warnings should have coloured icons. Project status (paused/pausing/restoring/etc) are grey.

Critical: 
<img width="791" alt="screenshot-2023-10-02-at-17 10 03" src="https://github.com/supabase/supabase/assets/105593/02474b8e-bc1a-4625-9f0f-7e084396f5ad">


Warning: 
<img width="967" alt="screenshot-2023-10-03-at-10 42 46" src="https://github.com/supabase/supabase/assets/105593/0e5239f3-5651-4bfd-b187-a2334cf8b639">


Project has 1 or more warnings:
<img width="805" alt="screenshot-2023-10-03-at-10 44 38" src="https://github.com/supabase/supabase/assets/105593/74e0e5ab-26ce-4d32-a9bc-8eb2afbf71e1">
