### PR TITLE
Chore: Added myself (Michael) to humans.txt

### DIFF
--- a/apps/docs/public/humans.txt
+++ b/apps/docs/public/humans.txt
@@ -52,6 +52,7 @@ Long Hoang
 Margarita Sandomirskaia
 Marijana Pavlinić
 Mark Burggraf
+Michael Ridley
 Monica El Khoury
 Oli R
 Pamela Chia


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Updated humans.txt to add myself

## What is the current behavior?

Michael is not humans.txt

## What is the new behavior?

Michael is in the humans.txt

## Additional context

N/A
