### PR TITLE
Fix introduction padding

### DIFF
--- a/apps/docs/layouts/ref/RefSubLayout.tsx
+++ b/apps/docs/layouts/ref/RefSubLayout.tsx
@@ -52,7 +52,7 @@ interface ISectionExamples {}
 
 const RefSubLayout: FC<RefSubLayoutType> & RefSubLayoutSubComponents = (props) => {
   return (
-    <div className="flex flex-col w-full divide-y px-5 max-w-7xl mx-auto py-16">
+    <div className="flex flex-col w-full divide-y px-5 max-w-7xl mx-auto pb-16 introduction-padding">
       {props.children}
     </div>
   )

--- a/apps/docs/styles/main.scss
+++ b/apps/docs/styles/main.scss
@@ -282,3 +282,7 @@ div[role='tablist'] {
   position: relative !important;
   height: unset !important;
 }
+
+.introduction-padding > article:first-child > div:first-child {
+  padding-top: 64px;
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

fix issue with introduction padding not being able to see title of introduction section.

## What is the current behavior?

![CleanShot 2023-10-04 at 21 05 15](https://github.com/supabase/supabase/assets/70828596/c49d4747-844b-48ea-9458-fc318b6b6323)

## What is the new behavior?

![CleanShot 2023-10-04 at 21 05 45](https://github.com/supabase/supabase/assets/70828596/3c08d768-4bdf-4cc9-8a0d-4005f7508806)

## Additional context

I don't know if there is a way to target the desired div like that in tailwindcss. We could also add more padding so it doesn't look weird super close to the navbar.