### PR TITLE
chore: adds back priorty

### DIFF
--- a/apps/www/internals/generate-sitemap.mjs
+++ b/apps/www/internals/generate-sitemap.mjs
@@ -89,7 +89,7 @@ async function generate() {
               <url>
                   <loc>${`https://supabase.com${route}`}</loc>
                   <changefreq>weekly</changefreq>
-                  <changefreq>0.5</changefreq>
+                  <priority>0.5</priority>
               </url>
             `
           })


### PR DESCRIPTION
we thought this was a bug previously that we had changefreq twice, but actually the second one was just not using the correct tag "priority"