### PR TITLE
misc: Add project name to docker-compose.yml

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -5,9 +5,8 @@
 #   Destroy:        docker compose -f docker-compose.yml -f ./dev/docker-compose.dev.yml down -v --remove-orphans
 
 version: "3.8"
-
+name: "supabase"
 services:
-
   studio:
     container_name: supabase-studio
     image: supabase/studio:20230921-d657f29


### PR DESCRIPTION
This makes any project listing display a nice stack of containers under `supabase` namespace instead of default `docker` name. Useful when running multiple containers on the same machine.

Note that this can be also achieved with `docker compose up -p supabase` or `--project-name`.

<img width="278" alt="image" src="https://github.com/supabase/supabase/assets/1523305/e27413cd-72cc-4b64-a830-8d004accfa63">