### PR TITLE
Docs: Redirect relative dashboard/blog links in dev/preview envs

### DIFF
--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -14,13 +14,6 @@ const withBundleAnalyzer = configureBundleAnalyzer({
   enabled: process.env.ANALYZE === 'true',
 })
 
-/**
- * Rewrites and redirects are handled by
- * apps/www nextjs config
- *
- * Do not add them in this config
- */
-
 const withMDX = nextMdx({
   extension: /\.mdx?$/,
   options: {
@@ -91,11 +84,30 @@ const nextConfig = {
       },
     ]
   },
+
+  /**
+   * Doc rewrites and redirects are
+   * handled by the `www` nextjs config:
+   *
+   * ./apps/www/lib/redirects.js
+   *
+   * Only add dev/preview specific redirects
+   * in this config.
+   */
   async redirects() {
     return [
+      // Redirect root to docs base path in dev/preview envs
       {
         source: '/',
         destination: '/docs',
+        basePath: false,
+        permanent: false,
+      },
+
+      // Redirect dashboard links in dev/preview envs
+      {
+        source: '/dashboard/:path*',
+        destination: 'https://supabase.com/dashboard/:path*',
         basePath: false,
         permanent: false,
       },

--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -111,6 +111,14 @@ const nextConfig = {
         basePath: false,
         permanent: false,
       },
+
+      // Redirect blog links in dev/preview envs
+      {
+        source: '/blog/:path*',
+        destination: 'https://supabase.com/blog/:path*',
+        basePath: false,
+        permanent: false,
+      },
     ]
   },
 }


### PR DESCRIPTION
## Problem
Now that the dashboard lives at `/dashboard`, we've begun linking to the dashboard from within the docs using its relative path:

```markdown
[My link](/dashboard/project/_/sql/new)
```

This works great in production, but not in local dev or preview environments, since those environments aren't proxied through `www`. Clicking these links in dev/preview results in a 404:

<img width="1081" alt="image" src="https://github.com/supabase/supabase/assets/4133076/924b62b2-133b-4e01-b3ef-11b33765e941">


Same thing with blog posts:
```markdown
[My link](/blog/my-post)
```

<img width="1081" alt="image" src="https://github.com/supabase/supabase/assets/4133076/924b62b2-133b-4e01-b3ef-11b33765e941">

## Solution
Add a redirect (just for local dev / preview environments) that replaces `/dashboard` with `https://supabase.com/dashboard` and `/blog` with `https://supabase.com/blog`.

## Test it out

### Dashboard redirects
Try clicking the **"organization billing page"** link on the [Billing Enterprise](https://docs-git-feat-redirect-doc-dashboard-links-in-dev-supabase.vercel.app/docs/guides/platform/enterprise-billing#monitoring-enterprise-usage) page under **"Monitoring Enterprise Usage"**.

### Blog redirects
Try clicking **"the blog post"** link on the [OpenAI GPT completions guide](https://docs-git-feat-redirect-doc-dashboard-links-in-dev-supabase.vercel.app/docs/guides/ai/examples/openai#go-deeper) under **"Go deeper"**.