### PR TITLE
Better storage file renaming

### DIFF
--- a/apps/studio/components/to-be-cleaned/Storage/StorageExplorer/FileExplorerRowEditing.tsx
+++ b/apps/studio/components/to-be-cleaned/Storage/StorageExplorer/FileExplorerRowEditing.tsx
@@ -34,7 +34,13 @@ const FileExplorerRowEditing = ({ item, view, columnIndex }: FileExplorerRowEdit
   }
 
   useEffect(() => {
-    if (inputRef.current) inputRef.current.select()
+    // select just the name of the file without the extension
+    if (inputRef.current) {
+      const dotIndex = item.name.lastIndexOf('.')
+      const selectionEnd = dotIndex !== -1 ? dotIndex : item.name.length
+      inputRef.current.setSelectionRange(0, selectionEnd)
+      inputRef.current.focus()
+    }
 
     // [Joshen] Esc should revert changes
     const handleEsc = (event: KeyboardEvent) => {


### PR DESCRIPTION
Select just the name of the file, without the extension to make renaming quicker. Like in MacOS.

![screenshot-2024-02-13-at-14 48 18](https://github.com/supabase/supabase/assets/105593/46add47c-1746-4774-8665-1aa1688cf7ed)

To test: 

https://supabase.com/dashboard/project/storage/buckets

1. Create a new Storage bucket
2. Add an item to the bucket
3. Right click the row, Rename 
4. See just the name of the file is selected