### PR TITLE
fix: update to make explicit that there can be multiple secrets

### DIFF
--- a/apps/docs/content/guides/auth/auth-hooks.mdx
+++ b/apps/docs/content/guides/auth/auth-hooks.mdx
@@ -102,11 +102,15 @@ When a HTTP hook is created, the secret generated should be of the following for
 - `whsec_` signifies that the secret is symmetric
 - `<standard-base64-secret>` implies a Standard Base64 encoded secret which can contain the characters `+`, `/` and `=`
 
+
 The secret is used to verify the payload received in your hook. Create an entry in your `.env.local` file to store the secret for each hook that you have. For example:
 
 ```bash
-HOOK_SECRET=<standard-base64-secret>
+HOOK_SECRETS=<standard-base64-secret>
 ```
+
+There field is expressed in plural rather than singular as there are plans to allow for asymmetric signing and multiple hook secrets for ease of secret rotation. For instance: `<standard-base-64-secret>|<another-standard-base-64-secret>`. 
+
 
 Use the secret in conjunction with the Standard Webhooks package to verify the payload before processing it:
 
@@ -115,7 +119,7 @@ import { Webhook } from 'https://esm.sh/standardwebhooks@1.0.0'
 
 Deno.serve(async (req) => {
   const payload = await req.text()
-  const hookSecret = Deno.env.get('HOOK_SECRET')
+  const hookSecret = Deno.env.get('HOOK_SECRETS')
   // Extract headers and security specific fields
   const headers = Object.fromEntries(req.headers)
   const wh = new Webhook(hookSecret)
@@ -231,7 +235,7 @@ Modify the `auth.hook.<hook_name>` field and set `uri` to a valid HTTP URI. For 
 [auth.hook.send_sms]
 enabled = true
 uri = "http://host.docker.internal:54321/functions/v1/send_sms"
-secret = "env(SEND_SMS_HOOK_SECRET)"
+secrets = "env(SEND_SMS_HOOK_SECRET)"
 ```
 
 `host.docker.internal` is a special DNS name used in Docker to allow a container to access the host machine's network. This allows the Auth container to reach the Functions container
@@ -239,7 +243,7 @@ secret = "env(SEND_SMS_HOOK_SECRET)"
 Fill in the Hook Secret in `supabase/functions/.env`
 
 ```bash
-SEND_SMS_HOOK_SECRET='v1,whsec_<base64_standard_secret>'
+SEND_SMS_HOOK_SECRETS='v1,whsec_<base64_standard_secret>'
 ```
 
 Start the function locally:

--- a/apps/docs/content/guides/auth/auth-hooks.mdx
+++ b/apps/docs/content/guides/auth/auth-hooks.mdx
@@ -102,15 +102,13 @@ When a HTTP hook is created, the secret generated should be of the following for
 - `whsec_` signifies that the secret is symmetric
 - `<standard-base64-secret>` implies a Standard Base64 encoded secret which can contain the characters `+`, `/` and `=`
 
-
 The secret is used to verify the payload received in your hook. Create an entry in your `.env.local` file to store the secret for each hook that you have. For example:
 
 ```bash
 HOOK_SECRETS=<standard-base64-secret>
 ```
 
-There field is expressed in plural rather than singular as there are plans to allow for asymmetric signing and multiple hook secrets for ease of secret rotation. For instance: `<standard-base-64-secret>|<another-standard-base-64-secret>`. 
-
+There field is expressed in plural rather than singular as there are plans to allow for asymmetric signing and multiple hook secrets for ease of secret rotation. For instance: `<standard-base-64-secret>|<another-standard-base-64-secret>`.
 
 Use the secret in conjunction with the Standard Webhooks package to verify the payload before processing it:
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES


## What is the change

Better express that an Auth Hook can make use of multiple secrets

Will set to ready after catching up on the discussion on the [standard-webhooks repo](https://github.com/standard-webhooks/standard-webhooks) (the library we use) on the plans to handle multiple secrets on the client (if any)

On Auth side we have an existing [convention](https://github.com/supabase/auth/blob/master/internal/conf/configuration.go#L564)