### PR TITLE
docs: change require to import in code sample

### DIFF
--- a/apps/docs/pages/guides/realtime/subscribing-to-database-changes.mdx
+++ b/apps/docs/pages/guides/realtime/subscribing-to-database-changes.mdx
@@ -50,7 +50,7 @@ alter
 You can use the `INSERT` event to stream all new rows.
 
 ```js
-const { createClient } = require('@supabase/supabase-js')
+import { createClient } from '@supabase/supabase-js'
 
 const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_KEY)
 
@@ -72,7 +72,7 @@ const channel = supabase
 You can use the `UPDATE` event to stream all updated rows.
 
 ```js
-const { createClient } = require('@supabase/supabase-js')
+import { createClient } from '@supabase/supabase-js'
 
 const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_KEY)
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Very small fix from probably an old docs that I found while working on updating the Flutter docs. 

Found two places that were using `require` instead of `import`. This PR changes them to `import`, which is the more preferred way in modern day js/ts.