### PR TITLE
ci: remove migration push from search action

### DIFF
--- a/.github/workflows/search.yml
+++ b/.github/workflows/search.yml
@@ -23,11 +23,8 @@ jobs:
 
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-      PROJECT_ID: ${{ secrets.SEARCH_SUPABASE_PROJECT_ID }}
       NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SEARCH_SUPABASE_URL }}
       SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SEARCH_SUPABASE_SERVICE_ROLE_KEY }}
-      SUPABASE_DB_PASSWORD: ${{ secrets.SEARCH_SUPABASE_DB_PASSWORD }}
       SEARCH_GITHUB_APP_ID: ${{ secrets.SEARCH_GITHUB_APP_ID }}
       SEARCH_GITHUB_APP_INSTALLATION_ID: ${{ secrets.SEARCH_GITHUB_APP_INSTALLATION_ID }}
       SEARCH_GITHUB_APP_PRIVATE_KEY: ${{ secrets.SEARCH_GITHUB_APP_PRIVATE_KEY }}
@@ -48,12 +45,6 @@ jobs:
 
       - name: Download dependencies
         run: npm ci
-
-      - name: Link Supabase project
-        run: npx supabase link --project-ref $PROJECT_ID
-
-      - name: Run migrations
-        run: npx supabase db push
 
       # Need the miscellaneous use API, which is available publicly (by design) in www
       - name: Copy environment variables


### PR DESCRIPTION
We don't need this for migration pushes since the Supabase integration will do it instead. Removing it makes this action less brittle since embedding updates get blocked on CLI problems.

Test: successful run here https://github.com/supabase/supabase/actions/runs/10203661699/job/28230464361