### PR TITLE
add await to this return function filterSerializedResponseHeaders

### DIFF
--- a/apps/docs/content/guides/auth/server-side/sveltekit.mdx
+++ b/apps/docs/content/guides/auth/server-side/sveltekit.mdx
@@ -118,7 +118,7 @@ const supabase: Handle = async ({ event, resolve }) => {
     return { session, user }
   }
 
-  return resolve(event, {
+  return await resolve(event, {
     filterSerializedResponseHeaders(name) {
       /**
        * Supabase libraries use the `content-range` and `x-supabase-api-version`


### PR DESCRIPTION
return await resolve(event, {
    filterSerializedResponseHeaders(name) {
      /**
       * Supabase libraries use the `content-range` and `x-supabase-api-version`
       * headers, so we need to tell SvelteKit to pass it through. */ return name === 'content-range' || name === 'x-supabase-api-version' }, })

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES/NO

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
