### PR TITLE
remove swap usage from DB report

### DIFF
--- a/apps/studio/data/analytics/infra-monitoring-query.ts
+++ b/apps/studio/data/analytics/infra-monitoring-query.ts
@@ -11,7 +11,6 @@ export type InfraMonitoringAttribute =
   | 'disk_io_budget'
   | 'ram_usage'
   | 'disk_io_consumption'
-  | 'swap_usage'
   | 'pg_stat_database_num_backends'
 
 export type InfraMonitoringVariables = {

--- a/apps/studio/lib/constants/metrics.tsx
+++ b/apps/studio/lib/constants/metrics.tsx
@@ -71,12 +71,6 @@ export const METRICS = [
     category: METRIC_CATEGORIES.INSTANCE,
   },
   {
-    key: 'swap_usage',
-    label: 'Swap % usage',
-    provider: 'infra-monitoring',
-    category: METRIC_CATEGORIES.INSTANCE,
-  },
-  {
     key: 'total_realtime_egress',
     label: 'Realtime Connection Egress',
     provider: 'daily-stats',

--- a/apps/studio/pages/project/[ref]/reports/database.tsx
+++ b/apps/studio/pages/project/[ref]/reports/database.tsx
@@ -137,17 +137,6 @@ const DatabaseUsage = () => {
               {dateRange && (
                 <ChartHandler
                   provider="infra-monitoring"
-                  attribute="swap_usage"
-                  label="Swap usage"
-                  interval={dateRange.interval}
-                  startDate={dateRange?.period_start?.date}
-                  endDate={dateRange?.period_end?.date}
-                />
-              )}
-
-              {dateRange && (
-                <ChartHandler
-                  provider="infra-monitoring"
                   attribute="avg_cpu_usage"
                   label="Average CPU usage"
                   interval={dateRange.interval}


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Current DB Reports page shows Swap usage amongst other infra related information. Swap is set to 1GB regardless of compute size and creates confusion amongst users, when it is mostly distracting

## What is the new behavior?

Swap chart has been removed from the Reports page

## Additional context

Add any other context or screenshots.
