### PR TITLE
feat: sidebar show and close

### DIFF
--- a/apps/studio/components/layouts/ProjectLayout/ProductMenuBar.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/ProductMenuBar.tsx
@@ -1,25 +1,41 @@
-import { PropsWithChildren } from 'react'
+import { ArrowLeft, ArrowRight } from 'lucide-react'
+import { PropsWithChildren, useState } from 'react'
 
 interface ProductMenuBarProps {
   title: string
 }
 
 const ProductMenuBar = ({ title, children }: PropsWithChildren<ProductMenuBarProps>) => {
+  const [open, setOpen] = useState(true)
   return (
     <div
       className={[
-        'hide-scrollbar flex w-64 flex-col border-r', // Layout
+        'hide-scrollbar flex flex-col border-r', // Layout
         'bg-background',
-        'border-default ',
+        'border-default ease-in-out duration-300',
+        open ? 'w-64' : 'w-10',
       ].join(' ')}
     >
       <div
-        className="border-default flex max-h-12 items-center border-b px-6"
+        className={[
+          'border-default flex max-h-12 items-center border-b justify-between ',
+          open ? 'px-6' : 'px-3',
+        ].join(' ')}
         style={{ minHeight: '3rem' }}
       >
-        <h4 className="text-lg">{title}</h4>
+        <h4 className={['text-lg ', open ? 'block' : 'hidden'].join(' ')}>{title}</h4>
+        <span className="cursor-pointer text-foreground-lighter" onClick={() => setOpen(!open)}>
+          {open ? (
+            <ArrowLeft size={16} strokeWidth={1.5} />
+          ) : (
+            <ArrowRight size={16} strokeWidth={1.5} />
+          )}
+        </span>
       </div>
-      <div className="flex-grow overflow-y-auto" style={{ maxHeight: 'calc(100vh - 96px)' }}>
+      <div
+        className={['flex-grow overflow-y-auto ', open ? 'block' : 'hidden'].join(' ')}
+        style={{ maxHeight: 'calc(100vh - 96px)' }}
+      >
         {children}
       </div>
     </div>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature - Supabase Studio

## What is the current behavior?

When working on a big table and other screens it would be nice to expand the width of the page so that you can see more.

## What is the new behavior?

I've added show and hide functionality just to give more width to the main panel:


https://github.com/supabase/supabase/assets/22655069/51039e6e-d5fb-499d-a204-001941d40e7d

This example is in auth but the change would happen on the majority of pages e.g. storage and table edtior.
