### PR TITLE
fix: new id in content query

### DIFF
--- a/apps/studio/pages/project/[ref]/sql/[id].tsx
+++ b/apps/studio/pages/project/[ref]/sql/[id].tsx
@@ -47,7 +47,7 @@ const SqlEditor: NextPageWithLayout = () => {
       // [Joshen] May need to investigate separately, but occasionally addSnippet doesnt exist in
       // the snapV2 valtio store for some reason hence why the added typeof check here
       retry: false,
-      enabled: enableFolders && id !== 'new' && typeof snapV2.addSnippet === 'function',
+      enabled: Boolean(enableFolders && id !== 'new' && typeof snapV2.addSnippet === 'function'),
       onSuccess: (data) => {
         snapV2.addSnippet({ projectRef: ref as string, snippet: data })
       },


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

`enableFolders && id !== 'new' && typeof snapV2.addSnippet === 'function'` `enableFolders` is `undefined` so that expression returns `undefined` instead of `false`, which then passes through to `enabled && typeof projectRef !== 'undefined' && typeof id !== 'undefined'` and now since enabled is `undefined` that whole expression returns `undefined` and when you don’t pass enabled to react-query (also known as `undefined`), it defaults to `true`




