### PR TITLE
ci: trigger deploy of site with shared origin [ci shared auth]

### DIFF
--- a/.github/workflows/deploy-docs-proxied.yml
+++ b/.github/workflows/deploy-docs-proxied.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - id: normalize
         name: Normalize branch name
-        run: echo "NORMALIZED_BRANCH=$(echo "$GITHUB_REF_NAME" | sed 's|/|-|' | sed 's|.||')" >> $GITHUB_OUTPUT
+        run: echo "NORMALIZED_BRANCH=$(echo "$GITHUB_REF_NAME" | sed 's|/|-|' | sed 's|\.||')" >> $GITHUB_OUTPUT
       - id: test
         name: Test
         run: echo "branch ${{ steps.normalize.outputs.NORMALIZED_BRANCH }}"

--- a/.github/workflows/deploy-docs-proxied.yml
+++ b/.github/workflows/deploy-docs-proxied.yml
@@ -1,9 +1,9 @@
 name: Proxy docs preview site via www preview site
 
-on: [pull_request, workflow_dispatch]
+on: [pull_request, workflow_dispatch] # pull_request for testing only, remove later
 
 env:
-  VERCEL_ORG_ID:
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
 
 jobs:
   setup:
@@ -17,11 +17,18 @@ jobs:
       - id: log
         name: Log branch name
         run: echo "branch ${{ steps.normalize.outputs.NORMALIZED_BRANCH }}"
+          #   docs:
+          #     runs-on: ubuntu-latest
+          #     needs: setup
+          #     env:
+          #       VERCEL_PROJECT_ID: 
   studio:
     runs-on: ubuntu-latest
     needs: setup
     env:
-      VERCEL_PROJECT_ID:
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_STUDIO_STAGING_PROJECT_ID }}
+    outputs:
+      url: ${{ steps.deploy.outputs.DEPLOY_URL }}
     steps:
       - id: checkout
         name: Checkout studio
@@ -54,48 +61,48 @@ jobs:
         name: Deploy
         working-directory: ./
         run: |
-          npx vercel deploy --cwd apps/studio --yes --token ${{ secrets.VERCEL_TOKEN }}
-  www:
-    runs-on: ubuntu-latest
-    needs: setup
-    environment:
-      name: preview
-      url: ${{ steps.deploy.outputs.DEPLOY_URL }}
-    env:
-      VERCEL_PROJECT_ID:
-    steps:
-      - id: checkout
-        name: Checkout www
-        uses: actions/checkout@v4
-        with:
-          sparse-checkout: |
-            apps/www
-            packages
-      - id: node
-        name: Set up Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18.x
-          cache: 'npm'
-      - id: install
-        name: Install dependencies
-        working-directory: ./
-        run: npm ci
-      - id: pull
-        name: Pull Vercel environment
-        working-directory: ./
-        run: |
-          npx vercel pull --cwd apps/www --environment-preview --yes --token ${{ secrets.VERCEL_TOKEN }}
-      - id: build
-        name: Build
-        working-directory: ./
-        run: |
-          npx vercel build --cwd apps/www --yes --token ${{ secrets.VERCEL_TOKEN }}
-      - id: deploy
-        name: Deploy
-        run: |
-          # See https://vercel.com/docs/deployments/generated-urls#url-with-git-branch
-          export DOCS_PATH="https://docs-git-${{ needs.setup.outputs.branch }}-supabase.vercel.app/docs"
-          export STUDIO_PATH="https://studio-staging-git-${{ needs.setup.outputs.branch }}-supabase.vercel.app/dashboard"
-          echo "DEPLOY_URL=$(npx vercel deploy --cwd apps/www --yes --token ${{ secrets.VERCEL_TOKEN }} \
-            --env NEXT_PUBLIC_STUDIO_URL=$DOCS_PATH NEXT_PUBLIC_DOCS_URL=$STUDIO_PATH)" >> $GITHUB_OUTPUT
+          echo "DEPLOY_URL=$(npx vercel deploy --cwd apps/studio --yes --token ${{ secrets.VERCEL_TOKEN }})" >> $GITHUB_OUTPUT
+          #   www:
+          #     runs-on: ubuntu-latest
+          #     needs: studio
+          #     environment:
+          #       name: preview
+          #       url: ${{ steps.deploy.outputs.DEPLOY_URL }}
+          #     env:
+          #       VERCEL_PROJECT_ID:
+          #     steps:
+          #       - id: checkout
+          #         name: Checkout www
+          #         uses: actions/checkout@v4
+          #         with:
+          #           sparse-checkout: |
+          #             apps/www
+          #             packages
+          #       - id: node
+          #         name: Set up Node
+          #         uses: actions/setup-node@v3
+          #         with:
+          #           node-version: 18.x
+          #           cache: 'npm'
+          #       - id: install
+          #         name: Install dependencies
+          #         working-directory: ./
+          #         run: npm ci
+          #       - id: pull
+          #         name: Pull Vercel environment
+          #         working-directory: ./
+          #         run: |
+          #           npx vercel pull --cwd apps/www --environment-preview --yes --token ${{ secrets.VERCEL_TOKEN }}
+          #       - id: build
+          #         name: Build
+          #         working-directory: ./
+          #         run: |
+          #           npx vercel build --cwd apps/www --yes --token ${{ secrets.VERCEL_TOKEN }}
+          #       - id: deploy
+          #         name: Deploy
+          #         run: |
+          #           # See https://vercel.com/docs/deployments/generated-urls#url-with-git-branch
+          #           export DOCS_PATH="https://docs-git-${{ needs.setup.outputs.branch }}-supabase.vercel.app/docs"
+          #           export STUDIO_PATH="https://studio-staging-git-${{ needs.studio.outputs.url }}-supabase.vercel.app/dashboard"
+          #           echo "DEPLOY_URL=$(npx vercel deploy --cwd apps/www --yes --token ${{ secrets.VERCEL_TOKEN }} \
+          #             --env NEXT_PUBLIC_STUDIO_URL=$DOCS_PATH NEXT_PUBLIC_DOCS_URL=$STUDIO_PATH)" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy-docs-proxied.yml
+++ b/.github/workflows/deploy-docs-proxied.yml
@@ -6,8 +6,25 @@ env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
 
 jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      branch: ${{ steps.normalize.outputs.NORMALIZED_BRANCH }}
