### PR TITLE
fix: sanitize NNBF characters in uploaded files

### DIFF
--- a/apps/studio/localStores/storageExplorer/StorageExplorerStore.tsx
+++ b/apps/studio/localStores/storageExplorer/StorageExplorerStore.tsx
@@ -561,7 +561,14 @@ class StorageExplorerStore {
       const fileName = !isWithinFolder
         ? this.sanitizeNameForDuplicateInColumn(file.name, autofix)
         : file.name
-      const formattedFileName = has(file, ['path']) && isWithinFolder ? file.path : fileName
+      const unsanitizedFormattedFileName =
+        has(file, ['path']) && isWithinFolder ? file.path : fileName
+      /**
+       * Storage maintains a list of allowed characters, which excludes
+       * characters such as the narrow no-break space used in Mac screenshots.
+       * To preempt errors, replace all non-word characters with underscores.
+       */
+      const formattedFileName = unsanitizedFormattedFileName.replace(/[^\w.-]/g, '_')
       const formattedPathToFile =
         pathToFile.length > 0 ? `${pathToFile}/${formattedFileName}` : formattedFileName
 


### PR DESCRIPTION
MacOS 14.0+ uses a narrow no-break space (U+202F) in the timestamp of automatically named screenshots (12-hour clock only). This is not a valid filename character for storage, and screenshots are probably a common-ish use case, so treat this as a special case and replace with a normal space.

See:

- https://forum.obsidian.md/t/unable-to-attach-screenshot-images-in-macos-14-0-when-wikilinks-turned-off-urlencode-u-202f-char/68410/6
- https://supabase.slack.com/archives/C0161K73J1J/p1715364364795329

**To test:**

- On a Mac, make sure your system is set to 12-hour clock.
- Take a screenshot **and save it with its default name.**
- Try uploading it to storage via the UI.