### PR TITLE
Add RLS policy template to "Enable users to view their own data only"

### DIFF
--- a/apps/studio/components/interfaces/Auth/Policies/PolicyEditorModal/PolicyEditorModal.constants.ts
+++ b/apps/studio/components/interfaces/Auth/Policies/PolicyEditorModal/PolicyEditorModal.constants.ts
@@ -176,16 +176,17 @@ for select using (
     id: 'policy-9',
     preview: false,
     templateName: 'Enable users to view their own data only',
-    description:
-      'This policy grants read access (SELECT) to users so they can only view rows where the "user_id" or "created_by" column matches their own user ID.',
-    statement: 
+    description: 'Restrict users to reading only their own data.',
+    statement: `
 create policy "Enable users to view their own data only"
 on "${schema}"."${table}"
 for select
 to authenticated
-using (auth.uid() = user_id OR auth.uid() = created_by);.trim(),
+using (
+  (select auth.uid()) = user_id
+);`.trim(),
     name: 'Enable users to view their own data only',
-    definition: 'auth.uid() = user_id OR auth.uid() = created_by',
+    definition: '(select auth.uid()) = user_id',
     check: '',
     command: 'SELECT',
     roles: ['authenticated'],

--- a/apps/studio/components/interfaces/Auth/Policies/PolicyEditorModal/PolicyEditorModal.constants.ts
+++ b/apps/studio/components/interfaces/Auth/Policies/PolicyEditorModal/PolicyEditorModal.constants.ts
@@ -172,6 +172,24 @@ for select using (
     command: 'SELECT',
     roles: [],
   },
+  {
+    id: 'policy-9',
+    preview: false,
+    templateName: 'Enable users to view their own data only',
+    description:
+      'This policy grants read access (SELECT) to users so they can only view rows where the "user_id" or "created_by" column matches their own user ID.',
+    statement: 
+create policy "Enable users to view their own data only"
+on "${schema}"."${table}"
+for select
+to authenticated
+using (auth.uid() = user_id OR auth.uid() = created_by);.trim(),
+    name: 'Enable users to view their own data only',
+    definition: 'auth.uid() = user_id OR auth.uid() = created_by',
+    check: '',
+    command: 'SELECT',
+    roles: ['authenticated'],
+  },
 ]
 
 export const getRealtimePolicyTemplates = (): PolicyTemplate[] => {

--- a/apps/studio/components/interfaces/Auth/Policies/PolicyEditorModal/PolicyEditorModal.constants.ts
+++ b/apps/studio/components/interfaces/Auth/Policies/PolicyEditorModal/PolicyEditorModal.constants.ts
@@ -175,7 +175,7 @@ for select using (
   {
     id: 'policy-9',
     preview: false,
-    templateName: 'Enable users to view their own data only',
+    templateName: 'Allow users to only view their own data',
     description: 'Restrict users to reading only their own data.',
     statement: `
 create policy "Enable users to view their own data only"


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES, however, I am not able to test this change because the `npm install` process failed.

## What kind of change does this PR introduce?

New policy template

## What is the current behavior?

Currently, the PostgreSQL policy templates in the getGeneralPolicyTemplates function provide a variety of access control scenarios, but they do not include a policy specifically designed to restrict users to viewing only their own data.

## What is the new behavior?

A new policy template has been added that enables users to view only their own data. This policy ensures that users can only access rows where the `user_id` or `created_by` column matches their own user ID.

### New Policy:
- Template Name: Enable users to view their own data only
- Description: Grants read access (SELECT) to users so they can only view rows where the user_id or created_by column matches their own user ID.
- SQL Statement:
```
create policy "Enable users to view their own data only"
on "${schema}"."${table}"
for select
to authenticated
using (auth.uid() = user_id OR auth.uid() = created_by);
```

## Additional context

This new policy is crucial for applications that require data privacy and security in multi-user environments. It helps enforce row-level security by ensuring users can only access their own records, thus protecting sensitive data.

Thanks to @saltcod for suggesting this PR.  
