### PR TITLE
Fix: Add force-dynamic to quickstart

### DIFF
--- a/apps/docs/pages/guides/getting-started/quickstarts/nextjs.mdx
+++ b/apps/docs/pages/guides/getting-started/quickstarts/nextjs.mdx
@@ -94,6 +94,8 @@ export const meta = {
         import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
         import { cookies } from "next/headers";
 
+        export const dynamic = "force-dynamic";
+
         export default async function Index() {
           const cookieStore = cookies()
           const supabase = createServerComponentClient({ cookies: () => cookieStore })


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

Quickstart fails when deployed as Next.js tries to statically generate page

## What is the new behavior?

Quickstart does not fail when deployed as we explicitly mark the route as `dynamic`

## Additional context

https://www.reddit.com/r/nextjs/comments/177o5l1/deployment_errors_cookie_related_supabase_nextjs/
