### PR TITLE
Silence config cat warnings

### DIFF
--- a/apps/studio/hooks/ui/useFlag.ts
+++ b/apps/studio/hooks/ui/useFlag.ts
@@ -1,9 +1,6 @@
-import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { useContext } from 'react'
 
 import FlagContext from 'components/ui/Flag/FlagContext'
-import { useOrgSubscriptionQuery } from 'data/subscriptions/org-subscription-query'
-import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
 
 export function useFlag<T = boolean>(name: string) {
   const store: any = useContext(FlagContext)

--- a/apps/studio/lib/configcat.ts
+++ b/apps/studio/lib/configcat.ts
@@ -18,7 +18,5 @@ function getClient() {
 }
 
 export async function getFlags(user?: User) {
-  return user?.email !== undefined
-    ? await getClient().getAllValuesAsync(new configcat.User(user.email))
-    : await getClient().getAllValuesAsync(new configcat.User(''))
+  return getClient().getAllValuesAsync(new configcat.User(user?.email ?? ''))
 }

--- a/apps/studio/lib/configcat.ts
+++ b/apps/studio/lib/configcat.ts
@@ -20,5 +20,5 @@ function getClient() {
 export async function getFlags(user?: User) {
   return user?.email !== undefined
     ? await getClient().getAllValuesAsync(new configcat.User(user.email))
-    : await getClient().getAllValuesAsync()
+    : await getClient().getAllValuesAsync(new configcat.User(''))
 }

--- a/apps/studio/state/sql-editor-v2.ts
+++ b/apps/studio/state/sql-editor-v2.ts
@@ -379,7 +379,7 @@ async function upsertFolder(id: string, projectRef: string, name: string) {
 
 if (typeof window !== 'undefined') {
   devtools(sqlEditorState, {
-    name: 'sqlEditorState',
+    name: 'sqlEditorStateV2',
     // [Joshen] So that jest unit tests can ignore this
     enabled: process.env.NEXT_PUBLIC_ENVIRONMENT !== undefined,
   })


### PR DESCRIPTION
Done by basically just ensuring that we pass _some_ param into `getAllValuesAsync()` to silence the warnings
The reason why we're doing so as this has been known to cause a lot of red herrings whenever users are debugging UI issues (despite the config cat warnings being completely unrelated all the time)