### PR TITLE
feat(docs): add hoverable anchor links to h4 tags

### DIFF
--- a/apps/docs/components/index.tsx
+++ b/apps/docs/components/index.tsx
@@ -97,6 +97,11 @@ const components = {
       {props.children}
     </Heading>
   ),
+  h4: (props: any) => (
+    <Heading tag="h4" {...props}>
+      {props.children}
+    </Heading>
+  ),
   RefSubLayout,
   RefHeaderSection: (props: any) => <RefHeaderSection {...props} />,
   CliGlobalFlagsHandler: () => <CliGlobalFlagsHandler />,


### PR DESCRIPTION
## Problem
On the docs site, `h4` tags don't show an anchor link when hovering over it making it difficult to discover the anchor ID for direct linking.
![image](https://github.com/supabase/supabase/assets/4133076/0b9c49bc-a1e9-4f59-b426-3401919ec47d)

## Solution
Wrap `h4`'s in our `Heading` component as part of the markdown rendering pipeline (like we do `h2` and `h3`).

![image](https://github.com/supabase/supabase/assets/4133076/7a93596c-a434-42f0-bf8a-fc0a37b1486c)
