### PR TITLE
feat(docs), refactor(docs,studio): add regions list to docs

### DIFF
--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
@@ -1721,6 +1721,7 @@ export const platform: NavMenuConstant = {
       name: 'Platform Management',
       url: undefined,
       items: [
+        { name: 'Regions', url: '/guides/platform/regions' },
         { name: 'Access Control', url: '/guides/platform/access-control' },
         {
           name: 'Custom Postgres Config',

--- a/apps/docs/components/RegionsList.tsx
+++ b/apps/docs/components/RegionsList.tsx
@@ -1,0 +1,14 @@
+import { AWS_REGIONS } from 'shared-data'
+
+export function RegionsList() {
+  return (
+    <ul>
+      {Object.keys(AWS_REGIONS).map((region) => (
+        <li key={region} className="flex flex-col gap-2">
+          <span className="w-fit !mt-0">{AWS_REGIONS[region].displayName}</span>
+          <code className="w-fit">{AWS_REGIONS[region].code}</code>
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/apps/docs/content/guides/platform/regions.mdx
+++ b/apps/docs/content/guides/platform/regions.mdx
@@ -1,0 +1,14 @@
+---
+title: Available regions
+subtitle: Spin up Supabase projects in our global regions
+---
+
+The following regions are available for your Supabase projects.
+
+## AWS
+
+<RegionsList />
+
+## Fly
+
+Our [Fly Postgres](/docs/guides/platform/fly-postgres) offering (in private alpha) is supported in every region where Fly operates.

--- a/apps/docs/features/docs/mdx.shared.tsx
+++ b/apps/docs/features/docs/mdx.shared.tsx
@@ -29,6 +29,7 @@ import {
 import { NavData } from '~/components/NavData'
 import { ProjectConfigVariables } from '~/components/ProjectConfigVariables'
 import { RealtimeLimitsEstimator } from '~/components/RealtimeLimitsEstimator'
+import { RegionsList } from '~/components/RegionsList'
 import { SharedData } from '~/components/SharedData'
 import StepHikeCompact from '~/components/StepHikeCompact'
 import { Accordion, AccordionItem } from '~/features/ui/Accordion'
@@ -68,6 +69,7 @@ const components = {
   ProjectSetup,
   QuickstartIntro,
   RealtimeLimitsEstimator,
+  RegionsList,
   SharedData,
   SocialProviderSettingsSupabase,
   SocialProviderSetup,

--- a/apps/studio/components/interfaces/ProjectCreation/ProjectCreation.utils.ts
+++ b/apps/studio/components/interfaces/ProjectCreation/ProjectCreation.utils.ts
@@ -1,5 +1,5 @@
-import { AWS_REGIONS, CloudProvider, FLY_REGIONS, Region } from 'lib/constants'
-import { pluckObjectFields } from 'lib/helpers'
+import type { CloudProvider, Region } from 'shared-data'
+import { AWS_REGIONS, FLY_REGIONS } from 'shared-data'
 
 export function getAvailableRegions(cloudProvider: CloudProvider): Region {
   if (cloudProvider === 'AWS') {

--- a/apps/studio/components/interfaces/ProjectCreation/RegionSelector.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/RegionSelector.tsx
@@ -1,7 +1,8 @@
-import { useDefaultRegionQuery } from 'data/misc/get-default-region-query'
-import { CloudProvider, PROVIDERS } from 'lib/constants'
 import { useRouter } from 'next/router'
 import { ControllerRenderProps, UseFormReturn } from 'react-hook-form'
+
+import { useDefaultRegionQuery } from 'data/misc/get-default-region-query'
+import { PROVIDERS } from 'lib/constants'
 import {
   SelectContent_Shadcn_,
   SelectGroup_Shadcn_,
@@ -11,6 +12,7 @@ import {
   Select_Shadcn_,
 } from 'ui'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
+import type { CloudProvider } from 'shared-data'
 import { getAvailableRegions } from './ProjectCreation.utils'
 
 interface RegionSelectorProps {
@@ -19,7 +21,7 @@ interface RegionSelectorProps {
   form: UseFormReturn<any>
 }
 
-export const RegionSelector = ({ cloudProvider, field, form }: RegionSelectorProps) => {
+export const RegionSelector = ({ cloudProvider, field }: RegionSelectorProps) => {
   const router = useRouter()
   const showNonProdFields =
     process.env.NEXT_PUBLIC_ENVIRONMENT === 'local' ||
@@ -55,7 +57,7 @@ export const RegionSelector = ({ cloudProvider, field, form }: RegionSelectorPro
         <SelectContent_Shadcn_>
           <SelectGroup_Shadcn_>
             {Object.keys(availableRegions).map((option: string, i) => {
-              const label = Object.values(availableRegions)[i] as string
+              const label = Object.values(availableRegions)[i].displayName as string
               return (
                 <SelectItem_Shadcn_ key={option} value={label}>
                   <div className="flex items-center gap-3">

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/DeployNewReplicaPanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/DeployNewReplicaPanel.tsx
@@ -12,7 +12,9 @@ import { useOrgSubscriptionQuery } from 'data/subscriptions/org-subscription-que
 import { useProjectAddonsQuery } from 'data/subscriptions/project-addons-query'
 import { useSelectedOrganization } from 'hooks/misc/useSelectedOrganization'
 import { useSelectedProject } from 'hooks/misc/useSelectedProject'
-import { AWS_REGIONS, AWS_REGIONS_DEFAULT, AWS_REGIONS_KEYS, BASE_PATH } from 'lib/constants'
+import { AWS_REGIONS_DEFAULT, BASE_PATH } from 'lib/constants'
+import type { AWS_REGIONS_KEYS } from 'shared-data'
+import { AWS_REGIONS } from 'shared-data'
 import {
   AlertDescription_Shadcn_,
   AlertTitle_Shadcn_,
@@ -22,7 +24,7 @@ import {
   SidePanel,
 } from 'ui'
 import { WarningIcon } from 'ui'
-import { AVAILABLE_REPLICA_REGIONS, AWS_REGIONS_VALUES } from './InstanceConfiguration.constants'
+import { AVAILABLE_REPLICA_REGIONS } from './InstanceConfiguration.constants'
 
 // [Joshen] FYI this is purely for AWS only, need to update to support Fly eventually
 
@@ -123,7 +125,7 @@ const DeployNewReplicaPanel = ({
       : AVAILABLE_REPLICA_REGIONS
 
   const onSubmit = async () => {
-    const regionKey = AWS_REGIONS_VALUES[selectedRegion]
+    const regionKey = AWS_REGIONS[selectedRegion as AWS_REGIONS_KEYS].code
     if (!projectRef) return console.error('Project is required')
     if (!regionKey) return toast.error('Unable to deploy replica: Unsupported region selected')
 

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/EnablePhysicalBackupsModal.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/EnablePhysicalBackupsModal.tsx
@@ -8,6 +8,8 @@ import { useEnablePhysicalBackupsMutation } from 'data/database/enable-physical-
 import { useProjectDetailQuery } from 'data/projects/project-detail-query'
 import { Region, useReadReplicaSetUpMutation } from 'data/read-replicas/replica-setup-mutation'
 import { useReadReplicasQuery } from 'data/read-replicas/replicas-query'
+import type { AWS_REGIONS_KEYS } from 'shared-data'
+import { AWS_REGIONS } from 'shared-data'
 import {
   Button,
   Dialog,
@@ -20,7 +22,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from 'ui'
-import { AVAILABLE_REPLICA_REGIONS, AWS_REGIONS_VALUES } from './InstanceConfiguration.constants'
+import { AVAILABLE_REPLICA_REGIONS } from './InstanceConfiguration.constants'
 
 interface EnablePhysicalBackupsModalProps {
   selectedRegion: string
@@ -46,7 +48,7 @@ export const EnablePhysicalBackupsModal = ({ selectedRegion }: EnablePhysicalBac
       onSuccess: (data) => {
         if (data.is_physical_backups_enabled) {
           setRefetchInterval(false)
-          const regionKey = AWS_REGIONS_VALUES[selectedRegion]
+          const regionKey = AWS_REGIONS[selectedRegion as AWS_REGIONS_KEYS].code
 
           if (ref === undefined) return toast.error('Project ref is required')
           if (!regionKey)

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceConfiguration.constants.ts
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceConfiguration.constants.ts
@@ -1,7 +1,9 @@
 import { ReadReplicaSetupError, ReadReplicaSetupProgress } from '@supabase/shared-types/out/events'
 
 import { components } from 'data/api'
-import { AWS_REGIONS, AWS_REGIONS_KEYS, PROJECT_STATUS } from 'lib/constants'
+import { PROJECT_STATUS } from 'lib/constants'
+import type { AWS_REGIONS_KEYS } from 'shared-data'
+import { AWS_REGIONS } from 'shared-data'
 
 export interface Region {
   key: AWS_REGIONS_KEYS
@@ -44,33 +46,14 @@ export const FLY_REGIONS_COORDINATES: { [key: string]: [number, number] } = {
   SOUTHEAST_ASIA: [103.8, 1.37],
 }
 
-export const AWS_REGIONS_VALUES: { [key: string]: string } = {
-  SOUTHEAST_ASIA: 'ap-southeast-1',
-  NORTHEAST_ASIA: 'ap-northeast-1',
-  NORTHEAST_ASIA_2: 'ap-northeast-2',
-  CENTRAL_CANADA: 'ca-central-1',
-  WEST_US: 'us-west-1',
-  EAST_US: 'us-east-1',
-  WEST_EU: 'eu-west-1',
-  WEST_EU_2: 'eu-west-2',
-  CENTRAL_EU: 'eu-central-1',
-  SOUTH_ASIA: 'ap-south-1',
-  OCEANIA: 'ap-southeast-2',
-  SOUTH_AMERICA: 'sa-east-1',
-}
-
-export const FLY_REGIONS_VALUES: { [key: string]: string } = {
-  SOUTHEAST_ASIA: 'sin',
-}
-
 // [Joshen] Just to make sure that we just depend on AWS_REGIONS to determine available
 // regions for replicas. Just FYI - might need to update this if we support Fly in future
 export const AVAILABLE_REPLICA_REGIONS: Region[] = Object.keys(AWS_REGIONS)
   .map((key) => {
     return {
       key: key as AWS_REGIONS_KEYS,
-      name: AWS_REGIONS?.[key as AWS_REGIONS_KEYS],
-      region: AWS_REGIONS_VALUES[key],
+      name: AWS_REGIONS?.[key as AWS_REGIONS_KEYS].displayName,
+      region: AWS_REGIONS?.[key as AWS_REGIONS_KEYS].code,
       coordinates: AWS_REGIONS_COORDINATES[key],
     }
   })

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceConfiguration.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceConfiguration.tsx
@@ -17,8 +17,8 @@ import {
   useReadReplicasStatusesQuery,
 } from 'data/read-replicas/replicas-status-query'
 import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
-import { AWS_REGIONS_KEYS } from 'lib/constants'
 import { timeout } from 'lib/helpers'
+import { type AWS_REGIONS_KEYS } from 'shared-data'
 import { useSubscriptionPageStateSnapshot } from 'state/subscription-page'
 import {
   Button,

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/MapView.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/MapView.tsx
@@ -140,8 +140,9 @@ const MapView = ({
           {AVAILABLE_REPLICA_REGIONS.map((region) => {
             const dbs =
               databases.filter((database) => database.region.includes(region.region)) ?? []
-            const coordinates = AVAILABLE_REPLICA_REGIONS.find((r) => r.region === region.region)
-              ?.coordinates
+            const coordinates = AVAILABLE_REPLICA_REGIONS.find(
+              (r) => r.region === region.region
+            )?.coordinates
 
             const hasNoDatabases = dbs.length === 0
             const hasPrimary = dbs.some((database) => database.identifier === ref)

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/MapView.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/MapView.tsx
@@ -18,7 +18,8 @@ import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import { Database, useReadReplicasQuery } from 'data/read-replicas/replicas-query'
 import { formatDatabaseID } from 'data/read-replicas/replicas.utils'
 import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
-import { AWS_REGIONS_KEYS, BASE_PATH } from 'lib/constants'
+import { BASE_PATH } from 'lib/constants'
+import type { AWS_REGIONS_KEYS } from 'shared-data'
 import {
   Badge,
   Button,
@@ -139,9 +140,8 @@ const MapView = ({
           {AVAILABLE_REPLICA_REGIONS.map((region) => {
             const dbs =
               databases.filter((database) => database.region.includes(region.region)) ?? []
-            const coordinates = AVAILABLE_REPLICA_REGIONS.find(
-              (r) => r.region === region.region
-            )?.coordinates
+            const coordinates = AVAILABLE_REPLICA_REGIONS.find((r) => r.region === region.region)
+              ?.coordinates
 
             const hasNoDatabases = dbs.length === 0
             const hasPrimary = dbs.some((database) => database.identifier === ref)

--- a/apps/studio/data/misc/get-default-region-query.ts
+++ b/apps/studio/data/misc/get-default-region-query.ts
@@ -8,7 +8,8 @@ import {
   AWS_REGIONS_COORDINATES,
   FLY_REGIONS_COORDINATES,
 } from 'components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceConfiguration.constants'
-import { AWS_REGIONS, CloudProvider, FLY_REGIONS } from 'lib/constants'
+import type { CloudProvider } from 'shared-data'
+import { AWS_REGIONS, FLY_REGIONS } from 'shared-data'
 
 const RESTRICTED_POOL = ['WEST_US', 'CENTRAL_EU', 'SOUTHEAST_ASIA']
 
@@ -50,8 +51,8 @@ export async function getDefaultRegionOption({
     const closestRegion = Object.keys(locations)[distances.indexOf(shortestDistance)]
 
     return cloudProvider === 'AWS'
-      ? AWS_REGIONS[closestRegion as keyof typeof AWS_REGIONS]
-      : FLY_REGIONS[closestRegion as keyof typeof FLY_REGIONS]
+      ? AWS_REGIONS[closestRegion as keyof typeof AWS_REGIONS].displayName
+      : FLY_REGIONS[closestRegion as keyof typeof FLY_REGIONS].displayName
   } catch (error) {
     throw error
   }

--- a/apps/studio/lib/constants/infrastructure.ts
+++ b/apps/studio/lib/constants/infrastructure.ts
@@ -1,34 +1,7 @@
+import type { CloudProvider } from 'shared-data'
+import { AWS_REGIONS, FLY_REGIONS } from 'shared-data'
+
 import type { components } from 'data/api'
-
-export type CloudProvider = 'FLY' | 'AWS'
-export type Region = typeof AWS_REGIONS | typeof FLY_REGIONS
-
-// Alias regions remain as the starting point for project creation
-// they are immediately translated to their respective cloud regions
-// and are afterward never referred to
-
-export const AWS_REGIONS = {
-  WEST_US: 'West US (North California)',
-  EAST_US: 'East US (North Virginia)',
-  CENTRAL_CANADA: 'Canada (Central)',
-  WEST_EU: 'West EU (Ireland)',
-  WEST_EU_2: 'West EU (London)',
-  // 'North EU': 'North EU',
-  CENTRAL_EU: 'Central EU (Frankfurt)',
-  SOUTH_ASIA: 'South Asia (Mumbai)',
-  SOUTHEAST_ASIA: 'Southeast Asia (Singapore)',
-  NORTHEAST_ASIA: 'Northeast Asia (Tokyo)',
-  NORTHEAST_ASIA_2: 'Northeast Asia (Seoul)',
-  OCEANIA: 'Oceania (Sydney)',
-  SOUTH_AMERICA: 'South America (São Paulo)',
-  // SOUTH_AFRICA: 'South Africa (Cape Town)',
-} as const
-
-export type AWS_REGIONS_KEYS = keyof typeof AWS_REGIONS
-
-export const FLY_REGIONS = {
-  SOUTHEAST_ASIA: 'Singapore',
-} as const
 
 export const AWS_REGIONS_DEFAULT =
   process.env.NEXT_PUBLIC_ENVIRONMENT !== 'prod' ? AWS_REGIONS.SOUTHEAST_ASIA : AWS_REGIONS.EAST_US

--- a/apps/studio/pages/integrations/vercel/[slug]/deploy-button/new-project.tsx
+++ b/apps/studio/pages/integrations/vercel/[slug]/deploy-button/new-project.tsx
@@ -18,9 +18,10 @@ import { useVercelProjectsQuery } from 'data/integrations/integrations-vercel-pr
 import { useOrganizationsQuery } from 'data/organizations/organizations-query'
 import { useProjectCreateMutation } from 'data/projects/project-create-mutation'
 import { useSelectedOrganization } from 'hooks/misc/useSelectedOrganization'
-import { AWS_REGIONS, DEFAULT_MINIMUM_PASSWORD_STRENGTH, PROVIDERS } from 'lib/constants'
+import { PROVIDERS } from 'lib/constants'
 import { getInitialMigrationSQLFromGitHubRepo } from 'lib/integration-utils'
 import passwordStrength from 'lib/password-strength'
+import { AWS_REGIONS } from 'shared-data'
 import { useIntegrationInstallationSnapshot } from 'state/integration-installation'
 import type { NextPageWithLayout } from 'types'
 
@@ -60,7 +61,7 @@ const CreateProject = () => {
   const [passwordStrengthMessage, setPasswordStrengthMessage] = useState('')
   const [passwordStrengthScore, setPasswordStrengthScore] = useState(-1)
   const [shouldRunMigrations, setShouldRunMigrations] = useState(true)
-  const [dbRegion, setDbRegion] = useState(PROVIDERS.AWS.default_region)
+  const [dbRegion, setDbRegion] = useState(PROVIDERS.AWS.default_region.displayName)
 
   const snapshot = useIntegrationInstallationSnapshot()
 
@@ -68,25 +69,18 @@ const CreateProject = () => {
     debounce((value: string) => checkPasswordStrength(value), 300)
   ).current
 
-  const {
-    slug,
-    configurationId,
-    next,
-    currentProjectId: foreignProjectId,
-    externalId,
-  } = useParams()
+  const { slug, next, currentProjectId: foreignProjectId, externalId } = useParams()
 
-  const { mutateAsync: createConnections, isLoading: isLoadingCreateConnections } =
-    useIntegrationVercelConnectionsCreateMutation()
+  const { mutateAsync: createConnections } = useIntegrationVercelConnectionsCreateMutation()
   const { mutateAsync: syncEnvs } = useIntegrationsVercelConnectionSyncEnvsMutation()
 
-  const { data: organizationData, isLoading: isLoadingOrganizationsQuery } = useOrganizationsQuery()
+  const { data: organizationData } = useOrganizationsQuery()
   const organization = organizationData?.find((x) => x.slug === slug)
 
   /**
    * array of integrations installed
    */
-  const { data: integrationData, isLoading: integrationDataLoading } = useIntegrationsQuery()
+  const { data: integrationData } = useIntegrationsQuery()
 
   /**
    * the vercel integration installed for organization chosen
@@ -102,11 +96,6 @@ const CreateProject = () => {
     },
     { enabled: organizationIntegration !== undefined }
   )
-
-  const canSubmit =
-    projectName != '' &&
-    passwordStrengthScore >= DEFAULT_MINIMUM_PASSWORD_STRENGTH &&
-    dbRegion != undefined
 
   function onProjectNameChange(e: ChangeEvent<HTMLInputElement>) {
     e.target.value = e.target.value.replace(/\./g, '')
@@ -278,7 +267,7 @@ const CreateProject = () => {
             descriptionText="Select a region close to your users for the best performance."
           >
             {Object.keys(AWS_REGIONS).map((option: string, i) => {
-              const label = Object.values(AWS_REGIONS)[i]
+              const label = Object.values(AWS_REGIONS)[i].displayName
               return (
                 <Listbox.Option
                   key={option}

--- a/apps/studio/pages/new/[slug].tsx
+++ b/apps/studio/pages/new/[slug].tsx
@@ -38,7 +38,6 @@ import { useFlag } from 'hooks/ui/useFlag'
 import { getCloudProviderArchitecture } from 'lib/cloudprovider-utils'
 import {
   AWS_REGIONS_DEFAULT,
-  CloudProvider,
   DEFAULT_MINIMUM_PASSWORD_STRENGTH,
   DEFAULT_PROVIDER,
   FLY_REGIONS_DEFAULT,
@@ -46,6 +45,7 @@ import {
   PROVIDERS,
 } from 'lib/constants'
 import passwordStrength from 'lib/password-strength'
+import type { CloudProvider } from 'shared-data'
 import type { NextPageWithLayout } from 'types'
 import {
   Admonition,
@@ -415,7 +415,7 @@ const Wizard: NextPageWithLayout = () => {
 
   useEffect(() => {
     if (defaultRegionError) {
-      form.setValue('dbRegion', PROVIDERS[DEFAULT_PROVIDER].default_region)
+      form.setValue('dbRegion', PROVIDERS[DEFAULT_PROVIDER].default_region.displayName)
     }
   }, [defaultRegionError])
 
@@ -568,7 +568,9 @@ const Wizard: NextPageWithLayout = () => {
                                   field.onChange(value)
                                   form.setValue(
                                     'dbRegion',
-                                    value === 'FLY' ? FLY_REGIONS_DEFAULT : AWS_REGIONS_DEFAULT
+                                    value === 'FLY'
+                                      ? FLY_REGIONS_DEFAULT.displayName
+                                      : AWS_REGIONS_DEFAULT.displayName
                                   )
                                 }}
                                 defaultValue={field.value}

--- a/apps/studio/pages/vercel/setupProject.tsx
+++ b/apps/studio/pages/vercel/setupProject.tsx
@@ -18,13 +18,13 @@ import { Loading } from 'components/ui/Loading'
 import PasswordStrengthBar from 'components/ui/PasswordStrengthBar'
 import { useProjectCreateMutation } from 'data/projects/project-create-mutation'
 import {
-  AWS_REGIONS,
   DEFAULT_MINIMUM_PASSWORD_STRENGTH,
   PRICING_TIER_PRODUCT_IDS,
   PROVIDERS,
 } from 'lib/constants'
 import passwordStrength from 'lib/password-strength'
 import { VERCEL_INTEGRATION_CONFIGS } from 'lib/vercelConfigs'
+import { AWS_REGIONS } from 'shared-data'
 
 interface ISetupProjectStore {
   token: string
@@ -150,7 +150,7 @@ const CreateProject = observer(() => {
   const [dbPass, setDbPass] = useState('')
   const [passwordStrengthMessage, setPasswordStrengthMessage] = useState('')
   const [passwordStrengthScore, setPasswordStrengthScore] = useState(-1)
-  const [dbRegion, setDbRegion] = useState(PROVIDERS.AWS.default_region)
+  const [dbRegion, setDbRegion] = useState(PROVIDERS.AWS.default_region.displayName)
 
   const delayedCheckPasswordStrength = useRef(
     debounce((value: string) => checkPasswordStrength(value), 300)
@@ -232,7 +232,7 @@ const CreateProject = observer(() => {
         organizationId: Number(_store.supabaseOrgId),
         name: projectName,
         dbPass: dbPass,
-        dbRegion: dbRegion,
+        dbRegion,
         dbSql: dbSql || '',
         dbPricingTierId: PRICING_TIER_PRODUCT_IDS.FREE,
         authSiteUrl: _store.selectedVercelProjectUrl,
@@ -286,7 +286,7 @@ const CreateProject = observer(() => {
             descriptionText="Select a region close to your users for the best performance."
           >
             {Object.keys(AWS_REGIONS).map((option: string, i) => {
-              const label = Object.values(AWS_REGIONS)[i]
+              const label = Object.values(AWS_REGIONS)[i].displayName
               return (
                 <Listbox.Option
                   key={option}

--- a/packages/shared-data/index.ts
+++ b/packages/shared-data/index.ts
@@ -1,11 +1,24 @@
-import tweets from './tweets'
+import config from './config'
+import extensions from './extensions.json'
 import logConstants from './logConstants'
 import { plans, PricingInformation } from './plans'
 import { pricing } from './pricing'
 import { products } from './products'
 import questions from './questions'
-import extensions from './extensions.json'
-import config from './config'
+import type { AWS_REGIONS_KEYS, CloudProvider, Region } from './regions'
+import { AWS_REGIONS, FLY_REGIONS } from './regions'
+import tweets from './tweets'
 
-export { config, tweets, logConstants, plans, pricing, products, questions, extensions }
-export type { PricingInformation }
+export type { AWS_REGIONS_KEYS, CloudProvider, PricingInformation, Region }
+export {
+  AWS_REGIONS,
+  FLY_REGIONS,
+  config,
+  extensions,
+  logConstants,
+  plans,
+  pricing,
+  products,
+  questions,
+  tweets,
+}

--- a/packages/shared-data/regions.ts
+++ b/packages/shared-data/regions.ts
@@ -1,0 +1,23 @@
+export type CloudProvider = 'FLY' | 'AWS'
+export type Region = typeof AWS_REGIONS | typeof FLY_REGIONS
+
+export const AWS_REGIONS = {
+  WEST_US: { code: 'us-west-1', displayName: 'West US (North California)' },
+  EAST_US: { code: 'us-east-1', displayName: 'East US (North Virginia)' },
+  CENTRAL_CANADA: { code: 'ca-central-1', displayName: 'Canada (Central)' },
+  WEST_EU: { code: 'eu-west-1', displayName: 'West EU (Ireland)' },
+  WEST_EU_2: { code: 'eu-west-2', displayName: 'West EU (London)' },
+  CENTRAL_EU: { code: 'eu-central-1', displayName: 'Central EU (Frankfurt)' },
+  SOUTH_ASIA: { code: 'ap-south-1', displayName: 'South Asia (Mumbai)' },
+  SOUTHEAST_ASIA: { code: 'ap-southeast-1', displayName: 'Southeast Asia (Singapore)' },
+  NORTHEAST_ASIA: { code: 'ap-northeast-1', displayName: 'Northeast Asia (Tokyo)' },
+  NORTHEAST_ASIA_2: { code: 'ap-northeast-2', displayName: 'Northeast Asia (Seoul)' },
+  OCEANIA: { code: 'ap-southeast-2', displayName: 'Oceania (Sydney)' },
+  SOUTH_AMERICA: { code: 'sa-east-1', displayName: 'South America (São Paulo)' },
+} as const
+
+export type AWS_REGIONS_KEYS = keyof typeof AWS_REGIONS
+
+export const FLY_REGIONS = {
+  SOUTHEAST_ASIA: { code: 'sin', displayName: 'Singapore' },
+} as const


### PR DESCRIPTION
Adds list of supported AWS regions to docs.

Pulls the region information into `shared-data` package to provide common source of truth for dashboard and docs.