### PR TITLE
fix the path for routing

### DIFF
--- a/apps/docs/content/guides/getting-started/tutorials/with-ionic-angular.mdx
+++ b/apps/docs/content/guides/getting-started/tutorials/with-ionic-angular.mdx
@@ -345,7 +345,7 @@ import { PreloadAllModules, RouterModule, Routes } from '@angular/router'
 
 const routes: Routes = [
   {
-    path: '/',
+    path: '',
     loadChildren: () => import('./login/login.module').then((m) => m.LoginPageModule),
   },
   {


### PR DESCRIPTION
Bug fix for the code generated from the tutorial. Without the fix, the app builds but shows a blank page in the browser, only.

The fix will make the page load and it will eliminate the following error message: Error: NG04014: Invalid configuration of route '/': path cannot start with a slash