### PR TITLE
Docs: Removed line breaks from Python docs introduction.mdx

### DIFF
--- a/apps/docs/docs/ref/python/introduction.mdx
+++ b/apps/docs/docs/ref/python/introduction.mdx
@@ -13,11 +13,7 @@ hideTitle: true
 </div>
 
 <div className="max-w-xl">
-  This reference documents every object and method available in the
-  [supabase-py](https://github.com/supabase-community/supabase-py) library from the Supabase
-  community. You can use `supabase-py` to interact with your Postgres database, listen to database
-  changes, invoke Deno Edge Functions, build login and user management functionality, and manage
-  large files.
+    This reference documents every object and method available in the [supabase-py](https://github.com/supabase-community/supabase-py) library from the Supabase community. You can use `supabase-py` to test with your Postgres database, listen to database changes, invoke Deno Edge Functions, build login and user management functionality, and manage large files.
 </div>
 
 <div className="max-w-xl bg-slate-300 px-4 py-2 rounded-md">

--- a/apps/docs/docs/ref/python/introduction.mdx
+++ b/apps/docs/docs/ref/python/introduction.mdx
@@ -13,7 +13,8 @@ hideTitle: true
 </div>
 
 <div className="max-w-xl">
-    This reference documents every object and method available in the [supabase-py](https://github.com/supabase-community/supabase-py) library from the Supabase community. You can use `supabase-py` to test with your Postgres database, listen to database changes, invoke Deno Edge Functions, build login and user management functionality, and manage large files.
+  {/* prettier-ignore */}
+  <p>This reference documents every object and method available in the [supabase-py](https://github.com/supabase-community/supabase-py) library from the Supabase community. You can use `supabase-py` to test with your Postgres database, listen to database changes, invoke Deno Edge Functions, build login and user management functionality, and manage large files.</p>
 </div>
 
 <div className="max-w-xl bg-slate-300 px-4 py-2 rounded-md">


### PR DESCRIPTION
## What kind of change does this PR introduce?

Small fix to Python documentation where erroneous line breaks were showing in the introduction section.

## What is the current behavior?

<img width="628" alt="Screenshot 2023-10-07 at 10 39 58 AM" src="https://github.com/supabase/supabase/assets/35545129/07f6d384-ddb8-4a34-b0a8-2441e56aef60">


## What is the new behavior?

<img width="606" alt="Screenshot 2023-10-07 at 10 39 35 AM" src="https://github.com/supabase/supabase/assets/35545129/68cb9691-c038-4448-8c61-3b19d9c221ed">

## Additional context

As requested in PR #17676 

