### PR TITLE
docs: allowlist of api logs

### DIFF
--- a/apps/docs/content/guides/platform/logs.mdx
+++ b/apps/docs/content/guides/platform/logs.mdx
@@ -126,6 +126,23 @@ Response headers:
 - `sb-gateway-mode`
 - `sb-gateway-version`
 
+### Additional request metadata
+
+To attach additional metadata to a request, it is recommended to use the `User-Agent` header for purposes such as device or version identification.
+
+For example:
+
+```
+node MyApp/1.2.3 (device-id:abc123)
+Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:47.0) Gecko/20100101 Firefox/47.0 MyApp/1.2.3 (Foo v1.3.2; Bar v2.2.2)
+```
+
+<Admonition type="note">
+
+Do not log Personal Identifiable Information (PII) within the `User-Agent` header, to avoid infringing data protection privacy laws. Overly fine-grained and detailed user agents may allow fingerprinting and identification of the end user through PII.
+
+</Admonition>
+
 ## Logging Postgres queries
 
 To enable query logs for other categories of statements:

--- a/apps/docs/content/guides/platform/logs.mdx
+++ b/apps/docs/content/guides/platform/logs.mdx
@@ -108,7 +108,6 @@ Request headers:
 - `x-real-ip`
 - `x-client-info`
 - `x-forwarded-user-agent`
-- `x-custom-metadata`
 - `range`
 - `prefer`
 
@@ -124,7 +123,6 @@ Response headers:
 - `transfer-encoding`
 - `x-kong-proxy-latency`
 - `x-kong-upstream-latency`
-- `x-custom-metadata`
 - `sb-gateway-mode`
 - `sb-gateway-version`
 

--- a/apps/docs/content/guides/platform/logs.mdx
+++ b/apps/docs/content/guides/platform/logs.mdx
@@ -93,7 +93,7 @@ Edge Function log messages have a max length of 10,000 characters. If you try to
 
 ### Allowed headers
 
-A strict list of request and response headers are permitted in the API logs.
+A strict list of request and response headers are permitted in the API logs. Request and response headers will still be received by the server(s) and client(s), but will not be attached to the API logs generated.
 
 Request headers:
 

--- a/apps/docs/content/guides/platform/logs.mdx
+++ b/apps/docs/content/guides/platform/logs.mdx
@@ -87,6 +87,47 @@ Edge Function log messages have a max length of 10,000 characters. If you try to
 
 ---
 
+## Working with API logs
+
+[API logs](https://supabase.com/dashboard/project/_/logs/edge-logs) run through the Cloudflare edge servers and will have attached Cloudflare metadata under the `metadata.request.cf.*` fields.
+
+### Allowed headers
+
+A strict list of request and response headers are permitted in the API logs.
+
+Request headers:
+
+- `accept`
+- `cf-connecting-ip`
+- `cf-ipcountry`
+- `host`
+- `user-agent`
+- `x-forwarded-proto`
+- `referer`
+- `content-length`
+- `x-real-ip`
+- `x-client-info`
+- `x-forwarded-user-agent`
+- `x-custom-metadata`
+- `range`
+- `prefer`
+
+Response headers:
+
+- `cf-cache-status`
+- `cf-ray`
+- `content-location`
+- `content-range`
+- `content-type`
+- `content-length`
+- `date`
+- `transfer-encoding`
+- `x-kong-proxy-latency`
+- `x-kong-upstream-latency`
+- `x-custom-metadata`
+- `sb-gateway-mode`
+- `sb-gateway-version`
+
 ## Logging Postgres queries
 
 To enable query logs for other categories of statements:


### PR DESCRIPTION
This PR adds in documentation around the allowlist for request/response headers for api logs.