### PR TITLE
docs: correct max storage upload size

### DIFF
--- a/apps/docs/content/guides/storage/uploads/s3-uploads.mdx
+++ b/apps/docs/content/guides/storage/uploads/s3-uploads.mdx
@@ -17,7 +17,7 @@ The S3 protocol supports file upload using:
 
 The `PutObject` action uploads the file in a single request. This matches the behavior of the Supabase SDK [Standard Upload](/docs/guides/storage/uploads/standard-uploads).
 
-Use `PutObject` to upload smaller files, where retrying the entire upload won't be an issue. The maximum file size on paid plans is 5 GB.
+Use `PutObject` to upload smaller files, where retrying the entire upload won't be an issue. The maximum file size on paid plans is 50 GB.
 
 For example, using JavaScript and the `aws-sdk` client:
 


### PR DESCRIPTION
Should be 50 GB ([pricing page](https://supabase.com/pricing) is source of truth)