### PR TITLE
perf: skip docs typecheck during next build

### DIFF
--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -155,6 +155,11 @@ const nextConfig = {
       },
     ]
   },
+  typescript: {
+    // WARNING: production builds can successfully complete even there are type errors
+    // Typechecking is checked separately via .github/workflows/typecheck.yml
+    ignoreBuildErrors: true,
+  },
 }
 
 const configExport = () => {


### PR DESCRIPTION
We're already doing typechecks through a separate action, there is no need to run typechecks again on builds. This is a recommendation from Vercel that has already been active in studio for a while.
