### PR TITLE
docs: Add redirectTo and authScreenLaunchMode parameter to signInWith OAuth calls in Flutter docs

### DIFF
--- a/apps/docs/content/guides/auth/social-login/auth-apple.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-apple.mdx
@@ -258,9 +258,11 @@ When developing with Expo, you can test Sign in with Apple via the Expo Go app, 
     This method of signing in is web based, and will open a browser window to perform the sign in. For non-web platforms, the user is brought back to the app via [deep linking](/docs/guides/auth/native-mobile-deep-linking?platform=flutter).
 
     ```dart
-    supabase.auth.signInWithOAuth(
+    await supabase.auth.signInWithOAuth(
       OAuthProvider.apple,
-      redirectTo: 'my-scheme://login-callback',
+      redirectTo: kIsWeb ? null : 'my.scheme://my-host', // Optionally set the redirect link to bring back the user via deeplink.
+      authScreenLaunchMode:
+          kIsWeb ? LaunchMode.platformDefault : LaunchMode.externalApplication, // Launch the auth screen in a new webview on mobile.
     );
     ```
 

--- a/apps/docs/content/guides/auth/social-login/auth-azure.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-azure.mdx
@@ -148,7 +148,9 @@ When your user signs in, call [signInWithOAuth()](/docs/reference/dart/auth-sign
 Future<void> signInWithAzure() async {
   await supabase.auth.signInWithOAuth(
     OAuthProvider.azure,
-    scopes: 'email',
+    redirectTo: kIsWeb ? null : 'my.scheme://my-host', // Optionally set the redirect link to bring back the user via deeplink.
+    authScreenLaunchMode:
+        kIsWeb ? LaunchMode.platformDefault : LaunchMode.externalApplication, // Launch the auth screen in a new webview on mobile.
   );
 }
 ```

--- a/apps/docs/content/guides/auth/social-login/auth-bitbucket.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-bitbucket.mdx
@@ -74,7 +74,12 @@ When your user signs in, call [signInWithOAuth()](/docs/reference/dart/auth-sign
 
 ```dart
 Future<void> signInWithBitbucket() async {
-  await supabase.auth.signInWithOAuth(OAuthProvider.bitbucket);
+  await supabase.auth.signInWithOAuth(
+    OAuthProvider.bitbucket,
+    redirectTo: kIsWeb ? null : 'my.scheme://my-host', // Optionally set the redirect link to bring back the user via deeplink.
+    authScreenLaunchMode:
+        kIsWeb ? LaunchMode.platformDefault : LaunchMode.externalApplication, // Launch the auth screen in a new webview on mobile.
+  );
 }
 ```
 

--- a/apps/docs/content/guides/auth/social-login/auth-discord.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-discord.mdx
@@ -73,7 +73,12 @@ When your user signs in, call [signInWithOAuth()](/docs/reference/dart/auth-sign
 
 ```dart
 Future<void> signInWithDiscord() async {
-  await supabase.auth.signInWithOAuth(OAuthProvider.discord);
+  await supabase.auth.signInWithOAuth(
+    OAuthProvider.discord,
+    redirectTo: kIsWeb ? null : 'my.scheme://my-host', // Optionally set the redirect link to bring back the user via deeplink.
+    authScreenLaunchMode:
+        kIsWeb ? LaunchMode.platformDefault : LaunchMode.externalApplication, // Launch the auth screen in a new webview on mobile.
+  );
 }
 ```
 

--- a/apps/docs/content/guides/auth/social-login/auth-facebook.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-facebook.mdx
@@ -90,7 +90,12 @@ When your user signs in, call [signInWithOAuth()](/docs/reference/dart/auth-sign
 
 ```dart
 Future<void> signInWithFacebook() async {
-  await supabase.auth.signInWithOAuth(OAuthProvider.facebook);
+  await supabase.auth.signInWithOAuth(
+    OAuthProvider.facebook,
+    redirectTo: kIsWeb ? null : 'my.scheme://my-host', // Optionally set the redirect link to bring back the user via deeplink.
+    authScreenLaunchMode:
+        kIsWeb ? LaunchMode.platformDefault : LaunchMode.externalApplication, // Launch the auth screen in a new webview on mobile.
+  );
 }
 ```
 

--- a/apps/docs/content/guides/auth/social-login/auth-figma.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-figma.mdx
@@ -72,9 +72,14 @@ async function signInWithFigma() {
 
 When your user signs in, call [signInWithOAuth()](/docs/reference/flutter/auth-signinwithoauth) with `figma` as the `provider`:
 
-```js
+```dart
 Future<void> signInWithFigma() async {
-  await supabase.auth.signInWithOAuth(OAuthProvider.figma);
+  await supabase.auth.signInWithOAuth(
+    OAuthProvider.figma,
+    redirectTo: kIsWeb ? null : 'my.scheme://my-host', // Optionally set the redirect link to bring back the user via deeplink.
+    authScreenLaunchMode:
+        kIsWeb ? LaunchMode.platformDefault : LaunchMode.externalApplication, // Launch the auth screen in a new webview on mobile.
+  );
 }
 ```
 

--- a/apps/docs/content/guides/auth/social-login/auth-github.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-github.mdx
@@ -68,7 +68,12 @@ When your user signs in, call [signInWithOAuth()](/docs/reference/dart/auth-sign
 
 ```dart
 Future<void> signInWithGithub() async {
-  await supabase.auth.signInWithOAuth(OAuthProvider.github);
+  await supabase.auth.signInWithOAuth(
+    OAuthProvider.github,
+    redirectTo: kIsWeb ? null : 'my.scheme://my-host', // Optionally set the redirect link to bring back the user via deeplink.
+    authScreenLaunchMode:
+        kIsWeb ? LaunchMode.platformDefault : LaunchMode.externalApplication, // Launch the auth screen in a new webview on mobile.
+  );
 }
 ```
 

--- a/apps/docs/content/guides/auth/social-login/auth-gitlab.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-gitlab.mdx
@@ -71,7 +71,12 @@ When your user signs in, call [signInWithOAuth()](/docs/reference/dart/auth-sign
 
 ```dart
 Future<void> signInWithGitLab() async {
-  await supabase.auth.signInWithOAuth(OAuthProvider.gitlab);
+  await supabase.auth.signInWithOAuth(
+    OAuthProvider.gitlab,
+    redirectTo: kIsWeb ? null : 'my.scheme://my-host', // Optionally set the redirect link to bring back the user via deeplink.
+    authScreenLaunchMode:
+        kIsWeb ? LaunchMode.platformDefault : LaunchMode.externalApplication, // Launch the auth screen in a new webview on mobile.
+  );
 }
 ```
 

--- a/apps/docs/content/guides/auth/social-login/auth-google.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-google.mdx
@@ -551,9 +551,11 @@ Google sign-in with Supabase on Web, macOS, Windows, and Linux is done through t
 This method of signing in is web based, and will open a browser window to perform the sign in. For non-web platforms, the user is brought back to the app via [deep linking](/docs/guides/auth/native-mobile-deep-linking?platform=flutter).
 
 ```dart
-supabase.auth.signInWithOAuth(
+await supabase.auth.signInWithOAuth(
   OAuthProvider.google,
-  redirectTo: 'my-scheme://login-callback',
+  redirectTo: kIsWeb ? null : 'my.scheme://my-host', // Optionally set the redirect link to bring back the user via deeplink.
+  authScreenLaunchMode:
+      kIsWeb ? LaunchMode.platformDefault : LaunchMode.externalApplication, // Launch the auth screen in a new webview on mobile.
 );
 ```
 

--- a/apps/docs/content/guides/auth/social-login/auth-kakao.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-kakao.mdx
@@ -96,7 +96,12 @@ When your user signs in, call [signInWithOAuth()](/docs/reference/dart/auth-sign
 
 ```dart
 Future<void> signInWithKakao() async {
-  await supabase.auth.signInWithOAuth(OAuthProvider.kakao);
+  await supabase.auth.signInWithOAuth(
+    OAuthProvider.kakao,
+    redirectTo: kIsWeb ? null : 'my.scheme://my-host', // Optionally set the redirect link to bring back the user via deeplink.
+    authScreenLaunchMode:
+        kIsWeb ? LaunchMode.platformDefault : LaunchMode.externalApplication, // Launch the auth screen in a new webview on mobile.
+  );
 }
 ```
 

--- a/apps/docs/content/guides/auth/social-login/auth-keycloak.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-keycloak.mdx
@@ -94,7 +94,9 @@ When your user signs in, call [signInWithOAuth()](/docs/reference/dart/auth-sign
 Future<void> signInWithKeycloak() async {
   await supabase.auth.signInWithOAuth(
     OAuthProvider.keycloak,
-    scopes: 'openid',
+    redirectTo: kIsWeb ? null : 'my.scheme://my-host', // Optionally set the redirect link to bring back the user via deeplink.
+    authScreenLaunchMode:
+        kIsWeb ? LaunchMode.platformDefault : LaunchMode.externalApplication, // Launch the auth screen in a new webview on mobile.
   );
 }
 ```

--- a/apps/docs/content/guides/auth/social-login/auth-linkedin.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-linkedin.mdx
@@ -82,7 +82,12 @@ When your user signs in, call [signInWithOAuth()](/docs/reference/dart/auth-sign
 
 ```dart
 Future<void> signInWithLinkedIn() async {
-  await supabase.auth.signInWithOAuth(OAuthProvider.linkedinOidc);
+  await supabase.auth.signInWithOAuth(
+    OAuthProvider.linkedinOidc,
+    redirectTo: kIsWeb ? null : 'my.scheme://my-host', // Optionally set the redirect link to bring back the user via deeplink.
+    authScreenLaunchMode:
+        kIsWeb ? LaunchMode.platformDefault : LaunchMode.externalApplication, // Launch the auth screen in a new webview on mobile.
+  );
 }
 ```
 

--- a/apps/docs/content/guides/auth/social-login/auth-notion.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-notion.mdx
@@ -74,7 +74,12 @@ When your user signs in, call [signInWithOAuth()](/docs/reference/dart/auth-sign
 
 ```dart
 Future<void> signInWithNotion() async {
-  await supabase.auth.signInWithOAuth(OAuthProvider.notion);
+  await supabase.auth.signInWithOAuth(
+    OAuthProvider.notion,
+    redirectTo: kIsWeb ? null : 'my.scheme://my-host', // Optionally set the redirect link to bring back the user via deeplink.
+    authScreenLaunchMode:
+        kIsWeb ? LaunchMode.platformDefault : LaunchMode.externalApplication, // Launch the auth screen in a new webview on mobile.
+  );
 }
 ```
 

--- a/apps/docs/content/guides/auth/social-login/auth-slack.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-slack.mdx
@@ -92,7 +92,12 @@ When your user signs in, call [signInWithOAuth()](/docs/reference/dart/auth-sign
 
 ```dart
 Future<void> signInWithSlack() async {
-  await supabase.auth.signInWithOAuth(OAuthProvider.slack);
+  await supabase.auth.signInWithOAuth(
+    OAuthProvider.slack,
+    redirectTo: kIsWeb ? null : 'my.scheme://my-host', // Optionally set the redirect link to bring back the user via deeplink.
+    authScreenLaunchMode:
+        kIsWeb ? LaunchMode.platformDefault : LaunchMode.externalApplication, // Launch the auth screen in a new webview on mobile.
+  );
 }
 ```
 

--- a/apps/docs/content/guides/auth/social-login/auth-spotify.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-spotify.mdx
@@ -86,7 +86,12 @@ When your user signs in, call [signInWithOAuth()](/docs/reference/dart/auth-sign
 
 ```dart
 Future<void> signInWithSpotify() async {
-  await supabase.auth.signInWithOAuth(OAuthProvider.spotify);
+  await supabase.auth.signInWithOAuth(
+    OAuthProvider.spotify,
+    redirectTo: kIsWeb ? null : 'my.scheme://my-host', // Optionally set the redirect link to bring back the user via deeplink.
+    authScreenLaunchMode:
+        kIsWeb ? LaunchMode.platformDefault : LaunchMode.externalApplication, // Launch the auth screen in a new webview on mobile.
+  );
 }
 ```
 

--- a/apps/docs/content/guides/auth/social-login/auth-twitch.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-twitch.mdx
@@ -89,7 +89,12 @@ When your user signs in, call [signInWithOAuth()](/docs/reference/dart/auth-sign
 
 ```dart
 Future<void> signInWithTwitch() async {
-  await supabase.auth.signInWithOAuth(OAuthProvider.twitch);
+  await supabase.auth.signInWithOAuth(
+    OAuthProvider.twitch,
+    redirectTo: kIsWeb ? null : 'my.scheme://my-host', // Optionally set the redirect link to bring back the user via deeplink.
+    authScreenLaunchMode:
+        kIsWeb ? LaunchMode.platformDefault : LaunchMode.externalApplication, // Launch the auth screen in a new webview on mobile.
+  );
 }
 ```
 

--- a/apps/docs/content/guides/auth/social-login/auth-twitter.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-twitter.mdx
@@ -80,7 +80,12 @@ When your user signs in, call [signInWithOAuth()](/docs/reference/dart/auth-sign
 
 ```dart
 Future<void> signInWithTwitter() async {
-  await supabase.auth.signInWithOAuth(OAuthProvider.twitter);
+  await supabase.auth.signInWithOAuth(
+    OAuthProvider.twitter,
+    redirectTo: kIsWeb ? null : 'my.scheme://my-host', // Optionally set the redirect link to bring back the user via deeplink.
+    authScreenLaunchMode:
+        kIsWeb ? LaunchMode.platformDefault : LaunchMode.externalApplication, // Launch the auth screen in a new webview on mobile.
+  );
 }
 ```
 

--- a/apps/docs/content/guides/auth/social-login/auth-workos.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-workos.mdx
@@ -89,6 +89,9 @@ When your user signs in, call [signInWithOAuth()](/docs/reference/dart/auth-sign
 Future<void> signInWithWorkOS() async {
   await supabase.auth.signInWithOAuth(
     OAuthProvider.workos,
+    redirectTo: kIsWeb ? null : 'my.scheme://my-host', // Optionally set the redirect link to bring back the user via deeplink.
+    authScreenLaunchMode:
+        kIsWeb ? LaunchMode.platformDefault : LaunchMode.externalApplication, // Launch the auth screen in a new webview on mobile.
     queryParams: {
       'connection': '<your_connection>',
       'organization': '<your_organization',

--- a/apps/docs/content/guides/auth/social-login/auth-zoom.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-zoom.mdx
@@ -87,7 +87,12 @@ When your user signs in, call [signInWithOAuth()](/docs/reference/dart/auth-sign
 
 ```dart
 Future<void> signInWithZoom() async {
-  await supabase.auth.signInWithOAuth(OAuthProvider.zoom);
+  await supabase.auth.signInWithOAuth(
+    OAuthProvider.zoom,
+    redirectTo: kIsWeb ? null : 'my.scheme://my-host', // Optionally set the redirect link to bring back the user via deeplink.
+    authScreenLaunchMode:
+        kIsWeb ? LaunchMode.platformDefault : LaunchMode.externalApplication, // Launch the auth screen in a new webview on mobile.
+  );
 }
 ```
 

--- a/apps/docs/spec/supabase_dart_v2.yml
+++ b/apps/docs/spec/supabase_dart_v2.yml
@@ -753,7 +753,12 @@ functions:
         isSpotlight: true
         code: |
           ```dart
-          await supabase.auth.signInWithOAuth(OAuthProvider.github);
+          await supabase.auth.signInWithOAuth(
+            OAuthProvider.github,
+            redirectTo: kIsWeb ? null : 'my.scheme://my-host', // Optionally set the redirect link to bring back the user via deeplink.
+            authScreenLaunchMode:
+                kIsWeb ? LaunchMode.platformDefault : LaunchMode.externalApplication, // Launch the auth screen in a new webview on mobile.
+          );
           ```
       - id: sign-in-using-a-third-party-provider-with-redirect
         name: With `redirectTo`


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Adds example code using the `redirectTo` and `authScreenLaunchMode` parameters to the Flutter docs. They are not requirements in every scenarios, but we often get users opening issues because they didn't know these parameters existed and their sign-in code isn't working.