### PR TITLE
Docs: Fix CLI Login hyperlink for various doc pages

### DIFF
--- a/apps/docs/content/guides/platform/custom-domains.mdx
+++ b/apps/docs/content/guides/platform/custom-domains.mdx
@@ -44,7 +44,7 @@ This example assumes your Supabase project is `abcdefghijklmnopqrst` with a corr
 To get started:
 
 1. [Install](/docs/guides/resources/supabase-cli) the latest version of the Supabase CLI.
-2. [Log in](/docs/guides/resources/supabase-getting-started/local-development#log-in-to-the-supabase-cli) to your Supabase account using the CLI.
+2. [Log in](/docs/guides/cli/local-development#log-in-to-the-supabase-cli) to your Supabase account using the CLI.
 3. Ensure you have [Owner or Admin permissions](/docs/guides/platform/access-control#manage-team-members) for the project.
 4. Get a custom domain from a DNS provider. Currently, only subdomains are supported.
    - Use `api.example.com` instead of `example.com`.
@@ -155,7 +155,7 @@ Vanity subdomains allow you to present a basic branded experience, compared to c
 To get started:
 
 1. [Install](/docs/guides/resources/supabase-cli) the latest version of the Supabase CLI.
-1. [Log in](/docs/guides/resources/supabase-getting-started/local-development#log-in-to-the-supabase-cli) to your Supabase account using the CLI.
+1. [Log in](/docs/guides/cli/local-development#log-in-to-the-supabase-cli) to your Supabase account using the CLI.
 1. Ensure that you have [Owner or Admin permissions](/docs/guides/platform/access-control#manage-team-members) for the project you'd like to set up a vanity subdomain for.
 1. Ensure that your organization is on a paid plan (Pro/Team/Enterprise plan) in the [Billing page of the Dashboard](https://supabase.com/dashboard/org/_/billing).
 

--- a/apps/docs/content/guides/platform/custom-postgres-config.mdx
+++ b/apps/docs/content/guides/platform/custom-postgres-config.mdx
@@ -40,7 +40,7 @@ The following parameters are available for overrides:
 To get started:
 
 1. [Install](/docs/guides/resources/supabase-cli) the Supabase CLI 1.69.0+.
-1. [Log in](/docs/guides/resources/supabase-getting-started/local-development#log-in-to-the-supabase-cli) to your Supabase account using the CLI.
+1. [Log in](/docs/guides/cli/local-development#log-in-to-the-supabase-cli) to your Supabase account using the CLI.
 
 The `postgres config` command of the CLI can be used for setting configuration parameters:
 

--- a/apps/docs/content/guides/platform/network-restrictions.mdx
+++ b/apps/docs/content/guides/platform/network-restrictions.mdx
@@ -21,7 +21,7 @@ Network restrictions can be configured in the [Database Settings](https://supaba
 ## To get started via the CLI:
 
 1. [Install](/docs/guides/cli) the Supabase CLI 1.22.0+.
-1. [Log in](/docs/guides/getting-started/local-development#log-in-to-the-supabase-cli) to your Supabase account using the CLI.
+1. [Log in](/docs/guides/cli/local-development#log-in-to-the-supabase-cli) to your Supabase account using the CLI.
 1. If your project was created before 23rd December 2022, it will need to be [upgraded to the latest Supabase version](/docs/guides/platform/migrating-and-upgrading-projects) before Network Restrictions can be used.
 1. Ensure that you have [Owner or Admin permissions](/docs/guides/platform/access-control#manage-team-members) for the project that you are enabling network restrictions.
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Update link for hyperlink that was leading to 404 errors

## What is the current behavior?

404 page not found errors for Log in hyperlinks for various doc pages

Please link any relevant issues here.

## What is the new behavior?

Now correctly links to the CLI log in docs page

## Additional context


