### PR TITLE
Replaced "redirectTo" with "emailRedirectTo" in Sign-in

### DIFF
--- a/apps/docs/pages/guides/auth/auth-email.mdx
+++ b/apps/docs/pages/guides/auth/auth-email.mdx
@@ -136,7 +136,7 @@ async function signInWithEmail() {
     email: 'example@email.com',
     password: 'example-password',
     options: {
-      redirectTo: 'https//example.com/welcome'
+      emailRedirectTo: 'https//example.com/welcome'
     }
   })
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Updated the documentation.

## What is the current behavior?

It is showing "redirectTo" in Sign up the user section.

## What is the new behavior?

I changed the "redirectTo" to "emailRedirectTo"

## Additional context

This commit fixes a Supabase authentication issue in the "Sign up the user" section. It replaces "redirectTo" with "emailRedirectTo" in the relevant code block.