### PR TITLE
Fix mime type wildcard hint for storage bucket

### DIFF
--- a/apps/studio/components/interfaces/Storage/CreateBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/CreateBucketModal.tsx
@@ -233,7 +233,7 @@ const CreateBucketModal = ({ visible, onClose }: CreateBucketModalProps) => {
                       name="allowed_mime_types"
                       layout="vertical"
                       label="Allowed MIME types"
-                      placeholder="e.g image/jpeg, image/png, audio/mpeg, video/mp4, etc"
+                      placeholder="e.g image/jpeg, image/png, image/*, audio/mpeg, video/mp4, vedio/* etc"
                       descriptionText="Comma separated values"
                     />
                   </div>

--- a/apps/studio/components/interfaces/Storage/EditBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/EditBucketModal.tsx
@@ -238,7 +238,7 @@ const EditBucketModal = ({ visible, bucket, onClose }: EditBucketModalProps) => 
                       name="allowed_mime_types"
                       layout="vertical"
                       label="Allowed MIME types"
-                      placeholder="e.g image/jpeg, image/png, audio/mpeg, video/mp4, etc"
+                      placeholder="e.g image/jpeg, image/png, image/*, audio/mpeg, video/mp4, vedio/* etc"
                       labelOptional="Comma separated values"
                       descriptionText="Leave the field blank to allow any MIME type to be uploaded"
                     />


### PR DESCRIPTION
## What kind of change does this PR introduce?
it resolve the #19057 issue 

Bug fix, feature, docs update, ...
updated the placeholder for the input file type

## What is the current behavior?
it doesn't show the  all file type that can be used 
Please link any relevant issues here.
#19057 
## What is the new behavior?
Now its show all the type of file that are allowed 
Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
