### PR TITLE
Chore: Add Validation to Account Name and Organization Name Text Fields to Prevent Malicious Input

### DIFF
--- a/apps/studio/components/interfaces/Account/Preferences/ProfileInformation.tsx
+++ b/apps/studio/components/interfaces/Account/Preferences/ProfileInformation.tsx
@@ -19,8 +19,18 @@ import type { Profile } from 'data/profile/types'
 import type { FormSchema } from 'types'
 
 const FormSchema = z.object({
-  first_name: z.string().optional(),
-  last_name: z.string().optional(),
+  first_name: z
+    .string()
+    .optional()
+    .refine((value) => /^[\p{L}\s]*$/u.test(value || ''), {
+      message: 'First name can only contain letters and spaces',
+    }),
+  last_name: z
+    .string()
+    .optional()
+    .refine((value) => /^[\p{L}\s]*$/u.test(value || ''), {
+      message: 'Last name can only contain letters and spaces',
+    }),
 })
 
 const formId = 'profile-information-form'

--- a/apps/studio/components/interfaces/Organization/GeneralSettings/GeneralSettings.tsx
+++ b/apps/studio/components/interfaces/Organization/GeneralSettings/GeneralSettings.tsx
@@ -21,6 +21,11 @@ import { OPT_IN_TAGS } from 'lib/constants'
 import { Collapsible, Form, IconChevronRight, Input, Toggle, cn } from 'ui'
 import OrganizationDeletePanel from './OrganizationDeletePanel'
 
+const isValidName = (name: string): boolean => {
+  const regex = /^[\p{L}\p{N}\s]*$/u
+  return regex.test(name)
+}
+
 const GeneralSettings = () => {
   const { slug } = useParams()
   const queryClient = useQueryClient()
@@ -44,6 +49,10 @@ const GeneralSettings = () => {
     }
 
     if (!slug) return console.error('Slug is required')
+
+    if (!isValidName(values.name)) {
+      return toast.error('Organization name contains invalid characters')
+    }
 
     const existingOptInTags = selectedOrganization?.opt_in_tags ?? []
     const updatedOptInTags =


### PR DESCRIPTION
## What is the current behavior?

Currently, the account name and organization name text fields lack validation, allowing any characters to be used. This vulnerability can be exploited for malicious purposes. For example, a malicious link can be saved in these text boxes. When users receive an invitation to join a New Relic account, these names render as valid links in email clients. Since the email is from a trusted domain like New Relic, users may click on these links, which could lead to harmful sites.

### Solution:

Added a regular expression validation to the relevant fields.

### Testing:

- Manually tested the account First name / Last name and the Organization name text fields to ensure that only valid characters are accepted.

![image](https://github.com/supabase/supabase/assets/99693443/3740f21f-3e59-4c71-ad40-5e4b4d01da77)

![image](https://github.com/supabase/supabase/assets/99693443/aefcb79a-dd21-4e69-b09c-55500a27ba9d)
