### PR TITLE
Chore: make auth helpers messaging consistent

### DIFF
--- a/apps/docs/pages/guides/auth/auth-helpers.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers.mdx
@@ -9,7 +9,7 @@ export const meta = {
 
 <Admonition type="caution">
 
-We generally recommend using the new `ssr` package instead of `auth-helpers`. `ssr` takes the core concepts of the Auth Helpers package and makes them available to any server language or framework. Check out the [migration doc](/docs/guides/auth/server-side/migrating-to-ssr-from-auth-helpers) to learn more.
+We generally recommend using the new `@supabase/ssr` package instead of `auth-helpers`. `@supabase/ssr` takes the core concepts of the Auth Helpers package and makes them available to any server framework. Check out the [migration doc](/docs/guides/auth/server-side/migrating-to-ssr-from-auth-helpers) to learn more.
 
 </Admonition>
 

--- a/apps/docs/pages/guides/auth/auth-helpers/nextjs-pages.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/nextjs-pages.mdx
@@ -8,9 +8,9 @@ export const meta = {
   sidebar_label: 'Next.js (pages)',
 }
 
-<Admonition type="danger">
+<Admonition type="caution">
 
-The `auth-helpers` packages have been deprecated in favor of the new `ssr` package. This takes the core concepts of the Auth Helpers package and makes them available to any server language or framework. Check out the [migration doc](/docs/guides/auth/server-side/migrating-to-ssr-from-auth-helpers) to learn more.
+We generally recommend using the new `@supabase/ssr` package instead of `auth-helpers`. `@supabase/ssr` takes the core concepts of the Auth Helpers package and makes them available to any server language or framework. Check out the [migration doc](/docs/guides/auth/server-side/migrating-to-ssr-from-auth-helpers) to learn more.
 
 </Admonition>
 

--- a/apps/docs/pages/guides/auth/auth-helpers/nextjs.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/nextjs.mdx
@@ -8,9 +8,9 @@ export const meta = {
   sidebar_label: 'Next.js',
 }
 
-<Admonition type="danger">
+<Admonition type="caution">
 
-The `auth-helpers` packages have been deprecated in favor of the new `ssr` package. This takes the core concepts of the Auth Helpers package and makes them available to any server language or framework. Check out the [migration doc](/docs/guides/auth/server-side/migrating-to-ssr-from-auth-helpers) to learn more.
+We generally recommend using the new `@supabase/ssr` package instead of `auth-helpers`. `@supabase/ssr` takes the core concepts of the Auth Helpers package and makes them available to any server framework. Check out the [migration doc](/docs/guides/auth/server-side/migrating-to-ssr-from-auth-helpers) to learn more.
 
 </Admonition>
 

--- a/apps/docs/pages/guides/auth/auth-helpers/remix.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/remix.mdx
@@ -7,9 +7,9 @@ export const meta = {
   sidebar_label: 'Remix',
 }
 
-<Admonition type="danger">
+<Admonition type="caution">
 
-The `auth-helpers` packages have been deprecated in favor of the new `ssr` package. This takes the core concepts of the Auth Helpers package and makes them available to any server language or framework. Check out the [migration doc](/docs/guides/auth/server-side/migrating-to-ssr-from-auth-helpers) to learn more.
+We generally recommend using the new `@supabase/ssr` package instead of `auth-helpers`. `@supabase/ssr` takes the core concepts of the Auth Helpers package and makes them available to any server framework. Check out the [migration doc](/docs/guides/auth/server-side/migrating-to-ssr-from-auth-helpers) to learn more.
 
 </Admonition>
 

--- a/apps/docs/pages/guides/auth/auth-helpers/sveltekit.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/sveltekit.mdx
@@ -7,9 +7,9 @@ export const meta = {
   sidebar_label: 'SvelteKit',
 }
 
-<Admonition type="danger">
+<Admonition type="caution">
 
-The `auth-helpers` packages have been deprecated in favor of the new `ssr` package. This takes the core concepts of the Auth Helpers package and makes them available to any server language or framework. Check out the [migration doc](/docs/guides/auth/server-side/migrating-to-ssr-from-auth-helpers) to learn more.
+We generally recommend using the new `@supabase/ssr` package instead of `auth-helpers`. `@supabase/ssr` takes the core concepts of the Auth Helpers package and makes them available to any server framework. Check out the [migration doc](/docs/guides/auth/server-side/migrating-to-ssr-from-auth-helpers) to learn more.
 
 </Admonition>
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

Banners at top of Auth Helpers pages have inconsistent messaging

## What is the new behavior?

Banners at top of Auth Helpers pages have consistent messaging

## Additional context

https://github.com/supabase/supabase/pull/18698
