### PR TITLE
fix: table editor fallback to undefined

### DIFF
--- a/apps/studio/data/table-editor/table-editor-query.ts
+++ b/apps/studio/data/table-editor/table-editor-query.ts
@@ -33,7 +33,7 @@ export async function getTableEditor(
     signal
   )
 
-  return result[0]?.entity as Entity | undefined
+  return (result[0]?.entity ?? undefined) as Entity | undefined
 }
 
 export type TableEditorData = Awaited<ReturnType<typeof getTableEditor>>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

If you try and query something on the table editor that isn't a table like object (for example an index), the query returns `null` and errors out the dashboard.

## What is the new behavior?

Fallback to `undefined` in this case so the 404 screen is correctly shown