### PR TITLE
fix open source card height

### DIFF
--- a/apps/www/components/OpenSource/RepoCard.tsx
+++ b/apps/www/components/OpenSource/RepoCard.tsx
@@ -10,10 +10,12 @@ const RepoCard = ({ repo, activeTab, index }: { repo: any; activeTab: number; in
     initial={{ opacity: 0, y: 5 }}
     animate={{ opacity: 1, y: 0, transition: { delay: 0 + index / 25 } }}
     exit={{ opacity: 0, y: 5, transition: { duration: 0.05 } }}
+    className="h-full"
   >
-    <Link href={repo.html_url} target="_blank">
+    <Link href={repo.html_url} target="_blank" className="h-full">
       <Panel
-        innerClassName="relative group flex flex-col gap-2 p-4 min-h-[170px] md:!h-[200px]"
+        outerClassName="md:h-full"
+        innerClassName="relative group flex flex-col gap-2 p-4 min-h-[170px] flex-1 md:h-full"
         hasActiveOnHover
       >
         <div className="flex gap-1 items-center">
@@ -38,7 +40,7 @@ const RepoCard = ({ repo, activeTab, index }: { repo: any; activeTab: number; in
           </p>
         </div>
         <p className="text-sm flex-1 text-foreground-lighter">{repo.description}</p>
-        <div className="text-sm w-full flex justify-between text-foreground-lighter mt-8">
+        <div className="text-sm w-full flex justify-between text-foreground-lighter mt-4">
           <p>{repo.full_name}</p>
           <div className="flex items-center gap-3">
             <div className="flex items-center gap-1">


### PR DESCRIPTION
Fix card height problem in open source page.

## What is the current behavior?

<img width="1528" alt="Screenshot 2024-02-22 at 16 28 10" src="https://github.com/supabase/supabase/assets/25671831/c7038c32-a53f-47c6-bd11-740dffe48422">

## What is the new behavior?

<img width="1625" alt="Screenshot 2024-02-22 at 16 28 03" src="https://github.com/supabase/supabase/assets/25671831/d222e17c-d82d-42e0-980c-51c63407ef5e">
