### PR TITLE
Remove statement_timeout from custom-postgres-config.mdx

### DIFF
--- a/apps/docs/content/guides/platform/custom-postgres-config.mdx
+++ b/apps/docs/content/guides/platform/custom-postgres-config.mdx
@@ -32,7 +32,6 @@ The following parameters are available for overrides:
 1. [max_worker_processes](https://postgresqlco.nf/doc/en/param/max_worker_processes/)
 1. [session_replication_role](https://postgresqlco.nf/doc/en/param/session_replication_role/)
 1. [shared_buffers](https://postgresqlco.nf/doc/en/param/shared_buffers/)
-1. [statement_timeout](https://postgresqlco.nf/doc/en/param/statement_timeout/)
 1. [work_mem](https://postgresqlco.nf/doc/en/param/work_mem/)
 
 ### Setting config using the CLI
@@ -61,17 +60,6 @@ $ supabase --experimental --project-ref <project-ref> postgres-config update --c
 - Custom Postgres Config -
 Config                  |Value    |
 max_parallel_workers    |3        |
-- End of Custom Postgres Config -
-```
-
-When configuring parameters that require time units, such as `statement_timeout`, the CLI expects a string value with a time unit. Supported units include `ms`, `s`, and `min`.
-
-```bash
-$ supabase --experimental --project-ref <project-ref> postgres-config update --config statement_timeout=1000ms
-
-- Custom Postgres Config -
-Config            |Value   |
-statement_timeout |1000ms  |
 - End of Custom Postgres Config -
 ```
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

The CLI has a bug that prevents statement_timeout from finalizing.

## What is the current behavior?

The docs recommends using a dysfunctional feature of the CLI.

## What is the new behavior?

Removes references to statement_timeout from the custom config docs

## Additional context

The statement_timeout variable is a user level configuration, so it can be changed with raw SQL by the `postgres` role:
- ALTER DATABASE postgres SET statement_timeout = '20min';

The CLI changes cluster level configurations. It's highly atypical for users to need clusters, as they can't be configured with Auth, PostgREST, the Dashboard, nor Realtime. Considering that an alternative method exists to modify the settings and that the CLI command is broken, it's best to remove this option from the docs. 

A troubleshooting doc was made for timeouts that should be adequate for developers:
- https://supabase.com/docs/guides/database/postgres/timeouts

