### PR TITLE
docs: React Native tutorial avatar implementation rework

### DIFF
--- a/apps/docs/pages/guides/getting-started/tutorials/with-expo-react-native.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-expo-react-native.mdx
@@ -451,10 +451,10 @@ photos and videos.
 
 ### Additional dependency installation
 
-You will need a file picker that works on the environment you will build the project for, we will use react-native-document-picker in this example.
+You will need an image picker that works on the environment you will build the project for, we will use `expo-image-picker` in this example.
 
 ```bash
-expo install react-native-document-picker
+expo install expo-image-picker
 ```
 
 ### Create an upload widget
@@ -466,7 +466,7 @@ We can start by creating a new component:
 import { useState, useEffect } from 'react'
 import { supabase } from '../lib/supabase'
 import { StyleSheet, View, Alert, Image, Button } from 'react-native'
-import DocumentPicker, { isCancel, isInProgress, types } from 'react-native-document-picker'
+import * as ImagePicker from 'expo-image-picker'
 
 interface Props {
   size: number
@@ -507,42 +507,43 @@ export default function Avatar({ url, size = 150, onUpload }: Props) {
     try {
       setUploading(true)
 
-      const file = await DocumentPicker.pickSingle({
-        presentationStyle: 'fullScreen',
-        copyTo: 'cachesDirectory',
-        type: types.images,
-        mode: 'open',
+      const result = await ImagePicker.launchImageLibraryAsync({ 
+        mediaTypes: ImagePicker.MediaTypeOptions.Images, // Restrict to only images
+        allowsMultipleSelection: false, // Can only select one image
+        allowsEditing: true, // Allows the user to crop / rotate their photo before uploading it
+        quality: 1,
+        exif: false // We don't want nor need that data.
       })
 
-      const photo = {
-        uri: file.fileCopyUri,
-        type: file.type,
-        name: file.name,
+      if (result.canceled || !result.assets || result.assets.length === 0) {
+        console.log("User cancelled image picker.");
+        return;
       }
 
-      const formData = new FormData()
-      formData.append('file', photo)
+      const image = result.assets[0]
+      console.log("Got image", image)
 
-      const fileExt = file.name.split('.').pop()
-      const filePath = `${Math.random()}.${fileExt}`
-
-      const { error } = await supabase.storage.from('avatars').upload(filePath, formData)
-
-      if (error) {
-        throw error
+      if (!image.uri) {
+        throw new Error("No image uri!") // Realistically, this should never happen, but just in case...
+        return;
       }
 
-      onUpload(filePath)
+      const arraybuffer = await fetch(image.uri).then(res => res.arrayBuffer())
+
+      const fileExt = image.fileName?.split(".").pop()?.toLowerCase() ?? "jpeg"
+      const path = `${Date.now()}.${fileExt}`
+      const { data, error: uploadError } = await supabase.storage.from("avatars")
+        .upload(path, arraybuffer)
+
+      if (uploadError) {
+        throw uploadError;
+      }
+
+      onUpload(data.path);
     } catch (error) {
-      if (isCancel(error)) {
-        console.warn('cancelled')
-        // User cancelled the picker, exit any dialogs or menus and move on
-      } else if (isInProgress(error)) {
-        console.warn('multiple pickers were opened, only the last will be considered')
-      } else if (error instanceof Error) {
-        Alert.alert(error.message)
-      } else {
-        throw error
+      console.error("Error uploading image: ", error);
+      if (error instanceof Error) {
+        Alert.alert("Error uploading image", error.message);
       }
     } finally {
       setUploading(false)


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR aims to fix the current implementation of how the developer uploads avatars to Supabase storage when bootstrapping their React Native project with Expo.

## What is the current behavior?

Currently, the developer utilizes the package `react-native-document-picker`. While this is not *technically* incorrect- the user *could* select an image from their filesystem- it's not one that provides the most optimal UX.

## What is the new behavior?

This PR replaces the `react-native-document-picker` package with `expo-image-picker`, which provides an easier access to the end user's photos to upload as an avatar for their account. I believe it is safe to assume that the developer is using expo for this project, since this page explicitly instructs the developer to bootstrap their React Native project with Expo. It also, since this is not a drop-in replacement, changes the way that the `uploadAvatar()` function is implemented to account for the differences between the packages, such as cancellation detection. Check the diff for more.

## Additional context

There were a couple different methods that I tried here, namely fetching the image returned by expo by its URI and converting the image to a Blob format. This did not appear to work, as [Blobs are not natively supported by React Native](https://github.com/react-native-community/discussions-and-proposals/issues/109). I ended up using array buffers and uploading the image data that way, as you can see with this PR.

Also, and this could be a point of discussion, is there a particular reason as to why these functions are just regular ol' `const`s and not utilizing `React.useCallback()`?
