### PR TITLE
fix(docs): local build without secrets

### DIFF
--- a/apps/docs/app/guides/(with-sidebar)/layout.tsx
+++ b/apps/docs/app/guides/(with-sidebar)/layout.tsx
@@ -1,10 +1,12 @@
 import { type PropsWithChildren } from 'react'
 
+import { IS_PLATFORM } from 'common'
+
 import { supabaseMisc } from '~/lib/supabaseMisc'
 import Layout from '~/layouts/guides'
 
 const GuidesLayout = async ({ children }: PropsWithChildren) => {
-  const partners = await getPartners()
+  const partners = IS_PLATFORM ? await getPartners() : []
   const partnerNavItems = partners.map((partner) => ({
     name: partner.title,
     url: `https://supabase.com/partners/integrations/${partner.slug}` as `https://${string}`,


### PR DESCRIPTION
Allow docs to build locally for contributors without secrets by guarding the partners DB query behind an IS_PLATFORM check.