### PR TITLE
feat: docs - add inferring type example

### DIFF
--- a/apps/docs/spec/supabase_js_v2.yml
+++ b/apps/docs/spec/supabase_js_v2.yml
@@ -1792,6 +1792,15 @@ functions:
               from:sender_id(name),
               to:receiver_id(name)
             `)
+          
+          // inferring types
+          const { data, error } = await supabase
+            .from('messages')
+            .select(`
+              content,
+              from:users!messages_from_fkey(name),
+              to:users!messages_from_fkey(name)
+            `)
           ```
         data:
           sql: |

--- a/apps/docs/spec/supabase_js_v2.yml
+++ b/apps/docs/spec/supabase_js_v2.yml
@@ -1793,13 +1793,14 @@ functions:
               to:receiver_id(name)
             `)
           
-          // inferring types
+          // To infer types, use the name of the table (in this case `users`) and
+          // the name of the foreign key constraint.
           const { data, error } = await supabase
             .from('messages')
             .select(`
               content,
-              from:users!messages_from_fkey(name),
-              to:users!messages_from_fkey(name)
+              from:users!messages_sender_id_fkey(name),
+              to:users!messages_receiver_id_fkey(name)
             `)
           ```
         data:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase Docs - [Link](https://supabase.com/docs/reference/javascript/select?example=query-the-same-referenced-table-multiple-times)


## What is the new behavior?

Added a note about an example of inferring types:
<img width="514" alt="Screenshot 2024-02-20 at 20 24 15" src="https://github.com/supabase/supabase/assets/22655069/e3c4b8d9-777d-4702-af11-67460c4d745a">



## Additional context

Mentioned [here](https://github.com/supabase/supabase-js/issues/959)
