### PR TITLE
fix(docs): remove non-existent history file from migration docs

### DIFF
--- a/apps/docs/pages/guides/platform/migrating-and-upgrading-projects.mdx
+++ b/apps/docs/pages/guides/platform/migrating-and-upgrading-projects.mdx
@@ -172,7 +172,6 @@ psql \
   --file schema.sql \
   --command 'SET session_replication_role = replica' \
   --file data.sql \
-  --file history.sql \
   --dbname "$NEW_DB_URL"
 ```
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

follow up: https://github.com/supabase/supabase/pull/20767

## What is the new behavior?

`history.sql` has been moved to a separate section.

## Additional context

Add any other context or screenshots.
