### PR TITLE
fix: mobile width for ref docs

### DIFF
--- a/apps/docs/layouts/ref/RefSubLayout.tsx
+++ b/apps/docs/layouts/ref/RefSubLayout.tsx
@@ -134,12 +134,20 @@ const StickyHeader: FC<StickyHeader> = ({ icon, ...props }) => {
 }
 
 const Details: FC<PropsWithChildren<ISectionDetails>> = (props) => {
-  return <div className="relative w-full">{props.children}</div>
+  /**
+   * `min-w` is necessary because these are used as grid children, which have
+   * default `min-w-auto`
+   */
+  return <div className="relative w-full min-w-full">{props.children}</div>
 }
 
 const Examples: FC<PropsWithChildren<ISectionExamples>> = (props) => {
+  /**
+   * `min-w` is necessary because these are used as grid children, which have
+   * default `min-w-auto`
+   */
   return (
-    <div className="w-full">
+    <div className="w-full min-w-full">
       <div className="sticky top-24">{props.children}</div>
     </div>
   )


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Mobile width of ref docs prose content grows too wide and forces horizontal scroll

## What is the new behavior?

Mobile width is constrained

## Additional context

Before:
<img width="437" alt="image" src="https://github.com/supabase/supabase/assets/26616127/53b25db2-f2b8-412b-a171-5eec38ec68b0">

After:
<img width="462" alt="image" src="https://github.com/supabase/supabase/assets/26616127/75ffc8b0-acc6-45ec-ad3e-9a7a8ae095dd">

