### PR TITLE
fix: make resumable upload work locally

### DIFF
--- a/docker/docker-compose.s3.yml
+++ b/docker/docker-compose.s3.yml
@@ -31,7 +31,7 @@ services:
 
   storage:
     container_name: supabase-storage
-    image: supabase/storage-api:v1.11.13
+    image: supabase/storage-api:v1.13.3
     depends_on:
       db:
         # Disable this if you are using an external Postgres database
@@ -77,6 +77,7 @@ services:
       REGION: stub
       ENABLE_IMAGE_TRANSFORMATION: "true"
       IMGPROXY_URL: http://imgproxy:5001
+      REQUEST_ALLOW_X_FORWARDED_PATH: "true"
     volumes:
       - ./volumes/storage:/var/lib/storage:z
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -225,7 +225,7 @@ services:
   # To use S3 backed storage: docker compose -f docker-compose.yml -f docker-compose.s3.yml up
   storage:
     container_name: supabase-storage
-    image: supabase/storage-api:v1.11.13
+    image: supabase/storage-api:v1.13.3
     depends_on:
       db:
         # Disable this if you are using an external Postgres database
@@ -263,6 +263,7 @@ services:
       GLOBAL_S3_BUCKET: stub
       ENABLE_IMAGE_TRANSFORMATION: "true"
       IMGPROXY_URL: http://imgproxy:5001
+      REQUEST_ALLOW_X_FORWARDED_PATH: "true"
     volumes:
       - ./volumes/storage:/var/lib/storage:z
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Issues: #29168, https://github.com/supabase/storage/issues/538

Resumable upload locally fails because of 401 error thrown for PATCH and HEAD requests. Issue happens because instead of `http://localhost:8000/storage/v1/upload/resumable/...`, `http://localhost:8000/upload/resumable/` url is called and it's not proxied to `storage` by `kong`.

## What is the new behavior?

`http://localhost:8000/storage/v1//upload/resumable/...` is called and resumable upload works well locally.

## Additional context

https://github.com/supabase/storage/pull/579 introduced `REQUEST_ALLOW_X_FORWARDED_PATH` env variable. That's why change of docker compose files is sufficient.
