### PR TITLE
Admonition styling update

### DIFF
--- a/apps/docs/pages/guides/platform/multi-factor-authentication.mdx
+++ b/apps/docs/pages/guides/platform/multi-factor-authentication.mdx
@@ -35,12 +35,6 @@ For security reasons, we will not be able to restore access to your account if y
 
 </Admonition>
 
-<Admonition type="danger">
-
-For security reasons, we will not be able to restore access to your account if you lose all your two-factor authentication credentials. Do register a backup factor if necessary.
-
-</Admonition>
-
 ## Login with MFA
 
 Once you've enabled MFA for your Supabase user account, you will be prompted to enter your second factor challenge code as seen in your preferred TOTP app.

--- a/apps/docs/pages/guides/platform/multi-factor-authentication.mdx
+++ b/apps/docs/pages/guides/platform/multi-factor-authentication.mdx
@@ -35,6 +35,12 @@ For security reasons, we will not be able to restore access to your account if y
 
 </Admonition>
 
+<Admonition type="danger">
+
+For security reasons, we will not be able to restore access to your account if you lose all your two-factor authentication credentials. Do register a backup factor if necessary.
+
+</Admonition>
+
 ## Login with MFA
 
 Once you've enabled MFA for your Supabase user account, you will be prompted to enter your second factor challenge code as seen in your preferred TOTP app.

--- a/packages/ui/src/components/Admonition/index.tsx
+++ b/packages/ui/src/components/Admonition/index.tsx
@@ -48,22 +48,12 @@ const WarningIcon = () => (
   </svg>
 )
 
-const admonitionTypeLabelVariants = cva('uppercase font-mono inline px-2 py-0.5 border rounded', {
-  variants: {
-    type: {
-      default: `bg-surface-100 text-foreground`,
-      warning: `bg-surface-100 text-foreground`,
-      destructive: `bg-surface-100 text-foreground`,
-    },
-  },
-})
-
 const admonitionSVG = cva('', {
   variants: {
     type: {
       default: `[&_svg]:bg-foreground-muted [&_svg]:text-background-muted`,
       warning: `[&_svg]:bg-warning [&_svg]:text-warning-100`,
-      destructive: `[&_svg]:bg-surface-100 [&_svg]:text-foreground`,
+      destructive: `[&_svg]:bg-destructive [&_svg]:text-white`,
     },
   },
 })
@@ -72,8 +62,8 @@ const admonitionBase = cva('', {
   variants: {
     type: {
       default: `bg-surface-200/25 border`,
-      warning: `bg-alternative ![&_p]:text-background-muted border`,
-      destructive: `bg-surface-300 border`,
+      warning: `bg-alternative border border-default ![&_p]:text-background-muted border`,
+      destructive: `bg-alternative border border-default`,
     },
   },
 })
@@ -92,7 +82,7 @@ export const Admonition = ({
         admonitionSVG({ type: typeMapped }),
         admonitionBase({ type: typeMapped })
       )}
