### PR TITLE
Update supabase_py_v2.yml

### DIFF
--- a/apps/docs/spec/supabase_py_v2.yml
+++ b/apps/docs/spec/supabase_py_v2.yml
@@ -48,7 +48,8 @@ functions:
           supabase: Client = create_client(url, key,
             options=ClientOptions(
               postgrest_client_timeout=10,
-              storage_client_timeout=10
+              storage_client_timeout=10,
+              schema="public",
             ))
           ```
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

The client does not show the default schema.

## What is the new behavior?

Example now shows the default schema = public


