### PR TITLE
fix: update all examples and snippets to use select for auth rls func…

### DIFF
--- a/apps/docs/components/MDX/user_management_quickstart_sql_template.mdx
+++ b/apps/docs/components/MDX/user_management_quickstart_sql_template.mdx
@@ -19,10 +19,10 @@ create policy "Public profiles are viewable by everyone." on profiles
   for select using (true);
 
 create policy "Users can insert their own profile." on profiles
-  for insert with check (auth.uid() = id);
+  for insert with check ((select auth.uid()) = id);
 
 create policy "Users can update own profile." on profiles
-  for update using (auth.uid() = id);
+  for update using ((select auth.uid()) = id);
 
 -- This trigger automatically creates a profile entry when a new user signs up via Supabase Auth.
 -- See https://supabase.com/docs/guides/auth/managing-user-data#using-triggers for more details.
@@ -51,5 +51,5 @@ create policy "Anyone can upload an avatar." on storage.objects
   for insert with check (bucket_id = 'avatars');
 
 create policy "Anyone can update their own avatar." on storage.objects
-  for update using (auth.uid() = owner) with check (bucket_id = 'avatars');
+  for update using ((select auth.uid()) = owner) with check (bucket_id = 'avatars');
 ```

--- a/apps/docs/content/guides/ai/rag-with-permissions.mdx
+++ b/apps/docs/content/guides/ai/rag-with-permissions.mdx
@@ -45,7 +45,7 @@ on document_sections for select to authenticated using (
   document_id in (
     select id
     from documents
-    where owner_id = auth.uid()
+    where (owner_id = (select auth.uid()))
   )
 );
 ```
@@ -100,7 +100,7 @@ on document_sections for select to authenticated using (
   document_id in (
     select document_id
     from document_owners
-    where owner_id = auth.uid()
+    where (owner_id = (select auth.uid()))
   )
 );
 ```
@@ -248,7 +248,7 @@ on document_sections for select to authenticated using (
   document_id in (
     select id
     from documents
-    where owner_id = auth.uid()
+    where (owner_id = (select auth.uid()))
   )
 );
 ```

--- a/apps/docs/content/guides/auth.mdx
+++ b/apps/docs/content/guides/auth.mdx
@@ -110,7 +110,7 @@ const { data, error } = await supabase
 // => { id: 'd0714948', name: 'Jane' }
 ```
 
-... you can simply define a rule on your database table, `auth.uid() = user_id`, and your request will return the rows which pass the rule, even when you remove the filter from your middleware:
+... you can simply define a rule on your database table, `(select auth.uid()) = user_id`, and your request will return the rows which pass the rule, even when you remove the filter from your middleware:
 
 ```js
 const { data, error } = await supabase.from('users').select('user_id, name')

--- a/apps/docs/content/guides/auth/auth-anonymous.mdx
+++ b/apps/docs/content/guides/auth/auth-anonymous.mdx
@@ -195,7 +195,7 @@ An anonymous user assumes the `authenticated` role just like a permanent user. Y
 create policy "Only permanent users can post to the news feed"
 on news_feed as restrictive for insert
 to authenticated
-with check ((auth.jwt()->>'is_anonymous')::boolean is false );
+with check ((select (auth.jwt()->>'is_anonymous')::boolean) is false );
 
 create policy "Anonymous and permanent users can view the news feed"
 on news_feed for select

--- a/apps/docs/content/guides/auth/auth-deep-dive/auth-policies.mdx
+++ b/apps/docs/content/guides/auth/auth-deep-dive/auth-policies.mdx
@@ -122,7 +122,7 @@ Now we'll write our policy, again in SQL, but note it's also possible to add via
 ```sql
 CREATE POLICY user_update_own_scores ON my_scores
     FOR ALL
-    USING (auth.uid() = user_id);
+    USING ((select auth.uid()) = user_id);
 ```
 
 Now, assuming you have an active session in your javascript/supabase-js environment you can do:
@@ -149,7 +149,7 @@ Once you get the hang of policies you can start to get a little bit fancy. Let's
 create policy "Only Blizzard staff can update leaderboard"
   on my_scores
   for update using (
-    right(auth.jwt() ->> 'email', 13) = '@blizzard.com'
+    right((select auth.jwt() ->> 'email'), 13) = '@blizzard.com'
   );
 ```
 

--- a/apps/docs/content/guides/auth/auth-mfa.mdx
+++ b/apps/docs/content/guides/auth/auth-mfa.mdx
@@ -457,7 +457,7 @@ create policy "Policy name."
   on table_name
   as restrictive
   to authenticated
-  using (auth.jwt()->>'aal' = 'aal2');
+  using ((select auth.jwt()->>'aal') = 'aal2');
 ```
 
 - Here the policy will not accept any JWTs with an `aal` claim other than
@@ -475,14 +475,14 @@ create policy "Policy name."
   as restrictive -- very important!
   to authenticated
   using
-    (array[auth.jwt()->>'aal'] <@ (
+    (array[(select auth.jwt()->>'aal')] <@ (
        select
          case
            when created_at >= '2022-12-12T00:00:00Z' then array['aal2']
            else array['aal1', 'aal2']
          end as aal
        from auth.users
-       where auth.uid() = id));
+       where (select auth.uid()) = id));
 ```
 
 - The policy will accept both `aal1` and `aal2` for users with a `created_at`
@@ -504,14 +504,14 @@ create policy "Policy name."
   as restrictive -- very important!
   to authenticated
   using (
-    array[auth.jwt()->>'aal'] <@ (
+    array[(select auth.jwt()->>'aal')] <@ (
       select
           case
             when count(id) > 0 then array['aal2']
             else array['aal1', 'aal2']
           end as aal
         from auth.mfa_factors
-        where auth.uid() = user_id and status = 'verified'
+        where ((select auth.uid()) = user_id) and status = 'verified'
     ));
 ```
 
