### PR TITLE
fix: use gotrue_id instead of email

### DIFF
--- a/apps/studio/components/interfaces/Organization/TeamSettings/MemberRow.tsx
+++ b/apps/studio/components/interfaces/Organization/TeamSettings/MemberRow.tsx
@@ -29,7 +29,7 @@ export const MemberRow = ({ member }: MemberRowProps) => {
     slug: selectedOrganization?.slug,
   })
 
-  const memberIsUser = member.primary_email == profile?.primary_email
+  const memberIsUser = member.gotrue_id == profile?.gotrue_id
   const isInvitedUser = Boolean(member.invited_id)
   const isEmailUser = member.username === member.primary_email
   const isFlyUser = Boolean(member.primary_email?.endsWith('customer.fly.io'))


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?
* Fixes an issue where it is not possible to manage access for an sso user if the sso user has the same email

## What is the current behavior?
<img width="1401" alt="image" src="https://github.com/user-attachments/assets/8b16ba04-568d-4251-b75a-04fa04a3355b">

## What is the new behavior?
<img width="1380" alt="image" src="https://github.com/user-attachments/assets/5aba3d20-983c-4c7c-90e1-4aac0e06a8bb">

## Additional context
We should also show if a member is an SSO user - but that will be done in a FLUP PR
