### PR TITLE
feat:  Show resource usage in function metrics

### DIFF
--- a/apps/studio/data/analytics/functions-req-stats-query.ts
+++ b/apps/studio/data/analytics/functions-req-stats-query.ts
@@ -1,0 +1,62 @@
+import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { get } from 'lib/common/fetch'
+import { API_URL } from 'lib/constants'
+import { analyticsKeys } from './keys'
+
+export type FunctionsReqStatsVariables = {
+  projectRef?: string
+  functionId?: string
+  interval?: string
+}
+
+export type FunctionsReqStatsResponse = any
+
+export async function getFunctionsReqStats(
+  { projectRef, functionId, interval }: FunctionsReqStatsVariables,
+  signal?: AbortSignal
+) {
+  if (!projectRef) {
+    throw new Error('projectRef is required')
+  }
+  if (!functionId) {
+    throw new Error('functionId is required')
+  }
+  if (!interval) {
+    throw new Error('interval is required')
+  }
+
+  const response = await get<FunctionsReqStatsResponse>(
+    `${API_URL}/projects/${projectRef}/analytics/endpoints/functions.req-stats?interval=${interval}&function_id=${functionId}`,
+    {
+      signal,
+    }
+  )
+  if (response.error) {
+    throw response.error
+  }
+
+  return response
+}
+
+export type FunctionsReqStatsData = Awaited<ReturnType<typeof getFunctionsReqStats>>
+export type FunctionsReqStatsError = unknown
+
+export const useFunctionsReqStatsQuery = <TData = FunctionsReqStatsData>(
+  { projectRef, functionId, interval }: FunctionsReqStatsVariables,
+  {
+    enabled = true,
+    ...options
+  }: UseQueryOptions<FunctionsReqStatsData, FunctionsReqStatsError, TData> = {}
+) =>
+  useQuery<FunctionsReqStatsData, FunctionsReqStatsError, TData>(
+    analyticsKeys.functionsReqStats(projectRef, { functionId, interval }),
+    ({ signal }) => getFunctionsReqStats({ projectRef, functionId, interval }, signal),
+    {
+      enabled:
+        enabled &&
+        typeof projectRef !== 'undefined' &&
+        typeof functionId !== 'undefined' &&
+        typeof interval !== 'undefined',
+      ...options,
+    }
+  )

--- a/apps/studio/data/analytics/functions-resource-usage-query.ts
+++ b/apps/studio/data/analytics/functions-resource-usage-query.ts
@@ -1,0 +1,62 @@
+import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { get } from 'lib/common/fetch'
+import { API_URL } from 'lib/constants'
+import { analyticsKeys } from './keys'
+
+export type FunctionsResourceUsageVariables = {
+  projectRef?: string
+  functionId?: string
+  interval?: string
+}
+
+export type FunctionsResourceUsageResponse = any
+
+export async function getFunctionsResourceUsage(
+  { projectRef, functionId, interval }: FunctionsResourceUsageVariables,
+  signal?: AbortSignal
+) {
+  if (!projectRef) {
+    throw new Error('projectRef is required')
+  }
+  if (!functionId) {
+    throw new Error('functionId is required')
+  }
+  if (!interval) {
+    throw new Error('interval is required')
+  }
+
+  const response = await get<FunctionsResourceUsageResponse>(
+    `${API_URL}/projects/${projectRef}/analytics/endpoints/functions.resource-usage?interval=${interval}&function_id=${functionId}`,
+    {
+      signal,
+    }
+  )
+  if (response.error) {
+    throw response.error
+  }
+
+  return response
+}
+
+export type FunctionsResourceUsageData = Awaited<ReturnType<typeof getFunctionsResourceUsage>>
+export type FunctionsResourceUsageError = unknown
+
+export const useFunctionsResourceUsageQuery = <TData = FunctionsResourceUsageData>(
+  { projectRef, functionId, interval }: FunctionsResourceUsageVariables,
+  {
+    enabled = true,
+    ...options
+  }: UseQueryOptions<FunctionsResourceUsageData, FunctionsResourceUsageError, TData> = {}
+) =>
+  useQuery<FunctionsResourceUsageData, FunctionsResourceUsageError, TData>(
+    analyticsKeys.functionsResourceUsage(projectRef, { functionId, interval }),
+    ({ signal }) => getFunctionsResourceUsage({ projectRef, functionId, interval }, signal),
+    {
+      enabled:
+        enabled &&
+        typeof projectRef !== 'undefined' &&
+        typeof functionId !== 'undefined' &&
+        typeof interval !== 'undefined',
+      ...options,
+    }
+  )

--- a/apps/studio/data/analytics/keys.ts
+++ b/apps/studio/data/analytics/keys.ts
@@ -1,8 +1,62 @@
 export const analyticsKeys = {
   functionsInvStats: (
     projectRef: string | undefined,
-    { interval, functionId }: { functionId: string | undefined; interval: string | undefined }
-  ) => ['projects', projectRef, 'functions-inv-stats', { interval, functionId }] as const,
+    {
+      interval,
+      functionId,
+    }: {
+      functionId: string | undefined
+      interval: string | undefined
+    }
+  ) =>
+    [
+      'projects',
+      projectRef,
+      'functions-inv-stats',
+      {
+        interval,
+        functionId,
+      },
+    ] as const,
+  functionsReqStats: (
+    projectRef: string | undefined,
+    {
+      interval,
+      functionId,
+    }: {
+      functionId: string | undefined
+      interval: string | undefined
+    }
+  ) =>
+    [
+      'projects',
+      projectRef,
+      'functions-req-stats',
+      {
+        interval,
+        functionId,
+      },
+    ] as const,
+  functionsResourceUsage: (
+    projectRef: string | undefined,
+    {
+      interval,
+      functionId,
+    }: {
+      functionId: string | undefined
+      interval: string | undefined
+    }
+  ) =>
+    [
+      'projects',
+      projectRef,
+      'functions-resource-usage',
+      {
+        interval,
+        functionId,
+      },
+    ] as const,
+
   dailyStats: (
     projectRef: string | undefined,
     {
@@ -10,7 +64,12 @@ export const analyticsKeys = {
       startDate,
       endDate,
       interval,
-    }: { attribute?: string; startDate?: string; endDate?: string; interval?: string }
+    }: {
+      attribute?: string
+      startDate?: string
+      endDate?: string
+      interval?: string
+    }
   ) =>
     [
       'projects',
@@ -58,7 +117,12 @@ export const analyticsKeys = {
       startDate,
       endDate,
       interval,
-    }: { attribute?: string; startDate?: string; endDate?: string; interval?: string }
+    }: {
+      attribute?: string
+      startDate?: string
+      endDate?: string
+      interval?: string
+    }
   ) =>
     [
       'projects',


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR adds resource usage charts to function metrics. Also, it modifies the invocations chart to split them up by response status.

![Screen Shot 2023-11-15 at 2 28 12 am](https://github.com/supabase/supabase/assets/5358/8f198c32-818c-4543-8539-688c9a282e16)

## What is the current behavior?

The current behavior shows only execution time and total number of invocations as charts.

## What is the new behavior?

Show CPU time, Memory usage charts. Modify invocations to split by response status.

## Additional context

The new behavior is feature flagged under `enableResourceUsageMetricsForEdgeFunctions`
