### PR TITLE
Only render RestrictionBanner if user is logged in

### DIFF
--- a/apps/studio/components/interfaces/App/AppBannerWrapper.tsx
+++ b/apps/studio/components/interfaces/App/AppBannerWrapper.tsx
@@ -4,12 +4,14 @@ import { PropsWithChildren, useMemo } from 'react'
 
 import IncidentBanner from 'components/layouts/AppLayout/IncidentBanner'
 import { NoticeBanner } from 'components/layouts/AppLayout/NoticeBanner'
-import { RestrictrionBanner } from 'components/layouts/AppLayout/RestrictionBanner'
+import { RestrictionBanner } from 'components/layouts/AppLayout/RestrictionBanner'
 import { getTheme } from 'components/ui/CodeEditor/CodeEditor.utils'
 import { useFlag } from 'hooks/ui/useFlag'
+import { useProfile } from 'lib/profile'
 
 const AppBannerWrapper = ({ children }: PropsWithChildren<{}>) => {
   const monaco = useMonaco()
+  const { profile } = useProfile()
   const { resolvedTheme } = useTheme()
 
   const ongoingIncident = useFlag('ongoingIncident')
@@ -29,7 +31,7 @@ const AppBannerWrapper = ({ children }: PropsWithChildren<{}>) => {
       <div className="flex-none">
         {ongoingIncident && <IncidentBanner />}
         {showNoticeBanner && <NoticeBanner />}
-        <RestrictrionBanner />
+        {profile !== undefined && <RestrictionBanner />}
       </div>
       {children}
     </div>

--- a/apps/studio/components/layouts/AppLayout/RestrictionBanner.tsx
+++ b/apps/studio/components/layouts/AppLayout/RestrictionBanner.tsx
@@ -8,7 +8,7 @@ import { AlertTitle_Shadcn_, Alert_Shadcn_, Button, CriticalIcon, WarningIcon } 
 /**
  * Shown on projects in organization which are above their qouta
  */
-export const RestrictrionBanner = () => {
+export const RestrictionBanner = () => {
   const project = useSelectedProject()
   const { data } = useOrganizationsQuery()
   const currentOrg = data?.find((org) => org.id === project?.organization_id)

--- a/apps/studio/components/layouts/SignInLayout/SignInLayout.tsx
+++ b/apps/studio/components/layouts/SignInLayout/SignInLayout.tsx
@@ -1,4 +1,5 @@
 import { useQueryClient } from '@tanstack/react-query'
+import { FileText } from 'lucide-react'
 import { useTheme } from 'next-themes'
 import Image from 'next/legacy/image'
 import Link from 'next/link'
@@ -9,7 +10,7 @@ import { useFlag } from 'hooks/ui/useFlag'
 import { BASE_PATH } from 'lib/constants'
 import { auth, buildPathWithParams, getAccessToken, getReturnToPath } from 'lib/gotrue'
 import { tweets } from 'shared-data'
-import { Button, IconFileText } from 'ui'
+import { Button } from 'ui'
 
 type SignInLayoutProps = {
   heading: string
@@ -108,7 +109,7 @@ const SignInLayout = ({
             </div>
 
             <div className="items-center hidden space-x-3 md:ml-10 md:flex md:pr-4">
-              <Button asChild type="default" icon={<IconFileText />}>
+              <Button asChild type="default" icon={<FileText />}>
                 <Link href="https://supabase.com/docs" target="_blank" rel="noreferrer">
                   Documentation
                 </Link>

--- a/apps/studio/data/organizations/organizations-query.ts
+++ b/apps/studio/data/organizations/organizations-query.ts
@@ -1,17 +1,13 @@
-import { QueryClient, useQuery, useQueryClient, UseQueryOptions } from '@tanstack/react-query'
-import { get } from 'lib/common/fetch'
-import { API_URL } from 'lib/constants'
-import { useCallback } from 'react'
+import { QueryClient, useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { get, handleError } from 'data/fetchers'
 import type { Organization, ResponseError } from 'types'
 import { organizationKeys } from './keys'
 
 export async function getOrganizations(signal?: AbortSignal): Promise<Organization[]> {
-  const data = await get(`${API_URL}/organizations`, { signal })
-  if (data.error) throw data.error
+  const { data, error } = await get('/platform/organizations', { signal })
 
-  if (!Array.isArray(data)) {
-    return []
-  }
+  if (error) handleError(error)
+  if (!Array.isArray(data)) return []
 
   const sorted = (data as Organization[]).sort((a, b) => a.name.localeCompare(b.name))
   return sorted
@@ -23,12 +19,13 @@ export type OrganizationsError = ResponseError
 export const useOrganizationsQuery = <TData = OrganizationsData>({
   enabled = true,
   ...options
-}: UseQueryOptions<OrganizationsData, OrganizationsError, TData> = {}) =>
-  useQuery<OrganizationsData, OrganizationsError, TData>(
+}: UseQueryOptions<OrganizationsData, OrganizationsError, TData> = {}) => {
+  return useQuery<OrganizationsData, OrganizationsError, TData>(
     organizationKeys.list(),
     ({ signal }) => getOrganizations(signal),
     { enabled: enabled, ...options, staleTime: 30 * 60 * 1000 }
   )
+}
 
 export function invalidateOrganizationsQuery(client: QueryClient) {
   return client.invalidateQueries(organizationKeys.list())


### PR DESCRIPTION
RestrictionBanner uses the useOrganizationQuery, which will be throwing a 401 if the user is not logged in as this component lives at the app level (e.g on the sign in screen). The change in this PR will help 
- prevent unnecessary calls to the GET organization endpoint when user is not logged in
- reduce confusion in unrelated console errors while on the sign in page