### PR TITLE
docs: self-hosting - checkout only docker directory from supabase project

### DIFF
--- a/apps/docs/content/guides/self-hosting/docker.mdx
+++ b/apps/docs/content/guides/self-hosting/docker.mdx
@@ -20,12 +20,11 @@ Follow these steps to start Supabase locally:
 ```sh
 # Get the code
 git clone --filter=blob:none --no-checkout https://github.com/supabase/supabase
-pushd supabase && git sparse-checkout set --cone docker
-git checkout master
-popd
+cd supabase
+git sparse-checkout set --cone docker && git checkout master
 
 # Go to the docker folder
-cd supabase/docker
+cd docker
 
 # Copy the fake env vars
 cp .env.example .env

--- a/apps/docs/content/guides/self-hosting/docker.mdx
+++ b/apps/docs/content/guides/self-hosting/docker.mdx
@@ -19,7 +19,10 @@ Follow these steps to start Supabase locally:
 
 ```sh
 # Get the code
-git clone --depth 1 https://github.com/supabase/supabase
+git clone --filter=blob:none --no-checkout https://github.com/supabase/supabase
+pushd supabase && git sparse-checkout set --cone docker
+git checkout master
+popd
 
 # Go to the docker folder
 cd supabase/docker


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

'Self-hosting with docker' document guides to checkout full project repository, which weighs around 766 MiB at 2024-05-01. Please refer supabase/supabase#23454.

## What is the new behavior?

'Self-hosting with docker' document guides to checkout only docker directory from project repository using git sparse checkout. Please refer supabase/supabase#23454.

## Additional context

supabase/supabase#23454
