### PR TITLE
fix: typo in auth-sql-rules-examples.js

### DIFF
--- a/apps/www/data/products/auth/auth-sql-rules-examples.js
+++ b/apps/www/data/products/auth/auth-sql-rules-examples.js
@@ -65,7 +65,7 @@ create table teams (
 
 create table members (
   team_id references team.id,
-  user_id referenced auth.users.id
+  user_id references auth.users.id
 );
 
 alter table teams enable row level security;

--- a/apps/www/data/products/auth/auth-sql-rules-examples.js
+++ b/apps/www/data/products/auth/auth-sql-rules-examples.js
@@ -59,26 +59,25 @@ using ( (select auth.uid()) = id );
     url: '/docs/guides/auth#policies-with-joins',
     code: `
 create table teams (
-  id serial primary key,
+  id bigint primary key generated always as identity,
   name text
 );
 
 create table members (
-  team_id references team.id,
-  user_id references auth.users.id
+  team_id bigint references teams,
+  user_id uuid references auth.users
 );
 
 alter table teams enable row level security;
 
--- Create Advanced Policies
-create policy "Team members can update team details"
-on teams
-for update using (
-  (select auth.uid()) in ( 
-    select user_id from members 
-    where team_id = id 
-  )
-);
+create policy "Team members can update team details if they belong to the team"
+  on teams
+  for update using (
+    (select auth.uid()) in (
+      select user_id from members
+      where team_id = id
+    )
+  );
 `.trim(),
   },
 ]


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Typo in SQL code

## What is the new behavior?

Fixed typo

## Additional context

Current bug visible on: https://supabase.com/auth
