### PR TITLE
feat: add warning to connection settings about SQLAlchemy dialect

### DIFF
--- a/apps/studio/components/interfaces/Settings/Database/DatabaseSettings/DatabaseConnectionString.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/DatabaseSettings/DatabaseConnectionString.tsx
@@ -2,7 +2,8 @@ import * as Tooltip from '@radix-ui/react-tooltip'
 import { useParams, useTelemetryProps } from 'common'
 import { useRouter } from 'next/router'
 import { useEffect, useRef, useState } from 'react'
-import { Button, IconChevronDown, IconExternalLink, Input, Separator, Tabs } from 'ui'
+import { Button, CollapsibleContent_Shadcn_, CollapsibleTrigger_Shadcn_, Collapsible_Shadcn_, IconChevronDown, IconExternalLink, Input, Separator, Tabs,
+ } from 'ui'
 
 import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
 import AlertError from 'components/ui/AlertError'
@@ -214,20 +215,21 @@ export const DatabaseConnectionString = () => {
           <>
             <Separator />
             <Panel.Content className="!py-3 space-y-2">
-              <div
-                className="flex items-center gap-x-2 transition cursor-pointer opacity-75 hover:opacity-100"
-                onClick={() => setShowUriSyntax(!showUriSyntax)}
-              >
-                <p className="text-xs text-foreground">
-                  How to connect to a different database or switch to another user
-                </p>
-                <IconChevronDown
-                  strokeWidth={1.5}
-                  className={`transition ${showUriSyntax ? '-rotate-180' : ''}`}
-                />
-              </div>
-              {showUriSyntax && (
-                <div className="text-foreground-light">
+              <Collapsible_Shadcn_ >
+                  <CollapsibleTrigger_Shadcn_ className="group [&[data-state=open]>div>svg]:!-rotate-180">
+                    <div className="flex items-center gap-x-2 w-full">
+                      <p className="text-xs text-foreground-light group-hover:text-foreground transition">
+                        How to connect to a different database or switch to another user
+                      </p>
+                      <IconChevronDown
+                        className="transition-transform duration-200"
+                        strokeWidth={1.5}
+                        size={14}
+                      />
+                    </div>
+                  </CollapsibleTrigger_Shadcn_>
+                  <CollapsibleContent_Shadcn_ className="my-2">
+                    <div className="text-foreground-light">
                   <p className="text-xs">
                     You can use the following URI format to switch to a different database or user
                     {usePoolerConnection ? ' when using connection pooling' : ''}.
@@ -267,35 +269,43 @@ export const DatabaseConnectionString = () => {
                     })}
                   </p>
                 </div>
-              )}
-            </Panel.Content>
+                  </CollapsibleContent_Shadcn_>
+                </Collapsible_Shadcn_>
+
             {selectedTab === 'python' && (
-              <Panel.Content className="!py-3 space-y-2">
-                <div
-                  className="flex items-center gap-x-2 transition cursor-pointer opacity-75 hover:opacity-100"
-                  onClick={() => setShowSQLAlchemy(!showSQLAlchemy)}
-                >
-                  <p className="text-xs text-foreground">Connecting to SQL Alchemy</p>
-                  <IconChevronDown
-                    strokeWidth={1.5}
-                    className={`transition ${showUriSyntax ? '-rotate-180' : ''}`}
-                  />
-                </div>
-                {showSQLAlchemy && (
-                  <div className="text-foreground-light">
-                    <p className="text-xs">
-                      Please use postgresql:// instead of postgres:// as your dialect when
-                      connecting via SQLAlchemy. For example:
-                      create_engine("postgresql+psycopg2://...")
-                    </p>
-                    <p className="text-sm font-mono tracking-tight text-foreground-lighter"></p>
-                  </div>
-                )}
-              </Panel.Content>
-            )}
+
+              <Collapsible_Shadcn_ >
+                  <CollapsibleTrigger_Shadcn_ className="group [&[data-state=open]>div>svg]:!-rotate-180">
+                    <div className="flex items-center gap-x-2 w-full">
+                      <p className="text-xs text-foreground-light group-hover:text-foreground transition">
+                        Connecting to SQL Alchemy
+                      </p>
+                      <IconChevronDown
+                        className="transition-transform duration-200"
+                        strokeWidth={1.5}
+                        size={14}
+                        />
+                    </div>
+                  </CollapsibleTrigger_Shadcn_>
+                  <CollapsibleContent_Shadcn_ className="my-2">
+                    <div className="text-foreground-light text-xs grid gap-2">
+                      <p>
+                        Please use <code>postgresql://</code> instead of <code>postgres://</code> as your dialect when
+                        connecting via SQLAlchemy.
+                      </p>
+                        <p>
+                          Example:
+                        <code>create_engine("postgresql+psycopg2://...")</code>
+                          </p>
+                      <p className="text-sm font-mono tracking-tight text-foreground-lighter"></p>
+                    </div>
+                  </CollapsibleContent_Shadcn_>
+                </Collapsible_Shadcn_>
+)}
+        </Panel.Content>
           </>
         )}
       </Panel>
     </div>
