### PR TITLE
fix: Disable vercel integration for vercel managed projects

### DIFF
--- a/apps/docs/content/guides/deployment/branching.mdx
+++ b/apps/docs/content/guides/deployment/branching.mdx
@@ -582,7 +582,7 @@ With the Supabase branching integration, you can sync the Git branch used by the
 
 <Admonition type="note" label="Vercel Branching support is in development.">
 
-    The Vercel Integration for Supabase branching is under development. To express your interest, [join the discussion on GitHub discussions](https://github.com/orgs/supabase/discussions/18938).
+    The Vercel Integration for Supabase branching is working only with Supabase managed projects. There is currently no support for Vercel Marketplace managed resources, however the support is planned in the future.
 
 </Admonition>
 

--- a/apps/studio/components/interfaces/Settings/Integrations/VercelIntegration/VercelSection.tsx
+++ b/apps/studio/components/interfaces/Settings/Integrations/VercelIntegration/VercelSection.tsx
@@ -31,9 +31,11 @@ import { useSelectedProject } from 'hooks/misc/useSelectedProject'
 import { pluralize } from 'lib/helpers'
 import { getIntegrationConfigurationUrl } from 'lib/integration-utils'
 import { useSidePanelsStateSnapshot } from 'state/side-panels'
-import { Button, cn } from 'ui'
+import { Alert_Shadcn_, AlertTitle_Shadcn_, Button, cn } from 'ui'
 import { IntegrationImageHandler } from '../IntegrationsSettings'
 import VercelIntegrationConnectionForm from './VercelIntegrationConnectionForm'
+import PartnerManagedResource from 'components/ui/PartnerManagedResource'
+import PartnerIcon from 'components/ui/PartnerIcon'
 
 const VercelSection = ({ isProjectScoped }: { isProjectScoped: boolean }) => {
   const project = useSelectedProject()
@@ -164,6 +166,18 @@ You can change the scope of the access for Supabase by configuring
         <ScaffoldSectionContent>
           {!canReadVercelConnection ? (
             <NoPermission resourceText="view this organization's Vercel connections" />
+          ) : org?.managed_by === 'vercel-marketplace' ? (
+            <Alert_Shadcn_ className="flex flex-col items-center gap-y-2 border-0 rounded-none">
+              <PartnerIcon
+                organization={{ managed_by: 'vercel-marketplace' }}
+                showTooltip={false}
+                size="large"
+              />
+
+              <AlertTitle_Shadcn_ className="text-sm">
+                Vercel Integration is not available for Vercel Marketplace managed projects.
+              </AlertTitle_Shadcn_>
+            </Alert_Shadcn_>
           ) : (
             <>
               <Markdown content={VercelContentSectionTop} />


### PR DESCRIPTION
Same as other places, but I did not reuse `PartnerManagedResource` as this one has custom message, requires no CTA and has only a single possible partner.

Swapped one admonition box as well to reflect the current state, as the old one is not necessary anymore.

![image](https://github.com/user-attachments/assets/8399a4a7-c49b-453b-8a15-eebaac8401e8)