### PR TITLE
feat: add email template preview

### DIFF
--- a/apps/studio/components/interfaces/Auth/EmailTemplates/TemplateEditor.tsx
+++ b/apps/studio/components/interfaces/Auth/EmailTemplates/TemplateEditor.tsx
@@ -2,7 +2,7 @@ import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { observer } from 'mobx-react-lite'
 import { useMemo, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
-import { Form, Input } from 'ui'
+import { Form, IconCode, IconMonitor, Tabs, Input } from 'ui'
 
 import CodeEditor from 'components/ui/CodeEditor'
 import { FormActions, FormSection, FormSectionContent, FormSectionLabel } from 'components/ui/Forms'
@@ -38,7 +38,6 @@ const TemplateEditor = ({ template, authConfig }: TemplateEditorProps) => {
   const messageSlug = `MAILER_TEMPLATES_${id}_CONTENT`
   const messageProperty = properties[messageSlug]
   const [bodyValue, setBodyValue] = useState((authConfig && authConfig[messageSlug]) ?? '')
-
   const onSubmit = (values: any, { resetForm }: any) => {
     const payload = { ...values }
 
@@ -130,17 +129,28 @@ const TemplateEditor = ({ template, authConfig }: TemplateEditorProps) => {
                         }
                       />
                     </div>
-                    <div className="relative h-96">
-                      <CodeEditor
-                        id="code-id"
-                        language="html"
-                        isReadOnly={!canUpdateConfig}
-                        className="!mb-0 h-96 overflow-hidden rounded border"
-                        onInputChange={(e: string | undefined) => setBodyValue(e ?? '')}
-                        options={{ wordWrap: 'off', contextmenu: false }}
-                        value={bodyValue}
-                      />
-                    </div>
+                    <Tabs defaultActiveId="preview" type="rounded-pills" size="tiny">
+                      <Tabs.Panel id={'preview'} icon={<IconMonitor />} label="Preview">
+                        <iframe
+                          className="!mb-0 overflow-hidden h-96 w-full rounded border"
+                          title={id}
+                          srcDoc={bodyValue}
+                        />
+                      </Tabs.Panel>
+                      <Tabs.Panel id={'source'} icon={<IconCode />} label="Source">
+                        <div className="relative h-96">
+                          <CodeEditor
+                            id="code-id"
+                            language="html"
+                            isReadOnly={!canUpdateConfig}
+                            className="!mb-0 h-96 overflow-hidden rounded border"
+                            onInputChange={(e: string | undefined) => setBodyValue(e ?? '')}
+                            options={{ wordWrap: 'off', contextmenu: false }}
+                            value={bodyValue}
+                          />
+                        </div>
+                      </Tabs.Panel>
+                    </Tabs>
                   </>
                 )}
                 <div className="col-span-12 flex w-full">

--- a/apps/studio/components/interfaces/Auth/EmailTemplates/TemplateEditor.tsx
+++ b/apps/studio/components/interfaces/Auth/EmailTemplates/TemplateEditor.tsx
@@ -154,7 +154,7 @@ const TemplateEditor = ({ template, authConfig }: TemplateEditorProps) => {
                       </Tabs.Panel>
                       <Tabs.Panel id={'preview'} icon={<IconMonitor />} label="Preview">
                         <Alert_Shadcn_ className="mb-2" variant="default">
-                          <IconInfo />
+                          <IconInfo strokeWidth={1.5} />
                           <AlertTitle_Shadcn_>
                             The preview may differ slightly from the actual rendering in the email
                             client.

--- a/apps/studio/components/interfaces/Auth/EmailTemplates/TemplateEditor.tsx
+++ b/apps/studio/components/interfaces/Auth/EmailTemplates/TemplateEditor.tsx
@@ -2,7 +2,16 @@ import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { observer } from 'mobx-react-lite'
 import { useMemo, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
-import { Form, IconCode, IconMonitor, Tabs, Input } from 'ui'
+import {
+  Form,
+  IconCode,
+  IconMonitor,
+  Tabs,
+  Input,
+  Alert_Shadcn_,
+  IconInfo,
+  AlertTitle_Shadcn_,
+} from 'ui'
 
 import CodeEditor from 'components/ui/CodeEditor'
 import { FormActions, FormSection, FormSectionContent, FormSectionLabel } from 'components/ui/Forms'
@@ -129,14 +138,7 @@ const TemplateEditor = ({ template, authConfig }: TemplateEditorProps) => {
                         }
                       />
                     </div>
-                    <Tabs defaultActiveId="preview" type="rounded-pills" size="tiny">
-                      <Tabs.Panel id={'preview'} icon={<IconMonitor />} label="Preview">
-                        <iframe
-                          className="!mb-0 overflow-hidden h-96 w-full rounded border"
-                          title={id}
-                          srcDoc={bodyValue}
-                        />
-                      </Tabs.Panel>
+                    <Tabs defaultActiveId="source" type="underlined" size="tiny">
                       <Tabs.Panel id={'source'} icon={<IconCode />} label="Source">
                         <div className="relative h-96">
                           <CodeEditor
@@ -149,6 +151,20 @@ const TemplateEditor = ({ template, authConfig }: TemplateEditorProps) => {
                             value={bodyValue}
                           />
                         </div>
+                      </Tabs.Panel>
+                      <Tabs.Panel id={'preview'} icon={<IconMonitor />} label="Preview">
+                        <Alert_Shadcn_ className="mb-2" variant="default">
+                          <IconInfo />
+                          <AlertTitle_Shadcn_>
+                            The preview may differ slightly from the actual rendering in the email
+                            client.
+                          </AlertTitle_Shadcn_>
+                        </Alert_Shadcn_>
+                        <iframe
+                          className="!mb-0 overflow-hidden h-96 w-full rounded border"
+                          title={id}
+                          srcDoc={bodyValue}
+                        />
                       </Tabs.Panel>
                     </Tabs>
                   </>


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Adds the option to preview your email templates

## What is the new behavior?

Default to show preview first:
<img width="1712" alt="image" src="https://github.com/supabase/supabase/assets/28647601/fef15758-1722-42ad-aa17-f0725980eba5">

Toggling to show the html source code:
<img width="1699" alt="image" src="https://github.com/supabase/supabase/assets/28647601/932e1a89-56ec-44e7-9990-f2bf5dc96ad8">

## What is the current behavior?

No option to preview email templates - developers are forced to send out a test email to themselves to check that the email is being rendered correctly
