### PR TITLE
Fix sharing favorite queries

### DIFF
--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorNav.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorNav.tsx
@@ -384,6 +384,7 @@ export const SQLEditorNav = ({ searchText: _searchText }: SQLEditorNavProps) => 
                       onSelectCopyPersonal={() => {
                         onSelectCopyPersonal(element.metadata as Snippet)
                       }}
+                      onSelectShare={() => setSelectedSnippetToShare(element.metadata as Snippet)}
                       onSelectUnshare={() => {
                         setSelectedSnippetToUnshare(element.metadata as Snippet)
                       }}

--- a/apps/studio/state/sql-editor-v2.ts
+++ b/apps/studio/state/sql-editor-v2.ts
@@ -309,6 +309,16 @@ export const sqlEditorState = proxy({
         },
       }
 
+      if (sqlEditorState.favoriteSnippets[id] !== undefined) {
+        sqlEditorState.favoriteSnippets[id] = {
+          projectRef: sqlEditorState.favoriteSnippets[id].projectRef,
+          snippet: {
+            ...sqlEditorState.favoriteSnippets[id].snippet,
+            visibility,
+          } as unknown as SqlSnippet,
+        }
+      }
+
       sqlEditorState.needsSaving.add(id)
     }
   },


### PR DESCRIPTION
Fix missing option to share (and unshare) queries for queries under the favorites section (you could do it under the private section)
![image](https://github.com/user-attachments/assets/28e4cf96-8034-469d-bd66-1e02c31eae53)
