### PR TITLE
Update connection-management.mdx | removed realtime role

### DIFF
--- a/apps/docs/content/guides/database/connection-management.mdx
+++ b/apps/docs/content/guides/database/connection-management.mdx
@@ -70,11 +70,10 @@ The usename can be used to identify the source:
 
 | Role                         | API/Tool                                                                  |
 | ---------------------------- | ------------------------------------------------------------------------- |
-| supabase_admin               | Used by Supabase to configure projects and for monitoring                 |
+| supabase_admin               | Used by Supabase for monitoring and by Realtime                           |
 | authenticator                | Data API (PostgREST)                                                      |
 | supabase_auth_admin          | Auth                                                                      |
 | supabase_storage_admin       | Storage                                                                   |
-| supabase_realtime_admin      | Realtime                                                                  |
 | supabase_replication_admin   | Synchronizes Read Replicas                                                |
 | postgres                     | Supabase Dashboard and External Tools (e.g., Prisma, SQLAlchemy, PSQL...) |
 | Custom roles defined by user | External Tools (e.g., Prisma, SQLAlchemy, PSQL...)                        |


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

References realtime role

## What is the new behavior?

Realtime requires superuser access for replication, so it connects using the `supabase_admin` role. Updated the documentation to clarify this.
