### PR TITLE
feat: rename logs section

### DIFF
--- a/apps/studio/components/layouts/LogsLayout/LogsMenu.utils.ts
+++ b/apps/studio/components/layouts/LogsLayout/LogsMenu.utils.ts
@@ -36,7 +36,7 @@ export const generateLogsMenu = (
       title: 'Infrastructure',
       items: [
         {
-          name: IS_PLATFORM ? 'API Edge Network' : 'Kong API',
+          name: 'API Gateway',
           key: 'edge-logs',
           url: `/project/${ref}/logs/edge-logs`,
           items: [],


### PR DESCRIPTION
users get confused between edge functions logs and we use api gateway in our docs instead of edge network
