### PR TITLE
fix: Refactor the host calculation logic for the realtime inspector

### DIFF
--- a/apps/studio/components/interfaces/Realtime/Inspector/useRealtimeMessages.ts
+++ b/apps/studio/components/interfaces/Realtime/Inspector/useRealtimeMessages.ts
@@ -64,16 +64,12 @@ export const useRealtimeMessages = ({
   enableDbChanges,
   enableBroadcast,
 }: RealtimeConfig) => {
+  const { data } = useProjectApiQuery({ projectRef: projectRef })
+
   // the default host is prod until the correct one comes through an API call.
-  const [host, setHost] = useState(`https://${projectRef}.supabase.co`)
-  useProjectApiQuery(
-    { projectRef: projectRef },
-    {
-      onSuccess: (data) => {
-        setHost(`${data.autoApiService.protocol}://${data.autoApiService.endpoint}`)
-      },
-    }
-  )
+  const host = data
+    ? `${data.autoApiService.protocol}://${data.autoApiService.endpoint}`
+    : `https://${projectRef}.supabase.co`
 
   const [logData, dispatch] = useReducer(reducer, [] as LogData[])
   const pushMessage = (messageType: string, metadata: any) => {


### PR DESCRIPTION
The previous logic didn't work properly if the user comes from another page (`/project/_/auth/users` for example) and he's not on production. 

The `useProjectApiQuery` doesn't fire because it's cached and the host URL stays broken until the cache invalidation time is passed. This is evident in the local/selfhosted environment but can also be replicated in staging or preview environments.