### PR TITLE
fix: auth smtp doc fix

### DIFF
--- a/apps/docs/pages/guides/auth/auth-smtp.mdx
+++ b/apps/docs/pages/guides/auth/auth-smtp.mdx
@@ -6,7 +6,7 @@ export const meta = {
   description: 'Moving towards production: Configuring a custom SMTP provider',
 }
 
-# Auth SMTP
+## Auth SMTP
 
 At present, you can trial the Supabase platform by sending up to **4** emails per hour via the built-in service. The default email service as a whole is offered on a best effort basis: we will do our best to maintain it and will review usage of the service on a regular basis to see if the email service should be continued.
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs Update - [Auth SMTP](https://supabase.com/docs/guides/auth/auth-smtp)

## What is the current behavior?

h1 in use.

## What is the new behavior?

Changed to h2

## Additional context

Closes #18434
