### PR TITLE
chore: link to upgrade existing org

### DIFF
--- a/apps/studio/components/interfaces/Organization/NewOrg/NewOrgForm.tsx
+++ b/apps/studio/components/interfaces/Organization/NewOrg/NewOrgForm.tsx
@@ -1,6 +1,8 @@
 import { PaymentElement, useElements, useStripe } from '@stripe/react-stripe-js'
 import type { PaymentMethod } from '@stripe/stripe-js'
 import { useQueryClient } from '@tanstack/react-query'
+import { ExternalLink } from 'lucide-react'
+import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
 import toast from 'react-hot-toast'
@@ -13,8 +15,6 @@ import { invalidateOrganizationsQuery } from 'data/organizations/organizations-q
 import { BASE_PATH, PRICING_TIER_LABELS_ORG } from 'lib/constants'
 import { getURL } from 'lib/helpers'
 import { Button, IconEdit2, IconHelpCircle, Input, Listbox, Toggle } from 'ui'
-import { ExternalLink } from 'lucide-react'
-import Link from 'next/link'
 
 const ORG_KIND_TYPES = {
   PERSONAL: 'Personal',
@@ -265,17 +265,18 @@ const NewOrgForm = ({ onPaymentMethodReset }: NewOrgFormProps) => {
         <Panel.Content>
           <Listbox
             label={
-              <div className="space-y-2">
+              <div className="flex flex-col gap-2">
                 <span>Plan</span>
 
-                <div className="flex flex-col space-y-2">
-                  <Link href="https://supabase.com/pricing" target="_blank">
-                    <div className="flex items-center space-x-2 opacity-75 hover:opacity-100 transition">
-                      <p className="text-sm m-0">Pricing</p>
-                      <ExternalLink size={16} strokeWidth={1.5} />
-                    </div>
-                  </Link>
-                </div>
+                <a
+                  href="https://supabase.com/pricing"
+                  target="_blank"
+                  rel="noreferrer noopener"
+                  className="text-sm flex items-center gap-2 opacity-75 hover:opacity-100 transition"
+                >
+                  Pricing
+                  <ExternalLink size={16} strokeWidth={1.5} />
+                </a>
               </div>
             }
             layout="horizontal"

--- a/apps/studio/components/interfaces/Organization/NewOrg/NewOrgForm.tsx
+++ b/apps/studio/components/interfaces/Organization/NewOrg/NewOrgForm.tsx
@@ -13,6 +13,8 @@ import { invalidateOrganizationsQuery } from 'data/organizations/organizations-q
 import { BASE_PATH, PRICING_TIER_LABELS_ORG } from 'lib/constants'
 import { getURL } from 'lib/helpers'
 import { Button, IconEdit2, IconHelpCircle, Input, Listbox, Toggle } from 'ui'
+import { ExternalLink } from 'lucide-react'
+import Link from 'next/link'
 
 const ORG_KIND_TYPES = {
   PERSONAL: 'Personal',
@@ -262,24 +264,35 @@ const NewOrgForm = ({ onPaymentMethodReset }: NewOrgFormProps) => {
 
         <Panel.Content>
           <Listbox
-            label="Pricing Plan"
+            label={
+              <div className="space-y-2">
+                <span>Plan</span>
+
+                <div className="flex flex-col space-y-2">
+                  <Link href="https://supabase.com/pricing" target="_blank">
+                    <div className="flex items-center space-x-2 opacity-75 hover:opacity-100 transition">
+                      <p className="text-sm m-0">Pricing</p>
+                      <ExternalLink size={16} strokeWidth={1.5} />
+                    </div>
+                  </Link>
+                </div>
+              </div>
+            }
             layout="horizontal"
             value={dbPricingTierKey}
             // @ts-ignore
             onChange={onDbPricingPlanChange}
             // @ts-ignore
             descriptionText={
-              <>
-                Select a plan that suits your needs.&nbsp;
-                <a
-                  className="underline"
-                  target="_blank"
-                  rel="noreferrer"
-                  href="https://supabase.com/pricing"
-                >
-                  More details
-                </a>
-              </>
+              dbPricingTierKey !== 'FREE' ? (
+                <p>
+                  The plan applies to your entire organization. To upgrade an existing organization,{' '}
+                  <Link className="underline" href="/org/_/billing?panel=subscriptionPlan">
+                    click here
+                  </Link>
+                  .
+                </p>
+              ) : undefined
             }
           >
             {Object.entries(PRICING_TIER_LABELS_ORG).map(([k, v]) => {

--- a/apps/studio/components/interfaces/Organization/NewOrg/NewOrgForm.tsx
+++ b/apps/studio/components/interfaces/Organization/NewOrg/NewOrgForm.tsx
@@ -286,7 +286,8 @@ const NewOrgForm = ({ onPaymentMethodReset }: NewOrgFormProps) => {
             descriptionText={
               dbPricingTierKey !== 'FREE' ? (
                 <p>
-                  The plan applies to your entire organization. To upgrade an existing organization,{' '}
+                  The plan applies only to this new organization. To upgrade an existing
+                  organization,{' '}
                   <Link className="underline" href="/org/_/billing?panel=subscriptionPlan">
                     click here
                   </Link>


### PR DESCRIPTION
Billing papercut: Customers regularly create a new organization on a paid plan instead of upgrading their existing one. To mitigate that we will now show a small text allowing customers to jump into the subscription upgrade side panel of an existing organization.

<img width="669" alt="Screenshot 2024-08-28 at 17 57 59" src="https://github.com/user-attachments/assets/7368b2f8-0d64-4a5e-971c-fcec887e472e">

<img width="672" alt="Screenshot 2024-08-28 at 17 58 04" src="https://github.com/user-attachments/assets/98d7e914-3cba-4a23-a96e-f1307bf12a34">
