### PR TITLE
Update using-custom-schemas.mdx to show both headers involved

### DIFF
--- a/apps/docs/pages/guides/api/using-custom-schemas.mdx
+++ b/apps/docs/pages/guides/api/using-custom-schemas.mdx
@@ -45,7 +45,9 @@ const { data: todos, error } = await supabase.from('todos').select('*')
 <TabPanel id="curl" label="cURL">
 
 ```bash
-# Append /rest/v1/ to your URL, and then use the table name as the route
+# Append /rest/v1/ to your URL, and then use the table name as the route.
+# Use Accept-Profile header for GET and HEAD.
+# Use Content-Profile header for POST, PATCH, PUT and DELETE.
 curl '<SUPABASE_URL>/rest/v1/todos' \
   -H "apikey: <SUPABASE_ANON_KEY>" \
   -H "Authorization: Bearer <SUPABASE_ANON_KEY>" \


### PR DESCRIPTION
PostgREST uses different headers for alternate schemas add note to CURL comments to mention this.

## What kind of change does this PR introduce?

Document update.  Resolves https://github.com/supabase/supabase/issues/19159

## What is the current behavior?

Does not show Content-Profile header in curl example

## What is the new behavior?

Mentions there are two headers involved.

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
