### PR TITLE
docs: fix typo in nextjs tutorial

### DIFF
--- a/apps/docs/content/guides/getting-started/tutorials/with-nextjs.mdx
+++ b/apps/docs/content/guides/getting-started/tutorials/with-nextjs.mdx
@@ -350,7 +350,7 @@ export async function updateSession(request) {
 
 <TabPanel id="ts" label="TypeScript">
 
-Create a `middleware.ts` file at the project root and another one within the `util/ssupbase` folder. The `utils/supabase` file contains the logic for updating the session. This is used by the `middleware.js` file, which is a Next.js convention.
+Create a `middleware.ts` file at the project root and another one within the `util/supabase` folder. The `utils/supabase` file contains the logic for updating the session. This is used by the `middleware.js` file, which is a Next.js convention.
 
 <CH.Code className="min-h-[30rem]">
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

specifically happens in the Typescript tab
<img width="822" alt="image" src="https://github.com/supabase/supabase/assets/79728151/2fb9544e-ccd1-45fb-971d-1e4810ab9b4e">

## What is the new behavior?

"`util/supabase`" instead of "`util/ssupbase`"
