### PR TITLE
chore: add prefetching delay

### DIFF
--- a/apps/studio/data/prefetchers/PrefetchableLink.tsx
+++ b/apps/studio/data/prefetchers/PrefetchableLink.tsx
@@ -1,0 +1,47 @@
+import Link from 'next/link'
+import { ComponentProps, forwardRef, useRef } from 'react'
+
+type LinkProps = ComponentProps<typeof Link>
+
+export interface PrefetchableLinkProps extends Omit<LinkProps, 'onMouseEnter' | 'onMouseLeave'> {
+  prefetcher: () => void
+}
+
+const DELAY = 100
+
+const PrefetchableLink = forwardRef<HTMLAnchorElement, PrefetchableLinkProps>(
+  function PrefetchableLink({ prefetcher, children, ...props }, ref) {
+    const mouseOverStartRef = useRef<number | null>(null)
+    const prefetchTimeoutRef = useRef<number | null>(null)
+
+    function onPrefetch() {
+      const now = Date.now()
+
+      // setTimeout is not guaranteed to be precise, so we need to check the time again
+      if (mouseOverStartRef.current && now - mouseOverStartRef.current >= DELAY) {
+        prefetcher()
+      }
+    }
+
+    function onMouseEnter() {
+      mouseOverStartRef.current = Date.now()
+      prefetchTimeoutRef.current = window.setTimeout(onPrefetch, DELAY)
+    }
+
+    function onMouseLeave() {
+      mouseOverStartRef.current = null
+      if (prefetchTimeoutRef.current) {
+        clearTimeout(prefetchTimeoutRef.current)
+        prefetchTimeoutRef.current = null
+      }
+    }
+
+    return (
+      <Link ref={ref} {...props} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
+        {children}
+      </Link>
+    )
+  }
+)
+
+export default PrefetchableLink

--- a/apps/studio/data/prefetchers/PrefetchableLink.tsx
+++ b/apps/studio/data/prefetchers/PrefetchableLink.tsx
@@ -7,7 +7,7 @@ export interface PrefetchableLinkProps extends Omit<LinkProps, 'onMouseEnter' | 
   prefetcher: () => void
 }
 
