### PR TITLE
fix: Install python and git when building the Docker image

### DIFF
--- a/apps/studio/Dockerfile
+++ b/apps/studio/Dockerfile
@@ -13,9 +13,13 @@ FROM node:18-slim as base
 # Fixes issues with Sentry CLI and SSL certificates during build
 # TODO: Git is added because it's needed to build libpg, remove it once they publish a binary on the S3 bucket
 RUN apt-get update -qq && \
-    apt-get install -y git ca-certificates && \
-    rm -rf /var/lib/apt/lists/* && \
-    update-ca-certificates
+  apt-get install -y --no-install-recommends \
+  git \
+  python3 \ 
+  ca-certificates \
+  build-essential && \ 
+  rm -rf /var/lib/apt/lists/* && \
+  update-ca-certificates
 
 WORKDIR /app
 
@@ -29,14 +33,7 @@ RUN npx turbo@1.12.3 prune --scope=studio --docker
 FROM base as deps
 COPY --from=turbo /app/out/json ./
 COPY --from=turbo /app/out/package-lock.json ./
-# Install additional dependencies for arm64 build (required by bufferutil)
-ARG TARGETARCH
 
-RUN if [ "$TARGETARCH" = "arm64" ]; then \
-    apt-get update && apt-get install -y --no-install-recommends \
-    python3 \
-    build-essential \
-    && rm -rf /var/lib/apt/lists/*; fi
 # No need to clean cache because production uses standalone build
 RUN npm clean-install
 


### PR DESCRIPTION
Install python, git and build essentials for both architectures when building the Docker image.