### PR TITLE
Update securing-your-api.mdx to fix  broken example

### DIFF
--- a/apps/docs/content/guides/api/securing-your-api.mdx
+++ b/apps/docs/content/guides/api/securing-your-api.mdx
@@ -292,8 +292,9 @@ create function public.check_request()
 declare
   req_app_api_key text := current_setting('request.headers', true)::json->>'x-app-api-key';
   is_app_api_key_registered boolean;
+  jwt_role text := current_setting('request.jwt.claims', true)::json->>'role';
 begin
-  if current_role <> 'anon' then
+  if jwt_role <> 'anon' then
     -- not `anon` role, allow the request to pass
     return;
   end if;
@@ -302,7 +303,7 @@ begin
     true into is_app_api_key_registered
   from private.anon_api_keys
   where
-    id = req_app_api_key
+    id = req_app_api_key::uuid
   limit 1;
 
   if is_app_api_key_registered is true then


### PR DESCRIPTION

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Doc Fix.

The example for checking additional API keys has a security flaw and bad code.

It checked current_role for anon to do security, but because it is a security definer function the role will never be anon.

Added to check for the role claim in the jwt.

Also the table used for keys is UUID and the type from the header is text for the key.  Cast it to UUID.

[Please link any relevant issues here.](https://supabase.com/docs/guides/api/securing-your-api?queryGroups=pre-request&pre-request=use-additional-api-key#examples)

## What is the new behavior?

See Above comments

## Additional context

![image](https://github.com/user-attachments/assets/1c5e29fa-a7fd-495e-ae0b-1b6d9f42c8bf)
