### PR TITLE
fix: Bail on audit logs permissions

### DIFF
--- a/apps/studio/components/interfaces/Organization/AuditLogs/AuditLogs.tsx
+++ b/apps/studio/components/interfaces/Organization/AuditLogs/AuditLogs.tsx
@@ -69,7 +69,7 @@ const AuditLogs = () => {
       {
         enabled: canReadAuditLogs,
         retry(_failureCount, error) {
-          if (error.message.endsWith('upgrade to team or Enterprise Plan to access audit logs.')) {
+          if (error.message.endsWith('upgrade to Team or Enterprise Plan to access audit logs.')) {
             return false
           }
           return true
@@ -144,7 +144,7 @@ const AuditLogs = () => {
           )}
 
           {isError ? (
-            error.message.endsWith('upgrade to team or Enterprise Plan to access audit logs.') ? (
+            error.message.endsWith('upgrade to Team or Enterprise Plan to access audit logs.') ? (
               <Alert_Shadcn_
                 variant="default"
                 title="Organization Audit Logs are not available on Free or Pro plans"

--- a/apps/studio/components/interfaces/Reports/renderers/ApiRenderers.tsx
+++ b/apps/studio/components/interfaces/Reports/renderers/ApiRenderers.tsx
@@ -1,6 +1,6 @@
 import sumBy from 'lodash/sumBy'
-import { Fragment, useState } from 'react'
 import { ChevronRight } from 'lucide-react'
+import { Fragment, useState } from 'react'
 
 import { useParams } from 'common'
 import {
@@ -8,20 +8,20 @@ import {
   TextFormatter,
 } from 'components/interfaces/Settings/Logs/LogsFormatters'
 import Table from 'components/to-be-cleaned/Table'
+import AlertError from 'components/ui/AlertError'
 import BarChart from 'components/ui/Charts/BarChart'
 import { useFillTimeseriesSorted } from 'hooks/analytics/useFillTimeseriesSorted'
+import { ResponseError } from 'types'
 import {
   Alert_Shadcn_,
   AlertDescription_Shadcn_,
   AlertTitle_Shadcn_,
   Button,
   Collapsible,
+  WarningIcon,
 } from 'ui'
 import { queryParamsToObject } from '../Reports.utils'
 import { ReportWidgetProps, ReportWidgetRendererProps } from '../ReportWidget'
-import AlertError from 'components/ui/AlertError'
-import { ResponseError } from 'types'
-import { WarningIcon } from 'ui-patterns/Icons/StatusIcons'
 
 export const NetworkTrafficRenderer = (
   props: ReportWidgetProps<{

--- a/apps/studio/pages/project/[ref]/functions/[functionSlug]/index.tsx
+++ b/apps/studio/pages/project/[ref]/functions/[functionSlug]/index.tsx
@@ -17,8 +17,13 @@ import { useEdgeFunctionQuery } from 'data/edge-functions/edge-function-query'
 import { useFillTimeseriesSorted } from 'hooks/analytics/useFillTimeseriesSorted'
 import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import type { ChartIntervals, NextPageWithLayout } from 'types'
-import { AlertDescription_Shadcn_, AlertTitle_Shadcn_, Alert_Shadcn_, Button } from 'ui'
-import { WarningIcon } from 'ui-patterns/Icons/StatusIcons'
+import {
+  AlertDescription_Shadcn_,
+  AlertTitle_Shadcn_,
+  Alert_Shadcn_,
+  Button,
+  WarningIcon,
+} from 'ui'
 
 const CHART_INTERVALS: ChartIntervals[] = [
   {


### PR DESCRIPTION
Introduced in https://github.com/supabase/supabase/commit/f1541878a9476e24f851158923808dadfc9fef0d#diff-bf58fba3c34c4b6642e81470fb1a66aa8fb02d35bcff524886ce8fb8d3c8dd72 and https://github.com/supabase/infrastructure/commit/775fe81d1fb2cd111f4261dc77c5a43ccb6ea2a2#diff-e9dbce55ad441c769c82cf04eae8543461014ceb2a63c22d55a67adcc96751b4

![image](https://github.com/user-attachments/assets/a12f4e85-1fda-4577-9400-ae1755212754)