### PR TITLE
Alternate setup (proxy) cors.mdx

### DIFF
--- a/apps/docs/content/guides/functions/cors.mdx
+++ b/apps/docs/content/guides/functions/cors.mdx
@@ -50,3 +50,59 @@ Deno.serve(async (req) => {
   }
 })
 ```
+
+### Alternate setup (Proxy)
+
+Each ``OPTIONS`` request from the browser to check for CORS counts towards your invocations count. You can get around this by setting up a reverse proxy on your website domain.
+Reverse proxying allow you to send users to different URLs without modifying the visible URL. This prevents any CORS checks as the browser is making a request through the same origin.
+
+Many hosting services like Vercel, Netlify, and Amplify have native support for using a reverse proxy. Let's take a look at how to set up rewrites to proxy requests to Supabase on Vercel [Docs](https://vercel.com/docs/edge-network/rewrites).
+
+First, we need to create a vercel.json file in the root directory of our app, and then add the following. Make sure to replace `<PROJECT_ID>` with your actual supabase project id.
+
+```json vercel.json
+{
+  "rewrites": [
+    {
+      "source": "/functions/v1/:path*",
+      "destination": "https://<PROJECT_ID>.supabase.co/functions/v1/:path*"
+    }
+  ]
+}
+```
+
+You can now trigger functions from the client/browser as if the function was under the same domain. Make sure you don't have any app routes under the same source as configured above.
+```tsx page.tsx
+const response = await fetch('/functions/v1/hello-world', { 
+  method: 'POST', 
+  body: JSON.stringify({ name: 'Supabase' })
+})
+const json = await response.json()
+
+console.log(json) // Output = { message: "Hello Supabase" }
+```
+
+If you have a middleware configured, we can also tell it to ignore Supabase function routes with something like the following:
+```ts middleware.ts
+export const config = {
+  matcher: [
+    /*
+     * Match all request paths except for the ones starting with:
+     * - api (API routes)
+     * - supabase functions
+     * - _next/static (static files)
+     * - _next/image (image optimization files)
+     * - favicon.ico (favicon file)
+     */
+    {
+      source: '/((?!api|functions/v1|_next/static|_next/image|favicon.ico).*)',
+      missing: [
+        { type: 'header', key: 'next-router-prefetch' },
+        { type: 'header', key: 'purpose', value: 'prefetch' },
+      ],
+    },
+  ],
+}
+```
+
+To verify the reverse proxy is working correctly, you can check the network tab in developer tools. You should see the request url as the same origin and the ``X-Served-By`` header equal to ``supabase-edge-runtime``.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update: The existing approach in the docs to invoke edge functions from the browser involves handling CORS preflight requests. This however counts as two function invocation in billing as there is always an OPTION request before the actual request.

The PR proposes adding an alternate approach to the docs showing how to use a simple proxy to route requests through the same origin and avoid CORS checks, therefore only invoking the function once per request.  The proposed approach mentions that hosting providers usually offer a built-in proxy solution, and goes on to show how to setup one for any app hosted on Vercel by configuring the vercel.json file.

## What is the current behavior?

Handling CORS preflight requests, which results in two function invocations per request.

## What is the new behavior?

Add another method for users to choose from to handle sending requests from the browser.

## Additional context

Add any other context or screenshots.

## Might be worth adding guides for Netlify, Cloudflare, etc in the future.
