### PR TITLE
fix: apply grants on create / update / delete auth postgres hook

### DIFF
--- a/apps/studio/components/interfaces/Auth/Hooks/CreateHookSheet.tsx
+++ b/apps/studio/components/interfaces/Auth/Hooks/CreateHookSheet.tsx
@@ -412,14 +412,17 @@ export const CreateHookSheet = ({
                       </FormItemLayout>
                     )}
                   />
-                </div>
-                <div className={cn('h-64 w-full')}>
-                  <CodeEditor
-                    id="postgres-hook-editor"
-                    isReadOnly={true}
-                    language="pgsql"
-                    value={statements.join('\n\n')}
-                  />
+                  <div className={cn('h-72 w-full col-span-2')}>
+                    <p className="py-4 text-sm text-foreground-light">
+                      {`The following statements will be executed on the function:`}
+                    </p>
+                    <CodeEditor
+                      id="postgres-hook-editor"
+                      isReadOnly={true}
+                      language="pgsql"
+                      value={statements.join('\n\n')}
+                    />
+                  </div>
                 </div>
               </>
             ) : (

--- a/apps/studio/components/interfaces/Auth/Hooks/CreateHookSheet.tsx
+++ b/apps/studio/components/interfaces/Auth/Hooks/CreateHookSheet.tsx
@@ -1,16 +1,19 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { X } from 'lucide-react'
 import randomBytes from 'randombytes'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo } from 'react'
 import { SubmitHandler, useForm } from 'react-hook-form'
 import toast from 'react-hot-toast'
 import ReactMarkdown from 'react-markdown'
 import * as z from 'zod'
 
 import { useParams } from 'common'
+import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
+import CodeEditor from 'components/ui/CodeEditor/CodeEditor'
 import SchemaSelector from 'components/ui/SchemaSelector'
-import { AuthConfigResponse, useAuthConfigQuery } from 'data/auth/auth-config-query'
+import { AuthConfigResponse } from 'data/auth/auth-config-query'
 import { useAuthConfigUpdateMutation } from 'data/auth/auth-config-update-mutation'
+import { executeSql } from 'data/sql/execute-sql-query'
 import { useFlag } from 'hooks/ui/useFlag'
 import {
   Button,
@@ -34,9 +37,6 @@ import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import FunctionSelector from './FunctionSelector'
 import { HOOKS_DEFINITIONS, HOOK_DEFINITION_TITLE, Hook } from './hooks.constants'
 import { extractMethod, getRevokePermissionStatements, isValidHook } from './hooks.utils'
-import CodeEditor from 'components/ui/CodeEditor/CodeEditor'
-import { executeSql } from 'data/sql/execute-sql-query'
-import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
 
 interface CreateHookSheetProps {
   visible: boolean
@@ -150,7 +150,6 @@ export const CreateHookSheet = ({
       postgresValues: {
         schema: 'public',
         functionName: '',
-        statements: '',
       },
     },
   })
@@ -194,7 +193,7 @@ export const CreateHookSheet = ({
         })
       }
     }
