### PR TITLE
fix: get tokenizer working again for Supabase AI

### DIFF
--- a/supabase/functions/common/tokenizer.ts
+++ b/supabase/functions/common/tokenizer.ts
@@ -1,19 +1,7 @@
-import { init, Tiktoken } from 'https://esm.sh/@dqbd/tiktoken@1.0.2/lite/init'
+import { getEncoding } from 'https://esm.sh/js-tiktoken@1.0.10'
 import { ChatCompletionRequestMessage } from 'https://esm.sh/v113/openai@3.2.1'
 
-const encoderResponse = await fetch('https://esm.sh/@dqbd/tiktoken@1.0.2/encoders/cl100k_base.json')
-const cl100kBase = await encoderResponse.json()
-
-await init(async (imports) => {
-  const req = await fetch('https://esm.sh/@dqbd/tiktoken/lite/tiktoken_bg.wasm')
-  return WebAssembly.instantiate(await req.arrayBuffer(), imports)
-})
-
-export const tokenizer = new Tiktoken(
-  cl100kBase.bpe_ranks,
-  cl100kBase.special_tokens,
-  cl100kBase.pat_str
-)
+export const tokenizer = getEncoding('cl100k_base')
 
 /**
  * Count the tokens for multi-message chat completion requests


### PR DESCRIPTION
AI responses suddenly broke because of WASM compatibility issues

`@dqbd/tiktoken` has now been split into two packages, one of which is `js-tiktoken`, which doesn't require WASM and should work better on Edge environments
switching to that seems to fix things