### PR TITLE
realtime: Bump Realtime image to 2.29.15

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -171,7 +171,7 @@ services:
   realtime:
     # This container name looks inconsistent but is correct because realtime constructs tenant id by parsing the subdomain
     container_name: realtime-dev.supabase-realtime
-    image: supabase/realtime:v2.29.13
+    image: supabase/realtime:v2.29.15
     depends_on:
       db:
         # Disable this if you are using an external Postgres database


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bump Realtime image to 2.29.15