### PR TITLE
fix: add missing asChild props

### DIFF
--- a/apps/studio/components/grid/components/formatter/ForeignKeyFormatter.tsx
+++ b/apps/studio/components/grid/components/formatter/ForeignKeyFormatter.tsx
@@ -2,12 +2,12 @@ import * as Tooltip from '@radix-ui/react-tooltip'
 import Link from 'next/link'
 import { PropsWithChildren } from 'react'
 import { RenderCellProps } from 'react-data-grid'
-import { Button, IconArrowRight } from 'ui'
 
 import { useParams } from 'common/hooks'
 import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
 import { useTableQuery } from 'data/tables/table-query'
 import { useTablesQuery } from 'data/tables/tables-query'
+import { Button, IconArrowRight } from 'ui'
 import { SupaRow } from '../../types'
 import { NullValue } from '../common'
 
@@ -51,19 +51,21 @@ export const ForeignKeyFormatter = (
       </span>
       {relationship !== undefined && targetTable !== undefined && value !== null && (
         <Tooltip.Root delayDuration={0}>
-          <Tooltip.Trigger>
-            <Link
-              href={`/project/${projectRef}/editor/${targetTable?.id}?filter=${relationship?.target_column_name}%3Aeq%3A${value}`}
+          <Tooltip.Trigger asChild>
+            <Button
+              type="default"
+              size="tiny"
+              className="translate-y-[2px]"
+              onClick={() => {}}
+              style={{ padding: '3px' }}
+              asChild
             >
-              <Button
-                type="default"
-                size="tiny"
-                className="translate-y-[2px]"
-                onClick={() => {}}
-                icon={<IconArrowRight size="tiny" />}
-                style={{ padding: '3px' }}
-              />
-            </Link>
+              <Link
+                href={`/project/${projectRef}/editor/${targetTable?.id}?filter=${relationship?.target_column_name}%3Aeq%3A${value}`}
+              >
+                <IconArrowRight size="tiny" />
+              </Link>
+            </Button>
           </Tooltip.Trigger>
           <Tooltip.Portal>
             <Tooltip.Portal>

--- a/apps/studio/components/grid/components/menu/ColumnMenu.tsx
+++ b/apps/studio/components/grid/components/menu/ColumnMenu.tsx
@@ -106,15 +106,9 @@ const ColumnMenu = ({ column, isEncrypted }: ColumnMenuProps) => {
   return (
     <>
       <DropdownMenu>
-        <DropdownMenuTrigger>
-          <Button
-            asChild
-            className="opacity-50 flex"
-            type="text"
-            icon={<IconChevronDown />}
-            style={{ padding: '3px' }}
-          >
-            <span></span>
+        <DropdownMenuTrigger asChild>
+          <Button className="opacity-50 flex" type="text" style={{ padding: '3px' }}>
+            <IconChevronDown />
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" side="bottom">

--- a/apps/studio/components/interfaces/Auth/Policies/AIPolicyEditorPanel/Message.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/AIPolicyEditorPanel/Message.tsx
@@ -97,7 +97,7 @@ const Message = memo(function Message({
                 />
                 <div className="absolute top-3 right-3 bg-surface-100 border-muted border rounded-lg h-[28px] hidden group-hover:block">
                   <Tooltip.Root delayDuration={0}>
-                    <Tooltip.Trigger>
+                    <Tooltip.Trigger asChild>
                       <Button type="text" size="tiny" onClick={() => onDiff(formatted)}>
                         <FileDiff className="h-4 w-4" />
                       </Button>
@@ -117,7 +117,7 @@ const Message = memo(function Message({
                     </Tooltip.Portal>
                   </Tooltip.Root>
                   <Tooltip.Root delayDuration={0}>
-                    <Tooltip.Trigger>
+                    <Tooltip.Trigger asChild>
                       <Button
                         type="text"
                         size="tiny"

--- a/apps/studio/components/interfaces/Auth/Policies/PolicyTableRow/PolicyRow.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/PolicyTableRow/PolicyRow.tsx
@@ -77,7 +77,7 @@ const PolicyRow = ({
       <div>
         {canUpdatePolicies ? (
           <DropdownMenu>
-            <DropdownMenuTrigger>
+            <DropdownMenuTrigger asChild>
               <Button
                 type="default"
                 style={{ paddingLeft: 4, paddingRight: 4 }}
@@ -98,7 +98,7 @@ const PolicyRow = ({
           </DropdownMenu>
         ) : (
           <Tooltip.Root delayDuration={0}>
-            <Tooltip.Trigger>
+            <Tooltip.Trigger asChild>
               <Button
                 disabled
                 type="default"

--- a/apps/studio/components/interfaces/Auth/Policies/PolicyTableRow/PolicyTableRowHeader.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/PolicyTableRow/PolicyTableRowHeader.tsx
@@ -50,7 +50,7 @@ const PolicyTableRowHeader = ({
         <div className="flex-1">
           <div className="flex flex-row justify-end gap-x-2">
             <Tooltip.Root delayDuration={0}>
-              <Tooltip.Trigger>
+              <Tooltip.Trigger asChild>
                 <Button
                   type="default"
                   disabled={!canToggleRLS}
@@ -79,7 +79,7 @@ const PolicyTableRowHeader = ({
             </Tooltip.Root>
             {!isAiAssistantEnabled && (
               <Tooltip.Root delayDuration={0}>
-                <Tooltip.Trigger>
+                <Tooltip.Trigger asChild>
                   <Button
                     type="outline"
                     disabled={!canCreatePolicies}

--- a/apps/studio/components/interfaces/Auth/Users/AddUserDropdown.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/AddUserDropdown.tsx
@@ -40,7 +40,7 @@ const AddUserDropdown = ({ projectKpsVersion }: AddUserDropdownProps) => {
   return (
     <>
       <DropdownMenu>
-        <DropdownMenuTrigger>
+        <DropdownMenuTrigger asChild>
           <Button type="primary" iconRight={<IconChevronDown strokeWidth={1.5} />}>
             Add user
           </Button>

--- a/apps/studio/components/interfaces/Auth/Users/UserDropdown.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/UserDropdown.tsx
@@ -125,15 +125,9 @@ const UserDropdown = ({ user, canRemoveUser, canRemoveMFAFactors }: UserDropdown
   return (
     <>
       <DropdownMenu>
-        <DropdownMenuTrigger>
-          <Button
-            asChild
-            type="text"
-            icon={<IconMoreHorizontal />}
-            loading={isLoading}
-            className="hover:border-gray-500 flex"
-          >
-            <span />
+        <DropdownMenuTrigger asChild>
+          <Button type="text" loading={isLoading} className="hover:border-gray-500 flex">
+            <IconMoreHorizontal />
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent>

--- a/apps/studio/components/interfaces/Database/Backups/PITR/PITRStatus.tsx
+++ b/apps/studio/components/interfaces/Database/Backups/PITR/PITRStatus.tsx
@@ -56,7 +56,7 @@ const PITRStatus = ({
               </span>
             </div>
             <Tooltip.Root delayDuration={0}>
-              <Tooltip.Trigger>
+              <Tooltip.Trigger asChild>
                 <Button disabled={!canTriggerPhysicalBackup} onClick={() => onSetConfiguration()}>
                   Start a restore
                 </Button>

--- a/apps/studio/components/interfaces/Database/EnumeratedTypes/EnumeratedTypes.tsx
+++ b/apps/studio/components/interfaces/Database/EnumeratedTypes/EnumeratedTypes.tsx
@@ -135,14 +135,9 @@ const EnumeratedTypes = () => {
                       {!isLocked && (
                         <div className="flex justify-end items-center space-x-2">
                           <DropdownMenu>
-                            <DropdownMenuTrigger>
-                              <Button
-                                asChild
-                                type="default"
-                                icon={<IconMoreVertical />}
-                                className="px-1"
-                              >
-                                <span></span>
+                            <DropdownMenuTrigger asChild>
+                              <Button type="default" className="px-1">
+                                <IconMoreVertical />
                               </Button>
                             </DropdownMenuTrigger>
                             <DropdownMenuContent side="bottom" align="end" className="w-32">

--- a/apps/studio/components/interfaces/Database/Functions/FunctionsList/FunctionList.tsx
+++ b/apps/studio/components/interfaces/Database/Functions/FunctionsList/FunctionList.tsx
@@ -101,9 +101,9 @@ const FunctionList = ({
                 <div className="flex items-center justify-end">
                   {canUpdateFunctions ? (
                     <DropdownMenu>
-                      <DropdownMenuTrigger>
-                        <Button asChild type="default" icon={<IconMoreVertical />} className="px-1">
-                          <span></span>
+                      <DropdownMenuTrigger asChild>
+                        <Button type="default" className="px-1">
+                          <IconMoreVertical />
                         </Button>
                       </DropdownMenuTrigger>
                       <DropdownMenuContent side="left">

--- a/apps/studio/components/interfaces/Database/Functions/FunctionsList/FunctionsList.tsx
+++ b/apps/studio/components/interfaces/Database/Functions/FunctionsList/FunctionsList.tsx
@@ -104,7 +104,7 @@ const FunctionsList = ({
 
             {!isLocked && (
               <Tooltip.Root delayDuration={0}>
-                <Tooltip.Trigger>
+                <Tooltip.Trigger asChild>
                   <Button disabled={!canCreateFunctions} onClick={() => createFunction()}>
                     Create a new function
                   </Button>

--- a/apps/studio/components/interfaces/Database/Hooks/HTTPRequestFields.tsx
+++ b/apps/studio/components/interfaces/Database/Hooks/HTTPRequestFields.tsx
@@ -168,12 +168,10 @@ const HTTPRequestFields = ({
               </Button>
               {type === 'supabase_function' && (
                 <DropdownMenu>
-                  <DropdownMenuTrigger>
-                    <Button
-                      type="default"
-                      className="rounded-l-none px-[4px] py-[5px]"
-                      icon={<IconChevronDown />}
-                    />
+                  <DropdownMenuTrigger asChild>
+                    <Button type="default" className="rounded-l-none px-[4px] py-[5px]">
+                      <IconChevronDown />
+                    </Button>
                   </DropdownMenuTrigger>
                   <DropdownMenuContent align="end" side="bottom">
                     <DropdownMenuItem

--- a/apps/studio/components/interfaces/Database/Hooks/HooksList/HookList.tsx
+++ b/apps/studio/components/interfaces/Database/Hooks/HooksList/HookList.tsx
@@ -91,9 +91,9 @@ const HookList = ({ schema, filterString, editHook = noop, deleteHook = noop }: 
               <div className="flex justify-end gap-4">
                 {canUpdateWebhook ? (
                   <DropdownMenu>
-                    <DropdownMenuTrigger>
-                      <Button asChild type="default" icon={<IconMoreVertical />} className="px-1">
-                        <span></span>
+                    <DropdownMenuTrigger asChild>
+                      <Button type="default" className="px-1">
+                        <IconMoreVertical />
                       </Button>
                     </DropdownMenuTrigger>
 

--- a/apps/studio/components/interfaces/Database/Hooks/HooksList/HooksList.tsx
+++ b/apps/studio/components/interfaces/Database/Hooks/HooksList/HooksList.tsx
@@ -97,7 +97,7 @@ const HooksList = ({
                   </Link>
                 </Button>
                 <Tooltip.Root delayDuration={0}>
-                  <Tooltip.Trigger>
+                  <Tooltip.Trigger asChild>
                     <Button disabled={!canCreateWebhooks} onClick={() => createHook()}>
                       Create a new hook
                     </Button>

--- a/apps/studio/components/interfaces/Database/Roles/RoleRow.tsx
+++ b/apps/studio/components/interfaces/Database/Roles/RoleRow.tsx
@@ -132,9 +132,9 @@ const RoleRow = ({ role, disabled = false, onSelectDelete }: RoleRowProps) => {
                   </p>
                   {!disabled && (
                     <DropdownMenu>
-                      <DropdownMenuTrigger>
-                        <Button asChild type="default" className="px-1" icon={<IconMoreVertical />}>
-                          <span></span>
+                      <DropdownMenuTrigger asChild>
+                        <Button type="default" className="px-1">
+                          <IconMoreVertical />
                         </Button>
                       </DropdownMenuTrigger>
                       <DropdownMenuContent side="bottom" className="w-[120px]">

--- a/apps/studio/components/interfaces/Database/Roles/RolesList.tsx
+++ b/apps/studio/components/interfaces/Database/Roles/RolesList.tsx
@@ -150,7 +150,7 @@ const RolesList = ({}) => {
               </Tooltip.Content>
             </Tooltip.Root>
             <Tooltip.Root delayDuration={0}>
-              <Tooltip.Trigger>
+              <Tooltip.Trigger asChild>
                 <Button
                   type="primary"
                   disabled={!canUpdateRoles}

--- a/apps/studio/components/interfaces/Database/Tables/ColumnList.tsx
+++ b/apps/studio/components/interfaces/Database/Tables/ColumnList.tsx
@@ -84,7 +84,7 @@ const ColumnList = ({
         {!isLocked && (
           <div>
             <Tooltip.Root delayDuration={0}>
-              <Tooltip.Trigger>
+              <Tooltip.Trigger asChild>
                 <Button
                   disabled={!canUpdateColumns}
                   icon={<IconPlus />}
@@ -167,14 +167,9 @@ const ColumnList = ({
                     <Table.td className="text-right">
                       {!isLocked && (
                         <DropdownMenu>
-                          <DropdownMenuTrigger>
-                            <Button
-                              asChild
-                              type="default"
-                              icon={<IconMoreVertical />}
-                              className="px-1"
-                            >
-                              <span />
+                          <DropdownMenuTrigger asChild>
+                            <Button type="default" className="px-1">
+                              <IconMoreVertical />
                             </Button>
                           </DropdownMenuTrigger>
                           <DropdownMenuContent side="bottom" align="end" className="w-32">

--- a/apps/studio/components/interfaces/Database/Tables/TableList.tsx
+++ b/apps/studio/components/interfaces/Database/Tables/TableList.tsx
@@ -116,7 +116,7 @@ const TableList = ({
         {!isLocked && (
           <div>
             <Tooltip.Root delayDuration={0}>
-              <Tooltip.Trigger>
+              <Tooltip.Trigger asChild>
                 <Button
                   disabled={!canUpdateTables}
                   icon={<IconPlus />}
@@ -268,14 +268,9 @@ const TableList = ({
 
                             {!isLocked && (
                               <DropdownMenu>
-                                <DropdownMenuTrigger>
-                                  <Button
-                                    asChild
-                                    type="default"
-                                    icon={<IconMoreVertical />}
-                                    className="px-1"
-                                  >
-                                    <span />
+                                <DropdownMenuTrigger asChild>
+                                  <Button type="default" className="px-1">
+                                    <IconMoreVertical />
                                   </Button>
                                 </DropdownMenuTrigger>
                                 <DropdownMenuContent side="bottom" align="end" className="w-32">

--- a/apps/studio/components/interfaces/Database/Triggers/TriggersList/TriggerList.tsx
+++ b/apps/studio/components/interfaces/Database/Triggers/TriggersList/TriggerList.tsx
@@ -114,9 +114,9 @@ const TriggerList = ({
               <div className="flex items-center justify-end">
                 {canUpdateTriggers ? (
                   <DropdownMenu>
-                    <DropdownMenuTrigger>
-                      <Button asChild type="default" className="px-1" icon={<IconMoreVertical />}>
-                        <span />
+                    <DropdownMenuTrigger asChild>
+                      <Button asChild type="default" className="px-1">
+                        <IconMoreVertical />
                       </Button>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent side="bottom" align="end" className="w-36">

--- a/apps/studio/components/interfaces/Database/Triggers/TriggersList/TriggersList.tsx
+++ b/apps/studio/components/interfaces/Database/Triggers/TriggersList/TriggersList.tsx
@@ -98,7 +98,7 @@ const TriggersList = ({
 
             {!isLocked && (
               <Tooltip.Root delayDuration={0}>
-                <Tooltip.Trigger>
+                <Tooltip.Trigger asChild>
                   <Button disabled={!canCreateTriggers} onClick={() => createTrigger()}>
                     Create a new trigger
                   </Button>

--- a/apps/studio/components/interfaces/Database/Wrappers/WrapperRow.tsx
+++ b/apps/studio/components/interfaces/Database/Wrappers/WrapperRow.tsx
@@ -141,7 +141,7 @@ const WrapperRow = ({
                       </Link>
                     ) : (
                       <Tooltip.Root delayDuration={0}>
-                        <Tooltip.Trigger>
+                        <Tooltip.Trigger asChild>
                           <Button
                             type="default"
                             disabled
@@ -169,7 +169,7 @@ const WrapperRow = ({
                       </Tooltip.Root>
                     )}
                     <Tooltip.Root delayDuration={0}>
-                      <Tooltip.Trigger>
+                      <Tooltip.Trigger asChild>
                         <Button
                           type="default"
                           disabled={!canManageWrappers}

--- a/apps/studio/components/interfaces/Database/Wrappers/WrappersDisabledState.tsx
+++ b/apps/studio/components/interfaces/Database/Wrappers/WrappersDisabledState.tsx
@@ -132,7 +132,7 @@ const WrappersDisabledState = () => {
                 </Link>
               </Button>
               <Tooltip.Root delayDuration={0}>
-                <Tooltip.Trigger>
+                <Tooltip.Trigger asChild>
                   <Button
                     type="primary"
                     loading={isEnabling}

--- a/apps/studio/components/interfaces/Database/Wrappers/WrappersDropdown.tsx
+++ b/apps/studio/components/interfaces/Database/Wrappers/WrappersDropdown.tsx
@@ -30,7 +30,7 @@ const WrapperDropdown = ({ buttonText = 'Add wrapper', align = 'end' }: WrapperD
   if (!canManageWrappers) {
     return (
       <Tooltip.Root delayDuration={0}>
-        <Tooltip.Trigger>
+        <Tooltip.Trigger asChild>
           <Button disabled type="primary" icon={<IconPlus strokeWidth={1.5} />}>
             {buttonText}
           </Button>
@@ -56,7 +56,7 @@ const WrapperDropdown = ({ buttonText = 'Add wrapper', align = 'end' }: WrapperD
 
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger>
+      <DropdownMenuTrigger asChild>
         <Button type="primary" icon={<IconPlus strokeWidth={1.5} />}>
           {buttonText}
         </Button>

--- a/apps/studio/components/interfaces/Docs/LangSelector.tsx
+++ b/apps/studio/components/interfaces/Docs/LangSelector.tsx
@@ -67,7 +67,7 @@ const LangSelector = ({
               <span>Project API key :</span>
             </div>
             <DropdownMenu>
-              <DropdownMenuTrigger>
+              <DropdownMenuTrigger asChild>
                 <Button type="default">{showApiKey.name}</Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" side="bottom">

--- a/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionDetails.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionDetails.tsx
@@ -261,7 +261,7 @@ const EdgeFunctionDetails = () => {
                   Make sure you have made a backup if you want to restore your edge function
                 </p>
                 <Tooltip.Root delayDuration={0}>
-                  <Tooltip.Trigger>
+                  <Tooltip.Trigger asChild>
                     <Button
                       type="danger"
                       disabled={!canUpdateEdgeFunction}

--- a/apps/studio/components/interfaces/Home/ProjectUsage.tsx
+++ b/apps/studio/components/interfaces/Home/ProjectUsage.tsx
@@ -89,8 +89,8 @@ const ProjectUsage = () => {
     <div className="space-y-6">
       <div className="flex flex-row items-center gap-2">
         <DropdownMenu>
-          <DropdownMenuTrigger>
-            <Button asChild type="default" iconRight={<IconChevronDown />}>
+          <DropdownMenuTrigger asChild>
+            <Button type="default" iconRight={<IconChevronDown />}>
               <span>{selectedInterval.label}</span>
             </Button>
           </DropdownMenuTrigger>

--- a/apps/studio/components/interfaces/Integrations/IntegrationConnection.tsx
+++ b/apps/studio/components/interfaces/Integrations/IntegrationConnection.tsx
@@ -80,8 +80,8 @@ const IntegrationConnectionItem = forwardRef<HTMLLIElement, IntegrationConnectio
                 onOpenChange={() => setDropdownVisible(!dropdownVisible)}
                 modal={false}
               >
-                <DropdownMenuTrigger>
-                  <Button asChild iconRight={<IconChevronDown />} type="default">
+                <DropdownMenuTrigger asChild>
+                  <Button iconRight={<IconChevronDown />} type="default">
                     <span>Manage</span>
                   </Button>
                 </DropdownMenuTrigger>

--- a/apps/studio/components/interfaces/Organization/BillingSettings/PaymentMethods.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/PaymentMethods.tsx
@@ -215,13 +215,14 @@ const PaymentMethods = () => {
                               </Tooltip.Root>
                             ) : (
                               <DropdownMenu>
-                                <DropdownMenuTrigger>
+                                <DropdownMenuTrigger asChild>
                                   <Button
                                     type="outline"
-                                    icon={<IconMoreHorizontal />}
                                     loading={isLoadingPaymentMethods}
                                     className="hover:border-gray-500"
-                                  />
+                                  >
+                                    <IconMoreHorizontal />
+                                  </Button>
                                 </DropdownMenuTrigger>
                                 <DropdownMenuContent>
                                   <DropdownMenuItem

--- a/apps/studio/components/interfaces/Organization/BillingSettings/PaymentMethods/PaymentMethods.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/PaymentMethods/PaymentMethods.tsx
@@ -171,14 +171,12 @@ const PaymentMethods = () => {
                                   {isActive && <Badge color="green">Active</Badge>}
                                   {canUpdatePaymentMethods && !isActive ? (
                                     <DropdownMenu>
-                                      <DropdownMenuTrigger>
+                                      <DropdownMenuTrigger asChild>
                                         <Button
-                                          asChild
                                           type="outline"
-                                          icon={<IconMoreHorizontal />}
                                           className="hover:border-gray-500 px-1"
                                         >
-                                          <span />
+                                          <IconMoreHorizontal />
                                         </Button>
                                       </DropdownMenuTrigger>
                                       <DropdownMenuContent align="end">

--- a/apps/studio/components/interfaces/Organization/OAuthApps/PublishAppSidePanel/index.tsx
+++ b/apps/studio/components/interfaces/Organization/OAuthApps/PublishAppSidePanel/index.tsx
@@ -250,8 +250,10 @@ const PublishAppSidePanel = ({
                             >
                               <div className="absolute bottom-1 right-1">
                                 <DropdownMenu>
-                                  <DropdownMenuTrigger>
-                                    <Button type="default" icon={<IconEdit />} className="px-1" />
+                                  <DropdownMenuTrigger asChild>
+                                    <Button type="default" className="px-1">
+                                      <IconEdit />
+                                    </Button>
                                   </DropdownMenuTrigger>
                                   <DropdownMenuContent align="end" side="bottom">
                                     <DropdownMenuItem

--- a/apps/studio/components/interfaces/Organization/TeamSettings/MemberActions.tsx
+++ b/apps/studio/components/interfaces/Organization/TeamSettings/MemberActions.tsx
@@ -153,15 +153,9 @@ const MemberActions = ({ member, roles }: MemberActionsProps) => {
     <>
       <div className="flex items-center justify-end">
         <DropdownMenu>
-          <DropdownMenuTrigger>
-            <Button
-              asChild
-              type="text"
-              disabled={isLoading}
-              loading={isLoading}
-              icon={<IconMoreHorizontal />}
-            >
-              <span></span>
+          <DropdownMenuTrigger asChild>
+            <Button type="text" disabled={isLoading} loading={isLoading}>
+              <IconMoreHorizontal />
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent side="bottom" align="end">

--- a/apps/studio/components/interfaces/Reports/ReportFilterBar.tsx
+++ b/apps/studio/components/interfaces/Reports/ReportFilterBar.tsx
@@ -153,9 +153,8 @@ const ReportFilterBar = ({
           helpers={datepickerHelpers}
         />
         <DropdownMenu>
-          <DropdownMenuTrigger>
+          <DropdownMenuTrigger asChild>
             <Button
-              asChild
               type="default"
               className="inline-flex flex-row gap-2"
               iconRight={<IconChevronDown size={14} />}

--- a/apps/studio/components/interfaces/Reports/ReportWidget.tsx
+++ b/apps/studio/components/interfaces/Reports/ReportWidget.tsx
@@ -73,7 +73,7 @@ const ReportWidget: React.FC<ReportWidgetProps> = (props) => {
           </div>
           {props.params && (
             <Tooltip.Root delayDuration={0}>
-              <Tooltip.Trigger>
+              <Tooltip.Trigger asChild>
                 <Button
                   type="default"
                   icon={<IconExternalLink strokeWidth={1.5} />}

--- a/apps/studio/components/interfaces/Reports/Reports.tsx
+++ b/apps/studio/components/interfaces/Reports/Reports.tsx
@@ -361,8 +361,8 @@ const Reports = () => {
 
           {canUpdateReport ? (
             <DropdownMenu>
-              <DropdownMenuTrigger>
-                <Button asChild type="default" iconRight={<IconSettings />}>
+              <DropdownMenuTrigger asChild>
+                <Button type="default" iconRight={<IconSettings />}>
                   <span>Add / Remove charts</span>
                 </Button>
               </DropdownMenuTrigger>
@@ -401,8 +401,8 @@ const Reports = () => {
         <div className="flex min-h-full items-center justify-center rounded border-2 border-dashed p-16 border-default">
           {canUpdateReport ? (
             <DropdownMenu>
-              <DropdownMenuTrigger>
-                <Button asChild type="default" iconRight={<IconPlus />}>
+              <DropdownMenuTrigger asChild>
+                <Button type="default" iconRight={<IconPlus />}>
                   <span>
                     {config.layout.length <= 0 ? 'Add your first chart' : 'Add another chart'}
                   </span>

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/ResultsDropdown.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/ResultsDropdown.tsx
@@ -106,8 +106,8 @@ const ResultsDropdown = ({ id, isExecuting }: ResultsDropdownProps) => {
 
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger>
-        <Button asChild type="text" iconRight={<IconChevronDown />}>
+      <DropdownMenuTrigger asChild>
+        <Button type="text" iconRight={<IconChevronDown />}>
           <span>
             Results
             {!isExecuting &&

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/ResultsDropdown.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/ResultsDropdown.tsx
@@ -116,14 +116,16 @@ const ResultsDropdown = ({ id, isExecuting }: ResultsDropdownProps) => {
               ` (${result.rows.length.toLocaleString()})`}
           </span>
         </Button>
-        <CSVLink
-          ref={csvRef}
-          className="hidden"
-          headers={headers}
-          data={csvData}
-          filename={`supabase_${project?.ref}_${snap.snippets[id]?.snippet.name}`}
-        />
       </DropdownMenuTrigger>
+
+      <CSVLink
+        ref={csvRef}
+        className="hidden"
+        headers={headers}
+        data={csvData}
+        filename={`supabase_${project?.ref}_${snap.snippets[id]?.snippet.name}`}
+      />
+
       <DropdownMenuContent side="bottom" align="start">
         <>
           <DropdownMenuItem onClick={onDownloadCSV} className="space-x-2">

--- a/apps/studio/components/interfaces/Settings/API/JWTSettings.tsx
+++ b/apps/studio/components/interfaces/Settings/API/JWTSettings.tsx
@@ -171,8 +171,8 @@ const JWTSettings = () => {
                             </Tooltip.Root>
                           ) : (
                             <DropdownMenu>
-                              <DropdownMenuTrigger>
-                                <Button asChild type="default" iconRight={<IconChevronDown />}>
+                              <DropdownMenuTrigger asChild>
+                                <Button type="default" iconRight={<IconChevronDown />}>
                                   <span>Generate a new secret</span>
                                 </Button>
                               </DropdownMenuTrigger>

--- a/apps/studio/components/interfaces/Settings/Database/NetworkRestrictions/NetworkRestrictions.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/NetworkRestrictions/NetworkRestrictions.tsx
@@ -23,7 +23,7 @@ interface AccessButtonProps {
 
 const AllowAllAccessButton = ({ disabled, onClick }: AccessButtonProps) => (
   <Tooltip.Root delayDuration={0}>
-    <Tooltip.Trigger>
+    <Tooltip.Trigger asChild>
       <Button type="default" disabled={disabled} onClick={() => onClick(true)}>
         Allow all access
       </Button>
@@ -50,7 +50,7 @@ const AllowAllAccessButton = ({ disabled, onClick }: AccessButtonProps) => (
 
 const DisallowAllAccessButton = ({ disabled, onClick }: AccessButtonProps) => (
   <Tooltip.Root delayDuration={0}>
-    <Tooltip.Trigger>
+    <Tooltip.Trigger asChild>
       <Button type="default" disabled={disabled} onClick={() => onClick(true)}>
         Restrict all access
       </Button>
@@ -120,7 +120,7 @@ const NetworkRestrictions = ({}) => {
               </Link>
             </Button>
             <Tooltip.Root delayDuration={0}>
-              <Tooltip.Trigger>
+              <Tooltip.Trigger asChild>
                 <Button
                   disabled={!canUpdateNetworkRestrictions}
                   onClick={() => setIsAddingAddress(true)}

--- a/apps/studio/components/interfaces/Settings/General/DeleteProjectPanel/DeleteProjectButton.tsx
+++ b/apps/studio/components/interfaces/Settings/General/DeleteProjectPanel/DeleteProjectButton.tsx
@@ -94,7 +94,7 @@ const DeleteProjectButton = ({ type = 'danger' }: DeleteProjectButtonProps) => {
   return (
     <>
       <Tooltip.Root delayDuration={0}>
-        <Tooltip.Trigger>
+        <Tooltip.Trigger asChild>
           <Button onClick={toggle} type={type} disabled={!canDeleteProject}>
             Delete project
           </Button>

--- a/apps/studio/components/interfaces/Settings/General/Infrastructure/PauseProjectButton.tsx
+++ b/apps/studio/components/interfaces/Settings/General/Infrastructure/PauseProjectButton.tsx
@@ -51,7 +51,7 @@ const PauseProjectButton = () => {
   return (
     <>
       <Tooltip.Root delayDuration={0}>
-        <Tooltip.Trigger>
+        <Tooltip.Trigger asChild>
           <Button
             type="default"
             icon={<IconPause />}

--- a/apps/studio/components/interfaces/Settings/General/Infrastructure/RestartServerButton.tsx
+++ b/apps/studio/components/interfaces/Settings/General/Infrastructure/RestartServerButton.tsx
@@ -95,7 +95,7 @@ const RestartServerButton = () => {
   return (
     <>
       <Tooltip.Root delayDuration={0}>
-        <Tooltip.Trigger>
+        <Tooltip.Trigger asChild>
           <div className="flex items-center">
             <Button
               type="default"

--- a/apps/studio/components/interfaces/Settings/General/TransferProjectPanel/TransferProjectButton.tsx
+++ b/apps/studio/components/interfaces/Settings/General/TransferProjectPanel/TransferProjectButton.tsx
@@ -84,7 +84,7 @@ const TransferProjectButton = () => {
   return (
     <>
       <Tooltip.Root delayDuration={0}>
-        <Tooltip.Trigger>
+        <Tooltip.Trigger asChild>
           <Button
             onClick={toggle}
             type="default"

--- a/apps/studio/components/interfaces/Settings/Logs/Logs.DatePickers.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.DatePickers.tsx
@@ -50,9 +50,8 @@ const DatePickers: React.FC<Props> = ({ to, from, onChange, helpers }) => {
   return (
     <div className="flex items-center">
       <DropdownMenu>
-        <DropdownMenuTrigger>
+        <DropdownMenuTrigger asChild>
           <Button
-            asChild
             type={helperValue ? 'secondary' : 'default'}
             icon={<IconClock size={12} />}
             className="rounded-r-none"

--- a/apps/studio/components/interfaces/Settings/Logs/LogsQueryPanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogsQueryPanel.tsx
@@ -83,8 +83,8 @@ const LogsQueryPanel = ({
         <div className="flex w-full flex-row items-center justify-between gap-x-4">
           <div className="flex items-center gap-2">
             <DropdownMenu>
-              <DropdownMenuTrigger>
-                <Button asChild type="default" iconRight={<IconChevronDown />}>
+              <DropdownMenuTrigger asChild>
+                <Button type="default" iconRight={<IconChevronDown />}>
                   <span>Insert source</span>
                 </Button>
               </DropdownMenuTrigger>
@@ -105,8 +105,8 @@ const LogsQueryPanel = ({
             </DropdownMenu>
 
             <DropdownMenu>
-              <DropdownMenuTrigger>
-                <Button asChild type="default" iconRight={<IconChevronDown />}>
+              <DropdownMenuTrigger asChild>
+                <Button type="default" iconRight={<IconChevronDown />}>
                   <span>Templates</span>
                 </Button>
               </DropdownMenuTrigger>
@@ -166,7 +166,7 @@ const LogsQueryPanel = ({
                 </Button>
                 {IS_PLATFORM && onSave && (
                   <Tooltip.Root delayDuration={0}>
-                    <Tooltip.Trigger>
+                    <Tooltip.Trigger asChild>
                       <Button
                         type="default"
                         onClick={() => onSave()}

--- a/apps/studio/components/interfaces/Settings/Vault/Keys/EncryptionKeysManagement.tsx
+++ b/apps/studio/components/interfaces/Settings/Vault/Keys/EncryptionKeysManagement.tsx
@@ -150,7 +150,7 @@ const EncryptionKeysManagement = () => {
               </Link>
             </Button>
             <Tooltip.Root delayDuration={0}>
-              <Tooltip.Trigger>
+              <Tooltip.Trigger asChild>
                 <Button
                   type="primary"
                   disabled={!canManageKeys}
@@ -217,7 +217,7 @@ const EncryptionKeysManagement = () => {
                           Added on {dayjs(key.created).format('MMM D, YYYY')}
                         </p>
                         <Tooltip.Root delayDuration={0}>
-                          <Tooltip.Trigger>
+                          <Tooltip.Trigger asChild>
                             <Button
                               type="default"
                               className="py-2"

--- a/apps/studio/components/interfaces/Settings/Vault/Secrets/SecretRow.tsx
+++ b/apps/studio/components/interfaces/Settings/Vault/Secrets/SecretRow.tsx
@@ -110,9 +110,9 @@ const SecretRow = ({ secret, onSelectEdit, onSelectRemove }: SecretRowProps) => 
           {dayjs(secret.updated_at).format('MMM D, YYYY')}
         </p>
         <DropdownMenu>
-          <DropdownMenuTrigger>
-            <Button asChild type="text" className="px-1" icon={<IconMoreVertical />}>
-              <span></span>
+          <DropdownMenuTrigger asChild>
+            <Button type="text" className="px-1">
+              <IconMoreVertical />
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent side="bottom">

--- a/apps/studio/components/interfaces/Settings/Vault/Secrets/SecretsManagement.tsx
+++ b/apps/studio/components/interfaces/Settings/Vault/Secrets/SecretsManagement.tsx
@@ -112,7 +112,7 @@ const SecretsManagement = () => {
               </Link>
             </Button>
             <Tooltip.Root delayDuration={0}>
-              <Tooltip.Trigger>
+              <Tooltip.Trigger asChild>
                 <Button
                   type="primary"
                   disabled={!canManageSecrets}

--- a/apps/studio/components/interfaces/Settings/Vault/VaultToggle.tsx
+++ b/apps/studio/components/interfaces/Settings/Vault/VaultToggle.tsx
@@ -116,7 +116,7 @@ const VaultToggle = () => {
                 </Link>
               </Button>
               <Tooltip.Root delayDuration={0}>
-                <Tooltip.Trigger>
+                <Tooltip.Trigger asChild>
                   <Button
                     type="primary"
                     loading={isEnabling}

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/InputWithSuggestions.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/InputWithSuggestions.tsx
@@ -95,32 +95,31 @@ const InputWithSuggestions = ({
         actions={
           showSuggestions && (
             <DropdownMenu>
-              <DropdownMenuTrigger>
-                <Tooltip.Root delayDuration={0}>
+              <Tooltip.Root delayDuration={0}>
+                <DropdownMenuTrigger asChild>
                   <Tooltip.Trigger asChild>
-                    <Button
-                      type="default"
-                      className="!px-1 mr-1"
-                      icon={<IconList strokeWidth={1.5} />}
-                    />
+                    <Button type="default" className="!px-1 mr-1">
+                      <IconList strokeWidth={1.5} />
+                    </Button>
                   </Tooltip.Trigger>
-                  <Tooltip.Portal>
-                    <Tooltip.Content side="bottom">
-                      <Tooltip.Arrow className="radix-tooltip-arrow" />
-                      <div
-                        className={[
-                          'bg-alternative rounded py-1 px-2 leading-none shadow',
-                          'border-background border',
-                        ].join(' ')}
-                      >
-                        <span className="text-foreground text-xs">
-                          {suggestionsTooltip || 'Suggestions'}
-                        </span>
-                      </div>
-                    </Tooltip.Content>
-                  </Tooltip.Portal>
-                </Tooltip.Root>
-              </DropdownMenuTrigger>
+                </DropdownMenuTrigger>
+                <Tooltip.Portal>
+                  <Tooltip.Content side="bottom">
+                    <Tooltip.Arrow className="radix-tooltip-arrow" />
+                    <div
+                      className={[
+                        'bg-alternative rounded py-1 px-2 leading-none shadow',
+                        'border-background border',
+                      ].join(' ')}
+                    >
+                      <span className="text-foreground text-xs">
+                        {suggestionsTooltip || 'Suggestions'}
+                      </span>
+                    </div>
+                  </Tooltip.Content>
+                </Tooltip.Portal>
+              </Tooltip.Root>
+
               <DropdownMenuContent align="end" side="bottom">
                 <DropdownMenuLabel>{suggestionsHeader || 'Suggestions'}</DropdownMenuLabel>
                 <DropdownMenuSeparator />

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/InputWithSuggestions.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/InputWithSuggestions.tsx
@@ -103,7 +103,6 @@ const InputWithSuggestions = ({
                     </Button>
                   </Tooltip.Trigger>
                 </DropdownMenuTrigger>
-
                 <Tooltip.Portal>
                   <Tooltip.Content side="bottom">
                     <Tooltip.Arrow className="radix-tooltip-arrow" />

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/Column.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/Column.tsx
@@ -93,7 +93,7 @@ const Column = ({
       </div>
       <div className="w-[5%] mr-2.5">
         <Tooltip.Root delayDuration={0}>
-          <Tooltip.Trigger>
+          <Tooltip.Trigger asChild>
             <Button
               type={column.foreignKey !== undefined ? 'secondary' : 'default'}
               onClick={() => onEditRelation(column)}

--- a/apps/studio/components/layouts/ProjectLayout/LayoutHeader/FeedbackDropdown/FeedbackWidget.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/LayoutHeader/FeedbackDropdown/FeedbackWidget.tsx
@@ -173,16 +173,14 @@ const FeedbackWidget = ({
               </div>
             ) : (
               <DropdownMenu>
-                <DropdownMenuTrigger>
+                <DropdownMenuTrigger asChild>
                   <Button
-                    asChild
                     type="default"
                     disabled={isSavingScreenshot}
                     loading={isSavingScreenshot}
                     className="px-2 py-1.5"
-                    icon={<IconImage size={14} />}
                   >
-                    <span></span>
+                    <IconImage size={14} />
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent side="bottom" align="end">

--- a/apps/studio/components/layouts/ProjectLayout/NavigationBar/NavigationBar.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/NavigationBar/NavigationBar.tsx
@@ -206,11 +206,9 @@ const NavigationBar = () => {
             </Tooltip.Root>
           )}
           <DropdownMenu>
-            <DropdownMenuTrigger>
-              <Button asChild type="text" size="tiny">
-                <span className="py-1 h-10 border-none">
-                  <IconUser size={18} strokeWidth={2} className="text-foreground-lighter" />
-                </span>
+            <DropdownMenuTrigger asChild>
+              <Button type="text" size="tiny" className="py-1 h-10 border-none">
+                <IconUser size={18} strokeWidth={2} className="text-foreground-lighter" />
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent side="right" align="start">

--- a/apps/studio/components/layouts/ProjectLayout/ProjectPausedState.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/ProjectPausedState.tsx
@@ -119,7 +119,7 @@ const ProjectPausedState = ({ product }: ProjectPausedStateProps) => {
 
               <div className="flex items-center justify-center gap-4">
                 <Tooltip.Root delayDuration={0}>
-                  <Tooltip.Trigger>
+                  <Tooltip.Trigger asChild>
                     <Button
                       size="tiny"
                       type="primary"

--- a/apps/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
+++ b/apps/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
@@ -208,28 +208,29 @@ const TableEditorMenu = () => {
 
             <div className="flex gap-3 items-center">
               <DropdownMenu>
-                <DropdownMenuTrigger>
-                  <Tooltip.Root delayDuration={0}>
+                <Tooltip.Root delayDuration={0}>
+                  <DropdownMenuTrigger asChild>
                     <Tooltip.Trigger>
                       <div className="text-foreground-lighter transition-colors hover:text-foreground">
                         <IconChevronsDown size={18} strokeWidth={1} />
                       </div>
                     </Tooltip.Trigger>
-                    <Tooltip.Portal>
-                      <Tooltip.Content side="bottom">
-                        <Tooltip.Arrow className="radix-tooltip-arrow" />
-                        <div
-                          className={[
-                            'rounded bg-alternative py-1 px-2 leading-none shadow',
-                            'border border-background',
-                          ].join(' ')}
-                        >
-                          <span className="text-xs">Sort By</span>
-                        </div>
-                      </Tooltip.Content>
-                    </Tooltip.Portal>
-                  </Tooltip.Root>
-                </DropdownMenuTrigger>
+                  </DropdownMenuTrigger>
+                  <Tooltip.Portal>
+                    <Tooltip.Content side="bottom">
+                      <Tooltip.Arrow className="radix-tooltip-arrow" />
+                      <div
+                        className={[
+                          'rounded bg-alternative py-1 px-2 leading-none shadow',
+                          'border border-background',
+                        ].join(' ')}
+                      >
+                        <span className="text-xs">Sort By</span>
+                      </div>
+                    </Tooltip.Content>
+                  </Tooltip.Portal>
+                </Tooltip.Root>
+
                 <DropdownMenuContent side="bottom" align="start" className="w-48">
                   <DropdownMenuRadioGroup
                     value={sort}

--- a/apps/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
+++ b/apps/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
@@ -232,28 +232,28 @@ const TableEditorMenu = () => {
 
                     <div className="flex gap-3 items-center">
                       <DropdownMenu>
-                        <DropdownMenuTrigger>
-                          <Tooltip.Root delayDuration={0}>
-                            <Tooltip.Trigger asChild>
+                        <Tooltip.Root delayDuration={0}>
+                          <DropdownMenuTrigger asChild>
+                            <Tooltip.Trigger>
                               <div className="text-foreground-lighter transition-colors hover:text-foreground">
                                 <IconChevronsDown size={18} strokeWidth={1} />
                               </div>
                             </Tooltip.Trigger>
-                            <Tooltip.Portal>
-                              <Tooltip.Content side="bottom">
-                                <Tooltip.Arrow className="radix-tooltip-arrow" />
-                                <div
-                                  className={[
-                                    'rounded bg-alternative py-1 px-2 leading-none shadow',
-                                    'border border-background',
-                                  ].join(' ')}
-                                >
-                                  <span className="text-xs">Sort By</span>
-                                </div>
-                              </Tooltip.Content>
-                            </Tooltip.Portal>
-                          </Tooltip.Root>
-                        </DropdownMenuTrigger>
+                          </DropdownMenuTrigger>
+                          <Tooltip.Portal>
+                            <Tooltip.Content side="bottom">
+                              <Tooltip.Arrow className="radix-tooltip-arrow" />
+                              <div
+                                className={[
+                                  'rounded bg-alternative py-1 px-2 leading-none shadow',
+                                  'border border-background',
+                                ].join(' ')}
+                              >
+                                <span className="text-xs">Sort By</span>
+                              </div>
+                            </Tooltip.Content>
+                          </Tooltip.Portal>
+                        </Tooltip.Root>
                         <DropdownMenuContent side="bottom" align="start" className="w-48">
                           <DropdownMenuRadioGroup
                             value={sort}

--- a/apps/studio/components/to-be-cleaned/DateRangePicker.tsx
+++ b/apps/studio/components/to-be-cleaned/DateRangePicker.tsx
@@ -195,8 +195,8 @@ const DateRangePicker = ({
   return (
     <>
       <DropdownMenu>
-        <DropdownMenuTrigger>
-          <Button asChild type="default" iconRight={<IconChevronDown />}>
+        <DropdownMenuTrigger asChild>
+          <Button type="default" iconRight={<IconChevronDown />}>
             <span>{timePeriod && options.find((x) => x.key === timePeriod)?.label}</span>
           </Button>
         </DropdownMenuTrigger>

--- a/apps/studio/components/to-be-cleaned/Dropdown/OrganizationDropdown.tsx
+++ b/apps/studio/components/to-be-cleaned/Dropdown/OrganizationDropdown.tsx
@@ -24,8 +24,8 @@ const OrganizationDropdown = ({
 
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger>
-        <Button asChild>
+      <DropdownMenuTrigger asChild>
+        <Button type="primary">
           <span>New project</span>
         </Button>
       </DropdownMenuTrigger>

--- a/apps/studio/components/to-be-cleaned/Storage/StorageExplorer/PreviewPane.tsx
+++ b/apps/studio/components/to-be-cleaned/Storage/StorageExplorer/PreviewPane.tsx
@@ -210,7 +210,7 @@ const PreviewPane = ({ onCopyUrl }: PreviewPaneProps) => {
                 </Button>
               ) : (
                 <DropdownMenu>
-                  <DropdownMenuTrigger>
+                  <DropdownMenuTrigger asChild>
                     <Button
                       type="outline"
                       icon={<IconClipboard size={16} strokeWidth={2} />}
@@ -256,7 +256,7 @@ const PreviewPane = ({ onCopyUrl }: PreviewPaneProps) => {
               )}
             </div>
             <Tooltip.Root delayDuration={0}>
-              <Tooltip.Trigger>
+              <Tooltip.Trigger asChild>
                 <Button
                   type="outline"
                   disabled={!canUpdateFiles}

--- a/apps/studio/components/ui/UpgradeToPro.tsx
+++ b/apps/studio/components/ui/UpgradeToPro.tsx
@@ -50,8 +50,12 @@ const UpgradeToPro = ({
             </div>
           </div>
           <Tooltip.Root delayDuration={0}>
-            <Tooltip.Trigger>
-              <Button type="primary" disabled={!canUpdateSubscription || projectUpdateDisabled}>
+            <Tooltip.Trigger asChild>
+              <Button
+                type="primary"
+                disabled={!canUpdateSubscription || projectUpdateDisabled}
+                asChild
+              >
                 <Link
                   href={
                     plan === 'free'
@@ -63,35 +67,34 @@ const UpgradeToPro = ({
                 </Link>
               </Button>
             </Tooltip.Trigger>
-            {!canUpdateSubscription || projectUpdateDisabled ? (
-              <Tooltip.Portal>
-                <Tooltip.Content side="bottom">
-                  <Tooltip.Arrow className="radix-tooltip-arrow" />
-                  <div
-                    className={[
-                      'border border-background text-center', //border
-                      'rounded bg-alternative py-1 px-2 leading-none shadow', // background
-                    ].join(' ')}
-                  >
-                    <span className="text-xs text-foreground">
-                      {projectUpdateDisabled ? (
-                        <>
-                          Subscription changes are currently disabled.
-                          <br />
-                          Our engineers are working on a fix.
-                        </>
-                      ) : !canUpdateSubscription ? (
-                        'You need additional permissions to amend subscriptions'
-                      ) : (
-                        ''
-                      )}
-                    </span>
-                  </div>
-                </Tooltip.Content>
-              </Tooltip.Portal>
-            ) : (
-              <></>
-            )}
+            {!canUpdateSubscription ||
+              (projectUpdateDisabled && (
+                <Tooltip.Portal>
+                  <Tooltip.Content side="bottom">
+                    <Tooltip.Arrow className="radix-tooltip-arrow" />
+                    <div
+                      className={[
+                        'border border-background text-center', //border
+                        'rounded bg-alternative py-1 px-2 leading-none shadow', // background
+                      ].join(' ')}
+                    >
+                      <span className="text-xs text-foreground">
+                        {projectUpdateDisabled ? (
+                          <>
+                            Subscription changes are currently disabled.
+                            <br />
+                            Our engineers are working on a fix.
+                          </>
+                        ) : !canUpdateSubscription ? (
+                          'You need additional permissions to amend subscriptions'
+                        ) : (
+                          ''
+                        )}
+                      </span>
+                    </div>
+                  </Tooltip.Content>
+                </Tooltip.Portal>
+              ))}
           </Tooltip.Root>
         </div>
       </div>

--- a/apps/studio/pages/project/[ref]/auth/policies.tsx
+++ b/apps/studio/pages/project/[ref]/auth/policies.tsx
@@ -141,7 +141,7 @@ const AuthPoliciesPage: NextPageWithLayout = () => {
             </a>
             {isAiAssistantEnabled && (
               <Tooltip.Root delayDuration={0}>
-                <Tooltip.Trigger>
+                <Tooltip.Trigger asChild>
                   <Button
                     type="primary"
                     disabled={!canCreatePolicies}

--- a/apps/studio/pages/support/new.tsx
+++ b/apps/studio/pages/support/new.tsx
@@ -43,7 +43,7 @@ const SupportPage = () => {
                 </Link>
               </Button>
               <Tooltip.Root delayDuration={0}>
-                <Tooltip.Trigger>
+                <Tooltip.Trigger asChild>
                   <Button
                     asChild
                     type="default"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix

## What is the current behaviour?

The dashboard has many `<button>` inside `<button>` rendered in the HTML.

## What is the new behaviour?

Adds the missing `asChild` props to `<Tooltip.Trigger>` and `<DropdownMenuTrigger>` to prevent them rendering the extra `<button>` elements.