### PR TITLE
fix(studio): backslash escaping in linter query

### DIFF
--- a/apps/studio/data/lint/lint-query.ts
+++ b/apps/studio/data/lint/lint-query.ts
@@ -240,16 +240,16 @@ where
     and (
         (
             -- Example: auth.uid()
-            qual  ~ '(auth)\.(uid|jwt|role|email)\(\)'
+            qual  ~ '(auth)\\.(uid|jwt|role|email)\\(\\)'
             -- Example: select auth.uid()
-            and lower(qual) !~ 'select\s+(auth)\.(uid|jwt|role|email)\(\)'
+            and lower(qual) !~ 'select\\s+(auth)\\.(uid|jwt|role|email)\\(\\)'
         )
         or
         (
             -- Example: auth.uid()
-            with_check  ~ '(auth)\.(uid|jwt|role|email)\(\)'
+            with_check  ~ '(auth)\\.(uid|jwt|role|email)\\(\\)'
             -- Example: select auth.uid()
-            and lower(with_check) !~ 'select\s+(auth)\.(uid|jwt|role|email)\(\)'
+            and lower(with_check) !~ 'select\\s+(auth)\\.(uid|jwt|role|email)\\(\\)'
         )
     ))
 union all


### PR DESCRIPTION
This was causing false positives in the `auth_rls_initplan` lint because the regex changed