### PR TITLE
Add fdw and migrations to cmd k nav

### DIFF
--- a/packages/ui-patterns/Cmdk/utils/shared-nav-items.json
+++ b/packages/ui-patterns/Cmdk/utils/shared-nav-items.json
@@ -47,6 +47,14 @@
         {
           "label": "Backups",
           "url": "/project/_/database/backups/scheduled"
+        },
+        {
+          "label": "Wrappers",
+          "url": "/project/_/database/wrappers"
+        },
+        {
+          "label": "Migrations",
+          "url": "/project/_/database/migrations"
         }
       ]
     },


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

- open ⌘ k 
- search migrations or wrappers 
- navigate there