### PR TITLE
Fix the footer links in the supabase.com

### DIFF
--- a/apps/www/components/Footer/index.tsx
+++ b/apps/www/components/Footer/index.tsx
@@ -144,13 +144,7 @@ const Footer = (props: Props) => {
                         return (
                           <li key={`${segment.title}_link_${idx}`}>
                             {link.url ? (
-                              link.url.startsWith('https') ? (
-                                <a href={link.url}>{children}</a>
-                              ) : (
-                                <Link href={link.url} legacyBehavior>
-                                  {children}
-                                </Link>
-                              )
+                              <a href={link.url}>{children}</a>
                             ) : (
                               Component && <Component>{children}</Component>
                             )}


### PR DESCRIPTION
## What kind of change does this PR introduce?
#18882 

Bug fix, feature, docs update, ...

## What is the current behavior?
Many of the links in the footer of https://supabase.com/ aren't rendering as links

Please link any relevant issues here.

## What is the new behavior?

In this the links are being rendered as the links rather than the div 's 

Feel free to include screenshots if it includes visual changes.
![image](https://github.com/supabase/supabase/assets/113853868/0afe6a39-8df1-4aee-9865-ce965e815da0)


## Additional context

Add any other context or screenshots.
