### PR TITLE
fix: add resend example to send email hook

### DIFF
--- a/apps/docs/content/guides/auth/auth-hooks/send-email-hook.mdx
+++ b/apps/docs/content/guides/auth/auth-hooks/send-email-hook.mdx
@@ -320,7 +320,7 @@ The Send Email Hook runs before an email is sent and allows for flexibility arou
   scrollable
   size="small"
   type="underlined"
-  defaultActiveId="sql"
+  defaultActiveId="http"
   queryGroup="language"
 >
 <TabPanel id="sql" label="SQL">
@@ -458,8 +458,99 @@ select
   scrollable
   size="small"
   type="underlined"
-  defaultActiveId="http-internationalization-for-emails"
+  defaultActiveId="http-send-email-with-resend"
 >
+<TabPanel id="http-send-email-with-resend" label="Use Resend as an email provider">
+You can configure [Resend](https://resend.com/) as the custom email provider through the "Send Email" hook. This allows you to take advantage of Resend's developer-friendly APIs to send emails and leverage [React Email](https://react.email/) for managing your email templates. If you want to send emails through the Supabase Resend integration, which uses Resend's SMTP server, check out [this integration](/partners/integrations/resend) instead.
+
+Create a `.env` file with the following environment variables:
+
+```bash
+RESEND_API_KEY=your_resend_api_key
+SEND_EMAIL_HOOK_SECRET=<base64_secret>
+```
+
+Set the secrets in your Supabase project:
+
+```bash
+$ supabase secret set --env-file .env
+```
+
+Create a new edge function:
+
+```bash
+$ supabase functions new send-email
+```
+
+Add the following code to your edge function:
+
+```javascript
+import { Webhook } from "https://esm.sh/standardwebhooks@1.0.0";
+import { Resend } from "npm:resend";
+
+const resend = new Resend(Deno.env.get("RESEND_API_KEY") as string);
+const hookSecret = Deno.env.get("SEND_EMAIL_HOOK_SECRET") as string;
+
+Deno.serve(async (req) => {
+  const payload = await req.text();
+  const headers = Object.fromEntries(req.headers);
+  const wh = new Webhook(hookSecret);
+  try {
+    const { user, email_data } = wh.verify(payload, headers) as {
+      user: {
+        email: string;
+      };
+      email_data: {
+        token: string;
+        token_hash: string;
+        redirect_to: string;
+        email_action_type: string;
+        site_url: string;
+        token_new: string;
+        token_hash_new: string;
+      };
+    };
+
+    const { error } = await resend.emails.send({
+      from: "welcome <onboarding@example.com>",
+      to: [user.email],
+      subject: "Welcome to my site!",
+      text: `Confirm you signup with this code: ${email_data.token}`,
+    });
+    if (error) {
+      throw error;
+    }
+  } catch (error) {
+    return new Response(
+      JSON.stringify({
+        error: {
+          http_code: error.code,
+          message: error.message,
+        },
+      }),
+      {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }
+
+  const responseHeaders = new Headers();
+  responseHeaders.set("Content-Type", "application/json");
+  return new Response(JSON.stringify({}), {
+    status: 200,
+    headers: responseHeaders,
+  });
+});
+```
+
+Deploy your edge function and [configure it as a hook](/dashboard/project/_/auth/hooks):
+
+```bash
+supabase functions deploy send-email --no-verify-jwt
+```
+
+</TabPanel>
 <TabPanel id="http-internationalization-for-emails" label="Add Internationalization for Email Templates">
 Your company is expanding to France and Spain. As part of expansion efforts, the company would like to deliver internationalized email templates to best support local users in their native language. Ensure that you have configured `POSTMARK_SERVER_TOKEN` and `AUTH_SEND_EMAIL_HOOK_SECRET` in your `.env` file.
 
@@ -601,7 +692,7 @@ Deno.serve(async (req) => {
 ```
 
 </TabPanel>
-<TabPanel id="http-backup-email-provider" label="Add Backup Email Provider">
+{/* <TabPanel id="http-backup-email-provider" label="Add Backup Email Provider">
 Your company is rapidly growing and depends heavily on email signups. You'd like to configure a backup email provider in case the email provider runs out of credits during your new product launch. Postmark and Sengrid are used as examples but in practice you can use any email provider.
 Ensure that you have configured `POSTMARK_SERVER_TOKEN`, `SENDGRID_API_KEY` and `AUTH_SEND_EMAIL_HOOK_SECRET` in your `.env` file.
 
@@ -750,7 +841,7 @@ Deno.serve(async (req) => {
 });
 ```
 
-</TabPanel>
+</TabPanel> */}
 </Tabs>
 </TabPanel>
 </Tabs>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?
* Add a simple example for using Resend's email API in the "Send Email" hook

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
