### PR TITLE
ref: Unify /v1 api requests, remove API_ADMIN_URL constant

### DIFF
--- a/apps/studio/components/interfaces/Settings/Database/SSLConfiguration.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/SSLConfiguration.tsx
@@ -58,7 +58,10 @@ const SSLConfiguration = () => {
       sslEnforcementConfiguration.currentConfig.database
     : false
 
-  const hasAccessToSSLEnforcement = !sslEnforcementConfiguration?.isNotAllowed
+  const hasAccessToSSLEnforcement =
+    sslEnforcementConfiguration !== undefined &&
+    'isNotAllowed' in sslEnforcementConfiguration &&
+    !sslEnforcementConfiguration?.isNotAllowed
   const env = process.env.NEXT_PUBLIC_ENVIRONMENT === 'prod' ? 'prod' : 'staging'
   const hasSSLCertificate =
     projectSettings?.project !== undefined &&

--- a/apps/studio/components/interfaces/Settings/Database/SSLConfiguration.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/SSLConfiguration.tsx
@@ -58,10 +58,11 @@ const SSLConfiguration = () => {
       sslEnforcementConfiguration.currentConfig.database
     : false
 
-  const hasAccessToSSLEnforcement =
+  const hasAccessToSSLEnforcement = !(
     sslEnforcementConfiguration !== undefined &&
     'isNotAllowed' in sslEnforcementConfiguration &&
-    !sslEnforcementConfiguration?.isNotAllowed
+    sslEnforcementConfiguration.isNotAllowed
+  )
   const env = process.env.NEXT_PUBLIC_ENVIRONMENT === 'prod' ? 'prod' : 'staging'
   const hasSSLCertificate =
     projectSettings?.project !== undefined &&

--- a/apps/studio/data/config/project-upgrade-status-query.ts
+++ b/apps/studio/data/config/project-upgrade-status-query.ts
@@ -4,9 +4,9 @@ import {
   DatabaseUpgradeStatus,
   DatabaseUpgradeProgress,
 } from '@supabase/shared-types/out/events'
-import { get } from 'lib/common/fetch'
-import { API_ADMIN_URL, PROJECT_STATUS } from 'lib/constants'
+import { PROJECT_STATUS } from 'lib/constants'
 import { configKeys } from './keys'
+import { get, handleError } from 'data/fetchers'
 
 export type ProjectUpgradingStatusVariables = {
   projectRef?: string
@@ -29,10 +29,13 @@ export async function getProjectUpgradingStatus(
 ) {
   if (!projectRef) throw new Error('projectRef is required')
 
-  const response = await get(`${API_ADMIN_URL}/projects/${projectRef}/upgrade/status`, { signal })
-  if (response.error) throw response.error
+  const { data, error } = await get(`/v1/projects/{ref}/upgrade/status`, {
+    params: { path: { ref: projectRef } },
+    signal,
+  })
+  if (error) handleError(error)
 
-  return response as ProjectUpgradingStatusResponse
+  return data as ProjectUpgradingStatusResponse
 }
 
 export type ProjectUpgradingStatusData = Awaited<ReturnType<typeof getProjectUpgradingStatus>>

--- a/apps/studio/data/config/project-upgrade-status-query.ts
+++ b/apps/studio/data/config/project-upgrade-status-query.ts
@@ -1,26 +1,12 @@
+import { DatabaseUpgradeStatus } from '@supabase/shared-types/out/events'
 import { useQuery, useQueryClient, UseQueryOptions } from '@tanstack/react-query'
-import {
-  DatabaseUpgradeError,
-  DatabaseUpgradeStatus,
-  DatabaseUpgradeProgress,
-} from '@supabase/shared-types/out/events'
+import { get, handleError } from 'data/fetchers'
 import { PROJECT_STATUS } from 'lib/constants'
 import { configKeys } from './keys'
-import { get, handleError } from 'data/fetchers'
 
 export type ProjectUpgradingStatusVariables = {
   projectRef?: string
   projectStatus?: string
-}
-
-export type ProjectUpgradingStatusResponse = {
-  databaseUpgradeStatus: {
-    error?: DatabaseUpgradeError
-    progress?: DatabaseUpgradeProgress
-    status: DatabaseUpgradeStatus
-    initiated_at: string
-    target_version: number
-  } | null
 }
 
 export async function getProjectUpgradingStatus(
@@ -35,7 +21,7 @@ export async function getProjectUpgradingStatus(
   })
   if (error) handleError(error)
 
-  return data as ProjectUpgradingStatusResponse
+  return data
 }
 
 export type ProjectUpgradingStatusData = Awaited<ReturnType<typeof getProjectUpgradingStatus>>
@@ -56,7 +42,7 @@ export const useProjectUpgradingStatusQuery = <TData = ProjectUpgradingStatusDat
     {
       enabled: enabled && typeof projectRef !== 'undefined',
       refetchInterval(data) {
-        const response = data as unknown as ProjectUpgradingStatusResponse
+        const response = data as unknown as ProjectUpgradingStatusData
         if (!response) return false
 
         const interval =
@@ -71,7 +57,7 @@ export const useProjectUpgradingStatusQuery = <TData = ProjectUpgradingStatusDat
         return interval
       },
       onSuccess(data) {
-        const response = data as unknown as ProjectUpgradingStatusResponse
+        const response = data as unknown as ProjectUpgradingStatusData
         if (response.databaseUpgradeStatus?.status === DatabaseUpgradeStatus.Upgraded) {
           client.invalidateQueries(configKeys.upgradeEligibility(projectRef))
         }

--- a/apps/studio/data/oauth/oauth-app-update-mutation.ts
+++ b/apps/studio/data/oauth/oauth-app-update-mutation.ts
@@ -2,10 +2,9 @@ import type { OAuthScope } from '@supabase/shared-types/out/constants'
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
-import { put } from 'lib/common/fetch'
-import { API_URL } from 'lib/constants'
 import type { ResponseError } from 'types'
 import { oauthAppKeys } from './keys'
+import { handleError, put } from 'data/fetchers'
 
 export type OAuthAppUpdateVariables = {
   id: string
@@ -32,15 +31,18 @@ export async function updateOAuthApp({
   if (!website) throw new Error('OAuth app URL is required')
   if (!redirect_uris || redirect_uris.length === 0) throw new Error('Redirect URIs are required')
 
-  const response = await put(`${API_URL}/organizations/${slug}/oauth/apps/${id}`, {
-    name,
-    website,
-    icon,
-    scopes,
-    redirect_uris,
+  const { data, error } = await put(`/platform/organizations/{slug}/oauth/apps/{id}`, {
+    params: { path: { id, slug } },
+    body: {
+      name,
+      website,
+      icon: icon as undefined, // Generated type is incorrect an allows for `string | undefined` only, while we need `null` here.
+      scopes,
+      redirect_uris,
+    },
   })
-  if (response.error) throw response.error
-  return response
+  if (error) throw handleError(error)
+  return data
 }
 
 type OAuthAppUpdateData = Awaited<ReturnType<typeof updateOAuthApp>>

--- a/apps/studio/data/ssl-enforcement/ssl-enforcement-query.ts
+++ b/apps/studio/data/ssl-enforcement/ssl-enforcement-query.ts
@@ -1,15 +1,8 @@
 import { useQuery, UseQueryOptions } from '@tanstack/react-query'
-import { sslEnforcementKeys } from './keys'
 import { get, handleError } from 'data/fetchers'
+import { sslEnforcementKeys } from './keys'
 
 export type SSLEnforcementVariables = { projectRef?: string }
-
-export type SSLEnforcementResponse = {
-  appliedSuccessfully: boolean
-  currentConfig: { database: boolean }
-  error?: any
-  isNotAllowed?: boolean
-}
 
 export async function getSSLEnforcementConfiguration(
   { projectRef }: SSLEnforcementVariables,
@@ -34,13 +27,13 @@ export async function getSSLEnforcementConfiguration(
         appliedSuccessfully: false,
         currentConfig: { database: false },
         isNotAllowed: true,
-      } as SSLEnforcementResponse
+      } as const
     } else {
       handleError(error)
     }
   }
 
-  return data as SSLEnforcementResponse
+  return data
 }
 
 export type SSLEnforcementData = Awaited<ReturnType<typeof getSSLEnforcementConfiguration>>

--- a/apps/studio/data/ssl-enforcement/ssl-enforcement-query.ts
+++ b/apps/studio/data/ssl-enforcement/ssl-enforcement-query.ts
@@ -1,7 +1,6 @@
 import { useQuery, UseQueryOptions } from '@tanstack/react-query'
-import { get } from 'lib/common/fetch'
-import { API_ADMIN_URL } from 'lib/constants'
 import { sslEnforcementKeys } from './keys'
+import { get, handleError } from 'data/fetchers'
 
 export type SSLEnforcementVariables = { projectRef?: string }
 
@@ -18,16 +17,17 @@ export async function getSSLEnforcementConfiguration(
 ) {
   if (!projectRef) throw new Error('projectRef is required')
 
-  const response = (await get(`${API_ADMIN_URL}/projects/${projectRef}/ssl-enforcement`, {
+  const { data, error } = await get(`/v1/projects/{ref}/ssl-enforcement`, {
+    params: { path: { ref: projectRef } },
     signal,
-  })) as SSLEnforcementResponse
+  })
 
   // Not allowed error is a valid response to denote if a project
   // has access to the SSL enforcement UI, so we'll handle it here
-  if (response.error) {
+  if (error) {
     const isNotAllowedError =
-      (response.error as any)?.code === 400 &&
-      (response.error as any)?.message?.includes('not allowed to configure SSL enforcements')
+      (error as any)?.code === 400 &&
+      (error as any)?.message?.includes('not allowed to configure SSL enforcements')
 
     if (isNotAllowedError) {
       return {
@@ -36,11 +36,11 @@ export async function getSSLEnforcementConfiguration(
         isNotAllowed: true,
       } as SSLEnforcementResponse
     } else {
-      throw response.error
+      handleError(error)
     }
   }
 
-  return response as SSLEnforcementResponse
+  return data as SSLEnforcementResponse
 }
 
 export type SSLEnforcementData = Awaited<ReturnType<typeof getSSLEnforcementConfiguration>>

--- a/apps/studio/data/ssl-enforcement/ssl-enforcement-update-mutation.ts
+++ b/apps/studio/data/ssl-enforcement/ssl-enforcement-update-mutation.ts
@@ -1,10 +1,9 @@
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
-import { put } from 'lib/common/fetch'
-import { API_ADMIN_URL } from 'lib/constants'
 import type { ResponseError } from 'types'
 import { sslEnforcementKeys } from './keys'
+import { handleError, put } from 'data/fetchers'
 
 export type SSLEnforcementUpdateVariables = {
   projectRef: string
@@ -23,12 +22,13 @@ export async function updateSSLEnforcement({
 }: SSLEnforcementUpdateVariables) {
   if (!projectRef) throw new Error('projectRef is required')
 
-  const response = (await put(`${API_ADMIN_URL}/projects/${projectRef}/ssl-enforcement`, {
-    requestedConfig,
-  })) as SSLEnforcementUpdateResponse
-  if (response.error) throw response.error
+  const { data, error } = await put(`/v1/projects/{ref}/ssl-enforcement`, {
+    params: { path: { ref: projectRef } },
+    body: { requestedConfig },
+  })
 
-  return response
+  if (error) handleError(error)
+  return data
 }
 
 type SSLEnforcementUpdateData = Awaited<ReturnType<typeof updateSSLEnforcement>>

--- a/apps/studio/lib/constants/index.ts
+++ b/apps/studio/lib/constants/index.ts
@@ -5,7 +5,6 @@ export * from './infrastructure'
 export const IS_PLATFORM = process.env.NEXT_PUBLIC_IS_PLATFORM === 'true'
 export const DEFAULT_HOME = IS_PLATFORM ? '/projects' : '/project/default'
 export const API_URL = IS_PLATFORM ? process.env.NEXT_PUBLIC_API_URL : '/api'
-export const API_ADMIN_URL = IS_PLATFORM ? process.env.NEXT_PUBLIC_API_ADMIN_URL : undefined
 export const PG_META_URL = IS_PLATFORM
   ? process.env.PLATFORM_PG_META_URL
   : process.env.STUDIO_PG_META_URL

--- a/apps/studio/next-env.d.ts
+++ b/apps/studio/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.


### PR DESCRIPTION
- Replace deprecated `put` with `data/fetchers`
- Deprecated `put` from `lib/common/fetch/put.ts` is not used anymore and can be safely removed
- Remove all `API_ADMIN_URL` usage and use standardized `data/fetchers` urls to query `/v1` directly
- `API_ADMIN_URL` can be removed from Vercel env variables

All changed behavior verified locally.