### PR TITLE
Add "outdated"-warning to Next.js web app tutorial / with-nextjs.mdx

### DIFF
--- a/apps/docs/content/guides/getting-started/tutorials/with-nextjs.mdx
+++ b/apps/docs/content/guides/getting-started/tutorials/with-nextjs.mdx
@@ -7,6 +7,12 @@ description: 'Learn how to use Supabase in your Next.js App.'
 
 ![Supabase User Management example](/docs/img/user-management-demo.png)
 
+<Admonition type="caution">
+
+The `auth-helpers` package has been replaced with the `@supabase/ssr` package. We recommend setting up Auth for your Next.js app with `@supabase/ssr` instead. See the [Next.js Server-Side Auth guide](/docs/guides/auth/server-side/nextjs) to learn how.
+
+</Admonition>
+
 <Admonition type="note">
 
 If you get stuck while working through this guide, refer to the [full example on GitHub](https://github.com/supabase/supabase/tree/master/examples/user-management/nextjs-user-management).


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update 

## What is the current behavior?

https://supabase.com/docs/guides/getting-started/tutorials/with-nextjs

The tutorial mainly revolves about setting up auth.
Unfortunately, it is still using @supabase/auth-helpers-nextjs even though the new package @supabase/ssr is now supposed to be used as mentioned in the auth docs: ["Migrating to the SSR package from Auth Helpers"](https://supabase.com/docs/guides/auth/server-side/migrating-to-ssr-from-auth-helpers).

It is a bit taxing to go through this tutorial to then later find out that the approach there is outdated and that now migrating to another approach is necessary.
Describe the improvement

Either adapt the tutorial to reflect current best practices or remove it or don't show it that prominently as a Next.js starting point to protect user's on-boarding experience.

## What is the new behavior?

Include the same warning as used for other parts of the auth documentation:

![image](https://github.com/supabase/supabase/assets/45669613/e56789f2-6f8f-4302-9919-a1dab190a78d)


Partly addresses #21207