### PR TITLE
fix: sql editor folder name editing

### DIFF
--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorTreeViewItem.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorTreeViewItem.tsx
@@ -83,6 +83,7 @@ export const SQLEditorTreeViewItem = ({
 
   // [Joshen] Folder contents are loaded on demand too
   const onOpenFolder = async (id: string) => {
+    console.log('2 id:', id)
     if (!ref) return console.error('Project ref is required')
 
     try {
@@ -125,6 +126,12 @@ export const SQLEditorTreeViewItem = ({
                   router.push(`/project/${ref}/sql/${element.id}`)
                 }
               } else {
+                // Prevent expanding folder while editing text
+                // as the user may double click to select etc
+                if (isEditing) {
+                  return
+                }
+
                 onClick(e)
                 if (!isExpanded) onOpenFolder(element.id)
               }

--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorTreeViewItem.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorTreeViewItem.tsx
@@ -83,7 +83,6 @@ export const SQLEditorTreeViewItem = ({
 
   // [Joshen] Folder contents are loaded on demand too
   const onOpenFolder = async (id: string) => {
-    console.log('2 id:', id)
     if (!ref) return console.error('Project ref is required')
 
     try {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

https://github.com/user-attachments/assets/441d37ee-b657-4e5d-a20d-8cca9e30544b

## What is the new behavior?

https://github.com/user-attachments/assets/7f9b215a-b172-4ea7-a9b1-b1517be79025

## Additional context

This also fixes another bug where a user would double click a on a new folder that hadn't been created yet. This would cause 'new-folder' to be sent in place of an actual uuid
