### PR TITLE
feat: alert for white space on field names

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.utils.ts
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.utils.ts
@@ -21,6 +21,9 @@ export const validateFields = (field: TableField) => {
   if (some(field.columns, (column: ColumnField) => column.name.length === 0)) {
     errors['columns'] = 'Ensure that all your columns are named'
   }
+  if (some(field.columns, (column: ColumnField) => /^\s|\s$/.test(column.name))) {
+    errors['columns'] = 'Ensure that all your columns dont have starting or ending whitespace'
+  }
   return errors
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Supabase Studio - Table Editor

## What is the current behavior?

From the table editor you can add/update column names with an starting or ending white space which can cause issues when querying.

## What is the new behavior?

An error now appears which does not allow the user to do this.


https://github.com/supabase/supabase/assets/22655069/0d91b799-d242-451e-9b5c-4b5454831482



## Additional context

Closes #22089 
