### PR TITLE
Docs: Temp remove realtime mention in python ref docs

### DIFF
--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.utils.ts
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.utils.ts
@@ -17,12 +17,18 @@ export function deepFilterSections<T extends ICommonItem>(
         section.type === 'markdown' ||
         specFunctionIds.includes(section.id)
     )
-    .map((section) => {
+    .flatMap((section) => {
       if ('items' in section) {
-        return {
-          ...section,
-          items: deepFilterSections(section.items, specFunctionIds),
+        const items = deepFilterSections(section.items, specFunctionIds)
+
+        if (items.length > 0) {
+          return {
+            ...section,
+            items,
+          }
         }
+
+        return []
       }
       return section
     })

--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.utils.ts
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.utils.ts
@@ -21,6 +21,7 @@ export function deepFilterSections<T extends ICommonItem>(
       if ('items' in section) {
         const items = deepFilterSections(section.items, specFunctionIds)
 
+        // Only include this category (heading) if it has subitems
         if (items.length > 0) {
           return {
             ...section,

--- a/spec/supabase_py_v2.yml
+++ b/spec/supabase_py_v2.yml
@@ -1988,7 +1988,3 @@ functions:
           ```
           res = supabase.storage.from_('bucket_name').list()
           ```
-  - id: subscribe
-    title: on().subscribe()
-    notes: |
-      - We are implementing this feature at the moment. If you have queries feel free to open an issue on the [realtime-py](https://github.com/supabase-community/realtime-py) repository.


### PR DESCRIPTION
Temporarily remove mention of realtime within the Python reference docs until it is implemented.

![image](https://github.com/supabase/supabase/assets/4133076/3d2dc0a5-7b96-4972-9e55-42ae01aa37e8)
