### PR TITLE
doc update : Updated the redirect path if user is not found

### DIFF
--- a/apps/docs/content/guides/auth/server-side/nextjs.mdx
+++ b/apps/docs/content/guides/auth/server-side/nextjs.mdx
@@ -495,7 +495,7 @@ export default async function PrivatePage() {
 
   const { data, error } = await supabase.auth.getUser()
   if (error || !data?.user) {
-    redirect('/')
+    redirect('/login')
   }
 
   return <p>Hello {data.user.email}</p>


### PR DESCRIPTION
In the next js , setting server side auth https://supabase.com/docs/guides/auth/server-side/nextjs?router=app , in the `Access user info from Server Component` section

If the user data is not present in the `getUser` then it should redirect to the login page so that the user can continue their login flow. The current doc redirects it to the root page itself as shown in the screenshot

<img width="563" alt="image" src="https://github.com/supabase/supabase/assets/34393560/66570fb6-52ef-4917-88f6-8e85542803eb">


## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Very minor doc update

## What is the current behavior?

As mentioned in the description the if the user data is not present the current doc redirects it to `/` instead of `/login` where the user can continue their login flow

## What is the new behavior?

doc update where the redirect path is changed from `/` to `/login`

## Additional context

No more additional context, PR introduces very minor doc change
