### PR TITLE
docs: add note re: requirement of PG14+ for read-only db role

### DIFF
--- a/apps/docs/content/guides/platform/access-control.mdx
+++ b/apps/docs/content/guides/platform/access-control.mdx
@@ -36,8 +36,8 @@ Each Supabase organization can have one or more owners. If you no longer want be
 
 The table below shows the corresponding permissions for each available role you can assign a team member in the Dashboard.
 
-| Permissions              | Owner                   | Administrator           | Developer               | Read only [^2]          |
-| ------------------------ | ----------------------- | ----------------------- | ----------------------- | ----------------------- |
+| Permissions              | Owner                   | Administrator           | Developer               | Read only [^2]                                  |
+| ------------------------ | ----------------------- | ----------------------- | ----------------------- | ----------------------------------------------- |
 | **Organization**         |
 | Change organization name | <IconCheck size={14} /> |                         |                         |
 | Delete organization      | <IconCheck size={14} /> |                         |                         |
@@ -71,7 +71,7 @@ The table below shows the corresponding permissions for each available role you 
 | Resume a project         | <IconCheck size={14} /> | <IconCheck size={14} /> |                         |
 | Restart a project        | <IconCheck size={14} /> | <IconCheck size={14} /> | <IconCheck size={14} /> |
 | Manage tables            | <IconCheck size={14} /> | <IconCheck size={14} /> | <IconCheck size={14} /> |
-| View Data                | <IconCheck size={14} /> | <IconCheck size={14} /> | <IconCheck size={14} /> | <IconCheck size={14} /> |
+| View Data                | <IconCheck size={14} /> | <IconCheck size={14} /> | <IconCheck size={14} /> | <IconCheck className="inline" size={14} /> [^3] |
 
 [^1]:
     Invites sent from a SSO account can only be accepted by another SSO account
@@ -80,3 +80,6 @@ The table below shows the corresponding permissions for each available role you 
     enterprise systems.
 
 [^2]: Available on the Teams and Enterprise Plans.
+[^3]:
+    Only available on projects using PostgreSQL 14 and above. You can upgrade
+    your project through [infrastructure settings](https://supabase.com/dashboard/project/_/settings/infrastructure).


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

no warning re: the need for PG14+ to use the read-only db role

## What is the new behavior?

warn of the need to be PG14+

<img width="510" alt="Screenshot 2024-03-06 at 13 20 16" src="https://github.com/supabase/supabase/assets/31685197/68066220-5884-4c21-8ffe-1bddd4541e0e">

(icons are not aligned - would appreciate some help with that)