+    steps:
+      - id: normalize
+        name: Normalize branch name
+        run: echo "NORMALIZED_BRANCH=$(echo "$GITHUB_REF_NAME" | sed 's|/|-|' | sed 's|\.||')" >> $GITHUB_OUTPUT
+      - id: log
+        name: Log branch name
+        run: echo "branch ${{ steps.normalize.outputs.NORMALIZED_BRANCH }}"
+          #   docs:
+          #     runs-on: ubuntu-latest
+          #     needs: setup
+          #     env:
+          #       VERCEL_PROJECT_ID: 
   studio:
     runs-on: ubuntu-latest
+    needs: setup
     env:
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_STUDIO_STAGING_PROJECT_ID }}
     outputs:
@@ -20,6 +37,16 @@ jobs:
           sparse-checkout: |
             apps/studio
             packages
+      - id: node
+        name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+          cache: 'npm'
+      - id: install
+        name: Install dependencies
+        working-directory: ./
+        run: npm ci
       - id: cli
         name: Install Vercel CLI
         run: npm install --global vercel

--- a/.github/workflows/deploy-docs-proxied.yml
+++ b/.github/workflows/deploy-docs-proxied.yml
@@ -5,12 +5,10 @@ on: [pull_request, workflow_dispatch]
 jobs:
   proxy:
     runs-on: ubuntu-latest
-    env:
-      BRANCH: ${{ GITHUB_REF }}
     steps:
       - id: normalize
         name: Normalize branch name
-        run: echo "NORMALIZED_BRANCH=$(echo "$BRANCH" | sed 's|/|-|' | sed 's|.||')" >> $GITHUB_OUTPUT
+        run: echo "NORMALIZED_BRANCH=$(echo "$GITHUB_REF" | sed 's|/|-|' | sed 's|.||')" >> $GITHUB_OUTPUT
       - id: test
         name: Test
         run: echo "$BRANCH"

--- a/.github/workflows/deploy-docs-proxied.yml
+++ b/.github/workflows/deploy-docs-proxied.yml
@@ -2,13 +2,100 @@ name: Proxy docs preview site via www preview site
 
 on: [pull_request, workflow_dispatch]
 
+env:
+  VERCEL_ORG_ID:
+
 jobs:
