### PR TITLE
Add pointer cursor for clickable elements in studio billing section

### DIFF
--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
@@ -160,7 +160,7 @@ const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
                         key={fee.description}
                         style={{ WebkitAppearance: 'initial' }}
                       >
-                        <td className="py-2 text-sm max-w-[200px]">
+                        <td className="py-2 text-sm max-w-[200px] cursor-pointer">
                           <Button
                             type="text"
                             className="!px-1"
@@ -215,7 +215,7 @@ const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
                       <>
                         {fee.breakdown?.map((breakdown) => (
                           <tr
-                            className="last:border-b cursor-pointer"
+                            className="last:border-b"
                             style={{ WebkitAppearance: 'initial' }}
                             key={breakdown.project_ref}
                           >


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

change style

## What is the current behavior?

pointer cursor style applied to non-clickable elements instead of clickable ones

## What is the new behavior?

Add pointer cursor for clickable elements

## Additional context

current

<img width="316" alt="image" src="https://github.com/user-attachments/assets/a4a6b6a9-e163-40b3-ba47-975329b4b329">
<img width="316" alt="image" src="https://github.com/user-attachments/assets/fe297011-b0fb-44e2-9047-b2259d6db757">

new

<img width="295" alt="image" src="https://github.com/user-attachments/assets/89a377c9-9e01-400a-9880-aa8eef6f47ef">
<img width="278" alt="image" src="https://github.com/user-attachments/assets/14ae8638-efbb-41cf-ac86-1f7d53085523">

