### PR TITLE
fix: change remediation links for database linter

### DIFF
--- a/apps/docs/components/GuidesTableOfContents.tsx
+++ b/apps/docs/components/GuidesTableOfContents.tsx
@@ -55,19 +55,32 @@ const GuidesTableOfContents = ({
   useEffect(() => {
     if (overrideToc) return
 
-    const headings = Array.from(
-      document.querySelector('#sb-docs-guide-main-article')?.querySelectorAll('h2, h3') ?? []
-    )
-    const newHeadings = headings
-      .filter((heading) => heading.id)
-      .map((heading) => {
-        const text = heading.textContent.replace('#', '')
-        const link = heading.querySelector('a').getAttribute('href')
-        const level = heading.tagName === 'H2' ? 2 : 3
-        return { text, link, level }
-      })
-    setTocList(newHeadings)
-  }, [pathname]) // needed to recalculate the toc when path changes
+    /**
+     * Because we're directly querying the DOM, needs the setTimeout so the DOM
+     * update will happen first.
+     */
+    const timeoutHandle = setTimeout(() => {
+      const headings = Array.from(
+        document.querySelector('#sb-docs-guide-main-article')?.querySelectorAll('h2, h3') ?? []
+      )
+      const newHeadings = headings
+        .filter((heading) => heading.id)
+        .map((heading) => {
+          const text = heading.textContent.replace('#', '')
+          const link = heading.querySelector('a').getAttribute('href')
+          const level = heading.tagName === 'H2' ? 2 : 3
+          return { text, link, level }
+        })
+      setTocList(newHeadings)
+    })
+
+    return () => clearTimeout(timeoutHandle)
+    /**
+     * window.location.href needed to recalculate toc when page changes,
+     * useRerenderOnEvt below will guarantee rerender on change
+     */
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [overrideToc, window.location.href])
 
   useEffect(() => {
     if (hash && displayedList.length > 0) {

--- a/apps/docs/hooks/useManualRerender.ts
+++ b/apps/docs/hooks/useManualRerender.ts
@@ -7,10 +7,12 @@ import { useEffect, useReducer } from 'react'
 const useRerenderOnEvt = (event: string, listeningElem?: Document | Window | HTMLElement) => {
   const [, rerender] = useReducer((state) => !state, true)
 
+  const elem = listeningElem ?? window
+
   useEffect(() => {
-    ;(listeningElem ?? window).addEventListener(event, rerender)
-    return () => (listeningElem ?? window).removeEventListener(event, rerender)
-  }, [event, listeningElem, rerender])
+    elem.addEventListener(event, rerender)
+    return () => elem.removeEventListener(event, rerender)
+  }, [elem, event, rerender])
 }
 
 export { useRerenderOnEvt }

--- a/apps/docs/pages/guides/database/database-linter.tsx
+++ b/apps/docs/pages/guides/database/database-linter.tsx
@@ -33,11 +33,11 @@ const meta = {
 const editLink = 'https://github.com/supabase/splinter/tree/main/docs'
 
 const markdownIntro = `
-You can use the Project Linter to check your database for issues such as missing indexes and improperly set-up RLS policies.
+You can use the Database Linter to check your database for issues such as missing indexes and improperly set-up RLS policies.
 
 ## Using the linter
 
-In the dashboard, navigate to [Database Linter](/dashboard/project/_/database/linter) under Database. The linter runs automatically. You can also manually rerun it after you're resolved issues, or ignore individual lints.
+In the dashboard, navigate to [Database Linter](/dashboard/project/_/database/linter) under Database. The linter runs automatically. You can also manually rerun it after you've resolved issues.
 `.trim()
 
 const getBasename = (path: string) => path.split('/').at(-1).replace(/\.md$/, '')

--- a/apps/studio/data/lint/lint-query.ts
+++ b/apps/studio/data/lint/lint-query.ts
@@ -45,7 +45,7 @@ select
         fk.table_,
         fk.fkey_name
     ) as detail,
-    'https://supabase.github.io/splinter/0001_unindexed_foreign_keys' as remediation,
+    'https://supabase.com/docs/guides/database/database-linter?lint=0001_unindexed_foreign_keys' as remediation,
     jsonb_build_object(
         'schema', fk.schema_,
         'name', fk.table_,
@@ -75,7 +75,7 @@ select
         'View/Materialized View "%s" in the public schema may expose \`auth.users\` data to anon or authenticated roles.',
         c.relname
     ) as detail,
-    'https://supabase.github.io/splinter/0002_auth_users_exposed' as remediation,
+    'https://supabase.com/docs/guides/database/database-linter?lint=0002_auth_users_exposed' as remediation,
     jsonb_build_object(
         'schema', 'public',
         'name', c.relname,
@@ -171,7 +171,7 @@ select
         table_,
         policy_name
     ) as detail,
-    'https://supabase.github.io/splinter/0003_auth_rls_initplan' as remediation,
+    'https://supabase.com/docs/guides/database/database-linter?lint=0003_auth_rls_initplan' as remediation,
     jsonb_build_object(
         'schema', schema_,
         'name', table_,
@@ -209,7 +209,7 @@ select
         pgns.nspname,
         pgc.relname
     ) as detail,
-    'https://supabase.github.io/splinter/0004_no_primary_key' as remediation,
+    'https://supabase.com/docs/guides/database/database-linter?lint=0004_no_primary_key' as remediation,
      jsonb_build_object(
         'schema', pgns.nspname,
         'name', pgc.relname,
@@ -250,7 +250,7 @@ select
         psui.schemaname,
         psui.relname
     ) as detail,
-    'https://supabase.github.io/splinter/0005_unused_index' as remediation,
+    'https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index' as remediation,
     jsonb_build_object(
         'schema', psui.schemaname,
         'name', psui.relname,
@@ -289,7 +289,7 @@ select
         act.cmd,
         array_agg(p.polname order by p.polname)
     ) as detail,
-    'https://supabase.github.io/splinter/0006_multiple_permissive_policies' as remediation,
+    'https://supabase.com/docs/guides/database/database-linter?lint=0006_multiple_permissive_policies' as remediation,
     jsonb_build_object(
         'schema', n.nspname,
         'name', c.relname,


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Fix

## What is the current behavior?

Linter remediation links point to external docs

## What is the new behavior?

Linter remediation links point to supabase.com/docs

## Additional context

Add any other context or screenshots.
