### PR TITLE
Revert "docs: added max request and repsonse for edge functions docs"

### DIFF
--- a/apps/docs/content/guides/functions/limits.mdx
+++ b/apps/docs/content/guides/functions/limits.mdx
@@ -14,8 +14,6 @@ subtitle: "Limits applied Edge Functions in Supabase's hosted platform."
 - Maximum Function Size (after bundling via CLI): 10MB
 - Maximum log message length: 10,000 characters
 - Log event threshold: 100 events per 10 seconds
-- Max Request: 5GB
-- Max Response: No limit
 
 ## Other limits & restrictions
 


### PR DESCRIPTION
These req/res limits are not accurate for Edge Functions. Reverting it for now, will update with new limits later.

Reverts supabase/supabase#28076