### PR TITLE
chore: bump turbo/supabase

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -89,7 +89,6 @@
     "npm-run-all": "^4.1.5",
     "openapi-types": "^12.0.2",
     "openapi-typescript": "^6.7.2",
-    "sass": "^1.68.0",
     "tsconfig": "*",
     "tsx": "^4.6.2",
     "typescript": "^5.2.2"

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -148,7 +148,6 @@
     "openapi-typescript": "^6.7.1",
     "postcss": "^8.4.31",
     "prettier": "^4.0.0-alpha.8",
-    "sass": "^1.68.0",
     "storybook-dark-mode": "^3.0.1",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.2.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,9 +19,9 @@
         "eslint-config-custom": "*",
         "prettier": "^4.0.0-alpha.8",
         "prettier-plugin-sql-cst": "^0.11.0",
-        "sass": "^1.68.0",
-        "supabase": "^1.45.2",
-        "turbo": "^1.11.2"
+        "sass": "^1.70.0",
+        "supabase": "^1.142.1",
+        "turbo": "^1.12.3"
       },
       "engines": {
         "node": ">=18.0.0",
@@ -536,7 +536,6 @@
         "npm-run-all": "^4.1.5",
         "openapi-types": "^12.0.2",
         "openapi-typescript": "^6.7.2",
-        "sass": "^1.68.0",
         "tsconfig": "*",
         "tsx": "^4.6.2",
         "typescript": "^5.2.2"
@@ -893,7 +892,6 @@
         "openapi-typescript": "^6.7.1",
         "postcss": "^8.4.31",
         "prettier": "^4.0.0-alpha.8",
-        "sass": "^1.68.0",
         "storybook-dark-mode": "^3.0.1",
         "tailwindcss": "^3.4.1",
         "typescript": "^5.2.2"
@@ -4030,8 +4028,9 @@
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
-      "devOptional": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
       },
@@ -4041,8 +4040,9 @@
     },
     "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.9",
-      "devOptional": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -11966,30 +11966,29 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@tootallnate/quickjs-emscripten": {
-      "version": "0.23.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
-      "devOptional": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
-      "devOptional": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
-      "devOptional": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
-      "devOptional": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/acorn": {
       "version": "4.0.6",
@@ -14561,14 +14560,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/basic-ftp": {
-      "version": "5.0.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/before-after-hook": {
       "version": "2.2.3",
       "license": "Apache-2.0"
@@ -14600,9 +14591,10 @@
       }
     },
     "node_modules/bin-links": {
-      "version": "4.0.2",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/bin-links/-/bin-links-4.0.3.tgz",
+      "integrity": "sha512-obsRaULtJurnfox/MDwgq6Yo9kzbv1CPTk/1/s7Z/61Lezc8IKkFCOXNeVLXz0456WRzBQmSsDWlai2tIhBsfA==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "cmd-shim": "^6.0.0",
         "npm-normalize-package-bin": "^3.0.0",
@@ -14615,8 +14607,9 @@
     },
     "node_modules/bin-links/node_modules/write-file-atomic": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+      "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^4.0.1"
@@ -15496,9 +15489,10 @@
       }
     },
     "node_modules/cmd-shim": {
-      "version": "6.0.1",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-6.0.2.tgz",
+      "integrity": "sha512-+FFYbB0YLaAkhkcrjkyNLYDiOsFSfRjwjY19LXk/psmMx1z00xlCv7hhQoTGXXIKi+YXHL/iiFo8NqMVQX9nOw==",
       "dev": true,
-      "license": "ISC",
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
@@ -16276,8 +16270,9 @@
     },
     "node_modules/create-require": {
       "version": "1.1.1",
-      "devOptional": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-fetch": {
       "version": "3.1.5",
@@ -16949,14 +16944,6 @@
       "version": "0.7.9",
       "license": "Apache-2.0"
     },
