### PR TITLE
style(docs): remove unused account import from app file in react native

### DIFF
--- a/apps/docs/content/guides/auth/quickstarts/react-native.mdx
+++ b/apps/docs/content/guides/auth/quickstarts/react-native.mdx
@@ -219,7 +219,6 @@ hideToc: true
       import { useState, useEffect } from 'react'
       import { supabase } from './lib/supabase'
       import Auth from './components/Auth'
-      import Account from './components/Account'
       import { View, Text } from 'react-native'
       import { Session } from '@supabase/supabase-js'
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The example code in the [React Native Auth Quickstart](https://supabase.com/docs/guides/auth/quickstarts/react-native) includes an unused `Account` import in the `App` component. This could confuse users as the import is not utilized.

## What is the new behavior?

The unused `Account` import has been removed from the example code to make it cleaner and easier to follow for users.

## Additional context

No additional context is required for this change as it is a minor documentation update.

Fix #30566 
