### PR TITLE
DOCS: Add warning about user sessions leaking into service client

### DIFF
--- a/apps/docs/content/guides/database/postgres/row-level-security.mdx
+++ b/apps/docs/content/guides/database/postgres/row-level-security.mdx
@@ -266,6 +266,12 @@ Supabase will adhere to the RLS policy of the signed-in user, even if the client
 
 </Admonition>
 
+<Admonition type="caution">
+
+Using a Service client for auth-related operations (such as serviceClient.auth.signUp()) will cause the service client to embed the user session. This will prevent the service client from bypassing RLS in subsequent database operations that rely on the same client.
+
+</Admonition>
+
 You can also create new [Postgres Roles](/docs/guides/database/postgres/roles) which can bypass Row Level Security using the "bypass RLS" privilege:
 
 ```sql


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?
Adds a callout to the [Bypassing Row Level Security](https://supabase.com/docs/guides/database/postgres/row-level-security#bypassing-row-level-security) section of the docs clarifying an edge case where a session can accidentally make its way into a service client, causing the service client to no longer bypass RLS.

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

New docs callout on:
[Bypassing Row Level Security
](https://supabase.com/docs/guides/database/postgres/row-level-security#bypassing-row-level-security)


## Additional context

Add any other context or screenshots.
