### PR TITLE
fix: access tokens layout fix

### DIFF
--- a/studio/pages/account/tokens.tsx
+++ b/studio/pages/account/tokens.tsx
@@ -47,7 +47,7 @@ const UserAccessTokens: NextPageWithLayout = () => {
       <div className="flex items-center justify-between">
         <Alert
           withIcon
-          className="mb-6 mr-6 w-full"
+          className="mb-6 w-full"
           variant="warning"
           title="Personal access tokens can be used to control your whole account and use features added in the future. Be careful when sharing them!"
         />

--- a/studio/pages/account/tokens.tsx
+++ b/studio/pages/account/tokens.tsx
@@ -23,12 +23,6 @@ const UserAccessTokens: NextPageWithLayout = () => {
             title="Access Tokens"
             description="Personal access tokens can be used with our Management API or CLI."
           />
-          <Alert
-            withIcon
-            className="mb-6 mr-6"
-            variant="warning"
-            title="Personal access tokens can be used to control your whole account and use features added in the future. Be careful when sharing them!"
-          />
         </div>
         <div className="flex items-center space-x-4 mb-6">
           <div className="flex items-center space-x-2">
@@ -49,6 +43,14 @@ const UserAccessTokens: NextPageWithLayout = () => {
           </div>
           <NewAccessTokenButton onCreateToken={setNewToken} />
         </div>
+      </div>
+      <div className="flex items-center justify-between">
+        <Alert
+          withIcon
+          className="mb-6 mr-6 w-full"
+          variant="warning"
+          title="Personal access tokens can be used to control your whole account and use features added in the future. Be careful when sharing them!"
+        />
       </div>
       <div className="space-y-4">
         {newToken && <NewTokenBanner token={newToken} />}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase Studio - Access Tokens

## What is the current behavior?

The `<Alert />` component is misaligned

## What is the new behavior?

The component is now displaying correctly:

<img width="1061" alt="Screenshot 2023-10-26 at 17 09 34" src="https://github.com/supabase/supabase/assets/22655069/63c2e04a-73a7-48ff-97e6-19474fdcca28">


## Additional context

Closes #18501