### PR TITLE
Move setProject out of withAuth so self-hosted still gets project ref #19046

### DIFF
--- a/apps/studio/hooks/misc/useStore.tsx
+++ b/apps/studio/hooks/misc/useStore.tsx
@@ -26,7 +26,6 @@ export const StoreProvider = ({ children, rootStore }: PropsWithChildren<StorePr
   const selectedProject = useSelectedProject()
   useEffect(() => {
     if (selectedProject) {
-      console.log({ selectedProject })
       rootStore.setProject(selectedProject)
     }
   }, [selectedProject])

--- a/apps/studio/hooks/misc/useStore.tsx
+++ b/apps/studio/hooks/misc/useStore.tsx
@@ -4,6 +4,7 @@ import toast from 'react-hot-toast'
 
 import SparkBar from 'components/ui/SparkBar'
 import { IRootStore } from 'stores'
+import { useSelectedProject } from './useSelectedProject'
 
 const StoreContext = createContext<IRootStore>(undefined!)
 
@@ -21,6 +22,14 @@ interface StoreProvider {
 }
 export const StoreProvider = ({ children, rootStore }: PropsWithChildren<StoreProvider>) => {
   const { ui } = rootStore
+
+  const selectedProject = useSelectedProject()
+  useEffect(() => {
+    if (selectedProject) {
+      console.log({ selectedProject })
+      rootStore.setProject(selectedProject)
+    }
+  }, [selectedProject])
 
   useEffect(() => {
     autorun(() => {

--- a/apps/studio/hooks/misc/withAuth.tsx
+++ b/apps/studio/hooks/misc/withAuth.tsx
@@ -3,7 +3,7 @@ import { ComponentType, useEffect } from 'react'
 
 import { usePermissionsQuery } from 'data/permissions/permissions-query'
 import { useAuthenticatorAssuranceLevelQuery } from 'data/profile/mfa-authenticator-assurance-level-query'
-import { useSelectedProject, useStore } from 'hooks'
+import { useStore } from 'hooks'
 import { useAuth } from 'lib/auth'
 import { IS_PLATFORM } from 'lib/constants'
 import { NextPageWithLayout, isNextPageWithLayout } from 'types'
@@ -73,13 +73,6 @@ export function withAuth<T>(
         router.push(`/sign-in?${searchParams.toString()}`)
       }
     }, [session, isLoading, router, aalData, isFinishedLoading, isLoggedIn])
-
-    const selectedProject = useSelectedProject()
-    useEffect(() => {
-      if (selectedProject) {
-        rootStore.setProject(selectedProject)
-      }
-    }, [selectedProject])
 
     const InnerComponent = WrappedComponent as any
 


### PR DESCRIPTION
Project ref was set via `setProject` in `withStore`

Since self-hosted setup doesn't use withAuth, this was no longer getting set. 
Not having a project ref ("default") causes lots of issues — creating a table, viewing logs, etc.

This PR moves that `setProject` call to the rootStore — **this is likely not the best place**. But is a temp work around if you're blocked. 

— 

props K-dog for the help. 