### PR TITLE
override feature flag for FLY

### DIFF
--- a/apps/studio/components/layouts/ProjectSettingsLayout/SettingsMenu.utils.tsx
+++ b/apps/studio/components/layouts/ProjectSettingsLayout/SettingsMenu.utils.tsx
@@ -1,9 +1,9 @@
+import { ArrowUpRight } from 'lucide-react'
+
 import type { ProductMenuGroup } from 'components/ui/ProductMenu/ProductMenu.types'
 import type { Project } from 'data/projects/project-detail-query'
 import { IS_PLATFORM, PROJECT_STATUS } from 'lib/constants'
 import type { Organization } from 'types'
-import { ArrowUpRight } from 'lucide-react'
-import { useFlag } from 'hooks/ui/useFlag'
 
 export const generateSettingsMenu = (
   ref?: string,
@@ -27,6 +27,7 @@ export const generateSettingsMenu = (
   const storageEnabled = features?.storage ?? true
   const warehouseEnabled = features?.warehouse ?? false
   const logDrainsEnabled = features?.logDrains ?? false
+  const newDiskComputeEnabled = features?.diskAndCompute ?? false
 
   return [
     {
@@ -38,7 +39,7 @@ export const generateSettingsMenu = (
           url: `/project/${ref}/settings/general`,
           items: [],
         },
-        ...(IS_PLATFORM && features?.diskAndCompute
+        ...(IS_PLATFORM && newDiskComputeEnabled
           ? [
               {
                 name: 'Compute and Disk',

--- a/apps/studio/hooks/ui/useFlag.ts
+++ b/apps/studio/hooks/ui/useFlag.ts
@@ -1,9 +1,9 @@
 import { useContext } from 'react'
 import FlagContext from 'components/ui/Flag/FlagContext'
-import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
+import { useSelectedProject } from 'hooks/misc/useSelectedProject'
 
 export function useFlag<T = boolean>(name: string) {
-  const { project } = useProjectContext()
+  const project = useSelectedProject()
   const store: any = useContext(FlagContext)
 
   // Temporary override as Fly projects are cant seem to upgrade their compute with the new disk UI

--- a/apps/studio/hooks/ui/useFlag.ts
+++ b/apps/studio/hooks/ui/useFlag.ts
@@ -1,9 +1,14 @@
 import { useContext } from 'react'
-
 import FlagContext from 'components/ui/Flag/FlagContext'
+import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
 
 export function useFlag<T = boolean>(name: string) {
+  const { project } = useProjectContext()
   const store: any = useContext(FlagContext)
+
+  if (name === 'diskAndComputeForm' && project?.cloud_provider === 'FLY') {
+    return false
+  }
 
   const isObjectEmpty = (objectName: Object) => {
     return Object.keys(objectName).length === 0

--- a/apps/studio/hooks/ui/useFlag.ts
+++ b/apps/studio/hooks/ui/useFlag.ts
@@ -6,6 +6,7 @@ export function useFlag<T = boolean>(name: string) {
   const { project } = useProjectContext()
   const store: any = useContext(FlagContext)
 
+  // Temporary override as Fly projects are cant seem to upgrade their compute with the new disk UI
   if (name === 'diskAndComputeForm' && project?.cloud_provider === 'FLY') {
     return false
   }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

- Allow Fly based projects to continue using disk and compute forms