### PR TITLE
docs(js): add example for deleting a record and returning it

### DIFF
--- a/apps/docs/spec/supabase_js_v2.yml
+++ b/apps/docs/spec/supabase_js_v2.yml
@@ -4128,6 +4128,42 @@ functions:
         hideCodeBlock: true
         isSpotlight: true
 
+      - id: delete-records-and-return-it
+        name: Delete a record and return it
+        code: |
+          ```ts
+          const { data, error } = await supabase
+            .from('countries')
+            .delete()
+            .eq('id', 1)
+            .select()
+          ```
+        data:
+          sql: |
+            ```sql
+            create table
+              countries (id int8 primary key, name text);
+
+            insert into
+              countries (id, name)
+            values
+              (1, 'Spain');
+            ```
+        response: |
+          ```json
+          {
+            "data": [
+              {
+                "id": 1,
+                "name": "Spain"
+              }
+            ],
+            "status": 200,
+            "statusText": "OK"
+          }
+          ```
+        hideCodeBlock: true
+
       - id: delete-multiple-records
         name: Delete multiple records
         code: |
@@ -4155,8 +4191,7 @@ functions:
             "statusText": "No Content"
           }
           ```
-        hideCodeBlock: false
-        isSpotlight: false
+        hideCodeBlock: true
 
   - id: rpc
     title: 'Postgres functions: rpc()'

--- a/apps/docs/spec/supabase_js_v2.yml
+++ b/apps/docs/spec/supabase_js_v2.yml
@@ -4102,7 +4102,7 @@ functions:
         name: Delete a single record
         code: |
           ```ts
-          const { error } = await supabase
+          const response = await supabase
             .from('countries')
             .delete()
             .eq('id', 1)
@@ -4168,7 +4168,7 @@ functions:
         name: Delete multiple records
         code: |
           ```ts
-          const { error } = await supabase
+          const response = await supabase
             .from('countries')
             .delete()
             .in('id', [1, 2, 3])


### PR DESCRIPTION
We have the example for returning modified rows on insert and update, but not delete

Also make it obvious that `status` and `statusText` comes from the whole response object, not `data` or `error`

Related: https://github.com/supabase/postgrest-js/issues/535