### PR TITLE
fix: allow editing of rate limit when SendEmailHook is enabled

### DIFF
--- a/apps/studio/components/interfaces/Auth/RateLimits/RateLimits.tsx
+++ b/apps/studio/components/interfaces/Auth/RateLimits/RateLimits.tsx
@@ -129,7 +129,6 @@ const RateLimits = () => {
 
   const hasAuthEmailHookEnabled = authConfig?.HOOK_SEND_EMAIL_ENABLED
 
-
   return (
     <div>
       <FormHeader
@@ -155,9 +154,9 @@ const RateLimits = () => {
                     handleReset={() => form.reset()}
                     disabled={!canUpdateConfig}
                     helper={
-                    !canUpdateConfig
-                    ? 'You need additional permissions to update authentication settings'
-                    : undefined
+                      !canUpdateConfig
+                        ? 'You need additional permissions to update authentication settings'
+                        : undefined
                     }
                   />
                 </div>
@@ -444,7 +443,7 @@ const RateLimits = () => {
         </Form_Shadcn_>
       )}
     </div>
-      )
+  )
 }
 
 export default RateLimits

--- a/apps/studio/components/interfaces/Auth/RateLimits/RateLimits.tsx
+++ b/apps/studio/components/interfaces/Auth/RateLimits/RateLimits.tsx
@@ -53,7 +53,8 @@ const RateLimits = () => {
   })
 
   const hasAuthEmailHookEnabled = authConfig?.HOOK_SEND_EMAIL_ENABLED
-  const canUpdateEmailLimit = authConfig?.EXTERNAL_EMAIL_ENABLED && (isSmtpEnabled(authConfig) || hasAuthEmailHookEnabled)
+  const canUpdateEmailLimit =
+    authConfig?.EXTERNAL_EMAIL_ENABLED && (isSmtpEnabled(authConfig) || hasAuthEmailHookEnabled)
   const canUpdateSMSRateLimit = authConfig?.EXTERNAL_PHONE_ENABLED && !authConfig?.SMS_AUTOCONFIRM
   const canUpdateAnonymousUsersRateLimit = authConfig?.EXTERNAL_ANONYMOUS_USERS_ENABLED
 
@@ -127,7 +128,6 @@ const RateLimits = () => {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isSuccess])
-
 
   return (
     <div>
@@ -210,12 +210,14 @@ const RateLimits = () => {
                           <Alert_Shadcn_>
                             <WarningIcon />
                             <AlertTitle_Shadcn_>
-                              Custom SMTP provider or Send Email Hook is required to update this configuration
+                              Custom SMTP provider or Send Email Hook is required to update this
+                              configuration
                             </AlertTitle_Shadcn_>
                             <AlertDescription_Shadcn_ className="flex flex-col gap-y-3">
                               <p className="!leading-tight">
                                 The built-in email service has a fixed rate limit. You will need to
-                                set up your own custom SMTP provider or a Send Email Hook to update your email rate limit
+                                set up your own custom SMTP provider or a Send Email Hook to update
+                                your email rate limit
                               </p>
                               <Button asChild type="default" className="w-min">
                                 <Link href={`/project/${projectRef}/settings/auth`}>

--- a/apps/studio/components/interfaces/Auth/RateLimits/RateLimits.tsx
+++ b/apps/studio/components/interfaces/Auth/RateLimits/RateLimits.tsx
@@ -52,7 +52,8 @@ const RateLimits = () => {
     },
   })
 
-  const canUpdateEmailLimit = authConfig?.EXTERNAL_EMAIL_ENABLED && isSmtpEnabled(authConfig)
+  const hasAuthEmailHookEnabled = authConfig?.HOOK_SEND_EMAIL_ENABLED
+  const canUpdateEmailLimit = authConfig?.EXTERNAL_EMAIL_ENABLED && (isSmtpEnabled(authConfig) || hasAuthEmailHookEnabled)
   const canUpdateSMSRateLimit = authConfig?.EXTERNAL_PHONE_ENABLED && !authConfig?.SMS_AUTOCONFIRM
   const canUpdateAnonymousUsersRateLimit = authConfig?.EXTERNAL_ANONYMOUS_USERS_ENABLED
 
@@ -127,7 +128,6 @@ const RateLimits = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isSuccess])
 
-  const hasAuthEmailHookEnabled = authConfig?.HOOK_SEND_EMAIL_ENABLED
 
   return (
     <div>

--- a/apps/studio/components/interfaces/Auth/RateLimits/RateLimits.tsx
+++ b/apps/studio/components/interfaces/Auth/RateLimits/RateLimits.tsx
@@ -210,12 +210,12 @@ const RateLimits = () => {
                           <Alert_Shadcn_>
                             <WarningIcon />
                             <AlertTitle_Shadcn_>
-                              Custom SMTP provider is required to update this configuration
+                              Custom SMTP provider or Send Email Hook is required to update this configuration
                             </AlertTitle_Shadcn_>
                             <AlertDescription_Shadcn_ className="flex flex-col gap-y-3">
                               <p className="!leading-tight">
                                 The built-in email service has a fixed rate limit. You will need to
-                                set up your own custom SMTP provider to update your email rate limit
+                                set up your own custom SMTP provider or a Send Email Hook to update your email rate limit
                               </p>
                               <Button asChild type="default" className="w-min">
                                 <Link href={`/project/${projectRef}/settings/auth`}>

--- a/apps/studio/components/interfaces/Auth/RateLimits/RateLimits.tsx
+++ b/apps/studio/components/interfaces/Auth/RateLimits/RateLimits.tsx
@@ -127,6 +127,9 @@ const RateLimits = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isSuccess])
 
+  const hasAuthEmailHookEnabled = authConfig?.HOOK_SEND_EMAIL_ENABLED
+
+
   return (
     <div>
       <FormHeader
@@ -152,9 +155,9 @@ const RateLimits = () => {
                     handleReset={() => form.reset()}
                     disabled={!canUpdateConfig}
                     helper={
-                      !canUpdateConfig
-                        ? 'You need additional permissions to update authentication settings'
-                        : undefined
+                    !canUpdateConfig
+                    ? 'You need additional permissions to update authentication settings'
+                    : undefined
                     }
                   />
                 </div>
@@ -204,7 +207,7 @@ const RateLimits = () => {
                               </Button>
                             </AlertDescription_Shadcn_>
                           </Alert_Shadcn_>
-                        ) : !isSmtpEnabled(authConfig) ? (
+                        ) : !(isSmtpEnabled(authConfig) || hasAuthEmailHookEnabled) ? (
                           <Alert_Shadcn_>
                             <WarningIcon />
                             <AlertTitle_Shadcn_>
@@ -441,7 +444,7 @@ const RateLimits = () => {
         </Form_Shadcn_>
       )}
     </div>
-  )
+      )
 }
 
 export default RateLimits


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

For developers who only use the Send Email Hook and not the default or custom smtp