-  proxy:
+  setup:
     runs-on: ubuntu-latest
+    outputs:
+      branch: ${{ steps.normalize.outputs.NORMALIZED_BRANCH }}
     steps:
       - id: normalize
         name: Normalize branch name
         run: echo "NORMALIZED_BRANCH=$(echo "$GITHUB_REF_NAME" | sed 's|/|-|' | sed 's|\.||')" >> $GITHUB_OUTPUT
-      - id: test
-        name: Test
+      - id: log
+        name: Log branch name
         run: echo "branch ${{ steps.normalize.outputs.NORMALIZED_BRANCH }}"
+  studio:
+    runs-on: ubuntu-latest
+    needs: setup
+    env:
+      VERCEL_PROJECT_ID:
+    steps:
+      - id: checkout
+        name: Checkout studio
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            apps/studio
+            packages
+      - id: node
+        name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+          cache: 'npm'
+      - id: install
+        name: Install dependencies
+        working-directory: ./
+        run: npm ci
+      - id: pull
+        name: Pull Vercel environment
+        working-directory: ./
+        run: |
+          npx vercel pull --cwd apps/studio --environment=preview --yes --token ${{ secrets.VERCEL_TOKEN }}
+      - id: build
+        name: Build
+        working-directory: ./
+        run: |
+          npx vercel build --cwd apps/studio --yes --token ${{ secrets.VERCEL_TOKEN }}
+      - id: deploy
+        name: Deploy
+        working-directory: ./
+        run: |
+          npx vercel deploy --cwd apps/studio --yes --token ${{ secrets.VERCEL_TOKEN }}
+  www:
+    runs-on: ubuntu-latest
+    needs: setup
+    environment:
+      name: preview
+      url: ${{ steps.deploy.outputs.DEPLOY_URL }}
+    env:
+      VERCEL_PROJECT_ID:
+    steps:
+      - id: checkout
+        name: Checkout www
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            apps/www
+            packages
+      - id: node
+        name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+          cache: 'npm'
+      - id: install
+        name: Install dependencies
+        working-directory: ./
+        run: npm ci
+      - id: pull
+        name: Pull Vercel environment
+        working-directory: ./
+        run: |
+          npx vercel pull --cwd apps/www --environment-preview --yes --token ${{ secrets.VERCEL_TOKEN }}
+      - id: build
+        name: Build
+        working-directory: ./
+        run: |
+          npx vercel build --cwd apps/www --yes --token ${{ secrets.VERCEL_TOKEN }}
+      - id: deploy
+        name: Deploy
+        run: |
+          # See https://vercel.com/docs/deployments/generated-urls#url-with-git-branch
+          export DOCS_PATH="https://docs-git-${{ needs.setup.outputs.branch }}-supabase.vercel.app/docs"
+          export STUDIO_PATH="https://studio-staging-git-${{ needs.setup.outputs.branch }}-supabase.vercel.app/dashboard"
+          echo "DEPLOY_URL=$(npx vercel deploy --cwd apps/www --yes --token ${{ secrets.VERCEL_TOKEN }} \
+            --env NEXT_PUBLIC_STUDIO_URL=$DOCS_PATH NEXT_PUBLIC_DOCS_URL=$STUDIO_PATH)" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy-docs-proxied.yml
+++ b/.github/workflows/deploy-docs-proxied.yml
@@ -50,21 +50,16 @@ jobs:
       - id: cli
         name: Install Vercel CLI
         run: npm install --global vercel
-      - id: pull
-        name: Pull Vercel environment
-        working-directory: ./
-        run: |
-          vercel pull --cwd apps/studio --environment=preview --yes --token ${{ secrets.VERCEL_TOKEN }}
       - id: build
         name: Build
         working-directory: ./
         run: |
-          vercel build --yes --token ${{ secrets.VERCEL_TOKEN }}
+          vercel build --cwd apps/studio --yes --token ${{ secrets.VERCEL_TOKEN }}
       - id: deploy
         name: Deploy
         working-directory: ./
         run: |
-          echo "DEPLOY_URL=$(vercel deploy --prebuilt --yes --token ${{ secrets.VERCEL_TOKEN }})" >> $GITHUB_OUTPUT
+          echo "DEPLOY_URL=$(vercel deploy --cwd apps/studio --prebuilt --yes --token ${{ secrets.VERCEL_TOKEN }})" >> $GITHUB_OUTPUT
           #   www:
           #     runs-on: ubuntu-latest
           #     needs: studio

