### PR TITLE
Issue #21650 | Bugfix | The new MinIO base images dropped cURL.  Updated the healthcheck command to fix it.

### DIFF
--- a/docker/docker-compose.s3.yml
+++ b/docker/docker-compose.s3.yml
@@ -12,7 +12,7 @@ services:
       MINIO_ROOT_PASSWORD: secret1234
     command: server --console-address ":9001" /data
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://minio:9000/minio/health/live" ]
+      test: timeout 5s bash -c ':> /dev/tcp/127.0.0.1/9000' || exit 1
       interval: 2s
       timeout: 10s
       retries: 5

--- a/docker/docker-compose.s3.yml
+++ b/docker/docker-compose.s3.yml
@@ -3,7 +3,7 @@ version: "3.8"
 services:
 
   minio:
-    image: minio/minio
+    image: minio/minio:RELEASE.2024-02-24T17-11-14Z
     ports:
       - '9000:9000'
       - '9001:9001'
@@ -20,7 +20,7 @@ services:
       - ./volumes/storage:/data:z
 
   minio-createbucket:
-    image: minio/mc
+    image: minio/mc:RELEASE.2024-02-24T01-33-20Z
     depends_on:
       minio:
         condition: service_healthy

--- a/docker/docker-compose.s3.yml
+++ b/docker/docker-compose.s3.yml
@@ -3,7 +3,7 @@ version: "3.8"
 services:
 
   minio:
-    image: minio/minio:RELEASE.2024-02-24T17-11-14Z
+    image: minio/minio:RELEASE.2024-07-16T23-46-41Z
     ports:
       - '9000:9000'
       - '9001:9001'
@@ -20,7 +20,7 @@ services:
       - ./volumes/storage:/data:z
 
   minio-createbucket:
-    image: minio/mc:RELEASE.2024-02-24T01-33-20Z
+    image: minio/mc:RELEASE.2024-07-15T17-46-06Z
     depends_on:
       minio:
         condition: service_healthy

--- a/docker/docker-compose.s3.yml
+++ b/docker/docker-compose.s3.yml
@@ -12,7 +12,7 @@ services:
       MINIO_ROOT_PASSWORD: secret1234
     command: server --console-address ":9001" /data
     healthcheck:
-      test: timeout 5s bash -c ':> /dev/tcp/127.0.0.1/9000' || exit 1
+      test: mc ready local || exit 1
       interval: 2s
       timeout: 10s
       retries: 5


### PR DESCRIPTION
## What kind of change does this PR introduce?

_Bug fix_

[The new MinIO base images dropped cURL. Updated needed on the healthcheck command to fix it. (already submitted a PR for it, see PR #21649) #21650](https://github.com/supabase/supabase/issues/21650)

## What is the current behavior?

The `minio` service defined in the `/docker/docker-compose.s3.yml` file has an outdated healthcheck command, that will always cause the service to be marked as unhealthy.  This is because `curl` is no longer available.  They changed the base image.

## What is the new behavior?

This updated healthcheck resotres the healthcheck functionality.

## Additional context

Updated the healthcheck command, following their suggestion from: https://github.com/minio/minio/issues/18373#issuecomment-1790003599