### PR TITLE
feat: add types for available regions in the docs

### DIFF
--- a/apps/docs/content/guides/functions/regional-invocation.mdx
+++ b/apps/docs/content/guides/functions/regional-invocation.mdx
@@ -66,6 +66,20 @@ These are the currently supported region values you can provide for `x-region` h
 - `us-west-1`
 - `us-west-2`
 
+## Using the client library
+
+You can also specify the region when invoking a Function using the Supabase client library:
+
+```js
+const { createClient, FunctionRegion } = require('@supabase/supabase-js')
+const { data: ret, error } = await supabase.functions.invoke('my-function-name', {
+  headers: { 'Content-Type': 'application/json' },
+  method: 'GET',
+  body: {},
+  region: FunctionRegion.UsEast1,
+})
+```
+
 ## Handling regional outages
 
 If you explicitly specify the region via `x-region` header, requests **will NOT** be automatically re-routed to another region and you should consider temporarily changing regions during the outage.

--- a/apps/docs/spec/supabase_js_v2.yml
+++ b/apps/docs/spec/supabase_js_v2.yml
@@ -568,7 +568,7 @@ functions:
     notes: |
       - Requires either an email or phone number.
       - This method is used for passwordless sign-ins where a OTP is sent to the user's email or phone number.
-      - If the user doesn't exist, `signInWithOtp()` will signup the user instead. To restrict this behaviour, you can set `shouldCreateUser` in `SignInWithPasswordlessCredentials.options` to `false`.
+      - If the user doesn't exist, `signInWithOtp()` will signup the user instead. To restrict this behavior, you can set `shouldCreateUser` in `SignInWithPasswordlessCredentials.options` to `false`.
       - If you're using an email, you can configure whether you want the user to receive a magiclink or a OTP.
       - If you're using phone, you can configure whether you want the user to receive a OTP.
       - The magic link's destination URL is determined by the [`SITE_URL`](/docs/guides/auth/concepts/redirect-urls).
@@ -4925,7 +4925,7 @@ functions:
     notes: |
       - Requires an Authorization header.
       - Invoke params generally match the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) spec.
-      - When you pass in a body to your function, we automatically attach the Content-Type header for `Blob`, `ArrayBuffer`, `File`, `FormData` and `String`. If it doesn't match any of these types we assume the payload is `json`, serialise it and attach the `Content-Type` header as `application/json`. You can override this behaviour by passing in a `Content-Type` header of your own.
+      - When you pass in a body to your function, we automatically attach the Content-Type header for `Blob`, `ArrayBuffer`, `File`, `FormData` and `String`. If it doesn't match any of these types we assume the payload is `json`, serialize it and attach the `Content-Type` header as `application/json`. You can override this behavior by passing in a `Content-Type` header of your own.
       - Responses are automatically parsed as `json`, `blob` and `form-data` depending on the `Content-Type` header sent by your function. Responses are parsed as `text` by default.
     examples:
       - id: basic-invocation
@@ -4994,7 +4994,15 @@ functions:
       - id: regional-invocation
         name: Invoking a Function in the UsEast1 region
         description: |
-          You can also set the region to use when invoking a function.
+          Here are the available regions:
+          - `FunctionRegion.Any`, `FunctionRegion.ApNortheast1`,
+          - `FunctionRegion.ApNortheast2`, `FunctionRegion.ApSouth1`,
+          - `FunctionRegion.ApSoutheast1`, `FunctionRegion.ApSoutheast2`,
+          - `FunctionRegion.CaCentral1`, `FunctionRegion.EuCentral1`,
+          - `FunctionRegion.EuWest1`, `FunctionRegion.EuWest2`,
+          - `FunctionRegion.EuWest3`, `FunctionRegion.SaEast1`,
+          - `FunctionRegion.UsEast1`, `FunctionRegion.UsWest1`,
+          - `FunctionRegion.UsWest2`
         isSpotlight: true
         code: |
           ```js

--- a/apps/docs/spec/supabase_js_v2.yml
+++ b/apps/docs/spec/supabase_js_v2.yml
@@ -4991,6 +4991,28 @@ functions:
             method: 'DELETE'
           })
           ```
+      - id: regional-invocation
+        name: Invoke in a particular region
+        description: |
+          You can also set the region to use when invoking a function.
+        isSpotlight: true
+        code: |
+          ```js
+          import { createClient, FunctionRegion } from '@supabase/supabase-js'
+
+          const { data, error } = await supabase.functions.invoke('hello', {
+            body: { foo: 'bar' },
+            region: FunctionRegion.US_EAST_1
+          })
+          ```
+        notes: |
+          - Available regions are:
+          - Any (default)
+          - ApNortheast1, ApNortheast2, ApSouth1, ApSoutheast1,
+          - ApSoutheast2, CaCentral1, EuCentral1, EuWest1,
+          - EuWest2, EuWest3, SaEast1,
+          - UsEast1, UsWest1, UsWest2
+
       - id: calling-with-get-verb
         name: Calling with GET HTTP verb
         description: |
@@ -5004,6 +5026,39 @@ functions:
             },
             method: 'GET'
           })
