### PR TITLE
docs: re-order Read Replicas doc sections

### DIFF
--- a/apps/docs/content/guides/platform/read-replicas.mdx
+++ b/apps/docs/content/guides/platform/read-replicas.mdx
@@ -1,46 +1,125 @@
 ---
 title: 'Read Replicas'
-description: 'Spin up additional read-only databases for your project.'
-subtitle: 'Spin up additional read-only databases for your project'
+description: 'Deploy additional read-only databases in multiple regions for your project.'
+subtitle: 'Deploy additional read-only databases in multiple regions for your project'
 ---
 
-<Admonition type="caution" label="Read replicas are only currently available for Early Access for projects on the Pro Plan and above.">
+<Admonition type="caution" label="Read Replicas are currently available to organizations on Pro plan and above who have signed up for early access.">
 
-To try out read replicas, [request access here](https://forms.supabase.com/read-replica).
+To sign up for early access, [request access here](https://forms.supabase.com/read-replica).
 
 </Admonition>
 
-Read replicas continuously replicate data from a primary database. You can both read and write data on a primary database, but you can _only_ read (for example, use `select` statements), and not write, on a read replica.
+<figure className="max-w-[700px] mx-auto">
+    <Image
+        className="hidden dark:block"
+        alt="Map view of all project databases"
+        src="/docs/img/guides/platform/read-replicas/map-view.png?v=1"
+    />
+
+    <Image
+        className="dark:hidden"
+        alt="Map view of all project databases."
+        src="/docs/img/guides/platform/read-replicas/map-view.png?v=1"
+    />
+
+</figure>
+
+Read Replicas are Postgres databases that are continuously synced to a Supabase project's Primary database. You can both read from and write to a Primary database, but you can _only_ read from a Read Replica, such as using `select` statements.
 
 |              | select | insert | update | delete |
 | ------------ | ------ | ------ | ------ | ------ |
 | Primary      | ✅     | ✅     | ✅     | ✅     |
 | Read Replica | ✅     | -      | -      | -      |
 
-When you create a project, the automatically created database is considered the primary database. If you then add read replicas, they will receive and synchronize data from this primary database. Replication is asynchronous. It happens in the background, so transactions on the primary aren't blocked. The time delay between writing data to the primary and the read replica receiving the change is called replication lag.
+A database is spun up automatically with every Supabase project. This database is the Primary database. You can choose to add Read Replicas to your project and those Replicas will receive and synchronize data from the Primary database.
 
-Read replicas have many applications:
+Replication is asynchronous and happens in the background so transactions on the Primary aren't blocked. The time delay between writing data to the Primary and the Read Replica receiving the change is replication lag.
 
-- They reduce read load on the primary database.
-  - For example, you can use a read replica for complex analytical queries and reserve the primary for user-facing create, update, and delete operations.
-- For projects that need to cover a global audience, additional databases can be spun up closer to users in any of our twelve supported regions to reduce latency.
-- Read replicas provide data redundancy.
+Read Replicas have many applications:
+
+- They reduce read load on the Primary database.
+  - For example, you can use a Read Replica for complex analytical queries and reserve the Primary for user-facing create, update, and delete operations.
+- For projects that need to cover a global audience, additional databases can be deployed closer to users in any of our twelve supported regions to reduce latency.
+- Read Replicas provide data redundancy.
+
+## Prerequisites
+
+A project needs to satisfy these requirements to deploy a Read Replica:
+
+1. Running on AWS.
+   - Support for projects on Fly.io will be added at a later date.
+1. Running on at least a [Small compute add-on](/docs/guides/platform/compute-add-ons).
+   - Read Replicas are currently placed on the same compute instance as the database to make sure they can keep up with the Primary's activities.
+1. Using [physical backups](/docs/guides/platform/backups#point-in-time-recovery)
+   - Physical backups are automatically enabled if using [PITR](/docs/guides/platform/backups#point-in-time-recovery)
+1. Running on Postgres 15.
+   - For projects running on older versions of PostgreSQL, you will need to [upgrade to the latest platform version](/docs/guides/platform/migrating-and-upgrading-projects#pgupgrade).
+
+## Getting started
+
+Read Replicas can be managed from the [infrastructure settings page](https://supabase.com/dashboard/project/_/settings/infrastructure). For now, each project can only deploy up to two Read Replicas and all Read Replicas inherit the compute size of their Primary database.
+
+Read Replicas offer the following features:
+
+### Dedicated endpoints
+
+Each Read Replica has its own dedicated database and API endpoints. The database endpoint can be found in your [dashboard database settings](https://supabase.com/dashboard/project/_/settings/database) under **Connection info**. The API endpoint can be found in [dashboard API settings](https://supabase.com/dashboard/project/_/settings/api) under **Project URL**.
+
+A Read Replica's API endpoint only supports `GET` requests to the [REST API](https://supabase.com/docs/guides/api). Requests towards other Supabase products, such as Auth, Storage, and Realtime, are not able to utilize a Read Replica nor its API endpoint for now. We are working on adding Read Replica support for them.
+
+### Dedicated connection pool
+
+A connection pool through Supavisor is also available for each Read Replica. Its unique connection string can be found in your [dashboard database settings](https://supabase.com/dashboard/project/_/settings/database) under **Connection string**.
+
+### Querying through the SQL editor
+
+<figure className="max-w-[700px] mx-auto">
+    <Image
+        className="hidden dark:block"
+        alt="SQL editor view."
+        src="/docs/img/guides/platform/read-replicas/sql-editor.png?v=1"
+    />
+
+    <Image
+        className="dark:hidden"
+        alt="SQL editor view."
+        src="/docs/img/guides/platform/read-replicas/sql-editor.png?v=1"
+    />
+
+</figure>
+
+In the SQL editor, you can choose if you want to run the query on the Primary or one of the Replicas.
+
+### API load balancer
+
+When Read Replicas are deployed, an API load balancer becomes available for the project. An endpoint for it is provisioned and can be found [here](https://supabase.com/dashboard/project/_/settings/api).
+
+The load balancer uses a round-robin strategy to route `GET` requests to any of the API endpoints available, including that of the Primary database. Non-`GET` requests can also be sent through this endpoint. They are immediately redirected to the Primary database.
+
+Similar to the Read Replica API endpoints, only requests to the REST API are available for now. Support for other Supabase products will become available once Read Replica support has been completed for them.
+
+When a project no longer has any Read Replicas, the load balancer and its endpoint are brought down as well.
+
+### Centralized configuration management
+
+All settings made through the dashboard will be propagated across all databases of a project. This ensures that no Read Replica get out of sync with its Primary database or with other Read Replicas.
 
 ## How are Read Replicas made?
 
-We use a hybrid approach to replicate data from a primary to its read replicas, combining the native methods of streaming replication and file-based log shipping.
+We use a hybrid approach to replicate data from a Primary to its Read Replicas, combining the native methods of streaming replication and file-based log shipping.
 
 ### Streaming replication
 
-Postgres generates a Write Ahead Log (WAL) as database changes occur. With streaming replication, these changes stream from the primary to the read replica server. The WAL alone is sufficient to reconstruct the database to its current state.
+Postgres generates a Write Ahead Log (WAL) as database changes occur. With streaming replication, these changes stream from the Primary to the Read Replica server. The WAL alone is sufficient to reconstruct the database to its current state.
 
-This replication method is fast, since changes are streamed directly from the primary to the read replica. On the other hand, it faces challenges when the read replica can't keep up with the WAL changes from its primary. This can happen when the read replica is too small, running on degraded hardware, or has a heavier workload running.
+This replication method is fast, since changes are streamed directly from the Primary to the Read Replica. On the other hand, it faces challenges when the Read Replica can't keep up with the WAL changes from its Primary. This can happen when the Read Replica is too small, running on degraded hardware, or has a heavier workload running.
 
-To address this, Postgres does provide tunable configuration, like `wal_keep_size`, to adjust the WAL retained by the primary. If the read replica fails to “catch up” before the WAL surpasses the `wal_keep_size` setting, the replication is terminated. Tuning is a bit of an art - the amount of WAL required is variable for every situation.
+To address this, Postgres does provide tunable configuration, like `wal_keep_size`, to adjust the WAL retained by the Primary. If the Read Replica fails to “catch up” before the WAL surpasses the `wal_keep_size` setting, the replication is terminated. Tuning is a bit of an art - the amount of WAL required is variable for every situation.
 
 ### File-based log shipping
 
-In this replication method, the primary continuously buffers WAL changes to a local file and then sends the file to the read replica. If multiple read replicas are present, files could also be sent to an intermediary location accessible by all. The read replica then reads the WAL files and applies those changes. There is higher replication lag than streaming replication since the primary buffers the changes locally first. It also means there is a small chance that WAL changes do not reach read replicas if the primary goes down before the file is transferred. In these cases, if the primary fails a replica using streaming replication would (in most cases) be more up-to-date than a replica using file-based log shipping.
+In this replication method, the Primary continuously buffers WAL changes to a local file and then sends the file to the Read Replica. If multiple Read Replicas are present, files could also be sent to an intermediary location accessible by all. The Read Replica then reads the WAL files and applies those changes. There is higher replication lag than streaming replication since the Primary buffers the changes locally first. It also means there is a small chance that WAL changes do not reach Read Replicas if the Primary goes down before the file is transferred. In these cases, if the Primary fails a Replica using streaming replication would (in most cases) be more up-to-date than a Replica using file-based log shipping.
 
 ### File-based log shipping 🤝 streaming replication
 
@@ -60,97 +139,17 @@ In this replication method, the primary continuously buffers WAL changes to a lo
 
 </figure>
 
-We bring these two methods together to achieve quick, stable, and reliable replication. Each method addresses the limitations of the other. Streaming replication minimizes replication lag, while file-based log shipping provides a fallback. For file-based log shipping, we use our existing Point In Time Recovery (PITR) infrastructure. We regularly archive files from the primary using [WAL-G](https://github.com/wal-g/wal-g), an open source archival and restoration tool, and ship the WAL files to S3.
+We bring these two methods together to achieve quick, stable, and reliable replication. Each method addresses the limitations of the other. Streaming replication minimizes replication lag, while file-based log shipping provides a fallback. For file-based log shipping, we use our existing Point In Time Recovery (PITR) infrastructure. We regularly archive files from the Primary using [WAL-G](https://github.com/wal-g/wal-g), an open source archival and restoration tool, and ship the WAL files to S3.
 
-We combine it with streaming replication to reduce replication lag. Once WAL-G files have been synced from S3, read replicas connect to the primary and stream the WAL directly.
+We combine it with streaming replication to reduce replication lag. Once WAL-G files have been synced from S3, Read Replicas connect to the Primary and stream the WAL directly.
 
-## Getting started
+## Operations blocked by Read Replicas
 
-<figure className="max-w-[700px] mx-auto">
-    <Image
-        className="hidden dark:block"
-        alt="Map view of all project databases"
-        src="/docs/img/guides/platform/read-replicas/map-view.png?v=1"
-    />
+### Project upgrades and data restorations
 
-    <Image
-        className="dark:hidden"
-        alt="Map view of all project databases."
-        src="/docs/img/guides/platform/read-replicas/map-view.png?v=1"
-    />
+The following procedures require all Read Replicas for a project to be brought down before they can be performed:
 
-</figure>
+1. [Project upgrades](/docs/guides/platform/migrating-and-upgrading-projects#pgupgrade)
+1. [Data restorations](/docs/guides/platform/backups#pitr-restoration-process)
 
-Read replicas can be managed from the [infrastructure settings page](https://supabase.com/dashboard/project/_/settings/infrastructure). For now, each project can only spin up to two read replicas. Read replicas also inherit the compute size of their primary database.
-
-Read replicas offer the following features:
-
-### Dedicated endpoints
-
-Each read replica has its own dedicated database and API endpoints. The database endpoint can be found in your [dashboard database settings](https://supabase.com/dashboard/project/_/settings/database) under **Connection info**. The API endpoint can be found in [dashboard API settings](https://supabase.com/dashboard/project/_/settings/api) under **Project URL**.
-
-A read replica's API endpoint only supports `GET` requests to the [REST API](https://supabase.com/docs/guides/api). Requests towards other Supabase products, such as Auth, Storage, and Realtime are not able to utilize a read replica nor its API endpoint for now. We are working on adding read replica support for them.
-
-### Dedicated connection pool
-
-A connection pool through Supavisor is also available for each read replica. Its unique connection string can be found in your [dashboard database settings](https://supabase.com/dashboard/project/_/settings/database) under **Connection string**.
-
-### Querying through the SQL editor
-
-<figure className="max-w-[700px] mx-auto">
-    <Image
-        className="hidden dark:block"
-        alt="SQL editor view."
-        src="/docs/img/guides/platform/read-replicas/sql-editor.png?v=1"
-    />
-
-    <Image
-        className="dark:hidden"
-        alt="SQL editor view."
-        src="/docs/img/guides/platform/read-replicas/sql-editor.png?v=1"
-    />
-
-</figure>
-
-In the SQL editor, you can choose if you want to run the query on the primary or one of the replicas.
-
-### API load balancer
-
-When read replicas are spun up, an API load balancer becomes available for the project. An endpoint for it is provisioned and can be found [here](https://supabase.com/dashboard/project/_/settings/api).
-
-The load balancer uses a round-robin strategy to route `GET` requests to any of the API endpoints available, including that of the primary database. Non-`GET` requests can also be sent through this endpoint. They are immediately redirected to the primary database.
-
-Similar to the read replica API endpoints, only requests to the REST API are available for now. Support for other Supabase products will become available once read replica support has been completed for them.
-
-When a project no longer has any read replicas, the load balancer and its endpoint are brought down as well.
-
-### Centralized configuration management
-
-All settings made through the dashboard will be propagated across all databases of a project. This ensures that no read replica get out of sync with its primary database or with other read replicas.
-
-## Limitations
-
-### Prerequisites for using read replicas
-
-A project needs to satisfy these requirements to spin up a read replica:
-
-1. Running on AWS.
-   - Support for projects on Fly.io will be added at a later date.
-1. Running on at least a [Small compute add-on](/docs/guides/platform/compute-add-ons).
-1. Using [physical backups](/docs/guides/platform/backups#point-in-time-recovery)
-   - Physical backups are automatically enabled if using [PITR](/docs/guides/platform/backups#point-in-time-recovery)
-1. Running on Postgres 15.
-   - For projects running on older versions of PostgreSQL, you will need to [upgrade to the latest platform version](/docs/guides/platform/migrating-and-upgrading-projects#pgupgrade).
-
-### Read replicas need to be brought down before starting the following procedures
-
-The following procedures require all read replicas for a project to be brought down before they can be started:
-
-1. [Upgrading a project](/docs/guides/platform/migrating-and-upgrading-projects#pgupgrade)
-1. Performing [data restoration](/docs/guides/platform/backups#pitr-restoration-process).
-
-Once these operations complete, read replicas can be spun back up.
-
-### Compute Add-ons
-
-In order to avoid replicas being unable to keep up with activity on the primaries they're following, Read Replicas are currently placed on the same Compute Add-on as the primary they're following.
+These operations need to be completed before Read Replicas can be re-deployed.

--- a/apps/docs/content/guides/platform/read-replicas.mdx
+++ b/apps/docs/content/guides/platform/read-replicas.mdx
@@ -4,7 +4,7 @@ description: 'Deploy additional read-only databases in multiple regions for your
 subtitle: 'Deploy additional read-only databases in multiple regions for your project'
 ---
 
-<Admonition type="caution" label="Read Replicas are currently available to organizations on Pro plan and above who have signed up for early access.">
+<Admonition type="note" label="Read Replicas are available to organizations on Pro plan and above who have signed up for early access.">
 
 To sign up for early access, [request access here](https://forms.supabase.com/read-replica).
 

--- a/apps/docs/content/guides/platform/read-replicas.mdx
+++ b/apps/docs/content/guides/platform/read-replicas.mdx
@@ -124,19 +124,11 @@ In this replication method, the Primary continuously buffers WAL changes to a lo
 ### File-based log shipping 🤝 streaming replication
 
 <figure className="max-w-[700px] mx-auto">
-    <Image
-        className="hidden dark:block"
-        alt="How replication is achieved."
-        src="/docs/img/guides/platform/read-replicas/streaming-replication-dark.png?v=1"
-    />
-
-    <Image
-        className="dark:hidden"
-        alt="How replication is achieved."
-        src="/docs/img/guides/platform/read-replicas/streaming-replication-light.png?v=1"
-    />
-    <figcaption>How replication is achieved.</figcaption>
-
+  <Image
+    alt="Map view of Primary and Read Replica databases"
+    src="/docs/img/guides/platform/read-replicas/streaming-replication-dark.png?v=1"
+  />
+  <figcaption>Map view of Primary and Read Replica databases</figcaption>
 </figure>
 
 We bring these two methods together to achieve quick, stable, and reliable replication. Each method addresses the limitations of the other. Streaming replication minimizes replication lag, while file-based log shipping provides a fallback. For file-based log shipping, we use our existing Point In Time Recovery (PITR) infrastructure. We regularly archive files from the Primary using [WAL-G](https://github.com/wal-g/wal-g), an open source archival and restoration tool, and ship the WAL files to S3.

--- a/apps/docs/content/guides/platform/read-replicas.mdx
+++ b/apps/docs/content/guides/platform/read-replicas.mdx
@@ -6,7 +6,7 @@ subtitle: 'Deploy additional read-only databases in multiple regions for your pr
 
 <Admonition type="note" label="Read Replicas are available to organizations on Pro plan and above who have signed up for early access.">
 
-To sign up for early access, [request access here](https://forms.supabase.com/read-replica).
+[Request early access here](https://forms.supabase.com/read-replica).
 
 </Admonition>
 

--- a/apps/docs/content/guides/platform/read-replicas.mdx
+++ b/apps/docs/content/guides/platform/read-replicas.mdx
@@ -48,7 +48,7 @@ Read Replicas have many applications:
 A project needs to satisfy these requirements to deploy a Read Replica:
 
 1. Running on AWS.
-   - Support for projects on Fly.io will be added at a later date.
+   - Support for projects on Fly.io is coming.
 1. Running on at least a [Small compute add-on](/docs/guides/platform/compute-add-ons).
    - Read Replicas are currently placed on the same compute instance as the database to make sure they can keep up with the Primary's activities.
 1. Using [physical backups](/docs/guides/platform/backups#point-in-time-recovery)

--- a/apps/studio/components/interfaces/Settings/Addons/ComputeInstanceSidePanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/ComputeInstanceSidePanel.tsx
@@ -399,7 +399,7 @@ const ComputeInstanceSidePanel = () => {
               <Alert_Shadcn_>
                 <WarningIcon />
                 <AlertTitle_Shadcn_>
-                  Your project will need to be restarted when changing it's compute size
+                  Your project will need to be restarted when changing its compute size
                 </AlertTitle_Shadcn_>
                 <AlertDescription_Shadcn_>
                   Your project will be unavailable for up to 2 minutes while the changes take place.
@@ -485,7 +485,7 @@ const ComputeInstanceSidePanel = () => {
             <Alert
               withIcon
               variant="warning"
-              title="Your project will need to be restarted when changing it's compute size"
+              title="Your project will need to be restarted when changing its compute size"
             >
               Your project will be unavailable for up to 2 minutes while the changes take place.
             </Alert>


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the new behavior?

get the read replicas doc ready for launch

## Additional Information

Purpose of this PR is to re-order the different sections of the Read Replicas docs in order to get it ready for launch. 

Focus is on `Prerequisites` and `Getting Started` so they're moved up while the section on how Read Replicas were made down towards the bottom.

Also, reframed `Limitations` since they aren't necessarily limitations of Read Replicas.

Then just updated some sentences here and there so they read better.
