### PR TITLE
docs: add React example for TUS uploads to Supabase protected folders…

### DIFF
--- a/apps/docs/content/guides/storage/uploads/resumable-uploads.mdx
+++ b/apps/docs/content/guides/storage/uploads/resumable-uploads.mdx
@@ -80,6 +80,100 @@ Supabase Storage implements the [TUS protocol](https://tus.io/) to enable resuma
     ```
 
   </TabPanel>
+  <TabPanel id="react" label="React">
+
+    Here's an example of how to upload a file using `@uppy/tus` with react:
+
+    ```javascript
+    import { useEffect, useState } from "react";
+    import { createClient } from "@supabase/supabase-js";
+    import Uppy from "@uppy/core";
+    import Tus from "@uppy/tus";
+    import Dashboard from "@uppy/dashboard";
+    import "@uppy/core/dist/style.min.css";
+    import "@uppy/dashboard/dist/style.min.css";
+
+    function App() {
+        // Initialize Uppy instance with the 'sample' bucket specified for uploads
+        const uppy = useUppyWithSupabase({ bucketName: "sample" });
+
+        useEffect(() => {
+            // Set up Uppy Dashboard to display as an inline component within a specified target
+            uppy.use(Dashboard, {
+                inline: true, // Ensures the dashboard is rendered inline
+                target: "#drag-drop-area", // HTML element where the dashboard renders
+                showProgressDetails: true, // Show progress details for file uploads
+            });
+        }, []);
+
+        return (
+            <div id="drag-drop-area">
+            </div>
+            {/* Target element for the Uppy Dashboard */}
+        );
+    }
+
+    export default App;
+
+    /**
+     * Custom hook for configuring Uppy with Supabase authentication and TUS resumable uploads
+     * @param {Object} options - Configuration options for the Uppy instance.
+     * @param {string} options.bucketName - The bucket name in Supabase where files are stored.
+     * @returns {Object} uppy - Uppy instance with configured upload settings.
+     */
+    export const useUppyWithSupabase = ({ bucketName }: { bucketName: string }) => {
+        // Initialize Uppy instance only once
+        const [uppy] = useState(() => new Uppy());
+        // Initialize Supabase client with project URL and anon key
+        const supabase = createClient(projectURL, anonKey);
+
+        useEffect(() => {
+            const initializeUppy = async () => {
+            // Retrieve the current user's session for authentication
+            const {
+                data: { session },
+            } = await supabase.auth.getSession();
+
+            uppy.use(Tus, {
+                    endpoint: `${projectURL}/storage/v1/upload/resumable`, // Supabase TUS endpoint
+                    retryDelays: [0, 3000, 5000, 10000, 20000], // Retry delays for resumable uploads
+                    headers: {
+                        authorization: `Bearer ${session?.access_token}`, // User session access token
+                        apikey: anonKey, // API key for Supabase
+                    },
+                    uploadDataDuringCreation: true, // Send metadata with file chunks
+                    removeFingerprintOnSuccess: true, // Remove fingerprint after successful upload
+                    chunkSize: 6 * 1024 * 1024, // Chunk size for TUS uploads (6MB)
+                    allowedMetaFields: [
+                        "bucketName",
+                        "objectName",
+                        "contentType",
+                        "cacheControl",
+                    ], // Metadata fields allowed for the upload
+                    onError: (error) => console.error("Upload error:", error), // Error handling for uploads
+                }).on("file-added", (file) => {
+                    // Attach metadata to each file, including bucket name and content type
+                    file.meta = {
+                        ...file.meta,
+                        bucketName, // Bucket specified by the user of the hook
+                        objectName: file.name, // Use file name as object name
+                        contentType: file.type, // Set content type based on file MIME type
+                    };
+                });
+            };
+
+            // Initialize Uppy with Supabase settings
+            initializeUppy();
+        }, [uppy, bucketName]);
+
+        // Return the configured Uppy instance
+        return uppy;
+    };
+
+    ```
+
+  </TabPanel>
+  
   <TabPanel id="kotlin" label="Kotlin">
 
     Kotlin supports resumable uploads natively for all targets:


### PR DESCRIPTION
Previously, the documentation provided a general TUS upload overview but lacked instructions for protected folder uploads and examples using Uppy's React library. This update aims to fill that gap, offering a straightforward guide for users needing secure file uploads.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?
- Adds a React-specific example for performing TUS uploads to protected folders.
## What is the current behavior?

- #26773 
- The documentation currently lacks an example of using TUS uploads with React. While there is a general overview of TUS uploads

## What is the new behavior?
- after update there is a tab for React example for TUS upload using uppy.
<img height="400" alt="React uppy" src="https://github.com/user-attachments/assets/0403569c-9cbf-49b2-9d16-6d230e88db69">

