### PR TITLE
fix: SQL editor charts performance

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/ChartConfig.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/ChartConfig.tsx
@@ -74,7 +74,6 @@ export function ChartConfig({ results = { rows: [] }, config, onConfigChange }: 
       y: row[config.yKey],
     }))
     const downsampledResults = LTTB(resultsToDownsample, 100) as { x: string; y: number }[]
-    console.log('DEBUG downsampled', downsampledResults)
 
     resultToRender = downsampledResults.map((row: { x: any; y: any }) => ({
       [config.xKey]: resultToRender[row.x][config.xKey],
@@ -192,7 +191,6 @@ export function ChartConfig({ results = { rows: [] }, config, onConfigChange }: 
                 name="cumulative"
                 checked={config.cumulative}
                 onClick={(e) => {
-                  console.log(e)
                   onConfigChange({ ...config, cumulative: !config.cumulative })
                 }}
               />

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -48,6 +48,7 @@
     "config": "*",
     "configcat-js": "^7.0.0",
     "dayjs": "^1.11.10",
+    "downsample": "^1.4.0",
     "file-saver": "^2.0.5",
     "framer-motion": "^11.0.3",
     "generate-password-browser": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2002,6 +2002,7 @@
         "config": "*",
         "configcat-js": "^7.0.0",
         "dayjs": "^1.11.10",
+        "downsample": "^1.4.0",
         "file-saver": "^2.0.5",
         "framer-motion": "^11.0.3",
         "generate-password-browser": "^1.1.0",
@@ -21174,6 +21175,11 @@
       "version": "0.1.2",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/downsample": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/downsample/-/downsample-1.4.0.tgz",
+      "integrity": "sha512-teYPhUPxqwtyICt47t1mP/LjhbRV/ghuKb/LmFDbcZ0CjqFD31tn6rVLZoeCEa1xr8+f2skW8UjRiLiGIKQE4w=="
     },
     "node_modules/duplexer": {
       "version": "0.1.2",


### PR DESCRIPTION
## What kind of change does this PR introduce?

- downsample data when above 300 results for performance and readability

## What is the current behavior?

the chart will be unreadable or even crash with too many results.

## What is the new behavior?

we downsample the data with LTTB to maintain perf and readability
