### PR TITLE
deprecated: alert - disk io bandwidth

### DIFF
--- a/apps/studio/components/interfaces/Billing/Usage/UsageWarningAlerts/DiskIOBandwidthWarnings.tsx
+++ b/apps/studio/components/interfaces/Billing/Usage/UsageWarningAlerts/DiskIOBandwidthWarnings.tsx
@@ -1,12 +1,5 @@
 import Link from 'next/link'
-import {
-  Alert_Shadcn_,
-  AlertDescription_Shadcn_,
-  AlertTitle_Shadcn_,
-  Button,
-  CriticalIcon,
-  WarningIcon,
-} from 'ui'
+import { Button } from 'ui'
 import { Admonition } from 'ui-patterns'
 
 // [Joshen] In the future, conditionals should be from resource exhaustion endpoint as single source of truth

--- a/apps/studio/components/interfaces/Billing/Usage/UsageWarningAlerts/DiskIOBandwidthWarnings.tsx
+++ b/apps/studio/components/interfaces/Billing/Usage/UsageWarningAlerts/DiskIOBandwidthWarnings.tsx
@@ -7,6 +7,7 @@ import {
   CriticalIcon,
   WarningIcon,
 } from 'ui'
+import { Admonition } from 'ui-patterns'
 
 // [Joshen] In the future, conditionals should be from resource exhaustion endpoint as single source of truth
 interface DiskIOBandwidthWarningsProps {
@@ -28,10 +29,12 @@ const DiskIOBandwidthWarnings = ({
 }: DiskIOBandwidthWarningsProps) => {
   if (hasLatest && latestIoBudgetConsumption >= 100) {
     return (
-        <Alert_Shadcn_ variant="destructive">
-          <WarningIcon />
-          <AlertTitle_Shadcn_>Your Disk IO Budget has been used up</AlertTitle_Shadcn_>
-          <AlertDescription_Shadcn_>
+      <Admonition
+        type="destructive"
+        title="Your Disk IO Budget has been used up"
+        description={
+          <>
+            {' '}
             <p className="mb-4">
               Your workload has used up all your Disk IO Budget and is now running at the baseline
               performance. If you need consistent disk performance, consider upgrading to a larger
@@ -42,74 +45,81 @@ const DiskIOBandwidthWarnings = ({
                 {isFreePlan ? 'Upgrade project' : 'Change compute add-on'}
               </Link>
             </Button>
-          </AlertDescription_Shadcn_>
-        </Alert_Shadcn_>
+          </>
+        }
+      />
     )
   }
 
   if (hasLatest && latestIoBudgetConsumption >= 80) {
     return (
-      <Alert_Shadcn_ variant="destructive">
-        <WarningIcon />
-        <AlertTitle_Shadcn_>You are close to running out of Disk IO Budget</AlertTitle_Shadcn_>
-        <AlertDescription_Shadcn_>
-          <p className="mb-4">
-            Your workload has consumed {latestIoBudgetConsumption}% of your Disk IO Budget. If you
-            use up all your Disk IO Budget, your instance will reverted to baseline performance. If
-            you need consistent disk performance, consider upgrading to a larger compute add-on.
-          </p>
-          <Button asChild type="danger">
-            <Link href={upgradeUrl}>
-              {isFreePlan ? 'Upgrade project' : 'Change compute add-on'}
-            </Link>
-          </Button>
-        </AlertDescription_Shadcn_>
-      </Alert_Shadcn_>
+      <Admonition
+        type="destructive"
+        title="You are close to running out of Disk IO Budget"
+        description={
+          <>
+            <p className="mb-4">
+              Your workload has consumed {latestIoBudgetConsumption}% of your Disk IO Budget. If you
+              use up all your Disk IO Budget, your instance will reverted to baseline performance.
+              If you need consistent disk performance, consider upgrading to a larger compute
+              add-on.
+            </p>
+            <Button asChild type="danger">
+              <Link href={upgradeUrl}>
+                {isFreePlan ? 'Upgrade project' : 'Change compute add-on'}
+              </Link>
+            </Button>
+          </>
+        }
+      />
     )
   }
 
   if (currentBillingCycleSelected && highestIoBudgetConsumption >= 100) {
     return (
-      <Alert_Shadcn_ variant="warning">
-        <CriticalIcon />
-        <AlertTitle_Shadcn_>You ran out of IO Budget at least once</AlertTitle_Shadcn_>
-        <AlertDescription_Shadcn_>
-          <p className="mb-4">
-            Your workload has used up all your Disk IO Budget and reverted to baseline performance
-            at least once during this billing cycle. If you need consistent disk performance,
-            consider upgrading to a larger compute add-on.
-          </p>
-          <Button asChild type="warning">
-            <Link href={upgradeUrl}>
-              {isFreePlan ? 'Upgrade project' : 'Change compute add-on'}
-            </Link>
-          </Button>
-        </AlertDescription_Shadcn_>
-      </Alert_Shadcn_>
+      <Admonition
+        type="warning"
+        title="You ran out of IO Budget at least once"
+        description={
+          <>
+            <p className="mb-4">
+              Your workload has used up all your Disk IO Budget and reverted to baseline performance
+              at least once during this billing cycle. If you need consistent disk performance,
+              consider upgrading to a larger compute add-on.
+            </p>
+            <Button asChild type="warning">
+              <Link href={upgradeUrl}>
+                {isFreePlan ? 'Upgrade project' : 'Change compute add-on'}
+              </Link>
+            </Button>
+          </>
+        }
+      />
     )
   }
 
   if (currentBillingCycleSelected && highestIoBudgetConsumption >= 80) {
     return (
-      <Alert_Shadcn_ variant="warning">
-        <CriticalIcon />
-        <AlertTitle_Shadcn_>
-          You were close to using all your IO Budget at least once
-        </AlertTitle_Shadcn_>
-        <AlertDescription_Shadcn_>
-          <p className="mb-4">
-            Your workload has consumed {highestIoBudgetConsumption}% of your Disk IO budget during
-            this billing cycle. If you use up all your Disk IO Budget, your instance will reverted
-            to baseline performance. If you need consistent disk performance, consider upgrading to
-            a larger compute add-on.
-          </p>
-          <Button asChild type="warning">
-            <Link href={upgradeUrl}>
-              {isFreePlan ? 'Upgrade project' : 'Change compute add-on'}
-            </Link>
-          </Button>
-        </AlertDescription_Shadcn_>
-      </Alert_Shadcn_>
+      <Admonition
+        type="warning"
+        title="You were close to using all your IO Budget at least once"
+        description={
+          <>
+            {' '}
+            <p className="mb-4">
+              Your workload has consumed {highestIoBudgetConsumption}% of your Disk IO budget during
+              this billing cycle. If you use up all your Disk IO Budget, your instance will reverted
+              to baseline performance. If you need consistent disk performance, consider upgrading
+              to a larger compute add-on.
+            </p>
+            <Button asChild type="warning">
+              <Link href={upgradeUrl}>
+                {isFreePlan ? 'Upgrade project' : 'Change compute add-on'}
+              </Link>
+            </Button>
+          </>
+        }
+      />
     )
   }
 

--- a/apps/studio/components/interfaces/Billing/Usage/UsageWarningAlerts/DiskIOBandwidthWarnings.tsx
+++ b/apps/studio/components/interfaces/Billing/Usage/UsageWarningAlerts/DiskIOBandwidthWarnings.tsx
@@ -27,7 +27,6 @@ const DiskIOBandwidthWarnings = ({
         title="Your Disk IO Budget has been used up"
         description={
           <>
-            {' '}
             <p className="mb-4">
               Your workload has used up all your Disk IO Budget and is now running at the baseline
               performance. If you need consistent disk performance, consider upgrading to a larger
@@ -98,7 +97,6 @@ const DiskIOBandwidthWarnings = ({
         title="You were close to using all your IO Budget at least once"
         description={
           <>
-            {' '}
             <p className="mb-4">
               Your workload has consumed {highestIoBudgetConsumption}% of your Disk IO budget during
               this billing cycle. If you use up all your Disk IO Budget, your instance will reverted

--- a/apps/studio/components/interfaces/Billing/Usage/UsageWarningAlerts/DiskIOBandwidthWarnings.tsx
+++ b/apps/studio/components/interfaces/Billing/Usage/UsageWarningAlerts/DiskIOBandwidthWarnings.tsx
@@ -1,5 +1,12 @@
 import Link from 'next/link'
-import { Alert, Button } from 'ui'
+import {
+  Alert_Shadcn_,
+  AlertDescription_Shadcn_,
+  AlertTitle_Shadcn_,
+  Button,
+  CriticalIcon,
+  WarningIcon,
+} from 'ui'
 
 // [Joshen] In the future, conditionals should be from resource exhaustion endpoint as single source of truth
 interface DiskIOBandwidthWarningsProps {
@@ -21,66 +28,88 @@ const DiskIOBandwidthWarnings = ({
 }: DiskIOBandwidthWarningsProps) => {
   if (hasLatest && latestIoBudgetConsumption >= 100) {
     return (
-      <Alert withIcon variant="danger" title="Your Disk IO Budget has been used up">
-        <p className="mb-4">
-          Your workload has used up all your Disk IO Budget and is now running at the baseline
-          performance. If you need consistent disk performance, consider upgrading to a larger
-          compute add-on.
-        </p>
-        <Button asChild type="danger">
-          <Link href={upgradeUrl}>{isFreePlan ? 'Upgrade project' : 'Change compute add-on'}</Link>
-        </Button>
-      </Alert>
+        <Alert_Shadcn_ variant="destructive">
+          <WarningIcon />
+          <AlertTitle_Shadcn_>Your Disk IO Budget has been used up</AlertTitle_Shadcn_>
+          <AlertDescription_Shadcn_>
+            <p className="mb-4">
+              Your workload has used up all your Disk IO Budget and is now running at the baseline
+              performance. If you need consistent disk performance, consider upgrading to a larger
+              compute add-on.
+            </p>
+            <Button asChild type="danger">
+              <Link href={upgradeUrl}>
+                {isFreePlan ? 'Upgrade project' : 'Change compute add-on'}
+              </Link>
+            </Button>
+          </AlertDescription_Shadcn_>
+        </Alert_Shadcn_>
     )
   }
 
   if (hasLatest && latestIoBudgetConsumption >= 80) {
     return (
-      <Alert withIcon variant="danger" title="You are close to running out of Disk IO Budget">
-        <p className="mb-4">
-          Your workload has consumed {latestIoBudgetConsumption}% of your Disk IO Budget. If you use
-          up all your Disk IO Budget, your instance will reverted to baseline performance. If you
-          need consistent disk performance, consider upgrading to a larger compute add-on.
-        </p>
-        <Button asChild type="danger">
-          <Link href={upgradeUrl}>{isFreePlan ? 'Upgrade project' : 'Change compute add-on'}</Link>
-        </Button>
-      </Alert>
+      <Alert_Shadcn_ variant="destructive">
+        <WarningIcon />
+        <AlertTitle_Shadcn_>You are close to running out of Disk IO Budget</AlertTitle_Shadcn_>
+        <AlertDescription_Shadcn_>
+          <p className="mb-4">
+            Your workload has consumed {latestIoBudgetConsumption}% of your Disk IO Budget. If you
+            use up all your Disk IO Budget, your instance will reverted to baseline performance. If
+            you need consistent disk performance, consider upgrading to a larger compute add-on.
+          </p>
+          <Button asChild type="danger">
+            <Link href={upgradeUrl}>
+              {isFreePlan ? 'Upgrade project' : 'Change compute add-on'}
+            </Link>
+          </Button>
+        </AlertDescription_Shadcn_>
+      </Alert_Shadcn_>
     )
   }
 
   if (currentBillingCycleSelected && highestIoBudgetConsumption >= 100) {
     return (
-      <Alert withIcon variant="warning" title="You ran out of IO Budget at least once">
-        <p className="mb-4">
-          Your workload has used up all your Disk IO Budget and reverted to baseline performance at
-          least once during this billing cycle. If you need consistent disk performance, consider
-          upgrading to a larger compute add-on.
-        </p>
-        <Button asChild type="warning">
-          <Link href={upgradeUrl}>{isFreePlan ? 'Upgrade project' : 'Change compute add-on'}</Link>
-        </Button>
-      </Alert>
+      <Alert_Shadcn_ variant="warning">
+        <CriticalIcon />
+        <AlertTitle_Shadcn_>You ran out of IO Budget at least once</AlertTitle_Shadcn_>
+        <AlertDescription_Shadcn_>
+          <p className="mb-4">
+            Your workload has used up all your Disk IO Budget and reverted to baseline performance
+            at least once during this billing cycle. If you need consistent disk performance,
+            consider upgrading to a larger compute add-on.
+          </p>
+          <Button asChild type="warning">
+            <Link href={upgradeUrl}>
+              {isFreePlan ? 'Upgrade project' : 'Change compute add-on'}
+            </Link>
+          </Button>
+        </AlertDescription_Shadcn_>
+      </Alert_Shadcn_>
     )
   }
 
   if (currentBillingCycleSelected && highestIoBudgetConsumption >= 80) {
     return (
-      <Alert
-        withIcon
-        variant="warning"
-        title="You were close to using all your IO Budget at least once"
-      >
-        <p className="mb-4">
-          Your workload has consumed {highestIoBudgetConsumption}% of your Disk IO budget during
-          this billing cycle. If you use up all your Disk IO Budget, your instance will reverted to
-          baseline performance. If you need consistent disk performance, consider upgrading to a
-          larger compute add-on.
-        </p>
-        <Button asChild type="warning">
-          <Link href={upgradeUrl}>{isFreePlan ? 'Upgrade project' : 'Change compute add-on'}</Link>
-        </Button>
-      </Alert>
+      <Alert_Shadcn_ variant="warning">
+        <CriticalIcon />
+        <AlertTitle_Shadcn_>
+          You were close to using all your IO Budget at least once
+        </AlertTitle_Shadcn_>
+        <AlertDescription_Shadcn_>
+          <p className="mb-4">
+            Your workload has consumed {highestIoBudgetConsumption}% of your Disk IO budget during
+            this billing cycle. If you use up all your Disk IO Budget, your instance will reverted
+            to baseline performance. If you need consistent disk performance, consider upgrading to
+            a larger compute add-on.
+          </p>
+          <Button asChild type="warning">
+            <Link href={upgradeUrl}>
+              {isFreePlan ? 'Upgrade project' : 'Change compute add-on'}
+            </Link>
+          </Button>
+        </AlertDescription_Shadcn_>
+      </Alert_Shadcn_>
     )
   }
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES/NO

## What kind of change does this PR introduce?
Alert deprecation - Disk IO Bandwith

## What is the current behavior?
Component currently using deprecated `<Alert />` component:

<img width="663" alt="Screenshot 2024-11-27 at 21 45 19" src="https://github.com/user-attachments/assets/8783d13b-b923-4b93-94bd-fb6995722d25">
<img width="642" alt="Screenshot 2024-11-27 at 21 40 08" src="https://github.com/user-attachments/assets/52646191-2fd5-40ef-8de3-cb6285df5cc1">
<img width="653" alt="Screenshot 2024-11-27 at 21 37 32" src="https://github.com/user-attachments/assets/9c364ff2-6136-4374-a396-84f5f6a50832">


## What is the new behavior?
Switched to use `<Alert_Shadcn />` :

<img width="597" alt="Screenshot 2024-11-27 at 21 45 58" src="https://github.com/user-attachments/assets/d1e542f5-46a6-4371-8059-ca663d248836">
<img width="606" alt="Screenshot 2024-11-27 at 21 42 56" src="https://github.com/user-attachments/assets/eb405ea4-98a4-4f85-b34f-9f724fb101ed">
<img width="602" alt="Screenshot 2024-11-27 at 21 37 41" src="https://github.com/user-attachments/assets/b34118aa-ecf6-4170-947c-1044ac4e4d06">

