### PR TITLE
fix webook undefined

### DIFF
--- a/studio/data/database-triggers/database-trigger-update-transaction-mutation.ts
+++ b/studio/data/database-triggers/database-trigger-update-transaction-mutation.ts
@@ -41,7 +41,7 @@ export async function updateDatabaseTrigger({
 }: DatabaseTriggerUpdateVariables) {
   const sql = getDatabaseTriggerUpdateSQL({ originalTrigger, updatedTrigger })
   const { result } = await executeSql({ projectRef, connectionString, sql })
-  return result
+  return updatedTrigger
 }
 
 type DatabaseTriggerUpdateTxnData = Awaited<ReturnType<typeof updateDatabaseTrigger>>


### PR DESCRIPTION
## What kind of change does this PR introduce?

#18615 

Bug fix, feature, docs update, ...

## What is the current behavior?

After updating the webhook, the UI notification displays the webhook name as "undefined."


## What is the new behavior?

This fix ensures that the UI notification correctly displays the edited webhook's name.


![webhook](https://github.com/supabase/supabase/assets/113853868/c9dad856-c772-47cc-bc7a-0080c4931af6)


## Additional context

Add any other context or screenshots.
