### PR TITLE
New link for interpreting disk io

### DIFF
--- a/apps/studio/components/interfaces/Settings/Infrastructure/Infrastructure.constants.ts
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/Infrastructure.constants.ts
@@ -84,6 +84,10 @@ export const INFRA_ACTIVITY_METRICS: CategoryMeta[] = [
             url: 'https://supabase.com/docs/guides/platform/compute-add-ons#disk-throughput-and-iops',
           },
           {
+            name: 'Interpreting Disk IO budget',
+            url: 'https://supabase.com/docs/guides/platform/compute-add-ons#bursting-and-disk-io-budget',
+          },
+          {
             name: 'Metrics',
             url: 'https://supabase.com/docs/guides/platform/metrics',
           },


### PR DESCRIPTION
Adds a new link here to help with some recent questions about this disk io chart

![screenshot-2024-06-11-at-16 43 57](https://github.com/supabase/supabase/assets/105593/12481623-f8da-4ce7-9ddf-b394b01a015f)
