### PR TITLE
fix: add missing supabase database roles

### DIFF
--- a/apps/studio/components/interfaces/Database/Roles/Roles.constants.ts
+++ b/apps/studio/components/interfaces/Database/Roles/Roles.constants.ts
@@ -6,6 +6,7 @@ export const SUPABASE_ROLES = [
   'dashboard_user',
   'supabase_admin',
   'supabase_auth_admin',
+  'supabase_read_only_user',
   'supabase_replication_admin',
   'supabase_storage_admin',
   'supabase_functions_admin',
@@ -13,6 +14,8 @@ export const SUPABASE_ROLES = [
   'pgsodium_keyholder',
   'pgsodium_keyiduser',
   'pgsodium_keymaker',
+  'pgtle_admin',
+  'postgres',
 ]
 
 export const ROLE_PERMISSIONS: any = {

--- a/apps/studio/components/interfaces/Database/Roles/Roles.constants.ts
+++ b/apps/studio/components/interfaces/Database/Roles/Roles.constants.ts
@@ -15,7 +15,6 @@ export const SUPABASE_ROLES = [
   'pgsodium_keyiduser',
   'pgsodium_keymaker',
   'pgtle_admin',
-  'postgres',
 ]
 
 export const ROLE_PERMISSIONS: any = {


### PR DESCRIPTION
These roles should be included under "Roles managed by Supabase":
![Screenshot 2023-12-06 at 19 59 26](https://github.com/supabase/supabase/assets/10985857/b2312824-b0ab-4356-9949-9e14da3a4bae)

edit: the postgres role is modifiable by users.