### PR TITLE
chore: remove console log from nextjs server example

### DIFF
--- a/apps/docs/content/guides/platform/sentry-monitoring.mdx
+++ b/apps/docs/content/guides/platform/sentry-monitoring.mdx
@@ -212,7 +212,6 @@ Sentry.init({
     }),
     new Sentry.Integrations.Undici({
       shouldCreateSpanForRequest: (url) => {
-        console.log('server', `${process.env.NEXT_PUBLIC_SUPABASE_URL}/rest`, url)
         return !url.startsWith(`${process.env.NEXT_PUBLIC_SUPABASE_URL}/rest`)
       },
     }),


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

This is a small update to remove a console.log statement in the Next JS documentation for using Sentry in the server context.

## What is the current behavior?

The docs currently include a console.log statement for the server example, but not one for the client and edge examples. I assume, therefore, that the inclusion on the server example is a mistake.

## What is the new behavior?

We won't show a console.log statement for the server example, making it consistent with the others.

## Additional context

N/A
