### PR TITLE
Vector page hero kaizen

### DIFF
--- a/apps/www/components/Sections/FeaturesSection.tsx
+++ b/apps/www/components/Sections/FeaturesSection.tsx
@@ -33,7 +33,7 @@ const FeaturesSection = ({ title, paragraph, cta, features }: Props) => {
             <h2 className="text-2xl sm:text-3xl xl:text-4xl max-w-[280px] sm:max-w-xs xl:max-w-[360px] tracking-[-1px]">
               {title}
             </h2>
-            <p className="text-muted mb-4">{paragraph}</p>
+            <p className="text-lighter mb-4">{paragraph}</p>
             {cta && (
               <Button asChild type="default" size="small" icon={<IconArrowUpRight />}>
                 <Link href={cta.link}>{cta.label ?? 'Explore documentation'}</Link>
@@ -94,7 +94,7 @@ const Feature = ({
       </div>
       <div className="text-sm lg:text-base">
         <h2 className="text-base">{feature.title}</h2>
-        <ReactMarkdown className="prose pt-1 text-sm text-foreground-muted">
+        <ReactMarkdown className="prose pt-1 text-sm text-foreground-lighter">
           {feature.text}
         </ReactMarkdown>
       </div>

--- a/apps/www/components/Sections/HighlightCards.tsx
+++ b/apps/www/components/Sections/HighlightCards.tsx
@@ -57,7 +57,7 @@ const HighlightCard = ({ highlight, index }: { highlight: Highlight; index: numb
         </div>
         <div className="p-8">
           <h3 className="text-lg text-foreground mb-2">{highlight.title}</h3>
-          <p className="text-muted">{highlight.paragraph}</p>
+          <p className="text-foreground-lighter">{highlight.paragraph}</p>
         </div>
       </Panel>
     </m.div>

--- a/apps/www/components/Sections/ProductHeaderCentered.tsx
+++ b/apps/www/components/Sections/ProductHeaderCentered.tsx
@@ -1,4 +1,4 @@
-import { Button, IconPlayCircle } from 'ui'
+import { Button, IconPlayCircle, cn } from 'ui'
 import Link from 'next/link'
 import ProductIcon from '../ProductIcon'
 import Image from 'next/image'
@@ -32,14 +32,14 @@ interface Types {
 
 const ProductHeaderCentered = (props: Types) => (
   <div
-    className={[
+    className={cn(
       'container relative w-full mx-auto px-6 pt-2 pb-0 sm:px-16 xl:px-20',
-      props.className,
-    ].join(' ')}
+      props.className
+    )}
   >
     <div className="flex flex-col text-center items-center">
       {props.image && typeof props.image === 'string' ? (
-        <div className="relative w-full max-w-[830px] mx-auto z-0 aspect-[2.3/1] -mb-8 md:-mb-12 lg:-mb-16">
+        <div className="relative w-full max-w-[630px] mx-auto z-0 aspect-[2.3/1] -mt-8 -mb-8 md:-mb-12 lg:-mb-12">
           <Image
             src={props.image}
             priority
@@ -56,7 +56,7 @@ const ProductHeaderCentered = (props: Types) => (
       )}
       <div className="relative w-full z-10 flex flex-col items-center space-y-2 mx-auto max-w-2xl">
         {props.announcement && (
-          <AnnouncementBadge {...props.announcement} className="pb-4 md:pb-8 z-10" />
+          <AnnouncementBadge {...props.announcement} className="pb-4 md:pb-4 z-10" />
         )}
         <div>
           {props.icon || props.title ? (
@@ -73,13 +73,13 @@ const ProductHeaderCentered = (props: Types) => (
             </div>
           ) : null}
         </div>
-        <div className={[styles['appear-from-bottom']].join(' ')}>
-          <h1 className="h1 text-3xl md:text-4xl xl:!text-5xl tracking-[-1.5px]" key={`h1`}>
+        <div className={cn(styles['appear-from-bottom'])}>
+          <h1 className="h1 text-3xl md:text-4xl tracking-[-1.5px]" key={`h1`}>
             {props.h1}
           </h1>
           <p className="p !text-foreground-light">{props.subheader}</p>
         </div>
-        <div className="w-full sm:w-auto flex flex-col items-stretch sm:flex-row pt-2 sm:pt-8 sm:items-center gap-2">
+        <div className="w-full sm:w-auto flex flex-col items-stretch sm:flex-row pt-2 sm:items-center gap-2">
           {props.cta && (
             <Button size="medium" className="text-white" asChild>
               <Link href={props.cta.link} as={props.cta.link}>

--- a/apps/www/components/Sections/TimedTabsSection.tsx
+++ b/apps/www/components/Sections/TimedTabsSection.tsx
@@ -43,7 +43,7 @@ const Tab = ({ isActive, label, paragraph, onClick, progress, intervalDuration }
         <motion.p
           initial={{ opacity: 0 }}
           animate={{ opacity: 1, transition: { delay: 0.2 } }}
-          className="hidden md:block mt-1 text-foreground-muted text-sm"
+          className="hidden md:block mt-1 text-foreground-lighter text-sm"
         >
           {paragraph}
         </motion.p>
@@ -133,7 +133,7 @@ const TimedTabsSection = ({
           <h2 className="text-3xl xl:text-4xl max-w-[280px] sm:max-w-xs xl:max-w-[360px] tracking-[-1px]">
             {title}
           </h2>
-          <p className="text-foreground-muted mb-4 max-w-sm">{paragraph}</p>
+          <p className="text-foreground-lighter mb-4 max-w-sm">{paragraph}</p>
           {cta && (
             <Button asChild type="default" size="small" icon={<IconArrowUpRight />}>
               <Link href={cta.link}>{cta.label ?? 'Explore more'}</Link>
@@ -191,7 +191,7 @@ const TimedTabsSection = ({
             initial={{ opacity: 0 }}
             animate={{ opacity: 1, transition: { duration: 0.1, delay: 0.2 } }}
             exit={{ opacity: 0, transition: { duration: 0.05 } }}
-            className="text-foreground-muted text-sm"
+            className="text-foreground-lighter text-sm"
           >
             {tabs[activeTab]?.paragraph}
           </motion.p>
@@ -206,7 +206,7 @@ const OpenInColab = ({ colabUrl, className }: { colabUrl: string; className?: st
     href={colabUrl}
     target="_blank"
     className={[
-      'flex items-center z-10 h-10 bg-surface-100 hover:bg-surface-200 hover:text-foreground-muted text-sm text-foreground-muted shadow-lg hover:shadow-md rounded-full py-1 px-3 gap-2',
+      'flex items-center z-10 h-10 bg-surface-100 hover:bg-surface-200 hover:text-foreground-lighter text-sm text-foreground-lighter shadow-lg hover:shadow-md rounded-full py-1 px-3 gap-2',
       className,
     ].join(' ')}
   >

--- a/apps/www/components/Sections/UseCasesSection.tsx
+++ b/apps/www/components/Sections/UseCasesSection.tsx
@@ -34,7 +34,7 @@ const UseCasesSection = ({ title, paragraph, useCases }: Props) => {
       <SectionContainer className="flex flex-col gap-12">
         <div className="flex flex-col text-center gap-4 items-center justify-center">
           <h2 className="heading-gradient text-2xl sm:text-3xl xl:text-4xl">{title}</h2>
-          <p className="mx-auto text-muted lg:w-1/2">{paragraph}</p>
+          <p className="mx-auto text-foreground-lighter lg:w-1/2">{paragraph}</p>
         </div>
         <div
           ref={ref}

--- a/apps/www/pages/vector/Vector.tsx
+++ b/apps/www/pages/vector/Vector.tsx
@@ -1,3 +1,5 @@
+import 'swiper/swiper.min.css'
+
 import { NextSeo } from 'next-seo'
 import dynamic from 'next/dynamic'
 import { useRouter } from 'next/router'
@@ -6,8 +8,6 @@ import DefaultLayout from '~/components/Layouts/Default'
 import { useBreakpoint } from 'common'
 import { PRODUCT_SHORTNAMES } from '~/lib/constants'
 import vectorPageData from '~/data/products/vector/pageData'
-
-import 'swiper/swiper.min.css'
 
 const ProductHeaderCentered = dynamic(() => import('~/components/Sections/ProductHeaderCentered'))
 const HighlightCards = dynamic(() => import('~/components/Sections/HighlightCards'))


### PR DESCRIPTION
## What kind of change does this PR introduce?

Improve "above the fold" spacing.

## What is the current behavior?

<img width="1442" alt="Screenshot 2024-02-14 at 12 30 18" src="https://github.com/supabase/supabase/assets/25671831/a4a1e5d9-d17b-45a0-ac3f-025d82e8bf8d">

## What is the new behavior?

<img width="1438" alt="Screenshot 2024-02-14 at 12 30 24" src="https://github.com/supabase/supabase/assets/25671831/0269114a-1736-4c1e-b63d-a0a247530fb8">
