### PR TITLE
docs: branching change sync to pull

### DIFF
--- a/apps/docs/pages/guides/platform/branching.mdx
+++ b/apps/docs/pages/guides/platform/branching.mdx
@@ -147,9 +147,9 @@ You can use the [Supabase CLI](/docs/guides/cli) to manage changes inside a loca
     </StepHikeCompact.Step>
 
     <StepHikeCompact.Step step={2}>
-        <StepHikeCompact.Details title="Sync your database migration" fullWidth>
+        <StepHikeCompact.Details title="Pull your database migration" fullWidth>
 
-            Sync your database changes using `supabase db pull`. You can find your database URL in your [database settings](https://supabase.com/dashboard/project/_/settings/database), under the URI tab of the Connection String settings panel.
+            Pull your database changes using `supabase db pull`. You can find your database URL in your [database settings](https://supabase.com/dashboard/project/_/settings/database), under the URI tab of the Connection String settings panel.
 
             <CH.Code lineNumbers={false}>
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase Docs - [Branching](https://supabase.com/docs/guides/platform/branching#preparing-your-git-repository)

Changing the word `sync` to `pull`
