### PR TITLE
Fix a typo in utils/supabase/server.js

### DIFF
--- a/apps/docs/content/guides/getting-started/tutorials/with-nextjs.mdx
+++ b/apps/docs/content/guides/getting-started/tutorials/with-nextjs.mdx
@@ -124,8 +124,8 @@ export function createClient() {
   // Create a server's supabase client with newly configured cookie,
   // which could be used to maintain user's session
   return createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
     {
       cookies: {
         getAll() {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Fix a typo in the documentation

## What is the current behavior?

Typo in https://supabase.com/docs/guides/getting-started/tutorials/with-nextjs?queryGroups=language&language=js#supabase-utilities

## What is the new behavior?



## Additional context

It seems that `utils/supabase/server.js` is not a valid JS code. Specifically it has non-null assertion operator. Remove the operator to make the code valid.
