### PR TITLE
fix: fix labelling for management api search items

### DIFF
--- a/apps/docs/scripts/search/sources/reference-doc.ts
+++ b/apps/docs/scripts/search/sources/reference-doc.ts
@@ -150,11 +150,14 @@ export class OpenApiReferenceSource extends ReferenceSource<enrichedOperation> {
   }
 
   extractSubtitle() {
-    return typeof this.specSection.description === 'string' ? this.specSection.description : ''
+    return `${this.meta.title}: ${this.specSection.description}`
   }
 
   extractTitle() {
-    return `${this.meta.title}: ${this.specSection.operation}`
+    return (
+      this.specSection.summary ||
+      (typeof this.meta.title === 'string' ? this.meta.title : this.specSection.operation)
+    )
   }
 
   extractIndexedContent(): string {


### PR DESCRIPTION
Before:
<img width="765" alt="image" src="https://github.com/supabase/supabase/assets/26616127/6acb7ff1-c7de-4659-a598-9d62e596c8ea">
After:
<img width="760" alt="image" src="https://github.com/supabase/supabase/assets/26616127/52ea862d-e4e8-464b-9d4d-f717c9be16af">
