### PR TITLE
[Design System] fix: `<Sheet />` z-index value

### DIFF
--- a/packages/ui/src/components/shadcn/ui/sheet.tsx
+++ b/packages/ui/src/components/shadcn/ui/sheet.tsx
@@ -13,7 +13,7 @@ const SheetTrigger = SheetPrimitive.Trigger
 
 const SheetClose = SheetPrimitive.Close
 
-const portalVariants = cva('fixed inset-0 z-40 flex', {
+const portalVariants = cva('fixed inset-0 z-50 flex', {
   variants: {
     side: {
       top: 'items-start',
@@ -42,7 +42,7 @@ const SheetOverlay = React.forwardRef<
 >(({ className, children, ...props }, ref) => (
   <SheetPrimitive.Overlay
     className={cn(
-      'fixed inset-0 z-40 bg-alternative/90 backdrop-blur-sm transition-all duration-100 data-[state=closed]:animate-out data-[state=closed]:fade-out data-[state=open]:fade-in',
+      'fixed inset-0 z-50 bg-alternative/90 backdrop-blur-sm transition-all duration-100 data-[state=closed]:animate-out data-[state=closed]:fade-out data-[state=open]:fade-in',
       className
     )}
     {...props}
@@ -51,7 +51,7 @@ const SheetOverlay = React.forwardRef<
 ))
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
 
-const sheetVariants = cva('fixed z-40 scale-100 gap-4 bg-studio opacity-100 shadow-lg', {
+const sheetVariants = cva('fixed z-50 scale-100 gap-4 bg-studio opacity-100 shadow-lg', {
   variants: {
     side: {
       top: 'animate-in slide-in-from-top w-full duration-300 border-b',

--- a/packages/ui/src/lib/theme/defaultTheme.ts
+++ b/packages/ui/src/lib/theme/defaultTheme.ts
@@ -849,7 +849,7 @@ export default {
 
   sidepanel: {
     base: `
-      z-40
+      z-50
       bg-overlay
       flex flex-col
       fixed
@@ -902,7 +902,7 @@ export default {
       bg-border
     `,
     overlay: `
-      z-40
+      z-50
       fixed
       bg-alternative
       h-full w-full


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

- fixes issue where `<Sheet />` had a lower index value than other overlays. Meant that the order in DOM wasn't being respected.

## What is the current behavior?

- Adjusted z-index to `50` for sheet, as standard across the rest.

## Additional context

- Might be worth checking shadcn docs, report the bug if it's z-40 in there.
