### PR TITLE
chore: skip import of combined JS spec for non-JS docs

### DIFF
--- a/apps/docs/pages/reference/csharp/crawlers/[...slug].tsx
+++ b/apps/docs/pages/reference/csharp/crawlers/[...slug].tsx
@@ -1,5 +1,4 @@
 import clientLibsCommonSections from '~/spec/common-client-libs-sections.json'
-import typeSpec from '~/spec/enrichments/tsdoc_v2/combined.json'
 import spec from '~/spec/supabase_csharp_v1.yml' assert { type: 'yml' }
 import RefSectionHandler from '~/components/reference/RefSectionHandler'
 import { flattenSections } from '~/lib/helpers'
@@ -30,7 +29,6 @@ export default function CSharpReference(props) {
         menuId={MenuId.RefCSharpV1}
         sections={filteredSection}
         spec={spec}
-        typeSpec={typeSpec as TypeSpec}
         pageProps={props}
         type="client-lib"
       />

--- a/apps/docs/pages/reference/csharp/v0/crawlers/[...slug].tsx
+++ b/apps/docs/pages/reference/csharp/v0/crawlers/[...slug].tsx
@@ -1,5 +1,4 @@
 import clientLibsCommonSections from '~/spec/common-client-libs-sections.json'
-import typeSpec from '~/spec/enrichments/tsdoc_v2/combined.json'
 import spec from '~/spec/supabase_csharp_v0.yml' assert { type: 'yml' }
 import RefSectionHandler from '~/components/reference/RefSectionHandler'
 import { flattenSections } from '~/lib/helpers'
@@ -28,7 +27,6 @@ export default function JSReference(props) {
         menuId={MenuId.RefCSharpV0}
         sections={filteredSection}
         spec={spec}
-        typeSpec={typeSpec}
         pageProps={props}
         type="client-lib"
       />

--- a/apps/docs/pages/reference/dart/crawlers/[...slug].tsx
+++ b/apps/docs/pages/reference/dart/crawlers/[...slug].tsx
@@ -1,5 +1,4 @@
 import clientLibsCommonSections from '~/spec/common-client-libs-sections.json'
-import typeSpec from '~/spec/enrichments/tsdoc_v2/combined.json'
 import spec from '~/spec/supabase_dart_v2.yml' assert { type: 'yml' }
 import RefSectionHandler from '~/components/reference/RefSectionHandler'
 import { flattenSections } from '~/lib/helpers'
@@ -29,7 +28,6 @@ export default function DartReference(props) {
         menuId={MenuId.RefDartV2}
         sections={filteredSection}
         spec={spec}
-        typeSpec={typeSpec}
         pageProps={props}
         type="client-lib"
       />

--- a/apps/docs/pages/reference/dart/v1/crawlers/[...slug].tsx
+++ b/apps/docs/pages/reference/dart/v1/crawlers/[...slug].tsx
@@ -1,5 +1,4 @@
 import clientLibsCommonSections from '~/spec/common-client-libs-sections.json'
-import typeSpec from '~/spec/enrichments/tsdoc_v2/combined.json'
 import spec from '~/spec/supabase_dart_v1.yml' assert { type: 'yml' }
 import RefSectionHandler from '~/components/reference/RefSectionHandler'
 import { flattenSections } from '~/lib/helpers'
@@ -28,7 +27,6 @@ export default function DartReference(props) {
         menuId={MenuId.RefDartV1}
         sections={filteredSection}
         spec={spec}
-        typeSpec={typeSpec}
         pageProps={props}
         type="client-lib"
       />

--- a/apps/docs/pages/reference/javascript/v1/crawlers/[...slug].tsx
+++ b/apps/docs/pages/reference/javascript/v1/crawlers/[...slug].tsx
@@ -1,5 +1,5 @@
 import clientLibsCommonSections from '~/spec/common-client-libs-sections.json'
-import typeSpec from '~/spec/enrichments/tsdoc_v2/combined.json'
+import typeSpec from '~/spec/enrichments/tsdoc_v1/combined.json'
 import spec from '~/spec/supabase_js_v1.yml' assert { type: 'yml' }
 import RefSectionHandler from '~/components/reference/RefSectionHandler'
 import { flattenSections } from '~/lib/helpers'

--- a/apps/docs/pages/reference/kotlin/crawlers/[...slug].tsx
+++ b/apps/docs/pages/reference/kotlin/crawlers/[...slug].tsx
@@ -1,5 +1,4 @@
 import clientLibsCommonSections from '~/spec/common-client-libs-sections.json'
-import typeSpec from '~/spec/enrichments/tsdoc_v2/combined.json'
 import spec from '~/spec/supabase_kt_v2.yml' assert { type: 'yml' }
 import RefSectionHandler from '~/components/reference/RefSectionHandler'
 import { flattenSections } from '~/lib/helpers'
@@ -29,7 +28,6 @@ export default function KotlinReference(props) {
         menuId={MenuId.RefKotlinV2}
         sections={filteredSection}
         spec={spec}
-        typeSpec={typeSpec}
         pageProps={props}
         type="client-lib"
       />

--- a/apps/docs/pages/reference/kotlin/v1/crawlers/[...slug].tsx
+++ b/apps/docs/pages/reference/kotlin/v1/crawlers/[...slug].tsx
@@ -1,5 +1,4 @@
 import clientLibsCommonSections from '~/spec/common-client-libs-sections.json'
-import typeSpec from '~/spec/enrichments/tsdoc_v2/combined.json'
 import spec from '~/spec/supabase_kt_v1.yml' assert { type: 'yml' }
 import RefSectionHandler from '~/components/reference/RefSectionHandler'
 import { flattenSections } from '~/lib/helpers'
@@ -28,7 +27,6 @@ export default function KotlinReference(props) {
         menuId={MenuId.RefKotlinV1}
         sections={filteredSection}
         spec={spec}
-        typeSpec={typeSpec}
         pageProps={props}
         type="client-lib"
       />

--- a/apps/docs/pages/reference/python/[...slug].tsx
+++ b/apps/docs/pages/reference/python/[...slug].tsx
@@ -1,5 +1,4 @@
 import clientLibsCommonSections from '~/spec/common-client-libs-sections.json'
-import typeSpec from '~/spec/enrichments/tsdoc_v2/combined.json'
 import spec from '~/spec/supabase_py_v2.yml' assert { type: 'yml' }
 import RefSectionHandler from '~/components/reference/RefSectionHandler'
 import { flattenSections } from '~/lib/helpers'
@@ -16,7 +15,6 @@ export default function PyReference(props) {
       menuId={MenuId.RefPythonV2}
       sections={sections}
       spec={spec}
-      typeSpec={typeSpec}
       pageProps={props}
       type="client-lib"
     />

--- a/apps/docs/pages/reference/python/crawlers/[...slug].tsx
+++ b/apps/docs/pages/reference/python/crawlers/[...slug].tsx
@@ -1,5 +1,4 @@
 import clientLibsCommonSections from '~/spec/common-client-libs-sections.json'
-import typeSpec from '~/spec/enrichments/tsdoc_v2/combined.json'
 import spec from '~/spec/supabase_py_v2.yml' assert { type: 'yml' }
 import RefSectionHandler from '~/components/reference/RefSectionHandler'
 import { flattenSections } from '~/lib/helpers'
@@ -29,7 +28,6 @@ export default function PyReference(props) {
         menuId={MenuId.RefPythonV2}
         sections={filteredSection}
         spec={spec}
-        typeSpec={typeSpec}
         pageProps={props}
         type="client-lib"
       />

--- a/apps/docs/pages/reference/swift/crawlers/[...slug].tsx
+++ b/apps/docs/pages/reference/swift/crawlers/[...slug].tsx
@@ -1,5 +1,4 @@
 import clientLibsCommonSections from '~/spec/common-client-libs-sections.json'
-import typeSpec from '~/spec/enrichments/tsdoc_v2/combined.json'
 import spec from '~/spec/supabase_swift_v2.yml' assert { type: 'yml' }
 import RefSectionHandler from '~/components/reference/RefSectionHandler'
 import { flattenSections } from '~/lib/helpers'
@@ -29,7 +28,6 @@ export default function SwiftReference(props) {
         menuId={MenuId.RefSwiftV2}
         sections={filteredSection}
         spec={spec}
-        typeSpec={typeSpec}
         pageProps={props}
         type="client-lib"
       />

--- a/apps/docs/pages/reference/swift/v1/crawlers/[...slug].tsx
+++ b/apps/docs/pages/reference/swift/v1/crawlers/[...slug].tsx
@@ -1,5 +1,4 @@
 import clientLibsCommonSections from '~/spec/common-client-libs-sections.json'
-import typeSpec from '~/spec/enrichments/tsdoc_v2/combined.json'
 import spec from '~/spec/supabase_swift_v2.yml' assert { type: 'yml' }
 import RefSectionHandler from '~/components/reference/RefSectionHandler'
 import { flattenSections } from '~/lib/helpers'
@@ -28,7 +27,6 @@ export default function SwiftReference(props) {
         menuId={MenuId.RefSwiftV1}
         sections={filteredSection}
         spec={spec}
-        typeSpec={typeSpec}
         pageProps={props}
         type="client-lib"
       />


### PR DESCRIPTION
The combined JS docs are only needed for JS and not for other languages. As discussed with Charis

Also fixed a wrong import of the v2 spec for v1 docs