### PR TITLE
chore: update tsx

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -82,7 +82,7 @@
     "openapi-types": "^12.0.2",
     "sass": "^1.68.0",
     "tsconfig": "*",
-    "tsx": "^3.14.0",
+    "tsx": "^4.6.2",
     "typescript": "^5.2.2"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -549,7 +549,7 @@
         "openapi-types": "^12.0.2",
         "sass": "^1.68.0",
         "tsconfig": "*",
-        "tsx": "^3.14.0",
+        "tsx": "^4.6.2",
         "typescript": "^5.2.2"
       }
     },
@@ -33064,28 +33064,22 @@
       "license": "0BSD"
     },
     "node_modules/tsx": {
-      "version": "3.14.0",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.6.2.tgz",
+      "integrity": "sha512-QPpBdJo+ZDtqZgAnq86iY/PD2KYCUPSUGIunHdGwyII99GKH+f3z3FZ8XNFLSGQIA4I365ui8wnQpl8OKLqcsg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "esbuild": "~0.18.20",
-        "get-tsconfig": "^4.7.2",
-        "source-map-support": "^0.5.21"
+        "get-tsconfig": "^4.7.2"
       },
       "bin": {
         "tsx": "dist/cli.mjs"
       },
+      "engines": {
+        "node": ">=18.0.0"
+      },
       "optionalDependencies": {
         "fsevents": "~2.3.3"
-      }
-    },
-    "node_modules/tsx/node_modules/source-map-support": {
-      "version": "0.5.21",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
       }
     },
     "node_modules/turbo": {


### PR DESCRIPTION
Embedding generation is failing in CI because of a breaking change in an experimental feature relied on by tsx@v3 when going from Node v18.18 to Node v18.19.

Update to tsx@v4 fixes this. Only affects embeddings script as this is the docs-specific `tsx` and docs doesn't use it for anything else.