### PR TITLE
fix: docker.mdx supabase-analytics instead of supabase-db

### DIFF
--- a/apps/docs/pages/guides/self-hosting/docker.mdx
+++ b/apps/docs/pages/guides/self-hosting/docker.mdx
@@ -308,7 +308,7 @@ docker exec -it $(docker ps | grep supabase-db | awk '{print $1}') psql -U supab
 # Drop all the data in the _analytics schema
 DROP PUBLICATION logflare_pub; DROP SCHEMA _analytics CASCADE; CREATE SCHEMA _analytics;\q
 # Drop the analytics container
-docker rm supabase-db
+docker rm supabase-analytics
 ```
 
 ---


### PR DESCRIPTION
## What kind of change does this PR introduce?

The documentation says to destroy the analytics container but the command shown destroy the database container

## What is the current behavior?

Following the actual documentation, user destroy his database container

## What is the new behavior?

It destroys the analytics container

## Additional context

Self-hosting
