### PR TITLE
chore: move sign_in telemetry event

### DIFF
--- a/apps/studio/components/interfaces/SignIn/SignInMfaForm.tsx
+++ b/apps/studio/components/interfaces/SignIn/SignInMfaForm.tsx
@@ -7,6 +7,7 @@ import { useEffect, useState } from 'react'
 import { Button, Form, IconLock, Input } from 'ui'
 import { object, string } from 'yup'
 
+import { useTelemetryProps } from 'common'
 import AlertError from 'components/ui/AlertError'
 import { GenericSkeletonLoader } from 'components/ui/ShimmeringLoader'
 import { useMfaChallengeAndVerifyMutation } from 'data/profile/mfa-challenge-and-verify-mutation'
@@ -14,6 +15,7 @@ import { useMfaListFactorsQuery } from 'data/profile/mfa-list-factors-query'
 import { useStore } from 'hooks'
 import { useSignOut } from 'lib/auth'
 import { getReturnToPath } from 'lib/gotrue'
+import Telemetry from 'lib/telemetry'
 
 const signInSchema = object({
   code: string().required('MFA Code is required'),
@@ -23,6 +25,8 @@ const SignInMfaForm = () => {
   const { ui } = useStore()
   const queryClient = useQueryClient()
   const router = useRouter()
+  const telemetryProps = useTelemetryProps()
+
   const {
     data: factors,
     error: factorsError,
@@ -71,6 +75,11 @@ const SignInMfaForm = () => {
               message: `Signed in successfully!`,
             })
 
+            Telemetry.sendEvent(
+              { category: 'account', action: 'sign_in', label: '' },
+              telemetryProps,
+              router
+            )
             await queryClient.resetQueries()
 
             router.push(getReturnToPath())

--- a/apps/studio/lib/auth.tsx
+++ b/apps/studio/lib/auth.tsx
@@ -1,15 +1,12 @@
 import { useQueryClient } from '@tanstack/react-query'
-import { useRouter } from 'next/router'
 import { PropsWithChildren, useCallback, useEffect } from 'react'
 
 import {
   AuthContext as AuthContextInternal,
   AuthProvider as AuthProviderInternal,
   gotrueClient,
-  useTelemetryProps,
 } from 'common'
 import { useStore } from 'hooks'
-import Telemetry from 'lib/telemetry'
 import { GOTRUE_ERRORS, IS_PLATFORM } from './constants'
 import { clearLocalStorage, resetSignInClicks } from './local-storage'
 
@@ -17,8 +14,6 @@ export const AuthContext = AuthContextInternal
 
 export const AuthProvider = ({ children }: PropsWithChildren<{}>) => {
   const { ui } = useStore()
-  const router = useRouter()
-  const telemetryProps = useTelemetryProps()
 
   // Check for unverified GitHub users after a GitHub sign in
   useEffect(() => {
@@ -35,22 +30,6 @@ export const AuthProvider = ({ children }: PropsWithChildren<{}>) => {
     }
 
     handleEmailVerificationError()
-  }, [])
-
-  useEffect(() => {
-    const {
-      data: { subscription },
-    } = gotrueClient.onAuthStateChange((event) => {
-      if (event === 'SIGNED_IN') {
-        Telemetry.sendEvent(
-          { category: 'account', action: 'sign_in', label: '' },
-          telemetryProps,
-          router
-        )
-      }
-    })
-
-    return subscription.unsubscribe
   }, [])
 
   return <AuthProviderInternal alwaysLoggedIn={!IS_PLATFORM}>{children}</AuthProviderInternal>

--- a/apps/studio/lib/local-storage.ts
+++ b/apps/studio/lib/local-storage.ts
@@ -1,3 +1,4 @@
+import { LOCAL_STORAGE_KEYS } from 'common'
 import { IS_PLATFORM } from './constants'
 
 export const LOCAL_STORAGE_KEYS_ALLOWLIST = [
@@ -7,6 +8,7 @@ export const LOCAL_STORAGE_KEYS_ALLOWLIST = [
   'supabase.dashboard.sign_in_clicks_v4',
   'supabase.dashboard.auth.debug',
   'supabase.dashboard.auth.navigatorLock.disabled',
+  LOCAL_STORAGE_KEYS.TELEMETRY_CONSENT,
 ]
 
 export function clearLocalStorage() {

--- a/apps/studio/lib/telemetry.ts
+++ b/apps/studio/lib/telemetry.ts
@@ -28,6 +28,11 @@ const sendEvent = (
 
   const { category, action, label, value } = event
 
+  // remove # section from router.asPath as it
+  // often includes sensitive information
+  // such as access/refresh tokens
+  const page_location = router.asPath.split('#')[0]
+
   return post(`${API_URL}/telemetry/event`, {
     action: action,
     category: category,
@@ -35,7 +40,7 @@ const sendEvent = (
     value: value,
     page_referrer: document?.referrer,
     page_title: document?.title,
-    page_location: router.asPath,
+    page_location,
     ga: {
       screen_resolution: gaProps?.screenResolution,
       language: gaProps?.language,

--- a/apps/studio/pages/sign-in-mfa.tsx
+++ b/apps/studio/pages/sign-in-mfa.tsx
@@ -41,23 +41,21 @@ const SignInMfaPage: NextPageWithLayout = () => {
             return router.push({ pathname: '/sign-in', query: router.query })
           }
 
-          if (data) {
-            if (data.currentLevel === data.nextLevel) {
-              Telemetry.sendEvent(
-                { category: 'account', action: 'sign_in', label: '' },
-                telemetryProps,
-                router
-              )
-              await queryClient.resetQueries()
+          if (data.currentLevel === data.nextLevel) {
+            Telemetry.sendEvent(
+              { category: 'account', action: 'sign_in', label: '' },
+              telemetryProps,
+              router
+            )
+            await queryClient.resetQueries()
 
-              router.push(getReturnToPath())
+            router.push(getReturnToPath())
 
-              return
-            }
-            if (data.currentLevel !== data.nextLevel) {
-              setLoading(false)
-              return
-            }
+            return
+          }
+          if (data.currentLevel !== data.nextLevel) {
+            setLoading(false)
+            return
           }
         } else {
           // if the user doesn't have a token, he needs to go back to the sign-in page

--- a/apps/studio/pages/sign-in-mfa.tsx
+++ b/apps/studio/pages/sign-in-mfa.tsx
@@ -1,17 +1,21 @@
 import { useQueryClient } from '@tanstack/react-query'
+import { useRouter } from 'next/router'
+import { useEffect, useState } from 'react'
+import toast from 'react-hot-toast'
+
+import { useTelemetryProps } from 'common'
 import SignInMfaForm from 'components/interfaces/SignIn/SignInMfaForm'
 import { SignInLayout } from 'components/layouts'
 import Loading from 'components/ui/Loading'
 import { auth, buildPathWithParams, getAccessToken, getReturnToPath } from 'lib/gotrue'
-import { useRouter } from 'next/router'
-import { useEffect, useState } from 'react'
-import toast from 'react-hot-toast'
+import Telemetry from 'lib/telemetry'
 import { NextPageWithLayout } from 'types'
 
 const SignInMfaPage: NextPageWithLayout = () => {
   const router = useRouter()
-  const [loading, setLoading] = useState(true)
+  const telemetryProps = useTelemetryProps()
   const queryClient = useQueryClient()
+  const [loading, setLoading] = useState(true)
 
   // This useEffect redirects the user to MFA if they're already halfway signed in
   useEffect(() => {
@@ -39,7 +43,13 @@ const SignInMfaPage: NextPageWithLayout = () => {
 
           if (data) {
             if (data.currentLevel === data.nextLevel) {
+              Telemetry.sendEvent(
+                { category: 'account', action: 'sign_in', label: '' },
+                telemetryProps,
+                router
+              )
               await queryClient.resetQueries()
+
               router.push(getReturnToPath())
 
               return


### PR DESCRIPTION
## What kind of change does this PR introduce?

chore

## What is the current behaviour?

Telemetry events for `sign_in` are being sent on every token refresh.

## What is the new behaviour?

`sign_in` events are only sent after the user successfully signs in.

## Additional context

This PR also adds the `TELEMETRY_CONSENT` key to `LOCAL_STORAGE_KEYS_ALLOWLIST` to stop the telemetry consent popup appearing everytime the user logs out and back in.

It also removes the # section from `router.asPath` as it often includes sensitive information such as access/refresh tokens.