### PR TITLE
docs: adds HonosJS + Supabase Auth example in Example Apps

### DIFF
--- a/apps/docs/content/guides/resources/examples.mdx
+++ b/apps/docs/content/guides/resources/examples.mdx
@@ -150,6 +150,7 @@ Build a basic Todo List with Supabase and your favorite frontend framework:
 - Supabase + Ory Cloud [Github](https://github.com/ory/examples/tree/master/supabase-ory-cloud)
 - Supabase Auth with React Native + Next.js (Monorepo) [Github](https://github.com/mateoguzmana/react-native-next-supabase-auth-monorepo)
 - Supabase Auth with Nuxt3 [Github](https://github.com/zackha/supaAuth)
+- Supabase Auth with HonosJS [Github](https://github.com/CarlosZiegler/hono-supabase)
 
 ### Blog posts
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

Current behaviour: No example related to HonosJS + Supabase Auth is present
Issue: #21156

## What is the new behavior?

A Github link to the boilerplate code of Supabase Auth with HonosJS is now available in `/docs/guides/resources/examples#example-apps` path

## Additional context

Attached screenshot with the change

<img width="1640" alt="image" src="https://github.com/supabase/supabase/assets/72190185/d780b24d-0b33-4009-8293-31569904677c">

