### PR TITLE
Feat: Add stale Action for marking stale issues and Action to auto label new issues with source

### DIFF
--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -36,7 +36,7 @@ jobs:
         USERNAME: ${{ github.event.issue.user.login }}
         GH_REPO: ${{ github.repository }}
         NUMBER: ${{ github.event.issue.number }}
-        LABELS: contributor-issue
+        LABELS: external-issue
       run: |
         echo "applying external label"
         gh issue edit $NUMBER --add-label $LABELS

--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -1,0 +1,65 @@
+name: Auto Label Issues
+on:
+  issues:
+    types: [opened, reopened]
+jobs:
+  check-external:
+    runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.is-member.outputs.result }}
+    steps:
+    - name: Get deps
+      run: |
+        sudo apt-get update && sudo apt-get install -y jq
+    - name: Get org members
+      id: is-member
+      env:
+        GH_ORG: supabase
+        GH_USER: ${{ github.event.issue.user.login }}
+        GH_TOKEN: ${{ secrets.SB_ORG_MEMBERSHIP_PAT }}
+      run: |
+        gh api /orgs/supabase/members/$GH_USER
+    - if: failure()
+      name: is-member
+      run: |
+        echo "User is not a member of Supabase org"
+        echo "result=false" >> "$GITHUB_OUTPUT"
+    - if: success()
+      run: |
+        echo "User is a member of Supabase org"
+        echo "result=true" >> "$GITHUB_OUTPUT"
+    - name: Label contributor
+      id: label-contributor
+      if:  ${{ steps.is-member.outputs.result == 'false' }}
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        USERNAME: ${{ github.event.issue.user.login }}
+        GH_REPO: ${{ github.repository }}
+        NUMBER: ${{ github.event.issue.number }}
+        LABELS: contributor-issue
+      run: |
+        echo "applying external label"
+        gh issue edit $NUMBER --add-label $LABELS
+    - name: Label internal
+      id: label-internal
+      if:  ${{ steps.is-member.outputs.result == 'true' }}
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        USERNAME: ${{ github.event.issue.user.login }}
+        GH_REPO: ${{ github.repository }}
+        NUMBER: ${{ github.event.issue.number }}
+        LABELS: internal-issue
+      run: |
+        echo "applying internal label"
+        gh issue edit $NUMBER --add-label $LABELS
+  triage-new:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label triage
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NUMBER: ${{ github.event.issue.number }}
+          LABELS: to-triage
+        run: |
+          echo "applying triage label"
+          gh issue edit $NUMBER --add-label $LABELS

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,18 @@
+name: Automatically label stale issues
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label Stale Issues
+        uses: actions/stale@v9.0.0
+        with:
+          days-before-issue-stale: 30
+          stale-issue-message: 'After 30 days of inactivity, this issue has been marked as stale. Commenting (or other activity) will remove the stale label.'
+          stale-issue-label: stale
+          any-of-labels: contributor
+          exempt-issue-labels: dnc, needs-analysis
+          exempt-all-assignees: true


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Feature

## What is the current behavior?

New issues are not labelled and old issues are not marked as `stale`

## What is the new behavior?

1. All new issues are marked with `to-triage`
2. All new issues are marked with `contributor` if they are opened by the community or `internal` if they  are opened by someone from within the Supabase org
3. After 30 days of inactivity, issues opened by someone outside of the Supabase org are marked as `stale` (but not closed)

## Additional context

Add any other context or screenshots.
