### PR TITLE
feat: add several frameworks to routing edge functions page

### DIFF
--- a/apps/docs/content/guides/functions/routing.mdx
+++ b/apps/docs/content/guides/functions/routing.mdx
@@ -15,14 +15,6 @@ To combine multiple endpoints into a single Edge Function, you can use web appli
 
 Let's dive into some examples.
 
-<Tabs
-  scrollable
-  size="small"
-  type="underlined"
-  defaultActiveId="hono"
-  queryGroup="framework"
->
-
 ## Routing with Frameworks
 
 Here's a simple hello world example using some popular web frameworks.
@@ -35,6 +27,13 @@ supabase functions new hello-world
 
 Copy and paste the following code:
 
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  defaultActiveId="hono"
+  queryGroup="framework"
+>
 <TabPanel id="expressjs" label="Express">
 
 ```ts
@@ -82,9 +81,10 @@ app.use(router.allowedMethods());
 
 app.listen({ port: 3000 });
 
-````
+```
 
 </TabPanel>
+
 <TabPanel id="hono" label="Hono">
 ```ts
 import { Hono } from 'https://deno.land/x/hono/mod.ts';
@@ -103,9 +103,10 @@ return new Response('Hello World!')
 
 Deno.serve(app.fetch);
 
-````
+```
 
 </TabPanel>
+
 <TabPanel id="deno" label="Deno">
 ```ts
 Deno.serve(async (req) => {
@@ -121,7 +122,9 @@ Deno.serve(async (req) => {
 ```
 
 </TabPanel>
+
 </Tabs>
+
 You will notice in the above example, we created two routes - `GET` and `POST`. The path for both routes are defined as `/hello-world`.
 If you run a server outside of Edge Functions, you'd usually set the root path as `/` .
 However, within Edge Functions, paths should always be prefixed with the function name (in this case `hello-world`).
@@ -200,9 +203,11 @@ const id = req.params.id
 // delete task
 })
 
-````
+```
 </TabPanel>
+
 <TabPanel id="oak" label="Oak">
+
 ```ts
 import { Application } from "jsr:@oak/oak/application";
 import { Router } from "jsr:@oak/oak/router";
@@ -262,10 +267,12 @@ app.use(router.routes());
 app.use(router.allowedMethods());
 
 app.listen({ port: 3000 });
-````
+```
 
 </TabPanel>
+
 <TabPanel id="hono" label="Hono">
+
 ```ts
 import { Hono } from 'https://deno.land/x/hono/mod.ts';
 import type { Context } from 'https://deno.land/x/hono/mod.ts';
@@ -311,9 +318,12 @@ return new Response('Task not found', { status: 404 });
 
 Deno.serve(app.fetch);
 
-````
+```
+
 </TabPanel>
+
 <TabPanel id="deno" label="Deno">
+
 ```ts
 interface Task {
  id: string;
@@ -400,10 +410,11 @@ Deno.serve(async (req) => {
      return new Response(`Internal Server Error: ${error}`, { status: 500 });
   }
  });
-````
+```
 
 </TabPanel>
 </Tabs>
+
 ## URL Patterns API
 
 If you prefer not to use a web framework, you can directly use [URLPattern API](https://developer.mozilla.org/en-US/docs/Web/API/URL_Pattern_API) within your Edge Functions to implement routing.

--- a/apps/docs/content/guides/functions/routing.mdx
+++ b/apps/docs/content/guides/functions/routing.mdx
@@ -102,7 +102,6 @@ return new Response('Hello World!')
 });
 
 Deno.serve(app.fetch);
-
 ````
 
 </TabPanel>
@@ -175,35 +174,36 @@ Keep in mind paths must be prefixed by function name (ie. `tasks` in this exampl
 ```ts
 import express from 'npm:express@4.18.2'
 
-const app = express()
-app.use(express.json())
+const app = express();
+app.use(express.json());
 
 app.get('/tasks', async (req, res) => {
 // return all tasks
-})
+});
 
 app.post('/tasks', async (req, res) => {
 // create a task
-})
+});
 
 app.get('/tasks/:id', async (req, res) => {
 const id = req.params.id
 const task = {} // get task
 
 res.json(task)
-})
+});
 
 app.patch('/tasks/:id', async (req, res) => {
 const id = req.params.id
 // modify task
-})
+});
 
 app.delete('/tasks/:id', async (req, res) => {
 const id = req.params.id
 // delete task
-})
+});
 
 ````
