### PR TITLE
docs(auth): update password reset function name in PKCE flow

### DIFF
--- a/apps/docs/content/guides/auth/passwords.mdx
+++ b/apps/docs/content/guides/auth/passwords.mdx
@@ -844,7 +844,7 @@ app.get("/auth/confirm", async function (req, res) {
 <TabPanel id="js" label="JavaScript">
 
 ```js
-async function signUpNewUser() {
+async function resetPassword() {
   const { data, error } = await supabase.auth.resetPasswordForEmail(email)
 }
 ```


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

I was setting up password rest functionality and the wrong name of this function caught me off guard. Spent 5-10 minutes googling until I understand that I don't have to update `signUpNewUser` function, which is mentioned at the top of the page, by including auth `auth.resetPasswordForEmail()` functionality, but rather create a new separate function for this purpose.

## What is the new behavior?

Less confusion for the reader.

## Additional context
