### PR TITLE
docs: Add error codes reference docs for Flutter

### DIFF
--- a/apps/docs/docs/ref/dart/auth-error-codes.mdx
+++ b/apps/docs/docs/ref/dart/auth-error-codes.mdx
@@ -1,0 +1,12 @@
+Supabase Auth can throw or return various errors when using the API. All errors originating from the `supabase.auth` namespace of the client library will be wrapped by the `AuthException` class.
+
+Error objects are split in a few classes. `AuthApiException` is exception which originate from the Supabase Auth API.
+
+Errors originating from the server API classed as `AuthApiException` always have a `code` property that can be used to identify the error returned by the server. The `statusCode` property is also present, encoding the HTTP status code received in the response.
+
+<AuthErrorCodesTable />
+
+### Tips for better error handling
+
+- Do not use string matching on error messages! Always use the error classes and `code` properties of error objects to identify the situation.
+- Although HTTP status codes generally don't change, they can suddenly change due to bugs, so avoid relying on them unless absolutely necessary.

--- a/apps/docs/docs/ref/dart/auth-error-codes.mdx
+++ b/apps/docs/docs/ref/dart/auth-error-codes.mdx
@@ -1,6 +1,6 @@
 Supabase Auth can throw or return various errors when using the API. All errors originating from the `supabase.auth` namespace of the client library will be wrapped by the `AuthException` class.
 
-Error objects are split in a few classes. `AuthApiException` is exception which originate from the Supabase Auth API.
+Error objects are split in a few classes. `AuthApiException` is an exception which originates from the Supabase Auth API.
 
 Errors originating from the server API classed as `AuthApiException` always have a `code` property that can be used to identify the error returned by the server. The `statusCode` property is also present, encoding the HTTP status code received in the response.
 

--- a/apps/docs/spec/common-client-libs-sections.json
+++ b/apps/docs/spec/common-client-libs-sections.json
@@ -406,7 +406,6 @@
         "type": "markdown",
         "excludes": [
           "reference_dart_v1",
-          "reference_dart_v2",
           "reference_python_v2",
           "reference_swift_v1",
           "reference_swift_v2"


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

The supabase-flutter library recently added support for error codes. This PR adds the error codes section to the Flutter reference docs.