### PR TITLE
fix: information box icons alignment

### DIFF
--- a/apps/studio/components/ui/InformationBox.tsx
+++ b/apps/studio/components/ui/InformationBox.tsx
@@ -36,7 +36,7 @@ const InformationBox = ({
     >
       <div className="flex flex-col px-4">
         <div className="flex items-center justify-between">
-          <div className="flex w-full space-x-3 lg:items-start">
+          <div className="flex w-full space-x-3 items-center">
             {icon && <span className="text-foreground-lighter">{icon}</span>}
             <div className="flex-grow">
               <h5 className="text-sm text-foreground">{title}</h5>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

UI - Information Box icons

## What is the current behavior?

The icons are not aligned in the top header:

<img width="819" alt="Screenshot 2024-04-02 at 19 33 42" src="https://github.com/supabase/supabase/assets/22655069/3010c7b5-6914-41db-be9b-c8fc8d4d1c86">


## What is the new behavior?

<img width="819" alt="Screenshot 2024-04-02 at 20 25 54" src="https://github.com/supabase/supabase/assets/22655069/daf1604e-548d-4ccb-a461-60bf5ec170ac">
