### PR TITLE
Add org slug as copyable input to org settings

### DIFF
--- a/apps/studio/components/interfaces/Organization/GeneralSettings/GeneralSettings.tsx
+++ b/apps/studio/components/interfaces/Organization/GeneralSettings/GeneralSettings.tsx
@@ -112,6 +112,14 @@ const GeneralSettings = () => {
                     label="Organization name"
                     disabled={!canUpdateOrganization}
                   />
+                  <Input
+                    copy
+                    disabled
+                    id="slug"
+                    size="small"
+                    label="Organization slug"
+                    value={selectedOrganization?.slug}
+                  />
                   <div className="mt-4">
                     <Toggle
                       id="isOptedIntoAi"


### PR DESCRIPTION
Add org slug as copyable input to org settings
![image](https://github.com/supabase/supabase/assets/19742402/54c120eb-6699-405f-9399-83d2eee9290f)
