### PR TITLE
Update auth-email-passwordless.mdx

### DIFF
--- a/apps/docs/content/guides/auth/auth-email-passwordless.mdx
+++ b/apps/docs/content/guides/auth/auth-email-passwordless.mdx
@@ -18,7 +18,7 @@ Supabase Auth offers two passwordless login methods that use the user's email ad
 
 ## With Magic Link
 
-Magic Links are a form of passwordless login where users click on a link sent to their email address to log in to their accounts. Magic Links only work with email addresses and are one-time use only.
+Magic Links are a form of passwordless login where users click on a link sent to their email address to log in to their accounts. Magic Links only work with email addresses and are one-time use only. It is important to note the user must open the link from the same browser and device the link is requested from.
 
 ### Enabling Magic Link
 
@@ -317,3 +317,27 @@ If successful, the user is now logged in, and you receive a valid session that l
   "user": {...}
 }
 ```
+
+#### Note: Overriding the OTP
+Sometimes, services require you submit a user name and password in order to verify with them (for example Apple). In order to do this, the following can be used with a profile in order to 'hardcode' the OTP for that account (it can also be useful in development mode). This should never be used with end users, but is a useful way to set a 'password' for an account.
+Replace <YOUR_EMAIL> and <NEW_CODE> with the account and code you wish to replace it with.
+
+
+```
+CREATE OR REPLACE FUNCTION preset_otp()
+RETURNS trigger
+AS $$
+begin
+IF (NEW.email = ('<YOUR_EMAIL>')) then
+NEW.recovery_token := encode(sha224(concat(NEW.email, '<NEW_CODE>')::bytea), 'hex');
+NEW.recovery_sent_at := NOW() - INTERVAL '2 minutes';
+END IF;
+RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE TRIGGER preset_otp BEFORE INSERT OR UPDATE ON auth.users FOR EACH ROW EXECUTE PROCEDURE public.preset_otp()
+```
+
+
+


### PR DESCRIPTION
1) Added a note about a common problem with magic link login 2) Added a way to set a static OTP for approval with different services. Credit to AMCreative https://www.reddit.com/r/Supabase/comments/1fgxqj6/how_to_bypass_otp_when_my_only_login_credentials/

These are two issues I had myself where I found the documentation was lacking.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.


Yes

## What kind of change does this PR introduce?

Documentation updates.
1) Showing the limitations of Magic Link
2) Providing a way to bypass the OTP and hardset a password where it is needed for different services (eg Apple)

## What is the current behavior?

In order to get this information a google/reddit search has to be performed.

## What is the new behavior?

It just adds to the documentation in order to provide this information upfront

## Additional context

Add any other context or screenshots.
