### PR TITLE
fix: auth0 migration guide typo

### DIFF
--- a/apps/docs/app/page.tsx
+++ b/apps/docs/app/page.tsx
@@ -72,7 +72,7 @@ const products = [
 
 const migrationGuides = [
   {
-    title: 'Auth',
+    title: 'Auth0',
     icon: '/docs/img/icons/auth0-icon',
     href: '/guides/resources/migrating-to-supabase/auth0',
   },


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?
<img width="705" alt="Screenshot 2024-08-27 at 09 34 51" src="https://github.com/user-attachments/assets/b1e83104-150f-400c-8489-c0c31b3be8f4">

## What is the new behavior?

Auth0 instead of just Auth