### PR TITLE
Docs: Use HNSW index as default in AI guides

### DIFF
--- a/apps/docs/pages/guides/ai/examples/building-chatgpt-plugins.mdx
+++ b/apps/docs/pages/guides/ai/examples/building-chatgpt-plugins.mdx
@@ -121,7 +121,7 @@ The plugin will split your data and documents into smaller chunks automatically.
 
 ```sql
 create index on documents
-using ivfflat (embedding vector_ip_ops)
+using hnsw (embedding vector_ip_ops)
 with (lists = 10);
 ```
 


### PR DESCRIPTION
Specifically updates "Building ChatGPT Plugins" guide to use `hnsw` instead of `ivfflat`.