### PR TITLE
chore: nav icons updated

### DIFF
--- a/apps/studio/components/layouts/ProjectLayout/NavigationBar/NavigationBar.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/NavigationBar/NavigationBar.tsx
@@ -39,6 +39,10 @@ import {
   generateToolRoutes,
 } from './NavigationBar.utils'
 import NavigationIconButton from './NavigationIconButton'
+import { Home } from 'icons'
+
+export const ICON_SIZE = 20
+export const ICON_STROKE_WIDTH = 1.5
 
 const NavigationBar = () => {
   const os = detectOS()
@@ -96,7 +100,7 @@ const NavigationBar = () => {
           route={{
             key: 'HOME',
             label: 'Home',
-            icon: <IconHome size={18} strokeWidth={2} />,
+            icon: <Home size={ICON_SIZE} strokeWidth={ICON_STROKE_WIDTH} />,
             link: `/project/${projectRef}`,
           }}
         />

--- a/apps/studio/components/layouts/ProjectLayout/NavigationBar/NavigationBar.utils.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/NavigationBar/NavigationBar.utils.tsx
@@ -1,10 +1,20 @@
-import SVG from 'react-inlinesvg'
-import { products } from 'shared-data'
-import { IconBarChart, IconFileText, IconList, IconSettings } from 'ui'
-
 import { Route } from 'components/ui/ui.types'
 import { Project } from 'data/projects/project-detail-query'
-import { BASE_PATH, IS_PLATFORM, PROJECT_STATUS } from 'lib/constants'
+import { IS_PLATFORM, PROJECT_STATUS } from 'lib/constants'
+import {
+  ApiDocs,
+  Auth,
+  Database,
+  EdgeFunctions,
+  Logs,
+  Realtime,
+  Reports,
+  Settings,
+  SqlEditor,
+  Storage,
+  TableEditor,
+} from 'icons'
+import { ICON_SIZE, ICON_STROKE_WIDTH } from './NavigationBar'
 
 export const generateToolRoutes = (ref?: string, project?: Project): Route[] => {
   const isProjectBuilding = project?.status === PROJECT_STATUS.COMING_UP
@@ -14,25 +24,13 @@ export const generateToolRoutes = (ref?: string, project?: Project): Route[] => 
     {
       key: 'editor',
       label: 'Table Editor',
-      icon: (
-        <SVG
-          src={`${BASE_PATH}/img/table-editor.svg`}
-          style={{ width: `${18}px`, height: `${18}px` }}
-          preProcessor={(code) => code.replace(/svg/, 'svg class="m-auto text-color-inherit"')}
-        />
-      ),
+      icon: <TableEditor size={ICON_SIZE} strokeWidth={ICON_STROKE_WIDTH} />,
       link: ref && (isProjectBuilding ? buildingUrl : `/project/${ref}/editor`),
     },
     {
       key: 'sql',
       label: 'SQL Editor',
-      icon: (
-        <SVG
-          src={`${BASE_PATH}/img/sql-editor.svg`}
-          style={{ width: `${18}px`, height: `${18}px`, strokeWidth: `4` }}
-          preProcessor={(code) => code.replace(/svg/, 'svg class="m-auto text-color-inherit"')}
-        />
-      ),
+      icon: <SqlEditor size={ICON_SIZE} strokeWidth={ICON_STROKE_WIDTH} />,
       link: !IS_PLATFORM
         ? `/project/${ref}/sql/1`
         : ref && (isProjectBuilding ? buildingUrl : `/project/${ref}/sql/new`),
@@ -56,24 +54,7 @@ export const generateProductRoutes = (
     {
       key: 'database',
       label: 'Database',
-      icon: (
-        <svg
-          width="18"
-          height="18"
-          viewBox="0 0 18 18"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d={products.database.icon[18]}
-            stroke="currentColor"
-            strokeWidth="1.5"
-            strokeMiterlimit="10"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          />
-        </svg>
-      ),
+      icon: <Database size={ICON_SIZE} strokeWidth={ICON_STROKE_WIDTH} />,
       link: ref && (isProjectBuilding ? buildingUrl : `/project/${ref}/database/tables`),
     },
     ...(authEnabled
@@ -81,24 +62,7 @@ export const generateProductRoutes = (
           {
             key: 'auth',
             label: 'Authentication',
-            icon: (
-              <svg
-                width="24"
-                height="24"
-                viewBox="0 0 24 24"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d={products.authentication.icon[24]}
-                  stroke="currentColor"
-                  strokeWidth="1.5"
-                  strokeMiterlimit="10"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
-            ),
+            icon: <Auth size={ICON_SIZE} strokeWidth={ICON_STROKE_WIDTH} />,
             link: ref && (isProjectBuilding ? buildingUrl : `/project/${ref}/auth/users`),
           },
         ]
@@ -108,24 +72,7 @@ export const generateProductRoutes = (
           {
             key: 'storage',
             label: 'Storage',
-            icon: (
-              <svg
-                width="18"
-                height="18"
-                viewBox="0 0 18 18"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d={products.storage.icon[18]}
-                  stroke="currentColor"
-                  strokeWidth="1.5"
-                  strokeMiterlimit="10"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
-            ),
+            icon: <Storage size={ICON_SIZE} strokeWidth={ICON_STROKE_WIDTH} />,
             link: ref && (isProjectBuilding ? buildingUrl : `/project/${ref}/storage/buckets`),
           },
         ]
@@ -135,24 +82,7 @@ export const generateProductRoutes = (
           {
             key: 'functions',
             label: 'Edge Functions',
-            icon: (
-              <svg
-                width="18"
-                height="18"
-                viewBox="0 0 18 18"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d={products.functions.icon[18]}
-                  stroke="currentColor"
-                  strokeWidth="1.5"
-                  strokeMiterlimit="10"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
-            ),
+            icon: <EdgeFunctions size={ICON_SIZE} strokeWidth={ICON_STROKE_WIDTH} />,
             link: ref && (isProjectBuilding ? buildingUrl : `/project/${ref}/functions`),
           },
         ]
@@ -162,24 +92,7 @@ export const generateProductRoutes = (
           {
             key: 'realtime',
             label: 'Realtime',
-            icon: (
-              <svg
-                width="18"
-                height="18"
-                viewBox="0 0 18 18"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d={products.realtime.icon[18]}
-                  stroke="currentColor"
-                  strokeWidth="1.5"
-                  strokeMiterlimit="10"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
-            ),
+            icon: <Realtime size={ICON_SIZE} strokeWidth={ICON_STROKE_WIDTH} />,
             link: ref && (isProjectBuilding ? buildingUrl : `/project/${ref}/realtime/inspector`),
           },
         ]
@@ -197,7 +110,7 @@ export const generateOtherRoutes = (ref?: string, project?: Project): Route[] =>
           {
             key: 'reports',
             label: 'Reports',
-            icon: <IconBarChart size={18} strokeWidth={2.5} />,
+            icon: <Reports size={ICON_SIZE} strokeWidth={ICON_STROKE_WIDTH} />,
             link: ref && (isProjectBuilding ? buildingUrl : `/project/${ref}/reports`),
           },
         ]
@@ -205,13 +118,13 @@ export const generateOtherRoutes = (ref?: string, project?: Project): Route[] =>
     {
       key: 'logs',
       label: 'Logs',
-      icon: <IconList size={18} strokeWidth={2.5} />,
+      icon: <Logs size={ICON_SIZE} strokeWidth={ICON_STROKE_WIDTH} />,
       link: ref && (isProjectBuilding ? buildingUrl : `/project/${ref}/logs/explorer`),
     },
     {
       key: 'api',
       label: 'API Docs',
-      icon: <IconFileText size={18} strokeWidth={2} />,
+      icon: <ApiDocs size={ICON_SIZE} strokeWidth={ICON_STROKE_WIDTH} />,
       link: ref && (isProjectBuilding ? buildingUrl : `/project/${ref}/api`),
     },
     ...(IS_PLATFORM
@@ -219,7 +132,7 @@ export const generateOtherRoutes = (ref?: string, project?: Project): Route[] =>
           {
             key: 'settings',
             label: 'Project Settings',
-            icon: <IconSettings size={18} strokeWidth={2.5} />,
+            icon: <Settings size={ICON_SIZE} strokeWidth={ICON_STROKE_WIDTH} />,
             link: ref && `/project/${ref}/settings/general`,
           },
         ]


### PR DESCRIPTION
out with the old, in with the new

consistent line stroke widths and sizes

old:
<img width="220" alt="Screenshot 2024-02-26 at 5 19 09 PM" src="https://github.com/supabase/supabase/assets/8291514/295386ac-9dc2-45db-a9c8-8232c5a5bdfd">

new:
<img width="220" alt="Screenshot 2024-02-26 at 5 19 19 PM" src="https://github.com/supabase/supabase/assets/8291514/a4764a28-e152-407b-a432-5dd0ebba63f4">
