### PR TITLE
fix typo

### DIFF
--- a/apps/docs/pages/guides/getting-started/quickstarts/laravel.mdx
+++ b/apps/docs/pages/guides/getting-started/quickstarts/laravel.mdx
@@ -123,7 +123,7 @@ export const meta = {
   <StepHikeCompact.Step step={6}>
     <StepHikeCompact.Details title="Start the app">
 
-    Run the development server. Go to http://127.0.0.1:8000 in a browser to see your application. You can also nvaigate to http://127.0.0.1:8000/register and http://127.0.0.1:8000/login to register and log in users.
+    Run the development server. Go to http://127.0.0.1:8000 in a browser to see your application. You can also navigate to http://127.0.0.1:8000/register and http://127.0.0.1:8000/login to register and log in users.
 
     </StepHikeCompact.Details>
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Simple typo fix, nvaigate -> navigate.

## What is the current behavior?

It's currently spelled "nvaigate".

## What is the new behavior?

It will now be correctly spelled "navigate".

## Additional context

https://www.dictionary.com/browse/navigate