### PR TITLE
Updated the Edge Functions Hero Call to Action text

### DIFF
--- a/apps/www/data/products/functions/page.tsx
+++ b/apps/www/data/products/functions/page.tsx
@@ -44,7 +44,7 @@ export default (isMobile?: boolean) => ({
     image: <FunctionsHero />,
     ctas: [
       {
-        label: 'Launch a free database',
+        label: 'Create a free account',
         href: '/dashboard',
         type: 'primary' as any,
       },


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Updates call to action for Edge function hero text from "Launch a free database" to "Create a free account"

## What is the current behavior?

The edge function hero CTA text is a bit misleading

## What is the new behavior?

The edge function hero CTA text is more accurate

## Additional context

NA
