### PR TITLE
Fix google nonce check

### DIFF
--- a/studio/stores/authConfig/schema/AuthProviders/AuthProvidersFormValidation.tsx
+++ b/studio/stores/authConfig/schema/AuthProviders/AuthProvidersFormValidation.tsx
@@ -916,7 +916,7 @@ const EXTERNAL_PROVIDER_GOOGLE = {
             'At least one Authorized Client ID is required when not using the OAuth flow.'
           ),
       }),
-    EXTERNAL_GOOGLE_SKIP_NONCE_CHECK: boolean(),
+    EXTERNAL_GOOGLE_SKIP_NONCE_CHECK: boolean().required(),
   }),
   misc: {
     iconKey: 'google-icon',


### PR DESCRIPTION
There were 2 issues here i think
- Projects would have `EXTERNAL_GOOGLE_SKIP_NONCE_CHECK` as NULL to begin with
- The Toggle in the provider form, when initially toggled to true, would somehow set the value of `EXTERNAL_GOOGLE_SKIP_NONCE_CHECK` as `[true]` instead of `true`
- Also users would then be unable to toggle it off as the UI component doesnt know how to read `[true]`

Fix here is to update `generateInitialValues`
- Properties that are boolean should be initialized to be `false` if `null`, and not empty strings, this might have been why
- Also just adding the required check in the form validation, i think the above is the main fix but this is just a why not