### PR TITLE
docs: update vector reference to pgvector

### DIFF
--- a/apps/docs/content/guides/ai/vector-columns.mdx
+++ b/apps/docs/content/guides/ai/vector-columns.mdx
@@ -24,7 +24,7 @@ Vectors in Supabase are enabled via [pgvector](https://github.com/pgvector/pgvec
 
 1. Go to the [Database](https://supabase.com/dashboard/project/_/database/tables) page in the Dashboard.
 2. Click on **Extensions** in the sidebar.
-3. Search for "vector" and enable the extension.
+3. Search for "pgvector" and enable the extension.
 
 </TabPanel>
 <TabPanel id="sql" label="SQL">


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the new behavior?

Update `vector` reference to `pgvector` now that the extension in Studio Database Extensions changed the extension name to pgvector. This is only cosmetic; to create the extension with SQL it will continue to be `CREATE EXTENSION vector`.

## Additional context

Complements https://github.com/supabase/supabase/pull/23286
