### PR TITLE
Update nextjs.mdx

### DIFF
--- a/apps/docs/content/guides/getting-started/quickstarts/nextjs.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/nextjs.mdx
@@ -150,7 +150,23 @@ hideToc: true
 
   </StepHikeCompact.Step>
 
-  <StepHikeCompact.Step step={5}>
+  <StepHikeCompact.Step step={4}>
+    <StepHikeCompact.Details title="Install the packages">
+
+    Install the packages
+
+    </StepHikeCompact.Details>
+
+    <StepHikeCompact.Code>
+
+      ```bash Terminal
+      npm install
+      ```
+
+    </StepHikeCompact.Code>
+
+  </StepHikeCompact.Step>
+<StepHikeCompact.Step step={5}>
     <StepHikeCompact.Details title="Start the app">
 
     Run the development server, go to http://localhost:3000/notes in a browser and you should see the list of notes.


### PR DESCRIPTION
Added steps for the installation as it was throwing an error because packages were not installed so I have added the steps for that.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

 docs update

## What is the current behavior?

```bash
$ npm run dev

> dev
> next dev

'next' is not recognized as an internal or external command,
operable program or batch file.
```

## What is the new behavior?

One will not encounter this error
## Additional context

Add any other context or screenshots.
PFA
![Screenshot (442)](https://github.com/supabase/supabase/assets/111265239/1a2d284d-eb32-42fd-8408-40897501ff04)

