### PR TITLE
fix: RLS Policy template for insert based on user_id

### DIFF
--- a/apps/studio/components/interfaces/Auth/Policies/PolicyEditorModal/PolicyEditorModal.constants.ts
+++ b/apps/studio/components/interfaces/Auth/Policies/PolicyEditorModal/PolicyEditorModal.constants.ts
@@ -101,7 +101,7 @@ for insert using (
 );`.trim(),
     name: 'Enable insert for users based on user_id',
     definition: 'auth.uid() = user_id',
-    check: 'true',
+    check: 'auth.uid() = user_id',
     command: 'INSERT',
     roles: [],
   },


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix to enter the same policy as the template.

```
create policy "Enable insert for users based on user_id"
on public.test
for insert using (
  auth.uid() = user_id
) with check (
  auth.uid() = user_id  //<- this
);
```

## What is the current behavior?

![스크린샷 2024-03-06 오후 6 28 39](https://github.com/supabase/supabase/assets/48237511/6c0acfc5-5859-4b58-9121-48414d07f08a)

## What is the new behavior?

![스크린샷 2024-03-06 오후 6 28 17](https://github.com/supabase/supabase/assets/48237511/0abb50e0-4ca9-449b-8753-34f3b37134a0)
