### PR TITLE
Remove Studio settings #26578

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -70,11 +70,8 @@ ENABLE_PHONE_AUTOCONFIRM=true
 ############
 # Studio - Configuration for the Dashboard
 ############
+# Note: Supabase Studio is not supported in self-hosted environments.
 
-STUDIO_DEFAULT_ORGANIZATION=Default Organization
-STUDIO_DEFAULT_PROJECT=Default Project
-
-STUDIO_PORT=3000
 # replace if you intend to use Studio outside of localhost
 SUPABASE_PUBLIC_URL=http://localhost:8000
 


### PR DESCRIPTION
Remove Studio settings from .env.sample for self-hosting

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

### Description

This PR removes the settings related to Supabase Studio from the `.env.sample` file in the `/docker` directory. Since Supabase Studio is not supported in self-hosted environments, including these settings can cause confusion among users.

### Changes Made

- Removed the `STUDIO_DEFAULT_ORGANIZATION`, `STUDIO_DEFAULT_PROJECT`, and `STUDIO_PORT` settings from the `.env.sample` file.

### Issue

The current `.env.sample` file includes settings for Supabase Studio, which is not supported in self-hosted environments. This can lead to confusion and misconfiguration for users attempting to self-host Supabase.

### Solution

By removing these settings, we can prevent confusion and ensure users have a clearer understanding of the supported configurations for self-hosting.
