### PR TITLE
docs: new connection management database subsection

### DIFF
--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
@@ -626,6 +626,15 @@ export const database: NavMenuConstant = {
       ],
     },
     {
+      name: 'Connection management',
+      url: undefined,
+      items: [
+        { name: 'Supavisor', url: '/guides/database/supavisor' },
+        { name: 'Pooling & pool modes', url: '/guides/database/supavisor-pool-modes' },
+        { name: 'Monitoring connections', url: '/guides/database/monitoring-connections' },
+      ],
+    },
+    {
       name: 'Postgres Guides',
       url: undefined,
       items: [

--- a/apps/docs/pages/guides/database/connecting-to-postgres.mdx
+++ b/apps/docs/pages/guides/database/connecting-to-postgres.mdx
@@ -10,7 +10,7 @@ export const meta = {
 Supabase provides several options for programmatically connecting to your Postgres database:
 
 1. Direct connections using Postgres' standard connection system
-2. Connection pooling using PgBouncer
+2. Connection pooling using Supavisor
 3. Programmatic access using the [Serverless APIs](/docs/guides/api)
 
 ## Serverless APIs
@@ -38,7 +38,7 @@ Every Supabase project provides a full Postgres database. You can connect to the
 
 ## Connection Pooler
 
-Every Supabase project comes with PgBouncer for connection pooling. A connection pooler is useful for managing a large number of _temporary_ connections. For example, if you are using [Prisma](/partners/integrations/prisma), Drizzle, Kysely, or anything deployed to a Serverless environment (AWS Lambdas or Edge Functions). You can find the connection pool config in the [Database settings](https://supabase.com/dashboard/project/_/settings/database) inside the dashboard:
+Every Supabase project comes with Supavisor for connection pooling. A connection pooler is useful for managing a large number of _temporary_ connections. For example, if you are using [Prisma](/partners/integrations/prisma), Drizzle, Kysely, or anything deployed to a Serverless environment (AWS Lambdas or Edge Functions). You can find the connection pool config in the [Database settings](https://supabase.com/dashboard/project/_/settings/database) inside the dashboard:
 
 1. Go to the `Settings` section.
 2. Click `Database`.
@@ -50,26 +50,6 @@ Every Supabase project comes with PgBouncer for connection pooling. A connection
     type="video/mp4"
   />
 </video>
-
-## Supavisor
-
-<Admonition type="note">
-
-PgBouncer is being deprecated in favor of Supavisor. Supavisor is available on all new and existing projects.
-
-On 15th January 2024 PgBouncer will be disabled. Additionally, your Supabase database domain (db.projectref.supabase.co) will start resolving to an IPv6 address. No changes are required if your network supports communicating via IPv6. Otherwise, update your applications to use Supavisor which will continue to support IPv4 connections.
-
-[Full details here](https://github.com/orgs/supabase/discussions/17817).
-
-</Admonition>
-
-Supavisor is a new connection pooler by Supabase. It can provide a more scalable connection pool than PgBouncer, and runs on a high-availability cluster segregated from your database.
-
-This can free up some CPU cycles for your database to use for queries. It also makes connecting to Postgres in a serverless environment much easier.
-
-We're building compatibility with PgBouncer, and application changes will not be required to switch from PgBouncer to Supavisor. When a project is switched from PgBouncer to Supavisor, the appropriate connection string will be made available under the Connection Pooling section on [Database settings](https://supabase.com/dashboard/project/_/settings/database). Note that while PgBouncer remains accessible for use, it will no longer be available for configuration from the dashboard. The PgBouncer connection string will also be similarly inaccessible from the dashboard.
-
-Supavisor is open source and compatible with any Postgres deployment. Check out [the Github repository](https://github.com/supabase/supavisor).
 
 ## Choosing a connection method
 
@@ -89,32 +69,6 @@ You should connect to your database using SSL wherever possible, to prevent snoo
 You can obtain your connection info and Server root certificate from your application's dashboard:
 
 ![Connection Info and Certificate.](/docs/img/guides/database/connection-info-cert.png)
-
-## How connection pooling works
-
-A "connection pool" is a system (external to Postgres) which manages connections, rather than PostgreSQL's native system. Supabase uses [PgBouncer](https://www.pgbouncer.org/) for connection pooling.
-
-When a client makes a request, PgBouncer "allocates" an available connection to the client. When the client transaction or session is completed the connection is returned to the pool and is free to be used by another client.
-
-![Connection pooling](/docs/img/guides/database/connection-pool.png)
-
-Pgbounce provides several Pool Modes, each handling connections differently:
-
-#### Session
-
-When a new client connects, a connection is assigned to the client until it disconnects. Afterward, the connection is returned back to the pool.
-
-All PostgreSQL features can be used with this option.
-
-#### Transaction
-
-This is the suggested option for serverless functions. A connection is only assigned to the client for the duration of a transaction. Two consecutive transactions from the same client could be executed over two different connections.
-
-Some session-based PostgreSQL features such as prepared statements are not available with this option. A comprehensive list of incompatible features can be found [here](https://www.pgbouncer.org/features.html).
-
-#### Statement
-
-This is the most granular option. Connections are returned to the pool after every statement. Transactions with multiple statements are not allowed. This is best used when `AUTOCOMMIT` is in use.
 
 ## Integrations
 

--- a/apps/docs/pages/guides/database/monitoring-connections.mdx
+++ b/apps/docs/pages/guides/database/monitoring-connections.mdx
@@ -46,10 +46,13 @@ We can see exactly how many connections Supavisor is using and confirm our conne
 ```sql
 select
   count(*) as count,
+  usename,
   application_name
 from pg_stat_activity
-where application_name like '%supavisor%'
-group by application_name
+where application_name ilike '%supavisor%'
+group by
+  usename,
+  application_name
 order by application_name desc;
 ```
 

--- a/apps/docs/pages/guides/database/monitoring-connections.mdx
+++ b/apps/docs/pages/guides/database/monitoring-connections.mdx
@@ -1,0 +1,61 @@
+import Layout from '~/layouts/DefaultGuideLayout'
+
+export const meta = {
+  id: 'monitoring-connections',
+  title: 'Monitoring Connections',
+  description: 'Monitoring connections with Postgres and Supavisor.',
+}
+
+## max_connections
+
+Every Postgres database has a connection limit.
+
+Return the direct connection limit of your database with the query:
+
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  defaultActiveId="sql"
+  queryGroup="database-method"
+>
+<TabPanel id="sql" label="SQL">
+
+```sql
+show max_connections;
+```
+
+</TabPanel>
+</Tabs>
+
+Change your `max_connections` with a [custom Postgres configuration](/docs/guides/platform/custom-postgres-config) using the CLI.
+
+## pg_stat_activity
+
+We can see exactly how many connections Supavisor is using and confirm our connection pool size:
+
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  defaultActiveId="sql"
+  queryGroup="database-method"
+>
+<TabPanel id="sql" label="SQL">
+
+```sql
+select
+  count(*) as count,
+  application_name
+from pg_stat_activity
+where application_name like '%supavisor%'
+group by application_name
+order by application_name desc;
+```
+
+</TabPanel>
+</Tabs>
+
+export const Page = ({ children }) => <Layout meta={meta} children={children} />
+
+export default Page

--- a/apps/docs/pages/guides/database/supavisor-pool-modes.mdx
+++ b/apps/docs/pages/guides/database/supavisor-pool-modes.mdx
@@ -1,0 +1,51 @@
+import Layout from '~/layouts/DefaultGuideLayout'
+
+export const meta = {
+  id: 'pool-modes',
+  title: 'Pooling & Pool Modes',
+  description: 'Understand different pool modes offered by Supavisor.',
+}
+
+## How connection pooling works
+
+A "connection pool" is a system (external to Postgres) which manages connections, rather than PostgreSQL's native system. Supabase uses [Supavisor](https://github.com/supabase/supavisor) for connection pooling.
+
+When a client makes a request, Supavisor "allocates" an available connection to the client. When the client transaction or session is completed the connection is returned to the pool and is free to be used by another client.
+
+![Connection pooling](/docs/img/guides/database/connection-pool.png)
+
+## Pool Modes
+
+Supavisor provides two Pool Modes, each handling connections differently:
+
+### Session
+
+When a new client connects, a connection is assigned to the client until it disconnects. Afterward, the connection is returned back to the pool.
+
+All PostgreSQL features except migrations can be used with this option.
+
+### Transaction
+
+This is the suggested option for serverless functions. A connection is only assigned to the client for the duration of a transaction. Two consecutive transactions from the same client could be executed over two different connections.
+
+Some session-based PostgreSQL features such as prepared statements are not available with this option. A comprehensive list of incompatible features can be found [here](https://www.pgbouncer.org/features.html).
+
+## Pooler Configuration
+
+You can [customize some parameters](https://supabase.com/dashboard/project/_/settings/database) for the connection pooler:
+
+1. Pooling Mode
+1. Default Pool Size
+
+The default pool size, and the maximum number of clients allowed to connect concurrently is automatically optimized based on the compute add-on being used. At the moment, the Dashboard only reflects any custom configuration being used, and does not include the default optimized numbers used for your project.
+
+A custom pooler configuration may also require manual updates to any relevant overrides when changing compute add-ons.
+
+## Additional Resources
+
+1. [Heroku Pooling Best Practices](https://devcenter.heroku.com/articles/best-practices-pgbouncer-configuration#database-connections-sessions-and-connection-pooling)
+1. [PgBouncer config](https://www.pgbouncer.org/config.html)
+
+export const Page = ({ children }) => <Layout meta={meta} children={children} />
+
+export default Page

--- a/apps/docs/pages/guides/database/supavisor.mdx
+++ b/apps/docs/pages/guides/database/supavisor.mdx
@@ -1,0 +1,43 @@
+import Layout from '~/layouts/DefaultGuideLayout'
+
+export const meta = {
+  id: 'supavisor',
+  title: 'Supavisor',
+  description: 'Connection pooling with Supavisor.',
+}
+
+<Admonition type="note">
+
+PgBouncer is being deprecated in favor of Supavisor. Supavisor is available on all new and existing projects.
+
+On 15th January 2024 PgBouncer will be disabled.
+
+Additionally, your Supabase database domain (db.projectref.supabase.co) will start resolving to an IPv6 address.
+
+No changes are required if your network supports communicating via IPv6. Otherwise, update your applications to use Supavisor which will continue to support IPv4 connections.
+
+[Full details here](https://github.com/orgs/supabase/discussions/17817).
+
+</Admonition>
+
+Supavisor is a connection pooler by Supabase. It can provide a more scalable connection pool than PgBouncer, and runs on a high-availability cluster segregated from your database.
+
+Using a clustered connection pooler can free up some CPU cycles for your database to use for queries. It also makes connecting to Postgres in a serverless environment much easier.
+
+## PgBouncer Compatability
+
+Supavisor is compatible with with PgBouncer pool modes. Application changes will not be required to switch from PgBouncer to Supavisor.
+
+## Migrating to Supavisor
+
+When a project is switched from PgBouncer to Supavisor, the appropriate connection string will be made available under the Connection Pooling section on [Database settings](https://supabase.com/dashboard/project/_/settings/database).
+
+While PgBouncer remains accessible for use, it will no longer be available for configuration from the dashboard. The PgBouncer connection string will also be similarly inaccessible from the dashboard.
+
+## Contribute
+
+Supavisor is open source and compatible with any Postgres deployment. Check out [the Github repository](https://github.com/supabase/supavisor).
+
+export const Page = ({ children }) => <Layout meta={meta} children={children} />
+
+export default Page

--- a/apps/docs/pages/guides/platform/custom-postgres-config.mdx
+++ b/apps/docs/pages/guides/platform/custom-postgres-config.mdx
@@ -73,15 +73,3 @@ max_parallel_workers    |3        |
 export const Page = ({ children }) => <Layout meta={meta} children={children} />
 
 export default Page
-
-## Pooler Config
-
-You can also [customize some parameters](https://supabase.com/dashboard/project/_/settings/database) for the Connection Pooler:
-
-1. [Pooling Mode](https://devcenter.heroku.com/articles/best-practices-pgbouncer-configuration#pgbouncer-s-connection-pooling-modes)
-1. [Default Pool Size](https://www.pgbouncer.org/config.html)
-1. [Max Client Connections](https://www.pgbouncer.org/config.html)
-
-The default pool size, and the maximum number of clients allowed to connect concurrently is automatically optimized based on the compute add-on being used. At the moment, the Dashboard only reflects any custom configuration being used, and does not include the default optimized numbers used for your project.
-
-Custom Pooler Config may also require manual updates to any relevant overrides when changing compute add-ons.


### PR DESCRIPTION
## What kind of change does this PR introduce?

WIP

Consolidates connection info into it's own section.

## What is the current behavior?

Some connection info was spread out across the docs.

## What is the new behavior?

One place for all things Postgres and pooler connection info.