### PR TITLE
remove duplicate instructions

### DIFF
--- a/apps/docs/content/guides/auth/social-login/auth-github.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-github.mdx
@@ -14,29 +14,13 @@ Setting up GitHub logins for your application consists of 3 parts:
 - Add your GitHub OAuth keys to your [Supabase Project](https://supabase.com/dashboard)
 - Add the login code to your [Supabase JS Client App](https://github.com/supabase/supabase-js)
 
-## Access your GitHub account
-
-- Go to [github.com](https://github.com).
-- Click on `Sign In` at the top right to log in.
-
-![GitHub Developer Portal.](/docs/img/guides/auth-github/github-portal.png)
-
-## Create a GitHub OAuth app
-
-Go to the [GitHub Developer Settings](https://github.com/settings/developers) page:
-
-- Click on your profile photo at the top right
-- Click Settings near the bottom of the menu
-- In the left sidebar, click `Developer settings` (near the bottom)
-- In the left sidebar, click `OAuth Apps`
-
 ## Find your callback URL
 
 <SocialProviderSetup provider="GitHub" />
 
 ## Register a new OAuth application on GitHub
 
-- Navigate to `Settings`/`Developer settings`/`OAuth Apps`
+- Navigate to the [OAuth apps page](https://github.com/settings/developers)
 - Click `Register a new application`. If you've created an app before, click `New OAuth App` here.
 - In `Application name`, type the name of your app.
 - In `Homepage URL`, type the full URL to your app's website.


### PR DESCRIPTION
we don't need to show how to login to github.
we can point to links instead of showing how to navigate to that page - users are going to click on the links anyway.