### PR TITLE
Remove `queue_` prefix from api endpoints

### DIFF
--- a/apps/studio/components/interfaces/Integrations/Queues/QueuesSettings.tsx
+++ b/apps/studio/components/interfaces/Integrations/Queues/QueuesSettings.tsx
@@ -202,12 +202,12 @@ export const QueuesSettings = () => {
                               queues via any Supabase client library or PostgREST endpoints:
                             </p>
                             <p className="mt-2">
-                              <code className="text-xs">queue_send</code>,{' '}
-                              <code className="text-xs">queue_send_batch</code>,{' '}
-                              <code className="text-xs">queue_read</code>,{' '}
-                              <code className="text-xs">queue_pop</code>,
-                              <code className="text-xs">queue_archive</code>, and
-                              <code className="text-xs">queue_delete</code>
+                              <code className="text-xs">send</code>,{' '}
+                              <code className="text-xs">send_batch</code>,{' '}
+                              <code className="text-xs">read</code>,{' '}
+                              <code className="text-xs">pop</code>,
+                              <code className="text-xs">archive</code>, and
+                              <code className="text-xs">delete</code>
                             </p>
                           </>
                         }


### PR DESCRIPTION
Currently the queue integration says the API endpoints are `queue_send` .... vs `send`. That is out-of-date. This was updated in #30695
![image](https://github.com/user-attachments/assets/37857552-cb9d-447f-b9de-cf751da382dd)

This PR updates the comment to match the API