### PR TITLE
chore(docs): added missing key prop in CliCommandSection component

### DIFF
--- a/apps/docs/components/reference/CLICommandSection.tsx
+++ b/apps/docs/components/reference/CLICommandSection.tsx
@@ -110,19 +110,17 @@ const CliCommandSection = (props) => {
                 <h3 className="text-lg text-foreground mb-3">Flags</h3>
                 <ul>
                   {commandFlags.map((flag: Flag) => (
-                    <>
-                      <li className="mt-0">
-                        <Param {...flag} isOptional={!flag.required}>
-                          {flag?.accepted_values && (
-                            <Options>
-                              {flag?.accepted_values.map((value) => {
-                                return <Options.Option {...value} />
-                              })}
-                            </Options>
-                          )}
-                        </Param>
-                      </li>
-                    </>
+                    <li key={flag.id} className="mt-0">
+                      <Param {...flag} isOptional={!flag.required}>
+                        {flag?.accepted_values && (
+                          <Options>
+                            {flag?.accepted_values.map((value) => {
+                              return <Options.Option key={value.id} {...value} />
+                            })}
+                          </Options>
+                        )}
+                      </Param>
+                    </li>
                   ))}
                 </ul>
               </>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Added missing `key` prop

## What is the current behavior?

`key` prop missing

## What is the new behavior?

`key` prop added

