### PR TITLE
Update inviteUserByEmail API usage docs

### DIFF
--- a/apps/studio/components/interfaces/Docs/Snippets.ts
+++ b/apps/studio/components/interfaces/Docs/Snippets.ts
@@ -647,7 +647,7 @@ curl -X POST '${endpoint}/auth/v1/invite' \\
     js: {
       language: 'js',
       code: `
-let { data, error } = await supabase.auth.api.inviteUserByEmail('someone@email.com')
+let { data, error } = await supabase.auth.admin.inviteUserByEmail('someone@email.com')
 `,
     },
   }),


### PR DESCRIPTION
The current usage of this API seems to be stored within `supabase.auth.admin.inviteUserByEmail`, not `supabase.auth.api.inviteUserByEmail`.

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

The documentation does not match the implementation.

## What is the new behavior?

Text content udpate.

## Additional context

Add any other context or screenshots.

<img width="943" alt="Screenshot 2024-02-07 at 20 55 47" src="https://github.com/supabase/supabase/assets/22284473/7e4c3fa9-5b3f-4c5c-b69b-fe64f7031a21">

![Screenshot 2024-02-07 at 20 56 40](https://github.com/supabase/supabase/assets/22284473/2e848a6b-1324-4a0b-a5cb-048c15772a88)

