### PR TITLE
docs: resend edge functions key

### DIFF
--- a/apps/docs/content/guides/functions/examples/send-emails.mdx
+++ b/apps/docs/content/guides/functions/examples/send-emails.mdx
@@ -77,6 +77,12 @@ Deploy function to Supabase:
 supabase functions deploy resend --no-verify-jwt
 ```
 
+<Admonition type="warning">
+
+When you deploy to Supabase, make sure that your `RESEND_API_KEY` is set in [Edge Function Secrets Management](https://supabase.com/dashboard/project/_/settings/functions)
+
+</Admonition>
+
 Open the endpoint URL to send an email:
 
 ### 4. Try it yourself


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Supabase Docs - [Resend Edge Function Example](https://supabase.com/dashboard/project/cpobogwrwzadnbvtbgvl/settings/functions)

## What is the current behavior?

No warning to the user to check that the `RESEND_API_KEY` is set in the edge functions settings

## What is the new behavior?

Added a note:

<img width="1440" alt="Screenshot 2024-07-18 at 22 05 13" src="https://github.com/user-attachments/assets/8fff569e-64de-4f47-b8e8-7d305f03a3b4">
