### PR TITLE
[Chore] [Dashboard] Remove button to open feature preview dialog

### DIFF
--- a/apps/studio/components/interfaces/Auth/Policies/AIPolicyEditorPanel/index.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/AIPolicyEditorPanel/index.tsx
@@ -356,9 +356,6 @@ export const AIPolicyEditorPanel = memo(function ({
                   />
                 )}
                 <SheetFooter_Shadcn_ className="flex items-center !justify-between px-5 py-4 w-full">
-                  <Button type="text" onClick={toggleFeaturePreviewModal}>
-                    Toggle feature preview
-                  </Button>
                   <div className="flex items-center gap-x-2">
                     <Button type="default" disabled={isExecuting} onClick={() => onSelectCancel()}>
                       Cancel
@@ -369,7 +366,7 @@ export const AIPolicyEditorPanel = memo(function ({
                       disabled={isExecuting || incomingChange !== undefined}
                       onClick={() => onExecuteSQL()}
                     >
-                      Save policy
+                      Insert policy
                     </Button>
                   </div>
                 </SheetFooter_Shadcn_>

--- a/apps/studio/components/interfaces/Auth/Policies/AIPolicyEditorPanel/index.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/AIPolicyEditorPanel/index.tsx
@@ -366,7 +366,7 @@ export const AIPolicyEditorPanel = memo(function ({
                       disabled={isExecuting || incomingChange !== undefined}
                       onClick={() => onExecuteSQL()}
                     >
-                      Insert policy
+                      Create policy
                     </Button>
                   </div>
                 </SheetFooter_Shadcn_>


### PR DESCRIPTION
## What kind of change does this PR introduce?

- i lost my progress in my policy when clicking this button
- Could reinstate if it warns user first that they will lose progress
- also "Create policy" language
  - I think the correct terminology is "create" or "define", not "save"

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
