### PR TITLE
Validate pg version in new project setup form

### DIFF
--- a/apps/studio/pages/new/[slug].tsx
+++ b/apps/studio/pages/new/[slug].tsx
@@ -271,11 +271,10 @@ const Wizard: NextPageWithLayout = () => {
         .min(3, 'Project name must be at least 3 characters long.') // Minimum length check
         .max(64, 'Project name must be no longer than 64 characters.'), // Maximum length check
       postgresVersion: z
-        .string({
-          required_error: 'Please enter a Postgres version.',
-        })
-        .regex(
-          /^1[2-9]\.\d+(\.\d+)?(-\d+)?$/,
+        .string()
+        .optional()
+        .refine(
+          (val) => !val || /^1[2-9]\.\d+(\.\d+)?(-\d+)?$/.test(val),
           'Invalid Postgres version: should start with a number between 12-19, a dot and additional characters, i.e. 15.2 or 15.2.0-3'
         ),
       dbRegion: z.string({
@@ -377,9 +376,9 @@ const Wizard: NextPageWithLayout = () => {
       dataApiUseApiSchema: !dataApi ? false : useApiSchema,
     }
     if (postgresVersion) {
-      if (!postgresVersion.match(/1[2-9]\..*/)) {
+      if (!postgresVersion.match(/^1[2-9]\.\d+(\.\d+)?(-\d+)?$/)) {
         toast.error(
-          `Invalid Postgres version, should start with a number between 12-19, a dot and additional characters, i.e. 15.2 or 15.2.0-3`
+          `Invalid Postgres version: should start with a number between 12-19, a dot and additional characters, i.e. 15.2 or 15.2.0-3`
         )
       }
 

--- a/apps/studio/pages/new/[slug].tsx
+++ b/apps/studio/pages/new/[slug].tsx
@@ -270,9 +270,14 @@ const Wizard: NextPageWithLayout = () => {
         .min(1, 'Please enter a project name.') // Required field check
         .min(3, 'Project name must be at least 3 characters long.') // Minimum length check
         .max(64, 'Project name must be no longer than 64 characters.'), // Maximum length check
-      postgresVersion: z.string({
-        required_error: 'Please enter a Postgres version.',
-      }),
+      postgresVersion: z
+        .string({
+          required_error: 'Please enter a Postgres version.',
+        })
+        .regex(
+          /^1[2-9]\.\d+(\.\d+)?(-\d+)?$/,
+          'Invalid Postgres version: should start with a number between 12-19, a dot and additional characters, i.e. 15.2 or 15.2.0-3'
+        ),
       dbRegion: z.string({
         required_error: 'Please select a region.',
       }),


### PR DESCRIPTION
We can currently create a project with an invalid pg version. We should validate the input rather than just showing a failed toast.

context: https://supabase.slack.com/archives/C0161K73J1J/p1722937534699409

![screenshot-2024-08-06-at-17 04 08](https://github.com/user-attachments/assets/eeda3958-f308-4d9e-9e56-ef5e384543dc)

