### PR TITLE
feat: command to query a table

### DIFF
--- a/apps/studio/components/interfaces/App/CommandMenu/CommandMenu.tsx
+++ b/apps/studio/components/interfaces/App/CommandMenu/CommandMenu.tsx
@@ -1,6 +1,9 @@
 import { IS_PLATFORM } from 'common'
 import { useBranchCommands } from 'components/interfaces/BranchManagement/Branch.Commands'
-import { useSnippetCommands } from 'components/layouts/SQLEditorLayout/SqlEditor.Commands'
+import {
+  useQueryTableCommands,
+  useSnippetCommands,
+} from 'components/layouts/SQLEditorLayout/SqlEditor.Commands'
 import { useGenerateSqlCommand } from 'components/interfaces/SqlGenerator/SqlGenerator.Commands'
 import { useProjectLevelTableEditorCommands } from 'components/layouts/TableEditorLayout/TableEditor.Commands'
 import { useLayoutNavCommands } from 'components/layouts/useLayoutNavCommands'
@@ -22,6 +25,7 @@ export default function StudioCommandMenu() {
   useProjectLevelTableEditorCommands()
   useProjectSwitchCommand()
   useConfigureOrganizationCommand()
+  useQueryTableCommands()
   useBranchCommands()
   useSnippetCommands()
   useLayoutNavCommands()

--- a/apps/studio/components/layouts/SQLEditorLayout/SqlEditor.Commands.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SqlEditor.Commands.tsx
@@ -1,5 +1,6 @@
-import { AlertTriangle, Code, Loader2 } from 'lucide-react'
-import { useRouter } from 'next/router'
+import { type PostgresColumn } from '@supabase/postgres-meta'
+import { AlertTriangle, Code, Loader2, Table2 } from 'lucide-react'
+import { useRouter } from 'next/navigation'
 
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { useParams } from 'common'
@@ -9,7 +10,14 @@ import { type SqlSnippet, useSqlSnippetsQuery } from 'data/content/sql-snippets-
 import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { useSelectedProject } from 'hooks/misc/useSelectedProject'
 import { useProfile } from 'lib/profile'
-import { cn, CodeBlock, CommandGroup_Shadcn_, CommandItem_Shadcn_, CommandList_Shadcn_ } from 'ui'
+import {
+  cn,
+  CodeBlock,
+  CommandEmpty_Shadcn_,
+  CommandGroup_Shadcn_,
+  CommandItem_Shadcn_,
+  CommandList_Shadcn_,
+} from 'ui'
 import type { CommandOptions } from 'ui-patterns/CommandMenu'
 import {
   Breadcrumb,
@@ -20,11 +28,15 @@ import {
   generateCommandClassNames,
   PageType,
   useCommandFilterState,
+  useCommandMenuOpen,
   useRegisterCommands,
   useRegisterPage,
   useSetCommandMenuSize,
   useSetPage,
 } from 'ui-patterns/CommandMenu'
+import { usePrefetchTables, useTablesQuery, type TablesData } from 'data/tables/tables-query'
+import { EXCLUDED_SCHEMAS } from 'lib/constants/schemas'
+import { useEffect, useRef } from 'react'
 
 export function useSqlEditorGotoCommands(options?: CommandOptions) {
   let { ref } = useParams()
@@ -229,4 +241,134 @@ function snippetValue(snippet: SqlSnippet) {
   return escapeAttributeSelector(
     `${snippet.id}-${snippet.name}-${snippet.content.sql.slice(0, 30)}`
   ).toLowerCase()
+}
+
+const QUERY_TABLE_PAGE_NAME = 'Query a table'
+
+export function useQueryTableCommands(options?: CommandOptions) {
+  const project = useSelectedProject()
+  const setPage = useSetPage()
+
+  const commandMenuOpen = useCommandMenuOpen()
+  const commandMenuPreviouslyOpen = useRef(commandMenuOpen)
+  const commandMenuJustOpened = commandMenuOpen && !commandMenuPreviouslyOpen.current
+  commandMenuPreviouslyOpen.current = commandMenuOpen
+
+  const prefetchTables = usePrefetchTables({
+    projectRef: project?.ref,
+    connectionString: project?.connectionString,
+  })
+  useEffect(() => {
+    if (project && commandMenuJustOpened) {
+      prefetchTables(undefined, true)
+    }
+  }, [project, prefetchTables, commandMenuJustOpened])
+
+  useRegisterPage(
+    QUERY_TABLE_PAGE_NAME,
+    {
+      type: PageType.Component,
+      component: TableSelector,
+    },
+    { enabled: !!project }
+  )
+
+  useRegisterCommands(
+    COMMAND_MENU_SECTIONS.ACTIONS,
+    [
+      {
+        id: 'query-table',
+        name: 'Query a table',
+        icon: () => <Table2 />,
+        action: () => setPage(QUERY_TABLE_PAGE_NAME),
+      },
+    ],
+    { ...options, enabled: (options?.enabled ?? true) && !!project }
+  )
+}
+
+function TableSelector() {
+  const router = useRouter()
+  const project = useSelectedProject()
+  const {
+    data: tables,
+    isLoading,
+    isError,
+    isSuccess,
+  } = useTablesQuery(
+    {
+      projectRef: project?.ref,
+      connectionString: project?.connectionString,
+      includeColumns: true,
+    },
+    { select: excludeSupabaseControlledSchemas }
+  )
+
+  return (
+    <CommandWrapper>
+      <CommandHeader>
+        <Breadcrumb />
+        <CommandInput autoFocus />
+      </CommandHeader>
+      <CommandList_Shadcn_>
+        {isLoading && <LoadingState />}
+        {isError && <ErrorState />}
+        {isSuccess && (
+          <>
+            <CommandEmpty_Shadcn_ />
+            <CommandGroup_Shadcn_>
+              {tables?.map((table) => (
+                <CommandItem_Shadcn_
+                  key={table.id}
+                  className={generateCommandClassNames(false)}
+                  value={escapeAttributeSelector(formatTableIdentifier(table))}
+                  onSelect={() => {
+                    router.push(
+                      `/project/${project?.ref ?? '_'}/sql/new?content=${encodeURIComponent(generateSelectStatement(table))}`
+                    )
+                  }}
+                >
+                  {formatTableIdentifier(table)}
+                </CommandItem_Shadcn_>
+              ))}
+            </CommandGroup_Shadcn_>
+          </>
+        )}
+      </CommandList_Shadcn_>
+    </CommandWrapper>
+  )
+}
+
+function generateSelectStatement(table: TablesData[number] & { columns?: Array<PostgresColumn> }) {
+  return `
+select ${
+    !table.columns
+      ? '*'
+      : `
+${table.columns.map((column, index, array) => `\t${column.name}`).join(',\n')}`
+  }
+from ${formatTableIdentifier(table)}
+-- where
+-- order by
+-- limit
+;
+  `.trim()
+}
+
+function excludeSupabaseControlledSchemas(tables: TablesData) {
+  return tables.filter((table) => !EXCLUDED_SCHEMAS.includes(table.schema))
+}
+
+// Not a perfectly spec-compliant regex , since Postgres also allows non-Latin
+// letters and letters with diacritical marks, but quoting them defensively
+// is easier than writing the regex. ¯\_(ツ)_/¯
+const VALID_UNQUOTED_IDENTIFIER_REGEX = /^[a-z_][a-z0-9_$]*$/
+function formatTableIdentifier(table: TablesData[number]) {
+  const schema = VALID_UNQUOTED_IDENTIFIER_REGEX.test(table.schema)
+    ? table.schema
+    : `"${table.schema}"`
+  const tableName = VALID_UNQUOTED_IDENTIFIER_REGEX.test(table.name)
+    ? table.name
+    : `"${table.name}"`
+  return `${schema}.${tableName}`
 }

--- a/apps/studio/components/layouts/SQLEditorLayout/SqlEditor.Commands.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SqlEditor.Commands.tsx
@@ -321,14 +321,14 @@ function TableSelector() {
                 <CommandItem_Shadcn_
                   key={table.id}
                   className={generateCommandClassNames(false)}
-                  value={escapeAttributeSelector(formatTableIdentifier(table))}
+                  value={escapeAttributeSelector(`${table.schema}.${table.name}`)}
                   onSelect={() => {
                     router.push(
                       `/project/${project?.ref ?? '_'}/sql/new?content=${encodeURIComponent(generateSelectStatement(table))}`
                     )
                   }}
                 >
-                  {formatTableIdentifier(table)}
+                  {`${table.schema}.${table.name}`}
                 </CommandItem_Shadcn_>
               ))}
             </CommandGroup_Shadcn_>

--- a/apps/studio/data/tables/tables-query.ts
+++ b/apps/studio/data/tables/tables-query.ts
@@ -1,5 +1,5 @@
 import type { PostgresTable } from '@supabase/postgres-meta'
-import { useQuery, useQueryClient, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery, useQueryClient, type UseQueryOptions } from '@tanstack/react-query'
 import { sortBy } from 'lodash'
 import { useCallback } from 'react'
 
@@ -89,6 +89,24 @@ export function useGetTables({
   return useCallback(
     (schema?: TablesVariables['schema'], includeColumns?: TablesVariables['includeColumns']) => {
       return queryClient.fetchQuery({
+        queryKey: tableKeys.list(projectRef, schema, includeColumns),
+        queryFn: ({ signal }) =>
+          getTables({ projectRef, connectionString, schema, includeColumns }, signal),
+      })
+    },
+    [connectionString, projectRef, queryClient]
+  )
+}
+
+export function usePrefetchTables({
+  projectRef,
+  connectionString,
+}: Pick<TablesVariables, 'projectRef' | 'connectionString'>) {
+  const queryClient = useQueryClient()
+
+  return useCallback(
+    (schema?: TablesVariables['schema'], includeColumns?: TablesVariables['includeColumns']) => {
+      return queryClient.prefetchQuery({
         queryKey: tableKeys.list(projectRef, schema, includeColumns),
         queryFn: ({ signal }) =>
           getTables({ projectRef, connectionString, schema, includeColumns }, signal),


### PR DESCRIPTION
Creates this subpage:

<img width="596" alt="image" src="https://github.com/user-attachments/assets/338b50a0-c1e6-4877-9287-086f3916f932">

Selecting a table brings you to the SQL editor with this prefilled:

<img width="735" alt="image" src="https://github.com/user-attachments/assets/d7a3dc7b-6364-4c16-b015-53e99748e678">
