### PR TITLE
fix: sign up redirect

### DIFF
--- a/apps/studio/components/layouts/SignInLayout/SignInLayout.tsx
+++ b/apps/studio/components/layouts/SignInLayout/SignInLayout.tsx
@@ -63,11 +63,6 @@ const SignInLayout = ({
 
           await queryClient.resetQueries()
           router.push(getReturnToPath())
-        } else {
-          // if the user doesn't have a token, he needs to go back to the sign-in page
-          const redirectTo = buildPathWithParams('/sign-in')
-          router.replace(redirectTo)
-          return
         }
       })
       .catch(() => {}) // catch all errors thrown by auth methods


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

`/sign-up` and `/sign-in-sso` are inaccessible via direct link
