### PR TITLE
feat/ design system: inner side bar docs

### DIFF
--- a/apps/design-system/__registry__/index.tsx
+++ b/apps/design-system/__registry__/index.tsx
@@ -1787,6 +1787,72 @@ export const Index: Record<string, any> = {
       subcategory: "undefined",
       chunks: []
     },
+    "inner-side-menu-demo": {
+      name: "inner-side-menu-demo",
+      type: "components:example",
+      registryDependencies: undefined,
+      component: React.lazy(() => import("@/registry/default/example/inner-side-menu-demo")),
+      source: "",
+      files: ["registry/default/example/inner-side-menu-demo.tsx"],
+      category: "undefined",
+      subcategory: "undefined",
+      chunks: []
+    },
+    "inner-side-menu-static-titles": {
+      name: "inner-side-menu-static-titles",
+      type: "components:example",
+      registryDependencies: undefined,
+      component: React.lazy(() => import("@/registry/default/example/inner-side-menu-static-titles")),
+      source: "",
+      files: ["registry/default/example/inner-side-menu-static-titles.tsx"],
+      category: "undefined",
+      subcategory: "undefined",
+      chunks: []
+    },
+    "inner-side-menu-loading": {
+      name: "inner-side-menu-loading",
+      type: "components:example",
+      registryDependencies: undefined,
+      component: React.lazy(() => import("@/registry/default/example/inner-side-menu-loading")),
+      source: "",
+      files: ["registry/default/example/inner-side-menu-loading.tsx"],
+      category: "undefined",
+      subcategory: "undefined",
+      chunks: []
+    },
+    "inner-side-menu-multiple-sections": {
+      name: "inner-side-menu-multiple-sections",
+      type: "components:example",
+      registryDependencies: undefined,
+      component: React.lazy(() => import("@/registry/default/example/inner-side-menu-multiple-sections")),
+      source: "",
+      files: ["registry/default/example/inner-side-menu-multiple-sections.tsx"],
+      category: "undefined",
+      subcategory: "undefined",
+      chunks: []
+    },
+    "inner-side-menu-empty": {
+      name: "inner-side-menu-empty",
+      type: "components:example",
+      registryDependencies: undefined,
+      component: React.lazy(() => import("@/registry/default/example/inner-side-menu-empty")),
+      source: "",
+      files: ["registry/default/example/inner-side-menu-empty.tsx"],
+      category: "undefined",
+      subcategory: "undefined",
+      chunks: []
+    },
+    "inner-side-menu-with-search": {
+      name: "inner-side-menu-with-search",
+      type: "components:example",
+      registryDependencies: undefined,
+      component: React.lazy(() => import("@/registry/default/example/inner-side-menu-with-search")),
+      source: "",
+      files: ["registry/default/example/inner-side-menu-with-search.tsx"],
+      category: "undefined",
+      subcategory: "undefined",
+      chunks: []
+    },
     "multi-select-demo": {
       name: "multi-select-demo",
       type: "components:example",

--- a/apps/design-system/config/docs.ts
+++ b/apps/design-system/config/docs.ts
@@ -103,6 +103,11 @@ export const docsConfig: DocsConfig = {
           items: [],
         },
         {
+          title: 'Inner Side Menu',
+          href: '/docs/fragments/inner-side-menu',
+          items: [],
+        },
+        {
           title: 'Form Item Layout',
           href: '/docs/fragments/form-item-layout',
           items: [],

--- a/apps/design-system/content/docs/fragments/inner-side-menu.mdx
+++ b/apps/design-system/content/docs/fragments/inner-side-menu.mdx
@@ -1,0 +1,142 @@
+---
+title: Inner Side Menu
+description: InnerSideMenu is a component that provides a collapsible side menu with multiple sections.
+component: true
+---
+
+<ComponentPreview name="inner-side-menu-demo" peekCode wide />
+
+## Examples
+
+{/* ### Multiple sections */}
+
+{/* <ComponentPreview name="inner-side-menu-multiple-sections" peekCode /> */}
+
+### Collapsible menus
+
+Inner Side Menu uses the `<InnerSideMenuCollapsible />` component to wrap the menu items.
+This is a wrapper component around the `<Collapsible />` component.
+
+```jsx {10-12,16-17}
+import {
+  InnerSideMenuCollapsible,
+  InnerSideMenuCollapsibleTrigger,
+  InnerSideMenuCollapsibleContent,
+  InnerSideMenuItem,
+} from 'ui-patterns/InnerSideMenu'
+
+function app() {
+  return (
+    <InnerSideMenuCollapsible key={category} defaultOpen>
+      <InnerSideMenuCollapsibleTrigger title={category} />
+      <InnerSideMenuCollapsibleContent>
+        <InnerSideMenuItem href="/dashboard">Dashboard</InnerSideMenuItem>
+        <InnerSideMenuItem href="/team">Team</InnerSideMenuItem>
+        <InnerSideMenuItem href="/settings">Settings</InnerSideMenuItem>
+      </InnerSideMenuCollapsibleContent>
+    </InnerSideMenuCollapsible>
+  )
+}
+```
+
+### Static titles
+
+If you don't need the Collapsible features, you can instead use `<InnerSideBarTitle />`.
+This doesn't require the use of the `<InnerSideMenuCollapsible />` parent component wrapped around it.
+
+You can wrap the `<InnerSideBarItem />` conponents however you like. Below we've put a `<div/ >` around them.
+
+```jsx {1}
+<InnerSideBarTitle>Projects</InnerSideBarTitle>
+<div className="mt-2">
+    <InnerSideMenuItem href="/dashboard">Dashboard</InnerSideMenuItem>
+    <InnerSideMenuItem href="/team">Team</InnerSideMenuItem>
+    <InnerSideMenuItem href="/settings">Settings</InnerSideMenuItem>
+</div>
+```
+
+<ComponentPreview name="inner-side-menu-static-titles" />
+
+### Loading state
+
+Use `<InnerSideMenuItemLoading />` to show a loading state for menu items.
+
+This item is a wrapper around the `<Skeleton />` component, and also includes some y-padding so the items don't layout shift when shifting to loaded state and to look visually seperated in a list.
+
+<ComponentPreview name="inner-side-menu-loading" />
+
+### With search
+
+Use the following components to add a search input to the menu.
+
+```jsx
+<InnerSideBarFilters>
+  <InnerSideBarFilterSearchInput
+    name="search-input"
+    placeholder="Search..."
+    value={searchTerm}
+    onChange={(e) => setSearchTerm(e.target.value)}
+    aria-labelledby="Search items"
+  />
+</InnerSideBarFilters>
+```
+
+There is also a Filter Dropdown component that can be used to sort the menu items.
+This can be used inside `<InnerSideBarFilterSearchInput />`.
+
+```jsx {9-16}
+<InnerSideBarFilters>
+  <InnerSideBarFilterSearchInput
+    name="search-input"
+    placeholder="Search..."
+    value={searchTerm}
+    onChange={(e) => setSearchTerm(e.target.value)}
+    aria-labelledby="Search items"
+  >
+    <InnerSideBarFilterSortDropdown value={sort} onValueChange={(value) => setSort(value)}>
+      <InnerSideBarFilterSortDropdownItem value="alphabetical">
+        Sort Alphabetically
+      </InnerSideBarFilterSortDropdownItem>
+      <InnerSideBarFilterSortDropdownItem value="reverse">
+        Sort Reverse Alphabetically
+      </InnerSideBarFilterSortDropdownItem>
+    </InnerSideBarFilterSortDropdown>
+  </InnerSideBarFilterSearchInput>
+</InnerSideBarFilters>
+```
+
+<ComponentPreview name="inner-side-menu-with-search" />
+
+### Empty list state
+
+Use `<InnerSideMenuEmptyState />` to show an empty state.
+
+Use the `actions` prop to add any actions like a `<Button />`.
+
+```jsx {4-7}
+<InnerSideBarEmptyPanel
+  title="No functions found"
+  description="Create your first serverless function to get started."
+  actions={
+    <Button type="default" onClick={createAction}>
+      Create Function
+    </Button>
+  }
+/>
+```
+
+You can also use the prop `illustration` to pass in a custom illustration, it accets any React Node.
+
+```jsx {4-7}
+<InnerSideBarEmptyPanel
+  title="No functions found"
+  description="Create your first serverless function to get started."
+  illustration={
+    <figure>
+      <svg>../</svg>
+    </figure>
+  }
+/>
+```
+
+<ComponentPreview name="inner-side-menu-empty" />

--- a/apps/design-system/content/docs/fragments/inner-side-menu.mdx
+++ b/apps/design-system/content/docs/fragments/inner-side-menu.mdx
@@ -61,7 +61,7 @@ You can wrap the `<InnerSideBarItem />` conponents however you like. Below we've
 
 Use `<InnerSideMenuItemLoading />` to show a loading state for menu items.
 
-This item is a wrapper around the `<Skeleton />` component, and also includes some y-padding so the items don't layout shift when shifting to loaded state and to look visually seperated in a list.
+This item is a wrapper around the `<Skeleton />` component, and also includes some y-padding so the items don't layout shift when shifting to loaded state and to look visually separated in a list.
 
 <ComponentPreview name="inner-side-menu-loading" />
 

--- a/apps/design-system/registry/default/example/inner-side-menu-demo.tsx
+++ b/apps/design-system/registry/default/example/inner-side-menu-demo.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import { Card } from 'ui'
+import {
+  InnerSideMenuCollapsible,
+  InnerSideMenuCollapsibleTrigger,
+  InnerSideMenuCollapsibleContent,
+  InnerSideMenuItem,
+  InnerSideMenuSeparator,
+} from 'ui-patterns/InnerSideMenu'
+
+export default function InnerSideMenuDemo() {
+  return (
+    <Card className="min-w-60 bg-dash-sidebar py-4 flex flex-col gap-6 h-full">
+      <InnerSideMenuCollapsible defaultOpen>
+        <InnerSideMenuCollapsibleTrigger title="Projects">Hello</InnerSideMenuCollapsibleTrigger>
+        <InnerSideMenuCollapsibleContent className="mt-2">
+          <InnerSideMenuItem href="/">Dashboard</InnerSideMenuItem>
+          <InnerSideMenuItem href="/">Team</InnerSideMenuItem>
+          <InnerSideMenuItem href="/">Settings</InnerSideMenuItem>
+        </InnerSideMenuCollapsibleContent>
+      </InnerSideMenuCollapsible>
+      <InnerSideMenuSeparator />
+      <InnerSideMenuCollapsible defaultOpen>
+        <InnerSideMenuCollapsibleTrigger title="Projects">Hello</InnerSideMenuCollapsibleTrigger>
+        <InnerSideMenuCollapsibleContent className="mt-2">
+          <InnerSideMenuItem href="/" title="Dashboard">
+            Dashboard
+          </InnerSideMenuItem>
+          <InnerSideMenuItem href="/">Team</InnerSideMenuItem>
+          <InnerSideMenuItem href="/">Settings</InnerSideMenuItem>
+        </InnerSideMenuCollapsibleContent>
+      </InnerSideMenuCollapsible>
+      <InnerSideMenuCollapsible defaultOpen>
+        <InnerSideMenuCollapsibleTrigger title="Projects">Hello</InnerSideMenuCollapsibleTrigger>
+        <InnerSideMenuCollapsibleContent className="mt-2">
+          <InnerSideMenuItem href="/" title="Dashboard">
+            Dashboard
+          </InnerSideMenuItem>
+          <InnerSideMenuItem href="/">Team</InnerSideMenuItem>
+          <InnerSideMenuItem href="/">Settings</InnerSideMenuItem>
+        </InnerSideMenuCollapsibleContent>
+      </InnerSideMenuCollapsible>
+    </Card>
+  )
+}

--- a/apps/design-system/registry/default/example/inner-side-menu-empty.tsx
+++ b/apps/design-system/registry/default/example/inner-side-menu-empty.tsx
@@ -1,0 +1,74 @@
+import React from 'react'
+import {
+  InnerSideMenuCollapsible,
+  InnerSideMenuCollapsibleTrigger,
+  InnerSideMenuCollapsibleContent,
+  InnerSideBarShimmeringLoaders,
+  InnerSideBarEmptyPanel,
+  InnerSideMenuItem,
+  InnerSideMenuSeparator,
+} from 'ui-patterns/InnerSideMenu'
+import { Button, Card } from 'ui'
+import { Heart, Pointer } from 'lucide-react'
+
+export default function InnerSideMenuEmpty() {
+  const [isLoading, setIsLoading] = React.useState(true)
+  const [hasItems, setHasItems] = React.useState(false)
+
+  React.useEffect(() => {
+    // Simulate loading
+    const timer = setTimeout(() => {
+      setIsLoading(false)
+    }, 2000)
+    return () => clearTimeout(timer)
+  }, [])
+
+  return (
+    <Card className="w-64 py-4 flex flex-col gap-4 bg-dash-sidebar">
+      <InnerSideMenuCollapsible defaultOpen>
+        <InnerSideMenuCollapsibleTrigger title="Functions" />
+        <InnerSideMenuCollapsibleContent className="pt-2">
+          <InnerSideBarEmptyPanel
+            className="mx-2"
+            title="No functions found"
+            description="Create your first serverless function to get started."
+            illustration={<div className="text-4xl">🚀</div>}
+            actions={
+              <Button type="default" onClick={() => setHasItems(true)}>
+                Create Function
+              </Button>
+            }
+          />
+        </InnerSideMenuCollapsibleContent>
+      </InnerSideMenuCollapsible>
+      <InnerSideMenuSeparator />
+      <InnerSideMenuCollapsible defaultOpen>
+        <InnerSideMenuCollapsibleTrigger title="Functions" />
+        <InnerSideMenuCollapsibleContent className="pt-2">
+          <InnerSideBarEmptyPanel
+            className="mx-2"
+            title="No functions found"
+            description="Create your first serverless function to get started."
+            illustration={
+              <figure className="relative mb-3">
+                <div className="h-6 w-6 bg-surface-100 border rounded-md flex items-center justify-center">
+                  <Heart className="text-light" size={13} />
+                </div>
+                <Pointer
+                  className="absolute -right-[6px] -bottom-2 text-lighter"
+                  strokeWidth={1.5}
+                  size={16}
+                />
+              </figure>
+            }
+            actions={
+              <Button type="default" onClick={() => setHasItems(true)}>
+                Create Function
+              </Button>
+            }
+          />
+        </InnerSideMenuCollapsibleContent>
+      </InnerSideMenuCollapsible>
+    </Card>
+  )
+}

--- a/apps/design-system/registry/default/example/inner-side-menu-loading.tsx
+++ b/apps/design-system/registry/default/example/inner-side-menu-loading.tsx
@@ -1,0 +1,32 @@
+import { Card } from 'ui'
+import {
+  InnerSideMenuCollapsible,
+  InnerSideMenuCollapsibleContent,
+  InnerSideMenuCollapsibleTrigger,
+  InnerSideMenuItemLoading,
+  InnerSideMenuSeparator,
+} from 'ui-patterns/InnerSideMenu'
+
+export default function InnerSideMenuLoading() {
+  return (
+    <Card className="w-64 py-4 flex flex-col gap-4 bg-dash-sidebar">
+      <InnerSideMenuCollapsible defaultOpen>
+        <InnerSideMenuCollapsibleTrigger title="Functions" />
+        <InnerSideMenuCollapsibleContent className="pt-2">
+          <InnerSideMenuItemLoading />
+          <InnerSideMenuItemLoading />
+          <InnerSideMenuItemLoading />
+        </InnerSideMenuCollapsibleContent>
+      </InnerSideMenuCollapsible>
+      <InnerSideMenuSeparator />
+      <InnerSideMenuCollapsible defaultOpen>
+        <InnerSideMenuCollapsibleTrigger title="Functions" />
+        <InnerSideMenuCollapsibleContent className="pt-2">
+          <InnerSideMenuItemLoading />
+          <InnerSideMenuItemLoading />
+          <InnerSideMenuItemLoading />
+        </InnerSideMenuCollapsibleContent>
+      </InnerSideMenuCollapsible>
+    </Card>
+  )
+}

--- a/apps/design-system/registry/default/example/inner-side-menu-multiple-sections.tsx
+++ b/apps/design-system/registry/default/example/inner-side-menu-multiple-sections.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import {
+  InnerSideMenuCollapsible,
+  InnerSideMenuCollapsibleTrigger,
+  InnerSideMenuCollapsibleContent,
+  InnerSideMenuItem,
+  InnerSideMenuSeparator,
+} from 'ui-patterns/InnerSideMenu'
+
+export default function InnerSideMenuMultipleSections() {
+  return (
+    <div className="w-64">
+      <InnerSideMenuCollapsible>
+        <InnerSideMenuCollapsibleTrigger title="Development" />
+        <InnerSideMenuCollapsibleContent>
+          <InnerSideMenuItem href="#" isActive>
+            API
+          </InnerSideMenuItem>
+          <InnerSideMenuItem href="#">Database</InnerSideMenuItem>
+        </InnerSideMenuCollapsibleContent>
+      </InnerSideMenuCollapsible>
+      <InnerSideMenuSeparator />
+      <InnerSideMenuCollapsible>
+        <InnerSideMenuCollapsibleTrigger title="Analytics" />
+        <InnerSideMenuCollapsibleContent>
+          <InnerSideMenuItem href="#">Reports</InnerSideMenuItem>
+          <InnerSideMenuItem href="#">Usage</InnerSideMenuItem>
+        </InnerSideMenuCollapsibleContent>
+      </InnerSideMenuCollapsible>
+    </div>
+  )
+}

--- a/apps/design-system/registry/default/example/inner-side-menu-static-titles.tsx
+++ b/apps/design-system/registry/default/example/inner-side-menu-static-titles.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import { Card } from 'ui'
+import {
+  InnerSideMenuCollapsible,
+  InnerSideMenuCollapsibleTrigger,
+  InnerSideMenuCollapsibleContent,
+  InnerSideMenuItem,
+  InnerSideMenuSeparator,
+  InnerSideBarTitle,
+} from 'ui-patterns/InnerSideMenu'
+
+export default function InnerSideMenuBasic() {
+  return (
+    <Card className="min-w-60 bg-dash-sidebar py-4 flex flex-col gap-6 h-full">
+      <div className="px-2">
+        <InnerSideBarTitle className="mb-2">Projects</InnerSideBarTitle>
+        <InnerSideMenuItem href="/">Dashboard</InnerSideMenuItem>
+        <InnerSideMenuItem href="/">Team</InnerSideMenuItem>
+        <InnerSideMenuItem href="/">Settings</InnerSideMenuItem>
+      </div>
+      <InnerSideMenuSeparator />
+      <div className="px-2">
+        <InnerSideBarTitle className="mb-2">Projects</InnerSideBarTitle>
+        <InnerSideMenuItem href="/" title="Dashboard">
+          Dashboard
+        </InnerSideMenuItem>
+        <InnerSideMenuItem href="/">Team</InnerSideMenuItem>
+        <InnerSideMenuItem href="/">Settings</InnerSideMenuItem>
+      </div>
+      <div className="px-2">
+        <InnerSideBarTitle className="mb-2">Projects</InnerSideBarTitle>
+        <InnerSideMenuItem href="/" title="Dashboard">
+          Dashboard
+        </InnerSideMenuItem>
+        <InnerSideMenuItem href="/">Team</InnerSideMenuItem>
+        <InnerSideMenuItem href="/">Settings</InnerSideMenuItem>
+      </div>
+    </Card>
+  )
+}

--- a/apps/design-system/registry/default/example/inner-side-menu-with-search.tsx
+++ b/apps/design-system/registry/default/example/inner-side-menu-with-search.tsx
@@ -1,0 +1,92 @@
+import React, { useState, useMemo } from 'react'
+import { Card } from 'ui'
+import {
+  InnerSideMenuCollapsible,
+  InnerSideMenuCollapsibleTrigger,
+  InnerSideMenuCollapsibleContent,
+  InnerSideMenuItem,
+  InnerSideBarFilters,
+  InnerSideBarFilterSearchInput,
+  InnerSideBarFilterSortDropdown,
+  InnerSideBarFilterSortDropdownItem,
+  InnerSideBarEmptyPanel,
+} from 'ui-patterns/InnerSideMenu'
+
+export default function InnerSideMenuWithSearch() {
+  const [sort, setSort] = useState('alphabetical')
+  const [searchTerm, setSearchTerm] = useState('')
+
+  const foodCategories = {
+    Fruits: ['Apple', 'Banana', 'Orange', 'Strawberry'],
+    Vegetables: ['Carrot', 'Broccoli', 'Spinach', 'Tomato'],
+    Grains: ['Rice', 'Wheat', 'Oats', 'Quinoa'],
+    Proteins: ['Chicken', 'Beef', 'Fish', 'Tofu'],
+  }
+
+  const filteredAndSortedCategories = useMemo(() => {
+    return Object.entries(foodCategories).reduce(
+      (acc, [category, items]) => {
+        let filteredItems = items.filter((item) =>
+          item.toLowerCase().includes(searchTerm.toLowerCase())
+        )
+
+        // Sort the filtered items
+        filteredItems.sort((a, b) => {
+          if (sort === 'alphabetical') {
+            return a.localeCompare(b)
+          } else {
+            return b.localeCompare(a)
+          }
+        })
+
+        acc[category] = filteredItems
+        return acc
+      },
+      {} as Record<string, string[]>
+    )
+  }, [foodCategories, searchTerm, sort])
+
+  return (
+    <Card className="w-64 py-4 flex flex-col gap-4 bg-dash-sidebar">
+      <InnerSideBarFilters>
+        <InnerSideBarFilterSearchInput
+          name="search-input"
+          placeholder="Search..."
+          value={searchTerm}
+          onChange={(e) => setSearchTerm(e.target.value)}
+          aria-labelledby="Search items"
+        >
+          <InnerSideBarFilterSortDropdown value={sort} onValueChange={(value) => setSort(value)}>
+            <InnerSideBarFilterSortDropdownItem value="alphabetical">
+              Sort Alphabetically
+            </InnerSideBarFilterSortDropdownItem>
+            <InnerSideBarFilterSortDropdownItem value="reverse">
+              Sort Reverse Alphabetically
+            </InnerSideBarFilterSortDropdownItem>
+          </InnerSideBarFilterSortDropdown>
+        </InnerSideBarFilterSearchInput>
+      </InnerSideBarFilters>
+
+      {Object.entries(filteredAndSortedCategories).map(([category, items]) => (
+        <InnerSideMenuCollapsible key={category} defaultOpen>
+          <InnerSideMenuCollapsibleTrigger title={category} />
+          <InnerSideMenuCollapsibleContent className="pt-2">
+            {items.length > 0 ? (
+              items.map((item) => (
+                <InnerSideMenuItem key={item} href="#">
+                  {item}
+                </InnerSideMenuItem>
+              ))
+            ) : (
+              <InnerSideBarEmptyPanel
+                className="mx-2"
+                title={`No ${category.toLowerCase()} found`}
+                description={`Your search did not return any results in ${category}`}
+              />
+            )}
+          </InnerSideMenuCollapsibleContent>
+        </InnerSideMenuCollapsible>
+      ))}
+    </Card>
+  )
+}

--- a/apps/design-system/registry/examples.ts
+++ b/apps/design-system/registry/examples.ts
@@ -1031,6 +1031,36 @@ export const examples: Registry = [
     files: ['example/info-tooltip-demo.tsx'],
   },
   {
+    name: 'inner-side-menu-demo',
+    type: 'components:example',
+    files: ['example/inner-side-menu-demo.tsx'],
+  },
+  {
+    name: 'inner-side-menu-static-titles',
+    type: 'components:example',
+    files: ['example/inner-side-menu-static-titles.tsx'],
+  },
+  {
+    name: 'inner-side-menu-loading',
+    type: 'components:example',
+    files: ['example/inner-side-menu-loading.tsx'],
+  },
+  {
+    name: 'inner-side-menu-multiple-sections',
+    type: 'components:example',
+    files: ['example/inner-side-menu-multiple-sections.tsx'],
+  },
+  {
+    name: 'inner-side-menu-empty',
+    type: 'components:example',
+    files: ['example/inner-side-menu-empty.tsx'],
+  },
+  {
+    name: 'inner-side-menu-with-search',
+    type: 'components:example',
+    files: ['example/inner-side-menu-with-search.tsx'],
+  },
+  {
     name: 'multi-select-demo',
     type: 'components:example',
     files: ['example/multi-select-demo.tsx'],

--- a/packages/ui-patterns/InnerSideMenu/index.tsx
+++ b/packages/ui-patterns/InnerSideMenu/index.tsx
@@ -27,7 +27,7 @@ const InnerSideBarTitle = forwardRef<HTMLSpanElement, React.ComponentPropsWithou
         ref={ref}
         {...restProps}
         className={cn(
-          'w-full flex gap-1 items-center group px-3 text-xs font-normal font-mono uppercase text-lighter tracking-wide group-hover:not-disabled:text-foreground',
+          'w-full flex gap-1 items-center group px-3 text-sm font-normal font-mono uppercase text-lighter tracking-wide group-hover:not-disabled:text-foreground',
           className
         )}
       />
@@ -51,7 +51,7 @@ const InnerSideMenuCollapsibleTrigger = forwardRef<
       ref={ref}
       {...props}
       className={cn(
-        'w-full flex gap-1 items-center group px-3 text-xs font-normal font-mono uppercase text-lighter tracking-wide',
+        'w-full flex gap-1 items-center group px-3 text-sm font-normal font-mono uppercase text-lighter tracking-wide',
         props.className
       )}
     >

--- a/packages/ui-patterns/InnerSideMenu/index.tsx
+++ b/packages/ui-patterns/InnerSideMenu/index.tsx
@@ -1,4 +1,4 @@
-import { ChevronsDown, Search } from 'lucide-react'
+import { ChevronRight, ChevronsDown, Search } from 'lucide-react'
 import Link from 'next/link'
 import { ElementRef, forwardRef } from 'react'
 import {
@@ -11,6 +11,7 @@ import {
   DropdownMenuRadioItem,
   DropdownMenuTrigger,
   Input_Shadcn_,
+  Skeleton,
   TooltipContent_Shadcn_,
   TooltipTrigger_Shadcn_,
   Tooltip_Shadcn_,
@@ -18,11 +19,27 @@ import {
 } from 'ui'
 import ShimmeringLoader from '../ShimmeringLoader'
 
+const InnerSideBarTitle = forwardRef<HTMLSpanElement, React.ComponentPropsWithoutRef<'span'>>(
+  (props, ref) => {
+    const { className, ...restProps } = props
+    return (
+      <span
+        ref={ref}
+        {...restProps}
+        className={cn(
+          'w-full flex gap-1 items-center group px-3 text-xs font-normal font-mono uppercase text-lighter tracking-wide group-hover:not-disabled:text-foreground',
+          className
+        )}
+      />
+    )
+  }
+)
+
 const InnerSideMenuCollapsible = forwardRef<
   ElementRef<typeof Collapsible_Shadcn_>,
   React.ComponentPropsWithoutRef<typeof Collapsible_Shadcn_>
 >(({ ...props }, ref) => {
-  return <Collapsible_Shadcn_ {...props} className={cn('w-full px-2', props.className)} />
+  return <Collapsible_Shadcn_ ref={ref} {...props} className={cn('w-full px-2', props.className)} />
 })
 
 const InnerSideMenuCollapsibleTrigger = forwardRef<
@@ -31,7 +48,6 @@ const InnerSideMenuCollapsibleTrigger = forwardRef<
 >(({ ...props }, ref) => {
   return (
     <CollapsibleTrigger_Shadcn_
-      disabled
       ref={ref}
       {...props}
       className={cn(
@@ -39,11 +55,11 @@ const InnerSideMenuCollapsibleTrigger = forwardRef<
         props.className
       )}
     >
-      {/* <ChevronRight
+      <ChevronRight
         className="transition-all text-foreground-muted group-data-[state=open]:rotate-90"
         size={16}
         strokeWidth={1.5}
-      /> */}
+      />
       <span className="group-hover:not-disabled:text-foreground">{props.title}</span>
     </CollapsibleTrigger_Shadcn_>
   )
@@ -55,8 +71,12 @@ const InnerSideMenuCollapsibleContent = forwardRef<
 >(({ ...props }, ref) => {
   return (
     <CollapsibleContent_Shadcn_
+      ref={ref}
       {...props}
-      className={cn('w-full data-[state=open]:pt-1 flex flex-col gap-2', props.className)}
+      className={cn(
+        'w-full flex flex-col gap-0 transition-all data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down',
+        props.className
+      )}
     />
   )
 })
@@ -91,6 +111,17 @@ const InnerSideMenuItem = forwardRef<
     />
   )
 })
+
+function InnerSideMenuItemLoading({
+  className,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof Skeleton>) {
+  return (
+    <div className="py-0.5 h-7">
+      <Skeleton {...props} className={cn('h-full w-full bg-surface-200', className)} />
+    </div>
+  )
+}
 
 const InnerSideBarFilters = forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<'div'>>(
   (props, ref) => {
@@ -199,7 +230,7 @@ const InnerSideBarEmptyPanel = forwardRef<
       ref={ref}
       {...props}
       className={cn(
-        'border bg-surface-100/50 flex flex-col gap-y-3 items-center justify-center rounded-md px-3 py-4',
+        'border bg-surface-100/50 flex flex-col gap-y-3 items-center justify-center rounded-md px-5 py-4',
         props.className
       )}
     >
@@ -217,14 +248,16 @@ const InnerSideBarEmptyPanel = forwardRef<
 
 export {
   InnerSideBarEmptyPanel,
+  InnerSideBarFilters,
   InnerSideBarFilterSearchInput,
   InnerSideBarFilterSortDropdown,
   InnerSideBarFilterSortDropdownItem,
-  InnerSideBarFilters,
   InnerSideBarShimmeringLoaders,
+  InnerSideBarTitle,
   InnerSideMenuCollapsible,
   InnerSideMenuCollapsibleContent,
   InnerSideMenuCollapsibleTrigger,
   InnerSideMenuItem,
+  InnerSideMenuItemLoading,
   InnerSideMenuSeparator,
 }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

- Adds docs for `<InnerSideBar />` component collection.

## Additional context

<img width="1344" alt="Screenshot 2024-10-23 at 16 37 01" src="https://github.com/user-attachments/assets/800cbc34-e63d-4d21-b641-9f6a5a28eaed">
<img width="1329" alt="Screenshot 2024-10-23 at 16 37 06" src="https://github.com/user-attachments/assets/845319fe-4ccb-4f76-985b-1797bd0675ca">
<img width="1373" alt="Screenshot 2024-10-23 at 16 37 11" src="https://github.com/user-attachments/assets/9456815b-4bdf-482e-8756-54d39a03fdfe">
<img width="1301" alt="Screenshot 2024-10-23 at 16 37 14" src="https://github.com/user-attachments/assets/f5127343-2192-4df2-bd6e-27a6f15001c9">
<img width="1348" alt="Screenshot 2024-10-23 at 16 37 18" src="https://github.com/user-attachments/assets/2a28e54d-b5ad-4f31-9bc0-df589ac1a252">




