### PR TITLE
chore: adjust project transfer texts

### DIFF
--- a/apps/docs/content/guides/platform/project-transfer.mdx
+++ b/apps/docs/content/guides/platform/project-transfer.mdx
@@ -51,8 +51,7 @@ Similarly, for other usage metrics such as database size, egress, image transfor
 
 ## Things to watch out for
 
-Transferring a project comes with no downtime at all, we’re just moving things internally and not your infrastructure.
-
+- Transferring a project might come with a short 1-2 minute downtime if you're moving a project from a paid to a free plan.
 - You could lose access to certain project features depending on the plan of the target organization, i.e. moving a project from a Pro plan to a Free plan.
 - When moving your project to a Free plan, we also ensure you’re not exceeding your two free project limit. In these cases, it is best to upgrade your target organization to Pro plan first.
 - You could have less rights on the project depending on your role in the target organization, i.e. you were an Owner in the previous organization and only have a Read-Only role in the target organization.

--- a/apps/studio/components/interfaces/Settings/General/TransferProjectPanel/TransferProjectButton.tsx
+++ b/apps/studio/components/interfaces/Settings/General/TransferProjectPanel/TransferProjectButton.tsx
@@ -21,7 +21,6 @@ import { useOrganizationsQuery } from 'data/organizations/organizations-query'
 import { useProjectTransferMutation } from 'data/projects/project-transfer-mutation'
 import { useProjectTransferPreviewQuery } from 'data/projects/project-transfer-preview-query'
 import { useCheckPermissions, useFlag, useSelectedProject } from 'hooks'
-import { formatCurrency } from 'lib/helpers'
 import { InfoIcon } from 'ui-patterns/Icons/StatusIcons'
 
 const TransferProjectButton = () => {
@@ -117,7 +116,7 @@ const TransferProjectButton = () => {
         onCancel={() => toggle()}
         visible={isOpen}
         loading={isTransferring}
-        size={'large'}
+        size={'xlarge'}
         header={`Transfer project ${project?.name}`}
         customFooter={
           <div className="flex items-center space-x-2 justify-end">
@@ -158,8 +157,11 @@ const TransferProjectButton = () => {
                 <IconLoader />
               </span>
               <div>
-                <p className="font-bold">No downtime</p>
-                <p>There is no downtime or restrictions involved when transferring a project.</p>
+                <p className="font-bold">Possible downtime</p>
+                <p>
+                  There might be a short downtime when transferring projects from a paid to a free
+                  organization.
+                </p>
               </div>
             </li>
 
@@ -222,78 +224,12 @@ const TransferProjectButton = () => {
                   ))}
                 </Listbox>
               )}
-
-              <p className="text-foreground-light text-sm">
-                The target organization needs to use{' '}
-                <Link
-                  href="https://supabase.com/docs/guides/platform/org-based-billing"
-                  target="_blank"
-                  rel="noreferrer"
-                  className="underline"
-                >
-                  organization-based billing
-                </Link>
-                . To migrate an organization to the new billing, head to your{' '}
-                <Link href="/org/_/billing" target="_blank" rel="noreferrer" className="underline">
-                  organizations billing settings
-                </Link>
-                .
-              </p>
             </div>
           )}
         </Modal.Content>
 
         <Loading active={selectedOrg !== undefined && transferPreviewIsLoading}>
           <Modal.Content>
-            {transferPreviewData && transferPreviewData.valid && (
-              <div className="text-sm text-foreground-light p-4 bg-surface-200">
-                {transferPreviewData.source_subscription_plan !==
-                transferPreviewData.target_subscription_plan ? (
-                  <div>
-                    <p>
-                      Your project is currently on the{' '}
-                      {transferPreviewData.source_subscription_plan} plan, whereas the target
-                      organization uses the {transferPreviewData.target_subscription_plan} plan.
-                    </p>
-                  </div>
-                ) : (
-                  <div>
-                    Your project and the target organization are both on the{' '}
-                    {transferPreviewData.source_subscription_plan} subscription plan.
-                  </div>
-                )}
-
-                <div className="my-4">
-                  {transferPreviewData.credits_on_source_organization === 0 ? (
-                    <span> Your current organization won't be granted any prorated credits.</span>
-                  ) : (
-                    <span>
-                      {' '}
-                      Your current organization will be granted{' '}
-                      <span className="text-brand">
-                        ${transferPreviewData.credits_on_source_organization}
-                      </span>{' '}
-                      in credits as proration.
-                    </span>
-                  )}
-                  {transferPreviewData.costs_on_target_organization === 0 ? (
-                    <span>
-                      {' '}
-                      The target organization won't be charged any immediate upfront payment.
-                    </span>
-                  ) : (
-                    <span>
-                      {' '}
-                      The target organization will be billed{' '}
-                      <span className="text-brand">
-                        {formatCurrency(transferPreviewData.costs_on_target_organization)}
-                      </span>{' '}
-                      immediately to prorate for the remainder of the billing period.
-                    </span>
-                  )}
-                </div>
-              </div>
-            )}
             {transferPreviewData && transferPreviewData.warnings.length > 0 && (
               <Alert
                 withIcon

--- a/apps/studio/components/interfaces/Settings/General/TransferProjectPanel/TransferProjectPanel.tsx
+++ b/apps/studio/components/interfaces/Settings/General/TransferProjectPanel/TransferProjectPanel.tsx
@@ -14,7 +14,7 @@ const TransferProjectPanel = () => {
     <section id="transfer-project">
       <FormHeader
         title="Transfer Project"
-        description="Transfer your project to a different organization with no downtime."
+        description="Transfer your project to a different organization."
       />
       <Panel>
         <Panel.Content>


### PR DESCRIPTION
## What kind of change does this PR introduce?

With recent changes to architecture, the previous texts are no longer accurate for all cases. Adjusted the texts and cleaned up the modal to concentrate on the relevant bits.

This is prep work for some API changes that will allow project transfers between paid and free plans with addons (will be auto-removed)