### PR TITLE
Add Kotlin third party auth & phone mfa docs

### DIFF
--- a/apps/docs/content/guides/auth/third-party/auth0.mdx
+++ b/apps/docs/content/guides/auth/third-party/auth0.mdx
@@ -84,6 +84,24 @@ Future<void> main() async {
 
 </TabPanel>
 
+<TabPanel id="kotlin" label="Kotlin">
+
+```kotlin
+import com.auth0.android.result.Credentials
+
+val supabase = createSupabaseClient(
+    "https://<supabase-project>.supabase.co",
+    "SUPABASE_ANON_KEY"
+) {
+    accessToken = {
+        val credentials: Credentials = ...; // Get credentials from Auth0
+        credentials.accessToken
+    }
+}
+```
+
+</TabPanel>
+
 </Tabs>
 
 ## Add a new Third-Party Auth integration to your project

--- a/apps/docs/content/guides/auth/third-party/aws-cognito.mdx
+++ b/apps/docs/content/guides/auth/third-party/aws-cognito.mdx
@@ -93,6 +93,38 @@ Future<void> main() async {
 
 </TabPanel>
 
+<TabPanel id="kotlin" label="Kotlin">
+
+```kotlin
+import com.amplifyframework.auth.AuthSession
+import com.amplifyframework.auth.cognito.AWSCognitoAuthSession
+import com.amplifyframework.core.Amplify
+
+val supabase = createSupabaseClient(
+    "https://<supabase-project>.supabase.co",
+    "SUPABASE_ANON_KEY"
+) {
+    accessToken = {
+        getAccessToken()
+    }
+}
+
+suspend fun getAccessToken(): String? {
+    return suspendCoroutine {
+        Amplify.Auth.fetchAuthSession(
+            { result: AuthSession ->
+                val cognitoAuthSession = result as AWSCognitoAuthSession
+                it.resume(cognitoAuthSession.userPoolTokensResult.value?.accessToken)
+            },
+            { _ ->
+                // Handle error
+            })
+    }
+}
+```
+
+</TabPanel>
+
 </Tabs>
 
 ## Add a new Third-Party Auth integration to your project

--- a/apps/docs/content/guides/auth/third-party/firebase-auth.mdx
+++ b/apps/docs/content/guides/auth/third-party/firebase-auth.mdx
@@ -69,6 +69,46 @@ let supabase = SupabaseClient(
 
 </TabPanel>
 
+<TabPanel id="kotlin" label="Kotlin (Android)">
+
+Create a Supabase client with the `accessToken` function that returns the Firebase Auth JWT of the current user. This code uses the [official Firebase SDK](https://firebase.google.com/docs/auth/android/start) for Android.
+
+```kotlin
+import com.google.firebase.auth.ktx.auth
+import com.google.firebase.ktx.Firebase
+
+val supabase = createSupabaseClient(
+    "https://<supabase-project>.supabase.co",
+    "SUPABASE_ANON_KEY"
+) {
+    accessToken = {
+        Firebase.auth.currentUser?.getIdToken(false)?.await()?.token
+    }
+}
+```
+
+</TabPanel>
+
+<TabPanel id="kotlinmp" label="Kotlin (Multiplatform)">
+
+Create a Supabase client with the `accessToken` function that returns the Firebase Auth JWT of the current user. This code uses a [community Firebase SDK](https://github.com/GitLiveApp/firebase-kotlin-sdk) which supports Kotlin Multiplatform.
+
+```kotlin
+import dev.gitlive.firebase.Firebase
+import dev.gitlive.firebase.auth.auth
+
+val supabase = createSupabaseClient(
+    "https://<supabase-project>.supabase.co",
+    "SUPABASE_ANON_KEY"
+) {
+    accessToken = {
+        Firebase.auth.currentUser?.getIdToken(false)
+    }
+}
+```
+
+</TabPanel>
+
 </Tabs>
 
 ## Add a new Third-Party Auth integration to your project

--- a/apps/docs/spec/supabase_kt_v2.yml
+++ b/apps/docs/spec/supabase_kt_v2.yml
@@ -3745,36 +3745,54 @@ functions:
     $ref: '@supabase/gotrue-js.GoTrueMFAApi.enroll'
     notes: |
       Enrolls a new factor.
-      - Currently, `totp` is the only supported `factorType`. The returned `id` should be used to create a challenge.
+      - Use `FactorType.TOTP` or `FactorType.Phone` as the factorType and use the returned id to create a challenge.
       - To create a challenge, see [`mfa.createChallenge()`](/docs/reference/kotlin/auth-mfa-challenge).
       - To verify a challenge, see [`mfa.verifyChallenge()`](/docs/reference/kotlin/auth-mfa-verify).
       - To create and verify a challenge in a single step, see [`mfa.createChallengeAndVerify()`](/docs/reference/kotlin/auth-mfa-challengeandverify).
     params:
       - name: factorType
         isOptional: false
-        type: FactorType<R>
-        description: The type of MFA factor to enroll. Currently only supports `FactorType.TOTP`.
+        type: FactorType<C, R>
+        description: The type of MFA factor to enroll. Currently supports `FactorType.TOTP` and `FactorType.Phone`.
       - name: issuer
         isOptional: true
         type: String?
         description: Domain which the user is enrolling with.
-      - name: friendlyName
+      - name: config
         isOptional: true
-        type: String?
-        description: Human readable name assigned to a device.
+        type: Config.() -> Unit
+        description: Factor type specific configuration.
     examples:
       - id: enroll-totp-factor
         name: Enroll a time-based, one-time password (TOTP) factor
         isSpotlight: true
         code: |
           ```kotlin
-          val factor = supabase.auth.mfa.enroll(factorType = FactorType.TOTP)
+          val factor = supabase.auth.mfa.enroll(factorType = FactorType.TOTP, friendlyName = "Your friendly Name") {
+                // Optional
+                issuer = "example.com"
+          }
 
           // Use the id to create a challenge.
           // The challenge can be verified by entering the code generated from the authenticator app.
           // The code will be generated upon scanning the qr_code or entering the secret into the authenticator app.
           val (id, type, qrCode) = factor.data //qrCode is a svg as a string
           val (factorId, factorType, _) = factor
+          val challenge = supabase.auth.mfa.createChallenge(factor.id)
+          ```
+      - id: enroll-phone-factor
+        name: Enroll a Phone Factor
+        isSpotlight: true
+        code: |
+          ```kotlin
+          val factor = supabase.auth.mfa.enroll(factorType = FactorType.Phone, friendlyName = "Your friendly Name") {
+                phone = "+123456789" 
+          }
+
+          // Use the id to create a challenge and send an SMS with a code to the user.
+          val (phone) = factor.data
+          val (factorId, factorType, _) = factor
+          val challenge = supabase.auth.mfa.createChallenge(factor.id)
           ```
       - id: get-local-verified-factors
         name: Check the local user for verified factors
@@ -3797,11 +3815,16 @@ functions:
       Creates a challenge for a factor.
       - An [enrolled factor](/docs/reference/kotlin/auth-mfa-enroll) is required before creating a challenge.
       - To verify a challenge, see [`mfa.verifyChallenge()`](/docs/reference/kotlin/auth-mfa-verify).
+      - A phone factor sends a code to the user upon challenge. The channel defaults to `Phone.Channel.SMS` unless otherwise specified.
     params:
       - name: factorId
         isOptional: false
         type: String
         description: The id of the MFA factor you want to create a challenge for.
+      - name: channel
+        isOptional: true
+        type: Phone.Channel?
+        description: The channel to send the challenge to. Defaults to `Phone.Channel.SMS`.
     examples:
       - id: create-mfa-challenge
         name: Create a challenge for a factor


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

No Kotlin third-party auth and phone mfa docs.

## What is the new behavior?

New Kotlin third-party auth and phone mfa docs.
