### PR TITLE
chore(logs): add 1hr as default in logs explorer

### DIFF
--- a/apps/studio/components/interfaces/Settings/Logs/Logs.constants.ts
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.constants.ts
@@ -658,10 +658,15 @@ export const PREVIEWER_DATEPICKER_HELPERS: DatetimeHelper[] = [
 ]
 export const EXPLORER_DATEPICKER_HELPERS: DatetimeHelper[] = [
   {
+    text: 'Last hour',
+    calcFrom: () => dayjs().subtract(1, 'hour').startOf('hour').toISOString(),
+    calcTo: () => '',
+    default: true,
+  },
+  {
     text: 'Last 24 hours',
     calcFrom: () => dayjs().subtract(1, 'day').startOf('day').toISOString(),
     calcTo: () => '',
-    default: true,
   },
   {
     text: 'Last 3 days',


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds "Last hour" as a default in logs explorer

## What is the current behavior?

defaults to 24h.

## What is the new behavior?

![CleanShot 2024-02-05 at 16 43 30@2x](https://github.com/supabase/supabase/assets/37541088/d8dd6893-f810-4b07-a8e8-575f2350166a)

