### PR TITLE
fix: improve database connection IPv4 warning

### DIFF
--- a/apps/studio/components/interfaces/Settings/Database/IPv4DeprecationNotice.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/IPv4DeprecationNotice.tsx
@@ -12,13 +12,17 @@ export const IPv4DeprecationNotice = () => {
     <Alert_Shadcn_ variant="warning">
       <IconAlertTriangle strokeWidth={2} />
       <AlertTitle_Shadcn_>
-        Direct database access via IPv4 and pgBouncer will be removed from January 26th 2024
+        Direct database access is only available via IPv6-compatible networks or if your project has
+        the IPv4 add on.
       </AlertTitle_Shadcn_>
       <AlertDescription_Shadcn_ className="space-y-3">
         <p>
           We strongly recommend using <span className="text-foreground">connection pooling</span> to
-          connect to your database. You'll only need to change the connection string that you're
-          using in your application to the pooler's connection string.
+          connect to your database because it's compatible with both IPv4 and IPv6 networks.
+        </p>
+        <p>
+          You'll only need to change the connection credentials that you're using in your
+          application to the pooler's connection credentials.
         </p>
         <Button asChild type="default" icon={<IconExternalLink strokeWidth={1.5} />}>
           <a

--- a/apps/studio/components/interfaces/Settings/Database/UsePoolerCheckbox.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/UsePoolerCheckbox.tsx
@@ -74,7 +74,7 @@ export const UsePoolerCheckbox = ({
             <div className="flex items-center gap-x-4">
               <div className="flex items-center gap-x-2">
                 <label htmlFor={`use-pooler-${id}`} className="text-sm cursor-pointer">
-                  Use connection pooling
+                  Display connection pooler
                 </label>
                 {checked && (
                   <>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

fix

## What is the current behavior?

- It's currently confusing when checking the `Use connection pool` checkbox.
- Improve `Direct database access...` copy and remove the `pgBouncer` removal date.

## What is the new behavior?

- Update the checkbox copy to `Display connection pooler` so it's clearer that you can still use direct database connection even if you check the box.
- Update the `Direct database access...` copy to read it's available via IPv6 and IPv4 only if project has IPv4 add on.

## What it looks like now

<img width="1034" alt="Screenshot 2024-04-25 at 21 46 31" src="https://github.com/supabase/supabase/assets/5532241/7014ec6f-215e-4808-b9f1-f84e427df3ac">