### PR TITLE
fix: Add minimum supabase-js version to the docs to use Broadcast

### DIFF
--- a/apps/docs/pages/guides/realtime/broadcast.mdx
+++ b/apps/docs/pages/guides/realtime/broadcast.mdx
@@ -290,6 +290,12 @@ Use this to guarantee that the server has received the message before resolving 
 
 ### Send messages using REST calls
 
+<Admonition type="warning">
+
+- You will need at least version 2.37.0 to use this feature
+
+</Admonition>
+
 You can also send a Broadcast message by making an HTTP request to Reatlime servers. This is useful when you want to send messages from your server or client without having to first establish a WebSocket connection.
 
 ```js


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add minimum supabase-js version to the docs to use Broadcast