### PR TITLE
Add client side validation for payload size in sql editor

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityTabResults.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityTabResults.tsx
@@ -1,4 +1,4 @@
-import { Loader2 } from 'lucide-react'
+import { ExternalLink, Loader2 } from 'lucide-react'
 
 import { useParams } from 'common'
 import { subscriptionHasHipaaAddon } from 'components/interfaces/Billing/Subscription/Subscription.utils'
@@ -10,6 +10,7 @@ import { AiIconAnimation, Button } from 'ui'
 import Results from './Results'
 import { useSqlEditorV2StateSnapshot } from 'state/sql-editor-v2'
 import { useFlag } from 'hooks/ui/useFlag'
+import Link from 'next/link'
 
 export type UtilityTabResultsProps = {
   id: string
@@ -58,6 +59,9 @@ const UtilityTabResults = ({
     const readReplicaError =
       state.selectedDatabaseId !== ref &&
       result.error.message.includes('in a read-only transaction')
+    const payloadTooLargeError = result.error.message.includes(
+      'Query is too large to be run via the SQL Editor'
+    )
 
     return (
       <div className="bg-table-header-light [[data-theme*=dark]_&]:bg-table-header-dark">
@@ -88,7 +92,7 @@ const UtilityTabResults = ({
               </p>
             </div>
           ) : (
-            <div className="">
+            <div className="flex flex-col gap-y-1">
               {formattedError.length > 0 ? (
                 formattedError.map((x: string, i: number) => (
                   <pre key={`error-${i}`} className="font-mono text-sm text-wrap">
@@ -96,7 +100,7 @@ const UtilityTabResults = ({
                   </pre>
                 ))
               ) : (
-                <p className="font-mono text-sm">Error: {result.error?.message}</p>
+                <p className="font-mono text-sm tracking-tight">Error: {result.error?.message}</p>
               )}
               {result.autoLimit && (
                 <p className="text-sm text-foreground-light">
@@ -108,6 +112,21 @@ const UtilityTabResults = ({
                 <p className="text-sm text-foreground-light">
                   Note: Read replicas are for read only queries. Run write queries on the primary
                   database instead.
+                </p>
+              )}
+              {payloadTooLargeError && (
+                <p className="text-sm text-foreground-light flex items-center gap-x-1">
+                  Run this query by{' '}
+                  <Link
+                    target="_blank"
+                    rel="noreferrer"
+                    href={`/project/${ref}/settings/database`}
+                    className="underline transition hover:text-foreground flex items-center gap-x-1"
+                  >
+                    connecting to your database directly
+                    <ExternalLink size={12} />
+                  </Link>
+                  .
                 </p>
               )}
             </div>

--- a/apps/studio/data/sql/execute-sql-query.ts
+++ b/apps/studio/data/sql/execute-sql-query.ts
@@ -7,6 +7,7 @@ import {
 } from 'lib/role-impersonation'
 import type { ResponseError } from 'types'
 import { sqlKeys } from './keys'
+import { MB } from 'lib/constants'
 
 export type ExecuteSqlVariables = {
   projectRef?: string
@@ -38,6 +39,12 @@ export async function executeSql(
   signal?: AbortSignal
 ): Promise<{ result: any }> {
   if (!projectRef) throw new Error('projectRef is required')
+
+  const sqlSize = new Blob([sql]).size
+  // [Joshen] I think the limit is around 1MB from testing, but its not exactly 1MB it seems
+  if (sqlSize > 0.98 * MB) {
+    throw new Error('Query is too large to be run via the SQL Editor')
+  }
 
   let headers = new Headers()
   if (connectionString) headers.set('x-connection-encrypted', connectionString)


### PR DESCRIPTION
Prevent users from running into "request body is too large" errors (and also save an unnecessary hammer on the API)
<img width="537" alt="image" src="https://github.com/user-attachments/assets/c362b6b9-3d35-424a-a4b4-81d62062736d">
