### PR TITLE
fix(storage): change replaced character to U+202F

### DIFF
--- a/apps/studio/localStores/storageExplorer/StorageExplorerStore.tsx
+++ b/apps/studio/localStores/storageExplorer/StorageExplorerStore.tsx
@@ -623,7 +623,10 @@ class StorageExplorerStore {
        * [Joshen] Am limiting to just replacing nbsp with a blank space instead of
        * all non-word characters per before
        * */
-      const formattedFileName = (unsanitizedFormattedFileName ?? 'unknown').replaceAll(/\xA0/g, ' ')
+      const formattedFileName = (unsanitizedFormattedFileName ?? 'unknown').replaceAll(
+        /\u{202F}/gu,
+        ' '
+      )
       const formattedPathToFile =
         pathToFile.length > 0 ? `${pathToFile}/${formattedFileName}` : (formattedFileName as string)
 


### PR DESCRIPTION
The character that was breaking screenshots was the Narrow No-Break Space (U+202F), which is apparently not the same thing as the No-Break Space (U+00A0). (TIL there are 17 different Unicode space separators.)

Tested on local by uploading a screenshot taken with default 12-hour timestamp (which was the broken case before).