### PR TITLE
Fix https://supabase.sentry.io/issues/6037628167/

### DIFF
--- a/apps/studio/components/grid/SupabaseGrid.tsx
+++ b/apps/studio/components/grid/SupabaseGrid.tsx
@@ -254,7 +254,7 @@ const SupabaseGridLayout = (props: SupabaseGridProps) => {
         table={props.table}
         sorts={sorts}
         filters={filters}
-        onAddRow={editable ? onAddRow : undefined}
+        onAddRow={editable && (props.table.columns ?? []).length > 0 ? onAddRow : undefined}
         onAddColumn={editable ? onAddColumn : undefined}
         onImportData={editable ? onImportData : undefined}
         headerActions={headerActions}

--- a/apps/studio/components/grid/SupabaseGrid.utils.ts
+++ b/apps/studio/components/grid/SupabaseGrid.utils.ts
@@ -3,7 +3,6 @@ import AwesomeDebouncePromise from 'awesome-debounce-promise'
 import { compact } from 'lodash'
 
 import type { Filter } from 'components/grid/types'
-import { ForeignKeyConstraintsData } from 'data/database/foreign-key-constraints-query'
 import { ENTITY_TYPE } from 'data/entity-types/entity-type-constants'
 import { TableLike } from 'data/table-editor/table-editor-query'
 import type { Dictionary, SchemaView } from 'types'

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnForeignKey.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnForeignKey.tsx
@@ -116,13 +116,20 @@ const ColumnForeignKey = ({
           table={{
             id: table.id,
             name: table.name,
-            columns:
-              column.isNewColumn && column.name
-                ? (table.columns as any[]).concat(column)
-                : (table.columns as any[]).map((c) => {
-                    if (c.id === column.id) return { ...c, name: column.name }
-                    else return c
-                  }),
+            columns: (column.isNewColumn && column.name
+              ? (table.columns ?? []).concat(column as any)
+              : (table.columns ?? []).map((c) => {
+                  if (c.id === column.id) return { ...c, name: column.name }
+                  else return c
+                })
+            ).map((x) => {
+              return {
+                id: x.id,
+                name: x.name,
+                format: x.format,
+                isNewColumn: !!(x as unknown as ColumnField).isNewColumn,
+              }
+            }),
           }}
           foreignKey={selectedFk}
           onClose={() => {

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnForeignKey.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnForeignKey.tsx
@@ -47,6 +47,9 @@ const ColumnForeignKey = ({
     id,
   })
   const table = getTableLikeFromTableEditor(tableData)
+  const formattedColumnsForFkSelector = (table?.columns ?? []).map((c) => {
+    return { id: c.id, name: c.name, format: column.format, isNewColumn: false }
+  })
 
   const getRelationStatus = (fk: ForeignKey) => {
     const existingRelation = (data ?? []).find((x) => x.id === fk.id)
@@ -116,20 +119,13 @@ const ColumnForeignKey = ({
           table={{
             id: table.id,
             name: table.name,
-            columns: (column.isNewColumn && column.name
-              ? (table.columns ?? []).concat(column as any)
-              : (table.columns ?? []).map((c) => {
-                  if (c.id === column.id) return { ...c, name: column.name }
-                  else return c
-                })
-            ).map((x) => {
-              return {
-                id: x.id,
-                name: x.name,
-                format: x.format,
-                isNewColumn: !!(x as unknown as ColumnField).isNewColumn,
-              }
-            }),
+            columns:
+              column.isNewColumn && column.name
+                ? formattedColumnsForFkSelector.concat(column)
+                : formattedColumnsForFkSelector.map((c) => {
+                    if (c.id === column.id) return { ...c, name: column.name }
+                    else return c
+                  }),
           }}
           foreignKey={selectedFk}
           onClose={() => {

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.utils.ts
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.utils.ts
@@ -49,7 +49,7 @@ export const generateRowFields = (
   const { primary_keys } = table
   const primaryKeyColumns = primary_keys.map((key) => key.name)
 
-  return table.columns!.map((column) => {
+  return (table.columns ?? []).map((column) => {
     const value = getRowValue({ column, row })
     const foreignKey = foreignKeys.find((fk) => {
       return fk.columns.map((x) => x.source).includes(column.name)


### PR DESCRIPTION
- Reproduced by clicking "Add new row" on a table that has 0 columns
- If a table has 0 columns, postgrest returns the `columns` property as null instead of an empty array
- This caused generateRowFields to error out, also due to the unnecessary `!` parameter
- Hide Add new row action if table has 0 columns