### PR TITLE
added missing submit button in authentication example using Sveltekit last code block (/priva…

### DIFF
--- a/apps/docs/content/guides/auth/server-side/sveltekit.mdx
+++ b/apps/docs/content/guides/auth/server-side/sveltekit.mdx
@@ -609,6 +609,8 @@ export const load: PageServerLoad = async ({ depends, locals: { supabase } }) =>
 		Add a note
 		<input name="note" type="text" />
 	</label>
+
+  <button>Add note</button>
 </form>
 ```
 


### PR DESCRIPTION
…te/+page.svelte)

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

A code example in the Sveltekit authentication guide was missing a button in the form. A small issue but thought I'd put it in :)

## What is the new behavior?

The code example with the form now contains a relevant submit button

## Additional context

-
