### PR TITLE
fix: show mean for the period as the highlighted values in function metrics

### DIFF
--- a/apps/studio/pages/project/[ref]/functions/[functionSlug]/index.tsx
+++ b/apps/studio/pages/project/[ref]/functions/[functionSlug]/index.tsx
@@ -15,6 +15,7 @@ import dayjs, { Dayjs } from 'dayjs'
 import { useCheckPermissions, useFlag } from 'hooks'
 import useFillTimeseriesSorted from 'hooks/analytics/useFillTimeseriesSorted'
 import sumBy from 'lodash/sumBy'
+import meanBy from 'lodash/meanBy'
 import { observer } from 'mobx-react-lite'
 import { useRouter } from 'next/router'
 import { useMemo, useState } from 'react'
@@ -194,11 +195,6 @@ const PageLayout: NextPageWithLayout = () => {
               resourceUsageMetricsEnabled ? reqStatsResult.isLoading : invStatsResult.isLoading
             }
             renderer={(props) => {
-              const latest = props.data[props.data.length - 1]
-              let highlightedValue
-              if (latest) {
-                highlightedValue = latest['avg_execution_time']
-              }
               return (
                 <AreaChart
                   className="w-full"
@@ -207,7 +203,7 @@ const PageLayout: NextPageWithLayout = () => {
                   yAxisKey="avg_execution_time"
                   data={props.data}
                   format="ms"
-                  highlightedValue={highlightedValue}
+                  highlightedValue={meanBy(props.data, 'avg_execution_time')}
                 />
               )
             }}
@@ -294,11 +290,6 @@ const PageLayout: NextPageWithLayout = () => {
                 data={resourceUsageChartData}
                 isLoading={resourceUsageResult.isLoading}
                 renderer={(props) => {
-                  const latest = props.data[props.data.length - 1]
-                  let highlightedValue
-                  if (latest) {
-                    highlightedValue = latest['avg_cpu_time_used']
-                  }
                   return (
                     <AreaChart
                       className="w-full"
@@ -307,7 +298,7 @@ const PageLayout: NextPageWithLayout = () => {
                       yAxisKey="avg_cpu_time_used"
                       data={props.data}
                       format="ms"
-                      highlightedValue={highlightedValue}
+                      highlightedValue={meanBy(props.data, 'avg_cpu_time_used')}
                     />
                   )
                 }}
@@ -318,11 +309,6 @@ const PageLayout: NextPageWithLayout = () => {
                 data={resourceUsageChartData}
                 isLoading={resourceUsageResult.isLoading}
                 renderer={(props) => {
-                  const latest = props.data[props.data.length - 1]
-                  let highlightedValue
-                  if (latest) {
-                    highlightedValue = latest['avg_memory_used']
-                  }
                   return (
                     <AreaChart
                       className="w-full"
@@ -331,7 +317,7 @@ const PageLayout: NextPageWithLayout = () => {
                       yAxisKey="avg_memory_used"
                       data={props.data}
                       format="MB"
-                      highlightedValue={highlightedValue}
+                      highlightedValue={meanBy(props.data, 'avg_memory_used')}
                     />
                   )
                 }}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Show mean value as the highlighted value in the function metrics charts.

## What is the current behavior?

Currently, it shows the latest value from the chart, which sometimes can be a zero value.

![Screen Shot 2023-11-16 at 2 26 39 pm](https://github.com/supabase/supabase/assets/5358/06ec1c33-ba9f-4873-9ef4-ff91798ced34)


## What is the new behavior?

Instead of the latest value, show the mean value for the period.
