### PR TITLE
chore: update styling, a11y and markup for table editor side panel

### DIFF
--- a/apps/studio/components/layouts/TableEditorLayout/EntityListItem.tsx
+++ b/apps/studio/components/layouts/TableEditorLayout/EntityListItem.tsx
@@ -123,7 +123,7 @@ const EntityListItem = ({ id, projectRef, item: entity, isLocked }: EntityListIt
     >
       <Link
         href={`/project/${projectRef}/editor/${entity.id}`}
-        className="flex items-center gap-2 py-1 pl-3 w-full max-w-[90%]"
+        className="flex items-center gap-2 py-1 pl-2 w-full max-w-[90%]"
       >
         <Tooltip.Root delayDuration={0} disableHoverableContent={true}>
           <Tooltip.Trigger className="flex items-center">

--- a/apps/studio/components/layouts/TableEditorLayout/EntityListItem.tsx
+++ b/apps/studio/components/layouts/TableEditorLayout/EntityListItem.tsx
@@ -15,6 +15,7 @@ import {
   IconEdit,
   IconLock,
   IconTrash,
+  cn,
 } from 'ui'
 
 import { parseSupaTable } from 'components/grid'
@@ -147,22 +148,25 @@ const EntityListItem = ({ id, projectRef, item: entity, isLocked }: EntityListIt
             )}
           </Tooltip.Trigger>
           <Tooltip.Portal>
-            <Tooltip.Content side="bottom">
+            <Tooltip.Content
+              side="bottom"
+              className={[
+                'rounded bg-alternative py-1 px-2 leading-none shadow',
+                'border border-background',
+                'text-xs text-foreground capitalize',
+              ].join(' ')}
+            >
               <Tooltip.Arrow className="radix-tooltip-arrow" />
-              <div
-                className={[
-                  'rounded bg-alternative py-1 px-2 leading-none shadow',
-                  'border border-background',
-                ].join(' ')}
-              >
-                <span className="text-xs text-foreground capitalize">
-                  {formatTooltipText(entity.type)}
-                </span>
-              </div>
+              {formatTooltipText(entity.type)}
             </Tooltip.Content>
           </Tooltip.Portal>
         </Tooltip.Root>
