### PR TITLE
fix: copying row values not working

### DIFF
--- a/apps/studio/components/grid/components/grid/Grid.tsx
+++ b/apps/studio/components/grid/components/grid/Grid.tsx
@@ -5,7 +5,6 @@ import DataGrid, { DataGridHandle, RowsChangeData } from 'react-data-grid'
 import AwesomeDebouncePromise from 'awesome-debounce-promise'
 import { forwardRef, useRef } from 'react'
 import { memo } from 'react-tracked'
-
 import { ForeignRowSelectorProps } from 'components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/ForeignRowSelector/ForeignRowSelector'
 import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
 import AlertError from 'components/ui/AlertError'
@@ -108,16 +107,19 @@ export const Grid = memo(
         copyToClipboard(text)
       }
 
-      useKeyboardShortcuts({
-        'Command+c': (event: KeyboardEvent) => {
-          event.stopPropagation()
-          copyCellValue()
+      useKeyboardShortcuts(
+        {
+          'Command+c': (event: KeyboardEvent) => {
+            event.stopPropagation()
+            copyCellValue()
+          },
+          'Control+c': (event: KeyboardEvent) => {
+            event.stopPropagation()
+            copyCellValue()
+          },
         },
-        'Control+c': (event: KeyboardEvent) => {
-          event.stopPropagation()
-          copyCellValue()
-        },
-      })
+        ['INPUT', 'TEXTAREA']
+      )
 
       function onSelectedCellChange(args: { rowIdx: number; row: any; column: any }) {
         selectedCellRef.current = args

--- a/apps/studio/hooks/deprecated.ts
+++ b/apps/studio/hooks/deprecated.ts
@@ -12,7 +12,11 @@ import TooltipListener from 'components/to-be-cleaned/TooltipListener'
  * @param {Array} whitelistClasses  If target class is in the whitelist classes array, will not
  *                                  trigger shortcut event
  */
-function useKeyboardShortcuts(keyMap: any, whitelistNodes = [], whitelistClasses = []) {
+function useKeyboardShortcuts(
+  keyMap: any,
+  whitelistNodes: string[] = [],
+  whitelistClasses: string[] = []
+) {
   const [lastKeydown, setLastKeydown] = useState()
 
   const handleKeydown = (event: any) => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes the issue reported by a user about not being able to copy the values in the row editor.

## What is the current behavior?

The useKeyboardShortcut hook to copy cell values in Grid is preventing ⌘ + v from working in inputs inside the row editor

## What is the new behavior?

Users can copy cell values AND values from the row editor
