### PR TITLE
updated pg_net docs | outlines configuration process

### DIFF
--- a/apps/docs/content/guides/database/extensions/pg_net.mdx
+++ b/apps/docs/content/guides/database/extensions/pg_net.mdx
@@ -329,7 +329,7 @@ where "name" like 'pg_net%';
 
 ### Alter settings
 
-Then variables can be changed:
+Change variables:
 
 ```sql
 alter role "postgres" set pg_net.ttl to '24 hour';

--- a/apps/docs/content/guides/database/extensions/pg_net.mdx
+++ b/apps/docs/content/guides/database/extensions/pg_net.mdx
@@ -309,9 +309,9 @@ order by "created" desc;
 
 ## Configuration
 
-<Admonition type="note" label="Only Self-Hosted Deployments can Modify Configuration Variables">
+<Admonition type="note" label="Must be on pg_net v0.10.0 or above to reconfigure ">
 
-See the [self-hosting docs](/docs/guides/hosting/overview#configuration) for self-hosting instructions.
+Supabase supports reconfiguring pg*net starting from v0.10.0+. For the latest release, initiate a postgres upgrade in the [Infrastructure Settings](https://supabase.com/dashboard/project/*/settings/infrastructure).
 
 </Admonition>
 
@@ -329,18 +329,11 @@ where "name" like 'pg_net%';
 
 ### Alter settings
 
-Note, that doing `ALTER SYSTEM` requires SUPERUSER but on PostgreSQL >= 15, you can do:
-
-```sql
-grant alter system on parameter pg_net.ttl to <role>;
-grant alter system on parameter pg_net.batch_size to <role>;
-```
-
 Then variables can be changed:
 
 ```sql
-alter system set pg_net.ttl to '1 hour'
-alter system set pg_net.batch_size to 500;
+alter role "postgres" set pg_net.ttl to '24 hour';
+alter role "postgres" set pg_net.batch_size to 500;
 ```
 
 Then reload the settings and restart the `pg_net` background worker with:


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

docs outlines how to update pg_net for self-hosted deployments only.

## What is the new behavior?

With the newest release of supautils, users can now reconfigure pg_net on the hosted platform. Updated docs to reflect the process. 

Also removed the instructions for updating on self-hosted instances. I thought it created noise, as those self-hosting would still be able to use the supautils method without issue or could follow the platform agnostic guide in the official [pg_net Github.](https://github.com/supabase/pg_net)