### PR TITLE
deprecated: alert - auditlog

### DIFF
--- a/apps/studio/components/interfaces/Account/AuditLogs.tsx
+++ b/apps/studio/components/interfaces/Account/AuditLogs.tsx
@@ -13,7 +13,7 @@ import type { AuditLog } from 'data/organizations/organization-audit-logs-query'
 import { useOrganizationsQuery } from 'data/organizations/organizations-query'
 import { useProfileAuditLogsQuery } from 'data/profile/profile-audit-logs-query'
 import { useProjectsQuery } from 'data/projects/projects-query'
-import { Alert, Button } from 'ui'
+import { Alert_Shadcn_, AlertDescription_Shadcn_, Button } from 'ui'
 
 const AuditLogs = () => {
   const currentTime = dayjs().utc().set('millisecond', 0)
@@ -112,16 +112,18 @@ const AuditLogs = () => {
               }}
               renderFooter={() => {
                 return (
-                  <Alert title="" variant="info" className="mx-3 pl-2 pr-2 pt-1 pb-2">
-                    You have a log retention period of{' '}
-                    <span className="text-brand">
-                      {retentionPeriod} day
-                      {retentionPeriod > 1 ? 's' : ''}
-                    </span>
-                    . You may only view logs from{' '}
-                    {dayjs().subtract(retentionPeriod, 'days').format('DD MMM YYYY')} as the
-                    earliest date.
-                  </Alert>
+                  <Alert_Shadcn_ className="mx-3 pl-2 pr-2 pt-1 pb-2 w-auto">
+                    <AlertDescription_Shadcn_ className="text-xs">
+                      You have a log retention period of{' '}
+                      <span className="text-brand">
+                        {retentionPeriod} day
+                        {retentionPeriod > 1 ? 's' : ''}
+                      </span>
+                      . You may only view logs from{' '}
+                      {dayjs().subtract(retentionPeriod, 'days').format('DD MMM YYYY')} as the
+                      earliest date.
+                    </AlertDescription_Shadcn_>
+                  </Alert_Shadcn_>
                 )
               }}
             />

--- a/apps/studio/components/interfaces/Account/AuditLogs.tsx
+++ b/apps/studio/components/interfaces/Account/AuditLogs.tsx
@@ -13,7 +13,8 @@ import type { AuditLog } from 'data/organizations/organization-audit-logs-query'
 import { useOrganizationsQuery } from 'data/organizations/organizations-query'
 import { useProfileAuditLogsQuery } from 'data/profile/profile-audit-logs-query'
 import { useProjectsQuery } from 'data/projects/projects-query'
-import { Alert_Shadcn_, AlertDescription_Shadcn_, Button } from 'ui'
+import { Button } from 'ui'
+import { Admonition } from 'ui-patterns'
 
 const AuditLogs = () => {
   const currentTime = dayjs().utc().set('millisecond', 0)
@@ -112,8 +113,13 @@ const AuditLogs = () => {
               }}
               renderFooter={() => {
                 return (
-                  <Alert_Shadcn_ className="mx-3 pl-2 pr-2 pt-1 pb-2 w-auto">
-                    <AlertDescription_Shadcn_ className="text-xs">
+                  <Admonition
+                    type="default"
+                    title=""
+                    showIcon={false}
+                    className="mx-3 pl-2 pr-2 pt-1 pb-2 w-auto"
+                  >
+                    <div className="text-xs">
                       You have a log retention period of{' '}
                       <span className="text-brand">
                         {retentionPeriod} day
@@ -122,8 +128,8 @@ const AuditLogs = () => {
                       . You may only view logs from{' '}
                       {dayjs().subtract(retentionPeriod, 'days').format('DD MMM YYYY')} as the
                       earliest date.
-                    </AlertDescription_Shadcn_>
-                  </Alert_Shadcn_>
+                    </div>
+                  </Admonition>
                 )
               }}
             />


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Changes the `<Alert/>` component to `<Alert_Shadcn_ />`

## What is the current behavior?

<img width="287" alt="Screenshot 2024-11-17 at 21 21 04" src="https://github.com/user-attachments/assets/994eddad-ee7d-4c0d-81dd-599c0ae43917">

## What is the new behavior?

<img width="287" alt="Screenshot 2024-11-17 at 21 36 08" src="https://github.com/user-attachments/assets/9171d2dd-f85c-4137-bb05-de2d5f622d31">

