### PR TITLE
Smol tweak to consent toast on mobile

### DIFF
--- a/apps/studio/data/telemetry/send-event-mutation.ts
+++ b/apps/studio/data/telemetry/send-event-mutation.ts
@@ -1,9 +1,8 @@
 import { useMutation, UseMutationOptions } from '@tanstack/react-query'
 import { components } from 'api-types'
 
-import { isBrowser } from 'common'
+import { isBrowser, LOCAL_STORAGE_KEYS } from 'common'
 import { handleError, post } from 'data/fetchers'
-import { LOCAL_STORAGE_KEYS } from 'lib/constants'
 import { useRouter } from 'next/router'
 import type { ResponseError } from 'types'
 

--- a/apps/studio/data/telemetry/send-groups-identify-mutation.ts
+++ b/apps/studio/data/telemetry/send-groups-identify-mutation.ts
@@ -1,8 +1,8 @@
 import { useMutation, UseMutationOptions } from '@tanstack/react-query'
 
 import { components } from 'api-types'
+import { LOCAL_STORAGE_KEYS } from 'common'
 import { handleError, post } from 'data/fetchers'
-import { LOCAL_STORAGE_KEYS } from 'lib/constants'
 import type { ResponseError } from 'types'
 
 export type SendGroupsIdentifyVariables = components['schemas']['TelemetryGroupsIdentityBody']

--- a/apps/studio/data/telemetry/send-groups-reset-mutation.ts
+++ b/apps/studio/data/telemetry/send-groups-reset-mutation.ts
@@ -1,8 +1,8 @@
 import { useMutation, UseMutationOptions } from '@tanstack/react-query'
 
 import { components } from 'api-types'
+import { LOCAL_STORAGE_KEYS } from 'common'
 import { handleError, post } from 'data/fetchers'
-import { LOCAL_STORAGE_KEYS } from 'lib/constants'
 import type { ResponseError } from 'types'
 
 export type SendGroupsResetVariables = components['schemas']['TelemetryGroupsResetBody']

--- a/apps/studio/data/telemetry/send-identify-mutation.ts
+++ b/apps/studio/data/telemetry/send-identify-mutation.ts
@@ -1,9 +1,9 @@
 import { useMutation, UseMutationOptions } from '@tanstack/react-query'
 
 import { components } from 'api-types'
+import { LOCAL_STORAGE_KEYS } from 'common'
 import { handleError, post } from 'data/fetchers'
 import { Profile } from 'data/profile/types'
-import { LOCAL_STORAGE_KEYS } from 'lib/constants'
 import type { ResponseError } from 'types'
 
 type SendIdentify = components['schemas']['TelemetryIdentifyBodyV2']

--- a/apps/studio/data/telemetry/send-page-leave-mutation.ts
+++ b/apps/studio/data/telemetry/send-page-leave-mutation.ts
@@ -1,8 +1,8 @@
 import { useMutation, UseMutationOptions } from '@tanstack/react-query'
 import { components } from 'api-types'
 
+import { LOCAL_STORAGE_KEYS } from 'common'
 import { handleError, post } from 'data/fetchers'
-import { LOCAL_STORAGE_KEYS } from 'lib/constants'
 import { useRouter } from 'next/router'
 import type { ResponseError } from 'types'
 

--- a/apps/studio/data/telemetry/send-page-mutation.ts
+++ b/apps/studio/data/telemetry/send-page-mutation.ts
@@ -1,9 +1,8 @@
 import { useMutation, UseMutationOptions } from '@tanstack/react-query'
 
 import { components } from 'api-types'
-import { isBrowser } from 'common'
+import { isBrowser, LOCAL_STORAGE_KEYS } from 'common'
 import { handleError, post } from 'data/fetchers'
-import { LOCAL_STORAGE_KEYS } from 'lib/constants'
 import { useRouter } from 'next/router'
 import type { ResponseError } from 'types'
 

