### PR TITLE
Fix community projects link

### DIFF
--- a/apps/docs/content/guides/self-hosting.mdx
+++ b/apps/docs/content/guides/self-hosting.mdx
@@ -38,7 +38,7 @@ There are several community-driven projects to help you deploy Supabase. We enco
 <div className="grid md:grid-cols-12 gap-4 not-prose">
   {community.map((x) => (
     <div className="md:col-span-6 xl:col-span-3" key={x.href}>
-      <Link href="https://supabase.com/pricing" passHref>
+      <Link href={x.href} passHref>
         <GlassPanel title={x.name}>{x.description}</GlassPanel>
       </Link>
     </div>


### PR DESCRIPTION
Currently, all the community projects are linked to Supabase's pricing.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

All the community projects are currently linking to Supabase's pricing page (changes made in #30167).

## What is the new behavior?

The community projects' block now links to the proper page.
