### PR TITLE
fix: update rate limit descriptions

### DIFF
--- a/apps/studio/components/interfaces/Auth/BasicAuthSettingsForm/BasicAuthSettingsForm.tsx
+++ b/apps/studio/components/interfaces/Auth/BasicAuthSettingsForm/BasicAuthSettingsForm.tsx
@@ -34,6 +34,7 @@ import { IS_PLATFORM } from 'lib/constants'
 import Link from 'next/link'
 import { WarningIcon } from 'ui-patterns/Icons/StatusIcons'
 import FormField from '../AuthProvidersForm/FormField'
+import { ExternalLink } from 'lucide-react'
 
 // Use a const string to represent no chars option. Represented as empty string on the backend side.
 const NO_REQUIRED_CHARACTERS = 'NO_REQUIRED_CHARS'
@@ -233,17 +234,30 @@ const BasicAuthSettingsForm = () => {
                             Anonymous users will use the{' '}
                             <code className="text-xs">authenticated</code> role when signing in
                           </AlertTitle_Shadcn_>
-                          <AlertDescription_Shadcn_>
-                            As a result, anonymous users will be subjected to RLS policies that
-                            apply to the <code className="text-xs">public</code> and{' '}
-                            <code className="text-xs">authenticated</code> roles. We strongly advise{' '}
-                            <Link
-                              href={`/project/${projectRef}/auth/policies`}
-                              className="text-foreground underline"
+                          <AlertDescription_Shadcn_ className="flex flex-col gap-y-3">
+                            <p>
+                              As a result, anonymous users will be subjected to RLS policies that
+                              apply to the <code className="text-xs">public</code> and{' '}
+                              <code className="text-xs">authenticated</code> roles. We strongly
+                              advise{' '}
+                              <Link
+                                href={`/project/${projectRef}/auth/policies`}
+                                className="text-foreground underline"
+                              >
+                                reviewing your RLS policies
+                              </Link>{' '}
+                              to ensure that access to your data is restricted where required.
+                            </p>
+                            <Button
+                              asChild
+                              type="default"
+                              className="w-min"
+                              icon={<ExternalLink size={14} />}
                             >
-                              reviewing your RLS policies
-                            </Link>{' '}
-                            to ensure that access to your data is restricted where required.
+                              <Link href="/docs/guides/auth/auth-anonymous#access-control">
+                                View access control docs
+                              </Link>
+                            </Button>
                           </AlertDescription_Shadcn_>
                         </div>
                       </Alert_Shadcn_>

--- a/apps/studio/components/interfaces/Auth/RateLimits/RateLimits.tsx
+++ b/apps/studio/components/interfaces/Auth/RateLimits/RateLimits.tsx
@@ -278,7 +278,8 @@ const RateLimits = () => {
                   <FormSectionLabel
                     description={
                       <p className="text-foreground-light text-sm">
-                        Number of sessions that can be refreshed in a 5 minute interval
+                        Number of sessions that can be refreshed in a 5 minute interval per IP
+                        address.
                       </p>
                     }
                   >
@@ -315,7 +316,7 @@ const RateLimits = () => {
                     description={
                       <p className="text-foreground-light text-sm">
                         Number of OTP/Magic link verifications that can be made in a 5 minute
-                        interval
+                        interval per IP address.
                       </p>
                     }
                   >
@@ -349,7 +350,7 @@ const RateLimits = () => {
                   <FormSectionLabel
                     description={
                       <p className="text-foreground-light text-sm">
-                        Number of anonymous sign-ins that can be made per hour
+                        Number of anonymous sign-ins that can be made per hour per IP address.
                       </p>
                     }
                   >


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?
* update rate limit descriptions to indicate which ones are ip-based
* add link to access control guide in anonymous sign-ins warning
![image](https://github.com/supabase/supabase/assets/28647601/c5a55d9c-594e-4f53-b4af-34d5c49e3960)


## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
