### PR TITLE
chore: remove unused next-transpile-modules dep

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -78,7 +78,6 @@
     "ejs": "^3.1.8",
     "globby": "^13.2.2",
     "jest-environment-jsdom": "^29.7.0",
-    "next-transpile-modules": "^9.0.0",
     "npm-run-all": "^4.1.5",
     "openapi-types": "^12.0.2",
     "sass": "^1.68.0",

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -37,7 +37,6 @@
     "next-mdx-remote": "^4.4.1",
     "next-seo": "^5.14.1",
     "next-themes": "^0.2.1",
-    "next-transpile-modules": "^9.0.0",
     "octokit": "^2.0.14",
     "parse-numeric-range": "^1.3.0",
     "react": "^18.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -263,7 +263,6 @@
         "ejs": "^3.1.8",
         "globby": "^13.2.2",
         "jest-environment-jsdom": "^29.7.0",
-        "next-transpile-modules": "^9.0.0",
         "npm-run-all": "^4.1.5",
         "openapi-types": "^12.0.2",
         "sass": "^1.68.0",
@@ -726,7 +725,6 @@
         "next-mdx-remote": "^4.4.1",
         "next-seo": "^5.14.1",
         "next-themes": "^0.2.1",
-        "next-transpile-modules": "^9.0.0",
         "octokit": "^2.0.14",
         "parse-numeric-range": "^1.3.0",
         "react": "^18.2.0",
@@ -25412,14 +25410,6 @@
     "node_modules/next-tick": {
       "version": "1.1.0",
       "license": "ISC"
-    },
-    "node_modules/next-transpile-modules": {
-      "version": "9.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "enhanced-resolve": "^5.10.0",
-        "escalade": "^3.1.1"
-      }
     },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.14",


### PR DESCRIPTION
No longer used nor necessary:

https://github.com/martpie/next-transpile-modules/releases/tag/the-end