### PR TITLE
fix/prisma connect missing pgbouncer param

### DIFF
--- a/apps/studio/components/interfaces/Home/Connect/content/prisma/content.tsx
+++ b/apps/studio/components/interfaces/Home/Connect/content/prisma/content.tsx
@@ -20,7 +20,7 @@ const ContentFile = ({ connectionStringPooler }: ContentFileProps) => {
         <SimpleCodeBlock className="bash" parentClassName="min-h-72">
           {`
 # Connect to Supabase via connection pooling with Supavisor.
-DATABASE_URL="${connectionStringPooler.transaction}"
+DATABASE_URL="${connectionStringPooler.transaction}?pgbouncer=true"
 
 # Direct connection to the database. Used for migrations.
 DIRECT_URL="${connectionStringPooler.session}"


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Supabase Studio > Connect

## What is the current behavior?

On the prisma tab the `?pgbouncer=true` is missing from the `DATABASE_URL` variable

## What is the new behavior?

Added `?pgbouncer=true`

## Additional context

Closes #22681