+
 </TabPanel>
 
 <TabPanel id="oak" label="Oak">
@@ -278,8 +278,8 @@ import { Hono } from 'https://deno.land/x/hono/mod.ts'
 import type { Context } from 'https://deno.land/x/hono/mod.ts'
 
 // You can set the basePath with Hono
-const functionName = 'routing'
-const app = new Hono().basePath(`/${functionName}`)
+const functionName = 'tasks';
+const app = new Hono().basePath(`/${functionName}`);
 
 // /tasks/id
 app.get('/:id', async (c: Context) => {
@@ -290,7 +290,7 @@ app.get('/:id', async (c: Context) => {
   } else {
     return new Response('Task not found', { status: 404 })
   }
-})
+});
 
 app.patch('/:id', async (c: Context) => {
   const id = c.req.param('id')
@@ -303,7 +303,7 @@ app.patch('/:id', async (c: Context) => {
   } else {
     return new Response('Task not found', { status: 404 })
   }
-})
+});
 
 app.delete('/:id', async (c: Context) => {
   const id = c.req.param('id')
@@ -314,9 +314,9 @@ app.delete('/:id', async (c: Context) => {
   } else {
     return new Response('Task not found', { status: 404 })
   }
-})
+});
 
-Deno.serve(app.fetch)
+Deno.serve(app.fetch);
 ```
 
 </TabPanel>
@@ -408,7 +408,7 @@ Deno.serve(async (req) => {
   } catch (error) {
     return new Response(`Internal Server Error: ${error}`, { status: 500 })
   }
-})
+});
 ```
 
 </TabPanel>

--- a/apps/docs/content/guides/functions/routing.mdx
+++ b/apps/docs/content/guides/functions/routing.mdx
@@ -15,9 +15,17 @@ To combine multiple endpoints into a single Edge Function, you can use web appli
 
 Let's dive into some examples.
 
-## Routing with Express
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  defaultActiveId="hono"
+  queryGroup="framework"
+>
 
-Here's a simple hello world example using popular web framework Express.
+## Routing with Frameworks
+
+Here's a simple hello world example using some popular web frameworks.
 
 Create a new function called `hello-world` using Supabase CLI:
 
@@ -27,6 +35,7 @@ supabase functions new hello-world
 
 Copy and paste the following code:
 
+<TabPanel id="expressjs" label="Express">
 ```ts
 import express from 'npm:express@4.18.2'
 
@@ -35,21 +44,82 @@ app.use(express.json())
 const port = 3000
 
 app.get('/hello-world', (req, res) => {
-  res.send('Hello World!')
+res.send('Hello World!')
 })
 
 app.post('/hello-world', (req, res) => {
-  const { name } = req.body
-  res.send(`Hello ${name}!`)
+const { name } = req.body
+res.send(`Hello ${name}!`)
 })
 
 app.listen(port, () => {
-  console.log(`Example app listening on port ${port}`)
+console.log(`Example app listening on port ${port}`)
 })
-```
 
