### PR TITLE
fix: add requirement on Docker client for edge funcs deploy

### DIFF
--- a/apps/docs/pages/guides/functions/deploy.mdx
+++ b/apps/docs/pages/guides/functions/deploy.mdx
@@ -54,7 +54,6 @@ Since Supabase CLI version 1.123.4, you must have [Docker Desktop](https://docs.
 
 </Admonition>
 
-
 You can deploy all of your Edge Functions with a single command:
 
 ```bash

--- a/apps/docs/pages/guides/functions/deploy.mdx
+++ b/apps/docs/pages/guides/functions/deploy.mdx
@@ -48,6 +48,13 @@ supabase link --project-ref your-project-id
 
 ## Deploy your Edge Functions
 
+<Admonition type="tip" label="Docker required">
+
+Since Supabase CLI version 1.123.4, you must have a [Docker client](https://docs.docker.com/desktop/) installed in your machine to deploy Edge Functions.
+
+</Admonition>
+
+
 You can deploy all of your Edge Functions with a single command:
 
 ```bash

--- a/apps/docs/pages/guides/functions/deploy.mdx
+++ b/apps/docs/pages/guides/functions/deploy.mdx
@@ -50,7 +50,7 @@ supabase link --project-ref your-project-id
 
 <Admonition type="tip" label="Docker required">
 
-Since Supabase CLI version 1.123.4, you must have a [Docker client](https://docs.docker.com/desktop/) installed in your machine to deploy Edge Functions.
+Since Supabase CLI version 1.123.4, you must have a [Docker Desktop](https://docs.docker.com/desktop/) installed in your machine to deploy Edge Functions.
 
 </Admonition>
 

--- a/apps/docs/pages/guides/functions/deploy.mdx
+++ b/apps/docs/pages/guides/functions/deploy.mdx
@@ -50,7 +50,7 @@ supabase link --project-ref your-project-id
 
 <Admonition type="tip" label="Docker required">
 
-Since Supabase CLI version 1.123.4, you must have a [Docker Desktop](https://docs.docker.com/desktop/) installed in your machine to deploy Edge Functions.
+Since Supabase CLI version 1.123.4, you must have [Docker Desktop](https://docs.docker.com/desktop/) installed to deploy Edge Functions.
 
 </Admonition>
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Updated the Edge Functions deploy docs to mention the requirement of Docker client.