### PR TITLE
update swift docs to use referencedTable instead of foreignTable. Closes #29966

### DIFF
--- a/apps/docs/spec/supabase_swift_v2.yml
+++ b/apps/docs/spec/supabase_swift_v2.yml
@@ -3041,7 +3041,7 @@ functions:
                   )
                 """
               )
-              .order("name", ascending: false, foreignTable: "cities")
+              .order("name", ascending: false, referencedTable: "cities")
               .execute()
             ```
         data:
@@ -3152,7 +3152,7 @@ functions:
               )
               """
             )
-            .limit(1, foreignTable: "cities")
+            .limit(1, referencedTable: "cities")
             .execute()
           ```
         data:


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

Behavior described in issue [#29966](https://github.com/supabase/supabase/issues/29966). TLDR the Swift docs reference `foreignTable` instead of `referencedTable` when limiting / ordering on foreign tables.

## What is the new behavior?

Docs updated with `referencedTable` instead of `foreignTable`.