### PR TITLE
1 liner explanation of RLS in auth docs

### DIFF
--- a/apps/docs/pages/guides/auth/row-level-security.mdx
+++ b/apps/docs/pages/guides/auth/row-level-security.mdx
@@ -8,7 +8,9 @@ export const meta = {
   tocVideo: 'Ow_Uzedfohk',
 }
 
-Supabase Auth is designed to work perfectly with [Postgres Row Level Security](/docs/guides/database/postgres/row-level-security) (RLS).
+[Postgres Row Level Security](/docs/guides/database/postgres/row-level-security) (RLS) is a feature of Postgres that allows you to control which users are permitted to perform SELECT/INSERT/UPDATE/DELETE statements on specific rows within tables and views. For example, you could restrict a `blog_post` table such that the current user is only allowed to UPDATE rows where their user id is set in the table's `author_id` column.
+
+Supabase Auth is designed to work perfectly with RLS.
 
 You can use RLS to create [Policies](https://www.postgresql.org/docs/current/sql-createpolicy.html) that are incredibly powerful and flexible, allowing you to write complex SQL rules which fit your unique business needs.
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
Adding a 1 liner to the RLS auth docs to explain what RLS is early in the document.

We received internal feedback that is isn't immediately clear what RLS does and this is intended to address that

ref: https://www.notion.so/supabase/RLS-guide-doesn-t-explain-what-RLS-is-c3337048e7fa41ba9ccb5576a1c22610#8692d03bb48c4886987bc4c2a1fe5314