### PR TITLE
chore: delete docs service key from turbo config

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -17,7 +17,7 @@
     },
     "docs#build": {
       "dependsOn": ["^build"],
-      "env": ["SUPABASE_SERVICE_ROLE_KEY", "OPENAI_API_KEY"],
+      "env": ["OPENAI_API_KEY"],
       "outputs": [".next/**", "!.next/cache/**"]
     },
     "studio#build": {


### PR DESCRIPTION
We don't actually use this in build (only used in scripts), so I'm pretty sure this will build properly without...