### PR TITLE
fix: update http to https and pathname to include **

### DIFF
--- a/apps/docs/components/GuidesTableOfContents.tsx
+++ b/apps/docs/components/GuidesTableOfContents.tsx
@@ -121,7 +121,7 @@ const GuidesTableOfContents = ({
 
   if (!displayedList.length) return
 
-  const tocVideoPreview = `http://img.youtube.com/vi/${video}/0.jpg`
+  const tocVideoPreview = `https://img.youtube.com/vi/${video}/0.jpg`
 
   return (
     <div className={cn('border-l', 'thin-scrollbar overflow-y-auto', 'px-2', className)}>

--- a/apps/docs/lib/remotePatterns.js
+++ b/apps/docs/lib/remotePatterns.js
@@ -39,7 +39,7 @@ module.exports = [
     protocol: 'https',
     hostname: 'img.youtube.com',
     port: '',
-    pathname: '/vi/*',
+    pathname: '/vi/**',
   },
   {
     protocol: 'https',

--- a/apps/www/pages/partners/integrations/[slug].tsx
+++ b/apps/www/pages/partners/integrations/[slug].tsx
@@ -216,7 +216,7 @@ function Partner({
 
 const PartnerDetails = ({ partner }: { partner: Partner }) => {
   const videoThumbnail = partner.video
-    ? `http://img.youtube.com/vi/${partner.video}/0.jpg`
+    ? `https://img.youtube.com/vi/${partner.video}/0.jpg`
     : undefined
 
   return (


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Receive the following error when loading the Auth guides locally.  The linked error seems to suggest a pattern mismatch and modifying the pattern seems to patch the error
<img width="856" alt="image" src="https://github.com/user-attachments/assets/416db67e-0d4f-45a8-8c10-58a3a775934c">

- Also change two URLs from `http` to `https` for avoidance of doubt on pattern matching


## What is the current behavior?

Can't load Auth guides

## What is the new behavior?

Auth guides load


