### PR TITLE
update Metrics doc page to include a prometheus configuration example

### DIFF
--- a/apps/docs/content/guides/platform/metrics.mdx
+++ b/apps/docs/content/guides/platform/metrics.mdx
@@ -28,4 +28,22 @@ Your project's metrics endpoint is accessible at `https://<project-ref>.supabase
 > curl https://<project-ref>.supabase.co/customer/v1/privileged/metrics --user 'service_role:<service-role-jwt>'
 ```
 
+## Configuring Prometheus
+For self-hosted prometheus, modify your `prometheus.yaml` file to add a Supabase job, and set the `metrics_path`, `scheme`, `basic_auth` and `targets` parameters. For example:
+```yaml
+scrape_configs:
+  - job_name: "MyJob"
+    metrics_path: "/customer/v1/privileged/metrics"
+    scheme: https
+    basic_auth:
+      username: "service_role"
+      password: "<your service_role JWT>"
+    static_configs:
+      - targets: [
+        "<your Supabase Project ID>.supabase.co:443"
+          ]
+        labels:
+          group: "MyGroupLabel"
+```
+
 Additionally, we [maintain a guide](https://github.com/supabase/supabase-grafana) on quickly setting up a scraping agent to work with Grafana Cloud.

--- a/apps/docs/content/guides/platform/metrics.mdx
+++ b/apps/docs/content/guides/platform/metrics.mdx
@@ -29,7 +29,9 @@ Your project's metrics endpoint is accessible at `https://<project-ref>.supabase
 ```
 
 ## Configuring Prometheus
+
 For self-hosted prometheus, modify your `prometheus.yaml` file to add a Supabase job, and set the `metrics_path`, `scheme`, `basic_auth` and `targets` parameters. For example:
+
 ```yaml
 scrape_configs:
   - job_name: "MyJob"


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

This is a docs update. It adds an example for configuring self-hosted Prometheus instances to scrape the metrics endpoint. 

## What is the current behavior?

Currently the docs include a link to an example for configuring Grafana Cloud

## What is the new behavior?

This extends the documentation to demonstrate how self-hosted Prometheus instances can be configured 

## Additional context

n/a
