### PR TITLE
fix: Move dat.gui dependency to the common package

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -57,7 +57,6 @@
     "@supabase/supabase-js": "^2.38.2",
     "common": "*",
     "config": "*",
-    "dat.gui": "^0.7.9",
     "framer-motion": "^6.5.1",
     "github-slugger": "^2.0.0",
     "gray-matter": "^4.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,6 @@
         "@supabase/supabase-js": "^2.38.2",
         "common": "*",
         "config": "*",
-        "dat.gui": "^0.7.9",
         "framer-motion": "^6.5.1",
         "github-slugger": "^2.0.0",
         "gray-matter": "^4.0.3",
@@ -9664,10 +9663,9 @@
       }
     },
     "node_modules/@types/dat.gui": {
-      "version": "0.7.10",
-      "resolved": "https://registry.npmjs.org/@types/dat.gui/-/dat.gui-0.7.10.tgz",
-      "integrity": "sha512-sLifoNrvs4lgJkAUZcTB28dbWy0AM05Yc0BzTqHheK0tRYRVsJHoFLocB5heDbb5amaFLEXna41GOM6IG06oqA==",
-      "dev": true
+      "version": "0.7.12",
+      "resolved": "https://registry.npmjs.org/@types/dat.gui/-/dat.gui-0.7.12.tgz",
+      "integrity": "sha512-el5dYeQZu2r6YW6Ft4rGtjr/dLe/uzXESMoie5UM6/weVShB1V8IRpXtTKrczd4qe7044fTKZS2l8d6EBFOkoA=="
     },
     "node_modules/@types/debounce-promise": {
       "version": "3.1.7",
@@ -35919,7 +35917,9 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
+        "@types/dat.gui": "^0.7.12",
         "config": "*",
+        "dat.gui": "^0.7.9",
         "lodash": "^4.17.21",
         "next-themes": "^0.2.1",
         "react-hot-toast": "^2.4.1",
@@ -37762,7 +37762,6 @@
         "common-tags": "^1.8.2",
         "config": "*",
         "configcat-js": "^7.0.0",
-        "dat.gui": "^0.7.9",
         "dayjs": "^1.11.10",
         "eslint-config-next": "^13.3.0",
         "file-saver": "^2.0.5",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -8,7 +8,9 @@
     "typecheck_CURRENTLY_IGNORED": "tsc --noEmit"
   },
   "dependencies": {
+    "@types/dat.gui": "^0.7.12",
     "config": "*",
+    "dat.gui": "^0.7.9",
     "lodash": "^4.17.21",
     "next-themes": "^0.2.1",
     "react-hot-toast": "^2.4.1",

--- a/studio/package.json
+++ b/studio/package.json
@@ -48,7 +48,6 @@
     "common-tags": "^1.8.2",
     "config": "*",
     "configcat-js": "^7.0.0",
-    "dat.gui": "^0.7.9",
     "dayjs": "^1.11.10",
     "eslint-config-next": "^13.3.0",
     "file-saver": "^2.0.5",


### PR DESCRIPTION
Remove dat.gui from docs and studio since it's not used directly. Add dat.gui as a dependency to `common` package.
