### PR TITLE
Remove text about Superuser roles (since we don't support it)

### DIFF
--- a/apps/docs/pages/guides/database/postgres/roles.mdx
+++ b/apps/docs/pages/guides/database/postgres/roles.mdx
@@ -13,10 +13,6 @@ Postgres manages database access permissions using the concept of roles. General
 
 In PostgreSQL, roles can function as users or groups of users. Users are roles with login privileges, while groups (also known as role groups) are roles that don't have login privileges but can be used to manage permissions for multiple users.
 
-## Superuser roles
-
-The superuser role has unrestricted access to the database system. Typically these roles will be able to bypass all security measures (like Row Level Security). Be cautious when granting superuser privileges as it can potentially lead to security risks.
-
 ## Creating roles
 
 You can create a role using the `create role` command:


### PR DESCRIPTION
I'm proposing we remove this block entirely since we do not allow Superuser access at all anymore (so this might be confusing for people if we left it in):

## Superuser roles

The superuser role has unrestricted access to the database system. Typically these roles will be able to bypass all security measures (like Row Level Security). Be cautious when granting superuser privileges as it can potentially lead to security risks.

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
