### PR TITLE
update link to vercel marketplace blog post

### DIFF
--- a/apps/docs/content/guides/integrations/vercel-marketplace.mdx
+++ b/apps/docs/content/guides/integrations/vercel-marketplace.mdx
@@ -10,7 +10,7 @@ The Vercel Marketplace is a feature that allows you to manage third-party resour
 
 When you create an organization and projects through Vercel Marketplace, they function just like those created directly within Supabase. However, the billing is handled through your Vercel account, and you can manage your resources directly from the Vercel dashboard or CLI. Additionally, environment variables are automatically synchronized, making them immediately available for your connected projects.
 
-For more information, see [Introducing the Vercel Marketplace](https://vercel.com/blog/share/introducing-the-vercel-marketplace) blog post.
+For more information, see [Introducing the Vercel Marketplace](https://vercel.com/blog/introducing-the-vercel-marketplace) blog post.
 
 <Admonition type="note">
 


### PR DESCRIPTION
remove share/ from the link https://vercel.com/blog/share/introducing-the-vercel-marketplace which leads to 404

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update 

## What is the current behavior?

Vercel marketplace link leads to 404

## What is the new behavior?

Vercel marketplace link leads to https://vercel.com/blog/introducing-the-vercel-marketplace

## Additional context

-
