### PR TITLE
docs: codeblock overflow

### DIFF
--- a/apps/docs/content/guides/storage/serving/image-transformations.mdx
+++ b/apps/docs/content/guides/storage/serving/image-transformations.mdx
@@ -90,7 +90,9 @@ url = supabase.storage.from_('avatars').get_public_url(
 
 An example URL could look like this:
 
-`https://project_id.supabase.co/storage/v1/render/image/public/bucket/image.jpg?width=500&height=600`
+```
+https://project_id.supabase.co/storage/v1/render/image/public/bucket/image.jpg?width=500&height=600`
+```
 
 ## Signing URLs with transformation options
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

[Storage Image Transformation](https://supabase.com/docs/guides/storage/serving/image-transformations?queryGroups=language&language=js)

## What is the current behavior?

Codeblock url example currently overflows on a mobile.

## What is the new behavior?

https://github.com/user-attachments/assets/345b5964-5381-4700-a6b6-376b2545d19d



## Additional context

Closes #29016 
