### PR TITLE
Format numbers in statistics charts

### DIFF
--- a/apps/studio/components/interfaces/Home/ProjectUsage.tsx
+++ b/apps/studio/components/interfaces/Home/ProjectUsage.tsx
@@ -71,6 +71,7 @@ const ProjectUsage = () => {
     endDateLocal.toISOString()
   )
   const datetimeFormat = selectedInterval.format || 'MMM D, ha'
+  const numberFormat = new Intl.NumberFormat()
 
   const handleBarClick = (
     value: UsageApiCounts,
@@ -129,7 +130,7 @@ const ProjectUsage = () => {
                 yAxisKey="total_rest_requests"
                 onBarClick={(v: unknown) => handleBarClick(v as UsageApiCounts, 'rest')}
                 customDateFormat={datetimeFormat}
-                highlightedValue={Intl.NumberFormat("en-US").format(sumBy(charts, 'total_rest_requests'))}
+                highlightedValue={numberFormat.format(sumBy(charts, 'total_rest_requests'))}
               />
             </Loading>
           </Panel.Content>
@@ -154,7 +155,7 @@ const ProjectUsage = () => {
                   yAxisKey="total_auth_requests"
                   onBarClick={(v: unknown) => handleBarClick(v as UsageApiCounts, 'auth')}
                   customDateFormat={datetimeFormat}
-                  highlightedValue={Intl.NumberFormat("en-US").format(sumBy(charts || [], 'total_auth_requests'))}
+                  highlightedValue={numberFormat.format(sumBy(charts || [], 'total_auth_requests'))}
                 />
               </Loading>
             </Panel.Content>
@@ -181,7 +182,7 @@ const ProjectUsage = () => {
                   yAxisKey="total_storage_requests"
                   onBarClick={(v: unknown) => handleBarClick(v as UsageApiCounts, 'storage')}
                   customDateFormat={datetimeFormat}
-                  highlightedValue={Intl.NumberFormat("en-US").format(sumBy(charts, 'total_storage_requests'))}
+                  highlightedValue={numberFormat.format(sumBy(charts, 'total_storage_requests'))}
                 />
               </Loading>
             </Panel.Content>
@@ -206,7 +207,7 @@ const ProjectUsage = () => {
                 yAxisKey="total_realtime_requests"
                 onBarClick={(v: unknown) => handleBarClick(v as UsageApiCounts, 'realtime')}
                 customDateFormat={datetimeFormat}
-                highlightedValue={Intl.NumberFormat("en-US").format(sumBy(charts, 'total_realtime_requests'))}
+                highlightedValue={numberFormat.format(sumBy(charts, 'total_realtime_requests'))}
               />
             </Loading>
           </Panel.Content>

--- a/apps/studio/components/interfaces/Home/ProjectUsage.tsx
+++ b/apps/studio/components/interfaces/Home/ProjectUsage.tsx
@@ -129,7 +129,7 @@ const ProjectUsage = () => {
                 yAxisKey="total_rest_requests"
                 onBarClick={(v: unknown) => handleBarClick(v as UsageApiCounts, 'rest')}
                 customDateFormat={datetimeFormat}
-                highlightedValue={sumBy(charts, 'total_rest_requests')}
+                highlightedValue={Intl.NumberFormat("en-US").format(sumBy(charts, 'total_rest_requests'))}
               />
             </Loading>
           </Panel.Content>
@@ -154,7 +154,7 @@ const ProjectUsage = () => {
                   yAxisKey="total_auth_requests"
                   onBarClick={(v: unknown) => handleBarClick(v as UsageApiCounts, 'auth')}
                   customDateFormat={datetimeFormat}
-                  highlightedValue={sumBy(charts || [], 'total_auth_requests')}
+                  highlightedValue={Intl.NumberFormat("en-US").format(sumBy(charts || [], 'total_auth_requests'))}
                 />
               </Loading>
             </Panel.Content>
@@ -181,7 +181,7 @@ const ProjectUsage = () => {
                   yAxisKey="total_storage_requests"
                   onBarClick={(v: unknown) => handleBarClick(v as UsageApiCounts, 'storage')}
                   customDateFormat={datetimeFormat}
-                  highlightedValue={sumBy(charts, 'total_storage_requests')}
+                  highlightedValue={Intl.NumberFormat("en-US").format(sumBy(charts, 'total_storage_requests'))}
                 />
               </Loading>
             </Panel.Content>
@@ -206,7 +206,7 @@ const ProjectUsage = () => {
                 yAxisKey="total_realtime_requests"
                 onBarClick={(v: unknown) => handleBarClick(v as UsageApiCounts, 'realtime')}
                 customDateFormat={datetimeFormat}
-                highlightedValue={sumBy(charts, 'total_realtime_requests')}
+                highlightedValue={Intl.NumberFormat("en-US").format(sumBy(charts, 'total_realtime_requests'))}
               />
             </Loading>
           </Panel.Content>


### PR DESCRIPTION
Addresses [Format numbers in statistics charts #21740](https://github.com/supabase/supabase/issues/21740#issue-2166945581)

Using `Intl.NumberFormat`, optionally can use the config parameters to set more compact formats for larger numbers (K, M, B).