### PR TITLE
feat: allow removing multiple redirect urls

### DIFF
--- a/apps/studio/components/interfaces/Auth/RedirectUrls/RedirectUrlList.tsx
+++ b/apps/studio/components/interfaces/Auth/RedirectUrls/RedirectUrlList.tsx
@@ -1,8 +1,8 @@
 import { noop } from 'lodash'
-import { Button, Checkbox } from 'ui'
+import { Checkbox } from 'ui'
 import { EmptyListState } from 'components/ui/States'
 import ValueContainer from './ValueContainer'
-import { Globe, Trash } from 'lucide-react'
+import { Globe } from 'lucide-react'
 
 interface RedirectUrlListProps {
   URI_ALLOW_LIST_ARRAY: string[]
@@ -14,10 +14,8 @@ interface RedirectUrlListProps {
 
 const RedirectUrlList = ({
   URI_ALLOW_LIST_ARRAY,
-  canUpdate,
   selectedUrls,
   onSelectUrl = noop,
-  onSelectUrlToDelete = noop,
 }: RedirectUrlListProps) => {
   return (
     <div className="-space-y-px">
@@ -36,41 +34,22 @@ const RedirectUrlList = ({
                   onSelectUrl(newSelectedUrls)
                 }}
               >
-                <div className={`flex items-center gap-4 font-mono group`}>
+                <div className={`flex items-center gap-4 font-mono group w-full`}>
                   <div className="w-5 h-5 flex items-center justify-center">
-                    {isSelected ? (
-                      <Checkbox
-                        checked={isSelected}
-                        onChange={() => {
-                          const newSelectedUrls = selectedUrls.filter(
-                            (selectedUrl) => selectedUrl !== url
-                          )
-                          onSelectUrl(newSelectedUrls)
-                        }}
-                      />
-                    ) : (
-                      <span className="text-foreground-lighter group-hover:hidden">
-                        <Globe strokeWidth={2} size={14} />
-                      </span>
-                    )}
-                    {!isSelected && (
-                      <div className="hidden group-hover:block">
-                        <Checkbox
-                          checked={isSelected}
-                          onChange={() => {
-                            onSelectUrl([...selectedUrls, url])
-                          }}
-                        />
-                      </div>
-                    )}
+                    <span className="text-foreground-lighter">
+                      <Globe strokeWidth={2} size={14} />
+                    </span>
                   </div>
-                  <span className="text-sm">{url}</span>
+                  <span className="text-sm flex-grow">{url}</span>
+                  <div className="flex-shrink-0">
+                    <Checkbox
+                      checked={isSelected}
+                      onChange={() => {
+                        onSelectUrl([...selectedUrls, url])
+                      }}
+                    />
+                  </div>
                 </div>
-                {canUpdate && (
-                  <Button type="default" icon={<Trash />} onClick={() => onSelectUrlToDelete(url)}>
-                    Remove
-                  </Button>
-                )}
               </ValueContainer>
             )
           })}

