### PR TITLE
Rename Live Share blog post

### DIFF
--- a/apps/www/_blog/2024-10-10-database-build-live-share.mdx
+++ b/apps/www/_blog/2024-10-10-database-build-live-share.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Live Share: connect to in-browser PGlite with any Postgres client'
+title: 'Live Share: Connect to in-browser PGlite with any Postgres client'
 description: Connect any Postgres client to your postgres.new databases.
 author: jgoux,gregnr
 image: database-build-live-share/database-build-live-share-og.png

--- a/apps/www/_blog/2024-10-10-database-build-live-share.mdx
+++ b/apps/www/_blog/2024-10-10-database-build-live-share.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Live Share: When your database escapes your browser'
+title: 'Live Share: connect to in-browser PGlite with any Postgres client'
 description: Connect any Postgres client to your postgres.new databases.
 author: jgoux,gregnr
 image: database-build-live-share/database-build-live-share-og.png


### PR DESCRIPTION
Renames the Live Share blog post to:

"Live Share: Connect to in-browser PGlite with any Postgres client"