### PR TITLE
feat(command menu v2): complete state management

### DIFF
--- a/packages/ui-patterns/CommandMenu/internal/state/pagesState.test.ts
+++ b/packages/ui-patterns/CommandMenu/internal/state/pagesState.test.ts
@@ -1,0 +1,107 @@
+import { PageType, initPagesState, type IPagesState, type PageDefinition } from './pagesState'
+
+describe('pagesState', () => {
+  let pagesState: IPagesState
+
+  beforeEach(() => {
+    pagesState = initPagesState()
+  })
+
+  it('Starts with an empty page stack', () => {
+    expect(pagesState.pageStack.length).toBe(0)
+  })
+
+  it('Starts with no pages', () => {
+    expect(Object.keys(pagesState.commandPages).length).toBe(0)
+  })
+
+  it('Registers a new page', () => {
+    const newPage: PageDefinition = {
+      type: PageType.Commands,
+      sections: [],
+    }
+
+    pagesState.registerNewPage('page', newPage)
+
+    expect(pagesState.commandPages.page).toStrictEqual(newPage)
+  })
+
+  it('Returned function unregisters the page', () => {
+    const newPage: PageDefinition = {
+      type: PageType.Commands,
+      sections: [],
+    }
+
+    const unregister = pagesState.registerNewPage('page', newPage)
+    expect(pagesState.commandPages.page).toStrictEqual(newPage)
+
+    unregister()
+    expect(Object.keys(pagesState.commandPages).length).toBe(0)
+  })
+
+  it('Registered page can be appended to page stack', () => {
+    const newPage: PageDefinition = {
+      type: PageType.Commands,
+      sections: [],
+    }
+
+    pagesState.registerNewPage('page', newPage)
+    pagesState.appendPageStack('page')
+
+    expect(pagesState.pageStack.length).toBe(1)
+    expect(pagesState.pageStack[0]).toBe('page')
+  })
+
+  it('Non-registered page cannot be appended to page stack', () => {
+    pagesState.appendPageStack('invalid')
+
+    expect(pagesState.pageStack.length).toBe(0)
+  })
+
+  it('Unregistered page cannot be appended to page stack', () => {
+    const newPage: PageDefinition = {
+      type: PageType.Commands,
+      sections: [],
+    }
+
+    const unregister = pagesState.registerNewPage('page', newPage)
+    unregister()
+
+    pagesState.appendPageStack('page')
+
+    expect(pagesState.pageStack.length).toBe(0)
+  })
+
+  it('Noops if reappending the currently active page', () => {
+    const newPage: PageDefinition = {
+      type: PageType.Commands,
+      sections: [],
+    }
+
+    pagesState.registerNewPage('page', newPage)
+
+    pagesState.appendPageStack('page')
+    pagesState.appendPageStack('page')
+
+    expect(pagesState.pageStack.length).toBe(1)
+    expect(pagesState.pageStack[0]).toBe('page')
+  })
+
+  it('Unregistered page is automatically popped from stack', () => {
+    const newPage: PageDefinition = {
+      type: PageType.Commands,
+      sections: [],
+    }
+
+    const unregister = pagesState.registerNewPage('page', newPage)
+    pagesState.appendPageStack('page')
+    expect(pagesState.pageStack.length).toBe(1)
+
+    unregister()
+    expect(pagesState.pageStack.length).toBe(0)
+  })
+
+  it('Does not error when popping from empty pagestack', () => {
+    expect(() => pagesState.popPageStack()).not.toThrowError()
+  })
+})

--- a/packages/ui-patterns/CommandMenu/internal/state/pagesState.ts
+++ b/packages/ui-patterns/CommandMenu/internal/state/pagesState.ts
@@ -1,0 +1,58 @@
+import { type ReactNode } from 'react'
+import { proxy } from 'valtio'
+
+import { type ICommandSection } from '../CommandSection'
+
+type PageComponent = () => ReactNode
+
+enum PageType {
+  Commands,
+  Component,
+}
+
+interface CommandsPage {
+  type: PageType.Commands
+  sections: ICommandSection[]
+}
+
+interface ComponentPage {
+  type: PageType.Component
+  component: PageComponent
+}
+
+type PageDefinition = CommandsPage | ComponentPage
+
+const isCommandsPage = (page: PageDefinition): page is CommandsPage =>
+  page.type === PageType.Commands
+const isComponentPage = (page: PageDefinition): page is ComponentPage =>
+  page.type === PageType.Component
+
+type IPagesState = {
+  commandPages: Record<string, PageDefinition>
+  pageStack: Array<string>
+  registerNewPage: (name: string, page: PageDefinition) => () => void
+  appendPageStack: (name: string) => void
+  popPageStack: () => void
+}
+
+const initPagesState = () => {
+  const state: IPagesState = proxy({
+    commandPages: {},
+    pageStack: [],
+    registerNewPage: (name, definition) => {
+      state.commandPages[name] = definition
+      return () => {
+        state.pageStack = state.pageStack.filter((page) => page !== name)
+        delete state.commandPages[name]
+      }
+    },
+    appendPageStack: (name) =>
+      name in state.commandPages && state.pageStack.at(-1) !== name && state.pageStack.push(name),
+    popPageStack: () => state.pageStack.pop(),
+  })
+
+  return state
+}
+
+export { PageType, initPagesState, isCommandsPage, isComponentPage }
+export type { IPagesState, PageDefinition }

--- a/packages/ui-patterns/CommandMenu/internal/state/queryState.ts
+++ b/packages/ui-patterns/CommandMenu/internal/state/queryState.ts
@@ -1,0 +1,17 @@
+import { proxy } from 'valtio'
+
+type IQueryState = {
+  query: string
+  setQuery: (newQuery: string) => void
+}
+
+const initQueryState = () => {
+  const state: IQueryState = proxy({
+    query: '',
+    setQuery: (newQuery) => (state.query = newQuery),
+  })
+  return state
+}
+
+export { initQueryState }
+export type { IQueryState }

--- a/packages/ui-patterns/CommandMenu/internal/state/viewState.ts
+++ b/packages/ui-patterns/CommandMenu/internal/state/viewState.ts
@@ -1,0 +1,39 @@
+import { proxy } from 'valtio'
+
+type DialogSize = 'small' | 'tiny' | 'medium' | 'large' | 'xlarge' | 'xxlarge' | 'xxxlarge'
+
+type IViewState = {
+  initiated: boolean
+  init: () => void
+  open: boolean
+  setOpen: (open: boolean) => void
+  toggleOpen: () => void
+  isNavigating: boolean
+  setIsNavigating: (isNavigating: boolean) => void
+  size: DialogSize
+  setSize: (size: DialogSize) => void
+}
+
+const initViewState = () => {
+  const state: IViewState = proxy({
+    initiated: false,
+    init: () => !state.initiated && (state.initiated = true),
+    open: false,
+    setOpen: (open) => {
+      state.init()
+      state.open = open
+    },
+    toggleOpen: () => {
+      state.init()
+      state.open = !state.open
+    },
+    isNavigating: false,
+    setIsNavigating: (isNavigating) => (state.isNavigating = isNavigating),
+    size: 'large',
+    setSize: (size) => (state.size = size),
+  })
+  return state
+}
+
+export { initViewState }
+export type { DialogSize, IViewState }


### PR DESCRIPTION
Add all the outstanding pieces for state management of new command menu:

- Pages state (handles routing between command menu views, e.g., docs search, AI, etc.)
- View state (handles opening and closing and initiation (needed for lazy loading))
- Query state (handles active search term)