### PR TITLE
Clarify SUPABASE_PROJECT_ID env is not auto-detected be CLI

### DIFF
--- a/apps/docs/pages/guides/cli/managing-environments.mdx
+++ b/apps/docs/pages/guides/cli/managing-environments.mdx
@@ -178,6 +178,9 @@ The Supabase CLI requires a few environment variables to run in non-interactive 
 
 We recommend adding these as [encrypted secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets) to your GitHub Actions runners.
 
+Note that the Supabase CLI will automatically detect and use the `SUPABASE_ACCESS_TOKEN` and `SUPABASE_DB_PASSWORD` environment variables if they are present. 
+However, the `SUPABASE_PROJECT_ID` needs to be passed via the `--project-ref` flag as shown in the example below. 
+
 Create the following files inside the `.github/workflows` directory:
 
 <Tabs


### PR DESCRIPTION
## What kind of change does this PR introduce?

Doc update with clarification about CLI and env var `SUPABASE_PROJECT_ID`

## What is the current behavior?

While the code example shows the correct use of `--project-ref`, the explanatory text does not mention this difference between token and db password versus the project id. This may lead to time lost when improving the infrastructure and ci build and trying to consolidate this env var.

## What is the new behavior?

Added a sentence that explains exactly what to expect

## Additional context

[Issue on cli repo](https://github.com/supabase/cli/issues/1627) when I thought this was a bug
