### PR TITLE
fix: rename AWS Cognito to Amazon Cognito

### DIFF
--- a/apps/docs/content/guides/auth/third-party/aws-cognito.mdx
+++ b/apps/docs/content/guides/auth/third-party/aws-cognito.mdx
@@ -1,14 +1,14 @@
 ---
 id: 'auth-third-party-aws-cognito'
-title: 'AWS Cognito (Amplify)'
-subtitle: 'Use AWS Cognito via Amplify or standalone with your Supabase project'
+title: 'Amazon Cognito (Amplify)'
+subtitle: 'Use Amazon Cognito via Amplify or standalone with your Supabase project'
 ---
 
-AWS Cognito User Pools (via AWS Amplify or on its own) can be used as a third-party authentication provider alongside Supabase Auth, or standalone, with your Supabase project.
+Amazon Cognito User Pools (via AWS Amplify or on its own) can be used as a third-party authentication provider alongside Supabase Auth, or standalone, with your Supabase project.
 
 ## Getting started
 
-1. First you need to add an integration to connect your Supabase project with your AWS Cognito User Pool. You will need the pool's ID and region.
+1. First you need to add an integration to connect your Supabase project with your Amazon Cognito User Pool. You will need the pool's ID and region.
 2. Add a new Third-party Auth integration in your project's [Authentication settings](/dashboard/project/_/settings/auth) or configure it in the CLI.
 3. Assign the `role: 'authenticated'` custom claim to all JWTs by using a Pre-Token Generation Trigger.
 4. Finally setup the Supabase client in your application.
@@ -144,9 +144,9 @@ user_pool_region = "<region>"
 
 Your Supabase project inspects the `role` claim present in all JWTs sent to it, to assign the correct Postgres role when using the Data API, Storage or Realtime authorization.
 
-By default, AWS Cognito JWTs (both ID token and access tokens) do not contain a `role` claim in them. If you were to send such a JWT to your Supabase project, the `anon` role would be assigned when executing the Postgres query. Most of your app's logic will be accessible by the `authenticated` role.
+By default, Amazon Cognito JWTs (both ID token and access tokens) do not contain a `role` claim in them. If you were to send such a JWT to your Supabase project, the `anon` role would be assigned when executing the Postgres query. Most of your app's logic will be accessible by the `authenticated` role.
 
-A recommended approach to do this is to configure a [Pre-Token Generation Trigger](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-pre-token-generation.html) either `V1_0` (ID token only) or `V2_0` (both access and ID token). To do this you will need to create a new Lambda function (in any language and runtime) and assign it to the [AWS Cognito User Pool's Lambda Triggers configuration](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-identity-pools-working-with-aws-lambda-triggers.html). For example, the Lambda function should look similar to this:
+A recommended approach to do this is to configure a [Pre-Token Generation Trigger](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-pre-token-generation.html) either `V1_0` (ID token only) or `V2_0` (both access and ID token). To do this you will need to create a new Lambda function (in any language and runtime) and assign it to the [Amazon Cognito User Pool's Lambda Triggers configuration](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-identity-pools-working-with-aws-lambda-triggers.html). For example, the Lambda function should look similar to this:
 
 <Tabs type="underlined" queryGroup="cognito-lambda">
 

--- a/apps/studio/components/interfaces/Auth/ThirdPartyAuthForm/CreateAwsCognitoAuthDialog.tsx
+++ b/apps/studio/components/interfaces/Auth/ThirdPartyAuthForm/CreateAwsCognitoAuthDialog.tsx
@@ -55,7 +55,7 @@ export const CreateAwsCognitoAuthIntegrationDialog = ({
   const { ref: projectRef } = useParams()
   const { mutate: createAuthIntegration, isLoading } = useCreateThirdPartyAuthIntegrationMutation({
     onSuccess: () => {
-      toast.success(`Successfully created a new AWS Cognito Auth integration.`)
+      toast.success(`Successfully created a new Amazon Cognito Auth integration.`)
       onClose()
     },
   })
@@ -98,12 +98,12 @@ export const CreateAwsCognitoAuthIntegrationDialog = ({
         <DialogHeader>
           <DialogTitle className="truncate">
             {isCreating
-              ? `Add new AWS Cognito Auth connection`
-              : `Update existing AWS Cognito Auth connection`}
+              ? `Add new Amazon Cognito Auth connection`
+              : `Update existing Amazon Cognito Auth connection`}
           </DialogTitle>
           <DialogDescription>
-            By adding an AWS Cognito Auth connection, you can authenticate users using AWS Cognito
-            User Pools.
+            By adding an Amazon Cognito Auth connection, you can authenticate users using Amazon
+            Cognito User Pools.
           </DialogDescription>
         </DialogHeader>
         <Separator />
@@ -118,7 +118,7 @@ export const CreateAwsCognitoAuthIntegrationDialog = ({
               render={({ field }) => (
                 <FormItemLayout
                   className="px-8"
-                  label={`Enable AWS Cognito Auth Connection`}
+                  label={`Enable Amazon Cognito Auth Connection`}
                   layout="flex"
                 >
                   <FormControl_Shadcn_>
@@ -133,7 +133,7 @@ export const CreateAwsCognitoAuthIntegrationDialog = ({
             />
             <Separator /> */}
               <p className="text-sm text-foreground-light">
-                This will enable a JWT token from AWS Cognito project to access data from this
+                This will enable a JWT token from Amazon Cognito project to access data from this
                 Supabase project.
               </p>
               <FormField_Shadcn_
@@ -141,7 +141,7 @@ export const CreateAwsCognitoAuthIntegrationDialog = ({
                 control={form.control}
                 name="awsCognitoUserPoolId"
                 render={({ field }) => (
-                  <FormItemLayout label="AWS Cognito User Pool ID">
+                  <FormItemLayout label="Amazon Cognito User Pool ID">
                     <div className="flex flex-row">
                       <Button
                         type="default"

--- a/apps/studio/components/interfaces/Auth/ThirdPartyAuthForm/IntegrationCard.tsx
+++ b/apps/studio/components/interfaces/Auth/ThirdPartyAuthForm/IntegrationCard.tsx
@@ -56,11 +56,11 @@ export const getIntegrationTypeDescription = (type: INTEGRATION_TYPES) => {
     case 'awsCognito':
       return (
         <>
-          Allow users to use Supabase with AWS Cognito project. Additional setup may be required.
-          You can read more in the{' '}
+          Allow users to use Supabase with an Amazon Cognito. Additional setup may be required. You
+          can read more in the{' '}
           <a
             className="hover:decoration-brand underline hover:text-foreground transition"
-            href="https://supabase.com/docs/guides/auth"
+            href="https://supabase.com/docs/guides/auth/third-party/aws-cognito"
           >
             documentation
           </a>

--- a/apps/studio/components/interfaces/Auth/ThirdPartyAuthForm/ThirdPartyAuthForm.utils.ts
+++ b/apps/studio/components/interfaces/Auth/ThirdPartyAuthForm/ThirdPartyAuthForm.utils.ts
@@ -29,7 +29,7 @@ export const getIntegrationTypeLabel = (type: INTEGRATION_TYPES) => {
     case 'auth0':
       return 'Auth0'
     case 'awsCognito':
-      return 'AWS Cognito'
+      return 'Amazon Cognito'
     case 'custom':
     default:
       return 'Custom'


### PR DESCRIPTION
It's supposedly called Amazon Cognito not AWS Cognito.