### PR TITLE
fix: add missing www dependency

### DIFF
--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -18,6 +18,7 @@
     "@mdx-js/react": "^2.3.0",
     "@next/bundle-analyzer": "^13.5.6",
     "@next/mdx": "^13.5.6",
+    "@octokit/plugin-paginate-graphql": "^2.0.3",
     "@octokit/rest": "^20.0.2",
     "@react-three/fiber": "^7.0.29",
     "@supabase/auth-helpers-react": "^0.4.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1034,6 +1034,7 @@
         "@mdx-js/react": "^2.3.0",
         "@next/bundle-analyzer": "^13.5.6",
         "@next/mdx": "^13.5.6",
+        "@octokit/plugin-paginate-graphql": "^2.0.3",
         "@octokit/rest": "^20.0.2",
         "@react-three/fiber": "^7.0.29",
         "@supabase/auth-helpers-react": "^0.4.2",
@@ -1149,6 +1150,86 @@
         "@octokit/plugin-retry": "^4.1.3",
         "@octokit/plugin-throttling": "^5.2.2",
         "@octokit/types": "^9.2.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "apps/www/node_modules/octokit/node_modules/@octokit/auth-token": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-3.0.4.tgz",
+      "integrity": "sha512-TWFX7cZF2LXoCvdmJWY7XVPi74aSY0+FfBZNSXEXFkMpjcqsQwDSYVv5FhRFaI0V1ECnwbz4j59T/G+rXNWaIQ==",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "apps/www/node_modules/octokit/node_modules/@octokit/core": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.2.4.tgz",
+      "integrity": "sha512-rYKilwgzQ7/imScn3M9/pFfUf4I1AZEH3KhyJmtPdE2zfaXAn2mFfUy4FbKewzc2We5y/LlKLj36fWJLKC2SIQ==",
+      "dependencies": {
+        "@octokit/auth-token": "^3.0.0",
+        "@octokit/graphql": "^5.0.0",
+        "@octokit/request": "^6.0.0",
+        "@octokit/request-error": "^3.0.0",
+        "@octokit/types": "^9.0.0",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "apps/www/node_modules/octokit/node_modules/@octokit/endpoint": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.6.tgz",
+      "integrity": "sha512-5L4fseVRUsDFGR00tMWD/Trdeeihn999rTMGRMC1G/Ldi1uWlWJzI98H4Iak5DB/RVvQuyMYKqSK/R6mbSOQyg==",
+      "dependencies": {
+        "@octokit/types": "^9.0.0",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "apps/www/node_modules/octokit/node_modules/@octokit/graphql": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-5.0.6.tgz",
+      "integrity": "sha512-Fxyxdy/JH0MnIB5h+UQ3yCoh1FG4kWXfFKkpWqjZHw/p+Kc8Y44Hu/kCgNBT6nU1shNumEchmW/sUO1JuQnPcw==",
+      "dependencies": {
+        "@octokit/request": "^6.0.0",
+        "@octokit/types": "^9.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "apps/www/node_modules/octokit/node_modules/@octokit/request": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.2.8.tgz",
+      "integrity": "sha512-ow4+pkVQ+6XVVsekSYBzJC0VTVvh/FCTUUgTsboGq+DTeWdyIFV8WSCdo0RIxk6wSkBTHqIK1mYuY7nOBXOchw==",
+      "dependencies": {
+        "@octokit/endpoint": "^7.0.0",
+        "@octokit/request-error": "^3.0.0",
+        "@octokit/types": "^9.0.0",
+        "is-plain-object": "^5.0.0",
+        "node-fetch": "^2.6.7",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "apps/www/node_modules/octokit/node_modules/@octokit/request-error": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-3.0.3.tgz",
+      "integrity": "sha512-crqw3V5Iy2uOU5Np+8M/YexTlT8zxCfI+qu+LxUB7SZpje4Qmx3mub5DfEKSO8Ylyk0aogi6TYdf6kxzh2BguQ==",
+      "dependencies": {
+        "@octokit/types": "^9.0.0",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
       },
       "engines": {
         "node": ">= 14"
@@ -6160,7 +6241,8 @@
     },
     "node_modules/@octokit/plugin-paginate-graphql": {
       "version": "2.0.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-graphql/-/plugin-paginate-graphql-2.0.3.tgz",
+      "integrity": "sha512-gMZN0bEksY1d67rN4oBdU9Jor682tGt7sbEiidDLHJtsKmhWYEPJgWmPG1e6omrxE5S52VZxSRm5UY/utYje5w==",
       "peerDependencies": {
         "@octokit/core": ">=4"
       }


### PR DESCRIPTION
www imports `@octokit/plugin-paginate-graphql` [here](https://github.com/supabase/supabase/blob/d7a2048c6d6054bb8d6b04e60d2a69147e198f85/apps/www/pages/changelog.tsx#L12) but doesn't define it in its own `package.json` (appears to be using the docs one)

causes an error when trying to manually trigger a www build on vercel 