### PR TITLE
fix double tabs in oss page

### DIFF
--- a/apps/www/components/OpenSource/Repos.tsx
+++ b/apps/www/components/OpenSource/Repos.tsx
@@ -142,7 +142,7 @@ const Repos = ({ tabs }: Props) => {
                     : SWIPER_STATE.MIDDLE
               )
             }
-            className="relative flex md:hidden justify-center max-w-full w-full overflow-hidden items-center rounded-full bg-surface-100 p-2"
+            className="relative flex md:!hidden justify-center max-w-full w-full overflow-hidden items-center rounded-full bg-surface-100 p-2"
           >
             <div
               className={cn(

--- a/apps/www/pages/open-source/index.tsx
+++ b/apps/www/pages/open-source/index.tsx
@@ -1,3 +1,5 @@
+import 'swiper/css'
+
 import { useRouter } from 'next/router'
 import { NextSeo } from 'next-seo'
 
@@ -10,9 +12,6 @@ import Repos from '~/components/OpenSource/Repos'
 import Sponsorships from '~/components/OpenSource/Sponsorships'
 
 import pageData from '~/data/open-source'
-
-// Import Swiper styles if swiper used on page
-import 'swiper/css'
 
 const OpenSource = () => {
   const router = useRouter()


### PR DESCRIPTION
## What is the current behavior?

<img width="1554" alt="Screenshot 2024-07-03 at 16 28 05" src="https://github.com/supabase/supabase/assets/25671831/58058c7d-b1e6-4599-b5ac-6ab8766ae4e7">

## What is the new behavior?

<img width="1159" alt="Screenshot 2024-07-03 at 16 28 57" src="https://github.com/supabase/supabase/assets/25671831/53f01294-9864-4648-97d3-8ff39caa31de">
