### PR TITLE
docs: fix incorrect sql command for FTS

### DIFF
--- a/apps/docs/content/guides/database/full-text-search.mdx
+++ b/apps/docs/content/guides/database/full-text-search.mdx
@@ -594,7 +594,7 @@ After creating this function, you can invoke it from your application using the 
 
 ```sql
 create or replace function search_books_by_title_prefix(prefix text)
-return setof books AS $$
+returns setof books AS $$
 begin
   return query
   select * from books where to_tsvector('english', title) @@ to_tsquery(prefix || ':*');


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

https://github.com/supabase/supabase/issues/22868

## What is the new behavior?

SQL reads returns setof instead of return setof
