### PR TITLE
ui fixes in Logs Templates

### DIFF
--- a/apps/studio/pages/project/[ref]/logs/explorer/templates.tsx
+++ b/apps/studio/pages/project/[ref]/logs/explorer/templates.tsx
@@ -1,6 +1,7 @@
 import { useParams } from 'common'
 import { useState } from 'react'
-import { Button, IconCode, Popover } from 'ui'
+import { Button, Popover } from 'ui'
+import { CodeIcon } from 'lucide-react'
 
 import { LogTemplate, TEMPLATES } from 'components/interfaces/Settings/Logs'
 import LogsLayout from 'components/layouts/LogsLayout/LogsLayout'
@@ -14,7 +15,7 @@ export const LogsTemplatesPage: NextPageWithLayout = () => {
   return (
     <div className="mx-auto h-full w-full px-5 py-6">
       <LogsExplorerHeader subtitle="Templates" />
-      <div className="grid grid-cols-3 gap-6 mt-4">
+      <div className="grid lg:grid-cols-3 gap-6 mt-4 pb-24">
         {TEMPLATES.sort((a, b) => a.label!.localeCompare(b.label!))
           .filter((template) => template.mode === 'custom')
           .map((template, i) => {
@@ -37,20 +38,30 @@ const Template = ({ projectRef, template }: { projectRef?: string; template: Log
       title={template.label}
       icon={
         <div
-          className="duration-400 flex h-6 w-6 items-center justify-center rounded
-          bg-foreground
-          text-background
-          transition-colors
-          group-hover:bg-brand
+          className="duration-400 flex h-6 w-6 items-center justify-center rounded transition-colors
+
+          border
+          bg-background-200
+
+          group-hover:bg-brand-300
           group-hover:text-brand-600
+          group-hover:border-brand-500
+
+          dark:border-background-selection
+          dark:bg-background-200
+          dark:text-foreground
+
+          dark:group-hover:border-brand-600
+          dark:group-hover:bg-brand-300
+          dark:group-hover:text-brand-600
         "
         >
           <div className="scale-100 group-hover:scale-110">
-            <IconCode size={12} strokeWidth={2} />
+            <CodeIcon size={12} strokeWidth={2} />
           </div>
         </div>
       }
-      className="h-40"
+      className="h-44"
       linkHref={`/project/${projectRef}/logs/explorer?q=${encodeURI(template.searchString)}`}
       description={template.description}
       footer={

--- a/apps/studio/pages/project/[ref]/logs/explorer/templates.tsx
+++ b/apps/studio/pages/project/[ref]/logs/explorer/templates.tsx
@@ -1,6 +1,6 @@
 import { useParams } from 'common'
 import { useState } from 'react'
-import { Button, Popover } from 'ui'
+import { Button, Popover, cn } from 'ui'
 import { CodeIcon } from 'lucide-react'
 
 import { LogTemplate, TEMPLATES } from 'components/interfaces/Settings/Logs'
@@ -38,23 +38,13 @@ const Template = ({ projectRef, template }: { projectRef?: string; template: Log
       title={template.label}
       icon={
         <div
-          className="duration-400 flex h-6 w-6 items-center justify-center rounded transition-colors
-
-          border
-          bg-background-200
-
-          group-hover:bg-brand-300
-          group-hover:text-brand-600
-          group-hover:border-brand-500
-
-          dark:border-background-selection
-          dark:bg-background-200
-          dark:text-foreground
-
-          dark:group-hover:border-brand-600
-          dark:group-hover:bg-brand-300
-          dark:group-hover:text-brand-600
-        "
+          className={cn(
+            'duration-400 flex h-6 w-6 items-center justify-center rounded transition-colors',
+            'border bg-background-200',
+            'group-hover:bg-brand-300 group-hover:text-brand-600 group-hover:border-brand-500',
+            'dark:border-background-selection dark:bg-background-200 dark:text-foreground',
+            'dark:group-hover:border-brand-600 dark:group-hover:bg-brand-300 dark:group-hover:text-brand-600'
+          )}
         >
           <div className="scale-100 group-hover:scale-110">
             <CodeIcon size={12} strokeWidth={2} />


### PR DESCRIPTION
## What kind of change does this PR introduce?

UI fixes in Logs Templates

## What is the current behavior?
![image](https://github.com/supabase/supabase/assets/37541088/70906aa2-2e32-4a0c-9e50-cc9fbec8eb78)

## What is the new behavior?
![CleanShot 2024-03-26 at 10 24 37@2x](https://github.com/supabase/supabase/assets/37541088/88d0814a-ea6e-42d1-ac0a-28331c186a4b)
![CleanShot 2024-03-26 at 10 24 52@2x](https://github.com/supabase/supabase/assets/37541088/da54dc1d-4318-4a57-9383-9408250b8c5f)
