### PR TITLE
docs: rls comments warning

### DIFF
--- a/apps/docs/pages/learn/auth-deep-dive/auth-row-level-security.mdx
+++ b/apps/docs/pages/learn/auth-deep-dive/auth-row-level-security.mdx
@@ -110,6 +110,12 @@ If you'd prefer to use the dashboard to add your policy you can do so by clickin
 
 ![Add a read only policy in Supabase](/docs/img/auth-deep-dive-2-2.png)
 
+<Admonition type="caution">
+
+Please note that comments are not supported when using RLS policies via the dashboard.
+
+</Admonition>
+
 You should now be able to read from your leaderboard, but will still not be able to write, update, or delete from it, which is exactly what we wanted!
 
 A quick reminder that you can always use your `service_role` API key to bypass these row level security policies. But be extra careful that you don't leak this key by including it in the client. This can be useful if you're building internal admin tools, or if you need to bulk insert or delete data via the API.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs - RLS Comments

## What is the current behavior?

Comments cause an issue when adding RLS via the dashboard.

## What is the new behavior?

Added a new warning in the RLS deep dive guide:

<img width="1440" alt="Screenshot 2024-01-23 at 21 05 45" src="https://github.com/supabase/supabase/assets/22655069/af5c5af4-299e-4d2c-8a51-fdeb436c30ad">

## Additional context

Closes #17600
