### PR TITLE
fix(dashboard): enumerated types window showing other types such as composite

### DIFF
--- a/apps/studio/data/enumerated-types/enumerated-types-query.ts
+++ b/apps/studio/data/enumerated-types/enumerated-types-query.ts
@@ -33,7 +33,8 @@ export async function getEnumeratedTypes(
   })
 
   if (error) throw error
-  return data
+  const enumeratedTypes = data.filter((type) => type.enums.length > 0)
+  return enumeratedTypes
 }
 
 export type EnumeratedTypesData = Awaited<ReturnType<typeof getEnumeratedTypes>>


### PR DESCRIPTION
## What kind of change does this PR introduce?

- The page `dashboard -> Database -> Enumerated Types` now only shows enumerated Types and filters all other types for example if its composite.

## What is the current behavior?

The page showing enumerated types also shows composite types. This page can be found in `dashboard -> Database -> Enumerated Types`.

Please link any relevant issues here.
- Closes #18180

## What is the new behavior?

### Before: 

![text](https://private-user-images.githubusercontent.com/54070985/274969636-97549bbf-e22c-4342-84ea-e61be5c8b511.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MDU2NzA3OTgsIm5iZiI6MTcwNTY3MDQ5OCwicGF0aCI6Ii81NDA3MDk4NS8yNzQ5Njk2MzYtOTc1NDliYmYtZTIyYy00MzQyLTg0ZWEtZTYxYmU1YzhiNTExLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDAxMTklMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQwMTE5VDEzMjEzOFomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWEzNWI4MjQwZDI3YTNjOWYzMWYzMWIwNTIxZWNiOTMyMjY3ZjVhZDY2ZDg4MTRlNjQ4Yzc2YjE2YmJlNzlkOTgmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.TCbmZqhRg_eo1g-64_aYnkb9ZoNBSDoikmIqyBPNV38)

### After: 


https://github.com/supabase/supabase/assets/65061890/5198b1ef-2811-4343-a027-60f812b91bcd




Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
