### PR TITLE
Correct link to Splinter docs

### DIFF
--- a/apps/studio/pages/project/[ref]/reports/linter.tsx
+++ b/apps/studio/pages/project/[ref]/reports/linter.tsx
@@ -108,7 +108,7 @@ const ProjectLints: NextPageWithLayout = () => {
           </div>
           <div className="flex items-center gap-x-2">
             <Button asChild type="default" icon={<ExternalLink />}>
-              <a href="/" target="_blank" rel="noreferrer">
+              <a href="https://supabase.github.io/splinter" target="_blank" rel="noreferrer">
                 Documentation
               </a>
             </Button>


### PR DESCRIPTION
## What is the current behavior?

Button "Documentation" on the Reports->Project Linter page points to "https://supabase.com"

## What is the new behavior?

Button "Documentation" on the Reports->Project Linter page points to "https://supabase.github.io/splinter"