### PR TITLE
chore: branches tabs use url state

### DIFF
--- a/apps/studio/components/interfaces/BranchManagement/BranchManagement.tsx
+++ b/apps/studio/components/interfaces/BranchManagement/BranchManagement.tsx
@@ -12,7 +12,7 @@ import { useBranchDeleteMutation } from 'data/branches/branch-delete-mutation'
 import { useBranchesDisableMutation } from 'data/branches/branches-disable-mutation'
 import { Branch, useBranchesQuery } from 'data/branches/branches-query'
 import { useGitHubConnectionsQuery } from 'data/integrations/github-connections-query'
-import { useSelectedOrganization, useSelectedProject } from 'hooks'
+import { useSelectedOrganization, useSelectedProject, useUrlState } from 'hooks'
 import { Button, IconExternalLink, IconGitHub } from 'ui'
 import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
 import TextConfirmModal from 'ui-patterns/Dialogs/TextConfirmModal'
@@ -37,7 +37,10 @@ const BranchManagement = () => {
   const projectRef =
     project !== undefined ? (isBranch ? project.parent_project_ref : ref) : undefined
 
-  const [view, setView] = useState<'overview' | 'prs' | 'branches'>('overview')
+  const [urlParams, setParams] = useUrlState()
+  const tab = (urlParams.tab ?? 'overview') as 'overview' | 'prs' | 'branches'
+  const setTab = (tab: 'overview' | 'prs' | 'branches') => setParams({ tab })
+
   const [showCreateBranch, setShowCreateBranch] = useState(false)
   const [showDisableBranching, setShowDisableBranching] = useState(false)
   const [selectedBranchToDelete, setSelectedBranchToDelete] = useState<Branch>()
@@ -146,27 +149,27 @@ const BranchManagement = () => {
                   <Button
                     type="default"
                     className={`rounded-r-none transition hover:opacity-90 ${
-                      view === 'overview' ? 'opacity-100' : 'opacity-60'
+                      tab === 'overview' ? 'opacity-100' : 'opacity-60'
                     }`}
-                    onClick={() => setView('overview')}
+                    onClick={() => setTab('overview')}
                   >
                     Overview
                   </Button>
                   <Button
                     type="default"
                     className={`rounded-none transition hover:opacity-90 ${
-                      view === 'prs' ? 'opacity-100' : 'opacity-60'
+                      tab === 'prs' ? 'opacity-100' : 'opacity-60'
                     }`}
-                    onClick={() => setView('prs')}
+                    onClick={() => setTab('prs')}
                   >
                     Pull requests
                   </Button>
                   <Button
                     type="default"
                     className={`rounded-l-none transition hover:opacity-90 ${
-                      view === 'branches' ? 'opacity-100' : 'opacity-60'
+                      tab === 'branches' ? 'opacity-100' : 'opacity-60'
                     }`}
-                    onClick={() => setView('branches')}
+                    onClick={() => setTab('branches')}
                   >
                     All branches
                   </Button>
@@ -237,26 +240,26 @@ const BranchManagement = () => {
                 </div>
               )}
 
-              {isErrorBranches && view === 'overview' && (
+              {isErrorBranches && tab === 'overview' && (
                 <AlertError error={branchesError} subject="Failed to retrieve preview branches" />
               )}
 
               {!isError && (
                 <>
-                  {view === 'overview' && (
+                  {tab === 'overview' && (
                     <Overview
                       isLoading={isLoading}
                       isSuccess={isSuccess}
                       repo={repo}
                       mainBranch={mainBranch}
                       previewBranches={previewBranches}
-                      onViewAllBranches={() => setView('branches')}
+                      onViewAllBranches={() => setTab('branches')}
                       onSelectCreateBranch={() => setShowCreateBranch(true)}
                       onSelectDeleteBranch={setSelectedBranchToDelete}
                       generateCreatePullRequestURL={generateCreatePullRequestURL}
                     />
                   )}
-                  {view === 'prs' && (
+                  {tab === 'prs' && (
                     <BranchManagementSection
                       header={`${branchesWithPRs.length} branches with pull requests found`}
                     >
@@ -280,7 +283,7 @@ const BranchManagement = () => {
                       )}
                     </BranchManagementSection>
                   )}
-                  {view === 'branches' && (
+                  {tab === 'branches' && (
                     <BranchManagementSection header={`${previewBranches.length} branches found`}>
                       {isLoadingBranches && <BranchLoader />}
                       {isErrorBranches && (

--- a/apps/studio/components/interfaces/BranchManagement/BranchManagement.tsx
+++ b/apps/studio/components/interfaces/BranchManagement/BranchManagement.tsx
@@ -25,6 +25,8 @@ import {
 } from './EmptyStates'
 import Overview from './Overview'
 
+type Tab = 'overview' | 'prs' | 'branches'
+
 const BranchManagement = () => {
   const router = useRouter()
   const { ref } = useParams()
@@ -38,8 +40,8 @@ const BranchManagement = () => {
     project !== undefined ? (isBranch ? project.parent_project_ref : ref) : undefined
 
   const [urlParams, setParams] = useUrlState()
-  const tab = (urlParams.tab ?? 'overview') as 'overview' | 'prs' | 'branches'
-  const setTab = (tab: 'overview' | 'prs' | 'branches') => setParams({ tab })
+  const tab = (urlParams.tab ?? 'overview') as Tab
+  const setTab = (tab: Tab) => setParams({ tab })
 
   const [showCreateBranch, setShowCreateBranch] = useState(false)
   const [showDisableBranching, setShowDisableBranching] = useState(false)

--- a/apps/studio/components/interfaces/BranchManagement/BranchManagement.tsx
+++ b/apps/studio/components/interfaces/BranchManagement/BranchManagement.tsx
@@ -39,8 +39,8 @@ const BranchManagement = () => {
   const projectRef =
     project !== undefined ? (isBranch ? project.parent_project_ref : ref) : undefined
 
-  const [urlParams, setParams] = useUrlState()
-  const tab = (urlParams.tab ?? 'overview') as Tab
+  const [urlParams, setParams] = useUrlState<{ tab: Tab }>()
+  const tab = urlParams.tab ?? 'overview'
   const setTab = (tab: Tab) => setParams({ tab })
 
   const [showCreateBranch, setShowCreateBranch] = useState(false)


### PR DESCRIPTION
## What kind of change does this PR introduce?

chore/feat

## What is the current behavior?

Branches tabs are not in the URL and so are not linkable

## What is the new behavior?

<img width="240" alt="Screenshot 2024-06-07 at 16 15 49" src="https://github.com/supabase/supabase/assets/10985857/53ffe133-9fda-47d7-b49e-8cfeac6374b6">

## Additional context

<img width="539" alt="Screenshot 2024-06-07 at 16 15 00" src="https://github.com/supabase/supabase/assets/10985857/8303f7f9-0953-4429-98b1-88ae18286d99">
