### PR TITLE
chore: kaizen changes for disk size billing

### DIFF
--- a/apps/docs/content/guides/platform/database-size.mdx
+++ b/apps/docs/content/guides/platform/database-size.mdx
@@ -134,6 +134,6 @@ set default_transaction_read_only = 'off';
 
 ### Reducing disk size
 
-Disks don't automatically downsize during normal operation. Once you have (reduced your database space usage)[/docs/guides/platform/database-size#database-space-management], they _will_ automatically "right-size" when a Supabase (or Postgres) update is applied. Their final size after the update is 1.2x the size of the database (min 8 GB). For example, if your database is 100GB in size, and you have a 200GB disk, the size after a Supabase update will be 120GB.
+Disks don't automatically downsize during normal operation. Once you have [reduced your database space usage](/docs/guides/platform/database-size#database-space-management), they _will_ automatically "right-size" when a Supabase (or Postgres) update is applied. Their final size after the update is 1.2x the size of the database (min 8 GB). For example, if your database is 100GB in size, and you have a 200GB disk, the size after a Supabase update will be 120GB.
 
 Learn more about [upgrading your project](/docs/guides/platform/migrating-and-upgrading-projects#upgrade-your-project).

--- a/apps/docs/content/guides/platform/org-based-billing.mdx
+++ b/apps/docs/content/guides/platform/org-based-billing.mdx
@@ -160,9 +160,11 @@ Free Plan customers are limited to 500 MB of database space.
 
 For paid plan customers, we provision 8 GB of GP3 disk by default. If your database grows close to the underlying disk limit, we autoscale it by 1.5x. The first 8 GB of provisioned disk per project are free of charge. Disk size beyond the first 8 GB costs $0.125/month/GB.
 
-Disk Size is prorated down to the hour, so your bill will show "Disk Size GB-Hrs". See [Database Size](/docs/guides/platform/database-size) for further information.
+Disk Size is prorated down to the hour, so your bill will show "Disk Size GB-Hrs".
 
-Read more about [disk management](/docs/guides/platform/database-size#disk-management).
+As an example, if your project is using 12 GB of provisioned disk for the entire month, that's 4 GB above the included quota and will cost an additional $0.5/month (4 GB x $0.125).
+
+While we automatically scale up your disk, we do not automatically scale down your disk. Read more about [disk management](/docs/guides/platform/database-size#disk-management) and how to [reduce your disk size](/docs/guides/platform/database-size#reducing-disk-size).
 
 ## Free Plan
 

--- a/apps/docs/content/guides/platform/org-based-billing.mdx
+++ b/apps/docs/content/guides/platform/org-based-billing.mdx
@@ -156,13 +156,19 @@ You can see a breakdown of the different types of egress on your [organization u
 ## Disk Size
 
 We differentiate between database space usage and disk size. Database Space is the actual amount of space used by all your database objects, whereas disk size is the size of the underlying provisioned disk. Each database has a provisioned disk.
+
 Free Plan customers are limited to 500 MB of database space.
 
-For paid plan customers, we provision 8 GB of GP3 disk by default. If your database grows close to the underlying disk limit, we autoscale it by 1.5x. The first 8 GB of provisioned disk per project are free of charge. Disk size beyond the first 8 GB costs $0.125/month/GB.
+For paid plan customers:
 
-Disk Size is prorated down to the hour, so your bill will show "Disk Size GB-Hrs".
+- Each project starts with 8 GB GP3 disk provisioned by default
+- The first 8 GB of provisioned disk per project is free, then $0.125 per additional GB
+- Charges are prorated down to the hour, which is advantageous for short-lived projects and branches
+- Each read replica has a provisioned disk as well, which adds to your disk usage
 
-As an example, if your project is using 12 GB of provisioned disk for the entire month, that's 4 GB above the included quota and will cost an additional $0.5/month (4 GB x $0.125).
+When your data gets close to the 8 GB disk size limit, we automatically scale it by 50% on paid plans to ensure your project does not run into a read-only mode. Each hour your disk is beyond the included 8 GB, it incurs one GB-Hr of usage. With a 12 GB provisioned disk (4 GB above the limit), this would incur a total monthly cost of $0.5 ($0.125 per GB / $0.000171 per GB-Hr). Disk Size is prorated down to the hour, so your bill will show "Disk Size GB-Hrs".
+
+You can see your project’s disk size in your [project settings](https://supabase.com/dashboard/project/_/settings/database) (Project Settings > Database).
 
 While we automatically scale up your disk, we do not automatically scale down your disk. Read more about [disk management](/docs/guides/platform/database-size#disk-management) and how to [reduce your disk size](/docs/guides/platform/database-size#reducing-disk-size).
 

--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/BillingBreakdown.constants.ts
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/BillingBreakdown.constants.ts
@@ -1,5 +1,4 @@
 import { PricingMetric } from 'data/analytics/org-daily-stats-query'
-import React from 'react'
 
 export const USAGE_APPROACHING_THRESHOLD = 0.8
 

--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/BillingBreakdown.constants.ts
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/BillingBreakdown.constants.ts
@@ -1,4 +1,5 @@
 import { PricingMetric } from 'data/analytics/org-daily-stats-query'
+import React from 'react'
 
 export const USAGE_APPROACHING_THRESHOLD = 0.8
 
@@ -10,6 +11,10 @@ export interface Metric {
   category: string
   unitName?: string
   tip?: string
+  docLink?: {
+    title: string
+    url: string
+  }
 }
 
 export const BILLING_BREAKDOWN_METRICS: Metric[] = [
@@ -94,7 +99,11 @@ export const BILLING_BREAKDOWN_METRICS: Metric[] = [
     units: 'absolute',
     unitName: 'GB-Hrs',
     category: 'Database',
-    tip: 'Each project gets provisioned with 8 GB of disk. When you get close to the disk size limit, we autoscale your disk by 1.5x. The first 8 GB of disk is free for every single project.',
+    tip: 'Each project gets provisioned with 8 GB of GP3 disk for free. When you get close to the disk size limit, we autoscale your disk by 1.5x. Each GB of provisioned disk size beyond 8 GB incurs a GB-Hr every hour. Each extra GB is billed at $0.125/month, prorated down to the hour.',
+    docLink: {
+      title: 'Read more',
+      url: 'https://supabase.com/docs/guides/platform/org-based-billing#disk-size',
+    },
   },
   {
     key: PricingMetric.DISK_SIZE_GB_HOURS_IO2,

--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/BillingMetric.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/BillingMetric.tsx
@@ -8,7 +8,7 @@ import { useMemo } from 'react'
 import { Button, HoverCard, HoverCardContent, HoverCardTrigger } from 'ui'
 import { billingMetricUnit, formatUsage } from '../helpers'
 import { Metric, USAGE_APPROACHING_THRESHOLD } from './BillingBreakdown.constants'
-import { ChevronRight, PieChart } from 'lucide-react'
+import { ChevronRight, InfoIcon, PieChart } from 'lucide-react'
 
 export interface BillingMetricProps {
   idx: number
@@ -77,8 +77,8 @@ const BillingMetric = ({
         : `(${(+(usageRatio * 100).toFixed(0)).toLocaleString()}%)`
 
   return (
-    <HoverCard openDelay={0} closeDelay={0}>
-      <HoverCardTrigger asChild>
+    <HoverCard openDelay={50} closeDelay={200}>
+      <HoverCardTrigger>
         <div className="flex items-center justify-between cursor-pointer">
           <div>
             {metric.anchor ? (
@@ -91,7 +91,7 @@ const BillingMetric = ({
                 </div>
               </Link>
             ) : (
-              <p className="text-xs text-foreground-light">{metric.name}</p>
+              <p className="text-xs text-foreground-light flex space-x-1">{metric.name}</p>
             )}
             <span className="text-sm">{usageLabel}</span>&nbsp;
             {relativeToSubscription && usageMeta.cost && usageMeta.cost > 0 ? (
@@ -136,9 +136,7 @@ const BillingMetric = ({
                     }
                   />
                 </svg>
-              ) : (
-                <PieChart className="h-8 w-8 p-1" />
-              )}
+              ) : null}
             </div>
           ) : (
             <div>
@@ -156,7 +154,18 @@ const BillingMetric = ({
 
           {metric.tip && (
             <div className="my-2">
-              <p className="text-sm">{metric.tip}</p>
+              <p className="text-sm">
+                {metric.tip}{' '}
+                {metric.docLink && (
+                  <Link
+                    href={metric.docLink.url}
+                    target="_blank"
+                    className="transition text-brand hover:text-brand-600 underline"
+                  >
+                    {metric.docLink.title}
+                  </Link>
+                )}
+              </p>
             </div>
           )}
 

--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/BillingMetric.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/BillingMetric.tsx
@@ -1,4 +1,3 @@
-import * as Tooltip from '@radix-ui/react-tooltip'
 import Link from 'next/link'
 
 import { PricingMetric } from 'data/analytics/org-daily-stats-query'
@@ -6,7 +5,7 @@ import type { OrgSubscription } from 'data/subscriptions/types'
 import type { OrgUsageResponse } from 'data/usage/org-usage-query'
 import { formatCurrency } from 'lib/helpers'
 import { useMemo } from 'react'
-import { Button } from 'ui'
+import { Button, HoverCard, HoverCardContent, HoverCardTrigger } from 'ui'
 import { billingMetricUnit, formatUsage } from '../helpers'
 import { Metric, USAGE_APPROACHING_THRESHOLD } from './BillingBreakdown.constants'
 import { ChevronRight, PieChart } from 'lucide-react'
@@ -78,32 +77,32 @@ const BillingMetric = ({
         : `(${(+(usageRatio * 100).toFixed(0)).toLocaleString()}%)`
 
   return (
-    <div className="flex items-center justify-between">
-      <div>
-        {metric.anchor ? (
-          <Link href={`/org/${slug}/usage#${metric.anchor}`}>
-            <div className="group flex items-center space-x-2">
-              <p className="text-sm text-foreground-light group-hover:text-foreground transition cursor-pointer">
-                {metric.name}
-              </p>
-              <ChevronRight strokeWidth={1.5} size={16} className="transition" />
-            </div>
-          </Link>
-        ) : (
-          <p className="text-sm text-foreground-light">{metric.name}</p>
-        )}
-        <span className="text-sm">{usageLabel}</span>&nbsp;
-        {relativeToSubscription && usageMeta.cost && usageMeta.cost > 0 ? (
-          <span className="text-sm">({formatCurrency(usageMeta.cost)})</span>
-        ) : usageMeta.available_in_plan && !usageMeta.unlimited && relativeToSubscription ? (
-          <span className="text-sm">{percentageLabel}</span>
-        ) : null}
-      </div>
+    <HoverCard openDelay={0} closeDelay={0}>
+      <HoverCardTrigger asChild>
+        <div className="flex items-center justify-between cursor-pointer">
+          <div>
+            {metric.anchor ? (
+              <Link href={`/org/${slug}/usage#${metric.anchor}`}>
+                <div className="group flex items-center space-x-1">
+                  <p className="text-sm text-foreground-light group-hover:text-foreground transition cursor-pointer">
+                    {metric.name}
+                  </p>
+                  <ChevronRight strokeWidth={1.5} size={16} className="transition" />
+                </div>
+              </Link>
+            ) : (
+              <p className="text-xs text-foreground-light">{metric.name}</p>
+            )}
+            <span className="text-sm">{usageLabel}</span>&nbsp;
+            {relativeToSubscription && usageMeta.cost && usageMeta.cost > 0 ? (
+              <span className="text-sm">({formatCurrency(usageMeta.cost)})</span>
+            ) : usageMeta.available_in_plan && !usageMeta.unlimited && relativeToSubscription ? (
+              <span className="text-sm">{percentageLabel}</span>
+            ) : null}
+          </div>
 
-      {usageMeta.available_in_plan ? (
-        <div>
-          <Tooltip.Root delayDuration={0}>
-            <Tooltip.Trigger>
+          {usageMeta.available_in_plan ? (
+            <div>
               {relativeToSubscription && !usageMeta.unlimited ? (
                 <svg className="h-8 w-8 -rotate-90 transform">
                   <circle
@@ -140,79 +139,72 @@ const BillingMetric = ({
               ) : (
                 <PieChart className="h-8 w-8 p-1" />
               )}
-            </Tooltip.Trigger>
-            <Tooltip.Portal>
-              <Tooltip.Content side="bottom">
-                <Tooltip.Arrow className="radix-tooltip-arrow" />
-                <div className="rounded bg-alternative py-1 px-2 leading-none shadow border border-background min-w-[300px] max-w-[450px] max-h-[300px] overflow-y-auto">
-                  <div className="text-xs text-foreground space-y-2">
-                    <p className="font-medium">{usageMeta.unit_price_desc}</p>
-
-                    {metric.tip && (
-                      <div className="my-2">
-                        <p className="text-xs">{metric.tip}</p>
-                      </div>
-                    )}
-
-                    {subscription.usage_billing_enabled === false &&
-                      relativeToSubscription &&
-                      (isApproachingLimit || isExceededLimit) && (
-                        <div className="mt-2">
-                          <p className="text-xs">
-                            Exceeding your plans included usage will lead to restrictions to your
-                            project. Upgrade to a usage-based plan or disable the spend cap to avoid
-                            restrictions.
-                          </p>
-                        </div>
-                      )}
-
-                    {sortedProjectAllocations && sortedProjectAllocations.length > 0 && (
-                      <table className="list-disc w-full">
-                        <thead>
-                          <tr>
-                            <th className="text-left">Project</th>
-                            <th className="text-right">Usage</th>
-                          </tr>
-                        </thead>
-                        <tbody>
-                          {sortedProjectAllocations.map((allocation) => (
-                            <tr key={`${usageMeta.metric}_${allocation.ref}`}>
-                              <td>{allocation.name}</td>
-                              <td className="text-right">
-                                {formatUsage(usageMeta.metric as PricingMetric, allocation)}
-                              </td>
-                            </tr>
-                          ))}
-                          <tr></tr>
-                        </tbody>
-                        <tfoot>
-                          <tr>
-                            <td className="py-2 border-t text-left">
-                              Total{unit && <span> ({unit})</span>}
-                            </td>
-                            <td className="py-2 border-t text-right">
-                              {formatUsage(usageMeta.metric as PricingMetric, {
-                                usage: usageMeta.usage_original,
-                              })}{' '}
-                            </td>
-                          </tr>
-                        </tfoot>
-                      </table>
-                    )}
-                  </div>
-                </div>
-              </Tooltip.Content>
-            </Tooltip.Portal>
-          </Tooltip.Root>
+            </div>
+          ) : (
+            <div>
+              <Button type="default" asChild>
+                <Link href={`/org/${slug}/billing?panel=subscriptionPlan`}>Upgrade</Link>
+              </Button>
+            </div>
+          )}
         </div>
-      ) : (
-        <div>
-          <Button type="default" asChild>
-            <Link href={`/org/${slug}/billing?panel=subscriptionPlan`}>Upgrade</Link>
-          </Button>
+      </HoverCardTrigger>
+
+      <HoverCardContent side="bottom" align="center" className="w-[500px]" animate="slide-in">
+        <div className="text-sm">
+          <p className="font-medium">{usageMeta.unit_price_desc}</p>
+
+          {metric.tip && (
+            <div className="my-2">
+              <p className="text-sm">{metric.tip}</p>
+            </div>
+          )}
+
+          {subscription.usage_billing_enabled === false &&
+            relativeToSubscription &&
+            (isApproachingLimit || isExceededLimit) && (
+              <div className="mt-2">
+                <p className="text-sm">
+                  Exceeding your plans included usage will lead to restrictions to your project.
+                  Upgrade to a usage-based plan or disable the spend cap to avoid restrictions.
+                </p>
+              </div>
+            )}
+
+          {sortedProjectAllocations && sortedProjectAllocations.length > 0 && (
+            <table className="list-disc w-full">
+              <thead>
+                <tr>
+                  <th className="text-left">Project</th>
+                  <th className="text-right">Usage</th>
+                </tr>
+              </thead>
+              <tbody>
+                {sortedProjectAllocations.map((allocation) => (
+                  <tr key={`${usageMeta.metric}_${allocation.ref}`}>
+                    <td>{allocation.name}</td>
+                    <td className="text-right">
+                      {formatUsage(usageMeta.metric as PricingMetric, allocation)}
+                    </td>
+                  </tr>
+                ))}
+                <tr></tr>
+              </tbody>
+              <tfoot>
+                <tr>
+                  <td className="py-2 border-t text-left">Total{unit && <span> ({unit})</span>}</td>
+                  <td className="py-2 border-t text-right">
+                    {formatUsage(usageMeta.metric as PricingMetric, {
+                      usage: usageMeta.usage_original,
+                    })}{' '}
+                  </td>
+                </tr>
+              </tfoot>
+            </table>
+          )}
         </div>
-      )}
-    </div>
+      </HoverCardContent>
+    </HoverCard>
   )
 }
 

--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/BillingMetric.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/BillingMetric.tsx
@@ -8,7 +8,7 @@ import { useMemo } from 'react'
 import { Button, HoverCard, HoverCardContent, HoverCardTrigger } from 'ui'
 import { billingMetricUnit, formatUsage } from '../helpers'
 import { Metric, USAGE_APPROACHING_THRESHOLD } from './BillingBreakdown.constants'
-import { ChevronRight, InfoIcon, PieChart } from 'lucide-react'
+import { ChevronRight } from 'lucide-react'
 
 export interface BillingMetricProps {
   idx: number

--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/BillingMetric.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/BillingMetric.tsx
@@ -87,7 +87,9 @@ const BillingMetric = ({
                   <p className="text-sm text-foreground-light group-hover:text-foreground transition cursor-pointer">
                     {metric.name}
                   </p>
-                  <ChevronRight strokeWidth={1.5} size={16} className="transition" />
+                  {usageMeta.available_in_plan && (
+                    <ChevronRight strokeWidth={1.5} size={16} className="transition" />
+                  )}
                 </div>
               </Link>
             ) : (
@@ -147,72 +149,75 @@ const BillingMetric = ({
           )}
         </div>
       </HoverCardTrigger>
+      {usageMeta.available_in_plan && (
+        <HoverCardContent side="bottom" align="center" className="w-[500px]" animate="slide-in">
+          <div className="text-sm">
+            <p className="font-medium">{usageMeta.unit_price_desc}</p>
 
-      <HoverCardContent side="bottom" align="center" className="w-[500px]" animate="slide-in">
-        <div className="text-sm">
-          <p className="font-medium">{usageMeta.unit_price_desc}</p>
-
-          {metric.tip && (
-            <div className="my-2">
-              <p className="text-sm">
-                {metric.tip}{' '}
-                {metric.docLink && (
-                  <Link
-                    href={metric.docLink.url}
-                    target="_blank"
-                    className="transition text-brand hover:text-brand-600 underline"
-                  >
-                    {metric.docLink.title}
-                  </Link>
-                )}
-              </p>
-            </div>
-          )}
-
-          {subscription.usage_billing_enabled === false &&
-            relativeToSubscription &&
-            (isApproachingLimit || isExceededLimit) && (
-              <div className="mt-2">
+            {metric.tip && (
+              <div className="my-2">
                 <p className="text-sm">
-                  Exceeding your plans included usage will lead to restrictions to your project.
-                  Upgrade to a usage-based plan or disable the spend cap to avoid restrictions.
+                  {metric.tip}{' '}
+                  {metric.docLink && (
+                    <Link
+                      href={metric.docLink.url}
+                      target="_blank"
+                      className="transition text-brand hover:text-brand-600 underline"
+                    >
+                      {metric.docLink.title}
+                    </Link>
+                  )}
                 </p>
               </div>
             )}
 
-          {sortedProjectAllocations && sortedProjectAllocations.length > 0 && (
-            <table className="list-disc w-full">
-              <thead>
-                <tr>
-                  <th className="text-left">Project</th>
-                  <th className="text-right">Usage</th>
-                </tr>
-              </thead>
-              <tbody>
-                {sortedProjectAllocations.map((allocation) => (
-                  <tr key={`${usageMeta.metric}_${allocation.ref}`}>
-                    <td>{allocation.name}</td>
-                    <td className="text-right">
-                      {formatUsage(usageMeta.metric as PricingMetric, allocation)}
+            {subscription.usage_billing_enabled === false &&
+              relativeToSubscription &&
+              (isApproachingLimit || isExceededLimit) && (
+                <div className="mt-2">
+                  <p className="text-sm">
+                    Exceeding your plans included usage will lead to restrictions to your project.
+                    Upgrade to a usage-based plan or disable the spend cap to avoid restrictions.
+                  </p>
+                </div>
+              )}
+
+            {sortedProjectAllocations && sortedProjectAllocations.length > 0 && (
+              <table className="list-disc w-full">
+                <thead>
+                  <tr>
+                    <th className="text-left">Project</th>
+                    <th className="text-right">Usage</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {sortedProjectAllocations.map((allocation) => (
+                    <tr key={`${usageMeta.metric}_${allocation.ref}`}>
+                      <td>{allocation.name}</td>
+                      <td className="text-right">
+                        {formatUsage(usageMeta.metric as PricingMetric, allocation)}
+                      </td>
+                    </tr>
+                  ))}
+                  <tr></tr>
+                </tbody>
+                <tfoot>
+                  <tr>
+                    <td className="py-2 border-t text-left">
+                      Total{unit && <span> ({unit})</span>}
+                    </td>
+                    <td className="py-2 border-t text-right">
+                      {formatUsage(usageMeta.metric as PricingMetric, {
+                        usage: usageMeta.usage_original,
+                      })}{' '}
                     </td>
                   </tr>
-                ))}
-                <tr></tr>
-              </tbody>
-              <tfoot>
-                <tr>
-                  <td className="py-2 border-t text-left">Total{unit && <span> ({unit})</span>}</td>
-                  <td className="py-2 border-t text-right">
-                    {formatUsage(usageMeta.metric as PricingMetric, {
-                      usage: usageMeta.usage_original,
-                    })}{' '}
-                  </td>
-                </tr>
-              </tfoot>
-            </table>
-          )}
-        </div>
-      </HoverCardContent>
+                </tfoot>
+              </table>
+            )}
+          </div>
+        </HoverCardContent>
+      )}
     </HoverCard>
   )
 }

--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/ComputeMetric.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/ComputeMetric.tsx
@@ -1,4 +1,3 @@
-import * as Tooltip from '@radix-ui/react-tooltip'
 import Link from 'next/link'
 
 import { PricingMetric } from 'data/analytics/org-daily-stats-query'
@@ -8,6 +7,7 @@ import { useMemo } from 'react'
 import { formatUsage } from '../helpers'
 import { Metric } from './BillingBreakdown.constants'
 import { ChevronRight, PieChart } from 'lucide-react'
+import { HoverCard, HoverCardContent, HoverCardTrigger } from 'ui'
 
 export interface ComputeMetricProps {
   slug?: string
@@ -36,86 +36,76 @@ const ComputeMetric = ({ slug, metric, usage, relativeToSubscription }: ComputeM
   }, [usageMeta])
 
   return (
-    <div className="flex items-center justify-between">
-      <div>
-        <Link href={`/org/${slug}/usage#${metric.anchor}`}>
-          <div className="group flex items-center space-x-2">
-            <p className="text-sm text-foreground-light group-hover:text-foreground transition cursor-pointer">
-              {metric.name}
+    <HoverCard openDelay={50} closeDelay={200}>
+      <HoverCardTrigger>
+        <div>
+          <Link href={`/org/${slug}/usage#${metric.anchor}`}>
+            <div className="group flex items-center space-x-2">
+              <p className="text-sm text-foreground-light group-hover:text-foreground transition cursor-pointer">
+                {metric.name}
+              </p>
+              <ChevronRight strokeWidth={1.5} size={16} className="transition" />
+            </div>
+          </Link>
+          <span className="text-sm">{usageLabel}</span>&nbsp;
+          {relativeToSubscription && usageMeta?.cost && usageMeta.cost > 0 ? (
+            <span className="text-sm">({formatCurrency(usageMeta?.cost)})</span>
+          ) : null}
+        </div>
+      </HoverCardTrigger>
+      <HoverCardContent side="bottom" align="center" className="w-[500px]" animate="slide-in">
+        <div className="text-sm text-foreground space-y-2">
+          <p className="font-medium">{usageMeta?.unit_price_desc}</p>
+
+          <div className="my-2">
+            <p className="text-sm">
+              Every project is a dedicated server and database. For every hour your project is
+              active, it incurs compute costs based on the compute size of your project. Paused
+              projects do not incur compute costs.{' '}
+              <Link
+                href="https://supabase.com/docs/guides/platform/org-based-billing#billing-for-compute-compute-hours"
+                target="_blank"
+                className="transition text-brand hover:text-brand-600 underline"
+              >
+                Read more
+              </Link>
             </p>
-            <ChevronRight strokeWidth={1.5} size={16} className="transition" />
           </div>
-        </Link>
-        <span className="text-sm">{usageLabel}</span>&nbsp;
-        {relativeToSubscription && usageMeta?.cost && usageMeta.cost > 0 ? (
-          <span className="text-sm">({formatCurrency(usageMeta?.cost)})</span>
-        ) : null}
-      </div>
-      <div>
-        <Tooltip.Root delayDuration={0}>
-          <Tooltip.Trigger>
-            <PieChart className="h-8 w-8 p-1" />
-          </Tooltip.Trigger>
-          <Tooltip.Portal>
-            <Tooltip.Content side="bottom">
-              <Tooltip.Arrow className="radix-tooltip-arrow" />
-              <div className="rounded bg-alternative py-1 px-2 leading-none shadow border border-background min-w-[300px] max-w-[450px] max-h-[300px] overflow-y-auto">
-                <div className="text-xs text-foreground space-y-2">
-                  <p className="font-medium">{usageMeta?.unit_price_desc}</p>
 
-                  <div className="my-2">
-                    <p className="text-xs">
-                      Every project is a dedicated server and database. For every hour your project
-                      is active, it incurs compute costs based on the compute size of your project.
-                      Paused projects do not incur compute costs.{' '}
-                      <Link
-                        href="https://supabase.com/docs/guides/platform/org-based-billing#billing-for-compute-compute-hours"
-                        target="_blank"
-                        className="transition text-brand hover:text-brand-600 underline"
-                      >
-                        Read more
-                      </Link>
-                    </p>
-                  </div>
-
-                  {usageMeta && sortedProjectAllocations.length > 0 && (
-                    <table className="list-disc w-full">
-                      <thead>
-                        <tr>
-                          <th className="text-left">Project</th>
-                          <th className="text-right">Usage</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {sortedProjectAllocations.map((allocation) => (
-                          <tr key={`${usageMeta.metric}_${allocation.ref}`}>
-                            <td>{allocation.name}</td>
-                            <td className="text-right">
-                              {formatUsage(usageMeta.metric as PricingMetric, allocation)}
-                            </td>
-                          </tr>
-                        ))}
-                        <tr></tr>
-                      </tbody>
-                      <tfoot>
-                        <tr>
-                          <td className="py-2 border-t text-left">Total (Hours)</td>
-                          <td className="py-2 border-t text-right">
-                            {formatUsage(usageMeta.metric as PricingMetric, {
-                              usage: usageMeta.usage_original,
-                            })}
-                          </td>
-                        </tr>
-                      </tfoot>
-                    </table>
-                  )}
-                </div>
-              </div>
-            </Tooltip.Content>
-          </Tooltip.Portal>
-        </Tooltip.Root>
-      </div>
-    </div>
+          {usageMeta && sortedProjectAllocations.length > 0 && (
+            <table className="list-disc w-full">
+              <thead>
+                <tr>
+                  <th className="text-left">Project</th>
+                  <th className="text-right">Usage</th>
+                </tr>
+              </thead>
+              <tbody>
+                {sortedProjectAllocations.map((allocation) => (
+                  <tr key={`${usageMeta.metric}_${allocation.ref}`}>
+                    <td>{allocation.name}</td>
+                    <td className="text-right">
+                      {formatUsage(usageMeta.metric as PricingMetric, allocation)}
+                    </td>
+                  </tr>
+                ))}
+                <tr></tr>
+              </tbody>
+              <tfoot>
+                <tr>
+                  <td className="py-2 border-t text-left">Total (Hours)</td>
+                  <td className="py-2 border-t text-right">
+                    {formatUsage(usageMeta.metric as PricingMetric, {
+                      usage: usageMeta.usage_original,
+                    })}
+                  </td>
+                </tr>
+              </tfoot>
+            </table>
+          )}
+        </div>
+      </HoverCardContent>
+    </HoverCard>
   )
 }
 

--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/ComputeMetric.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/ComputeMetric.tsx
@@ -6,7 +6,7 @@ import { formatCurrency } from 'lib/helpers'
 import { useMemo } from 'react'
 import { formatUsage } from '../helpers'
 import { Metric } from './BillingBreakdown.constants'
-import { ChevronRight, PieChart } from 'lucide-react'
+import { ChevronRight } from 'lucide-react'
 import { HoverCard, HoverCardContent, HoverCardTrigger } from 'ui'
 
 export interface ComputeMetricProps {


### PR DESCRIPTION
- Improved disk size docs on "How billing works" docs
- Fixed a link on the disk management docs
- Moved from tooltip on hover over the pie chart to using a hover card that is on the whole element, making it easier to spot
- Removed the static PieChart icon for compute hours or when usage is filtered by project
- Improved tooltip for disk size metric

<img width="509" alt="Screenshot 2024-10-07 at 20 21 33" src="https://github.com/user-attachments/assets/2d44cafd-9aae-45ff-a26d-9d2a8c5808a9">
