### PR TITLE
Chore/sql editor fixes

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/MoveQueryModal.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/MoveQueryModal.tsx
@@ -65,17 +65,21 @@ export const MoveQueryModal = ({ visible, snippets = [], onClose }: MoveQueryMod
 
   const { mutateAsync: createFolder, isLoading: isCreatingFolder } =
     useSQLSnippetFolderCreateMutation()
-  const {
-    mutate: moveSnippet,
-    mutateAsync: moveSnippetAsync,
-    isLoading: isMovingSnippet,
-  } = useContentUpsertV2Mutation({
+  const { mutateAsync: moveSnippetAsync, isLoading: isMovingSnippet } = useContentUpsertV2Mutation({
     onError: (error) => {
       toast.error(`Failed to move query: ${error.message}`)
     },
   })
 
-  const FormSchema = z.object({ name: z.string() })
+  const FormSchema = z.object({ name: z.string() }).refine(
+    (data) => {
+      return !snapV2.allFolderNames.includes(data.name)
+    },
+    {
+      message: 'This folder name already exists',
+      path: ['name'],
+    }
+  )
   const form = useForm<z.infer<typeof FormSchema>>({
     mode: 'onSubmit',
     reValidateMode: 'onSubmit',

--- a/apps/studio/components/interfaces/SQLEditor/MoveQueryModal.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/MoveQueryModal.tsx
@@ -71,15 +71,17 @@ export const MoveQueryModal = ({ visible, snippets = [], onClose }: MoveQueryMod
     },
   })
 
-  const FormSchema = z.object({ name: z.string() }).refine(
-    (data) => {
-      return !snapV2.allFolderNames.includes(data.name)
-    },
-    {
-      message: 'This folder name already exists',
-      path: ['name'],
-    }
-  )
+  const FormSchema = z
+    .object({ name: z.string().min(1, 'Please provide a name for the folder') })
+    .refine(
+      (data) => {
+        return !snapV2.allFolderNames.includes(data.name)
+      },
+      {
+        message: 'This folder name already exists',
+        path: ['name'],
+      }
+    )
   const form = useForm<z.infer<typeof FormSchema>>({
     mode: 'onSubmit',
     reValidateMode: 'onSubmit',

--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorNav.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorNav.tsx
@@ -531,8 +531,11 @@ export const SQLEditorNav = ({ searchText: _searchText }: SQLEditorNavProps) => 
                   onSelectShare={() => setSelectedSnippetToShare(element.metadata as Snippet)}
                   onEditSave={(name: string) => {
                     // [Joshen] Inline editing only for folders for now
-                    if (name.length === 0) snapV2.removeFolder(element.id as string)
-                    else snapV2.saveFolder({ id: element.id as string, name })
+                    if (name.length === 0 && element.id === 'new-folder') {
+                      snapV2.removeFolder(element.id as string)
+                    } else if (name.length > 0) {
+                      snapV2.saveFolder({ id: element.id as string, name })
+                    }
                   }}
                 />
               )}

--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorTreeViewItem.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorTreeViewItem.tsx
@@ -113,7 +113,7 @@ export const SQLEditorTreeViewItem = ({
             isEditing={isEditing}
             isLoading={isFetching || isSaving}
             onEditSubmit={(value) => {
-              if (onEditSave !== undefined && value) onEditSave(value)
+              if (onEditSave !== undefined) onEditSave(value)
             }}
             onClick={(e) => {
               if (!isBranch) {

--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorTreeViewItem.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorTreeViewItem.tsx
@@ -113,7 +113,7 @@ export const SQLEditorTreeViewItem = ({
             isEditing={isEditing}
             isLoading={isFetching || isSaving}
             onEditSubmit={(value) => {
-              if (onEditSave !== undefined) onEditSave(value)
+              if (onEditSave !== undefined && value) onEditSave(value)
             }}
             onClick={(e) => {
               if (!isBranch) {

--- a/apps/studio/state/sql-editor-v2.ts
+++ b/apps/studio/state/sql-editor-v2.ts
@@ -74,6 +74,10 @@ export const sqlEditorState = proxy({
   limit: 100,
   order: 'inserted_at' as 'name' | 'inserted_at',
 
+  get allFolderNames() {
+    return Object.values(sqlEditorState.folders).map((x) => x.folder.name)
+  },
+
   // ========================================================================
   // ## Methods to interact the store with
   // ========================================================================
@@ -203,8 +207,7 @@ export const sqlEditorState = proxy({
   },
 
   saveFolder: ({ id, name }: { id: string; name: string }) => {
-    const folderNames = Object.values(sqlEditorState.folders).map((x) => x.folder.name)
-    if (id === 'new-folder' && folderNames.includes(name)) {
+    if (id === 'new-folder' && sqlEditorState.allFolderNames.includes(name)) {
       sqlEditorState.removeFolder(id)
       return toast.error('This folder name already exists')
     }

--- a/apps/studio/state/sql-editor-v2.ts
+++ b/apps/studio/state/sql-editor-v2.ts
@@ -203,6 +203,12 @@ export const sqlEditorState = proxy({
   },
 
   saveFolder: ({ id, name }: { id: string; name: string }) => {
+    const folderNames = Object.values(sqlEditorState.folders).map((x) => x.folder.name)
+    if (id === 'new-folder' && folderNames.includes(name)) {
+      sqlEditorState.removeFolder(id)
+      return toast.error('This folder name already exists')
+    }
+
     const hasChanges = sqlEditorState.folders[id].folder.name !== name
     sqlEditorState.folders[id] = {
       projectRef: sqlEditorState.folders[id].projectRef,
@@ -390,6 +396,7 @@ async function upsertFolder(id: string, projectRef: string, name: string) {
     }
   } catch (error: any) {
     toast.error(`Failed to save folder: ${error.message}`)
+    if (error.message.includes('create')) sqlEditorState.removeFolder(id)
   }
 }
 

--- a/apps/studio/state/sql-editor-v2.ts
+++ b/apps/studio/state/sql-editor-v2.ts
@@ -209,12 +209,16 @@ export const sqlEditorState = proxy({
   },
 
   saveFolder: ({ id, name }: { id: string; name: string }) => {
+    const hasChanges = sqlEditorState.folders[id].folder.name !== name
+
     if (id === 'new-folder' && sqlEditorState.allFolderNames.includes(name)) {
       sqlEditorState.removeFolder(id)
       return toast.error('This folder name already exists')
+    } else if (hasChanges && sqlEditorState.allFolderNames.includes(name)) {
+      sqlEditorState.folders[id] = { ...sqlEditorState.folders[id], status: 'idle' }
+      return toast.error('This folder name already exists')
     }
 
-    const hasChanges = sqlEditorState.folders[id].folder.name !== name
     const originalFolderName = sqlEditorState.folders[id].folder.name.slice()
 
     sqlEditorState.folders[id] = {
@@ -393,7 +397,6 @@ const debouncedUpdateSnippet = (id: string, projectRef: string, payload: UpsertC
   memoizedUpdateSnippet(id)(id, projectRef, payload)
 
 async function upsertFolder(id: string, projectRef: string, name: string) {
-  const originalFolder = sqlEditorState.folders[id]
   try {
     if (id === NEW_FOLDER_ID) {
       const res = await createSQLSnippetFolder({ projectRef, name })

--- a/packages/ui/src/components/TreeView/TreeView.tsx
+++ b/packages/ui/src/components/TreeView/TreeView.tsx
@@ -70,8 +70,16 @@ const TreeViewItem = forwardRef<
     useEffect(() => {
       if (isEditing) {
         inputRef.current?.focus()
+      } else {
+        setLocalValueState(name)
       }
     }, [isEditing])
+
+    useEffect(() => {
+      if (!isLoading) {
+        setLocalValueState(name)
+      }
+    }, [isLoading])
 
     const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
       e.preventDefault()


### PR DESCRIPTION
- Add new folder: Add validation for creating a new folder of the same name as one of the existing folders
- Move query: Add validation for creating a new folder of the same name as one of the existing folders
- Move query: Add validation for new folder name to be minimum length of 1
- Rename folder: Handle state update back to idle if update failed (due to duplicate name)
- Rename folder: Add validation for renaming a folder to a same name as one of the existing folders