### PR TITLE
Chore/add validation for supabase prefix in edge functions secrets management

### DIFF
--- a/apps/studio/components/interfaces/Functions/EdgeFunctionSecrets/AddNewSecretModal.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionSecrets/AddNewSecretModal.tsx
@@ -1,10 +1,15 @@
-import { useParams } from 'common'
-import { useRef, useState } from 'react'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useEffect, useRef, useState } from 'react'
+import { SubmitHandler, useForm } from 'react-hook-form'
 import { toast } from 'sonner'
-import { Button, Form, Input, Modal } from 'ui'
+import z from 'zod'
 
+import { useParams } from 'common'
 import { useSecretsCreateMutation } from 'data/secrets/secrets-create-mutation'
-import { EyeOff, Eye } from 'lucide-react'
+import { Eye, EyeOff } from 'lucide-react'
+import { Button, Form_Shadcn_, FormControl_Shadcn_, FormField_Shadcn_, Modal } from 'ui'
+import { Input } from 'ui-patterns/DataInputs/Input'
+import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 
 interface AddNewSecretModalProps {
   visible: boolean
@@ -16,27 +21,45 @@ const AddNewSecretModal = ({ visible, onClose }: AddNewSecretModalProps) => {
   const submitRef = useRef<HTMLButtonElement>(null)
   const [showSecretValue, setShowSecretValue] = useState(false)
 
+  const FormSchema = z.object({
+    name: z
+      .string()
+      .min(1, 'Please provide a name for your secret')
+      .refine((value) => !value.match(/^(SUPABASE_).*/), {
+        message: 'Secret name must not start with the SUPABASE_ prefix',
+        path: ['name'],
+      }),
+    value: z.string().min(1, 'Please provider a value for your secret'),
+  })
+  const defaultValues = { name: '', value: '' }
+
+  const form = useForm({
+    resolver: zodResolver(FormSchema),
+    defaultValues,
+  })
+
+  const onSubmit: SubmitHandler<z.infer<typeof FormSchema>> = async (data) => {
+    createSecret({ projectRef, secrets: [data] })
+  }
+
   const { mutate: createSecret, isLoading: isCreating } = useSecretsCreateMutation({
-    onSuccess: (res, variables) => {
+    onSuccess: (_, variables) => {
       toast.success(`Successfully created new secret "${variables.secrets[0].name}"`)
       onClose()
     },
   })
 
-  const validate = (values: any) => {
-    const errors: any = {}
-    if (values.name.length === 0) errors.name = 'Please provide a name for your secret'
-    if (values.value.length === 0) errors.value = 'Please provide a value for your secret'
-    return errors
-  }
-
-  const onSubmit = (values: any) => {
-    createSecret({ projectRef, secrets: [values] })
-  }
+  useEffect(() => {
+    if (visible) {
+      form.reset(defaultValues)
+      setShowSecretValue(false)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [visible])
 
   return (
     <Modal
-      size="medium"
+      size="small"
       visible={visible}
       onCancel={onClose}
       header="Create a new secret"
@@ -57,37 +80,52 @@ const AddNewSecretModal = ({ visible, onClose }: AddNewSecretModalProps) => {
         </div>
       }
     >
-      <Form
-        validateOnBlur
-        initialValues={{ name: '', value: '' }}
-        validate={validate}
-        onSubmit={onSubmit}
-      >
-        {() => (
-          <>
-            <Modal.Content className="space-y-3">
-              <Input id="name" label="Secret name" />
-              <Input
-                id="value"
-                label="Secret value"
-                className="input-mono"
-                type={showSecretValue ? 'text' : 'password'}
-                actions={
-                  <div className="mr-1">
-                    <Button
-                      type="default"
-                      className="px-1"
-                      icon={showSecretValue ? <EyeOff /> : <Eye />}
-                      onClick={() => setShowSecretValue(!showSecretValue)}
+      <Modal.Content>
+        <Form_Shadcn_ {...form}>
+          <form
+            id="create-secret-form"
+            className="w-full flex flex-col gap-y-2"
+            onSubmit={form.handleSubmit(onSubmit)}
+          >
+            <FormField_Shadcn_
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItemLayout label="Secret name">
+                  <FormControl_Shadcn_>
+                    <Input {...field} />
+                  </FormControl_Shadcn_>
+                </FormItemLayout>
+              )}
+            />
+            <FormField_Shadcn_
+              control={form.control}
+              name="value"
+              render={({ field }) => (
+                <FormItemLayout label="Secret value">
+                  <FormControl_Shadcn_>
+                    <Input
+                      {...field}
+                      type={showSecretValue ? 'text' : 'password'}
+                      actions={
+                        <div className="mr-1">
+                          <Button
+                            type="default"
+                            className="px-1"
+                            icon={showSecretValue ? <EyeOff /> : <Eye />}
+                            onClick={() => setShowSecretValue(!showSecretValue)}
+                          />
+                        </div>
+                      }
                     />
-                  </div>
-                }
-              />
-            </Modal.Content>
+                  </FormControl_Shadcn_>
+                </FormItemLayout>
+              )}
+            />
             <button className="hidden" type="submit" ref={submitRef} />
-          </>
-        )}
-      </Form>
+          </form>
+        </Form_Shadcn_>
+      </Modal.Content>
     </Modal>
   )
 }

--- a/apps/studio/components/interfaces/Functions/EdgeFunctionSecrets/AddNewSecretModal.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionSecrets/AddNewSecretModal.tsx
@@ -26,8 +26,7 @@ const AddNewSecretModal = ({ visible, onClose }: AddNewSecretModalProps) => {
       .string()
       .min(1, 'Please provide a name for your secret')
       .refine((value) => !value.match(/^(SUPABASE_).*/), {
-        message: 'Secret name must not start with the SUPABASE_ prefix',
-        path: ['name'],
+        message: 'Name must not start with the SUPABASE_ prefix',
       }),
     value: z.string().min(1, 'Please provider a value for your secret'),
   })

--- a/apps/studio/components/interfaces/Functions/EdgeFunctionSecrets/EdgeFunctionSecret.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionSecrets/EdgeFunctionSecret.tsx
@@ -13,6 +13,10 @@ interface EdgeFunctionSecretProps {
 
 const EdgeFunctionSecret = ({ secret, onSelectDelete }: EdgeFunctionSecretProps) => {
   const canUpdateSecrets = useCheckPermissions(PermissionAction.FUNCTIONS_WRITE, '*')
+  // [Joshen] Following API's validation:
+  // https://github.com/supabase/infrastructure/blob/develop/api/src/routes/v1/projects/ref/secrets/secrets.controller.ts#L106
+  const isReservedSecret = !!secret.name.match(/^(SUPABASE_).*/)
+
   return (
     <Table.tr>
       <Table.td>
@@ -31,12 +35,14 @@ const EdgeFunctionSecret = ({ secret, onSelectDelete }: EdgeFunctionSecretProps)
             type="text"
             icon={<Trash />}
             className="px-1"
-            disabled={!canUpdateSecrets}
+            disabled={!canUpdateSecrets || isReservedSecret}
             onClick={() => onSelectDelete()}
             tooltip={{
               content: {
                 side: 'bottom',
-                text: 'You need additional permissions to delete edge function secrets',
+                text: isReservedSecret
+                  ? 'This is a reserved secret and cannot be deleted'
+                  : 'You need additional permissions to delete edge function secrets',
               },
             }}
           />

--- a/apps/studio/components/interfaces/Functions/EdgeFunctionSecrets/EdgeFunctionSecrets.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionSecrets/EdgeFunctionSecrets.tsx
@@ -12,10 +12,11 @@ import { GenericSkeletonLoader } from 'components/ui/ShimmeringLoader'
 import { useSecretsDeleteMutation } from 'data/secrets/secrets-delete-mutation'
 import { ProjectSecret, useSecretsQuery } from 'data/secrets/secrets-query'
 import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
-import { Button, Input } from 'ui'
+import { Button } from 'ui'
 import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
 import AddNewSecretModal from './AddNewSecretModal'
 import EdgeFunctionSecret from './EdgeFunctionSecret'
+import { Input } from 'ui-patterns/DataInputs/Input'
 
 const EdgeFunctionSecrets = () => {
   const { ref: projectRef } = useParams()


### PR DESCRIPTION
- Add validation for SUPABASE_ prefix when creating new secret
![image](https://github.com/user-attachments/assets/7001e674-ab08-498d-b9c6-9d302987ce96)

- Add validation for SUPABASE_ prefix when deleting secrets
![image](https://github.com/user-attachments/assets/c9ea223c-dd0e-466a-bc32-abc190062595)
