### PR TITLE
Set cookie secure to false in SvelteKit if dev server is running.

### DIFF
--- a/apps/docs/pages/guides/auth/server-side/oauth-with-pkce-flow-for-ssr.mdx
+++ b/apps/docs/pages/guides/auth/server-side/oauth-with-pkce-flow-for-ssr.mdx
@@ -109,9 +109,7 @@ export const handle: Handle = async ({ event, resolve }) => {
     supabaseUrl: PUBLIC_SUPABASE_URL,
     supabaseKey: PUBLIC_SUPABASE_ANON_KEY,
     event,
-    cookieOptions: {
-      secure: !dev
-    },
+    cookieOptions: { secure: !dev },
   })
 
   event.locals.getSession = async () => {

--- a/apps/docs/pages/guides/auth/server-side/oauth-with-pkce-flow-for-ssr.mdx
+++ b/apps/docs/pages/guides/auth/server-side/oauth-with-pkce-flow-for-ssr.mdx
@@ -102,12 +102,16 @@ Create a new `hooks.server.js` file in the root of your project and populate wit
 import { PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY } from '$env/static/public'
 import { createSupabaseServerClient } from '@supabase/auth-helpers-sveltekit'
 import type { Handle } from '@sveltejs/kit'
+import { dev } from '$app/environment'
 
 export const handle: Handle = async ({ event, resolve }) => {
   event.locals.supabase = createSupabaseServerClient({
     supabaseUrl: PUBLIC_SUPABASE_URL,
     supabaseKey: PUBLIC_SUPABASE_ANON_KEY,
     event,
+    cookieOptions: {
+ 	secure: dev ? false : true
+	},
   })
 
   event.locals.getSession = async () => {

--- a/apps/docs/pages/guides/auth/server-side/oauth-with-pkce-flow-for-ssr.mdx
+++ b/apps/docs/pages/guides/auth/server-side/oauth-with-pkce-flow-for-ssr.mdx
@@ -110,8 +110,8 @@ export const handle: Handle = async ({ event, resolve }) => {
     supabaseKey: PUBLIC_SUPABASE_ANON_KEY,
     event,
     cookieOptions: {
- 	secure: dev ? false : true
-	},
+      secure: !dev
+    },
   })
 
   event.locals.getSession = async () => {


### PR DESCRIPTION
oauth-with-pkce-flow-for-ssr.mdx

## What kind of change does this PR introduce?

Docs update.

## What is the current behavior?

Current behavior

PKCE verification cookie isn't set because Safari doesn't allow setting httpsOnly cookies set on http connections even on local host. Which causes an `AuthApiError: invalid request: both auth code and code verifier should be non-empty` error being thrown in `exchangeCodeForSession`

Reference - https://github.com/sveltejs/kit/issues/6632

<img width="1035" alt="Screenshot 2023-10-25 at 9 52 31 AM" src="https://github.com/supabase/supabase/assets/58698829/ecc0c89a-8ee5-43ac-9035-1bdfa418bf87">

Please link any relevant issues here.

https://github.com/supabase/gotrue-js/issues/292

## What is the new behavior?

Set cookie secure to false in `createSupabaseServerClient` if dev server is running  (SvelteKit)