### PR TITLE
feat: tabs active background colour

### DIFF
--- a/packages/ui/src/components/shadcn/ui/tabs/tabs.tsx
+++ b/packages/ui/src/components/shadcn/ui/tabs/tabs.tsx
@@ -26,7 +26,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      'inline-flex items-center justify-center whitespace-nowrap px-3 py-1.5 text-sm  ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm text-foreground-lighter hover:text-foreground data-[state=active]:border-foreground border-b-2 border-transparent',
+      'inline-flex items-center justify-center whitespace-nowrap px-3 py-1.5 text-sm  ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:text-foreground data-[state=active]:shadow-sm text-foreground-lighter hover:text-foreground data-[state=active]:border-foreground border-b-2 border-transparent',
       className
     )}
     {...props}


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

UI Tabs fix

## What is the current behavior?

On a active tab the background colour looks odd:

<img width="1024" alt="Screenshot 2024-04-15 at 21 17 18" src="https://github.com/supabase/supabase/assets/22655069/f5c5437c-8b27-46e1-b700-9215d7443c72">


## What is the new behavior?

Background colour does not change:

<img width="1024" alt="Screenshot 2024-04-15 at 21 18 26" src="https://github.com/supabase/supabase/assets/22655069/b4b2a0e6-91a8-4d72-a0b1-6702530383f0">


## Additional context

@MildTomato 
