### PR TITLE
fix: remove references to auth ui from docs

### DIFF
--- a/apps/docs/content/guides/auth/quickstarts/react.mdx
+++ b/apps/docs/content/guides/auth/quickstarts/react.mdx
@@ -72,14 +72,26 @@ hideToc: true
 
 
       ```js src/App.js
-      import React, { useState } from 'react';
+      import React, { useState, useEffect } from 'react';
       import { createClient } from '@supabase/supabase-js'
+
+      const supabase = createClient('https://<project>.supabase.co', '<your-anon-key>')
 
       function App() {
         const [email, setEmail] = useState('');
         const [password, setPassword] = useState('');
         const [loading, setLoading] = useState(false);
-        const supabase = createClient('https://<project>.supabase.co', '<your-anon-key>')
+        useEffect(() => {
+            supabase.auth.getSession().then(({ data: { session } }) => {
+              setSession(session)
+            })
+            const {
+              data: { subscription },
+            } = supabase.auth.onAuthStateChange((_event, session) => {
+            setSession(session)
+            })
+          return () => subscription.unsubscribe()
+        }, [])
 
         async function signInWithEmail(e) {
             e.preventDefault();
@@ -99,6 +111,9 @@ hideToc: true
 
         return (
             <div>
+                {session ? (
+                    <div> Logged in </div>
+                ) : (
                 <form onSubmit={signInWithEmail}>
                     <div>
                         <label htmlFor="email">
@@ -108,8 +123,9 @@ hideToc: true
                             name="email"
                             type="email"
                             value={email}
+                            autocomplete="email"
                             onChange={(e) => setEmail(e.target.value)}
-                        placeholder="email@address.com"
+                            placeholder="email@address.com"
                         />
                         </label>
                     </div>
@@ -122,7 +138,7 @@ hideToc: true
                             type="password"
                             value={password}
                             onChange={(e) => setPassword(e.target.value)}
-                        placeholder="Password"
+                            placeholder="Password"
                         />
                         </label>
                     </div>
@@ -140,8 +156,9 @@ hideToc: true
                     Sign up
                     </button>
                 </form>
+                )}
             </div>
-            );
+        );
       }
       export default App;
       ```

