### PR TITLE
fix: Use protocol property when building API url

### DIFF
--- a/apps/studio/components/interfaces/App/CommandMenu/ApiUrl.tsx
+++ b/apps/studio/components/interfaces/App/CommandMenu/ApiUrl.tsx
@@ -17,9 +17,9 @@ export function useApiUrlCommand() {
     { enabled: !!project }
   )
 
-  const apiUrl = settings?.app_config?.endpoint
-    ? `https://${settings.app_config.endpoint}`
-    : undefined
+  const protocol = settings?.app_config?.protocol ?? 'https'
+  const endpoint = settings?.app_config?.endpoint
+  const apiUrl = endpoint ? `${protocol}://${endpoint}` : undefined
 
   useRegisterCommands(
     COMMAND_MENU_SECTIONS.ACTIONS,

--- a/apps/studio/components/interfaces/App/CommandMenu/ApiUrl.tsx
+++ b/apps/studio/components/interfaces/App/CommandMenu/ApiUrl.tsx
@@ -2,9 +2,7 @@ import { Link } from 'lucide-react'
 
 import { useProjectSettingsV2Query } from 'data/config/project-settings-v2-query'
 import { useSelectedProject } from 'hooks/misc/useSelectedProject'
-import { IS_PLATFORM } from 'lib/constants'
 import { copyToClipboard } from 'lib/helpers'
-import { PROJECT_ENDPOINT_PROTOCOL } from 'pages/api/constants'
 import { Badge } from 'ui'
 import { useRegisterCommands, useSetCommandMenuOpen } from 'ui-patterns/CommandMenu'
 import { COMMAND_MENU_SECTIONS } from './CommandMenu.utils'
@@ -19,7 +17,7 @@ export function useApiUrlCommand() {
     { enabled: !!project }
   )
 
-  const protocol = IS_PLATFORM ? 'https' : PROJECT_ENDPOINT_PROTOCOL
+  const protocol = settings?.app_config?.protocol ?? 'https'
   const endpoint = settings?.app_config?.endpoint
   const apiUrl = endpoint ? `${protocol}://${endpoint}` : undefined
 

--- a/apps/studio/components/interfaces/App/CommandMenu/ApiUrl.tsx
+++ b/apps/studio/components/interfaces/App/CommandMenu/ApiUrl.tsx
@@ -2,7 +2,9 @@ import { Link } from 'lucide-react'
 
 import { useProjectSettingsV2Query } from 'data/config/project-settings-v2-query'
 import { useSelectedProject } from 'hooks/misc/useSelectedProject'
+import { IS_PLATFORM } from 'lib/constants'
 import { copyToClipboard } from 'lib/helpers'
+import { PROJECT_ENDPOINT_PROTOCOL } from 'pages/api/constants'
 import { Badge } from 'ui'
 import { useRegisterCommands, useSetCommandMenuOpen } from 'ui-patterns/CommandMenu'
 import { COMMAND_MENU_SECTIONS } from './CommandMenu.utils'
@@ -17,7 +19,7 @@ export function useApiUrlCommand() {
     { enabled: !!project }
   )
 
-  const protocol = settings?.app_config?.protocol ?? 'https'
+  const protocol = IS_PLATFORM ? 'https' : PROJECT_ENDPOINT_PROTOCOL
   const endpoint = settings?.app_config?.endpoint
   const apiUrl = endpoint ? `${protocol}://${endpoint}` : undefined
 

--- a/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
@@ -13,8 +13,7 @@ import { useAuthConfigUpdateMutation } from 'data/auth/auth-config-update-mutati
 import { useProjectSettingsV2Query } from 'data/config/project-settings-v2-query'
 import { useCustomDomainsQuery } from 'data/custom-domains/custom-domains-query'
 import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
-import { BASE_PATH, IS_PLATFORM } from 'lib/constants'
-import { PROJECT_ENDPOINT_PROTOCOL } from 'pages/api/constants'
+import { BASE_PATH } from 'lib/constants'
 import {
   Alert,
   Alert_Shadcn_,
@@ -112,7 +111,7 @@ const ProviderForm = ({ config, provider }: ProviderFormProps) => {
   }
 
   const { data: settings } = useProjectSettingsV2Query({ projectRef })
-  const protocol = IS_PLATFORM ? 'https' : PROJECT_ENDPOINT_PROTOCOL
+  const protocol = settings?.app_config?.protocol ?? 'https'
   const endpoint = settings?.app_config?.endpoint
   const apiUrl = `${protocol}://${endpoint}`
 

--- a/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
@@ -13,7 +13,8 @@ import { useAuthConfigUpdateMutation } from 'data/auth/auth-config-update-mutati
 import { useProjectSettingsV2Query } from 'data/config/project-settings-v2-query'
 import { useCustomDomainsQuery } from 'data/custom-domains/custom-domains-query'
 import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
-import { BASE_PATH } from 'lib/constants'
+import { BASE_PATH, IS_PLATFORM } from 'lib/constants'
+import { PROJECT_ENDPOINT_PROTOCOL } from 'pages/api/constants'
 import {
   Alert,
   Alert_Shadcn_,
@@ -111,7 +112,7 @@ const ProviderForm = ({ config, provider }: ProviderFormProps) => {
   }
 
   const { data: settings } = useProjectSettingsV2Query({ projectRef })
-  const protocol = settings?.app_config?.protocol ?? 'https'
+  const protocol = IS_PLATFORM ? 'https' : PROJECT_ENDPOINT_PROTOCOL
   const endpoint = settings?.app_config?.endpoint
   const apiUrl = `${protocol}://${endpoint}`
 

--- a/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
@@ -111,7 +111,9 @@ const ProviderForm = ({ config, provider }: ProviderFormProps) => {
   }
 
   const { data: settings } = useProjectSettingsV2Query({ projectRef })
-  const apiUrl = `https://${settings?.app_config?.endpoint}`
+  const protocol = settings?.app_config?.protocol ?? 'https'
+  const endpoint = settings?.app_config?.endpoint
+  const apiUrl = `${protocol}://${endpoint}`
 
   const { data: customDomainData } = useCustomDomainsQuery({ projectRef })
 

--- a/apps/studio/components/interfaces/Auth/Users/BanUserModal.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/BanUserModal.tsx
@@ -69,6 +69,7 @@ export const BanUserModal = ({ visible, user, onClose }: BanUserModalProps) => {
     }
 
     const durationHours = data.unit === 'hours' ? Number(data.value) : Number(data.value) * 24
+    const protocol = settings?.app_config?.protocol ?? 'https'
     const endpoint = settings?.app_config?.endpoint
     const { serviceKey } = getAPIKeys(settings)
 
@@ -77,6 +78,7 @@ export const BanUserModal = ({ visible, user, onClose }: BanUserModalProps) => {
 
     updateUser({
       projectRef,
+      protocol,
       endpoint,
       serviceApiKey: serviceKey.api_key,
       userId: user.id,

--- a/apps/studio/components/interfaces/Auth/Users/BanUserModal.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/BanUserModal.tsx
@@ -69,7 +69,6 @@ export const BanUserModal = ({ visible, user, onClose }: BanUserModalProps) => {
     }
 
     const durationHours = data.unit === 'hours' ? Number(data.value) : Number(data.value) * 24
-    const protocol = settings?.app_config?.protocol ?? 'https'
     const endpoint = settings?.app_config?.endpoint
     const { serviceKey } = getAPIKeys(settings)
 
@@ -78,7 +77,6 @@ export const BanUserModal = ({ visible, user, onClose }: BanUserModalProps) => {
 
     updateUser({
       projectRef,
-      protocol,
       endpoint,
       serviceApiKey: serviceKey.api_key,
       userId: user.id,

--- a/apps/studio/components/interfaces/Auth/Users/BanUserModal.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/BanUserModal.tsx
@@ -69,7 +69,8 @@ export const BanUserModal = ({ visible, user, onClose }: BanUserModalProps) => {
     }
 
     const durationHours = data.unit === 'hours' ? Number(data.value) : Number(data.value) * 24
-    const endpoint = settings.app_config?.endpoint
+    const protocol = settings?.app_config?.protocol ?? 'https'
+    const endpoint = settings?.app_config?.endpoint
     const { serviceKey } = getAPIKeys(settings)
 
     if (!endpoint) return toast.error(`Failed to ban user: Unable to retrieve API endpoint`)
@@ -77,7 +78,7 @@ export const BanUserModal = ({ visible, user, onClose }: BanUserModalProps) => {
 
     updateUser({
       projectRef,
-      protocol: 'https',
+      protocol,
       endpoint,
       serviceApiKey: serviceKey.api_key,
       userId: user.id,

--- a/apps/studio/components/interfaces/Auth/Users/CreateUserModal.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/CreateUserModal.tsx
@@ -60,6 +60,7 @@ const CreateUserModal = ({ visible, setVisible }: CreateUserModalProps) => {
     if (!isSuccess) {
       return toast.error(`Failed to create user: Error loading project config`)
     }
+    const protocol = settings?.app_config?.protocol ?? 'https'
     const endpoint = settings?.app_config?.endpoint
     const { serviceKey } = getAPIKeys(settings)
 
@@ -69,6 +70,7 @@ const CreateUserModal = ({ visible, setVisible }: CreateUserModalProps) => {
 
     createUser({
       projectRef,
+      protocol,
       endpoint,
       serviceApiKey: serviceKey.api_key,
       user: values,

--- a/apps/studio/components/interfaces/Auth/Users/CreateUserModal.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/CreateUserModal.tsx
@@ -60,7 +60,6 @@ const CreateUserModal = ({ visible, setVisible }: CreateUserModalProps) => {
     if (!isSuccess) {
       return toast.error(`Failed to create user: Error loading project config`)
     }
-    const protocol = settings?.app_config?.protocol ?? 'https'
     const endpoint = settings?.app_config?.endpoint
     const { serviceKey } = getAPIKeys(settings)
 
@@ -71,7 +70,6 @@ const CreateUserModal = ({ visible, setVisible }: CreateUserModalProps) => {
     createUser({
       projectRef,
       endpoint,
-      protocol,
       serviceApiKey: serviceKey.api_key,
       user: values,
     })

--- a/apps/studio/components/interfaces/Auth/Users/CreateUserModal.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/CreateUserModal.tsx
@@ -60,6 +60,7 @@ const CreateUserModal = ({ visible, setVisible }: CreateUserModalProps) => {
     if (!isSuccess) {
       return toast.error(`Failed to create user: Error loading project config`)
     }
+    const protocol = settings?.app_config?.protocol ?? 'https'
     const endpoint = settings?.app_config?.endpoint
     const { serviceKey } = getAPIKeys(settings)
 
@@ -70,7 +71,7 @@ const CreateUserModal = ({ visible, setVisible }: CreateUserModalProps) => {
     createUser({
       projectRef,
       endpoint,
-      protocol: 'https',
+      protocol,
       serviceApiKey: serviceKey.api_key,
       user: values,
     })

--- a/apps/studio/components/interfaces/Auth/Users/UserOverview.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/UserOverview.tsx
@@ -149,7 +149,8 @@ export const UserOverview = ({ user, onDeleteSuccess }: UserOverviewProps) => {
       return toast.error(`Failed to ban user: User ID not found`)
     }
 
-    const endpoint = settings.app_config?.endpoint
+    const protocol = settings?.app_config?.protocol ?? 'https'
+    const endpoint = settings?.app_config?.endpoint
     const { serviceKey } = getAPIKeys(settings)
 
     if (!endpoint) return toast.error(`Failed to unban user: Unable to retrieve API endpoint`)
@@ -157,7 +158,7 @@ export const UserOverview = ({ user, onDeleteSuccess }: UserOverviewProps) => {
 
     updateUser({
       projectRef,
-      protocol: 'https',
+      protocol,
       endpoint,
       serviceApiKey: serviceKey.api_key,
       userId: user.id,

--- a/apps/studio/components/interfaces/Auth/Users/UserOverview.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/UserOverview.tsx
@@ -149,6 +149,7 @@ export const UserOverview = ({ user, onDeleteSuccess }: UserOverviewProps) => {
       return toast.error(`Failed to ban user: User ID not found`)
     }
 
+    const protocol = settings?.app_config?.protocol ?? 'https'
     const endpoint = settings?.app_config?.endpoint
     const { serviceKey } = getAPIKeys(settings)
 
@@ -157,6 +158,7 @@ export const UserOverview = ({ user, onDeleteSuccess }: UserOverviewProps) => {
 
     updateUser({
       projectRef,
+      protocol,
       endpoint,
       serviceApiKey: serviceKey.api_key,
       userId: user.id,

--- a/apps/studio/components/interfaces/Auth/Users/UserOverview.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/UserOverview.tsx
@@ -149,7 +149,6 @@ export const UserOverview = ({ user, onDeleteSuccess }: UserOverviewProps) => {
       return toast.error(`Failed to ban user: User ID not found`)
     }
 
-    const protocol = settings?.app_config?.protocol ?? 'https'
     const endpoint = settings?.app_config?.endpoint
     const { serviceKey } = getAPIKeys(settings)
 
@@ -158,7 +157,6 @@ export const UserOverview = ({ user, onDeleteSuccess }: UserOverviewProps) => {
 
     updateUser({
       projectRef,
-      protocol,
       endpoint,
       serviceApiKey: serviceKey.api_key,
       userId: user.id,

--- a/apps/studio/components/interfaces/Docs/Authentication.tsx
+++ b/apps/studio/components/interfaces/Docs/Authentication.tsx
@@ -15,7 +15,9 @@ const Authentication = ({ selectedLang, showApiKey }: AuthenticationProps) => {
   const { data: settings } = useProjectSettingsV2Query({ projectRef })
 
   const { anonKey, serviceKey } = getAPIKeys(settings)
-  const endpoint = `https://${settings?.app_config?.endpoint ?? ''}`
+  const protocol = settings?.app_config?.protocol ?? 'https'
+  const hostEndpoint = settings?.app_config?.endpoint
+  const endpoint = `${protocol}://${hostEndpoint ?? ''}`
 
   // [Joshen] ShowApiKey should really be a boolean, its confusing
   const defaultApiKey =

--- a/apps/studio/components/interfaces/Docs/Authentication.tsx
+++ b/apps/studio/components/interfaces/Docs/Authentication.tsx
@@ -2,6 +2,8 @@ import Link from 'next/link'
 
 import { useParams } from 'common'
 import { getAPIKeys, useProjectSettingsV2Query } from 'data/config/project-settings-v2-query'
+import { IS_PLATFORM } from 'lib/constants'
+import { PROJECT_ENDPOINT_PROTOCOL } from 'pages/api/constants'
 import CodeSnippet from './CodeSnippet'
 import Snippets from './Snippets'
 
@@ -15,7 +17,7 @@ const Authentication = ({ selectedLang, showApiKey }: AuthenticationProps) => {
   const { data: settings } = useProjectSettingsV2Query({ projectRef })
 
   const { anonKey, serviceKey } = getAPIKeys(settings)
-  const protocol = settings?.app_config?.protocol ?? 'https'
+  const protocol = IS_PLATFORM ? 'https' : PROJECT_ENDPOINT_PROTOCOL
   const hostEndpoint = settings?.app_config?.endpoint
   const endpoint = `${protocol}://${hostEndpoint ?? ''}`
 

--- a/apps/studio/components/interfaces/Docs/Authentication.tsx
+++ b/apps/studio/components/interfaces/Docs/Authentication.tsx
@@ -2,8 +2,6 @@ import Link from 'next/link'
 
 import { useParams } from 'common'
 import { getAPIKeys, useProjectSettingsV2Query } from 'data/config/project-settings-v2-query'
-import { IS_PLATFORM } from 'lib/constants'
-import { PROJECT_ENDPOINT_PROTOCOL } from 'pages/api/constants'
 import CodeSnippet from './CodeSnippet'
 import Snippets from './Snippets'
 
@@ -17,7 +15,7 @@ const Authentication = ({ selectedLang, showApiKey }: AuthenticationProps) => {
   const { data: settings } = useProjectSettingsV2Query({ projectRef })
 
   const { anonKey, serviceKey } = getAPIKeys(settings)
-  const protocol = IS_PLATFORM ? 'https' : PROJECT_ENDPOINT_PROTOCOL
+  const protocol = settings?.app_config?.protocol ?? 'https'
   const hostEndpoint = settings?.app_config?.endpoint
   const endpoint = `${protocol}://${hostEndpoint ?? ''}`
 

--- a/apps/studio/components/interfaces/Docs/Introduction.tsx
+++ b/apps/studio/components/interfaces/Docs/Introduction.tsx
@@ -16,7 +16,9 @@ export default function Introduction({ selectedLang }: Props) {
   const { data: settings } = useProjectSettingsV2Query({ projectRef })
   const { data: config } = useProjectPostgrestConfigQuery({ projectRef })
 
-  const endpoint = `https://${settings?.app_config?.endpoint ?? ''}`
+  const protocol = settings?.app_config?.protocol ?? 'https'
+  const hostEndpoint = settings?.app_config?.endpoint
+  const endpoint = `${protocol}://${hostEndpoint ?? ''}`
 
   const isPublicSchemaEnabled = config?.db_schema
     .split(',')

--- a/apps/studio/components/interfaces/Docs/Introduction.tsx
+++ b/apps/studio/components/interfaces/Docs/Introduction.tsx
@@ -3,6 +3,8 @@ import Snippets from 'components/interfaces/Docs/Snippets'
 import { useProjectPostgrestConfigQuery } from 'data/config/project-postgrest-config-query'
 
 import { useProjectSettingsV2Query } from 'data/config/project-settings-v2-query'
+import { IS_PLATFORM } from 'lib/constants'
+import { PROJECT_ENDPOINT_PROTOCOL } from 'pages/api/constants'
 import CodeSnippet from './CodeSnippet'
 import PublicSchemaNotEnabledAlert from './PublicSchemaNotEnabledAlert'
 
@@ -16,7 +18,7 @@ export default function Introduction({ selectedLang }: Props) {
   const { data: settings } = useProjectSettingsV2Query({ projectRef })
   const { data: config } = useProjectPostgrestConfigQuery({ projectRef })
 
-  const protocol = settings?.app_config?.protocol ?? 'https'
+  const protocol = IS_PLATFORM ? 'https' : PROJECT_ENDPOINT_PROTOCOL
   const hostEndpoint = settings?.app_config?.endpoint
   const endpoint = `${protocol}://${hostEndpoint ?? ''}`
 

--- a/apps/studio/components/interfaces/Docs/Introduction.tsx
+++ b/apps/studio/components/interfaces/Docs/Introduction.tsx
@@ -3,8 +3,6 @@ import Snippets from 'components/interfaces/Docs/Snippets'
 import { useProjectPostgrestConfigQuery } from 'data/config/project-postgrest-config-query'
 
 import { useProjectSettingsV2Query } from 'data/config/project-settings-v2-query'
-import { IS_PLATFORM } from 'lib/constants'
-import { PROJECT_ENDPOINT_PROTOCOL } from 'pages/api/constants'
 import CodeSnippet from './CodeSnippet'
 import PublicSchemaNotEnabledAlert from './PublicSchemaNotEnabledAlert'
 
@@ -18,7 +16,7 @@ export default function Introduction({ selectedLang }: Props) {
   const { data: settings } = useProjectSettingsV2Query({ projectRef })
   const { data: config } = useProjectPostgrestConfigQuery({ projectRef })
 
-  const protocol = IS_PLATFORM ? 'https' : PROJECT_ENDPOINT_PROTOCOL
+  const protocol = settings?.app_config?.protocol ?? 'https'
   const hostEndpoint = settings?.app_config?.endpoint
   const endpoint = `${protocol}://${hostEndpoint ?? ''}`
 

--- a/apps/studio/components/interfaces/Docs/Pages/UserManagement.tsx
+++ b/apps/studio/components/interfaces/Docs/Pages/UserManagement.tsx
@@ -20,7 +20,9 @@ export default function UserManagement({ selectedLang, showApiKey }: UserManagem
   const keyToShow = showApiKey ? showApiKey : 'SUPABASE_KEY'
 
   const { data: settings } = useProjectSettingsV2Query({ projectRef })
-  const endpoint = `https://${settings?.app_config?.endpoint ?? ''}`
+  const protocol = settings?.app_config?.protocol ?? 'https'
+  const hostEndpoint = settings?.app_config?.endpoint ?? ''
+  const endpoint = `${protocol}://${hostEndpoint ?? ''}`
 
   return (
     <>

--- a/apps/studio/components/interfaces/Docs/Pages/UserManagement.tsx
+++ b/apps/studio/components/interfaces/Docs/Pages/UserManagement.tsx
@@ -3,7 +3,9 @@ import { useRouter } from 'next/router'
 
 import { useParams } from 'common'
 import { useProjectSettingsV2Query } from 'data/config/project-settings-v2-query'
+import { IS_PLATFORM } from 'lib/constants'
 import { makeRandomString } from 'lib/helpers'
+import { PROJECT_ENDPOINT_PROTOCOL } from 'pages/api/constants'
 import CodeSnippet from '../CodeSnippet'
 import Snippets from '../Snippets'
 
@@ -20,7 +22,7 @@ export default function UserManagement({ selectedLang, showApiKey }: UserManagem
   const keyToShow = showApiKey ? showApiKey : 'SUPABASE_KEY'
 
   const { data: settings } = useProjectSettingsV2Query({ projectRef })
-  const protocol = settings?.app_config?.protocol ?? 'https'
+  const protocol = IS_PLATFORM ? 'https' : PROJECT_ENDPOINT_PROTOCOL
   const hostEndpoint = settings?.app_config?.endpoint ?? ''
   const endpoint = `${protocol}://${hostEndpoint ?? ''}`
 

--- a/apps/studio/components/interfaces/Docs/Pages/UserManagement.tsx
+++ b/apps/studio/components/interfaces/Docs/Pages/UserManagement.tsx
@@ -3,9 +3,7 @@ import { useRouter } from 'next/router'
 
 import { useParams } from 'common'
 import { useProjectSettingsV2Query } from 'data/config/project-settings-v2-query'
-import { IS_PLATFORM } from 'lib/constants'
 import { makeRandomString } from 'lib/helpers'
-import { PROJECT_ENDPOINT_PROTOCOL } from 'pages/api/constants'
 import CodeSnippet from '../CodeSnippet'
 import Snippets from '../Snippets'
 
@@ -22,7 +20,7 @@ export default function UserManagement({ selectedLang, showApiKey }: UserManagem
   const keyToShow = showApiKey ? showApiKey : 'SUPABASE_KEY'
 
   const { data: settings } = useProjectSettingsV2Query({ projectRef })
-  const protocol = IS_PLATFORM ? 'https' : PROJECT_ENDPOINT_PROTOCOL
+  const protocol = settings?.app_config?.protocol ?? 'https'
   const hostEndpoint = settings?.app_config?.endpoint ?? ''
   const endpoint = `${protocol}://${hostEndpoint ?? ''}`
 

--- a/apps/studio/components/interfaces/Docs/RpcContent.tsx
+++ b/apps/studio/components/interfaces/Docs/RpcContent.tsx
@@ -29,7 +29,9 @@ const RpcContent = ({
 }: RpcContentProps) => {
   const { ref: projectRef } = useParams()
   const { data: settings } = useProjectSettingsV2Query({ projectRef })
-  const endpoint = `https://${settings?.app_config?.endpoint ?? ''}`
+  const protocol = settings?.app_config?.protocol ?? 'https'
+  const hostEndpoint = settings?.app_config?.endpoint ?? ''
+  const endpoint = `${protocol}://${hostEndpoint ?? ''}`
 
   const meta = rpcs[rpcId]
   const pathKey = `/rpc/${rpcId}`

--- a/apps/studio/components/interfaces/Docs/RpcContent.tsx
+++ b/apps/studio/components/interfaces/Docs/RpcContent.tsx
@@ -5,6 +5,8 @@ import Param from 'components/interfaces/Docs/Param'
 import Snippets from 'components/interfaces/Docs/Snippets'
 import { useProjectSettingsV2Query } from 'data/config/project-settings-v2-query'
 import { ProjectJsonSchemaPaths } from 'data/docs/project-json-schema-query'
+import { IS_PLATFORM } from 'lib/constants'
+import { PROJECT_ENDPOINT_PROTOCOL } from 'pages/api/constants'
 
 /**
  * TODO: need to support rpc with the same name and different params type
@@ -29,7 +31,7 @@ const RpcContent = ({
 }: RpcContentProps) => {
   const { ref: projectRef } = useParams()
   const { data: settings } = useProjectSettingsV2Query({ projectRef })
-  const protocol = settings?.app_config?.protocol ?? 'https'
+  const protocol = IS_PLATFORM ? 'https' : PROJECT_ENDPOINT_PROTOCOL
   const hostEndpoint = settings?.app_config?.endpoint ?? ''
   const endpoint = `${protocol}://${hostEndpoint ?? ''}`
 

--- a/apps/studio/components/interfaces/Docs/RpcContent.tsx
+++ b/apps/studio/components/interfaces/Docs/RpcContent.tsx
@@ -5,8 +5,6 @@ import Param from 'components/interfaces/Docs/Param'
 import Snippets from 'components/interfaces/Docs/Snippets'
 import { useProjectSettingsV2Query } from 'data/config/project-settings-v2-query'
 import { ProjectJsonSchemaPaths } from 'data/docs/project-json-schema-query'
-import { IS_PLATFORM } from 'lib/constants'
-import { PROJECT_ENDPOINT_PROTOCOL } from 'pages/api/constants'
 
 /**
  * TODO: need to support rpc with the same name and different params type
@@ -31,7 +29,7 @@ const RpcContent = ({
 }: RpcContentProps) => {
   const { ref: projectRef } = useParams()
   const { data: settings } = useProjectSettingsV2Query({ projectRef })
-  const protocol = IS_PLATFORM ? 'https' : PROJECT_ENDPOINT_PROTOCOL
+  const protocol = settings?.app_config?.protocol ?? 'https'
   const hostEndpoint = settings?.app_config?.endpoint ?? ''
   const endpoint = `${protocol}://${hostEndpoint ?? ''}`
 

--- a/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionDetails.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionDetails.tsx
@@ -56,11 +56,12 @@ const EdgeFunctionDetails = () => {
   const { anonKey } = getAPIKeys(settings)
   const apiKey = anonKey?.api_key ?? '[YOUR ANON KEY]'
 
+  const protocol = settings?.app_config?.protocol ?? 'https'
   const endpoint = settings?.app_config?.endpoint ?? ''
   const functionUrl =
     customDomainData?.customDomain?.status === 'active'
       ? `https://${customDomainData.customDomain.hostname}/functions/v1/${selectedFunction?.slug}`
-      : `https://${endpoint}/functions/v1/${selectedFunction?.slug}`
+      : `${protocol}://${endpoint}/functions/v1/${selectedFunction?.slug}`
 
   const { managementCommands, secretCommands, invokeCommands } = generateCLICommands(
     selectedFunction,

--- a/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionDetails.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionDetails.tsx
@@ -19,8 +19,6 @@ import { useEdgeFunctionQuery } from 'data/edge-functions/edge-function-query'
 import { useEdgeFunctionDeleteMutation } from 'data/edge-functions/edge-functions-delete-mutation'
 import { useEdgeFunctionUpdateMutation } from 'data/edge-functions/edge-functions-update-mutation'
 import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
-import { IS_PLATFORM } from 'lib/constants'
-import { PROJECT_ENDPOINT_PROTOCOL } from 'pages/api/constants'
 import {
   AlertDescription_Shadcn_,
   AlertTitle_Shadcn_,
@@ -58,7 +56,7 @@ const EdgeFunctionDetails = () => {
   const { anonKey } = getAPIKeys(settings)
   const apiKey = anonKey?.api_key ?? '[YOUR ANON KEY]'
 
-  const protocol = IS_PLATFORM ? 'https' : PROJECT_ENDPOINT_PROTOCOL
+  const protocol = settings?.app_config?.protocol ?? 'https'
   const endpoint = settings?.app_config?.endpoint ?? ''
   const functionUrl =
     customDomainData?.customDomain?.status === 'active'

--- a/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionDetails.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionDetails.tsx
@@ -19,6 +19,8 @@ import { useEdgeFunctionQuery } from 'data/edge-functions/edge-function-query'
 import { useEdgeFunctionDeleteMutation } from 'data/edge-functions/edge-functions-delete-mutation'
 import { useEdgeFunctionUpdateMutation } from 'data/edge-functions/edge-functions-update-mutation'
 import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import { IS_PLATFORM } from 'lib/constants'
+import { PROJECT_ENDPOINT_PROTOCOL } from 'pages/api/constants'
 import {
   AlertDescription_Shadcn_,
   AlertTitle_Shadcn_,
@@ -56,7 +58,7 @@ const EdgeFunctionDetails = () => {
   const { anonKey } = getAPIKeys(settings)
   const apiKey = anonKey?.api_key ?? '[YOUR ANON KEY]'
 
-  const protocol = settings?.app_config?.protocol ?? 'https'
+  const protocol = IS_PLATFORM ? 'https' : PROJECT_ENDPOINT_PROTOCOL
   const endpoint = settings?.app_config?.endpoint ?? ''
   const functionUrl =
     customDomainData?.customDomain?.status === 'active'

--- a/apps/studio/components/interfaces/Functions/TerminalInstructions.tsx
+++ b/apps/studio/components/interfaces/Functions/TerminalInstructions.tsx
@@ -35,11 +35,13 @@ const TerminalInstructions = forwardRef<
 
   const { anonKey } = getAPIKeys(settings)
   const apiKey = anonKey?.api_key ?? '[YOUR ANON KEY]'
+
+  const protocol = settings?.app_config?.protocol ?? 'https'
   const endpoint = settings?.app_config?.endpoint ?? ''
   const functionsEndpoint =
     customDomainData?.customDomain?.status === 'active'
       ? `https://${customDomainData.customDomain.hostname}/functions/v1`
-      : `https://${endpoint}/functions/v1`
+      : `${protocol}://${endpoint}/functions/v1`
 
   // get the .co or .net TLD from the restUrl
   const restUrl = `https://${endpoint}`

--- a/apps/studio/components/interfaces/Functions/TerminalInstructions.tsx
+++ b/apps/studio/components/interfaces/Functions/TerminalInstructions.tsx
@@ -15,6 +15,8 @@ import {
   Collapsible_Shadcn_,
 } from 'ui'
 import type { Commands } from './Functions.types'
+import { IS_PLATFORM } from 'lib/constants'
+import { PROJECT_ENDPOINT_PROTOCOL } from 'pages/api/constants'
 
 interface TerminalInstructionsProps extends ComponentPropsWithoutRef<typeof Collapsible_Shadcn_> {
   closable?: boolean
@@ -36,7 +38,7 @@ const TerminalInstructions = forwardRef<
   const { anonKey } = getAPIKeys(settings)
   const apiKey = anonKey?.api_key ?? '[YOUR ANON KEY]'
 
-  const protocol = settings?.app_config?.protocol ?? 'https'
+  const protocol = IS_PLATFORM ? 'https' : PROJECT_ENDPOINT_PROTOCOL
   const endpoint = settings?.app_config?.endpoint ?? ''
   const functionsEndpoint =
     customDomainData?.customDomain?.status === 'active'

--- a/apps/studio/components/interfaces/Functions/TerminalInstructions.tsx
+++ b/apps/studio/components/interfaces/Functions/TerminalInstructions.tsx
@@ -8,6 +8,8 @@ import { DocsButton } from 'components/ui/DocsButton'
 import { useAccessTokensQuery } from 'data/access-tokens/access-tokens-query'
 import { getAPIKeys, useProjectSettingsV2Query } from 'data/config/project-settings-v2-query'
 import { useCustomDomainsQuery } from 'data/custom-domains/custom-domains-query'
+import { IS_PLATFORM } from 'lib/constants'
+import { PROJECT_ENDPOINT_PROTOCOL } from 'pages/api/constants'
 import {
   Button,
   CollapsibleContent_Shadcn_,
@@ -15,8 +17,6 @@ import {
   Collapsible_Shadcn_,
 } from 'ui'
 import type { Commands } from './Functions.types'
-import { IS_PLATFORM } from 'lib/constants'
-import { PROJECT_ENDPOINT_PROTOCOL } from 'pages/api/constants'
 
 interface TerminalInstructionsProps extends ComponentPropsWithoutRef<typeof Collapsible_Shadcn_> {
   closable?: boolean

--- a/apps/studio/components/interfaces/Functions/TerminalInstructions.tsx
+++ b/apps/studio/components/interfaces/Functions/TerminalInstructions.tsx
@@ -8,8 +8,6 @@ import { DocsButton } from 'components/ui/DocsButton'
 import { useAccessTokensQuery } from 'data/access-tokens/access-tokens-query'
 import { getAPIKeys, useProjectSettingsV2Query } from 'data/config/project-settings-v2-query'
 import { useCustomDomainsQuery } from 'data/custom-domains/custom-domains-query'
-import { IS_PLATFORM } from 'lib/constants'
-import { PROJECT_ENDPOINT_PROTOCOL } from 'pages/api/constants'
 import {
   Button,
   CollapsibleContent_Shadcn_,
@@ -38,7 +36,7 @@ const TerminalInstructions = forwardRef<
   const { anonKey } = getAPIKeys(settings)
   const apiKey = anonKey?.api_key ?? '[YOUR ANON KEY]'
 
-  const protocol = IS_PLATFORM ? 'https' : PROJECT_ENDPOINT_PROTOCOL
+  const protocol = settings?.app_config?.protocol ?? 'https'
   const endpoint = settings?.app_config?.endpoint ?? ''
   const functionsEndpoint =
     customDomainData?.customDomain?.status === 'active'

--- a/apps/studio/components/interfaces/Home/Connect/Connect.tsx
+++ b/apps/studio/components/interfaces/Home/Connect/Connect.tsx
@@ -29,8 +29,6 @@ import { CONNECTION_TYPES, ConnectionType, FRAMEWORKS, MOBILES, ORMS } from './C
 import { getContentFilePath } from './Connect.utils'
 import ConnectDropdown from './ConnectDropdown'
 import ConnectTabContent from './ConnectTabContent'
-import { IS_PLATFORM } from 'lib/constants'
-import { PROJECT_ENDPOINT_PROTOCOL } from 'pages/api/constants'
 
 const Connect = () => {
   const { ref: projectRef } = useParams()
@@ -130,7 +128,7 @@ const Connect = () => {
     return []
   }
 
-  const protocol = IS_PLATFORM ? 'https' : PROJECT_ENDPOINT_PROTOCOL
+  const protocol = settings?.app_config?.protocol ?? 'https'
   const endpoint = settings?.app_config?.endpoint ?? ''
   const apiHost = canReadAPIKeys ? `${protocol}://${endpoint ?? '-'}` : ''
   const apiUrl = canReadAPIKeys ? apiHost : null

--- a/apps/studio/components/interfaces/Home/Connect/Connect.tsx
+++ b/apps/studio/components/interfaces/Home/Connect/Connect.tsx
@@ -29,6 +29,8 @@ import { CONNECTION_TYPES, ConnectionType, FRAMEWORKS, MOBILES, ORMS } from './C
 import { getContentFilePath } from './Connect.utils'
 import ConnectDropdown from './ConnectDropdown'
 import ConnectTabContent from './ConnectTabContent'
+import { IS_PLATFORM } from 'lib/constants'
+import { PROJECT_ENDPOINT_PROTOCOL } from 'pages/api/constants'
 
 const Connect = () => {
   const { ref: projectRef } = useParams()
@@ -128,7 +130,7 @@ const Connect = () => {
     return []
   }
 
-  const protocol = settings?.app_config?.protocol ?? 'https'
+  const protocol = IS_PLATFORM ? 'https' : PROJECT_ENDPOINT_PROTOCOL
   const endpoint = settings?.app_config?.endpoint ?? ''
   const apiHost = canReadAPIKeys ? `${protocol}://${endpoint ?? '-'}` : ''
   const apiUrl = canReadAPIKeys ? apiHost : null

--- a/apps/studio/components/interfaces/Home/Connect/Connect.tsx
+++ b/apps/studio/components/interfaces/Home/Connect/Connect.tsx
@@ -128,8 +128,9 @@ const Connect = () => {
     return []
   }
 
-  const endpoint = settings?.app_config?.endpoint
-  const apiHost = canReadAPIKeys ? `https://${endpoint ?? '-'}` : ''
+  const protocol = settings?.app_config?.protocol ?? 'https'
+  const endpoint = settings?.app_config?.endpoint ?? ''
+  const apiHost = canReadAPIKeys ? `${protocol}://${endpoint ?? '-'}` : ''
   const apiUrl = canReadAPIKeys ? apiHost : null
 
   const { anonKey } = canReadAPIKeys ? getAPIKeys(settings) : { anonKey: null }

--- a/apps/studio/components/interfaces/Home/NewProjectPanel/APIKeys.tsx
+++ b/apps/studio/components/interfaces/Home/NewProjectPanel/APIKeys.tsx
@@ -58,8 +58,9 @@ const APIKeys = () => {
   const isNotUpdatingJwtSecret =
     jwtSecretUpdateStatus === undefined || jwtSecretUpdateStatus === JwtSecretUpdateStatus.Updated
 
+  const protocol = settings?.app_config?.protocol ?? 'https'
   const endpoint = settings?.app_config?.endpoint
-  const apiUrl = `https://${endpoint ?? '-'}`
+  const apiUrl = `${protocol}://${endpoint ?? '-'}`
   const apiKeys = settings?.service_api_keys ?? []
   const { anonKey } = getAPIKeys(settings)
 

--- a/apps/studio/components/interfaces/Home/NewProjectPanel/APIKeys.tsx
+++ b/apps/studio/components/interfaces/Home/NewProjectPanel/APIKeys.tsx
@@ -11,6 +11,8 @@ import { useJwtSecretUpdatingStatusQuery } from 'data/config/jwt-secret-updating
 import { getAPIKeys, useProjectSettingsV2Query } from 'data/config/project-settings-v2-query'
 import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { Input } from 'ui'
+import { IS_PLATFORM } from 'lib/constants'
+import { PROJECT_ENDPOINT_PROTOCOL } from 'pages/api/constants'
 
 const generateInitSnippet = (endpoint: string) => ({
   js: `
@@ -58,7 +60,7 @@ const APIKeys = () => {
   const isNotUpdatingJwtSecret =
     jwtSecretUpdateStatus === undefined || jwtSecretUpdateStatus === JwtSecretUpdateStatus.Updated
 
-  const protocol = settings?.app_config?.protocol ?? 'https'
+  const protocol = IS_PLATFORM ? 'https' : PROJECT_ENDPOINT_PROTOCOL
   const endpoint = settings?.app_config?.endpoint
   const apiUrl = `${protocol}://${endpoint ?? '-'}`
   const apiKeys = settings?.service_api_keys ?? []

--- a/apps/studio/components/interfaces/Home/NewProjectPanel/APIKeys.tsx
+++ b/apps/studio/components/interfaces/Home/NewProjectPanel/APIKeys.tsx
@@ -11,8 +11,6 @@ import { useJwtSecretUpdatingStatusQuery } from 'data/config/jwt-secret-updating
 import { getAPIKeys, useProjectSettingsV2Query } from 'data/config/project-settings-v2-query'
 import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { Input } from 'ui'
-import { IS_PLATFORM } from 'lib/constants'
-import { PROJECT_ENDPOINT_PROTOCOL } from 'pages/api/constants'
 
 const generateInitSnippet = (endpoint: string) => ({
   js: `
@@ -60,7 +58,7 @@ const APIKeys = () => {
   const isNotUpdatingJwtSecret =
     jwtSecretUpdateStatus === undefined || jwtSecretUpdateStatus === JwtSecretUpdateStatus.Updated
 
-  const protocol = IS_PLATFORM ? 'https' : PROJECT_ENDPOINT_PROTOCOL
+  const protocol = settings?.app_config?.protocol ?? 'https'
   const endpoint = settings?.app_config?.endpoint
   const apiUrl = `${protocol}://${endpoint ?? '-'}`
   const apiKeys = settings?.service_api_keys ?? []

--- a/apps/studio/components/interfaces/ProjectAPIDocs/ProjectAPIDocs.tsx
+++ b/apps/studio/components/interfaces/ProjectAPIDocs/ProjectAPIDocs.tsx
@@ -49,10 +49,12 @@ const ProjectAPIDocs = () => {
   const apikey = showKeys
     ? anonKey?.api_key ?? 'SUPABASE_CLIENT_ANON_KEY'
     : 'SUPABASE_CLIENT_ANON_KEY'
+  const protocol = settings?.app_config?.protocol ?? 'https'
+  const hostEndpoint = settings?.app_config?.endpoint
   const endpoint =
     customDomainData?.customDomain?.status === 'active'
       ? `https://${customDomainData.customDomain?.hostname}`
-      : `https://${settings?.app_config?.endpoint ?? ''}`
+      : `${protocol}://${hostEndpoint ?? ''}`
 
   return (
     <SidePanel

--- a/apps/studio/components/interfaces/ProjectAPIDocs/ProjectAPIDocs.tsx
+++ b/apps/studio/components/interfaces/ProjectAPIDocs/ProjectAPIDocs.tsx
@@ -4,6 +4,8 @@ import { Button, SidePanel } from 'ui'
 import { useParams } from 'common'
 import { getAPIKeys, useProjectSettingsV2Query } from 'data/config/project-settings-v2-query'
 import { useCustomDomainsQuery } from 'data/custom-domains/custom-domains-query'
+import { IS_PLATFORM } from 'lib/constants'
+import { PROJECT_ENDPOINT_PROTOCOL } from 'pages/api/constants'
 import { useAppStateSnapshot } from 'state/app-state'
 import {
   Bucket,
@@ -49,7 +51,7 @@ const ProjectAPIDocs = () => {
   const apikey = showKeys
     ? anonKey?.api_key ?? 'SUPABASE_CLIENT_ANON_KEY'
     : 'SUPABASE_CLIENT_ANON_KEY'
-  const protocol = settings?.app_config?.protocol ?? 'https'
+  const protocol = IS_PLATFORM ? 'https' : PROJECT_ENDPOINT_PROTOCOL
   const hostEndpoint = settings?.app_config?.endpoint
   const endpoint =
     customDomainData?.customDomain?.status === 'active'

--- a/apps/studio/components/interfaces/ProjectAPIDocs/ProjectAPIDocs.tsx
+++ b/apps/studio/components/interfaces/ProjectAPIDocs/ProjectAPIDocs.tsx
@@ -4,8 +4,6 @@ import { Button, SidePanel } from 'ui'
 import { useParams } from 'common'
 import { getAPIKeys, useProjectSettingsV2Query } from 'data/config/project-settings-v2-query'
 import { useCustomDomainsQuery } from 'data/custom-domains/custom-domains-query'
-import { IS_PLATFORM } from 'lib/constants'
-import { PROJECT_ENDPOINT_PROTOCOL } from 'pages/api/constants'
 import { useAppStateSnapshot } from 'state/app-state'
 import {
   Bucket,
@@ -51,7 +49,7 @@ const ProjectAPIDocs = () => {
   const apikey = showKeys
     ? anonKey?.api_key ?? 'SUPABASE_CLIENT_ANON_KEY'
     : 'SUPABASE_CLIENT_ANON_KEY'
-  const protocol = IS_PLATFORM ? 'https' : PROJECT_ENDPOINT_PROTOCOL
+  const protocol = settings?.app_config?.protocol ?? 'https'
   const hostEndpoint = settings?.app_config?.endpoint
   const endpoint =
     customDomainData?.customDomain?.status === 'active'

--- a/apps/studio/components/interfaces/Realtime/Inspector/RealtimeTokensPopover/index.tsx
+++ b/apps/studio/components/interfaces/Realtime/Inspector/RealtimeTokensPopover/index.tsx
@@ -22,9 +22,7 @@ export const RealtimeTokensPopover = ({ config, onChangeConfig }: RealtimeTokens
   const { anonKey, serviceKey } = getAPIKeys(settings)
 
   const { data: postgrestConfig } = useProjectPostgrestConfigQuery(
-    {
-      projectRef: config.projectRef,
-    },
+    { projectRef: config.projectRef },
     { enabled: IS_PLATFORM }
   )
   const jwtSecret = postgrestConfig?.jwt_secret

--- a/apps/studio/components/interfaces/Realtime/Inspector/useRealtimeMessages.ts
+++ b/apps/studio/components/interfaces/Realtime/Inspector/useRealtimeMessages.ts
@@ -78,10 +78,10 @@ export const useRealtimeMessages = (
 
   const { data: settings } = useProjectSettingsV2Query({ projectRef: projectRef })
 
+  const protocol = settings?.app_config?.protocol ?? 'https'
+  const endpoint = settings?.app_config?.endpoint
   // the default host is prod until the correct one comes through an API call.
-  const host = settings
-    ? `https://${settings.app_config?.endpoint}`
-    : `https://${projectRef}.supabase.co`
+  const host = settings ? `${protocol}://${endpoint}` : `https://${projectRef}.supabase.co`
 
   const realtimeUrl = `${host}/realtime/v1`.replace(/^http/i, 'ws')
 

--- a/apps/studio/components/interfaces/Realtime/Inspector/useRealtimeMessages.ts
+++ b/apps/studio/components/interfaces/Realtime/Inspector/useRealtimeMessages.ts
@@ -8,8 +8,10 @@ import { Dispatch, SetStateAction, useCallback, useEffect, useReducer, useState 
 import { toast } from 'sonner'
 
 import { useProjectSettingsV2Query } from 'data/config/project-settings-v2-query'
+import { IS_PLATFORM } from 'lib/constants'
 import { uuidv4 } from 'lib/helpers'
 import { EMPTY_ARR } from 'lib/void'
+import { PROJECT_ENDPOINT_PROTOCOL } from 'pages/api/constants'
 import { useRoleImpersonationStateSnapshot } from 'state/role-impersonation-state'
 import type { LogData } from './Messages.types'
 
@@ -78,7 +80,7 @@ export const useRealtimeMessages = (
 
   const { data: settings } = useProjectSettingsV2Query({ projectRef: projectRef })
 
-  const protocol = settings?.app_config?.protocol ?? 'https'
+  const protocol = IS_PLATFORM ? 'https' : PROJECT_ENDPOINT_PROTOCOL
   const endpoint = settings?.app_config?.endpoint
   // the default host is prod until the correct one comes through an API call.
   const host = settings ? `${protocol}://${endpoint}` : `https://${projectRef}.supabase.co`

--- a/apps/studio/components/interfaces/Realtime/Inspector/useRealtimeMessages.ts
+++ b/apps/studio/components/interfaces/Realtime/Inspector/useRealtimeMessages.ts
@@ -8,10 +8,8 @@ import { Dispatch, SetStateAction, useCallback, useEffect, useReducer, useState 
 import { toast } from 'sonner'
 
 import { useProjectSettingsV2Query } from 'data/config/project-settings-v2-query'
-import { IS_PLATFORM } from 'lib/constants'
 import { uuidv4 } from 'lib/helpers'
 import { EMPTY_ARR } from 'lib/void'
-import { PROJECT_ENDPOINT_PROTOCOL } from 'pages/api/constants'
 import { useRoleImpersonationStateSnapshot } from 'state/role-impersonation-state'
 import type { LogData } from './Messages.types'
 
@@ -80,7 +78,7 @@ export const useRealtimeMessages = (
 
   const { data: settings } = useProjectSettingsV2Query({ projectRef: projectRef })
 
-  const protocol = IS_PLATFORM ? 'https' : PROJECT_ENDPOINT_PROTOCOL
+  const protocol = settings?.app_config?.protocol ?? 'https'
   const endpoint = settings?.app_config?.endpoint
   // the default host is prod until the correct one comes through an API call.
   const host = settings ? `${protocol}://${endpoint}` : `https://${projectRef}.supabase.co`

--- a/apps/studio/components/layouts/StorageLayout/StorageLayout.tsx
+++ b/apps/studio/components/layouts/StorageLayout/StorageLayout.tsx
@@ -21,7 +21,6 @@ const StorageLayout = ({ title, children }: StorageLayoutProps) => {
   const storageExplorerStore = useStorageStore()
 
   const { data: settings, isLoading } = useProjectSettingsV2Query({ projectRef })
-  const protocol = settings?.app_config?.protocol ?? 'https'
   const endpoint = settings?.app_config?.endpoint
   const { serviceKey } = getAPIKeys(settings)
 
@@ -29,20 +28,16 @@ const StorageLayout = ({ title, children }: StorageLayoutProps) => {
 
   useEffect(() => {
     if (!isLoading && endpoint && serviceKey?.api_key) {
-      initializeStorageStore(protocol, endpoint, serviceKey.api_key)
+      initializeStorageStore(endpoint, serviceKey.api_key)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isLoading, projectRef, endpoint, serviceKey?.api_key])
 
-  const initializeStorageStore = async (
-    protocol: string,
-    endpoint: string,
-    serviceApiKey: string
-  ) => {
+  const initializeStorageStore = async (endpoint: string, serviceApiKey: string) => {
     if (isPaused) return
 
     if (endpoint) {
-      storageExplorerStore.initStore(projectRef!, endpoint, serviceApiKey, protocol)
+      storageExplorerStore.initStore(projectRef!, endpoint, serviceApiKey)
     } else {
       toast.error(
         'Failed to fetch project configuration. Try refreshing your browser, or reach out to us at support@supabase.io'

--- a/apps/studio/components/layouts/StorageLayout/StorageLayout.tsx
+++ b/apps/studio/components/layouts/StorageLayout/StorageLayout.tsx
@@ -21,6 +21,7 @@ const StorageLayout = ({ title, children }: StorageLayoutProps) => {
   const storageExplorerStore = useStorageStore()
 
   const { data: settings, isLoading } = useProjectSettingsV2Query({ projectRef })
+  const protocol = settings?.app_config?.protocol ?? 'https'
   const endpoint = settings?.app_config?.endpoint
   const { serviceKey } = getAPIKeys(settings)
 
@@ -28,16 +29,20 @@ const StorageLayout = ({ title, children }: StorageLayoutProps) => {
 
   useEffect(() => {
     if (!isLoading && endpoint && serviceKey?.api_key) {
-      initializeStorageStore(endpoint, serviceKey.api_key)
+      initializeStorageStore(protocol, endpoint, serviceKey.api_key)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isLoading, projectRef, endpoint, serviceKey?.api_key])
 
-  const initializeStorageStore = async (endpoint: string, serviceApiKey: string) => {
+  const initializeStorageStore = async (
+    protocol: string,
+    endpoint: string,
+    serviceApiKey: string
+  ) => {
     if (isPaused) return
 
     if (endpoint) {
-      storageExplorerStore.initStore(projectRef!, endpoint, serviceApiKey, 'https')
+      storageExplorerStore.initStore(projectRef!, endpoint, serviceApiKey, protocol)
     } else {
       toast.error(
         'Failed to fetch project configuration. Try refreshing your browser, or reach out to us at support@supabase.io'

--- a/apps/studio/components/layouts/StorageLayout/StorageLayout.tsx
+++ b/apps/studio/components/layouts/StorageLayout/StorageLayout.tsx
@@ -37,7 +37,8 @@ const StorageLayout = ({ title, children }: StorageLayoutProps) => {
     if (isPaused) return
 
     if (endpoint) {
-      storageExplorerStore.initStore(projectRef!, endpoint, serviceApiKey)
+      const protocol = settings?.app_config?.protocol ?? 'https'
+      storageExplorerStore.initStore(projectRef!, endpoint, serviceApiKey, protocol)
     } else {
       toast.error(
         'Failed to fetch project configuration. Try refreshing your browser, or reach out to us at support@supabase.io'

--- a/apps/studio/components/to-be-cleaned/Storage/StorageExplorer/useCopyUrl.tsx
+++ b/apps/studio/components/to-be-cleaned/Storage/StorageExplorer/useCopyUrl.tsx
@@ -8,7 +8,9 @@ export const useCopyUrl = (ref: string) => {
   const { data: customDomainData } = useCustomDomainsQuery({ projectRef: ref })
   const { data: settings } = useProjectSettingsV2Query({ projectRef: ref })
 
-  const apiUrl = `https://${settings?.app_config?.endpoint ?? '-'}`
+  const protocol = settings?.app_config?.protocol ?? 'https'
+  const endpoint = settings?.app_config?.endpoint
+  const apiUrl = `${protocol}://${endpoint ?? '-'}`
 
   const onCopyUrl = (name: string, url: string | Promise<string>) => {
     const formattedUrl = Promise.resolve(url).then((url) => {

--- a/apps/studio/components/to-be-cleaned/Storage/StorageExplorer/useCopyUrl.tsx
+++ b/apps/studio/components/to-be-cleaned/Storage/StorageExplorer/useCopyUrl.tsx
@@ -2,15 +2,13 @@ import { toast } from 'sonner'
 
 import { useProjectSettingsV2Query } from 'data/config/project-settings-v2-query'
 import { useCustomDomainsQuery } from 'data/custom-domains/custom-domains-query'
-import { IS_PLATFORM } from 'lib/constants'
 import { copyToClipboard } from 'lib/helpers'
-import { PROJECT_ENDPOINT_PROTOCOL } from 'pages/api/constants'
 
 export const useCopyUrl = (ref: string) => {
   const { data: customDomainData } = useCustomDomainsQuery({ projectRef: ref })
   const { data: settings } = useProjectSettingsV2Query({ projectRef: ref })
 
-  const protocol = IS_PLATFORM ? 'https' : PROJECT_ENDPOINT_PROTOCOL
+  const protocol = settings?.app_config?.protocol ?? 'https'
   const endpoint = settings?.app_config?.endpoint
   const apiUrl = `${protocol}://${endpoint ?? '-'}`
 

--- a/apps/studio/components/to-be-cleaned/Storage/StorageExplorer/useCopyUrl.tsx
+++ b/apps/studio/components/to-be-cleaned/Storage/StorageExplorer/useCopyUrl.tsx
@@ -2,13 +2,15 @@ import { toast } from 'sonner'
 
 import { useProjectSettingsV2Query } from 'data/config/project-settings-v2-query'
 import { useCustomDomainsQuery } from 'data/custom-domains/custom-domains-query'
+import { IS_PLATFORM } from 'lib/constants'
 import { copyToClipboard } from 'lib/helpers'
+import { PROJECT_ENDPOINT_PROTOCOL } from 'pages/api/constants'
 
 export const useCopyUrl = (ref: string) => {
   const { data: customDomainData } = useCustomDomainsQuery({ projectRef: ref })
   const { data: settings } = useProjectSettingsV2Query({ projectRef: ref })
 
-  const protocol = settings?.app_config?.protocol ?? 'https'
+  const protocol = IS_PLATFORM ? 'https' : PROJECT_ENDPOINT_PROTOCOL
   const endpoint = settings?.app_config?.endpoint
   const apiUrl = `${protocol}://${endpoint ?? '-'}`
 

--- a/apps/studio/components/to-be-cleaned/Storage/StorageSettings/S3Connection.tsx
+++ b/apps/studio/components/to-be-cleaned/Storage/StorageSettings/S3Connection.tsx
@@ -41,9 +41,10 @@ export const S3Connection = () => {
     { enabled: canReadS3Credentials }
   )
 
+  const protocol = settings?.app_config?.protocol ?? 'https'
   const endpoint = settings?.app_config?.endpoint
   const hasStorageCreds = storageCreds?.data && storageCreds.data.length > 0
-  const s3connectionUrl = getConnectionURL(projectRef ?? '', endpoint)
+  const s3connectionUrl = getConnectionURL(projectRef ?? '', protocol, endpoint)
 
   return (
     <>

--- a/apps/studio/components/to-be-cleaned/Storage/StorageSettings/S3Connection.tsx
+++ b/apps/studio/components/to-be-cleaned/Storage/StorageSettings/S3Connection.tsx
@@ -15,6 +15,8 @@ import Panel from 'components/ui/Panel'
 import { useProjectSettingsV2Query } from 'data/config/project-settings-v2-query'
 import { useStorageCredentialsQuery } from 'data/storage/s3-access-key-query'
 import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import { IS_PLATFORM } from 'lib/constants'
+import { PROJECT_ENDPOINT_PROTOCOL } from 'pages/api/constants'
 import { AlertDescription_Shadcn_, Alert_Shadcn_, Button, WarningIcon } from 'ui'
 import { Input } from 'ui-patterns/DataInputs/Input'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
@@ -41,7 +43,7 @@ export const S3Connection = () => {
     { enabled: canReadS3Credentials }
   )
 
-  const protocol = settings?.app_config?.protocol ?? 'https'
+  const protocol = IS_PLATFORM ? 'https' : PROJECT_ENDPOINT_PROTOCOL
   const endpoint = settings?.app_config?.endpoint
   const hasStorageCreds = storageCreds?.data && storageCreds.data.length > 0
   const s3connectionUrl = getConnectionURL(projectRef ?? '', protocol, endpoint)

--- a/apps/studio/components/to-be-cleaned/Storage/StorageSettings/S3Connection.tsx
+++ b/apps/studio/components/to-be-cleaned/Storage/StorageSettings/S3Connection.tsx
@@ -15,8 +15,6 @@ import Panel from 'components/ui/Panel'
 import { useProjectSettingsV2Query } from 'data/config/project-settings-v2-query'
 import { useStorageCredentialsQuery } from 'data/storage/s3-access-key-query'
 import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
-import { IS_PLATFORM } from 'lib/constants'
-import { PROJECT_ENDPOINT_PROTOCOL } from 'pages/api/constants'
 import { AlertDescription_Shadcn_, Alert_Shadcn_, Button, WarningIcon } from 'ui'
 import { Input } from 'ui-patterns/DataInputs/Input'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
@@ -43,7 +41,7 @@ export const S3Connection = () => {
     { enabled: canReadS3Credentials }
   )
 
-  const protocol = IS_PLATFORM ? 'https' : PROJECT_ENDPOINT_PROTOCOL
+  const protocol = settings?.app_config?.protocol ?? 'https'
   const endpoint = settings?.app_config?.endpoint
   const hasStorageCreds = storageCreds?.data && storageCreds.data.length > 0
   const s3connectionUrl = getConnectionURL(projectRef ?? '', protocol, endpoint)

--- a/apps/studio/components/to-be-cleaned/Storage/StorageSettings/StorageSettings.utils.ts
+++ b/apps/studio/components/to-be-cleaned/Storage/StorageSettings/StorageSettings.utils.ts
@@ -25,8 +25,8 @@ export const convertToBytes = (size: number, unit: StorageSizeUnits = StorageSiz
   return size * Math.pow(k, i)
 }
 
-export function getConnectionURL(projectRef: string, endpoint?: string) {
-  const projUrl = endpoint ? `https://${endpoint}` : `https://${projectRef}.supabase.co`
+export function getConnectionURL(projectRef: string, protocol: string, endpoint?: string) {
+  const projUrl = endpoint ? `${protocol}://${endpoint}` : `https://${projectRef}.supabase.co`
 
   const url = new URL(projUrl)
   url.pathname = '/storage/v1/s3'

--- a/apps/studio/components/ui/ProjectSettings/DisplayConfigSettings.tsx
+++ b/apps/studio/components/ui/ProjectSettings/DisplayConfigSettings.tsx
@@ -30,7 +30,9 @@ const DisplayConfigSettings = () => {
     jwtSecretUpdateStatus === undefined || jwtSecretUpdateStatus === JwtSecretUpdateStatus.Updated
 
   const jwtSecret = config?.jwt_secret ?? ''
-  const apiUrl = `https://${settings?.app_config?.endpoint ?? '-'}`
+  const protocol = settings?.app_config?.protocol ?? 'https'
+  const endpoint = settings?.app_config?.endpoint
+  const apiUrl = endpoint ? `${protocol}://${endpoint}` : '-'
 
   return (
     <ConfigContentWrapper>

--- a/apps/studio/components/ui/ProjectSettings/DisplayConfigSettings.tsx
+++ b/apps/studio/components/ui/ProjectSettings/DisplayConfigSettings.tsx
@@ -7,8 +7,6 @@ import Panel from 'components/ui/Panel'
 import { useJwtSecretUpdatingStatusQuery } from 'data/config/jwt-secret-updating-status-query'
 import { useProjectPostgrestConfigQuery } from 'data/config/project-postgrest-config-query'
 import { useProjectSettingsV2Query } from 'data/config/project-settings-v2-query'
-import { IS_PLATFORM } from 'lib/constants'
-import { PROJECT_ENDPOINT_PROTOCOL } from 'pages/api/constants'
 import { Input } from 'ui'
 
 const DisplayConfigSettings = () => {
@@ -32,7 +30,7 @@ const DisplayConfigSettings = () => {
     jwtSecretUpdateStatus === undefined || jwtSecretUpdateStatus === JwtSecretUpdateStatus.Updated
 
   const jwtSecret = config?.jwt_secret ?? ''
-  const protocol = IS_PLATFORM ? 'https' : PROJECT_ENDPOINT_PROTOCOL
+  const protocol = settings?.app_config?.protocol ?? 'https'
   const endpoint = settings?.app_config?.endpoint
   const apiUrl = endpoint ? `${protocol}://${endpoint}` : '-'
 

--- a/apps/studio/components/ui/ProjectSettings/DisplayConfigSettings.tsx
+++ b/apps/studio/components/ui/ProjectSettings/DisplayConfigSettings.tsx
@@ -7,6 +7,8 @@ import Panel from 'components/ui/Panel'
 import { useJwtSecretUpdatingStatusQuery } from 'data/config/jwt-secret-updating-status-query'
 import { useProjectPostgrestConfigQuery } from 'data/config/project-postgrest-config-query'
 import { useProjectSettingsV2Query } from 'data/config/project-settings-v2-query'
+import { IS_PLATFORM } from 'lib/constants'
+import { PROJECT_ENDPOINT_PROTOCOL } from 'pages/api/constants'
 import { Input } from 'ui'
 
 const DisplayConfigSettings = () => {
@@ -30,7 +32,7 @@ const DisplayConfigSettings = () => {
     jwtSecretUpdateStatus === undefined || jwtSecretUpdateStatus === JwtSecretUpdateStatus.Updated
 
   const jwtSecret = config?.jwt_secret ?? ''
-  const protocol = settings?.app_config?.protocol ?? 'https'
+  const protocol = IS_PLATFORM ? 'https' : PROJECT_ENDPOINT_PROTOCOL
   const endpoint = settings?.app_config?.endpoint
   const apiUrl = endpoint ? `${protocol}://${endpoint}` : '-'
 

--- a/apps/studio/data/auth/user-create-mutation.ts
+++ b/apps/studio/data/auth/user-create-mutation.ts
@@ -1,15 +1,15 @@
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
-import { useFlag } from 'hooks/ui/useFlag'
+import { sqlKeys } from 'data/sql/keys'
 import { post } from 'lib/common/fetch'
+import { IS_PLATFORM } from 'lib/constants'
+import { PROJECT_ENDPOINT_PROTOCOL } from 'pages/api/constants'
 import type { ResponseError } from 'types'
 import { authKeys } from './keys'
-import { sqlKeys } from 'data/sql/keys'
 
 export type UserCreateVariables = {
   projectRef?: string
-  protocol: string
   endpoint: string
   serviceApiKey: string
   user: {
@@ -36,7 +36,8 @@ export type UserCreateResponse = {
   user_metadata: any
 }
 
-export async function createUser({ protocol, endpoint, serviceApiKey, user }: UserCreateVariables) {
+export async function createUser({ endpoint, serviceApiKey, user }: UserCreateVariables) {
+  const protocol = IS_PLATFORM ? 'https' : PROJECT_ENDPOINT_PROTOCOL
   const response = await post(
     `${protocol}://${endpoint}/auth/v1/admin/users`,
     {

--- a/apps/studio/data/auth/user-create-mutation.ts
+++ b/apps/studio/data/auth/user-create-mutation.ts
@@ -10,6 +10,7 @@ import { authKeys } from './keys'
 
 export type UserCreateVariables = {
   projectRef?: string
+  protocol: string
   endpoint: string
   serviceApiKey: string
   user: {
@@ -36,8 +37,7 @@ export type UserCreateResponse = {
   user_metadata: any
 }
 
-export async function createUser({ endpoint, serviceApiKey, user }: UserCreateVariables) {
-  const protocol = IS_PLATFORM ? 'https' : PROJECT_ENDPOINT_PROTOCOL
+export async function createUser({ protocol, endpoint, serviceApiKey, user }: UserCreateVariables) {
   const response = await post(
     `${protocol}://${endpoint}/auth/v1/admin/users`,
     {

--- a/apps/studio/data/auth/user-update-mutation.ts
+++ b/apps/studio/data/auth/user-update-mutation.ts
@@ -9,6 +9,7 @@ import { authKeys } from './keys'
 
 export type UserUpdateVariables = {
   projectRef?: string
+  protocol: string
   endpoint: string
   serviceApiKey: string
 
@@ -18,6 +19,7 @@ export type UserUpdateVariables = {
 }
 
 export async function updateUser({
+  protocol,
   endpoint,
   serviceApiKey,
   userId,
@@ -25,7 +27,6 @@ export async function updateUser({
 }: UserUpdateVariables) {
   // [Joshen] This is probably the only endpoint that needs the put method from lib/common/fetch
   // as it's not our internal API.
-  const protocol = IS_PLATFORM ? 'https' : PROJECT_ENDPOINT_PROTOCOL
   const response = await put(
     `${protocol}://${endpoint}/auth/v1/admin/users/${userId}`,
     { ban_duration: typeof banDuration === 'number' ? `${banDuration}h` : banDuration },

--- a/apps/studio/data/auth/user-update-mutation.ts
+++ b/apps/studio/data/auth/user-update-mutation.ts
@@ -1,14 +1,14 @@
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
-import { useFlag } from 'hooks/ui/useFlag'
 import { put } from 'lib/common/fetch'
+import { IS_PLATFORM } from 'lib/constants'
+import { PROJECT_ENDPOINT_PROTOCOL } from 'pages/api/constants'
 import type { ResponseError } from 'types'
 import { authKeys } from './keys'
 
 export type UserUpdateVariables = {
   projectRef?: string
-  protocol: string
   endpoint: string
   serviceApiKey: string
 
@@ -18,7 +18,6 @@ export type UserUpdateVariables = {
 }
 
 export async function updateUser({
-  protocol,
   endpoint,
   serviceApiKey,
   userId,
@@ -26,6 +25,7 @@ export async function updateUser({
 }: UserUpdateVariables) {
   // [Joshen] This is probably the only endpoint that needs the put method from lib/common/fetch
   // as it's not our internal API.
+  const protocol = IS_PLATFORM ? 'https' : PROJECT_ENDPOINT_PROTOCOL
   const response = await put(
     `${protocol}://${endpoint}/auth/v1/admin/users/${userId}`,
     { ban_duration: typeof banDuration === 'number' ? `${banDuration}h` : banDuration },

--- a/apps/studio/data/config/project-settings-v2-query.ts
+++ b/apps/studio/data/config/project-settings-v2-query.ts
@@ -8,7 +8,12 @@ import type { ResponseError } from 'types'
 import { configKeys } from './keys'
 
 export type ProjectSettingsVariables = { projectRef?: string }
-export type ProjectSettings = components['schemas']['ProjectSettingsResponse']
+
+// Manually add the protocol property to the response - specifically just for the local/CLI environment
+type ProjectAppConfig = components['schemas']['ProjectAppConfigResponse'] & { protocol?: string }
+export type ProjectSettings = components['schemas']['ProjectSettingsResponse'] & {
+  app_config?: ProjectAppConfig
+}
 
 export async function getProjectSettings(
   { projectRef }: ProjectSettingsVariables,

--- a/apps/studio/data/config/project-settings-v2-query.ts
+++ b/apps/studio/data/config/project-settings-v2-query.ts
@@ -8,12 +8,7 @@ import type { ResponseError } from 'types'
 import { configKeys } from './keys'
 
 export type ProjectSettingsVariables = { projectRef?: string }
-
-// manually add protocol to the response to make the local/CLI environment
-type ProjectAppConfig = components['schemas']['ProjectAppConfigResponse'] & { protocol?: string }
-export type ProjectSettings = components['schemas']['ProjectSettingsResponse'] & {
-  app_config?: ProjectAppConfig
-}
+export type ProjectSettings = components['schemas']['ProjectSettingsResponse']
 
 export async function getProjectSettings(
   { projectRef }: ProjectSettingsVariables,

--- a/apps/studio/data/config/project-settings-v2-query.ts
+++ b/apps/studio/data/config/project-settings-v2-query.ts
@@ -8,7 +8,12 @@ import type { ResponseError } from 'types'
 import { configKeys } from './keys'
 
 export type ProjectSettingsVariables = { projectRef?: string }
-export type ProjectSettings = components['schemas']['ProjectSettingsResponse']
+
+// manually add protocol to the response to make the local/CLI environment
+type ProjectAppConfig = components['schemas']['ProjectAppConfigResponse'] & { protocol?: string }
+export type ProjectSettings = components['schemas']['ProjectSettingsResponse'] & {
+  app_config?: ProjectAppConfig
+}
 
 export async function getProjectSettings(
   { projectRef }: ProjectSettingsVariables,

--- a/apps/studio/data/telemetry/send-event-mutation.ts
+++ b/apps/studio/data/telemetry/send-event-mutation.ts
@@ -3,6 +3,7 @@ import { components } from 'api-types'
 
 import { isBrowser, LOCAL_STORAGE_KEYS } from 'common'
 import { handleError, post } from 'data/fetchers'
+import { IS_PLATFORM } from 'lib/constants'
 import { useRouter } from 'next/router'
 import type { ResponseError } from 'types'
 
@@ -23,7 +24,7 @@ export async function sendEvent({ body }: { body: SendEventPayload }) {
       ? localStorage.getItem(LOCAL_STORAGE_KEYS.TELEMETRY_CONSENT)
       : null) === 'true'
 
-  if (!consent) return undefined
+  if (!consent || !IS_PLATFORM) return undefined
 
   const headers = { Version: '2' }
   const { data, error } = await post(`/platform/telemetry/event`, { body, headers })

--- a/apps/studio/data/telemetry/send-groups-identify-mutation.ts
+++ b/apps/studio/data/telemetry/send-groups-identify-mutation.ts
@@ -3,6 +3,7 @@ import { useMutation, UseMutationOptions } from '@tanstack/react-query'
 import { components } from 'api-types'
 import { LOCAL_STORAGE_KEYS } from 'common'
 import { handleError, post } from 'data/fetchers'
+import { IS_PLATFORM } from 'lib/constants'
 import type { ResponseError } from 'types'
 
 export type SendGroupsIdentifyVariables = components['schemas']['TelemetryGroupsIdentityBody']
@@ -13,7 +14,7 @@ export async function sendGroupsIdentify({ body }: { body: SendGroupsIdentifyVar
       ? localStorage.getItem(LOCAL_STORAGE_KEYS.TELEMETRY_CONSENT)
       : null) === 'true'
 
-  if (!consent) return undefined
+  if (!consent || !IS_PLATFORM) return undefined
 
   const { data, error } = await post(`/platform/telemetry/groups/identify`, {
     body,

--- a/apps/studio/data/telemetry/send-groups-reset-mutation.ts
+++ b/apps/studio/data/telemetry/send-groups-reset-mutation.ts
@@ -3,6 +3,7 @@ import { useMutation, UseMutationOptions } from '@tanstack/react-query'
 import { components } from 'api-types'
 import { LOCAL_STORAGE_KEYS } from 'common'
 import { handleError, post } from 'data/fetchers'
+import { IS_PLATFORM } from 'lib/constants'
 import type { ResponseError } from 'types'
 
 export type SendGroupsResetVariables = components['schemas']['TelemetryGroupsResetBody']
@@ -13,7 +14,7 @@ export async function sendGroupsReset({ body }: { body: SendGroupsResetVariables
       ? localStorage.getItem(LOCAL_STORAGE_KEYS.TELEMETRY_CONSENT)
       : null) === 'true'
 
-  if (!consent) return undefined
+  if (!consent || !IS_PLATFORM) return undefined
 
   const { data, error } = await post(`/platform/telemetry/groups/reset`, {
     body,

--- a/apps/studio/data/telemetry/send-identify-mutation.ts
+++ b/apps/studio/data/telemetry/send-identify-mutation.ts
@@ -4,6 +4,7 @@ import { components } from 'api-types'
 import { LOCAL_STORAGE_KEYS } from 'common'
 import { handleError, post } from 'data/fetchers'
 import { Profile } from 'data/profile/types'
+import { IS_PLATFORM } from 'lib/constants'
 import type { ResponseError } from 'types'
 
 type SendIdentify = components['schemas']['TelemetryIdentifyBodyV2']
@@ -22,7 +23,7 @@ export async function sendIdentify({ body }: { body: SendIdentifyPayload }) {
       ? localStorage.getItem(LOCAL_STORAGE_KEYS.TELEMETRY_CONSENT)
       : null) === 'true'
 
-  if (!consent) return undefined
+  if (!consent || !IS_PLATFORM) return undefined
 
   const headers = { Version: '2' }
   const { data, error } = await post(`/platform/telemetry/identify`, { body, headers })

--- a/apps/studio/data/telemetry/send-page-leave-mutation.ts
+++ b/apps/studio/data/telemetry/send-page-leave-mutation.ts
@@ -3,6 +3,7 @@ import { components } from 'api-types'
 
 import { LOCAL_STORAGE_KEYS } from 'common'
 import { handleError, post } from 'data/fetchers'
+import { IS_PLATFORM } from 'lib/constants'
 import { useRouter } from 'next/router'
 import type { ResponseError } from 'types'
 
@@ -14,7 +15,7 @@ export async function sendPageLeave({ body }: { body: SendPageLeaveBody }) {
       ? localStorage.getItem(LOCAL_STORAGE_KEYS.TELEMETRY_CONSENT)
       : null) === 'true'
 
-  if (!consent) return undefined
+  if (!consent || !IS_PLATFORM) return undefined
 
   const { data, error } = await post(`/platform/telemetry/page-leave`, {
     body,

--- a/apps/studio/data/telemetry/send-page-mutation.ts
+++ b/apps/studio/data/telemetry/send-page-mutation.ts
@@ -3,6 +3,7 @@ import { useMutation, UseMutationOptions } from '@tanstack/react-query'
 import { components } from 'api-types'
 import { isBrowser, LOCAL_STORAGE_KEYS } from 'common'
 import { handleError, post } from 'data/fetchers'
+import { IS_PLATFORM } from 'lib/constants'
 import { useRouter } from 'next/router'
 import type { ResponseError } from 'types'
 
@@ -20,7 +21,7 @@ export async function sendPage({ body }: { body: SendPagePayload }) {
       ? localStorage.getItem(LOCAL_STORAGE_KEYS.TELEMETRY_CONSENT)
       : null) === 'true'
 
-  if (!consent) return undefined
+  if (!consent || !IS_PLATFORM) return undefined
 
   const headers = { Version: '2' }
   const { data, error } = await post(`/platform/telemetry/page`, { body, headers })

--- a/apps/studio/data/telemetry/send-reset-mutation.ts
+++ b/apps/studio/data/telemetry/send-reset-mutation.ts
@@ -1,9 +1,12 @@
 import { useMutation, UseMutationOptions } from '@tanstack/react-query'
 
 import { handleError, post } from 'data/fetchers'
+import { IS_PLATFORM } from 'lib/constants'
 import type { ResponseError } from 'types'
 
 export async function sendReset() {
+  if (!IS_PLATFORM) return undefined
+
   const { data, error } = await post(`/platform/telemetry/reset`, {})
   if (error) handleError(error)
   return data

--- a/apps/studio/localStores/storageExplorer/StorageExplorerStore.tsx
+++ b/apps/studio/localStores/storageExplorer/StorageExplorerStore.tsx
@@ -44,6 +44,7 @@ import { IS_PLATFORM } from 'lib/constants'
 import { lookupMime } from 'lib/mime'
 import Link from 'next/link'
 import { Button, SONNER_DEFAULT_DURATION, SonnerProgress } from 'ui'
+import { PROJECT_ENDPOINT_PROTOCOL } from 'pages/api/constants'
 
 type CachedFile = { id: string; fetchedAt: number; expiresIn: number; url: string }
 
@@ -127,7 +128,8 @@ class StorageExplorerStore {
     }
   }
 
-  initStore(projectRef: string, url: string, serviceKey: string, protocol: string) {
+  initStore(projectRef: string, url: string, serviceKey: string) {
+    const protocol = IS_PLATFORM ? 'https' : PROJECT_ENDPOINT_PROTOCOL
     this.projectRef = projectRef
     this.resumableUploadUrl = `${IS_PLATFORM ? 'https' : protocol}://${url}/storage/v1/upload/resumable`
     this.serviceKey = serviceKey

--- a/apps/studio/localStores/storageExplorer/StorageExplorerStore.tsx
+++ b/apps/studio/localStores/storageExplorer/StorageExplorerStore.tsx
@@ -42,9 +42,8 @@ import { Bucket } from 'data/storage/buckets-query'
 import { moveStorageObject } from 'data/storage/object-move-mutation'
 import { IS_PLATFORM } from 'lib/constants'
 import { lookupMime } from 'lib/mime'
-import { PROJECT_ENDPOINT_PROTOCOL } from 'pages/api/constants'
-import { Button, SONNER_DEFAULT_DURATION, SonnerProgress } from 'ui'
 import Link from 'next/link'
+import { Button, SONNER_DEFAULT_DURATION, SonnerProgress } from 'ui'
 
 type CachedFile = { id: string; fetchedAt: number; expiresIn: number; url: string }
 
@@ -128,12 +127,7 @@ class StorageExplorerStore {
     }
   }
 
-  initStore(
-    projectRef: string,
-    url: string,
-    serviceKey: string,
-    protocol: string = PROJECT_ENDPOINT_PROTOCOL
-  ) {
+  initStore(projectRef: string, url: string, serviceKey: string, protocol: string) {
     this.projectRef = projectRef
     this.resumableUploadUrl = `${IS_PLATFORM ? 'https' : protocol}://${url}/storage/v1/upload/resumable`
     this.serviceKey = serviceKey

--- a/apps/studio/localStores/storageExplorer/StorageExplorerStore.tsx
+++ b/apps/studio/localStores/storageExplorer/StorageExplorerStore.tsx
@@ -128,8 +128,7 @@ class StorageExplorerStore {
     }
   }
 
-  initStore(projectRef: string, url: string, serviceKey: string) {
-    const protocol = IS_PLATFORM ? 'https' : PROJECT_ENDPOINT_PROTOCOL
+  initStore(projectRef: string, url: string, serviceKey: string, protocol: string) {
     this.projectRef = projectRef
     this.resumableUploadUrl = `${IS_PLATFORM ? 'https' : protocol}://${url}/storage/v1/upload/resumable`
     this.serviceKey = serviceKey

--- a/apps/studio/pages/api/projects/[ref]/settings.ts
+++ b/apps/studio/pages/api/projects/[ref]/settings.ts
@@ -1,7 +1,7 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import { components } from 'api-types'
 import apiWrapper from 'lib/api/apiWrapper'
+import { extractResponse, PROJECT_ENDPOINT, PROJECT_ENDPOINT_PROTOCOL } from 'pages/api/constants'
 
 export default (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)
 
@@ -17,20 +17,23 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
   }
 }
 
-const handleGetAll = async (req: NextApiRequest, res: NextApiResponse) => {
+type ResponseData = extractResponse<'/platform/projects/{ref}/settings', 'get'>
+
+const handleGetAll = async (req: NextApiRequest, res: NextApiResponse<ResponseData>) => {
   // Platform specific endpoint
-  const response: components['schemas']['ProjectSettingsResponse'] = {
+  const response = {
     app_config: {
       db_schema: 'public',
-      endpoint: '',
+      endpoint: PROJECT_ENDPOINT,
+      // manually added to force the frontend to use the correct URL
+      protocol: PROJECT_ENDPOINT_PROTOCOL,
     },
     cloud_provider: 'AWS',
-    db_dns_name: '',
+    db_dns_name: '-',
     db_host: 'localhost',
-    dp_ip_addr_config: '',
+    db_ip_addr_config: 'legacy' as const,
     db_name: 'postgres',
-    // @ts-expect-error API is typed wrongly
-    db_port: 5432,
+    db_port: '5432',
     db_user: 'postgres',
     inserted_at: '2021-08-02T06:40:40.646Z',
     jwt_secret:

--- a/apps/studio/pages/api/projects/[ref]/settings.ts
+++ b/apps/studio/pages/api/projects/[ref]/settings.ts
@@ -1,7 +1,8 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
+import { components } from 'api-types'
 import apiWrapper from 'lib/api/apiWrapper'
-import { extractResponse, PROJECT_ENDPOINT, PROJECT_ENDPOINT_PROTOCOL } from 'pages/api/constants'
+import { PROJECT_ENDPOINT } from 'pages/api/constants'
 
 export default (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)
 
@@ -17,23 +18,20 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
   }
 }
 
-type ResponseData = extractResponse<'/platform/projects/{ref}/settings', 'get'>
-
-const handleGetAll = async (req: NextApiRequest, res: NextApiResponse<ResponseData>) => {
+const handleGetAll = async (req: NextApiRequest, res: NextApiResponse) => {
   // Platform specific endpoint
-  const response = {
+  const response: components['schemas']['ProjectSettingsResponse'] = {
     app_config: {
       db_schema: 'public',
       endpoint: PROJECT_ENDPOINT,
-      // manually added to force the frontend to use the correct URL
-      protocol: PROJECT_ENDPOINT_PROTOCOL,
     },
     cloud_provider: 'AWS',
     db_dns_name: '-',
     db_host: 'localhost',
-    db_ip_addr_config: 'legacy' as const,
+    dp_ip_addr_config: 'legacy' as const,
     db_name: 'postgres',
-    db_port: '5432',
+    // @ts-expect-error API is typed wrongly
+    db_port: 5432,
     db_user: 'postgres',
     inserted_at: '2021-08-02T06:40:40.646Z',
     jwt_secret:

--- a/apps/studio/pages/api/projects/[ref]/settings.ts
+++ b/apps/studio/pages/api/projects/[ref]/settings.ts
@@ -2,7 +2,12 @@ import { NextApiRequest, NextApiResponse } from 'next'
 
 import { components } from 'api-types'
 import apiWrapper from 'lib/api/apiWrapper'
-import { PROJECT_ENDPOINT } from 'pages/api/constants'
+import { PROJECT_ENDPOINT, PROJECT_ENDPOINT_PROTOCOL } from 'pages/api/constants'
+
+type ProjectAppConfig = components['schemas']['ProjectAppConfigResponse'] & { protocol?: string }
+export type ProjectSettings = components['schemas']['ProjectSettingsResponse'] & {
+  app_config?: ProjectAppConfig
+}
 
 export default (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)
 
@@ -20,10 +25,13 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
 
 const handleGetAll = async (req: NextApiRequest, res: NextApiResponse) => {
   // Platform specific endpoint
-  const response: components['schemas']['ProjectSettingsResponse'] = {
+  console.log('AHH', PROJECT_ENDPOINT)
+  const response: ProjectSettings = {
     app_config: {
       db_schema: 'public',
       endpoint: PROJECT_ENDPOINT,
+      // manually added to force the frontend to use the correct URL
+      protocol: PROJECT_ENDPOINT_PROTOCOL,
     },
     cloud_provider: 'AWS',
     db_dns_name: '-',

--- a/apps/studio/pages/api/projects/[ref]/settings.ts
+++ b/apps/studio/pages/api/projects/[ref]/settings.ts
@@ -24,8 +24,6 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
 }
 
 const handleGetAll = async (req: NextApiRequest, res: NextApiResponse) => {
-  // Platform specific endpoint
-  console.log('AHH', PROJECT_ENDPOINT)
   const response: ProjectSettings = {
     app_config: {
       db_schema: 'public',

--- a/apps/studio/pages/project/[ref]/api/index.tsx
+++ b/apps/studio/pages/project/[ref]/api/index.tsx
@@ -37,10 +37,12 @@ const DocView = () => {
 
   const refreshDocs = async () => await refetch()
 
+  const protocol = settings?.app_config?.protocol ?? 'https'
+  const hostEndpoint = settings?.app_config?.endpoint
   const endpoint =
     customDomainData?.customDomain?.status === 'active'
       ? `https://${customDomainData.customDomain?.hostname}`
-      : `https://${settings?.app_config?.endpoint ?? '-'}`
+      : `${protocol}://${hostEndpoint ?? '-'}`
 
   const { paths } = jsonSchema || {}
   const PAGE_KEY: any = resource || rpc || page || 'index'

--- a/apps/studio/pages/project/[ref]/api/index.tsx
+++ b/apps/studio/pages/project/[ref]/api/index.tsx
@@ -9,8 +9,6 @@ import { useCustomDomainsQuery } from 'data/custom-domains/custom-domains-query'
 import { useProjectJsonSchemaQuery } from 'data/docs/project-json-schema-query'
 import { snakeToCamel } from 'lib/helpers'
 import type { NextPageWithLayout } from 'types'
-import { IS_PLATFORM } from 'lib/constants'
-import { PROJECT_ENDPOINT_PROTOCOL } from 'pages/api/constants'
 
 const PageConfig: NextPageWithLayout = () => {
   return <DocView />
@@ -39,7 +37,7 @@ const DocView = () => {
 
   const refreshDocs = async () => await refetch()
 
-  const protocol = IS_PLATFORM ? 'https' : PROJECT_ENDPOINT_PROTOCOL
+  const protocol = settings?.app_config?.protocol ?? 'https'
   const hostEndpoint = settings?.app_config?.endpoint
   const endpoint =
     customDomainData?.customDomain?.status === 'active'

--- a/apps/studio/pages/project/[ref]/api/index.tsx
+++ b/apps/studio/pages/project/[ref]/api/index.tsx
@@ -9,6 +9,8 @@ import { useCustomDomainsQuery } from 'data/custom-domains/custom-domains-query'
 import { useProjectJsonSchemaQuery } from 'data/docs/project-json-schema-query'
 import { snakeToCamel } from 'lib/helpers'
 import type { NextPageWithLayout } from 'types'
+import { IS_PLATFORM } from 'lib/constants'
+import { PROJECT_ENDPOINT_PROTOCOL } from 'pages/api/constants'
 
 const PageConfig: NextPageWithLayout = () => {
   return <DocView />
@@ -37,7 +39,7 @@ const DocView = () => {
 
   const refreshDocs = async () => await refetch()
 
-  const protocol = settings?.app_config?.protocol ?? 'https'
+  const protocol = IS_PLATFORM ? 'https' : PROJECT_ENDPOINT_PROTOCOL
   const hostEndpoint = settings?.app_config?.endpoint
   const endpoint =
     customDomainData?.customDomain?.status === 'active'


### PR DESCRIPTION
This PR reverts part of https://github.com/supabase/supabase/pull/30025 which assumed that all API urls start with https always.

Should further resolve https://github.com/supabase/cli/issues/2834