### PR TITLE
chore: use light mode of lottie

### DIFF
--- a/apps/www/components/LaunchWeek/7/Releases/index.tsx
+++ b/apps/www/components/LaunchWeek/7/Releases/index.tsx
@@ -1,7 +1,7 @@
 import Image from 'next/image'
 import { useEffect } from 'react'
 import { Accordion } from 'ui'
-import Lottie from 'lottie-react'
+import Lottie from 'lottie-light-react'
 
 import days, { WeekDayProps, endOfLW7 } from '~/components/LaunchWeek/7/lw7_days'
 import SectionContainer from '~/components/Layouts/SectionContainer'

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -31,7 +31,7 @@
     "framer-motion": "^6.5.1",
     "globby": "^13.2.2",
     "gray-matter": "^4.0.3",
-    "lottie-react": "^2.4.0",
+    "lottie-light-react": "^2.4.0",
     "markdown-toc": "^1.2.0",
     "next": "^13.5.3",
     "next-mdx-remote": "^4.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -280,7 +280,7 @@
         "framer-motion": "^6.5.1",
         "globby": "^13.2.2",
         "gray-matter": "^4.0.3",
-        "lottie-react": "^2.4.0",
+        "lottie-light-react": "^2.4.0",
         "markdown-toc": "^1.2.0",
         "next": "^13.5.3",
         "next-mdx-remote": "^4.4.1",
@@ -22101,10 +22101,10 @@
         "loose-envify": "cli.js"
       }
     },
-    "node_modules/lottie-react": {
+    "node_modules/lottie-light-react": {
       "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/lottie-react/-/lottie-react-2.4.0.tgz",
-      "integrity": "sha512-pDJGj+AQlnlyHvOHFK7vLdsDcvbuqvwPZdMlJ360wrzGFurXeKPr8SiRCjLf3LrNYKANQtSsh5dz9UYQHuqx4w==",
+      "resolved": "https://registry.npmjs.org/lottie-light-react/-/lottie-light-react-2.4.0.tgz",
+      "integrity": "sha512-TXJOnyqEc6ev9/um8Xkxve5EVcgCX2pi1olWc8jj+81qaPyFBA+VxHIc2Ojl42IqeAiKhGHz098ztQOIImJcyg==",
       "dependencies": {
         "lottie-web": "^5.10.2"
       },
@@ -36165,7 +36165,7 @@
         "date-fns": "^2.30.0",
         "formik": "^2.2.9",
         "lodash": "^4.17.21",
-        "lottie-react": "^2.4.0",
+        "lottie-light-react": "^2.4.0",
         "lucide-react": "^0.167.0",
         "next-themes": "^0.2.1",
         "openai": "^3.3.0",
@@ -37773,7 +37773,7 @@
         "json-logic-js": "^2.0.2",
         "jsonrepair": "^3.2.3",
         "lodash": "^4.17.21",
-        "lottie-react": "^2.4.0",
+        "lottie-light-react": "^2.4.0",
         "lucide-react": "^0.167.0",
         "markdown-table": "=2.0.0",
         "mobx": "^6.10.2",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -61,7 +61,7 @@
     "date-fns": "^2.30.0",
     "formik": "^2.2.9",
     "lodash": "^4.17.21",
-    "lottie-react": "^2.4.0",
+    "lottie-light-react": "^2.4.0",
     "lucide-react": "^0.167.0",
     "next-themes": "^0.2.1",
     "openai": "^3.3.0",

--- a/packages/ui/src/components/LogoLoader/LogoLoader.tsx
+++ b/packages/ui/src/components/LogoLoader/LogoLoader.tsx
@@ -1,4 +1,4 @@
-import Lottie from 'lottie-react'
+import Lottie from 'lottie-light-react'
 import loadingAnim from './LogoLoader.anim.json'
 
 const LogoLoader = () => (

--- a/studio/components/ui/Loading/Loading.tsx
+++ b/studio/components/ui/Loading/Loading.tsx
@@ -1,4 +1,4 @@
-import Lottie from 'lottie-react'
+import Lottie from 'lottie-light-react'
 import loadingAnim from './Loading.anim.json'
 
 const Connecting = () => (

--- a/studio/package.json
+++ b/studio/package.json
@@ -60,7 +60,7 @@
     "json-logic-js": "^2.0.2",
     "jsonrepair": "^3.2.3",
     "lodash": "^4.17.21",
-    "lottie-react": "^2.4.0",
+    "lottie-light-react": "^2.4.0",
     "lucide-react": "^0.167.0",
     "markdown-table": "=2.0.0",
     "mobx": "^6.10.2",


### PR DESCRIPTION
We use Lottie to animate our logo when showing the loading animation. Lottie is a very heavy library. Lottie-react adds 75.5kb of gzipped JavaScript, only to animate our logo.

Lottie has a light version which is sufficient for our use-case. It shaves of 28kb of gzipped JavaScript from our bundles.

Eventually we could switch to a static animation based on a gif or something similar to avoid loading that much javascript for simply rendering a loading animation.

Given it's a tiny change, still worth it. Reduces our main bundle size by 8-10%.