### PR TITLE
Chore/auth policies page fixes

### DIFF
--- a/apps/studio/components/grid/components/menu/ColumnMenu.tsx
+++ b/apps/studio/components/grid/components/menu/ColumnMenu.tsx
@@ -7,13 +7,10 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
   IconChevronDown,
-  IconEdit,
-  IconLock,
-  IconTrash,
-  IconUnlock,
   Separator,
 } from 'ui'
 
+import { ChevronDown, Edit, Lock, Trash, Unlock } from 'lucide-react'
 import { useDispatch, useTrackedState } from '../../store/Store'
 
 interface ColumnMenuProps {
@@ -51,7 +48,7 @@ const ColumnMenu = ({ column, isEncrypted }: ColumnMenuProps) => {
           <Tooltip.Root delayDuration={0}>
             <Tooltip.Trigger asChild className={`${isEncrypted ? 'opacity-50' : ''}`}>
               <DropdownMenuItem className="space-x-2" onClick={onEditColumn} disabled={isEncrypted}>
-                <IconEdit size="tiny" />
+                <Edit size={14} />
                 <p>Edit column</p>
               </DropdownMenuItem>
             </Tooltip.Trigger>
@@ -80,12 +77,12 @@ const ColumnMenu = ({ column, isEncrypted }: ColumnMenuProps) => {
         >
           {column.frozen ? (
             <>
-              <IconUnlock size="tiny" />
+              <Unlock size={14} />
               <p>Unfreeze column</p>
             </>
           ) : (
             <>
-              <IconLock size="tiny" />
+              <Lock size={14} />
               <p>Freeze column</p>
             </>
           )}
@@ -94,7 +91,7 @@ const ColumnMenu = ({ column, isEncrypted }: ColumnMenuProps) => {
           <>
             <Separator />
             <DropdownMenuItem className="space-x-2" onClick={onDeleteColumn}>
-              <IconTrash size="tiny" stroke="red" />
+              <Trash size={14} stroke="red" />
               <p>Delete column</p>
             </DropdownMenuItem>
           </>
@@ -107,9 +104,12 @@ const ColumnMenu = ({ column, isEncrypted }: ColumnMenuProps) => {
     <>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <Button className="opacity-50 flex" type="text" style={{ padding: '3px' }}>
-            <IconChevronDown />
-          </Button>
+          <Button
+            className="opacity-50 flex"
+            type="text"
+            style={{ padding: '3px' }}
+            icon={<ChevronDown />}
+          />
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" side="bottom">
           {renderMenu()}

--- a/apps/studio/components/interfaces/Account/NewAccessTokenButton.tsx
+++ b/apps/studio/components/interfaces/Account/NewAccessTokenButton.tsx
@@ -9,13 +9,12 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
   Form,
-  IconChevronDown,
-  IconExternalLink,
   Input,
   Modal,
 } from 'ui'
 
 import { useAccessTokenCreateMutation } from 'data/access-tokens/access-tokens-create-mutation'
+import { ChevronDown, ExternalLink } from 'lucide-react'
 
 export interface NewAccessTokenButtonProps {
   onCreateToken: (token: any) => void
@@ -59,13 +58,10 @@ const NewAccessTokenButton = ({ onCreateToken }: NewAccessTokenButtonProps) => {
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button
-                  asChild
                   type="primary"
                   className="rounded-l-none px-[4px] py-[5px]"
-                  icon={<IconChevronDown />}
-                >
-                  <span></span>
-                </Button>
+                  icon={<ChevronDown />}
+                />
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" side="bottom">
                 <DropdownMenuItem
@@ -119,7 +115,7 @@ const NewAccessTokenButton = ({ onCreateToken }: NewAccessTokenButtonProps) => {
                       such, be very careful when using this API.
                     </p>
                     <div className="mt-4">
-                      <Button asChild type="default" icon={<IconExternalLink strokeWidth={1.5} />}>
+                      <Button asChild type="default" icon={<ExternalLink />}>
                         <Link
                           href="https://api.supabase.com/api/v0"
                           target="_blank"

--- a/apps/studio/components/interfaces/Auth/Policies/AIPolicyEditorPanel/AIPolicyHeader.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/AIPolicyEditorPanel/AIPolicyHeader.tsx
@@ -1,5 +1,5 @@
 import type { PostgresPolicy } from '@supabase/postgres-meta'
-import { PanelLeftClose, PanelRightClose, X } from 'lucide-react'
+import { ChevronDown, PanelLeftClose, PanelRightClose, X } from 'lucide-react'
 import { useState } from 'react'
 
 import { useIsRLSAIAssistantEnabled } from 'components/interfaces/App/FeaturePreview/FeaturePreviewContext'
@@ -7,7 +7,6 @@ import {
   CollapsibleContent_Shadcn_,
   CollapsibleTrigger_Shadcn_,
   Collapsible_Shadcn_,
-  IconChevronDown,
   SheetClose,
   SheetHeader,
   SheetTitle,
@@ -63,7 +62,7 @@ export const AIPolicyHeader = ({
                   <p className="text-xs text-foreground-light group-hover:text-foreground transition">
                     View policy details
                   </p>
-                  <IconChevronDown
+                  <ChevronDown
                     className="transition-transform duration-200"
                     strokeWidth={1.5}
                     size={14}

--- a/apps/studio/components/interfaces/Auth/Policies/AIPolicyEditorPanel/PolicyDetailsV2.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/AIPolicyEditorPanel/PolicyDetailsV2.tsx
@@ -32,6 +32,8 @@ import {
   Select_Shadcn_,
 } from 'ui'
 import { MultiSelectV2 } from 'ui-patterns/MultiSelectDeprecated/MultiSelectV2'
+import { PermissionAction } from '@supabase/shared-types/out/constants'
+import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
 
 interface PolicyDetailsV2Props {
   schema: string
@@ -60,6 +62,7 @@ export const PolicyDetailsV2 = ({
 }: PolicyDetailsV2Props) => {
   const { project } = useProjectContext()
   const [open, setOpen] = useState(false)
+  const canUpdatePolicies = false // useCheckPermissions(PermissionAction.TENANT_SQL_ADMIN_WRITE, 'tables')
 
   const { data: tables, isSuccess: isSuccessTables } = useTablesQuery({
     projectRef: project?.ref,
@@ -112,6 +115,7 @@ export const PolicyDetailsV2 = ({
                 <FormControl_Shadcn_>
                   <Input_Shadcn_
                     {...field}
+                    disabled={!canUpdatePolicies}
                     className="bg-control border-control"
                     placeholder="Provide a name for your policy"
                   />
@@ -138,6 +142,7 @@ export const PolicyDetailsV2 = ({
                       <PopoverTrigger_Shadcn_ asChild>
                         <Button
                           type="default"
+                          disabled={!canUpdatePolicies}
                           className="w-full [&>span]:w-full h-[38px] text-sm"
                           iconRight={
                             <ChevronsUpDown
@@ -305,6 +310,7 @@ export const PolicyDetailsV2 = ({
                 </FormLabel_Shadcn_>
                 <FormControl_Shadcn_>
                   <MultiSelectV2
+                    disabled={!canUpdatePolicies}
                     options={formattedRoles}
                     value={field.value.length === 0 ? [] : field.value?.split(', ')}
                     placeholder="Defaults to all (public) roles if none selected"

--- a/apps/studio/components/interfaces/Auth/Policies/AIPolicyEditorPanel/PolicyDetailsV2.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/AIPolicyEditorPanel/PolicyDetailsV2.tsx
@@ -2,9 +2,11 @@ import { Check, ChevronsUpDown } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { UseFormReturn } from 'react-hook-form'
 
+import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
 import { useDatabaseRolesQuery } from 'data/database-roles/database-roles-query'
 import { useTablesQuery } from 'data/tables/tables-query'
+import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import {
   Button,
   CommandEmpty_Shadcn_,
@@ -32,8 +34,6 @@ import {
   Select_Shadcn_,
 } from 'ui'
 import { MultiSelectV2 } from 'ui-patterns/MultiSelectDeprecated/MultiSelectV2'
-import { PermissionAction } from '@supabase/shared-types/out/constants'
-import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
 
 interface PolicyDetailsV2Props {
   schema: string
@@ -62,7 +62,7 @@ export const PolicyDetailsV2 = ({
 }: PolicyDetailsV2Props) => {
   const { project } = useProjectContext()
   const [open, setOpen] = useState(false)
-  const canUpdatePolicies = false // useCheckPermissions(PermissionAction.TENANT_SQL_ADMIN_WRITE, 'tables')
+  const canUpdatePolicies = useCheckPermissions(PermissionAction.TENANT_SQL_ADMIN_WRITE, 'tables')
 
   const { data: tables, isSuccess: isSuccessTables } = useTablesQuery({
     projectRef: project?.ref,

--- a/apps/studio/components/interfaces/Auth/Policies/PolicyTableRow/PolicyRow.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/PolicyTableRow/PolicyRow.tsx
@@ -80,47 +80,32 @@ const PolicyRow = ({
         </div>
       </div>
       <div>
-        {true ? (
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button type="default" className="px-1.5" icon={<MoreVertical />} />
-            </DropdownMenuTrigger>
-            <DropdownMenuContent side="bottom" align="end" className="w-40">
-              <DropdownMenuItem className="gap-x-2" onClick={() => onSelectEditPolicy(policy)}>
-                <Edit size={14} />
-                <p>Edit policy</p>
-              </DropdownMenuItem>
-              <DropdownMenuSeparator />
-              <DropdownMenuItemTooltip
-                className="gap-x-2"
-                disabled={!canUpdatePolicies}
-                onClick={() => onSelectDeletePolicy(policy)}
-                tooltip={{
-                  content: {
-                    side: 'left',
-                    text: 'You need additional permissions to delete policies',
-                  },
-                }}
-              >
-                <Trash size={14} />
-                <p>Delete policy</p>
-              </DropdownMenuItemTooltip>
-            </DropdownMenuContent>
-          </DropdownMenu>
-        ) : (
-          <ButtonTooltip
-            disabled
-            type="default"
-            style={{ paddingLeft: 4, paddingRight: 4 }}
-            icon={<MoreVertical />}
-            tooltip={{
-              content: {
-                side: 'left',
-                text: 'You need additional permissions to edit RLS policies',
-              },
-            }}
-          />
-        )}
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button type="default" className="px-1.5" icon={<MoreVertical />} />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent side="bottom" align="end" className="w-40">
+            <DropdownMenuItem className="gap-x-2" onClick={() => onSelectEditPolicy(policy)}>
+              <Edit size={14} />
+              <p>Edit policy</p>
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItemTooltip
+              className="gap-x-2"
+              disabled={!canUpdatePolicies}
+              onClick={() => onSelectDeletePolicy(policy)}
+              tooltip={{
+                content: {
+                  side: 'left',
+                  text: 'You need additional permissions to delete policies',
+                },
+              }}
+            >
+              <Trash size={14} />
+              <p>Delete policy</p>
+            </DropdownMenuItemTooltip>
+          </DropdownMenuContent>
+        </DropdownMenu>
       </div>
     </Panel.Content>
   )

--- a/apps/studio/components/interfaces/Auth/Policies/PolicyTableRow/PolicyRow.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/PolicyTableRow/PolicyRow.tsx
@@ -20,6 +20,7 @@ import {
   TooltipContent_Shadcn_,
   TooltipTrigger_Shadcn_,
 } from 'ui'
+import { DropdownMenuItemTooltip } from 'components/ui/DropdownMenuItemTooltip'
 
 interface PolicyRowProps {
   policy: PostgresPolicy
@@ -79,25 +80,31 @@ const PolicyRow = ({
         </div>
       </div>
       <div>
-        {canUpdatePolicies ? (
+        {true ? (
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button
-                type="default"
-                style={{ paddingLeft: 4, paddingRight: 4 }}
-                icon={<MoreVertical />}
-              />
+              <Button type="default" className="px-1.5" icon={<MoreVertical />} />
             </DropdownMenuTrigger>
             <DropdownMenuContent side="bottom" align="end" className="w-40">
-              <DropdownMenuItem className="space-x-2" onClick={() => onSelectEditPolicy(policy)}>
+              <DropdownMenuItem className="gap-x-2" onClick={() => onSelectEditPolicy(policy)}>
                 <Edit size={14} />
                 <p>Edit policy</p>
               </DropdownMenuItem>
               <DropdownMenuSeparator />
-              <DropdownMenuItem className="space-x-2" onClick={() => onSelectDeletePolicy(policy)}>
+              <DropdownMenuItemTooltip
+                className="gap-x-2"
+                disabled={!canUpdatePolicies}
+                onClick={() => onSelectDeletePolicy(policy)}
+                tooltip={{
+                  content: {
+                    side: 'left',
+                    text: 'You need additional permissions to delete policies',
+                  },
+                }}
+              >
                 <Trash size={14} />
                 <p>Delete policy</p>
-              </DropdownMenuItem>
+              </DropdownMenuItemTooltip>
             </DropdownMenuContent>
           </DropdownMenu>
         ) : (

--- a/apps/studio/components/interfaces/Auth/Policies/PolicyTableRow/PolicyRow.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/PolicyTableRow/PolicyRow.tsx
@@ -1,9 +1,9 @@
-import * as Tooltip from '@radix-ui/react-tooltip'
 import type { PostgresPolicy } from '@supabase/postgres-meta'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { noop } from 'lodash'
 
 import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
+import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import Panel from 'components/ui/Panel'
 import { useAuthConfigQuery } from 'data/auth/auth-config-query'
 import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
@@ -16,8 +16,10 @@ import {
   DropdownMenuItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
+  Tooltip_Shadcn_,
+  TooltipContent_Shadcn_,
+  TooltipTrigger_Shadcn_,
 } from 'ui'
-import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 
 interface PolicyRowProps {
   policy: PostgresPolicy
@@ -55,37 +57,25 @@ const PolicyRow = ({
             <Badge color="yellow">Applies to anonymous users</Badge>
           ) : null}
         </div>
-        <div className="flex items-center space-x-2">
+        <div className="flex items-center gap-x-1">
           <p className="text-foreground-light text-sm">Applied to:</p>
           {policy.roles.slice(0, 3).map((role, i) => (
             <code key={`policy-${role}-${i}`} className="text-foreground-light text-xs">
               {role}
             </code>
           ))}
-          <Tooltip.Root delayDuration={0}>
-            <Tooltip.Trigger>
-              {policy.roles.length > 3 && (
-                <code key={`policy-etc`} className="text-foreground-light text-xs">
+          {policy.roles.length > 3 && (
+            <Tooltip_Shadcn_>
+              <TooltipTrigger_Shadcn_ asChild>
+                <code key="policy-etc" className="text-foreground-light text-xs">
                   + {policy.roles.length - 3} more roles
                 </code>
-              )}
-            </Tooltip.Trigger>
-            <Tooltip.Portal>
-              <Tooltip.Content side="bottom">
-                <Tooltip.Arrow className="radix-tooltip-arrow" />
-                <div
-                  className={[
-                    'rounded bg-alternative py-1 px-2 leading-none shadow',
-                    'border border-background max-w-[220px] text-center',
-                  ].join(' ')}
-                >
-                  <span className="text-xs text-foreground">
-                    {policy.roles.slice(3).join(', ')}
-                  </span>
-                </div>
-              </Tooltip.Content>
-            </Tooltip.Portal>
-          </Tooltip.Root>
+              </TooltipTrigger_Shadcn_>
+              <TooltipContent_Shadcn_ side="bottom" align="center">
+                {policy.roles.slice(3).join(', ')}
+              </TooltipContent_Shadcn_>
+            </Tooltip_Shadcn_>
+          )}
         </div>
       </div>
       <div>

--- a/apps/studio/components/interfaces/Auth/Policies/PolicyTableRow/PolicyRow.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/PolicyTableRow/PolicyRow.tsx
@@ -17,6 +17,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from 'ui'
+import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 
 interface PolicyRowProps {
   policy: PostgresPolicy
@@ -110,33 +111,18 @@ const PolicyRow = ({
             </DropdownMenuContent>
           </DropdownMenu>
         ) : (
-          <Tooltip.Root delayDuration={0}>
-            <Tooltip.Trigger asChild>
-              <Button
-                disabled
-                type="default"
-                style={{ paddingLeft: 4, paddingRight: 4 }}
-                icon={<MoreVertical />}
-              />
-            </Tooltip.Trigger>
-            {!canUpdatePolicies && (
-              <Tooltip.Portal>
-                <Tooltip.Content side="left">
-                  <Tooltip.Arrow className="radix-tooltip-arrow" />
-                  <div
-                    className={[
-                      'rounded bg-alternative py-1 px-2 leading-none shadow',
-                      'border border-background',
-                    ].join(' ')}
-                  >
-                    <span className="text-xs text-foreground">
-                      You need additional permissions to edit RLS policies
-                    </span>
-                  </div>
-                </Tooltip.Content>
-              </Tooltip.Portal>
-            )}
-          </Tooltip.Root>
+          <ButtonTooltip
+            disabled
+            type="default"
+            style={{ paddingLeft: 4, paddingRight: 4 }}
+            icon={<MoreVertical />}
+            tooltip={{
+              content: {
+                side: 'left',
+                text: 'You need additional permissions to edit RLS policies',
+              },
+            }}
+          />
         )}
       </div>
     </Panel.Content>

--- a/apps/studio/components/interfaces/Auth/Policies/PolicyTableRow/PolicyTableRowHeader.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/PolicyTableRow/PolicyTableRowHeader.tsx
@@ -1,4 +1,3 @@
-import * as Tooltip from '@radix-ui/react-tooltip'
 import type { PostgresTable } from '@supabase/postgres-meta'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { noop } from 'lodash'
@@ -7,8 +6,9 @@ import Link from 'next/link'
 import { useRouter } from 'next/router'
 
 import { useIsRLSAIAssistantEnabled } from 'components/interfaces/App/FeaturePreview/FeaturePreviewContext'
+import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
-import { Badge, Button, TooltipContent_Shadcn_, TooltipTrigger_Shadcn_, Tooltip_Shadcn_ } from 'ui'
+import { Badge } from 'ui'
 
 interface PolicyTableRowHeaderProps {
   table: PostgresTable
@@ -55,42 +55,35 @@ const PolicyTableRowHeader = ({
       {!isTableLocked && (
         <div className="flex-1">
           <div className="flex flex-row justify-end gap-x-2">
-            {!isRealtimeMessagesTable ? (
-              <Tooltip_Shadcn_ delayDuration={0}>
-                <TooltipTrigger_Shadcn_ asChild>
-                  <Button
-                    type="default"
-                    disabled={!canToggleRLS}
-                    onClick={() => onSelectToggleRLS(table)}
-                  >
-                    {table.rls_enabled ? 'Disable RLS' : 'Enable RLS'}
-                  </Button>
-                </TooltipTrigger_Shadcn_>
-                {!canToggleRLS && (
-                  <TooltipContent_Shadcn_ side="bottom">
-                    <Tooltip.Arrow className="radix-tooltip-arrow" />
-                    <div
-                      className={[
-                        'rounded bg-alternative py-1 px-2 leading-none shadow',
-                        'border border-background',
-                      ].join(' ')}
-                    >
-                      <span className="text-xs text-foreground">
-                        You need additional permissions to toggle RLS
-                      </span>
-                    </div>
-                  </TooltipContent_Shadcn_>
-                )}
-              </Tooltip_Shadcn_>
-            ) : null}
+            {!isRealtimeMessagesTable && (
+              <ButtonTooltip
+                type="default"
+                disabled={!canToggleRLS}
+                onClick={() => onSelectToggleRLS(table)}
+                tooltip={{
+                  content: {
+                    side: 'bottom',
+                    text: 'You need additional permissions to toggle RLS',
+                  },
+                }}
+              >
+                {table.rls_enabled ? 'Disable RLS' : 'Enable RLS'}
+              </ButtonTooltip>
+            )}
             {!isAiAssistantEnabled && (
-              <Button
+              <ButtonTooltip
                 type="default"
                 disabled={!canToggleRLS}
                 onClick={() => onSelectCreatePolicy()}
+                tooltip={{
+                  content: {
+                    side: 'bottom',
+                    text: 'You need additional permissions to create RLS policies',
+                  },
+                }}
               >
                 Create policy
-              </Button>
+              </ButtonTooltip>
             )}
           </div>
         </div>

--- a/apps/studio/components/to-be-cleaned/Storage/StoragePolicies/StoragePoliciesBucketRow.tsx
+++ b/apps/studio/components/to-be-cleaned/Storage/StoragePolicies/StoragePoliciesBucketRow.tsx
@@ -1,5 +1,6 @@
 import Panel from 'components/ui/Panel'
 import { isEmpty } from 'lodash'
+import { Archive, Edit, MoreVertical, Trash } from 'lucide-react'
 import {
   Badge,
   Button,
@@ -8,10 +9,6 @@ import {
   DropdownMenuItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-  IconArchive,
-  IconEdit,
-  IconMoreVertical,
-  IconTrash,
 } from 'ui'
 
 interface PolicyRowProps {
@@ -41,23 +38,19 @@ const PolicyRow = ({
         </div>
         <DropdownMenu>
           <DropdownMenuTrigger>
-            <Button
-              type="default"
-              style={{ paddingLeft: 4, paddingRight: 4 }}
-              icon={<IconMoreVertical />}
-            />
+            <Button type="default" className="px-1.5" icon={<MoreVertical />} />
           </DropdownMenuTrigger>
           <DropdownMenuContent side="bottom" align="end">
             <DropdownMenuItem
-              className="space-x-2"
+              className="gap-x-2"
               onClick={() => onSelectPolicyEdit(policy, bucketName, table)}
             >
-              <IconEdit size={14} />
+              <Edit size={14} />
               <p>Edit</p>
             </DropdownMenuItem>
             <DropdownMenuSeparator />
-            <DropdownMenuItem className="space-x-2" onClick={() => onSelectPolicyDelete(policy)}>
-              <IconTrash size={14} />
+            <DropdownMenuItem className="gap-x-2" onClick={() => onSelectPolicyDelete(policy)}>
+              <Trash size={14} />
               <p>Delete</p>
             </DropdownMenuItem>
           </DropdownMenuContent>
@@ -91,7 +84,7 @@ const StoragePoliciesBucketRow = ({
       title={[
         <div key={label} className="flex w-full items-center justify-between">
           <div className="flex items-center space-x-4">
-            <IconArchive className="text-foreground-light" size="small" />
+            <Archive className="text-foreground-light" size={14} />
             <h4 className="m-0 text-lg">
               <span>{label}</span>
             </h4>

--- a/apps/studio/components/ui/DropdownMenuItemTooltip.tsx
+++ b/apps/studio/components/ui/DropdownMenuItemTooltip.tsx
@@ -1,0 +1,43 @@
+import { ComponentProps, ComponentPropsWithoutRef, ElementRef, forwardRef } from 'react'
+import {
+  DropdownMenuItem,
+  TooltipContent_Shadcn_,
+  TooltipTrigger_Shadcn_,
+  Tooltip_Shadcn_,
+  cn,
+} from 'ui'
+
+export const DropdownMenuItemTooltip = forwardRef<
+  ElementRef<typeof DropdownMenuItem>,
+  ComponentPropsWithoutRef<typeof DropdownMenuItem> & {
+    tooltip: {
+      content: ComponentProps<typeof TooltipContent_Shadcn_> & {
+        text?: string
+      }
+    }
+  }
+>(({ ...props }, ref) => {
+  return (
+    <Tooltip_Shadcn_>
+      <TooltipTrigger_Shadcn_ asChild>
+        <DropdownMenuItem
+          ref={ref}
+          {...props}
+          className={cn(props.className, '!pointer-events-auto')}
+          onClick={(e) => {
+            if (!props.disabled && props.onClick) props.onClick(e)
+          }}
+        >
+          {props.children}
+        </DropdownMenuItem>
+      </TooltipTrigger_Shadcn_>
+      {props.disabled && props.tooltip.content.text !== undefined && (
+        <TooltipContent_Shadcn_ {...props.tooltip.content}>
+          {props.tooltip.content.text}
+        </TooltipContent_Shadcn_>
+      )}
+    </Tooltip_Shadcn_>
+  )
+})
+
+DropdownMenuItemTooltip.displayName = 'DropdownMenuItemTooltip'

--- a/apps/studio/pages/project/[ref]/auth/policies.tsx
+++ b/apps/studio/pages/project/[ref]/auth/policies.tsx
@@ -10,6 +10,7 @@ import Policies from 'components/interfaces/Auth/Policies/Policies'
 import AuthLayout from 'components/layouts/AuthLayout/AuthLayout'
 import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
 import AlertError from 'components/ui/AlertError'
+import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import NoPermission from 'components/ui/NoPermission'
 import SchemaSelector from 'components/ui/SchemaSelector'
 import { GenericSkeletonLoader } from 'components/ui/ShimmeringLoader'
@@ -20,7 +21,7 @@ import { useCheckPermissions, usePermissionsLoaded } from 'hooks/misc/useCheckPe
 import { useUrlState } from 'hooks/ui/useUrlState'
 import { EXCLUDED_SCHEMAS } from 'lib/constants/schemas'
 import type { NextPageWithLayout } from 'types'
-import { Button, Input, TooltipContent_Shadcn_, TooltipTrigger_Shadcn_, Tooltip_Shadcn_ } from 'ui'
+import { Button, Input } from 'ui'
 
 /**
  * Filter tables by table name and policy name
@@ -146,26 +147,23 @@ const AuthPoliciesPage: NextPageWithLayout = () => {
             </Button>
 
             {isAiAssistantEnabled && (
-              <Tooltip_Shadcn_>
-                <TooltipTrigger_Shadcn_ asChild>
-                  <Button
-                    type="primary"
-                    disabled={!canCreatePolicies || schemaHasNoTables}
-                    onClick={() => setShowPolicyAiEditor(true)}
-                  >
-                    Create a new policy
-                  </Button>
-                </TooltipTrigger_Shadcn_>
-                {(!canCreatePolicies || schemaHasNoTables) && (
-                  <TooltipContent_Shadcn_ side="bottom">
-                    {!canCreatePolicies
+              <ButtonTooltip
+                type="primary"
+                disabled={!canCreatePolicies || schemaHasNoTables}
+                onClick={() => setShowPolicyAiEditor(true)}
+                tooltip={{
+                  content: {
+                    side: 'bottom',
+                    text: !canCreatePolicies
                       ? 'You need additional permissions to create RLS policies'
                       : schemaHasNoTables
                         ? `No table in schema ${schema} to create policies on`
-                        : null}
-                  </TooltipContent_Shadcn_>
-                )}
-              </Tooltip_Shadcn_>
+                        : undefined,
+                  },
+                }}
+              >
+                Create a new policy
+              </ButtonTooltip>
             )}
           </div>
         </div>


### PR DESCRIPTION
- Replace manual tooltip buttons with the new ButtonTooltip component (the tooltips weren't showing so the refactor is necessary)
- Created new DropdownMenuItemTooltip component and use it in PolicyRow
- Update UI to allow access to the Edit Policy panel for a user who doesn't have update access BUT prevent saving from there
  - This is to allow such users to still be able to read the policy definitions despite not being able to save (without having to do any update to the Auth Policies UI atm)
- Minor refactors around to use lucide react icons