### PR TITLE
docs: update version label of swift reference docs

### DIFF
--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
@@ -202,7 +202,7 @@ export const REFERENCES: References = {
   swift: {
     name: 'Swift',
     library: 'supabase-swift',
-    versions: ['v0'],
+    versions: ['v1'],
     icon: '/docs/img/libraries/swift-icon.svg',
   },
   kotlin: {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Swift library has been updated to v1.0 recently. https://github.com/supabase/supabase/pull/18682

Currently though the reference docs has a v0.0 label.
<img width="368" alt="Screenshot 2023-11-14 at 11 02 40" src="https://github.com/supabase/supabase/assets/18113850/7d2aa7fe-3317-472a-a05a-4c5e0e786551">

This PR updates the label to say v1.0
<img width="356" alt="Screenshot 2023-11-14 at 11 03 26" src="https://github.com/supabase/supabase/assets/18113850/177fbde9-5f1f-4096-95d2-8420ee9ad3e4">
