### PR TITLE
deprecated: alert - migrations

### DIFF
--- a/apps/studio/components/interfaces/Database/Migrations/Migrations.tsx
+++ b/apps/studio/components/interfaces/Database/Migrations/Migrations.tsx
@@ -7,15 +7,7 @@ import Table from 'components/to-be-cleaned/Table'
 import CodeEditor from 'components/ui/CodeEditor/CodeEditor'
 import ShimmeringLoader from 'components/ui/ShimmeringLoader'
 import { DatabaseMigration, useMigrationsQuery } from 'data/database/migrations-query'
-import {
-  Alert_Shadcn_,
-  AlertDescription_Shadcn_,
-  AlertTitle_Shadcn_,
-  Button,
-  Input,
-  SidePanel,
-  WarningIcon,
-} from 'ui'
+import { Button, Input, SidePanel } from 'ui'
 import MigrationsEmptyState from './MigrationsEmptyState'
 import { Search } from 'lucide-react'
 import { Admonition } from 'ui-patterns'

--- a/apps/studio/components/interfaces/Database/Migrations/Migrations.tsx
+++ b/apps/studio/components/interfaces/Database/Migrations/Migrations.tsx
@@ -7,7 +7,15 @@ import Table from 'components/to-be-cleaned/Table'
 import CodeEditor from 'components/ui/CodeEditor/CodeEditor'
 import ShimmeringLoader from 'components/ui/ShimmeringLoader'
 import { DatabaseMigration, useMigrationsQuery } from 'data/database/migrations-query'
-import { Alert, Button, Input, SidePanel } from 'ui'
+import {
+  Alert_Shadcn_,
+  AlertDescription_Shadcn_,
+  AlertTitle_Shadcn_,
+  Button,
+  Input,
+  SidePanel,
+  WarningIcon,
+} from 'ui'
 import MigrationsEmptyState from './MigrationsEmptyState'
 import { Search } from 'lucide-react'
 
@@ -39,26 +47,26 @@ const Migrations = () => {
 
       <div>
         {isError && (
-          <Alert
-            withIcon
-            variant="warning"
-            title="Failed to retrieve migration history for database"
-            actions={[
-              <Button key="contact-support" asChild type="default" className="ml-4">
+          <Alert_Shadcn_ variant="warning">
+            <WarningIcon />
+            <AlertTitle_Shadcn_>
+              Failed to retrieve migration history for database
+            </AlertTitle_Shadcn_>
+            <AlertDescription_Shadcn_>
+              <p className="mb-1">
+                Try refreshing your browser, but if the issue persists, please reach out to us via
+                support.
+              </p>
+              <p className="mb-4">Error: {(error as any)?.message ?? 'Unknown'}</p>
+              <Button key="contact-support" asChild type="default">
                 <Link
                   href={`/support/new?ref=${project?.ref}&category=dashboard_bug&subject=Unable%20to%20view%20database%20migrations`}
                 >
                   Contact support
                 </Link>
-              </Button>,
-            ]}
-          >
-            <p className="mb-1">
-              Try refreshing your browser, but if the issue persists, please reach out to us via
-              support.
-            </p>
-            <p>Error: {(error as any)?.message ?? 'Unknown'}</p>
-          </Alert>
+              </Button>
+            </AlertDescription_Shadcn_>
+          </Alert_Shadcn_>
         )}
         {isSuccess && (
           <div>

--- a/apps/studio/components/interfaces/Database/Migrations/Migrations.tsx
+++ b/apps/studio/components/interfaces/Database/Migrations/Migrations.tsx
@@ -18,6 +18,7 @@ import {
 } from 'ui'
 import MigrationsEmptyState from './MigrationsEmptyState'
 import { Search } from 'lucide-react'
+import { Admonition } from 'ui-patterns'
 
 const Migrations = () => {
   const [search, setSearch] = useState('')
@@ -47,26 +48,27 @@ const Migrations = () => {
 
       <div>
         {isError && (
-          <Alert_Shadcn_ variant="warning">
-            <WarningIcon />
-            <AlertTitle_Shadcn_>
-              Failed to retrieve migration history for database
-            </AlertTitle_Shadcn_>
-            <AlertDescription_Shadcn_>
-              <p className="mb-1">
-                Try refreshing your browser, but if the issue persists, please reach out to us via
-                support.
-              </p>
-              <p className="mb-4">Error: {(error as any)?.message ?? 'Unknown'}</p>
-              <Button key="contact-support" asChild type="default">
-                <Link
-                  href={`/support/new?ref=${project?.ref}&category=dashboard_bug&subject=Unable%20to%20view%20database%20migrations`}
-                >
-                  Contact support
-                </Link>
-              </Button>
-            </AlertDescription_Shadcn_>
-          </Alert_Shadcn_>
+          <Admonition
+            type="warning"
+            title="Failed to retrieve migration history for database"
+            description={
+              <>
+                <p className="mb-1">
+                  Try refreshing your browser, but if the issue persists, please reach out to us via
+                  support.
+                </p>
+                <p className="mb-4">Error: {(error as any)?.message ?? 'Unknown'}</p>
+              </>
+            }
+          >
+            <Button key="contact-support" asChild type="default">
+              <Link
+                href={`/support/new?ref=${project?.ref}&category=dashboard_bug&subject=Unable%20to%20view%20database%20migrations`}
+              >
+                Contact support
+              </Link>
+            </Button>
+          </Admonition>
         )}
         {isSuccess && (
           <div>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Alert deprecation

## What is the current behavior?

Component currently using deprecated `<Alert />` component:

<img width="629" alt="Screenshot 2024-11-28 at 21 20 09" src="https://github.com/user-attachments/assets/c66baeaa-43d9-46d2-86b0-fdaf39a5c3c6">


## What is the new behavior?

Switched to use `<Alert_Shadcn />`
<img width="627" alt="Screenshot 2024-11-28 at 21 25 56" src="https://github.com/user-attachments/assets/aaabc3bf-4fcc-4fde-b17c-5b265477bedd">
:


