### PR TITLE
Fixed Issue #29573, there were typos in an example on the Storage page

### DIFF
--- a/apps/www/data/products/storage/permissions-examples.js
+++ b/apps/www/data/products/storage/permissions-examples.js
@@ -38,9 +38,9 @@ for all using (
   bucket_id = 'avatars' 
   and auth.role() = 'authenticated'
 );`,
-    detail_title: 'Allow any authenticated user access to a folder',
+    detail_title: 'Allow any authenticated user access to a bucket',
     detail_text:
-      "This will allow any authenticated user access to the folder named 'authenticated' in the bucket 'avatars'",
+      "This will allow any authenticated user access to the bucket 'avatars'",
     badges_label: '',
     badges: [],
     url: '',


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix (typo)

## What is the current behavior?

"Allow any authenticated user access to a folder"

"This will allow any authenticated user access to the folder named 'authenticated' in the bucket 'avatars'"

## What is the new behavior?

"Allow any authenticated user access to a bucket"

"This will allow any authenticated user access to the bucket 'avatars'"
