### PR TITLE
Fix command in documentation for typescript 

### DIFF
--- a/apps/docs/content/guides/api/rest/generating-types.mdx
+++ b/apps/docs/content/guides/api/rest/generating-types.mdx
@@ -37,13 +37,13 @@ npx supabase init
 Generate types for your project to produce the `database.types.ts` file:
 
 ```bash
-npx supabase gen types --lang=typescript --project-id "$PROJECT_REF" --schema public > database.types.ts
+npx supabase gen types typescript --project-id "$PROJECT_REF" --schema public > database.types.ts
 ```
 
 or in case of local development:
 
 ```bash
-npx supabase gen types --lang=typescript --local > database.types.ts
+npx supabase gen types typescript --local > database.types.ts
 ```
 
 These types are generated from your database schema. Given a table `public.movies`, the generated types will look like:


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

Command doesn't work in console
![image](https://github.com/user-attachments/assets/05e3c7c0-e549-4bd0-88e7-9c176ff20c31)


## What is the new behavior?

The command has been corrected and works without error

## Additional context

I am using the supabase CLI tool downloaded directly but I assume the behavior is the same
