### PR TITLE
chore: speed up preview builds

### DIFF
--- a/apps/docs/lib/constants.ts
+++ b/apps/docs/lib/constants.ts
@@ -1,4 +1,5 @@
 export const IS_PLATFORM = process.env.NEXT_PUBLIC_IS_PLATFORM === 'true'
+export const IS_PREVIEW = process.env.VERCEL_ENV === 'preview'
 export const LOCAL_SUPABASE = process.env.NEXT_PUBLIC_LOCAL_SUPABASE === 'true'
 export const API_URL = (
   process.env.NODE_ENV === 'development'


### PR DESCRIPTION
we can cut preview build time by half with a minor sacrifice in similarity between prod and preview

this isn't as good a solution as switching between statically pre-rendered and statically generated on demand on the server side, since the prod/preview mismatch is now in client-side code, but we've tried a few times and haven't been able to make the server-side solution work since the nextjs upgrade

in the vast, vast majority of cases, this mismatch won't be a problem
but if you need to confirm that something does prerender statically, you'll have to do a local build now