### PR TITLE
Darker footer + security section fix

### DIFF
--- a/apps/www/components/Footer/index.tsx
+++ b/apps/www/components/Footer/index.tsx
@@ -46,8 +46,9 @@ const Footer = (props: Props) => {
             </li>
           </ul>
         </SectionContainer>
+        <div className="w-full h-px bg-gradient-to-r from-transparent via-border to-transparent" />
       </div>
-      <SectionContainer>
+      <SectionContainer className="py-8">
         <div className="xl:grid xl:grid-cols-3 xl:gap-8">
           <div className="space-y-8 xl:col-span-1">
             <Link href="#" as="/">

--- a/apps/www/components/Footer/index.tsx
+++ b/apps/www/components/Footer/index.tsx
@@ -36,13 +36,13 @@ const Footer = (props: Props) => {
           </div>
           <span className="hidden md:block h-px w-8 bg-border" />
           <ul className="flex flex-col md:flex-row gap-2 md:gap-8 justify-center md:items-center">
-            <li className="flex items-center gap-2">
+            <li className="flex items-center gap-2 whitespace-nowrap flex-nowrap">
               <CheckIcon className="w-4 h-4" /> SOC2 Type 2{' '}
-              <span className="text-lighter">Certified</span>
+              <span className="text-lighter hidden sm:inline">Certified</span>
             </li>
-            <li className="flex items-center gap-2">
+            <li className="flex items-center gap-2 whitespace-nowrap flex-nowrap">
               <CheckIcon className="w-4 h-4" /> HIPAA{' '}
-              <span className="text-lighter">Compliant</span>
+              <span className="text-lighter hidden sm:inline">Compliant</span>
             </li>
           </ul>
         </SectionContainer>

--- a/apps/www/components/Footer/index.tsx
+++ b/apps/www/components/Footer/index.tsx
@@ -27,14 +27,13 @@ const Footer = (props: Props) => {
         Footer
       </h2>
       <div className="w-full !py-0">
-        <SectionContainer className="grid grid-cols-2 md:flex items-center justify-between md:justify-center gap-8 md:gap-10 !py-6 md:!py-10 text-sm">
+        <SectionContainer className="grid grid-cols-2 md:flex items-center justify-between md:justify-center gap-8 md:gap-16 xl:gap-28 !py-6 md:!py-10 text-sm">
           <div className="flex flex-col md:flex-row gap-2 md:items-center">
             We protect your data.
             <Link href="/security">
               <a className="text-brand hover:underline">More on Security</a>
             </Link>
           </div>
-          <span className="hidden md:block h-px w-8 bg-border" />
           <ul className="flex flex-col md:flex-row gap-2 md:gap-8 justify-center md:items-center">
             <li className="flex items-center gap-2 whitespace-nowrap flex-nowrap">
               <CheckIcon className="w-4 h-4" /> SOC2 Type 2{' '}

--- a/apps/www/components/Footer/index.tsx
+++ b/apps/www/components/Footer/index.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 import { useTheme } from 'next-themes'
-import { Badge } from 'ui'
+import { Badge, cn } from 'ui'
 import Image from 'next/image'
 import { useRouter } from 'next/router'
 import ThemeToggle from '@ui/components/ThemeProvider/ThemeToggle'
@@ -22,14 +22,11 @@ const Footer = (props: Props) => {
   const isLaunchWeekPage = pathname.includes('launch-week') || pathname === '/'
 
   return (
-    <footer
-      className={['border-border border-t', props.className].join(' ')}
-      aria-labelledby="footerHeading"
-    >
+    <footer className={cn('bg-alternative', props.className)} aria-labelledby="footerHeading">
       <h2 id="footerHeading" className="sr-only">
         Footer
       </h2>
-      <div className="w-full !py-0 border-b">
+      <div className="w-full !py-0">
         <SectionContainer className="grid grid-cols-2 md:flex items-center justify-between md:justify-center gap-8 md:gap-10 !py-6 md:!py-10 text-sm">
           <div className="flex flex-col md:flex-row gap-2 md:items-center">
             We protect your data.


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Darker footer bg
- Removed borders and left a gradient divider
- Fixed xs layout for security pre-footer section

## What is the current behavior?

<img width="2030" alt="Screenshot 2023-10-05 at 18 51 45" src="https://github.com/supabase/supabase/assets/25671831/1826e22a-2a34-475c-9ef6-026dfa70573a">
<img width="359" alt="Screenshot 2023-10-05 at 18 52 16" src="https://github.com/supabase/supabase/assets/25671831/2d4be840-408d-4912-b55e-c9b1d709346e">

## What is the new behavior?

<img width="1833" alt="Screenshot 2023-10-05 at 18 50 16" src="https://github.com/supabase/supabase/assets/25671831/6eaca0e8-2b8e-4022-ac2d-710789ce27a2">
<img width="499" alt="Screenshot 2023-10-05 at 18 50 22" src="https://github.com/supabase/supabase/assets/25671831/866ecc16-0d5a-40c9-a658-aedb31c1c2ca">

