### PR TITLE
Project filter status, active will only show active projects, not all

### DIFF
--- a/apps/studio/components/interfaces/Home/ProjectList/ProjectList.tsx
+++ b/apps/studio/components/interfaces/Home/ProjectList/ProjectList.tsx
@@ -187,7 +187,7 @@ const OrganizationProjects = ({
   // [Joshen] Just a UI thing, but we take all projects other than paused as "active"
   const filteredProjectsByStatus =
     filterStatus !== undefined
-      ? filterStatus.includes(PROJECT_STATUS.ACTIVE_HEALTHY)
+      ? filterStatus.length === 2
         ? filteredProjects
         : filteredProjects.filter((project) => filterStatus.includes(project.status))
       : filteredProjects


### PR DESCRIPTION
Currently having the filter with only "Active" still shows _all_ projects, this fixes it to only show active projects
![image](https://github.com/user-attachments/assets/eaf5ef73-58e9-4f16-81c7-9cb05586447b)
