### PR TITLE
fix: add frequently asked questions to auth identity linking docs

### DIFF
--- a/apps/docs/content/guides/auth/auth-identity-linking.mdx
+++ b/apps/docs/content/guides/auth/auth-identity-linking.mdx
@@ -173,7 +173,7 @@ if google_identity:
 </TabPanel>
 </Tabs>
 
-## Frequently Asked Questions
+## Frequently asked questions
 
 ### How do I add email with password login to my OAuth account?
 Call the `updateUser({ email: '<insert-desired-email>@supabase.io', password: '<insert-desired-password>'})` to add email with password authentication to an account created with an OAuth provider (Google, GitHub, etc.).

--- a/apps/docs/content/guides/auth/auth-identity-linking.mdx
+++ b/apps/docs/content/guides/auth/auth-identity-linking.mdx
@@ -178,5 +178,5 @@ if google_identity:
 ### How to add email/password login to an OAuth account?
 Call the `updateUser({ password: 'validpassword'})` to add email with password authentication to an account created with an OAuth provider (Google, GitHub, etc.).
 
-### What happens if I sign up with email after OAuth?
+### Can you sign up with email if already using OAuth?
 If you try to create an email account after previously signing up with OAuth using the same email, you'll receive an obfuscated user response with no verification email sent. This prevents user enumeration attacks.

--- a/apps/docs/content/guides/auth/auth-identity-linking.mdx
+++ b/apps/docs/content/guides/auth/auth-identity-linking.mdx
@@ -176,7 +176,9 @@ if google_identity:
 ## Frequently asked questions
 
 ### How to add email/password login to an OAuth account?
+
 Call the `updateUser({ password: 'validpassword'})` to add email with password authentication to an account created with an OAuth provider (Google, GitHub, etc.).
 
 ### Can you sign up with email if already using OAuth?
+
 If you try to create an email account after previously signing up with OAuth using the same email, you'll receive an obfuscated user response with no verification email sent. This prevents user enumeration attacks.

--- a/apps/docs/content/guides/auth/auth-identity-linking.mdx
+++ b/apps/docs/content/guides/auth/auth-identity-linking.mdx
@@ -175,8 +175,8 @@ if google_identity:
 
 ## Frequently asked questions
 
-### How do I add email with password login to my OAuth account?
-Call the `updateUser({ email: '<insert-desired-email>@supabase.io', password: '<insert-desired-password>'})` to add email with password authentication to an account created with an OAuth provider (Google, GitHub, etc.).
+### How to add email/password login to an OAuth account?
+Call the `updateUser({ password: 'validpassword'})` to add email with password authentication to an account created with an OAuth provider (Google, GitHub, etc.).
 
 ### What happens if I sign up with email after OAuth?
 If you try to create an email account after previously signing up with OAuth using the same email, you'll receive an obfuscated user response with no verification email sent. This prevents user enumeration attacks.

--- a/apps/docs/content/guides/auth/auth-identity-linking.mdx
+++ b/apps/docs/content/guides/auth/auth-identity-linking.mdx
@@ -172,3 +172,11 @@ if google_identity:
 
 </TabPanel>
 </Tabs>
+
+## Frequently Asked Questions
+
+### How do I add email with password login to my OAuth account?
+Call the `updateUser({ email: '<insert-desired-email>@supabase.io', password: '<insert-desired-password>'})` to add email with password authentication to an account created with an OAuth provider (Google, GitHub, etc.).
+
+### What happens if I sign up with email after OAuth?
+If you try to create an email account after previously signing up with OAuth using the same email, you'll receive an obfuscated user response with no verification email sent. This prevents user enumeration attacks.


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

Adds a frequently asked questions section in response to a support ticket with the intention of making scenarios clearer for users coming in fresh to Supabase Auth. 

This is not exactly linking related but guessing the questions if any would typically come when the developer interacts with this page. Open to exposing this information on another separate page if folks have one in mind