### PR TITLE
Docs: Update AI guides to reference pooler connection string

### DIFF
--- a/apps/docs/pages/guides/ai/examples/headless-vector-search.mdx
+++ b/apps/docs/pages/guides/ai/examples/headless-vector-search.mdx
@@ -37,7 +37,7 @@ There are 3 steps to build similarity search inside your documentation:
 
 ### Prepare your database
 
-To prepare, create a [new Supabase project](https://database.new) and store the database and API credentials, which you can find in the project [settings](https://supabase.com/dashboard/_/settings).
+To prepare, create a [new Supabase project](https://database.new) and store the database and API credentials, which you can find in the project [settings](https://supabase.com/dashboard/project/_/settings).
 
 Now we can use the [Headless Vector Search](https://github.com/supabase/headless-vector-search#set-up) instructions to set up the database:
 

--- a/apps/docs/pages/guides/ai/google-colab.mdx
+++ b/apps/docs/pages/guides/ai/google-colab.mdx
@@ -39,7 +39,7 @@ pip install vecs
 
 ## Connect to your database
 
-Find the Postgres pooler connection string for your Supabase project in the [database settings](https://supabase.com/dashboard/_/settings/database) of the dashboard. Copy the "URI" format, which should look something like `postgres://postgres.xxxx:password@xxxx.pooler.supabase.com:6543/postgres`
+Find the Postgres pooler connection string for your Supabase project in the [database settings](https://supabase.com/dashboard/project/_/settings/database) of the dashboard. Copy the "URI" format, which should look something like `postgres://postgres.xxxx:password@xxxx.pooler.supabase.com:6543/postgres`
 
 Create a new code block below the install block (`ctrl+m b`) and add the following code using the Postgres URI you copied above:
 

--- a/apps/docs/pages/guides/ai/integrations/llamaindex.mdx
+++ b/apps/docs/pages/guides/ai/integrations/llamaindex.mdx
@@ -1,3 +1,4 @@
+import { Admonition } from 'ui'
 import Layout from '~/layouts/DefaultGuideLayout'
 
 export const meta = {
@@ -46,7 +47,19 @@ DB_CONNECTION = "postgresql://<user>:<password>@<host>:<port>/<db_name>"
 vx = vecs.create_client(DB_CONNECTION)
 ```
 
-Replace the `DB_CONNECTION` with your own connection string for your database, which you set up in first step of this guide.
+Replace the `DB_CONNECTION` with your own connection string for your database. You can find the Postgres connection string in the [Database Settings](https://supabase.com/dashboard/project/_/settings/database) of your Supabase project.
+
+<Admonition type='note'>
+
+SQLAlchemy requires the connection string to start with `postgresql://` (instead of `postgres://`). Don't forget to rename this after copying the string from the dashboard.
+
+</Admonition>
+
+<Admonition type='note'>
+
+You must use the "connection pooling" string (domain ending in `*.pooler.supabase.com`) with Google Colab since Colab does not support IPv6.
+
+</Admonition>
 
 ## Stepping through the notebook
 

--- a/apps/docs/pages/guides/ai/quickstarts/face-similarity.mdx
+++ b/apps/docs/pages/guides/ai/quickstarts/face-similarity.mdx
@@ -1,5 +1,5 @@
+import { Admonition } from 'ui'
 import Layout from '~/layouts/DefaultGuideLayout'
-
 export const meta = {
   id: 'ai-vecs-python-client',
   title: 'Face similarity search',
@@ -43,7 +43,19 @@ DB_CONNECTION = "postgresql://<user>:<password>@<host>:<port>/<db_name>"
 vx = vecs.create_client(DB_CONNECTION)
 ```
 
-Replace the `DB_CONNECTION` with your own connection string for your database, which you set up in first step of this guide.
+Replace the `DB_CONNECTION` with your own connection string for your database. You can find the Postgres connection string in the [Database Settings](https://supabase.com/dashboard/project/_/settings/database) of your Supabase project.
+
+<Admonition type='note'>
+
+SQLAlchemy requires the connection string to start with `postgresql://` (instead of `postgres://`). Don't forget to rename this after copying the string from the dashboard.
+
+</Admonition>
+
+<Admonition type='note'>
+
+You must use the "connection pooling" string (domain ending in `*.pooler.supabase.com`) with Google Colab since Colab does not support IPv6.
+
+</Admonition>
 
 ## Stepping through the notebook
 

--- a/apps/docs/pages/guides/ai/quickstarts/hello-world.mdx
+++ b/apps/docs/pages/guides/ai/quickstarts/hello-world.mdx
@@ -1,3 +1,4 @@
+import { Admonition } from 'ui'
 import Layout from '~/layouts/DefaultGuideLayout'
 
 export const meta = {
@@ -43,7 +44,19 @@ DB_CONNECTION = "postgresql://<user>:<password>@<host>:<port>/<db_name>"
 vx = vecs.create_client(DB_CONNECTION)
 ```
 
-Replace the `DB_CONNECTION` with your own connection string for your database, which you set up in first step of this guide.
+Replace the `DB_CONNECTION` with your own connection string for your database. You can find the Postgres connection string in the [Database Settings](https://supabase.com/dashboard/project/_/settings/database) of your Supabase project.
+
+<Admonition type='note'>
+
+SQLAlchemy requires the connection string to start with `postgresql://` (instead of `postgres://`). Don't forget to rename this after copying the string from the dashboard.
+
+</Admonition>
+
+<Admonition type='note'>
+
+You must use the "connection pooling" string (domain ending in `*.pooler.supabase.com`) with Google Colab since Colab does not support IPv6.
+
+</Admonition>
 
 ## Stepping through the notebook
 

--- a/apps/docs/pages/guides/ai/quickstarts/text-deduplication.mdx
+++ b/apps/docs/pages/guides/ai/quickstarts/text-deduplication.mdx
@@ -1,5 +1,6 @@
-import Layout from '~/layouts/DefaultGuideLayout'
+import { Admonition } from 'ui'
 import HuggingFaceDeployment from '~/components/MDX/ai/quickstart_hf_deployment.mdx'
+import Layout from '~/layouts/DefaultGuideLayout'
 
 export const meta = {
   id: 'ai-vecs-python-client',
@@ -44,7 +45,19 @@ DB_CONNECTION = "postgresql://<user>:<password>@<host>:<port>/<db_name>"
 vx = vecs.create_client(DB_CONNECTION)
 ```
 
-Replace the `DB_CONNECTION` with your own connection string for your database, which you set up in first step of this guide.
+Replace the `DB_CONNECTION` with your own connection string for your database. You can find the Postgres connection string in the [Database Settings](https://supabase.com/dashboard/project/_/settings/database) of your Supabase project.
+
+<Admonition type='note'>
+
+SQLAlchemy requires the connection string to start with `postgresql://` (instead of `postgres://`). Don't forget to rename this after copying the string from the dashboard.
+
+</Admonition>
+
+<Admonition type='note'>
+
+You must use the "connection pooling" string (domain ending in `*.pooler.supabase.com`) with Google Colab since Colab does not support IPv6.
+
+</Admonition>
 
 ## Stepping through the notebook
 

--- a/examples/ai/face_similarity.ipynb
+++ b/examples/ai/face_similarity.ipynb
@@ -23,6 +23,16 @@
   },
   {
    "cell_type": "markdown",
+   "id": "69e93981",
+   "metadata": {},
+   "source": [
+    "## Setup GPU on Google Colab\n",
+    "\n",
+    "If you are running this in Google Colab, you must first ensure that the GPU is enabled. You can set this by navigating to **Runtime** > **Change runtime type**, then choose one of the available GPUs under **Hardware Accelerator**."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "3cab93f5-10d0-47c5-9f4e-64921461e7e2",
    "metadata": {},
    "source": [
@@ -189,7 +199,15 @@
     "## Initialize the Vecs Collection\n",
     "\n",
     "The [`vecs`](https://supabase.github.io/vecs/api/) library wraps a pythonic interface around PostgreSQL and pgvector.\n",
-    "A collection in `vecs` maps 1:1 with a PostgreSQL table."
+    "A collection in `vecs` maps 1:1 with a PostgreSQL table.\n",
+    "\n",
+    "First you will need to establish a connection to your database. You can find the Postgres connection string in the [Database Settings](https://supabase.com/dashboard/project/_/settings/database) of your Supabase project.\n",
+    "\n",
+    "> **Note:** SQLAlchemy requires the connection string to start with `postgresql://` (instead of `postgres://`). Don't forget to rename this after copying the string from the dashboard.\n",
+    "\n",
+    "> **Note:** You must use the \"connection pooling\" string (domain ending in `*.pooler.supabase.com`) with Google Colab since Colab does not support IPv6.\n",
+    "\n",
+    "This will also work with any other Postgres provider that supports pgvector."
    ]
   },
   {

--- a/examples/ai/llamaindex/llamaindex.ipynb
+++ b/examples/ai/llamaindex/llamaindex.ipynb
@@ -69,7 +69,7 @@
       "source": [
         "# Set up OpenAI\n",
         "\n",
-        "LlamaIndex uses OpenAI GPT-3 `text-davinci-003` model. Let's store that in an environment variable:"
+        "OpenAI requires an [API key](https://platform.openai.com/api-keys) to run their models. Let's store that in an environment variable:"
       ]
     },
     {
@@ -116,7 +116,13 @@
       "source": [
         "## Create an index in Supabase\n",
         "\n",
-        "Let's store Paul Graham's essays in Supabase. You can find the Postgres connection string in the [Database Settings](https://supabase.com/dashboard/_/settings/database) of your Supabase project. This will work with all Postgres providers that support pgvector."
+        "Let's store Paul Graham's essays in Supabase. You can find the Postgres connection string in the [Database Settings](https://supabase.com/dashboard/project/_/settings/database) of your Supabase project.\n",
+        "\n",
+        "> **Note:** SQLAlchemy requires the connection string to start with `postgresql://` (instead of `postgres://`). Don't forget to rename this after copying the string from the dashboard.\n",
+        "\n",
+        "> **Note:** You must use the \"connection pooling\" string (domain ending in `*.pooler.supabase.com`) with Google Colab since Colab does not support IPv6.\n",
+        "\n",
+        "This will also work with any other Postgres provider that supports pgvector."
       ]
     },
     {

--- a/examples/ai/semantic_text_deduplication.ipynb
+++ b/examples/ai/semantic_text_deduplication.ipynb
@@ -138,7 +138,15 @@
     "## Initialize the Vecs Collection\n",
     "\n",
     "The [`vecs`](https://supabase.github.io/vecs/api/) library wraps a pythonic interface around PostgreSQL and pgvector.\n",
-    "A collection in `vecs` maps 1:1 with a PostgreSQL table."
+    "A collection in `vecs` maps 1:1 with a PostgreSQL table.\n",
+    "\n",
+    "First you will need to establish a connection to your database. You can find the Postgres connection string in the [Database Settings](https://supabase.com/dashboard/project/_/settings/database) of your Supabase project.\n",
+    "\n",
+    "> **Note:** SQLAlchemy requires the connection string to start with `postgresql://` (instead of `postgres://`). Don't forget to rename this after copying the string from the dashboard.\n",
+    "\n",
+    "> **Note:** You must use the \"connection pooling\" string (domain ending in `*.pooler.supabase.com`) with Google Colab since Colab does not support IPv6.\n",
+    "\n",
+    "This will also work with any other Postgres provider that supports pgvector."
    ]
   },
   {

--- a/examples/ai/vector_hello_world.ipynb
+++ b/examples/ai/vector_hello_world.ipynb
@@ -52,12 +52,19 @@
         "id": "AeGQKpZegfCv"
       },
       "source": [
-        "##Usage\n",
-        "###Connecting\n",
+        "## Usage\n",
+        "\n",
+        "### Connecting\n",
         "\n",
         "Before you can interact with vecs, create the client to communicate with Postgres.\n",
         "\n",
-        "Note: In Supabase go to [Database Settings](https://supabase.com/dashboard/project/_/settings/database) to get your Postgres connection string."
+        "In Supabase, you can find the Postgres connection string in the [Database Settings](https://supabase.com/dashboard/project/_/settings/database) of your Supabase project.\n",
+        "\n",
+        "> **Note:** SQLAlchemy requires the connection string to start with `postgresql://` (instead of `postgres://`). Don't forget to rename this after copying the string from the dashboard.\n",
+        "\n",
+        "> **Note:** You must use the \"connection pooling\" string (domain ending in `*.pooler.supabase.com`) with Google Colab since Colab does not support IPv6.\n",
+        "\n",
+        "This will also work with any other Postgres provider that supports pgvector."
       ]
     },
     {


### PR DESCRIPTION
There are a few AI guides written in Python that require a direct DB connection (rather than going through the REST API).

This PR updates these guides/colab notebooks to use the pooler connection string since Google Colab doesn't support IPv6.