### PR TITLE
docs(snippets): fix bash example for user invite

### DIFF
--- a/apps/studio/components/interfaces/Docs/Snippets.ts
+++ b/apps/studio/components/interfaces/Docs/Snippets.ts
@@ -637,7 +637,7 @@ let { data, error } = await supabase.auth.verifyOtp({
       code: `
 curl -X POST '${endpoint}/auth/v1/invite' \\
 -H "apikey: ${apiKey}" \\
--H "Authorization: Bearer ${apiKey}" \\
+-H "Authorization: Bearer USER_TOKEN" \\
 -H "Content-Type: application/json" \\
 -d '{
   "email": "someone@email.com"

--- a/apps/studio/components/interfaces/Docs/Snippets.ts
+++ b/apps/studio/components/interfaces/Docs/Snippets.ts
@@ -710,7 +710,7 @@ let { data, error } = await supabase.auth.resetPasswordForEmail(email)
       code: `
       curl -X PUT '${endpoint}/auth/v1/user' \\
 -H "apikey: ${apiKey}" \\
--H "Authorization: Bearer <USERS-ACCESS-TOKEN>" \\
+-H "Authorization: Bearer USER_TOKEN" \\
 -H "Content-Type: application/json" \\
 -d '{
   "email": "someone@email.com",


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

doc fix (typo)

## What is the current behavior?

The bash example of user invite over email is incorrect

## What is the new behavior?

Fixes the example to have the correct bearer token

## Additional context

Closes #22273
