### PR TITLE
Update phone-login.mdx

### DIFF
--- a/apps/docs/content/guides/auth/phone-login.mdx
+++ b/apps/docs/content/guides/auth/phone-login.mdx
@@ -101,7 +101,7 @@ const {
   data: { session },
   error,
 } = await supabase.auth.verifyOtp({
-  phone: '+13334445555',
+  phone: '13334445555',
   token: '123456',
   type: 'sms',
 })


### PR DESCRIPTION
to verifyOTP, phone no. should not contains '+' sign.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

current verifyOTP example gives error if used as it is.

## What is the new behavior?

new changes solves the issue.

