### PR TITLE
depreacted: wrappers listbox

### DIFF
--- a/apps/studio/components/interfaces/Database/Wrappers/WrapperTableEditor.tsx
+++ b/apps/studio/components/interfaces/Database/Wrappers/WrapperTableEditor.tsx
@@ -90,16 +90,16 @@ const WrapperTableEditor = ({
               onValueChange={(value) => setSelectedTableIndex(value)}
             >
               <SelectTrigger_Shadcn_ className="mt-0">
-                <SelectValue_Shadcn_>
+                <SelectValue_Shadcn_ placeholder="---">
                   {selectedTableIndex
                     ? tables[selectedTableIndex as unknown as number].label
-                    : 'Select a value'}
+                    : '---'}
                 </SelectValue_Shadcn_>
               </SelectTrigger_Shadcn_>
               <SelectContent_Shadcn_>
                 {tables.map((table, i) => {
                   return (
-                    <SelectItem_Shadcn_ key={String(i)} value={String(i)}>
+                    <SelectItem_Shadcn_ key={String(i)} value={String(i)} className="max-w-[380px]">
                       <div className="space-y-1">
                         <p>{table.label}</p>
                         <p className="text-foreground-lighter">{table.description}</p>

--- a/apps/studio/components/interfaces/Database/Wrappers/WrapperTableEditor.tsx
+++ b/apps/studio/components/interfaces/Database/Wrappers/WrapperTableEditor.tsx
@@ -90,7 +90,7 @@ const WrapperTableEditor = ({
               onValueChange={(value) => setSelectedTableIndex(value)}
             >
               <SelectTrigger_Shadcn_ className="mt-0">
-                <SelectValue_Shadcn_ placeholder="---">
+                <SelectValue_Shadcn_ placeholder="Select a table">
                   {selectedTableIndex
                     ? tables[selectedTableIndex as unknown as number].label
                     : '---'}

--- a/apps/studio/components/interfaces/Database/Wrappers/WrapperTableEditor.tsx
+++ b/apps/studio/components/interfaces/Database/Wrappers/WrapperTableEditor.tsx
@@ -4,11 +4,23 @@ import ActionBar from 'components/interfaces/TableGridEditor/SidePanelEditor/Act
 import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
 import ShimmeringLoader from 'components/ui/ShimmeringLoader'
 import { useSchemasQuery } from 'data/database/schemas-query'
-import { Form, Input, Listbox, Modal, SidePanel } from 'ui'
+import {
+  Form,
+  Input,
+  Listbox,
+  Modal,
+  Select_Shadcn_,
+  SelectContent_Shadcn_,
+  SelectItem_Shadcn_,
+  SelectTrigger_Shadcn_,
+  SelectValue_Shadcn_,
+  SidePanel,
+} from 'ui'
 import WrapperDynamicColumns from './WrapperDynamicColumns'
 import type { Table, TableOption } from './Wrappers.types'
 import { makeValidateRequired } from './Wrappers.utils'
 import { Plus, Database } from 'lucide-react'
+import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 
 export type WrapperTableEditorProps = {
   visible: boolean
@@ -72,32 +84,32 @@ const WrapperTableEditor = ({
     >
       <SidePanel.Content>
         <div className="my-4 space-y-6">
-          <Listbox
-            size="small"
-            label="Select a target the table will point to"
-            value={selectedTableIndex}
-            onChange={(value) => setSelectedTableIndex(value)}
-          >
-            <Listbox.Option key="empty" value="" label="---">
-              ---
-            </Listbox.Option>
-
-            {tables.map((table, i) => {
-              return (
-                <Listbox.Option
-                  className="group"
-                  key={String(i)}
-                  value={String(i)}
-                  label={table.label}
-                >
-                  <div className="space-y-1">
-                    <p>{table.label}</p>
-                    <p className="text-foreground-lighter">{table.description}</p>
-                  </div>
-                </Listbox.Option>
-              )
-            })}
-          </Listbox>
+          <FormItemLayout label="Select a target the table will point to" isReactForm={false}>
+            <Select_Shadcn_
+              value={selectedTableIndex}
+              onValueChange={(value) => setSelectedTableIndex(value)}
+            >
+              <SelectTrigger_Shadcn_ className="mt-0">
+                <SelectValue_Shadcn_>
+                  {selectedTableIndex
+                    ? tables[selectedTableIndex as unknown as number].label
+                    : 'Select a value'}
+                </SelectValue_Shadcn_>
+              </SelectTrigger_Shadcn_>
+              <SelectContent_Shadcn_>
+                {tables.map((table, i) => {
+                  return (
+                    <SelectItem_Shadcn_ key={String(i)} value={String(i)}>
+                      <div className="space-y-1">
+                        <p>{table.label}</p>
+                        <p className="text-foreground-lighter">{table.description}</p>
+                      </div>
+                    </SelectItem_Shadcn_>
+                  )
+                })}
+              </SelectContent_Shadcn_>
+            </Select_Shadcn_>
+          </FormItemLayout>
 
           {selectedTable && (
             <TableForm table={selectedTable} onSubmit={onSubmit} initialData={initialData} />


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Deprecated UI - Listbox

[Wrappers Integration](https://supabase.com/dashboard/project/_/integrations/wrappers/new?type=stripe_wrapper)

## What is the current behavior?

The current ui uses a listbox component:

<img width="449" alt="Screenshot 2024-11-20 at 20 46 38" src="https://github.com/user-attachments/assets/0f260394-921d-428d-951d-1ad58e2920fa">


## What is the new behavior?

Changed to Select_Shadcn:

<img width="449" alt="Screenshot 2024-11-20 at 20 46 56" src="https://github.com/user-attachments/assets/2b415123-afb2-4881-aa99-000425946803">

