### PR TITLE
Update webhook label to new maximum of 10000ms

### DIFF
--- a/apps/studio/components/interfaces/Database/Hooks/HTTPRequestFields.tsx
+++ b/apps/studio/components/interfaces/Database/Hooks/HTTPRequestFields.tsx
@@ -115,7 +115,7 @@ const HTTPRequestFields = ({
             id="timeout_ms"
             name="timeout_ms"
             label="Timeout"
-            labelOptional="Between 1000ms to 10000ms"
+            labelOptional="Between 1000ms to 10,000ms"
             type="number"
             actions={<p className="text-foreground-light pr-2">ms</p>}
           />

--- a/apps/studio/components/interfaces/Database/Hooks/HTTPRequestFields.tsx
+++ b/apps/studio/components/interfaces/Database/Hooks/HTTPRequestFields.tsx
@@ -115,7 +115,7 @@ const HTTPRequestFields = ({
             id="timeout_ms"
             name="timeout_ms"
             label="Timeout"
-            labelOptional="Between 1000ms to 5000ms"
+            labelOptional="Between 1000ms to 10000ms"
             type="number"
             actions={<p className="text-foreground-light pr-2">ms</p>}
           />


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

update label for webhook timeout to reflect new maximum of 10,000ms

## What is the current behavior?

![image](https://github.com/user-attachments/assets/7fc434a9-74e9-4961-abfd-79ffb6f74e57)

## What is the new behavior?

update the small text label to 10,000ms as well

## Additional context

based on user feedback in #29066
