### PR TITLE
fix(self-host): supavisor pooler port redirection

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -455,8 +455,8 @@ services:
       - /app/bin/migrate && /app/bin/supavisor eval "$$(cat /etc/pooler/pooler.exs)" && /app/bin/server
     restart: unless-stopped
     ports:
-      - ${POSTGRES_PORT}:${POSTGRES_PORT}
-      - ${POOLER_PROXY_PORT_TRANSACTION}:${POOLER_PROXY_PORT_TRANSACTION}
+      - ${POSTGRES_PORT}:5432
+      - ${POOLER_PROXY_PORT_TRANSACTION}:6543
     environment:
       - PORT=4000
       - POSTGRES_PORT=${POSTGRES_PORT}


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When changing the ports to not default
pooler failed connection because the internal
port was wrongly exposed.

https://github.com/supabase/supabase/issues/29892

** To reproduce **

in .env file:
```
...defaults env settings
POSTGRES_PORT=5433
POOLER_PROXY_PORT_TRANSACTION=6544
```

```
docker-compose up
```

```
# will fail
 psql 'postgres://postgres.your-tenant-id:your-super-secret-and-long-postgres-password@localhost:5433/postgres'
 psql 'postgres://postgres.your-tenant-id:your-super-secret-and-long-postgres-password@localhost:6544/postgres'
```

## What is the new behavior?

```
# will succeed
 psql 'postgres://postgres.your-tenant-id:your-super-secret-and-long-postgres-password@localhost:5433/postgres'
 psql 'postgres://postgres.your-tenant-id:your-super-secret-and-long-postgres-password@localhost:6544/postgres'
```

## Additional context

Add any other context or screenshots.
