### PR TITLE
Account for br and hr tags

### DIFF
--- a/apps/www/_blog/2022-07-05-beta-update-june-2022.mdx
+++ b/apps/www/_blog/2022-07-05-beta-update-june-2022.mdx
@@ -103,11 +103,11 @@ The Supabase community is exploding and we’ve reached a point where we can’t
     <a href="https://twitter.com/sam_poder?ref_src=twsrc%5Etfw">@sam_poder</a>, as well as Singapore
     legends like
     <a href="https://twitter.com/swyx?ref_src=twsrc%5Etfw">@swyx</a> and
-    <a href="https://twitter.com/serrynaimo?ref_src=twsrc%5Etfw">@serrynaimo</a>! <br></br>
-    <br></br>
+    <a href="https://twitter.com/serrynaimo?ref_src=twsrc%5Etfw">@serrynaimo</a>! <br />
+    <br />
     And even a free JS community meetup with a little Edge Functions workshop!
-    <br></br>
-    <br></br>
+    <br />
+    <br />
     Check out the schedule 👉
     <a href="https://t.co/T6CAyjpWSa">https://t.co/T6CAyjpWSa</a>
     <a href="https://t.co/SNCAAQeCmz">https://t.co/SNCAAQeCmz</a>

--- a/apps/www/lib/mdx/mdxSerialize.ts
+++ b/apps/www/lib/mdx/mdxSerialize.ts
@@ -8,9 +8,9 @@ import codeHikeTheme from 'config/code-hike.theme.json' assert { type: 'json' }
 // mdx2 needs self-closing tags.
 // dragging an image onto a Github discussion creates an <img>
 // we need to fix this before running them through mdx
+// also checks for <br> and <hr>
 function addSelfClosingTags(htmlString: string): string {
-  const modifiedHTML = htmlString.replace(/<img[^>]*>/g, (match) => {
-    // Check if the <img> tag already has a closing slash
+  const modifiedHTML = htmlString.replace(/<img[^>]*>|<br[^>]*>|<hr[^>]*>/g, (match) => {
     if (match.endsWith('/>')) {
       return match
     } else {
@@ -18,7 +18,6 @@ function addSelfClosingTags(htmlString: string): string {
       return match.slice(0, -1) + ' />'
     }
   })
-
   return modifiedHTML
 }
 


### PR DESCRIPTION
Tags need to be self-closing. We're handling <img> already, but not <br> and <hr>. There's others as well, but these are the most likely to be included in Changelog posts.