### PR TITLE
Update ConnectionPooling.tsx

### DIFF
--- a/apps/studio/components/interfaces/Settings/Database/ConnectionPooling/ConnectionPooling.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/ConnectionPooling/ConnectionPooling.tsx
@@ -355,7 +355,7 @@ export const ConnectionPooling = () => {
                       <FormDescription_Shadcn_ className="col-start-5 col-span-8">
                         Please refer to our{' '}
                         <a
-                          href="https://supabase.com/docs/guides/platform/custom-postgres-config#pooler-config"
+                          href="https://supabase.com/docs/guides/database/connection-management#configuring-supavisors-pool-size"
                           target="_blank"
                           rel="noreferrer"
                           className="underline"
@@ -393,7 +393,7 @@ export const ConnectionPooling = () => {
                       <FormDescription_Shadcn_ className="col-start-5 col-span-8">
                         Please refer to our{' '}
                         <a
-                          href="https://supabase.com/docs/guides/platform/custom-postgres-config#pooler-config"
+                          href="https://supabase.com/docs/guides/database/connection-management#configuring-supavisors-pool-size"
                           target="_blank"
                           rel="noreferrer"
                           className="underline"


### PR DESCRIPTION
Fix incorrect link for docs on configuring pooler.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Link fix.

## What is the current behavior?

The link to learn more about configuring connection pool size goes to a page that does not contain the word "pool", "pond", "natatorium", etc.

## What is the new behavior?

Link goes to docs about configuring the pool size.

## Additional context

N/A