### PR TITLE
docs: update link for debugging performance

### DIFF
--- a/apps/docs/spec/supabase_js_v2.yml
+++ b/apps/docs/spec/supabase_js_v2.yml
@@ -4643,7 +4643,7 @@ functions:
       Explain is not enabled by default as it can reveal sensitive information about your database.
       It's best to only enable this for testing environments but if you wish to enable it for production you can provide additional protection by using a `pre-request` function.
 
-      Follow the [Performance Debugging Guide](/docs/guides/api/rest/debugging-performance) to enable the functionality on your project.
+      Follow the [Performance Debugging Guide](/docs/guides/database/debugging-performance) to enable the functionality on your project.
     examples:
       - id: get-execution-plan
         name: Get the execution plan


### PR DESCRIPTION
## What kind of change does this PR introduce?

This pull request updates the documentation link for performance debugging.

## What is the current behavior?

Currently, it leads to a 404 page.

## What is the new behavior?

It is directed to the correct page.

## Additional context

![image](https://github.com/supabase/supabase/assets/19822794/423d7ea2-eec6-4f4d-b4fd-cbaaf14b8911)

