### PR TITLE
feat: add Nano instance to pricing page

### DIFF
--- a/apps/www/components/Pricing/ComputePricingTable.tsx
+++ b/apps/www/components/Pricing/ComputePricingTable.tsx
@@ -28,20 +28,7 @@ const ComputePricingTable = () => {
           <tbody>
             {pricingAddOn.database.rows.map((row, i) => (
               <Fragment key={`row-${i}`}>
-                {i === 0 && (
-                  <tr>
-                    <td className="pb-1 bg-border-strong px-3 py-1 -mr-1 border-l-4 border-strong">
-                      <span>First instance is free on paid plans</span>
-                    </td>
-                  </tr>
-                )}
-                <tr
-                  key={i}
-                  className={cn(
-                    i % 2 === 0 ? 'bg-surface-100 rounded-lg' : '',
-                    i === 0 ? 'border-4 border-strong' : ''
-                  )}
-                >
+                <tr key={i}>
                   {row.columns.map((column) => (
                     <td key={column.key} className="p-3">
                       {column.key === 'dedicated' ? (

--- a/apps/www/data/PricingAddOnTable.json
+++ b/apps/www/data/PricingAddOnTable.json
@@ -10,6 +10,25 @@
     "rows": [
       {
         "columns": [
+          { "key": "plan", "title": "Plan", "value": "Nano (Free)" },
+          { "key": "pricing", "title": "Price USD", "value": "$0" },
+          { "key": "cpu", "title": "CPU", "value": "Shared" },
+          { "key": "dedicated", "title": "Dedicated", "value": false },
+          { "key": "memory", "title": "Memory", "value": "Up to 0.5 GB" },
+          {
+            "key": "directConnections",
+            "title": "Connections: Direct",
+            "value": "60"
+          },
+          {
+            "key": "poolerConnections",
+            "title": "Connections: Pooler",
+            "value": "200"
+          }
+        ]
+      },
+      {
+        "columns": [
           { "key": "plan", "title": "Plan", "value": "Micro" },
           { "key": "pricing", "title": "Price USD", "value": "$10" },
           { "key": "cpu", "title": "CPU", "value": "2-core ARM" },

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "prettier-plugin-sql-cst": "^0.11.0",
         "sass": "^1.72.0",
         "supabase": "^1.151.1",
-        "turbo": "^1.13.0"
+        "turbo": "^1.13.2"
       },
       "engines": {
         "node": ">=20.0.0",
@@ -44473,26 +44473,26 @@
       }
     },
     "node_modules/turbo": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/turbo/-/turbo-1.13.0.tgz",
-      "integrity": "sha512-r02GtNmkOPcQvUzVE6lg474QVLyU02r3yh3lUGqrFHf5h5ZEjgDGWILsAUqplVqjri1Y/oOkTssks4CObTAaiw==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-1.13.2.tgz",
+      "integrity": "sha512-rX/d9f4MgRT3yK6cERPAkfavIxbpBZowDQpgvkYwGMGDQ0Nvw1nc0NVjruE76GrzXQqoxR1UpnmEP54vBARFHQ==",
       "dev": true,
       "bin": {
         "turbo": "bin/turbo"
       },
       "optionalDependencies": {
-        "turbo-darwin-64": "1.13.0",
-        "turbo-darwin-arm64": "1.13.0",
-        "turbo-linux-64": "1.13.0",
-        "turbo-linux-arm64": "1.13.0",
-        "turbo-windows-64": "1.13.0",
-        "turbo-windows-arm64": "1.13.0"
+        "turbo-darwin-64": "1.13.2",
+        "turbo-darwin-arm64": "1.13.2",
+        "turbo-linux-64": "1.13.2",
+        "turbo-linux-arm64": "1.13.2",
+        "turbo-windows-64": "1.13.2",
+        "turbo-windows-arm64": "1.13.2"
       }
     },
     "node_modules/turbo-darwin-64": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.13.0.tgz",
-      "integrity": "sha512-ctHeJXtQgBcgxnCXwrJTGiq57HtwF7zWz5NTuSv//5yeU01BtQIt62ArKfjudOhRefWJbX3Z5srn88XTb9hfww==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.13.2.tgz",
+      "integrity": "sha512-CCSuD8CfmtncpohCuIgq7eAzUas0IwSbHfI8/Q3vKObTdXyN8vAo01gwqXjDGpzG9bTEVedD0GmLbD23dR0MLA==",
       "cpu": [
         "x64"
       ],
@@ -44503,9 +44503,9 @@
       ]
     },
     "node_modules/turbo-darwin-arm64": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.13.0.tgz",
-      "integrity": "sha512-/Q9/pNFkF9w83tNxwMpgapwLYdQ12p8mpty2YQRoUiS9ClWkcqe136jR0mtuMqzlNlpREOFZaoyIthjt6Sdo0g==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.13.2.tgz",
+      "integrity": "sha512-0HySm06/D2N91rJJ89FbiI/AodmY8B3WDSFTVEpu2+8spUw7hOJ8okWOT0e5iGlyayUP9gr31eOeL3VFZkpfCw==",
       "cpu": [
         "arm64"
       ],
@@ -44516,9 +44516,9 @@
       ]
     },
     "node_modules/turbo-linux-64": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.13.0.tgz",
-      "integrity": "sha512-hgbT7o020BGV4L7Sd8hhFTd5zVKPKxbsr0dPfel/9NkdTmptz2aGZ0Vb2MAa18SY3XaCQpDxmdYuOzvvRpo5ZA==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.13.2.tgz",
+      "integrity": "sha512-7HnibgbqZrjn4lcfIouzlPu8ZHSBtURG4c7Bedu7WJUDeZo+RE1crlrQm8wuwO54S0siYqUqo7GNHxu4IXbioQ==",
       "cpu": [
         "x64"
       ],
@@ -44529,9 +44529,9 @@
       ]
     },
     "node_modules/turbo-linux-arm64": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.13.0.tgz",
-      "integrity": "sha512-WK01i2wDZARrV+HEs495A3hNeGMwQR5suYk7G+ceqqW7b+dOTlQdvUjnI3sg7wAnZPgjafFs/hoBaZdJjVa/nw==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.13.2.tgz",
+      "integrity": "sha512-sUq4dbpk6SNKg/Hkwn256Vj2AEYSQdG96repio894h5/LEfauIK2QYiC/xxAeW3WBMc6BngmvNyURIg7ltrePg==",
       "cpu": [
         "arm64"
       ],
@@ -44542,9 +44542,9 @@
       ]
     },
     "node_modules/turbo-windows-64": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.13.0.tgz",
-      "integrity": "sha512-hJgSZJZwlWHNwLEthaqJqJWGm4NqF5X/I7vE0sPE4i/jeDl8f0n1hcOkgJkJiNXVxhj+qy/9+4dzbPLKT9imaQ==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.13.2.tgz",
+      "integrity": "sha512-DqzhcrciWq3dpzllJR2VVIyOhSlXYCo4mNEWl98DJ3FZ08PEzcI3ceudlH6F0t/nIcfSItK1bDP39cs7YoZHEA==",
       "cpu": [
         "x64"
       ],
@@ -44555,9 +44555,9 @@
       ]
     },
     "node_modules/turbo-windows-arm64": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.13.0.tgz",
