### PR TITLE
Fix active option selection colors

### DIFF
--- a/packages/ui/src/lib/theme/defaultTheme.ts
+++ b/packages/ui/src/lib/theme/defaultTheme.ts
@@ -676,8 +676,8 @@ export default {
           hover:bg-surface-300
         `,
         active: `
-          bg-surface-300 z-10
-          border-muted
+          bg-selection z-10
+          border-stronger
           border-1
         `,
         radio_offset: 'left-4',
@@ -712,8 +712,8 @@ export default {
           hover:bg-surface-300
         `,
         active: `
-          bg-surface-300 z-10
-          border-muted
+          bg-selection z-10
+          border-stronger
           border-1
         `,
         radio_offset: 'left-4',
@@ -752,8 +752,8 @@ export default {
           hover:bg-surface-300
         `,
         active: `
-          bg-surface-300 z-10
-          border-muted border-1
+          bg-selection z-10
+          border-stronger border-1
         `,
         radio_offset: 'left-4',
       },
@@ -788,8 +788,8 @@ export default {
           hover:bg-surface-300
         `,
         active: `
-          bg-surface-300 z-10
-          border-muted
+          bg-selection z-10
+          border-strong
           border-1
         `,
         radio_offset: 'left-4',


### PR DESCRIPTION
## What kind of change does this PR introduce?

Selected option wasn't noticeable after tokens migration PR.

## What is the current behavior?

<img width="219" alt="Screenshot 2023-11-14 at 11 41 46" src="https://github.com/supabase/supabase/assets/25671831/ac570efd-7da2-4cf0-be43-d51e878b1505">
<img width="233" alt="Screenshot 2023-11-14 at 11 41 54" src="https://github.com/supabase/supabase/assets/25671831/1dcf9abb-a10a-4a60-aa33-f55b129e08ad">

## What is the new behavior?

<img width="212" alt="Screenshot 2023-11-14 at 11 45 49" src="https://github.com/supabase/supabase/assets/25671831/96a6934d-0dce-41b3-8171-3d5136e4da71">
<img width="199" alt="Screenshot 2023-11-14 at 11 46 04" src="https://github.com/supabase/supabase/assets/25671831/af992ed8-3d86-443e-bcfa-d2032fc78d74">
