### PR TITLE
fix: update link in authorization.mdx

### DIFF
--- a/apps/docs/content/guides/realtime/authorization.mdx
+++ b/apps/docs/content/guides/realtime/authorization.mdx
@@ -307,7 +307,7 @@ Client access polices are cached for the duration of the connection. Your databa
 Realtime updates the access policy cache for a client based on your RLS polices when:
 
 - A client connects to Realtime and subscribes to a Channel
-- A new JWT is sent to Realtime from a client via the [`access_token` message](docs/guides/realtime/protocol#access-token)
+- A new JWT is sent to Realtime from a client via the [`access_token` message](/docs/guides/realtime/protocol#access-token)
 
 If a new JWT is never received on the Channel, the client will be disconnected when the JWT expires.
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?
doc update

## What is the current behavior?
Link sends user to: https://supabase.com/docs/guides/realtime/docs/guides/realtime/protocol#access-token which does not exist

Please link any relevant issues here.

## What is the new behavior?

Link sends user to: https://supabase.com/docs/guides/realtime/protocol#access-token which does exist and is relevant to the content.

## Additional context
n/a
