### PR TITLE
fix: Broken images in changelog

### DIFF
--- a/apps/www/_blog/2023-07-06-supabase-beta-update-june-2023.mdx
+++ b/apps/www/_blog/2023-07-06-supabase-beta-update-june-2023.mdx
@@ -16,7 +16,7 @@ Guess what? We've got some sizzling updates for you this month! Our partnership 
 
 ## Mozilla uses Supabase to build AI Help.
 
-![Mozilla uses Supabase to build AI Help.](https://obuldanrptloktxcffvn.supabase.co/storage/v1/object/public/images/marketing-emails/mdn_search.png)
+![Mozilla uses Supabase to build AI Help.](https://obuldanrptloktxcffvn.supabase.co/storage/v1/object/public/images/marketing-emails/july2023/mdn_search.png)
 
 MDN is one of the richest sources of developer documentation on the internet, and it just received an upgrade. Mozilla built AI Help, an AI chatbot to help with search and discovery. Mozilla chose Supabase Vector and OpenAI to power their new tool which you can try for free.
 
@@ -24,7 +24,7 @@ MDN is one of the richest sources of developer documentation on the internet, an
 
 ## Native Mobile Auth Support for Google and Apple Sign in
 
-![Native Mobile Auth Support for Google and Apple Sign in](https://obuldanrptloktxcffvn.supabase.co/storage/v1/object/public/images/marketing-emails/native-phone-support.png)
+![Native Mobile Auth Support for Google and Apple Sign in](https://obuldanrptloktxcffvn.supabase.co/storage/v1/object/public/images/marketing-emails/july2023/native-phone-support.png)
 
 Supabase Auth now has full native support for Sign in with Apple and Google, which means it can now be used with one-tap sign in methods like Sign in with Apple JS, Sign in with Google for Web, or even in Chrome extensions.
 
@@ -32,7 +32,7 @@ Supabase Auth now has full native support for Sign in with Apple and Google, whi
 
 ## Supabase CLI: what is new?
 
-![Supabase CLI: what is new?](https://obuldanrptloktxcffvn.supabase.co/storage/v1/object/public/images/marketing-emails/supabase-cli-cache-hi.png)
+![Supabase CLI: what is new?](https://obuldanrptloktxcffvn.supabase.co/storage/v1/object/public/images/marketing-emails/july2023/supabase-cli-cache-hi.png)
 
 It’s been a busy month for the Supabase CLI. We have added a tonne of new features:
 
@@ -44,7 +44,7 @@ It’s been a busy month for the Supabase CLI. We have added a tonne of new feat
 
 ## Revamped billing experience
 
-![Revamped billing experience](https://obuldanrptloktxcffvn.supabase.co/storage/v1/object/public/images/marketing-emails/billing.png)
+![Revamped billing experience](https://obuldanrptloktxcffvn.supabase.co/storage/v1/object/public/images/marketing-emails/july2023/billing.png)
 
 We have made huge improvements to the billing tooling inside Supabase Studio, including:
 
@@ -57,7 +57,7 @@ We have made huge improvements to the billing tooling inside Supabase Studio, in
 
 ## Login with Kakao
 
-![Login with Kakao](https://obuldanrptloktxcffvn.supabase.co/storage/v1/object/public/images/marketing-emails/kakao-social-login.png?t=2023-07-06T13%3A26%3A11.108Z)
+![Login with Kakao](https://obuldanrptloktxcffvn.supabase.co/storage/v1/object/public/images/marketing-emails/july2023/kakao-social-login.png?t=2023-07-06T13%3A26%3A11.108Z)
 
 Added the popular social platform Kakao as new social provider. Allow your users to effortlessly sign in using their Kakao accounts and make authentication a breeze while expanding your app's reach to a wider audience.
 
@@ -79,7 +79,7 @@ Added the popular social platform Kakao as new social provider. Allow your users
 
 ## Extended Community Highlights
 
-![Some of the faces from the community](https://obuldanrptloktxcffvn.supabase.co/storage/v1/object/public/images/marketing-emails/flutter_auth.png)
+![Some of the faces from the community](https://obuldanrptloktxcffvn.supabase.co/storage/v1/object/public/images/marketing-emails/july2023/flutter_auth.png)
 
 - Using Supabase with Cloudflare Workers. [Cloudflare TV](https://cloudflare.tv/event/using-supabase-with-cloudflare-workers/dgM90RgD)
 - Build a Chatbot with Next.js, LangChain, OpenAI, and Supabase Vector. [Video Tutorial](https://www.youtube.com/watch?v=Tt45NrVIBn8)
@@ -102,8 +102,8 @@ Come join one of the fastest-growing open source projects ever:
 
 ## ⚠️ Baking hot meme zone ⚠️
 
-![Our favorite meme from June 2023](https://obuldanrptloktxcffvn.supabase.co/storage/v1/object/public/images/marketing-emails/beta-update-june-2023-meme.png)
+![Our favorite meme from June 2023](https://obuldanrptloktxcffvn.supabase.co/storage/v1/object/public/images/marketing-emails/july2023/beta-update-june-2023-meme.png)
 
 ## Launch Week alert: save the date
 
-![Launch Week 8 is announced - From Monday 07/08 till Friday 11/08](https://obuldanrptloktxcffvn.supabase.co/storage/v1/object/public/images/marketing-emails/lw8-teaser.jpg)
+![Launch Week 8 is announced - From Monday 07/08 till Friday 11/08](https://obuldanrptloktxcffvn.supabase.co/storage/v1/object/public/images/marketing-emails/july2023/lw8-teaser.jpg)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes: #18062 

Edit 1:
This commit fixes broken images in "blog/supabase-beta-update-june-2023" page.

Before
![Screenshot from 2023-10-10 11-49-30](https://github.com/supabase/supabase/assets/71846487/5ce00225-2c9d-4ccc-bdc7-0c89276f2e45)

After
![Screenshot from 2023-10-10 11-49-44](https://github.com/supabase/supabase/assets/71846487/aa888ce0-ad6d-46f0-aa1c-3d3a8f8a9c1f)


Edit 2:
For Broken images in "changelog" page the data is coming from ```https://api.github.com/repos/supabase/supabase/releases```