### PR TITLE
Fix declaration scope of `headers`

### DIFF
--- a/apps/docs/pages/guides/auth/server-side/email-based-auth-with-pkce-flow-for-ssr.mdx
+++ b/apps/docs/pages/guides/auth/server-side/email-based-auth-with-pkce-flow-for-ssr.mdx
@@ -169,10 +169,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const token_hash = requestUrl.searchParams.get('token_hash')
   const type = requestUrl.searchParams.get('type') as EmailOtpType | null
   const next = requestUrl.searchParams.get('next') || '/'
+  const headers = new Headers()
 
   if (token_hash && type) {
     const cookies = parse(request.headers.get('Cookie') ?? '')
-    const headers = new Headers()
 
     const supabase = createServerClient(process.env.SUPABASE_URL!, process.env.SUPABASE_ANON_KEY!, {
       cookies: {


### PR DESCRIPTION
`headers` is undefined in the final return in `loader` because `headers` is declared within the nested `if` block.

## What kind of change does this PR introduce?

Docs bug fix