### PR TITLE
docs: Add tip to reload postgrest for timeout changes if using API calls

### DIFF
--- a/apps/docs/content/guides/database/postgres/timeouts.mdx
+++ b/apps/docs/content/guides/database/postgres/timeouts.mdx
@@ -68,7 +68,18 @@ Run the following query to change a role's timeout:
 alter role example_role set statement_timeout = '10min'; -- could also use seconds '10s'
 ```
 
-Unlike global settings, the result cannot be checked with `SHOW statement_timeout`. Instead, run:
+<Admonition type="tip">
+  If you are changing the timeout for the Supabase Client API calls, you will need to reload
+  postgREST to reflect the timeout changes by running the following script:
+
+```sql
+NOTIFY pgrst, 'reload config';
+```
+
+</Admonition>
+
+Unlike global settings, the result cannot be checked with `SHOW
+statement_timeout`. Instead, run:
 
 ```sql
 select


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Doc update

## What is the current behavior?

When users change timeout for the authenticator role, it does not reflect in postgREST client api calls

## What is the new behavior?

Add tip to reload postgrest config to make the changes reflect in API calls.

## Additional context

