### PR TITLE
docs: Add missing descriptions for Flutter docs

### DIFF
--- a/apps/docs/spec/supabase_dart_v2.yml
+++ b/apps/docs/spec/supabase_dart_v2.yml
@@ -1179,27 +1179,126 @@ functions:
   - id: rpc
     title: 'Stored Procedures: rpc()'
     description: |
-      You can call stored procedures as a "Remote Procedure Call".
+      Perform a function call.
 
-      That's a fancy way of saying that you can put some logic into your database then call it from anywhere.
-      It's especially useful when the logic rarely changes - like password resets and updates.
+      You can call Postgres functions as Remote Procedure Calls, logic in your database that you can execute from anywhere.
+      Functions are useful when the logic rarely changes—like for password resets and updates.
     examples:
-      - id: call-a-stored-procedure
-        name: Call a stored procedure
-        isSpotlight: true
-        description: This is an example invoking a stored procedure.
+      - id: call-a-postgres-function-without-arguments
+        name: Call a Postgres function without arguments
         code: |
           ```dart
           final data = await supabase
             .rpc('hello_world');
           ```
-      - id: with-parameters
-        name: With Parameters
+        data:
+          sql: |
+            ```sql
+            create function hello_world() returns text as $$
+              select 'Hello world';
+            $$ language sql;
+            ```
+        response: |
+          ```json
+          {
+            "data": "Hello world",
+            "status": 200,
+            "statusText": "OK"
+          }
+          ```
+        hideCodeBlock: true
+        isSpotlight: true
+      - id: call-a-postgres-function-with-arguments
+        name: Call a Postgres function with arguments
         code: |
           ```dart
           final data = await supabase
-            .rpc('echo_city', params: { 'name': 'The Shire' });
+            .rpc('echo_city', params: { 'say': '👋' });
           ```
+        data:
+          sql: |
+            ```sql
+            create function echo(say text) returns text as $$
+              select say;
+            $$ language sql;
+            ```
+        response: |
+          ```json
+            {
+              "data": "👋",
+              "status": 200,
+              "statusText": "OK"
+            }
+            ```
+        hideCodeBlock: true
+      - id: bulk-processing
+        name: Bulk processing
+        code: |
+          ```dart
+          final data = await supabase
+            .rpc('add_one_each', params: { arr: [1, 2, 3] });
+          ```
+        data:
+          sql: |
+            ```sql
+            create function add_one_each(arr int[]) returns int[] as $$
+              select array_agg(n + 1) from unnest(arr) as n;
+            $$ language sql;
+            ```
+        response: |
+          ```json
+          {
+            "data": [
+              2,
+              3,
+              4
+            ],
+            "status": 200,
+            "statusText": "OK"
+          }
+          ```
+        description: |
+          You can process large payloads by passing in an array as an argument.
+        hideCodeBlock: true
+      - id: call-a-postgres-function-with-filters
+        name: Call a Postgres function with filters
+        code: |
+          ```dart
+          final data = await supabase
+            .rpc('list_stored_countries')
+            .eq('id', 1)
+            .single();
+          ```
+        data:
+          sql: |
+            ```sql
+            create table
+              countries (id int8 primary key, name text);
+
+            insert into
+              countries (id, name)
+            values
+              (1, 'France'),
+              (2, 'United Kingdom');
+
+            create function list_stored_countries() returns setof countries as $$
+              select * from countries;
+            $$ language sql;
+            ```
+        response: |
+          ```json
+          {
+            "data": {
+              "id": 1,
+              "name": "France"
+            },
+            "status": 200,
+            "statusText": "OK"
+          }
+          ```
+        description: |
+          Postgres functions that return tables can also be combined with [Filters](/docs/reference/dart/using-filters) and [Modifiers](/docs/reference/dart/using-modifiers).
+        hideCodeBlock: true
 
   - id: subscribe
     description: |
@@ -2654,6 +2753,8 @@ functions:
     examples:
       - id: on-array-columns
         name: On array columns
