### PR TITLE
docs: remove references to Basic Authentication Message on twilio whatsapp guide

### DIFF
--- a/apps/docs/pages/guides/auth/phone-login/twilio.mdx
+++ b/apps/docs/pages/guides/auth/phone-login/twilio.mdx
@@ -415,17 +415,11 @@ Twilio Verify can be used with WhatsApp OTPs with no additional configuration.
 Complete the following steps to use WhatsApp OTP with Twilio Programmable Messaging:
 
 1. Go through the [Twilio self sign up guide for WhatsApp](https://www.twilio.com/docs/whatsapp/self-sign-up).
-2. [Register a Twilio Content Template](https://www.twilio.com/docs/content/whatsappauthentication) and note the corresponding Twilio Content SID.
+2. Register a Twilio Content Template via the [API](https://www.twilio.com/docs/content/whatsappauthentication) and note the corresponding Twilio Content SID. You can also use the Template Builder on the dashboard to create a template and obtain the Content SID (see screenshot below) 
 ![Twilio Content SID Image](/docs/img/guides/auth-twilio/twilio_content_sid.png)
 3. Register the Twilio Content SID on the Supabase dashboard under Authentication > Providers > Phone > Twilio Content SID. Ensure you have Twilio selected as your phone provider.
 
-Note that you may only use one Twilio Content SID at a time and that it will take precedence over the `SMS Message` field when using WhatsApp. Use Twilio Verify if you require internationalization for your message template.
-
-<Admonition type="caution">
-
-Twilio Programmable Messaging (WhatsApp) can only be used with the Basic Authentication Message. For advanced customization options, please use Twilio Verify.
-
-</Admonition>
+Note that you may only use one Twilio Content SID at a time and that Supabase Auth will use the Content Template over the `SMS Message` field when sending WhatsApp messages. Use Twilio Verify if you need to use multiple message templates.
 
 The sign in process with WhatsApp is similar to the sign in process for SMS. Do note the additional `whatsapp` parameter added:
 

--- a/apps/docs/pages/guides/auth/phone-login/twilio.mdx
+++ b/apps/docs/pages/guides/auth/phone-login/twilio.mdx
@@ -415,8 +415,8 @@ Twilio Verify can be used with WhatsApp OTPs with no additional configuration.
 Complete the following steps to use WhatsApp OTP with Twilio Programmable Messaging:
 
 1. Go through the [Twilio self sign up guide for WhatsApp](https://www.twilio.com/docs/whatsapp/self-sign-up).
-2. Register a Twilio Content Template via the [API](https://www.twilio.com/docs/content/whatsappauthentication) and note the corresponding Twilio Content SID. You can also use the Template Builder on the dashboard to create a template and obtain the Content SID (see screenshot below) 
-![Twilio Content SID Image](/docs/img/guides/auth-twilio/twilio_content_sid.png)
+2. Register a Twilio Content Template via the [API](https://www.twilio.com/docs/content/whatsappauthentication) and note the corresponding Twilio Content SID. You can also use the Template Builder on the dashboard to create a template and obtain the Content SID (see screenshot below)
+   ![Twilio Content SID Image](/docs/img/guides/auth-twilio/twilio_content_sid.png)
 3. Register the Twilio Content SID on the Supabase dashboard under Authentication > Providers > Phone > Twilio Content SID. Ensure you have Twilio selected as your phone provider.
 
 Note that you may only use one Twilio Content SID at a time and that Supabase Auth will use the Content Template over the `SMS Message` field when sending WhatsApp messages. Use Twilio Verify if you need to use multiple message templates.

--- a/apps/docs/pages/guides/auth/phone-login/twilio.mdx
+++ b/apps/docs/pages/guides/auth/phone-login/twilio.mdx
@@ -415,11 +415,11 @@ Twilio Verify can be used with WhatsApp OTPs with no additional configuration.
 Complete the following steps to use WhatsApp OTP with Twilio Programmable Messaging:
 
 1. Go through the [Twilio self sign up guide for WhatsApp](https://www.twilio.com/docs/whatsapp/self-sign-up).
-2. Register a Twilio Content Template via the [API](https://www.twilio.com/docs/content/whatsappauthentication) and note the corresponding Twilio Content SID. You can also use the Template Builder on the dashboard to create a template and obtain the Content SID (see screenshot below)
+2. Register a Twilio Content Template via the [API](https://www.twilio.com/docs/content/whatsappauthentication) and note the corresponding Twilio Content SID. You can also use the Template Builder on the Twilio dashboard to create a Content Template
    ![Twilio Content SID Image](/docs/img/guides/auth-twilio/twilio_content_sid.png)
 3. Register the Twilio Content SID on the Supabase dashboard under Authentication > Providers > Phone > Twilio Content SID. Ensure you have Twilio selected as your phone provider.
 
-Note that you may only use one Twilio Content SID at a time and that Supabase Auth will use the Content Template over the `SMS Message` field when sending WhatsApp messages. Use Twilio Verify if you need to use multiple message templates.
+Note that you may only use one Twilio Content SID at a time and that Supabase Auth will use the Content Template over the `SMS Message` field when sending WhatsApp messages. Use Twilio Verify if you need to use more than one message template.
 
 The sign in process with WhatsApp is similar to the sign in process for SMS. Do note the additional `whatsapp` parameter added:
 

--- a/apps/docs/pages/guides/auth/phone-login/twilio.mdx
+++ b/apps/docs/pages/guides/auth/phone-login/twilio.mdx
@@ -415,12 +415,11 @@ Twilio Verify can be used with WhatsApp OTPs with no additional configuration.
 Complete the following steps to use WhatsApp OTP with Twilio Programmable Messaging:
 
 1. Go through the [Twilio self sign up guide for WhatsApp](https://www.twilio.com/docs/whatsapp/self-sign-up).
-2. Follow the [Twilio Guide for Submitting Templates](https://www.twilio.com/docs/whatsapp/tutorial/send-whatsapp-notification-messages-templates#creating-message-templates-and-submitting-them-for-approval) and submit a Basic Authentication Message for approval.
-
-Alternatively, you can register a Twilio Content SID which corresponds to a message template.
+2. [Register a Twilio Content Template](https://www.twilio.com/docs/content/whatsappauthentication) and note the corresponding Twilio Content SID.
 ![Twilio Content SID Image](/docs/img/guides/auth-twilio/twilio_content_sid.png)
+3. Register the Twilio Content SID on the Supabase dashboard under Authentication > Providers > Phone > Twilio Content SID. Ensure you have Twilio selected as your phone provider.
 
-Note that you may only use one Twilio Content SID at a time. Use Twilio Verify or the Basic Authentication Message if you require internationalization for your message template.
+Note that you may only use one Twilio Content SID at a time and that it will take precedence over the `SMS Message` field when using WhatsApp. Use Twilio Verify if you require internationalization for your message template.
 
 <Admonition type="caution">
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Prompted by a few old issues that emerged: https://supabase.slack.com/archives/C022071RB2L/p1706003151318769

Also removes references to the Basic Authentication Message as that will likely be deprecated in the next few months in view of [Twilio's deprecation of Twilio WhatsApp Templates](https://support.twilio.com/hc/en-us/articles/19816296822299-Upgrading-WhatsApp-Templates-to-Content-Templates)