--- a/apps/studio/lib/constants/index.ts
+++ b/apps/studio/lib/constants/index.ts
@@ -29,7 +29,6 @@ export const USAGE_APPROACHING_THRESHOLD = 0.75
 
 export const LOCAL_STORAGE_KEYS = {
   RECENTLY_VISITED_ORGANIZATION: 'supabase-organization',
-  TELEMETRY_CONSENT: 'supabase-consent-ph',
 
   UI_PREVIEW_NAVIGATION_LAYOUT: 'supabase-ui-preview-nav-layout',
   UI_PREVIEW_API_SIDE_PANEL: 'supabase-ui-api-side-panel',

--- a/apps/studio/lib/local-storage.ts
+++ b/apps/studio/lib/local-storage.ts
@@ -1,4 +1,5 @@
 import { LOCAL_STORAGE_KEYS } from 'lib/constants'
+import { LOCAL_STORAGE_KEYS as COMMON_LOCAL_STORAGE_KEYS } from 'common'
 
 const LOCAL_STORAGE_KEYS_ALLOWLIST = [
   'graphiql:theme',
@@ -6,7 +7,7 @@ const LOCAL_STORAGE_KEYS_ALLOWLIST = [
   'supabaseDarkMode',
   'supabase.dashboard.auth.debug',
   'supabase.dashboard.auth.navigatorLock.disabled',
-  LOCAL_STORAGE_KEYS.TELEMETRY_CONSENT,
+  COMMON_LOCAL_STORAGE_KEYS.TELEMETRY_CONSENT,
   LOCAL_STORAGE_KEYS.UI_PREVIEW_API_SIDE_PANEL,
   LOCAL_STORAGE_KEYS.UI_PREVIEW_NAVIGATION_LAYOUT,
   LOCAL_STORAGE_KEYS.UI_PREVIEW_CLS,

--- a/apps/studio/pages/_app.tsx
+++ b/apps/studio/pages/_app.tsx
@@ -106,6 +106,14 @@ function CustomApp({ Component, pageProps }: AppPropsWithLayout) {
     [supabase]
   )
 
+  const TelemetryContainer = useMemo(
+    // eslint-disable-next-line react/display-name
+    () => (props: any) => {
+      return IS_PLATFORM ? <PageTelemetry>{props.children}</PageTelemetry> : <>{props.children}</>
+    },
+    []
+  )
+
   const errorBoundaryHandler = (error: Error, info: ErrorInfo) => {
     Sentry.withScope(function (scope) {
       scope.setTag('globalErrorBoundary', true)
@@ -131,7 +139,7 @@ function CustomApp({ Component, pageProps }: AppPropsWithLayout) {
                   <meta name="viewport" content="initial-scale=1.0, width=device-width" />
                 </Head>
                 <MetaFaviconsPagesRouter applicationName="Supabase Studio" />
-                <PageTelemetry>
+                <TelemetryContainer>
                   <TooltipProvider>
                     <RouteValidationWrapper>
                       <ThemeProvider
@@ -157,7 +165,7 @@ function CustomApp({ Component, pageProps }: AppPropsWithLayout) {
                       </ThemeProvider>
                     </RouteValidationWrapper>
                   </TooltipProvider>
-                </PageTelemetry>
+                </TelemetryContainer>
 
                 {!isTestEnv && <HCaptchaLoadedStore />}
                 {!isTestEnv && <ReactQueryDevtools initialIsOpen={false} position="bottom-right" />}

--- a/apps/studio/state/app-state.ts
+++ b/apps/studio/state/app-state.ts
@@ -1,6 +1,8 @@
+import { proxy, snapshot, useSnapshot } from 'valtio'
+
 import { SupportedAssistantEntities } from 'components/ui/AIAssistantPanel/AIAssistant.types'
 import { LOCAL_STORAGE_KEYS } from 'lib/constants'
-import { proxy, snapshot, useSnapshot } from 'valtio'
+import { LOCAL_STORAGE_KEYS as COMMON_LOCAL_STORAGE_KEYS } from 'common'
 
 const EMPTY_DASHBOARD_HISTORY: {
   sql?: string
@@ -56,7 +58,7 @@ export const appState = proxy({
   setIsOptedInTelemetry: (value: boolean | null) => {
     appState.isOptedInTelemetry = value === null ? false : value
     if (typeof window !== 'undefined' && value !== null) {
-      localStorage.setItem(LOCAL_STORAGE_KEYS.TELEMETRY_CONSENT, value.toString())
+      localStorage.setItem(COMMON_LOCAL_STORAGE_KEYS.TELEMETRY_CONSENT, value.toString())
     }
   },
   showEnableBranchingModal: false,

--- a/packages/ui-patterns/ConsentToast/index.tsx
+++ b/packages/ui-patterns/ConsentToast/index.tsx
@@ -30,7 +30,7 @@ export const ConsentToast = ({ onAccept = noop, onOptOut = noop }: ConsentToastP
             target="_blank"
             rel="noreferrer noopener"
             href="https://supabase.com/privacy#8-cookies-and-similar-technologies-used-on-our-european-services"
-            className="hidden sm:block underline underline-offset-2 decoration-foreground-lighter hover:decoration-foreground-light transition-all"
+            className="hidden sm:inline underline underline-offset-2 decoration-foreground-lighter hover:decoration-foreground-light transition-all"
           >
             Learn more
           </a>{' '}

--- a/packages/ui-patterns/ConsentToast/index.tsx
+++ b/packages/ui-patterns/ConsentToast/index.tsx
@@ -30,15 +30,27 @@ export const ConsentToast = ({ onAccept = noop, onOptOut = noop }: ConsentToastP
             target="_blank"
             rel="noreferrer noopener"
             href="https://supabase.com/privacy#8-cookies-and-similar-technologies-used-on-our-european-services"
-            className="underline underline-offset-2 decoration-foreground-lighter hover:decoration-foreground-light transition-all"
+            className="hidden sm:block underline underline-offset-2 decoration-foreground-lighter hover:decoration-foreground-light transition-all"
           >
             Learn more
           </a>{' '}
-          <PrivacySettings className="inline sm:hidden underline text-light">
+        </p>
+        <div className="flex items-center justify-start gap-x-2 sm:hidden">
+          <a
+            target="_blank"
+            rel="noreferrer noopener"
+            href="https://supabase.com/privacy#8-cookies-and-similar-technologies-used-on-our-european-services"
+            className="underline underline-offset-2 text-foreground-light hover:decoration-foreground-light transition-all"
+          >
+            Learn more
+          </a>
+          <span className="text-foreground-lighter text-xs">•</span>
+          <PrivacySettings className="underline underline-offset-2 inline text-light">
             Privacy settings
           </PrivacySettings>
-        </p>
+        </div>
       </div>
+
       <div className="flex items-center space-x-2">
         <Button
           type="default"

--- a/packages/ui-patterns/ConsentToast/index.tsx
+++ b/packages/ui-patterns/ConsentToast/index.tsx
@@ -128,11 +128,9 @@ export const useConsent = () => {
   }, [])
 
   useEffect(() => {
-    if (isBrowser) {
-      setTimeout(() => {
-        consentValue === null && triggerConsentToast()
-      }, 300)
-    }
+    setTimeout(() => {
+      consentValue === null && triggerConsentToast()
+    }, 300)
   }, [consentValue])
 
   return {

--- a/packages/ui-patterns/ConsentToast/index.tsx
+++ b/packages/ui-patterns/ConsentToast/index.tsx
@@ -128,9 +128,11 @@ export const useConsent = () => {
   }, [])
 
   useEffect(() => {
-    setTimeout(() => {
-      consentValue === null && triggerConsentToast()
-    }, 300)
+    if (isBrowser) {
+      setTimeout(() => {
+        consentValue === null && triggerConsentToast()
+      }, 300)
+    }
   }, [consentValue])
 
   return {


### PR DESCRIPTION
@pamelachia has approved hahaha

Before:
![image](https://github.com/user-attachments/assets/3ed08531-d3ac-4dd1-af9d-3827cf8eab04)

After:
![image](https://github.com/user-attachments/assets/c43cdb3a-14e3-48e7-8388-f8821aadfe17)

Also a couple of refactors:
- Removed manual calling of ConsentToast in dashboard, use `useConsent` hook just like www and docs so its all synced up now
- Removed dupe declaration of local storage key for telemetry, `common` to be only source of truth
- Have verified locally that opting in / out + updating in telemetry preference in account preferences still works
