### PR TITLE
Fix connect ui bg

### DIFF
--- a/apps/studio/components/interfaces/Home/Connect/Connect.tsx
+++ b/apps/studio/components/interfaces/Home/Connect/Connect.tsx
@@ -170,7 +170,7 @@ const Connect = () => {
             </span>
           </Button>
         </DialogTrigger>
-        <DialogContent className={cn('sm:max-w-5xl p-0')}>
+        <DialogContent className={cn('sm:max-w-5xl p-0 bg-surface-100')}>
           <DialogHeader className="pb-0">
             <DialogTitle>Connect to your project</DialogTitle>
             <DialogDescription>

--- a/apps/studio/components/interfaces/Reports/ReportWidget.tsx
+++ b/apps/studio/components/interfaces/Reports/ReportWidget.tsx
@@ -45,13 +45,7 @@ const ReportWidget = (props: ReportWidgetProps) => {
   const projectRef = ref as string
 
   return (
-    <Panel
-      noMargin
-      noHideOverflow
-      className={cn('pb-0', props.className)}
-      bodyClassName="h-full"
-      wrapWithLoading={false}
-    >
+    <Panel noMargin noHideOverflow className={cn('pb-0', props.className)} wrapWithLoading={false}>
       <Panel.Content className="space-y-4">
         <div className="flex flex-row items-start justify-between">
           <div className="gap-2">

--- a/apps/studio/components/interfaces/Settings/Database/DatabaseSettings/DatabaseConnectionString.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/DatabaseSettings/DatabaseConnectionString.tsx
@@ -169,7 +169,7 @@ export const DatabaseConnectionString = ({ appearance }: DatabaseConnectionStrin
     <div id="connection-string" className="w-full">
       <Panel
         className={cn(
-          '!m-0 [&>div:nth-child(1)]:!border-0 [&>div:nth-child(1)]:!p-0',
+          '!m-0 [&>div:nth-child(1)]:!border-0 [&>div:nth-child(1)]:!p-0 bg-transparent',
           appearance === 'minimal' && 'border-0 shadow-none'
         )}
         bodyClassName={cn(appearance === 'minimal' && 'bg-transparent')}

--- a/apps/studio/components/interfaces/Settings/Database/DatabaseSettings/DatabaseConnectionString.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/DatabaseSettings/DatabaseConnectionString.tsx
@@ -169,10 +169,9 @@ export const DatabaseConnectionString = ({ appearance }: DatabaseConnectionStrin
     <div id="connection-string" className="w-full">
       <Panel
         className={cn(
-          '!m-0 [&>div:nth-child(1)]:!border-0 [&>div:nth-child(1)]:!p-0 bg-transparent',
-          appearance === 'minimal' && 'border-0 shadow-none'
+          '!m-0 [&>div:nth-child(1)]:!border-0 [&>div:nth-child(1)]:!p-0',
+          appearance === 'minimal' && 'border-0 shadow-none bg-transparent'
         )}
-        bodyClassName={cn(appearance === 'minimal' && 'bg-transparent')}
         titleClasses={cn(appearance === 'minimal' && 'bg-transparent')}
         title={
           <div

--- a/apps/studio/components/ui/Panel.tsx
+++ b/apps/studio/components/ui/Panel.tsx
@@ -2,7 +2,6 @@ import { PropsWithChildren, ReactNode } from 'react'
 import { Loading, cn } from 'ui'
 
 interface PanelProps {
-  bodyClassName?: string
   className?: string
   footer?: JSX.Element | false
   loading?: boolean


### PR DESCRIPTION
1. fixes bg on connect ui 

before
![screenshot-2024-05-27-at-09 17 23](https://github.com/supabase/supabase/assets/105593/2f876939-b3ce-49e0-bcdb-5ebe7b1dd6e5)


after
![screenshot-2024-05-27-at-09 17 00](https://github.com/supabase/supabase/assets/105593/c913c5ec-19b4-41df-b98f-3a044a202beb)


Note the other instance of this still looks good:
![screenshot-2024-05-27-at-09 25 00](https://github.com/supabase/supabase/assets/105593/a504e3d6-6a25-45d1-b2ca-49b48c62c700)


2. removes unused bodyClassName prop from the <Panel> component