### PR TITLE
Fix: spelling error in countries quickstarts

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/SQLEditor.queries.ts
+++ b/apps/studio/components/interfaces/SQLEditor/SQLEditor.queries.ts
@@ -220,7 +220,7 @@ insert into public.countries (name,iso2,iso3,local_name,continent) values
   ('Central African Republic','CF','CAF','Centrafrique','Africa'),
   ('Chad','TD','TCD','Tchad/Tshad','Africa'),
   ('Chile','CL','CHL','Chile','South America'),
-  ('China','CN','CHN','Zhongquo','Asia'),
+  ('China','CN','CHN','Zhongguo','Asia'),
   ('Christmas Island','CX','CXR','Christmas Island','Oceania'),
   ('Cocos (Keeling) Islands','CC','CCK','Cocos (Keeling) Islands','Oceania'),
   ('Colombia','CO','COL','Colombia','South America'),


### PR DESCRIPTION
## What kind of change does this PR introduce?

Typo fix in China local_name "Zhongguo". 
