### PR TITLE
improve docs search performance by removing preflight

### DIFF
--- a/packages/ui/src/components/Command/DocsSearch.tsx
+++ b/packages/ui/src/components/Command/DocsSearch.tsx
@@ -256,6 +256,7 @@ const DocsSearch = () => {
             })
           })
           .catch((error) => {
+            sourcesLoaded += 1
             dispatch({
               type: 'errored',
               key: localKey,
@@ -287,18 +288,21 @@ const DocsSearch = () => {
 
   useEffect(() => {
     if (initialLoad.current) {
+      // On first navigation into 'docs search' page, search immediately
       if (search) {
         handleSearch(search)
       }
       initialLoad.current = false
     } else if (search) {
+      // Else if user is typing, debounce search
       debouncedSearch(search)
     } else {
+      // If user clears search, reset results
       debouncedSearch.cancel()
       key.current += 1
       dispatch({ type: 'reset', key: key.current })
     }
-  }, [])
+  }, [search])
 
   // Immediately run search if user presses enter
   // and abort any debounced searches that are waiting

--- a/packages/ui/src/components/Command/DocsSearch.tsx
+++ b/packages/ui/src/components/Command/DocsSearch.tsx
@@ -247,8 +247,8 @@ const DocsSearch = () => {
         })
           .then((response) => response.json())
           .then((results) => {
-            if (!results) {
-              throw Error('no results')
+            if (!Array.isArray(results)) {
+              throw Error("didn't get expected results array")
             }
             sourcesLoaded += 1
             dispatch({

--- a/packages/ui/src/components/Command/DocsSearch.tsx
+++ b/packages/ui/src/components/Command/DocsSearch.tsx
@@ -247,6 +247,9 @@ const DocsSearch = () => {
         })
           .then((response) => response.json())
           .then((results) => {
+            if (!results) {
+              throw Error('no results')
+            }
             sourcesLoaded += 1
             dispatch({
               type: 'resultsReturned',

--- a/packages/ui/src/components/Command/DocsSearch.tsx
+++ b/packages/ui/src/components/Command/DocsSearch.tsx
@@ -284,7 +284,7 @@ const DocsSearch = () => {
     })
   }
 
-  const debouncedSearch = useMemo(() => debounce(handleSearch, 1000), [handleSearch])
+  const debouncedSearch = useMemo(() => debounce(handleSearch, 300), [handleSearch])
 
   useEffect(() => {
     if (initialLoad.current) {

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -70,3 +70,9 @@ redirect_uri = ""
 # Overrides the default auth provider URL. Used to support self-hosted gitlab, single-tenant Azure,
 # or any other third-party OIDC providers.
 url = ""
+
+[functions.search-fts]
+verify_jwt = false
+
+[functions.search-embeddings]
+verify_jwt = false


### PR DESCRIPTION
## What kind of change does this PR introduce?

**Performance:** The docs search preflight is quite long (accounts for ~30% of the total time on FTS), but unneeded as this endpoint is open publicly. Removing the credentials automatically removes the browser preflight and speeds up search.

Also reduces debounce interval to improve perceived speed.

## What is the current behavior?

Each docs search request is preceded by a pre-flight, which can be > 50% as long as the actual request (for FTS).

<img width="585" alt="image" src="https://github.com/supabase/supabase/assets/26616127/4629f224-e45b-4898-907b-6acdf3c85fd7">

## What is the new behavior?

No pre-flight

<img width="577" alt="image" src="https://github.com/supabase/supabase/assets/26616127/ef8e39aa-0fe3-4213-9d4b-df79c1834329">

## Additional context

Add any other context or screenshots.
