### PR TITLE
Update stripe wrappers with more tables

### DIFF
--- a/apps/studio/components/interfaces/Database/Wrappers/Wrappers.constants.ts
+++ b/apps/studio/components/interfaces/Database/Wrappers/Wrappers.constants.ts
@@ -240,6 +240,50 @@ export const WRAPPERS: WrapperMeta[] = [
         ],
       },
       {
+        label: 'Checkout Sessions',
+        description:
+          "Customer's session as they pay for one-time purchases or subscriptions through Checkout or Payment Links",
+        availableColumns: [
+          {
+            name: 'id',
+            type: 'text',
+          },
+          {
+            name: 'customer',
+            type: 'text',
+          },
+          {
+            name: 'payment_intent',
+            type: 'text',
+          },
+          {
+            name: 'subscription',
+            type: 'text',
+          },
+          {
+            name: 'attrs',
+            type: 'jsonb',
+          },
+        ],
+        options: [
+          {
+            name: 'object',
+            defaultValue: 'checkout/sessions',
+            editable: false,
+            required: true,
+            type: 'text',
+          },
+          {
+            name: 'rowid_column',
+            label: 'Row ID Column',
+            defaultValue: 'id',
+            editable: true,
+            required: true,
+            type: 'text',
+          },
+        ],
+      },
+      {
         label: 'Customers',
         description: 'Customers on your Stripe account',
         availableColumns: [
@@ -281,6 +325,191 @@ export const WRAPPERS: WrapperMeta[] = [
             label: 'Row ID Column',
             defaultValue: 'id',
             editable: true,
+            required: true,
+            type: 'text',
+          },
+        ],
+      },
+      {
+        label: 'Disputes',
+        description: 'When a customer questions your charge with their card issuer',
+        availableColumns: [
+          {
+            name: 'id',
+            type: 'text',
+          },
+          {
+            name: 'amount',
+            type: 'bigint',
+          },
+          {
+            name: 'currency',
+            type: 'text',
+          },
+          {
+            name: 'charge',
+            type: 'text',
+          },
+          {
+            name: 'payment_intent',
+            type: 'text',
+          },
+          {
+            name: 'reason',
+            type: 'text',
+          },
+          {
+            name: 'status',
+            type: 'text',
+          },
+          {
+            name: 'created',
+            type: 'timestamp',
+          },
+          {
+            name: 'attrs',
+            type: 'jsonb',
+          },
+        ],
+        options: [
+          {
+            name: 'object',
+            defaultValue: 'disputes',
+            editable: false,
+            required: true,
+            type: 'text',
+          },
+        ],
+      },
+      {
+        label: 'Events',
+        description:
+          "Stripe's way of letting you know when something interesting happens in your account",
+        availableColumns: [
+          {
+            name: 'id',
+            type: 'text',
+          },
+          {
+            name: 'type',
+            type: 'text',
+          },
+          {
+            name: 'api_version',
+            type: 'text',
+          },
+          {
+            name: 'created',
+            type: 'timestamp',
+          },
+          {
+            name: 'attrs',
+            type: 'jsonb',
+          },
+        ],
+        options: [
+          {
+            name: 'object',
+            defaultValue: 'events',
+            editable: false,
+            required: true,
+            type: 'text',
+          },
+        ],
+      },
+      {
+        label: 'Files',
+        description: "Files that are hosted on Stripe's servers",
+        availableColumns: [
+          {
+            name: 'id',
+            type: 'text',
+          },
+          {
+            name: 'filename',
+            type: 'text',
+          },
+          {
+            name: 'purpose',
+            type: 'text',
+          },
+          {
+            name: 'title',
+            type: 'text',
+          },
+          {
+            name: 'size',
+            type: 'bigint',
+          },
+          {
+            name: 'type',
+            type: 'text',
+          },
+          {
+            name: 'url',
+            type: 'text',
+          },
+          {
+            name: 'created',
+            type: 'timestamp',
+          },
+          {
+            name: 'expires_at',
+            type: 'timestamp',
+          },
+          {
+            name: 'attrs',
+            type: 'jsonb',
+          },
+        ],
+        options: [
+          {
+            name: 'object',
+            defaultValue: 'files',
+            editable: false,
+            required: true,
+            type: 'text',
+          },
+        ],
+      },
+      {
+        label: 'File Links',
+        description: 'For sharing contents of a File object with non-Stripe users',
+        availableColumns: [
+          {
+            name: 'id',
+            type: 'text',
+          },
+          {
+            name: 'file',
+            type: 'text',
+          },
+          {
+            name: 'url',
+            type: 'text',
+          },
+          {
+            name: 'created',
+            type: 'timestamp',
+          },
+          {
+            name: 'expired',
+            type: 'bool',
+          },
+          {
+            name: 'expires_at',
+            type: 'timestamp',
+          },
+          {
+            name: 'attrs',
+            type: 'jsonb',
+          },
+        ],
+        options: [
+          {
+            name: 'object',
+            defaultValue: 'file_links',
+            editable: false,
             required: true,
             type: 'text',
           },
@@ -338,6 +567,42 @@ export const WRAPPERS: WrapperMeta[] = [
         ],
       },
       {
+        label: 'Mandates',
+        description:
+          'Records of the permission a customer has given you to debit their payment method',
+        availableColumns: [
+          {
+            name: 'id',
+            type: 'text',
+          },
+          {
+            name: 'payment_method',
+            type: 'text',
+          },
+          {
+            name: 'status',
+            type: 'text',
+          },
+          {
+            name: 'type',
+            type: 'text',
+          },
+          {
+            name: 'attrs',
+            type: 'jsonb',
+          },
+        ],
+        options: [
+          {
+            name: 'object',
+            defaultValue: 'mandates',
+            editable: false,
+            required: true,
+            type: 'text',
+          },
+        ],
+      },
+      {
         label: 'Payment Intents',
         description: 'Payment Intents on your Stripe account',
         availableColumns: [
@@ -374,6 +639,106 @@ export const WRAPPERS: WrapperMeta[] = [
           {
             name: 'object',
             defaultValue: 'payment_intents',
+            editable: false,
+            required: true,
+            type: 'text',
+          },
+        ],
+      },
+      {
+        label: 'Payouts',
+        description:
+          'Created when you receive funds rfom Stripe, or when you initiate a payout to either a bank account or debit card',
+        availableColumns: [
+          {
+            name: 'id',
+            type: 'text',
+          },
+          {
+            name: 'amount',
+            type: 'bigint',
+          },
+          {
+            name: 'currency',
+            type: 'text',
+          },
+          {
+            name: 'arrival_date',
+            type: 'timestamp',
+          },
+          {
+            name: 'description',
+            type: 'text',
+          },
+          {
+            name: 'statement_descriptor',
+            type: 'text',
+          },
+          {
+            name: 'status',
+            type: 'text',
+          },
+          {
+            name: 'created',
+            type: 'timestamp',
+          },
+          {
+            name: 'attrs',
+            type: 'jsonb',
+          },
+        ],
+        options: [
+          {
+            name: 'object',
+            defaultValue: 'payouts',
+            editable: false,
+            required: true,
+            type: 'text',
+          },
+        ],
+      },
+      {
+        label: 'Prices',
+        description:
+          'A Price object is needed for all your products to facilitate multiple currencies and pricing options',
+        availableColumns: [
+          {
+            name: 'id',
+            type: 'text',
+          },
+          {
+            name: 'active',
+            type: 'bool',
+          },
+          {
+            name: 'currency',
+            type: 'text',
+          },
+          {
+            name: 'product',
+            type: 'text',
+          },
+          {
+            name: 'unit_amount',
+            type: 'bigint',
+          },
+          {
+            name: 'type',
+            type: 'text',
+          },
+          {
+            name: 'created',
+            type: 'timestamp',
+          },
+          {
+            name: 'attrs',
+            type: 'jsonb',
+          },
+        ],
+        options: [
+          {
+            name: 'object',
+            defaultValue: 'prices',
             editable: false,
             required: true,
             type: 'text',
@@ -436,6 +801,165 @@ export const WRAPPERS: WrapperMeta[] = [
         ],
       },
       {
+        label: 'Refunds',
+        description:
+          'Allows you to refund a charge that has previously been created but not yet refunded',
+        availableColumns: [
+          {
+            name: 'id',
+            type: 'text',
+          },
+          {
+            name: 'amount',
+            type: 'bigint',
+          },
+          {
+            name: 'currency',
+            type: 'text',
+          },
+          {
+            name: 'charge',
+            type: 'text',
+          },
+          {
+            name: 'payment_intent',
+            type: 'text',
+          },
+          {
+            name: 'reason',
+            type: 'text',
+          },
+          {
+            name: 'status',
+            type: 'text',
+          },
+          {
+            name: 'created',
+            type: 'timestamp',
+          },
+          {
+            name: 'attrs',
+            type: 'jsonb',
+          },
+        ],
+        options: [
+          {
+            name: 'object',
+            defaultValue: 'refunds',
+            editable: false,
+            required: true,
+            type: 'text',
+          },
+        ],
+      },
+      {
+        label: 'Setup Attempts',
+        description: 'Attempted confirmations of a SetupIntent, either successful or unsuccessful',
+        availableColumns: [
+          {
+            name: 'id',
+            type: 'text',
+          },
+          {
+            name: 'application',
+            type: 'text',
+          },
+          {
+            name: 'customer',
+            type: 'text',
+          },
+          {
+            name: 'on_behalf_of',
+            type: 'text',
+          },
+          {
+            name: 'payment_method',
+            type: 'text',
+          },
+          {
+            name: 'setup_intent',
+            type: 'text',
+          },
+          {
+            name: 'status',
+            type: 'text',
+          },
+          {
+            name: 'usage',
+            type: 'text',
+          },
+          {
+            name: 'created',
+            type: 'timestamp',
+          },
+          {
+            name: 'attrs',
+            type: 'jsonb',
+          },
+        ],
+        options: [
+          {
+            name: 'object',
+            defaultValue: 'setup_attempts',
+            editable: false,
+            required: true,
+            type: 'text',
+          },
+        ],
+      },
+      {
+        label: 'Setup Intents',
+        description:
+          "Guides you through the process of setting up and saving a customer's payment credentials for future payments",
+        availableColumns: [
+          {
+            name: 'id',
+            type: 'text',
+          },
+          {
+            name: 'client_secret',
+            type: 'text',
+          },
+          {
+            name: 'customer',
+            type: 'text',
+          },
+          {
+            name: 'description',
+            type: 'text',
+          },
+          {
+            name: 'payment_method',
+            type: 'text',
+          },
+          {
+            name: 'status',
+            type: 'text',
+          },
+          {
+            name: 'usage',
+            type: 'text',
+          },
+          {
+            name: 'created',
+            type: 'timestamp',
+          },
+          {
+            name: 'attrs',
+            type: 'jsonb',
+          },
+        ],
+        options: [
+          {
+            name: 'object',
+            defaultValue: 'setup_intents',
+            editable: false,
+            required: true,
+            type: 'text',
+          },
+        ],
+      },
+      {
         label: 'Subscriptions',
         description: 'Subscriptions on your Stripe account',
         availableColumns: [
@@ -477,6 +1001,132 @@ export const WRAPPERS: WrapperMeta[] = [
             label: 'Row ID Column',
             defaultValue: 'id',
             editable: true,
+            required: true,
+            type: 'text',
+          },
+        ],
+      },
+      {
+        label: 'Tokens',
+        description:
+          'Tokenization is the process Stripe uses to collect sensitive card or bank account details in a secure manner',
+        availableColumns: [
+          {
+            name: 'id',
+            type: 'text',
+          },
+          {
+            name: 'customer',
+            type: 'text',
+          },
+          {
+            name: 'currency',
+            type: 'text',
+          },
+          {
+            name: 'current_period_start',
+            type: 'timestamp',
+          },
+          {
+            name: 'current_period_end',
+            type: 'timestamp',
+          },
+          {
+            name: 'attrs',
+            type: 'jsonb',
+          },
+        ],
+        options: [
+          {
+            name: 'object',
+            defaultValue: 'tokens',
+            editable: false,
+            required: true,
+            type: 'text',
+          },
+        ],
+      },
+      {
+        label: 'Top-ups',
+        description: 'To top up your Stripe balance',
+        availableColumns: [
+          {
+            name: 'id',
+            type: 'text',
+          },
+          {
+            name: 'amount',
+            type: 'bigint',
+          },
+          {
+            name: 'currency',
+            type: 'text',
+          },
+          {
+            name: 'description',
+            type: 'text',
+          },
+          {
+            name: 'status',
+            type: 'text',
+          },
+          {
+            name: 'created',
+            type: 'timestamp',
+          },
+          {
+            name: 'attrs',
+            type: 'jsonb',
+          },
+        ],
+        options: [
+          {
+            name: 'object',
+            defaultValue: 'topups',
+            editable: false,
+            required: true,
+            type: 'text',
+          },
+        ],
+      },
+      {
+        label: 'Transfers',
+        description: 'When moving funds between Stripe accounts as part of Connect',
+        availableColumns: [
+          {
+            name: 'id',
+            type: 'text',
+          },
+          {
+            name: 'amount',
+            type: 'bigint',
+          },
+          {
+            name: 'currency',
+            type: 'text',
+          },
+          {
+            name: 'description',
+            type: 'text',
+          },
+          {
+            name: 'destination',
+            type: 'text',
+          },
+          {
+            name: 'created',
+            type: 'timestamp',
+          },
+          {
+            name: 'attrs',
+            type: 'jsonb',
+          },
+        ],
+        options: [
+          {
+            name: 'object',
+            defaultValue: 'transfers',
+            editable: false,
             required: true,
             type: 'text',
           },

--- a/apps/studio/components/interfaces/Database/Wrappers/Wrappers.constants.ts
+++ b/apps/studio/components/interfaces/Database/Wrappers/Wrappers.constants.ts
@@ -648,7 +648,7 @@ export const WRAPPERS: WrapperMeta[] = [
       {
         label: 'Payouts',
         description:
-          'Created when you receive funds rfom Stripe, or when you initiate a payout to either a bank account or debit card',
+          'Created when you receive funds from Stripe, or when you initiate a payout to either a bank account or debit card',
         availableColumns: [
           {
             name: 'id',


### PR DESCRIPTION
As per PR title, added the following tables:
- Checkout Sessions
- Disputes
- Events
- Files
- File Links
- Mandates
- Payouts
- Prices
- Refunds
- Setup Attempts
- Setup Intents
- Tokens
- Top-ups
- Transfers

Source of truth: https://fdw.dev/catalog/stripe/