### PR TITLE
fix: Better errors in SQL editor

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
@@ -26,8 +26,8 @@ import {
   ResizablePanelGroup,
   cn,
 } from 'ui'
-
 import ConfirmModal from 'ui-patterns/Dialogs/ConfirmDialog'
+
 import { useSqlEditMutation } from 'data/ai/sql-edit-mutation'
 import { useSqlGenerateMutation } from 'data/ai/sql-generate-mutation'
 import { useSqlTitleGenerateMutation } from 'data/ai/sql-title-mutation'
@@ -329,6 +329,9 @@ const SQLEditor = () => {
             role: impersonatedRole,
           }),
           isRoleImpersonationEnabled: isRoleImpersonationEnabled(impersonatedRole),
+          handleError: (error) => {
+            throw error
+          },
         })
       }
     },


### PR DESCRIPTION
Throw the same error instead of wrapping it and losing information like `formattedError` (which is then rendered to the user).
