### PR TITLE
fix: autofix action

### DIFF
--- a/.github/workflows/autofix_linters.yml
+++ b/.github/workflows/autofix_linters.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'pull_request' && (github.event.label.name == 'autofix') }}
     steps:
-
       - uses: actions/checkout@v4
         with:
           sparse-checkout: apps
+          ref: ${{ github.head_ref }}
 
       - uses: actions/setup-node@v4
         with:
@@ -39,7 +39,7 @@ jobs:
           git config --global user.email 'github-tidy-bot@supabase.com'
           if [[ `git status --porcelain` ]]; then
             echo "[bot] Changes detected, committing."
-       
+
             echo "[bot] Running in non-squash mode."
             git commit -am "ci: Autofix updates from GitHub workflow"
             git push

--- a/apps/docs/app/api/ai/docs/route.ts
+++ b/apps/docs/app/api/ai/docs/route.ts
@@ -10,7 +10,8 @@ export const runtime = 'edge'
   Reference for Vercel regions: https://vercel.com/docs/edge-network/regions#region-list
   Reference for OpenAI regions: https://help.openai.com/en/articles/5347006-openai-api-supported-countries-and-territories
   */
-export const preferredRegion = [ 'arn1',
+export const preferredRegion = [
+  'arn1',
   'bom1',
   'cdg1',
   'cle1',

--- a/apps/docs/app/api/ai/docs/route.ts
+++ b/apps/docs/app/api/ai/docs/route.ts
@@ -6,12 +6,11 @@ import OpenAI from 'openai'
 export const runtime = 'edge'
 /* To avoid OpenAI errors, restrict to the Vercel Edge Function regions that
   overlap with the OpenAI API regions.
-  
+
   Reference for Vercel regions: https://vercel.com/docs/edge-network/regions#region-list
   Reference for OpenAI regions: https://help.openai.com/en/articles/5347006-openai-api-supported-countries-and-territories
   */
-export const preferredRegion = [
-  'arn1',
+export const preferredRegion = [ 'arn1',
   'bom1',
   'cdg1',
   'cle1',


### PR DESCRIPTION
Autofix action is failing with error message:

```
fatal: You are not currently on a branch.
To push the history leading to the current (detached HEAD)
state now, use

    git push origin HEAD:<name-of-remote-branch>
```

This is because the checkout action on a PR by default checks out the merge commit, which is not a branch. Instead, check out [`github.head_ref`](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context), which will point to the source of the PR.

Successful autofix run: https://github.com/supabase/supabase/actions/runs/11785230155/job/32826046987?pr=30421