### PR TITLE
Fixed spelling typo

### DIFF
--- a/apps/studio/components/interfaces/Settings/Integrations/GithubIntegration/GitHubIntegrationConnectionForm.tsx
+++ b/apps/studio/components/interfaces/Settings/Integrations/GithubIntegration/GitHubIntegrationConnectionForm.tsx
@@ -223,7 +223,7 @@ const GitHubIntegrationConnectionForm = ({
         <Alert_Shadcn_ className="w-full mb-0" variant="warning">
           <WarningIcon />
           <div>
-            <AlertTitle_Shadcn_ className="text-sm">Braching is not enabled</AlertTitle_Shadcn_>
+            <AlertTitle_Shadcn_ className="text-sm">Branching is not enabled</AlertTitle_Shadcn_>
             <AlertDescription_Shadcn_ className="text-xs">
               This integration has no effect without Branching feature being active.
               <br />


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Fix a spelling typo in alert text displayed to users ("braching" --> "branching")

## What is the current behavior?

Misspelled word.

## What is the new behavior?

Correctly spelled word.

## Additional context

Making Supabase better, one letter at a time.

![image](https://github.com/supabase/supabase/assets/8879811/2773f090-0abd-4db3-bcc9-145d1b3903f0)
