### PR TITLE
chore(docs:) added missing key prop in CliGlobalFlagsHandler component

### DIFF
--- a/apps/docs/components/reference/enrichments/cli/CliGlobalFlagsHandler.tsx
+++ b/apps/docs/components/reference/enrichments/cli/CliGlobalFlagsHandler.tsx
@@ -2,7 +2,6 @@ import RefSubLayout from '~/layouts/ref/RefSubLayout'
 
 import spec from '~/spec/cli_v1_commands.yaml' assert { type: 'yaml' }
 import Param from '~/components/Params'
-import Options from '~/components/Options'
 
 const CliGlobalFlagsHandler = () => {
   return (
@@ -14,6 +13,7 @@ const CliGlobalFlagsHandler = () => {
             return (
               <Param
                 {...flag}
+                key={flag.id}
                 id={`${spec.id}-${flag.id}`}
                 isOptional={flag.required === undefined ? true : !flag.required}
               ></Param>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Added missing `key` prop

## What is the current behavior?

`key` prop missing

## What is the new behavior?

`key` prop added
