### PR TITLE
fix: alert description overflow

### DIFF
--- a/apps/studio/components/ui/AlertError.tsx
+++ b/apps/studio/components/ui/AlertError.tsx
@@ -29,7 +29,7 @@ const AlertError = ({ ref, subject, error, className }: AlertErrorProps) => {
     <Alert_Shadcn_ className={className} variant="warning" title={subject}>
       <IconAlertCircle className="h-4 w-4" strokeWidth={2} />
       <AlertTitle_Shadcn_>{subject}</AlertTitle_Shadcn_>
-      <AlertDescription_Shadcn_ className="flex flex-col gap-3">
+      <AlertDescription_Shadcn_ className="flex flex-col gap-3 break-all">
         <div>
           {error?.message && <p>Error: {error?.message}</p>}
           <p>

--- a/apps/studio/components/ui/AlertError.tsx
+++ b/apps/studio/components/ui/AlertError.tsx
@@ -29,7 +29,7 @@ const AlertError = ({ ref, subject, error, className }: AlertErrorProps) => {
     <Alert_Shadcn_ className={className} variant="warning" title={subject}>
       <IconAlertCircle className="h-4 w-4" strokeWidth={2} />
       <AlertTitle_Shadcn_>{subject}</AlertTitle_Shadcn_>
-      <AlertDescription_Shadcn_ className="flex flex-col gap-3 break-all">
+      <AlertDescription_Shadcn_ className="flex flex-col gap-3 break-words">
         <div>
           {error?.message && <p>Error: {error?.message}</p>}
           <p>

--- a/apps/studio/components/ui/SchemaSelector.tsx
+++ b/apps/studio/components/ui/SchemaSelector.tsx
@@ -82,7 +82,7 @@ const SchemaSelector = ({
           <AlertTitle_Shadcn_ className="text-xs text-amber-900">
             Failed to load schemas
           </AlertTitle_Shadcn_>
-          <AlertDescription_Shadcn_ className="text-xs mb-2">
+          <AlertDescription_Shadcn_ className="text-xs mb-2 break-all">
             Error: {schemasError?.message}
           </AlertDescription_Shadcn_>
           <Button type="default" size="tiny" onClick={() => refetchSchemas()}>

--- a/apps/studio/components/ui/SchemaSelector.tsx
+++ b/apps/studio/components/ui/SchemaSelector.tsx
@@ -82,7 +82,7 @@ const SchemaSelector = ({
           <AlertTitle_Shadcn_ className="text-xs text-amber-900">
             Failed to load schemas
           </AlertTitle_Shadcn_>
-          <AlertDescription_Shadcn_ className="text-xs mb-2 break-all">
+          <AlertDescription_Shadcn_ className="text-xs mb-2 break-words">
             Error: {schemasError?.message}
           </AlertDescription_Shadcn_>
           <Button type="default" size="tiny" onClick={() => refetchSchemas()}>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase Studio > Table Editor (Connection Refused)

## What is the current behavior?

If a long description is in the `<Alert />` then the text will overflow.

## What is the new behavior?

Text does now not overflow:

<img width="256" alt="Screenshot 2024-02-09 at 08 43 46" src="https://github.com/supabase/supabase/assets/22655069/6f7bcf9c-a9a6-4f5d-a999-49388fdf665c">


## Additional context

Issue #21059 mentions this.
