### PR TITLE
Usage Summary - Link to docs in Compute Hours tooltip

### DIFF
--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/ComputeMetric.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/ComputeMetric.tsx
@@ -6,7 +6,7 @@ import { IconChevronRight, IconPieChart } from 'ui'
 import { Metric } from './BillingBreakdown.constants'
 import { formatUsage } from '../helpers'
 import { PricingMetric } from 'data/analytics/org-daily-stats-query'
-import { useMemo } from 'react'
+import React, { useMemo } from 'react'
 
 export interface ComputeMetricProps {
   slug?: string
@@ -93,7 +93,14 @@ const ComputeMetric = ({ slug, metric, usage, relativeToSubscription }: ComputeM
                     <p className="text-xs">
                       Every project is a dedicated server and database. For every hour your project
                       is active, it incurs compute costs based on the instance size of your project.
-                      Paused projects do not incur compute costs.
+                      Paused projects do not incur compute costs.{' '}
+                      <Link
+                        href="https://supabase.com/docs/guides/platform/org-based-billing#usage-based-billing-for-compute"
+                        target="_blank"
+                        className="transition text-brand hover:text-brand-600 underline"
+                      >
+                        Read more
+                      </Link>
                     </p>
                   </div>
                 </div>

--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
@@ -198,6 +198,34 @@ const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
             <tfoot>
               <tr>
                 <td className="py-4 text-sm font-medium">
+                  <span className="mr-2">Current Costs</span>
+                  <Tooltip.Root delayDuration={0}>
+                    <Tooltip.Trigger>
+                      <IconInfo size={12} strokeWidth={2} />
+                    </Tooltip.Trigger>
+                    <Tooltip.Portal>
+                      <Tooltip.Content side="bottom">
+                        <Tooltip.Arrow className="radix-tooltip-arrow" />
+                        <div
+                          className={[
+                            'rounded bg-alternative py-1 px-2 leading-none shadow',
+                            'border border-background',
+                          ].join(' ')}
+                        >
+                          <span className="text-xs text-foreground">
+                            Costs accumulated from the beginning of the billing cycle up to now.
+                          </span>
+                        </div>
+                      </Tooltip.Content>
+                    </Tooltip.Portal>
+                  </Tooltip.Root>
+                </td>
+                <td className="py-4 text-sm text-right font-medium" colSpan={3}>
+                  ${upcomingInvoice?.amount_total ?? '-'}
+                </td>
+              </tr>
+              <tr>
+                <td className="py-4 text-sm font-medium">
                   <span className="mr-2">Projected Costs</span>
                   <Tooltip.Root delayDuration={0}>
                     <Tooltip.Trigger>

--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
@@ -178,16 +178,17 @@ const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
                               billingMetricUnit(fee.usage_metric) &&
                               ` (${billingMetricUnit(fee.usage_metric)})`}
                           </span>
-                          {feeTooltipData.map(
-                            (tooltipData) =>
-                              fee.usage_metric?.startsWith(tooltipData.identifier) && (
-                                <InvoiceTooltip
-                                  text={tooltipData.text}
-                                  linkRef={tooltipData.linkRef}
-                                  key={tooltipData.identifier}
-                                />
-                              )
-                          )}
+                          {(() => {
+                            const matchingTooltipData = feeTooltipData.find((it) =>
+                              fee.usage_metric?.startsWith(it.identifier)
+                            )
+                            return matchingTooltipData ? (
+                              <InvoiceTooltip
+                                text={matchingTooltipData.text}
+                                linkRef={matchingTooltipData.linkRef}
+                              ></InvoiceTooltip>
+                            ) : null
+                          })()}
                         </td>
                         <td className="py-2 pr-4 text-sm text-right tabular-nums max-w-[100px]">
                           {fee.usage_original

--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
@@ -3,14 +3,35 @@ import clsx from 'clsx'
 import AlertError from 'components/ui/AlertError'
 import ShimmeringLoader from 'components/ui/ShimmeringLoader'
 import { useOrgUpcomingInvoiceQuery } from 'data/invoices/org-invoice-upcoming-query'
-import { useMemo, useState } from 'react'
+import React, { useMemo, useState } from 'react'
 import { Button, Collapsible, IconChevronRight, IconInfo } from 'ui'
 import * as Tooltip from '@radix-ui/react-tooltip'
 import { billingMetricUnit, formatUsage } from '../helpers'
+import Link from 'next/link'
 
 export interface UpcomingInvoiceProps {
   slug?: string
 }
+
+interface TooltipData {
+  identifier: string
+  text: string
+  link?: {
+    href: string
+    text: string
+  }
+}
+
+const tooltips: TooltipData[] = [
+  {
+    identifier: 'COMPUTE',
+    text: 'Every project is a dedicated server and database. For every hour your project is active, it incurs compute costs based on the instance size of your project. Paused projects do not incur compute costs.',
+    link: {
+      href: 'https://supabase.com/docs/guides/platform/org-based-billing#usage-based-billing-for-compute',
+      text: 'Compute Hours',
+    },
+  },
+]
 
 const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
   const {
@@ -156,12 +177,47 @@ const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
                               />
                             }
                           />{' '}
-                          <span>
+                          <span className="mr-2">
                             {fee.description}
                             {fee.usage_metric &&
                               billingMetricUnit(fee.usage_metric) &&
                               ` (${billingMetricUnit(fee.usage_metric)})`}
                           </span>
+                          {tooltips.map(
+                            (tip) =>
+                              fee.usage_metric?.startsWith(tip.identifier) && (
+                                <Tooltip.Root delayDuration={0} key={tip.identifier}>
+                                  <Tooltip.Trigger>
+                                    <IconInfo size={12} strokeWidth={2} />
+                                  </Tooltip.Trigger>
+                                  <Tooltip.Portal>
+                                    <Tooltip.Content side="bottom">
+                                      <Tooltip.Arrow className="radix-tooltip-arrow" />
+                                      <div
+                                        className={[
+                                          'rounded bg-alternative py-1 px-2 leading-none shadow',
+                                          'border border-background min-w-[300px] max-w-[450px] max-h-[300px] overflow-y-auto',
+                                        ].join(' ')}
+                                      >
+                                        <span className="text-xs text-foreground">
+                                          <p>
+                                            {tip.text} Read more on{' '}
+                                            <Link
+                                              href={tip.link?.href}
+                                              target="_blank"
+                                              className="transition text-brand hover:text-brand-600"
+                                            >
+                                              {tip.link?.text}
+                                            </Link>
+                                            .
+                                          </p>
+                                        </span>
+                                      </div>
+                                    </Tooltip.Content>
+                                  </Tooltip.Portal>
+                                </Tooltip.Root>
+                              )
+                          )}
                         </td>
                         <td className="py-2 pr-4 text-sm text-right tabular-nums max-w-[100px]">
                           {fee.usage_original
@@ -206,12 +262,49 @@ const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
               ))}
 
             {computeCredits && (
-              <tr className="border-b">
-                <td className="py-2 text-sm max-w-[200px]">{computeCredits.description}</td>
-                <td className="py-2 text-sm text-right pr-4">{null}</td>
-                <td className="py-2 text-sm">{null}</td>
-                <td className="py-2 text-sm text-right">${computeCredits.amount}</td>
-              </tr>
+              <tbody>
+                <tr className="border-b">
+                  <td className="py-2 text-sm max-w-[200px]">
+                    <span className="mr-2">{computeCredits.description}</span>
+                    <Tooltip.Root delayDuration={0}>
+                      <Tooltip.Trigger>
+                        <IconInfo size={12} strokeWidth={2} />
+                      </Tooltip.Trigger>
+                      <Tooltip.Portal>
+                        <Tooltip.Content side="bottom">
+                          <Tooltip.Arrow className="radix-tooltip-arrow" />
+                          <div
+                            className={[
+                              'rounded bg-alternative py-1 px-2 leading-none shadow',
+                              'border border-background min-w-[300px] max-w-[450px] max-h-[300px] overflow-y-auto',
+                            ].join(' ')}
+                          >
+                            <span className="text-xs text-foreground">
+                              <p>
+                                Paid plans come with $10 in Compute Credits to cover one Starter
+                                instance or parts of any other instance. Compute Credits are given
+                                to you not only for the first month but for every month while you
+                                are on a paid plan. Read more on{' '}
+                                <Link
+                                  href="https://supabase.com/docs/guides/platform/org-based-billing#compute-credits"
+                                  target="_blank"
+                                  className="transition text-brand hover:text-brand-600"
+                                >
+                                  Compute Credits
+                                </Link>
+                                .
+                              </p>
+                            </span>
+                          </div>
+                        </Tooltip.Content>
+                      </Tooltip.Portal>
+                    </Tooltip.Root>
+                  </td>
+                  <td className="py-2 text-sm text-right pr-4">{null}</td>
+                  <td className="py-2 text-sm">{null}</td>
+                  <td className="py-2 text-sm text-right">${computeCredits.amount}</td>
+                </tr>
+              </tbody>
             )}
 
             <tfoot>

