### PR TITLE
Add Apple client secret tool to Flutter tab

### DIFF
--- a/apps/docs/content/guides/auth/social-login/auth-apple.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-apple.mdx
@@ -272,6 +272,14 @@ When developing with Expo, you can test Sign in with Apple via the Expo Go app, 
     6. Create a signing **Key** in the [Keys](https://developer.apple.com/account/resources/authkeys/list) section of the Apple Developer Console. You can use this key to generate a secret key using the tool below, which is added to your Supabase project's Auth configuration. Make sure you safely store the `AuthKey_XXXXXXXXXX.p8` file. If you ever lose access to it, or make it public accidentally please revoke it from the Apple Developer Console and create a new one immediately. You will have to generate a new secret key using this file every 6 months, so make sure you schedule a recurring reminder in your calendar!
     7. Finally, add the information you configured above to the [Apple provider configuration in the Supabase dashboard](https://supabase.com/dashboard/project/_/auth/providers).
 
+    <Admonition>
+
+    Use this tool to generate a new Apple client secret. No keys leave your browser! Be aware that this tool does not currently work in Safari, so please use Firefox or a Chrome-based browser instead.
+
+    </Admonition>
+
+    <AppleSecretGenerator />
+
   </TabPanel>
 
   <TabPanel id="swift" label="Swift">


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update to add the Apple client secret generator tool to the Flutter tab on the [Login with Apple](https://supabase.com/docs/guides/auth/social-login/auth-apple) page.
 
## What is the current behavior?

The [docs](https://supabase.com/docs/guides/auth/social-login/auth-apple?platform=flutter#apple-sign-in-on-android-web-windows-and-linux) on the Flutter tab reference a "tool" to generate a new Apple client secret:

> 6. Create a signing Key in the [Keys](https://developer.apple.com/account/resources/authkeys/list) section of the Apple Developer Console. You can use this key to generate a secret key using the **tool** below, which is added to your Supabase project's Auth configuration...

The problem is that this tool is not on the Flutter tab. It is only on the "Web" tab which is not intuitive.

![image](https://github.com/supabase/supabase/assets/47997351/266bd33a-e99b-452e-8fcc-e71fb5e8abd4)


## What is the new behavior?

I added the tool to the Flutter tab as well.

