### PR TITLE
Fix project roles not showing which project

### DIFF
--- a/apps/studio/components/interfaces/Organization/TeamSettings/MemberRow.tsx
+++ b/apps/studio/components/interfaces/Organization/TeamSettings/MemberRow.tsx
@@ -36,6 +36,7 @@ export const MemberRow = ({ member }: MemberRowProps) => {
     slug: selectedOrganization?.slug,
   })
 
+  const hasProjectScopedRoles = (roles?.project_scoped_roles ?? []).length > 0
   const memberIsUser = member.gotrue_id == profile?.gotrue_id
   const isInvitedUser = Boolean(member.invited_id)
   const isEmailUser = member.username === member.primary_email
@@ -148,7 +149,7 @@ export const MemberRow = ({ member }: MemberRowProps) => {
             return (
               <div key={`role-${id}`} className="flex items-center gap-x-2">
                 <p>{roleName}</p>
-                {isOptedIntoProjectLevelPermissions && (
+                {hasProjectScopedRoles && (
                   <>
                     <span>•</span>
                     {projectsApplied.length === 1 ? (

--- a/apps/studio/data/organizations/organization-tax-id-query.ts
+++ b/apps/studio/data/organizations/organization-tax-id-query.ts
@@ -1,10 +1,11 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
-import { get, handleError } from 'data/fetchers'
-import { organizationKeys } from './keys'
-import type { ResponseError } from 'types'
-import { components } from 'api-types'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
+import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+
+import { components } from 'api-types'
+import { get, handleError } from 'data/fetchers'
 import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import type { ResponseError } from 'types'
+import { organizationKeys } from './keys'
 
 export type OrganizationTaxIdVariables = {
   slug?: string
@@ -40,7 +41,7 @@ export const useOrganizationTaxIdQuery = <TData = OrganizationTaxIdData>(
   }: UseQueryOptions<OrganizationTaxIdData, OrganizationTaxIdError, TData> = {}
 ) => {
   const canReadSubscriptions = useCheckPermissions(PermissionAction.BILLING_READ, 'stripe.tax_ids')
-  useQuery<OrganizationTaxIdData, OrganizationTaxIdError, TData>(
+  return useQuery<OrganizationTaxIdData, OrganizationTaxIdError, TData>(
     organizationKeys.taxId(slug),
     ({ signal }) => getOrganizationTaxId({ slug }, signal),
     {

--- a/apps/studio/data/organizations/organization-tax-id-query.ts
+++ b/apps/studio/data/organizations/organization-tax-id-query.ts
@@ -3,6 +3,8 @@ import { get, handleError } from 'data/fetchers'
 import { organizationKeys } from './keys'
 import type { ResponseError } from 'types'
 import { components } from 'api-types'
+import { PermissionAction } from '@supabase/shared-types/out/constants'
+import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
 
 export type OrganizationTaxIdVariables = {
   slug?: string
@@ -36,12 +38,14 @@ export const useOrganizationTaxIdQuery = <TData = OrganizationTaxIdData>(
     enabled = true,
     ...options
   }: UseQueryOptions<OrganizationTaxIdData, OrganizationTaxIdError, TData> = {}
-) =>
+) => {
+  const canReadSubscriptions = useCheckPermissions(PermissionAction.BILLING_READ, 'stripe.tax_ids')
   useQuery<OrganizationTaxIdData, OrganizationTaxIdError, TData>(
     organizationKeys.taxId(slug),
     ({ signal }) => getOrganizationTaxId({ slug }, signal),
     {
-      enabled: enabled && typeof slug !== 'undefined',
+      enabled: enabled && typeof slug !== 'undefined' && canReadSubscriptions,
       ...options,
     }
   )
+}

--- a/apps/studio/data/subscriptions/org-plans-query.ts
+++ b/apps/studio/data/subscriptions/org-plans-query.ts
@@ -1,6 +1,8 @@
 import { useQuery, UseQueryOptions } from '@tanstack/react-query'
 import { get, handleError } from 'data/fetchers'
 import { subscriptionKeys } from './keys'
+import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import { PermissionAction } from '@supabase/shared-types/out/constants'
 
 export type OrgPlansVariables = {
   orgSlug?: string
@@ -23,12 +25,18 @@ export type OrgPlansError = unknown
 export const useOrgPlansQuery = <TData = OrgPlansData>(
   { orgSlug }: OrgPlansVariables,
   { enabled = true, ...options }: UseQueryOptions<OrgPlansData, OrgPlansError, TData> = {}
-) =>
-  useQuery<OrgPlansData, OrgPlansError, TData>(
+) => {
+  const canReadSubscriptions = useCheckPermissions(
+    PermissionAction.BILLING_READ,
+    'stripe.subscriptions'
+  )
+
+  return useQuery<OrgPlansData, OrgPlansError, TData>(
     subscriptionKeys.orgPlans(orgSlug),
     ({ signal }) => getOrgPlans({ orgSlug }, signal),
     {
-      enabled: enabled && typeof orgSlug !== 'undefined',
+      enabled: enabled && typeof orgSlug !== 'undefined' && canReadSubscriptions,
       ...options,
     }
   )
+}


### PR DESCRIPTION
As per PR title
Was checking to show that info only if the org had access to project level roles - which checks for the org subscription, but if you’re a developer, you dont have access to the subscription info

Updated to just check if org already has _some_ project level roles instead

![image](https://github.com/user-attachments/assets/fa64bd34-3e5e-4a9e-bd66-8b88c3739247)
