### PR TITLE
feat: control increase disk modal via url state

### DIFF
--- a/apps/studio/components/interfaces/Settings/Database/DiskSizeConfiguration.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/DiskSizeConfiguration.tsx
@@ -68,7 +68,7 @@ const DiskSizeConfiguration = ({ disabled = false }: DiskSizeConfigurationProps)
 
   return (
     <div id="diskManagement">
-      <FormHeader title="Disk management" />
+      <FormHeader title="Disk Management" />
       {projectSubscriptionData?.usage_billing_enabled === true ? (
         <div className="flex flex-col gap-3">
           <Panel className="!m-0">

--- a/apps/studio/components/interfaces/Settings/Database/DiskSizeConfiguration.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/DiskSizeConfiguration.tsx
@@ -35,13 +35,6 @@ const DiskSizeConfiguration = ({ disabled = false }: DiskSizeConfigurationProps)
 
   const timeTillNextAvailableDatabaseResize =
     lastDatabaseResizeAt === null ? 0 : 6 * 60 - dayjs().diff(lastDatabaseResizeAt, 'minutes')
-  const isAbleToResizeDatabase = timeTillNextAvailableDatabaseResize <= 0
-  const formattedTimeTillNextAvailableResize =
-    timeTillNextAvailableDatabaseResize < 60
-      ? `${timeTillNextAvailableDatabaseResize} minute(s)`
-      : `${Math.floor(timeTillNextAvailableDatabaseResize / 60)} hours and ${
-          timeTillNextAvailableDatabaseResize % 60
-        } minute(s)`
 
   const [{ show_increase_disk_size_modal }, setUrlParams] = useUrlState()
   const showIncreaseDiskSizeModal = show_increase_disk_size_modal === 'true'
@@ -65,27 +58,7 @@ const DiskSizeConfiguration = ({ disabled = false }: DiskSizeConfigurationProps)
       },
     })
 
-  const confirmResetDbPass = async (values: { [prop: string]: any }) => {
-    if (!projectRef) return console.error('Project ref is required')
-    const volumeSize = values['new-disk-size']
-    updateProjectUsage({ projectRef, volumeSize })
-  }
-
   const currentDiskSize = project?.volumeSizeGb ?? 0
