### PR TITLE
fix: prevent project in transaction mode from changing pooler mode

### DIFF
--- a/apps/studio/components/interfaces/Settings/Database/ConnectionPooling/ConnectionPooling.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/ConnectionPooling/ConnectionPooling.tsx
@@ -234,26 +234,44 @@ export const ConnectionPooling = () => {
                       <FormLabel_Shadcn_ className="flex flex-col space-y-2 col-span-4 text-sm justify-center text-foreground-light">
                         Pool Mode
                       </FormLabel_Shadcn_>
-                      <FormControl_Shadcn_ className="col-span-8">
-                        <Listbox
-                          value={field.value}
-                          className="w-full"
-                          onChange={(value) => field.onChange(value)}
-                        >
-                          <Listbox.Option key="transaction" label="Transaction" value="transaction">
-                            <p>Transaction mode</p>
-                            <p className="text-xs text-foreground-lighter">
-                              {TRANSACTION_MODE_DESCRIPTION}
-                            </p>
-                          </Listbox.Option>
-                          <Listbox.Option key="session" label="Session" value="session">
-                            <p>Session mode</p>
-                            <p className="text-xs text-foreground-lighter">
-                              {SESSION_MODE_DESCRIPTION}
-                            </p>
-                          </Listbox.Option>
-                        </Listbox>
-                      </FormControl_Shadcn_>
+                      {poolingConfiguration?.pool_mode === 'session' ? (
+                        <FormControl_Shadcn_ className="col-span-8">
+                          <Listbox
+                            value={field.value}
+                            className="w-full"
+                            onChange={(value) => field.onChange(value)}
+                          >
+                            <Listbox.Option
+                              key="transaction"
+                              label="Transaction"
+                              value="transaction"
+                            >
+                              <p>Transaction mode</p>
+                              <p className="text-xs text-foreground-lighter">
+                                {TRANSACTION_MODE_DESCRIPTION}
+                              </p>
+                            </Listbox.Option>
+                            <Listbox.Option key="session" label="Session" value="session">
+                              <p>Session mode</p>
+                              <p className="text-xs text-foreground-lighter">
+                                {SESSION_MODE_DESCRIPTION}
+                              </p>
+                            </Listbox.Option>
+                          </Listbox>
+                        </FormControl_Shadcn_>
+                      ) : (
+                        <FormDescription_Shadcn_ className="col-start-5 col-span-8 flex flex-col gap-y-2">
+                          <Alert_Shadcn_>
+                            <AlertTitle_Shadcn_ className="text-foreground">
+                              Pool mode is set to transaction permanently on port 6543
+                            </AlertTitle_Shadcn_>
+                            <AlertDescription_Shadcn_>
+                              You can use session mode by pointing the pooler connection to use port
+                              5432.
+                            </AlertDescription_Shadcn_>
+                          </Alert_Shadcn_>
+                        </FormDescription_Shadcn_>
+                      )}
                       <FormDescription_Shadcn_ className="col-start-5 col-span-8 flex flex-col gap-y-2">
                         <p>
                           Specify when a connection can be returned to the pool.{' '}
@@ -262,23 +280,25 @@ export const ConnectionPooling = () => {
                             onClick={() => snap.setShowPoolingModeHelper(true)}
                             className="cursor-pointer underline underline-offset-2"
                           >
-                            Unsure which pooling mode to use?
+                            Learn more about pool modes
                           </span>
+                          .
                         </p>
-                        {field.value === 'session' && (
+                      </FormDescription_Shadcn_>
+                      {field.value === 'transaction' &&
+                      poolingConfiguration?.pool_mode === 'session' ? (
+                        <FormDescription_Shadcn_ className="col-start-5 col-span-8 flex flex-col gap-y-2">
                           <Alert_Shadcn_>
                             <AlertTitle_Shadcn_ className="text-foreground">
-                              Set to transaction mode to use both pooling modes concurrently
+                              Pool mode will be set to transaction permanently on port 6543
                             </AlertTitle_Shadcn_>
                             <AlertDescription_Shadcn_>
-                              Session mode can be used concurrently with transaction mode by using
-                              5432 for session and 6543 for transaction. However, by configuring the
-                              pooler mode to session here, you will not be able to use transaction
-                              mode at the same time.
+                              This will take into effect once saved. You can use session mode by
+                              pointing the pooler connection to use port 5432.
                             </AlertDescription_Shadcn_>
                           </Alert_Shadcn_>
-                        )}
-                      </FormDescription_Shadcn_>
+                        </FormDescription_Shadcn_>
+                      ) : null}
                       <FormMessage_Shadcn_ className="col-start-5 col-span-8" />
                     </FormItem_Shadcn_>
                   )}
