### PR TITLE
docs: self-hosting - add alternative command to make checkout faster

### DIFF
--- a/apps/docs/content/guides/self-hosting/docker.mdx
+++ b/apps/docs/content/guides/self-hosting/docker.mdx
@@ -17,6 +17,15 @@ You need the following installed in your system: [Git](https://git-scm.com/downl
 
 Follow these steps to start Supabase locally:
 
+<Tabs
+  scrollable
+  size="small"
+  type="general"
+  defaultActiveId="general"
+  queryGroup="running-supabase"
+>
+<TabPanel id="general" label="General">
+
 ```sh
 # Get the code
 git clone --depth 1 https://github.com/supabase/supabase
@@ -33,6 +42,31 @@ docker compose pull
 # Start the services (in detached mode)
 docker compose up -d
 ```
+
+</TabPanel>
+<TabPanel id="advanced" label="Advanced">
+
+```sh
+# Get the code using git sparse checkout
+git clone --filter=blob:none --no-checkout https://github.com/supabase/supabase
+cd supabase
+git sparse-checkout set --cone docker && git checkout master
+
+# Go to the docker folder
+cd docker
+
+# Copy the fake env vars
+cp .env.example .env
+
+# Pull the latest images
+docker compose pull
+
+# Start the services (in detached mode)
+docker compose up -d
+```
+
+</TabPanel>
+</Tabs>
 
 After all the services have started you can see them running in the background:
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

'Self-hosting with docker' document guides to checkout full project repository, which weighs around 766 MiB at 2024-05-01. Please refer supabase/supabase#23454.

## What is the new behavior?

Two versions of self hosting commands are provided, 'General' and 'Advanced' as tabs. General commands use shallow clone and advanced commands use sparse checkout.
I cannot attach a screenshot at the moment, because I was unable to set up fresh dev environment due to a series of build errors and npm timeouts.

## Additional context

supabase/supabase#23454