### PR TITLE
Fix: misnamed CSV files

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/ResultsDropdown.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/ResultsDropdown.tsx
@@ -123,7 +123,7 @@ const ResultsDropdown = ({ id, isExecuting }: ResultsDropdownProps) => {
         className="hidden"
         headers={headers}
         data={csvData}
-        filename={`supabase_${project?.ref}_${snap.snippets[id]?.snippet.name}`}
+        filename={`supabase_${project?.ref}_${snap.snippets[id]?.snippet.name}.csv`}
       />
 
       <DropdownMenuContent side="bottom" align="start">


### PR DESCRIPTION
## What kind of change does this PR introduce?

**Bug fix:** If a saved query is named "Something" it will download a CSV. However, if it is named "Something 1.0" it will not. In both situations, the file downloads, but in the non-working case, we have to append ".csv" at the end.
