### PR TITLE
feat: rename replication section to publication

### DIFF
--- a/apps/docs/pages/guides/auth/auth-helpers/remix.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/remix.mdx
@@ -757,7 +757,7 @@ export default function Index() {
 
 </Tabs>
 
-> Ensure you have [enabled replication](https://supabase.com/dashboard/project/_/database/replication) on the table you are subscribing to.
+> Ensure you have [enabled replication](https://supabase.com/dashboard/project/_/database/publication) on the table you are subscribing to.
 
 ## Migration Guide
 

--- a/apps/docs/pages/guides/realtime/postgres-changes.mdx
+++ b/apps/docs/pages/guides/realtime/postgres-changes.mdx
@@ -90,17 +90,17 @@ In this example we'll set up a database table, secure it with Row Level Security
   </StepHikeCompact.Step>
 
   <StepHikeCompact.Step step={3}>
-  
+
     <StepHikeCompact.Details title="Enable Postgres replication">
 
-      Go to your project's [Replication settings](https://supabase.com/dashboard/project/_/database/replication), and under `supabase_realtime`, toggle on the tables you want to listen to.
+      Go to your project's [Replication settings](https://supabase.com/dashboard/project/_/database/publication), and under `supabase_realtime`, toggle on the tables you want to listen to.
 
     </StepHikeCompact.Details>
 
   </StepHikeCompact.Step>
 
   <StepHikeCompact.Step step={4}>
-  
+
     <StepHikeCompact.Details title="Install the client">
 
       Install the Supabase JavaScript client.
@@ -118,7 +118,7 @@ In this example we'll set up a database table, secure it with Row Level Security
   </StepHikeCompact.Step>
 
   <StepHikeCompact.Step step={5}>
-  
+
     <StepHikeCompact.Details title="Create the client">
 
       This client will be used to listen to Postgres changes.

--- a/apps/studio/components/interfaces/Realtime/Inspector/MessagesTable.tsx
+++ b/apps/studio/components/interfaces/Realtime/Inspector/MessagesTable.tsx
@@ -71,7 +71,7 @@ const NoResultAlert = ({
                 <p className="text-foreground">Listen to a table for changes</p>
                 <p className="text-foreground-lighter text-xs">Tables must have realtime enabled</p>
               </div>
-              <Link href={`/project/${ref}/database/replication`} target="_blank" rel="noreferrer">
+              <Link href={`/project/${ref}/database/publication`} target="_blank" rel="noreferrer">
                 <Button type="default" iconRight={<IconExternalLink />}>
                   Replication settings
                 </Button>

--- a/apps/studio/components/interfaces/TableGridEditor/GridHeaderActions.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/GridHeaderActions.tsx
@@ -185,7 +185,7 @@ const GridHeaderActions = ({ table }: GridHeaderActionsProps) => {
           {!isRealtimeEnabled && (
             <p className="text-sm">
               You may also select which events to broadcast to subscribers on the{' '}
-              <Link href={`/project/${ref}/database/replication`} className="text-brand">
+              <Link href={`/project/${ref}/database/publication`} className="text-brand">
                 database replication
               </Link>{' '}
               settings.

--- a/apps/studio/components/layouts/DatabaseLayout/DatabaseMenu.utils.ts
+++ b/apps/studio/components/layouts/DatabaseLayout/DatabaseMenu.utils.ts
@@ -40,9 +40,9 @@ export const generateDatabaseMenu = (
         },
         { name: 'Roles', key: 'roles', url: `/project/${ref}/database/roles`, items: [] },
         {
-          name: 'Replication',
-          key: 'replication',
-          url: `/project/${ref}/database/replication`,
+          name: 'Publications',
+          key: 'publication',
+          url: `/project/${ref}/database/publication`,
           items: [],
         },
         ...(!!pgNetExtensionExists

--- a/apps/studio/next.config.js
+++ b/apps/studio/next.config.js
@@ -210,6 +210,11 @@ const nextConfig = {
         permanent: true,
       },
       {
+        source: '/project/:ref/database/replication',
+        destination: '/project/:ref/database/publication',
+        permanent: true,
+      },
+      {
         source: '/project/:ref/logs/pgbouncer-logs',
         destination: '/project/:ref/logs/pooler-logs',
         permanent: true,

--- a/apps/studio/pages/project/[ref]/database/publication.tsx
+++ b/apps/studio/pages/project/[ref]/database/publication.tsx
@@ -35,7 +35,7 @@ const DatabaseReplication: NextPageWithLayout = () => {
       <ScaffoldSection>
         <div className="col-span-12">
           <div className="mb-4">
-            <h3 className="mb-1 text-xl text-foreground">Database Replications</h3>
+            <h3 className="mb-1 text-xl text-foreground">Database Publications</h3>
           </div>
           {selectedPublicationId === undefined ? (
             <PublicationsList onSelectPublication={setSelectedPublicationId} />

--- a/apps/www/_blog/2022-11-17-fetching-and-caching-supabase-data-in-next-js-server-components.mdx
+++ b/apps/www/_blog/2022-11-17-fetching-and-caching-supabase-data-in-next-js-server-components.mdx
@@ -384,7 +384,7 @@ But now we have loading spinners! Yuck!
 
 # Realtime
 
-Realtime allows us to subscribe to changes in Supabase — inserted, updated or deleted posts — and update our UI dynamically. In order to receive realtime events, we need to [enable replication](https://supabase.com/dashboard/project/_/database/replication) on the posts table.
+Realtime allows us to subscribe to changes in Supabase — inserted, updated or deleted posts — and update our UI dynamically. In order to receive realtime events, we need to [enable replication](https://supabase.com/dashboard/project/_/database/publication) on the posts table.
 
 Let’s merge the two previous concepts and fetch the initial state of our posts in a Server Component, and then render a Client Component to do client-y things — like subscribe to changes in the DB and update the UI dynamically:
 

--- a/examples/caching/with-nextjs-13-server-components/app/realtime/realtime-posts.tsx
+++ b/examples/caching/with-nextjs-13-server-components/app/realtime/realtime-posts.tsx
@@ -17,7 +17,7 @@ export default function RealtimePosts({ serverPosts }: { serverPosts: any }) {
 
   useEffect(() => {
     // ensure you have enabled replication on the `posts` table
-    // https://supabase.com/dashboard/project/_/database/replication
+    // https://supabase.com/dashboard/project/_/database/publication
     const channel = supabase
       .channel('*')
       .on('postgres_changes', { event: 'INSERT', schema: 'public', table: 'posts' }, (payload) =>

--- a/packages/ui/src/components/Command/utils/shared-nav-items.json
+++ b/packages/ui/src/components/Command/utils/shared-nav-items.json
@@ -33,8 +33,8 @@
           "url": "/project/_/database/roles"
         },
         {
-          "label": "Replication",
-          "url": "/project/_/database/replication"
+          "label": "Publication",
+          "url": "/project/_/database/publication"
         },
         {
           "label": "Webhooks",


### PR DESCRIPTION
these correspond to Postgres publication and this clarifies that. Has the potential to also be confused with Postgres Read Replicas.

more internal context - https://supabase.slack.com/archives/C02FHG9QQAF/p1702114864204559