### PR TITLE
Footer not rendering as link Fix

### DIFF
--- a/apps/www/components/Footer/index.tsx
+++ b/apps/www/components/Footer/index.tsx
@@ -142,14 +142,12 @@ const Footer = (props: Props) => {
                         )
 
                         return (
-                          <li key={`${segment.title}_link_${idx}`} className="cursor-pointer">
+                          <li key={`${segment.title}_link_${idx}`}>
                             {link.url ? (
                               link.url.startsWith('https') ? (
                                 <a href={link.url}>{children}</a>
                               ) : (
-                                <Link href={link.url} legacyBehavior>
-                                  {children}
-                                </Link>
+                                <Link href={link.url}>{children}</Link>
                               )
                             ) : (
                               Component && <Component>{children}</Component>

--- a/apps/www/components/Footer/index.tsx
+++ b/apps/www/components/Footer/index.tsx
@@ -142,7 +142,7 @@ const Footer = (props: Props) => {
                         )
 
                         return (
-                          <li key={`${segment.title}_link_${idx}`}>
+                          <li key={`${segment.title}_link_${idx}`} className="cursor-pointer">
                             {link.url ? (
                               link.url.startsWith('https') ? (
                                 <a href={link.url}>{children}</a>


### PR DESCRIPTION
## What kind of change does this PR introduce?
It fix the link not rendering as a link 
Bug fix, feature, docs update, ...

## What is the current behavior?
The link are currenly appear as a text cursor 
Please link any relevant issues here.
#18883 
## What is the new behavior?
The link appear as a cursor pointer 
Feel free to include screenshots if it includes visual changes.

## Additional context
It  is the fix of #18883 in which the footer link appear as a cursor text now it will appear as a cursor pointer 
Add any other context or screenshots.
