### PR TITLE
Doc: update documentation for secret name.

### DIFF
--- a/apps/docs/content/guides/auth/auth-hooks.mdx
+++ b/apps/docs/content/guides/auth/auth-hooks.mdx
@@ -241,7 +241,7 @@ secrets = "env(SEND_SMS_HOOK_SECRET)"
 Fill in the Hook Secret in `supabase/functions/.env`
 
 ```bash
-SEND_SMS_HOOK_SECRETS='v1,whsec_<base64_standard_secret>'
+SEND_SMS_HOOK_SECRET='v1,whsec_<base64_standard_secret>'
 ```
 
 Start the function locally:


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

- The hook secret key that is present in the documentation has different names 
<img width="860" alt="image" src="https://github.com/user-attachments/assets/31fc27bc-98ea-40b2-abc2-437ee451ba88">

## What is the new behavior?

The  extra **S** has been removed.

## Additional context

this help preventing issues when trying to set up smshooks locally.
