### PR TITLE
fix: allow hipaa request for all plans

### DIFF
--- a/studio/components/interfaces/Organization/Documents/HIPAA.tsx
+++ b/studio/components/interfaces/Organization/Documents/HIPAA.tsx
@@ -16,13 +16,13 @@ const HIPAA = () => {
               This is only for HIPAA requests. Please ignore this if you already have HIPAA enabled.
             </p>
             <p>
-              Organizations on Teams plan or above are eligible for a paid HIPAA compliance add-on.
+              Organizations on the Teams plan or above are eligible for a paid HIPAA compliance add-on.
               You can submit a request here and we will get back to you on the pricing and process
               for your use case.
             </p>
             <p>
-              Organizations on a Free or Pro plan can also submit a request for HIPAA. Note that you
-              are still required to upgrade to Teams plan after your request is approved.
+              Organizations on the Free or Pro plan can also submit a request for HIPAA. Note that you
+              are still required to upgrade to the Teams plan after your request is approved.
             </p>
           </div>
         </ScaffoldSectionDetail>

--- a/studio/components/interfaces/Organization/Documents/HIPAA.tsx
+++ b/studio/components/interfaces/Organization/Documents/HIPAA.tsx
@@ -16,13 +16,13 @@ const HIPAA = () => {
               This is only for HIPAA requests. Please ignore this if you already have HIPAA enabled.
             </p>
             <p>
-              Organizations on the Teams plan or above are eligible for a paid HIPAA compliance add-on.
-              You can submit a request here and we will get back to you on the pricing and process
-              for your use case.
+              Organizations on the Teams plan or above are eligible for a paid HIPAA compliance
+              add-on. You can submit a request here and we will get back to you on the pricing and
+              process for your use case.
             </p>
             <p>
-              Organizations on the Free or Pro plan can also submit a request for HIPAA. Note that you
-              are still required to upgrade to the Teams plan after your request is approved.
+              Organizations on the Free or Pro plan can also submit a request for HIPAA. Note that
+              you are still required to upgrade to the Teams plan after your request is approved.
             </p>
           </div>
         </ScaffoldSectionDetail>

--- a/studio/components/interfaces/Organization/Documents/HIPAA.tsx
+++ b/studio/components/interfaces/Organization/Documents/HIPAA.tsx
@@ -1,68 +1,39 @@
-import Link from 'next/link'
-import { useParams } from 'common'
 import {
   ScaffoldSection,
   ScaffoldSectionContent,
   ScaffoldSectionDetail,
 } from 'components/layouts/Scaffold'
-import AlertError from 'components/ui/AlertError'
-import ShimmeringLoader from 'components/ui/ShimmeringLoader'
-import { useOrgSubscriptionQuery } from 'data/subscriptions/org-subscription-query'
 import { Button, IconExternalLink } from 'ui'
 
 const HIPAA = () => {
-  const { slug } = useParams()
-  const {
-    data: subscription,
-    error,
-    isLoading,
-    isError,
-    isSuccess,
-  } = useOrgSubscriptionQuery({ orgSlug: slug })
-  const currentPlan = subscription?.plan
-
   return (
     <>
       <ScaffoldSection>
         <ScaffoldSectionDetail className="sticky space-y-6 top-12">
           <p className="text-base m-0">HIPAA</p>
           <div className="space-y-2 text-sm text-foreground-light m-0">
-            <p>Organizations on Teams plan or above can request for a paid HIPAA add-on.</p>
             <p>
               This is only for HIPAA requests. Please ignore this if you already have HIPAA enabled.
+            </p>
+            <p>
+              Organizations on Teams plan or above are eligible for a paid HIPAA compliance add-on.
+              You can submit a request here and we will get back to you on the pricing and process
+              for your use case.
+            </p>
+            <p>
+              Organizations on a Free or Pro plan can also submit a request for HIPAA. Note that you
+              are still required to upgrade to Teams plan after your request is approved.
             </p>
           </div>
         </ScaffoldSectionDetail>
         <ScaffoldSectionContent>
-          {isLoading && (
-            <div className="space-y-2">
-              <ShimmeringLoader />
-              <ShimmeringLoader className="w-3/4" />
-              <ShimmeringLoader className="w-1/2" />
-            </div>
-          )}
-
-          {isError && <AlertError subject="Failed to retrieve subscription" error={error} />}
-
-          {isSuccess && (
-            <div className="flex items-center justify-center h-full">
-              {currentPlan?.id === 'free' || currentPlan?.id === 'pro' ? (
-                <Link href={`/org/${slug}/billing?panel=subscriptionPlan`}>
-                  <Button type="default">Upgrade to Teams</Button>
-                </Link>
-              ) : (
-                <a
-                  href="https://forms.supabase.com/hipaa2"
-                  target="_blank"
-                  rel="noreferrer noopener"
-                >
-                  <Button type="default" iconRight={<IconExternalLink />}>
-                    Request HIPAA Form
-                  </Button>
-                </a>
-              )}
-            </div>
-          )}
+          <div className="flex items-center justify-center h-full">
+            <a href="https://forms.supabase.com/hipaa2" target="_blank" rel="noreferrer noopener">
+              <Button type="default" iconRight={<IconExternalLink />}>
+                Request HIPAA
+              </Button>
+            </a>
+          </div>
         </ScaffoldSectionContent>
       </ScaffoldSection>
     </>


### PR DESCRIPTION
## What kind of change does this PR introduce?

- remove plan restriction for hipaa requests
- add clarification that teams plan is still needed for hipaa
