### PR TITLE
docs(lint): Fix indentation for JS REST call example in broadcast.mdx

### DIFF
--- a/apps/docs/content/guides/realtime/broadcast.mdx
+++ b/apps/docs/content/guides/realtime/broadcast.mdx
@@ -488,12 +488,12 @@ You can also send a Broadcast message by making an HTTP request to Realtime serv
     // No need to subscribe to channel
 
     channel
-    .send({
-    type: 'broadcast',
-    event: 'test',
-    payload: { message: 'Hi' },
-    })
-    .then((resp) => console.log(resp))
+      .send({
+        type: 'broadcast',
+        event: 'test',
+        payload: { message: 'Hi' },
+      })
+      .then((resp) => console.log(resp))
 
     // Remember to clean up the channel
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Whitespace only (indentation) formatting update to "Send messages using REST calls" docs JavaScript code example.

## What is the current behavior?

Docs page: https://supabase.com/docs/guides/realtime/broadcast#send-messages-using-rest-calls
Current formatting is missing indentation:

```js
const channel = client.channel('test-channel')

// No need to subscribe to channel

channel
.send({
type: 'broadcast',
event: 'test',
payload: { message: 'Hi' },
})
.then((resp) => console.log(resp))

// Remember to clean up the channel

client.removeChannel(channel)
```

## What is the new behavior?

New formatting uses 2 space indentation following the JS formatting observed in other examples:
```js
const channel = client.channel('test-channel')

// No need to subscribe to channel

channel
  .send({
    type: 'broadcast',
    event: 'test',
    payload: { message: 'Hi' },
  })
  .then((resp) => console.log(resp))

// Remember to clean up the channel

client.removeChannel(channel)
```

