### PR TITLE
fix: add reference docs back to search index

### DIFF
--- a/.github/workflows/search.yml
+++ b/.github/workflows/search.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           sparse-checkout: |
             apps/docs
+            spec
             supabase
 
       - name: Setup node


### PR DESCRIPTION
## What kind of change does this PR introduce?

**Bug fix**

Reference docs weren't being indexed properly because the specs weren't getting checked out at build time.

## What is the current behavior?

Example error:

```
Page '/reference/api' or one/multiple of its page sections failed to store properly. Page has been marked with null checksum to indicate that it needs to be re-generated.
[Error: ENOENT: no such file or directory, open '../../spec/transforms/api_v0_openapi_deparsed.json'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: '../../spec/transforms/api_v0_openapi_deparsed.json'
}
```