### PR TITLE
Avoid exposing Postgres database in default self-hosting setup

### DIFF
--- a/apps/docs/content/guides/self-hosting/docker.mdx
+++ b/apps/docs/content/guides/self-hosting/docker.mdx
@@ -315,7 +315,7 @@ By default, `docker compose` sets the database's `log_min_messages` configuratio
 
 #### Exposing your Postgres database
 
-By default, the Postgres database is only accessible locally. If you want to expose it to the outside world, you can update the `docker-compose.yml` file and remove the `127.0.0.1:` prefix from the `ports` section:
+By default, the Postgres database is only accessible locally. If you want to expose it to the outside world, you can update the `docker-compose.yml` file as follows:
 
 ```yaml docker-compose.yml
   db:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -338,7 +338,7 @@ services:
     # Uncomment to use Big Query backend for analytics
     # volumes:
     #   - type: bind
-    #     source: ${PWD}/gcloud.
+    #     source: ${PWD}/gcloud.json
     #     target: /opt/app/rel/logflare/bin/gcloud.json
     #     read_only: true
     environment:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -338,7 +338,7 @@ services:
     # Uncomment to use Big Query backend for analytics
     # volumes:
     #   - type: bind
-    #     source: ${PWD}/gcloud.json
+    #     source: ${PWD}/gcloud.
     #     target: /opt/app/rel/logflare/bin/gcloud.json
     #     read_only: true
     environment:
@@ -383,9 +383,6 @@ services:
       - -c
       - log_min_messages=fatal # prevents Realtime polling queries from appearing in logs
     restart: unless-stopped
-    ports:
-      # Pass down internal port because it's set dynamically by other services
-      - ${POSTGRES_PORT}:${POSTGRES_PORT}
     environment:
       POSTGRES_HOST: /var/run/postgresql
       PGPORT: ${POSTGRES_PORT}


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES ✅ 

## What kind of change does this PR introduce?

A "bug" fix (is that more a security fix ?), and associated docs update

## What is the current behavior?

Postgres database is exposed (via `db` service) by default in `docker/docker-compose.yml`, which could be a security issue (_anyone setting up a self-hosted Supabase instance is exposing its db..._) and is contradictory to what the documentation states:
> By default, the Postgres database is only accessible locally

## What is the new behavior?

**Service `db` is not exposed anymore by default.**

## Additional context

I also updated the documentation to remove a part mentioning a prefix that wasn't there anymore
> remove the 127.0.0.1: prefix from the ports section

Other services do not need that, they access the database through `${POSTGRES_HOST}:${POSTGRES_PORT}`, internally.
