### PR TITLE
Fix link underline brand color

### DIFF
--- a/packages/config/tailwind.config.js
+++ b/packages/config/tailwind.config.js
@@ -232,7 +232,7 @@ const uiConfig = ui({
               fontWeight: '400',
               color: 'hsl(var(--colors-scale12))',
               textDecorationLine: 'underline',
-              textDecorationColor: 'hsl(var(--brand-400))',
+              textDecorationColor: 'hsl(var(--brand-500))',
               textDecorationThickness: '1px',
               textUnderlineOffset: '4px',
             },


### PR DESCRIPTION
## What kind of change does this PR introduce?

Underline brand color was not noticeable after tokens update PR.

## What is the current behavior?

Please link any relevant issues here.

<img width="327" alt="Screenshot 2023-11-08 at 11 39 55" src="https://github.com/supabase/supabase/assets/25671831/069a7f93-b756-47f2-8a32-9d74f64086f7">

## New behaviour

<img width="354" alt="Screenshot 2023-11-08 at 11 40 04" src="https://github.com/supabase/supabase/assets/25671831/c49d6825-c999-43c8-b55f-ad043e16a995">
