### PR TITLE
Customize price plan info for partner Fly

### DIFF
--- a/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/EnterpriseCard.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/EnterpriseCard.tsx
@@ -5,9 +5,12 @@ import { Button, IconCheck } from 'ui'
 export interface EnterpriseCardProps {
   plan: PricingInformation
   isCurrentPlan: boolean
+  billingViaPartner: boolean
 }
 
-const EnterpriseCard = ({ plan, isCurrentPlan }: EnterpriseCardProps) => {
+const EnterpriseCard = ({ plan, isCurrentPlan, billingViaPartner }: EnterpriseCardProps) => {
+  const features = billingViaPartner ? plan.featuresPartner : plan.features
+
   return (
     <div
       key={plan.id}
@@ -44,7 +47,7 @@ const EnterpriseCard = ({ plan, isCurrentPlan }: EnterpriseCardProps) => {
           role="list"
           className="text-xs text-foreground-light md:grid md:grid-cols-2 md:gap-x-10"
         >
-          {plan.features.map((feature) => (
+          {features.map((feature) => (
             <li key={feature} className="flex items-center py-2 first:mt-0">
               <IconCheck className="text-brand h-4 w-4" aria-hidden="true" strokeWidth={3} />
               <span className="text-foreground mb-0 ml-3 ">{feature}</span>

--- a/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/PlanUpdateSidePanel.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/PlanUpdateSidePanel.tsx
@@ -178,11 +178,14 @@ const PlanUpdateSidePanel = () => {
           <div className="py-6 grid grid-cols-12 gap-3">
             {subscriptionsPlans.map((plan) => {
               const planMeta = availablePlans.find((p) => p.id === plan.id.split('tier_')[1])
-              const tierMeta = subscriptionsPlans.find((it) => it.id === plan.id)
               const price = planMeta?.price ?? 0
               const isDowngradeOption = planMeta?.change_type === 'downgrade'
               const isCurrentPlan = planMeta?.id === subscription?.plan?.id
               const features = billingViaPartner ? plan.featuresPartner : plan.features
+              const warning =
+                billingViaPartner && plan.warningPartner
+                  ? plan.warningPartner
+                  : plan.warning ?? null
 
               if (plan.id === 'tier_enterprise') {
                 return (
@@ -228,11 +231,11 @@ const PlanUpdateSidePanel = () => {
                       ) : (
                         <p className="text-foreground text-lg">${price}</p>
                       )}
-                      <p className="text-foreground-light text-sm">{tierMeta?.costUnit}</p>
+                      <p className="text-foreground-light text-sm">{plan.costUnit}</p>
                     </div>
-                    <div className={clsx('flex mt-1 mb-4', !tierMeta?.warning && 'opacity-0')}>
+                    <div className={clsx('flex mt-1 mb-4', !warning && 'opacity-0')}>
                       <div className="bg-background text-brand-600 border shadow-sm rounded-md bg-opacity-30 py-0.5 px-2 text-xs">
-                        {tierMeta?.warning}
+                        {warning}
                       </div>
                     </div>
                     {isCurrentPlan ? (

--- a/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/PlanUpdateSidePanel.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/PlanUpdateSidePanel.tsx
@@ -182,9 +182,17 @@ const PlanUpdateSidePanel = () => {
               const price = planMeta?.price ?? 0
               const isDowngradeOption = planMeta?.change_type === 'downgrade'
               const isCurrentPlan = planMeta?.id === subscription?.plan?.id
+              const features = billingViaPartner ? plan.featuresPartner : plan.features
 
               if (plan.id === 'tier_enterprise') {
-                return <EnterpriseCard key={plan.id} plan={plan} isCurrentPlan={isCurrentPlan} />
+                return (
+                  <EnterpriseCard
+                    key={plan.id}
+                    plan={plan}
+                    isCurrentPlan={isCurrentPlan}
+                    billingViaPartner={billingViaPartner}
+                  />
+                )
               }
 
               return (
@@ -287,7 +295,7 @@ const PlanUpdateSidePanel = () => {
                     <div className="border-t my-6" />
 
                     <ul role="list">
-                      {plan.features.map((feature) => (
+                      {features.map((feature) => (
                         <li key={feature} className="flex py-2">
                           <div className="w-[12px]">
                             <IconCheck

--- a/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/PlanUpdateSidePanel.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/PlanUpdateSidePanel.tsx
@@ -201,11 +201,9 @@ const PlanUpdateSidePanel = () => {
               return (
                 <div
                   key={plan.id}
-                  className={clsx(
-                    'border rounded-md px-4 py-4 flex flex-col items-start justify-between',
-                    plan.id === 'tier_enterprise' ? 'col-span-12' : 'col-span-12 md:col-span-4',
-                    plan.id === 'tier_enterprise' ? 'bg-background' : 'bg-surface-200'
-                  )}
+                  className={
+                    'border rounded-md px-4 py-4 flex flex-col items-start justify-between col-span-12 md:col-span-4 bg-surface-200'
+                  }
                 >
                   <div className="w-full">
                     <div className="flex items-center space-x-2">

--- a/packages/shared-data/plans.ts
+++ b/packages/shared-data/plans.ts
@@ -7,6 +7,7 @@ export interface PricingInformation {
   priceLabel?: string
   priceMonthly: number | string
   warning?: string
+  warningPartner?: string
   description: string
   preface: string
   features: string[]
@@ -25,6 +26,7 @@ export const plans: PricingInformation[] = [
     priceLabel: '',
     priceMonthly: 0,
     warning: 'Limit of 2 free organizations',
+    warningPartner: 'Limit of 1 free organization',
     description: 'Perfect for passion projects & simple websites.',
     preface: 'Get started with:',
     features: [

--- a/packages/shared-data/plans.ts
+++ b/packages/shared-data/plans.ts
@@ -10,6 +10,7 @@ export interface PricingInformation {
   description: string
   preface: string
   features: string[]
+  featuresPartner: string[]
   footer?: string
   cta: string
 }
@@ -40,6 +41,13 @@ export const plans: PricingInformation[] = [
       '1-day log retention',
       'Community support',
     ],
+    featuresPartner: [
+      'Unlimited API requests',
+      'Up to 500MB database space',
+      'Up to 5GB bandwidth',
+      '1-day log retention',
+      'Community support',
+    ],
     footer: 'Free projects are paused after 1 week of inactivity.',
     cta: 'Get Started',
   },
@@ -64,6 +72,14 @@ export const plans: PricingInformation[] = [
       '2M Edge Function invocations included',
       '500 concurrent Realtime connections included',
       '5 million Realtime messages included',
+      '7-day log retention',
+      'Email support',
+    ],
+    featuresPartner: [
+      'No project pausing',
+      'Daily backups stored for 7 days',
+      '8GB database space included',
+      '250GB bandwidth included',
       '7-day log retention',
       'Email support',
     ],
@@ -92,6 +108,16 @@ export const plans: PricingInformation[] = [
       'Priority email support & SLAs',
       '28-day log retention',
     ],
+    featuresPartner: [
+      'Additional Organization member roles',
+      'Daily backups stored for 14 days',
+      'Standardised Security Questionnaire',
+      'SOC2',
+      'HIPAA available as paid add-on',
+      'SSO for Supabase Dashboard',
+      'Priority email support & SLAs',
+      '28-day log retention',
+    ],
     footer: 'Additional fees apply for usage beyond included usage.',
     preface: 'Everything in the Pro plan, plus:',
     cta: 'Get Started',
@@ -104,6 +130,12 @@ export const plans: PricingInformation[] = [
     features: [
       `Designated Support manager & SLAs`,
       `On-premise support`,
+      `24×7×365 premium enterprise support`,
+      'Custom Security Questionnaires',
+      `Private Slack channel`,
+    ],
+    featuresPartner: [
+      `Designated Support manager & SLAs`,
       `24×7×365 premium enterprise support`,
       'Custom Security Questionnaires',
       `Private Slack channel`,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Customizes price plan info depending on whether it's a Fly subscription or not

## What is the current behavior?

The side panel for plan updates doesn't take into account the limited feature set for Fly subscriptions

## What is the new behavior?

The price plan info shows the actual feature set and number of free orgs for Fly subscriptions
<img width="505" alt="plan-update-sidepanel-fly" src="https://github.com/supabase/supabase/assets/31189692/875511f0-d753-4a54-bd29-5a085dc992f2">