### PR TITLE
fix: prettier json(c) formatting

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -7,5 +7,11 @@
   "endOfLine": "lf",
   "sqlKeywordCase": "lower",
   "pluginSearchDirs": false,
-  "plugins": ["prettier-plugin-sql-cst"]
+  "plugins": ["prettier-plugin-sql-cst"],
+  "overrides": [
+    {
+      "files": "**/*.json",
+      "options": { "parser": "json" }
+    }
+  ]
 }


### PR DESCRIPTION
Prettier recognizes some *.json files (i.e. tsconfig.json) as JSONC, whereas VSCode does not support JSONC for the prettier extension. This leads to different formatting in CI/CLI vs. local formatting in VSCode.

PR overwrites the inferred parser for prettier to always format *.json files with JSON (no trailing commas)