### PR TITLE
Fix: escape single quotes in queries to prevent syntax errors

### DIFF
--- a/apps/studio/data/database/retrieve-index-advisor-result-query.ts
+++ b/apps/studio/data/database/retrieve-index-advisor-result-query.ts
@@ -31,7 +31,6 @@ export async function getIndexAdvisorResult({
   const traceparent = "/* traceparent='00-xxx-01' */"
   const queryWithTraceparent = `${escapedQuery} ${traceparent}`
 
-  console.log('Original query with traceparent:', `${query} ${traceparent}`)
   console.log('Escaped query:', escapedQuery)
 
   const { result } = await executeSql({

--- a/apps/studio/data/database/retrieve-index-advisor-result-query.ts
+++ b/apps/studio/data/database/retrieve-index-advisor-result-query.ts
@@ -26,11 +26,8 @@ export async function getIndexAdvisorResult({
 }: GetIndexAdvisorResultVariables) {
   if (!projectRef) throw new Error('Project ref is required')
 
+  // swap single quotes for double to prevent syntax errors
   const escapedQuery = query.replace(/'/g, "''")
-
-  const traceparent = "/* traceparent='00-xxx-01' */"
-  const queryWithTraceparent = `${escapedQuery} ${traceparent}`
-
 
   const { result } = await executeSql({
     projectRef,

--- a/apps/studio/data/database/retrieve-index-advisor-result-query.ts
+++ b/apps/studio/data/database/retrieve-index-advisor-result-query.ts
@@ -31,7 +31,6 @@ export async function getIndexAdvisorResult({
   const traceparent = "/* traceparent='00-xxx-01' */"
   const queryWithTraceparent = `${escapedQuery} ${traceparent}`
 
-  console.log('Escaped query:', escapedQuery)
 
   const { result } = await executeSql({
     projectRef,

--- a/apps/studio/data/database/retrieve-index-advisor-result-query.ts
+++ b/apps/studio/data/database/retrieve-index-advisor-result-query.ts
@@ -26,10 +26,18 @@ export async function getIndexAdvisorResult({
 }: GetIndexAdvisorResultVariables) {
   if (!projectRef) throw new Error('Project ref is required')
 
+  const escapedQuery = query.replace(/'/g, "''")
+
+  const traceparent = "/* traceparent='00-xxx-01' */"
+  const queryWithTraceparent = `${escapedQuery} ${traceparent}`
+
+  console.log('Original query with traceparent:', `${query} ${traceparent}`)
+  console.log('Escaped query:', escapedQuery)
+
   const { result } = await executeSql({
     projectRef,
     connectionString,
-    sql: `select * from index_advisor('${query}');`,
+    sql: `select * from index_advisor('${escapedQuery}');`,
   })
   return result[0] as GetIndexAdvisorResultResponse
 }


### PR DESCRIPTION
Update the getIndexAdvisorResult function to properly escape single quotes in SQL queries. 

![image](https://github.com/supabase/supabase/assets/99693443/b8840918-2e5a-4ba7-a987-3dd54b88af06)
