### PR TITLE
fix: change warning to caution

### DIFF
--- a/apps/docs/pages/guides/auth/auth-helpers/auth-ui.mdx
+++ b/apps/docs/pages/guides/auth/auth-helpers/auth-ui.mdx
@@ -447,7 +447,7 @@ A full list of the available variables is below:
 
 </Tabs>
 
-<Admonition type="warning">
+<Admonition type="caution">
 
 Currently, translating error messages (e.g. "Invalid credentials") is not supported. Check [related issue.](https://github.com/supabase/auth-ui/issues/86)
 

--- a/apps/docs/pages/guides/database/postgres/enums.mdx
+++ b/apps/docs/pages/guides/database/postgres/enums.mdx
@@ -106,7 +106,7 @@ alter type mood add value 'content';
 
 Even though it is possible, it is unsafe to remove enum values once they have been created. It's better to leave the enum value in place.
 
-<Admonition type="warning">
+<Admonition type="caution">
 
 Read the [Postgres mailing list](https://www.postgresql.org/message-id/21012.1459434338%40sss.pgh.pa.us) for more information:
 

--- a/apps/docs/pages/guides/self-hosting/docker.mdx
+++ b/apps/docs/pages/guides/self-hosting/docker.mdx
@@ -292,7 +292,7 @@ Additional configuration is required for self-hosting the Analytics server. For 
 
 Due to the changes in the Analytics server, you will need to run the following commands to upgrade your Analytics server:
 
-<Admonition type="warning">
+<Admonition type="caution">
 
 All data in analytics will be deleted when you run the commands below.
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

The [warning admonition type](https://github.com/supabase/supabase/blob/c8bb436ba7c7d506f7043452c8e641c35125fcf1/packages/ui/src/components/Admonition/index.tsx#L16) doesn't exist