--- a/.github/workflows/deploy-docs-proxied.yml
+++ b/.github/workflows/deploy-docs-proxied.yml
@@ -11,4 +11,4 @@ jobs:
         run: echo "NORMALIZED_BRANCH=$(echo "$GITHUB_REF" | sed 's|/|-|' | sed 's|.||')" >> $GITHUB_OUTPUT
       - id: test
         name: Test
-        run: echo "$BRANCH"
+        run: echo "branch ${{ steps.normalize.outputs.NORMALIZED_BRANCH }}"

--- a/.github/workflows/deploy-docs-proxied.yml
+++ b/.github/workflows/deploy-docs-proxied.yml
@@ -54,7 +54,7 @@ jobs:
         name: Build
         working-directory: ./
         run: |
-          vercel build --cwd apps/studio --yes --token ${{ secrets.VERCEL_TOKEN }}
+          vercel build --yes --token ${{ secrets.VERCEL_TOKEN }}
       - id: deploy
         name: Deploy
         working-directory: ./

--- a/.github/workflows/deploy-docs-proxied.yml
+++ b/.github/workflows/deploy-docs-proxied.yml
@@ -6,25 +6,8 @@ env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
 
 jobs:
-  setup:
-    runs-on: ubuntu-latest
-    outputs:
-      branch: ${{ steps.normalize.outputs.NORMALIZED_BRANCH }}
-    steps:
-      - id: normalize
-        name: Normalize branch name
-        run: echo "NORMALIZED_BRANCH=$(echo "$GITHUB_REF_NAME" | sed 's|/|-|' | sed 's|\.||')" >> $GITHUB_OUTPUT
-      - id: log
-        name: Log branch name
-        run: echo "branch ${{ steps.normalize.outputs.NORMALIZED_BRANCH }}"
-          #   docs:
-          #     runs-on: ubuntu-latest
-          #     needs: setup
-          #     env:
-          #       VERCEL_PROJECT_ID: 
   studio:
     runs-on: ubuntu-latest
-    needs: setup
     env:
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_STUDIO_STAGING_PROJECT_ID }}
     outputs:
@@ -37,16 +20,6 @@ jobs:
           sparse-checkout: |
             apps/studio
             packages
-      - id: node
-        name: Set up Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18.x
-          cache: 'npm'
-      - id: install
-        name: Install dependencies
-        working-directory: ./
-        run: npm ci
       - id: cli
         name: Install Vercel CLI
         run: npm install --global vercel

--- a/.github/workflows/deploy-docs-proxied.yml
+++ b/.github/workflows/deploy-docs-proxied.yml
@@ -1,6 +1,6 @@
 name: Proxy docs preview site via www preview site
 
-on: workflow_dispatch
+on: [pull_request, workflow_dispatch]
 
 jobs:
   proxy:

--- a/.github/workflows/deploy-docs-proxied.yml
+++ b/.github/workflows/deploy-docs-proxied.yml
@@ -50,16 +50,10 @@ jobs:
       - id: cli
         name: Install Vercel CLI
         run: npm install --global vercel
-      - id: build
-        name: Build
-        working-directory: ./
-        run: |
-          vercel build --yes --token ${{ secrets.VERCEL_TOKEN }}
       - id: deploy
         name: Deploy
-        working-directory: ./
         run: |
-          echo "DEPLOY_URL=$(vercel deploy --cwd apps/studio --prebuilt --yes --token ${{ secrets.VERCEL_TOKEN }})" >> $GITHUB_OUTPUT
+          echo "DEPLOY_URL=$(vercel deploy --cwd apps/studio --yes --token ${{ secrets.VERCEL_TOKEN }})" >> $GITHUB_OUTPUT
           #   www:
           #     runs-on: ubuntu-latest
           #     needs: studio

--- a/.github/workflows/deploy-docs-proxied.yml
+++ b/.github/workflows/deploy-docs-proxied.yml
@@ -1,6 +1,6 @@
 name: Proxy docs preview site via www preview site
 
-on: [pull_request, workflow_dispatch]
+on: workflow_dispatch
 
 jobs:
   proxy:

