### PR TITLE
Update managing-config.mdx

### DIFF
--- a/apps/docs/content/guides/cli/managing-config.mdx
+++ b/apps/docs/content/guides/cli/managing-config.mdx
@@ -26,6 +26,20 @@ redirect_uri = "" # Overrides the default auth redirectUrl.
 
 You can reference environment variables within the `config.toml` file using the `env()` function. This will detect any values stored in an `.env` file at the root of your project directory. This is particularly useful for storing sensitive information like API keys, and any other values that you don't want to check into version control.
 
+```
+.
+├── .env
+├── .env.example
+└── supabase
+    └── config.toml
+```
+
+<Admonition type="caution">
+
+Do NOT commit your `.env` into git. Be sure to configure your `.gitignore` to exclude this file.
+
+</Admonition>
+
 For example, if your `.env` contained the following values:
 
 ```bash

--- a/apps/docs/content/guides/cli/managing-config.mdx
+++ b/apps/docs/content/guides/cli/managing-config.mdx
@@ -34,7 +34,7 @@ You can reference environment variables within the `config.toml` file using the 
     └── config.toml
 ```
 
-<Admonition type="caution">
+<Admonition type="danger">
 
 Do NOT commit your `.env` into git. Be sure to configure your `.gitignore` to exclude this file.
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs Update

## What is the current behavior?

There may be confusion on where the .env file should reside, as having it side-by-side with `config.toml` would not work.

## What is the new behavior?

This folder visual should help user identify where to put `.env`, as well as warn them about not to commit the file.

## Additional context

Add any other context or screenshots.
