### PR TITLE
docs: add schame name for wrappers extension creation

### DIFF
--- a/apps/docs/pages/guides/database/extensions/wrappers/overview.mdx
+++ b/apps/docs/pages/guides/database/extensions/wrappers/overview.mdx
@@ -47,7 +47,7 @@ from
 {/* prettier-ignore */}
 ```sql
 -- Enable the "wrappers" extension
-create extension wrappers with schema extensions;;
+create extension wrappers with schema extensions;
 
 -- Disable the "wrappers" extension
 drop extension if exists wrappers;

--- a/apps/docs/pages/guides/database/extensions/wrappers/overview.mdx
+++ b/apps/docs/pages/guides/database/extensions/wrappers/overview.mdx
@@ -47,7 +47,7 @@ from
 {/* prettier-ignore */}
 ```sql
 -- Enable the "wrappers" extension
-create extension wrappers;
+create extension wrappers with schema extensions;;
 
 -- Disable the "wrappers" extension
 drop extension if exists wrappers;


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to add schema name `extensions` when create wrappers extension.

## What is the current behavior?

Without specifying schema name, wrappers extension will create the stats collection table `wrappers_fdw_stats` in `public` schema which will cause RLS warning.

## What is the new behavior?

Wrappers extension should be created in `extensions` schema.

## Additional context

N/A
