### PR TITLE
docs: `pg_stat_statements` doc prettify and example bug fixing

### DIFF
--- a/apps/docs/pages/guides/database/extensions/pg_stat_statements.mdx
+++ b/apps/docs/pages/guides/database/extensions/pg_stat_statements.mdx
@@ -9,16 +9,16 @@ export const meta = {
 
 `pg_stat_statements` is a database extension that exposes a view, of the same name, to track statistics about SQL statements executed on the database. The following table shows some of the available statistics and metadata:
 
-| Column Type                           | Description                                                                                                                  |
-| ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| userid oid (references pg_authid.oid) | OID of user who executed the statement                                                                                       |
-| dbid oid (references pg_database.oid) | OID of database in which the statement was executed                                                                          |
-| toplevel bool                         | True if the query was executed as a top-level statement (always true if pg_stat_statements.track is set to top)              |
-| queryid bigint                        | Hash code to identify identical normalized queries.                                                                          |
-| query text                            | Text of a representative statement                                                                                           |
-| plans bigint                          | Number of times the statement was planned (if pg_stat_statements.track_planning is enabled, otherwise zero)                  |
-| total_plan_time double precision      | Total time spent planning the statement, in milliseconds (if pg_stat_statements.track_planning is enabled, otherwise zero)   |
-| min_plan_time double precision        | Minimum time spent planning the statement, in milliseconds (if pg_stat_statements.track_planning is enabled, otherwise zero) |
+| Column Name     | Column Type                      | Description                                                                                                                  |
+| --------------- | -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| userid          | oid (references pg_authid.oid)   | OID of user who executed the statement                                                                                       |
+| dbid            | oid (references pg_database.oid) | OID of database in which the statement was executed                                                                          |
+| toplevel        | bool                             | True if the query was executed as a top-level statement (always true if pg_stat_statements.track is set to top)              |
+| queryid         | bigint                           | Hash code to identify identical normalized queries.                                                                          |
+| query           | text                             | Text of a representative statement                                                                                           |
+| plans           | bigint                           | Number of times the statement was planned (if pg_stat_statements.track_planning is enabled, otherwise zero)                  |
+| total_plan_time | double precision                 | Total time spent planning the statement, in milliseconds (if pg_stat_statements.track_planning is enabled, otherwise zero)   |
+| min_plan_time   | double precision                 | Minimum time spent planning the statement, in milliseconds (if pg_stat_statements.track_planning is enabled, otherwise zero) |
 
 A full list of statistics is available in the [pg_stat_statements docs](https://www.postgresql.org/docs/current/pgstatstatements.html).
 
@@ -71,7 +71,7 @@ select
 	max_exec_time,
 	total_exec_time,
 	stddev_exec_time,
-	query,
+	query
 from
 	pg_stat_statements
 where


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to improve `pg_stat_statements` doc:

- separate column name and type to make the table more readable
- fix bug in the SQL example code

## What is the current behavior?

N/A

## What is the new behavior?

N/A

## Additional context

N/A
