### PR TITLE
docs: update Kotlin docs to v1.0

### DIFF
--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
@@ -208,7 +208,7 @@ export const REFERENCES: References = {
   kotlin: {
     name: 'Kotlin',
     library: 'supabase-kt',
-    versions: ['v0'],
+    versions: ['v1'],
     icon: '/docs/img/libraries/kotlin-icon.svg',
   },
   cli: {

--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.tsx
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.tsx
@@ -157,7 +157,7 @@ const menus: Menu[] = [
     id: 'reference_kotlin_v0',
     path: '/reference/kotlin',
     commonSectionsFile: 'common-client-libs-sections.json',
-    specFile: 'supabase_kt_v0.yml',
+    specFile: 'supabase_kt_v1.yml',
     type: 'reference',
   },
   {

--- a/apps/docs/docs/ref/kotlin/installing.mdx
+++ b/apps/docs/docs/ref/kotlin/installing.mdx
@@ -264,7 +264,7 @@ By default, [KotlinX Serialization](https://github.com/Kotlin/kotlinx.serializat
             </TabPanel>
         </Tabs>
         ```kotlin
-        val client = createSupabaseClient(supabaseUrl, supabaseKey) {
+        val supabase = createSupabaseClient(supabaseUrl, supabaseKey) {
             //Already the default serializer
         }
         ```
@@ -312,7 +312,7 @@ By default, [KotlinX Serialization](https://github.com/Kotlin/kotlinx.serializat
             </TabPanel>
         </Tabs>
         ```kotlin
-        val client = createSupabaseClient(supabaseUrl, supabaseKey) {
+        val supabase = createSupabaseClient(supabaseUrl, supabaseKey) {
             defaultSerializer = MoshiSerializer()
         }
         ```
@@ -361,7 +361,7 @@ By default, [KotlinX Serialization](https://github.com/Kotlin/kotlinx.serializat
             </TabPanel>
         </Tabs>
         ```kotlin
-        val client = createSupabaseClient(supabaseUrl, supabaseKey) {
+        val supabase = createSupabaseClient(supabaseUrl, supabaseKey) {
             defaultSerializer = JacksonSerializer()
         }
         ```
@@ -392,7 +392,7 @@ By default, [KotlinX Serialization](https://github.com/Kotlin/kotlinx.serializat
         ```
 
         ```kotlin
-        val client = createSupabaseClient(supabaseUrl, supabaseKey) {
+        val supabase = createSupabaseClient(supabaseUrl, supabaseKey) {
             defaultSerializer = CustomSerializer()
         }
         ```

--- a/apps/docs/internals/files/reference-lib.mjs
+++ b/apps/docs/internals/files/reference-lib.mjs
@@ -12,7 +12,7 @@ const clientLibFiles = [
   { fileName: 'supabase_py_v2', label: 'python', version: 'v2', versionSlug: false },
   { fileName: 'supabase_csharp_v0', label: 'csharp', version: 'v0', versionSlug: false },
   { fileName: 'supabase_swift_v1', label: 'swift', version: 'v1', versionSlug: false },
-  { fileName: 'supabase_kt_v0', label: 'kotlin', version: 'v0', versionSlug: false },
+  { fileName: 'supabase_kt_v1', label: 'kotlin', version: 'v0', versionSlug: false },
 ]
 
 export function generateReferencePages() {

--- a/apps/docs/pages/reference/kotlin/[...slug].tsx
+++ b/apps/docs/pages/reference/kotlin/[...slug].tsx
@@ -1,5 +1,5 @@
 import clientLibsCommonSections from '~/../../spec/common-client-libs-sections.json'
-import spec from '~/../../spec/supabase_kt_v0.yml' assert { type: 'yml' }
+import spec from '~/../../spec/supabase_kt_v1.yml' assert { type: 'yml' }
 import RefSectionHandler from '~/components/reference/RefSectionHandler'
 import { flattenSections } from '~/lib/helpers'
 import handleRefGetStaticPaths from '~/lib/mdx/handleRefStaticPaths'

--- a/apps/docs/pages/reference/kotlin/crawlers/[...slug].tsx
+++ b/apps/docs/pages/reference/kotlin/crawlers/[...slug].tsx
@@ -1,6 +1,6 @@
 import clientLibsCommonSections from '~/../../spec/common-client-libs-sections.json'
 import typeSpec from '~/../../spec/enrichments/tsdoc_v2/combined.json'
-import spec from '~/../../spec/supabase_kt_v0.yml' assert { type: 'yml' }
+import spec from '~/../../spec/supabase_kt_v1.yml' assert { type: 'yml' }
 import RefSectionHandler from '~/components/reference/RefSectionHandler'
 import { flattenSections } from '~/lib/helpers'
 import handleRefGetStaticPaths from '~/lib/mdx/handleRefStaticPaths'

--- a/apps/docs/pages/reference/kotlin/v0/[...slug].tsx
+++ b/apps/docs/pages/reference/kotlin/v0/[...slug].tsx
@@ -1,5 +1,5 @@
 import clientLibsCommonSections from '~/../../spec/common-client-libs-sections.json'
-import spec from '~/../../spec/supabase_kt_v0.yml' assert { type: 'yml' }
+import spec from '~/../../spec/supabase_kt_v1.yml' assert { type: 'yml' }
 import RefSectionHandler from '~/components/reference/RefSectionHandler'
 import { flattenSections } from '~/lib/helpers'
 import handleRefGetStaticPaths from '~/lib/mdx/handleRefStaticPaths'

--- a/apps/docs/pages/reference/kotlin/v0/crawlers/[...slug].tsx
+++ b/apps/docs/pages/reference/kotlin/v0/crawlers/[...slug].tsx
@@ -1,6 +1,6 @@
 import clientLibsCommonSections from '~/../../spec/common-client-libs-sections.json'
 import typeSpec from '~/../../spec/enrichments/tsdoc_v2/combined.json'
-import spec from '~/../../spec/supabase_kt_v0.yml' assert { type: 'yml' }
+import spec from '~/../../spec/supabase_kt_v1.yml' assert { type: 'yml' }
 import RefSectionHandler from '~/components/reference/RefSectionHandler'
 import { flattenSections } from '~/lib/helpers'
 import handleRefGetStaticPaths from '~/lib/mdx/handleRefStaticPaths'

--- a/apps/docs/scripts/search/sources/index.ts
+++ b/apps/docs/scripts/search/sources/index.ts
@@ -72,7 +72,7 @@ export async function fetchSources() {
     'kt-lib',
     '/reference/kotlin',
     { title: 'Kotlin Reference' },
-    '../../spec/supabase_kt_v0.yml',
+    '../../spec/supabase_kt_v1.yml',
     '../../spec/common-client-libs-sections.json'
   )
 

--- a/spec/supabase_kt_v1.yml
+++ b/spec/supabase_kt_v1.yml
@@ -7,7 +7,7 @@ info:
 
     Supabase Kotlin.
 
-  specUrl: https://github.com/supabase/supabase/edit/master/spec/supabase_kt_v0.yml
+  specUrl: https://github.com/supabase/supabase/edit/master/spec/supabase_kt_v1.yml
   slugPrefix: '/'
   libraries:
     - name: 'Kotlin'


### PR DESCRIPTION
## What kind of change does this PR introduce?

The Kotlin library for Supabase is currently at v1.0, but the docs was left at v0.0. This PR updates the Kotlin reference docs to v1.0. Also contains renaming `client` variable to `supabase` to align with other client libraries. 