### PR TITLE
fix: missed exclamation mark

### DIFF
--- a/i18n/README.ko.md
+++ b/i18n/README.ko.md
@@ -21,7 +21,7 @@
 - [x] 파일 스토리지. [Docs](https://supabase.com/docs/guides/storage)
 - [x] 대시보드
 
-[슈퍼베이스 대시보드](https://raw.githubusercontent.com/supabase/supabase/master/apps/www/public/images/github/supabase-dashboard.png)
+![슈퍼베이스 대시보드](https://raw.githubusercontent.com/supabase/supabase/master/apps/www/public/images/github/supabase-dashboard.png)
 
 ## 문서
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

An exclamation mark was added because it was missing in the markdown displaying the image.

## What is the current behavior?

<img width="1007" alt="current" src="https://github.com/supabase/supabase/assets/75208324/7b469566-4cc6-4322-a308-6bd757c478be">


## What is the new behavior?

<img width="1084" alt="new behavior" src="https://github.com/supabase/supabase/assets/75208324/9ab18df1-7369-4f40-98fa-d99bd6cde548">


## Additional context

Add any other context or screenshots.
