### PR TITLE
Docs update: Improved the clarity of the deep-link set up

### DIFF
--- a/apps/docs/pages/guides/getting-started/tutorials/with-flutter.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-flutter.mdx
@@ -46,7 +46,7 @@ Now that we have the dependencies installed let's setup deep links.
 Setting up deep links is required to bring back the user to the app when they click on the magic link to sign in.
 We can setup deep links with just a minor tweak on our Flutter application.
 
-We will use `io.supabase.flutterquickstart` as the scheme, and `login-callback` as the host for our deep link in this example, but you can change it to whatever you would like.
+We will use `io.supabase.flutterquickstart` as the scheme, and `login-callback` as the host for our deep link in this example, but you can change it to whatever you would like, it just needs to match the `applicationId` defined in your app at `android/app/build.gradle`.
 
 First, add `io.supabase.flutterquickstart://login-callback/` as a new [redirect URL](https://supabase.com/dashboard/project/_/auth/url-configuration) in the Dashboard.
 


### PR DESCRIPTION
In the initial documentation, it says we can choose any value we would like for the scheme, but it needs to be the exact same as the applicationId to work. (I got stuck on that error for a long time).

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

Initial document can lead to errors and miscomprehensions.

## What is the new behavior?

Now, it's clearer for the user what value he can choose.
