### PR TITLE
fix: EU tax ids for Orb

### DIFF
--- a/apps/studio/components/interfaces/Organization/BillingSettings/TaxID/TaxID.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/TaxID/TaxID.tsx
@@ -95,6 +95,7 @@ const TaxID = () => {
           ? {
               type: type,
               value: sanitizeTaxIdValue({ value, name: form.getValues().name }),
+              country: selectedTaxId?.countryIso2,
             }
           : null,
     })

--- a/apps/studio/data/organizations/organization-tax-id-update-mutation.ts
+++ b/apps/studio/data/organizations/organization-tax-id-update-mutation.ts
@@ -7,7 +7,7 @@ import { put, del, handleError } from 'data/fetchers'
 
 export type OrganizationTaxIdUpdateVariables = {
   slug: string
-  taxId: { type: string; value: string } | null
+  taxId: { type: string; value: string; country?: string } | null
 }
 
 export async function updateOrganizationTaxId({ slug, taxId }: OrganizationTaxIdUpdateVariables) {
@@ -22,7 +22,7 @@ export async function updateOrganizationTaxId({ slug, taxId }: OrganizationTaxId
           slug,
         },
       },
-      body: { type: taxId.type, value: taxId.value },
+      body: { type: taxId.type, value: taxId.value, country: taxId.country },
     })
 
     if (error) handleError(error)


### PR DESCRIPTION
Passes in the country to the tax id endpoint.  This fixes some tax ids for Orb.