### PR TITLE
fix: api docs crashed when navigation from graphiql

### DIFF
--- a/apps/studio/components/interfaces/Docs/ResourceContent.tsx
+++ b/apps/studio/components/interfaces/Docs/ResourceContent.tsx
@@ -20,6 +20,8 @@ const ResourceContent = ({
 }: any) => {
   const { ref } = useParams()
   const { data: customDomainData } = useCustomDomainsQuery({ projectRef: ref })
+  const { realtimeAll: realtimeEnabled } = useIsFeatureEnabled(['realtime:all'])
+
   const endpoint =
     customDomainData?.customDomain?.status === 'active'
       ? `https://${customDomainData.customDomain.hostname}`
@@ -38,8 +40,6 @@ const ResourceContent = ({
     id,
     required: resourceDefinition?.required?.includes(id),
   }))
-
-  const { realtimeAll: realtimeEnabled } = useIsFeatureEnabled(['realtime:all'])
 
   return (
     <>

--- a/apps/studio/components/interfaces/Docs/ResourceContent.tsx
+++ b/apps/studio/components/interfaces/Docs/ResourceContent.tsx
@@ -25,6 +25,8 @@ const ResourceContent = ({
       ? `https://${customDomainData.customDomain.hostname}`
       : autoApiService.endpoint
 
+  if (!paths || !definitions) return null
+
   const keyToShow = !!showApiKey ? showApiKey : 'SUPABASE_KEY'
   const resourcePaths = paths[`/${resourceId}`]
   const resourceDefinition = definitions[resourceId]
@@ -38,8 +40,6 @@ const ResourceContent = ({
   }))
 
   const { realtimeAll: realtimeEnabled } = useIsFeatureEnabled(['realtime:all'])
-
-  if (!paths || !definitions) return null
 
   return (
     <>


### PR DESCRIPTION
## What kind of change does this PR introduce?

API docs crashed when navigation from graphiql

## What is the current behavior?

https://github.com/supabase/supabase/issues/18970

## What is the new behavior?

We can access api docs when naviation grom graphiql without error.

## Additional context

Add any other context or screenshots.
