### PR TITLE
docs: rename vector to pgvector

### DIFF
--- a/apps/docs/content/guides/ai/vector-columns.mdx
+++ b/apps/docs/content/guides/ai/vector-columns.mdx
@@ -30,12 +30,12 @@ Vectors in Supabase are enabled via [pgvector](https://github.com/pgvector/pgvec
 <TabPanel id="sql" label="SQL">
 
 ```sql
- -- Example: enable the "vector" extension.
+ -- Example: enable the pgvector extension.
 create extension vector
 with
   schema extensions;
 
--- Example: disable the "vector" extension
+-- Example: disable the pgvector extension
 drop
   extension if exists vector;
 ```

--- a/apps/docs/content/guides/database/extensions/pgvector.mdx
+++ b/apps/docs/content/guides/database/extensions/pgvector.mdx
@@ -33,18 +33,18 @@ This is particularly useful if you're building on top of OpenAI's [GPT-3](https:
 
 1. Go to the [Database](https://supabase.com/dashboard/project/_/database/tables) page in the Dashboard.
 2. Click on **Extensions** in the sidebar.
-3. Search for "vector" and enable the extension.
+3. Search for "pgvector" and enable the extension.
 
 </TabPanel>
 <TabPanel id="sql" label="SQL">
 
 ```sql
- -- Example: enable the "vector" extension.
+ -- Example: enable the pgvector extension.
 create extension vector
 with
   schema extensions;
 
--- Example: disable the "vector" extension
+-- Example: disable the pgvector extension
 drop
   extension if exists vector;
 ```


### PR DESCRIPTION
Last spot to rename `vector` to `pgvector` in our docs (the database extension page).