### PR TITLE
Fixes item description and unit price of Billing Breakdown

### DIFF
--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
@@ -184,8 +184,8 @@ const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
                               ` (${billingMetricUnit(fee.usage_metric)})`}
                           </span>
                           {(() => {
-                            const matchingTooltipData = feeTooltipData.find(
-                              (it) => fee.usage_metric?.startsWith(it.identifier)
+                            const matchingTooltipData = feeTooltipData.find((it) =>
+                              fee.usage_metric?.startsWith(it.identifier)
                             )
                             return matchingTooltipData ? (
                               <InvoiceTooltip

--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
@@ -113,7 +113,7 @@ const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
                 <th className="py-2 font-medium text-right text-sm text-foreground-light pr-4">
                   Usage
                 </th>
-                <th className="py-2 font-medium text-left text-sm text-foreground-light">
+                <th className="py-2 pr-2 font-medium text-left text-sm text-foreground-light max-w-[200px]">
                   Unit price
                 </th>
                 <th className="py-2 font-medium text-right text-sm text-foreground-light">Cost</th>
@@ -124,6 +124,9 @@ const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
                 <tr key={item.description} className="border-b">
                   <td className="py-2 text-sm max-w-[200px]" colSpan={item.proration ? 3 : 1}>
                     {item.description ?? 'Unknown'}
+                    {item.usage_metric &&
+                      billingMetricUnit(item.usage_metric) &&
+                      ` (${billingMetricUnit(item.usage_metric)})`}
                   </td>
                   {!item.proration && (
                     <td className="py-2 text-sm text-right pr-4">
@@ -131,12 +134,12 @@ const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
                     </td>
                   )}
                   {!item.proration && (
-                    <td className="py-2 text-sm">
+                    <td className="py-2 pr-2 text-sm max-w-[200px]">
                       {item.unit_price === 0
                         ? 'FREE'
                         : item.unit_price
                           ? formatCurrency(item.unit_price)
-                          : null}
+                          : `${item.unit_price_desc}`}
                     </td>
                   )}
                   <td className="py-2 text-sm text-right">{formatCurrency(item.amount)}</td>
@@ -181,8 +184,8 @@ const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
                               ` (${billingMetricUnit(fee.usage_metric)})`}
                           </span>
                           {(() => {
-                            const matchingTooltipData = feeTooltipData.find((it) =>
-                              fee.usage_metric?.startsWith(it.identifier)
+                            const matchingTooltipData = feeTooltipData.find(
+                              (it) => fee.usage_metric?.startsWith(it.identifier)
                             )
                             return matchingTooltipData ? (
                               <InvoiceTooltip

--- a/apps/studio/components/interfaces/Organization/BillingSettings/helpers.ts
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/helpers.ts
@@ -46,6 +46,9 @@ export const billingMetricUnit = (pricingMetric: PricingMetric) => {
       PricingMetric.PITR_7,
       PricingMetric.PITR_14,
       PricingMetric.PITR_28,
+      PricingMetric.LOG_DRAIN,
+      PricingMetric.AUTH_MFA_PHONE,
+      PricingMetric.AUTH_MFA_WEB_AUTHN,
     ].includes(pricingMetric)
   ) {
     return 'Hours'

--- a/apps/studio/data/analytics/org-daily-stats-query.ts
+++ b/apps/studio/data/analytics/org-daily-stats-query.ts
@@ -40,6 +40,8 @@ export enum PricingMetric {
   DISK_THROUGHPUT_GP3 = 'DISK_THROUGHPUT_GP3',
   LOG_DRAIN = 'LOG_DRAIN',
   LOG_DRAIN_EVENTS = 'LOG_DRAIN_EVENTS',
+  AUTH_MFA_PHONE = 'AUTH_MFA_PHONE',
+  AUTH_MFA_WEB_AUTHN = 'AUTH_MFA_WEB_AUTHN',
 }
 
 export enum ComputeUsageMetric {


### PR DESCRIPTION
Fixes the Billing Breakdown regarding item description and unit price.

**Item description:** for "Log Drain", "Auth MFA Phone" and "Auth MFA WebAuthn" the "(Hours)" was missing
**Unit price:** was not shown for items without project breakdown

**Side note regarding formatting:** Now that the unit price description is also shown for items without a project breakdown we are running out of space for prices with Tiered Pricing (e.g. Auth MFA Phone) with ugly word wrapping in column "Item". I played around with abbreviations (e.g. "hr" instead of "hour", "$0.1027/hr" instead of "$0.1027 per hour) but that didn'f feel great. So I limited the max width of the column "Unit price". It's a bit dense but at least complete and understandable.

<img width="1000" alt="Screenshot 2024-10-19 at 19 17 43" src="https://github.com/user-attachments/assets/e7a604c6-9a65-4904-8322-2af973829c60">
