### PR TITLE
chore: remove disk exceeding global header

### DIFF
--- a/apps/studio/components/ui/OveragesBanner/OveragesBanner.utils.ts
+++ b/apps/studio/components/ui/OveragesBanner/OveragesBanner.utils.ts
@@ -5,8 +5,14 @@ export const getResourcesExceededLimitsOrg = (usageMetrics: OrgMetricsUsage[]): 
 
   return usageMetrics
     .filter((usageMetric) => {
-      if (!usageMetric.capped || !usageMetric.available_in_plan || usageMetric.unlimited)
+      if (
+        !usageMetric.capped ||
+        !usageMetric.available_in_plan ||
+        usageMetric.unlimited ||
+        usageMetric.metric === 'DISK_IOPS_GP3'
+      ) {
         return false
+      }
 
       const freeUnits = usageMetric.pricing_free_units || 0
 


### PR DESCRIPTION
Temporarily remove until we have better usage insights - we still show overages on the usage page, just not the aggressive top level banner
