### PR TITLE
docs: styling heading

### DIFF
--- a/apps/docs/pages/guides/getting-started/tutorials/with-nextjs.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-nextjs.mdx
@@ -64,7 +64,9 @@ NEXT_PUBLIC_SUPABASE_URL=YOUR_SUPABASE_URL
 NEXT_PUBLIC_SUPABASE_ANON_KEY=YOUR_SUPABASE_ANON_KEY
 ```
 
-And one optional step is to update the CSS file `app/globals.css` to make the app look nice.
+### App Styling (Optional)
+
+An optional step is to update the CSS file `app/globals.css` to make the app look nice.
 You can find the full contents of this file [here](https://raw.githubusercontent.com/supabase/supabase/master/examples/user-management/nextjs-user-management/app/globals.css).
 
 ### Supabase Auth Helpers

--- a/apps/docs/pages/guides/getting-started/tutorials/with-nuxt-3.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-nuxt-3.mdx
@@ -49,7 +49,9 @@ These variables will be exposed on the browser, and that's completely fine since
 Amazing thing about [NuxtSupabase](https://supabase.nuxtjs.org/) is that setting environment variables is all we need to do in order to start using Supabase.
 No need to initialize Supabase. The library will take care of it automatically.
 
-And one optional step is to update the CSS file `assets/main.css` to make the app look nice.
+### App Styling (Optional)
+
+An optional step is to update the CSS file `assets/main.css` to make the app look nice.
 You can find the full contents of this file [here](https://github.com/supabase-community/nuxt3-quickstarter/blob/main/assets/main.css).
 
 ```typescript nuxt.config.ts

--- a/apps/docs/pages/guides/getting-started/tutorials/with-react.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-react.mdx
@@ -59,7 +59,9 @@ const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY
 export const supabase = createClient(supabaseUrl, supabaseAnonKey)
 ```
 
-And one optional step is to update the CSS file `src/index.css` to make the app look nice.
+### App Styling (Optional)
+
+An optional step is to update the CSS file `src/index.css` to make the app look nice.
 You can find the full contents of this file [here](https://raw.githubusercontent.com/supabase/supabase/master/examples/user-management/react-user-management/src/index.css).
 
 ### Set up a Login component

--- a/apps/docs/pages/guides/getting-started/tutorials/with-redwoodjs.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-redwoodjs.mdx
@@ -157,7 +157,9 @@ const App = () => (
 export default App
 ```
 
-And one optional step is to update the CSS file `web/src/index.css` to make the app look nice.
+### App Styling (Optional)
+
+An optional step is to update the CSS file `web/src/index.css` to make the app look nice.
 You can find the full contents of this file [here](https://raw.githubusercontent.com/supabase/supabase/master/examples/user-management/react-user-management/src/index.css).
 
 ### Start RedwoodJS and your first Page

--- a/apps/docs/pages/guides/getting-started/tutorials/with-solidjs.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-solidjs.mdx
@@ -56,7 +56,9 @@ const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY
 export const supabase = createClient(supabaseUrl, supabaseAnonKey)
 ```
 
-And one optional step is to update the CSS file `src/index.css` to make the app look nice.
+### App Styling (Optional)
+
+An optional step is to update the CSS file `src/index.css` to make the app look nice.
 You can find the full contents of this file [here](https://raw.githubusercontent.com/supabase/supabase/master/examples/user-management/solid-user-management/src/index.css).
 
 ### Set up a Login component

--- a/apps/docs/pages/guides/getting-started/tutorials/with-svelte.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-svelte.mdx
@@ -57,7 +57,9 @@ const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY
 export const supabase = createClient(supabaseUrl, supabaseAnonKey)
 ```
 
-And one optional step is to update the CSS file `src/app.css` to make the app look nice.
+### App Styling (Optional)
+
+An optional step is to update the CSS file `src/app.css` to make the app look nice.
 You can find the full contents of this file [here](https://raw.githubusercontent.com/supabase/supabase/master/examples/user-management/svelte-user-management/src/app.css).
 
 ### Set up a Login component


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs - Getting Started

## What is the current behavior?

On the guides their is a link and a couple of lines on adding style changes, but it is easily missed when scrolling through.

## What is the new behavior?

A new App Styling (Optional) heading added:
<img width="1433" alt="Screenshot 2023-11-11 at 20 34 29" src="https://github.com/supabase/supabase/assets/22655069/f3d4ea29-10bc-4d07-9f49-3a1874bbae38">

