### PR TITLE
chore: add bootstrap command to docs page

### DIFF
--- a/apps/docs/spec/common-cli-sections.json
+++ b/apps/docs/spec/common-cli-sections.json
@@ -19,7 +19,7 @@
     "items": [
       {
         "id": "supabase-bootstrap",
-        "title": "Launch a new project from template",
+        "title": "Launch a quick start template",
         "slug": "supabase-bootstrap",
         "type": "cli-command"
       },

--- a/apps/docs/spec/common-cli-sections.json
+++ b/apps/docs/spec/common-cli-sections.json
@@ -18,6 +18,12 @@
     "title": "General",
     "items": [
       {
+        "id": "supabase-bootstrap",
+        "title": "Launch a new project from template",
+        "slug": "supabase-bootstrap",
+        "type": "cli-command"
+      },
+      {
         "id": "supabase-init",
         "title": "Initialize a local project",
         "slug": "supabase-init",


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the new behavior?

Adds missing docs page for bootstrap command.

## Additional context

Add any other context or screenshots.
