### PR TITLE
fix(cmdk): empty state shows up when it shouldn't

### DIFF
--- a/apps/studio/components/interfaces/BranchManagement/Branch.Commands.tsx
+++ b/apps/studio/components/interfaces/BranchManagement/Branch.Commands.tsx
@@ -17,7 +17,7 @@ export function useBranchCommands() {
 
   let { data: branches } = useBranchesQuery(
     {
-      projectRef: selectedProject?.ref,
+      projectRef: selectedProject?.parentRef,
     },
     { enabled: isBranchingEnabled }
   )

--- a/packages/ui-patterns/CommandMenu/internal/CommandEmpty.tsx
+++ b/packages/ui-patterns/CommandMenu/internal/CommandEmpty.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { type PropsWithChildren, type RefObject, useMemo, useState } from 'react'
+import { type PropsWithChildren, type RefObject, useEffect, useState } from 'react'
 
 import { cn } from 'ui'
 
@@ -24,14 +24,9 @@ const CommandEmpty = ({
   const query = useQuery()
 
   const [render, setRender] = useState(false)
-  useMemo(() => {
-    if (!query) setRender(false)
-    /**
-     * In a timeout so the DOM update happens before we query.
-     */
-    setTimeout(() => {
-      setRender(!listRef?.current?.querySelector('[cmdk-item]'))
-    })
+  useEffect(() => {
+    if (!query) return setRender(false)
+    setRender(!listRef?.current?.querySelector('[cmdk-item]'))
   }, [query])
 
   return (


### PR DESCRIPTION
Can't remember why on earth I put this in a useMemo instead of a useEffect...

To reproduce:

There's a race condition somewhere, so it can be hard to reproduce the bug. One method that works ~90% of the time for me:

1. Open command menu in a project with branching enabled.
2. Use the command menu to switch branches.
3. Open command menu and search "branch" again. You might get the bug at this stage, or you might get the empty state (unrelated bug, this should show other available branches). If you don't get the bug yet, continue:
4. Press "Escape" to clear the search (only works with Escape, not Backspace!)
5. See the empty state showing up on top of a clearly non-empty list:
<img width="604" alt="image" src="https://github.com/user-attachments/assets/8f1f20f2-14fc-4e32-be56-abe3df0d8531">

Fixed:
<img width="601" alt="image" src="https://github.com/user-attachments/assets/e623378f-f993-4a0f-a7c0-a0224fb0b246">
