### PR TITLE
docs: mention that apple key generator does not work on safari

### DIFF
--- a/apps/docs/pages/guides/auth/social-login/auth-apple.mdx
+++ b/apps/docs/pages/guides/auth/social-login/auth-apple.mdx
@@ -64,7 +64,7 @@ When developing with Expo, you can test Sign in with Apple via the Expo Go app, 
 
     <Admonition>
 
-    Use this tool to generate a new Apple client secret. No keys leave your browser!
+    Use this tool to generate a new Apple client secret. No keys leave your browser! Be aware that this tool does not currently work in Safari, so please use Firefox or a Chrome-based browser instead.
 
     </Admonition>
 


### PR DESCRIPTION
For some reason it doesn't work and I'm not able to quickly see why.