@@ -600,7 +600,7 @@ Use the `supabase.auth.getAuthenticatorAssuranceLevel()` method to get easy acce
 You can use this PostgreSQL snippet in RLS policies, too:
 
 ```sql
-jsonb_path_query(auth.jwt(), '$.amr[0]')
+jsonb_path_query((select auth.jwt()), '$.amr[0]')
 ```
 
 - [`jsonb_path_query(json, path)`](https://www.postgresql.org/docs/current/functions-json.html#FUNCTIONS-JSON-PROCESSING-TABLE)

--- a/apps/docs/content/guides/auth/auth-user-management.mdx
+++ b/apps/docs/content/guides/auth/auth-user-management.mdx
@@ -72,7 +72,7 @@ Supabase Auth provides these [configuration options](/dashboard/project/_/settin
   create policy "policy_name"
   ON public.posts
   for insert to authenticated with check (
-      auth.jwt()->>'email_verified' is true
+      (select auth.jwt()->>'email_verified') is true
   );
   ```
 

--- a/apps/docs/content/guides/auth/column-level-security.mdx
+++ b/apps/docs/content/guides/auth/column-level-security.mdx
@@ -30,7 +30,7 @@ You can restrict updates to just the user who created it using [RLS](/docs/guide
 ```sql
 create a policy "Allow update for owners" on posts for
 update
-  using (auth.uid () = user_id);
+  using ((select auth.uid()) = user_id);
 ```
 
 However, this gives the post owner full access to update the row, including all of the columns.
@@ -129,7 +129,7 @@ supabase migration new create_posts_table
       -- Add row-level security
       create a policy "Allow update for owners" on posts for
       update
-      using (auth.uid () = user_id);
+      using ((select auth.uid()) = user_id);
 
       -- Add column-level security
       revoke

--- a/apps/docs/content/guides/auth/custom-claims-and-role-based-access-control-rbac.mdx
+++ b/apps/docs/content/guides/auth/custom-claims-and-role-based-access-control-rbac.mdx
@@ -225,7 +225,7 @@ begin
   select count(*)
   from public.role_permissions
   where role_permissions.permission = authorize.requested_permission
-    and role_permissions.role = (auth.jwt() ->> 'user_role')::public.app_role
+    and (role_permissions.role = (select (auth.jwt() ->> 'user_role')::public.app_role))
   into bind_permissions;
 
   return bind_permissions > 0;

--- a/apps/docs/content/guides/auth/enterprise-sso/auth-sso-saml.mdx
+++ b/apps/docs/content/guides/auth/enterprise-sso/auth-sso-saml.mdx
@@ -129,7 +129,7 @@ CREATE POLICY "View organization settings."
   ON organization_settings
   AS RESTRICTIVE
   USING (
-    sso_provider_id = auth.jwt()#>>'{amr,0,provider}'
+    sso_provider_id = (select auth.jwt()#>>'{amr,0,provider}')
   );
 ```
 

--- a/apps/docs/content/guides/auth/managing-user-data.mdx
+++ b/apps/docs/content/guides/auth/managing-user-data.mdx
@@ -67,11 +67,11 @@ create policy "Public profiles are viewable by everyone."
 
 create policy "Users can insert their own profile."
   on profiles for insert
-  with check ( auth.uid() = id );
+  with check ( (select auth.uid()) = id );
 
 create policy "Users can update own profile."
   on profiles for update
-  using ( auth.uid() = id );
+  using ( (select auth.uid()) = id );
 ```
 
 ## Private access
@@ -81,7 +81,7 @@ If the data should only be _readable_ by the user who owns the data, we just nee
 ```sql
 create policy "Profiles are viewable by users who created them."
   on profiles for select
-  using ( auth.uid() = id );
+  using ( (select auth.uid()) = id );
 ```
 
 The nice thing about this pattern? We can now query this table via the API and we don't need to include data filters in our API queries - the Policies will handle that for us:

--- a/apps/docs/content/guides/auth/row-level-security.mdx
+++ b/apps/docs/content/guides/auth/row-level-security.mdx
@@ -28,7 +28,7 @@ Policies are easy to understand once you get the hang of them. Each policy is at
 ```sql
 create policy "Individuals can view their own todos."
 on todos for select
-using ( auth.uid() = user_id );
+using ( (select auth.uid()) = user_id );
 ```
 
 .. would translate to this whenever a user tries to select from the todos table:
@@ -178,7 +178,7 @@ create policy "Users can update their own profiles"
 on profiles for update
 to authenticated
 using (
-  auth.uid() = id
+  (select auth.uid()) = id
 );
 ```
 
@@ -208,7 +208,7 @@ alter table teams enable row level security;
 create policy "Team members can update team details if they belong to the team"
   on teams
   for update using (
-    auth.uid() in (
+    (select auth.uid()) in (
       select user_id from members
       where team_id = id
     )
@@ -272,7 +272,7 @@ create policy "Only Supabase staff can update the leaderboard"
 on leaderboard
 to authenticated
 for update using (
-  right(auth.jwt() ->> 'email', 13) = '@supabase.com'
+  right((select auth.jwt() ->> 'email'), 13) = '@supabase.com'
 );
 ```
 
@@ -286,7 +286,7 @@ on profiles
 as restrictive
 for update
 to authenticated using (
-  auth.jwt()->>'aal' = 'aal2'
+  (select auth.jwt()->>'aal') = 'aal2'
 );
 ```
 

--- a/apps/docs/content/guides/database/postgres/row-level-security.mdx
+++ b/apps/docs/content/guides/database/postgres/row-level-security.mdx
@@ -22,7 +22,7 @@ You can just think of them as adding a `WHERE` clause to every query. For exampl
 ```sql
 create policy "Individuals can view their own todos."
 on todos for select
-using ( auth.uid() = user_id );
+using ( (select auth.uid()) = user_id );
 ```
 
 .. would translate to this whenever a user tries to select from the todos table:
@@ -79,7 +79,7 @@ Alternatively, if you only wanted users to be able to see their own profiles:
 ```sql
 create policy "User can see their own profile only."
 on profiles
-for select using ( auth.uid() = user_id );
+for select using ( (select auth.uid()) = user_id );
 ```
 
 ### INSERT policies
@@ -103,7 +103,7 @@ alter table profiles enable row level security;
 create policy "Users can create a profile."
 on profiles for insert
 to authenticated                          -- the Postgres Role (recommended)
-with check ( auth.uid() = user_id );      -- the actual Policy
+with check ( (select auth.uid()) = user_id );      -- the actual Policy
 ```
 
 ### UPDATE policies
@@ -131,8 +131,8 @@ alter table profiles enable row level security;
 create policy "Users can update their own profile."
 on profiles for update
 to authenticated                    -- the Postgres Role (recommended)
-using ( auth.uid() = user_id )       -- checks if the existing row complies with the policy expression
-with check ( auth.uid() = user_id ); -- checks if the new row complies with the policy expression
+using ( (select auth.uid()) = user_id )       -- checks if the existing row complies with the policy expression
+with check ( (select auth.uid()) = user_id ); -- checks if the new row complies with the policy expression
 ```
 
 If no `with check` expression is defined, then the `using` expression will be used both to determine which rows are visible (normal USING case) and which new rows will be allowed to be added (WITH CHECK case).
@@ -158,7 +158,7 @@ alter table profiles enable row level security;
 create policy "Users can delete a profile."
 on profiles for delete
 to authenticated                     -- the Postgres Role (recommended)
-using ( auth.uid() = user_id );      -- the actual Policy
+using ( (select auth.uid()) = user_id );      -- the actual Policy
 ```
 
 ## Bypassing Row Level Security
@@ -184,7 +184,7 @@ Make sure you've added [indexes](/docs/guides/database/postgres/indexes) on any 
 ```sql
 create policy "rls_test_select" on test_table
 to authenticated
-using ( auth.uid() = user_id );
+using ( (select auth.uid()) = user_id );
 ```
 
 You can add an index like:
@@ -208,7 +208,7 @@ You can use `select` statement to improve policies that use functions. For examp
 ```sql
 create policy "rls_test_select" on test_table
 to authenticated
-using ( auth.uid() = user_id );
+using ( (select auth.uid()) = user_id );
 ```
 
 You can do:
@@ -276,7 +276,7 @@ to authenticated
 using (
   exists (
     select 1 from roles_table
-    where auth.uid() = user_id and role = 'good_role'
+    where (select auth.uid()) = user_id and role = 'good_role'
   )
 );
 ```
@@ -292,7 +292,7 @@ as $$
 begin
   return exists (
     select 1 from roles_table
-    where auth.uid() = user_id and role = 'good_role'
+    where (select auth.uid()) = user_id and role = 'good_role'
   );
 end;
 $$;
@@ -320,7 +320,7 @@ For example, this is an example of a slow policy which joins the source `test_ta
 create policy "rls_test_select" on test_table
 to authenticated
 using (
-  auth.uid() in (
+  (select auth.uid()) in (
     select user_id
     from team_user
     where team_user.team_id = team_id -- joins to the source "test_table.team_id"
@@ -337,7 +337,7 @@ using (
   team_id in (
     select team_id
     from team_user
-    where user_id = auth.uid() -- no join
+    where user_id = (select auth.uid()) -- no join
   )
 );
 ```
@@ -362,7 +362,7 @@ Always use the Role of inside your policies, specified by the `TO` operator. For
 
 ```sql
 create policy "rls_test_select" on rls_test
-using ( auth.uid() = user_id );
+using ( (select auth.uid()) = user_id );
 ```
 
 Use:
@@ -370,10 +370,10 @@ Use:
 ```sql
 create policy "rls_test_select" on rls_test
 to authenticated
-using ( auth.uid() = user_id );
+using ( (select auth.uid()) = user_id );
 ```
 
-This prevents the policy `( auth.uid() = user_id )` from running for any `anon` users, since the execution stops at the `to authenticated` step.
+This prevents the policy `( (select auth.uid()) = user_id )` from running for any `anon` users, since the execution stops at the `to authenticated` step.
 
 #### Benchmarks
 

--- a/apps/docs/content/guides/storage/security/access-control.mdx
+++ b/apps/docs/content/guides/storage/security/access-control.mdx
@@ -70,7 +70,7 @@ for insert
 to authenticated
 with check (
   bucket_id = 'my_bucket_id' and
-  (storage.foldername(name))[1] = auth.uid()::text
+  (storage.foldername(name))[1] = (select auth.uid()::text)
 );
 ```
 
@@ -80,7 +80,7 @@ Allow a user to access a file that was previously uploaded by the same user:
 create policy "Individual user Access"
 on storage.objects for select
 to authenticated
-using ( auth.uid() = owner_id );
+using ( (select auth.uid()) = owner_id );
 ```
 
 ---

--- a/apps/studio/components/interfaces/Auth/Policies/PolicyEditorModal/PolicyEditorModal.constants.ts
+++ b/apps/studio/components/interfaces/Auth/Policies/PolicyEditorModal/PolicyEditorModal.constants.ts
@@ -57,13 +57,13 @@ with check (true);`.trim(),
 create policy "Enable update for users based on email"
 on "${schema}"."${table}"
 for update using (
-  auth.jwt() ->> 'email' = email
+  (select auth.jwt()) ->> 'email' = email
 ) with check (
-  auth.jwt() ->> 'email' = email
+  (select auth.jwt()) ->> 'email' = email
 );`.trim(),
     name: 'Enable update for users based on email',
-    definition: `auth.jwt() ->> 'email' = email`,
-    check: `auth.jwt() ->> 'email' = email`,
+    definition: `(select auth.jwt()) ->> 'email' = email`,
+    check: `(select auth.jwt()) ->> 'email' = email`,
     command: 'UPDATE',
     roles: [],
   },
@@ -77,10 +77,10 @@ for update using (
 create policy "Enable delete for users based on user_id"
 on "${schema}"."${table}"
 for delete using (
-  auth.uid() = user_id
+  (select auth.uid()) = user_id
 );`.trim(),
     name: 'Enable delete for users based on user_id',
-    definition: 'auth.uid() = user_id',
+    definition: '(select auth.uid()) = user_id',
     check: '',
     command: 'DELETE',
     roles: [],
@@ -95,11 +95,11 @@ for delete using (
 create policy "Enable insert for users based on user_id"
 on "${schema}"."${table}"
 for insert with check (
-  auth.uid() = user_id
+  (select auth.uid()) = user_id
 );`.trim(),
     name: 'Enable insert for users based on user_id',
     definition: '',
-    check: 'auth.uid() = user_id',
+    check: '(select auth.uid()) = user_id',
     command: 'INSERT',
     roles: [],
   },
@@ -115,12 +115,12 @@ Assuming 2 tables called \`teams\` and \`members\`, you can query both tables in
     statement: `
 create policy "Members can update team details if they belong to the team"
 on teams for update using (
-  auth.uid() in (
+  (select auth.uid()) in (
     select user_id from members where team_id = id
   )
 );
 `.trim(),
-    definition: `auth.uid() in (select user_id from members where team_id = id)`,
+    definition: `(select auth.uid()) in (select user_id from members where team_id = id)`,
     check: '',
     command: 'UPDATE',
     roles: [],

--- a/apps/studio/components/interfaces/SQLEditor/SQLEditor.queries.ts
+++ b/apps/studio/components/interfaces/SQLEditor/SQLEditor.queries.ts
@@ -517,29 +517,29 @@ alter table public.role_permissions
 create policy "Allow logged-in read access" on public.users
   for select using (auth.role() = 'authenticated');
 create policy "Allow individual insert access" on public.users
-  for insert with check (auth.uid() = id);
+  for insert with check ((select auth.uid()) = id);
 create policy "Allow individual update access" on public.users
-  for update using ( auth.uid() = id );
+  for update using ( (select auth.uid()) = id );
 create policy "Allow logged-in read access" on public.channels
   for select using (auth.role() = 'authenticated');
 create policy "Allow individual insert access" on public.channels
-  for insert with check (auth.uid() = created_by);
+  for insert with check ((select auth.uid()) = created_by);
 create policy "Allow individual delete access" on public.channels
-  for delete using (auth.uid() = created_by);
+  for delete using ((select auth.uid()) = created_by);
 create policy "Allow authorized delete access" on public.channels
   for delete using (authorize('channels.delete', auth.uid()));
 create policy "Allow logged-in read access" on public.messages
   for select using (auth.role() = 'authenticated');
 create policy "Allow individual insert access" on public.messages
-  for insert with check (auth.uid() = user_id);
+  for insert with check ((select auth.uid()) = user_id);
 create policy "Allow individual update access" on public.messages
-  for update using (auth.uid() = user_id);
+  for update using ((select auth.uid()) = user_id);
 create policy "Allow individual delete access" on public.messages
-  for delete using (auth.uid() = user_id);
+  for delete using ((select auth.uid()) = user_id);
 create policy "Allow authorized delete access" on public.messages
   for delete using (authorize('messages.delete', auth.uid()));
 create policy "Allow individual read access" on public.user_roles
-  for select using (auth.uid() = user_id);
+  for select using ((select auth.uid()) = user_id);
 
 -- Send "previous data" on change
 alter table public.users
@@ -638,11 +638,11 @@ alter table todos enable row level security;
 create policy "Individuals can create todos." on todos for
     insert with check (auth.uid() = user_id);
 create policy "Individuals can view their own todos. " on todos for
-    select using (auth.uid() = user_id);
+    select using ((select auth.uid()) = user_id);
 create policy "Individuals can update their own todos." on todos for
-    update using (auth.uid() = user_id);
+    update using ((select auth.uid()) = user_id);
 create policy "Individuals can delete their own todos." on todos for
-    delete using (auth.uid() = user_id);
+    delete using ((select auth.uid()) = user_id);
 `.trim(),
   },
   {
@@ -668,9 +668,9 @@ create table users (
 alter table users
   enable row level security;
 create policy "Can view own user data." on users
-  for select using (auth.uid() = id);
+  for select using ((select auth.uid()) = id);
 create policy "Can update own user data." on users
-  for update using (auth.uid() = id);
+  for update using ((select auth.uid()) = id);
 
 /**
 * This trigger automatically creates a user entry when a new user signs up via Supabase Auth.
@@ -801,7 +801,7 @@ create table subscriptions (
 alter table subscriptions
   enable row level security;
 create policy "Can only view own subs data." on subscriptions
-  for select using (auth.uid() = user_id);
+  for select using ((select auth.uid()) = user_id);
 
 /**
  * REALTIME SUBSCRIPTIONS
@@ -838,10 +838,10 @@ create policy "Public profiles are viewable by everyone." on profiles
   for select using (true);
 
 create policy "Users can insert their own profile." on profiles
-  for insert with check (auth.uid() = id);
+  for insert with check ((select auth.uid()) = id);
 
 create policy "Users can update own profile." on profiles
-  for update using (auth.uid() = id);
+  for update using ((select auth.uid()) = id);
 
 -- This trigger automatically creates a profile entry when a new user signs up via Supabase Auth.
 -- See https://supabase.com/docs/guides/auth/managing-user-data#using-triggers for more details.

--- a/apps/studio/components/to-be-cleaned/Storage/StoragePolicies/StoragePolicies.constants.ts
+++ b/apps/studio/components/to-be-cleaned/Storage/StoragePolicies/StoragePolicies.constants.ts
@@ -46,10 +46,10 @@ CREATE POLICY "policy_name"
 ON storage.objects FOR {operation} {USING | WITH CHECK} (
     -- restrict bucket
     bucket_id = {bucket_name}
-    and auth.uid()::text = (storage.foldername(name))[1]
+    and (select auth.uid()::text) = (storage.foldername(name))[1]
 );
     `.trim(),
-    definition: `bucket_id = {bucket_id} AND auth.uid()::text = (storage.foldername(name))[1]`,
+    definition: `bucket_id = {bucket_id} AND (select auth.uid()::text) = (storage.foldername(name))[1]`,
     allowedOperations: [],
   },
   {
@@ -64,7 +64,7 @@ ON storage.objects FOR {operation} {USING | WITH CHECK} (
     -- restrict bucket
     bucket_id = {bucket_name}
     AND (storage.foldername(name))[1] = 'private'
-    AND auth.role() = 'authenticated'
+    AND (select auth.role()) = 'authenticated'
 );
     `.trim(),
     definition: `bucket_id = {bucket_id} AND (storage.foldername(name))[1] = 'private' AND auth.role() = 'authenticated'`,
@@ -82,10 +82,10 @@ ON storage.objects FOR {operation} {USING | WITH CHECK} (
 	  -- restrict bucket
     bucket_id = {bucket_name}
     AND (storage.foldername(name))[1] = 'admin' AND (storage.foldername(name))[2] = 'assets'
-    AND auth.uid()::text = 'd7bed83c-44a0-4a4f-925f-efc384ea1e50'
+    AND (select auth.uid()::text) = 'd7bed83c-44a0-4a4f-925f-efc384ea1e50'
 );
     `.trim(),
-    definition: `bucket_id = {bucket_id} AND (storage.foldername(name))[1] = 'admin' AND (storage.foldername(name))[2] = 'assets' AND auth.uid()::text = 'd7bed83c-44a0-4a4f-925f-efc384ea1e50'`,
+    definition: `bucket_id = {bucket_id} AND (storage.foldername(name))[1] = 'admin' AND (storage.foldername(name))[2] = 'assets' AND (select auth.uid()::text) = 'd7bed83c-44a0-4a4f-925f-efc384ea1e50'`,
     allowedOperations: [],
   },
   {
@@ -99,10 +99,10 @@ ON storage.objects FOR {operation} {USING | WITH CHECK} (
 	  -- restrict bucket
     bucket_id = {bucket_name}
     AND name = 'admin/assets/Costa Rican Frog.jpg'
-    AND auth.uid()::text = 'd7bed83c-44a0-4a4f-925f-efc384ea1e50'
+    AND (select auth.uid()::text) = 'd7bed83c-44a0-4a4f-925f-efc384ea1e50'
 );
     `.trim(),
-    definition: `bucket_id = {bucket_id} AND name = 'admin/assets/Costa Rican Frog.jpg' AND auth.uid()::text = 'd7bed83c-44a0-4a4f-925f-efc384ea1e50'`,
+    definition: `bucket_id = {bucket_id} AND name = 'admin/assets/Costa Rican Frog.jpg' AND (select auth.uid()::text) = 'd7bed83c-44a0-4a4f-925f-efc384ea1e50'`,
     allowedOperations: [],
   },
 ]

--- a/apps/studio/lib/vercelConfigs.ts
+++ b/apps/studio/lib/vercelConfigs.ts
@@ -186,11 +186,11 @@ create policy "Public profiles are viewable by everyone."
 
 create policy "Users can insert their own profile."
   on profiles for insert
-  with check ( auth.uid() = id );
+  with check ( (select auth.uid()) = id );
 
 create policy "Users can update own profile."
   on profiles for update
-  using ( auth.uid() = id );
+  using ( (select auth.uid()) = id );
 
 -- Create a trigger to sync profiles and auth.users
 create function public.handle_new_user()
@@ -249,7 +249,7 @@ create policy "Posts are viewable by everyone."
 
 create policy "Users can post as themselves."
     on posts for insert
-    with check ( auth.uid() = "authorId" );
+    with check ( (select auth.uid()) = "authorId" );
 
 -- Create a table for sites
 create table sites (
@@ -269,7 +269,7 @@ create policy "Sites are viewable by everyone."
 
 create policy "Users can create their own sites."
     on sites for insert
-    with check ( auth.uid() = "ownerId" );
+    with check ( (select auth.uid()) = "ownerId" );
 
 -- Create a table for votes
 create table votes (
@@ -289,11 +289,11 @@ create policy "Votes are viewable by everyone"
 
 create policy "Users can vote as themselves"
     on votes for insert
-    with check (auth.uid() = "userId");
+    with check ((select auth.uid()) = "userId");
 
 create policy "Users can update their own votes"
     on votes for update
-    using ( auth.uid() = "userId" );
+    using ( (select auth.uid()) = "userId" );
 
 
 -- Set up Realtime!

--- a/apps/studio/tests/unit/destructive-query-check.test.ts
+++ b/apps/studio/tests/unit/destructive-query-check.test.ts
@@ -34,7 +34,7 @@ describe(`destructive query check`, () => {
     const match = checkDestructiveQuery(stripIndent`
       create policy "Users can delete their own files"
       on storage.objects for delete to authenticated using (
-        bucket id = 'files' and auth.uid () = owner
+        bucket id = 'files' and (select auth.uid()) = owner
       );
     `)
 

--- a/apps/www/_alternatives/supabase-vs-auth0.mdx
+++ b/apps/www/_alternatives/supabase-vs-auth0.mdx
@@ -31,7 +31,7 @@ Row Level Security needs to be defined only once to implement authentication and
 ```sql
 create policy "Users can only view their own documents."
 on docs for select
-using ( auth.uid() = user_id );
+using ( (select auth.uid()) = user_id );
 ```
 
 The RLS policy above will be enforced, no matter if you use the REST API, edge functions or other methods of accessing your data.

--- a/apps/www/_blog/2020-08-05-supabase-auth.mdx
+++ b/apps/www/_blog/2020-08-05-supabase-auth.mdx
@@ -75,7 +75,7 @@ let user = await supabase.from('users').select('user_id, name').eq('user_id', lo
 // Returns { id: 'd0714948', name: 'Jane'
 ```
 
-... you can simply define a rule on your database table, `auth.uid() = user_id`, and your request will return the rows which pass the rule, even when you remove the filter from your middleware:
+... you can simply define a rule on your database table, `(select auth.uid()) = user_id`, and your request will return the rows which pass the rule, even when you remove the filter from your middleware:
 
 ```js
 let user = await supabase.from('users').select('user_id, name')\n

--- a/apps/www/_blog/2021-02-27-cracking-postgres-interview.mdx
+++ b/apps/www/_blog/2021-02-27-cracking-postgres-interview.mdx
@@ -101,7 +101,7 @@ We use Row Level Security in Supabase as a way to grant/restrict access on a row
 
 ```sql
 CREATE POLICY "Individuals can only write their own messages." ON messages FOR
-    INSERT WITH CHECK (auth.uid() = user_id);
+    INSERT WITH CHECK ((select auth.uid()) = user_id);
 
 -- auth.uid() is a function provided by Supabase which plucks the uid out
 --   of the JWT sent along with an API request more on this here:

--- a/apps/www/_blog/2021-03-30-supabase-storage.mdx
+++ b/apps/www/_blog/2021-03-30-supabase-storage.mdx
@@ -131,7 +131,7 @@ create policy crud_uid_file
 on storage.objects for all using (
 	bucket_id = 'avatars'
 	and name = 'folder/only_uid.jpg'
-	and auth.uid() = 'd8c7bce9-cfeb-497b-bd61-e66ce2cbdaa2'
+	and (select auth.uid()) = 'd8c7bce9-cfeb-497b-bd61-e66ce2cbdaa2'
 );
 ```
 

--- a/apps/www/_blog/2021-12-01-realtime-row-level-security-in-postgresql.mdx
+++ b/apps/www/_blog/2021-12-01-realtime-row-level-security-in-postgresql.mdx
@@ -64,7 +64,7 @@ For example, the following policy would allow users to select their own rows in 
 ```sql hideCopy
 create policy todo_select_policy
     on todos for select
-    using ( auth.uid() = user_id );
+    using ( (select auth.uid()) = user_id );
 ```
 
 which is equivalent to adding

--- a/apps/www/_blog/2022-08-24-building-a-realtime-trello-board-with-supabase-and-angular.mdx
+++ b/apps/www/_blog/2022-08-24-building-a-realtime-trello-board-with-supabase-and-angular.mdx
@@ -177,7 +177,7 @@ create policy "Users can update their boards" on boards for
     );
 
 create policy "Users can delete their created boards" on boards for
-    delete using (auth.uid() = creator);
+    delete using ((select auth.uid()) = creator);
 
 -- user_boards row level security
 alter table user_boards enable row level security;
@@ -186,10 +186,10 @@ create policy "Users can add their boards" on user_boards for
     insert to authenticated with check (true);
 
 create policy "Users can view boards" on user_boards for
-    select using (auth.uid() = user_id);
+    select using ((select auth.uid()) = user_id);
 
 create policy "Users can delete their boards" on user_boards for
-    delete using (auth.uid() = user_id);
+    delete using ((select auth.uid()) = user_id);
 
 -- lists row level security
 alter table lists enable row level security;

--- a/apps/www/_blog/2022-11-08-authentication-in-ionic-angular.mdx
+++ b/apps/www/_blog/2022-11-08-authentication-in-ionic-angular.mdx
@@ -115,7 +115,7 @@ create policy "Authenticated users can create groups." on groups for
   insert to authenticated with check (true);
 
 create policy "The owner can delete a group." on groups for
-    delete using (auth.uid() = creator);
+    delete using ((select auth.uid()) = creator);
 
 -- Message Policies
 create policy "Authenticated users can read messages." on messages

--- a/apps/www/_blog/2022-12-14-mfa-auth-via-rls.mdx
+++ b/apps/www/_blog/2022-12-14-mfa-auth-via-rls.mdx
@@ -102,7 +102,7 @@ create policy "Enforce MFA for all end users."
   on table_name
   as restrictive
   to authenticated
-  using ( auth.jwt()->>'aal' = 'aal2' );
+  using ( (select auth.jwt()->>'aal') = 'aal2' );
 ```
 
 _Enforce MFA for all end users_
@@ -120,7 +120,7 @@ create policy "Allow access on table only if user has gone through MFA"
             else array['aal1', 'aal2']
           end as aal
         from auth.mfa_factors
-        where auth.uid() = user_id and status = 'verified'
+        where (select auth.uid()) = user_id and status = 'verified'
     ));
 ```
 

--- a/apps/www/_blog/2023-04-13-supabase-auth-sso-pkce.mdx
+++ b/apps/www/_blog/2023-04-13-supabase-auth-sso-pkce.mdx
@@ -75,7 +75,7 @@ For example, you can use Row Level Security (RLS) to build multi-tenant applicat
 
 ```sql
 create policy "Only allow read-write access to tenants" on tablename as restrictive to authenticated using (
-  tenant_id = (auth.jwt () -> 'app_metadata' ->> 'provider')
+  tenant_id = (select auth.jwt() -> 'app_metadata' ->> 'provider')
 );
 ```
 

--- a/apps/www/_blog/2023-05-04-flutter-multi-factor-authentication.mdx
+++ b/apps/www/_blog/2023-05-04-flutter-multi-factor-authentication.mdx
@@ -643,7 +643,7 @@ alter table
 -- Create a policy that only allows read if they user has signed in via MFA
 create policy "Users can view private_posts if they have signed in via MFA" on public.private_posts for
 select
-  to authenticated using (auth.jwt () - > > 'aal' = 'aal2');
+  to authenticated using ((select auth.jwt() - >> 'aal') = 'aal2');
 ```
 
 `aal` here stands for [Authenticator Assurance Level](https://pages.nist.gov/800-63-3-Implementation-Resources/63B/AAL/), and it will be `aal1` for users who have only signed in with 1 sign-in method, and `aal2` for users who have completed the MFA flow. Checking the `aal` inside RLS policy ensures that the data cannot be viewed by users unless they complete the entire MFA flow.

--- a/apps/www/_blog/2023-08-01-react-native-storage.mdx
+++ b/apps/www/_blog/2023-08-01-react-native-storage.mdx
@@ -68,8 +68,8 @@ You can either do this through the UI and pick from examples, or simply run my S
 CREATE POLICY "Enable storage access for users based on user_id" ON "storage"."objects"
 AS PERMISSIVE FOR ALL
 TO public
-USING (bucket_id = 'files' AND auth.uid()::text = (storage.foldername(name))[1])
-WITH CHECK (bucket_id = 'files' AND auth.uid()::text = (storage.foldername(name))[1])
+USING (bucket_id = 'files' AND (SELECT auth.uid()::text )= (storage.foldername(name))[1])
+WITH CHECK (bucket_id = 'files' AND (SELECT auth.uid()::text) = (storage.foldername(name))[1])
 ```
 
 This will allow users to only access their own folder, and not any other files in the bucket.

--- a/apps/www/_blog/2024-01-17-what-is-saml-authentication.mdx
+++ b/apps/www/_blog/2024-01-17-what-is-saml-authentication.mdx
@@ -135,7 +135,7 @@ on invited_users
 as restrictive
 for insert
 with check (
-	sso_provider_id = auth.jwt()#>>'{amr,0,provider}'
+	sso_provider_id = (select auth.jwt()#>>'{amr,0,provider}')
 );
 ```
 

--- a/apps/www/data/products/auth/auth-sql-rules-examples.js
+++ b/apps/www/data/products/auth/auth-sql-rules-examples.js
@@ -45,7 +45,7 @@ alter table profiles enable row level security;
 -- 3. Create Policy
 create policy "Users can update their own profiles." 
 on profiles for update 
-using ( auth.uid() = id );
+using ( (select auth.uid()) = id );
 `.trim(),
   },
   {
@@ -74,7 +74,7 @@ alter table teams enable row level security;
 create policy "Team members can update team details"
 on teams
 for update using (
-  auth.uid() in ( 
+  (select auth.uid()) in ( 
     select user_id from members 
     where team_id = id 
   )

--- a/apps/www/data/products/storage/permissions-examples.js
+++ b/apps/www/data/products/storage/permissions-examples.js
@@ -53,7 +53,7 @@ on storage.objects for all
 using (
   bucket_id = 'avatars' 
   and name = 'folder/only_uid.jpg' 
-  and auth.uid() = 'd8c7bce9-cfeb-497b-bd61-e66ce2cbdaa2'
+  and (select auth.uid()) = 'd8c7bce9-cfeb-497b-bd61-e66ce2cbdaa2'
 );`,
     detail_title: 'Allow a specific user access to a file',
     detail_text:

--- a/examples/auth/flutter-mfa/README.md
+++ b/examples/auth/flutter-mfa/README.md
@@ -35,7 +35,7 @@ create policy "Users can view private_posts if they have signed in via MFA"
   on public.private_posts
   for select
   to authenticated
-  using (auth.jwt()->>'aal' = 'aal2');
+  using ((select auth.jwt()->>'aal') = 'aal2');
 ```
 
 - Run the app and test the login flow 🚀

--- a/examples/todo-list/nextjs-todo-list/README.md
+++ b/examples/todo-list/nextjs-todo-list/README.md
@@ -56,16 +56,16 @@ create table todos (
 alter table todos enable row level security;
 
 create policy "Individuals can create todos." on todos for
-    insert with check (auth.uid() = user_id);
+    insert with check ((select auth.uid()) = user_id);
 
 create policy "Individuals can view their own todos. " on todos for
-    select using (auth.uid() = user_id);
+    select using ((select auth.uid()) = user_id);
 
 create policy "Individuals can update their own todos." on todos for
-    update using (auth.uid() = user_id);
+    update using ((select auth.uid()) = user_id);
 
 create policy "Individuals can delete their own todos." on todos for
-    delete using (auth.uid() = user_id);
+    delete using ((select auth.uid()) = user_id);
 ```
 
 ## Authors

--- a/examples/todo-list/sveltejs-todo-list/README.md
+++ b/examples/todo-list/sveltejs-todo-list/README.md
@@ -47,16 +47,16 @@ create table todos (
 alter table todos enable row level security;
 
 create policy "Individuals can create todos." on todos for
-    insert with check (auth.uid() = user_id);
+    insert with check ((select auth.uid()) = user_id);
 
 create policy "Individuals can view their own todos. " on todos for
-    select using (auth.uid() = user_id);
+    select using ((select auth.uid()) = user_id);
 
 create policy "Individuals can update their own todos." on todos for
-    update using (auth.uid() = user_id);
+    update using ((select auth.uid()) = user_id);
 
 create policy "Individuals can delete their own todos." on todos for
-    delete using (auth.uid() = user_id);
+    delete using ((select auth.uid()) = user_id);
 ```
 
 ## Authors

--- a/examples/user-management/angular-user-management/README.md
+++ b/examples/user-management/angular-user-management/README.md
@@ -79,10 +79,10 @@ create policy "Public profiles are viewable by everyone."
   using ( true );
 create policy "Users can insert their own profile."
   on profiles for insert
-  with check ( auth.uid() = id );
+  with check ( (select auth.uid()) = id );
 create policy "Users can update own profile."
   on profiles for update
-  using ( auth.uid() = id );
+  using ( (select auth.uid()) = id );
 -- Set up Realtime!
 begin;
   drop publication if exists supabase_realtime;

--- a/examples/user-management/expo-user-management/README.md
+++ b/examples/user-management/expo-user-management/README.md
@@ -82,11 +82,11 @@ select
 
 create policy "Users can insert their own profile." on profiles for insert
 with
-  check (auth.uid () = id);
+  check ((select auth.uid()) = id);
 
 create policy "Users can update own profile." on profiles for
 update
-  using (auth.uid () = id);
+  using ((select auth.uid()) = id);
 
 -- Set up Realtime!
 begin;

--- a/examples/user-management/flutter-user-management/README.md
+++ b/examples/user-management/flutter-user-management/README.md
@@ -52,11 +52,11 @@ create policy "Public profiles are viewable by everyone."
 
 create policy "Users can insert their own profile."
   on profiles for insert
-  with check ( auth.uid() = id );
+  with check ( (select auth.uid()) = id );
 
 create policy "Users can update own profile."
   on profiles for update
-  using ( auth.uid() = id );
+  using ( (select auth.uid()) = id );
 
 -- Set up Realtime!
 begin;

--- a/examples/user-management/nextjs-user-management/README.md
+++ b/examples/user-management/nextjs-user-management/README.md
@@ -92,10 +92,10 @@ create policy "Public profiles are viewable by everyone." on profiles
   for select using (true);
 
 create policy "Users can insert their own profile." on profiles
-  for insert with check (auth.uid() = id);
+  for insert with check ((select auth.uid()) = id);
 
 create policy "Users can update own profile." on profiles
-  for update using (auth.uid() = id);
+  for update using ((select auth.uid()) = id);
 
 -- This trigger automatically creates a profile entry when a new user signs up via Supabase Auth.
 -- See https://supabase.com/docs/guides/auth/managing-user-data#using-triggers for more details.

--- a/examples/user-management/nuxt3-user-management/README.md
+++ b/examples/user-management/nuxt3-user-management/README.md
@@ -1,17 +1,19 @@
 # Supabase Nuxt User Management
 
-This repo is a quick sample of how you can get started building apps using Nuxt 3 and Supabase. You can find a step by step guide of how to build out this app in the [Quickstart: Nuxt  guide](https://supabase.io/docs/guides/with-nuxt-3). 
+This repo is a quick sample of how you can get started building apps using Nuxt 3 and Supabase. You can find a step by step guide of how to build out this app in the [Quickstart: Nuxt guide](https://supabase.io/docs/guides/with-nuxt-3).
 
 This repo will demonstrate how to:
+
 - sign users in with Supabase Auth using [magic link](https://supabase.io/docs/reference/dart/auth-signin#sign-in-with-magic-link)
 - store and retrieve data with [Supabase database](https://supabase.io/docs/guides/database)
 - store image files in [Supabase storage](https://supabase.io/docs/guides/storage)
 
 ## Getting Started
 
-Before running this app, you need to create a Supabase project and copy [your credentials](https://supabase.io/docs/guides/with-nuxt-3#get-the-api-keys) to `.env`. 
+Before running this app, you need to create a Supabase project and copy [your credentials](https://supabase.io/docs/guides/with-nuxt-3#get-the-api-keys) to `.env`.
 
 Run the following command to launch it on `localhost:3000`
+
 ```bash
 npm run dev
 ```
@@ -40,11 +42,11 @@ create policy "Public profiles are viewable by everyone."
 
 create policy "Users can insert their own profile."
   on profiles for insert
-  with check ( auth.uid() = id );
+  with check ( (select auth.uid()) = id );
 
 create policy "Users can update own profile."
   on profiles for update
-  using ( auth.uid() = id );
+  using ( (select auth.uid()) = id );
 
 -- Set up Realtime!
 begin;

--- a/examples/user-management/react-user-management/README.md
+++ b/examples/user-management/react-user-management/README.md
@@ -88,11 +88,11 @@ select
 
 create policy "Users can insert their own profile." on profiles for insert
 with
-  check (auth.uid () = id);
+  check ((select auth.uid()) = id);
 
 create policy "Users can update own profile." on profiles for
 update
-  using (auth.uid () = id);
+  using ((select auth.uid()) = id);
 
 -- Set up Realtime!
 begin;

--- a/examples/user-management/refine-user-management/README.MD
+++ b/examples/user-management/refine-user-management/README.MD
@@ -2,19 +2,17 @@
 
 This repo is a quick sample of how you can get started building apps using [refine](https://github.com/refinedev/refine) and Supabase: users can sign up with a magic link and then update their account with public profile information, including a profile image.
 
-
-
 ## About refine
 
 [refine](https://github.com/refinedev/refine) is a React-based framework for building data-intensive applications in no time ✨
 
 refine offers lots of out-of-the box functionality for rapid development, without compromising extreme customizability. Use-cases include, but are not limited to admin panels, B2B applications and dashboards.
 
-
 - To learn more about **refine**, please check out the [Documentation](https://refine.dev/docs)
 - [Step up to refine tutorials.](https://refine.dev/docs/tutorial/introduction/index/)
 
 ## Available Scripts
+
 ### Running the development server.
 
 ```bash
@@ -26,7 +24,6 @@ npm run dev
 ```bash
 npm run build
 ```
-
 
 ## Build from scratch
 
@@ -92,10 +89,10 @@ create policy "Public profiles are viewable by everyone."
   using ( true );
 create policy "Users can insert their own profile."
   on profiles for insert
-  with check ( auth.uid() = id );
+  with check ( (select auth.uid()) = id );
 create policy "Users can update own profile."
   on profiles for update
-  using ( auth.uid() = id );
+  using ( (select auth.uid()) = id );
 -- Set up Realtime!
 begin;
   drop publication if exists supabase_realtime;
@@ -113,9 +110,6 @@ create policy "Anyone can upload an avatar."
   with check ( bucket_id = 'avatars' );
 ```
 
-
-
 ## License
 
 MIT
-

--- a/examples/user-management/solid-user-management/README.md
+++ b/examples/user-management/solid-user-management/README.md
@@ -91,11 +91,11 @@ select
 
 create policy "Users can insert their own profile." on profiles for insert
 with
-	check (auth.uid () = id);
+	check ((select auth.uid()) = id);
 
 create policy "Users can update own profile." on profiles for
 update
-	using (auth.uid () = id);
+	using ((select auth.uid()) = id);
 
 -- Set up Realtime!
 begin;

--- a/examples/user-management/svelte-user-management/README.md
+++ b/examples/user-management/svelte-user-management/README.md
@@ -89,11 +89,11 @@ select
 
 create policy "Users can insert their own profile." on profiles for insert
 with
-	check (auth.uid () = id);
+	check ((select auth.uid()) = id);
 
 create policy "Users can update own profile." on profiles for
 update
-	using (auth.uid () = id);
+	using ((select auth.uid()) = id);
 
 -- Set up Realtime!
 begin;

--- a/examples/user-management/sveltekit-user-management/README.md
+++ b/examples/user-management/sveltekit-user-management/README.md
@@ -57,10 +57,10 @@ create policy "Public profiles are viewable by everyone."
   using ( true );
 create policy "Users can insert their own profile."
   on profiles for insert
-  with check ( auth.uid() = id );
+  with check ( (select auth.uid()) = id );
 create policy "Users can update own profile."
   on profiles for update
-  using ( auth.uid() = id );
+  using ( (select auth.uid()) = id );
 -- Set up Realtime!
 begin;
   drop publication if exists supabase_realtime;

--- a/examples/user-management/swift-user-management/README.md
+++ b/examples/user-management/swift-user-management/README.md
@@ -1,8 +1,9 @@
 # Supabase Swift User Management
 
-This repo is a quick sample of how you can get started building apps using Swift and Supabase. You can find a step by step guide of how to build out this app in the [Quickstart: Swift guide](https://supabase.io/docs/guides/with-swift). 
+This repo is a quick sample of how you can get started building apps using Swift and Supabase. You can find a step by step guide of how to build out this app in the [Quickstart: Swift guide](https://supabase.io/docs/guides/with-swift).
 
 This repo will demonstrate how to:
+
 - Sign users in with Supabase Auth using [magic link](https://supabase.io/docs/reference/dart/auth-signin#sign-in-with-magic-link)
 - Store and retrieve data with [Supabase database](https://supabase.io/docs/guides/database)
 - Store image files in [Supabase storage](https://supabase.io/docs/guides/storage)
@@ -39,11 +40,11 @@ create policy "Public profiles are viewable by everyone."
 
 create policy "Users can insert their own profile."
   on profiles for insert
-  with check ( auth.uid() = id );
+  with check ( (select auth.uid()) = id );
 
 create policy "Users can update own profile."
   on profiles for update
-  using ( auth.uid() = id );
+  using ( (select auth.uid()) = id );
 
 -- Set up Realtime!
 begin;

--- a/examples/user-management/vue3-user-management/README.md
+++ b/examples/user-management/vue3-user-management/README.md
@@ -1,17 +1,19 @@
 # Supabase Vue 3 User Management
 
-This repo is a quick sample of how you can get started building apps using Vue 3 and Supabase. You can find a step by step guide of how to build out this app in the [Quickstart: Vue guide](https://supabase.io/docs/guides/with-vue-3). 
+This repo is a quick sample of how you can get started building apps using Vue 3 and Supabase. You can find a step by step guide of how to build out this app in the [Quickstart: Vue guide](https://supabase.io/docs/guides/with-vue-3).
 
 This repo will demonstrate how to:
+
 - sign users in with Supabase Auth using [magic link](https://supabase.io/docs/reference/dart/auth-signin#sign-in-with-magic-link)
 - store and retrieve data with [Supabase database](https://supabase.io/docs/guides/database)
 - store image files in [Supabase storage](https://supabase.io/docs/guides/storage)
 
 ## Getting Started
 
-Before running this app, you need to create a Supabase project and copy [your credentials](https://supabase.io/docs/guides/with-vue-3#get-the-api-keys) to `.env`. 
+Before running this app, you need to create a Supabase project and copy [your credentials](https://supabase.io/docs/guides/with-vue-3#get-the-api-keys) to `.env`.
 
 Run the following command to launch it on `localhost:5173`
+
 ```bash
 npm run dev
 ```
@@ -40,11 +42,11 @@ create policy "Public profiles are viewable by everyone."
 
 create policy "Users can insert their own profile."
   on profiles for insert
-  with check ( auth.uid() = id );
+  with check ( (select auth.uid()) = id );
 
 create policy "Users can update own profile."
   on profiles for update
-  using ( auth.uid() = id );
+  using ( (select auth.uid()) = id );
 
 -- Set up Realtime!
 begin;


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Fix

## What is the current behavior?

Code examples and snippets didn't always follow best practice for using `select` when calling `auth.uid` or `auth.jwt` in RLS policies

## What is the new behavior?

Code examples and snippets use `(select auth.uid())`, etc.
