### PR TITLE
Update AI models to gpt-3.5-turbo-0125

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28718,9 +28718,9 @@
       }
     },
     "node_modules/openai": {
-      "version": "4.20.1",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-4.20.1.tgz",
-      "integrity": "sha512-Dd3q8EvINfganZFtg6V36HjrMaihqRgIcKiHua4Nq9aw/PxOP48dhbsk8x5klrxajt5Lpnc1KTOG5i1S6BKAJA==",
+      "version": "4.26.1",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.26.1.tgz",
+      "integrity": "sha512-DvWbjhWbappsFRatOWmu4Dp1/Q4RG9oOz6CfOSjy0/Drb8G+5iAiqWAO4PfpGIkhOOKtvvNfQri2SItl+U7LhQ==",
       "dependencies": {
         "@types/node": "^18.11.18",
         "@types/node-fetch": "^2.6.4",
@@ -37679,12 +37679,13 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
+        "@gregnr/libpg-query": "^13.4.0-dev.12",
         "@serafin/schema-builder": "^0.18.5",
         "ai": "^2.2.29",
         "common-tags": "^1.8.2",
         "config": "*",
         "jsonrepair": "^3.5.0",
-        "openai": "^4.20.1"
+        "openai": "^4.26.1"
       },
       "devDependencies": {
         "@babel/core": "^7.23.6",

--- a/packages/ai-commands/package.json
+++ b/packages/ai-commands/package.json
@@ -9,12 +9,13 @@
     "test": "jest"
   },
   "dependencies": {
+    "@gregnr/libpg-query": "^13.4.0-dev.12",
     "@serafin/schema-builder": "^0.18.5",
     "ai": "^2.2.29",
     "common-tags": "^1.8.2",
     "config": "*",
     "jsonrepair": "^3.5.0",
-    "openai": "^4.20.1"
+    "openai": "^4.26.1"
   },
   "devDependencies": {
     "@babel/core": "^7.23.6",

--- a/packages/ai-commands/src/__snapshots__/sql.test.ts.snap
+++ b/packages/ai-commands/src/__snapshots__/sql.test.ts.snap
@@ -39,7 +39,10 @@ exports[`generate single table with specified columns 1`] = `
 `;
 
 exports[`rls chat select policy using table definition 1`] = `
-"create policy select_todo_policy on todos for
-select
-  using (user_id = auth.uid ());"
+{
+  "checkExpression": undefined,
+  "command": "select",
+  "table": "todos",
+  "usingExpression": "user_id = auth.uid ()",
+}
 `;

--- a/packages/ai-commands/src/sql.edge.ts
+++ b/packages/ai-commands/src/sql.edge.ts
@@ -41,8 +41,10 @@ export async function chatRlsPolicy(
         - If the user asks for something that's not related to SQL policies, explain to the user 
           that you can only help with policies.
         
-        The output should look like this: 
-        "CREATE POLICY user_policy ON users FOR INSERT USING (user_name = current_user) WITH (true);" 
+        The output should look like this:
+        \`\`\`sql
+        CREATE POLICY "My descriptive policy." ON users FOR INSERT USING (user_name = current_user) WITH (true);
+        \`\`\`
       `,
     },
   ]
@@ -72,7 +74,7 @@ export async function chatRlsPolicy(
 
   try {
     const response = await openai.chat.completions.create({
-      model: 'gpt-3.5-turbo-1106',
+      model: 'gpt-3.5-turbo-0125',
       messages: initMessages,
       max_tokens: 1024,
       temperature: 0,

--- a/packages/ai-commands/src/sql.test.ts
+++ b/packages/ai-commands/src/sql.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from '@jest/globals'
 import { codeBlock } from 'common-tags'
 import OpenAI from 'openai'
-import { collectStream, extractMarkdownSql, formatSql } from '../test/util'
+import { collectStream, extractMarkdownSql, formatSql, getPolicyInfo } from '../test/util'
 import { debugSql, editSql, generateSql, titleSql } from './sql'
 import { chatRlsPolicy } from './sql.edge'
 
@@ -123,6 +123,11 @@ describe('rls chat', () => {
     const responseText = await collectStream(responseStream)
     const [sql] = extractMarkdownSql(responseText)
 
-    expect(formatSql(sql)).toMatchSnapshot()
+    const { name, ...otherInfo } = await getPolicyInfo(sql)
+
+    expect(otherInfo).toMatchSnapshot()
+    await expect(name).toMatchCriteria(
+      'policy says that users can select their own todos (not insert, update, delete, etc)'
+    )
   })
 })

--- a/packages/ai-commands/src/sql.ts
+++ b/packages/ai-commands/src/sql.ts
@@ -15,6 +15,7 @@ const generateSqlSchema = SchemaBuilder.emptySchema()
       - Prefer 'timestamp with time zone' over 'date'
       - Use vector(384) data type for any embedding/vector related query
       - Always use double apostrophe in SQL strings (eg. 'Night''s watch')
+      - Always use semicolons
     `,
   })
   .addString('title', {
@@ -36,6 +37,7 @@ const editSqlSchema = SchemaBuilder.emptySchema().addString('sql', {
       - Always use double apostrophe in SQL strings (eg. 'Night''s watch')
       - Use real examples when possible
       - Add constraints if requested
+      - Always use semicolons
     `,
 })
 
@@ -44,7 +46,8 @@ const debugSqlSchema = SchemaBuilder.emptySchema()
     description: 'A short suggested solution for the error (as concise as possible).',
   })
   .addString('sql', {
-    description: 'The SQL rewritten to apply the solution. Includes all the original logic, but modified to fix the issue.',
+    description:
+      'The SQL rewritten to apply the solution. Includes all the original logic, but modified to fix the issue.',
   })
 
 const generateTitleSchema = SchemaBuilder.emptySchema()
