### PR TITLE
chore: reduce main docs app bundle size

### DIFF
--- a/apps/docs/components/index.tsx
+++ b/apps/docs/components/index.tsx
@@ -3,7 +3,6 @@ import { Alert, Button, CodeBlock, GlassPanel, markdownComponents, Tabs } from '
 import StepHikeCompact from '~/components/StepHikeCompact'
 // Common components
 import ButtonCard from './ButtonCard'
-import JwtGenerator from './JwtGenerator'
 
 // Page specific components
 import AuthProviders from './AuthProviders'
@@ -12,7 +11,6 @@ import Frameworks from './Frameworks'
 import FunctionsExamples from './FunctionsExamples'
 
 // Other components
-import { Mermaid } from 'mdx-mermaid/lib/Mermaid'
 import RefSubLayout from '~/layouts/ref/RefSubLayout'
 import { Heading } from './CustomHTMLElements'
 import DatabaseSetup from './MDX/database_setup.mdx'
@@ -68,7 +66,6 @@ const components = {
   Frameworks,
   AuthProviders,
   FunctionsExamples,
-  JwtGenerator,
   QuickstartIntro,
   DatabaseSetup,
   ProjectSetup,
@@ -78,7 +75,6 @@ const components = {
   SocialProviderSettingsSupabase,
   StepHikeCompact,
   StorageManagement,
-  Mermaid,
   Extensions,
   Alert: (props: any) => (
     <Alert {...props} className="not-prose">

--- a/apps/docs/pages/guides/auth/auth-mfa.mdx
+++ b/apps/docs/pages/guides/auth/auth-mfa.mdx
@@ -1,4 +1,5 @@
 import Layout from '~/layouts/DefaultGuideLayout'
+import { Mermaid } from 'mdx-mermaid/lib/Mermaid'
 
 export const meta = {
   id: 'auth-mfa',

--- a/apps/docs/pages/guides/self-hosting/docker.mdx
+++ b/apps/docs/pages/guides/self-hosting/docker.mdx
@@ -1,4 +1,5 @@
 import Layout from '~/layouts/DefaultGuideLayout'
+import JwtGenerator from '~/components/JwtGenerator'
 
 export const meta = {
   title: 'Self-Hosting with Docker',


### PR DESCRIPTION
I was analyzing the docs Next build a bit and noticed the main app bundle that gets loaded on initial build is quite big and contains things that we only use once (mermaid/jsrsasign)

Seems to be because we export all components in a index.ts file (barrel file). If we instead import these components directly, they are only loaded on the actual page, instead on every page.

Reduces app bundle size by *38%*