### PR TITLE
Changed '' to '/', this fixes issues with accessing cookies from different routes

### DIFF
--- a/apps/docs/pages/guides/auth/server-side/creating-a-client.mdx
+++ b/apps/docs/pages/guides/auth/server-side/creating-a-client.mdx
@@ -468,10 +468,10 @@ export const handle: Handle = async ({ event, resolve }) => {
        * will replicate previous/standard behaviour (https://kit.svelte.dev/docs/types#public-types-cookies)
        */
       set: (key, value, options) => {
-        event.cookies.set(key, value, { ...options, path: '' })
+        event.cookies.set(key, value, { ...options, path: '/' })
       },
       remove: (key, options) => {
-        event.cookies.delete(key, { ...options, path: '' })
+        event.cookies.delete(key, { ...options, path: '/' })
       },
     },
   })


### PR DESCRIPTION
I earlier created : https://github.com/supabase/supabase/pull/20516
This got merged but still had an issue I wasn't aware of at the time, accessing the cookies from different routes, this can be achieved by setting the path to '/', this PR does that.

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

``{ path: '' }``

## What is the new behavior?

``{ path: '/' }``

## Additional context

probablykasper pointed out the issue here: https://github.com/supabase/supabase/pull/20516#issuecomment-1899011519