--- a/apps/docs/content/guides/auth/quickstarts/react.mdx
+++ b/apps/docs/content/guides/auth/quickstarts/react.mdx
@@ -74,99 +74,102 @@ hideToc: true
 
       ```js src/App.js
         import React, { useState } from 'react';
+        import { createClient } from '@supabase/supabase-js'
 
-        export default function Auth() {
-        const [email, setEmail] = useState('');
-        const [password, setPassword] = useState('');
-        const [loading, setLoading] = useState(false);
 
-        const supabase = createClient('https://<project>.supabase.co', '<your-anon-key>')
+        function App() {
+            const [email, setEmail] = useState('');
+            const [password, setPassword] = useState('');
+            const [loading, setLoading] = useState(false);
 
-        async function signInWithEmail() {
-            setLoading(true);
-            const { error } = await supabase.auth.signInWithPassword({ email, password});
-            if (error) alert(error.message);
-            setLoading(false);
-        }
+            const supabase = createClient('https://<project>.supabase.co', '<your-anon-key>')
 
-        async function signUpWithEmail() {
-            setLoading(true);
-            const { data: { session }, error} = await supabase.auth.signUp({ email, password});
-            if (error) alert(error.message);
-            if (!session) alert('Please check your inbox for email verification!');
-            setLoading(false);
-        }
-
-        const styles = {
-            container: {
-                maxWidth: '300px',
-                margin: '20px auto',
-                padding: '20px',
-            },
-            formGroup: {
-                marginBottom: '15px',
-            },
-            label: {
-                display: 'block',
-                marginBottom: '5px',
-            },
-            input: {
-                width: '100%',
-                padding: '8px',
-                marginBottom: '10px',
-            },
-            button: {
-                padding: '8px 16px',
-                marginRight: '10px',
-                cursor: 'pointer',
+            async function signInWithEmail() {
+                setLoading(true);
+                const { error } = await supabase.auth.signInWithPassword({ email, password});
+                if (error) alert(error.message);
+                setLoading(false);
             }
-        };
 
-        return (
-            <div style={styles.container}>
-              <div style={styles.formGroup}>
-                <label style={styles.label}>
-                  Email:
-                  <input
-                    type="email"
-                    value={email}
-                    onChange={(e) => setEmail(e.target.value)}
-                    placeholder="email@address.com"
-                    style={styles.input}
-                  />
-                </label>
-            </div>
+            async function signUpWithEmail() {
+                setLoading(true);
+                const { data: { session }, error} = await supabase.auth.signUp({ email, password});
+                if (error) alert(error.message);
+                if (!session) alert('Please check your inbox for email verification!');
+                setLoading(false);
+            }
 
-            <div style={styles.formGroup}>
-                <label style={styles.label}>
-                Password:
-                <input
-                    type="password"
-                    value={password}
-                    onChange={(e) => setPassword(e.target.value)}
-                    placeholder="Password"
-                    style={styles.input}
-                />
-                </label>
-            </div>
+            const styles = {
+                container: {
+                    maxWidth: '300px',
+                    margin: '20px auto',
+                    padding: '20px',
+                },
+                formGroup: {
+                    marginBottom: '15px',
+                },
+                label: {
+                    display: 'block',
+                    marginBottom: '5px',
+                },
+                input: {
+                    width: '100%',
+                    padding: '8px',
+                    marginBottom: '10px',
+                },
+                button: {
+                    padding: '8px 16px',
+                    marginRight: '10px',
+                    cursor: 'pointer',
+                }
+            };
 
-            <button
-                onClick={signInWithEmail}
-                disabled={loading}
-                style={styles.button}
-            >
-                Sign in
-            </button>
-            <button
-                onClick={signUpWithEmail}
-                disabled={loading}
-                style={styles.button}
-            >
-                Sign up
-            </button>
-            </div>
-        );
-      }
+            return (
+                <div style={styles.container}>
+                <div style={styles.formGroup}>
+                    <label style={styles.label}>
+                    Email:
+                    <input
+                        type="email"
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
+                        placeholder="email@address.com"
+                        style={styles.input}
+                    />
+                    </label>
+                </div>
+
+                <div style={styles.formGroup}>
+                    <label style={styles.label}>
+                    Password:
+                    <input
+                        type="password"
+                        value={password}
+                        onChange={(e) => setPassword(e.target.value)}
+                        placeholder="Password"
+                        style={styles.input}
+                    />
+                    </label>
+                </div>
+
+                <button
+                    onClick={signInWithEmail}
+                    disabled={loading}
+                    style={styles.button}
+                >
+                    Sign in
+                </button>
+                <button
+                    onClick={signUpWithEmail}
+                    disabled={loading}
+                    style={styles.button}
+                >
+                    Sign up
+                </button>
+                </div>
+            );
+        }
+      export default App
       ```
 
     </StepHikeCompact.Code>

--- a/apps/docs/content/guides/auth/quickstarts/react.mdx
+++ b/apps/docs/content/guides/auth/quickstarts/react.mdx
@@ -66,7 +66,6 @@ hideToc: true
 
     In `App.js`, create a Supabase client using your [Project URL and public API (anon) key](https://supabase.com/dashboard/project/_/settings/api).
 
-    You can configure the Auth component to display whenever there is no session inside `supabase.auth.getSession()`
 
     </StepHikeCompact.Details>
     <StepHikeCompact.Code>
@@ -103,49 +102,48 @@ hideToc: true
                 <form onSubmit={signInWithEmail}>
                     <div>
                         <label htmlFor="email">
-                            Email:
-                            <input
-                                    id="email"
-                                    name="email"
-                                    type="email"
-                                    value={email}
-                                    onChange={(e) => setEmail(e.target.value)}
-                                    placeholder="email@address.com"
-                                />
-                            </label>
-                        </div>
-                        <div>
-                            <label htmlFor="password">
-                                Password:
-                                <input
-                                    id="password"
-                                    name="password"
-                                    type="password"
-                                    value={password}
-                                    onChange={(e) => setPassword(e.target.value)}
-                                    placeholder="Password"
-                                />
-                            </label>
-                        </div>
-                        <button
-                            type="submit"
-                            disabled={loading}
+                        Email:
+                        <input
+                            id="email"
+                            name="email"
+                            type="email"
+                            value={email}
+                            onChange={(e) => setEmail(e.target.value)}
+                        placeholder="email@address.com"
+                        />
+                        </label>
+                    </div>
+                    <div>
+                        <label htmlFor="password">
+                        Password:
+                        <input
+                            id="password"
+                            name="password"
+                            type="password"
+                            value={password}
+                            onChange={(e) => setPassword(e.target.value)}
+                        placeholder="Password"
+                        />
+                        </label>
+                    </div>
+                    <button
+                        type="submit"
+                        disabled={loading}
                         >
-                            Sign in
-                        </button>
-                        <button
-                            type="button"
-                            onClick={signUpWithEmail}
-                            disabled={loading}
+                    Sign in
+                    </button>
+                    <button
+                        type="button"
+                        onClick={signUpWithEmail}
+                        disabled={loading}
                         >
-                            Sign up
-                        </button>
-                    </form>
-                </div>
+                    Sign up
+                    </button>
+                </form>
+            </div>
             );
