### PR TITLE
Update hybrid-search.mdx fix column name on documents table, fixes #26364

### DIFF
--- a/apps/docs/content/guides/ai/hybrid-search.mdx
+++ b/apps/docs/content/guides/ai/hybrid-search.mdx
@@ -62,7 +62,7 @@ The table contains 4 columns:
 - `id` is an auto-generated unique ID for the record. We'll use this later to match records when performing RRF.
 - `content` contains the actual text we will be searching over.
 - `fts` is an auto-generated `tsvector` column that is generated using the text in `content`. We will use this for [full text search](/docs/guides/database/full-text-search) (search by keyword).
-- `embedding` is a [vector column](/docs/guides/ai/vector-columns) that stores the vector generated from our embedding model. We will use this for [semantic search](/docs/guides/ai/semantic-search) (search by meaning). We chose 512 dimensions for this example, but adjust this to match the size of the embedding vectors generated from your preferred model.
+- `doc_vector` is a [vector column](/docs/guides/ai/vector-columns) that stores the vector generated from our embedding model. We will use this for [semantic search](/docs/guides/ai/semantic-search) (search by meaning). We chose 512 dimensions for this example, but adjust this to match the size of the embedding vectors generated from your preferred model.
 
 Next we'll create indexes on the `fts` and `embedding` columns so that their individual queries will remain fast at scale:
 

--- a/apps/docs/content/guides/ai/hybrid-search.mdx
+++ b/apps/docs/content/guides/ai/hybrid-search.mdx
@@ -53,7 +53,7 @@ create table documents (
   id bigint primary key generated always as identity,
   content text,
   fts tsvector generated always as (to_tsvector('english', content)) stored,
-  embedding vector(512)
+  doc_vector vector(512)
 );
 ```
 

--- a/apps/docs/content/guides/ai/hybrid-search.mdx
+++ b/apps/docs/content/guides/ai/hybrid-search.mdx
@@ -53,7 +53,7 @@ create table documents (
   id bigint primary key generated always as identity,
   content text,
   fts tsvector generated always as (to_tsvector('english', content)) stored,
-  doc_vector vector(512)
+  embedding vector(512)
 );
 ```
 
@@ -62,7 +62,7 @@ The table contains 4 columns:
 - `id` is an auto-generated unique ID for the record. We'll use this later to match records when performing RRF.
 - `content` contains the actual text we will be searching over.
 - `fts` is an auto-generated `tsvector` column that is generated using the text in `content`. We will use this for [full text search](/docs/guides/database/full-text-search) (search by keyword).
-- `doc_vector` is a [vector column](/docs/guides/ai/vector-columns) that stores the vector generated from our embedding model. We will use this for [semantic search](/docs/guides/ai/semantic-search) (search by meaning). We chose 512 dimensions for this example, but adjust this to match the size of the embedding vectors generated from your preferred model.
+- `embedding` is a [vector column](/docs/guides/ai/vector-columns) that stores the vector generated from our embedding model. We will use this for [semantic search](/docs/guides/ai/semantic-search) (search by meaning). We chose 512 dimensions for this example, but adjust this to match the size of the embedding vectors generated from your preferred model.
 
 Next we'll create indexes on the `fts` and `embedding` columns so that their individual queries will remain fast at scale:
 
@@ -108,7 +108,7 @@ with full_text as (
 semantic as (
   select
     id,
-    row_number() over (order by doc_vector <#> query_embedding) as rank_ix
+    row_number() over (order by embedding <#> query_embedding) as rank_ix
   from
     documents
   order by rank_ix


### PR DESCRIPTION
The function uses `doc_vector` but table is setup with `embedding` so changed it to `doc_vector`

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Update text in doc

## What is the current behavior?
## What is the new behavior?

See issue https://github.com/supabase/supabase/issues/26364

