### PR TITLE
Fix: project dropdown url for security advisor route

### DIFF
--- a/apps/studio/components/layouts/AppLayout/ProjectDropdown.tsx
+++ b/apps/studio/components/layouts/AppLayout/ProjectDropdown.tsx
@@ -41,9 +41,11 @@ export const sanitizeRoute = (route: string, routerQueries: ParsedUrlQuery) => {
     // [Joshen] Ideally we shouldn't use hard coded numbers, but temp workaround
     // for storage bucket route since its longer
     const isStorageBucketRoute = 'bucketId' in routerQueries
+    const isSecurityAdvisorRoute = 'preset' in routerQueries
+
     return route
       .split('/')
-      .slice(0, isStorageBucketRoute ? 5 : 4)
+      .slice(0, isStorageBucketRoute || isSecurityAdvisorRoute ? 5 : 4)
       .join('/')
   } else {
     return route


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When we were switching project through the dropdown menu, it was redirecting to an incorrect URL, resulting in a 404 error for the security advisor route.

## How to Test
Navigate to: https://supabase.com/dashboard/project/xxx/advisors/security.

- Switch to another project using the dropdown in the header.
- Verify that the URL correctly switches to: https://supabase.com/dashboard/project/xxxx/advisors/security.

Navigate to: https://supabase.com/dashboard/project/xxx/advisors/security?preset=WARN&id=.

- Switch to another project using the dropdown in the header.
- Verify that the URL correctly switches to: https://supabase.com/dashboard/project/xxx/advisors/security?preset=WARN&id=.