### PR TITLE
Replaced accessSecretKey with secretAccessKey in S3Client credentials

### DIFF
--- a/apps/docs/content/guides/storage/s3/authentication.mdx
+++ b/apps/docs/content/guides/storage/s3/authentication.mdx
@@ -42,7 +42,7 @@ This is all the information you need to connect to Supabase Storage using any S3
           endpoint: 'https://project_ref.supabase.co/storage/v1/s3',
           credentials: {
             accessKeyId: 'your_access_key_id',
-            accessSecretKey: 'your_secret_access_key',
+            secretAccessKey: 'your_secret_access_key',
           }
         })
         ```
@@ -89,7 +89,7 @@ const client = new S3Client({
   endpoint: 'https://project_ref.supabase.co/storage/v1/s3',
   credentials: {
     accessKeyId: 'project_ref',
-    accessSecretKey: 'anonKey',
+    secretAccessKey: 'anonKey',
     sessionToken: session.access_token,
   },
 })


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Typo fix in [s3 storage documentation](https://supabase.com/docs/guides/storage/s3/authentication?queryGroups=language&language=javascript)