### PR TITLE
fix: Fix the caching of the selected schema

### DIFF
--- a/apps/studio/hooks/misc/useSchemaQueryState.ts
+++ b/apps/studio/hooks/misc/useSchemaQueryState.ts
@@ -20,11 +20,10 @@ const useIsomorphicUseQueryState = (defaultSchema: string) => {
 export const useQuerySchemaState = () => {
   const { ref } = useParams()
 
-  let defaultSchema = 'public'
-  if (typeof window !== 'undefined' && ref && ref.length > 0) {
-    defaultSchema =
-      window.localStorage.getItem(LOCAL_STORAGE_KEYS.LAST_SELECTED_SCHEMA(ref)) || 'public'
-  }
+  const defaultSchema =
+    typeof window !== 'undefined' && ref && ref.length > 0
+      ? window.localStorage.getItem(LOCAL_STORAGE_KEYS.LAST_SELECTED_SCHEMA(ref)) || 'public'
+      : 'public'
 
   // cache the original default schema so that it's not changed by another tab and cause issues in the app (saving a
   // table on the wrong schema)


### PR DESCRIPTION
This PR fixes a bug where the user can add a table in wrong schema by changing the schema in another tab. To replicate the bug:

1. Open both tabs on `[supabase.com/project/_/database/tables](http://supabase.com/project/_/database/tables). They should be on the same schema. It's important that you have no ?schema=something at the end
2. Click new Table in tab 1. Take note what the side panel header says (Create a new table under public, for example)
3. Go to tab 2 and switch the schema to something else
4. When you go to tab 1 the header will change to the new schema