### PR TITLE
fix: users reload button show spinner

### DIFF
--- a/studio/components/interfaces/Auth/Users/Users.tsx
+++ b/studio/components/interfaces/Auth/Users/Users.tsx
@@ -20,7 +20,7 @@ const Users = () => {
   const [filterKeywords, setFilterKeywords] = useState('')
   const [filterVerified, setFilterVerified] = useState<'verified' | 'unverified'>()
 
-  const { data, isLoading, isSuccess, refetch } = useUsersQuery({
+  const { data, isLoading, isSuccess, refetch, isRefetching } = useUsersQuery({
     projectRef,
     page,
     keywords: filterKeywords,
@@ -101,7 +101,7 @@ const Users = () => {
             size="tiny"
             icon={<IconRefreshCw />}
             type="default"
-            loading={isLoading}
+            loading={isLoading || isRefetching}
             onClick={() => refetch()}
           >
             Reload


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behaviour?

There is no feedback when clicking reload
<img width="284" alt="Screenshot 2023-10-10 at 15 02 31" src="https://github.com/supabase/supabase/assets/10985857/6d667c57-b0cf-4189-bd52-7423043e1ee5">

## What is the new behaviour?

The opposite of that ^