### PR TITLE
Update index_advisor.mdx

### DIFF
--- a/apps/docs/content/guides/database/extensions/index_advisor.mdx
+++ b/apps/docs/content/guides/database/extensions/index_advisor.mdx
@@ -13,7 +13,7 @@ Features:
 - Identifies tables/columns obfuscated by views
 - Skips duplicate indexes
 
-index_advisor is accessible directly through Supabase Studio by navigating to the [Query Performance Report](/dashboard/project/_/database/query-performance) and selecting a query and then the "indexes" tab.
+index\_advisor is accessible directly through Supabase Studio by navigating to the [Query Performance Report](/dashboard/project/\_/database/query-performance) and selecting a query and then the "indexes" tab.
 
 ![Supabase Studio index_advisor integration.](/docs/img/index_advisor_studio.png)
 

--- a/apps/docs/content/guides/database/extensions/index_advisor.mdx
+++ b/apps/docs/content/guides/database/extensions/index_advisor.mdx
@@ -13,6 +13,7 @@ Features:
 - Identifies tables/columns obfuscated by views
 - Skips duplicate indexes
 
+{/* prettier-ignore */}
 index\_advisor is accessible directly through Supabase Studio by navigating to the [Query Performance Report](/dashboard/project/\_/database/query-performance) and selecting a query and then the "indexes" tab.
 
 ![Supabase Studio index_advisor integration.](/docs/img/index_advisor_studio.png)

--- a/apps/docs/content/guides/database/extensions/index_advisor.mdx
+++ b/apps/docs/content/guides/database/extensions/index_advisor.mdx
@@ -13,8 +13,7 @@ Features:
 - Identifies tables/columns obfuscated by views
 - Skips duplicate indexes
 
-{/* prettier-ignore */}
-index\_advisor is accessible directly through Supabase Studio by navigating to the [Query Performance Report](/dashboard/project/\_/database/query-performance) and selecting a query and then the "indexes" tab.
+`index_advisor` is accessible directly through Supabase Studio by navigating to the [Query Performance Report](/dashboard/project/_/database/query-performance) and selecting a query and then the "indexes" tab.
 
 ![Supabase Studio index_advisor integration.](/docs/img/index_advisor_studio.png)
 

--- a/apps/docs/content/guides/database/extensions/index_advisor.mdx
+++ b/apps/docs/content/guides/database/extensions/index_advisor.mdx
@@ -13,7 +13,7 @@ Features:
 - Identifies tables/columns obfuscated by views
 - Skips duplicate indexes
 
-index_advisor is accessible directly through Supabase Studio by navigating to the [Query Performance Report](/dashboard/project/*/database/query-performance) and selecting a query and then the "indexes" tab.
+index_advisor is accessible directly through Supabase Studio by navigating to the [Query Performance Report](/dashboard/project/_/database/query-performance) and selecting a query and then the "indexes" tab.
 
 ![Supabase Studio index_advisor integration.](/docs/img/index_advisor_studio.png)
 


### PR DESCRIPTION
Fix universal dashboard link to query-performance

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update, ...

## What is the current behavior?
The link to the dashboard has a * instead of a _ to allow uses to choose their project, which results in a 404.

## What is the new behavior?
It properly lets users select their own project.