-        <div className="text-sm text-foreground-light group-hover:text-foreground transition max-w-[175px] overflow-hidden text-ellipsis whitespace-nowrap flex items-center justify-between gap-2 relative w-full">
+        <div
+          className={cn(
+            'text-sm text-foreground-light group-hover:text-foreground transition max-w-[175px] overflow-hidden text-ellipsis whitespace-nowrap flex items-center gap-2 relative w-full',
+            isActive && 'text-foreground'
+          )}
+        >
           {/* only show tooltips if required, to reduce noise */}
           {entity.name.length > 20 ? (
             <Tooltip.Root delayDuration={0} disableHoverableContent={true}>
@@ -170,16 +174,16 @@ const EntityListItem = ({ id, projectRef, item: entity, isLocked }: EntityListIt
                 {entity.name}
               </Tooltip.Trigger>
               <Tooltip.Portal>
-                <Tooltip.Content side="right">
+                <Tooltip.Content
+                  side="right"
+                  className={[
+                    'rounded bg-alternative py-1 px-2 leading-none shadow',
+                    'border border-background',
+                    'text-xs text-foreground',
+                  ].join(' ')}
+                >
                   <Tooltip.Arrow className="radix-tooltip-arrow" />
-                  <div
-                    className={[
-                      'rounded bg-alternative py-1 px-2 leading-none shadow',
-                      'border border-background',
-                    ].join(' ')}
-                  >
-                    <span className="text-xs text-foreground">{entity.name}</span>
-                  </div>
+                  {entity.name}
                 </Tooltip.Content>
               </Tooltip.Portal>
             </Tooltip.Root>
@@ -187,9 +191,13 @@ const EntityListItem = ({ id, projectRef, item: entity, isLocked }: EntityListIt
             entity.name
           )}
 
-          {entity.type === ENTITY_TYPE.TABLE && entity.rls_enabled && (
+          {entity.type === ENTITY_TYPE.TABLE && !entity.rls_enabled && (
             <div className="w-4 px-0.5">
-              <Unlock size={14} className="text-orange-700" />
+              <Unlock
+                size={14}
+                strokeWidth={1}
+                className={cn(isActive ? 'text-warning' : 'text-warning-500')}
+              />
             </div>
           )}
         </div>
@@ -212,7 +220,7 @@ const EntityListItem = ({ id, projectRef, item: entity, isLocked }: EntityListIt
                 }}
               >
                 <IconEdit size="tiny" />
-                <p>Edit Table</p>
+                <span>Edit Table</span>
               </DropdownMenuItem>
               <DropdownMenuItem
                 key="duplicate-table"
@@ -223,7 +231,7 @@ const EntityListItem = ({ id, projectRef, item: entity, isLocked }: EntityListIt
                 }}
               >
                 <IconCopy size="tiny" />
-                <p>Duplicate Table</p>
+                <span>Duplicate Table</span>
               </DropdownMenuItem>
               <DropdownMenuItem key="delete-table" className="space-x-2" asChild>
                 <Link
@@ -231,7 +239,7 @@ const EntityListItem = ({ id, projectRef, item: entity, isLocked }: EntityListIt
                   href={`/project/${projectRef}/auth/policies?schema=${snap.selectedSchemaName}&search=${entity.id}`}
                 >
                   <IconLock size="tiny" />
-                  <p>View Policies</p>
+                  <span>View Policies</span>
                 </Link>
               </DropdownMenuItem>
               <DropdownMenuItem
@@ -243,7 +251,7 @@ const EntityListItem = ({ id, projectRef, item: entity, isLocked }: EntityListIt
                 }}
               >
                 <IconDownload size="tiny" />
-                <p>Export as CSV</p>
+                <span>Export as CSV</span>
               </DropdownMenuItem>
               <DropdownMenuSeparator />
               <DropdownMenuItem
@@ -255,7 +263,7 @@ const EntityListItem = ({ id, projectRef, item: entity, isLocked }: EntityListIt
                 }}
               >
                 <IconTrash size="tiny" />
-                <p>Delete Table</p>
+                <span>Delete Table</span>
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>

--- a/apps/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
+++ b/apps/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
@@ -30,6 +30,7 @@ import {
   IconPlusCircle,
   IconSearch,
   IconX,
+  cn,
 } from 'ui'
 import { useProjectContext } from '../ProjectLayout/ProjectContext'
 import EntityListItem from './EntityListItem'
@@ -163,9 +164,7 @@ const TableEditorMenu = () => {
             </Tooltip.Root>
           ) : (
             <Alert_Shadcn_>
-              <AlertTitle_Shadcn_ className="text-xs tracking-normal">
-                Viewing protected schema
-              </AlertTitle_Shadcn_>
+              <AlertTitle_Shadcn_ className="text-sm">Viewing protected schema</AlertTitle_Shadcn_>
               <AlertDescription_Shadcn_ className="text-xs">
                 <p className="mb-2">
                   This schema is managed by Supabase and is read-only through the table editor
@@ -192,7 +191,7 @@ const TableEditorMenu = () => {
                     <input
                       type="text"
                       placeholder="Search..."
-                      className="bg-default rounded-md px-2 py-0 h-8 focus:outline-none w-44 text-sm"
+                      className="bg-default text-foreground rounded-none px-0 py-0 h-8 focus:outline-none w-44 text-sm"
                       onChange={(e) => setSearchText(e.target.value.trim())}
                       value={searchText}
                       ref={inputRef}
@@ -201,7 +200,14 @@ const TableEditorMenu = () => {
                 )}
               </AnimatePresence>
               <motion.button
-                onClick={expandSearch}
+                onClick={
+                  !isSearchOpen
+                    ? () => expandSearch()
+                    : () => {
+                        setSearchText('')
+                        expandSearch()
+                      }
+                }
                 initial={{ x: 0 }}
                 animate={{ x: isSearchOpen ? 185 : 0, transition: { duration: 0 } }}
                 className="px-2 py-1 rounded-md mt-0.5 transition transform hover:scale-105 focus:outline-none"
@@ -214,14 +220,10 @@ const TableEditorMenu = () => {
                       strokeWidth={1.5}
                     />
                   ) : (
-                    <button onClick={() => setSearchText('')}>
-                      <IconX />
-                    </button>
+                    <IconX className={cn('hover:text-foreground transition-colors')} />
                   )
                 ) : (
-                  <button>
-                    <IconSearch />
-                  </button>
+                  <IconSearch className={cn('hover:text-foreground transition-colors')} />
                 )}
               </motion.button>
             </div>
