### PR TITLE
fix: branch query enabling condition

### DIFF
--- a/apps/studio/components/interfaces/BranchManagement/BranchPanels.tsx
+++ b/apps/studio/components/interfaces/BranchManagement/BranchPanels.tsx
@@ -107,7 +107,7 @@ export const BranchRow = ({
   const { data } = useBranchQuery(
     { projectRef, id: branch.id },
     {
-      enabled: branch.status === 'CREATING_PROJECT' && inView,
+      enabled: inView,
       refetchInterval(data) {
         if (data?.status !== 'ACTIVE_HEALTHY') {
           return 1000 * 3 // 3 seconds


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behaviour?

Branch reset might be disabled even if a project was active healthy because we aren't always querying for the project status

## What is the new behaviour?

We'll now always know if a branch is active healthy or not because we query for it