### PR TITLE
feat: add cognito migration guide

### DIFF
--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
@@ -1543,6 +1543,7 @@ export const migrate = {
   title: 'Migrate to Supabase',
   url: '/guides/migrate',
   items: [
+    { name: 'Cognito Auth', url: '/guides/migrations/cognito-auth' },
     { name: 'Firebase Auth', url: '/guides/migrations/firebase-auth' },
     { name: 'Firestore Data', url: '/guides/migrations/firestore-data' },
     { name: 'Firebase Storage', url: '/guides/migrations/firebase-storage' },

--- a/apps/docs/pages/guides/resources.mdx
+++ b/apps/docs/pages/guides/resources.mdx
@@ -109,6 +109,12 @@ export const resources = [
 
 export const migrationGuides = [
   {
+    title: 'Cognito Auth',
+    icon: '/docs/img/icons/cognito-icon',
+    href: '/guides/resources/migrating-to-supabase/cognito-auth',
+    description: 'Move your auth users from a Cognito User Pool to a Supabase project.',
+  },
+  {
     title: 'Firebase Auth',
     icon: '/docs/img/icons/firebase-icon',
     href: '/guides/resources/migrating-to-supabase/firebase-auth',

--- a/apps/docs/pages/guides/resources/migrating-to-supabase/cognito-auth.mdx
+++ b/apps/docs/pages/guides/resources/migrating-to-supabase/cognito-auth.mdx
@@ -7,20 +7,24 @@ export const meta = {
   sidebar_label: 'Cognito Auth',
 }
 
-Supabase provides
+This guide describes how to perform a bulk migration of your Amazon Web Services (AWS) Cognito User Pool to Supabase Auth. Unfortunately, this guide does not handle the migration of secrets such as
+Single Sign On (SSO) Identity Providers and Multi Factor Authentication devices. You will need to re-register MFA factors and SSO IDPs (to include link here).
 
-## Set up the migration tool
+## Export Users From Cognito
 
-Decide which user pool to migrate from
+Use this script to export users from a User Pool to CSV. // insert script after figuring out where to store it
 
-1. Export from [Cognito to CSV](https://github.com/hawkerfun/cognito-csv-exporter)
-2. Load CSV into database?
+## Load Cognito Users into Supabase
 
+Use a script to iterate through the CSV file and create users via the `supabase.auth.admin.createUser`. We provide a sample for reference but you can also write your own.
 
-### Migrating SAML IDP Providers
-
-
-### Migrating MFA Factors
+Here's how [Cognito User fields](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_UserType.html) map to Supabase fields map to fields on our `auth.users` schema.
+This can change as both services evolve. We recommend that you experiment with a few users in a local environment via [a local AWS Cognito emulator](https://hub.docker.com/r/jagregory/cognito-local) and the local Supabase setup.
 
 
 ### How are current users impacted?
+
+Users with a linked password sign in method will have to reset their password.
+
+
+AWS also provides a [reference architecture for user exports](https://aws.amazon.com/solutions/implementations/cognito-user-profiles-export-reference-architecture/)

--- a/apps/docs/pages/guides/resources/migrating-to-supabase/cognito-auth.mdx
+++ b/apps/docs/pages/guides/resources/migrating-to-supabase/cognito-auth.mdx
@@ -1,0 +1,26 @@
+import Layout from '~/layouts/DefaultGuideLayout'
+
+export const meta = {
+  id: 'cognito-auth',
+  title: 'Cognito Auth Migration',
+  description: 'Migrate Cognito auth users to a Supabase project.',
+  sidebar_label: 'Cognito Auth',
+}
+
+Supabase provides
+
+## Set up the migration tool
+
+Decide which user pool to migrate from
+
+1. Export from [Cognito to CSV](https://github.com/hawkerfun/cognito-csv-exporter)
+2. Load CSV into database?
+
+
+### Migrating SAML IDP Providers
+
+
+### Migrating MFA Factors
+
+
+### How are current users impacted?

--- a/apps/docs/pages/guides/resources/migrating-to-supabase/cognito-auth.mdx
+++ b/apps/docs/pages/guides/resources/migrating-to-supabase/cognito-auth.mdx
@@ -7,24 +7,42 @@ export const meta = {
   sidebar_label: 'Cognito Auth',
 }
 
-This guide describes how to perform a bulk migration of your Amazon Web Services (AWS) Cognito User Pool to Supabase Auth. Unfortunately, this guide does not handle the migration of secrets such as
-Single Sign On (SSO) Identity Providers and Multi Factor Authentication devices. You will need to re-register MFA factors and SSO IDPs (to include link here).
+This guide describes how to perform a bulk migration of your Amazon Web Services (AWS) Cognito User Pool to Supabase Auth. Unfortunately, this guide does not handle the migration of secrets such as Single Sign On (SSO) Identity Providers and Multi Factor Authentication devices. You will need to re-register [MFA factors](https://supabase.com/docs/guides/auth/auth-mfa) and [Single Sign On Identity Provider](https://supabase.com/docs/guides/auth/sso/auth-sso-saml)
+
+We primarily focus on two cases:
+
+1. You have email password logins
+2. You have email and password logins in addition to OAuth logins.
+
+You can export users via any one of the three approaches:
+
+1. Lambda Trigger
+2. Bulk Export Script
+3. Foreign Data Wrapper
 
 ## Export Users From Cognito
 
-Use this script to export users from a User Pool to CSV. // insert script after figuring out where to store it
-
-## Load Cognito Users into Supabase
-
-Use a script to iterate through the CSV file and create users via the `supabase.auth.admin.createUser`. We provide a sample for reference but you can also write your own.
-
-Here's how [Cognito User fields](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_UserType.html) map to Supabase fields map to fields on our `auth.users` schema.
-This can change as both services evolve. We recommend that you experiment with a few users in a local environment via [a local AWS Cognito emulator](https://hub.docker.com/r/jagregory/cognito-local) and the local Supabase setup.
+// List case with three tabs
 
 
 ### How are current users impacted?
 
 Users with a linked password sign in method will have to reset their password.
 
+## Bulk Export Script
+
+
+### How are current users impacted?
+
+Users with a linked password sign in method will have to reset their password.
+
+## Foreign Data Wrapper
+
+### How are current users impacted?
+
+Users with a linked password sign in method will have to reset their password.
+
+
+### Refrences
 
 AWS also provides a [reference architecture for user exports](https://aws.amazon.com/solutions/implementations/cognito-user-profiles-export-reference-architecture/)

--- a/apps/docs/pages/index.mdx
+++ b/apps/docs/pages/index.mdx
@@ -232,6 +232,11 @@ export const products = [
 
 export const migrationGuides = [
   {
+    title: 'Cognito Auth',
+    icon: '/docs/img/icons/cognito-icon',
+    href: '/guides/resources/migrating-to-supabase/cognito-auth',
+  },
+  {
     title: 'Firebase Auth',
     icon: '/docs/img/icons/firebase-icon',
     href: '/guides/resources/migrating-to-supabase/firebase-auth',


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add a Cognito migration guide which should allow developers to seamlessly migrate to Supabase. This guide is primarily targeted at bulk exports where the system owners wants to move all their users over at one go


We are still investigating how to migrate SAML/SSO users/connections.


### Related Context

Reddit Thread: https://www.reddit.com/r/Supabase/comments/18zzepu/can_i_move_userpool_from_aws_to_supabase/?share_id=rEdfj2RnNAZaku9gfoCTX&utm_content=1&utm_medium=android_app&utm_name=androidcss&utm_source=share&utm_term=1