### PR TITLE
chore: update pg_upgrade docs around incompatible extension versions; remove plv8 object exception

### DIFF
--- a/apps/docs/pages/guides/platform/migrating-and-upgrading-projects.mdx
+++ b/apps/docs/pages/guides/platform/migrating-and-upgrading-projects.mdx
@@ -74,28 +74,14 @@ When upgrading, the Supabase platform will "right-size" your disk based on the c
 pg_upgrade does not support upgrading of databases containing reg\* data types referencing system OIDs.
 If you have created any objects that depend on the following extensions, you will need to recreate them after the upgrade.
 
-Extensions registering system OID-specific reg\* data types:
+#### Extensions
 
-- `plv8`
-- `plcoffee`
-- `plls`
+pg_upgrade does not currently support upgrading of databases using extensions older than the following versions:
 
-As these extensions offer support to create functions in different languages, you will only need to check for functions using the languages enabled by the above extensions.
-Any objects depending on the detected objects (e.g. triggers, views, tables, etc.) will need to be modified to exclude references to them.
+- TimescaleDB 2.9.1
+- plv8 3.1.5
 
-The following query returns the function name and their definitions, to help in recreating them post-upgrade.
-
-```sql
-SELECT
-  pn.nspname || '.' || objid::regproc AS function_name,
-  pg_get_functiondef(objid) || ';' AS function_definition
-FROM pg_depend d
-  JOIN pg_language l on (d.refobjid = l.oid)
-  JOIN pg_proc pp on (d.objid = pp.oid)
-  JOIN pg_namespace pn on (pp.pronamespace = pn.oid)
-WHERE l.lanname in ('plls', 'plcoffee', 'plv8')
-  AND pn.nspname <> 'pg_catalog';
-```
+To upgrade to a newer version of Postgres, you will need to drop the extensions before the upgrade, and recreate them after the upgrade.
 
 #### Authentication method changes - deprecating md5 in favor of scram-sha-256
 


### PR DESCRIPTION
* Due to more complex upgrade paths for TimescaleDB and plv8, upgrading from versions prior to TimescaleDB 2.9.1 and plv8 3.1.5 is not currently supported
* Previous limitation of upgrading projects with plv8 enabled has been removed