### PR TITLE
Fix old listbox text colours 

### DIFF
--- a/apps/studio/components/interfaces/Database/Wrappers/WrapperTableEditor.tsx
+++ b/apps/studio/components/interfaces/Database/Wrappers/WrapperTableEditor.tsx
@@ -91,7 +91,7 @@ const WrapperTableEditor = ({
                 >
                   <div className="space-y-1">
                     <p>{table.label}</p>
-                    <p className="opacity-50">{table.description}</p>
+                    <p className="text-foreground-lighter">{table.description}</p>
                   </div>
                 </Listbox.Option>
               )

--- a/packages/ui/src/lib/theme/defaultTheme.ts
+++ b/packages/ui/src/lib/theme/defaultTheme.ts
@@ -1351,7 +1351,7 @@ export default {
     option: `
       w-listbox
       transition cursor-pointer select-none relative py-2 pl-3 pr-9
-      text-foreground-muted
+      text-foreground-light
       text-sm
       hover:bg-border-overlay
       focus:bg-border-overlay
@@ -1360,7 +1360,7 @@ export default {
       focus:outline-none
     `,
     option_active: `text-foreground bg-selection`,
-    option_disabled: `cursor-not-allowed opacity-50`,
+    option_disabled: `cursor-not-allowed opacity-60`,
     option_inner: `flex items-center space-x-3`,
     option_check: `absolute inset-y-0 right-0 flex items-center pr-3 text-brand`,
     option_check_active: `text-brand`,


### PR DESCRIPTION
Fix text colour of <listbox> options. 

Listbox is deprecated, but it's still in use all over.

Before/after

![screenshot-2024-07-31-at-12 52 05](https://github.com/user-attachments/assets/97445e74-235a-49bf-b9da-58ab11e9f0ad)
![screenshot-2024-07-31-at-12 51 52](https://github.com/user-attachments/assets/d2c92eb7-f7a8-40e1-aef9-4908df21143f)
![screenshot-2024-07-31-at-12 56 13](https://github.com/user-attachments/assets/17eb0803-aa1f-4936-98e3-fb7c6ab7936b)
![screenshot-2024-07-31-at-12 56 22](https://github.com/user-attachments/assets/ddf52f95-0939-4037-aaea-c65d96f66253)


