### PR TITLE
chore: prefetch project

### DIFF
--- a/studio/components/interfaces/Home/ProjectList/ProjectCard.tsx
+++ b/studio/components/interfaces/Home/ProjectList/ProjectCard.tsx
@@ -1,5 +1,7 @@
 import CardButton from 'components/ui/CardButton'
 import { IntegrationProjectConnection } from 'data/integrations/integrations.types'
+import { usePrefetchProjectDetail } from 'data/projects/project-detail-query'
+import { usePrefetchProjectUsage } from 'data/usage/project-usage-query'
 import { ResourceWarning } from 'data/usage/resource-warnings-query'
 import { BASE_PATH } from 'lib/constants'
 import { GitBranch, Github } from 'lucide-react'
@@ -30,6 +32,9 @@ const ProjectCard = ({
   const isVercelIntegrated = vercelIntegration !== undefined
   const githubRepository = githubIntegration?.metadata.name ?? undefined
   const projectStatus = inferProjectStatus(project)
+
+  const prefetchProjectDetail = usePrefetchProjectDetail()
+  const prefetchProjectUsage = usePrefetchProjectUsage()
 
   return (
     <li className="list-none">
@@ -69,6 +74,10 @@ const ProjectCard = ({
         footer={
           <ProjectCardStatus projectStatus={projectStatus} resourceWarnings={resourceWarnings} />
         }
+        onHover={() => {
+          prefetchProjectDetail(projectRef)
+          prefetchProjectUsage(projectRef)
+        }}
       />
     </li>
   )

--- a/studio/components/interfaces/Home/ProjectList/ProjectCard.tsx
+++ b/studio/components/interfaces/Home/ProjectList/ProjectCard.tsx
@@ -92,7 +92,6 @@ const ProjectCard = ({
             })
             .then((projectDetail) => {
               if (projectDetail !== undefined) {
-                console.log('running')
                 prefetchEntityTypes({
                   projectRef: projectDetail?.ref,
                   connectionString: projectDetail?.connectionString,

--- a/studio/components/interfaces/Home/ProjectUsageSection.tsx
+++ b/studio/components/interfaces/Home/ProjectUsageSection.tsx
@@ -1,5 +1,4 @@
 import { useParams } from 'common'
-import { observer } from 'mobx-react-lite'
 import { IconAlertCircle, IconLoader } from 'ui'
 
 import { NewProjectPanel } from 'components/interfaces/Home'
@@ -7,7 +6,7 @@ import InformationBox from 'components/ui/InformationBox'
 import { ProjectUsageResponseUsageKeys, useProjectUsageQuery } from 'data/usage/project-usage-query'
 import ProjectUsage from './ProjectUsage'
 
-const ProjectUsageSection = observer(() => {
+const ProjectUsageSection = () => {
   const { ref: projectRef } = useParams()
   const { data: usage, error: usageError, isLoading } = useProjectUsageQuery({ projectRef })
 
@@ -50,5 +49,6 @@ const ProjectUsageSection = observer(() => {
       )}
     </>
   )
-})
+}
+
 export default ProjectUsageSection

--- a/studio/components/ui/CardButton.tsx
+++ b/studio/components/ui/CardButton.tsx
@@ -1,3 +1,4 @@
+import { noop } from 'lib/void'
 import Link from 'next/link'
 import React, { PropsWithChildren } from 'react'
 import { IconChevronRight, IconLoader } from 'ui'
@@ -11,6 +12,7 @@ interface CardButtonProps {
   imgUrl?: string
   imgAlt?: string
   onClick?: () => void
+  onHover?: () => void
   icon?: React.ReactNode
   loading?: boolean
   className?: string
@@ -26,17 +28,28 @@ const CardButton = ({
   imgUrl,
   imgAlt,
   onClick,
+  onHover = noop,
   icon,
   className,
   loading = false,
 }: PropsWithChildren<CardButtonProps>) => {
   const LinkContainer = ({ children }: { children: React.ReactNode }) => (
-    <Link href={linkHref}>{children}</Link>
+    <Link href={linkHref} onMouseEnter={onHover}>
+      {children}
+    </Link>
   )
-  const UrlContainer = ({ children }: { children: React.ReactNode }) => <a href={url}>{children}</a>
-  const NonLinkContainer = ({ children }: { children: React.ReactNode }) => <div>{children}</div>
+  const UrlContainer = ({ children }: { children: React.ReactNode }) => (
+    <a href={url} onMouseEnter={onHover}>
+      {children}
+    </a>
+  )
+  const NonLinkContainer = ({ children }: { children: React.ReactNode }) => (
+    <div onMouseEnter={onHover}>{children}</div>
+  )
   const ButtonContainer = ({ children }: { children: React.ReactNode }) => (
-    <button onClick={onClick}>{children}</button>
+    <button onClick={onClick} onMouseEnter={onHover}>
+      {children}
+    </button>
   )
 
   const isLink = url || linkHref || onClick

--- a/studio/components/ui/CardButton.tsx
+++ b/studio/components/ui/CardButton.tsx
@@ -34,7 +34,7 @@ const CardButton = ({
   loading = false,
 }: PropsWithChildren<CardButtonProps>) => {
   const LinkContainer = ({ children }: { children: React.ReactNode }) => (
-    <Link href={linkHref} onMouseEnter={onHover}>
+    <Link href={linkHref} onClick={onClick} onMouseEnter={onHover}>
       {children}
     </Link>
   )
@@ -121,10 +121,10 @@ const CardButton = ({
     </div>
   )
 
-  if (onClick) {
-    return <ButtonContainer>{contents}</ButtonContainer>
-  } else if (linkHref) {
+  if (linkHref) {
     return <LinkContainer>{contents}</LinkContainer>
+  } else if (onClick) {
+    return <ButtonContainer>{contents}</ButtonContainer>
   } else if (url) {
     return <UrlContainer>{contents}</UrlContainer>
   } else {

--- a/studio/data/projects/project-detail-query.ts
+++ b/studio/data/projects/project-detail-query.ts
@@ -1,9 +1,10 @@
-import { QueryClient, useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { QueryClient, useQuery, useQueryClient, UseQueryOptions } from '@tanstack/react-query'
 
 import { get, isResponseOk } from 'lib/common/fetch'
 import { API_URL } from 'lib/constants'
 import { Project, ResponseError } from 'types'
 import { projectKeys } from './keys'
+import { useCallback } from 'react'
 
 export type ProjectDetailVariables = { ref?: string }
 
@@ -47,4 +48,24 @@ export async function getCachedProjectDetail(
   if (cached) return cached
 
   return await client.fetchQuery<ProjectDetailData, ProjectDetailError>(projectKeys.detail(ref))
+}
+
+export async function prefetchProjectDetail(client: QueryClient, ref: string | undefined) {
+  return await client.prefetchQuery<ProjectDetailData, ProjectDetailError>(
+    projectKeys.detail(ref),
+    {
+      queryFn: ({ signal }) => getProjectDetail({ ref }, signal),
+    }
+  )
+}
+
+export function usePrefetchProjectDetail() {
+  const client = useQueryClient()
+
+  return useCallback(
+    (ref: string | undefined) => {
+      return prefetchProjectDetail(client, ref)
+    },
+    [client]
+  )
 }

--- a/studio/data/projects/project-detail-query.ts
+++ b/studio/data/projects/project-detail-query.ts
@@ -50,13 +50,10 @@ export async function getCachedProjectDetail(
   return await client.fetchQuery<ProjectDetailData, ProjectDetailError>(projectKeys.detail(ref))
 }
 
-export async function prefetchProjectDetail(client: QueryClient, ref: string | undefined) {
-  return await client.prefetchQuery<ProjectDetailData, ProjectDetailError>(
-    projectKeys.detail(ref),
-    {
-      queryFn: ({ signal }) => getProjectDetail({ ref }, signal),
-    }
-  )
+export function prefetchProjectDetail(client: QueryClient, ref: string | undefined) {
+  return client.prefetchQuery<ProjectDetailData, ProjectDetailError>(projectKeys.detail(ref), {
+    queryFn: ({ signal }) => getProjectDetail({ ref }, signal),
+  })
 }
 
 export function usePrefetchProjectDetail() {

--- a/studio/data/query-client.ts
+++ b/studio/data/query-client.ts
@@ -16,6 +16,7 @@ export function getQueryClient() {
     new QueryClient({
       defaultOptions: {
         queries: {
+          staleTime: 60 * 1000, // 1 minute
           retry: (failureCount, error) => {
             // Don't retry on 404s
             if (

--- a/studio/data/usage/project-usage-query.ts
+++ b/studio/data/usage/project-usage-query.ts
@@ -1,4 +1,4 @@
-import { useQuery, useQueryClient, UseQueryOptions } from '@tanstack/react-query'
+import { QueryClient, useQuery, useQueryClient, UseQueryOptions } from '@tanstack/react-query'
 import { get } from 'lib/common/fetch'
 import { API_URL } from 'lib/constants'
 import { useCallback } from 'react'
@@ -81,3 +81,23 @@ export const useProjectUsageQuery = <TData = ProjectUsageData>(
       ...options,
     }
   )
+
+export async function prefetchProjectUsage(client: QueryClient, projectRef: string | undefined) {
+  return await client.prefetchQuery<ProjectUsageData, ProjectUsageError>(
+    usageKeys.usage(projectRef),
+    {
+      queryFn: ({ signal }) => getProjectUsage({ projectRef }, signal),
+    }
+  )
+}
+
+export function usePrefetchProjectUsage() {
+  const client = useQueryClient()
+
+  return useCallback(
+    (projectRef: string | undefined) => {
+      return prefetchProjectUsage(client, projectRef)
+    },
+    [client]
+  )
+}

--- a/studio/data/usage/project-usage-query.ts
+++ b/studio/data/usage/project-usage-query.ts
@@ -82,13 +82,10 @@ export const useProjectUsageQuery = <TData = ProjectUsageData>(
     }
   )
 
-export async function prefetchProjectUsage(client: QueryClient, projectRef: string | undefined) {
-  return await client.prefetchQuery<ProjectUsageData, ProjectUsageError>(
-    usageKeys.usage(projectRef),
-    {
-      queryFn: ({ signal }) => getProjectUsage({ projectRef }, signal),
-    }
-  )
+export function prefetchProjectUsage(client: QueryClient, projectRef: string | undefined) {
+  return client.prefetchQuery<ProjectUsageData, ProjectUsageError>(usageKeys.usage(projectRef), {
+    queryFn: ({ signal }) => getProjectUsage({ projectRef }, signal),
+  })
 }
 
 export function usePrefetchProjectUsage() {


### PR DESCRIPTION
Unknowns:

- Is each button knowing what it has to preload the best approach? Can we invert control here?
- Can the API handle the extra strain of so many requests?
- Is adding a default `staleTime` of 1 minute to all queries okay? Are we invalidating everything everywhere?