### PR TITLE
fix: Don't show the tooltip if the ipv4 addon is added

### DIFF
--- a/apps/studio/components/interfaces/Settings/Addons/Addons.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/Addons.tsx
@@ -435,7 +435,7 @@ const Addons = () => {
                               isBranch ||
                               !isProjectActive ||
                               projectUpdateDisabled ||
-                              !canUpdateIPv4
+                              !(canUpdateIPv4 && ipv4)
                             }
                           >
                             Change IPv4 address

--- a/apps/studio/components/interfaces/Settings/Addons/Addons.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/Addons.tsx
@@ -443,7 +443,8 @@ const Addons = () => {
                         </div>
                       </Tooltip.Trigger>
                       <Tooltip.Portal>
-                        {!canUpdateIPv4 && (
+                        {/* Only show the tooltip if the user can't add the addon and ipv4 is not currently applied */}
+                        {!(canUpdateIPv4 || ipv4) && (
                           <Tooltip.Content side="bottom">
                             <Tooltip.Arrow className="radix-tooltip-arrow" />
                             <div

--- a/apps/studio/components/interfaces/Settings/Addons/Addons.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/Addons.tsx
@@ -435,7 +435,7 @@ const Addons = () => {
                               isBranch ||
                               !isProjectActive ||
                               projectUpdateDisabled ||
-                              !(canUpdateIPv4 && ipv4)
+                              !(canUpdateIPv4 || ipv4)
                             }
                           >
                             Change IPv4 address


### PR DESCRIPTION
This PR fixes an issue where if the user has enabled IPv4 addon, a wrong tooltip is shown.
![Screenshot 2024-02-01 at 17 09 01](https://github.com/supabase/supabase/assets/568291/24adaac1-aa38-4ffd-96c9-cc197f70cd8d)

The tooltip is only shown if the project is still on legacy IPv4 and the addon hasn't been installed. 

To test, try upgrading a project on staging to use IPv4, check whether the tooltip is shown and then try to disable the addon.
