### PR TITLE
feat: auto-redirect to base path if set

### DIFF
--- a/studio/next.config.js
+++ b/studio/next.config.js
@@ -177,6 +177,16 @@ const nextConfig = {
         destination: '/project/:ref/sql/new',
         permanent: true,
       },
+      ...(process.env.NEXT_PUBLIC_BASE_PATH?.length
+        ? [
+            {
+              source: '/',
+              destination: process.env.NEXT_PUBLIC_BASE_PATH,
+              basePath: false,
+              permanent: true,
+            },
+          ]
+        : []),
     ]
   },
   async headers() {


### PR DESCRIPTION
When going to `/` and a base path is set to i.e. `/dashboard`, next will automatically redirect to it.