### PR TITLE
feat: Show Logs button in branching table

### DIFF
--- a/apps/studio/components/interfaces/BranchManagement/BranchPanels.tsx
+++ b/apps/studio/components/interfaces/BranchManagement/BranchPanels.tsx
@@ -103,6 +103,10 @@ export const BranchRow = ({
   const createPullRequestURL =
     generateCreatePullRequestURL?.(branch.git_branch) ?? 'https://github.com'
 
+  const shouldRenderLogsButton =
+    branch.pr_number !== undefined && branch.latest_check_run_id !== undefined
+  const checkRunLogsURL = `https://github.com/${repo}/pull/${branch.pr_number}/checks?check_run_id=${branch.latest_check_run_id}`
+
   const { ref, inView } = useInView()
   const { data } = useBranchQuery(
     { projectRef, id: branch.id },
@@ -259,6 +263,15 @@ export const BranchRow = ({
                 </Button>
               </div>
             )}
+
+            {shouldRenderLogsButton && (
+              <Button asChild type="default" iconRight={<IconExternalLink />}>
+                <Link passHref target="_blank" rel="noreferrer" href={checkRunLogsURL}>
+                  View Logs
+                </Link>
+              </Button>
+            )}
+
             <DropdownMenu modal={false}>
               <DropdownMenuTrigger asChild>
                 <Button type="text" icon={<IconMoreVertical />} className="px-1" />

--- a/packages/api-types/types/api.d.ts
+++ b/packages/api-types/types/api.d.ts
@@ -5028,6 +5028,7 @@ export interface components {
       is_default: boolean
       git_branch?: string
       pr_number?: number
+      latest_check_run_id?: number
       reset_on_push: boolean
       persistent: boolean
       /** @enum {string} */


### PR DESCRIPTION
Can be merged anytime as `latest_check_run_id` will simply be undefined until https://github.com/supabase/infrastructure/pull/18146 is deployed.

![image](https://github.com/supabase/supabase/assets/1523305/b163526c-4061-4033-b614-3d336366273e)
