### PR TITLE
Fix: embedding match query in blog post to correctly utilize index

### DIFF
--- a/apps/www/_blog/2023-02-03-openai-embeddings-postgres-vector.mdx
+++ b/apps/www/_blog/2023-02-03-openai-embeddings-postgres-vector.mdx
@@ -128,8 +128,8 @@ as $$
     documents.content,
     1 - (documents.embedding <=> query_embedding) as similarity
   from documents
-  where 1 - (documents.embedding <=> query_embedding) > match_threshold
-  order by similarity desc
+  where documents.embedding <=> query_embedding < 1 - match_threshold
+  order by documents.embedding <=> query_embedding
   limit match_count;
 $$;
 ```


### PR DESCRIPTION
## Problem

As explained very well in https://github.com/supabase/supabase/issues/18046, the embedding match query in the pgvector blog post won't utilize the vector index at all, since we're ordering/filtering by `1 - distance` instead of `distance` itself.

## Solution
Correct the query in `match_documents` to reference `distance` directly which correctly performs an index scan on the table.