### PR TITLE
Fix wrapper label not present

### DIFF
--- a/apps/studio/components/interfaces/Database/Wrappers/CreateWrapper.tsx
+++ b/apps/studio/components/interfaces/Database/Wrappers/CreateWrapper.tsx
@@ -20,7 +20,8 @@ import { useDatabaseExtensionsQuery } from 'data/database-extensions/database-ex
 import { invalidateSchemasQuery } from 'data/database/schemas-query'
 import { useFDWCreateMutation } from 'data/fdw/fdw-create-mutation'
 import { useCheckPermissions } from 'hooks'
-import { Button, Form, IconArrowLeft, IconEdit, IconExternalLink, IconTrash, Input } from 'ui'
+import { ArrowLeft, ExternalLink } from 'lucide-react'
+import { Button, Form, IconArrowLeft, IconEdit, IconTrash, Input } from 'ui'
 import InputField from './InputField'
 import WrapperTableEditor from './WrapperTableEditor'
 import { WRAPPERS } from './Wrappers.constants'
@@ -167,14 +168,14 @@ const CreateWrapper = () => {
           >
             <Link href={`/project/${ref}/database/wrappers`}>
               <div className="flex items-center space-x-2">
-                <IconArrowLeft strokeWidth={1.5} size={14} />
+                <ArrowLeft strokeWidth={1.5} size={14} />
                 <p className="text-sm">Back</p>
               </div>
             </Link>
           </div>
           <h3 className="mb-2 text-xl text-foreground">Create a {wrapperMeta.label} Wrapper</h3>
           <div className="flex items-center space-x-2">
-            <Button asChild type="default" icon={<IconExternalLink strokeWidth={1.5} />}>
+            <Button asChild type="default" icon={<ExternalLink strokeWidth={1.5} />}>
               <Link href={wrapperMeta.docsUrl} target="_blank" rel="noreferrer">
                 Documentation
               </Link>
@@ -268,7 +269,7 @@ const CreateWrapper = () => {
                                 {table.schema_name}.{table.table_name}
                               </p>
                               <p className="text-sm text-foreground-light">
-                                {wrapperMeta.tables[table.index].label}:{' '}
+                                Columns:{' '}
                                 {table.columns.map((column: any) => column.name).join(', ')}
                               </p>
                             </div>

--- a/apps/studio/components/interfaces/Database/Wrappers/EditWrapper.tsx
+++ b/apps/studio/components/interfaces/Database/Wrappers/EditWrapper.tsx
@@ -338,7 +338,7 @@ const EditWrapper = () => {
                     ) : (
                       <div className="space-y-2">
                         {wrapperTables.map((table, i) => {
-                          const label = wrapperMeta.tables[table.index].label
+                          const label = wrapperMeta.tables[table.index]?.label
 
                           return (
                             <div

--- a/apps/studio/components/interfaces/Database/Wrappers/EditWrapper.tsx
+++ b/apps/studio/components/interfaces/Database/Wrappers/EditWrapper.tsx
@@ -41,6 +41,7 @@ import {
   makeValidateRequired,
 } from './Wrappers.utils'
 import WrapperTableEditor from './WrapperTableEditor'
+import { ArrowLeft, ExternalLink } from 'lucide-react'
 
 const EditWrapper = () => {
   const formId = 'edit-wrapper-form'
@@ -182,14 +183,16 @@ const EditWrapper = () => {
           >
             <Link href={`/project/${ref}/database/wrappers`}>
               <div className="flex items-center space-x-2">
-                <IconArrowLeft strokeWidth={1.5} size={14} />
+                <ArrowLeft strokeWidth={1.5} size={14} />
                 <p className="text-sm">Back</p>
               </div>
             </Link>
           </div>
-          <h3 className="mb-2 text-xl text-foreground">Edit wrapper: {wrapper.name}</h3>
+          <h3 className="mb-2 text-xl text-foreground">
+            Edit {wrapperMeta.label} wrapper: {wrapper.name}
+          </h3>
           <div className="flex items-center space-x-2">
-            <Button asChild type="default" icon={<IconExternalLink strokeWidth={1.5} />}>
+            <Button asChild type="default" icon={<ExternalLink strokeWidth={1.5} />}>
               <Link
                 href="https://supabase.github.io/wrappers/stripe/"
                 target="_blank"
@@ -339,6 +342,7 @@ const EditWrapper = () => {
                       <div className="space-y-2">
                         {wrapperTables.map((table, i) => {
                           const label = wrapperMeta.tables[table.index]?.label
+                          const target = table?.table ?? table.object
 
                           return (
                             <div
@@ -347,10 +351,13 @@ const EditWrapper = () => {
                             >
                               <div>
                                 <p className="text-sm">
-                                  {table.schema_name}.{table.table_name}
+                                  {table.schema_name}.{table.table_name}{' '}
+                                </p>
+                                <p className="text-sm text-foreground-light mt-1">
+                                  Target: {target}
                                 </p>
                                 <p className="text-sm text-foreground-light">
-                                  {label}:{' '}
+                                  Columns:{' '}
                                   {table.columns.map((column: any) => column.name).join(', ')}
                                 </p>
                               </div>

--- a/apps/studio/components/interfaces/Database/Wrappers/Wrappers.constants.ts
+++ b/apps/studio/components/interfaces/Database/Wrappers/Wrappers.constants.ts
@@ -46,6 +46,57 @@ export const WRAPPERS: WrapperMeta[] = [
     },
     tables: [
       {
+        label: 'Accounts',
+        description: 'List of accounts on your Stripe account',
+        availableColumns: [
+          {
+            name: 'id',
+            type: 'text',
+          },
+          {
+            name: 'business_type',
+            type: 'text',
+          },
+          {
+            name: 'country',
+            type: 'text',
+          },
+          {
+            name: 'email',
+            type: 'text',
+          },
+          {
+            name: 'type',
+            type: 'text',
+          },
+          {
+            name: 'created',
+            type: 'timestamp',
+          },
+          {
+            name: 'attrs',
+            type: 'jsonb',
+          },
+        ],
+        options: [
+          {
+            name: 'object',
+            defaultValue: 'accounts',
+            editable: false,
+            required: true,
+            type: 'text',
+          },
+          {
+            name: 'rowid_column',
+            label: 'Row ID Column',
+            defaultValue: 'id',
+            editable: true,
+            required: true,
+            type: 'text',
+          },
+        ],
+      },
+      {
         label: 'Balance',
         description: 'The balance currently on your Stripe account',
         availableColumns: [


### PR DESCRIPTION
if user creates wrapper with sql and doesn't have a lable present, the page crashes

To reproduce: 
1. run this https://gist.github.com/saltcod/140a95d3161bf259c704efcd96dffecd
2. visit Database → wrappers → open Stripe wrapper
3. click Edit https://share.cleanshot.com/VMDcJcrG

Page crashes b/c label expected 

https://app.hubspot.com/contacts/19953346/record/0-5/2561901162