### PR TITLE
deprecated: alert - delete payment method modal

### DIFF
--- a/apps/studio/components/interfaces/Organization/BillingSettings/PaymentMethods/DeletePaymentMethodModal.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/PaymentMethods/DeletePaymentMethodModal.tsx
@@ -1,9 +1,10 @@
 import { useParams } from 'common'
 import { toast } from 'sonner'
-import { Alert, Button, Modal } from 'ui'
+import { Button, Modal } from 'ui'
 
 import { useOrganizationPaymentMethodDeleteMutation } from 'data/organizations/organization-payment-method-delete-mutation'
 import type { OrganizationPaymentMethod } from 'data/organizations/organization-payment-methods-query'
+import { Admonition } from 'ui-patterns'
 
 export interface DeletePaymentMethodModalProps {
   selectedPaymentMethod?: OrganizationPaymentMethod
@@ -55,9 +56,11 @@ const DeletePaymentMethodModal = ({
       }
     >
       <Modal.Content>
-        <Alert withIcon variant="info" title="This will permanently delete your payment method.">
-          <p>You can re-add the payment method any time.</p>
-        </Alert>
+        <Admonition
+          type="default"
+          title="This will permanently delete your payment method."
+          description="You can re-add the payment method any time."
+        />
       </Modal.Content>
     </Modal>
   )


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Supabase Studio - [Org Billing](https://supabase.com/dashboard/org/_/billing)

## What is the current behavior?

The component uses the deprecated `<Alert />' component:

<img width="529" alt="Screenshot 2024-12-08 at 17 48 26" src="https://github.com/user-attachments/assets/fa4347e3-f81b-4053-a08e-2803d8f2efa2">

## What is the new behavior?

Changed to use `<Admonition />:

<img width="529" alt="Screenshot 2024-12-08 at 17 50 15" src="https://github.com/user-attachments/assets/f17c5fb3-0a7e-4c2b-aec5-cdef7b180c0e">

