### PR TITLE
Fix next-themes resolvedTheme bug

### DIFF
--- a/apps/www/components/Footer/index.tsx
+++ b/apps/www/components/Footer/index.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react'
 import Link from 'next/link'
 import { useTheme } from 'next-themes'
 import { Badge, IconDiscord, IconGitHubSolid, IconTwitterX, IconYoutubeSolid, cn } from 'ui'
@@ -20,6 +21,21 @@ const Footer = (props: Props) => {
   const { pathname } = useRouter()
 
   const isLaunchWeekPage = pathname.includes('launch-week') || pathname === '/'
+
+  /**
+   * Temporary fix for next-theme client side bug
+   * https://github.com/pacocoursey/next-themes/issues/169
+   * TODO: remove when bug has been fixed
+   */
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  if (!mounted) {
+    return null
+  }
 
   return (
     <footer className={cn('bg-alternative', props.className)} aria-labelledby="footerHeading">
@@ -55,7 +71,7 @@ const Footer = (props: Props) => {
                 src={
                   isLaunchWeekPage
                     ? supabaseLogoWordmarkDark
-                    : resolvedTheme === 'dark'
+                    : mounted && resolvedTheme === 'dark'
                     ? supabaseLogoWordmarkDark
                     : supabaseLogoWordmarkLight
                 }

--- a/apps/www/components/Nav/index.tsx
+++ b/apps/www/components/Nav/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
@@ -51,6 +51,21 @@ const Nav = () => {
     if (width >= 1024) setOpen(false)
   }, [width])
 
+  /**
+   * Temporary fix for next-theme client side bug
+   * https://github.com/pacocoursey/next-themes/issues/169
+   * TODO: remove when bug has been fixed
+   */
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  if (!mounted) {
+    return null
+  }
+
   return (
     <>
       <div className="sticky top-0 z-40 transform" style={{ transform: 'translate3d(0,0,999px)' }}>
@@ -78,7 +93,7 @@ const Nav = () => {
                   >
                     <Image
                       src={
-                        isLaunchWeekPage || resolvedTheme === 'dark' || isHomePage
+                        isLaunchWeekPage || (mounted && resolvedTheme === 'dark') || isHomePage
                           ? supabaseLogoWordmarkDark
                           : supabaseLogoWordmarkLight
                       }
@@ -161,7 +176,7 @@ const Nav = () => {
           <MobileMenu
             open={open}
             setOpen={setOpen}
-            isDarkMode={isLaunchWeekPage || resolvedTheme === 'dark' || isHomePage}
+            isDarkMode={isLaunchWeekPage || (mounted && resolvedTheme === 'dark') || isHomePage}
             menu={menu}
           />
         </nav>


### PR DESCRIPTION
## What kind of change does this PR introduce?

It seems that using Next 13 the UI doesn't catch the resolvedTheme from `next-themes` when loading the first time (or refreshing the page or navigating without next/link). Hence the logo on the main website isn't correct in some cases.

This temporary workaround fixes this bug.

## What is the current behavior?

https://github.com/supabase/supabase/assets/25671831/93e9e325-b8c4-4e86-ac48-06174daeb259

## What is the new behavior?

https://github.com/supabase/supabase/assets/25671831/0f8dc765-f7dd-4af5-96bb-374c6e5f1aed


## Additional context

Related bug: https://github.com/pacocoursey/next-themes/issues/169
