### PR TITLE
fix: storage RLS example

### DIFF
--- a/apps/docs/content/guides/storage/management/delete-objects.mdx
+++ b/apps/docs/content/guides/storage/management/delete-objects.mdx
@@ -32,6 +32,6 @@ on storage.objects
 for delete
 TO authenticated
 USING (
-    owner_id = (select auth.uid())
+    owner = (select auth.uid())
 );
 ```


### PR DESCRIPTION
It's about the type fix.

ERROR: operator does not exist: text = uuid
Hint: No operator matches the given name and argument types. You might need to add explicit type casts.