### PR TITLE
docs: release auth hooks

### DIFF
--- a/apps/docs/pages/guides/auth/auth-hooks.mdx
+++ b/apps/docs/pages/guides/auth/auth-hooks.mdx
@@ -8,10 +8,6 @@ export const meta = {
   description: 'Use Supabase Postgres Functions to customize your authentication flow',
 }
 
-<Admonition type="info">
-  Hooks are in beta. They will be available for all projects in early 2024.
-</Admonition>
-
 Supabase allows you to use Postgres functions to alter the default Supabase Auth flow. Developers can use hooks to add custom behavior that's not supported natively.
 
 Hooks help you:


### PR DESCRIPTION
## What kind of change does this PR introduce?

We remove the notice that Auth Hooks in beta as we will be unflagging Auth Hooks on the dashboard.