### PR TITLE
docs: fix link

### DIFF
--- a/apps/docs/content/guides/database/testing.mdx
+++ b/apps/docs/content/guides/database/testing.mdx
@@ -63,6 +63,6 @@ Result: PASS
 
 ## More resources
 
-- [Testing RLS policies](/docs/guides/auth/row-level-security#testing-policies)
+- [Testing RLS policies](/docs/guides/database/extensions/pgtap#testing-rls-policies)
 - [pgTAP extension](/docs/guides/database/extensions/pgtap)
 - Official [pgTAP documentation](https://pgtap.org/)


### PR DESCRIPTION
the original link goes to a valid page (though the anchor is not valid) but the page is not relevant for testing

would be nice to have a link checker

