### PR TITLE
Mobile banner padding

### DIFF
--- a/packages/ui/src/layout/banners/IPV4Banner/index.tsx
+++ b/packages/ui/src/layout/banners/IPV4Banner/index.tsx
@@ -4,7 +4,7 @@ import { Button } from '../../../components/Button'
 
 const index = memo(() => {
   return (
-    <div className="relative w-full h-auto min-h-[44px] border-b p-2 flex items-center group justify-center text-foreground bg-surface-100 transition-colors overflow-hidden">
+    <div className="relative w-full h-auto min-h-[44px] border-b px-6 py-3 sm:py-2 flex items-center group justify-center text-foreground bg-surface-100 transition-colors overflow-hidden">
       <div className="relative z-10 flex items-center justify-center">
         <div className="w-full flex gap-4 items-center md:justify-center text-sm">
           <div className="flex gap-2 items-center">


### PR DESCRIPTION
## What kind of change does this PR introduce?

Padding adjustment.

## What is the current behavior?

<img width="401" alt="Screenshot 2024-02-08 at 11 23 31" src="https://github.com/supabase/supabase/assets/25671831/6a65aa49-e041-4327-8fa2-9d094dd165da">

## What is the new behavior?

<img width="396" alt="Screenshot 2024-02-08 at 11 23 23" src="https://github.com/supabase/supabase/assets/25671831/c7242699-a143-4473-b181-d4e062b8164a">
