### PR TITLE
fix logo on page refresh

### DIFF
--- a/apps/www/components/Nav/index.tsx
+++ b/apps/www/components/Nav/index.tsx
@@ -91,10 +91,19 @@ const Nav = (props: Props) => {
                     className="block w-auto h-6 focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-foreground-lighter focus-visible:ring-offset-4 focus-visible:ring-offset-background-alternative focus-visible:rounded-sm"
                   >
                     <Image
-                      src={showDarkLogo ? supabaseLogoWordmarkDark : supabaseLogoWordmarkLight}
+                      src={supabaseLogoWordmarkLight}
                       width={124}
                       height={24}
                       alt="Supabase Logo"
+                      className="dark:hidden"
+                      priority
+                    />
+                    <Image
+                      src={supabaseLogoWordmarkDark}
+                      width={124}
+                      height={24}
+                      alt="Supabase Logo"
+                      className="hidden dark:block"
                       priority
                     />
                   </Link>


### PR DESCRIPTION
## What kind of change does this PR introduce?

The navbar logo isn't in sync with theme when refreshing the page.
This was previously fixed by checking mount/unmount which was removed because it made the logo (and the whole navbar) flash on load.
This PR fixes it definitely.

## What is the current behavior?

https://github.com/supabase/supabase/assets/25671831/50230e0c-1b1c-46b9-a810-fa742354a8f7

## What is the new behavior?

https://github.com/supabase/supabase/assets/25671831/ab461356-2607-43f3-a4e7-9e77781d1e92

