### PR TITLE
Chore: Close parenthesis in code example

### DIFF
--- a/apps/docs/spec/supabase_csharp_v1.yml
+++ b/apps/docs/spec/supabase_csharp_v1.yml
@@ -1497,7 +1497,7 @@ functions:
         code: |
           ```c#
           var result = await supabase.From<City>()
-            .Where(x => x.Name == null
+            .Where(x => x.Name == null)
             .Get();
           ```
 


### PR DESCRIPTION
Small typo in [code example](https://supabase.com/docs/reference/csharp/is) 
![image](https://github.com/user-attachments/assets/de7b07f7-1733-4dde-ae18-298b479b2cd9)


## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Typo fix

## What is the current behavior?

Bug in a code example

## What is the new behavior?

no behavior change

## Additional context

