### PR TITLE
chore: project addon text adjustments for Orb

### DIFF
--- a/apps/studio/components/interfaces/Settings/Addons/CustomDomainSidePanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/CustomDomainSidePanel.tsx
@@ -256,36 +256,55 @@ const CustomDomainSidePanel = () => {
             <>
               {selectedOption === 'cd_none' ||
               (selectedCustomDomain?.price ?? 0) < (subscriptionCDOption?.variant.price ?? 0)
-                ? subscription?.billing_via_partner === false && (
+                ? subscription?.billing_via_partner === false &&
+                  // Old addon billing with upfront payment
+                  subscription.usage_based_billing_project_addons === true && (
                     <p className="text-sm text-foreground-light">
-                      Upon clicking confirm, the add-on is removed immediately and any unused time
-                      in the current billing cycle is added as prorated credits to your organization
-                      and used in subsequent billing cycles.
+                      <span>
+                        Upon clicking confirm, the add-on is removed immediately and any unused time
+                        in the current billing cycle is added as prorated credits to your
+                        organization and used in subsequent billing cycles.
+                      </span>
                     </p>
                   )
                 : !subscription?.billing_via_partner && (
                     <p className="text-sm text-foreground-light">
-                      Upon clicking confirm, the amount of{' '}
-                      <span className="text-foreground">
-                        {formatCurrency(selectedCustomDomain?.price)}
-                      </span>{' '}
-                      will be added to your monthly invoice. The addon is prepaid per month and in
-                      case of a downgrade, you get credits for the remaining time. For the current
-                      billing cycle you're immediately charged a prorated amount for the remaining
-                      days.
+                      {subscription?.usage_based_billing_project_addons === false ? (
+                        <span>
+                          Upon clicking confirm, the amount of{' '}
+                          <span className="text-foreground">
+                            {formatCurrency(selectedCustomDomain?.price)}
+                          </span>{' '}
+                          will be added to your monthly invoice. The addon is prepaid per month and
+                          in case of a downgrade, you get credits for the remaining time. For the
+                          current billing cycle you're immediately charged a prorated amount for the
+                          remaining days.
+                        </span>
+                      ) : (
+                        <span>
+                          There are no immediate charges. The addon is billed at the end of your
+                          billing cycle based on your usage and prorated to the hour.
+                        </span>
+                      )}
                     </p>
                   )}
 
-              {subscription?.billing_via_partner &&
-                subscription.scheduled_plan_change?.target_plan !== undefined && (
-                  <Alert_Shadcn_ variant={'warning'} className="mb-2">
-                    <IconAlertTriangle className="h-4 w-4" />
-                    <AlertDescription_Shadcn_>
-                      You have a scheduled subscription change that will be canceled if you change
-                      your custom domain add on.
-                    </AlertDescription_Shadcn_>
-                  </Alert_Shadcn_>
-                )}
+              {
+                // Billed via partner
+                subscription?.billing_via_partner &&
+                  // Project addons are still billed the old way (upfront payment)
+                  subscription?.usage_based_billing_project_addons === false &&
+                  // Scheduled billing plan change
+                  subscription.scheduled_plan_change?.target_plan !== undefined && (
+                    <Alert_Shadcn_ variant={'warning'} className="mb-2">
+                      <IconAlertTriangle className="h-4 w-4" />
+                      <AlertDescription_Shadcn_>
+                        You have a scheduled subscription change that will be canceled if you change
+                        your custom domain add on.
+                      </AlertDescription_Shadcn_>
+                    </Alert_Shadcn_>
+                  )
+              }
             </>
           )}
 

