### PR TITLE
Fix: update npm version in DEVELOPERS.md

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -38,7 +38,7 @@ You will need to install and configure the following dependencies on your machin
 
 - [Git](http://git-scm.com/)
 - [Node.js v20.x (LTS)](http://nodejs.org)
-- [npm](https://www.npmjs.com/) version 9.x.x or higher
+- [npm](https://www.npmjs.com/) version 10.x.x or higher
 - [Docker](https://docs.docker.com/get-docker/) (to run studio locally)
 
 ## Local development


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

update DEVELOPERS.md

## What is the current behavior?

```
taesu@Taesu-MacBook-Air supabase % npm install                       
npm ERR! code EBADENGINE
npm ERR! engine Unsupported engine
npm ERR! engine Not compatible with your version of node/npm: supabase@0.0.0
npm ERR! notsup Not compatible with your version of node/npm: supabase@0.0.0
npm ERR! notsup Required: {"npm":"^10.0.0","node":"^20.0.0"}
npm ERR! notsup Actual:   {"npm":"9.9.3","node":"v20.17.0"}
```

## What is the new behavior?

<img width="748" alt="image" src="https://github.com/user-attachments/assets/86f1dbe5-9475-43e7-aa61-e06f31f5c1fd">
