### PR TITLE
fix: table editor not refresh when change schema 

### DIFF
--- a/apps/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
+++ b/apps/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
@@ -34,8 +34,10 @@ import {
 } from 'ui'
 import { useProjectContext } from '../ProjectLayout/ProjectContext'
 import EntityListItem from './EntityListItem'
+import { useRouter } from 'next/router'
 
 const TableEditorMenu = () => {
+  const router = useRouter()
   const { id } = useParams()
   const snap = useTableEditorStateSnapshot()
 
@@ -108,6 +110,7 @@ const TableEditorMenu = () => {
           onSelectSchema={(name: string) => {
             setSearchText('')
             snap.setSelectedSchemaName(name)
+            router.push(`/project/${project?.ref}/editor`)
           }}
           onSelectCreateSchema={() => snap.onAddSchema()}
         />


### PR DESCRIPTION
## What kind of change does this PR introduce?

fixes: https://github.com/supabase/supabase/issues/20437

## What is the current behavior?

When we change the schema in the left menu of the table editor, it does not reset the selected table in the grid view, which can cause confusion for the user.

## What is the new behavior?

When we change the schema in the left menu of the table editor, it will reset selected table.

## Additional context

Add any other context or screenshots.
