### PR TITLE
chore: adjust copy for partner billed org when up/downgrading plan [GEN-8952]

### DIFF
--- a/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/PlanUpdateSidePanel.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/PlanUpdateSidePanel.tsx
@@ -547,10 +547,15 @@ const PlanUpdateSidePanel = () => {
             <div className="py-4 space-y-2">
               <p className="text-sm">
                 This organization is billed through our partner{' '}
-                {billingPartnerLabel(subscription?.billing_partner)} and you will be charged by them
-                directly.
+                {billingPartnerLabel(billingPartner)}.{' '}
+                {billingPartner === 'aws' ? (
+                  <>The organization's credit balance will be decreased accordingly.</>
+                ) : (
+                  <>You will be charged by them directly.</>
+                )}
               </p>
-              {subscriptionPreview?.billed_via_partner &&
+              {billingViaPartner &&
+                billingPartner === 'fly' &&
                 subscriptionPreview?.plan_change_type === 'downgrade' && (
                   <p className="text-sm">
                     Your organization will be downgraded at the end of your current billing cycle.


### PR DESCRIPTION
Adjustments to the copy in the plan upgrade/downgrade modal for AWS billed organizations. The texts used so far were for billing partner "Fly" specifically but were not 100% suitable for billing partner AWS.