### PR TITLE
fix storage api links

### DIFF
--- a/apps/docs/docs/ref/self-hosting-storage/introduction.mdx
+++ b/apps/docs/docs/ref/self-hosting-storage/introduction.mdx
@@ -35,7 +35,7 @@ hideTitle: true
     - [Source code](https://github.com/supabase/storage-api)
     - [Known bugs and issues](https://github.com/supabase/storage-js/issues)
     - [Storage guides](/docs/guides/storage)
-    - [OpenAPI docs](https://supabase.github.io/storage-api/)
+    - [OpenAPI docs](https://supabase.github.io/storage/)
     - [Why we built a new object storage service](https://supabase.com/blog/supabase-storage)
 
   </RefSubLayout.Examples>

--- a/apps/docs/pages/guides/storage.mdx
+++ b/apps/docs/pages/guides/storage.mdx
@@ -62,7 +62,7 @@ export const integrations = [
   {
     name: 'OpenAPI Spec',
     description: 'See the Swagger Documentation for Supabase Storage.',
-    href: 'https://supabase.github.io/storage-api/',
+    href: 'https://supabase.github.io/storage/',
   },
 ]
 

--- a/apps/www/_blog/2021-05-03-supabase-beta-april-2021.mdx
+++ b/apps/www/_blog/2021-05-03-supabase-beta-april-2021.mdx
@@ -75,7 +75,7 @@ With the help of the community, we [started internationalizing](https://github.c
 
 ## OpenAPI spec for Storage
 
-We released [Storage Api docs](https://supabase.github.io/storage-api) built using OpenAPI (swagger).
+We released [Storage Api docs](https://supabase.github.io/storage) built using OpenAPI (swagger).
 
 ![Storage API documentation](/images/blog/april-2021/storage-openapi.png)
 

--- a/apps/www/_blog/2021-07-27-storage-beta.mdx
+++ b/apps/www/_blog/2021-07-27-storage-beta.mdx
@@ -131,7 +131,7 @@ Supabase Storage now supports `upsert`. Shoutout to [@ankitjena](https://github.
 
 ![Storage now supports upserts](/images/blog/2021-june/supabase-storage-upsert.png)
 
-We also have automated API docs generated [here](https://supabase.github.io/storage-api/#/) if you want to use the Storage API directly.
+We also have automated API docs generated [here](https://supabase.github.io/storage/#/) if you want to use the Storage API directly.
 
 ### Storage in the wild
 

--- a/spec/Makefile
+++ b/spec/Makefile
@@ -32,7 +32,7 @@ download.api.v1:
 # 	curl -sS https://supabase.github.io/gotrue/swagger.json > $(REPO_DIR)/auth_v1_openapi.json
 
 download.storage.v1:
-	curl -sS https://supabase.github.io/storage-api/api.json > $(REPO_DIR)/storage_v0_openapi.json
+	curl -sS https://supabase.github.io/storage/api.json > $(REPO_DIR)/storage_v0_openapi.json
 
 # No longer updated
 # download.tsdoc.v1:


### PR DESCRIPTION
the storage github repo was renamed from storage-api to storage recently which broke the github pages link