### PR TITLE
fix(auth-emails): improve template selection and naming consistency

### DIFF
--- a/apps/studio/components/interfaces/Auth/AuthTemplatesValidation.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthTemplatesValidation.tsx
@@ -7,7 +7,7 @@ const CONFIRMATION: FormSchema = {
   $schema: JSON_SCHEMA_VERSION,
   id: 'CONFIRMATION',
   type: 'object',
-  title: 'Confirm signup',
+  title: 'Confirm SignUp',
   properties: {
     MAILER_SUBJECTS_CONFIRMATION: {
       title: 'Subject heading',
@@ -42,7 +42,7 @@ const INVITE: FormSchema = {
   $schema: JSON_SCHEMA_VERSION,
   id: 'INVITE',
   type: 'object',
-  title: 'Invite user',
+  title: 'Invite User',
   properties: {
     MAILER_SUBJECTS_INVITE: {
       title: 'Subject heading',

--- a/apps/studio/components/interfaces/Auth/Users/UserDropdown.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/UserDropdown.tsx
@@ -45,6 +45,7 @@ const UserDropdown = ({
   const { ref } = useParams()
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
   const [isDeleteFactorsModalOpen, setIsDeleteFactorsModalOpen] = useState(false)
+  const isUserConfirmed = user.email_confirmed_at || user.phone_confirmed_at
 
   const { canRemoveUser, canRemoveMFAFactors, canSendMagicLink, canSendRecovery, canSendOtp } =
     permissions
@@ -56,7 +57,7 @@ const UserDropdown = ({
   })
   const { mutate: sendMagicLink, isLoading: isSendingLink } = useUserSendMagicLinkMutation({
     onSuccess: () => {
-      toast.success(`Sent magic link to ${user.email}`)
+      toast.success(`${isUserConfirmed ? "Sent magic link to": "Sent confirm sign up link to"} ${user.email}`)
     },
   })
   const { mutate: sendOTP, isLoading: isSendingOTP } = useUserSendOTPMutation({
@@ -157,7 +158,7 @@ const UserDropdown = ({
                       }}
                     >
                       <Mail size={14} />
-                      <p>Send magic link</p>
+                      <p>{isUserConfirmed ? "Send magic link": "Send confirm sign up link"}</p>
                     </DropdownMenuItem>
                   </TooltipTrigger_Shadcn_>
                   {!canSendMagicLink && (


### PR DESCRIPTION
## What kind of change does this PR introduce?

frontend fix

- Update initial menu to be context-aware and display the correct option ("Confirm signup") when the user has not confirmed their email
- Standardize casing for email template tab names ("Confirm signup" and "Magic Link")

https://github.com/supabase/supabase/issues/27475

![Screenshot from 2024-07-02 17-43-56](https://github.com/supabase/supabase/assets/86585626/aea2336a-2002-4fbe-80b8-26f42ed54d71)
