### PR TITLE
fix: users displayName error when not strings

### DIFF
--- a/apps/studio/components/interfaces/Auth/Users/Users.utils.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/Users.utils.tsx
@@ -116,6 +116,7 @@ const phoneProviders = providers.phone.map((x) => {
 })
 
 function toPrettyJsonString(value: unknown): string | undefined {
+  if (!value) return undefined
   if (typeof value === 'string') return value
   if (Array.isArray(value)) return value.map((item) => toPrettyJsonString(item)).join(', ')
 

--- a/apps/studio/components/interfaces/Auth/Users/Users.utils.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/Users.utils.tsx
@@ -171,17 +171,17 @@ export function getDisplayName(user: User, fallback = '-'): string {
     ccFirstName ||
     cc_first_name
 
-  return (
+  return String(
     displayName ||
-    display_name ||
-    ccDisplayName ||
-    cc_display_name ||
-    fullName ||
-    full_name ||
-    ccFullName ||
-    cc_full_name ||
-    (first && last && `${first} ${last}`) ||
-    fallback
+      display_name ||
+      ccDisplayName ||
+      cc_display_name ||
+      fullName ||
+      full_name ||
+      ccFullName ||
+      cc_full_name ||
+      (first && last && `${first} ${last}`) ||
+      fallback
   )
 }
 

--- a/apps/studio/components/interfaces/Auth/Users/Users.utils.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/Users.utils.tsx
@@ -115,6 +115,19 @@ const phoneProviders = providers.phone.map((x) => {
   return key
 })
 
+function toPrettyJsonString(value: unknown): string | undefined {
+  if (typeof value === 'string') return value
+  if (Array.isArray(value)) return value.map((item) => toPrettyJsonString(item)).join(', ')
+
+  try {
+    return JSON.stringify(value)
+  } catch (error) {
+    // ignore the error
+  }
+
+  return undefined
+}
+
 export function getDisplayName(user: User, fallback = '-'): string {
   const {
     custom_claims,
@@ -149,39 +162,42 @@ export function getDisplayName(user: User, fallback = '-'): string {
     first_name: cc_first_name,
   } = custom_claims ?? {}
 
-  const last =
+  const last = toPrettyJsonString(
     familyName ||
-    family_name ||
-    surname ||
-    lastName ||
-    last_name ||
-    ccFamilyName ||
-    cc_family_name ||
-    ccSurname ||
-    ccLastName ||
-    cc_last_name
+      family_name ||
+      surname ||
+      lastName ||
+      last_name ||
+      ccFamilyName ||
+      cc_family_name ||
+      ccSurname ||
+      ccLastName ||
+      cc_last_name
+  )
 
-  const first =
+  const first = toPrettyJsonString(
     givenName ||
-    given_name ||
-    firstName ||
-    first_name ||
-    ccGivenName ||
-    cc_given_name ||
-    ccFirstName ||
-    cc_first_name
+      given_name ||
+      firstName ||
+      first_name ||
+      ccGivenName ||
+      cc_given_name ||
+      ccFirstName ||
+      cc_first_name
+  )
 
-  return String(
-    displayName ||
-      display_name ||
-      ccDisplayName ||
-      cc_display_name ||
-      fullName ||
-      full_name ||
-      ccFullName ||
-      cc_full_name ||
-      (first && last && `${first} ${last}`) ||
-      fallback
+  return (
+    toPrettyJsonString(
+      displayName ||
+        display_name ||
+        ccDisplayName ||
+        cc_display_name ||
+        fullName ||
+        full_name ||
+        ccFullName ||
+        cc_full_name ||
+        (first && last && `${first} ${last}`)
+    ) || fallback
   )
 }
 

--- a/apps/studio/components/interfaces/Auth/Users/Users.utils.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/Users.utils.tsx
@@ -118,7 +118,7 @@ const phoneProviders = providers.phone.map((x) => {
 function toPrettyJsonString(value: unknown): string | undefined {
   if (!value) return undefined
   if (typeof value === 'string') return value
-  if (Array.isArray(value)) return value.map((item) => toPrettyJsonString(item)).join(', ')
+  if (Array.isArray(value)) return value.map((item) => toPrettyJsonString(item)).join(' ')
 
   try {
     return JSON.stringify(value)

--- a/apps/studio/components/interfaces/Auth/Users/Users.utils.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/Users.utils.tsx
@@ -197,7 +197,9 @@ export function getDisplayName(user: User, fallback = '-'): string {
         full_name ||
         ccFullName ||
         cc_full_name ||
-        (first && last && `${first} ${last}`)
+        (first && last && `${first} ${last}`) ||
+        last ||
+        first
     ) || fallback
   )
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

If an object is in `raw_user_meta_data` for any of the name fields, React crashes with an error.

## What is the new behavior?

Always cast the name to a string. Most people shouldn't have objects for their name fields, so this is more just a fallback to prevent crashing