### PR TITLE
Add a note about consumers Azure tenent

### DIFF
--- a/apps/docs/content/guides/auth/social-login/auth-azure.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-azure.mdx
@@ -101,6 +101,8 @@ A Microsoft Entra tenant is the directory of users who are allowed to access you
 
 By default, Supabase Auth uses the _common_ Microsoft tenant (`https://login.microsoftonline.com/common`) which generally allows any Microsoft account to sign in to your project. Microsoft Entra further limits what accounts can access your project depending on the type of OAuth application you registered.
 
+If your app is registered as _Personal Microsoft accounts only_ for the _Supported account types_ set Microsoft tenant to _consumers_ (`https://login.microsoftonline.com/consumers`).
+
 If your app is registered as _My organization only_ for the _Supported account types_ you may want to configure Supabase Auth with the organization's tenant URL. This will use the tenant's authorization flows instead, and will limit access at the Supabase Auth level to Microsoft accounts arising from only the specified tenant.
 
 Configure this by storing a value under _Azure Tenant URL_ in the Supabase Auth provider configuration page for Azure that has the following format `https://login.microsoftonline.com/<tenant-id>`.


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

Currently, the document does not cover "Personal Microsoft accounts only" option in Azure, which leads to an error with default settings.

## What is the new behavior?

Updated the doc and added a note about Azure "Personal Microsoft accounts only" option and consumers tenant. 

