### PR TITLE
Sentry: capture message on support form err

### DIFF
--- a/apps/studio/components/interfaces/Support/SupportForm.tsx
+++ b/apps/studio/components/interfaces/Support/SupportForm.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { ChangeEvent, useEffect, useRef, useState } from 'react'
 import toast from 'react-hot-toast'
-
+import * as Sentry from '@sentry/nextjs'
 import { useParams } from 'common'
 import InformationBox from 'components/ui/InformationBox'
 import ShimmeringLoader from 'components/ui/ShimmeringLoader'
@@ -76,6 +76,7 @@ const SupportForm = ({ setSentCategory }: SupportFormProps) => {
     },
     onError: (error) => {
       toast.error(`Failed to submit support ticket: ${error.message}`)
+      Sentry.captureMessage('Failed to submit Support Form: ' + error.message)
       setIsSubmitting(false)
     },
   })


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?
if support form query fails we'll get an explicit message in sentry.