### PR TITLE
fixes case error in doc page, click MySQL returned a 404

### DIFF
--- a/apps/docs/pages/index.mdx
+++ b/apps/docs/pages/index.mdx
@@ -279,7 +279,7 @@ export const migrationGuides = [
   {
     title: 'MySQL',
     icon: '/docs/img/icons/mysql-icon',
-    href: '/guides/resources/migrating-to-supabase/MySQL',
+    href: '/guides/resources/migrating-to-supabase/mysql',
   },
   {
     title: 'MSSQL',


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes the case error in docs.

## What is the current behavior?

<img width="1440" alt="Screenshot 2023-10-20 at 9 55 05 AM" 
src="https://github.com/supabase/supabase/assets/95876621/5f7accdd-c3b8-4293-bb1a-6d651eb774e9">

<img width="1440" alt="Screenshot 2023-10-20 at 9 55 05 AM" 
src="https://user-images.githubusercontent.com/18202902/276805373-e463157c-1084-4a14-adfc-ff1a2d3c00e1.png">

When user click to Mysql in migrate to supabase docs it returned a 404 page

## What is the new behavior?

Now user gets to the correct page
<img width="1440" alt="Screenshot 2023-10-20 at 9 55 25 AM" src="https://github.com/supabase/supabase/assets/95876621/49d6b18e-47dd-428d-b6d8-83cc1152d023">

<img width="1440" alt="Screenshot 2023-10-20 at 9 56 10 AM" src="https://github.com/supabase/supabase/assets/95876621/214ef584-d198-4c2e-9e5c-f33523c74075">


## Additional context

fixes #18345 
