### PR TITLE
Blog: Update status of pgvector v0.7.0 on platform

### DIFF
--- a/apps/www/_blog/2024-05-01-pgvector-0-7-0.mdx
+++ b/apps/www/_blog/2024-05-01-pgvector-0-7-0.mdx
@@ -185,4 +185,13 @@ For a more complete comparison of pgvector performance over the last year, check
 
 ### Using v0.7.0 in Supabase
 
-We're currently testing pgvector v0.7.0 in Supabase. Stay tuned - we expect to make this available some time next week.
+All new projects ship with pgvector v0.7.0 (or later). Be sure to enable the extension if you haven't already:
+
+```sql
+create extension if not exists vector
+with
+  schema extensions;
+```
+
+If you are unsure which version of pgvector your project is using, search for `vector` on the [Extensions page](https://supabase.com/dashboard/project/_/database/extensions). If you are using a previous version, you can upgrade
+by navigating to the **Service Versions** section on the [Infrastructure page](https://supabase.com/dashboard/project/_/settings/infrastructure) and upgrading your Postgres version to `15.1.1.47` or later.


### PR DESCRIPTION
pgvector v0.7.0 is now available on the platform. 

Updates last section of pgvector v0.7.0 blog post with this info and instructions on how to upgrade to v0.7.0.