### PR TITLE
fix(sql editor): add padding to see last results when scrolling

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/Results.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/Results.tsx
@@ -91,7 +91,7 @@ const Results = ({ id, rows }: { id: string; rows: readonly any[] }) => {
         columns={columns}
         rows={rows}
         // style={{ height: '100%' }}
-        className="flex-grow border-t-0"
+        className="flex-grow border-t-0 pb-24"
         rowClass={() => '[&>.rdg-cell]:items-center'}
         onSelectedCellChange={onSelectedCellChange}
       />


### PR DESCRIPTION
# without padding
![CleanShot 2024-03-11 at 17 07 03@2x](https://github.com/supabase/supabase/assets/37541088/3e66bd8c-5aa6-4275-ae09-4eb6d3d0f6ba)

# with padding
![CleanShot 2024-03-11 at 17 06 50@2x](https://github.com/supabase/supabase/assets/37541088/372e103a-af35-4ec2-bde2-a2c9d2e463b3)
