### PR TITLE
fix: small typo error in heading

### DIFF
--- a/apps/www/_blog/2024-06-19-self-host-maps-storage-protomaps.mdx
+++ b/apps/www/_blog/2024-06-19-self-host-maps-storage-protomaps.mdx
@@ -29,7 +29,7 @@ In this tutorial, you will learn to
 - Use MapLibre to render the Map onto a Web Page.
 - Use Supabase Edge Functions to restrict File Access.
 
-## Excract an area into a static PMTiles file
+## Extract an area into a static PMTiles file
 
 Protomaps provides a [`pmtiles` CLI](https://docs.protomaps.com/guide/getting-started#_1-install-the-cli) that can be used to cut out certain areas from the world map and compress those into a single static file.
 


### PR DESCRIPTION
I fixed a small typo error in the last blog post