### PR TITLE
docs: Add caution callout to Apple secret generation form

### DIFF
--- a/apps/docs/pages/guides/auth/social-login/auth-apple.mdx
+++ b/apps/docs/pages/guides/auth/social-login/auth-apple.mdx
@@ -68,6 +68,12 @@ When developing with Expo, you can test Sign in with Apple via the Expo Go app, 
 
     </Admonition>
 
+    <Admonition type="caution">
+
+    Secret generation using Safari is temporarily down.
+
+    </Admonition>
+
     <AppleSecretGenerator />
 
     ## Using sign in with Apple JS
@@ -310,11 +316,11 @@ When developing with Expo, you can test Sign in with Apple via the Expo Go app, 
     </Admonition>
 
   </TabPanel>
-  
+
   <TabPanel id="kotlin" label="Kotlin">
-  
+
     ## Using native sign in with Apple in Kotlin
-  
+
 	When using [Compose Multiplatform](https://github.com/JetBrains/compose-multiplatform/), you can use the [compose-auth](https://supabase.com/docs/reference/kotlin/installing) plugin. On iOS it uses Native Apple Login automatically and on other platforms it uses `gotrue.signInWith(Apple)`.
 
     **Initialize the Supabase Client**


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs Update: Added temporary message before Safari secret generation is fixed
