### PR TITLE
(docs): fix return type error for futureBuilder

### DIFF
--- a/apps/docs/content/guides/getting-started/quickstarts/flutter.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/flutter.mdx
@@ -143,7 +143,7 @@ hideToc: true
         @override
         Widget build(BuildContext context) {
           return Scaffold(
-            body: FutureBuilder<List<Map<String, dynamic>>>(
+            body: FutureBuilder(
               future: _future,
               builder: (context, snapshot) {
                 if (!snapshot.hasData) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

This code change fixes an error where the return type for the future builder is not the same as the future that is being passed

## What is the current behavior?

The current behavior is the following error message is displayed when the code is copied and pasted from the documentation: `The argument type 'PostgrestFilterBuilder<dynamic>' can't be assigned to the parameter type 'Future<List<Map<String, dynamic>>>?'.`

## What is the new behavior?

The new behavior is the code works as expected once we remove the return type of `<List<Map<String, dynamic>>>`

<img width="1227" alt="Screenshot 2024-03-14 at 11 47 06 PM" src="https://github.com/supabase/supabase/assets/20735369/0276b2a0-cae0-4273-b517-ad08be7bb25f">

