### PR TITLE
chore: remove spinner waterfall on projects page

### DIFF
--- a/apps/studio/components/interfaces/Home/ProjectList/ProjectList.tsx
+++ b/apps/studio/components/interfaces/Home/ProjectList/ProjectList.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import { Button, IconPlus } from 'ui'
 
 import AlertError from 'components/ui/AlertError'
+import { useOrgIntegrationsQuery } from 'data/integrations/integrations-query-org-only'
 import {
   OverdueInvoicesResponse,
   useOverdueInvoicesQuery,
@@ -12,20 +13,19 @@ import { useOrganizationsQuery } from 'data/organizations/organizations-query'
 import { usePermissionsQuery } from 'data/permissions/permissions-query'
 import { useProjectsQuery } from 'data/projects/projects-query'
 import { ResourceWarning, useResourceWarningsQuery } from 'data/usage/resource-warnings-query'
+import { useSelectedOrganization } from 'hooks'
 import { IS_PLATFORM } from 'lib/constants'
 import { makeRandomString } from 'lib/helpers'
 import { Organization, Project, ResponseError } from 'types'
 import ProjectCard from './ProjectCard'
 import ShimmeringCard from './ShimmeringCard'
-import { useOrgIntegrationsQuery } from 'data/integrations/integrations-query-org-only'
-import { useSelectedOrganization } from 'hooks'
 
 export interface ProjectListProps {
   rewriteHref?: (projectRef: string) => string
 }
 
 const ProjectList = ({ rewriteHref }: ProjectListProps) => {
-  const { data: organizations, isSuccess } = useOrganizationsQuery()
+  const { data: organizations, isLoading, isSuccess } = useOrganizationsQuery()
   const {
     data: allProjects,
     isLoading: isLoadingProjects,
@@ -41,6 +41,15 @@ const ProjectList = ({ rewriteHref }: ProjectListProps) => {
   const { data: allOverdueInvoices } = useOverdueInvoicesQuery({ enabled: IS_PLATFORM })
   const projectsByOrg = groupBy(allProjects, 'organization_id')
   const isLoadingPermissions = IS_PLATFORM ? _isLoadingPermissions : false
+
+  if (isLoading) {
+    return (
+      <ul className="mx-auto grid grid-cols-1 gap-4 sm:grid-cols-1 md:grid-cols-1 lg:grid-cols-2 xl:grid-cols-3">
+        <ShimmeringCard />
+        <ShimmeringCard />
+      </ul>
+    )
+  }
 
   return isSuccess && organizations && organizations?.length > 0 ? (
     <>

--- a/apps/studio/components/interfaces/Home/ProjectList/ShimmeringCard.tsx
+++ b/apps/studio/components/interfaces/Home/ProjectList/ShimmeringCard.tsx
@@ -2,11 +2,15 @@ import CardButton from 'components/ui/CardButton'
 
 const ShimmeringCard = () => {
   return (
-    <CardButton title="" footer={<div className="shimmering-loader rounded py-3 mx-1 w-1/3" />}>
-      <div className="flex flex-col justify-between space-y-2">
-        <div className="shimmering-loader rounded py-3 mx-1 w-2/3" />
-      </div>
-    </CardButton>
+    <CardButton
+      className="h-44 !px-0 pt-5 pb-0"
+      title={
+        <div className="w-full justify-between space-y-1.5 px-5">
+          <p className="flex-shrink truncate text-sm pr-4 shimmering-loader h-5 w-20" />
+          <p className="text-sm lowercase text-foreground-light h-4 w-40 shimmering-loader" />
+        </div>
+      }
+    />
   )
 }
 

--- a/apps/studio/pages/projects.tsx
+++ b/apps/studio/pages/projects.tsx
@@ -10,23 +10,15 @@ import { useOrganizationsQuery } from 'data/organizations/organizations-query'
 import { useAutoProjectsPrefetch } from 'data/projects/projects-query'
 import { useFlag, useIsFeatureEnabled } from 'hooks'
 import { IS_PLATFORM, LOCAL_STORAGE_KEYS } from 'lib/constants'
-import { useProfile } from 'lib/profile'
 import { NextPageWithLayout } from 'types'
 
 const ProjectsPage: NextPageWithLayout = () => {
   const router = useRouter()
-  const {
-    data: organizations,
-    isLoading: isOrganizationLoading,
-    isError,
-    isSuccess,
-  } = useOrganizationsQuery()
+  const { data: organizations, isError, isSuccess } = useOrganizationsQuery()
   useAutoProjectsPrefetch()
 
   const projectCreationEnabled = useIsFeatureEnabled('projects:create')
 
-  const { isLoading: isProfileLoading } = useProfile()
-  const isLoading = isOrganizationLoading || isProfileLoading
   const navLayoutV2 = useFlag('navigationLayoutV2')
   const hasWindowLoaded = typeof window !== 'undefined'
 
@@ -45,12 +37,6 @@ const ProjectsPage: NextPageWithLayout = () => {
 
   return (
     <>
-      {(navLayoutV2 || isLoading) && (
-        <div className={`flex items-center justify-center h-full`}>
-          <Connecting />
-        </div>
-      )}
-
       {isError && (
         <div
           className={`py-4 px-5 ${navLayoutV2 ? 'h-full flex items-center justify-center' : ''}`}
@@ -59,9 +45,15 @@ const ProjectsPage: NextPageWithLayout = () => {
         </div>
       )}
 
-      {!navLayoutV2 && isSuccess && (
+      {navLayoutV2 && (
+        <div className={`flex items-center justify-center h-full`}>
+          <Connecting />
+        </div>
+      )}
+
+      {!navLayoutV2 && (
         <div className="py-4 px-5">
-          {IS_PLATFORM && projectCreationEnabled && organizations.length !== 0 && (
+          {IS_PLATFORM && projectCreationEnabled && isSuccess && organizations.length !== 0 && (
             <div className="my-2">
               <div className="flex">
                 <div className="">


### PR DESCRIPTION
## What kind of change does this PR introduce?

chore(perf)

## What is the current behaviour?

https://github.com/supabase/supabase/assets/10985857/c97ac434-2d4f-4d88-b7b8-826c0669a0a2

## What is the new behaviour?

https://github.com/supabase/supabase/assets/10985857/18037512-72af-4492-936e-65e5d5c88c7f

## Additional context

The second loading state is not so obvious in these videos, but there's another skeleton state if the projects are still loading after the organisations are loaded. This PR unifies both loading states to use the same skeleton components.