### PR TITLE
fix: Update the studio dockerfile with the new folder structure

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,7 +13,7 @@ tests
 
 **/.next
 .vercel
-.env.*
+**/.env.*
 
 .dockerignore
 apps/studio/Dockerfile

--- a/.dockerignore
+++ b/.dockerignore
@@ -3,7 +3,6 @@
 .git
 .github
 about
-apps
 docker
 examples
 i18n
@@ -17,4 +16,4 @@ tests
 .env.*
 
 .dockerignore
-studio/Dockerfile
+apps/studio/Dockerfile

--- a/apps/studio/Dockerfile
+++ b/apps/studio/Dockerfile
@@ -52,10 +52,10 @@ RUN npx turbo run build --scope=studio --include-dependencies --no-deps
 
 # Copy only compiled code and dependencies
 FROM base as production
-COPY --from=builder /app/studio/public ./studio/public
-COPY --from=builder /app/studio/.next/standalone ./
-COPY --from=builder /app/studio/.next/static ./studio/.next/static
+COPY --from=builder /app/apps/studio/public ./apps/studio/public
+COPY --from=builder /app/apps/studio/.next/standalone ./
+COPY --from=builder /app/apps/studio/.next/static ./apps/studio/.next/static
 EXPOSE 3000
 ENTRYPOINT ["docker-entrypoint.sh"]
 HEALTHCHECK --interval=5s --timeout=5s --retries=3 CMD node -e "require('http').get('http://localhost:3000/api/profile', (r) => {if (r.statusCode !== 200) throw new Error(r.statusCode)})"
-CMD ["node", "studio/server.js"]
+CMD ["node", "apps/studio/server.js"]


### PR DESCRIPTION
The Dockerfile for `studio` was not updated when the `studio` app was moved to `apps` folder. This caused this [build](https://github.com/supabase/supabase/actions/runs/6925369171) to fail.