### PR TITLE
feat: mobile connect tab

### DIFF
--- a/apps/studio/components/interfaces/Home/Connect/Connect.constants.ts
+++ b/apps/studio/components/interfaces/Home/Connect/Connect.constants.ts
@@ -155,6 +155,9 @@ export const FRAMEWORKS: ConnectionType[] = [
       },
     ],
   },
+]
+
+export const MOBILES: ConnectionType[] = [
   {
     key: 'exporeactnative',
     label: 'Expo React Native',
@@ -205,5 +208,6 @@ export const ORMS: ConnectionType[] = [
 
 export const CONNECTION_TYPES = [
   { key: 'frameworks', label: 'App Frameworks', obj: FRAMEWORKS },
+  { key: 'mobiles', label: 'Mobile Frameworks', obj: MOBILES },
   { key: 'orms', label: 'ORMs', obj: ORMS },
 ]

--- a/apps/studio/components/interfaces/Home/Connect/Connect.tsx
+++ b/apps/studio/components/interfaces/Home/Connect/Connect.tsx
@@ -213,7 +213,11 @@ const Connect = () => {
                       <ConnectDropdown
                         state={selectedParent}
                         updateState={handleParentChange}
-                        label={connectionObject === FRAMEWORKS || connectionObject === MOBILES ? 'Framework' : 'Tool'}
+                        label={
+                          connectionObject === FRAMEWORKS || connectionObject === MOBILES
+                            ? 'Framework'
+                            : 'Tool'
+                        }
                         items={connectionObject}
                       />
                       {selectedParent && hasChildOptions && (

--- a/apps/studio/components/interfaces/Home/Connect/Connect.tsx
+++ b/apps/studio/components/interfaces/Home/Connect/Connect.tsx
@@ -26,7 +26,7 @@ import { useProjectApiQuery } from 'data/config/project-api-query'
 import { useProjectSettingsQuery } from 'data/config/project-settings-query'
 import { useCheckPermissions } from 'hooks'
 import { DEFAULT_PROJECT_API_SERVICE_ID } from 'lib/constants'
-import { CONNECTION_TYPES, ConnectionType, FRAMEWORKS, ORMS } from './Connect.constants'
+import { CONNECTION_TYPES, ConnectionType, FRAMEWORKS, MOBILES, ORMS } from './Connect.constants'
 import { getContentFilePath } from './Connect.utils'
 import ConnectDropdown from './ConnectDropdown'
 import ConnectTabContent from './ConnectTabContent'
@@ -96,6 +96,11 @@ const Connect = () => {
     if (type === 'frameworks') {
       setConnectionObject(FRAMEWORKS)
       handleConnectionTypeChange(FRAMEWORKS)
+    }
+
+    if (type === 'mobiles') {
+      setConnectionObject(MOBILES)
+      handleConnectionTypeChange(MOBILES)
     }
 
     if (type === 'orms') {
@@ -208,7 +213,7 @@ const Connect = () => {
                       <ConnectDropdown
                         state={selectedParent}
                         updateState={handleParentChange}
-                        label={connectionObject === FRAMEWORKS ? 'Framework' : 'Tool'}
+                        label={connectionObject === FRAMEWORKS || connectionObject === MOBILES ? 'Framework' : 'Tool'}
                         items={connectionObject}
                       />
                       {selectedParent && hasChildOptions && (


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Supabase Studio > Connect

## What is the current behavior?

Now that their are a couple of mobile frameworks in the examples it may be good to split these into a new tab so its easier for users to find them.

## What is the new behavior?


https://github.com/supabase/supabase/assets/22655069/b2d89008-a235-45b9-a0ca-5a0db1f46518

A new `Mobile Frameworks` tab which displays the examples

## Additional context

Add any other context or screenshots.
