### PR TITLE
chore: only lint in CI, not on Vercel

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,4 +1,4 @@
-name: Check code with TypeScript
+name: Check code with TypeScript & Lint
 
 on:
   pull_request:
@@ -30,3 +30,6 @@ jobs:
 
       - name: Run TypeScript type check
         run: npx turbo run typecheck
+
+      - name: Run Lint
+        run: npx turbo run lint

--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -150,6 +150,10 @@ const nextConfig = {
     // Typechecking is checked separately via .github/workflows/typecheck.yml
     ignoreBuildErrors: true,
   },
+  eslint: {
+    // We are already running linting via GH action, this will skip linting during production build on Vercel
+    ignoreDuringBuilds: true,
+  },
 }
 
 const configExport = () => {

--- a/apps/studio/next.config.js
+++ b/apps/studio/next.config.js
@@ -469,6 +469,10 @@ const nextConfig = {
     // Typechecking is checked separately via .github/workflows/typecheck.yml
     ignoreBuildErrors: true,
   },
+  eslint: {
+    // We are already running linting via GH action, this will skip linting during production build on Vercel
+    ignoreDuringBuilds: true,
+  },
 }
 
 // module.exports = withBundleAnalyzer(nextConfig)

--- a/apps/www/next.config.mjs
+++ b/apps/www/next.config.mjs
@@ -93,6 +93,15 @@ const nextConfig = {
   async redirects() {
     return redirects
   },
+  typescript: {
+    // WARNING: production builds can successfully complete even there are type errors
+    // Typechecking is checked separately via .github/workflows/typecheck.yml
+    ignoreBuildErrors: true,
+  },
+  eslint: {
+    // We are already running linting via GH action, this will skip linting during production build on Vercel
+    ignoreDuringBuilds: true,
+  },
 }
 
 // next.config.js.


### PR DESCRIPTION
Same as typechecking, we will lint through GH actions, but no longer on Vercel to speed up builds.

Also added the typecheck skips for www
