### PR TITLE
chore: improve table grid loading skeleton

### DIFF
--- a/apps/studio/components/grid/components/grid/Grid.tsx
+++ b/apps/studio/components/grid/components/grid/Grid.tsx
@@ -5,10 +5,11 @@ import DataGrid, { DataGridHandle, RowsChangeData } from 'react-data-grid'
 import { memo } from 'react-tracked'
 
 import { formatClipboardValue } from 'components/grid/utils/common'
+import { TableGridInnerLoadingState } from 'components/interfaces/TableGridEditor/LoadingState'
+import { formatForeignKeys } from 'components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.utils'
 import { ForeignRowSelectorProps } from 'components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/ForeignRowSelector/ForeignRowSelector'
 import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
 import AlertError from 'components/ui/AlertError'
-import { GenericSkeletonLoader } from 'components/ui/ShimmeringLoader'
 import { useForeignKeyConstraintsQuery } from 'data/database/foreign-key-constraints-query'
 import { useUrlState } from 'hooks/ui/useUrlState'
 import { copyToClipboard } from 'lib/helpers'
@@ -17,7 +18,6 @@ import { useDispatch, useTrackedState } from '../../store/Store'
 import type { Filter, GridProps, SupaRow } from '../../types'
 import { useKeyboardShortcuts } from '../common/Hooks'
 import RowRenderer from './RowRenderer'
-import { formatForeignKeys } from 'components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.utils'
 
 const rowKeyGetter = (row: SupaRow) => {
   return row?.idx ?? -1
@@ -193,11 +193,7 @@ export const Grid = memo(
                 // RDG used to use flex, but with v7 they've moved to CSS grid and the
                 // in built no rows fallback only takes the width of the CSS grid itself
                 <div style={{ width: `calc(100vw - 255px - 55px)` }}>
-                  {isLoading && (
-                    <div className="p-2 col-span-full">
-                      <GenericSkeletonLoader />
-                    </div>
-                  )}
+                  {isLoading && <TableGridInnerLoadingState />}
                   {isError && (
                     <div className="p-2 col-span-full">
                       <AlertError error={error} subject="Failed to retrieve rows from table" />

--- a/apps/studio/components/interfaces/TableGridEditor/LoadingState.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/LoadingState.tsx
@@ -1,0 +1,20 @@
+import { GenericSkeletonLoader } from 'components/ui/ShimmeringLoader'
+
+export const TableGridInnerLoadingState = () => {
+  return (
+    <div className="p-2 col-span-full">
+      <GenericSkeletonLoader />
+    </div>
+  )
+}
+
+export const TableGridSkeletonLoader = () => {
+  return (
+    <div className="flex flex-col">
+      <div className="h-10 bg-dash-sidebar" />
+      <div className="h-[35px] border-y" />
+
+      <TableGridInnerLoadingState />
+    </div>
+  )
+}

--- a/apps/studio/components/interfaces/TableGridEditor/LoadingState.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/LoadingState.tsx
@@ -12,7 +12,7 @@ export const TableGridSkeletonLoader = () => {
   return (
     <div className="flex flex-col">
       <div className="h-10 bg-dash-sidebar" />
-      <div className="h-[35px] border-y" />
+      <div className="h-9 border-y" />
 
       <TableGridInnerLoadingState />
     </div>

--- a/apps/studio/components/interfaces/TableGridEditor/TableGridEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/TableGridEditor.tsx
@@ -11,7 +11,6 @@ import { SupabaseGrid } from 'components/grid/SupabaseGrid'
 import { parseSupaTable } from 'components/grid/SupabaseGrid.utils'
 import { SupaTable } from 'components/grid/types'
 import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
-import { Loading } from 'components/ui/Loading'
 import { FOREIGN_KEY_CASCADE_ACTION } from 'data/database/database-query-constants'
 import {
   ForeignKeyConstraint,
@@ -32,6 +31,7 @@ import { useTableEditorStateSnapshot } from 'state/table-editor'
 import type { Dictionary, SchemaView } from 'types'
 import { Button } from 'ui'
 import GridHeaderActions from './GridHeaderActions'
+import { TableGridSkeletonLoader } from './LoadingState'
 import NotFoundState from './NotFoundState'
 import SidePanelEditor from './SidePanelEditor/SidePanelEditor'
 import { useEncryptedColumns } from './SidePanelEditor/SidePanelEditor.utils'
@@ -138,7 +138,7 @@ const TableGridEditor = ({
 
   // NOTE: DO NOT PUT HOOKS AFTER THIS LINE
   if (isLoadingSelectedTable) {
-    return <Loading />
+    return <TableGridSkeletonLoader />
   }
 
   if (isUndefined(selectedTable)) {

--- a/apps/studio/components/ui/ShimmeringLoader.tsx
+++ b/apps/studio/components/ui/ShimmeringLoader.tsx
@@ -1,3 +1,4 @@
+import { useSynchronizedAnimation } from 'hooks/misc/useSynchronizedAnimation'
 import { cn } from 'ui'
 
 export interface ShimmeringLoader {
@@ -11,8 +12,11 @@ const ShimmeringLoader = ({
   delayIndex = 0,
   animationDelay = 150,
 }: ShimmeringLoader) => {
+  const ref = useSynchronizedAnimation<HTMLDivElement>('shimmer')
+
   return (
     <div
+      ref={ref}
       className={cn('shimmering-loader rounded py-3', className)}
       style={{
         animationFillMode: 'backwards',
@@ -25,8 +29,8 @@ const ShimmeringLoader = ({
 const GenericSkeletonLoader = () => (
   <div className="space-y-2">
     <ShimmeringLoader />
-    <ShimmeringLoader className="w-3/4" />
-    <ShimmeringLoader className="w-1/2" />
+    <ShimmeringLoader className="w-3/4" delayIndex={1} />
+    <ShimmeringLoader className="w-1/2" delayIndex={2} />
   </div>
 )
 

--- a/apps/studio/hooks/misc/useSynchronizedAnimation.ts
+++ b/apps/studio/hooks/misc/useSynchronizedAnimation.ts
@@ -1,0 +1,44 @@
+import { useLayoutEffect, useRef } from 'react'
+
+// Source: https://youtu.be/3kDVachh-BM
+
+let stashedTime: number | null = null
+
+export function useSynchronizedAnimation<T>(name: string) {
+  const ref = useRef<T>(null)
+
+  useLayoutEffect(() => {
+    const animations = document
+      .getAnimations()
+      .filter(
+        (animation) => animation instanceof CSSAnimation && animation.animationName === 'shimmer'
+      )
+
+    const myAnimation = animations.find(
+      (animation) =>
+        animation.effect instanceof KeyframeEffect && animation.effect.target === ref.current
+    )
+
+    if (myAnimation === undefined) {
+      return
+    }
+
+    const leadAnimation = animations[0]
+
+    if (myAnimation === leadAnimation && stashedTime) {
+      myAnimation.currentTime = stashedTime
+    }
+
+    if (myAnimation !== leadAnimation) {
+      myAnimation.currentTime = leadAnimation.currentTime
+    }
+
+    return () => {
+      if (myAnimation === leadAnimation && myAnimation.currentTime) {
+        stashedTime = Number(myAnimation.currentTime)
+      }
+    }
+  }, [])
+
+  return ref
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

chore

## What is the current behavior?

Currently we have a spinner, followed by a skeleton.

## What is the new behavior?

Skeleton only.

## Additional context


https://github.com/user-attachments/assets/aef7b3e2-ba26-4b2b-ba26-43d719e8c44e


