### PR TITLE
Update logs.mdx | remove restart suggestion

### DIFF
--- a/apps/docs/content/guides/monitoring-troubleshooting/logs.mdx
+++ b/apps/docs/content/guides/monitoring-troubleshooting/logs.mdx
@@ -148,9 +148,8 @@ Do not log Personal Identifiable Information (PII) within the `User-Agent` heade
 To enable query logs for other categories of statements:
 
 1. [Enable the pgAudit extension](https://supabase.com/dashboard/project/_/database/extensions).
-2. [Restart your project](https://supabase.com/dashboard/project/_/settings/general) using the **Fast database reboot** option.
-3. Configure `pgaudit.log` (see below). Perform a fast reboot if needed.
-4. View your query logs under [Logs > Postgres Logs](https://supabase.com/dashboard/project/_/logs/postgres-logs).
+2. Configure `pgaudit.log` (see below). Perform a fast reboot if needed.
+3. View your query logs under [Logs > Postgres Logs](https://supabase.com/dashboard/project/_/logs/postgres-logs).
 
 ### Configuring `pgaudit.log`
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Doc fix

## What is the current behavior?

Tells users they have to restart

## What is the new behavior?

Took out line suggesting pg_audit requires a restart

## Additional context

`pgaudit` variables have a context of superuser, which can be seen with the following query:

```sql
SELECT * FROM pg_settings where name ilike '%audit%';
```

the [superuser context ](https://www.postgresql.org/docs/current/view-pg-settings.html) doesn't require a restart.