### PR TITLE
fix: add configuration title to settings menu

### DIFF
--- a/apps/studio/components/layouts/ProjectSettingsLayout/SettingsMenu.utils.ts
+++ b/apps/studio/components/layouts/ProjectSettingsLayout/SettingsMenu.utils.ts
@@ -65,7 +65,7 @@ export const generateSettingsMenu = (
       ],
     },
     {
-      title: '',
+      title: 'Configuration',
       items: [
         {
           name: 'Database',


### PR DESCRIPTION
## What kind of change does this PR introduce?

adds Configuration title to the Settings database section
![CleanShot 2024-02-05 at 15 07 00@2x](https://github.com/supabase/supabase/assets/37541088/f0b2722b-43ad-4fcd-96ba-66d29d895346)
