### PR TITLE
update password docs to use confirm endpoint and email template change

### DIFF
--- a/apps/docs/content/guides/auth/passwords.mdx
+++ b/apps/docs/content/guides/auth/passwords.mdx
@@ -142,16 +142,19 @@ Your signup email template should contain the following HTML:
 
 Create an API endpoint at `<YOUR_SITE_URL>/auth/confirm` to handle the token exchange.
 
+<CreateClientSnippet />
+
 <Tabs scrollable size="small" type="underlined" defaultActiveId="nextjs" queryGroup="framework">
 <TabPanel id="nextjs" label="Next.js">
 
 Create a new file at `app/auth/confirm/route.ts` and populate with the following:
 
 ```ts app/auth/confirm/route.ts
-import { createServerClient, type CookieOptions } from '@supabase/ssr'
 import { type EmailOtpType } from '@supabase/supabase-js'
 import { cookies } from 'next/headers'
 import { NextRequest, NextResponse } from 'next/server'
+// The client you created from the Server-Side Auth instructions
+import { createClient } from '@/utils/supabase/server'
 
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url)
@@ -162,23 +165,7 @@ export async function GET(request: NextRequest) {
   redirectTo.pathname = next
 
   if (token_hash && type) {
-    const cookieStore = cookies()
-    const supabase = createServerClient(
-      process.env.NEXT_PUBLIC_SUPABASE_URL!,
-      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-      {
-        cookies: {
-          getAll() {
-            return cookieStore.getAll()
-          },
-          setAll(cookiesToSet) {
-            cookiesToSet.forEach(({ name, value, options }) =>
-              cookieStore.set(name, value, options)
-            )
-          },
-        },
-      }
-    )
+    const supabase = createClient()
 
     const { error } = await supabase.auth.verifyOtp({
       type,
@@ -336,6 +323,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
 Create a new route in your express app and populate with the following:
 
 ```js app.js
