### PR TITLE
improve initial load

### DIFF
--- a/apps/www/components/Footer/index.tsx
+++ b/apps/www/components/Footer/index.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from 'react'
 import Link from 'next/link'
 import { useTheme } from 'next-themes'
 import { Badge, IconDiscord, IconGitHubSolid, IconTwitterX, IconYoutubeSolid, cn } from 'ui'
@@ -24,18 +23,7 @@ const Footer = (props: Props) => {
   const isLaunchWeek = pathname.includes('launch-week')
   const forceDark = isLaunchWeek || pathname === '/'
 
-  /**
-   * Temporary fix for next-theme client side bug
-   * https://github.com/pacocoursey/next-themes/issues/169
-   * TODO: remove when bug has been fixed
-   */
-  const [mounted, setMounted] = useState(false)
-
-  useEffect(() => {
-    setMounted(true)
-  }, [])
-
-  if (!mounted || props.hideFooter) {
+  if (props.hideFooter) {
     return null
   }
 
@@ -76,7 +64,7 @@ const Footer = (props: Props) => {
                 src={
                   forceDark
                     ? supabaseLogoWordmarkDark
-                    : mounted && resolvedTheme?.includes('dark')
+                    : resolvedTheme?.includes('dark')
                       ? supabaseLogoWordmarkDark
                       : supabaseLogoWordmarkLight
                 }

--- a/apps/www/components/Footer/index.tsx
+++ b/apps/www/components/Footer/index.tsx
@@ -14,6 +14,7 @@ import { ThemeToggle } from 'ui-patterns/ThemeToggle'
 
 interface Props {
   className?: string
+  hideFooter?: boolean
 }
 
 const Footer = (props: Props) => {
@@ -34,7 +35,7 @@ const Footer = (props: Props) => {
     setMounted(true)
   }, [])
 
-  if (!mounted) {
+  if (!mounted || props.hideFooter) {
     return null
   }
 

--- a/apps/www/components/Hero/Hero.tsx
+++ b/apps/www/components/Hero/Hero.tsx
@@ -3,10 +3,9 @@ import { useRouter } from 'next/router'
 import Telemetry, { TelemetryEvent } from '~/lib/telemetry'
 import { useTelemetryProps } from 'common/hooks/useTelemetryProps'
 import gaEvents from '~/lib/gaEvents'
-import { Button, IconBookOpen, cn } from 'ui'
+import { Button, IconBookOpen } from 'ui'
 import SectionContainer from '~/components/Layouts/SectionContainer'
 import HeroFrameworks from './HeroFrameworks'
-import styles from './hero.module.css'
 
 const Hero = () => {
   const router = useRouter()
@@ -21,12 +20,7 @@ const Hero = () => {
         <div className="relative">
           <div className="mx-auto">
             <div className="mx-auto max-w-2xl lg:col-span-6 lg:flex lg:items-center justify-center text-center">
-              <div
-                className={cn(
-                  'relative z-10 appear-first lg:h-auto pt-[90px] lg:pt-[90px] lg:min-h-[300px] flex flex-col items-center justify-center sm:mx-auto md:w-3/4 lg:mx-0 lg:w-full gap-4 lg:gap-8',
-                  styles['hero-text']
-                )}
-              >
+              <div className="relative z-10 lg:h-auto pt-[90px] lg:pt-[90px] lg:min-h-[300px] flex flex-col items-center justify-center sm:mx-auto md:w-3/4 lg:mx-0 lg:w-full gap-4 lg:gap-8">
                 <div className="flex flex-col items-center">
                   {/* <div className="z-40 w-full flex justify-center mb-8 lg:mb-8">
                     <AnnouncementBadge

--- a/apps/www/components/Layouts/Default.tsx
+++ b/apps/www/components/Layouts/Default.tsx
@@ -21,9 +21,9 @@ const DefaultLayout = (props: Props) => {
 
   return (
     <>
-      {!hideHeader && <Nav />}
+      <Nav hideNavbar={hideHeader} />
       <main className={cn('relative min-h-screen', className)}>{children}</main>
-      {!hideFooter && <Footer className={footerClassName} />}
+      <Footer className={footerClassName} hideFooter={hideFooter} />
     </>
   )
 }

--- a/apps/www/components/Nav/index.tsx
+++ b/apps/www/components/Nav/index.tsx
@@ -146,7 +146,7 @@ const Nav = (props: Props) => {
                   </NavigationMenuList>
                 </NavigationMenu>
               </div>
-              <div className="flex items-center gap-2">
+              <div className="flex items-center gap-2 opacity-0 animate-fade-in !scale-100 delay-300">
                 <GitHubButton />
                 {!isUserLoading && (
                   <>

--- a/apps/www/components/Nav/index.tsx
+++ b/apps/www/components/Nav/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
@@ -56,23 +56,11 @@ const Nav = (props: Props) => {
     if (width >= 1024) setOpen(false)
   }, [width])
 
-  /**
-   * Temporary fix for next-theme client side bug
-   * https://github.com/pacocoursey/next-themes/issues/169
-   * TODO: remove when bug has been fixed
-   */
-  const [mounted, setMounted] = useState(false)
-
-  useEffect(() => {
-    setMounted(true)
-  }, [])
-
-  if (!mounted || props.hideNavbar) {
+  if (props.hideNavbar) {
     return null
   }
 
-  const showDarkLogo =
-    isLaunchWeekPage || (mounted && resolvedTheme?.includes('dark')!) || isHomePage
+  const showDarkLogo = isLaunchWeekPage || resolvedTheme?.includes('dark')! || isHomePage
 
   return (
     <>

--- a/apps/www/components/Nav/index.tsx
+++ b/apps/www/components/Nav/index.tsx
@@ -25,7 +25,11 @@ import { menu } from '~/data/nav'
 import * as supabaseLogoWordmarkDark from 'common/assets/images/supabase-logo-wordmark--dark.png'
 import * as supabaseLogoWordmarkLight from 'common/assets/images/supabase-logo-wordmark--light.png'
 
-const Nav = () => {
+interface Props {
+  hideNavbar: boolean
+}
+
+const Nav = (props: Props) => {
   const { resolvedTheme } = useTheme()
   const router = useRouter()
   const { width } = useWindowSize()
@@ -63,7 +67,7 @@ const Nav = () => {
     setMounted(true)
   }, [])
 
-  if (!mounted) {
+  if (!mounted || props.hideNavbar) {
     return null
   }
 

--- a/apps/www/components/Nav/index.tsx
+++ b/apps/www/components/Nav/index.tsx
@@ -98,6 +98,7 @@ const Nav = (props: Props) => {
                       width={124}
                       height={24}
                       alt="Supabase Logo"
+                      priority
                     />
                   </Link>
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Reduce layout shift on initial load
- Add fade-in animation to github stars and cta buttons in nav to wait for load
- Remove h1 fade-in animation to reduce ù
- Eager load supabase logo in navbar

## What is the current behavior?

https://github.com/supabase/supabase/assets/25671831/cec4da2e-6d48-4be8-be26-bb60c9e00644

## What is the new behavior?

https://github.com/supabase/supabase/assets/25671831/d992f580-2ab1-4937-bc8a-fd8e5ddce280

## Additional context

Removed the `mount` check that was needed for a previous hydration error.
