### PR TITLE
Direct users to self-update postgres to display network-restrictions.mdx

### DIFF
--- a/apps/docs/content/guides/platform/network-restrictions.mdx
+++ b/apps/docs/content/guides/platform/network-restrictions.mdx
@@ -6,7 +6,7 @@ description: "Apply network restrictions for your project's database."
 
 <Admonition type="note">
 
-Network Restrictions is currently in beta and is slowly being made available to all projects. [Contact support](https://supabase.com/dashboard/support/new) if you'd like to request early access.
+If you cannot find the Network Restrictions section at the bottom of your [Database Settings](https://supabase.com/dashboard/project/_/settings/database), you will need to update your version of Postgres in the [Infrastructure Settings](https://supabase.com/dashboard/project/_/settings/infrastructure)
 
 </Admonition>
 

--- a/apps/docs/content/guides/platform/network-restrictions.mdx
+++ b/apps/docs/content/guides/platform/network-restrictions.mdx
@@ -6,7 +6,7 @@ description: "Apply network restrictions for your project's database."
 
 <Admonition type="note">
 
-If you cannot find the Network Restrictions section at the bottom of your [Database Settings](https://supabase.com/dashboard/project/_/settings/database), you will need to update your version of Postgres in the [Infrastructure Settings](https://supabase.com/dashboard/project/_/settings/infrastructure)
+If you can't find the Network Restrictions section at the bottom of your [Database Settings](/dashboard/project/_/settings/database), update your version of Postgres in the [Infrastructure Settings](/dashboard/project/_/settings/infrastructure).
 
 </Admonition>
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

Users are told to contact Support to enable network restrictions. It's out of beta and is widely available. They just need to update their version of Postgres if it is not yet accessible through their Dashboard

## What is the new behavior?

Tells users to update their database if network restrictions are unavailable


