### PR TITLE
Fix docs toc

### DIFF
--- a/apps/docs/components/GuidesTableOfContents.tsx
+++ b/apps/docs/components/GuidesTableOfContents.tsx
@@ -32,6 +32,10 @@ const formatTOCHeader = (content: string) => {
         begin = false
         res.push(`</code>`)
       }
+    } else if (x === '<') {
+      res.push('&lt')
+    } else if (x === '>') {
+      res.push('&gt')
     } else {
       res.push(x)
     }


### PR DESCRIPTION
To handle rendering of `<` and `>` in the TOC

Before:
![image](https://github.com/user-attachments/assets/67c9efba-1ba5-48a3-8684-c1e1f4967c37)

After:
![image](https://github.com/user-attachments/assets/909987fd-8696-4dc6-9203-68c6f81b6d7d)
