### PR TITLE
fix: broken link for encryption key

### DIFF
--- a/apps/docs/pages/guides/database/extensions/pgsodium.mdx
+++ b/apps/docs/pages/guides/database/extensions/pgsodium.mdx
@@ -55,7 +55,7 @@ Note that Supabase projects are already encrypted at rest by default.
 
 ## Get the root encryption key for your Supabase project
 
-Encryption requires keys. Keeping the keys in the same database as the encrypted data would be unsafe. For more information about managing the pgsodium root encryption key on your Supabase project see **[encryption key location](#encryption-key-location)**. This key is required to decrypt values stored in [Supabase Vault](/docs/guides/database/vault) and data encrypted with Transparent Column Encryption.
+Encryption requires keys. Keeping the keys in the same database as the encrypted data would be unsafe. For more information about managing the pgsodium root encryption key on your Supabase project see **[encryption key location](/docs/guides/database/vault#encryption-key-location)**. This key is required to decrypt values stored in [Supabase Vault](/docs/guides/database/vault) and data encrypted with Transparent Column Encryption.
 
 ## Enable the extension
 

--- a/apps/docs/public/humans.txt
+++ b/apps/docs/public/humans.txt
@@ -67,6 +67,7 @@ Supun Sudaraka Kalidasa
 Terry Sutton
 Thomas E
 Thor Schaeff
+Tom Ashley
 Tyler Fontaine
 Tyler Shukert
 TzeYiing L


### PR DESCRIPTION
## What kind of change does this PR introduce?

fixes link to nowhere

## What is the current behavior?

Hanging link to nowhere

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
