### PR TITLE
Feat/non centered dialog option

### DIFF
--- a/apps/design-system/__registry__/index.tsx
+++ b/apps/design-system/__registry__/index.tsx
@@ -654,6 +654,17 @@ export const Index: Record<string, any> = {
       subcategory: "undefined",
       chunks: []
     },
+    "dialog-centered-off": {
+      name: "dialog-centered-off",
+      type: "components:example",
+      registryDependencies: ["dialog","button"],
+      component: React.lazy(() => import("@/registry/default/example/dialog-centered-off")),
+      source: "",
+      files: ["registry/default/example/dialog-centered-off.tsx"],
+      category: "undefined",
+      subcategory: "undefined",
+      chunks: []
+    },
     "drawer-demo": {
       name: "drawer-demo",
       type: "components:example",

--- a/apps/design-system/content/docs/components/dialog.mdx
+++ b/apps/design-system/content/docs/components/dialog.mdx
@@ -51,6 +51,17 @@ import {
 
 You can control whether the dialog is centered by passing `centered={false}` to the `DialogContent` component.
 
+```tsx {3}
+<Dialog>
+  <ContextMenuTrigger>Click here</ContextMenuTrigger>
+  <DialogContent centered={false}>
+    {/*
+     * Content in here
+     */}
+  </DialogContent>
+</Dialog>
+```
+
 <ComponentPreview name="dialog-centered-off" />
 
 ## Notes
@@ -61,7 +72,7 @@ To activate the `Dialog` component from within a `Context Menu` or `Dropdown Men
 ```tsx {14-25}
 <Dialog>
   <ContextMenu>
-    <ContextMenuTrigger>Right click</ContextMenuTrigger>
+    <ContextMenuTrigger>Dialog not centered</ContextMenuTrigger>
     <ContextMenuContent>
       <ContextMenuItem>Open</ContextMenuItem>
       <ContextMenuItem>Download</ContextMenuItem>

--- a/apps/design-system/content/docs/components/dialog.mdx
+++ b/apps/design-system/content/docs/components/dialog.mdx
@@ -13,44 +13,6 @@ source:
 
 <ComponentPreview name="dialog-demo" peekCode wide />
 
-## Installation
-
-<Tabs defaultValue="cli">
-
-<TabsList>
-  <TabsTrigger value="cli">CLI</TabsTrigger>
-  <TabsTrigger value="manual">Manual</TabsTrigger>
-</TabsList>
-<TabsContent value="cli">
-
-```bash
-npx shadcn-ui@latest add dialog
-```
-
-</TabsContent>
-
-<TabsContent value="manual">
-
-<Steps>
-
-<Step>Install the following dependencies:</Step>
-
-```bash
-npm install @radix-ui/react-dialog
-```
-
-<Step>Copy and paste the following code into your project.</Step>
-
-<ComponentSource name="dialog" />
-
-<Step>Update the import paths to match your project setup.</Step>
-
-</Steps>
-
-</TabsContent>
-
-</Tabs>
-
 ## Usage
 
 ```tsx
@@ -84,6 +46,12 @@ import {
 ### Custom close button
 
 <ComponentPreview name="dialog-close-button" />
+
+### Centered behaviour
+
+You can control whether the dialog is centered by passing `centered={false}` to the `DialogContent` component.
+
+<ComponentPreview name="dialog-centered-off" />
 
 ## Notes
 

--- a/apps/design-system/registry/default/example/dialog-centered-off.tsx
+++ b/apps/design-system/registry/default/example/dialog-centered-off.tsx
@@ -1,0 +1,46 @@
+import { Button, DialogSection, DialogSectionSeparator } from 'ui'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from 'ui'
+import { Input_Shadcn_ } from 'ui'
+import { Label_Shadcn_ } from 'ui'
+
+export default function DialogDemo() {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button type="default">Edit Profile</Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-[425px]" centered={false}>
+        <DialogHeader padding={'small'}>
+          <DialogTitle>This dialog is not centered.</DialogTitle>
+          <DialogDescription>This dialog is not centered.</DialogDescription>
+        </DialogHeader>
+        <DialogSectionSeparator />
+        <DialogSection className="space-y-4" padding={'small'}>
+          <div>
+            <Label_Shadcn_ htmlFor="name" className="text-right">
+              Name
+            </Label_Shadcn_>
+            <Input_Shadcn_ id="name" defaultValue="Pedro Duarte" className="col-span-3" />
+          </div>
+          <div>
+            <Label_Shadcn_ htmlFor="username" className="text-right">
+              Username
+            </Label_Shadcn_>
+            <Input_Shadcn_ id="username" defaultValue="@peduarte" className="col-span-3" />
+          </div>
+        </DialogSection>
+        <DialogFooter padding={'small'}>
+          <Button htmlType="submit">Save changes</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/design-system/registry/examples.ts
+++ b/apps/design-system/registry/examples.ts
@@ -432,6 +432,12 @@ export const examples: Registry = [
     files: ['example/dialog-close-button.tsx'],
   },
   {
+    name: 'dialog-centered-off',
+    type: 'components:example',
+    registryDependencies: ['dialog', 'button'],
+    files: ['example/dialog-centered-off.tsx'],
+  },
+  {
     name: 'drawer-demo',
     type: 'components:example',
     registryDependencies: ['drawer'],

--- a/apps/studio/components/interfaces/Home/Connect/Connect.tsx
+++ b/apps/studio/components/interfaces/Home/Connect/Connect.tsx
@@ -169,7 +169,7 @@ const Connect = () => {
             <span>Connect</span>
           </Button>
         </DialogTrigger>
-        <DialogContent className={cn('sm:max-w-5xl p-0')}>
+        <DialogContent className={cn('sm:max-w-5xl p-0')} centered={false}>
           <DialogHeader className="pb-3">
             <DialogTitle>Connect to your project</DialogTitle>
             <DialogDescription>

--- a/packages/ui/src/components/shadcn/ui/dialog.tsx
+++ b/packages/ui/src/components/shadcn/ui/dialog.tsx
@@ -37,8 +37,8 @@ DialogPortal.displayName = DialogPrimitive.Portal.displayName
 
 const DialogOverlay = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Overlay>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay> & { centered: boolean }
->(({ className, centered, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay> & { centered?: boolean }
+>(({ className, centered = true, ...props }, ref) => (
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(

--- a/packages/ui/src/components/shadcn/ui/dialog.tsx
+++ b/packages/ui/src/components/shadcn/ui/dialog.tsx
@@ -44,8 +44,7 @@ const DialogOverlay = React.forwardRef<
     className={cn(
       'bg-black/40 backdrop-blur-sm',
       'z-50 fixed inset-0 grid place-items-center overflow-y-auto data-closed:animate-overlay-hide py-8',
-      !centered &&
-        'flex flex-col flex-startpb-8 pt-8 lg:pt-20 [@media(min-height:720px)]:pt-[15vh] lg:px-5',
+      !centered && 'flex flex-col flex-start pb-8 sm:pt-12 md:pt-20 lg:pt-32 xl:pt-40 px-5',
       className
     )}
     {...props}
@@ -56,7 +55,7 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
 const DialogContentVariants = cva(
   cn(
     '',
-    'relative z-50 w-full border shadow-md dark:shadow-sm duration-200',
+    'relative z-50 w-full border shadow-md dark:shadow-sm',
     'data-[state=open]:animate-in data-[state=closed]:animate-out',
     'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
     'data-[state=closed]:slide-out-to-left-[0%] data-[state=closed]:slide-out-to-top-[0%]',

--- a/packages/ui/src/components/shadcn/ui/dialog.tsx
+++ b/packages/ui/src/components/shadcn/ui/dialog.tsx
@@ -37,13 +37,15 @@ DialogPortal.displayName = DialogPrimitive.Portal.displayName
 
 const DialogOverlay = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Overlay>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
->(({ className, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay> & { centered: boolean }
+>(({ className, centered, ...props }, ref) => (
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
       'bg-black/40 backdrop-blur-sm',
-      'z-50 fixed inset-0 grid place-items-center overflow-y-auto data-closed:animate-overlay-hide',
+      'z-50 fixed inset-0 grid place-items-center overflow-y-auto data-closed:animate-overlay-hide py-8',
+      !centered &&
+        'flex flex-col flex-startpb-8 pt-8 lg:pt-20 [@media(min-height:720px)]:pt-[15vh] lg:px-5',
       className
     )}
     {...props}
@@ -53,8 +55,8 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
 
 const DialogContentVariants = cva(
   cn(
-    'my-8',
-    'relative z-50 grid w-full border shadow-md dark:shadow-sm duration-200',
+    '',
+    'relative z-50 w-full border shadow-md dark:shadow-sm duration-200',
     'data-[state=open]:animate-in data-[state=closed]:animate-out',
     'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
     'data-[state=closed]:slide-out-to-left-[0%] data-[state=closed]:slide-out-to-top-[0%]',
@@ -86,26 +88,32 @@ const DialogContent = React.forwardRef<
     VariantProps<typeof DialogContentVariants> & {
       hideClose?: boolean
       dialogOverlayProps?: React.ComponentPropsWithoutRef<typeof DialogOverlay>
+      centered?: boolean
     }
->(({ className, children, size, hideClose, dialogOverlayProps, ...props }, ref) => (
-  <DialogPortal>
-    <DialogOverlay {...dialogOverlayProps}>
-      <DialogPrimitive.Content
-        ref={ref}
-        className={cn(DialogContentVariants({ size }), className)}
-        {...props}
-      >
-        {children}
-        {!hideClose && (
-          <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-20 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-foreground-muted">
-            <X className="h-4 w-4" />
-            <span className="sr-only">Close</span>
-          </DialogPrimitive.Close>
-        )}
-      </DialogPrimitive.Content>
-    </DialogOverlay>
-  </DialogPortal>
-))
+>(
+  (
+    { className, children, size, hideClose, dialogOverlayProps, centered = true, ...props },
+    ref
+  ) => (
+    <DialogPortal>
+      <DialogOverlay centered={centered} {...dialogOverlayProps}>
+        <DialogPrimitive.Content
+          ref={ref}
+          className={cn(DialogContentVariants({ size }), className)}
+          {...props}
+        >
+          {children}
+          {!hideClose && (
+            <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-20 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-foreground-muted">
+              <X className="h-4 w-4" />
+              <span className="sr-only">Close</span>
+            </DialogPrimitive.Close>
+          )}
+        </DialogPrimitive.Content>
+      </DialogOverlay>
+    </DialogPortal>
+  )
+)
 DialogContent.displayName = DialogPrimitive.Content.displayName
 
 const DialogHeader = React.forwardRef<

--- a/packages/ui/src/components/shadcn/ui/dialog.tsx
+++ b/packages/ui/src/components/shadcn/ui/dialog.tsx
@@ -54,7 +54,6 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
 
 const DialogContentVariants = cva(
   cn(
-    '',
     'relative z-50 w-full border shadow-md dark:shadow-sm',
     'data-[state=open]:animate-in data-[state=closed]:animate-out',
     'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES/NO

## What kind of change does this PR introduce?

- `<DialogContent />` updated to support a `centered` prop
- `<Connect />` component updated to use `centered={false}`

Please link any relevant issues here.

## What is the new behavior?

- 
```
// normal 
<DialogContent />

// top aligned
<DialogContent centered={false}/>
```

Feel free to include screenshots if it includes visual changes.

## Additional context

Added docs 
<img width="1127" alt="Screenshot 2024-10-09 at 17 20 22" src="https://github.com/user-attachments/assets/a26815a0-3e07-4106-bb89-a71c6a819ab4">
