### PR TITLE
fix: remove passwordless login redirect, page exists

### DIFF
--- a/apps/www/lib/redirects.js
+++ b/apps/www/lib/redirects.js
@@ -1563,11 +1563,6 @@ module.exports = [
   },
   {
     permanent: true,
-    source: '/docs/guides/auth/passwordless-login',
-    destination: '/docs/guides/auth/phone-login',
-  },
-  {
-    permanent: true,
     source: '/docs/guides/auth/passwordless-login/phone-sms-otp-messagebird',
     destination: '/docs/guides/auth/phone-login/messagebird',
   },


### PR DESCRIPTION
It's a permanent redirect so the redirect will still be cached in browsers, but we are actually for real getting rid of the page soon (PR is in review), so it's fine