### PR TITLE
[dashboard] fix: auth policies button

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/GridHeaderActions.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/GridHeaderActions.tsx
@@ -21,7 +21,7 @@ import useEntityType from 'hooks/misc/useEntityType'
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
 import { TableLike } from 'hooks/misc/useTable'
 import { EXCLUDED_SCHEMAS } from 'lib/constants/schemas'
-import { Button, PopoverContent_Shadcn_, PopoverTrigger_Shadcn_, Popover_Shadcn_ } from 'ui'
+import { Button, PopoverContent_Shadcn_, PopoverTrigger_Shadcn_, Popover_Shadcn_, cn } from 'ui'
 import ConfirmModal from 'ui-patterns/Dialogs/ConfirmDialog'
 import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
 import { RoleImpersonationPopover } from '../RoleImpersonationSelector'
@@ -228,9 +228,19 @@ const GridHeaderActions = ({ table }: GridHeaderActionsProps) => {
                   className="group"
                   icon={
                     isLocked || policies.length > 0 ? (
-                      <span className="text-right text-xs rounded-xl px-[6px] bg-foreground-lighter/30 text-brand-1100">
-                        {policies.length}
-                      </span>
+                      <div
+                        className={cn(
+                          'flex items-center justify-center',
+                          policies.length > 9
+                            ? 'h-[16px] px-1 rounded-full'
+                            : 'h-[16px] w-[16px] rounded-full',
+                          'bg-border-stronger'
+                        )}
+                      >
+                        <span className="text-[11px] text-foreground font-mono text-center">
+                          {policies.length}
+                        </span>
+                      </div>
                     ) : (
                       <PlusCircle strokeWidth={1.5} />
                     )

--- a/apps/studio/components/interfaces/TableGridEditor/GridHeaderActions.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/GridHeaderActions.tsx
@@ -230,11 +230,9 @@ const GridHeaderActions = ({ table }: GridHeaderActionsProps) => {
                     isLocked || policies.length > 0 ? (
                       <div
                         className={cn(
-                          'flex items-center justify-center',
-                          policies.length > 9
-                            ? 'h-[16px] px-1 rounded-full'
-                            : 'h-[16px] w-[16px] rounded-full',
-                          'bg-border-stronger'
+                          'flex items-center justify-center rounded-full bg-border-stronger h-[16px]',
+                          policies.length > 9 ? ' px-1' : 'w-[16px]',
+                          ''
                         )}
                       >
                         <span className="text-[11px] text-foreground font-mono text-center">


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

- color contrast fixed
- when below 10 policies uses a circle badge

<img width="367" alt="Screenshot 2024-08-09 at 1 31 04 PM" src="https://github.com/user-attachments/assets/660891f5-19ec-4429-842a-9371806bf6d4">
<img width="392" alt="Screenshot 2024-08-09 at 1 30 52 PM" src="https://github.com/user-attachments/assets/42bfd2c1-d5c7-4e2b-9a6a-65d2bb7fc6a6">

before:
<img width="262" alt="Screenshot 2024-08-09 at 1 32 08 PM" src="https://github.com/user-attachments/assets/ebbd0f35-ee49-46d3-a552-f5bcf950778f">
