### PR TITLE
📝 add guidance for syncing database schema with --schema option

### DIFF
--- a/apps/docs/content/guides/local-development/overview.mdx
+++ b/apps/docs/content/guides/local-development/overview.mdx
@@ -335,6 +335,28 @@ This will upload files from `supabase/images` directory to a bucket named `image
 supabase seed buckets
 ```
 
+### Sync any schema with `--schema`
+
+You can synchronize your database with a specific schema using the `--schema` option as follows:
+
+```bash
+supabase db pull --schema <schema_name>
+```
+
+<Admonition type="warning">
+
+Using `--schema`
+
+If the local `supabase/migrations` directory is empty, the db pull command will ignore the `--schema` parameter.
+
+</Admonition>
+
+To fix this, you can run the following command:
+```bash
+supabase db pull
+supabase db pull --schema <schema_name>
+```
+
 ## Limitations and considerations
 
 The local development environment is not as feature-complete as the Supabase Platform. Here are some of the differences:

--- a/apps/docs/content/guides/local-development/overview.mdx
+++ b/apps/docs/content/guides/local-development/overview.mdx
@@ -349,13 +349,14 @@ Using `--schema`
 
 If the local `supabase/migrations` directory is empty, the db pull command will ignore the `--schema` parameter.
 
-</Admonition>
+To fix this, you can pull twice:
 
-To fix this, you can run the following command:
 ```bash
 supabase db pull
 supabase db pull --schema <schema_name>
 ```
+
+</Admonition>
 
 ## Limitations and considerations
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The `--schema` flag for the `supabase db pull` command is ignored if the local `supabase/migrations` directory is empty. This behavior is misleading and not clearly documented.

Related issue: [supabase/cli#1840](https://github.com/supabase/cli/issues/1840#issuecomment-1894947366)

## What is the new behavior?

The documentation has been updated to clarify the behavior of the `--schema` flag when the `supabase/migrations` directory is empty. It now includes:

1. A clear warning in the documentation explaining that the `--schema` flag will be ignored if the `supabase/migrations` directory is empty.
2. A workaround instructing users to run `supabase db pull` twice:
    - First, to populate the `supabase/migrations` directory.
    - Then, with the `--schema` flag to pull the desired schema.

## Additional context

Issue:

![CleanShot_2024-12-02_at_18 23 192x](https://github.com/user-attachments/assets/b22a4f77-d02b-4d80-9c0c-92e960eb683f)

CLI:

![CleanShot_2024-12-02_at_18 26 522x](https://github.com/user-attachments/assets/8e50aa05-ba52-4fa2-bac1-832132a78fb5)

New doc:

<img width="865" alt="Capture d’écran 2024-12-02 à 20 57 43" src="https://github.com/user-attachments/assets/4313e1fc-2eef-4dbf-8bf0-1e7b8d12644d">