+````
+</TabPanel>
+<TabPanel id="oak" label="Oak">
+```ts
+import { Application } from "jsr:@oak/oak@15/application";
+import { Router } from "jsr:@oak/oak@15/router";
+
+const router = new Router();
+
+router.get("/hello-world", (ctx) => {
+  return new Response("Hello World!", {status: 200});
+});
+
+router.post("/hello-world", async (ctx) => {
+  const { name } = await ctx.request.body.json();
+  ctx.response.body = `Hello ${name}!`;
+});
+
+const app = new Application();
+app.use(router.routes());
+app.use(router.allowedMethods());
+
+app.listen({ port: 3000 });
+
+````
+
+</TabPanel>
+<TabPanel id="hono" label="Hono">
+```ts
+import { Hono } from 'https://deno.land/x/hono/mod.ts';
+import type { Context } from 'https://deno.land/x/hono/mod.ts';
+
+const app = new Hono();
+
+app.post('/hello-world', async (c: Context) => {
+const { name } = await c.req.json();
+return new Response(`Hello ${name}!`)
+});
+
+app.get('/hello-world', (c: Context) => {
+return new Response('Hello World!')
+});
+
+Deno.serve(app.fetch);
+
+````
+</TabPanel>
+<TabPanel id="deno" label="Deno">
+```ts
+Deno.serve(async (req) => {
+  if (req.method === 'GET') {
+    return new Response('Hello World!')
+  }
+  const { name } = await req.json()
+  if (name) {
+    return new Response(`Hello ${name}!`)
+  }
+  return new Response('Hello World!')
+});
+````
+
+</TabPanel>
 You will notice in the above example, we created two routes - `GET` and `POST`. The path for both routes are defined as `/hello-world`.
-If you run an Express server outside of Edge Functions, you'd usually set the root path as `/` .
+If you run a server outside of Edge Functions, you'd usually set the root path as `/` .
 However, within Edge Functions, paths should always be prefixed with the function name (in this case `hello-world`).
 
 You can deploy the function to Supabase via:
@@ -84,9 +154,10 @@ We should see a response printing `Hello Foo!`.
 
 We can use route parameters to capture values at specific URL segments (eg: `/tasks/:taskId/notes/:noteId`).
 
-Here's an example Edge Function implemented using Express for managing tasks using route parameters.
+Here's an example Edge Function implemented using the Framework for managing tasks using route parameters.
 Keep in mind paths must be prefixed by function name (ie. `tasks` in this example). Route parameters can only be used after the function name prefix.
 
+<TabPanel id="expressjs" label="Express">
 ```ts
 import express from 'npm:express@4.18.2'
 
@@ -94,31 +165,233 @@ const app = express()
 app.use(express.json())
 
 app.get('/tasks', async (req, res) => {
-  // return all tasks
+// return all tasks
 })
 
 app.post('/tasks', async (req, res) => {
-  // create a task
+// create a task
 })
 
 app.get('/tasks/:id', async (req, res) => {
-  const id = req.params.id
-  const task = {} // get task
+const id = req.params.id
+const task = {} // get task
 
-  res.json(task)
+res.json(task)
 })
 
 app.patch('/tasks/:id', async (req, res) => {
-  const id = req.params.id
-  // modify task
+const id = req.params.id
+// modify task
 })
 
 app.delete('/tasks/:id', async (req, res) => {
-  const id = req.params.id
-  // delete task
+const id = req.params.id
+// delete task
 })
