### PR TITLE
Update PH consent banner

### DIFF
--- a/apps/studio/components/interfaces/Account/Preferences/AnalyticsSettings.tsx
+++ b/apps/studio/components/interfaces/Account/Preferences/AnalyticsSettings.tsx
@@ -1,16 +1,23 @@
 import { Toggle } from 'ui'
 
 import Panel from 'components/ui/Panel'
-import { useAppStateSnapshot } from 'state/app-state'
 import { useSendResetMutation } from 'data/telemetry/send-reset-mutation'
+import { useFlag } from 'hooks/ui/useFlag'
+import { LOCAL_STORAGE_KEYS } from 'lib/constants'
+import { useAppStateSnapshot } from 'state/app-state'
 
 const AnalyticsSettings = () => {
   const snap = useAppStateSnapshot()
+  const enablePostHogTelemetry = useFlag('enablePosthogChanges')
   const { mutate: sendReset } = useSendResetMutation()
+
+  const consentFlag = enablePostHogTelemetry
+    ? LOCAL_STORAGE_KEYS.TELEMETRY_CONSENT_PH
+    : LOCAL_STORAGE_KEYS.TELEMETRY_CONSENT
 
   const onToggleOptIn = () => {
     const value = !snap.isOptedInTelemetry ? 'true' : 'false'
-    snap.setIsOptedInTelemetry(value === 'true')
+    snap.setIsOptedInTelemetry(value === 'true', consentFlag)
     if (value === 'false') sendReset()
   }
 

--- a/apps/studio/components/ui/PageTelemetry.tsx
+++ b/apps/studio/components/ui/PageTelemetry.tsx
@@ -1,7 +1,8 @@
 import { Sha256 } from '@aws-crypto/sha256-browser'
 import * as Sentry from '@sentry/nextjs'
 import { useRouter } from 'next/router'
-import { PropsWithChildren, useEffect, useState } from 'react'
+import { PropsWithChildren, useEffect, useRef } from 'react'
+import { toast } from 'sonner'
 
 import { useParams, useUser } from 'common'
 import { useSendGroupsIdentifyMutation } from 'data/telemetry/send-groups-identify-mutation'
@@ -13,6 +14,7 @@ import { useSelectedOrganization } from 'hooks/misc/useSelectedOrganization'
 import { useFlag } from 'hooks/ui/useFlag'
 import { IS_PLATFORM, LOCAL_STORAGE_KEYS } from 'lib/constants'
 import { useAppStateSnapshot } from 'state/app-state'
+import { ConsentToast } from 'ui-patterns/ConsentToast'
 
 const getAnonId = async (id: string) => {
   const hash = new Sha256()
@@ -30,6 +32,7 @@ const PageTelemetry = ({ children }: PropsWithChildren<{}>) => {
   const snap = useAppStateSnapshot()
   const organization = useSelectedOrganization()
 
+  const consentToastId = useRef<string | number>()
   const previousPathname = usePrevious(router.pathname)
   const enablePostHogTelemetry = useFlag('enablePosthogChanges')
   const consent =
@@ -44,13 +47,40 @@ const PageTelemetry = ({ children }: PropsWithChildren<{}>) => {
   const { mutate: sendGroupsReset } = useSendGroupsResetMutation()
 
   useEffect(() => {
-    const consent =
-      typeof window !== 'undefined'
-        ? localStorage.getItem(LOCAL_STORAGE_KEYS.TELEMETRY_CONSENT)
-        : null
-    if (consent !== null) snap.setIsOptedInTelemetry(consent === 'true')
+    if (typeof window !== 'undefined' && enablePostHogTelemetry !== undefined) {
+      const onAcceptConsent = () => {
+        snap.setIsOptedInTelemetry(true)
+        if (consentToastId.current) toast.dismiss(consentToastId.current)
+      }
+
+      const onOptOut = () => {
+        snap.setIsOptedInTelemetry(false)
+        if (consentToastId.current) toast.dismiss(consentToastId.current)
+      }
+
+      const hasAcknowledgedConsent = localStorage.getItem(
+        enablePostHogTelemetry
+          ? LOCAL_STORAGE_KEYS.TELEMETRY_CONSENT_PH
+          : LOCAL_STORAGE_KEYS.TELEMETRY_CONSENT
+      )
+      snap.setIsOptedInTelemetry(hasAcknowledgedConsent === 'true')
+
+      if (IS_PLATFORM && hasAcknowledgedConsent === null) {
+        setTimeout(() => {
+          consentToastId.current = toast(
+            <ConsentToast onAccept={onAcceptConsent} onOptOut={onOptOut} />,
+            {
+              id: 'consent-toast',
+              position: 'bottom-right',
+              duration: Infinity,
+            }
+          )
+        }, 300)
+      }
+    }
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [enablePostHogTelemetry])
 
   useEffect(() => {
     function handleRouteChange() {

--- a/apps/studio/data/telemetry/send-event-mutation.ts
+++ b/apps/studio/data/telemetry/send-event-mutation.ts
@@ -20,12 +20,16 @@ export type SendEventVariables = {
 
 type SendEventPayload = any
 
-export async function sendEvent(type: 'GA' | 'PH', body: SendEventPayload) {
-  const consent =
-    typeof window !== 'undefined'
-      ? localStorage.getItem(LOCAL_STORAGE_KEYS.TELEMETRY_CONSENT)
-      : null
-  if (consent !== 'true') return
+export async function sendEvent({
+  consent,
+  type,
+  body,
+}: {
+  consent: boolean
+  type: 'GA' | 'PH'
+  body: SendEventPayload
+}) {
+  if (!consent) return undefined
 
   const headers = type === 'PH' ? { Version: '2' } : undefined
   const { data, error } = await post(`/platform/telemetry/event`, {
@@ -49,6 +53,15 @@ export const useSendEventMutation = ({
 > = {}) => {
   const router = useRouter()
   const usePostHogParameters = useFlag('enablePosthogChanges')
+
+  const consent =
+    (typeof window !== 'undefined'
+      ? localStorage.getItem(
+          usePostHogParameters
+            ? LOCAL_STORAGE_KEYS.TELEMETRY_CONSENT_PH
+            : LOCAL_STORAGE_KEYS.TELEMETRY_CONSENT
+        )
+      : null) === 'true'
 
   const title = typeof document !== 'undefined' ? document?.title : ''
   const referrer = typeof document !== 'undefined' ? document?.referrer : ''
@@ -89,7 +102,7 @@ export const useSendEventMutation = ({
             custom_properties: otherVars,
           } as unknown as SendEventPH)
         : ({ ...vars, ...payload } as SendEventGA)
-      return sendEvent(type, body)
+      return sendEvent({ consent, type, body })
     },
     {
       async onSuccess(data, variables, context) {

--- a/apps/studio/data/telemetry/send-groups-identify-mutation.ts
+++ b/apps/studio/data/telemetry/send-groups-identify-mutation.ts
@@ -2,11 +2,20 @@ import { useMutation, UseMutationOptions } from '@tanstack/react-query'
 
 import { components } from 'api-types'
 import { handleError, post } from 'data/fetchers'
+import { LOCAL_STORAGE_KEYS } from 'lib/constants'
 import type { ResponseError } from 'types'
 
 export type SendGroupsIdentifyVariables = components['schemas']['TelemetryGroupsIdentityBody']
 
-export async function sendGroupsIdentify(body: SendGroupsIdentifyVariables) {
+export async function sendGroupsIdentify({
+  consent,
+  body,
+}: {
+  consent: boolean
+  body: SendGroupsIdentifyVariables
+}) {
+  if (!consent) return undefined
+
   const { data, error } = await post(`/platform/telemetry/groups/identify`, {
     body,
     credentials: 'include',
@@ -25,8 +34,13 @@ export const useSendGroupsIdentifyMutation = ({
   UseMutationOptions<SendGroupsIdentifyData, ResponseError, SendGroupsIdentifyVariables>,
   'mutationFn'
 > = {}) => {
+  const consent =
+    (typeof window !== 'undefined'
+      ? localStorage.getItem(LOCAL_STORAGE_KEYS.TELEMETRY_CONSENT_PH)
+      : null) === 'true'
+
   return useMutation<SendGroupsIdentifyData, ResponseError, SendGroupsIdentifyVariables>(
-    (vars) => sendGroupsIdentify(vars),
+    (vars) => sendGroupsIdentify({ consent, body: vars }),
     {
       async onSuccess(data, variables, context) {
         await onSuccess?.(data, variables, context)

--- a/apps/studio/data/telemetry/send-groups-reset-mutation.ts
+++ b/apps/studio/data/telemetry/send-groups-reset-mutation.ts
@@ -2,11 +2,20 @@ import { useMutation, UseMutationOptions } from '@tanstack/react-query'
 
 import { components } from 'api-types'
 import { handleError, post } from 'data/fetchers'
+import { LOCAL_STORAGE_KEYS } from 'lib/constants'
 import type { ResponseError } from 'types'
 
 export type SendGroupsResetVariables = components['schemas']['TelemetryGroupsResetBody']
 
-export async function sendGroupsReset(body: SendGroupsResetVariables) {
+export async function sendGroupsReset({
+  consent,
+  body,
+}: {
+  consent: boolean
+  body: SendGroupsResetVariables
+}) {
+  if (!consent) return undefined
+
   const { data, error } = await post(`/platform/telemetry/groups/reset`, {
     body,
     credentials: 'include',
@@ -25,8 +34,13 @@ export const useSendGroupsResetMutation = ({
   UseMutationOptions<SendGroupsResetData, ResponseError, SendGroupsResetVariables>,
   'mutationFn'
 > = {}) => {
+  const consent =
+    (typeof window !== 'undefined'
+      ? localStorage.getItem(LOCAL_STORAGE_KEYS.TELEMETRY_CONSENT_PH)
+      : null) === 'true'
+
   return useMutation<SendGroupsResetData, ResponseError, SendGroupsResetVariables>(
-    (vars) => sendGroupsReset(vars),
+    (vars) => sendGroupsReset({ consent, body: vars }),
     {
       async onSuccess(data, variables, context) {
         await onSuccess?.(data, variables, context)

--- a/apps/studio/data/telemetry/send-identify-mutation.ts
+++ b/apps/studio/data/telemetry/send-identify-mutation.ts
@@ -1,4 +1,5 @@
 import { useMutation, UseMutationOptions } from '@tanstack/react-query'
+import { useRouter } from 'next/router'
 
 import { components } from 'api-types'
 import { isBrowser } from 'common'
@@ -6,7 +7,6 @@ import { handleError, post } from 'data/fetchers'
 import { Profile } from 'data/profile/types'
 import { useFlag } from 'hooks/ui/useFlag'
 import { LOCAL_STORAGE_KEYS } from 'lib/constants'
-import { useRouter } from 'next/router'
 import type { ResponseError } from 'types'
 
 type SendIdentifyGA = components['schemas']['TelemetryIdentifyBody']
@@ -20,12 +20,16 @@ export type SendIdentifyVariables = {
 
 type SendIdentifyPayload = any
 
-export async function sendIdentify(type: 'GA' | 'PH', body: SendIdentifyPayload) {
-  const consent =
-    typeof window !== 'undefined'
-      ? localStorage.getItem(LOCAL_STORAGE_KEYS.TELEMETRY_CONSENT)
-      : null
-  if (consent !== 'true') return
+export async function sendIdentify({
+  consent,
+  type,
+  body,
+}: {
+  consent: boolean
+  type: 'GA' | 'PH'
+  body: SendIdentifyPayload
+}) {
+  if (!consent) return undefined
 
   const headers = type === 'PH' ? { Version: '2' } : undefined
   const { data, error } = await post(`/platform/telemetry/identify`, {
@@ -50,6 +54,15 @@ export const useSendIdentifyMutation = ({
   const router = useRouter()
   const usePostHogParameters = useFlag('enablePosthogChanges')
 
+  const consent =
+    (typeof window !== 'undefined'
+      ? localStorage.getItem(
+          usePostHogParameters
+            ? LOCAL_STORAGE_KEYS.TELEMETRY_CONSENT_PH
+            : LOCAL_STORAGE_KEYS.TELEMETRY_CONSENT
+        )
+      : null) === 'true'
+
   const payload = usePostHogParameters
     ? ({} as SendIdentifyPH)
     : ({
@@ -71,7 +84,7 @@ export const useSendIdentifyMutation = ({
             project_ref: ref,
           } as SendIdentifyPH)
         : ({ user: userInfo, ...payload } as SendIdentifyGA)
-      return sendIdentify(type, body)
+      return sendIdentify({ consent, type, body })
     },
     {
       async onSuccess(data, variables, context) {

--- a/apps/studio/data/telemetry/send-page-leave-mutation.ts
+++ b/apps/studio/data/telemetry/send-page-leave-mutation.ts
@@ -2,12 +2,22 @@ import { useMutation, UseMutationOptions } from '@tanstack/react-query'
 import { components } from 'api-types'
 
 import { handleError, post } from 'data/fetchers'
+import { useFlag } from 'hooks/ui/useFlag'
+import { LOCAL_STORAGE_KEYS } from 'lib/constants'
 import { useRouter } from 'next/router'
 import type { ResponseError } from 'types'
 
 type SendPageLeaveBody = components['schemas']['TelemetryPageLeaveBody']
 
-export async function sendPageLeave(body: SendPageLeaveBody) {
+export async function sendPageLeave({
+  consent,
+  body,
+}: {
+  consent: boolean
+  body: SendPageLeaveBody
+}) {
+  if (!consent) return undefined
+
   const { data, error } = await post(`/platform/telemetry/page-leave`, {
     body,
     credentials: 'include',
@@ -24,6 +34,11 @@ export const useSendPageLeaveMutation = ({
   ...options
 }: Omit<UseMutationOptions<SendPageLeaveData, ResponseError>, 'mutationFn'> = {}) => {
   const router = useRouter()
+  const consent =
+    (typeof window !== 'undefined'
+      ? localStorage.getItem(LOCAL_STORAGE_KEYS.TELEMETRY_CONSENT_PH)
+      : null) === 'true'
+
   const url = typeof window !== 'undefined' ? window.location.href : ''
   const title = typeof document !== 'undefined' ? document?.title : ''
 
@@ -33,7 +48,7 @@ export const useSendPageLeaveMutation = ({
     pathname: router.pathname,
   } as SendPageLeaveBody
 
-  return useMutation<SendPageLeaveData, ResponseError>((vars) => sendPageLeave(body), {
+  return useMutation<SendPageLeaveData, ResponseError>((vars) => sendPageLeave({ consent, body }), {
     async onSuccess(data, variables, context) {
       await onSuccess?.(data, variables, context)
     },

--- a/apps/studio/data/telemetry/send-page-mutation.ts
+++ b/apps/studio/data/telemetry/send-page-mutation.ts
@@ -4,6 +4,7 @@ import { components } from 'api-types'
 import { isBrowser } from 'common'
 import { handleError, post } from 'data/fetchers'
 import { useFlag } from 'hooks/ui/useFlag'
+import { LOCAL_STORAGE_KEYS } from 'lib/constants'
 import { useRouter } from 'next/router'
 import type { ResponseError } from 'types'
 
@@ -16,7 +17,17 @@ export type SendPageVariables = {
 
 type SendPagePayload = any
 
-export async function sendPage(type: 'GA' | 'PH', body: SendPagePayload) {
+export async function sendPage({
+  consent,
+  type,
+  body,
+}: {
+  consent: boolean
+  type: 'GA' | 'PH'
+  body: SendPagePayload
+}) {
+  if (!consent) return undefined
+
   const headers = type === 'PH' ? { Version: '2' } : undefined
   const { data, error } = await post(`/platform/telemetry/page`, {
     body,
@@ -36,6 +47,15 @@ export const useSendPageMutation = ({
 }: Omit<UseMutationOptions<SendPageData, ResponseError, SendPageVariables>, 'mutationFn'> = {}) => {
   const router = useRouter()
   const usePostHogParameters = useFlag('enablePosthogChanges')
+
+  const consent =
+    (typeof window !== 'undefined'
+      ? localStorage.getItem(
+          usePostHogParameters
+            ? LOCAL_STORAGE_KEYS.TELEMETRY_CONSENT_PH
+            : LOCAL_STORAGE_KEYS.TELEMETRY_CONSENT
+        )
+      : null) === 'true'
 
   const title = typeof document !== 'undefined' ? document?.title : ''
   const referrer = typeof document !== 'undefined' ? document?.referrer : ''
@@ -69,7 +89,7 @@ export const useSendPageMutation = ({
       const body = usePostHogParameters
         ? ({ page_url: url, ...payload } as SendPagePH)
         : ({ route: url, ...payload } as SendPageGA)
-      return sendPage(type, body)
+      return sendPage({ consent, type, body })
     },
     {
       async onSuccess(data, variables, context) {

--- a/apps/studio/data/telemetry/send-reset-mutation.ts
+++ b/apps/studio/data/telemetry/send-reset-mutation.ts
@@ -16,7 +16,7 @@ export const useSendResetMutation = ({
   onError,
   ...options
 }: Omit<UseMutationOptions<SendResetData, ResponseError>, 'mutationFn'> = {}) => {
-  return useMutation<SendResetData, ResponseError>((vars) => sendReset(), {
+  return useMutation<SendResetData, ResponseError>(() => sendReset(), {
     async onSuccess(data, variables, context) {
       await onSuccess?.(data, variables, context)
     },

--- a/apps/studio/lib/constants/index.ts
+++ b/apps/studio/lib/constants/index.ts
@@ -30,6 +30,8 @@ export const USAGE_APPROACHING_THRESHOLD = 0.75
 export const LOCAL_STORAGE_KEYS = {
   RECENTLY_VISITED_ORGANIZATION: 'supabase-organization',
   TELEMETRY_CONSENT: 'supabase-consent',
+  // Used for when we enable PH for telemetry instead of GA
+  TELEMETRY_CONSENT_PH: 'supabase-consent-ph',
 
   UI_PREVIEW_NAVIGATION_LAYOUT: 'supabase-ui-preview-nav-layout',
   UI_PREVIEW_API_SIDE_PANEL: 'supabase-ui-api-side-panel',

--- a/apps/studio/next-env.d.ts
+++ b/apps/studio/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.

--- a/apps/studio/pages/_app.tsx
+++ b/apps/studio/pages/_app.tsx
@@ -54,7 +54,6 @@ import HCaptchaLoadedStore from 'stores/hcaptcha-loaded-store'
 import { AppPropsWithLayout } from 'types'
 import { SonnerToaster } from 'ui'
 import { CommandProvider } from 'ui-patterns/CommandMenu'
-import { ConsentToast } from 'ui-patterns/ConsentToast'
 
 dayjs.extend(customParseFormat)
 dayjs.extend(utc)
@@ -118,36 +117,6 @@ function CustomApp({ Component, pageProps }: AppPropsWithLayout) {
 
     console.error(error.stack)
   }
-
-  useEffect(() => {
-    // Check for telemetry consent
-    if (typeof window !== 'undefined') {
-      const onAcceptConsent = () => {
-        snap.setIsOptedInTelemetry(true)
-        if (consentToastId.current) toast.dismiss(consentToastId.current)
-      }
-
-      const onOptOut = () => {
-        snap.setIsOptedInTelemetry(false)
-        if (consentToastId.current) toast.dismiss(consentToastId.current)
-      }
-
-      const hasAcknowledgedConsent = localStorage.getItem(LOCAL_STORAGE_KEYS.TELEMETRY_CONSENT)
-      if (IS_PLATFORM && hasAcknowledgedConsent === null) {
-        setTimeout(() => {
-          consentToastId.current = toast(
-            <ConsentToast onAccept={onAcceptConsent} onOptOut={onOptOut} />,
-            {
-              id: 'consent-toast',
-              position: 'bottom-right',
-              duration: Infinity,
-            }
-          )
-        }, 300)
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
 
   useThemeSandbox()
 

--- a/apps/studio/state/app-state.ts
+++ b/apps/studio/state/app-state.ts
@@ -36,11 +36,17 @@ export const appState = proxy({
   },
 
   isOptedInTelemetry: false,
-  setIsOptedInTelemetry: (value: boolean) => {
-    appState.isOptedInTelemetry = value
-    if (typeof window !== 'undefined') {
-      localStorage.setItem(LOCAL_STORAGE_KEYS.TELEMETRY_CONSENT, value.toString())
+  setIsOptedInTelemetry: (value: boolean | null, flag = LOCAL_STORAGE_KEYS.TELEMETRY_CONSENT) => {
+    appState.isOptedInTelemetry = value === null ? false : value
+    console.log('setIsOptedInTelemetry', value)
+    if (typeof window !== 'undefined' && value !== null) {
+      localStorage.setItem(flag, value.toString())
     }
+    // [Joshen] Eventually once we completely move to PH, we should just set local storage
+    // directly here, but since currently it's dependent on a feature flag, will need to pass in as a prop
+    // if (typeof window !== 'undefined') {
+    //   localStorage.setItem(LOCAL_STORAGE_KEYS.TELEMETRY_CONSENT, value.toString())
+    // }
   },
   showEnableBranchingModal: false,
   setShowEnableBranchingModal: (value: boolean) => {

--- a/packages/ui-patterns/ConsentToast/index.tsx
+++ b/packages/ui-patterns/ConsentToast/index.tsx
@@ -22,10 +22,10 @@ export const ConsentToast = ({ onAccept = noop, onOptOut = noop }: ConsentToastP
   const isMobile = useBreakpoint(639)
 
   return (
-    <div className="space-y-3 py-1 flex flex-col w-full">
+    <div className="py-1 flex flex-col gap-y-3 w-full">
       <div>
-        <p className="text-foreground">
-          We only collect analytics essential to ensuring smooth operation of our services.{' '}
+        <p className="text-sm text-foreground">
+          We use first-party cookies to improve our services.
           <Link
             className="inline sm:hidden underline text-light"
             target="_blank"


### PR DESCRIPTION
- Add telemetry consent check within all telemetry RQ mutations (except send-reset since that shouldn't need a check)
  - Ensures that cookies are only placed in users' browsers after they've opted in
- Update consent banner copy
- Add new local storage key for telemetry PH based on feature flag to reset user's preferences for opting in