### PR TITLE
fix: restrict access to the tokens page in self-hosted environments

### DIFF
--- a/apps/studio/pages/account/tokens.tsx
+++ b/apps/studio/pages/account/tokens.tsx
@@ -1,13 +1,13 @@
-import {
-  AccessTokenList,
-  NewAccessTokenButton,
-  NewTokenBanner,
-} from 'components/interfaces/Account'
-import { AccountLayout } from 'components/layouts'
-import { FormHeader } from 'components/ui/Forms'
-import { NewAccessToken } from 'data/access-tokens/access-tokens-create-mutation'
 import { useState } from 'react'
 import type { NextPageWithLayout } from 'types'
+import { FormHeader } from 'components/ui/Forms'
+import { AccountLayout } from 'components/layouts'
+import {
+  AccessTokenList,
+  NewTokenBanner,
+  NewAccessTokenButton,
+} from 'components/interfaces/Account'
+import { NewAccessToken } from 'data/access-tokens/access-tokens-create-mutation'
 
 import { IS_PLATFORM } from 'lib/constants'
 import Link from 'next/link'

--- a/apps/studio/pages/account/tokens.tsx
+++ b/apps/studio/pages/account/tokens.tsx
@@ -1,19 +1,35 @@
-import { useState } from 'react'
-import type { NextPageWithLayout } from 'types'
-import { FormHeader } from 'components/ui/Forms'
-import { AccountLayout } from 'components/layouts'
 import {
   AccessTokenList,
-  NewTokenBanner,
   NewAccessTokenButton,
+  NewTokenBanner,
 } from 'components/interfaces/Account'
+import { AccountLayout } from 'components/layouts'
+import { FormHeader } from 'components/ui/Forms'
 import { NewAccessToken } from 'data/access-tokens/access-tokens-create-mutation'
+import { useState } from 'react'
+import type { NextPageWithLayout } from 'types'
 
+import { IS_PLATFORM } from 'lib/constants'
 import Link from 'next/link'
 import { Alert, Button, IconExternalLink } from 'ui'
 
 const UserAccessTokens: NextPageWithLayout = () => {
   const [newToken, setNewToken] = useState<NewAccessToken | undefined>()
+
+  if (!IS_PLATFORM) {
+    return (
+      <div className="1xl:px-28 mx-auto flex flex-col px-5 pt-6 pb-14 lg:px-16 xl:px-24 2xl:px-32">
+        <div className="flex items-center justify-between">
+          <Alert
+            withIcon
+            className="mb-6 w-full"
+            variant="danger"
+            title="This function is not available for self-hosted environments. It is exclusively available for cloud services!"
+          />
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div className="1xl:px-28 mx-auto flex flex-col px-5 pt-6 pb-14 lg:px-16 xl:px-24 2xl:px-32">


### PR DESCRIPTION
## What kind of change does this PR introduce?

fixes: https://github.com/supabase/supabase/issues/13508

## What is the current behavior?
Access tokens cannot be created at `/account/tokens` in self-hosted environments

Please link any relevant issues here.

## What is the new behavior?
We restrict access to `tokens`; they are only available for cloud services.

Feel free to include screenshots if it includes visual changes.

## Additional context

<img width="1119" alt="image" src="https://github.com/supabase/supabase/assets/21276822/8c1b3f92-426e-4a9f-92cc-0f4f7d072a49">

