### PR TITLE
Chore/notice banner for auth smtp changes

### DIFF
--- a/apps/studio/components/interfaces/App/AppBannerWrapper.tsx
+++ b/apps/studio/components/interfaces/App/AppBannerWrapper.tsx
@@ -30,7 +30,7 @@ const AppBannerWrapper = ({ children }: PropsWithChildren<{}>) => {
     <div className="min-h-full flex flex-col">
       <div className="flex-none">
         {ongoingIncident && <IncidentBanner />}
-        {true && <NoticeBanner />}
+        {showNoticeBanner && <NoticeBanner />}
         {profile !== undefined && <RestrictionBanner />}
       </div>
       {children}

--- a/apps/studio/components/interfaces/App/AppBannerWrapper.tsx
+++ b/apps/studio/components/interfaces/App/AppBannerWrapper.tsx
@@ -30,7 +30,7 @@ const AppBannerWrapper = ({ children }: PropsWithChildren<{}>) => {
     <div className="min-h-full flex flex-col">
       <div className="flex-none">
         {ongoingIncident && <IncidentBanner />}
-        {showNoticeBanner && <NoticeBanner />}
+        {true && <NoticeBanner />}
         {profile !== undefined && <RestrictionBanner />}
       </div>
       {children}

--- a/apps/studio/components/interfaces/App/AppBannerWrapperContext.tsx
+++ b/apps/studio/components/interfaces/App/AppBannerWrapperContext.tsx
@@ -3,74 +3,44 @@ import { PropsWithChildren, createContext, useContext, useEffect, useState } fro
 
 import { LOCAL_STORAGE_KEYS } from 'lib/constants'
 
-const PGBOUNCER_BANNER_KEY = LOCAL_STORAGE_KEYS.PGBOUNCER_IPV6_DEPRECATION_WARNING
-const VERCEL_BANNER_KEY = LOCAL_STORAGE_KEYS.VERCEL_IPV6_DEPRECATION_WARNING
-const DEFAULT_NOTICE_BANNER_KEY = LOCAL_STORAGE_KEYS.PGBOUNCER_DEPRECATION_WARNING
+const AUTH_SMTP_CHANGES_WARNING_KEY = LOCAL_STORAGE_KEYS.AUTH_SMTP_CHANGES_WARNING
 
-// [Joshen] Update this as and when we need to use the NoticeBanner
+// [Joshen] This file is meant to be dynamic - update this as and when we need to use the NoticeBanner
 
 type AppBannerContextType = {
-  ipv6BannerAcknowledged: boolean
-  pgbouncerBannerAcknowledged: string[]
-  vercelBannerAcknowledged: string[]
-  onUpdateAcknowledged: (key: 'ipv6' | 'pgbouncer' | 'vercel', value: boolean | string) => void
+  authSmtpBannerAcknowledged: string[]
+  onUpdateAcknowledged: (key: 'auth-smtp', value: boolean | string) => void
 }
 
 const AppBannerContext = createContext<AppBannerContextType>({
-  ipv6BannerAcknowledged: false,
-  pgbouncerBannerAcknowledged: [],
-  vercelBannerAcknowledged: [],
+  authSmtpBannerAcknowledged: [],
   onUpdateAcknowledged: noop,
 })
 
 export const useAppBannerContext = () => useContext(AppBannerContext)
 
 export const AppBannerContextProvider = ({ children }: PropsWithChildren<{}>) => {
-  const [ipv6BannerAcknowledged, setIpv6BannerAcknowledged] = useState(false)
-
-  // [Joshen] These will take a list of refs instead since they are project specific
-  // Comma separated strings, no spaces
-  const [pgbouncerBannerAcknowledged, setPgbouncerBannerAcknowledged] = useState<string[]>([])
-  const [vercelBannerAcknowledged, setVercelBannerAcknowledged] = useState<string[]>([])
+  // [Joshen] If project specific, can take a list of refs instead - comma separated strings, no spaces
+  // Otherwise just a boolean will be fine
+  const [authSmtpBannerAcknowledged, setAuthSmtpBannerAcknowledged] = useState<string[]>([])
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
-      setIpv6BannerAcknowledged(localStorage.getItem(DEFAULT_NOTICE_BANNER_KEY) === 'true')
-
-      const acknowledgedPbBouncerRefs = localStorage.getItem(PGBOUNCER_BANNER_KEY)?.split(',') ?? []
-      setPgbouncerBannerAcknowledged(acknowledgedPbBouncerRefs)
-
-      const acknowledgedVercelRefs = localStorage.getItem(VERCEL_BANNER_KEY)?.split(',') ?? []
-      setVercelBannerAcknowledged(acknowledgedVercelRefs)
+      const acknowledgedProjectRefs =
+        localStorage.getItem(AUTH_SMTP_CHANGES_WARNING_KEY)?.split(',') ?? []
+      setAuthSmtpBannerAcknowledged(acknowledgedProjectRefs)
     }
   }, [])
 
   const value = {
-    ipv6BannerAcknowledged,
-    pgbouncerBannerAcknowledged,
-    vercelBannerAcknowledged,
-    onUpdateAcknowledged: (key: 'ipv6' | 'pgbouncer' | 'vercel', value: boolean | string) => {
-      if (key === 'ipv6' && typeof value === 'boolean') {
+    authSmtpBannerAcknowledged,
+    onUpdateAcknowledged: (key: 'auth-smtp', value: boolean | string) => {
+      if (key === 'auth-smtp' && typeof value === 'string' && value.length > 0) {
+        const updatedRefs = authSmtpBannerAcknowledged.concat([value])
         if (typeof window !== 'undefined') {
-          window.localStorage.setItem(DEFAULT_NOTICE_BANNER_KEY, value.toString())
+          window.localStorage.setItem(AUTH_SMTP_CHANGES_WARNING_KEY, updatedRefs.join(','))
         }
-        setIpv6BannerAcknowledged(value)
-      }
-
-      if (key === 'pgbouncer' && typeof value === 'string' && value.length > 0) {
-        const updatedRefs = pgbouncerBannerAcknowledged.concat([value])
-        if (typeof window !== 'undefined') {
-          window.localStorage.setItem(PGBOUNCER_BANNER_KEY, updatedRefs.join(','))
-        }
-        setPgbouncerBannerAcknowledged(updatedRefs)
-      }
-
-      if (key === 'vercel' && typeof value === 'string' && value.length > 0) {
-        const updatedRefs = pgbouncerBannerAcknowledged.concat([value])
-        if (typeof window !== 'undefined') {
-          window.localStorage.setItem(VERCEL_BANNER_KEY, updatedRefs.join(','))
-        }
-        setVercelBannerAcknowledged(updatedRefs)
+        setAuthSmtpBannerAcknowledged(updatedRefs)
       }
     },
   }
@@ -79,7 +49,6 @@ export const AppBannerContextProvider = ({ children }: PropsWithChildren<{}>) =>
 }
 
 export const useIsNoticeBannerShown = () => {
-  const { ipv6BannerAcknowledged, pgbouncerBannerAcknowledged, vercelBannerAcknowledged } =
-    useAppBannerContext()
-  return ipv6BannerAcknowledged && pgbouncerBannerAcknowledged && vercelBannerAcknowledged
+  const { authSmtpBannerAcknowledged } = useAppBannerContext()
+  return authSmtpBannerAcknowledged
 }

--- a/apps/studio/components/interfaces/Auth/EmailRateLimitsAlert/EmailRateLimitsAlert.tsx
+++ b/apps/studio/components/interfaces/Auth/EmailRateLimitsAlert/EmailRateLimitsAlert.tsx
@@ -29,6 +29,8 @@ export function EmailRateLimitsAlert() {
           custom SMTP server
         </Link>
         .<br />
+      </AlertDescription_Shadcn_>
+      <AlertDescription_Shadcn_ className="mt-2">
         <strong>
           You will not be able to modify the email templates unless you've set up a custom SMTP
           server or Send Email Hook server, except if you had changed it before this restriction

--- a/apps/studio/components/layouts/AppLayout/NoticeBanner.tsx
+++ b/apps/studio/components/layouts/AppLayout/NoticeBanner.tsx
@@ -1,5 +1,3 @@
-import { useSupabaseClient } from '@supabase/auth-helpers-react'
-import { useQuery } from '@tanstack/react-query'
 import { ExternalLink } from 'lucide-react'
 import { useRouter } from 'next/router'
 
@@ -7,105 +5,51 @@ import { useParams } from 'common'
 import { useAppBannerContext } from 'components/interfaces/App/AppBannerWrapperContext'
 import { useProfile } from 'lib/profile'
 import { Button } from 'ui'
+import { useAuthConfigQuery } from 'data/auth/auth-config-query'
+import { isSmtpEnabled } from 'components/interfaces/Auth/SmtpForm/SmtpForm.utils'
 
-// [Joshen] For this notice specifically, just FYI
-// 1 month after 26th Jan we'll need to add some contextual information about this deprecation
-// in the database settings pooling config section, for projects created before September 27th 2023
+// This file, like AppBannerWrapperContext.tsx, is meant to be dynamic - update this as and when we need to use the NoticeBanner
+
+// [Joshen] As of 19th September 24, this notice is around custom SMTP
+// https://github.com/orgs/supabase/discussions/29370
+// Timelines TLDR:
+// - 20th September 2024: Email template customization no longer possible without setting up custom SMTP provider
+// - 24th September 2024: Projects without custom SMTP will have their custom email templates returned back to default ones
+// - 26th September 2024: If no custom SMTP, emails can only be sent to email addresses in your project's organization
+// We can probably look to disable this banner perhaps a month from 26th Sept 2024 - so maybe end of October 2024
 
 export const NoticeBanner = () => {
   const router = useRouter()
+  const { ref: projectRef } = useParams()
   const { isLoading: isLoadingProfile } = useProfile()
 
   const appBannerContext = useAppBannerContext()
-  const {
-    ipv6BannerAcknowledged,
-    pgbouncerBannerAcknowledged,
-    vercelBannerAcknowledged,
-    onUpdateAcknowledged,
-  } = appBannerContext
+  const { authSmtpBannerAcknowledged, onUpdateAcknowledged } = appBannerContext
 
-  const supabase = useSupabaseClient()
-  const { ref: projectRef } = useParams()
+  const { data: authConfig } = useAuthConfigQuery({ projectRef })
+  const smtpEnabled = isSmtpEnabled(authConfig)
 
-  // [Alaister]: using inline queries here since this is temporary
-  const { data, isLoading: isLoadingIpv6Enabled } = useQuery(
-    ['projects', projectRef, 'pgbouncer-enabled'],
-    async ({ signal }) => {
-      let query = supabase.rpc('ipv6_active_status', { project_ref: projectRef }).returns<
-        {
-          pgbouncer_active: boolean
-          vercel_active: boolean
-        }[]
-      >()
+  const acknowledged = authSmtpBannerAcknowledged.includes(projectRef ?? '')
 
-      if (signal) {
-        query = query.abortSignal(signal)
-      }
-
-      const result = await query
-
-      if (result.data === null) {
-        return {
-          pgbouncer_active: false,
-          vercel_active: false,
-        }
-      }
-
-      return result.data[0]
-    },
-    { enabled: Boolean(projectRef) }
-  )
-
-  const pgbouncerEnabled = data?.pgbouncer_active ?? false
-  const vercelWithoutSupavisorEnabled = data?.vercel_active ?? false
-
-  // [Joshen] Pgbouncer list and vercel list are mutually exclusive
-  const pgbouncerProjectAcknowledged = pgbouncerBannerAcknowledged.includes(projectRef ?? '')
-  const vercelProjectAcknowledged = vercelBannerAcknowledged.includes(projectRef ?? '')
-  const allAcknowledged =
-    (!pgbouncerEnabled && !vercelWithoutSupavisorEnabled && ipv6BannerAcknowledged) ||
-    (ipv6BannerAcknowledged && pgbouncerEnabled && pgbouncerProjectAcknowledged) ||
-    (ipv6BannerAcknowledged && vercelWithoutSupavisorEnabled && vercelProjectAcknowledged)
-
-  if (
-    isLoadingProfile ||
-    isLoadingIpv6Enabled ||
-    router.pathname.includes('sign-in') ||
-    allAcknowledged
-  ) {
+  if (isLoadingProfile || router.pathname.includes('sign-in') || smtpEnabled || acknowledged) {
     return null
   }
 
-  const currentlyViewing =
-    pgbouncerEnabled && !pgbouncerProjectAcknowledged
-      ? ('pgbouncer' as const)
-      : vercelWithoutSupavisorEnabled && !vercelProjectAcknowledged
-        ? ('vercel' as const)
-        : ('ipv6' as const)
-
   return (
     <div
-      className="flex items-center justify-center gap-x-4 bg-surface-100 py-3 transition text-foreground box-border border-b border-default"
       style={{ height: '44px' }}
+      className="flex items-center justify-center gap-x-4 bg-surface-100 py-3 transition text-foreground box-border border-b border-default"
     >
       <p className="text-sm">
-        {currentlyViewing === 'pgbouncer' &&
-          'Our logs on 26th Jan show that you have accessed PgBouncer. Please migrate now. You can ignore this warning if you have already migrated.'}
-        {currentlyViewing === 'vercel' &&
-          "To prepare for the IPv4 migration, please redeploy your Vercel application to detect the updated environment variables if it hasn't been deployed since 27th January."}
-        {currentlyViewing === 'ipv6' &&
-          'We are migrating our infrastructure from IPv4 to IPv6. Please migrate now. You can ignore this warning if you have already migrated.'}
+        Action required: Set up a custom SMTP provider, further restrictions will be imposed for the
+        default email provider
       </p>
       <div className="flex items-center gap-x-1">
         <Button asChild type="link" iconRight={<ExternalLink size={14} />}>
           <a
-            href={
-              currentlyViewing === 'vercel'
-                ? 'https://supabase.com/partners/integrations/vercel'
-                : 'https://github.com/orgs/supabase/discussions/17817'
-            }
             target="_blank"
             rel="noreferrer"
+            href="https://github.com/orgs/supabase/discussions/29370"
           >
             Learn more
           </a>
@@ -113,12 +57,9 @@ export const NoticeBanner = () => {
         <Button
           type="text"
           className="opacity-75"
-          onClick={() =>
-            onUpdateAcknowledged(
-              currentlyViewing,
-              currentlyViewing === 'ipv6' ? true : projectRef ?? ''
-            )
-          }
+          onClick={() => {
+            if (projectRef) onUpdateAcknowledged('auth-smtp', projectRef)
+          }}
         >
           Dismiss
         </Button>

--- a/apps/studio/components/layouts/AppLayout/NoticeBanner.tsx
+++ b/apps/studio/components/layouts/AppLayout/NoticeBanner.tsx
@@ -28,10 +28,17 @@ export const NoticeBanner = () => {
 
   const { data: authConfig } = useAuthConfigQuery({ projectRef })
   const smtpEnabled = isSmtpEnabled(authConfig)
+  const hasAuthEmailHookEnabled = authConfig?.HOOK_SEND_EMAIL_ENABLED
 
   const acknowledged = authSmtpBannerAcknowledged.includes(projectRef ?? '')
 
-  if (isLoadingProfile || router.pathname.includes('sign-in') || smtpEnabled || acknowledged) {
+  if (
+    isLoadingProfile ||
+    router.pathname.includes('sign-in') ||
+    smtpEnabled ||
+    hasAuthEmailHookEnabled ||
+    acknowledged
+  ) {
     return null
   }
 

--- a/apps/studio/lib/constants/index.ts
+++ b/apps/studio/lib/constants/index.ts
@@ -50,9 +50,6 @@ export const LOCAL_STORAGE_KEYS = {
   GRAPHIQL_RLS_BYPASS_WARNING: 'graphiql-rls-bypass-warning-dismissed',
   CLS_DIFF_WARNING: 'cls-diff-warning-dismissed',
   CLS_SELECT_STAR_WARNING: 'cls-select-star-warning-dismissed',
-  PGBOUNCER_IPV6_DEPRECATION_WARNING: 'pgbouncer-ipv6-deprecation-warning-dismissed',
-  VERCEL_IPV6_DEPRECATION_WARNING: 'vercel-ipv6-deprecation-warning-dismissed',
-  PGBOUNCER_DEPRECATION_WARNING: 'pgbouncer-deprecation-warning-dismissed',
   PROJECT_LINT_IGNORE_LIST: 'supabase-project-lint-ignore-list',
   QUERY_PERF_SHOW_BOTTOM_SECTION: 'supabase-query-perf-show-bottom-section',
   // Key to track account deletion requests
@@ -71,6 +68,8 @@ export const LOCAL_STORAGE_KEYS = {
   // Used for allowing the main nav panel to expand on hover
   EXPAND_NAVIGATION_PANEL: 'supabase-expand-navigation-panel',
   GITHUB_AUTHORIZATION_STATE: 'supabase-github-authorization-state',
+  // Notice banner keys
+  AUTH_SMTP_CHANGES_WARNING: 'auth-smtp-changes-warning-dismissed',
 }
 
 export const OPT_IN_TAGS = {


### PR DESCRIPTION
- Set up notice banner for auth SMTP changes 
  - only shows up if custom smtp has not been set up
  - dismissible on a per project basis
- Deprecate old notice banner stuffs to do with ipv6, pgbouncer etc etc

Relevant discussion: https://github.com/orgs/supabase/discussions/29370

![image](https://github.com/user-attachments/assets/50f154e9-70a7-4561-82aa-94717dcdcdc3)
