### PR TITLE
feat: rework database health report disk space

### DIFF
--- a/studio/components/interfaces/Reports/Reports.constants.ts
+++ b/studio/components/interfaces/Reports/Reports.constants.ts
@@ -355,6 +355,29 @@ select
       },
     },
   },
+  [Presets.DATABASE]: {
+    title: 'database',
+    queries: {
+      largeObjects: {
+        queryType: 'db',
+        sql: (_) => `SELECT 
+        SCHEMA_NAME,
+        relname,
+        table_size
+      FROM
+        (SELECT 
+          pg_catalog.pg_namespace.nspname AS SCHEMA_NAME,
+          relname,
+          pg_relation_size(pg_catalog.pg_class.oid) AS table_size
+        FROM pg_catalog.pg_class
+        JOIN pg_catalog.pg_namespace ON relnamespace = pg_catalog.pg_namespace.oid
+        ) t
+      WHERE SCHEMA_NAME NOT LIKE 'pg_%'
+      ORDER BY table_size DESC
+      LIMIT 5;`,
+      },
+    },
+  },
 }
 
 export const DATETIME_FORMAT = 'MMM D, ha'

--- a/studio/components/interfaces/Reports/Reports.types.ts
+++ b/studio/components/interfaces/Reports/Reports.types.ts
@@ -6,6 +6,7 @@ export enum Presets {
   STORAGE = 'storage',
   AUTH = 'auth',
   QUERY_PERFORMANCE = 'query_performance',
+  DATABASE = 'database',
 }
 
 export type MetaQueryResponse = any & { error: ResponseError }
