### PR TITLE
chore: sign impersonation JWT with browser crypto

### DIFF
--- a/apps/studio/components/interfaces/Realtime/Inspector/RealtimeTokensPopover/index.tsx
+++ b/apps/studio/components/interfaces/Realtime/Inspector/RealtimeTokensPopover/index.tsx
@@ -1,4 +1,5 @@
 import { Dispatch, SetStateAction, useEffect } from 'react'
+import toast from 'react-hot-toast'
 
 import { RoleImpersonationPopover } from 'components/interfaces/RoleImpersonationSelector'
 import { useProjectApiQuery } from 'data/config/project-api-query'
@@ -42,9 +43,9 @@ export const RealtimeTokensPopover = ({ config, onChangeConfig }: RealtimeTokens
       snap.role.type === 'postgrest'
     ) {
       token = anonRoleKey
-      getRoleImpersonationJWT(config.projectRef, jwtSecret, snap.role).then(
-        (token) => (bearer = token)
-      )
+      getRoleImpersonationJWT(config.projectRef, jwtSecret, snap.role)
+        .then((token) => (bearer = token))
+        .catch((err) => toast.error(`Failed to get JWT for role: ${err.message}`))
     } else {
       token = serviceRoleKey
     }

--- a/apps/studio/components/interfaces/Realtime/Inspector/RealtimeTokensPopover/index.tsx
+++ b/apps/studio/components/interfaces/Realtime/Inspector/RealtimeTokensPopover/index.tsx
@@ -42,7 +42,9 @@ export const RealtimeTokensPopover = ({ config, onChangeConfig }: RealtimeTokens
       snap.role.type === 'postgrest'
     ) {
       token = anonRoleKey
-      bearer = getRoleImpersonationJWT(config.projectRef, jwtSecret, snap.role)
+      getRoleImpersonationJWT(config.projectRef, jwtSecret, snap.role).then(
+        (token) => (bearer = token)
+      )
     } else {
       token = serviceRoleKey
     }

--- a/apps/studio/lib/role-impersonation.ts
+++ b/apps/studio/lib/role-impersonation.ts
@@ -1,5 +1,3 @@
-import jwt from 'jwt-simple'
-
 import { User } from 'data/auth/users-query'
 import { uuidv4 } from './helpers'
 
