### PR TITLE
Ensure that database triggers, functions and indexes page and coherent with the protected schema UX

### DIFF
--- a/studio/components/interfaces/Database/Functions/FunctionsList/FunctionsList.tsx
+++ b/studio/components/interfaces/Database/Functions/FunctionsList/FunctionsList.tsx
@@ -102,32 +102,34 @@ const FunctionsList = ({
               />
             </div>
 
-            <Tooltip.Root delayDuration={0}>
-              <Tooltip.Trigger>
-                <Button disabled={!canCreateFunctions} onClick={() => createFunction()}>
-                  Create a new function
-                </Button>
-              </Tooltip.Trigger>
-              {!canCreateFunctions && (
-                <Tooltip.Portal>
+            {!isLocked && (
+              <Tooltip.Root delayDuration={0}>
+                <Tooltip.Trigger>
+                  <Button disabled={!canCreateFunctions} onClick={() => createFunction()}>
+                    Create a new function
+                  </Button>
+                </Tooltip.Trigger>
+                {!canCreateFunctions && (
                   <Tooltip.Portal>
-                    <Tooltip.Content side="bottom">
-                      <Tooltip.Arrow className="radix-tooltip-arrow" />
-                      <div
-                        className={[
-                          'rounded bg-alternative py-1 px-2 leading-none shadow',
-                          'border border-background',
-                        ].join(' ')}
-                      >
-                        <span className="text-xs text-foreground">
-                          You need additional permissions to create functions
-                        </span>
-                      </div>
-                    </Tooltip.Content>
+                    <Tooltip.Portal>
+                      <Tooltip.Content side="bottom">
+                        <Tooltip.Arrow className="radix-tooltip-arrow" />
+                        <div
+                          className={[
+                            'rounded bg-alternative py-1 px-2 leading-none shadow',
+                            'border border-background',
+                          ].join(' ')}
+                        >
+                          <span className="text-xs text-foreground">
+                            You need additional permissions to create functions
+                          </span>
+                        </div>
+                      </Tooltip.Content>
+                    </Tooltip.Portal>
                   </Tooltip.Portal>
-                </Tooltip.Portal>
-              )}
-            </Tooltip.Root>
+                )}
+              </Tooltip.Root>
+            )}
           </div>
 
           {isLocked && <ProtectedSchemaWarning schema={selectedSchema} entity="functions" />}

--- a/studio/components/interfaces/Database/Indexes/Indexes.tsx
+++ b/studio/components/interfaces/Database/Indexes/Indexes.tsx
@@ -29,6 +29,9 @@ import { useExecuteSqlMutation } from 'data/sql/execute-sql-mutation'
 import { useStore } from 'hooks'
 import CreateIndexSidePanel from './CreateIndexSidePanel'
 import SchemaSelector from 'components/ui/SchemaSelector'
+import { partition } from 'lodash'
+import { EXCLUDED_SCHEMAS } from 'lib/constants/schemas'
+import ProtectedSchemaWarning from '../ProtectedSchemaWarning'
 
 const Indexes = () => {
   const { ui } = useStore()
@@ -75,6 +78,12 @@ const Indexes = () => {
       })
     },
   })