@@ -18,9 +19,11 @@ export interface PresetConfig {
 export type BaseQueries<Keys extends string> = Record<Keys, ReportQuery>
 
 export interface ReportQuery {
-  queryType: 'db' | 'logs'
+  queryType: ReportQueryType
   sql: (filters: ReportFilterItem[]) => string
 }
+
+export type ReportQueryType = 'db' | 'logs'
 
 export interface StatusCodesDatum {
   timestamp: number

--- a/studio/components/interfaces/SQLEditor/SQLEditor.constants.ts
+++ b/studio/components/interfaces/SQLEditor/SQLEditor.constants.ts
@@ -1274,6 +1274,27 @@ drop extension if exists "supabase-dbdev";
 create extension "supabase-dbdev";
 `.trim(),
   },
+  {
+    id: 25,
+    type: 'template',
+    title: 'Large objects',
+    description: 'List large objects (tables/indexes) in your database.',
+    sql: `SELECT 
+    SCHEMA_NAME,
+    relname,
+    table_size
+  FROM
+    (SELECT 
+      pg_catalog.pg_namespace.nspname AS SCHEMA_NAME,
+      relname,
+      pg_relation_size(pg_catalog.pg_class.oid) AS table_size
+    FROM pg_catalog.pg_class
+    JOIN pg_catalog.pg_namespace ON relnamespace = pg_catalog.pg_namespace.oid
+    ) t
+  WHERE SCHEMA_NAME NOT LIKE 'pg_%'
+  ORDER BY table_size DESC
+  LIMIT 25`.trim(),
+  },
 ]
 
 export const SQL_SNIPPET_SCHEMA_VERSION = '1.0'

--- a/studio/hooks/analytics/useDbQuery.tsx
+++ b/studio/hooks/analytics/useDbQuery.tsx
@@ -17,6 +17,7 @@ export interface DbQueryHook<T = any> {
   runQuery: () => void
   setParams?: never
   changeQuery?: never
+  resolvedSql: string
 }
 
 const useDbQuery = (
@@ -53,7 +54,14 @@ const useDbQuery = (
   )
 
   const error = rqError || (typeof data === 'object' ? data?.error : '')
-  return { error, data, isLoading: isLoading || isRefetching, params, runQuery: refetch }
+  return {
+    error,
+    data,
+    isLoading: isLoading || isRefetching,
+    params,
+    runQuery: refetch,
+    resolvedSql,
+  }
 }
 
 export default useDbQuery

--- a/studio/pages/project/[ref]/reports/database.tsx
+++ b/studio/pages/project/[ref]/reports/database.tsx
@@ -1,23 +1,31 @@
 import { useParams } from 'common/hooks'
 import dayjs from 'dayjs'
 import { observer } from 'mobx-react-lite'
-import Link from 'next/link'
 import { useState } from 'react'
-import { Badge, Button, IconArrowRight, IconExternalLink } from 'ui'
+
+import { TIME_PERIODS_INFRA } from 'lib/constants'
+import { formatBytes } from 'lib/helpers'
+import { NextPageWithLayout } from 'types'
+import {
+  AlertDescription_Shadcn_,
+  Alert_Shadcn_,
+  Button,
+  IconArrowRight,
+  IconExternalLink,
+} from 'ui'
 
 import { ReportsLayout } from 'components/layouts'
 import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
 import ChartHandler from 'components/to-be-cleaned/Charts/ChartHandler'
 import DateRangePicker from 'components/to-be-cleaned/DateRangePicker'
 import Panel from 'components/ui/Panel'
-import SparkBar from 'components/ui/SparkBar'
 import { useDatabaseSizeQuery } from 'data/database/database-size-query'
-import { useProjectSubscriptionV2Query } from 'data/subscriptions/project-subscription-v2-query'
-import { useProjectUsageQuery } from 'data/usage/project-usage-query'
-import { useSelectedOrganization } from 'hooks'
-import { GB, TIME_PERIODS_INFRA, USAGE_APPROACHING_THRESHOLD } from 'lib/constants'
-import { formatBytes } from 'lib/helpers'
-import { NextPageWithLayout } from 'types'
+import ReportWidget from 'components/interfaces/Reports/ReportWidget'
+import { queriesFactory } from 'components/interfaces/Reports/Reports.utils'
+import { PRESET_CONFIG } from 'components/interfaces/Reports/Reports.constants'
+import Table from 'components/to-be-cleaned/Table'
+import Link from 'next/link'
+import { DbQueryHook } from 'hooks/analytics/useDbQuery'
 
 const DatabaseReport: NextPageWithLayout = () => {
   return (
@@ -36,170 +44,22 @@ DatabaseReport.getLayout = (page) => <ReportsLayout title="Database">{page}</Rep
 export default DatabaseReport
 
 const DatabaseUsage = observer(() => {
-  const { ref: projectRef } = useParams()
   const { project } = useProjectContext()
-  const selectedOrganization = useSelectedOrganization()
-  const { data: usage } = useProjectUsageQuery({ projectRef })
-  const { data: subscription } = useProjectSubscriptionV2Query({ projectRef })
 
   const [dateRange, setDateRange] = useState<any>(undefined)
-
-  const databaseUsageLimit = usage?.db_size?.limit ?? 0
-  const databaseEgressLimit = usage?.db_egress?.limit ?? 0
 
   const { data } = useDatabaseSizeQuery({
     projectRef: project?.ref,
     connectionString: project?.connectionString,
   })
-  const databaseSize = data?.result[0].db_size ?? 0
+  const databaseSizeBytes = data?.result[0].db_size ?? 0
 
-  const databaseSizeUsageRatio = databaseSize / databaseUsageLimit
-  const limitIsApproaching = databaseSizeUsageRatio >= USAGE_APPROACHING_THRESHOLD
-  const limitIsExceeded = databaseSizeUsageRatio >= 1
-
-  const diskSize = usage?.disk_volume_size_gb ?? 0
-  const diskSizeUsageRatio = databaseSize / diskSize
-
-  const egressIsApproaching = databaseSizeUsageRatio >= USAGE_APPROACHING_THRESHOLD
-  const egressIsExceeded = databaseSizeUsageRatio >= 1
-
-  const subscriptionPlan = subscription?.plan?.id
-
-  const isPaidTier = subscriptionPlan !== 'free'
-
-  // Can be null or undefined, thus !=
-  const orgLevelBilling = selectedOrganization?.subscription_id != undefined
-  const maxDiskVolumeSize =
-    (usage?.disk_volume_size_gb ?? 0 > 0 ? usage?.disk_volume_size_gb ?? 0 : Infinity) * GB
+  const report = useDatabaseReport()
 
   return (
     <>
       <div>
         <section>
-          <Panel title={<h2>Database usage</h2>}>
-            {orgLevelBilling ? (
-              <Panel.Content>
-                <div className="space-y-1">
-                  <h5 className="text-sm text-foreground">Disk Usage</h5>
-                  <SparkBar
-                    type="horizontal"
-                    value={databaseSize}
-                    max={maxDiskVolumeSize}
-                    barClass={`${
-                      diskSizeUsageRatio >= 0.9 && !isPaidTier
-                        ? 'bg-red-900'
-                        : diskSizeUsageRatio >= 0.9
-                        ? 'bg-yellow-900'
-                        : 'bg-brand'
-                    }`}
-                    bgClass="bg-gray-300 dark:bg-gray-600"
-                    labelBottom={formatBytes(databaseSize)}
-                    labelTop={usage?.disk_volume_size_gb ? usage?.disk_volume_size_gb + 'GB' : '-'}
-                  />
-                </div>
-
-                {isPaidTier && (
-                  <div className="flex justify-between items-center mt-3">
-                    <div className="flex flex-row space-x-3 text-foreground-light text-sm">
-                      <Badge>Auto-Scaling</Badge>
-                    </div>
-
-                    <Button type="default" icon={<IconExternalLink size={14} strokeWidth={1.5} />}>
-                      <a
-                        target="_blank"
-                        rel="noreferrer"
-                        href="https://supabase.com/docs/guides/platform/database-usage"
-                      >
-                        What is disk size?
-                      </a>
-                    </Button>
-                  </div>
-                )}
-              </Panel.Content>
-            ) : (
-              <Panel.Content>
-                <div className="space-y-1">
-                  <h5 className="text-sm text-foreground">Database size</h5>
-                  <SparkBar
-                    type="horizontal"
-                    value={databaseSize}
-                    max={databaseUsageLimit > 0 ? databaseUsageLimit : Infinity}
-                    barClass={`${
-                      limitIsExceeded
-                        ? 'bg-red-900'
-                        : limitIsApproaching
-                        ? 'bg-yellow-900'
-                        : 'bg-brand'
-                    }`}
-                    bgClass="bg-gray-300 dark:bg-gray-600"
-                    labelBottom={formatBytes(databaseSize)}
-                    labelTop={databaseUsageLimit > 0 ? formatBytes(databaseUsageLimit) : ''}
-                  />
-                </div>
-
-                {isPaidTier && (
-                  <div className="flex justify-between items-center mt-3">
-                    <div className="flex flex-row space-x-3 text-foreground-light text-sm">
-                      {usage?.disk_volume_size_gb && (
-                        <span>Disk Size: {usage.disk_volume_size_gb} GB</span>
-                      )}
-                      <Badge>Auto-Scaling</Badge>
-                    </div>
-
-                    <Button type="default" icon={<IconExternalLink size={14} strokeWidth={1.5} />}>
-                      <a
-                        target="_blank"
-                        rel="noreferrer"
-                        href="https://supabase.com/docs/guides/platform/database-usage"
-                      >
-                        What is disk size?
-                      </a>
-                    </Button>
-                  </div>
-                )}
-              </Panel.Content>
-            )}
-
-            {!orgLevelBilling && (
-              <Panel.Content>
-                <div className="space-y-1">
-                  <h5 className="text-sm text-foreground">Database egress</h5>
-                  <SparkBar
-                    type="horizontal"
-                    value={usage?.db_egress?.usage ?? 0}
-                    max={databaseEgressLimit > 0 ? databaseEgressLimit : Infinity}
-                    barClass={`${
-                      egressIsExceeded
-                        ? 'bg-red-900'
-                        : egressIsApproaching
-                        ? 'bg-yellow-900'
-                        : 'bg-brand'
-                    }`}
-                    bgClass="bg-gray-300 dark:bg-gray-600"
-                    labelBottom={formatBytes(usage?.db_egress?.usage ?? 0)}
-                    labelTop={databaseEgressLimit > 0 ? formatBytes(databaseEgressLimit) : ''}
-                  />
-                </div>
-              </Panel.Content>
-            )}
-
-            {orgLevelBilling && (
-              <Panel.Content>
-                <p className="text-sm text-foreground">
-                  Head to your{' '}
-                  <Link href={`/org/${selectedOrganization?.slug}/usage`}>
-                    <a>
-                      <span className="text-green-900 transition hover:text-green-1000">
-                        organizations usage page
-                      </span>
-                    </a>
-                  </Link>
-                  , to see a breakdown of your entire usage.
-                </p>
-              </Panel.Content>
-            )}
-          </Panel>
-
           <Panel title={<h2>Database health</h2>}>
             <Panel.Content>
               <div className="mb-4 flex items-center space-x-3">
@@ -282,8 +142,110 @@ const DatabaseUsage = observer(() => {
               </div>
             </Panel.Content>
           </Panel>
+
+          <ReportWidget
+            isLoading={report.isLoading}
+            params={report.params.largeObjects}
+            title="Database Size - Large Objects"
+            data={report.data.largeObjects || []}
+            queryType={'db'}
+            resolvedSql={report.largeObjectsSql}
+            renderer={(props) => {
+              return (
+                <div>
+                  <header className="text-sm">Database Size used</header>
+                  <p className="text-xl tracking-wide">{formatBytes(databaseSizeBytes)}</p>
+
+                  {!props.isLoading && props.data.length === 0 && (
+                    <span>No large objects found</span>
+                  )}
+                  {!props.isLoading && props.data.length > 0 && (
+                    <Table
+                      className="space-y-3 mt-4"
+                      head={[
+                        <Table.th key="object" className="py-2">
+                          Object
+                        </Table.th>,
+                        <Table.th key="size" className="py-2">
+                          Size
+                        </Table.th>,
+                      ]}
+                      body={props.data?.map((object) => {
+                        const percentage = (
+                          ((object.table_size as number) / databaseSizeBytes) *
+                          100
+                        ).toFixed(2)
+
+                        return (
+                          <Table.tr key={`${object.schema_name}.${object.relname}`}>
+                            <Table.td>
+                              {object.schema_name}.{object.relname}
+                            </Table.td>
+                            <Table.td>
+                              {formatBytes(object.table_size)} ({percentage}%)
+                            </Table.td>
+                          </Table.tr>
+                        )
+                      })}
+                    />
+                  )}
+                </div>
+              )
+            }}
+            append={() => (
+              <div className="px-6 pb-2">
+                <Alert_Shadcn_ variant="default" className="mt-4">
+                  <AlertDescription_Shadcn_>
+                    <div className="space-y-2">
+                      <p>
+                        New Supabase projects have a database size of ~40-60mb. This space includes
+                        pre-installed extensions, schemas, and default Postgres data. Additional
+                        database size is used when installing extensions, even if those extensions
+                        are inactive.
+                      </p>
+
+                      <Link href="https://supabase.com/docs/guides/platform/database-size#database-space-management" passHref>
+                        <Button asChild type="default" icon={<IconExternalLink />}>
+                          <a target="_blank" rel="noreferrer">
+                            Read about database space
+                          </a>
+                        </Button>
+                      </Link>
+                    </div>
+                  </AlertDescription_Shadcn_>
+                </Alert_Shadcn_>
+              </div>
+            )}
+          />
         </section>
       </div>
     </>
   )
 })
+
+const useDatabaseReport = () => {
+  const { ref: projectRef } = useParams()
+
+  const queryHooks = queriesFactory<keyof typeof PRESET_CONFIG.database.queries>(
+    PRESET_CONFIG.database.queries,
+    projectRef ?? 'default'
+  )
+  const largeObjects = queryHooks.largeObjects() as DbQueryHook
+  const activeHooks = [largeObjects]
+
+  const isLoading = activeHooks.some((hook) => hook.isLoading)
+
+  return {
+    data: {
+      largeObjects: largeObjects.data,
+    },
+    errors: {
+      largeObjects: largeObjects.error,
+    },
+    params: {
+      largeObjects: largeObjects.params,
+    },
+    largeObjectsSql: largeObjects.resolvedSql,
+    isLoading,
+  }
+}

--- a/studio/pages/project/[ref]/reports/database.tsx
+++ b/studio/pages/project/[ref]/reports/database.tsx
@@ -204,7 +204,10 @@ const DatabaseUsage = observer(() => {
                         are inactive.
                       </p>
 
-                      <Link href="https://supabase.com/docs/guides/platform/database-size#database-space-management" passHref>
+                      <Link
+                        href="https://supabase.com/docs/guides/platform/database-size#database-space-management"
+                        passHref
+                      >
                         <Button asChild type="default" icon={<IconExternalLink />}>
                           <a target="_blank" rel="noreferrer">
                             Read about database space


### PR DESCRIPTION
Everything related to database size on the reports page is currently super confusing. We mix multiple concepts (database space / disk size) and throw in usage, limits and project vs org-based billing. Users are pretty confused. On top of that, we were comparing bytes with GB, which lead to something like this:

![image](https://github.com/supabase/supabase/assets/14073399/33bad852-a3a3-4c5a-94ff-aaa63f3ed70e)

As this is the **database report** page, we don't need to mix in the subscription, plan usage etc.

This PR aims to improve the situation by providing more meaningful insights about database space:
* Show top 5 largest objects in database
* Show used database space
* Link to database space docs
* Move panel to the bottom (CPU/RAM/Swap is more important!)
* Refactor to use ReportWidget
* Adds large objects template to SQL templates

![Screenshot 2023-10-18 at 10 38 46](https://github.com/supabase/supabase/assets/14073399/d08d3a50-3e92-4019-b464-35bcb9b9906d)

![Screenshot 2023-10-18 at 10 38 22](https://github.com/supabase/supabase/assets/14073399/29317ec8-7a38-457e-b48c-9f7e21a1cff8)


Database space docs can also be improved greatly (show more ways to find big indexes or tables), go more in-depth, this is out of scope for this PR.