--- a/apps/studio/components/interfaces/Auth/RedirectUrls/RedirectUrlList.tsx
+++ b/apps/studio/components/interfaces/Auth/RedirectUrls/RedirectUrlList.tsx
@@ -8,34 +8,50 @@ import { Globe, Trash } from 'lucide-react'
 interface RedirectUrlListProps {
   URI_ALLOW_LIST_ARRAY: string[]
   canUpdate: boolean
+  selectedUrls: string[]
+  onSelectUrl: (urls: string[]) => void
   onSelectUrlToDelete: (url: string) => void
 }
 
 const RedirectUrlList = ({
   URI_ALLOW_LIST_ARRAY,
   canUpdate,
+  selectedUrls,
+  onSelectUrl = noop,
   onSelectUrlToDelete = noop,
 }: RedirectUrlListProps) => {
   return (
     <div className="-space-y-px">
       {URI_ALLOW_LIST_ARRAY.length > 0 ? (
-        URI_ALLOW_LIST_ARRAY.map((url) => {
-          return (
-            <ValueContainer key={url}>
-              <div className="flex items-center gap-4 font-mono">
-                <span className="text-foreground-lighter">
-                  <Globe strokeWidth={2} size={14} />
-                </span>
-                <span className="text-sm">{url}</span>
-              </div>
-              {canUpdate && (
-                <Button type="default" icon={<Trash />} onClick={() => onSelectUrlToDelete(url)}>
-                  Remove
-                </Button>
-              )}
-            </ValueContainer>
-          )
-        })
+        <>
+          {URI_ALLOW_LIST_ARRAY.map((url) => {
+            const isSelected = selectedUrls.includes(url)
+            return (
+              <ValueContainer
+                key={url}
+                isSelected={isSelected}
+                onClick={() => {
+                  const newSelectedUrls = isSelected
+                    ? selectedUrls.filter((selectedUrl) => selectedUrl !== url)
+                    : [...selectedUrls, url]
+                  onSelectUrl(newSelectedUrls)
+                }}
+              >
+                <div className={`flex items-center gap-4 font-mono`}>
+                  <span className="text-foreground-lighter">
+                    <Globe strokeWidth={2} size={14} />
+                  </span>
+                  <span className="text-sm">{url}</span>
+                </div>
+                {canUpdate && (
+                  <Button type="default" icon={<Trash />} onClick={() => onSelectUrlToDelete(url)}>
+                    Remove
+                  </Button>
+                )}
+              </ValueContainer>
+            )
+          })}
+        </>
       ) : (
         <div
           className={[

--- a/apps/studio/components/interfaces/Auth/RedirectUrls/RedirectUrlList.tsx
+++ b/apps/studio/components/interfaces/Auth/RedirectUrls/RedirectUrlList.tsx
@@ -1,6 +1,5 @@
 import { noop } from 'lodash'
-import { Button } from 'ui'
-
+import { Button, Checkbox } from 'ui'
 import { EmptyListState } from 'components/ui/States'
 import ValueContainer from './ValueContainer'
 import { Globe, Trash } from 'lucide-react'
@@ -37,10 +36,34 @@ const RedirectUrlList = ({
                   onSelectUrl(newSelectedUrls)
                 }}
               >
-                <div className={`flex items-center gap-4 font-mono`}>
-                  <span className="text-foreground-lighter">
-                    <Globe strokeWidth={2} size={14} />
-                  </span>
+                <div className={`flex items-center gap-4 font-mono group`}>
+                  <div className="w-5 h-5 flex items-center justify-center">
+                    {isSelected ? (
+                      <Checkbox
+                        checked={isSelected}
+                        onChange={() => {
+                          const newSelectedUrls = selectedUrls.filter(
+                            (selectedUrl) => selectedUrl !== url
+                          )
+                          onSelectUrl(newSelectedUrls)
+                        }}
+                      />
+                    ) : (
+                      <span className="text-foreground-lighter group-hover:hidden">
+                        <Globe strokeWidth={2} size={14} />
+                      </span>
+                    )}
+                    {!isSelected && (
+                      <div className="hidden group-hover:block">
+                        <Checkbox
+                          checked={isSelected}
+                          onChange={() => {
+                            onSelectUrl([...selectedUrls, url])
+                          }}
+                        />
+                      </div>
+                    )}
+                  </div>
                   <span className="text-sm">{url}</span>
                 </div>
                 {canUpdate && (

--- a/apps/studio/components/interfaces/Auth/RedirectUrls/RedirectUrls.tsx
+++ b/apps/studio/components/interfaces/Auth/RedirectUrls/RedirectUrls.tsx
@@ -100,7 +100,9 @@ const RedirectUrls = () => {
           toast.error(`Failed to remove URL(s): ${error?.message}`)
         },
         onSuccess: () => {
+          setSelectedUrls([])
           setSelectedUrlToDelete(undefined)
+          setOpenRemoveSelected(false)
           toast.success('Successfully removed URL(s)')
         },
       }

--- a/apps/studio/components/interfaces/Auth/RedirectUrls/RedirectUrls.tsx
+++ b/apps/studio/components/interfaces/Auth/RedirectUrls/RedirectUrls.tsx
@@ -1,11 +1,12 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
-import { useParams } from 'common'
 import { ExternalLink, Trash } from 'lucide-react'
 import Link from 'next/link'
 import { useMemo, useState } from 'react'
 import { toast } from 'sonner'
 import { object, string } from 'yup'
 
+import { Label } from '@ui/components/shadcn/ui/label'
+import { useParams } from 'common'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import { FormHeader } from 'components/ui/Forms/FormHeader'
 import { HorizontalShimmerWithIcon } from 'components/ui/Shimmers/Shimmers'
@@ -19,15 +20,17 @@ import {
   Button,
   DialogSectionSeparator,
   Form,
-  Input,
   Modal,
   WarningIcon,
 } from 'ui'
+import { Input } from 'ui-patterns/DataInputs/Input'
 import { urlRegex } from '../Auth.constants'
-import RedirectUrlList from './RedirectUrlList'
-import ValueContainer from './ValueContainer'
+import { RedirectUrlList } from './RedirectUrlList'
+import { ValueContainer } from './ValueContainer'
+
 const MAX_URLS_LENGTH = 2 * 1024
-const RedirectUrls = () => {
+
+export const RedirectUrls = () => {
   const { ref: projectRef } = useParams()
   const {
     data: authConfig,
@@ -47,7 +50,6 @@ const RedirectUrls = () => {
   const [open, setOpen] = useState(false)
   const [openRemoveSelected, setOpenRemoveSelected] = useState(false)
   const [selectedUrls, setSelectedUrls] = useState<string[]>([])
-  const [selectedUrlToDelete, setSelectedUrlToDelete] = useState<string>()
 
   const canUpdateConfig = useCheckPermissions(PermissionAction.UPDATE, 'custom_config_gotrue')
 
@@ -101,7 +103,6 @@ const RedirectUrls = () => {
         },
         onSuccess: () => {
           setSelectedUrls([])
-          setSelectedUrlToDelete(undefined)
           setOpenRemoveSelected(false)
           toast.success('Successfully removed URL(s)')
         },
@@ -117,41 +118,51 @@ const RedirectUrls = () => {
           description={`URLs that auth providers are permitted to redirect to post authentication. Wildcards are allowed, for example, https://*.domain.com`}
         />
         <div className="flex items-center gap-2 mb-6 ml-12">
-          <Button asChild type="default" icon={<ExternalLink />}>
-            <Link
-              href="https://supabase.com/docs/guides/auth/concepts/redirect-urls"
-              target="_blank"
-              rel="noreferrer"
-            >
-              Documentation
-            </Link>
-          </Button>
-          <ButtonTooltip
-            type="default"
-            disabled={!canUpdateConfig}
-            tooltip={{
-              content: {
-                side: 'bottom',
-                text: 'You need additional permissions to remove redirect URLs',
-              },
-            }}
-            icon={<Trash />}
-            onClick={() => (selectedUrls.length > 0 ? setOpenRemoveSelected(true) : null)}
-          >
-            Remove ({selectedUrls.length})
-          </ButtonTooltip>
-          <ButtonTooltip
-            disabled={!canUpdateConfig}
-            onClick={() => setOpen(true)}
-            tooltip={{
-              content: {
-                side: 'bottom',
-                text: 'You need additional permissions to update redirect URLs',
-              },
-            }}
-          >
-            Add URL
-          </ButtonTooltip>
+          {selectedUrls.length > 0 ? (
+            <>
+              <Button type="default" onClick={() => setSelectedUrls([])}>
+                Clear selection
+              </Button>
+              <ButtonTooltip
+                type="default"
+                disabled={!canUpdateConfig}
+                tooltip={{
+                  content: {
+                    side: 'bottom',
+                    text: 'You need additional permissions to remove redirect URLs',
+                  },
+                }}
+                icon={<Trash />}
+                onClick={() => (selectedUrls.length > 0 ? setOpenRemoveSelected(true) : null)}
+              >
+                Remove ({selectedUrls.length})
+              </ButtonTooltip>
+            </>
+          ) : (
+            <>
+              <Button asChild type="default" icon={<ExternalLink />}>
+                <Link
+                  href="https://supabase.com/docs/guides/auth/concepts/redirect-urls"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  Documentation
+                </Link>
+              </Button>
+              <ButtonTooltip
+                disabled={!canUpdateConfig}
+                onClick={() => setOpen(true)}
+                tooltip={{
+                  content: {
+                    side: 'bottom',
+                    text: 'You need additional permissions to update redirect URLs',
+                  },
+                }}
+              >
+                Add URL
+              </ButtonTooltip>
+            </>
+          )}
         </div>
       </div>
       {isLoading && (
@@ -173,11 +184,10 @@ const RedirectUrls = () => {
       )}
       {isSuccess && (
         <RedirectUrlList
-          URI_ALLOW_LIST_ARRAY={URI_ALLOW_LIST_ARRAY}
+          allowList={URI_ALLOW_LIST_ARRAY}
           selectedUrls={selectedUrls}
           onSelectUrl={setSelectedUrls}
           canUpdate={canUpdateConfig}
-          onSelectUrlToDelete={setSelectedUrlToDelete}
         />
       )}
       <Modal
@@ -198,8 +208,9 @@ const RedirectUrls = () => {
           {() => {
             return (
               <>
-                <Modal.Content>
-                  <Input id="url" name="url" label="URL" placeholder="https://mydomain.com" />
+                <Modal.Content className="flex flex-col gap-y-2">
+                  <Label htmlFor="url">URL</Label>
+                  <Input id="url" name="url" placeholder="https://mydomain.com" />
                 </Modal.Content>
                 <DialogSectionSeparator />
                 <Modal.Content>
@@ -271,5 +282,3 @@ const RedirectUrls = () => {
     </div>
   )
 }
-
-export default RedirectUrls

--- a/apps/studio/components/interfaces/Auth/RedirectUrls/RedirectUrls.tsx
+++ b/apps/studio/components/interfaces/Auth/RedirectUrls/RedirectUrls.tsx
@@ -127,6 +127,20 @@ const RedirectUrls = () => {
             </Link>
           </Button>
           <ButtonTooltip
+            type="default"
+            disabled={!canUpdateConfig}
+            tooltip={{
+              content: {
+                side: 'bottom',
+                text: 'You need additional permissions to remove redirect URLs',
+              },
+            }}
+            icon={<Trash />}
+            onClick={() => (selectedUrls.length > 0 ? setOpenRemoveSelected(true) : null)}
+          >
+            Remove ({selectedUrls.length})
+          </ButtonTooltip>
+          <ButtonTooltip
             disabled={!canUpdateConfig}
             onClick={() => setOpen(true)}
             tooltip={{
@@ -138,11 +152,6 @@ const RedirectUrls = () => {
           >
             Add URL
           </ButtonTooltip>
-          {selectedUrls.length > 0 && (
-            <Button type="default" icon={<Trash />} onClick={() => setOpenRemoveSelected(true)}>
-              Remove selected ({selectedUrls.length})
-            </Button>
-          )}
         </div>
       </div>
       {isLoading && (
@@ -209,43 +218,6 @@ const RedirectUrls = () => {
             )
           }}
         </Form>
-      </Modal>
-      <Modal
-        hideFooter
-        size="small"
-        visible={selectedUrlToDelete !== undefined}
-        header="Remove URL"
-        onCancel={() => setSelectedUrlToDelete(undefined)}
-      >
-        <Modal.Content>
-          <p className="mb-2 text-sm text-foreground-light">
-            Are you sure you want to remove{' '}
-            <span className="text-foreground">{selectedUrlToDelete}</span>?
-          </p>
-          <p className="text-foreground-light text-sm">
-            This URL will no longer work with your authentication configuration.
-          </p>
-        </Modal.Content>
-        <Modal.Separator />
-        <Modal.Content className="flex items-center gap-x-2">
-          <Button
-            block
-            type="default"
-            size="medium"
-            onClick={() => setSelectedUrlToDelete(undefined)}
-          >
-            Cancel
-          </Button>
-          <Button
-            block
-            size="medium"
-            type="warning"
-            loading={isUpdatingConfig}
-            onClick={() => onConfirmDeleteUrl(selectedUrlToDelete ? [selectedUrlToDelete] : [])}
-          >
-            {isUpdatingConfig ? 'Removing...' : 'Remove URL'}
-          </Button>
-        </Modal.Content>
       </Modal>
       <Modal
         hideFooter

--- a/apps/studio/components/interfaces/Auth/RedirectUrls/ValueContainer.tsx
+++ b/apps/studio/components/interfaces/Auth/RedirectUrls/ValueContainer.tsx
@@ -1,14 +1,26 @@
 import { PropsWithChildren } from 'react'
 
-const ValueContainer = ({ children }: PropsWithChildren<{}>) => (
+interface ValueContainerProps {
+  isSelected?: boolean
+  onClick?: () => void
+}
+
+const ValueContainer = ({
+  children,
+  isSelected = false,
+  onClick,
+}: PropsWithChildren<ValueContainerProps>) => (
   <div
-    className="
+    className={`
       bg-surface-100 border-default text-foreground flex items-center 
       justify-between gap-2
       border px-6 
       py-4 text-sm
       first:rounded-tr first:rounded-tl last:rounded-br last:rounded-bl
-    "
+      ${isSelected ? 'bg-surface-300' : ''}
+      ${onClick ? 'cursor-pointer' : ''}
+    `}
+    onClick={onClick}
   >
     {children}
   </div>

--- a/apps/studio/components/interfaces/Auth/RedirectUrls/ValueContainer.tsx
+++ b/apps/studio/components/interfaces/Auth/RedirectUrls/ValueContainer.tsx
@@ -17,6 +17,7 @@ const ValueContainer = ({
       border px-6 
       py-4 text-sm
       first:rounded-tr first:rounded-tl last:rounded-br last:rounded-bl
+      hover:bg-surface-300
       ${isSelected ? 'bg-surface-300' : ''}
       ${onClick ? 'cursor-pointer' : ''}
     `}

--- a/apps/studio/components/interfaces/Auth/RedirectUrls/ValueContainer.tsx
+++ b/apps/studio/components/interfaces/Auth/RedirectUrls/ValueContainer.tsx
@@ -1,30 +1,29 @@
-import { PropsWithChildren } from 'react'
+import { PropsWithChildren, MouseEvent } from 'react'
+
+import { cn } from 'ui'
 
 interface ValueContainerProps {
   isSelected?: boolean
-  onClick?: () => void
+  onClick?: (event: MouseEvent<HTMLElement>) => void
 }
 
-const ValueContainer = ({
+export const ValueContainer = ({
   children,
   isSelected = false,
   onClick,
 }: PropsWithChildren<ValueContainerProps>) => (
   <div
-    className={`
-      bg-surface-100 border-default text-foreground flex items-center 
-      justify-between gap-2
-      border px-6 
-      py-4 text-sm
-      first:rounded-tr first:rounded-tl last:rounded-br last:rounded-bl
-      hover:bg-surface-300
-      ${isSelected ? 'bg-surface-300' : ''}
-      ${onClick ? 'cursor-pointer' : ''}
-    `}
-    onClick={onClick}
+    className={cn(
+      'bg-surface-100 hover:bg-surface-200 border-default text-foreground flex items-center',
+      'transition justify-between gap-2 border px-6 py-4 text-sm',
+      'first:rounded-tr first:rounded-tl last:rounded-br last:rounded-bl',
+      isSelected ? 'bg-surface-300' : '',
+      onClick ? 'cursor-pointer' : ''
+    )}
+    onClick={(e) => {
+      if (onClick) onClick(e)
+    }}
   >
     {children}
   </div>
 )
-
-export default ValueContainer

--- a/apps/studio/pages/project/[ref]/auth/url-configuration.tsx
+++ b/apps/studio/pages/project/[ref]/auth/url-configuration.tsx
@@ -1,6 +1,6 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 
-import RedirectUrls from 'components/interfaces/Auth/RedirectUrls/RedirectUrls'
+import { RedirectUrls } from 'components/interfaces/Auth/RedirectUrls/RedirectUrls'
 import SiteUrl from 'components/interfaces/Auth/SiteUrl/SiteUrl'
 import AuthLayout from 'components/layouts/AuthLayout/AuthLayout'
 import { FormsContainer } from 'components/ui/Forms/FormsContainer'


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?
* Allow the user to selected multiple redirect urls for removal
* This also helps to reduce the number of times the API is called to update the config 

## What is the current behavior?
* User has to select 1 url at a time to remove them. We have some users with alot of redirect urls before we imposed the max length check, which leads to them being unable to remove urls 1 at a time. 

## What is the new behavior?
* User can select multiple urls and remove them at once
* Header shows "Remove" button with a count of the number of urls selected

Feel free to include screenshots if it includes visual changes.

Highlight rows selected:
<img width="2027" alt="image" src="https://github.com/user-attachments/assets/3c04e5a4-abf5-4cb2-9af0-5c99d337ec71">

Display the urls selected for removal neatly:
<img width="2013" alt="image" src="https://github.com/user-attachments/assets/40bdc820-3eb5-4a27-bda3-976a98910bdd">


Toast notification shown on successfully removing urls:
<img width="2023" alt="image" src="https://github.com/user-attachments/assets/fa6f5f13-fac1-4002-a7fa-5357a3d3da1b">


## Additional context

Add any other context or screenshots.
