### PR TITLE
fix: add schema name to url query params

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/GridHeaderActions.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/GridHeaderActions.tsx
@@ -17,12 +17,14 @@ import { useDatabasePublicationsQuery } from 'data/database-publications/databas
 import { useDatabasePublicationUpdateMutation } from 'data/database-publications/database-publications-update-mutation'
 import { useCheckPermissions, useIsFeatureEnabled } from 'hooks'
 import { RoleImpersonationPopover } from '../RoleImpersonationSelector'
+import { useTableEditorStateSnapshot } from 'state/table-editor'
 
 export interface GridHeaderActionsProps {
   table: PostgresTable
 }
 
 const GridHeaderActions = ({ table }: GridHeaderActionsProps) => {
+  const snap = useTableEditorStateSnapshot()
   const { ref } = useParams()
   const { project } = useProjectContext()
   const realtimeEnabled = useIsFeatureEnabled('realtime:all')
@@ -146,7 +148,9 @@ const GridHeaderActions = ({ table }: GridHeaderActionsProps) => {
               )
             }
           >
-            <Link href={`/project/${projectRef}/auth/policies?search=${table.id}`}>
+            <Link
+              href={`/project/${projectRef}/auth/policies?search=${table.id}&schema=${snap.selectedSchemaName}`}
+            >
               {!table.rls_enabled
                 ? 'RLS is not enabled'
                 : `${policies.length == 0 ? 'No' : policies.length} active RLS polic${


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds the schema name as a query param to the button that redirects to the policies page.

## What is the current behavior?

it always sends you to the "public" schema

## What is the new behavior?

It will load the correct schema when it redirects.

## Additional context

## BEFORE:
![CleanShot 2024-01-19 at 16 27 26](https://github.com/supabase/supabase/assets/37541088/13a2d33b-04d8-4438-ad73-bb92995c8c24)

## AFTER
![CleanShot 2024-01-19 at 16 30 11](https://github.com/supabase/supabase/assets/37541088/eba66a2a-dcd3-4479-858b-b81f7f3a4a10)

