### PR TITLE
docs: add local development section to auth hooks

### DIFF
--- a/apps/docs/content/guides/auth/auth-hooks.mdx
+++ b/apps/docs/content/guides/auth/auth-hooks.mdx
@@ -712,4 +712,4 @@ uri = "pg-functions://postgres/public/custom_access_token_hook"
 ...
 ```
 
-Save your Auth Hook as a migration in order to version the Auth Hook and share it with other team members. Run [`supabase migrations new`](https://supabase.com/docs/reference/cli/supabase-migration-new) to create a migration.
+Save your Auth Hook as a migration in order to version the Auth Hook and share it with other team members. Run [`supabase migration new`](https://supabase.com/docs/reference/cli/supabase-migration-new) to create a migration.

--- a/apps/docs/content/guides/auth/auth-hooks.mdx
+++ b/apps/docs/content/guides/auth/auth-hooks.mdx
@@ -578,14 +578,14 @@ as $$
     if is_admin then
       claims := event->'claims';
 
-      -- Check if 'user_metadata' exists in claims
-      if jsonb_typeof(claims->'user_metadata') is null then
-        -- If 'user_metadata' does not exist, create an empty object
-        claims := jsonb_set(claims, '{user_metadata}', '{}');
+      -- Check if 'app_metadata' exists in claims
+      if jsonb_typeof(claims->'app_metadata') is null then
+        -- If 'app_metadata' does not exist, create an empty object
+        claims := jsonb_set(claims, '{app_metadata}', '{}');
       end if;
 
       -- Set a claim of 'admin'
-      claims := jsonb_set(claims, '{user_metadata, admin}', 'true');
+      claims := jsonb_set(claims, '{app_metadata, admin}', 'true');
 
       -- Update the 'claims' object in the original event
       event := jsonb_set(event, '{claims}', claims);
@@ -695,3 +695,21 @@ revoke execute
 
 </TabPanel>
 </Tabs>
+
+## Local Development
+
+Unlike the hosted platform, the local development dashboard does not have a user interface for linking a Hook. Instead, edit `config.toml` to link an Auth Hook and run it with your local setup. Modify the `auth.hook.<hook_name>` field and set `uri` to a value of `pg-functions://postgres/<schema>/<function_name>`
+
+For instance, the `config.toml` for a Custom Access Token Hook which uses the function `public.custom_access_token_hook`:
+
+```
+...
+
+[auth.hook.custom_access_token]
+enabled = true
+uri = "pg-functions://postgres/public/custom_access_token_hook"
+
+...
+```
+
+Save your Auth Hook as a migration in order to version the Auth Hook and share it with other team members. Run [`supabase migrations new`](https://supabase.com/docs/reference/cli/supabase-migration-new) to create a migration.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Arises from two tickets about local development. Additionally we use app_metadata instead of user_metadata for storing claims (my bad). More internal context [here](https://supabase.slack.com/archives/C02FHG9QQAF/p1707387686521819?thread_ts=1707289169.664599&cid=C02FHG9QQAF)

[Sample `config.toml` when `supabase init` is run](https://github.com/supabase/cli/blob/861262644489ff5bf57fb1124d1e3d6030ffb01a/internal/utils/templates/init_config.toml#L113)