+// The client you created from the Server-Side Auth instructions
+const { createClient } = require("./lib/supabase")
 ...
 app.get("/auth/confirm", async function (req, res) {
   const token_hash = req.query.token_hash
@@ -495,6 +484,14 @@ suspend fun signInWithEmail() {
 
 ### Resetting a password
 
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  queryGroup="flow"
+>
+<TabPanel id="implicit" label="Implicit flow">
+
 #### Step 1: Create a reset password page
 
 Create a **reset password** page. This page should be publicly accessible.
@@ -545,31 +542,273 @@ If you are on one of the Kotlin targets that have built-in support for redirect 
 
 Create a **change password** page at the URL you specified in the previous step. This page should be accessible only to authenticated users.
 
-<Tabs
-  scrollable
-  size="small"
-  type="underlined"
-  queryGroup="flow"
->
-<TabPanel id="implicit" label="Implicit flow">
-
 Collect the user's new password and call `updateUser` to update their password.
 
 </TabPanel>
 
 <TabPanel id="pkce" label="PKCE flow">
 
-In the PKCE flow, the reset password link only works on the device or browser where the original request was made.
+The PKCE flow allows for server-side authentication. Unlike the implicit flow, which directly provides your app with the access token after the user clicks the confirmation link, the PKCE flow requires an intermediate token exchange step before you can get the access token.
 
-When the user clicks the link and is redirected to the change password page, their URL contains a `code` query param. If you aren't using the official Supabase libraries, extract the `code` from the URL and exchange it for a session. For example, in JavaScript, call [`supabase.auth.exchangeCodeForSession`](/docs/reference/javascript/auth-exchangecodeforsession). If you're using an official library, the code exchange is handled for you.
+##### Step 1: Update reset password email
 
-<Admonition type="tip">
+Update your reset password email template to send the token hash. See [Email Templates](/docs/guides/auth/auth-email-templates) for how to configure your email templates.
 
-If your page is server-rendered and the code isn't being automatically exchanged, check whether the Supabase client is being initialized eagerly. Your server-rendered page might be lazily initializing the Supabase client after user interaction, which means the automatic code exchange can't run.
+Your signup email template should contain the following HTML:
 
-You can either exchange the code yourself or initialize the Supabase client eagerly.
+```html
+<h2>Reset Password</h2>
 
-</Admonition>
+<p>Follow this link to reset the password for your user:</p>
+<p><a href="{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=recovery&next=/account/update-password">Reset Password</a></p>
+```
+
+##### Step 2: Create token exchange endpoint
+
+Create an API endpoint at `<YOUR_SITE_URL>/auth/confirm` to handle the token exchange.
+
+<CreateClientSnippet />
+
+<Tabs scrollable size="small" type="underlined" defaultActiveId="nextjs" queryGroup="framework">
+<TabPanel id="nextjs" label="Next.js">
+
+Create a new file at `app/auth/confirm/route.ts` and populate with the following:
+
+```ts app/auth/confirm/route.ts
+import { type EmailOtpType } from '@supabase/supabase-js'
+import { cookies } from 'next/headers'
+import { NextRequest, NextResponse } from 'next/server'
+// The client you created from the Server-Side Auth instructions
+import { createClient } from '@/utils/supabase/server'
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url)
+  const token_hash = searchParams.get('token_hash')
+  const type = searchParams.get('type') as EmailOtpType | null
+  const next = searchParams.get('next') ?? '/'
+  const redirectTo = request.nextUrl.clone()
+  redirectTo.pathname = next
+
+  if (token_hash && type) {
+    const supabase = createClient()
+
+    const { error } = await supabase.auth.verifyOtp({
+      type,
+      token_hash,
+    })
+    if (!error) {
+      return NextResponse.redirect(redirectTo)
+    }
+  }
+
+  // return the user to an error page with some instructions
+  redirectTo.pathname = '/auth/auth-code-error'
+  return NextResponse.redirect(redirectTo)
+}
+```
+
+</TabPanel>
+<TabPanel id="sveltekit" label="SvelteKit">
+
+Create a new file at `src/routes/auth/confirm/+server.ts` and populate with the following:
+
+```ts src/routes/auth/confirm/+server.ts
+import { redirect } from '@sveltejs/kit'
+import { type EmailOtpType } from '@supabase/supabase-js'
+
+export const GET = async (event) => {
+  const {
+    url,
+    locals: { supabase },
+  } = event
+  const token_hash = url.searchParams.get('token_hash') as string
+  const type = url.searchParams.get('type') as EmailOtpType | null
+  const next = url.searchParams.get('next') ?? '/'
+
+  /**
+   * Clean up the redirect URL by deleting the Auth flow parameters.
+   *
+   * `next` is preserved for now, because it's needed in the error case.
+   */
+  const redirectTo = new URL(url)
+  redirectTo.pathname = next
+  redirectTo.searchParams.delete('token_hash')
+  redirectTo.searchParams.delete('type')
+
+  if (token_hash && type) {
+    const { error } = await supabase.auth.verifyOtp({ token_hash, type })
+    if (!error) {
+      redirectTo.searchParams.delete('next')
+      redirect(303, redirectTo)
+    }
+  }
+
+  // return the user to an error page with some instructions
+  redirectTo.pathname = '/auth/error'
+  redirect(303, redirectTo)
+}
+```
+
+</TabPanel>
+
+<TabPanel id="astro" label="Astro">
+
+Create a new file at `src/pages/auth/confirm.ts` and populate with the following:
+
+```ts src/pages/auth/confirm.ts
+import { createServerClient, parseCookieHeader } from '@supabase/ssr'
+import { type EmailOtpType } from '@supabase/supabase-js'
+import { type APIRoute } from 'astro'
+
+export const GET: APIRoute = async ({ request, cookies, redirect }) => {
+  const requestUrl = new URL(request.url)
+  const token_hash = requestUrl.searchParams.get('token_hash')
+  const type = requestUrl.searchParams.get('type') as EmailOtpType | null
+  const next = requestUrl.searchParams.get('next') || '/'
+
+  if (token_hash && type) {
+    const supabase = createServerClient(
+      import.meta.env.PUBLIC_SUPABASE_URL,
+      import.meta.env.PUBLIC_SUPABASE_ANON_KEY,
+      {
+        cookies: {
+          getAll() {
+            return parseCookieHeader(request.headers.get('Cookie') ?? '')
+          },
+          setAll(cookiesToSet) {
+            cookiesToSet.forEach(({ name, value, options }) => cookies.set(name, value, options))
+          },
+        },
+      }
+    )
+
+    const { error } = await supabase.auth.verifyOtp({
+      type,
+      token_hash,
+    })
+
+    if (!error) {
+      return redirect(next)
+    }
+  }
+
+  // return the user to an error page with some instructions
+  return redirect('/auth/auth-code-error')
+}
+```
+
+</TabPanel>
+
+<TabPanel id="remix" label="Remix">
+
+Create a new file at `app/routes/auth.confirm.tsx` and populate with the following:
+
+```ts app/routes/auth.confirm.tsx
+import { redirect, type LoaderFunctionArgs } from '@remix-run/node'
+import { createServerClient, parseCookieHeader, serializeCookieHeader } from '@supabase/ssr'
+import { type EmailOtpType } from '@supabase/supabase-js'
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const requestUrl = new URL(request.url)
+  const token_hash = requestUrl.searchParams.get('token_hash')
+  const type = requestUrl.searchParams.get('type') as EmailOtpType | null
+  const next = requestUrl.searchParams.get('next') || '/'
+  const headers = new Headers()
+
+  if (token_hash && type) {
+    const supabase = createServerClient(process.env.SUPABASE_URL!, process.env.SUPABASE_ANON_KEY!, {
+      cookies: {
+        getAll() {
+          return parseCookieHeader(request.headers.get('Cookie') ?? '')
+        },
+        setAll(key, value, options) {
+          headers.append('Set-Cookie', serializeCookieHeader(key, value, options))
+        },
+      },
+    })
+
+    const { error } = await supabase.auth.verifyOtp({
+      type,
+      token_hash,
+    })
+
+    if (!error) {
+      return redirect(next, { headers })
+    }
+  }
+
+  // return the user to an error page with instructions
+  return redirect('/auth/auth-code-error', { headers })
+}
+```
+
+</TabPanel>
+<TabPanel id="express" label="Express">
+
+Create a new route in your express app and populate with the following:
+
+```js app.js
+// The client you created from the Server-Side Auth instructions
+const { createClient } = require("./lib/supabase")
+...
+app.get("/auth/confirm", async function (req, res) {
+  const token_hash = req.query.token_hash
+  const type = req.query.type
+  const next = req.query.next ?? "/"
+
+  if (token_hash && type) {
+    const supabase = createClient({ req, res })
+    const { error } = await supabase.auth.verifyOtp({
+      type,
+      token_hash,
+    })
+    if (!error) {
+      res.redirect(303, `/${next.slice(1)}`)
+    }
+  }
+
+  // return the user to an error page with some instructions
+  res.redirect(303, '/auth/auth-code-error')
+})
+```
+
+</TabPanel>
+</Tabs>
+
+##### Step 3: Call the reset password by email function to initiate the flow
+
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  queryGroup="language"
+>
+<TabPanel id="js" label="JavaScript">
+
+```js
+async function signUpNewUser() {
+  const { data, error } = await supabase.auth.resetPasswordForEmail(email)
+}
+```
+
+</TabPanel>
+<TabPanel id="swift" label="Swift">
+
+```swift
+try await supabase.auth.resetPasswordForEmail("hello@example.com")
+```
+
+</TabPanel>
+<TabPanel id="kotlin" label="Kotlin">
+
+```kotlin
+supabase.gotrue.sendRecoveryEmail(
+    email = "hello@example.com",
+)
+```
+
+</TabPanel>
+</Tabs>
 
 Once you have a session, collect the user's new password and call `updateUser` to update their password.
 

--- a/apps/docs/content/guides/auth/passwords.mdx
+++ b/apps/docs/content/guides/auth/passwords.mdx
@@ -560,7 +560,12 @@ Your signup email template should contain the following HTML:
 <h2>Reset Password</h2>
 
 <p>Follow this link to reset the password for your user:</p>
-<p><a href="{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=recovery&next=/account/update-password">Reset Password</a></p>
+<p>
+  <a
+    href="{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=recovery&next=/account/update-password"
+    >Reset Password</a
+  >
+</p>
 ```
 
 ##### Step 2: Create token exchange endpoint


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Update the password reset docs use the confirm endpoint instead of `.exchangeCodeForSession` method.

## What is the current behavior?

The current docs use `.exchangeCodeForSession` which limits where you can open the password reset email

## What is the new behavior?

The `.exchangeCodeForSession` is no longer required.

## Additional context

Add any other context or screenshots.
