### PR TITLE
Fix the projects dropdown in the Org Audit Logs

### DIFF
--- a/studio/components/interfaces/Organization/AuditLogs/AuditLogs.tsx
+++ b/studio/components/interfaces/Organization/AuditLogs/AuditLogs.tsx
@@ -121,6 +121,8 @@ const AuditLogs = () => {
       }
     })
 
+  const currentOrganization = organizations?.find((o) => o.slug === slug)
+
   return (
     <>
       <ScaffoldContainerLegacy>
@@ -138,7 +140,9 @@ const AuditLogs = () => {
               />
               <FilterPopover
                 name="Projects"
-                options={projects ?? []}
+                options={
+                  projects?.filter((p) => p.organization_id === currentOrganization?.id) ?? []
+                }
                 labelKey="name"
                 valueKey="ref"
                 activeOptions={filters.projects}


### PR DESCRIPTION
In the Org Audit Logs, the projects filter used to show all projects that the user has access to. This is wrong because you should be able to filter the audit logs only by the projects in that particular organization.