### PR TITLE
ref: Use label instead of name for GitHub branches

### DIFF
--- a/studio/components/interfaces/BranchManagement/BranchPanels.tsx
+++ b/studio/components/interfaces/BranchManagement/BranchPanels.tsx
@@ -234,7 +234,7 @@ const PullRequestPanel = ({
           <div>
             <div className="flex items-center space-x-4">
               <IconGitBranch className="text-brand-900" size={16} strokeWidth={2} />
-              <p>{pr.branch}</p>
+              <p>{pr.label}</p>
               <p className="text-light">
                 {daysFromNow > 1
                   ? `Created on ${formattedCreatedAt}`

--- a/studio/data/api.d.ts
+++ b/studio/data/api.d.ts
@@ -4155,7 +4155,9 @@ export interface components {
       id: number
       url: string
       title: string
+      repo: string
       branch: string
+      label: string
       created_at: string
       created_by?: string
     }
@@ -9365,6 +9367,10 @@ export interface operations {
   /** Gets github pull requests for a given repo */
   GitHubPullRequestController_getPullRequests: {
     parameters: {
+      query?: {
+        per_page?: number
+        page?: number
+      }
       path: {
         organization_integration_id: string
         repo_owner: string


### PR DESCRIPTION
Fixes case where we see multiple pull requests sent from `master` which makes then indistinguishable between each other.
This change will use GitHub-like label, eg. `kamilogorek:master` when PR is sent from the fork repo.

Depends on https://github.com/supabase/infrastructure/pull/15342