### PR TITLE
chore: remove entrypoint logflare

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -323,7 +323,6 @@ services:
       LOGFLARE_API_KEY: ${LOGFLARE_API_KEY}
       LOGFLARE_SINGLE_TENANT: true
       LOGFLARE_SUPABASE_MODE: true
-      LOGFLARE_MIN_CLUSTER_SIZE: 1
 
       # Comment variables to use Big Query backend for analytics
       POSTGRES_BACKEND_URL: postgresql://supabase_admin:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -336,12 +336,6 @@ services:
       # GOOGLE_PROJECT_NUMBER: ${GOOGLE_PROJECT_NUMBER}
     ports:
       - 4000:4000
-    entrypoint: |
-                  sh -c `cat <<'EOF' > run.sh && sh run.sh
-                  ./logflare eval Logflare.Release.migrate
-                  ./logflare start --sname logflare
-                  EOF
-                  `
 
   # Comment out everything below this point if you are using an external Postgres database
   db:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -324,7 +324,6 @@ services:
       LOGFLARE_SINGLE_TENANT: true
       LOGFLARE_SUPABASE_MODE: true
       LOGFLARE_MIN_CLUSTER_SIZE: 1
-      RELEASE_COOKIE: cookie
 
       # Comment variables to use Big Query backend for analytics
       POSTGRES_BACKEND_URL: postgresql://supabase_admin:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}


### PR DESCRIPTION
This PR removes unnecessary configs for the logflare docker compose service.

min cluster size defaults to 1.
release cookie is unnecessary as it is only needed for clustering.
Entrypoint is unnecessary as run.sh script will be run on container start and will already perform the migrations.