### PR TITLE
fix light mode bug

### DIFF
--- a/apps/www/components/LaunchWeek/11/Releases/components/DaySection.tsx
+++ b/apps/www/components/LaunchWeek/11/Releases/components/DaySection.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import Link from 'next/link'
 import Image from 'next/image'
 import { ArrowRightIcon } from '@heroicons/react/outline'
@@ -13,6 +13,14 @@ import { DayLink } from '.'
 const DaySection = ({ day, className }: { day: WeekDayProps; className?: string }) => {
   const isMobile = useBreakpoint(639)
   const cssGroup = 'group/d' + day.d
+
+  const [isMounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  if (!isMounted) return null
 
   return (
     <section


### PR DESCRIPTION
Fix light mode cards when refreshing page on GA page.

## Before

https://github.com/supabase/supabase/assets/25671831/b390ebd1-340f-44d6-8bad-51eb47bccf3d

## After

https://github.com/supabase/supabase/assets/25671831/2c743f60-dfb2-4585-80bb-cea5e80a2f20