### PR TITLE
feat: allow custom prefix for Docker container names in vector container

### DIFF
--- a/docker/volumes/logs/vector.yml
+++ b/docker/volumes/logs/vector.yml
@@ -30,13 +30,13 @@ transforms:
     inputs:
       - project_logs
     route:
-      kong: '.appname == "supabase-kong"'
-      auth: '.appname == "supabase-auth"'
-      rest: '.appname == "supabase-rest"'
-      realtime: '.appname == "supabase-realtime"'
-      storage: '.appname == "supabase-storage"'
-      functions: '.appname == "supabase-functions"'
-      db: '.appname == "supabase-db"'
+      kong: '.appname == "${DOCKER_PREFIX}supabase-kong"'
+      auth: '.appname == "${DOCKER_PREFIX}supabase-auth"'
+      rest: '.appname == "${DOCKER_PREFIX}supabase-rest"'
+      realtime: '.appname == "${DOCKER_PREFIX}supabase-realtime"'
+      storage: '.appname == "${DOCKER_PREFIX}supabase-storage"'
+      functions: '.appname == "${DOCKER_PREFIX}supabase-functions"'
+      db: '.appname == "${DOCKER_PREFIX}supabase-db"'
   # Ignores non nginx errors since they are related with kong booting up
   kong_logs:
     type: remap


### PR DESCRIPTION
## What kind of change does this PR introduce?

This change allows you to add the environment variable `DOCKER_PREFIX` to the `vector` container so you can even inspect logs when using a custom prefix (e.g. when running multiple Supabase instances locally).

## What is the current behavior?

Right now, the logs are empty in the dashboard when you use a custom prefix because obviously the Docker containers with the defined names are not available.

## What is the new behavior?

If the `DOCKER_PREFIX` environment variable is passed to the `vector` container, the logs will magically appear 😊 

## Additional context

n/a
