### PR TITLE
docs - custom schemas

### DIFF
--- a/apps/docs/content/guides/api/using-custom-schemas.mdx
+++ b/apps/docs/content/guides/api/using-custom-schemas.mdx
@@ -4,7 +4,19 @@ title: 'Using Custom Schemas'
 description: 'You need additional steps to use custom database schemas with data APIs.'
 ---
 
-By default, your database has a `public` schema which is automatically exposed on data APIs. You can also expose custom database schemas - to do so you need to follow these steps:
+By default, your database has a `public` schema which is automatically exposed on data APIs. 
+
+## Creating custom schemas
+
+You can create your own custom schema/s by running the following SQL, substituting `myschema` with the name you want to use for your schema:
+
+```sql
+create schema myschema;
+```
+
+## Exposing custom schemas
+
+You can expose custom database schemas - to do so you need to follow these steps:
 
 1. Go to [API settings](https://supabase.com/dashboard/project/_/settings/api) and add your custom schema to "Exposed schemas".
 2. Run the following SQL, substituting `myschema` with your schema name:

--- a/apps/docs/content/guides/api/using-custom-schemas.mdx
+++ b/apps/docs/content/guides/api/using-custom-schemas.mdx
@@ -4,7 +4,7 @@ title: 'Using Custom Schemas'
 description: 'You need additional steps to use custom database schemas with data APIs.'
 ---
 
-By default, your database has a `public` schema which is automatically exposed on data APIs. 
+By default, your database has a `public` schema which is automatically exposed on data APIs.
 
 ## Creating custom schemas
 

--- a/apps/docs/content/guides/api/using-custom-schemas.mdx
+++ b/apps/docs/content/guides/api/using-custom-schemas.mdx
@@ -11,7 +11,7 @@ By default, your database has a `public` schema which is automatically exposed o
 You can create your own custom schema/s by running the following SQL, substituting `myschema` with the name you want to use for your schema:
 
 ```sql
-create schema myschema;
+CREATE SCHEMA myschema;
 ```
 
 ## Exposing custom schemas


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Supabase Docs - [Using custom schemas](https://supabase.com/docs/guides/api/using-custom-schemas)

## What is the current behavior?

The doc does not mention how to create custom schemas:

<img width="1439" alt="Screenshot 2024-06-18 at 21 58 10" src="https://github.com/supabase/supabase/assets/22655069/f5456766-a17f-42d3-8bd6-54a8fe453833">


## What is the new behavior?

Section has been added to show how to create custom schemas and also added headings to the doc:

<img width="1439" alt="Screenshot 2024-06-18 at 21 58 00" src="https://github.com/supabase/supabase/assets/22655069/4c90c22b-26df-4587-aaee-bd231645c7d5">


## Additional context

Closes #27305 
