### PR TITLE
Invalid SQL syntax in rls bypass section

### DIFF
--- a/apps/docs/content/guides/database/postgres/row-level-security.mdx
+++ b/apps/docs/content/guides/database/postgres/row-level-security.mdx
@@ -269,7 +269,7 @@ Supabase will adhere to the RLS policy of the signed-in user, even if the client
 You can also create new [Postgres Roles](/docs/guides/database/postgres/roles) which can bypass Row Level Security using the "bypass RLS" privilege:
 
 ```sql
-grant bypassrls on "table_name" to "role_name";
+alter role "role_name" with bypassrls;
 ```
 
 This can be useful for system-level access. You should _never_ share login credentials for any Postgres Role with this privilege.


### PR DESCRIPTION
Unless there is some new SQL I'm not familiar the code shown: `grant bypassrls on "table_name" to "role_name";`
Will not work and instead should be:
`alter role "role_name" with bypassrls;`

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

 docs update, ...

![image](https://github.com/supabase/supabase/assets/54564956/b02c9669-3307-44ce-ba95-135393bc3eb4)

