### PR TITLE
Fix typos in connecting-to-postgres.mdx

### DIFF
--- a/apps/docs/pages/guides/database/connecting-to-postgres.mdx
+++ b/apps/docs/pages/guides/database/connecting-to-postgres.mdx
@@ -128,7 +128,7 @@ This is the most granular option. Connections are returned to the pool after eve
 
     <StepHikeCompact.Details title="Install">
 
-    Install Drizzle and releated dependencies.
+    Install Drizzle and related dependencies.
 
     </StepHikeCompact.Details>
 
@@ -289,7 +289,7 @@ psql "sslmode=verify-full sslrootcert=$HOME/Downloads/prod-supabase.cer host=db.
 
     <StepHikeCompact.Details title="Install">
 
-    Install Postgres.js and releated dependencies.
+    Install Postgres.js and related dependencies.
 
     </StepHikeCompact.Details>
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
Docs update: fix typos in `connecting-to-postgres.mdx`