### PR TITLE
Example react-user-management: Unsubscribe onAuthStateChange listener.

### DIFF
--- a/examples/user-management/react-user-management/src/App.jsx
+++ b/examples/user-management/react-user-management/src/App.jsx
@@ -12,9 +12,11 @@ function App() {
       setSession(session)
     })
 
-    supabase.auth.onAuthStateChange((_event, session) => {
+    const { data } = supabase.auth.onAuthStateChange((_event, session) => {
       setSession(session)
     })
+
+    return () => data.subscription.unsubscribe();
   }, [])
 
   return (


### PR DESCRIPTION
Example react-user-management:
Unsubscribe the sb.auth.onAuthStateChange listener on component cleanup.
This prevents leakage of listeners.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.
YES

## What kind of change does this PR introduce?
Fix a listener leakage.

## What is the current behavior?
No unsubscribe from sb.auth.onAuthStateChange.

## What is the new behavior?
Cleanup the subscription in useEffect cleanup.
