### PR TITLE
fix: code block styling

### DIFF
--- a/packages/ui/src/components/CodeBlock/CodeBlock.tsx
+++ b/packages/ui/src/components/CodeBlock/CodeBlock.tsx
@@ -82,7 +82,7 @@ export const CodeBlock = ({
   const showLineNumbers = !hideLineNumbers
 
   return (
-    <div>
+    <>
       {title && (
         <div className="text-sm rounded-t-md bg-surface-100 py-2 px-4 border border-b-0 border-default font-sans">
           {title}
@@ -158,6 +158,6 @@ export const CodeBlock = ({
       ) : (
         <code className={shortCodeBlockClasses}>{value || children}</code>
       )}
-    </div>
+    </>
   )
 }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Code blocks are also used for inline code in docs, which are broken with the wrapping div because they become block elements.

## What is the new behavior?

Removed the div. It was added in PR ##22641 (the index advisor PR), so I checked for regressions on Query Performance page and none found.

## Additional context

Docs before:
<img width="864" alt="image" src="https://github.com/supabase/supabase/assets/26616127/90f54ef3-5333-4642-9870-751261028ade">
Docs after:
<img width="874" alt="image" src="https://github.com/supabase/supabase/assets/26616127/fc29cd23-3ca2-4d24-9c26-0b0fac8d8ba0">
Query performance after:
<img width="526" alt="image" src="https://github.com/supabase/supabase/assets/26616127/bd529106-4b3a-487b-8065-da2059a25bb7">

