### PR TITLE
Fix settings/infrastructure compute instance data

### DIFF
--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureActivity.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureActivity.tsx
@@ -50,10 +50,18 @@ const InfrastructureActivity = () => {
   const selectedAddons = addons?.selected_addons ?? []
 
   const { computeInstance } = getAddons(selectedAddons)
-  const currentComputeInstanceSpecs =
-    computeInstance?.variant?.meta ?? project?.infra_compute_size === 'nano'
-      ? INSTANCE_NANO_SPECS
-      : INSTANCE_MICRO_SPECS
+
+  function getCurrentComputeInstanceSpecs() {
+    if (computeInstance?.variant.meta) {
+      // If user has a compute instance (called addons) return that
+      return computeInstance?.variant.meta
+    } else {
+      // Otherwise, return the default specs
+      return project?.infra_compute_size === 'nano' ? INSTANCE_NANO_SPECS : INSTANCE_MICRO_SPECS
+    }
+  }
+
+  const currentComputeInstanceSpecs = getCurrentComputeInstanceSpecs()
 
   const currentBillingCycleSelected = useMemo(() => {
     // Selected by default


### PR DESCRIPTION
## What kind of change does this PR introduce?

- fixes the info being rendered in settings/infrastructure

## What is the current behavior?

A user may have a compute instance addon but its always showing 2 CPU cores

## What is the new behavior?

it should render the correct info based on the compute instance 

## Additional context
If you want to test this:
- checkout to master
- create project
- add any addon over 2 CPU cores (XL or over)
- go to settings/infrastructure - it doesn't show the correct CPU cores
- checkout to this branch
- should show the correct CPU cores
