### PR TITLE
Fix: Correct default value for inbucket.port in configuration documentation

### DIFF
--- a/apps/docs/spec/cli_v1_config.yaml
+++ b/apps/docs/spec/cli_v1_config.yaml
@@ -261,7 +261,7 @@ parameters:
     title: 'inbucket.port'
     tags: ['local']
     required: false
-    default: 'true'
+    default: '54324'
     description: |
       Port to use for the email testing server web interface.
 
@@ -823,7 +823,7 @@ parameters:
     default: '"postgres"'
     description: |
       Configure one of the supported backends:
-      
+
       - `postgres`
       - `bigquery`
     links:

--- a/apps/docs/spec/cli_v1_config.yaml
+++ b/apps/docs/spec/cli_v1_config.yaml
@@ -823,7 +823,7 @@ parameters:
     default: '"postgres"'
     description: |
       Configure one of the supported backends:
-
+      
       - `postgres`
       - `bigquery`
     links:


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.
YES

## What kind of change does this PR introduce?
This PR introduces a documentation fix.

Specifically, it corrects an error in the configuration table for the `inbucket.port` setting. The current documentation contains incorrect information regarding the default value. This change aims to improve the accuracy of our documentation and prevent potential user confusion.

The change includes:
- Correcting the default value from 'true' to the actual default port number

This is a minor change that doesn't affect functionality but improves documentation accuracy for the inbucket port configuration.

## What is the current behavior?
Currently, the documentation for the `inbucket.port` configuration in the settings table contains an error. The 'Default' value for this setting is incorrectly listed as 'true'.

This is problematic because:
1. 'true' is not a valid port number, which may confuse users trying to configure their inbucket settings.
2. It does not provide the actual default port number that inbucket uses.
3. This incorrect information could lead to configuration errors or misunderstandings about how to properly set up inbucket.

This inaccuracy in the documentation may cause difficulties for users attempting to set up or troubleshoot their Supabase projects, particularly those working with inbucket configurations.

## What is the new behavior?
The new behavior corrects the 'Default' value for the `inbucket.port` setting in the configuration table. The incorrect value 'true' is replaced with the actual default port number used by inbucket.

This change ensures that:
1. Users are provided with accurate information about the default port number.
2. The documentation aligns with the actual behavior of the inbucket configuration.
3. Potential confusion or configuration errors due to incorrect information are mitigated.

## Additional context
This change was identified during a review of the documentation. While it's a small correction, it significantly improves the accuracy and usefulness of the configuration guide for users setting up inbucket with Supabase.

No visual changes are involved in this documentation update.