### PR TITLE
docs: add admonition to slack oauth guide

### DIFF
--- a/apps/docs/pages/guides/auth/social-login/auth-slack.mdx
+++ b/apps/docs/pages/guides/auth/social-login/auth-slack.mdx
@@ -10,6 +10,12 @@ To enable Slack Auth for your project, you need to set up a Slack OAuth applicat
 
 ## Overview
 
+<Admonition type="caution" label="update">
+
+The Slack OAuth provider supported by Supabase uses Slack's [**Legacy OAuth API**](https://api.slack.com/legacy/oauth). If you created an OAuth app on Slack recently, some of the scopes specified may not work with the Slack OAuth provider on Supabase. You can refer to the [**list of supported scopes**](https://api.slack.com/scopes) for the legacy oauth app and this [**github issue**](https://github.com/supabase/gotrue/issues/1294) for future updates.
+
+</Admonition>
+
 Setting up Slack logins for your application consists of 3 parts:
 
 - Create and configure a Slack Project and App on the [Slack Developer Dashboard](https://api.slack.com/apps).

--- a/apps/docs/pages/guides/auth/social-login/auth-slack.mdx
+++ b/apps/docs/pages/guides/auth/social-login/auth-slack.mdx
@@ -12,7 +12,7 @@ To enable Slack Auth for your project, you need to set up a Slack OAuth applicat
 
 <Admonition type="caution" label="update">
 
-The Slack OAuth provider supported by Supabase uses Slack's [**Legacy OAuth API**](https://api.slack.com/legacy/oauth). If you created an OAuth app on Slack recently, some of the scopes specified may not work with the Slack OAuth provider on Supabase. You can refer to the [**list of supported scopes**](https://api.slack.com/scopes) for the legacy oauth app and this [**github issue**](https://github.com/supabase/gotrue/issues/1294) for future updates.
+The Slack OAuth provider supported by Supabase uses Slack's [**Legacy OAuth API**](https://api.slack.com/legacy/oauth). If you created an OAuth app on Slack recently, some of the scopes specified may not work with the Slack OAuth provider on Supabase. You can refer to the [**list of supported scopes**](https://api.slack.com/scopes) for the legacy OAuth app and this [**github issue**](https://github.com/supabase/gotrue/issues/1294) for future updates.
 
 </Admonition>
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Slack deprecated their OAuth2.0 API recently and introduced a new set of V2 endpoints which we do not support yet. 
* Developers who are looking to create a new slack oauth app should take note of the legacy scopes supported 