--- a/apps/studio/components/interfaces/Settings/Addons/CustomDomainSidePanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/CustomDomainSidePanel.tsx
@@ -258,7 +258,7 @@ const CustomDomainSidePanel = () => {
               (selectedCustomDomain?.price ?? 0) < (subscriptionCDOption?.variant.price ?? 0)
                 ? subscription?.billing_via_partner === false &&
                   // Old addon billing with upfront payment
-                  subscription.usage_based_billing_project_addons === true && (
+                  subscription.usage_based_billing_project_addons === false && (
                     <p className="text-sm text-foreground-light">
                       <span>
                         Upon clicking confirm, the add-on is removed immediately and any unused time

--- a/apps/studio/components/interfaces/Settings/Addons/IPv4SidePanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/IPv4SidePanel.tsx
@@ -236,7 +236,7 @@ const IPv4SidePanel = () => {
               (selectedIPv4?.price ?? 0) < (subscriptionIpV4Option?.variant.price ?? 0) ? (
                 subscription?.billing_via_partner === false &&
                 // Old addon billing with upfront payment
-                subscription.usage_based_billing_project_addons === true && (
+                subscription.usage_based_billing_project_addons === false && (
                   <p className="text-sm text-foreground-light">
                     Upon clicking confirm, the add-on is removed immediately and any unused time in
                     the current billing cycle is added as prorated credits to your organization and

--- a/apps/studio/components/interfaces/Settings/Addons/IPv4SidePanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/IPv4SidePanel.tsx
@@ -14,7 +14,17 @@ import { useCheckPermissions, useSelectedOrganization } from 'hooks'
 import { formatCurrency } from 'lib/helpers'
 import Telemetry from 'lib/telemetry'
 import { useSubscriptionPageStateSnapshot } from 'state/subscription-page'
-import { Alert, Button, cn, IconExternalLink, Radio, SidePanel } from 'ui'
+import {
+  Alert,
+  Alert_Shadcn_,
+  AlertDescription_Shadcn_,
+  Button,
+  cn,
+  IconAlertTriangle,
+  IconExternalLink,
+  Radio,
+  SidePanel,
+} from 'ui'
 
 const IPv4SidePanel = () => {
   const router = useRouter()
@@ -224,7 +234,9 @@ const IPv4SidePanel = () => {
             <>
               {selectedOption === 'ipv4_none' ||
               (selectedIPv4?.price ?? 0) < (subscriptionIpV4Option?.variant.price ?? 0) ? (
-                subscription?.billing_via_partner === false && (
+                subscription?.billing_via_partner === false &&
+                // Old addon billing with upfront payment
+                subscription.usage_based_billing_project_addons === true && (
                   <p className="text-sm text-foreground-light">
                     Upon clicking confirm, the add-on is removed immediately and any unused time in
                     the current billing cycle is added as prorated credits to your organization and
@@ -253,12 +265,38 @@ const IPv4SidePanel = () => {
                   </p>
                   {!subscription?.billing_via_partner && (
                     <p className="text-sm text-foreground-light">
-                      Upon clicking confirm, the respective amount will be added to your monthly
-                      invoice. The addon is prepaid per month and in case of a downgrade, you get
-                      credits for the remaining time. For the current billing cycle you're
-                      immediately charged a prorated amount for the remaining days.
+                      {subscription?.usage_based_billing_project_addons === false ? (
+                        <span>
+                          Upon clicking confirm, the respective amount will be added to your monthly
+                          invoice. The addon is prepaid per month and in case of a downgrade, you
+                          get credits for the remaining time. For the current billing cycle you're
+                          immediately charged a prorated amount for the remaining days.
+                        </span>
+                      ) : (
+                        <span>
+                          There are no immediate charges. The addon is billed at the end of your
+                          billing cycle based on your usage and prorated to the hour.
+                        </span>
+                      )}
                     </p>
                   )}
+
+                  {
+                    // Billed via partner
+                    subscription?.billing_via_partner &&
+                      // Project addons are still billed the old way (upfront payment)
+                      subscription?.usage_based_billing_project_addons === false &&
+                      // Scheduled billing plan change
+                      subscription.scheduled_plan_change?.target_plan !== undefined && (
+                        <Alert_Shadcn_ variant={'warning'} className="mb-2">
+                          <IconAlertTriangle className="h-4 w-4" />
+                          <AlertDescription_Shadcn_>
+                            You have a scheduled subscription change that will be canceled if you
+                            change your PITR add on.
+                          </AlertDescription_Shadcn_>
+                        </Alert_Shadcn_>
+                      )
+                  }
                 </>
               )}
             </>

--- a/apps/studio/components/interfaces/Settings/Addons/PITRSidePanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/PITRSidePanel.tsx
@@ -385,7 +385,7 @@ const PITRSidePanel = () => {
               (selectedPitr?.price ?? 0) < (subscriptionPitr?.variant.price ?? 0)
                 ? subscription?.billing_via_partner === false &&
                   // Old addon billing with upfront payment
-                  subscription.usage_based_billing_project_addons === true && (
+                  subscription.usage_based_billing_project_addons === false && (
                     <p className="text-sm text-foreground-light">
                       Upon clicking confirm, the add-on is removed immediately and any unused time
                       in the current billing cycle is added as prorated credits to your organization

--- a/apps/studio/components/interfaces/Settings/Addons/PITRSidePanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/PITRSidePanel.tsx
@@ -383,7 +383,9 @@ const PITRSidePanel = () => {
             <>
               {selectedOption === 'pitr_0' ||
               (selectedPitr?.price ?? 0) < (subscriptionPitr?.variant.price ?? 0)
-                ? subscription?.billing_via_partner === false && (
+                ? subscription?.billing_via_partner === false &&
+                  // Old addon billing with upfront payment
+                  subscription.usage_based_billing_project_addons === true && (
                     <p className="text-sm text-foreground-light">
                       Upon clicking confirm, the add-on is removed immediately and any unused time
                       in the current billing cycle is added as prorated credits to your organization
@@ -392,25 +394,42 @@ const PITRSidePanel = () => {
                   )
                 : !subscription?.billing_via_partner && (
                     <p className="text-sm text-foreground-light">
-                      Upon clicking confirm, the amount of{' '}
-                      <span className="text-foreground">{formatCurrency(selectedPitr?.price)}</span>{' '}
-                      will be added to your monthly invoice. The addon is prepaid per month and in
-                      case of a downgrade, you get credits for the remaining time. For the current
-                      billing cycle you're immediately charged a prorated amount for the remaining
-                      days.
+                      {subscription?.usage_based_billing_project_addons === false ? (
+                        <span>
+                          Upon clicking confirm, the amount of{' '}
+                          <span className="text-foreground">
+                            {formatCurrency(selectedPitr?.price)}
+                          </span>{' '}
+                          will be added to your monthly invoice. The addon is prepaid per month and
+                          in case of a downgrade, you get credits for the remaining time. For the
+                          current billing cycle you're immediately charged a prorated amount for the
+                          remaining days.
+                        </span>
+                      ) : (
+                        <span>
+                          There are no immediate charges. The addon is billed at the end of your
+                          billing cycle based on your usage and prorated to the hour.
+                        </span>
+                      )}
                     </p>
                   )}
 
-              {subscription?.billing_via_partner &&
-                subscription.scheduled_plan_change?.target_plan !== undefined && (
-                  <Alert_Shadcn_ variant={'warning'} className="mb-2">
-                    <IconAlertTriangle className="h-4 w-4" />
-                    <AlertDescription_Shadcn_>
-                      You have a scheduled subscription change that will be canceled if you change
-                      your PITR add on.
-                    </AlertDescription_Shadcn_>
-                  </Alert_Shadcn_>
-                )}
+              {
+                // Billed via partner
+                subscription?.billing_via_partner &&
+                  // Project addons are still billed the old way (upfront payment)
+                  subscription?.usage_based_billing_project_addons === false &&
+                  // Scheduled billing plan change
+                  subscription.scheduled_plan_change?.target_plan !== undefined && (
+                    <Alert_Shadcn_ variant={'warning'} className="mb-2">
+                      <IconAlertTriangle className="h-4 w-4" />
+                      <AlertDescription_Shadcn_>
+                        You have a scheduled subscription change that will be canceled if you change
+                        your PITR add on.
+                      </AlertDescription_Shadcn_>
+                    </Alert_Shadcn_>
+                  )
+              }
             </>
           )}
         </div>

--- a/apps/studio/pages/api/organizations/[slug]/billing/subscription.ts
+++ b/apps/studio/pages/api/organizations/[slug]/billing/subscription.ts
@@ -38,6 +38,7 @@ const handleGet = async (req: NextApiRequest, res: NextApiResponse<ResponseData>
     scheduled_plan_change: null,
     customer_balance: 0,
     nano_enabled: false,
+    usage_based_billing_project_addons: false,
   }
 
   return res.status(200).json(response)

--- a/packages/api-types/types/api.d.ts
+++ b/packages/api-types/types/api.d.ts
@@ -3063,6 +3063,7 @@ export interface components {
       plan: components['schemas']['BillingSubscriptionPlan']
       project_addons: components['schemas']['BillingProjectAddonResponse'][]
       scheduled_plan_change: components['schemas']['ScheduledPlanChange'] | null
+      usage_based_billing_project_addons: boolean
       usage_billing_enabled: boolean
     }
     GetUserContentByIdResponse: {


### PR DESCRIPTION
Will be reviewed by billing team.

With Orb, project addons will be billed usage-based at the end of the month instead of an immediate proration/upfront charge.
