### PR TITLE
fix audit logs title

### DIFF
--- a/apps/studio/pages/account/audit.tsx
+++ b/apps/studio/pages/account/audit.tsx
@@ -20,11 +20,11 @@ const User: NextPageWithLayout = () => {
 
 User.getLayout = (page) => (
   <AccountLayout
-    title="Preferences"
+    title="Audit Logs"
     breadcrumbs={[
       {
         key: `supabase-settings`,
-        label: 'Preferences',
+        label: 'Audit Logs',
       },
     ]}
   >


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Selecting Audit Logs in the studio shows Preferences at the top:
<img width="714" alt="image" src="https://github.com/user-attachments/assets/c1f24b21-5d96-4d89-a3ab-f875a7142ca0">

## What is the new behavior?

Selecting Audit Logs in the studio shows Audit Logs at the top:

<img width="714" alt="image" src="https://github.com/user-attachments/assets/b565c1d3-38a3-4de5-9b0c-b4e242872c99">

## Additional context
N/A