### PR TITLE
deprecate: version information is obsolete

### DIFF
--- a/docker/docker-compose.s3.yml
+++ b/docker/docker-compose.s3.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
 
   minio:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -5,7 +5,6 @@
 #   Destroy:        docker compose -f docker-compose.yml -f ./dev/docker-compose.dev.yml down -v --remove-orphans
 
 name: supabase
-version: "3.8"
 
 services:
   studio:


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Remove obsolete field/value in docker compose files.

## What is the current behavior?

You receive the following warning when starting the docker compose stack:

```shell
WARN[0000] <Path>/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
```

## What is the new behavior?

The warning will not appear.

## Additional context

- [](https://docs.docker.com/reference/compose-file/version-and-name/#version-top-level-element-obsolete)