### PR TITLE
fix/logs-kaizen

### DIFF
--- a/apps/studio/components/interfaces/Settings/Logs/LogTable.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogTable.tsx
@@ -70,7 +70,7 @@ const LogTable = ({
         }
       },
       renderHeaderCell: (props) => {
-        return v
+        return <div className="flex items-center">{v}</div>
       },
       minWidth: 128,
     }

--- a/apps/studio/components/interfaces/Settings/Logs/LogTable.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogTable.tsx
@@ -50,7 +50,12 @@ const LogTable = ({
   const { ui } = useStore()
   const [focusedLog, setFocusedLog] = useState<LogData | null>(null)
   const firstRow: LogData | undefined = data?.[0] as LogData
-  const columnNames = Object.keys(data[0] || {})
+
+  // move timestamp to the first column
+  const { timestamp, ...rest } = firstRow || {}
+  const formattedFirstRow = { timestamp, ...rest }
+
+  const columnNames = Object.keys(formattedFirstRow || {})
   const hasId = columnNames.includes('id')
   const hasTimestamp = columnNames.includes('timestamp')
 
@@ -73,7 +78,9 @@ const LogTable = ({
         return <div className="flex items-center">{v}</div>
       },
       minWidth: 128,
+      maxWidth: v === 'timestamp' ? 240 : 600, // Without this, the column flickers on first render
     }
+
     return result
   })
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

- align items in header rows
- move timestamp to first col

## BEFORE
![CleanShot 2024-02-06 at 12 20 59@2x](https://github.com/supabase/supabase/assets/37541088/bcdd1066-83b7-4795-a64b-6d2c22a64b1e)

## AFTER
![CleanShot 2024-02-06 at 12 52 59@2x](https://github.com/supabase/supabase/assets/37541088/01aa4158-c139-4952-b059-6e0025cc3d38)


