### PR TITLE
fix: update curl snippet for invite user

### DIFF
--- a/apps/studio/components/interfaces/Docs/Snippets.ts
+++ b/apps/studio/components/interfaces/Docs/Snippets.ts
@@ -637,7 +637,7 @@ let { data, error } = await supabase.auth.verifyOtp({
       code: `
 curl -X POST '${endpoint}/auth/v1/invite' \\
 -H "apikey: ${apiKey}" \\
--H "Authorization: Bearer USER_TOKEN" \\
+-H "Authorization: Bearer SERVICE_ROLE_KEY" \\
 -H "Content-Type: application/json" \\
 -d '{
   "email": "someone@email.com"


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

Invite is an admin endpoint and should use a service role key. 

Updates a snippet, using old terminology for now (service_role_key) we will need to update this when we overhaul the naming for keys.

<img width="1154" alt="image" src="https://github.com/user-attachments/assets/cbcce0c5-08c8-4401-b156-9241aaf1e2d3">
