### PR TITLE
fix: fix the invoice status label tooltip for invoices in status 'issued' [GEN-10357]

### DIFF
--- a/apps/studio/components/interfaces/Billing/InvoiceStatusBadge.tsx
+++ b/apps/studio/components/interfaces/Billing/InvoiceStatusBadge.tsx
@@ -5,6 +5,7 @@ import { InvoiceStatus } from './Invoices.types'
 
 interface InvoiceStatusBadgeProps {
   status: InvoiceStatus
+  paymentAttempted: boolean
 }
 
 const invoiceStatusMapping: Record<
@@ -40,7 +41,7 @@ const invoiceStatusMapping: Record<
   },
 }
 
-const InvoiceStatusBadge = ({ status }: InvoiceStatusBadgeProps) => {
+const InvoiceStatusBadge = ({ status, paymentAttempted }: InvoiceStatusBadgeProps) => {
   const statusMapping = invoiceStatusMapping[status]
 
   return (
@@ -63,13 +64,22 @@ const InvoiceStatusBadge = ({ status }: InvoiceStatusBadgeProps) => {
               'w-[300px] space-y-2 border border-background',
             ].join(' ')}
           >
-            {[InvoiceStatus.OPEN, InvoiceStatus.UNCOLLECTIBLE].includes(status) && (
-              <p className="text-xs text-foreground">
-                We were not able to collect the money. Make sure you have a valid payment method and
-                enough funds. Outstanding invoices may cause restrictions. You can manually pay the
-                using the "Pay Now" button.
-              </p>
-            )}
+            {[InvoiceStatus.OPEN, InvoiceStatus.ISSUED, InvoiceStatus.UNCOLLECTIBLE].includes(
+              status
+            ) &&
+              (paymentAttempted ? (
+                <p className="text-xs text-foreground">
+                  We were not able to collect the money. Make sure you have a valid payment method
+                  and enough funds. Outstanding invoices may cause restrictions. You can manually
+                  pay the invoice using the "Pay Now" button.
+                </p>
+              ) : (
+                <p className="text-xs text-foreground">
+                  The invoice will soon be charged for. In case you pay via invoice instead of card,
+                  please make sure to make the payment in a timely manner. You can also pay the
+                  invoice using your card now using the "Pay Now" button.
+                </p>
+              ))}
 
             {status === InvoiceStatus.DRAFT && (
               <p className="text-xs text-foreground">

--- a/apps/studio/components/interfaces/Billing/InvoiceStatusBadge.tsx
+++ b/apps/studio/components/interfaces/Billing/InvoiceStatusBadge.tsx
@@ -69,7 +69,7 @@ const InvoiceStatusBadge = ({ status, paymentAttempted }: InvoiceStatusBadgeProp
             ) &&
               (paymentAttempted ? (
                 <p className="text-xs text-foreground">
-                  We were not able to collect the money. Make sure you have a valid payment method
+                  We were not able to collect the payment. Make sure you have a valid payment method
                   and enough funds. Outstanding invoices may cause restrictions. You can manually
                   pay the invoice using the "Pay Now" button.
                 </p>

--- a/apps/studio/components/interfaces/Organization/InvoicesSettings/InvoicesSettings.tsx
+++ b/apps/studio/components/interfaces/Organization/InvoicesSettings/InvoicesSettings.tsx
@@ -106,7 +106,10 @@ const InvoicesSettings = () => {
                         <p>{x.number}</p>
                       </Table.td>
                       <Table.td>
-                        <InvoiceStatusBadge status={x.status as InvoiceStatus} />
+                        <InvoiceStatusBadge
+                          status={x.status as InvoiceStatus}
+                          paymentAttempted={x.payment_attempted}
+                        />
                       </Table.td>
                       <Table.td className="align-right">
                         <div className="flex items-center justify-end space-x-2">

--- a/packages/api-types/types/api.d.ts
+++ b/packages/api-types/types/api.d.ts
@@ -3603,6 +3603,7 @@ export interface components {
       status: string
       subscription: string | null
       subtotal: number
+      payment_attempted: boolean
     }
     JoinResponse: {
       billing_email: string


### PR DESCRIPTION
## What is the current behavior?

The status label tooltip for an invoice in status "Issued" does not contain any text

<img width="1132" alt="gen-10357-before" src="https://github.com/user-attachments/assets/82c7d358-b5a0-455d-9006-3ed6c8a78620">


## What is the new behavior?

The status label tooltip for an invoice in status "Issued" does contain text depending on whether there was a payment attempt or not.

**Payment Attempt**

<img width="1063" alt="gen-10357-after-payment-attempt" src="https://github.com/user-attachments/assets/a5bbc60f-e2c5-4fb7-b3ca-9292a1aeb239">


**No Payment Attempt**

<img width="1062" alt="gen-10357-after-no-payment-attempt" src="https://github.com/user-attachments/assets/c61b02d9-aed6-4c84-b314-63fdd480985e">

## Additional context
- we decided on not introducing a new label but instead go with the already existing label "Outstanding" in case of an invoice in status "Issued" with no payment attempts. We don't want to overcomplicate things. "Outstanding" is not "Overdue".
- theoretically we could also take into consideration whether "auto-collection" is activated for an invoice or not. But again, let's not overcomplicate things and only a very small set of users don't have "auto-collection" enabled.
