### PR TITLE
Fix scroll issue in settings infra reactflow

### DIFF
--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceConfiguration.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceConfiguration.tsx
@@ -207,7 +207,7 @@ const InstanceConfigurationUI = () => {
   }, [isSuccessReplicas, isSuccessLoadBalancers, nodes, edges, view])
 
   return (
-    <div>
+    <div className="nowheel">
       <div
         className={`h-[500px] w-full relative ${
           isSuccessReplicas && !isLoadingProject ? '' : 'flex items-center justify-center px-28'


### PR DESCRIPTION
Currently if you try to mouse wheel scroll in settings/infrastructure while your cursor is in the react flow canvas, nothing happens. This fixes that by ensuring the page scroll works, since we've disabled zoom on scroll for our react flow anyways