### PR TITLE
fix: revalidate fetches every day

### DIFF
--- a/apps/docs/app/guides/ai/python/[slug]/page.tsx
+++ b/apps/docs/app/guides/ai/python/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { relative } from 'path'
 import rehypeSlug from 'rehype-slug'
 import { genGuideMeta } from '~/features/docs/GuidesMdx.utils'
 import { GuideTemplate, newEditLink } from '~/features/docs/GuidesMdx.template'
+import { fetchRevalidatePerDay } from '~/features/helpers.fetch'
 import { notFoundLink } from '~/features/recommendations/NotFound.utils'
 import { UrlTransformFunction, linkTransform } from '~/lib/mdx/plugins/rehypeLinkTransform'
 import remarkMkDocsAdmonition from '~/lib/mdx/plugins/remarkAdmonition'
@@ -79,7 +80,7 @@ const getContent = async ({ slug }: Params) => {
 
   const editLink = newEditLink(`${org}/${repo}/blob/${branch}/${docsDir}/${remoteFile}`)
 
-  const response = await fetch(
+  const response = await fetchRevalidatePerDay(
     `https://raw.githubusercontent.com/${org}/${repo}/${branch}/${docsDir}/${remoteFile}`
   )
 

--- a/apps/docs/app/guides/cli/github-action/[slug]/page.tsx
+++ b/apps/docs/app/guides/cli/github-action/[slug]/page.tsx
@@ -2,8 +2,10 @@ import { type SerializeOptions } from 'next-mdx-remote/dist/types'
 import { redirect } from 'next/navigation'
 import { relative } from 'node:path'
 import rehypeSlug from 'rehype-slug'
+
 import { genGuideMeta } from '~/features/docs/GuidesMdx.utils'
 import { GuideTemplate, newEditLink } from '~/features/docs/GuidesMdx.template'
+import { fetchRevalidatePerDay } from '~/features/helpers.fetch'
 import { notFoundLink } from '~/features/recommendations/NotFound.utils'
 import { UrlTransformFunction, linkTransform } from '~/lib/mdx/plugins/rehypeLinkTransform'
 import remarkMkDocsAdmonition from '~/lib/mdx/plugins/remarkAdmonition'
@@ -78,7 +80,7 @@ const getContent = async ({ slug }: Params) => {
 
   const editLink = newEditLink(`${org}/${repo}/blob/${branch}/${docsDir}/${remoteFile}`)
 
-  const response = await fetch(
+  const response = await fetchRevalidatePerDay(
     `https://raw.githubusercontent.com/${org}/${repo}/${branch}/${docsDir}/${remoteFile}`
   )
 

--- a/apps/docs/app/guides/database/database-advisors/page.tsx
+++ b/apps/docs/app/guides/database/database-advisors/page.tsx
@@ -2,11 +2,13 @@ import { Octokit } from '@octokit/core'
 import { capitalize } from 'lodash'
 import { type SerializeOptions } from 'next-mdx-remote/dist/types'
 import rehypeSlug from 'rehype-slug'
+
 import { Heading } from 'ui'
+
 import { genGuideMeta } from '~/features/docs/GuidesMdx.utils'
 import { GuideTemplate, MDXRemoteGuides, newEditLink } from '~/features/docs/GuidesMdx.template'
+import { fetchRevalidatePerDay } from '~/features/helpers.fetch'
 import { Tabs, TabPanel } from '~/features/ui/Tabs'
-
 import { UrlTransformFunction, linkTransform } from '~/lib/mdx/plugins/rehypeLinkTransform'
 import remarkMkDocsAdmonition from '~/lib/mdx/plugins/remarkAdmonition'
 import { removeTitle } from '~/lib/mdx/plugins/remarkRemoveTitle'
@@ -109,7 +111,7 @@ const urlTransform: (lints: Array<{ path: string }>) => UrlTransformFunction = (
  * Fetch lint remediation Markdown from external repo
  */
 const getLints = async () => {
-  const octokit = new Octokit()
+  const octokit = new Octokit({ request: { fetch: fetchRevalidatePerDay } })
 
   const response = await octokit.request('GET /repos/{owner}/{repo}/contents/{path}', {
     owner: org,
@@ -135,7 +137,7 @@ const getLints = async () => {
 
   const lints = await Promise.all(
     lintsList.map(async ({ path }) => {
-      const fileResponse = await fetch(
+      const fileResponse = await fetchRevalidatePerDay(
         `https://raw.githubusercontent.com/${org}/${repo}/${branch}/${path}`
       )
 

--- a/apps/docs/app/guides/database/extensions/wrappers/[[...slug]]/page.tsx
+++ b/apps/docs/app/guides/database/extensions/wrappers/[[...slug]]/page.tsx
@@ -4,8 +4,10 @@ import { readFile } from 'node:fs/promises'
 import { join, relative } from 'node:path'
 import rehypeSlug from 'rehype-slug'
 import emoji from 'remark-emoji'
+
 import { genGuideMeta, genGuidesStaticParams } from '~/features/docs/GuidesMdx.utils'
 import { GuideTemplate, newEditLink } from '~/features/docs/GuidesMdx.template'
+import { fetchRevalidatePerDay } from '~/features/helpers.fetch'
 import { GUIDES_DIRECTORY, isValidGuideFrontmatter } from '~/lib/docs'
 import { UrlTransformFunction, linkTransform } from '~/lib/mdx/plugins/rehypeLinkTransform'
 import remarkMkDocsAdmonition from '~/lib/mdx/plugins/remarkAdmonition'
@@ -159,7 +161,7 @@ const getContent = async (params: Params) => {
     ;({ remoteFile, meta } = federatedPage)
     const repoPath = `${org}/${repo}/${branch}/${docsDir}/${remoteFile}`
     editLink = `${org}/${repo}/blob/${branch}/${docsDir}/${remoteFile}`
-    const response = await fetch(`https://raw.githubusercontent.com/${repoPath}`)
+    const response = await fetchRevalidatePerDay(`https://raw.githubusercontent.com/${repoPath}`)
     content = await response.text()
   }
 

--- a/apps/docs/app/guides/graphql/[[...slug]]/page.tsx
+++ b/apps/docs/app/guides/graphql/[[...slug]]/page.tsx
@@ -2,8 +2,10 @@ import { type SerializeOptions } from 'next-mdx-remote/dist/types'
 import { redirect } from 'next/navigation'
 import { isAbsolute, relative } from 'path'
 import rehypeSlug from 'rehype-slug'
+
 import { genGuideMeta } from '~/features/docs/GuidesMdx.utils'
 import { GuideTemplate, newEditLink } from '~/features/docs/GuidesMdx.template'
+import { fetchRevalidatePerDay } from '~/features/helpers.fetch'
 import { notFoundLink } from '~/features/recommendations/NotFound.utils'
 import { UrlTransformFunction, linkTransform } from '~/lib/mdx/plugins/rehypeLinkTransform'
 import remarkMkDocsAdmonition from '~/lib/mdx/plugins/remarkAdmonition'
@@ -132,7 +134,7 @@ const getContent = async ({ slug }: Params) => {
 
   const editLink = newEditLink(`${org}/${repo}/blob/${branch}/${docsDir}/${remoteFile}`)
 
-  const response = await fetch(
+  const response = await fetchRevalidatePerDay(
     `https://raw.githubusercontent.com/${org}/${repo}/${branch}/${docsDir}/${remoteFile}`
   )
 

--- a/apps/docs/app/guides/platform/terraform/[[...slug]]/page.tsx
+++ b/apps/docs/app/guides/platform/terraform/[[...slug]]/page.tsx
@@ -4,6 +4,7 @@ import { redirect } from 'next/navigation'
 import rehypeSlug from 'rehype-slug'
 import { genGuideMeta } from '~/features/docs/GuidesMdx.utils'
 import { GuideTemplate, newEditLink } from '~/features/docs/GuidesMdx.template'
+import { fetchRevalidatePerDay } from '~/features/helpers.fetch'
 import { notFoundLink } from '~/features/recommendations/NotFound.utils'
 import { isValidGuideFrontmatter } from '~/lib/docs'
 import { UrlTransformFunction, linkTransform } from '~/lib/mdx/plugins/rehypeLinkTransform'
@@ -111,7 +112,7 @@ const getContent = async ({ slug }: Params) => {
     `${terraformDocsOrg}/${terraformDocsRepo}/blob/${terraformDocsBranch}/${useRoot ? '' : `${terraformDocsDocsDir}/`}${remoteFile}`
   )
 
-  let response = await fetch(
+  let response = await fetchRevalidatePerDay(
     `https://raw.githubusercontent.com/${terraformDocsOrg}/${terraformDocsRepo}/${terraformDocsBranch}/${useRoot ? '' : `${terraformDocsDocsDir}/`}${remoteFile}`
   )
 

--- a/apps/docs/app/guides/platform/terraform/reference/page.tsx
+++ b/apps/docs/app/guides/platform/terraform/reference/page.tsx
@@ -2,6 +2,7 @@ import { codeBlock } from 'common-tags'
 import { Check, PlusCircle } from 'lucide-react'
 import Link from 'next/link'
 import ReactMarkdown from 'react-markdown'
+
 import {
   CodeBlock,
   Heading,
@@ -9,8 +10,10 @@ import {
   PopoverTrigger_Shadcn_,
   Popover_Shadcn_,
 } from 'ui'
+
 import { genGuideMeta } from '~/features/docs/GuidesMdx.utils'
 import { GuideTemplate, newEditLink } from '~/features/docs/GuidesMdx.template'
+import { fetchRevalidatePerDay } from '~/features/helpers.fetch'
 import { TabPanel, Tabs } from '~/features/ui/Tabs'
 import {
   terraformDocsBranch,
@@ -391,7 +394,7 @@ const TerraformReferencePage = async () => {
  * Fetch JSON schema from external repo
  */
 const getSchema = async () => {
-  let response = await fetch(
+  let response = await fetchRevalidatePerDay(
     `https://raw.githubusercontent.com/${terraformDocsOrg}/${terraformDocsRepo}/${terraformDocsBranch}/${terraformDocsDocsDir}/schema.json`
   )
   if (!response.ok) throw Error('Failed to fetch Terraform JSON schema from GitHub')

--- a/apps/docs/app/not-found/page.tsx
+++ b/apps/docs/app/not-found/page.tsx
@@ -1,8 +1,6 @@
-import { createClient } from '@supabase/supabase-js'
 import { type Metadata } from 'next'
 import Link from 'next/link'
 
-import { DocsSearchResult, type Database } from 'common'
 import { Button } from 'ui'
 
 import { SearchButton, Recommendations } from '~/features/recommendations/NotFound.client'

--- a/apps/docs/features/helpers.fetch.ts
+++ b/apps/docs/features/helpers.fetch.ts
@@ -1,0 +1,17 @@
+/**
+ * Next.js extends native `fetch` with revalidation options.
+ *
+ * This module provides some reusable utility functions to set revalidation
+ * options for `fetch`, for example when it needs to be passed to a
+ * third-party API.
+ */
+
+import { ONE_DAY_IN_SECONDS } from './helpers.time'
+
+function fetchWithNextOptions(options: NextFetchRequestConfig) {
+  return (info: RequestInfo) => fetch(info, { next: options })
+}
+
+const fetchRevalidatePerDay = fetchWithNextOptions({ revalidate: ONE_DAY_IN_SECONDS })
+
+export { fetchWithNextOptions, fetchRevalidatePerDay }

--- a/apps/docs/features/helpers.time.ts
+++ b/apps/docs/features/helpers.time.ts
@@ -1,0 +1,3 @@
+const ONE_DAY_IN_SECONDS = 60 * 60 * 24
+
+export { ONE_DAY_IN_SECONDS }


### PR DESCRIPTION
The Vercel Data Cache caches data across deployments, and we want to check for updates in federated content, so let's revalidate the data once a day.

It may be more efficient to revalidate on-demand, since we don't change most of these sources once a day, but that requires setting up an API endpoint (and figuring out how to authenticate it), so this is quick-and-easy for now.