### PR TITLE
chore: add default project for local development

### DIFF
--- a/apps/studio/pages/_app.tsx
+++ b/apps/studio/pages/_app.tsx
@@ -55,7 +55,7 @@ import { ProfileProvider } from 'lib/profile'
 import { useAppStateSnapshot } from 'state/app-state'
 import { RootStore } from 'stores'
 import HCaptchaLoadedStore from 'stores/hcaptcha-loaded-store'
-import { AppPropsWithLayout } from 'types'
+import { AppPropsWithLayout, Project } from 'types'
 
 dayjs.extend(customParseFormat)
 dayjs.extend(utc)
@@ -92,9 +92,9 @@ function CustomApp({ Component, pageProps }: AppPropsWithLayout) {
   const [supabase] = useState(() =>
     IS_PLATFORM
       ? createClient(
-          process.env.NEXT_PUBLIC_SUPABASE_URL as string,
-          process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string
-        )
+        process.env.NEXT_PUBLIC_SUPABASE_URL as string,
+        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string
+      )
       : undefined
   )
 
@@ -141,6 +141,12 @@ function CustomApp({ Component, pageProps }: AppPropsWithLayout) {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
+
+  useEffect(() => {
+    if (!IS_PLATFORM) {
+      rootStore.setProject({ ref: 'default' } as Project)
+    }
+  }, [rootStore])
 
   useThemeSandbox()
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixed issue cannot go to API docs.

## What is the current behavior?

On latest version, when we go to `http://localhost:8082/project/default/api`, we will got stuck add loading page.

<img width="1064" alt="image" src="https://github.com/supabase/supabase/assets/21276822/4b7ea93c-7c52-4c44-8707-2c982c81f506">

When we check the console, it got stuck at getting `openApi` data and `ui.selectedProjectRef` didn't change.

## What is the new behavior?

We have added a default value for local development using `ref=default`. Now, we can access the API documentation page.

<img width="1111" alt="image" src="https://github.com/supabase/supabase/assets/21276822/530c4ec9-56fb-4d89-9ba5-5439c8d5fad0">


## Additional context

Is there a better place to update the default value for local development?
