### PR TITLE
Update actions/checkout to use v4 (node 20)

### DIFF
--- a/apps/docs/content/guides/functions/examples/github-actions.mdx
+++ b/apps/docs/content/guides/functions/examples/github-actions.mdx
@@ -34,7 +34,7 @@ jobs:
       PROJECT_ID: YOUR_SUPABASE_PROJECT_ID
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: supabase/setup-cli@v1
         with:


### PR DESCRIPTION
When Use the Supabase CLI   with GitHub Actions to automatically deploy our Supabase Edge get this warning :
```
github action deploy The following actions use a deprecated Node.js version and will be forced to run on node20: actions/checkout@v3. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
```

 