### PR TITLE
Update configuration.mdx | added more examples

### DIFF
--- a/apps/docs/pages/guides/database/postgres/configuration.mdx
+++ b/apps/docs/pages/guides/database/postgres/configuration.mdx
@@ -21,6 +21,7 @@ FROM pg_roles
 WHERE rolname IN (
   'anon',
   'authenticated',
+  'authenticator',
   'postgres',
   'service_role'
 );
@@ -46,9 +47,13 @@ npx supabase --experimental --project-ref <YOUR PROJECT REF> postgres-config upd
 
 The timeout values were picked as a reasonable default for the majority of use-cases, but can be modified using the [`alter role`](https://www.postgresql.org/docs/current/sql-alterrole.html) statement:
 
+<Admonition type="note" label="Self hosting">
+When updating either the `anon` or `authenticated` role, set the `authenticator` role to the greater timeout value between the two.
+</Admonition>
+
 ```sql
--- For API users
 alter role authenticated set statement_timeout = '15s';
+alter role authenticator set statement_timeout = '15s';
 ```
 
 You can also update the statement timeout for a session:

--- a/apps/docs/pages/guides/database/postgres/configuration.mdx
+++ b/apps/docs/pages/guides/database/postgres/configuration.mdx
@@ -20,19 +20,19 @@ SELECT
 FROM pg_roles
 WHERE rolname IN (
   'anon',
-  'authenticated'
+  'authenticated',
   'postgres',
-  'service_role',
+  'service_role'
 );
 ```
 
-Additionally, all users are subject to a global limit of _2 minutes_. This serves as a backstop against resource exhaustion due to either poorly written queries, or abusive usage. The current global timeout can be view with the following query:
+Additionally, all users are subject to a global limit of _2 minutes_. This serves as a backstop against resource exhaustion due to either poorly written queries, or abusive usage. To view the global timeout, you can execute the below query:
 
 ```sql
 SHOW statement_timeout;
 ```
 
-This can be overridden using [Custom Postgres configuration](https://supabase.com/docs/guides/platform/custom-postgres-config#supported-parameters). The below example is for changing the global timeout with NPX:
+This can be overridden using [Custom Postgres configuration](https://supabase.com/docs/guides/platform/custom-postgres-config#supported-parameters). The below example is for changing the global timeout with `npx`:
 
 ```bash
 #Logs you into the Supabase CLI

--- a/apps/docs/pages/guides/database/postgres/configuration.mdx
+++ b/apps/docs/pages/guides/database/postgres/configuration.mdx
@@ -12,7 +12,35 @@ Postgres provides a set of sensible defaults for you database size. In some case
 
 ## Timeouts
 
-By default, Supabase limits the maximum statement execution time to _8 seconds_ for users accessing the API. Additionally, all users are subject to a global limit of _2 minutes_. This serves as a backstop against resource exhaustion due to either poorly written queries, or abusive usage. This can be overridden using [Custom Postgres configuration](https://supabase.com/docs/guides/platform/custom-postgres-config#supported-parameters).
+By default, Supabase limits the maximum statement execution time to _8 seconds_ for users accessing the API. All role timeouts can be viewed with the following query:
+
+```sql
+SELECT
+  rolname, rolconfig
+FROM pg_roles
+WHERE rolname IN (
+  'anon',
+  'authenticated'
+  'postgres',
+  'service_role',
+);
+```
+
+Additionally, all users are subject to a global limit of _2 minutes_. This serves as a backstop against resource exhaustion due to either poorly written queries, or abusive usage. The current global timeout can be view with the following query:
+
+```sql
+SHOW statement_timeout;
+```
+
+This can be overridden using [Custom Postgres configuration](https://supabase.com/docs/guides/platform/custom-postgres-config#supported-parameters). The below example is for changing the global timeout with NPX:
+
+```bash
+#Logs you into the Supabase CLI
+npx supabase login
+
+#Change database timeout to 3 minutes
+npx supabase --experimental --project-ref <YOUR PROJECT REF> postgres-config update --config statement_timeout='3min'
+```
 
 ### Changing the default timeout
 
@@ -20,7 +48,7 @@ The timeout values were picked as a reasonable default for the majority of use-c
 
 ```sql
 -- For API users
-alter role authenticator set statement_timeout = '15s';
+alter role authenticated set statement_timeout = '15s';
 ```
 
 You can also update the statement timeout for a session:


### PR DESCRIPTION
Added more examples to the change timeout section. Updated examples to use the authenticated role instead of authenticator role(gotrue server)

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

Does not show users how to quickly update global timeout. Also provides an example that tells people to update the timeout for the authenticator role (gotrue) instead of the authenticated role(registered users)
## What is the new behavior?

Provides 2 new examples:
- how to inspect timeouts for roles
- how to update global timeout

Modified one example to use the authenticated role instead of authenticator.

Feel free to include screenshots if it includes visual changes.

## Additional context

I noticed a few users were getting confused and creating tickets when their authenticated role did not update (they were updating the authenticator role by mistake). This is supposed to prevent that issue.

Note, there is a bug with the CLI that prevents users from updating their global timeouts. I recommend withholding from approving this pull request until it is fixed.
