### PR TITLE
update functions doc for dart v2.0

### DIFF
--- a/apps/docs/spec/supabase_dart_v2.yml
+++ b/apps/docs/spec/supabase_dart_v2.yml
@@ -1068,17 +1068,17 @@ functions:
           final res = await supabase.functions.invoke('hello', body: {'foo': 'baa'});
           final data = res.data;
           ```
-      - id: specifying-response-type
-        name: Specifying response type.
+      - id: specifying-method-type
+        name: Specifying method type.
         description: |
-          By default, `invoke()` will parse the response as JSON. You can parse the response in the following formats: `json`, `blob`, `text`, and `arrayBuffer`.
+          By default, `invoke()` will make a POST request. You can parse the response in the following formats: `get`, `post`, `put`, `delete`, and `patch`.
         isSpotlight: true
         code: |
           ```dart
           final res = await supabase.functions.invoke(
             'hello',
             body: {'foo': 'baa'},
-            responseType: ResponseType.text,
+            method: HttpMethod.post,
           );
           final data = res.data;
           ```


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Doc update

## What is the current behavior?

Doc mentions `ResponseType` in v2.0 dart library. However is does not exist anymore and now we have `HttpMethod`.

## What is the new behavior?

Remove `ResponseType` and introduce `HttpMethod`. 

## Additional context

N/A
