### PR TITLE
Fixed typo in blog section

### DIFF
--- a/apps/www/_blog/2023-11-16-react-native-authentication.mdx
+++ b/apps/www/_blog/2023-11-16-react-native-authentication.mdx
@@ -379,7 +379,7 @@ For detailed setup and implementation instructions please refer to the [docs](ht
 
 Supabase Auth supports Sign in with Google on the web, native Android applications, and Chrome extensions.
 
-For detailed set up and implemenation instructions please refer to the [docs](https://supabase.com/docs/guides/auth/social-login/auth-google) and the [video tutorial](https://youtu.be/vojHmGUGUGc).
+For detailed set up and implementation instructions please refer to the [docs](https://supabase.com/docs/guides/auth/social-login/auth-google) and the [video tutorial](https://youtu.be/vojHmGUGUGc).
 
 ## One time passwords
 

--- a/apps/www/_blog/2023-12-08-postgres-language-server-implementing-parser.mdx
+++ b/apps/www/_blog/2023-12-08-postgres-language-server-implementing-parser.mdx
@@ -27,7 +27,7 @@ This is an update on the Parser, which is the fundamental primitive of a Languag
     There will be a few acronyms in this post. We don’t want this post to be “inside baseball” so here are a few concepts that you need to know:
 
     - ***LSP / Language Server Protocol:*** Something that helps code editors understand code better. It provides functionality like linting and error detection.
-    - **Postgres Language Server:** a server that will help with Postgres programing - writing SQL, type inference, etc.
+    - **Postgres Language Server:** a server that will help with Postgres programming - writing SQL, type inference, etc.
     - **Parser**: A parser converts written code into a form that tools can work with. For example, it identifies variables in code. and then the tools can easily access those variables. We’ll describe this more below.
 
 </details>

--- a/apps/www/_blog/2023-12-19-launch-week-x-best-launches.mdx
+++ b/apps/www/_blog/2023-12-19-launch-week-x-best-launches.mdx
@@ -167,7 +167,7 @@ Oh, and the [tldraw](https://www.tldraw.com/) team have been on an [absolute tea
 - [Svix Webhooks, from Postgres](https://www.svix.com/blog/use-svix-from-supabase/)
 - [Offline support with Powersync](https://www.powersync.com/blog/flutter-tutorial-building-an-offline-first-chat-app-with-supabase-and-powersync)
 - [Lowcode Supabase with Buildship](https://docs.buildship.com/supabase)
-- [Visual programing with Comnoco and Supabase](https://docs.comnoco.com/usecases/Supabase/)
+- [Visual programming with Comnoco and Supabase](https://docs.comnoco.com/usecases/Supabase/)
 
 ### And finally…
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Typo fixed in blog section

## What is the current behavior?

Typo `programing` and `implemenation`

## What is the new behavior?

`programing` --> `programming`
`implemenation` --> `implementation`

