### PR TITLE
fix: tutorial description

### DIFF
--- a/apps/docs/components/MDX/quickstart_intro.mdx
+++ b/apps/docs/components/MDX/quickstart_intro.mdx
@@ -1,5 +1,5 @@
 This tutorial demonstrates how to build a basic user management app. The app authenticates and identifies the user, stores their profile information in the database, and allows the user to log in, update their profile details, and upload a profile photo. The app uses:
 
 - [Supabase Database](/docs/guides/database) - a Postgres database for storing your user data and [Row Level Security](/docs/guides/auth#row-level-security) so data is protected and users can only access their own information.
-- [Supabase Auth](/docs/guides/auth) - users log in through magic links sent to their email (without having to set up passwords).
+- [Supabase Auth](/docs/guides/auth) - allow users to sign up and log in.
 - [Supabase Storage](/docs/guides/storage) - users can upload a profile photo.


### PR DESCRIPTION
Description says "magic link" but not (all?) the tutorials use magic links, so make it more general.