### PR TITLE
studio: Change Reference ID to Project ID

### DIFF
--- a/apps/docs/content/guides/monitoring-troubleshooting/metrics.mdx
+++ b/apps/docs/content/guides/monitoring-troubleshooting/metrics.mdx
@@ -102,7 +102,7 @@ Supabase Grafana only tracks metrics while it's active. For monitoring historica
   <StepHikeCompact.Step step={3}>
 
     <StepHikeCompact.Details title="Add your credentials">
-        - To monitor a single project, add your service_role key from the [API Settings](https://supabase.com/dashboard/project/_/settings/api) and Reference ID from the [General Settings](https://supabase.com/dashboard/project/_/settings/general).
+        - To monitor a single project, add your service_role key from the [API Settings](https://supabase.com/dashboard/project/_/settings/api) and Project ID from the [General Settings](https://supabase.com/dashboard/project/_/settings/general).
         - To monitor multiple projects, create an [account access token](https://supabase.com/dashboard/account/tokens) and add it to your `.env` file.
 
     </StepHikeCompact.Details>
@@ -224,7 +224,7 @@ Supabase Grafana only tracks metrics while it's active. For monitoring historica
 
         <StepHikeCompact.Step step={5} >
     <StepHikeCompact.Details title="Add your credentials and deploy">
-        Add your service_role key from the [API Settings](https://supabase.com/dashboard/project/_/settings/api) and Reference ID from the [General Settings](https://supabase.com/dashboard/project/_/settings/general) to your Grafana credentials. Then install your dashboard.
+        Add your service_role key from the [API Settings](https://supabase.com/dashboard/project/_/settings/api) and Project ID from the [General Settings](https://supabase.com/dashboard/project/_/settings/general) to your Grafana credentials. Then install your dashboard.
     </StepHikeCompact.Details>
     <StepHikeCompact.Code>
         ![Add credentials](/docs/img/guides/platform/add-credentials-grafana.png)

--- a/apps/studio/components/interfaces/Settings/General/General.tsx
+++ b/apps/studio/components/interfaces/Settings/General/General.tsx
@@ -123,7 +123,7 @@ const General = () => {
                       label="Project name"
                       disabled={isBranch || !canUpdateProject}
                     />
-                    <Input copy disabled id="ref" size="small" label="Reference ID" />
+                    <Input copy disabled id="ref" size="small" label="Project ID" />
                   </FormSectionContent>
                 </FormSection>
               </FormPanel>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Supabase Studio > General Settings

## What is the current behavior?

Reference ID is being used but their is a lot of places where Project ID is being used.

## What is the new behavior?

Changed Reference ID to Project ID:

<img width="727" alt="Screenshot 2024-11-03 at 19 47 50" src="https://github.com/user-attachments/assets/027539de-6ec2-4182-9869-41a61e033526">


## Additional context

Closes #30130
