### PR TITLE
docs: editing a cronjob

### DIFF
--- a/apps/docs/pages/guides/database/extensions/pg_cron.mdx
+++ b/apps/docs/pages/guides/database/extensions/pg_cron.mdx
@@ -109,6 +109,30 @@ select
   );
 ```
 
+### Edit a job
+
+Changes the frequency of a job called `'vacuum'` to once every 5 minutes.
+
+```sql
+select cron.alter_job(
+  job_id := (select jobid from cron.job where jobname = 'vacuum'),
+  schedule := '*/5 * * * *'
+);
+```
+
+Full options for the `cron.alter_job()` function is laid out below.
+
+```sql
+cron.alter_job(
+  job_id bigint,
+  schedule text default null,
+  command text default null,
+  database text default null,
+  username text default null,
+  active boolean default null
+)
+```
+
 ### Unschedule a job
 
 Unschedules a job called `'nightly-vacuum'`

--- a/apps/docs/pages/guides/database/extensions/pg_cron.mdx
+++ b/apps/docs/pages/guides/database/extensions/pg_cron.mdx
@@ -120,7 +120,7 @@ select cron.alter_job(
 );
 ```
 
-Full options for the `cron.alter_job()` function is laid out below.
+Full options for the `cron.alter_job()` function are:
 
 ```sql
 cron.alter_job(


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

No docs section on how to edit cron jobs

## What is the new behavior?

DML (e.g. `update`) on `cron.job` is no longer supported, so we need to use `cron.alter_job()` to edit cron jobs.