### PR TITLE
Data Type in create column side panel should reset for new column

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.tsx
@@ -276,6 +276,7 @@ const ColumnEditor = ({
             error={errors.format}
             disabled={columnFields?.foreignKey !== undefined}
             onOptionSelect={(format: string) => onUpdateField({ format, defaultValue: null })}
+            isNewRecord={isNewRecord}
           />
           {columnFields.foreignKey === undefined && (
             <div className="space-y-4">

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnType.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnType.tsx
@@ -34,7 +34,7 @@ interface ColumnTypeProps {
   description?: ReactNode
   showRecommendation?: boolean
   onOptionSelect: (value: string) => void
-  isNewRecord: boolean
+  isNewRecord?: boolean
 }
 
 const ColumnType = ({

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnType.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnType.tsx
@@ -49,7 +49,7 @@ const ColumnType = ({
   description,
   showRecommendation = false,
   onOptionSelect = noop,
-  isNewRecord,
+  isNewRecord = false,
 }: ColumnTypeProps) => {
   // @ts-ignore
   const availableTypes = POSTGRES_DATA_TYPES.concat(enumTypes.map((type) => type.name))

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnType.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnType.tsx
@@ -49,7 +49,7 @@ const ColumnType = ({
   description,
   showRecommendation = false,
   onOptionSelect = noop,
-  isNewRecord
+  isNewRecord,
 }: ColumnTypeProps) => {
   // @ts-ignore
   const availableTypes = POSTGRES_DATA_TYPES.concat(enumTypes.map((type) => type.name))

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnType.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnType.tsx
@@ -34,6 +34,7 @@ interface ColumnTypeProps {
   description?: ReactNode
   showRecommendation?: boolean
   onOptionSelect: (value: string) => void
+  isNewRecord: boolean
 }
 
 const ColumnType = ({
@@ -48,6 +49,7 @@ const ColumnType = ({
   description,
   showRecommendation = false,
   onOptionSelect = noop,
+  isNewRecord
 }: ColumnTypeProps) => {
   // @ts-ignore
   const availableTypes = POSTGRES_DATA_TYPES.concat(enumTypes.map((type) => type.name))
@@ -108,6 +110,7 @@ const ColumnType = ({
         className={`${className} ${disabled ? 'column-type-disabled' : ''} rounded-md`}
         onChange={(value: string) => onOptionSelect(value)}
         optionsWidth={480}
+        isNewRecord={isNewRecord}
       >
         <Listbox.Option key="empty" value="" label="---">
           ---

--- a/packages/ui/src/components/Listbox/Listbox2.tsx
+++ b/packages/ui/src/components/Listbox/Listbox2.tsx
@@ -58,7 +58,7 @@ function Listbox({
   validation,
   disabled,
   optionsWidth,
-  isNewRecord,
+  isNewRecord = false,
 }: Props) {
   const [selected, setSelected] = useState(undefined)
   const [selectedNode, setSelectedNode] = useState<any>({})

--- a/packages/ui/src/components/Listbox/Listbox2.tsx
+++ b/packages/ui/src/components/Listbox/Listbox2.tsx
@@ -33,6 +33,7 @@ export interface Props extends Omit<React.InputHTMLAttributes<HTMLButtonElement>
   // override the button prop for onchange we only return a single value
   // rather than a ChangeEvent<HTMLButtonElement>
   onChange?: (x: any) => void
+  isNewRecord?: boolean
 }
 
 function Listbox({
@@ -57,6 +58,7 @@ function Listbox({
   validation,
   disabled,
   optionsWidth,
+  isNewRecord,
 }: Props) {
   const [selected, setSelected] = useState(undefined)
   const [selectedNode, setSelectedNode] = useState<any>({})
@@ -84,7 +86,7 @@ function Listbox({
   }
 
   useEffect(() => {
-    if (value) {
+    if (value && !isNewRecord) {
       setSelected(value)
     }
   }, [value])
@@ -125,7 +127,7 @@ function Listbox({
     /*
      * value prop overrides everything
      */
-    if (value) {
+    if (value && !isNewRecord) {
       setSelected(value)
       const node: any = findNode(value)
       setSelectedNode(node?.props ? node.props : undefined)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

This PR fixes https://github.com/supabase/supabase/issues/19109

## What is the new behavior?

RCA: The issue was that the 'selected' state was being persisted even after closing the column editor side panel. This was happening because whenever we reopen the side panel, the old value of 'selected' get picked up.

Now, I passed the 'isNewRecord' variable from ColumnEditor to ColumnType to ListBox. There are two cases:
**Case 1** : When isNewRecord is true (i.e we are creating a new column), we open the column editor, the old value of 'selected' isn't picked up.
**Case 2**: When isNewRecord is false (i.e we are editing existing column), the old value of 'selected' is picked up. 
I have mentioned the two cases in attached video.

## Additional context


https://github.com/supabase/supabase/assets/151846514/3c067087-9b83-4f75-b70a-2156b899d7df


