### PR TITLE
fix: change to return jsonb

### DIFF
--- a/apps/docs/content/guides/auth/auth-hooks/send-email-hook.mdx
+++ b/apps/docs/content/guides/auth/auth-hooks/send-email-hook.mdx
@@ -351,7 +351,7 @@ create table job_queue (
 Create the hook
 
 ```sql
-create or replace function send_email(event jsonb) returns void as $$
+create or replace function send_email(event jsonb) returns jsonb as $$
 declare
     job_data jsonb;
     scheduled_time timestamp;
@@ -373,6 +373,8 @@ begin
 
     insert into job_queue (job_data, priority, scheduled_at, max_retries)
     values (job_data, priority, scheduled_time, 2);
+
+    return '{}'::jsonb;
 end;
 $$ language plpgsql;
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES


We need to return a jsonb for the hook to show up in the function selector