### PR TITLE
Fix/#21742 format stats chart numbers

### DIFF
--- a/apps/studio/components/interfaces/Home/ProjectUsage.tsx
+++ b/apps/studio/components/interfaces/Home/ProjectUsage.tsx
@@ -71,7 +71,6 @@ const ProjectUsage = () => {
     endDateLocal.toISOString()
   )
   const datetimeFormat = selectedInterval.format || 'MMM D, ha'
-  const numberFormat = new Intl.NumberFormat()
 
   const handleBarClick = (
     value: UsageApiCounts,
@@ -130,7 +129,7 @@ const ProjectUsage = () => {
                 yAxisKey="total_rest_requests"
                 onBarClick={(v: unknown) => handleBarClick(v as UsageApiCounts, 'rest')}
                 customDateFormat={datetimeFormat}
-                highlightedValue={numberFormat.format(sumBy(charts, 'total_rest_requests'))}
+                highlightedValue={sumBy(charts, 'total_rest_requests')}
               />
             </Loading>
           </Panel.Content>
@@ -155,7 +154,7 @@ const ProjectUsage = () => {
                   yAxisKey="total_auth_requests"
                   onBarClick={(v: unknown) => handleBarClick(v as UsageApiCounts, 'auth')}
                   customDateFormat={datetimeFormat}
-                  highlightedValue={numberFormat.format(sumBy(charts || [], 'total_auth_requests'))}
+                  highlightedValue={sumBy(charts || [], 'total_auth_requests')}
                 />
               </Loading>
             </Panel.Content>
@@ -182,7 +181,7 @@ const ProjectUsage = () => {
                   yAxisKey="total_storage_requests"
                   onBarClick={(v: unknown) => handleBarClick(v as UsageApiCounts, 'storage')}
                   customDateFormat={datetimeFormat}
-                  highlightedValue={numberFormat.format(sumBy(charts, 'total_storage_requests'))}
+                  highlightedValue={sumBy(charts, 'total_storage_requests')}
                 />
               </Loading>
             </Panel.Content>
@@ -207,7 +206,7 @@ const ProjectUsage = () => {
                 yAxisKey="total_realtime_requests"
                 onBarClick={(v: unknown) => handleBarClick(v as UsageApiCounts, 'realtime')}
                 customDateFormat={datetimeFormat}
-                highlightedValue={numberFormat.format(sumBy(charts, 'total_realtime_requests'))}
+                highlightedValue={sumBy(charts, 'total_realtime_requests')}
               />
             </Loading>
           </Panel.Content>

--- a/apps/studio/components/ui/Charts/Charts.utils.tsx
+++ b/apps/studio/components/ui/Charts/Charts.utils.tsx
@@ -15,7 +15,7 @@ dayjs.extend(utc)
  * numberFormatter(123, 2)    // "123.00"
  */
 export const numberFormatter = (num: number, precision = 2) =>
-  isFloat(num) ? precisionFormatter(num, precision) : String(num)
+  isFloat(num) ? precisionFormatter(num, precision) : num.toLocaleString()
 
 /**
  * Tests if a number is a float.
@@ -36,10 +36,10 @@ export const isFloat = (num: number) => String(num).includes('.')
 export const precisionFormatter = (num: number, precision: number): string => {
   if (isFloat(num)) {
     const [head, tail] = String(num).split('.')
-    return head + '.' + tail.slice(0, precision)
+    return Number(head).toLocaleString() + '.' + tail.slice(0, precision)
   } else {
     // pad int with 0
-    return String(num) + '.' + '0'.repeat(precision)
+    return num.toLocaleString() + '.' + '0'.repeat(precision)
   }
 }
 

--- a/apps/studio/tests/components/ui/Charts/Charts.utils.test.ts
+++ b/apps/studio/tests/components/ui/Charts/Charts.utils.test.ts
@@ -13,11 +13,14 @@ test('isFloat', () => {
 test('numberFormatter', () => {
   expect(numberFormatter(123)).toBe('123')
   expect(numberFormatter(123.123)).toBe('123.12')
+  expect(numberFormatter(123456.78)).toBe('123,456.78')
 })
 
 test('precisionFormatter', () => {
   expect(precisionFormatter(123, 1)).toBe('123.0')
   expect(precisionFormatter(123.12345, 4)).toBe('123.1234')
+  expect(precisionFormatter(123456, 2)).toBe('123,456.00')
+  expect(precisionFormatter(123456.78, 2)).toBe('123,456.78')
 })
 
 test('useStacked', () => {


### PR DESCRIPTION
Makes some adjustments to #21742 to allow number formatting in statistics charts in both the default view and when hovered.

The `BarChart` component was already using the `Charts.utils.numberFormatter` helper function to format the chart values, but the helper function did not format large numbers with commas. This PR removes the use of pre-formatted numbers in favor of allowing the BarChart to handle both default and hovered states.
