### PR TITLE
docs: signUrl await keyword

### DIFF
--- a/spec/supabase_js_v2.yml
+++ b/spec/supabase_js_v2.yml
@@ -5061,7 +5061,7 @@ functions:
         isSpotlight: true
         code: |
           ```js
-          const { data } = supabase
+          const { data } = await supabase
             .storage
             .from('avatars')
             .createSignedUrl('folder/avatar1.png', 60, {
@@ -5076,7 +5076,7 @@ functions:
         isSpotlight: true
         code: |
           ```js
-          const { data } = supabase
+          const { data } = await supabase
             .storage
             .from('avatars')
             .createSignedUrl('folder/avatar1.png', 60, {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update - [Signed URL](https://supabase.com/docs/reference/javascript/storage-from-createsignedurl?example=create-signed-url-with-download)

## What is the current behavior?

Missing `await` keyword on the examples

## What is the new behavior?

Added `await` keyword

## Additional context

Closes #18096 