@@ -230,22 +232,23 @@ const TableEditorMenu = () => {
                 <Tooltip.Root delayDuration={0}>
                   <DropdownMenuTrigger asChild>
                     <Tooltip.Trigger>
-                      <div className="text-foreground-lighter transition-colors hover:text-foreground">
-                        <IconChevronsDown size={18} strokeWidth={1} />
-                      </div>
+                      <IconChevronsDown
+                        size={18}
+                        strokeWidth={1}
+                        className="text-foreground-lighter transition-colors hover:text-foreground"
+                      />
                     </Tooltip.Trigger>
                   </DropdownMenuTrigger>
                   <Tooltip.Portal>
-                    <Tooltip.Content side="bottom">
+                    <Tooltip.Content
+                      side="bottom"
+                      className={[
+                        'rounded bg-alternative py-1 px-2 leading-none shadow',
+                        'border border-background text-xs',
+                      ].join(' ')}
+                    >
                       <Tooltip.Arrow className="radix-tooltip-arrow" />
-                      <div
-                        className={[
-                          'rounded bg-alternative py-1 px-2 leading-none shadow',
-                          'border border-background',
-                        ].join(' ')}
-                      >
-                        <span className="text-xs">Sort By</span>
-                      </div>
+                      Sort By
                     </Tooltip.Content>
                   </Tooltip.Portal>
                 </Tooltip.Root>

--- a/apps/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
+++ b/apps/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
@@ -199,6 +199,7 @@ const TableEditorMenu = () => {
                       <span className="sr-only">Search tables</span>
                       <input
                         id="search-tables"
+                        name="search-tables"
                         type="text"
                         placeholder="Search..."
                         className={cn(

--- a/apps/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
+++ b/apps/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
@@ -208,13 +208,24 @@ const TableEditorMenu = () => {
                           'border-transparent focus:border-transparent focus:ring-0',
                           'focus:border-b-red'
                         )}
-                        onChange={(e) => setSearchText(e.target.value.trim())}
+                        onChange={(e) => {
+                          setSearchText(e.target.value.trim())
+                        }}
                         value={searchText}
                         ref={(el) => {
                           inputRef.current = el
                           if (el) {
                             el.addEventListener('focus', handleSearchInputFocusChange)
                             el.addEventListener('blur', handleSearchInputFocusChange)
+                          }
+                        }}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Escape') {
+                            setIsSearchOpen(false)
+                            setSearchText('')
+                          }
+                          if (e.key === 'Backspace' && searchText.length === 0) {
+                            setIsSearchOpen(false)
                           }
                         }}
                       />

--- a/apps/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
+++ b/apps/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
@@ -34,6 +34,7 @@ import {
 } from 'ui'
 import { useProjectContext } from '../ProjectLayout/ProjectContext'
 import EntityListItem from './EntityListItem'
+import { Loader2 } from 'lucide-react'
 
 const TableEditorMenu = () => {
   const { id } = useParams()
@@ -47,6 +48,7 @@ const TableEditorMenu = () => {
   )
   const [isSearchOpen, setIsSearchOpen] = useState(false)
   const inputRef = useRef<HTMLInputElement | null>(null)
+  const [isSearchInputFocused, setIsSearchInputFocused] = useState(false)
 
   const { project } = useProjectContext()
   const {
@@ -107,6 +109,11 @@ const TableEditorMenu = () => {
       inputRef.current.focus()
     }
   }, [isSearchOpen])
