### PR TITLE
fix: LW ticket site auth state conflict with studio

### DIFF
--- a/packages/common/gotrue.ts
+++ b/packages/common/gotrue.ts
@@ -21,6 +21,10 @@ const shouldEnableNavigatorLock =
   process.env.NEXT_PUBLIC_IS_PLATFORM === 'true' &&
   !(globalThis?.localStorage?.getItem(AUTH_NAVIGATOR_LOCK_DISABLED_KEY) === 'true')
 
+const shouldDetectSessionInUrl = process.env.NEXT_PUBLIC_AUTH_DETECT_SESSION_IN_URL
+  ? process.env.NEXT_PUBLIC_AUTH_DETECT_SESSION_IN_URL === 'true'
+  : true
+
 const navigatorLockEnabled = !!(shouldEnableNavigatorLock && globalThis?.navigator?.locks)
 
 if (shouldEnableNavigatorLock && !globalThis?.navigator?.locks) {
@@ -103,7 +107,7 @@ const logIndexedDB = (message: string, ...args: any[]) => {
 export const gotrueClient = new AuthClient({
   url: process.env.NEXT_PUBLIC_GOTRUE_URL,
   storageKey: STORAGE_KEY,
-  detectSessionInUrl: true,
+  detectSessionInUrl: shouldDetectSessionInUrl,
   debug: debug ? (persistedDebug ? logIndexedDB : true) : false,
   lock: navigatorLockEnabled ? navigatorLock : undefined,
 })


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When a logged in dashboard user gets a LW ticket, they get logged out of the dashboard

## What is the new behavior?

This is somewhat guessing at the root error but I think what's happening is:

1. User gets redirected back to www site after clicking claim ticket
2. The two Supabase clients both try and grab the tokens from the URL (since `detectSessionInUrl` is default `true`)
3. The new tokens are invalid for use with the dashboard app, so auth-js removes them (even if there were existing ones)

This may not be the root issue, but I can see no reason why www would need to log a user in for the dashboard (only needs to check whether they are already logged in), so I've added `NEXT_PUBLIC_AUTH_DETECT_SESSION_IN_URL = false` in Vercel for www.