### PR TITLE
ref: Add GitHub configuration/revoke links for better UX

### DIFF
--- a/apps/studio/components/interfaces/Organization/IntegrationSettings/IntegrationSettings.tsx
+++ b/apps/studio/components/interfaces/Organization/IntegrationSettings/IntegrationSettings.tsx
@@ -20,6 +20,11 @@ import { useSidePanelsStateSnapshot } from 'state/side-panels'
 import { IntegrationConnectionItem } from '../../Integrations/IntegrationConnection'
 import SidePanelGitHubRepoLinker from './SidePanelGitHubRepoLinker'
 import SidePanelVercelProjectLinker from './SidePanelVercelProjectLinker'
+import { useGitHubAuthorizationQuery } from 'data/integrations/github-authorization-query'
+import {
+  GITHUB_INTEGRATION_INSTALLATION_URL,
+  GITHUB_INTEGRATION_REVOKE_AUTHORIZATION_URL,
+} from 'lib/github'
 
 const IntegrationImageHandler = ({ title }: { title: 'vercel' | 'github' }) => {
   return (
@@ -34,6 +39,8 @@ const IntegrationImageHandler = ({ title }: { title: 'vercel' | 'github' }) => {
 const IntegrationSettings = () => {
   const org = useSelectedOrganization()
   const hasAccessToBranching = useFlag<boolean>('branchManagement')
+  const { data: gitHubAuthorization, isLoading: isLoadingGitHubAuthorization } =
+    useGitHubAuthorizationQuery()
   const { data: connections } = useGitHubConnectionsQuery({ organizationId: org?.id })
 
   const { mutate: deleteGitHubConnection } = useGitHubConnectionDeleteMutation({
@@ -79,6 +86,10 @@ Connect any of your GitHub repositories to a project.
 You will be able to connect a GitHub repository to a Supabase project.
 The GitHub app will watch for changes in your repository such as file changes, branch changes as well as pull request activity.
 `
+
+  const GitHubContentSectionBottom = gitHubAuthorization
+    ? `You are authorized with Supabase GitHub App. You can configure your GitHub App installations and repository access [here](${GITHUB_INTEGRATION_INSTALLATION_URL}). You can revoke your authorization [here](${GITHUB_INTEGRATION_REVOKE_AUTHORIZATION_URL}).`
+    : ''
 
   const GitHubSection = () => (
     <ScaffoldContainer>
@@ -136,6 +147,9 @@ The GitHub app will watch for changes in your repository such as file changes, b
               </a>{' '}
               is required to add GitHub connections.
             </p>
+          )}
+          {GitHubContentSectionBottom && (
+            <Markdown content={GitHubContentSectionBottom} className="text-foreground-lighter" />
           )}
         </ScaffoldSectionContent>
       </ScaffoldSection>

--- a/apps/studio/lib/github.tsx
+++ b/apps/studio/lib/github.tsx
@@ -1,9 +1,9 @@
-const GITHUB_INTEGRATION_INSTALLATION_URL =
+const GITHUB_INTEGRATION_APP_NAME =
   process.env.NEXT_PUBLIC_ENVIRONMENT === 'prod'
-    ? `https://github.com/apps/supabase/installations/new`
+    ? `supabase`
     : process.env.NEXT_PUBLIC_ENVIRONMENT === 'staging'
-      ? `https://github.com/apps/supabase-staging/installations/new`
-      : `https://github.com/apps/supabase-local-testing/installations/new`
+      ? `supabase-staging`
+      : `supabase-local-testing`
 
 const GITHUB_INTEGRATION_CLIENT_ID =
   process.env.NEXT_PUBLIC_ENVIRONMENT === 'prod'
@@ -13,6 +13,8 @@ const GITHUB_INTEGRATION_CLIENT_ID =
       : `Iv1.5022a3b44d150fbf`
 
 const GITHUB_INTEGRATION_AUTHORIZATION_URL = `https://github.com/login/oauth/authorize?client_id=${GITHUB_INTEGRATION_CLIENT_ID}`
+export const GITHUB_INTEGRATION_INSTALLATION_URL = `https://github.com/apps/${GITHUB_INTEGRATION_APP_NAME}/installations/new`
+export const GITHUB_INTEGRATION_REVOKE_AUTHORIZATION_URL = `https://github.com/settings/connections/applications/${GITHUB_INTEGRATION_CLIENT_ID}`
 
 export function openInstallGitHubIntegrationWindow(type: 'install' | 'authorize') {
   const w = 600


### PR DESCRIPTION
On organization "Integrations" tab, users will now see this nice footer, that will point them exactly where they need to go in order to revoke/configure authorization/app.

We do not render this info on a specific project's page.

<img width="566" alt="image" src="https://github.com/supabase/supabase/assets/1523305/2519446a-4b9f-482a-badc-7c5d496ac202">

(fixed missing dot from the end of the screenshot)