-        }
+      }
       export default App;
-
       ```
 
     </StepHikeCompact.Code>

--- a/apps/docs/content/guides/auth/quickstarts/react.mdx
+++ b/apps/docs/content/guides/auth/quickstarts/react.mdx
@@ -105,7 +105,7 @@ hideToc: true
             setLoading(true);
             const { data: { session }, error } = await supabase.auth.signUp({ email, password });
             if (error) alert(error.message);
-            if (!session) alert('Please check your inbox for email verification!');
+            if (!error) alert('Please check your inbox for email verification!');
             setLoading(false);
         }
 
@@ -114,7 +114,7 @@ hideToc: true
                 {session ? (
                     <div> Logged in </div>
                 ) : (
-                <form onSubmit={signInWithEmail}>
+                <form>
                     <div>
                         <label htmlFor="email">
                         Email:
@@ -143,7 +143,8 @@ hideToc: true
                         </label>
                     </div>
                     <button
-                        type="submit"
+                        type="button"
+                        onClick={signInWithEmail}
                         disabled={loading}
                         >
                     Sign in

--- a/apps/docs/content/guides/auth/quickstarts/react.mdx
+++ b/apps/docs/content/guides/auth/quickstarts/react.mdx
@@ -73,103 +73,79 @@ hideToc: true
 
 
       ```js src/App.js
-        import React, { useState } from 'react';
-        import { createClient } from '@supabase/supabase-js'
+      import React, { useState } from 'react';
+      import { createClient } from '@supabase/supabase-js'
 
