### PR TITLE
fix: Add spacing between branch name and text

### DIFF
--- a/apps/studio/components/interfaces/BranchManagement/BranchManagement.tsx
+++ b/apps/studio/components/interfaces/BranchManagement/BranchManagement.tsx
@@ -337,7 +337,7 @@ const BranchManagement = () => {
         alert={{ title: 'You cannot recover this branch once deleted' }}
         text={
           <>
-            This will delete your database preview branch
+            This will delete your database preview branch{' '}
             <span className="text-bold text-foreground">{selectedBranchToDelete?.name}</span>.
           </>
         }


### PR DESCRIPTION
Without it, it's stuck together, preventing line breaks

<img width="387" alt="image" src="https://github.com/supabase/supabase/assets/1523305/fe9f9a58-a431-40f0-87e5-4488fca1b890">