### PR TITLE
ref: Add sentry logging to debug vercel issue

### DIFF
--- a/apps/studio/components/interfaces/Integrations/ProjectLinker.tsx
+++ b/apps/studio/components/interfaces/Integrations/ProjectLinker.tsx
@@ -132,7 +132,6 @@ const ProjectLinker = ({
       connection: {
         foreign_project_id: selectedForeignProject?.id,
         supabase_project_ref: selectedSupabaseProject?.ref,
-        integration_id: '0',
         metadata: {
           ...projectDetails,
         },

--- a/apps/studio/components/interfaces/Organization/IntegrationSettings/SidePanelVercelProjectLinker.tsx
+++ b/apps/studio/components/interfaces/Organization/IntegrationSettings/SidePanelVercelProjectLinker.tsx
@@ -15,6 +15,7 @@ import { useSelectedOrganization } from 'hooks'
 import { BASE_PATH } from 'lib/constants'
 import { EMPTY_ARR } from 'lib/void'
 import { useSidePanelsStateSnapshot } from 'state/side-panels'
+import * as Sentry from '@sentry/nextjs'
 
 const VERCEL_ICON = (
   <svg xmlns="http://www.w3.org/2000/svg" fill="white" viewBox="0 0 512 512" className="w-6">
@@ -100,6 +101,18 @@ const SidePanelVercelProjectLinker = () => {
 
   const onCreateConnections = useCallback(
     (vars: any) => {
+      // TODO(kamil): Remove once "missing connection name" bug has been squashed.
+      if (!vars.connection?.metadata?.name) {
+        Sentry.captureMessage('Vercel connection is missing name', {
+          contexts: {
+            connection: vars.connection,
+            source: {
+              file: 'Organization/IntegrationSettings/SidePanelVercelProjectLinker.tsx',
+            },
+          },
+        })
+      }
+
       createConnections({
         ...vars,
         connection: {

--- a/apps/studio/data/integrations/integrations.types.ts
+++ b/apps/studio/data/integrations/integrations.types.ts
@@ -248,7 +248,6 @@ export type IntegrationConnectionsCreateVariables = {
   connection: {
     foreign_project_id: string
     supabase_project_ref: string
-    integration_id: string
     metadata: any
   }
   orgSlug: string | undefined

--- a/apps/studio/pages/integrations/vercel/[slug]/deploy-button/new-project.tsx
+++ b/apps/studio/pages/integrations/vercel/[slug]/deploy-button/new-project.tsx
@@ -23,6 +23,7 @@ import { passwordStrength } from 'lib/helpers'
 import { getInitialMigrationSQLFromGitHubRepo } from 'lib/integration-utils'
 import { useIntegrationInstallationSnapshot } from 'state/integration-installation'
 import type { NextPageWithLayout } from 'types'
+import * as Sentry from '@sentry/nextjs'
 
 const VercelIntegration: NextPageWithLayout = () => {
   return (
@@ -203,12 +204,11 @@ const CreateProject = () => {
         const projectDetails = vercelProjects?.find((x: any) => x.id === foreignProjectId)
 
         try {
-          const { id: connectionId } = await createConnections({
+          const connection = {
             organizationIntegrationId: organizationIntegration?.id,
             connection: {
               foreign_project_id: foreignProjectId,
               supabase_project_ref: newProjectRef,
-              integration_id: '0',
               metadata: {
                 ...projectDetails,
                 supabaseConfig: {
@@ -219,8 +219,26 @@ const CreateProject = () => {
               },
             },
             orgSlug: selectedOrganization?.slug,
-          })
+          }
 
+          // TODO(kamil): Remove once "missing connection name" bug has been squashed.
+          if (!projectDetails?.name) {
+            Sentry.captureMessage('Vercel connection is missing name', {
+              contexts: {
+                connection: connection,
+                data: {
+                  projectDetails,
+                  vercelProjects,
+                  foreignProjectId,
+                },
+                source: {
+                  file: 'deploy-button/new-project.tsx',
+                },
+              },
+            })
+          }
+
+          const { id: connectionId } = await createConnections(connection)
           await syncEnvs({ connectionId })
         } catch (error) {
           console.error('An error occurred during createConnections:', error)

--- a/apps/studio/pages/integrations/vercel/[slug]/marketplace/choose-project.tsx
+++ b/apps/studio/pages/integrations/vercel/[slug]/marketplace/choose-project.tsx
@@ -19,6 +19,7 @@ import { BASE_PATH, PROJECT_STATUS } from 'lib/constants'
 import { EMPTY_ARR } from 'lib/void'
 import { useIntegrationInstallationSnapshot } from 'state/integration-installation'
 import type { NextPageWithLayout, Organization } from 'types'
+import * as Sentry from '@sentry/nextjs'
 
 const VERCEL_ICON = (
   <img src={`${BASE_PATH}/img/icons/vercel-icon.svg`} alt="Vercel Icon" className="w-4" />
@@ -128,6 +129,18 @@ const VercelIntegration: NextPageWithLayout = () => {
 
   const onCreateConnections = useCallback(
     (vars: any) => {
+      // TODO(kamil): Remove once "missing connection name" bug has been squashed.
+      if (!vars.connection?.metadata?.name) {
+        Sentry.captureMessage('Vercel connection is missing name', {
+          contexts: {
+            connection: vars.connection,
+            source: {
+              file: 'marketplace/choose-project.tsx',
+            },
+          },
+        })
+      }
+
       createConnections({
         ...vars,
         connection: {


### PR DESCRIPTION
It's almost impossible to understand this flow without better logging, as it's triggered via Vercel Deploy Button, which we don't have local dev flow set.