### PR TITLE
docs: Update next.js and sveltekit quick start guides

### DIFF
--- a/apps/docs/content/guides/getting-started/quickstarts/nextjs.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/nextjs.mdx
@@ -9,53 +9,7 @@ hideToc: true
 
   <StepHikeCompact.Step step={1}>
 
-    <StepHikeCompact.Details title="Create a Supabase project">
-
-      Go to [database.new](https://database.new) and create a new Supabase project.
-
-      When your project is up and running, go to the [Table Editor](https://supabase.com/dashboard/project/_/editor), create a new table and insert some data.
-
-      Alternatively, you can run the following snippet in your project's [SQL Editor](https://supabase.com/dashboard/project/_/sql/new). This will create a `notes` table with some sample data.
-
-    </StepHikeCompact.Details>
-
-    <StepHikeCompact.Code>
-
-      ```sql SQL_EDITOR
-      -- Create the table
-      create table notes (
-        id bigint primary key generated always as identity,
-        title text not null
-      );
-
-      -- Insert some sample data into the table
-      insert into notes (title)
-      values
-        ('Today I created a Supabase project.'),
-        ('I added some data and queried it from Next.js.'),
-        ('It was awesome!');
-
-      alter table notes enable row level security;
-      ```
-
-    </StepHikeCompact.Code>
-
-    <StepHikeCompact.Details>
-
-    Make the data in your table publicly readable by adding an RLS policy:
-
-    </StepHikeCompact.Details>
-
-    <StepHikeCompact.Code>
-
-      ```sql SQL_EDITOR
-      create policy "public can read notes"
-      on public.notes
-      for select to anon
-      using (true);
-      ```
-
-    </StepHikeCompact.Code>
+    <QuickstartDbSetup />
 
   </StepHikeCompact.Step>
 
@@ -104,9 +58,9 @@ hideToc: true
   <StepHikeCompact.Step step={4}>
     <StepHikeCompact.Details title="Query Supabase data from Next.js">
 
-    Create a new file at `app/notes/page.tsx` and populate with the following.
+    Create a new file at `app/countries/page.tsx` and populate with the following.
 
-    This will select all the rows from the `notes` table in Supabase and render them on the page.
+    This will select all the rows from the `countries` table in Supabase and render them on the page.
 
     </StepHikeCompact.Details>
 
@@ -114,14 +68,14 @@ hideToc: true
 
     <CH.Code className="min-h-[34rem]">
 
-      ```ts app/notes/page.tsx
+      ```ts app/countries/page.tsx
         import { createClient } from '@/utils/supabase/server';
 
-        export default async function Notes() {
+        export default async function Countries() {
           const supabase = await createClient();
-          const { data: notes } = await supabase.from("notes").select();
+          const { data: countries } = await supabase.from("countries").select();
 
-          return <pre>{JSON.stringify(notes, null, 2)}</pre>
+          return <pre>{JSON.stringify(countries, null, 2)}</pre>
         }
       ```
 
@@ -166,7 +120,7 @@ hideToc: true
   <StepHikeCompact.Step step={5}>
     <StepHikeCompact.Details title="Start the app">
 
-    Run the development server, go to http://localhost:3000/notes in a browser and you should see the list of notes.
+    Run the development server, go to http://localhost:3000/countries in a browser and you should see the list of countries.
 
     </StepHikeCompact.Details>
 

--- a/apps/docs/content/guides/getting-started/quickstarts/sveltekit.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/sveltekit.mdx
@@ -24,7 +24,7 @@ hideToc: true
     <StepHikeCompact.Code>
 
       ```bash Terminal
-      npm create svelte@latest myapp
+      npx sv create my-app
       ```
 
     </StepHikeCompact.Code>
@@ -43,7 +43,7 @@ hideToc: true
     <StepHikeCompact.Code>
 
       ```bash Terminal
-      cd myapp && npm install @supabase/supabase-js
+      cd my-app && npm install @supabase/supabase-js
       ```
 
     </StepHikeCompact.Code>
@@ -53,7 +53,7 @@ hideToc: true
   <StepHikeCompact.Step step={4}>
     <StepHikeCompact.Details title="Create the Supabase client">
 
-    Create a `/src/lib` directory in your SvelteKit app, create a file called `supabaseClient.js` and add the following code to initialize the Supabase client with your project URL and public API (anon) key:
+    Create a `src/lib` directory in your SvelteKit app, create a file called `supabaseClient.js` and add the following code to initialize the Supabase client with your project URL and public API (anon) key:
 
     <ProjectConfigVariables variable="url" />
     <ProjectConfigVariables variable="anonKey" />
@@ -77,7 +77,7 @@ hideToc: true
 
     Use `load` method to fetch the data server-side and display the query results as a simple list.
 
-    Create `+page.server.js` file in the `routes` directory with the following code.
+    Create `+page.server.js` file in the `src/routes` directory with the following code.
 
     </StepHikeCompact.Details>
     <StepHikeCompact.Code>
@@ -98,7 +98,7 @@ hideToc: true
 
     <StepHikeCompact.Details title="">
 
-    Replace the existing content in your `+page.svelte` file in the `routes` directory with the following code.
+    Replace the existing content in your `+page.svelte` file in the `src/routes` directory with the following code.
 
     </StepHikeCompact.Details>
     <StepHikeCompact.Code>


### PR DESCRIPTION
While working on quick start guides for Vercel Marketplace I noticed that some things were not precise or out of date. Fixed them all here.