### PR TITLE
docs: Update links in triggers.mdx

### DIFF
--- a/apps/docs/pages/guides/database/postgres/triggers.mdx
+++ b/apps/docs/pages/guides/database/postgres/triggers.mdx
@@ -13,7 +13,7 @@ In Postgres, a trigger executes a set of actions automatically on table events s
 
 Creating triggers involve 2 parts:
 
-1. A [Function](docs/guides/database/functions) which will be executed (called the Trigger Function)
+1. A [Function](/docs/guides/database/functions) which will be executed (called the Trigger Function)
 2. The actual Trigger object, with parameters around when the trigger should be run.
 
 An example of a trigger is:
@@ -27,7 +27,7 @@ execute function trigger_function();
 
 ## Trigger functions
 
-A trigger function is a user-defined [Function](docs/guides/database/functions) that Postgres executes when the trigger is fired.
+A trigger function is a user-defined [Function](/docs/guides/database/functions) that Postgres executes when the trigger is fired.
 
 ### Example trigger function
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

a Function Link accesses to 404 pages in https://supabase.com/docs/guides/database/postgres/triggers

## What is the new behavior?

a Function Link accesses to right page, https://supabase.com/docs/guides/database/functions

