### PR TITLE
fix(pagination): Calculate any selectedRows in useMemo and Ensure cancel is called after confirm

### DIFF
--- a/apps/studio/components/grid/components/footer/pagination/Pagination.tsx
+++ b/apps/studio/components/grid/components/footer/pagination/Pagination.tsx
@@ -1,5 +1,5 @@
 import { ArrowLeft, ArrowRight, HelpCircle } from 'lucide-react'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { PostgresTable } from '@supabase/postgres-meta'
 
 import { formatFilterURLParams } from 'components/grid/SupabaseGrid.utils'
@@ -74,9 +74,11 @@ const Pagination = () => {
   const maxPages = Math.ceil((data?.count ?? 0) / snap.rowsPerPage)
   const totalPages = (data?.count ?? 0) > 0 ? maxPages : 1
 
+  const hasAnySelectedRows = useMemo(() => state.selectedRows.size >= 1, [state.selectedRows])
+
   const onPreviousPage = () => {
     if (page > 1) {
-      if (state.selectedRows.size >= 1) {
+      if (hasAnySelectedRows) {
         setIsConfirmPreviousModalOpen(true)
       } else {
         goToPreviousPage()
@@ -94,7 +96,7 @@ const Pagination = () => {
 
   const onNextPage = () => {
     if (page < maxPages) {
-      if (state.selectedRows.size >= 1) {
+      if (hasAnySelectedRows) {
         setIsConfirmNextModalOpen(true)
       } else {
         goToNextPage()

--- a/packages/ui-patterns/Dialogs/ConfirmationModal.tsx
+++ b/packages/ui-patterns/Dialogs/ConfirmationModal.tsx
@@ -73,6 +73,7 @@ const ConfirmationModal = forwardRef<
       e.stopPropagation()
       setLoading(true)
       onConfirm()
+      onCancel()
     }
 
     return (


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Select some rows in Table editor, then go to next page, since confirmation modal is not being open, the selected rows are incorrect. But since the problem is that state changes are not being reflected in pagination component, it only works problematic if select only 1 row.

https://github.com/supabase/supabase/issues/27921

Also, I noticed that we should call `onCancel` after clicking confirm in the opening confirmation modal

## What is the new behavior?

If there is any selected rows before changing the page, we are showing a confirmation modal now.

## Additional context

- Calculated anySelectedRow exist information from state in useMemo to ensure state changes are reflected when selectedRows.size >= 1.
- Added a call to cancel after confirm in the confirmation modal.

