### PR TITLE
fix: typo in tooltip for advisor

### DIFF
--- a/apps/studio/components/interfaces/Linter/Linter.constants.ts
+++ b/apps/studio/components/interfaces/Linter/Linter.constants.ts
@@ -18,7 +18,7 @@ export const LINT_TABS = [
   {
     id: LINTER_LEVELS.ERROR,
     label: 'Errors',
-    description: 'You should consider these issues urgent and and fix them as soon as you can.',
+    description: 'You should consider these issues urgent and fix them as soon as you can.',
   },
   {
     id: LINTER_LEVELS.WARN,


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

fix for typo in security advisor tooltip

## What is the current behavior?

Tooltip for urgent errors - "You should consider these issues urgent and and fix them as soon as you can."

## What is the new behavior?

Tooltip for urgent errors - "You should consider these issues urgent and fix them as soon as you can."

## Additional context
