### PR TITLE
docs: add kakao to the external OAuth provider list

### DIFF
--- a/apps/docs/spec/cli_v1_config.yaml
+++ b/apps/docs/spec/cli_v1_config.yaml
@@ -655,6 +655,7 @@ parameters:
       - `github`
       - `gitlab`
       - `google`
+      - `kakao`
       - `keycloak`
       - `linkedin`
       - `notion`


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Documentation update that adds kakao to external OAuth provider list.
