### PR TITLE
docs: clarify language in range documentation

### DIFF
--- a/apps/docs/spec/supabase_py_v2.yml
+++ b/apps/docs/spec/supabase_py_v2.yml
@@ -6006,11 +6006,11 @@ functions:
   - id: range
     title: range()
     params:
-      - name: start
+      - name: from
         isOptional: false
         type: number
         description: The starting index from which to limit the result.
-      - name: end
+      - name: to
         isOptional: false
         type: number
         description: The last index to which to limit the result.
@@ -6019,7 +6019,7 @@ functions:
         type: string
         description: Set this to limit rows of foreign tables instead of the parent table.
     notes: |
-      Limit the query result by starting at an offset (`from`) and ending at the offset (`from + to`). Only records within this range are returned. This respects the query order and if there is no order clause the range could behave unexpectedly.
+      Limit the query result by starting at an offset (`from`) and ending at the offset (`to`). Only records within this range are returned. This respects the query order and if there is no order clause the range could behave unexpectedly.
 
       The `from` and `to` values are 0-based and inclusive: `range(1, 3)` will include the second, third and fourth rows of the query.
     examples:

--- a/apps/docs/spec/supabase_py_v2.yml
+++ b/apps/docs/spec/supabase_py_v2.yml
@@ -6006,11 +6006,11 @@ functions:
   - id: range
     title: range()
     params:
-      - name: from
+      - name: start
         isOptional: false
         type: number
         description: The starting index from which to limit the result.
-      - name: to
+      - name: end
         isOptional: false
         type: number
         description: The last index to which to limit the result.
@@ -6019,9 +6019,9 @@ functions:
         type: string
         description: Set this to limit rows of foreign tables instead of the parent table.
     notes: |
-      Limit the query result by starting at an offset (`from`) and ending at the offset (`to`). Only records within this range are returned. This respects the query order and if there is no order clause the range could behave unexpectedly.
+      Limit the query result by starting at an offset (`start`) and ending at the offset (`end`). Only records within this range are returned. This respects the query order and if there is no order clause the range could behave unexpectedly.
 
-      The `from` and `to` values are 0-based and inclusive: `range(1, 3)` will include the second, third and fourth rows of the query.
+      The `start` and `end` values are 0-based and inclusive: `range(1, 3)` will include the second, third and fourth rows of the query.
     examples:
       - id: with-select
         name: With `select()`


### PR DESCRIPTION
Fixes #908 in supabase/supabase-py repo
- Change parameter names from start/end to from/to for consistency
- Fix incorrect offset description in notes section

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

The python range documentation has the following issues:
1. Inconsistent naming - The parameter list uses `start` and `end` while the description uses `from` and `to`
2. Incorrect offset end description - The description states that the result is limited by "starting at an offset (`from`) and ending at the offset (`from + to`)". This is incorrect as the end index is just `to`. E.g. `range(20, 30)` returns 11 items (20-30), not 51 items (20-20+30)

## What is the new behavior?

1. Range indices are referenced as `from` and `to` in parameter list. This is aligned with the documentation for other languages.
2. Description states that range offset ends at just `to`

## Additional context

Add any other context or screenshots.
![Screenshot 2024-12-07 172643](https://github.com/user-attachments/assets/ea3141fa-5703-478d-ac45-38e28784ee51)
