### PR TITLE
chore: increase react-query staleTime on some queries

### DIFF
--- a/apps/studio/data/auth/users-infinite-query.ts
+++ b/apps/studio/data/auth/users-infinite-query.ts
@@ -104,7 +104,6 @@ export const useUsersInfiniteQuery = <TData = UsersData>(
       )
     },
     {
-      staleTime: 0,
       enabled: enabled && typeof projectRef !== 'undefined',
 
       getNextPageParam(lastPage, pages) {

--- a/apps/studio/data/database-triggers/database-triggers-query.ts
+++ b/apps/studio/data/database-triggers/database-triggers-query.ts
@@ -42,8 +42,7 @@ export const useDatabaseHooksQuery = <TData = DatabaseTriggersData>(
     databaseTriggerKeys.list(projectRef),
     ({ signal }) => getDatabaseTriggers({ projectRef, connectionString }, signal),
     {
-      staleTime: 0,
-      // @ts-ignore
+      // @ts-expect-error - select typings are funky
       select(data) {
         return (data as PostgresTrigger[]).filter(
           (trigger) =>

--- a/apps/studio/data/entity-types/entity-types-infinite-query.ts
+++ b/apps/studio/data/entity-types/entity-types-infinite-query.ts
@@ -141,7 +141,6 @@ export const useEntityTypesQuery = <TData = EntityTypesData>(
       ),
     {
       enabled: enabled && typeof projectRef !== 'undefined',
-      staleTime: 0,
       getNextPageParam(lastPage, pages) {
         const page = pages.length
         const currentTotalCount = page * limit

--- a/apps/studio/data/enumerated-types/enumerated-types-query.ts
+++ b/apps/studio/data/enumerated-types/enumerated-types-query.ts
@@ -50,7 +50,6 @@ export const useEnumeratedTypesQuery = <TData = EnumeratedTypesData>(
     ({ signal }) => getEnumeratedTypes({ projectRef, connectionString }, signal),
     {
       enabled: enabled && typeof projectRef !== 'undefined',
-      staleTime: 0,
       ...options,
     }
   )

--- a/apps/studio/data/foreign-tables/foreign-table-query.ts
+++ b/apps/studio/data/foreign-tables/foreign-table-query.ts
@@ -52,7 +52,6 @@ export const useForeignTableQuery = <TData = ForeignTableData>(
     ({ signal }) => getForeignTable({ projectRef, connectionString, id }, signal),
     {
       enabled: enabled && typeof projectRef !== 'undefined' && typeof id !== 'undefined',
-      staleTime: 0,
       ...options,
     }
   )

--- a/apps/studio/data/foreign-tables/foreign-tables-query.ts
+++ b/apps/studio/data/foreign-tables/foreign-tables-query.ts
@@ -49,7 +49,6 @@ export const useForeignTablesQuery = <TData = ForeignTablesData>(
     ({ signal }) => getForeignTables({ projectRef, connectionString, schema }, signal),
     {
       enabled: enabled && typeof projectRef !== 'undefined',
-      staleTime: 0,
       ...options,
     }
   )

--- a/apps/studio/data/materialized-views/materialized-view-query.ts
+++ b/apps/studio/data/materialized-views/materialized-view-query.ts
@@ -56,7 +56,6 @@ export const useMaterializedViewQuery = <TData = MaterializedViewData>(
     ({ signal }) => getMaterializedView({ projectRef, connectionString, id }, signal),
     {
       enabled: enabled && typeof projectRef !== 'undefined' && typeof id !== 'undefined',
-      staleTime: 0,
       ...options,
     }
   )

--- a/apps/studio/data/materialized-views/materialized-views-query.ts
+++ b/apps/studio/data/materialized-views/materialized-views-query.ts
@@ -54,7 +54,6 @@ export const useMaterializedViewsQuery = <TData = MaterializedViewsData>(
     ({ signal }) => getMaterializedViews({ projectRef, connectionString, schema }, signal),
     {
       enabled: enabled && typeof projectRef !== 'undefined',
-      staleTime: 0,
       ...options,
     }
   )

--- a/apps/studio/data/service-status/postgres-service-status-query.ts
+++ b/apps/studio/data/service-status/postgres-service-status-query.ts
@@ -46,7 +46,6 @@ export const usePostgresServiceStatusQuery = <TData = PostgresServiceStatusData>
     {
       enabled:
         enabled && typeof projectRef !== 'undefined' && typeof connectionString !== 'undefined',
-      staleTime: 0,
       ...options,
     }
   )

--- a/apps/studio/data/sql/execute-sql-query.ts
+++ b/apps/studio/data/sql/execute-sql-query.ts
@@ -127,5 +127,5 @@ export const useExecuteSqlQuery = <TData = ExecuteSqlData>(
         { projectRef, connectionString, sql, queryKey, handleError, isRoleImpersonationEnabled },
         signal
       ),
-    { enabled: enabled && typeof projectRef !== 'undefined', staleTime: 0, ...options }
+    { enabled: enabled && typeof projectRef !== 'undefined',  ...options }
   )

--- a/apps/studio/data/tables/table-query.ts
+++ b/apps/studio/data/tables/table-query.ts
@@ -51,7 +51,6 @@ export const useTableQuery = <TData = TableData>(
     ({ signal }) => getTable({ projectRef, connectionString, id }, signal),
     {
       enabled: enabled && typeof projectRef !== 'undefined' && typeof id !== 'undefined',
-      staleTime: 0,
       ...options,
     }
   )

--- a/apps/studio/data/tables/tables-query.ts
+++ b/apps/studio/data/tables/tables-query.ts
@@ -72,7 +72,7 @@ export const useTablesQuery = <TData = TablesData>(
   return useQuery<TablesData, TablesError, TData>(
     tableKeys.list(projectRef, schema, includeColumns),
     ({ signal }) => getTables({ projectRef, connectionString, schema, includeColumns }, signal),
-    { enabled: enabled && typeof projectRef !== 'undefined', staleTime: 0, ...options }
+    { enabled: enabled && typeof projectRef !== 'undefined', ...options }
   )
 }
 

--- a/apps/studio/data/views/view-query.ts
+++ b/apps/studio/data/views/view-query.ts
@@ -51,7 +51,6 @@ export const useViewQuery = <TData = ViewData>(
     ({ signal }) => getView({ projectRef, connectionString, id }, signal),
     {
       enabled: enabled && typeof projectRef !== 'undefined' && typeof id !== 'undefined',
-      staleTime: 0,
       ...options,
     }
   )

--- a/apps/studio/data/views/views-query.ts
+++ b/apps/studio/data/views/views-query.ts
@@ -48,7 +48,6 @@ export const useViewsQuery = <TData = ViewsData>(
     ({ signal }) => getViews({ projectRef, connectionString, schema }, signal),
     {
       enabled: enabled && typeof projectRef !== 'undefined',
-      staleTime: 0,
       ...options,
     }
   )


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

A few queries are always stale causing lots of excess fetching for little benefit since we manually invalidate when things change. We also offer refresh buttons on most data views in the dashboard.

## What is the new behavior?

Most queries now follow the same rule:
`react-queries are revalidated at most once every 5 minutes or when manually invalidated`