### PR TITLE
Fix/improving disk related descriptions

### DIFF
--- a/apps/docs/content/guides/platform/compute-add-ons.mdx
+++ b/apps/docs/content/guides/platform/compute-add-ons.mdx
@@ -52,13 +52,13 @@ SSD Disks are attached to your servers and the disk performance depends on the c
 
 [Contact us](https://supabase.com/contact/enterprise) if you require a custom plan.
 
-### Bursting and disk budget
+### Bursting and disk IO budget
 
-Smaller compute instances can burst up to their largest throughput and IOPS for 30 minutes in a day. Beyond that, the performance reverts to the baseline. For example, the free tier can burst up to 2,085 Mbps for 30 minutes a day and reverts to the baseline performance of 87 Mbps. Your disk budget gets replenished throughout the day.
+Smaller compute instances can burst up to their largest throughput and IOPS for 30 minutes in a day. Beyond that, the performance reverts to the baseline. For example, the free tier can burst up to 2,085 Mbps for 30 minutes a day and reverts to the baseline performance of 87 Mbps. Your disk IO budget gets replenished throughout the day.
 
 If you need consistent disk performance, choose the 4XL or larger compute add-on which has the same baseline and maximum disk throughput and IOPS.
 
-If you're unsure of how much throughput or IOPS your application requires, you can load test your project and inspect these [metrics in the Dashboard](https://supabase.com/dashboard/project/_/reports). If the `Disk IO % consumed` stat is more than 1%, it indicates that your workload has burst beyond the baseline IO throughput during the day. If this metric goes to 100%, the workload has used up all available disk budget and will revert to baseline performance. Projects that use any disk budget are good candidates for upgrading to a larger compute add-on with higher baseline throughput.
+If you're unsure of how much throughput or IOPS your application requires, you can load test your project and inspect these [metrics in the Dashboard](https://supabase.com/dashboard/project/_/reports). If the `Disk IO % consumed` stat is more than 1%, it indicates that your workload has burst beyond the baseline IO throughput during the day. If this metric goes to 100%, the workload has used up all available disk IO budget and will revert to baseline performance. Projects that use any disk IO budget are good candidates for upgrading to a larger compute add-on with higher baseline throughput.
 
 ## Postgres replication slots and WAL senders
 

--- a/apps/docs/content/guides/platform/exhaust-disk-io.mdx
+++ b/apps/docs/content/guides/platform/exhaust-disk-io.mdx
@@ -1,18 +1,18 @@
 ---
 id: 'exhaust-disk-io'
 title: 'High Disk IO Consumption'
-description: 'Understand Disk IO, what can deplete your Disk Budget and what you can do about it.'
+description: 'Understand Disk IO, what can deplete your Disk IO Budget and what you can do about it.'
 ---
 
-## Understanding disk IO and disk budget
+## Understanding disk IO and disk IO budget
 
 Disk IO refers to two metrics: throughput in Megabits per Second and IOPS which are Input/Output Operations per Second. Depending on the compute add-on of your instance you will have [different baseline performances](https://supabase.com/docs/guides/platform/compute-add-ons#disk-io).
 
-Smaller compute instances can burst and exceed their baseline performance for a short quota of time every day. This quota is represented as your Disk Budget and once your Disk Budget is consumed, your instance reverts back to its baseline performance. You can read more about this under [Bursting and Disk Budget](https://supabase.com/docs/guides/platform/compute-add-ons#bursting-and-disk-budget).
+Smaller compute instances can burst and exceed their baseline performance for a short quota of time every day. This quota is represented as your Disk IO Budget and once your Disk IO Budget is consumed, your instance reverts back to its baseline performance. You can read more about this under [Bursting and Disk IO Budget](https://supabase.com/docs/guides/platform/compute-add-ons#bursting-and-disk-io-budget).
 
-## Depleting your disk budget
+## Depleting your disk IO budget
 
-Running out of Disk Budget means that your instance is using more disk than its compute add-on can handle and essentially gets throttled. This could have a wide range of implications:
+Running out of Disk IO Budget means that your instance is using more disk than its compute add-on can handle and essentially gets throttled. This could have a wide range of implications:
 
 - Response times on requests can increase noticeably
 - CPU usage rises noticeably due to IO wait
@@ -20,15 +20,15 @@ Running out of Disk Budget means that your instance is using more disk than its 
 - Disruption of internal Postgres processes such as [autovacuuming](https://supabase.com/docs/guides/platform/database-size#vacuum-operations)
 - Your instance may become unresponsive
 
-## Monitor your disk budget
+## Monitor your disk IO budget
 
-To check your Disk Budget on the Supabase Platform, head over to [Database Health in the Reports section](https://supabase.com/dashboard/project/_/reports/database).
+To check your Disk IO Budget on the Supabase Platform, head over to [Database Health in the Reports section](https://supabase.com/dashboard/project/_/reports/database).
 
 It is also possible to monitor your resources and set up alerts using Prometheus/Grafana. With Grafana you will be able to see how much of your RAM is used for caching and you can track other metrics such as your Swap usage. Read the [Metrics Guide](https://supabase.com/docs/guides/platform/metrics) to learn more.
 
 ## Common reasons for high disk IO usage
 
-Most operations on your Supabase project require the disk in some form. Hence, there can be many reasons for high disk usage. Here are some common ones:
+Most operations on your Supabase project require disk IO in some form. Hence, there can be many reasons for high disk IO usage. Here are some common ones:
 
 - **High Memory Usage:** Every Supabase project has 1GB of disk allocated for swapping. When your memory usage is high, the operating system might frequently move parts of the memory back and forth of the swap space on the disk.
 - **Low Cache Usage:** If your cache hit rate is low, many of your database requests might go straight to the disk. Go to the [Cache Hit Rate Guide](https://supabase.com/docs/guides/platform/performance#hit-rate) to learn more.

--- a/apps/studio/components/interfaces/Settings/Infrastructure/Infrastructure.constants.ts
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/Infrastructure.constants.ts
@@ -89,7 +89,7 @@ export const INFRA_ACTIVITY_METRICS: CategoryMeta[] = [
           },
         ],
         description:
-          'The disk performance of your workload is determined by the Disk IO bandwidth.\nSmaller compute instances (below 4XL) can burst up to their largest throughput and IOPS for 30 minutes in a day. Beyond that, the performance reverts to the baseline. Your disk budget gets replenished throughout the day.',
+          'The disk performance of your workload is determined by the Disk IO bandwidth.\nSmaller compute instances (below 4XL) can burst up to their largest throughput and IOPS for 30 minutes in a day. Beyond that, the performance reverts to the baseline. Your disk IO budget gets replenished throughout the day.',
         chartDescription: '',
       },
     ],

--- a/apps/studio/components/ui/ResourceExhaustionWarningBanner/ResourceExhaustionWarningBanner.constants.ts
+++ b/apps/studio/components/ui/ResourceExhaustionWarningBanner/ResourceExhaustionWarningBanner.constants.ts
@@ -60,23 +60,23 @@ export const RESOURCE_WARNING_MESSAGES = {
     bannerContent: {
       warning: {
         title:
-          'Your project is about to exhaust its disk space budget, and may become unresponsive once fully exhausted',
+          'Your project is about to exhaust its available disk space, and may become unresponsive once fully exhausted',
         description:
           'You can opt to increase your disk size up to 200GB on the database settings page.',
       },
       critical: {
-        title: 'Your project has exhausted its disk space budget, and may become unresponsive',
+        title: 'Your project has exhausted its available disk space, and may become unresponsive',
         description:
           'You can opt to increase your disk size up to 200GB on the database settings page.',
       },
     },
     cardContent: {
       warning: {
-        title: 'Project is exhausting disk space budget',
+        title: 'Project is exhausting its available disk space',
         description: 'It may become unresponsive if fully exhausted',
       },
       critical: {
-        title: 'Project has exhausted disk space budget',
+        title: 'Project has exhausted its available disk space',
         description: 'It may become unresponsive',
       },
     },


### PR DESCRIPTION
## What kind of change does this PR introduce?

- remove 'budget' terms in disk space related warnings
- add 'IO' in disk budget in disk IO related docs and descriptions
