### PR TITLE
Update docs for pg-safeupdate

### DIFF
--- a/apps/docs/content/guides/database/extensions/pg-safeupdate.mdx
+++ b/apps/docs/content/guides/database/extensions/pg-safeupdate.mdx
@@ -10,11 +10,12 @@ The `pg-safeupdate` extension is a useful tool for protecting data integrity and
 
 ## Enable the extension
 
-`pg-safeupdate` can be enabled on a per connection basis:
+`pg-safeupdate` can be enabled on a role basis (where `anon` is the role we want to modify in this example):
 
 {/* prettier-ignore */}
 ```sql
-load 'safeupdate';
+GRANT SET ON PARAMETER session_preload_libraries TO anon;
+ALTER ROLE anon SET session_preload_libraries = 'safeupdate';
 ```
 
 or for all connections:
@@ -30,8 +31,6 @@ Let's take a look at an example to see how pg-safeupdate works. Suppose we have 
 
 {/* prettier-ignore */}
 ```sql
-load 'safeupdate';
-
 update employees set date_of_birth = '1987-01-28';
 ```
 
@@ -52,3 +51,4 @@ update employees set date_of_birth = '1987-01-28' where id = 12345;
 ## Resources
 
 - Official [pg-safeupdate documentation](https://github.com/eradman/pg-safeupdate)
+- Using [pg-safeupdate with PostgREST](https://postgrest.org/en/v12/integrations/pg-safeupdate.html)


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

Current examples in docs are not functional

## What is the new behavior?

Update examples for 2 scenarios:
1. Using `pg-safeupdate` on a per-user basis
2. Using `pg-safeupdate` on all connections to a database

Add link to resource on using `pg-safeupdate` with [PostgREST](https://postgrest.org/en/v12/integrations/pg-safeupdate.html)
