### PR TITLE
fix: update Supabase cron link in extensions

### DIFF
--- a/packages/shared-data/extensions.json
+++ b/packages/shared-data/extensions.json
@@ -231,7 +231,7 @@
     "link": "/guides/database/extensions/pg_cron",
     "github_url": "https://github.com/citusdata/pg_cron",
     "product": "Supabase Cron Jobs",
-    "product_url": "/project/{ref}/database/cron-jobs"
+    "product_url": "/project/{ref}/integrations/cron-jobs"
   },
   {
     "name": "pg_freespacemap",


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

fix

## What is the current behavior?

clicking "Supabase Cron Jobs" takes me to https://supabase.com/dashboard/project/_/database/cron-jobs which results in 404.

<img width="363" alt="Screenshot 2024-11-05 at 19 05 51" src="https://github.com/user-attachments/assets/959bd3b3-22cb-489e-8b0e-34928ce39f95">

## What is the new behavior?

clicking "Supabase Cron Jobs" takes me to https://supabase.com/dashboard/project/_/integrations/cron-jobs which is the correct page.