### PR TITLE
Fix: convertArgumentTypes parsing bug

### DIFF
--- a/apps/studio/components/interfaces/Database/Functions/Functions.utils.ts
+++ b/apps/studio/components/interfaces/Database/Functions/Functions.utils.ts
@@ -5,21 +5,32 @@ import { isEmpty } from 'lodash'
  * to args = {value: [{name:'a', type:'integer'}, {name:'b', type:'integer'}]}
  */
 export function convertArgumentTypes(value: string) {
-  const items = value?.split(',')
-  if (isEmpty(value) || !items || items?.length == 0) return { value: [] }
+  const items = value?.split(',').map((item) => item.trim())
+  if (isEmpty(value) || !items || items.length === 0) return { value: [] }
+
   const temp = items
     .map((x) => {
-      const str = x.trim()
-      const splitted = str.split(' ')
-      if (splitted.length === 2) {
-        return { name: splitted[0], type: splitted[1] }
+      const regex = /(\w+)\s+([\w\[\]]+)(?:\s+DEFAULT\s+(.*))?/i
+      const match = x.match(regex)
+      if (match) {
+        const [, name, type, defaultValue] = match
+        let parsedDefaultValue = defaultValue ? defaultValue.trim() : undefined
+
+        if (
+          ['timestamp', 'time', 'timetz', 'timestamptz'].includes(type.toLowerCase()) &&
+          parsedDefaultValue
+        ) {
+          parsedDefaultValue = `'${parsedDefaultValue}'`
+        }
+
+        return { name, type, defaultValue: parsedDefaultValue }
+      } else {
+        console.error('Error while trying to parse function arguments', x)
+        return null
       }
-      if (splitted.length === 1) {
-        return { name: splitted[0], type: splitted[0] }
-      }
-      console.error('Error while trying to parse function arguments', value)
     })
-    .filter(Boolean) as { name: string; type: string }[]
+    .filter(Boolean)
+
   return { value: temp }
 }
 

--- a/apps/studio/components/interfaces/Database/Functions/Functions.utils.ts
+++ b/apps/studio/components/interfaces/Database/Functions/Functions.utils.ts
@@ -29,8 +29,7 @@ export function convertArgumentTypes(value: string) {
         return null
       }
     })
-    .filter(Boolean)
-
+    .filter(Boolean) as { name: string; type: string; defaultValue?: string }[]
   return { value: temp }
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix...

## How to test?

1. Open the SQL Editor and execute the following SQL statement:

```
CREATE OR REPLACE FUNCTION demo_all_types(
    _a_smallint SMALLINT,
    _a_integer INTEGER DEFAULT 0,
    _a_bigint BIGINT DEFAULT 1000000,
    _a_numeric NUMERIC DEFAULT 999.99,
    _a_real REAL DEFAULT 1.23,
    _a_double DOUBLE PRECISION DEFAULT 3.14,
    _a_boolean BOOLEAN DEFAULT TRUE,
    _a_char CHAR DEFAULT 'A',
    _a_varchar VARCHAR DEFAULT 'default',
    _a_text TEXT DEFAULT 'default text',
    _a_bytea BYTEA DEFAULT '\\xDEADBEEF',
    _a_date DATE DEFAULT CURRENT_DATE,
    _a_time TIME DEFAULT CURRENT_TIME,
    _a_timetz TIME WITH TIME ZONE DEFAULT CURRENT_TIME AT TIME ZONE 'UTC',
    _a_timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
    _a_timestamptz TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP AT TIME ZONE 'UTC',
    _a_interval INTERVAL DEFAULT '1 year',
    _a_uuid UUID DEFAULT gen_random_uuid(),
    _a_json JSON DEFAULT '{}'::json,
    _a_jsonb JSONB DEFAULT '{}'::jsonb,
    _a_xml XML DEFAULT '<tag>value</tag>',
    _a_array INTEGER[] DEFAULT ARRAY[1, 2, 3],
    _a_text_array TEXT[] DEFAULT ARRAY['text1', 'text2', 'text3'],
    _a_point POINT DEFAULT POINT(0, 0),
    _a_line LINE DEFAULT '{1,0,0}',
    _a_lseg LSEG DEFAULT '[(0,0),(1,1)]',
    _a_box BOX DEFAULT '(0,0),(1,1)',
    _a_path PATH DEFAULT '((0,0),(1,1),(2,2))',
    _a_polygon POLYGON DEFAULT '((0,0),(1,1),(2,2))',
    _a_circle CIRCLE DEFAULT '<(0,0),1>'
)
RETURNS TEXT
AS $$
BEGIN
    RETURN 'Function executed successfully';
END;
$$ LANGUAGE plpgsql;
```

2. Navigate to Database > Functions.

3. Edit the newly created demo_all_types function. Ensure that all arguments are displayed correctly with their types in the editor.