### PR TITLE
docs: added max request and repsonse for edge functions docs

### DIFF
--- a/apps/docs/content/guides/functions/limits.mdx
+++ b/apps/docs/content/guides/functions/limits.mdx
@@ -14,6 +14,8 @@ subtitle: "Limits applied Edge Functions in Supabase's hosted platform."
 - Maximum Function Size (after bundling via CLI): 10MB
 - Maximum log message length: 10,000 characters
 - Log event threshold: 100 events per 10 seconds
+- Max Request: 5GB
+- Max Response: No limit
 
 ## Other limits & restrictions
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Supabase Docs - [Edge Functions Limits](https://supabase.com/docs/guides/functions/limits)

## What is the current behavior?

No details on max request and response.

## What is the new behavior?

<img width="1440" alt="Screenshot 2024-07-18 at 22 31 45" src="https://github.com/user-attachments/assets/8a5ff4e2-3989-45bb-8969-297f5b1be262">


## Additional context

Closes #28053 
