### PR TITLE
Removed extra <changefreq> in sitemap xml

### DIFF
--- a/apps/docs/internals/generate-sitemap.mjs
+++ b/apps/docs/internals/generate-sitemap.mjs
@@ -45,7 +45,6 @@ async function generate() {
               <url>
                   <loc>${`https://supabase.com/docs/${path}`}</loc>
                   <changefreq>weekly</changefreq>
-                  <changefreq>0.5</changefreq>
               </url>
             `
           })


### PR DESCRIPTION
There should only be one <changefreq> within the sitemap XML as per the [protocol](https://www.sitemaps.org/protocol.html).

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

https://supabase.com/docs/sitemap.xml <-- sitemap has two <changefreq> tags in each <url>

## What is the new behavior?

Removes incorrect <changefreq> tag