### PR TITLE
feat: expose auth reauthentication template

### DIFF
--- a/apps/studio/components/interfaces/Auth/AuthTemplatesValidation.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthTemplatesValidation.tsx
@@ -193,9 +193,7 @@ const REAUTHENTICATION: FormSchema = {
       descriptionOptional: 'HTML body of your email',
       type: 'code',
       description: `
-- \`{{ .ConfirmationURL }}\` : URL to confirm the password reset
 - \`{{ .Token }}\` : The 6-digit numeric email OTP
-- \`{{ .TokenHash }}\` : The hashed token used in the URL
 - \`{{ .SiteURL }}\` : The URL of the site
 - \`{{ .Email }}\` : The user's email address
 - \`{{ .Data }}\` : The user's \`user_metadata\`

--- a/apps/studio/components/interfaces/Auth/AuthTemplatesValidation.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthTemplatesValidation.tsx
@@ -182,7 +182,7 @@ const REAUTHENTICATION: FormSchema = {
   $schema: JSON_SCHEMA_VERSION,
   id: 'REAUTHENTICATION',
   type: 'object',
-  title: 'REAUTHENTICATION',
+  title: 'Reauthentication',
   properties: {
     MAILER_SUBJECTS_REAUTHENTICATION: {
       title: 'Subject heading',

--- a/apps/studio/components/interfaces/Auth/AuthTemplatesValidation.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthTemplatesValidation.tsx
@@ -178,5 +178,45 @@ const RECOVERY: FormSchema = {
             [Learn more](https://supabase.com/docs/guides/auth/social-login/auth-apple#configure-your-services-id)`,
   },
 }
+const REAUTHENTICATION: FormSchema = {
+  $schema: JSON_SCHEMA_VERSION,
+  id: 'REAUTHENTICATION',
+  type: 'object',
+  title: 'REAUTHENTICATION',
+  properties: {
+    MAILER_SUBJECTS_REAUTHENTICATION: {
+      title: 'Subject heading',
+      type: 'string',
+    },
+    MAILER_TEMPLATES_REAUTHENTICATION_CONTENT: {
+      title: 'Message body',
+      descriptionOptional: 'HTML body of your email',
+      type: 'code',
+      description: `
+- \`{{ .ConfirmationURL }}\` : URL to confirm the password reset
+- \`{{ .Token }}\` : The 6-digit numeric email OTP
+- \`{{ .TokenHash }}\` : The hashed token used in the URL
+- \`{{ .SiteURL }}\` : The URL of the site
+- \`{{ .Email }}\` : The user's email address
+- \`{{ .Data }}\` : The user's \`user_metadata\`
+`,
+    },
+  },
+  validationSchema: object().shape({
+    MAILER_SUBJECTS_REAUTHENTICATION: string().required('"Subject heading is required.'),
+  }),
+  misc: {
+    iconKey: 'email-icon2',
+    helper: `To complete setup, add this authorisation callback URL to your app's configuration in the Apple Developer Console.
+            [Learn more](https://supabase.com/docs/guides/auth/social-login/auth-apple#configure-your-services-id)`,
+  },
+}
 
-export const TEMPLATES_SCHEMAS = [CONFIRMATION, INVITE, MAGIC_LINK, EMAIL_CHANGE, RECOVERY]
+export const TEMPLATES_SCHEMAS = [
+  CONFIRMATION,
+  INVITE,
+  MAGIC_LINK,
+  EMAIL_CHANGE,
+  RECOVERY,
+  REAUTHENTICATION,
+]

