### PR TITLE
Update the links in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ To ensure a positive and inclusive environment, please read our [code of conduc
 
 If you find a bug, please create an Issue and we’ll triage it.
 
-- Please search [existing Issues](https://github.com/supabase/supabase) before creating a new one.
+- Please search [existing Issues](https://github.com/supabase/supabase/issues) before creating a new one.
 - Please include a clear description of the problem along with steps to reproduce it. Exact steps with screenshots and urls really help here.
 
 ## Pull Requests
@@ -23,7 +23,7 @@ We actively welcome your Pull Requests! A couple of things to keep in mind befor
 
 - If you’re fixing an Issue, make sure someone else hasn’t already created a PR fixing the same issue. Likewise, make sure to link your PR to the related Issue(s).
 - We will always try to accept the first viable PR that resolves the Issue.
-- If you're new, we encourage you to take a look at issues tagged with [good first issue](https://github.com/supabase/supabase/pulls?q=is%3Aopen+is%3Apr+label%3A%22good+first+issue%22).
+- If you're new, we encourage you to take a look at issues tagged with [good first issue](https://github.com/supabase/supabase/labels/good%20first%20issue).
 - If you’re submitting a new feature, make sure you have opened a [Discussion](https://github.com/orgs/supabase/discussions/new/choose) to discuss the new feature before opening a PR. We’d love to accept your hard work, but unfortunately if a feature hasn’t gone through a proper design process, your PR will be closed.
 - Please use the PR message template and provide detailed context for quicker review. PRs without clear problem statements will be closed.
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Update the links in CONTRIBUTING.md

## What is the current behavior?

- Closes https://github.com/supabase/supabase/issues/22799

## What is the new behavior?


The updated links should be:

'existing issues': ["https://github.com/supabase/supabase/issues"](https://github.com/supabase/supabase/issues)
'good first issue': ["https://github.com/supabase/supabase/labels/good%20first%20issue"](https://github.com/supabase/supabase/labels/good%20first%20issue)

Add any other context or screenshots.
