### PR TITLE
fix: fixes org usage summary

### DIFF
--- a/apps/studio/components/interfaces/Organization/BillingSettings/helpers.ts
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/helpers.ts
@@ -6,21 +6,21 @@ const pricingMetricBytes = [
   PricingMetric.STORAGE_SIZE,
 ]
 
+const pricingMetricNotHrs = [
+  PricingMetric.FUNCTION_INVOCATIONS,
+  PricingMetric.LOG_DRAIN_EVENTS,
+  PricingMetric.MONTHLY_ACTIVE_USERS,
+  PricingMetric.MONTHLY_ACTIVE_SSO_USERS,
+  PricingMetric.MONTHLY_ACTIVE_THIRD_PARTY_USERS,
+  PricingMetric.REALTIME_MESSAGE_COUNT,
+  PricingMetric.REALTIME_PEAK_CONNECTIONS,
+  PricingMetric.STORAGE_IMAGES_TRANSFORMED,
+]
+
 export const formatUsage = (
   pricingMetric: PricingMetric,
   allocation: { usage: number; hours?: number }
 ) => {
-  if (allocation.hours) {
-    return (
-      allocation.usage.toLocaleString() +
-      ' (' +
-      Math.round(allocation.usage / allocation.hours).toLocaleString() +
-      'x' +
-      allocation.hours.toLocaleString() +
-      ' hours)'
-    )
-  }
-
   if (pricingMetricBytes.includes(pricingMetric)) {
     const formattedUsage = +(allocation.usage / 1e9).toFixed(2).toLocaleString()
 
@@ -30,6 +30,17 @@ export const formatUsage = (
     } else {
       return formattedUsage
     }
+  }
+
+  if (allocation.hours && !pricingMetricNotHrs.includes(pricingMetric)) {
+    return (
+      allocation.usage.toLocaleString() +
+      ' (' +
+      Math.round(allocation.usage / allocation.hours).toLocaleString() +
+      'x' +
+      allocation.hours.toLocaleString() +
+      ' hours)'
+    )
   } else {
     return allocation.usage.toLocaleString()
   }


### PR DESCRIPTION
Org usage summary broke, now that Mgmt-API returns "hours" for all metrics (introduced [here](https://github.com/supabase/infrastructure/pull/20401)). It's not the most elegant fix but should do for now. I'm happy to do find a more elegant solution tomorrow morning.

**Beore GB vs Byte:**
<img width="842" alt="before-1" src="https://github.com/user-attachments/assets/79a3ff7d-fc83-4eb7-b168-939e5ab386d8">

**After GB vs Byte:**
<img width="1010" alt="after-1" src="https://github.com/user-attachments/assets/ffaea105-a097-4a04-b68e-bbb76f584e17">

**Before Metric not billed by hour:**
<img width="741" alt="before-2" src="https://github.com/user-attachments/assets/2e62b80a-f1c7-4735-817d-238d37370aad">

**After Metric not billed by hour:**
<img width="723" alt="after-2" src="https://github.com/user-attachments/assets/99770e00-2efe-4220-b1e9-c6eff053313b">
