### PR TITLE
fix: open connection string docs link in new tab

### DIFF
--- a/apps/studio/components/interfaces/Settings/Database/DatabaseSettings/DatabaseConnectionString.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/DatabaseSettings/DatabaseConnectionString.tsx
@@ -198,7 +198,10 @@ export const DatabaseConnectionString = ({ appearance }: DatabaseConnectionStrin
               >
                 {readReplicasEnabled && <DatabaseSelector />}
                 <Button asChild type="default" icon={<ExternalLink strokeWidth={1.5} />}>
-                  <a target="_blank" href="https://supabase.com/docs/guides/database/connecting-to-postgres">
+                  <a
+                    target="_blank"
+                    href="https://supabase.com/docs/guides/database/connecting-to-postgres"
+                  >
                     Documentation
                   </a>
                 </Button>

--- a/apps/studio/components/interfaces/Settings/Database/DatabaseSettings/DatabaseConnectionString.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/DatabaseSettings/DatabaseConnectionString.tsx
@@ -198,7 +198,7 @@ export const DatabaseConnectionString = ({ appearance }: DatabaseConnectionStrin
               >
                 {readReplicasEnabled && <DatabaseSelector />}
                 <Button asChild type="default" icon={<ExternalLink strokeWidth={1.5} />}>
-                  <a href="https://supabase.com/docs/guides/database/connecting-to-postgres">
+                  <a target="_blank" href="https://supabase.com/docs/guides/database/connecting-to-postgres">
                     Documentation
                   </a>
                 </Button>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

'Documentation' button looks like it should open in a new tab, but it doesn't.

## What is the new behavior?

Opens the docs link in new tab.

## Additional context
https://supabase.com/dashboard/project/_/settings/database
<img width="1399" alt="image" src="https://github.com/supabase/supabase/assets/27228526/70e48cf3-26cf-4a27-baae-ea0262697bad">

