### PR TITLE
Revert Button change

### DIFF
--- a/apps/www/components/Nav/GitHubButton.tsx
+++ b/apps/www/components/Nav/GitHubButton.tsx
@@ -34,7 +34,7 @@ const GitHubButton = () => {
       type="text"
       asChild
     >
-      <a href="https://github.com/supabase/supabase" target="_blank">
+      <a type={undefined} href="https://github.com/supabase/supabase" target="_blank">
         <span className="flex items-center gap-1">
           <svg
             className="w-6 h-6"

--- a/apps/www/components/Nav/MobileMenu.tsx
+++ b/apps/www/components/Nav/MobileMenu.tsx
@@ -170,12 +170,16 @@ const MobileMenu = ({ open, setOpen, isDarkMode, menu }: Props) => {
             <div className="absolute bottom-0 left-0 right-0 top-auto w-full bg-alternative flex items-stretch p-4 gap-4">
               <Link href="https://supabase.com/dashboard" passHref>
                 <Button block type="default" asChild>
-                  <a className="">Sign in</a>
+                  <a type={undefined} className="">
+                    Sign in
+                  </a>
                 </Button>
               </Link>
               <Link href="https://supabase.com/dashboard" passHref>
                 <Button block asChild>
-                  <a className="h-10 py-4">Start your project</a>
+                  <a type={undefined} className="h-10 py-4">
+                    Start your project
+                  </a>
                 </Button>
               </Link>
             </div>

--- a/apps/www/components/Nav/index.tsx
+++ b/apps/www/components/Nav/index.tsx
@@ -135,19 +135,19 @@ const Nav = () => {
                     {isLoggedIn ? (
                       <Link href="/dashboard/projects" passHref>
                         <Button className="hidden text-white lg:block" asChild>
-                          <a>Dashboard</a>
+                          <a type={undefined}>Dashboard</a>
                         </Button>
                       </Link>
                     ) : (
                       <>
                         <Link href="https://supabase.com/dashboard" passHref>
                           <Button type="default" className="hidden lg:block" asChild>
-                            <a>Sign in</a>
+                            <a type={undefined}>Sign in</a>
                           </Button>
                         </Link>
                         <Link href="https://supabase.com/dashboard" passHref>
                           <Button className="hidden text-white lg:block" asChild>
-                            <a>Start your project</a>
+                            <a type={undefined}>Start your project</a>
                           </Button>
                         </Link>
                       </>

--- a/packages/ui/src/components/Button/Button.tsx
+++ b/packages/ui/src/components/Button/Button.tsx
@@ -162,13 +162,12 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       icon,
       iconRight,
       iconLeft,
-      htmlType,
+      htmlType = 'button',
       ...props
     },
     ref
   ) => {
     const Comp = asChild ? Slot : 'button'
-    const resolvedHtmlType = asChild ? htmlType : 'button'
     const { className, disabled } = props
     const showIcon = loading || icon
     // decrecating 'showIcon' for rightIcon
@@ -179,7 +178,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     return (
       <Comp
         ref={ref}
-        type={resolvedHtmlType}
+        type={htmlType}
         {...props}
         className={cn(buttonVariants({ type, size, disabled, block }), className)}
       >


### PR DESCRIPTION
Revert Button component to previous state.

Note: the occurrences of `type={undefined}` fix a bug that the Button change was supposed to fix, where the buttons with asChild lose styling in Safari.