### PR TITLE
docs: Fix markdown link in branching docs

### DIFF
--- a/apps/docs/pages/guides/platform/branching.mdx
+++ b/apps/docs/pages/guides/platform/branching.mdx
@@ -222,7 +222,7 @@ Before turning on branching, make sure your [GitHub repository is prepared](#set
 
 <Admonition type="note" label="Branching is early access only">
 
-Sign up for early access (here)[https://forms.supabase.com/branching-request].
+Sign up for early access [here](https://forms.supabase.com/branching-request).
 
 </Admonition>
 


### PR DESCRIPTION
![image](https://github.com/supabase/supabase/assets/1523305/ae942c40-529b-466c-8483-5a16ebae5a13)

https://twitter.com/kamilogorek/status/1724801389191479674