### PR TITLE
Fix template overflow

### DIFF
--- a/apps/studio/components/interfaces/Auth/Policies/PolicyTemplates/TemplatesList.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/PolicyTemplates/TemplatesList.tsx
@@ -16,7 +16,7 @@ const TemplatesList = ({
   selectedTemplate,
   setSelectedTemplate = noop,
 }: TemplatesListProps) => (
-  <div className="flex flex-col justify-between border-r border-default" style={{ width: '30%' }}>
+  <div className="flex flex-col justify-between border-r border-default">
     <div
       className="hide-scrollbar  divide-border-primary space-y-0 divide-y divide-solid overflow-y-auto"
       style={{ maxHeight: '24rem' }}


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.
YES

## What kind of change does this PR introduce?
Bug fix - #27148 
Just removed `style = {{width = 30%}}` for the TemplateList comonent 

## What is the current behavior?
Policy Templates are overflowing from the modal on clicking quickly get started button.

## What is the new behavior?
Overflow is fived
![image](https://github.com/supabase/supabase/assets/120726854/a2910894-092f-48e4-aefa-be99a6633403)
