### PR TITLE
Fix: auth phone provider docs

### DIFF
--- a/apps/docs/pages/guides/auth/phone-login/messagebird.mdx
+++ b/apps/docs/pages/guides/auth/phone-login/messagebird.mdx
@@ -49,13 +49,11 @@ You will need the following values to get started:
 - Live API Key / Test API Key
 - MessageBird originator
 
-Now go to the Auth > Settings page in the Supabase dashboard (https://supabase.com/dashboard/project/YOUR-PROJECT-REF/auth/settings).
+Now go to the [Auth > Providers](https://supabase.com/dashboard/project/_/auth/providers) page in the Supabase dashboard and select "Phone" from the Auth Providers list.
 
-You should see an option to enable Phone Signup.
+You should see an option to enable the Phone provider.
 
-![Enable Phone Sign-Up](/docs/img/guides/auth-twilio/7.png)
-
-Toggle it on, and copy the 2 values over from the messagebird dashboard. Click save.
+Toggle it on, and copy the 2 values over from the Messagebird dashboard. Click save.
 
 Note: If you use the Test API Key, the OTP will not be delivered to the mobile number specified but messagebird will log the response in the dashboard.
 If the Live API Key is used instead, the OTP will be delivered and there will be a deduction in your free credits.
@@ -68,7 +66,7 @@ Now the backend should be setup, we can proceed to add our client-side code!
 
 The SMS message sent to a phone containing an OTP code can be customized. This is useful if you need to mention a brand name or display a website address.
 
-Go to Auth > Templates page in the Supabase dashboard (https://supabase.com/dashboard/project/YOUR-PROJECT-REF/auth/templates).
+Go to [Auth > Templates](https://supabase.com/dashboard/project/_/auth/templates) page in the Supabase dashboard.
 
 Use the variable `.Code` in the template to display the code.
 

--- a/apps/docs/pages/guides/auth/phone-login/twilio.mdx
+++ b/apps/docs/pages/guides/auth/phone-login/twilio.mdx
@@ -94,13 +94,11 @@ You should now be able to see all three values you'll need to get started:
 
 ![All the credentials you'll need](/docs/img/guides/auth-twilio/6.png)
 
-Now go to the Auth > Providers page in the Supabase dashboard and select "Phone" from the Auth Providers list (https://supabase.com/dashboard/project/_/auth/providers).
+Now go to the [Auth > Providers](https://supabase.com/dashboard/project/_/auth/providers) page in the Supabase dashboard and select "Phone" from the Auth Providers list.
 
-You should see an option to enable Phone Signup:
+You should see an option to enable the Phone provider.
 
-![Enable Phone Sign-Up](/docs/img/guides/auth-twilio/7.png)
-
-Toggle it on, and copy the 3 values over from the twilio dashboard. Click save.
+Toggle it on, and copy the 3 values over from the Twilio dashboard. Click save.
 
 Note: for "Twilio Message Service SID" you can use the Sender Phone Number generated above.
 
@@ -112,7 +110,7 @@ Now the backend should be setup, we can proceed to add our client-side code!
 
 The SMS message sent to a phone containing an OTP code can be customized. This is useful if you need to mention a brand name or display a website address.
 
-Go to Auth > Providers page (under "Configuration") in the Supabase dashboard and select "Phone" from the Auth Providers list (https://supabase.com/dashboard/project/_/auth/providers). Scroll to the very bottom of the "Phone" section to the "SMS Message" input - you can customize the SMS message here.
+Go to the [Auth > Providers](https://supabase.com/dashboard/project/_/auth/providers) page in the Supabase dashboard and select "Phone" from the Auth Providers list. Scroll to the very bottom of the "Phone" section to the "SMS Message" input - you can customize the SMS message here.
 
 Use the variable `.Code` in the template to display the OTP code. Here's an example in the SMS template.
 

--- a/apps/docs/pages/guides/auth/phone-login/vonage.mdx
+++ b/apps/docs/pages/guides/auth/phone-login/vonage.mdx
@@ -49,11 +49,11 @@ Select the country you want a number for. You will need a mobile phone number wi
 
 ### Configure Supabase
 
-Now go to the Auth > Settings page in the Supabase dashboard (https://supabase.com/dashboard/project/YOUR-PROJECT-REF/auth/settings).
+Now go to the [Auth > Providers](https://supabase.com/dashboard/project/_/auth/providers) page in the Supabase dashboard and select "Phone" from the Auth Providers list.
 
-You should see an option to enable Phone Signup.
+You should see an option to enable the Phone provider.
 
-Toggle it on, and copy the api key, api secret and phone number values over from the Vonage dashboard. Click save.
+Toggle it on, and copy the API key, API secret and phone number values over from the Vonage dashboard. Click save.
 
 Now the backend should be setup, we can proceed to add our client-side code!
 
@@ -61,7 +61,7 @@ Now the backend should be setup, we can proceed to add our client-side code!
 
 The SMS message sent to a phone containing an OTP code can be customized. This is useful if you need to mention a brand name or display a website address.
 
-Go to Auth > Templates page in the Supabase dashboard (https://supabase.com/dashboard/project/YOUR-PROJECT-REF/auth/templates).
+Go to [Auth > Templates](https://supabase.com/dashboard/project/_/auth/templates) page in the Supabase dashboard.
 
 Use the variable `.Code` in the template to display the code.
 


### PR DESCRIPTION
The auth phone provider docs reference old non-existent pages in the dashboard:

![image](https://github.com/supabase/supabase/assets/4133076/9746620c-c61a-4e4c-9a92-fba3900667c1)

Fixes docs to point to the right place.