### PR TITLE
Fix support form again

### DIFF
--- a/apps/studio/components/interfaces/Support/SupportFormV2.tsx
+++ b/apps/studio/components/interfaces/Support/SupportFormV2.tsx
@@ -136,7 +136,7 @@ export const SupportFormV2 = ({ setSentCategory, setSelectedProject }: SupportFo
     isLoading: isLoadingSubscription,
     isSuccess: isSuccessSubscription,
   } = useOrgSubscriptionQuery({
-    orgSlug: organizationSlug,
+    orgSlug: organizationSlug === 'no-org' ? undefined : organizationSlug,
   })
 
   const {
@@ -256,7 +256,9 @@ export const SupportFormV2 = ({ setSentCategory, setSelectedProject }: SupportFo
   useEffect(() => {
     // For prefilling form fields via URL, project ref will taking higher precedence than org slug
     if (isSuccessOrganizations && isSuccessProjects) {
-      if (ref) {
+      if (organizations.length === 0) {
+        form.setValue('organizationSlug', 'no-org')
+      } else if (ref) {
         const selectedProject = allProjects.find((p) => p.ref === ref)
         if (selectedProject !== undefined) {
           form.setValue('organizationSlug', selectedProject.organization_slug)
@@ -323,8 +325,14 @@ export const SupportFormV2 = ({ setSentCategory, setSelectedProject }: SupportFo
                   <SelectTrigger_Shadcn_ className="w-full">
                     <SelectValue_Shadcn_ asChild placeholder="Select an organization">
                       <div className="flex items-center gap-x-2">
-                        {(organizations ?? []).find((o) => o.slug === field.value)?.name}
-                        {isLoadingSubscription && <Loader2 size={14} className="animate-spin" />}
+                        {organizationSlug === 'no-org' ? (
+                          <span>No specific organization</span>
+                        ) : (
+                          (organizations ?? []).find((o) => o.slug === field.value)?.name
+                        )}
+                        {organizationSlug !== 'no-org' && isLoadingSubscription && (
+                          <Loader2 size={14} className="animate-spin" />
+                        )}
                         {isSuccessSubscription && (
                           <Badge variant="outline" className="capitalize">
                             {subscriptionPlanId}
@@ -338,6 +346,11 @@ export const SupportFormV2 = ({ setSentCategory, setSelectedProject }: SupportFo
                       {organizations?.map((org) => (
                         <SelectItem_Shadcn_ value={org.slug}>{org.name}</SelectItem_Shadcn_>
                       ))}
+                      {isSuccessOrganizations && (organizations ?? []).length === 0 && (
+                        <SelectItem_Shadcn_ value="no-org">
+                          No specific organization
+                        </SelectItem_Shadcn_>
+                      )}
                     </SelectGroup_Shadcn_>
                   </SelectContent_Shadcn_>
                 </Select_Shadcn_>

--- a/apps/studio/components/interfaces/Support/SupportFormV2.tsx
+++ b/apps/studio/components/interfaces/Support/SupportFormV2.tsx
@@ -200,6 +200,7 @@ export const SupportFormV2 = ({ setSentCategory, setSelectedProject }: SupportFo
 
     const payload = {
       ...values,
+      organizationSlug: values.organizationSlug === 'no-org' ? undefined : values.organizationSlug,
       library:
         values.category === 'Problem' && selectedLibrary !== undefined ? selectedLibrary.key : '',
       message: formatMessage(values.message, attachments),

--- a/apps/studio/data/subscriptions/org-subscription-query.ts
+++ b/apps/studio/data/subscriptions/org-subscription-query.ts
@@ -56,14 +56,6 @@ export const useOrgSubscriptionQuery = <TData = OrgSubscriptionData>(
 }
 
 export const useHasAccessToProjectLevelPermissions = (slug: string) => {
-  const canReadSubscriptions = useCheckPermissions(
-    PermissionAction.BILLING_READ,
-    'stripe.subscriptions'
-  )
-  const { data: subscription } = useOrgSubscriptionQuery(
-    { orgSlug: slug },
-    { enabled: canReadSubscriptions }
-  )
-
+  const { data: subscription } = useOrgSubscriptionQuery({ orgSlug: slug })
   return subscription?.plan.id === 'enterprise'
 }


### PR DESCRIPTION
Related to https://github.com/supabase/supabase/pull/29794, just starting from scratch

From @kevcodez in the attached PR:
Currently customers are forced to select an organization to submit the form. However, when the customer has no orgs, they are in a deadlock.

This PR allows customer to submit the form without an org selected, BUT only if they do not have any orgs. That is to prevent people from forgetting to select their org while creating a ticket related to an org. This is the least invasive change while still allowing customers to create a ticket.

Shadcn SelectItem doesn't allow null/undefined/empty string so we gotta do some nonsense to represent the empty value state here.