### PR TITLE
fix: allow spaces in snippet search

### DIFF
--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorMenu.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorMenu.tsx
@@ -142,7 +142,7 @@ export const SQLEditorMenu = ({ onViewOngoingQueries }: { onViewOngoingQueries: 
                     placeholder="Search queries..."
                     aria-labelledby="Search queries"
                     value={searchText}
-                    onChange={(e) => setSearchText(e.target.value.trim())}
+                    onChange={(e) => setSearchText(e.target.value)}
                   >
                     <InnerSideBarFilterSortDropdown
                       value={snapV2.order}

--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV1.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV1.tsx
@@ -32,13 +32,14 @@ interface SQLEditorNavV1Props {
 }
 
 export const SQLEditorNavV1 = ({
-  searchText,
+  searchText: _searchText,
   selectedQueries,
   handleNewQuery,
   setSearchText,
   setSelectedQueries,
   setShowDeleteModal,
 }: SQLEditorNavV1Props) => {
+  const searchText = _searchText.trim()
   const router = useRouter()
   const { ref, id: activeId } = useParams()
   const enableFolders = useFlag('sqlFolderOrganization')
@@ -168,14 +169,15 @@ export const SQLEditorNavV1 = ({
               <InnerSideBarFilterSearchInput
                 name="search-queries"
                 placeholder="Search queries..."
-                onChange={(e) => setSearchText(e.target.value.trim())}
-                value={searchText}
+                onChange={(e) => setSearchText(e.target.value)}
+                value={_searchText}
                 aria-labelledby="Search queries"
               />
             </InnerSideBarFilters>
           )}
 
           {searchText.length > 0 &&
+            personalSnippets.length === 0 &&
             filteredProjectSnippets.length === 0 &&
             filteredFavoriteSnippets.length === 0 &&
             filteredProjectSnippets.length === 0 && (

--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorNav.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorNav.tsx
@@ -49,7 +49,8 @@ interface SQLEditorNavProps {
   searchText: string
 }
 
-export const SQLEditorNav = ({ searchText }: SQLEditorNavProps) => {
+export const SQLEditorNav = ({ searchText: _searchText }: SQLEditorNavProps) => {
+  const searchText = _searchText.trim()
   const router = useRouter()
   const { profile } = useProfile()
   const project = useSelectedProject()


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The space key does nothing when using the "search queries" input on `/project/_/sql`

## What is the new behavior?

It work