### PR TITLE
Fix Incorrect URL in Supabase Docs for Studio Source Code

### DIFF
--- a/apps/docs/pages/guides/getting-started/architecture.mdx
+++ b/apps/docs/pages/guides/getting-started/architecture.mdx
@@ -37,7 +37,7 @@ PostgreSQL is the core of Supabase. We do not abstract the PostgreSQL database â
 An open source Dashboard for managing your database and services.
 
 - Official Docs: [Supabase docs](/docs)
-- Source code: [github.com/supabase/supabase](https://github.com/supabase/supabase/tree/master/studio)
+- Source code: [github.com/supabase/supabase](https://github.com/supabase/supabase/tree/master/apps/studio)
 - License: [Apache 2](https://github.com/supabase/supabase/blob/master/LICENSE)
 - Language: TypeScript
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix.

## What is the current behavior?

The [current documentation](https://supabase.com/docs/guides/getting-started/architecture) incorrectly links to the Supabase Studio source code, leading to a 404 error page. The link provided is https://github.com/supabase/supabase/tree/master/studio, which does not exist in the master branch of the Supabase repository.

## What is the new behavior?
The updated link in the documentation now correctly points to https://github.com/supabase/supabase/tree/master/apps/studio. This change ensures users can navigate to the correct location of the Supabase Studio source code on GitHub.

## Additional context
This change was made to improve the accuracy and user experience of the Supabase documentation. It helps users quickly find the correct source code without encountering a 404 error.