--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
@@ -262,9 +262,9 @@ const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
                       link={computeCreditTooltipData.link}
                     />
                   </td>
-                  <td className="py-2 text-sm text-right pr-4">{null}</td>
-                  <td className="py-2 text-sm">{null}</td>
-                  <td className="py-2 text-sm text-right">${computeCredits.amount}</td>
+                  <td className="py-2 text-sm text-right" colSpan={3}>
+                    ${computeCredits.amount}
+                  </td>
                 </tr>
               </tbody>
             )}
@@ -280,11 +280,11 @@ const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
                 </td>
               </tr>
               <tr>
-                <td className="py-4 text-sm font-medium">
+                <td className="text-sm font-medium">
                   <span className="mr-2">Projected Costs</span>
                   <Tooltips text={projectedCostsTooltipText} />
                 </td>
-                <td className="py-4 text-sm text-right font-medium" colSpan={3}>
+                <td className="text-sm text-right font-medium" colSpan={3}>
                   ${upcomingInvoice?.amount_projected ?? '-'}
                 </td>
               </tr>

--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
@@ -8,6 +8,7 @@ import { Button, Collapsible, IconChevronRight, IconInfo } from 'ui'
 import * as Tooltip from '@radix-ui/react-tooltip'
 import { billingMetricUnit, formatUsage } from '../helpers'
 import Link from 'next/link'
