### PR TITLE
deprecated: alert - new access token

### DIFF
--- a/apps/studio/components/interfaces/Account/NewAccessTokenButton.tsx
+++ b/apps/studio/components/interfaces/Account/NewAccessTokenButton.tsx
@@ -4,9 +4,6 @@ import { useState } from 'react'
 
 import { useAccessTokenCreateMutation } from 'data/access-tokens/access-tokens-create-mutation'
 import {
-  Alert_Shadcn_,
-  AlertDescription_Shadcn_,
-  AlertTitle_Shadcn_,
   Button,
   DialogFooter,
   DropdownMenu,
@@ -16,8 +13,8 @@ import {
   Form,
   Input,
   Modal,
-  WarningIcon,
 } from 'ui'
+import { Admonition } from 'ui-patterns'
 
 export interface NewAccessTokenButtonProps {
   onCreateToken: (token: any) => void
@@ -108,30 +105,30 @@ const NewAccessTokenButton = ({ onCreateToken }: NewAccessTokenButtonProps) => {
             <>
               {tokenScope === 'V0' && (
                 <Modal.Content>
-                  <Alert_Shadcn_ variant="warning">
-                    <WarningIcon />
-                    <AlertTitle_Shadcn_>
-                      The experimental API provides additional endpoints which allows you to manage
-                      your organizations and projects.
-                    </AlertTitle_Shadcn_>
-                    <AlertDescription_Shadcn_>
-                      <p>
-                        These include deleting organizations and projects which cannot be undone. As
-                        such, be very careful when using this API.
-                      </p>
-                      <div className="mt-4">
-                        <Button asChild type="default" icon={<ExternalLink />}>
-                          <Link
-                            href="https://api.supabase.com/api/v0"
-                            target="_blank"
-                            rel="noreferrer"
-                          >
-                            Experimental API documentation
-                          </Link>
-                        </Button>
-                      </div>
-                    </AlertDescription_Shadcn_>
-                  </Alert_Shadcn_>
+                  <Admonition
+                    type="warning"
+                    title="The experimental API provides additional endpoints which allows you to manage
+                      your organizations and projects."
+                    description={
+                      <>
+                        <p>
+                          These include deleting organizations and projects which cannot be undone.
+                          As such, be very careful when using this API.
+                        </p>
+                        <div className="mt-4">
+                          <Button asChild type="default" icon={<ExternalLink />}>
+                            <Link
+                              href="https://api.supabase.com/api/v0"
+                              target="_blank"
+                              rel="noreferrer"
+                            >
+                              Experimental API documentation
+                            </Link>
+                          </Button>
+                        </div>
+                      </>
+                    }
+                  />
                 </Modal.Content>
               )}
               <Modal.Content>

--- a/apps/studio/components/interfaces/Account/NewAccessTokenButton.tsx
+++ b/apps/studio/components/interfaces/Account/NewAccessTokenButton.tsx
@@ -4,7 +4,6 @@ import { useState } from 'react'
 
 import { useAccessTokenCreateMutation } from 'data/access-tokens/access-tokens-create-mutation'
 import {
-  Alert,
   Alert_Shadcn_,
   AlertDescription_Shadcn_,
   AlertTitle_Shadcn_,

--- a/apps/studio/components/interfaces/Account/NewAccessTokenButton.tsx
+++ b/apps/studio/components/interfaces/Account/NewAccessTokenButton.tsx
@@ -5,6 +5,9 @@ import { useState } from 'react'
 import { useAccessTokenCreateMutation } from 'data/access-tokens/access-tokens-create-mutation'
 import {
   Alert,
+  Alert_Shadcn_,
+  AlertDescription_Shadcn_,
+  AlertTitle_Shadcn_,
   Button,
   DialogFooter,
   DropdownMenu,
@@ -14,6 +17,7 @@ import {
   Form,
   Input,
   Modal,
+  WarningIcon,
 } from 'ui'
 
 export interface NewAccessTokenButtonProps {
@@ -105,27 +109,30 @@ const NewAccessTokenButton = ({ onCreateToken }: NewAccessTokenButtonProps) => {
             <>
               {tokenScope === 'V0' && (
                 <Modal.Content>
-                  <Alert
-                    withIcon
-                    variant="warning"
-                    title="The experimental API provides additional endpoints which allows you to manage your organizations and projects."
-                  >
-                    <p>
-                      These include deleting organizations and projects which cannot be undone. As
-                      such, be very careful when using this API.
-                    </p>
-                    <div className="mt-4">
-                      <Button asChild type="default" icon={<ExternalLink />}>
-                        <Link
-                          href="https://api.supabase.com/api/v0"
-                          target="_blank"
-                          rel="noreferrer"
-                        >
-                          Experimental API documentation
-                        </Link>
-                      </Button>
-                    </div>
-                  </Alert>
+                  <Alert_Shadcn_ variant="warning">
+                    <WarningIcon />
+                    <AlertTitle_Shadcn_>
+                      The experimental API provides additional endpoints which allows you to manage
+                      your organizations and projects.
+                    </AlertTitle_Shadcn_>
+                    <AlertDescription_Shadcn_>
+                      <p>
+                        These include deleting organizations and projects which cannot be undone. As
+                        such, be very careful when using this API.
+                      </p>
+                      <div className="mt-4">
+                        <Button asChild type="default" icon={<ExternalLink />}>
+                          <Link
+                            href="https://api.supabase.com/api/v0"
+                            target="_blank"
+                            rel="noreferrer"
+                          >
+                            Experimental API documentation
+                          </Link>
+                        </Button>
+                      </div>
+                    </AlertDescription_Shadcn_>
+                  </Alert_Shadcn_>
                 </Modal.Content>
               )}
               <Modal.Content>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Switches deprecated Alert

## What is the current behavior?

<img width="385" alt="Screenshot 2024-11-18 at 19 45 12" src="https://github.com/user-attachments/assets/dc9d1d3e-8e4a-4508-9f42-4fd2a1d8920d">


## What is the new behavior?

<img width="385" alt="Screenshot 2024-11-18 at 20 02 34" src="https://github.com/user-attachments/assets/bc874b3a-737b-4d6f-923f-aad7694de703">
