### PR TITLE
docs: add info about React Native `AppState` and Supabase Auth

### DIFF
--- a/apps/docs/pages/guides/auth/quickstarts/react-native.mdx
+++ b/apps/docs/pages/guides/auth/quickstarts/react-native.mdx
@@ -73,6 +73,7 @@ export const meta = {
 
 
       ```ts lib/supabase.ts
+      import { AppState } from 'react-native'
       import 'react-native-url-polyfill/auto'
       import AsyncStorage from '@react-native-async-storage/async-storage'
       import { createClient } from '@supabase/supabase-js'
@@ -87,6 +88,19 @@ export const meta = {
           persistSession: true,
           detectSessionInUrl: false,
         },
+      })
+
+      // Tells Supabase Auth to continuously refresh the session automatically
+      // if the app is in the foreground. When this is added, you will continue
+      // to receive `onAuthStateChange` events with the `TOKEN_REFRESHED` or
+      // `SIGNED_OUT` event if the user's session is terminated. This should
+      // only be registered once.
+      AppState.addEventListener('change', (state) => {
+        if (state === 'active') {
+          supabase.auth.startAutoRefresh()
+        } else {
+          supabase.auth.stopAutoRefresh()
+        }
       })
       ```
 

--- a/apps/docs/pages/guides/getting-started/tutorials/with-expo-react-native.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-expo-react-native.mdx
@@ -169,9 +169,21 @@ Users would be able to sign in with their email and password.
 
 ```tsx components/Auth.tsx
 import React, { useState } from 'react'
-import { Alert, StyleSheet, View } from 'react-native'
+import { Alert, StyleSheet, View, AppState } from 'react-native'
 import { supabase } from '../lib/supabase'
 import { Button, Input } from 'react-native-elements'
+
+// Tells Supabase Auth to continuously refresh the session automatically if
+// the app is in the foreground. When this is added, you will continue to receive
+// `onAuthStateChange` events with the `TOKEN_REFRESHED` or `SIGNED_OUT` event
+// if the user's session is terminated. This should only be registered once.
+AppState.addEventListener('change', (state) => {
+  if (state === 'active') {
+    supabase.auth.startAutoRefresh()
+  } else {
+    supabase.auth.stopAutoRefresh()
+  }
+})
 
 export default function Auth() {
   const [email, setEmail] = useState('')

--- a/apps/docs/spec/common-client-libs-sections.json
+++ b/apps/docs/spec/common-client-libs-sections.json
@@ -613,6 +613,20 @@
         "type": "function"
       },
       {
+        "id": "start-auto-refresh",
+        "title": "Start auto-refresh session (non-browser)",
+        "slug": "auth-startautorefresh",
+        "product": "auth",
+        "type": "function"
+      },
+      {
+        "id": "stop-auto-refresh",
+        "title": "Stop auto-refresh session (non-browser)",
+        "slug": "auth-stopautorefresh",
+        "product": "auth",
+        "type": "function"
+      },
+      {
         "id": "auth-mfa-api",
         "title": "Auth MFA",
         "slug": "auth-mfa-api",

--- a/apps/docs/spec/supabase_js_v2.yml
+++ b/apps/docs/spec/supabase_js_v2.yml
@@ -749,6 +749,56 @@ functions:
           ```js
           const { data, error } = await supabase.auth.getSession()
           ```
+  - id: start-auto-refresh
+    title: 'startAutoRefresh()'
+    $ref: '@supabase/gotrue-js.GoTrueClient.startAutoRefresh'
+    notes: |
+      - Only useful in non-browser environments such as React Native or Electron.
+      - The Supabase Auth library automatically starts and stops proactively refreshing the session when a tab is focused or not.
+      - On non-browser platforms, such as mobile or desktop apps built with web technologies, the library is not able to effectively determine whether the application is _focused_ or not.
+      - To give this hint to the application, you should be calling this method when the app is in focus and calling `supabase.auth.stopAutoRefresh()` when it's out of focus.
+    examples:
+      - id: start-stop-auto-refresh-react-native
+        name: Start and stop auto refresh in React Native
+        isSpotlight: true
+        code: |
+          ```js
+          import { AppState } from 'react-native'
+
+          // make sure you register this only once!
+          AppState.addEventListener('change', (state) => {
+            if (state === 'active') {
+              supabase.auth.startAutoRefresh()
+            } else {
+              supabase.auth.stopAutoRefresh()
+            }
+          })
+          ```
+  - id: stop-auto-refresh
+    title: 'stopAutoRefresh()'
+    $ref: '@supabase/gotrue-js.GoTrueClient.stopAutoRefresh'
+    notes: |
+      - Only useful in non-browser environments such as React Native or Electron.
+      - The Supabase Auth library automatically starts and stops proactively refreshing the session when a tab is focused or not.
+      - On non-browser platforms, such as mobile or desktop apps built with web technologies, the library is not able to effectively determine whether the application is _focused_ or not.
+      - When your application goes in the background or out of focus, call this method to stop the proactive refreshing of the session.
+    examples:
+      - id: start-stop-auto-refresh-react-native
+        name: Start and stop auto refresh in React Native
+        isSpotlight: true
+        code: |
+          ```js
+          import { AppState } from 'react-native'
+
+          // make sure you register this only once!
+          AppState.addEventListener('change', (state) => {
+            if (state === 'active') {
+              supabase.auth.startAutoRefresh()
+            } else {
+              supabase.auth.stopAutoRefresh()
+            }
+          })
+          ```
   - id: get-user
     title: 'getUser()'
     $ref: '@supabase/gotrue-js.GoTrueClient.getUser'


### PR DESCRIPTION
It wasn't explained anywhere that folks should call start/stopAutoRefresh in React Native or other non-browser environments.