### PR TITLE
Update Array methods in docs from `cs` and `cd` to `contains` and `containedBy`

### DIFF
--- a/apps/studio/components/interfaces/Docs/Snippets.ts
+++ b/apps/studio/components/interfaces/Docs/Snippets.ts
@@ -366,8 +366,8 @@ let { data: ${resourceId}, error } = await supabase
   .in('column', ['Array', 'Values'])
   .neq('column', 'Not equal to')
   // Arrays
-  .cs('array_column', ['array', 'contains'])
-  .cd('array_column', ['contained', 'by'])
+  .contains('array_column', ['array', 'contains'])
+  .containedBy('array_column', ['contained', 'by'])
 `,
     },
   }),

--- a/apps/studio/components/interfaces/ProjectAPIDocs/ProjectAPIDocs.constants.ts
+++ b/apps/studio/components/interfaces/ProjectAPIDocs/ProjectAPIDocs.constants.ts
@@ -745,8 +745,8 @@ let { data: ${resourceId}, error } = await supabase
   .neq('column', 'Not equal to')
 
   // Arrays
-  .cs('array_column', ['array', 'contains'])
-  .cd('array_column', ['contained', 'by'])
+  .contains('array_column', ['array', 'contains'])
+  .containedBy('array_column', ['contained', 'by'])
           `,
         },
       ]


### PR DESCRIPTION
## What kind of change does this PR introduce?

Closes #18036 by updating docs to show correct Array methods

## What is the current behavior?

Docs currently show methods (`cs` and `cd`) that are no longer used

