### PR TITLE
Fix copy on pricing page

### DIFF
--- a/apps/www/components/Pricing/PricingComputeSection.tsx
+++ b/apps/www/components/Pricing/PricingComputeSection.tsx
@@ -70,7 +70,7 @@ const PricingComputeSection = () => {
 
             <div className="grid lg:grid-cols-2 gap-4 md:gap-8 mt-4 md:mt-0 border-t">
               <div className="max-w-4xl prose p-4 md:p-8 relative z-10">
-                <h4 className="text-lg">Choose best compute size you</h4>
+                <h4 className="text-lg">Choose the best compute size for you</h4>
                 <p className="text-[13px] text-foreground-lighter">
                   Every project on the Supabase Platform comes with its own dedicated Postgres
                   instance running inside a virtual machine (VM). The table above describes the base


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes copy in compute add-on box on pricing page

## What is the current behavior?

Copy reads "Choose best compute size you"

<img width="960" alt="Screenshot 2024-02-07 at 10 47 58" src="https://github.com/supabase/supabase/assets/31189692/febc9ecd-55b3-40bc-9a35-638a23f1bc71">


## What is the new behavior?

Copy reads "Choose the best compute size for you"

<img width="952" alt="Screenshot 2024-02-07 at 10 52 07" src="https://github.com/supabase/supabase/assets/31189692/a8fe37b4-39eb-4c78-86f9-7240dafdf764">

