### PR TITLE
fix: Fix the loading state on the Continue with Github button

### DIFF
--- a/studio/components/interfaces/SignIn/SignInWithGitHub.tsx
+++ b/studio/components/interfaces/SignIn/SignInWithGitHub.tsx
@@ -35,7 +35,6 @@ const SignInWithGitHub = () => {
       if (error) throw error
     } catch (error) {
       console.error(error)
-    } finally {
       setLoading(false)
     }
   }
@@ -44,7 +43,8 @@ const SignInWithGitHub = () => {
     <Button
       block
       onClick={handleGithubSignIn}
-      icon={<IconGitHub width={18} height={18} />}
+      // set the width to 20 so that it matches the loading spinner and don't push the text when loading
+      icon={<IconGitHub width={20} height={18} />}
       size="large"
       type="default"
       loading={loading}


### PR DESCRIPTION
This PR fixes the `Continue with Github` button to use its loading state correctly. Previously the loading state was too fast, now it continues (if there's no error) until you're redirected to Github.