### PR TITLE
docs: fix parameter name to fileSizeLimit

### DIFF
--- a/apps/docs/content/guides/storage/buckets/creating-buckets.mdx
+++ b/apps/docs/content/guides/storage/buckets/creating-buckets.mdx
@@ -78,7 +78,7 @@ You can achieve the following by providing: `allowedMimeTypes` and `maxFileSize`
 const { data, error } = await supabase.storage.createBucket('avatars', {
   public: true,
   allowedMimeTypes: ['image/*'],
-  maxFileSize: '1MB',
+  fileSizeLimit: '1MB',
 })
 ```
 


### PR DESCRIPTION
the newest version of api use `fileSizeLimit` rather than `maxFileSize`

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

use `maxFileSize`

## What is the new behavior?

use `fileSizeLimit`
