### PR TITLE
fix: include branches exceeding disk quota

### DIFF
--- a/apps/studio/components/interfaces/Organization/Usage/UsageSection/DiskUsage.tsx
+++ b/apps/studio/components/interfaces/Organization/Usage/UsageSection/DiskUsage.tsx
@@ -63,7 +63,11 @@ const DiskUsage = ({
 
             const isActiveProject = project.status !== PROJECT_STATUS.INACTIVE
 
-            return (!project.is_branch || isBranchExceedingFreeQuota) && isActiveProject
+            const isHostedOnAws = project.databases.every((db) => db.cloud_provider === 'AWS')
+
+            return (
+              (!project.is_branch || isBranchExceedingFreeQuota) && isActiveProject && isHostedOnAws
+            )
           })
           .filter((it) => it.ref === projectRef || !projectRef)
       : []

--- a/apps/studio/components/interfaces/Organization/Usage/UsageSection/DiskUsage.tsx
+++ b/apps/studio/components/interfaces/Organization/Usage/UsageSection/DiskUsage.tsx
@@ -53,18 +53,29 @@ const DiskUsage = ({
     }
   )
 
+  const relevantProjects = useMemo(() => {
+    return diskUsage
+      ? diskUsage.projects
+          .filter((project) => {
+            // We do want to show branches that are exceeding the 8 GB limit, as people could have persistent or very long-living branches
+            const isBranchExceedingFreeQuota =
+              project.is_branch && project.databases.some((db) => (db.disk_volume_size_gb ?? 8) > 8)
+
+            const isActiveProject = project.status !== PROJECT_STATUS.INACTIVE
+
+            return (!project.is_branch || isBranchExceedingFreeQuota) && isActiveProject
+          })
+          .filter((it) => it.ref === projectRef || !projectRef)
+      : []
+  }, [diskUsage, projectRef])
+
   const hasProjectsExceedingDiskSize = useMemo(() => {
-    if (diskUsage) {
-      return diskUsage.projects.some((it) =>
-        it.databases.some(
-          (db) =>
-            db.type === 'READ_REPLICA' || (db.disk_volume_size_gb && db.disk_volume_size_gb > 8)
-        )
+    return relevantProjects.some((it) =>
+      it.databases.some(
+        (db) => db.type === 'READ_REPLICA' || (db.disk_volume_size_gb && db.disk_volume_size_gb > 8)
       )
-    } else {
-      return false
-    }
-  }, [diskUsage])
+    )
+  }, [relevantProjects])
 
   const gp3UsageInPeriod = usage?.usages.find(
     (it) => it.metric === PricingMetric.DISK_SIZE_GB_HOURS_GP3
@@ -72,14 +83,6 @@ const DiskUsage = ({
   const io2UsageInPeriod = usage?.usages.find(
     (it) => it.metric === PricingMetric.DISK_SIZE_GB_HOURS_IO2
   )
-
-  const relevantProjects = useMemo(() => {
-    return diskUsage
-      ? diskUsage.projects
-          .filter((it) => !it.is_branch && it.status !== PROJECT_STATUS.INACTIVE)
-          .filter((it) => it.ref === projectRef || !projectRef)
-      : []
-  }, [diskUsage, projectRef])
 
   return (
     <div id={attribute.anchor} className="scroll-my-12">


### PR DESCRIPTION
Fixes two issues:

- The check for exceeding disk size should only look at relevant projects and ignore projects that are filtered out
- We now include branches that exceed the 8 GB disk, as customers can have long-running / persistent branches
