### PR TITLE
Update error about Magic Link in auth-ui.mdx

### DIFF
--- a/apps/docs/content/guides/auth/auth-helpers/auth-ui.mdx
+++ b/apps/docs/content/guides/auth/auth-helpers/auth-ui.mdx
@@ -397,7 +397,7 @@ A full list of the available variables is below:
 | `email_input_placeholder` | Your email address                  |
 | `button_label`            | Sign in                             |
 | `loading_button_label`    | Signing in ...                      |
-| `link_text`               | Already have an account? Sign in    |
+| `link_text`               | Send a magic link email             |
 | `confirmation_text`       | Check your email for the magic link |
 
 </TabPanel>


### PR DESCRIPTION
In documentation, the default label for Magic Link `link_text` was wrong

## What kind of change does this PR introduce?

Documentation update

## What is the current behavior?

Wrong label

## What is the new behavior?

Correct label