### PR TITLE
chore: bump @supabase/sql-to-rest to v0.1.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19117,9 +19117,9 @@
       "integrity": "sha512-MPOaMkUlysDlP51e0h0PTIAXAPJwHvRb1szjxW2SRrCmH1dmKtg5PuwtR2sWAGRCajjutgx1ofPZuIYXj5mvzQ=="
     },
     "node_modules/@supabase/sql-to-rest": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@supabase/sql-to-rest/-/sql-to-rest-0.1.4.tgz",
-      "integrity": "sha512-CZmkvybmPuk3ggtIE+wITfaLEJKWi8H0z/ktS5tm/R9N+Q+YjsBykNs6WMjLxZsc4VNIJnZE5Fi2dLElXyRnDw==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@supabase/sql-to-rest/-/sql-to-rest-0.1.6.tgz",
+      "integrity": "sha512-06KgjeINtc6405XQvfnchBE1azEsU8G2NElfadmvVHKmHa5l2bFzjbtFbpaYgpgTzccHlcDmBaCgedVf2Gyl8Q==",
       "dependencies": {
         "@babel/parser": "^7.24.5",
         "libpg-query": "^15.1.0",
@@ -52902,7 +52902,7 @@
       "license": "MIT",
       "dependencies": {
         "@monaco-editor/react": "^4.6.0",
-        "@supabase/sql-to-rest": "^0.1.4",
+        "@supabase/sql-to-rest": "^0.1.6",
         "cmdk": "^0.2.1",
         "common": "*",
         "common-tags": "^1.8.2",

--- a/packages/ui-patterns/package.json
+++ b/packages/ui-patterns/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@monaco-editor/react": "^4.6.0",
-    "@supabase/sql-to-rest": "^0.1.4",
+    "@supabase/sql-to-rest": "^0.1.6",
     "cmdk": "^0.2.1",
     "common": "*",
     "common-tags": "^1.8.2",


### PR DESCRIPTION
Bumps [`@supabase/sql-to-rest`](https://github.com/supabase-community/sql-to-rest) to v0.1.6 which fixes:
- `select distinct` should not be supported
- aliases on resource embedding that are spread should be stripped ([related Twitter/X thread](https://x.com/spattanaik01/status/1798729072736162150))
- order by joined relation using incorrect syntax