### PR TITLE
Reinstate default sort but limited to within threshold row count

### DIFF
--- a/apps/studio/components/grid/SupabaseGrid.utils.ts
+++ b/apps/studio/components/grid/SupabaseGrid.utils.ts
@@ -120,6 +120,7 @@ export function parseSupaTable(
     comment: table.comment,
     schema: table.schema,
     columns: supaColumns,
+    estimateRowCount: table.live_rows_estimate,
   }
 }
 

--- a/apps/studio/components/grid/components/grid/Grid.tsx
+++ b/apps/studio/components/grid/components/grid/Grid.tsx
@@ -11,7 +11,7 @@ import { GenericSkeletonLoader } from 'components/ui/ShimmeringLoader'
 import { useForeignKeyConstraintsQuery } from 'data/database/foreign-key-constraints-query'
 import { useUrlState } from 'hooks/ui/useUrlState'
 import { copyToClipboard } from 'lib/helpers'
-import { Button } from 'ui'
+import { Button, cn } from 'ui'
 import { useDispatch, useTrackedState } from '../../store/Store'
 import type { Filter, GridProps, SupaRow } from '../../types'
 import { useKeyboardShortcuts } from '../common/Hooks'
@@ -170,7 +170,7 @@ export const Grid = memo(
 
       return (
         <div
-          className={`${containerClass} flex flex-col`}
+          className={cn(`flex flex-col`, containerClass)}
           style={{ width: width || '100%', height: height || '50vh' }}
         >
           <DataGrid

--- a/apps/studio/components/grid/types/table.ts
+++ b/apps/studio/components/grid/types/table.ts
@@ -24,6 +24,7 @@ export interface SupaTable {
   readonly name: string
   readonly schema?: string | null
   readonly comment?: string | null
+  readonly estimateRowCount: number
 }
 
 export interface SupaRow extends Dictionary<any> {

--- a/apps/studio/components/layouts/ProjectLayout/LayoutHeader/LayoutHeader.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/LayoutHeader/LayoutHeader.tsx
@@ -47,7 +47,7 @@ const LayoutHeader = ({ customHeaderComponents, breadcrumbs = [], headerBorder =
 
   return (
     <div
-      className={`flex min-h-12 max-h-12 items-center justify-between py-2 px-5 bg-dash-sidebar ${
+      className={`flex h-12 max-h-12 min-h-12 items-center justify-between py-2 px-5 bg-dash-sidebar ${
         headerBorder ? 'border-b border-default' : ''
       }`}
     >

--- a/apps/studio/components/layouts/ProjectLayout/LayoutHeader/LayoutHeader.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/LayoutHeader/LayoutHeader.tsx
@@ -47,7 +47,7 @@ const LayoutHeader = ({ customHeaderComponents, breadcrumbs = [], headerBorder =
 
   return (
     <div
-      className={`flex h-12 max-h-12 items-center justify-between py-2 px-5 bg-dash-sidebar ${
+      className={`flex min-h-12 max-h-12 items-center justify-between py-2 px-5 bg-dash-sidebar ${
         headerBorder ? 'border-b border-default' : ''
       }`}
     >


### PR DESCRIPTION
The original problem we were addressing was that users would be confused when updating a column cell in the table editor as the rows would get "sorted" if the table did not have a sort applied to it. (more specifically - the updated row will be chucked to the bottom of the last page, or the bottom of the select query)
- You can easily reproduce this with the Countries quick start SQL template, then updating a cell value

This is technically the nature of PG - the order of the rows is not deterministic without a specific ORDER BY param, although understandably is a source of UX confusion. We've previously tried to mitigate this by applying a "default sort" (ORDER BY) when retrieving the rows in the table editor by apply an ORDER BY with the table's primary key if available. However, this caused performance issues for large tables (> 1m rows) and was also causing resource constraint issues on the database itself. Hence we [previously removed it](https://github.com/supabase/supabase/pull/28072)

We've now going to reinstate this behaviour, but within boundaries by only applying the default sort if the table has a row count within a specific threshold limit (in this case, 50k). This should strike a balance between a better UX when updating smaller tables, and releasing the hand-hold for larger tables