### PR TITLE
Fix fill color of checkbox icon

### DIFF
--- a/apps/studio/styles/grid.scss
+++ b/apps/studio/styles/grid.scss
@@ -170,7 +170,7 @@
   }
 
   [type='checkbox']:checked {
-    background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='black' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e");
+    background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e");
   }
 
   [type='checkbox']:checked {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

It fixes fill color of checkbox icon

## What is the current behavior?

Right now both the background color of checkbox in checked state and fill color of the checkmark icon are black -> icon is not visible

 
<img width="121" alt="Screenshot 2024-05-11 at 14 17 15" src="https://github.com/supabase/supabase/assets/80686534/db848bdf-de3f-453f-bdef-c171a0cd85bc">


## What is the new behavior?

When the checkbox is checked the icon will be white

