### PR TITLE
fix: allow downgrade to Free Plan with no active projects

### DIFF
--- a/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/PlanUpdateSidePanel.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/PlanUpdateSidePanel.tsx
@@ -102,7 +102,9 @@ const PlanUpdateSidePanel = () => {
   } = useOrganizationBillingSubscriptionPreview({ tier: selectedTier, organizationSlug: slug })
 
   const availablePlans: OrgPlan[] = plans?.plans ?? []
-  const hasMembersExceedingFreeTierLimit = (membersExceededLimit || []).length > 0
+  const hasMembersExceedingFreeTierLimit =
+    (membersExceededLimit || []).length > 0 &&
+    orgProjects.filter((it) => it.status !== 'INACTIVE' && it.status !== 'GOING_DOWN').length > 0
   const subscriptionPlanMeta = subscriptionsPlans.find((tier) => tier.id === selectedTier)
 
   const expandUsageFee = (fee: string) => {


### PR DESCRIPTION
The member exceeding Free Plan limits modal should not be displayed if the org to be downgraded has no active projects.
