### PR TITLE
feat: Update edge-runtime version to v1.31.0

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -273,7 +273,7 @@ services:
 
   functions:
     container_name: supabase-edge-functions
-    image: supabase/edge-runtime:v1.29.1
+    image: supabase/edge-runtime:v1.31.0
     restart: unless-stopped
     depends_on:
       analytics:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

[InvalidWorkerResponse: user worker failed to respond](https://github.com/supabase/supabase/issues/20554)

## What is the new behavior?

The v1.31.0 of edge-runtime resolves the issues with InvalidWorkerResponse and it allows to unlock the CPU limit in `./volumes/functions/main/index.ts` when only updating the edge-runtime version is not enough.

## Additional context

To unlock the CPU limit you should add those lines in the `./volumes/functions/main/index.ts`:

    const memoryLimitMb = 150
    const workerTimeoutMs = 1 * 60 * 1000
    const cpuTimeSoftLimitMs = 0; // here
    const cpuTimeHardLimitMs = 0; // here
    const noModuleCache = false
    const importMapPath = null
    const envVarsObj = Deno.env.toObject()
    const envVars = Object.keys(envVarsObj).map((k) => [k, envVarsObj[k]])
    ...
        const worker = await EdgeRuntime.userWorkers.create({
          servicePath,
          memoryLimitMb,
          workerTimeoutMs,
          cpuTimeSoftLimitMs, // <-
          cpuTimeHardLimitMs, // <-
          noModuleCache,
          importMapPath,
          envVars,
        })