### PR TITLE
Fix toast handling extremely long messages

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityTabResults.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityTabResults.tsx
@@ -165,7 +165,14 @@ const UtilityTabResults = ({ id, isExecuting }: UtilityTabResultsProps) => {
                     })
                     setSelectedDiffType(DiffType.Modification)
                   } catch (error: unknown) {
-                    if (isError(error)) toast.error(`Failed to debug: ${error.message}`)
+                    // [Joshen] There's a tendency for the SQL debug to chuck a lengthy error message
+                    // that's not relevant for the user - so we prettify it here by avoiding to return the
+                    // entire error body from the assistant
+                    if (isError(error)) {
+                      toast.error(
+                        `Sorry, the assistant failed to debug your query! Please try again with a different one.`
+                      )
+                    }
                   }
                 }}
               >

--- a/packages/ui/src/layout/PortalToast/PortalToast.tsx
+++ b/packages/ui/src/layout/PortalToast/PortalToast.tsx
@@ -1,3 +1,4 @@
+import { X } from 'lucide-react'
 import dynamic from 'next/dynamic'
 import { Toaster, ToastBar, toast } from 'react-hot-toast'
 import { Button, IconX } from 'ui'
@@ -14,7 +15,7 @@ const PortalToast = () => (
     <Toaster
       position="top-right"
       toastOptions={{
-        className: '!bg-overlay !text border !max-w-[600px]',
+        className: '!bg-overlay !text border !max-w-[600px] !items-start',
         style: {
           padding: '8px',
           paddingLeft: '16px',
@@ -33,15 +34,15 @@ const PortalToast = () => (
             const isConsentToast = t.id === 'consent-toast'
             return (
               <>
-                {icon}
-                <div className="w-full flex items-center">
+                <div className="mt-1">{icon}</div>
+                <div className="w-full flex items-start">
                   <div
                     className={`toast-message w-full ${
                       t.type === 'loading'
                         ? 'max-w-[380px]'
                         : isConsentToast
-                        ? 'max-w-none sm:max-w-[800px]'
-                        : 'max-w-[260px]'
+                          ? 'max-w-none sm:max-w-[800px]'
+                          : 'max-w-[260px]'
                     }`}
                   >
                     {message}
@@ -57,7 +58,7 @@ const PortalToast = () => (
                           toast.dismiss(t.id)
                         }}
                       >
-                        <IconX size={14} strokeWidth={2} />
+                        <X size={14} strokeWidth={2} />
                       </Button>
                     </div>
                   )}


### PR DESCRIPTION
Resolves https://github.com/supabase/supabase/issues/21471

Previously for toasts, the icon and close button were vertically center aligned - if the message body ends up really long, the buttons are not clickable. This PR shifts the icon and close button to be up top instead

<img width="390" alt="image" src="https://github.com/supabase/supabase/assets/19742402/004d7e16-b042-4d98-b0ae-e008a044369c">

Also, for the SQL debug, there's a tendency whereby the assistant will fail to parse the query and it'll return a lengthy error message thats irrelevant from the user's POV. so we prettify it by avoiding to return the entire error message
