### PR TITLE
added warning to timeout docs

### DIFF
--- a/apps/docs/content/guides/database/postgres/timeouts.mdx
+++ b/apps/docs/content/guides/database/postgres/timeouts.mdx
@@ -3,9 +3,11 @@ title: Timeouts
 subtitle: Extend database timeouts to execute longer transactions
 ---
 
-Requests made through the Supabase API and Dashboard have a timeout of 60 seconds. The database also has a global default timeout of 2 minutes.
+<Admonition type="note">
 
-To execute longer transactions, connect to your database using [Supavisor](/docs/guides/database/connecting-to-postgres#connection-pooler) or the [direct connection string](/docs/guides/database/connecting-to-postgres#direct-connections), and change the timeout settings.
+Dashboard and [Client](/docs/guides/api/rest/client-libs) queries have a max-configurable timeout of 60 seconds. For longer transactions, use [Supavisor or a direct connection](/docs/guides/database/connecting-to-postgres#quick-summary).
+
+</Admonition>
 
 ## Change Postgres timeout
 

--- a/apps/docs/content/guides/database/postgres/timeouts.mdx
+++ b/apps/docs/content/guides/database/postgres/timeouts.mdx
@@ -5,7 +5,7 @@ subtitle: Extend database timeouts to execute longer transactions
 
 <Admonition type="note">
 
-Dashboard and [Client](/docs/guides/api/rest/client-libs) queries have a max-configurable timeout of 60 seconds. For longer transactions, use [Supavisor or a direct connection](/docs/guides/database/connecting-to-postgres#quick-summary).
+Dashboard and [Client](/docs/guides/api/rest/client-libs) queries have a max-configurable timeout of 60 seconds. For longer transactions, use [Supavisor or direct connections](/docs/guides/database/connecting-to-postgres#quick-summary).
 
 </Admonition>
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

The docs contains the following warning:

```md
Requests made through the Supabase API and Dashboard have a timeout of 60 seconds. The database also has a global default timeout of 2 minutes.

To execute longer transactions, connect to your database using [Supavisor](https://supabase.com/docs/guides/database/connecting-to-postgres#connection-pooler) or the [direct connection string](https://supabase.com/docs/guides/database/connecting-to-postgres#direct-connections), and change the timeout settings.
```

## What is the new behavior?

Updated the warning and wrapped it in an admonition tag.
