### PR TITLE
fix: Clarify that you can no longer use auth.uid() in RLS policies when using Auth0 Third Party Auth

### DIFF
--- a/apps/docs/content/guides/auth/third-party/auth0.mdx
+++ b/apps/docs/content/guides/auth/third-party/auth0.mdx
@@ -137,3 +137,5 @@ At this time, Auth0 tenants with the following [signing algorithms](https://auth
 
 - HS256 (HMAC with SHA-256) -- also known as symmetric JWTs
 - PS256 (RSA-PSS with SHA-256)
+
+In addition, you will no longer be able to use `auth.uid()` in your RLS policies. Auth0 prepends all their uid's with auth0 and the connection type, which is incompatible with the `auth.uid()` function. Use `auth.jwt() -> 'sub'` instead.


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

This change modifies the limitations for Auth0 Third Party Auth to include that you can no longer use the `auth.uid` function in RLS policies, and need to update these to instead use `auth.jwt() -> 'sub'`

`auth.uid()` requires the return type of the jwt sub claim to be a uuid, and will throw an `invalid input syntax for type uuid` error when you attempt to use it for RLS policies.

In addition, according to https://github.com/supabase/auth/pull/484/files we should be using auth.jwt() always anyway, but that message hasn't made it to the docs.

## What is the current behavior?

Currently this is not informed in the docs which is confusing.

## What is the new behavior?

Users understand the limitations
