### PR TITLE
docs(python): add error codes to the reference docs

### DIFF
--- a/apps/docs/docs/ref/python/auth-error-codes.mdx
+++ b/apps/docs/docs/ref/python/auth-error-codes.mdx
@@ -1,0 +1,17 @@
+Supabase Auth can throw or return various errors when using the API. All errors originating from the `supabase.auth` namespace of the client library will be wrapped by the `AuthError` class.
+
+Error objects are split in a few classes:
+
+- `AuthApiError` -- errors which originate from the Supabase Auth API.
+  - Use `isAuthApiError` instead of `instanceof` checks to see if an error you caught is of this type.
+- `CustomAuthError` -- errors which generally originate from state in the client library.
+  - Use the `name` property on the error to identify the class of error received.
+
+Errors originating from the server API classed as `AuthApiError` always have a `code` property that can be used to identify the error returned by the server. The `status` property is also present, encoding the HTTP status code received in the response.
+
+<AuthErrorCodesTable />
+
+### Tips for better error handling
+
+- Do not use string matching on error messages! Always use the `name` and `code` properties of error objects to identify the situation.
+- Although HTTP status codes generally don't change, they can suddenly change due to bugs, so avoid relying on them unless absolutely necessary.

--- a/apps/docs/docs/ref/python/auth-error-codes.mdx
+++ b/apps/docs/docs/ref/python/auth-error-codes.mdx
@@ -1,11 +1,6 @@
 Supabase Auth can throw or return various errors when using the API. All errors originating from the `supabase.auth` namespace of the client library will be wrapped by the `AuthError` class.
 
-Error objects are split in a few classes:
-
-- `AuthApiError` -- errors which originate from the Supabase Auth API.
-  - Use `isAuthApiError` instead of `instanceof` checks to see if an error you caught is of this type.
-- `CustomAuthError` -- errors which generally originate from state in the client library.
-  - Use the `name` property on the error to identify the class of error received.
+Error objects are split in a few classes. `AuthApiError` is an error which originate from the Supabase Auth API.
 
 Errors originating from the server API classed as `AuthApiError` always have a `code` property that can be used to identify the error returned by the server. The `status` property is also present, encoding the HTTP status code received in the response.
 

--- a/apps/docs/spec/common-client-libs-sections.json
+++ b/apps/docs/spec/common-client-libs-sections.json
@@ -407,7 +407,6 @@
           "reference_dart_v1",
           "reference_javascript_v1",
           "reference_kotlin_v1",
-          "reference_python_v2",
           "reference_swift_v1",
           "reference_swift_v2"
         ]


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update: add error codes to the python reference docs

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
