### PR TITLE
fix(docs): duplicate heading ids

### DIFF
--- a/apps/docs/content/guides/ai/choosing-compute-addon.mdx
+++ b/apps/docs/content/guides/ai/choosing-compute-addon.mdx
@@ -17,7 +17,7 @@ The number of dimensions in your embeddings is the most important factor in choo
 
 ## HNSW
 
-### 384 dimensions
+### 384 dimensions [#hnsw-384-dimensions]
 
 This benchmark uses the dbpedia-entities-openai-1M dataset containing 1,000,000 embeddings of text, regenerated for 384 dimension embeddings. Each embedding is generated using [gte-small](https://huggingface.co/Supabase/gte-small).
 
@@ -48,7 +48,7 @@ Accuracy was 0.99 for benchmarks.
 </TabPanel>
 </Tabs>
 
-### 960 dimensions
+### 960 dimensions [#hnsw-960-dimensions]
 
 This benchmark uses the [gist-960](http://corpus-texmex.irisa.fr/) dataset, which contains 1,000,000 embeddings of images. Each embedding is 960 dimensions.
 
@@ -81,7 +81,7 @@ QPS can also be improved by increasing [`m` and `ef_construction`](/docs/guides/
 </TabPanel>
 </Tabs>
 
-### 1536 dimensions
+### 1536 dimensions [#hnsw-1536-dimensions]
 
 This benchmark uses the [dbpedia-entities-openai-1M](https://huggingface.co/datasets/KShivendu/dbpedia-entities-openai-1M) dataset, which contains 1,000,000 embeddings of text. And 224,482 embeddings from [Wikipedia articles](https://huggingface.co/datasets/Supabase/wikipedia-en-embeddings) for compute add-ons `large` and below. Each embedding is 1536 dimensions created with the [OpenAI Embeddings API](https://platform.openai.com/docs/guides/embeddings).
 
@@ -131,7 +131,7 @@ It is possible to upload more vectors to a single table if Memory allows it (for
 
 ## IVFFlat
 
-### 384 dimensions
+### 384 dimensions [#ivfflat-384-dimensions]
 
 This benchmark uses the dbpedia-entities-openai-1M dataset containing 1,000,000 embeddings of text, regenerated for 384 dimension embeddings. Each embedding is generated using [gte-small](https://huggingface.co/Supabase/gte-small).
 
@@ -176,7 +176,7 @@ This benchmark uses the dbpedia-entities-openai-1M dataset containing 1,000,000 
 </TabPanel>
 </Tabs>
 
-### 960 dimensions
+### 960 dimensions [#ivfflat-960-dimensions]
 
 This benchmark uses the [gist-960](http://corpus-texmex.irisa.fr/) dataset, which contains 1,000,000 embeddings of images. Each embedding is 960 dimensions.
 
@@ -205,7 +205,7 @@ This benchmark uses the [gist-960](http://corpus-texmex.irisa.fr/) dataset, whic
 </TabPanel>
 </Tabs>
 
-### 1536 dimensions
+### 1536 dimensions [#ivfflat-1536-dimensions]
 
 This benchmark uses the [dbpedia-entities-openai-1M](https://huggingface.co/datasets/KShivendu/dbpedia-entities-openai-1M) dataset, which contains 1,000,000 embeddings of text. Each embedding is 1536 dimensions created with the [OpenAI Embeddings API](https://platform.openai.com/docs/guides/embeddings).
 

--- a/apps/docs/spec/supabase_js_v2.yml
+++ b/apps/docs/spec/supabase_js_v2.yml
@@ -3869,35 +3869,6 @@ functions:
           ```
         hideCodeBlock: true
         isSpotlight: true
-      - id: update-a-record-with-count
-        name: Update a record and return count
-        code: |
-          ```ts
-          const result = await supabase
-            .from('countries')
-            .update({ name: 'Australia' }, {count: 'exact'})
-            .eq('id', 1)
-          ```
-        data:
-          sql: |
-            ```sql
-            create table
-              countries (id int8 primary key, name text);
-            insert into
-                countries (id, name)
-            values
-                (1, 'Taiwan');
-            ```
-        response: |
-          ```json
-          {
-            error: null,
-            data: null,
-            count: 1,
-            status: 204,
-            statusText: 'No Content'
-          }
-          ```
       - id: update-a-record-and-return-it
         name: Update a record and return it
         code: |

--- a/apps/docs/spec/supabase_js_v2.yml
+++ b/apps/docs/spec/supabase_js_v2.yml
@@ -3869,6 +3869,35 @@ functions:
           ```
         hideCodeBlock: true
         isSpotlight: true
+      - id: update-a-record-with-count
+        name: Update a record and return count
+        code: |
+          ```ts
+          const result = await supabase
+            .from('countries')
+            .update({ name: 'Australia' }, {count: 'exact'})
+            .eq('id', 1)
+          ```
+        data:
+          sql: |
+            ```sql
+            create table
+              countries (id int8 primary key, name text);
+            insert into
+                countries (id, name)
+            values
+                (1, 'Taiwan');
+            ```
+        response: |
+          ```json
+          {
+            error: null,
+            data: null,
+            count: 1,
+            status: 204,
+            statusText: 'No Content'
+          }
+          ```
       - id: update-a-record-and-return-it
         name: Update a record and return it
         code: |


### PR DESCRIPTION
Duplicate heading IDs interferes with the Table of Contents highlighting, so add custom unique IDs for those sections.