### PR TITLE
feat: Allow for configuring target envs for Vercel integration

### DIFF
--- a/apps/studio/components/interfaces/Reports/Reports.CreateReportModal.tsx
+++ b/apps/studio/components/interfaces/Reports/Reports.CreateReportModal.tsx
@@ -46,7 +46,6 @@ export const CreateReportModal = ({ visible, onCancel, afterSubmit }: CreateRepo
         },
       })
       toast.success('New report created')
-
       const newReportId = res[0].id
       router.push(`/project/${ref}/reports/${newReportId}`)
       afterSubmit()

--- a/apps/studio/components/interfaces/Settings/Integrations/VercelIntegration/VercelIntegrationConnectionForm.tsx
+++ b/apps/studio/components/interfaces/Settings/Integrations/VercelIntegration/VercelIntegrationConnectionForm.tsx
@@ -1,29 +1,23 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useForm } from 'react-hook-form'
 import toast from 'react-hot-toast'
+import * as z from 'zod'
+
+import type {
+  EnvironmentTargets,
+  Integration,
+  IntegrationProjectConnection,
+} from 'data/integrations/integrations.types'
+import { useVercelConnectionUpdateMutation } from 'data/integrations/vercel-connection-update-mutate'
 import {
-  AlertDescription_Shadcn_,
-  AlertTitle_Shadcn_,
-  Alert_Shadcn_,
   FormControl_Shadcn_,
   FormDescription_Shadcn_,
   FormField_Shadcn_,
   FormItem_Shadcn_,
   FormLabel_Shadcn_,
   Form_Shadcn_,
-  IconClock,
   Switch,
-  cn,
 } from 'ui'
