### PR TITLE
Chore/link to storage settings

### DIFF
--- a/apps/studio/components/interfaces/Storage/CreateBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/CreateBucketModal.tsx
@@ -200,14 +200,14 @@ const CreateBucketModal = ({ visible, onClose }: CreateBucketModalProps) => {
                           {IS_PLATFORM && (
                             <div className="col-span-12">
                               <p className="text-foreground-light text-sm">
-                                Note: The{' '}
+                                Note: Individual bucket uploads will still be capped at the{' '}
                                 <Link
                                   href={`/project/${ref}/settings/storage`}
-                                  className="text-brand opacity-80 hover:opacity-100 transition"
+                                  className="font-bold underline"
                                 >
                                   global upload limit
                                 </Link>{' '}
-                                takes precedence over this value ({formattedGlobalUploadLimit})
+                                of {formattedGlobalUploadLimit}
                               </p>
                             </div>
                           )}

--- a/apps/studio/components/interfaces/Storage/EditBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/EditBucketModal.tsx
@@ -204,16 +204,16 @@ const EditBucketModal = ({ visible, bucket, onClose }: EditBucketModalProps) => 
                             </Listbox>
                           </div>
                           {IS_PLATFORM && (
-                            <div className="col-span-12">
+                            <div className="col-span-12 mt-2">
                               <p className="text-foreground-light text-sm">
-                                Note: The{' '}
+                                Note: Individual bucket upload will still be capped at the{' '}
                                 <Link
                                   href={`/project/${ref}/settings/storage`}
-                                  className="text-brand opacity-80 hover:opacity-100 transition"
+                                  className="font-bold underline"
                                 >
                                   global upload limit
                                 </Link>{' '}
-                                takes precedence over this value ({formattedGlobalUploadLimit})
+                                of {formattedGlobalUploadLimit}
                               </p>
                             </div>
                           )}

--- a/apps/studio/localStores/storageExplorer/StorageExplorerStore.tsx
+++ b/apps/studio/localStores/storageExplorer/StorageExplorerStore.tsx
@@ -567,18 +567,19 @@ class StorageExplorerStore {
           <p className="text-foreground">
             Failed to upload {numberOfFilesRejected} file{numberOfFilesRejected > 1 ? 's' : ''} as{' '}
             {numberOfFilesRejected > 1 ? 'their' : 'its'} size
-            {numberOfFilesRejected > 1 ? 's are' : ' is'} beyond the upload limit of {value}
+            {numberOfFilesRejected > 1 ? 's are' : ' is'} beyond the global upload limit of {value}
             {unit}.
           </p>
           <p className="text-foreground-light">
-            You can change the file size upload limit in{' '}
+            You can change the global file size upload limit in{' '}
             <Link
               className="underline"
               href={`/project/${this.projectRef}/settings/storage`}
               target="_blank"
             >
-              Storage settings.
+              Storage settings
             </Link>
+            .
           </p>
         </div>,
         { duration: 8000 }

--- a/apps/studio/localStores/storageExplorer/StorageExplorerStore.tsx
+++ b/apps/studio/localStores/storageExplorer/StorageExplorerStore.tsx
@@ -44,6 +44,7 @@ import { IS_PLATFORM } from 'lib/constants'
 import { lookupMime } from 'lib/mime'
 import { PROJECT_ENDPOINT_PROTOCOL } from 'pages/api/constants'
 import { Button, SONNER_DEFAULT_DURATION, SonnerProgress } from 'ui'
+import Link from 'next/link'
 
 type CachedFile = { id: string; fetchedAt: number; expiresIn: number; url: string }
 
@@ -570,9 +571,17 @@ class StorageExplorerStore {
             {unit}.
           </p>
           <p className="text-foreground-light">
-            You may change the file size upload limit under Storage in Project Settings.
+            You can change the file size upload limit in{' '}
+            <Link
+              className="underline"
+              href={`/project/${this.projectRef}/settings/storage`}
+              target="_blank"
+            >
+              Storage settings.
+            </Link>
           </p>
-        </div>
+        </div>,
+        { duration: 8000 }
       )
 
       if (numberOfFilesRejected === filesToUpload.length) return


### PR DESCRIPTION
PR Does a few things: 

- Add a link to storage settings if the file is larger than the global upload max size

![screenshot-2024-10-09-at-21 22 10](https://github.com/user-attachments/assets/ffa66bdc-cf2c-4b37-8e74-030e757775b7)

- Update the 413 (too large) error to be more reader friendly (before/after)
 
![screenshot-2024-10-10-at-10 49 44](https://github.com/user-attachments/assets/173a9825-7747-40b6-b638-6d519492441a)

- add 413 to doNotRetryStatuses. Previously, files that were too  large would retry 7 times before finally failing, when they could just fail immediately 
