### PR TITLE
Add Coolify Setup Guide

### DIFF
--- a/apps/docs/content/guides/self-hosting/coolify
+++ b/apps/docs/content/guides/self-hosting/coolify
@@ -1,0 +1,30 @@
+---
+title: "Self-Hosting with Coolify"
+description: "Learn how to configure and deploy Supabase with Coolify."
+subtitle: "Learn how to configure and deploy Supabase with Coolify."
+---
+
+Coolify is an open-source, self-hosting platform that simplifies deploying and managing applications like Supabase. This guide assumes you are running the commands from the machine you intend to host from.
+
+## Before you begin
+
+You need the following installed on your system:
+
+- A server or virtual machine with a Linux-based OS (Ubuntu, Debian, etc.)
+- Root or sudo access to the server
+- [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/)
+- [Git](https://git-scm.com/downloads)
+- A domain name pointed to your server's IP (optional but recommended)
+
+## Running Supabase
+
+Follow these steps to start Supabase using Coolify:
+
+<div className="video-container">
+  <iframe
+    src="https://www.youtube.com/embed/NlBsJuUndws"
+    frameBorder="1"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+    allowFullScreen
+  ></iframe>
+</div>


### PR DESCRIPTION
Add Coolify Setup Guide

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Adds docs ressource for self-hosting with Coolify as its more and more in demand.
This video a full guide to setting up NextJS and Supabase together on Coolify.

## What is the current behavior?

There is simply no guide to self-host Coolify in the docs

## What is the new behavior?

Added embedded guide.


