### PR TITLE
fix: When inserting a row, default value on optional fields was not working

### DIFF
--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.utils.ts
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.utils.ts
@@ -1,16 +1,16 @@
-import dayjs from 'dayjs'
-import { find, isUndefined, compact, isEqual, omitBy, isNull, isString } from 'lodash'
-import { Dictionary } from 'components/grid'
 import type { PostgresTable } from '@supabase/postgres-meta'
+import { Dictionary } from 'components/grid'
+import dayjs from 'dayjs'
+import { compact, find, isEqual, isNull, isString, isUndefined, omitBy } from 'lodash'
 
 import { minifyJSON, tryParseJson } from 'lib/helpers'
-import { RowField } from './RowEditor.types'
 import {
   DATETIME_TYPES,
-  TIME_TYPES,
-  TIMESTAMP_TYPES,
   TEXT_TYPES,
+  TIMESTAMP_TYPES,
+  TIME_TYPES,
 } from '../SidePanelEditor.constants'
+import { RowField } from './RowEditor.types'
 
 export const generateRowFields = (
   row: Dictionary<any> | undefined,
@@ -188,17 +188,7 @@ export const generateRowObjectFromFields = (
       rowObject[field.name] = value
     }
   })
-  if (includeNullProperties) {
-    return rowObject
-  } else {
-    return omitBy(rowObject, (v, k) => {
-      const field = fields.find((f) => f.name === k)
-      if (field && field.isNullable) {
-        return false
-      }
-      return isNull(v)
-    })
-  }
+  return includeNullProperties ? rowObject : omitBy(rowObject, isNull)
 }
 
 export const generateUpdateRowPayload = (originalRow: any, field: RowField[]) => {

--- a/studio/tests/components/Editor/RowEditor.utils.test.js
+++ b/studio/tests/components/Editor/RowEditor.utils.test.js
@@ -1,4 +1,7 @@
-import { parseValue } from 'components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.utils'
+import {
+  generateRowObjectFromFields,
+  parseValue,
+} from 'components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.utils'
 
 describe('parseValue', () => {
   it('should return null when originalValue is null', () => {
@@ -90,5 +93,57 @@ describe('parseValue', () => {
       throw new Error('Mocked error')
     })
     expect(parseValue(originalValue, format)).toEqual(originalValue)
+  })
+})
+
+describe('generateRowObjectFromFields', () => {
+  it('should not force NULL values', () => {
+    const sampleRowFields = [
+      { id: '1', name: 'id', value: '', comment: '', defaultValue: null, format: 'int8' },
+      {
+        id: '2',
+        name: 'time_not_null',
+        value: '',
+        comment: '',
+        defaultValue: 'now()',
+        format: 'timestamptz',
+        isNullable: false, // [Joshen] technically this method doesnt even check this property
+      },
+      {
+        id: '3',
+        name: 'time_nullable',
+        value: '',
+        comment: '',
+        defaultValue: 'now()',
+        format: 'timestamptz',
+        isNullable: true,
+      },
+    ]
+    const result = generateRowObjectFromFields(sampleRowFields)
+    expect(result).toEqual({})
+  })
+  it('should discern EMPTY values for text', () => {
+    const sampleRowFields = [
+      { id: '1', name: 'id', value: '', comment: '', defaultValue: null, format: 'int8' },
+      { id: '2', name: 'name', value: '', comment: '', defaultValue: null, format: 'text' },
+    ]
+    const result = generateRowObjectFromFields(sampleRowFields)
+    expect(result).toEqual({ name: '' })
+  })
+  it('should discern NULL values for text', () => {
+    const sampleRowFields = [
+      { id: '1', name: 'id', value: '', comment: '', defaultValue: null, format: 'int8' },
+      { id: '2', name: 'name', value: null, comment: '', defaultValue: null, format: 'text' },
+    ]
+    const result = generateRowObjectFromFields(sampleRowFields)
+    expect(result).toEqual({})
+  })
+  it('should discern NULL values for booleans', () => {
+    const sampleRowFields = [
+      { id: '1', name: 'id', value: '', comment: '', defaultValue: null, format: 'int8' },
+      { id: '2', name: 'bool-test', value: null, comment: '', defaultValue: null, format: 'bool' },
+    ]
+    const result = generateRowObjectFromFields(sampleRowFields)
+    expect(result).toEqual({})
   })
 })


### PR DESCRIPTION
This PR fixes https://github.com/supabase/supabase/issues/18316. It reverts the second half of https://github.com/supabase/supabase/pull/17844. The solution didn't trigger the default value routine in Postgres because `NULL` was sent for the optional fields.

Unfortunately, a solution is not possible where the user can do both:
- change the value of a field in a newly inserted row from the default value to `NULL`
- leave the value of a field in newly inserted row so that it can be filled out by DB.

The second feature is more important so the first one will be left out as a limitation. To solve this, the UI has to be changed so that the user intention is clear.