### PR TITLE
Feat/save assistant messages

### DIFF
--- a/apps/studio/components/layouts/ProjectLayout/ProjectLayout.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/ProjectLayout.tsx
@@ -1,6 +1,6 @@
 import Head from 'next/head'
 import { useRouter } from 'next/router'
-import { forwardRef, Fragment, PropsWithChildren, ReactNode, useEffect } from 'react'
+import { forwardRef, Fragment, PropsWithChildren, ReactNode, useEffect, useState } from 'react'
 
 import { useParams } from 'common'
 import ProjectAPIDocs from 'components/interfaces/ProjectAPIDocs/ProjectAPIDocs'
@@ -110,6 +110,12 @@ const ProjectLayout = forwardRef<HTMLDivElement, PropsWithChildren<ProjectLayout
       router.pathname === '/project/[ref]' || router.pathname.includes('/project/[ref]/settings')
     const showPausedState = isPaused && !ignorePausedState
 
+    const [isClient, setIsClient] = useState(false)
+
+    useEffect(() => {
+      setIsClient(true)
+    }, [])
+
     useEffect(() => {
       const handler = (e: KeyboardEvent) => {
         if (e.metaKey && e.code === 'KeyI' && !e.altKey && !e.shiftKey) {
@@ -195,7 +201,7 @@ const ProjectLayout = forwardRef<HTMLDivElement, PropsWithChildren<ProjectLayout
                       )}
                     </main>
                   </ResizablePanel>
-                  {aiAssistantPanel.open && (
+                  {isClient && aiAssistantPanel.open && (
                     <>
                       <ResizableHandle />
                       <ResizablePanel

--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
@@ -135,7 +135,6 @@ export const AIAssistant = ({
     id,
     api: `${BASE_PATH}/api/ai/sql/generate-v3`,
     maxSteps: 5,
-    // [Joshen] Not currently used atm, but initialMessages will be for...
     initialMessages,
     body: {
       includeSchemaMetadata,
@@ -143,6 +142,11 @@ export const AIAssistant = ({
       connectionString: project?.connectionString,
       schema: currentSchema,
       table: currentTable?.name,
+    },
+    onFinish: (message) => {
+      setAiAssistantPanel({
+        messages: [...chatMessages, message],
+      })
     },
   })
 
@@ -185,7 +189,7 @@ export const AIAssistant = ({
       headers: { Authorization: headerData.get('Authorization') ?? '' },
     })
 
-    setAiAssistantPanel({ sqlSnippets: undefined })
+    setAiAssistantPanel({ sqlSnippets: undefined, messages: [...messages, payload] })
     setValue('')
     setAssistantError(undefined)
     setLastSentMessage(payload)

--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
@@ -404,7 +404,7 @@ export const AIAssistant = ({
               </h3>
               {suggestions.title && <p>{suggestions.title}</p>}
               <div className="-mx-3 mt-4 mb-12">
-                {suggestions?.prompts?.map((prompt, idx) => (
+                {suggestions?.prompts?.map((prompt: string, idx: number) => (
                   <Button
                     key={`suggestion-${idx}`}
                     size="small"
@@ -500,7 +500,7 @@ export const AIAssistant = ({
         <div className="p-5 pt-0 z-20 relative">
           {sqlSnippets && sqlSnippets.length > 0 && (
             <div className="mb-2">
-              {sqlSnippets.map((snippet, index) => (
+              {sqlSnippets.map((snippet: string, index: number) => (
                 <CollapsibleCodeBlock
                   key={index}
                   hideLineNumbers
@@ -556,7 +556,9 @@ export const AIAssistant = ({
               event.preventDefault()
               if (includeSchemaMetadata) {
                 const sqlSnippetsString =
-                  sqlSnippets?.map((snippet) => '```sql\n' + snippet + '\n```').join('\n') || ''
+                  sqlSnippets
+                    ?.map((snippet: string) => '```sql\n' + snippet + '\n```')
+                    .join('\n') || ''
                 const valueWithSnippets = [value, sqlSnippetsString].filter(Boolean).join('\n\n')
                 sendMessageToAssistant(valueWithSnippets)
               } else {

--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistantPanel.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistantPanel.tsx
@@ -7,20 +7,9 @@ import type { Message as MessageType } from 'ai/react'
 
 export const AiAssistantPanel = () => {
   const { aiAssistantPanel, resetAiAssistantPanel } = useAppStateSnapshot()
-  const [initialMessages, setInitialMessages] = useState<MessageType[] | undefined>(undefined)
-
-  useEffect(() => {
-    // set initial state of local messages to the global state if it exists
-    if (aiAssistantPanel.messages) {
-      const messagesCopy = aiAssistantPanel.messages.map((msg) => ({
-        content: msg.content,
-        createdAt: msg.createdAt,
-        role: msg.role,
-        id: msg.id,
-      }))
-      setInitialMessages(messagesCopy)
-    }
-  }, [])
+  const [initialMessages, setInitialMessages] = useState<MessageType[] | undefined>(
+    aiAssistantPanel.messages?.length > 0 ? aiAssistantPanel.messages : undefined
+  )
 
   const { open } = aiAssistantPanel
   const [chatId, setChatId] = useState(() => uuidv4())

--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistantPanel.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistantPanel.tsx
@@ -1,3 +1,4 @@
+import type { Message as MessageType } from 'ai/react'
 import { uuidv4 } from 'lib/helpers'
 import { useState } from 'react'
 import { useAppStateSnapshot } from 'state/app-state'
@@ -6,8 +7,8 @@ import { AIAssistant } from './AIAssistant'
 
 export const AiAssistantPanel = () => {
   const { aiAssistantPanel, resetAiAssistantPanel } = useAppStateSnapshot()
-  const [initialMessages, setInitialMessages] = useState(
-    aiAssistantPanel.messages?.length > 0 ? aiAssistantPanel.messages : undefined
+  const [initialMessages, setInitialMessages] = useState<MessageType[] | undefined>(
+    aiAssistantPanel.messages?.length > 0 ? (aiAssistantPanel.messages as any) : undefined
   )
 
   const { open } = aiAssistantPanel

--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistantPanel.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistantPanel.tsx
@@ -1,13 +1,12 @@
 import { uuidv4 } from 'lib/helpers'
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import { useAppStateSnapshot } from 'state/app-state'
 import { cn } from 'ui'
 import { AIAssistant } from './AIAssistant'
-import type { Message as MessageType } from 'ai/react'
 
 export const AiAssistantPanel = () => {
   const { aiAssistantPanel, resetAiAssistantPanel } = useAppStateSnapshot()
-  const [initialMessages, setInitialMessages] = useState<MessageType[] | undefined>(
+  const [initialMessages, setInitialMessages] = useState(
     aiAssistantPanel.messages?.length > 0 ? aiAssistantPanel.messages : undefined
   )
 

--- a/apps/studio/lib/constants/index.ts
+++ b/apps/studio/lib/constants/index.ts
@@ -30,6 +30,8 @@ export const USAGE_APPROACHING_THRESHOLD = 0.75
 export const LOCAL_STORAGE_KEYS = {
   RECENTLY_VISITED_ORGANIZATION: 'supabase-organization',
 
+  AI_ASSISTANT_STATE: 'supabase-ai-assistant-state',
+
   UI_PREVIEW_NAVIGATION_LAYOUT: 'supabase-ui-preview-nav-layout',
   UI_PREVIEW_API_SIDE_PANEL: 'supabase-ui-api-side-panel',
   UI_PREVIEW_CLS: 'supabase-ui-cls',

--- a/apps/studio/state/app-state.ts
+++ b/apps/studio/state/app-state.ts
@@ -76,14 +76,20 @@ const getInitialState = () => {
   const urlParams = new URLSearchParams(window.location.search)
   const aiAssistantPanelOpenParam = urlParams.get('aiAssistantPanelOpen')
 
-  const parsedAiAssistant = stored
-    ? JSON.parse(stored, (key, value) => {
+  let parsedAiAssistant = INITIAL_AI_ASSISTANT
+
+  try {
+    if (stored) {
+      parsedAiAssistant = JSON.parse(stored, (key, value) => {
         if (key === 'createdAt' && value) {
           return new Date(value)
         }
         return value
       })
-    : INITIAL_AI_ASSISTANT
+    }
+  } catch {
+    // Ignore parsing errors
+  }
 
   return {
     aiAssistantPanel: {

--- a/apps/studio/state/app-state.ts
+++ b/apps/studio/state/app-state.ts
@@ -1,17 +1,8 @@
-import { proxy, snapshot, useSnapshot } from 'valtio'
-
+import { proxy, subscribe, snapshot, useSnapshot } from 'valtio'
+import type { Message as MessageType } from 'ai/react'
 import { SupportedAssistantEntities } from 'components/ui/AIAssistantPanel/AIAssistant.types'
 import { LOCAL_STORAGE_KEYS } from 'lib/constants'
 import { LOCAL_STORAGE_KEYS as COMMON_LOCAL_STORAGE_KEYS } from 'common'
-import type { Message as MessageType } from 'ai/react'
-
-const EMPTY_DASHBOARD_HISTORY: {
-  sql?: string
-  editor?: string
-} = {
-  sql: undefined,
-  editor: undefined,
-}
 
 export type CommonDatabaseEntity = {
   id: number
@@ -27,7 +18,7 @@ export type SuggestionsType = {
 
 type AiAssistantPanelType = {
   open: boolean
-  messages?: MessageType[] | undefined
+  messages: MessageType[]
   initialInput: string
   sqlSnippets?: string[]
   suggestions?: SuggestionsType
@@ -39,9 +30,14 @@ type AiAssistantPanelType = {
   tables: { schema: string; name: string }[]
 }
 
+type DashboardHistoryType = {
+  sql?: string
+  editor?: string
+}
+
 const INITIAL_AI_ASSISTANT: AiAssistantPanelType = {
   open: false,
-  messages: undefined,
+  messages: [],
   sqlSnippets: undefined,
   initialInput: '',
   suggestions: undefined,
@@ -51,16 +47,67 @@ const INITIAL_AI_ASSISTANT: AiAssistantPanelType = {
   tables: [],
 }
 
+const EMPTY_DASHBOARD_HISTORY: DashboardHistoryType = {
+  sql: undefined,
+  editor: undefined,
+}
+
+const getInitialState = () => {
+  if (typeof window === 'undefined') {
+    return {
+      aiAssistantPanel: INITIAL_AI_ASSISTANT,
+      dashboardHistory: EMPTY_DASHBOARD_HISTORY,
+      activeDocsSection: ['introduction'],
+      docsLanguage: 'js',
+      showProjectApiDocs: false,
+      isOptedInTelemetry: false,
+      showEnableBranchingModal: false,
+      showFeaturePreviewModal: false,
+      selectedFeaturePreview: '',
+      showAiSettingsModal: false,
+      showGenerateSqlModal: false,
+      navigationPanelOpen: false,
+      navigationPanelJustClosed: false,
+    }
+  }
+
+  const stored = localStorage.getItem(LOCAL_STORAGE_KEYS.AI_ASSISTANT_STATE)
+  const storedDashboardHistory = localStorage.getItem(LOCAL_STORAGE_KEYS.DASHBOARD_HISTORY)
+
+  const parsedAiAssistant = stored
+    ? JSON.parse(stored, (key, value) => {
+        if (key === 'createdAt' && value) {
+          return new Date(value)
+        }
+        return value
+      })
+    : INITIAL_AI_ASSISTANT
+
+  return {
+    aiAssistantPanel: parsedAiAssistant,
+    dashboardHistory: storedDashboardHistory
+      ? JSON.parse(storedDashboardHistory)
+      : EMPTY_DASHBOARD_HISTORY,
+    activeDocsSection: ['introduction'],
+    docsLanguage: 'js',
+    showProjectApiDocs: false,
+    isOptedInTelemetry: false,
+    showEnableBranchingModal: false,
+    showFeaturePreviewModal: false,
+    selectedFeaturePreview: '',
+    showAiSettingsModal: false,
+    showGenerateSqlModal: false,
+    navigationPanelOpen: false,
+    navigationPanelJustClosed: false,
+  }
+}
+
 export const appState = proxy({
-  // [Joshen] Last visited "entity" for any page that we wanna track
-  dashboardHistory: EMPTY_DASHBOARD_HISTORY,
+  ...getInitialState(),
+
   setDashboardHistory: (ref: string, key: 'sql' | 'editor', id: string) => {
     if (appState.dashboardHistory[key] !== id) {
       appState.dashboardHistory[key] = id
-      localStorage.setItem(
-        LOCAL_STORAGE_KEYS.DASHBOARD_HISTORY(ref),
-        JSON.stringify(appState.dashboardHistory)
-      )
     }
   },
 
@@ -84,22 +131,27 @@ export const appState = proxy({
       localStorage.setItem(COMMON_LOCAL_STORAGE_KEYS.TELEMETRY_CONSENT, value.toString())
     }
   },
+
   showEnableBranchingModal: false,
   setShowEnableBranchingModal: (value: boolean) => {
     appState.showEnableBranchingModal = value
   },
+
   showFeaturePreviewModal: false,
   setShowFeaturePreviewModal: (value: boolean) => {
     appState.showFeaturePreviewModal = value
   },
+
   selectedFeaturePreview: '',
   setSelectedFeaturePreview: (value: string) => {
     appState.selectedFeaturePreview = value
   },
+
   showAiSettingsModal: false,
   setShowAiSettingsModal: (value: boolean) => {
     appState.showAiSettingsModal = value
   },
+
   showGenerateSqlModal: false,
   setShowGenerateSqlModal: (value: boolean) => {
     appState.showGenerateSqlModal = value
@@ -109,18 +161,14 @@ export const appState = proxy({
   navigationPanelJustClosed: false,
   setNavigationPanelOpen: (value: boolean, trackJustClosed: boolean = false) => {
     if (value === false) {
-      // If closing navigation panel by clicking on icon/button, nav bar should not open again until mouse leaves nav bar
       if (trackJustClosed) {
         appState.navigationPanelOpen = false
         appState.navigationPanelJustClosed = true
       } else {
-        // If closing navigation panel by leaving nav bar, nav bar can open again when mouse re-enter
         appState.navigationPanelOpen = false
         appState.navigationPanelJustClosed = false
       }
     } else {
-      // If opening nav panel, check if it was just closed by a nav icon/button click
-      // If yes, do not open nav panel, otherwise open as per normal
       if (appState.navigationPanelJustClosed === false) {
         appState.navigationPanelOpen = true
       }
@@ -137,7 +185,6 @@ export const appState = proxy({
     }
   },
 
-  aiAssistantPanel: INITIAL_AI_ASSISTANT as AiAssistantPanelType,
   setAiAssistantPanel: (value: Partial<AiAssistantPanelType>) => {
     const hasEntityChanged = value.entity?.id !== appState.aiAssistantPanel.entity?.id
 
@@ -148,6 +195,20 @@ export const appState = proxy({
     }
   },
 })
+
+// Set up localStorage subscription
+if (typeof window !== 'undefined') {
+  subscribe(appState, () => {
+    localStorage.setItem(
+      LOCAL_STORAGE_KEYS.AI_ASSISTANT_STATE,
+      JSON.stringify(appState.aiAssistantPanel)
+    )
+    localStorage.setItem(
+      LOCAL_STORAGE_KEYS.DASHBOARD_HISTORY,
+      JSON.stringify(appState.dashboardHistory)
+    )
+  })
+}
 
 export const getAppStateSnapshot = () => snapshot(appState)
 

--- a/apps/studio/state/app-state.ts
+++ b/apps/studio/state/app-state.ts
@@ -74,6 +74,9 @@ const getInitialState = () => {
   const stored = localStorage.getItem(LOCAL_STORAGE_KEYS.AI_ASSISTANT_STATE)
   const storedDashboardHistory = localStorage.getItem(LOCAL_STORAGE_KEYS.DASHBOARD_HISTORY)
 
+  const urlParams = new URLSearchParams(window.location.search)
+  const aiAssistantPanelOpenParam = urlParams.get('aiAssistantPanelOpen')
+
   const parsedAiAssistant = stored
     ? JSON.parse(stored, (key, value) => {
         if (key === 'createdAt' && value) {
@@ -84,7 +87,13 @@ const getInitialState = () => {
     : INITIAL_AI_ASSISTANT
 
   return {
-    aiAssistantPanel: parsedAiAssistant,
+    aiAssistantPanel: {
+      ...parsedAiAssistant,
+      open:
+        aiAssistantPanelOpenParam !== null
+          ? aiAssistantPanelOpenParam === 'true'
+          : parsedAiAssistant.open,
+    },
     dashboardHistory: storedDashboardHistory
       ? JSON.parse(storedDashboardHistory)
       : EMPTY_DASHBOARD_HISTORY,

--- a/apps/studio/state/app-state.ts
+++ b/apps/studio/state/app-state.ts
@@ -72,7 +72,6 @@ const getInitialState = () => {
   }
 
   const stored = localStorage.getItem(LOCAL_STORAGE_KEYS.AI_ASSISTANT_STATE)
-  const storedDashboardHistory = localStorage.getItem(LOCAL_STORAGE_KEYS.DASHBOARD_HISTORY)
 
   const urlParams = new URLSearchParams(window.location.search)
   const aiAssistantPanelOpenParam = urlParams.get('aiAssistantPanelOpen')
@@ -94,9 +93,7 @@ const getInitialState = () => {
           ? aiAssistantPanelOpenParam === 'true'
           : parsedAiAssistant.open,
     },
-    dashboardHistory: storedDashboardHistory
-      ? JSON.parse(storedDashboardHistory)
-      : EMPTY_DASHBOARD_HISTORY,
+    dashboardHistory: EMPTY_DASHBOARD_HISTORY,
     activeDocsSection: ['introduction'],
     docsLanguage: 'js',
     showProjectApiDocs: false,

--- a/apps/studio/state/app-state.ts
+++ b/apps/studio/state/app-state.ts
@@ -108,6 +108,10 @@ export const appState = proxy({
   setDashboardHistory: (ref: string, key: 'sql' | 'editor', id: string) => {
     if (appState.dashboardHistory[key] !== id) {
       appState.dashboardHistory[key] = id
+      localStorage.setItem(
+        LOCAL_STORAGE_KEYS.DASHBOARD_HISTORY(ref),
+        JSON.stringify(appState.dashboardHistory)
+      )
     }
   },
 
@@ -202,10 +206,6 @@ if (typeof window !== 'undefined') {
     localStorage.setItem(
       LOCAL_STORAGE_KEYS.AI_ASSISTANT_STATE,
       JSON.stringify(appState.aiAssistantPanel)
-    )
-    localStorage.setItem(
-      LOCAL_STORAGE_KEYS.DASHBOARD_HISTORY,
-      JSON.stringify(appState.dashboardHistory)
     )
   })
 }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

This PR saves aiAssistantState to local storage so that chat history is saved. It adds user message to state and then once useChat finishes, it adds assistant messages to state. valtio [subscribe](https://valtio.dev/docs/how-tos/how-to-persist-states) is used to watch for state changes and save to storage. 

The added is isClient state added to [fix hydration error](https://nextjs.org/docs/messages/react-hydration-error#solution-1-using-useeffect-to-run-on-the-client-only) however I'm not sure if this is the best approach. Would it be better to remove the open check on project layout, and render the component dynamically instead with a conditional inside the component to return null if open is false?