### PR TITLE
fix inline code word break

### DIFF
--- a/apps/docs/content/guides/auth/jwts.mdx
+++ b/apps/docs/content/guides/auth/jwts.mdx
@@ -66,7 +66,7 @@ The first segment `eyJhbGciOiJIUzI1NiJ9` is known as the "header", and when deco
 }
 ```
 
-The second segment `eyJzdWIiOiIwMDAxIiwibmFtZSI6IlNhbSBWaW1lcyIsImlhdCI6MTUxNjIzOTAyMiwiZXhwIjoxNTE4MjM5MDIyfQ` contains our original payload:
+The second segment <code className="break-all">eyJzdWIiOiIwMDAxIiwibmFtZSI6IlNhbSBWaW1lcyIsImlhdCI6MTUxNjIzOTAyMiwiZXhwIjoxNTE4MjM5MDIyfQ</code> contains our original payload:
 
 ```js
 {

--- a/packages/config/tailwind.config.js
+++ b/packages/config/tailwind.config.js
@@ -242,7 +242,6 @@ const uiConfig = ui({
               backgroundColor: 'hsl(var(--background-surface-200))',
               border: '1px solid ' + 'hsl(var(--background-surface-300))',
               borderRadius: theme('borderRadius.lg'),
-              // wordBreak: 'break-all',
             },
             a: {
               position: 'relative',


### PR DESCRIPTION
## What is the current behavior?

<img width="786" alt="Screenshot 2024-08-23 at 12 14 22" src="https://github.com/user-attachments/assets/941c49aa-1c2c-4394-83f3-368da2df6004">

## What is the new behavior?

<img width="623" alt="Screenshot 2024-08-23 at 12 15 27" src="https://github.com/user-attachments/assets/61eb9f98-26e6-4ee9-84d9-ec5814cb0b83">