### PR TITLE
Clarify language in `range` documentation

### DIFF
--- a/apps/docs/spec/supabase_py_v2.yml
+++ b/apps/docs/spec/supabase_py_v2.yml
@@ -4762,9 +4762,9 @@ functions:
         type: string
         description: Set this to limit rows of foreign tables instead of the parent table.
     notes: |
-      Limit the query result by starting at an offset (`from`) and ending at the offset (`from + to`). Only records within this range are returned. This respects the query order and if there is no order clause the range could behave unexpectedly.
+      Limit the query result by starting at an offset (`start`) and ending at the offset (`end`). Only records within this range are returned. This respects the query order and if there is no order clause the range could behave unexpectedly.
       
-      The `from` and `to` values are 0-based and inclusive: `range(1, 3)` will include the second, third and fourth rows of the query.
+      The `start` and `end` values are 0-based and inclusive: `range(1, 3)` will include the second, third and fourth rows of the query.
     examples:
       - id: with-select
         name: With `select()`

--- a/apps/docs/spec/supabase_py_v2.yml
+++ b/apps/docs/spec/supabase_py_v2.yml
@@ -4749,11 +4749,11 @@ functions:
   - id: range
     title: range()
     params:
-      - name: start
+      - name: from
         isOptional: false
         type: number
         description: The starting index from which to limit the result.
-      - name: end
+      - name: to
         isOptional: false
         type: number
         description: The last index to which to limit the result.
@@ -4762,9 +4762,9 @@ functions:
         type: string
         description: Set this to limit rows of foreign tables instead of the parent table.
     notes: |
-      Limit the query result by starting at an offset (`start`) and ending at the offset (`end`). Only records within this range are returned. This respects the query order and if there is no order clause the range could behave unexpectedly.
+      Limit the query result by starting at an offset (`from`) and ending at the offset (`to`). Only records within this range are returned. This respects the query order and if there is no order clause the range could behave unexpectedly.
       
-      The `start` and `end` values are 0-based and inclusive: `range(1, 3)` will include the second, third and fourth rows of the query.
+      The `from` and `to` values are 0-based and inclusive: `range(1, 3)` will include the second, third and fourth rows of the query.
     examples:
       - id: with-select
         name: With `select()`


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

The python [range documentation](https://supabase.com/docs/reference/python/range) has the following issues:
1. Inconsistent naming - The parameter list uses `start` and `end` while the description uses `from` and `to`
2. Incorrect offset end description - The description states that the result is limited by "starting at an offset (`from`) and ending at the offset (`from + to`)". This is incorrect as the end index is just `to`. E.g. `range(20, 30)` returns 11 items (20-30), not 51 items (20-20+30)

## What is the new behavior?

1. Range indices are references as `from` and `to` in parameter list. This is aligned with the documentation for other languages.
2. Description states that range offset ends at just `to`

## Additional context

[relevant implementation](https://github.com/supabase/postgrest-py/blob/main/postgrest/base_request_builder.py#L598-L608)
