### PR TITLE
Fix: pooler connection limit warning message

### DIFF
--- a/apps/studio/components/interfaces/Settings/Database/ConnectionPooling/ConnectionPooling.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/ConnectionPooling/ConnectionPooling.tsx
@@ -331,14 +331,14 @@ export const ConnectionPooling = () => {
                           placeholder={field.value === null ? `${defaultPoolSize}` : ''}
                         />
                       </FormControl_Shadcn_>
-                      {maxConnData !== undefined &&
+                      {defaultMaxClientConn !== undefined &&
                         Number(form.getValues('default_pool_size') ?? 15) >
-                          maxConnData.maxConnections * 0.8 && (
+                          defaultMaxClientConn * 0.8 && (
                           <div className="col-start-5 col-span-8">
                             <Alert_Shadcn_ variant="warning">
                               <AlertTitle_Shadcn_ className="text-foreground">
                                 Pool size is greater than 80% of the max connections (
-                                {maxConnData.maxConnections}) on your database
+                                {defaultMaxClientConn}) on your database
                               </AlertTitle_Shadcn_>
                               <AlertDescription_Shadcn_>
                                 This may result in instability and unreliability with your database


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The warning message indicates the maximum connection limit for direct connections, not for the connection pooler.

## What is the new behavior?

![Screenshot 2024-06-27 at 2 02 05 PM](https://github.com/supabase/supabase/assets/99693443/32e00158-426e-4618-9734-9c86d7950eaf)

