### PR TITLE
feat: bump to v4 of random logouts counter

### DIFF
--- a/studio/lib/local-storage.ts
+++ b/studio/lib/local-storage.ts
@@ -4,7 +4,7 @@ export const LOCAL_STORAGE_KEYS_ALLOWLIST = [
   'graphiql:theme',
   'theme',
   'supabaseDarkMode',
-  'supabase.dashboard.sign_in_clicks_v3',
+  'supabase.dashboard.sign_in_clicks_v4',
   'supabase.dashboard.auth.debug',
   'supabase.dashboard.auth.navigatorLock.disabled',
 ]
@@ -19,16 +19,16 @@ export function clearLocalStorage() {
 
 function inferSignInClicks() {
   // remove old data from local storage
-  ;['', '_v2'].forEach((suffix) => {
+  ;['', '_v2', '_v3'].forEach((suffix) => {
     localStorage.removeItem(`supabase.dashboard.sign_in_clicks${suffix}`)
   })
 
-  if (localStorage.getItem('supabase.dashboard.sign_in_clicks_v3')) {
+  if (localStorage.getItem('supabase.dashboard.sign_in_clicks_v4')) {
     return
   }
 
   localStorage.setItem(
-    'supabase.dashboard.sign_in_clicks_v3',
+    'supabase.dashboard.sign_in_clicks_v4',
     localStorage.getItem('supabase.dashboard.auth.token') ? '1' : '0'
   )
 }
@@ -37,7 +37,7 @@ export function getSignInClicks(): number {
   let count: number | null = null
 
   try {
-    count = JSON.parse(localStorage.getItem('supabase.dashboard.sign_in_clicks_v3') || '0')
+    count = JSON.parse(localStorage.getItem('supabase.dashboard.sign_in_clicks_v4') || '0')
   } catch (e: any) {
     // do nothing
   }
@@ -48,7 +48,7 @@ export function getSignInClicks(): number {
 export function incrementSignInClicks(): number {
   const clicks = getSignInClicks()
 
-  localStorage.setItem('supabase.dashboard.sign_in_clicks_v3', JSON.stringify(clicks + 1))
+  localStorage.setItem('supabase.dashboard.sign_in_clicks_v4', JSON.stringify(clicks + 1))
 
   return clicks + 1
 }
@@ -56,7 +56,7 @@ export function incrementSignInClicks(): number {
 export function resetSignInClicks(): number {
   const clicks = getSignInClicks()
 
-  localStorage.setItem('supabase.dashboard.sign_in_clicks_v3', '0')
+  localStorage.setItem('supabase.dashboard.sign_in_clicks_v4', '0')
 
   return clicks
 }


### PR DESCRIPTION
Updates the random logouts counter logic to use `v4` which should reset the metrics in Sentry and we can see if the newest changes are improving the situation.

Please deploy on Tuesday in the regular time!