### PR TITLE
chore: temporarily remove fail-on-error for vale

### DIFF
--- a/.github/workflows/lint-prose.yml
+++ b/.github/workflows/lint-prose.yml
@@ -20,4 +20,6 @@ jobs:
       - uses: errata-ai/vale-action@reviewdog
         with:
           files: apps/docs/content
-          fail_on_error: true
+          # [Charis] Temporary because we still have to go through giant backlog of existing errors
+          # Don't want people to worry about this (just want them looking at the specific PR comments)
+          # fail_on_error: true

--- a/apps/docs/content/guides/ai.mdx
+++ b/apps/docs/content/guides/ai.mdx
@@ -6,8 +6,6 @@ subtitle: 'The best vector database is the database you already have.'
 hideToc: true
 ---
 
-TEST
-
 Supabase provides an open source toolkit for developing AI applications using Postgres and pgvector. Use the Supabase client libraries to store, index, and query your vector embeddings at scale.
 
 The toolkit includes:

--- a/apps/docs/content/guides/ai.mdx
+++ b/apps/docs/content/guides/ai.mdx
@@ -6,6 +6,8 @@ subtitle: 'The best vector database is the database you already have.'
 hideToc: true
 ---
 
+TEST
+
 Supabase provides an open source toolkit for developing AI applications using Postgres and pgvector. Use the Supabase client libraries to store, index, and query your vector embeddings at scale.
 
 The toolkit includes:


### PR DESCRIPTION
Remove `fail_on_error` for Vale so people don't feel like they have to dig through the error logs, which still contain a giant backlog of existing errors

PR commenting is still preserved, which is the feature we do want people looking at right now