### PR TITLE
fix blog links display

### DIFF
--- a/apps/www/lib/mdx/mdxComponents.tsx
+++ b/apps/www/lib/mdx/mdxComponents.tsx
@@ -43,8 +43,13 @@ const getCaptionAlign = (align?: 'left' | 'center' | 'right') => {
 }
 
 const LinkComponent = (props: PropsWithChildren<HTMLAnchorElement>) => (
-  <a href={props.href} target={props.target} className="inline-flex">
-    {props.children} {props.target === '_blank' && <IconArrowUpRight className="w-3" />}
+  <a
+    href={props.href}
+    target={props.target}
+    className={cn('inline relative [&_p]:inline', props.target === '_blank' && 'mr-4')}
+  >
+    {props.children}{' '}
+    {props.target === '_blank' && <IconArrowUpRight className="absolute -right-3.5 w-3 top-0" />}
   </a>
 )
 
@@ -132,7 +137,6 @@ export default function mdxComponents(type?: 'blog' | 'lp' | undefined) {
       </figure>
     ),
     Link: LinkComponent,
-    a: LinkComponent,
     code: (props: any) => <InlineCodeTag>{props.children}</InlineCodeTag>,
     BlogCollapsible: (props: any) => <BlogCollapsible {...props} />,
     Admonition,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix broken link styling.

## What is the current behavior?

<img width="866" alt="Screenshot 2024-02-21 at 10 24 43" src="https://github.com/supabase/supabase/assets/25671831/da984fde-30a1-4136-a2ed-52e308bbe421">

## What is the new behavior?

<img width="828" alt="Screenshot 2024-02-21 at 10 24 56" src="https://github.com/supabase/supabase/assets/25671831/fc5db0a6-1c9e-4130-970d-bd617e231ea6">