--- a/.github/workflows/deploy-docs-proxied.yml
+++ b/.github/workflows/deploy-docs-proxied.yml
@@ -1,0 +1,16 @@
+name: Proxy docs preview site via www preview site
+
+on: workflow_dispatch
+
+jobs:
+  proxy:
+    runs-on: ubuntu-latest
+    env:
+      BRANCH: ${{ GITHUB_REF }}
+    steps:
+      - id: normalize
+        name: Normalize branch name
+        run: echo "NORMALIZED_BRANCH=$(echo "$BRANCH" | sed 's|/|-|' | sed 's|.||')" >> $GITHUB_OUTPUT
+      - id: test
+        name: Test
+        run: echo "$BRANCH"

--- a/.github/workflows/deploy-docs-proxied.yml
+++ b/.github/workflows/deploy-docs-proxied.yml
@@ -47,21 +47,24 @@ jobs:
         name: Install dependencies
         working-directory: ./
         run: npm ci
+      - id: cli
+        name: Install Vercel CLI
+        run: npm install --global vercel
       - id: pull
         name: Pull Vercel environment
         working-directory: ./
         run: |
-          npx vercel pull --cwd apps/studio --environment=preview --yes --token ${{ secrets.VERCEL_TOKEN }}
+          vercel pull --cwd apps/studio --environment=preview --yes --token ${{ secrets.VERCEL_TOKEN }}
       - id: build
         name: Build
         working-directory: ./
         run: |
-          npx vercel build --cwd apps/studio --yes --token ${{ secrets.VERCEL_TOKEN }}
+          vercel build --cwd apps/studio --yes --token ${{ secrets.VERCEL_TOKEN }}
       - id: deploy
         name: Deploy
         working-directory: ./
         run: |
-          echo "DEPLOY_URL=$(npx vercel deploy --cwd apps/studio --yes --token ${{ secrets.VERCEL_TOKEN }})" >> $GITHUB_OUTPUT
+          echo "DEPLOY_URL=$(vercel deploy --prebuilt --cwd apps/studio --yes --token ${{ secrets.VERCEL_TOKEN }})" >> $GITHUB_OUTPUT
           #   www:
           #     runs-on: ubuntu-latest
           #     needs: studio
@@ -88,21 +91,24 @@ jobs:
           #         name: Install dependencies
           #         working-directory: ./
           #         run: npm ci
+          #       - id: cli
+          #         name: Install Vercel CLI
+          #         run: npm install --global vercel
           #       - id: pull
           #         name: Pull Vercel environment
           #         working-directory: ./
           #         run: |
-          #           npx vercel pull --cwd apps/www --environment-preview --yes --token ${{ secrets.VERCEL_TOKEN }}
+          #           vercel pull --cwd apps/www --environment-preview --yes --token ${{ secrets.VERCEL_TOKEN }}
           #       - id: build
           #         name: Build
           #         working-directory: ./
           #         run: |
-          #           npx vercel build --cwd apps/www --yes --token ${{ secrets.VERCEL_TOKEN }}
+          #           vercel build --cwd apps/www --yes --token ${{ secrets.VERCEL_TOKEN }}
           #       - id: deploy
           #         name: Deploy
           #         run: |
           #           # See https://vercel.com/docs/deployments/generated-urls#url-with-git-branch
           #           export DOCS_PATH="https://docs-git-${{ needs.setup.outputs.branch }}-supabase.vercel.app/docs"
           #           export STUDIO_PATH="https://studio-staging-git-${{ needs.studio.outputs.url }}-supabase.vercel.app/dashboard"
-          #           echo "DEPLOY_URL=$(npx vercel deploy --cwd apps/www --yes --token ${{ secrets.VERCEL_TOKEN }} \
+          #           echo "DEPLOY_URL=$(vercel deploy --prebuilt --cwd apps/www --yes --token ${{ secrets.VERCEL_TOKEN }} \
           #             --env NEXT_PUBLIC_STUDIO_URL=$DOCS_PATH NEXT_PUBLIC_DOCS_URL=$STUDIO_PATH)" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy-docs-proxied.yml
+++ b/.github/workflows/deploy-docs-proxied.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - id: normalize
         name: Normalize branch name
