### PR TITLE
fix: truncation while impersonating roles

### DIFF
--- a/apps/studio/components/grid/components/header/Header.tsx
+++ b/apps/studio/components/grid/components/header/Header.tsx
@@ -1,8 +1,18 @@
+import * as Tooltip from '@radix-ui/react-tooltip'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import clsx from 'clsx'
 import saveAs from 'file-saver'
 import Papa from 'papaparse'
 import { ReactNode, useState } from 'react'
+
+import { useDispatch, useTrackedState } from 'components/grid/store'
+import { Filter, Sort, SupaTable } from 'components/grid/types'
+import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
+import { useTableRowsCountQuery } from 'data/table-rows/table-rows-count-query'
+import { useTableRowsQuery } from 'data/table-rows/table-rows-query'
+import { useCheckPermissions, useStore, useUrlState } from 'hooks'
+import { useRoleImpersonationStateSnapshot } from 'state/role-impersonation-state'
+import { useTableEditorStateSnapshot } from 'state/table-editor'
 import {
   Button,
   DropdownMenu,
@@ -17,15 +27,6 @@ import {
   IconX,
   cn,
 } from 'ui'
-
-import { useDispatch, useTrackedState } from 'components/grid/store'
-import { Filter, Sort, SupaTable } from 'components/grid/types'
-import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
-import { useTableRowsCountQuery } from 'data/table-rows/table-rows-count-query'
-import { useTableRowsQuery } from 'data/table-rows/table-rows-query'
-import { useCheckPermissions, useStore, useUrlState } from 'hooks'
-import { useRoleImpersonationStateSnapshot } from 'state/role-impersonation-state'
-import { useTableEditorStateSnapshot } from 'state/table-editor'
 import RLSBannerWarning from './RLSBannerWarning'
 import RefreshButton from './RefreshButton'
 import FilterDropdown from './filter'
@@ -240,6 +241,7 @@ const RowHeader = ({ table, sorts, filters }: RowHeaderProps) => {
   const snap = useTableEditorStateSnapshot()
 
   const roleImpersonationState = useRoleImpersonationStateSnapshot()
+  const isImpersonatingRole = roleImpersonationState.role !== undefined
 
   const [isExporting, setIsExporting] = useState(false)
 
@@ -351,9 +353,31 @@ const RowHeader = ({ table, sorts, filters }: RowHeaderProps) => {
             : `${selectedRows.size} row selected`}
         </span>
         {!allRowsSelected && totalRows > allRows.length && (
-          <Button type="link" onClick={() => onSelectAllRows()}>
-            Select all {totalRows} rows
-          </Button>
+          <Tooltip.Root delayDuration={0}>
+            <Tooltip.Trigger asChild>
+              <Button type="link" onClick={() => onSelectAllRows()} disabled={isImpersonatingRole}>
+                Select all {totalRows} rows
+              </Button>
+            </Tooltip.Trigger>
+
+            {isImpersonatingRole && (
+              <Tooltip.Portal>
+                <Tooltip.Content side="bottom">
+                  <Tooltip.Arrow className="radix-tooltip-arrow" />
+                  <div
+                    className={[
+                      'rounded bg-alternative py-1 px-2 leading-none shadow',
+                      'border border-background',
+                    ].join(' ')}
+                  >
+                    <span className="text-xs text-foreground">
+                      Table truncation is not supported when impersonating a role
+                    </span>
+                  </div>
+                </Tooltip.Content>
+              </Tooltip.Portal>
+            )}
+          </Tooltip.Root>
         )}
       </div>
       <div className="h-[20px] border-r border-gray-700" />

--- a/apps/studio/components/interfaces/TableGridEditor/DeleteConfirmationDialogs.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/DeleteConfirmationDialogs.tsx
@@ -193,11 +193,15 @@ const DeleteConfirmationDialogs = ({
 
     if (snap.confirmationDialog.allRowsSelected) {
       if (filters.length === 0) {
+        if (getImpersonatedRole() !== undefined) {
+          snap.closeConfirmationDialog()
+          return toast.error('Table truncation is not supported when impersonating a role')
+        }
+
         truncateRows({
           projectRef: project.ref,
           connectionString: project.connectionString,
           table: selectedTable as any,
-          impersonatedRole: getImpersonatedRole(),
         })
       } else {
         deleteAllRows({

--- a/apps/studio/data/table-rows/table-row-truncate-mutation.ts
+++ b/apps/studio/data/table-rows/table-row-truncate-mutation.ts
@@ -4,15 +4,12 @@ import { toast } from 'react-hot-toast'
 import { Query, SupaTable } from 'components/grid'
 import { executeSql } from 'data/sql/execute-sql-query'
 import { sqlKeys } from 'data/sql/keys'
-import { ImpersonationRole, wrapWithRoleImpersonation } from 'lib/role-impersonation'
-import { isRoleImpersonationEnabled } from 'state/role-impersonation-state'
 import { ResponseError } from 'types'
 
 export type TableRowTruncateVariables = {
   projectRef: string
   connectionString?: string
   table: SupaTable
-  impersonatedRole?: ImpersonationRole
 }
 
 export function getTableRowTruncateSql({ table }: Pick<TableRowTruncateVariables, 'table'>) {
@@ -25,18 +22,13 @@ export async function truncateTableRow({
   projectRef,
   connectionString,
   table,
-  impersonatedRole,
 }: TableRowTruncateVariables) {
-  const sql = wrapWithRoleImpersonation(getTableRowTruncateSql({ table }), {
-    projectRef,
-    role: impersonatedRole,
-  })
+  const sql = getTableRowTruncateSql({ table })
 
   const { result } = await executeSql({
     projectRef,
     connectionString,
     sql,
-    isRoleImpersonationEnabled: isRoleImpersonationEnabled(impersonatedRole),
   })
 
   return result


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes #20327

- disallows selecting all rows while user impersonation is enabled
- removes impersonation logic from table-row-truncate-mutation.ts since it's not actually supported

> Operations that apply to the whole table, such as TRUNCATE and REFERENCES, are not subject to row security.

![Screenshot 2024-01-12 at 00 47 27](https://github.com/supabase/supabase/assets/10985857/ea46afb9-e486-48ce-b0c0-ce99552f9542)
