### PR TITLE
chore: integrations pill based filtering

### DIFF
--- a/apps/studio/components/interfaces/Integrations/Landing/AvailableIntegrations.tsx
+++ b/apps/studio/components/interfaces/Integrations/Landing/AvailableIntegrations.tsx
@@ -1,13 +1,12 @@
-import { Search } from 'lucide-react'
-import { useState } from 'react'
-
 import AlertError from 'components/ui/AlertError'
 import NoSearchResults from 'components/ui/NoSearchResults'
-import { Tabs_Shadcn_, TabsList_Shadcn_, TabsTrigger_Shadcn_ } from 'ui'
+import { Search } from 'lucide-react'
+import { useState } from 'react'
+import { buttonVariants, cn, Tabs_Shadcn_, TabsList_Shadcn_, TabsTrigger_Shadcn_ } from 'ui'
+import { Admonition } from 'ui-patterns'
 import { Input } from 'ui-patterns/DataInputs/Input'
 import { IntegrationCard, IntegrationLoadingCard } from './IntegrationCard'
 import { useInstalledIntegrations } from './useInstalledIntegrations'
-import { Admonition } from 'ui-patterns'
 
 type IntegrationCategory = 'all' | 'wrapper' | 'postgres_extensions' | 'custom'
 
@@ -40,11 +39,33 @@ export const AvailableIntegrations = () => {
         value={selectedCategory}
         onValueChange={(value) => setSelectedCategory(value as IntegrationCategory)}
       >
-        <TabsList_Shadcn_ className="px-10 gap-5">
+        <TabsList_Shadcn_ className="px-10 gap-2 border-b-0 border-t pt-5">
+          {['all', 'wrapper', 'postgres_extension'].map((category) => (
+            <TabsTrigger_Shadcn_
+              key={category}
+              value={category}
+              onClick={() => setSelectedCategory(category as IntegrationCategory)}
+              className={cn(
+                buttonVariants({
+                  size: 'tiny',
+                  type: selectedCategory === category ? 'default' : 'outline',
+                }),
+                selectedCategory === category ? 'text-foreground' : 'text-foreground-lighter',
+                '!rounded-full px-3'
+              )}
+            >
+              {category === 'all'
+                ? 'All Integrations'
+                : category.replace('_', ' ').replace(/\b\w/g, (char) => char.toUpperCase())}
+            </TabsTrigger_Shadcn_>
+          ))}
           <Input
             value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            containerClassName="group w-40"
+            onChange={(e) => {
+              setSearch(e.target.value)
+              setSelectedCategory('all')
+            }}
+            containerClassName="group w-40 ml-5"
             icon={
               <Search
                 size={14}
@@ -55,13 +76,9 @@ export const AvailableIntegrations = () => {
             className="pl-7 rounded-none !border-0 border-transparent bg-transparent !shadow-none !ring-0 !ring-offset-0"
             placeholder="Search..."
           />
-          <TabsTrigger_Shadcn_ value="all">All Integrations</TabsTrigger_Shadcn_>
-          <TabsTrigger_Shadcn_ value="wrapper">Foreign Data Wrappers</TabsTrigger_Shadcn_>
-          <TabsTrigger_Shadcn_ value="postgres_extension">Postgres Extensions</TabsTrigger_Shadcn_>
         </TabsList_Shadcn_>
       </Tabs_Shadcn_>
       <div className="p-10 py-8 flex flex-col gap-y-5">
-        <h2>Available integrations</h2>
         <div className="grid xl:grid-cols-3 2xl:grid-cols-4 gap-x-4 gap-y-3">
           {isLoading &&
             new Array(3)


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

- Integrations tabs now changed to rounded buttons like the [Blog page](https://supabase.com/blog)
- Originally the Tab Menu was going to 'scroll to section' but since there's not enough items yet to make that work effectively, using tab pills instead which feel a bit more like they 'filter' what is on the page.

<img width="1156" alt="Screenshot 2024-11-28 at 15 01 06" src="https://github.com/user-attachments/assets/7b28a9c8-3344-4566-afa4-dea710740bc4">
