### PR TITLE
docs: Removes `overrideParams` from the docs code

### DIFF
--- a/apps/docs/components/reference/RefFunctionSection.tsx
+++ b/apps/docs/components/reference/RefFunctionSection.tsx
@@ -57,18 +57,9 @@ const RefFunctionSection: React.FC<IRefFunctionSection> = (props) => {
                 <h5 className="mb-3 text-base text-foreground">Parameters</h5>
                 <ul>
                   {parameters.map((param) => {
-                    // grab override params from yaml file
-                    const overrideParams = item.overrideParams
-
-                    // params from the yaml file can override the params from parameters if it matches the name
-                    const overide = overrideParams?.filter((x) => {
-                      return param.name === x.name
-                    })
-
-                    const paramItem = overide?.length > 0 ? overide[0] : param
                     return (
-                      <Param {...paramItem} key={param.name}>
-                        {paramItem.subContent && (
+                      <Param {...param} key={param.name}>
+                        {param.subContent && (
                           <div className="mt-3">
                             <Options>
                               {param.subContent.map((param) => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Now that we have the `params` parameter on the reference docs, we don't need the `overrideParams` related code on the docs codebase as `overrideParams` parameter is not being used anywhere. This PR removes them to avoid future confusion.

Related https://github.com/supabase/supabase/pull/21708