### PR TITLE
Downtime note on IPv4 add-on panel

### DIFF
--- a/apps/studio/components/interfaces/Settings/Addons/Addons.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/Addons.tsx
@@ -354,7 +354,7 @@ const Addons = () => {
                     <p className="text-sm text-foreground-light m-0">More information</p>
                     <div>
                       <Link
-                        href="https://github.com/orgs/supabase/discussions/17817"
+                        href="https://supabase.com/docs/guides/platform/ipv4-address"
                         target="_blank"
                         rel="noreferrer"
                       >
@@ -383,7 +383,7 @@ const Addons = () => {
                     <div className="mt-2">
                       <Button asChild type="default" icon={<IconExternalLink strokeWidth={1.5} />}>
                         <a
-                          href="https://github.com/orgs/supabase/discussions/17817"
+                          href="https://supabase.com/docs/guides/platform/ipv4-address"
                           target="_blank"
                           rel="noreferrer"
                         >

--- a/apps/studio/components/interfaces/Settings/Addons/IPv4SidePanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/IPv4SidePanel.tsx
@@ -132,7 +132,7 @@ const IPv4SidePanel = () => {
           <h4>IPv4 address</h4>
           <Button asChild type="default" icon={<IconExternalLink strokeWidth={1.5} />}>
             <Link
-              href="https://github.com/orgs/supabase/discussions/17817"
+              href="https://supabase.com/docs/guides/platform/ipv4-address"
               target="_blank"
               rel="noreferrer"
             >
@@ -238,11 +238,18 @@ const IPv4SidePanel = () => {
                   the future.
                 </p>
               ) : (
-                <p className="text-sm text-foreground-light">
-                  Upon clicking confirm, the amount of{' '}
-                  <span className="text-foreground">${selectedIPv4?.price.toLocaleString()}</span>{' '}
-                  will be added to your monthly invoice.
-                </p>
+                <>
+                  <Alert withIcon variant="info" title="Potential downtime">
+                    There might be some downtime when enabling the add-on since some DNS clients
+                    might have cached the old DNS entry. Generally, this should be less than a
+                    minute.
+                  </Alert>
+                  <p className="text-sm text-foreground-light">
+                    Upon clicking confirm, the amount of{' '}
+                    <span className="text-foreground">${selectedIPv4?.price.toLocaleString()}</span>{' '}
+                    will be added to your monthly invoice.
+                  </p>
+                </>
               )}
             </>
           )}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Informs about potential downtime in IPv4 add-on panel

## What is the new behavior?

User gets informed about a potential downtime once they enable the IPv4 add-on. Furthermore links on the add-ons page and on the IPv4 add-on panel lead you to the docs instead of a GH discussion.
<img width="737" alt="ipv4-panel-downtime-note" src="https://github.com/supabase/supabase/assets/31189692/73dc8f58-aa32-4db5-9dd4-66c5a1f965f3">
