### PR TITLE
docs: Replace deprecated command with environment file

### DIFF
--- a/apps/docs/pages/guides/api/rest/generating-types.mdx
+++ b/apps/docs/pages/guides/api/rest/generating-types.mdx
@@ -88,7 +88,7 @@ jobs:
       - name: check for file changes
         id: git_status
         run: |
-          echo "::set-output name=status::$(git status -s)"
+          echo "status=$(git status -s)" >> $GITHUB_OUTPUT
       - name: Commit files
         if: ${{contains(steps.git_status.outputs.status, ' ')}}
         run: |


### PR DESCRIPTION
## What kind of change does this PR introduce?

Update workflow example to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

**AS-IS**

```yaml
echo "::set-output name=status::$(git status -s)"
```

**TO-BE**

```yaml
echo "status=$(git status -s)" >> $GITHUB_OUTPUT
```