### PR TITLE
docs: fix link

### DIFF
--- a/apps/www/data/Footer.ts
+++ b/apps/www/data/Footer.ts
@@ -96,7 +96,7 @@ const footerData = [
       },
       {
         text: 'Contributing',
-        url: '/docs/handbook/contributing',
+        url: 'https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md',
       },
       {
         text: 'Open Source',


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

fix 404 link

## What is the current behavior?

Contributing link is 404 page

## What is the new behavior?

link to https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md

## Additional context

fixed: #22611
