### PR TITLE
chore: fix websocket URI when missing port

### DIFF
--- a/apps/studio/next.config.js
+++ b/apps/studio/next.config.js
@@ -20,7 +20,7 @@ const SUPABASE_PROJECTS_URL_WS = 'wss://*.supabase.co'
 let SUPABASE_LOCAL_PROJECTS_URL_WS = ''
 if (SUPABASE_URL) {
   const url = new URL(SUPABASE_URL)
-  const wsUrl = `${url.hostname}:${url.port}`
+  const wsUrl = `${url.hostname}${url.port ? ':' + url.port : ''}`
   SUPABASE_LOCAL_PROJECTS_URL_WS = `ws://${wsUrl} wss://${wsUrl}`
 }
 


### PR DESCRIPTION


## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.
YES

## What kind of change does this PR introduce?
Bug fix

## What is the current behavior?
When `SUPABASE_URL` does not specify a port, we produce a bad CSP header for `ws://` and `wss://`

![Screenshot 2024-11-22 at 15 42 32](https://github.com/user-attachments/assets/36bd4aeb-fbe0-43ed-a828-6e5fffbc0818)

![Screenshot 2024-11-22 at 15 41 43](https://github.com/user-attachments/assets/dfc2d353-353b-436c-9245-adf8970a5a5d)


## What is the new behavior?
This only appends the `:port` if a port is actually present in the `SUPABASE_URL`

