### PR TITLE
Doc : Prevent token consumption by link verification services in emails (Outlook)

### DIFF
--- a/apps/docs/content/guides/auth/auth-email-templates.mdx
+++ b/apps/docs/content/guides/auth/auth-email-templates.mdx
@@ -50,6 +50,8 @@ To guard against this:
     >Confirm your signup
   </a>
   ```
+  
+- Or by blocking HTTP HEAD requests, as mentioned [here](docs/guides/auth/server-side/nextjs).
 
   The user should be brought to a page on your site where they can confirm the action by clicking a button.
   The button should contain the actual confirmation link which can be obtained from parsing the `confirmation_url={{ .ConfirmationURL }}` query parameter in the URL.

--- a/apps/docs/content/guides/auth/server-side/nextjs.mdx
+++ b/apps/docs/content/guides/auth/server-side/nextjs.mdx
@@ -415,20 +415,25 @@ Create a Route Handler for `auth/confirm`. When a user clicks their confirmation
 
 Since this is a Router Handler, use the Supabase client from `@/utils/supabase/server.ts`.
 
-Attention: in certain specific cases, such as with Microsoft's email provider, it is possible that links in emails are pre-opened (e.g., [Safe Links in Microsoft Defender for Office 365](https://learn.microsoft.com/en-us/defender-office-365/safe-links-about?view=o365-worldwide)). This can result in the confirmation link being opened before the user clicks on it, consuming the confirmation token and rendering it expired. To perform this action, email services send an HTTP HEAD request to check the validity of the link.
+<Admonition type="caution">
+  Attention: in certain specific cases, such as with Microsoft's email provider, it is possible that links in emails are pre-opened (e.g., [Safe Links in Microsoft Defender for Office 365](https://learn.microsoft.com/en-us/defender-office-365/safe-links-about?view=o365-worldwide)). This can result in the confirmation link being opened before the user clicks on it, consuming the confirmation token and rendering it expired. To perform this action, email services send an HTTP HEAD request to check the validity of the link.
 
-To avoid this issue, a double confirmation system can be implemented. For example, by directing the user to a confirmation page where they need to click a button to confirm their email, as explained [here](/docs/guides/auth/auth-email-templates#limitations).
+  To avoid this issue, a double confirmation system can be implemented. For example, by directing the user to a confirmation page where they need to click a button to confirm their email, as explained [here](/docs/guides/auth/auth-email-templates#limitations).
 
-Another solution is to "block" HTTP HEAD requests (thus preventing the token from being consumed) by adding this code at the beginning of your route:
+  Another solution is to "block" HTTP HEAD requests (thus preventing the token from being consumed) by adding this code at the beginning of your route:
 
-```ts app/auth/confirm/route.ts
-export async function GET(request: NextRequest) {
-  if (request.method !== 'GET') {
-      return new NextResponse('Method Not Allowed', { status: 405 });
+  ```ts app/auth/confirm/route.ts
+  export async function GET(request: NextRequest) {
+    if (request.method !== 'GET') {
+        return new NextResponse(
+          'Method Not Allowed', 
+          { status: 405 }
+        );
+    }
+    // Rest of the code
   }
-  // Rest of the code
-}
-```
+  ```
+</Admonition>
 
 </StepHikeCompact.Details>
 

--- a/apps/docs/content/guides/auth/server-side/nextjs.mdx
+++ b/apps/docs/content/guides/auth/server-side/nextjs.mdx
@@ -415,6 +415,21 @@ Create a Route Handler for `auth/confirm`. When a user clicks their confirmation
 
 Since this is a Router Handler, use the Supabase client from `@/utils/supabase/server.ts`.
 
+Attention: in certain specific cases, such as with Microsoft's email provider, it is possible that links in emails are pre-opened (e.g., [Safe Links in Microsoft Defender for Office 365](https://learn.microsoft.com/en-us/defender-office-365/safe-links-about?view=o365-worldwide)). This can result in the confirmation link being opened before the user clicks on it, consuming the confirmation token and rendering it expired. To perform this action, email services send an HTTP HEAD request to check the validity of the link.
+
+To avoid this issue, a double confirmation system can be implemented. For example, by directing the user to a confirmation page where they need to click a button to confirm their email, as explained [here](/docs/guides/auth/auth-email-templates#limitations).
+
+Another solution is to "block" HTTP HEAD requests (thus preventing the token from being consumed) by adding this code at the beginning of your route:
+
+```ts app/auth/confirm/route.ts
+export async function GET(request: NextRequest) {
+  if (request.method !== 'GET') {
+      return new NextResponse('Method Not Allowed', { status: 405 });
+  }
+  // Rest of the code
+}
+```
+
 </StepHikeCompact.Details>
 
 <StepHikeCompact.Code>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Updated authentication documentation to prevent link protection services used by email providers from consuming tokens.

## What is the current behavior?

When a link (such as a magic link) is sent via Outlook, Microsoft's link verification service performs an HTTP HEAD request and consumes the token, rendering it invalid for the end user.

https://github.com/orgs/supabase/discussions/3961

## What is the new behavior?

Added a piece of code to prevent HEAD requests in NextJS routes for connection confirmation.

