### PR TITLE
fix: Slack OIDC enabled badge

### DIFF
--- a/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
@@ -79,11 +79,14 @@ const ProviderForm = ({ config, provider }: ProviderFormProps) => {
     provider.title === 'LinkedIn (OIDC)' &&
     config &&
     (config as any)['EXTERNAL_LINKEDIN_OIDC_ENABLED']
+  const isSlackOIDCEnabled =
+    provider.title === 'Slack (OIDC)' && config['EXTERNAL_SLACK_OIDC_ENABLED']
   const isExternalProviderAndEnabled: boolean =
     config && (config as any)[`EXTERNAL_${provider?.title?.toUpperCase()}_ENABLED`]
 
   // [Joshen] Doing this check as SAML doesn't follow the same naming structure as the other provider options
-  const isActive: boolean = isSAMLEnabled || isExternalProviderAndEnabled || isLinkedInOIDCEnabled
+  const isActive: boolean =
+    isSAMLEnabled || isExternalProviderAndEnabled || isLinkedInOIDCEnabled || isSlackOIDCEnabled
   const INITIAL_VALUES = generateInitialValues()
 
   const onSubmit = (values: any, { resetForm }: any) => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Even when Slack (OIDC) was enabled, the badge on the row showed as disabled:
<img width="896" alt="Screenshot 2024-07-17 at 11 51 15" src="https://github.com/user-attachments/assets/99bffa24-72a5-49cb-9bd8-15da0e363aa3">


## What is the new behavior?

<img width="891" alt="Screenshot 2024-07-17 at 11 51 31" src="https://github.com/user-attachments/assets/07e9aff9-5093-4a5f-a7bf-b06e3bf7698b">
