### PR TITLE
chore: bump supabase-js

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -30,7 +30,7 @@
     "@octokit/plugin-paginate-graphql": "^4.0.0",
     "@radix-ui/react-accordion": "^1.1.2",
     "@supabase/auth-helpers-react": "^0.4.2",
-    "@supabase/supabase-js": "^2.39.3",
+    "@supabase/supabase-js": "^2.41.1",
     "@tailwindcss/container-queries": "^0.1.1",
     "@tanstack/react-query": "^5.13.4",
     "common": "*",

--- a/apps/studio/components/interfaces/SignIn/SignInMfaForm.tsx
+++ b/apps/studio/components/interfaces/SignIn/SignInMfaForm.tsx
@@ -1,4 +1,4 @@
-import type { AuthError } from '@supabase/gotrue-js'
+import type { AuthError } from '@supabase/auth-js'
 import type { Factor } from '@supabase/supabase-js'
 import { useQueryClient } from '@tanstack/react-query'
 import Link from 'next/link'

--- a/apps/studio/lib/gotrue.ts
+++ b/apps/studio/lib/gotrue.ts
@@ -1,4 +1,4 @@
-import type { Session, User } from '@supabase/gotrue-js'
+import type { Session, User } from '@supabase/auth-js'
 import { gotrueClient } from 'common'
 
 export const auth = gotrueClient

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -33,7 +33,7 @@
     "@stripe/stripe-js": "^3.0.5",
     "@supabase/auth-helpers-react": "^0.4.2",
     "@supabase/shared-types": "0.1.55",
-    "@supabase/supabase-js": "^2.39.3",
+    "@supabase/supabase-js": "^2.41.1",
     "@tanstack/react-query": "4.35.7",
     "@tanstack/react-query-devtools": "4.35.7",
     "@uidotdev/usehooks": "^2.4.1",

