### PR TITLE
Add docs page on high swap usage

### DIFF
--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
@@ -1766,6 +1766,10 @@ export const platform: NavMenuConstant = {
           name: 'High RAM Usage',
           url: '/guides/platform/exhaust-ram',
         },
+        {
+          name: 'High Swap Usage',
+          url: '/guides/platform/exhaust-swap',
+        },
       ],
     },
   ],

--- a/apps/docs/pages/guides/platform/exhaust-swap.mdx
+++ b/apps/docs/pages/guides/platform/exhaust-swap.mdx
@@ -1,0 +1,71 @@
+import Layout from '~/layouts/DefaultGuideLayout'
+
+export const meta = {
+  id: 'exhaust-swap',
+  title: 'High swap usage',
+  description:
+    'Learn what high Swap usage could mean for your Supabase instance and what could have caused it.',
+}
+
+Learn what high Swap usage means, what can cause it, and how to solve it.
+
+## What is Swap for?
+
+<Admonition type="tip">
+
+High Swap is usually not a problem unless other resources (such as RAM) are constrained.
+
+</Admonition>
+
+Every Supabase project runs on its own dedicated virtual machine. The machine's underlying specs and hardware depend on your [compute add-on](https://supabase.com/docs/guides/platform/compute-add-ons). If your hardware isn't suitable for your workload, you might experience high Swap usage.
+
+Swap is a portion of your instance's disk that is reserved for the operating system to use when the available RAM has been utilized. As it uses the disk, Swap is slower to access and is generally used as a last resort.
+
+Swap can be used even if your instance has plenty of RAM. If this is the case, do not worry. Your instance might try to "preemptively swap" by swapping background processes to make space for your traffic in RAM.
+
+### When is high Swap concerning?
+
+High Swap is concerning if your instance is using all of the available RAM (i.e. consistently using more than 75%).
+
+High Swap usage can affect your database performance. For example, you might see:
+
+- **Slower query responses.**
+- **Degraded performance due to swapping regularly between RAM and disk.**
+- **Higher Disk I/O due to swapping regularly.**
+
+## Monitor your Swap
+
+You can check your Swap usage directly on the Supabase Platform. Navigate to the [**Database** page](https://supabase.com/dashboard/project/_/reports/database) of the **Reports** section.
+
+You can also monitor your resources and set up alerts using Prometheus/Grafana. See the [metrics guide](https://supabase.com/docs/guides/platform/metrics) for more information.
+
+An [example repository](https://github.com/supabase/supabase-grafana) to ingest metrics and visualize them with Grafana is provided in the linked guide, where we maintain a [list of the exported metrics](https://github.com/supabase/supabase-grafana/blob/main/docs/metrics.md).
+
+Some useful metrics to monitor are (this is not an exhaustive list):
+
+- `node_memory_SwapFree_bytes` - The total amount of Swap available in bytes.
+- `node_disk_io_time_seconds_total` and `node_disk_io_now` - The amount of time spent on disk I/O. An increase might be an indirect sign of excessive swapping, but not always.
+- `node_memory_MemTotal_bytes` and `node_memory_MemFree_bytes` - The total RAM and available RAM.
+- `node_vmstat_pswpin` and `node_vmstat_pswpout` - The number of pages that have been swapped in or out (monitoring this for spikes means that your instance is swapping).
+
+## Common reasons for high Swap usage
+
+Everything you do with your Supabase project requires compute. Hence, there can be many reasons for high Swap usage. Here are some common ones:
+
+- **Query performance:** You might have high read traffic or queries that process a large amount of data on disk (this can happen even if you are returning a small amount of data).
+- **Missing indexes:** Your database might have to scan through a large amount of data to find the information it needs. Creating indexes helps your database find data faster. See the [indexes guide](https://supabase.com/docs/guides/database/postgres/indexes) to learn more.
+- **Unsuitable compute:** The instance size of your Supabase project might not be suitable for your application as you might have more traffic or run resource-intensive operations.
+- **Workload style:** The usage pattern of your Supabase project might be more read heavy, or involve large amounts of data.
+- **Extensions:** You might be using extensions that perform intensive operations on large datasets. This increases resource usage.
+
+## Solving high Swap usage
+
+If you find that your RAM and Swap usage are high, you have three options:
+
+1. **Optimize performance:** Get more out of your instance's resources by optimizing your usage. See the [performance tuning guide](https://supabase.com/docs/guides/platform/performance#examining-query-performance) and our [production readiness guide](https://supabase.com/docs/guides/platform/going-into-prod#performance).
+2. **Upgrade your compute:** You can get a Compute Add-on for your project. Navigate to [the **Addons** section in project settings](https://supabase.com/dashboard/project/_/settings/addons?panel=computeInstance) to see your upgrade options.
+3. **Read Replicas:** You can spread the load on your Supabase project by creating a Read Replica. See [the read replicas guide](https://supabase.com/docs/guides/platform/read-replicas) for more information.
+
+export const Page = ({ children }) => <Layout meta={meta} children={children} />
+
+export default Page


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update to add information on high swap usage; causes, when it is a concern and when it is not.

## What is the current behaviour?

Currently, we only have docs on high CPU, RAM and Disk I/O

## What is the new behaviour?

High Swap is now added to this `troubleshooting` section of the platform docs.
