### PR TITLE
add panel to show selected log in logs explorer, and some ui fixes

### DIFF
--- a/apps/studio/components/interfaces/DataWarehouse/WarehouseCollectionDetail.tsx
+++ b/apps/studio/components/interfaces/DataWarehouse/WarehouseCollectionDetail.tsx
@@ -128,7 +128,7 @@ export const WarehouseCollectionDetail = () => {
               data={results}
               params={params}
               maxHeight="calc(100vh - 139px)"
-              hideHeader={true}
+              showHeader={false}
               emptyState={
                 <ProductEmptyState
                   title="Send your first event"

--- a/apps/studio/components/interfaces/Settings/Logs/LogSelection.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogSelection.tsx
@@ -224,8 +224,12 @@ const LogSelection = ({
                 <TabsContent_Shadcn_ className="bg-surface-100 space-y-6" value="details">
                   <Formatter />
                 </TabsContent_Shadcn_>
-                <TabsContent_Shadcn_ value="raw" className="px-4">
-                  <CodeBlock language="json" className="prose w-full max-w-full">
+                <TabsContent_Shadcn_ value="raw">
+                  <CodeBlock
+                    hideLineNumbers
+                    language="json"
+                    className="prose w-full pt-0 max-w-full border-none"
+                  >
                     {JSON.stringify(fullLog || partialLog, null, 2)}
                   </CodeBlock>
                 </TabsContent_Shadcn_>

--- a/apps/studio/components/interfaces/Settings/Logs/LogSelectionRenderers/DefaultExplorerSelectionRenderer.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogSelectionRenderers/DefaultExplorerSelectionRenderer.tsx
@@ -12,7 +12,7 @@ const DefaultExplorerSelectionRenderer = ({ log }: any) => {
     code?: boolean
   }) => {
     return (
-      <div className="grid grid-cols-12">
+      <div className="flex gap-2 flex-wrap">
         <span className="text-foreground-lighter text-sm col-span-3">{label}</span>
         <span
           className={`text-foreground text-sm col-span-9 overflow-x-auto ${
@@ -33,10 +33,7 @@ const DefaultExplorerSelectionRenderer = ({ log }: any) => {
     <div className="overflow-hidden overflow-x-auto space-y-6">
       {Object.entries(log).map(([key, value], index) => {
         return (
-          <div
-            key={`${key}-${index}`}
-            className={`${LOGS_TAILWIND_CLASSES.log_selection_x_padding}`}
-          >
+          <div key={`${key}-${index}`} className="px-4 pb-4">
             {value && typeof value === 'object' ? (
               <DetailedJsonRow label={key} value={value} />
             ) : (

--- a/apps/studio/components/interfaces/Settings/Logs/LogsFormatters.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogsFormatters.tsx
@@ -30,7 +30,7 @@ export const SelectionDetailedRow = ({
   valueRender?: React.ReactNode
 }) => {
   return (
-    <div className="grid grid-cols-12 group items-center">
+    <div className="group flex items-center gap-2 flex-wrap relative">
       <span className="text-foreground-lighter text-sm col-span-3 whitespace-pre-wrap">
         {label}
       </span>
@@ -43,7 +43,7 @@ export const SelectionDetailedRow = ({
       <CopyButton
         iconOnly
         text={value}
-        className="group-hover:opacity-100 opacity-0 p-0 h-6 w-6 col-span-1"
+        className="group-hover:opacity-100 opacity-0 p-0 h-6 w-6 col-span-1 absolute top-1 right-1"
         type="text"
         title="Copy to clipboard"
       />

--- a/apps/studio/pages/project/[ref]/logs/explorer/index.tsx
+++ b/apps/studio/pages/project/[ref]/logs/explorer/index.tsx
@@ -222,6 +222,7 @@ export const LogsExplorerPage: NextPageWithLayout = () => {
         <ResizablePanel collapsible minSize={5} className="flex flex-col flex-grow">
           <LoadingOpacity active={isLoading}>
             <LogTable
+              showHistogramToggle={false}
               onRun={handleRun}
               onSave={handleOnSave}
               hasEditorValue={Boolean(editorValue)}

--- a/apps/studio/styles/react-data-grid-logs.scss
+++ b/apps/studio/styles/react-data-grid-logs.scss
@@ -15,7 +15,7 @@
 
   .rdg-row {
     &.rdg-row--focused {
-      @apply border-r border-brand bg-background-surface-300;
+      @apply border-r border-brand;
       border-right-width: 4px;
     }
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YE

- users can now click the logs in the logs explorer grid to show the full log detail.

![CleanShot 2024-05-31 at 22 03 16@2x](https://github.com/supabase/supabase/assets/37541088/58e79caa-0b87-4a2e-87f2-f3082608c98a)

