### PR TITLE
feat: update email rate-limit notice to inform about template change restrictions

### DIFF
--- a/apps/studio/components/interfaces/Auth/EmailRateLimitsAlert/EmailRateLimitsAlert.tsx
+++ b/apps/studio/components/interfaces/Auth/EmailRateLimitsAlert/EmailRateLimitsAlert.tsx
@@ -9,7 +9,7 @@ export function EmailRateLimitsAlert() {
   return (
     <Alert_Shadcn_ variant="warning">
       <WarningIcon />
-      <AlertTitle_Shadcn_>Built-in email service is rate-limited!</AlertTitle_Shadcn_>
+      <AlertTitle_Shadcn_>Email rate-limits and template changes!</AlertTitle_Shadcn_>
       <AlertDescription_Shadcn_>
         You're using the built-in email service. The service has rate limits and it's not meant to
         be used for production apps. Check the{' '}
@@ -27,8 +27,12 @@ export function EmailRateLimitsAlert() {
           href={`/project/${projectRef}/settings/auth#auth-config-smtp-form`}
         >
           custom SMTP server
-        </Link>{' '}
-        if you're planning on having large number of users.
+        </Link>
+        .<br />
+        <strong>
+          You will not be able to modify the email templates unless you've set up a custom SMTP
+          server, except if you had changed it before this restriction went into effect.
+        </strong>
       </AlertDescription_Shadcn_>
     </Alert_Shadcn_>
   )

--- a/apps/studio/components/interfaces/Auth/EmailRateLimitsAlert/EmailRateLimitsAlert.tsx
+++ b/apps/studio/components/interfaces/Auth/EmailRateLimitsAlert/EmailRateLimitsAlert.tsx
@@ -9,7 +9,7 @@ export function EmailRateLimitsAlert() {
   return (
     <Alert_Shadcn_ variant="warning">
       <WarningIcon />
-      <AlertTitle_Shadcn_>Email rate-limits and template changes!</AlertTitle_Shadcn_>
+      <AlertTitle_Shadcn_>Email rate-limits and template changes</AlertTitle_Shadcn_>
       <AlertDescription_Shadcn_>
         You're using the built-in email service. The service has rate limits and it's not meant to
         be used for production apps. Check the{' '}
@@ -31,7 +31,8 @@ export function EmailRateLimitsAlert() {
         .<br />
         <strong>
           You will not be able to modify the email templates unless you've set up a custom SMTP
-          server, except if you had changed it before this restriction went into effect.
+          server or Send Email Hook server, except if you had changed it before this restriction
+          went into effect.
         </strong>
       </AlertDescription_Shadcn_>
     </Alert_Shadcn_>


### PR DESCRIPTION
Let the user know that email templates can only be modified with a custom SMTP setup, except if a project already exists and the template was already modified prior to this restriction taking place.

Editor is not "disabled" -- something for follow up PRs -- because there's no way to detect whether the template was customized or not at this stage.