### PR TITLE
fix row level security docs url in expo tutorial

### DIFF
--- a/apps/docs/content/guides/getting-started/tutorials/with-expo-react-native.mdx
+++ b/apps/docs/content/guides/getting-started/tutorials/with-expo-react-native.mdx
@@ -40,7 +40,7 @@ npx expo install @supabase/supabase-js @react-native-async-storage/async-storage
 Now let's create a helper file to initialize the Supabase client.
 We need the API URL and the `anon` key that you copied [earlier](#get-the-api-keys).
 These variables are safe to expose in your Expo app since Supabase has
-[Row Level Security](/docs/guides/auth#row-level-security) enabled on your Database.
+[Row Level Security](/docs/guides/database/postgres/row-level-security) enabled on your Database.
 
 <Tabs
   scrollable


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

Incorrect Row Level Security docs URL

## What is the new behavior?

Incorrect Row Level Security docs URL
