### PR TITLE
fix(last changed): timestamps from gh actions

### DIFF
--- a/.github/workflows/docs-last-changed.yml
+++ b/.github/workflows/docs-last-changed.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           sparse-checkout: |
             apps/docs
 


### PR DESCRIPTION
Need a fetch-depth 0 in order to preserve commit dates within GitHub Actions, otherwise a shallow fetch will use the current date as the commit date, which renders this entire flow useless.