### PR TITLE
fix: hide legacy auth-helpers docs so deprecation notice is more obvious

### DIFF
--- a/apps/docs/content/guides/auth/auth-helpers/nextjs-pages.mdx
+++ b/apps/docs/content/guides/auth/auth-helpers/nextjs-pages.mdx
@@ -11,6 +11,20 @@ The `auth-helpers` package has been replaced with the `@supabase/ssr` package. W
 
 </Admonition>
 
+<Accordion
+  type="default"
+  openBehaviour="multiple"
+  chevronAlign="right"
+  justified
+  size="medium"
+  className="text-foreground-light border-b mt-8 pb-2"
+  >
+  
+  <Accordion.Item
+        header="See legacy docs"
+        id="legacy-docs"
+      >
+
 This submodule provides convenience helpers for implementing user authentication in Next.js applications using the pages directory.
 
 > Note: As of [Next.js 13.4](https://nextjs.org/blog/next-13-4), the App Router has reached stable status. This is now the recommended path for new Next.js app. Check out our guide on using [Auth Helpers with the Next.js App Directory](/docs/guides/auth/auth-helpers/nextjs).
@@ -914,3 +928,7 @@ import { Database } from '../database.types'
 
 const supabaseClient = useSupabaseClient<Database>()
 ```
+
+</Accordion.Item>
+
+</Accordion>

--- a/apps/docs/content/guides/auth/auth-helpers/nextjs.mdx
+++ b/apps/docs/content/guides/auth/auth-helpers/nextjs.mdx
@@ -11,6 +11,20 @@ The `auth-helpers` package has been replaced with the `@supabase/ssr` package. W
 
 </Admonition>
 
+<Accordion
+  type="default"
+  openBehaviour="multiple"
+  chevronAlign="right"
+  justified
+  size="medium"
+  className="text-foreground-light border-b mt-8 pb-2"
+  >
+  
+  <Accordion.Item
+        header="See legacy docs"
+        id="legacy-docs"
+      >
+
 The [Next.js Auth Helpers package](https://github.com/supabase/auth-helpers) configures Supabase Auth to store the user's `session` in a `cookie`, rather than `localStorage`. This makes it available across the client and server of the App Router - [Client Components](/docs/guides/auth/auth-helpers/nextjs#client-components), [Server Components](/docs/guides/auth/auth-helpers/nextjs#server-components), [Server Actions](/docs/guides/auth/auth-helpers/nextjs#server-actions), [Route Handlers](/docs/guides/auth/auth-helpers/nextjs#route-handlers) and [Middleware](/docs/guides/auth/auth-helpers/nextjs#middleware). The `session` is automatically sent along with any requests to Supabase.
 
 <div className="video-container">
@@ -1312,3 +1326,7 @@ export default function() {
 ```
 
 For an example of creating multiple Supabase clients, check [Singleton section](/docs/guides/auth/auth-helpers/nextjs#singleton) above.
+
+</Accordion.Item>
+
+</Accordion>

--- a/apps/docs/content/guides/auth/auth-helpers/remix.mdx
+++ b/apps/docs/content/guides/auth/auth-helpers/remix.mdx
@@ -11,6 +11,20 @@ We generally recommend using the new `@supabase/ssr` package instead of `auth-he
 
 </Admonition>
 
+<Accordion
+  type="default"
+  openBehaviour="multiple"
+  chevronAlign="right"
+  justified
+  size="medium"
+  className="text-foreground-light border-b mt-8 pb-2"
+  >
+  
+  <Accordion.Item
+        header="See legacy docs"
+        id="legacy-docs"
+      >
+
 This submodule provides convenience helpers for implementing user authentication in Remix applications.
 
 <div className="video-container">
@@ -782,3 +796,7 @@ supabaseClient.auth.signUp({
   },
 })
 ```
+
+</Accordion.Item>
+
+</Accordion>

--- a/apps/docs/content/guides/auth/auth-helpers/sveltekit.mdx
+++ b/apps/docs/content/guides/auth/auth-helpers/sveltekit.mdx
@@ -11,6 +11,20 @@ We generally recommend using the new `@supabase/ssr` package instead of `auth-he
 
 </Admonition>
 
+<Accordion
+  type="default"
+  openBehaviour="multiple"
+  chevronAlign="right"
+  justified
+  size="medium"
+  className="text-foreground-light border-b mt-8 pb-2"
+  >
+  
+  <Accordion.Item
+        header="See legacy docs"
+        id="legacy-docs"
+      >
+
 This submodule provides convenience helpers for implementing user authentication in [SvelteKit](https://kit.svelte.dev/) applications.
 
 ## Configuration
@@ -1966,3 +1980,7 @@ export const GET: RequestHandler = withAuth(async ({ session, getSupabaseClient 
 
 - [Auth Helpers Source code](https://github.com/supabase/auth-helpers)
 - [SvelteKit example](https://github.com/supabase/auth-helpers/tree/main/examples/sveltekit)
+
+</Accordion.Item>
+
+</Accordion>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Deprecation notice on Auth Helpers docs is too easy to miss, leading to people wasting their time setting it up before noticing the link to the new instructions.

## What is the new behavior?

Hid the legacy docs in a collapsible so you can't miss the callout.

<img width="884" alt="image" src="https://github.com/supabase/supabase/assets/26616127/a43b254a-de79-4864-b40e-bc45abf65bd5">

## Additional context

Add any other context or screenshots.
