### PR TITLE
docs: change Local Development href to '/guides/cli/getting-started'

### DIFF
--- a/apps/docs/pages/guides/getting-started.mdx
+++ b/apps/docs/pages/guides/getting-started.mdx
@@ -344,7 +344,7 @@ export const resources = [
   {
     title: 'Local Development',
     hasLightIcon: true,
-    href: '/guides/getting-started/local-development',
+    href: '/guides/cli/getting-started',
     description: 'Use the Supabase CLI to develop locally and collaborate between teams.',
   },
 ]


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix. Fixing issue #19230

## What is the current behavior?

### Docs

In the current version, in the **Getting Started** page, the **Local development** section redirects to **Developing with supabase/Local development** which might confuse developers that have not previously installed the CLI (referenced in the issue).

## What is the new behavior?

In this new version, it redirects to the **Using the CLI/Getting Started** section, where developers have all the instructions to set up the CLI.

