### PR TITLE
Integrate updated GH PR endpoint

### DIFF
--- a/studio/components/interfaces/BranchManagement/BranchManagement.tsx
+++ b/studio/components/interfaces/BranchManagement/BranchManagement.tsx
@@ -70,6 +70,10 @@ const BranchManagement = () => {
   } = useBranchesQuery({ projectRef })
   const [[mainBranch], previewBranches] = partition(branches, (branch) => branch.is_default)
   const branchesWithPRs = previewBranches.filter((branch) => branch.pr_number !== undefined)
+  const prNumbers =
+    branches !== undefined
+      ? (branchesWithPRs.map((branch) => branch.pr_number).filter(Boolean) as number[])
+      : undefined
 
   const githubIntegration = integrations?.find(
     (integration) =>
@@ -92,7 +96,7 @@ const BranchManagement = () => {
     organizationIntegrationId: githubIntegration?.id,
     repoOwner,
     repoName,
-    target: mainBranch?.git_branch,
+    prNumbers,
   })
   const pullRequests = allPullRequests ?? []
 

--- a/studio/components/interfaces/BranchManagement/BranchPanels.tsx
+++ b/studio/components/interfaces/BranchManagement/BranchPanels.tsx
@@ -114,14 +114,7 @@ export const BranchRow = ({
       <div className="flex items-center gap-x-8">
         {pullRequest !== undefined && (
           <div className="flex items-center">
-            <Link
-              href={pullRequest.url}
-              target="_blank"
-              rel="noreferrer"
-              className="text-xs transition text-foreground-lighter mr-4 hover:text-foreground"
-            >
-              #{branch.pr_number}
-            </Link>
+            <p className="text-xs text-foreground-lighter mr-4">#{branch.pr_number}</p>
             <div className="flex items-center gap-x-2 bg-brand-500 px-3 py-1 rounded-full">
               <GitPullRequest size={14} />
               <p className="text-xs">Open</p>
@@ -139,6 +132,7 @@ export const BranchRow = ({
             </Button>
           </div>
         )}
+
         {isMain ? (
           <div className="flex items-center gap-x-2">
             <Button asChild type="default" iconRight={<IconExternalLink />}>

--- a/studio/components/interfaces/BranchManagement/BranchPanels.tsx
+++ b/studio/components/interfaces/BranchManagement/BranchPanels.tsx
@@ -114,7 +114,14 @@ export const BranchRow = ({
       <div className="flex items-center gap-x-8">
         {pullRequest !== undefined && (
           <div className="flex items-center">
-            <p className="text-xs text-foreground-lighter mr-4">#{branch.pr_number}</p>
+            <Link
+              href={pullRequest.url}
+              target="_blank"
+              rel="noreferrer"
+              className="text-xs transition text-foreground-lighter mr-4 hover:text-foreground"
+            >
+              #{branch.pr_number}
+            </Link>
             <div className="flex items-center gap-x-2 bg-brand-500 px-3 py-1 rounded-full">
               <GitPullRequest size={14} />
               <p className="text-xs">Open</p>

--- a/studio/data/api.d.ts
+++ b/studio/data/api.d.ts
@@ -52,6 +52,10 @@ export interface paths {
      */
     get: operations['ProjectsResourceWarningsController_getProjectsResourceWarnings']
   }
+  '/platform/tos/fly': {
+    /** Redirects to Fly sso flow */
+    get: operations['TermsOfServiceController_flyTosAccepted']
+  }
   '/platform/auth/{ref}/config': {
     /** Gets GoTrue config */
     get: operations['GoTrueConfigController_getGoTrueConfig']
@@ -549,6 +553,10 @@ export interface paths {
     /** Gets project's usage api counts */
     get: operations['UsageApiController_getApiCounts']
   }
+  '/platform/projects/{ref}/analytics/endpoints/usage.api-requests-count': {
+    /** Gets project's usage api requests count */
+    get: operations['UsageApiController_getApiRequestsCount']
+  }
   '/platform/projects/{ref}/config/pgbouncer': {
     /** Gets project's pgbouncer config */
     get: operations['PgbouncerConfigController_getPgbouncerConfig']
@@ -791,6 +799,10 @@ export interface paths {
   '/platform/integrations/github/branches/{organization_integration_id}/{repo_owner}/{repo_name}/{branch_name}': {
     /** Gets a specific github branch for a given repo */
     get: operations['GitHubBranchController_getBranchByName']
+  }
+  '/platform/integrations/github/pull-requests/{organization_integration_id}/{repo_owner}/{repo_name}': {
+    /** Gets github pull requests for a given repo */
+    get: operations['GitHubPullRequestController_getPullRequestsByNumber']
   }
   '/platform/integrations/github/pull-requests/{organization_integration_id}/{repo_owner}/{repo_name}/{target}': {
     /** Gets github pull requests for a given repo */
@@ -1281,6 +1293,10 @@ export interface paths {
     /** Gets project's usage api counts */
     get: operations['UsageApiController_getApiCounts']
   }
+  '/v0/projects/{ref}/analytics/endpoints/usage.api-requests-count': {
+    /** Gets project's usage api requests count */
+    get: operations['UsageApiController_getApiRequestsCount']
+  }
   '/v0/projects/{ref}/config/pgbouncer': {
     /** Gets project's pgbouncer config */
     get: operations['PgbouncerConfigController_getPgbouncerConfig']
@@ -1655,7 +1671,7 @@ export interface paths {
     get: operations['SnippetsController_getSnippet']
   }
   '/partners/flyio/callback': {
-    /** Redirects to Supabase dashboard after Fly sso with Gotrue */
+    /** Redirects to Supabase dashboard after completing Fly sso */
     get: operations['CallbackController_redirectToDashboardFlyioExtensionScreen']
   }
   '/partners/flyio/extensions/{extension_id}': {
@@ -1665,7 +1681,7 @@ export interface paths {
     delete: operations['ExtensionController_deleteResource']
   }
   '/partners/flyio/extensions/{extension_id}/sso': {
-    /** Starts Flyio single sign on */
+    /** Starts Fly single sign on */
     get: operations['ExtensionController_startFlyioSSO']
   }
   '/partners/flyio/extensions/{extension_id}/billing': {
@@ -1675,6 +1691,14 @@ export interface paths {
   '/partners/flyio/extensions': {
     /** Creates a database */
     post: operations['ExtensionsController_provisionResource']
+  }
+  '/partners/flyio/organizations/{organization_id}/extensions': {
+    /** Gets all databases that belong to the Fly organization */
+    get: operations['OrganizationsController_getOrgExtensions']
+  }
+  '/partners/flyio/organizations/{organization_id}/sso': {
+    /** Starts Fly single sign on */
+    get: operations['OrganizationsController_startFlyioSSO']
   }
 }
 
@@ -3295,11 +3319,11 @@ export interface components {
         | 'project_storage:all'
         | 'project_edge_function:all'
         | 'profile:update'
-        | 'billing:all'
         | 'billing:account_data'
         | 'billing:credits'
         | 'billing:invoices'
         | 'billing:payment_methods'
+        | 'realtime:all'
       )[]
     }
     UpdateProfileBody: {
@@ -4164,7 +4188,7 @@ export interface components {
     GitRef: {
       repo: string
       branch: string
-      label: string
+      label?: string
     }
     GetGithubPullRequest: {
       id: number
@@ -4175,7 +4199,7 @@ export interface components {
       created_by?: string
       repo: string
       branch: string
-      label: string
+      label?: string
     }
     FunctionResponse: {
       id: string
@@ -4403,6 +4427,9 @@ export interface components {
     }
     UpgradeDatabaseBody: {
       target_version: number
+    }
+    ProjectUpgradeInitiateResponse: {
+      tracking_id: string
     }
     ProjectVersion: {
       postgres_version: number
@@ -4728,40 +4755,6 @@ export interface components {
       extensionId: string
       items: components['schemas']['ResourceBillingItem'][]
     }
-    ResourceProvisioningBody: {
-      /** @description A UNIX epoch timestamp value */
-      timestamp: number
-      /** @description A random unique string identifying the individual request */
-      nonce: string
-      /** @description The full request target URL */
-      url: string
-      /** @description Name of the extension */
-      name: string
-      /** @description Unique ID representing the extension */
-      id: string
-      /** @description Unique ID representing an organization */
-      organization_id: string
-      /** @description Display name for an organization */
-      organization_name: string
-      /** @description Obfuscated email that routes to all organization admins */
-      organization_email: string
-      /** @description Obfuscated email that routes to the provisioning user */
-      user_email: string
-      /** @description Unique ID representing an user */
-      user_id: string
-      /** @description The three-letter, primary Fly.io region where the target app intends to write from */
-      primary_region: string
-      /** @description An IPv6 address on the customer network assigned to this extension */
-      ip_address: string
-      /**
-       * @description An array of Fly.io region codes where read replicas should be provisioned
-       * @default []
-       */
-      read_regions: string[]
-      /** @description Database password (Optional, don't send to generate one) */
-      db_pass?: string
-      user_name: string
-    }
     ResourceProvisioningConfigResponse: {
       /**
        * @description PSQL connection string
@@ -4784,6 +4777,29 @@ export interface components {
       id: string
       /** @description Welcome message */
       message: string
+    }
+    OrganizationExtensionStatus: {
+      /** @description Supabase project instance compute size */
+      compute: string
+      /** @description Unique ID representing the fly extension */
+      id: string
+      /**
+       * @description Supabase project status
+       * @example ACTIVE_HEALTHY
+       * @enum {string}
+       */
+      status:
+        | 'REMOVED'
+        | 'COMING_UP'
+        | 'INACTIVE'
+        | 'ACTIVE_HEALTHY'
+        | 'ACTIVE_UNHEALTHY'
+        | 'UNKNOWN'
+        | 'GOING_DOWN'
+        | 'INIT_FAILED'
+        | 'RESTORING'
+        | 'UPGRADING'
+        | 'PAUSING'
     }
   }
   responses: never
@@ -4957,6 +4973,20 @@ export interface operations {
         content: {
           'application/json': components['schemas']['ProjectResourceWarningsResponse'][]
         }
+      }
+    }
+  }
+  /** Redirects to Fly sso flow */
+  TermsOfServiceController_flyTosAccepted: {
+    parameters: {
+      query: {
+        extension_id: string
+        organization_id: string
+      }
+    }
+    responses: {
+      200: {
+        content: never
       }
     }
   }
@@ -8778,6 +8808,26 @@ export interface operations {
       }
     }
   }
+  /** Gets project's usage api requests count */
+  UsageApiController_getApiRequestsCount: {
+    parameters: {
+      path: {
+        /** @description Project ref */
+        ref: string
+      }
+    }
+    responses: {
+      200: {
+        content: {
+          'application/json': components['schemas']['AnalyticsResponse']
+        }
+      }
+      /** @description Failed to get project's usage api requests count */
+      500: {
+        content: never
+      }
+    }
+  }
   /** Gets project's pgbouncer config */
   PgbouncerConfigController_getPgbouncerConfig: {
     parameters: {
@@ -10124,6 +10174,30 @@ export interface operations {
         }
       }
       /** @description Failed to get github branch for a given repo */
+      500: {
+        content: never
+      }
+    }
+  }
+  /** Gets github pull requests for a given repo */
+  GitHubPullRequestController_getPullRequestsByNumber: {
+    parameters: {
+      query: {
+        pr_number: number
+      }
+      path: {
+        organization_integration_id: string
+        repo_owner: string
+        repo_name: string
+      }
+    }
+    responses: {
+      200: {
+        content: {
+          'application/json': components['schemas']['GetGithubPullRequest'][]
+        }
+      }
+      /** @description Failed to get github pull requests for a given repo */
       500: {
         content: never
       }
@@ -11477,7 +11551,9 @@ export interface operations {
     }
     responses: {
       201: {
-        content: never
+        content: {
+          'application/json': components['schemas']['ProjectUpgradeInitiateResponse']
+        }
       }
       403: {
         content: never
@@ -12137,7 +12213,7 @@ export interface operations {
       }
     }
   }
-  /** Redirects to Supabase dashboard after Fly sso with Gotrue */
+  /** Redirects to Supabase dashboard after completing Fly sso */
   CallbackController_redirectToDashboardFlyioExtensionScreen: {
     responses: {
       200: {
@@ -12173,7 +12249,7 @@ export interface operations {
       }
     }
   }
-  /** Starts Flyio single sign on */
+  /** Starts Fly single sign on */
   ExtensionController_startFlyioSSO: {
     parameters: {
       path: {
@@ -12203,16 +12279,39 @@ export interface operations {
   }
   /** Creates a database */
   ExtensionsController_provisionResource: {
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['ResourceProvisioningBody']
-      }
-    }
     responses: {
       201: {
         content: {
           'application/json': components['schemas']['ResourceProvisioningResponse']
         }
+      }
+    }
+  }
+  /** Gets all databases that belong to the Fly organization */
+  OrganizationsController_getOrgExtensions: {
+    parameters: {
+      path: {
+        organization_id: string
+      }
+    }
+    responses: {
+      200: {
+        content: {
+          'application/json': components['schemas']['OrganizationExtensionStatus'][]
+        }
+      }
+    }
+  }
+  /** Starts Fly single sign on */
+  OrganizationsController_startFlyioSSO: {
+    parameters: {
+      path: {
+        organization_id: string
+      }
+    }
+    responses: {
+      200: {
+        content: never
       }
     }
   }

--- a/studio/data/integrations/integrations-github-pull-requests-query.ts
+++ b/studio/data/integrations/integrations-github-pull-requests-query.ts
@@ -8,27 +8,30 @@ export type GithubPullRequestsVariables = {
   organizationIntegrationId?: string
   repoOwner: string
   repoName: string
-  target?: string
+  prNumbers?: number[]
 }
 
 export type GitHubPullRequest = components['schemas']['GetGithubPullRequest']
 
 export async function getGitHubPullRequests(
-  { organizationIntegrationId, repoOwner, repoName, target }: GithubPullRequestsVariables,
+  { organizationIntegrationId, repoOwner, repoName, prNumbers }: GithubPullRequestsVariables,
   signal?: AbortSignal
 ) {
   if (!organizationIntegrationId) throw new Error('Organization integration ID is required')
-  if (!target) throw new Error('Target branch is required')
+  if (!prNumbers) throw new Error('A list of PR numbers is required')
 
   const { data, error } = await get(
-    `/platform/integrations/github/pull-requests/{organization_integration_id}/{repo_owner}/{repo_name}/{target}`,
+    `/platform/integrations/github/pull-requests/{organization_integration_id}/{repo_owner}/{repo_name}`,
     {
       params: {
         path: {
           organization_integration_id: organizationIntegrationId,
           repo_owner: repoOwner,
           repo_name: repoName,
-          target,
+        },
+        query: {
+          // @ts-ignore generated api types is incorrect here, to remove ignore statement once fixed
+          pr_number: prNumbers,
         },
       },
       signal,
@@ -43,23 +46,24 @@ export type GithubPullRequestsData = Awaited<ReturnType<typeof getGitHubPullRequ
 export type GithubPullRequestsError = ResponseError
 
 export const useGithubPullRequestsQuery = <TData = GithubPullRequestsData>(
-  { organizationIntegrationId, repoOwner, repoName, target }: GithubPullRequestsVariables,
+  { organizationIntegrationId, repoOwner, repoName, prNumbers }: GithubPullRequestsVariables,
   {
     enabled = true,
     ...options
   }: UseQueryOptions<GithubPullRequestsData, GithubPullRequestsError, TData> = {}
 ) =>
   useQuery<GithubPullRequestsData, GithubPullRequestsError, TData>(
-    integrationKeys.githubPullRequestsList(organizationIntegrationId, repoOwner, repoName, target),
+    // [Joshen] Just fyi im not sure if we need to include prNumber in the RQ key here
+    integrationKeys.githubPullRequestsList(organizationIntegrationId, repoOwner, repoName),
     ({ signal }) =>
-      getGitHubPullRequests({ organizationIntegrationId, repoOwner, repoName, target }, signal),
+      getGitHubPullRequests({ organizationIntegrationId, repoOwner, repoName, prNumbers }, signal),
     {
       enabled:
         enabled &&
         typeof organizationIntegrationId !== 'undefined' &&
         typeof repoOwner !== 'undefined' &&
         typeof repoName !== 'undefined' &&
-        typeof target !== 'undefined',
+        typeof prNumbers !== 'undefined',
       ...options,
     }
   )

--- a/studio/data/integrations/keys.ts
+++ b/studio/data/integrations/keys.ts
@@ -29,16 +29,8 @@ export const integrationKeys = {
   githubPullRequestsList: (
     organization_integration_id: string | undefined,
     repo_owner: string,
-    repo_name: string,
-    target: string | undefined
-  ) => [
-    'organizations',
-    organization_integration_id,
-    'pull-requests',
-    repo_owner,
-    repo_name,
-    target,
-  ],
+    repo_name: string
+  ) => ['organizations', organization_integration_id, 'pull-requests', repo_owner, repo_name],
   githubConnectionsList: (organization_integration_id: string | undefined) =>
     ['organizations', organization_integration_id, 'github-connections'] as const,
 }


### PR DESCRIPTION
Fetch GH pull requests by passing an array of PR numbers, instead of trying to fetch all PRs from a specified target branch
This is to:
- only fetch what we need
- mitigate being unable to fetch what we need if target has a number of PRs that exceed the page limit