### PR TITLE
Clarify how to use the service role key with the rest API

### DIFF
--- a/apps/docs/content/guides/auth/jwts.mdx
+++ b/apps/docs/content/guides/auth/jwts.mdx
@@ -162,6 +162,14 @@ You'll notice that this token is quite a bit longer, since it contains informati
 }
 ```
 
+If using the service role key, you'll need to pass it into both the `apikey` and `authorization` headers (again, only do this from a secure environment such as your own server):
+
+```bash
+curl "$YOUR_PROJECT_URL/rest/v1/colors?select=name" \
+ -H "apikey: $YOUR_SERVICE_ROLE_KEY" \
+ -H "authorization: Bearer $YOUR_SERVICE_ROLE_KEY"
+```
+
 Now that you understand what JWTs are and where they're used in Supabase, you can explore how to use them in combination with Row Level Security to start restricting access to certain tables, rows, and columns in your Postgres database.
 
 ## Resources


### PR DESCRIPTION
I struggled with this for a while. v0 was able to figure this out from the docs, but I wasn't, so I thought an explicit example which makes it easy to go from values you see in the dashboard to what-do-i-need-to-do would help.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

People like me getting confused as to how to use the service role key when working with the rest API directly (not using a client library)

## What is the new behavior?

A `curl` example showing how to use it

## Additional context

There is an example saying that you need to pass both the `apikey` and `authorization` header when auth'ing a *user*, but it doesn't for a service role.

I reiterated that people should only use the service role key from a secure environment like a server because I don't want to be responsible for people not doing that. But I can remove if it feels like too much.
