### PR TITLE
fix chart widths

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityPanel.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityPanel.tsx
@@ -99,7 +99,7 @@ const UtilityPanel = ({
   const chartConfig = getChartConfig()
 
   function onConfigChange(config: ChartConfig) {
-    if (!ref || !snippet.id) return
+    if (!ref || !snippet?.id) return
 
     upsertContent({
       projectRef: ref,

--- a/apps/studio/components/to-be-cleaned/Charts/ChartHandler.tsx
+++ b/apps/studio/components/to-be-cleaned/Charts/ChartHandler.tsx
@@ -167,6 +167,9 @@ const ChartHandler = ({
       </div>
       {chartStyle === 'bar' ? (
         <BarChart
+          YAxisProps={{
+            width: 1,
+          }}
           data={(chartData?.data ?? []) as any}
           format={format || chartData?.format}
           xAxisKey={'period_start'}

--- a/apps/studio/components/ui/Charts/BarChart.tsx
+++ b/apps/studio/components/ui/Charts/BarChart.tsx
@@ -68,6 +68,7 @@ const BarChart = ({
   const _YAxisProps = YAxisProps || {
     tickFormatter: (value) => numberFormatter(value, valuePrecision),
     tick: false,
+    width: 0,
   }
 
   const day = (value: number | string) => (displayDateInUtc ? dayjs(value).utc() : dayjs(value))

--- a/apps/studio/components/ui/Charts/BarChart.tsx
+++ b/apps/studio/components/ui/Charts/BarChart.tsx
@@ -121,12 +121,6 @@ const BarChart = ({
       <Container>
         <RechartBarChart
           data={data}
-          margin={{
-            top: 0,
-            right: 0,
-            left: -58, // [Joshen] 120724 Not sure why bar charts have a weird left margin suddenly, but this is a temp fix
-            bottom: 0,
-          }}
           className="overflow-visible"
           //   mouse hover focusing logic
           onMouseMove={(e: any) => {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

- fixes left margin in some charts (it was due to the Y axis being min 60px in width even when its empty)
- fixes the chart in sql editor not fitting the viewport 