### PR TITLE
fix(self-hosted): GraphiQL invalided authentication credentials

### DIFF
--- a/apps/studio/pages/project/[ref]/api/graphiql.tsx
+++ b/apps/studio/pages/project/[ref]/api/graphiql.tsx
@@ -71,7 +71,9 @@ const GraphiQLPage: NextPageWithLayout = () => {
         ...opts,
         headers: {
           ...opts?.headers,
-          Authorization: `Bearer ${accessToken}`,
+          ...(accessToken && {
+            Authorization: `Bearer ${accessToken}`,
+          }),
           'x-graphql-authorization':
             opts?.headers?.['Authorization'] ??
             opts?.headers?.['authorization'] ??


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix. Addresses https://github.com/supabase/supabase/issues/29209

## What is the current behavior?

The `Authorization` header is overwriting the Basic authentication header on self-hosted.

## What is the new behavior?

If there isn't an `Authorization` header it won't be included.