+      function App() {
+        const [email, setEmail] = useState('');
+        const [password, setPassword] = useState('');
+        const [loading, setLoading] = useState(false);
+        const supabase = createClient('https://<project>.supabase.co', '<your-anon-key>')
 
-        function App() {
-            const [email, setEmail] = useState('');
-            const [password, setPassword] = useState('');
-            const [loading, setLoading] = useState(false);
+        async function signInWithEmail(e) {
+            e.preventDefault();
+            setLoading(true);
+            const { error } = await supabase.auth.signInWithPassword({ email, password });
+            if (error) alert(error.message);
+            setLoading(false);
+        }
 
-            const supabase = createClient('https://<project>.supabase.co', '<your-anon-key>')
+        async function signUpWithEmail() {
+            setLoading(true);
+            const { data: { session }, error } = await supabase.auth.signUp({ email, password });
+            if (error) alert(error.message);
+            if (!session) alert('Please check your inbox for email verification!');
+            setLoading(false);
+        }
 
-            async function signInWithEmail() {
-                setLoading(true);
-                const { error } = await supabase.auth.signInWithPassword({ email, password});
-                if (error) alert(error.message);
-                setLoading(false);
-            }
-
-            async function signUpWithEmail() {
-                setLoading(true);
-                const { data: { session }, error} = await supabase.auth.signUp({ email, password});
-                if (error) alert(error.message);
-                if (!session) alert('Please check your inbox for email verification!');
-                setLoading(false);
-            }
-
-            const styles = {
-                container: {
-                    maxWidth: '300px',
-                    margin: '20px auto',
-                    padding: '20px',
-                },
-                formGroup: {
-                    marginBottom: '15px',
-                },
-                label: {
-                    display: 'block',
-                    marginBottom: '5px',
-                },
-                input: {
-                    width: '100%',
-                    padding: '8px',
-                    marginBottom: '10px',
-                },
-                button: {
-                    padding: '8px 16px',
-                    marginRight: '10px',
-                    cursor: 'pointer',
-                }
-            };
-
-            return (
-                <div style={styles.container}>
-                <div style={styles.formGroup}>
-                    <label style={styles.label}>
-                    Email:
-                    <input
-                        type="email"
-                        value={email}
-                        onChange={(e) => setEmail(e.target.value)}
-                        placeholder="email@address.com"
-                        style={styles.input}
-                    />
-                    </label>
-                </div>
-
-                <div style={styles.formGroup}>
-                    <label style={styles.label}>
-                    Password:
-                    <input
-                        type="password"
-                        value={password}
-                        onChange={(e) => setPassword(e.target.value)}
-                        placeholder="Password"
-                        style={styles.input}
-                    />
-                    </label>
-                </div>
-
-                <button
-                    onClick={signInWithEmail}
-                    disabled={loading}
-                    style={styles.button}
-                >
-                    Sign in
-                </button>
-                <button
-                    onClick={signUpWithEmail}
-                    disabled={loading}
-                    style={styles.button}
-                >
-                    Sign up
-                </button>
+        return (
+            <div>
+                <form onSubmit={signInWithEmail}>
+                    <div>
+                        <label htmlFor="email">
+                            Email:
+                            <input
+                                    id="email"
+                                    name="email"
+                                    type="email"
+                                    value={email}
+                                    onChange={(e) => setEmail(e.target.value)}
+                                    placeholder="email@address.com"
+                                />
+                            </label>
+                        </div>
+                        <div>
+                            <label htmlFor="password">
+                                Password:
+                                <input
+                                    id="password"
+                                    name="password"
+                                    type="password"
+                                    value={password}
+                                    onChange={(e) => setPassword(e.target.value)}
+                                    placeholder="Password"
+                                />
+                            </label>
+                        </div>
+                        <button
+                            type="submit"
+                            disabled={loading}
+                        >
+                            Sign in
+                        </button>
+                        <button
+                            type="button"
+                            onClick={signUpWithEmail}
+                            disabled={loading}
+                        >
+                            Sign up
+                        </button>
+                    </form>
                 </div>
             );
         }
-      export default App
+      export default App;
+
       ```
 
     </StepHikeCompact.Code>

--- a/apps/docs/content/guides/auth/quickstarts/react.mdx
+++ b/apps/docs/content/guides/auth/quickstarts/react.mdx
@@ -84,23 +84,14 @@ hideToc: true
 
         async function signInWithEmail() {
             setLoading(true);
-            const { error } = await supabase.auth.signInWithPassword({
-            email,
-            password,
-            });
+            const { error } = await supabase.auth.signInWithPassword({ email, password});
             if (error) alert(error.message);
             setLoading(false);
         }
 
         async function signUpWithEmail() {
             setLoading(true);
-            const {
-            data: { session },
-            error,
-            } = await supabase.auth.signUp({
-            email,
-            password,
-            });
+            const { data: { session }, error} = await supabase.auth.signUp({ email, password});
             if (error) alert(error.message);
             if (!session) alert('Please check your inbox for email verification!');
             setLoading(false);

--- a/apps/docs/content/guides/auth/quickstarts/react.mdx
+++ b/apps/docs/content/guides/auth/quickstarts/react.mdx
@@ -47,8 +47,6 @@ hideToc: true
   <StepHikeCompact.Step step={3}>
     <StepHikeCompact.Details title="Install the Supabase client library">
 
-    The fastest way to get started is to use Supabase's `auth-ui-react` library which provides a convenient interface for working with Supabase Auth from a React app.
-
     Navigate to the React app and install the Supabase libraries.
 
     </StepHikeCompact.Details>
@@ -56,7 +54,7 @@ hideToc: true
     <StepHikeCompact.Code>
 
       ```bash Terminal
-      cd my-app && npm install @supabase/supabase-js @supabase/auth-ui-react @supabase/auth-ui-shared
+      cd my-app && npm install @supabase/supabase-js
       ```
 
     </StepHikeCompact.Code>
@@ -75,38 +73,109 @@ hideToc: true
 
 
       ```js src/App.js
-        import './index.css'
-        import { useState, useEffect } from 'react'
-        import { createClient } from '@supabase/supabase-js'
-        import { Auth } from '@supabase/auth-ui-react'
-        import { ThemeSupa } from '@supabase/auth-ui-shared'
+        import React, { useState } from 'react';
+
+        export default function Auth() {
+        const [email, setEmail] = useState('');
+        const [password, setPassword] = useState('');
+        const [loading, setLoading] = useState(false);
 
         const supabase = createClient('https://<project>.supabase.co', '<your-anon-key>')
 
-        export default function App() {
-          const [session, setSession] = useState(null)
-
-          useEffect(() => {
-            supabase.auth.getSession().then(({ data: { session } }) => {
-              setSession(session)
-            })
-
-            const {
-              data: { subscription },
-            } = supabase.auth.onAuthStateChange((_event, session) => {
-              setSession(session)
-            })
-
-            return () => subscription.unsubscribe()
-          }, [])
-
-          if (!session) {
-            return (<Auth supabaseClient={supabase} appearance={{ theme: ThemeSupa }} />)
-          }
-          else {
-            return (<div>Logged in!</div>)
-          }
+        async function signInWithEmail() {
+            setLoading(true);
+            const { error } = await supabase.auth.signInWithPassword({
+            email,
+            password,
+            });
+            if (error) alert(error.message);
+            setLoading(false);
         }
+
+        async function signUpWithEmail() {
+            setLoading(true);
+            const {
+            data: { session },
+            error,
+            } = await supabase.auth.signUp({
+            email,
+            password,
+            });
+            if (error) alert(error.message);
+            if (!session) alert('Please check your inbox for email verification!');
+            setLoading(false);
+        }
+
+        const styles = {
+            container: {
+                maxWidth: '300px',
+                margin: '20px auto',
+                padding: '20px',
+            },
+            formGroup: {
+                marginBottom: '15px',
+            },
+            label: {
+                display: 'block',
+                marginBottom: '5px',
+            },
+            input: {
+                width: '100%',
+                padding: '8px',
+                marginBottom: '10px',
+            },
+            button: {
+                padding: '8px 16px',
+                marginRight: '10px',
+                cursor: 'pointer',
+            }
+        };
+
+        return (
+            <div style={styles.container}>
+              <div style={styles.formGroup}>
+                <label style={styles.label}>
+                  Email:
+                  <input
+                    type="email"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    placeholder="email@address.com"
+                    style={styles.input}
+                  />
+                </label>
+            </div>
+
+            <div style={styles.formGroup}>
+                <label style={styles.label}>
+                Password:
+                <input
+                    type="password"
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    placeholder="Password"
+                    style={styles.input}
+                />
+                </label>
+            </div>
+
+            <button
+                onClick={signInWithEmail}
+                disabled={loading}
+                style={styles.button}
+            >
+                Sign in
+            </button>
+            <button
+                onClick={signUpWithEmail}
+                disabled={loading}
+                style={styles.button}
+            >
+                Sign up
+            </button>
+            </div>
+        );
+      }
       ```
 
     </StepHikeCompact.Code>

--- a/apps/docs/content/guides/auth/quickstarts/react.mdx
+++ b/apps/docs/content/guides/auth/quickstarts/react.mdx
@@ -108,57 +108,153 @@ hideToc: true
             if (!error) alert('Please check your inbox for email verification!');
             setLoading(false);
         }
+        if (session) {
+          return <div className="container"><div className="form-card">Logged in</div></div>;
+        }
 
         return (
-            <div>
-                {session ? (
-                    <div> Logged in </div>
-                ) : (
-                <form>
-                    <div>
-                        <label htmlFor="email">
-                        Email:
-                        <input
-                            id="email"
-                            name="email"
-                            type="email"
-                            value={email}
-                            autocomplete="email"
-                            onChange={(e) => setEmail(e.target.value)}
-                            placeholder="email@address.com"
-                        />
-                        </label>
-                    </div>
-                    <div>
-                        <label htmlFor="password">
-                        Password:
-                        <input
-                            id="password"
-                            name="password"
-                            type="password"
-                            value={password}
-                            onChange={(e) => setPassword(e.target.value)}
-                            placeholder="Password"
-                        />
-                        </label>
-                    </div>
-                    <button
-                        type="button"
-                        onClick={signInWithEmail}
-                        disabled={loading}
-                        >
+            <div className="container">
+              <div className="form-card">
+                <div className="tabs">
+                  <button
+                    className={`tab ${activeTab === 'signin' ? 'active' : ''}`}
+                    onClick={() => setActiveTab('signin')}
+                  >
                     Sign in
-                    </button>
-                    <button
-                        type="button"
-                        onClick={signUpWithEmail}
-                        disabled={loading}
-                        >
+                  </button>
+                  <button
+                    className={`tab ${activeTab === 'signup' ? 'active' : ''}`}
+                    onClick={() => setActiveTab('signup')}
+                  >
                     Sign up
-                    </button>
-                </form>
-                )}
-            </div>
+                  </button>
+                </div>
+
+                <p className="info">Make changes to your account here.</p>
+
+        <form onSubmit={activeTab === 'signin' ? signInWithEmail : signUpWithEmail}>
+          <div className="input-group">
+            <label htmlFor="email" >Email</label>
+            <input
+              id="email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="email@address.com"
+              autoComplete="email"
+            />
+          </div>
+
+          <div className="input-group">
+            <label htmlFor="password">Password</label>
+            <input
+              id="password"
+              name="password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder="Password"
+            />
+          </div>
+
+          <button
+            type="submit"
+            className="submit-btn"
+            disabled={loading}
+          >
+            {loading ? 'Loading...' : activeTab === 'signin' ? 'Sign in' : 'Sign up'}
+          </button>
+        </form>
+
+        <style>{`
+          .container {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            min-height: 100vh;
+            background: #6366f1;
+            font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+          }
+
+          .form-card {
+            background: white;
+            padding: 24px;
+            border-radius: 8px;
+            width: 100%;
+            max-width: 400px;
+            box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+          }
+
+          .tabs {
+            display: flex;
+            margin-bottom: 20px;
+            border-bottom: 1px solid #eee;
+          }
+
+          .tab {
+            background: none;
+            border: none;
+            padding: 10px 20px;
+            font-size: 16px;
+            color: #666;
+            cursor: pointer;
+          }
+
+          .tab.active {
+            color: #6366f1;
+            border-bottom: 2px solid #6366f1;
+          }
+
+          .info {
+            color: #666;
+            margin-bottom: 24px;
+          }
+
+          .input-group {
+            margin-bottom: 16px;
+          }
+
+          label {
+            display: block;
+            margin-bottom: 8px;
+            color: #333;
+          }
+
+          input {
+            width: 100%;
+            padding: 8px;
+            border: 1px solid #ddd;
+            border-radius: 4px;
+            font-size: 16px;
+          }
+
+          input:focus {
+            outline: none;
+            border-color: #6366f1;
+          }
+
+          .submit-btn {
+            width: 100%;
+            padding: 10px;
+            background: #6366f1;
+            color: white;
+            border: none;
+            border-radius: 4px;
+            font-size: 16px;
+            cursor: pointer;
+          }
+
+          .submit-btn:hover {
+            background: #4f46e5;
+          }
+
+          .submit-btn:disabled {
+            background: #a5a6f6;
+            cursor: not-allowed;
+          }
+        `}</style>
+        </div>
+      </div>
         );
       }
       export default App;


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Updates the quickstart guide

## What is the current behavior?

React quickstart guide references Auth UI, which is now deprecated

## What is the new behavior?

React quickstart guide uses vanilla html and css.

## TODOs

- [x] Need to test the flow and run npm format.
- [x] Need to confirm what flows we want to show case. Currently we opt for an email / password flow as it doesn't require setup. Magic link is an option too.  Update: it sounds like we are okay with this flow

This is an important page since it's one of the first few interactions with Supabase for a developer starting out with Auth so might need to seek input internally before finalizing