@@ -114,12 +112,63 @@ export function wrapWithRoleImpersonation(
   `
 }
 
-export function getRoleImpersonationJWT(
+export async function getRoleImpersonationJWT(
   projectRef: string,
   jwtSecret: string,
   role: PostgrestImpersonationRole
-) {
+): Promise<string> {
   const claims = getPostgrestClaims(projectRef, role)
 
-  return jwt.encode(claims, jwtSecret, 'HS256')
+  return createToken(claims, jwtSecret)
+}
+
+async function createToken(payload: object, key: string) {
+  var header = { typ: 'JWT', alg: 'HS256' }
+
+  var segments = []
+  segments.push(btoa(JSON.stringify(header)).replace(/=/g, ''))
+  segments.push(btoa(JSON.stringify(payload)).replace(/=/g, ''))
+
+  var footer = await sign(segments.join('.'), btoa(key).replace(/=/g, ''))
+
+  segments.push(footer.replace(/=/g, ''))
+
+  return segments.join('.')
+}
+
+async function sign(data: string, key: string) {
+  return window.crypto.subtle
+    .importKey(
+      'jwk',
+      {
+        //this is an example jwk key, "raw" would be an ArrayBuffer
+        kty: 'oct',
+        k: key,
+        alg: 'HS256',
+      },
+      {
+        name: 'HMAC',
+        hash: { name: 'SHA-256' },
+      },
+      false,
+      ['sign', 'verify']
+    )
+    .then((key) => {
+      var jsonString = JSON.stringify(data)
+      var encodedData = new TextEncoder().encode(jsonString)
+
+      return window.crypto.subtle.sign(
+        {
+          name: 'HMAC',
+        },
+        key,
+        encodedData
+      )
+    })
+    .then((token) => {
+      var u8 = new Uint8Array(token)
+      var b64encoded = btoa(String.fromCharCode.apply(null, u8))
+
+      return b64encoded
+    })
 }

--- a/apps/studio/lib/role-impersonation.ts
+++ b/apps/studio/lib/role-impersonation.ts
@@ -167,7 +167,7 @@ async function sign(data: string, key: string) {
     })
     .then((token) => {
       var u8 = new Uint8Array(token)
-      var b64encoded = btoa(String.fromCharCode.apply(null, u8))
+      var b64encoded = btoa(String.fromCharCode(...u8))
 
       return b64encoded
     })

--- a/apps/studio/lib/role-impersonation.ts
+++ b/apps/studio/lib/role-impersonation.ts
@@ -123,13 +123,13 @@ export async function getRoleImpersonationJWT(
 }
 
 async function createToken(payload: object, key: string) {
-  var header = { typ: 'JWT', alg: 'HS256' }
+  const header = { typ: 'JWT', alg: 'HS256' }
 
-  var segments = []
+  const segments = []
   segments.push(btoa(JSON.stringify(header)).replace(/=/g, ''))
   segments.push(btoa(JSON.stringify(payload)).replace(/=/g, ''))
 
-  var footer = await sign(segments.join('.'), btoa(key).replace(/=/g, ''))
+  const footer = await sign(segments.join('.'), btoa(key).replace(/=/g, ''))
 
   segments.push(footer.replace(/=/g, ''))
 
@@ -154,8 +154,8 @@ async function sign(data: string, key: string) {
       ['sign', 'verify']
     )
     .then((key) => {
-      var jsonString = JSON.stringify(data)
-      var encodedData = new TextEncoder().encode(jsonString)
+      const jsonString = JSON.stringify(data)
+      const encodedData = new TextEncoder().encode(jsonString)
 
       return window.crypto.subtle.sign(
         {
@@ -166,9 +166,13 @@ async function sign(data: string, key: string) {
       )
     })
     .then((token) => {
-      var u8 = new Uint8Array(token)
-      var b64encoded = btoa(String.fromCharCode(...u8))
+      const u8 = new Uint8Array(token)
+      const b64encoded = btoa(String.fromCharCode(...u8))
 
       return b64encoded
+    })
+    .catch((err) => {
+      console.error('Error signing token', { err })
+      throw err
     })
 }

--- a/apps/studio/lib/role-impersonation.ts
+++ b/apps/studio/lib/role-impersonation.ts
@@ -128,13 +128,9 @@ async function createToken(payload: object, key: string) {
   segments.push(btoa(JSON.stringify(header)).replace(/=/g, ''))
   segments.push(btoa(JSON.stringify(payload)).replace(/=/g, ''))
 
-  try {
-    const footer = await sign(segments.join('.'), btoa(key).replace(/=/g, ''))
-    segments.push(footer.replace(/=/g, ''))
-    return segments.join('.')
-  } catch (err) {
-    throw err
-  }
+  const footer = await sign(segments.join('.'), btoa(key).replace(/=/g, ''))
+  segments.push(footer.replace(/=/g, ''))
+  return segments.join('.')
 }
 
 async function sign(data: string, key: string) {
@@ -169,8 +165,5 @@ async function sign(data: string, key: string) {
       const u8 = new Uint8Array(token)
       const b64encoded = btoa(String.fromCharCode(...u8))
       return b64encoded
-    })
-    .catch((err) => {
-      throw err
     })
 }

--- a/apps/studio/lib/role-impersonation.ts
+++ b/apps/studio/lib/role-impersonation.ts
@@ -155,28 +155,20 @@ async function sign(data: string, key: string) {
       ['sign', 'verify']
     )
     .then((key) => {
-      try {
-        const jsonString = JSON.stringify(data)
-        const encodedData = new TextEncoder().encode(jsonString)
-        return window.crypto.subtle.sign(
-          {
-            name: 'HMAC',
-          },
-          key,
-          encodedData
-        )
-      } catch (err) {
-        throw err
-      }
+      const jsonString = JSON.stringify(data)
+      const encodedData = new TextEncoder().encode(jsonString)
+      return window.crypto.subtle.sign(
+        {
+          name: 'HMAC',
+        },
+        key,
+        encodedData
+      )
     })
     .then((token) => {
-      try {
-        const u8 = new Uint8Array(token)
-        const b64encoded = btoa(String.fromCharCode(...u8))
-        return b64encoded
-      } catch (err) {
-        throw err
-      }
+      const u8 = new Uint8Array(token)
+      const b64encoded = btoa(String.fromCharCode(...u8))
+      return b64encoded
     })
     .catch((err) => {
       throw err

--- a/apps/studio/next.config.js
+++ b/apps/studio/next.config.js
@@ -84,8 +84,7 @@ const nextConfig = {
   experimental: {
     // [Kevin] Next polyfills Node modules like Crypto by default, blowing up the bundle size. We use generate-password-browser (safe to use in browser) and the polyfills are not needed for us
     // Revisit on Next 14 upgrade (PR #19909)
-    // [Ivan] Temporarily enable until we find a fix for breaking anon-role in the Realtime inspector
-    // fallbackNodePolyfills: false,
+    fallbackNodePolyfills: false,
   },
   async redirects() {
     return [

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -56,7 +56,6 @@
     "ip-num": "^1.5.1",
     "json-logic-js": "^2.0.2",
     "jsonrepair": "^3.2.3",
-    "jwt-simple": "^0.5.6",
     "lodash": "^4.17.21",
     "lucide-react": "^0.167.0",
     "markdown-table": "=2.0.0",

--- a/apps/studio/pages/project/[ref]/api/graphiql.tsx
+++ b/apps/studio/pages/project/[ref]/api/graphiql.tsx
@@ -49,7 +49,7 @@ const GraphiQLPage: NextPageWithLayout = () => {
       url: `${API_URL}/projects/${projectRef}/api/graphql`,
       fetch,
     })
-    const customFetcher: Fetcher = (graphqlParams, opts) => {
+    const customFetcher: Fetcher = async (graphqlParams, opts) => {
       let userAuthorization: string | undefined
 
       const role = getImpersonatedRole()
@@ -59,7 +59,8 @@ const GraphiQLPage: NextPageWithLayout = () => {
         role !== undefined &&
         role.type === 'postgrest'
       ) {
-        userAuthorization = `Bearer ${getRoleImpersonationJWT(projectRef, jwtSecret, role)}`
+        const token = await getRoleImpersonationJWT(projectRef, jwtSecret, role)
+        userAuthorization = 'Bearer ' + token
       }
 
       return fetcherFn(graphqlParams, {

--- a/apps/studio/pages/project/[ref]/api/graphiql.tsx
+++ b/apps/studio/pages/project/[ref]/api/graphiql.tsx
@@ -4,6 +4,7 @@ import { useParams } from 'common'
 import { observer } from 'mobx-react-lite'
 import { useTheme } from 'next-themes'
 import { useMemo } from 'react'
+import toast from 'react-hot-toast'
 
 import ExtensionCard from 'components/interfaces/Database/Extensions/ExtensionCard'
 import GraphiQL from 'components/interfaces/GraphQL/GraphiQL'
@@ -59,8 +60,12 @@ const GraphiQLPage: NextPageWithLayout = () => {
         role !== undefined &&
         role.type === 'postgrest'
       ) {
-        const token = await getRoleImpersonationJWT(projectRef, jwtSecret, role)
-        userAuthorization = 'Bearer ' + token
+        try {
+          const token = await getRoleImpersonationJWT(projectRef, jwtSecret, role)
+          userAuthorization = 'Bearer ' + token
+        } catch (err: any) {
+          toast.error(`Failed to get JWT for role: ${err.message}`)
+        }
       }
 
       return fetcherFn(graphqlParams, {

--- a/package-lock.json
+++ b/package-lock.json
@@ -803,7 +803,6 @@
         "ip-num": "^1.5.1",
         "json-logic-js": "^2.0.2",
         "jsonrepair": "^3.2.3",
-        "jwt-simple": "^0.5.6",
         "lodash": "^4.17.21",
         "lucide-react": "^0.167.0",
         "markdown-table": "=2.0.0",
@@ -23730,14 +23729,6 @@
       "dependencies": {
         "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/jwt-simple": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/jwt-simple/-/jwt-simple-0.5.6.tgz",
-      "integrity": "sha512-40aUybvhH9t2h71ncA1/1SbtTNCVZHgsTsTgqPUxGWDmUDrXyDf2wMNQKEbdBjbf4AI+fQhbECNTV6lWxQKUzg==",
-      "engines": {
-        "node": ">= 0.4.0"
       }
     },
     "node_modules/kasi": {


### PR DESCRIPTION
jwt-simple was published 5 years ago and is not compatible with browsers. Thus, Next.js polyfills all the Node.js crypto APIs blowing up our bundle.

This PR aims to get rid of the jwt-simple library and use built-in crypto APIs from the browser and removes the polyfill from Next.js.

Tested on staging by creating multiple users, setting up an RLS policy and then impersonating the user