### PR TITLE
Testing github deploys

### DIFF
--- a/.github/workflows/publish_studio_vercel.yml
+++ b/.github/workflows/publish_studio_vercel.yml
@@ -1,0 +1,36 @@
+name: Vercel Preview Deployment
+env:
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+# Cancel old builds on new commit for same workflow + branch/PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+
+      - name: Pull Vercel Environment Information
+        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Build Project Artifacts
+        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Deploy Project Artifacts to Vercel
+        run: vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/publish_studio_vercel.yml
+++ b/.github/workflows/publish_studio_vercel.yml
@@ -34,7 +34,7 @@ jobs:
         run: npm install --global vercel@latest
 
       - name: Pull Vercel Environment Information
-        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel pull --cwd studio --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Build Project Artifacts
         run: vercel build --cwd studio --token=${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/publish_studio_vercel.yml
+++ b/.github/workflows/publish_studio_vercel.yml
@@ -39,4 +39,4 @@ jobs:
       - name: Build Project Artifacts
         run: vercel build --cwd studio --token=${{ secrets.VERCEL_TOKEN }}
       - name: Deploy Project Artifacts to Vercel
-        run: vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel deploy --cwd studio --prebuilt --token=${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/publish_studio_vercel.yml
+++ b/.github/workflows/publish_studio_vercel.yml
@@ -15,14 +15,20 @@ on:
 jobs:
   deploy-preview:
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18.x]
+
     steps:
       - name: Check out repo
         uses: actions/checkout@v4
 
-      - name: Setup node
+      - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
 
       - name: Install Vercel CLI
         run: npm install --global vercel@latest
@@ -31,6 +37,6 @@ jobs:
         run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Build Project Artifacts
-        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel build --cwd studio --token=${{ secrets.VERCEL_TOKEN }}
       - name: Deploy Project Artifacts to Vercel
         run: vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/publish_studio_vercel.yml
+++ b/.github/workflows/publish_studio_vercel.yml
@@ -34,7 +34,7 @@ jobs:
         run: npm install --global vercel@latest
 
       - name: Link Studio folder
-        run: vercel link studio --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel link --cwd studio --yes --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Pull Vercel Environment Information
         run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/publish_studio_vercel.yml
+++ b/.github/workflows/publish_studio_vercel.yml
@@ -1,7 +1,7 @@
 name: Vercel Preview Deployment
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_STUDIO_STAGING_PROJECT_ID }}
 
 # Cancel old builds on new commit for same workflow + branch/PR
 concurrency:
@@ -33,12 +33,14 @@ jobs:
       - name: Install Vercel CLI
         run: npm install --global vercel@latest
 
+      - name: Link Studio folder
+        run: vercel link studio --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+
       - name: Pull Vercel Environment Information
-        run: vercel pull --cwd studio --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Build Project Artifacts
-        run: |
-          npm install
-          vercel build --cwd studio --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
+
       - name: Deploy Project Artifacts to Vercel
-        run: vercel deploy --cwd studio --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/publish_studio_vercel.yml
+++ b/.github/workflows/publish_studio_vercel.yml
@@ -33,9 +33,6 @@ jobs:
       - name: Install Vercel CLI
         run: npm install --global vercel@latest
 
-      - name: Link Studio folder
-        run: vercel link --cwd studio --yes --token=${{ secrets.VERCEL_TOKEN }}
-
       - name: Pull Vercel Environment Information
         run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
 

--- a/.github/workflows/publish_studio_vercel.yml
+++ b/.github/workflows/publish_studio_vercel.yml
@@ -34,18 +34,18 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
 
-      - name: Install Vercel CLI
-        run: |
-          npm install
-          npm install --global vercel@latest turbo-ignore
-
       - name: Check for changes to studio
         run: |
+          npm install --global turbo-ignore
           if npx turbo-ignore studio; then
             echo "HAS_CHANGES=false" >> "$GITHUB_ENV"
           else
             echo "HAS_CHANGES=true" >> "$GITHUB_ENV"
           fi
+
+      - name: Install Vercel CLI
+        if: env.HAS_CHANGES == 'true'
+        run: npm install --global vercel@latest
 
       - name: Pull Vercel Environment Information
         if: env.HAS_CHANGES == 'true'

--- a/.github/workflows/publish_studio_vercel.yml
+++ b/.github/workflows/publish_studio_vercel.yml
@@ -1,7 +1,7 @@
 name: Vercel Preview Deployment
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_STUDIO_STAGING_PROJECT_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
 # Cancel old builds on new commit for same workflow + branch/PR
 concurrency:

--- a/.github/workflows/publish_studio_vercel.yml
+++ b/.github/workflows/publish_studio_vercel.yml
@@ -26,6 +26,7 @@ jobs:
         # use the PR head commit, not the merge commit between this branch and master
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 2
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3

--- a/.github/workflows/publish_studio_vercel.yml
+++ b/.github/workflows/publish_studio_vercel.yml
@@ -42,9 +42,9 @@ jobs:
       - name: Check for changes to studio
         run: |
           if npx turbo-ignore studio; then
