### PR TITLE
Docs: Update local dev guide to use correct db sync command

### DIFF
--- a/apps/docs/pages/guides/cli/local-development.mdx
+++ b/apps/docs/pages/guides/cli/local-development.mdx
@@ -365,12 +365,12 @@ Associate your project with your remote project using [`supabase link`](/docs/re
 supabase link --project-ref <project-id>
 # You can get <project-id> from your project's dashboard URL: https://supabase.com/dashboard/project/<project-id>
 
-supabase db pull
+supabase db remote commit
 # Capture any changes that you have made to your remote database before you went through the steps above
 # If you have not made any changes to the remote database, skip this step
 ```
 
-`supabase/migrations` is now populated with a migration in `<timestamp>_remote_schema.sql`.
+`supabase/migrations` is now populated with a migration in `<timestamp>_remote_commit.sql`.
 This migration captures any changes required for your local database to match the schema of your remote Supabase project.
 
 <Admonition type="note">


### PR DESCRIPTION
Docs show CLI command that no longer exists

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

Docs currently instruct users to use `supabase db pull` which isn't a valid command in order to receive their existing supabase db schema when linking their local environment. It appears the correct usage is to use `supabase db remote commit`

## What is the new behavior?

Use `supabase db remote commit`
