### PR TITLE
Update Cookie-based Auth URL in Next.js getting started docs

### DIFF
--- a/apps/docs/content/guides/getting-started/quickstarts/nextjs.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/nextjs.mdx
@@ -44,7 +44,7 @@ hideToc: true
     <StepHikeCompact.Details title="Create a Next.js app">
 
     Use the `create-next-app` command and the `with-supabase` template, to create a Next.js app pre-configured with:
-    - [Cookie-based Auth](https://supabase.com/docs/guides/auth/auth-helpers/nextjs)
+    - [Cookie-based Auth](https://supabase.com/docs/guides/auth/server-side/nextjs)
     - [TypeScript](https://www.typescriptlang.org/)
     - [Tailwind CSS](https://tailwindcss.com/)
 


### PR DESCRIPTION
Although `npx create-next-app -e with-supabase` installs the correct package - `@supabase/ssr` - the link in the docs link to an outdated package docs, which can be a tad confusing.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Link takes to legacy docs

## What is the new behavior?

Link takes to up-to-date docs

## Additional context

n/a
