### PR TITLE
chore(docs): fix auth apple guide by removing import GoTrue

### DIFF
--- a/apps/docs/content/guides/auth/social-login/auth-apple.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-apple.mdx
@@ -298,7 +298,6 @@ When developing with Expo, you can test Sign in with Apple via the Expo Go app, 
     import SwiftUI
     import AuthenticationServices
     import Supabase
-    import GoTrue
 
     struct SignInView: View {
         let client = SupabaseClient(supabaseURL: URL(string: "your url")!, supabaseKey: "your anon key")


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES/NO

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
