### PR TITLE
Chore/support more granular updates via events for spinning up replica

### DIFF
--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceConfiguration.constants.ts
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceConfiguration.constants.ts
@@ -1,3 +1,5 @@
+import { ReadReplicaSetupProgress } from '@supabase/shared-types/out/events'
+
 import { components } from 'data/api'
 import { AWS_REGIONS, AWS_REGIONS_KEYS, PROJECT_STATUS } from 'lib/constants'
 
@@ -73,3 +75,14 @@ export const AVAILABLE_REPLICA_REGIONS: Region[] = Object.keys(AWS_REGIONS)
     }
   })
   .filter((x) => x.coordinates !== undefined)
+
+// [Joshen] Just a more user friendly language, so that all the verbs are progressive
+export const INIT_PROGRESS = {
+  [ReadReplicaSetupProgress.Requested]: 'Requesting replica instance',
+  [ReadReplicaSetupProgress.Started]: 'Launching replica instance',
+  [ReadReplicaSetupProgress.LaunchedReadReplicaInstance]: 'Initiating replica setup',
+  [ReadReplicaSetupProgress.InitiatedReadReplicaSetup]: 'Downloading base backup',
+  [ReadReplicaSetupProgress.DownloadedBaseBackup]: 'Replaying WAL archives',
+  [ReadReplicaSetupProgress.ReplayedWalArchives]: 'Completing set up',
+  [ReadReplicaSetupProgress.CompletedReadReplicaSetup]: 'Completed',
+}

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceConfiguration.constants.ts
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceConfiguration.constants.ts
@@ -1,4 +1,4 @@
-import { ReadReplicaSetupProgress } from '@supabase/shared-types/out/events'
+import { ReadReplicaSetupError, ReadReplicaSetupProgress } from '@supabase/shared-types/out/events'
 
 import { components } from 'data/api'
 import { AWS_REGIONS, AWS_REGIONS_KEYS, PROJECT_STATUS } from 'lib/constants'
@@ -85,4 +85,12 @@ export const INIT_PROGRESS = {
   [ReadReplicaSetupProgress.DownloadedBaseBackup]: 'Replaying WAL archives',
   [ReadReplicaSetupProgress.ReplayedWalArchives]: 'Completing set up',
   [ReadReplicaSetupProgress.CompletedReadReplicaSetup]: 'Completed',
+}
+
+export const ERROR_STATES = {
+  [ReadReplicaSetupError.ReadReplicaInstanceLaunchFailed]: 'Failed to launch replica',
+  [ReadReplicaSetupError.InitiateReadReplicaSetupFailed]: 'Failed to initiate replica',
+  [ReadReplicaSetupError.DownloadBaseBackupFailed]: 'Failed to download backup',
+  [ReadReplicaSetupError.ReplayWalArchivesFailed]: 'Failed to replay WAL archives',
+  [ReadReplicaSetupError.CompleteReadReplicaSetupFailed]: 'Failed to set up replica',
 }

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceConfiguration.utils.ts
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceConfiguration.utils.ts
@@ -168,3 +168,10 @@ export const addRegionNodes = (nodes: Node[], edges: Edge[]) => {
 
   return { nodes: [...regionNodes, ...nodes], edges }
 }
