### PR TITLE
chore: use service versions endpoint

### DIFF
--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureInfo.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureInfo.tsx
@@ -127,7 +127,7 @@ const InfrastructureInfo = () => {
                         <Input
                           readOnly
                           disabled
-                          value={currentPgVersion}
+                          value={currentPgVersion || serviceVersions?.['supabase-postgres'] || ''}
                           label="Postgres version"
                           actions={[
                             isOnNonGenerallyAvailableReleaseChannel && (

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureInfo.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureInfo.tsx
@@ -10,6 +10,7 @@ import {
 import AlertError from 'components/ui/AlertError'
 import { GenericSkeletonLoader } from 'components/ui/ShimmeringLoader'
 import { useProjectUpgradeEligibilityQuery } from 'data/config/project-upgrade-eligibility-query'
+import { useProjectServiceVersionsQuery } from 'data/projects/project-service-versions'
 import { useReadReplicasQuery } from 'data/read-replicas/replicas-query'
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
 import {
@@ -41,6 +42,15 @@ const InfrastructureInfo = () => {
   } = useProjectUpgradeEligibilityQuery({
     projectRef: ref,
   })
+
+  const {
+    data: serviceVersions,
+    error: serviceVersionsError,
+    isLoading: isLoadingServiceVersions,
+    isError: isErrorServiceVersions,
+    isSuccess: isSuccessServiceVersions,
+  } = useProjectServiceVersionsQuery({ projectRef: ref })
+
   const { data: databases } = useReadReplicasQuery({ projectRef: ref })
   const { current_app_version, current_app_version_release_channel, latest_app_version } =
     data || {}
@@ -91,53 +101,66 @@ const InfrastructureInfo = () => {
                 )}
                 {isSuccessUpgradeEligibility && (
                   <>
-                    {authEnabled && (
-                      <Input
-                        readOnly
-                        disabled
-                        label="Auth version"
-                        value={project?.serviceVersions?.gotrue ?? ''}
+                    {isLoadingServiceVersions && <GenericSkeletonLoader />}
+                    {isErrorServiceVersions && (
+                      <AlertError
+                        error={serviceVersionsError}
+                        subject="Failed to retrieve versions"
                       />
                     )}
-                    <Input
-                      readOnly
-                      disabled
-                      label="PostgREST version"
-                      value={project?.serviceVersions?.postgrest ?? ''}
-                    />
-                    <Input
-                      readOnly
-                      disabled
-                      value={currentPgVersion}
-                      label="Postgres version"
-                      actions={[
-                        isOnNonGenerallyAvailableReleaseChannel && (
-                          <Tooltip_Shadcn_>
-                            <TooltipTrigger_Shadcn_>
-                              <Badge variant="warning" className="mr-1 capitalize">
-                                {isOnNonGenerallyAvailableReleaseChannel}
-                              </Badge>
-                            </TooltipTrigger_Shadcn_>
-                            <TooltipContent_Shadcn_ side="bottom" className="w-44 text-center">
-                              This project uses a {isOnNonGenerallyAvailableReleaseChannel} database
-                              version release
-                            </TooltipContent_Shadcn_>
-                          </Tooltip_Shadcn_>
-                        ),
-                        isOnLatestVersion && (
-                          <Tooltip_Shadcn_>
-                            <TooltipTrigger_Shadcn_>
-                              <Badge variant="brand" className="mr-1">
-                                Latest
-                              </Badge>
-                            </TooltipTrigger_Shadcn_>
-                            <TooltipContent_Shadcn_ side="bottom" className="w-52 text-center">
-                              Project is on the latest version of Postgres that Supabase supports
-                            </TooltipContent_Shadcn_>
-                          </Tooltip_Shadcn_>
-                        ),
-                      ]}
-                    />
+                    {isSuccessServiceVersions && (
+                      <>
+                        {authEnabled && (
+                          <Input
+                            readOnly
+                            disabled
+                            label="Auth version"
+                            value={serviceVersions?.gotrue ?? ''}
+                          />
+                        )}
+                        <Input
+                          readOnly
+                          disabled
+                          label="PostgREST version"
+                          value={serviceVersions?.postgrest ?? ''}
+                        />
+                        <Input
+                          readOnly
+                          disabled
+                          value={currentPgVersion}
+                          label="Postgres version"
+                          actions={[
+                            isOnNonGenerallyAvailableReleaseChannel && (
+                              <Tooltip_Shadcn_>
+                                <TooltipTrigger_Shadcn_>
+                                  <Badge variant="warning" className="mr-1 capitalize">
+                                    {isOnNonGenerallyAvailableReleaseChannel}
+                                  </Badge>
+                                </TooltipTrigger_Shadcn_>
+                                <TooltipContent_Shadcn_ side="bottom" className="w-44 text-center">
+                                  This project uses a {isOnNonGenerallyAvailableReleaseChannel}{' '}
+                                  database version release
+                                </TooltipContent_Shadcn_>
+                              </Tooltip_Shadcn_>
+                            ),
+                            isOnLatestVersion && (
+                              <Tooltip_Shadcn_>
+                                <TooltipTrigger_Shadcn_>
+                                  <Badge variant="brand" className="mr-1">
+                                    Latest
+                                  </Badge>
+                                </TooltipTrigger_Shadcn_>
+                                <TooltipContent_Shadcn_ side="bottom" className="w-52 text-center">
+                                  Project is on the latest version of Postgres that Supabase
+                                  supports
+                                </TooltipContent_Shadcn_>
+                              </Tooltip_Shadcn_>
+                            ),
+                          ]}
+                        />
+                      </>
+                    )}
+
                     {data?.eligible && !hasReadReplicas && <ProjectUpgradeAlert />}
                     {data.eligible && hasReadReplicas && (
                       <Alert_Shadcn_>

--- a/apps/studio/data/analytics/project-daily-stats-query.ts
+++ b/apps/studio/data/analytics/project-daily-stats-query.ts
@@ -1,18 +1,13 @@
 import { useQuery, UseQueryOptions } from '@tanstack/react-query'
 import dayjs from 'dayjs'
 
+import { operations } from 'api-types'
 import { get, handleError } from 'data/fetchers'
 import type { AnalyticsData } from './constants'
 import { analyticsKeys } from './keys'
 
 export type ProjectDailyStatsAttribute =
-  | 'max_cpu_usage'
-  | 'avg_cpu_usage'
-  | 'disk_io_budget'
-  | 'ram_usage'
-  | 'disk_io_consumption'
-  | 'swap_usage'
-
+  operations['DailyStatsController_getDailyStats']['parameters']['query']['attribute']
 export type ProjectDailyStatsInterval = '1m' | '5m' | '10m' | '30m' | '1h' | '1d'
 
 export type ProjectDailyStatsVariables = {

--- a/apps/studio/data/projects/keys.ts
+++ b/apps/studio/data/projects/keys.ts
@@ -3,6 +3,8 @@ export const projectKeys = {
   status: (projectRef: string | undefined) => ['project', projectRef, 'status'] as const,
   types: (projectRef: string | undefined) => ['project', projectRef, 'types'] as const,
   detail: (projectRef: string | undefined) => ['project', projectRef, 'detail'] as const,
+  serviceVersions: (projectRef: string | undefined) =>
+    ['project', projectRef, 'service-versions'] as const,
   readonlyStatusList: () => ['projects', 'readonly-statuses'] as const,
   readonlyStatus: (projectRef: string | undefined) =>
     ['projects', projectRef, 'readonly-status'] as const,

--- a/apps/studio/data/projects/project-service-versions.ts
+++ b/apps/studio/data/projects/project-service-versions.ts
@@ -1,0 +1,42 @@
+import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+
+import { get, handleError } from 'data/fetchers'
+import type { ResponseError } from 'types'
+import { projectKeys } from './keys'
+
+export type ProjectServiceVersionsVariables = {
+  projectRef?: string
+}
+
+export async function getProjectServiceVersions(
+  { projectRef }: ProjectServiceVersionsVariables,
+  signal?: AbortSignal
+) {
+  if (!projectRef) throw new Error('projectRef is required')
+
+  const { data, error } = await get(`/platform/projects/{ref}/service-versions`, {
+    params: { path: { ref: projectRef } },
+    signal,
+  })
+  if (error) handleError(error)
+  return data
+}
+
+export type ProjectServiceVersionsData = Awaited<ReturnType<typeof getProjectServiceVersions>>
+export type ProjectServiceVersionsError = ResponseError
+
+export const useProjectServiceVersionsQuery = <TData = ProjectServiceVersionsData>(
+  { projectRef }: ProjectServiceVersionsVariables,
+  {
+    enabled = true,
+    ...options
+  }: UseQueryOptions<ProjectServiceVersionsData, ProjectServiceVersionsError, TData> = {}
+) =>
+  useQuery<ProjectServiceVersionsData, ProjectServiceVersionsError, TData>(
+    projectKeys.serviceVersions(projectRef),
+    ({ signal }) => getProjectServiceVersions({ projectRef }, signal),
+    {
+      enabled: enabled && typeof projectRef !== 'undefined',
+      ...options,
+    }
+  )

--- a/apps/studio/pages/api/projects/[ref]/settings.ts
+++ b/apps/studio/pages/api/projects/[ref]/settings.ts
@@ -34,9 +34,8 @@ const handleGetAll = async (req: NextApiRequest, res: NextApiResponse) => {
     cloud_provider: 'AWS',
     db_dns_name: '-',
     db_host: 'localhost',
-    dp_ip_addr_config: 'legacy' as const,
+    db_ip_addr_config: 'legacy' as const,
     db_name: 'postgres',
-    // @ts-expect-error API is typed wrongly
     db_port: 5432,
     db_user: 'postgres',
     inserted_at: '2021-08-02T06:40:40.646Z',

--- a/apps/studio/types/base.ts
+++ b/apps/studio/types/base.ts
@@ -44,7 +44,6 @@ export interface Project extends ProjectBase {
   maxDatabasePreprovisionGb?: string | null
   parent_project_ref?: string
   is_branch_enabled?: boolean
-  serviceVersions: { gotrue: string; postgrest: string; 'supabase-postgres': string }
 
   /**
    * postgrestStatus is available on client side only.

--- a/packages/api-types/types/api.d.ts
+++ b/packages/api-types/types/api.d.ts
@@ -5390,8 +5390,8 @@ export interface components {
       service_api_keys: components['schemas']['ServiceApiKeyResponse'][]
     }
     ServiceVersions: {
-      gotrue: string
-      postgrest: string
+      gotrue?: string
+      postgrest?: string
       'supabase-postgres': string
     }
     SettingsResponse: {
@@ -13221,7 +13221,7 @@ export interface operations {
     responses: {
       200: {
         content: {
-          'application/json': Record<string, never>
+          'application/json': components['schemas']['ServiceVersions']
         }
       }
     }

--- a/packages/api-types/types/api.d.ts
+++ b/packages/api-types/types/api.d.ts
@@ -959,6 +959,10 @@ export interface paths {
     /** Run project lints */
     get: operations['ProjectRunLintsController_runProjectLints']
   }
+  '/platform/projects/{ref}/service-versions': {
+    /** Gets service versions for a specific project */
+    get: operations['ProjectServiceVersionsController_getServiceVersions']
+  }
   '/platform/projects/{ref}/settings': {
     /** Gets project's settings */
     get: operations['SettingsController_getProjectApi']
@@ -1205,6 +1209,10 @@ export interface paths {
     /** Creates a partner organization */
     post: operations['AwsPartnerOrganizationsSystemController_createPartnerOrganization']
   }
+  '/system/partner-organizations/{slug}': {
+    /** Converts an organization into a partner organization */
+    put: operations['AwsPartnerOrganizationsSystemController_convertToPartnerOrganization']
+  }
   '/system/projects': {
     /** Create a project */
     post: operations['SystemProjectsController_createProject']
@@ -1224,6 +1232,20 @@ export interface paths {
   '/system/projects/{ref}/credentials/aws': {
     /** Allows a project to obtain temporary credentials. */
     post: operations['AwsCredentialsController_getTemporaryCredentials']
+  }
+  '/system/projects/{ref}/disk': {
+    /** Get database disk attributes */
+    get: operations['SystemProjectDiskController_getDisk']
+    /** Modify database disk */
+    post: operations['SystemProjectDiskController_modifyDisk']
+  }
+  '/system/projects/{ref}/disk/util': {
+    /** Get disk utilization */
+    get: operations['SystemProjectDiskController_getDiskUtilization']
+  }
+  '/system/projects/{ref}/disk/volume_info': {
+    /** Get AWS disk volume information */
+    get: operations['SystemProjectDiskController_getAwsDiskInfo']
   }
   '/system/projects/{ref}/functions': {
     /**
@@ -2095,6 +2117,12 @@ export interface paths {
     /** Updates project's Postgres config */
     put: operations['v1-update-postgres-config']
   }
+  '/v1/projects/{ref}/config/storage': {
+    /** Gets project's storage config */
+    get: operations['v1-get-storage-config']
+    /** Updates project's storage config */
+    patch: operations['v1-update-storage-config']
+  }
   '/v1/projects/{ref}/custom-hostname': {
     /** [Beta] Gets project's custom hostname config */
     get: operations['v1-get-hostname-config']
@@ -2564,9 +2592,8 @@ export interface components {
       uri_allow_list: string | null
     }
     AuthHealthResponse: {
-      description: string
-      name: string
-      version: string
+      /** @enum {string} */
+      name: 'GoTrue'
     }
     AutoApiService: {
       app: {
@@ -2681,16 +2708,19 @@ export interface components {
     }
     BranchResetResponse: {
       message: string
+      workflow_run_id: string
     }
     BranchResponse: {
       created_at: string
       git_branch?: string
       id: string
       is_default: boolean
+      /** Format: int64 */
       latest_check_run_id?: number
       name: string
       parent_project_ref: string
       persistent: boolean
+      /** Format: int32 */
       pr_number?: number
       project_ref: string
       reset_on_push: boolean
@@ -2727,6 +2757,9 @@ export interface components {
       is_grantable: boolean
       /** @enum {string} */
       privilege_type: 'ALL' | 'SELECT' | 'INSERT' | 'UPDATE' | 'REFERENCES'
+    }
+    ConvertIntoAwsPartnerOrganizationBody: {
+      partner_billing: components['schemas']['AwsPartnerBillingBody']
     }
     CopyObjectBody: {
       from: string
@@ -3256,7 +3289,7 @@ export interface components {
         | '8_attached_volume_to_upgraded_instance'
         | '9_completed_upgrade'
         | '10_completed_post_physical_backup'
-      /** @enum {number} */
+      /** @enum {integer} */
       status: 0 | 1 | 2
       target_version: number
     }
@@ -3459,6 +3492,7 @@ export interface components {
       query: string
     }
     FunctionResponse: {
+      /** Format: int64 */
       created_at: number
       entrypoint_path?: string
       id: string
@@ -3468,11 +3502,13 @@ export interface components {
       slug: string
       /** @enum {string} */
       status: 'ACTIVE' | 'REMOVED' | 'THROTTLED'
+      /** Format: int64 */
       updated_at: number
       verify_jwt?: boolean
       version: number
     }
     FunctionSlugResponse: {
+      /** Format: int64 */
       created_at: number
       entrypoint_path?: string
       id: string
@@ -3482,6 +3518,7 @@ export interface components {
       slug: string
       /** @enum {string} */
       status: 'ACTIVE' | 'REMOVED' | 'THROTTLED'
+      /** Format: int64 */
       updated_at: number
       verify_jwt?: boolean
       version: number
@@ -4205,6 +4242,7 @@ export interface components {
     }
     OAuthTokenResponse: {
       access_token: string
+      /** Format: int64 */
       expires_in: number
       refresh_token: string
       /** @enum {string} */
@@ -4483,6 +4521,7 @@ export interface components {
       session_replication_role?: 'origin' | 'replica' | 'local'
       shared_buffers?: string
       statement_timeout?: string
+      track_commit_timestamp?: boolean
       wal_keep_size?: string
       wal_sender_timeout?: string
       work_mem?: string
@@ -4796,10 +4835,6 @@ export interface components {
         | 'PAUSE_FAILED'
         | 'RESIZING'
       subscription_id: string
-      v2MaintenanceWindow: {
-        end?: string
-        start?: string
-      }
       volumeSizeGb?: number
     }
     ProjectInfo: {
@@ -4927,10 +4962,9 @@ export interface components {
       cloud_provider: string
       db_dns_name: string
       db_host: string
-      /** @enum {string|null} */
-      db_ip_addr_config: 'legacy' | 'static-ipv4' | 'concurrent-ipv6' | 'ipv6' | null
+      db_ip_addr_config: string
       db_name: string
-      db_port: string
+      db_port: number
       db_user: string
       inserted_at: string
       jwt_secret?: string
@@ -5022,8 +5056,6 @@ export interface components {
     }
     RealtimeHealthResponse: {
       connected_cluster: number
-      db_connected: boolean
-      healthy: boolean
     }
     Relationship: {
       constraint_name: string
@@ -5441,6 +5473,7 @@ export interface components {
       visibility: 'user' | 'project' | 'org' | 'public'
     }
     SnippetProject: {
+      /** Format: int64 */
       id: number
       name: string
     }
@@ -5460,6 +5493,7 @@ export interface components {
       visibility: 'user' | 'project' | 'org' | 'public'
     }
     SnippetUser: {
+      /** Format: int64 */
       id: number
       username: string
     }
@@ -5487,8 +5521,15 @@ export interface components {
       updated_at: string
     }
     StorageConfigResponse: {
+      features: components['schemas']['StorageFeatures']
+      /** Format: int64 */
       fileSizeLimit: number
-      isFreeTier: boolean
+    }
+    StorageFeatureImageTransformation: {
+      enabled: boolean
+    }
+    StorageFeatures: {
+      imageTransformation: components['schemas']['StorageFeatureImageTransformation']
     }
     StorageObject: {
       bucket_id: string
@@ -6272,6 +6313,7 @@ export interface components {
       session_replication_role?: 'origin' | 'replica' | 'local'
       shared_buffers?: string
       statement_timeout?: string
+      track_commit_timestamp?: boolean
       wal_keep_size?: string
       wal_sender_timeout?: string
       work_mem?: string
@@ -6356,10 +6398,9 @@ export interface components {
       public: boolean
     }
     UpdateStorageConfigBody: {
-      fileSizeLimit: number
-    }
-    UpdateStorageConfigResponse: {
-      fileSizeLimit: number
+      features?: components['schemas']['StorageFeatures']
+      /** Format: int64 */
+      fileSizeLimit?: number
     }
     UpdateSubscriptionBody: {
       payment_method?: string
@@ -6698,7 +6739,9 @@ export interface components {
       pool_mode?: 'transaction' | 'session' | 'statement'
     }
     V1PhysicalBackup: {
+      /** Format: int64 */
       earliest_physical_backup_date_unix?: number
+      /** Format: int64 */
       latest_physical_backup_date_unix?: number
     }
     V1PostgrestConfigResponse: {
@@ -6709,6 +6752,7 @@ export interface components {
       max_rows: number
     }
     V1ProjectRefResponse: {
+      /** Format: int64 */
       id: number
       name: string
       ref: string
@@ -6750,6 +6794,7 @@ export interface components {
         | 'RESIZING'
     }
     V1RestorePitrBody: {
+      /** Format: int64 */
       recovery_time_target_unix: number
     }
     V1RunQueryBody: {
@@ -7548,6 +7593,9 @@ export interface operations {
   /** Retrieve CLI login session */
   CliLoginController_getCliLoginSession: {
     parameters: {
+      query?: {
+        device_code?: string
+      }
       path: {
         session_id: string
       }
@@ -12350,7 +12398,7 @@ export interface operations {
     responses: {
       200: {
         content: {
-          'application/json': components['schemas']['UpdateStorageConfigResponse']
+          'application/json': components['schemas']['StorageConfigResponse']
         }
       }
       403: {
@@ -12692,7 +12740,46 @@ export interface operations {
   DailyStatsController_getDailyStats: {
     parameters: {
       query: {
-        attribute: string
+        attribute:
+          | 'total_realtime_requests'
+          | 'total_realtime_egress'
+          | 'avg_cpu_usage'
+          | 'total_ingress'
+          | 'total_egress'
+          | 'total_requests'
+          | 'total_get_requests'
+          | 'total_patch_requests'
+          | 'total_post_requests'
+          | 'total_delete_requests'
+          | 'total_options_requests'
+          | 'total_supavisor_egress_bytes'
+          | 'total_rest_ingress'
+          | 'total_rest_egress'
+          | 'total_rest_requests'
+          | 'total_rest_get_requests'
+          | 'total_rest_post_requests'
+          | 'total_rest_patch_requests'
+          | 'total_rest_delete_requests'
+          | 'total_rest_options_requests'
+          | 'total_auth_billing_period_mau'
+          | 'total_auth_billing_period_sso_mau'
+          | 'total_auth_ingress'
+          | 'total_auth_egress'
+          | 'total_auth_requests'
+          | 'total_auth_get_requests'
+          | 'total_auth_post_requests'
+          | 'total_auth_patch_requests'
+          | 'total_auth_options_requests'
+          | 'total_auth_delete_requests'
+          | 'total_storage_ingress'
+          | 'total_storage_egress'
+          | 'total_storage_image_render_count'
+          | 'total_storage_requests'
+          | 'total_storage_get_requests'
+          | 'total_storage_post_requests'
+          | 'total_storage_delete_requests'
+          | 'total_storage_options_requests'
+          | 'total_storage_patch_requests'
         interval: string
         endDate: string
         startDate: string
@@ -13120,6 +13207,22 @@ export interface operations {
       }
       403: {
         content: never
+      }
+    }
+  }
+  /** Gets service versions for a specific project */
+  ProjectServiceVersionsController_getServiceVersions: {
+    parameters: {
+      path: {
+        /** @description Project ref */
+        ref: string
+      }
+    }
+    responses: {
+      200: {
+        content: {
+          'application/json': Record<string, never>
+        }
       }
     }
   }
@@ -14486,6 +14589,29 @@ export interface operations {
       }
     }
   }
+  /** Converts an organization into a partner organization */
+  AwsPartnerOrganizationsSystemController_convertToPartnerOrganization: {
+    parameters: {
+      path: {
+        /** @description Organization slug */
+        slug: string
+      }
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['ConvertIntoAwsPartnerOrganizationBody']
+      }
+    }
+    responses: {
+      200: {
+        content: never
+      }
+      /** @description Unexpected error while converting organization into a partner organization */
+      500: {
+        content: never
+      }
+    }
+  }
   /** Create a project */
   SystemProjectsController_createProject: {
     requestBody: {
@@ -14578,6 +14704,92 @@ export interface operations {
       }
       /** @description Failed to obtain temporary credentials. */
       500: {
+        content: never
+      }
+    }
+  }
+  /** Get database disk attributes */
+  SystemProjectDiskController_getDisk: {
+    parameters: {
+      path: {
+        /** @description Project ref */
+        ref: string
+      }
+    }
+    responses: {
+      200: {
+        content: {
+          'application/json': components['schemas']['DiskResponse']
+        }
+      }
+      403: {
+        content: never
+      }
+      /** @description Failed to get database disk attributes */
+      500: {
+        content: never
+      }
+    }
+  }
+  /** Modify database disk */
+  SystemProjectDiskController_modifyDisk: {
+    parameters: {
+      path: {
+        /** @description Project ref */
+        ref: string
+      }
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['DiskRequestBody']
+      }
+    }
+    responses: {
+      201: {
+        content: never
+      }
+      403: {
+        content: never
+      }
+      /** @description Failed to modify database disk */
+      500: {
+        content: never
+      }
+    }
+  }
+  /** Get disk utilization */
+  SystemProjectDiskController_getDiskUtilization: {
+    parameters: {
+      path: {
+        /** @description Project ref */
+        ref: string
+      }
+    }
+    responses: {
+      200: {
+        content: {
+          'application/json': components['schemas']['DiskUtilMetricsResponse']
+        }
+      }
+      403: {
+        content: never
+      }
+      /** @description Failed to get disk utilization */
+      500: {
+        content: never
+      }
+    }
+  }
+  /** Get AWS disk volume information */
+  SystemProjectDiskController_getAwsDiskInfo: {
+    parameters: {
+      path: {
+        /** @description Project ref */
+        ref: string
+      }
+    }
+    responses: {
+      200: {
         content: never
       }
     }
@@ -15661,6 +15873,55 @@ export interface operations {
       }
     }
   }
+  /** Gets project's storage config */
+  'v1-get-storage-config': {
+    parameters: {
+      path: {
+        /** @description Project ref */
+        ref: string
+      }
+    }
+    responses: {
+      200: {
+        content: {
+          'application/json': components['schemas']['StorageConfigResponse']
+        }
+      }
+      403: {
+        content: never
+      }
+      /** @description Failed to retrieve project's storage config */
+      500: {
+        content: never
+      }
+    }
+  }
+  /** Updates project's storage config */
+  'v1-update-storage-config': {
+    parameters: {
+      path: {
+        /** @description Project ref */
+        ref: string
+      }
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['UpdateStorageConfigBody']
+      }
+    }
+    responses: {
+      200: {
+        content: never
+      }
+      403: {
+        content: never
+      }
+      /** @description Failed to update project's storage config */
+      500: {
+        content: never
+      }
+    }
+  }
   /** [Beta] Gets project's custom hostname config */
   'v1-get-hostname-config': {
     parameters: {
@@ -15938,6 +16199,9 @@ export interface operations {
         content: {
           'application/json': components['schemas']['V1ServiceHealthResponse'][]
         }
+      }
+      403: {
+        content: never
       }
       /** @description Failed to retrieve project's service health status */
       500: {


### PR DESCRIPTION
## What kind of change does this PR introduce?

chore

## What is the current behavior?

Service versions are shown from the project detail endpoint.

## What is the new behavior?

These fields are now moved to a dedicated endpoint.

## Additional context

We're planning to remove the service versions from the project detail endpoint as it slows it down a lot.