### PR TITLE
chore: Supabase AI types in examples

### DIFF
--- a/examples/ai/edge-functions/supabase/functions/generate-embedding/index.ts
+++ b/examples/ai/edge-functions/supabase/functions/generate-embedding/index.ts
@@ -1,3 +1,4 @@
+/// <reference types="https://esm.sh/@supabase/functions-js@2.3.1/src/edge-runtime.d.ts" />
 import { createClient } from "npm:@supabase/supabase-js@2.42.0";
 import { Database, Tables } from "../_shared/database.types.ts";
 
@@ -14,7 +15,6 @@ const supabase = createClient<Database>(
   Deno.env.get("SUPABASE_URL")!,
   Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
 );
-// @ts-ignore TODO: import Supabase AI types.
 const model = new Supabase.ai.Session("gte-small");
 
 Deno.serve(async (req) => {

--- a/examples/ai/edge-functions/supabase/functions/search/index.ts
+++ b/examples/ai/edge-functions/supabase/functions/search/index.ts
@@ -1,3 +1,4 @@
+/// <reference types="https://esm.sh/@supabase/functions-js@2.3.1/src/edge-runtime.d.ts" />
 import { createClient } from "npm:@supabase/supabase-js@2.42.0";
 import { Database } from "../_shared/database.types.ts";
 
@@ -5,7 +6,6 @@ const supabase = createClient<Database>(
   Deno.env.get("SUPABASE_URL")!,
   Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
 );
-// @ts-ignore TODO: import Supabase AI types.
 const model = new Supabase.ai.Session("gte-small");
 
 Deno.serve(async (req) => {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

examples update

## What is the current behavior?

`Supabase.ai` is untyped

## What is the new behavior?

It's now typed