### PR TITLE
fix(ui): Update vercel-icon.svg to support both color modes

### DIFF
--- a/apps/studio/public/img/icons/vercel-icon.svg
+++ b/apps/studio/public/img/icons/vercel-icon.svg
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" fill="white" viewBox="0 0 512 512">
+<svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 512 512">
   <path fill-rule="evenodd" d="M256,48,496,464H16Z" />
 </svg>


### PR DESCRIPTION
Changes `fill` from `white` to `currentColor`.

Pre:

![image](https://github.com/supabase/supabase/assets/1523305/acc861c3-a63e-4cfb-92c2-ee2b55d82278)

Post:

![image](https://github.com/supabase/supabase/assets/1523305/3fc024bb-a9f8-496b-941b-1d14976fc779)
