### PR TITLE
Update auth-apple.mdx

### DIFF
--- a/apps/docs/content/guides/auth/social-login/auth-apple.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-apple.mdx
@@ -227,7 +227,7 @@ When developing with Expo, you can test Sign in with Apple via the Expo Go app, 
             'Could not find ID Token from generated credential.');
       }
 
-      return signInWithIdToken(
+      return supabase.auth.signInWithIdToken(
         provider: OAuthProvider.apple,
         idToken: idToken,
         nonce: rawNonce,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update to fix Flutter code sample.

## What is the current behavior?

Before the code reference `signInWithIdToken` but that is not available as a top-level function.

## What is the new behavior?

Updated the code to use `supabase.auth.signInWithIdToken`.

