### PR TITLE
Auth policies dont show warning if schema is protected

### DIFF
--- a/apps/studio/components/interfaces/Auth/Policies/PolicyTableRow/index.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/PolicyTableRow/index.tsx
@@ -60,7 +60,7 @@ const PolicyTableRow = ({
               </AlertDescription_Shadcn_>
             </Alert_Shadcn_>
           )}
-          {!table.rls_enabled && (
+          {!table.rls_enabled && !isLocked && (
             <Alert_Shadcn_ variant="warning">
               <WarningIcon />
               <AlertTitle_Shadcn_>


### PR DESCRIPTION
Comparison: schema that's not protected vs schema thats protected

public schema:
![image](https://github.com/user-attachments/assets/d4ed22bc-089c-4531-9aad-0e4f0ec263e0)

realtime schema:
![image](https://github.com/user-attachments/assets/f64f9834-f3d0-404a-817d-f1d067fcdfbc)
