### PR TITLE
docs: fix syntax error in `triggers.mdx`

### DIFF
--- a/apps/docs/pages/guides/database/postgres/triggers.mdx
+++ b/apps/docs/pages/guides/database/postgres/triggers.mdx
@@ -22,7 +22,7 @@ An example of a trigger is:
 create trigger "trigger_name"
 after insert on "table_name"
 for each row
-execute statement trigger_function();
+execute function trigger_function();
 ```
 
 ## Trigger Functions
@@ -82,7 +82,7 @@ Executes before the triggering event.
 create trigger before_insert_trigger
 before insert on orders
 for each row
-execute statement before_insert_function();
+execute function before_insert_function();
 ```
 
 ### Trigger after changed are made
@@ -93,7 +93,7 @@ Executes after the triggering event.
 create trigger after_delete_trigger
 after delete on customers
 for each row
-execute statement after_delete_function();
+execute function after_delete_function();
 ```
 
 ## Execution frequency


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix syntax error in the docs section for creating triggers. I believe `function` can be interchanged with `procedure`, but `statement` will result in a syntax error.

## What is the current behavior?

If you ran the example in Supabase Studio as-is, you’d get a syntax error (as expected):

<img width="1132" alt="CleanShot 2023-10-23 at 20 34 42@2x" src="https://github.com/supabase/supabase/assets/14703164/f79c6624-9fd2-4e9a-85df-71a84c983ab9">

## What is the new behavior?

No errors here:

<img width="1131" alt="CleanShot 2023-10-23 at 20 33 42@2x" src="https://github.com/supabase/supabase/assets/14703164/406ceb35-52f2-4412-935d-92dd2c86a705">


## Additional context

The official Postgres (15) docs on [triggers](https://www.postgresql.org/docs/15/sql-createtrigger.html) confirm my change(s).
