### PR TITLE
chore(docs): add edge-runtime and new inbucket to config reference

### DIFF
--- a/apps/docs/spec/cli_v1_config.yaml
+++ b/apps/docs/spec/cli_v1_config.yaml
@@ -1128,7 +1128,6 @@ parameters:
     default: '"oneshot"'
     description: |
       Configure the request handling policy for Edge Functions. Available options:
-
       - `oneshot`: Recommended for development with hot reload support
       - `per_worker`: Recommended for load testing scenarios
     links: []

--- a/apps/docs/spec/cli_v1_config.yaml
+++ b/apps/docs/spec/cli_v1_config.yaml
@@ -1114,7 +1114,7 @@ parameters:
 
   - id: 'edge_runtime.enabled'
     title: 'edge_runtime.enabled'
-    tags: ['local']
+    tags: ['edge-functions']
     required: false
     default: 'true'
     description: |
@@ -1123,7 +1123,7 @@ parameters:
 
   - id: 'edge_runtime.policy'
     title: 'edge_runtime.policy'
-    tags: ['local']
+    tags: ['edge-functions']
     required: false
     default: '"oneshot"'
     description: |
@@ -1135,7 +1135,7 @@ parameters:
 
   - id: 'edge_runtime.inspector_port'
     title: 'edge_runtime.inspector_port'
-    tags: ['local']
+    tags: ['edge-functions']
     required: false
     default: '8083'
     description: |

--- a/apps/docs/spec/cli_v1_config.yaml
+++ b/apps/docs/spec/cli_v1_config.yaml
@@ -554,6 +554,22 @@ parameters:
       - name: 'Inbucket documentation'
         link: 'https://www.inbucket.org'
 
+  - id: 'inbucket.admin_email'
+    title: 'inbucket.admin_email'
+    tags: ['local']
+    required: false
+    default: 'admin@email.com'
+    description: |
+      Email used as the sender for emails sent from the application.
+
+  - id: 'inbucket.sender_name'
+    title: 'inbucket.sender_name'
+    tags: ['local']
+    required: false
+    default: 'Admin'
+    description: |
+      Display name used as the sender for emails sent from the application.
+
   - id: 'storage.enabled'
     title: 'storage.enabled'
     tags: ['storage']
@@ -1095,6 +1111,36 @@ parameters:
     links:
       - name: 'Auth Server configuration'
         link: 'https://supabase.com/docs/reference/auth'
+
+  - id: 'edge-runtime.enabled'
+    title: 'edge-runtime.enabled'
+    tags: ['local']
+    required: false
+    default: 'true'
+    description: |
+      Enable the local Edge Runtime service for Edge Functions.
+    links: []
+
+  - id: 'edge-runtime.policy'
+    title: 'edge-runtime.policy'
+    tags: ['local']
+    required: false
+    default: '"oneshot"'
+    description: |
+      Configure the request handling policy for Edge Functions. Available options:
+
+      - `oneshot`: Recommended for development with hot reload support
+      - `per_worker`: Recommended for load testing scenarios
+    links: []
+
+  - id: 'edge-runtime.inspector_port'
+    title: 'edge-runtime.inspector_port'
+    tags: ['local']
+    required: false
+    default: '8083'
+    description: |
+      Port to attach the Chrome inspector for debugging Edge Functions.
+    links: []
 
   - id: 'functions.function_name.enabled'
     title: 'functions.<function_name>.enabled'

--- a/apps/docs/spec/cli_v1_config.yaml
+++ b/apps/docs/spec/cli_v1_config.yaml
@@ -1112,8 +1112,8 @@ parameters:
       - name: 'Auth Server configuration'
         link: 'https://supabase.com/docs/reference/auth'
 
-  - id: 'edge-runtime.enabled'
-    title: 'edge-runtime.enabled'
+  - id: 'edge_runtime.enabled'
+    title: 'edge_runtime.enabled'
     tags: ['local']
     required: false
     default: 'true'
@@ -1121,8 +1121,8 @@ parameters:
       Enable the local Edge Runtime service for Edge Functions.
     links: []
 
-  - id: 'edge-runtime.policy'
-    title: 'edge-runtime.policy'
+  - id: 'edge_runtime.policy'
+    title: 'edge_runtime.policy'
     tags: ['local']
     required: false
     default: '"oneshot"'
@@ -1133,8 +1133,8 @@ parameters:
       - `per_worker`: Recommended for load testing scenarios
     links: []
 
-  - id: 'edge-runtime.inspector_port'
-    title: 'edge-runtime.inspector_port'
+  - id: 'edge_runtime.inspector_port'
+    title: 'edge_runtime.inspector_port'
     tags: ['local']
     required: false
     default: '8083'


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

- Add missing local development config.toml settings for `inbucket` and `edge-runtime`

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
