### PR TITLE
fix: signal that Auth Helpers is deprecated

### DIFF
--- a/apps/docs/content/guides/auth/auth-helpers.mdx
+++ b/apps/docs/content/guides/auth/auth-helpers.mdx
@@ -6,7 +6,7 @@ sidebar_label: 'Overview'
 ---
 
 <Admonition type="caution">
-The Auth helpers package are deprecated. Use the new `@supabase/ssr` package for Server Side Authentication. `@supabase/ssr` takes the core concepts of the Auth Helpers package and makes them available to any server framework. Check out the [migration doc](/docs/guides/auth/server-side/migrating-to-ssr-from-auth-helpers) to learn more.
+The Auth helpers package is deprecated. Use the new `@supabase/ssr` package for Server Side Authentication. `@supabase/ssr` takes the core concepts of the Auth Helpers package and makes them available to any server framework. Check out the [migration doc](/docs/guides/auth/server-side/migrating-to-ssr-from-auth-helpers) to learn more.
 
 </Admonition>
 

--- a/apps/docs/content/guides/auth/auth-helpers.mdx
+++ b/apps/docs/content/guides/auth/auth-helpers.mdx
@@ -6,7 +6,7 @@ sidebar_label: 'Overview'
 ---
 
 <Admonition type="caution">
-The Auth helpers package is in maintenance mode and we won’t be actively improving it. We strongly recommend using the new `@supabase/ssr` package instead of `auth-helpers`. `@supabase/ssr` takes the core concepts of the Auth Helpers package and makes them available to any server framework. Check out the [migration doc](/docs/guides/auth/server-side/migrating-to-ssr-from-auth-helpers) to learn more.
+The Auth helpers package are deprecated. Use the new `@supabase/ssr` package for Server Side Authentication. `@supabase/ssr` takes the core concepts of the Auth Helpers package and makes them available to any server framework. Check out the [migration doc](/docs/guides/auth/server-side/migrating-to-ssr-from-auth-helpers) to learn more.
 
 </Admonition>
 

--- a/apps/docs/content/guides/auth/auth-helpers/nextjs.mdx
+++ b/apps/docs/content/guides/auth/auth-helpers/nextjs.mdx
@@ -8,7 +8,7 @@ sitemapPriority: 0.5
 
 <Admonition type="caution">
 
-The `auth-helpers` is now deprecated. Use `@supabase/ssr` to set up Auth for your Next.js app. See the [Next.js Server-Side Auth guide](/docs/guides/auth/server-side/nextjs) to learn how.
+The `auth-helpers` are now deprecated. Use `@supabase/ssr` to set up Auth for your Next.js app. See the [Next.js Server-Side Auth guide](/docs/guides/auth/server-side/nextjs) to learn how.
 
 </Admonition>
 

--- a/apps/docs/content/guides/auth/auth-helpers/nextjs.mdx
+++ b/apps/docs/content/guides/auth/auth-helpers/nextjs.mdx
@@ -8,7 +8,7 @@ sitemapPriority: 0.5
 
 <Admonition type="caution">
 
-The `auth-helpers` package has been replaced with the `@supabase/ssr` package. We recommend setting up Auth for your Next.js app with `@supabase/ssr` instead. See the [Next.js Server-Side Auth guide](/docs/guides/auth/server-side/nextjs) to learn how.
+The `auth-helpers` is now deprecated. Use `@supabase/ssr` to set up Auth for your Next.js app. See the [Next.js Server-Side Auth guide](/docs/guides/auth/server-side/nextjs) to learn how.
 
 </Admonition>
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Updates copy to signal more strongly that Auth Helpers are deprecated