### PR TITLE
fix: korean tax id

### DIFF
--- a/apps/studio/components/interfaces/Organization/BillingSettings/TaxID/TaxID.constants.ts
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/TaxID/TaxID.constants.ts
@@ -365,7 +365,7 @@ export const TAX_IDS: TaxId[] = [
     type: 'kr_brn',
     country: 'Korea',
     placeholder: '123-45-67890',
-    countryIso2: 'Kr',
+    countryIso2: 'KR',
   },
   {
     name: 'LI UID',


### PR DESCRIPTION
Tax ID is case sensitive. Korea was the only iso 2 code not in uppercase