### PR TITLE
[Design System] chore: `<DropdownMenu />` `modal` prop set to `false` as default

### DIFF
--- a/packages/ui/src/components/shadcn/ui/dropdown-menu.tsx
+++ b/packages/ui/src/components/shadcn/ui/dropdown-menu.tsx
@@ -6,7 +6,9 @@ import * as React from 'react'
 
 import { cn } from '../../../lib/utils/cn'
 
-const DropdownMenu = DropdownMenuPrimitive.Root
+const DropdownMenu = (props: React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Root>) => (
+  <DropdownMenuPrimitive.Root modal={false} {...props} />
+)
 
 const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

- `<DropdownMenu />` set to `modal` false as default as most Dropdown Menus need to be able to trigger other dropdown menus easily. saves clicking twice. can be overridden. 

