### PR TITLE
fix/various improvements to Free plan downgrade [GEN-8955]

### DIFF
--- a/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/DowngradeModal.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/DowngradeModal.tsx
@@ -76,33 +76,33 @@ const DowngradeModal = ({
             <Alert
               withIcon
               variant="warning"
-              title="Downgrading to the free plan will lead to reductions in your organization's quota"
+              title="Downgrading to the Free plan will lead to reductions in your organization's quota"
             >
               <p>
-                If you're already past the limits of the free plan, your projects could become
+                If you're already past the limits of the Free plan, your projects could become
                 unresponsive or enter read only mode.
               </p>
             </Alert>
 
-            {(previousProjectAddons.length ?? 0) > 0 ||
-              (hasInstancesOnMicro && downgradingToNano && (
-                <Alert title={`Projects affected by the downgrade`} variant="warning" withIcon>
-                  <ul className="space-y-1 max-h-[100px] overflow-y-auto">
-                    {previousProjectAddons.map((project) => (
-                      <ProjectDowngradeListItem key={project.ref} projectAddon={project} />
-                    ))}
+            {((previousProjectAddons.length ?? 0) > 0 ||
+              (hasInstancesOnMicro && downgradingToNano)) && (
+              <Alert title={`Projects affected by the downgrade`} variant="warning" withIcon>
+                <ul className="space-y-1 max-h-[100px] overflow-y-auto">
+                  {previousProjectAddons.map((project) => (
+                    <ProjectDowngradeListItem key={project.ref} projectAddon={project} />
+                  ))}
 
-                    {projects
-                      .filter((it) => it.infra_compute_size === 'micro')
-                      .map((project) => (
-                        <li className="list-disc ml-6" key={project.id}>
-                          {project.name}: Compute will be downgraded. Project will also{' '}
-                          <span className="font-bold">need to be restarted</span>.
-                        </li>
-                      ))}
-                  </ul>
-                </Alert>
-              ))}
+                  {projects
+                    .filter((it) => it.infra_compute_size === 'micro')
+                    .map((project) => (
+                      <li className="list-disc ml-6" key={project.id}>
+                        {project.name}: Compute will be downgraded. Project will also{' '}
+                        <span className="font-bold">need to be restarted</span>.
+                      </li>
+                    ))}
+                </ul>
+              </Alert>
+            )}
           </div>
 
           <ul className="mt-4 space-y-5 text-sm">
@@ -141,7 +141,7 @@ const DowngradeModal = ({
             </li>
           </ul>
 
-          {subscription?.billing_via_partner === true && (
+          {subscription?.billing_via_partner === true && subscription.billing_partner === 'fly' && (
             <p className="mt-4 text-sm">
               Your organization will be downgraded at the end of your current billing cycle.
             </p>

--- a/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/PlanUpdateSidePanel.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/PlanUpdateSidePanel.tsx
@@ -574,6 +574,7 @@ const PlanUpdateSidePanel = () => {
       <ExitSurveyModal
         visible={showExitSurvey}
         subscription={subscription}
+        projects={orgProjects}
         onClose={(success?: boolean) => {
           setShowExitSurvey(false)
           if (success) onClose()


### PR DESCRIPTION
The following was fixed/improved for the two-step downgrade to plan Free:

**Step 1**
- (fix) the addons that will be removed on downgrade were not shown due to missing parentheses
- (improvement) the text that the downgrade will take place at the end of the current billing cycle is now only shown for orgs billed via Fly

**Step 2 (Survey/final confirmation)**
- (fix) no hint regarding project restart was shown for projects that are created with Micro compute instead of being upgraded to Micro compute after project creation. Resulting in a mismatch between the projects listed in Step 1 and Step 2
- (improvement) the text that the downgrade will happen immediately after clicking confirm was changed for orgs billed via Fly
- (improvement) the success message after clicking confirm was adjusted regarding immediate/scheduled downgrade and projects being restarted
- (improvement) the text regarding credits that will be given is now only shown if the downgrade happens immediately