### PR TITLE
docs: update postgress CDC message

### DIFF
--- a/apps/docs/content/guides/realtime/protocol.mdx
+++ b/apps/docs/content/guides/realtime/protocol.mdx
@@ -115,8 +115,7 @@ To update the access token, you need to send to the server a message specifying 
 
 ## Postgres CDC message
 
-Realtime sends a message with the following structure
-
+Realtime sends a message with the following structure. By default, the payload only includes new record changes, and the `old` entry includes the changed row's primary id. If you want to receive old records, you can set the replicate identity of your table to full. Check out [this section of the guide](/docs/guides/realtime/postgres-changes#receiving-old-records).
 ```ts
 {
    "event": "postgres_changes",
@@ -128,7 +127,7 @@ Realtime sends a message with the following structure
          commit_timestamp: string,
          eventType: "*" | "INSERT" | "UPDATE" | "DELETE",
          new: {[key: string]: boolean | number | string | null},
-         old: {[key:string]: number | string},
+         old: {[key: string]: number | string},
          errors: string | null
       },
       "ids": Array<number>

--- a/apps/docs/content/guides/realtime/protocol.mdx
+++ b/apps/docs/content/guides/realtime/protocol.mdx
@@ -116,6 +116,7 @@ To update the access token, you need to send to the server a message specifying 
 ## Postgres CDC message
 
 Realtime sends a message with the following structure. By default, the payload only includes new record changes, and the `old` entry includes the changed row's primary id. If you want to receive old records, you can set the replicate identity of your table to full. Check out [this section of the guide](/docs/guides/realtime/postgres-changes#receiving-old-records).
+
 ```ts
 {
    "event": "postgres_changes",

--- a/apps/docs/content/guides/realtime/protocol.mdx
+++ b/apps/docs/content/guides/realtime/protocol.mdx
@@ -123,14 +123,13 @@ Realtime sends a message with the following structure
    "topic": string,
    "payload": {
       "data": {
-         "columns": Array<{name: string, type: string}>,
-         "commit_timestamp": string,
-         "errors": null | string,
-         "old_record": {"id": number | string},
-         "record": {[key: string]: boolean | number | string | null},
-         "type": "*" | "INSERT" | "UPDATE" | "DELETE",
-         "schema": string,
-         "table": string
+         schema: string,
+         table: string,
+         commit_timestamp: string,
+         eventType: "*" | "INSERT" | "UPDATE" | "DELETE",
+         new: {[key: string]: boolean | number | string | null},
+         old: {[key:string]: number | string},
+         errors: string | null
       },
       "ids": Array<number>
    },


### PR DESCRIPTION
## What kind of change does this PR introduce?
According to #21660, the structure of the documented Postgres CDC message is outdated with the current message. This PR updates the docs.

## What is the current behavior?
The main difference is in the **payload**.

The current structure and instructions:
<img width="822" alt="image" src="https://github.com/supabase/supabase/assets/62190721/89029441-844e-44ef-9d7e-06c846131673">

## What is the new behavior?

The new structure and updated instructions:
<img width="815" alt="image" src="https://github.com/supabase/supabase/assets/62190721/c292e809-4e5d-4dfa-bf81-fe71efb2d0a6">


## Additional context
