### PR TITLE
feat: Add automatic login flow support

### DIFF
--- a/studio/data/api.d.ts
+++ b/studio/data/api.d.ts
@@ -10160,6 +10160,7 @@ export interface operations {
       /** @description Failed to get github pull requests for a given repo */
       500: {
         content: never
+      }
     }
   }
   /** Create CLI login session */

--- a/studio/data/api.d.ts
+++ b/studio/data/api.d.ts
@@ -796,6 +796,14 @@ export interface paths {
     /** Gets github pull requests for a given repo */
     get: operations['GitHubPullRequestController_getPullRequests']
   }
+  '/platform/cli/login': {
+    /** Create CLI login session */
+    post: operations['CliLoginController_createCliLoginSession']
+  }
+  '/platform/cli/login/{session_id}': {
+    /** Retrieve CLI login session */
+    get: operations['CliLoginController_getCliLoginSession']
+  }
   '/system/auth/{ref}/templates/{template}': {
     /** Gets GoTrue template */
     get: operations['AuthTemplateController_getTemplate']
@@ -10152,7 +10160,25 @@ export interface operations {
       /** @description Failed to get github pull requests for a given repo */
       500: {
         content: never
+    }
+  }
+  /** Create CLI login session */
+  CliLoginController_createCliLoginSession: {
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['CreateCliLoginSessionBody']
       }
+    }
+    responses: {
+      /** @description Failed to create CLI login session */
+      500: never
+    }
+  }
+  /** Retrieve CLI login session */
+  CliLoginController_getCliLoginSession: {
+    responses: {
+      /** @description Failed to retrieve CLI login session */
+      500: never
     }
   }
   /** Gets GoTrue template */

--- a/studio/data/cli/login.ts
+++ b/studio/data/cli/login.ts
@@ -1,0 +1,21 @@
+import { post } from 'data/fetchers'
+
+export async function createCliLoginSession(
+  sessionId: string,
+  publicKey: string,
+  tokenName?: string
+) {
+  if (!sessionId) {
+    throw new Error('sessionId is required')
+  }
+
+  const { data } = await post(`/platform/cli/login`, {
+    body: {
+      session_id: sessionId,
+      public_key: publicKey,
+      token_name: tokenName,
+    },
+  })
+
+  return data
+}

--- a/studio/data/cli/login.ts
+++ b/studio/data/cli/login.ts
@@ -9,13 +9,15 @@ export async function createCliLoginSession(
     throw new Error('sessionId is required')
   }
 
-  const { data } = await post(`/platform/cli/login`, {
+  const { data, error } = await post(`/platform/cli/login`, {
     body: {
       session_id: sessionId,
       public_key: publicKey,
       token_name: tokenName,
     },
   })
+
+  if (error) throw error
 
   return data
 }

--- a/studio/pages/cli/login.tsx
+++ b/studio/pages/cli/login.tsx
@@ -1,0 +1,54 @@
+import { NextPage } from 'next'
+import APIAuthorizationLayout from 'components/layouts/APIAuthorizationLayout'
+import { createCliLoginSession } from 'data/cli/login'
+import { useParams } from 'common'
+import { useRouter } from 'next/router'
+import { withAuth } from 'hooks'
+import Connecting from 'components/ui/Loading/Loading'
+import { useEffect, useState } from 'react'
+
+const CliLoginPage: NextPage = () => {
+  const router = useRouter()
+  const { session_id, public_key, token_name, success } = useParams()
+  const [isSuccessfulLogin, setSuccessfulLogin] = useState(false)
+
+  useEffect(() => {
+    if (!router.isReady) {
+      return
+    }
+
+    if (success) {
+      setSuccessfulLogin(true)
+      return
+    }
+
+    async function createSession() {
+      if (!session_id || !public_key) {
+        router.push('/404')
+        return
+      }
+
+      const session = await createCliLoginSession(session_id, public_key, token_name)
+
+      if (session) {
+        router.push(`/cli/login?success=true`)
+      } else {
+        router.push(`/404`)
+      }
+    }
+
+    createSession()
+  }, [router, router.isReady, session_id, public_key, token_name, success])
+
+  return (
+    <APIAuthorizationLayout>
+      <div>
+        <div className={`flex items-center justify-center h-full`}>
+          {isSuccessfulLogin ? 'Well done! Now close this window, go back to your terminal and hack away!' : <Connecting /> }
+        </div>
+      </div>
+    </APIAuthorizationLayout>
+  )
+}
+
+export default withAuth(CliLoginPage)

--- a/studio/pages/cli/login.tsx
+++ b/studio/pages/cli/login.tsx
@@ -1,4 +1,5 @@
 import { NextPage } from 'next'
+import toast from 'react-hot-toast'
 import APIAuthorizationLayout from 'components/layouts/APIAuthorizationLayout'
 import { createCliLoginSession } from 'data/cli/login'
 import { useParams } from 'common'
@@ -6,6 +7,7 @@ import { useRouter } from 'next/router'
 import { withAuth } from 'hooks'
 import Connecting from 'components/ui/Loading/Loading'
 import { useEffect, useState } from 'react'
+import Link from 'next/link'
 
 const CliLoginPage: NextPage = () => {
   const router = useRouter()
@@ -28,12 +30,17 @@ const CliLoginPage: NextPage = () => {
         return
       }
 
-      const session = await createCliLoginSession(session_id, public_key, token_name)
+      try {
+        const session = await createCliLoginSession(session_id, public_key, token_name)
 
-      if (session) {
-        router.push(`/cli/login?success=true`)
-      } else {
-        router.push(`/404`)
+        if (session) {
+          router.push(`/cli/login?success=true`)
+        } else {
+          router.push(`/404`)
+        }
+      } catch (error: any) {
+        toast.error(`Failed to create login session: ${error.message}`)
+        router.push(`/500`)
       }
     }
 
@@ -42,10 +49,21 @@ const CliLoginPage: NextPage = () => {
 
   return (
     <APIAuthorizationLayout>
-      <div>
-        <div className={`flex items-center justify-center h-full`}>
-          {isSuccessfulLogin ? 'Well done! Now close this window, go back to your terminal and hack away!' : <Connecting /> }
-        </div>
+      <div className={`flex flex-col items-center justify-center h-full`}>
+        {isSuccessfulLogin ? (
+          <>
+            <p>Well done! Now close this window, go back to your terminal and hack away!</p>
+            <p>
+              If you ever want to remove your new token, go to{' '}
+              <Link href="/account/tokens" className="underline">
+                Access Tokens
+              </Link>{' '}
+              page.
+            </p>
+          </>
+        ) : (
+          <Connecting />
+        )}
       </div>
     </APIAuthorizationLayout>
   )


### PR DESCRIPTION
Adds support for CLI automated login flow, which uses the browser session to authenticate and generate a new token, which is used in the cli `login` command.

RFC: https://www.notion.so/supabase/RFC-Automatic-browser-based-CLI-login-flow-fc4f91fc7e7f4f168d2da6192841dcec?d=d8c9bcbe826c4665a89f9240d0854a36

CLI changes: https://github.com/supabase/cli/pull/1630
API changes: https://github.com/supabase/infrastructure/pull/15529