### PR TITLE
[Dashboard] init layouts in project settings

### DIFF
--- a/apps/studio/components/interfaces/Functions/EdgeFunctionSecrets/EdgeFunctionSecrets.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionSecrets/EdgeFunctionSecrets.tsx
@@ -38,13 +38,6 @@ const EdgeFunctionSecrets = () => {
 
   return (
     <>
-      <div>
-        <h3 className="mb-2 text-xl text-foreground">Edge Function Secrets Management</h3>
-        <div className="text-sm text-foreground-lighter">
-          Manage the secrets for your project's edge functions
-        </div>
-      </div>
-
       {isLoading && <GenericSkeletonLoader />}
 
       {isError && <AlertError error={error} subject="Failed to retrieve project secrets" />}

--- a/apps/studio/components/interfaces/Settings/API/ServiceList.tsx
+++ b/apps/studio/components/interfaces/Settings/API/ServiceList.tsx
@@ -92,12 +92,10 @@ const ServiceList = () => {
 
   return (
     <div>
-      <h3 className="mb-6 text-xl text-foreground">API Settings</h3>
       {isLoading ? (
         <GenericSkeletonLoader />
       ) : project?.status !== PROJECT_STATUS.ACTIVE_HEALTHY ? (
         <div>
-          <h3 className="mb-6 text-xl text-foreground">API Settings</h3>
           <div className="flex items-center justify-center rounded border border-overlay bg-surface-100 p-8">
             <IconAlertCircle strokeWidth={1.5} />
             <p className="text-sm text-foreground-light ml-2">

--- a/apps/studio/components/interfaces/Settings/Addons/Addons.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/Addons.tsx
@@ -120,15 +120,6 @@ const Addons = () => {
 
   return (
     <>
-      <ScaffoldContainer>
-        <div className="mx-auto flex flex-col gap-10 py-6">
-          <div>
-            <p className="text-xl">Add ons</p>
-            <p className="text-sm text-foreground-light">Level up your project with add-ons</p>
-          </div>
-        </div>
-      </ScaffoldContainer>
-
       <ScaffoldDivider />
 
       {isBranch && (

--- a/apps/studio/components/interfaces/Settings/General/General.tsx
+++ b/apps/studio/components/interfaces/Settings/General/General.tsx
@@ -77,8 +77,6 @@ const General = () => {
 
   return (
     <div>
-      <FormHeader title="Project Settings" description="" />
-
       {isBranch && (
         <Alert_Shadcn_ variant="default" className="mb-6">
           <WarningIcon />

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureInfo.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureInfo.tsx
@@ -71,17 +71,6 @@ const InfrastructureInfo = () => {
 
   return (
     <>
-      <ScaffoldContainer>
-        <div className="mx-auto flex flex-col gap-10 py-6">
-          <div>
-            <p className="text-xl">Infrastructure</p>
-            <p className="text-sm text-foreground-light">
-              General information regarding your server instance
-            </p>
-          </div>
-        </div>
-      </ScaffoldContainer>
-
       <ScaffoldDivider />
 
       {showReadReplicasUI && (

--- a/apps/studio/components/layouts/OrganizationLayout.tsx
+++ b/apps/studio/components/layouts/OrganizationLayout.tsx
@@ -73,11 +73,11 @@ const OrganizationLayout = ({ children }: PropsWithChildren<{}>) => {
       title={selectedOrganization?.name ?? 'Supabase'}
       breadcrumbs={[{ key: `org-settings`, label: 'Settings' }]}
     >
-      <ScaffoldHeader>
+      <ScaffoldHeader className="pb-0">
         <ScaffoldContainer id="billing-page-top">
-          <ScaffoldTitle>{selectedOrganization?.name ?? 'Organization'} settings</ScaffoldTitle>
-        </ScaffoldContainer>
-        <ScaffoldContainer>
+          <ScaffoldTitle className="pb-3">
+            {selectedOrganization?.name ?? 'Organization'} settings
+          </ScaffoldTitle>
           <NavMenu className="border-none" aria-label="Organization menu navigation">
             {filteredNavMenuItems.map((item) => (
               <NavMenuItem key={item.label} active={item.href === router.asPath}>

--- a/apps/studio/components/layouts/Scaffold.tsx
+++ b/apps/studio/components/layouts/Scaffold.tsx
@@ -31,11 +31,18 @@ const ScaffoldDescription = React.forwardRef<
   return <span ref={ref} {...props} className={cn('text-sm text-foreground-light', className)} />
 })
 
-const ScaffoldContainer = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => {
-    return <div ref={ref} {...props} className={cn(maxWidthClasses, paddingClasses, className)} />
-  }
-)
+const ScaffoldContainer = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & { bottomPadding?: boolean }
+>(({ className, bottomPadding, ...props }, ref) => {
+  return (
+    <div
+      ref={ref}
+      {...props}
+      className={cn(maxWidthClasses, paddingClasses, bottomPadding && 'pb-16', className)}
+    />
+  )
+})
 
 const ScaffoldDivider = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => {

--- a/apps/studio/components/layouts/Scaffold.tsx
+++ b/apps/studio/components/layouts/Scaffold.tsx
@@ -11,7 +11,7 @@ const ScaffoldHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTM
       <header
         {...props}
         ref={ref}
-        className={cn('w-full', 'flex-col gap-3 py-5', className)}
+        className={cn('w-full', 'flex-col gap-3 py-6', className)}
       ></header>
     )
   }

--- a/apps/studio/components/layouts/Scaffold.tsx
+++ b/apps/studio/components/layouts/Scaffold.tsx
@@ -8,7 +8,11 @@ const maxWidthClassesColumn = 'min-w-[420px]'
 const ScaffoldHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => {
     return (
-      <header {...props} ref={ref} className={cn('w-full', 'flex-col gap-3', className)}></header>
+      <header
+        {...props}
+        ref={ref}
+        className={cn('w-full', 'flex-col gap-3 py-5', className)}
+      ></header>
     )
   }
 )
@@ -17,7 +21,14 @@ const ScaffoldTitle = React.forwardRef<
   HTMLHeadingElement,
   React.HTMLAttributes<HTMLHeadingElement>
 >(({ className, ...props }, ref) => {
-  return <h1 ref={ref} {...props} className={cn('text-3xl pt-6 pb-4', className)} />
+  return <h1 ref={ref} {...props} className={cn('text-2xl', className)} />
+})
+
+const ScaffoldDescription = React.forwardRef<
+  HTMLHeadingElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => {
+  return <span ref={ref} {...props} className={cn('text-sm text-foreground-light', className)} />
 })
 
 const ScaffoldContainer = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
@@ -120,6 +131,7 @@ const ScaffoldContainerLegacy = React.forwardRef<
 
 ScaffoldHeader.displayName = 'ScaffoldHeader'
 ScaffoldTitle.displayName = 'ScaffoldTitle'
+ScaffoldDescription.displayName = 'ScaffoldDescription'
 ScaffoldContainer.displayName = 'ScaffoldContainer'
 ScaffoldDivider.displayName = 'ScaffoldDivider'
 ScaffoldSection.displayName = 'ScaffoldSection'
@@ -134,6 +146,7 @@ ScaffoldContainerLegacy.displayName = 'ScaffoldContainerLegacy'
 export {
   ScaffoldHeader,
   ScaffoldTitle,
+  ScaffoldDescription,
   ScaffoldContainer,
   ScaffoldDivider,
   ScaffoldSection,

--- a/apps/studio/components/to-be-cleaned/Storage/StorageSettings/StorageSettings.tsx
+++ b/apps/studio/components/to-be-cleaned/Storage/StorageSettings/StorageSettings.tsx
@@ -103,11 +103,6 @@ const StorageSettings = () => {
 
           return (
             <>
-              <FormHeader
-                title="Storage Settings"
-                description="Configure your project's storage settings."
-              />
-
               {isLoading && <GenericSkeletonLoader />}
               {isError && (
                 <AlertError

--- a/apps/studio/pages/project/[ref]/settings/addons.tsx
+++ b/apps/studio/pages/project/[ref]/settings/addons.tsx
@@ -1,9 +1,25 @@
 import Addons from 'components/interfaces/Settings/Addons/Addons'
 import { SettingsLayout } from 'components/layouts'
+import {
+  ScaffoldContainer,
+  ScaffoldDescription,
+  ScaffoldHeader,
+  ScaffoldTitle,
+} from 'components/layouts/Scaffold'
 import type { NextPageWithLayout } from 'types'
 
 const ProjectAddons: NextPageWithLayout = () => {
-  return <Addons />
+  return (
+    <>
+      <ScaffoldContainer>
+        <ScaffoldHeader>
+          <ScaffoldTitle>Add ons</ScaffoldTitle>
+          <ScaffoldDescription>Level up your project with add-ons</ScaffoldDescription>
+        </ScaffoldHeader>
+      </ScaffoldContainer>
+      <Addons />
+    </>
+  )
 }
 
 ProjectAddons.getLayout = (page) => <SettingsLayout title="Add ons">{page}</SettingsLayout>

--- a/apps/studio/pages/project/[ref]/settings/api.tsx
+++ b/apps/studio/pages/project/[ref]/settings/api.tsx
@@ -1,12 +1,26 @@
 import ServiceList from 'components/interfaces/Settings/API/ServiceList'
 import { SettingsLayout } from 'components/layouts'
+import {
+  ScaffoldColumn,
+  ScaffoldContainer,
+  ScaffoldHeader,
+  ScaffoldSection,
+  ScaffoldTitle,
+} from 'components/layouts/Scaffold'
 import type { NextPageWithLayout } from 'types'
 
 const ApiSettings: NextPageWithLayout = () => {
   return (
-    <div className="flex flex-col gap-8 px-5 py-6 mx-auto 1xl:px-28 lg:px-16 xl:px-24 2xl:px-32">
-      <ServiceList />
-    </div>
+    <>
+      <ScaffoldContainer id="billing-page-top">
+        <ScaffoldHeader>
+          <ScaffoldTitle>API Services</ScaffoldTitle>
+        </ScaffoldHeader>
+      </ScaffoldContainer>
+      <ScaffoldContainer>
+        <ServiceList />
+      </ScaffoldContainer>
+    </>
   )
 }
 

--- a/apps/studio/pages/project/[ref]/settings/api.tsx
+++ b/apps/studio/pages/project/[ref]/settings/api.tsx
@@ -17,7 +17,7 @@ const ApiSettings: NextPageWithLayout = () => {
           <ScaffoldTitle>API Services</ScaffoldTitle>
         </ScaffoldHeader>
       </ScaffoldContainer>
-      <ScaffoldContainer>
+      <ScaffoldContainer bottomPadding>
         <ServiceList />
       </ScaffoldContainer>
     </>

--- a/apps/studio/pages/project/[ref]/settings/api.tsx
+++ b/apps/studio/pages/project/[ref]/settings/api.tsx
@@ -14,7 +14,7 @@ const ApiSettings: NextPageWithLayout = () => {
     <>
       <ScaffoldContainer id="billing-page-top">
         <ScaffoldHeader>
-          <ScaffoldTitle>API Services</ScaffoldTitle>
+          <ScaffoldTitle>API Settings</ScaffoldTitle>
         </ScaffoldHeader>
       </ScaffoldContainer>
       <ScaffoldContainer bottomPadding>

--- a/apps/studio/pages/project/[ref]/settings/auth.tsx
+++ b/apps/studio/pages/project/[ref]/settings/auth.tsx
@@ -6,6 +6,12 @@ import {
   AdvancedAuthSettingsForm,
 } from 'components/interfaces/Auth'
 import { SettingsLayout } from 'components/layouts'
+import {
+  ScaffoldContainer,
+  ScaffoldDescription,
+  ScaffoldHeader,
+  ScaffoldTitle,
+} from 'components/layouts/Scaffold'
 import { FormHeader } from 'components/ui/Forms'
 import NoPermission from 'components/ui/NoPermission'
 import { GenericSkeletonLoader } from 'components/ui/ShimmeringLoader'
@@ -17,24 +23,27 @@ const AuthSettings: NextPageWithLayout = () => {
   const canReadAuthSettings = useCheckPermissions(PermissionAction.READ, 'custom_config_gotrue')
 
   return (
-    <div className="1xl:px-28 mx-auto flex flex-col gap-8 px-5 py-6 lg:px-16 xl:px-24 2xl:px-32">
-      <FormHeader
-        className="!mb-0"
-        title="Auth Settings"
-        description="Configure security and user session settings."
-      />
-      {!isPermissionsLoaded ? (
-        <GenericSkeletonLoader />
-      ) : !canReadAuthSettings ? (
-        <NoPermission isFullPage resourceText="access your project's authentication settings" />
-      ) : (
-        <>
-          <BasicAuthSettingsForm />
-          <SmtpForm />
-          <AdvancedAuthSettingsForm />
-        </>
-      )}
-    </div>
+    <>
+      <ScaffoldContainer>
+        <ScaffoldHeader>
+          <ScaffoldTitle>Auth settings</ScaffoldTitle>
+          <ScaffoldDescription>Configure security and user session settings</ScaffoldDescription>
+        </ScaffoldHeader>
+      </ScaffoldContainer>
+      <ScaffoldContainer>
+        {!isPermissionsLoaded ? (
+          <GenericSkeletonLoader />
+        ) : !canReadAuthSettings ? (
+          <NoPermission isFullPage resourceText="access your project's authentication settings" />
+        ) : (
+          <>
+            <BasicAuthSettingsForm />
+            <SmtpForm />
+            <AdvancedAuthSettingsForm />
+          </>
+        )}
+      </ScaffoldContainer>
+    </>
   )
 }
 

--- a/apps/studio/pages/project/[ref]/settings/auth.tsx
+++ b/apps/studio/pages/project/[ref]/settings/auth.tsx
@@ -30,7 +30,7 @@ const AuthSettings: NextPageWithLayout = () => {
           <ScaffoldDescription>Configure security and user session settings</ScaffoldDescription>
         </ScaffoldHeader>
       </ScaffoldContainer>
-      <ScaffoldContainer className="flex flex-col gap-10">
+      <ScaffoldContainer className="flex flex-col gap-10" bottomPadding>
         {!isPermissionsLoaded ? (
           <GenericSkeletonLoader />
         ) : !canReadAuthSettings ? (

--- a/apps/studio/pages/project/[ref]/settings/auth.tsx
+++ b/apps/studio/pages/project/[ref]/settings/auth.tsx
@@ -30,7 +30,7 @@ const AuthSettings: NextPageWithLayout = () => {
           <ScaffoldDescription>Configure security and user session settings</ScaffoldDescription>
         </ScaffoldHeader>
       </ScaffoldContainer>
-      <ScaffoldContainer>
+      <ScaffoldContainer className="flex flex-col gap-10">
         {!isPermissionsLoaded ? (
           <GenericSkeletonLoader />
         ) : !canReadAuthSettings ? (

--- a/apps/studio/pages/project/[ref]/settings/database.tsx
+++ b/apps/studio/pages/project/[ref]/settings/database.tsx
@@ -12,14 +12,19 @@ import { DatabaseConnectionString } from 'components/interfaces/Settings/Databas
 import DiskSizeConfiguration from 'components/interfaces/Settings/Database/DiskSizeConfiguration'
 import { PoolingModesModal } from 'components/interfaces/Settings/Database/PoolingModesModal'
 import SSLConfiguration from 'components/interfaces/Settings/Database/SSLConfiguration'
+import { ScaffoldContainer, ScaffoldHeader, ScaffoldTitle } from 'components/layouts/Scaffold'
 
 const ProjectSettings: NextPageWithLayout = () => {
   return (
-    <div className="1xl:px-28 mx-auto flex flex-col px-5 pt-6 pb-14 lg:px-16 xl:px-24 2xl:px-32">
-      <div className="content h-full w-full overflow-y-auto space-y-6">
-        <h3 className="text-foreground text-xl">Database Settings</h3>
+    <>
+      <ScaffoldContainer>
+        <ScaffoldHeader>
+          <ScaffoldTitle>Database Settings</ScaffoldTitle>
+        </ScaffoldHeader>
+      </ScaffoldContainer>
+      <ScaffoldContainer>
         <div className="space-y-10">
-          <div className="flex flex-col gap-y-4">
+          <div className="flex flex-col gap-y-10">
             <DatabaseReadOnlyAlert />
             <DatabaseConnectionString appearance="default" />
             <DatabaseSettings />
@@ -31,9 +36,9 @@ const ProjectSettings: NextPageWithLayout = () => {
           <NetworkRestrictions />
           <BannedIPs />
         </div>
-      </div>
+      </ScaffoldContainer>
       <PoolingModesModal />
-    </div>
+    </>
   )
 }
 

--- a/apps/studio/pages/project/[ref]/settings/database.tsx
+++ b/apps/studio/pages/project/[ref]/settings/database.tsx
@@ -22,7 +22,7 @@ const ProjectSettings: NextPageWithLayout = () => {
           <ScaffoldTitle>Database Settings</ScaffoldTitle>
         </ScaffoldHeader>
       </ScaffoldContainer>
-      <ScaffoldContainer>
+      <ScaffoldContainer bottomPadding>
         <div className="space-y-10">
           <div className="flex flex-col gap-y-10">
             <DatabaseReadOnlyAlert />

--- a/apps/studio/pages/project/[ref]/settings/functions.tsx
+++ b/apps/studio/pages/project/[ref]/settings/functions.tsx
@@ -1,12 +1,28 @@
 import EdgeFunctionSecrets from 'components/interfaces/Functions/EdgeFunctionSecrets/EdgeFunctionSecrets'
 import { SettingsLayout } from 'components/layouts'
+import {
+  ScaffoldContainer,
+  ScaffoldDescription,
+  ScaffoldHeader,
+  ScaffoldTitle,
+} from 'components/layouts/Scaffold'
 import type { NextPageWithLayout } from 'types'
 
 const PageLayout: NextPageWithLayout = () => {
   return (
-    <div className="1xl:px-28 mx-auto flex flex-col gap-8 px-5 py-6 lg:px-16 xl:px-24 2xl:px-32">
-      <EdgeFunctionSecrets />
-    </div>
+    <>
+      <ScaffoldContainer>
+        <ScaffoldHeader>
+          <ScaffoldTitle>Edge Function Secrets Management</ScaffoldTitle>
+          <ScaffoldDescription>
+            Manage the secrets for your project's edge functions
+          </ScaffoldDescription>
+        </ScaffoldHeader>
+      </ScaffoldContainer>
+      <ScaffoldContainer>
+        <EdgeFunctionSecrets />
+      </ScaffoldContainer>
+    </>
   )
 }
 

--- a/apps/studio/pages/project/[ref]/settings/functions.tsx
+++ b/apps/studio/pages/project/[ref]/settings/functions.tsx
@@ -19,7 +19,7 @@ const PageLayout: NextPageWithLayout = () => {
           </ScaffoldDescription>
         </ScaffoldHeader>
       </ScaffoldContainer>
-      <ScaffoldContainer>
+      <ScaffoldContainer bottomPadding>
         <EdgeFunctionSecrets />
       </ScaffoldContainer>
     </>

--- a/apps/studio/pages/project/[ref]/settings/general.tsx
+++ b/apps/studio/pages/project/[ref]/settings/general.tsx
@@ -22,7 +22,7 @@ const ProjectSettings: NextPageWithLayout = () => {
           <ScaffoldTitle>Project Settings</ScaffoldTitle>
         </ScaffoldHeader>
       </ScaffoldContainer>
-      <ScaffoldContainer className="flex flex-col gap-10">
+      <ScaffoldContainer className="flex flex-col gap-10" bottomPadding>
         <General />
         {!isBranch ? (
           <>

--- a/apps/studio/pages/project/[ref]/settings/general.tsx
+++ b/apps/studio/pages/project/[ref]/settings/general.tsx
@@ -6,6 +6,7 @@ import {
 } from 'components/interfaces/Settings/General'
 import { SettingsLayout } from 'components/layouts'
 import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
+import { ScaffoldContainer, ScaffoldHeader, ScaffoldTitle } from 'components/layouts/Scaffold'
 import { useIsFeatureEnabled } from 'hooks'
 import type { NextPageWithLayout } from 'types'
 
@@ -16,16 +17,23 @@ const ProjectSettings: NextPageWithLayout = () => {
 
   // [Joshen] Opting for larger gap instead of gap-8 as compared to other pages for better grouping of content
   return (
-    <div className="1xl:px-28 mx-auto flex flex-col gap-10 px-5 py-6 lg:px-16 xl:px-24 2xl:px-32">
-      <General />
-      {!isBranch ? (
-        <>
-          <CustomDomainConfig />
-          {projectTransferEnabled && <TransferProjectPanel />}
-          <DeleteProjectPanel />
-        </>
-      ) : null}
-    </div>
+    <>
+      <ScaffoldContainer>
+        <ScaffoldHeader>
+          <ScaffoldTitle>Project Settings</ScaffoldTitle>
+        </ScaffoldHeader>
+      </ScaffoldContainer>
+      <ScaffoldContainer>
+        <General />
+        {!isBranch ? (
+          <>
+            <CustomDomainConfig />
+            {projectTransferEnabled && <TransferProjectPanel />}
+            <DeleteProjectPanel />
+          </>
+        ) : null}
+      </ScaffoldContainer>
+    </>
   )
 }
 

--- a/apps/studio/pages/project/[ref]/settings/general.tsx
+++ b/apps/studio/pages/project/[ref]/settings/general.tsx
@@ -22,7 +22,7 @@ const ProjectSettings: NextPageWithLayout = () => {
           <ScaffoldTitle>Project Settings</ScaffoldTitle>
         </ScaffoldHeader>
       </ScaffoldContainer>
-      <ScaffoldContainer>
+      <ScaffoldContainer className="flex flex-col gap-10">
         <General />
         {!isBranch ? (
           <>

--- a/apps/studio/pages/project/[ref]/settings/general.tsx
+++ b/apps/studio/pages/project/[ref]/settings/general.tsx
@@ -15,7 +15,6 @@ const ProjectSettings: NextPageWithLayout = () => {
   const isBranch = !!project?.parent_project_ref
   const { projectsTransfer: projectTransferEnabled } = useIsFeatureEnabled(['projects:transfer'])
 
-  // [Joshen] Opting for larger gap instead of gap-8 as compared to other pages for better grouping of content
   return (
     <>
       <ScaffoldContainer>

--- a/apps/studio/pages/project/[ref]/settings/infrastructure.tsx
+++ b/apps/studio/pages/project/[ref]/settings/infrastructure.tsx
@@ -1,12 +1,27 @@
 import InfrastructureActivity from 'components/interfaces/Settings/Infrastructure/InfrastructureActivity'
 import InfrastructureInfo from 'components/interfaces/Settings/Infrastructure/InfrastructureInfo'
 import { SettingsLayout } from 'components/layouts'
-import { ScaffoldDivider } from 'components/layouts/Scaffold'
+import {
+  ScaffoldContainer,
+  ScaffoldDescription,
+  ScaffoldDivider,
+  ScaffoldHeader,
+  ScaffoldTitle,
+} from 'components/layouts/Scaffold'
 import type { NextPageWithLayout } from 'types'
 
 const ProjectInfrastructure: NextPageWithLayout = () => {
   return (
     <>
+      <ScaffoldContainer>
+        <ScaffoldHeader>
+          <ScaffoldTitle>Infrastructure</ScaffoldTitle>
+
+          <ScaffoldDescription>
+            General information regarding your server instance
+          </ScaffoldDescription>
+        </ScaffoldHeader>
+      </ScaffoldContainer>
       <InfrastructureInfo />
       <ScaffoldDivider />
       <InfrastructureActivity />

--- a/apps/studio/pages/project/[ref]/settings/infrastructure.tsx
+++ b/apps/studio/pages/project/[ref]/settings/infrastructure.tsx
@@ -16,7 +16,6 @@ const ProjectInfrastructure: NextPageWithLayout = () => {
       <ScaffoldContainer>
         <ScaffoldHeader>
           <ScaffoldTitle>Infrastructure</ScaffoldTitle>
-
           <ScaffoldDescription>
             General information regarding your server instance
           </ScaffoldDescription>

--- a/apps/studio/pages/project/[ref]/settings/integrations.tsx
+++ b/apps/studio/pages/project/[ref]/settings/integrations.tsx
@@ -1,9 +1,25 @@
 import IntegrationSettings from 'components/interfaces/Settings/Integrations/IntegrationsSettings'
 import { SettingsLayout } from 'components/layouts'
+import {
+  ScaffoldContainer,
+  ScaffoldDivider,
+  ScaffoldHeader,
+  ScaffoldTitle,
+} from 'components/layouts/Scaffold'
 import type { NextPageWithLayout } from 'types'
 
 const OrgIntegrationSettings: NextPageWithLayout = () => {
-  return <IntegrationSettings />
+  return (
+    <>
+      <ScaffoldContainer>
+        <ScaffoldHeader>
+          <ScaffoldTitle>Integrations</ScaffoldTitle>
+        </ScaffoldHeader>
+      </ScaffoldContainer>
+      <ScaffoldDivider />
+      <IntegrationSettings />
+    </>
+  )
 }
 
 OrgIntegrationSettings.getLayout = (page) => <SettingsLayout>{page}</SettingsLayout>

--- a/apps/studio/pages/project/[ref]/settings/storage.tsx
+++ b/apps/studio/pages/project/[ref]/settings/storage.tsx
@@ -1,14 +1,28 @@
 import { SettingsLayout } from 'components/layouts'
+import {
+  ScaffoldContainer,
+  ScaffoldDescription,
+  ScaffoldHeader,
+  ScaffoldTitle,
+} from 'components/layouts/Scaffold'
 import { StorageSettings } from 'components/to-be-cleaned/Storage'
 import { S3Connection } from 'components/to-be-cleaned/Storage/StorageSettings/S3Connection'
 import type { NextPageWithLayout } from 'types'
 
 const PageLayout: NextPageWithLayout = () => {
   return (
-    <div className="1xl:px-28 mx-auto flex flex-col gap-y-10 px-5 py-6 lg:px-16 xl:px-24 2xl:px-32 pb-32">
-      <StorageSettings />
-      <S3Connection />
-    </div>
+    <>
+      <ScaffoldContainer>
+        <ScaffoldHeader>
+          <ScaffoldTitle>Storage Settings</ScaffoldTitle>
+          <ScaffoldDescription>Configure your project's storage settings</ScaffoldDescription>
+        </ScaffoldHeader>
+      </ScaffoldContainer>
+      <ScaffoldContainer className="flex flex-col gap-10">
+        <StorageSettings />
+        <S3Connection />
+      </ScaffoldContainer>
+    </>
   )
 }
 

--- a/apps/studio/pages/project/[ref]/settings/storage.tsx
+++ b/apps/studio/pages/project/[ref]/settings/storage.tsx
@@ -18,7 +18,7 @@ const PageLayout: NextPageWithLayout = () => {
           <ScaffoldDescription>Configure your project's storage settings</ScaffoldDescription>
         </ScaffoldHeader>
       </ScaffoldContainer>
-      <ScaffoldContainer className="flex flex-col gap-10">
+      <ScaffoldContainer className="flex flex-col gap-10" bottomPadding>
         <StorageSettings />
         <S3Connection />
       </ScaffoldContainer>

--- a/apps/studio/pages/project/[ref]/settings/vault/keys.tsx
+++ b/apps/studio/pages/project/[ref]/settings/vault/keys.tsx
@@ -11,6 +11,13 @@ import type { NextPageWithLayout } from 'types'
 import ShimmeringLoader from 'components/ui/ShimmeringLoader'
 import Link from 'next/link'
 import VaultNavTabs from 'components/interfaces/Settings/Vault/VaultNavTabs'
+import {
+  ScaffoldColumn,
+  ScaffoldContainer,
+  ScaffoldDescription,
+  ScaffoldHeader,
+  ScaffoldTitle,
+} from 'components/layouts/Scaffold'
 
 const VaultSettingsSecrets: NextPageWithLayout = () => {
   const { ref } = useParams()
@@ -25,23 +32,30 @@ const VaultSettingsSecrets: NextPageWithLayout = () => {
   const isEnabled = vaultExtension !== undefined && vaultExtension.installed_version !== null
 
   return (
-    <div className="1xl:px-28 mx-auto flex flex-col px-5 py-6 lg:px-16 xl:px-24 2xl:px-32 ">
-      <FormHeader title="Vault" description="Application level encryption for your project" />
-      {isLoading ? (
-        <div className="border rounded border-default p-12 space-y-2">
-          <ShimmeringLoader />
-          <ShimmeringLoader className="w-3/4" />
-          <ShimmeringLoader className="w-1/2" />
-        </div>
-      ) : !isEnabled ? (
-        <VaultToggle />
-      ) : (
-        <>
-          <VaultNavTabs projRef={ref || ''} activeTab={'keys'} />
-          <EncryptionKeysManagement />
-        </>
-      )}
-    </div>
+    <>
+      <ScaffoldContainer>
+        <ScaffoldHeader>
+          <ScaffoldTitle>Vault</ScaffoldTitle>
+          <ScaffoldDescription>Application level encryption for your project</ScaffoldDescription>
+        </ScaffoldHeader>
+      </ScaffoldContainer>
+      <ScaffoldContainer>
+        {isLoading ? (
+          <div className="border rounded border-default p-12 space-y-2">
+            <ShimmeringLoader />
+            <ShimmeringLoader className="w-3/4" />
+            <ShimmeringLoader className="w-1/2" />
+          </div>
+        ) : !isEnabled ? (
+          <VaultToggle />
+        ) : (
+          <>
+            <VaultNavTabs projRef={ref || ''} activeTab={'keys'} />
+            <EncryptionKeysManagement />
+          </>
+        )}
+      </ScaffoldContainer>
+    </>
   )
 }
 

--- a/apps/studio/pages/project/[ref]/settings/vault/keys.tsx
+++ b/apps/studio/pages/project/[ref]/settings/vault/keys.tsx
@@ -39,7 +39,7 @@ const VaultSettingsSecrets: NextPageWithLayout = () => {
           <ScaffoldDescription>Application level encryption for your project</ScaffoldDescription>
         </ScaffoldHeader>
       </ScaffoldContainer>
-      <ScaffoldContainer>
+      <ScaffoldContainer bottomPadding>
         {isLoading ? (
           <div className="border rounded border-default p-12 space-y-2">
             <ShimmeringLoader />

--- a/apps/studio/pages/project/[ref]/settings/vault/secrets.tsx
+++ b/apps/studio/pages/project/[ref]/settings/vault/secrets.tsx
@@ -8,6 +8,12 @@ import ShimmeringLoader from 'components/ui/ShimmeringLoader'
 import { useDatabaseExtensionsQuery } from 'data/database-extensions/database-extensions-query'
 import type { NextPageWithLayout } from 'types'
 import VaultNavTabs from 'components/interfaces/Settings/Vault/VaultNavTabs'
+import {
+  ScaffoldContainer,
+  ScaffoldDescription,
+  ScaffoldHeader,
+  ScaffoldTitle,
+} from 'components/layouts/Scaffold'
 
 const VaultSettingsSecrets: NextPageWithLayout = () => {
   const router = useRouter()
@@ -23,23 +29,30 @@ const VaultSettingsSecrets: NextPageWithLayout = () => {
   const isEnabled = vaultExtension !== undefined && vaultExtension.installed_version !== null
 
   return (
-    <div className="1xl:px-28 mx-auto flex flex-col px-5 py-6 lg:px-16 xl:px-24 2xl:px-32 ">
-      <FormHeader title="Vault" description="Application level encryption for your project" />
-      {isLoading ? (
-        <div className="border rounded border-default p-12 space-y-2">
-          <ShimmeringLoader />
-          <ShimmeringLoader className="w-3/4" />
-          <ShimmeringLoader className="w-1/2" />
-        </div>
-      ) : !isEnabled ? (
-        <VaultToggle />
-      ) : (
-        <>
-          <VaultNavTabs projRef={ref || ''} activeTab="secrets" />
-          <SecretsManagement />
-        </>
-      )}
-    </div>
+    <>
+      <ScaffoldContainer>
+        <ScaffoldHeader>
+          <ScaffoldTitle>Vault</ScaffoldTitle>
+          <ScaffoldDescription>Application level encryption for your project</ScaffoldDescription>
+        </ScaffoldHeader>
+      </ScaffoldContainer>
+      <ScaffoldContainer>
+        {isLoading ? (
+          <div className="border rounded border-default p-12 space-y-2">
+            <ShimmeringLoader />
+            <ShimmeringLoader className="w-3/4" />
+            <ShimmeringLoader className="w-1/2" />
+          </div>
+        ) : !isEnabled ? (
+          <VaultToggle />
+        ) : (
+          <>
+            <VaultNavTabs projRef={ref || ''} activeTab="secrets" />
+            <SecretsManagement />
+          </>
+        )}
+      </ScaffoldContainer>
+    </>
   )
 }
 

--- a/apps/studio/pages/project/[ref]/settings/vault/secrets.tsx
+++ b/apps/studio/pages/project/[ref]/settings/vault/secrets.tsx
@@ -36,7 +36,7 @@ const VaultSettingsSecrets: NextPageWithLayout = () => {
           <ScaffoldDescription>Application level encryption for your project</ScaffoldDescription>
         </ScaffoldHeader>
       </ScaffoldContainer>
-      <ScaffoldContainer>
+      <ScaffoldContainer bottomPadding>
         {isLoading ? (
           <div className="border rounded border-default p-12 space-y-2">
             <ShimmeringLoader />

--- a/apps/studio/styles/main.scss
+++ b/apps/studio/styles/main.scss
@@ -254,3 +254,7 @@ div[data-radix-portal]:not(.portal--toast) {
 [data-radix-popper-content-wrapper] {
   @apply z-50 #{!important};
 }
+
+.settings-container {
+  @apply mx-auto max-w-4xl xl:max-w-6xl;
+}

--- a/packages/ui/src/components/NavMenu/index.tsx
+++ b/packages/ui/src/components/NavMenu/index.tsx
@@ -12,7 +12,9 @@ export const NavMenu = forwardRef<HTMLDivElement, NavMenuProps>(
   ) => {
     return (
       <nav ref={forwardedRef} dir="ltr" {...props} className={cn('border-b', props.className)}>
-        <ul role="menu">{props.children}</ul>
+        <ul role="menu" className="flex gap-3">
+          {props.children}
+        </ul>
       </nav>
     )
   }
@@ -31,7 +33,7 @@ export const NavMenuItem = ({
     aria-selected={active ? 'true' : 'false'}
     data-state={active ? 'active' : 'inactive'}
     className={cn(
-      'inline-flex items-center justify-center whitespace-nowrap text-sm ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground text-foreground-lighter hover:text-foreground data-[state=active]:border-foreground border-b-2 border-transparent *:px-3 *:py-1.5',
+      'inline-flex items-center justify-center whitespace-nowrap text-sm ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground text-foreground-lighter hover:text-foreground data-[state=active]:border-foreground border-b-2 border-transparent *:py-1.5',
       className
     )}
     {...props}

--- a/packages/ui/src/components/NavMenu/index.tsx
+++ b/packages/ui/src/components/NavMenu/index.tsx
@@ -12,7 +12,7 @@ export const NavMenu = forwardRef<HTMLDivElement, NavMenuProps>(
   ) => {
     return (
       <nav ref={forwardedRef} dir="ltr" {...props} className={cn('border-b', props.className)}>
-        <ul role="menu" className="flex gap-3">
+        <ul role="menu" className="flex gap-5">
           {props.children}
         </ul>
       </nav>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

init layouts for project settings

after:
<img width="2201" alt="Screenshot 2024-05-27 at 5 15 53 PM" src="https://github.com/supabase/supabase/assets/8291514/8b8b7207-6997-4451-a560-c4d809d3e873">

before:
<img width="2198" alt="Screenshot 2024-05-27 at 5 15 46 PM" src="https://github.com/supabase/supabase/assets/8291514/0281f39a-b1b6-4613-9d87-af27092c4d92">
