### PR TITLE
fix: functions argument truncation

### DIFF
--- a/apps/studio/components/interfaces/Database/Functions/FunctionsList/FunctionList.tsx
+++ b/apps/studio/components/interfaces/Database/Functions/FunctionsList/FunctionList.tsx
@@ -92,7 +92,9 @@ const FunctionList = ({
               <p title={x.name}>{x.name}</p>
             </Table.td>
             <Table.td className="hidden md:table-cell md:overflow-auto">
-              <p title={x.argument_types} className='truncate'>{x.argument_types || '-'}</p>
+              <p title={x.argument_types} className="truncate">
+                {x.argument_types || '-'}
+              </p>
             </Table.td>
             <Table.td className="hidden lg:table-cell">
               <p title={x.return_type}>{x.return_type}</p>

--- a/apps/studio/components/interfaces/Database/Functions/FunctionsList/FunctionList.tsx
+++ b/apps/studio/components/interfaces/Database/Functions/FunctionsList/FunctionList.tsx
@@ -92,7 +92,7 @@ const FunctionList = ({
               <p title={x.name}>{x.name}</p>
             </Table.td>
             <Table.td className="hidden md:table-cell md:overflow-auto">
-              <p title={x.argument_types}>{x.argument_types || '-'}</p>
+              <p title={x.argument_types} className='truncate'>{x.argument_types || '-'}</p>
             </Table.td>
             <Table.td className="hidden lg:table-cell">
               <p title={x.return_type}>{x.return_type}</p>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase Studio > Database > Functions

## What is the current behavior?

If you have a long argument name the field overlaps.

## What is the new behavior?

Added some truncation to make the field not overlap:

<img width="448" alt="Screenshot 2024-02-02 at 20 51 23" src="https://github.com/supabase/supabase/assets/22655069/e9915cae-ccb7-4f0a-8971-df4068fe5819">


## Additional context

Closes #20810 
