### PR TITLE
docs: Update auth self-host docs to the latest info

### DIFF
--- a/apps/docs/app/guides/(with-sidebar)/self-hosting/analytics/config/page.tsx
+++ b/apps/docs/app/guides/(with-sidebar)/self-hosting/analytics/config/page.tsx
@@ -21,7 +21,7 @@ const AnalyticsConfigPage = async () => {
     <GuideTemplate
       meta={meta}
       editLink={newEditLink(
-        'supabase/supabase/blob/master/apps/docs/pages/guides/self-hosting/analytics/config.tsx'
+        'supabase/supabase/blob/master/apps/docs/app/guides/(with-sidebar)/self-hosting/analytics/config/page.tsx'
       )}
     >
       <MDXRemoteBase source={descriptionMdx} />

--- a/apps/docs/app/guides/(with-sidebar)/self-hosting/auth/config/page.tsx
+++ b/apps/docs/app/guides/(with-sidebar)/self-hosting/auth/config/page.tsx
@@ -21,7 +21,7 @@ const AuthConfigPage = async () => {
     <GuideTemplate
       meta={meta}
       editLink={newEditLink(
-        'supabase/supabase/blob/master/apps/docs/pages/guides/self-hosting/auth/config.tsx'
+        'supabase/supabase/blob/master/apps/docs/app/guides/(with-sidebar)/self-hosting/auth/config/page.tsx'
       )}
     >
       <MDXRemoteBase source={descriptionMdx} />

--- a/apps/docs/app/guides/(with-sidebar)/self-hosting/realtime/config/page.tsx
+++ b/apps/docs/app/guides/(with-sidebar)/self-hosting/realtime/config/page.tsx
@@ -21,7 +21,7 @@ const RealtimeConfigPage = async () => {
     <GuideTemplate
       meta={meta}
       editLink={newEditLink(
-        'supabase/supabase/blob/master/apps/docs/pages/guides/self-hosting/realtime/config.tsx'
+        'supabase/supabase/blob/master/apps/docs/app/guides/(with-sidebar)/self-hosting/realtime/config/page.tsx'
       )}
     >
       <MDXRemoteBase source={descriptionMdx} />

--- a/apps/docs/app/guides/(with-sidebar)/self-hosting/storage/config/page.tsx
+++ b/apps/docs/app/guides/(with-sidebar)/self-hosting/storage/config/page.tsx
@@ -21,7 +21,7 @@ const StorageConfigPage = async () => {
     <GuideTemplate
       meta={meta}
       editLink={newEditLink(
-        'supabase/supabase/blob/master/apps/docs/pages/guides/self-hosting/storage/config.tsx'
+        'supabase/supabase/blob/master/apps/docs/app/guides/(with-sidebar)/self-hosting/storage/config/page.tsx'
       )}
     >
       <MDXRemoteBase source={descriptionMdx} />

--- a/apps/docs/content/guides/self-hosting/docker.mdx
+++ b/apps/docs/content/guides/self-hosting/docker.mdx
@@ -265,7 +265,7 @@ Each system has a number of configuration options which can be found in the rele
 - [Postgres](https://hub.docker.com/_/postgres/)
 - [PostgREST](https://postgrest.org/en/stable/configuration.html)
 - [Realtime](https://github.com/supabase/realtime#server)
-- [GoTrue](https://github.com/supabase/gotrue)
+- [Auth](https://github.com/supabase/auth)
 - [Storage](https://github.com/supabase/storage-api)
 - [Kong](https://docs.konghq.com/gateway/latest/install/docker/)
 - [Supavisor](https://supabase.github.io/supavisor/development/docs/)

--- a/apps/docs/spec/gotrue_v1_config.yaml
+++ b/apps/docs/spec/gotrue_v1_config.yaml
@@ -13,8 +13,7 @@ info:
   bugs: 'https://github.com/supabase/gotrue/issues' # {string} Where developers can file bugs.
   spec: 'https://github.com/supabase/supabase/blob/master/docs/spec/gotrue_v1_config.yaml' # {string} Where developers can find this spec (to link directly in the docs).
   description: |
-    In a self-hosted environment, you do not have access to the Auth configuration such as third party OAuth provider settings through the Supabase dashboard.
-    Instead, you configure them through the `docker-compose.yml` file. You can read more about the configuration in the [Self-hosting guide](/docs/guides/self-hosting/docker#configuring-services).
+    In a self-hosted environment, you do not have access to the Auth configuration such as third party OAuth provider settings through the Supabase dashboard. Instead, you configure them through the `docker-compose.yml` file. You can read more about the configuration in the [Self-hosting guide](/docs/guides/self-hosting/docker#configuring-services).
 
     You can find the complete list of available configuration parameters on the README of the [Auth repository](https://github.com/supabase/auth?tab=readme-ov-file#configuration).
   tags:

--- a/apps/docs/spec/gotrue_v1_config.yaml
+++ b/apps/docs/spec/gotrue_v1_config.yaml
@@ -56,7 +56,7 @@ parameters:
     tags: ['general'] # {string[]} These tags are useful for grouping parameters
     required: true
     description: |
-      A comma separated list of URIs (e.g. `"https://foo.example.com,https://*.foo.example.com,https://bar.example.com"`) which are permitted as valid `redirect_to` destinations. Defaults to []. Supports wildcard matching through globbing. e.g. `https://*.foo.example.com` will allow `https://a.foo.example.com` and `https://b.foo.example.com` to be accepted. Globbing is also supported on subdomains. e.g. `https://foo.example.com/*` will allow `https://foo.example.com/page1` and `https://foo.example.com/page2` to be accepted.
+      A comma separated list of URIs (e.g. `"https://foo.example.com,https://*.foo.example.com,https://bar.example.com"`) which are permitted as valid `redirect_to` destinations.
   - id: 'GOTRUE_JWT_EXP' # {string} A unique identifier for this param.
     title: 'GOTRUE_JWT_EXP' # {string} Any name.
     tags: ['general'] # {string[]} These tags are useful for grouping parameters

--- a/apps/docs/spec/gotrue_v1_config.yaml
+++ b/apps/docs/spec/gotrue_v1_config.yaml
@@ -13,7 +13,10 @@ info:
   bugs: 'https://github.com/supabase/gotrue/issues' # {string} Where developers can file bugs.
   spec: 'https://github.com/supabase/supabase/blob/master/docs/spec/gotrue_v1_config.yaml' # {string} Where developers can find this spec (to link directly in the docs).
   description: |
-    You can find the complete list of available parameters on the README of the [Auth repository](https://github.com/supabase/auth?tab=readme-ov-file#configuration).
+    In a self-hosted environment, you do not have access to the Auth configuration such as third party OAuth provider settings through the Supabase dashboard.
+    Instead, you configure them through the `docker-compose.yml` file. You can read more about the configuration in the [Self-hosting guide](/docs/guides/self-hosting/docker#configuring-services).
+
+    You can find the complete list of available configuration parameters on the README of the [Auth repository](https://github.com/supabase/auth?tab=readme-ov-file#configuration).
   tags:
     - id: general
       title: General

--- a/apps/docs/spec/gotrue_v1_config.yaml
+++ b/apps/docs/spec/gotrue_v1_config.yaml
@@ -51,8 +51,8 @@ parameters:
     required: false
     description: |
       The URI a OAuth2 provider will redirect to with the `code` and `state` values.
-  - id: 'URI_ALLOW_LIST' # {string} A unique identifier for this param.
-    title: 'URI_ALLOW_LIST' # {string} Any name.
+  - id: 'GOTRUE_URI_ALLOW_LIST' # {string} A unique identifier for this param.
+    title: 'GOTRUE_URI_ALLOW_LIST' # {string} Any name.
     tags: ['general'] # {string[]} These tags are useful for grouping parameters
     required: true
     description: |

--- a/apps/docs/spec/gotrue_v1_config.yaml
+++ b/apps/docs/spec/gotrue_v1_config.yaml
@@ -11,9 +11,9 @@ info:
   title: 'GoTrue' # {string} A readable name.
   source: 'https://github.com/supabase/gotrue' # {string} Where developers can find the source code.
   bugs: 'https://github.com/supabase/gotrue/issues' # {string} Where developers can file bugs.
-  spec: 'https://github.com/supabase/supabase/blob/master/spec/gotrue_v1_config.yaml' # {string} Where developers can find this spec (to link directly in the docs).
+  spec: 'https://github.com/supabase/supabase/blob/master/docs/spec/gotrue_v1_config.yaml' # {string} Where developers can find this spec (to link directly in the docs).
   description: |
-    A `config.toml` file is generated after running `supabase init`. This file is located in the `supabase` folder under `supabase/config.toml`.
+    You can find the complete list of available parameters on the README of the [Auth repository](https://github.com/supabase/auth?tab=readme-ov-file#configuration).
   tags:
     - id: general
       title: General
@@ -21,58 +21,68 @@ info:
 
 # This section is an array of public functions which a user might need to execute.
 parameters:
-  - id: 'project_id' # {string} A unique identifier for this param.
-    title: 'project_id' # {string} Any name.
-    tags: ['general'] # {string[]} These tags are useful for grouping parameters
-    required: true
-    # default: '5432'
-    description: |
-      A string used to distinguish different Supabase projects on the same host. Defaults to the working directory name when running `supabase init`.
-  - id: 'GOTRUE_EXTERNAL_GITHUB' # {string} A unique identifier for this param.
-    title: 'auth.external.github' # {string} Any name.
-    tags: ['general'] # {string[]} These tags are useful for grouping parameters
-    required: true
-    # default: '5432'
-    description: |
-      Describes whether the Github provider is enabled or not.
   - id: 'GOTRUE_SITE_URL' # {string} A unique identifier for this param.
-    title: 'auth.site_url' # {string} Any name.
+    title: 'GOTRUE_SITE_URL' # {string} Any name.
     tags: ['general'] # {string[]} These tags are useful for grouping parameters
     required: true
     description: |
       The base URL of your website. Used as an allow-list for redirects and for constructing URLs used in emails.
-  - id: 'GOTRUE_URI_ALLOW_LIST' # {string} A unique identifier for this param.
-    title: 'auth.additional_redirect_urls' # {string} Any name.
+  - id: 'GOTRUE_EXTERNAL_GITHUB_ENABLED' # {string} A unique identifier for this param.
+    title: 'GOTRUE_EXTERNAL_GITHUB_ENABLED' # {string} Any name.
+    tags: ['general'] # {string[]} These tags are useful for grouping parameters
+    required: false
+    description: |
+      Whether the external provider, GitHub in this case, is enabled or not.
+  - id: 'GOTRUE_EXTERNAL_GITHUB_CLIENT_ID' # {string} A unique identifier for this param.
+    title: 'GOTRUE_EXTERNAL_GITHUB_CLIENT_ID' # {string} Any name.
+    tags: ['general'] # {string[]} These tags are useful for grouping parameters
+    required: false
+    description: |
+      The OAuth2 Client ID registered with the external provider.
+  - id: 'GOTRUE_EXTERNAL_GITHUB_SECRET' # {string} A unique identifier for this param.
+    title: 'GOTRUE_EXTERNAL_GITHUB_SECRET' # {string} Any name.
+    tags: ['general'] # {string[]} These tags are useful for grouping parameters
+    required: false
+    description: |
+      The OAuth2 Client Secret provided by the external provider when you registered.
+  - id: 'GOTRUE_EXTERNAL_GITHUB_REDIRECT_URI' # {string} A unique identifier for this param.
+    title: 'GOTRUE_EXTERNAL_GITHUB_REDIRECT_URI' # {string} Any name.
+    tags: ['general'] # {string[]} These tags are useful for grouping parameters
+    required: false
+    description: |
+      The URI a OAuth2 provider will redirect to with the `code` and `state` values.
+  - id: 'URI_ALLOW_LIST' # {string} A unique identifier for this param.
+    title: 'URI_ALLOW_LIST' # {string} Any name.
     tags: ['general'] # {string[]} These tags are useful for grouping parameters
     required: true
     description: |
-      A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
+      A comma separated list of URIs (e.g. `"https://foo.example.com,https://*.foo.example.com,https://bar.example.com"`) which are permitted as valid `redirect_to` destinations. Defaults to []. Supports wildcard matching through globbing. e.g. `https://*.foo.example.com` will allow `https://a.foo.example.com` and `https://b.foo.example.com` to be accepted. Globbing is also supported on subdomains. e.g. `https://foo.example.com/*` will allow `https://foo.example.com/page1` and `https://foo.example.com/page2` to be accepted.
   - id: 'GOTRUE_JWT_EXP' # {string} A unique identifier for this param.
-    title: 'auth.jwt_expiry' # {string} Any name.
+    title: 'GOTRUE_JWT_EXP' # {string} Any name.
     tags: ['general'] # {string[]} These tags are useful for grouping parameters
     required: true
     description: |
       How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 seconds (one week).
   - id: 'GOTRUE_DISABLE_SIGNUP' # {string} A unique identifier for this param.
-    title: 'auth.enable_signup' # {string} Any name.
+    title: 'GOTRUE_DISABLE_SIGNUP' # {string} Any name.
     tags: ['general'] # {string[]} These tags are useful for grouping parameters
     required: true
     description: |
       Allow/disallow new user signups to your project.
   - id: 'GOTRUE_EXTERNAL_EMAIL_ENABLED' # {string} A unique identifier for this param.
-    title: 'auth.email.enable_signup' # {string} Any name.
+    title: 'GOTRUE_EXTERNAL_EMAIL_ENABLED' # {string} Any name.
     tags: ['general', 'email'] # {string[]} These tags are useful for grouping parameters
     required: true
     description: |
       Allow/disallow new user signups via email to your project.
   - id: 'GOTRUE_MAILER_SECURE_EMAIL_CHANGE_ENABLED' # {string} A unique identifier for this param.
-    title: 'auth.email.double_confirm_changes' # {string} Any name.
+    title: 'GOTRUE_MAILER_SECURE_EMAIL_CHANGE_ENABLED' # {string} Any name.
     tags: ['general', 'email'] # {string[]} These tags are useful for grouping parameters
     required: true
     description: |
       If enabled, a user will be required to confirm any email change on both the old, and new email addresses. If disabled, only the new email is required to confirm.
   - id: 'GOTRUE_MAILER_AUTOCONFIRM' # {string} A unique identifier for this param.
-    title: 'auth.email.enable_confirmations' # {string} Any name.
+    title: 'GOTRUE_MAILER_AUTOCONFIRM' # {string} Any name.
     tags: ['general', 'email'] # {string[]} These tags are useful for grouping parameters
     required: true
     description: |


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Currently, the auth self-host guide just simply contains the wrong information, confusing the users (and myself) such as [this case](https://x.com/waahbete/status/1847539659787600000). It seems like the current set of instructions and the parameters are just a copy and paste of the local Supabase development through the CLI. This PR fixes it. 

This PR include:

- Updating the self-host auth guide description to provide a link to the complete set of available environment variables
- Updating the list of environment variable names.
- Update the edit link of all self-host guides. 
- Minor text edit of `Gotrue` -> `Auth`