+        description: |
+          Only relevant for jsonb, array, and range columns. Match only rows where `column` contains every element appearing in `value`.
         isSpotlight: true
         code: |
           ```dart
@@ -2767,6 +2868,8 @@ functions:
 
   - id: contained-by
     title: containedBy()
+    description: |
+      Only relevant for jsonb, array, and range columns. Match only rows where every element appearing in `column` is contained by `value`.
     examples:
       - id: on-array-columns
         name: On array columns
@@ -2881,6 +2984,8 @@ functions:
 
   - id: range-lt
     title: rangeLt()
+    description: |
+      Only relevant for range columns. Match only rows where every element in `column` is less than any element in `range`.
     examples:
       - id: with-select
         name: With `select()`
@@ -2927,6 +3032,8 @@ functions:
 
   - id: range-gt
     title: rangeGt()
+    description: |
+      Only relevant for range columns. Match only rows where every element in `column` is greater than any element in `range`.
     examples:
       - id: with-select
         name: With `select()`
@@ -2973,6 +3080,8 @@ functions:
 
   - id: range-gte
     title: rangeGte()
+    description: |
+      Only relevant for range columns. Match only rows where every element in `column` is either contained in `range` or greater than any element in `range`.
     examples:
       - id: with-select
         name: With `select()`
@@ -3019,7 +3128,8 @@ functions:
 
   - id: range-lte
     title: rangeLte()
-    $ref: '@supabase/postgrest-js.PostgrestFilterBuilder.rangeLte'
+    description: |
+      Only relevant for range columns. Match only rows where every element in `column` is either contained in `range` or less than any element in `range`.
     examples:
       - id: with-select
         name: With `select()`
@@ -3066,6 +3176,8 @@ functions:
 
   - id: range-adjacent
     title: rangeAdjacent()
+    description: |
+      Only relevant for range columns. Match only rows where `column` is mutually exclusive to `range` and there can be no element between the two ranges.
     examples:
       - id: with-select
         name: With `select()`
@@ -3112,6 +3224,8 @@ functions:
 
   - id: overlaps
     title: overlaps()
+    description: |
+      Only relevant for array and range columns. Match only rows where `column` and `value` have an element in common.
     examples:
       - id: on-array-columns
         name: On array columns

--- a/apps/docs/spec/supabase_dart_v2.yml
+++ b/apps/docs/spec/supabase_dart_v2.yml
@@ -1584,7 +1584,6 @@ functions:
     description: |
       Retrieves the details of all Storage buckets within an existing product.
     title: 'listBuckets()'
-    $ref: '@supabase/storage-js.packages/StorageBucketApi.default.listBuckets'
     notes: |
       - Policy permissions required:
         - `buckets` permissions: `select`
@@ -1604,7 +1603,6 @@ functions:
     description: |
       Retrieves the details of an existing Storage bucket.
     title: 'getBucket()'
-    $ref: '@supabase/storage-js.packages/StorageBucketApi.default.getBucket'
     notes: |
       - Policy permissions required:
         - `buckets` permissions: `select`
@@ -1699,7 +1697,6 @@ functions:
     description: |
       Uploads a file to an existing bucket.
     title: 'from.upload()'
-    $ref: '@supabase/storage-js.packages/StorageFileApi.default.upload'
     notes: |
       - Policy permissions required:
         - `buckets` permissions: none
@@ -2584,7 +2581,6 @@ functions:
     title: like()
     description: |
       Finds all rows whose value in the stated `column` matches the supplied `pattern` (case sensitive).
-    $ref: '@supabase/postgrest-js.PostgrestFilterBuilder.lte'
     examples:
       - id: with-select
         name: With `select()`

--- a/apps/docs/spec/supabase_js_v2.yml
+++ b/apps/docs/spec/supabase_js_v2.yml
@@ -2617,9 +2617,7 @@ functions:
           }
           ```
         description: |
-          Postgres functions that return tables can also be combined with
-          [Filters](/docs/reference/javascript/using-filters) and
-          [Modifiers](/docs/reference/javascript/using-modifiers).
+          Postgres functions that return tables can also be combined with [Filters](/docs/reference/javascript/using-filters) and [Modifiers](/docs/reference/javascript/using-modifiers).
         hideCodeBlock: true
 
   - id: using-filters


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Add a few missing descriptions for reference Flutter docs. 
- Fix minor line break issues. 
- Remove a few $ref to js docs in the Flutter docs.