-            echo "HAS_CHANGES=true" >> "$GITHUB_ENV"
-          else
             echo "HAS_CHANGES=false" >> "$GITHUB_ENV"
+          else
+            echo "HAS_CHANGES=true" >> "$GITHUB_ENV"
           fi
 
       - name: Pull Vercel Environment Information

--- a/.github/workflows/publish_studio_vercel.yml
+++ b/.github/workflows/publish_studio_vercel.yml
@@ -34,13 +34,26 @@ jobs:
           cache: 'npm'
 
       - name: Install Vercel CLI
-        run: npm install --global vercel@latest
+        run: |
+          npm install
+          npm install --global vercel@latest turbo-ignore
+
+      - name: Check for changes to studio
+        run: |
+          if npx turbo-ignore studio; then
+            echo "NO_CHANGES=false" >> "$GITHUB_ENV"
+          else
+            echo "NO_CHANGES=true" >> "$GITHUB_ENV"
+          fi
 
       - name: Pull Vercel Environment Information
+        if: env.NO_CHANGES != 'true'
         run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Build Project Artifacts
+        if: env.NO_CHANGES != 'true'
         run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Deploy Project Artifacts to Vercel
+        if: env.NO_CHANGES != 'true'
         run: vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/publish_studio_vercel.yml
+++ b/.github/workflows/publish_studio_vercel.yml
@@ -42,19 +42,19 @@ jobs:
       - name: Check for changes to studio
         run: |
           if npx turbo-ignore studio; then
-            echo "NO_CHANGES=false" >> "$GITHUB_ENV"
+            echo "HAS_CHANGES=true" >> "$GITHUB_ENV"
           else
-            echo "NO_CHANGES=true" >> "$GITHUB_ENV"
+            echo "HAS_CHANGES=false" >> "$GITHUB_ENV"
           fi
 
       - name: Pull Vercel Environment Information
-        if: env.NO_CHANGES != 'true'
+        if: env.HAS_CHANGES == 'true'
         run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Build Project Artifacts
-        if: env.NO_CHANGES != 'true'
+        if: env.HAS_CHANGES == 'true'
         run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Deploy Project Artifacts to Vercel
-        if: env.NO_CHANGES != 'true'
+        if: env.HAS_CHANGES == 'true'
         run: vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/publish_studio_vercel.yml
+++ b/.github/workflows/publish_studio_vercel.yml
@@ -1,7 +1,7 @@
 name: Vercel Preview Deployment
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_STUDIO_STAGING_PROJECT_ID }}
 
 # Cancel old builds on new commit for same workflow + branch/PR
 concurrency:

--- a/.github/workflows/publish_studio_vercel.yml
+++ b/.github/workflows/publish_studio_vercel.yml
@@ -23,6 +23,9 @@ jobs:
     steps:
       - name: Check out repo
         uses: actions/checkout@v4
+        # use the PR head commit, not the merge commit between this branch and master
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3

--- a/.github/workflows/publish_studio_vercel.yml
+++ b/.github/workflows/publish_studio_vercel.yml
@@ -37,6 +37,8 @@ jobs:
         run: vercel pull --cwd studio --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Build Project Artifacts
-        run: vercel build --cwd studio --token=${{ secrets.VERCEL_TOKEN }}
+        run: |
+          npm install
+          vercel build --cwd studio --token=${{ secrets.VERCEL_TOKEN }}
       - name: Deploy Project Artifacts to Vercel
         run: vercel deploy --cwd studio --prebuilt --token=${{ secrets.VERCEL_TOKEN }}

--- a/studio/package.json
+++ b/studio/package.json
@@ -17,8 +17,8 @@
     "codegen": "openapi-typescript http://localhost:8080/api-json -o data/api.d.ts && prettier --write data/api.d.ts"
   },
   "dependencies": {
-    "@dagrejs/dagre": "^1.0.4",
     "@graphiql/react": "^0.19.4",
+    "@dagrejs/dagre": "^1.0.4",
     "@graphiql/toolkit": "^0.9.1",
     "@hcaptcha/react-hcaptcha": "^1.8.1",
     "@headlessui/react": "^1.7.17",


### PR DESCRIPTION
This PR is for moving the Vercel deploys to be built on Github. Things to do:
- [ ] Previews for `studio-staging`
- [ ] Previews for `studio` (production) - should be run on demand
- [ ] Previews for `studio-self-hosted` - should be run on demand
- [ ] Previews for `docs`
- [ ] Previews for `www`
- [ ] Production for `studio-staging`
- [ ] Production for `studio`
- [ ] Production for `studio-self-hosted`
- [ ] Production for `docs`
- [ ] Production for `www`

For all workflows:
- [ ] Add details link when the build is finished (https://github.com/marketplace/actions/github-checks)
- [ ] Add conditional building with `turbo-ignore` for all previews
 