### PR TITLE
Set noindex for preview builds of docs site

### DIFF
--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -111,6 +111,27 @@ const nextConfig = {
             value: 'DENY',
           },
         ],
+        has: [
+          {
+            type: 'host',
+            value: 'supabase.com',
+          },
+        ],
+      },
+      {
+        source: '/:path*',
+        headers: [
+          {
+            key: 'X-Robots-Tag',
+            value: 'noindex',
+          }
+        ],
+        has: [
+          {
+            type: 'host',
+            value: '*.vercel.app',
+          },
+        ],
       },
     ]
   },

--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -122,9 +122,17 @@ const nextConfig = {
         source: '/:path*',
         headers: [
           {
+            key: 'Strict-Transport-Security',
+            value: '',
+          },
+          {
             key: 'X-Robots-Tag',
             value: 'noindex',
-          }
+          },
+          {
+            key: 'X-Frame-Options',
+            value: 'DENY',
+          },
         ],
         has: [
           {

--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -137,7 +137,7 @@ const nextConfig = {
         has: [
           {
             type: 'host',
-            value: '*.vercel.app',
+            value: '(?:.+\\.vercel\\.app)',
           },
         ],
       },


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Currently, preview builds of the site (i.e. https://docs-rog1zs1kv-supabase.vercel.app) are indexed as `X-Robots-Tag` is set to `all`. By default, [Vercel](https://vercel.com/guides/are-vercel-preview-deployment-indexed-by-search-engines) sets this to `noindex` and we override it here

## What is the new behavior?

This adds an additional check for the host domain and sets the header to `noindex` when it is not the production site

## Additional context

Fixes #28753 
