### PR TITLE
fixed typo

### DIFF
--- a/apps/studio/components/to-be-cleaned/Storage/StoragePolicies/StoragePolicies.constants.ts
+++ b/apps/studio/components/to-be-cleaned/Storage/StoragePolicies/StoragePolicies.constants.ts
@@ -37,7 +37,7 @@ ON storage.objects FOR {operation} {USING | WITH CHECK} (
   },
   {
     id: 'policy-2',
-    templateName: 'Give users access to only their own a top level folder named as uid',
+    templateName: 'Give users access to only their own top level folder named as uid',
     description:
       'For example a user with id d7bed83c-44a0-4a4f-925f-efc384ea1e50 will be able to access anything under the folder d7bed83c-44a0-4a4f-925f-efc384ea1e50/',
     name: 'Give users access to own folder',


### PR DESCRIPTION
Fixed typo in string "Give users access to only their own a top level folder named as uid"
