### PR TITLE
Update manual identity linking when self-hosting

### DIFF
--- a/apps/docs/content/guides/auth/auth-identity-linking.mdx
+++ b/apps/docs/content/guides/auth/auth-identity-linking.mdx
@@ -76,7 +76,7 @@ response = supabase.auth.link_identity({'provider': 'google'})
 </TabPanel>
 </Tabs>
 
-In the example above, the user will be redirected to Google to complete the OAuth2.0 flow. Once the OAuth2.0 flow has completed successfully, the user will be redirected back to the application and the Google identity will be linked to the user. You can enable manual linking from your project's authentication [configuration options](/dashboard/project/_/settings/auth) or by setting the environment variable `GOTRUE_SECURITY_MANUAL_LINKING_ENABLED: true` when self-hosting.
+In the example above, the user will be redirected to Google to complete the OAuth2.0 flow. Once the OAuth2.0 flow has completed successfully, the user will be redirected back to the application and the Google identity will be linked to the user. You can enable manual linking from your project's authentication [configuration options](/dashboard/project/_/settings/auth) or by setting the environment variable `enable_manual_linking = true` in the `config.toml` when self-hosting.
 
 ## Unlink an identity
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Update **Identity Linking** guide for self-hosting users attempting to enable manual linking:
- Replaces `GOTRUE_SECURITY_MANUAL_LINKING_ENABLED: true`  with `enable_manual_linking = true`.


