### PR TITLE
feat: update last_changed table daily

### DIFF
--- a/.github/workflows/docs-last-changed.yml
+++ b/.github/workflows/docs-last-changed.yml
@@ -3,11 +3,8 @@ name: [Docs] Update last-changed dates
 on:
   # Temporarily turned off until the action is validated manually
   #
-  # push:
-  #   branches:
-  #     - master
-  #   paths:
-  #     - 'apps/docs/content/**'
+  # schedule:
+  #   - cron: '0 0 * * *'
   workflow_dispatch:
     inputs:
       reset:

--- a/.github/workflows/docs-last-changed.yml
+++ b/.github/workflows/docs-last-changed.yml
@@ -1,4 +1,4 @@
-name: [Docs] Update last-changed dates
+name: "[Docs] Update last-changed dates"
 
 on:
   # Temporarily turned off until the action is validated manually

--- a/.github/workflows/docs-last-changed.yml
+++ b/.github/workflows/docs-last-changed.yml
@@ -1,0 +1,49 @@
+name: [Docs] Update last-changed dates
+
+on:
+  # Temporarily turned off until the action is validated manually
+  #
+  # push:
+  #   branches:
+  #     - master
+  #   paths:
+  #     - 'apps/docs/content/**'
+  workflow_dispatch:
+    inputs:
+      reset:
+        description: 'Reset last-updated dates using Git commit dates'
+        required: false
+        type: boolean
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    env:
+      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SEARCH_SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SEARCH_SUPABASE_SERVICE_ROLE_KEY }}
+
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            apps/docs
+
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Download dependencies
+        run: npm ci
+
+      - name: Update last-changed dates
+        working-directory: ./apps/docs
+        if: ${{ !inputs.reset }}
+        run: npm run last-changed
+
+      - name: Reset last-changed dates
+        working-directory: ./apps/docs
+        if: ${{ inputs.reset }}
+        run: npm run last-changed:reset

--- a/apps/docs/content/guides/ai.mdx
+++ b/apps/docs/content/guides/ai.mdx
@@ -6,6 +6,8 @@ subtitle: 'The best vector database is the database you already have.'
 hideToc: true
 ---
 
+TEST TEST
+
 Supabase provides an open source toolkit for developing AI applications using Postgres and pgvector. Use the Supabase client libraries to store, index, and query your vector embeddings at scale.
 
 The toolkit includes:

--- a/apps/docs/content/guides/ai.mdx
+++ b/apps/docs/content/guides/ai.mdx
@@ -6,7 +6,7 @@ subtitle: 'The best vector database is the database you already have.'
 hideToc: true
 ---
 
-SUPABASE provides an open source toolkit for developing AI applications using Postgres and pgvector. Use the Supabase client libraries to store, index, and query your vector embeddings at scale.
+Supabase provides an open source toolkit for developing AI applications using Postgres and pgvector. Use the Supabase client libraries to store, index, and query your vector embeddings at scale.
 
 The toolkit includes:
 

--- a/apps/docs/content/guides/ai.mdx
+++ b/apps/docs/content/guides/ai.mdx
@@ -6,7 +6,7 @@ subtitle: 'The best vector database is the database you already have.'
 hideToc: true
 ---
 
-Supabase provides an open source toolkit for developing AI applications using Postgres and pgvector. Use the Supabase client libraries to store, index, and query your vector embeddings at scale.
+SUPABASE provides an open source toolkit for developing AI applications using Postgres and pgvector. Use the Supabase client libraries to store, index, and query your vector embeddings at scale.
 
 The toolkit includes:
 

--- a/apps/docs/content/guides/ai.mdx
+++ b/apps/docs/content/guides/ai.mdx
@@ -6,8 +6,6 @@ subtitle: 'The best vector database is the database you already have.'
 hideToc: true
 ---
 
-TEST TEST
-
 Supabase provides an open source toolkit for developing AI applications using Postgres and pgvector. Use the Supabase client libraries to store, index, and query your vector embeddings at scale.
 
 The toolkit includes:

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -14,6 +14,8 @@
     "build:sitemap": "node ./internals/generate-sitemap.mjs",
     "embeddings": "tsx scripts/search/generate-embeddings.ts",
     "embeddings:refresh": "npm run embeddings -- --refresh",
