### PR TITLE
fix: use parent ref for contact support button when in a branch

### DIFF
--- a/apps/studio/components/layouts/ProjectLayout/LayoutHeader/HelpPopover.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/LayoutHeader/HelpPopover.tsx
@@ -3,6 +3,7 @@ import Image from 'next/legacy/image'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import SVG from 'react-inlinesvg'
+
 import {
   Button,
   IconActivity,
@@ -16,10 +17,12 @@ import {
   PopoverTrigger_Shadcn_,
   Popover_Shadcn_,
 } from 'ui'
+import { useProjectContext } from '../ProjectContext'
 
 const HelpPopover = () => {
   const router = useRouter()
-  const projectRef = router.query.ref
+  const { project } = useProjectContext()
+  const projectRef = project?.parent_project_ref ?? router.query.ref
   const supportUrl = `/support/new${projectRef ? `?ref=${projectRef}` : ''}`
 
   return (


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix – we don't allow branch projects to be selected when emailing support

## What is the current behavior?

Wonky looking selector after clicking contact support when on a branch
<img width="617" alt="Screenshot 2024-07-26 at 17 48 27" src="https://github.com/user-attachments/assets/e4e07827-89e6-4b7c-ab91-c9b40dcdd7c9">

## What is the new behavior?

Properly selects parent project ref


