### PR TITLE
Fix ai debug

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
@@ -414,7 +414,15 @@ const SQLEditor = () => {
         )
       }
     }
-  }, [debugSql, entityDefinitions, id, snap.results, snap.snippets])
+  }, [
+    debugSql,
+    entityDefinitions,
+    id,
+    snap.results,
+    snap.snippets,
+    snapV2.results,
+    snapV2.snippets,
+  ])
 
   const acceptAiHandler = useCallback(async () => {
     try {


### PR DESCRIPTION
To reproduce: 
- go to the SQL Editor and create a new snippet by adding `select * from no_exist;`
- refresh the page
- run the `select * from no_exist;` query
- when that fails, click Debug with AI 
- this should fail to even run and give you an error toast 
