### PR TITLE
feat: explicit gotrue-js package dependency, version 2.58.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9998,8 +9998,9 @@
       }
     },
     "node_modules/@supabase/gotrue-js": {
-      "version": "2.57.0",
-      "license": "MIT",
+      "version": "2.58.0",
+      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.58.0.tgz",
+      "integrity": "sha512-cDslIiiPUzS8DQQqYxK9kT+Ngbrbx0a68e+AsU3H4+eLyAfq+m9aAqKXHHr3H5jqeFvIprSe87r4SeyOYyMnrQ==",
       "dependencies": {
         "@supabase/node-fetch": "^2.6.14"
       }
@@ -34638,6 +34639,7 @@
         "typescript": "^5.2.2"
       },
       "peerDependencies": {
+        "@supabase/gotrue-js": "^2.58.0",
         "@supabase/supabase-js": "*",
         "next": "*",
         "react": "*",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -24,6 +24,7 @@
   },
   "peerDependencies": {
     "@supabase/supabase-js": "*",
+    "@supabase/gotrue-js": "^2.58.0",
     "next": "*",
     "react": "*",
     "react-dom": "*"


### PR DESCRIPTION
gotrue-js was removed from being an explicit dependency. This is useful for us to independently bump the version. This also bumps the version to 2.58.0 which fixes a bug with `SIGNED_OUT` not being called.