### PR TITLE
Update auth hooks to use new endpoint and add perms checking

### DIFF
--- a/apps/studio/components/interfaces/Auth/Hooks/AddHookDropdown.tsx
+++ b/apps/studio/components/interfaces/Auth/Hooks/AddHookDropdown.tsx
@@ -16,7 +16,6 @@ import {
   DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-  SheetSection,
 } from 'ui'
 import { HOOKS_DEFINITIONS, HOOK_DEFINITION_TITLE, Hook } from './hooks.constants'
 import { extractMethod, isValidHook } from './hooks.utils'

--- a/apps/studio/components/interfaces/Auth/Hooks/AddHookDropdown.tsx
+++ b/apps/studio/components/interfaces/Auth/Hooks/AddHookDropdown.tsx
@@ -38,7 +38,7 @@ export const AddHookDropdown = ({
     { enabled: IS_PLATFORM }
   )
   const { data: authConfig } = useAuthConfigQuery({ projectRef })
-  const canUpdateConfig = useCheckPermissions(PermissionAction.UPDATE, 'custom_config_gotrue')
+  const canUpdateAuthHook = useCheckPermissions(PermissionAction.AUTH_EXECUTE, '*')
 
   const hooks: Hook[] = HOOKS_DEFINITIONS.map((definition) => {
     return {
@@ -57,7 +57,7 @@ export const AddHookDropdown = ({
   const isTeamsOrEnterprisePlan =
     subscription?.plan.id === 'team' || subscription?.plan.id === 'enterprise'
 
-  if (!canUpdateConfig) {
+  if (!canUpdateAuthHook) {
     return (
       <ButtonTooltip
         disabled
@@ -78,7 +78,7 @@ export const AddHookDropdown = ({
           {buttonText}
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent className="w-76 p-0" align="end">
+      <DropdownMenuContent className="w-76" align="end">
         <div>
           {nonEnterpriseHookOptions.map((h) => (
             <DropdownMenuItem key={h.title} onClick={() => onSelectHook(h.title)}>
@@ -87,7 +87,7 @@ export const AddHookDropdown = ({
           ))}
         </div>
 
-        <DropdownMenuSeparator className="my-0" />
+        <DropdownMenuSeparator />
 
         {!isTeamsOrEnterprisePlan && (
           <DropdownMenuLabel className="grid gap-1 bg-surface-200">

--- a/apps/studio/components/interfaces/Auth/Hooks/HookCard.tsx
+++ b/apps/studio/components/interfaces/Auth/Hooks/HookCard.tsx
@@ -1,18 +1,20 @@
+import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { Check, Webhook } from 'lucide-react'
 import { Badge, Input } from 'ui'
 
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
+import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { copyToClipboard } from 'lib/helpers'
 import { Hook } from './hooks.constants'
 
 interface HookCardProps {
   hook: Hook
-  canUpdateConfig: boolean
-  onToggle: (enabled: boolean) => void
   onSelect: () => void
 }
 
-export const HookCard = ({ hook, canUpdateConfig, onToggle, onSelect }: HookCardProps) => {
+export const HookCard = ({ hook, onSelect }: HookCardProps) => {
+  const canUpdateAuthHook = useCheckPermissions(PermissionAction.AUTH_EXECUTE, '*')
+
   return (
     <div className="bg-surface-100 border-default overflow-hidden border shadow px-5 py-4 flex flex-row first:rounded-t-md last:rounded-b-md space-x-4">
       <div className="">
@@ -93,7 +95,7 @@ export const HookCard = ({ hook, canUpdateConfig, onToggle, onSelect }: HookCard
         <div className="flex flex-row gap-2">
           <ButtonTooltip
             type="default"
-            disabled={!canUpdateConfig}
+            disabled={!canUpdateAuthHook}
             onClick={() => onSelect()}
             tooltip={{
               content: {

--- a/apps/studio/components/interfaces/Auth/Hooks/HooksListing.tsx
+++ b/apps/studio/components/interfaces/Auth/Hooks/HooksListing.tsx
@@ -1,23 +1,21 @@
-import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { useState } from 'react'
 import { toast } from 'sonner'
 
 import { useParams } from 'common'
+import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
 import AlertError from 'components/ui/AlertError'
+import CodeEditor from 'components/ui/CodeEditor/CodeEditor'
 import { FormHeader } from 'components/ui/Forms/FormHeader'
 import { useAuthConfigQuery } from 'data/auth/auth-config-query'
-import { useAuthConfigUpdateMutation } from 'data/auth/auth-config-update-mutation'
-import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import { useAuthHooksUpdateMutation } from 'data/auth/auth-hooks-update-mutation'
+import { executeSql } from 'data/sql/execute-sql-query'
+import { cn } from 'ui'
 import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
 import { AddHookDropdown } from './AddHookDropdown'
 import { CreateHookSheet } from './CreateHookSheet'
 import { HookCard } from './HookCard'
 import { HOOKS_DEFINITIONS, HOOK_DEFINITION_TITLE, Hook } from './hooks.constants'
 import { extractMethod, getRevokePermissionStatements, isValidHook } from './hooks.utils'
-import { executeSql } from 'data/sql/execute-sql-query'
-import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
-import CodeEditor from 'components/ui/CodeEditor/CodeEditor'
-import { cn } from 'ui'
 
 export const HooksListing = () => {
   const { ref: projectRef } = useParams()
@@ -27,8 +25,27 @@ export const HooksListing = () => {
   const [selectedHook, setSelectedHook] = useState<HOOK_DEFINITION_TITLE | null>(null)
   const [selectedHookForDeletion, setSelectedHookForDeletion] = useState<Hook | null>(null)
 
-  const { mutateAsync: updateAuthConfig } = useAuthConfigUpdateMutation()
-  const canUpdateConfig = useCheckPermissions(PermissionAction.UPDATE, 'custom_config_gotrue')
+  const { mutate: updateAuthHooks, isLoading: isDeletingAuthHook } = useAuthHooksUpdateMutation({
+    onSuccess: async () => {
+      if (!selectedHookForDeletion) return
+
+      const { method } = selectedHookForDeletion
+      if (method.type === 'postgres') {
+        const revokeStatements = getRevokePermissionStatements(method.schema, method.functionName)
+        await executeSql({
+          projectRef,
+          connectionString: project!.connectionString,
+          sql: revokeStatements.join('\n'),
+        })
+      }
+      toast.success(`${selectedHookForDeletion.title} has been deleted.`)
+      setSelectedHookForDeletion(null)
+      setSelectedHook(null)
+    },
+    onError: (error) => {
+      toast.error(`Failed to delete hook: ${error.message}`)
+    },
+  })
 
   const hooks: Hook[] = HOOKS_DEFINITIONS.map((definition) => {
     return {
@@ -78,16 +95,7 @@ export const HooksListing = () => {
               <HookCard
                 key={hook.enabledKey}
                 hook={hook}
-                canUpdateConfig={canUpdateConfig}
-                onToggle={(enabled) =>
-                  updateAuthConfig({
-                    projectRef: projectRef!,
-                    config: { [hook.enabledKey]: enabled },
-                  })
-                }
-                onSelect={() => {
-                  setSelectedHook(hook.title)
-                }}
+                onSelect={() => setSelectedHook(hook.title)}
               />
             )
           })}
@@ -98,9 +106,7 @@ export const HooksListing = () => {
         visible={!!selectedHook}
         onDelete={() => {
           const hook = hooks.find((h) => h.title === selectedHook)
-          if (hook) {
-            setSelectedHookForDeletion(hook)
-          }
+          if (hook) setSelectedHookForDeletion(hook)
         }}
         onClose={() => setSelectedHook(null)}
         authConfig={authConfig!}
@@ -110,16 +116,14 @@ export const HooksListing = () => {
         visible={!!selectedHookForDeletion}
         size="large"
         variant="destructive"
-        title="Confirm to delete"
+        loading={isDeletingAuthHook}
+        title={`Confirm to delete ${selectedHookForDeletion?.title}`}
         confirmLabel="Delete"
         confirmLabelLoading="Deleting"
         onCancel={() => setSelectedHookForDeletion(null)}
-        onConfirm={async () => {
-          if (!selectedHookForDeletion) {
-            return
-          }
-
-          await updateAuthConfig({
+        onConfirm={() => {
+          if (!selectedHookForDeletion) return
+          updateAuthHooks({
             projectRef: projectRef!,
             config: {
               [selectedHookForDeletion.enabledKey]: false,
@@ -127,35 +131,20 @@ export const HooksListing = () => {
               [selectedHookForDeletion.secretsKey]: null,
             },
           })
-
-          const { method } = selectedHookForDeletion
-
-          if (method.type === 'postgres') {
-            const revokeStatements = getRevokePermissionStatements(
-              method.schema,
-              method.functionName
-            )
-            await executeSql({
-              projectRef,
-              connectionString: project!.connectionString,
-              sql: revokeStatements.join('\n'),
-            })
-          }
-          toast.success(`${selectedHookForDeletion.title} has been deleted.`)
-          setSelectedHookForDeletion(null)
-          setSelectedHook(null)
         }}
       >
         <div>
-          <p className="py-4 text-sm text-foreground-light">
-            {`Are you sure you want to delete the ${selectedHookForDeletion?.title}?`}
+          <p className="text-sm text-foreground-light">
+            Are you sure you want to delete the {selectedHookForDeletion?.title}?
           </p>
           {selectedHookForDeletion?.method.type === 'postgres' && (
             <>
-              <p className="py-4 text-sm text-foreground-light">
-                {`The following statements will be executed on the ${selectedHookForDeletion?.method.schema}.${selectedHookForDeletion?.method.functionName} function:`}
+              <p className="text-sm text-foreground-light">
+                The following statements will be executed on the{' '}
+                {selectedHookForDeletion?.method.schema}.
+                {selectedHookForDeletion?.method.functionName} function:
               </p>
-              <div className={cn('h-72')}>
+              <div className={cn('mt-4', 'h-72')}>
                 <CodeEditor
                   id="deletion-hook-editor"
                   isReadOnly={true}

--- a/apps/studio/components/interfaces/Functions/EdgeFunctionSecrets/EdgeFunctionSecrets.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionSecrets/EdgeFunctionSecrets.tsx
@@ -24,8 +24,8 @@ const EdgeFunctionSecrets = () => {
   const [showCreateSecret, setShowCreateSecret] = useState(false)
   const [selectedSecret, setSelectedSecret] = useState<ProjectSecret>()
 
-  const canReadSecrets = useCheckPermissions(PermissionAction.FUNCTIONS_READ, '*')
-  const canUpdateSecrets = useCheckPermissions(PermissionAction.FUNCTIONS_WRITE, '*')
+  const canReadSecrets = useCheckPermissions(PermissionAction.SECRETS_READ, '*')
+  const canUpdateSecrets = useCheckPermissions(PermissionAction.SECRETS_WRITE, '*')
 
   const { data, error, isLoading, isSuccess, isError } = useSecretsQuery({
     projectRef: projectRef,

--- a/apps/studio/data/auth/auth-hooks-update-mutation.ts
+++ b/apps/studio/data/auth/auth-hooks-update-mutation.ts
@@ -1,0 +1,54 @@
+import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+
+import type { components } from 'data/api'
+import { handleError, patch } from 'data/fetchers'
+import type { ResponseError } from 'types'
+import { authKeys } from './keys'
+
+export type AuthHooksUpdateVariables = {
+  projectRef: string
+  config: components['schemas']['UpdateGoTrueConfigHooksBody']
+}
+
+export async function updateAuthHooks({ projectRef, config }: AuthHooksUpdateVariables) {
+  const { data, error } = await patch('/platform/auth/{ref}/config/hooks', {
+    params: { path: { ref: projectRef } },
+    body: config,
+  })
+
+  if (error) handleError(error)
+  return data
+}
+
+type AuthHooksUpdateData = Awaited<ReturnType<typeof updateAuthHooks>>
+
+export const useAuthHooksUpdateMutation = ({
+  onSuccess,
+  onError,
+  ...options
+}: Omit<
+  UseMutationOptions<AuthHooksUpdateData, ResponseError, AuthHooksUpdateVariables>,
+  'mutationFn'
+> = {}) => {
+  const queryClient = useQueryClient()
+
+  return useMutation<AuthHooksUpdateData, ResponseError, AuthHooksUpdateVariables>(
+    (vars) => updateAuthHooks(vars),
+    {
+      async onSuccess(data, variables, context) {
+        const { projectRef } = variables
+        await queryClient.invalidateQueries(authKeys.authConfig(projectRef))
+        await onSuccess?.(data, variables, context)
+      },
+      async onError(data, variables, context) {
+        if (onError === undefined) {
+          toast.error(`Failed to update auth hooks: ${data.message}`)
+        } else {
+          onError(data, variables, context)
+        }
+      },
+      ...options,
+    }
+  )
+}

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -40,7 +40,7 @@
     "@supabase/auth-js": "2.64.2",
     "@supabase/pg-meta": "*",
     "@supabase/realtime-js": "2.10.2",
-    "@supabase/shared-types": "0.1.70",
+    "@supabase/shared-types": "0.1.73",
     "@supabase/supabase-js": "^2.44.3",
     "@tanstack/react-query": "4.35.7",
     "@tanstack/react-query-devtools": "4.35.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1826,7 +1826,7 @@
         "@supabase/auth-js": "2.64.2",
         "@supabase/pg-meta": "*",
         "@supabase/realtime-js": "2.10.2",
-        "@supabase/shared-types": "0.1.70",
+        "@supabase/shared-types": "0.1.73",
         "@supabase/supabase-js": "^2.44.3",
         "@tanstack/react-query": "4.35.7",
         "@tanstack/react-query-devtools": "4.35.7",
@@ -14739,9 +14739,9 @@
       }
     },
     "node_modules/@supabase/shared-types": {
-      "version": "0.1.70",
-      "resolved": "https://registry.npmjs.org/@supabase/shared-types/-/shared-types-0.1.70.tgz",
-      "integrity": "sha512-Z/JBbISlxMcOjFcomZdB5AGKrQdTy/dy3HQ8EpHx3xKz1yktbUDrzVcEFUKidRPrQu1GAt9JSW6qBsBlXHcyLA=="
+      "version": "0.1.73",
+      "resolved": "https://registry.npmjs.org/@supabase/shared-types/-/shared-types-0.1.73.tgz",
+      "integrity": "sha512-5BhGYrJ/ICBlIWdAZL3lRD2w6ZUAYvjpulvIkHfVKNcXpF3LpZ+2ONRDkm0B8dlWp+ZE1bm7DbFgJvoW+AT3XA=="
     },
     "node_modules/@supabase/sql-to-rest": {
       "version": "0.1.6",

--- a/packages/api-types/types/api.d.ts
+++ b/packages/api-types/types/api.d.ts
@@ -101,6 +101,10 @@ export interface paths {
     /** Updates GoTrue config */
     patch: operations['GoTrueConfigController_updateGoTrueConfig']
   }
+  '/platform/auth/{ref}/config/hooks': {
+    /** Updates GoTrue config hooks */
+    patch: operations['GoTrueConfigController_updateGoTrueConfigHooks']
+  }
   '/platform/auth/{ref}/invite': {
     /** Sends an invite to the given email */
     post: operations['AuthInviteController_sendInvite']
@@ -122,10 +126,24 @@ export interface paths {
     get: operations['TemplateController_getTemplate']
   }
   '/platform/auth/{ref}/users': {
-    /** Gets users */
+    /**
+     * Gets users
+     * @deprecated
+     */
     get: operations['UsersController_getUsers']
-    /** Delete user with given ID */
+    /** Creates user */
+    post: operations['UsersController_createUser']
+    /**
+     * Delete user with given ID
+     * @deprecated
+     */
     delete: operations['UsersController_deleteUser']
+  }
+  '/platform/auth/{ref}/users/{id}': {
+    /** Delete user with given ID */
+    delete: operations['UsersController_deleteUserById']
+    /** Updates user with given ID */
+    patch: operations['UsersController_updateUserById']
   }
   '/platform/auth/{ref}/users/{id}/factors': {
     /** Delete all factors associated to a user */
@@ -456,6 +474,10 @@ export interface paths {
   '/platform/organizations/{slug}/payments/setup-intent': {
     /** Sets up a payment method */
     post: operations['SetupIntentOrgController_setUpPaymentMethod']
+  }
+  '/platform/organizations/{slug}/projects': {
+    /** Gets all projects for the given organization */
+    get: operations['OrganizationProjectsController_getProjects']
   }
   '/platform/organizations/{slug}/roles': {
     /** Gets the given organization's roles */
@@ -1286,6 +1308,10 @@ export interface paths {
     /** Updates GoTrue config */
     patch: operations['GoTrueConfigController_updateGoTrueConfig']
   }
+  '/v0/auth/{ref}/config/hooks': {
+    /** Updates GoTrue config hooks */
+    patch: operations['GoTrueConfigController_updateGoTrueConfigHooks']
+  }
   '/v0/auth/{ref}/invite': {
     /** Sends an invite to the given email */
     post: operations['AuthInviteController_sendInvite']
@@ -1307,10 +1333,24 @@ export interface paths {
     get: operations['TemplateController_getTemplate']
   }
   '/v0/auth/{ref}/users': {
-    /** Gets users */
+    /**
+     * Gets users
+     * @deprecated
+     */
     get: operations['UsersController_getUsers']
-    /** Delete user with given ID */
+    /** Creates user */
+    post: operations['UsersController_createUser']
+    /**
+     * Delete user with given ID
+     * @deprecated
+     */
     delete: operations['UsersController_deleteUser']
+  }
+  '/v0/auth/{ref}/users/{id}': {
+    /** Delete user with given ID */
+    delete: operations['UsersController_deleteUserById']
+    /** Updates user with given ID */
+    patch: operations['UsersController_updateUserById']
   }
   '/v0/auth/{ref}/users/{id}/factors': {
     /** Delete all factors associated to a user */
@@ -3022,12 +3062,54 @@ export interface components {
       table: string
       table_id?: number
     }
+    CreateUserBody: {
+      email: string
+      email_confirm: boolean
+      password: string
+    }
     CreateUserContentFolderResponse: {
       id: string
       name: string
       owner_id: number
       parent_id?: string | null
       project_id: number
+    }
+    CreateUserReponse: {
+      aud?: string
+      banned_until?: string
+      confirmation_sent_at?: string
+      confirmation_token?: string
+      confirmed_at?: string
+      created_at?: string
+      deleted_at?: string
+      email?: string
+      email_change?: string
+      email_change_confirm_status?: number
+      email_change_sent_at?: string
+      email_change_token_current?: string
+      email_change_token_new?: string
+      email_confirmed_at?: string
+      encrypted_password?: string
+      id?: string
+      instance_id?: string
+      invited_at?: string
+      is_anonymous?: boolean
+      is_sso_user?: boolean
+      is_super_admin?: boolean
+      last_sign_in_at?: string
+      phone?: string
+      phone_change?: string
+      phone_change_sent_at?: string
+      phone_change_token?: string
+      phone_confirmed_at?: string
+      raw_app_meta_data?: Record<string, never>
+      raw_user_meta_data?: Record<string, never>
+      reauthentication_sent_at?: string
+      reauthentication_token?: string
+      recovery_sent_at?: string
+      recovery_token?: string
+      role?: string
+      updated_at?: string
     }
     CreateVercelConnectionResponse: {
       env_sync_error?: components['schemas']['SyncVercelEnvError']
@@ -3116,6 +3198,21 @@ export interface components {
         | 'RESTARTING'
         | 'RESIZING'
     }
+    /** @enum {string} */
+    DatabaseStatus:
+      | 'ACTIVE_HEALTHY'
+      | 'ACTIVE_UNHEALTHY'
+      | 'COMING_UP'
+      | 'GOING_DOWN'
+      | 'INIT_FAILED'
+      | 'REMOVED'
+      | 'RESTORING'
+      | 'UNKNOWN'
+      | 'UPGRADING'
+      | 'INIT_READ_REPLICA'
+      | 'INIT_READ_REPLICA_FAILED'
+      | 'RESTARTING'
+      | 'RESIZING'
     DatabaseStatusResponse: {
       identifier: string
       replicaInitializationStatus?: Record<string, never>
@@ -3135,6 +3232,8 @@ export interface components {
         | 'RESTARTING'
         | 'RESIZING'
     }
+    /** @enum {string} */
+    DatabaseType: 'PRIMARY' | 'READ_REPLICA'
     DatabaseUpgradeStatus: {
       /** @enum {string} */
       error?:
@@ -4169,6 +4268,9 @@ export interface components {
        */
       supabase_org_id: string
     }
+    OrganizationProjectsResponse: {
+      projects: components['schemas']['ProjectWithDatabases'][]
+    }
     OrganizationResponse: {
       billing_email: string | null
       id: number
@@ -4669,6 +4771,19 @@ export interface components {
       release_channel: components['schemas']['ReleaseChannel']
       version: string
     }
+    ProjectDatabase: {
+      cloud_provider: string
+      disk_last_modified_at?: string
+      disk_throughput_mbps?: number
+      /** @enum {string} */
+      disk_type?: 'gp3' | 'io2'
+      disk_volume_size_gb?: number
+      identifier: string
+      infra_compute_size?: components['schemas']['DbInstanceSize']
+      region: string
+      status: components['schemas']['DatabaseStatus']
+      type: components['schemas']['DatabaseType']
+    }
     ProjectDetailResponse: {
       cloud_provider: string
       connectionString: string
@@ -4852,6 +4967,23 @@ export interface components {
       ssl_enforced: boolean
       status: string
     }
+    /** @enum {string} */
+    ProjectStatus:
+      | 'ACTIVE_HEALTHY'
+      | 'ACTIVE_UNHEALTHY'
+      | 'COMING_UP'
+      | 'GOING_DOWN'
+      | 'INACTIVE'
+      | 'INIT_FAILED'
+      | 'REMOVED'
+      | 'RESTARTING'
+      | 'UNKNOWN'
+      | 'UPGRADING'
+      | 'PAUSING'
+      | 'RESTORING'
+      | 'RESTORE_FAILED'
+      | 'PAUSE_FAILED'
+      | 'RESIZING'
     ProjectUnpauseVersionInfo: {
       postgres_engine: components['schemas']['PostgresEngine']
       release_channel: components['schemas']['ReleaseChannel']
@@ -4875,6 +5007,14 @@ export interface components {
       app_version: string
       postgres_version: components['schemas']['PostgresEngine']
       release_channel: components['schemas']['ReleaseChannel']
+    }
+    ProjectWithDatabases: {
+      databases: components['schemas']['ProjectDatabase'][]
+      is_branch: boolean
+      name: string
+      ref: string
+      region: string
+      status: components['schemas']['ProjectStatus']
     }
     Provider: {
       created_at?: string
@@ -6140,6 +6280,23 @@ export interface components {
       SMTP_USER?: string
       URI_ALLOW_LIST?: string
     }
+    UpdateGoTrueConfigHooksBody: {
+      HOOK_CUSTOM_ACCESS_TOKEN_ENABLED?: boolean
+      HOOK_CUSTOM_ACCESS_TOKEN_SECRETS?: string
+      HOOK_CUSTOM_ACCESS_TOKEN_URI?: string
+      HOOK_MFA_VERIFICATION_ATTEMPT_ENABLED?: boolean
+      HOOK_MFA_VERIFICATION_ATTEMPT_SECRETS?: string
+      HOOK_MFA_VERIFICATION_ATTEMPT_URI?: string
+      HOOK_PASSWORD_VERIFICATION_ATTEMPT_ENABLED?: boolean
+      HOOK_PASSWORD_VERIFICATION_ATTEMPT_SECRETS?: string
+      HOOK_PASSWORD_VERIFICATION_ATTEMPT_URI?: string
+      HOOK_SEND_EMAIL_ENABLED?: boolean
+      HOOK_SEND_EMAIL_SECRETS?: string
+      HOOK_SEND_EMAIL_URI?: string
+      HOOK_SEND_SMS_ENABLED?: boolean
+      HOOK_SEND_SMS_SECRETS?: string
+      HOOK_SEND_SMS_URI?: string
+    }
     UpdateMemberBody: {
       role_id: number
     }
@@ -6357,6 +6514,46 @@ export interface components {
       schema?: string
       table?: string
       table_id?: number
+    }
+    UpdateUserBody: {
+      ban_duration?: string
+    }
+    UpdateUserReponse: {
+      aud?: string
+      banned_until?: string
+      confirmation_sent_at?: string
+      confirmation_token?: string
+      confirmed_at?: string
+      created_at?: string
+      deleted_at?: string
+      email?: string
+      email_change?: string
+      email_change_confirm_status?: number
+      email_change_sent_at?: string
+      email_change_token_current?: string
+      email_change_token_new?: string
+      email_confirmed_at?: string
+      encrypted_password?: string
+      id?: string
+      instance_id?: string
+      invited_at?: string
+      is_anonymous?: boolean
+      is_sso_user?: boolean
+      is_super_admin?: boolean
+      last_sign_in_at?: string
+      phone?: string
+      phone_change?: string
+      phone_change_sent_at?: string
+      phone_change_token?: string
+      phone_confirmed_at?: string
+      raw_app_meta_data?: Record<string, never>
+      raw_user_meta_data?: Record<string, never>
+      reauthentication_sent_at?: string
+      reauthentication_token?: string
+      recovery_sent_at?: string
+      recovery_token?: string
+      role?: string
+      updated_at?: string
     }
     UpdateVercelConnectionsBody: {
       env_sync_targets?: ('production' | 'preview' | 'development')[]
@@ -7078,6 +7275,34 @@ export interface operations {
       }
     }
   }
+  /** Updates GoTrue config hooks */
+  GoTrueConfigController_updateGoTrueConfigHooks: {
+    parameters: {
+      path: {
+        /** @description Project ref */
+        ref: string
+      }
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['UpdateGoTrueConfigHooksBody']
+      }
+    }
+    responses: {
+      200: {
+        content: {
+          'application/json': components['schemas']['GoTrueConfigResponse']
+        }
+      }
+      403: {
+        content: never
+      }
+      /** @description Failed to update GoTrue config hooks */
+      500: {
+        content: never
+      }
+    }
+  }
   /** Sends an invite to the given email */
   AuthInviteController_sendInvite: {
     parameters: {
@@ -7216,7 +7441,10 @@ export interface operations {
       }
     }
   }
-  /** Gets users */
+  /**
+   * Gets users
+   * @deprecated
+   */
   UsersController_getUsers: {
     parameters: {
       query: {
@@ -7245,7 +7473,38 @@ export interface operations {
       }
     }
   }
-  /** Delete user with given ID */
+  /** Creates user */
+  UsersController_createUser: {
+    parameters: {
+      path: {
+        /** @description Project ref */
+        ref: string
+      }
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['CreateUserBody']
+      }
+    }
+    responses: {
+      201: {
+        content: {
+          'application/json': components['schemas']['CreateUserReponse']
+        }
+      }
+      403: {
+        content: never
+      }
+      /** @description Failed to create user */
+      500: {
+        content: never
+      }
+    }
+  }
+  /**
+   * Delete user with given ID
+   * @deprecated
+   */
   UsersController_deleteUser: {
     parameters: {
       path: {
@@ -7268,6 +7527,57 @@ export interface operations {
         content: never
       }
       /** @description Failed to delete user */
+      500: {
+        content: never
+      }
+    }
+  }
+  /** Delete user with given ID */
+  UsersController_deleteUserById: {
+    parameters: {
+      path: {
+        /** @description Project ref */
+        ref: string
+        id: string
+      }
+    }
+    responses: {
+      200: {
+        content: never
+      }
+      403: {
+        content: never
+      }
+      /** @description Failed to delete user */
+      500: {
+        content: never
+      }
+    }
+  }
+  /** Updates user with given ID */
+  UsersController_updateUserById: {
+    parameters: {
+      path: {
+        /** @description Project ref */
+        ref: string
+        id: string
+      }
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['UpdateUserBody']
+      }
+    }
+    responses: {
+      200: {
+        content: {
+          'application/json': components['schemas']['UpdateUserReponse']
+        }
+      }
+      403: {
+        content: never
+      }
+      /** @description Failed to update user with given ID */
       500: {
         content: never
       }
@@ -9190,6 +9500,29 @@ export interface operations {
         content: never
       }
       /** @description Failed to set up a payment method */
+      500: {
+        content: never
+      }
+    }
+  }
+  /** Gets all projects for the given organization */
+  OrganizationProjectsController_getProjects: {
+    parameters: {
+      path: {
+        /** @description Organization slug */
+        slug: string
+      }
+    }
+    responses: {
+      200: {
+        content: {
+          'application/json': components['schemas']['OrganizationProjectsResponse']
+        }
+      }
+      403: {
+        content: never
+      }
+      /** @description Failed to retrieve projects */
       500: {
         content: never
       }
@@ -12089,6 +12422,9 @@ export interface operations {
         content: {
           'application/json': components['schemas']['UpdateSecretsResponse']
         }
+      }
+      403: {
+        content: never
       }
       /** @description Failed to update project's secrets config */
       500: {


### PR DESCRIPTION
Dependent on API changes here to be merged and deployed:
https://github.com/supabase/infrastructure/pull/20067

Related discussion:
https://github.com/orgs/supabase/discussions/29494

To be merged on 15th October, but can only be tested locally for now
- Update auth hooks to use new endpoints that support more granular permissions checking + update perms checking on client side for auth hooks
  - Developer role will have restriction permissions for auth config, but they should still be able to configure auth hooks
- Update perms checking on client side for edge functions secrets
  -  Developers can no longer create or delete edge functions secrets