### PR TITLE
Update creating-a-client.mdx because of redundancy / confusion

### DIFF
--- a/apps/docs/pages/guides/auth/server-side/creating-a-client.mdx
+++ b/apps/docs/pages/guides/auth/server-side/creating-a-client.mdx
@@ -195,11 +195,6 @@ export async function middleware(request: NextRequest) {
               headers: request.headers,
             },
           })
-          response.cookies.set({
-            name,
-            value,
-            ...options,
-          })
         },
         remove(name: string, options: CookieOptions) {
           request.cookies.set({
@@ -211,11 +206,6 @@ export async function middleware(request: NextRequest) {
             request: {
               headers: request.headers,
             },
-          })
-          response.cookies.set({
-            name,
-            value: '',
-            ...options,
           })
         },
       },


### PR DESCRIPTION
As to my research the header passing is already containing the changed cookie (as cookies are part of the header) so the second setting of the cookie becomes unnecessary.
