### PR TITLE
docs: fix the broken link

### DIFF
--- a/apps/docs/content/guides/auth/passwords.mdx
+++ b/apps/docs/content/guides/auth/passwords.mdx
@@ -123,7 +123,7 @@ The PKCE flow allows for server-side authentication. Unlike the implicit flow, w
 
 ##### Step 1: Update signup confirmation email
 
-Update your signup email template to send the token hash. See [Email Templates](/docs/guides/auth/email-templates) for how to configure your email templates.
+Update your signup email template to send the token hash. See [Email Templates](/docs/guides/auth/auth-email-templates) for how to configure your email templates.
 
 Your signup email template should contain the following HTML:
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

In the [password-based auth page](https://supabase.com/docs/guides/auth/passwords), the link to email templates in the PKCE flow tab is broken.

## What is the new behavior?

The link is updated for the correct page.
