### PR TITLE
fix graphql section relative paths

### DIFF
--- a/apps/docs/pages/guides/graphql/[[...slug]].tsx
+++ b/apps/docs/pages/guides/graphql/[[...slug]].tsx
@@ -167,7 +167,7 @@ export const getStaticProps: GetStaticProps<PGGraphQLDocsProps> = async ({ param
 
       // If we have a mapping for this page, use the mapped path
       if (page) {
-        return page.slug + hash
+        return 'graphql/' + page.slug + hash
       }
 
       // If we don't have this page in our docs, link to original docs


### PR DESCRIPTION
Fixes broken relative paths in federated GraphQL docs.

A bit confused by the relative URL resolution here but I tested it and it definitely works.

Resolves #19807 