### PR TITLE
docs: Remove beta notification from Management API pages

### DIFF
--- a/apps/docs/docs/ref/api/api.mdx
+++ b/apps/docs/docs/ref/api/api.mdx
@@ -8,10 +8,6 @@ sidebar_label: Management API
 
 The Management API allows you to manage your projects programmatically.
 
-## Status
-
-The Management API is in `beta`. It is usable in it's current state, but it's likely that there will be breaking changes.
-
 ## Authentication
 
 All API requests require a Supabase Personal token to be included in the Authorization header: `Authorization: Bearer <supabase_personal_token>`.

--- a/apps/docs/docs/ref/api/introduction.mdx
+++ b/apps/docs/docs/ref/api/introduction.mdx
@@ -16,10 +16,6 @@ hideTitle: true
 
       Manage your Supabase organizations and projects programmatically.
 
-      ## Status
-
-      The Management API is in `beta`. It is usable in it's current state, but it's likely that there will be breaking changes.
-
       ## Authentication
 
       All API requests require a Supabase Personal token to be included in the Authorization header: `Authorization Bearer <supabase_personal_token`.


### PR DESCRIPTION
It's GA now.