### PR TITLE
fix some styling in command menu

### DIFF
--- a/packages/ui/src/components/Command/AiCommand.tsx
+++ b/packages/ui/src/components/Command/AiCommand.tsx
@@ -377,7 +377,7 @@ const AiCommand = () => {
 
   return (
     <div onClick={(e) => e.stopPropagation()}>
-      <div className={cn('relative mb-[145px] py-4 max-h-[720px] overflow-auto')}>
+      <div className={cn('relative mb-[145px] py-4 max-h-[720px]')}>
         {!hasError &&
           messages.map((message, index) => {
             switch (message.role) {
@@ -399,7 +399,7 @@ const AiCommand = () => {
                 )
               case MessageRole.Assistant:
                 return (
-                  <div key={index} className="px-4 [overflow-anchor:none] mb-6">
+                  <div key={index} className="px-4 [overflow-anchor:none] mb-[150px]">
                     <div className="flex gap-6 [overflow-anchor:none] mb-6">
                       <AiIconChat
                         loading={

--- a/packages/ui/src/components/Command/CommandMenu.tsx
+++ b/packages/ui/src/components/Command/CommandMenu.tsx
@@ -84,7 +84,11 @@ const CommandMenu = () => {
   }
 
   const commandListMaxHeight =
-    currentPage === COMMAND_ROUTES.DOCS_SEARCH ? 'min(600px, 50vh)' : '300px'
+    currentPage === COMMAND_ROUTES.DOCS_SEARCH ||
+    currentPage === COMMAND_ROUTES.AI ||
+    currentPage === COMMAND_ROUTES.GENERATE_SQL
+      ? 'min(600px, 50vh)'
+      : '300px'
 
   return (
     <>
@@ -113,7 +117,12 @@ const CommandMenu = () => {
         <CommandList
           style={{
             maxHeight: commandListMaxHeight,
-            height: currentPage === COMMAND_ROUTES.DOCS_SEARCH ? commandListMaxHeight : 'auto',
+            height:
+              currentPage === COMMAND_ROUTES.DOCS_SEARCH ||
+              currentPage === COMMAND_ROUTES.AI ||
+              currentPage === COMMAND_ROUTES.GENERATE_SQL
+                ? commandListMaxHeight
+                : 'auto',
           }}
           className="my-2"
         >

--- a/packages/ui/src/components/Command/GenerateSQL/GenerateSQL.tsx
+++ b/packages/ui/src/components/Command/GenerateSQL/GenerateSQL.tsx
@@ -129,7 +129,7 @@ const GenerateSQL = () => {
                 answer.replace(/^-- /, '') === "Sorry, I don't know how to help with that."
 
               return (
-                <div className="px-4 [overflow-anchor:none] mb-6">
+                <div className="px-4 [overflow-anchor:none] mb-[150px]">
                   <div className="flex gap-6 [overflow-anchor:none] mb-6">
                     <div>
                       <AiIconChat


### PR DESCRIPTION
Get rid of the double scrollbar problem in Supabase AI
Also expand the command menu height when using Supabase AI because there's not enough room to read

![image](https://github.com/supabase/supabase/assets/26616127/b9c897ef-3aaf-46a4-9698-c723073f77c7)
![image](https://github.com/supabase/supabase/assets/26616127/aa6fc802-3e79-4d61-8b8e-32e9120ab9a8)


