### PR TITLE
This commit adds a redirect rule to the 'redirect.js' file

### DIFF
--- a/apps/www/lib/redirects.js
+++ b/apps/www/lib/redirects.js
@@ -2368,4 +2368,9 @@ module.exports = [
     source: '/guides/api/rest/joins-and-nesting',
     destination: '/guides/database/joins-and-nesting',
   },
+  {
+    permanent: true,
+    source: '/docs/guides/storage/uploads',
+    destination: '/docs/guides/storage/uploads/standard-uploads',
+  },
 ]


### PR DESCRIPTION
This commit adds a redirect rule to the 'redirect.js' file to permanently redirect requests from '/docs/guides/storage/uploads' to '/docs/guides/storage/uploads/standard-uploads'. This will ensure that users accessing the old URL are redirected to the appropriate location.
