### PR TITLE
fix: SSR warning for aria-selected prop

### DIFF
--- a/packages/ui/src/components/NavMenu/index.tsx
+++ b/packages/ui/src/components/NavMenu/index.tsx
@@ -27,7 +27,7 @@ export const NavMenuItem = ({
   active: boolean
 }>) => (
   <li
-    aria-selected={props.active}
+    aria-selected={props.active ? 'true' : 'false'}
     data-state={props.active ? 'active' : 'inactive'}
     className={cn(
       'inline-flex items-center justify-center whitespace-nowrap text-sm ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground text-foreground-lighter hover:text-foreground data-[state=active]:border-foreground border-b-2 border-transparent *:px-3 *:py-1.5',


### PR DESCRIPTION
When rendering via SSR

```
Warning: Received `false` for a non-boolean attribute `active`.

If you want to write it to the DOM, pass a string instead: active="false" or active={value.toString()}.

If you used to conditionally omit it with active={condition && value}, pass active={condition ? value : undefined} instead.
 ....
```

PR fixes the warning. `.toString()` did not work as it does not satisfy TS types