### PR TITLE
fix: Cannot access list projects on self-host

### DIFF
--- a/apps/studio/components/interfaces/Home/ProjectList/ProjectCard.tsx
+++ b/apps/studio/components/interfaces/Home/ProjectList/ProjectCard.tsx
@@ -26,7 +26,7 @@ const ProjectCard = ({
   const { name, ref: projectRef } = project
   const desc = `${project.cloud_provider} | ${project.region}`
 
-  const isBranchingEnabled = project.preview_branch_refs.length > 0
+  const isBranchingEnabled = project.preview_branch_refs?.length > 0
   const isGithubIntegrated = githubIntegration !== undefined
   const isVercelIntegrated = vercelIntegration !== undefined
   const githubRepository = githubIntegration?.metadata.name ?? undefined

--- a/apps/studio/components/layouts/AccountLayout/AccountLayout.tsx
+++ b/apps/studio/components/layouts/AccountLayout/AccountLayout.tsx
@@ -1,6 +1,6 @@
 import Head from 'next/head'
 import { useRouter } from 'next/router'
-import { PropsWithChildren } from 'react'
+import { PropsWithChildren, useEffect } from 'react'
 
 import { useOrganizationsQuery } from 'data/organizations/organizations-query'
 import { useFlag, useSelectedOrganization, withAuth } from 'hooks'
@@ -30,6 +30,12 @@ const AccountLayout = ({ children, title, breadcrumbs }: PropsWithChildren<Accou
     await signOut()
     await router.push('/sign-in')
   }
+
+  useEffect(() => {
+    if (!IS_PLATFORM) {
+      router.push('/project/default')
+    }
+  }, [router])
 
   const organizationsLinks = (organizations ?? [])
     .map((organization) => ({


### PR DESCRIPTION
## What kind of change does this PR introduce?
Currently, when self-hosting, accessing `/projects` results in an error. This PR addresses and resolves that issue

## What is the current behavior?
It shows an error:

<img width="1382" alt="Screenshot 2024-03-04 224432" src="https://github.com/supabase/supabase/assets/21276822/ee0da022-c779-45cd-b53c-052632e79fb5">

## What is the new behavior?
We can access to projects page normally.

<img width="746" alt="image" src="https://github.com/supabase/supabase/assets/21276822/476cc34b-e07b-460f-9ab7-d86b3dfb8027">
