### PR TITLE
deprecated: tokens and new token banner

### DIFF
--- a/apps/studio/components/interfaces/Account/NewTokenBanner.tsx
+++ b/apps/studio/components/interfaces/Account/NewTokenBanner.tsx
@@ -1,5 +1,6 @@
 import { NewAccessToken } from 'data/access-tokens/access-tokens-create-mutation'
-import { Alert, Input } from 'ui'
+import { Input } from 'ui'
+import { Admonition } from 'ui-patterns'
 
 interface NewTokenBannerProps {
   token: NewAccessToken
@@ -7,22 +8,28 @@ interface NewTokenBannerProps {
 
 const NewTokenBanner = ({ token }: NewTokenBannerProps) => {
   return (
-    <Alert withIcon variant="success" title="Successfully generated a new token!">
-      <div className="w-full space-y-2">
-        <p className="text-sm">
-          Do copy this access token and store it in a secure place - you will not be able to see it
-          again.
-        </p>
-        <Input
-          copy
-          readOnly
-          size="small"
-          className="max-w-xl input-mono"
-          value={token.token}
-          onChange={() => {}}
-        />
-      </div>
-    </Alert>
+    <Admonition
+      type="default"
+      title="Successfully generated a new token!"
+      description={
+        <>
+          <div className="w-full space-y-2">
+            <p className="text-sm">
+              Do copy this access token and store it in a secure place - you will not be able to see
+              it again.
+            </p>
+            <Input
+              copy
+              readOnly
+              size="small"
+              className="max-w-xl input-mono"
+              value={token.token}
+              onChange={() => {}}
+            />
+          </div>
+        </>
+      }
+    />
   )
 }
 

--- a/apps/studio/pages/account/tokens.tsx
+++ b/apps/studio/pages/account/tokens.tsx
@@ -10,8 +10,9 @@ import AccountLayout from 'components/layouts/AccountLayout/AccountLayout'
 import { FormHeader } from 'components/ui/Forms/FormHeader'
 import { NewAccessToken } from 'data/access-tokens/access-tokens-create-mutation'
 import type { NextPageWithLayout } from 'types'
-import { Alert, Button } from 'ui'
+import { Button } from 'ui'
 import { ExternalLink } from 'lucide-react'
+import { Admonition } from 'ui-patterns'
 
 const UserAccessTokens: NextPageWithLayout = () => {
   const [newToken, setNewToken] = useState<NewAccessToken | undefined>()
@@ -50,11 +51,10 @@ const UserAccessTokens: NextPageWithLayout = () => {
         </div>
       </div>
       <div className="flex items-center justify-between">
-        <Alert
-          withIcon
-          className="mb-6 w-full"
-          variant="warning"
+        <Admonition
+          type="warning"
           title="Personal access tokens can be used to control your whole account and use features added in the future. Be careful when sharing them!"
+          className="mb-6 w-full"
         />
       </div>
       <div className="space-y-4">


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

Yes

## What kind of change does this PR introduce?

Supabase Studio - [Token](https://supabase.com/dashboard/account/tokens)

## What is the current behavior?

The alerts are using the deprecated component:

<img width="1021" alt="Screenshot 2024-12-08 at 16 49 49" src="https://github.com/user-attachments/assets/95b9adc9-30d0-46e0-8300-0831d7acaa6c">


## What is the new behavior?

Changed to use `<Admonition />`:

<img width="1021" alt="Screenshot 2024-12-08 at 16 58 46" src="https://github.com/user-attachments/assets/7b7a9d61-fbef-491f-9f60-6343943fa9e0">
