### PR TITLE
fix: spend cap permissions tooltip

### DIFF
--- a/packages/ui/src/components/SidePanel/SidePanel.tsx
+++ b/packages/ui/src/components/SidePanel/SidePanel.tsx
@@ -75,14 +75,16 @@ const SidePanel = ({
       {onConfirm !== undefined && (
         <Tooltip>
           <TooltipTrigger asChild>
-            <Button
-              htmlType="submit"
-              disabled={disabled || loading}
-              loading={loading}
-              onClick={() => (onConfirm ? onConfirm() : null)}
-            >
-              {confirmText}
-            </Button>
+            <span className="inline-block">
+              <Button
+                htmlType="submit"
+                disabled={disabled || loading}
+                loading={loading}
+                onClick={() => (onConfirm ? onConfirm() : null)}
+              >
+                {confirmText}
+              </Button>
+            </span>
           </TooltipTrigger>
           {tooltip !== undefined && <TooltipContent side="bottom">{tooltip}</TooltipContent>}
         </Tooltip>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

Currently the tooltip won't show because the button is disabled. This PR introduces a wrapping span which separates the tooltips disabled state from the buttons disabled state.

<img width="340" alt="Screenshot 2024-08-26 at 21 17 09" src="https://github.com/user-attachments/assets/5e0ba418-1289-4030-a3cf-d54633b2509e">
