### PR TITLE
remove live slack clone demo

### DIFF
--- a/examples/slack-clone/nextjs-slack-clone/README.md
+++ b/examples/slack-clone/nextjs-slack-clone/README.md
@@ -10,7 +10,6 @@ This is a full-stack Slack clone example using:
 
 ## Demo
 
-- Live demo: http://supabase-slack-clone-supabase.vercel.app/
 - CodeSandbox: https://codesandbox.io/s/github/supabase/supabase/tree/master/examples/nextjs-slack-clone
 
 ![Demo animation gif](./public/slack-clone-demo.gif)


### PR DESCRIPTION
Example doesn't work already. Got Thor's confirmation [here](https://supabase.slack.com/archives/CS7RWBQ8K/p1712822464678959?thread_ts=1712668278.893099&cid=CS7RWBQ8K)
