### PR TITLE
fix: update results tab to be scrollable on content overflow

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityTabResults.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityTabResults.tsx
@@ -59,7 +59,7 @@ const UtilityTabResults = ({
     )
 
     return (
-      <div className="bg-table-header-light [[data-theme*=dark]_&]:bg-table-header-dark">
+      <div className="bg-table-header-light overflow-y-auto [[data-theme*=dark]_&]:bg-table-header-dark">
         <div className="flex flex-row justify-between items-start py-4 px-6 gap-x-4">
           {isTimeout ? (
             <div className="flex flex-col gap-y-1">
@@ -155,7 +155,7 @@ const UtilityTabResults = ({
     )
   } else if (!result) {
     return (
-      <div className="bg-table-header-light [[data-theme*=dark]_&]:bg-table-header-dark">
+      <div className="bg-table-header-light overflow-y-auto [[data-theme*=dark]_&]:bg-table-header-dark">
         <p className="m-0 border-0 px-6 py-4 text-sm text-foreground-light">
           Click <code>Run</code> to execute your query.
         </p>
@@ -163,7 +163,7 @@ const UtilityTabResults = ({
     )
   } else if (result.rows.length <= 0) {
     return (
-      <div className="bg-table-header-light [[data-theme*=dark]_&]:bg-table-header-dark">
+      <div className="bg-table-header-light overflow-y-auto [[data-theme*=dark]_&]:bg-table-header-dark">
         <p className="m-0 border-0 px-6 py-4 font-mono text-sm">Success. No rows returned</p>
       </div>
     )


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix,

## What is the current behavior?

When you make some request in the SQL Editor and the result does not fit within the result tab, you can't scroll.

#30453 

## What is the new behavior?

When you make some request  in the SQL Editor and the result does not fit within the result tab, you can now scroll down.

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
