### PR TITLE
Fix Navbar unusable in smaller res screens

### DIFF
--- a/apps/studio/components/layouts/ProjectLayout/NavigationBar/NavigationBar.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/NavigationBar/NavigationBar.tsx
@@ -79,7 +79,7 @@ const NavigationBar = () => {
   return (
     <div
       className={[
-        'flex w-14 flex-col justify-between overflow-y-hidden p-2',
+        'flex w-14 flex-col justify-between p-2 overflow-y-auto',
         'border-r bg-background border-default',
       ].join(' ')}
     >


### PR DESCRIPTION
## What kind of change does this PR introduce?
Makes the nav bar scrollable

## What is the current behavior?

NavBar isn't scrollable which is problematic for smaller resolution screens. Or if you want to have supabase studio in a smaller window.

## What is the new behavior?

This will make the navbar scrollable on smaller 

## Additional context

fixes #19567 
