### PR TITLE
Show correct number of private snippets for SQL folders

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/MoveQueryModal.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/MoveQueryModal.tsx
@@ -10,7 +10,7 @@ import { getContentById } from 'data/content/content-id-query'
 import { useContentUpsertV2Mutation } from 'data/content/content-upsert-v2-mutation'
 import { useSQLSnippetFolderCreateMutation } from 'data/content/sql-folder-create-mutation'
 import { Snippet, SnippetDetail } from 'data/content/sql-folders-query'
-import { useSqlEditorV2StateSnapshot } from 'state/sql-editor-v2'
+import { useSnippetFolders, useSqlEditorV2StateSnapshot } from 'state/sql-editor-v2'
 import {
   Button,
   CommandEmpty_Shadcn_,
@@ -83,7 +83,7 @@ export const MoveQueryModal = ({ visible, snippets = [], onClose }: MoveQueryMod
     defaultValues: { name: '' },
   })
 
-  const folders = Object.values(snapV2.folders).map((x) => x.folder)
+  const folders = useSnippetFolders(ref as string)
   const selectedFolder =
     selectedId === 'root'
       ? 'Root of the editor'

--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorNav.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorNav.tsx
@@ -39,6 +39,7 @@ import { ROOT_NODE, formatFolderResponseForTreeView } from './SQLEditorNav.utils
 import { SQLEditorTreeViewItem } from './SQLEditorTreeViewItem'
 import { untitledSnippetTitle } from 'components/interfaces/SQLEditor/SQLEditor.constants'
 import { useSqlSnippetsQuery } from 'data/content/sql-snippets-query'
+import { useContentCountQuery } from 'data/content/content-count-query'
 
 interface SQLEditorNavProps {
   searchText: string
@@ -84,9 +85,8 @@ export const SQLEditorNav = ({ searchText: _searchText }: SQLEditorNavProps) => 
   const snippet = snapV2.snippets[id as string]?.snippet
 
   const privateSnippets = contents.filter((snippet) => snippet.visibility === 'user')
-  const numPrivateSnippets = Object.keys(snapV2.snippets).length
   const privateSnippetsTreeState =
-    folders.length === 0 && numPrivateSnippets === 0
+    folders.length === 0 && Object.keys(snapV2.snippets).length === 0
       ? [ROOT_NODE]
       : formatFolderResponseForTreeView({ folders, contents: privateSnippets })
 
@@ -129,6 +129,9 @@ export const SQLEditorNav = ({ searchText: _searchText }: SQLEditorNavProps) => 
       }
     },
   })
