### PR TITLE
Fix typos in testing-and-linting.mdx

### DIFF
--- a/apps/docs/pages/guides/cli/testing-and-linting.mdx
+++ b/apps/docs/pages/guides/cli/testing-and-linting.mdx
@@ -11,7 +11,7 @@ The Supabase CLI provides a set of tools to help you test and lint your Postgres
 
 ## Testing your database
 
-The Supabase CLI provides Postgres liniting using the `supabase test db` command.
+The Supabase CLI provides Postgres linting using the `supabase test db` command.
 
 {/* prettier-ignore */}
 ```markdown
@@ -50,7 +50,7 @@ The "default" email provided by Supabase is only for development purposes. It is
 
 ## Linting your database
 
-The Supabase CLI provides Postgres liniting using the `supabase db lint` command:
+The Supabase CLI provides Postgres linting using the `supabase db lint` command:
 
 {/* prettier-ignore */}
 ```markdown


### PR DESCRIPTION
Change "liniting" to "linting" in testing-and-linting.mdx
