### PR TITLE
Speed up Studio development via SWC and keeping built pages in memory for longer

### DIFF
--- a/apps/studio/.babelrc
+++ b/apps/studio/.babelrc
@@ -1,4 +1,0 @@
-{
-  "presets": ["next/babel"],
-  "plugins": []
-}

--- a/apps/studio/next.config.js
+++ b/apps/studio/next.config.js
@@ -359,7 +359,7 @@ const nextConfig = {
   onDemandEntries: {
     maxInactiveAge: 24 * 60 * 60 * 1000,
     pagesBufferLength: 100,
-  }
+  },
 }
 
 // module.exports = withBundleAnalyzer(nextConfig)

--- a/apps/studio/next.config.js
+++ b/apps/studio/next.config.js
@@ -356,6 +356,10 @@ const nextConfig = {
 
     return config
   },
+  onDemandEntries: {
+    maxInactiveAge: 24 * 60 * 60 * 1000,
+    pagesBufferLength: 100,
+  }
 }
 
 // module.exports = withBundleAnalyzer(nextConfig)

--- a/apps/studio/tsconfig.json
+++ b/apps/studio/tsconfig.json
@@ -18,7 +18,8 @@
     "incremental": true,
     "paths": {
       "@ui/*": ["./../../packages/ui/src/*"] // handle ui package paths
-    }
+    },
+    "useDefineForClassFields": true
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
1. Enable `useDefineForClassFields`, per https://mobx.js.org/installation.html#use-spec-compliant-transpilation-for-class-properties. Needed to switch to SWC.
2. Remove `.babelrc` to enable SWC. This was tried previously and reverted. I believe that it should work now with `useDefineForClassField` enabled, support for which was added to Next.js in https://github.com/vercel/next.js/pull/36335.
3. Set `onDemandEntries` options `maxInactiveAge` to 1 day, `pagesBufferLength` to 100. This will keep up to 100 built pages in memory for 1 day, speeding up development. You'd expect that this speed up would come at the cost of memory usage, but in my unscientific testing involving clicking around every page I could get to, with SWC compilation, `next-router-worker` memory usage maxed out at ~3.3 GB with these options enabled, and no compilation was needed for any revisited pages, whereas without these options, memory usage maxed out at ~4 GB(?!), and revisited pages were compiled once they were out of the buffer. Perhaps the recompilation actually worsens memory usage.

After removing `.next/`, compilation for the initial page can take up to 89.5s on my late 2019 Intel MacBook Pro, and anywhere from 1s to 11s for subsequent pages. After these changes, initial compilation took 21.4s and subsequent pages aren't compiled again within 1 day if no changes are made.