### PR TITLE
Add bullet point for custom otp emails using admin api or hooks

### DIFF
--- a/apps/docs/spec/examples/examples.yml
+++ b/apps/docs/spec/examples/examples.yml
@@ -194,6 +194,7 @@ functions:
       - If you're using an email, you can configure whether you want the user to receive a magiclink or a OTP.
       - If you're using phone, you can configure whether you want the user to receive a OTP.
       - The magic link's destination URL is determined by the [`SITE_URL`](https://supabase.com/docs/guides/auth/redirect-urls). You can modify the `SITE_URL` or add additional redirect URLs in [your project](https://supabase.com/dashboard/project/_/auth/url-configuration).
+      - If you are looking to send your own OTP emails, you can use the [Auth Admin command](https://supabase.com/docs/reference/javascript/auth-admin-generatelink) or the `Send Email` [Auth Hook](https://supabase.com/docs/guides/auth/auth-hooks)
     examples:
       - id: sign-in-with-email.
         name: Sign in with email.


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs

## What is the current behavior?

Feedback has noted that the current docs for https://supabase.com/docs/reference/javascript/auth-admin-generatelink is hard to find, so linking to it from https://supabase.com/docs/reference/javascript/auth-signinwithotp

## What is the new behavior?

Now we gots ourselves some links. Also added a shoutout to Auth Hooks as they are a newer feature

## Additional context
