### PR TITLE
fix: handle non-dates in chart header label

### DIFF
--- a/apps/studio/components/ui/Charts/BarChart.tsx
+++ b/apps/studio/components/ui/Charts/BarChart.tsx
@@ -47,12 +47,22 @@ const BarChart = ({
     return <ChartNoData message={emptyStateMessage} size={size} className={className} />
 
   const day = (value: number | string) => (displayDateInUtc ? dayjs(value).utc() : dayjs(value))
-  const resolvedHighlightedLabel =
-    (focusDataIndex !== null &&
-      data &&
-      data[focusDataIndex] !== undefined &&
-      day(data[focusDataIndex][xAxisKey]).format(customDateFormat)) ||
-    highlightedLabel
+
+  function getHeaderLabel() {
+    if (!xAxisIsDate) {
+      if (!focusDataIndex) return highlightedLabel
+      return data[focusDataIndex]?.[xAxisKey]
+    }
+    return (
+      (focusDataIndex !== null &&
+        data &&
+        data[focusDataIndex] !== undefined &&
+        day(data[focusDataIndex][xAxisKey]).format(customDateFormat)) ||
+      highlightedLabel
+    )
+  }
+
+  const resolvedHighlightedLabel = getHeaderLabel()
 
   const resolvedHighlightedValue =
     focusDataIndex !== null ? data[focusDataIndex]?.[yAxisKey] : highlightedValue


### PR DESCRIPTION
## What kind of change does this PR introduce?

If the X axis is not a valid date, the chart header will not show the label, it will show "Invalid Date" instead. This fixes this case.

## What is the new behavior?

If the x axis label is not a valid date it will just render whatever the value is. 
For example, a chart with total population (Y) and country names (X) will show the country name in the chart header

## Additional context

### BEFORE
![CleanShot 2024-03-05 at 12 07 50@2x](https://github.com/supabase/supabase/assets/37541088/1346c18c-7360-4c46-9abf-9d5b4f6e04da)


### AFTER
![CleanShot 2024-03-05 at 12 07 28@2x](https://github.com/supabase/supabase/assets/37541088/53cb7ad0-943b-4ab5-9005-97fdbf4023ad)

