### PR TITLE
docs: Fix grammatical errors in the function secrets guide

### DIFF
--- a/apps/docs/pages/guides/functions/secrets.mdx
+++ b/apps/docs/pages/guides/functions/secrets.mdx
@@ -14,7 +14,7 @@ Deno.env.get(MY_SECRET_NAME)
 
 ### Local Development
 
-When developing functions locally, you be able to load environment variables two ways:
+When developing functions locally, you will be able to load environment variables in two ways:
 
 1. Through a default `.env` file placed at `supabase/functions/.env`, which will get loaded on `supabase start`
 2. Through the `--env-file` option for `supabase functions serve`, for example: `supabase functions serve --env-file ./path/to/.env-file`


### PR DESCRIPTION
## What kind of change does this PR introduce?

It fixes two grammatical errors in the doc for secrets under the functions guide.

## What is the current behavior?

The text currently is: `you be able to load environment variables two ways `(https://supabase.com/docs/guides/functions/secrets#local-development)

## What is the new behavior?

I changed it to: `you will be able to load environment variables in two ways`