### PR TITLE
fix: Remove redirect for Flutter upgrade guide

### DIFF
--- a/apps/www/lib/redirects.js
+++ b/apps/www/lib/redirects.js
@@ -1909,11 +1909,6 @@ module.exports = [
   },
   {
     permanent: true,
-    source: '/docs/reference/dart/upgrade-guide',
-    destination: '/docs/reference/dart/v0/upgrade-guide',
-  },
-  {
-    permanent: true,
     source: '/docs/guides/examples',
     destination: '/docs/guides/resources/examples',
   },


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently, https://supabase.com/docs/reference/dart/upgrade-guide is unreachable with a direct link as it takes the user to https://supabase.com/docs/reference/dart/v0/upgrade-guide . To fix this, this PR removes a redirect. 

This redirect was set when supabase_flutter went from v0 to v1, but should've been removed when v2 docs were added as it's making the upgrade guide for v2 unreachable. 