### PR TITLE
feat: limit sign-in password length to 72

### DIFF
--- a/apps/studio/components/interfaces/SignIn/PasswordConditionsHelper.tsx
+++ b/apps/studio/components/interfaces/SignIn/PasswordConditionsHelper.tsx
@@ -15,7 +15,8 @@ const PasswordConditionsHelper = ({ password }: PasswordConditionsHelperProps) =
       <PasswordCondition title="Lowercase letter" isMet={hasLowercase} />
       <PasswordCondition title="Number" isMet={hasNumber} />
       <PasswordCondition title="Special character (e.g. !?<>@#$%)" isMet={hasSpecialCharacter} />
-      <PasswordCondition title="> 7 characters" isMet={isEightCharactersLong} />
+      <PasswordCondition title="8 characters or more" isMet={isEightCharactersLong} />
+      {password.length > 72 && <PasswordCondition title="72 characters or less" isMet />}
     </div>
   )
 }

--- a/apps/studio/components/interfaces/SignIn/PasswordConditionsHelper.tsx
+++ b/apps/studio/components/interfaces/SignIn/PasswordConditionsHelper.tsx
@@ -16,7 +16,7 @@ const PasswordConditionsHelper = ({ password }: PasswordConditionsHelperProps) =
       <PasswordCondition title="Number" isMet={hasNumber} />
       <PasswordCondition title="Special character (e.g. !?<>@#$%)" isMet={hasSpecialCharacter} />
       <PasswordCondition title="8 characters or more" isMet={isEightCharactersLong} />
-      {password.length > 72 && <PasswordCondition title="72 characters or less" isMet />}
+      {password.length > 72 && <PasswordCondition title="72 characters or less" isMet={false} />}
     </div>
   )
 }

--- a/apps/studio/components/interfaces/SignIn/SignInForm.tsx
+++ b/apps/studio/components/interfaces/SignIn/SignInForm.tsx
@@ -16,7 +16,7 @@ const signInSchema = object({
   email: string().email('Must be a valid email').required('Email is required'),
   password: string()
     .required('Password is required')
-    .max(72, 'Good job with the password, but it should be 72 chars or less'),
+    .max(72, 'Password must be at most 72 characters'),
 })
 
 const SignInForm = () => {

--- a/apps/studio/components/interfaces/SignIn/SignInForm.tsx
+++ b/apps/studio/components/interfaces/SignIn/SignInForm.tsx
@@ -14,9 +14,7 @@ import { Button, Form, Input } from 'ui'
 
 const signInSchema = object({
   email: string().email('Must be a valid email').required('Email is required'),
-  password: string()
-    .required('Password is required')
-    .max(72, 'Password cannot exceed 72 characters'),
+  password: string().required('Password is required'),
 })
 
 const SignInForm = () => {

--- a/apps/studio/components/interfaces/SignIn/SignInForm.tsx
+++ b/apps/studio/components/interfaces/SignIn/SignInForm.tsx
@@ -16,7 +16,7 @@ const signInSchema = object({
   email: string().email('Must be a valid email').required('Email is required'),
   password: string()
     .required('Password is required')
-    .max(72, 'Password must be at most 72 characters'),
+    .max(72, 'Password cannot exceed 72 characters'),
 })
 
 const SignInForm = () => {

--- a/apps/studio/components/interfaces/SignIn/SignInForm.tsx
+++ b/apps/studio/components/interfaces/SignIn/SignInForm.tsx
@@ -14,7 +14,9 @@ import { Button, Form, Input } from 'ui'
 
 const signInSchema = object({
   email: string().email('Must be a valid email').required('Email is required'),
-  password: string().required('Password is required'),
+  password: string()
+    .required('Password is required')
+    .max(72, 'Good job with the password, but it should be 72 chars or less'),
 })
 
 const SignInForm = () => {

--- a/apps/studio/lib/schemas.ts
+++ b/apps/studio/lib/schemas.ts
@@ -5,5 +5,10 @@ import YupPassword from 'yup-password'
 YupPassword(yup)
 
 export const passwordSchema = yup.object({
-  password: yup.string().password().required().label('Password'),
+  password: yup
+    .string()
+    .password()
+    .required()
+    .max(72, 'Password must be at most 72 characters')
+    .label('Password'),
 })

--- a/apps/studio/lib/schemas.ts
+++ b/apps/studio/lib/schemas.ts
@@ -9,6 +9,6 @@ export const passwordSchema = yup.object({
     .string()
     .password()
     .required()
-    .max(72, 'Password must be at most 72 characters')
+    .max(72, 'Password cannot exceed 72 characters')
     .label('Password'),
 })


### PR DESCRIPTION
Anything over 72 is not acceptable.