### PR TITLE
Fix/ef selection

### DIFF
--- a/apps/studio/components/interfaces/Integrations/CronJobs/CronJobsTab.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CronJobsTab.tsx
@@ -81,7 +81,7 @@ export const CronjobsTab = () => {
                   })
                 }
               >
-                Create a queue
+                Create a cron job
               </Button>
             </div>
             {filteredCronJobs.length === 0 ? (

--- a/apps/studio/components/interfaces/Integrations/CronJobs/EdgeFunctionSection.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/EdgeFunctionSection.tsx
@@ -40,8 +40,9 @@ export const EdgeFunctionSection = ({ form }: HTTPRequestFieldsProps) => {
 
   const edgeFunctions = useMemo(() => functions ?? [], [functions])
 
+  // Only set a default value if the field is empty
   useEffect(() => {
-    if (isSuccess && edgeFunctions.length > 0) {
+    if (isSuccess && edgeFunctions.length > 0 && !form.getValues('values.edgeFunctionName')) {
       const fn = edgeFunctions[0]
       const functionUrl = buildFunctionUrl(
         fn.slug,
@@ -51,7 +52,6 @@ export const EdgeFunctionSection = ({ form }: HTTPRequestFieldsProps) => {
       form.setValue('values.edgeFunctionName', functionUrl)
     }
   }, [edgeFunctions, form, isSuccess, selectedProject?.ref, selectedProject?.restUrl])
-
   return (
     <SheetSection className="flex flex-col gap-6">
       <FormField_Shadcn_


### PR DESCRIPTION
In the cron ui, the EF you choose saves fine, 
but whenever you re-open the Cron sheet, it chooses 
the first edge function it finds — edgeFunctions[0]

![screenshot-2024-11-26-at-15 27 54](https://github.com/user-attachments/assets/0716b28e-9bcd-4af6-b032-1596e2d4b858)
