### PR TITLE
Chore/jwt modal warning update

### DIFF
--- a/apps/studio/components/interfaces/Settings/API/JWTSettings.tsx
+++ b/apps/studio/components/interfaces/Settings/API/JWTSettings.tsx
@@ -232,7 +232,7 @@ const JWTSettings = () => {
               Generating a new JWT secret will invalidate <u className="text-foreground">all</u> of
               your API keys, including your <code className="text-xs">service_role</code> and{' '}
               <code className="text-xs">anon</code> keys. Your project will also be restarted during
-              this process, which will terminate any existing connections.
+              this process, which will terminate any existing connections. You may receive API errors for up to 2 minutes while the keys are deployed.
             </AlertDescription_Shadcn_>
           </Alert_Shadcn_>
           <p className="text-foreground text-sm">

--- a/apps/studio/components/interfaces/Settings/API/JWTSettings.tsx
+++ b/apps/studio/components/interfaces/Settings/API/JWTSettings.tsx
@@ -232,7 +232,7 @@ const JWTSettings = () => {
               Generating a new JWT secret will invalidate <u className="text-foreground">all</u> of
               your API keys, including your <code className="text-xs">service_role</code> and{' '}
               <code className="text-xs">anon</code> keys. Your project will also be restarted during
-              this process, which will terminate any existing connections. You may receive API errors for up to 2 minutes while the keys are deployed.
+              this process, which will terminate any existing connections. You may receive API errors for up to 2 minutes while the new secret is deployed.
             </AlertDescription_Shadcn_>
           </Alert_Shadcn_>
           <p className="text-foreground text-sm">

--- a/apps/studio/components/interfaces/Settings/API/JWTSettings.tsx
+++ b/apps/studio/components/interfaces/Settings/API/JWTSettings.tsx
@@ -232,7 +232,8 @@ const JWTSettings = () => {
               Generating a new JWT secret will invalidate <u className="text-foreground">all</u> of
               your API keys, including your <code className="text-xs">service_role</code> and{' '}
               <code className="text-xs">anon</code> keys. Your project will also be restarted during
-              this process, which will terminate any existing connections. You may receive API errors for up to 2 minutes while the new secret is deployed.
+              this process, which will terminate any existing connections. You may receive API
+              errors for up to 2 minutes while the new secret is deployed.
             </AlertDescription_Shadcn_>
           </Alert_Shadcn_>
           <p className="text-foreground text-sm">


### PR DESCRIPTION
## What kind of change does this PR introduce?

Improved Modal text

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Includes a note that the API may return errors for up to 2 minutes after JWT secret rotation.
<img width="487" alt="Screenshot 2024-01-26 at 22 02 44" src="https://github.com/supabase/supabase/assets/1923424/2d077235-01e6-4ea4-8ae4-19f9125f114f">



## Additional context

Adds accurate expectations for API behavior when rotating JWT keys.