### PR TITLE
Fix documentation error for SvelteKit User Management

### DIFF
--- a/apps/docs/pages/guides/getting-started/tutorials/with-sveltekit.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-sveltekit.mdx
@@ -309,7 +309,8 @@ Create a new `src/routes/account/+page.svelte` file with the content below.
 ```svelte src/routes/account/+page.svelte
 <!-- src/routes/account/+page.svelte -->
 <script lang="ts">
-	import { enhance, type SubmitFunction } from '$app/forms'
+	import { enhance } from '$app/forms';
+	import type { SubmitFunction } from '@sveltejs/kit';
 
 	export let data
 	export let form


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

There's a Typescript error with the current documentation, see e.g. https://www.reddit.com/r/Supabase/comments/155jeim/having_trouble_with_the_usermanagement_tutorial/

## What is the new behavior?

Fixes the error by using the solution suggested in this comment: https://www.reddit.com/r/Supabase/comments/155jeim/comment/jy9ysrf/

## Additional context

N/A
