### PR TITLE
chore: remove duplicate build

### DIFF
--- a/.github/workflows/studio-tests.yml
+++ b/.github/workflows/studio-tests.yml
@@ -30,7 +30,6 @@ jobs:
         node-version: [18.x]
         cmd:
           - npm run test:studio
-          - npm run build:studio
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -12,7 +12,8 @@ concurrency:
 
 jobs:
   typecheck:
-    runs-on: ubuntu-latest
+    # Uses larger hosted runner as it significantly decreases build times
+    runs-on: [larger-runner-4cpu]
 
     strategy:
       matrix:


### PR DESCRIPTION
We are already type-checking the entire code base in a separate job, so we can remove the build on GH.

Also uses larger runner for type-check to speed it up
