### PR TITLE
Removed the "emailRedirectTo" in signIn

### DIFF
--- a/apps/docs/pages/guides/auth/auth-email.mdx
+++ b/apps/docs/pages/guides/auth/auth-email.mdx
@@ -134,10 +134,7 @@ When your user signs in, call [signInWithPassword()](/docs/reference/javascript/
 async function signInWithEmail() {
   const { data, error } = await supabase.auth.signInWithPassword({
     email: 'example@email.com',
-    password: 'example-password',
-    options: {
-      emailRedirectTo: 'https//example.com/welcome'
-    }
+    password: 'example-password'
   })
 }
 ```


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update, ...

## What is the current behavior?

Previously Sign in the user has "emailRedirectTo" property.

## What is the new behavior?

Removed this code block from the Sign in the user:
`    options: {
      emailRedirectTo: 'https//example.com/welcome'
    }`

## Additional context

I removed the emailRedirectTo from the "Sign in the user" beacuse as such there is no property of emailRedirectTo options. Since, emailRedirectTo  should only available in "Sign up the user".