### PR TITLE
chore: exclude Log Drains and MFA Phone from list of removed addons in downgrade modal

### DIFF
--- a/apps/studio/components/interfaces/Auth/AdvancedAuthSettingsForm/AdvancedAuthSettingsForm.tsx
+++ b/apps/studio/components/interfaces/Auth/AdvancedAuthSettingsForm/AdvancedAuthSettingsForm.tsx
@@ -354,9 +354,9 @@ const AdvancedAuthSettingsForm = () => {
                     <Alert_Shadcn_ variant="warning">
                       <WarningIcon />
                       <AlertTitle_Shadcn_>
-                        Enabling advanced MFA with phone will result in an add additional charge of
-                        $75 per month for the first project in the organization and an additional
-                        $10 per month for additional projects.
+                        Enabling advanced MFA with phone will result in an additional charge of $75
+                        per month for the first project in the organization and an additional $10
+                        per month for additional projects.
                       </AlertTitle_Shadcn_>
                     </Alert_Shadcn_>
                   )}

--- a/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/DowngradeModal.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/DowngradeModal.tsx
@@ -15,14 +15,24 @@ export interface DowngradeModalProps {
 
 const ProjectDowngradeListItem = ({ projectAddon }: { projectAddon: ProjectAddon }) => {
   const needsRestart = projectAddon.addons.find((addon) => addon.type === 'compute_instance')
-  const addons = projectAddon.addons.map((addon) => {
+
+  /**
+   * We do not include Log Drains and Advanced MFA Phone for the following reasons:
+   * 1. These addons are not removed automatically. Instead, users have to remove the respective configuration themselves
+   * 2. It's not obvious to users that Log Drains and MFA Phone are addons
+   */
+  const relevantAddonsToList = projectAddon.addons.filter(
+    (addon) => !['log_drain', 'auth_mfa_phone'].includes(addon.type)
+  )
+
+  const addonNames = relevantAddonsToList.map((addon) => {
     if (addon.type === 'compute_instance') return `${addon.variant.name} Compute Instance`
     return addon.variant.name
   })
 
   return (
     <li className="list-disc ml-6">
-      {projectAddon.name}: {addons.join(', ')} will be removed.
+      {projectAddon.name}: {addonNames.join(', ')} will be removed.
       {needsRestart ? (
         <>
           {' '}

--- a/apps/studio/components/interfaces/Settings/General/TransferProjectPanel/TransferProjectButton.tsx
+++ b/apps/studio/components/interfaces/Settings/General/TransferProjectPanel/TransferProjectButton.tsx
@@ -204,60 +204,63 @@ const TransferProjectButton = () => {
 
         <Loading active={selectedOrg !== undefined && transferPreviewIsLoading}>
           <Modal.Content>
-            {transferPreviewData && transferPreviewData.warnings.length > 0 && (
-              <Alert
-                withIcon
-                variant="warning"
-                title="Warnings for project transfer"
-                className="mt-3"
-              >
-                <div className="space-y-1">
-                  {transferPreviewData.warnings.map((warning) => (
-                    <p key={warning.key}>{warning.message}</p>
-                  ))}
-                </div>
-              </Alert>
-            )}
-            {transferPreviewData && transferPreviewData.errors.length > 0 && (
-              <Alert withIcon variant="danger" title="Project cannot be transferred">
-                <div className="space-y-1">
-                  {transferPreviewData.errors.map((error) => (
-                    <p key={error.key}>{error.message}</p>
-                  ))}
-                </div>
-                {transferPreviewData.members_exceeding_free_project_limit.length > 0 && (
-                  <div className="space-y-2">
-                    <p className="text-sm text-foreground-light">
-                      These members have reached their maximum limits for the number of active Free
-                      plan projects within organizations where they are an administrator or owner:
-                    </p>
-                    <ul className="pl-5 text-sm list-disc text-foreground-light">
-                      {(transferPreviewData.members_exceeding_free_project_limit || []).map(
-                        (member, idx: number) => (
-                          <li key={`member-${idx}`}>
-                            {member.name} (Limit: {member.limit} free projects)
-                          </li>
-                        )
-                      )}
-                    </ul>
-                    <p className="text-sm text-foreground-light">
-                      These members will need to either delete, pause, or upgrade one or more of
-                      their projects before you can downgrade this project.
-                    </p>
+            <div className="space-y-2">
+              {transferPreviewData && transferPreviewData.warnings.length > 0 && (
+                <Alert
+                  withIcon
+                  variant="warning"
+                  title="Warnings for project transfer"
+                  className="mt-3"
+                >
+                  <div className="space-y-1">
+                    {transferPreviewData.warnings.map((warning) => (
+                      <p key={warning.key}>{warning.message}</p>
+                    ))}
                   </div>
-                )}
-              </Alert>
-            )}
-            {transferPreviewError && !transferError && (
-              <Alert withIcon variant="danger" title="Project cannot be transferred">
-                <p>{transferPreviewError.message}</p>
-              </Alert>
-            )}
-            {transferError && (
-              <Alert withIcon variant="danger" title="Project cannot be transferred">
-                <p>{transferError.message}</p>
-              </Alert>
-            )}
+                </Alert>
+              )}
+              {transferPreviewData && transferPreviewData.errors.length > 0 && (
+                <Alert withIcon variant="danger" title="Project cannot be transferred">
+                  <div className="space-y-1">
+                    {transferPreviewData.errors.map((error) => (
+                      <p key={error.key}>{error.message}</p>
+                    ))}
+                  </div>
+                  {transferPreviewData.members_exceeding_free_project_limit.length > 0 && (
+                    <div className="space-y-2">
+                      <p className="text-sm text-foreground-light">
+                        These members have reached their maximum limits for the number of active
+                        Free plan projects within organizations where they are an administrator or
+                        owner:
+                      </p>
+                      <ul className="pl-5 text-sm list-disc text-foreground-light">
+                        {(transferPreviewData.members_exceeding_free_project_limit || []).map(
+                          (member, idx: number) => (
+                            <li key={`member-${idx}`}>
+                              {member.name} (Limit: {member.limit} free projects)
+                            </li>
+                          )
+                        )}
+                      </ul>
+                      <p className="text-sm text-foreground-light">
+                        These members will need to either delete, pause, or upgrade one or more of
+                        their projects before you can downgrade this project.
+                      </p>
+                    </div>
+                  )}
+                </Alert>
+              )}
+              {transferPreviewError && !transferError && (
+                <Alert withIcon variant="danger" title="Project cannot be transferred">
+                  <p>{transferPreviewError.message}</p>
+                </Alert>
+              )}
+              {transferError && (
+                <Alert withIcon variant="danger" title="Project cannot be transferred">
+                  <p>{transferError.message}</p>
+                </Alert>
+              )}
+            </div>
           </Modal.Content>
         </Loading>
       </Modal>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adjusts copy on "Downgrade to Free" modal regarding addons that will be removed.

## What is the current behavior?
Log Drains and MFA Phone are listed as addons that will be removed from the project once downgrading.

<img width="590" alt="before" src="https://github.com/user-attachments/assets/3017d023-4a32-4194-9c7b-362351c2cdff">

## What is the new behavior?
Log Drains and MFA Phone are no longer listed.

<img width="593" alt="after" src="https://github.com/user-attachments/assets/6354713a-e701-4fd6-a490-2f3125c967f9">


**Additional**
- fixed typo in Adanved MFA Phone section
- fixed spacing on Project Transfer modal
