### PR TITLE
fix(docs): remove redundant header on ai python docs

### DIFF
--- a/apps/docs/app/guides/(with-sidebar)/ai/python/[slug]/page.tsx
+++ b/apps/docs/app/guides/(with-sidebar)/ai/python/[slug]/page.tsx
@@ -1,9 +1,9 @@
-import { type SerializeOptions } from 'next-mdx-remote/dist/types'
+import type { SerializeOptions } from 'next-mdx-remote/dist/types'
 import { notFound } from 'next/navigation'
 import { relative } from 'path'
 import rehypeSlug from 'rehype-slug'
 
-import { genGuideMeta } from '~/features/docs/GuidesMdx.utils'
+import { genGuideMeta, removeRedundantH1 } from '~/features/docs/GuidesMdx.utils'
 import { GuideTemplate, newEditLink } from '~/features/docs/GuidesMdx.template'
 import { fetchRevalidatePerDay } from '~/features/helpers.fetch'
 import { UrlTransformFunction, linkTransform } from '~/lib/mdx/plugins/rehypeLinkTransform'
@@ -84,7 +84,8 @@ const getContent = async ({ slug }: Params) => {
     `https://raw.githubusercontent.com/${org}/${repo}/${branch}/${docsDir}/${remoteFile}`
   )
 
-  const content = await response.text()
+  let content = await response.text()
+  content = removeRedundantH1(content)
 
   return {
     pathname: `/guides/ai/python/${slug}` satisfies `/${string}`,


### PR DESCRIPTION
Before:

<img width="876" alt="image" src="https://github.com/user-attachments/assets/bc4aef83-5505-48d7-b662-1b2d888dc1f4">

After:

<img width="878" alt="image" src="https://github.com/user-attachments/assets/15fb5e24-717a-4d11-ada4-fedf93e9599f">