--- a/apps/studio/types/base.ts
+++ b/apps/studio/types/base.ts
@@ -88,7 +88,7 @@ export interface ResponseFailure {
 export type SupaResponse<T> = T | ResponseFailure
 
 export interface ResponseError {
-  code?: number
+  code?: number | string
   message: string
   requestId?: string
 }

--- a/apps/www/lib/database.types.ts
+++ b/apps/www/lib/database.types.ts
@@ -1,8 +1,62 @@
 export type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[]
 
-export interface Database {
+export type Database = {
   public: {
     Tables: {
+      dpa_downloads: {
+        Row: {
+          contact_email: string
+          created_at: string | null
+          document: string | null
+          id: number
+          updated_at: string | null
+        }
+        Insert: {
+          contact_email: string
+          created_at?: string | null
+          document?: string | null
+          id?: number
+          updated_at?: string | null
+        }
+        Update: {
+          contact_email?: string
+          created_at?: string | null
+          document?: string | null
+          id?: number
+          updated_at?: string | null
+        }
+        Relationships: []
+      }
+      lwx_meetups: {
+        Row: {
+          created_at: string | null
+          display_info: string | null
+          id: number
+          isLive: boolean
+          link: string | null
+          start_at: string | null
+          title: string | null
+        }
+        Insert: {
+          created_at?: string | null
+          display_info?: string | null
+          id?: number
+          isLive?: boolean
+          link?: string | null
+          start_at?: string | null
+          title?: string | null
+        }
+        Update: {
+          created_at?: string | null
+          display_info?: string | null
+          id?: number
+          isLive?: boolean
+          link?: string | null
+          start_at?: string | null
+          title?: string | null
+        }
+        Relationships: []
+      }
       partner_contacts: {
         Row: {
           company: string
@@ -64,7 +118,7 @@ export interface Database {
           description: string
           developer: string
           docs: string | null
-          featured: boolean
+          featured: boolean | null
           id: number
           images: string[] | null
           logo: string
@@ -85,7 +139,7 @@ export interface Database {
           description: string
           developer: string
           docs?: string | null
-          featured?: boolean
+          featured?: boolean | null
           id?: number
           images?: string[] | null
           logo: string
@@ -106,7 +160,7 @@ export interface Database {
           description?: string
           developer?: string
           docs?: string | null
-          featured?: boolean
+          featured?: boolean | null
           id?: number
           images?: string[] | null
           logo?: string
@@ -122,13 +176,38 @@ export interface Database {
           {
             foreignKeyName: 'partners_contact_fkey'
             columns: ['contact']
+            isOneToOne: false
             referencedRelation: 'partner_contacts'
             referencedColumns: ['id']
           },
         ]
       }
     }
-    Views: {}
+    Views: {
+      lwx_tickets_golden: {
+        Row: {
+          createdAt: string | null
+          golden: boolean | null
+          id: string | null
+          metadata: Json | null
+          name: string | null
+          referrals: number | null
+          sharedOnLinkedIn: string | null
+          sharedOnTwitter: string | null
+          ticketNumber: number | null
+          username: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: 'lwx_tickets_id_fkey'
+            columns: ['id']
+            isOneToOne: true
+            referencedRelation: 'users'
+            referencedColumns: ['id']
+          },
+        ]
+      }
+    }
     Functions: {}
     Enums: {
       partner_type: 'technology' | 'expert'
@@ -138,3 +217,77 @@ export interface Database {
     }
   }
 }
+
+type PublicSchema = Database[Extract<keyof Database, 'public'>]
+
+export type Tables<
+  PublicTableNameOrOptions extends
+    | keyof (PublicSchema['Tables'] & PublicSchema['Views'])
+    | { schema: keyof Database },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+    ? keyof (Database[PublicTableNameOrOptions['schema']]['Tables'] &
+        Database[PublicTableNameOrOptions['schema']]['Views'])
+    : never = never,
+> = PublicTableNameOrOptions extends { schema: keyof Database }
+  ? (Database[PublicTableNameOrOptions['schema']]['Tables'] &
+      Database[PublicTableNameOrOptions['schema']]['Views'])[TableName] extends {
+      Row: infer R
+    }
+    ? R
+    : never
+  : PublicTableNameOrOptions extends keyof (PublicSchema['Tables'] & PublicSchema['Views'])
+    ? (PublicSchema['Tables'] & PublicSchema['Views'])[PublicTableNameOrOptions] extends {
+        Row: infer R
+      }
+      ? R
+      : never
+    : never
+
+export type TablesInsert<
+  PublicTableNameOrOptions extends keyof PublicSchema['Tables'] | { schema: keyof Database },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+    ? keyof Database[PublicTableNameOrOptions['schema']]['Tables']
+    : never = never,
+> = PublicTableNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicTableNameOrOptions['schema']]['Tables'][TableName] extends {
+      Insert: infer I
+    }
+    ? I
+    : never
+  : PublicTableNameOrOptions extends keyof PublicSchema['Tables']
+    ? PublicSchema['Tables'][PublicTableNameOrOptions] extends {
+        Insert: infer I
+      }
+      ? I
+      : never
+    : never
+
+export type TablesUpdate<
+  PublicTableNameOrOptions extends keyof PublicSchema['Tables'] | { schema: keyof Database },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+    ? keyof Database[PublicTableNameOrOptions['schema']]['Tables']
+    : never = never,
+> = PublicTableNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicTableNameOrOptions['schema']]['Tables'][TableName] extends {
+      Update: infer U
+    }
+    ? U
+    : never
+  : PublicTableNameOrOptions extends keyof PublicSchema['Tables']
+    ? PublicSchema['Tables'][PublicTableNameOrOptions] extends {
+        Update: infer U
+      }
+      ? U
+      : never
+    : never
+
+export type Enums<
+  PublicEnumNameOrOptions extends keyof PublicSchema['Enums'] | { schema: keyof Database },
+  EnumName extends PublicEnumNameOrOptions extends { schema: keyof Database }
+    ? keyof Database[PublicEnumNameOrOptions['schema']]['Enums']
+    : never = never,
+> = PublicEnumNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicEnumNameOrOptions['schema']]['Enums'][EnumName]
+  : PublicEnumNameOrOptions extends keyof PublicSchema['Enums']
+    ? PublicSchema['Enums'][PublicEnumNameOrOptions]
+    : never

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -26,7 +26,7 @@
     "@react-three/fiber": "^7.0.29",
     "@supabase/auth-helpers-react": "^0.4.2",
     "@supabase/auth-ui-react": "^0.4.5",
-    "@supabase/supabase-js": "^2.39.3",
+    "@supabase/supabase-js": "^2.41.1",
     "classnames": "^2.3.1",
     "cobe": "^0.6.2",
     "common": "*",

--- a/apps/www/pages/launch-week/index.tsx
+++ b/apps/www/pages/launch-week/index.tsx
@@ -132,7 +132,7 @@ export const getServerSideProps: GetServerSideProps = async () => {
 
   return {
     props: {
-      meetups: meetups?.sort((a, b) => (new Date(a.start_at) > new Date(b.start_at) ? 1 : -1)),
+      meetups: meetups?.sort((a, b) => (new Date(a.start_at!) > new Date(b.start_at!) ? 1 : -1)),
     },
   }
 }

--- a/apps/www/pages/launch-week/tickets/[username].tsx
+++ b/apps/www/pages/launch-week/tickets/[username].tsx
@@ -142,7 +142,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
     user = data
   }
 
-  const ticketType = user?.metadata?.hasSecretTicket
+  const ticketType = (user?.metadata as any).hasSecretTicket
     ? 'secret'
     : user?.golden
       ? 'platinum'

--- a/package-lock.json
+++ b/package-lock.json
@@ -235,7 +235,7 @@
         "@octokit/plugin-paginate-graphql": "^4.0.0",
         "@radix-ui/react-accordion": "^1.1.2",
         "@supabase/auth-helpers-react": "^0.4.2",
-        "@supabase/supabase-js": "^2.39.3",
+        "@supabase/supabase-js": "^2.41.1",
         "@tailwindcss/container-queries": "^0.1.1",
         "@tanstack/react-query": "^5.13.4",
         "common": "*",
@@ -2116,7 +2116,7 @@
         "@stripe/stripe-js": "^3.0.5",
         "@supabase/auth-helpers-react": "^0.4.2",
         "@supabase/shared-types": "0.1.55",
-        "@supabase/supabase-js": "^2.39.3",
+        "@supabase/supabase-js": "^2.41.1",
         "@tanstack/react-query": "4.35.7",
         "@tanstack/react-query-devtools": "4.35.7",
         "@uidotdev/usehooks": "^2.4.1",
@@ -3393,7 +3393,7 @@
         "@react-three/fiber": "^7.0.29",
         "@supabase/auth-helpers-react": "^0.4.2",
         "@supabase/auth-ui-react": "^0.4.5",
-        "@supabase/supabase-js": "^2.39.3",
+        "@supabase/supabase-js": "^2.41.1",
         "classnames": "^2.3.1",
         "cobe": "^0.6.2",
         "common": "*",
@@ -15674,6 +15674,14 @@
         "@supabase/supabase-js": "^2.19.0"
       }
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.63.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.63.0.tgz",
+      "integrity": "sha512-yIgcHnlgv24GxHtVGUhwGqAFDyJkPIC/xjx7HostN08A8yCy8HIfl4JEkTKyBqD1v1L05jNEJOUke4Lf4O1+Qg==",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
     "node_modules/@supabase/auth-ui-react": {
       "version": "0.4.5",
       "dependencies": {
@@ -15699,8 +15707,9 @@
       "link": true
     },
     "node_modules/@supabase/functions-js": {
-      "version": "2.1.5",
-      "license": "MIT",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.2.2.tgz",
+      "integrity": "sha512-sJGq1nludmi7pY/fdtCpyY/pYonx7MfHdN408bqb736guWcVI1AChYVbI4kUM978EuOE4Ci6l7bUudfGg07QRw==",
       "dependencies": {
         "@supabase/node-fetch": "^2.6.14"
       }
@@ -15709,17 +15718,10 @@
       "resolved": "apps/docs/spec/parser",
       "link": true
     },
-    "node_modules/@supabase/gotrue-js": {
-      "version": "2.62.0",
-      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.62.0.tgz",
-      "integrity": "sha512-4eBuZNXGOk7ewqJuHPYMnk8clCtEx6Hfnu6yHLjZlx7w18TqcojcTRUBZagErtpgwwdfzUwKbquexhbrpH/ysw==",
-      "dependencies": {
-        "@supabase/node-fetch": "^2.6.14"
-      }
-    },
     "node_modules/@supabase/node-fetch": {
-      "version": "2.6.14",
-      "license": "MIT",
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -15838,23 +15840,24 @@
       }
     },
     "node_modules/@supabase/storage-js": {
-      "version": "2.5.4",
-      "license": "MIT",
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.5.5.tgz",
+      "integrity": "sha512-OpLoDRjFwClwc2cjTJZG8XviTiQH4Ik8sCiMK5v7et0MDu2QlXjCAW3ljxJB5+z/KazdMOTnySi+hysxWUPu3w==",
       "dependencies": {
         "@supabase/node-fetch": "^2.6.14"
       }
     },
     "node_modules/@supabase/supabase-js": {
-      "version": "2.39.3",
-      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.39.3.tgz",
-      "integrity": "sha512-NoltJSaJNKDJNutO5sJPAAi5RIWrn1z2XH+ig1+cHDojT6BTN7TvZPNa3Kq3gFQWfO5H1N9El/bCTZJ3iFW2kQ==",
+      "version": "2.41.1",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.41.1.tgz",
+      "integrity": "sha512-xmECLhYugMo/6SObpsOhu5xaxVfsk+JK/d4JSh055bpESmgmN3PLpzbfqejKCpaUeeUNF21+lrJp/U9HQzT9mA==",
       "dependencies": {
-        "@supabase/functions-js": "^2.1.5",
-        "@supabase/gotrue-js": "^2.60.0",
-        "@supabase/node-fetch": "^2.6.14",
-        "@supabase/postgrest-js": "^1.9.0",
-        "@supabase/realtime-js": "^2.9.3",
-        "@supabase/storage-js": "^2.5.4"
+        "@supabase/auth-js": "2.63.0",
+        "@supabase/functions-js": "2.2.2",
+        "@supabase/node-fetch": "2.6.15",
+        "@supabase/postgrest-js": "1.9.2",
+        "@supabase/realtime-js": "2.9.3",
+        "@supabase/storage-js": "2.5.5"
       }
     },
     "node_modules/@swc/core": {
@@ -46139,7 +46142,7 @@
         "typescript": "^5.4.3"
       },
       "peerDependencies": {
-        "@supabase/gotrue-js": "^2.58.0",
+        "@supabase/auth-js": "^2.63.0",
         "@supabase/supabase-js": "*",
         "next": "*",
         "react": "*",
@@ -46960,7 +46963,7 @@
       "license": "MIT",
       "devDependencies": {
         "@faker-js/faker": "^6.1.2",
-        "@supabase/supabase-js": "^2.39.3",
+        "@supabase/supabase-js": "^2.41.1",
         "@testdeck/jest": "^0.3.3",
         "@types/jest": "^29.5.4",
         "@types/node": "^20.11.16",

--- a/packages/common/gotrue.ts
+++ b/packages/common/gotrue.ts
@@ -1,4 +1,4 @@
-import { GoTrueClient, navigatorLock } from '@supabase/gotrue-js'
+import { AuthClient, navigatorLock } from '@supabase/auth-js'
 
 export const STORAGE_KEY = process.env.NEXT_PUBLIC_STORAGE_KEY || 'supabase.dashboard.auth.token'
 export const AUTH_DEBUG_KEY =
@@ -100,7 +100,7 @@ const logIndexedDB = (message: string, ...args: any[]) => {
   })()
 }
 
-export const gotrueClient = new GoTrueClient({
+export const gotrueClient = new AuthClient({
   url: process.env.NEXT_PUBLIC_GOTRUE_URL,
   storageKey: STORAGE_KEY,
   detectSessionInUrl: true,

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -24,7 +24,7 @@
   },
   "peerDependencies": {
     "@supabase/supabase-js": "*",
-    "@supabase/gotrue-js": "^2.58.0",
+    "@supabase/auth-js": "^2.63.0",
     "next": "*",
     "react": "*",
     "react-dom": "*"

--- a/tests/package.json
+++ b/tests/package.json
@@ -18,7 +18,7 @@
   "license": "MIT",
   "devDependencies": {
     "@faker-js/faker": "^6.1.2",
-    "@supabase/supabase-js": "^2.39.3",
+    "@supabase/supabase-js": "^2.41.1",
     "@testdeck/jest": "^0.3.3",
     "@types/jest": "^29.5.4",
     "@types/node": "^20.11.16",


### PR DESCRIPTION
* bumps supabase-js to the latest version
* originally reverted because the API wasn't allowing the `X-Supabase-Api-Version` header 