### PR TITLE
fix: subscription unsubscribe doc

### DIFF
--- a/apps/docs/spec/supabase_js_v2.yml
+++ b/apps/docs/spec/supabase_js_v2.yml
@@ -364,7 +364,7 @@ functions:
         isSpotlight: true
         code: |
           ```js
-          const subscription = supabase.auth.onAuthStateChange((event, session) => {
+          const { data } = supabase.auth.onAuthStateChange((event, session) => {
             console.log(event, session)
 
             if (event === 'INITIAL_SESSION') {
@@ -383,7 +383,7 @@ functions:
           })
 
           // call unsubscribe to remove the callback
-          subscription.unsubscribe()
+          data.subscription.unsubscribe()
           ```
       - id: listen-to-sign-out
         name: Listen to sign out


### PR DESCRIPTION
## What kind of change does this PR introduce?
Fix issue no. #20966

## What is the current behavior?
Current docs [listen to auth docs](https://supabase.com/docs/reference/javascript/auth-onauthstatechange?example=listen-to-auth-changes) 

```js
const subscription = supabase.auth.onAuthStateChange()

// call unsubscribe to remove the callback which is ❌ 
subscription.unsubscribe()
```
![Screenshot from 2024-02-07 01-48-39](https://github.com/supabase/supabase/assets/55092280/d5ba0e11-6f94-4d48-afd7-abed1651c6f9)

## What is the new behavior?

added changes to docs to 
```js
  const { data } = supabase.auth.onAuthStateChange()
  
 // call unsubscribe to remove the callback is now ✅ 
data.subscription.unsubscribe()
```
![image](https://github.com/supabase/supabase/assets/55092280/9a89e712-1ceb-47c2-ab45-5fdefefff671)

Changes in docs :
![image](https://github.com/supabase/supabase/assets/55092280/1a7fc1ac-b49b-4085-98fa-858570e1e483)