### PR TITLE
fix: freeze column on a table causes it to crash

### DIFF
--- a/apps/studio/components/grid/components/grid/ColumnHeader.tsx
+++ b/apps/studio/components/grid/components/grid/ColumnHeader.tsx
@@ -8,6 +8,7 @@ import { IconArrowRight, IconKey, IconLink, IconLock } from 'ui'
 import { useDispatch, useTrackedState } from '../../store'
 import { ColumnHeaderProps, ColumnType, DragItem, GridForeignKey } from '../../types'
 import { ColumnMenu } from '../menu'
+import { useEffect } from 'react'
 
 export function ColumnHeader<R>({
   column,
@@ -26,12 +27,14 @@ export function ColumnHeader<R>({
   const hoverValue = column.name as string
 
   // keep state.gridColumns' order in sync with data grid component
-  if (state.gridColumns[columnIdx].key != columnKey) {
-    dispatch({
-      type: 'UPDATE_COLUMN_IDX',
-      payload: { columnKey, columnIdx },
-    })
-  }
+  useEffect(() => {
+    if (state.gridColumns[columnIdx].key != columnKey) {
+      dispatch({
+        type: 'UPDATE_COLUMN_IDX',
+        payload: { columnKey, columnIdx },
+      })
+    }
+  }, [columnKey, columnIdx, state.gridColumns])
 
   const [{ isDragging }, drag] = useDrag({
     type: 'column-header',


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixing the issue where freezing a column in a table causes it to crash: 

fixes https://github.com/supabase/supabase/issues/18962

## What is the current behavior?

When you freeze column in a table, it cause rerender many time, so it make page crash with this error:
```
Maximum update depth exceeded. This can happen when a component calls setState inside useEffect
```

## What is the new behavior?

Use effect to void render many time.

## Additional context

Add any other context or screenshots.
