### PR TITLE
fix error from missing env var in local

### DIFF
--- a/apps/docs/lib/constants.ts
+++ b/apps/docs/lib/constants.ts
@@ -1,3 +1,7 @@
 export const IS_PLATFORM = process.env.NEXT_PUBLIC_IS_PLATFORM === 'true'
 export const LOCAL_SUPABASE = process.env.NEXT_PUBLIC_LOCAL_SUPABASE === 'true'
-export const API_URL = process.env.NEXT_PUBLIC_API_URL.replace(/\/platform$/, '')
+export const API_URL = (
+  process.env.NODE_ENV === 'development'
+    ? process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080'
+    : process.env.NEXT_PUBLIC_API_URL
+).replace(/\/platform$/, '')


### PR DESCRIPTION
if local dev, fall back to localhost:8080
not falling back in preview/prod because I'd rather it error out and catch the missing env var in preview