### PR TITLE
docs: clarify cli upgrade process with logical backup

### DIFF
--- a/apps/docs/content/guides/cli/getting-started.mdx
+++ b/apps/docs/content/guides/cli/getting-started.mdx
@@ -123,11 +123,11 @@ npm update supabase --save-dev
 </TabPanel>
 </Tabs>
 
-If you have any Supabase containers running locally, you want to stop them and delete their data volumes before proceeding with the upgrade. This ensures that new migrations of Supabase managed services can be run against a clean state of the local database.
+If you have any Supabase containers running locally, stop them and delete their data volumes before proceeding with the upgrade. This ensures that Supabase managed services can apply new migrations on a clean state of the local database.
 
 <Admonition type="tip" label="Logical backup">
 
-Remember to save any local schema and data changes before stopping as they will be deleted by `--no-backup` flag.
+Remember to save any local schema and data changes before stopping because the `--no-backup` flag will delete them.
 
 ```sh
 supabase db diff my_schema

--- a/apps/docs/content/guides/cli/getting-started.mdx
+++ b/apps/docs/content/guides/cli/getting-started.mdx
@@ -127,16 +127,16 @@ If you have any Supabase containers running locally, you want to stop them and d
 
 <Admonition type="tip" label="Logical backup">
 
-Remember to save any local schema and data changes you've made before stopping, as they will be deleted by `--no-backup` flag.
+Remember to save any local schema and data changes before stopping as they will be deleted by `--no-backup` flag.
 
-```bash
+```sh
 supabase db diff my_schema
 supabase db dump --local --data-only > supabase/seed.sql
 ```
 
 </Admonition>
 
-```bash 
+```sh
 supabase stop --no-backup
 supabase start
 ```

--- a/apps/docs/content/guides/cli/getting-started.mdx
+++ b/apps/docs/content/guides/cli/getting-started.mdx
@@ -123,9 +123,20 @@ npm update supabase --save-dev
 </TabPanel>
 </Tabs>
 
-If you have any Supabase containers running locally, remember to restart them after upgrading to use the new features.
+If you have any Supabase containers running locally, you want to stop them and delete their data volumes before proceeding with the upgrade. This ensures that new migrations of Supabase managed services can be run against a clean state of the local database.
+
+<Admonition type="tip" label="Logical backup">
+
+Remember to save any local schema and data changes you've made before stopping, as they will be deleted by `--no-backup` flag.
 
 ```bash
+supabase db diff my_schema
+supabase db dump --local --data-only > supabase/seed.sql
+```
+
+</Admonition>
+
+```bash 
 supabase stop --no-backup
 supabase start
 ```


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

Unclear why we need to `stop --no-backup` before upgrade.

## What is the new behavior?

Suggest saving local schema and data changes before upgrade.

## Additional context

Add any other context or screenshots.
