### PR TITLE
Truncate project names in popover

### DIFF
--- a/apps/studio/pages/new/[slug].tsx
+++ b/apps/studio/pages/new/[slug].tsx
@@ -821,7 +821,9 @@ const Wizard: NextPageWithLayout = () => {
                                   <TableBody className="[&_td]:py-2">
                                     {organizationProjects.map((project) => (
                                       <TableRow key={project.ref} className="text-foreground-light">
-                                        <TableCell className="w-[170px]">{project.name}</TableCell>
+                                        <TableCell className="w-[170px] truncate">
+                                          {project.name}
+                                        </TableCell>
                                         <TableCell className="text-center">
                                           {instanceLabel(project.infra_compute_size)}
                                         </TableCell>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

- Should truncate project names in the popover

how it was:
<img width="526" alt="Screenshot 2024-07-02 at 4 10 16 PM" src="https://github.com/supabase/supabase/assets/8291514/21c6805f-a1b4-427d-8b61-2025935fff1a">
