### PR TITLE
fix(docs): use invoker security setting in additional API keys example (fixes #26882)

### DIFF
--- a/apps/docs/content/guides/api/securing-your-api.mdx
+++ b/apps/docs/content/guides/api/securing-your-api.mdx
@@ -287,7 +287,7 @@ Create the `public.check_request` function:
 create function public.check_request()
   returns void
   language plpgsql
-  security definer
+  security invoker
   as $$
 declare
   req_app_api_key text := current_setting('request.headers', true)::json->>'x-app-api-key';


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Updates _"Use additional API keys"_ docs to use `security invoker` instead of `security definer`. 

## What is the current behavior?

With `security definer` the `current_role` will always be `postgres` upon function invocation via API. First described in #26882.

## What is the new behavior?

`current_role` returns the role that invoked the function.

### Own sandbox test-case

Both test-cases used `anon` as `SUPABASE_KEY` and following bash `curl`

```bash
curl -X POST 'https://<SUPABASE_ID>.supabase.co/rest/v1/rpc/get_role' \
-H "Content-Type: application/json" \
-H "apikey: SUPABASE_KEY" \
-H "Authorization: Bearer SUPABASE_KEY"
```

#### Dummy function with OLD behavior

```psql
create or replace function get_role()
returns text
language sql
security definer
as $$
  select current_role;
$$;
```

**Result**

```bash
"postgres"%
```

#### Dummy function with NEW behavior

```psql
create or replace function get_role()
returns text
language sql
security invoker
as $$
  select current_role;
$$;
```

**Result**

```bash
"anon"%
```

## Additional context
