### PR TITLE
chore: Bump the OpenAI lib version to v4 in the docs app

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -51,7 +51,7 @@
     "next-plugin-yaml": "^1.0.1",
     "next-seo": "^5.14.1",
     "next-themes": "^0.2.1",
-    "openai": "^3.3.0",
+    "openai": "^4.17.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-intersection-observer": "^9.5.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -554,7 +554,7 @@
         "next-plugin-yaml": "^1.0.1",
         "next-seo": "^5.14.1",
         "next-themes": "^0.2.1",
-        "openai": "^3.3.0",
+        "openai": "^4.17.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-intersection-observer": "^9.5.2",
@@ -617,7 +617,6 @@
     },
     "apps/docs/node_modules/@types/node": {
       "version": "18.18.8",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -692,6 +691,25 @@
         }
       ],
       "license": "MIT"
+    },
+    "apps/docs/node_modules/openai": {
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.20.0.tgz",
+      "integrity": "sha512-VbAYerNZFfIIeESS+OL9vgDkK8Mnri55n+jN0UN/HZeuM0ghGh6nDN6UGRZxslNgyJ7XmY/Ca9DO4YYyvrszGA==",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "digest-fetch": "^1.3.0",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7",
+        "web-streams-polyfill": "^3.2.1"
+      },
+      "bin": {
+        "openai": "bin/cli"
+      }
     },
     "apps/docs/node_modules/slash": {
       "version": "4.0.0",


### PR DESCRIPTION
This PR bumps the `openai` lib to v4 and migrates all its usage in the `docs` app. All things should work as before.