+
+  const handleSearchInputFocusChange = () => {
+    setIsSearchInputFocused(inputRef.current === document.activeElement)
+  }
+
   return (
     <>
       <div
@@ -188,14 +195,35 @@ const TableEditorMenu = () => {
                     exit={{ x: 20, opacity: 0, transition: { duration: 0 } }}
                     className="absolute top-0 left-2"
                   >
-                    <input
-                      type="text"
-                      placeholder="Search..."
-                      className="bg-default text-foreground rounded-none px-0 py-0 h-8 focus:outline-none w-44 text-sm"
-                      onChange={(e) => setSearchText(e.target.value.trim())}
-                      value={searchText}
-                      ref={inputRef}
-                    />
+                    <label htmlFor={'search-tables'} className="relative">
+                      <span className="sr-only">Search tables</span>
+                      <input
+                        id="search-tables"
+                        type="text"
+                        placeholder="Search..."
+                        className={cn(
+                          'bg-default text-foreground rounded-none px-0 py-0 h-5 focus:outline-none w-44 text-sm',
+                          'border-b outline-none focus:outline-none',
+                          'border-transparent focus:border-transparent focus:ring-0',
+                          'focus:border-b-red'
+                        )}
+                        onChange={(e) => setSearchText(e.target.value.trim())}
+                        value={searchText}
+                        ref={(el) => {
+                          inputRef.current = el
+                          if (el) {
+                            el.addEventListener('focus', handleSearchInputFocusChange)
+                            el.addEventListener('blur', handleSearchInputFocusChange)
+                          }
+                        }}
+                      />
+                      <div
+                        className={cn(
+                          'absolute -bottom-1 w-full h-px bg-border transition-colors',
+                          isSearchInputFocused && 'bg-border-stronger'
+                        )}
+                      ></div>
+                    </label>
                   </motion.div>
                 )}
               </AnimatePresence>
@@ -214,20 +242,20 @@ const TableEditorMenu = () => {
               >
                 {isSearchOpen ? (
                   isSearching ? (
-                    <IconLoader
-                      className="animate-spin text-foreground-lighter"
+                    <Loader2
+                      className="w-4 h-4 animate-spin text-foreground"
                       size={15}
-                      strokeWidth={1.5}
+                      strokeWidth={1}
                     />
                   ) : (
-                    <IconX className={cn('hover:text-foreground transition-colors')} />
+                    <IconX className={cn('w-4  h-4 hover:text-foreground transition-colors')} />
                   )
                 ) : (
-                  <IconSearch className={cn('hover:text-foreground transition-colors')} />
+                  <IconSearch className={cn('w-4 h-4 hover:text-foreground transition-colors')} />
                 )}
               </motion.button>
             </div>
-            <div className="flex gap-3 items-center absolute right-2 top-1.5">
+            <div className="flex gap-3 items-center absolute right-1 top-1.5">
               <DropdownMenu>
                 <Tooltip.Root delayDuration={0}>
                   <DropdownMenuTrigger asChild>


### PR DESCRIPTION
- removed a bunch of unnecessary tags, 
- removed nested buttons for a11y
- stopped duplicate onClick events
- updated styling of table items to match design.
- input matches design, added screen reader stuff to label
  - slightly hacky process of using ref to determine if input is focussed or not for underline.
- align all items in sidebar
- focus/hover styles added
- chore: added Esc and backspace control to close and empty search string state
probably makes sense if when the focus comes off the input, the focus then goes onto the ‘search icon’ - but I haven’t done that yet
- fixed the layout shifting issue when searching
  


## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.

https://github.com/supabase/supabase/assets/8291514/5891ba92-1bb1-4062-96da-11966115f37d



