### PR TITLE
Update Login with Google docs: correct link to Expo installation docs

### DIFF
--- a/apps/docs/pages/guides/auth/social-login/auth-google.mdx
+++ b/apps/docs/pages/guides/auth/social-login/auth-google.mdx
@@ -168,7 +168,7 @@ Before you can use Sign in with Google, you need to obtain a [Google Cloud Platf
 
     When working with Expo, you can use the [`react-native-google-signin/google-signin` library](https://github.com/react-native-google-signin/google-signin#expo-installation) library to obtain an ID token that you can pass to supabase-js [`signInWithIdToken` method](/docs/reference/javascript/auth-signinwithidtoken).
 
-    Follow the [Expo installation docs](https://github.com/react-native-google-signin/google-signin#expo-installation) for installation and configuration instructions. See the [supabase-js reference](/docs/reference/javascript/initializing?example=react-native-options-async-storage) for instructions on initializing the supabase-js client in React Native.
+    Follow the [Expo installation docs](https://react-native-google-signin.github.io/docs/setting-up/expo) for installation and configuration instructions. See the [supabase-js reference](/docs/reference/javascript/initializing?example=react-native-options-async-storage) for instructions on initializing the supabase-js client in React Native.
 
     ```tsx ./components/Auth.native.tsx
     import {


### PR DESCRIPTION
Issue reference: https://github.com/supabase/supabase/issues/20228

## What kind of change does this PR introduce?

This PR updates the [Login with Google documentation](https://supabase.com/docs/guides/auth/social-login/auth-google?platform=react-native#using-native-sign-in-with-google-in-expo) for the Expo installation documentation at the link "Expo installation docs".

## What is the current behavior?

The "Expo installation docs" link currently links to [google-signin](https://github.com/react-native-google-signin/google-signin#expo-installation) in the GitHub repo. 

## What is the new behavior?

"Expo installation docs" now links to the [Expo setup documentation](https://react-native-google-signin.github.io/docs/setting-up/expo).

## Additional context

Issue reference: #20228  
