### PR TITLE
chore: add Chris Stockton to humans.txt

### DIFF
--- a/apps/docs/public/humans.txt
+++ b/apps/docs/public/humans.txt
@@ -21,6 +21,7 @@ Chris Caruso
 Chris Chandler
 Chris Copplestone
 Chris Gwilliams
+Chris Stockton
 Craig Cannon
 Dave Wilson
 Deji I


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Chore

## What is the current behavior?

Chris Stockton missing from humans.txt

## What is the new behavior?

Chris Stockton included in humans.txt :partying_face: 

## Additional context

I've recently joined the Supabase team, this is one of the onboarding steps.