### PR TITLE
Chore/disk mgt UI updates

### DIFF
--- a/apps/studio/components/interfaces/DiskManagement/DiskManagement.constants.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagement.constants.tsx
@@ -1,4 +1,5 @@
 import { PlanType } from 'data/subscriptions/org-subscription-query'
+import { AddonVariantId } from 'data/subscriptions/types'
 
 export enum DiskType {
   GP3 = 'gp3',
@@ -50,4 +51,30 @@ export const PLAN_DETAILS: Record<PlanType, PlanDetails> = {
   pro: { includedDiskGB: { gp3: 8, io2: 0 } },
   team: { includedDiskGB: { gp3: 8, io2: 0 } },
   enterprise: { includedDiskGB: { gp3: 8, io2: 0 } },
+}
+
+export const COMPUTE_SIZE_MAX_IOPS = {
+  ci_micro: 11800,
+  ci_small: 11800,
+  ci_medium: 11800,
+  ci_large: 4750,
+  ci_xlarge: 20000,
+  ci_2xlarge: 20000,
+  ci_4xlarge: 20000,
+  ci_8xlarge: 40000,
+  ci_12xlarge: 50000,
+  ci_16xlarge: 80000,
+}
+
+export const COMPUTE_SIZE_MAX_THROUGHPUT = {
+  ci_micro: 2085,
+  ci_small: 2085,
+  ci_medium: 2085,
+  ci_large: 4750,
+  ci_xlarge: 4750,
+  ci_2xlarge: 4750,
+  ci_4xlarge: 4750,
+  ci_8xlarge: 9500,
+  ci_12xlarge: 14250,
+  ci_16xlarge: 19000,
 }

--- a/apps/studio/components/interfaces/DiskManagement/DiskManagement.constants.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagement.constants.tsx
@@ -1,9 +1,17 @@
 import { PlanType } from 'data/subscriptions/org-subscription-query'
-import { AddonVariantId } from 'data/subscriptions/types'
 
 export enum DiskType {
   GP3 = 'gp3',
   IO2 = 'io2',
+}
+
+export const IOPS_RANGE = {
+  [DiskType.GP3]: { min: 3000, max: 16000 },
+  [DiskType.IO2]: { min: 100, max: 256000 },
+}
+
+export const THROUGHPUT_RANGE = {
+  [DiskType.GP3]: { min: 125, max: 1000 },
 }
 
 export const DISK_PRICING = {

--- a/apps/studio/components/interfaces/DiskManagement/DiskManagement.constants.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagement.constants.tsx
@@ -8,12 +8,12 @@ export enum DiskType {
 
 export const DISK_PRICING = {
   [DiskType.GP3]: {
-    storage: 0.125, // per GB per month
+    storage: 0.125, // per GiB per month
     iops: 0.024, // per IOPS per month, charged after 3000 IOPS
     throughput: 0.095, // per MB/s per month, charged after 125 MB/s
   },
   [DiskType.IO2]: {
-    storage: 0.195, // per GB per month
+    storage: 0.195, // per GiB per month
     iops: 0.119, // per IOPS per month
   },
 }

--- a/apps/studio/components/interfaces/DiskManagement/DiskManagement.constants.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagement.constants.tsx
@@ -75,14 +75,14 @@ export const COMPUTE_SIZE_MAX_IOPS = {
 }
 
 export const COMPUTE_SIZE_MAX_THROUGHPUT = {
-  ci_micro: 2085,
-  ci_small: 2085,
-  ci_medium: 2085,
-  ci_large: 4750,
-  ci_xlarge: 4750,
-  ci_2xlarge: 4750,
-  ci_4xlarge: 4750,
-  ci_8xlarge: 9500,
-  ci_12xlarge: 14250,
-  ci_16xlarge: 19000,
+  ci_micro: 260.625,
+  ci_small: 260.625,
+  ci_medium: 260.625,
+  ci_large: 593.75,
+  ci_xlarge: 593.75,
+  ci_2xlarge: 593.75,
+  ci_4xlarge: 593.75,
+  ci_8xlarge: 1187.5,
+  ci_12xlarge: 1781.25,
+  ci_16xlarge: 2375,
 }

--- a/apps/studio/components/interfaces/DiskManagement/DiskManagementPanelForm.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagementPanelForm.tsx
@@ -103,8 +103,9 @@ export function DiskManagementPanelForm() {
     })
 
   const { data: addons } = useProjectAddonsQuery({ projectRef })
-  const currentCompute = (addons?.selected_addons ?? []).find((x) => x.type === 'compute_instance')
-    ?.variant
+  const currentCompute = (addons?.selected_addons ?? []).find(
+    (x) => x.type === 'compute_instance'
+  )?.variant
   const maxIopsBasedOnCompute =
     COMPUTE_SIZE_MAX_IOPS[(currentCompute?.identifier ?? '') as keyof typeof COMPUTE_SIZE_MAX_IOPS]
 

--- a/apps/studio/components/interfaces/DiskManagement/DiskManagementPanelForm.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagementPanelForm.tsx
@@ -104,8 +104,9 @@ export function DiskManagementPanelForm() {
     })
 
   const { data: addons } = useProjectAddonsQuery({ projectRef })
-  const currentCompute = (addons?.selected_addons ?? []).find((x) => x.type === 'compute_instance')
-    ?.variant
+  const currentCompute = (addons?.selected_addons ?? []).find(
+    (x) => x.type === 'compute_instance'
+  )?.variant
   const maxIopsBasedOnCompute =
     COMPUTE_SIZE_MAX_IOPS[(currentCompute?.identifier ?? '') as keyof typeof COMPUTE_SIZE_MAX_IOPS]
   const maxThroughputBasedOnCompute =

--- a/apps/studio/components/interfaces/DiskManagement/DiskManagementPanelForm.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagementPanelForm.tsx
@@ -555,7 +555,14 @@ export function DiskManagementPanelForm() {
                   name="totalSize"
                   control={control}
                   render={({ field }) => (
-                    <FormItemLayout label="Disk Size" layout="horizontal">
+                    <FormItemLayout
+                      label="Disk Size"
+                      layout="horizontal"
+                      description={
+                        includedDiskGB > 0 &&
+                        `Your plan includes ${includedDiskGB} GiB of disk size for ${watchedStorageType}.`
+                      }
+                    >
                       <div className="mt-1 relative flex gap-2 items-center">
                         <div className="flex -space-x-px max-w-48">
                           <FormControl_Shadcn_>
@@ -589,7 +596,6 @@ export function DiskManagementPanelForm() {
                               animate={{ opacity: 1, scale: 1, x: 0 }}
                               exit={{ opacity: 0, scale: 0.95, x: -2 }}
                               transition={{ duration: 0.15 }}
-                              style={{ overflow: 'hidden' }}
                             >
                               <Button
                                 htmlType="button"
@@ -612,12 +618,6 @@ export function DiskManagementPanelForm() {
                             diskSizePrice.oldPrice !== diskSizePrice.newPrice
                           }
                         />
-                        {includedDiskGB > 0 && (
-                          <div className="text-xs text-foreground-light">
-                            Your plan includes {includedDiskGB} GiB of disk size for{' '}
-                            {watchedStorageType}.
-                          </div>
-                        )}
                       </div>
                     </FormItemLayout>
                   )}

--- a/apps/studio/components/interfaces/DiskManagement/DiskManagementPanelSchema.ts
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagementPanelSchema.ts
@@ -5,7 +5,7 @@ const baseSchema = z.object({
   totalSize: z
     .number()
     .min(8, { message: 'Allocated disk size must be at least 8 GiB.' })
-    .max(16384, { message: 'Allocated disk size must not exceed 16 TiB.' })
+    .max(16384, { message: 'Allocated disk size must not exceed 16,384 GiB.' })
     .describe('Allocated disk size in GiB'),
   provisionedIOPS: z.number().describe('Provisioned IOPS for storage type'),
   throughput: z.number().optional().describe('Throughput in MiBps for gp3'),
@@ -20,14 +20,14 @@ export const DiskStorageSchema = baseSchema.superRefine((data, ctx) => {
     if (provisionedIOPS < 100) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: 'Provisioned IOPS must be at least 100 for io2.',
+        message: 'Provisioned IOPS must be at least 100',
         path: ['provisionedIOPS'],
       })
     } else if (provisionedIOPS > maxIOPS) {
       if (totalSize >= 8) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
-          message: `Provisioned IOPS must be at most ${maxIOPS} for io2.`,
+          message: `Provisioned IOPS must be at most ${maxIOPS}.`,
           path: ['provisionedIOPS'],
         })
       } else {
@@ -53,14 +53,14 @@ export const DiskStorageSchema = baseSchema.superRefine((data, ctx) => {
     if (provisionedIOPS < 3000) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: `Provisioned IOPS must be at least 3000 for gp3.`,
+        message: `Provisioned IOPS must be at least 3000`,
         path: ['provisionedIOPS'],
       })
     } else if (provisionedIOPS > maxIOPS) {
       if (totalSize >= 8) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
-          message: `Provisioned IOPS must be at most ${maxIOPS} for gp3.`,
+          message: `Provisioned IOPS must be at most ${maxIOPS}`,
           path: ['provisionedIOPS'],
         })
       } else {

--- a/apps/studio/components/interfaces/DiskManagement/DiskSpaceBar.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/DiskSpaceBar.tsx
@@ -5,9 +5,6 @@ import { useState } from 'react'
 import {
   badgeVariants,
   cn,
-  HoverCard,
-  HoverCardContent,
-  HoverCardTrigger,
   Tooltip_Shadcn_,
   TooltipContent_Shadcn_,
   TooltipTrigger_Shadcn_,
@@ -26,8 +23,6 @@ export default function DiskSpaceBar({
   usedSize,
   newTotalSize,
 }: DiskSpaceBarProps) {
-  //   const [totalSize, setTotalSize] = useState<number>(8) // 8 GB total disk size
-  //   const [usedSize, setUsedSize] = useState<number>(4) // Starting with 4 GB used (50% usage)
   const [resizeThreshold, setResizeThreshold] = useState<number>(0.5) // 500 MB threshold for resize
 
   const usedPercentage = (usedSize / totalSize) * 100
@@ -42,7 +37,7 @@ export default function DiskSpaceBar({
     <div className="flex flex-col gap-2">
       <div className="flex items-center h-6 gap-3">
         <span className="text-foreground-light text-sm font-mono flex items-center gap-2">
-          {usedSize.toFixed(2)} GB used of{' '}
+          {usedSize.toFixed(2)} GiB used of{' '}
           <span className="text-foreground font-semibold -mt-[2px]">
             <MotionNumber
               value={newTotalSize}
@@ -53,7 +48,7 @@ export default function DiskSpaceBar({
               className="font-mono"
             />
           </span>{' '}
-          GB
+          GiB
         </span>
       </div>
       <div className="relative">


### PR DESCRIPTION
- Refrain from using "GB", all to use "GiB"
- Refrain from using "TiB", all to use "GiB"
- Add note to IOPS input field RE final usable IOPS, if value exceeds the max IOPS supported by the current compute size
- Adjust language for IOPS and Throughput fields to be more accurate regarding their max values, and added tooltips for more details and clarity