### PR TITLE
fix: clarify that ipv4 now billed hourly

### DIFF
--- a/apps/studio/components/interfaces/Settings/Addons/IPv4SidePanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/IPv4SidePanel.tsx
@@ -172,11 +172,12 @@ const IPv4SidePanel = () => {
                       <p className="text-foreground-light">
                         Allow direct database connections via IPv4 address
                       </p>
-                      <div className="flex items-center space-x-1 mt-2">
+                      <div className="grid grid-cols-[max-content,1fr] space-x-1 mt-2">
                         <p className="text-foreground text-sm">{formatCurrency(option.price)}</p>
-                        <p className="text-foreground-light translate-y-[1px]">
+                        <p className="text-foreground-light translate-y-[2px]">
                           / month / database
                         </p>
+                        <span className="col-start-2 text-foreground-light">(billed hourly)</span>
                       </div>
                     </div>
                   </div>


### PR DESCRIPTION
ipv4 is now billed hourly at the prorated former monthly rate (see [changelog](https://github.com/orgs/supabase/discussions/28438)), but we don't mention this in the dashboard, which discourages quick experimentation

context here: https://github.com/supabase/supabase/pull/29166#discussion_r1750596095

<img width="436" alt="image" src="https://github.com/user-attachments/assets/343ba3e4-edfd-4679-85f1-eaaa61d9afe7">
