### PR TITLE
Update actions/checkout to v4 for Node.js 20 compatibility 

### DIFF
--- a/apps/docs/content/guides/cli/managing-environments.mdx
+++ b/apps/docs/content/guides/cli/managing-environments.mdx
@@ -211,7 +211,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: supabase/setup-cli@v1
         with:
@@ -252,7 +252,7 @@ jobs:
       SUPABASE_PROJECT_ID: ${{ secrets.STAGING_PROJECT_ID }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: supabase/setup-cli@v1
         with:
@@ -284,7 +284,7 @@ jobs:
       SUPABASE_PROJECT_ID: ${{ secrets.PRODUCTION_PROJECT_ID }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: supabase/setup-cli@v1
         with:


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The current GitHub Actions workflow in the documentation uses actions/checkout@v3, which relies on Node.js 16. Node.js 16 is deprecated, causing a deprecation warning in the GitHub Actions workflow.

Issue: https://github.com/supabase/supabase/issues/27187

<img width="1649" alt="Screenshot 2024-06-11 at 12 42 16 PM" src="https://github.com/supabase/supabase/assets/25427129/951ab0b6-276f-4155-8d72-80226076bcf4">


## What is the new behavior?

This PR updates actions/checkout from v3 to v4 to ensure compatibility with Node.js 20. This update removes the deprecation warning related to Node.js 16 and ensures future compatibility with GitHub Actions infrastructure.

## Additional context

For more information, see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/ 
