### PR TITLE
Fix button padding with icon

### DIFF
--- a/packages/ui/src/components/Input/Input.tsx
+++ b/packages/ui/src/components/Input/Input.tsx
@@ -142,6 +142,8 @@ function Input({
   if (disabled) inputClasses.push(__styles.disabled)
   if (inputClassName) inputClasses.push(inputClassName)
 
+  console.log(cn(inputClasses))
+
   return (
     <FormLayout
       label={label}
@@ -171,7 +173,7 @@ function Input({
           ref={inputRef}
           type={type}
           value={reveal && hidden ? HIDDEN_PLACEHOLDER : value}
-          className={cn(inputClasses)}
+          className={inputClasses.join(' ')}
           {...props}
         />
         {icon && <InputIconContainer icon={icon} className={iconContainerClassName} />}

--- a/packages/ui/src/components/Input/Input.tsx
+++ b/packages/ui/src/components/Input/Input.tsx
@@ -142,8 +142,6 @@ function Input({
   if (disabled) inputClasses.push(__styles.disabled)
   if (inputClassName) inputClasses.push(inputClassName)
 
-  console.log(cn(inputClasses))
-
   return (
     <FormLayout
       label={label}

--- a/packages/ui/src/components/Input/Input.tsx
+++ b/packages/ui/src/components/Input/Input.tsx
@@ -137,8 +137,8 @@ function Input({
 
   if (error) inputClasses.push(__styles.variants.error)
   if (!error) inputClasses.push(__styles.variants.standard)
-  if (icon) inputClasses.push(__styles.with_icon)
   if (size) inputClasses.push(__styles.size[size])
+  if (icon) inputClasses.push(__styles.with_icon)
   if (disabled) inputClasses.push(__styles.disabled)
   if (inputClassName) inputClasses.push(inputClassName)
 
@@ -171,7 +171,7 @@ function Input({
           ref={inputRef}
           type={type}
           value={reveal && hidden ? HIDDEN_PLACEHOLDER : value}
-          className={inputClasses.join(' ')}
+          className={cn(inputClasses)}
           {...props}
         />
         {icon && <InputIconContainer icon={icon} className={iconContainerClassName} />}


### PR DESCRIPTION
For some reason `cn` was stripping away the `pl-10` class that would be part of `inputClasses` if an icon is provided