### PR TITLE
fix performance problem with auth container constantly recreated

### DIFF
--- a/apps/docs/pages/_app.tsx
+++ b/apps/docs/pages/_app.tsx
@@ -9,7 +9,7 @@ import { createClient } from '@supabase/supabase-js'
 import { QueryClientProvider, useQueryClient } from '@tanstack/react-query'
 import { AuthProvider, ThemeProvider, useTelemetryProps, useThemeSandbox } from 'common'
 import { useRouter } from 'next/router'
-import { PropsWithChildren, useCallback, useEffect, useState } from 'react'
+import { type PropsWithChildren, useCallback, useEffect, useState } from 'react'
 import { AppPropsWithLayout } from 'types'
 import { CommandMenuProvider, PortalToast, useConsent } from 'ui'
 import { TabsProvider } from 'ui/src/components/Tabs'
@@ -44,14 +44,7 @@ function SignOutHandler({ children }: PropsWithChildren) {
   return <>{children}</>
 }
 
-function MyApp({ Component, pageProps }: AppPropsWithLayout) {
-  const router = useRouter()
-  const telemetryProps = useTelemetryProps()
-  const { consentValue, hasAcceptedConsent } = useConsent()
-  const queryClient = useRootQueryClient()
-
-  useThemeSandbox()
-
+function AuthContainer({ children }: PropsWithChildren) {
   const [supabase] = useState(() =>
     IS_PLATFORM
       ? createClient(
@@ -60,6 +53,23 @@ function MyApp({ Component, pageProps }: AppPropsWithLayout) {
         )
       : undefined
   )
+
+  return IS_PLATFORM ? (
+    <SessionContextProvider supabaseClient={supabase}>
+      <AuthProvider>{children}</AuthProvider>
+    </SessionContextProvider>
+  ) : (
+    <AuthProvider>{children}</AuthProvider>
+  )
+}
+
+function MyApp({ Component, pageProps }: AppPropsWithLayout) {
+  const router = useRouter()
+  const telemetryProps = useTelemetryProps()
+  const { consentValue, hasAcceptedConsent } = useConsent()
+  const queryClient = useRootQueryClient()
+
+  useThemeSandbox()
 
   const handlePageTelemetry = useCallback(
     (route: string) => {
@@ -175,16 +185,6 @@ function MyApp({ Component, pageProps }: AppPropsWithLayout) {
       window.removeEventListener('popstate', handler)
     }
   }, [router])
-
-  const AuthContainer = ({ children }) => {
-    return IS_PLATFORM ? (
-      <SessionContextProvider supabaseClient={supabase}>
-        <AuthProvider>{children}</AuthProvider>
-      </SessionContextProvider>
-    ) : (
-      <AuthProvider>{children}</AuthProvider>
-    )
-  }
 
   return (
     <>


### PR DESCRIPTION
move the Auth component outside of the MyApp component

now it's stable across renders, rather than being unmounted and remounted every time MyApp renders, which causes its values to be recreated and cascades down to everything using the auth contexts

you can see this most clearly in prod, where the "Dashboard" button flickers on every page navigation, whereas in this preview it no longer flickers