### PR TITLE
chore: undo title change for april fools

### DIFF
--- a/apps/www/lib/authors.json
+++ b/apps/www/lib/authors.json
@@ -362,7 +362,7 @@
     "author_id": "long",
     "author": "Long Hoang",
     "username": "loong",
-    "position": "Analog Engineering",
+    "position": "Growth",
     "author_url": "https://github.com/loong",
     "author_image_url": "https://github.com/loong.png"
   },


### PR DESCRIPTION
Changed my title to "Analog Engineering" just for April fools. It's May now, so changing it back