### PR TITLE
docs: update Next.js Quickstart example env file name

### DIFF
--- a/apps/docs/content/guides/getting-started/quickstarts/nextjs.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/nextjs.mdx
@@ -63,7 +63,7 @@ hideToc: true
   <StepHikeCompact.Step step={3}>
     <StepHikeCompact.Details title="Declare Supabase Environment Variables">
 
-    Rename `.env.local.example` to `.env.local` and populate with your Supabase connection variables:
+    Rename `.env.example` to `.env.local` and populate with your Supabase connection variables:
 
     <ProjectConfigVariables variable="url" />
     <ProjectConfigVariables variable="anonKey" />


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update 📝 

## What is the current behavior?

The [Next.js quickstart](https://supabase.com/docs/guides/getting-started/quickstarts/nextjs) has the wrong name for the example env file `.env.local.example` 

## What is the new behavior?

Updated the doc with the correct example env file name `.env.example`
