### PR TITLE
Move setProject out of withAuth so self-hosted still gets project ref

### DIFF
--- a/apps/studio/hooks/misc/useStore.tsx
+++ b/apps/studio/hooks/misc/useStore.tsx
@@ -4,6 +4,7 @@ import toast from 'react-hot-toast'
 
 import SparkBar from 'components/ui/SparkBar'
 import { IRootStore } from 'stores'
+import { useSelectedProject } from './useSelectedProject'
 
 const StoreContext = createContext<IRootStore>(undefined!)
 
@@ -21,6 +22,14 @@ interface StoreProvider {
 }
 export const StoreProvider = ({ children, rootStore }: PropsWithChildren<StoreProvider>) => {
   const { ui } = rootStore
+
+  const selectedProject = useSelectedProject()
+    useEffect(() => {
+      if (selectedProject) {
+        console.log({selectedProject})
+        rootStore.setProject(selectedProject)
+      }
+    }, [selectedProject])
 
   useEffect(() => {
     autorun(() => {

--- a/apps/studio/hooks/misc/withAuth.tsx
+++ b/apps/studio/hooks/misc/withAuth.tsx
@@ -74,12 +74,7 @@ export function withAuth<T>(
       }
     }, [session, isLoading, router, aalData, isFinishedLoading, isLoggedIn])
 
-    const selectedProject = useSelectedProject()
-    useEffect(() => {
-      if (selectedProject) {
-        rootStore.setProject(selectedProject)
-      }
-    }, [selectedProject])
+
 
     const InnerComponent = WrappedComponent as any
 


### PR DESCRIPTION
Project ref was set via `setProject` in `withStore`

Since self-hosted setup doesn't use withAuth, this was no longer getting set. 
Not having a project ref ("default") causes lots of issues — creating a table, viewing logs, etc.

This PR moves that `setProject` call to the rootStore — **this is likely not the best place**. But is a temp work around if you're blocked. 

— 

props K-dog for the help. 