### PR TITLE
Fix/allow count wildcard

### DIFF
--- a/apps/studio/components/interfaces/Settings/Logs/Logs.utils.ts
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.utils.ts
@@ -550,6 +550,8 @@ export function checkForILIKEClause(query: string) {
 export function checkForWildcard(query: string) {
   const queryWithoutComments = query.replace(/--.*$/gm, '').replace(/\/\*[\s\S]*?\*\//gm, '')
 
+  const queryWithoutCount = queryWithoutComments.replace(/count\(\*\)/gi, '')
+
   const wildcardRegex = /\*/
-  return wildcardRegex.test(queryWithoutComments)
+  return wildcardRegex.test(queryWithoutCount)
 }

--- a/apps/studio/tests/pages/projects/Logs.utils.test.ts
+++ b/apps/studio/tests/pages/projects/Logs.utils.test.ts
@@ -91,4 +91,8 @@ describe('checkForWildcard', () => {
     expect(checkForWildcard('-- *\nSELECT column FROM table')).toBe(false)
     expect(checkForWildcard('/* * */\nSELECT column FROM table')).toBe(false)
   })
+
+  test('count(*)', () => {
+    expect(checkForWildcard('SELECT count(*) FROM table')).toBe(false)
+  })
 })


### PR DESCRIPTION
the wilcard check is not allowing users to do `count(*)` in log explorer queries.