### PR TITLE
UI/Docs: fixed typos in `tailwind-theming.md` and removed trailing whitespace

### DIFF
--- a/apps/docs/public/.well-known/security.txt
+++ b/apps/docs/public/.well-known/security.txt
@@ -21,8 +21,8 @@ Out of scope vulnerabilities:
 
 Please do the following:
 
-- E-mail your findings to security@supabase.io. 
-- Do not run automated scanners on our infrastructure or dashboard. If you wish to do this, contact us and we will set up a sandbox for you. 
+- E-mail your findings to security@supabase.io.
+- Do not run automated scanners on our infrastructure or dashboard. If you wish to do this, contact us and we will set up a sandbox for you.
 - Do not take advantage of the vulnerability or problem you have discovered, for example by downloading more data than necessary to demonstrate the vulnerability or deleting or modifying other people's data,
 - Do not reveal the problem to others until it has been resolved,
 - Do not use attacks on physical security, social engineering, distributed denial of service, spam or applications of third parties, and

--- a/packages/ui/tailwind-theming.md
+++ b/packages/ui/tailwind-theming.md
@@ -64,7 +64,7 @@ bg-foreground-light
 | `{background}-surface-100`      | Panels and surfaces on the same level of the main background |
 | `{background}-surface-200`      | Surfaces that overlap the main content (ex. dropdowns)        |
 | `{background}-surface-300`      | Surfaces that are stacked above {background}-surface-200     |
-| `{background}-alternative`      | Alernative background (inverted)                             |
+| `{background}-alternative`      | Alternative background (inverted)                             |
 | `{background}-overlay`          | Overlays, Dropdowns, Popovers                                |
 | `{background}-control`          | Inputs, Radios, Checkboxes                                   |
 | `{background}-button-{DEFAULT}` | Button default                                               |
@@ -88,7 +88,7 @@ text-background-surface-100
 | ------------------------- | ---------------------------------------- |
 | `border-{DEFAULT}`        | Default border (**DEFAULT** is optional) |
 | `border-secondary`        | Secondary border                         |
-| `border-alternative`      | Alernative border (inverted)             |
+| `border-alternative`      | Alternative border (inverted)             |
 | `border-overlay`          | Overlays, Dropdowns, Popovers            |
 | `border-control`          | Inputs, Radios, Checkboxes               |
 | `border-strong`           | Hover, Focus                             |

--- a/packages/ui/tailwind-theming.md
+++ b/packages/ui/tailwind-theming.md
@@ -62,7 +62,7 @@ bg-foreground-light
 | ------------------------------- | ------------------------------------------------------------ |
 | `{background}-{DEFAULT}`        | Main body background (**DEFAULT** is optional)               |
 | `{background}-surface-100`      | Panels and surfaces on the same level of the main background |
-| `{background}-surface-200`      | Surfaces that overlap the main content (ex. drodowns)        |
+| `{background}-surface-200`      | Surfaces that overlap the main content (ex. dropdowns)        |
 | `{background}-surface-300`      | Surfaces that are stacked above {background}-surface-200     |
 | `{background}-alternative`      | Alernative background (inverted)                             |
 | `{background}-overlay`          | Overlays, Dropdowns, Popovers                                |


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs/UI update - fixed typos and trailing whitespace

## What is the current behavior?

Typos fixed and trailing whitespace removed

## What is the new behavior?

Fixed all typos and trailing whitespace

