### PR TITLE
Added crypto package for sha256

### DIFF
--- a/apps/docs/content/guides/auth/social-login/auth-apple.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-apple.mdx
@@ -209,6 +209,7 @@ When developing with Expo, you can test Sign in with Apple via the Expo Go app, 
     ```dart
     import 'package:sign_in_with_apple/sign_in_with_apple.dart';
     import 'package:supabase_flutter/supabase_flutter.dart';
+    import 'package:crypto/crypto.dart';
 
     /// Performs Apple sign in on iOS or macOS
     Future<AuthResponse> signInWithApple() async {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

Code snippet does not include the crypto package, so from an initial copy it doesn't work.

## What is the new behavior?

Adds the crypto package dependency to the code snipper which is required for sha256 to be called 