### PR TITLE
fix: Remove sorting if the column doesn't exist

### DIFF
--- a/apps/studio/components/grid/SupabaseGrid.tsx
+++ b/apps/studio/components/grid/SupabaseGrid.tsx
@@ -83,6 +83,22 @@ const SupabaseGridLayout = (props: SupabaseGridProps) => {
     },
     {
       keepPreviousData: true,
+      retryDelay: (retryAttempt, error: any) => {
+        // when an errorMissingColumn error occurs, it's due to non-existant column in the sort parameter. Delete the
+        // sort param and try again.
+        if (error && error.routine === 'errorMissingColumn') {
+          setParams((prevParams) => {
+            return {
+              ...prevParams,
+              ...{ sort: undefined },
+            }
+          })
+        }
+        if (retryAttempt > 3) {
+          return Infinity
+        }
+        return 5000
+      },
       onSuccess(data) {
         dispatch({
           type: 'SET_ROWS_COUNT',


### PR DESCRIPTION
This PR fixes an issue where if you sort by a column, share the link and then delete the column, the link no longer works. 

If you delete the column while sorted, it automatically removes the sorting so this bug only happens with a shared or bookmarked link.