### PR TITLE
Renamed Sveltekit Variable from SUPABASE_KEY to SUPABASE_ANON_KEY

### DIFF
--- a/apps/studio/components/interfaces/Home/Connect/content/sveltekit/supabasejs/content.tsx
+++ b/apps/studio/components/interfaces/Home/Connect/content/sveltekit/supabasejs/content.tsx
@@ -33,7 +33,7 @@ SUPABASE_ANON_KEY=${projectKeys.anonKey ?? 'your-anon-key'}
 import { createClient } from "@supabase/supabase-js";
 
 const supabaseUrl = process.env.SUPABASE_URL;
-const supabaseKey = process.env.SUPABASE_KEY;
+const supabaseKey = process.env.SUPABASE_ANON_KEY;
 
 export const supabase = createClient(supabaseUrl, supabaseKey);
         `}


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Improving consistency across example.

## What is the current behavior?

References SUPABASE_ANON_KEY as an environment variable, but uses SUPABASE_KEY in code

## What is the new behavior?

Just uses SUPABASE_ANON_KEY

## Additional context

Someone pointed out the inconsistency in feedback
