### PR TITLE
Remove TCE support for table editor

### DIFF
--- a/studio/components/interfaces/TableGridEditor/TableGridEditor.tsx
+++ b/studio/components/interfaces/TableGridEditor/TableGridEditor.tsx
@@ -223,10 +223,6 @@ const TableGridEditor = ({
     if (gridRef.current) gridRef.current.rowEdited(row, idx)
   }
 
-  const onColumnSaved = (hasEncryptedColumns = false) => {
-    if (hasEncryptedColumns) getEncryptedColumns(selectedTable)
-  }
-
   const onTableCreated = (table: PostgresTable) => {
     router.push(`/project/${projectRef}/editor/${table.id}`)
   }
@@ -396,7 +392,6 @@ const TableGridEditor = ({
           selectedTable={selectedTable as PostgresTable}
           onRowCreated={onRowCreated}
           onRowUpdated={onRowUpdated}
-          onColumnSaved={onColumnSaved}
           onTableCreated={onTableCreated}
         />
       )}

--- a/studio/stores/pgmeta/MetaStore.ts
+++ b/studio/stores/pgmeta/MetaStore.ts
@@ -96,8 +96,7 @@ export interface IMetaStore {
   createColumn: (
     payload: CreateColumnPayload,
     selectedTable: PostgresTable,
-    foreignKey?: ExtendedPostgresRelationship,
-    securityConfiguration?: { isEncrypted: boolean; keyId?: string; keyName?: string }
+    foreignKey?: ExtendedPostgresRelationship
   ) => any
   updateColumn: (
     id: string,
@@ -391,8 +390,7 @@ export default class MetaStore implements IMetaStore {
   async createColumn(
     payload: CreateColumnPayload,
     selectedTable: PostgresTable,
-    foreignKey?: ExtendedPostgresRelationship,
-    securityConfiguration?: { isEncrypted: boolean; keyId?: string; keyName?: string }
+    foreignKey?: ExtendedPostgresRelationship
   ) {
     const toastId = this.rootStore.ui.setNotification({
       category: 'loading',
@@ -435,24 +433,6 @@ export default class MetaStore implements IMetaStore {
         if (relation.error) throw relation.error
       }
 
-      const { isEncrypted, keyId, keyName } = securityConfiguration || {}
-      if (isEncrypted) {
-        this.rootStore.ui.setNotification({
-          id: toastId,
-          category: 'loading',
-          message: 'Encrypting column...',
-        })
-        let encryptionKey = keyId
-        if (keyId === 'create-new') {
-          const addKeyRes = await this.rootStore.vault.addKey(keyName)
-          if (addKeyRes.error) throw addKeyRes.error
-          else encryptionKey = addKeyRes[0].id
-        }
-        if (encryptionKey !== undefined) {
-          const encryptColumnRes = await this.rootStore.vault.encryptColumn(column, encryptionKey)
-          if (encryptColumnRes.error) throw encryptColumnRes.error
-        }
-      }
       this.rootStore.ui.setNotification({
         id: toastId,
         category: 'success',


### PR DESCRIPTION
Transparent column encryption can still be done through the SQL, we're just removing it from the table editor as it's been causing quite a lot of issues due to its ease of use through the GUI