### PR TITLE
Open folder of snippet when opening a snippet on fresh browser session

### DIFF
--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorMenu.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorMenu.tsx
@@ -37,7 +37,11 @@ import {
 import { SQLEditorNavV1 } from './SQLEditorNavV1'
 import { SQLEditorNav as SQLEditorNavV2 } from './SQLEditorNavV2/SQLEditorNav'
 
-export const SQLEditorMenu = ({ onViewOngoingQueries }: { onViewOngoingQueries: () => void }) => {
+interface SQLEditorMenuProps {
+  onViewOngoingQueries: () => void
+}
+
+export const SQLEditorMenu = ({ onViewOngoingQueries }: SQLEditorMenuProps) => {
   const router = useRouter()
   const { profile } = useProfile()
   const project = useSelectedProject()


### PR DESCRIPTION
Related to SQL folders: 
- Open the folder which the snippet belongs to when opening a snippet on a fresh browser session
  - Only if the snippet belongs to a folder
  - And also fetch the contents of the folder