### PR TITLE
fix: avatar url startsWith error

### DIFF
--- a/apps/studio/components/interfaces/Auth/Users/Users.utils.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/Users.utils.tsx
@@ -211,9 +211,9 @@ export function getAvatarUrl(user: User): string | undefined {
     profileImageUrl ||
     profileImageURL ||
     profile_image_url ||
-    '') as string | undefined
+    '') as unknown
 
-  if (url === undefined) return undefined
+  if (typeof url !== 'string') return undefined
   const isSupported = SUPPORTED_CSP_AVATAR_URLS.some((x) => url.startsWith(x))
   return isSupported ? url : undefined
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Sometimes `x.startsWith is not a function` errors due to users being able to put anything in these fields

## What is the new behavior?

Only check startsWith on strings