### PR TITLE
fix: update realtime code to v2 on realtime overview page

### DIFF
--- a/apps/docs/pages/guides/realtime.mdx
+++ b/apps/docs/pages/guides/realtime.mdx
@@ -64,7 +64,10 @@ const handleInserts = (payload) => {
 }
 
 // Listen to inserts
-const { data: todos, error } = await supabase.from('todos').on('INSERT', handleInserts).subscribe()
+supabase
+  .channel('todos')
+  .on('postgres_changes', { event: 'INSERT', schema: 'public', table: 'todos' }, handleInserts)
+  .subscribe()
 ```
 
 Use [subscribe()](/docs/reference/javascript/subscribe) to listen to database changes.


### PR DESCRIPTION
## What kind of change does this PR introduce?

There were some leftover v1 code on the realtime overview page. This PR updates the code to the v2 one.