### PR TITLE
Add Basejump link to RLS docs

### DIFF
--- a/apps/docs/pages/guides/auth/row-level-security.mdx
+++ b/apps/docs/pages/guides/auth/row-level-security.mdx
@@ -287,6 +287,11 @@ to authenticated using (
 );
 ```
 
+## More resources
+
+- [Testing your database](/docs/guides/database/testing)
+- Community repo on testing RLS using [pgTAP and dbdev](https://github.com/usebasejump/supabase-test-helpers/tree/main)
+
 export const Page = ({ children }) => <Layout meta={meta} children={children} />
 
 export default Page


### PR DESCRIPTION
## What kind of change does this PR introduce?

closes #9576 

Basejump created a guide and extension for testing RLS policies using pgTAP with their own extension added to `dbdev`. Added link from the RLS page in docs for easier discovery

## What is the new behavior?

Link added to resources section for RLS

## Additional context

Add any other context or screenshots.
