### PR TITLE
pg_cron docs: warn about scheduling system maintenance

### DIFF
--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
@@ -674,7 +674,7 @@ export const database: NavMenuConstant = {
         },
         {
           name: 'pg_cron: Job Scheduling',
-          url: '/guides/database/extensions/pgcron',
+          url: '/guides/database/extensions/pg_cron',
         },
         {
           name: 'pg_graphql: GraphQL Support',

--- a/apps/docs/pages/guides/database/extensions/pg_cron.mdx
+++ b/apps/docs/pages/guides/database/extensions/pg_cron.mdx
@@ -61,6 +61,12 @@ The schedule uses the standard cron syntax, in which \* means "run every time pe
 
 You can use [crontab.guru](https://crontab.guru/) to help validate your cron schedules.
 
+### Scheduling System Maintenance
+
+Be extremely careful when setting up pg_cron jobs for system maintenance tasks as they can have unintended consequences. For instance, scheduling a command to terminate idle connections with `pg_terminate_backend(pid)` can disrupt critical background processes like nightly backups. Often, there is an existing Postgres setting e.g. `idle_session_timeout` that can perform these common maintenance tasks without the risk.
+
+Reach out to [Supabase Support](https://supabase.com/support) if you're unsure if that applies to your use case.
+
 ## Examples
 
 ### Delete data every week


### PR DESCRIPTION
## What kind of change does this PR introduce?
Adds a warning to pg_cron extension docs that users should not schedule system maintenance unless they're 100% sure they know what they're doing

Also fixes the pg_cron link in the nav pane, which was previously 404-ing