### PR TITLE
Missing import in Astro example

### DIFF
--- a/apps/docs/content/guides/auth/server-side/creating-a-client.mdx
+++ b/apps/docs/content/guides/auth/server-side/creating-a-client.mdx
@@ -482,6 +482,8 @@ const supabase = createServerClient(
 
 ```html index.astro
 <script>
+import { createBrowserClient } from "@supabase/ssr";
+
   const supabase = createBrowserClient(
     import.meta.env.PUBLIC_SUPABASE_URL,
     import.meta.env.PUBLIC_SUPABASE_ANON_KEY

--- a/apps/docs/content/guides/auth/server-side/creating-a-client.mdx
+++ b/apps/docs/content/guides/auth/server-side/creating-a-client.mdx
@@ -482,7 +482,7 @@ const supabase = createServerClient(
 
 ```html index.astro
 <script>
-import { createBrowserClient } from "@supabase/ssr";
+  import { createBrowserClient } from "@supabase/ssr";
 
   const supabase = createBrowserClient(
     import.meta.env.PUBLIC_SUPABASE_URL,


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

Missing `createBrowserClient` import in the Astro SSR example.

## What is the new behavior?

Adds `import` statement.

