### PR TITLE
Add stale GH Action for marking issues and closing PRs unless assigned

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,13 +10,12 @@ jobs:
       - name: Close Stale Issues
         uses: actions/stale@v9.0.0
         with:
-          days-before-pr-close: 30
+          days-before-pr-stale: 30
+          days-before-pr-close: 7
           days-before-issue-stale: 30
-          days-before-issue-close: 10
-          stale-issue-message: 'After 30 days of inactivity, this issue has been marked as stale. This issue will be auto-closed in 10 days. Comment, assign or remove the stale label to prevent this.'
-          stale-issue-label: stale
-          close-issue-label: staled
-          close-pr-label: staled
+          days-before-issue-close: 7
+          stale-pr-message: 'This pull request has been inactive for 30 days and will be closed in another week. If you want to give it another month, leave a comment, assign it to someone, or remove a `Stale` label.'
+          stale-issue-message: 'This issue has been inactive for 30 days and will be closed in another week. If you want to give it another month, leave a comment, assign it to someone, or remove a `Stale` label.'
           any-of-labels: contributor
           exempt-issue-labels: dnc, needs-analysis
           exempt-pr-labels: dnc

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,24 @@
+name: Automatically stale issue and PRs
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close Stale Issues
+        uses: actions/stale@v9.0.0
+        with:
+          days-before-pr-close: 30
+          days-before-issue-stale: 30
+          days-before-issue-close: 10
+          stale-issue-message: 'After 30 days of inactivity, this issue has been marked as stale. This issue will be auto-closed in 10 days. Comment, assign or remove the stale label to prevent this.'
+          stale-issue-label: stale
+          close-issue-label: staled
+          close-pr-label: staled
+          any-of-labels: contributor
+          exempt-issue-labels: dnc, needs-analysis
+          exempt-pr-labels: dnc
+          exempt-all-assignees: true
+          exempt-draft-pr: false


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

[Stale](https://github.com/actions/stale) bot added to actions workflow to run on a schedule 

## What is the current behavior?

No automatic activity for issues or PRs

## What is the new behavior?

- PRs are closed if:
	- They do **not**  have the label: `dnc`
	- They are **not** assigned
	- They are inactive for more than 30 days
- Issues are labelled as `stale` if:
	- They do **not** have the label: `dnc` or `needs-analysis`
	- They are inactive for more than 30 days
	- They as **not** assigned 
- Issues are closed if:
	- They are labelled as `stale`
	- They remain inactive for 10 days after being labelled as `stale`


