### PR TITLE
feat: Support private channels in the realtime inspector

### DIFF
--- a/apps/studio/components/interfaces/Realtime/Inspector/ChooseChannelPopover/index.tsx
+++ b/apps/studio/components/interfaces/Realtime/Inspector/ChooseChannelPopover/index.tsx
@@ -7,6 +7,7 @@ import { useForm } from 'react-hook-form'
 import {
   Button,
   FormControl_Shadcn_,
+  FormDescription_Shadcn_,
   FormField_Shadcn_,
   FormItem_Shadcn_,
   FormLabel_Shadcn_,
@@ -123,7 +124,7 @@ export const ChooseChannelPopover = ({ config, onChangeConfig }: ChooseChannelPo
                             Listen to channel
                           </Button>
                         </div>
-                        <p className="text-xs text-foreground-lighter mt-2">
+                        <FormDescription_Shadcn_ className="text-xs text-foreground-lighter mt-2">
                           The channel you initialize with the Supabase Realtime client. Learn more
                           in{' '}
                           <Link
@@ -134,7 +135,7 @@ export const ChooseChannelPopover = ({ config, onChangeConfig }: ChooseChannelPo
                           >
                             our docs
                           </Link>
-                        </p>
+                        </FormDescription_Shadcn_>
                       </FormItem_Shadcn_>
                     )}
                   />
@@ -145,17 +146,23 @@ export const ChooseChannelPopover = ({ config, onChangeConfig }: ChooseChannelPo
                       control={form.control}
                       name="isPrivate"
                       render={({ field }) => (
-                        <FormItem_Shadcn_ className="flex items-center gap-x-2">
-                          <FormControl_Shadcn_>
-                            <Switch
-                              checked={field.value}
-                              onCheckedChange={field.onChange}
-                              disabled={field.disabled}
-                            />
-                          </FormControl_Shadcn_>
-                          <FormLabel_Shadcn_ className="text-xs">
-                            Is channel private?
-                          </FormLabel_Shadcn_>
+                        <FormItem_Shadcn_ className="">
+                          <div className="flex flex-row items-center gap-x-2">
+                            <FormControl_Shadcn_>
+                              <Switch
+                                checked={field.value}
+                                onCheckedChange={field.onChange}
+                                disabled={field.disabled}
+                              />
+                            </FormControl_Shadcn_>
+                            <FormLabel_Shadcn_ className="text-xs">
+                              Is channel private?
+                            </FormLabel_Shadcn_>
+                          </div>
+                          <FormDescription_Shadcn_ className="text-xs text-foreground-lighter mt-2">
+                            If the channel is marked as private, it will use RLS policies to filter
+                            messages.
+                          </FormDescription_Shadcn_>
                         </FormItem_Shadcn_>
                       )}
                     />

--- a/apps/studio/components/interfaces/Realtime/Inspector/ChooseChannelPopover/index.tsx
+++ b/apps/studio/components/interfaces/Realtime/Inspector/ChooseChannelPopover/index.tsx
@@ -20,6 +20,7 @@ import {
 } from 'ui'
 import * as z from 'zod'
 
+import { useFlag } from 'hooks'
 import Telemetry from 'lib/telemetry'
 import { RealtimeConfig } from '../useRealtimeMessages'
 

--- a/apps/studio/components/interfaces/Realtime/Inspector/ChooseChannelPopover/index.tsx
+++ b/apps/studio/components/interfaces/Realtime/Inspector/ChooseChannelPopover/index.tsx
@@ -34,6 +34,7 @@ export const ChooseChannelPopover = ({ config, onChangeConfig }: ChooseChannelPo
   const [open, setOpen] = useState(false)
   const telemetryProps = useTelemetryProps()
   const router = useRouter()
+  const authzEnabled = useFlag('authzRealtime')
 
   const form = useForm<z.infer<typeof FormSchema>>({
     mode: 'onBlur',
@@ -137,25 +138,27 @@ export const ChooseChannelPopover = ({ config, onChangeConfig }: ChooseChannelPo
                     )}
                   />
 
-                  <FormField_Shadcn_
-                    key="isPrivate"
-                    control={form.control}
-                    name="isPrivate"
-                    render={({ field }) => (
-                      <FormItem_Shadcn_ className="flex items-center gap-x-2">
-                        <FormControl_Shadcn_>
-                          <Switch
-                            checked={field.value}
-                            onCheckedChange={field.onChange}
-                            disabled={field.disabled}
-                          />
-                        </FormControl_Shadcn_>
-                        <FormLabel_Shadcn_ className="text-xs">
-                          Is channel private?
-                        </FormLabel_Shadcn_>
-                      </FormItem_Shadcn_>
-                    )}
-                  />
+                  {authzEnabled ? (
+                    <FormField_Shadcn_
+                      key="isPrivate"
+                      control={form.control}
+                      name="isPrivate"
+                      render={({ field }) => (
+                        <FormItem_Shadcn_ className="flex items-center gap-x-2">
+                          <FormControl_Shadcn_>
+                            <Switch
+                              checked={field.value}
+                              onCheckedChange={field.onChange}
+                              disabled={field.disabled}
+                            />
+                          </FormControl_Shadcn_>
+                          <FormLabel_Shadcn_ className="text-xs">
+                            Is channel private?
+                          </FormLabel_Shadcn_>
+                        </FormItem_Shadcn_>
+                      )}
+                    />
+                  ) : null}
                 </form>
               </Form_Shadcn_>
             </>

--- a/apps/studio/components/interfaces/Realtime/Inspector/ChooseChannelPopover/index.tsx
+++ b/apps/studio/components/interfaces/Realtime/Inspector/ChooseChannelPopover/index.tsx
@@ -1,6 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useTelemetryProps } from 'common'
-import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { Dispatch, SetStateAction, useState } from 'react'
 import { useForm } from 'react-hook-form'
@@ -23,6 +22,7 @@ import * as z from 'zod'
 
 import { useFlag } from 'hooks'
 import Telemetry from 'lib/telemetry'
+import { ExternalLink } from 'lucide-react'
 import { RealtimeConfig } from '../useRealtimeMessages'
 
 interface ChooseChannelPopoverProps {
@@ -103,38 +103,40 @@ export const ChooseChannelPopover = ({ config, onChangeConfig }: ChooseChannelPo
                     name="channel"
                     control={form.control}
                     render={({ field }) => (
-                      <FormItem_Shadcn_>
-                        <label className="text-foreground text-xs mb-2">Name of channel</label>
-                        <div className="flex flex-row">
-                          <FormControl_Shadcn_>
-                            <Input_Shadcn_
-                              {...field}
-                              autoComplete="off"
-                              className="rounded-r-none text-xs px-2.5 py-1 h-auto"
-                              placeholder="Enter a channel name"
-                            />
-                          </FormControl_Shadcn_>
+                      <FormItem_Shadcn_ className="flex flex-col gap-y-2">
+                        <div className="flex flex-col gap-y-1">
+                          <label className="text-foreground text-xs">Name of channel</label>
+                          <div className="flex flex-row">
+                            <FormControl_Shadcn_>
+                              <Input_Shadcn_
+                                {...field}
+                                autoComplete="off"
+                                className="rounded-r-none text-xs px-2.5 py-1 h-auto"
+                                placeholder="Enter a channel name"
+                              />
+                            </FormControl_Shadcn_>
 
-                          <Button
-                            type="primary"
-                            className="rounded-l-none"
-                            disabled={form.getValues().channel.length === 0}
-                            onClick={() => onSubmit()}
-                          >
-                            Listen to channel
-                          </Button>
+                            <Button
+                              type="primary"
+                              className="rounded-l-none"
+                              disabled={form.getValues().channel.length === 0}
+                              onClick={() => onSubmit()}
+                            >
+                              Listen to channel
+                            </Button>
+                          </div>
                         </div>
-                        <FormDescription_Shadcn_ className="text-xs text-foreground-lighter mt-2">
+                        <FormDescription_Shadcn_ className="text-xs text-foreground-lighter">
                           The channel you initialize with the Supabase Realtime client. Learn more
                           in{' '}
-                          <Link
-                            href="https://supabase.com/docs/guides/realtime/concepts#channels"
+                          <a
                             target="_blank"
                             rel="noreferrer"
                             className="underline hover:text-foreground transition"
+                            href="https://supabase.com/docs/guides/realtime/concepts#channels"
                           >
                             our docs
-                          </Link>
+                          </a>
                         </FormDescription_Shadcn_>
                       </FormItem_Shadcn_>
                     )}
@@ -167,6 +169,16 @@ export const ChooseChannelPopover = ({ config, onChangeConfig }: ChooseChannelPo
                       )}
                     />
                   ) : null}
+
+                  <Button asChild type="default" className="w-min" icon={<ExternalLink />}>
+                    <a
+                      target="_blank"
+                      rel="noreferrer"
+                      href="https://github.com/orgs/supabase/discussions/22484"
+                    >
+                      Documentation
+                    </a>
+                  </Button>
                 </form>
               </Form_Shadcn_>
             </>

--- a/apps/studio/components/interfaces/Realtime/Inspector/index.tsx
+++ b/apps/studio/components/interfaces/Realtime/Inspector/index.tsx
@@ -25,6 +25,7 @@ export const RealtimeInspector = () => {
     token: '', // will be filled out by RealtimeTokensPopover
     schema: 'public',
     table: '*',
+    isChannelPrivate: false,
     filter: undefined,
     bearer: null,
     enablePresence: true,

--- a/apps/studio/components/interfaces/Realtime/Inspector/useRealtimeMessages.ts
+++ b/apps/studio/components/interfaces/Realtime/Inspector/useRealtimeMessages.ts
@@ -1,5 +1,9 @@
-import { RealtimeChannel, SupabaseClient } from '@supabase/supabase-js'
-import { sortBy, take } from 'lodash'
+import { RealtimeChannel, RealtimeClient } from '@supabase/realtime-js-next'
+import {
+  DEFAULT_GLOBAL_OPTIONS,
+  DEFAULT_REALTIME_OPTIONS,
+} from '@supabase/supabase-js/dist/main/lib/constants'
+import { merge, sortBy, take } from 'lodash'
 import { Dispatch, SetStateAction, useCallback, useEffect, useReducer, useState } from 'react'
 import toast from 'react-hot-toast'
 
@@ -63,6 +67,7 @@ export const useRealtimeMessages = (
     token,
     schema,
     table,
+    isChannelPrivate,
     filter,
     bearer,
     enablePresence,
@@ -77,40 +82,43 @@ export const useRealtimeMessages = (
     ? `${data.autoApiService.protocol}://${data.autoApiService.endpoint}`
     : `https://${projectRef}.supabase.co`
 
+  const realtimeUrl = `${host}/realtime/v1`.replace(/^http/i, 'ws')
+
   const [logData, dispatch] = useReducer(reducer, [] as LogData[])
   const pushMessage = (messageType: string, metadata: any) => {
     dispatch({ type: 'add', payload: { messageType, metadata } })
   }
 
   // Instantiate our client with the Realtime server and params to connect with
-  let [client, setClient] = useState<SupabaseClient<any, 'public', any> | undefined>()
+  let [client, setClient] = useState<RealtimeClient>()
   let [channel, setChannel] = useState<RealtimeChannel | undefined>()
 
   useEffect(() => {
     if (!enabled) {
       return
     }
-    const opts = {
-      global: {
-        headers: {
-          'User-Agent': `supabase-api/${process.env.VERCEL_GIT_COMMIT_SHA || 'unknown-sha'}`,
-        },
+
+    const globalOptions = merge(DEFAULT_GLOBAL_OPTIONS, {
+      headers: {
+        'User-Agent': `supabase-api/${process.env.VERCEL_GIT_COMMIT_SHA || 'unknown-sha'}`,
       },
-      realtime: {
-        params: {
-          log_level: logLevel,
-        },
-      },
+    })
+    const realtimeOptions = merge(DEFAULT_REALTIME_OPTIONS, { params: { log_level: logLevel } })
+
+    const options = {
+      headers: globalOptions.headers,
+      ...realtimeOptions,
+      params: { apikey: token, ...realtimeOptions.params },
     }
-    const newClient = new SupabaseClient(host, token, opts)
+    const realtimeClient = new RealtimeClient(realtimeUrl, options)
 
     if (bearer) {
-      newClient.realtime.setAuth(bearer)
+      realtimeClient.setAuth(bearer)
     }
 
-    setClient(newClient)
+    setClient(realtimeClient)
     return () => {
-      client?.realtime.disconnect()
+      realtimeClient.disconnect()
       setClient(undefined)
     }
   }, [enabled, bearer, host, logLevel, token])

--- a/apps/studio/components/interfaces/Realtime/Inspector/useRealtimeMessages.ts
+++ b/apps/studio/components/interfaces/Realtime/Inspector/useRealtimeMessages.ts
@@ -43,6 +43,7 @@ export interface RealtimeConfig {
   token: string
   schema: string
   table: string
+  isChannelPrivate: boolean
   filter: string | undefined
   bearer: string | null
   enableBroadcast: boolean
@@ -120,7 +121,7 @@ export const useRealtimeMessages = (
     }
     dispatch({ type: 'clear' })
     const newChannel = client?.channel(channelName, {
-      config: { broadcast: { self: true } },
+      config: { broadcast: { self: true }, private: isChannelPrivate },
     })
     // Hack to confirm Postgres is subscribed
     // Need to add 'extension' key in the 'payload'

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -38,6 +38,7 @@
     "@stripe/stripe-js": "^3.0.5",
     "@supabase/auth-helpers-react": "^0.4.2",
     "@supabase/pg-meta": "*",
+    "@supabase/realtime-js-next": "npm:@supabase/realtime-js@2.10.0-next.8",
     "@supabase/shared-types": "0.1.65",
     "@supabase/supabase-js": "^2.41.1",
     "@tanstack/react-query": "4.35.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -793,6 +793,7 @@
         "@stripe/stripe-js": "^3.0.5",
         "@supabase/auth-helpers-react": "^0.4.2",
         "@supabase/pg-meta": "*",
+        "@supabase/realtime-js-next": "npm:@supabase/realtime-js@2.10.0-next.8",
         "@supabase/shared-types": "0.1.65",
         "@supabase/supabase-js": "^2.41.1",
         "@tanstack/react-query": "4.35.7",
@@ -13609,6 +13610,18 @@
       "version": "2.9.3",
       "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.9.3.tgz",
       "integrity": "sha512-lAp50s2n3FhGJFq+wTSXLNIDPw5Y0Wxrgt44eM5nLSA3jZNUUP3Oq2Ccd1CbZdVntPCWLZvJaU//pAd2NE+QnQ==",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14",
+        "@types/phoenix": "^1.5.4",
+        "@types/ws": "^8.5.10",
+        "ws": "^8.14.2"
+      }
+    },
+    "node_modules/@supabase/realtime-js-next": {
+      "name": "@supabase/realtime-js",
+      "version": "2.10.0-next.8",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.10.0-next.8.tgz",
+      "integrity": "sha512-mwyvgG6pBqpThgGwZxDQNG7HIwEQgto6ImaLPkGclxyCucTkapCvZiYXQOWrVQKNqe5JiPksNbX+3Ssv7k4xUg==",
       "dependencies": {
         "@supabase/node-fetch": "^2.6.14",
         "@types/phoenix": "^1.5.4",


### PR DESCRIPTION
How to test:
1. Add these policies using the SQL editor:
```
create policy  "Enable select to broadcast for authenticated users only"
on realtime.messages for select
to public
using ( realtime.messages.extension = 'broadcast' );

create policy  "Enable insert to broadcast for authenticated users only"
on realtime.messages for insert
to authenticated
WITH CHECK ( realtime.messages.extension = 'broadcast' );
```

2. Open 2 inspectors in separate tabs. Setup one of them with anon role, another with service or authenticated role. 
3. Connect both inspectors
4. Try broadcasting a message from both inspectors. Toast will appear for both but only the authenticated inspector will send a message which can be seen in both inspectors.