### PR TITLE
feat: dark mode theme toggle placement

### DIFF
--- a/apps/www/components/Footer/index.tsx
+++ b/apps/www/components/Footer/index.tsx
@@ -9,7 +9,6 @@ import SectionContainer from '../Layouts/SectionContainer'
 import footerData from 'data/Footer'
 import * as supabaseLogoWordmarkDark from 'common/assets/images/supabase-logo-wordmark--dark.png'
 import * as supabaseLogoWordmarkLight from 'common/assets/images/supabase-logo-wordmark--light.png'
-import { ThemeToggle } from 'ui-patterns/ThemeToggle'
 
 interface Props {
   className?: string
@@ -157,9 +156,6 @@ const Footer = (props: Props) => {
         </div>
         <div className="border-default mt-32 flex justify-between border-t pt-8">
           <small className="small">&copy; Supabase Inc</small>
-          <div className={cn(forceDark && 'hidden')}>
-            <ThemeToggle forceDark={forceDark} />
-          </div>
         </div>
       </SectionContainer>
     </footer>

--- a/apps/www/components/Nav/index.tsx
+++ b/apps/www/components/Nav/index.tsx
@@ -153,9 +153,14 @@ const Nav = (props: Props) => {
                 {!isUserLoading && (
                   <>
                     {isLoggedIn ? (
-                      <Button className="hidden text-white lg:block" asChild>
-                        <Link href="/dashboard/projects">Dashboard</Link>
-                      </Button>
+                      <>
+                        <Button className="hidden text-white lg:block" asChild>
+                          <Link href="/dashboard/projects">Dashboard</Link>
+                        </Button>
+                        <div className={cn(forceDark && 'hidden')}>
+                          <ThemeToggle forceDark={forceDark} />
+                        </div>
+                      </>
                     ) : (
                       <>
                         <Button type="default" className="hidden lg:block" asChild>
@@ -168,9 +173,6 @@ const Nav = (props: Props) => {
                     )}
                   </>
                 )}
-                <div className={cn(forceDark && 'hidden')}>
-                  <ThemeToggle forceDark={forceDark} />
-                </div>
               </div>
             </div>
             <HamburgerButton

--- a/apps/www/components/Nav/index.tsx
+++ b/apps/www/components/Nav/index.tsx
@@ -24,6 +24,7 @@ import { menu } from '~/data/nav'
 
 import * as supabaseLogoWordmarkDark from 'common/assets/images/supabase-logo-wordmark--dark.png'
 import * as supabaseLogoWordmarkLight from 'common/assets/images/supabase-logo-wordmark--light.png'
+import { ThemeToggle } from 'ui-patterns'
 
 interface Props {
   hideNavbar: boolean
@@ -41,6 +42,7 @@ const Nav = (props: Props) => {
   const isLaunchWeekPage = router.pathname.includes('launch-week')
   const isLaunchWeekXPage = router.pathname === '/launch-week'
   const showLaunchWeekNavMode = isLaunchWeekPage && !open
+  const forceDark = isLaunchWeekPage || isHomePage
 
   React.useEffect(() => {
     if (open) {
@@ -166,6 +168,9 @@ const Nav = (props: Props) => {
                     )}
                   </>
                 )}
+                <div className={cn(forceDark && 'hidden')}>
+                  <ThemeToggle forceDark={forceDark} />
+                </div>
               </div>
             </div>
             <HamburgerButton


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase website feature - Dark Mode toggle

## What is the current behavior?

The toggle is currently on the footer 

## What is the new behavior?

The toggle is now on the header:

<img width="1426" alt="Screenshot 2024-02-25 at 18 25 35" src="https://github.com/supabase/supabase/assets/22655069/32ba35f0-45f8-4dbc-8f07-fa14120efb65">


## Additional context

Closes #21524
