### PR TITLE
feat: update emails to use a valid email address

### DIFF
--- a/apps/docs/content/guides/auth/auth-anonymous.mdx
+++ b/apps/docs/content/guides/auth/auth-anonymous.mdx
@@ -116,7 +116,7 @@ Converting an anonymous user to a permanent user requires [linking an identity](
 You can use the [`updateUser()`](/docs/reference/javascript/auth-updateuser) method to link an email or phone identity to the anonymous user. To add a password for the anonymous user, the user's email or phone number needs to be verified first.
 
 ```js
-const { data, error } = await supabase.auth.updateUser({ email: 'example@email.com' })
+const { data, error } = await supabase.auth.updateUser({ email: 'valid.email@supabase.io' })
 
 // verify the user's email by clicking on the email change link
 // or entering the 6-digit OTP sent to the email address
@@ -131,7 +131,7 @@ const { data, error } = await supabase.auth.updateUser({ password: 'password' })
 You can use the [`updateUser()`](/docs/reference/dart/auth-updateuser) method to link an email or phone identity to the anonymous user.
 
 ```dart
-await supabase.auth.updateUser(UserAttributes(email: 'example@email.com'));
+await supabase.auth.updateUser(UserAttributes(email: 'valid.email@supabase.io'));
 ```
 
 </TabPanel>
@@ -141,7 +141,7 @@ You can use the [`updateUser()`](/docs/reference/swift/auth-updateuser) method t
 
 ```swift
 try await supabase.auth.updateUser(
-  user: UserAttributes(email: "example@email.com")
+  user: UserAttributes(email: "valid.email@supabase.io")
 )
 ```
 
@@ -152,7 +152,7 @@ You can use the [`updateUser()`](/docs/reference/kotlin/auth-updateuser) method 
 
 ```kotlin
 supabase.auth.updateUser {
-    email = "example@email.com"
+    email = "valid.email@supabase.io"
 }
 ```
 
@@ -163,7 +163,7 @@ You can use the [`update_user()`](/docs/reference/python/auth-updateuser) method
 
 ```python
 response = supabase.auth.update_user({
-  'email': 'example@email.com',
+  'email': 'valid.email@supabase.io',
 })
 
 # verify the user's email by clicking on the email change link
@@ -274,7 +274,7 @@ const { data: anonData, error: anonError } = await supabase.auth.getSession()
 
 // 2. Attempt to update the user with the existing email
 const { data: updateData, error: updateError } = await supabase.auth.updateUser({
-  email: 'existing_user@example.com',
+  email: 'valid.email@supabase.io',
 })
 
 // 3. Handle the error (since the email belongs to an existing user)
@@ -286,7 +286,7 @@ if (updateError) {
     data: { user: existingUser },
     error: signInError,
   } = await supabase.auth.signInWithPassword({
-    email: 'existing_user@example.com',
+    email: 'valid.email@supabase.io',
     password: 'user_password',
   })
 

--- a/apps/docs/content/guides/auth/auth-email-passwordless.mdx
+++ b/apps/docs/content/guides/auth/auth-email-passwordless.mdx
@@ -48,7 +48,7 @@ If the user hasn't signed up yet, they are automatically signed up by default. T
 ```js
 async function signInWithEmail() {
   const { data, error } = await supabase.auth.signInWithOtp({
-    email: 'example@email.com',
+    email: 'valid.email@supabase.io',
     options: {
       // set this to false if you do not want the user to be automatically signed up
       shouldCreateUser: false,
@@ -67,7 +67,7 @@ import { makeRedirectUri } from 'expo-auth-session'
 const redirectTo = makeRedirectUri()
 
 const { error } = await supabase.auth.signInWithOtp({
-  email: 'example@email.com',
+  email: 'valid.email@supabase.io',
   options: {
     emailRedirectTo: redirectTo,
   },
@@ -81,7 +81,7 @@ Read the [Deep Linking Documentation](/docs/guides/auth/native-mobile-deep-linki
 
 ```dart
 Future<void> signInWithEmail() async {
-  final AuthResponse res = await supabase.auth.signinwithotp(email: 'example@email.com');
+  final AuthResponse res = await supabase.auth.signinwithotp(email: 'valid.email@supabase.io');
 }
 ```
 
@@ -90,7 +90,7 @@ Future<void> signInWithEmail() async {
 
 ```swift
 try await supabase.auth.signInWithOTP(
-  email: "example@email.com",
+  email: "valid.email@supabase.io",
   redirectTo: URL(string: "https://example.com/welcome"),
   // set this to false if you do not want the user to be automatically signed up
   shouldCreateUser: false
@@ -103,7 +103,7 @@ try await supabase.auth.signInWithOTP(
 ```kotlin
 suspend fun signInWithEmail() {
 	supabase.auth.signInWith(OTP) {
-		email = "example@email.com"
+		email = "valid.email@supabase.io"
 	}
 }
 ```
@@ -113,7 +113,7 @@ suspend fun signInWithEmail() {
 
 ```python
 response = supabase.auth.sign_in_with_otp({
-  'email': 'example@email.com',
+  'email': 'valid.email@supabase.io',
   'options': {
     # set this to false if you do not want the user to be automatically signed up
     'should_create_user': False,
@@ -181,7 +181,7 @@ If the user hasn't signed up yet, they are automatically signed up by default. T
 
 ```js
 const { data, error } = await supabase.auth.signInWithOtp({
-  email: 'example@email.com',
+  email: 'valid.email@supabase.io',
   options: {
     // set this to false if you do not want the user to be automatically signed up
     shouldCreateUser: false,
@@ -194,7 +194,7 @@ const { data, error } = await supabase.auth.signInWithOtp({
 
 ```dart
 Future<void> signInWithEmailOtp() async {
-  final AuthResponse res = await supabase.auth.signInWithOtp(email: 'example@email.com');
+  final AuthResponse res = await supabase.auth.signInWithOtp(email: 'valid.email@supabase.io');
 }
 ```
 
@@ -203,7 +203,7 @@ Future<void> signInWithEmailOtp() async {
 
 ```swift
 try await supabase.auth.signInWithOTP(
-  email: "example@email.com",
+  email: "valid.email@supabase.io",
   // set this to false if you do not want the user to be automatically signed up
   shouldCreateUser: false
 )
@@ -215,7 +215,7 @@ try await supabase.auth.signInWithOTP(
 ```kotlin
 suspend fun signInWithEmailOtp() {
 	supabase.auth.signInWith(OTP) {
-		email = "example@email.com"
+		email = "valid.email@supabase.io"
 	}
 }
 ```
@@ -225,7 +225,7 @@ suspend fun signInWithEmailOtp() {
 
 ```python
 response = supabase.auth.sign_in_with_otp({
-  'email': 'example@email.com',
+  'email': 'valid.email@supabase.io',
   'options': {
     # set this to false if you do not want the user to be automatically signed up
     'should_create_user': False,

--- a/apps/docs/content/guides/auth/auth-helpers/nextjs-pages.mdx
+++ b/apps/docs/content/guides/auth/auth-helpers/nextjs-pages.mdx
@@ -664,7 +664,7 @@ For authentication methods that have a `redirectTo` or `emailRedirectTo`, this m
 
 ```jsx
 supabase.auth.signUp({
-  email: 'jon@example.com',
+  email: 'valid.email@supabase.io',
   password: 'sup3rs3cur3',
   options: {
     emailRedirectTo: 'http://localhost:3000/auth/callback',

--- a/apps/docs/content/guides/auth/auth-helpers/nextjs.mdx
+++ b/apps/docs/content/guides/auth/auth-helpers/nextjs.mdx
@@ -1294,7 +1294,7 @@ For authentication methods that have a `redirectTo` or `emailRedirectTo`, this m
 
 ```jsx
 supabase.auth.signUp({
-  email: 'jon@example.com',
+  email: 'valid.email@supabase.io',
   password: 'sup3rs3cur3',
   options: {
     emailRedirectTo: 'http://localhost:3000/auth/callback',

--- a/apps/docs/content/guides/auth/auth-helpers/remix.mdx
+++ b/apps/docs/content/guides/auth/auth-helpers/remix.mdx
@@ -613,7 +613,7 @@ export default function Login() {
 
   const handleEmailLogin = async () => {
     await supabase.auth.signInWithPassword({
-      email: 'jon@supabase.com',
+      email: 'valid.email@supabase.io',
       password: 'password',
     })
   }
@@ -651,7 +651,7 @@ export default function Login() {
 
   const handleEmailLogin = async () => {
     await supabase.auth.signInWithPassword({
-      email: 'jon@supabase.com',
+      email: 'valid.email@supabase.io',
       password: 'password',
     })
   }
@@ -826,7 +826,7 @@ For authentication methods that have a `redirectTo` or `emailRedirectTo`, this m
 
 ```jsx
 supabaseClient.auth.signUp({
-  email: 'jon@example.com',
+  email: 'valid.email@supabase.io',
   password: 'sup3rs3cur3',
   options: {
     emailRedirectTo: 'http://localhost:3000/auth/callback',

--- a/apps/docs/content/guides/auth/auth-helpers/sveltekit.mdx
+++ b/apps/docs/content/guides/auth/auth-helpers/sveltekit.mdx
@@ -903,7 +903,7 @@ For authentication methods that have a `redirectTo` or `emailRedirectTo`, this m
 
 ```ts
 await supabase.auth.signUp({
-  email: 'jon@example.com',
+  email: 'valid.email@supabase.io',
   password: 'sup3rs3cur3',
   options: {
     emailRedirectTo: 'http://localhost:3000/auth/callback',

--- a/apps/docs/content/guides/auth/auth-hooks/send-email-hook.mdx
+++ b/apps/docs/content/guides/auth/auth-hooks/send-email-hook.mdx
@@ -37,14 +37,14 @@ Email sending depends on two settings: Email Provider and Auth Hook status.
     "id": "8484b834-f29e-4af2-bf42-80644d154f76",
     "aud": "authenticated",
     "role": "authenticated",
-    "email": "john@soupbase.io",
+    "email": "valid.email@supabase.io",
     "phone": "",
     "app_metadata": {
       "provider": "email",
       "providers": ["email"]
     },
     "user_metadata": {
-      "email": "john@soupbase.io",
+      "email": "valid.email@supabase.io",
       "email_verified": false,
       "phone_verified": false,
       "sub": "8484b834-f29e-4af2-bf42-80644d154f76"
@@ -55,7 +55,7 @@ Email sending depends on two settings: Email Provider and Auth Hook status.
         "id": "8484b834-f29e-4af2-bf42-80644d154f76",
         "user_id": "8484b834-f29e-4af2-bf42-80644d154f76",
         "identity_data": {
-          "email": "john@soupbase.io",
+          "email": "valid.email@supabase.io",
           "email_verified": false,
           "phone_verified": false,
           "sub": "8484b834-f29e-4af2-bf42-80644d154f76"
@@ -64,7 +64,7 @@ Email sending depends on two settings: Email Provider and Auth Hook status.
         "last_sign_in_at": "2024-05-14T12:56:33.824231484Z",
         "created_at": "2024-05-14T12:56:33.824261Z",
         "updated_at": "2024-05-14T12:56:33.824261Z",
-        "email": "john@soupbase.io"
+        "email": "valid.email@supabase.io"
       }
     ],
     "created_at": "2024-05-14T12:56:33.821567Z",

--- a/apps/docs/content/guides/auth/enterprise-sso/auth-sso-saml.mdx
+++ b/apps/docs/content/guides/auth/enterprise-sso/auth-sso-saml.mdx
@@ -80,7 +80,7 @@ Alternatively, you can use the `supabase sso info --project-ref <your-project>` 
 User accounts and identities created via SSO differ from regular (email, phone, password, social login...) accounts in these ways:
 
 - **No automatic linking.**
-  Each user account verified using a SSO identity provider will not be automatically linked to existing user accounts in the system. That is, if a user `jane.doe@company.com` had signed up with a password, and then uses their company SSO login with your project, there will be two `jane.doe@company.com` user accounts in the system.
+  Each user account verified using a SSO identity provider will not be automatically linked to existing user accounts in the system. That is, if a user `valid.email@supabase.io` had signed up with a password, and then uses their company SSO login with your project, there will be two `valid.email@supabase.io` user accounts in the system.
 - **Emails are not necessarily unique.**
   Given the behavior with no automatic linking, email addresses are no longer a unique identifier for a user account. Please always use the user's UUID to correctly reference user accounts.
 - **Sessions may have a maximum duration.**
@@ -288,7 +288,7 @@ Given a SAML 2.0 assertion that includes these attributes:
     NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic"
     >
     <saml:AttributeValue xsi:type="xs:string">
-      jane.doe@company.com
+      valid.email@supabase.io
     </saml:AttributeValue>
   </saml:Attribute>
 
@@ -308,7 +308,7 @@ Will result in the following claims in the user's identity in the database and J
 
 ```json
 {
-  "email": "jane.doe@company.com",
+  "email": "valid.email@supabase.io",
   "custom_claims": {
     "first_name": "Jane Doe"
   }

--- a/apps/docs/content/guides/auth/jwts.mdx
+++ b/apps/docs/content/guides/auth/jwts.mdx
@@ -133,7 +133,7 @@ The `user access token` is the JWT issued when you call for example:
 
 ```js
 supabase.auth.signIn({
-  email: 'lao.gimmie@gov.sg',
+  email: 'valid.email@supabase.io',
   password: 'They_Live_1988!',
 })
 ```
@@ -153,7 +153,7 @@ You'll notice that this token is quite a bit longer, since it contains informati
   "aud": "authenticated",
   "exp": 1615824388,
   "sub": "0334744a-f2a2-4aba-8c8a-6e748f62a172",
-  "email": "d.l.solove@gmail.com",
+  "email": "valid.email@supabase.io",
   "app_metadata": {
     "provider": "email"
   },

--- a/apps/docs/content/guides/auth/managing-user-data.mdx
+++ b/apps/docs/content/guides/auth/managing-user-data.mdx
@@ -69,7 +69,7 @@ You can assign metadata to users on sign up:
 
 ```js
 const { data, error } = await supabase.auth.signUp({
-  email: 'example@email.com',
+  email: 'valid.email@supabase.io',
   password: 'example-password',
   options: {
     data: {
@@ -85,7 +85,7 @@ const { data, error } = await supabase.auth.signUp({
 
 ```dart
 final res = await supabase.auth.signUp(
-  email: 'example@email.com',
+  email: 'valid.email@supabase.io',
   password: 'example-password',
   data: {
     'first_name': 'John',
@@ -99,7 +99,7 @@ final res = await supabase.auth.signUp(
 
 ```swift
 try await supabase.auth.signUp(
-  email: "example@email.com",
+  email: "valid.email@supabase.io",
   password: "example-password",
   data: [
     "first_name": .string("John"),
@@ -113,7 +113,7 @@ try await supabase.auth.signUp(
 
 ```kotlin
 val data = supabase.auth.signUpWith(Email) {
-    email = "example@email.com"
+    email = "valid.email@supabase.io"
     password = "example-password"
     data = buildJsonObject {
         put("first_name", "John")

--- a/apps/docs/content/guides/auth/native-mobile-deep-linking.mdx
+++ b/apps/docs/content/guides/auth/native-mobile-deep-linking.mdx
@@ -85,7 +85,7 @@ With Deep Linking, you can configure this redirect to open a specific page. This
 
     const sendMagicLink = async () => {
       const { error } = await supabase.auth.signInWithOtp({
-        email: "example@email.com",
+        email: "valid.email@supabase.io",
         options: {
           emailRedirectTo: redirectTo,
         },

--- a/apps/docs/content/guides/auth/passwords.mdx
+++ b/apps/docs/content/guides/auth/passwords.mdx
@@ -58,7 +58,7 @@ If you don't specify a redirect URL, the user is automatically redirected to you
 ```js
 async function signUpNewUser() {
   const { data, error } = await supabase.auth.signUp({
-    email: 'example@email.com',
+    email: 'valid.email@supabase.io',
     password: 'example-password',
     options: {
       emailRedirectTo: 'https://example.com/welcome',
@@ -75,7 +75,7 @@ To sign up the user, call [signUp()](/docs/reference/dart/auth-signup) with thei
 ```dart
 Future<void> signUpNewUser() async {
   final AuthResponse res = await supabase.auth.signUp(
-    email: 'example@email.com',
+    email: 'valid.email@supabase.io',
     password: 'example-password'
   );
 }
@@ -92,7 +92,7 @@ If you don't specify a redirect URL, the user is automatically redirected to you
 
 ```swift
 let response = try await supabase.auth.signUp(
-  email: "example@email.com",
+  email: "valid.email@supabase.io",
   password: "example-password",
   redirectTo: URL(string: "https://example.com/welcome")
 )
@@ -106,7 +106,7 @@ To sign up the user, call [signUpWith(Email)](/docs/reference/kotlin/auth-signup
 ```kotlin
 suspend fun signUpNewUser() {
 	supabase.auth.signUpWith(Email) {
-		email = "example@email.com"
+		email = "valid.email@supabase.io"
 		password = "example-password"
 	}
 }
@@ -123,7 +123,7 @@ If you don't specify a redirect URL, the user is automatically redirected to you
 
 ```python
 data = await supabase.auth.sign_up({
-  'email': 'example@email.com',
+  'email': 'valid.email@supabase.io',
   'password': 'example-password',
   'options': {
     'email_redirect_to': 'https://example.com/welcome',
@@ -387,7 +387,7 @@ If you don't specify a redirect URL, the user is automatically redirected to you
 ```js
 async function signUpNewUser() {
   const { data, error } = await supabase.auth.signUp({
-    email: 'example@email.com',
+    email: 'valid.email@supabase.io',
     password: 'example-password',
     options: {
       emailRedirectTo: 'https://example.com/welcome',
@@ -404,7 +404,7 @@ To sign up the user, call [signUp()](/docs/reference/dart/auth-signup) with thei
 ```dart
 Future<void> signUpNewUser() async {
   final AuthResponse res = await supabase.auth.signUp(
-    email: 'example@email.com',
+    email: 'valid.email@supabase.io',
     password: 'example-password'
   );
 }
@@ -417,7 +417,7 @@ To sign up the user, call [signUp()](/docs/reference/swift/auth-signup) with the
 
 ```swift
 let response = try await supabase.auth.signUp(
-  email: "example@email.com",
+  email: "valid.email@supabase.io",
   password: "example-password",
 )
 ```
@@ -430,7 +430,7 @@ To sign up the user, call [signUpWith(Email)](/docs/reference/kotlin/auth-signup
 ```kotlin
 suspend fun signUpNewUser() {
 	supabase.auth.signUpWith(Email) {
-		email = "example@email.com"
+		email = "valid.email@supabase.io"
 		password = "example-password"
 	}
 }
@@ -443,7 +443,7 @@ To sign up the user, call [signUp()](/docs/reference/python/auth-signup) with th
 
 ```python
 data = supabase.auth.sign_up({
-  'email': 'example@email.com',
+  'email': 'valid.email@supabase.io',
   'password': 'example-password',
 })
 ```
@@ -470,7 +470,7 @@ When your user signs in, call [signInWithPassword()](/docs/reference/javascript/
 ```js
 async function signInWithEmail() {
   const { data, error } = await supabase.auth.signInWithPassword({
-    email: 'example@email.com',
+    email: 'valid.email@supabase.io',
     password: 'example-password',
   })
 }
@@ -484,7 +484,7 @@ When your user signs in, call [signInWithPassword()](/docs/reference/dart/auth-s
 ```dart
 Future<void> signInWithEmail() async {
   final AuthResponse res = await supabase.auth.signInWithPassword(
-    email: 'example@email.com',
+    email: 'valid.email@supabase.io',
     password: 'example-password'
   );
 }
@@ -497,7 +497,7 @@ When your user signs in, call [signIn(email:password:)](/docs/reference/swift/au
 
 ```swift
 try await supabase.auth.signIn(
-  email: "example@email.com",
+  email: "valid.email@supabase.io",
   password: "example-password"
 )
 ```
@@ -510,7 +510,7 @@ When your user signs in, call [signInWith(Email)](/docs/reference/kotlin/auth-si
 ```kotlin
 suspend fun signInWithEmail() {
 	supabase.auth.signInWith(Email) {
-		email = "example@email.com"
+		email = "valid.email@supabase.io"
 		password = "example-password"
 	}
 }
@@ -523,7 +523,7 @@ When your user signs in, call [sign_in_with_password()](/docs/reference/python/a
 
 ```python
 data = client.auth.sign_in_with_password({
-  'email': 'example@email.com',
+  'email': 'valid.email@supabase.io',
   'password': 'example-password',
 })
 ```
@@ -557,7 +557,7 @@ Collect the user's email address and request a password reset email. Specify the
 <TabPanel id="js" label="JavaScript">
 
 ```js
-await supabase.auth.resetPasswordForEmail('hello@example.com', {
+await supabase.auth.resetPasswordForEmail('valid.email@supabase.io', {
   redirectTo: 'http://example.com/account/update-password',
 })
 ```
@@ -567,7 +567,7 @@ await supabase.auth.resetPasswordForEmail('hello@example.com', {
 
 ```swift
 try await supabase.auth.resetPasswordForEmail(
-   "hello@example.com",
+   "valid.email@supabase.io",
    redirectTo: URL(string: "http://example.com/account/update-password")
 )
 ```
@@ -577,7 +577,7 @@ try await supabase.auth.resetPasswordForEmail(
 
 ```kotlin
 supabase.gotrue.sendRecoveryEmail(
-    email = "hello@example.com",
+    email = "valid.email@supabase.io",
     redirectUrl = "http://example.com/account/update-password"
 )
 ```
@@ -589,7 +589,7 @@ If you are on one of the Kotlin targets that have built-in support for redirect 
 
 ```python
 client.auth.reset_password_email(
-  'hello@example.com',
+  'valid.email@supabase.io',
   {'redirect_to':'http://example.com/account/update-password'}
 )
 ```
@@ -859,7 +859,7 @@ async function resetPassword() {
 <TabPanel id="swift" label="Swift">
 
 ```swift
-try await supabase.auth.resetPasswordForEmail("hello@example.com")
+try await supabase.auth.resetPasswordForEmail("valid.email@supabase.io")
 ```
 
 </TabPanel>
@@ -867,7 +867,7 @@ try await supabase.auth.resetPasswordForEmail("hello@example.com")
 
 ```kotlin
 supabase.gotrue.sendRecoveryEmail(
-    email = "hello@example.com",
+    email = "valid.email@supabase.io",
 )
 ```
 
@@ -875,7 +875,7 @@ supabase.gotrue.sendRecoveryEmail(
 <TabPanel id="python" label="Python">
 
 ```python
-supabase.auth.reset_password_email('hello@example.com')
+supabase.auth.reset_password_email('valid.email@supabase.io')
 ```
 
 </TabPanel>

--- a/apps/docs/content/guides/platform/migrating-to-supabase/auth0.mdx
+++ b/apps/docs/content/guides/platform/migrating-to-supabase/auth0.mdx
@@ -80,7 +80,7 @@ Migrate existing users to Supabase Auth. This requires two main steps: first, ch
 
     ```ts
     const { data, error } = await supabase.auth.admin.createUser({
-      email: 'foo@example.com',
+      email: 'valid.email@supabase.io',
       password_hash: '$2y$10$a9pghn27d7m0ltXvlX8LiOowy7XfFw0hW0G80OjKYQ1jaoejaA7NC',
       email_confirm: true,
     })
@@ -96,7 +96,7 @@ Migrate existing users to Supabase Auth. This requires two main steps: first, ch
 
     ```ts
     const { data, error } = await supabase.auth.admin.createUser({
-      email: 'foo@example.com',
+      email: 'valid.email@supabase.io',
       password: 'supersecurepassword123!',
     })
     ```
@@ -115,7 +115,7 @@ For passwordless signin via email or phone, check for users with verified email 
 
 ```ts
 const { data, error } = await supabase.auth.admin.createUser({
-  email: 'foo@example.com',
+  email: 'valid.email@supabase.io',
   email_confirm: true,
 })
 ```
@@ -151,7 +151,7 @@ Both columns are accessible from the admin user methods. To create a user with c
 
 ```ts
 const { data, error } = await supabase.auth.admin.createUser({
-  email: 'foo@example.com',
+  email: 'valid.email@supabase.io',
   user_metadata: {
     full_name: 'Foo Bar',
   },
@@ -207,7 +207,7 @@ New users in Supabase Auth will always be created with a UUID V4 ID by default.
 // specify a custom id
 const { data, error } = await supabase.auth.admin.createUser({
   id: 'e7f5ae65-376e-4d05-a18c-10a91295727a',
-  email: 'foo@example.com',
+  email: 'valid.email@supabase.io',
 })
 ```
 

--- a/apps/docs/content/guides/platform/read-replicas.mdx
+++ b/apps/docs/content/guides/platform/read-replicas.mdx
@@ -142,7 +142,7 @@ const supabase = createClient(supabaseUrl, supabaseKey, {
 async function createUser() {
   // Make the Auth call to create a user
   const { data, error } = await supabase.auth.signUp({
-    email: 'my-new-user@example.com',
+    email: 'valid.email@supabase.io',
     password: 'my--really-strong-password',
   })
 


### PR DESCRIPTION
The purpose of this change is to reduce the bounce back rate of the default email provider at Supabase. This change will allow users to continue copying examples from the docs. Without it, an upcoming change in supabase/auth[1] will begin rejecting these invalid emails.

[1] https://github.com/supabase/auth/pull/1845