### PR TITLE
fix(ui): fix datepicker color issues

### DIFF
--- a/apps/studio/components/ui/DatePicker/DatePicker.tsx
+++ b/apps/studio/components/ui/DatePicker/DatePicker.tsx
@@ -181,7 +181,7 @@ function _DatePicker({
               <div className="flex items-stretch justify-between py-2">
                 {!selectsRange ? null : (
                   <>
-                    <div className="flex grow flex-col gap-1">
+                    <div className="flex grow flex-col gap-1 pl-2">
                       <TimeSplitInput
                         type="start"
                         startTime={startTime}
@@ -207,7 +207,7 @@ function _DatePicker({
                     </div>
                   </>
                 )}
-                <div className="flex grow flex-col gap-1">
+                <div className="flex grow flex-col gap-1 pr-2">
                   <TimeSplitInput
                     type="end"
                     startTime={startTime}
@@ -223,7 +223,7 @@ function _DatePicker({
               </div>
             </>
           )}
-          <div className="px-3 py-4">
+          <div className="p-2">
             <DatePicker
               inline
               selectsRange={selectsRange}
@@ -244,7 +244,7 @@ function _DatePicker({
                 prevMonthButtonDisabled,
                 nextMonthButtonDisabled,
               }) => (
-                <div className="flex items-center justify-between px-2 py-2">
+                <div className="flex items-center justify-between">
                   <div className="flex w-full items-center justify-between">
                     <button
                       onClick={decreaseMonth}
@@ -252,7 +252,7 @@ function _DatePicker({
                       type="button"
                       className={`
                         ${prevMonthButtonDisabled && 'cursor-not-allowed opacity-50'}
-                        text-foreground-light hover:text-foreground focus:outline-none
+                        text-foreground-light hover:text-foreground focus:outline-none p-2
                     `}
                     >
                       <IconChevronLeft size={16} strokeWidth={2} />
@@ -266,7 +266,7 @@ function _DatePicker({
                       type="button"
                       className={`
                         ${nextMonthButtonDisabled && 'cursor-not-allowed opacity-50'}
-                        text-foreground-light hover:text-foreground focus:outline-none
+                        text-foreground-light p-2 hover:text-foreground focus:outline-none
                     `}
                     >
                       <IconChevronRight size={16} strokeWidth={2} />

--- a/apps/studio/styles/date-picker.scss
+++ b/apps/studio/styles/date-picker.scss
@@ -17,7 +17,7 @@
 }
 
 .react-datepicker__portal {
-  @apply absolute z-10 w-72 text-sm transform-none bg-white shadow px-3 py-2 top-12 right-0 border-2 border-background rounded;
+  @apply absolute z-10 w-72 text-sm transform-none bg-background shadow px-3 py-2 top-12 right-0 border-2 border-background rounded;
 }
 
 .react-datepicker__month-container {
@@ -58,7 +58,7 @@
 }
 
 .react-datepicker__day {
-  @apply w-10 h-10 flex items-center font-normal justify-center text-sm leading-loose transition text-foreground-light;
+  @apply w-10 h-10 flex items-center font-normal justify-center text-sm leading-loose transition text-foreground-light cursor-pointer;
   /* @apply mb-1 py-1; */
   @apply -space-y-px;
   @apply border border-default;
@@ -73,34 +73,32 @@
 }
 
 .react-datepicker__day--in-range {
-  @apply bg-brand-300 text-scale-fixed-100 border-brand-300;
+  @apply bg-brand-400 text-scale-fixed-100 border-brand-300 text-foreground;
 }
 
 .react-datepicker__day--in-selecting-range {
-  @apply bg-brand-400 text-scale-fixed-100 border-brand-400;
+  @apply bg-brand-400 text-scale-fixed-100 border-brand-400 text-foreground;
 }
 
-.react-datepicker__day--selecting-range-start {
-  @apply bg-background;
-}
-
+.react-datepicker__day--selecting-range-start,
 .react-datepicker__day--selecting-range-end {
-  @apply bg-background;
+  @apply bg-brand-300 text-foreground hover:bg-brand-400;
 }
 
 .react-datepicker__day--selected,
 .react-datepicker__day--selected.react-datepicker__day--highlighted {
-  @apply bg-brand-300 text-white;
+  @apply bg-brand text-foreground;
 }
 
-.react-datepicker__day--range-start {
-  @apply bg-brand text-white hover:text-border-strong hover:bg-white;
-}
-
+.react-datepicker__day--range-start,
 .react-datepicker__day--range-end {
-  @apply bg-brand text-white hover:text-border-strong hover:bg-white;
+  @apply bg-brand-accent text-foreground;
 }
 
 .react-datepicker__day--highlighted {
   @apply bg-brand-600 text-foreground-light;
+}
+
+.react-datepicker__aria-live {
+  @apply sr-only;
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?
Fixes issues with the colors in the datepicker 

## What is the current behavior?

- missing padding in header
- missing padding in next/prev month buttons (click target 2 smol)
- color contrast in date selection is unreadable
- duplicate month and year in header

## New behavior:
- fixed all issues above 

## Before
![CleanShot 2024-01-22 at 13 52 30](https://github.com/supabase/supabase/assets/37541088/40ec253b-c203-4bbb-85c1-41d5e68c1d18)


## After
![CleanShot 2024-01-22 at 13 56 33](https://github.com/supabase/supabase/assets/37541088/8be76e32-766f-4c52-9c7c-9b2b13d6e997)

