### PR TITLE
docs: fix env configuration vars for Redwood

### DIFF
--- a/apps/docs/content/guides/getting-started/quickstarts/redwoodjs.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/redwoodjs.mdx
@@ -90,19 +90,19 @@ hideToc: true
 
       In your `.env` file, add the following environment variables for your database connection:
 
-      * The `DIRECT_URL` should use the Transaction mode connection string you copied in Step 1.
+      * The `DATABASE_URL` should use the Transaction mode connection string you copied in Step 1.
 
-      * The `DATABASE_URL` should use the Session mode connection string you copied in Step 1.
+      * The `DIRECT_URL` should use the Session mode connection string you copied in Step 1.
 
     </StepHikeCompact.Details>
 
     <StepHikeCompact.Code>
       ```bash .env
       # Transaction mode connection string used for migrations
-      DIRECT_URL="postgres://postgres.[project-ref]:[db-password]@xxx.pooler.supabase.com:6543/postgres?pgbouncer=true&connection_limit=1"
+      DATABASE_URL="postgres://postgres.[project-ref]:[db-password]@xxx.pooler.supabase.com:6543/postgres?pgbouncer=true&connection_limit=1"
 
       # Session mode connection string — used by Prisma Client
-      DATABASE_URL="postgres://postgres.[project-ref]:[db-password]@xxx.pooler.supabase.com:5432/postgres"
+      DIRECT_URL="postgres://postgres.[project-ref]:[db-password]@xxx.pooler.supabase.com:5432/postgres"
       ```
     </StepHikeCompact.Code>
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Fixes documentation error in Supabase with Redwood setup. `DATABASE_URL` and `DIRECT_URL` should be inverted (https://github.com/supabase/supabase/issues/26953).


## What is the current behavior?

See https://github.com/supabase/supabase/issues/26953#issuecomment-2239741318.

## What is the new behavior?

Env variables have been swapped with the correct example and description.