### PR TITLE
Add special characters warning to DB password in new project prompt

### DIFF
--- a/apps/studio/components/ui/PasswordStrengthBar.tsx
+++ b/apps/studio/components/ui/PasswordStrengthBar.tsx
@@ -1,4 +1,5 @@
 import { PASSWORD_STRENGTH_COLOR, PASSWORD_STRENGTH_PERCENTAGE } from 'lib/constants'
+import { Admonition } from 'ui'
 
 interface Props {
   passwordStrengthScore: number
@@ -45,6 +46,12 @@ const PasswordStrengthBar = ({
           Generate a password
         </span>
       </p>
+      <Admonition type="danger">
+        Be careful when using special characters in your database password as they may cause
+        problems when connecting. See the
+        [documentation](https://supabase.com/docs/guides/database/postgres/roles#special-symbols-in-passwords)
+        for recommendations.
+      </Admonition>
     </>
   )
 }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Enhancement

## What is the current behavior?

Current behaviour is that special characters are called out in the docs but not when creating a password which results in user confusion when unable to connect

## What is the new behavior?

Add a warning to the project creation prompt to provide warnings about using special chars and link to the docs

## Additional context

Add any other context or screenshots.
