### PR TITLE
Add: new regex for custom scheme URLs

### DIFF
--- a/apps/studio/components/interfaces/Auth/Auth.constants.ts
+++ b/apps/studio/components/interfaces/Auth/Auth.constants.ts
@@ -20,8 +20,11 @@ const localhostRegex = /^(?:^|\s)((https?:\/\/)?(?:localhost|[\w-]+(?:\.[\w-]+)+
 // "chrome-extension://<extension-id>"
 const chromeExtensionRegex = /chrome-extension:\/\/([a-zA-Z]*)/gm
 
+// New regex for custom scheme URLs
+const customSchemeRegex = /^([a-zA-Z][a-zA-Z0-9+.-]*):(?:\/{1,3})?([a-zA-Z0-9_.-]*)$/;
+
 // combine the above regexes
 export const urlRegex = new RegExp(
-  `(${baseUrlRegex.source})|(${localhostRegex.source})|(${appRegex.source})|(${chromeExtensionRegex.source})`,
+  `(${baseUrlRegex.source})|(${localhostRegex.source})|(${appRegex.source})|(${chromeExtensionRegex.source})|(${customSchemeRegex.source})`,
   'i'
 )

--- a/apps/studio/components/interfaces/Auth/Auth.constants.ts
+++ b/apps/studio/components/interfaces/Auth/Auth.constants.ts
@@ -21,7 +21,7 @@ const localhostRegex = /^(?:^|\s)((https?:\/\/)?(?:localhost|[\w-]+(?:\.[\w-]+)+
 const chromeExtensionRegex = /chrome-extension:\/\/([a-zA-Z]*)/gm
 
 // New regex for custom scheme URLs
-const customSchemeRegex = /^([a-zA-Z][a-zA-Z0-9+.-]*):(?:\/{1,3})?([a-zA-Z0-9_.-]*)$/;
+const customSchemeRegex = /^([a-zA-Z][a-zA-Z0-9+.-]*):(?:\/{1,3})?([a-zA-Z0-9_.-]*)$/; 
 
 // combine the above regexes
 export const urlRegex = new RegExp(

--- a/apps/studio/components/interfaces/Auth/Auth.constants.ts
+++ b/apps/studio/components/interfaces/Auth/Auth.constants.ts
@@ -21,7 +21,7 @@ const localhostRegex = /^(?:^|\s)((https?:\/\/)?(?:localhost|[\w-]+(?:\.[\w-]+)+
 const chromeExtensionRegex = /chrome-extension:\/\/([a-zA-Z]*)/gm
 
 // New regex for custom scheme URLs
-const customSchemeRegex = /^([a-zA-Z][a-zA-Z0-9+.-]*):(?:\/{1,3})?([a-zA-Z0-9_.-]*)$/; 
+const customSchemeRegex = /^([a-zA-Z][a-zA-Z0-9+.-]*):(?:\/{1,3})?([a-zA-Z0-9_.-]*)$/
 
 // combine the above regexes
 export const urlRegex = new RegExp(


### PR DESCRIPTION
## What kind of change does this PR introduce?

The existing regex for URL validation did not fully support custom scheme URLs in the format scheme:auth-callback, scheme:/auth-callback, and scheme:///auth-callback. 

The regex `/^([a-zA-Z][a-zA-Z0-9+.-]*):(?:\/{1,3})?([a-zA-Z0-9_.-]*)$/` breaks down as follows:

`([a-zA-Z][a-zA-Z0-9+.-]*)`: ensuring it starts with a letter and can contain letters, digits, plus, dot, and hyphen.
`:`: Matches the colon. 
`(?:\/{1,3})?`: Non-capturing group for an optional 1 to 3 slashes after the colon.
`([a-zA-Z0-9_.-]*)`: Captures the rest of the URL, allowing letters, digits, dot, underscore, and hyphen.

## Additional context

![image](https://github.com/supabase/supabase/assets/99693443/0beeb4b3-a831-4466-a172-7297ce1ec4d0)


