### PR TITLE
Add a size map

### DIFF
--- a/packages/ui/src/lib/Layout/InputErrorIcon.tsx
+++ b/packages/ui/src/lib/Layout/InputErrorIcon.tsx
@@ -7,12 +7,20 @@ interface Props {
   size?: 'tiny' | 'small' | 'medium' | 'large' | 'xlarge'
 }
 
-export default function InputErrorIcon({ style, size }: Props) {
+const sizeMap = {
+  tiny: 14,
+  small: 16,
+  medium: 20,
+  large: 24,
+  xlarge: 32,
+}
+
+export default function InputErrorIcon({ style, size = 'medium' }: Props) {
   const __styles = styleHandler('inputErrorIcon')
 
   return (
     <div className={__styles.base} style={style}>
-      <AlertCircle size={size} strokeWidth={2} />
+      <AlertCircle size={sizeMap[size]} strokeWidth={2} />
     </div>
   )
 }


### PR DESCRIPTION
Add a size map for input error icons
![screenshot-2024-09-04-at-22 13 59](https://github.com/user-attachments/assets/a058f822-2217-4804-81b6-8000387eca40)
![screenshot-2024-09-04-at-22 13 47](https://github.com/user-attachments/assets/fa5f9674-b685-43db-aaf8-5564612b6a80)
