### PR TITLE
fix syntax errors

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,8 +3,6 @@
 #   With helpers:   docker compose -f docker-compose.yml -f ./dev/docker-compose.dev.yml up
 #   Stop:           docker compose down
 #   Destroy:        docker compose -f docker-compose.yml -f ./dev/docker-compose.dev.yml down -v --remove-orphans
-
-name: supabase
 version: "3.8"
 services:
 
@@ -40,7 +38,7 @@ services:
 
       LOGFLARE_API_KEY: ${LOGFLARE_API_KEY}
       LOGFLARE_URL: http://analytics:4000
-      NEXT_PUBLIC_ENABLE_LOGS: true
+      NEXT_PUBLIC_ENABLE_LOGS: "true"
       # Comment to use Big Query backend for analytics
       NEXT_ANALYTICS_BACKEND_PROVIDER: postgres
       # Uncomment to use Big Query backend for analytics
@@ -321,8 +319,8 @@ services:
       DB_PASSWORD: ${POSTGRES_PASSWORD}
       DB_SCHEMA: _analytics
       LOGFLARE_API_KEY: ${LOGFLARE_API_KEY}
-      LOGFLARE_SINGLE_TENANT: true
-      LOGFLARE_SUPABASE_MODE: true
+      LOGFLARE_SINGLE_TENANT: "true"
+      LOGFLARE_SUPABASE_MODE: "true"
       LOGFLARE_MIN_CLUSTER_SIZE: 1
       RELEASE_COOKIE: cookie
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

fix syntax docker compose file errors

## What is the current behavior?

ERROR detail:

```
@vncloudsco ➜ /workspaces/supabase/docker (master) $ docker-compose up -d
ERROR: The Compose file './docker-compose.yml' is invalid because:
'name' does not match any of the regexes: '^x-'

You might be seeing this error because you're using the wrong Compose file version. Either specify a supported version (e.g "2.2" or "3.3") and place your service definitions under the `services` key, or omit the `version` key and place your service definitions at the root of the file to use version 1.
For more on the Compose file format versions, see https://docs.docker.com/compose/compose-file/
services.analytics.environment.LOGFLARE_SINGLE_TENANT contains true, which is an invalid type, it should be a string, number, or a null
services.studio.environment.NEXT_PUBLIC_ENABLE_LOGS contains true, which is an invalid type, it should be a string, number, or a null

```

## What is the new behavior?

fix syntax docker compose file errors

## Additional context


![image](https://github.com/supabase/supabase/assets/41409442/a9dfc6fa-de29-4862-8a1d-13849950aaae)

