### PR TITLE
fix: revert renaming vector to pgvector on the client

### DIFF
--- a/apps/docs/content/guides/ai/vector-columns.mdx
+++ b/apps/docs/content/guides/ai/vector-columns.mdx
@@ -24,7 +24,7 @@ Vectors in Supabase are enabled via [pgvector](https://github.com/pgvector/pgvec
 
 1. Go to the [Database](https://supabase.com/dashboard/project/_/database/tables) page in the Dashboard.
 2. Click on **Extensions** in the sidebar.
-3. Search for "pgvector" and enable the extension.
+3. Search for "vector" and enable the extension.
 
 </TabPanel>
 <TabPanel id="sql" label="SQL">

--- a/apps/docs/content/guides/ai/vector-columns.mdx
+++ b/apps/docs/content/guides/ai/vector-columns.mdx
@@ -30,12 +30,12 @@ Vectors in Supabase are enabled via [pgvector](https://github.com/pgvector/pgvec
 <TabPanel id="sql" label="SQL">
 
 ```sql
- -- Example: enable the pgvector extension.
+ -- Example: enable the "vector" extension.
 create extension vector
 with
   schema extensions;
 
--- Example: disable the pgvector extension
+-- Example: disable the "vector" extension
 drop
   extension if exists vector;
 ```

--- a/apps/docs/content/guides/database/extensions/pgvector.mdx
+++ b/apps/docs/content/guides/database/extensions/pgvector.mdx
@@ -33,18 +33,18 @@ This is particularly useful if you're building on top of OpenAI's [GPT-3](https:
 
 1. Go to the [Database](https://supabase.com/dashboard/project/_/database/tables) page in the Dashboard.
 2. Click on **Extensions** in the sidebar.
-3. Search for "pgvector" and enable the extension.
+3. Search for "vector" and enable the extension.
 
 </TabPanel>
 <TabPanel id="sql" label="SQL">
 
 ```sql
- -- Example: enable the pgvector extension.
+ -- Example: enable the "vector" extension.
 create extension vector
 with
   schema extensions;
 
--- Example: disable the pgvector extension
+-- Example: disable the "vector" extension
 drop
   extension if exists vector;
 ```

--- a/apps/docs/content/guides/database/extensions/pgvector.mdx
+++ b/apps/docs/content/guides/database/extensions/pgvector.mdx
@@ -6,6 +6,12 @@ description: 'pgvector: a PostgreSQL extension for storing embeddings and perfor
 
 [pgvector](https://github.com/pgvector/pgvector/) is a PostgreSQL extension for vector similarity search. It can also be used for storing [embeddings](https://supabase.com/blog/openai-embeddings-postgres-vector).
 
+<Admonition type="note">
+
+The name of pgvector's Postgres extension is [vector](https://github.com/pgvector/pgvector/blob/258eaf58fdaff1843617ff59ea855e0768243fe9/README.md?plain=1#L64).
+
+</Admonition>
+
 Learn more about Supabase's [AI & Vector](/docs/guides/ai) offering.
 
 ## Concepts

--- a/apps/studio/components/interfaces/Database/Extensions/ExtensionCard.tsx
+++ b/apps/studio/components/interfaces/Database/Extensions/ExtensionCard.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link'
 import { useState } from 'react'
 import toast from 'react-hot-toast'
 import { extensions } from 'shared-data'
-import { Badge, IconExternalLink, IconLoader, Toggle } from 'ui'
+import { Badge, IconExternalLink, IconLoader, Modal, Toggle } from 'ui'
 import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
 
 import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
@@ -72,7 +72,7 @@ const ExtensionCard = ({ extension }: ExtensionCardProps) => {
                 title={extension.name}
                 className="h-5 m-0 text-sm truncate cursor-pointer text-foreground"
               >
-                {extension.altName || extension.name}
+                {extension.name}
               </h3>
               <p className="text-sm text-foreground-light">
                 {extension?.installed_version ?? extension.default_version}

--- a/apps/studio/components/interfaces/Database/Extensions/Extensions.constants.ts
+++ b/apps/studio/components/interfaces/Database/Extensions/Extensions.constants.ts
@@ -17,3 +17,7 @@ export const HIDDEN_EXTENSIONS = [
   'xml2',
   'pg_tle',
 ]
+
+export const SEARCH_TERMS: Record<string, string[]> = {
+  vector: ['pgvector', 'pg_vector'],
+}

--- a/apps/studio/components/interfaces/Database/Extensions/Extensions.tsx
+++ b/apps/studio/components/interfaces/Database/Extensions/Extensions.tsx
@@ -13,7 +13,7 @@ import { useDatabaseExtensionsQuery } from 'data/database-extensions/database-ex
 import { useCheckPermissions, usePermissionsLoaded } from 'hooks'
 import ExtensionCard from './ExtensionCard'
 import ExtensionCardSkeleton from './ExtensionCardSkeleton'
-import { HIDDEN_EXTENSIONS } from './Extensions.constants'
+import { HIDDEN_EXTENSIONS, SEARCH_TERMS } from './Extensions.constants'
 
 const Extensions = () => {
   const { filter } = useParams()
@@ -25,17 +25,16 @@ const Extensions = () => {
     connectionString: project?.connectionString,
   })
 
-  const formattedExtensions = (data ?? []).map((ext) => {
-    if (ext.name === 'vector') return { ...ext, name: 'pgvector' }
-    else return ext
-  })
-
   const extensions =
     filterString.length === 0
-      ? formattedExtensions
-      : formattedExtensions.filter((ext) =>
-          ext.name.toLowerCase().includes(filterString.toLowerCase())
-        )
+      ? data ?? []
+      : (data ?? []).filter((ext) => {
+          const nameMatchesSearch = ext.name.toLowerCase().includes(filterString.toLowerCase())
+          const searchTermsMatchesSearch = (SEARCH_TERMS[ext.name] || []).some((x) =>
+            x.includes(filterString.toLowerCase())
+          )
+          return nameMatchesSearch || searchTermsMatchesSearch
+        })
   const extensionsWithoutHidden = extensions.filter((ext) => !HIDDEN_EXTENSIONS.includes(ext.name))
   const [enabledExtensions, disabledExtensions] = partition(
     extensionsWithoutHidden,

--- a/apps/studio/components/interfaces/Database/Extensions/Extensions.tsx
+++ b/apps/studio/components/interfaces/Database/Extensions/Extensions.tsx
@@ -26,7 +26,7 @@ const Extensions = () => {
   })
 
   const formattedExtensions = (data ?? []).map((ext) => {
-    if (ext.name === 'vector') return { ...ext, altName: 'pgvector' }
+    if (ext.name === 'vector') return { ...ext, name: 'pgvector' }
     else return ext
   })
 
@@ -34,7 +34,7 @@ const Extensions = () => {
     filterString.length === 0
       ? formattedExtensions
       : formattedExtensions.filter((ext) =>
-          (ext?.altName ?? ext.name).toLowerCase().includes(filterString.toLowerCase())
+          ext.name.toLowerCase().includes(filterString.toLowerCase())
         )
   const extensionsWithoutHidden = extensions.filter((ext) => !HIDDEN_EXTENSIONS.includes(ext.name))
   const [enabledExtensions, disabledExtensions] = partition(

--- a/apps/studio/data/database-extensions/database-extensions-query.ts
+++ b/apps/studio/data/database-extensions/database-extensions-query.ts
@@ -2,16 +2,10 @@ import { UseQueryOptions, useQuery } from '@tanstack/react-query'
 import { get } from 'data/fetchers'
 import type { ResponseError } from 'types'
 import { databaseExtensionsKeys } from './keys'
-import { components } from 'api-types'
 
 export type DatabaseExtensionsVariables = {
   projectRef?: string
   connectionString?: string
-}
-
-export type Extension = components['schemas']['PostgresExtension']
-export interface DatabaseExtension extends Extension {
-  altName?: string
 }
 
 export async function getDatabaseExtensions(
@@ -37,7 +31,7 @@ export async function getDatabaseExtensions(
   })
 
   if (error) throw error
-  return data as DatabaseExtension[]
+  return data
 }
 
 export type DatabaseExtensionsData = Awaited<ReturnType<typeof getDatabaseExtensions>>

--- a/packages/shared-data/extensions.json
+++ b/packages/shared-data/extensions.json
@@ -396,7 +396,7 @@
     "link": "/guides/database/extensions/uuid-ossp"
   },
   {
-    "name": "pgvector",
+    "name": "vector",
     "comment": "vector data type with similarity search",
     "tags": ["AI", "Data Type", "Search"],
     "link": "/guides/database/extensions/pgvector"


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

fix

## What is the new behavior?

- Revert changes made to the `vector` extension name.
- Add to pgvector docs that the extension name is `vector`.
- Add a link to pgvector docs from Studio > pgvector extension card.

## Note

~Do not run formatter on docs.~