### PR TITLE
fix const that should be let in svelte example

### DIFF
--- a/apps/docs/pages/guides/auth/auth-helpers/sveltekit.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/sveltekit.mdx
@@ -755,7 +755,7 @@ For [row level security](https://supabase.com/docs/guides/auth/row-level-securit
 <script lang="ts">
   export let data
 
-  const { user, tableData } = data
+  let { user, tableData } = data
   $: ({ user, tableData } = data)
 </script>
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

`const` in Svelte example that should be `let` because Svelte needs to reactively reassign it

Resolves #18393