### PR TITLE
enh(docs): more checks for external CodeSample

### DIFF
--- a/apps/docs/app/contributing/content.mdx
+++ b/apps/docs/app/contributing/content.mdx
@@ -167,7 +167,7 @@ const PI = 3.14
 ```
 ````
 
-Of, you can use the `<$CodeSample />` component to include code samples from a source code file.
+Or, you can use the `<$CodeSample />` component to include code samples from a source code file.
 
 If the file is within the `supabase/supabase` repo's `examples` directory:
 
@@ -183,7 +183,7 @@ meta="display/path.js"
 />
 ```
 
-If the file is within some other GitHub repo (note that the repo must be public):
+If the file is within some other GitHub repo:
 
 ```mdx
 <$CodeSample
@@ -196,6 +196,8 @@ lines={[[1, 3], [5, -1]]}
 meta="display/path.js"
 />
 ```
+
+The repo must be public, the org must be on the allow list, and the commit must be an immutable SHA (not a mutable tag or branch name).
 
 ### Icons
 

--- a/apps/docs/features/directives/CodeSample.ts
+++ b/apps/docs/features/directives/CodeSample.ts
@@ -48,6 +48,8 @@ import { z, type SafeParseError } from 'zod'
 import { fetchWithNextOptions } from '~/features/helpers.fetch'
 import { EXAMPLES_DIRECTORY } from '~/lib/docs'
 
+const ALLOW_LISTED_GITHUB_ORGS = ['supabase'] as [string, ...string[]]
+
 const linesSchema = z.array(z.tuple([z.coerce.number(), z.coerce.number()]))
 const linesValidator = z.string().transform((v, ctx) => {
   try {
@@ -70,7 +72,9 @@ type AdditionalMeta = {
 
 const codeSampleExternalSchema = z.object({
   external: z.coerce.boolean().refine((v) => v === true),
-  org: z.string(),
+  org: z.enum(ALLOW_LISTED_GITHUB_ORGS, {
+    errorMap: () => ({ message: 'Org must be one of: ' + ALLOW_LISTED_GITHUB_ORGS.join(', ') }),
+  }),
   repo: z.string(),
   commit: z.string(),
   path: z.string().transform((v) => (v.startsWith('/') ? v : `/${v}`)),

--- a/apps/docs/features/directives/utils.ts
+++ b/apps/docs/features/directives/utils.ts
@@ -6,7 +6,7 @@ import { toMarkdown } from 'mdast-util-to-markdown'
 import { gfm } from 'micromark-extension-gfm'
 import { mdxjs } from 'micromark-extension-mdxjs'
 
-import { getGitHubFileContents } from '~/lib/octokit'
+import { getGitHubFileContentsImmutableOnly } from '~/lib/octokit'
 import { codeSampleRemark } from './CodeSample'
 
 type Transformer = (ast: Root) => Root | Promise<Root>
@@ -26,5 +26,9 @@ export async function preprocessMdx<T>(mdx: string, transformers: Transformer[])
 }
 
 export function preprocessMdxWithDefaults(mdx: string) {
-  return preprocessMdx(mdx, [codeSampleRemark({ fetchFromGitHub: getGitHubFileContents })])
+  return preprocessMdx(mdx, [
+    codeSampleRemark({
+      fetchFromGitHub: getGitHubFileContentsImmutableOnly,
+    }),
+  ])
 }


### PR DESCRIPTION
We allow fetching external data in CodeSamples into a MDX environment, so we have to be careful about preventing code execution.

Current checks:

- External data is inserted as a code block (via the AST, not direct string manipulation), so it is escaped.

Added two new layers of checks:

- Allow-list of organizations, currently set to Supabase-only
- Only allow immutable commit references