### PR TITLE
chore: remove data cache from not-found docs page

### DIFF
--- a/apps/docs/app/not-found/page.tsx
+++ b/apps/docs/app/not-found/page.tsx
@@ -5,6 +5,8 @@ import { DocsSearchResult, type Database } from 'common'
 
 import { NotFound } from '~/features/recommendations/NotFound.client'
 
+export const fetchCache = 'force-no-store'
+
 const metadata: Metadata = {
   robots: {
     index: false,


### PR DESCRIPTION
There's no real need to cache data fetches for this (it's just an upgraded 404 page) and I don't like the amount of data we're writing to the Data Cache for it.