### PR TITLE
fix: oid types in text editor

### DIFF
--- a/apps/studio/components/grid/components/editor/TextEditor.tsx
+++ b/apps/studio/components/grid/components/editor/TextEditor.tsx
@@ -49,7 +49,8 @@ export const TextEditor = <TRow, TSummaryRow = unknown>({
   })
 
   const gridColumn = state.gridColumns.find((x) => x.name == column.key)
-  const initialValue = row[column.key as keyof TRow] as unknown as string
+  const rawValue = row[column.key as keyof TRow] as unknown
+  const initialValue = rawValue ? String(rawValue) : null
   const [isPopoverOpen, setIsPopoverOpen] = useState(true)
   const [value, setValue] = useState<string | null>(initialValue)
   const [isConfirmNextModalOpen, setIsConfirmNextModalOpen] = useState(false)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Double clicking on an oid column value explodes

## What is the new behavior?

Value is cast to a string so it can be rendered correctly by Monaco
