### PR TITLE
chore: document atomic function.enabled config flag

### DIFF
--- a/apps/docs/spec/cli_v1_config.yaml
+++ b/apps/docs/spec/cli_v1_config.yaml
@@ -760,6 +760,20 @@ parameters:
       - name: 'Auth Server configuration'
         link: 'https://supabase.com/docs/reference/auth'
 
+  - id: 'functions.function_name.enabled'
+    title: 'functions.<function_name>.enabled'
+    tags: ['edge-functions']
+    required: false
+    default: 'true'
+    description: |
+      Controls whether a function is deployed or served. When set to false,
+      the function will be skipped during deployment and won't be served locally.
+      This is useful for disabling demo functions or temporarily disabling a function
+      without removing its code.
+    links:
+      - name: '`supabase functions` CLI subcommands'
+        link: 'https://supabase.com/docs/reference/cli/supabase-functions'
+
   - id: 'functions.function_name.verify_jwt'
     title: 'functions.<function_name>.verify_jwt'
     tags: ['edge-functions']


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Add documentation for the new [function.function_name.enabled] flag for the config.toml

Related: https://github.com/supabase/cli/pull/2688

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