-```
 
+````
+</TabPanel>
+<TabPanel id="oak" label="Oak">
+```ts
+import { Application } from "jsr:@oak/oak/application";
+import { Router } from "jsr:@oak/oak/router";
+
+const router = new Router();
+
+let tasks: { [id: string]: any } = {};
+
+router
+  .get("/tasks", (ctx) => {
+    ctx.response.body = Object.values(tasks);
+  })
+  .post("/tasks", async (ctx) => {
+    const body = ctx.request.body();
+    const { name } = await body.value;
+    const id = Math.random().toString(36).substring(7);
+    tasks[id] = { id, name };
+    ctx.response.body = tasks[id];
+  })
+  .get("/tasks/:id", (ctx) => {
+    const id = ctx.params.id;
+    const task = tasks[id];
+    if (task) {
+      ctx.response.body = task;
+    } else {
+      ctx.response.status = 404;
+      ctx.response.body = 'Task not found';
+    }
+  })
+  .patch("/tasks/:id", async (ctx) => {
+    const id = ctx.params.id;
+    const body = ctx.request.body();
+    const updates = await body.value;
+    const task = tasks[id];
+    if (task) {
+      tasks[id] = { ...task, ...updates };
+      ctx.response.body = tasks[id];
+    } else {
+      ctx.response.status = 404;
+      ctx.response.body = 'Task not found';
+    }
+  })
+  .delete("/tasks/:id", (ctx) => {
+    const id = ctx.params.id;
+    if (tasks[id]) {
+      delete tasks[id];
+      ctx.response.body = 'Task deleted successfully';
+    } else {
+      ctx.response.status = 404;
+      ctx.response.body = 'Task not found';
+    }
+  });
+
+
+const app = new Application();
+app.use(router.routes());
+app.use(router.allowedMethods());
+
+app.listen({ port: 3000 });
+````
+
+</TabPanel>
+<TabPanel id="hono" label="Hono">
+```ts
+import { Hono } from 'https://deno.land/x/hono/mod.ts';
+import type { Context } from 'https://deno.land/x/hono/mod.ts';
+
+// You can set the basePath with Hono
+const functionName = 'routing'
+const app = new Hono().basePath(`/${functionName}`)
+
+// /tasks/id
+app.get('/:id', async (c: Context) => {
+const id = c.req.param('id');
+const task = {}; // Fetch task by id here
+if (task) {
+return new Response(JSON.stringify(task));
+} else {
+return new Response('Task not found', { status: 404 });
+}
+});
+
+app.patch('/:id', async (c: Context) => {
+const id = c.req.param('id');
+const body = await c.req.body();
+const updates = body.value;
+const task = {}; // Fetch task by id here
+if (task) {
+Object.assign(task, updates);
+return new Response(JSON.stringify(task));
+} else {
+return new Response('Task not found', { status: 404 });
+}
+});
+
+app.delete('/:id', async (c: Context) => {
+const id = c.req.param('id');
+const task = {}; // Fetch task by id here
+if (task) {
+// Delete task
+return new Response('Task deleted successfully');
+} else {
+return new Response('Task not found', { status: 404 });
+}
+});
+
+Deno.serve(app.fetch);
+
+````
+</TabPanel>
+<TabPanel id="deno" label="Deno">
+```ts
+interface Task {
+ id: string;
+ name: string;
+}
+
+let tasks: Task[] = [];
+
+const router = new Map<string, (req: Request) => Promise<Response>>();
+
+async function getAllTasks(): Promise<Response> {
+ return new Response(JSON.stringify(tasks));
+}
+
+async function getTask(id: string): Promise<Response> {
+ const task = tasks.find(t => t.id === id);
+ if (task) {
+    return new Response(JSON.stringify(task));
+ } else {
+    return new Response('Task not found', { status: 404 });
+ }
+}
+
+async function createTask(req: Request): Promise<Response> {
+ const id = Math.random().toString(36).substring(7);
+ const task = { id, name: ''};
+ tasks.push(task);
+ return new Response(JSON.stringify(task), { status: 201 });
+}
+
+async function updateTask(id: string, req: Request): Promise<Response> {
+ const index = tasks.findIndex(t => t.id === id);
+ if (index !== -1) {
+    tasks[index] = { ...tasks[index] };
+    return new Response(JSON.stringify(tasks[index]));
+ } else {
+    return new Response('Task not found', { status: 404 });
+ }
+}
+
+async function deleteTask(id: string): Promise<Response> {
+ const index = tasks.findIndex(t => t.id === id);
+ if (index !== -1) {
+    tasks.splice(index, 1);
+    return new Response('Task deleted successfully');
+ } else {
+    return new Response('Task not found', { status: 404 });
+ }
+}
+
+Deno.serve(async (req) => {
+  const url = new URL(req.url);
+  const method = req.method;
+  // Extract the last part of the path as the command
+  const command = url.pathname.split("/").pop();
+  // Assuming the last part of the path is the task ID
+  const id = command;
+  try {
+     switch (method) {
+       case 'GET':
+         if (id) {
+           return getTask(id);
+         } else {
+           return getAllTasks();
+         }
+       case 'POST':
+         return createTask(req);
+       case 'PUT':
+         if (id) {
+           return updateTask(id, req);
+         } else {
+           return new Response('Bad Request', { status: 400 });
+         }
+       case 'DELETE':
+         if (id) {
+           return deleteTask(id);
+         } else {
+           return new Response('Bad Request', { status: 400 });
+         }
+       default:
+         return new Response('Method Not Allowed', { status: 405 });
+     }
+  } catch (error) {
+     return new Response(`Internal Server Error: ${error}`, { status: 500 });
+  }
+ });
+````
+
+</TabPanel>
 ## URL Patterns API
 
 If you prefer not to use a web framework, you can directly use [URLPattern API](https://developer.mozilla.org/en-US/docs/Web/API/URL_Pattern_API) within your Edge Functions to implement routing.

--- a/apps/docs/content/guides/functions/routing.mdx
+++ b/apps/docs/content/guides/functions/routing.mdx
@@ -81,7 +81,7 @@ app.use(router.allowedMethods());
 
 app.listen({ port: 3000 });
 
-```
+````
 
 </TabPanel>
 
@@ -103,7 +103,7 @@ return new Response('Hello World!')
 
 Deno.serve(app.fetch);
 
-```
+````
 
 </TabPanel>
 
@@ -203,7 +203,7 @@ const id = req.params.id
 // delete task
 })
 
