### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,6 @@
 /packages/shared-data/pricing.ts @roryw10 @kevcodez
 /packages/shared-data/plans.ts @roryw10 @kevcodez
 
-/apps/docs/pages/ @supabase/developers
 /apps/studio/ @supabase/Dashboard
 /apps/www/ @supabase/Website
 /docker/ @supabase/cli


### PR DESCRIPTION
the intention before was to let anyone approve apps/docs/pages but this led to an increase in notifications for everyone. 

removing this codeowner rule should have the same effect.