### PR TITLE
19768 - Added Custom Styling for Docs Sidenav Scrollbar

### DIFF
--- a/apps/docs/layouts/SiteLayout.tsx
+++ b/apps/docs/layouts/SiteLayout.tsx
@@ -305,6 +305,7 @@ const NavContainer = memo(function NavContainer() {
           'border-r overflow-auto h-screen',
           'backdrop-blur backdrop-filter bg-background',
           'flex flex-col',
+          'custom-scrollbar'
         ].join(' ')}
       >
         <div className="top-0 sticky z-10">

--- a/apps/docs/styles/main.scss
+++ b/apps/docs/styles/main.scss
@@ -54,6 +54,26 @@ article h1 {
   scrollbar-width: thin;
 }
 
+.custom-scrollbar {
+  &::-webkit-scrollbar {
+    width: 8px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: hsl(var(--scrollbar-track));
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: hsl(var(--scrollbar-thumb));
+    border-radius: 100vh;
+    border: 2px solid hsl(var(--scrollbar-track));
+  }
+
+  &::-webkit-scrollbar-thumb:hover {
+    background: hsl(var(--scrollbar-hover));
+  }
+}
+
 .sidebar-width {
   width: var(--sidebar-width);
 }

--- a/packages/ui/build/css/themes/dark.css
+++ b/packages/ui/build/css/themes/dark.css
@@ -31,6 +31,9 @@
   --destructive-200: 10.9deg 23.4% 9.2%;
   --background-alternative-200: 0deg 0% 5.5%;
   --foreground-contrast: 0deg 0% 11%;
+  --scrollbar-track: 0deg   0%  20%;
+  --scrollbar-thumb: 136deg 56% 45%;
+  --scrollbar-hover: 136deg 56% 49%;
   --border-button-hover: var(--colors-gray-dark-800);
   --border-button-default: var(--colors-gray-dark-700);
   --border-stronger: var(--colors-gray-dark-800);

--- a/packages/ui/build/css/themes/light.css
+++ b/packages/ui/build/css/themes/light.css
@@ -32,6 +32,9 @@
   --background-alternative-default: 0deg 0% 100%;
   --background-alternative-200: 0deg 0% 100%;
   --foreground-contrast: 210deg 25% 98.4%;
+  --scrollbar-track: 192deg 15% 94%;
+  --scrollbar-thumb: 153deg 58% 42%;
+  --scrollbar-hover: 153deg 59% 35%;
   --border-button-hover: var(--colors-slate-light-700);
   --border-button-default: var(--colors-slate-light-600);
   --border-stronger: var(--colors-gray-light-800);


### PR DESCRIPTION
## What kind of change does this PR introduce?

Enhancement - https://github.com/supabase/supabase/issues/19768

## What is the current behavior?

The default side navigation scrollbar on the [Supabase Documentation](https://supabase.com/docs) website appear bulky and dull, especially when positioned at the center of the screen.

## What is the new behavior?

I have implemented a refined styling for the scrollbar, ensuring compatibility with both dark and light themes and optimizing it for mobile responsiveness.

## Screenshots
![Screenshot 2023-12-13 172701](https://github.com/supabase/supabase/assets/41871409/388c65e2-5198-4536-94c0-e83111429b07)

![Screenshot 2023-12-13 172908](https://github.com/supabase/supabase/assets/41871409/641eeca9-b502-4aa3-b9d5-598f40089d1c)