-```
+````
 </TabPanel>
 
 <TabPanel id="oak" label="Oak">
@@ -267,15 +267,15 @@ app.use(router.routes());
 app.use(router.allowedMethods());
 
 app.listen({ port: 3000 });
-```
+````
 
 </TabPanel>
 
 <TabPanel id="hono" label="Hono">
 
 ```ts
-import { Hono } from 'https://deno.land/x/hono/mod.ts';
-import type { Context } from 'https://deno.land/x/hono/mod.ts';
+import { Hono } from 'https://deno.land/x/hono/mod.ts'
+import type { Context } from 'https://deno.land/x/hono/mod.ts'
 
 // You can set the basePath with Hono
 const functionName = 'routing'
@@ -283,41 +283,40 @@ const app = new Hono().basePath(`/${functionName}`)
 
 // /tasks/id
 app.get('/:id', async (c: Context) => {
-const id = c.req.param('id');
-const task = {}; // Fetch task by id here
-if (task) {
-return new Response(JSON.stringify(task));
-} else {
-return new Response('Task not found', { status: 404 });
-}
-});
+  const id = c.req.param('id')
+  const task = {} // Fetch task by id here
+  if (task) {
+    return new Response(JSON.stringify(task))
+  } else {
+    return new Response('Task not found', { status: 404 })
+  }
+})
 
 app.patch('/:id', async (c: Context) => {
-const id = c.req.param('id');
-const body = await c.req.body();
-const updates = body.value;
-const task = {}; // Fetch task by id here
-if (task) {
-Object.assign(task, updates);
-return new Response(JSON.stringify(task));
-} else {
-return new Response('Task not found', { status: 404 });
-}
-});
+  const id = c.req.param('id')
+  const body = await c.req.body()
+  const updates = body.value
+  const task = {} // Fetch task by id here
+  if (task) {
+    Object.assign(task, updates)
+    return new Response(JSON.stringify(task))
+  } else {
+    return new Response('Task not found', { status: 404 })
+  }
+})
 
 app.delete('/:id', async (c: Context) => {
-const id = c.req.param('id');
-const task = {}; // Fetch task by id here
-if (task) {
-// Delete task
-return new Response('Task deleted successfully');
-} else {
-return new Response('Task not found', { status: 404 });
-}
-});
+  const id = c.req.param('id')
+  const task = {} // Fetch task by id here
+  if (task) {
+    // Delete task
+    return new Response('Task deleted successfully')
+  } else {
+    return new Response('Task not found', { status: 404 })
+  }
+})
 
-Deno.serve(app.fetch);
-
+Deno.serve(app.fetch)
 ```
 
 </TabPanel>
