### PR TITLE
docs: add instructions for using custom schema with self-hosted

### DIFF
--- a/apps/docs/pages/guides/api/using-custom-schemas.mdx
+++ b/apps/docs/pages/guides/api/using-custom-schemas.mdx
@@ -9,6 +9,7 @@ export const meta = {
 By default, your database has a `public` schema which is automatically exposed on Serverless APIs. You can also expose custom database schemas - to do so you need to follow these steps:
 
 1. Go to [API settings](https://supabase.com/dashboard/project/_/settings/api) and add your custom schema to "Exposed schemas".
+  1. If you're running a self-hosted instance of Supabase, append your schema's name to the `PGRST_DB_SCHEMAS` variable in `.env`.
 2. Run the following SQL, substituting `myschema` with your schema name:
 
 ```sql


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

There is no documentation for how to configure PostgREST to expose custom schemas on self-hosted instances.

## What is the new behavior?

Documents the (currently undocumented) existing configuration option.
Re: #18440 

## Additional context

Add any other context or screenshots.
