### PR TITLE
feat: full screen side panel button

### DIFF
--- a/packages/ui/src/components/SidePanel/SidePanel.tsx
+++ b/packages/ui/src/components/SidePanel/SidePanel.tsx
@@ -1,8 +1,9 @@
 import * as Dialog from '@radix-ui/react-dialog'
 import * as Tooltip from '@radix-ui/react-tooltip'
-import React from 'react'
+import React, { useState } from 'react'
 import { Button } from '../../../index'
 import styleHandler from '../../lib/theme/styleHandler'
+import { Maximize2, Minimize2 } from 'lucide-react'
 
 export type SidePanelProps = RadixProps & CustomProps
 
@@ -60,6 +61,7 @@ const SidePanel = ({
   ...props
 }: SidePanelProps) => {
   const __styles = styleHandler('sidepanel')
+  const [fullscreen, setFullscreen] = useState(false)
 
   const footerContent = customFooter ? (
     customFooter
@@ -127,7 +129,7 @@ const SidePanel = ({
         <Dialog.Content
           className={[
             __styles.base,
-            __styles.size[size],
+            fullscreen ? 'max-w-full w-screen' : __styles.size[size],
             __styles.align[align],
             className && className,
           ].join(' ')}
@@ -141,7 +143,24 @@ const SidePanel = ({
             if (props.onInteractOutside) props.onInteractOutside(event)
           }}
         >
-          {header && <header className={__styles.header}>{header}</header>}
+          {header && (
+            <header className={__styles.header}>
+              {header}
+              <div>
+                {!fullscreen ? (
+                  <Maximize2
+                    className="h-4 w-4 cursor-pointer"
+                    onClick={() => setFullscreen(true)}
+                  />
+                ) : (
+                  <Minimize2
+                    className="h-4 w-4 cursor-pointer"
+                    onClick={() => setFullscreen(false)}
+                  />
+                )}
+              </div>
+            </header>
+          )}
           <div className={__styles.contents}>{children}</div>
           {!hideFooter && footerContent}
         </Dialog.Content>

--- a/packages/ui/src/lib/theme/defaultTheme.ts
+++ b/packages/ui/src/lib/theme/defaultTheme.ts
@@ -859,7 +859,8 @@ export default {
     `,
     header: `
       space-y-1 py-4 px-4 bg-overlay sm:px-6
-      border-b border-overlay
+      border-b border-overlay flex justify-between
+      items-center
     `,
     contents: `
       relative


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase Studio > Side Panel

## What is the current behavior?

Currently the side panel just shows on a small side of the screen.

## What is the new behavior?

Users now have the ability to full size the panel:


https://github.com/supabase/supabase/assets/22655069/873da0a5-2ffe-4cc3-8a36-6d9f32105568



## Additional context

Discussed in #21438