-    "node_modules/data-uri-to-buffer": {
-      "version": "6.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/data-urls": {
       "version": "3.0.2",
       "dev": true,
@@ -17164,30 +17151,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/degenerator": {
-      "version": "5.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ast-types": "^0.13.4",
-        "escodegen": "^2.1.0",
-        "esprima": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/degenerator/node_modules/ast-types": {
-      "version": "0.13.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/del": {
       "version": "6.1.1",
       "dev": true,
@@ -17344,8 +17307,9 @@
     },
     "node_modules/diff": {
       "version": "4.0.2",
-      "devOptional": true,
       "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -20170,49 +20134,6 @@
       },
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
-      }
-    },
-    "node_modules/get-uri": {
-      "version": "6.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "basic-ftp": "^5.0.2",
-        "data-uri-to-buffer": "^6.0.0",
-        "debug": "^4.3.4",
-        "fs-extra": "^8.1.0"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/get-uri/node_modules/fs-extra": {
-      "version": "8.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/get-uri/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/get-uri/node_modules/universalify": {
-      "version": "0.1.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
       }
     },
     "node_modules/giget": {
@@ -27676,14 +27597,6 @@
       "version": "2.6.2",
       "license": "MIT"
     },
-    "node_modules/netmask": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/next": {
       "version": "13.5.6",
       "resolved": "https://registry.npmjs.org/next/-/next-13.5.6.tgz",
@@ -28179,8 +28092,9 @@
     },
     "node_modules/npm-normalize-package-bin": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-3.0.1.tgz",
+      "integrity": "sha512-dMxCf+zZ+3zeQZXKxmyuCKlIDPGuv8EF940xbkC4kQVDTtqoh6rJFO+JTKSA6/Rwi0getWmtuy4Itup0AMcaDQ==",
       "dev": true,
-      "license": "ISC",
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
@@ -29067,90 +28981,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/pac-proxy-agent": {
-      "version": "7.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tootallnate/quickjs-emscripten": "^0.23.0",
-        "agent-base": "^7.0.2",
-        "debug": "^4.3.4",
-        "get-uri": "^6.0.1",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.2",
-        "pac-resolver": "^7.0.0",
-        "socks-proxy-agent": "^8.0.2"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/pac-proxy-agent/node_modules/agent-base": {
-      "version": "7.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/pac-proxy-agent/node_modules/http-proxy-agent": {
-      "version": "7.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/pac-proxy-agent/node_modules/https-proxy-agent": {
-      "version": "7.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.0.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/pac-proxy-agent/node_modules/socks-proxy-agent": {
-      "version": "8.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.0.2",
-        "debug": "^4.3.4",
-        "socks": "^2.7.1"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/pac-resolver": {
-      "version": "7.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "degenerator": "^5.0.0",
-        "ip": "^1.1.8",
-        "netmask": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/pac-resolver/node_modules/ip": {
-      "version": "1.1.8",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/packet-reader": {
       "version": "1.0.0",
@@ -30101,80 +29931,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/proxy-agent": {
-      "version": "6.3.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.0.2",
-        "debug": "^4.3.4",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.2",
-        "lru-cache": "^7.14.1",
-        "pac-proxy-agent": "^7.0.1",
-        "proxy-from-env": "^1.1.0",
-        "socks-proxy-agent": "^8.0.2"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/proxy-agent/node_modules/agent-base": {
-      "version": "7.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/proxy-agent/node_modules/http-proxy-agent": {
-      "version": "7.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/proxy-agent/node_modules/https-proxy-agent": {
-      "version": "7.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.0.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/proxy-agent/node_modules/lru-cache": {
-      "version": "7.18.3",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/proxy-agent/node_modules/socks-proxy-agent": {
-      "version": "8.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.0.2",
-        "debug": "^4.3.4",
-        "socks": "^2.7.1"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/proxy-compare": {
@@ -31315,8 +31071,9 @@
     },
     "node_modules/read-cmd-shim": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-4.0.0.tgz",
+      "integrity": "sha512-yILWifhaSEEytfXI76kB9xEEiG1AiozaCJZ83A87ytjRiN+jVibXjedjCRNjoZviinhG+4UkalO3mWTd8u5O0Q==",
       "dev": true,
-      "license": "ISC",
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
@@ -33085,9 +32842,10 @@
       "license": "MIT"
     },
     "node_modules/sass": {
-      "version": "1.68.0",
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.70.0.tgz",
+      "integrity": "sha512-uUxNQ3zAHeAx5nRFskBnrWzDUJrrvpCPD5FNAoRvTi0WwremlheES3tg+56PaVtCs5QDRX5CBLxxKMDJMEa1WQ==",
       "devOptional": true,
-      "license": "MIT",
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -34522,14 +34280,15 @@
       }
     },
     "node_modules/supabase": {
-      "version": "1.99.5",
+      "version": "1.142.1",
+      "resolved": "https://registry.npmjs.org/supabase/-/supabase-1.142.1.tgz",
+      "integrity": "sha512-bBq2bHgpkRdAWYUPM9RoToWDw8CrkjxYQYLmo9+MvdrOFeXwZ5XGWvy9RDqNDRy31q9gJki84idy0yOnqDebWA==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
-        "bin-links": "^4.0.1",
-        "node-fetch": "^3.2.10",
-        "proxy-agent": "^6.3.1",
+        "bin-links": "^4.0.3",
+        "https-proxy-agent": "^7.0.2",
+        "node-fetch": "^3.3.2",
         "tar": "6.2.0"
       },
       "bin": {
@@ -34543,12 +34302,37 @@
       "resolved": "tests",
       "link": true
     },
+    "node_modules/supabase/node_modules/agent-base": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+      "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/supabase/node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/supabase/node_modules/https-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "^7.0.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/supabase/node_modules/node-fetch": {
@@ -35665,8 +35449,9 @@
     },
     "node_modules/ts-node": {
       "version": "10.9.1",
-      "devOptional": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -35707,8 +35492,9 @@
     },
     "node_modules/ts-node/node_modules/arg": {
       "version": "4.1.3",
-      "devOptional": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/tsconfig": {
       "resolved": "packages/tsconfig",
@@ -35918,26 +35704,26 @@
       }
     },
     "node_modules/turbo": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/turbo/-/turbo-1.11.2.tgz",
-      "integrity": "sha512-jPC7LVQJzebs5gWf8FmEvsvXGNyKbN+O9qpvv98xpNaM59aS0/Irhd0H0KbcqnXfsz7ETlzOC3R+xFWthC4Z8A==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-1.12.3.tgz",
+      "integrity": "sha512-a6q8I0TK9ohACYbkmxzG/JYPuDC4VCvfmXLTlf321qQ4BIAhoyaOj/O2g+zJ6L1vNYnZ82G4LrbMfgLLngbLsg==",
       "dev": true,
       "bin": {
         "turbo": "bin/turbo"
       },
       "optionalDependencies": {
-        "turbo-darwin-64": "1.11.2",
-        "turbo-darwin-arm64": "1.11.2",
-        "turbo-linux-64": "1.11.2",
-        "turbo-linux-arm64": "1.11.2",
-        "turbo-windows-64": "1.11.2",
-        "turbo-windows-arm64": "1.11.2"
+        "turbo-darwin-64": "1.12.3",
+        "turbo-darwin-arm64": "1.12.3",
+        "turbo-linux-64": "1.12.3",
+        "turbo-linux-arm64": "1.12.3",
+        "turbo-windows-64": "1.12.3",
+        "turbo-windows-arm64": "1.12.3"
       }
     },
     "node_modules/turbo-darwin-64": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.11.2.tgz",
