### PR TITLE
fix: LinkedIn (OIDC) & Slack (OIDC) providers filter under Authentication > Users

### DIFF
--- a/apps/studio/components/interfaces/Auth/AuthProvidersFormValidation.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersFormValidation.tsx
@@ -948,7 +948,6 @@ const EXTERNAL_PROVIDER_LINKEDIN_OIDC = {
   $schema: JSON_SCHEMA_VERSION,
   type: 'object',
   title: 'LinkedIn (OIDC)',
-  value: 'linkedin_oidc',
   link: 'https://supabase.com/docs/guides/auth/social-login/auth-linkedin',
   properties: {
     EXTERNAL_LINKEDIN_OIDC_ENABLED: {
@@ -1144,7 +1143,6 @@ const EXTERNAL_PROVIDER_SLACK_OIDC = {
   $schema: JSON_SCHEMA_VERSION,
   type: 'object',
   title: 'Slack (OIDC)',
-  value: 'slack_oidc',
   link: 'https://supabase.com/docs/guides/auth/social-login/auth-slack',
   properties: {
     EXTERNAL_SLACK_OIDC_ENABLED: {

--- a/apps/studio/components/interfaces/Auth/AuthProvidersFormValidation.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersFormValidation.tsx
@@ -948,6 +948,7 @@ const EXTERNAL_PROVIDER_LINKEDIN_OIDC = {
   $schema: JSON_SCHEMA_VERSION,
   type: 'object',
   title: 'LinkedIn (OIDC)',
+  value: 'linkedin_oidc',
   link: 'https://supabase.com/docs/guides/auth/social-login/auth-linkedin',
   properties: {
     EXTERNAL_LINKEDIN_OIDC_ENABLED: {
@@ -1143,6 +1144,7 @@ const EXTERNAL_PROVIDER_SLACK_OIDC = {
   $schema: JSON_SCHEMA_VERSION,
   type: 'object',
   title: 'Slack (OIDC)',
+  value: 'slack_oidc',
   link: 'https://supabase.com/docs/guides/auth/social-login/auth-slack',
   properties: {
     EXTERNAL_SLACK_OIDC_ENABLED: {

--- a/apps/studio/components/interfaces/Auth/Users/Users.constants.ts
+++ b/apps/studio/components/interfaces/Auth/Users/Users.constants.ts
@@ -3,7 +3,12 @@ import { PROVIDER_PHONE, PROVIDERS_SCHEMAS } from '../AuthProvidersFormValidatio
 
 export const PROVIDER_FILTER_OPTIONS = PROVIDERS_SCHEMAS.map((provider) => ({
   name: provider.title,
-  value: provider.value || provider.title.toLowerCase(),
+  value:
+    provider.title === 'Slack (OIDC)'
+      ? 'slack_oidc'
+      : provider.title === 'LinkedIn (OIDC)'
+        ? 'linkedin_oidc'
+        : provider.title.toLowerCase(),
   icon: `${BASE_PATH}/img/icons/${provider.misc.iconKey}.svg`,
   iconClass: provider.title === 'GitHub' ? 'dark:invert' : '',
 })).concat(

--- a/apps/studio/components/interfaces/Auth/Users/Users.constants.ts
+++ b/apps/studio/components/interfaces/Auth/Users/Users.constants.ts
@@ -3,7 +3,7 @@ import { PROVIDER_PHONE, PROVIDERS_SCHEMAS } from '../AuthProvidersFormValidatio
 
 export const PROVIDER_FILTER_OPTIONS = PROVIDERS_SCHEMAS.map((provider) => ({
   name: provider.title,
-  value: provider.title.toLowerCase(),
+  value: provider.value || provider.title.toLowerCase(),
   icon: `${BASE_PATH}/img/icons/${provider.misc.iconKey}.svg`,
   iconClass: provider.title === 'GitHub' ? 'dark:invert' : '',
 })).concat(


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Users are not displayed when using filtering by provider LinkedIn (OIDC) or Slack (OIDC) under Authentication > Users

![image](https://github.com/user-attachments/assets/9ffee4fe-5c99-4a44-9549-1d5a1498ddf5)

![image](https://github.com/user-attachments/assets/99dc2768-abee-4ad9-94a7-d1ce44de7f14)


## What is the new behavior?

<img width="896" alt="image" src="https://github.com/user-attachments/assets/81ec33c6-8173-48af-8d0c-96d6d68e9e32">
