### PR TITLE
fix: Include the schema in the table link in the sidebar

### DIFF
--- a/apps/studio/components/layouts/TableEditorLayout/EntityListItem.tsx
+++ b/apps/studio/components/layouts/TableEditorLayout/EntityListItem.tsx
@@ -279,7 +279,7 @@ const EntityListItem: ItemRenderer<Entity, EntityListItemProps> = ({
   return (
     <Link
       title={entity.name}
-      href={`/project/${projectRef}/editor/${entity.id}`}
+      href={`/project/${projectRef}/editor/${entity.id}?schema=${selectedSchema}`}
       role="button"
       aria-label={`View ${entity.name}`}
       className={cn(


### PR DESCRIPTION
To replicate the bug:
- In the table editor, select another schema
- Select a table
- When clicking the link to the table, the sidebar reverts to the previous schema