### PR TITLE
fix Enumerated Types Doesn't Reset the List

### DIFF
--- a/apps/studio/components/interfaces/Database/EnumeratedTypes/EditEnumeratedTypeSidePanel.tsx
+++ b/apps/studio/components/interfaces/Database/EnumeratedTypes/EditEnumeratedTypeSidePanel.tsx
@@ -131,6 +131,12 @@ const EditEnumeratedTypeSidePanel = ({
         values: originalEnumeratedTypes,
       })
     }
+
+    if (selectedEnumeratedType == undefined) {
+      form.reset({
+        values: originalEnumeratedTypes,
+      })
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedEnumeratedType])
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

#20193  Bug fix for the EnumeratedTypesSidePanel

## What is the current behavior?

As the issue described its showing a rolling phantom list when closing the sidepanel

## What is the new behavior?

No extra list created when EnumeratedTypeSidePanel is closed

## Additional context


https://github.com/supabase/supabase/assets/91425128/393491ca-d460-4f86-ad0e-0dbefde8960e


