### PR TITLE
fix(ai): restrict edge function regions

### DIFF
--- a/apps/studio/pages/api/ai/sql/generate-v2.ts
+++ b/apps/studio/pages/api/ai/sql/generate-v2.ts
@@ -3,7 +3,34 @@ import { chatSql } from 'ai-commands/edge'
 import { NextRequest } from 'next/server'
 import OpenAI from 'openai'
 
-export const runtime = 'edge'
+export const config = {
+  runtime: 'edge',
+  /* To avoid OpenAI errors, restrict to the Vercel Edge Function regions that
+  overlap with the OpenAI API regions.
+  
+  Reference for Vercel regions: https://vercel.com/docs/edge-network/regions#region-list
+  Reference for OpenAI regions: https://help.openai.com/en/articles/5347006-openai-api-supported-countries-and-territories
+  */
+  regions: [
+    'arn1',
+    'bom1',
+    'cdg1',
+    'cle1',
+    'cpt1',
+    'dub1',
+    'fra1',
+    'gru1',
+    'hnd1',
+    'iad1',
+    'icn1',
+    'kix1',
+    'lhr1',
+    'pdx1',
+    'sfo1',
+    'sin1',
+    'syd1',
+  ],
+}
 
 const openAiKey = process.env.OPENAI_API_KEY
 

--- a/apps/studio/pages/api/ai/sql/suggest.ts
+++ b/apps/studio/pages/api/ai/sql/suggest.ts
@@ -3,7 +3,34 @@ import { chatRlsPolicy } from 'ai-commands/edge'
 import { NextRequest } from 'next/server'
 import OpenAI from 'openai'
 
-export const runtime = 'edge'
+export const config = {
+  runtime: 'edge',
+  /* To avoid OpenAI errors, restrict to the Vercel Edge Function regions that
+  overlap with the OpenAI API regions.
+  
+  Reference for Vercel regions: https://vercel.com/docs/edge-network/regions#region-list
+  Reference for OpenAI regions: https://help.openai.com/en/articles/5347006-openai-api-supported-countries-and-territories
+  */
+  regions: [
+    'arn1',
+    'bom1',
+    'cdg1',
+    'cle1',
+    'cpt1',
+    'dub1',
+    'fra1',
+    'gru1',
+    'hnd1',
+    'iad1',
+    'icn1',
+    'kix1',
+    'lhr1',
+    'pdx1',
+    'sfo1',
+    'sin1',
+    'syd1',
+  ],
+}
 
 const openAiKey = process.env.OPENAI_API_KEY
 


### PR DESCRIPTION
Missed some routes when restricting edge function regions in an earlier PR. Any edge function that calls OpenAI needs to be called from an OpenAI-supported region.