### PR TITLE
Add LWX blog entries to planet postgres feed

### DIFF
--- a/apps/www/_blog/2023-12-13-postgrest-12.mdx
+++ b/apps/www/_blog/2023-12-13-postgrest-12.mdx
@@ -11,7 +11,7 @@ tags:
 date: '2023-12-13'
 published_at: '2023-12-13:00:00.000-07:00'
 to_depth: 3
-author: steve_chavez
+author: oli_rice
 image: lwx-postgrest-12/postgrest12-OG.png
 thumb: lwx-postgrest-12/postgrest12-thumb.png
 ---


### PR DESCRIPTION
## What kind of change does this PR introduce?
Revert author on blog post & publish to planet postgres

The update was requested by Steve