-        run: echo "NORMALIZED_BRANCH=$(echo "$GITHUB_REF" | sed 's|/|-|' | sed 's|.||')" >> $GITHUB_OUTPUT
+        run: echo "NORMALIZED_BRANCH=$(echo "$GITHUB_REF_NAME" | sed 's|/|-|' | sed 's|.||')" >> $GITHUB_OUTPUT
       - id: test
         name: Test
         run: echo "branch ${{ steps.normalize.outputs.NORMALIZED_BRANCH }}"

--- a/.github/workflows/deploy-docs-proxied.yml
+++ b/.github/workflows/deploy-docs-proxied.yml
@@ -26,7 +26,7 @@ jobs:
       - id: deploy
         name: Deploy
         run: |
-          echo "DEPLOY_URL=$(vercel deploy --cwd apps/studio --yes --token ${{ secrets.VERCEL_TOKEN }})" >> $GITHUB_OUTPUT
+          echo "DEPLOY_URL=$(vercel deploy --yes --token ${{ secrets.VERCEL_TOKEN }})" >> $GITHUB_OUTPUT
           #   www:
           #     runs-on: ubuntu-latest
           #     needs: studio

--- a/.github/workflows/deploy-docs-proxied.yml
+++ b/.github/workflows/deploy-docs-proxied.yml
@@ -59,12 +59,12 @@ jobs:
         name: Build
         working-directory: ./
         run: |
-          vercel build --cwd apps/studio --yes --token ${{ secrets.VERCEL_TOKEN }}
+          vercel build --yes --token ${{ secrets.VERCEL_TOKEN }}
       - id: deploy
         name: Deploy
         working-directory: ./
         run: |
-          echo "DEPLOY_URL=$(vercel deploy --prebuilt --cwd apps/studio --yes --token ${{ secrets.VERCEL_TOKEN }})" >> $GITHUB_OUTPUT
+          echo "DEPLOY_URL=$(vercel deploy --prebuilt --yes --token ${{ secrets.VERCEL_TOKEN }})" >> $GITHUB_OUTPUT
           #   www:
           #     runs-on: ubuntu-latest
           #     needs: studio
@@ -103,12 +103,12 @@ jobs:
           #         name: Build
           #         working-directory: ./
           #         run: |
-          #           vercel build --cwd apps/www --yes --token ${{ secrets.VERCEL_TOKEN }}
+          #           vercel build --yes --token ${{ secrets.VERCEL_TOKEN }}
           #       - id: deploy
           #         name: Deploy
           #         run: |
           #           # See https://vercel.com/docs/deployments/generated-urls#url-with-git-branch
           #           export DOCS_PATH="https://docs-git-${{ needs.setup.outputs.branch }}-supabase.vercel.app/docs"
           #           export STUDIO_PATH="https://studio-staging-git-${{ needs.studio.outputs.url }}-supabase.vercel.app/dashboard"
-          #           echo "DEPLOY_URL=$(vercel deploy --prebuilt --cwd apps/www --yes --token ${{ secrets.VERCEL_TOKEN }} \
+          #           echo "DEPLOY_URL=$(vercel deploy --prebuilt --yes --token ${{ secrets.VERCEL_TOKEN }} \
           #             --env NEXT_PUBLIC_STUDIO_URL=$DOCS_PATH NEXT_PUBLIC_DOCS_URL=$STUDIO_PATH)" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy-single-origin.yml
+++ b/.github/workflows/deploy-single-origin.yml
@@ -26,7 +26,7 @@ jobs:
       - id: deploy
         name: Deploy
         run: |
-          echo "DEPLOY_URL=$(vercel deploy --yes --token ${{ secrets.VERCEL_TOKEN }})" >> $GITHUB_OUTPUT
+          echo "DEPLOY_URL=$(vercel deploy --token ${{ secrets.VERCEL_TOKEN }})" >> $GITHUB_OUTPUT
           #   www:
           #     runs-on: ubuntu-latest
           #     needs: studio

--- a/.github/workflows/deploy-single-origin.yml
+++ b/.github/workflows/deploy-single-origin.yml
@@ -78,5 +78,5 @@ jobs:
         name: Deploy
         run: |
           echo "DEPLOY_URL=$(vercel deploy --token ${{ secrets.VERCEL_TOKEN }} \
-            --env NEXT_PUBLIC_STUDIO_URL="${{ needs.studio.outputs.url }}" \
-              NEXT_PUBLIC_DOCS_URL="${{ needs.docs.outputs.url }}")" >> $GITHUB_OUTPUT
+                --env NEXT_PUBLIC_STUDIO_URL="${{ needs.studio.outputs.url }}" \
+                --env NEXT_PUBLIC_DOCS_URL="${{ needs.docs.outputs.url }}")" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy-single-origin.yml
+++ b/.github/workflows/deploy-single-origin.yml
@@ -1,6 +1,9 @@
 name: Deploy under single origin
 
