### PR TITLE
ref: Open GitHub and Vercel integrations links in new tabs

### DIFF
--- a/apps/studio/components/interfaces/Organization/IntegrationSettings/IntegrationSettings.tsx
+++ b/apps/studio/components/interfaces/Organization/IntegrationSettings/IntegrationSettings.tsx
@@ -150,7 +150,11 @@ The GitHub app will watch for changes in your repository such as file changes, b
             </p>
           )}
           {GitHubContentSectionBottom && (
-            <Markdown content={GitHubContentSectionBottom} className="text-foreground-lighter" />
+            <Markdown
+              extLinks
+              content={GitHubContentSectionBottom}
+              className="text-foreground-lighter"
+            />
           )}
         </ScaffoldSectionContent>
       </ScaffoldSection>

--- a/apps/studio/components/interfaces/Settings/Integrations/VercelIntegration/VercelSection.tsx
+++ b/apps/studio/components/interfaces/Settings/Integrations/VercelIntegration/VercelSection.tsx
@@ -215,7 +215,11 @@ You can change the scope of the access for Supabase by configuring
             </div>
           )}
           {VercelContentSectionBottom && (
-            <Markdown content={VercelContentSectionBottom} className="text-foreground-lighter" />
+            <Markdown
+              extLinks
+              content={VercelContentSectionBottom}
+              className="text-foreground-lighter"
+            />
           )}
         </ScaffoldSectionContent>
       </ScaffoldSection>


### PR DESCRIPTION
By adding `extLinks` to `Markdown` components.