### PR TITLE
fix: erroring table of contents

### DIFF
--- a/apps/docs/components/GuidesTableOfContents.tsx
+++ b/apps/docs/components/GuidesTableOfContents.tsx
@@ -99,7 +99,7 @@ const GuidesTableOfContents = ({
 
           return { text, link, level } as Partial<TOCHeader>
         })
-        .filter((x): x is TOCHeader => !!x.text && !!x.link && !!x.level)
+        .filter((x): x is TOCHeader => !!x && !!x.text && !!x.link && !!x.level)
       setTocList(newHeadings)
     })
 


### PR DESCRIPTION
Table of Contents errored in some cases because I forgot to check for the case where the value can be null.