### PR TITLE
chore: update consent banner

### DIFF
--- a/packages/ui-patterns/ConsentToast/index.tsx
+++ b/packages/ui-patterns/ConsentToast/index.tsx
@@ -12,6 +12,7 @@ import Link from 'next/link'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { Button, cn } from 'ui'
+import { PrivacySettings } from '../PrivacySettings'
 
 interface ConsentToastProps {
   onAccept: () => void
@@ -25,15 +26,17 @@ export const ConsentToast = ({ onAccept = noop, onOptOut = noop }: ConsentToastP
     <div className="py-1 flex flex-col gap-y-3 w-full">
       <div>
         <p className="text-sm text-foreground">
-          We use first-party cookies to improve our services.
+          We use{' '}
           <Link
-            className="inline sm:hidden underline text-light"
-            target="_blank"
-            rel="noreferrer"
-            href="https://supabase.com/privacy"
+            href="https://supabase.com/privacy#8-cookies-and-similar-technologies-used-on-our-european-services"
+            className="inline hover:underline"
           >
-            Learn more
-          </Link>
+            first-party cookies
+          </Link>{' '}
+          to improve our services.{' '}
+          <PrivacySettings className="inline sm:hidden underline text-light">
+            Privacy settings
+          </PrivacySettings>
         </p>
       </div>
       <div className="flex items-center space-x-2">
@@ -54,9 +57,7 @@ export const ConsentToast = ({ onAccept = noop, onOptOut = noop }: ConsentToastP
           Opt out
         </Button>
         <Button asChild type="text" className="hidden sm:block text-light hover:text-foreground">
-          <Link target="_blank" rel="noreferrer" href="https://supabase.com/privacy">
-            Learn more
-          </Link>
+          <PrivacySettings>Privacy settings</PrivacySettings>
         </Button>
       </div>
     </div>

--- a/packages/ui-patterns/ConsentToast/index.tsx
+++ b/packages/ui-patterns/ConsentToast/index.tsx
@@ -8,7 +8,6 @@ import {
   useTelemetryProps,
 } from 'common'
 import { noop } from 'lodash'
-import Link from 'next/link'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { Button, cn } from 'ui'
@@ -26,14 +25,15 @@ export const ConsentToast = ({ onAccept = noop, onOptOut = noop }: ConsentToastP
     <div className="py-1 flex flex-col gap-y-3 w-full">
       <div>
         <p className="text-sm text-foreground">
-          We use{' '}
-          <Link
+          We use first-party cookies to improve our services.{' '}
+          <a
+            target="_blank"
+            rel="noreferrer noopener"
             href="https://supabase.com/privacy#8-cookies-and-similar-technologies-used-on-our-european-services"
-            className="inline hover:underline"
+            className="underline underline-offset-2 decoration-foreground-lighter hover:decoration-foreground-light transition-all"
           >
-            first-party cookies
-          </Link>{' '}
-          to improve our services.{' '}
+            Learn more
+          </a>{' '}
           <PrivacySettings className="inline sm:hidden underline text-light">
             Privacy settings
           </PrivacySettings>

--- a/packages/ui-patterns/PrivacySettings/index.tsx
+++ b/packages/ui-patterns/PrivacySettings/index.tsx
@@ -93,7 +93,10 @@ export const PrivacySettings = ({
                 <>
                   By opting in to sending telemetry data, Supabase can improve the overall user
                   experience.{' '}
-                  <Link href="https://supabase.com/privacy" className="underline">
+                  <Link
+                    href="https://supabase.com/privacy#8-cookies-and-similar-technologies-used-on-our-european-services"
+                    className="underline"
+                  >
                     Learn more
                   </Link>
                 </>

--- a/packages/ui-patterns/PrivacySettings/index.tsx
+++ b/packages/ui-patterns/PrivacySettings/index.tsx
@@ -93,12 +93,14 @@ export const PrivacySettings = ({
                 <>
                   By opting in to sending telemetry data, Supabase can improve the overall user
                   experience.{' '}
-                  <Link
-                    href="https://supabase.com/privacy#8-cookies-and-similar-technologies-used-on-our-european-services"
+                  <a
+                    target="_blank"
+                    rel="noreferrer noopener"
                     className="underline"
+                    href="https://supabase.com/privacy#8-cookies-and-similar-technologies-used-on-our-european-services"
                   >
                     Learn more
-                  </Link>
+                  </a>
                 </>
               }
             />


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

- change learn more button to privacy settings
- link directly to cookies section of privacy page instead of privacy page generally for privacy settings and consent toast

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
