### PR TITLE
Update metrics.mdx | put .env variables in quotes

### DIFF
--- a/apps/docs/content/guides/platform/metrics.mdx
+++ b/apps/docs/content/guides/platform/metrics.mdx
@@ -119,15 +119,15 @@ Supabase Grafana only tracks metrics while it's active. For monitoring historica
 
             - Add the values to your `.env` file:
             ```text .env
-            SUPABASE_PROJECT_REF=<your_project_reference>
-            SUPABASE_SERVICE_ROLE_KEY=<your_service_role>
+            SUPABASE_PROJECT_REF="your_project_reference"
+            SUPABASE_SERVICE_ROLE_KEY="your_service_role"
             ```
         </TabPanel>
         <TabPanel id="monitor-an-org" label="monitor multiple projects">
 
 
             ```text .env
-            SUPABASE_ACCESS_TOKEN=<your_access_token>
+            SUPABASE_ACCESS_TOKEN="your_access_token"
             ```
         </TabPanel>
         </Tabs>
@@ -144,7 +144,7 @@ Supabase Grafana only tracks metrics while it's active. For monitoring historica
         </StepHikeCompact.Details>
         <StepHikeCompact.Code>
                 ```text .env
-                GRAFANA_PASSWORD=<your password>
+                GRAFANA_PASSWORD="your password"
                 ```
             </StepHikeCompact.Code>
     </StepHikeCompact.Step>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

`.env` variables are represented as blank text

## What is the new behavior?

wraps .env variables in quotes. For some reason, this is necessary for Grafana to work

## Additional context

I was managing a ticket related to the metrics page and wrapping the .env values in quotes solved the issue. Not sure why
