### PR TITLE
SQl editor wrap errors instead of overflow scroll

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityTabResults.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityTabResults.tsx
@@ -104,10 +104,10 @@ const UtilityTabResults = ({ id, isExecuting }: UtilityTabResultsProps) => {
               </p>
             </div>
           ) : (
-            <div className="overflow-x-auto">
+            <div className="">
               {formattedError.length > 0 ? (
                 formattedError.map((x: string, i: number) => (
-                  <pre key={`error-${i}`} className="font-mono text-sm">
+                  <pre key={`error-${i}`} className="font-mono text-sm text-wrap">
                     {x}
                   </pre>
                 ))


### PR DESCRIPTION
Before:
![image](https://github.com/supabase/supabase/assets/19742402/5feb08c3-1003-4c69-a0a3-82b83aa6fbb9)

After:
![image](https://github.com/supabase/supabase/assets/19742402/d36a42be-e4d9-49ad-a1fe-c5c64519d30b)
