### PR TITLE
fix: og image generation for customer stories

### DIFF
--- a/supabase/functions/og-images/handler.tsx
+++ b/supabase/functions/og-images/handler.tsx
@@ -97,7 +97,7 @@ export async function handler(req: Request) {
         fonts: [
           {
             name: 'Circular',
-            data: fontData,
+            data: CIRCULAR_FONT_DATA,
             style: 'normal',
           },
         ],


### PR DESCRIPTION
fontData wasn't defined, so swapped in what I think is the correct font (based on what was done above for the docs OG images).