-      "integrity": "sha512-toFmRG/adriZY3hOps7nYCfqHAS+Ci6xqgX3fbo82kkLpC6OBzcXnleSwuPqjHVAaRNhVoB83L5njcE9Qwi2og==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.12.3.tgz",
+      "integrity": "sha512-dDglIaux+A4jOnB9CDH69sujmrnuLJLrKw1t3J+if6ySlFuxSwC++gDq9TVuOZo2+S7lFkGh+x5ytn3wp+jE8Q==",
       "cpu": [
         "x64"
       ],
@@ -35948,9 +35734,9 @@
       ]
     },
     "node_modules/turbo-darwin-arm64": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.11.2.tgz",
-      "integrity": "sha512-FCsEDZ8BUSFYEOSC3rrARQrj7x2VOrmVcfrMUIhexTxproRh4QyMxLfr6LALk4ymx6jbDCxWa6Szal8ckldFbA==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.12.3.tgz",
+      "integrity": "sha512-5TqqeujEyHMoVUWGzSzUl5ERSg7HDCdbU3gBs5ziWTpFRpeJ/+Y15kYyZJcMQcubRIH3Y1hL/yA5IhlGdgXOMA==",
       "cpu": [
         "arm64"
       ],
@@ -35961,9 +35747,9 @@
       ]
     },
     "node_modules/turbo-linux-64": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.11.2.tgz",