+
+  const { data } = useContentCountQuery({ projectRef, type: 'sql' })
+  const numPrivateSnippets = data?.count ?? 0
 
   const { mutate: deleteContent, isLoading: isDeleting } = useContentDeleteMutation({
     onError: (error, data) => {

--- a/apps/studio/data/content/content-count-query.ts
+++ b/apps/studio/data/content/content-count-query.ts
@@ -1,0 +1,41 @@
+import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+
+import { get, handleError } from 'data/fetchers'
+import { ResponseError } from 'types'
+import { contentKeys } from './keys'
+
+interface getContentCountVariables {
+  projectRef?: string
+  type: 'sql' | 'report' | 'log_sql'
+}
+
+export async function getContentCount(
+  { projectRef, type }: getContentCountVariables,
+  signal?: AbortSignal
+) {
+  if (typeof projectRef === 'undefined') throw new Error('projectRef is required')
+
+  const { data, error } = await get('/platform/projects/{ref}/content/count', {
+    params: { path: { ref: projectRef }, query: { type } },
+    signal,
+  })
+
+  if (error) throw handleError(error)
+  return data
+}
+
+export type ContentIdData = Awaited<ReturnType<typeof getContentCount>>
+export type ContentIdError = ResponseError
+
+export const useContentCountQuery = <TData = ContentIdData>(
+  { projectRef, type }: getContentCountVariables,
+  { enabled = true, ...options }: UseQueryOptions<ContentIdData, ContentIdError, TData> = {}
+) =>
+  useQuery<ContentIdData, ContentIdError, TData>(
+    contentKeys.count(projectRef, type),
+    ({ signal }) => getContentCount({ projectRef, type }, signal),
+    {
+      enabled: enabled && typeof projectRef !== 'undefined',
+      ...options,
+    }
+  )

--- a/apps/studio/data/content/content-id-query.ts
+++ b/apps/studio/data/content/content-id-query.ts
@@ -3,7 +3,6 @@ import { useQuery, UseQueryOptions } from '@tanstack/react-query'
 import { get, handleError } from 'data/fetchers'
 import { ResponseError } from 'types'
 import { contentKeys } from './keys'
-import { components } from 'api-types'
 
 export async function getContentById(
   { projectRef, id }: { projectRef?: string; id?: string },

--- a/apps/studio/data/content/keys.ts
+++ b/apps/studio/data/content/keys.ts
@@ -4,4 +4,6 @@ export const contentKeys = {
     ['projects', projectRef, 'content', 'folders', id].filter(Boolean),
   resource: (projectRef: string | undefined, id?: string) =>
     ['projects', projectRef, 'content', id] as const,
+  count: (projectRef: string | undefined, type?: string) =>
+    ['projects', projectRef, 'content', 'count', type].filter(Boolean),
 }

--- a/packages/api-types/types/api.d.ts
+++ b/packages/api-types/types/api.d.ts
@@ -795,6 +795,10 @@ export interface paths {
      */
     patch: operations['ContentController_updateContent']
   }
+  '/platform/projects/{ref}/content/count': {
+    /** Gets the count of a user's content by type */
+    get: operations['ContentController_getContentCount']
+  }
   '/platform/projects/{ref}/content/folders': {
     /** Gets project's content root folder */
     get: operations['ContentFoldersController_getRootFolder']
@@ -1626,6 +1630,10 @@ export interface paths {
      */
     patch: operations['ContentController_updateContent']
   }
+  '/v0/projects/{ref}/content/count': {
+    /** Gets the count of a user's content by type */
+    get: operations['ContentController_getContentCount']
+  }
   '/v0/projects/{ref}/content/item/{id}': {
     /** Gets project's content by the given id */
     get: operations['ContentController_getContentById']
@@ -1868,7 +1876,7 @@ export interface paths {
   '/v1/projects/{ref}/config/auth/third-party-auth': {
     /** [Alpha] Lists all third-party auth integrations */
     get: operations['ThirdPartyAuthController_listTPAForProject']
-    /** [Alpha] Creates a new third-party auth integration */
+    /** Creates a new third-party auth integration */
     post: operations['ThirdPartyAuthController_createTPAForProject']
   }
   '/v1/projects/{ref}/config/auth/third-party-auth/{tpa_id}': {
@@ -2283,6 +2291,8 @@ export interface components {
       mailer_templates_reauthentication_content: string | null
       mailer_templates_recovery_content: string | null
       mfa_max_enrolled_factors: number | null
+      mfa_totp_enroll_enabled: boolean | null
+      mfa_totp_verify_enabled: boolean | null
       password_hibp_enabled: boolean | null
       password_min_length: number | null
       password_required_characters: string | null
@@ -3134,6 +3144,9 @@ export interface components {
       verify_jwt?: boolean
       version: number
     }
+    GetContentCountResponse: {
+      count: number
+    }
     GetMetricsBody: {
       /** @enum {string} */
       interval: '1d' | '3d' | '7d'
@@ -3452,6 +3465,8 @@ export interface components {
       MAILER_TEMPLATES_REAUTHENTICATION_CONTENT: string
       MAILER_TEMPLATES_RECOVERY_CONTENT: string
       MFA_MAX_ENROLLED_FACTORS: number
+      MFA_TOTP_ENROLL_ENABLED: boolean
+      MFA_TOTP_VERIFY_ENABLED: boolean
       PASSWORD_HIBP_ENABLED: boolean
       PASSWORD_MIN_LENGTH: number
       PASSWORD_REQUIRED_CHARACTERS: string
@@ -4451,6 +4466,7 @@ export interface components {
         | 'rls_references_user_metadata'
         | 'materialized_view_in_api'
         | 'foreign_table_in_api'
+        | 'unsupported_reg_types'
         | 'auth_otp_long_expiry'
         | 'auth_otp_short_length'
       remediation: Record<string, never>
@@ -5407,6 +5423,8 @@ export interface components {
       mailer_templates_reauthentication_content?: string
       mailer_templates_recovery_content?: string
       mfa_max_enrolled_factors?: number
+      mfa_totp_enroll_enabled?: boolean
+      mfa_totp_verify_enabled?: boolean
       password_hibp_enabled?: boolean
       password_min_length?: number
       /** @enum {string} */
@@ -5647,6 +5665,8 @@ export interface components {
       MAILER_TEMPLATES_REAUTHENTICATION_CONTENT?: string
       MAILER_TEMPLATES_RECOVERY_CONTENT?: string
       MFA_MAX_ENROLLED_FACTORS?: number
+      MFA_TOTP_ENROLL_ENABLED?: boolean
+      MFA_TOTP_VERIFY_ENABLED?: boolean
       PASSWORD_HIBP_ENABLED?: boolean
       PASSWORD_MIN_LENGTH?: number
       /** @enum {string} */
@@ -11649,6 +11669,29 @@ export interface operations {
       }
     }
   }
+  /** Gets the count of a user's content by type */
+  ContentController_getContentCount: {
+    parameters: {
+      query: {
+        type: string
+      }
+      path: {
+        /** @description Project ref */
+        ref: string
+      }
+    }
+    responses: {
+      200: {
+        content: {
+          'application/json': components['schemas']['GetContentCountResponse']
+        }
+      }
+      /** @description Failed to retrieve user's content count */
+      500: {
+        content: never
+      }
+    }
+  }
   /** Gets project's content root folder */
   ContentFoldersController_getRootFolder: {
     parameters: {
@@ -14249,7 +14292,7 @@ export interface operations {
       }
     }
   }
-  /** [Alpha] Creates a new third-party auth integration */
+  /** Creates a new third-party auth integration */
   ThirdPartyAuthController_createTPAForProject: {
     parameters: {
       path: {


### PR DESCRIPTION
Dependent on API changes here:
https://github.com/supabase/infrastructure/pull/19245

Count for private snippets under the new SQL Editor nav UI is not accurate as queries within folders are loaded on demand
This should address it