-on: [pull_request, workflow_dispatch] # pull_request for testing only, remove later
+on:
+  pull_request:
+    branches:
+      - master
 
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
@@ -8,6 +11,7 @@ env:
 jobs:
   studio:
     runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.title, '[ci shared auth]')
     env:
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_STUDIO_STAGING_PROJECT_ID }}
     outputs:

--- a/.github/workflows/deploy-single-origin.yml
+++ b/.github/workflows/deploy-single-origin.yml
@@ -31,6 +31,29 @@ jobs:
         name: Deploy
         run: |
           echo "DEPLOY_URL=$(vercel deploy --token ${{ secrets.VERCEL_TOKEN }})" >> $GITHUB_OUTPUT
+
+  docs:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.title, '[ci shared auth]')
+    env:
+      VERCEL_PROJECT_ID: ${{ secrets. VERCEL_DOCS_PROJECT_ID }}
+    outputs:
+      url: ${{ steps.deploy.outputs.DEPLOY_URL }}
+    steps:
+      - id: checkout
+        name: Checkout docs
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            apps/docs
+            packages
+      - id: cli
+        name: Install Vercel CLI
+        run: npm install --global vercel
+      - id: deploy
+        name: Deploy
+        run: |
+          echo "DEPLOY_URL=$(vercel deploy --token ${{ secrets.VERCEL_TOKEN }})" >> $GITHUB_OUTPUT
           #   www:
           #     runs-on: ubuntu-latest
           #     needs: studio

--- a/.github/workflows/deploy-single-origin.yml
+++ b/.github/workflows/deploy-single-origin.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     if: contains(github.event.pull_request.title, '[ci shared auth]')
     env:
-      VERCEL_PROJECT_ID: ${{ secrets. VERCEL_DOCS_PROJECT_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_DOCS_PROJECT_ID }}
     outputs:
       url: ${{ steps.deploy.outputs.DEPLOY_URL }}
     steps:
@@ -54,50 +54,29 @@ jobs:
         name: Deploy
         run: |
           echo "DEPLOY_URL=$(vercel deploy --token ${{ secrets.VERCEL_TOKEN }})" >> $GITHUB_OUTPUT
-          #   www:
-          #     runs-on: ubuntu-latest
-          #     needs: studio
-          #     environment:
-          #       name: preview
-          #       url: ${{ steps.deploy.outputs.DEPLOY_URL }}
-          #     env:
-          #       VERCEL_PROJECT_ID:
-          #     steps:
-          #       - id: checkout
-          #         name: Checkout www
-          #         uses: actions/checkout@v4
-          #         with:
-          #           sparse-checkout: |
-          #             apps/www
-          #             packages
-          #       - id: node
-          #         name: Set up Node
-          #         uses: actions/setup-node@v3
-          #         with:
-          #           node-version: 18.x
-          #           cache: 'npm'
-          #       - id: install
-          #         name: Install dependencies
-          #         working-directory: ./
-          #         run: npm ci
-          #       - id: cli
-          #         name: Install Vercel CLI
-          #         run: npm install --global vercel
-          #       - id: pull
-          #         name: Pull Vercel environment
-          #         working-directory: ./
-          #         run: |
-          #           vercel pull --cwd apps/www --environment-preview --yes --token ${{ secrets.VERCEL_TOKEN }}
-          #       - id: build
-          #         name: Build
-          #         working-directory: ./
-          #         run: |
-          #           vercel build --yes --token ${{ secrets.VERCEL_TOKEN }}
-          #       - id: deploy
-          #         name: Deploy
-          #         run: |
-          #           # See https://vercel.com/docs/deployments/generated-urls#url-with-git-branch
-          #           export DOCS_PATH="https://docs-git-${{ needs.setup.outputs.branch }}-supabase.vercel.app/docs"
-          #           export STUDIO_PATH="https://studio-staging-git-${{ needs.studio.outputs.url }}-supabase.vercel.app/dashboard"
-          #           echo "DEPLOY_URL=$(vercel deploy --prebuilt --yes --token ${{ secrets.VERCEL_TOKEN }} \
-          #             --env NEXT_PUBLIC_STUDIO_URL=$DOCS_PATH NEXT_PUBLIC_DOCS_URL=$STUDIO_PATH)" >> $GITHUB_OUTPUT
+
+  www:
+    runs-on: ubuntu-latest
+    needs: [docs, studio]
+    environment:
+      name: preview
+      url: ${{ steps.deploy.outputs.DEPLOY_URL }}
+    env:
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_WWW_PROJECT_ID }}
+    steps:
+      - id: checkout
+        name: Checkout www
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            apps/www
+            packages
+      - id: cli
+        name: Install Vercel CLI
+        run: npm install --global vercel
+      - id: deploy
+        name: Deploy
+        run: |
+          echo "DEPLOY_URL=$(vercel deploy --token ${{ secrets.VERCEL_TOKEN }} \
+            --env NEXT_PUBLIC_STUDIO_URL="${{ needs.studio.outputs.url }}" \
+              NEXT_PUBLIC_DOCS_URL="${{ needs.docs.outputs.url }}")" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy-single-origin.yml
+++ b/.github/workflows/deploy-single-origin.yml
@@ -1,4 +1,4 @@
-name: Proxy docs preview site via www preview site
+name: Deploy under single origin
 
 on: [pull_request, workflow_dispatch] # pull_request for testing only, remove later
 

