### PR TITLE
Update access-control.mdx (type cast owner_id to uuid)

### DIFF
--- a/apps/docs/content/guides/storage/security/access-control.mdx
+++ b/apps/docs/content/guides/storage/security/access-control.mdx
@@ -80,7 +80,7 @@ Allow a user to access a file that was previously uploaded by the same user:
 create policy "Individual user Access"
 on storage.objects for select
 to authenticated
-using ( (select auth.uid()) = owner_id );
+using ( (select auth.uid()) = owner_id::uuid );
 ```
 
 ---


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update.

## What is the current behavior?

Page for explaining how to enable RLS on objects has the following code snippet:

```sql
create policy "Individual user Access"
on storage.objects for select
to authenticated
using ( (select auth.uid()) = owner_id );
```
In the schema, owner_id is type `text`:

![image](https://github.com/user-attachments/assets/628ce26b-4f09-4818-9c9d-e7e1f605e56d)

This snippet compares two different types, and throws an error.
In order to fix this, we need to type case owner_id to uuid so the proper comparison can be made.

```sql
create policy "Individual user Access"
on storage.objects for select
to authenticated
using ( (select auth.uid()) = owner_id::uuid );
```

## What is the new behavior?

Added `::uuid` type cast.
