### PR TITLE
docs: email templates link change

### DIFF
--- a/apps/docs/content/guides/auth/auth-email-templates.mdx
+++ b/apps/docs/content/guides/auth/auth-email-templates.mdx
@@ -27,7 +27,7 @@ The templating system provides the following variables for use:
 
 ## Editing email templates
 
-On hosted Supabase projects, edit your email templates on the [Email Templates](/dashboard/project/_/auth/templates) page. On self-hosted projects or in local development, edit your [configuration files](/docs/guides/cli/customizing-email-templates).
+On hosted Supabase projects, edit your email templates on the [Email Templates](/dashboard/project/_/auth/templates) page. On self-hosted projects or in local development, edit your [configuration files](/docs/guides/local-development/customizing-email-templates).
 
 ## Mobile Deep Linking
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Supabase Docs - [Auth Email Templates](https://supabase.com/docs/guides/auth/auth-email-templates#editing-email-templates)

## What is the current behavior?

Edit your configuration files link goes to a 404.

## What is the new behavior?

No longer going to a 404.

## Additional context

Closes #30101
