### PR TITLE
docs(python): fix wrong type for on_conflict param

### DIFF
--- a/apps/docs/spec/supabase_py_v2.yml
+++ b/apps/docs/spec/supabase_py_v2.yml
@@ -1372,7 +1372,7 @@ functions:
         description:  Whether duplicate rows should be ignored.
       - name: on_conflict
         isOptional: true
-        type: bool
+        type: string
         description:  Specified columns to be made to work with UNIQUE constraint.
       - name: default_to_null
         isOptional: true
@@ -1484,7 +1484,7 @@ functions:
         description:  Whether duplicate rows should be ignored.
       - name: on_conflict
         isOptional: true
-        type: bool
+        type: string
         description:  Specified columns to be made to work with UNIQUE constraint.
       - name: default_to_null
         isOptional: true


### PR DESCRIPTION
## What kind of change does this PR introduce?

Wrong param type for `on_conflict`, stated in https://github.com/supabase/postgrest-py/issues/488