### PR TITLE
fix: stripe wrapper not working as expected in self hosted

### DIFF
--- a/apps/studio/pages/api/pg-meta/[ref]/foreign-tables.ts
+++ b/apps/studio/pages/api/pg-meta/[ref]/foreign-tables.ts
@@ -13,6 +13,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
 
   switch (method) {
     case 'GET':
+      if (req.query.id) return handleGetOne(req, res)
       return handleGetAll(req, res)
     default:
       res.setHeader('Allow', ['GET'])
@@ -23,6 +24,17 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
 const handleGetAll = async (req: NextApiRequest, res: NextApiResponse) => {
   const headers = constructHeaders(req.headers)
   let response = await get(`${PG_META_URL}/foreign-tables`, {
+    headers,
+  })
+  if (response.error) {
+    return res.status(400).json({ error: response.error })
+  }
+  return res.status(200).json(response)
+}
+
+const handleGetOne = async (req: NextApiRequest, res: NextApiResponse) => {
+  const headers = constructHeaders(req.headers)
+  let response = await get(`${PG_META_URL}/foreign-tables/${req.query.id}`, {
     headers,
   })
   if (response.error) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

fixes: https://github.com/supabase/supabase/issues/20891

## What is the current behavior?

Currently, when we add a new Stripe wrapper, it will throw an exception when you access that table in the Table Editor. This is because, in the self-hosted version, we do not yet support querying a foreign table with a specific ID.

## What is the new behavior?

Update the foreign table endpoint to support querying with a specific ID

<img width="970" alt="image" src="https://github.com/supabase/supabase/assets/21276822/e55101a9-7163-432b-80c9-9301fddb08c9">


## Additional context

Add any other context or screenshots.
