### PR TITLE
Fix tooltip overlapped by instance node

### DIFF
--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceNode.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceNode.tsx
@@ -205,8 +205,13 @@ export const ReplicaNode = ({ data }: NodeProps<ReplicaNodeData>) => {
                     <TooltipTrigger_Shadcn_>
                       <IconHelpCircle />
                     </TooltipTrigger_Shadcn_>
-                    <TooltipContent_Shadcn_ side="bottom" className="w-60 text-center">
-                      Replica failed to initialize. Please drop this replica, and spin up a new one.
+                    <TooltipContent_Shadcn_
+                      side="bottom"
+                      align="end"
+                      alignOffset={-70}
+                      className="w-60 text-center"
+                    >
+                      Replica failed to initialize. Please drop this replica and spin up a new one.
                     </TooltipContent_Shadcn_>
                   </Tooltip_Shadcn_>
                 </>


### PR DESCRIPTION
Nodes are rendered by react flow which are absolutely positioned, so rather than tweaking z-indexes just shifting the tooltip a little

![image](https://github.com/supabase/supabase/assets/19742402/9a1f715e-31f1-4e7b-803b-75a8a30d0352)
