### PR TITLE
Fix missing `>` in the api introduction document

### DIFF
--- a/apps/docs/docs/ref/api/introduction.mdx
+++ b/apps/docs/docs/ref/api/introduction.mdx
@@ -17,7 +17,7 @@ hideTitle: true
 
       ## Authentication
 
-      All API requests require a Supabase Personal token to be included in the Authorization header: `Authorization Bearer <supabase_personal_token`.
+      All API requests require a Supabase Personal token to be included in the Authorization header: `Authorization Bearer <supabase_personal_token>`.
       To generate or manage your API token, visit your [account](https://supabase.com/dashboard/account/tokens) page.
       Your API tokens carry the same privileges as your user account, so be sure to keep it secret.
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Doc update

## What is the current behavior?

Typo in the API introduction template `Authorization Bearer <supabase_personal_token`

## What is the new behavior?

Changes text from `Authorization Bearer <supabase_personal_token` to `Authorization Bearer <supabase_personal_token>`

