### PR TITLE
Update tailwind.config.js - adjusts ol:li margins in blog

### DIFF
--- a/packages/config/tailwind.config.js
+++ b/packages/config/tailwind.config.js
@@ -200,7 +200,6 @@ const uiConfig = ui({
               display: 'block',
               position: 'relative',
               paddingLeft: '1rem',
-              marginBottom: '2rem',
             },
             'ol>li::before': {
               position: 'absolute',


### PR DESCRIPTION
## What kind of change does this PR introduce?

- adjusts ol:li margins

before:
<img width="1013" alt="Screenshot 2023-12-15 at 12 22 15 AM" src="https://github.com/supabase/supabase/assets/8291514/49a1f380-b0eb-44f2-a86f-8f7a91ab90ed">

after:
<img width="862" alt="Screenshot 2023-12-15 at 12 21 37 AM" src="https://github.com/supabase/supabase/assets/8291514/bb4d1575-ec11-4f71-afa7-47a22c0ec3d9">

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