-  )
+    )
 }

--- a/apps/studio/components/interfaces/Settings/Database/DatabaseSettings/DatabaseConnectionString.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/DatabaseSettings/DatabaseConnectionString.tsx
@@ -2,8 +2,17 @@ import * as Tooltip from '@radix-ui/react-tooltip'
 import { useParams, useTelemetryProps } from 'common'
 import { useRouter } from 'next/router'
 import { useEffect, useRef, useState } from 'react'
-import { Button, CollapsibleContent_Shadcn_, CollapsibleTrigger_Shadcn_, Collapsible_Shadcn_, IconChevronDown, IconExternalLink, Input, Separator, Tabs,
- } from 'ui'
+import {
+  Button,
+  CollapsibleContent_Shadcn_,
+  CollapsibleTrigger_Shadcn_,
+  Collapsible_Shadcn_,
+  IconChevronDown,
+  IconExternalLink,
+  Input,
+  Separator,
+  Tabs,
+} from 'ui'
 
 import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
 import AlertError from 'components/ui/AlertError'
@@ -215,66 +224,65 @@ export const DatabaseConnectionString = () => {
           <>
             <Separator />
             <Panel.Content className="!py-3 space-y-2">
-              <Collapsible_Shadcn_ >
-                  <CollapsibleTrigger_Shadcn_ className="group [&[data-state=open]>div>svg]:!-rotate-180">
-                    <div className="flex items-center gap-x-2 w-full">
-                      <p className="text-xs text-foreground-light group-hover:text-foreground transition">
-                        How to connect to a different database or switch to another user
-                      </p>
-                      <IconChevronDown
-                        className="transition-transform duration-200"
-                        strokeWidth={1.5}
-                        size={14}
-                      />
-                    </div>
-                  </CollapsibleTrigger_Shadcn_>
-                  <CollapsibleContent_Shadcn_ className="my-2">
-                    <div className="text-foreground-light">
-                  <p className="text-xs">
-                    You can use the following URI format to switch to a different database or user
-                    {usePoolerConnection ? ' when using connection pooling' : ''}.
-                  </p>
-                  <p className="text-sm font-mono tracking-tight text-foreground-lighter">
-                    {poolerConnStringSyntax.map((x, idx) => {
-                      if (x.tooltip) {
-                        return (
-                          <Tooltip.Root key={`syntax-${idx}`} delayDuration={0}>
-                            <Tooltip.Trigger asChild>
-                              <span className="text-foreground text-xs">{x.value}</span>
-                            </Tooltip.Trigger>
-                            <Tooltip.Portal>
+              <Collapsible_Shadcn_>
+                <CollapsibleTrigger_Shadcn_ className="group [&[data-state=open]>div>svg]:!-rotate-180">
+                  <div className="flex items-center gap-x-2 w-full">
+                    <p className="text-xs text-foreground-light group-hover:text-foreground transition">
+                      How to connect to a different database or switch to another user
+                    </p>
+                    <IconChevronDown
+                      className="transition-transform duration-200"
+                      strokeWidth={1.5}
+                      size={14}
+                    />
+                  </div>
+                </CollapsibleTrigger_Shadcn_>
+                <CollapsibleContent_Shadcn_ className="my-2">
+                  <div className="text-foreground-light">
+                    <p className="text-xs">
+                      You can use the following URI format to switch to a different database or user
+                      {usePoolerConnection ? ' when using connection pooling' : ''}.
+                    </p>
+                    <p className="text-sm font-mono tracking-tight text-foreground-lighter">
+                      {poolerConnStringSyntax.map((x, idx) => {
+                        if (x.tooltip) {
+                          return (
+                            <Tooltip.Root key={`syntax-${idx}`} delayDuration={0}>
+                              <Tooltip.Trigger asChild>
+                                <span className="text-foreground text-xs">{x.value}</span>
+                              </Tooltip.Trigger>
                               <Tooltip.Portal>
-                                <Tooltip.Content side="bottom">
-                                  <Tooltip.Arrow className="radix-tooltip-arrow" />
-                                  <div
-                                    className={[
-                                      'rounded bg-alternative py-1 px-2 leading-none shadow',
-                                      'border border-background',
-                                    ].join(' ')}
-                                  >
-                                    <span className="text-xs text-foreground">{x.tooltip}</span>
-                                  </div>
-                                </Tooltip.Content>
+                                <Tooltip.Portal>
+                                  <Tooltip.Content side="bottom">
+                                    <Tooltip.Arrow className="radix-tooltip-arrow" />
+                                    <div
+                                      className={[
+                                        'rounded bg-alternative py-1 px-2 leading-none shadow',
+                                        'border border-background',
+                                      ].join(' ')}
+                                    >
+                                      <span className="text-xs text-foreground">{x.tooltip}</span>
+                                    </div>
+                                  </Tooltip.Content>
+                                </Tooltip.Portal>
                               </Tooltip.Portal>
-                            </Tooltip.Portal>
-                          </Tooltip.Root>
-                        )
-                      } else {
-                        return (
-                          <span key={`syntax-${idx}`} className="text-xs">
-                            {x.value}
-                          </span>
-                        )
-                      }
-                    })}
-                  </p>
-                </div>
-                  </CollapsibleContent_Shadcn_>
-                </Collapsible_Shadcn_>
+                            </Tooltip.Root>
+                          )
+                        } else {
+                          return (
+                            <span key={`syntax-${idx}`} className="text-xs">
+                              {x.value}
+                            </span>
+                          )
+                        }
+                      })}
+                    </p>
+                  </div>
+                </CollapsibleContent_Shadcn_>
+              </Collapsible_Shadcn_>
 
-            {selectedTab === 'python' && (
-
-              <Collapsible_Shadcn_ >
+              {selectedTab === 'python' && (
+                <Collapsible_Shadcn_>
                   <CollapsibleTrigger_Shadcn_ className="group [&[data-state=open]>div>svg]:!-rotate-180">
                     <div className="flex items-center gap-x-2 w-full">
                       <p className="text-xs text-foreground-light group-hover:text-foreground transition">
@@ -284,28 +292,28 @@ export const DatabaseConnectionString = () => {
                         className="transition-transform duration-200"
                         strokeWidth={1.5}
                         size={14}
-                        />
+                      />
                     </div>
                   </CollapsibleTrigger_Shadcn_>
                   <CollapsibleContent_Shadcn_ className="my-2">
                     <div className="text-foreground-light text-xs grid gap-2">
                       <p>
-                        Please use <code>postgresql://</code> instead of <code>postgres://</code> as your dialect when
-                        connecting via SQLAlchemy.
+                        Please use <code>postgresql://</code> instead of <code>postgres://</code> as
+                        your dialect when connecting via SQLAlchemy.
                       </p>
-                        <p>
-                          Example:
+                      <p>
+                        Example:
                         <code>create_engine("postgresql+psycopg2://...")</code>
-                          </p>
+                      </p>
                       <p className="text-sm font-mono tracking-tight text-foreground-lighter"></p>
                     </div>
                   </CollapsibleContent_Shadcn_>
                 </Collapsible_Shadcn_>
-)}
-        </Panel.Content>
+              )}
+            </Panel.Content>
           </>
         )}
       </Panel>
     </div>
