### PR TITLE
chore: Mention Fly.io explicitly on plan upgrade page

### DIFF
--- a/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/PlanUpdateSidePanel.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/PlanUpdateSidePanel.tsx
@@ -519,7 +519,7 @@ const PlanUpdateSidePanel = () => {
           ) : (
             <div className="py-4 space-y-2">
               <p className="text-sm">
-                This organization is billed through one of our partners and you will be charged by
+                This organization is billed through our partner Fly.io and you will be charged by
                 them directly.
               </p>
               {subscriptionPreview?.billed_via_partner &&


### PR DESCRIPTION
## What is the current behavior?

When upgrading the plan for an organization that is billed via partner Fly.io the text reads "...through one of our partners" without mentioning Fly.io explicitly.

## What is the new behavior?

Fly.io is mentioned explicitly.
