### PR TITLE
Alpha sort db functions, triggers and indexes tables

### DIFF
--- a/apps/studio/components/interfaces/Database/Functions/FunctionsList/FunctionList.tsx
+++ b/apps/studio/components/interfaces/Database/Functions/FunctionsList/FunctionList.tsx
@@ -47,7 +47,7 @@ const FunctionList = ({
   )
   const _functions = sortBy(
     filteredFunctions.filter((x) => x.schema == schema),
-    'name'
+    (func) => func.name.toLocaleLowerCase()
   )
   const projectRef = selectedProject?.ref
   const canUpdateFunctions = useCheckPermissions(

--- a/apps/studio/components/interfaces/Database/Functions/FunctionsList/FunctionList.tsx
+++ b/apps/studio/components/interfaces/Database/Functions/FunctionsList/FunctionList.tsx
@@ -1,6 +1,6 @@
 import * as Tooltip from '@radix-ui/react-tooltip'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
-import { includes, noop } from 'lodash'
+import { includes, noop, sortBy } from 'lodash'
 import { useRouter } from 'next/router'
 import {
   Button,
@@ -45,9 +45,11 @@ const FunctionList = ({
   const filteredFunctions = (functions ?? []).filter((x) =>
     includes(x.name.toLowerCase(), filterString.toLowerCase())
   )
-  const _functions = filteredFunctions.filter((x) => x.schema == schema)
+  const _functions = sortBy(
+    filteredFunctions.filter((x) => x.schema == schema),
+    'name'
+  )
   const projectRef = selectedProject?.ref
-
   const canUpdateFunctions = useCheckPermissions(
     PermissionAction.TENANT_SQL_ADMIN_WRITE,
     'functions'

--- a/apps/studio/components/interfaces/Database/Indexes/Indexes.tsx
+++ b/apps/studio/components/interfaces/Database/Indexes/Indexes.tsx
@@ -12,7 +12,6 @@ import {
   IconSearch,
   IconTrash,
   Input,
-  Listbox,
   Modal,
   SidePanel,
 } from 'ui'
@@ -22,16 +21,16 @@ import Table from 'components/to-be-cleaned/Table'
 import AlertError from 'components/ui/AlertError'
 import CodeEditor from 'components/ui/CodeEditor'
 import ConfirmationModal from 'components/ui/ConfirmationModal'
+import SchemaSelector from 'components/ui/SchemaSelector'
 import ShimmeringLoader, { GenericSkeletonLoader } from 'components/ui/ShimmeringLoader'
 import { DatabaseIndex, useIndexesQuery } from 'data/database/indexes-query'
 import { useSchemasQuery } from 'data/database/schemas-query'
 import { useExecuteSqlMutation } from 'data/sql/execute-sql-mutation'
 import { useStore } from 'hooks'
-import CreateIndexSidePanel from './CreateIndexSidePanel'
-import SchemaSelector from 'components/ui/SchemaSelector'
-import { partition, sortBy } from 'lodash'
 import { EXCLUDED_SCHEMAS } from 'lib/constants/schemas'
+import { partition, sortBy } from 'lodash'
 import ProtectedSchemaWarning from '../ProtectedSchemaWarning'
+import CreateIndexSidePanel from './CreateIndexSidePanel'
 
 const Indexes = () => {
   const { ui } = useStore()
@@ -85,7 +84,7 @@ const Indexes = () => {
   const schema = schemas?.find((schema) => schema.name === selectedSchema)
   const isLocked = protectedSchemas.some((s) => s.id === schema?.id)
 
-  const sortedIndexes = sortBy(allIndexes?.result ?? [], 'name')
+  const sortedIndexes = sortBy(allIndexes?.result ?? [], (index) => index.name.toLocaleLowerCase())
   const indexes =
     search.length > 0
       ? sortedIndexes.filter((index) => index.name.includes(search) || index.table.includes(search))

--- a/apps/studio/components/interfaces/Database/Indexes/Indexes.tsx
+++ b/apps/studio/components/interfaces/Database/Indexes/Indexes.tsx
@@ -29,7 +29,7 @@ import { useExecuteSqlMutation } from 'data/sql/execute-sql-mutation'
 import { useStore } from 'hooks'
 import CreateIndexSidePanel from './CreateIndexSidePanel'
 import SchemaSelector from 'components/ui/SchemaSelector'
-import { partition } from 'lodash'
+import { partition, sortBy } from 'lodash'
 import { EXCLUDED_SCHEMAS } from 'lib/constants/schemas'
 import ProtectedSchemaWarning from '../ProtectedSchemaWarning'
 
@@ -85,9 +85,7 @@ const Indexes = () => {
   const schema = schemas?.find((schema) => schema.name === selectedSchema)
   const isLocked = protectedSchemas.some((s) => s.id === schema?.id)
 
-  const sortedIndexes = (allIndexes?.result ?? []).sort(
-    (a, b) => a.table.localeCompare(b.table) || a.name.localeCompare(b.name)
-  )
+  const sortedIndexes = sortBy(allIndexes?.result ?? [], 'name')
   const indexes =
     search.length > 0
       ? sortedIndexes.filter((index) => index.name.includes(search) || index.table.includes(search))

--- a/apps/studio/components/interfaces/Database/Triggers/TriggersList/TriggerList.tsx
+++ b/apps/studio/components/interfaces/Database/Triggers/TriggersList/TriggerList.tsx
@@ -1,6 +1,6 @@
 import * as Tooltip from '@radix-ui/react-tooltip'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
-import { includes } from 'lodash'
+import { includes, sortBy } from 'lodash'
 import {
   Badge,
   Button,
@@ -45,7 +45,10 @@ const TriggerList = ({
     includes(x.name.toLowerCase(), filterString.toLowerCase())
   )
 
-  const _triggers = filteredTriggers.filter((x: any) => x.schema == schema)
+  const _triggers = sortBy(
+    filteredTriggers.filter((x: any) => x.schema == schema),
+    'name'
+  )
   const canUpdateTriggers = useCheckPermissions(PermissionAction.TENANT_SQL_ADMIN_WRITE, 'triggers')
 
   if (_triggers.length === 0 && filterString.length === 0) {

--- a/apps/studio/components/interfaces/Database/Triggers/TriggersList/TriggerList.tsx
+++ b/apps/studio/components/interfaces/Database/Triggers/TriggersList/TriggerList.tsx
@@ -41,13 +41,13 @@ const TriggerList = ({
     projectRef: project?.ref,
     connectionString: project?.connectionString,
   })
-  const filteredTriggers = (triggers ?? []).filter((x: any) =>
+  const filteredTriggers = (triggers ?? []).filter((x) =>
     includes(x.name.toLowerCase(), filterString.toLowerCase())
   )
 
   const _triggers = sortBy(
-    filteredTriggers.filter((x: any) => x.schema == schema),
-    'name'
+    filteredTriggers.filter((x) => x.schema == schema),
+    (trigger) => trigger.name.toLocaleLowerCase()
   )
   const canUpdateTriggers = useCheckPermissions(PermissionAction.TENANT_SQL_ADMIN_WRITE, 'triggers')
 


### PR DESCRIPTION
Alpha sort by name the functions, triggers and indexes tables

previously, this indignity was suffered: 
<img width="505" alt="screenshot-2023-12-18-at-21 13 12" src="https://github.com/supabase/supabase/assets/105593/e4875469-2a29-43b4-8d21-0f3ceac28310">
