### PR TITLE
chore: update docs for express payload limit

### DIFF
--- a/apps/docs/content/guides/functions/routing.mdx
+++ b/apps/docs/content/guides/functions/routing.mdx
@@ -39,8 +39,12 @@ Copy and paste the following code:
 ```ts
 import express from 'npm:express@4.18.2'
 
+
 const app = express()
 app.use(express.json())
+// If you want a payload larger than 100kb, then you can tweak it here:
+// app.use( express.json({ limit : "300kb" }));
+
 const port = 3000
 
 app.get('/hello-world', (req, res) => {

--- a/apps/docs/content/guides/functions/routing.mdx
+++ b/apps/docs/content/guides/functions/routing.mdx
@@ -39,7 +39,6 @@ Copy and paste the following code:
 ```ts
 import express from 'npm:express@4.18.2'
 
-
 const app = express()
 app.use(express.json())
 // If you want a payload larger than 100kb, then you can tweak it here:


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Highlights the default payload limit that express has when receiving payload from requests. 

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
