### PR TITLE
Fix bug: verify email links don't work if opened in a different browser

### DIFF
--- a/apps/docs/pages/guides/getting-started/tutorials/with-sveltekit.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-sveltekit.mdx
@@ -267,12 +267,23 @@ In the following code snippet, we perform the following steps:
 ```js title=src/routes/auth/callback/+server.js
 // src/routes/auth/callback/+server.js
 import { redirect } from '@sveltejs/kit'
+import { isAuthApiError } from '@supabase/supabase-js'
 
 export const GET = async ({ url, locals: { supabase } }) => {
   const code = url.searchParams.get('code')
 
   if (code) {
-    await supabase.auth.exchangeCodeForSession(code)
+    try {
+      await supabase.auth.exchangeCodeForSession(code)
+    } catch (error) {
+       // If opened in another browser without PCKE cookie, need to redirect user to login.
+       if (isAuthApiError(error)) {
+         // optionally add "Email verified! Please login." message to your login UI using the query param.
+         throw redirect(303, "/?verified=true")
+       } else {
+         throw error
+       }
+     }
   }
 
   throw redirect(303, '/account')


### PR DESCRIPTION
Currently following this guide, you get a 500 error if clicking there "verify email" link in a browser other than the one you submitted the create account request from. 

We should verify in the callback, but then redirect the user to login (as opposed to error), as this isn't a real error path, and user action is needed to recover.

## What kind of change does this PR introduce?

Bug fix for the sample code in the guide.

## What is the current behavior?

Long discussions on issue and best UX here:

 - https://github.com/supabase/auth-helpers/issues/545
 - https://github.com/supabase/auth-helpers/issues/545#issuecomment-1666960329

## What is the new behavior?

Detects possible issue (500) and redirects user to login to resolve the issue.

## Additional context

NA
