### PR TITLE
fix comment tag appearing in title

### DIFF
--- a/apps/docs/layouts/guides/index.tsx
+++ b/apps/docs/layouts/guides/index.tsx
@@ -77,7 +77,7 @@ const Layout: FC<Props> = (props) => {
   return (
     <>
       <Head>
-        <title>{props.meta?.title} | Supabase Docs</title>
+        <title>{`${props.meta?.title} | Supabase Docs`}</title>
         <meta name="description" content={props.meta?.description} />
         <meta property="og:image" content={ogImageUrl} />
         <meta name="twitter:image" content={ogImageUrl} />


### PR DESCRIPTION
## What kind of change does this PR introduce?

**Bug fix**

Comment tags were appearing in the generated title on guide pages and showing up in OG images and Google Search results.

## What is the current behavior?

`<title>Managing User Data<!-- --> | Supabase Docs</title>`

## What is the new behavior?

`<title>Managing User Data | Supabase Docs</title>`
