### PR TITLE
Fix(example): methods cors on restful-tasks edge

### DIFF
--- a/examples/edge-functions/supabase/functions/restful-tasks/index.ts
+++ b/examples/edge-functions/supabase/functions/restful-tasks/index.ts
@@ -7,6 +7,7 @@ import { createClient, SupabaseClient } from 'https://esm.sh/@supabase/supabase-
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey',
+  'Access-Control-Allow-Methods': 'POST, GET, OPTIONS, PUT, DELETE',
 }
 
 interface Task {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Hi there !

Had an issue implementing CRUD in edge function. Was following this example ([restful-tasks](https://github.com/supabase/supabase/blob/master/examples/edge-functions/supabase/functions/restful-tasks/index.ts)).
Work fine with `POST`, `GET` & `OPTIONS` but failed for others, see following logs

## What is the current behavior?

```
Access to fetch at 'http://localhost:54321/functions/v1/events' from origin 'http://localhost:3000' has been blocked by CORS policy:
Method PATCH is not allowed by Access-Control-Allow-Methods in preflight response.
```

## Additional context

```json
"supabase": "1.123.4",
"@supabase/gotrue-js": "2.55.0",
"@supabase/supabase-js": "^2.36.0",
```
