### PR TITLE
fix: do not warn about navigator lock when not used

### DIFF
--- a/packages/common/gotrue.ts
+++ b/packages/common/gotrue.ts
@@ -17,13 +17,13 @@ const persistedDebug =
   process.env.NEXT_PUBLIC_IS_PLATFORM === 'true' &&
   globalThis?.localStorage?.getItem(AUTH_DEBUG_PERSISTED_KEY) === 'true'
 
-const navigatorLockEnabled = !!(
+const shouldEnableNavigatorLock =
   process.env.NEXT_PUBLIC_IS_PLATFORM === 'true' &&
-  !(globalThis?.localStorage?.getItem(AUTH_NAVIGATOR_LOCK_DISABLED_KEY) === 'true') &&
-  globalThis?.navigator?.locks
-)
+  !(globalThis?.localStorage?.getItem(AUTH_NAVIGATOR_LOCK_DISABLED_KEY) === 'true')
 
-if (!globalThis?.navigator?.locks) {
+const navigatorLockEnabled = !!(shouldEnableNavigatorLock && globalThis?.navigator?.locks)
+
+if (shouldEnableNavigatorLock && !globalThis?.navigator?.locks) {
   console.warn('This browser does not support the Navigator Locks API. Please update it.')
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

follow up https://github.com/supabase/supabase/pull/16212

## What is the current behavior?

`navigator.lock` is not implemented for nodejs. Currently any module which imports `packages/common/gotrue.ts` will emit this warning because it is being checked at global scope. This causes confusion https://github.com/supabase/supabase/issues/17630

## What is the new behavior?

Only emit this warning if navigator lock should be enabled, ie. in browser environments.

## Additional context

Add any other context or screenshots.
