### PR TITLE
Fix: SQL Editor destructive query false positive

### DIFF
--- a/studio/components/interfaces/SQLEditor/SQLEditor.constants.ts
+++ b/studio/components/interfaces/SQLEditor/SQLEditor.constants.ts
@@ -1298,4 +1298,4 @@ export const sqlAiDisclaimerComment = stripIndent`
 
 export const untitledSnippetTitle = 'Untitled query'
 
-export const destructiveSqlRegex = [/(drop|delete|truncate)\s/i]
+export const destructiveSqlRegex = [/^(.*;)?\s*(drop|delete|truncate)\s/is]

--- a/studio/components/interfaces/SQLEditor/SQLEditor.tsx
+++ b/studio/components/interfaces/SQLEditor/SQLEditor.tsx
@@ -41,18 +41,14 @@ import {
   useStore,
 } from 'hooks'
 import { IS_PLATFORM, OPT_IN_TAGS } from 'lib/constants'
-import { removeCommentsFromSql, uuidv4 } from 'lib/helpers'
+import { uuidv4 } from 'lib/helpers'
 import { useProfile } from 'lib/profile'
 import Telemetry from 'lib/telemetry'
 import { getSqlEditorStateSnapshot, useSqlEditorStateSnapshot } from 'state/sql-editor'
 import { subscriptionHasHipaaAddon } from '../BillingV2/Subscription/Subscription.utils'
 import AISchemaSuggestionPopover from './AISchemaSuggestionPopover'
 import AISettingsModal from './AISettingsModal'
-import {
-  destructiveSqlRegex,
-  sqlAiDisclaimerComment,
-  untitledSnippetTitle,
-} from './SQLEditor.constants'
+import { sqlAiDisclaimerComment, untitledSnippetTitle } from './SQLEditor.constants'
 import {
   ContentDiff,
   DiffType,
@@ -61,6 +57,7 @@ import {
   SQLEditorContextValues,
 } from './SQLEditor.types'
 import {
+  checkDestructiveQuery,
   createSqlSnippetSkeleton,
   getDiffTypeButtonLabel,
   getDiffTypeDropdownLabel,
@@ -263,9 +260,7 @@ const SQLEditor = () => {
           ? (selectedValue || editorRef.current?.getValue()) ?? snippet.snippet.content.sql
           : selectedValue || editorRef.current?.getValue()
 
-        const containsDestructiveOperations = destructiveSqlRegex.some((regex) =>
-          regex.test(removeCommentsFromSql(sql))
-        )
+        const containsDestructiveOperations = checkDestructiveQuery(sql)
 
         if (!force && containsDestructiveOperations) {
           setIsConfirmModalOpen(true)

--- a/studio/components/interfaces/SQLEditor/SQLEditor.utils.ts
+++ b/studio/components/interfaces/SQLEditor/SQLEditor.utils.ts
@@ -1,8 +1,9 @@
 // @ts-ignore
 import MarkdownTable from 'markdown-table'
-import { NEW_SQL_SNIPPET_SKELETON } from './SQLEditor.constants'
+import { NEW_SQL_SNIPPET_SKELETON, destructiveSqlRegex } from './SQLEditor.constants'
 import { SqlSnippets, UserContent } from 'types'
 import { DiffType } from './SQLEditor.types'
+import { removeCommentsFromSql } from 'lib/helpers'
 
 export const getResultsMarkdown = (results: any[]) => {
   const columns = Object.keys(results[0])
@@ -66,4 +67,8 @@ export function getDiffTypeDropdownLabel(diffType: DiffType) {
     default:
       throw new Error(`Unknown diff type '${diffType}'`)
   }
+}
+
+export function checkDestructiveQuery(sql: string) {
+  return destructiveSqlRegex.some((regex) => regex.test(removeCommentsFromSql(sql)))
 }

--- a/studio/tests/unit/destructive-query-check.test.ts
+++ b/studio/tests/unit/destructive-query-check.test.ts
@@ -1,0 +1,58 @@
+import { stripIndent } from 'common-tags'
+import { checkDestructiveQuery } from 'components/interfaces/SQLEditor/SQLEditor.utils'
+
+describe(`destructive query check`, () => {
+  it('drop statement matches', () => {
+    const match = checkDestructiveQuery('drop table films, distributors;')
+
+    expect(match).toBe(true)
+  })
+
+  it('truncate statement matches', () => {
+    const match = checkDestructiveQuery('truncate films;')
+
+    expect(match).toBe(true)
+  })
+
+  it('delete statement matches', () => {
+    const match = checkDestructiveQuery("delete from films where kind <> 'Musical';")
+
+    expect(match).toBe(true)
+  })
+
+  it('delete statement after another statement matches', () => {
+    const match = checkDestructiveQuery(stripIndent`
+      select * from films;
+
+      delete from films where kind <> 'Musical';
+    `)
+
+    expect(match).toBe(true)
+  })
+
+  it("rls policy containing delete doesn't match", () => {
+    const match = checkDestructiveQuery(stripIndent`
+      create policy "Users can delete their own files"
+      on storage.objects for delete to authenticated using (
+        bucket id = 'files' and auth.uid () = owner
+      );
+    `)
+
+    expect(match).toBe(false)
+  })
+
+  it('capitalized statement matches', () => {
+    const match = checkDestructiveQuery("DELETE FROM films WHERE kind <> 'Musical';")
+
+    expect(match).toBe(true)
+  })
+
+  it("comment containing keyword doesn't match", () => {
+    const match = checkDestructiveQuery(stripIndent`
+      -- Going to drop this in here, might delete later
+      select * from films;
+    `)
+
+    expect(match).toBe(false)
+  })
+})


### PR DESCRIPTION
## Problem
RLS policy containing the keyword `delete` flags the destructive query warning. Eg:
```sql
create policy "Users can delete their own files"
on storage.objects for delete to authenticated using (
  bucket id = 'files' and auth.uid () = owner
);
```
## Fix
- Improves regex by checking for semicolon before the keyword, unless its the first statement in the query
- Adds unit tests

## Other
To see some of the tests in action:
https://regex101.com/r/oQeUkq/3