### PR TITLE
Update pause/restore window start date

### DIFF
--- a/apps/docs/content/guides/platform/migrating-and-upgrading-projects.mdx
+++ b/apps/docs/content/guides/platform/migrating-and-upgrading-projects.mdx
@@ -65,7 +65,7 @@ If you are upgrading from a significantly older version, you will need to consid
 
 #### Time Limits
 
-Starting from 2024-06-13, when a project is paused, users then have a 90-day window to restore the project on the platform from within Supabase Studio.
+Starting from 2024-06-24, when a project is paused, users then have a 90-day window to restore the project on the platform from within Supabase Studio.
 
 The 90-day window allows Supabase to introduce platform changes that may not be backwards compatible with older backups. Unlike active projects, static backups can't be updated to accommodate such changes.
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?
Corrects the effective start date for the free tier pause/restore 90 window