### PR TITLE
Set different colors for RLS templates UPDATE and ALL, and add placeholders with using and with check monaco fields

### DIFF
--- a/apps/studio/components/interfaces/Auth/Policies/AIPolicyEditorPanel/PolicyTemplates.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/AIPolicyEditorPanel/PolicyTemplates.tsx
@@ -83,10 +83,15 @@ export const PolicyTemplates = ({
                   icon={
                     <div className="min-w-16">
                       <Badge
-                        className="!rounded font-mono"
+                        className={cn(
+                          '!rounded font-mono',
+                          template.command === 'UPDATE'
+                            ? 'bg-blue-400 text-blue-900 border border-blue-800'
+                            : ''
+                        )}
                         variant={
                           template.command === 'ALL'
-                            ? 'default'
+                            ? 'outline'
                             : template.command === 'SELECT'
                               ? 'brand'
                               : template.command === 'UPDATE'

--- a/apps/studio/components/interfaces/Auth/Policies/AIPolicyEditorPanel/index.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/AIPolicyEditorPanel/index.tsx
@@ -551,14 +551,20 @@ export const AIPolicyEditorPanel = memo(function ({
                         />
 
                         <div
-                          className={`py-1 relative ${incomingChange ? 'hidden' : 'block'}`}
+                          className={`mt-1 relative ${incomingChange ? 'hidden' : 'block'}`}
                           style={{
                             height:
                               expOneContentHeight <= 100 ? `${8 + expOneContentHeight}px` : '108px',
                           }}
                         >
                           <RLSCodeEditor
+                            disableTabToUsePlaceholder
                             id="rls-exp-one-editor"
+                            placeholder={
+                              command === 'insert'
+                                ? '-- Provide a SQL expression for the with check statement'
+                                : '-- Provide a SQL expression for the using statement'
+                            }
                             defaultValue={command === 'insert' ? check : using}
                             value={command === 'insert' ? check : using}
                             editorRef={editorOneRef}
@@ -608,7 +614,7 @@ export const AIPolicyEditorPanel = memo(function ({
                         {showCheckBlock && (
                           <>
                             <div
-                              className={`py-1 relative ${incomingChange ? 'hidden' : 'block'}`}
+                              className={`mt-1 relative ${incomingChange ? 'hidden' : 'block'}`}
                               style={{
                                 height:
                                   expTwoContentHeight <= 100
@@ -617,7 +623,9 @@ export const AIPolicyEditorPanel = memo(function ({
                               }}
                             >
                               <RLSCodeEditor
+                                disableTabToUsePlaceholder
                                 id="rls-exp-two-editor"
+                                placeholder="-- Provide a SQL expression for the with check statement"
                                 defaultValue={check}
                                 value={check}
                                 editorRef={editorTwoRef}

--- a/apps/studio/data/database/schemas-query.ts
+++ b/apps/studio/data/database/schemas-query.ts
@@ -1,10 +1,9 @@
-import { QueryClient, UseQueryOptions } from '@tanstack/react-query'
 import pgMeta from '@supabase/pg-meta'
+import { QueryClient, UseQueryOptions } from '@tanstack/react-query'
 import { z } from 'zod'
 
-import { databaseKeys } from './keys'
 import { ExecuteSqlData, useExecuteSqlQuery } from 'data/sql/execute-sql-query'
-import { ResponseError } from 'types'
+import { databaseKeys } from './keys'
 
 export type SchemasVariables = {
   projectRef?: string


### PR DESCRIPTION
Addresses 2 feedback from Terry's twitter thread [here](https://twitter.com/saltcod/status/1772324383345807601)

- Make RLS templates badge colors different for UPDATE and ALL command type templates
- Add placeholder text for using and with check monaco editor input fields