### PR TITLE
feat: update inviteUserByEmail to specify PKCE is not supported

### DIFF
--- a/spec/supabase_js_v2.yml
+++ b/spec/supabase_js_v2.yml
@@ -1017,6 +1017,7 @@ functions:
     notes: |
       - Sends an invite link to the user's email address.
       - The `inviteUserByEmail()` method is typically used by administrators to invite users to join the application.
+      - Note that PKCE is not supported when using `inviteUserByEmail` 
     examples:
       - id: invite-a-user
         name: Invite a user

--- a/spec/supabase_js_v2.yml
+++ b/spec/supabase_js_v2.yml
@@ -1017,7 +1017,7 @@ functions:
     notes: |
       - Sends an invite link to the user's email address.
       - The `inviteUserByEmail()` method is typically used by administrators to invite users to join the application.
-      - Note that PKCE is not supported when using `inviteUserByEmail` 
+      - Note that PKCE is not supported when using `inviteUserByEmail`. This is because the browser initiating the invite is often different from the browser acecpting the invite which makes it difficult to provide the security guarantees required of the PKCE flow.
     examples:
       - id: invite-a-user
         name: Invite a user


### PR DESCRIPTION
## What kind of change does this PR introduce?

`inviteUserByEmail` is not supported with PKCE as the browser/device initiating the flow is distinct from the device/browser confirming the flow (the user's browser). This makes it challenging to provide the security guarantees PKCE is supposed to provide