### PR TITLE
🐞 fix: right sidebar guides table of contents not scrollable

### DIFF
--- a/apps/docs/pages/guides/cli/config.tsx
+++ b/apps/docs/pages/guides/cli/config.tsx
@@ -39,7 +39,7 @@ export default function Config() {
           </div>
         </div>
         <div className="md:col-span-3">
-          <div className="sticky top-20 border-l">
+          <div className="fixed pb-20 overflow-auto h-screen top-20 border-l">
             <span className="block font-mono text-xs uppercase text-scale-1200 pl-5 mb-4">
               On this page
             </span>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix
## What is the current behavior?

Right sidebar guides table of contents not scrollable

## What is the new behavior?

We can now scroll the guides table of contents (sidebar)

## Additional context

[Issue: 18736](https://github.com/supabase/supabase/issues/18736)