### PR TITLE
Update DisplayApiSettings.tsx | add note on how to rotate service_rol…

### DIFF
--- a/apps/studio/components/ui/ProjectSettings/DisplayApiSettings.tsx
+++ b/apps/studio/components/ui/ProjectSettings/DisplayApiSettings.tsx
@@ -121,7 +121,7 @@ const DisplayApiSettings = ({ legacy }: { legacy?: boolean }) => {
                 onChange={() => {}}
                 descriptionText={
                   x.tags === 'service_role'
-                    ? 'This key has the ability to bypass Row Level Security. Never share it publicly. ' +
+                    ? 'This key has the ability to bypass Row Level Security. Never share it publicly. If leaked, generate a new JWT secret. ' +
                       (legacy ? 'Prefer using Publishable API keys instead.' : '')
                     : 'This key is safe to use in a browser if you have enabled Row Level Security for your tables and configured policies. ' +
                       (legacy ? 'Prefer using Secret API keys instead.' : '')

--- a/apps/studio/components/ui/ProjectSettings/DisplayApiSettings.tsx
+++ b/apps/studio/components/ui/ProjectSettings/DisplayApiSettings.tsx
@@ -121,7 +121,7 @@ const DisplayApiSettings = ({ legacy }: { legacy?: boolean }) => {
                 onChange={() => {}}
                 descriptionText={
                   x.tags === 'service_role'
-                    ? 'This key has the ability to bypass Row Level Security. Never share it publicly. If leaked, generate a new JWT secret. ' +
+                    ? 'This key has the ability to bypass Row Level Security. Never share it publicly. If leaked, generate a new JWT secret immediately. ' +
                       (legacy ? 'Prefer using Publishable API keys instead.' : '')
                     : 'This key is safe to use in a browser if you have enabled Row Level Security for your tables and configured policies. ' +
                       (legacy ? 'Prefer using Secret API keys instead.' : '')


### PR DESCRIPTION
…e key

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Change front-end wording

## What is the current behavior?

Information on how to rotate service_role key is hidden behind the `Generate a new secret` button

## What is the new behavior?

Added a small note to service_role subtext explaining to generate a new secret if service_role key is leaked.

## Additional context

[Slack](https://supabase.slack.com/archives/C0161K73J1J/p1731001880554949)