### PR TITLE
Fix typo in testing-and-linting.mdx

### DIFF
--- a/apps/docs/pages/guides/cli/testing-and-linting.mdx
+++ b/apps/docs/pages/guides/cli/testing-and-linting.mdx
@@ -11,7 +11,7 @@ The Supabase CLI provides a set of tools to help you test and lint your Postgres
 
 ## Testing your database
 
-The Supabase CLI provides Postgres liniting using the `supabase test db` command.
+The Supabase CLI provides Postgres linting using the `supabase test db` command.
 
 {/* prettier-ignore */}
 ```markdown


### PR DESCRIPTION
Fix single-character typo in Testing and Linting docs