### PR TITLE
fix(docs): hydration error on js references

### DIFF
--- a/apps/docs/spec/supabase_js_v2.yml
+++ b/apps/docs/spec/supabase_js_v2.yml
@@ -2246,7 +2246,7 @@ functions:
       - To verify a challenge, see [`mfa.verify()`](/docs/reference/javascript/auth-mfa-verify).
       - To create and verify a challenge in a single step, see [`mfa.challengeAndVerify()`](/docs/reference/javascript/auth-mfa-challengeandverify).
       - To generate a QR code for the `totp` secret in nextjs, you can do the following:
-      ```html
+      ```
       <Image src={data.totp.qr_code} alt={data.totp.uri} layout="fill"></Image>
       ```
     examples:


### PR DESCRIPTION
Our syntax highlighter doesn't recognize HTML (tried to install it but it's not on the list of supported languages) and this somehow causes the server and client to make different highlighting decisions, with the server attempting to highlight the code block and the client not.

Removing the html language specifier removes the hydration error (and since the client never properly highlighted it anyway, we don't lose much in terms of syntax highlighting.)