### PR TITLE
chore: improve tooltips for usage breakdowns

### DIFF
--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/BillingMetric.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/BillingMetric.tsx
@@ -125,8 +125,8 @@ const BillingMetric = ({
             <Tooltip.Portal>
               <Tooltip.Content side="bottom">
                 <Tooltip.Arrow className="radix-tooltip-arrow" />
-                <div className="rounded bg-alternative py-1 px-2 leading-none shadow border border-background min-w-[250px]">
-                  <div className="text-xs text-foreground max-w-sm space-y-2">
+                <div className="rounded bg-alternative py-1 px-2 leading-none shadow border border-background min-w-[300px] max-w-[450px] max-h-[300px] overflow-y-auto">
+                  <div className="text-xs text-foreground space-y-2">
                     <p className="font-medium">{usageMeta.unit_price_desc}</p>
 
                     {usageMeta.project_allocations && usageMeta.project_allocations.length > 0 && (

--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/ComputeMetric.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/ComputeMetric.tsx
@@ -52,8 +52,8 @@ const ComputeMetric = ({ slug, metric, usage, relativeToSubscription }: ComputeM
           <Tooltip.Portal>
             <Tooltip.Content side="bottom">
               <Tooltip.Arrow className="radix-tooltip-arrow" />
-              <div className="rounded bg-alternative py-1 px-2 leading-none shadow border border-background min-w-[250px]">
-                <div className="text-xs text-foreground max-w-sm space-y-2">
+              <div className="rounded bg-alternative py-1 px-2 leading-none shadow border border-background min-w-[300px] max-w-[450px] max-h-[300px] overflow-y-auto">
+                <div className="text-xs text-foreground space-y-2">
                   <p className="font-medium">{usageMeta?.unit_price_desc}</p>
 
                   {usageMeta?.project_allocations && usageMeta.project_allocations.length > 0 && (


### PR DESCRIPTION
Especially with branching, we can have quite a few project entries in the breakdown. PR improves styling and caps the height.

![Screenshot 2023-12-13 at 12 02 15](https://github.com/supabase/supabase/assets/14073399/e0fdbf88-2521-4de1-9c6a-8bd036eefb97)
