### PR TITLE
Chore/composite foreign key fixes

### DIFF
--- a/apps/studio/components/grid/components/grid/Grid.tsx
+++ b/apps/studio/components/grid/components/grid/Grid.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/display-name */
 import AwesomeDebouncePromise from 'awesome-debounce-promise'
 import { forwardRef, useRef } from 'react'
 import DataGrid, { DataGridHandle, RowsChangeData } from 'react-data-grid'
@@ -16,6 +17,7 @@ import { useDispatch, useTrackedState } from '../../store/Store'
 import type { Filter, GridProps, SupaRow } from '../../types'
 import { useKeyboardShortcuts } from '../common/Hooks'
 import RowRenderer from './RowRenderer'
+import { formatForeignKeys } from 'components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.utils'
 
 const rowKeyGetter = (row: SupaRow) => {
   return row?.idx ?? -1
@@ -142,12 +144,13 @@ export const Grid = memo(
         const { targetTableSchema, targetTableName, targetColumnName } =
           table?.columns.find((x) => x.name == columnName)?.foreignKey ?? {}
 
-        return data?.find(
+        const fk = data?.find(
           (key: any) =>
             key.target_schema == targetTableSchema &&
             key.target_table == targetTableName &&
             key.target_columns == targetColumnName
         )
+        return fk !== undefined ? formatForeignKeys([fk])[0] : undefined
       }
 
       function onRowDoubleClick(row: any, column: any) {

--- a/apps/studio/components/grid/utils/gridColumns.tsx
+++ b/apps/studio/components/grid/utils/gridColumns.tsx
@@ -194,7 +194,7 @@ function getCellRenderer(
       return BooleanFormatter
     }
     case 'foreign_key': {
-      if (columnDef.isPrimaryKey || !columnDef.isUpdatable) {
+      if (!columnDef.isUpdatable) {
         return DefaultFormatter
       } else {
         // eslint-disable-next-line react/display-name

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/ForeignRowSelector/ForeignRowSelector.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/ForeignRowSelector/ForeignRowSelector.tsx
@@ -1,8 +1,8 @@
 import type { PostgresTable } from '@supabase/postgres-meta'
+import { Loader2 } from 'lucide-react'
 import { useState } from 'react'
 import { DndProvider } from 'react-dnd'
 import { HTML5Backend } from 'react-dnd-html5-backend'
-import { IconLoader, SidePanel } from 'ui'
 
 import {
   formatFilterURLParams,
@@ -13,19 +13,20 @@ import RefreshButton from 'components/grid/components/header/RefreshButton'
 import FilterPopover from 'components/grid/components/header/filter/FilterPopover'
 import { SortPopover } from 'components/grid/components/header/sort'
 import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
-import type { ForeignKeyConstraint } from 'data/database/foreign-key-constraints-query'
 import { useTableRowsQuery } from 'data/table-rows/table-rows-query'
 import { useTableQuery } from 'data/tables/table-query'
 import { useRoleImpersonationStateSnapshot } from 'state/role-impersonation-state'
+import { SidePanel } from 'ui'
 import ActionBar from '../../ActionBar'
+import { ForeignKey } from '../../ForeignKeySelector/ForeignKeySelector.types'
 import { useEncryptedColumns } from '../../SidePanelEditor.utils'
 import Pagination from './Pagination'
 import SelectorGrid from './SelectorGrid'
 
 export interface ForeignRowSelectorProps {
   visible: boolean
-  foreignKey?: ForeignKeyConstraint
-  onSelect: (value: any) => void
+  foreignKey?: ForeignKey
+  onSelect: (value?: { [key: string]: any }) => void
   closePanel: () => void
 }
 
@@ -37,12 +38,7 @@ const ForeignRowSelector = ({
 }: ForeignRowSelectorProps) => {
   const { project } = useProjectContext()
 
-  const {
-    target_id: _tableId,
-    target_schema: schemaName,
-    target_table: tableName,
-    target_columns: columnName,
-  } = foreignKey ?? {}
+  const { tableId: _tableId, schema: schemaName, table: tableName, columns } = foreignKey ?? {}
   const tableId = _tableId ? Number(_tableId) : undefined
 
   const { data: table } = useTableQuery({
@@ -111,7 +107,7 @@ const ForeignRowSelector = ({
         <div className="h-full">
           {isLoading && (
             <div className="flex h-full py-6 flex-col items-center justify-center space-y-2">
-              <IconLoader className="animate-spin" />
+              <Loader2 size={14} className="animate-spin" />
               <p className="text-sm text-foreground-light">Loading rows</p>
             </div>
           )}
@@ -167,7 +163,12 @@ const ForeignRowSelector = ({
                 <SelectorGrid
                   table={supaTable}
                   rows={data.rows}
-                  onRowSelect={(row) => onSelect(row[columnName?.[0] ?? ''])}
+                  onRowSelect={(row) => {
+                    const value = columns?.reduce((a, b) => {
+                      return { ...a, [b.source]: row[b.target] }
+                    }, {})
+                    onSelect(value)
+                  }}
                 />
               ) : (
                 <div className="flex h-full items-center justify-center border-b border-t border-default">

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
@@ -186,20 +186,19 @@ const SidePanelEditor = ({
     }
   }
 
-  const onSaveForeignRow = async (value: any) => {
+  const onSaveForeignRow = async (value?: { [key: string]: any }) => {
     if (selectedTable === undefined || !(snap.sidePanel?.type === 'foreign-row-selector')) return
     const selectedForeignKeyToEdit = snap.sidePanel.foreignKey
 
     try {
-      const { row, column } = selectedForeignKeyToEdit
-      const payload = { [column.name]: value }
+      const { row } = selectedForeignKeyToEdit
       const identifiers = {} as Dictionary<any>
       selectedTable.primary_keys.forEach((column) => (identifiers[column.name] = row![column.name]))
 
       const isNewRecord = false
       const configuration = { identifiers, rowIdx: row.idx }
 
-      saveRow(payload, isNewRecord, configuration, () => {})
+      saveRow(value, isNewRecord, configuration, () => {})
     } catch (error) {}
   }
 

--- a/apps/studio/state/table-editor.tsx
+++ b/apps/studio/state/table-editor.tsx
@@ -184,7 +184,6 @@ export const createTableEditorState = () => {
       }
     },
     onEditForeignKeyColumnValue: (foreignKey: ForeignKeyState) => {
-      console.log('onEditFK', { foreignKey })
       state.ui = {
         open: 'side-panel',
         sidePanel: { type: 'foreign-row-selector', foreignKey },

--- a/apps/studio/state/table-editor.tsx
+++ b/apps/studio/state/table-editor.tsx
@@ -1,13 +1,14 @@
 import type { PostgresColumn } from '@supabase/postgres-meta'
 import type { SupaRow } from 'components/grid/types'
+import { ForeignKey } from 'components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.types'
 import type { ForeignRowSelectorProps } from 'components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/ForeignRowSelector/ForeignRowSelector'
 import type { EditValue } from 'components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.types'
 import { PropsWithChildren, createContext, useContext, useRef } from 'react'
 import type { Dictionary } from 'types'
 import { proxy, useSnapshot } from 'valtio'
 
-type ForeignKey = {
-  foreignKey: NonNullable<ForeignRowSelectorProps['foreignKey']>
+type ForeignKeyState = {
+  foreignKey: ForeignKey
   row: Dictionary<any>
   column: PostgresColumn
 }
@@ -21,7 +22,7 @@ export type SidePanel =
   | { type: 'json'; jsonValue: EditValue }
   | {
       type: 'foreign-row-selector'
-      foreignKey: ForeignKey
+      foreignKey: ForeignKeyState
     }
   | { type: 'csv-import' }
 
@@ -182,7 +183,8 @@ export const createTableEditorState = () => {
         sidePanel: { type: 'cell', value: { column, row } },
       }
     },
-    onEditForeignKeyColumnValue: (foreignKey: ForeignKey) => {
+    onEditForeignKeyColumnValue: (foreignKey: ForeignKeyState) => {
+      console.log('onEditFK', { foreignKey })
       state.ui = {
         open: 'side-panel',
         sidePanel: { type: 'foreign-row-selector', foreignKey },


### PR DESCRIPTION
- Fix inability to select button to view referencing row from Table Editor grid if the column has both FK and is also a PK, should now see the button
![image](https://github.com/user-attachments/assets/a96c56a8-a73c-4e23-9fcf-539aa8d52be6)
- Fix inaccuracy of column mapping for composite foreign key columns
  - Before: Notice both are `public.properties.property_id`
![image](https://github.com/user-attachments/assets/1c504671-5ac8-4a4d-bca3-9d833ed19230)
  - After:
![image](https://github.com/user-attachments/assets/76d58ecf-b9b4-4d48-a67e-84ed0ae4c7b5)
- Fix inability to update composite foreign key columns via RowEditor
  - It's related to the above problem, and also a UX problem where users are expected to select values separately for the columns under the composite foreign key, when just one row is needed
  - Selecting the target row will now update the values for all input fields of columns that are under the same composite foreign key
