### PR TITLE
Add resize info in postgres upgrade modal

### DIFF
--- a/apps/studio/components/interfaces/DiskManagement/DiskManagementPanelForm.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagementPanelForm.tsx
@@ -55,7 +55,6 @@ import {
   calculateIOPSPrice,
   calculateThroughputPrice,
 } from './DiskManagement.utils'
-import { getDiskStorageSchema } from './DiskManagementPanelSchema'
 import { DiskManagementReviewAndSubmitDialog } from './DiskManagementReviewAndSubmitDialog'
 import { BillingChangeBadge } from './ui/BillingChangeBadge'
 import { DiskCountdownRadial } from './ui/DiskCountdownRadial'
@@ -169,7 +168,6 @@ export function DiskManagementPanelForm() {
     totalSize: size_gb,
     computeSize: undefined,
   }
-  const DiskStorageSchema = getDiskStorageSchema(size_gb)
   const form = useForm<DiskStorageSchemaType>({
     resolver: zodResolver(CreateDiskStorageSchema(defaultValues.totalSize)),
     defaultValues,

--- a/apps/studio/components/interfaces/Settings/General/Infrastructure/ProjectUpgradeAlert/ProjectUpgradeAlert.tsx
+++ b/apps/studio/components/interfaces/Settings/General/Infrastructure/ProjectUpgradeAlert/ProjectUpgradeAlert.tsx
@@ -43,6 +43,7 @@ import { useDiskAttributesQuery } from 'data/config/disk-attributes-query'
 import { PLAN_DETAILS } from 'components/interfaces/DiskManagement/ui/DiskManagement.constants'
 import { useOrgSubscriptionQuery } from 'data/subscriptions/org-subscription-query'
 import { useSelectedOrganization } from 'hooks/misc/useSelectedOrganization'
+import { Markdown } from 'components/interfaces/Markdown'
 
 interface PostgresVersionDetails {
   postgresEngine: string
@@ -180,10 +181,12 @@ const ProjectUpgradeAlert = () => {
                   Postgres {currentPgVersion}.
                 </p>
                 {isDiskSizeUpdated && (
-                  <p className="text-sm">
-                    Your disk size will also be reverted back to {includedDiskGB}GB from{' '}
-                    {diskAttributes?.attributes.size_gb}GB with the upgrade.
-                  </p>
+                  <Markdown
+                    extLinks
+                    className="text-foreground"
+                    content={`Your current disk size of ${diskAttributes?.attributes.size_gb}GB will also be
+                    [right-sized](https://supabase.com/docs/guides/platform/upgrading#disk-sizing) with the upgrade.`}
+                  />
                 )}
                 {(data?.potential_breaking_changes ?? []).length > 0 && (
                   <Alert_Shadcn_ variant="destructive" title="Breaking changes">


### PR DESCRIPTION
To inform users that their disk will be resized back to the original value when they upgrade their postgres version

![image](https://github.com/user-attachments/assets/5ce3abef-1e9c-4528-9a44-5fceb8520e9b)

