### PR TITLE
docs: compute upgrade downtime

### DIFF
--- a/apps/docs/content/guides/platform/compute-add-ons.mdx
+++ b/apps/docs/content/guides/platform/compute-add-ons.mdx
@@ -103,3 +103,7 @@ The maximum number of replication slots and WAL senders depends on your compute 
 As mentioned in the Postgres [documentation](https://postgresqlco.nf/doc/en/param/max_replication_slots/), setting `max_replication_slots` to a lower value than the current number of replication slots will prevent the server from starting. If you are downgrading your compute add-on, please ensure that you are using fewer slots than the maximum number of replication slots available for the new compute add-on.
 
 </Admonition>
+
+## Upgrade downtime
+
+Compute add-on changes are usually applied with less than 2 minutes of downtime, but can take longer depending on the Cloud Provider.


### PR DESCRIPTION
Information sourced from: https://www.notion.so/supabase/Docs-there-is-no-data-on-downtime-for-upgrades-8e4a290e56ea4c42a32dac73452f8461?d=280f51b424834d60b177990ef22fd191