### PR TITLE
chore: Update billing related text on add on upgrade pages

### DIFF
--- a/apps/studio/components/interfaces/Settings/Addons/ComputeInstanceSidePanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/ComputeInstanceSidePanel.tsx
@@ -383,38 +383,22 @@ const ComputeInstanceSidePanel = () => {
               </p>
             )}
 
-            {hasChanges &&
-              (selectedCategory !== 'micro' && selectedCompute?.price_interval === 'monthly' ? (
-                // Monthly payment with project-level subscription
-                <p className="text-sm text-foreground-light">
-                  Upon clicking confirm, the amount of{' '}
-                  <span className="text-foreground">
-                    ${selectedCompute?.price.toLocaleString()}
-                  </span>{' '}
-                  will be added to your monthly invoice. Any previous compute addon is prorated and
-                  you're immediately charged for the remaining days of your billing cycle. The addon
-                  is prepaid per month and in case of a downgrade, you get credits for the remaining
-                  time.
-                </p>
-              ) : selectedCategory !== 'micro' ? (
-                // Hourly usage-billing with org-based subscription
-                <p className="text-sm text-foreground-light">
-                  There are no immediate charges when changing compute. Compute Hours are a
-                  usage-based item and you're billed at the end of your billing cycle based on your
-                  compute usage. Read more about{' '}
-                  <Link
-                    href="https://supabase.com/docs/guides/platform/org-based-billing#usage-based-billing-for-compute"
-                    target="_blank"
-                    rel="noreferrer"
-                    className="underline"
-                  >
-                    Compute Billing
-                  </Link>
-                  .
-                </p>
-              ) : (
-                <></>
-              ))}
+            {hasChanges && selectedCategory !== 'micro' && (
+              <p className="text-sm text-foreground-light">
+                There are no immediate charges when changing compute. Compute Hours are a
+                usage-based item and you're billed at the end of your billing cycle based on your
+                compute usage. Read more about{' '}
+                <Link
+                  href="https://supabase.com/docs/guides/platform/org-based-billing#usage-based-billing-for-compute"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="underline"
+                >
+                  Compute Billing
+                </Link>
+                .
+              </p>
+            )}
 
             {hasChanges && !blockMicroDowngradeDueToPitr && (
               <Alert
@@ -453,7 +437,7 @@ const ComputeInstanceSidePanel = () => {
                   <IconAlertTriangle className="h-4 w-4" />
                   <AlertDescription_Shadcn_>
                     You have a scheduled subscription change that will be canceled if you change
-                    your PITR add on.
+                    your Optimized Compute add on.
                   </AlertDescription_Shadcn_>
                 </Alert_Shadcn_>
               )}

--- a/apps/studio/components/interfaces/Settings/Addons/CustomDomainSidePanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/CustomDomainSidePanel.tsx
@@ -246,8 +246,9 @@ const CustomDomainSidePanel = () => {
               (selectedCustomDomain?.price ?? 0) < (subscriptionCDOption?.variant.price ?? 0) ? (
                 subscription?.billing_via_partner === false && (
                   <p className="text-sm text-foreground-light">
-                    Upon clicking confirm, the amount of that's unused during the current billing
-                    cycle will be returned as credits that can be used for subsequent billing cycles
+                    Upon clicking confirm, the add-on is removed immediately and any unused time in
+                    the current billing cycle is added as prorated credits to your organization and
+                    used in subsequent billing cycles
                   </p>
                 )
               ) : (
@@ -259,14 +260,14 @@ const CustomDomainSidePanel = () => {
                   will be added to your monthly invoice.{' '}
                   {subscription?.billing_via_partner ? (
                     <>
-                      For the current billing cycle you'll be charged a pro-rated amount at the end
+                      For the current billing cycle you'll be charged a prorated amount at the end
                       of the cycle.{' '}
                     </>
                   ) : (
                     <>
                       The addon is prepaid per month and in case of a downgrade, you get credits for
                       the remaining time. For the current billing cycle you're immediately charged a
-                      pro-rated amount for the remaining days.
+                      prorated amount for the remaining days.
                     </>
                   )}
                 </p>

--- a/apps/studio/components/interfaces/Settings/Addons/CustomDomainSidePanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/CustomDomainSidePanel.tsx
@@ -248,7 +248,7 @@ const CustomDomainSidePanel = () => {
                   <p className="text-sm text-foreground-light">
                     Upon clicking confirm, the add-on is removed immediately and any unused time in
                     the current billing cycle is added as prorated credits to your organization and
-                    used in subsequent billing cycles
+                    used in subsequent billing cycles.
                   </p>
                 )
               ) : (

--- a/apps/studio/components/interfaces/Settings/Addons/CustomDomainSidePanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/CustomDomainSidePanel.tsx
@@ -244,19 +244,31 @@ const CustomDomainSidePanel = () => {
             <>
               {selectedOption === 'cd_none' ||
               (selectedCustomDomain?.price ?? 0) < (subscriptionCDOption?.variant.price ?? 0) ? (
-                <p className="text-sm text-foreground-light">
-                  Upon clicking confirm, the amount of that's unused during the current billing
-                  cycle will be returned as credits that can be used for subsequent billing cycles
-                </p>
+                !subscription?.billing_via_partner && (
+                  <p className="text-sm text-foreground-light">
+                    Upon clicking confirm, the amount of that's unused during the current billing
+                    cycle will be returned as credits that can be used for subsequent billing cycles
+                  </p>
+                )
               ) : (
                 <p className="text-sm text-foreground-light">
                   Upon clicking confirm, the amount of{' '}
                   <span className="text-foreground">
                     ${selectedCustomDomain?.price.toLocaleString()}
                   </span>{' '}
-                  will be added to your monthly invoice. You're immediately charged for the
-                  remaining days of your billing cycle. The addon is prepaid per month and in case
-                  of a downgrade, you get credits for the remaining time.
+                  will be added to your monthly invoice.{' '}
+                  {subscription?.billing_via_partner ? (
+                    <>
+                      For the current billing cycle you'll be charged a pro-rated amount at the end
+                      of the cycle.{' '}
+                    </>
+                  ) : (
+                    <>
+                      The addon is prepaid per month and in case of a downgrade, you get credits for
+                      the remaining time. For the current billing cycle you're immediately charged a
+                      pro-rated amount for the remaining days.
+                    </>
+                  )}
                 </p>
               )}
 

--- a/apps/studio/components/interfaces/Settings/Addons/CustomDomainSidePanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/CustomDomainSidePanel.tsx
@@ -244,7 +244,7 @@ const CustomDomainSidePanel = () => {
             <>
               {selectedOption === 'cd_none' ||
               (selectedCustomDomain?.price ?? 0) < (subscriptionCDOption?.variant.price ?? 0) ? (
-                !subscription?.billing_via_partner && (
+                subscription?.billing_via_partner === false && (
                   <p className="text-sm text-foreground-light">
                     Upon clicking confirm, the amount of that's unused during the current billing
                     cycle will be returned as credits that can be used for subsequent billing cycles

--- a/apps/studio/components/interfaces/Settings/Addons/PITRSidePanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/PITRSidePanel.tsx
@@ -23,6 +23,7 @@ import {
   IconExternalLink,
   Radio,
   SidePanel,
+  IconAlertTriangle,
 } from 'ui'
 import { useOrgSubscriptionQuery } from 'data/subscriptions/org-subscription-query'
 import { AlertTriangleIcon } from 'lucide-react'
@@ -341,19 +342,42 @@ const PITRSidePanel = () => {
             <>
               {selectedOption === 'pitr_0' ||
               (selectedPitr?.price ?? 0) < (subscriptionPitr?.variant.price ?? 0) ? (
-                <p className="text-sm text-foreground-light">
-                  Upon clicking confirm, the amount of that's unused during the current billing
-                  cycle will be returned as credits that can be used for subsequent billing cycles
-                </p>
+                !subscription?.billing_via_partner && (
+                  <p className="text-sm text-foreground-light">
+                    Upon clicking confirm, the amount of that's unused during the current billing
+                    cycle will be returned as credits that can be used for subsequent billing cycles
+                  </p>
+                )
               ) : (
                 <p className="text-sm text-foreground-light">
                   Upon clicking confirm, the amount of{' '}
                   <span className="text-foreground">${selectedPitr?.price.toLocaleString()}</span>{' '}
-                  will be added to your monthly invoice. You're immediately charged for the
-                  remaining days of your billing cycle. The addon is prepaid per month and in case
-                  of a downgrade, you get credits for the remaining time.
+                  will be added to your monthly invoice.{' '}
+                  {subscription?.billing_via_partner ? (
+                    <>
+                      For the current billing cycle you'll be charged a pro-rated amount at the end
+                      of the cycle.{' '}
+                    </>
+                  ) : (
+                    <>
+                      The addon is prepaid per month and in case of a downgrade, you get credits for
+                      the remaining time. For the current billing cycle you're immediately charged a
+                      pro-rated amount for the remaining days.
+                    </>
+                  )}
                 </p>
               )}
+
+              {subscription?.billing_via_partner &&
+                subscription.scheduled_plan_change?.target_plan !== undefined && (
+                  <Alert_Shadcn_ variant={'warning'} className="mb-2">
+                    <IconAlertTriangle className="h-4 w-4" />
+                    <AlertDescription_Shadcn_>
+                      You have a scheduled subscription change that will be canceled if you change
+                      your PITR add on.
+                    </AlertDescription_Shadcn_>
+                  </Alert_Shadcn_>
+                )}
             </>
           )}
         </div>

--- a/apps/studio/components/interfaces/Settings/Addons/PITRSidePanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/PITRSidePanel.tsx
@@ -346,7 +346,7 @@ const PITRSidePanel = () => {
                   <p className="text-sm text-foreground-light">
                     Upon clicking confirm, the add-on is removed immediately and any unused time in
                     the current billing cycle is added as prorated credits to your organization and
-                    used in subsequent billing cycles
+                    used in subsequent billing cycles.
                   </p>
                 )
               ) : (

--- a/apps/studio/components/interfaces/Settings/Addons/PITRSidePanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/PITRSidePanel.tsx
@@ -344,8 +344,9 @@ const PITRSidePanel = () => {
               (selectedPitr?.price ?? 0) < (subscriptionPitr?.variant.price ?? 0) ? (
                 subscription?.billing_via_partner === false && (
                   <p className="text-sm text-foreground-light">
-                    Upon clicking confirm, the amount of that's unused during the current billing
-                    cycle will be returned as credits that can be used for subsequent billing cycles
+                    Upon clicking confirm, the add-on is removed immediately and any unused time in
+                    the current billing cycle is added as prorated credits to your organization and
+                    used in subsequent billing cycles
                   </p>
                 )
               ) : (
@@ -355,14 +356,14 @@ const PITRSidePanel = () => {
                   will be added to your monthly invoice.{' '}
                   {subscription?.billing_via_partner ? (
                     <>
-                      For the current billing cycle you'll be charged a pro-rated amount at the end
+                      For the current billing cycle you'll be charged a prorated amount at the end
                       of the cycle.{' '}
                     </>
                   ) : (
                     <>
                       The addon is prepaid per month and in case of a downgrade, you get credits for
                       the remaining time. For the current billing cycle you're immediately charged a
-                      pro-rated amount for the remaining days.
+                      prorated amount for the remaining days.
                     </>
                   )}
                 </p>

--- a/apps/studio/components/interfaces/Settings/Addons/PITRSidePanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/PITRSidePanel.tsx
@@ -342,7 +342,7 @@ const PITRSidePanel = () => {
             <>
               {selectedOption === 'pitr_0' ||
               (selectedPitr?.price ?? 0) < (subscriptionPitr?.variant.price ?? 0) ? (
-                !subscription?.billing_via_partner && (
+                subscription?.billing_via_partner === false && (
                   <p className="text-sm text-foreground-light">
                     Upon clicking confirm, the amount of that's unused during the current billing
                     cycle will be returned as credits that can be used for subsequent billing cycles


### PR DESCRIPTION
## What kind of change does this PR introduce?

Update of explanation text.

## What is the current behavior?

At the moment texts on the add-on upgrade pages do not take into account whether billing is done via Supabase or a partner.

## What is the new behavior?

Texts are customized depending on billing system.