### PR TITLE
Update generating-types.mdx

### DIFF
--- a/apps/docs/content/guides/api/rest/generating-types.mdx
+++ b/apps/docs/content/guides/api/rest/generating-types.mdx
@@ -37,13 +37,13 @@ npx supabase init
 Generate types for your project to produce the `types/supabase.ts` file:
 
 ```bash
-npx supabase gen types typescript --project-id "$PROJECT_REF" --schema public > types/supabase.ts
+npx supabase gen types --lang=typescript --project-id "$PROJECT_REF" --schema public > types/supabase.ts
 ```
 
 or in case of local development:
 
 ```bash
-npx supabase gen types typescript --local > types/supabase.ts
+npx supabase gen types --lang=typescript --local > types/supabase.ts
 ```
 
 These types are generated from your database schema. Given a table `public.movies`, the generated types will look like:
@@ -209,7 +209,7 @@ One way to keep your type definitions in sync with your database is to set up a 
 Add the following script to your `package.json` to run it using `npm run update-types`
 
 ```json
-"update-types": "npx supabase gen types typescript --project-id \"$PROJECT_REF\" > types/supabase.ts"
+"update-types": "npx supabase gen types --lang=typescript --project-id \"$PROJECT_REF\" > types/supabase.ts"
 ```
 
 Create a file `.github/workflows/update-types.yml` with the following snippet to define the action along with the environment variables. This script will commit new type changes to your repo every night.


### PR DESCRIPTION
Command "typescript" is deprecated, use "gen types --lang=typescript" instead.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Error when run `npx supabase gen types typescript --project-id "<PROJECT_ID>" --schema public > types/supabase.ts`
Error: Command "typescript" is deprecated, use "gen types --lang=typescript" instead.

## What is the new behavior?

The solution to the problem is to use -lang=typescript

## Additional context

Update the docs
