### PR TITLE
docs: update vector sorting to ensure index gets used

### DIFF
--- a/apps/docs/pages/guides/ai/vector-columns.mdx
+++ b/apps/docs/pages/guides/ai/vector-columns.mdx
@@ -132,7 +132,7 @@ as $$
     1 - (documents.embedding <=> query_embedding) as similarity
   from documents
   where 1 - (documents.embedding <=> query_embedding) > match_threshold
-  order by similarity desc
+  order by (documents.embedding <=> query_embedding) asc
   limit match_count;
 $$;
 ```
@@ -140,6 +140,8 @@ $$;
 This function takes a `query_embedding` argument and compares it to all other embeddings in the `documents` table. Each comparison returns a similarity score. If the similarity is greater than the `match_threshold` argument, it is returned. The number of rows returned is limited by the `match_count` argument.
 
 Feel free to modify this method to fit the needs of your application. The `match_threshold` ensures that only documents that have a minimum similarity to the `query_embedding` are returned. Without this, you may end up returning documents that subjectively don't match. This value will vary for each application - you will need to perform your own testing to determine the threshold that makes sense for your app.
+
+If you use an index to improve the performance of your queries, ensure that the `order by` uses the distance function directly (rather than the calculated `similarity`, which may lead to the index not being utilized).
 
 To execute the function from your client library, call `rpc()` with the name of your Postgres function:
 

--- a/apps/docs/pages/guides/ai/vector-columns.mdx
+++ b/apps/docs/pages/guides/ai/vector-columns.mdx
@@ -141,7 +141,7 @@ This function takes a `query_embedding` argument and compares it to all other em
 
 Feel free to modify this method to fit the needs of your application. The `match_threshold` ensures that only documents that have a minimum similarity to the `query_embedding` are returned. Without this, you may end up returning documents that subjectively don't match. This value will vary for each application - you will need to perform your own testing to determine the threshold that makes sense for your app.
 
-If you use an index to improve the performance of your queries, ensure that the `order by` uses the distance function directly (rather than the calculated `similarity`, which may lead to the index not being utilized).
+If you index your vector column, ensure that the `order by` sorts by the distance function directly (rather than sorting by the calculated `similarity` column, which may lead to the index being ignored and poor performance).
 
 To execute the function from your client library, call `rpc()` with the name of your Postgres function:
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

The current guidance leads to a query that does not leverage the index successfully, resulting in poor performance if implemented exactly as mentioned. Discussed in more detail in #18046 

## What is the current behavior?

Example query that does not leverage the index.

## What is the new behavior?

A better example query.

## Additional context

#18046 
