### PR TITLE
updated deprecated Sentry config

### DIFF
--- a/apps/docs/content/guides/platform/sentry-monitoring.mdx
+++ b/apps/docs/content/guides/platform/sentry-monitoring.mdx
@@ -184,7 +184,7 @@ Sentry.init({
       breadcrumbs: true,
       errors: true,
     }),
-    new Sentry.BrowserTracing({
+    Sentry.browserTracingIntegration({
       shouldCreateSpanForRequest: (url) => {
         return !url.startsWith(`${process.env.NEXT_PUBLIC_SUPABASE_URL}/rest`)
       },


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

`new Sentry.BrowserTracing - @deprecated — Use browserTracingIntegration instead.`