### PR TITLE
:wheelchair: fix: contrast ratio for buttons and diff Editor

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/DiffActionBar.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/DiffActionBar.tsx
@@ -63,7 +63,7 @@ export const DiffActionBar = ({
         type="alternative"
         size="tiny"
         className="bg-brand-300 hover:bg-brand-400 dark:bg-brand-400 dark:hover:bg-brand-500 text-brand-600 group"
-        iconRight={<span className="dark:text-brand-500 group-hover:text-brand-600">ESC</span>}
+        iconRight={<span className="text-brand-600">ESC</span>}
         onClick={onCancel}
       >
         Discard

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityActions.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityActions.tsx
@@ -266,7 +266,7 @@ const UtilityActions = ({
                   {os === 'macos' ? (
                     <Command size={10} strokeWidth={1.5} />
                   ) : (
-                    <p className="text-xs text-foreground-light">CTRL</p>
+                    <p className="text-xs">CTRL</p>
                   )}
                   <CornerDownLeft size={10} strokeWidth={1.5} />
                 </div>

--- a/apps/studio/components/ui/CodeEditor/CodeEditor.utils.ts
+++ b/apps/studio/components/ui/CodeEditor/CodeEditor.utils.ts
@@ -23,7 +23,7 @@ export const getTheme = (theme: string) => {
         foreground: isDarkMode ? 'd4d4d4' : '444444',
       },
       { token: 'string.sql', foreground: '24b47e' },
-      { token: 'comment', foreground: '666666' },
+      // { token: 'comment', foreground: '666666' },
       { token: 'predefined.sql', foreground: isDarkMode ? 'D4D4D4' : '444444' },
     ],
     colors: { 'editor.background': isDarkMode ? '#1f1f1f' : '#f0f0f0' },


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Fix Text visibility for certain buttons and comments inside Diff Checker for SQL Editor

## What is the current behavior?

[#23245](https://github.com/supabase/supabase/issues/23245)

## What is the new behavior?

**Dark Mode**
![image](https://github.com/supabase/supabase/assets/29174602/9dbc6d77-57e8-42ce-9331-0dffe76fc414)

![image](https://github.com/supabase/supabase/assets/29174602/83aa6723-7600-4fdb-a0b8-7a0f33595a22)

**Light Mode**
![image](https://github.com/supabase/supabase/assets/29174602/1906ff63-4f9c-4526-bb89-bdb768b4aeed)

![image](https://github.com/supabase/supabase/assets/29174602/e0358e7d-cdd3-48fc-ad53-1b34256f3444)


## Additional context

Please let me know if you need some other color or anything else. 
