### PR TITLE
Docs: fixed the broken link to SAML SSO

### DIFF
--- a/apps/docs/content/guides/platform/sso.mdx
+++ b/apps/docs/content/guides/platform/sso.mdx
@@ -5,7 +5,7 @@ description: 'General information about enabling single sign-on (SSO) for your o
 
 <Admonition>
 
-Looking for docs on how to add Single Sign-On support in your Supabase project? Head on over to [Single Sign-On with SAML 2.0 for Projects](/docs/guides/auth/sso/auth-sso-saml).
+Looking for docs on how to add Single Sign-On support in your Supabase project? Head on over to [Single Sign-On with SAML 2.0 for Projects](/docs/guides/auth/enterprise-sso/auth-sso-saml).
 
 </Admonition>
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update. Fixes a broken link in /docs/guides/platform/sso

## What is the current behavior?

Currently, the link "Single Sign-On with SAML 2.0 for Projects" is broken on the https://supabase.com/docs/guides/platform/sso page. It's currently linked to https://supabase.com/docs/guides/auth/sso/auth-sso-saml, but it should be https://supabase.com/docs/guides/auth/enterprise-sso/auth-sso-saml

## What is the new behavior?

https://supabase.com/docs/guides/platform/sso page correctly points to https://supabase.com/docs/guides/auth/enterprise-sso/auth-sso-saml
