### PR TITLE
Replace Authy with Ente Auth

### DIFF
--- a/apps/docs/content/guides/platform/multi-factor-authentication.mdx
+++ b/apps/docs/content/guides/platform/multi-factor-authentication.mdx
@@ -14,7 +14,7 @@ Multi-factor authentication (MFA) adds an additional layer of security to your u
 
 ## Supported authentication factors
 
-Currently, Supabase supports adding a unique time-based one-time password (TOTP) to your user account as an additional security factor. You can manage your TOTP factor using apps such as 1Password, Authy, Google Authenticator or Apple's Keychain.
+Currently, Supabase supports adding a unique time-based one-time password (TOTP) to your user account as an additional security factor. You can manage your TOTP factor using apps such as 1Password, Ente Auth, Google Authenticator or Apple's Keychain.
 
 ## Enable MFA
 


### PR DESCRIPTION
Authy has discontinued their desktop app.

Recommending [Ente Auth](https://ente.io/auth) as the alternative that is FOSS, available on all platforms and comes with end-to-end encrypted backups out of the box.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## Disclosure

One of the folks working on Ente Auth here.