### PR TITLE
fix undefined timestamp in log explorer

### DIFF
--- a/apps/studio/components/interfaces/Settings/Logs/LogTable.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogTable.tsx
@@ -84,6 +84,9 @@ const LogTable = ({
     if (!firstRow) return {}
 
     const { timestamp, ...rest } = firstRow || {}
+
+    if (!timestamp) return firstRow
+
     return { timestamp, ...rest }
   }
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

if no timestamps in response, return it as is so the table doesn't render a timestamp column with undefined results.