### PR TITLE
enhancement: store query params in docs feedback

### DIFF
--- a/apps/docs/components/Feedback/Feedback.tsx
+++ b/apps/docs/components/Feedback/Feedback.tsx
@@ -85,7 +85,13 @@ function Feedback() {
   const showNo = unanswered || isNo
 
   async function sendFeedbackVote(response: Response) {
-    const { error } = await supabase.from('feedback').insert({ vote: response, page: pathname })
+    const { error } = await supabase.from('feedback').insert({
+      vote: response,
+      page: pathname,
+      metadata: {
+        query: Object.fromEntries(new URLSearchParams(window.location.search).entries()),
+      },
+    })
     if (error) console.error(error)
   }
 

--- a/supabase/migrations/20240403133820_track_feedback_query_params.sql
+++ b/supabase/migrations/20240403133820_track_feedback_query_params.sql
@@ -1,0 +1,2 @@
+alter table public.feedback
+add column metadata jsonb;


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Enhancement

## What is the current behavior?

Query params are not stored when users submit feedback

## What is the new behavior?

Store query params so we can figure out what tab the feedback refers to.

## Additional context

<img width="1130" alt="image" src="https://github.com/supabase/supabase/assets/26616127/45d91de5-c281-4db8-91bb-b1124f5ef9e9">
