### PR TITLE
Chore/persist schema visualizer node positions

### DIFF
--- a/apps/studio/components/interfaces/Database/Schemas/SchemaGraph.tsx
+++ b/apps/studio/components/interfaces/Database/Schemas/SchemaGraph.tsx
@@ -1,208 +1,26 @@
-import dagre from '@dagrejs/dagre'
-import type { PostgresTable } from '@supabase/postgres-meta'
-import { uniqBy } from 'lodash'
+import type { PostgresSchema, PostgresTable } from '@supabase/postgres-meta'
+import { Loader2 } from 'lucide-react'
 import { useTheme } from 'next-themes'
-import { useEffect, useMemo } from 'react'
-import ReactFlow, {
-  Background,
-  BackgroundVariant,
-  Edge,
-  MiniMap,
-  Node,
-  Position,
-  ReactFlowProvider,
-  useReactFlow,
-} from 'reactflow'
+import { useEffect, useMemo, useState } from 'react'
+import ReactFlow, { Background, BackgroundVariant, MiniMap, Node, useReactFlow } from 'reactflow'
 import 'reactflow/dist/style.css'
 
 import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
+import AlertError from 'components/ui/AlertError'
+import SchemaSelector from 'components/ui/SchemaSelector'
+import { useSchemasQuery } from 'data/database/schemas-query'
 import { useTablesQuery } from 'data/tables/tables-query'
-import { Loader } from 'lucide-react'
-import { TABLE_NODE_ROW_HEIGHT, TABLE_NODE_WIDTH, TableNode } from 'ui-patterns/SchemaTableNode'
-import SchemaGraphLegend from './SchemaGraphLegend'
+import { TableNode } from 'ui-patterns/SchemaTableNode'
+import { SchemaGraphLegend } from './SchemaGraphLegend'
+import { getGraphDataFromTables, getLayoutedElementsViaDagre } from './Schemas.utils'
+import { Button } from 'ui'
 
-type TableNodeData = {
-  name: string
-  isForeign: boolean
-  columns: {
-    id: string
-    isPrimary: boolean
-    isNullable: boolean
-    isUnique: boolean
-    isUpdateable: boolean
-    isIdentity: boolean
-    name: string
-    format: string
-  }[]
-}
+// [Joshen] Persisting logic: Only save positions to local storage WHEN a node is moved OR when explicitly clicked to reset layout
 