-      "integrity": "sha512-Vzda/o/QyEske5CxLf0wcu7UUS+7zB90GgHZV4tyN+WZtoouTvbwuvZ3V6b5Wgd3OJ/JwWR0CXDK7Sf4VEMr7A==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.12.3.tgz",
+      "integrity": "sha512-yUreU+/gq4vlBtcdyfjz7slwz4zM1RG8sSXvyHmAS+QXqSrGkegg4qLl2fRbv/c3EyA/XbfcZuD6tcrXkejr6g==",
       "cpu": [
         "x64"
       ],
@@ -35974,9 +35760,9 @@
       ]
     },
     "node_modules/turbo-linux-arm64": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.11.2.tgz",
-      "integrity": "sha512-bRLwovQRz0yxDZrM4tQEAYV0fBHEaTzUF0JZ8RG1UmZt/CqtpnUrJpYb1VK8hj1z46z9YehARpYCwQ2K0qU4yw==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.12.3.tgz",
+      "integrity": "sha512-XRwAsp2eRSqZmaMVNrmHoKqofeJMuD87zmefZLTRAObh38hIwKgyl2QRsJIbteob5RN77yFbv3lAJ36UIY5h7w==",
       "cpu": [
         "arm64"
       ],
@@ -35987,9 +35773,9 @@
       ]
     },
     "node_modules/turbo-windows-64": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.11.2.tgz",
-      "integrity": "sha512-LgTWqkHAKgyVuLYcEPxZVGPInTjjeCnN5KQMdJ4uQZ+xMDROvMFS2rM93iQl4ieDJgidwHCxxCxaU9u8c3d/Kg==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.12.3.tgz",
+      "integrity": "sha512-CPnRfnUCtmFeShOtUdMCthySjmyHaoTyh9JueiYFvtCNeO3WfDMj63dpOQstQWHdJFYmIrIGfhAclcds9ePQYA==",
       "cpu": [
         "x64"
       ],
@@ -36000,9 +35786,9 @@
       ]
     },
     "node_modules/turbo-windows-arm64": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.11.2.tgz",
-      "integrity": "sha512-829aVBU7IX0c/B4G7g1VI8KniAGutHhIupkYMgF6xPkYVev2G3MYe6DMS/vsLt9GGM9ulDtdWxWrH5P2ngK8IQ==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.12.3.tgz",
+      "integrity": "sha512-cYA/wlzvp4vlCNHYJ2AjNS3FLXWwUC/5CJompBkTeKFFB6AviE/iLkbIhFikCVSNXZk/3AGanpMUXIkt3bdlwg==",
       "cpu": [
         "arm64"
       ],
@@ -36777,8 +36563,9 @@
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
-      "devOptional": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.1.0",
@@ -37807,8 +37594,9 @@
     },
     "node_modules/yn": {
       "version": "3.1.1",
-      "devOptional": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -38818,12 +38606,10 @@
         "allure-commandline": "^2.17.2",
         "allure-js-commons": "^2.0.0-beta.14",
         "cross-fetch": "^3.1.5",
-        "eslint": "^8.56.0",
         "jest-allure2-adapter": "^0.3.12",
         "jest-environment-jsdom": "^29.7.0",
         "postgres": "^3.0.5",
         "ts-jest": "^29.1.1",
-        "ts-node": "^10.9.1",
         "typescript": "^5.2.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
     "eslint-config-custom": "*",
     "prettier": "^4.0.0-alpha.8",
     "prettier-plugin-sql-cst": "^0.11.0",
-    "sass": "^1.68.0",
-    "supabase": "^1.45.2",
-    "turbo": "^1.11.2"
+    "sass": "^1.70.0",
+    "supabase": "^1.142.1",
+    "turbo": "^1.12.3"
   },
   "repository": {
     "type": "git",

--- a/tests/package.json
+++ b/tests/package.json
@@ -27,12 +27,10 @@
     "allure-commandline": "^2.17.2",
     "allure-js-commons": "^2.0.0-beta.14",
     "cross-fetch": "^3.1.5",
-    "eslint": "^8.56.0",
     "ts-jest": "^29.1.1",
     "jest-allure2-adapter": "^0.3.12",
     "jest-environment-jsdom": "^29.7.0",
     "postgres": "^3.0.5",
-    "ts-node": "^10.9.1",
     "typescript": "^5.2.2"
   }
 }


### PR DESCRIPTION
- Bumps turbo, sass, supabase
- Removes duplicate definitions of `sass` dependency, as it's registered in the parent package.json
- Removed unused ts-node dependency