### PR TITLE
fix: update vercel integration links

### DIFF
--- a/apps/docs/pages/guides/platform/branching.mdx
+++ b/apps/docs/pages/guides/platform/branching.mdx
@@ -594,7 +594,7 @@ With the Supabase branching integration, you can sync the Git branch used by the
 
 Install the Vercel integration:
 
-- From the [Vercel marketplace](https://vercel.com/integrations/supabase-v2) or
+- From the [Vercel marketplace](https://vercel.com/integrations/supabase) or
 - By clicking the blue `Deploy` button in a Supabase example app's `README` file
 
 <Admonition type="note" label="Vercel GitHub integration also required.">

--- a/apps/studio/components/interfaces/Settings/Integrations/VercelIntegration/VercelSection.tsx
+++ b/apps/studio/components/interfaces/Settings/Integrations/VercelIntegration/VercelSection.tsx
@@ -122,7 +122,7 @@ You can change the scope of the access for Supabase by configuring
   const integrationUrl =
     process.env.NEXT_PUBLIC_ENVIRONMENT === 'staging'
       ? 'https://vercel.com/integrations/supabase-v2-staging'
-      : 'https://vercel.com/integrations/supabase-v2'
+      : 'https://vercel.com/integrations/supabase'
 
   let connections =
     (isProjectScoped

--- a/apps/www/_blog/2023-08-10-using-supabase-with-vercel.mdx
+++ b/apps/www/_blog/2023-08-10-using-supabase-with-vercel.mdx
@@ -21,7 +21,7 @@ At Supabase, we feel it's important to provide developers with the tools they ne
 
 ## The New Supabase x Vercel integration
 
-Our new [Vercel Integration](https://vercel.com/integrations/supabase-v2) streamlines the process of creating, deploying, and maintaining web applications.
+Our new [Vercel Integration](https://vercel.com/integrations/supabase) streamlines the process of creating, deploying, and maintaining web applications.
 
 ### Monorepo support
 

--- a/apps/www/_blog/2023-12-13-supabase-branching.mdx
+++ b/apps/www/_blog/2023-12-13-supabase-branching.mdx
@@ -78,7 +78,7 @@ We've designed Supabase Branching to work perfectly with Vercel's [Preview](http
   captionAlign="left"
 />
 
-We've made several improvements to our [Vercel Integration](https://vercel.com/integrations/supabase-v2) to make the Vercel experience seamless. For example, since we provide distinct, secure database credentials for every Supabase Preview Branch, we automatically populate the environment variables on Vercel with the connection secrets your app needs to connect to the Preview Branch.
+We've made several improvements to our [Vercel Integration](https://vercel.com/integrations/supabase) to make the Vercel experience seamless. For example, since we provide distinct, secure database credentials for every Supabase Preview Branch, we automatically populate the environment variables on Vercel with the connection secrets your app needs to connect to the Preview Branch.
 
 <Img
   alt="Vercel environment variables settings page, showing the Git branch based env vars."


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

Vercel updated the URL of the integration to remove `-v2`.