--- a/apps/studio/pages/api/auth/[ref]/config.ts
+++ b/apps/studio/pages/api/auth/[ref]/config.ts
@@ -122,15 +122,20 @@ const handleGetAll = async (req: NextApiRequest, res: NextApiResponse) => {
     MAILER_SUBJECTS_MAGIC_LINK: 'Your Magic Link',
     MAILER_SUBJECTS_REAUTHENTICATION: 'Confirm Reauthentication',
     MAILER_TEMPLATES_INVITE: null,
-    MAILER_TEMPLATES_INVITE_CONTENT: '<h2>You have been invited</h2>\n\n<p>You have been invited to create a user on {{ .SiteURL }}. Follow this link to accept the invite:</p>\n<p><a href="{{ .ConfirmationURL }}">Accept the invite</a></p>',
+    MAILER_TEMPLATES_INVITE_CONTENT:
+      '<h2>You have been invited</h2>\n\n<p>You have been invited to create a user on {{ .SiteURL }}. Follow this link to accept the invite:</p>\n<p><a href="{{ .ConfirmationURL }}">Accept the invite</a></p>',
     MAILER_TEMPLATES_CONFIRMATION: null,
-    MAILER_TEMPLATES_CONFIRMATION_CONTENT: '<h2>Confirm your email</h2>\n\n<p>Follow this link to confirm your email:</p>\n\n<p><a href="{{ .ConfirmationURL }}">Confirm your email address</a></p>',
+    MAILER_TEMPLATES_CONFIRMATION_CONTENT:
+      '<h2>Confirm your email</h2>\n\n<p>Follow this link to confirm your email:</p>\n\n<p><a href="{{ .ConfirmationURL }}">Confirm your email address</a></p>',
     MAILER_TEMPLATES_RECOVERY: null,
-    MAILER_TEMPLATES_RECOVERY_CONTENT: '<h2>Reset Password</h2>\n\n<p>Follow this link to reset the password for your user:</p>\n<p><a href="{{ .ConfirmationURL }}">Reset Password</a></p>',
+    MAILER_TEMPLATES_RECOVERY_CONTENT:
+      '<h2>Reset Password</h2>\n\n<p>Follow this link to reset the password for your user:</p>\n<p><a href="{{ .ConfirmationURL }}">Reset Password</a></p>',
     MAILER_TEMPLATES_EMAIL_CHANGE: null,
-    MAILER_TEMPLATES_EMAIL_CHANGE_CONTENT: '<h2>Confirm Change of Email</h2>\n\n<p>Follow this link to confirm the update of your email from {{ .Email }} to {{ .NewEmail }}:</p>\n<p><a href="{{ .ConfirmationURL }}">Change Email</a></p>',
+    MAILER_TEMPLATES_EMAIL_CHANGE_CONTENT:
+      '<h2>Confirm Change of Email</h2>\n\n<p>Follow this link to confirm the update of your email from {{ .Email }} to {{ .NewEmail }}:</p>\n<p><a href="{{ .ConfirmationURL }}">Change Email</a></p>',
     MAILER_TEMPLATES_MAGIC_LINK: null,
-    MAILER_TEMPLATES_MAGIC_LINK_CONTENT: '<h2>Magic Link</h2>\n\n<p>Follow this link to login:</p>\n<p><a href="{{ .ConfirmationURL }}">Log In</a></p>',
+    MAILER_TEMPLATES_MAGIC_LINK_CONTENT:
+      '<h2>Magic Link</h2>\n\n<p>Follow this link to login:</p>\n<p><a href="{{ .ConfirmationURL }}">Log In</a></p>',
     PASSWORD_MIN_LENGTH: 6,
     SMTP_SENDER_NAME: null,
     SMS_AUTOCONFIRM: phone_autoconfirm ?? false,
@@ -163,7 +168,8 @@ const handleGetAll = async (req: NextApiRequest, res: NextApiResponse) => {
     SMS_TEXTLOCAL_API_KEY: null,
     SMS_TEXTLOCAL_SENDER: null,
     MAILER_TEMPLATES_REAUTHENTICATION: null,
-    MAILER_TEMPLATES_REAUTHENTICATION_CONTENT: '<h2>Confirm reauthentication</h2> <p>Enter the code: {{ .Token }}</p>',
+    MAILER_TEMPLATES_REAUTHENTICATION_CONTENT:
+      '<h2>Confirm reauthentication</h2> <p>Enter the code: {{ .Token }}</p>',
   })
 }
 

