### PR TITLE
Fix foreign key mgt table editor open in new tab

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/ForeignKeysManagement/ForeignKeyRow.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/ForeignKeysManagement/ForeignKeyRow.tsx
@@ -78,9 +78,10 @@ export const ForeignKeyRow = ({
               }
             >
               <EditorTablePageLink
+                target="_blank"
+                rel="norefererer"
                 projectRef={ref}
                 id={String(foreignKey.tableId)}
-                onClick={() => closePanel()}
               >
                 {foreignKey.schema}.{foreignKey.table}
               </EditorTablePageLink>

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/ForeignKeysManagement/ForeignKeyRow.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/ForeignKeysManagement/ForeignKeyRow.tsx
@@ -7,6 +7,7 @@ import { Badge, Button, cn } from 'ui'
 import { EditorTablePageLink } from 'data/prefetchers/project.$ref.editor.$id'
 import { BASE_PATH } from 'lib/constants'
 import type { ForeignKey } from '../../ForeignKeySelector/ForeignKeySelector.types'
+import Link from 'next/link'
 
 interface ForeignKeyProps {
   foreignKey: ForeignKey
@@ -77,14 +78,13 @@ export const ForeignKeyRow = ({
                 />
               }
             >
-              <EditorTablePageLink
+              <Link
                 target="_blank"
                 rel="norefererer"
-                projectRef={ref}
-                id={String(foreignKey.tableId)}
+                href={`/project/${ref}/editor/${foreignKey.tableId}`}
               >
                 {foreignKey.schema}.{foreignKey.table}
-              </EditorTablePageLink>
+              </Link>
             </Button>
           </div>
         </div>

--- a/apps/studio/components/layouts/ProjectIntegrationsLayout/ProjectIntegrationsLayout.tsx
+++ b/apps/studio/components/layouts/ProjectIntegrationsLayout/ProjectIntegrationsLayout.tsx
@@ -24,7 +24,7 @@ const ProjectIntegrationsMenu = () => {
     projectRef: project?.ref,
     connectionString: project?.connectionString,
   })
-  console.log({ data })
+
   const pgNetExtensionExists = (data ?? []).find((ext) => ext.name === 'pg_net') !== undefined
   const graphqlExtensionExists = (data ?? []).find((ext) => ext.name === 'pg_graphql') !== undefined
 


### PR DESCRIPTION
For example: clicking on `auth.users` here will open the `auth.users` table in the table editor,  but if you're midway editing the table (e.g adding a new foreign key) the panel closes and you lose your progress
![image](https://github.com/user-attachments/assets/a254bc4d-9d83-4b86-bc45-4a8adc2c522f)

Change here ensures that the button opens the referenced table in a new tab (understandably you just want to see the table, you don't necessarily want to switch context entirely)