### PR TITLE
Fix: improve docs for `@supabase/ssr`

### DIFF
--- a/apps/docs/pages/guides/auth/server-side/creating-a-client.mdx
+++ b/apps/docs/pages/guides/auth/server-side/creating-a-client.mdx
@@ -560,6 +560,16 @@ export const actions: Actions = {
 </TabPanel>
 <TabPanel id="astro" label="Astro">
 
+By default, Astro apps are static. This means the requests for data happen at build time, rather than when the user requests a page. At build time, there is no user, session or cookies. Therefore, we need to configure Astro for Server-side Rendering (SSR) if you want data to be fetched dynamically per request.
+
+```js astro.config.mjs
+import { defineConfig } from 'astro/config'
+
+export default defineConfig({
+  output: 'server',
+})
+```
+
 <Tabs
   scrollable
   size="small"

--- a/apps/docs/pages/guides/auth/server-side/creating-a-client.mdx
+++ b/apps/docs/pages/guides/auth/server-side/creating-a-client.mdx
@@ -317,12 +317,12 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
         },
         set(name: string, value: string, options: CookieOptions) {
           context.res.appendHeader(
-            "set-cookie",
+            "Set-Cookie",
             serialize(name, value, options)
           );
         },
         remove(name: string, options: CookieOptions) {
-          context.res.appendHeader("set-cookie", serialize(name, "", options));
+          context.res.appendHeader("Set-Cookie", serialize(name, "", options));
         },
       },
     }
@@ -374,10 +374,10 @@ export default async function handler(
           return req.cookies[name];
         },
         set(name: string, value: string, options: CookieOptions) {
-          res.appendHeader("set-cookie", serialize(name, value, options));
+          res.appendHeader("Set-Cookie", serialize(name, value, options));
         },
         remove(name: string, options: CookieOptions) {
-          res.appendHeader("set-cookie", serialize(name, "", options));
+          res.appendHeader("Set-Cookie", serialize(name, "", options));
         },
       },
     }

--- a/apps/docs/pages/guides/auth/server-side/creating-a-client.mdx
+++ b/apps/docs/pages/guides/auth/server-side/creating-a-client.mdx
@@ -607,6 +607,37 @@ const supabase = createServerClient(
 ```
 
 </TabPanel>
+
+<TabPanel id="astro-server-endpoint" label="Server Endpoint">
+
+```ts route.ts
+import { createServerClient, type CookieOptions } from "@supabase/ssr";
+import type { APIContext } from "astro";
+
+export async function GET(context: APIContext) {
+  const supabase = createServerClient(
+    import.meta.env.PUBLIC_SUPABASE_URL,
+    import.meta.env.PUBLIC_SUPABASE_ANON_KEY,
+    {
+      cookies: {
+        get(key: string) {
+          return context.cookies.get(key)?.value;
+        },
+        set(key: string, value: string, options: CookieOptions) {
+          context.cookies.set(key, value, options);
+        },
+        remove(key: string, options) {
+          context.cookies.delete(key, options);
+        },
+      },
+    }
+  );
+
+  return ...
+}
+```
+
+</TabPanel>
 </Tabs>
 
 </TabPanel>

--- a/apps/docs/pages/guides/auth/server-side/creating-a-client.mdx
+++ b/apps/docs/pages/guides/auth/server-side/creating-a-client.mdx
@@ -302,39 +302,27 @@ export default async function Page () {
 
 <TabPanel id="get-server-side-props" label="getServerSideProps">
 
-Cookies have many edge cases when not using a helper function, therefore we recommend using the `cookies` package in `getServerSideProps` to provide a similar API to the Next.js `cookies` function in the App Router.
-
-```bash
-npm install cookies
-```
-
-Types can optionally be installed as well.
-
-```bash
-npm install --save-dev @types/cookies
-```
-
 ```ts index.tsx
 import { type GetServerSidePropsContext } from 'next'
-import { createServerClient, type CookieOptions } from '@supabase/ssr'
-import Cookies from 'cookies'
+import { createServerClient, type CookieOptions, serialize } from '@supabase/ssr'
 
 export const getServerSideProps = async (context: GetServerSidePropsContext) => {
-  const cookies = new Cookies(context.req, context.res)
-
   const supabase = createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
       cookies: {
         get(name: string) {
-          return cookies.get(name)
+          return context.req.cookies[name];
         },
         set(name: string, value: string, options: CookieOptions) {
-          cookies.set(name, value, options)
+          context.res.appendHeader(
+            "set-cookie",
+            serialize(name, value, options)
+          );
         },
         remove(name: string, options: CookieOptions) {
-          cookies.set(name, '', options)
+          context.res.appendHeader("set-cookie", serialize(name, "", options));
         },
       },
     }
@@ -356,8 +344,6 @@ from `supabase-js`.
 import { createClient } from '@supabase/supabase-js'
 
 export const getStaticProps = async () => {
-  const cookies = new Cookies(context.req, context.res)
-
   const supabase = createClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
@@ -371,42 +357,27 @@ export const getStaticProps = async () => {
 
 <TabPanel id="api-route" label="API Route">
 
-Cookies have many edge cases when not using a helper function, therefore, we recommend using the `cookies` package in API Routes to provide a similar API to the Next.js `cookies` function in the App Router.
-
-```bash
-npm install cookies
-```
-
-Types can optionally be installed as well.
-
-```bash
-npm install --save-dev @types/cookies
-```
-
 ```ts index.tsx
-import { createServerClient, type CookieOptions } from "@supabase/ssr"
+import { createServerClient, type CookieOptions, serialize } from "@supabase/ssr"
 import { type NextApiRequest, type NextApiResponse } from "next"
-import Cookies from "cookies"
 
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
-  const cookies = new Cookies(req, res)
-
   const supabase = createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
       cookies: {
         get(name: string) {
-          return cookies.get(name)
+          return req.cookies[name];
         },
         set(name: string, value: string, options: CookieOptions) {
-          cookies.set(name, value, options)
+          res.appendHeader("set-cookie", serialize(name, value, options));
         },
         remove(name: string, options: CookieOptions) {
-          cookies.set(name, "", options)
+          res.appendHeader("set-cookie", serialize(name, "", options));
         },
       },
     }

--- a/apps/docs/pages/guides/auth/server-side/email-based-auth-with-pkce-flow-for-ssr.mdx
+++ b/apps/docs/pages/guides/auth/server-side/email-based-auth-with-pkce-flow-for-ssr.mdx
@@ -64,12 +64,12 @@ export async function GET(request: Request) {
       token_hash,
     })
     if (!error) {
-      return NextResponse.redirect(new URL(`/${next.slice(1)}`, request.url))
+      return NextResponse.redirect(next)
     }
   }
 
   // return the user to an error page with some instructions
-  return NextResponse.redirect(new URL('/auth/auth-code-error', request.url))
+  return NextResponse.redirect('/auth/auth-code-error')
 }
 ```
 
@@ -144,7 +144,7 @@ export const GET: APIRoute = async ({ request, cookies, redirect }) => {
     })
 
     if (!error) {
-      return redirect(`/${next.slice(1)}`)
+      return redirect(next)
     }
   }
 
@@ -194,12 +194,12 @@ export async function loader({ request }: LoaderFunctionArgs) {
     })
 
     if (!error) {
-      return redirect(`/${next.slice(1)}`)
+      return redirect(next, { headers })
     }
   }
 
   // return the user to an error page with instructions