--- a/apps/studio/pages/api/auth/[ref]/config.ts
+++ b/apps/studio/pages/api/auth/[ref]/config.ts
@@ -121,20 +121,15 @@ const handleGetAll = async (req: NextApiRequest, res: NextApiResponse) => {
     MAILER_SUBJECTS_EMAIL_CHANGE: 'Confirm Email Change',
     MAILER_SUBJECTS_MAGIC_LINK: 'Your Magic Link',
     MAILER_TEMPLATES_INVITE: null,
-    MAILER_TEMPLATES_INVITE_CONTENT:
-      '<h2>You have been invited</h2>\n\n<p>You have been invited to create a user on {{ .SiteURL }}. Follow this link to accept the invite:</p>\n<p><a href="{{ .ConfirmationURL }}">Accept the invite</a></p>',
+    MAILER_TEMPLATES_INVITE_CONTENT: '<h2>You have been invited</h2>\n\n<p>You have been invited to create a user on {{ .SiteURL }}. Follow this link to accept the invite:</p>\n<p><a href="{{ .ConfirmationURL }}">Accept the invite</a></p>',
     MAILER_TEMPLATES_CONFIRMATION: null,
-    MAILER_TEMPLATES_CONFIRMATION_CONTENT:
-      '<h2>Confirm your email</h2>\n\n<p>Follow this link to confirm your email:</p>\n\n<p><a href="{{ .ConfirmationURL }}">Confirm your email address</a></p>',
+    MAILER_TEMPLATES_CONFIRMATION_CONTENT: '<h2>Confirm your email</h2>\n\n<p>Follow this link to confirm your email:</p>\n\n<p><a href="{{ .ConfirmationURL }}">Confirm your email address</a></p>',
     MAILER_TEMPLATES_RECOVERY: null,
-    MAILER_TEMPLATES_RECOVERY_CONTENT:
-      '<h2>Reset Password</h2>\n\n<p>Follow this link to reset the password for your user:</p>\n<p><a href="{{ .ConfirmationURL }}">Reset Password</a></p>',
+    MAILER_TEMPLATES_RECOVERY_CONTENT: '<h2>Reset Password</h2>\n\n<p>Follow this link to reset the password for your user:</p>\n<p><a href="{{ .ConfirmationURL }}">Reset Password</a></p>',
     MAILER_TEMPLATES_EMAIL_CHANGE: null,
-    MAILER_TEMPLATES_EMAIL_CHANGE_CONTENT:
-      '<h2>Confirm Change of Email</h2>\n\n<p>Follow this link to confirm the update of your email from {{ .Email }} to {{ .NewEmail }}:</p>\n<p><a href="{{ .ConfirmationURL }}">Change Email</a></p>',
+    MAILER_TEMPLATES_EMAIL_CHANGE_CONTENT: '<h2>Confirm Change of Email</h2>\n\n<p>Follow this link to confirm the update of your email from {{ .Email }} to {{ .NewEmail }}:</p>\n<p><a href="{{ .ConfirmationURL }}">Change Email</a></p>',
     MAILER_TEMPLATES_MAGIC_LINK: null,
-    MAILER_TEMPLATES_MAGIC_LINK_CONTENT:
-      '<h2>Magic Link</h2>\n\n<p>Follow this link to login:</p>\n<p><a href="{{ .ConfirmationURL }}">Log In</a></p>',
+    MAILER_TEMPLATES_MAGIC_LINK_CONTENT: '<h2>Magic Link</h2>\n\n<p>Follow this link to login:</p>\n<p><a href="{{ .ConfirmationURL }}">Log In</a></p>',
     PASSWORD_MIN_LENGTH: 6,
     SMTP_SENDER_NAME: null,
     SMS_AUTOCONFIRM: phone_autoconfirm ?? false,
@@ -166,6 +161,8 @@ const handleGetAll = async (req: NextApiRequest, res: NextApiResponse) => {
     SMS_VONAGE_FROM: null,
     SMS_TEXTLOCAL_API_KEY: null,
     SMS_TEXTLOCAL_SENDER: null,
+    MAILER_TEMPLATES_REAUTHENTICATION: null,
+    MAILER_TEMPLATES_REAUTHENTICATION_CONTENT: '<h2>Confirm reauthentication</h2> <p>Enter the code: {{ .Token }}</p>',
   })
 }
 

--- a/apps/studio/pages/api/auth/[ref]/config.ts
+++ b/apps/studio/pages/api/auth/[ref]/config.ts
@@ -120,6 +120,7 @@ const handleGetAll = async (req: NextApiRequest, res: NextApiResponse) => {
     MAILER_SUBJECTS_RECOVERY: 'Reset Your Password',
     MAILER_SUBJECTS_EMAIL_CHANGE: 'Confirm Email Change',
     MAILER_SUBJECTS_MAGIC_LINK: 'Your Magic Link',
+    MAILER_SUBJECTS_REAUTHENTICATION: 'Confirm Reauthentication',
     MAILER_TEMPLATES_INVITE: null,
     MAILER_TEMPLATES_INVITE_CONTENT: '<h2>You have been invited</h2>\n\n<p>You have been invited to create a user on {{ .SiteURL }}. Follow this link to accept the invite:</p>\n<p><a href="{{ .ConfirmationURL }}">Accept the invite</a></p>',
     MAILER_TEMPLATES_CONFIRMATION: null,


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

Introduces the reauthentication template so developers can customize the reauthentication template

Supporting backend PR: https://github.com/supabase/infrastructure/pull/17477

Tested locally, by modifying the subject and template body and checking the corresponding instance to see that env vars are updated. Also tested by sending a reauth email with the local project