### PR TITLE
Chore/trigger name length

### DIFF
--- a/apps/studio/components/interfaces/Database/Triggers/TriggersList/TriggerList.tsx
+++ b/apps/studio/components/interfaces/Database/Triggers/TriggersList/TriggerList.tsx
@@ -82,8 +82,8 @@ const TriggerList = ({
         <Table.tr key={x.id}>
           <Table.td className="space-x-2">
             <Tooltip_Shadcn_>
-              <TooltipTrigger_Shadcn_ asChild className="cursor-default">
-                <span className="truncate max-w-48 inline-block">{x.name}</span>
+              <TooltipTrigger_Shadcn_ className="cursor-default truncate max-w-48 inline-block">
+                {x.name}
               </TooltipTrigger_Shadcn_>
               <TooltipContent_Shadcn_ side="bottom" align="center">
                 {x.name}

--- a/apps/studio/components/interfaces/Database/Triggers/TriggersList/TriggerList.tsx
+++ b/apps/studio/components/interfaces/Database/Triggers/TriggersList/TriggerList.tsx
@@ -8,6 +8,9 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
+  Tooltip_Shadcn_,
+  TooltipContent_Shadcn_,
+  TooltipTrigger_Shadcn_,
 } from 'ui'
 
 import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
@@ -78,9 +81,14 @@ const TriggerList = ({
       {_triggers.map((x: any) => (
         <Table.tr key={x.id}>
           <Table.td className="space-x-2">
-            <p title={x.name} className="truncate">
-              {x.name}
-            </p>
+            <Tooltip_Shadcn_>
+              <TooltipTrigger_Shadcn_ asChild className="cursor-default">
+                <span className="truncate max-w-48 inline-block">{x.name}</span>
+              </TooltipTrigger_Shadcn_>
+              <TooltipContent_Shadcn_ side="bottom" align="center">
+                {x.name}
+              </TooltipContent_Shadcn_>
+            </Tooltip_Shadcn_>
           </Table.td>
 
           <Table.td className="break-all">


### PR DESCRIPTION
prevent long trigger names from overflowing the triggers table

**test data**:  https://gist.github.com/saltcod/c2f0ec9294563e23f37231f647b7bcec

**Note**: 
trigger names are limited to 63 chars and are automatically truncated
https://share.cleanshot.com/fldH3dY6

![screenshot-2024-11-21-at-13 25 13](https://github.com/user-attachments/assets/1ecde25e-fa5f-43e1-89e9-1788f9f42d49)
