### PR TITLE
fix: update edge function logging & troubleshooting guides

### DIFF
--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
@@ -1142,12 +1142,12 @@ export const functions: NavMenuConstant = {
           url: '/guides/functions/debugging-tools',
         },
         {
-          name: 'Logging and Troubleshooting',
-          url: '/guides/functions/debugging',
+          name: 'Logging',
+          url: '/guides/functions/logging',
         },
         {
-          name: 'Logging and Using Headers',
-          url: '/guides/functions/functions-headers',
+          name: 'Troubleshooting Common Issues',
+          url: '/guides/functions/troubleshooting',
         },
         {
           name: 'Testing your Edge Functions',

--- a/apps/docs/content/guides/functions/debugging-tools.mdx
+++ b/apps/docs/content/guides/functions/debugging-tools.mdx
@@ -1,8 +1,8 @@
 ---
 id: 'functions-debugging-tools'
-title: 'Debugging Tools'
-description: 'Debugging Tools for Edge Functions.'
-subtitle: 'Debugging Tools for Edge Functions.'
+title: 'Local Debugging with DevTools'
+description: 'How to use Chrome DevTools to debug Edge Functions.'
+subtitle: 'How to use Chrome DevTools to debug Edge Functions.'
 tocVideo: 'sOrtcoKg5zQ'
 ---
 

--- a/apps/docs/content/guides/functions/logging.mdx
+++ b/apps/docs/content/guides/functions/logging.mdx
@@ -1,9 +1,69 @@
 ---
-id: 'functions-headers'
-title: 'Logging and Using Headers'
-description: 'How to log the headers to console.'
-subtitle: 'How to log the headers received and use them.'
+id: 'functions-logging'
+title: 'Logging'
+description: 'How to access logs for your Edge Functions.'
+subtitle: 'How to access logs for your Edge Functions.'
 ---
+
+Logs are provided for each function invocation, locally and in hosted environments.
+
+## How to access logs
+
+### Hosted
+
+You can access both tools from the [Functions section](https://supabase.com/dashboard/project/_/functions) of the Dashboard. Select your function from the list, and click `Invocations` or `Logs`:
+
+- **Invocations**: shows the Request and Response for each execution. You can see the headers, body, status code, and duration of each invocation. You can also filter the invocations by date, time, or status code.
+- **Logs**: shows any platform events, uncaught exceptions, and custom log events. You can see the timestamp, level, and message of each log event. You can also filter the log events by date, time, or level.
+
+![Function invocations.](/docs/img/guides/functions/function-logs.png)
+
+### Local
+
+When [developing locally](/docs/guides/functions/local-development) you will see error messages and console log statements printed to your local terminal window.
+
+## Events that get logged
+
+- **Uncaught exceptions**: Uncaught exceptions thrown by a function during execution are automatically logged. You can see the error message and stack trace in the Logs tool.
+- **Custom log events**: You can use `console.log`, `console.error`, and `console.warn` in your code to emit custom log events. These events also appear in the Logs tool.
+- **Boot and Shutdown Logs**: The Logs tool extends its coverage to include logs for the boot and shutdown of functions.
+
+<Admonition type="note">
+  A custom log message can contain up to 10,000 characters. A function can log up to 100 events
+  within a 10 second period.
+</Admonition>
+
+Here is an example of how to use custom logs events in your function:
+
+```typescript
+Deno.serve(async (req) => {
+  try {
+    const { name } = await req.json()
+
+    if (!name) {
+      console.warn('Empty name provided')
+    }
+
+    const data = {
+      message: `Hello ${name || 'Guest'}!`, // Provide a default value if name is empty
+    }
+
+    console.log(`Name: ${name}`)
+
+    return new Response(JSON.stringify(data), { headers: { 'Content-Type': 'application/json' } })
+  } catch (error) {
+    console.error(`Error processing request: ${error.message}`)
+    return new Response(JSON.stringify({ error: 'Internal Server Error' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+})
+```
+
+## Logging Tips
+
+### Logging Request Headers
 
 When debugging Edge Functions, a common mistake is to try to log headers to the developer console via code like this:
 

--- a/apps/docs/content/guides/functions/regional-invocation.mdx
+++ b/apps/docs/content/guides/functions/regional-invocation.mdx
@@ -45,7 +45,7 @@ const { data, error } = await supabase.functions.invoke('hello-world', {
 
 </CH.Code>
 
-You can verify the execution region by looking at the `x-sb-edge-region` HTTP header in the response. You can also find it as metadata in [Edge Function Logs](/docs/guides/functions/debugging).
+You can verify the execution region by looking at the `x-sb-edge-region` HTTP header in the response. You can also find it as metadata in [Edge Function Logs](/docs/guides/functions/logging).
 
 ## Available regions
 

--- a/apps/docs/content/guides/functions/troubleshooting.mdx
+++ b/apps/docs/content/guides/functions/troubleshooting.mdx
@@ -1,69 +1,9 @@
 ---
 id: 'functions-debugging'
-title: 'Debugging Edge Functions'
-description: 'Debugging tips and Edge Function limitations.'
-subtitle: 'Debugging tips and Edge Function limitations.'
+title: 'Troubleshooting Common Issues'
+description: 'How to solve common problems and issues related to Edge Functions.'
+subtitle: 'How to solve common problems and issues related to Edge Functions.'
 ---
-
-## Logs & debugging
-
-Logs are provided for each function invocation, locally and in production.
-
-## How to access logs
-
-### Hosted
-
-You can access both tools from the [Functions section](https://supabase.com/dashboard/project/_/functions) of the Dashboard. Select your function from the list, and click `Invocations` or `Logs`:
-
-- **Invocations**: shows the Request and Response for each execution. You can see the headers, body, status code, and duration of each invocation. You can also filter the invocations by date, time, or status code.
-- **Logs**: shows any platform events, uncaught exceptions, and custom log events. You can see the timestamp, level, and message of each log event. You can also filter the log events by date, time, or level.
-
-![Function invocations.](/docs/img/guides/functions/function-logs.png)
-
-### Local
-
-When [developing locally](/docs/guides/functions/local-development) you will see error messages and console log statements printed to your local terminal window.
-
-## Events that get logged
-
-- **Uncaught exceptions**: Uncaught exceptions thrown by a function during execution are automatically logged. You can see the error message and stack trace in the Logs tool.
-- **Custom log events**: You can use `console.log`, `console.error`, and `console.warn` in your code to emit custom log events. These events also appear in the Logs tool.
-- **Boot and Shutdown Logs**: The Logs tool extends its coverage to include logs for the boot and shutdown of functions.
-
-<Admonition type="note">
-  A custom log message can contain up to 10,000 characters. A function can log up to 100 events
-  within a 10 second period.
-</Admonition>
-
-Here is an example of how to use custom logs events in your function:
-
-```typescript
-Deno.serve(async (req) => {
-  try {
-    const { name } = await req.json()
-
-    if (!name) {
-      console.warn('Empty name provided')
-    }
-
-    const data = {
-      message: `Hello ${name || 'Guest'}!`, // Provide a default value if name is empty
-    }
-
-    console.log(`Name: ${name}`)
-
-    return new Response(JSON.stringify(data), { headers: { 'Content-Type': 'application/json' } })
-  } catch (error) {
-    console.error(`Error processing request: ${error.message}`)
-    return new Response(JSON.stringify({ error: 'Internal Server Error' }), {
-      status: 500,
-      headers: { 'Content-Type': 'application/json' },
-    })
-  }
-})
-```
-
-## Troubleshooting
 
 If you encounter any problems or issues with your Edge Functions, here are some tips and steps to help you resolve them.
 

--- a/apps/www/lib/redirects.js
+++ b/apps/www/lib/redirects.js
@@ -2340,11 +2340,6 @@ module.exports = [
   },
   {
     permanent: true,
-    source: '/docs/guides/functions/troubleshooting',
-    destination: '/docs/guides/functions/debugging',
-  },
-  {
-    permanent: true,
     source: '/docs/guides/auth/auth-magic-link',
     destination: '/docs/guides/auth/passwordless-login/auth-magic-link',
   },
@@ -2537,5 +2532,15 @@ module.exports = [
     permanent: true,
     source: '/docs/guides/api/data-apis',
     destination: '/docs/guides/api',
+  },
+  {
+    permanent: true,
+    source: '/docs/guides/functions/debugging',
+    destination: '/docs/functions/logging',
+  },
+  {
+    permanent: true,
+    source: '/docs/guides/functions/functions-headers',
+    destination: '/docs/functions/logging',
   },
 ]


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR does few changes to Edge Functions logging & troubleshooting guides.

1. Break Logging & Troubleshooting into two separate pages
2. Move "Logging and Using Headers" into Logging page
3. Add redirects for removed pages
