### PR TITLE
fix: Handle an unparseable connection string in the connection pooling page

### DIFF
--- a/apps/studio/components/interfaces/Settings/Database/ConnectionPooling/ConnectionPooling.utils.ts
+++ b/apps/studio/components/interfaces/Settings/Database/ConnectionPooling/ConnectionPooling.utils.ts
@@ -49,7 +49,11 @@ export const constructConnStringSyntax = (
 }
 
 export const getPoolerTld = (connString: string) => {
-  const segment = connString.split('pooler.supabase.')[1]
-  const tld = segment.split(':6543')[0]
-  return tld
+  try {
+    const segment = connString.split('pooler.supabase.')[1]
+    const tld = segment.split(':6543')[0]
+    return tld
+  } catch {
+    return 'com'
+  }
 }


### PR DESCRIPTION
The `getPoolerTld` may throw an error if the connection string doesn't contain `pooler.supabase.` which can happen on some projects (reported via Hubspot).