### PR TITLE
Fix wrong style width value in solid tutorial

### DIFF
--- a/apps/docs/content/guides/getting-started/tutorials/with-solidjs.mdx
+++ b/apps/docs/content/guides/getting-started/tutorials/with-solidjs.mdx
@@ -354,7 +354,7 @@ const Avatar: Component<Props> = (props) => {
   }
 
   return (
-    <div style={{ width: props.size }} aria-live="polite">
+    <div style={{ width: `${props.size}px` }} aria-live="polite">
       {avatarUrl() ? (
         <img
           src={avatarUrl()!}

--- a/examples/user-management/solid-user-management/src/Auth.tsx
+++ b/examples/user-management/solid-user-management/src/Auth.tsx
@@ -12,7 +12,7 @@ const Auth: Component = () => {
 			setLoading(true)
 			const { error } = await supabase.auth.signInWithOtp({ email: email() })
 			if (error) throw error
-			alert('Check your email for login link!')
+			alert('Check your email for the login link!')
 		} catch (error) {
 			if (error instanceof Error) {
 				alert(error.message)

--- a/examples/user-management/solid-user-management/src/Avatar.tsx
+++ b/examples/user-management/solid-user-management/src/Avatar.tsx
@@ -61,7 +61,7 @@ const Avatar: Component<Props> = (props) => {
 	}
 
 	return (
-		<div style={{ width: props.size }} aria-live="polite">
+		<div style={{ width: `${props.size}px` }} aria-live="polite">
 			{avatarUrl() ? (
 				<img
 					src={avatarUrl()!}


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Fix issue in code in the solid tutorial.

## What is the current behavior?

The previous code gave a ts error:
`Type 'number' is not assignable to type 'Width<0 | (string & {})> | undefined'.ts(2322)`

## What is the new behavior?

The error goes away.

## Additional context

This is using the same logic than the div below. An alternative is just to remove the style on this div, all children have the width specified.
