### PR TITLE
Minor Typo `roject` -> `project`

### DIFF
--- a/apps/docs/content/guides/platform/upgrading.mdx
+++ b/apps/docs/content/guides/platform/upgrading.mdx
@@ -123,7 +123,7 @@ nix run 'github:supabase/postgres?ref=15.6.1.115#start-server' 15
 
 where `15` refers to the backup's Postgres major version.
 
-Note that the earliest Supabase Postgres version that supports a direct reference is `15.6.1.115`. If you don't know your roject's Postgres version or it is lower than `15.6.1.115` then omit the `ref` option to build our most recent image:
+Note that the earliest Supabase Postgres version that supports a direct reference is `15.6.1.115`. If you don't know your project's Postgres version or it is lower than `15.6.1.115` then omit the `ref` option to build our most recent image:
 
 ```sh
 nix run 'github:supabase/postgres#start-server' -- 15


### PR DESCRIPTION
Typo from `roject` to `project`