### PR TITLE
move code snippet above tip that references it

### DIFF
--- a/apps/docs/content/guides/api/rest/generating-types.mdx
+++ b/apps/docs/content/guides/api/rest/generating-types.mdx
@@ -206,11 +206,11 @@ const countriesWithCities: CountriesWithCities = data
 
 One way to keep your type definitions in sync with your database is to set up a GitHub action that runs on a schedule.
 
-Add the script above to your `package.json` to run it using `npm run update-types`
-
 ```json
 "update-types": "npx supabase gen types typescript --project-id \"$PROJECT_REF\" > types/supabase.ts"
 ```
+
+Add the script above to your `package.json` to run it using `npm run update-types`
 
 Create a file `.github/workflows/update-types.yml` with the following snippet to define the action along with the environment variables. This script will commit new type changes to your repo every night.
 

--- a/apps/docs/content/guides/api/rest/generating-types.mdx
+++ b/apps/docs/content/guides/api/rest/generating-types.mdx
@@ -206,11 +206,11 @@ const countriesWithCities: CountriesWithCities = data
 
 One way to keep your type definitions in sync with your database is to set up a GitHub action that runs on a schedule.
 
+Add the following script to your `package.json` to run it using `npm run update-types`
+
 ```json
 "update-types": "npx supabase gen types typescript --project-id \"$PROJECT_REF\" > types/supabase.ts"
 ```
-
-Add the script above to your `package.json` to run it using `npm run update-types`
 
 Create a file `.github/workflows/update-types.yml` with the following snippet to define the action along with the environment variables. This script will commit new type changes to your repo every night.
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

A tip says to "use the script above" but the script is below lol.

## What is the new behavior?

I just moved the script above the text so it makes sense.

## Additional context

I'm trying to get more involved in open source so this was mostly an exercise for myself.