### PR TITLE
Fix foreign key management bugs

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.tsx
@@ -77,19 +77,27 @@ export const ForeignKeySelector = ({
   const disableApply = selectedTable === undefined || hasTypeErrors
 
   const updateSelectedSchema = (schema: string) => {
-    const updatedFk = { ...EMPTY_STATE, schema }
+    const updatedFk = { ...EMPTY_STATE, id: fk.id, schema }
     setFk(updatedFk)
   }
 
   const updateSelectedTable = (tableId: number) => {
     setErrors({})
     if (!tableId) {
-      return setFk({ ...EMPTY_STATE, schema: fk.schema, columns: [{ source: '', target: '' }] })
+      return setFk({
+        ...EMPTY_STATE,
+        id: fk.id,
+        name: fk.name,
+        schema: fk.schema,
+        columns: [{ source: '', target: '' }],
+      })
     }
     const table = (tables ?? []).find((x) => x.id === tableId)
     if (table)
       setFk({
         ...EMPTY_STATE,
+        id: fk.id,
+        name: fk.name,
         tableId: table.id,
         schema: table.schema,
         table: table.name,

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx
@@ -742,7 +742,7 @@ export const updateTable = async ({
   }
 
   // Foreign keys will get updated here accordingly
-  const relationsToAdd = foreignKeyRelations.filter((x) => x.id === undefined)
+  const relationsToAdd = foreignKeyRelations.filter((x) => typeof x.id === 'string')
   if (relationsToAdd.length > 0) {
     await addForeignKey({
       projectRef,
@@ -762,7 +762,9 @@ export const updateTable = async ({
     })
   }
 
-  const remainingRelations = foreignKeyRelations.filter((x) => x.id !== undefined && !x.toRemove)
+  const remainingRelations = foreignKeyRelations.filter(
+    (x) => typeof x.id === 'number' && !x.toRemove
+  )
   const relationsToUpdate = remainingRelations.filter((x) => {
     const existingRelation = existingForeignKeyRelations.find((y) => x.id === y.id)
     if (existingRelation !== undefined) {

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/ForeignKeysManagement/ForeignKeysManagement.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/ForeignKeysManagement/ForeignKeysManagement.tsx
@@ -12,6 +12,7 @@ import { TableField } from '../TableEditor.types'
 import { ForeignKeyRow } from './ForeignKeyRow'
 import { ForeignKey } from '../../ForeignKeySelector/ForeignKeySelector.types'
 import { checkIfRelationChanged } from './ForeignKeysManagement.utils'
+import { uuidv4 } from 'lib/helpers'
 
 interface ForeignKeysManagementProps {
   table: TableField
@@ -83,7 +84,7 @@ export const ForeignKeysManagement = ({
                   }}
                   onSelectRemove={() => {
                     setEditorDirty()
-                    if (fk.id === undefined) {
+                    if (status === 'ADD') {
                       const updatedRelations = relations.filter((x) => x.id !== fk.id)
                       onUpdateFkRelations(updatedRelations)
                     } else {


### PR DESCRIPTION
- Fix adding a new FK, then updating that FK that's in transit creates a new FK instead, and clicking remove ends up removing both of them
- Fix updating an existing FK broken when trying to update FK to target another table