### PR TITLE
fix: misleading CTA / current billing cycle check

### DIFF
--- a/studio/components/interfaces/BillingV2/Usage/Usage.tsx
+++ b/studio/components/interfaces/BillingV2/Usage/Usage.tsx
@@ -154,6 +154,7 @@ const Usage = () => {
                     options={[...TIME_PERIODS_BILLING, ...TIME_PERIODS_REPORTS]}
                     loading={isLoadingSubscription}
                     currentBillingPeriodStart={subscription?.current_period_start}
+                    currentBillingPeriodEnd={subscription?.current_period_end}
                   />
                 )}
 

--- a/studio/components/interfaces/Organization/Usage/Usage.constants.tsx
+++ b/studio/components/interfaces/Organization/Usage/Usage.constants.tsx
@@ -1,5 +1,6 @@
 import { USAGE_APPROACHING_THRESHOLD } from 'components/interfaces/BillingV2/Billing.constants'
 import { EgressType, PricingMetric } from 'data/analytics/org-daily-stats-query'
+import { OrgSubscription } from 'data/subscriptions/org-subscription-query'
 import { OrgUsageResponse } from 'data/usage/org-usage-query'
 import { Alert } from 'ui'
 
@@ -37,7 +38,7 @@ export interface CategoryAttribute {
   description: string
   chartPrefix?: 'Max' | 'Average'
   chartDescription: string
-  additionalInfo?: (usage?: OrgUsageResponse) => JSX.Element | null
+  additionalInfo?: (subscription?: OrgSubscription, usage?: OrgUsageResponse) => JSX.Element | null
 }
 
 export type CategoryMetaKey = 'bandwidth' | 'sizeCount' | 'activity'
@@ -93,7 +94,7 @@ export const USAGE_CATEGORIES: CategoryMeta[] = [
           },
         ],
         chartDescription: 'The data refreshes every 24 hours.',
-        additionalInfo: (usage?: OrgUsageResponse) => {
+        additionalInfo: (subscription?: OrgSubscription, usage?: OrgUsageResponse) => {
           const usageMeta = usage?.usages.find((x) => x.metric === PricingMetric.DATABASE_SIZE)
           const usageRatio =
             typeof usageMeta !== 'number'
@@ -104,6 +105,8 @@ export const USAGE_CATEGORIES: CategoryMeta[] = [
           const isApproachingLimit = hasLimit && usageRatio >= USAGE_APPROACHING_THRESHOLD
           const isExceededLimit = hasLimit && usageRatio >= 1
           const isCapped = usageMeta?.capped
+
+          const onFreePlan = subscription?.plan?.name === 'Free'
 
           return (
             <div>
@@ -120,7 +123,10 @@ export const USAGE_CATEGORIES: CategoryMeta[] = [
                   <div className="flex w-full items-center flex-col justify-center space-y-2 md:flex-row md:justify-between">
                     <div>
                       When you reach your database size limit, your project can go into read-only
-                      mode. Please upgrade your plan.
+                      mode.{' '}
+                      {onFreePlan
+                        ? 'Please upgrade your plan.'
+                        : 'Disable your spend cap to scale seamlessly and pay for over-usage beyond your plans quota.'}
                     </div>
                   </div>
                 </Alert>

--- a/studio/components/interfaces/Organization/Usage/Usage.tsx
+++ b/studio/components/interfaces/Organization/Usage/Usage.tsx
@@ -63,6 +63,8 @@ const Usage = () => {
     )
   }, [dateRange, subscription])
 
+  console.log({ currentBillingCycleSelected, dateRange, subscription })
+
   const startDate = useMemo(() => {
     // If end date is in future, set end date to now
     if (!dateRange?.period_start?.date) {
@@ -121,6 +123,7 @@ const Usage = () => {
                 options={[...TIME_PERIODS_BILLING, ...TIME_PERIODS_REPORTS]}
                 loading={isLoadingSubscription}
                 currentBillingPeriodStart={subscription?.current_period_start}
+                currentBillingPeriodEnd={subscription?.current_period_end}
               />
 
               <Listbox

--- a/studio/components/interfaces/Organization/Usage/Usage.tsx
+++ b/studio/components/interfaces/Organization/Usage/Usage.tsx
@@ -63,8 +63,6 @@ const Usage = () => {
     )
   }, [dateRange, subscription])
 
-  console.log({ currentBillingCycleSelected, dateRange, subscription })
-
   const startDate = useMemo(() => {
     // If end date is in future, set end date to now
     if (!dateRange?.period_start?.date) {

--- a/studio/components/interfaces/Organization/Usage/UsageSection/AttributeUsage.tsx
+++ b/studio/components/interfaces/Organization/Usage/UsageSection/AttributeUsage.tsx
@@ -227,7 +227,7 @@ const AttributeUsage = ({
                   </div>
                 )}
 
-                {attribute.additionalInfo?.(usage)}
+                {attribute.additionalInfo?.(subscription, usage)}
 
                 <div className="space-y-1">
                   <p className="text-sm">

--- a/studio/components/interfaces/Settings/Infrastructure/InfrastructureActivity.tsx
+++ b/studio/components/interfaces/Settings/Infrastructure/InfrastructureActivity.tsx
@@ -194,6 +194,7 @@ const InfrastructureActivity = () => {
                 options={[...TIME_PERIODS_BILLING, ...TIME_PERIODS_REPORTS]}
                 loading={isLoadingSubscription}
                 currentBillingPeriodStart={subscription?.current_period_start}
+                currentBillingPeriodEnd={subscription?.current_period_end}
               />
               <p className="text-sm text-foreground-light">
                 {dayjs(startDate).format('DD MMM YYYY')} - {dayjs(endDate).format('DD MMM YYYY')}

--- a/studio/components/to-be-cleaned/DateRangePicker.tsx
+++ b/studio/components/to-be-cleaned/DateRangePicker.tsx
@@ -34,6 +34,7 @@ interface DateRangePickerProps {
   }) => void
   options: { key: string; label: string; interval?: string }[]
   currentBillingPeriodStart?: number
+  currentBillingPeriodEnd?: number
 }
 
 const DateRangePicker = ({
@@ -42,6 +43,7 @@ const DateRangePicker = ({
   options,
   loading,
   currentBillingPeriodStart,
+  currentBillingPeriodEnd,
 }: DateRangePickerProps) => {
   const [timePeriod, setTimePeriod] = useState(value)
 
@@ -68,10 +70,7 @@ const DateRangePicker = ({
             time_period: '1d',
           },
           period_end: {
-            date: dayjs
-              .unix(currentBillingPeriodStart ?? 0)
-              .add(1, 'month')
-              .format(DATE_FORMAT),
+            date: dayjs.unix(currentBillingPeriodEnd ?? 0).format(DATE_FORMAT),
             time_period: 'today',
           },
           interval: '1d',


### PR DESCRIPTION
* Correctly tell the user to upgrade plan OR disable spend cap, depending on their subscription
* Pass in subscription end date to correct check if the current billing cycle is selected (previously, we just added 1 month in the date range picker leading to false negatives)