### PR TITLE
fix: Fix the Docker build for studio

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -154,7 +154,7 @@ services:
     command: "postgrest"
 
   realtime:
-    container_name: realtime-dev.supabase-realtime
+    container_name: supabase-realtime
     image: supabase/realtime:v2.10.1
     depends_on:
       db:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -154,7 +154,8 @@ services:
     command: "postgrest"
 
   realtime:
-    container_name: supabase-realtime
+    # This container name looks inconsistent but is correct because realtime constructs tenant id by parsing the subdomain
+    container_name: realtime-dev.supabase-realtime
     image: supabase/realtime:v2.10.1
     depends_on:
       db:

--- a/studio/Dockerfile
+++ b/studio/Dockerfile
@@ -53,7 +53,7 @@ RUN npx turbo run build --scope=studio --include-dependencies --no-deps
 # Copy only compiled code and dependencies
 FROM base as production
 COPY --from=builder /app/studio/public ./studio/public
-COPY --from=builder /app/studio/.next/standalone/app ./
+COPY --from=builder /app/studio/.next/standalone ./
 COPY --from=builder /app/studio/.next/static ./studio/.next/static
 EXPOSE 3000
 ENTRYPOINT ["docker-entrypoint.sh"]


### PR DESCRIPTION
The Docker build was broken because we upgraded to Nextjs 13 and it builds a different folder structure. The Dockerfile for building `studio` had to be updated.