### PR TITLE
fix: change some docs links to make more sense

### DIFF
--- a/apps/docs/content/guides/getting-started/quickstarts/nextjs.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/nextjs.mdx
@@ -171,6 +171,6 @@ hideToc: true
 
 ## Next steps
 
-- Set up [Auth](/docs/guides/auth/server-side/overview) for your app
+- Set up [Auth](/docs/guides/auth) for your app
 - [Insert more data](/docs/guides/database/import-data) into your database
 - Upload and serve static files using [Storage](/docs/guides/storage)

--- a/apps/docs/content/guides/getting-started/quickstarts/reactjs.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/reactjs.mdx
@@ -139,6 +139,6 @@ hideToc: true
 
 ## Next steps
 
-- Set up [Auth](/docs/guides/auth/server-side/overview) for your app
+- Set up [Auth](/docs/guides/auth) for your app
 - [Insert more data](/docs/guides/database/import-data) into your database
 - Upload and serve static files using [Storage](/docs/guides/storage)

--- a/apps/docs/content/guides/getting-started/quickstarts/sveltekit.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/sveltekit.mdx
@@ -161,6 +161,6 @@ hideToc: true
 
 ## Next steps
 
-- Set up [Auth](/docs/guides/auth/server-side/overview) for your app
+- Set up [Auth](/docs/guides/auth) for your app
 - [Insert more data](/docs/guides/database/import-data) into your database
 - Upload and serve static files using [Storage](/docs/guides/storage)

--- a/apps/docs/data/footer.ts
+++ b/apps/docs/data/footer.ts
@@ -23,10 +23,13 @@ export const primaryLinks = [
 ]
 
 export const secondaryLinks = [
-  { title: 'Contributing', url: '/handbook/contributing' },
+  {
+    title: 'Contributing',
+    url: 'https://github.com/supabase/supabase/blob/master/apps/docs/DEVELOPERS.md',
+  },
   {
     title: 'Author Styleguide',
-    url: 'https://github.com/supabase/supabase/blob/master/DEVELOPERS.md',
+    url: 'https://github.com/supabase/supabase/blob/master/apps/docs/CONTRIBUTING.md',
   },
   { title: 'Open Source', url: 'https://supabase.com/open-source' },
   { title: 'SupaSquad', url: 'https://supabase.com/supasquad' },


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Links for Quick Start next steps and contributing don't point to the most sensible place

## What is the current behavior?

Links point somewhere better

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
