### PR TITLE
chore: remove www redirects from codeownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,6 +2,9 @@
 /packages/shared-data/plans.ts @roryw10 @kevcodez
 
 /apps/studio/ @supabase/Dashboard
+
 /apps/www/ @supabase/marketing
 /apps/www/public/images/blog @supabase/marketing
+/apps/www/lib/redirects.js
+
 /docker/ @supabase/cli


### PR DESCRIPTION
As discussed on [Slack](https://supabase.slack.com/archives/C03AP03JFDZ/p1723571589483789?thread_ts=1723513089.588769&cid=C03AP03JFDZ), this unblocks docs PRs, which can be approved by anyone on the Supabase team.