### PR TITLE
Truncate table names

### DIFF
--- a/apps/studio/components/interfaces/Database/Tables/TableList.tsx
+++ b/apps/studio/components/interfaces/Database/Tables/TableList.tsx
@@ -230,9 +230,11 @@ const TableList = ({
                           <p>{x.name}</p>
                         )}
                       </Table.td>
-                      <Table.td className="hidden max-w-sm truncate lg:table-cell break-all whitespace-normal">
+                      <Table.td className="hidden lg:table-cell ">
                         {x.comment !== null ? (
-                          <p title={x.comment}>{x.comment}</p>
+                          <span className="lg:max-w-48 truncate inline-block" title={x.comment}>
+                            {x.comment}
+                          </span>
                         ) : (
                           <p className="text-border-stronger">No description</p>
                         )}


### PR DESCRIPTION
Truncate table names to prevent odd wrapping:

before
![screenshot-2024-04-24-at-16 41 17](https://github.com/supabase/supabase/assets/105593/b357b8d3-a128-4bce-935e-d1ba7871ea28)


after
![screenshot-2024-04-24-at-16 45 14](https://github.com/supabase/supabase/assets/105593/54eec39e-2309-460f-ba79-8328349aafda)
