### PR TITLE
fix: usage summary for stripe org [GEN-10963]

### DIFF
--- a/apps/studio/components/interfaces/Organization/Usage/TotalUsage.tsx
+++ b/apps/studio/components/interfaces/Organization/Usage/TotalUsage.tsx
@@ -73,7 +73,7 @@ const TotalUsage = ({
     if (!usage) return []
 
     const breakdownMetrics = BILLING_BREAKDOWN_METRICS.filter((metric) =>
-      usage.usages.some((usage) => !usage.available_in_plan || usage.metric === metric.key)
+      usage.usages.some((usage) => usage.metric === metric.key)
     ).filter((metric) => {
       if (!METRICS_TO_HIDE_WITH_NO_USAGE.includes(metric.key as PricingMetric)) return true
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes the usage summary for Stripe orgs

## What is the current behavior?

Cells for metrics that are not returned by the Mgmt-API are not displayed correctly. For the metrics "Monthly Active Third Party Users" and "Log Drain Events" no usage data is returned from Mgmt-API because these metrics do not exist for Stripe orgs.

<img width="669" alt="10963-before" src="https://github.com/user-attachments/assets/f5023454-0811-4747-9606-a966c73055fe">


## What is the new behavior?
### Free Plan
<img width="681" alt="10963-after-free" src="https://github.com/user-attachments/assets/fb711af1-dd68-4f07-842b-b4ae8c7acab7">

### Pro Plan
<img width="672" alt="10963-after-pro" src="https://github.com/user-attachments/assets/282f44ab-40e5-4d41-a73a-4d4998f990f6">
