### PR TITLE
fix: add missing quotation mark in studio service health check test in docker-compose.yml

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -18,7 +18,7 @@ services:
           "CMD",
           "node",
           "-e",
-          "require('http').get('http://localhost:3000/api/profile', (r) => {if (r.statusCode !== 200) throw new Error(r.statusCode)})"
+          "\"require('http').get('http://localhost:3000/api/profile', (r) => {if (r.statusCode !== 200) throw new Error(r.statusCode)})\""
         ]
       timeout: 5s
       interval: 5s


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?
Add missing quotation mark in healthcheck in docker-compose.yml

## What is the current behavior?
#28105 
<img width="1109" alt="image" src="https://github.com/user-attachments/assets/1d5f6220-3d97-4bc1-944a-ceb38d324d39">


## What is the new behavior?

<img width="1046" alt="image" src="https://github.com/user-attachments/assets/784c35e5-cf60-432c-b7a2-7601608d96bd">


## Additional context

Add any other context or screenshots.
