### PR TITLE
feat: add reports navigation items to cmdk menu

### DIFF
--- a/packages/ui/src/components/Command/utils/shared-nav-items.json
+++ b/packages/ui/src/components/Command/utils/shared-nav-items.json
@@ -111,6 +111,28 @@
       ]
     },
     {
+      "label": "Reports",
+      "url": "/project/_/reports",
+      "subItems": [
+        {
+          "label": "API reports",
+          "url": "/project/_/reports/api-overview"
+        },
+        {
+          "label": "Storage reports",
+          "url": "/project/_/reports/storage"
+        },
+        {
+          "label": "Database reports",
+          "url": "/project/_/reports/database"
+        },
+        {
+          "label": "Query performance reports",
+          "url": "/project/_/reports/query-performance"
+        }
+      ]
+    },
+    {
       "label": "API Docs",
       "url": "/project/_/api",
       "subItems": [


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Adds reports navigation items to cmdk menu
- 
## What is the current behavior?

cant navigate to reports screens from cmdk menu

## What is the new behavior?

you can do that

## Additional context

![CleanShot 2024-01-25 at 11 03 39@2x](https://github.com/supabase/supabase/assets/37541088/e33a4392-93f7-4601-a094-3eac8d23ec56)