### PR TITLE
docs: Update host for postgres command in self-hosted

### DIFF
--- a/apps/docs/pages/guides/self-hosting/docker.mdx
+++ b/apps/docs/pages/guides/self-hosting/docker.mdx
@@ -72,7 +72,7 @@ You can add new Functions as `volumes/functions/<FUNCTION_NAME>/index.ts`. Resta
 You can connect to the Postgres database locally on port `5432`. For example, if you have `psql` on your local machine you can run:
 
 ```bash
-psql -h localhost -p 5432 -d postgres -U postgres
+psql -h 127.0.0.1 -p 5432 -d postgres -U postgres
 ```
 
 The default password is `your-super-secret-and-long-postgres-password`. You should change this as soon as possible using the [instructions below](#update-secrets). By default the database is not accessible from outside the local machine. You can [change this](#exposing-your-postgres-database) by updating the `docker-compose.yml` file.


### PR DESCRIPTION
Using `localhost` on systems that by default resolve to IPv6 will fail with

```
psql: error: connection to server at "localhost" (::1), port 5432 failed: FATAL:  role "postgres" does not exist
```

it's more "builetproof" to use the address directly instead.