### PR TITLE
fix(sveltekit ssr docs): createBrowserClient use

### DIFF
--- a/apps/docs/content/guides/auth/server-side/creating-a-client.mdx
+++ b/apps/docs/content/guides/auth/server-side/creating-a-client.mdx
@@ -514,26 +514,33 @@ Page components can get access to the supabase client from the `data` object due
 ```ts +layout.ts
 import { PUBLIC_SUPABASE_ANON_KEY, PUBLIC_SUPABASE_URL } from '$env/static/public'
 import type { LayoutLoad } from './$types'
-import { createBrowserClient, isBrowser, parse } from '@supabase/ssr'
+import { createBrowserClient, createServerClient, isBrowser, parse } from '@supabase/ssr'
 
 export const load: LayoutLoad = async ({ fetch, data, depends }) => {
   depends('supabase:auth')
 
-  const supabase = createBrowserClient(PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY, {
-    global: {
-      fetch,
-    },
-    cookies: {
-      get(key) {
-        if (!isBrowser()) {
-          return JSON.stringify(data.session)
-        }
-
-        const cookie = parse(document.cookie)
-        return cookie[key]
-      },
-    },
-  })
+  const supabase = isBrowser()
+    ? createBrowserClient(PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY, {
+        global: {
+          fetch,
+        },
+        cookies: {
+          get(key) {
+            const cookie = parse(document.cookie)
+            return cookie[key]
+          },
+        },
+      })
+    : createServerClient(PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY, {
+        global: {
+          fetch,
+        },
+        cookies: {
+          get() {
+            return JSON.stringify(data.session)
+          },
+        },
+      })
 
   /**
    * It's fine to use `getSession` here, because on the client, `getSession` is


### PR DESCRIPTION
In the abbreviated SvelteKit SSR instructions, `createBrowserClient` is used in hybrid code that runs on both the server and client, with changes in the configuration depending on where it's run. That's just confusing, because the name implies it should not run on the server.

Change it to match the [full SvelteKit SSR tutorial](https://supabase.com/docs/guides/auth/server-side/sveltekit), which selectively runs `createBrowserClient` or `createServerClient` depending on the current environment.