### PR TITLE
Update supabase/ssr Pages router snippets

### DIFF
--- a/apps/docs/content/guides/auth/server-side/nextjs.mdx
+++ b/apps/docs/content/guides/auth/server-side/nextjs.mdx
@@ -627,7 +627,7 @@ export function createClient({ req, res }: GetServerSidePropsContext) {
     {
       cookies: {
         getAll() {
-          return Object.keys(req.cookies).map((name) => ({ name, value: req.cookies[name] }))
+          return Object.keys(req.cookies).map((name) => ({ name, value: req.cookies[name] || '' }))
         },
         setAll(cookiesToSet) {
           res.setHeader(
@@ -682,7 +682,7 @@ export default function createClient(req: NextApiRequest, res: NextApiResponse) 
     {
       cookies: {
         getAll() {
-          return Object.keys(req.cookies).map((name) => ({ name, value: req.cookies[name] }))
+          return Object.keys(req.cookies).map((name) => ({ name, value: req.cookies[name] || '' }))
         },
         setAll(cookiesToSet) {
           res.setHeader(


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Doc update

## What is the current behavior?

`return Object.keys(req.cookies).map((name) => ({ name, value: req.cookies[name] }))`

Typescript complains about this being potentially `undefined`

## What is the new behavior?

`return Object.keys(req.cookies).map((name) => ({ name, value: req.cookies[name] || '' }))`

Safely returns an empty string if undefined.

Fixes [#22](https://github.com/supabase/ssr/issues/22)
