### PR TITLE
Fix weird wide resizeable panel if load table editor or sql editor from a fresh browser session

### DIFF
--- a/apps/studio/components/layouts/ProjectLayout/ProjectLayout.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/ProjectLayout.tsx
@@ -90,10 +90,11 @@ const ProjectLayout = ({
   const navLayoutV2 = useFlag('navigationLayoutV2')
 
   const isPaused = selectedProject?.status === PROJECT_STATUS.INACTIVE
-  const showProductMenu =
-    selectedProject?.status === PROJECT_STATUS.ACTIVE_HEALTHY ||
-    (selectedProject?.status !== PROJECT_STATUS.ACTIVE_HEALTHY &&
-      router.pathname.includes('/project/[ref]/settings'))
+  const showProductMenu = selectedProject
+    ? selectedProject?.status === PROJECT_STATUS.ACTIVE_HEALTHY ||
+      (selectedProject?.status === PROJECT_STATUS.COMING_UP &&
+        router.pathname.includes('/project/[ref]/settings'))
+    : true
   const ignorePausedState =
     router.pathname === '/project/[ref]' || router.pathname.includes('/project/[ref]/settings')
   const showPausedState = isPaused && !ignorePausedState
@@ -128,7 +129,7 @@ const ProjectLayout = ({
               <>
                 <ResizablePanel
                   className={cn(resizableSidebar ? 'min-w-64 max-w-[32rem]' : 'min-w-64 max-w-64')}
-                  defaultSize={1} // forces panel to smallest width possible, at w-64
+                  defaultSize={0} // forces panel to smallest width possible, at w-64
                 >
                   <MenuBarWrapper
                     isLoading={isLoading}

--- a/apps/studio/components/layouts/ProjectLayout/ProjectLayout.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/ProjectLayout.tsx
@@ -91,8 +91,8 @@ const ProjectLayout = ({
 
   const isPaused = selectedProject?.status === PROJECT_STATUS.INACTIVE
   const showProductMenu = selectedProject
-    ? selectedProject?.status === PROJECT_STATUS.ACTIVE_HEALTHY ||
-      (selectedProject?.status === PROJECT_STATUS.COMING_UP &&
+    ? selectedProject.status === PROJECT_STATUS.ACTIVE_HEALTHY ||
+      (selectedProject.status === PROJECT_STATUS.COMING_UP &&
         router.pathname.includes('/project/[ref]/settings'))
     : true
   const ignorePausedState =


### PR DESCRIPTION
As per PR title - can reproduce on prod by opening the table editor then hitting refresh