### PR TITLE
fix: entity types query keepPreviousData

### DIFF
--- a/apps/studio/components/interfaces/Database/Indexes/CreateIndexSidePanel.tsx
+++ b/apps/studio/components/interfaces/Database/Indexes/CreateIndexSidePanel.tsx
@@ -36,16 +36,13 @@ const CreateIndexSidePanel = ({ visible, onClose }: CreateIndexSidePanelProps) =
     projectRef: project?.ref,
     connectionString: project?.connectionString,
   })
-  const { data: entities } = useEntityTypesQuery(
-    {
-      schema: selectedSchema,
-      sort: 'alphabetical',
-      search: undefined,
-      projectRef: project?.ref,
-      connectionString: project?.connectionString,
-    },
-    { keepPreviousData: true }
-  )
+  const { data: entities } = useEntityTypesQuery({
+    schema: selectedSchema,
+    sort: 'alphabetical',
+    search: undefined,
+    projectRef: project?.ref,
+    connectionString: project?.connectionString,
+  })
   const {
     data: tableColumns,
     isLoading: isLoadingTableColumns,

--- a/apps/studio/components/interfaces/TableGridEditor/EmptyState.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/EmptyState.tsx
@@ -21,17 +21,12 @@ const EmptyState = ({}: EmptyStateProps) => {
   )
 
   const { project } = useProjectContext()
-  const { data } = useEntityTypesQuery(
-    {
-      projectRef: project?.ref,
-      connectionString: project?.connectionString,
-      schema: snap.selectedSchemaName,
-      sort,
-    },
-    {
-      keepPreviousData: true,
-    }
-  )
+  const { data } = useEntityTypesQuery({
+    projectRef: project?.ref,
+    connectionString: project?.connectionString,
+    schema: snap.selectedSchemaName,
+    sort,
+  })
 
   const totalCount = data?.pages?.[0].data.count ?? 0
 

--- a/apps/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
+++ b/apps/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
@@ -68,7 +68,7 @@ const TableEditorMenu = () => {
       sort,
     },
     {
-      keepPreviousData: true,
+      keepPreviousData: Boolean(searchText),
     }
   )
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix, follow up to #20466

## What is the current behaviour?

Shows the tables from the previously selected schema while the new ones are loading:

https://github.com/supabase/supabase/assets/10985857/e859bfc0-4a5b-40ea-8c6b-315390c594cf



## What is the new behaviour?

Shows loading state after switching schemas:

https://github.com/supabase/supabase/assets/10985857/2af97fd8-f505-42bc-a497-b8fa106c22d5

