### PR TITLE
fixed local development link in RBAC docs

### DIFF
--- a/apps/docs/content/guides/auth/custom-claims-and-role-based-access-control-rbac.mdx
+++ b/apps/docs/content/guides/auth/custom-claims-and-role-based-access-control-rbac.mdx
@@ -202,7 +202,7 @@ using (true)
 
 In the dashboard, navigate to [`Authentication > Hooks (Beta)`](/dashboard/project/_/auth/hooks) and select the appropriate PostgreSQL function from the dropdown menu.
 
-When developing locally, follow the [local development](/guides/auth/auth-hooks#local-development) instructions.
+When developing locally, follow the [local development](/docs/guides/auth/auth-hooks#local-development) instructions.
 
 <Admonition type="note">
   


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

Fixed link URL to point to /docs/guides instead of /guides