@@ -326,90 +325,90 @@ Deno.serve(app.fetch);
 
 ```ts
 interface Task {
- id: string;
- name: string;
+  id: string
+  name: string
 }
 
-let tasks: Task[] = [];
+let tasks: Task[] = []
 
-const router = new Map<string, (req: Request) => Promise<Response>>();
+const router = new Map<string, (req: Request) => Promise<Response>>()
 
 async function getAllTasks(): Promise<Response> {
- return new Response(JSON.stringify(tasks));
+  return new Response(JSON.stringify(tasks))
 }
 
 async function getTask(id: string): Promise<Response> {
- const task = tasks.find(t => t.id === id);
- if (task) {
-    return new Response(JSON.stringify(task));
- } else {
-    return new Response('Task not found', { status: 404 });
- }
+  const task = tasks.find((t) => t.id === id)
+  if (task) {
+    return new Response(JSON.stringify(task))
+  } else {
+    return new Response('Task not found', { status: 404 })
+  }
 }
 
 async function createTask(req: Request): Promise<Response> {
- const id = Math.random().toString(36).substring(7);
- const task = { id, name: ''};
- tasks.push(task);
- return new Response(JSON.stringify(task), { status: 201 });
+  const id = Math.random().toString(36).substring(7)
+  const task = { id, name: '' }
+  tasks.push(task)
+  return new Response(JSON.stringify(task), { status: 201 })
 }
 
 async function updateTask(id: string, req: Request): Promise<Response> {
- const index = tasks.findIndex(t => t.id === id);
- if (index !== -1) {
-    tasks[index] = { ...tasks[index] };
-    return new Response(JSON.stringify(tasks[index]));
- } else {
-    return new Response('Task not found', { status: 404 });
- }
+  const index = tasks.findIndex((t) => t.id === id)
+  if (index !== -1) {
+    tasks[index] = { ...tasks[index] }
+    return new Response(JSON.stringify(tasks[index]))
+  } else {
+    return new Response('Task not found', { status: 404 })
+  }
 }
 
 async function deleteTask(id: string): Promise<Response> {
- const index = tasks.findIndex(t => t.id === id);
- if (index !== -1) {
-    tasks.splice(index, 1);
-    return new Response('Task deleted successfully');
- } else {
-    return new Response('Task not found', { status: 404 });
- }
+  const index = tasks.findIndex((t) => t.id === id)
+  if (index !== -1) {
+    tasks.splice(index, 1)
+    return new Response('Task deleted successfully')
+  } else {
+    return new Response('Task not found', { status: 404 })
+  }
 }
 
 Deno.serve(async (req) => {
-  const url = new URL(req.url);
-  const method = req.method;
+  const url = new URL(req.url)
+  const method = req.method
   // Extract the last part of the path as the command
-  const command = url.pathname.split("/").pop();
+  const command = url.pathname.split('/').pop()
   // Assuming the last part of the path is the task ID
-  const id = command;
+  const id = command
   try {
-     switch (method) {
-       case 'GET':
-         if (id) {
-           return getTask(id);
-         } else {
-           return getAllTasks();
-         }
-       case 'POST':
-         return createTask(req);
-       case 'PUT':
-         if (id) {
-           return updateTask(id, req);
-         } else {
-           return new Response('Bad Request', { status: 400 });
-         }
-       case 'DELETE':
-         if (id) {
-           return deleteTask(id);
-         } else {
-           return new Response('Bad Request', { status: 400 });
-         }
-       default:
-         return new Response('Method Not Allowed', { status: 405 });
-     }
+    switch (method) {
+      case 'GET':
+        if (id) {
+          return getTask(id)
+        } else {
+          return getAllTasks()
+        }
+      case 'POST':
+        return createTask(req)
+      case 'PUT':
+        if (id) {
+          return updateTask(id, req)
+        } else {
+          return new Response('Bad Request', { status: 400 })
+        }
+      case 'DELETE':
+        if (id) {
+          return deleteTask(id)
+        } else {
+          return new Response('Bad Request', { status: 400 })
+        }
+      default:
+        return new Response('Method Not Allowed', { status: 405 })
+    }
   } catch (error) {
-     return new Response(`Internal Server Error: ${error}`, { status: 500 });
+    return new Response(`Internal Server Error: ${error}`, { status: 500 })
   }
- });
+})
 ```
 
 </TabPanel>

--- a/apps/docs/content/guides/functions/routing.mdx
+++ b/apps/docs/content/guides/functions/routing.mdx
@@ -278,8 +278,8 @@ import { Hono } from 'https://deno.land/x/hono/mod.ts'
 import type { Context } from 'https://deno.land/x/hono/mod.ts'
 
 // You can set the basePath with Hono
