### PR TITLE
Support deleting project in restore failed state

### DIFF
--- a/apps/studio/components/interfaces/Auth/Policies/PolicyTableRow/PolicyRow.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/PolicyTableRow/PolicyRow.tsx
@@ -7,6 +7,7 @@ import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectConte
 import Panel from 'components/ui/Panel'
 import { useAuthConfigQuery } from 'data/auth/auth-config-query'
 import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import { Edit, MoreVertical, Trash } from 'lucide-react'
 import {
   Badge,
   Button,
@@ -15,9 +16,6 @@ import {
   DropdownMenuItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-  IconEdit,
-  IconMoreVertical,
-  IconTrash,
 } from 'ui'
 
 interface PolicyRowProps {
@@ -96,17 +94,17 @@ const PolicyRow = ({
               <Button
                 type="default"
                 style={{ paddingLeft: 4, paddingRight: 4 }}
-                icon={<IconMoreVertical />}
+                icon={<MoreVertical />}
               />
             </DropdownMenuTrigger>
             <DropdownMenuContent side="bottom" align="end" className="w-40">
               <DropdownMenuItem className="space-x-2" onClick={() => onSelectEditPolicy(policy)}>
-                <IconEdit size={14} />
+                <Edit size={14} />
                 <p>Edit policy</p>
               </DropdownMenuItem>
               <DropdownMenuSeparator />
               <DropdownMenuItem className="space-x-2" onClick={() => onSelectDeletePolicy(policy)}>
-                <IconTrash size={14} />
+                <Trash size={14} />
                 <p>Delete policy</p>
               </DropdownMenuItem>
             </DropdownMenuContent>
@@ -118,7 +116,7 @@ const PolicyRow = ({
                 disabled
                 type="default"
                 style={{ paddingLeft: 4, paddingRight: 4 }}
-                icon={<IconMoreVertical />}
+                icon={<MoreVertical />}
               />
             </Tooltip.Trigger>
             {!canUpdatePolicies && (

--- a/apps/studio/components/interfaces/Settings/General/DeleteProjectPanel/DeleteProjectButton.tsx
+++ b/apps/studio/components/interfaces/Settings/General/DeleteProjectPanel/DeleteProjectButton.tsx
@@ -1,200 +1,39 @@
-import * as Tooltip from '@radix-ui/react-tooltip'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
-import { useRouter } from 'next/router'
-import { useEffect, useState } from 'react'
-import toast from 'react-hot-toast'
+import { useState } from 'react'
 
-import { CANCELLATION_REASONS } from 'components/interfaces/Billing/Billing.constants'
 import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
-import { useSendDowngradeFeedbackMutation } from 'data/feedback/exit-survey-send'
-import { useProjectDeleteMutation } from 'data/projects/project-delete-mutation'
-import { useOrgSubscriptionQuery } from 'data/subscriptions/org-subscription-query'
+import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
-import { useSelectedOrganization } from 'hooks/misc/useSelectedOrganization'
-import { Button, Input } from 'ui'
-import TextConfirmModal from 'ui-patterns/Dialogs/TextConfirmModal'
+import DeleteProjectModal from './DeleteProjectModal'
 
 export interface DeleteProjectButtonProps {
   type?: 'danger' | 'default'
 }
 
 const DeleteProjectButton = ({ type = 'danger' }: DeleteProjectButtonProps) => {
-  const router = useRouter()
   const { project } = useProjectContext()
-  const organization = useSelectedOrganization()
-
-  const projectRef = project?.ref
-  const { data: subscription } = useOrgSubscriptionQuery({ orgSlug: organization?.slug })
-  const projectPlan = subscription?.plan?.id ?? 'free'
-  const isFree = projectPlan === 'free'
-
   const [isOpen, setIsOpen] = useState(false)
-  const [message, setMessage] = useState<string>('')
-  const [selectedReasons, setSelectedReasons] = useState<string[]>([])
-
-  const { mutate: deleteProject, isLoading: isDeleting } = useProjectDeleteMutation({
-    onSuccess: async () => {
-      if (!isFree) {
-        try {
-          await sendExitSurvey({
-            projectRef,
-            message,
-            reasons: selectedReasons.reduce((a, b) => `${a}- ${b}\n`, ''),
-            exitAction: 'delete',
-          })
-        } catch (error) {
-          // [Joshen] In this case we don't raise any errors if the exit survey fails to send since it shouldn't block the user
-        }
-      }
-
-      toast.success(`Successfully deleted ${project?.name}`)
-      router.push(`/projects`)
-    },
-  })
-  const { mutateAsync: sendExitSurvey, isLoading: isSending } = useSendDowngradeFeedbackMutation()
-  const isSubmitting = isDeleting || isSending
-
-  useEffect(() => {
-    if (isOpen) {
-      setSelectedReasons([])
-      setMessage('')
-    }
-  }, [isOpen])
 
   const canDeleteProject = useCheckPermissions(PermissionAction.UPDATE, 'projects', {
-    resource: {
-      project_id: project?.id,
-    },
+    resource: { project_id: project?.id },
   })
-
-  const toggle = () => {
-    if (isSubmitting) return
-    setIsOpen(!isOpen)
-  }
-
-  const onSelectCancellationReason = (reason: string) => {
-    const existingSelection = selectedReasons.find((x) => x === reason)
-    const updatedSelection =
-      existingSelection === undefined
-        ? selectedReasons.concat([reason])
-        : selectedReasons.filter((x) => x !== reason)
-    setSelectedReasons(updatedSelection)
-  }
-
-  async function handleDeleteProject() {
-    if (project === undefined) return
-    if (!isFree && selectedReasons.length === 0) {
-      return toast.error('Please select at least one reason for deleting your project')
-    }
-
-    deleteProject({ projectRef: project.ref })
-  }
 
   return (
     <>
-      <Tooltip.Root delayDuration={0}>
-        <Tooltip.Trigger asChild>
-          <Button onClick={toggle} type={type} disabled={!canDeleteProject}>
-            Delete project
-          </Button>
-        </Tooltip.Trigger>
-        {!canDeleteProject && (
-          <Tooltip.Portal>
-            <Tooltip.Content side="bottom">
-              <Tooltip.Arrow className="radix-tooltip-arrow" />
-              <div
-                className={[
-                  'rounded bg-alternative py-1 px-2 leading-none shadow', // background
-                  'border border-background', //border
-                ].join(' ')}
-              >
-                <span className="text-xs text-foreground">
-                  You need additional permissions to delete this project
-                </span>
-              </div>
-            </Tooltip.Content>
-          </Tooltip.Portal>
-        )}
-      </Tooltip.Root>
-      <TextConfirmModal
-        visible={isOpen}
-        loading={isSubmitting}
-        size={isFree ? 'small' : 'medium'}
-        title={`Confirm deletion of ${project?.name}`}
-        variant="destructive"
-        alert={{
-          title: isFree
-            ? 'This action cannot be undone.'
-            : `This will permanently delete the ${project?.name}`,
-          description: !isFree ? `All project data will be lost, and cannot be undone` : '',
+      <ButtonTooltip
+        type={type}
+        disabled={!canDeleteProject}
+        onClick={() => setIsOpen(true)}
+        tooltip={{
+          content: {
+            side: 'bottom',
+            text: 'You need additional permissions to delete this project',
+          },
         }}
-        text={
-          isFree
-            ? `This will permanently delete the ${project?.name} project and all of its data.`
-            : undefined
-        }
-        confirmPlaceholder="Type the project name in here"
-        confirmString={project?.name || ''}
-        confirmLabel="I understand, delete this project"
-        onConfirm={handleDeleteProject}
-        onCancel={toggle}
       >
-        {/* 
-          [Joshen] This is basically ExitSurvey.tsx, ideally we have one shared component but the one
-          in ExitSurvey has a Form wrapped around it already. Will probably need some effort to refactor
-          but leaving that for the future.
-        */}
-        {!isFree && (
-          <>
-            <div className="space-y-1">
-              <h4 className="text-base">We're sad that you're leaving.</h4>
-              <p className="text-sm text-foreground-light">
-                We always strive to improve Supabase as much as we can. Please let us know the
-                reasons you are deleting your project so that we can improve in the future.
-              </p>
-            </div>
-            <div className="space-y-4 pt-4">
-              <div className="flex flex-wrap gap-2" data-toggle="buttons">
-                {CANCELLATION_REASONS.map((option) => {
-                  const active = selectedReasons.find((x) => x === option)
-                  return (
-                    <label
-                      key={option}
-                      className={[
-                        'flex cursor-pointer items-center space-x-2 rounded-md py-1',
-                        'pl-2 pr-3 text-center text-sm shadow-sm transition-all duration-100',
-                        `${
-                          active
-                            ? ` bg-foreground text-background opacity-100 hover:bg-opacity-75`
-                            : ` bg-border-strong text-foreground opacity-25 hover:opacity-50`
-                        }`,
-                      ].join(' ')}
-                    >
-                      <input
-                        type="checkbox"
-                        name="options"
-                        value={option}
-                        className="hidden"
-                        onClick={(event: any) => onSelectCancellationReason(event.target.value)}
-                      />
-                      <div>{option}</div>
-                    </label>
-                  )
-                })}
-              </div>
-              <div className="text-area-text-sm">
-                <Input.TextArea
-                  name="message"
-                  label="Anything else that we can improve on?"
-                  rows={3}
-                  value={message}
-                  onChange={(event) => setMessage(event.target.value)}
-                />
-              </div>
-            </div>
-          </>
-        )}
-      </TextConfirmModal>
+        Delete project
+      </ButtonTooltip>
+      <DeleteProjectModal visible={isOpen} onClose={() => setIsOpen(false)} />
     </>
   )
 }

--- a/apps/studio/components/interfaces/Settings/General/DeleteProjectPanel/DeleteProjectModal.tsx
+++ b/apps/studio/components/interfaces/Settings/General/DeleteProjectPanel/DeleteProjectModal.tsx
@@ -1,0 +1,169 @@
+import { PermissionAction } from '@supabase/shared-types/out/constants'
+import { useRouter } from 'next/router'
+import { useEffect, useState } from 'react'
+import toast from 'react-hot-toast'
+
+import { CANCELLATION_REASONS } from 'components/interfaces/Billing/Billing.constants'
+import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
+import { useSendDowngradeFeedbackMutation } from 'data/feedback/exit-survey-send'
+import { useProjectDeleteMutation } from 'data/projects/project-delete-mutation'
+import { useOrgSubscriptionQuery } from 'data/subscriptions/org-subscription-query'
+import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import { useSelectedOrganization } from 'hooks/misc/useSelectedOrganization'
+import { Input } from 'ui'
+import TextConfirmModal from 'ui-patterns/Dialogs/TextConfirmModal'
+
+const DeleteProjectModal = ({ visible, onClose }: { visible: boolean; onClose: () => void }) => {
+  const router = useRouter()
+  const { project } = useProjectContext()
+  const organization = useSelectedOrganization()
+
+  const projectRef = project?.ref
+  const { data: subscription } = useOrgSubscriptionQuery({ orgSlug: organization?.slug })
+  const projectPlan = subscription?.plan?.id ?? 'free'
+  const isFree = projectPlan === 'free'
+
+  const [message, setMessage] = useState<string>('')
+  const [selectedReasons, setSelectedReasons] = useState<string[]>([])
+
+  const { mutate: deleteProject, isLoading: isDeleting } = useProjectDeleteMutation({
+    onSuccess: async () => {
+      if (!isFree) {
+        try {
+          await sendExitSurvey({
+            projectRef,
+            message,
+            reasons: selectedReasons.reduce((a, b) => `${a}- ${b}\n`, ''),
+            exitAction: 'delete',
+          })
+        } catch (error) {
+          // [Joshen] In this case we don't raise any errors if the exit survey fails to send since it shouldn't block the user
+        }
+      }
+
+      toast.success(`Successfully deleted ${project?.name}`)
+      router.push(`/projects`)
+    },
+  })
+  const { mutateAsync: sendExitSurvey, isLoading: isSending } = useSendDowngradeFeedbackMutation()
+  const isSubmitting = isDeleting || isSending
+
+  useEffect(() => {
+    if (visible) {
+      setSelectedReasons([])
+      setMessage('')
+    }
+  }, [visible])
+
+  const canDeleteProject = useCheckPermissions(PermissionAction.UPDATE, 'projects', {
+    resource: {
+      project_id: project?.id,
+    },
+  })
+
+  const onSelectCancellationReason = (reason: string) => {
+    const existingSelection = selectedReasons.find((x) => x === reason)
+    const updatedSelection =
+      existingSelection === undefined
+        ? selectedReasons.concat([reason])
+        : selectedReasons.filter((x) => x !== reason)
+    setSelectedReasons(updatedSelection)
+  }
+
+  async function handleDeleteProject() {
+    if (project === undefined) return
+    if (!isFree && selectedReasons.length === 0) {
+      return toast.error('Please select at least one reason for deleting your project')
+    }
+
+    deleteProject({ projectRef: project.ref })
+  }
+
+  return (
+    <>
+      <TextConfirmModal
+        visible={visible}
+        loading={isSubmitting}
+        size={isFree ? 'small' : 'medium'}
+        title={`Confirm deletion of ${project?.name}`}
+        variant="destructive"
+        alert={{
+          title: isFree
+            ? 'This action cannot be undone.'
+            : `This will permanently delete the ${project?.name}`,
+          description: !isFree ? `All project data will be lost, and cannot be undone` : '',
+        }}
+        text={
+          isFree
+            ? `This will permanently delete the ${project?.name} project and all of its data.`
+            : undefined
+        }
+        confirmPlaceholder="Type the project name in here"
+        confirmString={project?.name || ''}
+        confirmLabel="I understand, delete this project"
+        onConfirm={handleDeleteProject}
+        onCancel={() => {
+          if (!isSubmitting) onClose()
+        }}
+      >
+        {/* 
+          [Joshen] This is basically ExitSurvey.tsx, ideally we have one shared component but the one
+          in ExitSurvey has a Form wrapped around it already. Will probably need some effort to refactor
+          but leaving that for the future.
+        */}
+        {!isFree && (
+          <>
+            <div className="space-y-1">
+              <h4 className="text-base">We're sad that you're leaving.</h4>
+              <p className="text-sm text-foreground-light">
+                We always strive to improve Supabase as much as we can. Please let us know the
+                reasons you are deleting your project so that we can improve in the future.
+              </p>
+            </div>
+            <div className="space-y-4 pt-4">
+              <div className="flex flex-wrap gap-2" data-toggle="buttons">
+                {CANCELLATION_REASONS.map((option) => {
+                  const active = selectedReasons.find((x) => x === option)
+                  return (
+                    <label
+                      key={option}
+                      className={[
+                        'flex cursor-pointer items-center space-x-2 rounded-md py-1',
+                        'pl-2 pr-3 text-center text-sm shadow-sm transition-all duration-100',
+                        `${
+                          active
+                            ? ` bg-foreground text-background opacity-100 hover:bg-opacity-75`
+                            : ` bg-border-strong text-foreground opacity-25 hover:opacity-50`
+                        }`,
+                      ].join(' ')}
+                    >
+                      <input
+                        type="checkbox"
+                        name="options"
+                        value={option}
+                        className="hidden"
+                        onClick={(event: any) => onSelectCancellationReason(event.target.value)}
+                      />
+                      <div>{option}</div>
+                    </label>
+                  )
+                })}
+              </div>
+              <div className="text-area-text-sm">
+                <Input.TextArea
+                  name="message"
+                  label="Anything else that we can improve on?"
+                  rows={3}
+                  value={message}
+                  onChange={(event) => setMessage(event.target.value)}
+                />
+              </div>
+            </div>
+          </>
+        )}
+      </TextConfirmModal>
+    </>
+  )
+}
+
+export default DeleteProjectModal

--- a/apps/studio/components/layouts/DatabaseLayout/DatabaseLayout.tsx
+++ b/apps/studio/components/layouts/DatabaseLayout/DatabaseLayout.tsx
@@ -42,7 +42,7 @@ const DatabaseProductMenu = () => {
           columnLevelPrivileges,
         })}
       />
-      <div className="px-3">
+      <div className="px-3 pb-3">
         <Alert_Shadcn_>
           <AlertTitle_Shadcn_ className="text-sm">
             Replication section has been renamed

--- a/apps/studio/components/layouts/ProjectLayout/RestoreFailedState.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/RestoreFailedState.tsx
@@ -47,10 +47,20 @@ const RestoreFailedState = () => {
                 <DropdownMenuTrigger>
                   <Button type="default" className="px-1.5" icon={<MoreVertical />} />
                 </DropdownMenuTrigger>
-                <DropdownMenuContent className="w-48" align="end">
-                  <DropdownMenuItem onClick={() => setVisible(true)} className="gap-x-2">
-                    <Trash size={14} />
-                    Delete project
+                <DropdownMenuContent className="w-72" align="end">
+                  <DropdownMenuItem
+                    onClick={() => setVisible(true)}
+                    className="items-start gap-x-2"
+                  >
+                    <div className="translate-y-0.5">
+                      <Trash size={14} />
+                    </div>
+                    <div className="">
+                      <p>Delete project</p>
+                      <p className="text-foreground-lighter">
+                        Project cannot be restored once it is deleted
+                      </p>
+                    </div>
                   </DropdownMenuItem>
                 </DropdownMenuContent>
               </DropdownMenu>

--- a/apps/studio/components/layouts/ProjectLayout/RestoreFailedState.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/RestoreFailedState.tsx
@@ -1,40 +1,65 @@
+import { MoreVertical, Trash } from 'lucide-react'
 import Link from 'next/link'
+import { useState } from 'react'
 
-import { Button, CriticalIcon } from 'ui'
+import DeleteProjectModal from 'components/interfaces/Settings/General/DeleteProjectPanel/DeleteProjectModal'
+import {
+  Button,
+  CriticalIcon,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from 'ui'
 import { useProjectContext } from './ProjectContext'
 
 const RestoreFailedState = () => {
   const { project } = useProjectContext()
+  const [visible, setVisible] = useState(false)
 
   return (
-    <div className="flex items-center justify-center h-full">
-      <div className="bg-surface-100 border border-overlay rounded-md w-3/4 lg:w-1/2">
-        <div className="space-y-6 pt-6">
-          <div className="flex px-8 space-x-8">
-            <div className="mt-1">
-              <CriticalIcon className="w-5 h-5" />
+    <>
+      <div className="flex items-center justify-center h-full">
+        <div className="bg-surface-100 border border-overlay rounded-md w-3/4 lg:w-1/2">
+          <div className="space-y-6 pt-6">
+            <div className="flex px-8 space-x-8">
+              <div className="mt-1">
+                <CriticalIcon className="w-5 h-5" />
+              </div>
+              <div className="space-y-1">
+                <p>Something went wrong while restoring your project</p>
+                <p className="text-sm text-foreground-light">
+                  Your project's data is intact, but your project is inaccessible due to the
+                  restoration failure. Please contact support for assistance.
+                </p>
+              </div>
             </div>
-            <div className="space-y-1">
-              <p>Something went wrong while restoring your project</p>
-              <p className="text-sm text-foreground-light">
-                Your project's data is intact, but your project is inaccessible due to the
-                restoration failure. Please contact support for assistance.
-              </p>
-            </div>
-          </div>
 
-          <div className="border-t border-overlay flex items-center justify-end py-4 px-8">
-            <Button asChild type="default">
-              <Link
-                href={`/support/new?category=Database_unresponsive&ref=${project?.ref}&subject=Restoration%20failed%20for%20project`}
-              >
-                Contact support
-              </Link>
-            </Button>
+            <div className="border-t border-overlay flex items-center justify-end py-4 px-8 gap-x-2">
+              <Button asChild type="default">
+                <Link
+                  href={`/support/new?category=Database_unresponsive&ref=${project?.ref}&subject=Restoration%20failed%20for%20project`}
+                >
+                  Contact support
+                </Link>
+              </Button>
+              <DropdownMenu>
+                <DropdownMenuTrigger>
+                  <Button type="default" className="px-1.5" icon={<MoreVertical />} />
+                </DropdownMenuTrigger>
+                <DropdownMenuContent className="w-48" align="end">
+                  <DropdownMenuItem onClick={() => setVisible(true)} className="gap-x-2">
+                    <Trash size={14} />
+                    Delete project
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
           </div>
         </div>
       </div>
-    </div>
+      <DeleteProjectModal visible={visible} onClose={() => setVisible(false)} />
+    </>
   )
 }
 


### PR DESCRIPTION
As per title:
![image](https://github.com/user-attachments/assets/90b1ab6d-b9e7-4f50-b40f-95d618037324)

Opting to put it behind a dropdown as I'd avoid raising the delete project CTA in this context - its not always the case that a user would want to delete the project for a failed restore state (and may unnecessarily raise anxiety seeing that CTA if the failed restore was indeed something went wrong)