### PR TITLE
Update cloudflare-turnstile.mdx

### DIFF
--- a/apps/docs/content/guides/functions/examples/cloudflare-turnstile.mdx
+++ b/apps/docs/content/guides/functions/examples/cloudflare-turnstile.mdx
@@ -78,7 +78,7 @@ Deno.serve(async (req) => {
 
 ```bash
 supabase functions deploy cloudflare-turnstile
-supabase secrets set CLOUDFLARE_TURNSTILE_SECRET_KEY=your_secret_key
+supabase secrets set CLOUDFLARE_SECRET_KEY=your_secret_key
 ```
 
 ## Invoke the function from your site


### PR DESCRIPTION
Incorrect secret name in documentation breaks implementation.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES ... skimmed it.

## What kind of change does this PR introduce?

Fix error in documentation

## What is the current behavior?

Incorrect secret name causes challenge to always fail

## What is the new behavior?

Challenge now succeeds/fails appropriately.
