### PR TITLE
fix: new www anon key

### DIFF
--- a/apps/www/.env.local.example
+++ b/apps/www/.env.local.example
@@ -1,7 +1,7 @@
 # Copy this file in the same folder, rename it to .env.local and fill out the env vars to get www working
 NEXT_PUBLIC_API_URL="https://api.supabase.green/platform"
 NEXT_PUBLIC_DOCS_URL="http://localhost:3005"
-NEXT_PUBLIC_MISC_USE_ANON_KEY="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im9idWxkYW5ycHRsb2t0eGNmZnZuIiwicm9sZSI6ImFub24iLCJpYXQiOjE2OTIyNjkzMjYsImV4cCI6MjAwNzg0NTMyNn0.1S6qpBbHtEmGuMsIx5UOhRiFd4YbVv-yLTrLk6tVGmM"
+NEXT_PUBLIC_MISC_USE_ANON_KEY="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im9idWxkYW5ycHRsb2t0eGNmZnZuIiwicm9sZSI6ImFub24iLCJpYXQiOjE3MTg2MTQ2ODUsImV4cCI6MjAzNDE5MDY4NX0.NFt49g6DFkc1X5khCzN5p01iAVo2TMxlx88cY1V0E2M"
 NEXT_PUBLIC_MISC_USE_URL="https://obuldanrptloktxcffvn.supabase.co"
 MISC_USE_SERVICE_ROLE_KEY="secret"
 NEXT_PUBLIC_REFERENCE_DOCS_URL="https://localhost:3010"


### PR DESCRIPTION
Embeddings gen is currently broken because the GitHub Action copies this key from www repo to access partners database