### PR TITLE
deprecated: alert - encryption-keys-management

### DIFF
--- a/apps/studio/components/interfaces/Integrations/Vault/Keys/EncryptionKeysManagement.tsx
+++ b/apps/studio/components/interfaces/Integrations/Vault/Keys/EncryptionKeysManagement.tsx
@@ -14,18 +14,8 @@ import { usePgSodiumKeyDeleteMutation } from 'data/pg-sodium-keys/pg-sodium-key-
 import { usePgSodiumKeysQuery } from 'data/pg-sodium-keys/pg-sodium-keys-query'
 import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { Key, Loader, Search, Trash, X } from 'lucide-react'
-import {
-  Alert_Shadcn_,
-  AlertDescription_Shadcn_,
-  AlertTitle_Shadcn_,
-  Button,
-  Form,
-  Input,
-  Listbox,
-  Modal,
-  Separator,
-  WarningIcon,
-} from 'ui'
+import { Button, Form, Input, Listbox, Modal, Separator } from 'ui'
+import { Admonition } from 'ui-patterns'
 
 const DEFAULT_KEY_NAME = 'No description provided'
 
@@ -267,16 +257,12 @@ export const EncryptionKeysManagement = () => {
         header="Confirm to delete key"
       >
         <Modal.Content className="space-y-4">
-          <Alert_Shadcn_ variant="warning">
-            <WarningIcon />
-            <AlertTitle_Shadcn_>
-              Deleting a key that's in use will cause any secret or column which depends on it to be
-              unusable.
-            </AlertTitle_Shadcn_>
-            <AlertDescription_Shadcn_>
-              Do ensure that the key is not currently in use to prevent any issues.
-            </AlertDescription_Shadcn_>
-          </Alert_Shadcn_>
+          <Admonition
+            type="warning"
+            title="Deleting a key that's in use will cause any secret or column which depends on it to be
+              unusable."
+            description="Do ensure that the key is not currently in use to prevent any issues."
+          />
           <p className="text-sm">
             The following key will be permanently removed and cannot be recovered.
           </p>

--- a/apps/studio/components/interfaces/Integrations/Vault/Keys/EncryptionKeysManagement.tsx
+++ b/apps/studio/components/interfaces/Integrations/Vault/Keys/EncryptionKeysManagement.tsx
@@ -14,7 +14,18 @@ import { usePgSodiumKeyDeleteMutation } from 'data/pg-sodium-keys/pg-sodium-key-
 import { usePgSodiumKeysQuery } from 'data/pg-sodium-keys/pg-sodium-keys-query'
 import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { Key, Loader, Search, Trash, X } from 'lucide-react'
-import { Alert, Button, Form, Input, Listbox, Modal, Separator } from 'ui'
+import {
+  Alert_Shadcn_,
+  AlertDescription_Shadcn_,
+  AlertTitle_Shadcn_,
+  Button,
+  Form,
+  Input,
+  Listbox,
+  Modal,
+  Separator,
+  WarningIcon,
+} from 'ui'
 
 const DEFAULT_KEY_NAME = 'No description provided'
 
@@ -256,13 +267,16 @@ export const EncryptionKeysManagement = () => {
         header="Confirm to delete key"
       >
         <Modal.Content className="space-y-4">
-          <Alert
-            withIcon
-            variant="warning"
-            title="Deleting a key that's in use will cause any secret or column which depends on it to be unusable."
-          >
-            Do ensure that the key is not currently in use to prevent any issues.
-          </Alert>
+          <Alert_Shadcn_ variant="warning">
+            <WarningIcon />
+            <AlertTitle_Shadcn_>
+              Deleting a key that's in use will cause any secret or column which depends on it to be
+              unusable.
+            </AlertTitle_Shadcn_>
+            <AlertDescription_Shadcn_>
+              Do ensure that the key is not currently in use to prevent any issues.
+            </AlertDescription_Shadcn_>
+          </Alert_Shadcn_>
           <p className="text-sm">
             The following key will be permanently removed and cannot be recovered.
           </p>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Alert deprecation

## What is the current behavior?

Component currently using deprecated `<Alert />` component:

<img width="510" alt="Screenshot 2024-11-28 at 21 42 45" src="https://github.com/user-attachments/assets/e4756d1b-f9e6-4c9b-a767-fd23095166dd">


## What is the new behavior?

Switched to use `<Alert_Shadcn />`:

<img width="512" alt="Screenshot 2024-11-28 at 21 45 36" src="https://github.com/user-attachments/assets/7f1d01df-e2a4-497f-8919-7d8b1a9c1b83">


