### PR TITLE
feat: add avatar picker to profile

### DIFF
--- a/apps/studio/components/interfaces/Database/Triggers/TriggersList/TriggerList.tsx
+++ b/apps/studio/components/interfaces/Database/Triggers/TriggersList/TriggerList.tsx
@@ -107,6 +107,12 @@ const TriggerList = ({
             </div>
           </Table.td>
 
+          <Table.td className="hidden space-x-2 xl:table-cell">
+            <p title={x.orientation} className="truncate">
+              {x.orientation}
+            </p>
+          </Table.td>
+
           <Table.td className="hidden xl:table-cell">
             <div className="flex items-center justify-center">
               {x.enabled_mode !== 'DISABLED' ? (

--- a/apps/studio/components/interfaces/Database/Triggers/TriggersList/TriggersList.tsx
+++ b/apps/studio/components/interfaces/Database/Triggers/TriggersList/TriggersList.tsx
@@ -150,6 +150,9 @@ const TriggersList = ({
                 <Table.th key="events" className="hidden xl:table-cell">
                   Events
                 </Table.th>
+                <Table.th key="orientation" className="hidden xl:table-cell">
+                  Orientation
+                </Table.th>
                 <Table.th key="enabled" className="hidden w-20 xl:table-cell">
                   Enabled
                 </Table.th>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Feature

## What is the current behavior?

Once a trigger is created, there is no way to see its orientation in the UI
[issue 27832](https://github.com/orgs/supabase/discussions/27832)

## What is the new behavior?

Orientation is now listed in the table for triggers

