### PR TITLE
prevent use of WITH, ILIKE or wildcards (*) in logs explorer

### DIFF
--- a/apps/studio/components/interfaces/Settings/Logs/LogTable.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogTable.tsx
@@ -14,7 +14,6 @@ import { useProfile } from 'lib/profile'
 import { Item, Menu, useContextMenu } from 'react-contexify'
 import { createPortal } from 'react-dom'
 import {
-  Alert,
   Button,
   DropdownMenu,
   DropdownMenuContent,
@@ -319,8 +318,9 @@ const LogTable = ({
     </div>
   )
 
-  const renderErrorAlert = () => {
+  const RenderErrorAlert = () => {
     if (!error) return null
+
     const childProps = {
       isCustomQuery: queryType ? false : true,
       error: error!,
@@ -334,19 +334,17 @@ const LogTable = ({
     }
 
     return (
-      <div className="flex w-1/2 justify-center px-5">
-        <Alert variant="danger" title="Sorry! An error occurred when fetching data." withIcon>
-          <Renderer {...childProps} />
-        </Alert>
+      <div className="text-foreground flex gap-2 font-mono px-6">
+        <Renderer {...childProps} />
       </div>
     )
   }
 
-  const renderNoResultAlert = () => {
+  const RenderNoResultAlert = () => {
     if (emptyState) return emptyState
     else
       return (
-        <div className="flex scale-100 flex-col items-center justify-center gap-6 text-center opacity-100">
+        <div className="flex scale-100 flex-col items-center justify-center gap-6 text-center opacity-100 h-full">
           <div className="flex flex-col gap-1">
             <div className="relative flex h-4 w-32 items-center rounded border border-dashed border-stronger px-2" />
             <div className="relative flex h-4 w-32 items-center rounded border border-dashed border-stronger px-2" />
@@ -401,9 +399,9 @@ const LogTable = ({
             renderers={{
               renderRow: RowRenderer,
               noRowsFallback: !isLoading ? (
-                <div className="mx-auto flex h-full items-center justify-center space-y-12 py-4 transition-all delay-200 duration-500">
-                  {!error && renderNoResultAlert()}
-                  {error && renderErrorAlert()}
+                <div className="">
+                  {logDataRows.length === 0 && !error && <RenderNoResultAlert />}
+                  {error && <RenderErrorAlert />}
                 </div>
               ) : null,
             }}

--- a/apps/studio/components/interfaces/Settings/Logs/LogTable.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogTable.tsx
@@ -33,7 +33,7 @@ import FunctionsLogsColumnRender from './LogColumnRenderers/FunctionsLogsColumnR
 import LogSelection, { LogSelectionProps } from './LogSelection'
 import type { LogData, LogQueryError, QueryType } from './Logs.types'
 import { isDefaultLogPreviewFormat } from './Logs.utils'
-import DefaultErrorRenderer from './LogsErrorRenderers/DefaultErrorRenderer'
+import { DefaultErrorRenderer } from './LogsErrorRenderers/DefaultErrorRenderer'
 import ResourcesExceededErrorRenderer from './LogsErrorRenderers/ResourcesExceededErrorRenderer'
 
 interface Props {
@@ -325,17 +325,17 @@ const LogTable = ({
       isCustomQuery: queryType ? false : true,
       error: error!,
     }
-    let Renderer = DefaultErrorRenderer
+
     if (
       typeof error === 'object' &&
       error.error?.errors.find((err) => err.reason === 'resourcesExceeded')
     ) {
-      Renderer = ResourcesExceededErrorRenderer
+      return <ResourcesExceededErrorRenderer {...childProps} />
     }
 
     return (
       <div className="text-foreground flex gap-2 font-mono px-6">
-        <Renderer {...childProps} />
+        <DefaultErrorRenderer {...childProps} />
       </div>
     )
   }

--- a/apps/studio/components/interfaces/Settings/Logs/Logs.utils.ts
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.utils.ts
@@ -532,3 +532,11 @@ const _getTruncation = (date: Dayjs) => {
   }[zeroCount]!
   return truncation
 }
+
+export function checkForWithClause(query: string) {
+  const queryWithoutComments = query.replace(/--.*$/gm, '').replace(/\/\*[\s\S]*?\*\//gm, '')
+
+  // Check for WITH clause, ensuring it's not inside a string literal
+  const withClauseRegex = /\b(WITH)\b(?=(?:[^']*'[^']*')*[^']*$)/i
+  return withClauseRegex.test(queryWithoutComments)
+}

--- a/apps/studio/components/interfaces/Settings/Logs/Logs.utils.ts
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.utils.ts
@@ -546,3 +546,11 @@ export function checkForILIKEClause(query: string) {
   const ilikeClauseRegex = /\b(ILIKE)\b(?=(?:[^']*'[^']*')*[^']*$)/i
   return ilikeClauseRegex.test(queryWithoutComments)
 }
+
+export function checkForWildcard(query: string) {
+  const queryWithoutComments = query.replace(/--.*$/gm, '').replace(/\/\*[\s\S]*?\*\//gm, '')
+  console.log(queryWithoutComments)
+
+  const wildcardRegex = /\*/
+  return wildcardRegex.test(queryWithoutComments)
+}

--- a/apps/studio/components/interfaces/Settings/Logs/Logs.utils.ts
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.utils.ts
@@ -549,7 +549,6 @@ export function checkForILIKEClause(query: string) {
 
 export function checkForWildcard(query: string) {
   const queryWithoutComments = query.replace(/--.*$/gm, '').replace(/\/\*[\s\S]*?\*\//gm, '')
-  console.log(queryWithoutComments)
 
   const wildcardRegex = /\*/
   return wildcardRegex.test(queryWithoutComments)

--- a/apps/studio/components/interfaces/Settings/Logs/Logs.utils.ts
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.utils.ts
@@ -536,7 +536,13 @@ const _getTruncation = (date: Dayjs) => {
 export function checkForWithClause(query: string) {
   const queryWithoutComments = query.replace(/--.*$/gm, '').replace(/\/\*[\s\S]*?\*\//gm, '')
 
-  // Check for WITH clause, ensuring it's not inside a string literal
   const withClauseRegex = /\b(WITH)\b(?=(?:[^']*'[^']*')*[^']*$)/i
   return withClauseRegex.test(queryWithoutComments)
+}
+
+export function checkForILIKEClause(query: string) {
+  const queryWithoutComments = query.replace(/--.*$/gm, '').replace(/\/\*[\s\S]*?\*\//gm, '')
+
+  const ilikeClauseRegex = /\b(ILIKE)\b(?=(?:[^']*'[^']*')*[^']*$)/i
+  return ilikeClauseRegex.test(queryWithoutComments)
 }

--- a/apps/studio/components/interfaces/Settings/Logs/LogsErrorRenderers/DefaultErrorRenderer.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogsErrorRenderers/DefaultErrorRenderer.tsx
@@ -1,16 +1,15 @@
-import { CodeBlock, Input } from 'ui'
+import { CodeBlock } from 'ui'
 import type { LogQueryError } from '../Logs.types'
-import { Label } from '@ui/components/shadcn/ui/label'
 
 export interface ErrorRendererProps {
   error: LogQueryError
   isCustomQuery: boolean
 }
 
-const DefaultErrorRenderer: React.FC<ErrorRendererProps> = ({ error }) => (
-  <div className="flex w-full flex-col gap-2 prose min-w-full">
-    <Label>Error</Label>
+export const DefaultErrorRenderer: React.FC<ErrorRendererProps> = ({ error }) => (
+  <div className="w-full prose min-w-full text-foreground text-sm">
     <CodeBlock
+      title="Error fetching logs"
       language="json"
       hideLineNumbers
       value={typeof error === 'string' ? error : JSON.stringify(error, null, 2)}
@@ -18,4 +17,3 @@ const DefaultErrorRenderer: React.FC<ErrorRendererProps> = ({ error }) => (
     />
   </div>
 )
-export default DefaultErrorRenderer

--- a/apps/studio/components/interfaces/Settings/Logs/LogsErrorRenderers/DefaultErrorRenderer.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogsErrorRenderers/DefaultErrorRenderer.tsx
@@ -1,5 +1,6 @@
-import { Input } from 'ui'
+import { CodeBlock, Input } from 'ui'
 import type { LogQueryError } from '../Logs.types'
+import { Label } from '@ui/components/shadcn/ui/label'
 
 export interface ErrorRendererProps {
   error: LogQueryError
@@ -7,13 +8,14 @@ export interface ErrorRendererProps {
 }
 
 const DefaultErrorRenderer: React.FC<ErrorRendererProps> = ({ error }) => (
-  <Input.TextArea
-    size="tiny"
-    value={typeof error === 'string' ? error : JSON.stringify(error, null, 2)}
-    borderless
-    className="mt-4 w-full font-mono"
-    copy
-    rows={7}
-  />
+  <div className="flex w-full flex-col gap-2 prose min-w-full">
+    <Label>Error</Label>
+    <CodeBlock
+      language="json"
+      hideLineNumbers
+      value={typeof error === 'string' ? error : JSON.stringify(error, null, 2)}
+      className="w-full font-mono"
+    />
+  </div>
 )
 export default DefaultErrorRenderer

--- a/apps/studio/components/interfaces/Settings/Logs/LogsErrorRenderers/LogsErrorRenderers.stories.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogsErrorRenderers/LogsErrorRenderers.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 
-import DefaultErrorRenderer from './DefaultErrorRenderer'
+import { DefaultErrorRenderer } from './DefaultErrorRenderer'
 import ResourcesExceededErrorRenderer from './ResourcesExceededErrorRenderer'
 import { Alert } from 'ui'
 

--- a/apps/studio/hooks/analytics/useLogsQuery.tsx
+++ b/apps/studio/hooks/analytics/useLogsQuery.tsx
@@ -13,6 +13,7 @@ import type {
 } from 'components/interfaces/Settings/Logs/Logs.types'
 import { get, isResponseOk } from 'lib/common/fetch'
 import { API_URL } from 'lib/constants'
+import { checkForWithClause } from 'components/interfaces/Settings/Logs/Logs.utils'
 
 export interface LogsQueryHook {
   params: LogsEndpointParams
@@ -47,6 +48,8 @@ const useLogsQuery = (
 
   const queryParams = genQueryParams(params as any)
 
+  const usesWith = checkForWithClause(params.sql || '')
+
   const {
     data,
     error: rqError,
@@ -69,6 +72,12 @@ const useLogsQuery = (
 
   if (!error && data?.error) {
     error = data?.error
+  }
+  if (usesWith) {
+    error = {
+      message: 'The parser does not yet support WITH and subquery statements.',
+      docs: 'https://supabase.com/docs/guides/platform/advanced-log-filtering#the-with-keyword-and-subqueries-are-not-supported',
+    }
   }
   const changeQuery = (newQuery = '') => {
     setParams((prev) => ({ ...prev, sql: newQuery }))

--- a/apps/studio/hooks/analytics/useLogsQuery.tsx
+++ b/apps/studio/hooks/analytics/useLogsQuery.tsx
@@ -15,6 +15,7 @@ import { get, isResponseOk } from 'lib/common/fetch'
 import { API_URL } from 'lib/constants'
 import {
   checkForILIKEClause,
+  checkForWildcard,
   checkForWithClause,
 } from 'components/interfaces/Settings/Logs/Logs.utils'
 import { IS_PLATFORM } from 'common'
@@ -54,6 +55,7 @@ const useLogsQuery = (
 
   const usesWith = checkForWithClause(params.sql || '')
   const usesILIKE = checkForILIKEClause(params.sql || '')
+  const usesWildcard = checkForWildcard(params.sql || '')
 
   const {
     data,
@@ -89,7 +91,14 @@ const useLogsQuery = (
     if (usesILIKE) {
       error = {
         message: 'BigQuery does not support ILIKE. Use REGEXP_CONTAINS instead.',
-        docs: 'https://cloud.google.com/bigquery/docs/reference/standard-sql/string_functions#regexp_contains',
+        docs: 'https://supabase.com/docs/guides/platform/advanced-log-filtering#the-ilike-and-similar-to-keywords-are-not-supported',
+      }
+    }
+    if (usesWildcard) {
+      error = {
+        message:
+          'Wildcard (*) queries are not supported. Please remove the wildcard and try again.',
+        docs: 'https://supabase.com/docs/guides/platform/advanced-log-filtering#the-wildcard-operator--to-select-columns-is-not-supported',
       }
     }
   }

--- a/apps/studio/pages/project/[ref]/logs/explorer/index.tsx
+++ b/apps/studio/pages/project/[ref]/logs/explorer/index.tsx
@@ -27,6 +27,7 @@ import {
   LogsWarning,
 } from 'components/interfaces/Settings/Logs/Logs.types'
 import {
+  checkForWithClause,
   maybeShowUpgradePrompt,
   useEditorHints,
 } from 'components/interfaces/Settings/Logs/Logs.utils'
@@ -185,6 +186,12 @@ export const LogsExplorerPage: NextPageWithLayout = () => {
 
   const handleRun = (value?: string | React.MouseEvent<HTMLButtonElement>) => {
     const query = typeof value === 'string' ? value || editorValue : editorValue
+    const usesWith = checkForWithClause(query)
+
+    if (usesWith) {
+      toast.error('WITH clause is not supported in Log Explorer.')
+      return
+    }
 
     if (value && typeof value === 'string') {
       setEditorValue(value)

--- a/apps/studio/pages/project/[ref]/logs/explorer/index.tsx
+++ b/apps/studio/pages/project/[ref]/logs/explorer/index.tsx
@@ -27,7 +27,6 @@ import {
   LogsWarning,
 } from 'components/interfaces/Settings/Logs/Logs.types'
 import {
-  checkForWithClause,
   maybeShowUpgradePrompt,
   useEditorHints,
 } from 'components/interfaces/Settings/Logs/Logs.utils'

--- a/apps/studio/pages/project/[ref]/logs/explorer/index.tsx
+++ b/apps/studio/pages/project/[ref]/logs/explorer/index.tsx
@@ -186,12 +186,6 @@ export const LogsExplorerPage: NextPageWithLayout = () => {
 
   const handleRun = (value?: string | React.MouseEvent<HTMLButtonElement>) => {
     const query = typeof value === 'string' ? value || editorValue : editorValue
-    const usesWith = checkForWithClause(query)
-
-    if (usesWith) {
-      toast.error('WITH clause is not supported in Log Explorer.')
-      return
-    }
 
     if (value && typeof value === 'string') {
       setEditorValue(value)
@@ -304,7 +298,7 @@ export const LogsExplorerPage: NextPageWithLayout = () => {
   return (
     <div className="w-full h-full mx-auto">
       <ResizablePanelGroup
-        className="w-full h-full"
+        className="w-full h-full max-h-screen"
         direction="vertical"
         autoSaveId={LOCAL_STORAGE_KEYS.LOG_EXPLORER_SPLIT_SIZE}
       >
@@ -357,9 +351,10 @@ export const LogsExplorerPage: NextPageWithLayout = () => {
           )}
         </ResizablePanel>
         <ResizableHandle withHandle />
-        <ResizablePanel collapsible minSize={5} className="flex flex-col flex-grow">
+        <ResizablePanel collapsible minSize={5} className="overflow-auto">
           <LoadingOpacity active={isLoading}>
             <LogTable
+              maxHeight="100%"
               showHistogramToggle={false}
               onRun={handleRun}
               onSave={handleOnSave}
@@ -369,10 +364,11 @@ export const LogsExplorerPage: NextPageWithLayout = () => {
               error={error}
               projectRef={projectRef}
             />
+
+            <div className="flex flex-row justify-end mt-2">
+              <UpgradePrompt show={showUpgradePrompt} setShowUpgradePrompt={setShowUpgradePrompt} />
+            </div>
           </LoadingOpacity>
-          <div className="flex flex-row justify-end mt-2">
-            <UpgradePrompt show={showUpgradePrompt} setShowUpgradePrompt={setShowUpgradePrompt} />
-          </div>
         </ResizablePanel>
       </ResizablePanelGroup>
 

--- a/apps/studio/tests/pages/projects/LogTable.test.tsx
+++ b/apps/studio/tests/pages/projects/LogTable.test.tsx
@@ -235,29 +235,11 @@ test.each([
   ])
 })
 
-// [Terry] removing, doesn't look like the histogram is being rendered in the LogTable component anymore
-// test('toggle histogram', async () => {
-//   const mockFn = vi.fn()
-//   render(
-//     <LogTable
-//       projectRef="mockProjectRef" // Provide a mock value for projectRef
-//       params={{}} // Provide a mock value for params
-//       queryType={QueryType.Auth} // Provide a mock value for queryType
-//       onHistogramToggle={mockFn}
-//       isHistogramShowing={true}
-//     />
-//   )
-//   const toggle = await screen.getByText(/Histogram/)
-//   userEvent.click(toggle)
-//   expect(mockFn).toBeCalled()
-// })
-
 test('error message handling', async () => {
   // Render LogTable with error as a string
-  render(<LogTable projectRef="ref" params={{}} error="some \nstring" />)
-  await expect(screen.findByText('some \nstring')).rejects.toThrow()
-  await screen.findByDisplayValue(/some/)
-  await screen.findByDisplayValue(/string/)
+  render(<LogTable projectRef="ref" params={{}} error={'some error message'} />)
+
+  expect(screen.getByText(`some error message`)).toBeTruthy()
 
   // Rerender LogTable with error as null
   render(<LogTable projectRef="ref" params={{}} error={null} />)

--- a/apps/studio/tests/pages/projects/Logs.utils.test.ts
+++ b/apps/studio/tests/pages/projects/Logs.utils.test.ts
@@ -1,6 +1,7 @@
 import {
   checkForWithClause,
   checkForILIKEClause,
+  checkForWildcard,
 } from 'components/interfaces/Settings/Logs/Logs.utils'
 
 describe('checkForWithClause', () => {
@@ -74,5 +75,19 @@ describe('checkForILIKEClause', () => {
         'SELECT * FROM table WHERE column IN (SELECT * FROM subtable WHERE column ILIKE "%value%")'
       )
     ).toBe(true)
+  })
+})
+
+describe('checkForWildcard', () => {
+  test('basic queries', () => {
+    expect(checkForWildcard('SELECT * FROM table')).toBe(true)
+    expect(checkForWildcard('SELECT column FROM table')).toBe(false)
+  })
+
+  test('comments', () => {
+    expect(checkForWildcard('SELECT column FROM table -- *')).toBe(false)
+    expect(checkForWildcard('SELECT column FROM table /* * */')).toBe(false)
+    expect(checkForWildcard('-- *\nSELECT column FROM table')).toBe(false)
+    expect(checkForWildcard('/* * */\nSELECT column FROM table')).toBe(false)
   })
 })

--- a/apps/studio/tests/pages/projects/Logs.utils.test.ts
+++ b/apps/studio/tests/pages/projects/Logs.utils.test.ts
@@ -1,236 +1,38 @@
-import { fillTimeseries } from 'components/interfaces/Settings/Logs/Logs.utils'
-import dayjs from 'dayjs'
-import { isEqual } from 'lodash'
+import { checkForWithClause } from 'components/interfaces/Settings/Logs/Logs.utils'
 
-// describe.each(Object.values(LogsTableName))('%s', (table) => {
-//   const templates = SQL_FILTER_TEMPLATES[ table ];
-//   const stringTemplateKey = Object.keys(templates).find((key) => {
-//     if (typeof templates[ key ] === 'string' && key.split('.').length === 2) {
-//       return true;
-//     } else {
-//       false;
-//     }
-//   });
-//   const [ root, child ] = (stringTemplateKey || '').split('.');
-//   describe.skip.each([
-//     { filter: { search_query: '' } },
-//     { filter: { search_query: undefined } },
-//     { filter: {} },
-//     { filter: { search_query: '123test' }, contains: [ '123test' ] },
-//     //   test behavior with overrides
-//     {
-//       filter: { search_query: '123test', override: 'something' },
-//       contains: [ '123test', 'override', 'something' ],
-//     },
-//     {
-//       filter: { search_query: '', override: 'something' },
-//       contains: [ 'override', 'something' ],
-//     },
-//     {
-//       filter: { search_query: undefined, override: 'something' },
-//       contains: [ 'override', 'something' ],
-//     },
-//     {
-//       filter: { override: 'something' },
-//       contains: [ 'override', 'something' ],
-//     },
-//     {
-//       filter: { 'override.nested': 'something' },
-//       contains: [ 'override.nested', 'something' ],
-//     },
-//     // check for when string templates are set to false.
-//     ...(stringTemplateKey
-//       ? [
-//         {
-//           filter: { search_query: 'some-search-query', [ root ]: { [ child ]: false } },
-//           excludes: [ templates[ stringTemplateKey ], '()' ],
-//           contains: [ 'some-search-query' ],
-//         },
-//       ]
-//       : []),
-//   ])('generates sql for filter $filter', ({ filter, contains = [], excludes = [] }) => {
-//     test('generates query correctly', async () => {
-//       const generated = genDefaultQuery(table, filter);
-//       //   should not contain functions
-//       expect(generated).not.toMatch(/function[ A-Za-z_-]+\(.+\).+\{.+return.+\}/);
-//       expect(generated).not.toMatch(/\=\>|\$\{.+\}/);
-//       expect(generated).not.toContain('return');
-//       contains.forEach((str) => expect(generated).toContain(str));
-//       excludes.forEach((str) => expect(generated).not.toContain(str));
-//     });
-//     test('generated chart query should include filters', () => {
-//       const generated = genChartQuery(table, {}, { 'override.nested': 'something' });
-//       expect(generated).toContain('override.nested');
-//       expect(generated).toContain('something');
-//       expect(generated).toContain('timestamp_trunc');
-//     });
-//   });
-// });
+describe('checkForWithClause', () => {
+  test('basic queries', () => {
+    expect(checkForWithClause('SELECT * FROM table')).toBe(false)
+    expect(checkForWithClause('SELECT * FROM table WITH clause')).toBe(true)
+    expect(checkForWithClause('WITH test AS (SELECT * FROM table) SELECT * FROM test')).toBe(true)
+    expect(checkForWithClause('SELECT * FROM withsomething')).toBe(false)
+  })
 
-const base = dayjs().subtract(2, 'day')
-const baseIso = base.toISOString()
-// test.skip.each([
-//   {
-//     case: 'next start is after initial start',
-//     initial: [base.subtract(1, 'day').toISOString(), baseIso],
-//     next: [base.subtract(2, 'day').toISOString(), null],
-//     expected: [base.subtract(2, 'day').toISOString(), baseIso],
-//   },
-//   {
-//     case: 'next end is before initial start',
-//     initial: [base.subtract(1, 'day').toISOString(), baseIso],
-//     next: [null, base.subtract(2, 'day').toISOString()],
-//     expected: [base.subtract(3, 'day').toISOString(), base.subtract(2, 'day').toISOString()],
-//   },
-//   {
-//     case: 'next end is not before initial start',
-//     initial: [base.subtract(2, 'day').toISOString(), baseIso],
-//     next: [null, base.subtract(1, 'day').toISOString()],
-//     expected: [base.subtract(2, 'day').toISOString(), base.subtract(1, 'day').toISOString()],
-//   },
-// ])('ensure no timestamp conflict: $case', ({ initial, next, expected }) => {
-//   const result = ensureNoTimestampConflict(initial, next)
-//   expect(result[0]).toEqual(expected[0])
-//   expect(result[1]).toEqual(expected[1])
-// })
+  test('case sensitivity', () => {
+    expect(checkForWithClause('with test AS (SELECT * FROM table) SELECT * FROM test')).toBe(true)
+    expect(checkForWithClause('WiTh test AS (SELECT * FROM table) SELECT * FROM test')).toBe(true)
+  })
 
-// test for log trunc filling
-test.skip.each([
-  {
-    // truncate timestamp string from bigquery
-    case: 'bq utc timestamp, truncated minutely',
-    data: [
-      { timestamp: '2023-04-26T17:18:00', count: 123 },
-      { timestamp: '2023-04-26T17:20:00', count: 123 },
-    ],
-    // expected
-    len: 3,
-    includes: [{ timestamp: '2023-04-26T17:19:00.000Z', count: 0 }],
-  },
-  // hourly truncation
-  {
-    case: 'bq timestamp truncated hourly, different options',
-    data: [
-      { period: '2023-04-26T17:00:00.000Z', value: 123 },
-      { period: '2023-04-26T20:00:00.000Z', value: 123 },
-    ],
-    // expected
-    len: 4,
-    defaultVal: 1,
-    valKey: 'value',
-    tsKey: 'period',
-    includes: [
-      { period: '2023-04-26T18:00:00.000Z', value: 1 },
-      { period: '2023-04-26T19:00:00.000Z', value: 1 },
-    ],
-  },
-  // fill beyong data min/max
-  {
-    case: 'fill beyond min/max',
-    data: [],
-    len: 3,
-    min: '2023-04-26T18:00:00.000Z',
-    max: '2023-04-26T20:00:00.000Z',
-    includes: [
-      { timestamp: '2023-04-26T18:00:00.000Z', count: 0 },
-      { timestamp: '2023-04-26T19:00:00.000Z', count: 0 },
-      { timestamp: '2023-04-26T20:00:00.000Z', count: 0 },
-    ],
-  },
-  // fill multiple keys in one go
-  {
-    case: 'fill multiple keys when both not given',
-    data: [],
-    len: 2,
-    min: '2023-04-26T18:00:00.000Z',
-    max: '2023-04-26T19:00:00.000Z',
-    valKey: ['count', 'other'],
-    includes: [
-      { timestamp: '2023-04-26T18:00:00.000Z', count: 0, other: 0 },
-      { timestamp: '2023-04-26T19:00:00.000Z', count: 0, other: 0 },
-    ],
-  },
+  test('comments', () => {
+    expect(checkForWithClause('SELECT * FROM table -- WITH clause')).toBe(false)
+    expect(checkForWithClause('SELECT * FROM table /* WITH clause */')).toBe(false)
+    expect(checkForWithClause('-- WITH clause\nSELECT * FROM table')).toBe(false)
+    expect(checkForWithClause('/* WITH clause */\nSELECT * FROM table')).toBe(false)
+  })
 
-  {
-    case: 'truncation detection should check underlying data',
-    data: [
-      {
-        timestamp: '2023-05-18T00:00:00',
-        total_auth_requests: 4,
-        total_realtime_requests: 0,
-        total_rest_requests: 0,
-        total_storage_requests: 0,
-      },
-      {
-        timestamp: '2023-05-18T03:00:00',
-        total_auth_requests: 4,
-        total_realtime_requests: 0,
-        total_rest_requests: 0,
-        total_storage_requests: 0,
-      },
-      {
-        timestamp: '2023-05-18T07:00:00',
-        total_auth_requests: 4,
-        total_realtime_requests: 0,
-        total_rest_requests: 0,
-        total_storage_requests: 0,
-      },
-      {
-        timestamp: '2023-05-18T08:00:00',
-        total_auth_requests: 2,
-        total_realtime_requests: 0,
-        total_rest_requests: 0,
-        total_storage_requests: 0,
-      },
-      {
-        timestamp: '2023-05-18T09:00:00',
-        total_auth_requests: 2,
-        total_realtime_requests: 0,
-        total_rest_requests: 0,
-        total_storage_requests: 0,
-      },
-      {
-        timestamp: '2023-05-18T13:00:00',
-        total_auth_requests: 0,
-        total_realtime_requests: 0,
-        total_rest_requests: 0,
-        total_storage_requests: 0,
-      },
-      {
-        timestamp: '2023-05-18T16:00:00',
-        total_auth_requests: 0,
-        total_realtime_requests: 0,
-        total_rest_requests: 1,
-        total_storage_requests: 0,
-      },
-    ],
-    len: 24,
-    min: '2023-05-18T00:00:00',
-    max: '2023-05-18T23:00:00',
-    valKey: [
-      'total_auth_requests',
-      'total_realtime_requests',
-      'total_rest_requests',
-      'total_storage_requests',
-    ],
-    includes: [
-      {
-        // timestamp format is with higher precision and with tz
-        timestamp: '2023-05-18T14:00:00.000Z',
-        total_auth_requests: 0,
-        total_realtime_requests: 0,
-        total_rest_requests: 0,
-        total_storage_requests: 0,
-      },
-    ],
-  },
-])(
-  'fillTimeseries : $case',
-  ({ data, len, includes, min, max, tsKey = 'timestamp', valKey = 'count', defaultVal = 0 }) => {
-    const result = fillTimeseries(data, tsKey, valKey, defaultVal, min, max)
-    expect(result.length).toEqual(len)
-    for (const inc of includes) {
-      expect(result.find((d) => isEqual(d, inc))).toBeTruthy()
-    }
-  }
-)
+  test('string literals', () => {
+    expect(checkForWithClause("SELECT 'WITH' FROM table")).toBe(false)
+    expect(checkForWithClause("SELECT * FROM table WHERE column = 'WITH clause'")).toBe(false)
+  })
+
+  test('subqueries', () => {
+    expect(
+      checkForWithClause('SELECT * FROM (WITH subquery AS (SELECT 1) SELECT * FROM subquery)')
+    ).toBe(true)
+    expect(
+      checkForWithClause(
+        'SELECT * FROM table WHERE column IN (WITH subquery AS (SELECT 1) SELECT * FROM subquery)'
+      )
+    ).toBe(true)
+  })
+})

--- a/packages/ui/src/components/CodeBlock/CodeBlock.tsx
+++ b/packages/ui/src/components/CodeBlock/CodeBlock.tsx
@@ -3,7 +3,7 @@
 import { Check, Copy } from 'lucide-react'
 import { useTheme } from 'next-themes'
 import { Children, ReactNode, useState } from 'react'
-import * as CopyToClipboard from 'react-copy-to-clipboard'
+import { CopyToClipboard } from 'react-copy-to-clipboard'
 import { Light as SyntaxHighlighter, SyntaxHighlighterProps } from 'react-syntax-highlighter'
 import { cn } from '../../lib/utils/cn'
 import { Button } from '../Button/Button'


### PR DESCRIPTION
to test
go to logs explorer
try a query with a WITH/ILIKE/wildcard statement
should show new error and send you to docs.

```
WITH test AS
 select
 cast (timestamp as datetime) as timestamp,
  event_message,
  metadata
from postgres_logs
where
  NOT REGEXP_CONTAINS (event_message, 'n')
SELECT event_message FROM test;
``` 