### PR TITLE
Refine lint warning on homepage

### DIFF
--- a/apps/studio/components/interfaces/Home/SecurityStatus.tsx
+++ b/apps/studio/components/interfaces/Home/SecurityStatus.tsx
@@ -1,26 +1,27 @@
 import { CheckCircle2, Loader2 } from 'lucide-react'
 import { useState } from 'react'
 import { Button, PopoverContent_Shadcn_, PopoverTrigger_Shadcn_, Popover_Shadcn_, cn } from 'ui'
-
 import { useProjectLintsQuery } from 'data/lint/lint-query'
 import { useSelectedProject } from 'hooks/misc/useSelectedProject'
-
 import Link from 'next/link'
 import { WarningIcon } from 'ui/src/components/StatusIcon'
 
 export const SecurityStatus = () => {
   const project = useSelectedProject()
   const [open, setOpen] = useState(false)
-  const { data, isLoading } = useProjectLintsQuery({
-    projectRef: project?.ref,
-  })
+  const { data, isLoading } = useProjectLintsQuery({ projectRef: project?.ref })
 
-  const securityLints = (data ?? []).filter(
-    (lint) =>
-      lint.categories.includes('SECURITY') && (lint.level === 'ERROR' || lint.level === 'WARN')
-  )
+  const securityLints = (data ?? []).filter((lint) => lint.categories.includes('SECURITY'))
+  const errorLints = securityLints.filter((lint) => lint.level === 'ERROR')
+  const warnLints = securityLints.filter((lint) => lint.level === 'WARN')
+  const noIssuesFound = errorLints.length === 0 && warnLints.length === 0
+  const totalIssues = securityLints.length
 
-  const noIssuesFound = securityLints.length === 0
+  const badgeColor = noIssuesFound
+    ? 'bg-brand'
+    : errorLints.length > 0
+      ? 'bg-destructive-600'
+      : 'bg-warning-600'
 
   return (
     <Popover_Shadcn_ modal={false} open={open} onOpenChange={setOpen}>
@@ -33,8 +34,12 @@ export const SecurityStatus = () => {
             ) : (
               <div
                 className={cn(
-                  `w-2 h-2 rounded-full`,
-                  noIssuesFound ? 'bg-brand' : 'bg-destructive-600'
+                  'w-2 h-2 rounded-full',
+                  noIssuesFound
+                    ? 'bg-brand'
+                    : errorLints.length > 0
+                      ? 'bg-destructive-600'
+                      : 'bg-warning-600'
                 )}
               />
             )
@@ -54,7 +59,6 @@ export const SecurityStatus = () => {
           ) : (
             <WarningIcon className="shrink-0" />
           )}
-
           <div className="flex flex-col gap-y-3 -mt-1">
             {noIssuesFound ? (
               <div className="flex flex-col gap-y-1">
@@ -66,16 +70,19 @@ export const SecurityStatus = () => {
             ) : (
               <div className="flex flex-col gap-y-1">
                 <p className="text-xs">
-                  {securityLints.length} security issues requiring urgent attention
+                  {totalIssues} security issue{totalIssues > 1 ? 's' : ''} require
+                  {totalIssues > 1 ? '' : 's'}{' '}
+                  {errorLints.length > 0 ? 'urgent attention' : 'attention'}
                 </p>
                 <p className="text-xs text-foreground-light">
                   Check the Security Advisor to address them
                 </p>
               </div>
             )}
-
             <Button asChild type="default" className="w-min">
-              <Link href={`/project/${project?.ref}/database/security-advisor`}>
+              <Link
+                href={`/project/${project?.ref}/database/security-advisor${errorLints.length === 0 ? '?preset=WARN' : ''}`}
+              >
                 Head to Security Advisor
               </Link>
             </Button>

--- a/apps/studio/components/interfaces/Home/SecurityStatus.tsx
+++ b/apps/studio/components/interfaces/Home/SecurityStatus.tsx
@@ -17,12 +17,6 @@ export const SecurityStatus = () => {
   const noIssuesFound = errorLints.length === 0 && warnLints.length === 0
   const totalIssues = securityLints.length
 
-  const badgeColor = noIssuesFound
-    ? 'bg-brand'
-    : errorLints.length > 0
-      ? 'bg-destructive-600'
-      : 'bg-warning-600'
-
   return (
     <Popover_Shadcn_ modal={false} open={open} onOpenChange={setOpen}>
       <PopoverTrigger_Shadcn_ asChild>

--- a/apps/studio/components/layouts/ProjectLayout/NavigationBar/NavigationBar.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/NavigationBar/NavigationBar.tsx
@@ -78,10 +78,8 @@ const NavigationBar = () => {
     projectRef: project?.ref,
   })
 
-  const securityLints = (data ?? []).filter(
-    (lint) =>
-      lint.categories.includes('SECURITY') && (lint.level === 'ERROR' || lint.level === 'WARN')
-  )
+  const securityLints = (data ?? []).filter((lint) => lint.categories.includes('SECURITY'))
+  const errorLints = securityLints.filter((lint) => lint.level === 'ERROR')
 
   const activeRoute = router.pathname.split('/')[3]
   const toolRoutes = generateToolRoutes(projectRef, project)
@@ -180,7 +178,12 @@ const NavigationBar = () => {
               return (
                 <div className="relative">
                   {securityLints.length > 0 && (
-                    <div className="absolute flex h-2 w-2 left-6 top-2 z-10 bg-destructive-600 rounded-full" />
+                    <div
+                      className={cn(
+                        'absolute flex h-2 w-2 left-6 top-2 z-10 rounded-full',
+                        errorLints.length > 0 ? 'bg-destructive-600' : 'bg-warning-600'
+                      )}
+                    />
                   )}
 
                   <NavigationIconLink


### PR DESCRIPTION
Refine the homepage Security Issues badge: 

separate warn and error lints — link to the warn tab if only warn lints exist 


To confirm: 

1. create a foreign data wrapper using Stripe with defaults. This will generate a warn lint.
2. this will show an amber dot and link to the warn tab in Security Advisor
3. next, run the countries quickstart in the SQL Editor. This will generate an error lint. 
4. this will show a red dot and link to the error tab in the Security Advisor 


![screenshot-2024-08-06-at-15 14 25](https://github.com/user-attachments/assets/1231e3ba-ba8b-4f1b-b01c-696c5a9f699c)

