### PR TITLE
fix: invalid next config warning

### DIFF
--- a/apps/studio/next.config.js
+++ b/apps/studio/next.config.js
@@ -81,7 +81,7 @@ const nextConfig = {
     // [Kevin] Next polyfills Node modules like Crypto by default, blowing up the bundle size. We use generate-password-browser (safe to use in browser) and the polyfills are not needed for us
     // Revisit on Next 14 upgrade (PR #19909)
     // [Ivan] Temporarily enable until we find a fix for breaking anon-role in the Realtime inspector
-    fallbackNodePolyfills: true,
+    // fallbackNodePolyfills: false,
   },
   async redirects() {
     return [


### PR DESCRIPTION
Fixes

> Invalid next.config.js options detected: 
> ⚠     Invalid literal value, expected false at "experimental.fallbackNodePolyfills"

Allowed values are only `false` and `undefined` 🤡 