### PR TITLE
Fix the boolean listbox in RowEditor to handle background changes to a row

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/GridHeaderActions.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/GridHeaderActions.tsx
@@ -9,9 +9,9 @@ import { Button, IconAlertCircle, IconLock, Modal } from 'ui'
 
 import { rlsAcknowledgedKey } from 'components/grid/constants'
 import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
-import ConfirmationModal from 'components/ui/ConfirmationModal'
-import { useCheckPermissions, useStore, useIsFeatureEnabled } from 'hooks'
 import APIDocsButton from 'components/ui/APIDocsButton'
+import ConfirmationModal from 'components/ui/ConfirmationModal'
+import { useCheckPermissions, useIsFeatureEnabled, useStore } from 'hooks'
 
 export interface GridHeaderActionsProps {
   table: PostgresTable
@@ -22,7 +22,6 @@ const GridHeaderActions = ({ table }: GridHeaderActionsProps) => {
   const { meta, ui } = useStore()
   const { project } = useProjectContext()
   const realtimeEnabled = useIsFeatureEnabled('realtime:all')
-  console.log({ realtimeEnabled })
 
   const [isTogglingRealtime, setIsTogglingRealtime] = useState(false)
   const [showEnableRealtime, setShowEnableRealtime] = useState(false)


### PR DESCRIPTION
This PR fixes a bug where the boolean list box was showing values from a previously edited row. Reported [here](https://www.notion.so/supabase/table-editor-boolean-input-bug-02301f0cc432499795fd3d50c0465241).