### PR TITLE
fix: remove reference to Hugo templating in Auth Email guide

### DIFF
--- a/apps/docs/content/guides/auth/auth-email-templates.mdx
+++ b/apps/docs/content/guides/auth/auth-email-templates.mdx
@@ -86,7 +86,7 @@ const {
 
 ## Customization
 
-Supabase Auth makes use of [Go Templates](https://pkg.go.dev/text/template). This means it is possible to conditionally render information based on template properties.You may wish to checkout this [guide by Hugo](https://gohugo.io/templates/introduction/) for a guide on the templating language.
+Supabase Auth makes use of [Go Templates](https://pkg.go.dev/text/template). This means it is possible to conditionally render information based on template properties.
 
 ### Send different email to early access users
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Remove a reference to Hugo Operators as the reference appears to confuse users. 

We support only a subset of of operators listed on the Hugo website. Hugo and Auth both make use of [`html/template`](https://pkg.go.dev/html/template) so Auth supports a subset of what Hugo supports but not all
