### PR TITLE
fix(example): remove supabase kong config from nextjs-todo-list example

### DIFF
--- a/examples/todo-list/nextjs-todo-list/supabase/config.toml
+++ b/examples/todo-list/nextjs-todo-list/supabase/config.toml
@@ -25,11 +25,6 @@ major_version = 15
 # Port to use for Supabase Studio.
 port = 54323
 
-[kong]
-# Number of nginx workers for handling requests. Set this to 1 to minimize memory usage.
-# Omitting it or setting it to 0 will autodetect based on the number of CPU cores.
-nginx_worker_processes = 1
-
 # Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
 # are monitored, and you can view the emails that would have been sent from the web interface.
 [inbucket]


### PR DESCRIPTION
## What kind of change does this PR introduce?

Remove supabase kong config from nextjs-todo-list example

## What is the current behavior?
[1274](https://github.com/supabase/cli/pull/1274) has been removed kong config from cli, so if a supabase config has a kong configuration, it will print an "Unknown config" error.

The example will print a err: Unknown config fields: [kong kong.nginx_worker_processes]
```
owen@vm:~/goproject/src/github.com/supabase/cli/supabase/nextjs-todo-list|main ⇒  supabase start
Unknown config fields: [kong kong.nginx_worker_processes]
Applying migration 20230712094349_init.sql...
Seeding data supabase/seed.sql...
v1.23.0: Pulling from supabase/edge-runtime
1f7ce2fa46ab: Already exists
c21a08377ebc: Pull complete
af44e9fbc3d7: Pull complete
3193d6739b95: Pull complete
```