+          ```
+  - id: invoke-regional
+    title: invoke()
+    description: |
+      Invoke a Supabase Edge Function in a particular region.
+    $ref: '@supabase/functions-js.FunctionsClient.invoke'
+    notes: |
+      - Requires an Authorization header.
+      - You can specify the region to use when invoking a function.
+      - You can also set it globally using `supabase.setRegion()`.
+      - Invoke params generally match the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) spec.
+      - When you pass in a body to your function, we automatically attach the Content-Type header for `Blob`, `ArrayBuffer`, `File`, `FormData` and `String`. If it doesn't match any of these types we assume the payload is `json`, serialise it and attach the `Content-Type` header as `application/json`. You can override this behaviour by passing in a `Content-Type` header of your own.
+      - Responses are automatically parsed as `json`, `blob` and `form-data` depending on the `Content-Type` header sent by your function. Responses are parsed as `text` by default.
+    examples:
+      - id: listen-to-broadcast
+        name: Listen to broadcast messages
+        isSpotlight: true
+        code: |
+          ```js
+          supabase
+            .channel('room1')
+            .on('broadcast', { event: 'cursor-pos' }, payload => {
+              console.log('Cursor position received!', payload)
+            })
+            .subscribe((status) => {
+              if (status === 'SUBSCRIBED') {
+                channel.send({
+                  type: 'broadcast',
+                  event: 'cursor-pos',
+                  payload: { x: Math.random(), y: Math.random() },
+                })
+              }
+            })
           ```
 
   - id: subscribe

--- a/apps/docs/spec/supabase_js_v2.yml
+++ b/apps/docs/spec/supabase_js_v2.yml
@@ -4995,13 +4995,20 @@ functions:
         name: Invoking a Function in the UsEast1 region
         description: |
           Here are the available regions:
-          - `FunctionRegion.Any`, `FunctionRegion.ApNortheast1`,
-          - `FunctionRegion.ApNortheast2`, `FunctionRegion.ApSouth1`,
-          - `FunctionRegion.ApSoutheast1`, `FunctionRegion.ApSoutheast2`,
-          - `FunctionRegion.CaCentral1`, `FunctionRegion.EuCentral1`,
-          - `FunctionRegion.EuWest1`, `FunctionRegion.EuWest2`,
-          - `FunctionRegion.EuWest3`, `FunctionRegion.SaEast1`,
-          - `FunctionRegion.UsEast1`, `FunctionRegion.UsWest1`,
+          - `FunctionRegion.Any`
+          - `FunctionRegion.ApNortheast1`
+          - `FunctionRegion.ApNortheast2`
+          - `FunctionRegion.ApSouth1`
+          - `FunctionRegion.ApSoutheast1`
+          - `FunctionRegion.ApSoutheast2`
+          - `FunctionRegion.CaCentral1`
+          - `FunctionRegion.EuCentral1`
+          - `FunctionRegion.EuWest1`
+          - `FunctionRegion.EuWest2`
+          - `FunctionRegion.EuWest3`
+          - `FunctionRegion.SaEast1`
+          - `FunctionRegion.UsEast1`
+          - `FunctionRegion.UsWest1`
           - `FunctionRegion.UsWest2`
         isSpotlight: true
         code: |

--- a/apps/docs/spec/supabase_js_v2.yml
+++ b/apps/docs/spec/supabase_js_v2.yml
@@ -5002,7 +5002,7 @@ functions:
 
           const { data, error } = await supabase.functions.invoke('hello', {
             body: { foo: 'bar' },
-            region: FunctionRegion.US_EAST_1
+            region: FunctionRegion.UsEast1
           })
           ```
         notes: |
@@ -5026,39 +5026,6 @@ functions:
             },
             method: 'GET'
           })
-          ```
-  - id: invoke-regional
-    title: invoke()
-    description: |
-      Invoke a Supabase Edge Function in a particular region.
-    $ref: '@supabase/functions-js.FunctionsClient.invoke'
-    notes: |
-      - Requires an Authorization header.
-      - You can specify the region to use when invoking a function.
-      - You can also set it globally using `supabase.setRegion()`.
-      - Invoke params generally match the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) spec.
-      - When you pass in a body to your function, we automatically attach the Content-Type header for `Blob`, `ArrayBuffer`, `File`, `FormData` and `String`. If it doesn't match any of these types we assume the payload is `json`, serialise it and attach the `Content-Type` header as `application/json`. You can override this behaviour by passing in a `Content-Type` header of your own.
-      - Responses are automatically parsed as `json`, `blob` and `form-data` depending on the `Content-Type` header sent by your function. Responses are parsed as `text` by default.
-    examples:
-      - id: listen-to-broadcast
-        name: Listen to broadcast messages
-        isSpotlight: true
-        code: |
-          ```js
-          supabase
-            .channel('room1')
-            .on('broadcast', { event: 'cursor-pos' }, payload => {
-              console.log('Cursor position received!', payload)
-            })
-            .subscribe((status) => {
-              if (status === 'SUBSCRIBED') {
-                channel.send({
-                  type: 'broadcast',
-                  event: 'cursor-pos',
-                  payload: { x: Math.random(), y: Math.random() },
-                })
-              }
-            })
           ```
 
   - id: subscribe

--- a/apps/docs/spec/supabase_js_v2.yml
+++ b/apps/docs/spec/supabase_js_v2.yml
@@ -4992,7 +4992,7 @@ functions:
           })
           ```
       - id: regional-invocation
-        name: Invoke in a particular region
+        name: Invoking a Function in the UsEast1 region
         description: |
           You can also set the region to use when invoking a function.
         isSpotlight: true
@@ -5005,13 +5005,6 @@ functions:
             region: FunctionRegion.UsEast1
           })
           ```
-        notes: |
-          - Available regions are:
-          - Any (default)
-          - ApNortheast1, ApNortheast2, ApSouth1, ApSoutheast1,
-          - ApSoutheast2, CaCentral1, EuCentral1, EuWest1,
-          - EuWest2, EuWest3, SaEast1,
-          - UsEast1, UsWest1, UsWest2
 
       - id: calling-with-get-verb
         name: Calling with GET HTTP verb


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Small improvement in the docs by documenting available types for invoking a function in a particular region.

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
