### PR TITLE
feat: Added back the once removed exposed docker compose port for Studio

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -26,6 +26,8 @@ services:
     depends_on:
       analytics:
         condition: service_healthy
+    ports:
+      - ${STUDIO_PORT}:3000/tcp
     environment:
       STUDIO_PG_META_URL: http://meta:8080
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds an exposed port 3000 in docker-compose for Studio.

## What is the current behavior?

- Going directly to `http://localhost:3000` does not work. The last time it did was `v0.23.06`
- `.env.example` mentions a `STUDIO_PORT` -- which isn't used anywhere else in the stack.
- Going through kong `http://localhost:8000` each time is annoying, since you have to enter your basic auth creds every time.

## What is the new behavior?

- Going directly to `http://localhost:3000` now loads up Supabase Studio dashboard directly, without going through Kong.
