### PR TITLE
Update access-control.mdx to fix missing () and cast to text

### DIFF
--- a/apps/docs/pages/guides/storage/security/access-control.mdx
+++ b/apps/docs/pages/guides/storage/security/access-control.mdx
@@ -59,7 +59,7 @@ for insert
 to authenticated
 with check (
   bucket_id = 'my_bucket_id' and
-  storage.foldername(name)[1] = 'private'
+  (storage.foldername(name))[1] = 'private'
 );
 ```
 
@@ -72,7 +72,7 @@ for insert
 to authenticated
 with check (
   bucket_id = 'my_bucket_id' and
-  storage.foldername(name)[1] = auth.uid()
+  (storage.foldername(name))[1] = auth.uid()::text
 );
 ```
 


### PR DESCRIPTION
Using storage.foldername(name)[1] requires this format: (storage.foldername(name))[1]

Also comparing the result to auth.uid() requires a cast.  I showed using auth.uid()::text as the example.

## What kind of change does this PR introduce?

docs update, ...

## What is the current behavior?

See above

## What is the new behavior?

See above

## Additional context

Add any other context or screenshots.
