### PR TITLE
chore: Remove MFA_ENABLED env var from docker-compose.yml

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -132,7 +132,6 @@ services:
 
       GOTRUE_EXTERNAL_PHONE_ENABLED: ${ENABLE_PHONE_SIGNUP}
       GOTRUE_SMS_AUTOCONFIRM: ${ENABLE_PHONE_AUTOCONFIRM}
-      MFA_ENABLED: ${MFA_ENABLED}
 
   rest:
     container_name: supabase-rest


### PR DESCRIPTION
MFA_ENABLED is not used in the `supabase/gotrue` used in this Docker compose file anymore.
This change fixes an immediate warning when trying to run docker containers.

```
WARN[0000] The "MFA_ENABLED" variable is not set. Defaulting to a blank string.
```