### PR TITLE
fix: close github authorization window

### DIFF
--- a/apps/studio/pages/integrations/github/authorize.tsx
+++ b/apps/studio/pages/integrations/github/authorize.tsx
@@ -4,7 +4,7 @@ import { useParams } from 'common'
 import { useGitHubAuthorizationCreateMutation } from 'data/integrations/github-authorization-create-mutation'
 
 const GitHubIntegrationAuthorize = () => {
-  const { code, state } = useParams()
+  const { code, state, setup_action } = useParams()
 
   const { mutate, isSuccess, isError, isLoading } = useGitHubAuthorizationCreateMutation({
     onSuccess() {
@@ -15,8 +15,10 @@ const GitHubIntegrationAuthorize = () => {
   useEffect(() => {
     if (code && state) {
       mutate({ code, state })
+    } else if (setup_action === 'install') {
+      window.close()
     }
-  }, [code, state, mutate])
+  }, [code, state, mutate, setup_action])
 
   return (
     <div className="h-screen flex flex-col justify-center items-center gap-4">


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

After clicking "add repositories", the window stays open.

## What is the new behavior?

Closes after adding repos.

## Additional context

Adding repos is handled via the webhook, meaning this last screen isn't actually required.