-async function getGraphDataFromTables(tables: PostgresTable[]): Promise<{
-  nodes: Node<TableNodeData>[]
-  edges: Edge[]
-}> {
-  if (!tables.length) {
-    return { nodes: [], edges: [] }
-  }
-
-  const nodes = tables.map((table) => {
-    const columns = (table.columns || []).map((column) => {
-      return {
-        id: column.id,
-        isPrimary: table.primary_keys.some((pk) => pk.name === column.name),
-        name: column.name,
-        format: column.format,
-        isNullable: column.is_nullable,
-        isUnique: column.is_unique,
-        isUpdateable: column.is_updatable,
-        isIdentity: column.is_identity,
-      }
-    })
-
-    return {
-      id: `${table.id}`,
-      type: 'table',
-      data: {
-        name: table.name,
-        isForeign: false,
-        columns,
-      },
-      position: { x: 0, y: 0 },
-    }
-  })
-
-  const edges: Edge[] = []
-  const currentSchema = tables[0].schema
-  const uniqueRelationships = uniqBy(
-    tables.flatMap((t) => t.relationships),
-    'id'
-  )
-
-  for (const rel of uniqueRelationships) {
-    // TODO: Support [external->this] relationship?
-    if (rel.source_schema !== currentSchema) {
-      continue
-    }
-
-    // Create additional [this->foreign] node that we can point to on the graph.
-    if (rel.target_table_schema !== currentSchema) {
-      nodes.push({
-        id: rel.constraint_name,
-        type: 'table',
-        data: {
-          name: `${rel.target_table_schema}.${rel.target_table_name}.${rel.target_column_name}`,
-          isForeign: true,
-          columns: [],
-        },
-        position: { x: 0, y: 0 },
-      })
-
-      const [source, sourceHandle] = findTablesHandleIds(
-        tables,
-        rel.source_table_name,
-        rel.source_column_name
-      )
-
-      if (source) {
-        edges.push({
-          id: String(rel.id),
-          source,
-          sourceHandle,
-          target: rel.constraint_name,
-          targetHandle: rel.constraint_name,
-        })
-      }
-
-      continue
-    }
-
-    const [source, sourceHandle] = findTablesHandleIds(
-      tables,
-      rel.source_table_name,
-      rel.source_column_name
-    )
-    const [target, targetHandle] = findTablesHandleIds(
-      tables,
-      rel.target_table_name,
-      rel.target_column_name
-    )
-
-    // We do not support [external->this] flow currently.
-    if (source && target) {
-      edges.push({
-        id: String(rel.id),
-        source,
-        sourceHandle,
-        target,
-        targetHandle,
-      })
-    }
-  }
-
-  return getLayoutedElements(nodes, edges)
-}
-
-function findTablesHandleIds(
-  tables: PostgresTable[],
-  table_name: string,
-  column_name: string
-): [string?, string?] {
-  for (const table of tables) {
-    if (table_name !== table.name) continue
-
-    for (const column of table.columns || []) {
-      if (column_name !== column.name) continue
-
-      return [String(table.id), column.id]
-    }
-  }
-
-  return []
-}
-
-const getLayoutedElements = (nodes: Node[], edges: Edge[]) => {
-  const dagreGraph = new dagre.graphlib.Graph()
-  dagreGraph.setDefaultEdgeLabel(() => ({}))
-  dagreGraph.setGraph({
-    rankdir: 'LR',
-    align: 'UR',
-    nodesep: 25,
-    ranksep: 50,
-  })
-
-  nodes.forEach((node) => {
-    dagreGraph.setNode(node.id, {
-      width: TABLE_NODE_WIDTH / 2,
-      height: (TABLE_NODE_ROW_HEIGHT / 2) * (node.data.columns.length + 1), // columns + header
-    })
-  })
-
-  edges.forEach((edge) => {
-    dagreGraph.setEdge(edge.source, edge.target)
-  })
-
-  dagre.layout(dagreGraph)
-
-  nodes.forEach((node) => {
-    const nodeWithPosition = dagreGraph.node(node.id)
-    node.targetPosition = Position.Left
-    node.sourcePosition = Position.Right
-    // We are shifting the dagre node position (anchor=center center) to the top left
-    // so it matches the React Flow node anchor point (top left).
-    node.position = {
-      x: nodeWithPosition.x - nodeWithPosition.width / 2,
-      y: nodeWithPosition.y - nodeWithPosition.height / 2,
-    }
-
-    return node
-  })
-
-  return { nodes, edges }
-}
-
-const TablesGraph = ({ tables }: { tables: PostgresTable[] }) => {
+export const SchemaGraph = () => {
   const { resolvedTheme } = useTheme()
-  const backgroundPatternColor = resolvedTheme?.includes('dark') ? '#2e2e2e' : '#e6e8eb'
-  const edgeStrokeColor = resolvedTheme?.includes('dark') ? '#ededed' : '#111318'
+  const { project } = useProjectContext()
+  const [selectedSchema, setSelectedSchema] = useState<string>('public')
 
   const miniMapNodeColor = '#111318'
   const miniMapMaskColor = resolvedTheme?.includes('dark')
@@ -217,92 +35,131 @@ const TablesGraph = ({ tables }: { tables: PostgresTable[] }) => {
     []
   )
 
-  useEffect(() => {
-    getGraphDataFromTables(tables).then(({ nodes, edges }) => {
-      reactFlowInstance.setNodes(nodes)
-      reactFlowInstance.setEdges(edges)
-      setTimeout(() => reactFlowInstance.fitView({})) // it needs to happen during next event tick
-    })
-  }, [tables, resolvedTheme])
+  const {
+    data: schemas,
+    error: errorSchemas,
+    isSuccess: isSuccessSchemas,
+    isLoading: isLoadingSchemas,
+    isError: isErrorSchemas,
+  } = useSchemasQuery({
+    projectRef: project?.ref,
+    connectionString: project?.connectionString,
+  })
 
-  return (
-    <>
-      <div className="w-full h-full">
-        <ReactFlow
-          defaultNodes={[]}
-          defaultEdges={[]}
-          defaultEdgeOptions={{
-            type: 'smoothstep',
-            animated: true,
-            deletable: false,
-            style: {
-              stroke: 'hsl(var(--border-stronger))',
-              strokeWidth: 0.5,
-            },
-          }}
-          nodeTypes={nodeTypes}
-          fitView
-          minZoom={0.8}
-          maxZoom={1.8}
-          proOptions={{ hideAttribution: true }}
-        >
-          <Background
-            gap={16}
-            className="[&>*]:stroke-foreground-muted opacity-[25%]"
-            variant={BackgroundVariant.Dots}
-            color={'inherit'}
-          />
-          <MiniMap
-            pannable
-            zoomable
-            nodeColor={miniMapNodeColor}
-            maskColor={miniMapMaskColor}
-            className="border rounded-md shadow-sm"
-          />
-          <SchemaGraphLegend />
-        </ReactFlow>
-      </div>
-    </>
-  )
-}
-
-const SchemaGraph = ({ schema }: { schema: string }) => {
-  const { project } = useProjectContext()
   const {
     data: tables,
-    isLoading,
-    isError,
-    error,
+    error: errorTables,
+    isSuccess: isSuccessTables,
+    isLoading: isLoadingTables,
+    isError: isErrorTables,
   } = useTablesQuery({
     projectRef: project?.ref,
     connectionString: project?.connectionString,
-    schema,
+    schema: selectedSchema,
     includeColumns: true,
   })
 
-  if (isLoading) {
-    return (
-      <div className="flex h-full w-full items-center justify-center space-x-2">
-        <Loader className="animate-spin" size={14} />
-        <p className="text-sm text-foreground-light">Loading table...</p>
-      </div>
-    )
+  const resetLayout = () => {
+    const nodes = reactFlowInstance.getNodes()
+    const edges = reactFlowInstance.getEdges()
+
+    getLayoutedElementsViaDagre(nodes, edges)
+    reactFlowInstance.setNodes(nodes)
+    reactFlowInstance.setEdges(edges)
+    setTimeout(() => reactFlowInstance.fitView({}))
   }
 
-  if (isError) {
-    return (
-      <div className="px-6 py-4 text-foreground-light">
-        <p>Error connecting to API</p>
-        <p>{`${error?.message ?? 'Unknown error'}`}</p>
-      </div>
-    )
+  const onNodeDragStop = (node: Node) => {
+    // TODO WHEN WE ARE BACK JOSHEN
+    console.log(node)
   }
+
+  useEffect(() => {
+    if (isSuccessTables && isSuccessSchemas && tables.length > 0) {
+      const schema = schemas.find((s) => s.name === selectedSchema) as PostgresSchema
+      getGraphDataFromTables(schema, tables as PostgresTable[]).then(({ nodes, edges }) => {
+        reactFlowInstance.setNodes(nodes)
+        reactFlowInstance.setEdges(edges)
+        setTimeout(() => reactFlowInstance.fitView({})) // it needs to happen during next event tick
+      })
+    }
+  }, [isSuccessTables, isSuccessSchemas, tables, resolvedTheme])
 
   return (
-    <ReactFlowProvider>
-      <TablesGraph tables={tables} />
-    </ReactFlowProvider>
+    <>
+      <div className="flex items-center justify-between p-4 border-b border-muted">
+        {isLoadingSchemas && (
+          <div className="h-[34px] w-[260px] bg-foreground-lighter rounded shimmering-loader" />
+        )}
+
+        {isErrorSchemas && (
+          <AlertError error={errorSchemas as any} subject="Failed to retrieve schemas" />
+        )}
+
+        {isSuccessSchemas && (
+          <>
+            <SchemaSelector
+              className="w-[260px]"
+              size="small"
+              showError={false}
+              selectedSchemaName={selectedSchema}
+              onSelectSchema={setSelectedSchema}
+            />
+            <Button type="default" onClick={resetLayout}>
+              Reset layout
+            </Button>
+          </>
+        )}
+      </div>
+      {isLoadingTables && (
+        <div className="w-full h-full flex items-center justify-center gap-x-2">
+          <Loader2 className="animate-spin text-foreground-light" size={16} />
+          <p className="text-sm text-foreground-light">Loading tables</p>
+        </div>
+      )}
+      {isErrorTables && (
+        <div className="w-full h-full flex items-center justify-center px-20">
+          <AlertError subject="Failed to retrieve tables" error={errorTables} />
+        </div>
+      )}
+      {isSuccessTables && (
+        <div className="w-full h-full">
+          <ReactFlow
+            defaultNodes={[]}
+            defaultEdges={[]}
+            defaultEdgeOptions={{
+              type: 'smoothstep',
+              animated: true,
+              deletable: false,
+              style: {
+                stroke: 'hsl(var(--border-stronger))',
+                strokeWidth: 0.5,
+              },
+            }}
+            nodeTypes={nodeTypes}
+            fitView
+            minZoom={0.8}
+            maxZoom={1.8}
+            proOptions={{ hideAttribution: true }}
+            onNodeDragStop={(_, node) => onNodeDragStop(node)}
+          >
+            <Background
+              gap={16}
+              className="[&>*]:stroke-foreground-muted opacity-[25%]"
+              variant={BackgroundVariant.Dots}
+              color={'inherit'}
+            />
+            <MiniMap
+              pannable
+              zoomable
+              nodeColor={miniMapNodeColor}
+              maskColor={miniMapMaskColor}
+              className="border rounded-md shadow-sm"
+            />
+            <SchemaGraphLegend />
+          </ReactFlow>
+        </div>
+      )}
+    </>
   )
 }
-
-export default SchemaGraph

--- a/apps/studio/components/interfaces/Database/Schemas/SchemaGraphLegend.tsx
+++ b/apps/studio/components/interfaces/Database/Schemas/SchemaGraphLegend.tsx
@@ -1,9 +1,8 @@
 import { DiamondIcon, Fingerprint, Hash, Key } from 'lucide-react'
 
-const SchemaGraphLegend = () => {
+export const SchemaGraphLegend = () => {
   return (
     <div className="absolute bottom-0 left-0 border-t flex justify-center px-1 py-2 shadow-md bg-surface-100 w-full z-10">
-      {/* <h3 className="text-xs font-bold">Legend</h3> */}
       <ul className="flex flex-wrap  items-center justify-center gap-4">
         <li className="flex items-center text-xs font-mono gap-1">
           <Key size={15} strokeWidth={1.5} className="flex-shrink-0 text-light" />
@@ -34,5 +33,3 @@ const SchemaGraphLegend = () => {
     </div>
   )
 }
-
-export default SchemaGraphLegend

--- a/apps/studio/components/interfaces/Database/Schemas/Schemas.utils.ts
+++ b/apps/studio/components/interfaces/Database/Schemas/Schemas.utils.ts
@@ -201,10 +201,23 @@ const getLayoutedElementsViaLocalStorage = (
   edges: Edge[],
   positions: { [key: string]: { x: number; y: number } }
 ) => {
+  // [Joshen] Potentially look into auto fitting new nodes?
+  // https://github.com/xyflow/xyflow/issues/1113
+
+  let newNodeCount = 0
+
   nodes.forEach((node) => {
+    const existingPosition = positions?.[node.id]
+
     node.targetPosition = Position.Left
     node.sourcePosition = Position.Right
-    node.position = positions?.[node.id] ?? { x: 0, y: 0 }
+
+    if (existingPosition) {
+      node.position = existingPosition
+    } else {
+      node.position = { x: newNodeCount * 10, y: newNodeCount * 10 }
+      newNodeCount += 1
+    }
   })
   return { nodes, edges }
 }

--- a/apps/studio/components/interfaces/Support/SupportFormV2.tsx
+++ b/apps/studio/components/interfaces/Support/SupportFormV2.tsx
@@ -268,7 +268,10 @@ export const SupportFormV2 = ({ setSentCategory, setSelectedProject }: SupportFo
           form.setValue('organizationSlug', selectedOrganization.slug)
         }
       } else if (ref === undefined && slug === undefined) {
-        form.setValue('organizationSlug', organizations[0].slug)
+        const firstOrganization = organizations?.[0]
+        if (firstOrganization !== undefined) {
+          form.setValue('organizationSlug', firstOrganization.slug)
+        }
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/studio/lib/constants/index.ts
+++ b/apps/studio/lib/constants/index.ts
@@ -42,7 +42,6 @@ export const LOCAL_STORAGE_KEYS = {
   SQL_EDITOR_INTELLISENSE: 'supabase_sql-editor-intellisense-enabled',
   SQL_EDITOR_SPLIT_SIZE: 'supabase_sql-editor-split-size',
   SQL_EDITOR_AI_PANEL_SPLIT_SIZE: 'supabase_sql-editor-ai-panel-split-size',
-
   // Key to track which schemas are ok to be sent to AI. The project ref is intentionally put at the end for easier search in the browser console.
   SQL_EDITOR_AI_SCHEMA: (ref: string) => `supabase_sql-editor-ai-schema-enabled-${ref}`,
   SQL_EDITOR_AI_OPEN: 'supabase_sql-editor-ai-open',
@@ -53,25 +52,20 @@ export const LOCAL_STORAGE_KEYS = {
   PGBOUNCER_IPV6_DEPRECATION_WARNING: 'pgbouncer-ipv6-deprecation-warning-dismissed',
   VERCEL_IPV6_DEPRECATION_WARNING: 'vercel-ipv6-deprecation-warning-dismissed',
   PGBOUNCER_DEPRECATION_WARNING: 'pgbouncer-deprecation-warning-dismissed',
-
   PROJECT_LINT_IGNORE_LIST: 'supabase-project-lint-ignore-list',
-
   QUERY_PERF_SHOW_BOTTOM_SECTION: 'supabase-query-perf-show-bottom-section',
-
   // Key to track account deletion requests
   ACCOUNT_DELETION_REQUEST: 'supabase-account-deletion-request',
-
   // Used for storing a user id when sending reports to Sentry. The id is hashed for anonymity.
   SENTRY_USER_ID: 'supabase-sentry-user-id',
-
   // Used for storing the last sign in method used by the user
   LAST_SIGN_IN_METHOD: 'supabase-last-sign-in-method',
-
   // Key to track the last selected schema. The project ref is intentionally put at the end for easier search in the browser console.
   LAST_SELECTED_SCHEMA: (ref: string) => `last-selected-schema-${ref}`,
-
   // Key to show a warning on the SQL Editor AI Assistant that the org hasn't opted-in to sending anon data
   SHOW_AI_NOT_OPTIMIZED_WARNING: (ref: string) => `supabase-show-ai-not-optimized-${ref}`,
+  // Track position of nodes for schema visualizer
+  SCHEMA_VISUALIZER_POSITIONS: (schemaId: number) => `schema-visualizer-positions-${schemaId}`,
 }
 
 export const OPT_IN_TAGS = {

--- a/apps/studio/lib/constants/index.ts
+++ b/apps/studio/lib/constants/index.ts
@@ -65,7 +65,8 @@ export const LOCAL_STORAGE_KEYS = {
   // Key to show a warning on the SQL Editor AI Assistant that the org hasn't opted-in to sending anon data
   SHOW_AI_NOT_OPTIMIZED_WARNING: (ref: string) => `supabase-show-ai-not-optimized-${ref}`,
   // Track position of nodes for schema visualizer
-  SCHEMA_VISUALIZER_POSITIONS: (schemaId: number) => `schema-visualizer-positions-${schemaId}`,
+  SCHEMA_VISUALIZER_POSITIONS: (ref: string, schemaId: number) =>
+    `schema-visualizer-positions-${ref}-${schemaId}`,
 }
 
 export const OPT_IN_TAGS = {

--- a/apps/studio/pages/project/[ref]/database/schemas.tsx
+++ b/apps/studio/pages/project/[ref]/database/schemas.tsx
@@ -1,58 +1,16 @@
-import { partition } from 'lodash'
-import { useState } from 'react'
+import { ReactFlowProvider } from 'reactflow'
 
-import SchemaGraph from 'components/interfaces/Database/Schemas/SchemaGraph'
+import { SchemaGraph } from 'components/interfaces/Database/Schemas/SchemaGraph'
 import DatabaseLayout from 'components/layouts/DatabaseLayout/DatabaseLayout'
-import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
-import AlertError from 'components/ui/AlertError'
-import SchemaSelector from 'components/ui/SchemaSelector'
-import { useSchemasQuery } from 'data/database/schemas-query'
-import { EXCLUDED_SCHEMAS } from 'lib/constants/schemas'
 import type { NextPageWithLayout } from 'types'
 
 const SchemasPage: NextPageWithLayout = () => {
-  const { project } = useProjectContext()
-  const {
-    data: schemas,
-    isSuccess,
-    isLoading,
-    isError,
-    error,
-  } = useSchemasQuery({
-    projectRef: project?.ref,
-    connectionString: project?.connectionString,
-  })
-  const [selectedSchema, setSelectedSchema] = useState<string>('public')
-  const [protectedSchemas, openSchemas] = partition(schemas, (schema) =>
-    EXCLUDED_SCHEMAS.includes(schema?.name ?? '')
-  )
-  const schema = schemas?.find((schema) => schema.name === selectedSchema)
-  const isLocked = protectedSchemas.some((s) => s.id === schema?.id)
-
   return (
-    <>
-      <div className="flex w-full h-full flex-col">
-        <div className="p-4 border-b border-muted">
-          {isLoading && (
-            <div className="h-[34px] w-[260px] bg-foreground-lighter rounded shimmering-loader" />
-          )}
-
-          {isError && <AlertError error={error as any} subject="Failed to retrieve schemas" />}
-
-          {isSuccess && (
-            <SchemaSelector
-              className="w-[260px]"
-              size="small"
-              showError={false}
-              selectedSchemaName={selectedSchema}
-              onSelectSchema={setSelectedSchema}
-            />
-          )}
-        </div>
-
-        <SchemaGraph schema={selectedSchema}></SchemaGraph>
-      </div>
-    </>
+    <div className="flex w-full h-full flex-col">
+      <ReactFlowProvider>
+        <SchemaGraph />
+      </ReactFlowProvider>
+    </div>
   )
 }
 


### PR DESCRIPTION
- Persist positions of nodes in the schema visualizer by storing in local storage
- Add a button to automatically arrange the layout of the nodes in the schema visualizer
![image](https://github.com/user-attachments/assets/55e18a2a-096a-4e88-b0d1-48ca0856a9a8)
- Note: new tables added into the schema will have their positions default to `n * 10, n * 10` where n is the idx for each new table,  if there's an existing set of stored data of positions for the schema in local storage
  - Users can either manually drag the nodes to the desired location OR
  - Hit auto layout to let the dagre library handle the layout (which is the original default behaviour everytime a user opens the schema visualizer)
