### PR TITLE
Fixed a typo in database connection pool settings

### DIFF
--- a/apps/studio/components/interfaces/Settings/Database/ConnectionPooling/ConnectionPooling.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/ConnectionPooling/ConnectionPooling.tsx
@@ -395,7 +395,7 @@ export const ConnectionPooling = () => {
                             >
                               documentation
                             </a>{' '}
-                            to found out more.
+                            to find out more.
                           </FormDescription_Shadcn_>
                           <FormMessage_Shadcn_ className="col-start-5 col-span-8" />
                         </FormItem_Shadcn_>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes a typo in the pooler connection settings. Thix exact line is a laber for the `Max Client Connections` setting.

## What is the current behavior?

> Please refer to our [documentation](https://supabase.com/docs/guides/platform/custom-postgres-config#pooler-config) to **_found_** out more.

## What is the new behavior?

> Please refer to our [documentation](https://supabase.com/docs/guides/platform/custom-postgres-config#pooler-config) to **_find_** out more.

## Additional context

Just a simple typo fix.
