### PR TITLE
fix(docs): ref scroll

### DIFF
--- a/apps/docs/features/docs/Reference.ui.tsx
+++ b/apps/docs/features/docs/Reference.ui.tsx
@@ -100,7 +100,7 @@ export function StickyHeader({ title, monoFont = false, className }: StickyHeade
     <h2
       tabIndex={-1} // For programmatic focus on auto-scroll to section
       className={cn(
-        'sticky top-0 z-10',
+        'sticky top-0 z-[1]',
         'w-full',
         // Enough padding to cover the background when stuck to the top,
         // then readjust with negative margin to prevent it looking too
@@ -111,6 +111,7 @@ export function StickyHeader({ title, monoFont = false, className }: StickyHeade
         'bg-gradient-to-b from-background from-85% to-transparent to-100%',
         'text-2xl font-medium text-foreground',
         'scroll-mt-[calc(var(--header-height)+1rem)]',
+        'focus:outline-none',
         monoFont && 'font-mono',
         className
       )}

--- a/apps/docs/layouts/MainSkeleton.tsx
+++ b/apps/docs/layouts/MainSkeleton.tsx
@@ -300,6 +300,7 @@ const NavContainer = memo(function NavContainer({ children }: PropsWithChildren)
           'relative lg:sticky',
           'w-full lg:w-auto',
           'h-fit lg:h-screen overflow-y-scroll lg:overflow-auto',
+          '[overscroll-behavior:contain]',
           'backdrop-blur backdrop-filter bg-background',
           'flex flex-col flex-grow'
         )}


### PR DESCRIPTION
Fix various scrolling bugs with reference pages:

- Take out smooth scrolling as it tends to lead to buggy scrolling position
- Add overscroll-behavior: contain to the nav, otherwise overscrolling on the nav scrolls the main page, which causes the nav to jump around unexpectedly
- Put aria-current calculation in useEffect as otherwise it doesn't trigger properly on first load

See https://supabase.slack.com/archives/C023E4L60R3/p1728116359237709