### PR TITLE
fix: update confirm email documentation

### DIFF
--- a/apps/docs/content/guides/auth/server-side/nextjs.mdx
+++ b/apps/docs/content/guides/auth/server-side/nextjs.mdx
@@ -410,7 +410,7 @@ import { type EmailOtpType } from '@supabase/supabase-js'
 import { cookies } from 'next/headers'
 import { type NextRequest, NextResponse } from 'next/server'
 
-import { createClient } from '@/utils/supabase/server'
+import { createClient } from '@/utils/supabase/actions'
 
 export async function GET(request: NextRequest) {
   const cookieStore = cookies()


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix the next.js documentation where the email confirmation path uses the wrong action, so it doesn't work.

## What is the current behavior?

The app/auth/confirm path does not work correctly because it uses the wrong action, so it does not generate the user session.

## What is the new behavior?

It uses the correct action so the route works as expected, generating the user's session when confirming the email.

## Additional context

