### PR TITLE
Chore/sentry fixes

### DIFF
--- a/apps/studio/components/interfaces/Linter/LinterDataGrid.tsx
+++ b/apps/studio/components/interfaces/Linter/LinterDataGrid.tsx
@@ -143,6 +143,7 @@ const LinterDataGrid = ({
             renderRow(idx, props) {
               return (
                 <Row
+                  key={props.row.cache_key}
                   {...props}
                   onClick={() => {
                     if (typeof idx === 'number' && idx >= 0) {

--- a/apps/studio/pages/_app.tsx
+++ b/apps/studio/pages/_app.tsx
@@ -112,7 +112,9 @@ function CustomApp({ Component, pageProps }: AppPropsWithLayout) {
 
   const errorBoundaryHandler = (error: Error, info: ErrorInfo) => {
     console.error(error.stack)
-    Sentry.captureMessage(`Full page crash: ${error.message || 'Unknown error message'}`)
+    Sentry.captureMessage(`Full page crash: ${error.message || 'Unknown error message'}`, {
+      level: 'error',
+    })
   }
 
   useEffect(() => {

--- a/packages/ui-patterns/form/Layout/FormLayout.tsx
+++ b/packages/ui-patterns/form/Layout/FormLayout.tsx
@@ -307,10 +307,10 @@ export const FormLayout = React.forwardRef<
             id={id + '-before'}
             data-formlayout-id={'beforeLabel'}
           >
-            {beforeLabel}
+            <span>{beforeLabel}</span>
           </span>
         )}
-        {label}
+        <span>{label}</span>
         {afterLabel && (
           <span
             className={cn(LabelAfterVariants({ size }))}


### PR DESCRIPTION
— make the full page crash event show up as an error, instead of the default (Info)([screenshot](https://share.cleanshot.com/Gq6fRXfC))
— fix crash on settings/auth page when page is translated
— add key to fix console error

