### PR TITLE
docs: clarify compute credit assignment

### DIFF
--- a/apps/docs/pages/guides/platform/org-based-billing.mdx
+++ b/apps/docs/pages/guides/platform/org-based-billing.mdx
@@ -90,7 +90,7 @@ Compute Credits are deducted from your Compute Usage. You can launch as many ins
 
 Compute Credits do not apply to other usage fees like egress, database size, ... They solely apply to Compute usage.
 
-Additionally, Compute Credits reset every month and do not accumulate, in case you're not running any projects.
+Additionally, Compute Credits are given to you not only for the first month but for every month while you are on a paid plan. Notice though, that they reset every month and do not accumulate, in case you're not running any projects.
 
 ## Unified egress
 

--- a/apps/www/components/Pricing/ComputePricingModal.tsx
+++ b/apps/www/components/Pricing/ComputePricingModal.tsx
@@ -62,7 +62,8 @@ export default function ComputePricingModal({ showComputeModal, setShowComputeMo
                 Compute instances are billed hourly and you can scale up or down at any time if you
                 need extra performance. You'll only be charged at the end of the month for the hours
                 you've used. Paid plans come with $10 in Compute Credits to cover one Starter
-                instance or parts of any other instance. Read more on{' '}
+                instance or parts of any other instance. Compute Credits are given to you not only
+                for the first month but for every month while you are on a paid plan. Read more on{' '}
                 <Link
                   href="https://supabase.com/docs/guides/platform/org-based-billing#usage-based-billing-for-compute"
                   target="_blank"


### PR DESCRIPTION
Some customers think that they get Compute Credits only once (for the first month). We want to get the info across that  you get credits every month.
We therefore adjust the copy in the docs (https://supabase.com/docs/guides/platform/org-based-billing#compute-credits) and on the pricing page (click "See pricing breakdown" on the "Optimized Compute" card)

Notion-Task: https://www.notion.so/supabase/Improve-transparency-for-compute-credits-compute-hours-projected-costs-af166fcce9164ab98b498786b7b0b4ac?pvs=4