### PR TITLE
fix: update self-hosted auth redirects

### DIFF
--- a/studio/next.config.js
+++ b/studio/next.config.js
@@ -29,48 +29,83 @@ const nextConfig = {
   output: 'standalone',
   async redirects() {
     return [
-      {
-        source: '/',
-        has: [
-          {
-            type: 'query',
-            key: 'next',
-            value: 'new-project',
-          },
-        ],
-        destination: '/new/new-project',
-        permanent: false,
-      },
-      {
-        source: '/',
-        destination: '/projects',
-        permanent: false,
-      },
-      {
-        source: '/register',
-        destination: '/sign-up',
-        permanent: false,
-      },
-      {
-        source: '/signup',
-        destination: '/sign-up',
-        permanent: false,
-      },
-      {
-        source: '/signin',
-        destination: '/sign-in',
-        permanent: false,
-      },
-      {
-        source: '/login',
-        destination: '/sign-in',
-        permanent: false,
-      },
-      {
-        source: '/log-in',
-        destination: '/sign-in',
-        permanent: false,
-      },
+      ...(process.env.NEXT_PUBLIC_IS_PLATFORM === 'true'
+        ? [
+            {
+              source: '/',
+              has: [
+                {
+                  type: 'query',
+                  key: 'next',
+                  value: 'new-project',
+                },
+              ],
+              destination: '/new/new-project',
+              permanent: false,
+            },
+            {
+              source: '/',
+              destination: '/projects',
+              permanent: false,
+            },
+            {
+              source: '/register',
+              destination: '/sign-up',
+              permanent: false,
+            },
+            {
+              source: '/signup',
+              destination: '/sign-up',
+              permanent: false,
+            },
+            {
+              source: '/signin',
+              destination: '/sign-in',
+              permanent: false,
+            },
+            {
+              source: '/login',
+              destination: '/sign-in',
+              permanent: false,
+            },
+            {
+              source: '/log-in',
+              destination: '/sign-in',
+              permanent: false,
+            },
+          ]
+        : [
+            {
+              source: '/',
+              destination: '/project/default',
+              permanent: false,
+            },
+            {
+              source: '/register',
+              destination: '/project/default',
+              permanent: false,
+            },
+            {
+              source: '/signup',
+              destination: '/project/default',
+              permanent: false,
+            },
+            {
+              source: '/signin',
+              destination: '/project/default',
+              permanent: false,
+            },
+            {
+              source: '/login',
+              destination: '/project/default',
+              permanent: false,
+            },
+            {
+              source: '/log-in',
+              destination: '/project/default',
+              permanent: false,
+            },
+          ]),
       {
         source: '/project/:ref/auth',
         destination: '/project/:ref/auth/users',


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix / chore

## What is the new behaviour?

All auth-related routes are redirected to `/project/default`