### PR TITLE
[Dashboard] fix: dialog branching, add `block`

### DIFF
--- a/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/PlanUpdateSidePanel.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/PlanUpdateSidePanel.tsx
@@ -356,7 +356,7 @@ const PlanUpdateSidePanel = () => {
         visible={selectedTier !== undefined && selectedTier !== 'tier_free'}
         onCancel={() => setSelectedTier(undefined)}
         onConfirm={onUpdateSubscription}
-        overlayClassName="pointer-events-none"
+        dialogOverlayProps={{ className: 'pointer-events-none' }}
         header={`Confirm ${planMeta?.change_type === 'downgrade' ? 'downgrade' : 'upgrade'} to ${subscriptionPlanMeta?.name}`}
       >
         <Modal.Content>

--- a/apps/studio/components/layouts/AppLayout/EnableBranchingButton/EnableBranchingModal.tsx
+++ b/apps/studio/components/layouts/AppLayout/EnableBranchingButton/EnableBranchingModal.tsx
@@ -137,7 +137,7 @@ const EnableBranchingModal = () => {
         hideFooter
         visible={snap.showEnableBranchingModal}
         onCancel={() => snap.setShowEnableBranchingModal(false)}
-        className="!bg !max-w-[40rem]"
+        className="block"
         size="medium"
         hideClose
       >

--- a/packages/ui/src/components/Modal/Modal.tsx
+++ b/packages/ui/src/components/Modal/Modal.tsx
@@ -41,6 +41,7 @@ export interface ModalProps extends React.ComponentProps<typeof DialogContent> {
   variant?: ButtonVariantProps['type']
   overlayStyle?: React.CSSProperties
   contentStyle?: React.CSSProperties
+  dialogOverlayProps?: React.ComponentProps<typeof DialogContent>['dialogOverlayProps']
   // @deprecated please consider using <Dialog/> and <DialogTrigger/> components
   triggerElement?: React.ReactNode
   // @deprecated please consider using <Dialog/> and <DialogHeader/> components

--- a/packages/ui/src/components/Modal/Modal.tsx
+++ b/packages/ui/src/components/Modal/Modal.tsx
@@ -41,7 +41,6 @@ export interface ModalProps extends React.ComponentProps<typeof DialogContent> {
   variant?: ButtonVariantProps['type']
   overlayStyle?: React.CSSProperties
   contentStyle?: React.CSSProperties
-  overlayClassName?: string
   // @deprecated please consider using <Dialog/> and <DialogTrigger/> components
   triggerElement?: React.ReactNode
   // @deprecated please consider using <Dialog/> and <DialogHeader/> components
@@ -88,8 +87,6 @@ const Modal = forwardRef<
       style,
       overlayStyle,
       contentStyle,
-      className = '',
-      overlayClassName,
       triggerElement,
       header,
       modal,

--- a/packages/ui/src/components/shadcn/ui/dialog.tsx
+++ b/packages/ui/src/components/shadcn/ui/dialog.tsx
@@ -82,10 +82,13 @@ const DialogContentVariants = cva(
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> &
-    VariantProps<typeof DialogContentVariants> & { hideClose?: boolean }
->(({ className, children, size, hideClose, ...props }, ref) => (
+    VariantProps<typeof DialogContentVariants> & {
+      hideClose?: boolean
+      dialogOverlayProps?: React.ComponentPropsWithoutRef<typeof DialogOverlay>
+    }
+>(({ className, children, size, hideClose, dialogOverlayProps, ...props }, ref) => (
   <DialogPortal>
-    <DialogOverlay>
+    <DialogOverlay {...dialogOverlayProps}>
       <DialogPrimitive.Content
         ref={ref}
         className={cn(DialogContentVariants({ size }), className)}


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES/NO

## What kind of change does this PR introduce?

- Content of dialog was escaping. threw a display:block on the dialog content


