### PR TITLE
fix: move SSO/SAML from Enterprise to Teams

### DIFF
--- a/packages/shared-data/plans.ts
+++ b/packages/shared-data/plans.ts
@@ -84,6 +84,7 @@ export const plans: PricingInformation[] = [
     features: [
       'Additional Organization member roles',
       'Daily backups stored for 14 days',
+      `SSO/SAML`,
       'Standardised Security Questionnaire',
       'SOC2',
       'HIPAA available as paid add-on',
@@ -102,7 +103,6 @@ export const plans: PricingInformation[] = [
     description: 'For large-scale applications managing serious workloads.',
     features: [
       `Designated Support manager & SLAs`,
-      `SSO/SAML`,
       `On-premise support`,
       `24×7×365 premium enterprise support`,
       'Custom Security Questionnaires',


### PR DESCRIPTION
We are moving this feature- SSO/SAML from the Enterprise plan and add it to the Teams plan, as it is a feature exclusive to the Teams plan.
