### PR TITLE
chore: adjust logic for new project screen

### DIFF
--- a/apps/studio/components/interfaces/Home/ProjectUsageSection.tsx
+++ b/apps/studio/components/interfaces/Home/ProjectUsageSection.tsx
@@ -42,7 +42,7 @@ const ProjectUsageSection = observer(() => {
   const hasProjectData =
     usage?.result && usage.result.length > 0 ? usage.result[0].count > 25 : false
 
-  const isNewProject = dayjs(project?.inserted_at).isAfter(dayjs().subtract(1, 'day'))
+  const isNewProject = dayjs(project?.inserted_at).isAfter(dayjs().subtract(2, 'day'))
 
   return (
     <>

--- a/apps/studio/components/interfaces/Home/ProjectUsageSection.tsx
+++ b/apps/studio/components/interfaces/Home/ProjectUsageSection.tsx
@@ -8,19 +8,22 @@ import InformationBox from 'components/ui/InformationBox'
 import { useProjectLogRequestsCountQuery } from 'data/analytics/project-log-requests-count-query'
 import { useProjectLogStatsQuery } from 'data/analytics/project-log-stats-query'
 import ProjectUsage from './ProjectUsage'
+import { useSelectedProject } from 'hooks'
+import dayjs from 'dayjs'
 
 const ProjectUsageSection = observer(() => {
-  const { ref: projectRef } = useParams()
+  const project = useSelectedProject()
+
   const {
     data: usage,
     error: usageError,
     isLoading,
-  } = useProjectLogRequestsCountQuery({ projectRef })
+  } = useProjectLogRequestsCountQuery({ projectRef: project?.ref })
 
   // wait for the stats to load before showing the usage section
   // to eliminate multiple spinners
   const { isLoading: isLogsStatsLoading } = useProjectLogStatsQuery({
-    projectRef,
+    projectRef: project?.ref,
     interval: 'hourly',
   })
 
@@ -35,14 +38,17 @@ const ProjectUsageSection = observer(() => {
     )
   }
 
+  // if the project has more than 25 requests, we assume the project has usage
   const hasProjectData =
-    usage?.result && usage.result.length > 0 ? usage.result[0].count > 0 : false
+    usage?.result && usage.result.length > 0 ? usage.result[0].count > 25 : false
+
+  const isNewProject = dayjs(project?.inserted_at).isAfter(dayjs().subtract(1, 'day'))
 
   return (
     <>
       {isLoading || isLogsStatsLoading ? (
         <ProjectUsageLoadingState />
-      ) : hasProjectData ? (
+      ) : hasProjectData && !isNewProject ? (
         <ProjectUsage />
       ) : (
         <NewProjectPanel />


### PR DESCRIPTION
While there are surely ways to avoid this whole usage vs no-usage situation, we need to make sure that customers launching new projects are absolutely guaranteed to see the new project screen with instructions first. We had people reach out that it was difficult to find the project keys etc - because they had 2 requests (maybe through dashboard) and we showed them the usage sections rather than the onboarding.

PR ensures we show customers the onboarding on the project dashboard if
* Project is no older than 48h
* Project has <25 requests in last week