+import { formatCurrency } from 'lib/helpers'
 
 export interface UpcomingInvoiceProps {
   slug?: string
@@ -133,11 +134,11 @@ const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
                       {item.unit_price === 0
                         ? 'FREE'
                         : item.unit_price
-                        ? formatToCurrency(item.unit_price)
+                        ? formatCurrency(item.unit_price)
                         : null}
                     </td>
                   )}
-                  <td className="py-2 text-sm text-right">{formatToCurrency(item.amount)}</td>
+                  <td className="py-2 text-sm text-right">{formatCurrency(item.amount)}</td>
                 </tr>
               ))}
             </tbody>
@@ -201,11 +202,11 @@ const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
                           {fee.unit_price_desc
                             ? `${fee.unit_price_desc}`
                             : fee.unit_price
-                            ? formatToCurrency(fee.unit_price)
+                            ? formatCurrency(fee.unit_price)
                             : null}
                         </td>
                         <td className="py-2 text-sm text-right max-w-[70px]">
-                          {formatToCurrency(fee.amount) ?? formatToCurrency(0)}
+                          {formatCurrency(fee.amount) ?? formatCurrency(0)}
                         </td>
                       </tr>
                     </Collapsible.Trigger>
@@ -245,7 +246,7 @@ const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
                     />
                   </td>
                   <td className="py-2 text-sm text-right" colSpan={3}>
-                    {formatToCurrency(computeCredits.amount)}
+                    {formatCurrency(computeCredits.amount)}
                   </td>
                 </tr>
               </tbody>
@@ -258,7 +259,7 @@ const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
                   <InvoiceTooltip text="Costs accumulated from the beginning of the billing cycle up to now." />
                 </td>
                 <td className="py-4 text-sm text-right font-medium" colSpan={3}>
-                  {formatToCurrency(upcomingInvoice?.amount_total) ?? '-'}
+                  {formatCurrency(upcomingInvoice?.amount_total) ?? '-'}
                 </td>
               </tr>
               <tr>
@@ -267,7 +268,7 @@ const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
                   <InvoiceTooltip text="Estimated costs at the end of the billing cycle. Final amounts may vary depending on your usage." />
                 </td>
                 <td className="text-sm text-right font-medium" colSpan={3}>
