### PR TITLE
fix: sveltekit examples pass headers through

### DIFF
--- a/apps/docs/content/guides/auth/auth-helpers/sveltekit.mdx
+++ b/apps/docs/content/guides/auth/auth-helpers/sveltekit.mdx
@@ -96,7 +96,7 @@ export const handle = async ({ event, resolve }) => {
 
   return resolve(event, {
     filterSerializedResponseHeaders(name) {
-      return name === 'content-range'
+      return name === 'content-range' || name === 'x-supabase-api-version'
     },
   })
 }
@@ -143,7 +143,7 @@ export const handle: Handle = async ({ event, resolve }) => {
 
   return resolve(event, {
     filterSerializedResponseHeaders(name) {
-      return name === 'content-range'
+      return name === 'content-range' || name === 'x-supabase-api-version'
     },
   })
 }
@@ -154,7 +154,7 @@ export const handle: Handle = async ({ event, resolve }) => {
 
 <Admonition type="note">
 
-Note that we are specifying filterSerializedResponseHeaders here. We need to tell SvelteKit that supabase needs the content-range header.
+Note that we are specifying filterSerializedResponseHeaders here. We need to tell SvelteKit that supabase needs the `content-range` and `x-supabase-api-version` headers.
 
 </Admonition>
 
@@ -679,7 +679,7 @@ async function supabase({ event, resolve }) {
 
   return resolve(event, {
     filterSerializedResponseHeaders(name) {
-      return name === 'content-range'
+      return name === 'content-range' || name === 'x-supabase-api-version'
     },
   })
 }
@@ -747,7 +747,7 @@ async function supabase({ event, resolve }) {
 
   return resolve(event, {
     filterSerializedResponseHeaders(name) {
-      return name === 'content-range'
+      return name === 'content-range' || name === 'x-supabase-api-version'
     },
   })
 }
@@ -972,7 +972,7 @@ export const handle: Handle = async ({ event, resolve }) => {
 
   return resolve(event, {
     filterSerializedResponseHeaders(name) {
-      return name === 'content-range'
+      return name === 'content-range' || name === 'x-supabase-api-version'
     },
   })
 }

--- a/apps/docs/content/guides/auth/server-side/creating-a-client.mdx
+++ b/apps/docs/content/guides/auth/server-side/creating-a-client.mdx
@@ -495,7 +495,7 @@ export const handle: Handle = async ({ event, resolve }) => {
 
   return resolve(event, {
     filterSerializedResponseHeaders(name) {
-      return name === 'content-range'
+      return name === 'content-range' || name === 'x-supabase-api-version'
     },
   })
 }

--- a/apps/docs/content/guides/auth/server-side/sveltekit.mdx
+++ b/apps/docs/content/guides/auth/server-side/sveltekit.mdx
@@ -121,10 +121,10 @@ const supabase: Handle = async ({ event, resolve }) => {
   return resolve(event, {
     filterSerializedResponseHeaders(name) {
       /**
-       * Supabase libraries use the `content-range` header, so we need to
-       * tell SvelteKit to pass it through.
+       * Supabase libraries use the `content-range` and `x-supabase-api-version`
+       * headers, so we need to tell SvelteKit to pass it through.
        */
-      return name === 'content-range'
+      return name === 'content-range' || name === 'x-supabase-api-version'
     },
   })
 }

--- a/apps/docs/content/guides/getting-started/tutorials/with-sveltekit.mdx
+++ b/apps/docs/content/guides/getting-started/tutorials/with-sveltekit.mdx
@@ -111,7 +111,7 @@ export const handle: Handle = async ({ event, resolve }) => {
 
   return resolve(event, {
     filterSerializedResponseHeaders(name) {
-      return name === 'content-range'
+      return name === 'content-range' || name === 'x-supabase-api-version'
     },
   })
 }

--- a/examples/user-management/sveltekit-user-management/src/hooks.server.ts
+++ b/examples/user-management/sveltekit-user-management/src/hooks.server.ts
@@ -43,8 +43,8 @@ export const handle: Handle = async ({ event, resolve }) => {
   }
 
   return resolve(event, {
-    filterSerializedResponseHeaders(name) {
-      return name === 'content-range'
+    filterSerializedResponseHeaders(name: string) {
+      return name === 'content-range' || name === 'x-supabase-api-version'
     },
   })
 }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Resolves #23350

## What is the new behavior?

The `x-supabase-api-version` header was added to Supabase APIs, so it needs to be passed through in SvelteKit examples.