-import * as z from 'zod'
-
-import { ScaffoldDivider } from 'components/layouts/Scaffold'
-import type {
-  Integration,
-  IntegrationProjectConnection,
-} from 'data/integrations/integrations.types'
-import { useVercelConnectionUpdateMutation } from 'data/integrations/vercel-connection-update-mutate'
-import { useFlag } from 'hooks'
 
 const VercelIntegrationConnectionForm = ({
   connection,
@@ -32,190 +26,124 @@ const VercelIntegrationConnectionForm = ({
   connection: IntegrationProjectConnection
   integration: Integration
 }) => {
-  const config = connection.metadata.supabaseConfig
-  const enableVercelConnectionsConfig = useFlag('enableVercelConnectionsConfig')
+  const envSyncTargets = connection.env_sync_targets ?? []
 
   const FormSchema = z.object({
-    environmentVariablesProduction: z
-      .boolean()
-      .default(config?.environmentVariables?.production ?? true),
-    authRedirectUrisProduction: z.boolean().default(config?.authRedirectUris?.production ?? true),
-    environmentVariablesPreview: z.boolean().default(config?.environmentVariables?.preview ?? true),
-    authRedirectUrisPreview: z.boolean().default(config?.authRedirectUris?.preview ?? true),
+    environmentVariablesProduction: z.boolean().default(envSyncTargets.includes('production')),
+    environmentVariablesPreview: z.boolean().default(envSyncTargets.includes('preview')),
+    environmentVariablesDevelopment: z.boolean().default(envSyncTargets.includes('development')),
   })
 
   const form = useForm<z.infer<typeof FormSchema>>({
     resolver: zodResolver(FormSchema),
     defaultValues: {
-      environmentVariablesProduction: config?.environmentVariables?.production ?? true,
-      environmentVariablesPreview: config?.environmentVariables?.preview ?? true,
-      authRedirectUrisProduction: config?.authRedirectUris?.production ?? true,
-      authRedirectUrisPreview: config?.authRedirectUris?.preview ?? true,
+      environmentVariablesProduction: envSyncTargets.includes('production'),
+      environmentVariablesPreview: envSyncTargets.includes('preview'),
+      environmentVariablesDevelopment: envSyncTargets.includes('development'),
     },
   })
 
   const { mutate: updateVercelConnection } = useVercelConnectionUpdateMutation({
-    onSuccess: (data) => {
-      toast.success(`Updated Supabase directory`)
-    },
+    onSuccess: () => toast.success(`Updated Supabase directory`),
   })
 
   function onSubmit(data: z.infer<typeof FormSchema>) {
-    /**
-     * remove this hardcoded if statement when we are ready to enable this feature
-     */
-    if (!enableVercelConnectionsConfig) return
+    const {
+      environmentVariablesProduction,
+      environmentVariablesPreview,
+      environmentVariablesDevelopment,
+    } = data
 
-    const metadata = {
-      ...connection.metadata,
-    }
+    const envSyncTargets: string[] = []
 
-    metadata.supabaseConfig = {
-      environmentVariables: {
-        production: data.environmentVariablesProduction,
-        preview: data.environmentVariablesPreview,
-      },
-      authRedirectUris: {
-        production: data.authRedirectUrisProduction,
-        preview: data.authRedirectUrisPreview,
-      },
-    }
+    if (environmentVariablesProduction) envSyncTargets.push('production')
+    if (environmentVariablesPreview) envSyncTargets.push('preview')
+    if (environmentVariablesDevelopment) envSyncTargets.push('development')
 
     updateVercelConnection({
       id: connection.id,
-      metadata,
+      envSyncTargets: envSyncTargets as EnvironmentTargets[],
       organizationIntegrationId: integration.id,
     })
   }
 
   return (
     <Form_Shadcn_ {...form}>
-      <div className="py-4 px-8">
-        <Alert_Shadcn_ variant="default">
-          <IconClock className="h-4 w-4" strokeWidth={2} />
-          <AlertTitle_Shadcn_>Vercel Connection configuration coming soon</AlertTitle_Shadcn_>
-          <AlertDescription_Shadcn_>
-            This configuration will allow you to control the environment variables and auth
-            redirects for production and preview deployments.
-          </AlertDescription_Shadcn_>
-        </Alert_Shadcn_>
-      </div>
-      <ScaffoldDivider />
-      <form
-        onSubmit={form.handleSubmit(onSubmit)}
-        className={cn(!enableVercelConnectionsConfig && 'opacity-30', 'w-full space-y-6')}
-      >
-        <div>
-          {/* {isUpdatingVercelConnection && 'isUpdatingVercelConnection'} */}
-          <div className="flex flex-col gap-6 px-8 py-8">
-            <h5 className="text-foreground text-sm">Vercel Production deployments </h5>
+      <form onSubmit={form.handleSubmit(onSubmit)} className={'w-full space-y-6'}>
+        <div className="px-6 py-4 flex flex-col gap-y-4">
+          <h5 className="text-foreground text-sm">
+            Sync environment variables for selected target environments
+          </h5>
+          <div className="flex flex-col gap-4">
             <FormField_Shadcn_
               control={form.control}
               name="environmentVariablesProduction"
               render={({ field }) => (
-                <FormItem_Shadcn_ className="flex flex-row items-center justify-between">
-                  <div>
-                    <FormLabel_Shadcn_ className="!text">
-                      Sync environment variables for Vercel Production deployments
-                    </FormLabel_Shadcn_>
-                    <FormDescription_Shadcn_ className="text-xs text-foreground-lighter">
-                      Deploy Edge Functions when merged into Production Branch
-                    </FormDescription_Shadcn_>
-                  </div>
+                <FormItem_Shadcn_ className="space-y-0 flex gap-x-4">
                   <FormControl_Shadcn_>
                     <Switch
+                      className="mt-1"
                       checked={field.value}
-                      disabled={!enableVercelConnectionsConfig}
                       onCheckedChange={(e) => {
                         field.onChange(e)
                         form.handleSubmit(onSubmit)()
                       }}
                     />
                   </FormControl_Shadcn_>
-                </FormItem_Shadcn_>
-              )}
-            />
-            {/* <Button htmlType="submit">Submit</Button> */}
-            <FormField_Shadcn_
-              control={form.control}
-              name="authRedirectUrisProduction"
-              render={({ field }) => (
-                <FormItem_Shadcn_ className="flex flex-row items-center justify-between">
                   <div>
-                    <FormLabel_Shadcn_ className="!text">
-                      Auto update Auth Redirect URIs for Vercel Production Deployments
-                    </FormLabel_Shadcn_>
+                    <FormLabel_Shadcn_ className="!text">Production</FormLabel_Shadcn_>
                     <FormDescription_Shadcn_ className="text-xs text-foreground-lighter">
-                      Deploy Edge Functions when merged into Production Branch
+                      Sync environment variables for <code>production</code> environment.
                     </FormDescription_Shadcn_>
                   </div>
-                  <FormControl_Shadcn_>
-                    <Switch
-                      checked={field.value}
-                      disabled={!enableVercelConnectionsConfig}
-                      onCheckedChange={(e) => {
-                        field.onChange(e)
-                        form.handleSubmit(onSubmit)()
-                      }}
-                    />
-                  </FormControl_Shadcn_>
                 </FormItem_Shadcn_>
               )}
             />
-          </div>
-          <ScaffoldDivider />
-          <div className="flex flex-col gap-6 px-8 py-8">
-            <h5 className="text-foreground text-sm">Vercel Preview deployments </h5>
             <FormField_Shadcn_
               control={form.control}
               name="environmentVariablesPreview"
               render={({ field }) => (
-                <FormItem_Shadcn_ className="flex flex-row items-center justify-between">
-                  <div>
-                    <FormLabel_Shadcn_ className="!text">
-                      Sync environment variables for Vercel Preview Deployments
-                    </FormLabel_Shadcn_>
-                    <FormDescription_Shadcn_ className="text-xs text-foreground-lighter">
-                      Preview deployments will be able to connect to Supabase Database Preview
-                      branches
-                    </FormDescription_Shadcn_>
-                  </div>
+                <FormItem_Shadcn_ className="space-y-0 flex gap-x-4">
                   <FormControl_Shadcn_>
                     <Switch
+                      className="mt-1"
                       checked={field.value}
-                      disabled={!enableVercelConnectionsConfig}
                       onCheckedChange={(e) => {
                         field.onChange(e)
                         form.handleSubmit(onSubmit)()
                       }}
                     />
                   </FormControl_Shadcn_>
+                  <div>
+                    <FormLabel_Shadcn_ className="!text">Preview</FormLabel_Shadcn_>
+                    <FormDescription_Shadcn_ className="text-xs text-foreground-lighter">
+                      Sync environment variables for <code>preview</code> environment.
+                    </FormDescription_Shadcn_>
+                  </div>
                 </FormItem_Shadcn_>
               )}
             />
             <FormField_Shadcn_
               control={form.control}
-              name="authRedirectUrisPreview"
+              name="environmentVariablesDevelopment"
               render={({ field }) => (
-                <FormItem_Shadcn_ className="flex flex-row items-center justify-between">
-                  <div>
-                    <FormLabel_Shadcn_ className="!text">
-                      Auto update Auth Redirect URIs for Vercel Preview Deployments
-                    </FormLabel_Shadcn_>
-                    <FormDescription_Shadcn_ className="text-xs text-foreground-lighter">
-                      Deploy Edge Functions when merged into Production Branch
-                    </FormDescription_Shadcn_>
-                  </div>
+                <FormItem_Shadcn_ className="space-y-0 flex gap-x-4">
                   <FormControl_Shadcn_>
                     <Switch
+                      className="mt-1"
                       checked={field.value}
-                      disabled={!enableVercelConnectionsConfig}
                       onCheckedChange={(e) => {
                         field.onChange(e)
                         form.handleSubmit(onSubmit)()
                       }}
                     />
                   </FormControl_Shadcn_>
+                  <div>
+                    <FormLabel_Shadcn_ className="!text">Development</FormLabel_Shadcn_>
+                    <FormDescription_Shadcn_ className="text-xs text-foreground-lighter">
+                      Sync environment variables for <code>development</code> environment.
+                    </FormDescription_Shadcn_>
+                  </div>
                 </FormItem_Shadcn_>
               )}
             />

--- a/apps/studio/data/content/content-insert-mutation.ts
+++ b/apps/studio/data/content/content-insert-mutation.ts
@@ -7,7 +7,7 @@ import type { ResponseError } from 'types'
 import type { Content } from './content-query'
 import { contentKeys } from './keys'
 
-export type InsertContentPayload = Omit<components['schemas']['CreateContentParams'], 'content'> & {
+export type InsertContentPayload = Omit<components['schemas']['CreateContentBody'], 'content'> & {
   content: Content['content']
 }
 
@@ -15,6 +15,8 @@ export type InsertContentVariables = {
   projectRef: string
   payload: InsertContentPayload
 }
+
+export type InsertContentResponse = components['schemas']['UserContentObject']
 
 export async function insertContent(
   { projectRef, payload }: InsertContentVariables,
@@ -35,7 +37,8 @@ export async function insertContent(
   })
   if (error) throw error
 
-  return data
+  // [Joshen] There's an issue with the API codegen due to content endpoint having 2 versions
+  return data as unknown as InsertContentResponse[]
 }
 
 export type InsertContentData = Awaited<ReturnType<typeof insertContent>>

--- a/apps/studio/data/content/content-upsert-mutation.ts
+++ b/apps/studio/data/content/content-upsert-mutation.ts
@@ -7,7 +7,7 @@ import type { ResponseError } from 'types'
 import type { Content } from './content-query'
 import { contentKeys } from './keys'
 
-export type UpsertContentPayload = Omit<components['schemas']['UpsertContentParams'], 'content'> & {
+export type UpsertContentPayload = Omit<components['schemas']['UpsertContentBody'], 'content'> & {
   content: Content['content']
 }
 

--- a/apps/studio/data/integrations/integrations.types.ts
+++ b/apps/studio/data/integrations/integrations.types.ts
@@ -154,6 +154,7 @@ export type IntegrationProjectConnection = {
   supabase_project_ref: string
   foreign_project_id: string
   organization_integration_id: string
+  env_sync_targets?: string[]
   metadata: Imetadata
 }
 
@@ -264,8 +265,10 @@ export type GitHubConnectionCreateVariables = {
   connection: components['schemas']['CreateGitHubConnectionsBody']
 }
 
+export type EnvironmentTargets = 'production' | 'preview' | 'development'
+
 export type UpdateConnectionPayload = {
   id: string
   organizationIntegrationId: string
-  metadata: Imetadata
+  envSyncTargets: EnvironmentTargets[]
 }

--- a/apps/studio/data/integrations/vercel-connection-update-mutate.ts
+++ b/apps/studio/data/integrations/vercel-connection-update-mutate.ts
@@ -6,18 +6,13 @@ import type { ResponseError } from 'types'
 import type { UpdateConnectionPayload } from './integrations.types'
 import { integrationKeys } from './keys'
 
-export async function updateVercelConnection({
-  id,
-  metadata,
-  organizationIntegrationId,
-}: UpdateConnectionPayload) {
+export async function updateVercelConnection({ id, envSyncTargets }: UpdateConnectionPayload) {
   const { data, error } = await patch('/platform/integrations/vercel/connections/{connection_id}', {
     params: {
       path: { connection_id: id },
     },
     body: {
-      // @ts-expect-error
-      metadata,
+      env_sync_targets: envSyncTargets,
     },
   })
 

--- a/packages/api-types/types/api.d.ts
+++ b/packages/api-types/types/api.d.ts
@@ -472,16 +472,40 @@ export interface paths {
     get: operations['ProjectsController_getProjectByFlyExtensionId']
   }
   '/platform/projects/{ref}/content': {
-    /** Gets project's content */
+    /**
+     * Gets project's content
+     * @deprecated
+     */
     get: operations['ContentController_getContent']
     /** Updates project's content */
-    put: operations['ContentController_updateWholeContent']
+    put: operations['ContentController_updateWholeContentV2']
     /** Creates project's content */
-    post: operations['ContentController_createContent']
+    post: operations['ContentController_createContentV2']
     /** Deletes project's contents */
     delete: operations['ContentController_deleteContents']
-    /** Updates project's content */
+    /**
+     * Updates project's content
+     * @deprecated
+     */
     patch: operations['ContentController_updateContent']
+  }
+  '/platform/projects/{ref}/content/item/{id}': {
+    /** Gets project's content by the given id */
+    get: operations['ContentController_getContentById']
+  }
+  '/platform/projects/{ref}/content/folders': {
+    /** Gets project's content root folder */
+    get: operations['ContentFoldersController_getRootFolder']
+    /** Creates project's content folder */
+    post: operations['ContentFoldersController_createFolder']
+    /** Deletes project's content folders */
+    delete: operations['ContentFoldersController_DeleteFolder']
+  }
+  '/platform/projects/{ref}/content/folders/{id}': {
+    /** Gets project's content folder */
+    get: operations['ContentFoldersController_getFolder']
+    /** Updates project's content folder */
+    patch: operations['ContentFoldersController_updateFolder']
   }
   '/platform/projects/{ref}/daily-stats': {
     /** Gets daily project stats */
@@ -924,6 +948,11 @@ export interface paths {
   }
   '/system/projects/{ref}/functions/{function_slug}': {
     /**
+     * Delete a function
+     * @description Deletes a function with the specified slug from the specified project.
+     */
+    delete: operations['SystemFunctionSlugController_deleteFunction']
+    /**
      * Update a function
      * @description Updates a function with the specified slug and project.
      */
@@ -1328,16 +1357,26 @@ export interface paths {
     get: operations['V0ProjectsMetricsController_getProjectsMetrics']
   }
   '/v0/projects/{ref}/content': {
-    /** Gets project's content */
+    /**
+     * Gets project's content
+     * @deprecated
+     */
     get: operations['ContentController_getContent']
     /** Updates project's content */
-    put: operations['ContentController_updateWholeContent']
+    put: operations['ContentController_updateWholeContentV2']
     /** Creates project's content */
-    post: operations['ContentController_createContent']
+    post: operations['ContentController_createContentV2']
     /** Deletes project's contents */
     delete: operations['ContentController_deleteContents']
-    /** Updates project's content */
+    /**
+     * Updates project's content
+     * @deprecated
+     */
     patch: operations['ContentController_updateContent']
+  }
+  '/v0/projects/{ref}/content/item/{id}': {
+    /** Gets project's content by the given id */
+    get: operations['ContentController_getContentById']
   }
   '/v0/projects/{ref}/databases': {
     /** Gets non-removed databases of a specified project */
@@ -3709,15 +3748,28 @@ export interface components {
       description?: string
       project_id: number
       owner_id: number
-      last_updated_by: number
+      last_updated_by?: number
     }
     GetUserContentResponse: {
       data: components['schemas']['GetUserContentObject'][]
     }
-    CreateContentParams: {
+    GetUserContentByIdResponse: {
+      folder_id?: string
       id: string
+      inserted_at: string
+      updated_at: string
+      type: Record<string, never>
+      visibility: Record<string, never>
       name: string
-      description: string
+      description?: string
+      project_id: number
+      owner_id: number
+      last_updated_by?: number
+    }
+    CreateContentBody: {
+      id?: string
+      name: string
+      description?: string
       /** @enum {string} */
       type: 'sql' | 'report' | 'log_sql'
       /** @enum {string} */
@@ -3735,21 +3787,34 @@ export interface components {
       description?: string
       project_id: number
       owner_id: number
-      last_updated_by: number
+      last_updated_by?: number
     }
-    UpsertContentParams: {
-      id: string
+    CreateContentBodyV2: {
+      id?: string
       name: string
-      description: string
+      description?: string
       /** @enum {string} */
       type: 'sql' | 'report' | 'log_sql'
       /** @enum {string} */
       visibility: 'user' | 'project' | 'org' | 'public'
       content?: Record<string, never>
       owner_id?: number
-      project_id: number
+      folder_id?: string
     }
-    UpdateContentParams: {
+    UserContentObjectV2: {
+      id: string
+      inserted_at: string
+      updated_at: string
+      type: Record<string, never>
+      visibility: Record<string, never>
+      name: string
+      description?: string
+      project_id: number
+      owner_id: number
+      last_updated_by?: number
+      folder_id?: string
+    }
+    UpdateContentBody: {
       id?: string
       name?: string
       description?: string
@@ -3760,8 +3825,73 @@ export interface components {
       content?: Record<string, never>
       owner_id?: number
     }
+    UpsertContentBody: {
+      id?: string
+      name: string
+      description?: string
+      /** @enum {string} */
+      type: 'sql' | 'report' | 'log_sql'
+      /** @enum {string} */
+      visibility: 'user' | 'project' | 'org' | 'public'
+      content?: Record<string, never>
+      owner_id?: number
+      project_id: number
+    }
+    UpsertContentBodyV2: {
+      id?: string
+      name: string
+      description?: string
+      /** @enum {string} */
+      type: 'sql' | 'report' | 'log_sql'
+      /** @enum {string} */
+      visibility: 'user' | 'project' | 'org' | 'public'
+      content?: Record<string, never>
+      owner_id?: number
+      project_id: number
+      folder_id?: string
+    }
     BulkDeleteUserContentResponse: {
       id: string
+    }
+    UserContentFolder: {
+      id: string
+      name: string
+      project_id: number
+      owner_id: number
+      parent_id?: string | null
+    }
+    UserContentObjectMeta: {
+      id: string
+      inserted_at: string
+      updated_at: string
+      type: Record<string, never>
+      visibility: Record<string, never>
+      name: string
+      description?: string
+      project_id: number
+      owner_id: number
+      last_updated_by?: number
+      folder_id?: string
+    }
+    GetUserContentFolderResponse: {
+      data: {
+        folders?: components['schemas']['UserContentFolder'][]
+        contents?: components['schemas']['UserContentObjectMeta'][]
+      }
+    }
+    CreateContentFolderBody: {
+      name: string
+      parent_id?: string
+    }
+    CreateUserContentFolderResponse: {
+      id: string
+      name: string
+      project_id: number
+      owner_id: number
+      parent_id?: string | null
+    }
+    UpdateContentFolderBody: {
+      name: string
     }
     DatabaseDetailResponse: {
       /** @enum {string} */
@@ -4557,7 +4687,7 @@ export interface components {
       env_sync_error?: components['schemas']['SyncVercelEnvError']
     }
     UpdateVercelConnectionsBody: {
-      metadata: Record<string, never>
+      env_sync_targets?: ('production' | 'preview' | 'development')[]
     }
     DeleteVercelConnectionResponse: {
       id: string
@@ -5663,7 +5793,7 @@ export interface components {
       /** @enum {string} */
       visibility: 'user' | 'project' | 'org' | 'public'
       name: string
-      description: string | null
+      description?: string
       project: components['schemas']['SnippetProject']
       owner: components['schemas']['SnippetUser']
       updated_by: components['schemas']['SnippetUser']
@@ -5685,7 +5815,7 @@ export interface components {
       /** @enum {string} */
       visibility: 'user' | 'project' | 'org' | 'public'
       name: string
-      description: string | null
+      description?: string
       project: components['schemas']['SnippetProject']
       owner: components['schemas']['SnippetUser']
       updated_by: components['schemas']['SnippetUser']
@@ -9350,7 +9480,10 @@ export interface operations {
       }
     }
   }
-  /** Gets project's content */
+  /**
+   * Gets project's content
+   * @deprecated
+   */
   ContentController_getContent: {
     parameters: {
       path: {
@@ -9371,17 +9504,15 @@ export interface operations {
     }
   }
   /** Updates project's content */
-  ContentController_updateWholeContent: {
+  ContentController_updateWholeContentV2: {
     requestBody: {
       content: {
-        'application/json': components['schemas']['UpsertContentParams']
+        'application/json': components['schemas']['UpsertContentBodyV2']
       }
     }
     responses: {
       200: {
-        content: {
-          'application/json': components['schemas']['UserContentObject']
-        }
+        content: never
       }
       /** @description Failed to update project's content */
       500: {
@@ -9390,7 +9521,7 @@ export interface operations {
     }
   }
   /** Creates project's content */
-  ContentController_createContent: {
+  ContentController_createContentV2: {
     parameters: {
       path: {
         /** @description Project ref */
@@ -9399,13 +9530,13 @@ export interface operations {
     }
     requestBody: {
       content: {
-        'application/json': components['schemas']['CreateContentParams']
+        'application/json': components['schemas']['CreateContentBodyV2']
       }
     }
     responses: {
       201: {
         content: {
-          'application/json': components['schemas']['UserContentObject'][]
+          'application/json': components['schemas']['UserContentObjectV2']
         }
       }
       /** @description Failed to create project's content */
@@ -9437,7 +9568,10 @@ export interface operations {
       }
     }
   }
-  /** Updates project's content */
+  /**
+   * Updates project's content
+   * @deprecated
+   */
   ContentController_updateContent: {
     parameters: {
       query: {
@@ -9446,7 +9580,7 @@ export interface operations {
     }
     requestBody: {
       content: {
-        'application/json': components['schemas']['UpdateContentParams']
+        'application/json': components['schemas']['UpdateContentBody']
       }
     }
     responses: {
@@ -9456,6 +9590,140 @@ export interface operations {
         }
       }
       /** @description Failed to update project's content */
+      500: {
+        content: never
+      }
+    }
+  }
+  /** Gets project's content by the given id */
+  ContentController_getContentById: {
+    parameters: {
+      path: {
+        /** @description Project ref */
+        ref: string
+        /** @description Content id */
+        id: string
+      }
+    }
+    responses: {
+      200: {
+        content: {
+          'application/json': components['schemas']['GetUserContentByIdResponse']
+        }
+      }
+      /** @description Failed to retrieve project's content by the given id */
+      500: {
+        content: never
+      }
+    }
+  }
+  /** Gets project's content root folder */
+  ContentFoldersController_getRootFolder: {
+    parameters: {
+      query?: {
+        type?: 'sql' | 'report' | 'log_sql'
+      }
+      path: {
+        /** @description Project ref */
+        ref: string
+      }
+    }
+    responses: {
+      200: {
+        content: {
+          'application/json': components['schemas']['GetUserContentFolderResponse']
+        }
+      }
+      /** @description Failed to retrieve project's content root folder */
+      500: {
+        content: never
+      }
+    }
+  }
+  /** Creates project's content folder */
+  ContentFoldersController_createFolder: {
+    parameters: {
+      path: {
+        /** @description Project ref */
+        ref: string
+      }
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['CreateContentFolderBody']
+      }
+    }
+    responses: {
+      201: {
+        content: {
+          'application/json': components['schemas']['CreateUserContentFolderResponse']
+        }
+      }
+      /** @description Failed to create project's content folder */
+      500: {
+        content: never
+      }
+    }
+  }
+  /** Deletes project's content folders */
+  ContentFoldersController_DeleteFolder: {
+    parameters: {
+      query: {
+        ids: string[]
+      }
+    }
+    responses: {
+      200: {
+        content: never
+      }
+      /** @description Failed to delete project's content folders */
+      500: {
+        content: never
+      }
+    }
+  }
+  /** Gets project's content folder */
+  ContentFoldersController_getFolder: {
+    parameters: {
+      path: {
+        /** @description Project ref */
+        ref: string
+        /** @description Content folder id */
+        id: string
+      }
+    }
+    responses: {
+      200: {
+        content: {
+          'application/json': components['schemas']['GetUserContentFolderResponse']
+        }
+      }
+      /** @description Failed to retrieve project's content folder */
+      500: {
+        content: never
+      }
+    }
+  }
+  /** Updates project's content folder */
+  ContentFoldersController_updateFolder: {
+    parameters: {
+      path: {
+        /** @description Project ref */
+        ref: string
+        /** @description Content folder id */
+        id: string
+      }
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['UpdateContentFolderBody']
+      }
+    }
+    responses: {
+      200: {
+        content: never
+      }
+      /** @description Failed to update project's content folder */
       500: {
         content: never
       }
@@ -11743,7 +12011,7 @@ export interface operations {
       }
     }
     responses: {
-      200: {
+      204: {
         content: never
       }
       /** @description Failed to update Vercel connection */
@@ -12115,6 +12383,32 @@ export interface operations {
         content: never
       }
       /** @description Failed to reset JWT */
+      500: {
+        content: never
+      }
+    }
+  }
+  /**
+   * Delete a function
+   * @description Deletes a function with the specified slug from the specified project.
+   */
+  SystemFunctionSlugController_deleteFunction: {
+    parameters: {
+      path: {
+        /** @description Project ref */
+        ref: string
+        /** @description Function slug */
+        function_slug: string
+      }
+    }
+    responses: {
+      200: {
+        content: never
+      }
+      403: {
+        content: never
+      }
+      /** @description Failed to delete function with given slug */
       500: {
         content: never
       }


### PR DESCRIPTION
This PR depends on https://github.com/supabase/infrastructure/pull/18002 changes, but can be already tested locally using code from the linked PR.

I want to update the Vercel integration UI to look like that (feel free to change it as much as you want; the top alert is gone in second commit).

![image](https://github.com/supabase/supabase/assets/1523305/28b93168-1ff4-4387-8ac0-e63e19884c55)

From technical side, what should change is:
- `env_sync_targets` is now returned for connection endpoints and should be used to determine what toggles should be on/off (it returns an array of 3 possible string values)
- `{ env_sync_targets: string[] }` should be send to update Vercel connection endpoint

It "works" now, but I'm sure there is a better way to work with arrays in Shadcdn form components.

Also API types codegen is completely borked for me locally and it generates a lot of gibberish :( (I used `api-shared` fwiw).