### PR TITLE
Fix react-contexify light

### DIFF
--- a/studio/styles/contextMenu.scss
+++ b/studio/styles/contextMenu.scss
@@ -4,7 +4,7 @@
 
   .react-contexify__item {
     .react-contexify__item__content {
-      @apply text-foreground text-sm;
+      @apply text-foreground-light text-sm;
     }
     .react-contexify__submenu {
       @apply bg-surface-100 border;
@@ -14,7 +14,7 @@
     > .react-contexify__item__content,
   .react-contexify__item:not(.react-contexify__item--disabled):focus
     > .react-contexify__item__content {
-    background-color: hsl(var(--background-overlay-hover)) !important;
+    @apply bg-overlay-hover text-foreground;
   }
   .react-contexify__separator {
     @apply bg-overlay;

--- a/studio/styles/contextMenu.scss
+++ b/studio/styles/contextMenu.scss
@@ -14,7 +14,7 @@
     > .react-contexify__item__content,
   .react-contexify__item:not(.react-contexify__item--disabled):focus
     > .react-contexify__item__content {
-    @apply bg-overlay-hover;
+    background-color: hsl(var(--background-overlay-hover)) !important;
   }
   .react-contexify__separator {
     @apply bg-overlay;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixed react-contexify light mode appearance.
Follows up on #18802 and fixes #18800 

## What is the current behavior?

<img width="330" alt="Screenshot 2023-11-08 at 10 28 40" src="https://github.com/supabase/supabase/assets/25671831/6706d3d5-6255-40e2-8b8b-c6b6299968f2">

## What is the new behavior?

<img width="311" alt="Screenshot 2023-11-08 at 10 28 59" src="https://github.com/supabase/supabase/assets/25671831/24efe6c7-1261-4256-8a48-d2fbdd234c53">