### PR TITLE
Add spam validation check in auth email templates

### DIFF
--- a/apps/studio/components/interfaces/Auth/EmailTemplates/EmailTemplates.tsx
+++ b/apps/studio/components/interfaces/Auth/EmailTemplates/EmailTemplates.tsx
@@ -67,11 +67,7 @@ const EmailTemplates = () => {
                       <EmailRateLimitsAlert />
                     </div>
                   ) : null}
-                  <TemplateEditor
-                    key={template.title}
-                    template={template}
-                    authConfig={authConfig as any}
-                  />
+                  <TemplateEditor key={template.title} template={template} />
                 </Tabs.Panel>
               )
             })}

--- a/apps/studio/components/interfaces/Auth/EmailTemplates/EmailTemplates.tsx
+++ b/apps/studio/components/interfaces/Auth/EmailTemplates/EmailTemplates.tsx
@@ -1,18 +1,12 @@
 import { ExternalLink } from 'lucide-react'
 
 import { useParams } from 'common'
+import AlertError from 'components/ui/AlertError'
 import { FormHeader } from 'components/ui/Forms/FormHeader'
 import { FormPanel } from 'components/ui/Forms/FormPanel'
 import { GenericSkeletonLoader } from 'components/ui/ShimmeringLoader'
 import { useAuthConfigQuery } from 'data/auth/auth-config-query'
-import {
-  AlertDescription_Shadcn_,
-  AlertTitle_Shadcn_,
-  Alert_Shadcn_,
-  Button,
-  Tabs,
-  WarningIcon,
-} from 'ui'
+import { Button, Tabs } from 'ui'
 import { TEMPLATES_SCHEMAS } from '../AuthTemplatesValidation'
 import EmailRateLimitsAlert from '../EmailRateLimitsAlert'
 import TemplateEditor from './TemplateEditor'
