### PR TITLE
add planetpg tag to 'How pg_graphql works' blog

### DIFF
--- a/apps/www/_blog/2024-01-24-how-pg-graphql-works.mdx
+++ b/apps/www/_blog/2024-01-24-how-pg-graphql-works.mdx
@@ -9,6 +9,7 @@ categories:
 tags:
   - pg-graphql
   - supabase-engineering
+  - planetpg
 date: '2024-01-24'
 toc_depth: 3
 ---


### PR DESCRIPTION
In preparation to publish the blog to Planet PostgreSQL, tagged `How pg_graphql works` with `planetpg`.