### PR TITLE
fix: Adjust .sb-grid checkbox styles for light and dark themes

### DIFF
--- a/apps/studio/styles/grid.scss
+++ b/apps/studio/styles/grid.scss
@@ -174,7 +174,7 @@
   }
 
   [type='checkbox']:checked {
-    @apply bg-foreground;
+    @apply bg-background dark:bg-foreground;
     border-color: transparent;
     background-size: 100% 100%;
     background-position: center;
@@ -184,7 +184,7 @@
   [type='checkbox'] {
     @apply cursor-pointer rounded border border-solid;
 
-    @apply text-foreground border-default transition-all;
+    @apply text-background dark:text-foreground border-default transition-all;
     @apply hover:border-foreground focus:ring-0 focus:outline-none;
 
     @apply bg-transparent;


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix for issue https://github.com/supabase/supabase/issues/27914

## What is the current behavior?

Checkboxes style is all black in table editor when set theme with light.

https://github.com/supabase/supabase/issues/27914

![image](https://github.com/user-attachments/assets/5cab0610-d9d1-4319-ba94-50583f0d64a2)


## What is the new behavior?

Updated checkbox styles to properly apply colors for both light and dark themes. The `bg-background` and `text-background` classes are used for light theme compatibility, while `dark:bg-foreground` and `dark:text-foreground` are used for dark theme compatibility. This ensures consistent styling across different themes.

Light theme:
![image](https://github.com/user-attachments/assets/f5cf715e-4959-430c-b956-d4a017119e2c)

Dark theme:
![image](https://github.com/user-attachments/assets/06d2ec87-92d8-43fd-96e1-915e00628a5f)


## Additional context

Add any other context or screenshots.
