### PR TITLE
bug: fix sign-in when returnTo=sign-in

### DIFF
--- a/apps/studio/components/interfaces/SignIn/SignInForm.tsx
+++ b/apps/studio/components/interfaces/SignIn/SignInForm.tsx
@@ -52,8 +52,8 @@ const SignInForm = () => {
 
         toast.success(`Signed in successfully!`, { id: toastId })
         await queryClient.resetQueries()
-
-        router.push(getReturnToPath())
+        const returnTo = getReturnToPath()
+        router.push(returnTo !== '/sign-in' ? returnTo : '/projects')
       } catch (error) {
         toast.error((error as AuthError).message, { id: toastId })
       }

--- a/apps/studio/components/interfaces/SignIn/SignInForm.tsx
+++ b/apps/studio/components/interfaces/SignIn/SignInForm.tsx
@@ -53,7 +53,8 @@ const SignInForm = () => {
         toast.success(`Signed in successfully!`, { id: toastId })
         await queryClient.resetQueries()
         const returnTo = getReturnToPath()
-        router.push(returnTo !== '/sign-in' ? returnTo : '/projects')
+        // since we're already on the /sign-in page, prevent redirect loops
+        router.push(returnTo === '/sign-in' ? '/projects' : returnTo)
       } catch (error) {
         toast.error((error as AuthError).message, { id: toastId })
       }


### PR DESCRIPTION
- default redirect to /projects instead

fix #23665 

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

yes

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

#23665 when `returnTo=sign-in` then signing in returns to the same page

## What is the new behavior?

`SigninLayout` now checks if `returnTo` is the same as the page it's already on and if it is then defaults to `/projects`

## Additional context

Add any other context or screenshots.
