### PR TITLE
fix: vector.yml include containers

### DIFF
--- a/docker/volumes/logs/vector.yml
+++ b/docker/volumes/logs/vector.yml
@@ -1,3 +1,4 @@
+# You can configure from here https://vector.dev/docs/reference/configuration/
 api:
   enabled: true
   address: 0.0.0.0:9001
@@ -5,8 +6,21 @@ api:
 sources:
   docker_host:
     type: docker_logs
-    exclude_containers:
-      - supabase-vector
+    # only works on this containers
+    include_containers:
+    - supabase-imgproxy
+    - supabase-db
+    - supabase-analytics
+    - supabase-auth
+    - realtime-dev.supabase-realtime
+    - supabase-meta
+    - supabase-rest
+    - supabase-kong
+    - supabase-studio
+    - supabase-edge-functions
+    - supabase-storage
+    - supabase-functions
+    - supabase-realtime
 
 transforms:
   project_logs:


### PR DESCRIPTION

## What kind of change does this PR introduce?

Bug Fix

## What is the current behavior?

[Issue Link](https://github.com/supabase/supabase/issues/21766)

## What is the new behavior?

Within the Timber.io configuration, we have selectively included specific containers to be processed. This decision was made to ensure that Timber.io focuses solely on the logs generated by the included containers. Excluding other containers from this process was intentional, as it prevents Timber.io from reading logs originating from every container, providing a more targeted and streamlined log collection strategy.
