### PR TITLE
fix: mobile search width

### DIFF
--- a/packages/ui/src/components/Command/Command.utils.tsx
+++ b/packages/ui/src/components/Command/Command.utils.tsx
@@ -69,6 +69,7 @@ export const CommandDialog = ({ children, onKeyDown, page, ...props }: CommandDi
         '!border-overlay/90',
         'transition ease-out',
         'place-self-start mx-auto top-24',
+        'max-w-[80%] xs:max-w-[50%]',
         animateBounce ? 'scale-[101.5%]' : 'scale-100'
       )}
     >
@@ -233,13 +234,13 @@ export const CommandItem = React.forwardRef<CommandPrimitiveItemElement, Command
         aria-selected:scale-[100.3%]
         data-[disabled]:pointer-events-none data-[disabled]:opacity-50`
           : type === 'link'
-          ? `
+            ? `
         px-2
         transition-all
         outline-none
         aria-selected:bg-overlay-hover/90
         data-[disabled]:pointer-events-none data-[disabled]:opacity-50`
-          : `
+            : `
         px-2
         aria-selected:bg-overlay-hover/80
         aria-selected:backdrop-filter

--- a/packages/ui/src/components/Command/Command.utils.tsx
+++ b/packages/ui/src/components/Command/Command.utils.tsx
@@ -69,7 +69,7 @@ export const CommandDialog = ({ children, onKeyDown, page, ...props }: CommandDi
         '!border-overlay/90',
         'transition ease-out',
         'place-self-start mx-auto top-24',
-        'max-w-[80%] xs:max-w-[50%]',
+        'max-w-[calc(100vw-60px)] xs:max-w-[50%]',
         animateBounce ? 'scale-[101.5%]' : 'scale-100'
       )}
     >


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase Docs

## What is the current behavior?

On a mobile the search window expands the full width

## What is the new behavior?

The modal now has a max width:

<img width="401" alt="Screenshot 2024-02-03 at 18 41 42" src="https://github.com/supabase/supabase/assets/22655069/726fdd17-dc6c-4b87-aabd-49aa61bc7e7a">

## Additional context

Closes #17437
