### PR TITLE
Fix styling on SSL switch

### DIFF
--- a/apps/studio/components/interfaces/Settings/Database/SSLConfiguration.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/SSLConfiguration.tsx
@@ -131,17 +131,20 @@ const SSLConfiguration = () => {
               {isSuccess && (
                 <Tooltip_Shadcn_>
                   <TooltipTrigger_Shadcn_ asChild>
-                    <Switch
-                      size="large"
-                      checked={isEnforced}
-                      disabled={
-                        isLoading ||
-                        isSubmitting ||
-                        !canUpdateSSLEnforcement ||
-                        !hasAccessToSSLEnforcement
-                      }
-                      onCheckedChange={toggleSSLEnforcement}
-                    />
+                    {/* [Joshen] Added div as tooltip is messing with data state property of toggle */}
+                    <div>
+                      <Switch
+                        size="large"
+                        checked={isEnforced}
+                        disabled={
+                          isLoading ||
+                          isSubmitting ||
+                          !canUpdateSSLEnforcement ||
+                          !hasAccessToSSLEnforcement
+                        }
+                        onCheckedChange={toggleSSLEnforcement}
+                      />
+                    </div>
                   </TooltipTrigger_Shadcn_>
                   {(!canUpdateSSLEnforcement || !hasAccessToSSLEnforcement) && (
                     <TooltipContent_Shadcn_ side="bottom" className="w-64 text-center">


### PR DESCRIPTION
Tooltip parent was messing with data-state property of the switch component