### PR TITLE
docs: update auth-ui.mdx

### DIFF
--- a/apps/docs/content/guides/auth/auth-helpers/auth-ui.mdx
+++ b/apps/docs/content/guides/auth/auth-helpers/auth-ui.mdx
@@ -470,3 +470,14 @@ Setting `showLinks` to `false` will hide the following links:
 - Already have an account? Sign in
 - Send a magic link email
 - Forgot your password?
+
+### Sign in and Sign up views
+
+Add `sign_in` or `sign_up` views with the `view` prop:
+
+```
+<Auth
+  supabaseClient={supabase}
+  view="sign_up"
+/>
+```


### PR DESCRIPTION
Add instructions for the "view" prop and "sign_up" and "sign_in" values

## What kind of change does this PR introduce?

Doc update.

## What is the current behavior?

It does not have information about the view prop for the auth-ui. I was only able to find it in a StackOverflow post: https://stackoverflow.com/questions/76704330/supabase-auth-ui-show-the-sign-up-ui-not-the-sign-in-ui

## What is the new behavior?

Directions on the view prop for sign_up and sign_in values.

## Additional information

If this information is noted elsewhere in the current docs, I'd love to get a link so I can reference it in the future!
