### PR TITLE
fix: sort policies alphabetically

### DIFF
--- a/apps/studio/components/interfaces/Auth/Policies/PolicyTableRow/index.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/PolicyTableRow/index.tsx
@@ -30,9 +30,9 @@ const PolicyTableRow = ({
     projectRef: project?.ref,
     connectionString: project?.connectionString,
   })
-  const policies = (data ?? []).filter(
-    (policy) => policy.schema === table.schema && policy.table === table.name
-  )
+  const policies = (data ?? [])
+    .filter((policy) => policy.schema === table.schema && policy.table === table.name)
+    .sort((a, b) => a.name.localeCompare(b.name))
 
   return (
     <Panel

--- a/apps/studio/components/to-be-cleaned/Storage/StoragePolicies/StoragePolicies.tsx
+++ b/apps/studio/components/to-be-cleaned/Storage/StoragePolicies/StoragePolicies.tsx
@@ -195,7 +195,8 @@ const StoragePolicies = () => {
               find(formattedStorageObjectPolicies, { name: bucket.name }),
               ['policies'],
               []
-            )
+            ).sort((a: any, b: any) => a.name.localeCompare(b.name))
+
             return (
               <StoragePoliciesBucketRow
                 key={bucket.name}


### PR DESCRIPTION
## What kind of change does this PR introduce?

fixes: https://github.com/supabase/supabase/issues/20158

## What is the current behavior?

Presently, it is sorted by the creation time.

## What is the new behavior?

We updated it to be sorted alphabetically.

## Additional context

This is a local sort. Maybe in the future, we can update the endpoint to default to sorting alphabetically.
