### PR TITLE
Storage delete bucket modal fix styling

### DIFF
--- a/apps/studio/components/layouts/StorageLayout/BucketRow.tsx
+++ b/apps/studio/components/layouts/StorageLayout/BucketRow.tsx
@@ -15,6 +15,7 @@ import {
   IconLoader,
   IconTrash,
   IconXCircle,
+  cn,
 } from 'ui'
 
 import type { Bucket } from 'data/storage/buckets-query'
@@ -50,7 +51,7 @@ const BucketRow = ({
       {/* Even though we trim whitespaces from bucket names, there may be some existing buckets with trailing whitespaces. */}
       <Link
         href={`/project/${projectRef}/storage/buckets/${encodeURIComponent(bucket.id)}`}
-        className="py-1 px-3 w-full"
+        className={cn('py-1 px-3', isSelected ? 'w-[88%]' : 'w-full')}
       >
         <div className="flex items-center justify-between space-x-2 truncate w-full">
           <p
@@ -64,22 +65,16 @@ const BucketRow = ({
           {bucket.public && <Badge variant="warning">Public</Badge>}
         </div>
       </Link>
-      {/* [JOSHEN TODO] need to change this */}
-      {false ? (
-        <IconLoader className="animate-spin" size={16} strokeWidth={2} />
-      ) : canUpdateBuckets && isSelected ? (
+      {canUpdateBuckets && isSelected ? (
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button
-              asChild
               type="text"
               icon={
                 <IconChevronDown size="tiny" strokeWidth={2} className="text-foreground-light" />
               }
               className="mr-1 p-0.5"
-            >
-              <span></span>
-            </Button>
+            />
           </DropdownMenuTrigger>
           <DropdownMenuContent side="bottom" align="start">
             <DropdownMenuItem

--- a/apps/studio/components/to-be-cleaned/Storage/DeleteBucketModal.tsx
+++ b/apps/studio/components/to-be-cleaned/Storage/DeleteBucketModal.tsx
@@ -89,7 +89,7 @@ const DeleteBucketModal = ({ visible = false, bucket, onClose }: DeleteBucketMod
         title: 'You cannot recover this bucket once deleted.',
         description: 'All bucket data will be lost.',
       }}
-      confirmLabel={`Delete bucket ${bucket?.name}`}
+      confirmLabel="Delete bucket"
     />
   )
 }

--- a/packages/ui-patterns/Dialogs/TextConfirmModal.tsx
+++ b/packages/ui-patterns/Dialogs/TextConfirmModal.tsx
@@ -117,7 +117,7 @@ const TextConfirmModal = forwardRef<
           }
         }}
       >
-        <DialogContent ref={ref} className="p-0 gap-0 pb-5" size={size}>
+        <DialogContent ref={ref} className="p-0 gap-0 pb-5 !block" size={size}>
           <DialogHeader className={cn('border-b')} padding={'small'}>
             <DialogTitle className="">{title}</DialogTitle>
           </DialogHeader>
@@ -164,13 +164,14 @@ const TextConfirmModal = forwardRef<
                   </FormItem_Shadcn_>
                 )}
               />
-              <div className="flex justify-end gap-2">
+              <div className="flex gap-2">
                 {!blockDeleteButton && (
                   <Button size="medium" block type="default" disabled={loading}>
                     {cancelLabel}
                   </Button>
                 )}
                 <Button
+                  block
                   size="medium"
                   type={
                     variant === 'destructive'
@@ -180,9 +181,9 @@ const TextConfirmModal = forwardRef<
                         : 'primary'
                   }
                   htmlType="submit"
-                  block
                   loading={loading}
                   disabled={loading}
+                  className="truncate"
                 >
                   {confirmLabel}
                 </Button>


### PR DESCRIPTION
Resolves https://github.com/supabase/supabase/issues/22078

- Fixes BucketRow overflowing when bucket name is long
- Fixes DeleteBucketModal overflowing when bucket name is long
<img width="417" alt="image" src="https://github.com/supabase/supabase/assets/19742402/969f80b7-47eb-42b7-ba66-24cc891f5a54">
