### PR TITLE
bug: need to include "use client" in error.tsx file

### DIFF
--- a/apps/docs/content/guides/auth/server-side/nextjs.mdx
+++ b/apps/docs/content/guides/auth/server-side/nextjs.mdx
@@ -382,6 +382,7 @@ export async function signup(formData: FormData) {
 ```
 
 ```ts app/error/page.tsx
+"use client";
 export default function ErrorPage() {
   return <p>Sorry, something went wrong</p>
 }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

In the latest Supabase documentation, there's a code snippet for error.tsx, which is currently set up as a server component. 
This causes an error in the Next.js application. To convert error.tsx into a client component, we need to add `use client` at the top of the file.

Docs Page: https://supabase.com/docs/guides/auth/server-side/nextjs

You can verify this at the official nextjs documentation - https://nextjs.org/docs/app/building-your-application/routing/error-handling

<img width="677" alt="Screenshot 2024-05-18 at 4 26 29 PM" src="https://github.com/supabase/supabase/assets/65452005/345c808c-121d-4028-a84d-3747feec272a">



