### PR TITLE
docs: fix webhook signing admonision for log drains

### DIFF
--- a/apps/docs/content/guides/platform/log-drains.mdx
+++ b/apps/docs/content/guides/platform/log-drains.mdx
@@ -33,9 +33,11 @@ Logs are sent as a JSON payload. Both HTTP1 and HTTP2 are supported. A preset co
 
 Note that requests are **unsigned**.
 
-:::note
-Unsigned webhook requests are temporary and all requests are signed in the near future.
-:::
+<Admonition type="note">
+
+Unsigned webhook requests are temporary and signed requests will be supported soon.
+
+</Admonition>
 
 #### Datadog
 


### PR DESCRIPTION
fix webhook signing admonition