### PR TITLE
fix: index_advisor docs links

### DIFF
--- a/apps/docs/pages/guides/database/extensions/index_advisor.mdx
+++ b/apps/docs/pages/guides/database/extensions/index_advisor.mdx
@@ -6,7 +6,7 @@ export const meta = {
   description: 'Automatically optimize SQL queries',
 }
 
-[Index advisor](https://github.com/supabase/index_advisor) is a Postgres extension for recommending indexes to improve query performance.
+[Index advisor](https://database.dev/olirice/index_advisor) is a Postgres extension for recommending indexes to improve query performance.
 
 For example:
 
@@ -154,7 +154,8 @@ from
 
 ## Resources
 
-- Official [`index_advisor` GitHub Repository](https://github.com/supabase/index_advisor)
+- dbdev [`index_advisor`](https://database.dev/olirice/index_advisor) docs
+- dbdev [Github Repository](https://github.com/supabase/dbdev)
 
 export const Page = ({ children }) => <Layout meta={meta} children={children} />
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase Docs - [index_advisor](https://supabase.com/docs/guides/database/extensions/index_advisor) extension

## What is the current behavior?

The links go to a 404 page

## What is the new behavior?

Links are now changed and also added a new resource to dbdev

## Additional context

Closes #20879
