### PR TITLE
fix: handle round numbers for github button

### DIFF
--- a/apps/www/components/Nav/GitHubButton.tsx
+++ b/apps/www/components/Nav/GitHubButton.tsx
@@ -8,7 +8,7 @@ const GitHubButton = () => {
 
   const kFormatter = (num: number) => {
     const kFormat = num / 1000
-    const decimals = kFormat.toString().split('.')[1]
+    const decimals = kFormat.toFixed(2).split('.')[1]
     const firstDecimal = decimals.split('')[0]
     const showDecimals = firstDecimal !== '0'
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Number was perfectly 58000 and errored out. Handles for this now