### PR TITLE
feat: docs breadcrumbs

### DIFF
--- a/apps/docs/app/guides/layout.tsx
+++ b/apps/docs/app/guides/layout.tsx
@@ -12,7 +12,7 @@ const GuidesLayout = ({ children }: PropsWithChildren) => {
   return <Layout menuId={menuId}>{children}</Layout>
 }
 
-const getMenuId = (pathname: string | null) => {
+export const getMenuId = (pathname: string | null) => {
   pathname = (pathname ??= '').replace(/^\/guides\//, '')
 
   switch (true) {

--- a/apps/docs/components/Breadcrumbs.tsx
+++ b/apps/docs/components/Breadcrumbs.tsx
@@ -42,7 +42,7 @@ const Breadcrumbs = ({ className }: { className?: string }) => {
   const appendedBreadcrumbs = breadcrumbs?.slice(-ITEMS_TO_DISPLAY + 1, isMobile ? -1 : undefined)
 
   return (
-    <Breadcrumb className={className}>
+    <Breadcrumb className={cn(className)}>
       <BreadcrumbList className="text-foreground-lighter p-0">
         {breadcrumbs.length >= ITEMS_TO_DISPLAY && (
           <>

--- a/apps/docs/components/Breadcrumbs.tsx
+++ b/apps/docs/components/Breadcrumbs.tsx
@@ -107,7 +107,7 @@ const Breadcrumbs = ({ className }: { className?: string }) => {
         {breadcrumbs?.slice(-ITEMS_TO_DISPLAY + 1).map((crumb, i) => (
           <Fragment key={crumb.url}>
             {i !== 0 && <BreadcrumbSeparator />}
-            <BreadcrumbItem className="flex items-center overflow-hidden">
+            <BreadcrumbItem className="flex items-center overflow-hidden last:text-foreground">
               {crumb.url ? (
                 <BreadcrumbLink href={`/docs${crumb.url}`}>
                   {crumb.title || crumb.name}

--- a/apps/docs/components/Breadcrumbs.tsx
+++ b/apps/docs/components/Breadcrumbs.tsx
@@ -38,20 +38,24 @@ const Breadcrumbs = ({ className }: { className?: string }) => {
   const ITEMS_TO_DISPLAY = 3
 
   if (!breadcrumbs?.length || breadcrumbs?.length === 1) return null
-
+  console.log(breadcrumbs?.length, breadcrumbs.length <= ITEMS_TO_DISPLAY)
   return (
     <Breadcrumb className={className}>
       <BreadcrumbList className="text-foreground-lighter p-0">
-        <BreadcrumbItem>
-          {breadcrumbs[0].url ? (
-            <BreadcrumbLink href={`/docs${breadcrumbs[0].url}`}>
-              {breadcrumbs[0].title || breadcrumbs[0].name}
-            </BreadcrumbLink>
-          ) : (
-            <BreadcrumbPage>{breadcrumbs[0].title || breadcrumbs[0].name}</BreadcrumbPage>
-          )}
-        </BreadcrumbItem>
-        <BreadcrumbSeparator />
+        {breadcrumbs.length >= ITEMS_TO_DISPLAY && (
+          <>
+            <BreadcrumbItem>
+              {breadcrumbs[0].url ? (
+                <BreadcrumbLink href={`/docs${breadcrumbs[0].url}`}>
+                  {breadcrumbs[0].title || breadcrumbs[0].name}
+                </BreadcrumbLink>
+              ) : (
+                <BreadcrumbPage>{breadcrumbs[0].title || breadcrumbs[0].name}</BreadcrumbPage>
+              )}
+            </BreadcrumbItem>
+            <BreadcrumbSeparator />
+          </>
+        )}
         {breadcrumbs.length > ITEMS_TO_DISPLAY && (
           <>
             <BreadcrumbItem>
@@ -107,7 +111,7 @@ const Breadcrumbs = ({ className }: { className?: string }) => {
         {breadcrumbs?.slice(-ITEMS_TO_DISPLAY + 1).map((crumb, i) => (
           <Fragment key={crumb.url}>
             {i !== 0 && <BreadcrumbSeparator />}
-            <BreadcrumbItem className="flex items-center overflow-hidden last:text-foreground">
+            <BreadcrumbItem className="flex items-center overflow-hidden">
               {crumb.url ? (
                 <BreadcrumbLink href={`/docs${crumb.url}`}>
                   {crumb.title || crumb.name}

--- a/apps/docs/components/Breadcrumbs.tsx
+++ b/apps/docs/components/Breadcrumbs.tsx
@@ -35,9 +35,11 @@ const Breadcrumbs = ({ className }: { className?: string }) => {
   const [open, setOpen] = React.useState(false)
   const isMobile = useBreakpoint('md')
 
-  const ITEMS_TO_DISPLAY = 3
+  const ITEMS_TO_DISPLAY = isMobile ? 4 : 3
 
   if (!breadcrumbs?.length || breadcrumbs?.length === 1) return null
+
+  const appendedBreadcrumbs = breadcrumbs?.slice(-ITEMS_TO_DISPLAY + 1, isMobile ? -1 : undefined)
 
   return (
     <Breadcrumb className={className}>
@@ -108,10 +110,14 @@ const Breadcrumbs = ({ className }: { className?: string }) => {
             <BreadcrumbSeparator />
           </>
         )}
-        {breadcrumbs?.slice(-ITEMS_TO_DISPLAY + 1).map((crumb, i) => (
+        {appendedBreadcrumbs?.map((crumb, i) => (
           <Fragment key={crumb.url}>
-            {i !== 0 && <BreadcrumbSeparator />}
-            <BreadcrumbItem className="flex items-center overflow-hidden last:text-foreground-light">
+            <BreadcrumbItem
+              className={cn(
+                'flex items-center overflow-hidden',
+                i === appendedBreadcrumbs.length - 1 && 'md:text-foreground-light'
+              )}
+            >
               {crumb.url ? (
                 <BreadcrumbLink href={`/docs${crumb.url}`}>
                   {crumb.title || crumb.name}
@@ -120,6 +126,9 @@ const Breadcrumbs = ({ className }: { className?: string }) => {
                 <BreadcrumbPage>{crumb.title || crumb.name}</BreadcrumbPage>
               )}
             </BreadcrumbItem>
+            <BreadcrumbSeparator
+              className={cn(i === appendedBreadcrumbs.length - 1 && 'md:hidden')}
+            />
           </Fragment>
         ))}
       </BreadcrumbList>

--- a/apps/docs/components/Breadcrumbs.tsx
+++ b/apps/docs/components/Breadcrumbs.tsx
@@ -38,7 +38,7 @@ const Breadcrumbs = ({ className }: { className?: string }) => {
   const ITEMS_TO_DISPLAY = 3
 
   if (!breadcrumbs?.length || breadcrumbs?.length === 1) return null
-  console.log(breadcrumbs?.length, breadcrumbs.length <= ITEMS_TO_DISPLAY)
+
   return (
     <Breadcrumb className={className}>
       <BreadcrumbList className="text-foreground-lighter p-0">
@@ -128,19 +128,20 @@ const Breadcrumbs = ({ className }: { className?: string }) => {
 }
 
 function findMenuItemByUrl(menu, targetUrl, parents = []) {
-  // Check if the current menu object itself has the target URL
-  if (menu.url === targetUrl) {
-    return [...parents, menu]
-  }
-
   // If the menu has items, recursively search through them
   if (menu.items) {
     for (let item of menu.items) {
+      console.log('items', item)
       const result = findMenuItemByUrl(item, targetUrl, [...parents, menu])
       if (result) {
         return result
       }
     }
+  }
+
+  // Check if the current menu object itself has the target URL
+  if (menu.url === targetUrl) {
+    return [...parents, menu]
   }
 
   // If the URL is not found, return null

--- a/apps/docs/components/Breadcrumbs.tsx
+++ b/apps/docs/components/Breadcrumbs.tsx
@@ -131,7 +131,6 @@ function findMenuItemByUrl(menu, targetUrl, parents = []) {
   // If the menu has items, recursively search through them
   if (menu.items) {
     for (let item of menu.items) {
-      console.log('items', item)
       const result = findMenuItemByUrl(item, targetUrl, [...parents, menu])
       if (result) {
         return result

--- a/apps/docs/components/Breadcrumbs.tsx
+++ b/apps/docs/components/Breadcrumbs.tsx
@@ -111,7 +111,7 @@ const Breadcrumbs = ({ className }: { className?: string }) => {
         {breadcrumbs?.slice(-ITEMS_TO_DISPLAY + 1).map((crumb, i) => (
           <Fragment key={crumb.url}>
             {i !== 0 && <BreadcrumbSeparator />}
-            <BreadcrumbItem className="flex items-center overflow-hidden">
+            <BreadcrumbItem className="flex items-center overflow-hidden last:text-foreground-light">
               {crumb.url ? (
                 <BreadcrumbLink href={`/docs${crumb.url}`}>
                   {crumb.title || crumb.name}

--- a/apps/docs/components/Breadcrumbs.tsx
+++ b/apps/docs/components/Breadcrumbs.tsx
@@ -1,0 +1,76 @@
+'use client'
+
+import { usePathname } from 'next/navigation'
+import React, { Fragment } from 'react'
+import {
+  Breadcrumb_Shadcn_ as Breadcrumb,
+  BreadcrumbList_Shadcn_ as BreadcrumbList,
+  BreadcrumbItem_Shadcn_ as BreadcrumbItem,
+  BreadcrumbLink_Shadcn_ as BreadcrumbLink,
+  BreadcrumbSeparator_Shadcn_ as BreadcrumbSeparator,
+  BreadcrumbPage_Shadcn_ as BreadcrumbPage,
+  BreadcrumbEllipsis_Shadcn_ as BreadcrumbEllipsis,
+} from 'ui'
+import { getMenuId } from '../app/guides/layout'
+import * as NavItems from './Navigation/NavigationMenu/NavigationMenu.constants'
+
+const Breadcrumbs = ({ className }: { className?: string }) => {
+  const pathname = usePathname()
+  const menuId = getMenuId(pathname)
+  const menu = NavItems[menuId]
+  const breadcrumbs = findParentsByUrl(menu, pathname, [], { removeChild: false })
+
+  if (!breadcrumbs?.length || breadcrumbs?.length === 1) return null
+
+  return (
+    <Breadcrumb className={className}>
+      <BreadcrumbList className="m-0 mb-2 text-foreground-lighter p-0 [&>li]:before:hidden [&>li]:p-0">
+        {/* <BreadcrumbItem>
+          <BreadcrumbLink href="/docs">Docs</BreadcrumbLink>
+        </BreadcrumbItem> */}
+        {breadcrumbs?.map((crumb, i) => (
+          <Fragment key={crumb.url}>
+            {i !== 0 && <BreadcrumbSeparator />}
+            <BreadcrumbItem>
+              {crumb.url ? (
+                <BreadcrumbLink href={`/docs${crumb.url}`}>
+                  {crumb.title || crumb.name}
+                </BreadcrumbLink>
+              ) : (
+                <BreadcrumbPage>{crumb.title || crumb.name}</BreadcrumbPage>
+              )}
+            </BreadcrumbItem>
+          </Fragment>
+        ))}
+        {/* <BreadcrumbItem>
+          <BreadcrumbEllipsis />
+        </BreadcrumbItem> */}
+      </BreadcrumbList>
+    </Breadcrumb>
+  )
+}
+interface Options {
+  removeChild?: boolean
+}
+
+function findParentsByUrl(menu, targetUrl, parents = [], options?: Options) {
+  // Check if the current menu object itself has the target URL
+  if (menu.url === targetUrl) {
+    return options?.removeChild ? parents : [...parents, menu]
+  }
+
+  // If the menu has items, recursively search through them
+  if (menu.items) {
+    for (let item of menu.items) {
+      const result = findParentsByUrl(item, targetUrl, [...parents, menu])
+      if (result) {
+        return result
+      }
+    }
+  }
+
+  // If the URL is not found, return null
+  return null
+}
+
+export default Breadcrumbs

--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
@@ -245,6 +245,7 @@ export const REFERENCES: References = {
 export const gettingstarted: NavMenuConstant = {
   icon: 'getting-started',
   title: 'Start with Supabase',
+  url: '/guides/getting-started',
   items: [
     { name: 'Features', url: '/guides/getting-started/features' },
     { name: 'Architecture', url: '/guides/getting-started/architecture' },

--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
@@ -1198,7 +1198,7 @@ export const functions: NavMenuConstant = {
     },
     {
       name: 'Examples',
-      url: '/guides/functions/examples',
+      url: undefined,
       items: [
         {
           name: 'CORS support for invoking from the browser',

--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.tsx
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.tsx
@@ -234,7 +234,7 @@ const menus: Menu[] = [
   },
 ]
 
-function getMenuById(id: MenuId) {
+export function getMenuById(id: MenuId) {
   return menus.find((menu) => menu.id === id)
 }
 

--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenuGuideList.tsx
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenuGuideList.tsx
@@ -3,7 +3,6 @@
 import * as Accordion from '@radix-ui/react-accordion'
 
 import * as NavItems from './NavigationMenu.constants'
-import { getPathWithoutHash } from './NavigationMenu.utils'
 import NavigationMenuGuideListItems from './NavigationMenuGuideListItems'
 import { usePathname } from 'next/navigation'
 

--- a/apps/docs/features/docs/GuidesMdx.template.tsx
+++ b/apps/docs/features/docs/GuidesMdx.template.tsx
@@ -121,12 +121,12 @@ const GuideTemplate = ({ meta, content, children, editLink, mdxOptions }: GuideT
           hideToc ? 'col-span-12' : 'col-span-12 md:col-span-9'
         )}
       >
+        <Breadcrumbs className="mb-3 w-full" />
         <article
           // Used to get headings for the table of contents
           id="sb-docs-guide-main-article"
           className="prose max-w-none"
         >
-          <Breadcrumbs className="-mt-1" />
           <h1 className="mb-0">{meta?.title || 'Supabase Docs'}</h1>
           {meta?.subtitle && (
             <h2 className="mt-3 text-xl text-foreground-light">{meta.subtitle}</h2>

--- a/apps/docs/features/docs/GuidesMdx.template.tsx
+++ b/apps/docs/features/docs/GuidesMdx.template.tsx
@@ -13,6 +13,7 @@ import { components } from '~/features/docs/mdx.shared'
 import type { WithRequired } from '~/features/helpers.types'
 import { type GuideFrontmatter } from '~/lib/docs'
 import { MDXProviderGuides } from './GuidesMdx.client'
+import Breadcrumbs from '~/components/Breadcrumbs'
 
 const codeHikeOptions: CodeHikeConfig = {
   theme: codeHikeTheme,
@@ -125,6 +126,7 @@ const GuideTemplate = ({ meta, content, children, editLink, mdxOptions }: GuideT
           id="sb-docs-guide-main-article"
           className="prose max-w-none"
         >
+          <Breadcrumbs className="-mt-1" />
           <h1 className="mb-0">{meta?.title || 'Supabase Docs'}</h1>
           {meta?.subtitle && (
             <h2 className="mt-3 text-xl text-foreground-light">{meta.subtitle}</h2>
@@ -163,11 +165,11 @@ const GuideTemplate = ({ meta, content, children, editLink, mdxOptions }: GuideT
             /**
              * --header-height: height of nav
              * 1px: height of nav border
-             * 4rem: content padding
+             * 2rem: content padding
              */
-            'top-[calc(var(--header-height)+1px+4rem)]',
+            'top-[calc(var(--header-height)+1px+2rem)]',
             // 5rem accounts for 4rem of top padding + 1rem of extra breathing room
-            'max-h-[calc(100vh-var(--header-height)-5rem)]'
+            'max-h-[calc(100vh-var(--header-height)-3rem)]'
           )}
         />
       )}

--- a/apps/docs/features/docs/GuidesMdx.template.tsx
+++ b/apps/docs/features/docs/GuidesMdx.template.tsx
@@ -168,7 +168,7 @@ const GuideTemplate = ({ meta, content, children, editLink, mdxOptions }: GuideT
              * 2rem: content padding
              */
             'top-[calc(var(--header-height)+1px+2rem)]',
-            // 5rem accounts for 4rem of top padding + 1rem of extra breathing room
+            // 3rem accounts for 2rem of top padding + 1rem of extra breathing room
             'max-h-[calc(100vh-var(--header-height)-3rem)]'
           )}
         />

--- a/apps/docs/features/docs/GuidesMdx.template.tsx
+++ b/apps/docs/features/docs/GuidesMdx.template.tsx
@@ -121,7 +121,7 @@ const GuideTemplate = ({ meta, content, children, editLink, mdxOptions }: GuideT
           hideToc ? 'col-span-12' : 'col-span-12 md:col-span-9'
         )}
       >
-        <Breadcrumbs className="mb-3 w-full" />
+        <Breadcrumbs className="mb-2" />
         <article
           // Used to get headings for the table of contents
           id="sb-docs-guide-main-article"

--- a/apps/docs/layouts/DefaultLayout.tsx
+++ b/apps/docs/layouts/DefaultLayout.tsx
@@ -3,4 +3,4 @@ import { type FC, type PropsWithChildren } from 'react'
 export const LayoutMainContent: FC<PropsWithChildren<{ className?: string }>> = ({
   className,
   children,
-}) => <div className={['max-w-7xl px-5 mx-auto py-16', className].join(' ')}>{children}</div>
+}) => <div className={['max-w-7xl px-5 mx-auto py-8', className].join(' ')}>{children}</div>

--- a/apps/docs/layouts/ref/RefSubLayout.tsx
+++ b/apps/docs/layouts/ref/RefSubLayout.tsx
@@ -122,7 +122,7 @@ const StickyHeader: FC<StickyHeader> = ({ icon, ...props }) => {
           id={props.slug}
           data-ref-id={props.id}
           className={cn(
-            'text-2xl font-medium text-foreground scroll-mt-[calc(33px+2rem)] lg:scroll-mt-[calc(var(--header-height)+1px+4rem)]',
+            'text-2xl font-medium text-foreground scroll-mt-[calc(32px+2rem)] lg:scroll-mt-[calc(var(--header-height)+1px+4rem)]',
             !icon && 'mb-8',
             props.monoFont && 'font-mono'
           )}

--- a/packages/ui/index.tsx
+++ b/packages/ui/index.tsx
@@ -190,6 +190,16 @@ export { Input as Input_Shadcn_ } from './src/components/shadcn/ui/input'
 
 export { Button as Button_Shadcn_ } from './src/components/shadcn/ui/button'
 
+export {
+  Breadcrumb as Breadcrumb_Shadcn_,
+  BreadcrumbItem as BreadcrumbItem_Shadcn_,
+  BreadcrumbLink as BreadcrumbLink_Shadcn_,
+  BreadcrumbList as BreadcrumbList_Shadcn_,
+  BreadcrumbEllipsis as BreadcrumbEllipsis_Shadcn_,
+  BreadcrumbPage as BreadcrumbPage_Shadcn_,
+  BreadcrumbSeparator as BreadcrumbSeparator_Shadcn_,
+} from './src/components/shadcn/ui/breadcrumb'
+
 export { TextArea as TextArea_Shadcn_ } from './src/components/shadcn/ui/text-area'
 
 export { Label as Label_Shadcn_ } from './src/components/shadcn/ui/label'

--- a/packages/ui/src/components/shadcn/ui/breadcrumb.tsx
+++ b/packages/ui/src/components/shadcn/ui/breadcrumb.tsx
@@ -16,7 +16,7 @@ const BreadcrumbList = React.forwardRef<HTMLOListElement, React.ComponentPropsWi
     <ol
       ref={ref}
       className={cn(
-        'flex flex-wrap items-center gap-1.5 break-words text-sm text-muted-foreground sm:gap-1.5',
+        'flex flex-wrap items-center gap-0.5 break-words text-sm text-muted-foreground sm:gap-1.5',
         className
       )}
       {...props}

--- a/packages/ui/src/components/shadcn/ui/breadcrumb.tsx
+++ b/packages/ui/src/components/shadcn/ui/breadcrumb.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { ChevronRightIcon, Dot } from 'lucide-react'
+import { ChevronRightIcon } from 'lucide-react'
 import { Slot } from '@radix-ui/react-slot'
 import { cn } from '../../../lib/utils'
 
@@ -50,7 +50,7 @@ const BreadcrumbLink = React.forwardRef<
   return (
     <Comp
       ref={ref}
-      className={cn('transition-colors no-underline hover:text-foreground', className)}
+      className={cn('transition-colors underline lg:no-underline hover:text-foreground', className)}
       {...props}
     />
   )
@@ -84,12 +84,7 @@ const BreadcrumbSeparator = ({ children, className, ...props }: React.ComponentP
 BreadcrumbSeparator.displayName = 'BreadcrumbSeparator'
 
 const BreadcrumbEllipsis = ({ className, ...props }: React.ComponentProps<'span'>) => (
-  <span
-    role="presentation"
-    aria-hidden="true"
-    className={cn('flex h-4 w-4 items-center justify-center', className)}
-    {...props}
-  >
+  <span className={cn('flex h-4 w-4 items-center justify-center', className)} {...props}>
     <svg width="15" height="15" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
       <path
         d="M3.625 7.5C3.625 8.12132 3.12132 8.625 2.5 8.625C1.87868 8.625 1.375 8.12132 1.375 7.5C1.375 6.87868 1.87868 6.375 2.5 6.375C3.12132 6.375 3.625 6.87868 3.625 7.5ZM8.625 7.5C8.625 8.12132 8.12132 8.625 7.5 8.625C6.87868 8.625 6.375 8.12132 6.375 7.5C6.375 6.87868 6.87868 6.375 7.5 6.375C8.12132 6.375 8.625 6.87868 8.625 7.5ZM12.5 8.625C13.1213 8.625 13.625 8.12132 13.625 7.5C13.625 6.87868 13.1213 6.375 12.5 6.375C11.8787 6.375 11.375 6.87868 11.375 7.5C11.375 8.12132 11.8787 8.625 12.5 8.625Z"
@@ -101,7 +96,7 @@ const BreadcrumbEllipsis = ({ className, ...props }: React.ComponentProps<'span'
     <span className="sr-only">More</span>
   </span>
 )
-BreadcrumbEllipsis.displayName = 'BreadcrumbElipssis'
+BreadcrumbEllipsis.displayName = 'BreadcrumbEllipsis'
 
 export {
   Breadcrumb,

--- a/packages/ui/src/components/shadcn/ui/breadcrumb.tsx
+++ b/packages/ui/src/components/shadcn/ui/breadcrumb.tsx
@@ -29,7 +29,10 @@ const BreadcrumbItem = React.forwardRef<HTMLLIElement, React.ComponentPropsWitho
   ({ className, ...props }, ref) => (
     <li
       ref={ref}
-      className={cn('inline-flex items-center gap-1.5 leading-5', className)}
+      className={cn(
+        'inline-flex text-foreground-lighter items-center gap-1.5 leading-5',
+        className
+      )}
       {...props}
     />
   )
@@ -47,10 +50,7 @@ const BreadcrumbLink = React.forwardRef<
   return (
     <Comp
       ref={ref}
-      className={cn(
-        'transition-colors no-underline text-foreground-lighter hover:text-foreground',
-        className
-      )}
+      className={cn('transition-colors no-underline hover:text-foreground', className)}
       {...props}
     />
   )
@@ -64,7 +64,7 @@ const BreadcrumbPage = React.forwardRef<HTMLSpanElement, React.ComponentPropsWit
       role="link"
       aria-disabled="true"
       aria-current="page"
-      className={cn('no-underline text-foreground-lighter', className)}
+      className={cn('no-underline', className)}
       {...props}
     />
   )

--- a/packages/ui/src/components/shadcn/ui/breadcrumb.tsx
+++ b/packages/ui/src/components/shadcn/ui/breadcrumb.tsx
@@ -1,0 +1,110 @@
+import * as React from 'react'
+import { ChevronRightIcon, Dot } from 'lucide-react'
+import { Slot } from '@radix-ui/react-slot'
+import { cn } from '../../../lib/utils'
+
+const Breadcrumb = React.forwardRef<
+  HTMLElement,
+  React.ComponentPropsWithoutRef<'nav'> & {
+    separator?: React.ReactNode
+  }
+>(({ ...props }, ref) => <nav ref={ref} aria-label="breadcrumb" {...props} />)
+Breadcrumb.displayName = 'Breadcrumb'
+
+const BreadcrumbList = React.forwardRef<HTMLOListElement, React.ComponentPropsWithoutRef<'ol'>>(
+  ({ className, ...props }, ref) => (
+    <ol
+      ref={ref}
+      className={cn(
+        'flex flex-wrap items-center gap-1.5 break-words text-sm text-muted-foreground sm:gap-1.5',
+        className
+      )}
+      {...props}
+    />
+  )
+)
+BreadcrumbList.displayName = 'BreadcrumbList'
+
+const BreadcrumbItem = React.forwardRef<HTMLLIElement, React.ComponentPropsWithoutRef<'li'>>(
+  ({ className, ...props }, ref) => (
+    <li ref={ref} className={cn('inline-flex items-center gap-1.5', className)} {...props} />
+  )
+)
+BreadcrumbItem.displayName = 'BreadcrumbItem'
+
+const BreadcrumbLink = React.forwardRef<
+  HTMLAnchorElement,
+  React.ComponentPropsWithoutRef<'a'> & {
+    asChild?: boolean
+  }
+>(({ asChild, className, ...props }, ref) => {
+  const Comp = asChild ? Slot : 'a'
+
+  return (
+    <Comp
+      ref={ref}
+      className={cn(
+        'transition-colors no-underline text-foreground-lighter hover:text-foreground',
+        className
+      )}
+      {...props}
+    />
+  )
+})
+BreadcrumbLink.displayName = 'BreadcrumbLink'
+
+const BreadcrumbPage = React.forwardRef<HTMLSpanElement, React.ComponentPropsWithoutRef<'span'>>(
+  ({ className, ...props }, ref) => (
+    <span
+      ref={ref}
+      role="link"
+      aria-disabled="true"
+      aria-current="page"
+      className={cn('no-underline inline-flex h-[22px] text-foreground-lighter', className)}
+      {...props}
+    />
+  )
+)
+BreadcrumbPage.displayName = 'BreadcrumbPage'
+
+const BreadcrumbSeparator = ({ children, className, ...props }: React.ComponentProps<'li'>) => (
+  <li
+    role="presentation"
+    aria-hidden="true"
+    className={cn('[&>svg]:size-3.5', className)}
+    {...props}
+  >
+    {children ?? <ChevronRightIcon />}
+  </li>
+)
+BreadcrumbSeparator.displayName = 'BreadcrumbSeparator'
+
+const BreadcrumbEllipsis = ({ className, ...props }: React.ComponentProps<'span'>) => (
+  <span
+    role="presentation"
+    aria-hidden="true"
+    className={cn('flex h-4 w-4 items-center justify-center', className)}
+    {...props}
+  >
+    <svg width="15" height="15" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M3.625 7.5C3.625 8.12132 3.12132 8.625 2.5 8.625C1.87868 8.625 1.375 8.12132 1.375 7.5C1.375 6.87868 1.87868 6.375 2.5 6.375C3.12132 6.375 3.625 6.87868 3.625 7.5ZM8.625 7.5C8.625 8.12132 8.12132 8.625 7.5 8.625C6.87868 8.625 6.375 8.12132 6.375 7.5C6.375 6.87868 6.87868 6.375 7.5 6.375C8.12132 6.375 8.625 6.87868 8.625 7.5ZM12.5 8.625C13.1213 8.625 13.625 8.12132 13.625 7.5C13.625 6.87868 13.1213 6.375 12.5 6.375C11.8787 6.375 11.375 6.87868 11.375 7.5C11.375 8.12132 11.8787 8.625 12.5 8.625Z"
+        fill="currentColor"
+        fillRule="evenodd"
+        clipRule="evenodd"
+      ></path>
+    </svg>
+    <span className="sr-only">More</span>
+  </span>
+)
+BreadcrumbEllipsis.displayName = 'BreadcrumbElipssis'
+
+export {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+  BreadcrumbEllipsis,
+}

--- a/packages/ui/src/components/shadcn/ui/breadcrumb.tsx
+++ b/packages/ui/src/components/shadcn/ui/breadcrumb.tsx
@@ -85,13 +85,21 @@ BreadcrumbSeparator.displayName = 'BreadcrumbSeparator'
 
 const BreadcrumbEllipsis = ({ className, ...props }: React.ComponentProps<'span'>) => (
   <span className={cn('flex h-4 w-4 items-center justify-center', className)} {...props}>
-    <svg width="15" height="15" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <svg
+      role="presentation"
+      aria-hidden="true"
+      width="15"
+      height="15"
+      viewBox="0 0 15 15"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
       <path
         d="M3.625 7.5C3.625 8.12132 3.12132 8.625 2.5 8.625C1.87868 8.625 1.375 8.12132 1.375 7.5C1.375 6.87868 1.87868 6.375 2.5 6.375C3.12132 6.375 3.625 6.87868 3.625 7.5ZM8.625 7.5C8.625 8.12132 8.12132 8.625 7.5 8.625C6.87868 8.625 6.375 8.12132 6.375 7.5C6.375 6.87868 6.87868 6.375 7.5 6.375C8.12132 6.375 8.625 6.87868 8.625 7.5ZM12.5 8.625C13.1213 8.625 13.625 8.12132 13.625 7.5C13.625 6.87868 13.1213 6.375 12.5 6.375C11.8787 6.375 11.375 6.87868 11.375 7.5C11.375 8.12132 11.8787 8.625 12.5 8.625Z"
         fill="currentColor"
         fillRule="evenodd"
         clipRule="evenodd"
-      ></path>
+      />
     </svg>
     <span className="sr-only">More</span>
   </span>

--- a/packages/ui/src/components/shadcn/ui/breadcrumb.tsx
+++ b/packages/ui/src/components/shadcn/ui/breadcrumb.tsx
@@ -27,7 +27,11 @@ BreadcrumbList.displayName = 'BreadcrumbList'
 
 const BreadcrumbItem = React.forwardRef<HTMLLIElement, React.ComponentPropsWithoutRef<'li'>>(
   ({ className, ...props }, ref) => (
-    <li ref={ref} className={cn('inline-flex items-center gap-1.5', className)} {...props} />
+    <li
+      ref={ref}
+      className={cn('inline-flex items-center gap-1.5 leading-5', className)}
+      {...props}
+    />
   )
 )
 BreadcrumbItem.displayName = 'BreadcrumbItem'
@@ -60,7 +64,7 @@ const BreadcrumbPage = React.forwardRef<HTMLSpanElement, React.ComponentPropsWit
       role="link"
       aria-disabled="true"
       aria-current="page"
-      className={cn('no-underline inline-flex h-[22px] text-foreground-lighter', className)}
+      className={cn('no-underline text-foreground-lighter', className)}
       {...props}
     />
   )

--- a/packages/ui/src/components/shadcn/ui/drawer.tsx
+++ b/packages/ui/src/components/shadcn/ui/drawer.tsx
@@ -31,19 +31,20 @@ DrawerOverlay.displayName = DrawerPrimitive.Overlay.displayName
 
 const DrawerContent = React.forwardRef<
   React.ElementRef<typeof DrawerPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Content>
->(({ className, children, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Content> & { showHandle?: boolean }
+>(({ className, children, showHandle = true, ...props }, ref) => (
   <DrawerPortal>
     <DrawerOverlay />
     <DrawerPrimitive.Content
       ref={ref}
       className={cn(
         'fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border bg-background',
+        !showHandle && 'pt-4',
         className
       )}
       {...props}
     >
-      <div className="mx-auto mt-4 h-2 w-[100px] rounded-full bg-muted" />
+      {showHandle && <div className="mx-auto mt-4 h-2 w-[100px] rounded-full bg-muted" />}
       {children}
     </DrawerPrimitive.Content>
   </DrawerPortal>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Adds breadcrumbs to docs guides pages.

## What is the current behavior?

No breadcrumbs.

## What is the new behavior?

<img width="1434" alt="Screenshot 2024-07-11 at 15 51 06" src="https://github.com/supabase/supabase/assets/25671831/2d01ef0c-b545-4015-8330-58621850b523">

<img width="1421" alt="Screenshot 2024-07-11 at 15 50 58" src="https://github.com/supabase/supabase/assets/25671831/017afaaa-d348-4289-aaae-f79833f315a2">
