### PR TITLE
doc: Remove redundant calls to assign response within the set and remove

### DIFF
--- a/apps/docs/content/guides/auth/server-side/nextjs.mdx
+++ b/apps/docs/content/guides/auth/server-side/nextjs.mdx
@@ -248,12 +248,7 @@ export async function updateSession(request: NextRequest) {
             name,
             value,
             ...options,
-          })
-          response = NextResponse.next({
-            request: {
-              headers: request.headers,
-            },
-          })
+          })         
           response.cookies.set({
             name,
             value,
@@ -265,11 +260,6 @@ export async function updateSession(request: NextRequest) {
             name,
             value: '',
             ...options,
-          })
-          response = NextResponse.next({
-            request: {
-              headers: request.headers,
-            },
           })
           response.cookies.set({
             name,


### PR DESCRIPTION
Analysis of the Current Implementation
1. Initial NextResponse.next() Call: The initial call to NextResponse.next() creates a response object that is intended to be modified and eventually returned by the middleware function. This response object is configured to carry over the headers from the incoming request.
2. Subsequent NextResponse.next() Calls: Within both the set and remove methods for cookies, there is a reassignment of the response variable to a new NextResponse.next() call. This effectively creates a new response object each time a cookie is set or removed. Each of these new response objects also carries over the headers from the original request, just like the initial response object.

Issues with Repeated Calls
Redundancy: Each new call to NextResponse.next() with the same headers configuration does not add any new functionality or change the behavior in a meaningful way compared to the initial response object. Performance Concerns: Creating multiple response objects unnecessarily can lead to increased processing time and memory usage, which is generally undesirable, especially in a middleware that should be as efficient as possible. Potential for Bugs: Repeatedly reassigning the response variable could lead to bugs or confusion about the state of the response at any given point in the middleware's execution. Suggested Improvement
You can optimize the code by maintaining a single response object and modifying it as needed without recreating it multiple times. Here’s how you could refactor the code:

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

Redundant code in the sample

## What is the new behavior?

Simpler sample code

## Additional context

N/A
