### PR TITLE
chore: change URLs from Twitter to X for alignment

### DIFF
--- a/apps/www/components/Blog/ShareArticleActions.tsx
+++ b/apps/www/components/Blog/ShareArticleActions.tsx
@@ -5,7 +5,7 @@ const ShareArticleActions = ({ title, slug }: { title: string; slug: string }) =
   <div className="mt-4 flex items-center space-x-4">
     <Link
       aria-label="Share on X"
-      href={`https://twitter.com/share?text=${title}&url=https://supabase.com/blog/${slug}`}
+      href={`https://x.com/share?text=${title}&url=https://supabase.com/blog/${slug}`}
       target="_blank"
       className="text-foreground-lighter hover:text-foreground"
     >

--- a/apps/www/components/Footer/index.tsx
+++ b/apps/www/components/Footer/index.tsx
@@ -86,10 +86,10 @@ const Footer = (props: Props) => {
             </Link>
             <div className="flex space-x-5">
               <a
-                href="https://twitter.com/supabase"
+                href="https://x.com/supabase"
                 className="text-foreground-lighter hover:text-foreground transition"
               >
-                <span className="sr-only">Twitter</span>
+                <span className="sr-only">X</span>
                 <IconTwitterX size={22} />
               </a>
 

--- a/apps/www/components/LaunchWeek/X/Ticket/TicketActions.tsx
+++ b/apps/www/components/LaunchWeek/X/Ticket/TicketActions.tsx
@@ -20,7 +20,7 @@ export default function TicketActions() {
   const permalink = encodeURIComponent(link)
   const text = hasSecretTicket ? TWEET_TEXT_SECRET : golden ? TWEET_TEXT_GOLDEN : TWEET_TEXT
   const encodedText = encodeURIComponent(text)
-  const tweetUrl = `https://twitter.com/intent/tweet?url=${permalink}&text=${encodedText}`
+  const tweetUrl = `https://x.com/intent/tweet?url=${permalink}&text=${encodedText}`
   const linkedInUrl = `https://www.linkedin.com/sharing/share-offsite/?url=${permalink}`
   const downloadUrl = `https://obuldanrptloktxcffvn.supabase.co/functions/v1/lwx-og?username=${encodeURIComponent(
     username ?? ''


### PR DESCRIPTION
Updated the URLs associated with X, changing them from Twitter (e.g., https://twitter.com/supabase) to X (e.g., https://x.com/supabase), to ensure consistency with the X visual. This change aligns the visual (X) with the expected destination (x.com).