### PR TITLE
Chore/read replica fixes 260224

### DIFF
--- a/apps/studio/components/interfaces/Database/Backups/PITR/PITRStatus.tsx
+++ b/apps/studio/components/interfaces/Database/Backups/PITR/PITRStatus.tsx
@@ -61,6 +61,7 @@ const PITRStatus = ({
             </div>
             <Tooltip.Root delayDuration={0}>
               <Tooltip.Trigger asChild>
+                {/* [Joshen TODO] Double check if this is intentional */}
                 <Button
                   disabled={hasReadReplicas || !canTriggerPhysicalBackup}
                   onClick={() => onSetConfiguration()}
@@ -68,23 +69,28 @@ const PITRStatus = ({
                   Start a restore
                 </Button>
               </Tooltip.Trigger>
-              {!canTriggerPhysicalBackup && (
-                <Tooltip.Portal>
-                  <Tooltip.Content side="left">
-                    <Tooltip.Arrow className="radix-tooltip-arrow" />
-                    <div
-                      className={[
-                        'rounded bg-alternative py-1 px-2 leading-none shadow',
-                        'border border-background',
-                      ].join(' ')}
-                    >
-                      <span className="text-xs text-foreground">
-                        You need additional permissions to trigger a PITR recovery
-                      </span>
-                    </div>
-                  </Tooltip.Content>
-                </Tooltip.Portal>
-              )}
+              {hasReadReplicas ||
+                (!canTriggerPhysicalBackup && (
+                  <Tooltip.Portal>
+                    <Tooltip.Content side="left">
+                      <Tooltip.Arrow className="radix-tooltip-arrow" />
+                      <div
+                        className={[
+                          'rounded bg-alternative py-1 px-2 leading-none shadow',
+                          'border border-background',
+                        ].join(' ')}
+                      >
+                        <span className="text-xs text-foreground">
+                          {hasReadReplicas
+                            ? 'You will need to remove all read replicas first to trigger a PITR recovery'
+                            : !canTriggerPhysicalBackup
+                              ? 'You need additional permissions to trigger a PITR recovery'
+                              : null}
+                        </span>
+                      </div>
+                    </Tooltip.Content>
+                  </Tooltip.Portal>
+                ))}
             </Tooltip.Root>
           </div>
         }

--- a/apps/studio/components/interfaces/Settings/Addons/ComputeInstanceSidePanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/ComputeInstanceSidePanel.tsx
@@ -35,6 +35,8 @@ import {
 import * as Tooltip from '@radix-ui/react-tooltip'
 import { useOrgSubscriptionQuery } from 'data/subscriptions/org-subscription-query'
 import { AddonVariantId, ProjectAddonVariantMeta } from 'data/subscriptions/types'
+import { useReadReplicasQuery } from 'data/read-replicas/replicas-query'
+import { WarningIcon } from 'components/ui/Icons'
 
 const ComputeInstanceSidePanel = () => {
   const queryClient = useQueryClient()
@@ -61,6 +63,7 @@ const ComputeInstanceSidePanel = () => {
     snap.setPanelKey(undefined)
   }
 
+  const { data: databases } = useReadReplicasQuery({ projectRef })
   const { data: addons, isLoading } = useProjectAddonsQuery({ projectRef })
   const { data: subscription } = useOrgSubscriptionQuery({ orgSlug: organization?.slug })
   const { mutate: updateAddon, isLoading: isUpdating } = useProjectAddonUpdateMutation({
@@ -105,7 +108,6 @@ const ComputeInstanceSidePanel = () => {
   const [selectedOption, setSelectedOption] = useState<string>('')
 
   const isSubmitting = isUpdating || isRemoving
-
   const projectId = selectedProject?.id
   const cpuArchitecture = getCloudProviderArchitecture(selectedProject?.cloud_provider)
   const selectedAddons = addons?.selected_addons ?? []
@@ -162,9 +164,12 @@ const ComputeInstanceSidePanel = () => {
   const selectedCompute = availableOptions.find((option) => option.identifier === selectedOption)
   const hasChanges =
     selectedOption !== (subscriptionCompute?.variant.identifier ?? defaultInstanceSize)
+  const hasReadReplicas = (databases ?? []).length > 1
 
   const blockDowngradeDueToPitr =
     pitrAddon !== undefined && ['ci_micro', 'ci_nano'].includes(selectedOption) && hasChanges
+  const blockDowngradeDueToReadReplicas =
+    hasChanges && hasReadReplicas && ['ci_micro', 'ci_nano'].includes(selectedOption)
 
   useEffect(() => {
     if (visible) {
@@ -217,7 +222,12 @@ const ComputeInstanceSidePanel = () => {
         onConfirm={() => setShowConfirmationModal(true)}
         loading={isLoading}
         disabled={
-          isFreePlan || isLoading || !hasChanges || blockDowngradeDueToPitr || !canUpdateCompute
+          isFreePlan ||
+          isLoading ||
+          !hasChanges ||
+          blockDowngradeDueToPitr ||
+          blockDowngradeDueToReadReplicas ||
+          !canUpdateCompute
         }
         tooltip={
           isFreePlan
@@ -382,38 +392,54 @@ const ComputeInstanceSidePanel = () => {
               </p>
             )}
 
-            {hasChanges && !blockDowngradeDueToPitr && (
-              <Alert
-                withIcon
-                variant="info"
-                title="Your project will need to be restarted when changing it's compute size"
-              >
-                Your project will be unavailable for up to 2 minutes while the changes take place.
-              </Alert>
+            {hasChanges && !blockDowngradeDueToPitr && !blockDowngradeDueToReadReplicas && (
+              <Alert_Shadcn_>
+                <WarningIcon />
+                <AlertTitle_Shadcn_>
+                  Your project will need to be restarted when changing it's compute size
+                </AlertTitle_Shadcn_>
+                <AlertDescription_Shadcn_>
+                  Your project will be unavailable for up to 2 minutes while the changes take place.
+                </AlertDescription_Shadcn_>
+              </Alert_Shadcn_>
             )}
 
-            {blockDowngradeDueToPitr && (
-              <Alert
-                withIcon
-                variant="info"
-                className="mb-4"
-                title="Disable PITR before downgrading"
-                actions={
+            {blockDowngradeDueToReadReplicas ? (
+              <Alert_Shadcn_>
+                <WarningIcon />
+                <AlertTitle_Shadcn_>Remove all read replicas before downgrading</AlertTitle_Shadcn_>
+                <AlertDescription_Shadcn_>
+                  You currently have active read replicas. The minimum compute instance size for
+                  using read replicas is the Small Compute. You need to remove all read replicas
+                  before downgrading Compute as it requires at least a Small compute instance.
+                </AlertDescription_Shadcn_>
+                <AlertDescription_Shadcn_ className="mt-2">
+                  <Button asChild type="default">
+                    <Link href={`/project/${projectRef}/settings/infrastructure`}>
+                      Manage read replicas
+                    </Link>
+                  </Button>
+                </AlertDescription_Shadcn_>
+              </Alert_Shadcn_>
+            ) : blockDowngradeDueToPitr ? (
+              <Alert_Shadcn_>
+                <WarningIcon />
+                <AlertTitle_Shadcn_>Disable PITR before downgrading</AlertTitle_Shadcn_>
+                <AlertDescription_Shadcn_>
+                  You currently have PITR enabled. The minimum compute instance size for using PITR
+                  is the Small Compute.
+                </AlertDescription_Shadcn_>
+                <AlertDescription_Shadcn_>
+                  You need to disable PITR before downgrading Compute as it requires at least a
+                  Small compute instance.
+                </AlertDescription_Shadcn_>
+                <AlertDescription_Shadcn_ className="mt-2">
                   <Button type="default" onClick={() => snap.setPanelKey('pitr')}>
                     Change PITR
                   </Button>
-                }
-              >
-                <p>
-                  You currently have PITR enabled. The minimum compute instance size for using PITR
-                  is the Small Compute.
-                </p>
-                <p>
-                  You need to disable PITR before downgrading Compute as it requires at least a
-                  Small compute instance.
-                </p>
-              </Alert>
-            )}
+                </AlertDescription_Shadcn_>
+              </Alert_Shadcn_>
+            ) : null}
 
             {hasChanges &&
               subscription?.billing_via_partner &&

--- a/apps/studio/components/interfaces/Settings/Addons/ComputeInstanceSidePanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/ComputeInstanceSidePanel.tsx
@@ -414,15 +414,20 @@ const ComputeInstanceSidePanel = () => {
             {blockDowngradeDueToReadReplicas ? (
               <Alert_Shadcn_>
                 <WarningIcon />
-                <AlertTitle_Shadcn_>Remove all read replicas before downgrading</AlertTitle_Shadcn_>
+                <AlertTitle_Shadcn_>
+                  Unable to downgrade as project has active read replicas
+                </AlertTitle_Shadcn_>
                 <AlertDescription_Shadcn_>
-                  You currently have active read replicas. The minimum compute instance size for
-                  using read replicas is the Small Compute. You need to remove all read replicas
-                  before downgrading Compute as it requires at least a Small compute instance.
+                  The minimum compute instance size for using read replicas is the Small Compute.
+                  You need to remove all read replicas before downgrading Compute as it requires at
+                  least a Small compute instance.
                 </AlertDescription_Shadcn_>
                 <AlertDescription_Shadcn_ className="mt-2">
                   <Button asChild type="default">
-                    <Link href={`/project/${projectRef}/settings/infrastructure`}>
+                    <Link
+                      href={`/project/${projectRef}/settings/infrastructure`}
+                      onClick={() => snap.setPanelKey(undefined)}
+                    >
                       Manage read replicas
                     </Link>
                   </Button>

--- a/apps/studio/components/interfaces/Settings/Addons/ComputeInstanceSidePanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/ComputeInstanceSidePanel.tsx
@@ -401,6 +401,13 @@ const ComputeInstanceSidePanel = () => {
                 <AlertDescription_Shadcn_>
                   Your project will be unavailable for up to 2 minutes while the changes take place.
                 </AlertDescription_Shadcn_>
+                {hasReadReplicas && (
+                  <AlertDescription_Shadcn_>
+                    The compute sizes for <span className="text-foreground">all read replicas</span>{' '}
+                    on your project will also be changed to the {selectedCompute?.name} size as
+                    well.
+                  </AlertDescription_Shadcn_>
+                )}
               </Alert_Shadcn_>
             )}
 

--- a/apps/studio/components/interfaces/Settings/Addons/PITRSidePanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/PITRSidePanel.tsx
@@ -5,14 +5,20 @@ import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
 
 import { useParams } from 'common'
-import { useTheme } from 'next-themes'
 import { useProjectAddonRemoveMutation } from 'data/subscriptions/project-addon-remove-mutation'
 import { useProjectAddonUpdateMutation } from 'data/subscriptions/project-addon-update-mutation'
 import { useProjectAddonsQuery } from 'data/subscriptions/project-addons-query'
 import { useCheckPermissions, useSelectedOrganization, useSelectedProject, useStore } from 'hooks'
 import { BASE_PATH } from 'lib/constants'
 import Telemetry from 'lib/telemetry'
+import { useTheme } from 'next-themes'
 
+import { subscriptionHasHipaaAddon } from 'components/interfaces/Billing/Subscription/Subscription.utils'
+import { CriticalIcon, WarningIcon } from 'components/ui/Icons'
+import { useReadReplicasQuery } from 'data/read-replicas/replicas-query'
+import { useOrgSubscriptionQuery } from 'data/subscriptions/org-subscription-query'
+import { AddonVariantId } from 'data/subscriptions/types'
+import { formatCurrency } from 'lib/helpers'
 import { useSubscriptionPageStateSnapshot } from 'state/subscription-page'
 import {
   Alert,
@@ -20,16 +26,11 @@ import {
   AlertTitle_Shadcn_,
   Alert_Shadcn_,
   Button,
+  IconAlertTriangle,
   IconExternalLink,
   Radio,
   SidePanel,
-  IconAlertTriangle,
 } from 'ui'
-import { useOrgSubscriptionQuery } from 'data/subscriptions/org-subscription-query'
-import { AlertTriangleIcon } from 'lucide-react'
-import { AddonVariantId } from 'data/subscriptions/types'
-import { subscriptionHasHipaaAddon } from 'components/interfaces/Billing/Subscription/Subscription.utils'
-import { formatCurrency } from 'lib/helpers'
 
 const PITR_CATEGORY_OPTIONS: {
   id: 'off' | 'on'
@@ -76,6 +77,7 @@ const PITRSidePanel = () => {
     snap.setPanelKey(undefined)
   }
 
+  const { data: databases } = useReadReplicasQuery({ projectRef })
   const { data: addons, isLoading } = useProjectAddonsQuery({ projectRef })
   const { data: subscription } = useOrgSubscriptionQuery({ orgSlug: organization?.slug })
   const hasHipaaAddon = subscriptionHasHipaaAddon(subscription)
@@ -121,9 +123,12 @@ const PITRSidePanel = () => {
   const subscriptionPitr = selectedAddons.find((addon) => addon.type === 'pitr')
   const availableOptions = availableAddons.find((addon) => addon.type === 'pitr')?.variants ?? []
 
+  const hasReadReplicas = (databases ?? []).length > 1
   const hasChanges = selectedOption !== (subscriptionPitr?.variant.identifier ?? 'pitr_0')
   const selectedPitr = availableOptions.find((option) => option.identifier === selectedOption)
   const isFreePlan = subscription?.plan?.id === 'free'
+  const blockDowngradeDueToReadReplicas =
+    hasChanges && hasReadReplicas && selectedCategory === 'off' && selectedOption === 'pitr_0'
 
   useEffect(() => {
     if (visible) {
@@ -167,7 +172,13 @@ const PITRSidePanel = () => {
       onConfirm={onConfirm}
       loading={isLoading || isSubmitting}
       disabled={
-        isFreePlan || isLoading || !hasChanges || isSubmitting || !canUpdatePitr || hasHipaaAddon
+        isFreePlan ||
+        isLoading ||
+        !hasChanges ||
+        isSubmitting ||
+        !canUpdatePitr ||
+        hasHipaaAddon ||
+        blockDowngradeDueToReadReplicas
       }
       tooltip={
         hasHipaaAddon
@@ -225,7 +236,13 @@ const PITRSidePanel = () => {
                     className={clsx('col-span-3 group space-y-1', isFreePlan && 'opacity-75')}
                     onClick={() => {
                       setSelectedCategory(option.id)
-                      if (option.id === 'off') setSelectedOption('pitr_0')
+                      if (option.id === 'off') {
+                        setSelectedOption('pitr_0')
+                      } else if (subscriptionPitr?.variant.identifier !== undefined) {
+                        setSelectedOption(subscriptionPitr.variant.identifier)
+                      } else {
+                        setSelectedOption('pitr_7')
+                      }
                       Telemetry.sendActivity(
                         {
                           activity: 'Option Selected',
@@ -270,13 +287,32 @@ const PITRSidePanel = () => {
 
           {selectedCategory === 'off' && subscriptionPitr !== undefined && isBranchingEnabled && (
             <Alert_Shadcn_ variant="warning">
-              <AlertTriangleIcon strokeWidth={2} />
+              <CriticalIcon />
               <AlertTitle_Shadcn_>
                 Are you sure you want to disable this while using Branching?
               </AlertTitle_Shadcn_>
               <AlertDescription_Shadcn_>
                 Without PITR, you might not be able to recover lost data if you accidentally merge a
                 branch that deletes a column or user data. We don't recommend this.
+              </AlertDescription_Shadcn_>
+            </Alert_Shadcn_>
+          )}
+
+          {blockDowngradeDueToReadReplicas && (
+            <Alert_Shadcn_>
+              <WarningIcon />
+              <AlertTitle_Shadcn_>Remove all read replicas before downgrading</AlertTitle_Shadcn_>
+              <AlertDescription_Shadcn_>
+                You currently have active read replicas. The minimum compute instance size for using
+                read replicas is the Small Compute. You need to remove all read replicas before
+                downgrading Compute as it requires at least a Small compute instance.
+              </AlertDescription_Shadcn_>
+              <AlertDescription_Shadcn_ className="mt-2">
+                <Button asChild type="default">
+                  <Link href={`/project/${projectRef}/settings/infrastructure`}>
+                    Manage read replicas
+                  </Link>
+                </Button>
               </AlertDescription_Shadcn_>
             </Alert_Shadcn_>
           )}
@@ -358,7 +394,7 @@ const PITRSidePanel = () => {
             </div>
           )}
 
-          {hasChanges && (
+          {hasChanges && !blockDowngradeDueToReadReplicas && (
             <>
               {selectedOption === 'pitr_0' ||
               (selectedPitr?.price ?? 0) < (subscriptionPitr?.variant.price ?? 0) ? (

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/DeployNewReplicaPanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/DeployNewReplicaPanel.tsx
@@ -6,7 +6,6 @@ import {
   AlertTitle_Shadcn_,
   Alert_Shadcn_,
   Button,
-  IconAlertCircle,
   Listbox,
   SidePanel,
 } from 'ui'
@@ -81,6 +80,11 @@ const DeployNewReplicaPanel = ({
   const [selectedRegion, setSelectedRegion] = useState<string>(defaultRegion)
   const [selectedCompute, setSelectedCompute] = useState(defaultCompute)
   const selectedComputeMeta = computeAddons.find((addon) => addon.identifier === selectedCompute)
+
+  const availableRegions =
+    process.env.NEXT_PUBLIC_ENVIRONMENT === 'staging'
+      ? AVAILABLE_REPLICA_REGIONS.filter((x) => x.key === 'SOUTHEAST_ASIA')
+      : AVAILABLE_REPLICA_REGIONS
 
   const onSubmit = async () => {
     const regionKey = AWS_REGIONS_VALUES[selectedRegion]
@@ -171,7 +175,7 @@ const DeployNewReplicaPanel = ({
           onChange={setSelectedRegion}
           label="Select a region to deploy your read replica in"
         >
-          {AVAILABLE_REPLICA_REGIONS.map((region) => (
+          {availableRegions.map((region) => (
             <Listbox.Option
               key={region.key}
               label={region.name}

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/DropAllReplicasConfirmationModal.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/DropAllReplicasConfirmationModal.tsx
@@ -1,0 +1,91 @@
+import { useParams } from 'common'
+import toast from 'react-hot-toast'
+import {
+  AlertDescription_Shadcn_,
+  AlertTitle_Shadcn_,
+  Alert_Shadcn_,
+  IconAlertTriangle,
+  Modal,
+} from 'ui'
+
+import ConfirmationModal from 'components/ui/ConfirmationModal'
+import { useReadReplicaRemoveMutation } from 'data/read-replicas/replica-remove-mutation'
+import { Database, useReadReplicasQuery } from 'data/read-replicas/replicas-query'
+import { useQueryClient } from '@tanstack/react-query'
+import { replicaKeys } from 'data/read-replicas/keys'
+
+interface DropAllReplicasConfirmationModalProps {
+  visible: boolean
+  onSuccess: () => void
+  onCancel: () => void
+}
+
+const DropAllReplicasConfirmationModal = ({
+  visible,
+  onSuccess,
+  onCancel,
+}: DropAllReplicasConfirmationModalProps) => {
+  const { ref: projectRef } = useParams()
+  const queryClient = useQueryClient()
+  const { data: databases } = useReadReplicasQuery({ projectRef })
+  const { mutateAsync: removeReadReplica, isLoading: isRemoving } = useReadReplicaRemoveMutation()
+
+  const onConfirmRemove = async () => {
+    if (!projectRef) return console.error('Project is required')
+    if (databases === undefined) return console.error('Unable to retrieve replicas')
+    if (databases.length === 1) toast('Your project has no read replicas')
+
+    const replicas = databases.filter((db) => db.identifier !== projectRef)
+    await Promise.all(
+      replicas.map((db) =>
+        removeReadReplica({ projectRef, identifier: db.identifier, skipInvalidateOnSuccess: true })
+      )
+    )
+    toast.success(`Tearing down all read replicas`)
+
+    queryClient.setQueriesData<any>(replicaKeys.list(projectRef), (old: Database[]) => {
+      return old.filter((db: Database) => db.identifier === projectRef)
+    })
+    queryClient.setQueriesData<any>(replicaKeys.loadBalancers(projectRef), (old: Database[]) => [])
+
+    setTimeout(async () => {
+      await queryClient.invalidateQueries(replicaKeys.list(projectRef))
+      await queryClient.invalidateQueries(replicaKeys.loadBalancers(projectRef))
+    }, 5000)
+
+    onSuccess()
+    onCancel()
+  }
+
+  return (
+    <ConfirmationModal
+      danger
+      size="medium"
+      loading={isRemoving}
+      visible={visible}
+      header="Confirm to drop all read replicas?"
+      buttonLabel="Drop all replicas"
+      buttonLoadingLabel="Dropping all replicas"
+      onSelectCancel={() => onCancel()}
+      onSelectConfirm={() => onConfirmRemove()}
+    >
+      <Modal.Content className="py-3">
+        <Alert_Shadcn_ variant="warning">
+          <IconAlertTriangle strokeWidth={2} />
+          <AlertTitle_Shadcn_>This action cannot be undone</AlertTitle_Shadcn_>
+          <AlertDescription_Shadcn_>
+            You may still deploy new replicas in this region thereafter
+          </AlertDescription_Shadcn_>
+        </Alert_Shadcn_>
+        <div className="text-sm px-1 pt-4">
+          <p>Before deleting all replicas, consider:</p>
+          <ul className="text-foreground-light py-1 list-disc mx-4 space-y-1">
+            <li>Network traffic from this region may slow down</li>
+          </ul>
+        </div>
+      </Modal.Content>
+    </ConfirmationModal>
+  )
+}
+
+export default DropAllReplicasConfirmationModal

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/DropReplicaConfirmationModal.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/DropReplicaConfirmationModal.tsx
@@ -26,7 +26,7 @@ const DropReplicaConfirmationModal = ({
 }: DropReplicaConfirmationModalProps) => {
   const { ref: projectRef } = useParams()
   const formattedId = formatDatabaseID(selectedReplica?.identifier ?? '')
-  const { mutateAsync: removeReadReplica } = useReadReplicaRemoveMutation({
+  const { mutateAsync: removeReadReplica, isLoading: isRemoving } = useReadReplicaRemoveMutation({
     onSuccess: () => {
       toast.success(`Tearing down read replica (ID: ${formattedId})`)
       onSuccess()
@@ -45,6 +45,7 @@ const DropReplicaConfirmationModal = ({
     <ConfirmationModal
       danger
       size="medium"
+      loading={isRemoving}
       visible={selectedReplica !== undefined}
       header={`Confirm to drop selected replica? (ID: ${formattedId})`}
       buttonLabel="Drop replica"

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceConfiguration.utils.ts
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceConfiguration.utils.ts
@@ -20,11 +20,9 @@ export const generateNodes = (
   loadBalancers: LoadBalancer[],
   {
     onSelectRestartReplica,
-    onSelectResizeReplica,
     onSelectDropReplica,
   }: {
     onSelectRestartReplica: (database: Database) => void
-    onSelectResizeReplica: (database: Database) => void
     onSelectDropReplica: (database: Database) => void
   }
 ): Node[] => {
@@ -88,7 +86,6 @@ export const generateNodes = (
           computeSize: database.size,
           status: database.status,
           onSelectRestartReplica: () => onSelectRestartReplica(database),
-          onSelectResizeReplica: () => onSelectResizeReplica(database),
           onSelectDropReplica: () => onSelectDropReplica(database),
         },
       }

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceNode.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceNode.tsx
@@ -214,18 +214,21 @@ export const ReplicaNode = ({ data }: NodeProps<ReplicaNodeData>) => {
             <Button type="text" icon={<IconMoreVertical />} className="px-1" />
           </DropdownMenuTrigger>
           <DropdownMenuContent className="w-40" side="bottom" align="end">
-            <DropdownMenuItem className="gap-x-2">
+            <DropdownMenuItem
+              disabled={status !== PROJECT_STATUS.ACTIVE_HEALTHY}
+              className="gap-x-2"
+            >
               <Link href={`/project/${ref}/settings/database?connectionString=${id}`}>
                 View connection string
               </Link>
             </DropdownMenuItem>
+            <DropdownMenuSeparator />
             {/* <DropdownMenuItem className="gap-x-2" onClick={() => onSelectRestartReplica()}>
                 Restart replica
               </DropdownMenuItem> */}
             {/* <DropdownMenuItem className="gap-x-2" onClick={() => onSelectResizeReplica()}>
                 Resize replica
               </DropdownMenuItem> */}
-            <DropdownMenuSeparator />
             <DropdownMenuItem className="gap-x-2" onClick={() => onSelectDropReplica()}>
               Drop replica
             </DropdownMenuItem>

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/MapView.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/MapView.tsx
@@ -22,27 +22,20 @@ import {
   ScrollArea,
 } from 'ui'
 
+import { Database, useReadReplicasQuery } from 'data/read-replicas/replicas-query'
+import { formatDatabaseID } from 'data/read-replicas/replicas.utils'
 import { AWS_REGIONS_KEYS, BASE_PATH, PROJECT_STATUS } from 'lib/constants'
 import { AVAILABLE_REPLICA_REGIONS } from './InstanceConfiguration.constants'
 import GeographyData from './MapData.json'
-import { Database, useReadReplicasQuery } from 'data/read-replicas/replicas-query'
-import { formatDatabaseID } from 'data/read-replicas/replicas.utils'
 
 // [Joshen] Foresee that we'll skip this view for initial launch
 
 interface MapViewProps {
   onSelectDeployNewReplica: (region: AWS_REGIONS_KEYS) => void
-  onSelectRestartReplica: (database: Database) => void
-  onSelectResizeReplica: (database: Database) => void
   onSelectDropReplica: (database: Database) => void
 }
 
-const MapView = ({
-  onSelectDeployNewReplica,
-  onSelectRestartReplica,
-  onSelectResizeReplica,
-  onSelectDropReplica,
-}: MapViewProps) => {
+const MapView = ({ onSelectDeployNewReplica, onSelectDropReplica }: MapViewProps) => {
   const { ref } = useParams()
   const [mount, setMount] = useState(false)
   const [zoom, setZoom] = useState<number>(1.5)
@@ -137,9 +130,8 @@ const MapView = ({
           {AVAILABLE_REPLICA_REGIONS.map((region) => {
             const dbs =
               databases.filter((database) => database.region.includes(region.region)) ?? []
-            const coordinates = AVAILABLE_REPLICA_REGIONS.find(
-              (r) => r.region === region.region
-            )?.coordinates
+            const coordinates = AVAILABLE_REPLICA_REGIONS.find((r) => r.region === region.region)
+              ?.coordinates
 
             const hasNoDatabases = dbs.length === 0
             const hasPrimary = dbs.some((database) => database.identifier === ref)
@@ -290,18 +282,6 @@ const MapView = ({
                                 View connection string
                               </Link>
                             </DropdownMenuItem>
-                            {/* <DropdownMenuItem
-                              className="gap-x-2"
-                              onClick={() => onSelectRestartReplica(database)}
-                            >
-                              Restart replica
-                            </DropdownMenuItem>
-                            <DropdownMenuItem
-                              className="gap-x-2"
-                              onClick={() => onSelectResizeReplica(database)}
-                            >
-                              Resize replica
-                            </DropdownMenuItem> */}
                             <div className="border-t" />
                             <DropdownMenuItem
                               className="gap-x-2"

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/MapView.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/MapView.tsx
@@ -130,8 +130,9 @@ const MapView = ({ onSelectDeployNewReplica, onSelectDropReplica }: MapViewProps
           {AVAILABLE_REPLICA_REGIONS.map((region) => {
             const dbs =
               databases.filter((database) => database.region.includes(region.region)) ?? []
-            const coordinates = AVAILABLE_REPLICA_REGIONS.find((r) => r.region === region.region)
-              ?.coordinates
+            const coordinates = AVAILABLE_REPLICA_REGIONS.find(
+              (r) => r.region === region.region
+            )?.coordinates
 
             const hasNoDatabases = dbs.length === 0
             const hasPrimary = dbs.some((database) => database.identifier === ref)


### PR DESCRIPTION
- Staging: only allow apse1 as selection for replica
- Fix modal stuck in loading state if dropping replica fails
- Add warnings to prevent deploying RR if cloud provider is not AWS, or PG version is not at least 15
- Add warnings on add ons side panels for downgrading compute and pitr if read replicas are present
- Add links to change compute instance from settings/infrastructure
- Add option to remove all replicas in one action from settings/infrastructure