+	"last-changed": "tsx scripts/last-changed.ts",
+	"last-changed:reset": "npm run last-changed -- --reset",
     "codemod:frontmatter": "node ./scripts/codemod/mdx-meta.mjs && prettier --write \"content/**/*.mdx\"",
     "postbuild": "node ./internals/generate-sitemap.mjs"
   },

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -14,8 +14,8 @@
     "build:sitemap": "node ./internals/generate-sitemap.mjs",
     "embeddings": "tsx scripts/search/generate-embeddings.ts",
     "embeddings:refresh": "npm run embeddings -- --refresh",
-	"last-changed": "tsx scripts/last-changed.ts",
-	"last-changed:reset": "npm run last-changed -- --reset",
+    "last-changed": "tsx scripts/last-changed.ts",
+    "last-changed:reset": "npm run last-changed -- --reset",
     "codemod:frontmatter": "node ./scripts/codemod/mdx-meta.mjs && prettier --write \"content/**/*.mdx\"",
     "postbuild": "node ./internals/generate-sitemap.mjs"
   },

--- a/apps/docs/scripts/last-changed.ts
+++ b/apps/docs/scripts/last-changed.ts
@@ -175,7 +175,7 @@ function processMdx(rawContent: string): Array<SectionWithChecksum> {
     if (seenHeadings.has(rawHeading)) {
       const idx = seenHeadings.get(rawHeading) + 1
       seenHeadings.set(rawHeading, idx)
-      heading = `${rawHeading} (${idx})`
+      heading = `${rawHeading} (__UNIQUE_MARKER__${idx})`
     } else {
       seenHeadings.set(rawHeading, 1)
     }
@@ -255,7 +255,7 @@ async function updateTimestampsWithChecksumMatch(
     if (error) {
       throw Error(error.message || 'Error running function to update checksum')
     }
-    if (timestamp.toISOString() === new Date(data).toISOString()) {
+    if (timestamp.toISOString() === new Date(data ?? null).toISOString()) {
       ctx.stats.sectionsUpdated++
     }
   } catch (err) {

--- a/apps/docs/scripts/last-changed.ts
+++ b/apps/docs/scripts/last-changed.ts
@@ -207,18 +207,21 @@ async function updateTimestampsWithLastCommitDate(
   try {
     const updatedAt = await getGitUpdatedAt(filePath, ctx)
 
-    const { error } = await ctx.supabase.from('last_changed').upsert(
-      {
-        parent_page: parentPage,
-        heading: section.heading,
-        checksum: section.checksum,
-        last_updated: updatedAt,
-        last_checked: timestamp,
-      },
-      {
-        onConflict: 'parent_page,heading',
-      }
-    )
+    const { error } = await ctx.supabase
+      .from('last_changed')
+      .upsert(
+        {
+          parent_page: parentPage,
+          heading: section.heading,
+          checksum: section.checksum,
+          last_updated: updatedAt,
+          last_checked: timestamp,
+        },
+        {
+          onConflict: 'parent_page,heading',
+        }
+      )
+      .lt('last_checked', timestamp)
     if (error) {
       throw Error(error.message ?? 'Failed to upsert')
     }

--- a/supabase/migrations/20240605171314_last_changed_update.sql
+++ b/supabase/migrations/20240605171314_last_changed_update.sql
@@ -66,6 +66,9 @@ end;
 $$
 ;
 
+revoke all on function public.update_last_changed_checksum
+from public, anon, authenticated;
+
 create or replace function cleanup_last_changed_pages()
 returns integer
 language plpgsql
@@ -93,3 +96,6 @@ begin
 end;
 $$
 ;
+
+revoke all on function public.cleanup_last_changed_pages
+from public, anon, authenticated;

--- a/supabase/migrations/20240605171314_last_changed_update.sql
+++ b/supabase/migrations/20240605171314_last_changed_update.sql
@@ -27,7 +27,9 @@ begin
     then
       update public.last_changed set
         last_checked = check_time
-        where last_changed.id = existing_id
+        where
+		  last_changed.id = existing_id
+		  and last_changed.last_checked < check_time
 		returning last_checked into updated_check_time
       ;
 
@@ -53,6 +55,7 @@ begin
           last_checked = check_time
         where
           last_changed.id = existing_id
+		  and last_changed.last_checked < check_time
 	  returning last_checked into updated_check_time
       ;
 

--- a/supabase/migrations/20240605171314_last_changed_update.sql
+++ b/supabase/migrations/20240605171314_last_changed_update.sql
@@ -1,0 +1,90 @@
+create or replace function update_last_changed_checksum(
+  new_parent_page text,
+  new_heading text,
+  new_checksum text,
+  git_update_time timestamp with time zone,
+  check_time timestamp with time zone  
+)
+returns timestamp with time zone
+language plpgsql
+as $$
+declare
+  existing_id bigint;
+  previous_checksum text;
+  updated_check_time timestamp with time zone;
+begin
+  select id, checksum into existing_id, previous_checksum
+    from public.last_changed
+    where
+      parent_page = new_parent_page
+      and heading = new_heading
+  ;
+
+  if existing_id is not null
+    and previous_checksum is not null
+    and previous_checksum = new_checksum
+
+    then
+      update public.last_changed set
+        last_checked = check_time
+        where last_changed.id = existing_id
+		returning last_checked into updated_check_time
+      ;
+
+    else
+      insert into public.last_changed (
+        parent_page,
+        heading,
+        checksum,
+        last_updated,
+        last_checked
+      ) values (
+        new_parent_page,
+        new_heading,
+        new_checksum,
+        git_update_time,
+        check_time
+      )
+      on conflict
+	    on constraint last_changed_parent_page_heading_key
+        do update set
+          checksum = new_checksum,
+          last_updated = git_update_time,
+          last_checked = check_time
+        where
+          last_changed.id = existing_id
+	  returning last_checked into updated_check_time
+      ;
+
+  end if;
+
+  return updated_check_time;
+end;
+$$
+
+create or replace function cleanup_last_changed_pages()
+returns integer
+language plpgsql
+as $$
+declare
+  newest_check_time timestamp with time zone;
+  number_deleted integer;
+begin
+  select last_checked into newest_check_time
+    from public.last_changed
+    order by last_checked desc
+    limit 1
+  ;
+
+  with deleted as (
+    delete from public.last_changed
+    where last_checked <> newest_check_time
+    returning id
+  )
+  select count(*)
+  from deleted
+  into number_deleted;
+
+  return number_deleted;
+end;
+$$

--- a/supabase/migrations/20240605171314_last_changed_update.sql
+++ b/supabase/migrations/20240605171314_last_changed_update.sql
@@ -61,6 +61,7 @@ begin
   return updated_check_time;
 end;
 $$
+;
 
 create or replace function cleanup_last_changed_pages()
 returns integer
@@ -88,3 +89,4 @@ begin
   return number_deleted;
 end;
 $$
+;


### PR DESCRIPTION
Keeps track of fine-grained (per section) edit times for docs content.

Once daily, a GitHub Action runs that:

- Checks whether content hashes have changed for each section
- Updates the table that tracks content edit times if the hashes have changed

**Note**: The cron job isn't scheduled yet. I'll run the Action manually a few times to validate it, then turn it on in another PR.

## Testing

You'll have to test locally because that's the only way to have the right env variables:

1. Reset your local database: `npx supabase db reset --local`. Make sure your `apps/docs/.env` file has the right values for the Supabase URL and service role key.
2. Seed the `last_changed` table by running the script: `npm --prefix=apps/docs run last-changed`
3. Check localhost:54321 to make sure the table is populated.
4. Open a random content MDX file and change a random heading.
5. Run the script again: `npm --prefix=apps/docs run last-changed`. The number of updated sections should be the same as for the last run, but the number of removed sections should be 1 (the row with the old heading should be removed).
6. Check localhost:54321 to see that the row with the old heading is gone and the row with the new heading is added.
7. Check to see that timestamps are updated: `select distinct last_checked from last_changed`