### PR TITLE
Fix broken links to the badges

### DIFF
--- a/i18n/README.sv.md
+++ b/i18n/README.sv.md
@@ -200,7 +200,7 @@ Vårt tillvägagångssätt för klientbibliotek är modulärt. Varje delbibliote
 
 ## Märken
 
-![Made with Supabase](./apps/www/public/badge-made-with-supabase.svg)
+![Made with Supabase](../apps/www/public/badge-made-with-supabase.svg)
 
 ```md
 [![Made with Supabase](https://supabase.com/badge-made-with-supabase.svg)](https://supabase.com)
@@ -217,7 +217,7 @@ Vårt tillvägagångssätt för klientbibliotek är modulärt. Varje delbibliote
 </a>
 ```
 
-![Made with Supabase (dark)](./apps/www/public/badge-made-with-supabase-dark.svg)
+![Made with Supabase (dark)](../apps/www/public/badge-made-with-supabase-dark.svg)
 
 ```md
 [![Made with Supabase](https://supabase.com/badge-made-with-supabase-dark.svg)](https://supabase.com)


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Fix broken relative image links for Made with Supabase-badges

## What is the current behavior?

The links don't work

## What is the new behavior?

The links work and the badges are showing

## Additional context

None