### PR TITLE
doc: route.js changed to route.ts

### DIFF
--- a/apps/docs/pages/guides/auth/server-side/creating-a-client.mdx
+++ b/apps/docs/pages/guides/auth/server-side/creating-a-client.mdx
@@ -232,7 +232,7 @@ export async function middleware(request: NextRequest) {
 
 <TabPanel id="route-handler" label="Route Handler">
 
-```ts route.js
+```ts route.ts
 import { createServerClient, type CookieOptions } from '@supabase/ssr'
 import { cookies } from 'next/headers'
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Documentation edit for clarity.

## What is the current behavior?

The filename for example code for Next.js' Route Handler is `route.js`.

![Screenshot 2023-10-28 at 2 50 08 AM](https://github.com/supabase/supabase/assets/56215649/e6af9a4e-cf1b-4fcc-a456-dd6a60d092b9)


## What is the new behavior?

The filename should be `route.ts` not `route.js`.

![Screenshot 2023-10-28 at 2 52 22 AM](https://github.com/supabase/supabase/assets/56215649/25547220-eddf-4333-a591-f3f387ad07df)

## Additional context

closes https://github.com/supabase/supabase/issues/18548