### PR TITLE
Fix missing https for endpoint in API docs

### DIFF
--- a/apps/studio/components/interfaces/Docs/Authentication.tsx
+++ b/apps/studio/components/interfaces/Docs/Authentication.tsx
@@ -15,7 +15,7 @@ const Authentication = ({ selectedLang, showApiKey }: AuthenticationProps) => {
   const { data: settings } = useProjectSettingsV2Query({ projectRef })
 
   const { anonKey, serviceKey } = getAPIKeys(settings)
-  const endpoint = settings?.app_config?.endpoint ?? ''
+  const endpoint = `https://${settings?.app_config?.endpoint ?? ''}`
 
   // [Joshen] ShowApiKey should really be a boolean, its confusing
   const defaultApiKey =

--- a/apps/studio/components/interfaces/Docs/Introduction.tsx
+++ b/apps/studio/components/interfaces/Docs/Introduction.tsx
@@ -16,7 +16,7 @@ export default function Introduction({ selectedLang }: Props) {
   const { data: settings } = useProjectSettingsV2Query({ projectRef })
   const { data: config } = useProjectPostgrestConfigQuery({ projectRef })
 
-  const endpoint = settings?.app_config?.endpoint ?? ''
+  const endpoint = `https://${settings?.app_config?.endpoint ?? ''}`
 
   const isPublicSchemaEnabled = config?.db_schema
     .split(',')

--- a/apps/studio/components/interfaces/Docs/Pages/UserManagement.tsx
+++ b/apps/studio/components/interfaces/Docs/Pages/UserManagement.tsx
@@ -20,7 +20,7 @@ export default function UserManagement({ selectedLang, showApiKey }: UserManagem
   const keyToShow = showApiKey ? showApiKey : 'SUPABASE_KEY'
 
   const { data: settings } = useProjectSettingsV2Query({ projectRef })
-  const endpoint = settings?.app_config?.endpoint ?? ''
+  const endpoint = `https://${settings?.app_config?.endpoint ?? ''}`
 
   return (
     <>

--- a/apps/studio/components/interfaces/Docs/RpcContent.tsx
+++ b/apps/studio/components/interfaces/Docs/RpcContent.tsx
@@ -29,7 +29,7 @@ const RpcContent = ({
 }: RpcContentProps) => {
   const { ref: projectRef } = useParams()
   const { data: settings } = useProjectSettingsV2Query({ projectRef })
-  const endpoint = settings?.app_config?.endpoint ?? ''
+  const endpoint = `https://${settings?.app_config?.endpoint ?? ''}`
 
   const meta = rpcs[rpcId]
   const pathKey = `/rpc/${rpcId}`


### PR DESCRIPTION
As per PR title, in API docs -> Introduction (JS), Authentication (JS and Bash), User Management (JS and Bash)