### PR TITLE
ref: Rework VercelSection component to be shared in proj/org settings

### DIFF
--- a/studio/components/interfaces/Settings/Integrations/IntegrationsSettings.tsx
+++ b/studio/components/interfaces/Settings/Integrations/IntegrationsSettings.tsx
@@ -20,7 +20,7 @@ const IntegrationSettings = () => {
     <>
       <GitHubSection />
       <ScaffoldDivider />
-      <VercelSection />
+      <VercelSection isProjectScoped={true} />
       <SidePanelVercelProjectLinker />
       <SidePanelGitHubRepoLinker />
     </>


### PR DESCRIPTION
This changes how `VercelSection` is used across Organization and Project pages. Instead of using separate, essentially the same components, it's now using a unified one, with optional `isProjectScoped` prop, that decides whether to:
- show all connections or only the ones for the project in question (previously project page displayed _all_ connections, which was incorrect)
- show connection configuration panel

It also:
- fixes few color mismatches with links and panels
- missing "Create connection" button on project page
- broken panel title when there are no connections

GitHub Integration should be also unified, but I will do this when I work on it later.