### PR TITLE
Update docs with replication role creation

### DIFF
--- a/apps/docs/content/guides/database/postgres/roles-superuser.mdx
+++ b/apps/docs/content/guides/database/postgres/roles-superuser.mdx
@@ -12,7 +12,6 @@ However, this does mean that some operations, that typically require `superuser`
 
 ## Unsupported operations
 
-- `CREATE ROLE ... WITH REPLICATION`
 - `CREATE SUBSCRIPTION`
 - `CREATE EVENT TRIGGER`
 - `COPY ... FROM PROGRAM`

--- a/apps/docs/content/guides/database/postgres/setup-replication-external.mdx
+++ b/apps/docs/content/guides/database/postgres/setup-replication-external.mdx
@@ -31,6 +31,8 @@ This will need a direct connection to your database and you can find the connect
 
 You will also need to ensure that ipv6 is supported by your replication destination.
 
+If you would prefer not to use the `postgres` user, then you can run `CREATE ROLE <user> WITH REPLICATION;` using the `postgres` user.
+
 </Admonition>
 
 ```sql


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update for logical replication

## What is the current behavior?

Current docs restrict replication to `postgres` user

## What is the new behavior?

Changes now allow the `postgres` user to create roles with the replication privilege so that a privileged role does not need to be used

## Additional context

This may benefit from expanding further to cover permissions but I opted not to as replication is possible but not officially supported / covered
