### PR TITLE
docs: update url label in Social Auth setup docs

### DIFF
--- a/apps/docs/components/MDX/social_provider_setup.mdx
+++ b/apps/docs/components/MDX/social_provider_setup.mdx
@@ -3,4 +3,4 @@ The next step requires a callback URL, which looks like this: `https://<project-
 - Go to your [Supabase Project Dashboard](https://supabase.com/dashboard)
 - Click on the `Authentication` icon in the left sidebar
 - Click on [`Providers`](https://supabase.com/dashboard/project/_/auth/providers) under the Configuration section
-- Click on **{props.provider}** from the accordion list to expand and you'll find your **Redirect URL**, you can click `Copy` to copy it to the clipboard
+- Click on **{props.provider}** from the accordion list to expand and you'll find your **Callback URL**, you can click `Copy` to copy it to the clipboard


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

Issue: #22435

`Callback URL` i.e. mentioned in Social Auth providers is being referenced as `Redirect URL` in the last step in [docs](https://supabase.com/docs/guides/auth/social-login/auth-twitter#find-your-callback-url)

## What is the new behavior?

The `Redirect URL` label is now updated to `Callback URL`

## Additional context

Attached screenshot

<img width="1695" alt="image" src="https://github.com/supabase/supabase/assets/72190185/58ee5806-e31a-49e4-aba6-695dc9e88518">

