### PR TITLE
Chore/update self host guide

### DIFF
--- a/apps/docs/components/JwtGenerator/JwtGenerator.tsx
+++ b/apps/docs/components/JwtGenerator/JwtGenerator.tsx
@@ -75,7 +75,7 @@ export default function JwtGenerator({}) {
   }
 
   return (
-    <div>
+    <div className="border rounded-lg p-4">
       <div className="grid mb-8">
         <label htmlFor="secret">JWT Secret:</label>
         <Input
@@ -88,7 +88,7 @@ export default function JwtGenerator({}) {
         />
       </div>
       <div className="grid mb-8">
-        <label htmlFor="service">Preconfigured Payload:</label>
+        <label htmlFor="service">Key:</label>
         <Select id="service" style={{ fontFamily: 'monospace' }} onChange={handleKeySelection}>
           <Select.Option value="anon">ANON_KEY</Select.Option>
           <Select.Option value="service">SERVICE_KEY</Select.Option>
@@ -96,7 +96,7 @@ export default function JwtGenerator({}) {
       </div>
 
       <div className="grid mb-8">
-        <label htmlFor="token">Payload:</label>
+        <label htmlFor="token">The JWT will be generated from this info:</label>
         <Input.TextArea
           id="token"
           type="text"

--- a/apps/docs/content/guides/self-hosting.mdx
+++ b/apps/docs/content/guides/self-hosting.mdx
@@ -20,6 +20,7 @@ There are several ways to host Supabase on your own computer, server, or cloud.
       Deploy Supabase within your own infrastructure using Docker Compose.
       </GlassPanel>
     </Link>
+
   </div>
   <div className="md:col-span-6 xl:col-span-3" key="/pricing">
     <Link href="https://supabase.com/pricing" passHref>
@@ -37,7 +38,7 @@ There are several community-driven projects to help you deploy Supabase. We enco
 <div className="grid md:grid-cols-12 gap-4 not-prose">
   {community.map((x) => (
     <div className="md:col-span-6 xl:col-span-3" key={x.href}>
-      <Link href={x.href} passHref>
+      <Link href="https://supabase.com/pricing" passHref>
         <GlassPanel title={x.name}>{x.description}</GlassPanel>
       </Link>
     </div>

--- a/apps/docs/content/guides/self-hosting.mdx
+++ b/apps/docs/content/guides/self-hosting.mdx
@@ -10,28 +10,23 @@ There are several ways to host Supabase on your own computer, server, or cloud.
 ## Officially supported
 
 <div className="grid md:grid-cols-12 gap-4 not-prose">
-  {official.map((x) => (
-    <div className="md:col-span-6 xl:col-span-3" key={x.href}>
-      <Link href={x.href} passHref>
-        <GlassPanel title={x.name}>{x.description}</GlassPanel>
-      </Link>
-    </div>
-  ))}
-</div>
+  <div className="md:col-span-6 xl:col-span-3 relative" key="/guides/self-hosting/docker">
+    <span className=" absolute left-28 top-[34px] uppercase text-xs whitespace-nowrap text-foreground-lighter font-mono z-10 border rounded-full px-2 py-0.5">
+      Most common
+    </span>
+    <Link href="/guides/self-hosting/docker" passHref>
+      <GlassPanel title="Docker">
 
-export const official = [
-  {
-    name: 'Docker',
-    description: 'Deploy Supabase within your own infrastructure using Docker Compose.',
-    href: '/guides/self-hosting/docker',
-  },
-  {
-    name: 'BYO Cloud',
-    description:
-      'Contact our Enterprise sales team if you need Supabase managed in your own cloud.',
-    href: '/pricing',
-  },
-]
+      Deploy Supabase within your own infrastructure using Docker Compose.
+      </GlassPanel>
+    </Link>
+  </div>
+  <div className="md:col-span-6 xl:col-span-3" key="/pricing">
+    <Link href="/pricing" passHref>
+      <GlassPanel title="BYO Cloud">Contact our Enterprise sales team if you need Supabase managed in your own cloud.</GlassPanel>
+    </Link>
+  </div>
+</div>
 
 Supabase is also a hosted platform. If you want to get started for free, visit [supabase.com/dashboard](https://supabase.com/dashboard).
 

--- a/apps/docs/content/guides/self-hosting.mdx
+++ b/apps/docs/content/guides/self-hosting.mdx
@@ -22,7 +22,7 @@ There are several ways to host Supabase on your own computer, server, or cloud.
     </Link>
   </div>
   <div className="md:col-span-6 xl:col-span-3" key="/pricing">
-    <Link href="/pricing" passHref>
+    <Link href="https://supabase.com/pricing" passHref>
       <GlassPanel title="BYO Cloud">Contact our Enterprise sales team if you need Supabase managed in your own cloud.</GlassPanel>
     </Link>
   </div>

--- a/apps/docs/content/guides/self-hosting/docker.mdx
+++ b/apps/docs/content/guides/self-hosting/docker.mdx
@@ -434,7 +434,7 @@ A minimal setup working on Ubuntu, hosted on Digital Ocean.
   ></iframe>
 </div>
 
-### Digital Ocean setup notes:
+### Demo using Digital Ocean
 1. A Digital Ocean Droplet with 1GB memory and 25GB SSD is sufficient to start
 2. To access the Dashboard, use the ipv4 IP address of your Droplet.
 3. If you're unable to access Dashboard, run `docker compose ps` to see if the Studio service is running and healthy.

--- a/apps/docs/content/guides/self-hosting/docker.mdx
+++ b/apps/docs/content/guides/self-hosting/docker.mdx
@@ -7,15 +7,23 @@ tocVideo: "FqiQKRKsfZE"
 
 
 
-Docker is the easiest way to get started with self-hosted Supabase. This guide assumes you are running the command from the machine you intend to host from.
+Docker is the easiest way to get started with self-hosted Supabase. It should only take you a few minutes to get up and running. This guide assumes you are running the command from the machine you intend to host from.
+
+## Contents
+1. [Before you begin](#before-you-begin)
+2. [Installing and running Supabase](#installing-and-running-supabase)
+3. [Accessing your services](#accessing-supabase-studio)
+4. [Updating your services](#updating-your-services)
+5. [Securing your services](#securing-your-services)
+
 
 ## Before you begin
 
 You need the following installed in your system: [Git](https://git-scm.com/downloads) and Docker ([Windows](https://docs.docker.com/desktop/install/windows-install/), [MacOS](https://docs.docker.com/desktop/install/mac-install/), or [Linux](https://docs.docker.com/desktop/install/linux-install/)).
 
-## Running Supabase
+## Installing and running Supabase
 
-Follow these steps to start Supabase locally:
+Follow these steps to start Supabase on your machine:
 
 <Tabs
   scrollable
@@ -67,7 +75,15 @@ docker compose up -d
 </TabPanel>
 </Tabs>
 
+
+<Admonition>
+
 If you are using rootless docker, edit `.env` and set `DOCKER_SOCKET_LOCATION` to your docker socket location. For example: `/run/user/1000/docker.sock`. Otherwise, you will see an error like `container supabase-vector exited (0)`.
+
+
+</Admonition>
+
+
 
 After all the services have started you can see them running in the background:
 
@@ -75,13 +91,21 @@ After all the services have started you can see them running in the background:
 docker compose ps
 ```
 
+All of the services should have a status `running (healthy)`. If you see a status like `created` but not `running`, try starting that service manually with `docker compose start <service-name>`.
+
+
+<Admonition type="danger">
+
+Your app is now running with default credentials.
 Please [secure your services](#securing-your-services) as soon as possible using the instructions below.
 
-For security reasons, we "pin" the versions of each service in the docker-compose file (these versions are updated ~monthly). If you want to update any services immediately, you can do so by updating the version number in the docker compose file and then running `docker compose pull`. You can find all the latest docker images in the [Supabase Docker Hub](https://hub.docker.com/u/supabase).
 
-### Accessing Supabase dashboard
+</Admonition>
 
-You can access the Supabase Dashboard through the API gateway on port `8000`. For example: `http://<your-ip>:8000`, or [localhost:8000](http://localhost:8000) if you are running Docker locally.
+
+### Accessing Supabase Studio
+
+You can access Supabase Studio through the API gateway on port `8000`. For example: `http://<your-ip>:8000`, or [localhost:8000](http://localhost:8000) if you are running Docker locally.
 
 You will be prompted for a username and password. By default, the credentials are:
 
@@ -127,21 +151,38 @@ The default tenant ID is `your-tenant-id`, and the default password is `your-sup
 
 By default, the database is not accessible from outside the local machine but the pooler is. You can [change this](#exposing-your-postgres-database) by updating the `docker-compose.yml` file.
 
+## Updating your services
+For security reasons, we "pin" the versions of each service in the docker-compose file (these versions are updated ~monthly). If you want to update any services immediately, you can do so by updating the version number in the docker compose file and then running `docker compose pull`. You can find all the latest docker images in the [Supabase Docker Hub](https://hub.docker.com/u/supabase).
+
+You should update your services frequently to get the latest features and bug fixes and security patches. Note that you will need to restart the services to pick up the changes, which will result in some downtime for your services.
+
+**Example**
+You'll want to update the Studio(Dashboard) frequently to get the latest features and bug fixes. To update the Dashboard:
+1. Visit the [supabase/studio](https://hub.docker.com/r/supabase/studio/tags) image in the [Supabase Docker Hub](https://hub.docker.com/u/supabase)
+2. Find the latest version (tag) number. It will look something like `20241029-46e1e40`
+3. Update the `image` field in the `docker-compose.yml` file to the new version. It should look like this: `image: supabase/studio:20241028-a265374`
+4. Run `docker compose pull` and then `docker compose up -d` to restart the service with the new version.
+
+
+
 ## Securing your services
 
 While we provided you with some example secrets for getting started, you should NEVER deploy your Supabase setup using the defaults we have provided. Please follow all of the steps in this section to ensure you have a secure setup, and then [restart all services](#restarting-all-services) to pick up the changes.
 
+
 ### Generate API keys
+We need to generate secure keys for accessing your services. We'll use the `JWT Secret` to generate `anon` and `service` API keys using the form below.
 
-Create a new `JWT_SECRET` and store it securely.
+1. **Obtain a Secret**: Use the 40-character secret provided, or create your own. If creating, ensure it's a strong, random string of 40 characters.
+2. **Store Securely**: Save the secret in a secure location on your local machine. Don't share this secret publicly or commit it to version control.
+3. **Generate a JWT**: Use the form below to generate a new `JWT` using your secret.
 
-We can use your JWT Secret to generate new `anon` and `service` API keys using the form below. Update the "JWT Secret" and then run "Generate JWT" once for the `SERVICE_KEY` and once for the `ANON_KEY`:
 
 <JwtGenerator />
 
 ### Update API keys
 
-Replace the values in the `.env` file:
+Run this form twice to generate new `anon` and `service` API keys. Replace the values in the `./docker/.env` file:
 
   - `ANON_KEY` - replace with an `anon` key
   - `SERVICE_ROLE_KEY` - replace with a `service` key
@@ -150,7 +191,7 @@ You will need to [restart](#restarting-all-services) the services for the change
 
 ### Update secrets
 
-Update the `.env` file with your own secrets. In particular, these are required:
+Update the `./docker/.env` file with your own secrets. In particular, these are required:
 
 - `POSTGRES_PASSWORD`: the password for the `postgres` role.
 - `JWT_SECRET`: used by PostgREST and GoTrue, among others.
@@ -162,12 +203,12 @@ You will need to [restart](#restarting-all-services) the services for the change
 
 ### Dashboard authentication
 
-The dashboard is protected with Basic Authentication. The default user and password MUST be updated before using Supabase in production.
-Update the following values in the `.env` file:
+The Dashboard is protected with basic authentication. The default user and password MUST be updated before using Supabase in production.
+Update the following values in the `./docker/.env` file:
  - `DASHBOARD_USERNAME`: The default username for the Dashboard
  - `DASHBOARD_PASSWORD`: The default password for the Dashboard
 
-You can also add more credentials in `./docker/volumes/api/kong.yml`. For example:
+You can also add more credentials for multiple users in `./docker/volumes/api/kong.yml`. For example:
 
 ```yaml docker/volumes/api/kong.yml
 basicauth_credentials:
@@ -254,7 +295,7 @@ If the tool doesn't exist, we build and open source it ourselves.
 - [PostgreSQL](https://www.postgresql.org/) is an object-relational database system with over 30 years of active development that has earned it a strong reputation for reliability, feature robustness, and performance.
 - [Supavisor](https://github.com/supabase/supavisor) is a scalable connection pooler for Postgres, allowing for efficient management of database connections.
 
-For the system to work cohesively, some services require additional configuration within the Postgres database. For example, the APIs and Auth system require several [default roles](/docs/guides/database/postgres/roles) and the `pgjwt` Postgres extension. 
+For the system to work cohesively, some services require additional configuration within the Postgres database. For example, the APIs and Auth system require several [default roles](/docs/guides/database/postgres/roles) and the `pgjwt` Postgres extension.
 
 You can find all the default extensions inside the [schema migration scripts repo](https://github.com/supabase/postgres/tree/develop/migrations). These scripts are mounted at `/docker-entrypoint-initdb.d` to run automatically when starting the database container.
 
@@ -270,7 +311,7 @@ Each system has a number of configuration options which can be found in the rele
 - [Kong](https://docs.konghq.com/gateway/latest/install/docker/)
 - [Supavisor](https://supabase.github.io/supavisor/development/docs/)
 
- These configuration items are generally added to the `env` section of each service, inside the `docker-compose.yml` section. If these configuration items are sensitive, they should be stored in a [secret manager](/docs/guides/self-hosting#managing-your-secrets) or using an `.env` file and then referenced using the `${}` syntax. 
+ These configuration items are generally added to the `env` section of each service, inside the `docker-compose.yml` section. If these configuration items are sensitive, they should be stored in a [secret manager](/docs/guides/self-hosting#managing-your-secrets) or using an `.env` file and then referenced using the `${}` syntax.
 
 
 <CH.Code>
@@ -294,7 +335,7 @@ services:
 
 Each system can be [configured](../self-hosting#configuration) independently. Some of the most common configuration options are listed below.
 
-#### Configuring an email server 
+#### Configuring an email server
 
 You will need to use a production-ready SMTP server for sending emails. You can configure the SMTP server by updating the following environment variables:
 
@@ -309,7 +350,7 @@ SMTP_SENDER_NAME=
 
 We recommend using [AWS SES](https://aws.amazon.com/ses/). It's extremely cheap and reliable. Restart all services to pick up the new configuration.
 
-#### Configuring S3 Storage 
+#### Configuring S3 Storage
 
 By default all files are stored locally on the server. You can configure the Storage service to use S3 by updating the following environment variables:
 
@@ -341,7 +382,7 @@ If you need direct access to the Postgres database without going through Supavis
 # Comment or remove the supavisor section of the docker-compose file
 #  supavisor:
 #    ports:
-# ...      
+# ...
   db:
     ports:
       - ${POSTGRES_PORT}:${POSTGRES_PORT}
@@ -394,6 +435,11 @@ A minimal setup working on Ubuntu, hosted on Digital Ocean.
     allowFullScreen
   ></iframe>
 </div>
+
+### Digital Ocean setup notes:
+1. A Digital Ocean Droplet with 1GB memory and 25GB SSD is sufficient to start
+2. To access the Dashboard, use the ipv4 IP address of your Droplet.
+3. If you're unable to access Dashboard, run `docker compose ps` to see if the Studio service is running and healthy.
 
 
 

--- a/apps/docs/content/guides/self-hosting/docker.mdx
+++ b/apps/docs/content/guides/self-hosting/docker.mdx
@@ -435,7 +435,7 @@ A minimal setup working on Ubuntu, hosted on Digital Ocean.
 </div>
 
 ### Demo using Digital Ocean
-1. A Digital Ocean Droplet with 1GB memory and 25GB SSD is sufficient to start
+1. A Digital Ocean Droplet with 1 GB memory and 25 GB solid-state drive (SSD) is sufficient to start
 2. To access the Dashboard, use the ipv4 IP address of your Droplet.
 3. If you're unable to access Dashboard, run `docker compose ps` to see if the Studio service is running and healthy.
 

--- a/apps/docs/content/guides/self-hosting/docker.mdx
+++ b/apps/docs/content/guides/self-hosting/docker.mdx
@@ -163,8 +163,6 @@ You'll want to update the Studio(Dashboard) frequently to get the latest feature
 3. Update the `image` field in the `docker-compose.yml` file to the new version. It should look like this: `image: supabase/studio:20241028-a265374`
 4. Run `docker compose pull` and then `docker compose up -d` to restart the service with the new version.
 
-
-
 ## Securing your services
 
 While we provided you with some example secrets for getting started, you should NEVER deploy your Supabase setup using the defaults we have provided. Please follow all of the steps in this section to ensure you have a secure setup, and then [restart all services](#restarting-all-services) to pick up the changes.

--- a/apps/studio/components/interfaces/SQLEditor/AiAssistantPanel/index.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/AiAssistantPanel/index.tsx
@@ -36,7 +36,6 @@ import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
 import OptInToOpenAIToggle from '../../Organization/GeneralSettings/OptInToOpenAIToggle'
 import { DiffType } from '../SQLEditor.types'
 import Message from './Message'
-import ReactMarkdown from 'react-markdown'
 
 export type MessageWithDebug = MessageType & { isDebug: boolean }
 
@@ -47,7 +46,6 @@ interface AiAssistantPanelProps {
   onDiff: ({ id, diffType, sql }: { id: string; diffType: DiffType; sql: string }) => void
   onClose: () => void
 }
-const openAiKey = process.env.OPENAI_API_KEY
 
 export const AiAssistantPanel = ({
   selectedMessage,
@@ -291,18 +289,6 @@ export const AiAssistantPanel = ({
         <div ref={bottomRef} className="h-1" />
       </div>
 
-      {!openAiKey && (
-        <div className="sticky p-5 flex-0 border-t">
-          <Alert_Shadcn_>
-            <AlertTitle_Shadcn_>OpenAI API key not found</AlertTitle_Shadcn_>
-            <AlertDescription_Shadcn_>
-              <ReactMarkdown>
-                Please set the `OPENAI_API_KEY` environment variable in your `config.toml` file.
-              </ReactMarkdown>
-            </AlertDescription_Shadcn_>
-          </Alert_Shadcn_>
-        </div>
-      )}
       <div className="sticky p-5 flex-0 border-t">
         <AssistantChatForm
           textAreaRef={inputRef}

--- a/apps/studio/components/interfaces/SQLEditor/AiAssistantPanel/index.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/AiAssistantPanel/index.tsx
@@ -36,6 +36,7 @@ import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
 import OptInToOpenAIToggle from '../../Organization/GeneralSettings/OptInToOpenAIToggle'
 import { DiffType } from '../SQLEditor.types'
 import Message from './Message'
+import ReactMarkdown from 'react-markdown'
 
 export type MessageWithDebug = MessageType & { isDebug: boolean }
 
@@ -46,6 +47,7 @@ interface AiAssistantPanelProps {
   onDiff: ({ id, diffType, sql }: { id: string; diffType: DiffType; sql: string }) => void
   onClose: () => void
 }
+const openAiKey = process.env.OPENAI_API_KEY
 
 export const AiAssistantPanel = ({
   selectedMessage,
@@ -289,6 +291,18 @@ export const AiAssistantPanel = ({
         <div ref={bottomRef} className="h-1" />
       </div>
 
+      {!openAiKey && (
+        <div className="sticky p-5 flex-0 border-t">
+          <Alert_Shadcn_>
+            <AlertTitle_Shadcn_>OpenAI API key not found</AlertTitle_Shadcn_>
+            <AlertDescription_Shadcn_>
+              <ReactMarkdown>
+                Please set the `OPENAI_API_KEY` environment variable in your `config.toml` file.
+              </ReactMarkdown>
+            </AlertDescription_Shadcn_>
+          </Alert_Shadcn_>
+        </div>
+      )}
       <div className="sticky p-5 flex-0 border-t">
         <AssistantChatForm
           textAreaRef={inputRef}


### PR DESCRIPTION
Updates to the self-hosting guide

1. added a table of contents:
2. added some more detail 
3. add "most common" to the Card in the overview page
4. more detail in the Securing / jwt section
5. attempted to make the JWT generator more user friendly (just language changes)
6. fleshed out "Updating services" section
7. Added some digital ocean specific notes that tripped me up