### PR TITLE
chore: adjust copy in addon update modal for partner billing[GEN-8953]

### DIFF
--- a/apps/studio/components/interfaces/Settings/Addons/CustomDomainSidePanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/CustomDomainSidePanel.tsx
@@ -255,35 +255,26 @@ const CustomDomainSidePanel = () => {
           {hasChanges && (
             <>
               {selectedOption === 'cd_none' ||
-              (selectedCustomDomain?.price ?? 0) < (subscriptionCDOption?.variant.price ?? 0) ? (
-                subscription?.billing_via_partner === false && (
-                  <p className="text-sm text-foreground-light">
-                    Upon clicking confirm, the add-on is removed immediately and any unused time in
-                    the current billing cycle is added as prorated credits to your organization and
-                    used in subsequent billing cycles.
-                  </p>
-                )
-              ) : (
-                <p className="text-sm text-foreground-light">
-                  Upon clicking confirm, the amount of{' '}
-                  <span className="text-foreground">
-                    {formatCurrency(selectedCustomDomain?.price)}
-                  </span>{' '}
-                  will be added to your monthly invoice.{' '}
-                  {subscription?.billing_via_partner ? (
-                    <>
-                      For the current billing cycle you'll be charged a prorated amount at the end
-                      of the cycle.{' '}
-                    </>
-                  ) : (
-                    <>
-                      The addon is prepaid per month and in case of a downgrade, you get credits for
-                      the remaining time. For the current billing cycle you're immediately charged a
-                      prorated amount for the remaining days.
-                    </>
+              (selectedCustomDomain?.price ?? 0) < (subscriptionCDOption?.variant.price ?? 0)
+                ? subscription?.billing_via_partner === false && (
+                    <p className="text-sm text-foreground-light">
+                      Upon clicking confirm, the add-on is removed immediately and any unused time
+                      in the current billing cycle is added as prorated credits to your organization
+                      and used in subsequent billing cycles.
+                    </p>
+                  )
+                : !subscription?.billing_via_partner && (
+                    <p className="text-sm text-foreground-light">
+                      Upon clicking confirm, the amount of{' '}
+                      <span className="text-foreground">
+                        {formatCurrency(selectedCustomDomain?.price)}
+                      </span>{' '}
+                      will be added to your monthly invoice. The addon is prepaid per month and in
+                      case of a downgrade, you get credits for the remaining time. For the current
+                      billing cycle you're immediately charged a prorated amount for the remaining
+                      days.
+                    </p>
                   )}
-                </p>
-              )}
 
               {subscription?.billing_via_partner &&
                 subscription.scheduled_plan_change?.target_plan !== undefined && (

--- a/apps/studio/components/interfaces/Settings/Addons/IPv4SidePanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/IPv4SidePanel.tsx
@@ -14,7 +14,7 @@ import { useCheckPermissions, useSelectedOrganization } from 'hooks'
 import { formatCurrency } from 'lib/helpers'
 import Telemetry from 'lib/telemetry'
 import { useSubscriptionPageStateSnapshot } from 'state/subscription-page'
-import { Alert, Button, IconExternalLink, Radio, SidePanel, cn } from 'ui'
+import { Alert, Button, cn, IconExternalLink, Radio, SidePanel } from 'ui'
 
 const IPv4SidePanel = () => {
   const router = useRouter()
@@ -224,10 +224,13 @@ const IPv4SidePanel = () => {
             <>
               {selectedOption === 'ipv4_none' ||
               (selectedIPv4?.price ?? 0) < (subscriptionIpV4Option?.variant.price ?? 0) ? (
-                <p className="text-sm text-foreground-light">
-                  Upon clicking confirm, the add-on is removed immediately and won't be billed in
-                  the future.
-                </p>
+                subscription?.billing_via_partner === false && (
+                  <p className="text-sm text-foreground-light">
+                    Upon clicking confirm, the add-on is removed immediately and any unused time in
+                    the current billing cycle is added as prorated credits to your organization and
+                    used in subsequent billing cycles.
+                  </p>
+                )
               ) : (
                 <>
                   <Alert withIcon variant="info" title="Potential downtime">
@@ -245,9 +248,17 @@ const IPv4SidePanel = () => {
                       Read replicas
                     </Link>{' '}
                     are used, each replica also gets its own IPv4 address, with a corresponding{' '}
-                    <span className="text-foreground">{formatCurrency(selectedIPv4?.price)}</span>
+                    <span className="text-foreground">{formatCurrency(selectedIPv4?.price)}</span>{' '}
                     charge.
                   </p>
+                  {!subscription?.billing_via_partner && (
+                    <p className="text-sm text-foreground-light">
+                      Upon clicking confirm, the respective amount will be added to your monthly
+                      invoice. The addon is prepaid per month and in case of a downgrade, you get
+                      credits for the remaining time. For the current billing cycle you're
+                      immediately charged a prorated amount for the remaining days.
+                    </p>
+                  )}
                 </>
               )}
             </>

--- a/apps/studio/components/interfaces/Settings/Addons/PITRSidePanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/PITRSidePanel.tsx
@@ -382,33 +382,24 @@ const PITRSidePanel = () => {
           {hasChanges && !blockDowngradeDueToReadReplicas && (
             <>
               {selectedOption === 'pitr_0' ||
-              (selectedPitr?.price ?? 0) < (subscriptionPitr?.variant.price ?? 0) ? (
-                subscription?.billing_via_partner === false && (
-                  <p className="text-sm text-foreground-light">
-                    Upon clicking confirm, the add-on is removed immediately and any unused time in
-                    the current billing cycle is added as prorated credits to your organization and
-                    used in subsequent billing cycles.
-                  </p>
-                )
-              ) : (
-                <p className="text-sm text-foreground-light">
-                  Upon clicking confirm, the amount of{' '}
-                  <span className="text-foreground">{formatCurrency(selectedPitr?.price)}</span>{' '}
-                  will be added to your monthly invoice.{' '}
-                  {subscription?.billing_via_partner ? (
-                    <>
-                      For the current billing cycle you'll be charged a prorated amount at the end
-                      of the cycle.{' '}
-                    </>
-                  ) : (
-                    <>
-                      The addon is prepaid per month and in case of a downgrade, you get credits for
-                      the remaining time. For the current billing cycle you're immediately charged a
-                      prorated amount for the remaining days.
-                    </>
+              (selectedPitr?.price ?? 0) < (subscriptionPitr?.variant.price ?? 0)
+                ? subscription?.billing_via_partner === false && (
+                    <p className="text-sm text-foreground-light">
+                      Upon clicking confirm, the add-on is removed immediately and any unused time
+                      in the current billing cycle is added as prorated credits to your organization
+                      and used in subsequent billing cycles.
+                    </p>
+                  )
+                : !subscription?.billing_via_partner && (
+                    <p className="text-sm text-foreground-light">
+                      Upon clicking confirm, the amount of{' '}
+                      <span className="text-foreground">{formatCurrency(selectedPitr?.price)}</span>{' '}
+                      will be added to your monthly invoice. The addon is prepaid per month and in
+                      case of a downgrade, you get credits for the remaining time. For the current
+                      billing cycle you're immediately charged a prorated amount for the remaining
+                      days.
+                    </p>
                   )}
-                </p>
-              )}
 
               {subscription?.billing_via_partner &&
                 subscription.scheduled_plan_change?.target_plan !== undefined && (


### PR DESCRIPTION
Removes sentences like
> “Upon clicking confirm, the amount of $10 will be added to your monthly invoice. For the current billing cycle you'll be charged a prorated amount at the end of the cycle.”

from the addon modal for both billing partners "AWS" and "Fly".
Reason is that this text is confusing given that we don't provide/send out monthly invoices to customers billed via a partner and we want to simplify things.

**Additional:**
I aligned the texts for the IPv4 addon with the other addons.
1. The text _"Upon clicking confirm, the add-on is removed..."_ is not displayed for partner billed customers
2. The text _"Upon clicking confirm, the respective amount will be added to your monthly invoice..."_ is displayed for non partner billed customers. We use the word "respective" instead of an exact amount because its $4 for each Read replica. This additional text not necessarily makes the modal arranged more clearly but I thought it would be better to be consistent across addons.
<img width="670" alt="Screenshot 2024-05-15 at 17 45 29" src="https://github.com/supabase/supabase/assets/31189692/ef065f50-45a3-4fdf-ab06-3d2ec3e3176c">
