### PR TITLE
docs: cli link fix

### DIFF
--- a/apps/docs/content/guides/deployment.mdx
+++ b/apps/docs/content/guides/deployment.mdx
@@ -25,5 +25,5 @@ See the [self-hosting guides](/docs/guides/self-hosting) for instructions on hos
 You can automate deployments using:
 
 - The [Supabase GitHub integration](/dashboard/project/_/settings/integrations) (with branching enabled)
-- The [Supabase CLI](/docs/local-development/cli) in your own continuous deployment pipeline
+- The [Supabase CLI](/docs/guides/local-development) in your own continuous deployment pipeline
 - The [Supabase Terraform provider](/docs/guides/deployment/terraform)


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

[Supabase Deployment](https://supabase.com/docs/guides/deployment) - CLI link fix

## What is the current behavior?

Link goes to 404.

## What is the new behavior?

Link now goes to [here](https://supabase.com/docs/guides/local-development)

Closes #30023 
