### PR TITLE
Studio: Update image to 20240812-111a9d5

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,7 +10,7 @@ version: "3.8"
 services:
   studio:
     container_name: supabase-studio
-    image: supabase/studio:20240729-ce42139
+    image: supabase/studio:20240812-111a9d5
     restart: unless-stopped
     healthcheck:
       test:


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

update

## What is the current behavior?

The current version for Studio is supabase/studio:20240729-ce42139 in docker-compose.yml

## What is the new behavior?

Update to the new version for Studio is supabase/studio:20240812-111a9d5

## Additional context

. 
