### PR TITLE
docs: remove ! from ci.yml for comparing types.gen.ts

### DIFF
--- a/apps/docs/pages/guides/cli/managing-environments.mdx
+++ b/apps/docs/pages/guides/cli/managing-environments.mdx
@@ -213,7 +213,7 @@ jobs:
       - name: Verify generated types are checked in
         run: |
           supabase gen types typescript --local > types.gen.ts
-          if ! git diff --ignore-space-at-eol --exit-code --quiet types.gen.ts; then
+          if git diff --ignore-space-at-eol --exit-code --quiet types.gen.ts; then
             echo "Detected uncommitted changes after build. See status below:"
             git diff
             exit 1


### PR DESCRIPTION

## What kind of change does this PR introduce?

docs

## What is the current behavior?

```
if not changes in types.gen.ts {
    show changes;
    exit with code 1 (which means error);
}
```

## What is the new behavior?

```
if changes in types.gen.ts {
    show changes;
    exit with code 1 (which means error);
}
```
