### PR TITLE
ci(docs): fix linter v2 pipeline

### DIFF
--- a/.github/workflows/docs-lint-v2.yml
+++ b/.github/workflows/docs-lint-v2.yml
@@ -45,6 +45,6 @@ jobs:
         run: |
           set -o pipefail
           git diff --name-only origin/$BASE_REF HEAD \
-            | grep -E "^apps/docs/content/guides/(getting-started|ai|api|auth|database|deployment|functions)/" \
+            | { grep -E "^apps/docs/content/guides/(getting-started|ai|api|auth|database|deployment|functions)/" || test $? = 1; } \
             | xargs -r supa-mdx-lint --format rdf \
             | reviewdog -f=rdjsonl -reporter=github-pr-review


### PR DESCRIPTION
The linter was failing whenever grep turned up empty because pipefail was on, now ignoring grep so it'll stop erroring on all irrelevant PRs 😵