### PR TITLE
fix blog image height

### DIFF
--- a/apps/www/_blog/2023-08-11-supabase-soc2-hipaa.mdx
+++ b/apps/www/_blog/2023-08-11-supabase-soc2-hipaa.mdx
@@ -52,7 +52,6 @@ We receive many requests from users who want to build healthcare apps on top of 
 <Img
   src="/images/blog/launch-week-8/day-5/soc2-to-hipaa.png"
   alt="soc2 to HIPAA"
-  className="!max-h-[450px]"
   zoomable={false}
 />
 


### PR DESCRIPTION
Fixes blog image height overflow.

## Previous behaviour

<img width="1267" alt="Screenshot 2024-02-20 at 12 41 19" src="https://github.com/supabase/supabase/assets/25671831/f8867615-143b-48e9-97b2-54a0619504fe">

## New behaviour

<img width="1308" alt="Screenshot 2024-02-20 at 12 41 31" src="https://github.com/supabase/supabase/assets/25671831/c7b3693e-bb1d-40ea-8f54-999d9f5b6ac8">
