### PR TITLE
fix: misspelling "lower then" -> "lower than" file-limits.mdx

### DIFF
--- a/apps/docs/pages/guides/storage/uploads/file-limits.mdx
+++ b/apps/docs/pages/guides/storage/uploads/file-limits.mdx
@@ -32,7 +32,7 @@ It is a good practice to have the global limit set to the highest possible file 
 ## Per Bucket Restrictions
 
 You can have different restrictions on a per bucket level.
-You are able to restrict the file types (eg. `pdf`, `images`, `videos`) along with the max file size which should be lower then the global limit.
+You are able to restrict the file types (eg. `pdf`, `images`, `videos`) along with the max file size which should be lower than the global limit.
 
 To apply these limit on a bucket level see [Creating Bucket](/docs/guides/storage/buckets/creating-buckets#restricting-uploads)
 


### PR DESCRIPTION
to make prod happy:
<img width="497" alt="Screenshot 2023-10-30 at 17 23 32" src="https://github.com/supabase/supabase/assets/10985857/8d4a331a-256f-457d-b74c-ca09feaddb13">
