### PR TITLE
fix: cmdk force-mount

### DIFF
--- a/packages/ui-patterns/CommandMenu/internal/Command.tsx
+++ b/packages/ui-patterns/CommandMenu/internal/Command.tsx
@@ -85,7 +85,6 @@ const CommandItem = forwardRef<
 >(({ children, className, command: _command, ...props }, ref) => {
   const router = useCrossCompatRouter()
   const setIsOpen = useSetCommandMenuOpen()
-  const query = useQuery()
 
   const command = _command as ICommand // strip the readonly applied from the proxy
 
@@ -103,11 +102,8 @@ const CommandItem = forwardRef<
               }
             : () => {}
       }
-      value={
-        command.forceMount
-          ? `${query} ${command.value ?? command.name}`
-          : command.value ?? command.name
-      }
+      value={command.value ?? command.name}
+      forceMount={command.forceMount}
       className={cn(
         generateCommandClassNames(isRouteCommand(command)),
         className,


### PR DESCRIPTION
We were hacking around force-mount behavior because it wasn't working in a previous version of cmdk. cmdk version was bumped a few weeks ago which fixes force-mount. (there was also a bug in the hack which is now irrelevant)