-      "integrity": "sha512-L/ErxYoXeq8tmjU/AIGicC9VyBN1zdYw8JlM4yPmMI0pJdY8E4GaYK1IiIazqq7M72lmQhU/WW7fV9FqEktwrw==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.13.2.tgz",
+      "integrity": "sha512-WnPMrwfCXxK69CdDfS1/j2DlzcKxSmycgDAqV0XCYpK/812KB0KlvsVAt5PjEbZGXkY88pCJ1BLZHAjF5FcbqA==",
       "cpu": [
         "arm64"
       ],

--- a/package.json
+++ b/package.json
@@ -5,7 +5,13 @@
   "author": "Supabase, Inc.",
   "license": "Apache-2.0",
   "private": true,
-  "workspaces": ["apps/*", "apps/docs/spec/parser", "tests", "playwright-tests", "packages/*"],
+  "workspaces": [
+    "apps/*",
+    "apps/docs/spec/parser",
+    "tests",
+    "playwright-tests",
+    "packages/*"
+  ],
   "scripts": {
     "build": "turbo run build",
     "build:studio": "turbo run build --filter=studio",
@@ -37,7 +43,7 @@
     "prettier-plugin-sql-cst": "^0.11.0",
     "sass": "^1.72.0",
     "supabase": "^1.151.1",
-    "turbo": "^1.13.0"
+    "turbo": "^1.13.2"
   },
   "repository": {
     "type": "git",
@@ -47,7 +53,14 @@
     "npm": ">=9.0.0",
     "node": ">=20.0.0"
   },
-  "keywords": ["postgres", "firebase", "storage", "functions", "database", "auth"],
+  "keywords": [
+    "postgres",
+    "firebase",
+    "storage",
+    "functions",
+    "database",
+    "auth"
+  ],
   "volta": {
     "node": "20.11.1"
   }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Pricing update

## What is the current behavior?

Pricing page doesn't include the new Nano compute instance that was added to docs: https://supabase.com/docs/guides/platform/compute-add-ons

## What is the new behavior?

- Pricing page includes mention and specs of Nano compute instance.
- Includes an update to the Compute pricing calculator where credits are not applied if all compute add ons are on the `Nano (Free)` but the moment this changes then credits kick in:

https://github.com/supabase/supabase/assets/5532241/f0c0638f-c89d-4344-8238-e66096656500