-  // to do, update with max_disk_volume_size_gb
-  const maxDiskSize = 200
-
-  const INITIAL_VALUES = {
-    'new-disk-size': currentDiskSize,
-  }
-
-  const diskSizeValidationSchema = object({
-    'new-disk-size': number()
-      .required('Please enter a GB amount you want to resize the disk up to.')
-      .min(Number(currentDiskSize ?? 0), `Must be more than ${currentDiskSize} GB`)
-      // to do, update with max_disk_volume_size_gb
-      .max(Number(maxDiskSize), 'Must not be more than 200 GB'),
-  })
 
   const { data } = useDatabaseSizeQuery({
     projectRef: project?.ref,

--- a/apps/studio/components/interfaces/Settings/Database/DiskSizeConfiguration.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/DiskSizeConfiguration.tsx
@@ -2,7 +2,7 @@ import { PermissionAction } from '@supabase/shared-types/out/constants'
 import dayjs from 'dayjs'
 import { ExternalLink, Info } from 'lucide-react'
 import Link from 'next/link'
-import { useState } from 'react'
+import { SetStateAction } from 'react'
 import toast from 'react-hot-toast'
 import { number, object } from 'yup'
 
@@ -18,6 +18,7 @@ import { useDatabaseSizeQuery } from 'data/database/database-size-query'
 import { useOrgSubscriptionQuery } from 'data/subscriptions/org-subscription-query'
 import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { useSelectedOrganization } from 'hooks/misc/useSelectedOrganization'
+import { useUrlState } from 'hooks/ui/useUrlState'
 import { formatBytes } from 'lib/helpers'
 import { AlertDescription_Shadcn_, AlertTitle_Shadcn_, Alert_Shadcn_, Button } from 'ui'
 
@@ -42,7 +43,12 @@ const DiskSizeConfiguration = ({ disabled = false }: DiskSizeConfigurationProps)
           timeTillNextAvailableDatabaseResize % 60
         } minute(s)`
 
-  const [showIncreaseDiskSizeModal, setshowIncreaseDiskSizeModal] = useState(false)
+  const [{ show_increase_disk_size_modal }, setUrlParams] = useUrlState()
+  const showIncreaseDiskSizeModal = show_increase_disk_size_modal === 'true'
+  const setShowIncreaseDiskSizeModal = (value: SetStateAction<boolean>) => {
+    const show = typeof value === 'function' ? value(showIncreaseDiskSizeModal) : value
+    setUrlParams({ show_increase_disk_size_modal: show ? 'true' : undefined })
+  }
 
   const canUpdateDiskSizeConfig = useCheckPermissions(PermissionAction.UPDATE, 'projects', {
     resource: {
@@ -55,7 +61,7 @@ const DiskSizeConfiguration = ({ disabled = false }: DiskSizeConfigurationProps)
     useProjectDiskResizeMutation({
       onSuccess: (res, variables) => {
         toast.success(`Successfully updated disk size to ${variables.volumeSize} GB`)
-        setshowIncreaseDiskSizeModal(false)
+        setShowIncreaseDiskSizeModal(false)
       },
     })
 
@@ -110,7 +116,7 @@ const DiskSizeConfiguration = ({ disabled = false }: DiskSizeConfigurationProps)
                       <ButtonTooltip
                         type="default"
                         disabled={!canUpdateDiskSizeConfig || disabled}
-                        onClick={() => setshowIncreaseDiskSizeModal(true)}
+                        onClick={() => setShowIncreaseDiskSizeModal(true)}
                         tooltip={{
                           content: {
                             side: 'bottom',
@@ -213,7 +219,7 @@ Read more about [disk management](https://supabase.com/docs/guides/platform/data
       <DiskSizeConfigurationModal
         visible={showIncreaseDiskSizeModal}
         loading={isUpdatingDiskSize}
-        hideModal={setshowIncreaseDiskSizeModal}
+        hideModal={setShowIncreaseDiskSizeModal}
       />
     </div>
   )

--- a/apps/studio/components/interfaces/Settings/Database/DiskSizeConfigurationModal.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/DiskSizeConfigurationModal.tsx
@@ -139,7 +139,7 @@ const DiskSizeConfigurationModal = ({
                   id="new-disk-size"
                   label="New disk size"
                   labelOptional="GB"
-                  disabled={!isAbleToResizeDatabase}
+                  disabled={!isAbleToResizeDatabase || isLoading}
                 />
               </Modal.Content>
               <Modal.Separator />

--- a/apps/studio/components/interfaces/Settings/Database/DiskSizeConfigurationModal.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/DiskSizeConfigurationModal.tsx
@@ -9,6 +9,8 @@ import { number, object } from 'yup'
 import { useParams } from 'common'
 import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
 import { useProjectDiskResizeMutation } from 'data/config/project-disk-resize-mutation'
+import { useOrgSubscriptionQuery } from 'data/subscriptions/org-subscription-query'
+import { useSelectedOrganization } from 'hooks/misc/useSelectedOrganization'
 import {
   AlertDescription_Shadcn_,
   AlertTitle_Shadcn_,
@@ -19,6 +21,7 @@ import {
   Modal,
   WarningIcon,
 } from 'ui'
+import ShimmeringLoader from 'ui-patterns/ShimmeringLoader'
 
 export interface DiskSizeConfigurationProps {
   visible: boolean
@@ -32,12 +35,18 @@ const DiskSizeConfigurationModal = ({
   hideModal,
 }: DiskSizeConfigurationProps) => {
   const { ref: projectRef } = useParams()
-  const { project, isLoading } = useProjectContext()
+  const { project, isLoading: isLoadingProject } = useProjectContext()
   const { lastDatabaseResizeAt } = project ?? {}
+
+  const organization = useSelectedOrganization()
+  const { data: projectSubscriptionData, isLoading: isLoadingSubscription } =
+    useOrgSubscriptionQuery({ orgSlug: organization?.slug })
+
+  const isLoading = isLoadingProject || isLoadingSubscription
 
   const timeTillNextAvailableDatabaseResize =
     lastDatabaseResizeAt === null ? 0 : 6 * 60 - dayjs().diff(lastDatabaseResizeAt, 'minutes')
-  const isAbleToResizeDatabase = isLoading || timeTillNextAvailableDatabaseResize <= 0
+  const isAbleToResizeDatabase = timeTillNextAvailableDatabaseResize <= 0
   const formattedTimeTillNextAvailableResize =
     timeTillNextAvailableDatabaseResize < 60
       ? `${timeTillNextAvailableDatabaseResize} minute(s)`
@@ -84,82 +93,123 @@ const DiskSizeConfigurationModal = ({
       onCancel={() => hideModal(false)}
       hideFooter
     >
-      <Form
-        name="disk-resize-form"
-        initialValues={INITIAL_VALUES}
-        validationSchema={diskSizeValidationSchema}
-        onSubmit={confirmResetDbPass}
-      >
-        {() =>
-          currentDiskSize >= maxDiskSize ? (
-            <Alert_Shadcn_ variant="warning" className="rounded-t-none border-0">
-              <WarningIcon />
-              <AlertTitle_Shadcn_>Maximum manual disk size increase reached</AlertTitle_Shadcn_>
-              <AlertDescription_Shadcn_>
-                <p>
-                  You cannot manually expand the disk size any more than {maxDiskSize}GB. If you
-                  need more than this, contact us via support for help.
-                </p>
-                <Button asChild type="default" className="mt-3">
-                  <Link
-                    href={`/support/new?ref=${projectRef}&category=${SupportCategories.PERFORMANCE_ISSUES}&subject=Increase%20disk%20size%20beyond%20200GB`}
+      {isLoading ? (
+        <div className="flex flex-col gap-4 p-4">
+          <ShimmeringLoader />
+          <ShimmeringLoader />
+        </div>
+      ) : projectSubscriptionData?.usage_billing_enabled === true ? (
+        <Form
+          name="disk-resize-form"
+          initialValues={INITIAL_VALUES}
+          validationSchema={diskSizeValidationSchema}
+          onSubmit={confirmResetDbPass}
+        >
+          {() =>
+            currentDiskSize >= maxDiskSize ? (
+              <Alert_Shadcn_ variant="warning" className="rounded-t-none border-0">
+                <WarningIcon />
+                <AlertTitle_Shadcn_>Maximum manual disk size increase reached</AlertTitle_Shadcn_>
+                <AlertDescription_Shadcn_>
+                  <p>
+                    You cannot manually expand the disk size any more than {maxDiskSize}GB. If you
+                    need more than this, contact us via support for help.
+                  </p>
+                  <Button asChild type="default" className="mt-3">
+                    <Link
+                      href={`/support/new?ref=${projectRef}&category=${SupportCategories.PERFORMANCE_ISSUES}&subject=Increase%20disk%20size%20beyond%20200GB`}
+                    >
+                      Contact support
+                    </Link>
+                  </Button>
+                </AlertDescription_Shadcn_>
+              </Alert_Shadcn_>
+            ) : (
+              <>
+                <Modal.Content className="w-full space-y-4">
+                  <Alert_Shadcn_ variant={isAbleToResizeDatabase ? 'default' : 'warning'}>
+                    <Info size={16} />
+                    <AlertTitle_Shadcn_>
+                      This operation is only possible every 6 hours
+                    </AlertTitle_Shadcn_>
+                    <AlertDescription_Shadcn_>
+                      <div className="mb-4">
+                        {isAbleToResizeDatabase
+                          ? `Upon updating your disk size, the next disk size update will only be available from ${dayjs().format(
+                              'DD MMM YYYY, HH:mm (ZZ)'
+                            )}`
+                          : `Your database was last resized at ${dayjs(lastDatabaseResizeAt).format(
+                              'DD MMM YYYY, HH:mm (ZZ)'
+                            )}. You can resize your database again in approximately ${formattedTimeTillNextAvailableResize}`}
+                      </div>
+                      <Button asChild type="default" iconRight={<ExternalLink size={14} />}>
+                        <Link href="https://supabase.com/docs/guides/platform/database-size#disk-management">
+                          Read more about disk management
+                        </Link>
+                      </Button>
+                    </AlertDescription_Shadcn_>
+                  </Alert_Shadcn_>
+                  <InputNumber
+                    required
+                    id="new-disk-size"
+                    label="New disk size"
+                    labelOptional="GB"
+                    disabled={!isAbleToResizeDatabase}
+                  />
+                </Modal.Content>
+                <Modal.Separator />
+                <Modal.Content className="flex space-x-2 justify-end">
+                  <Button type="default" onClick={() => hideModal(false)}>
+                    Cancel
+                  </Button>
+                  <Button
+                    htmlType="submit"
+                    type="primary"
+                    disabled={!isAbleToResizeDatabase || isUpdatingDiskSize}
+                    loading={isUpdatingDiskSize}
                   >
-                    Contact support
-                  </Link>
-                </Button>
-              </AlertDescription_Shadcn_>
-            </Alert_Shadcn_>
-          ) : (
-            <>
-              <Modal.Content className="w-full space-y-4">
-                <Alert_Shadcn_ variant={isAbleToResizeDatabase ? 'default' : 'warning'}>
-                  <Info size={16} />
-                  <AlertTitle_Shadcn_>
-                    This operation is only possible every 6 hours
-                  </AlertTitle_Shadcn_>
-                  <AlertDescription_Shadcn_>
-                    <div className="mb-4">
-                      {isAbleToResizeDatabase
-                        ? `Upon updating your disk size, the next disk size update will only be available from ${dayjs().format(
-                            'DD MMM YYYY, HH:mm (ZZ)'
-                          )}`
-                        : `Your database was last resized at ${dayjs(lastDatabaseResizeAt).format(
-                            'DD MMM YYYY, HH:mm (ZZ)'
-                          )}. You can resize your database again in approximately ${formattedTimeTillNextAvailableResize}`}
-                    </div>
-                    <Button asChild type="default" iconRight={<ExternalLink size={14} />}>
-                      <Link href="https://supabase.com/docs/guides/platform/database-size#disk-management">
-                        Read more about disk management
-                      </Link>
-                    </Button>
-                  </AlertDescription_Shadcn_>
-                </Alert_Shadcn_>
-                <InputNumber
-                  required
-                  id="new-disk-size"
-                  label="New disk size"
-                  labelOptional="GB"
-                  disabled={!isAbleToResizeDatabase || isLoading}
-                />
-              </Modal.Content>
-              <Modal.Separator />
-              <Modal.Content className="flex space-x-2 justify-end">
-                <Button type="default" onClick={() => hideModal(false)}>
-                  Cancel
-                </Button>
-                <Button
-                  htmlType="submit"
-                  type="primary"
-                  disabled={!isAbleToResizeDatabase || isUpdatingDiskSize || isLoading}
-                  loading={isUpdatingDiskSize}
-                >
-                  Update disk size
-                </Button>
-              </Modal.Content>
-            </>
-          )
-        }
-      </Form>
+                    Update disk size
+                  </Button>
+                </Modal.Content>
+              </>
+            )
+          }
+        </Form>
+      ) : (
+        <Alert_Shadcn_ className="border-none">
+          <Info size={16} />
+          <AlertTitle_Shadcn_>
+            {projectSubscriptionData?.plan?.id === 'free'
+              ? 'Disk size configuration is not available for projects on the Free Plan'
+              : 'Disk size configuration is only available when the spend cap has been disabled'}
+          </AlertTitle_Shadcn_>
+          <AlertDescription_Shadcn_>
+            {projectSubscriptionData?.plan?.id === 'free' ? (
+              <p>
+                If you are intending to use more than 500MB of disk space, then you will need to
+                upgrade to at least the Pro Plan.
+              </p>
+            ) : (
+              <p>
+                If you are intending to use more than 8GB of disk space, then you will need to
+                disable your spend cap.
+              </p>
+            )}
+            <Button asChild type="default" className="mt-3">
+              <Link
+                href={`/org/${organization?.slug}/billing?panel=${
+                  projectSubscriptionData?.plan?.id === 'free' ? 'subscriptionPlan' : 'costControl'
+                }`}
+                target="_blank"
+              >
+                {projectSubscriptionData?.plan?.id === 'free'
+                  ? 'Upgrade subscription'
+                  : 'Disable spend cap'}
+              </Link>
+            </Button>
+          </AlertDescription_Shadcn_>
+        </Alert_Shadcn_>
+      )}
     </Modal>
   )
 }

--- a/apps/studio/components/interfaces/Settings/Database/DiskSizeConfigurationModal.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/DiskSizeConfigurationModal.tsx
@@ -32,12 +32,12 @@ const DiskSizeConfigurationModal = ({
   hideModal,
 }: DiskSizeConfigurationProps) => {
   const { ref: projectRef } = useParams()
-  const { project } = useProjectContext()
+  const { project, isLoading } = useProjectContext()
   const { lastDatabaseResizeAt } = project ?? {}
 
   const timeTillNextAvailableDatabaseResize =
     lastDatabaseResizeAt === null ? 0 : 6 * 60 - dayjs().diff(lastDatabaseResizeAt, 'minutes')
-  const isAbleToResizeDatabase = timeTillNextAvailableDatabaseResize <= 0
+  const isAbleToResizeDatabase = isLoading || timeTillNextAvailableDatabaseResize <= 0
   const formattedTimeTillNextAvailableResize =
     timeTillNextAvailableDatabaseResize < 60
       ? `${timeTillNextAvailableDatabaseResize} minute(s)`
@@ -150,7 +150,7 @@ const DiskSizeConfigurationModal = ({
                 <Button
                   htmlType="submit"
                   type="primary"
-                  disabled={!isAbleToResizeDatabase || isUpdatingDiskSize}
+                  disabled={!isAbleToResizeDatabase || isUpdatingDiskSize || isLoading}
                   loading={isUpdatingDiskSize}
                 >
                   Update disk size

--- a/apps/studio/components/interfaces/Support/SupportForm.tsx
+++ b/apps/studio/components/interfaces/Support/SupportForm.tsx
@@ -558,7 +558,7 @@ const SupportForm = ({ setSentCategory, setSelectedProject }: SupportFormProps) 
               )}
 
             {isLoadingProjects && (
-              <div className="space-y-2">
+              <div className="px-6 space-y-2">
                 <p className="text-sm prose">Which project is affected?</p>
                 <ShimmeringLoader className="!py-[19px]" />
               </div>

--- a/apps/studio/pages/project/[ref]/reports/database.tsx
+++ b/apps/studio/pages/project/[ref]/reports/database.tsx
@@ -1,7 +1,7 @@
 import dayjs from 'dayjs'
 import { ArrowRight } from 'lucide-react'
 import Link from 'next/link'
-import { SetStateAction, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { AlertDescription_Shadcn_, Alert_Shadcn_, Button, IconExternalLink } from 'ui'
 
 import { PermissionAction } from '@supabase/shared-types/out/constants'
@@ -21,7 +21,6 @@ import { useProjectDiskResizeMutation } from 'data/config/project-disk-resize-mu
 import { useDatabaseSizeQuery } from 'data/database/database-size-query'
 import { useDatabaseReport } from 'data/reports/database-report-query'
 import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
-import { useUrlState } from 'hooks/ui/useUrlState'
 import { TIME_PERIODS_INFRA } from 'lib/constants/metrics'
 import { formatBytes } from 'lib/helpers'
 import toast from 'react-hot-toast'
@@ -56,13 +55,7 @@ const DatabaseUsage = () => {
   const databaseSizeBytes = data?.result[0].db_size ?? 0
   const currentDiskSize = project?.volumeSizeGb ?? 0
 
-  const [{ show_increase_disk_size_modal }, setUrlParams] = useUrlState()
-  const showIncreaseDiskSizeModal = show_increase_disk_size_modal === 'true'
-  const setShowIncreaseDiskSizeModal = (value: SetStateAction<boolean>) => {
-    const show = typeof value === 'function' ? value(showIncreaseDiskSizeModal) : value
-    setUrlParams({ show_increase_disk_size_modal: show ? 'true' : undefined })
-  }
-
+  const [showIncreaseDiskSizeModal, setshowIncreaseDiskSizeModal] = useState(false)
   const canUpdateDiskSizeConfig = useCheckPermissions(PermissionAction.UPDATE, 'projects', {
     resource: {
       project_id: project?.id,
@@ -72,7 +65,7 @@ const DatabaseUsage = () => {
   const { isLoading: isUpdatingDiskSize } = useProjectDiskResizeMutation({
     onSuccess: (res, variables) => {
       toast.success(`Successfully updated disk size to ${variables.volumeSize} GB`)
-      setShowIncreaseDiskSizeModal(false)
+      setshowIncreaseDiskSizeModal(false)
     },
   })
 
@@ -223,7 +216,7 @@ const DatabaseUsage = () => {
                     <ButtonTooltip
                       type="default"
                       disabled={!canUpdateDiskSizeConfig}
-                      onClick={() => setShowIncreaseDiskSizeModal(true)}
+                      onClick={() => setshowIncreaseDiskSizeModal(true)}
                       tooltip={{
                         content: {
                           side: 'bottom',
@@ -303,7 +296,7 @@ const DatabaseUsage = () => {
         <DiskSizeConfigurationModal
           visible={showIncreaseDiskSizeModal}
           loading={isUpdatingDiskSize}
-          hideModal={setShowIncreaseDiskSizeModal}
+          hideModal={setshowIncreaseDiskSizeModal}
         />
       </section>
     </>

--- a/apps/studio/pages/project/[ref]/reports/database.tsx
+++ b/apps/studio/pages/project/[ref]/reports/database.tsx
@@ -21,12 +21,12 @@ import { useProjectDiskResizeMutation } from 'data/config/project-disk-resize-mu
 import { useDatabaseSizeQuery } from 'data/database/database-size-query'
 import { useDatabaseReport } from 'data/reports/database-report-query'
 import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import { useUrlState } from 'hooks/ui/useUrlState'
 import { TIME_PERIODS_INFRA } from 'lib/constants/metrics'
 import { formatBytes } from 'lib/helpers'
 import toast from 'react-hot-toast'
 import { useDatabaseSelectorStateSnapshot } from 'state/database-selector'
 import type { NextPageWithLayout } from 'types'
-import { useUrlState } from 'hooks/ui/useUrlState'
 
 const DatabaseReport: NextPageWithLayout = () => {
   return (
@@ -60,7 +60,7 @@ const DatabaseUsage = () => {
   const showIncreaseDiskSizeModal = show_increase_disk_size_modal === 'true'
   const setShowIncreaseDiskSizeModal = (value: SetStateAction<boolean>) => {
     const show = typeof value === 'function' ? value(showIncreaseDiskSizeModal) : value
-    setUrlParams({ show_increase_disk_size_modal: String(show) })
+    setUrlParams({ show_increase_disk_size_modal: show ? 'true' : undefined })
   }
 
   const canUpdateDiskSizeConfig = useCheckPermissions(PermissionAction.UPDATE, 'projects', {


### PR DESCRIPTION
## What kind of change does this PR introduce?

feat

## What is the current behavior?

The increase disk is unable to be controlled via the URL, so we can't link directly to it.

## What is the new behavior?

Add `?show_increase_disk_size_modal=true` on the `/database` settings page to open the modal.
