### PR TITLE
chore: org usage stale time

### DIFF
--- a/apps/studio/data/usage/org-usage-query.ts
+++ b/apps/studio/data/usage/org-usage-query.ts
@@ -43,6 +43,7 @@ export const useOrgUsageQuery = <TData = OrgUsageData>(
     ({ signal }) => getOrgUsage({ orgSlug, projectRef, start, end }, signal),
     {
       enabled: enabled && typeof orgSlug !== 'undefined',
+      staleTime: 1000 * 60 * 30, // 30 mins, underlying usage data only refreshes once an hour, so safe to cache for a while
       ...options,
     }
   )


### PR DESCRIPTION
Endpoint is quite expensive, so we shouldn't call it all too much