### PR TITLE
Chore/improvements to datetime editing in table editor

### DIFF
--- a/apps/studio/components/grid/components/editor/DateEditor.tsx
+++ b/apps/studio/components/grid/components/editor/DateEditor.tsx
@@ -1,10 +1,5 @@
-import * as React from 'react'
+import { ChangeEvent, useEffect, useRef } from 'react'
 import type { RenderEditCellProps } from 'react-data-grid'
-
-function autoFocusAndSelect(input: HTMLInputElement | null) {
-  input?.focus()
-  input?.select()
-}
 
 export function DateEditor<TRow, TSummaryRow = unknown>({
   row,
@@ -12,22 +7,30 @@ export function DateEditor<TRow, TSummaryRow = unknown>({
   onRowChange,
   onClose,
 }: RenderEditCellProps<TRow, TSummaryRow>) {
+  const ref = useRef<HTMLInputElement>(null)
   const value = row[column.key as keyof TRow] as unknown as string
 
-  function onChange(event: React.ChangeEvent<HTMLInputElement>) {
+  function onChange(event: ChangeEvent<HTMLInputElement>) {
     let _value = event.target.value
     if (_value == '') onRowChange({ ...row, [column.key]: null })
     else onRowChange({ ...row, [column.key]: _value })
   }
 
+  useEffect(() => {
+    if (ref.current) {
+      ref.current.focus()
+      ref.current.showPicker()
+    }
+  }, [])
+
   return (
     <input
-      className="sb-grid-date-editor"
-      ref={autoFocusAndSelect}
+      ref={ref}
+      type="date"
+      className="h-full w-full px-2 text-sm"
       value={value ?? ''}
       onChange={onChange}
       onBlur={() => onClose(true)}
-      type="date"
     />
   )
 }

--- a/apps/studio/components/grid/components/editor/DateTimeEditor.tsx
+++ b/apps/studio/components/grid/components/editor/DateTimeEditor.tsx
@@ -1,14 +1,6 @@
-import type { ChangeEvent } from 'react'
-import type { RenderEditCellProps } from 'react-data-grid'
 import dayjs from 'dayjs'
-import customParseFormat from 'dayjs/plugin/customParseFormat'
-
-dayjs.extend(customParseFormat)
-
-function autoFocusAndSelect(input: HTMLInputElement | null) {
-  input?.focus()
-  input?.select()
-}
+import { useEffect, useRef, type ChangeEvent } from 'react'
+import type { RenderEditCellProps } from 'react-data-grid'
 
 interface Props<TRow, TSummaryRow = unknown> extends RenderEditCellProps<TRow, TSummaryRow> {
   format: string
@@ -23,6 +15,7 @@ function BaseEditor<TRow, TSummaryRow = unknown>({
   onRowChange,
   onClose,
 }: Props<TRow, TSummaryRow>) {
+  const ref = useRef<HTMLInputElement>(null)
   const value = row[column.key as keyof TRow] as unknown as string
   const timeValue = value ? dayjs(value, format).format(INPUT_DATE_TIME_FORMAT) : value
 
@@ -36,15 +29,22 @@ function BaseEditor<TRow, TSummaryRow = unknown>({
     }
   }
 
+  useEffect(() => {
+    if (ref.current) {
+      ref.current.focus()
+      ref.current.showPicker()
+    }
+  }, [])
+
   return (
     <input
-      className="sb-grid-datetime-editor"
-      ref={autoFocusAndSelect}
+      ref={ref}
+      step="1"
+      type="datetime-local"
+      className="h-full w-full px-2 text-sm"
       value={timeValue ?? ''}
       onChange={onChange}
       onBlur={() => onClose(true)}
-      type="datetime-local"
-      step="1"
     />
   )
 }

--- a/apps/studio/components/grid/components/editor/DateTimeEditor.tsx
+++ b/apps/studio/components/grid/components/editor/DateTimeEditor.tsx
@@ -2,11 +2,10 @@ import dayjs from 'dayjs'
 import { useEffect, useRef, type ChangeEvent } from 'react'
 import type { RenderEditCellProps } from 'react-data-grid'
 
-interface Props<TRow, TSummaryRow = unknown> extends RenderEditCellProps<TRow, TSummaryRow> {
+interface BaseEditorProps<TRow, TSummaryRow = unknown>
+  extends RenderEditCellProps<TRow, TSummaryRow> {
   format: string
 }
-
-const INPUT_DATE_TIME_FORMAT = 'YYYY-MM-DDTHH:mm:ss'
 
 function BaseEditor<TRow, TSummaryRow = unknown>({
   row,
@@ -14,10 +13,10 @@ function BaseEditor<TRow, TSummaryRow = unknown>({
   format,
   onRowChange,
   onClose,
-}: Props<TRow, TSummaryRow>) {
+}: BaseEditorProps<TRow, TSummaryRow>) {
   const ref = useRef<HTMLInputElement>(null)
   const value = row[column.key as keyof TRow] as unknown as string
-  const timeValue = value ? dayjs(value, format).format(INPUT_DATE_TIME_FORMAT) : value
+  const timeValue = value ? dayjs(value, format).format('YYYY-MM-DDTHH:mm:ss') : value
 
   function onChange(event: ChangeEvent<HTMLInputElement>) {
     const _value = event.target.value

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnType.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnType.tsx
@@ -277,7 +277,7 @@ const ColumnType = ({
       </Popover_Shadcn_>
 
       {showRecommendation && recommendation !== undefined && (
-        <Alert_Shadcn_ variant="warning">
+        <Alert_Shadcn_ variant="warning" className="mt-2">
           <CriticalIcon />
           <AlertTitle_Shadcn_>
             {' '}

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/DateTimeInput/DateTimeInput.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/DateTimeInput/DateTimeInput.tsx
@@ -1,8 +1,17 @@
 import dayjs from 'dayjs'
 import { ReactNode } from 'react'
-import { Button, cn, Input } from 'ui'
+import {
+  Button,
+  cn,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  Input,
+} from 'ui'
 
 import { getColumnType } from './DateTimeInput.utils'
+import { Edit } from 'lucide-react'
 
 interface DateTimeInputProps {
   name: string
@@ -31,7 +40,7 @@ const DateTimeInput = ({
   return (
     <Input
       layout="horizontal"
-      className={cn('w-full', isNullable && '[&>div>div>div>input]:pr-24')}
+      className={cn('w-full', isNullable && '[&>div>div>div>input]:pr-10')}
       label={name}
       descriptionText={
         <div className="space-y-1">
@@ -48,12 +57,23 @@ const DateTimeInput = ({
       step={inputType == 'datetime-local' || inputType == 'time' ? '1' : undefined}
       actions={
         isNullable && (
-          <Button type="default" onClick={() => onChange('')}>
-            Set to NULL
-          </Button>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button type="default" icon={<Edit />} className="px-1.5" />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-28">
+              <DropdownMenuItem onClick={() => onChange('')}>Set to NULL</DropdownMenuItem>
+              <DropdownMenuItem onClick={() => onChange(dayjs().format('YYYY-MM-DDTHH:mm:ss'))}>
+                Set to now
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
         )
       }
-      onChange={(e) => onChange(e.target.value)}
+      onChange={(e) => {
+        console.log(e.target.value)
+        onChange(e.target.value)
+      }}
     />
   )
 }

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/DateTimeInput/DateTimeInput.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/DateTimeInput/DateTimeInput.tsx
@@ -61,17 +61,28 @@ const DateTimeInput = ({
             <Button type="default" icon={<Edit />} className="px-1.5" />
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end" className="w-28">
-            <DropdownMenuItem onClick={() => onChange('')}>Set to NULL</DropdownMenuItem>
-            <DropdownMenuItem onClick={() => onChange(dayjs().format('YYYY-MM-DDTHH:mm:ss'))}>
+            {isNullable && (
+              <DropdownMenuItem onClick={() => onChange('')}>Set to NULL</DropdownMenuItem>
+            )}
+            <DropdownMenuItem
+              onClick={() =>
+                onChange(
+                  dayjs().format(
+                    format === 'date'
+                      ? 'YYYY-MM-DD'
+                      : ['time', 'timetz'].includes(format)
+                        ? 'HH:mm:ss'
+                        : 'YYYY-MM-DDTHH:mm:ss'
+                  )
+                )
+              }
+            >
               Set to now
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
       }
-      onChange={(e) => {
-        console.log(e.target.value)
-        onChange(e.target.value)
-      }}
+      onChange={(e) => onChange(e.target.value)}
     />
   )
 }

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/DateTimeInput/DateTimeInput.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/DateTimeInput/DateTimeInput.tsx
@@ -1,6 +1,6 @@
 import dayjs from 'dayjs'
 import { ReactNode } from 'react'
-import { Input } from 'ui'
+import { Button, cn, Input } from 'ui'
 
 import { getColumnType } from './DateTimeInput.utils'
 
@@ -8,6 +8,7 @@ interface DateTimeInputProps {
   name: string
   format: string
   value: string
+  isNullable: boolean
   description: string | ReactNode
   onChange: (value: string) => void
 }
@@ -17,19 +18,20 @@ interface DateTimeInputProps {
  * e.g Yes: 2022-05-13T14:29:03
  *     No:  2022-05-13T14:29:03+0800
  */
-const DateTimeInput = ({ value, onChange, name, format, description }: DateTimeInputProps) => {
+const DateTimeInput = ({
+  value,
+  onChange,
+  name,
+  isNullable,
+  format,
+  description,
+}: DateTimeInputProps) => {
   const inputType = getColumnType(format)
-
-  function handleOnChange(e: any) {
-    const temp = e.target.value
-    if (temp.length === 0 && temp !== '') return
-    onChange(temp)
-  }
 
   return (
     <Input
       layout="horizontal"
-      className="w-full"
+      className={cn('w-full', isNullable && '[&>div>div>div>input]:pr-24')}
       label={name}
       descriptionText={
         <div className="space-y-1">
@@ -43,8 +45,15 @@ const DateTimeInput = ({ value, onChange, name, format, description }: DateTimeI
       size="small"
       value={value}
       type={inputType}
-      onChange={handleOnChange}
       step={inputType == 'datetime-local' || inputType == 'time' ? '1' : undefined}
+      actions={
+        isNullable && (
+          <Button type="default" onClick={() => onChange('')}>
+            Set to NULL
+          </Button>
+        )
+      }
+      onChange={(e) => onChange(e.target.value)}
     />
   )
 }

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/DateTimeInput/DateTimeInput.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/DateTimeInput/DateTimeInput.tsx
@@ -1,5 +1,7 @@
 import dayjs from 'dayjs'
+import { Edit } from 'lucide-react'
 import { ReactNode } from 'react'
+
 import {
   Button,
   cn,
@@ -9,9 +11,7 @@ import {
   DropdownMenuTrigger,
   Input,
 } from 'ui'
-
 import { getColumnType } from './DateTimeInput.utils'
-import { Edit } from 'lucide-react'
 
 interface DateTimeInputProps {
   name: string
@@ -40,7 +40,7 @@ const DateTimeInput = ({
   return (
     <Input
       layout="horizontal"
-      className={cn('w-full', isNullable && '[&>div>div>div>input]:pr-10')}
+      className={cn('w-full [&>div>div>div>input]:pr-10')}
       label={name}
       descriptionText={
         <div className="space-y-1">
@@ -56,19 +56,17 @@ const DateTimeInput = ({
       type={inputType}
       step={inputType == 'datetime-local' || inputType == 'time' ? '1' : undefined}
       actions={
-        isNullable && (
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button type="default" icon={<Edit />} className="px-1.5" />
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-28">
-              <DropdownMenuItem onClick={() => onChange('')}>Set to NULL</DropdownMenuItem>
-              <DropdownMenuItem onClick={() => onChange(dayjs().format('YYYY-MM-DDTHH:mm:ss'))}>
-                Set to now
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-        )
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button type="default" icon={<Edit />} className="px-1.5" />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-28">
+            <DropdownMenuItem onClick={() => onChange('')}>Set to NULL</DropdownMenuItem>
+            <DropdownMenuItem onClick={() => onChange(dayjs().format('YYYY-MM-DDTHH:mm:ss'))}>
+              Set to now
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
       }
       onChange={(e) => {
         console.log(e.target.value)

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/InputField.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/InputField.tsx
@@ -231,6 +231,7 @@ const InputField = ({
         name={field.name}
         format={field.format}
         value={field.value ?? ''}
+        isNullable={field.isNullable}
         description={
           <>
             {field.defaultValue && <p>Default: {field.defaultValue}</p>}

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/InputField.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/InputField.tsx
@@ -168,7 +168,7 @@ const InputField = ({
               <DropdownMenuTrigger asChild>
                 <Button type="default" icon={<Edit />} className="px-1.5" />
               </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-40">
+              <DropdownMenuContent align="end" className="w-28">
                 <DropdownMenuItem onClick={() => onUpdateField({ [field.name]: null })}>
                   Set to NULL
                 </DropdownMenuItem>

--- a/apps/studio/pages/project/[ref]/database/functions.tsx
+++ b/apps/studio/pages/project/[ref]/database/functions.tsx
@@ -43,7 +43,10 @@ const FunctionsPage: NextPageWithLayout = () => {
       <ScaffoldContainer>
         <ScaffoldSection>
           <div className="col-span-12">
-            <FormHeader title="Database Functions" />
+            <FormHeader
+              title="Database Functions"
+              docsUrl="https://supabase.com/docs/guides/database/functions"
+            />
             <FunctionsList
               createFunction={createFunction}
               editFunction={editFunction}

--- a/apps/studio/pages/project/[ref]/database/tables/index.tsx
+++ b/apps/studio/pages/project/[ref]/database/tables/index.tsx
@@ -18,7 +18,7 @@ const DatabaseTables: NextPageWithLayout = () => {
     <>
       <ScaffoldContainer>
         <ScaffoldSection>
-          <div className="col-span-12 space-x-2">
+          <div className="col-span-12">
             <FormHeader title="Database Tables" />
             <TableList
               onAddTable={snap.onAddTable}

--- a/apps/studio/pages/project/[ref]/database/triggers.tsx
+++ b/apps/studio/pages/project/[ref]/database/triggers.tsx
@@ -42,7 +42,11 @@ const TriggersPage: NextPageWithLayout = () => {
       <ScaffoldContainer>
         <ScaffoldSection>
           <div className="col-span-12">
-            <FormHeader title="Database Triggers" />
+            <FormHeader
+              title="Database Triggers"
+              description="Execute a set of actions automatically on specified table events"
+              docsUrl="https://supabase.com/docs/guides/database/postgres/triggers"
+            />
             <TriggersList
               createTrigger={createTrigger}
               editTrigger={editTrigger}

--- a/apps/studio/styles/grid.scss
+++ b/apps/studio/styles/grid.scss
@@ -339,22 +339,6 @@
 }
 
 /*
-  DateEditor
-*/
-
-.sb-grid-date-editor {
-  @apply h-full w-full px-2;
-}
-
-/*
-  DateTimeEditor
-*/
-
-.sb-grid-datetime-editor {
-  @apply h-full w-full px-2;
-}
-
-/*
   JsonEditor
 */
 


### PR DESCRIPTION
### Small improvements to datetime editing
- In the grid: Date time picker automatically opens when you click to edit a cell
- In the side panel: Added an action for time input types, to either set to NULL or set to now
  - This should alleviate a problem on Safari as the default browser date picker UI does not support setting the value to NULL (See bottom for browser date picker references)
  - On Safari you still can't set a time type field to NULL within the grid editor still though, I haven't been able to figure out a good solution for this just yet as its a little more complicated with the grid cell's focusing state and all
![image](https://github.com/user-attachments/assets/8c796525-6a7a-4a1b-b620-47e5183a4f58)

Reference for default browser pickers:
- Chrome: 
![image](https://github.com/user-attachments/assets/94c88bc9-5678-4f75-b2b8-76b753055014)
- Safari: 
![image](https://github.com/user-attachments/assets/c7eb67af-48a0-4083-88e1-ef787b6c50f6)
- Firefox:
![image](https://github.com/user-attachments/assets/8d52fcea-b70a-4140-a926-cda7b944565d)

