### PR TITLE
feat: add UI to configure skip nonce check for Google

### DIFF
--- a/studio/stores/authConfig/schema/AuthProviders/AuthProvidersFormValidation.tsx
+++ b/studio/stores/authConfig/schema/AuthProviders/AuthProvidersFormValidation.tsx
@@ -850,6 +850,12 @@ const EXTERNAL_PROVIDER_GOOGLE = {
         'Comma separated list of client IDs of Android apps, One Tap or Chrome extensions that are allowed to log in to your project.',
       type: 'string',
     },
+    EXTERNAL_GOOGLE_SKIP_NONCE_CHECK: {
+      title: 'Skip nonce checks',
+      description:
+        "Allows ID tokens with any nonce to be accepted, which is less secure. Useful in situations where you don't have access to the nonce used to issue the ID token, such with iOS.",
+      type: 'boolean',
+    },
   },
   validationSchema: object().shape({
     EXTERNAL_GOOGLE_ENABLED: boolean().required(),
@@ -910,6 +916,7 @@ const EXTERNAL_PROVIDER_GOOGLE = {
             'At least one Authorized Client ID is required when not using the OAuth flow.'
           ),
       }),
+    EXTERNAL_GOOGLE_SKIP_NONCE_CHECK: boolean(),
   }),
   misc: {
     iconKey: 'google-icon',


### PR DESCRIPTION
Adds the UI option to skip nonce checks for Google ID tokens. Useful in React Native for iOS.

Preview:

<img width="870" alt="image" src="https://github.com/supabase/supabase/assets/295870/ff39d855-db87-4cee-a656-185cb6553374">