+
+export const formatSeconds = (value: number) => {
+  const minutes = Math.floor((value % 3600) / 60)
+  const seconds = Math.floor(value % 60)
+
+  return `${minutes > 0 ? `${minutes}m` : ''} ${seconds > 0 ? `${seconds}s` : ''}`.trim()
+}

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceConfiguration.utils.ts
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceConfiguration.utils.ts
@@ -170,8 +170,9 @@ export const addRegionNodes = (nodes: Node[], edges: Edge[]) => {
 }
 
 export const formatSeconds = (value: number) => {
+  const hours = ~~(value / 3600)
   const minutes = Math.floor((value % 3600) / 60)
   const seconds = Math.floor(value % 60)
 
-  return `${minutes > 0 ? `${minutes}m` : ''} ${seconds > 0 ? `${seconds}s` : ''}`.trim()
+  return `${hours > 0 ? `${hours}h` : ''} ${minutes > 0 ? `${minutes}m` : ''} ${seconds > 0 ? `${seconds}s` : ''}`.trim()
 }

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceConfiguration.utils.ts
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceConfiguration.utils.ts
@@ -10,22 +10,24 @@ import {
 import { groupBy } from 'lodash'
 import type { Database } from 'data/read-replicas/replicas-query'
 import type { LoadBalancer } from 'data/read-replicas/load-balancers-query'
+import { DatabaseStatus } from 'data/read-replicas/replicas-status-query'
 
 // [Joshen] Just FYI the nodes generation assumes each project only has one load balancer
 // Will need to change if this eventually becomes otherwise
 
-export const generateNodes = (
-  primary: Database,
-  replicas: Database[],
-  loadBalancers: LoadBalancer[],
-  {
-    onSelectRestartReplica,
-    onSelectDropReplica,
-  }: {
-    onSelectRestartReplica: (database: Database) => void
-    onSelectDropReplica: (database: Database) => void
-  }
-): Node[] => {
+export const generateNodes = ({
+  primary,
+  replicas,
+  loadBalancers,
+  onSelectRestartReplica,
+  onSelectDropReplica,
+}: {
+  primary: Database
+  replicas: Database[]
+  loadBalancers: LoadBalancer[]
+  onSelectRestartReplica: (database: Database) => void
+  onSelectDropReplica: (database: Database) => void
+}): Node[] => {
   const position = { x: 0, y: 0 }
   const regions = groupBy(replicas, (d) => {
     const region = AVAILABLE_REPLICA_REGIONS.find((region) => d.region.includes(region.region))

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceNode.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceNode.tsx
@@ -20,6 +20,7 @@ import {
   cn,
 } from 'ui'
 import {
+  ERROR_STATES,
   INIT_PROGRESS,
   NODE_SEP,
   NODE_WIDTH,
@@ -31,7 +32,7 @@ import {
   ReplicaInitializationStatus,
   useReadReplicasStatusesQuery,
 } from 'data/read-replicas/replicas-status-query'
-import { ReadReplicaSetupProgress } from '@supabase/shared-types/out/events'
+import { ReadReplicaSetupError, ReadReplicaSetupProgress } from '@supabase/shared-types/out/events'
 import SparkBar from 'components/ui/SparkBar'
 import { formatSeconds } from './InstanceConfiguration.utils'
 
@@ -186,11 +187,13 @@ export const ReplicaNode = ({ data }: NodeProps<ReplicaNodeData>) => {
     status: initStatus,
     progress,
     estimations,
+    error,
   } = (replicaInitializationStatus as {
     status?: string
     progress?: string
     estimations?: DatabaseInitEstimations
-  }) ?? { status: undefined, progress: undefined, estimations: undefined }
+    error?: string
+  }) ?? { status: undefined, progress: undefined, estimations: undefined, error: undefined }
 
   const stage = progress !== undefined ? Number(progress.split('_')[0]) : 0
   const stagePercent = stage / (Object.keys(INIT_PROGRESS).length - 1)
@@ -314,6 +317,10 @@ export const ReplicaNode = ({ data }: NodeProps<ReplicaNodeData>) => {
                   </TooltipContent_Shadcn_>
                 )}
               </Tooltip_Shadcn_>
+            ) : error !== undefined ? (
+              <p className="text-sm text-foreground-light">
+                Error: {ERROR_STATES[error as keyof typeof ERROR_STATES]}
+              </p>
             ) : (
               <p className="text-sm text-foreground-light">Created: {created}</p>
             )}

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceNode.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceNode.tsx
@@ -19,7 +19,20 @@ import {
   Tooltip_Shadcn_,
   cn,
 } from 'ui'
-import { NODE_SEP, NODE_WIDTH, REPLICA_STATUS, Region } from './InstanceConfiguration.constants'
+import {
+  INIT_PROGRESS,
+  NODE_SEP,
+  NODE_WIDTH,
+  REPLICA_STATUS,
+  Region,
+} from './InstanceConfiguration.constants'
+import {
+  DatabaseInitEstimations,
+  ReplicaInitializationStatus,
+  useReadReplicasStatusesQuery,
+} from 'data/read-replicas/replicas-status-query'
+import { ReadReplicaSetupProgress } from '@supabase/shared-types/out/events'
+import SparkBar from 'components/ui/SparkBar'
 
 interface NodeData {
   id: string
@@ -164,14 +177,33 @@ export const ReplicaNode = ({ data }: NodeProps<ReplicaNodeData>) => {
   const { ref } = useParams()
   const created = dayjs(inserted_at).format('DD MMM YYYY')
 
-  const isInTransition = (
-    [
-      REPLICA_STATUS.COMING_UP,
-      REPLICA_STATUS.GOING_DOWN,
-      REPLICA_STATUS.RESTORING,
-      REPLICA_STATUS.INIT_READ_REPLICA,
-    ] as string[]
-  ).includes(status)
+  const { data: databaseStatuses } = useReadReplicasStatusesQuery({ projectRef: ref })
+  const { replicaInitializationStatus } =
+    (databaseStatuses ?? []).find((db) => db.identifier === id) || {}
+
+  const {
+    status: initStatus,
+    progress,
+    estimations,
+  } = (replicaInitializationStatus as {
+    status?: string
+    progress?: string
+    estimations?: DatabaseInitEstimations
+  }) ?? { status: undefined, progress: undefined, estimations: undefined }
+
+  const stage = progress !== undefined ? Number(progress.split('_')[0]) : 0
+  const stagePercent = stage / (Object.keys(INIT_PROGRESS).length - 1)
+
+  const isInTransition =
+    (
+      [
+        REPLICA_STATUS.UNKNOWN,
+        REPLICA_STATUS.COMING_UP,
+        REPLICA_STATUS.GOING_DOWN,
+        REPLICA_STATUS.RESTORING,
+        REPLICA_STATUS.INIT_READ_REPLICA,
+      ] as string[]
+    ).includes(status) || initStatus === ReplicaInitializationStatus.InProgress
 
   return (
     <>
@@ -184,7 +216,8 @@ export const ReplicaNode = ({ data }: NodeProps<ReplicaNodeData>) => {
           <div
             className={cn(
               'w-8 h-8 border rounded-md flex items-center justify-center',
-              status === REPLICA_STATUS.ACTIVE_HEALTHY
+              status === REPLICA_STATUS.ACTIVE_HEALTHY &&
+                initStatus === ReplicaInitializationStatus.Completed
                 ? 'bg-brand-400 border-brand-500'
                 : 'bg-surface-100 border-foreground/20'
             )}
@@ -200,11 +233,13 @@ export const ReplicaNode = ({ data }: NodeProps<ReplicaNodeData>) => {
               <p className="text-sm truncate">
                 Replica {id.length > 0 && `(ID: ${formatDatabaseID(id)})`}
               </p>
-              {status === REPLICA_STATUS.ACTIVE_HEALTHY ? (
-                <Badge variant="brand">Healthy</Badge>
-              ) : status === REPLICA_STATUS.INIT_READ_REPLICA ? (
-                <Badge>Initializing</Badge>
-              ) : status === REPLICA_STATUS.INIT_READ_REPLICA_FAILED ? (
+              {initStatus === ReplicaInitializationStatus.InProgress ||
+              status === REPLICA_STATUS.COMING_UP ||
+              status === REPLICA_STATUS.UNKNOWN ||
+              status === REPLICA_STATUS.INIT_READ_REPLICA ? (
+                <Badge>Coming up</Badge>
+              ) : initStatus === ReplicaInitializationStatus.Failed ||
+                status === REPLICA_STATUS.INIT_READ_REPLICA_FAILED ? (
                 <>
                   <Badge variant="destructive">Init failed</Badge>
                   <Tooltip_Shadcn_>
@@ -221,12 +256,13 @@ export const ReplicaNode = ({ data }: NodeProps<ReplicaNodeData>) => {
                     </TooltipContent_Shadcn_>
                   </Tooltip_Shadcn_>
                 </>
-              ) : status === REPLICA_STATUS.COMING_UP || status === REPLICA_STATUS.UNKNOWN ? (
-                <Badge>Coming up</Badge>
               ) : status === REPLICA_STATUS.GOING_DOWN ? (
                 <Badge>Going down</Badge>
               ) : status === REPLICA_STATUS.RESTORING ? (
                 <Badge>Restarting</Badge>
+              ) : initStatus === ReplicaInitializationStatus.Completed &&
+                status === REPLICA_STATUS.ACTIVE_HEALTHY ? (
+                <Badge variant="brand">Healthy</Badge>
               ) : (
                 <Badge variant="warning">Unhealthy</Badge>
               )}
@@ -235,11 +271,28 @@ export const ReplicaNode = ({ data }: NodeProps<ReplicaNodeData>) => {
               <p className="text-sm text-foreground-light">{region.name}</p>
               <p className="flex text-sm text-foreground-light items-center gap-x-1">
                 <span>{provider}</span>
-                <span>•</span>
-                <span>{computeSize}</span>
+                {!!computeSize && (
+                  <>
+                    <span>•</span>
+                    <span>{computeSize}</span>
+                  </>
+                )}
               </p>
             </div>
-            <p className="text-sm text-foreground-light">Created: {created}</p>
+            {initStatus === ReplicaInitializationStatus.InProgress && progress !== undefined ? (
+              <div className="w-52 -mt-0.5">
+                <SparkBar
+                  labelBottom={INIT_PROGRESS[progress as keyof typeof INIT_PROGRESS]}
+                  labelBottomClass="text-xs !normal-nums text-foreground-light"
+                  type="horizontal"
+                  value={stagePercent * 100}
+                  max={100}
+                  barClass="bg-brand"
+                />
+              </div>
+            ) : (
+              <p className="text-sm text-foreground-light">Created: {created}</p>
+            )}
           </div>
         </div>
         <DropdownMenu modal={false}>

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceNode.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceNode.tsx
@@ -33,6 +33,7 @@ import {
 } from 'data/read-replicas/replicas-status-query'
 import { ReadReplicaSetupProgress } from '@supabase/shared-types/out/events'
 import SparkBar from 'components/ui/SparkBar'
+import { formatSeconds } from './InstanceConfiguration.utils'
 
 interface NodeData {
   id: string
@@ -280,16 +281,39 @@ export const ReplicaNode = ({ data }: NodeProps<ReplicaNodeData>) => {
               </p>
             </div>
             {initStatus === ReplicaInitializationStatus.InProgress && progress !== undefined ? (
-              <div className="w-52 -mt-0.5">
-                <SparkBar
-                  labelBottom={INIT_PROGRESS[progress as keyof typeof INIT_PROGRESS]}
-                  labelBottomClass="text-xs !normal-nums text-foreground-light"
-                  type="horizontal"
-                  value={stagePercent * 100}
-                  max={100}
-                  barClass="bg-brand"
-                />
-              </div>
+              <Tooltip_Shadcn_>
+                <TooltipTrigger_Shadcn_ asChild>
+                  <div className="w-56">
+                    <SparkBar
+                      labelBottom={INIT_PROGRESS[progress as keyof typeof INIT_PROGRESS]}
+                      labelBottomClass="text-xs !normal-nums text-foreground-light"
+                      type="horizontal"
+                      value={stagePercent * 100}
+                      max={100}
+                      barClass="bg-brand"
+                    />
+                  </div>
+                </TooltipTrigger_Shadcn_>
+                {estimations !== undefined && (
+                  <TooltipContent_Shadcn_ asChild side="bottom">
+                    <div className="w-56">
+                      <p className="text-foreground-light mb-0.5">Duration estimates:</p>
+                      {estimations.baseBackupDownloadEstimateSeconds !== undefined && (
+                        <p>
+                          Base backup download:{' '}
+                          {formatSeconds(estimations.baseBackupDownloadEstimateSeconds)}
+                        </p>
+                      )}
+                      {estimations.walArchiveReplayEstimateSeconds !== undefined && (
+                        <p>
+                          WAL archive replay:{' '}
+                          {formatSeconds(estimations.walArchiveReplayEstimateSeconds)}
+                        </p>
+                      )}
+                    </div>
+                  </TooltipContent_Shadcn_>
+                )}
+              </Tooltip_Shadcn_>
             ) : (
               <p className="text-sm text-foreground-light">Created: {created}</p>
             )}

--- a/apps/studio/data/read-replicas/replicas-status-query.ts
+++ b/apps/studio/data/read-replicas/replicas-status-query.ts
@@ -3,6 +3,21 @@ import { get } from 'data/fetchers'
 import { useProjectDetailQuery } from 'data/projects/project-detail-query'
 import type { ResponseError } from 'types'
 import { replicaKeys } from './keys'
+import { components } from 'api-types'
+
+// [Joshen] Is it possible to import this from the code gen?
+// https://github.com/supabase/infrastructure/blob/develop/api/src/routes/platform/projects/ref/databases-statuses.dto.ts#L7
+export enum ReplicaInitializationStatus {
+  'InProgress' = 'in_progress',
+  'Completed' = 'completed',
+  'Failed' = 'failed',
+}
+
+export type DatabaseStatus = components['schemas']['DatabaseStatusResponse']
+export type DatabaseInitEstimations = {
+  baseBackupDownloadEstimateSeconds: number
+  walArchiveReplayEstimateSeconds: number
+}
 
 export type ReadReplicasStatusesVariables = {
   projectRef?: string

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -34,7 +34,7 @@
     "@stripe/stripe-js": "^3.0.5",
     "@supabase/auth-helpers-react": "^0.4.2",
     "@supabase/pg-meta": "*",
-    "@supabase/shared-types": "0.1.55",
+    "@supabase/shared-types": "0.1.65",
     "@supabase/supabase-js": "^2.41.1",
     "@tanstack/react-query": "4.35.7",
     "@tanstack/react-query-devtools": "4.35.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2116,7 +2116,7 @@
         "@stripe/stripe-js": "^3.0.5",
         "@supabase/auth-helpers-react": "^0.4.2",
         "@supabase/pg-meta": "*",
-        "@supabase/shared-types": "0.1.55",
+        "@supabase/shared-types": "0.1.65",
         "@supabase/supabase-js": "^2.41.1",
         "@tanstack/react-query": "4.35.7",
         "@tanstack/react-query-devtools": "4.35.7",
@@ -16013,9 +16013,9 @@
       }
     },
     "node_modules/@supabase/shared-types": {
-      "version": "0.1.55",
-      "resolved": "https://registry.npmjs.org/@supabase/shared-types/-/shared-types-0.1.55.tgz",
-      "integrity": "sha512-oHB9AR2Jq6jZvghtxrpd3/UVK7XOVyrTq/Oh1EZ3AQAo3xqK26CxhbJZ70IkQoS5uD0Qcae7Rwbx88S/+g4BzQ=="
+      "version": "0.1.65",
+      "resolved": "https://registry.npmjs.org/@supabase/shared-types/-/shared-types-0.1.65.tgz",
+      "integrity": "sha512-MPOaMkUlysDlP51e0h0PTIAXAPJwHvRb1szjxW2SRrCmH1dmKtg5PuwtR2sWAGRCajjutgx1ofPZuIYXj5mvzQ=="
     },
     "node_modules/@supabase/ssr": {
       "version": "0.1.0",

--- a/packages/api-types/types/api.d.ts
+++ b/packages/api-types/types/api.d.ts
@@ -160,7 +160,7 @@ export interface paths {
   }
   '/platform/organizations/{slug}/roles': {
     /** Gets the given organization's roles */
-    get: operations['OrganizationRolesController_addMember']
+    get: operations['OrganizationRolesController_getAllRolesV2']
   }
   '/platform/organizations/{slug}/tax-ids': {
     /** Gets the given organization's tax IDs */
@@ -199,26 +199,33 @@ export interface paths {
     get: operations['OrgAuditLogsController_getAuditLogs']
   }
   '/platform/organizations/{slug}/members/invite': {
-    /** Gets invited users */
+    /**
+     * Gets invited users
+     * @deprecated
+     */
     get: operations['OrganizationInviteController_getInvitedUsers']
-    /** Invites user */
+    /**
+     * Invites user
+     * @deprecated
+     */
     post: operations['OrganizationInviteController_inviteUser']
-    /** Delete invited user */
+    /**
+     * Delete invited user
+     * @deprecated
+     */
     delete: operations['OrganizationInviteController_deleteInvitedUser']
   }
   '/platform/organizations/{slug}/members/join': {
-    /** Gets invite */
+    /**
+     * Gets invite
+     * @deprecated
+     */
     get: operations['JoinController_getInvite']
-    /** Joins organization */
+    /**
+     * Joins organization
+     * @deprecated
+     */
     post: operations['JoinController_joinOrganization']
-  }
-  '/platform/organizations/{slug}/members/leave': {
-    /** Leaves the given organization */
-    post: operations['MembersDeprecatedController_leaveOrganization']
-  }
-  '/platform/organizations/{slug}/members/remove': {
-    /** Leaves the given organization */
-    delete: operations['MembersDeprecatedController_removeMember']
   }
   '/platform/organizations/{slug}/members': {
     /** Gets organization's members */
@@ -227,12 +234,32 @@ export interface paths {
   '/platform/organizations/{slug}/members/{gotrue_id}': {
     /** Removes organization member */
     delete: operations['MembersController_deleteMember']
-    /** Updates organization member */
-    patch: operations['MembersController_updateMember']
+    /** Updates organization member role */
+    patch: operations['MembersController_updateMemberRoleV2']
+  }
+  '/platform/organizations/{slug}/members/{gotrue_id}/roles/{role_id}': {
+    /** Removes organization member */
+    delete: operations['MembersController_deleteMemberRole']
   }
   '/platform/organizations/{slug}/members/reached-free-project-limit': {
     /** Gets organization members who have reached their free project limit */
     get: operations['ReachedFreeProjectLimitController_getMembersWhoReachedFreeProjectLimit']
+  }
+  '/platform/organizations/{slug}/members/invitations': {
+    /** Gets organization invitations */
+    get: operations['InvitationsController_getAllInvitations']
+    /** Creates organization invitation */
+    post: operations['InvitationsController_createInvitation']
+  }
+  '/platform/organizations/{slug}/members/invitations/{token}': {
+    /** Gets organization invitation by token */
+    get: operations['InvitationsController_getInvitationByToken']
+    /** Accepts organization invitation by token */
+    post: operations['InvitationsController_acceptInvitationByToken']
+  }
+  '/platform/organizations/{slug}/members/invitations/{id}': {
+    /** Deletes organization invitation with given id */
+    delete: operations['InvitationsController_deleteInvitation']
   }
   '/platform/organizations/{slug}/payments': {
     /** Gets Stripe payment methods for the given organization */
@@ -1153,20 +1180,35 @@ export interface paths {
   }
   '/v0/organizations/{slug}/roles': {
     /** Gets the given organization's roles */
-    get: operations['OrganizationRolesController_addMember']
+    get: operations['OrganizationRolesController_getAllRolesV2']
   }
   '/v0/organizations/{slug}/members/invite': {
-    /** Gets invited users */
+    /**
+     * Gets invited users
+     * @deprecated
+     */
     get: operations['OrganizationInviteController_getInvitedUsers']
-    /** Invites user */
+    /**
+     * Invites user
+     * @deprecated
+     */
     post: operations['OrganizationInviteController_inviteUser']
-    /** Delete invited user */
+    /**
+     * Delete invited user
+     * @deprecated
+     */
     delete: operations['OrganizationInviteController_deleteInvitedUser']
   }
   '/v0/organizations/{slug}/members/join': {
-    /** Gets invite */
+    /**
+     * Gets invite
+     * @deprecated
+     */
     get: operations['JoinController_getInvite']
-    /** Joins organization */
+    /**
+     * Joins organization
+     * @deprecated
+     */
     post: operations['JoinController_joinOrganization']
   }
   '/v0/organizations/{slug}/members': {
@@ -1176,8 +1218,12 @@ export interface paths {
   '/v0/organizations/{slug}/members/{gotrue_id}': {
     /** Removes organization member */
     delete: operations['MembersController_deleteMember']
-    /** Updates organization member */
-    patch: operations['MembersController_updateMember']
+    /** Updates organization member role */
+    patch: operations['MembersController_updateMemberRoleV2']
+  }
+  '/v0/organizations/{slug}/members/{gotrue_id}/roles/{role_id}': {
+    /** Removes organization member */
+    delete: operations['MembersController_deleteMemberRole']
   }
   '/v0/pg-meta/{ref}/column-privileges': {
     /** Retrieve column privileges */
@@ -2557,9 +2603,21 @@ export interface components {
         stripeAccount?: string
       }
     }
-    Role: {
+    OrganizationRole: {
       id: number
       name: string
+      description: string
+    }
+    OrganizationRoleV2: {
+      id: number
+      name: string
+      description: string
+      project_ids: number[]
+      base_role_id: number
+    }
+    OrganizationRoleResponseV2: {
+      org_scoped_roles: components['schemas']['OrganizationRoleV2'][]
+      project_scoped_roles: components['schemas']['OrganizationRoleV2'][]
     }
     TaxId: {
       id: string
@@ -2719,9 +2777,6 @@ export interface components {
       slug: string
       stripe_customer_id: string
     }
-    RemoveMemberBody: {
-      member_id: number
-    }
     Member: {
       gotrue_id: string
       primary_email: string | null
@@ -2732,10 +2787,36 @@ export interface components {
     UpdateMemberBody: {
       role_id: number
     }
+    UpdateMemberRoleBodyV2: {
+      role_id: number
+      role_scoped_projects?: string[]
+    }
     MemberWithFreeProjectLimit: {
       free_project_limit: number
       primary_email: string
       username: string
+    }
+    Invitation: {
+      id: number
+      invited_at: string
+      invited_email: string
+      role_id: number
+    }
+    InvitationResponse: {
+      invitations: components['schemas']['Invitation'][]
+    }
+    InvitationByTokenResponse: {
+      organization_name: string
+      invite_id?: number
+      token_does_not_exist: boolean
+      email_match: boolean
+      authorized_user: boolean
+      expired_token: boolean
+    }
+    CreateInvitationBody: {
+      email: string
+      role_id: number
+      role_scoped_projects?: string[]
     }
     Payment: {
       id: string
@@ -3923,6 +4004,7 @@ export interface components {
         | 'INIT_READ_REPLICA'
         | 'INIT_READ_REPLICA_FAILED'
       identifier: string
+      replicaInitializationStatus?: Record<string, never>
     }
     UpdatePasswordBody: {
       password: string
@@ -6891,7 +6973,7 @@ export interface operations {
     }
   }
   /** Gets the given organization's roles */
-  OrganizationRolesController_addMember: {
+  OrganizationRolesController_getAllRolesV2: {
     parameters: {
       path: {
         /** @description Organization slug */
@@ -6901,7 +6983,7 @@ export interface operations {
     responses: {
       200: {
         content: {
-          'application/json': components['schemas']['Role'][]
+          'application/json': components['schemas']['OrganizationRoleResponseV2']
         }
       }
       /** @description Failed to retrieve the organization's roles */
@@ -7160,7 +7242,10 @@ export interface operations {
       }
     }
   }
-  /** Gets invited users */
+  /**
+   * Gets invited users
+   * @deprecated
+   */
   OrganizationInviteController_getInvitedUsers: {
     parameters: {
       path: {
@@ -7180,7 +7265,10 @@ export interface operations {
       }
     }
   }
-  /** Invites user */
+  /**
+   * Invites user
+   * @deprecated
+   */
   OrganizationInviteController_inviteUser: {
     parameters: {
       path: {
@@ -7205,7 +7293,10 @@ export interface operations {
       }
     }
   }
-  /** Delete invited user */
+  /**
+   * Delete invited user
+   * @deprecated
+   */
   OrganizationInviteController_deleteInvitedUser: {
     parameters: {
       query: {
@@ -7226,7 +7317,10 @@ export interface operations {
       }
     }
   }
-  /** Gets invite */
+  /**
+   * Gets invite
+   * @deprecated
+   */
   JoinController_getInvite: {
     parameters: {
       query: {
@@ -7249,7 +7343,10 @@ export interface operations {
       }
     }
   }
-  /** Joins organization */
+  /**
+   * Joins organization
+   * @deprecated
+   */
   JoinController_joinOrganization: {
     parameters: {
       query: {
@@ -7267,51 +7364,6 @@ export interface operations {
         }
       }
       /** @description Failed to join organization */
-      500: {
-        content: never
-      }
-    }
-  }
-  /** Leaves the given organization */
-  MembersDeprecatedController_leaveOrganization: {
-    parameters: {
-      path: {
-        /** @description Organization slug */
-        slug: string
-      }
-    }
-    responses: {
-      201: {
-        content: {
-          'application/json': Record<string, never>
-        }
-      }
-      /** @description Failed to leave organization */
-      500: {
-        content: never
-      }
-    }
-  }
-  /** Leaves the given organization */
-  MembersDeprecatedController_removeMember: {
-    parameters: {
-      path: {
-        /** @description Organization slug */
-        slug: string
-      }
-    }
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['RemoveMemberBody']
-      }
-    }
-    responses: {
-      200: {
-        content: {
-          'application/json': Record<string, never>
-        }
-      }
-      /** @description Failed to leave organization */
       500: {
         content: never
       }
@@ -7356,8 +7408,8 @@ export interface operations {
       }
     }
   }
-  /** Updates organization member */
-  MembersController_updateMember: {
+  /** Updates organization member role */
+  MembersController_updateMemberRoleV2: {
     parameters: {
       path: {
         /** @description Organization slug */
@@ -7367,14 +7419,34 @@ export interface operations {
     }
     requestBody: {
       content: {
-        'application/json': components['schemas']['UpdateMemberBody']
+        'application/json': components['schemas']['UpdateMemberRoleBodyV2']
       }
     }
     responses: {
       200: {
         content: never
       }
-      /** @description Failed to update organization member */
+      /** @description Failed to update organization member role */
+      500: {
+        content: never
+      }
+    }
+  }
+  /** Removes organization member */
+  MembersController_deleteMemberRole: {
+    parameters: {
+      path: {
+        /** @description Organization slug */
+        slug: string
+        gotrue_id: string
+        role_id: string
+      }
+    }
+    responses: {
+      200: {
+        content: never
+      }
+      /** @description Failed to remove organization member */
       500: {
         content: never
       }
@@ -7395,6 +7467,108 @@ export interface operations {
         }
       }
       /** @description Failed to retrieve organization members who have reached their free project limit */
+      500: {
+        content: never
+      }
+    }
+  }
+  /** Gets organization invitations */
+  InvitationsController_getAllInvitations: {
+    parameters: {
+      path: {
+        /** @description Organization slug */
+        slug: string
+      }
+    }
+    responses: {
+      200: {
+        content: {
+          'application/json': components['schemas']['InvitationResponse']
+        }
+      }
+      /** @description Failed to get organization invitations */
+      500: {
+        content: never
+      }
+    }
+  }
+  /** Creates organization invitation */
+  InvitationsController_createInvitation: {
+    parameters: {
+      path: {
+        /** @description Organization slug */
+        slug: string
+      }
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['CreateInvitationBody']
+      }
+    }
+    responses: {
+      201: {
+        content: never
+      }
+      /** @description Failed to create organization invitation */
+      500: {
+        content: never
+      }
+    }
+  }
+  /** Gets organization invitation by token */
+  InvitationsController_getInvitationByToken: {
+    parameters: {
+      path: {
+        /** @description Organization slug */
+        slug: string
+        token: string
+      }
+    }
+    responses: {
+      200: {
+        content: {
+          'application/json': components['schemas']['InvitationByTokenResponse']
+        }
+      }
+      /** @description Failed to get organization invitation by token */
+      500: {
+        content: never
+      }
+    }
+  }
+  /** Accepts organization invitation by token */
+  InvitationsController_acceptInvitationByToken: {
+    parameters: {
+      path: {
+        /** @description Organization slug */
+        slug: string
+        token: string
+      }
+    }
+    responses: {
+      201: {
+        content: never
+      }
+      /** @description Failed to accept organization invitation by token */
+      500: {
+        content: never
+      }
+    }
+  }
+  /** Deletes organization invitation with given id */
+  InvitationsController_deleteInvitation: {
+    parameters: {
+      path: {
+        /** @description Organization slug */
+        slug: string
+        id: number
+      }
+    }
+    responses: {
+      200: {
+        content: never
+      }
+      /** @description Failed to delete organization invitation with given id */
       500: {
         content: never
       }


### PR DESCRIPTION
Spinning up replicas will show more granular status updates while the replica is initializing:
![image](https://github.com/supabase/supabase/assets/19742402/1cfb0fc8-6dbd-4e96-8477-21810138fb74)

If estimates are available, hovering over the progress bar will show:
![image](https://github.com/supabase/supabase/assets/19742402/8a9038d5-cd64-4a37-a365-472dc52f1197)

If an error happens during set up, error will show accordingly:
![image](https://github.com/supabase/supabase/assets/19742402/c9d11540-d721-4bac-8fe4-d53dfe573dcf)

