### PR TITLE
Estimate the estimated count in table editor

### DIFF
--- a/apps/studio/components/grid/components/footer/pagination/Pagination.tsx
+++ b/apps/studio/components/grid/components/footer/pagination/Pagination.tsx
@@ -20,6 +20,7 @@ import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
 import { useParams } from 'common'
 import { useDispatch, useTrackedState } from '../../../store/Store'
 import { DropdownControl } from '../../common/DropdownControl'
+import { formatEstimatedCount } from './Pagination.utils'
 
 const rowsPerPageOptions = [
   { value: 100, label: '100 rows' },
@@ -71,6 +72,7 @@ const Pagination = () => {
     }
   )
 
+  const count = data?.is_estimate ? formatEstimatedCount(data.count) : data?.count.toLocaleString()
   const maxPages = Math.ceil((data?.count ?? 0) / snap.rowsPerPage)
   const totalPages = (data?.count ?? 0) > 0 ? maxPages : 1
 
@@ -193,9 +195,7 @@ const Pagination = () => {
 
           <div className="flex items-center gap-x-2">
             <p className="text-xs text-foreground-light">
-              {`${data.count.toLocaleString()} ${
-                data.count === 0 || data.count > 1 ? `records` : 'record'
-              }`}{' '}
+              {`${count} ${data.count === 0 || data.count > 1 ? `records` : 'record'}`}{' '}
               {data.is_estimate ? '(estimated)' : ''}
             </p>
 

--- a/apps/studio/components/grid/components/footer/pagination/Pagination.utils.test.ts
+++ b/apps/studio/components/grid/components/footer/pagination/Pagination.utils.test.ts
@@ -1,0 +1,48 @@
+import { formatEstimatedCount } from './Pagination.utils'
+
+describe('formatEstimatedCount', () => {
+  test('Should estimate thousands correctly (I)', () => {
+    const output = formatEstimatedCount(1530)
+    expect(output).toStrictEqual('1.5K')
+  })
+  test('Should estimate thousands correctly (II)', () => {
+    const output = formatEstimatedCount(15310)
+    expect(output).toStrictEqual('15.3K')
+  })
+  test('Should estimate thousands correctly (III)', () => {
+    const output = formatEstimatedCount(153122)
+    expect(output).toStrictEqual('153.1K')
+  })
+  test('Should estimate millions correctly (I)', () => {
+    const output = formatEstimatedCount(1531021)
+    expect(output).toStrictEqual('1.5M')
+  })
+  test('Should estimate millions correctly (II)', () => {
+    const output = formatEstimatedCount(15310212)
+    expect(output).toStrictEqual('15.3M')
+  })
+  test('Should estimate millions correctly (III)', () => {
+    const output = formatEstimatedCount(153102121)
+    expect(output).toStrictEqual('153.1M')
+  })
+  test('Should estimate billions correctly (I)', () => {
+    const output = formatEstimatedCount(1531021211)
+    expect(output).toStrictEqual('1.5B')
+  })
+  test('Should estimate billions correctly (II)', () => {
+    const output = formatEstimatedCount(15310212112)
+    expect(output).toStrictEqual('15.3B')
+  })
+  test('Should estimate billions correctly (III)', () => {
+    const output = formatEstimatedCount(153102121123)
+    expect(output).toStrictEqual('153.1B')
+  })
+  test('Should estimate trillions correctly (I)', () => {
+    const output = formatEstimatedCount(1531021211232)
+    expect(output).toStrictEqual('1.5T')
+  })
+  test('Should estimate trillions correctly (II) and max out at trillions', () => {
+    const output = formatEstimatedCount(1531021211232222)
+    expect(output).toStrictEqual('1531.0T')
+  })
+})

--- a/apps/studio/components/grid/components/footer/pagination/Pagination.utils.ts
+++ b/apps/studio/components/grid/components/footer/pagination/Pagination.utils.ts
@@ -1,0 +1,11 @@
+export const formatEstimatedCount = (value: number) => {
+  const sizes = ['', 'K', 'M', 'B', 'T']
+  if (value === 0) return '0'
+
+  const k = 1000
+  const i = Math.floor(Math.log(value) / Math.log(k))
+
+  const unit = i > 4 ? 'T' : sizes[i]
+
+  return `${(value / Math.pow(k, i > 4 ? 4 : i)).toFixed(1)}${unit}`
+}


### PR DESCRIPTION
Use rounded numbers instead of the exact "estimated" value (the exactness of the estimate can easily throw users off).

Before: 
![image](https://github.com/user-attachments/assets/ba645bf2-81f3-40be-b14d-4c36701bdeae)

After:
![image](https://github.com/user-attachments/assets/cca00ffd-78f2-4200-8214-0d76d0f10bea)
