### PR TITLE
docs: Add `params` option to reference docs so that non-js client libs can add parameters

### DIFF
--- a/apps/docs/components/reference/RefFunctionSection.tsx
+++ b/apps/docs/components/reference/RefFunctionSection.tsx
@@ -22,7 +22,7 @@ const RefFunctionSection: React.FC<IRefFunctionSection> = (props) => {
 
   const tsDefinition =
     hasTsRef && props.typeSpec ? extractTsDocNode(hasTsRef, props.typeSpec) : null
-  const parameters = hasTsRef && tsDefinition ? generateParameters(tsDefinition) : ''
+  const parameters = hasTsRef && tsDefinition ? generateParameters(tsDefinition) : item.params
   const shortText = hasTsRef && tsDefinition ? tsDefinition.signatures[0].comment.shortText : ''
 
   return (
@@ -51,7 +51,7 @@ const RefFunctionSection: React.FC<IRefFunctionSection> = (props) => {
                 </ReactMarkdown>
               </div>
             )}
-            {/* // parameters */}
+            {/* parameters */}
             {parameters && (
               <div className="not-prose mt-12">
                 <h5 className="mb-3 text-base text-foreground">Parameters</h5>

--- a/apps/docs/spec/supabase_dart_v2.yml
+++ b/apps/docs/spec/supabase_dart_v2.yml
@@ -2,22 +2,55 @@ openref: 0.1
 
 info:
   id: reference/dart
-  title: Supabase Dart Client
+  title: Supabase Flutter Client
   description: |
 
-    Supabase Dart.
-
-  definition: spec/enrichments/tsdoc_v2/combined.json
+    Supabase Flutter.
   slugPrefix: '/'
   specUrl: https://github.com/supabase/supabase/edit/master/apps/docs/spec/supabase_dart_v2.yml
   libraries:
-    - name: 'Dart'
-      id: 'dart'
+    - id: 'dart'
       version: '0.0.1'
 
 functions:
   - id: initializing
     title: 'Initializing'
+    params:
+      - name: url
+        isOptional: false
+        type: string
+        description: The unique Supabase URL which is supplied when you create a new project in your project dashboard.
+      - name: anonKey
+        isOptional: false
+        type: string
+        description: The unique Supabase Key which is supplied when you create a new project in your project dashboard.
+      - name: authOptions
+        isOptional: true
+        type: FlutterAuthClientOptions
+        description: Options to change the Auth behaviors.
+        subContent:
+          - name: authFlowType
+            isOptional: true
+            type: AuthFlowType
+            description: Whether to use the `pkce` flow or the `implicit` flow. Defaults to `pkce`.
+          - name: localStorage
+            isOptional: true
+            type: LocalStorage
+            description: Parameter to override the local storage to store auth tokens.
+          - name: autoRefreshToken
+            isOptional: true
+            type: boolean
+            description: Whether to automatically refresh the token when it expires. Defaults to `true`.
+      - name: realtimeClientOptions
+        isOptional: true
+        type: RealtimeClientOptions
+        description: Options to change the Realtime behaviors.
+        subContent:
+          - name: logLevel
+            isOptional: true
+            type: RealtimeLogLevel
+            description: Level of realtime server logs to to be logged.
+
     description: |
       You can initialize Supabase with the static `initialize()` method of the `Supabase` class.
 

--- a/apps/docs/spec/supabase_dart_v2.yml
+++ b/apps/docs/spec/supabase_dart_v2.yml
@@ -15,6 +15,11 @@ info:
 functions:
   - id: initializing
     title: 'Initializing'
+    description: |
+      You can initialize Supabase with the static `initialize()` method of the `Supabase` class.
+
+      The Supabase client is your entrypoint to the rest of the Supabase functionality
+      and is the easiest way to interact with everything we offer within the Supabase ecosystem.
     params:
       - name: url
         isOptional: false
@@ -50,13 +55,6 @@ functions:
             isOptional: true
             type: RealtimeLogLevel
             description: Level of realtime server logs to to be logged.
-
-    description: |
-      You can initialize Supabase with the static `initialize()` method of the `Supabase` class.
-
-      The Supabase client is your entrypoint to the rest of the Supabase functionality
-      and is the easiest way to interact with everything we offer within the Supabase ecosystem.
-
     examples:
       - id: flutter-initialize
         name: For Flutter

--- a/apps/docs/spec/supabase_dart_v2.yml
+++ b/apps/docs/spec/supabase_dart_v2.yml
@@ -10,7 +10,7 @@ info:
   specUrl: https://github.com/supabase/supabase/edit/master/apps/docs/spec/supabase_dart_v2.yml
   libraries:
     - name: 'Dart'
-    - id: 'dart'
+      id: 'dart'
       version: '0.0.1'
 
 functions:

--- a/apps/docs/spec/supabase_dart_v2.yml
+++ b/apps/docs/spec/supabase_dart_v2.yml
@@ -2,13 +2,14 @@ openref: 0.1
 
 info:
   id: reference/dart
-  title: Supabase Flutter Client
+  title: Supabase Dart Client
   description: |
 
-    Supabase Flutter.
+    Supabase Dart.
   slugPrefix: '/'
   specUrl: https://github.com/supabase/supabase/edit/master/apps/docs/spec/supabase_dart_v2.yml
   libraries:
+    - name: 'Dart'
     - id: 'dart'
       version: '0.0.1'
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Something I should have done a looong time ago. 

Until now, there is no great way to add params on non-js client libs' reference docs. This PR introduces a new `params` parameter on the spec yaml file so that non-js client libs can have parameter definitions in the reference docs, and makes it aligned with the js reference docs. 

<img width="1435" alt="Screenshot 2024-03-02 at 18 58 16" src="https://github.com/supabase/supabase/assets/18113850/06152e65-880c-4574-b643-efe636d38885">

## What is the current behavior?

There is the [overrideParams](https://github.com/supabase/supabase/blob/master/apps/docs/components/reference/RefFunctionSection.tsx#L61) parameter that we can add to the spec yaml files, but it only allows us to override what exists on the js client libs, and does not allow us to add any parameters specific to the client libraries. 

## What is the new behavior?

A new `params` parameter is introduced on the spec yaml files, where we can add the parameter definitions. I have done a quick example with the `initializing` function for the Flutter docs. 

## Additional Context

If this PR is merged, I will work on adding other parameters for all the methods and ask the maintainers of other libraries to add parameters.