### PR TITLE
fix: dark mode icon for remix icon on the connector dropdown

### DIFF
--- a/apps/studio/components/interfaces/Home/Connect/ConnectionIcon.tsx
+++ b/apps/studio/components/interfaces/Home/Connect/ConnectionIcon.tsx
@@ -13,7 +13,7 @@ const ConnectionIcon = ({ connection }: ConnectionIconProps) => {
     <Image
       className="transition-all group-hover:scale-110"
       src={`${BASE_PATH}/img/libraries/${connection.toLowerCase()}${
-        ['expo', 'nextjs', 'prisma', 'drizzle', 'astro'].includes(connection.toLowerCase())
+        ['expo', 'nextjs', 'prisma', 'drizzle', 'astro', 'remix'].includes(connection.toLowerCase())
           ? resolvedTheme?.includes('dark')
             ? '-dark'
             : ''


### PR DESCRIPTION
## What kind of change does this PR introduce?

Just a tiny follow up to #21373 , I forgot to include remix in the list of frameworks that include icons for dark mode

## What is the current behavior?

The icon is the same for dark and light mode

## What is the new behavior?

The correct icon is shown on light mode

## Additional context

n/a
