### PR TITLE
fix: time until hackathon end count down clock

### DIFF
--- a/apps/www/components/LaunchWeek/X/Releases/MainStage.tsx
+++ b/apps/www/components/LaunchWeek/X/Releases/MainStage.tsx
@@ -5,7 +5,7 @@ import SectionContainer from '~/components/Layouts/SectionContainer'
 import DaySection from './components/DaySection'
 import { TextLink } from 'ui'
 import CountdownComponent from '../Countdown'
-import { endOfLWX } from './data/lwx_data'
+import { endOfLWXHackathon } from './data/lwx_data'
 
 const MainStage: FC = () => (
   <SectionContainer className="relative !max-w-none !py-0 lg:!container" id="main-stage">
@@ -14,7 +14,7 @@ const MainStage: FC = () => (
     </h3>
     <div className="font-mono uppercase tracking-[1px] py-8 border-t border-[#111718] text-[#575E61] scroll-mt-16 flex flex-col md:flex-row justify-between gap-2">
       <div className="!text-foreground [&_*]:text-foreground text-sm flex flex-col sm:flex-row sm:items-center sm:gap-3">
-        Hackathon ends in <CountdownComponent date={endOfLWX} showCard={false} />
+        Hackathon ends in <CountdownComponent date={endOfLWXHackathon} showCard={false} />
       </div>
       <div className="!m-0 flex items-center">
         <TextLink

--- a/apps/www/components/LaunchWeek/X/Releases/data/lwx_data.tsx
+++ b/apps/www/components/LaunchWeek/X/Releases/data/lwx_data.tsx
@@ -49,7 +49,7 @@ export interface WeekDayProps {
   steps: StepProps[] | []
 }
 
-export const endOfLWX = '2023-12-15T23:59:59.999-08:00'
+export const endOfLWXHackathon = '2023-12-17T23:59:59.999-08:00'
 
 const days: WeekDayProps[] = [
   {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently, the count down on the launch week landing page is set to count down the time until the LWX ends, but the hackathon actually goes for another two days as it says so in the hackathon blog post:

>The submission deadline is 11:59 pm Sunday midnight PT 17th December 2023

<img width="1182" alt="Screenshot 2023-12-14 at 14 49 33" src="https://github.com/supabase/supabase/assets/18113850/70af99ce-bd74-477d-8669-bf45f243f3f5">

This PR fixes the count down clock.