### PR TITLE
Fix RowContextMenu bg

### DIFF
--- a/studio/components/grid/components/menu/RowContextMenu.tsx
+++ b/studio/components/grid/components/menu/RowContextMenu.tsx
@@ -60,7 +60,7 @@ const RowContextMenu = ({ rows }: RowContextMenuProps) => {
 
   return (
     <>
-      <Menu id={ROW_CONTEXT_MENU_ID} animation={false}>
+      <Menu id={ROW_CONTEXT_MENU_ID} animation={false} className="!bg-surface-200">
         <Item onClick={onCopyCellContent}>
           <IconClipboard size="tiny" />
           <span className="ml-2 text-xs">Copy cell content</span>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes Table row actions modal background color on dark mode.

## What is the current behavior?

<img width="268" alt="Screenshot 2023-11-07 at 14 56 15" src="https://github.com/supabase/supabase/assets/25671831/3e0ffb13-251f-419e-a260-1ce60523559b">

## What is the new behavior?

<img width="290" alt="Screenshot 2023-11-07 at 14 53 55" src="https://github.com/supabase/supabase/assets/25671831/26b3116b-1daa-45c9-8d86-2cfa40c0a49f">

