### PR TITLE
feat/ mono font table editor

### DIFF
--- a/apps/studio/styles/grid.scss
+++ b/apps/studio/styles/grid.scss
@@ -13,6 +13,7 @@
   @apply text-grid;
   @apply border-secondary border-r border-b;
   @apply text-foreground;
+  @apply font-mono;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

- uses mono font in table editor
- because it looks good

## Additional context

Add any other context or screenshots.

before
<img width="1221" alt="Screenshot 2024-12-10 at 14 25 39" src="https://github.com/user-attachments/assets/f0874c85-e528-49de-b283-e9cccc24184c">

after
<img width="1231" alt="Screenshot 2024-12-10 at 14 25 34" src="https://github.com/user-attachments/assets/51d7a975-5f0a-4d06-95fb-a91c8eee5d06">

