### PR TITLE
Updated example code for ownership owner_id in storage

### DIFF
--- a/apps/docs/content/guides/storage/security/ownership.mdx
+++ b/apps/docs/content/guides/storage/security/ownership.mdx
@@ -32,7 +32,7 @@ on storage.objects
 for delete
 to authenticated
 using (
-    owner_id = (select auth.uid())
+    owner_id = (select auth.uid())::text
 );
 ```
 


### PR DESCRIPTION
Corrected the example code in the documentation for storage in supabase
Corrected the example code in the documentation to reflect that owner_id is a text string, not a UUID. This update prevents errors caused by incorrect usage of owner_id as a UUID in examples.

I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.
YES

What kind of change does this PR introduce?
Docs update

What is the current behavior?
The current behavior in the documentation incorrectly suggests using owner_id as a UUID, leading to potential errors when users attempt to apply this in practice.

What is the new behavior?
The documentation now correctly reflects that owner_id is a text string, providing accurate guidance for users.

Additional context
This update ensures that developers who reference the documentation will no longer encounter errors related to incorrect data types when using owner_id in their projects.