@@ -52,11 +46,7 @@ const EmailTemplates = () => {
         </div>
       </div>
       {isError && (
-        <Alert_Shadcn_ variant="destructive">
-          <WarningIcon />
-          <AlertTitle_Shadcn_>Failed to retrieve auth configuration</AlertTitle_Shadcn_>
-          <AlertDescription_Shadcn_>{authConfigError.message}</AlertDescription_Shadcn_>
-        </Alert_Shadcn_>
+        <AlertError error={authConfigError} subject="Failed to retrieve auth configuration" />
       )}
       {isLoading && <GenericSkeletonLoader />}
       {isSuccess && (

--- a/apps/studio/components/interfaces/Auth/EmailTemplates/SpamValidation.tsx
+++ b/apps/studio/components/interfaces/Auth/EmailTemplates/SpamValidation.tsx
@@ -3,75 +3,57 @@ import { Check } from 'lucide-react'
 import Table from 'components/to-be-cleaned/Table'
 import InformationBox from 'components/ui/InformationBox'
 import { ValidateSpamResponse } from 'data/auth/validate-spam-mutation'
-import { cn, CriticalIcon, WarningIcon } from 'ui'
+import { cn, WarningIcon } from 'ui'
 
 interface SpamValidationProps {
   validationResult?: ValidateSpamResponse
 }
 
-// [Joshen] Referring to this to understand SpamAssasin results:
-// https://www.mailercheck.com/articles/spamassassin-score#test
-// TLDR: A total score of above 5 is considered spam, ideal score is 0 - 2, everything in between is a warning
-// Any individual metric above 0 is considered to be a warning
+// [Joshen] According to API, we label as a spam risk as long as there are spam
+// rules identified with scores above 0. Scores are irrelevant in our context and
+// are hence not visualized in the UI
 
 export const SpamValidation = ({ validationResult }: SpamValidationProps) => {
-  const totalSpamScore = (validationResult?.rules ?? []).reduce((a, b) => a + b.score, 0)
-  const hasSpamWarning = totalSpamScore > 2
-  const exceedsThreshold = totalSpamScore >= 5
-  const sortedRules = (validationResult?.rules ?? []).sort((a, b) => b.score - a.score)
+  const spamRules = (validationResult?.rules ?? []).filter((rule) => rule.score > 0)
+  const hasSpamWarning = spamRules.length > 0
 
   return (
     <InformationBox
       className={cn('mb-2', hasSpamWarning && '!bg-alternative')}
-      icon={
-        exceedsThreshold ? (
-          <CriticalIcon />
-        ) : hasSpamWarning ? (
-          <WarningIcon />
-        ) : (
-          <Check size={16} className="text-brand" />
-        )
-      }
+      icon={hasSpamWarning ? <WarningIcon /> : <Check size={16} className="text-brand" />}
       title={
         hasSpamWarning
-          ? exceedsThreshold
-            ? 'Email content has been identified as spam and deliverability may be affected'
-            : 'Email has a high probability of being marked as spam and deliverability may be affected'
+          ? 'Email has a high probability of being marked as spam and deliverability may be affected'
           : 'Email content is unlikely to be marked as spam'
       }
       description={
-        <>
-          <p>
-            Spam score by SpamAssasin: <span className="text-foreground">{totalSpamScore}</span>
-          </p>
-          <p className="mt-1">
-            A score above 5 is considered spam, whereas an ideal score is 0 - 2. Higher scores
-            indicate the chances of your email landing in the spam folder.
-            {sortedRules.length > 0
-              ? hasSpamWarning
-                ? ` Rectify the following issues to improve your email's deliverability in order of priority:`
-                : ` Address the following issues to improve your email's deliverability:`
-              : ''}
-          </p>
+        hasSpamWarning ? (
+          <>
+            <p>
+              {spamRules.length > 0
+                ? hasSpamWarning
+                  ? ` Rectify the following issues to improve your email's deliverability in order of priority:`
+                  : ` Address the following issues to improve your email's deliverability:`
+                : ''}
+            </p>
 
-          {sortedRules.length > 0 && (
-            <Table
-              className="mt-3"
-              head={[
-                <Table.th key="score">Score</Table.th>,
-                <Table.th key="name">Description</Table.th>,
-                <Table.th key="desc"></Table.th>,
-              ]}
-              body={sortedRules.map((rule) => (
-                <Table.tr key={rule.name}>
-                  <Table.td className="tabular-nums">{rule.score}</Table.td>
-                  <Table.td>{rule.name}</Table.td>
-                  <Table.td>{rule.desc}</Table.td>
-                </Table.tr>
-              ))}
-            />
-          )}
-        </>
+            {spamRules.length > 0 && (
+              <Table
+                className="mt-3"
+                head={[
+                  <Table.th key="name">Warning</Table.th>,
+                  <Table.th key="desc">Description</Table.th>,
+                ]}
+                body={spamRules.map((rule) => (
+                  <Table.tr key={rule.name}>
+                    <Table.td>{rule.name}</Table.td>
+                    <Table.td>{rule.desc}</Table.td>
+                  </Table.tr>
+                ))}
+              />
+            )}
+          </>
+        ) : null
       }
     />
   )

--- a/apps/studio/components/interfaces/Auth/EmailTemplates/SpamValidation.tsx
+++ b/apps/studio/components/interfaces/Auth/EmailTemplates/SpamValidation.tsx
@@ -1,0 +1,67 @@
+import { Check } from 'lucide-react'
+
+import Table from 'components/to-be-cleaned/Table'
+import InformationBox from 'components/ui/InformationBox'
+import { ValidateSpamResponse } from 'data/auth/validate-spam-mutation'
+import { cn, WarningIcon } from 'ui'
+
+interface SpamValidationProps {
+  validationResult?: ValidateSpamResponse
+}
+
+// [Joshen] Referring to this to understand SpamAssasin results:
+// https://www.mailercheck.com/articles/spamassassin-score#test
+// TLDR: A total score of above 5 is considered spam, ideal score is 0 - 2
+// Any individual metric above 0 is a considered to be a warning
+
+export const SpamValidation = ({ validationResult }: SpamValidationProps) => {
+  const totalSpamScore = (validationResult?.rules ?? []).reduce((a, b) => a + b.score, 0)
+  const hasSpamWarning = totalSpamScore >= 5
+  const sortedRules = (validationResult?.rules ?? []).sort((a, b) => b.score - a.score)
+
+  return (
+    <InformationBox
+      className={cn('mb-2', hasSpamWarning && '!bg-alternative')}
+      icon={hasSpamWarning ? <WarningIcon /> : <Check size={16} className="text-brand" />}
+      title={
+        hasSpamWarning
+          ? 'Email content has been identified as spam and deliverability may be affected'
+          : 'Email content is unlikely to be marked as spam'
+      }
+      description={
+        <>
+          <p>
+            Spam score by SpamAssasin: <span className="text-foreground">{totalSpamScore}</span>
+          </p>
+          <p className="mt-1">
+            A score above 5 is considered spam, which results in a high probability that your email
+            will land in the spam folder.
+            {sortedRules.length > 0
+              ? hasSpamWarning
+                ? ` The following issues need to rectified to improve your email's deliverability in order or priority:`
+                : ` The following issues can be addressed to improve your email's deliverability:`
+              : ''}
+          </p>
+
+          {sortedRules.length > 0 && (
+            <Table
+              className="mt-3"
+              head={[
+                <Table.th key="score">Score</Table.th>,
+                <Table.th key="name">Description</Table.th>,
+                <Table.th key="desc"></Table.th>,
+              ]}
+              body={sortedRules.map((rule) => (
+                <Table.tr key={rule.name}>
+                  <Table.td className="tabular-nums">{rule.score}</Table.td>
+                  <Table.td>{rule.name}</Table.td>
+                  <Table.td>{rule.desc}</Table.td>
+                </Table.tr>
+              ))}
+            />
+          )}
+        </>
+      }
+    />
+  )
+}

--- a/apps/studio/components/interfaces/Auth/EmailTemplates/SpamValidation.tsx
+++ b/apps/studio/components/interfaces/Auth/EmailTemplates/SpamValidation.tsx
@@ -12,7 +12,7 @@ interface SpamValidationProps {
 // [Joshen] Referring to this to understand SpamAssasin results:
 // https://www.mailercheck.com/articles/spamassassin-score#test
 // TLDR: A total score of above 5 is considered spam, ideal score is 0 - 2
-// Any individual metric above 0 is a considered to be a warning
+// Any individual metric above 0 is considered to be a warning
 
 export const SpamValidation = ({ validationResult }: SpamValidationProps) => {
   const totalSpamScore = (validationResult?.rules ?? []).reduce((a, b) => a + b.score, 0)

--- a/apps/studio/components/ui/CodeEditor/CodeEditor.tsx
+++ b/apps/studio/components/ui/CodeEditor/CodeEditor.tsx
@@ -4,13 +4,12 @@ import { editor } from 'monaco-editor'
 import { MutableRefObject, useEffect, useRef, useState } from 'react'
 
 import { Markdown } from 'components/interfaces/Markdown'
+import { formatQuery } from 'data/sql/format-sql-query'
+import { useSelectedProject } from 'hooks/misc/useSelectedProject'
 import { timeout } from 'lib/helpers'
 import { cn } from 'ui'
 import { Loading } from '../Loading'
 import { alignEditor } from './CodeEditor.utils'
-import { useSelectedProject } from 'hooks/misc/useSelectedProject'
-import { formatQuery } from 'data/sql/format-sql-query'
-import { useIsDatabaseFunctionsAssistantEnabled } from 'components/interfaces/App/FeaturePreview/FeaturePreviewContext'
 
 type CodeEditorActions = { enabled: boolean; callback: (value: any) => void }
 const DEFAULT_ACTIONS = {

--- a/apps/studio/data/auth/validate-spam-mutation.ts
+++ b/apps/studio/data/auth/validate-spam-mutation.ts
@@ -1,0 +1,51 @@
+import { useMutation, UseMutationOptions } from '@tanstack/react-query'
+import { toast } from 'sonner'
+
+import type { components } from 'data/api'
+import { handleError, post } from 'data/fetchers'
+import type { ResponseError } from 'types'
+
+export type ValidateSpamVariables = {
+  projectRef: string
+  template: components['schemas']['ValidateSpamBody']
+}
+export type ValidateSpamResponse = components['schemas']['ValidateSpamResponse']
+
+export async function validateSpam({ projectRef, template }: ValidateSpamVariables) {
+  const { data, error } = await post('/platform/auth/{ref}/validate/spam', {
+    // @ts-expect-error API doesnt have the param check cause it's not being used in the controller
+    params: { path: { ref: projectRef } },
+    body: template,
+  })
+
+  if (error) handleError(error)
+  return data
+}
+
+type ValidateSpamData = Awaited<ReturnType<typeof validateSpam>>
+
+export const useValidateSpamMutation = ({
+  onSuccess,
+  onError,
+  ...options
+}: Omit<
+  UseMutationOptions<ValidateSpamData, ResponseError, ValidateSpamVariables>,
+  'mutationFn'
+> = {}) => {
+  return useMutation<ValidateSpamData, ResponseError, ValidateSpamVariables>(
+    (vars) => validateSpam(vars),
+    {
+      async onSuccess(data, variables, context) {
+        await onSuccess?.(data, variables, context)
+      },
+      async onError(data, variables, context) {
+        if (onError === undefined) {
+          toast.error(`Failed to validate template: ${data.message}`)
+        } else {
+          onError(data, variables, context)
+        }
+      },
+      ...options,
+    }
+  )
+}

--- a/packages/api-types/types/api.d.ts
+++ b/packages/api-types/types/api.d.ts
@@ -145,6 +145,10 @@ export interface paths {
     /** Delete all factors associated to a user */
     delete: operations['FactorsController_deleteFactors']
   }
+  '/platform/auth/{ref}/validate/spam': {
+    /** Validate spam based on the given email content */
+    post: operations['ValidateController_validateSpam']
+  }
   '/platform/cli/login': {
     /** Create CLI login session */
     post: operations['CliLoginController_createCliLoginSession']
@@ -1345,6 +1349,10 @@ export interface paths {
   '/v0/auth/{ref}/users/{id}/factors': {
     /** Delete all factors associated to a user */
     delete: operations['FactorsController_deleteFactors']
+  }
+  '/v0/auth/{ref}/validate/spam': {
+    /** Validate spam based on the given email content */
+    post: operations['ValidateController_validateSpam']
   }
   '/v0/database/{ref}/backups': {
     /** Gets project backups */
@@ -6777,6 +6785,18 @@ export interface components {
     ValidateQueryResponse: {
       valid: boolean
     }
+    ValidateSpamBody: {
+      content: string
+      subject: string
+    }
+    ValidateSpamResponse: {
+      rules: components['schemas']['ValidateSpamRule'][]
+    }
+    ValidateSpamRule: {
+      desc: string
+      name: string
+      score: number
+    }
     ValidationError: {
       message: string
     }
@@ -7481,6 +7501,28 @@ export interface operations {
         content: never
       }
       /** @description Failed to delete factors */
+      500: {
+        content: never
+      }
+    }
+  }
+  /** Validate spam based on the given email content */
+  ValidateController_validateSpam: {
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['ValidateSpamBody']
+      }
+    }
+    responses: {
+      200: {
+        content: {
+          'application/json': components['schemas']['ValidateSpamResponse']
+        }
+      }
+      403: {
+        content: never
+      }
+      /** @description Failed to validate spam based on the given email content */
       500: {
         content: never
       }

--- a/packages/ui/src/components/StatusIcon.tsx
+++ b/packages/ui/src/components/StatusIcon.tsx
@@ -1,5 +1,6 @@
 import { SVGProps, forwardRef } from 'react'
 import { cn } from '../lib/utils'
+import { Check } from 'lucide-react'
 
 export interface StatusIconProps {
   hideBackground?: boolean


### PR DESCRIPTION
Related API PR: https://github.com/supabase/infrastructure/pull/20234

Adds a spam validation check in the auth email templates page. We're using SpamAssassin for the check
- Show risk of spam if > 1 spam rule with score > 0 is returned
- Prevent saving if > 1 spam rule with score > 0 is returned while using built in email service

Validation check happens on 2 events
- Debounce after 1s when editing content
- When going between templates

Example spam detected:
![image](https://github.com/user-attachments/assets/2ac36d62-c1cb-41b4-99c4-e4736c9e4689)

Example spam not detected:
![image](https://github.com/user-attachments/assets/ae251749-befc-4ae7-899f-244c1fb20a34)


