### PR TITLE
Chore: Add matcher for middleware

### DIFF
--- a/apps/docs/pages/guides/auth/server-side/creating-a-client.mdx
+++ b/apps/docs/pages/guides/auth/server-side/creating-a-client.mdx
@@ -216,6 +216,19 @@ export async function middleware(request: NextRequest) {
 
   return response
 }
+
+export const config = {
+  matcher: [
+    /*
+     * Match all request paths except for the ones starting with:
+     * - _next/static (static files)
+     * - _next/image (image optimization files)
+     * - favicon.ico (favicon file)
+     * Feel free to modify this pattern to include more paths.
+     */
+    '/((?!_next/static|_next/image|favicon.ico).*)',
+  ],
+}
 ```
 
 </TabPanel>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Big fix

## What is the current behavior?

Middleware runs for every asset on every load

## What is the new behavior?

Matcher excludes assets from middleware

## Additional context

https://github.com/supabase/supabase/pull/19732
