### PR TITLE
Support up to 5 RRs for XL compute and above

### DIFF
--- a/apps/studio/components/interfaces/Settings/Addons/ComputeInstanceSidePanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/ComputeInstanceSidePanel.tsx
@@ -12,7 +12,7 @@ import {
   useProjectContext,
 } from 'components/layouts/ProjectLayout/ProjectContext'
 import { setProjectStatus } from 'data/projects/projects-query'
-import { useReadReplicasQuery } from 'data/read-replicas/replicas-query'
+import { MAX_REPLICAS_BELOW_XL, useReadReplicasQuery } from 'data/read-replicas/replicas-query'
 import { useOrgSubscriptionQuery } from 'data/subscriptions/org-subscription-query'
 import { useProjectAddonRemoveMutation } from 'data/subscriptions/project-addon-remove-mutation'
 import { useProjectAddonUpdateMutation } from 'data/subscriptions/project-addon-update-mutation'
@@ -163,12 +163,18 @@ const ComputeInstanceSidePanel = () => {
   const selectedCompute = availableOptions.find((option) => option.identifier === selectedOption)
   const hasChanges =
     selectedOption !== (subscriptionCompute?.variant.identifier ?? defaultInstanceSize)
-  const hasReadReplicas = (databases ?? []).length > 1
+  const numReadReplicas = 3 // (databases ?? []).filter((db) => db.identifier !== projectRef).length
+  const hasReadReplicas = numReadReplicas > 0
 
-  const blockDowngradeDueToPitr =
-    pitrAddon !== undefined && ['ci_micro', 'ci_nano'].includes(selectedOption) && hasChanges
+  const isDowngradingToBelowSmall = ['ci_micro', 'ci_nano'].includes(selectedOption)
+  const blockDowngradeDueToPitr = pitrAddon !== undefined && isDowngradingToBelowSmall && hasChanges
+  const hasMoreThanTwoReplicasForXLAndAbove =
+    numReadReplicas > MAX_REPLICAS_BELOW_XL &&
+    ['ci_micro', 'ci_small', 'ci_medium', 'ci_large'].includes(selectedOption)
   const blockDowngradeDueToReadReplicas =
-    hasChanges && hasReadReplicas && ['ci_micro', 'ci_nano'].includes(selectedOption)
+    hasChanges &&
+    hasReadReplicas &&
+    (isDowngradingToBelowSmall || hasMoreThanTwoReplicasForXLAndAbove)
 
   useEffect(() => {
     if (visible) {
@@ -409,12 +415,14 @@ const ComputeInstanceSidePanel = () => {
               <Alert_Shadcn_>
                 <WarningIcon />
                 <AlertTitle_Shadcn_>
-                  Unable to downgrade as project has active read replicas
+                  {hasMoreThanTwoReplicasForXLAndAbove && selectedOption !== 'ci_micro'
+                    ? `Unable to downgrade as project has more than ${MAX_REPLICAS_BELOW_XL} read replicas`
+                    : 'Unable to downgrade as project has active read replicas'}
                 </AlertTitle_Shadcn_>
                 <AlertDescription_Shadcn_>
-                  The minimum compute size for using read replicas is the Small Compute. You need to
-                  remove all read replicas before downgrading Compute as it requires at least a
-                  Small compute instance.
+                  {hasMoreThanTwoReplicasForXLAndAbove && selectedOption !== 'ci_micro'
+                    ? `You can only have up to ${MAX_REPLICAS_BELOW_XL} read replicas for compute sizes below XL, as such you will need to remove at least ${numReadReplicas - MAX_REPLICAS_BELOW_XL} read replica${numReadReplicas - MAX_REPLICAS_BELOW_XL > 1 ? 's' : ''} before downgrading your compute.`
+                    : 'The minimum compute size for using read replicas is the Small Compute. You need to remove all read replicas before downgrading Compute as it requires at least a Small compute instance.'}
                 </AlertDescription_Shadcn_>
                 <AlertDescription_Shadcn_ className="mt-2">
                   <Button asChild type="default">

--- a/apps/studio/components/interfaces/Settings/Addons/ComputeInstanceSidePanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/ComputeInstanceSidePanel.tsx
@@ -163,7 +163,7 @@ const ComputeInstanceSidePanel = () => {
   const selectedCompute = availableOptions.find((option) => option.identifier === selectedOption)
   const hasChanges =
     selectedOption !== (subscriptionCompute?.variant.identifier ?? defaultInstanceSize)
-  const numReadReplicas = 3 // (databases ?? []).filter((db) => db.identifier !== projectRef).length
+  const numReadReplicas = (databases ?? []).filter((db) => db.identifier !== projectRef).length
   const hasReadReplicas = numReadReplicas > 0
 
   const isDowngradingToBelowSmall = ['ci_micro', 'ci_nano'].includes(selectedOption)

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/DropAllReplicasConfirmationModal.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/DropAllReplicasConfirmationModal.tsx
@@ -70,7 +70,7 @@ const DropAllReplicasConfirmationModal = ({
       }}
     >
       <p className="text-sm">Before deleting all replicas, consider:</p>
-      <ul className="text-sm text-foreground-light list-disc">
+      <ul className="text-sm text-foreground-light list-disc pl-6">
         <li>Network traffic from this region may slow down</li>
       </ul>
     </ConfirmationModal>

--- a/apps/studio/data/read-replicas/replicas-query.ts
+++ b/apps/studio/data/read-replicas/replicas-query.ts
@@ -6,6 +6,9 @@ import { get, handleError } from 'data/fetchers'
 import type { ResponseError } from 'types'
 import { replicaKeys } from './keys'
 
+export const MAX_REPLICAS_BELOW_XL = 2
+export const MAX_REPLICAS_ABOVE_XL = 5
+
 export type ReadReplicasVariables = {
   projectRef?: string
 }


### PR DESCRIPTION
As per PR title
- If on small compute (and medium, large), can deploy up to 2 RRs
- From XL compute and above, can deploy up to 5 RRs
- The necessary validations for downgrading compute should hold in place

Updated message when trying to deploy a third replica while on Small compute:
![Screenshot 2024-09-12 at 16 51 30](https://github.com/user-attachments/assets/9d827205-2538-491c-b24d-93c6f841b0e9)

Updated message when trying to downgrade from XL while having more than 2 replicas
![Screenshot 2024-09-12 at 17 09 53](https://github.com/user-attachments/assets/8348d8c9-30a7-4ac6-8d85-57038e95a952)

Will use the same message when trying to downgrade to micro from XL while having more than 2 replicas
![image](https://github.com/user-attachments/assets/0dca1934-be8b-4ca7-9451-abcef2638ae2)
