### PR TITLE
[www] chore: revert to 5 hours for partner page invalidation

### DIFF
--- a/apps/www/pages/partners/experts/[slug].tsx
+++ b/apps/www/pages/partners/experts/[slug].tsx
@@ -250,7 +250,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
 
   return {
     props: { partner, overview },
-    revalidate: 10, // this was 1800 (5 hours) @mildtomato changed to 10 seconds for making rapid updates
+    revalidate: 1800, // 5 hours
   }
 }
 

--- a/apps/www/pages/partners/integrations/[slug].tsx
+++ b/apps/www/pages/partners/integrations/[slug].tsx
@@ -335,7 +335,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
 
   return {
     props: { partner, overview },
-    revalidate: 10, // this was 1800 (5 hours) @mildtomato changed to 10 seconds for making rapid updates
+    revalidate: 1800, // 5 hours
   }
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

- invalidation of partners pages bumped to 5 hours

