### PR TITLE
Update docs with "make" requirement

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -39,6 +39,7 @@ You will need to install and configure the following dependencies on your machin
 - [Git](http://git-scm.com/)
 - [Node.js v20.x (LTS)](http://nodejs.org)
 - [npm](https://www.npmjs.com/) version 10.x.x or higher
+- [make](https://www.gnu.org/software/make/) or the equivalent to `build-essentials` for your OS
 - [Docker](https://docs.docker.com/get-docker/) (to run studio locally)
 
 ## Local development


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

Doc recommends git, npm, node, and docker

## What is the new behavior?

Adding requirement for `make` or some equivalent to the `build-essentials` package, based on my experience with the installation on a totally fresh system.

## Additional context

Fairly self explanatory. I ran the setup on a very fresh system, and ran into problems running `npm install` because some packages had build steps that required `make`.