### PR TITLE
chore: temporarily turn off docs feedback comments

### DIFF
--- a/apps/docs/components/Feedback/Feedback.tsx
+++ b/apps/docs/components/Feedback/Feedback.tsx
@@ -178,12 +178,14 @@ function Feedback() {
           )}
         >
           <span className="text-foreground-light">Thanks for your feedback!</span>
+          {/**
           <FeedbackButton
             ref={feedbackButtonRef}
             onClick={() => setModalOpen(true)}
             isYes={isYes}
             visible={!unanswered}
           />
+          */}
         </div>
       </div>
       <FeedbackModal


### PR DESCRIPTION
temporarily turning off the comment function on feedback until we can route it away from hubspot and support's workload

voting is still possible