### PR TITLE
chore: add update object function to the docs

### DIFF
--- a/spec/supabase_py_v2.yml
+++ b/spec/supabase_py_v2.yml
@@ -1952,8 +1952,8 @@ functions:
         name: Update file
         code: |
           ```python
-          supabase.storage.from_("bucket_name")
-            .update(file=f, path=path_on_supastorage, file_options={"cache-control": "3600", "upsert": "true"})
+          with open(filepath, 'rb') as f:
+            supabase.storage.from_("bucket_name").update(file=f, path=path_on_supastorage, file_options={"cache-control": "3600", "upsert": "true"})
           ```
   - id: from-move
     title: 'from_.move()'

--- a/spec/supabase_py_v2.yml
+++ b/spec/supabase_py_v2.yml
@@ -1940,6 +1940,21 @@ functions:
           with open(filepath, 'rb') as f:
               supabase.storage.from_("testbucket").upload(file=f,path=path_on_supastorage, file_options={"content-type": "audio/mpeg"})
           ```
+  - id: from-update
+    title: from_.update()
+    notes: |
+      - RLS policy permissions required:
+        - `buckets` table permissions: none
+        - `objects` table permissions: `update` and `select`
+      - Refer to the [Storage guide](/docs/guides/storage/security/access-control) on how access control works
+    examples:
+      - id: update-file
+        name: Update file
+        code: |
+          ```python
+          supabase.storage.from_("bucket_name")
+            .update(file=f, path=path_on_supastorage, file_options={"cache-control": "3600", "upsert": "true"})
+          ```
   - id: from-move
     title: 'from_.move()'
     notes: |


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

Python docs doesn't have the `update` storage object function

## What is the new behavior?

Python docs now contain the `update` storage object function

## Additional context

In relations to this PR https://github.com/supabase-community/storage-py/pull/165