### PR TITLE
fix: stricter validation of returnTo path

### DIFF
--- a/apps/studio/lib/gotrue.ts
+++ b/apps/studio/lib/gotrue.ts
@@ -64,7 +64,11 @@ export const getReturnToPath = (fallback = '/projects') => {
     // if no error, returnTo is a valid URL and NOT an internal page
     validReturnTo = fallback
   } catch (_) {
-    validReturnTo = returnTo
+    // check returnTo doesn't try trick the browser to redirect
+    // don't try sanitize, it is a losing battle. Go to fallback
+    // disallow anything that starts with /non-word-char+/ or non-char+/
+    const pattern = /^\/?[\W]+\//
+    validReturnTo = pattern.test(returnTo) ? fallback : returnTo
   }
 
   return validReturnTo + (remainingSearchParams ? `?${remainingSearchParams}` : '')


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

A `returnTo` path with `/%09/place.website` would cause the browser to redirect to place.website instead of staying on the studio.

## What is the new behavior?

Non-standard / invalid `returnTo` path will be replaced with the fallback path. This is the same behaviour as we have for a valid URL in the `returnTo`

## Additional context

For more payloads: https://github.com/cujanovic/Open-Redirect-Payloads/blob/master/Open-Redirect-payloads.txt

```
const fs = require('node:fs');
const readline = require('node:readline');

const rl = readline.createInterface({
  input: fs.createReadStream('Open-Redirect-payloads.txt'),
  crlfDelay: Infinity,
});

rl.on('line', (line) => {
    let searchParams = new URLSearchParams(`returnTo=${line}`)
    let returnTo = searchParams.get('returnTo')
    let fallback = "/projects"
    try {
        new URL(returnTo)
        console.log(fallback)
    } catch (_) {
        // check returnTo doesn't try trick the browser to redirect
        const pattern = /^\/?[\W]+\//
        validReturnTo = pattern.test(returnTo) ? fallback : returnTo
        console.log(validReturnTo)
    }
}); 
```

There are some that get through, such as `http://XY>.7d8T\205pZM@www.whitelisteddomain.tld @localdomain.pw/` but these do not lead to a redirect (break the router, but a refresh loads the dashboard). We could amend the pattern to `/^\/?[\W]+\/|^[\w]+:\/\//`, which feels a bit more brittle than it is worth. 
