### PR TITLE
Update tailwind.config.js - adds default classes - `bg-default` `border-default`, and `text-default`

### DIFF
--- a/packages/config/tailwind.config.js
+++ b/packages/config/tailwind.config.js
@@ -24,10 +24,26 @@ function generateTwColorClasses(globalKey, twAttributes) {
   let classes = {}
   Object.values(twAttributes).map((attr, i) => {
     const attrKey = Object.keys(twAttributes)[i]
+
     if (attrKey.includes(globalKey)) {
+      const keySplit = attrKey.split('-').splice(1).join('-')
+
+      let payload = {
+        [keySplit]: `hsl(${attr.cssVariable} / <alpha-value>)`,
+      }
+
+      if (keySplit == 'DEFAULT') {
+        // includes a 'default' duplicate
+        // this allows for classes like `border-default` which is the same as `border`
+        payload = {
+          ...payload,
+          default: `hsl(${attr.cssVariable} / <alpha-value>)`,
+        }
+      }
+
       classes = {
         ...classes,
-        [attrKey.split('-').splice(1).join('-')]: `hsl(${attr.cssVariable} / <alpha-value>)`,
+        ...payload,
       }
     }
   })


### PR DESCRIPTION
## What kind of change does this PR introduce?

- DEFAULT class names for `bg`, `border`, and `text` are now accessible with `*-default` rather than just shorthand
- for example; you can access the default border color, this is helpful if you need to explicitly set a color. like `border border-transparent hover:border-default`

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
