### PR TITLE
fix minio healthcheck

### DIFF
--- a/docker/docker-compose.s3.yml
+++ b/docker/docker-compose.s3.yml
@@ -12,7 +12,7 @@ services:
       MINIO_ROOT_PASSWORD: secret1234
     command: server --console-address ":9001" /data
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://minio:9000/minio/health/live" ]
+      test: [ "CMD", "mc", "ready", "local" ]
       interval: 2s
       timeout: 10s
       retries: 5


### PR DESCRIPTION
Minio has no curl and this is not correct healthcheck (and it fails)

See https://github.com/minio/minio/issues/18389

Also questionable to have in this compose file `storage` and `imgproxy` services — because if to start both, basic compose and compose.s3 — this will produce conflict in services