### PR TITLE
Actions to Automate PR and Issue Management

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,15 @@
+teams/cli:
+- changed-files:
+  - any-glob-to-any-file: 'docker/**/*'
+
+team/docs:
+- changed-files:
+  - any-glob-to-any-file: 'app/docs/**/*'
+
+teams/frontend:
+- changed-files:
+  - any-glob-to-any-file: 'apps/studio/**/*'
+
+teams/website:
+- changed-files:
+  - any-glob-to-any-file: 'apps/www/**/*'

--- a/.github/workflows/auto-stale.yml
+++ b/.github/workflows/auto-stale.yml
@@ -1,0 +1,27 @@
+name: Automatically stale issue and PRs
+on:
+  push:
+    branches:
+      - master
+
+# Cancel old builds on new commit for same workflow + branch/PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close Stale Issues
+        uses: actions/stale@v9.0.0
+        with:
+          days-before-pr-close: 30
+          days-before-issue-close: 90
+          close-issue-label: staled
+          close-pr-label: staled
+          any-of-labels: contributor
+          exempt-issue-labels: dnc, needs-analysis
+          exempt-pr-labels: dnc
+          exempt-all-pr-assignees: true
+          exempt-draft-pr: false

--- a/.github/workflows/label-external-prs.yml
+++ b/.github/workflows/label-external-prs.yml
@@ -1,0 +1,50 @@
+name: Auto Label PRs
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  check-external:
+    runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.is-member.outputs.result }}
+    steps:
+    - name: Get deps
+      run: |
+        sudo apt-get update && sudo apt-get install -y jq
+    - name: Get org members
+      id: is-member
+      env:
+        GH_ORG: supabase
+        GH_USER: ${{ github.event.pull_request.user.login }}
+        GH_TOKEN: ${{ secrets.GH_ORG_MEMBERSHIP_PAT }}
+      run: |
+        gh api /orgs/supabase/members/$GH_USER
+    - if: failure()
+      name: is-member
+      run: |
+        echo "User is not a member of Supabase org"
+        echo "result=false" >> $GH_OUTPUT
+    - if: success()
+      run: |
+        echo "User is a member of Supabase org, not applying labels"
+    - name: Label contributor
+      id: label-contributor
+      if:  ${{ steps.is-member.outputs.result == 'false' }}
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        USERNAME: ${{ github.event.pull_request.user.login }}
+        GH_REPO: ${{ github.repository }}
+        NUMBER: ${{ github.event.pull_request.number }}
+        LABELS: contributor
+      run: |
+        gh pr edit $NUMBER --add-label $LABELS
+    - uses: actions/checkout@v4
+      if:  ${{ steps.is-member.outputs.result == 'false' }}
+    - name: Label PR
+      if:  ${{ steps.is-member.outputs.result == 'false' }}
+      uses: actions/labeler@v5
+    
+    
+
+
+      


### PR DESCRIPTION
### I have read the CONTRIBUTING.md file.
YES

### What kind of change does this PR introduce?
This PR introduces three new Actions to help support community management efforts

### What is the current behavior?
No auto labelling or staleness is currently used

### What is the new behavior?
- Auto label externally contributed PRs with the `contributor` label
- Auto label externally contributed PRs with the relevant teams (i.e. `teams/frontend`)
- Auto-close issues (after 90 days) and PRs (after 30 days) when they have the `contributor` label (unless they have the `dnc` label)

### Additional context

- This is a first pass at an attempt to support the community better and to help teams deal with triaged issues.
- Due to the limited scope of the GITHUB_TOKEN used for Github Actions, an additional org level token is needed with the permissions to `read members`
   - For the purposes of this PR, a secret has been added with this permission that will expire in 7 days (3rd April 2024)
   - If merged, this would need a token with that privilege to be present in the secrets
