### PR TITLE
Update email-based-auth-with-pkce-flow-for-ssr.mdx

### DIFF
--- a/apps/docs/pages/guides/auth/server-side/email-based-auth-with-pkce-flow-for-ssr.mdx
+++ b/apps/docs/pages/guides/auth/server-side/email-based-auth-with-pkce-flow-for-ssr.mdx
@@ -277,7 +277,7 @@ Let's update the URL in our email templates to point to our new confirmation end
 <h2>Magic Link</h2>
 
 <p>Follow this link to login:</p>
-<p><a href="{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=email">Log In</a></p>
+<p><a href="{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=magiclink">Log In</a></p>
 ```
 
 **Change Email Address template**


### PR DESCRIPTION
Wrong email auth type param passed on magic link event. Should be one time login through magic link via 'magiclink' not confirm email via 'email'

## What kind of change does this PR introduce?

Tiny bug fix in email magic link 

## What is the current behavior?

Wrong param passed

## What is the new behavior?

Magic links work - param is correct
