### PR TITLE
Just changed the MyApp constructor to make it slightly more efficient

### DIFF
--- a/apps/docs/content/guides/getting-started/quickstarts/flutter.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/flutter.mdx
@@ -117,7 +117,7 @@ hideToc: true
 
       ```dart lib/main.dart
       class MyApp extends StatelessWidget {
-        const MyApp({Key? key}) : super(key: key);
+        const MyApp({super.key});
 
         @override
         Widget build(BuildContext context) {


### PR DESCRIPTION
Cleaned up MyApp's constructor to read as follows:

const MyApp({super.key});

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES/NO

## What kind of change does this PR introduce?

Minor clean up of code

## What is the current behavior?

  const MyApp({Key? key}) : super(key: key);

## What is the new behavior?

const MyApp({super.key});

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
