### PR TITLE
feat: table header show table name

### DIFF
--- a/apps/studio/components/grid/components/header/Header.tsx
+++ b/apps/studio/components/grid/components/header/Header.tsx
@@ -81,6 +81,7 @@ const Header = ({
             )}
           </>
         )}
+        <span className="text-xs truncate px-4">{table.name}</span>
         <div className="sb-grid-header__inner">{headerActions}</div>
       </div>
       <RLSBannerWarning />


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase Studio > Table Editor

## What is the current behavior?

The table name is shown on the left hand menu but not in the table header

## What is the new behavior?

The table name is shown in the header:

<img width="1381" alt="Screenshot 2023-11-22 at 19 55 35" src="https://github.com/supabase/supabase/assets/22655069/738061ab-9a69-44d9-8d2d-12b8549a5089">

## Additional context

Feature requested [here](https://github.com/orgs/supabase/discussions/19097)
