### PR TITLE
fix(docs): document how to copy migration history to new project

### DIFF
--- a/apps/docs/pages/guides/platform/migrating-and-upgrading-projects.mdx
+++ b/apps/docs/pages/guides/platform/migrating-and-upgrading-projects.mdx
@@ -147,6 +147,7 @@ Migrating projects can be achieved using the Supabase CLI. This is particularly 
 supabase db dump --db-url "$OLD_DB_URL" -f roles.sql --role-only
 supabase db dump --db-url "$OLD_DB_URL" -f schema.sql
 supabase db dump --db-url "$OLD_DB_URL" -f data.sql --use-copy --data-only
+supabase db dump --db-url "$OLD_DB_URL" -f history.sql --use-copy --data-only --schema supabase_migrations
 ```
 
 ### Restore to your new project
@@ -180,6 +181,7 @@ psql \
   --file schema.sql \
   --command 'SET session_replication_role = replica' \
   --file data.sql \
+  --file history.sql \
   --dbname "$NEW_DB_URL"
 ```
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

When migrating an old project to a new project, the original migration history isn't copied over.

## What is the new behavior?

Add commands to move migration history over to new project.

## Additional context

Add any other context or screenshots.
