### PR TITLE
Fix: healthcheck for storage in main docker-compose

### DIFF
--- a/docker/docker-compose.s3.yml
+++ b/docker/docker-compose.s3.yml
@@ -52,7 +52,7 @@ services:
           "--no-verbose",
           "--tries=1",
           "--spider",
-          "http://localhost:5000/status"
+          "http://storage:5000/status"
         ]
       timeout: 5s
       interval: 5s

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -241,7 +241,7 @@ services:
           "--no-verbose",
           "--tries=1",
           "--spider",
-          "http://localhost:5000/status"
+          "http://storage:5000/status"
         ]
       timeout: 5s
       interval: 5s


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES/NO

## What kind of change does this PR introduce?

Bug fix for https://github.com/supabase/supabase/issues/27312

## What is the current behavior?

The docker container is unhealthy in its default configuration.

## What is the new behavior?

It is healthy 🙂 💊 .

closes https://github.com/supabase/supabase/issues/27312