### PR TITLE
refactor: use the platform route instead of v1

### DIFF
--- a/apps/studio/data/oauth/authorized-app-revoke-mutation.ts
+++ b/apps/studio/data/oauth/authorized-app-revoke-mutation.ts
@@ -2,7 +2,7 @@ import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react
 import { toast } from 'react-hot-toast'
 
 import { post } from 'lib/common/fetch'
-import { API_ADMIN_URL } from 'lib/constants'
+import { API_URL } from 'lib/constants'
 import { ResponseError } from 'types'
 import { oauthAppKeys } from './keys'
 
@@ -15,7 +15,7 @@ export async function revokeAuthorizedApp({ id, slug }: AuthorizedAppRevokeVaria
   if (!id) throw new Error('App ID is required')
   if (!slug) throw new Error('Organization slug is required')
 
-  const response = await post(`${API_ADMIN_URL}/organizations/${slug}/oauth/apps/${id}/revoke`, {})
+  const response = await post(`${API_URL}/organizations/${slug}/oauth/apps/${id}/revoke`, {})
   if (response.error) throw response.error
   return response
 }

--- a/apps/studio/data/oauth/authorized-apps-query.ts
+++ b/apps/studio/data/oauth/authorized-apps-query.ts
@@ -1,6 +1,6 @@
 import { useQuery, UseQueryOptions } from '@tanstack/react-query'
 import { get } from 'lib/common/fetch'
-import { API_ADMIN_URL } from 'lib/constants'
+import { API_URL } from 'lib/constants'
 import { oauthAppKeys } from './keys'
 import { ResponseError } from 'types'
 
@@ -19,7 +19,7 @@ export type AuthorizedApp = {
 export async function getAuthorizedApps({ slug }: AuthorizedAppsVariables, signal?: AbortSignal) {
   if (!slug) throw new Error('Organization slug is required')
 
-  const response = await get(`${API_ADMIN_URL}/organizations/${slug}/oauth/apps?type=authorized`, {
+  const response = await get(`${API_URL}/organizations/${slug}/oauth/apps?type=authorized`, {
     signal,
   })
   if (response.error) throw response.error

--- a/apps/studio/data/oauth/oauth-app-create-mutation.ts
+++ b/apps/studio/data/oauth/oauth-app-create-mutation.ts
@@ -3,7 +3,7 @@ import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react
 import { toast } from 'react-hot-toast'
 
 import { post } from 'lib/common/fetch'
-import { API_ADMIN_URL } from 'lib/constants'
+import { API_URL } from 'lib/constants'
 import { ResponseError } from 'types'
 import { oauthAppKeys } from './keys'
 
@@ -30,7 +30,7 @@ export async function createOAuthApp({
   scopes,
   redirect_uris,
 }: OAuthAppCreateVariables) {
-  const response = await post(`${API_ADMIN_URL}/organizations/${slug}/oauth/apps`, {
+  const response = await post(`${API_URL}/organizations/${slug}/oauth/apps`, {
     name,
     website,
     icon,

--- a/apps/studio/data/oauth/oauth-app-delete-mutation.ts
+++ b/apps/studio/data/oauth/oauth-app-delete-mutation.ts
@@ -2,7 +2,7 @@ import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react
 import { toast } from 'react-hot-toast'
 
 import { delete_ } from 'lib/common/fetch'
-import { API_ADMIN_URL } from 'lib/constants'
+import { API_URL } from 'lib/constants'
 import { ResponseError } from 'types'
 import { oauthAppKeys } from './keys'
 
@@ -15,9 +15,7 @@ export async function deleteOAuthApp({ id, slug }: OAuthAppDeleteVariables) {
   if (!id) throw new Error('OAuth app ID is required')
   if (!slug) throw new Error('Organization slug is required')
 
-  const response = await delete_(
-    `${API_ADMIN_URL}/organizations/${slug}/oauth/apps/${id}?type=published`
-  )
+  const response = await delete_(`${API_URL}/organizations/${slug}/oauth/apps/${id}?type=published`)
   if (response.error) throw response.error
   return response
 }

--- a/apps/studio/data/oauth/oauth-app-update-mutation.ts
+++ b/apps/studio/data/oauth/oauth-app-update-mutation.ts
@@ -3,7 +3,7 @@ import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react
 import { toast } from 'react-hot-toast'
 
 import { put } from 'lib/common/fetch'
-import { API_ADMIN_URL } from 'lib/constants'
+import { API_URL } from 'lib/constants'
 import { ResponseError } from 'types'
 import { oauthAppKeys } from './keys'
 
@@ -32,7 +32,7 @@ export async function updateOAuthApp({
   if (!website) throw new Error('OAuth app URL is required')
   if (!redirect_uris || redirect_uris.length === 0) throw new Error('Redirect URIs are required')
 
-  const response = await put(`${API_ADMIN_URL}/organizations/${slug}/oauth/apps/${id}`, {
+  const response = await put(`${API_URL}/organizations/${slug}/oauth/apps/${id}`, {
     name,
     website,
     icon,

--- a/apps/studio/data/oauth/oauth-apps-query.ts
+++ b/apps/studio/data/oauth/oauth-apps-query.ts
@@ -1,7 +1,7 @@
 import { OAuthScope } from '@supabase/shared-types/out/constants'
 import { useQuery, UseQueryOptions } from '@tanstack/react-query'
 import { get } from 'lib/common/fetch'
-import { API_ADMIN_URL } from 'lib/constants'
+import { API_URL } from 'lib/constants'
 import { ResponseError } from 'types'
 import { oauthAppKeys } from './keys'
 
@@ -24,7 +24,7 @@ export type OAuthApp = {
 export async function getOAuthApps({ slug }: OAuthAppsVariables, signal?: AbortSignal) {
   if (!slug) throw new Error('Organization slug is required')
 
-  const response = await get(`${API_ADMIN_URL}/organizations/${slug}/oauth/apps?type=published`, {
+  const response = await get(`${API_URL}/organizations/${slug}/oauth/apps?type=published`, {
     signal,
   })
   if (response.error) throw response.error


### PR DESCRIPTION
## What kind of change does this PR introduce?
* use the `/platform` endpoint instead of the `/v1` endpoint for mutating published and authorized oauth apps in an organization
* API changes were merged in and deployed to prod already (https://github.com/supabase/infrastructure/pull/16328)