### PR TITLE
fix: Fix the drag resizing in the GraphiQL

### DIFF
--- a/apps/studio/components/interfaces/GraphQL/GraphiQL.tsx
+++ b/apps/studio/components/interfaces/GraphQL/GraphiQL.tsx
@@ -100,7 +100,7 @@ export const GraphiQLInterface = ({ theme }: GraphiQLInterfaceProps) => {
     direction: 'horizontal',
     initiallyHidden: pluginContext?.visiblePlugin ? undefined : 'second',
     onHiddenElementChange: (resizableElement) => {
-      if (resizableElement === 'first') {
+      if (resizableElement === 'second') {
         pluginContext?.setVisiblePlugin(null)
       }
     },

--- a/apps/studio/components/interfaces/GraphQL/GraphiQL.tsx
+++ b/apps/studio/components/interfaces/GraphQL/GraphiQL.tsx
@@ -207,7 +207,7 @@ export const GraphiQLInterface = ({ theme }: GraphiQLInterfaceProps) => {
         <div className="graphiql-main">
           <div
             ref={pluginResize.firstRef}
-            style={{ minWidth: 0 }}
+            style={{ minWidth: '750px' }}
             className={clsx('graphiql-sessions', styles.graphiqlSessions)}
           >
             <div


### PR DESCRIPTION
When resizing the three panels (query, response and docs) in GraphiQL it's possible to over-expand the docs panel and squish the response panel. Also, when collapsing the docs panel by dragging, disable the docs icon.