### PR TITLE
Update Session connection pooler string to include pgbouncer (#27438)

### DIFF
--- a/apps/www/pages/partners/integrations/[slug].tsx
+++ b/apps/www/pages/partners/integrations/[slug].tsx
@@ -340,12 +340,15 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
   }
 
   // Parse markdown
-  const overview = await serialize(partner.overview, {
+  const overview = await serialize(partner.overview.replace(
+    /postgres:\/\/\[db-user\]\.\[project-ref\]:\[db-password\]@aws-0-\[aws-region\]\.pooler\.supabase\.com:5432\/\[db-name\]/g,
+    'postgres://[db-user].[project-ref]:[db-password]@aws-0-[aws-region].pooler.supabase.com:5432/[db-name]?pgbouncer=true&connection_limit=1'
+  ), {
     mdxOptions: {
       useDynamicImport: true,
       remarkPlugins: [remarkGfm, [remarkCodeHike, codeHikeOptions]],
     },
-  })
+  });
 
   return {
     props: { partner, overview },


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The current Session connection pooler string does not include ?pgbouncer=true&connection_limit=1 after the database name.

[https://github.com/supabase/supabase/issues/27438](#27438 )

## What is the new behavior?

The Session connection pooler string now includes ?pgbouncer=true&connection_limit=1 after the database name. This ensures that the connection uses pgbouncer with a specified connection limit.

**Before:** 
```
> To get the Session connection pooler string, change the port to 5432. If your database is Postgres 14 and above, it will look like this

postgres://[db-user].[project-ref]:[db-password]@aws-0-[aws-region].pooler.supabase.com:5432/[db-name]

```

**After:**

```
> To get the Session connection pooler string, change the port to 5432. If your database is Postgres 14 and above, it will look like this

postgres://[db-user].[project-ref]:[db-password]@aws-0-[aws-region].pooler.supabase.com:5432/[db-name]?pgbouncer=true&connection_limit=1

```

