### PR TITLE
docs: Add Query nested foreign tables throught a join table example for supabase-js

### DIFF
--- a/spec/examples/examples.yml
+++ b/spec/examples/examples.yml
@@ -1067,6 +1067,112 @@ functions:
           </TabPanel>
           </Tabs>
         hideCodeBlock: true
+      - id: query-nested-foreign-tables-through-a-join-table
+        name: Query nested foreign tables through a join table
+        code: |
+          ```ts
+            const { data, error } = await supabase
+              .from('games')
+              .select(`
+                game_id:id,
+                away_team:teams!games_away_team_fkey (
+                  users (
+                    id,
+                    name
+                  )
+                )
+              `)
+            ```
+        data:
+          sql: |
+            ```sql
+            create table
+              users (
+                id int8 primary key,
+                name text
+              );
+            create table
+              teams (
+                id int8 primary key,
+                name text
+              );
+            -- join table
+            create table
+              users_teams (
+                user_id int8 not null references users,
+                team_id int8 not null references teams,
+
+                primary key (user_id, team_id)
+              );
+            create table
+              games (
+                id int8 primary key,
+                home_team int8 not null references teams,
+                away_team int8 not null references teams,
+                name text
+              );
+
+            insert into users (id, name)
+            values
+              (1, 'Kiran'),
+              (2, 'Evan');
+            insert into
+              teams (id, name)
+            values
+              (1, 'Green'),
+              (2, 'Blue');
+            insert into
+              users_teams (user_id, team_id)
+            values
+              (1, 1),
+              (1, 2),
+              (2, 2);
+            insert into
+              games (id, home_team, away_team, name)
+            values
+              (1, 1, 2, 'Green vs Blue'),
+              (2, 2, 1, 'Blue vs Green')
+            ```
+        response: |
+          ```json
+            {
+              "data": [
+                {
+                  "game_id": 1,
+                  "away_team": {
+                    "users": [
+                      {
+                        "id": 1,
+                        "name": "Kiran"
+                      },
+                      {
+                        "id": 2,
+                        "name": "Evan"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "game_id": 2,
+                  "away_team": {
+                    "users": [
+                      {
+                        "id": 1,
+                        "name": "Kiran"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "status": 200,
+              "statusText": "OK"
+            }
+            ```
+        description: |
+          You can use the result of a joined table to gather data in
+          another foreign table. With multiple references to the same foreign
+          table you must specify the column on which to conduct the join.
+        hideCodeBlock: true
       - id: filtering-through-foreign-tables
         name: Filtering through foreign tables
         description: |

--- a/spec/supabase_js_v2.yml
+++ b/spec/supabase_js_v2.yml
@@ -1540,6 +1540,112 @@ functions:
           joined column to identify which join to use. You can also give each
           column an alias.
         hideCodeBlock: true
+      - id: query-nested-foreign-tables-through-a-join-table
+        name: Query nested foreign tables through a join table
+        code: |
+          ```ts
+            const { data, error } = await supabase
+              .from('games')
+              .select(`
+                game_id:id,
+                away_team:teams!games_away_team_fkey (
+                  users (
+                    id,
+                    name
+                  )
+                )
+              `)
+            ```
+        data:
+          sql: |
+            ```sql
+            create table
+              users (
+                id int8 primary key,
+                name text
+              );
+            create table
+              teams (
+                id int8 primary key,
+                name text
+              );
+            -- join table
+            create table
+              users_teams (
+                user_id int8 not null references users,
+                team_id int8 not null references teams,
+
+                primary key (user_id, team_id)
+              );
+            create table
+              games (
+                id int8 primary key,
+                home_team int8 not null references teams,
+                away_team int8 not null references teams,
+                name text
+              );
+
+            insert into users (id, name)
+            values
+              (1, 'Kiran'),
+              (2, 'Evan');
+            insert into
+              teams (id, name)
+            values
+              (1, 'Green'),
+              (2, 'Blue');
+            insert into
+              users_teams (user_id, team_id)
+            values
+              (1, 1),
+              (1, 2),
+              (2, 2);
+            insert into
+              games (id, home_team, away_team, name)
+            values
+              (1, 1, 2, 'Green vs Blue'),
+              (2, 2, 1, 'Blue vs Green')
+            ```
+        response: |
+          ```json
+            {
+              "data": [
+                {
+                  "game_id": 1,
+                  "away_team": {
+                    "users": [
+                      {
+                        "id": 1,
+                        "name": "Kiran"
+                      },
+                      {
+                        "id": 2,
+                        "name": "Evan"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "game_id": 2,
+                  "away_team": {
+                    "users": [
+                      {
+                        "id": 1,
+                        "name": "Kiran"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "status": 200,
+              "statusText": "OK"
+            }
+            ```
+        description: |
+          You can use the result of a joined table to gather data in
+          another foreign table. With multiple references to the same foreign
+          table you must specify the column on which to conduct the join.
+        hideCodeBlock: true
       - id: filtering-through-foreign-tables
         name: Filtering through foreign tables
         code: |


### PR DESCRIPTION

## What kind of change does this PR introduce?

Docs update

## What is the new behavior?

Add a new example of nested foreign table joins (joining 3 tables) using specific foreign keys and renaming columns

![Query-nested-1](https://github.com/supabase/supabase/assets/5422965/8e214961-7283-4c54-9d15-2af67a73c7f6)
![query-nested-2](https://github.com/supabase/supabase/assets/5422965/f9b88e24-bde0-4a18-98c4-7892687acf0a)
![query-nested-3](https://github.com/supabase/supabase/assets/5422965/61b5adfc-6ce7-432c-8c3e-2d01faf84f79)
![query-nested-4](https://github.com/supabase/supabase/assets/5422965/6371df84-bbef-4d54-a3de-d618abe60b1c)


## Additional context

Test Plan: Run the query in a server webapp environment using supabase-js and ensure results as shown. Additionally npm run dev:docs
