### PR TITLE
Update link to Database Webhooks in webhooks.mdx

### DIFF
--- a/apps/docs/content/guides/database/webhooks.mdx
+++ b/apps/docs/content/guides/database/webhooks.mdx
@@ -27,7 +27,7 @@ This video demonstrates how you can create a new customer in Stripe each time a 
 
 ## Creating a webhook
 
-1. Create a new [Database Webhook](https://supabase.com/dashboard/project/_/database/hooks) in the Dashboard.
+1. Create a new [Database Webhook](https://supabase.com/dashboard/project/_/integrations/hooks) in the Dashboard.
 1. Give your Webhook a name.
 1. Select the table you want to hook into.
 1. Select one or more events (table inserts, updates, or deletes) you want to hook into.


### PR DESCRIPTION
update link in the dashboard to /integrations/hooks from /database/hooks

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

Opening the link to Database Webhooks leads to 404 as it was moved from /database/hooks

## What is the new behavior?

The link leads to /integrations/hooks

## Additional context

Add any other context or screenshots.
