### PR TITLE
Modify safeupdate usage to fit with extension changes

### DIFF
--- a/apps/docs/content/guides/database/extensions/pg-safeupdate.mdx
+++ b/apps/docs/content/guides/database/extensions/pg-safeupdate.mdx
@@ -11,9 +11,9 @@ The `pg-safeupdate` extension is a useful tool for protecting data integrity and
 ## Enable the extension
 
 <Admonition type="warning" className="mt-3">
-  Your project's Postgres version needs to be 15.1.1.73+ to use this extension. You can check and
-  upgrade your project in the
-  [Settings](https://supabase.com/dashboard/project/_/settings/infrastructure)
+
+Your project's Postgres version needs to be 15.1.1.73+ to use this extension. You can check and upgrade your project in the [Settings](https://supabase.com/dashboard/project/_/settings/infrastructure)
+
 </Admonition>
 
 `pg-safeupdate` can be enabled on a role basis (where `anon` is the role we want to modify in this example):

--- a/apps/docs/content/guides/database/extensions/pg-safeupdate.mdx
+++ b/apps/docs/content/guides/database/extensions/pg-safeupdate.mdx
@@ -10,19 +10,17 @@ The `pg-safeupdate` extension is a useful tool for protecting data integrity and
 
 ## Enable the extension
 
+<Admonition type="warning" className="mt-3">
+  Your project's Postgres version needs to be 15.1.1.73+ to use this extension. You can check and
+  upgrade your project in the
+  [Settings](https://supabase.com/dashboard/project/_/settings/infrastructure)
+</Admonition>
+
 `pg-safeupdate` can be enabled on a role basis (where `anon` is the role we want to modify in this example):
 
 {/* prettier-ignore */}
 ```sql
-GRANT SET ON PARAMETER session_preload_libraries TO anon;
-ALTER ROLE anon SET session_preload_libraries = 'safeupdate';
-```
-
-or for all connections:
-
-{/* prettier-ignore */}
-```sql
-alter database some_db set session_preload_libraries = 'safeupdate';
+ALTER ROLE anon SET safeupdate.enabled = on;
 ```
 
 ## Usage


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

Current behaviour is inconsistent across project versions and can result in permissions errors

## What is the new behavior?

New behaviour loads `safeupdate` by default into `shared_preload_libraries` (for all versions after 15.1.173) and can then be enabled on a per-role basis.

Closes supabase/postgres#1308 

