### PR TITLE
fix: drag and drop causes page crash

### DIFF
--- a/studio/components/grid/SupabaseGrid.tsx
+++ b/studio/components/grid/SupabaseGrid.tsx
@@ -29,7 +29,7 @@ export const SupabaseGrid = forwardRef<SupabaseGridRef, SupabaseGridProps>((prop
 
   return (
     <StoreProvider>
-      <DndProvider backend={HTML5Backend}>
+      <DndProvider backend={HTML5Backend} context={window}>
         <SupabaseGridLayout ref={ref} {..._props} />
       </DndProvider>
     </StoreProvider>

--- a/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/ForeignRowSelector/ForeignRowSelector.tsx
+++ b/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/ForeignRowSelector/ForeignRowSelector.tsx
@@ -140,7 +140,7 @@ const ForeignRowSelector = ({
                       setParams(...args)
                     }}
                   />
-                  <DndProvider backend={HTML5Backend}>
+                  <DndProvider backend={HTML5Backend} context={window}>
                     <SortPopover
                       table={supaTable}
                       sorts={params.sort ?? []}


### PR DESCRIPTION
## What kind of change does this PR introduce?

This bug is related to drag and drop feature. When user tries to load data into the table from csv file by dragging and switches table, the page crashes.
This is a bug fix.

## What is the current behavior?

Currently when user tries to load data into the table by using drag and drop. after loading the data, If user clicks on another table. The page crashes.


https://github.com/supabase/supabase/assets/28553853/9cfdca8d-e10d-4319-8452-86d19fca7e76





## What is the new behavior?

The new fix will remove the error causing page crash. 
This bug is resolved by providing the individual context to DnDProvider componenets.

https://github.com/supabase/supabase/assets/28553853/e955bfb4-196d-4f6e-b0f3-d4f87a7e1f3e



## Additional context

Add any other context or screenshots.
