### PR TITLE
await createClient() promise in AuthButton.tsx

### DIFF
--- a/examples/auth/nextjs/components/AuthButton.tsx
+++ b/examples/auth/nextjs/components/AuthButton.tsx
@@ -12,7 +12,7 @@ export default async function AuthButton() {
   const signOut = async () => {
     'use server'
 
-    const supabase = createClient()
+    const supabase = await createClient()
     await supabase.auth.signOut()
     return redirect('/login')
   }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

`Error: Cannot read properties of undefined (reading 'signOut')`

## What is the new behavior?

It works
