### PR TITLE
chore(docs): add example for fetching custom schema in Swift

### DIFF
--- a/apps/docs/spec/supabase_swift_v2.yml
+++ b/apps/docs/spec/supabase_swift_v2.yml
@@ -49,6 +49,26 @@ functions:
             )
           )
           ```
+      - id: api-schemas
+        name: With custom schemas
+        code: |
+          ```swift
+          let supabase = SupabaseClient(
+            supabaseURL: URL(string: "https://xyzcompany.supabase.co")!,
+            supabaseKey: "public-anon-key",
+            options: SupabaseClientOptions(
+              db: .init(
+                // Provide a custom schema. Defaults to "public".
+                schema: "other_schema"
+              )
+            )
+          ) 
+          ```
+        description: |
+          By default the API server points to the `public` schema. You can enable other database schemas within the Dashboard.
+          Go to [Settings > API > Exposed schemas](/dashboard/project/_/settings/api) and add the schema which you want to expose to the API.
+
+          Note: each client connection can only access a single schema, so the code above can access the `other_schema` schema but cannot access the `public` schema.
   - id: auth-api
     title: "Overview"
     notes: |
@@ -1756,6 +1776,40 @@ functions:
         description: |
           If you don't want to return the foreign table contents, you can leave the parenthesis empty.
           Like `.select('name, countries!inner()')`.
+        hideCodeBlock: true
+      - id: switching-schemas-per-query
+        name: Switching schemas per query
+        code: |
+          ```swift
+          try await supabase
+            .schema("myschema")
+            .from("mytable")
+            .select()
+          ```
+        data:
+          sql: |
+            ```sql
+            create schema myschema;
+
+            create table myschema.mytable (
+              id uuid primary key default gen_random_uuid(),
+              data text
+            );
+
+            insert into myschema.mytable (data) values ('mydata');
+            ```
+        response: |
+          ```json
+          [
+            {
+              "id": "4162e008-27b0-4c0f-82dc-ccaeee9a624d",
+              "data": "mydata"
+            }
+          ]
+          ```
+        description: |
+          In addition to setting the schema during initialization, you can also switch schemas on a per-query basis.
+          Make sure you've set up your [database privileges and API settings](/docs/guides/api/using-custom-schemas).
         hideCodeBlock: true
 
   - id: insert

--- a/package-lock.json
+++ b/package-lock.json
@@ -13212,9 +13212,9 @@
       }
     },
     "node_modules/@storybook/csf": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@storybook/csf/-/csf-0.1.8.tgz",
-      "integrity": "sha512-Ntab9o7LjBCbFIao5l42itFiaSh/Qu+l16l/r/9qmV9LnYZkO+JQ7tzhdlwpgJfhs+B5xeejpdAtftDRyXNajw==",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@storybook/csf/-/csf-0.1.11.tgz",
+      "integrity": "sha512-dHYFQH3mA+EtnCkHXzicbLgsvzYjcDJ1JWsogbItZogkPHgSJM/Wr71uMkcvw8v9mmCyP4NpXJuu6bPoVsOnzg==",
       "dev": true,
       "dependencies": {
         "type-fest": "^2.19.0"
@@ -14525,9 +14525,10 @@
       }
     },
     "node_modules/@types/express": {
-      "version": "4.17.18",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
+      "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.33",
@@ -26926,9 +26927,10 @@
       }
     },
     "node_modules/markdown-to-jsx": {
-      "version": "7.3.2",
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.4.7.tgz",
+      "integrity": "sha512-0+ls1IQZdU6cwM1yu0ZjjiVWYtkbExSyUIFU2ZeDIFuZM1W42Mh4OlJ4nb4apX4H8smxDHRdFaoIVJGwfv5hkg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 10"
       },
@@ -41014,12 +41016,6 @@
         "webpack-virtual-modules": "^0.6.1"
       }
     },
-    "node_modules/unplugin/node_modules/webpack-virtual-modules": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.1.tgz",
-      "integrity": "sha512-poXpCylU7ExuvZK8z+On3kX+S8o/2dQ/SVYueKA0D4WEMXROXgY8Ez50/bQEUmvoSMMrWcrJqCHuhAbsiwg7Dg==",
-      "dev": true
-    },
     "node_modules/untildify": {
       "version": "4.0.0",
       "dev": true,
@@ -42496,6 +42492,12 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/webpack-virtual-modules": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
+      "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
+      "dev": true
     },
     "node_modules/webpack/node_modules/eslint-scope": {
       "version": "5.1.1",


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES/NO

## What kind of change does this PR introduce?

Add missing example for fetching data from custom schema in Swift.