### PR TITLE
Docs: Corrected SvelteKit tutorial errors caused by inaccurate constants.

### DIFF
--- a/apps/docs/pages/guides/auth/auth-helpers/sveltekit.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/sveltekit.mdx
@@ -339,7 +339,7 @@ We need to create an event listener in the root `+layout.svelte` file in order t
 
   export let data
 
-  const { supabase, session } = data
+  let { supabase, session } = data
   $: ({ supabase, session } = data)
 
   onMount(() => {
@@ -368,7 +368,7 @@ We can access the supabase instance in our `+page.svelte` file through the data 
 <!-- // src/routes/auth/+page.svelte -->
 <script>
   export let data
-  const { supabase } = data
+  let { supabase } = data
   $: ({ supabase } = data)
 
   let email


### PR DESCRIPTION
The Sveltekit Auth guide's sample code tried to update constants, causing errors

## What kind of change does this PR introduce?

Docs

## What is the current behavior?

The existing sample code triggers errors.

## What is the new behavior?

Transforms constants into conventional variables, addressing the reassignment issue.

## Additional context

Screenshot of error message from unmodified sample code:

<img width="841" alt="Screenshot 2023-10-23 at 1 29 53 AM" src="https://github.com/supabase/supabase/assets/91111415/257ac40a-ed32-42bf-861e-d4511ebe0fe7">

