### PR TITLE
Fix code text color

### DIFF
--- a/apps/docs/styles/prism-okaidia.scss
+++ b/apps/docs/styles/prism-okaidia.scss
@@ -6,7 +6,7 @@
 
 code[class*='language-'],
 pre[class*='language-'] {
-  color: #555;
+  @apply text-foreground;
   text-shadow: 0 1px rgba(0, 0, 0, 0.3);
   font-family: Consolas, Monaco, 'Andale Mono', monospace;
   direction: ltr;
@@ -24,10 +24,6 @@ pre[class*='language-'] {
   -moz-hyphens: none;
   -ms-hyphens: none;
   hyphens: none;
-
-  .dark & {
-    color: #f8f8f2;
-  }
 }
 
 /* Code blocks */

--- a/apps/www/pages/_app.tsx
+++ b/apps/www/pages/_app.tsx
@@ -94,7 +94,6 @@ export default function App({ Component, pageProps }: AppProps) {
       <SessionContextProvider supabaseClient={supabase}>
         <AuthProvider>
           <ThemeProvider
-            // attribute="class"
             themes={themes.map((theme) => theme.value)}
             defaultTheme="system"
             enableSystem

--- a/packages/config/tailwind.config.js
+++ b/packages/config/tailwind.config.js
@@ -87,7 +87,7 @@ function kebabToNested(obj) {
  */
 const uiConfig = ui({
   mode: 'JIT',
-  darkMode: ['class', '[data-mode*="dark"]'],
+  darkMode: ['class', '[data-theme*="dark"]'],
   theme: {
     /**
      * Spread all theme colors and custom generated colors into theme


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix code text color in dark mode.

## What is the current behavior?

Current: https://supabase.com/docs/reference/javascript/lte

<img width="694" alt="Screenshot 2023-11-17 at 14 49 39" src="https://github.com/supabase/supabase/assets/25671831/544d6c44-1ab4-4c1c-b865-98d99fab6a4a">

## What is the new behavior?

Fixed: https://docs-git-fix-code-text-color-supabase.vercel.app/docs/reference/javascript/lte

<img width="700" alt="Screenshot 2023-11-17 at 14 49 34" src="https://github.com/supabase/supabase/assets/25671831/a936bb10-7160-40a9-acd7-41de46de1bb0">

