### PR TITLE
chore: suggest sso at invite members

### DIFF
--- a/apps/studio/components/interfaces/Organization/TeamSettings/InviteMemberButton.tsx
+++ b/apps/studio/components/interfaces/Organization/TeamSettings/InviteMemberButton.tsx
@@ -20,6 +20,7 @@ import {
   Button,
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogSection,
   DialogSectionSeparator,
@@ -337,6 +338,17 @@ export const InviteMemberButton = () => {
                   </FormItem_Shadcn_>
                 )}
               />
+              <DialogDescription>
+                <a
+                  target="_blank"
+                  rel="noreferrer"
+                  className="underline hover:text-foreground transition"
+                  href="https://supabase.com/docs/guides/platform/sso"
+                >
+                  Enable SSO
+                </a>{' '}
+                for your organization to provide additional account security.
+              </DialogDescription>
             </DialogSection>
             <DialogSectionSeparator />
             <DialogSection className="pt-0">

--- a/apps/studio/components/interfaces/Organization/TeamSettings/InviteMemberButton.tsx
+++ b/apps/studio/components/interfaces/Organization/TeamSettings/InviteMemberButton.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import toast from 'react-hot-toast'
 import * as z from 'zod'
+import Link from 'next/link'
 
 import { useParams } from 'common'
 import { useOrganizationCreateInvitationMutation } from 'data/organization-members/organization-invitation-create-mutation'
@@ -20,7 +21,6 @@ import {
   Button,
   Dialog,
   DialogContent,
-  DialogDescription,
   DialogHeader,
   DialogSection,
   DialogSectionSeparator,
@@ -45,6 +45,7 @@ import {
   Tooltip_Shadcn_,
 } from 'ui'
 import { useGetRolesManagementPermissions } from './TeamSettings.utils'
+import InformationBox from 'components/ui/InformationBox'
 
 export const InviteMemberButton = () => {
   const { slug } = useParams()
@@ -338,17 +339,32 @@ export const InviteMemberButton = () => {
                   </FormItem_Shadcn_>
                 )}
               />
-              <DialogDescription>
-                <a
-                  target="_blank"
-                  rel="noreferrer"
-                  className="underline hover:text-foreground transition"
-                  href="https://supabase.com/docs/guides/platform/sso"
-                >
-                  Enable SSO
-                </a>{' '}
-                for your organization to provide additional account security.
-              </DialogDescription>
+              <InformationBox
+                defaultVisibility={false}
+                title="Single Sign-on (SSO) login option available"
+                hideCollapse={false}
+                description={
+                  <div className="space-y-4 mb-1">
+                    <p>
+                      Supabase offers single sign-on (SSO) as a login option to provide additional
+                      account security for your team. This allows company administrators to enforce
+                      the use of an identity provider when logging into Supabase.
+                    </p>
+                    <p>This is only available for organizations on teams plan or above.</p>
+                    <div className="flex items-center space-x-2">
+                      <Button asChild type="default">
+                        <Link
+                          href="https://supabase.com/docs/guides/platform/sso"
+                          target="_blank"
+                          rel="noreferrer"
+                        >
+                          How SSO works
+                        </Link>
+                      </Button>
+                    </div>
+                  </div>
+                }
+              />
             </DialogSection>
             <DialogSectionSeparator />
             <DialogSection className="pt-0">

--- a/apps/studio/components/interfaces/Organization/TeamSettings/InviteMemberButton.tsx
+++ b/apps/studio/components/interfaces/Organization/TeamSettings/InviteMemberButton.tsx
@@ -372,7 +372,7 @@ export const InviteMemberButton = () => {
                           target="_blank"
                           rel="noreferrer"
                         >
-                          How SSO works
+                          Learn more
                         </Link>
                       </Button>
                       {isSuccessSubscription &&


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Suggest to enable SSO when users are thinking of inviting members. 

## What is the current behavior?

## What is the new behavior?
<img width="563" alt="Screenshot 2024-07-08 at 6 56 36 PM" src="https://github.com/supabase/supabase/assets/26612111/c117e9ec-25a1-405c-ae8a-b7f40e8b0165">
<img width="567" alt="Screenshot 2024-07-08 at 6 56 42 PM" src="https://github.com/supabase/supabase/assets/26612111/3ca5e14e-3f3a-4e1b-b31f-45685cb74a19">


Link to enable SSO guide https://supabase.com/docs/guides/platform/sso in the dialog

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
