### PR TITLE
docs: remove Intel Mac warning for Supabase Studio on Supabase CLI --> Getting Started

### DIFF
--- a/apps/docs/content/guides/cli/getting-started.mdx
+++ b/apps/docs/content/guides/cli/getting-started.mdx
@@ -147,12 +147,6 @@ The Supabase CLI uses Docker containers to manage the local development stack. T
 
 - Install [Docker Desktop](https://docs.docker.com/desktop)
 
-<Admonition type="tip" label="Intel-based Mac">
-
-If you are running Supabase on Intel-based Mac, disable [MacOS Virtualization Framework](https://github.com/supabase/cli/issues/1083#issuecomment-1691431279) to prevent Studio from being stuck in a crashloop.
-
-</Admonition>
-
 Inside the folder where you want to create your project, run:
 
 ```bash


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

Work as expected from default Docker configuration on macOS

## What is the new behavior?

Intel Mac users are no longer required to disable MacOS Virtualization Framework with Docker 4.30.0+

## Additional context

Removed doc about disabling MacOS Virtualization Framework on Intel-based Macs. This issue has been resolved in Docker Desktop 4.30.0+.

Ref: https://docs.docker.com/desktop/release-notes/#4300
