### PR TITLE
Add warning about custom role passwords omitted in backups to relevant docs pages

### DIFF
--- a/apps/docs/content/guides/platform/upgrading.mdx
+++ b/apps/docs/content/guides/platform/upgrading.mdx
@@ -22,6 +22,11 @@ This upgrade method is currently in Beta.
 
 </Admonition>
 
+<Admonition type="note">
+  For security purposes, passwords for custom roles are not backed up and, following a restore, they
+  would need to be reset. See [here](/docs/guides/platform/backups#daily-backups) for more details
+</Admonition>
+
 pg_upgrade performs an in-place upgrade on your database. For projects larger than 1GB, pg_upgrade is generally faster than a pause+restore cycle, and the speed advantage grows with the size of the database.
 
 1. Plan for an appropriate downtime window, and ensure you have reviewed the [caveats](#caveats) section of this document before executing the upgrade.


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs

## What is the current behavior?

Passwords for custom roles are not included in backups as we use the `--no-role-passwords` flag when taking a backup

## What is the new behavior?

The original mention of this is now linked in other relevant docs through an admonition (Roles and Upgrading Projects).

## Additional context

Fixes #28731 