-  }, [authConfig, title, visible, definition, form])
+  }, [authConfig, title, visible, definition])
 
   const onSubmit: SubmitHandler<z.infer<typeof FormSchema>> = async (values) => {
     if (!project) return console.error('Project is required')
@@ -263,7 +262,7 @@ export const CreateHookSheet = ({
     }
   }
 
-  const values = form.getValues()
+  const values = form.watch()
 
   const statements = useMemo(() => {
     let permissionChanges: string[] = []
@@ -344,7 +343,7 @@ export const CreateHookSheet = ({
                   <FormItemLayout label="Hook type" className="px-8">
                     <FormControl_Shadcn_>
                       <RadioGroupStacked
-                        value={values.selectedType}
+                        value={field.value}
                         onValueChange={(value) => field.onChange(value)}
                       >
                         <RadioGroupStackedItem
@@ -412,17 +411,17 @@ export const CreateHookSheet = ({
                       </FormItemLayout>
                     )}
                   />
-                  <div className={cn('h-72 w-full col-span-2')}>
-                    <p className="py-4 text-sm text-foreground-light">
-                      {`The following statements will be executed on the function:`}
-                    </p>
-                    <CodeEditor
-                      id="postgres-hook-editor"
-                      isReadOnly={true}
-                      language="pgsql"
-                      value={statements.join('\n\n')}
-                    />
-                  </div>
+                </div>
+                <div className="h-72 w-full px-8 gap-3 flex flex-col">
+                  <p className="text-sm text-foreground-light">
+                    The following statements will be executed on the function:
+                  </p>
+                  <CodeEditor
+                    id="postgres-hook-editor"
+                    isReadOnly={true}
+                    language="pgsql"
+                    value={statements.join('\n\n')}
+                  />
                 </div>
               </>
             ) : (

--- a/apps/studio/components/interfaces/Auth/Hooks/CreateHookSheet.tsx
+++ b/apps/studio/components/interfaces/Auth/Hooks/CreateHookSheet.tsx
@@ -67,7 +67,6 @@ const FormSchema = z
     postgresValues: z.object({
       schema: z.string(),
       functionName: z.string(),
-      statements: z.string(),
     }),
   })
   .superRefine((data, ctx) => {
@@ -173,7 +172,6 @@ export const CreateHookSheet = ({
           postgresValues: {
             schema: (values.type === 'postgres' && values.schema) || 'public',
             functionName: (values.type === 'postgres' && values.functionName) || '',
-            statements: '',
           },
         })
       } else {
@@ -188,7 +186,6 @@ export const CreateHookSheet = ({
           postgresValues: {
             schema: 'public',
             functionName: '',
-            statements: '',
           },
         })
       }
@@ -235,31 +232,11 @@ export const CreateHookSheet = ({
           onClose()
         },
         onError: (error) => {
-          if (statements.length > 0 && hook.method.type === 'postgres') {
-            const revokeStatements = getRevokePermissionStatements(
-              hook.method.schema,
-              hook.method.functionName
-            )
-            executeSql({
-              projectRef,
-              connectionString: project.connectionString,
-              sql: revokeStatements.join('\n'),
-            })
-          }
           toast.error(`Failed to create hook: ${error.message}`)
           onClose()
         },
       }
     )
-
-    // grant permissions to new function
-    if (values.postgresValues.statements.length > 0) {
-      await executeSql({
-        projectRef,
-        connectionString: project.connectionString,
-        sql: values.postgresValues.statements,
-      })
-    }
   }
 
   const values = form.watch()

--- a/apps/studio/components/interfaces/Auth/Hooks/HooksListing.tsx
+++ b/apps/studio/components/interfaces/Auth/Hooks/HooksListing.tsx
@@ -108,6 +108,7 @@ export const HooksListing = () => {
 
       <ConfirmationModal
         visible={!!selectedHookForDeletion}
+        size="large"
         variant="destructive"
         title="Confirm to delete"
         confirmLabel="Delete"

--- a/apps/studio/components/interfaces/Auth/Hooks/HooksListing.tsx
+++ b/apps/studio/components/interfaces/Auth/Hooks/HooksListing.tsx
@@ -13,10 +13,15 @@ import { AddHookDropdown } from './AddHookDropdown'
 import { CreateHookSheet } from './CreateHookSheet'
 import { HookCard } from './HookCard'
 import { HOOKS_DEFINITIONS, HOOK_DEFINITION_TITLE, Hook } from './hooks.constants'
-import { extractMethod, isValidHook } from './hooks.utils'
+import { extractMethod, getRevokePermissionStatements, isValidHook } from './hooks.utils'
+import { executeSql } from 'data/sql/execute-sql-query'
+import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
+import CodeEditor from 'components/ui/CodeEditor/CodeEditor'
+import { cn } from 'ui'
 
 export const HooksListing = () => {
   const { ref: projectRef } = useParams()
+  const { project } = useProjectContext()
   const { data: authConfig, error: authConfigError, isError } = useAuthConfigQuery({ projectRef })
 
   const [selectedHook, setSelectedHook] = useState<HOOK_DEFINITION_TITLE | null>(null)
@@ -112,6 +117,7 @@ export const HooksListing = () => {
           if (!selectedHookForDeletion) {
             return
           }
+
           await updateAuthConfig({
             projectRef: projectRef!,
             config: {
@@ -120,14 +126,48 @@ export const HooksListing = () => {
               [selectedHookForDeletion.secretsKey]: null,
             },
           })
+
+          const { method } = selectedHookForDeletion
+
+          if (method.type === 'postgres') {
+            const revokeStatements = getRevokePermissionStatements(
+              method.schema,
+              method.functionName
+            )
+            await executeSql({
+              projectRef,
+              connectionString: project!.connectionString,
+              sql: revokeStatements.join('\n'),
+            })
+          }
           toast.success(`${selectedHookForDeletion.title} has been deleted.`)
           setSelectedHookForDeletion(null)
           setSelectedHook(null)
         }}
       >
-        <p className="py-4 text-sm text-foreground-light">
-          {`Are you sure you want to delete the ${selectedHookForDeletion?.title}?`}
-        </p>
+        <div>
+          <p className="py-4 text-sm text-foreground-light">
+            {`Are you sure you want to delete the ${selectedHookForDeletion?.title}?`}
+          </p>
+          {selectedHookForDeletion?.method.type === 'postgres' && (
+            <>
+              <p className="py-4 text-sm text-foreground-light">
+                {`The following statements will be executed on the ${selectedHookForDeletion?.method.schema}.${selectedHookForDeletion?.method.functionName} function:`}
+              </p>
+              <div className={cn('h-72')}>
+                <CodeEditor
+                  id="deletion-hook-editor"
+                  isReadOnly={true}
+                  language="pgsql"
+                  value={getRevokePermissionStatements(
+                    selectedHookForDeletion?.method.schema,
+                    selectedHookForDeletion?.method.functionName
+                  ).join('\n\n')}
+                />
+              </div>
+            </>
+          )}
+        </div>
       </ConfirmationModal>
     </div>
   )

--- a/apps/studio/components/interfaces/Auth/Hooks/hooks.utils.ts
+++ b/apps/studio/components/interfaces/Auth/Hooks/hooks.utils.ts
@@ -27,3 +27,17 @@ export const isValidHook = (h: Hook) => {
     (h.method.type === 'https' && h.method.url.startsWith('https') && h.method.secret.length > 0)
   )
 }
+
+/**
+ *
+ * @param schema the schema that the function belongs to
+ * @param functionName the function name associated with the hook
+ * @returns an array of SQL statements to restore the original permissions to the function
+ */
+export const getRevokePermissionStatements = (schema: string, functionName: string): string[] => {
+  return [
+    `-- Revoke access to function from supabase_auth_admin\nrevoke execute on function ${schema}.${functionName} from supabase_auth_admin;`,
+    `-- Revoke access to schema from supabase_auth_admin\nrevoke usage on schema ${schema} from supabase_auth_admin;`,
+    `-- Restore function permissions to authenticated, anon and public\ngrant execute on function ${schema}.${functionName} to authenticated, anon, public;`,
+  ]
+}


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?
* Currently, users need to manually run these SQL statements if they create a postgres hook (https://supabase.com/docs/guides/auth/auth-hooks#security-model). If they don't remember to run them, the postgres function acting as the webhook will be insecure as it is accessible from the data API. This PR aims to improve the DX by running these statements on the postgres function selected as the webhook.

## What is the current behavior?
* Users have to remember to manually run these statements to secure the postgres function configured as the hook

## What is the new behavior?
* Run these statements when the postgres function is configured as the hook - this significantly improves the DX and makes it secure-by-default since the user doesn't have to remember to run them.

* When a hook is created, we display the statements that will be run on the postgres function:
<img width="683" alt="image" src="https://github.com/user-attachments/assets/b407e8af-5205-4a9d-ae5a-f0d83e581c65">

* When a hook is updated, we restore the original permissions to the old function and apply the new permissions to the new function (note the revoke statements applied to `hook_foo`):
<img width="676" alt="image" src="https://github.com/user-attachments/assets/f4385f98-89d1-4bda-befa-b7ae7632aa44">

* When a hook is deleted, we restore the original permissions to the function (edit: made modal bigger):
<img width="792" alt="image" src="https://github.com/user-attachments/assets/9e5c728e-072f-4e40-b63d-20a28d1eb5fd">


## Additional context
* All of these statements are executed through `pg_meta` 

Add any other context or screenshots.
