### PR TITLE
fix: Bump up Realtime to 2.25.35

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -156,7 +156,7 @@ services:
   realtime:
     # This container name looks inconsistent but is correct because realtime constructs tenant id by parsing the subdomain
     container_name: realtime-dev.supabase-realtime
-    image: supabase/realtime:v2.25.27
+    image: supabase/realtime:v2.25.35
     depends_on:
       db:
         # Disable this if you are using an external Postgres database


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump up Realtime to 2.25.35

Fixes seeding issues:
https://github.com/supabase/realtime/pull/742
https://github.com/supabase/realtime/pull/739
https://github.com/supabase/realtime/pull/736