### PR TITLE
fix: invalid migration

### DIFF
--- a/supabase/migrations/20241121205753_add_meetups_columns.sql
+++ b/supabase/migrations/20241121205753_add_meetups_columns.sql
@@ -1,7 +1,5 @@
 alter table public.meetups
 add column timezone text;
 
-comment on column public.meetups is 'Needs to be in America/Los_Angeles format.';
-
 alter table public.meetups
 add column city text;

--- a/supabase/migrations/20241127183137_comment_meetup_timezone.sql
+++ b/supabase/migrations/20241127183137_comment_meetup_timezone.sql
@@ -1,0 +1,1 @@
+comment on column meetups.timezone is 'Needs to be in America/Los_Angeles format.';


### PR DESCRIPTION
Fixes an invalid migration that was preventing other migration files from being pushed on top. The two `alter table` changes are already in prod migration history under this timestamp, but the `comment` change is not, so we should be safe to just delete it and add it in a separate migration.