### PR TITLE
fix: disable sms provider validation when sms hook is enabled

### DIFF
--- a/apps/studio/components/interfaces/Auth/AuthProvidersForm/AuthProvidersForm.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersForm/AuthProvidersForm.tsx
@@ -12,7 +12,7 @@ import {
   Button,
   WarningIcon,
 } from 'ui'
-import { PROVIDERS_SCHEMAS } from '../AuthProvidersFormValidation'
+import { getPhoneProviderValidationSchema, PROVIDERS_SCHEMAS } from '../AuthProvidersFormValidation'
 import { ProviderCollapsibleClasses } from './AuthProvidersForm.constants'
 import ProviderForm from './ProviderForm'
 
@@ -57,14 +57,16 @@ const AuthProvidersForm = () => {
           </Alert_Shadcn_>
         )}
         {isLoading &&
-          PROVIDERS_SCHEMAS.map((provider) => (
-            <div
-              key={`provider_${provider.title}`}
-              className={[...ProviderCollapsibleClasses, 'px-6 py-3'].join(' ')}
-            >
-              <HorizontalShimmerWithIcon />
-            </div>
-          ))}
+          PROVIDERS_SCHEMAS.map((provider) => {
+            return (
+              <div
+                key={`provider_${provider.title}`}
+                className={[...ProviderCollapsibleClasses, 'px-6 py-3'].join(' ')}
+              >
+                <HorizontalShimmerWithIcon />
+              </div>
+            )
+          })}
         {isError && (
           <Alert_Shadcn_ variant="destructive">
             <WarningIcon />
@@ -74,11 +76,15 @@ const AuthProvidersForm = () => {
         )}
         {isSuccess &&
           PROVIDERS_SCHEMAS.map((provider) => {
+            const providerSchema =
+              provider.title === 'Phone'
+                ? { ...provider, validationSchema: getPhoneProviderValidationSchema(authConfig) }
+                : provider
             return (
               <ProviderForm
-                key={`provider_${provider.title}`}
+                key={`provider_${providerSchema.title}`}
                 config={authConfig}
-                provider={provider as any}
+                provider={providerSchema as any}
               />
             )
           })}

--- a/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
@@ -1,6 +1,6 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { useParams } from 'common'
-import { Check, ChevronUp } from 'lucide-react'
+import { Check, ChevronUp, ExternalLink } from 'lucide-react'
 import { useState } from 'react'
 import toast from 'react-hot-toast'
 import ReactMarkdown from 'react-markdown'
@@ -26,6 +26,7 @@ import {
 import { ProviderCollapsibleClasses } from './AuthProvidersForm.constants'
 import type { Provider } from './AuthProvidersForm.types'
 import FormField from './FormField'
+import Link from 'next/link'
 
 export interface ProviderFormProps {
   config: components['schemas']['GoTrueConfigResponse']
@@ -38,7 +39,71 @@ const ProviderForm = ({ config, provider }: ProviderFormProps) => {
   const { mutate: updateAuthConfig, isLoading: isUpdatingConfig } = useAuthConfigUpdateMutation()
 
   const doubleNegativeKeys = ['MAILER_AUTOCONFIRM', 'SMS_AUTOCONFIRM']
-  const canUpdateConfig = useCheckPermissions(PermissionAction.UPDATE, 'custom_config_gotrue')
+  const canUpdateConfig: boolean = useCheckPermissions(
+    PermissionAction.UPDATE,
+    'custom_config_gotrue'
+  )
+
+  const shouldDisableField = (field: string): boolean => {
+    const shouldDisableSmsFields =
+      config.HOOK_SEND_SMS_ENABLED &&
+      field.startsWith('SMS_') &&
+      ![
+        'SMS_AUTOCONFIRM',
+        'SMS_OTP_EXP',
+        'SMS_OTP_LENGTH',
+        'SMS_OTP_LENGTH',
+        'SMS_TEMPLATE',
+        'SMS_TEST_OTP',
+        'SMS_TEST_OTP_VALID_UNTIL',
+      ].includes(field)
+    return (
+      ['EXTERNAL_SLACK_CLIENT_ID', 'EXTERNAL_SLACK_SECRET'].includes(field) ||
+      shouldDisableSmsFields
+    )
+  }
+
+  const showAlert = (title: string) => {
+    switch (title) {
+      case 'Slack (Deprecated)':
+        return (
+          <Alert_Shadcn_ variant="warning">
+            <WarningIcon />
+            <AlertTitle_Shadcn_>Slack (Deprecated) Provider</AlertTitle_Shadcn_>
+            <AlertDescription_Shadcn_>
+              Recently, Slack has updated their OAuth API. Please use the new Slack (OIDC) provider
+              below. Developers using this provider should move over to the new provider. Please
+              refer to our{' '}
+              <a
+                href="https://supabase.com/docs/guides/auth/social-login/auth-slack"
+                className="underline"
+                target="_blank"
+              >
+                documentation
+              </a>{' '}
+              for more details.
+            </AlertDescription_Shadcn_>
+          </Alert_Shadcn_>
+        )
+      case 'Phone':
+        return (
+          config.HOOK_SEND_SMS_ENABLED && (
+            <Alert_Shadcn_ variant="warning">
+              <WarningIcon />
+              <AlertTitle_Shadcn_>SMS hook enabled</AlertTitle_Shadcn_>
+              <AlertDescription_Shadcn_ className="flex flex-col gap-y-3">
+                <p>The SMS provider settings will be disabled when the SMS hook is enabled.</p>
+                <Button asChild type="default" className="w-min" icon={<ExternalLink size={14} />}>
+                  <Link href={`/project/${projectRef}/auth/hooks`}>View auth hooks</Link>
+                </Button>
+              </AlertDescription_Shadcn_>
+            </Alert_Shadcn_>
+          )
+        )
+      default:
+        return null
+    }
+  }
 
   const { data: settings } = useProjectApiQuery({ projectRef })
   const apiUrl = `${settings?.autoApiService.protocol}://${settings?.autoApiService.endpoint}`
@@ -165,26 +230,8 @@ const ProviderForm = ({ config, provider }: ProviderFormProps) => {
           return (
             <Collapsible.Content>
               <div className="group border-t border-strong bg-surface-100 py-6 px-6 text-foreground">
-                {provider.title === 'Slack (Deprecated)' && (
-                  <Alert_Shadcn_ variant="warning">
-                    <WarningIcon />
-                    <AlertTitle_Shadcn_>Slack (Deprecated) Provider</AlertTitle_Shadcn_>
-                    <AlertDescription_Shadcn_>
-                      Recently, Slack has updated their OAuth API. Please use the new Slack (OIDC)
-                      provider below. Developers using this provider should move over to the new
-                      provider. Please refer to our{' '}
-                      <a
-                        href="https://supabase.com/docs/guides/auth/social-login/auth-slack"
-                        className="underline"
-                        target="_blank"
-                      >
-                        documentation
-                      </a>{' '}
-                      for more details.
-                    </AlertDescription_Shadcn_>
-                  </Alert_Shadcn_>
-                )}
                 <div className="mx-auto my-6 max-w-lg space-y-6">
+                  {showAlert(provider.title)}
                   {Object.keys(provider.properties).map((x: string) => (
                     <FormField
                       key={x}
@@ -193,8 +240,7 @@ const ProviderForm = ({ config, provider }: ProviderFormProps) => {
                       formValues={values}
                       disabled={
                         // TODO (KM): Remove after 10th October 2024 when we disable the provider
-                        ['EXTERNAL_SLACK_CLIENT_ID', 'EXTERNAL_SLACK_SECRET'].includes(x) ||
-                        !canUpdateConfig
+                        shouldDisableField(x) || !canUpdateConfig
                       }
                     />
                   ))}

--- a/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
@@ -65,6 +65,7 @@ const ProviderForm = ({ config, provider }: ProviderFormProps) => {
 
   const showAlert = (title: string) => {
     switch (title) {
+      // TODO (KM): Remove after 10th October 2024 when we disable the provider
       case 'Slack (Deprecated)':
         return (
           <Alert_Shadcn_ variant="warning">

--- a/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
@@ -89,12 +89,14 @@ const ProviderForm = ({ config, provider }: ProviderFormProps) => {
       case 'Phone':
         return (
           config.HOOK_SEND_SMS_ENABLED && (
-            <Alert_Shadcn_ variant="warning">
+            <Alert_Shadcn_>
               <WarningIcon />
-              <AlertTitle_Shadcn_>SMS hook enabled</AlertTitle_Shadcn_>
+              <AlertTitle_Shadcn_>
+                SMS provider settings are disabled while the SMS hook is enabled.
+              </AlertTitle_Shadcn_>
               <AlertDescription_Shadcn_ className="flex flex-col gap-y-3">
-                <p>The SMS provider settings will be disabled when the SMS hook is enabled.</p>
-                <Button asChild type="default" className="w-min" icon={<ExternalLink size={14} />}>
+                <p>The SMS hook will be used in place of the SMS provider configured</p>
+                <Button asChild type="default" className="w-min" icon={<ExternalLink />}>
                   <Link href={`/project/${projectRef}/auth/hooks`}>View auth hooks</Link>
                 </Button>
               </AlertDescription_Shadcn_>

--- a/apps/studio/components/interfaces/Auth/AuthProvidersFormValidation.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersFormValidation.tsx
@@ -70,6 +70,8 @@ const smsProviderValidation = (config: ProjectAuthConfigData, provider: string) 
   }
 }
 
+// getPhoneProviderValidationSchema generate the validation schema for the SMS providers
+// based on whether the SMS hook is enabled
 export const getPhoneProviderValidationSchema = (config: ProjectAuthConfigData) => {
   return object().shape({
     EXTERNAL_PHONE_ENABLED: boolean().required(),

--- a/apps/studio/components/interfaces/Auth/AuthProvidersFormValidation.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersFormValidation.tsx
@@ -1,5 +1,6 @@
 import { boolean, number, object, string } from 'yup'
 import { urlRegex } from 'components/interfaces/Auth/Auth.constants'
+import { ProjectAuthConfigData } from 'data/auth/auth-config-query'
 
 const parseBase64URL = (b64url: string) => {
   return atob(b64url.replace(/[-]/g, '+').replace(/[_]/g, '/'))
@@ -59,6 +60,118 @@ const PROVIDER_EMAIL = {
     helper: `To complete setup, add this authorisation callback URL to your app's configuration in the Apple Developer Console.
             [Learn more](https://supabase.com/docs/guides/auth/social-login/auth-apple#configure-your-services-id)`,
   },
+}
+
+const smsProviderValidation = (config: ProjectAuthConfigData, provider: string) => {
+  return {
+    is: (EXTERNAL_PHONE_ENABLED: boolean, SMS_PROVIDER: string) => {
+      return EXTERNAL_PHONE_ENABLED && SMS_PROVIDER === provider && !config.HOOK_SEND_SMS_ENABLED
+    },
+  }
+}
+
+export const getPhoneProviderValidationSchema = (config: ProjectAuthConfigData) => {
+  return object().shape({
+    EXTERNAL_PHONE_ENABLED: boolean().required(),
+    SMS_PROVIDER: string(),
+
+    // Twilio
+    SMS_TWILIO_ACCOUNT_SID: string().when(['EXTERNAL_PHONE_ENABLED', 'SMS_PROVIDER'], {
+      ...smsProviderValidation(config, 'twilio'),
+      then: (schema) => schema.required('Twilio Account SID is required'),
+      otherwise: (schema) => schema,
+    }),
+    SMS_TWILIO_AUTH_TOKEN: string().when(['EXTERNAL_PHONE_ENABLED', 'SMS_PROVIDER'], {
+      ...smsProviderValidation(config, 'twilio'),
+      then: (schema) => schema.required('Twilio Auth Token is required'),
+      otherwise: (schema) => schema,
+    }),
+    SMS_TWILIO_MESSAGE_SERVICE_SID: string().when(['EXTERNAL_PHONE_ENABLED', 'SMS_PROVIDER'], {
+      ...smsProviderValidation(config, 'twilio'),
+      then: (schema) => schema.required('Twilio Message Service SID is required'),
+      otherwise: (schema) => schema,
+    }),
+
+    // Twilio Verify
+    SMS_TWILIO_VERIFY_ACCOUNT_SID: string().when(['EXTERNAL_PHONE_ENABLED', 'SMS_PROVIDER'], {
+      ...smsProviderValidation(config, 'twilio_verify'),
+      then: (schema) => schema.required('Twilio Verify Account SID is required'),
+      otherwise: (schema) => schema,
+    }),
+    SMS_TWILIO_VERIFY_AUTH_TOKEN: string().when(['EXTERNAL_PHONE_ENABLED', 'SMS_PROVIDER'], {
+      ...smsProviderValidation(config, 'twilio_verify'),
+      then: (schema) => schema.required('Twilio Verify Auth Token is required'),
+      otherwise: (schema) => schema,
+    }),
+    SMS_TWILIO_VERIFY_MESSAGE_SERVICE_SID: string().when(
+      ['EXTERNAL_PHONE_ENABLED', 'SMS_PROVIDER'],
+      {
+        ...smsProviderValidation(config, 'twilio_verify'),
+        then: (schema) => schema.required('Twilio Verify Service SID is required'),
+        otherwise: (schema) => schema,
+      }
+    ),
+
+    // Messagebird
+    SMS_MESSAGEBIRD_ACCESS_KEY: string().when(['EXTERNAL_PHONE_ENABLED', 'SMS_PROVIDER'], {
+      ...smsProviderValidation(config, 'messagebird'),
+      then: (schema) => schema.required('Messagebird Access Key is required'),
+      otherwise: (schema) => schema,
+    }),
+    SMS_MESSAGEBIRD_ORIGINATOR: string().when(['EXTERNAL_PHONE_ENABLED', 'SMS_PROVIDER'], {
+      ...smsProviderValidation(config, 'messagebird'),
+      then: (schema) => schema.required('Messagebird Originator is required'),
+      otherwise: (schema) => schema,
+    }),
+
+    // Textlocal
+    SMS_TEXTLOCAL_API_KEY: string().when(['EXTERNAL_PHONE_ENABLED', 'SMS_PROVIDER'], {
+      ...smsProviderValidation(config, 'textlocal'),
+      then: (schema) => schema.required('Textlocal API Key is required'),
+      otherwise: (schema) => schema,
+    }),
+    SMS_TEXTLOCAL_SENDER: string().when(['EXTERNAL_PHONE_ENABLED', 'SMS_PROVIDER'], {
+      ...smsProviderValidation(config, 'textlocal'),
+      then: (schema) => schema.required('Textlocal Sender is required'),
+      otherwise: (schema) => schema,
+    }),
+
+    // Vonage
+    SMS_VONAGE_API_KEY: string().when(['EXTERNAL_PHONE_ENABLED', 'SMS_PROVIDER'], {
+      ...smsProviderValidation(config, 'vonage'),
+      then: (schema) => schema.required('Vonage API is required'),
+      otherwise: (schema) => schema,
+    }),
+    SMS_VONAGE_API_SECRET: string().when(['EXTERNAL_PHONE_ENABLED', 'SMS_PROVIDER'], {
+      ...smsProviderValidation(config, 'vonage'),
+      then: (schema) => schema.required('Vonage API Secret is required'),
+      otherwise: (schema) => schema,
+    }),
+    SMS_VONAGE_FROM: string().when(['EXTERNAL_PHONE_ENABLED', 'SMS_PROVIDER'], {
+      ...smsProviderValidation(config, 'vonage'),
+      then: (schema) => schema.required('Vonage From is required'),
+      otherwise: (schema) => schema,
+    }),
+
+    // Phone SMS
+    SMS_OTP_EXP: number().min(0, 'Must be more than 0').required('This is required'),
+    SMS_OTP_LENGTH: number().min(6, 'Must be 6 or more in length').required('This is required'),
+    SMS_TEMPLATE: string().required('SMS template is required.'),
+    SMS_TEST_OTP: string()
+      .matches(
+        /^\s*([0-9]{1,15}=[0-9]+)(\s*,\s*[0-9]{1,15}=[0-9]+)*\s*$/g,
+        'Must be a comma-separated list of <phone number>=<OTP> pairs. Phone numbers should be in international format, without spaces, dashes or the + prefix. Example: 123456789=987654'
+      )
+      .trim()
+      .transform((value: string) => value.replace(/\s+/g, '')),
+    SMS_TEST_OTP_VALID_UNTIL: string().when(['SMS_TEST_OTP'], {
+      is: (SMS_TEST_OTP: string | null) => {
+        return !!SMS_TEST_OTP
+      },
+      then: (schema) => schema.required('You must provide a valid until date.'),
+      otherwise: (schema) => schema.transform((value: string) => ''),
+    }),
+  })
 }
 
 const PROVIDER_PHONE = {
@@ -261,133 +374,7 @@ const PROVIDER_PHONE = {
       },
     },
   },
-  validationSchema: object().shape({
-    EXTERNAL_PHONE_ENABLED: boolean().required(),
-    SMS_PROVIDER: string().required(),
-
-    // Twilio
-    SMS_TWILIO_ACCOUNT_SID: string().when(['EXTERNAL_PHONE_ENABLED', 'SMS_PROVIDER'], {
-      is: (EXTERNAL_PHONE_ENABLED: boolean, SMS_PROVIDER: string) => {
-        return EXTERNAL_PHONE_ENABLED && SMS_PROVIDER === 'twilio'
-      },
-      then: (schema) => schema.required('Twilio Account SID is required'),
-      otherwise: (schema) => schema,
-    }),
-    SMS_TWILIO_AUTH_TOKEN: string().when(['EXTERNAL_PHONE_ENABLED', 'SMS_PROVIDER'], {
-      is: (EXTERNAL_PHONE_ENABLED: boolean, SMS_PROVIDER: string) => {
-        return EXTERNAL_PHONE_ENABLED && SMS_PROVIDER === 'twilio'
-      },
-      then: (schema) => schema.required('Twilio Auth Token is required'),
-      otherwise: (schema) => schema,
-    }),
-    SMS_TWILIO_MESSAGE_SERVICE_SID: string().when(['EXTERNAL_PHONE_ENABLED', 'SMS_PROVIDER'], {
-      is: (EXTERNAL_PHONE_ENABLED: boolean, SMS_PROVIDER: string) => {
-        return EXTERNAL_PHONE_ENABLED && SMS_PROVIDER === 'twilio'
-      },
-      then: (schema) => schema.required('Twilio Message Service SID is required'),
-      otherwise: (schema) => schema,
-    }),
-
-    // Twilio Verify
-    SMS_TWILIO_VERIFY_ACCOUNT_SID: string().when(['EXTERNAL_PHONE_ENABLED', 'SMS_PROVIDER'], {
-      is: (EXTERNAL_PHONE_ENABLED: boolean, SMS_PROVIDER: string) => {
-        return EXTERNAL_PHONE_ENABLED && SMS_PROVIDER === 'twilio-verify'
-      },
-      then: (schema) => schema.required('Twilio Verify Account SID is required'),
-      otherwise: (schema) => schema,
-    }),
-    SMS_TWILIO_VERIFY_AUTH_TOKEN: string().when(['EXTERNAL_PHONE_ENABLED', 'SMS_PROVIDER'], {
-      is: (EXTERNAL_PHONE_ENABLED: boolean, SMS_PROVIDER: string) => {
-        return EXTERNAL_PHONE_ENABLED && SMS_PROVIDER === 'twilio-verify'
-      },
-      then: (schema) => schema.required('Twilio Verify Auth Token is required'),
-      otherwise: (schema) => schema,
-    }),
-    SMS_TWILIO_VERIFY_MESSAGE_SERVICE_SID: string().when(
-      ['EXTERNAL_PHONE_ENABLED', 'SMS_PROVIDER'],
-      {
-        is: (EXTERNAL_PHONE_ENABLED: boolean, SMS_PROVIDER: string) => {
-          return EXTERNAL_PHONE_ENABLED && SMS_PROVIDER === 'twilio-verify'
-        },
-        then: (schema) => schema.required('Twilio Verify Service SID is required'),
-        otherwise: (schema) => schema,
-      }
-    ),
-
-    // Messagebird
-    SMS_MESSAGEBIRD_ACCESS_KEY: string().when(['EXTERNAL_PHONE_ENABLED', 'SMS_PROVIDER'], {
-      is: (EXTERNAL_PHONE_ENABLED: boolean, SMS_PROVIDER: string) => {
-        return EXTERNAL_PHONE_ENABLED && SMS_PROVIDER === 'messagebird'
-      },
-      then: (schema) => schema.required('Messagebird Access Key is required'),
-      otherwise: (schema) => schema,
-    }),
-    SMS_MESSAGEBIRD_ORIGINATOR: string().when(['EXTERNAL_PHONE_ENABLED', 'SMS_PROVIDER'], {
-      is: (EXTERNAL_PHONE_ENABLED: boolean, SMS_PROVIDER: string) => {
-        return EXTERNAL_PHONE_ENABLED && SMS_PROVIDER === 'messagebird'
-      },
-      then: (schema) => schema.required('Messagebird Originator is required'),
-      otherwise: (schema) => schema,
-    }),
-
-    // Textlocal
-    SMS_TEXTLOCAL_API_KEY: string().when(['EXTERNAL_PHONE_ENABLED', 'SMS_PROVIDER'], {
-      is: (EXTERNAL_PHONE_ENABLED: boolean, SMS_PROVIDER: string) => {
-        return EXTERNAL_PHONE_ENABLED && SMS_PROVIDER === 'textlocal'
-      },
-      then: (schema) => schema.required('Textlocal API Key is required'),
-      otherwise: (schema) => schema,
-    }),
-    SMS_TEXTLOCAL_SENDER: string().when(['EXTERNAL_PHONE_ENABLED', 'SMS_PROVIDER'], {
-      is: (EXTERNAL_PHONE_ENABLED: boolean, SMS_PROVIDER: string) => {
-        return EXTERNAL_PHONE_ENABLED && SMS_PROVIDER === 'textlocal'
-      },
-      then: (schema) => schema.required('Textlocal Sender is required'),
-      otherwise: (schema) => schema,
-    }),
-
-    // Vonage
-    SMS_VONAGE_API_KEY: string().when(['EXTERNAL_PHONE_ENABLED', 'SMS_PROVIDER'], {
-      is: (EXTERNAL_PHONE_ENABLED: boolean, SMS_PROVIDER: string) => {
-        return EXTERNAL_PHONE_ENABLED && SMS_PROVIDER === 'vonage'
-      },
-      then: (schema) => schema.required('Vonage API is required'),
-      otherwise: (schema) => schema,
-    }),
-    SMS_VONAGE_API_SECRET: string().when(['EXTERNAL_PHONE_ENABLED', 'SMS_PROVIDER'], {
-      is: (EXTERNAL_PHONE_ENABLED: boolean, SMS_PROVIDER: string) => {
-        return EXTERNAL_PHONE_ENABLED && SMS_PROVIDER === 'vonage'
-      },
-      then: (schema) => schema.required('Vonage API Secret is required'),
-      otherwise: (schema) => schema,
-    }),
-    SMS_VONAGE_FROM: string().when(['EXTERNAL_PHONE_ENABLED', 'SMS_PROVIDER'], {
-      is: (EXTERNAL_PHONE_ENABLED: boolean, SMS_PROVIDER: string) => {
-        return EXTERNAL_PHONE_ENABLED && SMS_PROVIDER === 'vonage'
-      },
-      then: (schema) => schema.required('Vonage From is required'),
-      otherwise: (schema) => schema,
-    }),
-
-    // Phone SMS
-    SMS_OTP_EXP: number().min(0, 'Must be more than 0').required('This is required'),
-    SMS_OTP_LENGTH: number().min(6, 'Must be 6 or more in length').required('This is required'),
-    SMS_TEMPLATE: string().required('SMS template is required.'),
-    SMS_TEST_OTP: string()
-      .matches(
-        /^\s*([0-9]{1,15}=[0-9]+)(\s*,\s*[0-9]{1,15}=[0-9]+)*\s*$/g,
-        'Must be a comma-separated list of <phone number>=<OTP> pairs. Phone numbers should be in international format, without spaces, dashes or the + prefix. Example: 123456789=987654'
-      )
-      .trim()
-      .transform((value: string) => value.replace(/\s+/g, '')),
-    SMS_TEST_OTP_VALID_UNTIL: string().when(['SMS_TEST_OTP'], {
-      is: (SMS_TEST_OTP: string | null) => {
-        return !!SMS_TEST_OTP
-      },
-      then: (schema) => schema.required('You must provide a valid until date.'),
-      otherwise: (schema) => schema.transform((value: string) => ''),
-    }),
-  }),
+  validationSchema: null,
   misc: {
     iconKey: 'phone-icon4',
     helper: `To complete setup, add this authorisation callback URL to your app's configuration in the Apple Developer Console.

--- a/apps/studio/components/interfaces/Auth/Hooks/CreateHookSheet.tsx
+++ b/apps/studio/components/interfaces/Auth/Hooks/CreateHookSheet.tsx
@@ -300,7 +300,16 @@ export const CreateHookSheet = ({
               control={form.control}
               name="enabled"
               render={({ field }) => (
-                <FormItemLayout className="px-8" label={`Enable ${values.hookType}`} layout="flex">
+                <FormItemLayout
+                  layout="flex"
+                  className="px-8"
+                  label={`Enable ${values.hookType}`}
+                  description={
+                    values.hookType === 'Send SMS hook'
+                      ? 'SMS Provider settings will be disabled in favor of SMS hooks'
+                      : undefined
+                  }
+                >
                   <FormControl_Shadcn_>
                     <Switch
                       checked={field.value}


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?
* When the SMS hook is enabled, we should disable the validation for the SMS provider selected. The SMS hook will be used in place of the SMS provider configured. 
* Only the configuration related to the SMS provider (e.g. twilio, messagebird, vonage, textlocal) should be disabled - other configs like `SMS_AUTOCONFIRM`, `SMS_OTP_LENGTH`, etc should remain unaffected since they are still applicable when the hook is configured

## What is the current behavior?
* A user will not be able to enable the phone provider without added the configuration for the SMS provider (see [comment](https://github.com/supabase/auth/issues/1582#issuecomment-2292810035)

## What is the new behavior?
* We show an alert in the "Phone" provider form section if the SMS hook is enabled and disable the sms provider fields.
* If the hook is disabled, we should apply the validation for the SMS provider fields.

<img width="868" alt="image" src="https://github.com/user-attachments/assets/6c5fe376-5f17-4c8c-9d53-2f3e00bc8750">


## Additional context

Add any other context or screenshots.
