### PR TITLE
fix: handle inherited tables definitions

### DIFF
--- a/apps/studio/data/database/database-table-definition.ts
+++ b/apps/studio/data/database/database-table-definition.ts
@@ -206,7 +206,7 @@ export const CREATE_PG_GET_TABLEDEF_SQL = minify(
             WHERE t.table_schema=s.table_schema AND t.table_name=s.table_name AND t.table_schema = in_schema AND t.table_name = in_table AND t.table_type = 'BASE TABLE');      		  
             
             --Issue#19 put double-quotes around SQL keyword column names
-            SELECT COUNT(*) INTO v_cnt2 FROM pg_get_keywords() WHERE word = v_colrec.column_name AND catcode = 'R';
+            SELECT COUNT(*) INTO v_cnt2 FROM pg_get_keywords() WHERE word = in_table AND catcode = 'R';
             
             IF bInheritance THEN
               -- inheritance-based


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

After creating two simple tables like such:

```sql
create table public.parent (foo text null);
create table public.child (bar text null) inherits (parent);
```

Checking the table definition for `child` errors with a `400` and displays a blank page:

<img width="1718" alt="image" src="https://github.com/user-attachments/assets/dd029589-4133-4ce3-a68e-22049aba536e">

## What is the new behavior?

After creating the same tables as above, the definition of the table is displayed correctly:

<img width="1714" alt="image" src="https://github.com/user-attachments/assets/7d87bc44-16b6-4012-8c75-bed51c752cc9">

## Additional context

Currently, when displaying the definition of a table that was created as inherited from another table (via the `inherit` keyword), the server errors.

This is due to the fact that in the `CREATE_PG_GET_TABLEDEF_SQL` query the variable `v_colrec` is used when still not initialized.

This commit fixes this by using the correct variable: `in_table`.

Reference: https://github.com/MichaelDBA/pg_get_tabledef/commit/c330a897d6afc710dabd21f1632ad767b3fafaa1#diff-455c3b153a7da564b1a3c4660a53bad68ac681f08c37d2cbd6da76375a36f76dR277
