### PR TITLE
Add next page loading state

### DIFF
--- a/apps/studio/components/interfaces/Auth/Users/UsersV2.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/UsersV2.tsx
@@ -1,5 +1,5 @@
 import dayjs from 'dayjs'
-import { RefreshCw, Search, User as UserIcon, Users, X } from 'lucide-react'
+import { Loader2, RefreshCw, Search, User as UserIcon, Users, X } from 'lucide-react'
 import { UIEvent, useMemo, useRef, useState } from 'react'
 import DataGrid, { Column, DataGridHandle, Row } from 'react-data-grid'
 
@@ -328,8 +328,14 @@ export const UsersV2 = () => {
           />
         )}
       </ResizablePanelGroup>
-      <div className="flex min-h-9 h-9 overflow-hidden items-center px-6 w-full border-t text-xs text-foreground-light">
-        Total: {totalUsers} users
+
+      <div className="flex justify-between min-h-9 h-9 overflow-hidden items-center px-6 w-full border-t text-xs text-foreground-light">
+        {isLoading || isRefetching ? 'Loading users...' : `Total: ${totalUsers} users`}
+        {(isLoading || isRefetching || isFetchingNextPage) && (
+          <span className="flex items-center gap-2">
+            <Loader2 size={14} className="animate-spin" /> Loading...
+          </span>
+        )}
       </div>
     </div>
   )

--- a/apps/studio/components/interfaces/Auth/Users/UsersV2.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/UsersV2.tsx
@@ -253,7 +253,7 @@ export const UsersV2 = () => {
           <AddUserDropdown projectKpsVersion={project?.kpsVersion} />
         </div>
       </div>
-      <LoadingLine loading={isLoading || isRefetching} />
+      <LoadingLine loading={isLoading || isRefetching || isFetchingNextPage} />
       <ResizablePanelGroup
         direction="horizontal"
         className="relative flex flex-grow bg-alternative min-h-0"

--- a/apps/studio/data/auth/users-infinite-query.ts
+++ b/apps/studio/data/auth/users-infinite-query.ts
@@ -14,7 +14,7 @@ export type UsersVariables = {
   filter?: Filter
 }
 
-export const USERS_PAGE_LIMIT = 20
+export const USERS_PAGE_LIMIT = 50
 export type User = components['schemas']['UserBody']
 
 export async function getUsers(


### PR DESCRIPTION
- adjusts the default fetch from 20 → 50 
- adds footer loading state
- hides "Total: __ users" until the total is ready to display
- add LoadingLine on isLoading || isRefetching || isFetchingNextPage 

![screenshot-2024-09-28-at-09 27 38](https://github.com/user-attachments/assets/0c5aea93-f461-4da6-a864-930aa079b83b)
