### PR TITLE
Hide billing info for partner-billed org based on org/subscription level data

### DIFF
--- a/apps/studio/components/interfaces/Billing/Subscription/Subscription.utils.ts
+++ b/apps/studio/components/interfaces/Billing/Subscription/Subscription.utils.ts
@@ -17,3 +17,16 @@ export const subscriptionHasHipaaAddon = (subscription?: OrgSubscription): boole
     (addon) => addon.supabase_prod_id === 'addon_security_hipaa'
   )
 }
+
+export const billingPartnerLabel = (billingPartner?: string) => {
+  if (!billingPartner) return billingPartner
+
+  switch (billingPartner) {
+    case 'fly':
+      return 'Fly.io'
+    case 'aws':
+      return 'AWS'
+    default:
+      return billingPartner
+  }
+}

--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingSettings.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingSettings.tsx
@@ -8,13 +8,24 @@ import CreditBalance from './CreditBalance'
 import PaymentMethods from './PaymentMethods/PaymentMethods'
 import Subscription from './Subscription/Subscription'
 import TaxID from './TaxID/TaxID'
+import { useParams } from 'common'
+import { useOrgSubscriptionQuery } from '../../../../data/subscriptions/org-subscription-query'
 
 const BillingSettings = () => {
   const {
-    billingAccountData: billingAccountDataEnabled,
-    billingPaymentMethods: billingPaymentMethodsEnabled,
-    billingCredits: billingCreditsEnabled,
+    billingAccountData: isBillingAccountDataEnabledOnProfileLevel,
+    billingPaymentMethods: isBillingPaymentMethodsEnabledOnProfileLevel,
+    billingCredits: isBillingCreditsEnabledOnProfileLevel,
   } = useIsFeatureEnabled(['billing:account_data', 'billing:payment_methods', 'billing:credits'])
+
+  const { slug: orgSlug } = useParams()
+  const { data: subscription } = useOrgSubscriptionQuery({ orgSlug })
+  const isNotOrgWithPartnerBilling = !subscription?.billing_via_partner ?? true
+
+  const billingAccountDataEnabled =
+    isBillingAccountDataEnabledOnProfileLevel && isNotOrgWithPartnerBilling
+  const billingPaymentMethodsEnabled =
+    isBillingPaymentMethodsEnabledOnProfileLevel && isNotOrgWithPartnerBilling
 
   return (
     <>
@@ -34,7 +45,7 @@ const BillingSettings = () => {
         <BillingBreakdown />
       </ScaffoldContainer>
 
-      {billingCreditsEnabled && (
+      {isBillingCreditsEnabledOnProfileLevel && (
         <>
           <ScaffoldDivider />
 

--- a/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/PlanUpdateSidePanel.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/PlanUpdateSidePanel.tsx
@@ -39,6 +39,7 @@ import ExitSurveyModal from './ExitSurveyModal'
 import UpgradeSurveyModal from './UpgradeModal'
 import MembersExceedLimitModal from './MembersExceedLimitModal'
 import PaymentMethodSelection from './PaymentMethodSelection'
+import { billingPartnerLabel } from 'components/interfaces/Billing/Subscription/Subscription.utils'
 
 const PlanUpdateSidePanel = () => {
   const router = useRouter()
@@ -545,8 +546,9 @@ const PlanUpdateSidePanel = () => {
           ) : (
             <div className="py-4 space-y-2">
               <p className="text-sm">
-                This organization is billed through our partner Fly.io and you will be charged by
-                them directly.
+                This organization is billed through our partner{' '}
+                {billingPartnerLabel(subscription?.billing_partner)} and you will be charged by them
+                directly.
               </p>
               {subscriptionPreview?.billed_via_partner &&
                 subscriptionPreview?.plan_change_type === 'downgrade' && (

--- a/apps/studio/components/layouts/OrganizationLayout.tsx
+++ b/apps/studio/components/layouts/OrganizationLayout.tsx
@@ -8,13 +8,17 @@ import { AccountLayout } from './'
 import { ScaffoldContainer, ScaffoldDivider, ScaffoldHeader, ScaffoldTitle } from './Scaffold'
 import SettingsLayout from './SettingsLayout/SettingsLayout'
 import Link from 'next/link'
+import { useOrgSubscriptionQuery } from '../../data/subscriptions/org-subscription-query'
 
 const OrganizationLayout = ({ children }: PropsWithChildren<{}>) => {
   const selectedOrganization = useSelectedOrganization()
   const router = useRouter()
   const { slug } = useParams()
 
-  const invoicesEnabled = useIsFeatureEnabled('billing:invoices')
+  const invoicesEnabledOnProfileLevel = useIsFeatureEnabled('billing:invoices')
+  const { data: subscription } = useOrgSubscriptionQuery({ orgSlug: slug })
+  const isNotOrgWithPartnerBilling = !subscription?.billing_via_partner ?? true
+  const invoicesEnabled = invoicesEnabledOnProfileLevel && isNotOrgWithPartnerBilling
 
   const navLayoutV2 = useFlag('navigationLayoutV2')
 


### PR DESCRIPTION
Right now the decision whether info like "Credit Balance" or "Payment Methods" is shown or not is based on enabled/disabled features on profile level. But this applies to Fly customers only where we have SSO. For customers that are billed via a partner that doesn't support SSO the info whether an org is billed via partner is not on the profile level but org/subscription level.

This PR introduces a quick and **temporary** solution until we've figured out how to address this in the API properly (Slack discussion will be started for this).