### PR TITLE
fix: Handle Trigger name length in Triggers page

### DIFF
--- a/apps/studio/components/interfaces/Database/Triggers/TriggersList/TriggerList.tsx
+++ b/apps/studio/components/interfaces/Database/Triggers/TriggersList/TriggerList.tsx
@@ -77,7 +77,7 @@ const TriggerList = ({
     <>
       {_triggers.map((x: any) => (
         <Table.tr key={x.id}>
-          <Table.td className="space-x-2">
+          <Table.td className="space-x-2 max-w-[250px] truncate">
             <p title={x.name} className="truncate">
               {x.name}
             </p>
@@ -96,7 +96,7 @@ const TriggerList = ({
           </Table.td>
 
           <Table.td>
-            <div className="flex gap-2 flex-wrap">
+            <div className="flex gap-2 flex-wrap truncate">
               {x.events.map((event: string) => (
                 <Badge key={event}>{`${x.activation} ${event}`}</Badge>
               ))}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

**Problem:** The trigger name is up to 63 characters; when having such a long name, the triggers table is cut off and the only way to see it is to zoom out.

**Steps to reproduce:**

create a trigger with the 63-character name, for example, "The_most_valuable_experiences_come_from_stepping_outside_your_c"

refresh the page, the table should be cut off.

Tested in Chrome, Firefox and Brave - everywhere looks the same and the table is indeed cut off, however, it is visible when zooming out on 80%. 

100% Chrome

![image](https://github.com/user-attachments/assets/24748df5-4ee9-498a-9740-f7842877c280)

80%

![image](https://github.com/user-attachments/assets/b970fdd5-b14f-4d55-82bc-2e5807ff8503)

## What is the new behavior?

<img width="1034" alt="image" src="https://github.com/user-attachments/assets/1cf65e61-d676-4ee6-a92e-ad75952b0b87">

