### PR TITLE
Fix json side panel editor in table editor not updating properly

### DIFF
--- a/studio/components/grid/components/editor/JsonEditor.tsx
+++ b/studio/components/grid/components/editor/JsonEditor.tsx
@@ -36,7 +36,7 @@ export const JsonEditor = <TRow, TSummaryRow = unknown>({
   }, [])
 
   const saveChanges = useCallback((newValue: string | null) => {
-    commitChange(newValue)
+    if (newValue !== value) commitChange(newValue)
   }, [])
 
   const onChange = (_value: string | undefined) => {

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/JsonEditor/JsonCodeEditor.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/JsonEditor/JsonCodeEditor.tsx
@@ -1,6 +1,7 @@
 import Editor from '@monaco-editor/react'
+import { uuidv4 } from 'lib/helpers'
 import { noop } from 'lodash'
-import { useRef } from 'react'
+import { useRef, useState, useEffect } from 'react'
 
 // [Joshen] Should just use CodeEditor instead of declaring Editor here so that all the mount logic is consistent
 
@@ -12,12 +13,13 @@ interface JsonEditorProps {
 }
 
 const JsonEditor = ({
-  queryId = '',
+  queryId,
   defaultValue = '',
   readOnly = false,
   onInputChange = noop,
 }: JsonEditorProps) => {
   const editorRef = useRef()
+  const [id, setId] = useState<string>(uuidv4())
 
   const onMount = (editor: any, monaco: any) => {
     editorRef.current = editor
@@ -34,13 +36,17 @@ const JsonEditor = ({
 
   const Loading = () => <h4>Loading</h4>
 
+  useEffect(() => {
+    setId(uuidv4())
+  }, [defaultValue])
+
   return (
     <Editor
       className="monaco-editor"
       theme="supabase"
       defaultLanguage="json"
       defaultValue={defaultValue}
-      path={queryId}
+      path={queryId || id}
       loading={<Loading />}
       options={{
         readOnly,


### PR DESCRIPTION
Addresses a bug in which clicking "Expand JSON" from the table editor grid on a cell that's of JSON type doesn't update the value in the code editor that appears in the side panel (along the lines of stale state issue)

Fix is to ensure that `path` in JsonEditor of the Monaco editor component is always updated everytime defaultValue changes - to ensure that the monaco editor updates properly

Also added a small fix such that if the cell popover editor for JSON is closed with the changes made, the save functionality should not be run