### PR TITLE
fix: add warning notice for long otp expiry time

### DIFF
--- a/apps/studio/components/interfaces/Auth/AuthProvidersForm/AuthProvidersForm.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersForm/AuthProvidersForm.tsx
@@ -2,10 +2,19 @@ import { useParams } from 'common'
 import { FormHeader } from 'components/ui/Forms'
 import { HorizontalShimmerWithIcon } from 'components/ui/Shimmers'
 import { useAuthConfigQuery } from 'data/auth/auth-config-query'
-import { AlertDescription_Shadcn_, AlertTitle_Shadcn_, Alert_Shadcn_, IconAlertCircle } from 'ui'
+import {
+  AlertDescription_Shadcn_,
+  AlertTitle_Shadcn_,
+  Alert_Shadcn_,
+  Button,
+  IconAlertCircle,
+} from 'ui'
 import { PROVIDERS_SCHEMAS } from '../AuthProvidersFormValidation'
 import { ProviderCollapsibleClasses } from './AuthProvidersForm.constants'
 import ProviderForm from './ProviderForm'
+import { WarningIcon } from 'ui-patterns/Icons/StatusIcons'
+import Link from 'next/link'
+import { ExternalLink } from 'lucide-react'
 
 const AuthProvidersForm = () => {
   const { ref: projectRef } = useParams()
@@ -25,6 +34,28 @@ const AuthProvidersForm = () => {
       />
 
       <div className="-space-y-px">
+        {authConfig?.EXTERNAL_EMAIL_ENABLED && authConfig?.MAILER_OTP_EXP > 3600 && (
+          <Alert_Shadcn_
+            className="flex w-full items-center justify-between my-3"
+            variant="warning"
+          >
+            <WarningIcon />
+            <div>
+              <AlertTitle_Shadcn_>OTP expiry exceeds recommended threshold</AlertTitle_Shadcn_>
+              <AlertDescription_Shadcn_ className="flex flex-col gap-y-3">
+                <p>
+                  We have detected that you have enabled the email provider with the OTP expiry set
+                  to more than an hour. It is recommended to set this value to less than an hour.
+                </p>
+                <Button asChild type="default" className="w-min" icon={<ExternalLink size={14} />}>
+                  <Link href="https://supabase.com/docs/guides/platform/going-into-prod#security">
+                    View security recommendations
+                  </Link>
+                </Button>
+              </AlertDescription_Shadcn_>
+            </div>
+          </Alert_Shadcn_>
+        )}
         {isLoading &&
           PROVIDERS_SCHEMAS.map((provider) => (
             <div


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?
* Warning shows up if the email provider is enabled and the OTP expiry is 
detected to be longer than 1 hour (3600 seconds)
* Button links to the security section in the going to prod guide

![image](https://github.com/supabase/supabase/assets/28647601/f643117f-b930-4911-8648-6cb39043342e)


## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
