### PR TITLE
Fix: Incorrect auth.sign_up method usage in Python documentation

### DIFF
--- a/apps/docs/content/guides/auth/passwords.mdx
+++ b/apps/docs/content/guides/auth/passwords.mdx
@@ -122,7 +122,7 @@ You can optionally specify a URL to redirect to after the user clicks the confir
 If you don't specify a redirect URL, the user is automatically redirected to your site URL. This defaults to `localhost:3000`, but you can also configure this.
 
 ```python
-data = await supabase.auth.sign_up({
+data = client.auth.sign_up({
   'email': 'example@email.com',
   'password': 'example-password',
   'options': {


### PR DESCRIPTION
The existing way of signing up with the Python package in the Readme does not work. I believe the call needs to reference the client instead of the package, and it should not be awaited.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The Supabase Python library documentation for the auth.sign_up method incorrectly shows calling supabase.auth.sign_up directly. This method cannot be awaited.

## What is the new behavior?

This pull request updates the documentation to reflect the correct way to call the auth.sign_up method, which is through the client object and should not be awaited.

## Additional context

Please note:

You'll need to replace "client" with the actual variable name used in your Supabase project setup.
This pull request clarifies the documentation and improves the developer experience.
