### PR TITLE
fix: Handle Cloudflare errors in the region selector

### DIFF
--- a/apps/studio/components/interfaces/ProjectCreation/RegionSelector.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/RegionSelector.tsx
@@ -19,11 +19,24 @@ export const RegionSelector = ({
 }: RegionSelectorProps) => {
   const router = useRouter()
   const availableRegions = getAvailableRegions(PROVIDERS[cloudProvider].id)
-  const { data: region, isLoading, isSuccess } = useDefaultRegionQuery({ cloudProvider })
+  const {
+    data: region,
+    isSuccess,
+    isError,
+  } = useDefaultRegionQuery(
+    { cloudProvider },
+    { refetchOnMount: false, refetchOnWindowFocus: false, refetchInterval: false }
+  )
 
   useEffect(() => {
-    if (isSuccess && region) onSelectRegion(region)
-  }, [isSuccess, region])
+    // only pick a region if one hasn't already been selected
+    if (isSuccess && region && !selectedRegion) {
+      onSelectRegion(region)
+    } else if (isError && !selectedRegion) {
+      // if an error happened, and the user haven't selected a region, just select the default one for him
+      onSelectRegion(PROVIDERS[cloudProvider].default_region)
+    }
+  }, [cloudProvider, isError, isSuccess, region, selectedRegion])
 
   return (
     <Listbox
@@ -31,7 +44,6 @@ export const RegionSelector = ({
       label="Region"
       type="select"
       value={selectedRegion}
-      disabled={isLoading}
       onChange={(value) => onSelectRegion(value)}
       descriptionText="Select the region closest to your users for the best performance."
     >

--- a/apps/studio/data/misc/get-default-region-query.ts
+++ b/apps/studio/data/misc/get-default-region-query.ts
@@ -67,5 +67,11 @@ export const useDefaultRegionQuery = <TData = DefaultRegionData>(
   useQuery<DefaultRegionData, DefaultRegionError, TData>(
     miscKeys.defaultRegion(cloudProvider, useRestrictedPool ?? true),
     () => getDefaultRegionOption({ cloudProvider, useRestrictedPool }),
-    { enabled: enabled && typeof cloudProvider !== 'undefined', ...options }
+    {
+      enabled: enabled && typeof cloudProvider !== 'undefined',
+      retry(failureCount) {
+        return failureCount < 1
+      },
+      ...options,
+    }
   )

--- a/apps/studio/pages/new/[slug].tsx
+++ b/apps/studio/pages/new/[slug].tsx
@@ -148,19 +148,12 @@ const Wizard: NextPageWithLayout = () => {
 
   function onCloudProviderChange(cloudProviderId: CloudProvider) {
     setCloudProvider(cloudProviderId)
-    if (cloudProviderId === PROVIDERS.AWS.id) {
-      setDbRegion(
-        ['staging', 'local'].includes(process.env.NEXT_PUBLIC_ENVIRONMENT ?? '')
-          ? PROVIDERS['AWS'].default_region
-          : ''
-      )
-    } else {
-      setDbRegion(
-        ['staging', 'local'].includes(process.env.NEXT_PUBLIC_ENVIRONMENT ?? '')
-          ? PROVIDERS['FLY'].default_region
-          : ''
-      )
-    }
+    // on local/staging quick-select the default region, don't wait for the cloudflare location
+    setDbRegion(
+      ['staging', 'local'].includes(process.env.NEXT_PUBLIC_ENVIRONMENT ?? '')
+        ? PROVIDERS[cloudProviderId].default_region
+        : ''
+    )
   }
 
   async function checkPasswordStrength(value: any) {


### PR DESCRIPTION
If the user has `ublock Origin`, the region selector is frozen for 5-6 seconds and the user can't select a region. This also happens on window focus. The implementation has been changed to make the select work the whole time but if the user selects a region while waiting for response from Cloudflare, just ignore the response.