### PR TITLE
ref: Fetch all GitHub repositories for GitHub integration config page

### DIFF
--- a/studio/data/api.d.ts
+++ b/studio/data/api.d.ts
@@ -9305,6 +9305,10 @@ export interface operations {
   /** Gets github repos for the given organization */
   GitHubRepoController_getRepos: {
     parameters: {
+      query?: {
+        per_page?: number
+        page?: number
+      }
       path: {
         organization_integration_id: string
       }

--- a/studio/data/integrations/integrations-github-repos-query.ts
+++ b/studio/data/integrations/integrations-github-repos-query.ts
@@ -8,6 +8,9 @@ export type GitHubReposVariables = {
   integrationId: string | undefined
 }
 
+// We don't want to fetch more than 1000 repositories, as it's already more than enough.
+const MAX_PAGES = 10
+
 export async function getGitHubRepos(
   { integrationId }: GitHubReposVariables,
   signal?: AbortSignal
@@ -16,12 +19,42 @@ export async function getGitHubRepos(
     throw new Error('integrationId is required')
   }
 
+  const repos: Awaited<ReturnType<typeof getSingleGithubReposPage>> = []
+  const perPage = 100
+  let page = 1
+
+  // This is unfortunate, because we will do redundant API call in case there are exactly 100 results,
+  // but the API is returning an array instead of `{ repos: [], total_count: n }`.
+  while (true) {
+    const reposChunk = await getSingleGithubReposPage(integrationId, perPage, page, signal)
+    repos.push(...reposChunk)
+    page += 1
+
+    // Stop asking for more data if last request was exhaustive or we reached a limit, .
+    if (reposChunk.length < perPage || page > MAX_PAGES) {
+      break
+    }
+  }
+
+  return repos
+}
+
+async function getSingleGithubReposPage(
+  integrationId: string,
+  perPage: number,
+  page: number,
+  signal?: AbortSignal
+) {
   const { data, error } = await get(
     '/platform/integrations/github/repos/{organization_integration_id}',
     {
       params: {
         path: {
           organization_integration_id: integrationId,
+        },
+        query: {
+          per_page: perPage,
+          page,
         },
       },
       signal,
@@ -30,7 +63,6 @@ export async function getGitHubRepos(
   if (error) {
     throw error
   }
-
   return data
 }
 


### PR DESCRIPTION
Depends on https://github.com/supabase/infrastructure/pull/15346 and requires recreating openapi types.