### PR TITLE
fix(docs): api crawler routes

### DIFF
--- a/apps/docs/app/api/crawlers/route.ts
+++ b/apps/docs/app/api/crawlers/route.ts
@@ -30,9 +30,11 @@ export async function GET(request: Request) {
     slug = maybeVersion
   }
 
-  const flattenedSections = await getFlattenedSections(lib, version)
-  const sectionsWithUrl: Array<AbbrevCommonClientLibSection & { url: URL }> =
-    flattenedSections!.map((section) => {
+  let section: AbbrevCommonClientLibSection
+  let sectionsWithUrl: Array<AbbrevCommonClientLibSection & { url: URL }>
+  try {
+    const flattenedSections = (await getFlattenedSections(lib, version)) ?? []
+    sectionsWithUrl = flattenedSections.map((section) => {
       const url = new URL(request.url)
       url.pathname = [BASE_PATH, 'reference', lib, isVersion ? version : null, section.slug]
         .filter(Boolean)
@@ -43,10 +45,11 @@ export async function GET(request: Request) {
         url,
       }
     })
-  const section = flattenedSections!.find(
-    (section) =>
-      (section.type === 'markdown' || section.type === 'function') && section.slug === slug
-  )
+    section = flattenedSections.find(
+      (section) =>
+        (section.type === 'markdown' || section.type === 'function') && section.slug === slug
+    )
+  } catch {}
 
   if (!section) {
     redirect(notFoundLink(`${lib}/${slug}`))

--- a/apps/docs/lib/docs.ts
+++ b/apps/docs/lib/docs.ts
@@ -12,7 +12,10 @@ import remarkMath from 'remark-math'
 
 import codeHikeTheme from 'config/code-hike.theme.json' assert { type: 'json' }
 
-const DOCS_DIRECTORY = join(dirname(fileURLToPath(import.meta.url)), '..')
+// MUST be process.cwd() here, not import.meta.url, or files that are added
+// with outputFileTracingIncludes (not auto-traced) will not be found at
+// runtime.
+const DOCS_DIRECTORY = process.cwd()
 export const GUIDES_DIRECTORY = join(DOCS_DIRECTORY, 'content/guides')
 export const REF_DOCS_DIRECTORY = join(DOCS_DIRECTORY, 'docs/ref')
 export const SPEC_DIRECTORY = join(DOCS_DIRECTORY, 'spec')


### PR DESCRIPTION
Two fixes:

- Better error handling for unsupported client library versions (right now it 500s, with the fix it redirects to not found)
- Make MDX files available at runtime