### PR TITLE
wrap tab lists to prevent overflow

### DIFF
--- a/apps/docs/components/index.tsx
+++ b/apps/docs/components/index.tsx
@@ -85,7 +85,7 @@ const components = {
       {props.children}
     </Alert>
   ),
-  Tabs,
+  Tabs: (props: any) => <Tabs wrappable {...props} />,
   TabPanel: (props: any) => <Tabs.Panel {...props}>{props.children}</Tabs.Panel>,
   h2: (props: any) => (
     <Heading tag="h2" {...props}>

--- a/apps/docs/styles/main.scss
+++ b/apps/docs/styles/main.scss
@@ -249,10 +249,6 @@ article p code {
   border: none;
 }
 
-.prose div[role='tablist'] {
-  flex-wrap: wrap;
-}
-
 /*
 * sets the image in @Next/Image components
 * to respect the height of the content

--- a/apps/docs/styles/main.scss
+++ b/apps/docs/styles/main.scss
@@ -249,7 +249,6 @@ article p code {
   border: none;
 }
 
-// prevent horizontal scroll on mobile for tablist tab headers
 .prose div[role='tablist'] {
   flex-wrap: wrap;
 }

--- a/apps/docs/styles/main.scss
+++ b/apps/docs/styles/main.scss
@@ -250,18 +250,8 @@ article p code {
 }
 
 // prevent horizontal scroll on mobile for tablist tab headers
-div[role='tablist'] {
-  @media screen and (min-width: 320px) {
-    max-width: 320px;
-  }
-
-  @media screen and (min-width: 600px) {
-    max-width: 520px;
-  }
-
-  @media screen and (min-width: 769px) {
-    max-width: 620px;
-  }
+.prose div[role='tablist'] {
+  flex-wrap: wrap;
 }
 
 /*

--- a/packages/ui/src/components/Tabs/Tabs.tsx
+++ b/packages/ui/src/components/Tabs/Tabs.tsx
@@ -16,6 +16,7 @@ interface TabsProps {
   onChange?: any
   onClick?: any
   scrollable?: boolean
+  wrappable?: boolean
   addOnBefore?: React.ReactNode
   addOnAfter?: React.ReactNode
   listClassNames?: string
@@ -35,6 +36,7 @@ const Tabs: React.FC<PropsWithChildren<TabsProps>> & TabsSubComponents = ({
   onChange,
   onClick,
   scrollable,
+  wrappable,
   addOnBefore,
   addOnAfter,
   listClassNames,
@@ -89,7 +91,10 @@ const Tabs: React.FC<PropsWithChildren<TabsProps>> & TabsSubComponents = ({
 
   const listClasses = [__styles[type].list]
   if (scrollable) listClasses.push(__styles.scrollable)
+  if (wrappable) listClasses.push(__styles.wrappable)
   if (listClassNames) listClasses.push(listClassNames)
+  console.log(wrappable)
+  console.log(listClasses)
 
   return (
     <TabsPrimitive.Root value={active} className={__styles.base}>

--- a/packages/ui/src/components/Tabs/Tabs.tsx
+++ b/packages/ui/src/components/Tabs/Tabs.tsx
@@ -93,8 +93,6 @@ const Tabs: React.FC<PropsWithChildren<TabsProps>> & TabsSubComponents = ({
   if (scrollable) listClasses.push(__styles.scrollable)
   if (wrappable) listClasses.push(__styles.wrappable)
   if (listClassNames) listClasses.push(listClassNames)
-  console.log(wrappable)
-  console.log(listClasses)
 
   return (
     <TabsPrimitive.Root value={active} className={__styles.base}>

--- a/packages/ui/src/lib/theme/defaultTheme.ts
+++ b/packages/ui/src/lib/theme/defaultTheme.ts
@@ -409,6 +409,7 @@ export default {
       ...default__padding_and_text,
     },
     scrollable: `overflow-auto whitespace-nowrap no-scrollbar mask-fadeout-right`,
+    wrappable: `flex-wrap`,
     content: `focus:outline-none transition-height`,
   },
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

**Bug fix**

Quick fix to add a wrapping option that makes tabs visible if there are many of them.

Long-term fix would be to detect overflow and switch to a dropdown in that case. Or use dropdown for smaller screens only and let it wrap on larger screens (since it will be rarer for wrapping to trigger there).

## What is the current behavior?

Tabs are cut off on the right when there are many of them. There is no way to scroll right on desktop because scrollbar width is set to 0. Also not super obvious on mobile that there is room to scroll.

![image](https://github.com/supabase/supabase/assets/26616127/e4098dcf-65f0-4dfd-81e2-1b9c1023c332)

## What is the new behavior?

![image](https://github.com/supabase/supabase/assets/26616127/5abfaa04-887d-4420-b0ea-707bb39f60f5)

## Additional context

Add any other context or screenshots.
