### PR TITLE
Update sveltekit.mdx to use Svelte 5

### DIFF
--- a/apps/docs/content/guides/getting-started/quickstarts/sveltekit.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/sveltekit.mdx
@@ -106,7 +106,7 @@ hideToc: true
 
       ```svelte src/routes/+page.svelte
         <script>
-          export let data;
+          let { data } = $props();
         </script>
 
         <ul>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

SvelteKit integration docs up-to-date upgrade

## What is the current behavior?

- Docs are using Svelte 4

## What is the new behavior?

- Changed code to match Svelte 5 new correct syntax

## Additional context

The old docs code was using the `export let` syntax for props, however, since 5 is new latest version for Svelte, changed it to `let _ = $props()` syntax 
