### PR TITLE
Update row-level-security.mdx  to fix aggressive bad SQL cleanup

### DIFF
--- a/apps/docs/content/guides/database/postgres/row-level-security.mdx
+++ b/apps/docs/content/guides/database/postgres/row-level-security.mdx
@@ -362,7 +362,7 @@ Always use the Role of inside your policies, specified by the `TO` operator. For
 
 ```sql
 create policy "rls_test_select" on rls_test
-using ( (select auth.uid()) = user_id );
+using ( auth.uid() = user_id );
 ```
 
 Use:


### PR DESCRIPTION
The cleanup last done to show better RLS SQL changed the bad example and is causing user confusion now that it is highlighted by the linter.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

doc cleanup

## What is the current behavior?

See description

## What is the new behavior?

Still show the bad example with the fixed example.

## Additional context

Add any other context or screenshots.
