### PR TITLE
Linking replication docs and highlighting responsibilities

### DIFF
--- a/apps/docs/content/guides/database/postgres/setup-replication-external.mdx
+++ b/apps/docs/content/guides/database/postgres/setup-replication-external.mdx
@@ -1,8 +1,18 @@
 ---
-title: 'Replicate to another Postgres database using Logical Replication'
+title: 'Replicate from Supabase to another Postgres database using Logical Replication'
 description: 'Example to setup logical replication using publish-subscribe to a Postgres database outside of Supabase'
 footerHelpType: 'postgres'
 ---
+
+For most use cases, our managed [Read Replica](/docs/content/guides/platform/read-replicas.mdx) service will be more than enough for your [replication](/docs/content/guides/database/replication.mdx) needs.
+
+When you need a more manual replication setup, setting up logical replication is the way to go. Before we dive in, let's cover some points about logical replication.
+
+Logical replication works by creating [publications](https://www.postgresql.org/docs/current/sql-createpublication.html), that use [replication slots](https://www.postgresql.org/docs/current/warm-standby.html#STREAMING-REPLICATION-SLOTS), to send data from your database to any [subscriptions](https://www.postgresql.org/docs/current/logical-replication-subscription.html) against your publication.
+
+Supabase Realtime uses [replication](/docs/docs/ref/realtime/realtime.mdx) in this way. Being able to configure your own replication can be vital for some, but it can also have some side effects that impact on your database performance.
+
+## Replication from Supabase to PostgreSQL
 
 For this example, you will need:
 
@@ -60,3 +70,16 @@ ALTER PUBLICATION example_pub ADD TABLE example_table;
 ```sql
 select * from pg_stat_replication;
 ```
+
+## Replication from Supabase to Data Warehouses using ETL tools
+
+For this example, you will need:
+- A Supabase project
+- An ETL tool, such as: [Estuary](https://supabase.com/partners/integrations/estuary), 
+A destination data-source (such as [Airbyte](https://airbyte.com/), [Materialize](https://materialize.com/) or [Estuary](https://estuary.dev/))
+
+ETL stands for `Extract`, `Transform` and `Load` and they do exactly that. Using the logical replication functionality of PostgreSQL, these tools extract changes from your database, transform them (if necessary) to suit your needs or to support the destination and then load the data to your configured destination.
+
+The steps are similar to the section above but you should check the specific documentation for the tool/service that you are using.
+
+

--- a/apps/docs/content/guides/database/replication.mdx
+++ b/apps/docs/content/guides/database/replication.mdx
@@ -6,10 +6,24 @@ slug: 'replication'
 
 Replication is a technique for copying the data from one database to another. Supabase uses replication functionality to provide a real-time API. Replication is useful for:
 
-- Spreading out the "load." For example, if your database has a lot of reads, you might want to split it between two databases.
-- Reducing latency. For example, you may want one database in London to serve your European customers, and one in New York to serve the US.
+1. Spreading out the "load." For example, if your database has a lot of reads, you might want to split it between two databases.
+2. Reducing latency. For example, you may want one database in London to serve your European customers, and one in New York to serve the US.
+3. Extracting data from your database into a Data Warehouse (or a different destination)
+4. Listening to the database for changes (as realtime does)
 
 Replication is done through _publications_, a method of choosing which changes to send to other systems (usually another Postgres database). Publications can be managed in the [Dashboard](https://supabase.com/dashboard) or with SQL.
+
+If points 1 and 2 are your goals, check out our managed [Read Replicas](/docs/content/guides/platform/read-replicas.mdx)
+
+If point 3 is your aim, a guide on using replication to send data to external tools can be found [here](/docs/content/guides/database/postgres/setup-replication-external.mdx)
+
+<Admonition type="caution">
+
+When setting up replication, you are responsible for the publication and the subscriptions. Replication from Supabase is not part of the platform's core features and is not covered by support. For more information, see our [Shared Responsibility Model](/docs/content/guides/platform/shared-responsibility-model.mdx)
+
+If your destination is not available (or if your Supabase project has a spike in traffic) then you will see your disk usage grow and your replication can fail. It is your responsibility to monitor and remedy this.
+
+</Admonition>
 
 ## Manage publications in the dashboard
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update to link all replication docs together 

## What is the current behavior?

3 replication docs that are related in content but not necessarily linked to each other

## What is the new behavior?

Using the primary replication doc to link to `read replicas` and the `external replication guide` and highlight the responsibility when setting up own replication

## Additional context

Add any other context or screenshots.
