### PR TITLE
Update storage_management.mdx

### DIFF
--- a/apps/docs/components/MDX/storage_management.mdx
+++ b/apps/docs/components/MDX/storage_management.mdx
@@ -64,7 +64,7 @@ declare
   avatar_name text;
 begin
   if coalesce(old.avatar_url, '') <> ''
-      and (tg_op = 'DELETE' or (old.avatar_url <> new.avatar_url)) then
+      and (tg_op = 'DELETE' or (old.avatar_url <> coalesce(new.avatar_url, ''))) then
     -- extract avatar name
     avatar_name := old.avatar_url;
     select


### PR DESCRIPTION
Handle the case in which the new `avatar_url` is set to null.

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

If the new `avatar_url` is set to `NULL`, the condition is never met and the old file is not deleted.

## What is the new behavior?

Handles this case using [`coalesce`](https://www.postgresql.org/docs/15/functions-conditional.html#FUNCTIONS-COALESCE-NVL-IFNULL).
