### PR TITLE
chore: update pg_net docs 

### DIFF
--- a/apps/docs/pages/guides/database/extensions/pg_net.mdx
+++ b/apps/docs/pages/guides/database/extensions/pg_net.mdx
@@ -95,8 +95,6 @@ request_id
 (1 row)
 ```
 
-After triggering `http_get`, use [`http_get_result`](#http_get_result) to get the result of the request.
-
 ## `http_post`
 
 Creates an HTTP POST request with a JSON body, returning the request's ID. HTTP requests are not started until the transaction is committed.


### PR DESCRIPTION
## What kind of change does this PR introduce?

There's a reference to `http_get_result()` which seems to be a broken link. [Searching the pg_net repo](https://github.com/search?q=repo%3Asupabase%2Fpg_net%20http_get_result&type=code)  for the method seems to give no results so guessing it might be deleted/deprecated. 