@@ -304,15 +324,15 @@ export const ConnectionPooling = () => {
                         Number(form.getValues('default_pool_size') ?? 15) >
                           maxConnData.maxConnections * 0.8 && (
                           <div className="col-start-5 col-span-8">
-                            <Alert_Shadcn_ variant="warning">
-                              <IconAlertTriangle strokeWidth={2} />
-                              <AlertTitle_Shadcn_>
-                                Pool size is greater than 80% of the max connections (
-                                {maxConnData.maxConnections}) on your database
+                            <Alert_Shadcn_>
+                              <AlertTitle_Shadcn_ className="text-foreground">
+                                Set to transaction mode to use both pooling modes concurrently
                               </AlertTitle_Shadcn_>
                               <AlertDescription_Shadcn_>
-                                This may result in instability and unreliability with your database
-                                connections.
+                                Session mode can be used concurrently with transaction mode by using
+                                5432 for session and 6543 for transaction. However, by configuring
+                                the pooler mode to session here, you will not be able to use
+                                transaction mode at the same time.
                               </AlertDescription_Shadcn_>
                             </Alert_Shadcn_>
                           </div>

--- a/apps/studio/components/interfaces/Settings/Database/ConnectionPooling/ConnectionPooling.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/ConnectionPooling/ConnectionPooling.tsx
@@ -18,7 +18,6 @@ import {
   FormLabel_Shadcn_,
   FormMessage_Shadcn_,
   Form_Shadcn_,
-  IconAlertTriangle,
   IconExternalLink,
   Input_Shadcn_,
   Listbox,
@@ -234,44 +233,57 @@ export const ConnectionPooling = () => {
                       <FormLabel_Shadcn_ className="flex flex-col space-y-2 col-span-4 text-sm justify-center text-foreground-light">
                         Pool Mode
                       </FormLabel_Shadcn_>
-                      {poolingConfiguration?.pool_mode === 'session' ? (
-                        <FormControl_Shadcn_ className="col-span-8">
-                          <Listbox
-                            value={field.value}
-                            className="w-full"
-                            onChange={(value) => field.onChange(value)}
-                          >
-                            <Listbox.Option
-                              key="transaction"
-                              label="Transaction"
-                              value="transaction"
-                            >
-                              <p>Transaction mode</p>
-                              <p className="text-xs text-foreground-lighter">
-                                {TRANSACTION_MODE_DESCRIPTION}
-                              </p>
-                            </Listbox.Option>
-                            <Listbox.Option key="session" label="Session" value="session">
-                              <p>Session mode</p>
-                              <p className="text-xs text-foreground-lighter">
-                                {SESSION_MODE_DESCRIPTION}
-                              </p>
-                            </Listbox.Option>
-                          </Listbox>
-                        </FormControl_Shadcn_>
-                      ) : (
+                      <FormControl_Shadcn_ className="col-span-8">
+                        <Listbox
+                          disabled={poolingConfiguration?.pool_mode === 'transaction'}
+                          value={field.value}
+                          className="w-full"
+                          onChange={(value) => field.onChange(value)}
+                        >
+                          <Listbox.Option key="transaction" label="Transaction" value="transaction">
+                            <p>Transaction mode</p>
+                            <p className="text-xs text-foreground-lighter">
+                              {TRANSACTION_MODE_DESCRIPTION}
+                            </p>
+                          </Listbox.Option>
+                          <Listbox.Option key="session" label="Session" value="session">
+                            <p>Session mode</p>
+                            <p className="text-xs text-foreground-lighter">
+                              {SESSION_MODE_DESCRIPTION}
+                            </p>
+                          </Listbox.Option>
+                        </Listbox>
+                      </FormControl_Shadcn_>
+
+                      {poolingConfiguration?.pool_mode === 'transaction' && (
                         <FormDescription_Shadcn_ className="col-start-5 col-span-8 flex flex-col gap-y-2">
                           <Alert_Shadcn_>
                             <AlertTitle_Shadcn_ className="text-foreground">
-                              Pool mode is set to transaction permanently on port 6543
+                              Pool mode is permanently set to Transaction on port 6543
                             </AlertTitle_Shadcn_>
                             <AlertDescription_Shadcn_>
-                              You can use session mode by pointing the pooler connection to use port
-                              5432.
+                              You can use Session mode by connecting to the pooler on port 5432
+                              instead
                             </AlertDescription_Shadcn_>
                           </Alert_Shadcn_>
                         </FormDescription_Shadcn_>
                       )}
+
+                      {field.value === 'transaction' &&
+                        poolingConfiguration?.pool_mode === 'session' && (
+                          <FormDescription_Shadcn_ className="col-start-5 col-span-8 flex flex-col gap-y-2">
+                            <Alert_Shadcn_>
+                              <AlertTitle_Shadcn_ className="text-foreground">
+                                Pool mode will be set to transaction permanently on port 6543
+                              </AlertTitle_Shadcn_>
+                              <AlertDescription_Shadcn_>
+                                This will take into effect once saved. You can use session mode by
+                                pointing the pooler connection to use port 5432.
+                              </AlertDescription_Shadcn_>
+                            </Alert_Shadcn_>
+                          </FormDescription_Shadcn_>
+                        )}
+
                       <FormDescription_Shadcn_ className="col-start-5 col-span-8 flex flex-col gap-y-2">
                         <p>
                           Specify when a connection can be returned to the pool.{' '}
@@ -285,20 +297,7 @@ export const ConnectionPooling = () => {
                           .
                         </p>
                       </FormDescription_Shadcn_>
-                      {field.value === 'transaction' &&
-                      poolingConfiguration?.pool_mode === 'session' ? (
-                        <FormDescription_Shadcn_ className="col-start-5 col-span-8 flex flex-col gap-y-2">
-                          <Alert_Shadcn_>
-                            <AlertTitle_Shadcn_ className="text-foreground">
-                              Pool mode will be set to transaction permanently on port 6543
-                            </AlertTitle_Shadcn_>
-                            <AlertDescription_Shadcn_>
-                              This will take into effect once saved. You can use session mode by
-                              pointing the pooler connection to use port 5432.
-                            </AlertDescription_Shadcn_>
-                          </Alert_Shadcn_>
-                        </FormDescription_Shadcn_>
-                      ) : null}
+
                       <FormMessage_Shadcn_ className="col-start-5 col-span-8" />
                     </FormItem_Shadcn_>
                   )}


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

Project can't change pooler mode to session once in transaction mode.

## Preview

When project is in transaction mode:

<img width="957" alt="Screenshot 2024-03-21 at 16 50 46" src="https://github.com/supabase/supabase/assets/5532241/c48197dd-9198-414a-9258-1c0df59f711c">

When project is in session mode:

https://github.com/supabase/supabase/assets/5532241/3493e15e-9a09-4cc7-9701-b39ee9e39366

## Additional context

https://www.notion.so/supabase/Prevent-user-from-setting-Supavisor-pool-mode-when-in-transaction-mode-6fe2894127d443db88fe6f857ce740b4?pvs=4
