### PR TITLE
docs: Remove extra `await` from Swift sample

### DIFF
--- a/apps/docs/content/guides/getting-started/tutorials/with-swift.mdx
+++ b/apps/docs/content/guides/getting-started/tutorials/with-swift.mdx
@@ -272,7 +272,7 @@ struct AppView: View {
       }
     }
     .task {
-      for await state in await supabase.auth.authStateChanges {
+      for await state in supabase.auth.authStateChanges {
         if [.initialSession, .signedIn, .signedOut].contains(state.event) {
           isAuthenticated = state.session != nil
         }


### PR DESCRIPTION
Removed extra await in `AppView` example

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

Yes

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

There is an extra `await` in a Swift code example which prevents the project from building:

```
Group {
  if isAuthenticated {
    ProfileView()
  } else {
    AuthView()
  }
}
.task {
  for await state in await supabase.auth.authStateChanges {     // this is invalid syntax
    if [.initialSession, .signedIn, .signedOut].contains(state.event) {
      isAuthenticated = state.session != nil
    }
  }
}
```

## What is the new behavior?

The extra `await` is removed and the application builds successfully as a result.

## Additional context

Add any other context or screenshots.
