### PR TITLE
chore: change current to all local for migrations in db reset command

### DIFF
--- a/spec/cli_v1_commands.yaml
+++ b/spec/cli_v1_commands.yaml
@@ -2700,11 +2700,11 @@ commands:
         default_value: ''
       - id: linked
         name: --linked
-        description: Resets the linked project to all local migrations.
+        description: Resets the linked project with local migrations.
         default_value: 'false'
       - id: local
         name: --local
-        description: Resets the local database to all local migrations.
+        description: Resets the local database with local migrations.
         default_value: 'true'
       - id: version
         name: --version <string>

--- a/spec/cli_v1_commands.yaml
+++ b/spec/cli_v1_commands.yaml
@@ -2700,11 +2700,11 @@ commands:
         default_value: ''
       - id: linked
         name: --linked
-        description: Resets the linked project to current migrations.
+        description: Resets the linked project to all local migrations.
         default_value: 'false'
       - id: local
         name: --local
-        description: Resets the local database to current migrations.
+        description: Resets the local database to all local migrations.
         default_value: 'true'
       - id: version
         name: --version <string>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Updates docs for db reset command in cli. Make it clear that all local migrations will be applied. At least for me "current" isn't that clear that all migrations available locally can be applied.

## What is the current behavior?

## What is the new behavior?

## Additional context
