### PR TITLE
fix: prevent crashing when attempting to enable wrappers

### DIFF
--- a/apps/studio/pages/api/pg-meta/[ref]/extensions.ts
+++ b/apps/studio/pages/api/pg-meta/[ref]/extensions.ts
@@ -30,7 +30,7 @@ const handleGetAll = async (req: NextApiRequest, res: NextApiResponse) => {
     headers,
   })
   if (response.error) {
-    return res.status(400).json({ error: response.error })
+    return res.status(400).json(response.error)
   }
   return res.status(200).json(response)
 }
@@ -44,7 +44,7 @@ const handlePost = async (req: NextApiRequest, res: NextApiResponse) => {
 
   if (response.error) {
     console.error('Extensions POST:', response.error)
-    return res.status(400).json({ error: response.error })
+    return res.status(400).json(response.error)
   }
 
   return res.status(200).json(response)
@@ -56,7 +56,7 @@ const handleDelete = async (req: NextApiRequest, res: NextApiResponse) => {
 
   if (response.error) {
     console.error('Extensions DELETE:', response.error)
-    return res.status(400).json({ error: response.error })
+    return res.status(400).json(response.error)
   }
 
   return res.status(200).json(response)


### PR DESCRIPTION
## What kind of change does this PR introduce?

fixes: https://github.com/supabase/supabase/issues/20229

## What is the current behavior?

When we enable wrappers, it will throw errors.

## What is the new behavior?

Instead of displaying the crash page, we will show the error in a toast notification.

## Additional context

Should we simplify our API when an error occurs? Instead of wrapping it in an error, it will directly return an error object
