### PR TITLE
fix(docs): external code sample on local dev

### DIFF
--- a/apps/docs/features/directives/CodeSample.client.tsx
+++ b/apps/docs/features/directives/CodeSample.client.tsx
@@ -4,6 +4,17 @@ import Link from 'next/link'
 import { useState, type PropsWithChildren } from 'react'
 
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from 'ui'
+import { Admonition } from 'ui-patterns/admonition'
+
+export function CodeSampleDummy() {
+  return (
+    <Admonition type="caution" title="Local development warning">
+      The <code>$CodeSample</code> directive with external repos is not supported in local
+      development because it relies on a GitHub API key. Please check the preview site to see the
+      final UI.
+    </Admonition>
+  )
+}
 
 export function CodeSampleWrapper({
   children,

--- a/apps/docs/features/directives/CodeSample.test.ts
+++ b/apps/docs/features/directives/CodeSample.test.ts
@@ -14,10 +14,17 @@ const transformWithMock = codeSampleRemark({
 
 let env: NodeJS.Process['env']
 
+vi.mock('~/lib/constants', () => ({
+  IS_PLATFORM: true,
+}))
+
 describe('$CodeSample', () => {
   beforeAll(() => {
     env = process.env
-    process.env = { NODE_ENV: 'test', NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA: '1234567890' }
+    process.env = {
+      NODE_ENV: 'test',
+      NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA: '1234567890',
+    }
   })
 
   afterAll(() => {

--- a/apps/docs/features/directives/CodeSample.ts
+++ b/apps/docs/features/directives/CodeSample.ts
@@ -46,6 +46,7 @@ import { visitParents } from 'unist-util-visit-parents'
 import { z, type SafeParseError } from 'zod'
 
 import { fetchWithNextOptions } from '~/features/helpers.fetch'
+import { IS_PLATFORM } from '~/lib/constants'
 import { EXAMPLES_DIRECTORY } from '~/lib/docs'
 
 const ALLOW_LISTED_GITHUB_ORGS = ['supabase'] as [string, ...string[]]
@@ -141,6 +142,12 @@ async function fetchSourceCodeContent(tree: Root, deps: Dependencies) {
     const isExternal = getAttributeValueExpression(getAttributeValue(node, 'external')) === 'true'
 
     if (isExternal) {
+      if (!IS_PLATFORM) {
+        node.name = 'CodeSampleDummy'
+        node.attributes = []
+        return
+      }
+
       const org = getAttributeValue(node, 'org')
       const repo = getAttributeValue(node, 'repo')
       const commit = getAttributeValue(node, 'commit')

--- a/apps/docs/features/docs/MdxBase.shared.tsx
+++ b/apps/docs/features/docs/MdxBase.shared.tsx
@@ -35,7 +35,7 @@ import { RealtimeLimitsEstimator } from '~/components/RealtimeLimitsEstimator'
 import { RegionsList } from '~/components/RegionsList'
 import { SharedData } from '~/components/SharedData'
 import StepHikeCompact from '~/components/StepHikeCompact'
-import { CodeSampleWrapper } from '~/features/directives/CodeSample.client'
+import { CodeSampleDummy, CodeSampleWrapper } from '~/features/directives/CodeSample.client'
 import { Accordion, AccordionItem } from '~/features/ui/Accordion'
 import * as CH from '~/features/ui/CodeHike'
 import { ShowUntil } from '~/features/ui/ShowUntil'
@@ -53,6 +53,7 @@ const components = {
   Button,
   ButtonCard,
   CH,
+  CodeSampleDummy,
   CodeSampleWrapper,
   CostWarning,
   CreateClientSnippet,


### PR DESCRIPTION
Pages incorporating an external code sample on local dev will fail for contributors without the GitHub API key. This PR fixes the local DX by replacing such code samples with a local-only message describing the error, and asking contributors to check the preview site.