### PR TITLE
Update sveltekit ssr guide

### DIFF
--- a/apps/docs/pages/guides/auth/server-side/creating-a-client.mdx
+++ b/apps/docs/pages/guides/auth/server-side/creating-a-client.mdx
@@ -467,7 +467,7 @@ export const handle: Handle = async ({ event, resolve }) => {
 
 </TabPanel>
 
-<TabPanel id="layout" label="Layout Load">
+<TabPanel id="layout" label="Root Layout Load">
 
 <Admonition type="note">
 
@@ -478,7 +478,7 @@ Page components can get access to the supabase client from the `data` object due
 ```ts +layout.ts
 import { PUBLIC_SUPABASE_ANON_KEY, PUBLIC_SUPABASE_URL } from '$env/static/public'
 import type { LayoutLoad } from './$types'
-import { createBrowserClient, isBrowser, parse } from '@supabase/ssr'
+import { combineChunks, createBrowserClient, isBrowser, parse } from '@supabase/ssr'
 
 export const load: LayoutLoad = async ({ fetch, data, depends }) => {
   depends('supabase:auth')
@@ -493,8 +493,11 @@ export const load: LayoutLoad = async ({ fetch, data, depends }) => {
           return JSON.stringify(data.session)
         }
 
-        const cookie = parse(document.cookie)
-        return cookie[key]
+        const cookie = combineChunks(key, (name) => {
+          const cookies = parse(document.cookie)
+          return cookies[name]
+        })
+        return cookie
       },
     },
   })
@@ -504,6 +507,20 @@ export const load: LayoutLoad = async ({ fetch, data, depends }) => {
   } = await supabase.auth.getSession()
 
   return { supabase, session }
+}
+```
+
+</TabPanel>
+
+<TabPanel id="layout-server" label="Root Server Layout">
+
+```ts +layout.server.ts
+import type { LayoutServerLoad } from './$types'
+
+export const load: LayoutServerLoad = async ({ locals: { getSession } }) => {
+	return {
+		session: await getSession()
+	}
 }
 ```
 

--- a/apps/docs/pages/guides/auth/server-side/creating-a-client.mdx
+++ b/apps/docs/pages/guides/auth/server-side/creating-a-client.mdx
@@ -518,9 +518,9 @@ export const load: LayoutLoad = async ({ fetch, data, depends }) => {
 import type { LayoutServerLoad } from './$types'
 
 export const load: LayoutServerLoad = async ({ locals: { getSession } }) => {
-	return {
-		session: await getSession()
-	}
+  return {
+    session: await getSession(),
+  }
 }
 ```
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

Cookie chunking doesn't work in the browser client since it runs on both client and server.

## What is the new behavior?

Cookie chunking now works on browser client when you import the chunking function and perform the operation inside of the `cookies.get` method.

## Additional context

Add any other context or screenshots.
