### PR TITLE
fix: allow developer role to update buckets

### DIFF
--- a/apps/studio/components/layouts/StorageLayout/BucketRow.tsx
+++ b/apps/studio/components/layouts/StorageLayout/BucketRow.tsx
@@ -34,7 +34,7 @@ const BucketRow = ({
   onSelectDeleteBucket = noop,
   onSelectEditBucket = noop,
 }: BucketRowProps) => {
-  const canUpdateBuckets = useCheckPermissions(PermissionAction.STORAGE_ADMIN_WRITE, '*')
+  const canUpdateBuckets = useCheckPermissions(PermissionAction.STORAGE_WRITE, '*')
 
   return (
     <div

--- a/apps/studio/components/layouts/StorageLayout/StorageMenu.tsx
+++ b/apps/studio/components/layouts/StorageLayout/StorageMenu.tsx
@@ -37,7 +37,7 @@ const StorageMenu = () => {
   const [selectedBucketToEdit, setSelectedBucketToEdit] = useState<StorageBucket>()
   const [selectedBucketToEmpty, setSelectedBucketToEmpty] = useState<StorageBucket>()
   const [selectedBucketToDelete, setSelectedBucketToDelete] = useState<StorageBucket>()
-  const canCreateBuckets = useCheckPermissions(PermissionAction.STORAGE_ADMIN_WRITE, '*')
+  const canCreateBuckets = useCheckPermissions(PermissionAction.STORAGE_WRITE, '*')
 
   const [sort, setSort] = useLocalStorage<'alphabetical' | 'created-at'>(
     'storage-explorer-sort',


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

`PermissionAction.STORAGE_ADMIN_WRITE` is used.

## What is the new behavior?

Use `PermissionAction.STORAGE_WRITE` instead.