### PR TITLE
fix: show last_sign_in_at for anonymous users

### DIFF
--- a/apps/studio/components/interfaces/Auth/Users/UsersListItem.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/UsersListItem.tsx
@@ -48,10 +48,10 @@ const UserListItem = ({
         <span className="text-foreground">{createdAt?.format('DD MMM, YYYY HH:mm')}</span>
       </Table.td>
       <Table.td className="table-cell">
-        {!isUserConfirmed ? (
-          <Badge variant="warning">Waiting for verification..</Badge>
-        ) : user.last_sign_in_at ? (
+        {user.last_sign_in_at ? (
           lastSignedIn?.format('DD MMM, YYYY HH:mm')
+        ) : !isUserConfirmed ? (
+          <Badge variant="warning">Waiting for verification..</Badge>
         ) : (
           'Never'
         )}

--- a/apps/studio/components/interfaces/Auth/Users/UsersListItem.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/UsersListItem.tsx
@@ -48,7 +48,7 @@ const UserListItem = ({
         <span className="text-foreground">{createdAt?.format('DD MMM, YYYY HH:mm')}</span>
       </Table.td>
       <Table.td className="table-cell">
-        {user.last_sign_in_at ? (
+        {user?.last_sign_in_at ? (
           lastSignedIn?.format('DD MMM, YYYY HH:mm')
         ) : !isUserConfirmed ? (
           <Badge variant="warning">Waiting for verification..</Badge>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?
* User management page should show the `last_sign_in_at` field for anonymous users instead of the "Waiting for verification badge"

<img width="1734" alt="image" src="https://github.com/supabase/supabase/assets/28647601/ec150a3a-7c94-4a69-8cd5-847472a7b89b">

Previously
<img width="1681" alt="image" src="https://github.com/supabase/supabase/assets/28647601/d8dcf7f9-e949-4617-8875-e9a074396ea5">

