### PR TITLE
variable should be let as it is reassigned

### DIFF
--- a/apps/docs/pages/guides/getting-started/tutorials/with-sveltekit.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-sveltekit.mdx
@@ -163,7 +163,7 @@ Update your `src/routes/+layout.svelte`:
 
 	export let data
 
-	const { supabase, session } = data
+	let { supabase, session } = data
 	$: ({ supabase, session } = data)
 
 	onMount(() => {
@@ -314,7 +314,7 @@ Create a new `src/routes/account/+page.svelte` file with the content below.
 	export let data
 	export let form
 
-	const { session, supabase, profile } = data
+	let { session, supabase, profile } = data
 	$: ({ session, supabase, profile } = data)
 
 	let profileForm: HTMLFormElement


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

The [Sveltekit example](https://supabase.com/docs/guides/getting-started/tutorials/with-sveltekit) initializes destructured variables as `const` but these variables are reassigned and should be initialized as `let`, [as described in this issue](https://github.com/supabase/supabase/issues/19218)

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
