### PR TITLE
Add check for project active healthy status in some RQs that are unnecessary when project is paused

### DIFF
--- a/apps/studio/components/interfaces/Database/Backups/BackupItem.tsx
+++ b/apps/studio/components/interfaces/Database/Backups/BackupItem.tsx
@@ -7,16 +7,17 @@ import { useBackupDownloadMutation } from 'data/database/backup-download-mutatio
 import type { DatabaseBackup } from 'data/database/backups-query'
 import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { Badge } from 'ui'
+import { useParams } from 'common'
 
 interface BackupItemProps {
   index: number
   isHealthy: boolean
-  projectRef: string
   backup: DatabaseBackup
   onSelectBackup: () => void
 }
 
-const BackupItem = ({ index, isHealthy, backup, projectRef, onSelectBackup }: BackupItemProps) => {
+const BackupItem = ({ index, isHealthy, backup, onSelectBackup }: BackupItemProps) => {
+  const { ref: projectRef } = useParams()
   const canTriggerScheduledBackups = useCheckPermissions(
     PermissionAction.INFRA_EXECUTE,
     'queue_job.restore.prepare'
@@ -62,7 +63,10 @@ const BackupItem = ({ index, isHealthy, backup, projectRef, onSelectBackup }: Ba
               icon={<Download />}
               loading={isDownloading}
               disabled={!canTriggerScheduledBackups || isDownloading}
-              onClick={() => downloadBackup({ ref: projectRef, backup })}
+              onClick={() => {
+                if (!projectRef) return console.error('Project ref is required')
+                downloadBackup({ ref: projectRef, backup })
+              }}
               tooltip={{
                 content: {
                   side: 'bottom',

--- a/apps/studio/components/interfaces/Database/Backups/BackupsList.tsx
+++ b/apps/studio/components/interfaces/Database/Backups/BackupsList.tsx
@@ -1,4 +1,3 @@
-import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { useQueryClient } from '@tanstack/react-query'
 import dayjs from 'dayjs'
 import { Clock } from 'lucide-react'
@@ -12,27 +11,22 @@ import UpgradeToPro from 'components/ui/UpgradeToPro'
 import { useBackupRestoreMutation } from 'data/database/backup-restore-mutation'
 import { DatabaseBackup, useBackupsQuery } from 'data/database/backups-query'
 import { setProjectStatus } from 'data/projects/projects-query'
-import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { PROJECT_STATUS } from 'lib/constants'
 import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
 import BackupItem from './BackupItem'
 import BackupsEmpty from './BackupsEmpty'
 import BackupsStorageAlert from './BackupsStorageAlert'
+import { useParams } from 'common'
 
 const BackupsList = () => {
   const router = useRouter()
   const queryClient = useQueryClient()
+  const { ref: projectRef } = useParams()
 
   const { project: selectedProject } = useProjectContext()
-  const projectRef = selectedProject?.ref || 'default'
   const isHealthy = selectedProject?.status === PROJECT_STATUS.ACTIVE_HEALTHY
 
   const [selectedBackup, setSelectedBackup] = useState<DatabaseBackup>()
-
-  const canTriggerScheduledBackups = useCheckPermissions(
-    PermissionAction.INFRA_EXECUTE,
-    'queue_job.restore.prepare'
-  )
 
   const { data: backups } = useBackupsQuery({ projectRef })
   const {
@@ -41,15 +35,17 @@ const BackupsList = () => {
     isSuccess: isSuccessBackup,
   } = useBackupRestoreMutation({
     onSuccess: () => {
-      setTimeout(() => {
-        setProjectStatus(queryClient, projectRef, PROJECT_STATUS.RESTORING)
-        toast.success(
-          `Restoring database back to ${dayjs(selectedBackup?.inserted_at).format(
-            'DD MMM YYYY HH:mm:ss'
-          )}`
-        )
-        router.push(`/project/${projectRef}`)
-      }, 3000)
+      if (projectRef) {
+        setTimeout(() => {
+          setProjectStatus(queryClient, projectRef, PROJECT_STATUS.RESTORING)
+          toast.success(
+            `Restoring database back to ${dayjs(selectedBackup?.inserted_at).format(
+              'DD MMM YYYY HH:mm:ss'
+            )}`
+          )
+          router.push(`/project/${projectRef}`)
+        }, 3000)
+      }
     },
   })
 
@@ -86,7 +82,6 @@ const BackupsList = () => {
                   <BackupItem
                     key={x.id}
                     backup={x}
-                    projectRef={projectRef}
                     index={i}
                     isHealthy={isHealthy}
                     onSelectBackup={() => setSelectedBackup(x)}
@@ -106,6 +101,7 @@ const BackupsList = () => {
         loading={isRestoring || isSuccessBackup}
         onCancel={() => setSelectedBackup(undefined)}
         onConfirm={() => {
+          if (projectRef === undefined) return console.error('Project ref required')
           if (selectedBackup === undefined) return console.error('Backup required')
           restoreFromBackup({ ref: projectRef, backup: selectedBackup })
         }}

--- a/apps/studio/components/interfaces/Database/Backups/DatabaseBackupsNav.tsx
+++ b/apps/studio/components/interfaces/Database/Backups/DatabaseBackupsNav.tsx
@@ -1,23 +1,26 @@
 import Link from 'next/link'
 import React from 'react'
+
+import { useParams } from 'common'
 import { NavMenu, NavMenuItem } from 'ui'
 
 type Props = {
-  projRef: string
   active: 'scheduled' | 'pitr'
 }
 
-function DatabaseBackupsNav({ projRef, active }: Props) {
+function DatabaseBackupsNav({ active }: Props) {
+  const { ref } = useParams()
+
   const navMenuItems = [
     {
       id: 'scheduled',
       label: 'Scheduled backups',
-      href: `/project/${projRef}/database/backups/scheduled`,
+      href: `/project/${ref}/database/backups/scheduled`,
     },
     {
       id: 'pitr',
       label: 'Point in time',
-      href: `/project/${projRef}/database/backups/pitr`,
+      href: `/project/${ref}/database/backups/pitr`,
     },
   ]
 

--- a/apps/studio/data/auth/users-count-query.ts
+++ b/apps/studio/data/auth/users-count-query.ts
@@ -1,8 +1,8 @@
 import { UseQueryOptions } from '@tanstack/react-query'
 
 import { ExecuteSqlData, ExecuteSqlError, useExecuteSqlQuery } from 'data/sql/execute-sql-query'
-import { Filter } from './users-infinite-query'
 import { authKeys } from './keys'
+import { Filter } from './users-infinite-query'
 
 type UsersCountVariables = {
   projectRef?: string
@@ -65,8 +65,8 @@ export type UsersCountError = ExecuteSqlError
 export const useUsersCountQuery = <TData extends UsersCountData = UsersCountData>(
   { projectRef, connectionString, keywords, filter, providers }: UsersCountVariables,
   options: UseQueryOptions<ExecuteSqlData, UsersCountError, TData> = {}
-) =>
-  useExecuteSqlQuery(
+) => {
+  return useExecuteSqlQuery(
     {
       projectRef,
       connectionString,
@@ -75,3 +75,4 @@ export const useUsersCountQuery = <TData extends UsersCountData = UsersCountData
     },
     options
   )
+}

--- a/apps/studio/data/auth/users-infinite-query.ts
+++ b/apps/studio/data/auth/users-infinite-query.ts
@@ -2,6 +2,8 @@ import { useInfiniteQuery, UseInfiniteQueryOptions } from '@tanstack/react-query
 
 import type { components } from 'data/api'
 import { executeSql, ExecuteSqlError } from 'data/sql/execute-sql-query'
+import { useSelectedProject } from 'hooks/misc/useSelectedProject'
+import { PROJECT_STATUS } from 'lib/constants'
 import { authKeys } from './keys'
 
 export type Filter = 'verified' | 'unverified' | 'anonymous'
@@ -82,8 +84,11 @@ export type UsersError = ExecuteSqlError
 export const useUsersInfiniteQuery = <TData = UsersData>(
   { projectRef, connectionString, keywords, filter, providers, sort, order }: UsersVariables,
   { enabled = true, ...options }: UseInfiniteQueryOptions<UsersData, UsersError, TData> = {}
-) =>
-  useInfiniteQuery<UsersData, UsersError, TData>(
+) => {
+  const project = useSelectedProject()
+  const isActive = project?.status === PROJECT_STATUS.ACTIVE_HEALTHY
+
+  return useInfiniteQuery<UsersData, UsersError, TData>(
     authKeys.usersInfinite(projectRef, { keywords, filter, providers, sort, order }),
     ({ signal, pageParam }) => {
       return executeSql(
@@ -105,7 +110,7 @@ export const useUsersInfiniteQuery = <TData = UsersData>(
     },
     {
       staleTime: 0,
-      enabled: enabled && typeof projectRef !== 'undefined',
+      enabled: enabled && typeof projectRef !== 'undefined' && isActive,
 
       getNextPageParam(lastPage, pages) {
         const page = pages.length
@@ -116,3 +121,4 @@ export const useUsersInfiniteQuery = <TData = UsersData>(
       ...options,
     }
   )
+}

--- a/apps/studio/data/database-extensions/database-extensions-query.ts
+++ b/apps/studio/data/database-extensions/database-extensions-query.ts
@@ -3,6 +3,8 @@ import { get, handleError } from 'data/fetchers'
 import type { ResponseError } from 'types'
 import { databaseExtensionsKeys } from './keys'
 import { components } from 'api-types'
+import { useSelectedProject } from 'hooks/misc/useSelectedProject'
+import { PROJECT_STATUS } from 'lib/constants'
 
 export type DatabaseExtension = components['schemas']['PostgresExtension']
 
@@ -46,12 +48,16 @@ export const useDatabaseExtensionsQuery = <TData = DatabaseExtensionsData>(
     enabled = true,
     ...options
   }: UseQueryOptions<DatabaseExtensionsData, DatabaseExtensionsError, TData> = {}
-) =>
-  useQuery<DatabaseExtensionsData, DatabaseExtensionsError, TData>(
+) => {
+  const project = useSelectedProject()
+  const isActive = project?.status === PROJECT_STATUS.ACTIVE_HEALTHY
+
+  return useQuery<DatabaseExtensionsData, DatabaseExtensionsError, TData>(
     databaseExtensionsKeys.list(projectRef),
     ({ signal }) => getDatabaseExtensions({ projectRef, connectionString }, signal),
     {
-      enabled: enabled && typeof projectRef !== 'undefined',
+      enabled: enabled && typeof projectRef !== 'undefined' && isActive,
       ...options,
     }
   )
+}

--- a/apps/studio/data/database-policies/database-policies-query.ts
+++ b/apps/studio/data/database-policies/database-policies-query.ts
@@ -1,6 +1,8 @@
 import { UseQueryOptions, useQuery } from '@tanstack/react-query'
 
 import { get, handleError } from 'data/fetchers'
+import { useSelectedProject } from 'hooks/misc/useSelectedProject'
+import { PROJECT_STATUS } from 'lib/constants'
 import type { ResponseError } from 'types'
 import { databasePoliciesKeys } from './keys'
 
@@ -45,12 +47,16 @@ export const useDatabasePoliciesQuery = <TData = DatabasePoliciesData>(
     enabled = true,
     ...options
   }: UseQueryOptions<DatabasePoliciesData, DatabasePoliciesError, TData> = {}
-) =>
-  useQuery<DatabasePoliciesData, DatabasePoliciesError, TData>(
+) => {
+  const project = useSelectedProject()
+  const isActive = project?.status === PROJECT_STATUS.ACTIVE_HEALTHY
+
+  return useQuery<DatabasePoliciesData, DatabasePoliciesError, TData>(
     databasePoliciesKeys.list(projectRef, schema),
     ({ signal }) => getDatabasePolicies({ projectRef, connectionString, schema }, signal),
     {
-      enabled: enabled && typeof projectRef !== 'undefined',
+      enabled: enabled && typeof projectRef !== 'undefined' && isActive,
       ...options,
     }
   )
+}

--- a/apps/studio/data/lint/lint-query.ts
+++ b/apps/studio/data/lint/lint-query.ts
@@ -2,6 +2,8 @@ import { UseQueryOptions, useQuery } from '@tanstack/react-query'
 
 import { components } from 'api-types'
 import { get, handleError } from 'data/fetchers'
+import { useSelectedProject } from 'hooks/misc/useSelectedProject'
+import { PROJECT_STATUS } from 'lib/constants'
 import { ResponseError } from 'types'
 import { lintKeys } from './keys'
 
@@ -31,12 +33,16 @@ export type ProjectLintsError = ResponseError
 export const useProjectLintsQuery = <TData = ProjectLintsData>(
   { projectRef }: ProjectLintsVariables,
   { enabled = true, ...options }: UseQueryOptions<ProjectLintsData, ProjectLintsError, TData> = {}
-) =>
-  useQuery<ProjectLintsData, ProjectLintsError, TData>(
+) => {
+  const project = useSelectedProject()
+  const isActive = project?.status === PROJECT_STATUS.ACTIVE_HEALTHY
+
+  return useQuery<ProjectLintsData, ProjectLintsError, TData>(
     lintKeys.lint(projectRef),
     ({ signal }) => getProjectLints({ projectRef }, signal),
     {
-      enabled: enabled && typeof projectRef !== 'undefined',
+      enabled: enabled && typeof projectRef !== 'undefined' && isActive,
       ...options,
     }
   )
+}

--- a/apps/studio/data/sql/execute-sql-query.ts
+++ b/apps/studio/data/sql/execute-sql-query.ts
@@ -7,7 +7,8 @@ import {
 } from 'lib/role-impersonation'
 import type { ResponseError } from 'types'
 import { sqlKeys } from './keys'
-import { MB } from 'lib/constants'
+import { MB, PROJECT_STATUS } from 'lib/constants'
+import { useSelectedProject } from 'hooks/misc/useSelectedProject'
 
 export type ExecuteSqlVariables = {
   projectRef?: string
@@ -123,13 +124,17 @@ export const useExecuteSqlQuery = <TData = ExecuteSqlData>(
     isRoleImpersonationEnabled,
   }: ExecuteSqlVariables,
   { enabled = true, ...options }: UseQueryOptions<ExecuteSqlData, ExecuteSqlError, TData> = {}
-) =>
-  useQuery<ExecuteSqlData, ExecuteSqlError, TData>(
+) => {
+  const project = useSelectedProject()
+  const isActive = project?.status === PROJECT_STATUS.ACTIVE_HEALTHY
+
+  return useQuery<ExecuteSqlData, ExecuteSqlError, TData>(
     sqlKeys.query(projectRef, queryKey ?? [btoa(sql)]),
     ({ signal }) =>
       executeSql(
         { projectRef, connectionString, sql, queryKey, handleError, isRoleImpersonationEnabled },
         signal
       ),
-    { enabled: enabled && typeof projectRef !== 'undefined', staleTime: 0, ...options }
+    { enabled: enabled && typeof projectRef !== 'undefined' && isActive, staleTime: 0, ...options }
   )
+}

--- a/apps/studio/data/storage/buckets-query.ts
+++ b/apps/studio/data/storage/buckets-query.ts
@@ -1,9 +1,9 @@
-import { useQuery, useQueryClient, UseQueryOptions } from '@tanstack/react-query'
+import { useQuery, UseQueryOptions } from '@tanstack/react-query'
 import { get, handleError } from 'data/fetchers'
-import { API_URL } from 'lib/constants'
-import { useCallback } from 'react'
-import { storageKeys } from './keys'
+import { useSelectedProject } from 'hooks/misc/useSelectedProject'
+import { PROJECT_STATUS } from 'lib/constants'
 import type { ResponseError } from 'types'
+import { storageKeys } from './keys'
 
 export type BucketsVariables = { projectRef?: string }
 
@@ -36,12 +36,15 @@ export type BucketsError = ResponseError
 export const useBucketsQuery = <TData = BucketsData>(
   { projectRef }: BucketsVariables,
   { enabled = true, ...options }: UseQueryOptions<BucketsData, BucketsError, TData> = {}
-) =>
-  useQuery<BucketsData, BucketsError, TData>(
+) => {
+  const project = useSelectedProject()
+  const isActive = project?.status === PROJECT_STATUS.ACTIVE_HEALTHY
+
+  return useQuery<BucketsData, BucketsError, TData>(
     storageKeys.buckets(projectRef),
     ({ signal }) => getBuckets({ projectRef }, signal),
     {
-      enabled: enabled && typeof projectRef !== 'undefined',
+      enabled: enabled && typeof projectRef !== 'undefined' && isActive,
       ...options,
       retry: (failureCount, error) => {
         if (
@@ -61,3 +64,4 @@ export const useBucketsQuery = <TData = BucketsData>(
       },
     }
   )
+}

--- a/apps/studio/pages/project/[ref]/database/backups/pitr.tsx
+++ b/apps/studio/pages/project/[ref]/database/backups/pitr.tsx
@@ -1,5 +1,7 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
+import { AlertCircle } from 'lucide-react'
 
+import { useParams } from 'common'
 import DatabaseBackupsNav from 'components/interfaces/Database/Backups/DatabaseBackupsNav'
 import { PITRNotice, PITRSelection } from 'components/interfaces/Database/Backups/PITR'
 import DatabaseLayout from 'components/layouts/DatabaseLayout/DatabaseLayout'
@@ -15,21 +17,17 @@ import { useOrgSubscriptionQuery } from 'data/subscriptions/org-subscription-que
 import { useCheckPermissions, usePermissionsLoaded } from 'hooks/misc/useCheckPermissions'
 import { useSelectedOrganization } from 'hooks/misc/useSelectedOrganization'
 import { PROJECT_STATUS } from 'lib/constants'
-import { AlertCircle } from 'lucide-react'
 import type { NextPageWithLayout } from 'types'
 import { Alert_Shadcn_, AlertDescription_Shadcn_, AlertTitle_Shadcn_ } from 'ui'
 
 const DatabasePhysicalBackups: NextPageWithLayout = () => {
-  const { project } = useProjectContext()
-  const ref = project?.ref ?? 'default'
-
   return (
     <ScaffoldContainer>
       <ScaffoldSection>
         <div className="col-span-12">
           <div className="space-y-6">
             <FormHeader className="!mb-0" title="Database Backups" />
-            <DatabaseBackupsNav active="pitr" projRef={ref} />
+            <DatabaseBackupsNav active="pitr" />
             <div className="space-y-8">
               <PITR />
             </div>
@@ -45,17 +43,10 @@ DatabasePhysicalBackups.getLayout = (page) => (
 )
 
 const PITR = () => {
+  const { ref: projectRef } = useParams()
   const { project } = useProjectContext()
   const organization = useSelectedOrganization()
-  const {
-    data: backups,
-    error,
-    isLoading,
-    isError,
-    isSuccess,
-  } = useBackupsQuery({
-    projectRef: project?.ref,
-  })
+  const { data: backups, error, isLoading, isError, isSuccess } = useBackupsQuery({ projectRef })
 
   const { data: subscription } = useOrgSubscriptionQuery({ orgSlug: organization?.slug })
 

--- a/apps/studio/pages/project/[ref]/database/backups/scheduled.tsx
+++ b/apps/studio/pages/project/[ref]/database/backups/scheduled.tsx
@@ -1,10 +1,10 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { Info } from 'lucide-react'
 
+import { useParams } from 'common'
 import { BackupsList } from 'components/interfaces/Database'
 import DatabaseBackupsNav from 'components/interfaces/Database/Backups/DatabaseBackupsNav'
 import DatabaseLayout from 'components/layouts/DatabaseLayout/DatabaseLayout'
-import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
 import { ScaffoldContainer, ScaffoldSection } from 'components/layouts/Scaffold'
 import AlertError from 'components/ui/AlertError'
 import { FormHeader } from 'components/ui/Forms/FormHeader'
@@ -16,16 +16,9 @@ import { useCheckPermissions, usePermissionsLoaded } from 'hooks/misc/useCheckPe
 import type { NextPageWithLayout } from 'types'
 
 const DatabaseScheduledBackups: NextPageWithLayout = () => {
-  const { project } = useProjectContext()
-  const ref = project?.ref || 'default'
+  const { ref: projectRef } = useParams()
 
-  const {
-    data: backups,
-    error,
-    isLoading,
-    isError,
-    isSuccess,
-  } = useBackupsQuery({ projectRef: ref })
+  const { data: backups, error, isLoading, isError, isSuccess } = useBackupsQuery({ projectRef })
 
   const isPitrEnabled = backups?.pitr_enabled
   const isPermissionsLoaded = usePermissionsLoaded()
@@ -39,7 +32,7 @@ const DatabaseScheduledBackups: NextPageWithLayout = () => {
           <div className="space-y-6">
             <FormHeader className="!mb-0" title="Database Backups" />
 
-            <DatabaseBackupsNav active="scheduled" projRef={ref} />
+            <DatabaseBackupsNav active="scheduled" />
             <div className="flex flex-col gap-y-4">
               {isLoading && <GenericSkeletonLoader />}
 


### PR DESCRIPTION
Mainly the ones which are dependent on the database being online
- /run-lints
- any pg-meta ones, i've only added in for extensions since thats the one thats getting triggered while on a paused state, but technically any pg-meta RQs should have that check
- any that are executing SQL on the DB