### PR TITLE
Restore dark: tw selector

### DIFF
--- a/apps/studio/components/interfaces/Realtime/Inspector/SelectedRealtimeMessagePanel.tsx
+++ b/apps/studio/components/interfaces/Realtime/Inspector/SelectedRealtimeMessagePanel.tsx
@@ -3,7 +3,7 @@ import { jsonSyntaxHighlight, SelectionDetailedTimestampRow } from './MessagesFo
 
 const LogsDivider = () => {
   return (
-    <div className="h-px w-full bg-panel-border-interior-light [[data-theme*=dark]_&]:bg-panel-border-interior-dark" />
+    <div className="h-px w-full bg-panel-border-interior-light dark:bg-panel-border-interior-dark" />
   )
 }
 

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/Results.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/Results.tsx
@@ -78,7 +78,7 @@ const Results = ({ id, rows }: { id: string; rows: readonly any[] }) => {
 
   if (rows.length <= 0) {
     return (
-      <div className="bg-table-header-light [[data-theme*=dark]_&]:bg-table-header-dark">
+      <div className="bg-table-header-light dark:bg-table-header-dark">
         <p className="m-0 border-0 px-6 py-4 font-mono text-sm">Success. No rows returned</p>
       </div>
     )

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityTabResults.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityTabResults.tsx
@@ -64,7 +64,7 @@ const UtilityTabResults = ({ id, isExecuting }: UtilityTabResultsProps) => {
 
   if (isExecuting) {
     return (
-      <div className="bg-table-header-light [[data-theme*=dark]_&]:bg-table-header-dark">
+      <div className="bg-table-header-light dark:bg-table-header-dark">
         <p className="m-0 border-0 px-6 py-4 font-mono text-sm">Running...</p>
       </div>
     )
@@ -74,7 +74,7 @@ const UtilityTabResults = ({ id, isExecuting }: UtilityTabResultsProps) => {
     )
 
     return (
-      <div className="bg-table-header-light [[data-theme*=dark]_&]:bg-table-header-dark">
+      <div className="bg-table-header-light dark:bg-table-header-dark">
         <div className="flex flex-row justify-between items-start py-4 px-6">
           {isTimeout ? (
             <div className="flex flex-col gap-y-1">
@@ -161,7 +161,7 @@ const UtilityTabResults = ({ id, isExecuting }: UtilityTabResultsProps) => {
     )
   } else if (!result) {
     return (
-      <div className="bg-table-header-light [[data-theme*=dark]_&]:bg-table-header-dark">
+      <div className="bg-table-header-light dark:bg-table-header-dark">
         <p className="m-0 border-0 px-6 py-4 text-sm text-foreground-light">
           Click <code>Run</code> to execute your query.
         </p>

--- a/apps/studio/components/interfaces/Settings/API/JWTSettings.tsx
+++ b/apps/studio/components/interfaces/Settings/API/JWTSettings.tsx
@@ -94,7 +94,7 @@ const JWTSettings = () => {
   return (
     <>
       <Panel title={<h5 className="mb-0">JWT Settings</h5>}>
-        <Panel.Content className="space-y-6 border-t border-panel-border-interior-light [[data-theme*=dark]_&]:border-panel-border-interior-dark">
+        <Panel.Content className="space-y-6 border-t border-panel-border-interior-light dark:border-panel-border-interior-dark">
           {isError ? (
             <div className="flex items-center justify-center py-8 space-x-2">
               <IconAlertCircle size={16} strokeWidth={1.5} />

--- a/apps/studio/components/interfaces/Settings/Logs/LogSelectionRenderers/FunctionLogsSelectionRender.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogSelectionRenderers/FunctionLogsSelectionRender.tsx
@@ -17,7 +17,7 @@ const FunctionLogsSelectionRender = ({ log }: any) => {
           {log.event_message}
         </div>
       </div>
-      <div className="h-px w-full bg-panel-border-interior-light [[data-theme*=dark]_&]:bg-panel-border-interior-dark"></div>
+      <div className="h-px w-full bg-panel-border-interior-light dark:bg-panel-border-interior-dark"></div>
       <div className={`${LOGS_TAILWIND_CLASSES.log_selection_x_padding} space-y-2`}>
         <SelectionDetailedRow
           label="Severity"

--- a/apps/studio/components/interfaces/Settings/Logs/Logs.Divider.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.Divider.tsx
@@ -1,6 +1,6 @@
 const LogsDivider = () => {
   return (
-    <div className="h-px w-full bg-panel-border-interior-light [[data-theme*=dark]_&]:bg-panel-border-interior-dark"></div>
+    <div className="h-px w-full bg-panel-border-interior-light dark:bg-panel-border-interior-dark"></div>
   )
 }
 

--- a/apps/studio/components/to-be-cleaned/ListIcons.tsx
+++ b/apps/studio/components/to-be-cleaned/ListIcons.tsx
@@ -15,7 +15,7 @@ export const vercelIcon = (
 )
 
 export const databaseIcon = (
-  <div className="flex items-center justify-center rounded bg-green-500 p-1 [[data-theme*=dark]_&]:text-typography-body-dark ">
+  <div className="flex items-center justify-center rounded bg-green-500 p-1 dark:text-typography-body-dark ">
     {/* <SVG
       src={'/icons/feather/database.svg'}
       style={{ width: `12px`, height: `12px`, strokeWidth: '2px' }}

--- a/apps/studio/components/to-be-cleaned/Storage/StorageExplorer/FileExplorerColumn.tsx
+++ b/apps/studio/components/to-be-cleaned/Storage/StorageExplorer/FileExplorerColumn.tsx
@@ -164,7 +164,7 @@ const FileExplorerColumn = ({
       {/* Checkbox selection for select all */}
       {view === STORAGE_VIEWS.COLUMNS && (
         <div
-          className={`sticky top-0 z-10 mb-0 flex items-center bg-table-header-light px-2.5 [[data-theme*=dark]_&]:bg-table-header-dark ${
+          className={`sticky top-0 z-10 mb-0 flex items-center bg-table-header-light px-2.5 dark:bg-table-header-dark ${
             haveSelectedItems ? 'h-10 py-3 opacity-100' : 'h-0 py-0 opacity-0'
           } transition-all duration-200`}
           onClick={(event) => event.stopPropagation()}
@@ -273,7 +273,7 @@ const FileExplorerColumn = ({
         <div
           className="
           sticky bottom-0
-          z-10 flex min-w-min items-center bg-panel-footer-light px-2.5 py-2 [[data-theme*=dark]_&]:bg-panel-footer-dark
+          z-10 flex min-w-min items-center bg-panel-footer-light px-2.5 py-2 dark:bg-panel-footer-dark
         "
         >
           <p className="text-sm">

--- a/apps/studio/components/to-be-cleaned/Storage/StorageExplorer/FileExplorerHeaderSelection.tsx
+++ b/apps/studio/components/to-be-cleaned/Storage/StorageExplorer/FileExplorerHeaderSelection.tsx
@@ -13,7 +13,7 @@ const FileExplorerHeaderSelection = () => {
   } = storageExplorerStore
 
   return (
-    <div className="z-10 flex h-[40px] items-center rounded-t-md bg-brand-400 px-2 py-1 shadow [[data-theme*=dark]_&]:bg-brand-600">
+    <div className="z-10 flex h-[40px] items-center rounded-t-md bg-brand-400 px-2 py-1 shadow dark:bg-brand-600">
       <Button
         icon={<IconX size={16} strokeWidth={2} />}
         type="text"

--- a/apps/studio/components/to-be-cleaned/Storage/StorageExplorer/FileExplorerRow.tsx
+++ b/apps/studio/components/to-be-cleaned/Storage/StorageExplorer/FileExplorerRow.tsx
@@ -320,7 +320,7 @@ const FileExplorerRow = ({
       <div
         className={[
           'storage-row group flex h-full items-center px-2.5',
-          'hover:bg-panel-footer-light [[data-theme*=dark]_&]:hover:bg-panel-footer-dark',
+          'hover:bg-panel-footer-light dark:hover:bg-panel-footer-dark',
           `${isOpened ? 'bg-surface-200' : ''}`,
           `${isPreviewed ? 'bg-green-500 hover:bg-green-500' : ''}`,
           `${item.status !== STORAGE_ROW_STATUS.LOADING ? 'cursor-pointer' : ''}`,

--- a/apps/studio/components/to-be-cleaned/Storage/StoragePolicies/StoragePoliciesBucketRow.js
+++ b/apps/studio/components/to-be-cleaned/Storage/StoragePolicies/StoragePoliciesBucketRow.js
@@ -105,7 +105,7 @@ const StoragePoliciesBucketRow = ({
           <p className="text-sm text-foreground-lighter">No policies created yet</p>
         </div>
       ) : (
-        <div className="grid grid-cols-1 divide-y [[data-theme*=dark]_&]:divide-dark">
+        <div className="grid grid-cols-1 divide-y dark:divide-dark">
           {policies.map((policy) => (
             <PolicyRow
               key={policy.name}

--- a/apps/studio/components/ui/MultiSelect/Badges.tsx
+++ b/apps/studio/components/ui/MultiSelect/Badges.tsx
@@ -3,7 +3,7 @@ import { IconX } from 'ui'
 export const BadgeDisabled = ({ name }: { name: string }) => (
   <div
     className={[
-      'text-typography-body-light [[data-theme*=dark]_&]:text-typography-body-dark',
+      'text-typography-body-light dark:text-typography-body-dark',
       'flex cursor-not-allowed items-center space-x-2 rounded bg-gray-600',
       'py-0.5 px-2 text-sm',
     ].join(' ')}
@@ -21,7 +21,7 @@ export const BadgeSelected = ({
 }) => (
   <div
     className={[
-      'text-typography-body-light [[data-theme*=dark]_&]:text-typography-body-dark',
+      'text-typography-body-light dark:text-typography-body-dark',
       'flex items-center space-x-2 rounded bg-surface-300',
       'py-0.5 px-2 text-sm',
     ].join(' ')}

--- a/apps/studio/components/ui/MultiSelect/index.tsx
+++ b/apps/studio/components/ui/MultiSelect/index.tsx
@@ -209,14 +209,10 @@ export default function MultiSelect({
                       key={`multiselect-option-${option.id}`}
                       onClick={() => handleChange(option)}
                       className={[
-                        'text-typography-body-light [[data-theme*=dark]_&]:text-typography-body-dark',
+                        'text-typography-body-light dark:text-typography-body-dark',
                         'group flex cursor-pointer items-center justify-between transition',
                         'space-x-1 rounded bg-transparent p-2 px-4 text-sm hover:bg-overlay-hover',
-                        `${
-                          active
-                            ? ' [[data-theme*=dark]_&]:bg-green-600 [[data-theme*=dark]_&]:bg-opacity-25'
-                            : ''
-                        }`,
+                        `${active ? ' dark:bg-green-600 dark:bg-opacity-25' : ''}`,
                       ].join(' ')}
                     >
                       <div className="flex items-center space-x-2">

--- a/apps/studio/components/ui/ProjectSettings/DisplayApiSettings.tsx
+++ b/apps/studio/components/ui/ProjectSettings/DisplayApiSettings.tsx
@@ -77,7 +77,7 @@ const DisplayApiSettings = () => {
             key={x.api_key}
             className={
               i >= 1 &&
-              'border-t border-panel-border-interior-light [[data-theme*=dark]_&]:border-panel-border-interior-dark'
+              'border-t border-panel-border-interior-light dark:border-panel-border-interior-dark'
             }
           >
             <Input

--- a/apps/studio/components/ui/ProjectSettings/DisplayConfigSettings.tsx
+++ b/apps/studio/components/ui/ProjectSettings/DisplayConfigSettings.tsx
@@ -67,7 +67,7 @@ const DisplayConfigSettings = () => {
               layout="horizontal"
             />
           </Panel.Content>
-          <Panel.Content className="border-t border-panel-border-interior-light [[data-theme*=dark]_&]:border-panel-border-interior-dark">
+          <Panel.Content className="border-t border-panel-border-interior-light dark:border-panel-border-interior-dark">
             <Input
               label="JWT Secret"
               readOnly

--- a/apps/studio/pages/new/[slug].tsx
+++ b/apps/studio/pages/new/[slug].tsx
@@ -261,7 +261,7 @@ const Wizard: NextPageWithLayout = () => {
           </p>
         </Panel.Content>
         {projectCreationDisabled ? (
-          <Panel.Content className="pb-8 border-t border-panel-border-interior-light [[data-theme*=dark]_&]:border-panel-border-interior-dark">
+          <Panel.Content className="pb-8 border-t border-panel-border-interior-light dark:border-panel-border-interior-dark">
             <DisabledWarningDueToIncident title="Project creation is currently disabled" />
           </Panel.Content>
         ) : (
@@ -269,7 +269,7 @@ const Wizard: NextPageWithLayout = () => {
             <Panel.Content
               className={[
                 'space-y-4 border-t border-b',
-                'border-panel-border-interior-light [[data-theme*=dark]_&]:border-panel-border-interior-dark',
+                'border-panel-border-interior-light dark:border-panel-border-interior-dark',
               ].join(' ')}
             >
               {(organizations?.length ?? 0) > 0 && (
@@ -300,7 +300,7 @@ const Wizard: NextPageWithLayout = () => {
                 <Panel.Content
                   className={[
                     'border-b',
-                    'border-panel-border-interior-light [[data-theme*=dark]_&]:border-panel-border-interior-dark',
+                    'border-panel-border-interior-light dark:border-panel-border-interior-dark',
                   ].join(' ')}
                 >
                   <Input
@@ -319,7 +319,7 @@ const Wizard: NextPageWithLayout = () => {
                   <Panel.Content
                     className={[
                       'border-b',
-                      'border-panel-border-interior-light [[data-theme*=dark]_&]:border-panel-border-interior-dark',
+                      'border-panel-border-interior-light dark:border-panel-border-interior-dark',
                     ].join(' ')}
                   >
                     <Input
@@ -346,7 +346,7 @@ const Wizard: NextPageWithLayout = () => {
                   <Panel.Content
                     className={[
                       'border-b',
-                      'border-panel-border-interior-light [[data-theme*=dark]_&]:border-panel-border-interior-dark',
+                      'border-panel-border-interior-light dark:border-panel-border-interior-dark',
                     ].join(' ')}
                   >
                     <Listbox
@@ -370,7 +370,7 @@ const Wizard: NextPageWithLayout = () => {
                   </Panel.Content>
                 )}
 
-                <Panel.Content className="border-b border-panel-border-interior-light [[data-theme*=dark]_&]:border-panel-border-interior-dark">
+                <Panel.Content className="border-b border-panel-border-interior-light dark:border-panel-border-interior-dark">
                   <Input
                     id="password"
                     copy={dbPass.length > 0}
@@ -392,7 +392,7 @@ const Wizard: NextPageWithLayout = () => {
                   />
                 </Panel.Content>
 
-                <Panel.Content className="border-b border-panel-border-interior-light [[data-theme*=dark]_&]:border-panel-border-interior-dark">
+                <Panel.Content className="border-b border-panel-border-interior-light dark:border-panel-border-interior-dark">
                   <Listbox
                     layout="horizontal"
                     label="Region"

--- a/apps/studio/pages/vercel/integrate.tsx
+++ b/apps/studio/pages/vercel/integrate.tsx
@@ -277,7 +277,7 @@ const IntegrationProject = observer(() => {
       </div>
       <div
         className="w-full rounded-sm border border-strong
-      bg-panel-header-light [[data-theme*=dark]_&]:bg-panel-header-dark"
+      bg-panel-header-light dark:bg-panel-header-dark"
       >
         <div className="flex items-center justify-between p-6">
           <h4 className="my-auto mr-8 text-lg capitalize">{name}</h4>

--- a/apps/studio/styles/grid.scss
+++ b/apps/studio/styles/grid.scss
@@ -85,7 +85,7 @@
 }
 
 .rdg-header-row .rdg-cell p {
-  @apply text-typography-body-light [[data-theme*=dark]_&]:text-typography-body-dark;
+  @apply text-typography-body-light dark:text-typography-body-dark;
 }
 .rdg-header-row .rdg-cell .react-contextmenu-wrapper {
   @apply flex h-full items-center px-2 transition duration-100 ease-in-out;
@@ -114,8 +114,8 @@
 */
 
 .rdg-row {
-  @apply bg-table-body-light [[data-theme*=dark]_&]:bg-table-body-dark transition-colors;
-  @apply hover:bg-table-header-light [[data-theme*=dark]_&]:hover:bg-table-header-dark;
+  @apply bg-table-body-light dark:bg-table-body-dark transition-colors;
+  @apply hover:bg-table-header-light dark:hover:bg-table-header-dark;
 }
 
 /* edit button */

--- a/apps/studio/styles/ui.scss
+++ b/apps/studio/styles/ui.scss
@@ -359,7 +359,7 @@
 
 .radix-tooltip-arrow {
   polygon {
-    @apply fill-background-alternative [[data-theme*=dark]_&]:fill-background-alternative;
+    @apply fill-background-alternative dark:fill-background-alternative;
     // fill: #eeeeee;
   }
 }

--- a/apps/www/pages/_app.tsx
+++ b/apps/www/pages/_app.tsx
@@ -94,7 +94,6 @@ export default function App({ Component, pageProps }: AppProps) {
       <SessionContextProvider supabaseClient={supabase}>
         <AuthProvider>
           <ThemeProvider
-            // attribute="class"
             themes={themes.map((theme) => theme.value)}
             defaultTheme="system"
             enableSystem

--- a/apps/www/pages/customers/[slug].tsx
+++ b/apps/www/pages/customers/[slug].tsx
@@ -149,9 +149,9 @@ function CaseStudyPage(props: any) {
                                 object-contain
                                 m-0
 
-                                [[data-theme*=dark]_&]:brightness-200
-                                [[data-theme*=dark]_&]:contrast-0
-                                [[data-theme*=dark]_&]:filter
+                                dark:brightness-200
+                                dark:contrast-0
+                                dark:filter
                               "
                           />
                         </div>

--- a/apps/www/pages/partners/index.tsx
+++ b/apps/www/pages/partners/index.tsx
@@ -185,7 +185,7 @@ const Partners = () => {
                   className="group flex flex-col items-center text-center gap-4 px-8 py-6"
                   key={i}
                 >
-                  <div className="bg-brand-300 [[data-theme*=dark]_&]:bg-brand-500 text-brand-1200 group-hover:text-brand-800 [[data-theme*=dark]_&]:group-hover:text-brand-1000 flex h-12 w-12 items-center justify-center rounded-md border border-brand transition-all group-hover:scale-105">
+                  <div className="bg-brand-300 dark:bg-brand-500 text-brand-1200 group-hover:text-brand-800 dark:group-hover:text-brand-1000 flex h-12 w-12 items-center justify-center rounded-md border border-brand transition-all group-hover:scale-105">
                     {item.icon ? item.icon : <IconCode strokeWidth={2} />}
                   </div>
 

--- a/packages/config/tailwind.config.js
+++ b/packages/config/tailwind.config.js
@@ -87,7 +87,7 @@ function kebabToNested(obj) {
  */
 const uiConfig = ui({
   mode: 'JIT',
-  darkMode: ['class', '[data-mode*="dark"]'],
+  darkMode: ['class', '[data-theme*="dark"]'],
   theme: {
     /**
      * Spread all theme colors and custom generated colors into theme

--- a/packages/ui/src/components/Breadcrumb/Breadcrumb.module.css
+++ b/packages/ui/src/components/Breadcrumb/Breadcrumb.module.css
@@ -10,17 +10,17 @@
 .sbui-breadcrumb--item {
   @apply text-gray-500 hover:text-gray-600;
   @apply cursor-pointer;
-  @apply [[data-theme*=dark]_&]:text-dark-200 [[data-theme*=dark]_&]:hover:text-brand-400;
+  @apply dark:text-dark-200 dark:hover:text-brand-400;
 }
 
 .sbui-breadcrumb--item__active {
-  @apply text-brand-400 [[data-theme*=dark]_&]:text-brand-400;
+  @apply text-brand-400 dark:text-brand-400;
 }
 
 .sbui-breadcrumb--separator {
   @apply mx-2;
   @apply text-gray-500 hover:text-gray-600;
-  @apply [[data-theme*=dark]_&]:text-dark-200 [[data-theme*=dark]_&]:hover:text-white;
+  @apply dark:text-dark-200 dark:hover:text-white;
 }
 
 .sbui-breadcrumb--separator-small {

--- a/packages/ui/src/components/Card/Card.module.css
+++ b/packages/ui/src/components/Card/Card.module.css
@@ -1,5 +1,5 @@
 .sbui-card {
-  @apply flex flex-col bg-white [[data-theme*=dark]_&]:bg-dark-700 rounded-md shadow-lg overflow-hidden relative;
+  @apply flex flex-col bg-white dark:bg-dark-700 rounded-md shadow-lg overflow-hidden relative;
 
   border: 1px solid #e0e0e0;
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

- `dark:` tailwind css selector working again
- swap all `[[data-theme*=dark]_&]:` with `dark:`

