### PR TITLE
Fix sveltekit hooks.server.ts example

### DIFF
--- a/apps/docs/content/guides/auth/server-side/creating-a-client.mdx
+++ b/apps/docs/content/guides/auth/server-side/creating-a-client.mdx
@@ -477,7 +477,7 @@ export const handle: Handle = async ({ event, resolve }) => {
     const {
       data: { user },
       error,
-    } = await supabase.auth.getUser()
+    } = await event.locals.supabase.auth.getUser()
     if (error) {
       return { session: null, user: null }
     }


### PR DESCRIPTION
The `supabase` variable doesn't exist in this context, but an instance is accessible through the `event.locals`.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

Invalid example

## What is the new behavior?

Fix the example

## Additional context
