### PR TITLE
Update managing-environments.mdx

### DIFF
--- a/apps/docs/pages/guides/cli/managing-environments.mdx
+++ b/apps/docs/pages/guides/cli/managing-environments.mdx
@@ -213,7 +213,7 @@ jobs:
       - name: Verify generated types are checked in
         run: |
           supabase gen types typescript --local > types.gen.ts
-          if git diff --ignore-space-at-eol --exit-code --quiet types.gen.ts; then
+          if ! git diff --ignore-space-at-eol --exit-code --quiet types.gen.ts; then
             echo "Detected uncommitted changes after build. See status below:"
             git diff
             exit 1


### PR DESCRIPTION
Fix for the issue #20322

## What kind of change does this PR introduce?
It fixes the issue raised in #20322. It is a typo. Which can cause people to use wrong command.

Bug fix, feature, docs update, ...

## What is the current behavior?
![image](https://github.com/supabase/supabase/assets/110852661/7a09c8b3-93a1-48c8-801e-4fcd7a56607b)

Please link any relevant issues here.

## What is the new behavior?
```
if ! git diff --ignore-space-at-eol --exit-code --quiet types.gen.ts; then
```
