### PR TITLE
Update docs

### DIFF
--- a/apps/docs/content/guides/ai/examples/headless-vector-search.mdx
+++ b/apps/docs/content/guides/ai/examples/headless-vector-search.mdx
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: supabase/supabase-embeddings-generator@v0.0.x # Update this to the latest version.
+      - uses: supabase/embeddings-generator@v0.0.x # Update this to the latest version.
         with:
           supabase-url: 'https://your-project-ref.supabase.co' # Update this to your project URL.
           supabase-service-role-key: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}


### PR DESCRIPTION
update Supabase embeddings generator GitHub action name

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

The headless-vector-search.mdx is pointing to the wrong GitHub action name.
https://github.com/supabase/supabase/blob/master/apps/docs/content/guides/ai/examples/headless-vector-search.mdx

## What is the new behavior?

rename supabase/supabase-embeddings-generator@v0.0.x to supabase/embeddings-generator@v0.0.x

