### PR TITLE
Add new self-hosting option with ansible

### DIFF
--- a/apps/docs/content/guides/self-hosting.mdx
+++ b/apps/docs/content/guides/self-hosting.mdx
@@ -84,6 +84,11 @@ The following third-party providers have shown consistent support for the self-h
       description: 'Deploys using Kubernetes.',
       href: 'https://stackgres.io/blog/running-supabase-on-top-of-stackgres/',
     },
+    {
+      name: 'Pigsty',
+      description: 'Deploys using Ansible.',
+      href: 'https://pigsty.io/blog/db/supabase/',
+    },
   ].map((x) => (
     <div className="md:col-span-6" key={x.href}>
       <Link href={x.href} passHref>


### PR DESCRIPTION
Add a new self-hosting option <Pigsty> with link https://pigsty.io/blog/db/supabase/.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES/NO

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
