### PR TITLE
Docs: fix column name in `match_documents` example

### DIFF
--- a/apps/docs/content/guides/ai/vector-columns.mdx
+++ b/apps/docs/content/guides/ai/vector-columns.mdx
@@ -119,14 +119,16 @@ create or replace function match_documents (
 )
 returns table (
   id bigint,
-  content text,
+  title text,
+  body text,
   similarity float
 )
 language sql stable
 as $$
   select
     documents.id,
-    documents.content,
+    documents.title,
+    documents.body,
     1 - (documents.embedding <=> query_embedding) as similarity
   from documents
   where 1 - (documents.embedding <=> query_embedding) > match_threshold


### PR DESCRIPTION
In the vector column docs, the [`match_documents` function](https://supabase.com/docs/guides/ai/vector-columns#querying-a-vector--embedding) references a non-existent column `content`. Fixes to point to `body` column instead.