### PR TITLE
perf: lazyload feature preview modal

### DIFF
--- a/apps/studio/pages/_app.tsx
+++ b/apps/studio/pages/_app.tsx
@@ -57,13 +57,25 @@ import HCaptchaLoadedStore from 'stores/hcaptcha-loaded-store'
 import type { AppPropsWithLayout } from 'types'
 import { Toaster } from 'ui'
 import { FeaturePreviewContextProvider } from 'components/interfaces/App/FeaturePreview/FeaturePreviewContext'
-import FeaturePreviewModal from 'components/interfaces/App/FeaturePreview/FeaturePreviewModal'
+import dynamic from 'next/dynamic'
 
 dayjs.extend(customParseFormat)
 dayjs.extend(utc)
 dayjs.extend(timezone)
 dayjs.extend(relativeTime)
 dart(Prism)
+
+/**
+ * FeaturePreviewModal is quite heavy with react-markdown and other dependencies, not needed on initial load,
+ * so we will load it lazily.
+ */
+const LazyFeaturePreviewModal = dynamic(
+  () =>
+    import('components/interfaces/App/FeaturePreview/FeaturePreviewModal').then(
+      (mod) => mod.default
+    ),
+  { ssr: false }
+)
 
 loader.config({
   // [Joshen] Attempt for offline support/bypass ISP issues is to store the assets required for monaco
@@ -170,7 +182,7 @@ function CustomApp({ Component, pageProps }: AppPropsWithLayout) {
                             <AppBannerWrapper>
                               <FeaturePreviewContextProvider>
                                 {getLayout(<Component {...pageProps} />)}
-                                <FeaturePreviewModal />
+                                <LazyFeaturePreviewModal />
                               </FeaturePreviewContextProvider>
                             </AppBannerWrapper>
                           </CommandMenuWrapper>


### PR DESCRIPTION
The feature preview modal brings in some heavy dependencies such as react-markdown. There is no need to render this in a blocking fashion.

PR aims to load the feature preview modal lazily. Shaves ~16% off the main bundle 🚀 

Tested locally, but please test, too.