### PR TITLE
Correct RLS description

### DIFF
--- a/apps/docs/content/guides/storage/schema/helper-functions.mdx
+++ b/apps/docs/content/guides/storage/schema/helper-functions.mdx
@@ -17,7 +17,7 @@ Returns the name of a file. For example, if your file is stored in `public/subfo
 This example demonstrates how you would allow any user to download a file called `favicon.ico`:
 
 ```sql
-create policy "Allow authenticated uploads"
+create policy "Allow public downloads"
 on storage.objects
 for select
 to public


### PR DESCRIPTION
The RLS description appeared to have been copy-pasted from elsewhere, and did not reflect the RLS rule.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Minor docs correction.

## What is the current behavior?

RLS rule is incorrectly described, potentially confusing readers.

## What is the new behavior?

Corrected RLS header to reflect the RLS logic it references.