### PR TITLE
fix: Disable sorting by json/jsonb columns

### DIFF
--- a/apps/studio/components/grid/components/header/sort/SortPopover.tsx
+++ b/apps/studio/components/grid/components/header/sort/SortPopover.tsx
@@ -69,6 +69,11 @@ const SortOverlay = ({ table, sorts: sortsFromUrl, onApplySorts }: SortOverlayPr
   const [sorts, setSorts] = useState<Sort[]>(initialSorts)
 
   const columns = table.columns!.filter((x) => {
+    // exclude json/jsonb columns from sorting. Sorting by json fields in PG is only possible if you provide key from
+    // the JSON object.
+    if (x.dataType === 'json' || x.dataType === 'jsonb') {
+      return false
+    }
     const found = sorts.find((y) => y.column == x.name)
     return !found
   })


### PR DESCRIPTION
This PR removes the json/jsonb columns from the sort popover. Json/jsonb columns can only be used in a order by clause if you also specify a key in the JSON object.