### PR TITLE
fix: update no policies warning to 0 results

### DIFF
--- a/apps/studio/components/interfaces/Auth/Policies/PolicyTableRow/index.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/PolicyTableRow/index.tsx
@@ -56,8 +56,7 @@ const PolicyTableRow = ({
                 Row Level Security is enabled for this table, but no policies are set
               </AlertTitle_Shadcn_>
               <AlertDescription_Shadcn_>
-                Select queries will return an{' '}
-                <span className="text-foreground underline">empty array</span> of results.
+                Select queries may return 0 results.
               </AlertDescription_Shadcn_>
             </Alert_Shadcn_>
           )}

--- a/apps/studio/components/interfaces/TableGridEditor/GridHeaderActions.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/GridHeaderActions.tsx
@@ -214,9 +214,7 @@ const GridHeaderActions = ({ table }: GridHeaderActionsProps) => {
                       >
                         <div className="text-xs text-foreground p-1 leading-relaxed">
                           <p>RLS is enabled for this table, but no policies are set. </p>
-                          <p>
-                            Select queries will return an <u>empty array</u> of results.
-                          </p>
+                          <p>Select queries may return 0 results.</p>
                         </div>
                       </div>
                     </Tooltip.Content>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES
## What kind of change does this PR introduce?

improvement

## What is the current behavior?

current copy disregards queries made by users that bypass rls and queries made via other clients

## What is the new behavior?

generic copy that writes 0 results.
