### PR TITLE
feat(docs): track last-changed date

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -97,6 +97,7 @@
     "jest-environment-jsdom": "^29.7.0",
     "npm-run-all": "^4.1.5",
     "openapi-types": "^12.1.3",
+    "simple-git": "^3.24.0",
     "tsconfig": "*",
     "tsx": "^4.6.2",
     "typescript": "^5.4.3"

--- a/apps/docs/scripts/helpers.mdx.ts
+++ b/apps/docs/scripts/helpers.mdx.ts
@@ -13,7 +13,7 @@ import { filter } from 'unist-util-filter'
 
 type Json = Record<string, string | number | boolean | null | Json[] | { [key: string]: Json }>
 
-type Section = {
+interface Section {
   content: string
   heading?: string
   slug?: string

--- a/apps/docs/scripts/helpers.mdx.ts
+++ b/apps/docs/scripts/helpers.mdx.ts
@@ -13,7 +13,7 @@ import { filter } from 'unist-util-filter'
 
 type Json = Record<string, string | number | boolean | null | Json[] | { [key: string]: Json }>
 
-interface Section {
+type Section = {
   content: string
   heading?: string
   slug?: string

--- a/apps/docs/scripts/last-changed.ts
+++ b/apps/docs/scripts/last-changed.ts
@@ -1,0 +1,265 @@
+/**
+ * Updates the `last_changed` table with new content changes.
+ *
+ * The default behavior is to match checksums to determine the `last_changed`
+ * date.
+ *
+ * Options:
+ *
+ * --reset, -r
+ *  If the `reset` flag is given, the `last_changed` date is determined from
+ *  the last Git commit date.
+ */
+
+import 'dotenv/config'
+
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+import matter from 'gray-matter'
+import { createHash } from 'node:crypto'
+import { readdirSync } from 'node:fs'
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { parseArgs } from 'node:util'
+import { simpleGit } from 'simple-git'
+
+import { Section } from './helpers.mdx'
+
+interface Options {
+  reset: boolean
+}
+
+interface SectionWithChecksum extends Section {
+  checksum: string
+}
+
+const REQUIRED_ENV_VARS = {
+  SUPABASE_URL: 'NEXT_PUBLIC_SUPABASE_URL',
+  SERVICE_ROLE_KEY: 'SUPABASE_SERVICE_ROLE_KEY',
+} as const
+
+async function main() {
+  console.log('Updating content change times...')
+
+  checkEnv()
+
+  const { reset } = parseOptions()
+  const supabase = createSupabaseClient()
+
+  await updateContentDates({ reset, supabase })
+
+  console.log('Content change times successfully updated')
+}
+
+function checkEnv() {
+  const requiredEnvVars = Object.values(REQUIRED_ENV_VARS)
+
+  for (const variable of requiredEnvVars) {
+    if (!process.env[variable]) {
+      abortWithError(`Missing required environment variable: ${variable}`)
+    }
+  }
+}
+
+function abortWithError(message: string) {
+  console.error(message)
+  process.exit(1)
+}
+
+function parseOptions(): Options {
+  const args = process.argv.slice(2)
+  const options = {
+    reset: {
+      type: 'boolean',
+      short: 'r',
+    },
+  } as const
+
+  const {
+    values: { reset },
+  } = parseArgs({ args, options })
+  return { reset: reset ?? false }
+}
+
+function createSupabaseClient() {
+  return createClient(
+    process.env[REQUIRED_ENV_VARS.SUPABASE_URL],
+    process.env[REQUIRED_ENV_VARS.SERVICE_ROLE_KEY]
+  )
+}
+
+async function updateContentDates({
+  supabase,
+  reset,
+}: {
+  supabase: SupabaseClient
+  reset: boolean
+}) {
+  const CONTENT_DIR = getContentDir()
+  const mdxFiles = await walkDir(CONTENT_DIR)
+
+  const timestamp = new Date()
+
+  const updateTasks: Array<Promise<void>> = []
+  for (const file of mdxFiles) {
+    const tasks = await updateTimestamps(file, { supabase, reset, timestamp })
+    updateTasks.push(...tasks)
+  }
+  await Promise.all(updateTasks)
+
+  await cleanupObsoleteRows(timestamp, supabase)
+}
+
+function getContentDir() {
+  return join(__dirname, '..', 'content')
+}
+
+async function walkDir(fullPath: string) {
+  const allFiles = readdirSync(fullPath, { withFileTypes: true, recursive: true })
+  const mdxFiles = allFiles
+    .filter((file) => file.isFile() && file.name.endsWith('.mdx'))
+    .map((file) => join(file.parentPath, file.name))
+  return mdxFiles
+}
+
+async function updateTimestamps(
+  filePath: string,
+  { supabase, reset, timestamp }: { supabase: SupabaseClient; reset: boolean; timestamp: Date }
+) {
+  try {
+    const content = await readFile(filePath, 'utf-8')
+    const sections = processMdx(content)
+    return sections.map((section) =>
+      reset
+        ? updateTimestampsWithLastCommitDate(filePath, section, timestamp, supabase)
+        : updateTimestampsWithChecksumMatch(filePath, section, timestamp, supabase).catch(() =>
+            updateTimestampsWithLastCommitDate(filePath, section, timestamp, supabase)
+          )
+    )
+  } catch (err) {
+    console.error(`Failed to update sections for file ${filePath}`)
+  }
+}
+
+function processMdx(rawContent: string): Array<SectionWithChecksum> {
+  const { content } = matter(rawContent)
+
+  const GLOBAL_HEADING_REGEX = /(?:^|\n)(?=#+\s+[^\n]+[\n$])/g
+  const sections = content.split(GLOBAL_HEADING_REGEX)
+
+  const seenHeadings = new Map<string, number>()
+
+  const HEADING_MATCH_REGEX = /^#+\s+([^\n]+)[\n$]/
+  const result: Array<SectionWithChecksum> = sections.map((section) => {
+    const rawHeading = section.match(HEADING_MATCH_REGEX)?.[1] ?? null
+
+    let heading = rawHeading
+    if (rawHeading && seenHeadings.has(rawHeading)) {
+      const idx = seenHeadings.get(rawHeading) + 1
+      seenHeadings.set(rawHeading, idx)
+      heading = `${rawHeading} (${idx})`
+    } else if (rawHeading) {
+      seenHeadings.set(rawHeading, 1)
+    }
+
+    const normalizedSection = section
+      .trim()
+      .replace(/[\n\t]/g, ' ')
+      .replace(/\s+/g, ' ')
+    const checksum = createHash('sha256').update(normalizedSection).digest('base64')
+
+    return {
+      heading,
+      content: normalizedSection,
+      checksum,
+    }
+  })
+
+  return result
+}
+
+async function updateTimestampsWithLastCommitDate(
+  filePath: string,
+  section: SectionWithChecksum,
+  timestamp: Date,
+  supabase: SupabaseClient
+) {
+  try {
+    const git = simpleGit()
+    const updatedAt = (await git.raw('log', '-1', '--format=%cI', filePath)).trim()
+
+    const contentDir = getContentDir()
+    const parentPage = `/content${filePath.replace(contentDir, '')}`
+
+    await supabase.from('last_changed').upsert(
+      {
+        parent_page: parentPage,
+        heading: section.heading,
+        checksum: section.checksum,
+        last_updated: updatedAt,
+        last_checked: timestamp,
+      },
+      { onConflict: 'parent_page,heading' }
+    )
+  } catch (err) {
+    console.error(
+      `Failed to update timestamp with last commit date for section ${filePath}${section.heading ? `:${section.heading}` : ''}`
+    )
+  }
+}
+
+async function updateTimestampsWithChecksumMatch(
+  filePath: string,
+  section: SectionWithChecksum,
+  timestamp: Date,
+  supabase: SupabaseClient
+) {
+  const contentDir = getContentDir()
+  const parentPage = `/content${filePath.replace(contentDir, '')}`
+
+  try {
+    const { data } =
+      'heading' in section && section.heading
+        ? await supabase
+            .from('last_changed')
+            .select('id,checksum')
+            .eq('parent_page', parentPage)
+            .eq('heading', section.heading)
+            .maybeSingle()
+        : await supabase
+            .from('last_changed')
+            .select('id,checksum')
+            .eq('parent_page', parentPage)
+            .is('heading', null)
+
+    if (!data || !('id' in data) || !('checksum' in data)) {
+      await updateTimestampsWithLastCommitDate(filePath, section, timestamp, supabase)
+    } else {
+      const hasChanged = data.checksum !== section.checksum
+      if (!hasChanged) return
+
+      await supabase.from('last_changed').update({
+        id: data.id,
+        checksum: section.checksum,
+        last_updated: timestamp,
+        last_checked: timestamp,
+      })
+    }
+  } catch (err) {
+    console.error(
+      `Failed to update the following section via checksum match: ${parentPage}${section.heading ? `:${section.heading}` : ''}`
+    )
+
+    // Rethrow error to trigger fallback update via Git commit date
+    throw err
+  }
+}
+
+async function cleanupObsoleteRows(timestamp: Date, supabase: SupabaseClient) {
+  try {
+    await supabase.from('last_changed').delete().neq('last_checked', timestamp)
+  } catch (err) {
+    console.error(`Error cleanup obsolete rows: ${err}`)
+  }
+}
+
+main()

--- a/package-lock.json
+++ b/package-lock.json
@@ -787,6 +787,7 @@
         "jest-environment-jsdom": "^29.7.0",
         "npm-run-all": "^4.1.5",
         "openapi-types": "^12.1.3",
+        "simple-git": "^3.24.0",
         "tsconfig": "*",
         "tsx": "^4.6.2",
         "typescript": "^5.4.3"
@@ -9225,6 +9226,21 @@
       "version": "3.4.0",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/@kwsites/file-exists": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1"
+      }
+    },
+    "node_modules/@kwsites/promise-deferred": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+      "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
+      "dev": true
     },
     "node_modules/@lezer/common": {
       "version": "1.1.0",
@@ -46393,6 +46409,21 @@
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/simple-git": {
+      "version": "3.24.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.24.0.tgz",
+      "integrity": "sha512-QqAKee9Twv+3k8IFOFfPB2hnk6as6Y6ACUpwCtQvRYBAes23Wv3SZlHVobAzqcE8gfsisCvPw3HGW3HYM+VYYw==",
+      "dev": true,
+      "dependencies": {
+        "@kwsites/file-exists": "^1.1.1",
+        "@kwsites/promise-deferred": "^1.1.1",
+        "debug": "^4.3.4"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/steveukx/git-js?sponsor=1"
       }
     },
     "node_modules/simple-swizzle": {

--- a/supabase/migrations/20240604035404_last_changed.sql
+++ b/supabase/migrations/20240604035404_last_changed.sql
@@ -2,7 +2,7 @@ create table last_changed (
 	id bigint primary key generated always as identity,
 	checksum text not null,
 	parent_page text not null,
-	heading text,
+	heading text not null,
 	last_updated timestamp with time zone default now() not null,
 	last_checked timestamp with time zone default now() not null,
 	unique (parent_page, heading)

--- a/supabase/migrations/20240604035404_last_changed.sql
+++ b/supabase/migrations/20240604035404_last_changed.sql
@@ -1,0 +1,28 @@
+create table last_changed (
+	id bigint primary key generated always as identity,
+	checksum text not null,
+	parent_page text not null,
+	heading text,
+	last_updated timestamp with time zone default now() not null,
+	last_checked timestamp with time zone default now() not null,
+	unique (parent_page, heading)
+);
+
+comment on table last_changed is
+'Records when page sections from docs content were last edited.';
+comment on column last_changed.checksum is
+'Checksum of most recent section contents.';
+comment on column last_changed.parent_page is
+'Path of the page containing this section.';
+comment on column last_changed.last_updated is
+'When the content was last edited.';
+comment on column last_changed.last_checked is
+'When the content was last checked. Used to identify and delete obsolete sections.';
+
+alter table last_changed enable row level security;
+
+revoke all on last_changed from anon;
+revoke all on last_changed from authenticated;
+
+create index idx_last_changed_parent_page_btree
+on last_changed (parent_page);


### PR DESCRIPTION
Add a table to track the last-changed date for docs content, and a script to seed the database with last-changed dates based on Git commit dates.

After the schema changes are in prod, I'll run the script to seed the table, and make a followup PR to update the timestamps when PRs are merged into master.

The point of doing this rather than just relying on Git commits is that the timestamp updates on merge will check section checksums, to avoid prematurely updating timestamps for _sections_ that were not edited even though the _parent file_ was updated. (In other words, we might have a very old section in a file where some other section was very recently edited, and we want to be able to detect the very old section.)