### PR TITLE
Added warning about vacuum full

### DIFF
--- a/apps/docs/content/guides/platform/database-size.mdx
+++ b/apps/docs/content/guides/platform/database-size.mdx
@@ -57,7 +57,7 @@ vacuum full <table name>;
 
 <Admonition type="note">
 
-Vacuum operations can temporarily increase resource utilization, which may adversely impact the observed performance of your project until the maintenance is completed.
+Vacuum operations can temporarily increase resource utilization, which may adversely impact the observed performance of your project until the maintenance is completed. The [vacuum full](https://www.postgresql.org/docs/current/sql-vacuum.html) command will lock the table until the operation concludes.
 
 </Admonition>
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES/NO

## What kind of change does this PR introduce?

Added warning

## What is the current behavior?

Doesn't warn that vacuum full locks tables

## What is the new behavior?

Adds short warning

## Additional context


