### PR TITLE
fix: fix color of ai code blocks in light mode

### DIFF
--- a/packages/ui/src/components/CodeBlock/CodeBlock.tsx
+++ b/packages/ui/src/components/CodeBlock/CodeBlock.tsx
@@ -98,7 +98,7 @@ export const CodeBlock = ({
             // @ts-ignore
             style={monokaiTheme}
             className={cn(
-              'code-block border border-surface p-4 w-full !my-0 bg-surface-100',
+              'code-block border border-surface p-4 w-full !my-0 !bg-surface-100',
               `${!title ? '!rounded-md' : '!rounded-t-none !rounded-b-md'}`,
               `${!showLineNumbers ? 'pl-6' : ''}`,
               className


### PR DESCRIPTION
Before:
<img width="779" alt="image" src="https://github.com/supabase/supabase/assets/26616127/e94038f7-85e3-4915-a624-b261ef4ac86e">

After:
<img width="780" alt="image" src="https://github.com/supabase/supabase/assets/26616127/8c056efd-6f5e-4a3c-8cb1-293e45a23318">
