### PR TITLE
fix: upload data during creation only for files above the chunk size

### DIFF
--- a/apps/studio/localStores/storageExplorer/StorageExplorerStore.tsx
+++ b/apps/studio/localStores/storageExplorer/StorageExplorerStore.tsx
@@ -712,6 +712,7 @@ class StorageExplorerStore {
 
           // Max chunk size is 500MB
           chunkSize = Math.min(chunkSize, 500 * 1024 * 1024)
+          const uploadDataDuringCreation = file.size <= chunkSize
 
           const upload = new tus.Upload(file, {
             endpoint: this.resumableUploadUrl,
@@ -720,7 +721,7 @@ class StorageExplorerStore {
               authorization: `Bearer ${this.serviceKey}`,
               'x-source': 'supabase-dashboard',
             },
-            uploadDataDuringCreation: true,
+            uploadDataDuringCreation: uploadDataDuringCreation,
             removeFingerprintOnSuccess: true,
             metadata: {
               bucketName: this.selectedBucket.name,


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Improvement

## What is the new behaviour?

With this PR we only upload data during the Upload URL creation for files equal to or lower than the defined chunk size.
This will improve DX as well as the calculation of the elapsed time.