-const DELAY = 100
+const DELAY = 75
 
 const PrefetchableLink = forwardRef<HTMLAnchorElement, PrefetchableLinkProps>(
   function PrefetchableLink({ prefetcher, children, ...props }, ref) {

--- a/apps/studio/data/prefetchers/project.$ref.editor.$id.tsx
+++ b/apps/studio/data/prefetchers/project.$ref.editor.$id.tsx
@@ -1,7 +1,6 @@
 import { QueryClient, useQueryClient } from '@tanstack/react-query'
-import Link from 'next/link'
 import { useRouter } from 'next/router'
-import { ComponentProps, PropsWithChildren, useCallback } from 'react'
+import { PropsWithChildren, useCallback } from 'react'
 
 import { loadTableEditorSortsAndFiltersFromLocalStorage } from 'components/grid/SupabaseGrid'
 import {
@@ -17,6 +16,7 @@ import { useFlag } from 'hooks/ui/useFlag'
 import { ImpersonationRole } from 'lib/role-impersonation'
 import { useRoleImpersonationStateSnapshot } from 'state/role-impersonation-state'
 import { TABLE_EDITOR_DEFAULT_ROWS_PER_PAGE } from 'state/table-editor'
+import PrefetchableLink, { PrefetchableLinkProps } from './PrefetchableLink'
 
 interface PrefetchEditorTablePageArgs {
   queryClient: QueryClient
@@ -96,14 +96,12 @@ export function usePrefetchEditorTablePage() {
   )
 }
 
-type LinkProps = ComponentProps<typeof Link>
-
-interface EditorTablePageLinkProps extends Omit<LinkProps, 'href'> {
+interface EditorTablePageLinkProps extends Omit<PrefetchableLinkProps, 'href' | 'prefetcher'> {
   projectRef?: string
   id?: string
   sorts?: Sort[]
   filters?: Filter[]
-  href?: LinkProps['href']
+  href?: PrefetchableLinkProps['href']
 }
 
 export function EditorTablePageLink({
@@ -118,12 +116,12 @@ export function EditorTablePageLink({
   const prefetch = usePrefetchEditorTablePage()
 
   return (
-    <Link
+    <PrefetchableLink
       href={href || `/project/${projectRef}/editor/${id}`}
-      onMouseEnter={() => prefetch({ id, sorts, filters })}
+      prefetcher={() => prefetch({ id, sorts, filters })}
       {...props}
     >
       {children}
-    </Link>
+    </PrefetchableLink>
   )
 }

--- a/apps/studio/data/prefetchers/project.$ref.editor.tsx
+++ b/apps/studio/data/prefetchers/project.$ref.editor.tsx
@@ -1,7 +1,6 @@
 import { useQueryClient } from '@tanstack/react-query'
-import Link from 'next/link'
 import { useRouter } from 'next/router'
-import { ComponentProps, PropsWithChildren, useCallback } from 'react'
+import { PropsWithChildren, useCallback } from 'react'
 
 import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
 import { prefetchSchemas } from 'data/database/schemas-query'
@@ -9,6 +8,7 @@ import { ENTITY_TYPE } from 'data/entity-types/entity-type-constants'
 import { prefetchEntityTypes } from 'data/entity-types/entity-types-infinite-query'
 import { useLocalStorage } from 'hooks/misc/useLocalStorage'
 import { useFlag } from 'hooks/ui/useFlag'
+import PrefetchableLink, { PrefetchableLinkProps } from './PrefetchableLink'
 
 export function usePrefetchEditorIndexPage() {
   const router = useRouter()
@@ -45,11 +45,9 @@ export function usePrefetchEditorIndexPage() {
   }, [entityTypesSort, project, queryClient, router])
 }
 
-type LinkProps = ComponentProps<typeof Link>
-
-interface EditorIndexPageLinkProps extends Omit<LinkProps, 'href'> {
+interface EditorIndexPageLinkProps extends Omit<PrefetchableLinkProps, 'href' | 'prefetcher'> {
   projectRef?: string
-  href?: LinkProps['href']
+  href?: PrefetchableLinkProps['href']
 }
 
 export function EditorIndexPageLink({
@@ -61,8 +59,12 @@ export function EditorIndexPageLink({
   const prefetch = usePrefetchEditorIndexPage()
 
   return (
-    <Link href={href || `/project/${projectRef}/editor`} onMouseEnter={prefetch} {...props}>
+    <PrefetchableLink
+      href={href || `/project/${projectRef}/editor`}
+      prefetcher={prefetch}
+      {...props}
+    >
       {children}
-    </Link>
+    </PrefetchableLink>
   )
 }

--- a/apps/studio/data/prefetchers/project.$ref.tsx
+++ b/apps/studio/data/prefetchers/project.$ref.tsx
@@ -1,11 +1,11 @@
 import { useQueryClient } from '@tanstack/react-query'
-import Link from 'next/link'
 import { useRouter } from 'next/router'
-import { ComponentProps, PropsWithChildren, useCallback } from 'react'
+import { PropsWithChildren, useCallback } from 'react'
 
 import { prefetchProjectLogRequestsCount } from 'data/analytics/project-log-requests-count-query'
 import { prefetchProjectLogStats } from 'data/analytics/project-log-stats-query'
 import { prefetchProjectDetail } from 'data/projects/project-detail-query'
+import PrefetchableLink, { PrefetchableLinkProps } from './PrefetchableLink'
 
 export function usePrefetchProjectIndexPage() {
   const router = useRouter()
@@ -40,11 +40,9 @@ export function usePrefetchProjectIndexPage() {
   )
 }
 
-type LinkProps = ComponentProps<typeof Link>
-
-interface ProjectIndexPageLinkProps extends Omit<LinkProps, 'href'> {
+interface ProjectIndexPageLinkProps extends Omit<PrefetchableLinkProps, 'href' | 'prefetcher'> {
   projectRef?: string
-  href?: LinkProps['href']
+  href?: PrefetchableLinkProps['href']
 }
 
 export function ProjectIndexPageLink({
@@ -56,12 +54,12 @@ export function ProjectIndexPageLink({
   const prefetch = usePrefetchProjectIndexPage()
 
   return (
-    <Link
+    <PrefetchableLink
       href={href || `/project/${projectRef}`}
-      onMouseEnter={() => prefetch({ projectRef })}
+      prefetcher={() => prefetch({ projectRef })}
       {...props}
     >
       {children}
-    </Link>
+    </PrefetchableLink>
   )
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

chore

## What is the current behavior?

Prefetching is triggered immediately when a user hovers a prefetchable link.

## What is the new behavior?

Prefetching is only triggered after a user has hovered a link for 75ms. This should indicate that the user actually intends to click the link.

## Shout out to Josh

https://www.youtube.com/watch?v=7bfTpZxRGto&t=929s