### PR TITLE
chore: remove unnecessary keyword from upgrade dialog

### DIFF
--- a/studio/components/interfaces/Settings/General/Infrastructure/ProjectUpgradeAlert/ProjectUpgradeAlert.tsx
+++ b/studio/components/interfaces/Settings/General/Infrastructure/ProjectUpgradeAlert/ProjectUpgradeAlert.tsx
@@ -146,8 +146,7 @@ const ProjectUpgradeAlert = () => {
                                   {legacyAuthCustomRoles.map((role) => (
                                     <div key={role} className="pb-1">
                                       ALTER ROLE <span className="text-brand">{role}</span> WITH
-                                      ENCRYPTED PASSWORD '
-                                      <span className="text-brand">newpassword</span>';
+                                      PASSWORD '<span className="text-brand">newpassword</span>';
                                     </div>
                                   ))}
                                 </code>


### PR DESCRIPTION
* [Docs](https://supabase.com/docs/guides/platform/migrating-and-upgrading-projects#caveats) suggest using the simplified form of the statement - better to be consistent