### PR TITLE
update postgrest 12.2 blog post title

### DIFF
--- a/apps/www/_blog/2024-08-16-postgrest-12-2.mdx
+++ b/apps/www/_blog/2024-08-16-postgrest-12-2.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'PostgREST 12.2: Prometheus compatibility and statement timeouts'
+title: 'PostgREST 12.2: Prometheus metrics'
 description: New features in the latest 12.2 release of PostgREST
 author: steve_chavez
 image: lw12/day-5/OG_postgREST.png


### PR DESCRIPTION
Statement timeouts are not really a postgrest feature. The hoisted function settings feature does more than statement timeouts too.