### PR TITLE
Fix: Hide function doc link for triggers

### DIFF
--- a/studio/components/interfaces/Database/Functions/FunctionsList/FunctionList.tsx
+++ b/studio/components/interfaces/Database/Functions/FunctionsList/FunctionList.tsx
@@ -44,7 +44,6 @@ const FunctionList = ({
     includes(x.name.toLowerCase(), filterString.toLowerCase())
   )
   const _functions = filteredFunctions.filter((x) => x.schema == schema)
-  const isApiDocumentAvailable = schema == 'public'
   const projectRef = selectedProject?.ref
 
   const canUpdateFunctions = useCheckPermissions(
@@ -81,6 +80,8 @@ const FunctionList = ({
   return (
     <>
       {_functions.map((x) => {
+        const isApiDocumentAvailable = schema == 'public' && x.return_type !== 'trigger'
+
         return (
           <Table.tr key={x.id}>
             <Table.td className="truncate">


### PR DESCRIPTION
## Problem
On the Database > Functions page in the dashboard, there is a link to open the function in the auto-generated API docs. This link appears for all functions in the `public` schema, including trigger functions:

![image](https://github.com/supabase/supabase/assets/4133076/b7f80aad-7a31-404e-9b51-43ebfee4494e)

However trigger functions cannot be called as an `rpc()`, so clicking this doc link takes you a non-existent page:

![image](https://github.com/supabase/supabase/assets/4133076/1aeb49e5-5f33-429b-8885-d34447365205)

## Solution
Hide the docs link for trigger functions:

![image](https://github.com/supabase/supabase/assets/4133076/49d38bea-f815-4907-bc19-03190d6a22f5)
