### PR TITLE
feat: project breakdown for subscription preview

### DIFF
--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
@@ -103,7 +103,7 @@ const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
                   </td>
                   {!item.proration && (
                     <td className="py-2 text-sm text-right pr-4">
-                      {item.quantity.toLocaleString()}
+                      {item.quantity?.toLocaleString()}
                     </td>
                   )}
                   {!item.proration && (

--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
@@ -102,7 +102,7 @@ const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
                     {item.description ?? 'Unknown'}
                   </td>
                   {!item.proration && (
-                    <td className="py-2 text-sm text-right pr-4">{item.quantity}</td>
+                    <td className="py-2 text-sm text-right pr-4">{item.quantity.toLocaleString()}</td>
                   )}
                   {!item.proration && (
                     <td className="py-2 text-sm">

--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
@@ -102,7 +102,9 @@ const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
                     {item.description ?? 'Unknown'}
                   </td>
                   {!item.proration && (
-                    <td className="py-2 text-sm text-right pr-4">{item.quantity.toLocaleString()}</td>
+                    <td className="py-2 text-sm text-right pr-4">
+                      {item.quantity.toLocaleString()}
+                    </td>
                   )}
                   {!item.proration && (
                     <td className="py-2 text-sm">

--- a/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/PlanUpdateSidePanel.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/PlanUpdateSidePanel.tsx
@@ -389,7 +389,7 @@ const PlanUpdateSidePanel = () => {
                             {item.description.endsWith('Compute') && ` (Hours)`}
                           </Table.td>
                           <Table.td className="text-right pr-4 tabular-nums">
-                            {item.quantity}
+                            {item.quantity.toLocaleString()}
                           </Table.td>
                           <Table.td>
                             {item.unit_price_desc
@@ -450,8 +450,8 @@ const PlanUpdateSidePanel = () => {
                     <p className="text-sm mt-2">
                       Each project is a dedicated server and database. Paid plans come with $10 of
                       Compute Credits to cover one project on the default Starter Compute size or
-                      parts of any compute addon. Additional unpaused projects on paid plans at
-                      least incur compute usage costs starting at $10 per month, billed hourly.
+                      parts of any compute addon. Additional unpaused projects on paid plans will
+                      incur compute usage costs starting at $10 per month, billed hourly.
                     </p>
 
                     {subscription?.plan?.id === 'free' && (
@@ -483,7 +483,7 @@ const PlanUpdateSidePanel = () => {
                             target="_blank"
                             rel="noreferrer"
                           >
-                            Project Transfers
+                            Project transfers
                           </Link>
                         </Button>
                       )}

--- a/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/PlanUpdateSidePanel.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/PlanUpdateSidePanel.tsx
@@ -6,7 +6,6 @@ import { useEffect, useState } from 'react'
 
 import Table from 'components/to-be-cleaned/Table'
 import AlertError from 'components/ui/AlertError'
-import InformationBox from 'components/ui/InformationBox'
 import ShimmeringLoader from 'components/ui/ShimmeringLoader'
 import { useFreeProjectLimitCheckQuery } from 'data/organizations/free-project-limit-check-query'
 import { useOrganizationBillingSubscriptionPreview } from 'data/organizations/organization-billing-subscription-preview'
@@ -20,12 +19,21 @@ import Telemetry from 'lib/telemetry'
 import { useRouter } from 'next/router'
 import { plans as subscriptionsPlans } from 'shared-data/plans'
 import { useOrgSettingsPageStateSnapshot } from 'state/organization-settings'
-import { Button, IconCheck, IconExternalLink, Modal, SidePanel } from 'ui'
+import {
+  Button,
+  IconCheck,
+  IconChevronRight,
+  IconExternalLink,
+  IconInfo,
+  Modal,
+  SidePanel,
+} from 'ui'
 import DowngradeModal from './DowngradeModal'
 import EnterpriseCard from './EnterpriseCard'
 import ExitSurveyModal from './ExitSurveyModal'
 import MembersExceedLimitModal from './MembersExceedLimitModal'
 import PaymentMethodSelection from './PaymentMethodSelection'
+import InformationBox from 'components/ui/InformationBox'
 
 // [Joshen TODO] Need to remove all contexts of "projects"
 
@@ -39,6 +47,7 @@ const PlanUpdateSidePanel = () => {
   const [selectedPaymentMethod, setSelectedPaymentMethod] = useState<string>()
   const [showDowngradeError, setShowDowngradeError] = useState(false)
   const [selectedTier, setSelectedTier] = useState<'tier_free' | 'tier_pro' | 'tier_team'>()
+  const [usageFeesExpanded, setUsageFeesExpanded] = useState<string[]>([])
 
   const canUpdateSubscription = useCheckPermissions(
     PermissionAction.BILLING_WRITE,
@@ -86,6 +95,14 @@ const PlanUpdateSidePanel = () => {
   const availablePlans = plans ?? []
   const hasMembersExceedingFreeTierLimit = (membersExceededLimit || []).length > 0
   const subscriptionPlanMeta = subscriptionsPlans.find((tier) => tier.id === selectedTier)
+
+  const expandUsageFee = (fee: string) => {
+    setUsageFeesExpanded([...usageFeesExpanded, fee])
+  }
+
+  const collapseUsageFee = (fee: string) => {
+    setUsageFeesExpanded(usageFeesExpanded.filter((item) => item !== fee))
+  }
 
   useEffect(() => {
     if (visible) {
@@ -304,7 +321,7 @@ const PlanUpdateSidePanel = () => {
       <Modal
         loading={isUpdating}
         alignFooter="right"
-        size="large"
+        size="xlarge"
         visible={selectedTier !== undefined && selectedTier !== 'tier_free'}
         onCancel={() => setSelectedTier(undefined)}
         onConfirm={onUpdateSubscription}
@@ -321,73 +338,159 @@ const PlanUpdateSidePanel = () => {
             />
           )}
           {subscriptionPreviewIsLoading && (
-            <span className="text-sm">Estimating monthly costs...</span>
+            <div className="space-y-2">
+              <span className="text-sm">Estimating monthly costs...</span>
+              <ShimmeringLoader />
+              <ShimmeringLoader className="w-3/4" />
+              <ShimmeringLoader className="w-1/2" />
+            </div>
           )}
           {subscriptionPreviewInitialized && (
             <div>
-              <InformationBox
-                defaultVisibility={false}
-                title={
-                  <span>
-                    Estimated monthly price is $
-                    {Math.round(
-                      subscriptionPreview.breakdown.reduce((prev, cur) => prev + cur.total_price, 0)
-                    )}{' '}
-                    + usage
-                  </span>
-                }
-                hideCollapse={false}
-                description={
-                  <Table
-                    borderless={true}
-                    head={[
-                      <Table.th key="header-item">Item</Table.th>,
-                      <Table.th key="header-count">Count</Table.th>,
-                      <Table.th key="header-unit-price">Unit Price</Table.th>,
-                      <Table.th key="header-price" className="text-right">
-                        Price
-                      </Table.th>,
-                    ]}
-                    body={
+              <Table
+                className="mt-2"
+                borderless={true}
+                head={[
+                  <Table.th key="header-item">Item</Table.th>,
+                  <Table.th key="header-count" className="text-right pr-4">
+                    Usage
+                  </Table.th>,
+                  <Table.th key="header-unit-price">Unit Price</Table.th>,
+                  <Table.th key="header-price" className="text-right">
+                    Cost
+                  </Table.th>,
+                ]}
+                body={
+                  <>
+                    {subscriptionPreview.breakdown.map((item) => (
                       <>
-                        {subscriptionPreview.breakdown.map((item) => (
-                          <Table.tr key={item.description}>
-                            <Table.td>{item.description ?? 'Unknown'}</Table.td>
-                            <Table.td>{item.quantity}</Table.td>
-                            <Table.td>
-                              {item.unit_price === 0 ? 'FREE' : `$${item.unit_price}`}
-                            </Table.td>
-                            <Table.td className="text-right">${item.total_price}</Table.td>
-                          </Table.tr>
-                        ))}
-
-                        <Table.tr>
-                          <Table.td>Total</Table.td>
-                          <Table.td />
-                          <Table.td />
-                          <Table.td className=" text-right">
-                            $
-                            {Math.round(
-                              subscriptionPreview.breakdown.reduce(
-                                (prev, cur) => prev + cur.total_price,
-                                0
-                              )
-                            ) ?? 0}
+                        <Table.tr key={item.description}>
+                          <Table.td>
+                            {item.breakdown && item.breakdown.length > 0 && (
+                              <Button
+                                type="text"
+                                className="!pl-0 !pr-1"
+                                icon={
+                                  <IconChevronRight
+                                    className={clsx(
+                                      'transition',
+                                      usageFeesExpanded.includes(item.description) && 'rotate-90'
+                                    )}
+                                  />
+                                }
+                                onClick={() =>
+                                  usageFeesExpanded.includes(item.description)
+                                    ? collapseUsageFee(item.description)
+                                    : expandUsageFee(item.description)
+                                }
+                              />
+                            )}
+                            {item.description ?? 'Unknown'}{' '}
+                            {item.description.endsWith('Compute') && ` (Hours)`}
                           </Table.td>
+                          <Table.td className="text-right pr-4 tabular-nums">
+                            {item.quantity}
+                          </Table.td>
+                          <Table.td>
+                            {item.unit_price_desc
+                              ? item.unit_price_desc
+                              : item.unit_price === 0
+                              ? 'FREE'
+                              : item.unit_price
+                              ? `$${item.unit_price}`
+                              : ''}
+                          </Table.td>
+                          <Table.td className="text-right">${item.total_price}</Table.td>
                         </Table.tr>
+
+                        {usageFeesExpanded.includes(item.description) &&
+                          item.breakdown &&
+                          item.breakdown.length > 0 &&
+                          item.breakdown.map((project) => (
+                            <Table.tr key={project.project_ref}>
+                              <Table.td className="!pl-12">{project.project_name}</Table.td>
+                              <Table.td className="text-right pr-4 tabular-nums">
+                                {project.usage}
+                              </Table.td>
+                              <Table.td />
+                              <Table.td />
+                            </Table.tr>
+                          ))}
                       </>
-                    }
-                  ></Table>
+                    ))}
+
+                    <Table.tr>
+                      <Table.td className="font-medium">
+                        Monthly Costs (excluding over-usage and credits)
+                      </Table.td>
+                      <Table.td />
+                      <Table.td />
+                      <Table.td className="text-right font-medium">
+                        $
+                        {Math.round(
+                          subscriptionPreview.breakdown.reduce(
+                            (prev, cur) => prev + cur.total_price,
+                            0
+                          )
+                        ) ?? 0}
+                      </Table.td>
+                    </Table.tr>
+                  </>
+                }
+              ></Table>
+
+              <InformationBox
+                className="mt-4"
+                title="Usage-billing for Compute"
+                icon={<IconInfo />}
+                defaultVisibility={true}
+                hideCollapse={true}
+                description={
+                  <div>
+                    <p className="text-sm mt-2">
+                      Each project is a dedicated server and database. Paid plans come with $10 of
+                      Compute Credits to cover one project on the default Starter Compute size or
+                      parts of any compute addon. Additional unpaused projects on paid plans at
+                      least incur compute usage costs starting at $10 per month, billed hourly.
+                    </p>
+
+                    {subscription?.plan?.id === 'free' && (
+                      <p className="text-sm mt-2">
+                        Mixing paid and non-paid projects in a single organization is not possible.
+                        If you want projects to be on the free plan, use self-serve project
+                        transfers.
+                      </p>
+                    )}
+
+                    <div className="space-x-3 mt-2">
+                      <Button asChild type="default" icon={<IconExternalLink strokeWidth={1.5} />}>
+                        <Link
+                          href="https://supabase.com/docs/guides/platform/org-based-billing"
+                          target="_blank"
+                          rel="noreferrer"
+                        >
+                          How billing works
+                        </Link>
+                      </Button>
+                      {subscription?.plan?.id === 'free' && (
+                        <Button
+                          asChild
+                          type="default"
+                          icon={<IconExternalLink strokeWidth={1.5} />}
+                        >
+                          <Link
+                            href="https://supabase.com/docs/guides/platform/project-transfer"
+                            target="_blank"
+                            rel="noreferrer"
+                          >
+                            Project Transfers
+                          </Link>
+                        </Button>
+                      )}
+                    </div>
+                  </div>
                 }
               />
-
-              {subscriptionPreview.number_of_projects !== undefined &&
-                subscriptionPreview.number_of_projects > 1 && (
-                  <p className="text-sm mt-2">
-                    All {subscriptionPreview.number_of_projects} projects from your organization "
-                    {selectedOrganization?.name}" will use the new {planMeta?.name} plan.
-                  </p>
-                )}
             </div>
           )}
         </Modal.Content>

--- a/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/PlanUpdateSidePanel.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/PlanUpdateSidePanel.tsx
@@ -389,7 +389,7 @@ const PlanUpdateSidePanel = () => {
                             {item.description.endsWith('Compute') && ` (Hours)`}
                           </Table.td>
                           <Table.td className="text-right pr-4 tabular-nums">
-                            {item.quantity.toLocaleString()}
+                            {item.quantity?.toLocaleString()}
                           </Table.td>
                           <Table.td>
                             {item.unit_price_desc

--- a/apps/studio/data/invoices/org-invoice-upcoming-query.ts
+++ b/apps/studio/data/invoices/org-invoice-upcoming-query.ts
@@ -20,7 +20,7 @@ export type UpcomingInvoiceResponse = {
     description: string
     proration: boolean
     period: { start: string; end: string }
-    quantity: number
+    quantity?: number
     unit_price: number
     unit_price_desc: string
     usage_based: boolean

--- a/apps/studio/data/organizations/organization-billing-subscription-preview.ts
+++ b/apps/studio/data/organizations/organization-billing-subscription-preview.ts
@@ -14,7 +14,7 @@ export type OrganizationBillingSubscriptionPreviewResponse = {
     description: string
     unit_price: number
     unit_price_desc?: string
-    quantity: number
+    quantity?: number
     total_price: number
     breakdown: {
       project_name: string

--- a/apps/studio/data/organizations/organization-billing-subscription-preview.ts
+++ b/apps/studio/data/organizations/organization-billing-subscription-preview.ts
@@ -13,8 +13,14 @@ export type OrganizationBillingSubscriptionPreviewResponse = {
   breakdown: {
     description: string
     unit_price: number
+    unit_price_desc?: string
     quantity: number
     total_price: number
+    breakdown: {
+      project_name: string
+      project_ref: string
+      usage: number
+    }[]
   }[]
   number_of_projects?: number
   plan_change_type?: 'downgrade' | 'none' | 'upgrade'
@@ -50,6 +56,9 @@ export async function previewOrganizationBillingSubscription({
       params: { path: { slug: organizationSlug } },
       body: {
         tier,
+      },
+      headers: {
+        Version: '2',
       },
     }
   )


### PR DESCRIPTION
Improves the subscription preview/confirmation screen.

* Per-project breakdown
* Information about usage-billing for compute
* Educate about project transfers when upgrading from free to paid

![Screenshot 2023-12-04 at 15 30 19](https://github.com/supabase/supabase/assets/14073399/df76cecb-880f-4001-8ac2-58da39f282d9)

![Screenshot 2023-12-04 at 15 30 25](https://github.com/supabase/supabase/assets/14073399/9ebeba76-37ea-473c-8b79-bd02fbf1aff6)

![Screenshot 2023-12-04 at 15 31 02](https://github.com/supabase/supabase/assets/14073399/abea84b3-65f0-4b04-ac52-6aa537aa4c8e)

