### PR TITLE
fix: hackathon link change

### DIFF
--- a/apps/www/components/LaunchWeek/11/Releases/PrizeActions.tsx
+++ b/apps/www/components/LaunchWeek/11/Releases/PrizeActions.tsx
@@ -8,7 +8,7 @@ export default function PrizeActions() {
         <Link href="/ga-week#ticket">Claim your ticket</Link>
       </Button>
       <Button onClick={() => null} type="default" size="tiny">
-        <Link href="/blog/<link-to-hackathon-blog-post>">Join Hackathon</Link>
+        <Link href="/blog/supabase-oss-hackathon">Join Hackathon</Link>
       </Button>
     </div>
   )


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What is the new behavior?

Hackathon link change.

## Additional context

Closes #22758
