### PR TITLE
chore: remove custom domain activation warning

### DIFF
--- a/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainActivate.tsx
+++ b/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainActivate.tsx
@@ -159,8 +159,8 @@ const CustomDomainActivate = ({ projectRef, customDomain }: CustomDomainActivate
         onConfirm={onActivateCustomDomain}
       >
         <p className="text-sm">
-          This will activate the custom domain <code>{customDomain.hostname}</code> for the project{' '}
-          <code>{projectRef}</code>. This action can be undone at any time.
+          This will activate the custom domain <code>{customDomain.hostname}</code>. Your project's
+          Supabase domain will also remain active.
         </p>
       </ConfirmationModal>
     </>

--- a/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainActivate.tsx
+++ b/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainActivate.tsx
@@ -158,7 +158,10 @@ const CustomDomainActivate = ({ projectRef, customDomain }: CustomDomainActivate
         onCancel={() => setIsActivateConfirmModalVisible(false)}
         onConfirm={onActivateCustomDomain}
       >
-        <p className="text-sm">The existing Supabase subdomain will be deactivated.</p>
+        <p className="text-sm">
+          This will activate the custom domain <code>{customDomain.hostname}</code> for the project{' '}
+          <code>{projectRef}</code>. This action can be undone at any time.
+        </p>
       </ConfirmationModal>
     </>
   )


### PR DESCRIPTION
## What kind of change does this PR introduce?

chore/fix

## What is the current behavior?

Custom domains previously could not be used interchangeably with the old supabase domain.

## What is the new behavior?

> The project's Supabase domain remains active

https://supabase.com/docs/guides/platform/custom-domains#prepare-to-activate-your-domain