### PR TITLE
Replace deprecated to_timestamp! with parse_timestamp! function in vector.yml

### DIFF
--- a/docker/volumes/logs/vector.yml
+++ b/docker/volumes/logs/vector.yml
@@ -101,7 +101,7 @@ transforms:
       parsed, err = parse_regex(.event_message, r'^(?P<time>.*): (?P<msg>.*)$')
       if err == null {
           .event_message = parsed.msg
-          .timestamp = to_timestamp!(parsed.time)
+          .timestamp = parse_timestamp!(parsed.time, format: "%v %R %:z")
           .metadata.host = .project
       }
   # Realtime logs are structured so we parse the severity level using regex (ignore time because it has no date)


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

```
2024-08-27 20:04:37 2024-08-27T13:04:37.271778Z ERROR vector::topology::builder: Configuration error. error=Transform "rest_logs": 
2024-08-27 20:04:37 error[E105]: call to undefined function
2024-08-27 20:04:37   ┌─ :4:18
2024-08-27 20:04:37   │
2024-08-27 20:04:37 4 │     .timestamp = to_timestamp!(parsed.time)
2024-08-27 20:04:37   │                  ^^^^^^^^^^^^
2024-08-27 20:04:37   │                  │
2024-08-27 20:04:37   │                  undefined function
2024-08-27 20:04:37   │                  did you mean "is_timestamp"?
2024-08-27 20:04:37   │
2024-08-27 20:04:37   = learn more about error code 105 at https://errors.vrl.dev/105
2024-08-27 20:04:37   = see language documentation at https://vrl.dev
2024-08-27 20:04:37   = try your code in the VRL REPL, learn more at https://vrl.dev/examples
```

## What is the new behavior?

```
.timestamp = parse_timestamp!(parsed.time, format: "%v %R %:z")
```

## Additional context

https://github.com/vectordotdev/vector/blob/master/website/content/en/highlights/2023-08-15-0-32-0-upgrade-guide.md#vrl-to_timestamp-function-deprecated-to-timestamp