### PR TITLE
Only query eligibility endpoint when project is active healthy

### DIFF
--- a/apps/studio/data/config/project-upgrade-eligibility-query.ts
+++ b/apps/studio/data/config/project-upgrade-eligibility-query.ts
@@ -52,8 +52,7 @@ export const useProjectUpgradeEligibilityQuery = <TData = ProjectUpgradeEligibil
       enabled:
         enabled &&
         project !== undefined &&
-        project.status !== PROJECT_STATUS.INACTIVE &&
-        project.status !== PROJECT_STATUS.COMING_UP &&
+        project.status === PROJECT_STATUS.ACTIVE_HEALTHY &&
         typeof projectRef !== 'undefined' &&
         IS_PLATFORM,
       ...options,


### PR DESCRIPTION
As per title, there has been feedback that the eligibility endpoint is getting queried while the project is being upgraded.  Change here just prevents the RQ from triggering unless project status is active healthy (I can't imagine a scenario where we need to query the upgrade eligibility when the project is not active)