### PR TITLE
Update connecting-to-postgres.mdx to mention clients

### DIFF
--- a/apps/docs/content/guides/database/connecting-to-postgres.mdx
+++ b/apps/docs/content/guides/database/connecting-to-postgres.mdx
@@ -10,6 +10,7 @@ Supabase provides several options for programmatically connecting to your Postgr
 1. Programmatic access using the Data APIs
 1. Connection pooling for scalable connections
 1. Direct connections using the built-in Postgres connection system
+1. Using one of the many [Client Libraries](https://supabase.com/docs#client-libraries)
 
 <Admonition type="caution">
 


### PR DESCRIPTION
It seems (I am not an expert by any means) that beyond the 3 strategies described here, you can also connect to Supabase using the clients -- but that doesn't get mentioned here. For those just learning Supabase, like me, I feel like this would make the documentation clearer.

I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

What kind of change does this PR introduce?

Update to the docs, to indicate that a 4th way of connecting to Supabase databases is via client software

What is the current behavior?

The connection strategies don't mention clients

What is the new behavior?

It mentions that you can connect to Supabase using clients, which I think is hugely important.

Additional context

Add any other context or screenshots.