### PR TITLE
docs: mention local option in generating-types.mdx

### DIFF
--- a/apps/docs/content/guides/api/rest/generating-types.mdx
+++ b/apps/docs/content/guides/api/rest/generating-types.mdx
@@ -30,6 +30,12 @@ Generate types for your project to produce the `types/supabase.ts` file:
 npx supabase gen types typescript --project-id "$PROJECT_REF" --schema public > types/supabase.ts
 ```
 
+or in case of local development:
+
+```bash
+npx supabase gen types typescript --local > types/supabase.ts
+```
+
 These types are generated from your database schema. Given a table `public.movies`, the generated types will look like:
 
 ```sql


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs: searching google for "supabase generate types" shows this as the best result. However, the guide doesn't mention much the options for type generation locally, so I added the main part for that (the command).

I think it's useful, but feel free to ignore.
