### PR TITLE
fix: replace docs blockquotes with admonitions

### DIFF
--- a/apps/docs/content/guides/auth/auth-helpers/nextjs-pages.mdx
+++ b/apps/docs/content/guides/auth/auth-helpers/nextjs-pages.mdx
@@ -27,7 +27,11 @@ The `auth-helpers` package has been replaced with the `@supabase/ssr` package. W
 
 This submodule provides convenience helpers for implementing user authentication in Next.js applications using the pages directory.
 
-> Note: As of [Next.js 13.4](https://nextjs.org/blog/next-13-4), the App Router has reached stable status. This is now the recommended path for new Next.js app. Check out our guide on using [Auth Helpers with the Next.js App Directory](/docs/guides/auth/auth-helpers/nextjs).
+<Admonition type="note">
+
+Note: As of [Next.js 13.4](https://nextjs.org/blog/next-13-4), the App Router has reached stable status. This is now the recommended path for new Next.js app. Check out our guide on using [Auth Helpers with the Next.js App Directory](/docs/guides/auth/auth-helpers/nextjs).
+
+</Admonition>
 
 ## Install the Next.js helper library
 

--- a/apps/docs/content/guides/auth/auth-helpers/remix.mdx
+++ b/apps/docs/content/guides/auth/auth-helpers/remix.mdx
@@ -36,7 +36,11 @@ This submodule provides convenience helpers for implementing user authentication
   ></iframe>
 </div>
 
-> For a complete implementation example, check out [this free egghead course](https://egghead.io/courses/build-a-realtime-chat-app-with-remix-and-supabase-d36e2618) or [this GitHub repo](https://github.com/supabase/auth-helpers/tree/main/examples/remix).
+<Admonition type="tip">
+
+For a complete implementation example, check out [this free egghead course](https://egghead.io/courses/build-a-realtime-chat-app-with-remix-and-supabase-d36e2618) or [this GitHub repo](https://github.com/supabase/auth-helpers/tree/main/examples/remix).
+
+</Admonition>
 
 ## Install the Remix helper library
 
@@ -179,7 +183,11 @@ export const loader = async ({ request }) => {
 }
 ```
 
-> Supabase will set cookie headers to manage the user's auth session, therefore, the `response.headers` must be returned from the `Loader` function.
+<Admonition type="tip">
+
+Supabase will set cookie headers to manage the user's auth session, therefore, the `response.headers` must be returned from the `Loader` function.
+
+</Admonition>
 
 </TabPanel>
 <TabPanel id="ts" label="TypeScript">
@@ -209,7 +217,11 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
 }
 ```
 
-> Supabase will set cookie headers to manage the user's auth session, therefore, the `response.headers` must be returned from the `Loader` function.
+<Admonition type="tip">
+
+Supabase will set cookie headers to manage the user's auth session, therefore, the `response.headers` must be returned from the `Loader` function.
+
+</Admonition>
 
 </TabPanel>
 </Tabs>
@@ -251,7 +263,11 @@ export const action = async ({ request }) => {
 }
 ```
 
-> Supabase will set cookie headers to manage the user's auth session, therefore, the `response.headers` must be returned from the `Action` function.
+<Admonition type="tip">
+
+Supabase will set cookie headers to manage the user's auth session, therefore, the `response.headers` must be returned from the `Action` function.
+
+</Admonition>
 
 </TabPanel>
 <TabPanel id="ts" label="TypeScript">
@@ -282,7 +298,11 @@ export const action = async ({ request }: ActionFunctionArgs) => {
 }
 ```
 
-> Supabase will set cookie headers to manage the user's auth session, therefore, the `response.headers` must be returned from the `Action` function.
+<Admonition type="tip">
+
+Supabase will set cookie headers to manage the user's auth session, therefore, the `response.headers` must be returned from the `Action` function.
+
+</Admonition>
 
 </TabPanel>
 </Tabs>
@@ -341,7 +361,11 @@ export const loader = () => {
 }
 ```
 
-> These may not be stored in `process.env` for environments other than Node.
+<Admonition type="tip">
+
+These may not be stored in `process.env` for environments other than Node.
+
+</Admonition>
 
 Next, we call the `useLoaderData` hook in our component to get the `env` object.
 
@@ -375,7 +399,11 @@ export const loader = ({}: LoaderFunctionArgs) => {
 }
 ```
 
-> These may not be stored in `process.env` for environments other than Node.
+<Admonition type="tip">
+
+These may not be stored in `process.env` for environments other than Node.
+
+</Admonition>
 
 Next, we call the `useLoaderData` hook in our component to get the `env` object.
 
@@ -558,7 +586,11 @@ useEffect(() => {
 
 </Tabs>
 
-> Check out [this repo](https://github.com/supabase/auth-helpers/tree/main/examples/remix) for full implementation example
+<Admonition type="tip">
+
+Check out [this repo](https://github.com/supabase/auth-helpers/tree/main/examples/remix) for full implementation example
+
+</Admonition>
 
 ### Authentication
 
@@ -771,7 +803,11 @@ export default function Index() {
 
 </Tabs>
 
-> Ensure you have [enabled replication](https://supabase.com/dashboard/project/_/database/publications) on the table you are subscribing to.
+<Admonition type="tip">
+
+Ensure you have [enabled replication](https://supabase.com/dashboard/project/_/database/publications) on the table you are subscribing to.
+
+</Admonition>
 
 ## Migration guide
 

--- a/apps/docs/content/guides/database/extensions/pgaudit.mdx
+++ b/apps/docs/content/guides/database/extensions/pgaudit.mdx
@@ -214,7 +214,11 @@ where rolname = 'postgres';
 
 PGAudit was designed for storing logs as CSV files with the following headers:
 
-> Referenced from the [PGAudit official docs](https://github.com/pgaudit/pgaudit/blob/master/README.md#format)
+<Admonition type="note">
+
+Referenced from the [PGAudit official docs](https://github.com/pgaudit/pgaudit/blob/master/README.md#format)
+
+</Admonition>
 
 | header          | Description                                                                                                                               |
 | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |

--- a/apps/docs/content/guides/getting-started/tutorials/with-ionic-angular.mdx
+++ b/apps/docs/content/guides/getting-started/tutorials/with-ionic-angular.mdx
@@ -138,7 +138,11 @@ export class SupabaseService {
 Let's set up a route to manage logins and signups. We'll use Magic Links so users can sign in with their email without using passwords.
 Create a **LoginPage** with the `ionic g page login` Ionic CLI command.
 
-> This guide will show the template inline, but the example app will have `templateUrl`s
+<Admonition type="tip">
+
+This guide will show the template inline, but the example app will have `templateUrl`s
+
+</Admonition>
 
 ```ts src/app/login/login.page.ts
 import { Component, OnInit } from '@angular/core'

--- a/apps/docs/content/guides/getting-started/tutorials/with-redwoodjs.mdx
+++ b/apps/docs/content/guides/getting-started/tutorials/with-redwoodjs.mdx
@@ -456,7 +456,11 @@ const HomePage = () => {
 export default HomePage
 ```
 
-> What we're doing here is showing the sign in form if you aren't logged in and your account profile if you are.
+<Admonition type="note">
+
+What we're doing here is showing the sign in form if you aren't logged in and your account profile if you are.
+
+</Admonition>
 
 ### Launch!
 

--- a/apps/docs/content/guides/getting-started/tutorials/with-sveltekit.mdx
+++ b/apps/docs/content/guides/getting-started/tutorials/with-sveltekit.mdx
@@ -158,7 +158,11 @@ export const load = (async ({ locals: { safeGetSession } }) => {
 }) satisfies LayoutServerLoad
 ```
 
-> Start your dev server (`npm run dev`) in order to generate the `./$types` files we are referencing in our project.
+<Admonition type="tip">
+
+Start your dev server (`npm run dev`) in order to generate the `./$types` files we are referencing in our project.
+
+</Admonition>
 
 Create a new `src/routes/+layout.ts` file to handle the session and the supabase object on the client-side.
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Fix (consistency)

## What is the current behavior?

Blockquotes in use in some docs pages

## What is the new behavior?

Move everything to admonitions for visual consistency

## Additional context

Add any other context or screenshots.
