### PR TITLE
Chore/rls assistant iteration templates styling

### DIFF
--- a/apps/database-new/package.json
+++ b/apps/database-new/package.json
@@ -21,7 +21,7 @@
     "dayjs": "^1.11.10",
     "eslint-config-next": "^14.1.0",
     "lodash": "^4.17.21",
-    "lucide-react": "^0.292.0",
+    "lucide-react": "^0.336.0",
     "next": "^14.0.3",
     "openai": "^4.17.0",
     "react": "^18.2.0",

--- a/apps/studio/components/interfaces/Auth/Policies/AIPolicyEditorPanel/AIPolicyChat.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/AIPolicyEditorPanel/AIPolicyChat.tsx
@@ -78,7 +78,7 @@ export const AIPolicyChat = ({
 
   return (
     <div id={'ai-chat-assistant'} className="flex flex-col h-full max-w-full">
-      <div className="overflow-auto flex-1 divide-y divide-border-overlay">
+      <div className="overflow-auto flex-1 divide-y divide-border">
         <Message
           key="zero"
           role="assistant"

--- a/apps/studio/components/interfaces/Auth/Policies/AIPolicyEditorPanel/AIPolicyChat.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/AIPolicyEditorPanel/AIPolicyChat.tsx
@@ -78,7 +78,7 @@ export const AIPolicyChat = ({
 
   return (
     <div id={'ai-chat-assistant'} className="flex flex-col h-full max-w-full">
-      <div className="overflow-auto flex-1">
+      <div className="overflow-auto flex-1 divide-y divide-border-overlay">
         <Message
           key="zero"
           role="assistant"

--- a/apps/studio/components/interfaces/Auth/Policies/AIPolicyEditorPanel/AIPolicyHeader.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/AIPolicyEditorPanel/AIPolicyHeader.tsx
@@ -2,7 +2,16 @@ import { PostgresPolicy } from '@supabase/postgres-meta'
 import styles from '@ui/layout/ai-icon-animation/ai-icon-animation-style.module.css'
 import clsx from 'clsx'
 import { PanelLeftClose, PanelRightClose, X } from 'lucide-react'
-import { Button, SheetClose_Shadcn_, SheetHeader_Shadcn_, SheetTitle_Shadcn_, cn } from 'ui'
+import {
+  Button,
+  SheetClose_Shadcn_,
+  SheetHeader_Shadcn_,
+  SheetTitle_Shadcn_,
+  TooltipContent_Shadcn_,
+  TooltipTrigger_Shadcn_,
+  Tooltip_Shadcn_,
+  cn,
+} from 'ui'
 
 export const AIPolicyHeader = ({
   selectedPolicy,
@@ -39,22 +48,29 @@ export const AIPolicyHeader = ({
             : 'Create a new Row Level Security policy'}
         </SheetTitle_Shadcn_>
       </div>
-      <button
-        aria-expanded={assistantVisible}
-        aria-controls="ai-chat-assistant"
-        className={cn(
-          !assistantVisible ? 'text-foreground-lighter' : 'text-light',
-          'hover:text-foreground',
-          'transition'
-        )}
-        onClick={() => setAssistantVisible(!assistantVisible)}
-      >
-        {!assistantVisible ? (
-          <PanelLeftClose size={19} strokeWidth={1} />
-        ) : (
-          <PanelRightClose size={19} strokeWidth={1} />
-        )}
-      </button>
+      <Tooltip_Shadcn_>
+        <TooltipTrigger_Shadcn_ asChild>
+          <button
+            aria-expanded={assistantVisible}
+            aria-controls="ai-chat-assistant"
+            className={cn(
+              !assistantVisible ? 'text-foreground-lighter' : 'text-light',
+              'hover:text-foreground',
+              'transition'
+            )}
+            onClick={() => setAssistantVisible(!assistantVisible)}
+          >
+            {!assistantVisible ? (
+              <PanelLeftClose size={19} strokeWidth={1} />
+            ) : (
+              <PanelRightClose size={19} strokeWidth={1} />
+            )}
+          </button>
+        </TooltipTrigger_Shadcn_>
+        <TooltipContent_Shadcn_ side="left">
+          {assistantVisible ? 'Hide' : 'Show'} AI chat assistant
+        </TooltipContent_Shadcn_>
+      </Tooltip_Shadcn_>
       {/* <Button
         aria-expanded={assistantVisible}
         aria-controls="ai-chat-assistant"

--- a/apps/studio/components/interfaces/Auth/Policies/AIPolicyEditorPanel/AIPolicyHeader.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/AIPolicyEditorPanel/AIPolicyHeader.tsx
@@ -1,7 +1,7 @@
 import { PostgresPolicy } from '@supabase/postgres-meta'
 import styles from '@ui/layout/ai-icon-animation/ai-icon-animation-style.module.css'
 import clsx from 'clsx'
-import { X } from 'lucide-react'
+import { PanelLeftClose, PanelRightClose, X } from 'lucide-react'
 import { Button, SheetClose_Shadcn_, SheetHeader_Shadcn_, SheetTitle_Shadcn_, cn } from 'ui'
 
 export const AIPolicyHeader = ({
@@ -15,29 +15,47 @@ export const AIPolicyHeader = ({
 }) => {
   return (
     <SheetHeader_Shadcn_
-      className={`${
-        selectedPolicy !== undefined ? 'pt-3 pb-0' : 'py-3'
-      } flex flex-row justify-between items-center !pr-0`}
+      className={cn(
+        selectedPolicy !== undefined ? 'pt-3 pb-0' : 'py-3',
+        'flex flex-row justify-between items-center'
+      )}
     >
       <div className="flex flex-row gap-3 items-center max-w-[75%]">
         <SheetClose_Shadcn_
           className={clsx(
-            'text-light hover:text ring-offset-background transition-opacity hover:opacity-100',
+            'text-muted hover:text ring-offset-background transition-opacity hover:opacity-100',
             'focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
-            'disabled:pointer-events-none data-[state=open]:bg-secondary'
+            'disabled:pointer-events-none data-[state=open]:bg-secondary',
+            'transition'
           )}
         >
           <X className="h-3 w-3" />
           <span className="sr-only">Close</span>
         </SheetClose_Shadcn_>
-        <div className="h-[24px] w-[1px] bg-border" />
+        <div className="h-[24px] w-[1px] bg-border-overlay" />
         <SheetTitle_Shadcn_ className="truncate">
           {selectedPolicy !== undefined
             ? `Update policy: ${selectedPolicy.name}`
             : 'Create a new Row Level Security policy'}
         </SheetTitle_Shadcn_>
       </div>
-      <Button
+      <button
+        aria-expanded={assistantVisible}
+        aria-controls="ai-chat-assistant"
+        className={cn(
+          !assistantVisible ? 'text-foreground-lighter' : 'text-light',
+          'hover:text-foreground',
+          'transition'
+        )}
+        onClick={() => setAssistantVisible(!assistantVisible)}
+      >
+        {!assistantVisible ? (
+          <PanelLeftClose size={19} strokeWidth={1} />
+        ) : (
+          <PanelRightClose size={19} strokeWidth={1} />
+        )}
+      </button>
+      {/* <Button
         aria-expanded={assistantVisible}
         aria-controls="ai-chat-assistant"
         size="tiny"
@@ -67,7 +85,7 @@ export const AIPolicyHeader = ({
           </svg>
         }
         onClick={() => setAssistantVisible(!assistantVisible)}
-      />
+      /> */}
     </SheetHeader_Shadcn_>
   )
 }

--- a/apps/studio/components/interfaces/Auth/Policies/AIPolicyEditorPanel/AIPolicyPre.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/AIPolicyEditorPanel/AIPolicyPre.tsx
@@ -44,7 +44,7 @@ export const AIPolicyPre = ({ onDiff, children, className }: AAIPolicyPreProps) 
         value={formatted}
         language="sql"
         className={cn(
-          '!bg-transparent !py-3 !px-3.5 prose dark:prose-dark',
+          '!py-3 !px-3.5 prose dark:prose-dark',
           // change the look of the code block. The flex hack is so that the code is wrapping since
           // every word is a separate span
           '[&>code]:m-0 [&>code>span]:flex [&>code>span]:flex-wrap'
@@ -52,12 +52,25 @@ export const AIPolicyPre = ({ onDiff, children, className }: AAIPolicyPreProps) 
         hideCopy
         hideLineNumbers
       />
-      <div className="absolute top-5 right-2 bg-surface-100 border-muted border rounded-lg h-[28px] hidden group-hover:block">
+      <div
+        className={cn(
+          'absolute',
+          'top-4 right-2',
+          'bg-surface-300',
+          'border border-strong',
+          'rounded',
+          'h-[28px]',
+          'opacity-0 group-hover:opacity-100',
+          'group-hover:top-5',
+          'transition-all'
+        )}
+      >
         <Tooltip.Root delayDuration={0}>
           <Tooltip.Trigger asChild>
             <Button
               type="text"
               size="tiny"
+              className={cn('text-foreground-lighter hover:text-foreground', 'transition')}
               onClick={() => {
                 onDiff(formatted)
                 Telemetry.sendEvent(
@@ -71,7 +84,7 @@ export const AIPolicyPre = ({ onDiff, children, className }: AAIPolicyPreProps) 
                 )
               }}
             >
-              <FileDiff className="h-4 w-4" />
+              <FileDiff className={cn('h-4 w-4')} />
             </Button>
           </Tooltip.Trigger>
           <Tooltip.Portal>
@@ -93,6 +106,7 @@ export const AIPolicyPre = ({ onDiff, children, className }: AAIPolicyPreProps) 
             <Button
               type="text"
               size="tiny"
+              className={cn('text-foreground-lighter hover:text-foreground', 'transition')}
               onClick={() => {
                 handleCopy(formatted)
                 Telemetry.sendEvent(
@@ -106,7 +120,11 @@ export const AIPolicyPre = ({ onDiff, children, className }: AAIPolicyPreProps) 
                 )
               }}
             >
-              {copied ? <Check size={16} className="text-brand-600" /> : <Copy size={16} />}
+              {copied ? (
+                <Check size={16} className="text-brand-600" />
+              ) : (
+                <Copy size={16} className={cn('h-4 w-4')} />
+              )}
             </Button>
           </Tooltip.Trigger>
           <Tooltip.Portal>

--- a/apps/studio/components/interfaces/Auth/Policies/AIPolicyEditorPanel/Message.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/AIPolicyEditorPanel/Message.tsx
@@ -4,7 +4,7 @@ import Image from 'next/image'
 import { PropsWithChildren, memo, useMemo } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
-import { AiIconAnimation, Badge, markdownComponents } from 'ui'
+import { AiIconAnimation, Badge, cn, markdownComponents } from 'ui'
 
 import { useProfile } from 'lib/profile'
 import { AIPolicyPre } from './AIPolicyPre'
@@ -31,12 +31,21 @@ const Message = memo(function Message({
 
   const icon = useMemo(() => {
     return role === 'assistant' ? (
-      <AiIconAnimation
-        loading={content === 'Thinking...'}
-        className="[&>div>div]:border-black dark:[&>div>div]:border-white"
-      />
+      <div
+        className={cn(
+          'bg-foreground border border-foreground-light rounded-full',
+          'w-8 h-8',
+          'flex items-center justify-center'
+        )}
+      >
+        <AiIconAnimation
+          loading={content === 'Thinking...'}
+          className={cn('scale-75', '[&>div>div]:border-background')}
+        />
+      </div>
     ) : (
       <div className="relative border shadow-lg w-8 h-8 rounded-full overflow-hidden">
+        {/* // TODO: this only works for GitHub profiles */}
         <Image
           src={`https://github.com/${profile?.username}.png` || ''}
           width={30}
@@ -54,7 +63,9 @@ const Message = memo(function Message({
     <div className="flex flex-col py-4 gap-4 px-5 text-foreground-light text-sm">
       <div className="flex flex-row gap-3 items-center">
         {icon}
-        <span className="text-sm">{role === 'assistant' ? 'Assistant' : name ? name : 'You'}</span>
+        <span className="text-foreground">
+          {role === 'assistant' ? 'Assistant' : name ? name : 'You'}
+        </span>
         {createdAt && (
           <span className="text-xs text-foreground-muted">{dayjs(createdAt).fromNow()}</span>
         )}

--- a/apps/studio/components/interfaces/Auth/Policies/AIPolicyEditorPanel/PolicyTemplates.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/AIPolicyEditorPanel/PolicyTemplates.tsx
@@ -1,8 +1,12 @@
 import { useState } from 'react'
 import {
   Badge,
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
   IconSearch,
   Input,
+  ScrollArea,
   TooltipContent_Shadcn_,
   TooltipTrigger_Shadcn_,
   Tooltip_Shadcn_,
@@ -14,6 +18,7 @@ import { getGeneralPolicyTemplates } from '../PolicyEditorModal/PolicyEditorModa
 import NoSearchResults from 'components/ui/NoSearchResults'
 import { Markdown } from 'components/interfaces/Markdown'
 import CopyButton from 'components/ui/CopyButton'
+import { Search } from 'lucide-react'
 
 interface PolicyTemplatesProps {
   onSelectTemplate: (template: any) => void
@@ -32,46 +37,58 @@ export const PolicyTemplates = ({ onSelectTemplate }: PolicyTemplatesProps) => {
       : templates
 
   return (
-    <div className="flex flex-col gap-y-4 p-4">
+    <div className="h-full px-content py-content flex flex-col gap-3">
+      <label className="sr-only" htmlFor="template-search">
+        Search templates
+      </label>
       <Input
         size="small"
-        icon={<IconSearch />}
+        id="template-search"
+        icon={<Search size={16} className="text-foreground-muted" />}
         placeholder="Search templates"
         value={search}
         onChange={(event) => setSearch(event.target.value)}
       />
-      <div className="flex flex-col gap-y-2">
-        {search.length > 0 && filteredTemplates.length === 0 && (
-          <NoSearchResults searchString={search} />
-        )}
-        {filteredTemplates.map((template) => (
-          <Tooltip_Shadcn_ key={template.id} delayDuration={100}>
-            <TooltipTrigger_Shadcn_ asChild>
-              <div
-                className={cn(
-                  'grid grid-cols-12 rounded px-4 py-3 gap-x-4 cursor-pointer transition',
-                  'border bg-surface-100 hover:border-strong'
-                )}
-                onClick={() => onSelectTemplate(template.statement)}
+
+      {search.length > 0 && filteredTemplates.length === 0 && (
+        <NoSearchResults searchString={search} className="min-w-full" />
+      )}
+
+      <div className="flex flex-col gap-1.5">
+        {filteredTemplates.map((template) => {
+          return (
+            <HoverCard key={template.id} openDelay={100} closeDelay={0}>
+              <HoverCardTrigger asChild>
+                <button
+                  key={template.id}
+                  className={cn(
+                    'text-left',
+                    'flex flex-row',
+                    'rounded-panel px-4 py-3 gap-x-4 cursor-pointer transition',
+                    'border bg-surface-100 hover:border-strong'
+                  )}
+                  onClick={() => onSelectTemplate(template.statement)}
+                >
+                  <div className="min-w-16">
+                    <Badge className="!rounded font-mono" color="scale">
+                      {template.command}
+                    </Badge>
+                  </div>
+                  <div className="text-sm mt-[3px] flex flex-col gap-y-1">
+                    <p>{template.name}</p>
+                    <Markdown content={template.description} className="[&>p]:m-0 space-y-2" />
+                    {/* <p>{template.description}</p> */}
+                  </div>
+                </button>
+              </HoverCardTrigger>
+              <HoverCardContent
+                hideWhenDetached
+                side="left"
+                align="center"
+                className="w-96 flex flex-col gap-y-2"
               >
-                <div className="col-span-2">
-                  <Badge className="!rounded" color="scale">
-                    {template.command}
-                  </Badge>
-                </div>
-                <div className="col-span-10 text-sm mt-[3px] flex flex-col gap-y-1">
-                  <p>{template.name}</p>
-                  <Markdown content={template.description} className="[&>p]:m-0 space-y-2" />
-                </div>
-              </div>
-            </TooltipTrigger_Shadcn_>
-            <TooltipContent_Shadcn_
-              side="left"
-              align="start"
-              className="w-96 flex flex-col gap-y-2 py-3"
-            >
-              <p className="text-xs">Policy SQL preview:</p>
-              <div className="bg-surface-300 py-2 px-3 rounded relative">
+                {/* <p className="text-xs">Policy SQL preview:</p> */}
+                {/* <div className="bg-surface-300 py-2 px-3 rounded relative"> */}
                 <SimpleCodeBlock
                   showCopy={false}
                   className="sql"
@@ -85,10 +102,11 @@ export const PolicyTemplates = ({ onSelectTemplate }: PolicyTemplatesProps) => {
                   className="px-1 absolute top-1.5 right-1.5"
                   text={template.statement}
                 />
-              </div>
-            </TooltipContent_Shadcn_>
-          </Tooltip_Shadcn_>
-        ))}
+                {/* </div> */}
+              </HoverCardContent>
+            </HoverCard>
+          )
+        })}
       </div>
     </div>
   )

--- a/apps/studio/components/interfaces/Auth/Policies/AIPolicyEditorPanel/PolicyTemplates.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/AIPolicyEditorPanel/PolicyTemplates.tsx
@@ -65,7 +65,7 @@ export const PolicyTemplates = ({ onSelectTemplate }: PolicyTemplatesProps) => {
                     'text-left',
                     'flex flex-row',
                     'rounded-panel px-4 py-3 gap-x-4 cursor-pointer transition',
-                    'border bg-surface-100 hover:border-strong'
+                    'border bg-surface-100 hover:border-stronger'
                   )}
                   onClick={() => onSelectTemplate(template.statement)}
                 >
@@ -85,14 +85,13 @@ export const PolicyTemplates = ({ onSelectTemplate }: PolicyTemplatesProps) => {
                 hideWhenDetached
                 side="left"
                 align="center"
-                className="w-96 flex flex-col gap-y-2"
+                className="w-96 flex"
+                animate="slide-in"
               >
-                {/* <p className="text-xs">Policy SQL preview:</p> */}
-                {/* <div className="bg-surface-300 py-2 px-3 rounded relative"> */}
                 <SimpleCodeBlock
                   showCopy={false}
                   className="sql"
-                  parentClassName="!p-0 [&>div>span]:text-xs [&>div>span]:tracking-tighter"
+                  parentClassName="!p-0 [&>div>span]:text-xs"
                 >
                   {template.statement}
                 </SimpleCodeBlock>
@@ -102,7 +101,6 @@ export const PolicyTemplates = ({ onSelectTemplate }: PolicyTemplatesProps) => {
                   className="px-1 absolute top-1.5 right-1.5"
                   text={template.statement}
                 />
-                {/* </div> */}
               </HoverCardContent>
             </HoverCard>
           )

--- a/apps/studio/components/interfaces/Auth/Policies/AIPolicyEditorPanel/PolicyTemplates.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/AIPolicyEditorPanel/PolicyTemplates.tsx
@@ -19,6 +19,7 @@ import NoSearchResults from 'components/ui/NoSearchResults'
 import { Markdown } from 'components/interfaces/Markdown'
 import CopyButton from 'components/ui/CopyButton'
 import { Search } from 'lucide-react'
+import CardButton from 'components/ui/CardButton'
 
 interface PolicyTemplatesProps {
   onSelectTemplate: (template: any) => void
@@ -58,28 +59,23 @@ export const PolicyTemplates = ({ onSelectTemplate }: PolicyTemplatesProps) => {
         {filteredTemplates.map((template) => {
           return (
             <HoverCard key={template.id} openDelay={100} closeDelay={0}>
-              <HoverCardTrigger asChild>
-                <button
+              <HoverCardTrigger>
+                <CardButton
+                  title={template.name}
                   key={template.id}
-                  className={cn(
-                    'text-left',
-                    'flex flex-row',
-                    'rounded-panel px-4 py-3 gap-x-4 cursor-pointer transition',
-                    'border bg-surface-100 hover:border-stronger'
-                  )}
                   onClick={() => onSelectTemplate(template.statement)}
+                  hideChevron
+                  fixedHeight={false}
+                  icon={
+                    <div className="min-w-16">
+                      <Badge className="!rounded font-mono" color="scale">
+                        {template.command}
+                      </Badge>
+                    </div>
+                  }
                 >
-                  <div className="min-w-16">
-                    <Badge className="!rounded font-mono" color="scale">
-                      {template.command}
-                    </Badge>
-                  </div>
-                  <div className="text-sm mt-[3px] flex flex-col gap-y-1">
-                    <p>{template.name}</p>
-                    <Markdown content={template.description} className="[&>p]:m-0 space-y-2" />
-                    {/* <p>{template.description}</p> */}
-                  </div>
-                </button>
+                  <Markdown content={template.description} className="[&>p]:m-0 space-y-2" />
+                </CardButton>
               </HoverCardTrigger>
               <HoverCardContent
                 hideWhenDetached

--- a/apps/studio/components/interfaces/Auth/Policies/AIPolicyEditorPanel/index.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/AIPolicyEditorPanel/index.tsx
@@ -11,6 +11,7 @@ import toast from 'react-hot-toast'
 import {
   Button,
   Modal,
+  ScrollArea,
   SheetContent_Shadcn_,
   SheetFooter_Shadcn_,
   Sheet_Shadcn_,
@@ -289,6 +290,7 @@ export const AIPolicyEditorPanel = memo(function ({
         <SheetContent_Shadcn_
           size={assistantVisible ? 'lg' : 'default'}
           className={cn(
+            'bg-surface-200',
             'p-0 flex flex-row gap-0',
             assistantVisible ? '!min-w-[1200px]' : '!min-w-[600px]'
           )}
@@ -308,7 +310,7 @@ export const AIPolicyEditorPanel = memo(function ({
 
             <div className="flex flex-col h-full w-full justify-between">
               {incomingChange ? (
-                <div className="px-5 py-3 flex justify-between gap-3 bg-muted">
+                <div className="px-5 py-3 flex justify-between gap-3 bg-surface-75">
                   <div className="flex gap-2 items-center text-foreground-light">
                     <FileDiff className="h-4 w-4" />
                     <span className="text-sm">Accept changes from assistant</span>
@@ -415,20 +417,34 @@ export const AIPolicyEditorPanel = memo(function ({
             </div>
           </div>
           {assistantVisible && (
-            <div className={cn('border-l', assistantVisible && 'w-[50%]')}>
+            <div
+              className={cn(
+                'border-l shadow-[rgba(0,0,0,0.13)_-4px_0px_6px_0px] z-10',
+                assistantVisible && 'w-[50%]',
+                'bg-studio'
+              )}
+            >
               <Tabs_Shadcn_ defaultValue="templates" className="flex flex-col h-full w-full">
-                <TabsList_Shadcn_ className="flex gap-4 px-4 pt-2">
+                <TabsList_Shadcn_ className="flex gap-4 px-content pt-2">
                   <TabsTrigger_Shadcn_ key="templates" value="templates" className="px-0">
                     RLS Templates
                   </TabsTrigger_Shadcn_>
                   {!hasHipaaAddon && (
                     <TabsTrigger_Shadcn_ key="conversation" value="conversation" className="px-0">
-                      AI Suggestions
+                      Assistant
                     </TabsTrigger_Shadcn_>
                   )}
                 </TabsList_Shadcn_>
-                <TabsContent_Shadcn_ value="templates" className="!mt-0 overflow-y-auto relative">
-                  <PolicyTemplates onSelectTemplate={updateEditorWithCheckForDiff} />
+                <TabsContent_Shadcn_
+                  value="templates"
+                  className={cn(
+                    '!mt-0 overflow-y-auto',
+                    'data-[state=active]:flex data-[state=active]:grow'
+                  )}
+                >
+                  <ScrollArea className="h-full w-full">
+                    <PolicyTemplates onSelectTemplate={updateEditorWithCheckForDiff} />
+                  </ScrollArea>
                 </TabsContent_Shadcn_>
                 <TabsContent_Shadcn_
                   value="conversation"

--- a/apps/studio/components/interfaces/Auth/Policies/AIPolicyEditorPanel/index.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/AIPolicyEditorPanel/index.tsx
@@ -426,11 +426,19 @@ export const AIPolicyEditorPanel = memo(function ({
             >
               <Tabs_Shadcn_ defaultValue="templates" className="flex flex-col h-full w-full">
                 <TabsList_Shadcn_ className="flex gap-4 px-content pt-2">
-                  <TabsTrigger_Shadcn_ key="templates" value="templates" className="px-0">
+                  <TabsTrigger_Shadcn_
+                    key="templates"
+                    value="templates"
+                    className="px-0 data-[state=active]:bg-transparent"
+                  >
                     RLS Templates
                   </TabsTrigger_Shadcn_>
                   {!hasHipaaAddon && (
-                    <TabsTrigger_Shadcn_ key="conversation" value="conversation" className="px-0">
+                    <TabsTrigger_Shadcn_
+                      key="conversation"
+                      value="conversation"
+                      className="px-0 data-[state=active]:bg-transparent"
+                    >
                       Assistant
                     </TabsTrigger_Shadcn_>
                   )}

--- a/apps/studio/components/interfaces/Auth/Policies/AIPolicyEditorPanel/index.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/AIPolicyEditorPanel/index.tsx
@@ -407,7 +407,7 @@ export const AIPolicyEditorPanel = memo(function ({
                       disabled={isExecuting || incomingChange !== undefined}
                       onClick={() => onExecuteSQL()}
                     >
-                      Save policy
+                      Create policy
                     </Button>
                   </div>
                 </SheetFooter_Shadcn_>

--- a/apps/studio/components/interfaces/Auth/Policies/AIPolicyEditorPanel/index.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/AIPolicyEditorPanel/index.tsx
@@ -409,7 +409,7 @@ export const AIPolicyEditorPanel = memo(function ({
                       disabled={isExecuting || incomingChange !== undefined}
                       onClick={() => onExecuteSQL()}
                     >
-                      Create policy
+                      Save policy
                     </Button>
                   </div>
                 </SheetFooter_Shadcn_>

--- a/apps/studio/components/ui/CardButton.tsx
+++ b/apps/studio/components/ui/CardButton.tsx
@@ -3,7 +3,6 @@ import React, { PropsWithChildren } from 'react'
 import { IconChevronRight, IconLoader, cn } from 'ui'
 
 interface CardButtonProps {
-  title: string | React.ReactNode
   description?: string
   footer?: React.ReactNode
   url?: string
@@ -18,6 +17,26 @@ interface CardButtonProps {
   hideChevron?: boolean
 }
 
+// Define separate interfaces for each type of container
+interface LinkContainerProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+  href: string
+}
+
+interface UrlContainerProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+  href: string
+}
+
+interface NonLinkContainerProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+interface ButtonContainerProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
+
+// Union of all container props
+type ContainerProps =
+  | LinkContainerProps
+  | UrlContainerProps
+  | NonLinkContainerProps
+  | ButtonContainerProps
+
 const CardButton = ({
   title,
   description,
@@ -27,35 +46,37 @@ const CardButton = ({
   linkHref = '',
   imgUrl,
   imgAlt,
-  onClick,
   icon,
   className,
   loading = false,
   fixedHeight = true,
   hideChevron = false,
   ...props
-}: PropsWithChildren<CardButtonProps>) => {
-  const LinkContainer = React.forwardRef<HTMLAnchorElement, React.PropsWithChildren<any>>(
-    (props, ref) => <Link ref={ref} {...props} href={linkHref} />
-  )
-  LinkContainer.displayName = 'LinkContainer'
+}: PropsWithChildren<CardButtonProps & ContainerProps>) => {
+  const isLink = url || linkHref || props.onClick
 
-  const UrlContainer = React.forwardRef<HTMLAnchorElement, React.PropsWithChildren<any>>(
-    (props, ref) => <a ref={ref} {...props} href={url} />
-  )
+  let Container: React.ElementType
+  let containerProps: ContainerProps = {}
 
-  UrlContainer.displayName = 'UrlContainer'
-  const NonLinkContainer = React.forwardRef<HTMLDivElement, React.PropsWithChildren<any>>(
-    (props, ref) => <div ref={ref} {...props} />
-  )
-  NonLinkContainer.displayName = 'NonLinkContainer'
-
-  const ButtonContainer = React.forwardRef<HTMLButtonElement, React.PropsWithChildren<any>>(
-    (props, ref) => <button onClick={onClick} {...props} ref={ref} />
-  )
-  ButtonContainer.displayName = 'ButtonContainer'
-
-  const isLink = url || linkHref || onClick
+  if (props.onClick) {
+    Container = 'button'
+    containerProps = props
+  } else if (linkHref) {
+    Container = Link
+    containerProps = {
+      href: linkHref,
+      ...props,
+    }
+  } else if (url) {
+    Container = 'a'
+    containerProps = {
+      href: url,
+      ...props,
+    }
+  } else {
+    Container = 'div'
+    containerProps = props
+  }
 
   let containerClasses = [
     'group relative text-left',
@@ -133,31 +154,11 @@ const CardButton = ({
     </>
   )
 
-  if (onClick) {
-    return (
-      <ButtonContainer {...props} className={cn(containerClasses, className)}>
-        {contents}
-      </ButtonContainer>
-    )
-  } else if (linkHref) {
-    return (
-      <LinkContainer {...props} className={cn(containerClasses, className)}>
-        {contents}
-      </LinkContainer>
-    )
-  } else if (url) {
-    return (
-      <UrlContainer {...props} className={cn(containerClasses, className)}>
-        {contents}
-      </UrlContainer>
-    )
-  } else {
-    return (
-      <NonLinkContainer {...props} className={cn(containerClasses, className)}>
-        {contents}
-      </NonLinkContainer>
-    )
-  }
+  return (
+    <Container {...containerProps} className={cn(containerClasses, className)}>
+      {contents}
+    </Container>
+  )
 }
 
 export default CardButton

--- a/apps/studio/components/ui/CardButton.tsx
+++ b/apps/studio/components/ui/CardButton.tsx
@@ -3,6 +3,7 @@ import React, { PropsWithChildren } from 'react'
 import { IconChevronRight, IconLoader, cn } from 'ui'
 
 interface CardButtonProps {
+  title?: string | React.ReactNode
   description?: string
   footer?: React.ReactNode
   url?: string
@@ -18,17 +19,18 @@ interface CardButtonProps {
 }
 
 // Define separate interfaces for each type of container
-interface LinkContainerProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+interface LinkContainerProps extends Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'title'> {
   href: string
 }
 
-interface UrlContainerProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+interface UrlContainerProps extends Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'title'> {
   href: string
 }
 
-interface NonLinkContainerProps extends React.HTMLAttributes<HTMLDivElement> {}
+interface NonLinkContainerProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'title'> {}
 
-interface ButtonContainerProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
+interface ButtonContainerProps
+  extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'title'> {}
 
 // Union of all container props
 type ContainerProps =

--- a/apps/studio/components/ui/CardButton.tsx
+++ b/apps/studio/components/ui/CardButton.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 import React, { PropsWithChildren } from 'react'
-import { IconChevronRight, IconLoader } from 'ui'
+import { IconChevronRight, IconLoader, cn } from 'ui'
 
 interface CardButtonProps {
   title: string | React.ReactNode
@@ -14,6 +14,8 @@ interface CardButtonProps {
   icon?: React.ReactNode
   loading?: boolean
   className?: string
+  fixedHeight?: boolean
+  hideChevron?: boolean
 }
 
 const CardButton = ({
@@ -29,24 +31,37 @@ const CardButton = ({
   icon,
   className,
   loading = false,
+  fixedHeight = true,
+  hideChevron = false,
+  ...props
 }: PropsWithChildren<CardButtonProps>) => {
-  const LinkContainer = ({ children }: { children: React.ReactNode }) => (
-    <Link href={linkHref}>{children}</Link>
+  const LinkContainer = React.forwardRef<HTMLAnchorElement, React.PropsWithChildren<any>>(
+    (props, ref) => <Link ref={ref} {...props} href={linkHref} />
   )
-  const UrlContainer = ({ children }: { children: React.ReactNode }) => <a href={url}>{children}</a>
-  const NonLinkContainer = ({ children }: { children: React.ReactNode }) => <div>{children}</div>
-  const ButtonContainer = ({ children }: { children: React.ReactNode }) => (
-    <button onClick={onClick}>{children}</button>
+  LinkContainer.displayName = 'LinkContainer'
+
+  const UrlContainer = React.forwardRef<HTMLAnchorElement, React.PropsWithChildren<any>>(
+    (props, ref) => <a ref={ref} {...props} href={url} />
   )
+
+  UrlContainer.displayName = 'UrlContainer'
+  const NonLinkContainer = React.forwardRef<HTMLDivElement, React.PropsWithChildren<any>>(
+    (props, ref) => <div ref={ref} {...props} />
+  )
+  NonLinkContainer.displayName = 'NonLinkContainer'
+
+  const ButtonContainer = React.forwardRef<HTMLButtonElement, React.PropsWithChildren<any>>(
+    (props, ref) => <button onClick={onClick} {...props} ref={ref} />
+  )
+  ButtonContainer.displayName = 'ButtonContainer'
 
   const isLink = url || linkHref || onClick
 
   let containerClasses = [
-    className,
     'group relative text-left',
     'bg-surface-100',
     'border border-surface',
-    'rounded-md p-5 flex flex-row h-32',
+    'rounded-md p-5 flex flex-row',
     'transition ease-in-out duration-150',
   ]
 
@@ -59,12 +74,16 @@ const CardButton = ({
     ]
   }
 
+  if (fixedHeight) {
+    containerClasses = [...containerClasses, 'h-32']
+  }
+
   const ImageContainer = ({ children }: { children: React.ReactNode }) => {
     return <div className="mr-4 flex flex-col">{children}</div>
   }
 
   const contents = (
-    <div className={containerClasses.join(' ')}>
+    <>
       {imgUrl && (
         <ImageContainer>
           <img
@@ -102,20 +121,42 @@ const CardButton = ({
           group-hover:text-foreground
         "
         >
-          {loading ? <IconLoader className="animate-spin" /> : <IconChevronRight />}
+          {loading ? (
+            <IconLoader className="animate-spin" />
+          ) : !hideChevron ? (
+            <IconChevronRight />
+          ) : (
+            <></>
+          )}
         </div>
       )}
-    </div>
+    </>
   )
 
   if (onClick) {
-    return <ButtonContainer>{contents}</ButtonContainer>
+    return (
+      <ButtonContainer {...props} className={cn(containerClasses, className)}>
+        {contents}
+      </ButtonContainer>
+    )
   } else if (linkHref) {
-    return <LinkContainer>{contents}</LinkContainer>
+    return (
+      <LinkContainer {...props} className={cn(containerClasses, className)}>
+        {contents}
+      </LinkContainer>
+    )
   } else if (url) {
-    return <UrlContainer>{contents}</UrlContainer>
+    return (
+      <UrlContainer {...props} className={cn(containerClasses, className)}>
+        {contents}
+      </UrlContainer>
+    )
   } else {
-    return <NonLinkContainer>{contents}</NonLinkContainer>
+    return (
+      <NonLinkContainer {...props} className={cn(containerClasses, className)}>
+        {contents}
+      </NonLinkContainer>
+    )
   }
 }
 

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -57,7 +57,7 @@
     "json-logic-js": "^2.0.2",
     "jsonrepair": "^3.2.3",
     "lodash": "^4.17.21",
-    "lucide-react": "^0.167.0",
+    "lucide-react": "^0.336.0",
     "markdown-table": "=2.0.0",
     "mobx": "^6.10.2",
     "mobx-react-lite": "^4.0.5",

--- a/apps/studio/styles/monaco.scss
+++ b/apps/studio/styles/monaco.scss
@@ -3,6 +3,12 @@
   -webkit-text-size-adjust: 100%;
 }
 
+.monaco-editor,
+.monaco-diff-editor {
+  --vscode-editor-background: hsl(var(--background-surface-200)) !important;
+  --vscode-editorGutter-background: hsl(var(--background-surface-200)) !important;
+}
+
 .gutter {
   @apply bg-border-control;
   cursor: row-resize;

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "dayjs": "^1.11.10",
         "eslint-config-next": "^14.1.0",
         "lodash": "^4.17.21",
-        "lucide-react": "^0.292.0",
+        "lucide-react": "^0.336.0",
         "next": "^14.0.3",
         "openai": "^4.17.0",
         "react": "^18.2.0",
@@ -382,14 +382,6 @@
       },
       "peerDependencies": {
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
-      }
-    },
-    "apps/database-new/node_modules/lucide-react": {
-      "version": "0.292.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.292.0.tgz",
-      "integrity": "sha512-rRgUkpEHWpa5VCT66YscInCQmQuPCB1RFRzkkxMxg4b+jaL0V12E3riWWR2Sh5OIiUhCwGW/ZExuEO4Az32E6Q==",
-      "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
       }
     },
     "apps/database-new/node_modules/next": {
@@ -806,7 +798,7 @@
         "json-logic-js": "^2.0.2",
         "jsonrepair": "^3.2.3",
         "lodash": "^4.17.21",
-        "lucide-react": "^0.167.0",
+        "lucide-react": "^0.336.0",
         "markdown-table": "=2.0.0",
         "mobx": "^6.10.2",
         "mobx-react-lite": "^4.0.5",
@@ -24176,8 +24168,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.167.0",
-      "license": "ISC",
+      "version": "0.336.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.336.0.tgz",
+      "integrity": "sha512-e06J4Qrdrk3BP/hf3MnkW3LnymdthfyEtVbdEg0xPQ/olTEKfOfTv03DYmdRm1+XpaNQdCpiHT7Vi6regbxDCQ==",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
       }
@@ -37344,7 +37337,7 @@
         "date-fns": "^2.30.0",
         "formik": "^2.2.9",
         "lodash": "^4.17.21",
-        "lucide-react": "^0.167.0",
+        "lucide-react": "^0.336.0",
         "next-themes": "^0.2.1",
         "openai": "^4.17.0",
         "postcss": "^8.4.31",

--- a/packages/config/tailwind.config.js
+++ b/packages/config/tailwind.config.js
@@ -87,7 +87,7 @@ function kebabToNested(obj) {
  */
 const uiConfig = ui({
   mode: 'JIT',
-  darkMode: [ 'class', '[data-theme*="dark"]' ],
+  darkMode: ['class', '[data-theme*="dark"]'],
   theme: {
     /**
      * Spread all theme colors and custom generated colors into theme
@@ -102,7 +102,7 @@ const uiConfig = ui({
       /*
        * custom background re-maps
        */
-      "studio": `hsl(var(--background-200)/ <alpha-value>)`
+      studio: `hsl(var(--background-200)/ <alpha-value>)`,
     }),
     borderColor: (theme) => ({
       ...theme('colors'),
@@ -361,8 +361,8 @@ const uiConfig = ui({
         xs: '480px',
       },
       fontFamily: {
-        sans: [ 'Circular', 'custom-font', 'Helvetica Neue', 'Helvetica', 'Arial', 'sans-serif' ],
-        mono: [ 'Office Code Pro', 'Source Code Pro', 'Menlo', 'monospace' ],
+        sans: ['Circular', 'custom-font', 'Helvetica Neue', 'Helvetica', 'Arial', 'sans-serif'],
+        mono: ['Office Code Pro', 'Source Code Pro', 'Menlo', 'monospace'],
       },
 
       // shadcn defaults START
@@ -375,6 +375,15 @@ const uiConfig = ui({
       animation: {
         'flash-code': 'flash-code 1s forwards',
         'flash-code-slow': 'flash-code 2s forwards',
+      },
+      borderRadius: {
+        // lg: `var(--radius)`,
+        // md: `calc(var(--radius) - 2px)`,
+        // sm: 'calc(var(--radius) - 4px)',
+        panel: '6px',
+      },
+      padding: {
+        content: '21px',
       },
       // borderRadius: {
       //   lg: `var(--radius)`,
@@ -397,8 +406,8 @@ const uiConfig = ui({
       // shadcn defaults END
     },
   },
-  plugins: [ require('@tailwindcss/typography'), require('tailwindcss-animate') ],
-});
+  plugins: [require('@tailwindcss/typography'), require('tailwindcss-animate')],
+})
 
 function arrayMergeFn(destinationArray, sourceArray) {
   return destinationArray.concat(sourceArray).reduce((acc, cur) => {

--- a/packages/ui/index.tsx
+++ b/packages/ui/index.tsx
@@ -171,6 +171,8 @@ export { Checkbox as Checkbox_Shadcn_ } from './src/components/shadcn/ui/checkbo
 
 export * from './src/components/shadcn/ui/scroll-area'
 
+export * from './src/components/shadcn/ui/hover-card'
+
 export {
   Collapsible as Collapsible_Shadcn_,
   CollapsibleTrigger as CollapsibleTrigger_Shadcn_,

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -61,7 +61,7 @@
     "date-fns": "^2.30.0",
     "formik": "^2.2.9",
     "lodash": "^4.17.21",
-    "lucide-react": "^0.167.0",
+    "lucide-react": "^0.336.0",
     "next-themes": "^0.2.1",
     "openai": "^4.17.0",
     "postcss": "^8.4.31",

--- a/packages/ui/src/components/shadcn/ui/hover-card.tsx
+++ b/packages/ui/src/components/shadcn/ui/hover-card.tsx
@@ -11,14 +11,19 @@ const HoverCardTrigger = HoverCardPrimitive.Trigger
 
 const HoverCardContent = React.forwardRef<
   React.ElementRef<typeof HoverCardPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof HoverCardPrimitive.Content>
->(({ className, align = 'center', sideOffset = 4, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof HoverCardPrimitive.Content> & {
+    animate?: 'zoom-in' | 'slide-in'
+  }
+>(({ className, align = 'center', animate = 'zoom-in', sideOffset = 4, ...props }, ref) => (
   <HoverCardPrimitive.Content
     ref={ref}
     align={align}
     sideOffset={sideOffset}
     className={cn(
-      'z-50 w-64 rounded-md border bg-overlay p-4 text-popover-foreground shadow-md outline-none animate-in zoom-in-90',
+      'z-50 w-64 rounded-md border bg-overlay p-4 text-popover-foreground shadow-md outline-none',
+      animate === 'zoom-in'
+        ? 'animate-in zoom-in-[99%]'
+        : 'animate-in fade-in-50 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1',
       className
     )}
     {...props}

--- a/packages/ui/src/components/shadcn/ui/scroll-area.tsx
+++ b/packages/ui/src/components/shadcn/ui/scroll-area.tsx
@@ -14,7 +14,7 @@ const ScrollArea = React.forwardRef<
     className={cn('relative overflow-hidden', className)}
     {...props}
   >
-    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
+    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit] shadow-[0_2px_10px]">
       {children}
     </ScrollAreaPrimitive.Viewport>
     <ScrollBar />

--- a/packages/ui/src/components/shadcn/ui/tabs/tabs.tsx
+++ b/packages/ui/src/components/shadcn/ui/tabs/tabs.tsx
@@ -13,7 +13,7 @@ const TabsList = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <TabsPrimitive.List
     ref={ref}
-    className={cn('flex items-center border-b border-secondary', className)}
+    className={cn('flex items-center border-b', className)}
     {...props}
   />
 ))

--- a/packages/ui/src/components/shadcn/ui/tooltip.tsx
+++ b/packages/ui/src/components/shadcn/ui/tooltip.tsx
@@ -7,7 +7,9 @@ import { cn } from '../../../lib/utils/cn'
 
 const TooltipProvider = TooltipPrimitive.Provider
 
-const Tooltip = TooltipPrimitive.Root
+const Tooltip = (props: React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Root>) => (
+  <TooltipPrimitive.Root delayDuration={180} {...props} />
+)
 
 const TooltipTrigger = TooltipPrimitive.Trigger
 
@@ -18,11 +20,11 @@ const TooltipContent = React.forwardRef<
   <TooltipPrimitive.Content
     ref={ref}
     sideOffset={sideOffset}
+    {...props}
     className={cn(
-      'z-50 overflow-hidden rounded-md border bg-overlay px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-50 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1',
+      'z-50 overflow-hidden rounded-md border bg-alternative px-3 py-1.5 text-xs text-foreground shadow-md animate-in fade-in-50 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1',
       className
     )}
-    {...props}
   />
 ))
 TooltipContent.displayName = TooltipPrimitive.Content.displayName


### PR DESCRIPTION
## What kind of change does this PR introduce?

### big changes

- monaco editor updated
  - background color updated across all of studio inline with themes in figma.
- updated styling of codeblocks in RLS chat
- add new tailwind classes
  - `p-content` and `rounded-panel`
- Updated tab label to "Assistant" and adjusted background colors
- updated open / close button. also added a tooltip
- template cards section updated to use new tailwind classes 
  - also now using ScrollArea
- message styling updated to use circle AI icon
- "Save policy" -> "Create policy" more friendly Postgres language.
- CardButton refactored to show all props
  - CardButton now used in template list

### smaller things
  
- update icon pack
- expose hover card
  - also use hover card in templates
  - added 'slide in' animation option for Hover Card. there is now a `animation` prop on HoverCard.
- add slight shadow to scroll area
- tabs border-b updated
- header updated to use simpler open/close button
- divide-y styling added to chat
- fix tabs bg state
- shadcn tooltip updated to use correct bg 
- divide border styling

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.

<img width="1321" alt="Screenshot 2024-02-23 at 2 05 23 AM" src="https://github.com/supabase/supabase/assets/8291514/953a8102-f4a3-4116-a701-8471350c7cc5">