+
+  const [protectedSchemas] = partition(schemas ?? [], (schema) =>
+    EXCLUDED_SCHEMAS.includes(schema?.name ?? '')
+  )
+  const schema = schemas?.find((schema) => schema.name === selectedSchema)
+  const isLocked = protectedSchemas.some((s) => s.id === schema?.id)
 
   const sortedIndexes = (allIndexes?.result ?? []).sort(
     (a, b) => a.table.localeCompare(b.table) || a.name.localeCompare(b.name)
@@ -125,109 +134,117 @@ const Indexes = () => {
           </div>
         </div>
 
-        <div className="flex items-center justify-between mb-4">
-          <div className="flex items-center space-x-2">
-            {isLoadingSchemas && <ShimmeringLoader className="w-[260px]" />}
-            {isErrorSchemas && (
-              <div className="w-[260px] text-foreground-light text-sm border px-3 py-1.5 rounded flex items-center space-x-2">
-                <IconAlertCircle strokeWidth={2} size={16} />
-                <p>Failed to load schemas</p>
-              </div>
-            )}
-            {isSuccessSchemas && (
-              <SchemaSelector
-                className="w-[260px]"
+        <div className="flex flex-col gap-y-4">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center space-x-2">
+              {isLoadingSchemas && <ShimmeringLoader className="w-[260px]" />}
+              {isErrorSchemas && (
+                <div className="w-[260px] text-foreground-light text-sm border px-3 py-1.5 rounded flex items-center space-x-2">
+                  <IconAlertCircle strokeWidth={2} size={16} />
+                  <p>Failed to load schemas</p>
+                </div>
+              )}
+              {isSuccessSchemas && (
+                <SchemaSelector
+                  className="w-[260px]"
+                  size="small"
+                  showError={false}
+                  selectedSchemaName={selectedSchema}
+                  onSelectSchema={setSelectedSchema}
+                />
+              )}
+              <Input
                 size="small"
-                showError={false}
-                selectedSchemaName={selectedSchema}
-                onSelectSchema={setSelectedSchema}
+                value={search}
+                className="w-64"
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder="Search for an index"
+                icon={<IconSearch size={14} />}
               />
+            </div>
+            {!isLocked && (
+              <Button
+                type="primary"
+                onClick={() => setShowCreateIndex(true)}
+                disabled={!isSuccessSchemas}
+              >
+                Create index
+              </Button>
             )}
-            <Input
-              size="small"
-              value={search}
-              className="w-64"
-              onChange={(e) => setSearch(e.target.value)}
-              placeholder="Search for an index"
-              icon={<IconSearch size={14} />}
-            />
           </div>
-          <Button
-            type="primary"
-            onClick={() => setShowCreateIndex(true)}
-            disabled={!isSuccessSchemas}
-          >
-            Create index
-          </Button>
-        </div>
 
-        {isLoadingIndexes && <GenericSkeletonLoader />}
+          {isLocked && <ProtectedSchemaWarning schema={selectedSchema} entity="indexes" />}
 
-        {isErrorIndexes && (
-          <AlertError error={indexesError as any} subject="Failed to retrieve database indexes" />
-        )}
+          {isLoadingIndexes && <GenericSkeletonLoader />}
 
-        {isSuccessIndexes && (
-          <Table
-            head={[
-              <Table.th key="schema">Schema</Table.th>,
-              <Table.th key="table">Table</Table.th>,
-              <Table.th key="name">Name</Table.th>,
-              <Table.th key="buttons"></Table.th>,
-            ]}
-            body={
-              <>
-                {sortedIndexes.length === 0 && search.length === 0 && (
-                  <Table.tr>
-                    <Table.td colSpan={4}>
-                      <p className="text-sm text-foreground">No indexes created yet</p>
-                      <p className="text-sm text-foreground-light">
-                        There are no indexes found in the schema "{selectedSchema}"
-                      </p>
-                    </Table.td>
-                  </Table.tr>
-                )}
-                {sortedIndexes.length === 0 && search.length > 0 && (
-                  <Table.tr>
-                    <Table.td colSpan={4}>
-                      <p className="text-sm text-foreground">No results found</p>
-                      <p className="text-sm text-foreground-light">
-                        Your search for "{search}" did not return any results
-                      </p>
-                    </Table.td>
-                  </Table.tr>
-                )}
-                {indexes.length > 0 &&
-                  indexes.map((index) => (
-                    <Table.tr key={index.name}>
-                      <Table.td>
-                        <p title={index.schema}>{index.schema}</p>
-                      </Table.td>
-                      <Table.td>
-                        <p title={index.table}>{index.table}</p>
-                      </Table.td>
-                      <Table.td>
-                        <p title={index.name}>{index.name}</p>
-                      </Table.td>
-                      <Table.td>
-                        <div className="flex justify-end items-center space-x-2">
-                          <Button type="default" onClick={() => setSelectedIndex(index)}>
-                            View definition
-                          </Button>
-                          <Button
-                            type="text"
-                            className="px-1"
-                            icon={<IconTrash />}
-                            onClick={() => setSelectedIndexToDelete(index)}
-                          />
-                        </div>
+          {isErrorIndexes && (
+            <AlertError error={indexesError as any} subject="Failed to retrieve database indexes" />
+          )}
+
+          {isSuccessIndexes && (
+            <Table
+              head={[
+                <Table.th key="schema">Schema</Table.th>,
+                <Table.th key="table">Table</Table.th>,
+                <Table.th key="name">Name</Table.th>,
+                <Table.th key="buttons"></Table.th>,
+              ]}
+              body={
+                <>
+                  {sortedIndexes.length === 0 && search.length === 0 && (
+                    <Table.tr>
+                      <Table.td colSpan={4}>
+                        <p className="text-sm text-foreground">No indexes created yet</p>
+                        <p className="text-sm text-foreground-light">
+                          There are no indexes found in the schema "{selectedSchema}"
+                        </p>
                       </Table.td>
                     </Table.tr>
-                  ))}
-              </>
-            }
-          />
-        )}
+                  )}
+                  {sortedIndexes.length === 0 && search.length > 0 && (
+                    <Table.tr>
+                      <Table.td colSpan={4}>
+                        <p className="text-sm text-foreground">No results found</p>
+                        <p className="text-sm text-foreground-light">
+                          Your search for "{search}" did not return any results
+                        </p>
+                      </Table.td>
+                    </Table.tr>
+                  )}
+                  {indexes.length > 0 &&
+                    indexes.map((index) => (
+                      <Table.tr key={index.name}>
+                        <Table.td>
+                          <p title={index.schema}>{index.schema}</p>
+                        </Table.td>
+                        <Table.td>
+                          <p title={index.table}>{index.table}</p>
+                        </Table.td>
+                        <Table.td>
+                          <p title={index.name}>{index.name}</p>
+                        </Table.td>
+                        <Table.td>
+                          <div className="flex justify-end items-center space-x-2">
+                            <Button type="default" onClick={() => setSelectedIndex(index)}>
+                              View definition
+                            </Button>
+                            {!isLocked && (
+                              <Button
+                                type="text"
+                                className="px-1"
+                                icon={<IconTrash />}
+                                onClick={() => setSelectedIndexToDelete(index)}
+                              />
+                            )}
+                          </div>
+                        </Table.td>
+                      </Table.tr>
+                    ))}
+                </>
+              }
+            />
+          )}
+        </div>
       </div>
 
       <SidePanel

--- a/studio/components/interfaces/Database/Triggers/TriggersList/TriggersList.tsx
+++ b/studio/components/interfaces/Database/Triggers/TriggersList/TriggersList.tsx
@@ -96,30 +96,32 @@ const TriggersList = ({
               />
             </div>
 
-            <Tooltip.Root delayDuration={0}>
-              <Tooltip.Trigger>
-                <Button disabled={!canCreateTriggers} onClick={() => createTrigger()}>
-                  Create a new trigger
-                </Button>
-              </Tooltip.Trigger>
-              {!canCreateTriggers && (
-                <Tooltip.Portal>
-                  <Tooltip.Content side="bottom">
-                    <Tooltip.Arrow className="radix-tooltip-arrow" />
-                    <div
-                      className={[
-                        'rounded bg-alternative py-1 px-2 leading-none shadow',
-                        'border border-background',
-                      ].join(' ')}
-                    >
-                      <span className="text-xs text-foreground">
-                        You need additional permissions to create triggers
-                      </span>
-                    </div>
-                  </Tooltip.Content>
-                </Tooltip.Portal>
-              )}
-            </Tooltip.Root>
+            {!isLocked && (
+              <Tooltip.Root delayDuration={0}>
+                <Tooltip.Trigger>
+                  <Button disabled={!canCreateTriggers} onClick={() => createTrigger()}>
+                    Create a new trigger
+                  </Button>
+                </Tooltip.Trigger>
+                {!canCreateTriggers && (
+                  <Tooltip.Portal>
+                    <Tooltip.Content side="bottom">
+                      <Tooltip.Arrow className="radix-tooltip-arrow" />
+                      <div
+                        className={[
+                          'rounded bg-alternative py-1 px-2 leading-none shadow',
+                          'border border-background',
+                        ].join(' ')}
+                      >
+                        <span className="text-xs text-foreground">
+                          You need additional permissions to create triggers
+                        </span>
+                      </div>
+                    </Tooltip.Content>
+                  </Tooltip.Portal>
+                )}
+              </Tooltip.Root>
+            )}
           </div>
 
           {isLocked && <ProtectedSchemaWarning schema={selectedSchema} entity="triggers" />}


### PR DESCRIPTION
The dashboard always had a guard rail to prevent users from managing things via the dashboard GUI in protected schemas, by showing this warning where appropriate
![image](https://github.com/supabase/supabase/assets/19742402/b2ee610f-3ad2-4b64-8e2d-b7e4c5ba433a)

For more context on what protected schemas are:
![image](https://github.com/supabase/supabase/assets/19742402/5fab3150-50f9-45f8-993b-36716bc1726a)

But we realised that triggers + functions were still showing the "create" button while viewing a protected schema, despite not being able to create triggers/functions in protected schemas - this is no change in behaviour, just making the UX consistent.

However, indexes were missing this protected schemas check, and as such this PR adds the protected schemas check to the indexes page. _**This means that the following behaviour will change on the dashboard**_
- Users will no longer be able to create/update/delete indexes through the database/indexes page, while in a protected schema.
- The alternative is do so the relevant operations via the SQL editor instead (as per the same as all other database/xxx pages)