### PR TITLE
Chore/table editor fixes

### DIFF
--- a/apps/studio/components/grid/components/grid/Grid.tsx
+++ b/apps/studio/components/grid/components/grid/Grid.tsx
@@ -146,6 +146,7 @@ export const Grid = memo(
 
         const fk = data?.find(
           (key: any) =>
+            key.source_columns == columnName &&
             key.target_schema == targetTableSchema &&
             key.target_table == targetTableName &&
             key.target_columns == targetColumnName

--- a/apps/studio/components/grid/components/grid/Grid.tsx
+++ b/apps/studio/components/grid/components/grid/Grid.tsx
@@ -146,11 +146,14 @@ export const Grid = memo(
 
         const fk = data?.find(
           (key: any) =>
-            key.source_columns == columnName &&
-            key.target_schema == targetTableSchema &&
-            key.target_table == targetTableName &&
-            key.target_columns == targetColumnName
+            key.source_schema === table?.schema &&
+            key.source_table === table?.name &&
+            key.source_columns.includes(columnName) &&
+            key.target_schema === targetTableSchema &&
+            key.target_table === targetTableName &&
+            key.target_columns.includes(targetColumnName)
         )
+
         return fk !== undefined ? formatForeignKeys([fk])[0] : undefined
       }
 

--- a/apps/studio/data/table-rows/table-rows-query.ts
+++ b/apps/studio/data/table-rows/table-rows-query.ts
@@ -36,10 +36,14 @@ type GetTableRowsArgs = {
 // [Joshen] We can probably make this reasonably high, but for now max aim to load 10kb
 export const MAX_CHARACTERS = 10 * KB
 
-// return the primary key column if exists, otherwise return the first column
-// to use as a default sort
-const getDefaultOrderByColumn = (table: SupaTable) => {
-  return table.columns.find((column) => column.isPrimaryKey)?.name || table.columns[0]?.name
+// return the primary key columns if exists, otherwise return the first column to use as a default sort
+const getDefaultOrderByColumns = (table: SupaTable) => {
+  const primaryKeyColumns = table.columns.filter((col) => col?.isPrimaryKey).map((col) => col.name)
+  if (primaryKeyColumns.length === 0) {
+    return [table.columns[0]?.name]
+  } else {
+    return primaryKeyColumns
+  }
 }
 
 // Updated fetchAllTableRows function
@@ -76,9 +80,11 @@ export const fetchAllTableRows = async ({
 
   // If sorts is empty and table row count is within threshold, use the primary key as the default sort
   if (sorts.length === 0 && table.estimateRowCount <= THRESHOLD_COUNT) {
-    const primaryKey = getDefaultOrderByColumn(table)
-    if (primaryKey) {
-      queryChains = queryChains.order(table.name, primaryKey, true, true)
+    const primaryKeys = getDefaultOrderByColumns(table)
+    if (primaryKeys.length > 0) {
+      primaryKeys.forEach((col) => {
+        queryChains = queryChains.order(table.name, col, true, true)
+      })
     }
   } else {
     sorts.forEach((sort) => {
@@ -146,9 +152,11 @@ export const getTableRowsSqlQuery = ({
 
   // If sorts is empty and table row count is within threshold, use the primary key as the default sort
   if (sorts.length === 0 && table.estimateRowCount <= THRESHOLD_COUNT) {
-    const defaultOrderByColumn = getDefaultOrderByColumn(table)
-    if (defaultOrderByColumn) {
-      queryChains = queryChains.order(table.name, defaultOrderByColumn, true, true)
+    const defaultOrderByColumns = getDefaultOrderByColumns(table)
+    if (defaultOrderByColumns.length > 0) {
+      defaultOrderByColumns.forEach((col) => {
+        queryChains = queryChains.order(table.name, col, true, true)
+      })
     }
   } else {
     sorts.forEach((x) => {


### PR DESCRIPTION
Fixes a couple of issues with the table editor around updating cell values of columns that have a foreign key
- Fixes default sort behaviour on tables with composite primary keys, currently it only picks one of the columns from the composite PK and applies the sort on it, which means that the rows will still move around after updating a cell
  - Threshold of default sort to be applied only for tables below 50k rows still apply
- For a table that has 2 columns with foreign keys targeting the same table, fix to update the correct column when the foreign row is selected
- For a table that has a composite foreign key, support updating the foreign key columns from the grid editor itself (it currently works only via the RowEditor side panel)