### PR TITLE
Remove references to non-empty search path as they are now lint warnings

### DIFF
--- a/apps/docs/content/guides/auth/custom-claims-and-role-based-access-control-rbac.mdx
+++ b/apps/docs/content/guides/auth/custom-claims-and-role-based-access-control-rbac.mdx
@@ -230,7 +230,7 @@ begin
 
   return bind_permissions > 0;
 end;
-$$ language plpgsql security definer set search_path = public;
+$$ language plpgsql security definer set search_path = '';
 ```
 
 <Admonition type="note">

--- a/apps/docs/content/guides/auth/managing-user-data.mdx
+++ b/apps/docs/content/guides/auth/managing-user-data.mdx
@@ -267,7 +267,7 @@ Example:
 create function public.handle_new_user()
 returns trigger
 language plpgsql
-security definer set search_path = public
+security definer set search_path = ''
 as $$
 begin
   insert into public.profiles (id, first_name, age)

--- a/apps/docs/content/guides/auth/row-level-security.mdx
+++ b/apps/docs/content/guides/auth/row-level-security.mdx
@@ -257,11 +257,11 @@ create function private.get_teams_for_authenticated_user()
 returns setof bigint
 language sql
 security definer
-set search_path = public
+set search_path = ''
 stable
 as $$
   select team_id
-  from members
+  from public.members
   where user_id = auth.uid()
 $$;
 

--- a/apps/docs/content/guides/database/functions.mdx
+++ b/apps/docs/content/guides/database/functions.mdx
@@ -356,7 +356,7 @@ Postgres allows you to specify whether you want the function to be executed as t
 create function hello_world()
 returns text
 language plpgsql
-security definer set search_path = public
+security definer set search_path = ''
 as $$
 begin
   select 'hello world';

--- a/apps/www/_blog/2022-08-24-building-a-realtime-trello-board-with-supabase-and-angular.mdx
+++ b/apps/www/_blog/2022-08-24-building-a-realtime-trello-board-with-supabase-and-angular.mdx
@@ -135,11 +135,11 @@ create or replace function get_boards_for_authenticated_user()
 returns setof bigint
 language sql
 security definer
-set search_path = public
+set search_path = ''
 stable
 as $$
     select board_id
-    from user_boards
+    from public.user_boards
     where user_id = auth.uid()
 $$;
 ```

--- a/apps/www/_blog/2024-04-25-exploring-support-tooling.mdx
+++ b/apps/www/_blog/2024-04-25-exploring-support-tooling.mdx
@@ -212,7 +212,7 @@ CREATE OR REPLACE FUNCTION "public"."get_embedded_event_names"
 	("date_param" timestamp with time zone DEFAULT "now"())
   RETURNS "jsonb"
   LANGUAGE "plpgsql" SECURITY DEFINER
-  SET "search_path" TO 'public', 'extensions', 'vault'
+  SET "search_path" TO ''
   AS $$
 DECLARE
   target_date timestamp with time zone := COALESCE(date_param, now());
@@ -233,7 +233,7 @@ BEGIN
 
   api_url := base_url || '&timeMin=' || time_min || '&timeMax=' || time_max;
 
-  select "content"::jsonb into response from http_get(api_url);
+  select "content"::jsonb into response from extensions.http_get(api_url);
   events := response->'items'; -- Remove the typecast to ::jsonb
 
   SELECT ARRAY_AGG(event->>'summary')


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?
Our [linter](GitHub.com/supabase/splinter) now expects functions to have [empty `search_paths`](https://supabase.github.io/splinter/0011_function_search_path_mutable/) which forces fully qualified use entity reference inside function bodies. This PR updates the docs to update functions which had a `search_path` set, that was not empty, such that it is empty.

Note that there may be (and probably are) other function declarations in our docs that do not include `set serach_path` at all. Those should also be updated but will be in a separate PR