### PR TITLE
fix: add link in docs to compute size change

### DIFF
--- a/apps/docs/pages/guides/platform/compute-add-ons.mdx
+++ b/apps/docs/pages/guides/platform/compute-add-ons.mdx
@@ -25,7 +25,7 @@ Number of connections above are recommended values.
 
 We charge hourly for additional compute based on your usage. Read more about [usage-based billing for compute](/docs/guides/platform/org-based-billing#usage-based-billing-for-compute).
 
-[Contact us](https://supabase.com/contact/enterprise) if you require a custom plan.
+Compute sizes can be changed in [the dashboard here by selecting your project](https://supabase.com/dashboard/project/_/settings/addons?panel=computeInstance). [Contact us](https://supabase.com/contact/enterprise) if you require a custom plan.
 
 ## Dedicated vs. shared CPU
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Not obvious when looking at compute add ons doc how users can change compute size after reading everything. Added a sentence and link to compute add ons in dashboard. 