### PR TITLE
chore: tidy project padding. remove redundant classes

### DIFF
--- a/studio/components/interfaces/Home/ProjectList/ProjectCard.tsx
+++ b/studio/components/interfaces/Home/ProjectList/ProjectCard.tsx
@@ -1,9 +1,8 @@
-import { IconGitBranch, IconGitHub } from 'ui'
-
 import CardButton from 'components/ui/CardButton'
 import { IntegrationProjectConnection } from 'data/integrations/integrations.types'
 import { ResourceWarning } from 'data/usage/resource-warnings-query'
 import { BASE_PATH } from 'lib/constants'
+import { GitBranch, Github } from 'lucide-react'
 import { Project } from 'types'
 import { inferProjectStatus } from './ProjectCard.utils'
 import { ProjectCardStatus } from './ProjectCardStatus'
@@ -53,13 +52,13 @@ const ProjectCard = ({
               )}
               {isBranchingEnabled && (
                 <div className="w-fit p-1 border rounded-md flex items-center border-scale-600">
-                  <IconGitBranch size={12} strokeWidth={1.5} />
+                  <GitBranch size={12} strokeWidth={1.5} />
                 </div>
               )}
               {isGithubIntegrated && (
                 <>
                   <div className="w-fit p-1 border rounded-md flex items-center border-scale-600">
-                    <IconGitHub size={12} strokeWidth={1.5} />
+                    <Github size={12} strokeWidth={1.5} />
                   </div>
                   <p className="text-xs !ml-2 text-foreground-light">{githubRepository}</p>
                 </>
@@ -70,7 +69,7 @@ const ProjectCard = ({
         footer={
           <ProjectCardStatus projectStatus={projectStatus} resourceWarnings={resourceWarnings} />
         }
-      ></CardButton>
+      />
     </li>
   )
 }

--- a/studio/components/interfaces/Home/ProjectList/ProjectCard.tsx
+++ b/studio/components/interfaces/Home/ProjectList/ProjectCard.tsx
@@ -33,12 +33,12 @@ const ProjectCard = ({
   const projectStatus = inferProjectStatus(project)
 
   return (
-    <li className="col-span-1 list-none">
+    <li className="list-none">
       <CardButton
         linkHref={rewriteHref ? rewriteHref : `/project/${projectRef}`}
-        className="h-44 !px-0 group pt-6 pb-0"
+        className="h-44 !px-0 group pt-5 pb-0"
         title={
-          <div className="w-full justify-between space-y-1.5 px-4">
+          <div className="w-full justify-between space-y-1.5 px-5">
             <p className="flex-shrink truncate text-sm">{name}</p>
             <span className="text-sm lowercase text-foreground-light">{desc}</span>
             <div className="flex items-center space-x-1.5">
@@ -68,9 +68,7 @@ const ProjectCard = ({
           </div>
         }
         footer={
-          <div className="mb-[-10px]">
-            <ProjectCardStatus projectStatus={projectStatus} resourceWarnings={resourceWarnings} />
-          </div>
+          <ProjectCardStatus projectStatus={projectStatus} resourceWarnings={resourceWarnings} />
         }
       ></CardButton>
     </li>

--- a/studio/components/interfaces/Home/ProjectList/ProjectCardStatus.tsx
+++ b/studio/components/interfaces/Home/ProjectList/ProjectCardStatus.tsx
@@ -1,17 +1,10 @@
-import { RESOURCE_WARNING_MESSAGES } from 'components/ui/ResourceExhaustionWarningBanner/ResourceExhaustionWarningBanner.constants'
-import { ResourceWarning } from 'data/usage/resource-warnings-query'
-import {
-  Alert_Shadcn_,
-  AlertTitle_Shadcn_,
-  cn,
-  IconAlertTriangle,
-  IconPauseCircle,
-  IconRefreshCw,
-} from 'ui'
-import { InferredProjectStatus } from './ProjectCard.utils'
-import { getWarningContent } from 'components/ui/ResourceExhaustionWarningBanner/ResourceExhaustionWarningBanner.utils'
 import * as Tooltip from '@radix-ui/react-tooltip'
-import { Info } from 'lucide-react'
+import { RESOURCE_WARNING_MESSAGES } from 'components/ui/ResourceExhaustionWarningBanner/ResourceExhaustionWarningBanner.constants'
+import { getWarningContent } from 'components/ui/ResourceExhaustionWarningBanner/ResourceExhaustionWarningBanner.utils'
+import { ResourceWarning } from 'data/usage/resource-warnings-query'
+import { AlertTriangle, Info, RefreshCcw } from 'lucide-react'
+import { Alert_Shadcn_, AlertTitle_Shadcn_, cn, IconPauseCircle } from 'ui'
+import { InferredProjectStatus } from './ProjectCard.utils'
 
 export interface ProjectCardWarningsProps {
   resourceWarnings?: ResourceWarning
@@ -93,11 +86,11 @@ export const ProjectCardStatus = ({
       )}
     >
       {projectStatus === 'isPaused' || projectStatus === 'isPausing' ? (
-        <IconPauseCircle strokeWidth={2} />
+        <IconPauseCircle strokeWidth={1.5} size={12} />
       ) : projectStatus === 'isRestoring' || projectStatus === 'isComingUp' ? (
-        <IconRefreshCw strokeWidth={2} />
+        <RefreshCcw strokeWidth={1.5} size={12} />
       ) : (
-        <IconAlertTriangle strokeWidth={2} />
+        <AlertTriangle strokeWidth={1.5} size={12} />
       )}
       <div className="flex justify-between items-center w-full">
         <AlertTitle_Shadcn_ className="text-xs mb-0">{alertTitle}</AlertTitle_Shadcn_>

--- a/studio/components/interfaces/Home/ProjectList/ProjectCardStatus.tsx
+++ b/studio/components/interfaces/Home/ProjectList/ProjectCardStatus.tsx
@@ -100,7 +100,7 @@ export const ProjectCardStatus = ({
         <IconAlertTriangle strokeWidth={2} />
       )}
       <div className="flex justify-between items-center w-full">
-        <AlertTitle_Shadcn_ className="text-xs mb-0">{alertTitle} hello world</AlertTitle_Shadcn_>
+        <AlertTitle_Shadcn_ className="text-xs mb-0">{alertTitle}</AlertTitle_Shadcn_>
         <Tooltip.Root delayDuration={0}>
           <Tooltip.Trigger>
             <Info size={14} className="text-foreground-light hover:text-foreground" />

--- a/studio/components/interfaces/Home/ProjectList/ProjectCardStatus.tsx
+++ b/studio/components/interfaces/Home/ProjectList/ProjectCardStatus.tsx
@@ -79,10 +79,10 @@ export const ProjectCardStatus = ({
     <Alert_Shadcn_
       variant={alertType}
       className={cn(
-        'border-0 p-5',
+        'border-0 p-5 pb-[1.25rem]',
         'bg-transparent',
-        '[&>svg]:left-[21px] [&>svg]:top-3.5',
-        !isCritical ? '[&>svg]:text-foreground [&>svg]:bg-surface-300' : ''
+        '[&>svg]:left-[1.25rem] [&>svg]:top-3.5 [&>svg]:border',
+        !isCritical ? '[&>svg]:text-foreground [&>svg]:bg-surface-100' : ''
       )}
     >
       {projectStatus === 'isPaused' || projectStatus === 'isPausing' ? (

--- a/studio/components/interfaces/Home/ProjectList/ProjectCardStatus.tsx
+++ b/studio/components/interfaces/Home/ProjectList/ProjectCardStatus.tsx
@@ -80,48 +80,46 @@ export const ProjectCardStatus = ({
     ? 'default'
     : 'warning'
 
-  if (activeWarnings.length === 0 && projectStatus === 'isHealthy') return <div className="py-2" />
+  if (activeWarnings.length === 0 && projectStatus === 'isHealthy') return null
 
   return (
-    <div>
-      <Alert_Shadcn_
-        variant={alertType}
-        className={cn(
-          `border-0 rounded-none rounded-b-md my-2 mb-2.5 [&>svg]:top-2.5 [&>svg]:w-[24px] [&>svg]:h-[24px] [&>svg]:p-1.5 [&>svg]:left-4 pl-2 bg-transparent transition-colors flex items-center`,
-          !isCritical
-            ? '[&>svg]:text-foreground [&>svg]:bg-scale-400 [&>svg]:dark:bg-scale-600'
-            : ''
-        )}
-      >
-        {projectStatus === 'isPaused' || projectStatus === 'isPausing' ? (
-          <IconPauseCircle strokeWidth={2} />
-        ) : projectStatus === 'isRestoring' || projectStatus === 'isComingUp' ? (
-          <IconRefreshCw size={14} strokeWidth={2} />
-        ) : (
-          <IconAlertTriangle strokeWidth={2} />
-        )}
-        <div className="flex justify-between items-center w-full pr-0.5">
-          <AlertTitle_Shadcn_ className="text-xs mb-0 mr-8">{alertTitle}</AlertTitle_Shadcn_>
-          <Tooltip.Root delayDuration={0}>
-            <Tooltip.Trigger>
-              <Info size={14} />
-            </Tooltip.Trigger>
-            <Tooltip.Portal>
-              <Tooltip.Content side="bottom">
-                <Tooltip.Arrow className="radix-tooltip-arrow" />
-                <div
-                  className={[
-                    'rounded bg-scale-100 py-1 px-2 leading-none shadow',
-                    'border border-scale-200',
-                  ].join(' ')}
-                >
-                  <span className="text-xs text-foreground">{alertDescription}</span>
-                </div>
-              </Tooltip.Content>
-            </Tooltip.Portal>
-          </Tooltip.Root>
-        </div>
-      </Alert_Shadcn_>
-    </div>
+    <Alert_Shadcn_
+      variant={alertType}
+      className={cn(
+        'border-0 p-5',
+        'bg-transparent',
+        '[&>svg]:left-[21px] [&>svg]:top-3.5',
+        !isCritical ? '[&>svg]:text-foreground [&>svg]:bg-surface-300' : ''
+      )}
+    >
+      {projectStatus === 'isPaused' || projectStatus === 'isPausing' ? (
+        <IconPauseCircle strokeWidth={2} />
+      ) : projectStatus === 'isRestoring' || projectStatus === 'isComingUp' ? (
+        <IconRefreshCw strokeWidth={2} />
+      ) : (
+        <IconAlertTriangle strokeWidth={2} />
+      )}
+      <div className="flex justify-between items-center w-full">
+        <AlertTitle_Shadcn_ className="text-xs mb-0">{alertTitle} hello world</AlertTitle_Shadcn_>
+        <Tooltip.Root delayDuration={0}>
+          <Tooltip.Trigger>
+            <Info size={14} className="text-foreground-light hover:text-foreground" />
+          </Tooltip.Trigger>
+          <Tooltip.Portal>
+            <Tooltip.Content side="bottom">
+              <Tooltip.Arrow className="radix-tooltip-arrow" />
+              <div
+                className={[
+                  'rounded bg-scale-100 py-1 px-2 leading-none shadow',
+                  'border border-scale-200',
+                ].join(' ')}
+              >
+                <span className="text-xs text-foreground">{alertDescription}</span>
+              </div>
+            </Tooltip.Content>
+          </Tooltip.Portal>
+        </Tooltip.Root>
+      </div>
+    </Alert_Shadcn_>
   )
 }

--- a/studio/components/ui/CardButton.tsx
+++ b/studio/components/ui/CardButton.tsx
@@ -46,9 +46,9 @@ const CardButton = ({
   let containerClasses = [
     className,
     'group relative text-left',
-    'bg-panel-header-light dark:bg-panel-header-dark',
-    'border border-panel-border-light dark:border-panel-border-dark',
-    'rounded-md py-4 px-6 flex flex-row h-32',
+    'bg-surface-100',
+    'border border-surface',
+    'rounded-md p-5 flex flex-row h-32',
     'transition ease-in-out duration-150',
   ]
 
@@ -56,9 +56,8 @@ const CardButton = ({
     containerClasses = [
       ...containerClasses,
       'cursor-pointer',
-      'hover:bg-panel-border-light dark:hover:bg-panel-border-dark',
-      'hover:border-panel-border-hover-light',
-      'dark:hover:border-panel-border-hover-dark hover:border-gray-300',
+      'hover:bg-surface-200',
+      'hover:border-control',
     ]
   }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adjusted padding slightly for cards

before:
<img width="1579" alt="Screenshot 2023-10-04 at 6 08 52 PM" src="https://github.com/supabase/supabase/assets/8291514/842800ec-9711-4f48-8f2c-f28847196d2c">

after:
<img width="995" alt="Screenshot 2023-10-04 at 6 08 15 PM" src="https://github.com/supabase/supabase/assets/8291514/c287ebc3-2bc7-42da-b8aa-af0e13587db5">


## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
