### PR TITLE
Include "to authenticated" in example rls policies

### DIFF
--- a/apps/docs/content/guides/database/postgres/custom-claims-and-role-based-access-control-rbac.mdx
+++ b/apps/docs/content/guides/database/postgres/custom-claims-and-role-based-access-control-rbac.mdx
@@ -246,8 +246,8 @@ You can read more about using functions in RLS policies in the [RLS guide](/docs
 You can then use the `authorize` method within your RLS policies. For example, to enable the desired delete access, you would add the following policies:
 
 ```sql
-create policy "Allow authorized delete access" on public.channels for delete using ( (SELECT authorize('channels.delete')) );
-create policy "Allow authorized delete access" on public.messages for delete using ( (SELECT authorize('messages.delete')) );
+create policy "Allow authorized delete access" on public.channels for delete to authenticated using ( (SELECT authorize('channels.delete')) );
+create policy "Allow authorized delete access" on public.messages for delete to authenticated using ( (SELECT authorize('messages.delete')) );
 ```
 
 ## Accessing custom claims in your application


### PR DESCRIPTION
Update custom-claims-and-role-based-access-control-rbac.mdx and added "to authenticated" in the rls policy which only allows logged in users to query instead of non logged in users as per "Specify roles in your policies" found here https://supabase.com/docs/guides/database/postgres/row-level-security#specify-roles-in-your-policies

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Include "to authenticated" in example rls policies

## What is the current behavior?

No roles and uses extra resources for no reason