### PR TITLE
fix: match docs nav icons between sidebar and mobile header

### DIFF
--- a/apps/docs/components/Navigation/NavigationMenu/HomeMenuIconPicker.tsx
+++ b/apps/docs/components/Navigation/NavigationMenu/HomeMenuIconPicker.tsx
@@ -26,58 +26,58 @@ import {
   IconMenuDevCli,
 } from './HomeMenuIcons'
 
-function getMenuIcon(menuKey: string, width: number = 16, height: number = 16) {
+function getMenuIcon(menuKey: string, width: number = 16, height: number = 16, className) {
   switch (menuKey) {
     case 'home':
-      return <IconMenuHome width={width} height={height} />
+      return <IconMenuHome width={width} height={height} className={className} />
     case 'getting-started':
-      return <IconMenuGettingStarted width={width} height={height} />
+      return <IconMenuGettingStarted width={width} height={height} className={className} />
     case 'database':
-      return <IconMenuDatabase width={width} height={height} />
+      return <IconMenuDatabase width={width} height={height} className={className} />
     case 'rest':
-      return <IconMenuRestApis width={width} height={height} />
+      return <IconMenuRestApis width={width} height={height} className={className} />
     case 'graphql':
-      return <IconMenuGraphQL width={width} height={height} />
+      return <IconMenuGraphQL width={width} height={height} className={className} />
     case 'auth':
-      return <IconMenuAuth width={width} height={height} />
+      return <IconMenuAuth width={width} height={height} className={className} />
     case 'edge-functions':
-      return <IconMenuEdgeFunctions width={width} height={height} />
+      return <IconMenuEdgeFunctions width={width} height={height} className={className} />
     case 'realtime':
-      return <IconMenuRealtime width={width} height={height} />
+      return <IconMenuRealtime width={width} height={height} className={className} />
     case 'storage':
-      return <IconMenuStorage width={width} height={height} />
+      return <IconMenuStorage width={width} height={height} className={className} />
     case 'ai':
-      return <IconMenuAI width={width} height={height} />
+      return <IconMenuAI width={width} height={height} className={className} />
     case 'platform':
-      return <IconMenuPlatform width={width} height={height} />
+      return <IconMenuPlatform width={width} height={height} className={className} />
     case 'resources':
-      return <IconMenuResources width={width} height={height} />
+      return <IconMenuResources width={width} height={height} className={className} />
     case 'self-hosting':
-      return <IconMenuSelfHosting width={width} height={height} />
+      return <IconMenuSelfHosting width={width} height={height} className={className} />
     case 'integrations':
-      return <IconMenuIntegrations width={width} height={height} />
+      return <IconMenuIntegrations width={width} height={height} className={className} />
     case 'reference-javascript':
-      return <IconMenuJavascript width={width} height={height} />
+      return <IconMenuJavascript width={width} height={height} className={className} />
     case 'reference-dart':
-      return <IconMenuFlutter width={width} height={height} />
+      return <IconMenuFlutter width={width} height={height} className={className} />
     case 'reference-python':
-      return <IconMenuPython width={width} height={height} />
+      return <IconMenuPython width={width} height={height} className={className} />
     case 'reference-csharp':
-      return <IconMenuCsharp width={width} height={height} />
+      return <IconMenuCsharp width={width} height={height} className={className} />
     case 'reference-swift':
-      return <IconMenuSwift width={width} height={height} />
+      return <IconMenuSwift width={width} height={height} className={className} />
     case 'reference-kotlin':
-      return <IconMenuKotlin width={width} height={height} />
+      return <IconMenuKotlin width={width} height={height} className={className} />
     case 'reference-api':
-      return <IconMenuApi width={width} height={height} />
+      return <IconMenuApi width={width} height={height} className={className} />
     case 'dev-cli':
-      return <IconMenuDevCli width={width} height={height} />
+      return <IconMenuDevCli width={width} height={height} className={className} />
     case 'reference-cli':
-      return <IconMenuCli width={width} height={height} />
+      return <IconMenuCli width={width} height={height} className={className} />
     case 'status':
-      return <IconMenuStatus width={width} height={height} />
+      return <IconMenuStatus width={width} height={height} className={className} />
     default:
-      return <IconMenuPlatform width={width} height={height} />
+      return <IconMenuPlatform width={width} height={height} className={className} />
   }
 }
 
@@ -85,12 +85,14 @@ type HomeMenuIconPickerProps = {
   icon: string
   width?: number
   height?: number
+  className?: string
 }
 
 export default function HomeMenuIconPicker({
   icon,
   width = 16,
   height = 16,
+  className,
 }: HomeMenuIconPickerProps) {
-  return getMenuIcon(icon, width, height)
+  return getMenuIcon(icon, width, height, className)
 }

--- a/apps/docs/components/Navigation/NavigationMenu/HomeMenuIcons.tsx
+++ b/apps/docs/components/Navigation/NavigationMenu/HomeMenuIcons.tsx
@@ -3,11 +3,13 @@ import { products } from 'shared-data'
 type HomeMenuIcon = {
   width?: number
   height?: number
+  className?: string
 }
-export function IconMenuHome({ width = 16, height = 16 }: HomeMenuIcon) {
+export function IconMenuHome({ width = 16, height = 16, className }: HomeMenuIcon) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
+      className={className}
       width={width}
       height={height}
       viewBox="0 0 16 16"
@@ -23,10 +25,11 @@ export function IconMenuHome({ width = 16, height = 16 }: HomeMenuIcon) {
   )
 }
 
-export function IconMenuGraphQL({ width = 16, height = 16 }: HomeMenuIcon) {
+export function IconMenuGraphQL({ width = 16, height = 16, className }: HomeMenuIcon) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
+      className={className}
       width={width}
       height={height}
       viewBox="0 0 16 16"
@@ -42,10 +45,11 @@ export function IconMenuGraphQL({ width = 16, height = 16 }: HomeMenuIcon) {
   )
 }
 
-export function IconMenuApi({ width = 16, height = 16 }: HomeMenuIcon) {
+export function IconMenuApi({ width = 16, height = 16, className }: HomeMenuIcon) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
+      className={className}
       width={width}
       height={height}
       viewBox="0 0 16 16"
@@ -77,7 +81,7 @@ export function IconMenuApi({ width = 16, height = 16 }: HomeMenuIcon) {
   )
 }
 
-export function IconMenuAuth({ width = 16, height = 16 }: HomeMenuIcon) {
+export function IconMenuAuth({ width = 16, height = 16, className }: HomeMenuIcon) {
   return (
     <svg
       viewBox="0 0 16 16"
@@ -96,10 +100,11 @@ export function IconMenuAuth({ width = 16, height = 16 }: HomeMenuIcon) {
   )
 }
 
-export function IconMenuDevCli({ width = 16, height = 16 }: HomeMenuIcon) {
+export function IconMenuDevCli({ width = 16, height = 16, className }: HomeMenuIcon) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
+      className={className}
       width={width}
       height={height}
       viewBox="0 0 16 16"
@@ -115,10 +120,11 @@ export function IconMenuDevCli({ width = 16, height = 16 }: HomeMenuIcon) {
   )
 }
 
-export function IconMenuCli({ width = 16, height = 16 }: HomeMenuIcon) {
+export function IconMenuCli({ width = 16, height = 16, className }: HomeMenuIcon) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
+      className={className}
       width={width}
       height={height}
       viewBox="0 0 16 16"
@@ -132,7 +138,7 @@ export function IconMenuCli({ width = 16, height = 16 }: HomeMenuIcon) {
   )
 }
 
-export function IconMenuCsharp({ width = 16, height = 16 }: HomeMenuIcon) {
+export function IconMenuCsharp({ width = 16, height = 16, className }: HomeMenuIcon) {
   return (
     <svg
       viewBox="0 0 16 16"
@@ -151,10 +157,11 @@ export function IconMenuCsharp({ width = 16, height = 16 }: HomeMenuIcon) {
   )
 }
 
-export function IconMenuDatabase({ width = 16, height = 16 }: HomeMenuIcon) {
+export function IconMenuDatabase({ width = 16, height = 16, className }: HomeMenuIcon) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
+      className={className}
       width={width}
       height={width}
       viewBox="0 0 16 16"
@@ -170,7 +177,7 @@ export function IconMenuDatabase({ width = 16, height = 16 }: HomeMenuIcon) {
   )
 }
 
-export function IconMenuRestApis({ width = 16, height = 16 }: HomeMenuIcon) {
+export function IconMenuRestApis({ width = 16, height = 16, className }: HomeMenuIcon) {
   return (
     <svg
       viewBox="0 0 16 16"
@@ -189,10 +196,11 @@ export function IconMenuRestApis({ width = 16, height = 16 }: HomeMenuIcon) {
   )
 }
 
-export function IconMenuEdgeFunctions({ width = 16, height = 16 }: HomeMenuIcon) {
+export function IconMenuEdgeFunctions({ width = 16, height = 16, className }: HomeMenuIcon) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
+      className={className}
       width={width}
       height={height}
       viewBox="0 0 16 16"
@@ -208,7 +216,7 @@ export function IconMenuEdgeFunctions({ width = 16, height = 16 }: HomeMenuIcon)
   )
 }
 
-export function IconMenuExtensions({ width = 16, height = 16 }: HomeMenuIcon) {
+export function IconMenuExtensions({ width = 16, height = 16, className }: HomeMenuIcon) {
   return (
     <svg
       viewBox="0 0 16 16"
@@ -227,7 +235,7 @@ export function IconMenuExtensions({ width = 16, height = 16 }: HomeMenuIcon) {
   )
 }
 
-export function IconMenuFlutter({ width = 16, height = 16 }: HomeMenuIcon) {
+export function IconMenuFlutter({ width = 16, height = 16, className }: HomeMenuIcon) {
   return (
     <svg
       viewBox="0 0 16 16"
@@ -246,10 +254,11 @@ export function IconMenuFlutter({ width = 16, height = 16 }: HomeMenuIcon) {
   )
 }
 
-export function IconMenuGettingStarted({ width = 16, height = 16 }: HomeMenuIcon) {
+export function IconMenuGettingStarted({ width = 16, height = 16, className }: HomeMenuIcon) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
+      className={className}
       width={width}
       height={height}
       viewBox="0 0 16 16"
@@ -265,10 +274,11 @@ export function IconMenuGettingStarted({ width = 16, height = 16 }: HomeMenuIcon
   )
 }
 
-export function IconMenuIntegrations({ width = 16, height = 16 }: HomeMenuIcon) {
+export function IconMenuIntegrations({ width = 16, height = 16, className }: HomeMenuIcon) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
+      className={className}
       width={width}
       height={height}
       viewBox="0 0 16 16"
@@ -284,7 +294,7 @@ export function IconMenuIntegrations({ width = 16, height = 16 }: HomeMenuIcon) 
   )
 }
 
-export function IconMenuJavascript({ width = 16, height = 16 }: HomeMenuIcon) {
+export function IconMenuJavascript({ width = 16, height = 16, className }: HomeMenuIcon) {
   return (
     <svg
       width={width}
@@ -303,7 +313,7 @@ export function IconMenuJavascript({ width = 16, height = 16 }: HomeMenuIcon) {
   )
 }
 
-export function IconMenuPlatform({ width = 16, height = 16 }: HomeMenuIcon) {
+export function IconMenuPlatform({ width = 16, height = 16, className }: HomeMenuIcon) {
   return (
     <svg
       viewBox="0 0 16 16"
@@ -322,7 +332,7 @@ export function IconMenuPlatform({ width = 16, height = 16 }: HomeMenuIcon) {
   )
 }
 
-export function IconMenuPython({ width = 16, height = 16 }: HomeMenuIcon) {
+export function IconMenuPython({ width = 16, height = 16, className }: HomeMenuIcon) {
   return (
     <svg
       viewBox="0 0 16 16"
@@ -341,10 +351,11 @@ export function IconMenuPython({ width = 16, height = 16 }: HomeMenuIcon) {
   )
 }
 
-export function IconMenuRealtime({ width = 16, height = 16 }: HomeMenuIcon) {
+export function IconMenuRealtime({ width = 16, height = 16, className }: HomeMenuIcon) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
+      className={className}
       width={width}
       height={height}
       viewBox="0 0 16 16"
@@ -360,10 +371,11 @@ export function IconMenuRealtime({ width = 16, height = 16 }: HomeMenuIcon) {
   )
 }
 
-export function IconMenuResources({ width = 16, height = 16 }: HomeMenuIcon) {
+export function IconMenuResources({ width = 16, height = 16, className }: HomeMenuIcon) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
+      className={className}
       width={width}
       height={height}
       viewBox="0 0 16 16"
@@ -379,7 +391,7 @@ export function IconMenuResources({ width = 16, height = 16 }: HomeMenuIcon) {
   )
 }
 
-export function IconMenuSelfHosting({ width = 16, height = 16 }: HomeMenuIcon) {
+export function IconMenuSelfHosting({ width = 16, height = 16, className }: HomeMenuIcon) {
   return (
     <svg
       viewBox="0 0 16 16"
@@ -398,7 +410,7 @@ export function IconMenuSelfHosting({ width = 16, height = 16 }: HomeMenuIcon) {
   )
 }
 
-export function IconMenuStorage({ width = 16, height = 16 }: HomeMenuIcon) {
+export function IconMenuStorage({ width = 16, height = 16, className }: HomeMenuIcon) {
   return (
     <svg
       viewBox="0 0 16 16"
@@ -417,7 +429,7 @@ export function IconMenuStorage({ width = 16, height = 16 }: HomeMenuIcon) {
   )
 }
 
-export function IconMenuAI({ width = 16, height = 16 }: HomeMenuIcon) {
+export function IconMenuAI({ width = 16, height = 16, className }: HomeMenuIcon) {
   return (
     <svg
       width={width}
@@ -437,7 +449,7 @@ export function IconMenuAI({ width = 16, height = 16 }: HomeMenuIcon) {
   )
 }
 
-export function IconMenuSwift({ width = 16, height = 16 }: HomeMenuIcon) {
+export function IconMenuSwift({ width = 16, height = 16, className }: HomeMenuIcon) {
   return (
     <svg
       viewBox="0 0 16 16"
@@ -456,10 +468,11 @@ export function IconMenuSwift({ width = 16, height = 16 }: HomeMenuIcon) {
   )
 }
 
-export function IconMenuKotlin({ width = 16, height = 16 }: HomeMenuIcon) {
+export function IconMenuKotlin({ width = 16, height = 16, className }: HomeMenuIcon) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
+      className={className}
       viewBox="0 0 16 16"
       width={width}
       height={height}
@@ -475,7 +488,7 @@ export function IconMenuKotlin({ width = 16, height = 16 }: HomeMenuIcon) {
   )
 }
 
-export function IconMenuStatus({ width = 16, height = 16 }: HomeMenuIcon) {
+export function IconMenuStatus({ width = 16, height = 16, className }: HomeMenuIcon) {
   return (
     <svg
       width={width}

--- a/apps/docs/components/Navigation/NavigationMenu/HomeMenuIcons.tsx
+++ b/apps/docs/components/Navigation/NavigationMenu/HomeMenuIcons.tsx
@@ -84,6 +84,7 @@ export function IconMenuApi({ width = 16, height = 16, className }: HomeMenuIcon
 export function IconMenuAuth({ width = 16, height = 16, className }: HomeMenuIcon) {
   return (
     <svg
+      className={className}
       viewBox="0 0 16 16"
       width={width}
       height={height}
@@ -141,6 +142,7 @@ export function IconMenuCli({ width = 16, height = 16, className }: HomeMenuIcon
 export function IconMenuCsharp({ width = 16, height = 16, className }: HomeMenuIcon) {
   return (
     <svg
+      className={className}
       viewBox="0 0 16 16"
       width={width}
       height={height}
@@ -180,6 +182,7 @@ export function IconMenuDatabase({ width = 16, height = 16, className }: HomeMen
 export function IconMenuRestApis({ width = 16, height = 16, className }: HomeMenuIcon) {
   return (
     <svg
+      className={className}
       viewBox="0 0 16 16"
       width={width}
       height={height}
@@ -219,6 +222,7 @@ export function IconMenuEdgeFunctions({ width = 16, height = 16, className }: Ho
 export function IconMenuExtensions({ width = 16, height = 16, className }: HomeMenuIcon) {
   return (
     <svg
+      className={className}
       viewBox="0 0 16 16"
       width={width}
       height={height}
@@ -238,6 +242,7 @@ export function IconMenuExtensions({ width = 16, height = 16, className }: HomeM
 export function IconMenuFlutter({ width = 16, height = 16, className }: HomeMenuIcon) {
   return (
     <svg
+      className={className}
       viewBox="0 0 16 16"
       width={width}
       height={height}
@@ -297,6 +302,7 @@ export function IconMenuIntegrations({ width = 16, height = 16, className }: Hom
 export function IconMenuJavascript({ width = 16, height = 16, className }: HomeMenuIcon) {
   return (
     <svg
+      className={className}
       width={width}
       height={height}
       fill="none"
@@ -316,6 +322,7 @@ export function IconMenuJavascript({ width = 16, height = 16, className }: HomeM
 export function IconMenuPlatform({ width = 16, height = 16, className }: HomeMenuIcon) {
   return (
     <svg
+      className={className}
       viewBox="0 0 16 16"
       width={width}
       height={height}
@@ -335,6 +342,7 @@ export function IconMenuPlatform({ width = 16, height = 16, className }: HomeMen
 export function IconMenuPython({ width = 16, height = 16, className }: HomeMenuIcon) {
   return (
     <svg
+      className={className}
       viewBox="0 0 16 16"
       width={width}
       height={height}
@@ -394,6 +402,7 @@ export function IconMenuResources({ width = 16, height = 16, className }: HomeMe
 export function IconMenuSelfHosting({ width = 16, height = 16, className }: HomeMenuIcon) {
   return (
     <svg
+      className={className}
       viewBox="0 0 16 16"
       width={width}
       height={height}
@@ -413,6 +422,7 @@ export function IconMenuSelfHosting({ width = 16, height = 16, className }: Home
 export function IconMenuStorage({ width = 16, height = 16, className }: HomeMenuIcon) {
   return (
     <svg
+      className={className}
       viewBox="0 0 16 16"
       width={width}
       height={height}
@@ -432,6 +442,7 @@ export function IconMenuStorage({ width = 16, height = 16, className }: HomeMenu
 export function IconMenuAI({ width = 16, height = 16, className }: HomeMenuIcon) {
   return (
     <svg
+      className={className}
       width={width}
       height={height}
       viewBox="0 0 16 16"
@@ -452,6 +463,7 @@ export function IconMenuAI({ width = 16, height = 16, className }: HomeMenuIcon)
 export function IconMenuSwift({ width = 16, height = 16, className }: HomeMenuIcon) {
   return (
     <svg
+      className={className}
       viewBox="0 0 16 16"
       width={width}
       height={height}
@@ -491,6 +503,7 @@ export function IconMenuKotlin({ width = 16, height = 16, className }: HomeMenuI
 export function IconMenuStatus({ width = 16, height = 16, className }: HomeMenuIcon) {
   return (
     <svg
+      className={className}
       width={width}
       height={height}
       viewBox="0 0 18 18"

--- a/apps/docs/layouts/MainSkeleton.tsx
+++ b/apps/docs/layouts/MainSkeleton.tsx
@@ -6,141 +6,142 @@ import { type CSSProperties, type PropsWithChildren, memo, useEffect } from 'rea
 import { cn } from 'ui'
 
 import Footer from '~/components/Navigation/Footer'
+import HomeMenuIconPicker from '~/components/Navigation/NavigationMenu/HomeMenuIconPicker'
 import NavigationMenu, { type MenuId } from '~/components/Navigation/NavigationMenu/NavigationMenu'
 import TopNavBar from '~/components/Navigation/NavigationMenu/TopNavBar'
 import { menuState, useMenuMobileOpen } from '~/hooks/useMenuState'
 
 const levelsData = {
   home: {
-    icon: '/docs/img/icons/menu/home',
+    icon: 'home',
     name: 'Home',
   },
   gettingstarted: {
-    icon: '/docs/img/icons/menu/getting-started',
+    icon: 'getting-started',
     name: 'Getting Started',
   },
   database: {
-    icon: '/docs/img/icons/menu/database',
+    icon: 'database',
     name: 'Database',
   },
   api: {
-    icon: '/docs/img/icons/menu/rest',
+    icon: 'rest',
     name: 'REST API',
   },
   graphql: {
-    icon: '/docs/img/icons/menu/graphql',
+    icon: 'graphql',
     name: 'GraphQL',
   },
   auth: {
-    icon: '/docs/img/icons/menu/auth',
+    icon: 'auth',
     name: 'Auth',
   },
   functions: {
-    icon: '/docs/img/icons/menu/functions',
+    icon: 'edge-functions',
     name: 'Edge Functions',
   },
   realtime: {
-    icon: '/docs/img/icons/menu/realtime',
+    icon: 'realtime',
     name: 'Realtime',
   },
   analytics: {
-    icon: '/docs/img/icons/menu/analytics',
+    icon: 'analytics',
     name: 'Analytics',
   },
   storage: {
-    icon: '/docs/img/icons/menu/storage',
+    icon: 'storage',
     name: 'Storage',
   },
   ai: {
-    icon: '/docs/img/icons/menu/ai',
+    icon: 'ai',
     name: 'AI & Vectors',
   },
   supabase_cli: {
-    icon: '/docs/img/icons/menu/reference-cli',
+    icon: 'reference-cli',
     name: 'Supabase CLI',
   },
   platform: {
-    icon: '/docs/img/icons/menu/platform',
+    icon: 'platform',
     name: 'Platform',
   },
   resources: {
-    icon: '/docs/img/icons/menu/resources',
+    icon: 'resources',
     name: 'Resources',
   },
   self_hosting: {
-    icon: '/docs/img/icons/menu/self-hosting',
+    icon: 'self-hosting',
     name: 'Self-Hosting',
   },
   integrations: {
-    icon: '/docs/img/icons/menu/integrations',
+    icon: 'integrations',
     name: 'Integrations',
   },
   reference_javascript_v1: {
-    icon: '/docs/img/icons/menu/reference-javascript',
+    icon: 'reference-javascript',
     name: 'Javascript Reference v1.0',
   },
   reference_javascript_v2: {
-    icon: '/docs/img/icons/menu/reference-javascript',
+    icon: 'reference-javascript',
     name: 'Javascript Reference v2.0',
   },
   reference_dart_v1: {
-    icon: '/docs/img/icons/menu/reference-dart',
+    icon: 'reference-dart',
     name: 'Dart Reference v1.0',
   },
   reference_dart_v2: {
-    icon: '/docs/img/icons/menu/reference-dart',
+    icon: 'reference-dart',
     name: 'Dart Reference v2.0',
   },
   reference_csharp_v0: {
-    icon: '/docs/img/icons/menu/reference-csharp',
+    icon: 'reference-csharp',
     name: 'C# Reference v0.0',
   },
   reference_python_v2: {
-    icon: '/docs/img/icons/menu/reference-python',
+    icon: 'reference-python',
     name: 'Python Reference v2.0',
   },
   reference_swift_v1: {
-    icon: '/docs/img/icons/menu/reference-swift',
+    icon: 'reference-swift',
     name: 'Swift Reference v1.0',
   },
   reference_swift_v2: {
-    icon: '/docs/img/icons/menu/reference-swift',
+    icon: 'reference-swift',
     name: 'Swift Reference v2.0',
   },
   reference_kotlin_v1: {
-    icon: '/docs/img/icons/menu/reference-kotlin',
+    icon: 'reference-kotlin',
     name: 'Kotlin Reference v1.0',
   },
   reference_kotlin_v2: {
-    icon: '/docs/img/icons/menu/reference-kotlin',
+    icon: 'reference-kotlin',
     name: 'Kotlin Reference v2.0',
   },
   reference_cli: {
-    icon: '/docs/img/icons/menu/reference-cli',
+    icon: 'reference-cli',
     name: 'CLI Reference',
   },
   reference_api: {
-    icon: '/docs/img/icons/menu/reference-api',
+    icon: 'reference-api',
     name: 'Management API Reference',
   },
   reference_self_hosting_auth: {
-    icon: '/docs/img/icons/menu/reference-auth',
+    icon: 'reference-auth',
     name: 'Auth Server Reference',
   },
   reference_self_hosting_storage: {
-    icon: '/docs/img/icons/menu/reference-storage',
+    icon: 'reference-storage',
     name: 'Storage Server Reference',
   },
   reference_self_hosting_realtime: {
-    icon: '/docs/img/icons/menu/reference-realtime',
+    icon: 'reference-realtime',
     name: 'Realtime Server Reference',
   },
   reference_self_hosting_analytics: {
-    icon: '/docs/img/icons/menu/reference-analytics',
+    icon: 'reference-analytics',
     name: 'Analytics Server Reference',
   },
   reference_self_hosting_functions: {
-    icon: '/docs/img/icons/menu/reference-functions',
+    icon: 'reference-functions',
     name: 'Functions Server Reference',
   },
 }
@@ -187,8 +188,8 @@ const MobileHeader = memo(function MobileHeader({ menuId }: { menuId: MenuId }) 
         </div>
       </button>
       <div className={[].join(' ')}>
-        <img
-          src={menuLevel ? levelsData[menuLevel].icon + '.svg' : levelsData['home'].icon + '.svg'}
+        <HomeMenuIconPicker
+          icon={menuLevel ? levelsData[menuLevel].icon : 'home'}
           className={[
             'transition-all duration-200',
             mobileMenuOpen ? 'invisible w-0 h-0' : 'w-4 h-4',


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Styling is slightly off between sidebar and mobile header icons

## What is the new behavior?

Styling is the same (modulo currentColor)

## Additional context

Add any other context or screenshots.
