### PR TITLE
feat/table name whitespace

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.tsx
@@ -177,7 +177,7 @@ const TableEditor = ({
 
       if (isEmpty(errors)) {
         const payload = {
-          name: tableFields.name,
+          name: tableFields.name.trim(),
           schema: snap.selectedSchemaName,
           comment: tableFields.comment,
           ...(!isNewRecord && { rls_enabled: tableFields.isRLSEnabled }),


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase Studio - Table Editor

## What is the current behavior?

When you create a table with ending white space you can not use the table in the SQL Editor

## What is the new behavior?

When adding a new table or updating the table name the name automatically gets trimmed.

## Additional context

Discussed in #21842
