### PR TITLE
Update 2024-08-16-vec2pg.mdx

### DIFF
--- a/apps/www/_blog/2024-08-16-vec2pg.mdx
+++ b/apps/www/_blog/2024-08-16-vec2pg.mdx
@@ -102,7 +102,7 @@ Since `vector` is just another column type in Postgres, you can write policies t
 
 pgvector has world class performance in terms of raw throughput and dominates in performance per dollar. Check out some of our prior blog posts for more information on functionality and performance:
 
-- https://supabase.com/blog/pgvector-0-7-0
+- [**What's new in pgvector v0.7.0**](https://supabase.com/blog/pgvector-0-7-0)
 - [**pgvector 0.6.0: 30x faster with parallel index builds**](https://supabase.com/blog/pgvector-fast-builds)
 - [**Matryoshka embeddings: faster OpenAI vector search using Adaptive Retrieval**](https://supabase.com/blog/matryoshka-embeddings)
 


### PR DESCRIPTION
Fixed missing title for blog post "What's new in pgvector v0.7.0"

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Blog content update

## What is the current behavior?

Title missing from blog link

## What is the new behavior?

Added title

## Additional context

N/A