-    )
+  )
 }

--- a/apps/studio/components/interfaces/Settings/Database/DatabaseSettings/DatabaseConnectionString.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/DatabaseSettings/DatabaseConnectionString.tsx
@@ -50,6 +50,7 @@ export const DatabaseConnectionString = () => {
     'transaction'
   )
   const [showUriSyntax, setShowUriSyntax] = useState(false)
+  const [showSQLAlchemy, setShowSQLAlchemy] = useState(false)
   const [selectedTab, setSelectedTab] = useState<
     'uri' | 'psql' | 'golang' | 'jdbc' | 'dotnet' | 'nodejs' | 'php' | 'python'
   >('uri')
@@ -273,6 +274,30 @@ export const DatabaseConnectionString = () => {
                 </div>
               )}
             </Panel.Content>
+            {selectedTab === 'python' && (
+              <Panel.Content className="!py-3 space-y-2">
+                <div
+                  className="flex items-center gap-x-2 transition cursor-pointer opacity-75 hover:opacity-100"
+                  onClick={() => setShowSQLAlchemy(!showSQLAlchemy)}
+                >
+                  <p className="text-xs text-foreground">Connecting to SQL Alchemy</p>
+                  <IconChevronDown
+                    strokeWidth={1.5}
+                    className={`transition ${showUriSyntax ? '-rotate-180' : ''}`}
+                  />
+                </div>
+                {showSQLAlchemy && (
+                  <div className="text-foreground-light">
+                    <p className="text-xs">
+                      Please use postgresql:// instead of postgres:// as your dialect when
+                      connecting via SQLAlchemy. For example:
+                      create_engine("postgresql+psycopg2://...")
+                    </p>
+                    <p className="text-sm font-mono tracking-tight text-foreground-lighter"></p>
+                  </div>
+                )}
+              </Panel.Content>
+            )}
           </>
         )}
       </Panel>

