### PR TITLE
fix: use nulls last when sorting users

### DIFF
--- a/apps/studio/data/auth/users-infinite-query.ts
+++ b/apps/studio/data/auth/users-infinite-query.ts
@@ -33,7 +33,7 @@ export const getUsersSQL = ({
   keywords?: string
   providers?: string[]
   sort: string
-  order: string
+  order: 'asc' | 'desc'
 }) => {
   const offset = page * USERS_PAGE_LIMIT
   const hasValidKeywords = keywords && keywords !== ''
@@ -73,7 +73,7 @@ export const getUsersSQL = ({
   const sortOn = sort ?? 'created_at'
   const sortOrder = order ?? 'desc'
 
-  return `${baseQueryUsers}${conditions.length > 0 ? ` where ${combinedConditions}` : ''} order by "${sortOn}" ${sortOrder} limit ${USERS_PAGE_LIMIT} offset ${offset};`
+  return `${baseQueryUsers}${conditions.length > 0 ? ` where ${combinedConditions}` : ''} order by "${sortOn}" ${sortOrder} nulls last limit ${USERS_PAGE_LIMIT} offset ${offset};`
 }
 
 export type UsersData = { result: User[] }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When sorting on last sign in at descending, you have to scroll past a bunch of users that haven't ever signed in before you can see your most recent sign in

## What is the new behavior?

Moves these users to the end

## Additional context
Before:
<img width="975" alt="Screenshot 2024-11-12 at 16 13 01" src="https://github.com/user-attachments/assets/56d91454-df73-4595-9ca9-af5992d5e53b">

