### PR TITLE
fix: update next.js oauth pkce flow docs

### DIFF
--- a/apps/docs/components/MDX/oauth_pkce_flow.mdx
+++ b/apps/docs/components/MDX/oauth_pkce_flow.mdx
@@ -71,7 +71,16 @@ export async function GET(request: Request) {
     const supabase = createClient()
     const { error } = await supabase.auth.exchangeCodeForSession(code)
     if (!error) {
-      return NextResponse.redirect(`${origin}${next}`)
+      const forwardedHost = request.headers.get('x-forwarded-host') // original origin before load balancer
+      const isLocalEnv = process.env.NODE_ENV === 'development'
+      if (isLocalEnv) {
+        // we can be sure that there is no load balancer in between, so no need to watch for X-Forwarded-Host
+        return NextResponse.redirect(`${origin}${next}`)
+      } else if (forwardedHost) {
+        return NextResponse.redirect(`https://${forwardedHost}${next}`)
+      } else {
+        return NextResponse.redirect(`${origin}${next}`)
+      }
     }
   }
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

fix for issue #27614 

## What is the current behavior?

#27614 

As described in the issue: 

> When using a custom domain and Azure Oauth provider, the provided /auth/callback example in the docs is not working, since the {origin} will be http://localhost:8080/.

## What is the new behavior?

Oauth section in the docs got updated as the following:

```js
const { error } = await supabase.auth.exchangeCodeForSession(code)
    if (!error) {
      const forwardedHost = request.headers.get("x-forwarded-host") // original origin before load balancer
      const isLocalEnv = process.env.NODE_ENV === "development"
      if (isLocalEnv) {
        // we can be sure that there is no load balancer in between, so no need to watch for X-Forwarded-Host
        return NextResponse.redirect(`${origin}${next}`)
      } else if (forwardedHost) {
        return NextResponse.redirect(`https://${forwardedHost}${next}`)
      } else {
        return NextResponse.redirect(`${origin}${next}`)
      }
    }
```

## Additional context

[Doc Link](https://supabase.com/docs/guides/auth/social-login/auth-azure#add-login-code-to-your-client-app)

Note: as the oauth pkce flow file get updated, it is expected that other pages that uses this file gets affected.
