### PR TITLE
docs(timescaledb): fix typo in documentation example

### DIFF
--- a/apps/docs/content/guides/database/extensions/timescaledb.mdx
+++ b/apps/docs/content/guides/database/extensions/timescaledb.mdx
@@ -47,7 +47,7 @@ First we create a hypertable, which is a virtual table that is partitioned into 
 {/* prettier-ignore */}
 ```sql
 create table temperatures (
-  time timestamp not null,
+  time timestampz not null,
   sensor_id int not null,
   temperature double precision not null
 );


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

#22598

## What is the new behavior?

The usage example now correctly specifies the data type for the 'time' column as 'timestampz' instead of 'timestamp'.

## Additional context

changed 'timestamp' to 'timestampz' for correct data type specification.
