### PR TITLE
feat(hooks): update default edge function url

### DIFF
--- a/studio/components/interfaces/Database/Hooks/EditHookPanel.tsx
+++ b/studio/components/interfaces/Database/Hooks/EditHookPanel.tsx
@@ -96,7 +96,8 @@ const EditHookPanel = ({ visible, selectedHook, onClose }: EditHookPanelProps) =
   const restUrlTld = new URL(restUrl as string).hostname.split('.').pop()
 
   const isEdgeFunction = (url: string) =>
-    url.includes(`https://${ref}.functions.supabase.${restUrlTld}/`)
+    url.includes(`https://${ref}.functions.supabase.${restUrlTld}/`) ||
+    url.includes(`https://${ref}.supabase.${restUrlTld}/functions/`)
 
   const initialValues = {
     name: selectedHook?.name ?? '',
@@ -397,7 +398,7 @@ const FormContents = ({
       }
     } else if (values.function_type === 'supabase_function') {
       const fnSlug = (functions ?? [])[0]?.slug
-      const defaultFunctionUrl = `https://${projectRef}.functions.supabase.${restUrlTld}/${fnSlug}`
+      const defaultFunctionUrl = `https://${projectRef}.supabase.${restUrlTld}/functions/v1/${fnSlug}`
       const updatedValues = {
         ...values,
         http_url: isEdgeFunction(values.http_url) ? values.http_url : defaultFunctionUrl,

--- a/studio/components/interfaces/Database/Hooks/HTTPRequestFields.tsx
+++ b/studio/components/interfaces/Database/Hooks/HTTPRequestFields.tsx
@@ -107,7 +107,7 @@ const HTTPRequestFields = ({
               {edgeFunctions.map((fn) => {
                 const restUrl = selectedProject?.restUrl
                 const restUrlTld = new URL(restUrl as string).hostname.split('.').pop()
-                const functionUrl = `https://${ref}.functions.supabase.${restUrlTld}/${fn.slug}`
+                const functionUrl = `https://${ref}.supabase.${restUrlTld}/functions/v1/${fn.slug}`
 
                 return (
                   <Listbox.Option key={fn.id} id={functionUrl} value={functionUrl} label={fn.name}>

--- a/studio/components/interfaces/Database/Hooks/HooksList/HookList.tsx
+++ b/studio/components/interfaces/Database/Hooks/HooksList/HookList.tsx
@@ -52,7 +52,8 @@ const HookList = ({ schema, filterString, editHook = noop, deleteHook = noop }: 
     <>
       {filteredHooks.map((x: any) => {
         const isEdgeFunction = (url: string) =>
-          url.includes(`https://${ref}.functions.supabase.${restUrlTld}/`)
+          url.includes(`https://${ref}.functions.supabase.${restUrlTld}/`) ||
+          url.includes(`https://${ref}.supabase.${restUrlTld}/functions/`)
         const [url, method] = x.function_args
 
         return (


### PR DESCRIPTION
Currently when you create a webhook through the dashboard, it uses the old subdomain-based functions URL in the format:

`https://<project-ref>.functions.supabase.co/<function-name>`

This updates the URL format to be path-based:

`https://<project-ref>.supabase.co/functions/v1/<function-name>`

while also providing backwards compatibility with old webhooks that use the original URL format.