### PR TITLE
Update minio health check

### DIFF
--- a/docker/docker-compose.s3.yml
+++ b/docker/docker-compose.s3.yml
@@ -12,7 +12,7 @@ services:
       MINIO_ROOT_PASSWORD: secret1234
     command: server --console-address ":9001" /data
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://minio:9000/minio/health/live" ]
+      test: "mc ready local"
       interval: 2s
       timeout: 10s
       retries: 5


### PR DESCRIPTION
curl was removed from the image, now we can use `mc ready local` to health check, https://github.com/minio/minio/issues/18389

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Unhealthy container

## What is the new behavior?

Healthy

## Additional context

Add any other context or screenshots.