-  return redirect('/auth/auth-code-error')
+  return redirect('/auth/auth-code-error', { headers })
 }
 ```
 

--- a/apps/docs/pages/guides/auth/server-side/oauth-with-pkce-flow-for-ssr.mdx
+++ b/apps/docs/pages/guides/auth/server-side/oauth-with-pkce-flow-for-ssr.mdx
@@ -60,12 +60,12 @@ export async function GET(request: Request) {
 
     const { error } = await supabase.auth.exchangeCodeForSession(code)
     if (!error) {
-      return NextResponse.redirect(new URL(`/${next.slice(1)}`, request.url))
+      return NextResponse.redirect(next)
     }
   }
 
   // return the user to an error page with instructions
-  return NextResponse.redirect(new URL('/auth/auth-code-error', request.url))
+  return NextResponse.redirect('/auth/auth-code-error'))
 }
 ```
 
@@ -134,7 +134,7 @@ export const GET: APIRoute = async ({ request, cookies, redirect }) => {
     const { error } = await supabase.auth.exchangeCodeForSession(code)
 
     if (!error) {
-      return redirect(`/${next.slice(1)}`)
+      return redirect(next)
     }
   }
 
@@ -179,12 +179,12 @@ export async function loader({ request }: LoaderFunctionArgs) {
     const { error } = await supabase.auth.exchangeCodeForSession(code)
 
     if (!error) {
-      return redirect(`/${next.slice(1)}`)
+      return redirect(next, { headers })
     }
   }
 
   // return the user to an error page with instructions
-  return redirect('/auth/auth-code-error')
+  return redirect('/auth/auth-code-error', { headers })
 }
 ```
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix

## What is the current behavior?

[1] User is signed out if using Supabase across client and server of Pages router
[2] Remix actions do not return headers
[3] No Server Endpoint example in Astro create client page
[4] No step to configure Astro for SSR

## What is the new behavior?

[1] User remains signed in while using Supabase across client and server of Pages router
[2] Remix actions return headers
[3] New Server Endpoint example in Astro create client page
[4] Added a step to configure Astro for SSR
