### PR TITLE
Fix standalone docker compose issues

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -241,7 +241,7 @@ services:
           "--no-verbose",
           "--tries=1",
           "--spider",
-          "http://localhost:5000/status"
+          "http://127.0.0.1:5000/status"
         ]
       timeout: 5s
       interval: 5s

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -383,6 +383,7 @@ services:
       - log_min_messages=fatal # prevents Realtime polling queries from appearing in logs
     restart: unless-stopped
     environment:
+      POSTGRES_USER: supabase_admin
       POSTGRES_HOST: /var/run/postgresql
       PGPORT: ${POSTGRES_PORT}
       POSTGRES_PORT: ${POSTGRES_PORT}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,7 +17,7 @@ services:
           "CMD",
           "node",
           "-e",
-          "require('http').get('http://localhost:3000/api/profile', (r) => {if (r.statusCode !== 200) throw new Error(r.statusCode)})"
+          "require('http').get('http://studio:3000/api/profile', (r) => {if (r.statusCode !== 200) throw new Error(r.statusCode)})"
         ]
       timeout: 5s
       interval: 5s


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix when running a local supabase with docker compose.

## What is the current behavior?

The health checks fail for multiple services (storage and studio).
The owner of the database is not supabase_admin that supabase requires.

## What is the new behavior?

The health checks work for multiple services (storage and studio), and the
owner of the database is supabase_admin.

## Additional context

It is an open question if the supabase/postgres should directly specify the supabase_admin user, or if it should be done in the docker compose file. I can remove that if not applicable.
