### PR TITLE
docs: fix redundant package installation in documentation

### DIFF
--- a/apps/docs/pages/guides/getting-started/tutorials/with-sveltekit.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-sveltekit.mdx
@@ -55,7 +55,7 @@ It can be challenging to authenticate your users in all these different environm
 Install the auth helpers for SvelteKit:
 
 ```bash
-npm install @supabase/auth-helpers-sveltekit @supabase/supabase-js
+npm install @supabase/auth-helpers-sveltekit
 ```
 
 Add the code below to your `src/hooks.server.ts` to initialize the client on the server:


### PR DESCRIPTION
Removed the instruction to install `@supabase/supabase-js` a second time. The package was previously installed and doesn't need to be installed again, simplifying the installation steps for users.