-      variant={'default'}
+      variant={typeMapped}
     >
       {typeMapped === 'warning' || typeMapped === 'destructive' ? <WarningIcon /> : <InfoIcon />}
       {label ? (

--- a/packages/ui/src/components/Admonition/index.tsx
+++ b/packages/ui/src/components/Admonition/index.tsx
@@ -1,6 +1,7 @@
+import { cn } from '@ui/lib/utils'
+import { cva } from 'class-variance-authority'
 import { PropsWithChildren } from 'react'
-import { AlertVariant } from '../Alert'
-import { AlertDescription, AlertTitle, Alert } from './../shadcn/ui/alert'
+import { Alert, AlertDescription, AlertTitle } from './../shadcn/ui/alert'
 export interface AdmonitionProps {
   type: 'note' | 'tip' | 'caution' | 'danger' | 'deprecation'
   label?: string
@@ -28,7 +29,6 @@ const InfoIcon = () => (
       fill-rule="evenodd"
       clip-rule="evenodd"
       d="M0.625 9.8252C0.625 4.44043 4.99023 0.0751953 10.375 0.0751953C15.7598 0.0751953 20.125 4.44043 20.125 9.8252C20.125 15.21 15.7598 19.5752 10.375 19.5752C4.99023 19.5752 0.625 15.21 0.625 9.8252ZM9.3584 4.38135C9.45117 4.28857 9.55518 4.20996 9.66699 4.14648C9.88086 4.02539 10.1245 3.96045 10.375 3.96045C10.5845 3.96045 10.7896 4.00586 10.9766 4.09229C11.1294 4.1626 11.2705 4.26025 11.3916 4.38135C11.6611 4.65088 11.8125 5.0166 11.8125 5.39795C11.8125 5.5249 11.7959 5.6499 11.7637 5.77002C11.6987 6.01172 11.5718 6.23438 11.3916 6.41455C11.1221 6.68408 10.7563 6.83545 10.375 6.83545C9.99365 6.83545 9.62793 6.68408 9.3584 6.41455C9.08887 6.14502 8.9375 5.7793 8.9375 5.39795C8.9375 5.29492 8.94873 5.19287 8.97021 5.09375C9.02783 4.82568 9.16162 4.57812 9.3584 4.38135ZM10.375 15.6899C10.0933 15.6899 9.82275 15.5781 9.62354 15.3789C9.42432 15.1797 9.3125 14.9092 9.3125 14.6274V9.31494C9.3125 9.0332 9.42432 8.7627 9.62354 8.56348C9.82275 8.36426 10.0933 8.25244 10.375 8.25244C10.6567 8.25244 10.9272 8.36426 11.1265 8.56348C11.3257 8.7627 11.4375 9.0332 11.4375 9.31494V14.6274C11.4375 14.7944 11.3979 14.9575 11.3242 15.104C11.2739 15.2046 11.2075 15.2979 11.1265 15.3789C10.9272 15.5781 10.6567 15.6899 10.375 15.6899Z"
-      fill="black"
     />
   </svg>
 )
@@ -48,25 +48,70 @@ const WarningIcon = () => (
   </svg>
 )
 
+const admonitionTypeLabelVariants = cva('uppercase font-mono inline px-2 py-0.5 border rounded', {
+  variants: {
+    type: {
+      default: `bg-surface-100 text-foreground`,
+      warning: `bg-surface-100 text-foreground`,
+      destructive: `bg-surface-100 text-foreground`,
+    },
+  },
+})
+
+const admonitionSVG = cva('', {
+  variants: {
+    type: {
+      default: `[&_svg]:bg-foreground-muted [&_svg]:text-background-muted`,
+      warning: `[&_svg]:bg-warning [&_svg]:text-warning-100`,
+      destructive: `[&_svg]:bg-surface-100 [&_svg]:text-foreground`,
+    },
+  },
+})
+
+const admonitionBase = cva('', {
+  variants: {
+    type: {
+      default: `bg-surface-200/25 border`,
+      warning: `bg-alternative ![&_p]:text-background-muted border`,
+      destructive: `bg-surface-300 border`,
+    },
+  },
+})
+
 export const Admonition = ({
   type = 'note',
   label,
   children,
 }: PropsWithChildren<AdmonitionProps>) => {
-  const variant = admonitionToAlertMapping[type]
+  const typeMapped = admonitionToAlertMapping[type]
 
   return (
-    <Alert className="not-prose mb-2" variant={variant}>
-      {variant === 'warning' || variant === 'destructive' ? <WarningIcon /> : <InfoIcon />}
-
-      <AlertTitle className="text mt-1">
-        <span className="flex gap-2">
-          <span className="uppercase">{`${type}${label ? ':' : ''}`}</span>
-          {label}
-        </span>
-      </AlertTitle>
-
-      <AlertDescription>{children}</AlertDescription>
+    <Alert
+      className={cn(
+        'mb-2',
+        admonitionSVG({ type: typeMapped }),
+        admonitionBase({ type: typeMapped })
+      )}
+      variant={'default'}
+    >
+      {typeMapped === 'warning' || typeMapped === 'destructive' ? <WarningIcon /> : <InfoIcon />}
+      {label ? (
+        <>
+          <AlertTitle
+            className={cn(
+              'text mt-0.5 flex gap-3 items-center text-sm [&_p]:mb-1.5 [&_p]:mt-0',
+              !label && 'flex-col'
+            )}
+          >
+            {label}
+          </AlertTitle>
+          {children && (
+            <AlertDescription className="mt-3 [&_p]:mb-1.5 [&_p]:mt-0">{children}</AlertDescription>
+          )}
+        </>
+      ) : (
+        <div className="text mt [&_p]:mb-1.5 [&_p]:mt-0 mt-0.5 [&_p]:last:mb-0">{children}</div>
+      )}
     </Alert>
   )
 }

--- a/packages/ui/src/components/Admonition/index.tsx
+++ b/packages/ui/src/components/Admonition/index.tsx
@@ -62,7 +62,7 @@ const admonitionBase = cva('', {
   variants: {
     type: {
       default: `bg-surface-200/25 border`,
-      warning: `bg-alternative border border-default ![&_p]:text-background-muted border`,
+      warning: `bg-alternative border border-default ![&_p]:text-background-muted`,
       destructive: `bg-alternative border border-default`,
     },
   },

--- a/packages/ui/src/components/shadcn/ui/alert.tsx
+++ b/packages/ui/src/components/shadcn/ui/alert.tsx
@@ -35,9 +35,7 @@ const Alert = React.forwardRef<
 Alert.displayName = 'Alert'
 
 const AlertTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(
-  ({ className, ...props }, ref) => (
-    <h5 ref={ref} className={cn('mb-1 leading-none tracking-tight', className)} {...props} />
-  )
+  ({ className, ...props }, ref) => <h5 ref={ref} className={cn('mb-1', className)} {...props} />
 )
 AlertTitle.displayName = 'AlertTitle'
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

mute/tone down the Admonition a bit in docs.

warning and destructive Admonition have more pronounced background

Bug fix, feature, docs update, ...
<img width="1372" alt="Screenshot 2023-12-04 at 6 53 18 PM" src="https://github.com/supabase/supabase/assets/8291514/478e76a0-dca1-426c-85bf-bfd21b9e5ff7">
<img width="1546" alt="Screenshot 2023-12-04 at 6 53 13 PM" src="https://github.com/supabase/supabase/assets/8291514/872649e3-f9bc-4d98-94a0-802528eab48e">
<img width="1408" alt="Screenshot 2023-12-04 at 6 53 08 PM" src="https://github.com/supabase/supabase/assets/8291514/6852818b-daeb-4576-a21c-3ff2ebda097e">
<img width="1391" alt="Screenshot 2023-12-04 at 6 52 31 PM" src="https://github.com/supabase/supabase/assets/8291514/35de9ba8-9589-433f-bf40-ea19b3093881">


## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
