### PR TITLE
chore: use data/fetchers for custom domains

### DIFF
--- a/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainActivate.tsx
+++ b/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainActivate.tsx
@@ -75,8 +75,7 @@ const CustomDomainActivate = ({ projectRef, customDomain }: CustomDomainActivate
             <Alert_Shadcn_>
               <IconAlertCircle className="text-foreground-light" strokeWidth={1.5} />
               <AlertTitle_Shadcn_>
-                Do remember to restore the original CNAME record from the first step before
-                activating
+                Remember to restore the original CNAME record from the first step before activating
               </AlertTitle_Shadcn_>
               <AlertDescription_Shadcn_>
                 <p className="col-span-12 text-sm lg:col-span-7 leading-6">
@@ -88,7 +87,7 @@ const CustomDomainActivate = ({ projectRef, customDomain }: CustomDomainActivate
                     "your project's API URL"
                   )}
                   , with as low a TTL as possible. If you're using Cloudflare as your DNS provider,
-                  do disable the proxy option.
+                  disable the proxy option.
                 </p>
               </AlertDescription_Shadcn_>
             </Alert_Shadcn_>

--- a/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainVerify.tsx
+++ b/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainVerify.tsx
@@ -83,8 +83,8 @@ const CustomDomainVerify = ({ projectRef, customDomain, settings }: CustomDomain
                 {isNotVerifiedYet ? (
                   <div className="mt-2">
                     <p>
-                      Do check again in a bit as it may take up to 24 hours for changes in DNS
-                      records to propagate.
+                      Please check again soon. Note that it may take up to 24 hours for changes in
+                      DNS records to propagate.
                     </p>
                     <p>
                       You may also visit{' '}

--- a/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainsConfigureHostname.tsx
+++ b/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainsConfigureHostname.tsx
@@ -121,7 +121,7 @@ const CustomDomainsConfigureHostname = () => {
                     "your project's API URL"
                   )}
                   , with as low a TTL as possible. If you're using Cloudflare as your DNS provider,
-                  do disable the proxy option.
+                  disable the proxy option.
                 </p>
               </FormSection>
             </FormPanel>

--- a/apps/studio/data/custom-domains/custom-domains-activate-mutation.ts
+++ b/apps/studio/data/custom-domains/custom-domains-activate-mutation.ts
@@ -1,8 +1,7 @@
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
 import toast from 'react-hot-toast'
 
-import { post } from 'lib/common/fetch'
-import { API_ADMIN_URL } from 'lib/constants'
+import { post } from 'data/fetchers'
 import { ResponseError } from 'types'
 import { customDomainKeys } from './keys'
 
@@ -11,13 +10,12 @@ export type CustomDomainActivateVariables = {
 }
 
 export async function activateCustomDomain({ projectRef }: CustomDomainActivateVariables) {
-  const response = await post(
-    `${API_ADMIN_URL}/projects/${projectRef}/custom-hostname/activate`,
-    {}
-  )
+  const { data, error } = await post(`/v1/projects/{ref}/custom-hostname/activate`, {
+    params: { path: { ref: projectRef } },
+  })
 
-  if (response.error) throw response.error
-  return response
+  if (error) throw error
+  return data
 }
 
 type CustomDomainActivateData = Awaited<ReturnType<typeof activateCustomDomain>>

--- a/apps/studio/data/custom-domains/custom-domains-create-mutation.ts
+++ b/apps/studio/data/custom-domains/custom-domains-create-mutation.ts
@@ -1,8 +1,7 @@
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'react-hot-toast'
 
-import { post } from 'lib/common/fetch'
-import { API_ADMIN_URL } from 'lib/constants'
+import { post } from 'data/fetchers'
 import { ResponseError } from 'types'
 import { customDomainKeys } from './keys'
 
@@ -15,13 +14,13 @@ export async function createCustomDomain({
   projectRef,
   customDomain,
 }: CustomDomainCreateVariables) {
-  const response = await post(
-    `${API_ADMIN_URL}/projects/${projectRef}/custom-hostname/initialize`,
-    { custom_hostname: customDomain }
-  )
+  const { data, error } = await post(`/v1/projects/{ref}/custom-hostname/initialize`, {
+    params: { path: { ref: projectRef } },
+    body: { custom_hostname: customDomain },
+  })
 
-  if (response.error) throw response.error
-  return response
+  if (error) throw error
+  return data
 }
 
 type CustomDomainCreateData = Awaited<ReturnType<typeof createCustomDomain>>

--- a/apps/studio/data/custom-domains/custom-domains-delete-mutation.ts
+++ b/apps/studio/data/custom-domains/custom-domains-delete-mutation.ts
@@ -1,19 +1,22 @@
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
-import { delete_ } from 'lib/common/fetch'
-import { API_ADMIN_URL } from 'lib/constants'
-import { customDomainKeys } from './keys'
+import { del } from 'data/fetchers'
 import { toast } from 'react-hot-toast'
 import { ResponseError } from 'types'
+import { customDomainKeys } from './keys'
 
 export type CustomDomainDeleteVariables = {
   projectRef: string
 }
 
 export async function deleteCustomDomain({ projectRef }: CustomDomainDeleteVariables) {
-  const response = await delete_(`${API_ADMIN_URL}/projects/${projectRef}/custom-hostname`, {})
+  const { data, error } = await del(`/v1/projects/{ref}/custom-hostname`, {
+    params: {
+      path: { ref: projectRef },
+    },
+  })
 
-  if (response.error) throw response.error
-  return response
+  if (error) throw error
+  return data
 }
 
 type CustomDomainDeleteData = Awaited<ReturnType<typeof deleteCustomDomain>>

--- a/apps/studio/data/custom-domains/custom-domains-query.ts
+++ b/apps/studio/data/custom-domains/custom-domains-query.ts
@@ -1,21 +1,12 @@
 import { useQuery, UseQueryOptions } from '@tanstack/react-query'
 
-import { get } from 'lib/common/fetch'
-import { API_ADMIN_URL, IS_PLATFORM } from 'lib/constants'
+import { get } from 'data/fetchers'
+import { IS_PLATFORM } from 'lib/constants'
 import { customDomainKeys } from './keys'
 
 export type CustomDomainsVariables = {
   projectRef?: string
 }
-
-type CustomDomainStatus =
-  | '0_not_allowed'
-  | '0_no_hostname_configured'
-  | '1_not_started'
-  | '2_initiated'
-  | '3_challenge_verified'
-  | '4_origin_setup_completed'
-  | '5_services_reconfigured'
 
 type Settings = {
   http2: string
@@ -76,27 +67,23 @@ export async function getCustomDomains(
     throw new Error('projectRef is required')
   }
 
-  const response = (await get(`${API_ADMIN_URL}/projects/${projectRef}/custom-hostname`, {
+  const { data, error } = await get('/v1/projects/{ref}/custom-hostname', {
+    params: {
+      path: {
+        ref: projectRef,
+      },
+    },
     signal,
-  })) as {
-    data: {
-      errors: any[]
-      result: CustomDomainResponse
-      success: boolean
-      messages: any[]
-    }
-    status: CustomDomainStatus
-    error: unknown
-  }
+  })
 
-  if (response.error) {
+  if (error) {
     // not allowed error and no hostname configured error are
     // valid steps in the process of setting up a custom domain
     // so we convert them to data instead of errors
 
-    const isNotAllowedError =
-      (response.error as any)?.code === 400 &&
-      (response.error as any)?.message?.includes('not allowed to set up custom domain')
+    const isNotAllowedError = (error as any)?.message?.includes(
+      'not allowed to set up custom domain'
+    )
 
     if (isNotAllowedError) {
       return {
@@ -105,9 +92,9 @@ export async function getCustomDomains(
       } as const
     }
 
-    const isNoHostnameConfiguredError =
-      (response.error as any)?.code === 400 &&
-      (response.error as any)?.message?.includes('custom hostname configuration')
+    const isNoHostnameConfiguredError = (error as any)?.message?.includes(
+      'custom hostname configuration'
+    )
 
     if (isNoHostnameConfiguredError) {
       return {
@@ -116,10 +103,10 @@ export async function getCustomDomains(
       } as const
     }
 
-    throw response.error
+    throw error
   }
 
-  return { customDomain: response?.data?.result, status: response.status }
+  return { customDomain: data.data.result as CustomDomainResponse, status: data.status }
 }
 
 export type CustomDomainsData = Awaited<ReturnType<typeof getCustomDomains>>

--- a/apps/studio/data/custom-domains/custom-domains-reverify-mutation.ts
+++ b/apps/studio/data/custom-domains/custom-domains-reverify-mutation.ts
@@ -1,22 +1,21 @@
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
-import { post } from 'lib/common/fetch'
-import { API_ADMIN_URL } from 'lib/constants'
-import { customDomainKeys } from './keys'
+
+import { post } from 'data/fetchers'
 import { toast } from 'react-hot-toast'
 import { ResponseError } from 'types'
+import { customDomainKeys } from './keys'
 
 export type CustomDomainReverifyVariables = {
   projectRef: string
 }
 
 export async function reverifyCustomDomain({ projectRef }: CustomDomainReverifyVariables) {
-  const response = await post(
-    `${API_ADMIN_URL}/projects/${projectRef}/custom-hostname/reverify`,
-    {}
-  )
+  const { data, error } = await post(`/v1/projects/{ref}/custom-hostname/reverify`, {
+    params: { path: { ref: projectRef } },
+  })
 
-  if (response.error) throw response.error
-  return response
+  if (error) throw error
+  return data
 }
 
 type CustomDomainReverifyData = Awaited<ReturnType<typeof reverifyCustomDomain>>


### PR DESCRIPTION
## What kind of change does this PR introduce?

chore

## What is the current behaviour?

Seeing this annoying error in the console constantly.
<img width="1796" alt="Screenshot 2023-12-20 at 14 49 06" src="https://github.com/supabase/supabase/assets/10985857/a528dbea-6d37-4709-b603-eabda196605c">

## What is the new behaviour?

Custom domains fetches using the `data/fetchers` methods because it needed updating, and the above error is fixed. Also some wording has been improved.