### PR TITLE
Document unsupported operations

### DIFF
--- a/apps/docs/pages/guides/database/roles-superuser.mdx
+++ b/apps/docs/pages/guides/database/roles-superuser.mdx
@@ -1,0 +1,26 @@
+import Layout from '~/layouts/DefaultGuideLayout'
+
+export const meta = {
+  id: 'roles',
+  title: 'Roles and Unsupported Operations',
+  slug: 'roles',
+}
+
+Supabase provides the default `postgres` role to all instances deployed. Superuser access is not given as it allows destructive operations to be performed on the database.
+
+To ensure you are not impacted by this, additional privileges are granted to the `postgres` user and we have developed Supautils to provide helper functions for certain privileged operations.
+
+However, this does mean that some operations, typically requiring `superuser` privileges are not available on Supabase. These are documented below.
+
+## Unsupported operations
+
+- `CREATE ROLE ... WITH REPLICATION`
+- `CREATE SUBSCRIPTION`
+- `CREATE EVENT TRIGGER`
+- `COPY ... FROM PROGRAM`
+- `ALTER USER ... WITH SUPERUSER`
+
+
+export const Page = ({ children }) => <Layout meta={meta} children={children} />
+
+export default Page


### PR DESCRIPTION
## What kind of change does this PR introduce?

Additional docs page on unsupported operations and reasoning for lack of access to superuser

## What is the current behavior?

This is not currently documented

## What is the new behavior?

Documenting operations that cannot currently be run by Supabase users.

## Additional context

Add any other context or screenshots.
