### PR TITLE
fix: Enable the Node polyfills flag

### DIFF
--- a/apps/studio/next.config.js
+++ b/apps/studio/next.config.js
@@ -30,7 +30,8 @@ const nextConfig = {
   experimental: {
     // [Kevin] Next polyfills Node modules like Crypto by default, blowing up the bundle size. We use generate-password-browser (safe to use in browser) and the polyfills are not needed for us
     // Revisit on Next 14 upgrade (PR #19909)
-    fallbackNodePolyfills: false,
+    // [Ivan] Temporarily enable until we find a fix for breaking anon-role in the Realtime inspector
+    fallbackNodePolyfills: true,
   },
   async redirects() {
     return [


### PR DESCRIPTION
Temporarily enable the Node polyfills flag to fix a bug in the Realtime Inspector where the anon role impersonation wasn't working.