### PR TITLE
fix: org dropdown with two orgs with same name

### DIFF
--- a/studio/components/layouts/AppLayout/OrganizationDropdown.tsx
+++ b/studio/components/layouts/AppLayout/OrganizationDropdown.tsx
@@ -83,7 +83,7 @@ const OrganizationDropdown = ({ isNewNav = false }: OrganizationDropdownProps) =
                       <Link passHref href={href} key={org.slug}>
                         <CommandItem_Shadcn_
                           asChild
-                          value={org.name}
+                          value={`${org.name} - ${org.slug}`}
                           className="cursor-pointer w-full flex items-center justify-between"
                           onSelect={() => {
                             setOpen(false)


### PR DESCRIPTION
Previously when you had two orgs with the same name (can also have different casing), it would highlight both:

![Screenshot 2023-10-12 at 14 05 14](https://github.com/supabase/supabase/assets/14073399/7abab59e-4b3c-4246-88db-ccf33d0b0049)

PR fixes it - `value` property is used for hover effect but also for searching. It needs to be unique but also contain the name to be searchable:

![Screenshot 2023-10-12 at 14 05 50](https://github.com/supabase/supabase/assets/14073399/7783edb5-889a-4eca-b6ae-494d72133f1b)
