### PR TITLE
fix: docs ssr build

### DIFF
--- a/apps/docs/components/GuidesTableOfContents.tsx
+++ b/apps/docs/components/GuidesTableOfContents.tsx
@@ -80,7 +80,7 @@ const GuidesTableOfContents = ({
      * useRerenderOnEvt below will guarantee rerender on change
      */
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [overrideToc, window.location.href])
+  }, [overrideToc, typeof window !== 'undefined' && window.location.href])
 
   useEffect(() => {
     if (hash && displayedList.length > 0) {

--- a/apps/docs/hooks/useManualRerender.ts
+++ b/apps/docs/hooks/useManualRerender.ts
@@ -7,11 +7,11 @@ import { useEffect, useReducer } from 'react'
 const useRerenderOnEvt = (event: string, listeningElem?: Document | Window | HTMLElement) => {
   const [, rerender] = useReducer((state) => !state, true)
 
-  const elem = listeningElem ?? window
+  const elem = listeningElem ?? (typeof window !== 'undefined' ? window : undefined)
 
   useEffect(() => {
-    elem.addEventListener(event, rerender)
-    return () => elem.removeEventListener(event, rerender)
+    elem?.addEventListener(event, rerender)
+    return () => elem?.removeEventListener(event, rerender)
   }, [elem, event, rerender])
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behaviour?

There are a couple of references to `window` in the docs, which is causing the build to fail.

## What is the new behaviour?

Guards those references so they work server side.
