### PR TITLE
chore: improve loading on table editor index page

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/InputWithSuggestions.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/InputWithSuggestions.tsx
@@ -95,8 +95,8 @@ const InputWithSuggestions = ({
         actions={
           showSuggestions && (
             <DropdownMenu>
-              <DropdownMenuTrigger>
-                <Tooltip.Root delayDuration={0}>
+              <Tooltip.Root delayDuration={0}>
+                <DropdownMenuTrigger asChild>
                   <Tooltip.Trigger asChild>
                     <Button
                       type="default"
@@ -104,23 +104,25 @@ const InputWithSuggestions = ({
                       icon={<IconList strokeWidth={1.5} />}
                     />
                   </Tooltip.Trigger>
-                  <Tooltip.Portal>
-                    <Tooltip.Content side="bottom">
-                      <Tooltip.Arrow className="radix-tooltip-arrow" />
-                      <div
-                        className={[
-                          'bg-alternative rounded py-1 px-2 leading-none shadow',
-                          'border-background border',
-                        ].join(' ')}
-                      >
-                        <span className="text-foreground text-xs">
-                          {suggestionsTooltip || 'Suggestions'}
-                        </span>
-                      </div>
-                    </Tooltip.Content>
-                  </Tooltip.Portal>
-                </Tooltip.Root>
-              </DropdownMenuTrigger>
+                </DropdownMenuTrigger>
+
+                <Tooltip.Portal>
+                  <Tooltip.Content side="bottom">
+                    <Tooltip.Arrow className="radix-tooltip-arrow" />
+                    <div
+                      className={[
+                        'bg-alternative rounded py-1 px-2 leading-none shadow',
+                        'border-background border',
+                      ].join(' ')}
+                    >
+                      <span className="text-foreground text-xs">
+                        {suggestionsTooltip || 'Suggestions'}
+                      </span>
+                    </div>
+                  </Tooltip.Content>
+                </Tooltip.Portal>
+              </Tooltip.Root>
+
               <DropdownMenuContent align="end" side="bottom">
                 <DropdownMenuLabel>{suggestionsHeader || 'Suggestions'}</DropdownMenuLabel>
                 <DropdownMenuSeparator />

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/Column.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/Column.tsx
@@ -1,5 +1,6 @@
 import * as Tooltip from '@radix-ui/react-tooltip'
 import type { PostgresType } from '@supabase/postgres-meta'
+
 import {
   Button,
   Checkbox,
@@ -11,7 +12,6 @@ import {
   Input,
   Popover,
 } from 'ui'
-
 import { FOREIGN_KEY_CASCADE_ACTION } from 'data/database/database-query-constants'
 import { noop } from 'lodash'
 import { typeExpressionSuggestions } from '../ColumnEditor/ColumnEditor.constants'
@@ -20,6 +20,7 @@ import { getForeignKeyCascadeAction } from '../ColumnEditor/ColumnEditor.utils'
 import ColumnType from '../ColumnEditor/ColumnType'
 import InputWithSuggestions from '../ColumnEditor/InputWithSuggestions'
 import { ColumnField } from '../SidePanelEditor.types'
+import { EMPTY_ARR, EMPTY_OBJ } from 'lib/void'
 
 /**
  * [Joshen] For context:
@@ -51,11 +52,11 @@ interface ColumnProps {
 }
 
 const Column = ({
-  column = {} as ColumnField,
-  enumTypes = [] as PostgresType[],
+  column = EMPTY_OBJ as ColumnField,
+  enumTypes = EMPTY_ARR as PostgresType[],
   isNewRecord = false,
   hasImportContent = false,
-  dragHandleProps = {},
+  dragHandleProps = EMPTY_OBJ,
   onEditRelation = noop,
   onUpdateColumn = noop,
   onRemoveColumn = noop,
@@ -93,7 +94,7 @@ const Column = ({
       </div>
       <div className="w-[5%] mr-2.5">
         <Tooltip.Root delayDuration={0}>
-          <Tooltip.Trigger>
+          <Tooltip.Trigger asChild>
             <Button
               type={column.foreignKey !== undefined ? 'secondary' : 'default'}
               onClick={() => onEditRelation(column)}

--- a/apps/studio/components/layouts/ProjectLayout/ProjectLayout.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/ProjectLayout.tsx
@@ -46,6 +46,7 @@ const routesToIgnorePostgrestConnection = [
 export interface ProjectLayoutProps {
   title?: string
   isLoading?: boolean
+  isBlocking?: boolean
   product?: string
   productMenu?: ReactNode
   hideHeader?: boolean
@@ -56,6 +57,7 @@ export interface ProjectLayoutProps {
 const ProjectLayout = ({
   title,
   isLoading = false,
+  isBlocking = true,
   product = '',
   productMenu,
   children,
@@ -99,7 +101,7 @@ const ProjectLayout = ({
           {!hideIconBar && <NavigationBar />}
           {/* Product menu bar */}
           {!showPausedState && (
-            <MenuBarWrapper isLoading={isLoading} productMenu={productMenu}>
+            <MenuBarWrapper isLoading={isLoading} isBlocking={isBlocking} productMenu={productMenu}>
               <ProductMenuBar title={product}>{productMenu}</ProductMenuBar>
             </MenuBarWrapper>
           )}
@@ -112,7 +114,7 @@ const ProjectLayout = ({
                 </div>
               </div>
             ) : (
-              <ContentWrapper isLoading={isLoading}>
+              <ContentWrapper isLoading={isLoading} isBlocking={isBlocking}>
                 <ResourceExhaustionWarningBanner />
                 {children}
               </ContentWrapper>
@@ -134,23 +136,34 @@ export default ProjectLayout
 
 interface MenuBarWrapperProps {
   isLoading: boolean
+  isBlocking?: boolean
   productMenu?: ReactNode
   children: ReactNode
 }
 
-const MenuBarWrapper = ({ isLoading, productMenu, children }: MenuBarWrapperProps) => {
+const MenuBarWrapper = ({
+  isLoading,
+  isBlocking = true,
+  productMenu,
+  children,
+}: MenuBarWrapperProps) => {
   const router = useRouter()
   const selectedProject = useSelectedProject()
   const requiresProjectDetails = !routesToIgnoreProjectDetailsRequest.includes(router.pathname)
 
+  if (!isBlocking) {
+    return children
+  }
+
   const showMenuBar =
     !requiresProjectDetails || (requiresProjectDetails && selectedProject !== undefined)
 
-  return <>{!isLoading && productMenu && showMenuBar ? children : null}</>
+  return !isLoading && productMenu && showMenuBar ? children : null
 }
 
 interface ContentWrapperProps {
   isLoading: boolean
+  isBlocking?: boolean
   children: ReactNode
 }
 
@@ -166,7 +179,7 @@ interface ContentWrapperProps {
  *
  * [TODO] Next iteration should scrape long polling and just listen to the project's status
  */
-const ContentWrapper = ({ isLoading, children }: ContentWrapperProps) => {
+const ContentWrapper = ({ isLoading, isBlocking = true, children }: ContentWrapperProps) => {
   const router = useRouter()
   const selectedProject = useSelectedProject()
 
@@ -188,92 +201,29 @@ const ContentWrapper = ({ isLoading, children }: ContentWrapperProps) => {
     selectedProject?.status === PROJECT_STATUS.PAUSING
   const isProjectOffline = selectedProject?.postgrestStatus === 'OFFLINE'
 
-  return (
-    <>
-      {isLoading || (requiresProjectDetails && selectedProject === undefined) ? (
-        router.pathname.endsWith('[ref]') ? (
-          <LoadingState />
-        ) : (
-          <Connecting />
-        )
-      ) : isProjectUpgrading ? (
-        <UpgradingState />
-      ) : isProjectPausing ? (
-        <PausingState project={selectedProject} />
-      ) : requiresPostgrestConnection && isProjectOffline ? (
-        <ConnectingState project={selectedProject} />
-      ) : requiresDbConnection && isProjectRestoring ? (
-        <RestoringState />
-      ) : requiresDbConnection && isProjectBuilding ? (
-        <BuildingState />
-      ) : (
-        <Fragment key={selectedProject?.ref}>{children}</Fragment>
-      )}
-    </>
-  )
-}
+  if (isBlocking && (isLoading || (requiresProjectDetails && selectedProject === undefined))) {
+    return router.pathname.endsWith('[ref]') ? <LoadingState /> : <Connecting />
+  }
 
-/**
- * Shows the children irregardless of whether the selected project has loaded or not
- * We'll eventually want to use this instead of the current ProjectLayout to prevent
- * a catch-all spinner on the dashboard
- */
-export const ProjectLayoutNonBlocking = ({
-  title,
-  product = '',
-  productMenu,
-  children,
-  hideHeader = false,
-  hideIconBar = false,
-}: PropsWithChildren<ProjectLayoutProps>) => {
-  const selectedProject = useSelectedProject()
-  const router = useRouter()
-  const { ref: projectRef } = useParams()
-  const isPaused = selectedProject?.status === PROJECT_STATUS.INACTIVE
-  const ignorePausedState =
-    router.pathname === '/project/[ref]' || router.pathname.includes('/project/[ref]/settings')
-  const showPausedState = isPaused && !ignorePausedState
+  if (isProjectUpgrading) {
+    return <UpgradingState />
+  }
 
-  const navLayoutV2 = useFlag('navigationLayoutV2')
+  if (isProjectPausing) {
+    return <PausingState project={selectedProject} />
+  }
 
-  return (
-    <AppLayout>
-      <ProjectContextProvider projectRef={projectRef}>
-        <Head>
-          <title>{title ? `${title} | Supabase` : 'Supabase'}</title>
-          <meta name="description" content="Supabase Studio" />
-          <link rel="icon" href="/favicon.ico" />
-        </Head>
-        <div className="flex h-full">
-          {/* Left-most navigation side bar to access products */}
-          {!hideIconBar && <NavigationBar />}
+  if (requiresPostgrestConnection && isProjectOffline) {
+    return <ConnectingState project={selectedProject} />
+  }
 
-          {/* Product menu bar */}
-          {productMenu && !showPausedState && (
-            <ProductMenuBar title={product}>{productMenu}</ProductMenuBar>
-          )}
+  if (requiresDbConnection && isProjectRestoring) {
+    return <RestoringState />
+  }
 
-          <main className="flex w-full flex-1 flex-col overflow-x-hidden">
-            {!navLayoutV2 && !hideHeader && IS_PLATFORM && <LayoutHeader />}
-            {showPausedState ? (
-              <div className="mx-auto my-16 w-full h-full max-w-7xl flex items-center">
-                <div className="w-full">
-                  <ProjectPausedState product={product} />
-                </div>
-              </div>
-            ) : (
-              <>
-                <ResourceExhaustionWarningBanner />
-                {children}
-              </>
-            )}
-          </main>
-        </div>
+  if (requiresDbConnection && isProjectBuilding) {
+    return <BuildingState />
+  }
 
-        <EnableBranchingModal />
-        <AISettingsModal />
-        <ProjectAPIDocs />
-      </ProjectContextProvider>
-    </AppLayout>
-  )
+  return <Fragment key={selectedProject?.ref}>{children}</Fragment>
 }

--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorLayout.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorLayout.tsx
@@ -1,6 +1,6 @@
-import { ReactNode, useMemo } from 'react'
 import { withAuth } from 'hooks'
-import { ProjectLayoutNonBlocking } from '../'
+import { ReactNode, useMemo } from 'react'
+import ProjectLayout from '../'
 import SQLEditorMenu from './SQLEditorMenu'
 
 export interface SQLEditorLayoutProps {
@@ -12,9 +12,14 @@ const SQLEditorLayout = ({ title, children }: SQLEditorLayoutProps) => {
   const productMenu = useMemo(() => <SQLEditorMenu key="sql-editor-menu" />, [])
 
   return (
-    <ProjectLayoutNonBlocking title={title || 'SQL'} product="SQL Editor" productMenu={productMenu}>
+    <ProjectLayout
+      title={title || 'SQL'}
+      product="SQL Editor"
+      productMenu={productMenu}
+      isBlocking={false}
+    >
       {children}
-    </ProjectLayoutNonBlocking>
+    </ProjectLayout>
   )
 }
 

--- a/apps/studio/components/layouts/TableEditorLayout/TableEditorLayout.tsx
+++ b/apps/studio/components/layouts/TableEditorLayout/TableEditorLayout.tsx
@@ -7,12 +7,7 @@ import { useCheckPermissions, usePermissionsLoaded, useStore } from 'hooks'
 import { ProjectLayoutWithAuth } from '../'
 import TableEditorMenu from './TableEditorMenu'
 
-const TableEditorLayout = ({
-  children,
-  isBlocking = true,
-}: PropsWithChildren<{
-  isBlocking?: boolean
-}>) => {
+const TableEditorLayout = ({ children }: PropsWithChildren<{}>) => {
   const { vault, meta, ui } = useStore()
 
   const canReadTables = useCheckPermissions(PermissionAction.TENANT_SQL_ADMIN_READ, 'tables')
@@ -41,18 +36,14 @@ const TableEditorLayout = ({
   if (isPermissionsLoaded && !canReadTables) {
     debugger
     return (
-      <ProjectLayoutWithAuth isBlocking={isBlocking}>
+      <ProjectLayoutWithAuth isBlocking={false}>
         <NoPermission isFullPage resourceText="view tables from this project" />
       </ProjectLayoutWithAuth>
     )
   }
 
   return (
-    <ProjectLayoutWithAuth
-      product="Table Editor"
-      productMenu={tableEditorMenu}
-      isBlocking={isBlocking}
-    >
+    <ProjectLayoutWithAuth product="Table Editor" productMenu={tableEditorMenu} isBlocking={false}>
       {children}
     </ProjectLayoutWithAuth>
   )

--- a/apps/studio/components/layouts/TableEditorLayout/TableEditorLayout.tsx
+++ b/apps/studio/components/layouts/TableEditorLayout/TableEditorLayout.tsx
@@ -1,16 +1,22 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { observer } from 'mobx-react-lite'
-import { PropsWithChildren, useEffect } from 'react'
+import { PropsWithChildren, useEffect, useMemo } from 'react'
 
 import NoPermission from 'components/ui/NoPermission'
-import { useCheckPermissions, useStore } from 'hooks'
+import { useCheckPermissions, usePermissionsLoaded, useStore } from 'hooks'
 import { ProjectLayoutWithAuth } from '../'
 import TableEditorMenu from './TableEditorMenu'
 
-const TableEditorLayout = ({ children }: PropsWithChildren<{}>) => {
+const TableEditorLayout = ({
+  children,
+  isBlocking = true,
+}: PropsWithChildren<{
+  isBlocking?: boolean
+}>) => {
   const { vault, meta, ui } = useStore()
 
   const canReadTables = useCheckPermissions(PermissionAction.TENANT_SQL_ADMIN_READ, 'tables')
+  const isPermissionsLoaded = usePermissionsLoaded()
 
   const vaultExtension = meta.extensions.byId('supabase_vault')
   const isVaultEnabled = vaultExtension !== undefined && vaultExtension.installed_version !== null
@@ -30,16 +36,23 @@ const TableEditorLayout = ({ children }: PropsWithChildren<{}>) => {
     }
   }, [ui.selectedProjectRef, isVaultEnabled])
 
-  if (!canReadTables) {
+  const tableEditorMenu = useMemo(() => <TableEditorMenu />, [])
+
+  if (isPermissionsLoaded && !canReadTables) {
+    debugger
     return (
-      <ProjectLayoutWithAuth>
+      <ProjectLayoutWithAuth isBlocking={isBlocking}>
         <NoPermission isFullPage resourceText="view tables from this project" />
       </ProjectLayoutWithAuth>
     )
   }
 
   return (
-    <ProjectLayoutWithAuth product="Table Editor" productMenu={<TableEditorMenu />}>
+    <ProjectLayoutWithAuth
+      product="Table Editor"
+      productMenu={tableEditorMenu}
+      isBlocking={isBlocking}
+    >
       {children}
     </ProjectLayoutWithAuth>
   )

--- a/apps/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
+++ b/apps/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
@@ -3,6 +3,17 @@ import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { useParams } from 'common'
 import { partition } from 'lodash'
 import { useMemo, useState } from 'react'
+
+import { ProtectedSchemaModal } from 'components/interfaces/Database/ProtectedSchemaWarning'
+import AlertError from 'components/ui/AlertError'
+import InfiniteList from 'components/ui/InfiniteList'
+import SchemaSelector from 'components/ui/SchemaSelector'
+import ShimmeringLoader from 'components/ui/ShimmeringLoader'
+import { useSchemasQuery } from 'data/database/schemas-query'
+import { useEntityTypesQuery } from 'data/entity-types/entity-types-infinite-query'
+import { useCheckPermissions, useLocalStorage } from 'hooks'
+import { EXCLUDED_SCHEMAS } from 'lib/constants/schemas'
+import { useTableEditorStateSnapshot } from 'state/table-editor'
 import {
   AlertDescription_Shadcn_,
   AlertTitle_Shadcn_,
@@ -20,17 +31,7 @@ import {
   IconSearch,
   IconX,
   Input,
-  Menu,
 } from 'ui'
-
-import { ProtectedSchemaModal } from 'components/interfaces/Database/ProtectedSchemaWarning'
-import InfiniteList from 'components/ui/InfiniteList'
-import SchemaSelector from 'components/ui/SchemaSelector'
-import { useSchemasQuery } from 'data/database/schemas-query'
-import { useEntityTypesQuery } from 'data/entity-types/entity-types-infinite-query'
-import { useCheckPermissions, useLocalStorage } from 'hooks'
-import { EXCLUDED_SCHEMAS } from 'lib/constants/schemas'
-import { useTableEditorStateSnapshot } from 'state/table-editor'
 import { useProjectContext } from '../ProjectLayout/ProjectContext'
 import EntityListItem from './EntityListItem'
 
@@ -49,6 +50,9 @@ const TableEditorMenu = () => {
   const {
     data,
     isLoading,
+    isSuccess,
+    isError,
+    error,
     refetch,
     isRefetching,
     hasNextPage,
@@ -193,113 +197,113 @@ const TableEditorMenu = () => {
           </div>
         </div>
 
-        {isLoading ? (
-          <div className="mx-4 flex items-center space-x-2">
-            <IconLoader className="animate-spin" size={14} strokeWidth={1.5} />
-            <p className="text-sm text-foreground-light">Loading entities...</p>
-          </div>
-        ) : searchText.length === 0 && (entityTypes?.length ?? 0) === 0 ? (
-          <div className="mx-4 space-y-1 rounded-md border border-muted bg-surface-100 py-3 px-4">
-            <p className="text-xs">No entities available</p>
-            <p className="text-xs text-foreground-light">
-              This schema has no entities available yet
-            </p>
-          </div>
-        ) : searchText.length > 0 && (entityTypes?.length ?? 0) === 0 ? (
-          <div className="mx-4 space-y-1 rounded-md border border-muted bg-surface-100 py-3 px-4">
-            <p className="text-xs">No results found</p>
-            <p className="text-xs text-foreground-light">
-              There are no entities that match your search
-            </p>
-          </div>
-        ) : (
-          <Menu
-            type="pills"
-            className="flex flex-auto px-2 space-y-6 pb-4"
-            ulClassName="flex flex-auto flex-col"
-          >
-            <Menu.Group
-              // @ts-ignore
-              title={
-                <>
-                  <div className="flex w-full items-center justify-between">
-                    <div className="flex items-center space-x-1">
-                      <p>Tables</p>
-                      {totalCount !== undefined && (
-                        <p style={{ fontVariantNumeric: 'tabular-nums' }}>({totalCount})</p>
-                      )}
-                    </div>
-
-                    <div className="flex gap-3 items-center">
-                      <DropdownMenu>
-                        <DropdownMenuTrigger>
-                          <Tooltip.Root delayDuration={0}>
-                            <Tooltip.Trigger asChild>
-                              <div className="text-foreground-lighter transition-colors hover:text-foreground">
-                                <IconChevronsDown size={18} strokeWidth={1} />
-                              </div>
-                            </Tooltip.Trigger>
-                            <Tooltip.Portal>
-                              <Tooltip.Content side="bottom">
-                                <Tooltip.Arrow className="radix-tooltip-arrow" />
-                                <div
-                                  className={[
-                                    'rounded bg-alternative py-1 px-2 leading-none shadow',
-                                    'border border-background',
-                                  ].join(' ')}
-                                >
-                                  <span className="text-xs">Sort By</span>
-                                </div>
-                              </Tooltip.Content>
-                            </Tooltip.Portal>
-                          </Tooltip.Root>
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent side="bottom" align="start" className="w-48">
-                          <DropdownMenuRadioGroup
-                            value={sort}
-                            onValueChange={(value: any) => setSort(value)}
-                          >
-                            <DropdownMenuRadioItem key="alphabetical" value="alphabetical">
-                              Alphabetical
-                            </DropdownMenuRadioItem>
-                            <DropdownMenuRadioItem
-                              key="grouped-alphabetical"
-                              value="grouped-alphabetical"
-                            >
-                              Entity Type
-                            </DropdownMenuRadioItem>
-                          </DropdownMenuRadioGroup>
-                        </DropdownMenuContent>
-                      </DropdownMenu>
-
-                      <button
-                        className="cursor-pointer text-foreground-lighter transition-colors hover:text-foreground"
-                        onClick={refreshTables}
-                      >
-                        <IconRefreshCw className={isRefetching ? 'animate-spin' : ''} size={14} />
-                      </button>
-                    </div>
-                  </div>
-                </>
-              }
-            />
-
-            <div className="flex flex-1">
-              <InfiniteList
-                items={entityTypes}
-                ItemComponent={EntityListItem}
-                itemProps={{
-                  projectRef: project?.ref,
-                  id: Number(id),
-                }}
-                getItemSize={() => 28}
-                hasNextPage={hasNextPage}
-                isLoadingNextPage={isFetchingNextPage}
-                onLoadNextPage={() => fetchNextPage()}
-              />
+        <nav className="flex flex-auto flex-col gap-2 pb-4 px-2">
+          <div className="flex items-center justify-between w-full px-3">
+            <div className="flex items-center gap-1 text-sm text-foreground-lighter">
+              <p>Tables</p>
+              {totalCount !== undefined && (
+                <p style={{ fontVariantNumeric: 'tabular-nums' }}>({totalCount})</p>
+              )}
             </div>
-          </Menu>
-        )}
+
+            <div className="flex gap-3 items-center">
+              <DropdownMenu>
+                <DropdownMenuTrigger>
+                  <Tooltip.Root delayDuration={0}>
+                    <Tooltip.Trigger asChild>
+                      <div className="text-foreground-lighter transition-colors hover:text-foreground">
+                        <IconChevronsDown size={18} strokeWidth={1} />
+                      </div>
+                    </Tooltip.Trigger>
+                    <Tooltip.Portal>
+                      <Tooltip.Content side="bottom">
+                        <Tooltip.Arrow className="radix-tooltip-arrow" />
+                        <div
+                          className={[
+                            'rounded bg-alternative py-1 px-2 leading-none shadow',
+                            'border border-background',
+                          ].join(' ')}
+                        >
+                          <span className="text-xs">Sort By</span>
+                        </div>
+                      </Tooltip.Content>
+                    </Tooltip.Portal>
+                  </Tooltip.Root>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent side="bottom" align="start" className="w-48">
+                  <DropdownMenuRadioGroup
+                    value={sort}
+                    onValueChange={(value: any) => setSort(value)}
+                  >
+                    <DropdownMenuRadioItem key="alphabetical" value="alphabetical">
+                      Alphabetical
+                    </DropdownMenuRadioItem>
+                    <DropdownMenuRadioItem key="grouped-alphabetical" value="grouped-alphabetical">
+                      Entity Type
+                    </DropdownMenuRadioItem>
+                  </DropdownMenuRadioGroup>
+                </DropdownMenuContent>
+              </DropdownMenu>
+
+              <button
+                className="cursor-pointer text-foreground-lighter transition-colors hover:text-foreground"
+                onClick={refreshTables}
+              >
+                <IconRefreshCw className={isRefetching ? 'animate-spin' : ''} size={14} />
+              </button>
+            </div>
+          </div>
+
+          {isLoading && (
+            <div className="flex flex-col px-2 gap-1 pb-4">
+              <ShimmeringLoader className="w-full h-7 rounded-md" delayIndex={0} />
+              <ShimmeringLoader className="w-full h-7 rounded-md" delayIndex={1} />
+              <ShimmeringLoader className="w-full h-7 rounded-md" delayIndex={2} />
+            </div>
+          )}
+
+          {isError && (
+            <AlertError error={(error ?? null) as any} subject="Failed to retrieve tables" />
+          )}
+
+          {isSuccess && (
+            <>
+              {searchText.length === 0 && (entityTypes?.length ?? 0) <= 0 && (
+                <div className="mx-4 space-y-1 rounded-md border border-muted bg-surface-100 py-3 px-4">
+                  <p className="text-xs">No entities available</p>
+                  <p className="text-xs text-foreground-light">
+                    This schema has no entities available yet
+                  </p>
+                </div>
+              )}
+              {searchText.length > 0 && (entityTypes?.length ?? 0) <= 0 && (
+                <div className="mx-4 space-y-1 rounded-md border border-muted bg-surface-100 py-3 px-4">
+                  <p className="text-xs">No results found</p>
+                  <p className="text-xs text-foreground-light">
+                    There are no entities that match your search
+                  </p>
+                </div>
+              )}
+
+              {(entityTypes?.length ?? 0) > 0 && (
+                <div className="flex flex-1">
+                  <InfiniteList
+                    items={entityTypes}
+                    ItemComponent={EntityListItem}
+                    itemProps={{
+                      projectRef: project?.ref,
+                      id: Number(id),
+                    }}
+                    getItemSize={() => 28}
+                    hasNextPage={hasNextPage}
+                    isLoadingNextPage={isFetchingNextPage}
+                    onLoadNextPage={() => fetchNextPage()}
+                  />
+                </div>
+              )}
+            </>
+          )}
+        </nav>
       </div>
 
       <ProtectedSchemaModal visible={showModal} onClose={() => setShowModal(false)} />

--- a/apps/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
+++ b/apps/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
@@ -269,7 +269,7 @@ const TableEditorMenu = () => {
           {isSuccess && (
             <>
               {searchText.length === 0 && (entityTypes?.length ?? 0) <= 0 && (
-                <div className="mx-4 space-y-1 rounded-md border border-muted bg-surface-100 py-3 px-4">
+                <div className="mx-2 my-2 space-y-1 rounded-md border border-muted bg-surface-100 py-3 px-4">
                   <p className="text-xs">No entities available</p>
                   <p className="text-xs text-foreground-light">
                     This schema has no entities available yet
@@ -277,7 +277,7 @@ const TableEditorMenu = () => {
                 </div>
               )}
               {searchText.length > 0 && (entityTypes?.length ?? 0) <= 0 && (
-                <div className="mx-4 space-y-1 rounded-md border border-muted bg-surface-100 py-3 px-4">
+                <div className="mx-2 my-2 space-y-1 rounded-md border border-muted bg-surface-100 py-3 px-4">
                   <p className="text-xs">No results found</p>
                   <p className="text-xs text-foreground-light">
                     There are no entities that match your search

--- a/apps/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
+++ b/apps/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
@@ -280,7 +280,7 @@ const TableEditorMenu = () => {
                 <div className="mx-2 my-2 space-y-1 rounded-md border border-muted bg-surface-100 py-3 px-4">
                   <p className="text-xs">No results found</p>
                   <p className="text-xs text-foreground-light">
-                    There are no entities that match your search
+                    Your search for "{searchText}" did not return any results
                   </p>
                 </div>
               )}

--- a/apps/studio/components/layouts/index.ts
+++ b/apps/studio/components/layouts/index.ts
@@ -5,10 +5,7 @@ import DatabaseLayout from './DatabaseLayout/DatabaseLayout'
 import DocsLayout from './DocsLayout/DocsLayout'
 import LogsLayout from './LogsLayout/LogsLayout'
 import OrganizationLayout from './OrganizationLayout'
-import ProjectLayout, {
-  ProjectLayoutNonBlocking,
-  ProjectLayoutWithAuth,
-} from './ProjectLayout/ProjectLayout'
+import ProjectLayout, { ProjectLayoutWithAuth } from './ProjectLayout/ProjectLayout'
 import SettingsLayout from './ProjectSettingsLayout/SettingsLayout'
 import ReportsLayout from './ReportsLayout/ReportsLayout'
 import SQLEditorLayout from './SQLEditorLayout/SQLEditorLayout'
@@ -29,7 +26,6 @@ export {
   ForgotPasswordLayout,
   LogsLayout,
   OrganizationLayout,
-  ProjectLayoutNonBlocking,
   ProjectLayoutWithAuth,
   ReportsLayout,
   SQLEditorLayout,

--- a/apps/studio/components/ui/ShimmeringLoader.tsx
+++ b/apps/studio/components/ui/ShimmeringLoader.tsx
@@ -1,9 +1,19 @@
-const ANIMATION_DELAY = 150
+import { cn } from 'ui'
 
-const ShimmeringLoader = ({ className = '', delayIndex = 0, animationDelay = 150 }) => {
+export interface ShimmeringLoader {
+  className?: string
+  delayIndex?: number
+  animationDelay?: number
+}
+
+const ShimmeringLoader = ({
+  className,
+  delayIndex = 0,
+  animationDelay = 150,
+}: ShimmeringLoader) => {
   return (
     <div
-      className={`shimmering-loader rounded py-3 ${className}`}
+      className={cn('shimmering-loader rounded py-3', className)}
       style={{
         animationFillMode: 'backwards',
         animationDelay: `${delayIndex * animationDelay}ms`,

--- a/apps/studio/hooks/misc/useCheckPermissions.ts
+++ b/apps/studio/hooks/misc/useCheckPermissions.ts
@@ -1,6 +1,7 @@
 import { useIsLoggedIn } from 'common'
 import jsonLogic from 'json-logic-js'
 
+import { useOrganizationsQuery } from 'data/organizations/organizations-query'
 import { usePermissionsQuery } from 'data/permissions/permissions-query'
 import { IS_PLATFORM } from 'lib/constants'
 import { Permission } from 'types'
@@ -80,4 +81,14 @@ export function useCheckPermissions(
   if (!IS_PLATFORM) return true
 
   return doPermissionsCheck(allPermissions, action, resource, data, orgId)
+}
+
+export function usePermissionsLoaded() {
+  const isLoggedIn = useIsLoggedIn()
+  const { isFetched: isPermissionsFetched } = usePermissionsQuery({ enabled: isLoggedIn })
+  const { isFetched: isOrganizationsFetched } = useOrganizationsQuery({ enabled: isLoggedIn })
+
+  if (!IS_PLATFORM) return true
+
+  return isLoggedIn && isPermissionsFetched && isOrganizationsFetched
 }

--- a/apps/studio/pages/project/[ref]/editor/index.tsx
+++ b/apps/studio/pages/project/[ref]/editor/index.tsx
@@ -25,7 +25,7 @@ const TableEditorPage: NextPageWithLayout = () => {
 
 TableEditorPage.getLayout = (page) => (
   <ProjectContextFromParamsProvider>
-    <TableEditorLayout>{page}</TableEditorLayout>
+    <TableEditorLayout isBlocking={false}>{page}</TableEditorLayout>
   </ProjectContextFromParamsProvider>
 )
 

--- a/apps/studio/pages/project/[ref]/editor/index.tsx
+++ b/apps/studio/pages/project/[ref]/editor/index.tsx
@@ -25,7 +25,7 @@ const TableEditorPage: NextPageWithLayout = () => {
 
 TableEditorPage.getLayout = (page) => (
   <ProjectContextFromParamsProvider>
-    <TableEditorLayout isBlocking={false}>{page}</TableEditorLayout>
+    <TableEditorLayout>{page}</TableEditorLayout>
   </ProjectContextFromParamsProvider>
 )
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

chore(perf)

## What is the current behaviour?

https://github.com/supabase/supabase/assets/10985857/13cacb5a-9afb-4c9c-84ff-a7fef5432bfe

## What is the new behaviour?

https://github.com/supabase/supabase/assets/10985857/08b2a0a7-959b-486b-8145-bbeed1a23952

## Additional context

The loading experience on an individual table is _slightly_ improved also (loader no longer wraps menu bar), but that page will need a lot more refactoring to remove the large spinner.