### PR TITLE
Pass search term to entity query

### DIFF
--- a/apps/studio/components/interfaces/Database/Indexes/CreateIndexSidePanel.tsx
+++ b/apps/studio/components/interfaces/Database/Indexes/CreateIndexSidePanel.tsx
@@ -1,4 +1,4 @@
-import { Check, ChevronsUpDown } from 'lucide-react'
+import { Check, ChevronsUpDown, Loader2 } from 'lucide-react'
 import Link from 'next/link'
 import { useEffect, useMemo, useState } from 'react'
 import { toast } from 'sonner'
@@ -50,7 +50,7 @@ const CreateIndexSidePanel = ({ visible, onClose }: CreateIndexSidePanelProps) =
   const [selectedIndexType, setSelectedIndexType] = useState<string>(INDEX_TYPES[0].value)
   const [schemaDropdownOpen, setSchemaDropdownOpen] = useState(false)
   const [tableDropdownOpen, setTableDropdownOpen] = useState(false)
-
+  const [searchTerm, setSearchTerm] = useState('')
   const { refetch: refetchIndexes } = useIndexesQuery({
     schema: selectedSchema,
     projectRef: project?.ref,
@@ -60,10 +60,10 @@ const CreateIndexSidePanel = ({ visible, onClose }: CreateIndexSidePanelProps) =
     projectRef: project?.ref,
     connectionString: project?.connectionString,
   })
-  const { data: entities, isLoading } = useEntityTypesQuery({
+  const { data: entities, isLoading: isLoadingEntities } = useEntityTypesQuery({
     schema: selectedSchema,
     sort: 'alphabetical',
-    search: undefined,
+    search: searchTerm,
     projectRef: project?.ref,
     connectionString: project?.connectionString,
   })
@@ -93,6 +93,10 @@ const CreateIndexSidePanel = ({ visible, onClose }: CreateIndexSidePanelProps) =
     () => entities?.pages.flatMap((page) => page.data.entities) || [],
     [entities?.pages]
   )
+
+  function handleSearchChange(value: string) {
+    setSearchTerm(value)
+  }
 
   const columns = tableColumns?.result[0]?.columns ?? []
   const columnOptions: MultiSelectOption[] = columns
@@ -181,7 +185,11 @@ CREATE INDEX ON "${selectedSchema}"."${selectedEntity}" USING ${selectedIndexTyp
                 sameWidthAsTrigger
               >
                 <Command_Shadcn_>
-                  <CommandInput_Shadcn_ placeholder="Find schema..." />
+                  <CommandInput_Shadcn_
+                    placeholder="Find table..."
+                    value={searchTerm}
+                    onValueChange={handleSearchChange}
+                  />
                   <CommandList_Shadcn_>
                     <CommandEmpty_Shadcn_>No schemas found</CommandEmpty_Shadcn_>
                     <CommandGroup_Shadcn_>
@@ -218,7 +226,7 @@ CREATE INDEX ON "${selectedSchema}"."${selectedEntity}" USING ${selectedIndexTyp
             name="select-table"
             description={
               isSelectEntityDisabled &&
-              !isLoading &&
+              !isLoadingEntities &&
               'Create a table in this schema via the Table or SQL editor first'
             }
             isReactForm={false}
@@ -228,28 +236,27 @@ CREATE INDEX ON "${selectedSchema}"."${selectedEntity}" USING ${selectedIndexTyp
               open={tableDropdownOpen}
               onOpenChange={setTableDropdownOpen}
             >
-              <PopoverTrigger_Shadcn_ asChild disabled={isSelectEntityDisabled || isLoading}>
-                {isLoading ? (
-                  <ShimmeringLoader className="h-[38px]" />
-                ) : (
-                  <Button
-                    type="default"
-                    size="medium"
-                    className={cn(
-                      'w-full [&>span]:w-full text-left',
-                      selectedEntity === '' && 'text-foreground-lighter'
-                    )}
-                    iconRight={
-                      <ChevronsUpDown className="text-foreground-muted" strokeWidth={2} size={14} />
-                    }
-                  >
-                    {selectedEntity !== undefined && selectedEntity !== ''
-                      ? selectedEntity
-                      : isSelectEntityDisabled
-                        ? 'No tables available in schema'
-                        : 'Choose a table'}
-                  </Button>
-                )}
+              <PopoverTrigger_Shadcn_
+                asChild
+                disabled={isSelectEntityDisabled || isLoadingEntities}
+              >
+                <Button
+                  type="default"
+                  size="medium"
+                  className={cn(
+                    'w-full [&>span]:w-full text-left',
+                    selectedEntity === '' && 'text-foreground-lighter'
+                  )}
+                  iconRight={
+                    <ChevronsUpDown className="text-foreground-muted" strokeWidth={2} size={14} />
+                  }
+                >
+                  {selectedEntity !== undefined && selectedEntity !== ''
+                    ? selectedEntity
+                    : isSelectEntityDisabled
+                      ? 'No tables available in schema'
+                      : 'Choose a table'}
+                </Button>
               </PopoverTrigger_Shadcn_>
               <PopoverContent_Shadcn_
                 className="p-0"
@@ -257,10 +264,25 @@ CREATE INDEX ON "${selectedSchema}"."${selectedEntity}" USING ${selectedIndexTyp
                 align="start"
                 sameWidthAsTrigger
               >
-                <Command_Shadcn_>
-                  <CommandInput_Shadcn_ placeholder="Find table..." />
+                {/* [Terry] shouldFilter context:
+                https://github.com/pacocoursey/cmdk/issues/267#issuecomment-2252717107 */}
+                <Command_Shadcn_ shouldFilter={false}>
+                  <CommandInput_Shadcn_
+                    placeholder="Find table..."
+                    value={searchTerm}
+                    onValueChange={handleSearchChange}
+                  />
                   <CommandList_Shadcn_>
-                    <CommandEmpty_Shadcn_>No tables found</CommandEmpty_Shadcn_>
+                    <CommandEmpty_Shadcn_>
+                      {isLoadingEntities ? (
+                        <div className="flex items-center gap-2 text-center justify-center">
+                          <Loader2 size={12} className="animate-spin" />
+                          Loading...
+                        </div>
+                      ) : (
+                        'No tables found'
+                      )}
+                    </CommandEmpty_Shadcn_>
                     <CommandGroup_Shadcn_>
                       <ScrollArea className={(entityTypes || []).length > 7 ? 'h-[210px]' : ''}>
                         {(entityTypes ?? []).map((entity) => (


### PR DESCRIPTION
The entities query powering the table dropdown only shows 100 tables by default.  There's a search input field here, but the search term isn't getting passed to the query. So if you're looking to index your 101st table, you won't find it in this list. 

https://supabase.com/dashboard/project/_/database/indexes

The search term will filter this local list, but it won't cause the query to refetch results

![screenshot-2024-10-18-at-16 17 41](https://github.com/user-attachments/assets/fbbce8e1-c9d6-4eb2-bcff-d8218d18eb0c)
