### PR TITLE
ResolvedTheme in GraphiQL

### DIFF
--- a/studio/pages/project/[ref]/database/graphiql.tsx
+++ b/studio/pages/project/[ref]/database/graphiql.tsx
@@ -18,8 +18,8 @@ import { NextPageWithLayout } from 'types'
 const GraphiQLPage: NextPageWithLayout = () => {
   const { ref: projectRef } = useParams()
   const { ui, meta } = useStore()
-  const { theme } = useTheme()
-  const currentTheme = theme === 'dark' ? 'dark' : 'light'
+  const { resolvedTheme } = useTheme()
+  const currentTheme = resolvedTheme === 'dark' ? 'dark' : 'light'
 
   const isExtensionsLoading = meta.extensions.isLoading
   const pgGraphqlExtension = meta.extensions.byId('pg_graphql')


### PR DESCRIPTION
## What kind of change does this PR introduce?

Graphiql wasn't styled correctly when "System" theme option was selected.
Using the "resolvedTheme" from next-themes fixes it.

Fixes #18806 

## What is the current behavior?

<img width="1596" alt="Screenshot 2023-11-09 at 09 18 41" src="https://github.com/supabase/supabase/assets/25671831/8b38dd13-aca9-44e9-baab-33b0064c732e">

## What is the new behavior?

<img width="1504" alt="Screenshot 2023-11-09 at 09 18 49" src="https://github.com/supabase/supabase/assets/25671831/73f4d860-ca94-4aac-a0bb-05e4d3d3cd98">

