### PR TITLE
fix typo from local-development page

### DIFF
--- a/apps/docs/pages/guides/cli/local-development.mdx
+++ b/apps/docs/pages/guides/cli/local-development.mdx
@@ -436,7 +436,7 @@ supabase db pull --schema auth
 
 ### Sync Storage buckets
 
-Your RLS policies on storge buckets can be pulled locally by specifying `storage` schema. For example,
+Your RLS policies on storage buckets can be pulled locally by specifying `storage` schema. For example,
 
 ```bash
 supabase db pull --schema storage


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

A comment with the word `storge` instead of `storage`
![image](https://github.com/supabase/supabase/assets/50243385/38f3cd77-16cc-4ddd-ad73-14128c8e98e9)

## What is the new behavior?

The correct word being used as `storage`

## Additional context

NA
