### PR TITLE
removed type CookieOptions

### DIFF
--- a/apps/docs/content/guides/getting-started/quickstarts/nextjs.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/nextjs.mdx
@@ -126,7 +126,7 @@ hideToc: true
       ```
 
       ```ts utils/supabase/server.ts
-        import { createServerClient, type CookieOptions } from '@supabase/ssr'
+        import { createServerClient } from '@supabase/ssr'
         import { cookies } from 'next/headers'
 
         export function createClient() {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

In the documentation, the type CookieOptions was included in the code example but was not being used. 

## What is the new behavior?

The unused type CookieOptions was removed from the code example to make it clearer and more concise.

## Additional context

N/A
