### PR TITLE
fix: update postgresql version to the latest version on functions guide page

### DIFF
--- a/apps/docs/pages/guides/functions/connect-to-postgres.mdx
+++ b/apps/docs/pages/guides/functions/connect-to-postgres.mdx
@@ -19,7 +19,7 @@ export const meta = {
 Supabase Edge Functions allow you to go beyond HTTP and can connect to your Postgres Database directly!
 
 ```ts index.ts
-import * as postgres from 'https://deno.land/x/postgres@v0.14.2/mod.ts'
+import * as postgres from 'https://deno.land/x/postgres@v0.17.0/mod.ts'
 import { serve } from 'https://deno.land/std@0.177.0/http/server.ts'
 
 // Get the connection string from the environment variable "SUPABASE_DB_URL"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug postgresql v14.x. I just copied the code example and got error `segmentation fault`. I'm new at supabase and confuse for a moment after got this error.

```sh
> supabase functions serve --debug
...
DEBUG Specifier "https://deno.land/std@0.177.0/async/deferred.ts" was not mapped in import map.
DEBUG Specifier "https://deno.land/std@0.177.0/async/deferred.ts" was not mapped in import map.
DEBUG Specifier "https://deno.land/std@0.177.0/async/deferred.ts" was not mapped in import map.
Segmentation fault (core dumped)
2023/10/20 14:48:17 Sent Header: Host [api.moby.localhost]
2023/10/20 14:48:17 Sent Header: User-Agent [Docker-Client/unknown-version (linux)]
2023/10/20 14:48:17 Send Done
2023/10/20 14:48:17 Recv First Byte
error running container: exit 139

```

## What is the current behavior?

After I update postgresql version to the latest ([0.17.0](https://deno.land/x/postgres@v0.17.0)). The error is gone. I hope this will be helpfull for other new-comers to supabase.

## What is the new behavior?

Nothing new. Just copy the code and run perfectly.

## Additional context

-
