### PR TITLE
Add install docs to python docs

### DIFF
--- a/apps/docs/docs/ref/python/installing.mdx
+++ b/apps/docs/docs/ref/python/installing.mdx
@@ -46,15 +46,15 @@ custom_edit_url: https://github.com/supabase/supabase/edit/master/spec/supabase_
 <RefSubLayout.EducationRow>
   <RefSubLayout.Details>
 
-  You can also install locally after cloning this repo. Install Development mode with `pip install -e`, which makes it so when you edit the source code the changes will be reflected in your python module.
+You can also install locally after cloning this repo. Install Development mode with `pip install -e`, which makes it so when you edit the source code the changes will be reflected in your python module.
 
   </RefSubLayout.Details>
 
   <RefSubLayout.Examples>
 
-  ```sh Terminal
-  pip install -e
-  ```
-  
+```sh Terminal
+pip install -e
+```
+
   </RefSubLayout.Examples>
 </RefSubLayout.EducationRow>

--- a/apps/docs/docs/ref/python/installing.mdx
+++ b/apps/docs/docs/ref/python/installing.mdx
@@ -40,21 +40,3 @@ custom_edit_url: https://github.com/supabase/supabase/edit/master/spec/supabase_
 
   </RefSubLayout.Examples>
 </RefSubLayout.EducationRow>
-
-### Local Installation
-
-<RefSubLayout.EducationRow>
-  <RefSubLayout.Details>
-
-You can also install locally after cloning this repo. Install Development mode with `pip install -e`, which makes it so when you edit the source code the changes will be reflected in your python module.
-
-  </RefSubLayout.Details>
-
-  <RefSubLayout.Examples>
-
-```sh Terminal
-pip install -e
-```
-
-  </RefSubLayout.Examples>
-</RefSubLayout.EducationRow>

--- a/apps/docs/docs/ref/python/installing.mdx
+++ b/apps/docs/docs/ref/python/installing.mdx
@@ -2,7 +2,7 @@
 id: installing
 title: 'Installing'
 slug: installing
-custom_edit_url: https://github.com/supabase/supabase/edit/master/web/spec/supabase.yml
+custom_edit_url: https://github.com/supabase/supabase/edit/master/spec/supabase_py_v2.yml
 ---
 
 ### Install with PyPi

--- a/apps/docs/docs/ref/python/installing.mdx
+++ b/apps/docs/docs/ref/python/installing.mdx
@@ -1,0 +1,60 @@
+---
+id: installing
+title: 'Installing'
+slug: installing
+custom_edit_url: https://github.com/supabase/supabase/edit/master/web/spec/supabase.yml
+---
+
+### Install with PyPi
+
+<RefSubLayout.EducationRow>
+  <RefSubLayout.Details>
+
+    You can install supabase-py via the terminal. (for > Python 3.7)
+
+  </RefSubLayout.Details>
+
+  <RefSubLayout.Examples>
+
+    <Tabs
+      size="small"
+      type="underlined"
+      defaultActiveId="pip"
+      queryGroup="platform"
+    >
+      <TabPanel id="pip" label="PIP">
+
+        ```sh Terminal
+        pip install supabase
+        ```
+
+      </TabPanel>
+      <TabPanel id="conda" label="Conda">
+
+        ```sh Terminal
+        conda install -c conda-forge supabase
+        ```
+
+      </TabPanel>
+    </Tabs>
+
+  </RefSubLayout.Examples>
+</RefSubLayout.EducationRow>
+
+### Local Installation
+
+<RefSubLayout.EducationRow>
+  <RefSubLayout.Details>
+
+  You can also install locally after cloning this repo. Install Development mode with `pip install -e`, which makes it so when you edit the source code the changes will be reflected in your python module.
+
+  </RefSubLayout.Details>
+
+  <RefSubLayout.Examples>
+
+  ```sh Terminal
+  pip install -e
+  ```
+  
+  </RefSubLayout.Examples>
+</RefSubLayout.EducationRow>

--- a/spec/common-client-libs-sections.json
+++ b/spec/common-client-libs-sections.json
@@ -13,7 +13,6 @@
     "excludes": [
       "reference_javascript_v1",
       "reference_dart_v0",
-      "reference_python_v2",
       "reference_swift_v1"
     ]
   },


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds docs on how to install supabase-py

## What is the current behavior?

![CleanShot 2023-10-04 at 19 38 53@2x](https://github.com/supabase/supabase/assets/70828596/6b9424c6-3df3-4c73-bfb1-e2c92c1ef86d)

## What is the new behavior?

![CleanShot 2023-10-04 at 19 39 18@2x](https://github.com/supabase/supabase/assets/70828596/926044b9-203b-4f77-99f3-18a89995c837)