### PR TITLE
chore: add myself to humans.txt

### DIFF
--- a/apps/docs/public/humans.txt
+++ b/apps/docs/public/humans.txt
@@ -56,6 +56,7 @@ Kevin Grüneberg
 Lakshan Perera
 Laura C
 Long Hoang
+Łukasz Niemier
 Margarita Sandomirskaia
 Mark Burggraf
 Monica El Khoury


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Adds myself to `humans.txt`.

## What is the current behavior?

I am not in `humans.txt`.

## What is the new behavior?

I am in `humans.txt`.

## Additional context

![Photo on 24 09 2024 at 12 03](https://github.com/user-attachments/assets/cb0e4f15-76c0-4efc-b628-64f97f89b0cc)
