### PR TITLE
docs: fix Flutter reference docs `auth.resend` code example

### DIFF
--- a/apps/docs/spec/supabase_dart_v2.yml
+++ b/apps/docs/spec/supabase_dart_v2.yml
@@ -1346,7 +1346,7 @@ functions:
         code: |
           ```dart
           final ResendResponse res = await supabase.auth.resend(
-            type: OtpType.email,
+            type: OtpType.signup,
             email: 'email@example.com',
           );
           ```


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Fixes the example code for `auth.resend` method to use the correct OtpType.

Closes https://github.com/supabase/supabase-flutter/issues/1008