### PR TITLE
Adjust texts shown when user doesn't have permission for org settings

### DIFF
--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/BillingBreakdown.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/BillingBreakdown.tsx
@@ -52,7 +52,7 @@ const BillingBreakdown = () => {
       </ScaffoldSectionDetail>
       <ScaffoldSectionContent>
         {!canReadSubscriptions ? (
-          <NoPermission resourceText="view this organization's billing" />
+          <NoPermission resourceText="view this organization's billing breakdown" />
         ) : (
           <>
             {isLoadingSubscription && (

--- a/apps/studio/components/interfaces/Organization/OAuthApps/OAuthApps.tsx
+++ b/apps/studio/components/interfaces/Organization/OAuthApps/OAuthApps.tsx
@@ -61,7 +61,7 @@ const OAuthApps = () => {
   if (!canReadOAuthApps) {
     return (
       <ScaffoldContainerLegacy>
-        <NoPermission resourceText="view invoices" />
+        <NoPermission resourceText="view OAuth apps" />
       </ScaffoldContainerLegacy>
     )
   }

--- a/apps/studio/components/ui/NoPermission.tsx
+++ b/apps/studio/components/ui/NoPermission.tsx
@@ -22,7 +22,7 @@ const NoPermission = ({ resourceText, isFullPage = false }: NoPermissionProps) =
             <p className="text-sm">You need additional permissions to {resourceText}</p>
             <div>
               <p className="text-sm text-foreground-light">
-                Contact your organization owner or adminstrator for assistance.
+                Contact your organization owner or administrator for assistance.
               </p>
             </div>
           </div>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix wording of texts shown to the user if they don't have permission to view/edit parts of org settings
