### PR TITLE
docs: remove reference to SSO from OAuth docs

### DIFF
--- a/apps/docs/content/guides/auth/server-side/oauth-with-pkce-flow-for-ssr.mdx
+++ b/apps/docs/content/guides/auth/server-side/oauth-with-pkce-flow-for-ssr.mdx
@@ -231,7 +231,7 @@ await supabase.auth.signInWithOAuth({
 
 <TabPanel id="server" label="Server">
 
-In the server, you need to handle the redirect to the SSO provider's authentication endpoint. The `signInWithOAuth` method returns the endpoint URL, which you can redirect to.
+In the server, you need to handle the redirect to the OAuth provider's authentication endpoint. The `signInWithOAuth` method returns the endpoint URL, which you can redirect to.
 
 ```js
 const { data, error } = await supabase.auth.signInWithOAuth({


### PR DESCRIPTION
## What kind of change does this PR introduce?

There seems to be slight confusion (via ticket) about terminology. Users might think that they need to upgrade to Teams / Pro to use sign in with OAuth.

While SSO is a valid term in tis scenario, we hope to sidestep the need to unpack the term by using "OAuth"