### PR TITLE
Add note about security definer views

### DIFF
--- a/apps/docs/content/guides/database/tables.mdx
+++ b/apps/docs/content/guides/database/tables.mdx
@@ -456,7 +456,7 @@ select * from transcripts;
 ### View security
 
 
-By default, views are accessed with their creator's permission ("security definer"). If a privileged role creates a view, others accessing it will use that role's elevated permissions. To enforce RLS policies, define the view with the "security invoker" modifier.
+By default, views are accessed with their creator's permission ("security definer"). If a privileged role creates a view, others accessing it will use that role's elevated permissions. To enforce row level security policies, define the view with the "security invoker" modifier.
 
 ```sql
 -- alter a security_definer view to be security_invoker

--- a/apps/docs/content/guides/database/tables.mdx
+++ b/apps/docs/content/guides/database/tables.mdx
@@ -455,7 +455,6 @@ select * from transcripts;
 
 ### View security
 
-
 By default, views are accessed with their creator's permission ("security definer"). If a privileged role creates a view, others accessing it will use that role's elevated permissions. To enforce row level security policies, define the view with the "security invoker" modifier.
 
 ```sql
@@ -468,7 +467,6 @@ create view <view name> with(security_invoker=true) as (
   select * from <some table>
 );
 ```
-
 
 ### When to use views
 

--- a/apps/docs/content/guides/database/tables.mdx
+++ b/apps/docs/content/guides/database/tables.mdx
@@ -401,12 +401,6 @@ create table private.salaries (
 
 A View is a convenient shortcut to a query. Creating a view does not involve new tables or data. When run, an underlying query is executed, returning its results to the user.
 
-<Admonition type="caution">
-
-By default, PostgreSQL views bypass Row Level Security unless you change their owner (see https://github.com/supabase/supabase/discussions/901). PostgreSQL v15 (coming soon) will have a more intuitive control for this through [security invoker views](https://www.depesz.com/2022/03/22/waiting-for-postgresql-15-add-support-for-security-invoker-views/) and the previous step won't be needed.
-
-</Admonition>
-
 Say we have the following tables from a database of a university:
 
 **`students`**
@@ -458,6 +452,23 @@ Once done, we can now access the underlying query with:
 ```sql
 select * from transcripts;
 ```
+
+### View security
+
+
+By default, views are accessed with their creator's permission ("security definer"). If a privileged role creates a view, others accessing it will use that role's elevated permissions. To enforce RLS policies, define the view with the "security invoker" modifier.
+
+```sql
+-- alter a security_definer view to be security_invoker
+alter view <view name>
+set (security_inkoker = true);
+
+-- create a view with the security_invoker modifier
+create view <view name> with(security_invoker=true) as (
+  select * from <some table>
+);
+```
+
 
 ### When to use views
 

--- a/apps/docs/content/guides/database/tables.mdx
+++ b/apps/docs/content/guides/database/tables.mdx
@@ -461,7 +461,7 @@ By default, views are accessed with their creator's permission ("security define
 ```sql
 -- alter a security_definer view to be security_invoker
 alter view <view name>
-set (security_inkoker = true);
+set (security_invoker = true);
 
 -- create a view with the security_invoker modifier
 create view <view name> with(security_invoker=true) as (


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs Update

## What is the current behavior?

Display workarounds to create "security invoker" views in Postgres 14

## What is the new behavior?

Tells users how to create security invoker views in Postgres 15

## Additional context

Security Advisor regularly warns users to update their views. This provides pre-emptive guidance to prevent the vulnerability in the first place