### PR TITLE
deprecated: Divider component

### DIFF
--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenuCliList.tsx
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenuCliList.tsx
@@ -4,6 +4,7 @@ import { BASE_PATH } from '~/lib/constants'
 import clientLibsCommon from '~/spec/common-cli.yml' assert { type: 'yml' }
 import * as NavItems from './NavigationMenu.constants'
 import { ChevronLeft } from 'lucide-react'
+import { Separator } from 'ui'
 
 const NavigationMenuCliList = ({ currentLevel, setLevel, id }) => {
   const menu = NavItems[id]
@@ -44,10 +45,6 @@ const NavigationMenuCliList = ({ currentLevel, setLevel, id }) => {
         {title}
       </span>
     )
-  }
-
-  const Divider = () => {
-    return <div className="h-px w-full bg-border my-3"></div>
   }
 
   const MenuSections = [
@@ -123,7 +120,7 @@ const NavigationMenuCliList = ({ currentLevel, setLevel, id }) => {
           {MenuSections.map((section) => {
             return (
               <>
-                <Divider />
+                <Separator className="h-px w-full bg-border border-t my-3" />
                 <SideMenuTitle title={section.label} />
 
                 {clientLibsCommon.commands
@@ -134,8 +131,7 @@ const NavigationMenuCliList = ({ currentLevel, setLevel, id }) => {
               </>
             )
           })}
-
-          <Divider />
+          <Separator className="h-px w-full bg-border border-t my-3" />
         </ul>
       </div>
     </div>

--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenuRefListItems.tsx
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenuRefListItems.tsx
@@ -4,7 +4,7 @@ import * as Accordion from '@radix-ui/react-accordion'
 import { ChevronUp } from 'lucide-react'
 import Image from 'next/legacy/image'
 import { Fragment, memo } from 'react'
-import { cn } from 'ui'
+import { cn, Separator } from 'ui'
 import RevVersionDropdown from '~/components/RefVersionDropdown'
 import type { ICommonItem, ICommonSection } from '~/components/reference/Reference.types'
 import { menuState, useMenuActiveRefId } from '~/hooks/useMenuState'
@@ -156,10 +156,6 @@ const SideMenuTitle = ({ title }: { title: string }) => {
   )
 }
 
-const Divider = () => {
-  return <div className="h-px w-full bg-control my-3"></div>
-}
-
 interface NavigationMenuRefListItemsProps {
   id: string
   basePath: string
@@ -192,7 +188,7 @@ const NavigationMenuRefListItems = ({
             <Fragment key={section.title}>
               {section.type === 'category' ? (
                 <>
-                  <Divider />
+                  <Separator className="h-px w-full bg-border border-t my-3" />
                   <SideMenuTitle title={section.title} />
                   {section.items.map((item) => (
                     <RenderLink key={item.id} section={item} basePath={basePath} />

--- a/apps/docs/features/docs/Reference.navigation.tsx
+++ b/apps/docs/features/docs/Reference.navigation.tsx
@@ -1,6 +1,6 @@
 import { Fragment, type PropsWithChildren } from 'react'
 
-import { cn } from 'ui'
+import { cn, Separator } from 'ui'
 
 import MenuIconPicker from '~/components/Navigation/NavigationMenu/MenuIconPicker'
 import RefVersionDropdown from '~/components/RefVersionDropdown'
@@ -73,7 +73,7 @@ function RefCategory({
 
   return (
     <>
-      <Divider />
+      <Separator className="w-full h-px my-3 bg-control border-t" />
       {'title' in section && <SideMenuTitle className="py-2">{section.title}</SideMenuTitle>}
       <ul className="space-y-2">
         {section.items.map((item) => (
@@ -84,10 +84,6 @@ function RefCategory({
       </ul>
     </>
   )
-}
-
-function Divider() {
-  return <hr className="w-full h-px my-3 bg-control" />
 }
 
 function SideMenuTitle({ children, className }: PropsWithChildren<{ className?: string }>) {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Removes the `<Divider />` component and uses the shadui `<Separator />`

