### PR TITLE
Replace minio healthcheck curl with mc.

### DIFF
--- a/docker/docker-compose.s3.yml
+++ b/docker/docker-compose.s3.yml
@@ -12,7 +12,7 @@ services:
       MINIO_ROOT_PASSWORD: secret1234
     command: server --console-address ":9001" /data
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://minio:9000/minio/health/live" ]
+      test: mc ready local
       interval: 2s
       timeout: 10s
       retries: 5


### PR DESCRIPTION
Curl is no longer on the $PATH, so existing healthcheck definitions now fail and the container health is erroneously deemed unhealthy, leading to restarts or failed deployments.

https://github.com/minio/minio/issues/18371#issuecomment-1791075775

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
