### PR TITLE
fix: default forms to post

### DIFF
--- a/packages/ui/src/components/Form/Form.tsx
+++ b/packages/ui/src/components/Form/Form.tsx
@@ -60,6 +60,7 @@ export default function Form({ validate, ...props }: Props) {
       onSubmit={formik.handleSubmit}
       className={props.className}
       style={props.style}
+      method="POST"
     >
       <FormContextProvider
         values={formik.values}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behaviour?

If a form is submitted before the JS loads (or if the user has JS disabled), the values can end up in the URL.

## What is the new behaviour?

Forms will default to sending a POST request instead, preventing values from ending up in the URL. This shouldn't affect existing behaviour since formik does a `preventDefault()` on the forms once JS takes over.