### PR TITLE
chore: fixed release-notes.mdx

### DIFF
--- a/apps/docs/docs/ref/javascript/release-notes.mdx
+++ b/apps/docs/docs/ref/javascript/release-notes.mdx
@@ -185,7 +185,7 @@ Supabase.js v2 release notes.
   <RefSubLayout.Details>
 
     We're removing the `signIn()` method in favor of more explicit function signatures:
-    `signInWithPassword()`, `signInWithOtp()`, and `signInWithOtp()`.
+    `signInWithPassword()`, `signInWithOtp()`, and `signInWithOAuth()`.
 
   </RefSubLayout.Details>
   <RefSubLayout.Examples>


### PR DESCRIPTION
`signInWithOtp()` was referenced two times. I think one of them should be `signInWithOAuth()`

