### PR TITLE
fix: logs explorer grid - unwonkify resize and allow bigger columns

### DIFF
--- a/apps/studio/components/interfaces/Settings/Logs/LogTable.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogTable.tsx
@@ -110,7 +110,7 @@ const LogTable = ({
         return <div className="flex items-center">{v}</div>
       },
       minWidth: 128,
-      maxWidth: v === 'timestamp' ? 240 : 600, // Without this, the column flickers on first render
+      maxWidth: v === 'timestamp' ? 240 : 2400, // Without this, the column flickers on first render
     }
 
     return result

--- a/apps/studio/pages/project/[ref]/logs/explorer/index.tsx
+++ b/apps/studio/pages/project/[ref]/logs/explorer/index.tsx
@@ -221,17 +221,15 @@ export const LogsExplorerPage: NextPageWithLayout = () => {
         <ResizableHandle withHandle />
         <ResizablePanel collapsible minSize={5} className="flex flex-col flex-grow">
           <LoadingOpacity active={isLoading}>
-            <div className="flex flex-grow">
-              <LogTable
-                onRun={handleRun}
-                onSave={handleOnSave}
-                hasEditorValue={Boolean(editorValue)}
-                params={params}
-                data={logData}
-                error={error}
-                projectRef={projectRef as string}
-              />
-            </div>
+            <LogTable
+              onRun={handleRun}
+              onSave={handleOnSave}
+              hasEditorValue={Boolean(editorValue)}
+              params={params}
+              data={logData}
+              error={error}
+              projectRef={projectRef as string}
+            />
           </LoadingOpacity>
           <div className="flex flex-row justify-end mt-2">
             <UpgradePrompt show={showUpgradePrompt} setShowUpgradePrompt={setShowUpgradePrompt} />

--- a/apps/studio/styles/react-data-grid-logs.scss
+++ b/apps/studio/styles/react-data-grid-logs.scss
@@ -27,7 +27,7 @@
 }
 
 .data-grid--logs-explorer {
-  @apply transition-all overflow-x-scroll pb-12;
+  @apply overflow-x-scroll pb-12;
 
   .rdg-cell,
   .rdg-cell span {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Removes transitions from column resize in logs explorer table, the transitions make resizing slow and wonky.
Allows bigger column size so users can see the whole query or message