-const functionName = 'tasks';
-const app = new Hono().basePath(`/${functionName}`);
+const functionName = 'tasks'
+const app = new Hono().basePath(`/${functionName}`)
 
 // /tasks/id
 app.get('/:id', async (c: Context) => {
@@ -290,7 +290,7 @@ app.get('/:id', async (c: Context) => {
   } else {
     return new Response('Task not found', { status: 404 })
   }
-});
+})
 
 app.patch('/:id', async (c: Context) => {
   const id = c.req.param('id')
@@ -303,7 +303,7 @@ app.patch('/:id', async (c: Context) => {
   } else {
     return new Response('Task not found', { status: 404 })
   }
-});
+})
 
 app.delete('/:id', async (c: Context) => {
   const id = c.req.param('id')
@@ -314,9 +314,9 @@ app.delete('/:id', async (c: Context) => {
   } else {
     return new Response('Task not found', { status: 404 })
   }
-});
+})
 
-Deno.serve(app.fetch);
+Deno.serve(app.fetch)
 ```
 
 </TabPanel>
@@ -408,7 +408,7 @@ Deno.serve(async (req) => {
   } catch (error) {
     return new Response(`Internal Server Error: ${error}`, { status: 500 })
   }
-});
+})
 ```
 
 </TabPanel>

--- a/apps/docs/content/guides/functions/routing.mdx
+++ b/apps/docs/content/guides/functions/routing.mdx
@@ -36,6 +36,7 @@ supabase functions new hello-world
 Copy and paste the following code:
 
 <TabPanel id="expressjs" label="Express">
+
 ```ts
 import express from 'npm:express@4.18.2'
 
@@ -44,20 +45,21 @@ app.use(express.json())
 const port = 3000
 
 app.get('/hello-world', (req, res) => {
-res.send('Hello World!')
+  res.send('Hello World!')
 })
 
 app.post('/hello-world', (req, res) => {
-const { name } = req.body
-res.send(`Hello ${name}!`)
+  const { name } = req.body
+  res.send(`Hello ${name}!`)
 })
 
 app.listen(port, () => {
-console.log(`Example app listening on port ${port}`)
+  console.log(`Example app listening on port ${port}`)
 })
+```
 
-````
 </TabPanel>
+
 <TabPanel id="oak" label="Oak">
 ```ts
 import { Application } from "jsr:@oak/oak@15/application";
@@ -66,12 +68,12 @@ import { Router } from "jsr:@oak/oak@15/router";
 const router = new Router();
 
 router.get("/hello-world", (ctx) => {
-  return new Response("Hello World!", {status: 200});
+return new Response("Hello World!", {status: 200});
 });
 
 router.post("/hello-world", async (ctx) => {
-  const { name } = await ctx.request.body.json();
-  ctx.response.body = `Hello ${name}!`;
+const { name } = await ctx.request.body.json();
+ctx.response.body = `Hello ${name}!`;
 });
 
 const app = new Application();
@@ -102,6 +104,7 @@ return new Response('Hello World!')
 Deno.serve(app.fetch);
 
 ````
+
 </TabPanel>
 <TabPanel id="deno" label="Deno">
 ```ts
@@ -115,9 +118,10 @@ Deno.serve(async (req) => {
   }
   return new Response('Hello World!')
 });
-````
+```
 
 </TabPanel>
+</Tabs>
 You will notice in the above example, we created two routes - `GET` and `POST`. The path for both routes are defined as `/hello-world`.
 If you run a server outside of Edge Functions, you'd usually set the root path as `/` .
 However, within Edge Functions, paths should always be prefixed with the function name (in this case `hello-world`).
@@ -157,6 +161,13 @@ We can use route parameters to capture values at specific URL segments (eg: `/ta
 Here's an example Edge Function implemented using the Framework for managing tasks using route parameters.
 Keep in mind paths must be prefixed by function name (ie. `tasks` in this example). Route parameters can only be used after the function name prefix.
 
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  defaultActiveId="Hono"
+  queryGroup="framework"
+>
 <TabPanel id="expressjs" label="Express">
 ```ts
 import express from 'npm:express@4.18.2'
@@ -392,6 +403,7 @@ Deno.serve(async (req) => {
 ````
 
 </TabPanel>
+</Tabs>
 ## URL Patterns API
 
 If you prefer not to use a web framework, you can directly use [URLPattern API](https://developer.mozilla.org/en-US/docs/Web/API/URL_Pattern_API) within your Edge Functions to implement routing.


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Improve the guides for routing Edge Functions to show examples in different frameworks

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
