### PR TITLE
26733: Add await to resolve() in documentation for sveltekit.

### DIFF
--- a/apps/docs/content/guides/auth/auth-helpers/sveltekit.mdx
+++ b/apps/docs/content/guides/auth/auth-helpers/sveltekit.mdx
@@ -94,7 +94,7 @@ export const handle = async ({ event, resolve }) => {
     return { session, user }
   }
 
-  return resolve(event, {
+  return await resolve(event, {
     filterSerializedResponseHeaders(name) {
       return name === 'content-range' || name === 'x-supabase-api-version'
     },
@@ -141,7 +141,7 @@ export const handle: Handle = async ({ event, resolve }) => {
     return { session, user }
   }
 
-  return resolve(event, {
+  return await resolve(event, {
     filterSerializedResponseHeaders(name) {
       return name === 'content-range' || name === 'x-supabase-api-version'
     },
@@ -677,7 +677,7 @@ async function supabase({ event, resolve }) {
     return { session, user }
   }
 
-  return resolve(event, {
+  return await resolve(event, {
     filterSerializedResponseHeaders(name) {
       return name === 'content-range' || name === 'x-supabase-api-version'
     },
@@ -703,7 +703,7 @@ async function authorization({ event, resolve }) {
     }
   }
 
-  return resolve(event)
+  return await resolve(event)
 }
 
 export const handle = sequence(supabase, authorization)
@@ -745,7 +745,7 @@ async function supabase({ event, resolve }) {
     return { session, user }
   }
 
-  return resolve(event, {
+  return await resolve(event, {
     filterSerializedResponseHeaders(name) {
       return name === 'content-range' || name === 'x-supabase-api-version'
     },
@@ -771,7 +771,7 @@ async function authorization({ event, resolve }) {
     }
   }
 
-  return resolve(event)
+  return await resolve(event)
 }
 
 export const handle: Handle = sequence(supabase, authorization)
@@ -970,7 +970,7 @@ export const handle: Handle = async ({ event, resolve }) => {
     return { session, user }
   }
 
-  return resolve(event, {
+  return await resolve(event, {
     filterSerializedResponseHeaders(name) {
       return name === 'content-range' || name === 'x-supabase-api-version'
     },

--- a/apps/docs/content/guides/auth/server-side/creating-a-client.mdx
+++ b/apps/docs/content/guides/auth/server-side/creating-a-client.mdx
@@ -493,7 +493,7 @@ export const handle: Handle = async ({ event, resolve }) => {
     return { session, user }
   }
 
-  return resolve(event, {
+  return await resolve(event, {
     filterSerializedResponseHeaders(name) {
       return name === 'content-range' || name === 'x-supabase-api-version'
     },

--- a/apps/docs/content/guides/auth/server-side/sveltekit.mdx
+++ b/apps/docs/content/guides/auth/server-side/sveltekit.mdx
@@ -118,7 +118,7 @@ const supabase: Handle = async ({ event, resolve }) => {
     return { session, user }
   }
 
-  return resolve(event, {
+  return await resolve(event, {
     filterSerializedResponseHeaders(name) {
       /**
        * Supabase libraries use the `content-range` and `x-supabase-api-version`
@@ -142,7 +142,7 @@ const authGuard: Handle = async ({ event, resolve }) => {
     return redirect(303, '/private')
   }
 
-  return resolve(event)
+  return await resolve(event)
 }
 
 export const handle: Handle = sequence(supabase, authGuard)

--- a/apps/docs/content/guides/getting-started/tutorials/with-sveltekit.mdx
+++ b/apps/docs/content/guides/getting-started/tutorials/with-sveltekit.mdx
@@ -109,7 +109,7 @@ export const handle: Handle = async ({ event, resolve }) => {
     return { session, user }
   }
 
-  return resolve(event, {
+  return await resolve(event, {
     filterSerializedResponseHeaders(name) {
       return name === 'content-range' || name === 'x-supabase-api-version'
     },


### PR DESCRIPTION
This prevents a race condition in which headers are modified (setting cookies) after being sent.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Documentation update

## What is the current behavior?

Sometimes this code causes a race condition in which the code attempts to modify the cookies after the headers have been sent.
```
  return resolve(event, {
    filterSerializedResponseHeaders(name) {
      return name === 'content-range' || name === 'x-supabase-api-version'
    },
  })
 ```

## What is the new behavior?

The new behavior awaits on the `resolve()` so cookies are set before the return of the local function, and consequently before headers are sent.

```
  return await resolve(event, {
   filterSerializedResponseHeaders(name) {
     return name === 'content-range' || name === 'x-supabase-api-version'
   },
 })
```

This seems to correlate the [sveltekit samples](https://kit.svelte.dev/docs/hooks) in which `resolve()` is always awaited.

## Additional context


