### PR TITLE
fix: error on invalid mime types

### DIFF
--- a/apps/studio/components/to-be-cleaned/Storage/StorageExplorer/FileExplorerHeader.tsx
+++ b/apps/studio/components/to-be-cleaned/Storage/StorageExplorer/FileExplorerHeader.tsx
@@ -7,6 +7,20 @@ import { useIsAPIDocsSidePanelEnabled } from 'components/interfaces/App/FeatureP
 import APIDocsButton from 'components/ui/APIDocsButton'
 import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { useStorageStore } from 'localStores/storageExplorer/StorageExplorerStore'
+import {
+  Check,
+  ChevronLeft,
+  ChevronRight,
+  Columns,
+  Edit2,
+  FolderPlus,
+  List,
+  Loader,
+  RefreshCw,
+  Search,
+  Upload,
+  X,
+} from 'lucide-react'
 import { useStorageExplorerStateSnapshot } from 'state/storage-explorer'
 import {
   Button,
@@ -19,22 +33,8 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
   Input,
-  Upload,
 } from 'ui'
 import { STORAGE_SORT_BY, STORAGE_SORT_BY_ORDER, STORAGE_VIEWS } from '../Storage.constants'
-import {
-  Loader,
-  Edit2,
-  ChevronRight,
-  ChevronLeft,
-  RefreshCw,
-  List,
-  Columns,
-  Check,
-  FolderPlus,
-  Search,
-  X,
-} from 'lucide-react'
 
 const VIEW_OPTIONS = [
   { key: STORAGE_VIEWS.COLUMNS, name: 'As columns' },

--- a/apps/studio/localStores/storageExplorer/StorageExplorerStore.tsx
+++ b/apps/studio/localStores/storageExplorer/StorageExplorerStore.tsx
@@ -1,6 +1,17 @@
 import { SupabaseClient, createClient } from '@supabase/supabase-js'
 import { BlobReader, BlobWriter, ZipWriter } from '@zip.js/zip.js'
-import { chunk, compact, find, findIndex, has, isEqual, isObject, uniq, uniqBy } from 'lodash'
+import {
+  capitalize,
+  chunk,
+  compact,
+  find,
+  findIndex,
+  has,
+  isEqual,
+  isObject,
+  uniq,
+  uniqBy,
+} from 'lodash'
 import { makeAutoObservable } from 'mobx'
 import { toast } from 'sonner'
 import * as tus from 'tus-js-client'
@@ -682,21 +693,6 @@ class StorageExplorerStore {
 
       return () => {
         return new Promise<void>(async (resolve, reject) => {
-          // Check if the mime type is NOT allowed
-          if (
-            !(
-              this.selectedBucket.allowed_mime_types &&
-              metadata.mimetype &&
-              this.selectedBucket.allowed_mime_types.includes(metadata.mimetype)
-            )
-          ) {
-            numberOfFilesUploadedFail += 1
-            toast.error(`Failed to upload ${file.name}: ${metadata.mimetype} is not allowed`, {
-              description: `Allowed MIME types: ${this.selectedBucket.allowed_mime_types?.join(', ')}`,
-            })
-            return reject(new Error(`Invalid file type: ${metadata.mimetype} is not allowed`))
-          }
-
           const fileSizeInMB = file.size / (1024 * 1024)
           const startTime = Date.now()
 
@@ -737,13 +733,29 @@ class StorageExplorerStore {
             chunkSize,
             onShouldRetry(error) {
               const status = error.originalResponse ? error.originalResponse.getStatus() : 0
-              const doNotRetryStatuses = [400, 403, 404, 409, 429]
+              const doNotRetryStatuses = [400, 403, 404, 409, 415, 429]
 
               return !doNotRetryStatuses.includes(status)
             },
-            onError(error) {
+            onError: (error) => {
               numberOfFilesUploadedFail += 1
-              toast.error(`Failed to upload ${file.name}: ${error.message}`)
+              if (
+                error instanceof tus.DetailedError &&
+                error.originalResponse?.getStatus() === 415
+              ) {
+                // Unsupported mime type
+                toast.error(
+                  capitalize(
+                    error.originalResponse.getBody() ??
+                      `Failed to upload ${file.name}: ${metadata.mimetype} is not allowed`
+                  ),
+                  {
+                    description: `Allowed MIME types: ${this.selectedBucket.allowed_mime_types?.join(', ')}`,
+                  }
+                )
+              } else {
+                toast.error(`Failed to upload ${file.name}: ${error.message}`)
+              }
               reject(error)
             },
             onProgress: (bytesSent, bytesTotal) => {

--- a/apps/studio/localStores/storageExplorer/StorageExplorerStore.tsx
+++ b/apps/studio/localStores/storageExplorer/StorageExplorerStore.tsx
@@ -682,6 +682,21 @@ class StorageExplorerStore {
 
       return () => {
         return new Promise<void>(async (resolve, reject) => {
+          // Check if the mime type is NOT allowed
+          if (
+            !(
+              this.selectedBucket.allowed_mime_types &&
+              metadata.mimetype &&
+              this.selectedBucket.allowed_mime_types.includes(metadata.mimetype)
+            )
+          ) {
+            numberOfFilesUploadedFail += 1
+            toast.error(`Failed to upload ${file.name}: ${metadata.mimetype} is not allowed`, {
+              description: `Allowed MIME types: ${this.selectedBucket.allowed_mime_types?.join(', ')}`,
+            })
+            return reject(new Error(`Invalid file type: ${metadata.mimetype} is not allowed`))
+          }
+
           const fileSizeInMB = file.size / (1024 * 1024)
           const startTime = Date.now()
 

--- a/apps/studio/localStores/storageExplorer/StorageExplorerStore.tsx
+++ b/apps/studio/localStores/storageExplorer/StorageExplorerStore.tsx
@@ -746,7 +746,7 @@ class StorageExplorerStore {
                 // Unsupported mime type
                 toast.error(
                   capitalize(
-                    error.originalResponse.getBody() ??
+                    error.originalResponse.getBody() ||
                       `Failed to upload ${file.name}: ${metadata.mimetype} is not allowed`
                   ),
                   {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

If an invalid mime type is uploaded, the storage explorer will continually retry.

## What is the new behavior?

<img width="435" alt="Screenshot 2024-09-17 at 15 07 03" src="https://github.com/user-attachments/assets/4fd078cc-495f-4403-92e5-4d5c9886808b">
