### PR TITLE
fix: the pagination of storage is not functioning on self-hosted systems

### DIFF
--- a/apps/studio/pages/api/storage/[ref]/buckets/[id]/objects/list.ts
+++ b/apps/studio/pages/api/storage/[ref]/buckets/[id]/objects/list.ts
@@ -23,7 +23,7 @@ const handlePost = async (req: NextApiRequest, res: NextApiResponse) => {
   const { id } = req.query
   const { path, ...params } = req.body
 
-  const { data, error } = await supabase.storage.from(id as string).list(path, params)
+  const { data, error } = await supabase.storage.from(id as string).list(path, params.options)
   if (error) {
     return res.status(500).json({ error: error.message })
   }


### PR DESCRIPTION
## What kind of change does this PR introduce?

fixes: https://github.com/supabase/supabase/issues/21914

## What is the current behavior?

Currently, when we access storage and select a bucket, it displays only the first 100 items, and we are unable to search for items. This issue occurs because we did not pass options in the request, resulting in always showing the default first 100 items.

## What is the new behavior?

We passed the options in the request.

## Additional context

After fixed:

<img width="718" alt="image" src="https://github.com/supabase/supabase/assets/21276822/58bb5119-c9a8-4981-b892-b5bdf458d27e">

<img width="1618" alt="image" src="https://github.com/supabase/supabase/assets/21276822/5ff94c00-5d43-4a3b-82d0-273f6ee5e154">

