### PR TITLE
fix: compute badge micro instance meta

### DIFF
--- a/apps/studio/components/ui/ComputeBadgeWrapper.tsx
+++ b/apps/studio/components/ui/ComputeBadgeWrapper.tsx
@@ -7,6 +7,7 @@ import { useOrgSubscriptionQuery } from 'data/subscriptions/org-subscription-que
 import { useProjectAddonsQuery } from 'data/subscriptions/project-addons-query'
 import { ProjectAddonVariantMeta } from 'data/subscriptions/types'
 import { getCloudProviderArchitecture } from 'lib/cloudprovider-utils'
+import { INSTANCE_MICRO_SPECS } from 'lib/constants'
 import { Button, HoverCard, HoverCardContent, HoverCardTrigger, Separator } from 'ui'
 import { ComputeBadge } from 'ui-patterns/ComputeBadge/ComputeBadge'
 import ShimmeringLoader from './ShimmeringLoader'
@@ -49,7 +50,11 @@ export const ComputeBadgeWrapper = ({ project }: ComputeBadgeWrapperProps) => {
 
   const { computeInstance } = getAddons(selectedAddons)
 
-  const meta = computeInstance?.variant?.meta as ProjectAddonVariantMeta | undefined
+  let meta = computeInstance?.variant?.meta as ProjectAddonVariantMeta | undefined
+  // some older instances on micro compute are missing metadata
+  if (meta === undefined && project.infra_compute_size === 'micro') {
+    meta = INSTANCE_MICRO_SPECS
+  }
 
   const availableCompute = addons?.available_addons.find(
     (addon) => addon.name === 'Compute Instance'


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Some older instances on micro compute are missing metadata and are showing the nano specs:

<img width="399" alt="Screenshot 2024-08-27 at 18 36 18" src="https://github.com/user-attachments/assets/3522e1f5-c1e7-46ce-a7e7-1cda8f0a0371">

## What is the new behavior?

<img width="400" alt="Screenshot 2024-08-27 at 18 36 32" src="https://github.com/user-attachments/assets/e83e0c30-cbca-43d1-baf9-0f64ee78636a">
