### PR TITLE
Fix: update default medium text size from text-sm to text-base

### DIFF
--- a/packages/ui/src/lib/theme/defaultTheme.ts
+++ b/packages/ui/src/lib/theme/defaultTheme.ts
@@ -38,7 +38,7 @@ const defaults = {
     text: {
       tiny: 'text-xs',
       small: 'text-sm leading-4',
-      medium: 'text-sm',
+      medium: 'text-base',
       large: 'text-base',
       xlarge: 'text-base',
     },


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

Yes

## What kind of change does this PR introduce?

Improving UX 

## What is the current behavior?

Currently, when using input text fields in Supabase on iOS mobile, the screen zooms in on the text field. 
I found this unnecessary and have improved it.

![before-2](https://github.com/user-attachments/assets/cc4367f9-c114-4b9c-b26d-5afcd9ca86e3)
![before](https://github.com/user-attachments/assets/39e6eca6-f500-4509-9312-e0bf07452908)


## What is the new behavior?

The unintended zoom is now removed, eliminating the inconvenience of having to manually zoom out after finishing text input. Improved the UX such as logging into Supabase on iOS mobile devices.

![after](https://github.com/user-attachments/assets/8d3cb105-87f2-45dd-bce7-853b802d056e)


## Additional context

> https://css-tricks.com/16px-or-larger-text-prevents-ios-form-zoom/

In my personal project, I noticed that input text fields were zooming in only on iOS. After investigating, I found that when text smaller than 16px is applied, iOS automatically zooms in on the text field. By changing from text-sm to text-base, which sets font-size: 1rem; /* 16px */, the unnecessary zoom effect can be avoided.

(+ And I feel that the name 'base' was appropriate to use with 'medium')