### PR TITLE
chore(docs): Fix key prop error in RefFunctionSection component

### DIFF
--- a/apps/docs/components/reference/RefFunctionSection.tsx
+++ b/apps/docs/components/reference/RefFunctionSection.tsx
@@ -149,7 +149,7 @@ const RefFunctionSection: React.FC<IRefFunctionSection> = (props) => {
                       return (
                         <Tabs.Panel
                           id={example.id}
-                          key={example.id}
+                          key={exampleIndex}
                           label={example.name}
                           className="flex flex-col gap-3"
                         >


### PR DESCRIPTION
## What kind of change does this PR introduce?

Added unique `key` prop

## What is the current behavior?

`key` prop isn't unique

## What is the new behavior?

Unique `key` prop added

