### PR TITLE
[fix supabase#26999] updation of social oauth for Keycloak guide

### DIFF
--- a/apps/docs/content/guides/auth/social-login/auth-keycloak.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-keycloak.mdx
@@ -8,7 +8,7 @@ To enable Keycloak Auth for your project, you need to set up an Keycloak OAuth a
 
 ## Overview
 
-To get started with Keycloak, you can run it in a docker container with: `docker run -e KEYCLOAK_USER=admin -e KEYCLOAK_PASSWORD=admin -p 8080:8080 jboss/keycloak:latest`
+To get started with Keycloak, you can run it in a docker container with: `docker run -p 8080:8080 -e KEYCLOAK_ADMIN=admin -e KEYCLOAK_ADMIN_PASSWORD=admin quay.io/keycloak/keycloak:latest start-dev`
 
 This guide will be assuming that you are running keycloak in a docker container as described in the command above.
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?
https://github.com/supabase/supabase/blob/master/apps/docs/content/guides/auth/social-login/auth-keycloak.mdx


Updated the Docker command in accordance with the official Keycloak documentation.
For more details, refer to the
https://www.keycloak.org/getting-started/getting-started-docker

## What is the current behavior?


## What is the new behavior?
Updated the Docker command to pull the image from the new Quay.io registry, as per the official Keycloak documentation.

Feel free to include screenshots if it includes visual changes.

## Additional context

