### PR TITLE
fix: restrict ai edge function regions

### DIFF
--- a/apps/docs/pages/api/ai/docs.ts
+++ b/apps/docs/pages/api/ai/docs.ts
@@ -3,7 +3,34 @@ import { ApplicationError, UserError, clippy } from 'ai-commands/edge'
 import { NextRequest } from 'next/server'
 import OpenAI from 'openai'
 
-export const runtime = 'edge'
+export const config = {
+  runtime: 'edge',
+  /* To avoid OpenAI errors, restrict to the Vercel Edge Function regions that
+  overlap with the OpenAI API regions.
+  
+  Reference for Vercel regions: https://vercel.com/docs/edge-network/regions#region-list
+  Reference for OpenAI regions: https://help.openai.com/en/articles/5347006-openai-api-supported-countries-and-territories
+  */
+  regions: [
+    'arn1',
+    'bom1',
+    'cdg1',
+    'cle1',
+    'cpt1',
+    'dub1',
+    'fra1',
+    'gru1',
+    'hnd1',
+    'iad1',
+    'icn1',
+    'kix1',
+    'lhr1',
+    'pdx1',
+    'sfo1',
+    'sin1',
+    'syd1',
+  ],
+}
 
 const openAiKey = process.env.OPENAI_API_KEY
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string

--- a/apps/studio/pages/api/ai/docs.ts
+++ b/apps/studio/pages/api/ai/docs.ts
@@ -3,7 +3,34 @@ import { ApplicationError, UserError, clippy } from 'ai-commands/edge'
 import { NextRequest } from 'next/server'
 import OpenAI from 'openai'
 
-export const runtime = 'edge'
+export const config = {
+  runtime: 'edge',
+  /* To avoid OpenAI errors, restrict to the Vercel Edge Function regions that
+  overlap with the OpenAI API regions.
+  
+  Reference for Vercel regions: https://vercel.com/docs/edge-network/regions#region-list
+  Reference for OpenAI regions: https://help.openai.com/en/articles/5347006-openai-api-supported-countries-and-territories
+  */
+  regions: [
+    'arn1',
+    'bom1',
+    'cdg1',
+    'cle1',
+    'cpt1',
+    'dub1',
+    'fra1',
+    'gru1',
+    'hnd1',
+    'iad1',
+    'icn1',
+    'kix1',
+    'lhr1',
+    'pdx1',
+    'sfo1',
+    'sin1',
+    'syd1',
+  ],
+}
 
 const openAiKey = process.env.OPENAI_API_KEY
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string

--- a/apps/www/pages/api/ai/docs.ts
+++ b/apps/www/pages/api/ai/docs.ts
@@ -3,7 +3,34 @@ import { ApplicationError, UserError, clippy } from 'ai-commands/edge'
 import { NextRequest } from 'next/server'
 import OpenAI from 'openai'
 
-export const runtime = 'edge'
+export const config = {
+  runtime: 'edge',
+  /* To avoid OpenAI errors, restrict to the Vercel Edge Function regions that
+  overlap with the OpenAI API regions.
+  
+  Reference for Vercel regions: https://vercel.com/docs/edge-network/regions#region-list
+  Reference for OpenAI regions: https://help.openai.com/en/articles/5347006-openai-api-supported-countries-and-territories
+  */
+  regions: [
+    'arn1',
+    'bom1',
+    'cdg1',
+    'cle1',
+    'cpt1',
+    'dub1',
+    'fra1',
+    'gru1',
+    'hnd1',
+    'iad1',
+    'icn1',
+    'kix1',
+    'lhr1',
+    'pdx1',
+    'sfo1',
+    'sin1',
+    'syd1',
+  ],
+}
 
 const openAiKey = process.env.OPENAI_API_KEY
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string


### PR DESCRIPTION
AI edge functions error if Vercel runs them in a region that is not supported by OpenAI. To prevent this, restrict the Edge Function regions to the OpenAI-supported regions.

Slack discussion for context: https://supabase.slack.com/archives/C02BJ2239GA/p1723137812659199