-                  {formatToCurrency(upcomingInvoice?.amount_projected) ?? '-'}
+                  {formatCurrency(upcomingInvoice?.amount_projected) ?? '-'}
                 </td>
               </tr>
             </tfoot>
@@ -307,18 +308,6 @@ const InvoiceTooltip = ({ text, linkRef }: { text: string; linkRef?: string }) =
       </Tooltip.Portal>
     </Tooltip.Root>
   )
-}
-
-const formatToCurrency = (amount: number | undefined | null): string | null => {
-  if (amount === undefined || amount === null) {
-    return null
-  } else {
-    return Intl.NumberFormat('en-US', {
-      style: 'currency',
-      currency: 'USD',
-      minimumFractionDigits: 0,
-    }).format(amount)
-  }
 }
 
 export default UpcomingInvoice

--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
@@ -35,7 +35,7 @@ const feeTooltipData: TooltipData[] = [
   },
 ]
 
-const computeCreditTooltipData: Omit<TooltipData, ['identifier']> = {
+const computeCreditTooltipData: Omit<TooltipData, 'identifier'> = {
   text: 'Paid plans come with $10 in Compute Credits to cover one Starter instance or parts of any other instance. Compute Credits are given to you not only for the first month but for every month while you are on a paid plan.',
   link: {
     href: 'https://supabase.com/docs/guides/platform/org-based-billing#compute-credits',

--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
@@ -16,38 +16,17 @@ export interface UpcomingInvoiceProps {
 interface TooltipData {
   identifier: string
   text: string
-  link?: TooltipLink
-}
-
-interface TooltipLink {
-  href: string
-  text: string
+  linkRef?: string
 }
 
 const feeTooltipData: TooltipData[] = [
   {
     identifier: 'COMPUTE',
     text: 'Every project is a dedicated server and database. For every hour your project is active, it incurs compute costs based on the instance size of your project. Paused projects do not incur compute costs.',
-    link: {
-      href: 'https://supabase.com/docs/guides/platform/org-based-billing#usage-based-billing-for-compute',
-      text: 'Compute Hours',
-    },
+    linkRef:
+      'https://supabase.com/docs/guides/platform/org-based-billing#usage-based-billing-for-compute',
   },
 ]
-
-const computeCreditTooltipData: Omit<TooltipData, 'identifier'> = {
-  text: 'Paid plans come with $10 in Compute Credits to cover one Starter instance or parts of any other instance. Compute Credits are given to you not only for the first month but for every month while you are on a paid plan.',
-  link: {
-    href: 'https://supabase.com/docs/guides/platform/org-based-billing#compute-credits',
-    text: 'Compute Credits',
-  },
-}
-
-const currentCostsTooltipText =
-  'Costs accumulated from the beginning of the billing cycle up to now.'
-
-const projectedCostsTooltipText =
-  ' Estimated costs at the end of the billing cycle. Final amounts may vary depending on your usage.'
 
 const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
   const {
@@ -73,13 +52,13 @@ const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
         // Prorations should be below regular usage fees
         return Number(a.proration) - Number(b.proration)
       })
-  }, [upcomingInvoice])
+  }, [upcomingInvoice, computeCredits])
 
   const feesWithBreakdown = useMemo(() => {
     return (upcomingInvoice?.lines || [])
       .filter((item) => item !== computeCredits && item.breakdown?.length)
       .sort((a, b) => Number(a.usage_based) - Number(b.usage_based) || b.amount - a.amount)
-  }, [upcomingInvoice])
+  }, [upcomingInvoice, computeCredits])
 
   const expandUsageFee = (fee: string) => {
     setUsageFeesExpanded([...usageFeesExpanded, fee])
@@ -202,9 +181,9 @@ const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
                           {feeTooltipData.map(
                             (tooltipData) =>
                               fee.usage_metric?.startsWith(tooltipData.identifier) && (
-                                <Tooltips
+                                <InvoiceTooltip
                                   text={tooltipData.text}
-                                  link={tooltipData.link}
+                                  linkRef={tooltipData.linkRef}
                                   key={tooltipData.identifier}
                                 />
                               )
@@ -257,9 +236,9 @@ const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
                 <tr className="border-b">
                   <td className="py-2 text-sm max-w-[200px]">
                     <span className="mr-2">{computeCredits.description}</span>
-                    <Tooltips
-                      text={computeCreditTooltipData.text}
-                      link={computeCreditTooltipData.link}
+                    <InvoiceTooltip
+                      text="Paid plans come with $10 in Compute Credits to cover one Starter instance or parts of any other instance. Compute Credits are given to you not only for the first month but for every month while you are on a paid plan."
+                      linkRef="https://supabase.com/docs/guides/platform/org-based-billing#compute-credits"
                     />
                   </td>
                   <td className="py-2 text-sm text-right" colSpan={3}>
@@ -273,7 +252,7 @@ const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
               <tr>
                 <td className="py-4 text-sm font-medium">
                   <span className="mr-2">Current Costs</span>
-                  <Tooltips text={currentCostsTooltipText} />
+                  <InvoiceTooltip text="Costs accumulated from the beginning of the billing cycle up to now." />
                 </td>
                 <td className="py-4 text-sm text-right font-medium" colSpan={3}>
                   ${upcomingInvoice?.amount_total ?? '-'}
@@ -282,7 +261,7 @@ const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
               <tr>
                 <td className="text-sm font-medium">
                   <span className="mr-2">Projected Costs</span>
-                  <Tooltips text={projectedCostsTooltipText} />
+                  <InvoiceTooltip text="Estimated costs at the end of the billing cycle. Final amounts may vary depending on your usage." />
                 </td>
                 <td className="text-sm text-right font-medium" colSpan={3}>
                   ${upcomingInvoice?.amount_projected ?? '-'}
@@ -296,7 +275,7 @@ const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
   )
 }
 
-const Tooltips = ({ text, link }: { text: string; link?: TooltipLink }) => {
+const InvoiceTooltip = ({ text, linkRef }: { text: string; linkRef?: string }) => {
   return (
     <Tooltip.Root delayDuration={0}>
       <Tooltip.Trigger>
@@ -314,18 +293,14 @@ const Tooltips = ({ text, link }: { text: string; link?: TooltipLink }) => {
             <span className="text-xs text-foreground">
               <p>
                 {text}{' '}
-                {link && (
-                  <>
-                    Read more on{' '}
-                    <Link
-                      href={link.href}
-                      target="_blank"
-                      className="transition text-brand hover:text-brand-600"
-                    >
-                      {link.text}
-                    </Link>
-                    .
-                  </>
+                {linkRef && (
+                  <Link
+                    href={linkRef}
+                    target="_blank"
+                    className="transition text-brand hover:text-brand-600"
+                  >
+                    Read more
+                  </Link>
                 )}
               </p>
             </span>

--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
@@ -25,7 +25,7 @@ const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
 
   const fixedFees = useMemo(() => {
     return (upcomingInvoice?.lines || [])
-      .filter((item) => !item.breakdown)
+      .filter((item) => !item.breakdown || !item.breakdown.length)
       .sort((a, b) => {
         // Prorations should be below regular usage fees
         return Number(a.proration) - Number(b.proration)
@@ -108,7 +108,11 @@ const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
                   )}
                   {!item.proration && (
                     <td className="py-2 text-sm">
-                      {item.unit_price === 0 ? 'FREE' : `$${item.unit_price}`}
+                      {item.unit_price === 0
+                        ? 'FREE'
+                        : item.unit_price
+                        ? `$${item.unit_price}`
+                        : null}
                     </td>
                   )}
                   <td className="py-2 text-sm text-right">${item.amount}</td>

--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
@@ -238,7 +238,7 @@ const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
                   <td className="py-2 text-sm max-w-[200px]">
                     <span className="mr-2">{computeCredits.description}</span>
                     <InvoiceTooltip
-                      text="Paid plans come with $10 in Compute Credits to cover one Starter instance or parts of any other instance. Compute Credits are given to you not only for the first month but for every month while you are on a paid plan."
+                      text="Paid plans come with $10 in Compute Credits to cover one Starter instance or parts of any other instance. Compute Credits are given to you every month and do not stack up while you are on a paid plan."
                       linkRef="https://supabase.com/docs/guides/platform/org-based-billing#compute-credits"
                     />
                   </td>

--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
@@ -23,9 +23,15 @@ const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
 
   const [usageFeesExpanded, setUsageFeesExpanded] = useState<string[]>([])
 
+  const computeCredits = useMemo(() => {
+    return (upcomingInvoice?.lines || []).find((item) =>
+      item.description.startsWith('Compute Credits')
+    )
+  }, [upcomingInvoice])
+
   const fixedFees = useMemo(() => {
     return (upcomingInvoice?.lines || [])
-      .filter((item) => !item.breakdown || !item.breakdown.length)
+      .filter((item) => item !== computeCredits && (!item.breakdown || !item.breakdown.length))
       .sort((a, b) => {
         // Prorations should be below regular usage fees
         return Number(a.proration) - Number(b.proration)
@@ -34,7 +40,7 @@ const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
 
   const feesWithBreakdown = useMemo(() => {
     return (upcomingInvoice?.lines || [])
-      .filter((item) => item.breakdown?.length)
+      .filter((item) => item !== computeCredits && item.breakdown?.length)
       .sort((a, b) => Number(a.usage_based) - Number(b.usage_based) || b.amount - a.amount)
   }, [upcomingInvoice])
 
@@ -198,6 +204,15 @@ const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
                   </tbody>
                 </Collapsible>
               ))}
+
+            {computeCredits && (
+              <tr className="border-b">
+                <td className="py-2 text-sm max-w-[200px]">{computeCredits.description}</td>
+                <td className="py-2 text-sm text-right pr-4">{null}</td>
+                <td className="py-2 text-sm">{null}</td>
+                <td className="py-2 text-sm text-right">${computeCredits.amount}</td>
+              </tr>
+            )}
 
             <tfoot>
               <tr>

--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
@@ -201,15 +201,20 @@ const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
                                       >
                                         <span className="text-xs text-foreground">
                                           <p>
-                                            {tip.text} Read more on{' '}
-                                            <Link
-                                              href={tip.link?.href}
-                                              target="_blank"
-                                              className="transition text-brand hover:text-brand-600"
-                                            >
-                                              {tip.link?.text}
-                                            </Link>
-                                            .
+                                            {tip.text}{' '}
+                                            {tip.link && (
+                                              <>
+                                                Read more on{' '}
+                                                <Link
+                                                  href={tip.link?.href!!}
+                                                  target="_blank"
+                                                  className="transition text-brand hover:text-brand-600"
+                                                >
+                                                  {tip.link?.text}
+                                                </Link>
+                                                .
+                                              </>
+                                            )}
                                           </p>
                                         </span>
                                       </div>

--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
@@ -16,13 +16,15 @@ export interface UpcomingInvoiceProps {
 interface TooltipData {
   identifier: string
   text: string
-  link?: {
-    href: string
-    text: string
-  }
+  link?: TooltipLink
 }
 
-const tooltips: TooltipData[] = [
+interface TooltipLink {
+  href: string
+  text: string
+}
+
+const feeTooltipData: TooltipData[] = [
   {
     identifier: 'COMPUTE',
     text: 'Every project is a dedicated server and database. For every hour your project is active, it incurs compute costs based on the instance size of your project. Paused projects do not incur compute costs.',
@@ -32,6 +34,20 @@ const tooltips: TooltipData[] = [
     },
   },
 ]
+
+const computeCreditTooltipData: Omit<TooltipData, ['identifier']> = {
+  text: 'Paid plans come with $10 in Compute Credits to cover one Starter instance or parts of any other instance. Compute Credits are given to you not only for the first month but for every month while you are on a paid plan.',
+  link: {
+    href: 'https://supabase.com/docs/guides/platform/org-based-billing#compute-credits',
+    text: 'Compute Credits',
+  },
+}
+
+const currentCostsTooltipText =
+  'Costs accumulated from the beginning of the billing cycle up to now.'
+
+const projectedCostsTooltipText =
+  ' Estimated costs at the end of the billing cycle. Final amounts may vary depending on your usage.'
 
 const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
   const {
@@ -183,44 +199,14 @@ const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
                               billingMetricUnit(fee.usage_metric) &&
                               ` (${billingMetricUnit(fee.usage_metric)})`}
                           </span>
-                          {tooltips.map(
-                            (tip) =>
-                              fee.usage_metric?.startsWith(tip.identifier) && (
-                                <Tooltip.Root delayDuration={0} key={tip.identifier}>
-                                  <Tooltip.Trigger>
-                                    <IconInfo size={12} strokeWidth={2} />
-                                  </Tooltip.Trigger>
-                                  <Tooltip.Portal>
-                                    <Tooltip.Content side="bottom">
-                                      <Tooltip.Arrow className="radix-tooltip-arrow" />
-                                      <div
-                                        className={[
-                                          'rounded bg-alternative py-1 px-2 leading-none shadow',
-                                          'border border-background min-w-[300px] max-w-[450px] max-h-[300px] overflow-y-auto',
-                                        ].join(' ')}
-                                      >
-                                        <span className="text-xs text-foreground">
-                                          <p>
-                                            {tip.text}{' '}
-                                            {tip.link && (
-                                              <>
-                                                Read more on{' '}
-                                                <Link
-                                                  href={tip.link?.href!!}
-                                                  target="_blank"
-                                                  className="transition text-brand hover:text-brand-600"
-                                                >
-                                                  {tip.link?.text}
-                                                </Link>
-                                                .
-                                              </>
-                                            )}
-                                          </p>
-                                        </span>
-                                      </div>
-                                    </Tooltip.Content>
-                                  </Tooltip.Portal>
-                                </Tooltip.Root>
+                          {feeTooltipData.map(
+                            (tooltipData) =>
+                              fee.usage_metric?.startsWith(tooltipData.identifier) && (
+                                <Tooltips
+                                  text={tooltipData.text}
+                                  link={tooltipData.link}
+                                  key={tooltipData.identifier}
+                                />
                               )
                           )}
                         </td>
@@ -271,39 +257,10 @@ const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
                 <tr className="border-b">
                   <td className="py-2 text-sm max-w-[200px]">
                     <span className="mr-2">{computeCredits.description}</span>
-                    <Tooltip.Root delayDuration={0}>
-                      <Tooltip.Trigger>
-                        <IconInfo size={12} strokeWidth={2} />
-                      </Tooltip.Trigger>
-                      <Tooltip.Portal>
-                        <Tooltip.Content side="bottom">
-                          <Tooltip.Arrow className="radix-tooltip-arrow" />
-                          <div
-                            className={[
-                              'rounded bg-alternative py-1 px-2 leading-none shadow',
-                              'border border-background min-w-[300px] max-w-[450px] max-h-[300px] overflow-y-auto',
-                            ].join(' ')}
-                          >
-                            <span className="text-xs text-foreground">
-                              <p>
-                                Paid plans come with $10 in Compute Credits to cover one Starter
-                                instance or parts of any other instance. Compute Credits are given
-                                to you not only for the first month but for every month while you
-                                are on a paid plan. Read more on{' '}
-                                <Link
-                                  href="https://supabase.com/docs/guides/platform/org-based-billing#compute-credits"
-                                  target="_blank"
-                                  className="transition text-brand hover:text-brand-600"
-                                >
-                                  Compute Credits
-                                </Link>
-                                .
-                              </p>
-                            </span>
-                          </div>
-                        </Tooltip.Content>
-                      </Tooltip.Portal>
-                    </Tooltip.Root>
+                    <Tooltips
+                      text={computeCreditTooltipData.text}
+                      link={computeCreditTooltipData.link}
+                    />
                   </td>
                   <td className="py-2 text-sm text-right pr-4">{null}</td>
                   <td className="py-2 text-sm">{null}</td>
@@ -316,26 +273,7 @@ const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
               <tr>
                 <td className="py-4 text-sm font-medium">
                   <span className="mr-2">Current Costs</span>
-                  <Tooltip.Root delayDuration={0}>
-                    <Tooltip.Trigger>
-                      <IconInfo size={12} strokeWidth={2} />
-                    </Tooltip.Trigger>
-                    <Tooltip.Portal>
-                      <Tooltip.Content side="bottom">
-                        <Tooltip.Arrow className="radix-tooltip-arrow" />
-                        <div
-                          className={[
-                            'rounded bg-alternative py-1 px-2 leading-none shadow',
-                            'border border-background',
-                          ].join(' ')}
-                        >
-                          <span className="text-xs text-foreground">
-                            Costs accumulated from the beginning of the billing cycle up to now.
-                          </span>
-                        </div>
-                      </Tooltip.Content>
-                    </Tooltip.Portal>
-                  </Tooltip.Root>
+                  <Tooltips text={currentCostsTooltipText} />
                 </td>
                 <td className="py-4 text-sm text-right font-medium" colSpan={3}>
                   ${upcomingInvoice?.amount_total ?? '-'}
@@ -344,27 +282,7 @@ const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
               <tr>
                 <td className="py-4 text-sm font-medium">
                   <span className="mr-2">Projected Costs</span>
-                  <Tooltip.Root delayDuration={0}>
-                    <Tooltip.Trigger>
-                      <IconInfo size={12} strokeWidth={2} />
-                    </Tooltip.Trigger>
-                    <Tooltip.Portal>
-                      <Tooltip.Content side="bottom">
-                        <Tooltip.Arrow className="radix-tooltip-arrow" />
-                        <div
-                          className={[
-                            'rounded bg-alternative py-1 px-2 leading-none shadow',
-                            'border border-background',
-                          ].join(' ')}
-                        >
-                          <span className="text-xs text-foreground">
-                            Estimated costs at the end of the billing cycle. Final amounts may vary
-                            depending on your usage.
-                          </span>
-                        </div>
-                      </Tooltip.Content>
-                    </Tooltip.Portal>
-                  </Tooltip.Root>
+                  <Tooltips text={projectedCostsTooltipText} />
                 </td>
                 <td className="py-4 text-sm text-right font-medium" colSpan={3}>
                   ${upcomingInvoice?.amount_projected ?? '-'}
@@ -375,6 +293,46 @@ const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
         </div>
       )}
     </>
+  )
+}
+
+const Tooltips = ({ text, link }: { text: string; link?: TooltipLink }) => {
+  return (
+    <Tooltip.Root delayDuration={0}>
+      <Tooltip.Trigger>
+        <IconInfo size={12} strokeWidth={2} />
+      </Tooltip.Trigger>
+      <Tooltip.Portal>
+        <Tooltip.Content side="bottom">
+          <Tooltip.Arrow className="radix-tooltip-arrow" />
+          <div
+            className={[
+              'rounded bg-alternative py-1 px-2 leading-none shadow',
+              'border border-background min-w-[300px] max-w-[450px] max-h-[300px] overflow-y-auto',
+            ].join(' ')}
+          >
+            <span className="text-xs text-foreground">
+              <p>
+                {text}{' '}
+                {link && (
+                  <>
+                    Read more on{' '}
+                    <Link
+                      href={link.href}
+                      target="_blank"
+                      className="transition text-brand hover:text-brand-600"
+                    >
+                      {link.text}
+                    </Link>
+                    .
+                  </>
+                )}
+              </p>
+            </span>
+          </div>
+        </Tooltip.Content>
+      </Tooltip.Portal>
+    </Tooltip.Root>
   )
 }
 

--- a/apps/studio/data/invoices/org-invoice-upcoming-query.ts
+++ b/apps/studio/data/invoices/org-invoice-upcoming-query.ts
@@ -10,6 +10,7 @@ export type UpcomingInvoiceVariables = {
 
 export type UpcomingInvoiceResponse = {
   amount_projected: number
+  amount_total: number
   currency: string
   customer_balance: number
   subscription_id: string

--- a/apps/studio/lib/helpers.ts
+++ b/apps/studio/lib/helpers.ts
@@ -298,3 +298,17 @@ export const getDistanceLatLonKM = (lat1: number, lon1: number, lat2: number, lo
   const d = R * c // Distance in KM
   return d
 }
+
+const currencyFormatter = Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  minimumFractionDigits: 0,
+})
+
+export const formatCurrency = (amount: number | undefined | null): string | null => {
+  if (amount === undefined || amount === null) {
+    return null
+  } else {
+    return currencyFormatter.format(amount)
+  }
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Improve Usage Summary in Studio

## What is the new behavior?

In Usage Summary, the tooltip for Compute Hours now shows a link to the docs. The UI follows the concise "Read more" approach from the tooltips in the Billing Breakdown.