### PR TITLE
Added comment regarding disabling of prepare

### DIFF
--- a/apps/docs/pages/guides/database/connecting-to-postgres.mdx
+++ b/apps/docs/pages/guides/database/connecting-to-postgres.mdx
@@ -183,8 +183,8 @@ This is the most granular option. Connections are returned to the pool after eve
     import { users } from './schema'
 
     const connectionString = process.env.DATABASE_URL
-    
-    // Disable prefetch as it is not supported for "Transaction" pool mode 
+
+    // Disable prefetch as it is not supported for "Transaction" pool mode
     const client = postgres(connectionString, { prepare: false })
     const db = drizzle(client);
 

--- a/apps/docs/pages/guides/database/connecting-to-postgres.mdx
+++ b/apps/docs/pages/guides/database/connecting-to-postgres.mdx
@@ -183,7 +183,9 @@ This is the most granular option. Connections are returned to the pool after eve
     import { users } from './schema'
 
     const connectionString = process.env.DATABASE_URL
-    const client = postgres(connectionString)
+    
+    // Disable prefetch as it is not supported for "Transaction" pool mode 
+    const client = postgres(connectionString, { prepare: false })
     const db = drizzle(client);
 
     const allUsers = await db.select().from(users);


### PR DESCRIPTION
Prepared statements are not supported on transaction pool mode. Let potential users to save sometime 😅

## What kind of change does this PR introduce?

Updating docs so users are aware that prepared statements is not supported on "Transaction" pool mode

## Additional context

Hi Supabase team 👋 

I recently launched a new venture using Supabase + Drizzle on a Next.js app deployed on Vercel. On launch day my app would keep crashing with the following Postgres error `prepared statement "xxx" does not exist`, this drove me crazy until I searched Postgres.js and found this issue: https://github.com/porsager/postgres/issues/547

I think we should warn users about this in the docs so they don't go crazy finding a solution. Happy to change any other docs as needed. Love Supabase btw ❤️ 
