### PR TITLE
Fix typo in RLS docs code example

### DIFF
--- a/apps/docs/pages/guides/database/postgres/row-level-security.mdx
+++ b/apps/docs/pages/guides/database/postgres/row-level-security.mdx
@@ -288,7 +288,7 @@ begin
   return exists (
     select 1 from roles_table
     where auth.uid() = user_id and role = 'good_role'
-  )
+  );
 end;
 $$;
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update to fix typo in code example, for using a `security definer` function for implementing RLS policies.

## What is the current behavior?

[Current code example](https://supabase.com/docs/guides/database/postgres/row-level-security#use-security-definer-functions) is missing a semicolon on `return` statement (see [Database Functions](https://supabase.com/docs/guides/database/functions#passing-parameters) for comparison).

This causes this error when included in a Postgres migration:

> ERROR: syntax error at end of input (SQLSTATE 42601)

## What is the new behavior?

Migration runs successfully.
