### PR TITLE
docs: update Cloudflare worker itty router link example 

### DIFF
--- a/examples/with-cloudflare-workers/README.md
+++ b/examples/with-cloudflare-workers/README.md
@@ -68,7 +68,7 @@ return new Response(JSON.stringify(data), {
 
 ---
 
-[👉 Next lesson](/04-proxy-supabase-requests-with-cloudflare-workers-and-itty-router)
+[👉 Next lesson](https://github.com/dijonmusters/supabase-data-at-the-edge/tree/main/04-proxy-supabase-requests-with-cloudflare-workers-and-itty-router)
 
 ---
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

links goes to Github 404 page 

## What is the new behavior?

link fixes the correct itty router example 
