### PR TITLE
docs(reference): add example for dynamic schema switching

### DIFF
--- a/spec/supabase_dart_v1.yml
+++ b/spec/supabase_dart_v1.yml
@@ -885,7 +885,7 @@ functions:
         name: Switching schemas per-query
         description: |
           You can perform queries on custom schemas.
-          Make sure you've set up your [database privileges and API settings](https://supabase.com/docs/guides/api/using-custom-schemas).
+          Make sure you've set up your [database privileges and API settings](/docs/guides/api/using-custom-schemas).
         code: |
           ```dart
           final data = await supabase

--- a/spec/supabase_dart_v1.yml
+++ b/spec/supabase_dart_v1.yml
@@ -881,6 +881,18 @@ functions:
             .select()
             .csv();
           ```
+      - id: switching-schemas-per-query
+        name: Switching schemas per-query
+        description: |
+          You can perform queries on custom schemas.
+          Make sure you've set up your [database privileges and API settings](https://supabase.com/docs/guides/api/using-custom-schemas).
+        code: |
+          ```dart
+          final data = await supabase
+            .useSchema('myschema')
+            .from('users')
+            .select();
+          ```
 
   - id: insert
     description: |

--- a/spec/supabase_dart_v1.yml
+++ b/spec/supabase_dart_v1.yml
@@ -882,7 +882,7 @@ functions:
             .csv();
           ```
       - id: switching-schemas-per-query
-        name: Switching schemas per-query
+        name: Switching schemas per query
         description: |
           You can perform queries on custom schemas.
           Make sure you've set up your [database privileges and API settings](/docs/guides/api/using-custom-schemas).

--- a/spec/supabase_js_v2.yml
+++ b/spec/supabase_js_v2.yml
@@ -1814,7 +1814,7 @@ functions:
           ```
         description: |
           In addition to setting the schema during initialization, you can also switch schemas on a per-query basis.
-          Make sure you've set up your [database privileges and API settings](https://supabase.com/docs/guides/api/using-custom-schemas).
+          Make sure you've set up your [database privileges and API settings](/docs/guides/api/using-custom-schemas).
         hideCodeBlock: true
 
   - id: insert

--- a/spec/supabase_js_v2.yml
+++ b/spec/supabase_js_v2.yml
@@ -1779,7 +1779,7 @@ functions:
           Like `.select('name, countries!inner()')`.
         hideCodeBlock: true
       - id: switching-schemas-per-query
-        name: Switching schemas per-query
+        name: Switching schemas per query
         code: |
           ```ts
           const { data, error } = await supabase

--- a/spec/supabase_js_v2.yml
+++ b/spec/supabase_js_v2.yml
@@ -26,7 +26,7 @@ functions:
 
     examples:
       - id: create-client
-        name: createClient()
+        name: Creating a client
         code: |
           ```js
           import { createClient } from '@supabase/supabase-js'
@@ -34,7 +34,7 @@ functions:
           // Create a single supabase client for interacting with your database
           const supabase = createClient('https://xyzcompany.supabase.co', 'public-anon-key')
           ```
-      - id: create-client
+      - id: with-custom-domain
         name: With a custom domain
         code: |
           ```js
@@ -65,13 +65,13 @@ functions:
           const supabase = createClient("https://xyzcompany.supabase.co", "public-anon-key", options)
           ```
       - id: api-schemas
-        name: API schemas
+        name: With custom schemas
         code: |
           ```js
           import { createClient } from '@supabase/supabase-js'
 
-          // Provide a custom schema. Defaults to "public".
           const supabase = createClient('https://xyzcompany.supabase.co', 'public-anon-key', {
+            // Provide a custom schema. Defaults to "public".
             db: { schema: 'other_schema' }
           })
           ```
@@ -81,7 +81,7 @@ functions:
 
           Note: each client connection can only access a single schema, so the code above can access the `other_schema` schema but cannot access the `public` schema.
       - id: custom-fetch-implementation
-        name: Custom `fetch` implementation
+        name: Custom fetch implementation
         code: |
           ```js
           import { createClient } from '@supabase/supabase-js'
@@ -1777,6 +1777,44 @@ functions:
         description: |
           If you don't want to return the referenced table contents, you can leave the parenthesis empty.
           Like `.select('name, countries!inner()')`.
+        hideCodeBlock: true
+      - id: switching-schemas-per-query
+        name: Switching schemas per-query
+        code: |
+          ```ts
+          const { data, error } = await supabase
+            .schema('myschema')
+            .from('mytable')
+            .select()
+          ```
+        data:
+          sql: |
+            ```sql
+            create schema myschema;
+
+            create table myschema.mytable (
+              id uuid primary key default gen_random_uuid(),
+              data text
+            );
+
+            insert into myschema.mytable (data) values ('mydata');
+            ```
+        response: |
+          ```json
+          {
+            "data": [
+              {
+                "id": "4162e008-27b0-4c0f-82dc-ccaeee9a624d",
+                "data": "mydata"
+              }
+            ],
+            "status": 200,
+            "statusText": "OK"
+          }
+          ```
+        description: |
+          In addition to setting the schema during initialization, you can also switch schemas on a per-query basis.
+          Make sure you've set up your [database privileges and API settings](https://supabase.com/docs/guides/api/using-custom-schemas).
         hideCodeBlock: true
 
   - id: insert


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

No example for dynamic schema switching in the reference docs. There's one [here](https://supabase.com/docs/guides/api/using-custom-schemas) but it's a bit hidden.

## What is the new behavior?

Add example for dynamic schema switching in the reference docs. Context:
- https://github.com/supabase/postgrest-js/pull/455
- https://github.com/supabase/supabase-flutter/pull/525