### PR TITLE
Update Query Performance docs

### DIFF
--- a/apps/docs/pages/guides/platform/performance.mdx
+++ b/apps/docs/pages/guides/platform/performance.mdx
@@ -24,6 +24,15 @@ Database performance is a large topic and many factors can contribute. Some of t
 
 Thankfully there are solutions to all these issues, which we will cover in the following sections.
 
+<Admonition type="note">
+
+If you're seeing `insufficient privilege` error when viewing the Query Performance page from the dashboard. You'll need to run this command: 
+```shell
+$ grant pg_read_all_stats to postgres;
+```
+
+</Admonition>
+
 ### Postgres cumulative statistics system
 
 Postgres collects data about its own operations using the [cumulative statistics system](https://www.postgresql.org/docs/current/monitoring-stats.html). In addition to this, every Supabase project has the [pg_stat_statements extension](/docs/guides/database/extensions/pg_stat_statements) enabled by default. This extension records query execution performance details and is the best way to find inefficient queries. This information can be combined with the Postgres query plan analyzer to develop more efficient queries.

--- a/apps/docs/pages/guides/platform/performance.mdx
+++ b/apps/docs/pages/guides/platform/performance.mdx
@@ -26,7 +26,8 @@ Thankfully there are solutions to all these issues, which we will cover in the f
 
 <Admonition type="note">
 
-If you're seeing `insufficient privilege` error when viewing the Query Performance page from the dashboard. You'll need to run this command: 
+If you're seeing `insufficient privilege` error when viewing the Query Performance page from the dashboard. You'll need to run this command:
+
 ```shell
 $ grant pg_read_all_stats to postgres;
 ```

--- a/apps/docs/pages/guides/platform/performance.mdx
+++ b/apps/docs/pages/guides/platform/performance.mdx
@@ -26,7 +26,7 @@ Thankfully there are solutions to all these issues, which we will cover in the f
 
 <Admonition type="note">
 
-If you're seeing `insufficient privilege` error when viewing the Query Performance page from the dashboard. You'll need to run this command:
+If you're seeing an `insufficient privilege` error when viewing the Query Performance page from the dashboard, run this command:
 
 ```shell
 $ grant pg_read_all_stats to postgres;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

There are users still encountering `insufficient privilege` error when viewing the Query Performance page from the dashboard.

## What is the new behavior?

Users can view the queries from the report

## Additional context

In response to a feedback from the ticket mentioned on this task
https://www.notion.so/supabase/Update-documentation-f9983dcf814e4eca9b22df7b9ad56e20?pvs=4
