### PR TITLE
fix: remove warning on branching that services are not available

### DIFF
--- a/apps/docs/content/guides/platform/branching.mdx
+++ b/apps/docs/content/guides/platform/branching.mdx
@@ -22,7 +22,7 @@ If you understand Git, you already understand Supabase Branching.
 
 Supabase Branching works with Git. You can test changes in a separate, temporary environment without affecting your production setup. When you're ready to ship your changes, merge your branch to update your production instance with the new changes.
 
-You can run multiple Preview Branches for every Supabase project. Branches contain all the Supabase features with their own API credentials. Preview Environments pause automatically after <SharedData data="config">branching.inactivity_period_in_minutes</SharedData> minutes of inactivity.
+You can run multiple Preview Branches for every Supabase project. Branches contain all the Supabase features with their own API credentials. Preview Environments pause automatically after <SharedData data="config">branching.inactivity_period_in_minutes</SharedData> minutes of inactivity. Note that `pg_cron` executions will be impacted by inactivity related pausing.
 
 <figure className="max-w-[700px] mx-auto">
   <Image

--- a/apps/docs/content/guides/platform/branching.mdx
+++ b/apps/docs/content/guides/platform/branching.mdx
@@ -24,14 +24,6 @@ Supabase Branching works with Git. You can test changes in a separate, temporary
 
 You can run multiple Preview Branches for every Supabase project. Branches contain all the Supabase features with their own API credentials. Preview Environments pause automatically after 5 minutes of inactivity.
 
-<Admonition type="caution" label="Some features may not work as expected on Preview Branches">
-
-Due to Preview Branches running on Fly Postgres instances, some features like `pg-cron` are not fully supported.
-
-For a full list of limitations, see [Fly Postgres limitations](/docs/guides/platform/fly-postgres#limitations).
-
-</Admonition>
-
 <figure className="max-w-[700px] mx-auto">
   <Image
     className="hidden dark:block"

--- a/apps/docs/content/guides/platform/branching.mdx
+++ b/apps/docs/content/guides/platform/branching.mdx
@@ -22,7 +22,7 @@ If you understand Git, you already understand Supabase Branching.
 
 Supabase Branching works with Git. You can test changes in a separate, temporary environment without affecting your production setup. When you're ready to ship your changes, merge your branch to update your production instance with the new changes.
 
-You can run multiple Preview Branches for every Supabase project. Branches contain all the Supabase features with their own API credentials. Preview Environments pause automatically after 5 minutes of inactivity.
+You can run multiple Preview Branches for every Supabase project. Branches contain all the Supabase features with their own API credentials. Preview Environments pause automatically after <SharedData data="config">branching.inactivity_period_in_minutes</SharedData> minutes of inactivity.
 
 <figure className="max-w-[700px] mx-auto">
   <Image

--- a/packages/shared-data/config.ts
+++ b/packages/shared-data/config.ts
@@ -99,6 +99,11 @@ const config = {
       },
     },
   },
+  branching: {
+    inactivity_period_in_minutes: {
+      value: 5,
+    },
+  },
 } as const
 
 export default config


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Enforces the distinction between the capabilities of Fly Postgres and the capabilities of branching. We also convert the inactivity duration to a constant in config so it is easier to keep in sync.

Removes the callout mentioning that branches do not have all features due to use of Fly Postgres. This cuts down on confusion and allows us to roll out support for different features for both of those at different points in time, rather than having them unified

What it looks like post change:

<img width="674" alt="CleanShot 2024-06-11 at 11 57 51@2x" src="https://github.com/supabase/supabase/assets/8011761/5e0c416b-87db-4f32-b952-43549e0b0ff7">


Relevant Internal Discussion: https://supabase.slack.com/archives/C01D6TWFFFW/p1718096770383279

