### PR TITLE
Minor clarification in wording on Getting Started With Flutter Guide

### DIFF
--- a/apps/docs/pages/guides/getting-started/tutorials/with-flutter.mdx
+++ b/apps/docs/pages/guides/getting-started/tutorials/with-flutter.mdx
@@ -47,7 +47,7 @@ Now that we have the dependencies installed let's setup deep links.
 Setting up deep links is required to bring back the user to the app when they click on the magic link to sign in.
 We can setup deep links with just a minor tweak on our Flutter application.
 
-We will use `io.supabase.flutterquickstart` as the scheme, and `login-callback` as the host for our deep link in this example, but you can change it to whatever you would like.
+We have to use `io.supabase.flutterquickstart` as the scheme. In this example, we will use `login-callback` as the host for our deep link, but you can change it to whatever you would like.
 
 First, add `io.supabase.flutterquickstart://login-callback/` as a new [redirect URL](https://supabase.com/dashboard/project/_/auth/url-configuration) in the Dashboard.
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

NA

## What is the new behavior?

NA

## Additional context

This sentence was confusing to me and led me to believe I should put my own domain as the scheme. The wording of "you can change it to whatever you like" looks like it might apply to both scheme and host. This change clarifies that the guide is only referring to the host for the deep link.

The discord discussion gives further details of the challenge I had because of my misinterpretation: https://discord.com/channels/839993398554656828/1202047697948004472/1202047697948004472
