### PR TITLE
Updated "connecting-to-postgres.mdx" (1/8) for Supavisor switchover on January 15.

### DIFF
--- a/apps/docs/pages/guides/database/connecting-to-postgres.mdx
+++ b/apps/docs/pages/guides/database/connecting-to-postgres.mdx
@@ -1,30 +1,32 @@
-import Layout from '~/layouts/DefaultGuideLayout'
-import StepHikeCompact from '~/components/StepHikeCompact'
+import Layout from '~/layouts/DefaultGuideLayout';
+import StepHikeCompact from '~/components/StepHikeCompact';
 
 export const meta = {
   id: 'connecting-to-postgres',
   title: 'Connecting to your database',
   description: 'Explore the options for connecting to your Postgres database.',
   subtitle: 'Explore the options for connecting to your Postgres database.',
-}
+};
+
+const switchOverDate = 'January 15th, 2024';
 
 Supabase provides several options for programmatically connecting to your Postgres database:
 
 1. Programmatic access using the Data APIs
-1. Direct connections using the built-in Postgres connection system
-1. Connection pooling for scalable connections
+2. Direct connections using the built-in Postgres connection system
+3. Connection pooling for scalable connections
 
 ## Data APIs
 
 Supabase provides auto-updating Data APIs. These are the easiest way to get started if you are managing data (fetching, inserting, updating). We provide several types of API to suit your preferences:
 
-- [REST](/docs/guides/api): interact with your database through a REST interface.
-- [GraphQL](/docs/guides/graphql/api): interact with your database through a GraphQL interface.
-- [Realtime](/docs/guides/realtime#realtime-api): listen to database changes over websockets.
+- [REST](/docs/guides/api)
+- [GraphQL](/docs/guides/graphql/api)
+- [Realtime](/docs/guides/realtime#realtime-api)
 
 ## Direct connections
 
-Every Supabase project provides a full Postgres database. You can connect to the database using any tool which supports Postgres. Direct connections are on port `5432`. You can find the connection string in the [Database settings](https://supabase.com/dashboard/project/_/settings/database) inside the dashboard:
+Every Supabase project provides a full Postgres database. You can connect to the database using any tool that supports Postgres. Direct connections are on port `5432`. You can find the connection string in the [Database settings](https://supabase.com/dashboard/project/_/settings/database) inside the dashboard:
 
 1. Go to the `Settings` section.
 2. Click `Database`.
@@ -39,7 +41,7 @@ Every Supabase project provides a full Postgres database. You can connect to the
 
 ## Connection pooler
 
-Every Supabase project comes with a connection pooler for managing connections to your Postgres database. A connection pooler is useful for managing a large number of _temporary_ connections - for example, if you are using Prisma, Drizzle, Kysely, or anything deployed to a Serverless environment (AWS Lambdas or Edge Functions). You can find the connection pool config in the [Database settings](/dashboard/project/_/settings/database) inside the dashboard:
+Every Supabase project comes with a connection pooler for managing connections to your Postgres database. As of ${switchOverDate}, Supavisor is the default connection pooler, replacing PgBouncer. A connection pooler is useful for managing a large number of _temporary_ connections - for example, if you are using Prisma, Drizzle, Kysely, or anything deployed to a Serverless environment (AWS Lambdas or Edge Functions). You can find the connection pool config in the [Database settings](/dashboard/project/_/settings/database) inside the dashboard:
 
 1. Go to the `Settings` section.
 2. Click `Database`.
@@ -55,8 +57,8 @@ Every Supabase project comes with a connection pooler for managing connections t
 ## Choosing a connection method
 
 - The Data APIs provide programmatic access and have [built-in connection pooling](https://postgrest.org/en/stable/references/connection_pool.html). You can use these for all browser and application interactions. We recommend using these wherever possible.
-- A "direct connection" is Postgres' native connection system. You should use this for tools which are always alive - usually installed on a long-running server, like Node.js, Ruby, Python, etc.
-- A "connection pooler" is a tool which keeps connections "alive". You should use this for serverless functions and tools which disconnect from the database frequently, like Prisma, Drizzle, Kysely, etc.
+- A "direct connection" is Postgres' native connection system. You should use this for tools that are always alive - usually installed on a long-running server, like Node.js, Ruby, Python, etc.
+- A "connection pooler" is a tool that keeps connections "alive". You should use this for serverless functions and tools that disconnect from the database frequently, like Prisma, Drizzle, Kysely, etc.
 
 Why would you use a connection pool? Primarily because the way that Postgres handles connections isn't very scalable for a large number of _temporary_ connections. You can use these simple questions to determine which connection method to use:
 
@@ -340,12 +342,12 @@ This is the most granular option. Connections are returned to the pool after eve
 
 Supabase previously used PgBouncer for connection pooling. We have now deprecated PgBouncer in favor of Supavisor. Supavisor is available on all new and existing projects.
 
-[Supavisor](https://github.com/supabase/supavisor) is a new connection pooler by Supabase that runs on a high-availability cluster, segregated from your database. This means more resources are available for your database. No Application changes are required to switch from PgBouncer to Supavisor, you simply need to choose the new connection string from the "Connection Pooling" section on [Database settings](https://supabase.com/dashboard/project/_/settings/database).
+[Supavisor](https://github.com/supabase/supavisor) is a new connection pooler by Supabase that runs on a high-availability cluster, segregated from your database. This means more resources are available for your database. No Application changes are required to switch from PgBouncer to Supavisor; you simply need to choose the new connection string from the "Connection Pooling" section on [Database settings](https://supabase.com/dashboard/project/_/settings/database).
 
-On 15th January 2024 PgBouncer will be disabled. Additionally, your Supabase database domain (db.projectref.supabase.co) will start resolving to an IPv6 address. No changes are required if your network supports IPv6. Otherwise, update your applications to use Supavisor which will continue to support IPv4 connections.
+On ${switchOverDate}, PgBouncer will be disabled. Additionally, your Supabase database domain update the things here: (db.projectref.supabase.co) will start resolving to an IPv6 address. No changes are required if your network supports IPv6. Otherwise, update your applications to use Supavisor, which will continue to support IPv4 connections.
 
 [Read the full details](https://github.com/orgs/supabase/discussions/17817).
 
-export const Page = ({ children }) => <Layout meta={meta} children={children} />
+export const Page = ({ children }) => <Layout meta={meta} children={children} />;
 
-export default Page
+export default Page;


### PR DESCRIPTION
Updated documentation to reflect the switch from PgBouncer to Supavisor on January 15, 2024.