### PR TITLE
Chore/self hosted assistant disabled

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/AiAssistantPanel/index.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/AiAssistantPanel/index.tsx
@@ -325,7 +325,7 @@ export const AiAssistantPanel = ({
         <AssistantChatForm
           textAreaRef={inputRef}
           loading={isLoading}
-          disabled={isLoading || isApiKeySet}
+          disabled={isLoading || !isApiKeySet}
           icon={
             <AiIconAnimation
               allowHoverEffect

--- a/apps/studio/components/interfaces/SQLEditor/AiAssistantPanel/index.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/AiAssistantPanel/index.tsx
@@ -9,6 +9,7 @@ import { Message as MessageType } from 'ai'
 import { useChat } from 'ai/react'
 import { useParams } from 'common'
 import { IS_PLATFORM } from 'common/constants/environment'
+import { Markdown } from 'components/interfaces/Markdown'
 import { SchemaComboBox } from 'components/ui/SchemaComboBox'
 import { useCheckOpenAIKeyQuery } from 'data/ai/check-api-key-query'
 import { useEntityDefinitionsQuery } from 'data/database/entity-definitions-query'
@@ -22,7 +23,6 @@ import { useSelectedProject } from 'hooks/misc/useSelectedProject'
 import { BASE_PATH, LOCAL_STORAGE_KEYS, OPT_IN_TAGS } from 'lib/constants'
 import { useProfile } from 'lib/profile'
 import uuidv4 from 'lib/uuid'
-import ReactMarkdown from 'react-markdown'
 import {
   AiIconAnimation,
   Alert_Shadcn_,
@@ -301,11 +301,13 @@ export const AiAssistantPanel = ({
           <Alert>
             <AlertTitle>OpenAI API key not set</AlertTitle>
             <AlertDescription>
-              <ReactMarkdown>
-                {IS_PLATFORM
-                  ? 'AI Assistant will not be able to reply to prompts'
-                  : 'Add your `OPENAI_API_KEY` to `./docker/.env` to use the AI Assistant.'}
-              </ReactMarkdown>
+              <Markdown
+                content={
+                  IS_PLATFORM
+                    ? 'AI Assistant will not be able to reply to prompts'
+                    : 'Add your `OPENAI_API_KEY` to `./docker/.env` to use the AI Assistant.'
+                }
+              />
             </AlertDescription>
           </Alert>
         )}

--- a/apps/studio/components/interfaces/SQLEditor/AiAssistantPanel/index.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/AiAssistantPanel/index.tsx
@@ -78,7 +78,7 @@ export const AiAssistantPanel = ({
     selectedOrganization && !includeSchemaMetadata && showAiNotOptimizedWarningSetting
 
   const { data: check } = useCheckOpenAIKeyQuery()
-  const isApiKeySet = !!check?.hasKey
+  const isApiKeySet = IS_PLATFORM || !!check?.hasKey
 
   const { data } = useEntityDefinitionsQuery(
     {
@@ -302,11 +302,7 @@ export const AiAssistantPanel = ({
             <AlertTitle>OpenAI API key not set</AlertTitle>
             <AlertDescription>
               <Markdown
-                content={
-                  IS_PLATFORM
-                    ? 'AI Assistant will not be able to reply to prompts'
-                    : 'Add your `OPENAI_API_KEY` to `./docker/.env` to use the AI Assistant.'
-                }
+                content={'Add your `OPENAI_API_KEY` to `./docker/.env` to use the AI Assistant.'}
               />
             </AlertDescription>
           </Alert>

--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
@@ -9,10 +9,13 @@ import { toast } from 'sonner'
 import type { Message as MessageType } from 'ai/react'
 import { useChat } from 'ai/react'
 import { useParams } from 'common'
+import { Markdown } from 'components/interfaces/Markdown'
 import OptInToOpenAIToggle from 'components/interfaces/Organization/GeneralSettings/OptInToOpenAIToggle'
 import { MessageWithDebug } from 'components/interfaces/SQLEditor/AiAssistantPanel'
 import { DiffType } from 'components/interfaces/SQLEditor/SQLEditor.types'
+import { useCheckOpenAIKeyQuery } from 'data/ai/check-api-key-query'
 import { useSqlDebugMutation } from 'data/ai/sql-debug-mutation'
+import { useEntityDefinitionQuery } from 'data/database/entity-definition-query'
 import { useEntityDefinitionsQuery } from 'data/database/entity-definitions-query'
 import { useOrganizationUpdateMutation } from 'data/organizations/organization-update-mutation'
 import { useSendEventMutation } from 'data/telemetry/send-event-mutation'
@@ -60,7 +63,6 @@ import { ContextBadge } from './ContextBadge'
 import { EntitiesDropdownMenu } from './EntitiesDropdownMenu'
 import { Message } from './Message'
 import { SchemasDropdownMenu } from './SchemasDropdownMenu'
-import { useEntityDefinitionQuery } from 'data/database/entity-definition-query'
 
 const ANIMATION_DURATION = 0.3
 
@@ -114,6 +116,9 @@ export const AIAssistant = ({
     selectedDatabaseEntity.length === 0 &&
     selectedSchemas.length === 0 &&
     selectedTables.length === 0
+
+  const { data: check } = useCheckOpenAIKeyQuery()
+  const isApiKeySet = !!check?.hasKey
 
   const { data: existingDefinition } = useEntityDefinitionQuery({
     id: entity?.id,
@@ -456,6 +461,21 @@ export const AIAssistant = ({
                   description="Give us a moment while we work on bringing the Assistant back online"
                 />
               )}
+              {!isApiKeySet && (
+                <Admonition
+                  type="warning"
+                  title="OpenAI API key not set"
+                  description={
+                    <Markdown
+                      content={
+                        IS_PLATFORM
+                          ? 'AI Assistant will not be able to reply to prompts'
+                          : 'Add your `OPENAI_API_KEY` to `./docker/.env` to use the AI Assistant.'
+                      }
+                    />
+                  }
+                />
+              )}
               <div className="w-full border rounded">
                 <div className="py-2 px-3 border-b flex gap-2 flex-wrap">
                   <DropdownMenu>
@@ -618,7 +638,7 @@ export const AIAssistant = ({
                     '[&>textarea]:rounded-none [&>textarea]:border-0 [&>textarea]:!outline-none [&>textarea]:!ring-offset-0 [&>textarea]:!ring-0'
                   )}
                   loading={isLoading}
-                  disabled={disablePrompts || isLoading}
+                  disabled={!isApiKeySet || disablePrompts || isLoading}
                   placeholder={
                     hasMessages ? 'Reply to the assistant...' : 'How can we help you today?'
                   }
@@ -629,7 +649,7 @@ export const AIAssistant = ({
                     sendMessageToAssistant(value)
                   }}
                 />
-                {!hasMessages && (
+                {!hasMessages && IS_PLATFORM && (
                   <div className="text-xs text-foreground-lighter text-opacity-60 bg-control px-3 pb-2">
                     The Assistant is in Alpha and your prompts might be rate limited
                   </div>

--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
@@ -118,7 +118,7 @@ export const AIAssistant = ({
     selectedTables.length === 0
 
   const { data: check } = useCheckOpenAIKeyQuery()
-  const isApiKeySet = !!check?.hasKey
+  const isApiKeySet = IS_PLATFORM || !!check?.hasKey
 
   const { data: existingDefinition } = useEntityDefinitionQuery({
     id: entity?.id,
@@ -468,9 +468,7 @@ export const AIAssistant = ({
                   description={
                     <Markdown
                       content={
-                        IS_PLATFORM
-                          ? 'AI Assistant will not be able to reply to prompts'
-                          : 'Add your `OPENAI_API_KEY` to `./docker/.env` to use the AI Assistant.'
+                        'Add your `OPENAI_API_KEY` to `./docker/.env` to use the AI Assistant.'
                       }
                     />
                   }

--- a/apps/studio/data/ai/check-api-key-query.ts
+++ b/apps/studio/data/ai/check-api-key-query.ts
@@ -1,7 +1,7 @@
 import { useQuery, UseQueryOptions } from '@tanstack/react-query'
 
 import { get, isResponseOk } from 'lib/common/fetch'
-import { BASE_PATH } from 'lib/constants'
+import { BASE_PATH, IS_PLATFORM } from 'lib/constants'
 import { resourceKeys } from './keys'
 
 // check to see if the OPENAI_API_KEY env var is set in self-hosted
@@ -27,5 +27,5 @@ export const useCheckOpenAIKeyQuery = <TData = ResourceData>({
   useQuery<ResourceData, ResourceError, TData>(
     resourceKeys.apiKey(),
     ({ signal }) => checkOpenAIKey(signal),
-    options
+    { enabled: !IS_PLATFORM && enabled, ...options }
   )

--- a/apps/studio/data/ai/check-api-key-query.ts
+++ b/apps/studio/data/ai/check-api-key-query.ts
@@ -1,0 +1,31 @@
+import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+
+import { get, isResponseOk } from 'lib/common/fetch'
+import { BASE_PATH } from 'lib/constants'
+import { resourceKeys } from './keys'
+
+// check to see if the OPENAI_API_KEY env var is set in self-hosted
+// so we can disable the chat editor and add a warning about manually adding the key
+
+export async function checkOpenAIKey(signal?: AbortSignal) {
+  const response = await get(`${BASE_PATH}/api/ai/sql/check-api-key`, { signal })
+
+  if (!isResponseOk(response)) {
+    throw (response as any).error
+  }
+
+  return response as { hasKey: boolean }
+}
+
+export type ResourceData = Awaited<ReturnType<typeof checkOpenAIKey>>
+export type ResourceError = { errorEventId: string; message: string }
+
+export const useCheckOpenAIKeyQuery = <TData = ResourceData>({
+  enabled = true,
+  ...options
+}: UseQueryOptions<ResourceData, ResourceError, TData> = {}) =>
+  useQuery<ResourceData, ResourceError, TData>(
+    resourceKeys.apiKey(),
+    ({ signal }) => checkOpenAIKey(signal),
+    options
+  )

--- a/apps/studio/data/ai/keys.ts
+++ b/apps/studio/data/ai/keys.ts
@@ -1,0 +1,3 @@
+export const resourceKeys = {
+  apiKey: () => ['api-key'] as const,
+}

--- a/apps/studio/pages/api/ai/sql/check-api-key.ts
+++ b/apps/studio/pages/api/ai/sql/check-api-key.ts
@@ -1,0 +1,9 @@
+import { NextApiResponse } from 'next'
+
+export default function handler(res: NextApiResponse) {
+  if (process.env.OPENAI_API_KEY) {
+    res.status(200).send('OK')
+  } else {
+    res.status(401).send('API key not found')
+  }
+}

--- a/apps/studio/pages/api/ai/sql/check-api-key.ts
+++ b/apps/studio/pages/api/ai/sql/check-api-key.ts
@@ -1,9 +1,24 @@
-import { NextApiResponse } from 'next'
+import apiWrapper from 'lib/api/apiWrapper'
+import { NextApiRequest, NextApiResponse } from 'next'
 
-export default function handler(res: NextApiResponse) {
+export default (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)
+
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { method } = req
+
+  switch (method) {
+    case 'GET':
+      return handleGet(req, res)
+    default:
+      res.setHeader('Allow', ['POST'])
+      res.status(405).json({ data: null, error: { message: `Method ${method} Not Allowed` } })
+  }
+}
+
+const handleGet = async (req: NextApiRequest, res: NextApiResponse) => {
   if (process.env.OPENAI_API_KEY) {
-    res.status(200).send('OK')
+    return res.status(200).json({ hasKey: true })
   } else {
-    res.status(401).send('API key not found')
+    return res.status(404).json({ hasKey: false })
   }
 }


### PR DESCRIPTION
in self-hosted, if you don't have a OPENAI_API_KEY set, the assistant will look like it's working, but will just silently fail.

added an api route to check for the existence of the key, and an alert to notify if not present


![screenshot-2024-10-30-at-16 40 00](https://github.com/user-attachments/assets/d51dd14c-224a-481c-b202-ab9d00ac47ee)


