### PR TITLE
fix: escape/remove double quotes in combobox items to prevent crashing

### DIFF
--- a/apps/studio/components/interfaces/Auth/Hooks/FunctionSelector.tsx
+++ b/apps/studio/components/interfaces/Auth/Hooks/FunctionSelector.tsx
@@ -131,6 +131,7 @@ const FunctionSelector = ({
                     {functions?.map((func) => (
                       <CommandItem_Shadcn_
                         key={func.id}
+                        value={func.name.replaceAll('"', '')}
                         className="cursor-pointer flex items-center justify-between space-x-2 w-full"
                         onSelect={() => {
                           onSelectFunction(func.name)

--- a/apps/studio/components/interfaces/Integrations/ProjectLinker.tsx
+++ b/apps/studio/components/interfaces/Integrations/ProjectLinker.tsx
@@ -228,7 +228,7 @@ const ProjectLinker = ({
                         {supabaseProjects.map((project, i) => {
                           return (
                             <CommandItem_Shadcn_
-                              value={`${project.name}-${i}`}
+                              value={`${project.name.replaceAll('"', '')}-${i}`}
                               key={project.ref}
                               className="flex gap-2 items-center"
                               onSelect={() => {
@@ -301,7 +301,7 @@ const ProjectLinker = ({
                           return (
                             <CommandItem_Shadcn_
                               key={project.id}
-                              value={`${project.name}-${i}`}
+                              value={`${project.name.replaceAll('"', '')}-${i}`}
                               className="flex gap-2 items-center"
                               onSelect={() => {
                                 if (project.id) setForeignProjectId(project.id)

--- a/apps/studio/components/interfaces/Settings/Integrations/GithubIntegration/GitHubIntegrationConnectionForm.tsx
+++ b/apps/studio/components/interfaces/Settings/Integrations/GithubIntegration/GitHubIntegrationConnectionForm.tsx
@@ -186,7 +186,7 @@ const GitHubIntegrationConnectionForm = ({
                     return (
                       <CommandItem_Shadcn_
                         key={branch.name}
-                        value={branch.name}
+                        value={branch.name.replaceAll('"', '')}
                         className="cursor-pointer w-full flex items-center justify-between"
                         onSelect={() => {
                           setOpen(false)

--- a/apps/studio/components/layouts/AppLayout/BranchDropdown.tsx
+++ b/apps/studio/components/layouts/AppLayout/BranchDropdown.tsx
@@ -44,7 +44,7 @@ const BranchLink = ({
   return (
     <Link passHref href={href}>
       <CommandItem_Shadcn_
-        value={branch.name}
+        value={branch.name.replaceAll('"', '')}
         className="cursor-pointer w-full flex items-center justify-between"
         onSelect={() => {
           setOpen(false)

--- a/apps/studio/components/layouts/AppLayout/OrganizationDropdown.tsx
+++ b/apps/studio/components/layouts/AppLayout/OrganizationDropdown.tsx
@@ -80,7 +80,7 @@ const OrganizationDropdown = ({ isNewNav = false }: OrganizationDropdownProps) =
                     return (
                       <CommandItem_Shadcn_
                         key={org.slug}
-                        value={`${org.name} - ${org.slug}`}
+                        value={`${org.name.replaceAll('"', '')} - ${org.slug}`}
                         className="cursor-pointer w-full"
                         onSelect={() => {
                           setOpen(false)

--- a/apps/studio/components/layouts/AppLayout/ProjectDropdown.tsx
+++ b/apps/studio/components/layouts/AppLayout/ProjectDropdown.tsx
@@ -67,7 +67,7 @@ const ProjectLink = ({
   return (
     <CommandItem_Shadcn_
       key={project.ref}
-      value={`${project.name}-${project.ref}`}
+      value={`${project.name.replaceAll('"', '')}-${project.ref}`}
       className="cursor-pointer w-full"
       onSelect={() => {
         router.push(href)

--- a/apps/studio/components/layouts/ProjectLayout/LayoutHeader/NotificationsPopoverV2/NotificationsFilter.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/LayoutHeader/NotificationsPopoverV2/NotificationsFilter.tsx
@@ -121,6 +121,7 @@ export const NotificationsFilter = ({ activeTab }: { activeTab: 'inbox' | 'archi
               {(organizations ?? []).map((org) => (
                 <CommandItem_Shadcn_
                   key={org.slug}
+                  value={org.name.replaceAll('"', '')}
                   className="flex items-center gap-x-2"
                   onSelect={() => {
                     snap.setFilters(org.slug, 'organizations')


### PR DESCRIPTION
didn't touch the comboboxes where the items can't possibly have double quotes in them (not valid postgres schema names, etc.)