--- a/apps/studio/components/interfaces/Settings/Database/DatabaseSettings/DatabaseConnectionString.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/DatabaseSettings/DatabaseConnectionString.tsx
@@ -1,5 +1,4 @@
 import * as Tooltip from '@radix-ui/react-tooltip'
-
 import { useParams, useTelemetryProps } from 'common'
 import { useRouter } from 'next/router'
 import { useEffect, useRef, useState } from 'react'

--- a/apps/studio/components/interfaces/Settings/Database/DatabaseSettings/DatabaseConnectionString.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/DatabaseSettings/DatabaseConnectionString.tsx
@@ -256,6 +256,11 @@ export const DatabaseConnectionString = () => {
                             </Tooltip.Portal>
                           </Tooltip.Root>
                         )
+                        {
+                          selectedTab === 'python' && (
+                            <p>Please uses `postgresql://` instead of `postgres://` if you are using sqlalchemy</p>
+                          )
+                        }
                       } else {
                         return (
                           <span key={`syntax-${idx}`} className="text-xs">

--- a/apps/studio/components/interfaces/Settings/Database/DatabaseSettings/DatabaseConnectionString.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/DatabaseSettings/DatabaseConnectionString.tsx
@@ -1,4 +1,5 @@
 import * as Tooltip from '@radix-ui/react-tooltip'
+
 import { useParams, useTelemetryProps } from 'common'
 import { useRouter } from 'next/router'
 import { useEffect, useRef, useState } from 'react'
@@ -59,8 +60,6 @@ export const DatabaseConnectionString = () => {
   const [poolingMode, setPoolingMode] = useState<'transaction' | 'session' | 'statement'>(
     'transaction'
   )
-  const [showUriSyntax, setShowUriSyntax] = useState(false)
-  const [showSQLAlchemy, setShowSQLAlchemy] = useState(false)
   const [selectedTab, setSelectedTab] = useState<
     'uri' | 'psql' | 'golang' | 'jdbc' | 'dotnet' | 'nodejs' | 'php' | 'python'
   >('uri')

--- a/apps/studio/components/interfaces/Settings/Database/DatabaseSettings/DatabaseConnectionString.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/DatabaseSettings/DatabaseConnectionString.tsx
@@ -257,11 +257,6 @@ export const DatabaseConnectionString = () => {
                             </Tooltip.Portal>
                           </Tooltip.Root>
                         )
-                        {
-                          selectedTab === 'python' && (
-                            <p>Please uses `postgresql://` instead of `postgres://` if you are using sqlalchemy</p>
-                          )
-                        }
                       } else {
                         return (
                           <span key={`syntax-${idx}`} className="text-xs">


### PR DESCRIPTION
## What kind of change does this PR introduce?

Callout to developers of SQLAlchemy that they should URLs with `postgresql://` instead of `postgres://` if one is using SQLAlchemy. See [this post](https://stackoverflow.com/questions/62688256/sqlalchemy-exc-nosuchmoduleerror-cant-load-plugin-sqlalchemy-dialectspostgre) and [this thread](https://supabase.slack.com/archives/C023E4L60R3/p1706587490627419?thread_ts=1706561320.842189&cid=C023E4L60R3) for more context

<img width="990" alt="CleanShot 2024-01-30 at 16 49 05@2x" src="https://github.com/supabase/supabase/assets/8011761/90dfbe7d-d677-448f-83b1-62c5d111457f">
