### PR TITLE
Fix/docs nav widescreen

### DIFF
--- a/apps/docs/components/HomePageCover.tsx
+++ b/apps/docs/components/HomePageCover.tsx
@@ -102,7 +102,7 @@ const HomePageCover = (props) => {
   )
 
   return (
-    <div className="w-full bg-alternative border-b max-w-none mb-16 md:mb-12 xl:mb-0">
+    <div className="relative z-10 w-full bg-alternative border-b max-w-none mb-16 md:mb-12 xl:mb-0">
       <div className="max-w-7xl px-5 mx-auto py-8 sm:pb-16 sm:pt-12 xl:pt-16 flex flex-col xl:flex-row justify-between gap-12 xl:gap-12">
         <div className="flex flex-col sm:flex-row gap-4 sm:gap-8 items-start sm:items-center w-full max-w-xl xl:max-w-[33rem]">
           <DocsCoverLogo aria-hidden="true" />

--- a/apps/docs/components/Navigation/NavigationMenu/TopNavBar.tsx
+++ b/apps/docs/components/Navigation/NavigationMenu/TopNavBar.tsx
@@ -29,7 +29,7 @@ const TopNavBar: FC = () => {
             <HeaderLogo />
             <GlobalNavigationMenu />
           </div>
-          <div className="w-full grow lg:w-auto max-w-7xl flex gap-3 justify-between lg:justify-end items-center h-full">
+          <div className="w-full grow lg:w-auto flex gap-3 justify-between lg:justify-end items-center h-full">
             <div className="lg:hidden">
               <HeaderLogo />
             </div>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

- [ ] Fix topnav spacing on wide screens.
- [ ] Fix Getting started box overlap

## What is the current behavior?

![Screenshot 2024-07-18 at 09 37 24](https://github.com/user-attachments/assets/8f94c719-132a-4d8a-a31c-715cefa280c7)

## What is the new behavior?

![Screenshot 2024-07-18 at 09 37 28](https://github.com/user-attachments/assets/27594a34-9519-49f7-840f-30816971bdf6)

