### PR TITLE
update storage image tag

### DIFF
--- a/docker/docker-compose.s3.yml
+++ b/docker/docker-compose.s3.yml
@@ -33,7 +33,7 @@ services:
 
   storage:
     container_name: supabase-storage
-    image: supabase/storage-api:v0.43.11
+    image: supabase/storage-api:v1.0.6
     depends_on:
       db:
         # Disable this if you are using an external Postgres database


### PR DESCRIPTION
update storage image tag, same as the image in docker-compose.yml

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

errors in storage logs when `docker compose -f docker-compose.yml -f docker-compose.s3.yml up -d`

## What is the new behavior?

Fixed