### PR TITLE
fix: use the comment of extension in shared-data over builtin

### DIFF
--- a/apps/studio/components/interfaces/Database/Extensions/ExtensionCard.tsx
+++ b/apps/studio/components/interfaces/Database/Extensions/ExtensionCard.tsx
@@ -88,7 +88,7 @@ const ExtensionCard = ({ extension }: ExtensionCardProps) => {
         )}
 
         <div className={cn('flex h-full flex-col gap-y-3 py-3', X_PADDING)}>
-          <p className="text-sm text-foreground-light capitalize-sentence">{extension.comment}</p>
+          <p className="text-sm text-foreground-light capitalize-sentence">{(extensionMeta ?? extension).comment}</p>
           <div className="flex items-center gap-x-2">
             {extensionMeta?.github_url && (
               <Button asChild type="default" icon={<Github />} className="rounded-full">


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The comment of extension shows in ExtensionCard is queried from database. In `packages/shared-data/extensions.json`, we provide metadata of some predefined extensions. We should use the comment in `packages/shared-data/extensions.json` if available.

## What is the new behavior?

Use predefined comment instead of queried from database

## Additional context

Add any other context or screenshots.
