### PR TITLE
Update connecting-to-postgres.mdx

### DIFF
--- a/apps/docs/content/guides/database/connecting-to-postgres.mdx
+++ b/apps/docs/content/guides/database/connecting-to-postgres.mdx
@@ -128,7 +128,7 @@ If you'd like us to add a new quickstart guide, share your [feedback](https://su
 
 - [Prisma](/docs/guides/database/prisma)
 - [Drizzle](/docs/guides/database/drizzle)
-- [Postgres.js](/docs/guides/database/drizzle)
+- [Postgres.js](/docs/guides/database/postgres-js)
 
 ### External tools
 


### PR DESCRIPTION
Fixed link to External Libraries > Postgres.js

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the new behavior?

Old link external libraries for both drizzle and Postgres.js link to drizzle docs.  Simple update to link to the correct document.