--- a/.github/workflows/deploy-single-origin.yml
+++ b/.github/workflows/deploy-single-origin.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
 
@@ -78,5 +82,5 @@ jobs:
         name: Deploy
         run: |
           echo "DEPLOY_URL=$(vercel deploy --token ${{ secrets.VERCEL_TOKEN }} \
-                --env NEXT_PUBLIC_STUDIO_URL="${{ needs.studio.outputs.url }}" \
-                --env NEXT_PUBLIC_DOCS_URL="${{ needs.docs.outputs.url }}")" >> $GITHUB_OUTPUT
+                --build-env NEXT_PUBLIC_STUDIO_URL="${{ needs.studio.outputs.url }}" \
+                --build-env NEXT_PUBLIC_DOCS_URL="${{ needs.docs.outputs.url }}")" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy-single-origin.yml
+++ b/.github/workflows/deploy-single-origin.yml
@@ -82,5 +82,5 @@ jobs:
         name: Deploy
         run: |
           echo "DEPLOY_URL=$(vercel deploy --token ${{ secrets.VERCEL_TOKEN }} \
-                --build-env NEXT_PUBLIC_STUDIO_URL="${{ needs.studio.outputs.url }}" \
-                --build-env NEXT_PUBLIC_DOCS_URL="${{ needs.docs.outputs.url }}")" >> $GITHUB_OUTPUT
+                --build-env NEXT_PUBLIC_STUDIO_URL="${{ needs.studio.outputs.url }}/dashboard" \
+                --build-env NEXT_PUBLIC_DOCS_URL="${{ needs.docs.outputs.url }}/docs")" >> $GITHUB_OUTPUT

--- a/apps/docs/.gitignore
+++ b/apps/docs/.gitignore
@@ -23,3 +23,4 @@ yarn-error.log*
 **/*/generated/**/*
 !**/*/generated/.gitkeep
 !**/*/generated/**/.gitkeep
+.vercel

--- a/apps/www/components/Nav/index.tsx
+++ b/apps/www/components/Nav/index.tsx
@@ -164,10 +164,10 @@ const Nav = () => {
                     ) : (
                       <>
                         <Button type="default" className="hidden lg:block" asChild>
-                          <Link href="https://supabase.com/dashboard">Sign in</Link>
+                          <Link href="/dashboard">Sign in</Link>
                         </Button>
                         <Button className="hidden text-white lg:block" asChild>
-                          <Link href="https://supabase.com/dashboard">Start your project</Link>
+                          <Link href="/dashboard">Start your project</Link>
                         </Button>
                       </>
                     )}


### PR DESCRIPTION
add a trigger to generate a set of preview deploys for studio/docs/www that are proxied together via www's URL
makes it possible to test authenticated features in preview for docs/www, which otherwise have no signin mechanism