### PR TITLE
Case insensitive search

### DIFF
--- a/apps/studio/components/interfaces/Database/Tables/TableList.tsx
+++ b/apps/studio/components/interfaces/Database/Tables/TableList.tsx
@@ -81,7 +81,7 @@ const TableList = ({
       select(tables) {
         return filterString.length === 0
           ? tables
-          : tables.filter((table) => table.name.includes(filterString))
+          : tables.filter((table) => table.name.toLowerCase().includes(filterString.toLowerCase()))
       },
     }
   )


### PR DESCRIPTION
searching tables here is case-sensitive 
https://supabase.com/dashboard/project/_/database/tables

before:
![screenshot-2024-06-17-at-22 39 09](https://github.com/supabase/supabase/assets/105593/c6467920-9fd4-4450-8d19-23b93c61672a)

after: 
![screenshot-2024-06-17-at-22 39 41](https://github.com/supabase/supabase/assets/105593/ccdcf0e0-ba7c-406f-8f92-4974a6b56745)
