### PR TITLE
fix: Update edge function examples in guides

### DIFF
--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
@@ -847,7 +847,7 @@ export const functions: NavMenuConstant = {
         { name: 'Managing environment variables', url: '/guides/functions/secrets' },
         { name: 'Integrating with Supabase Auth', url: '/guides/functions/auth' },
         {
-          name: 'Connecting directly to Postgres',
+          name: 'Integrating with Postgres',
           url: '/guides/functions/connect-to-postgres',
         },
         {

--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
@@ -847,7 +847,7 @@ export const functions: NavMenuConstant = {
         { name: 'Managing environment variables', url: '/guides/functions/secrets' },
         { name: 'Integrating with Supabase Auth', url: '/guides/functions/auth' },
         {
-          name: 'Integrating with Postgres',
+          name: 'Connecting directly to Postgres',
           url: '/guides/functions/connect-to-postgres',
         },
         {

--- a/apps/docs/pages/guides/functions/connect-to-postgres.mdx
+++ b/apps/docs/pages/guides/functions/connect-to-postgres.mdx
@@ -50,7 +50,6 @@ Because Edge Functions are a server-side technology, it's safe to connect direct
 
 ```ts index.ts
 import * as postgres from 'https://deno.land/x/postgres@v0.17.0/mod.ts'
-import { serve } from 'https://deno.land/std@0.177.0/http/server.ts'
 
 // Get the connection string from the environment variable "SUPABASE_DB_URL"
 const databaseUrl = Deno.env.get('SUPABASE_DB_URL')!
@@ -58,7 +57,7 @@ const databaseUrl = Deno.env.get('SUPABASE_DB_URL')!
 // Create a database pool with three connections that are lazily established
 const pool = new postgres.Pool(databaseUrl, 3, true)
 
-serve(async (_req) => {
+Deno.serve(async (_req) => {
   try {
     // Grab a connection from the pool
     const connection = await pool.connect()

--- a/apps/docs/pages/guides/functions/cors.mdx
+++ b/apps/docs/pages/guides/functions/cors.mdx
@@ -24,12 +24,11 @@ export const corsHeaders = {
 You can then import and use the CORS headers within your functions:
 
 ```ts index.ts
-import { serve } from 'https://deno.land/std@0.177.0/http/server.ts'
 import { corsHeaders } from '../_shared/cors.ts'
 
 console.log(`Function "browser-with-cors" up and running!`)
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   // This is needed if you're planning to invoke your function from a browser.
   if (req.method === 'OPTIONS') {
     return new Response('ok', { headers: corsHeaders })

--- a/apps/docs/pages/guides/functions/debugging.mdx
+++ b/apps/docs/pages/guides/functions/debugging.mdx
@@ -28,7 +28,7 @@ When [developing locally](/docs/guides/functions/local-development) you will see
 
 - Outgoing connections to ports `25`, `465`, and `587` are not allowed.
 - Serving of HTML content is not supported (`GET` requests that return `text/html` will be rewritten to `text/plain`).
-- Functions cannot read or write to the file system (Deno FileSystem APIs are not available to use within edge functions).
+- Deno FileSystem APIs are not available to use within Edge Functions.
 - Importing modules using `npm:` specifier is currently not supported ([use a CDN to load npm modules](/docs/guides/functions/import-maps)).
 
 ## Troubleshooting

--- a/apps/docs/pages/guides/functions/debugging.mdx
+++ b/apps/docs/pages/guides/functions/debugging.mdx
@@ -26,15 +26,10 @@ When [developing locally](/docs/guides/functions/local-development) you will see
 
 ## Limitations
 
-### Deno Deploy limitations
-
-- Deno does not support outgoing connections to ports `25`, `465`, and `587`.
-- Deno-deployed functions cannot read or write to the file system.
-- NPM modules are not supported.
-
-### Supabase Edge Functions
-
+- Outgoing connections to ports `25`, `465`, and `587` are not allowed.
 - Serving of HTML content is not supported (`GET` requests that return `text/html` will be rewritten to `text/plain`).
+- Functions cannot read or write to the file system (Deno FileSystem APIs are not available to use within edge functions).
+- Importing modules using `npm:` specifier is currently not supported ([use a CDN to load npm modules](/docs/guides/functions/import-maps)).
 
 ## Troubleshooting
 

--- a/apps/docs/pages/guides/functions/examples/cloudflare-turnstile.mdx
+++ b/apps/docs/pages/guides/functions/examples/cloudflare-turnstile.mdx
@@ -34,7 +34,6 @@ supabase functions new cloudflare-turnstile
 And add the code to the `index.ts` file:
 
 ```ts index.ts
-import { serve } from 'https://deno.land/std@0.177.0/http/server.ts'
 import { corsHeaders } from '../_shared/cors.ts'
 
 console.log('Hello from Cloudflare Trunstile!')
@@ -43,7 +42,7 @@ function ips(req: Request) {
   return req.headers.get('x-forwarded-for')?.split(/\s*,\s*/)
 }
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   // This is needed if you're planning to invoke your function from a browser.
   if (req.method === 'OPTIONS') {
     return new Response('ok', { headers: corsHeaders })

--- a/apps/docs/pages/guides/functions/examples/discord-bot.mdx
+++ b/apps/docs/pages/guides/functions/examples/discord-bot.mdx
@@ -47,10 +47,10 @@ This will register a Slash Command named `hello` that accepts a parameter named 
 // Sift is a small routing library that abstracts away details like starting a
 // listener on a port, and provides a simple function (serve) that has an API
 // to invoke a function for a specific path.
-import { json, serve, validateRequest } from 'sift'
+import { json, serve, validateRequest } from 'https://deno.land/x/sift@0.6.0/mod.ts'
 // TweetNaCl is a cryptography library that we use to verify requests
 // from Discord.
-import nacl from 'tweetnacl'
+import nacl from 'https://cdn.skypack.dev/tweetnacl@v1.0.3?dts'
 
 enum DiscordCommandType {
   Ping = 1,

--- a/apps/docs/pages/guides/functions/examples/og-image.mdx
+++ b/apps/docs/pages/guides/functions/examples/og-image.mdx
@@ -50,12 +50,11 @@ export default function handler(req: Request) {
 Create an `index.ts` file to execute the handler on incoming requests:
 
 ```ts index.ts
-import { serve } from 'https://deno.land/std@0.177.0/http/server.ts'
 import handler from './handler.tsx'
 
 console.log('Hello from og-image Function!')
 
-serve(handler)
+Deno.serve(handler)
 ```
 
 export const Page = ({ children }) => <Layout meta={meta} children={children} />

--- a/apps/docs/pages/guides/functions/examples/send-emails.mdx
+++ b/apps/docs/pages/guides/functions/examples/send-emails.mdx
@@ -31,8 +31,6 @@ Store the `RESEND_API_KEY` in your `.env` file.
 Paste the following code into the `index.ts` file:
 
 ```tsx
-import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
-
 const RESEND_API_KEY = Deno.env.get('RESEND_API_KEY')
 
 const handler = async (_request: Request): Promise<Response> => {
@@ -60,7 +58,7 @@ const handler = async (_request: Request): Promise<Response> => {
   })
 }
 
-serve(handler)
+Deno.serve(handler)
 ```
 
 ### 3. Deploy and send email

--- a/apps/docs/pages/guides/functions/examples/slack-bot-mention.mdx
+++ b/apps/docs/pages/guides/functions/examples/slack-bot-mention.mdx
@@ -29,14 +29,13 @@ set SLACK_TOKEN=<xoxb-0000000000-0000000000-01010101010nacho101010>
 Here's the code of the Edge Function, you can change the response to handle the text received:
 
 ```ts index.ts
-import { serve } from 'https://deno.land/std@0.197.0/http/server.ts'
 import { WebClient } from 'https://deno.land/x/slack_web_api@6.7.2/mod.js'
 
 const slackBotToken = Deno.env.get('SLACK_TOKEN') ?? ''
 const botClient = new WebClient(slackBotToken)
 
 console.log(`Slack URL verification function up and running!`)
-serve(async (req) => {
+Deno.serve(async (req) => {
   try {
     const reqBody = await req.json()
     console.log(JSON.stringify(reqBody, null, 2))

--- a/apps/docs/pages/guides/functions/examples/upstash-redis.mdx
+++ b/apps/docs/pages/guides/functions/examples/upstash-redis.mdx
@@ -41,12 +41,11 @@ supabase functions new upstash-redis-counter
 And add the code to the `index.ts` file:
 
 ```ts index.ts
-import { serve } from 'https://deno.land/std@0.177.0/http/server.ts'
 import { Redis } from 'https://deno.land/x/upstash_redis@v1.19.3/mod.ts'
 
 console.log(`Function "upstash-redis-counter" up and running!`)
 
-serve(async (_req) => {
+Deno.serve(async (_req) => {
   try {
     const redis = new Redis({
       url: Deno.env.get('UPSTASH_REDIS_REST_URL')!,


### PR DESCRIPTION
## What kind of change does this PR introduce?

* Updated all edge function examples in guides to use `Deno.serve`.
* Use URL import paths in all examples in guides
* Minor edits to edge function guides
