### PR TITLE
tests: Add playwright example with network mocks

### DIFF
--- a/playwright-tests/tests/fixtures/projects.json
+++ b/playwright-tests/tests/fixtures/projects.json
@@ -1,0 +1,29 @@
+[
+  {
+    "id": 25491,
+    "ref": "default",
+    "name": "Segment Production",
+    "status": "ACTIVE_HEALTHY",
+    "organization_id": 1,
+    "inserted_at": "2021-06-16T04:03:09.700217",
+    "subscription_id": "sub_subscription_id",
+    "cloud_provider": "AWS",
+    "region": "us-east-1",
+    "disk_volume_size_gb": 2373,
+    "size": "m6g.large",
+    "db_user_supabase": "db_user_supabase",
+    "db_pass_supabase": "db_pass_supabase",
+    "db_dns_name": "12.123.123.123",
+    "db_host": "db.projectref.supabase.co",
+    "db_port": 5432,
+    "db_name": "postgres",
+    "ssl_enforced": false,
+    "read_replicas_enabled": false,
+    "walg_enabled": true,
+    "infra_compute_size": "large",
+    "preview_branch_refs": [],
+    "is_branch_enabled": false,
+    "is_read_replicas_enabled": false,
+    "is_physical_backups_enabled": true
+  }
+]

--- a/playwright-tests/tests/fixtures/projects/default.json
+++ b/playwright-tests/tests/fixtures/projects/default.json
@@ -1,0 +1,28 @@
+{
+  "cloud_provider": "AWS",
+  "db_host": "db.projectref.supabase.co",
+  "id": 2137,
+  "inserted_at": "2023-01-30T16:07:16.040884",
+  "name": "[LIVE] supabase-com",
+  "organization_id": 1,
+  "ref": "projectref",
+  "region": "us-east-1",
+  "status": "ACTIVE_HEALTHY",
+  "subscription_id": "sub_subscription_id",
+  "connectionString": "connectionString",
+  "restUrl": "https://projectref.supabase.co/rest/v1/",
+  "volumeSizeGb": 8,
+  "maxDatabasePreprovisionGb": null,
+  "lastDatabaseResizeAt": null,
+  "is_branch_enabled": true,
+  "is_read_replicas_enabled": true,
+  "is_physical_backups_enabled": false,
+  "infra_compute_size": "micro",
+  "kpsVersion": "supabase-postgres-15.1.0.33",
+  "dbVersion": "supabase-postgres-15.1.0.33",
+  "serviceVersions": {
+    "gotrue": "2.150.1",
+    "postgrest": "10.2.0",
+    "supabase-postgres": "15.1.0.33"
+  }
+}

--- a/playwright-tests/tests/snapshot/spec/overview.spec.ts
+++ b/playwright-tests/tests/snapshot/spec/overview.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test } from '@playwright/test'
+import * as path from 'path'
+import * as fs from 'fs/promises'
+
+test.describe('Project Overview', () => {
+  // Global mock
+  test.beforeEach(async ({ context }) => {
+    await context.route('**/api/projects', async (route) =>
+      route.fulfill({
+        status: 200,
+        body: await fs.readFile(path.resolve(__dirname, '../../fixtures/projects.json'), 'utf-8'),
+      })
+    )
+  })
+
+  test('should have a heading with project name', async ({ page }) => {
+    page.on('request', (request) => console.log('>>', request.method(), request.url()))
+    page.on('response', (response) => console.log('<<', response.status(), response.url()))
+
+    // Local mock
+    await page.route('**/api/projects/default', async (route) =>
+      route.fulfill({
+        status: 200,
+        body: await fs.readFile(
+          path.resolve(__dirname, '../../fixtures/projects/default.json'),
+          'utf-8'
+        ),
+      })
+    )
+
+    await page.goto('/project/default')
+    await expect(page.getByText('[LIVE] supabase-com')).toBeVisible()
+  })
+})


### PR DESCRIPTION
```sh
npx playwright test tests/snapshot/spec/overview.spec.ts
```

Works out of the box, no need to run any other commands.

(Fixtures data is sanitized, just in case anyone wonders [edit: was with initial commit as well, made it more obvious now])