### PR TITLE
feat(search index): add recent changelogs

### DIFF
--- a/apps/docs/scripts/fetch-discussion-categories.ts
+++ b/apps/docs/scripts/fetch-discussion-categories.ts
@@ -1,0 +1,52 @@
+/* eslint-disable turbo/no-undeclared-env-vars */
+import { createAppAuth } from '@octokit/auth-app'
+import { Octokit } from '@octokit/core'
+import dotenv from 'dotenv'
+
+dotenv.config()
+
+async function fetchDiscussionCategories(owner: string, repo: string) {
+  const octokit = new Octokit({
+    authStrategy: createAppAuth,
+    auth: {
+      appId: process.env.SEARCH_GITHUB_APP_ID,
+      installationId: process.env.SEARCH_GITHUB_APP_INSTALLATION_ID,
+      privateKey: process.env.SEARCH_GITHUB_APP_PRIVATE_KEY,
+    },
+  })
+
+  const query = `
+    query fetchDiscussionCategories($owner: String!, $repo: String!) {
+      repository(owner: $owner, name: $repo) {
+        discussionCategories(first: 100) {
+          nodes {
+            id
+            name
+          }
+        }
+      }
+    }
+  `
+
+  const { repository } = await octokit.graphql<{
+    repository: { discussionCategories: { nodes: { id: string; name: string }[] } }
+  }>(query, { owner, repo })
+  return repository.discussionCategories.nodes
+}
+
+async function main() {
+  const owner = 'supabase'
+  const repo = 'supabase'
+
+  try {
+    const categories = await fetchDiscussionCategories(owner, repo)
+    console.log('Discussion Categories:')
+    categories.forEach((category) => {
+      console.log(`ID: ${category.id}, Name: ${category.name}`)
+    })
+  } catch (error) {
+    console.error('Error fetching discussion categories:', error)
+  }
+}
+
+main()

--- a/apps/docs/scripts/search/sources/index.ts
+++ b/apps/docs/scripts/search/sources/index.ts
@@ -2,6 +2,7 @@ import {
   GitHubDiscussionLoader,
   type GitHubDiscussionSource,
   fetchDiscussions,
+  fetchDiscussionsSinceDate,
 } from './github-discussion'
 import { MarkdownLoader, type MarkdownSource } from './markdown'
 import { IntegrationLoader, type IntegrationSource, fetchPartners } from './partner-integrations'
@@ -110,6 +111,33 @@ export async function fetchSources() {
     )
   ).map((discussion) => new GitHubDiscussionLoader('supabase/supabase', discussion).load())
 
+  const oneYearAgo = new Date()
+  oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1)
+
+  const threeMonthsAgo = new Date()
+  threeMonthsAgo.setMonth(threeMonthsAgo.getMonth() - 3)
+
+  const githubChangeLogSources = (
+    await fetchDiscussionsSinceDate(
+      'supabase',
+      'supabase',
+      'DIC_kwDODMpXOc4CAFUr', // 'Changelog' category
+      {
+        orderBy: 'CREATED_AT',
+        sinceDate: oneYearAgo,
+      }
+    )
+  ).map((discussion) => {
+    if (
+      new Date(discussion.createdAt) < threeMonthsAgo &&
+      !discussion.labels.nodes.some((label) => label.name === 'persist-in-search')
+    ) {
+      discussion.ragIgnore = true
+    }
+
+    return new GitHubDiscussionLoader('supabase/supabase', discussion).load()
+  })
+
   const sources: SearchSource[] = (
     await Promise.all([
       openApiReferenceSource,
@@ -121,6 +149,7 @@ export async function fetchSources() {
       ktLibReferenceSource,
       cliReferenceSource,
       ...githubDiscussionSources,
+      ...githubChangeLogSources,
       ...partnerIntegrationSources,
       ...guideSources,
     ])


### PR DESCRIPTION
Include recent changelogs (from the past year) in the search index. To prevent the AI from responding with outdated information, changelogs from > 3 months ago are indexed (show up in search) but ignored for RAG (never sent as context). You can override this behavior by tagging your GitHub discussion with 'persist-in-search', which will keep it on the RAG inclusion list until it hits the 1-year search index expiry date.