@@ -91,6 +94,7 @@ const completionFunctions = {
       - Prefer 'timestamp with time zone' over 'date'
       - Use vector(384) data type for any embedding/vector related query
       - Always use double apostrophe in SQL strings (eg. 'Night''s watch')
+      - Always use semicolons
     `,
     parameters: debugSqlSchema.schema as Record<string, unknown>,
   },

--- a/packages/ai-commands/src/sql.ts
+++ b/packages/ai-commands/src/sql.ts
@@ -132,7 +132,7 @@ export async function generateSql(openai: OpenAI, prompt: string, entityDefiniti
 
   try {
     const completionResponse = await openai.chat.completions.create({
-      model: 'gpt-3.5-turbo-1106',
+      model: 'gpt-3.5-turbo-0125',
       messages: completionMessages,
       max_tokens: 1024,
       temperature: 0,
@@ -218,7 +218,7 @@ export async function editSql(
 
   try {
     const completionResponse = await openai.chat.completions.create({
-      model: 'gpt-3.5-turbo-1106',
+      model: 'gpt-3.5-turbo-0125',
       messages: completionMessages,
       max_tokens: 2048,
       temperature: 0,
@@ -307,7 +307,7 @@ export async function debugSql(
 
   try {
     const completionResponse = await openai.chat.completions.create({
-      model: 'gpt-3.5-turbo-1106',
+      model: 'gpt-3.5-turbo-0125',
       messages: completionMessages,
       max_tokens: 2048,
       temperature: 0,
@@ -367,7 +367,7 @@ export async function titleSql(openai: OpenAI, sql: string) {
 
   try {
     const completionResponse = await openai.chat.completions.create({
-      model: 'gpt-3.5-turbo-1106',
+      model: 'gpt-3.5-turbo-0125',
       messages: completionMessages,
       max_tokens: 1024,
       temperature: 0,

--- a/packages/ai-commands/test/util.ts
+++ b/packages/ai-commands/test/util.ts
@@ -1,3 +1,4 @@
+import { parseQuery } from '@gregnr/libpg-query'
 import { fromMarkdown } from 'mdast-util-from-markdown'
 import type { Code } from 'mdast-util-from-markdown/lib'
 import { format } from 'sql-formatter'
@@ -6,6 +7,14 @@ declare global {
   interface ReadableStream<R = any> {
     [Symbol.asyncIterator](): AsyncIterableIterator<R>
   }
+}
+
+export type PolicyInfo = {
+  name: string
+  table: string
+  command?: string
+  usingExpression?: string
+  checkExpression?: string
 }
 
 /**
@@ -44,4 +53,53 @@ export function extractMarkdownSql(markdown: string) {
   return mdTree.children
     .filter((node): node is Code => node.type === 'code' && node.lang === 'sql')
     .map(({ value }) => value)
+}
+
+/**
+ * Parses a Postgres SQL policy.
+ *
+ * @returns Information about the policy, including its name, table, command, and expressions.
+ */
+export async function getPolicyInfo(sql: string) {
+  const result = await parseQuery(sql)
+
+  if (result.stmts.length === 0) {
+    throw new Error('Expected a statement, but received none')
+  }
+
+  if (result.stmts.length > 1) {
+    throw new Error('Expected a single statement, but received multiple')
+  }
+
+  const [{ stmt }] = result.stmts
+
+  const createPolicyStatement = stmt.CreatePolicyStmt
+
+  if (!createPolicyStatement) {
+    throw new Error('Expected a create policy statement')
+  }
+
+  const formattedSql = formatSql(sql)
+
+  const usingMatch = formattedSql.match(/using\s*\((.*)\)/i)
+  let usingExpression
+  if (usingMatch) {
+    usingExpression = usingMatch[1]
+  }
+
+  const withCheckMatch = formattedSql.match(/with check\s*\((.*)\)/i)
+  let checkExpression
+  if (withCheckMatch) {
+    checkExpression = withCheckMatch[1]
+  }
+
+  const policyInfo: PolicyInfo = {
+    name: createPolicyStatement.policy_name,
+    table: createPolicyStatement.table.relname,
+    command: createPolicyStatement.cmd_name,
+    usingExpression,
+    checkExpression,
+  }
+
+  return policyInfo
 }

--- a/packages/ai-commands/test/util.ts
+++ b/packages/ai-commands/test/util.ts
@@ -81,13 +81,13 @@ export async function getPolicyInfo(sql: string) {
 
   const formattedSql = formatSql(sql)
 
-  const usingMatch = formattedSql.match(/using\s*\((.*)\)/i)
+  const usingMatch = formattedSql.match(/using\s*\((.*)\)/is)
   let usingExpression
   if (usingMatch) {
     usingExpression = usingMatch[1]
   }
 
-  const withCheckMatch = formattedSql.match(/with check\s*\((.*)\)/i)
+  const withCheckMatch = formattedSql.match(/with check\s*\((.*)\)/is)
   let checkExpression
   if (withCheckMatch) {
     checkExpression = withCheckMatch[1]


### PR DESCRIPTION
OpenAI made `gpt-3.5-turbo-0125` available at the end of last week. This updates our AI logic to use this new model (and makes minor prompt adjustments accordingly).

Also updates our AI policy tests to be more robust against varying policy titles (since GPT isn't deterministic).