### PR TITLE
fix: show execution ID in Function invocation details

### DIFF
--- a/apps/studio/components/interfaces/Settings/Logs/LogSelectionRenderers/FunctionInvocationSelectionRender.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogSelectionRenderers/FunctionInvocationSelectionRender.tsx
@@ -29,6 +29,7 @@ const FunctionInvocationSelectionRender = ({ log }: { log: PreviewLogData }) => 
         <SelectionDetailedRow label="Method" value={method} />
         <SelectionDetailedTimestampRow value={log.timestamp} />
         <SelectionDetailedRow label="Execution Time" value={`${executionTimeMs}ms`} />
+        <SelectionDetailedRow label="Execution ID" value={metadata.execution_id} />
         <SelectionDetailedRow label="Deployment ID" value={deploymentId} />
         <SelectionDetailedRow label="Log ID" value={log.id} />
         {requestUrl !== undefined && (


### PR DESCRIPTION
## What kind of change does this PR introduce?

Show Execution ID in Function invocation details view.
