### PR TITLE
enhance(sql editor): set result column width roughly based on contents

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/Results.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/Results.tsx
@@ -56,26 +56,34 @@ const Results = ({ id, rows }: { id: string; rows: readonly any[] }) => {
   }
 
   const EST_CHAR_WIDTH = 8.25
-  const columns: CalculatedColumn<any>[] = Object.keys(rows?.[0] ?? []).map((key, idx) => ({
-    idx,
-    key,
-    name: key,
-    resizable: true,
-    parent: undefined,
-    level: 0,
-    width:
-      typeof rows[0][key] === 'string' || typeof rows[0][key] === 'number'
-        ? Math.min(String(rows[0][key]).length * EST_CHAR_WIDTH, 500)
-        : 120,
-    minWidth: 120,
-    maxWidth: undefined,
-    draggable: false,
-    frozen: false,
-    sortable: false,
-    isLastFrozenColumn: false,
-    renderCell: ({ row }: any) => formatter(key, row),
-    renderHeaderCell: () => columnRender(key),
-  }))
+  const MIN_COLUMN_WIDTH = 100
+  const MAX_COLUMN_WIDTH = 500
+
+  const columns: CalculatedColumn<any>[] = Object.keys(rows?.[0] ?? []).map((key, idx) => {
+    const maxColumnValueLength = Math.max(...rows.map((row) => String(row[key]).length))
+    const columnWidth = Math.max(
+      Math.min(maxColumnValueLength * EST_CHAR_WIDTH, MAX_COLUMN_WIDTH),
+      MIN_COLUMN_WIDTH
+    )
+
+    return {
+      idx,
+      key,
+      name: key,
+      resizable: true,
+      parent: undefined,
+      level: 0,
+      width: columnWidth,
+      minWidth: MIN_COLUMN_WIDTH,
+      maxWidth: undefined,
+      draggable: false,
+      frozen: false,
+      sortable: false,
+      isLastFrozenColumn: false,
+      renderCell: ({ row }: any) => formatter(key, row),
+      renderHeaderCell: () => columnRender(key),
+    }
+  })
 
   function onSelectedCellChange(position: any) {
     setCellPosition(position)

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/Results.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/Results.tsx
@@ -55,6 +55,7 @@ const Results = ({ id, rows }: { id: string; rows: readonly any[] }) => {
     return <div className="flex h-full items-center justify-center font-mono text-xs">{name}</div>
   }
 
+  const EST_CHAR_WIDTH = 8.25
   const columns: CalculatedColumn<any>[] = Object.keys(rows?.[0] ?? []).map((key, idx) => ({
     idx,
     key,
@@ -62,7 +63,10 @@ const Results = ({ id, rows }: { id: string; rows: readonly any[] }) => {
     resizable: true,
     parent: undefined,
     level: 0,
-    width: 120,
+    width:
+      typeof rows[0][key] === 'string' || typeof rows[0][key] === 'number'
+        ? Math.min(String(rows[0][key]).length * EST_CHAR_WIDTH, 500)
+        : 120,
     minWidth: 120,
     maxWidth: undefined,
     draggable: false,

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityPanel.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityPanel.tsx
@@ -2,7 +2,6 @@ import { useQueryClient } from '@tanstack/react-query'
 import { useParams } from 'common'
 import toast from 'react-hot-toast'
 
-import { useContentQuery } from 'data/content/content-query'
 import { useContentUpsertMutation } from 'data/content/content-upsert-mutation'
 import { contentKeys } from 'data/content/keys'
 import { useSqlEditorStateSnapshot } from 'state/sql-editor'
@@ -38,7 +37,6 @@ const UtilityPanel = ({
 }: UtilityPanelProps) => {
   const snap = useSqlEditorStateSnapshot()
   const { ref } = useParams()
-  const { data } = useContentQuery(ref)
   const snippet = snap.snippets[id]?.snippet
 
   const queryKeys = contentKeys.list(ref)


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Enhancement

## What is the current behavior?

Column width of the SQL editor results always starts at 120 regardless of the content

## What is the new behavior?

Column width adjusts (very roughly) to content. Doesn't adjust for arrays and JSON (assuming those tend to be too long anyway), and for speed only adjusts based on the first returned row, not on the max length of all rows. Works quite well for things like UUIDs and timestamps though, where width is uniform across rows.

<img width="1154" alt="image" src="https://github.com/supabase/supabase/assets/26616127/575a881d-78ec-44f1-b7d7-d9688b126aec">
<img width="486" alt="image" src="https://github.com/supabase/supabase/assets/26616127/6631de70-b27a-403e-a0d8-09ea4e31c748">

## Additional context

Add any other context or screenshots.
