### PR TITLE
docs: update instructions for iOS google sign in

### DIFF
--- a/apps/docs/content/guides/auth/social-login/auth-google.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-google.mdx
@@ -166,9 +166,9 @@ To use Google's pre-built signin buttons:
 
     ### Configuration [#ios-configuration]
 
-    1. Follow the integration instructions on the [get started with Google Sign-In](https://developers.google.com/identity/sign-in/ios/start-integrating) for iOS guide.
+    1. Follow the integration instructions on the [get started with Google Sign-In](https://developers.google.com/identity/sign-in/ios/start-integrating) for the iOS guide.
     2. Configure the [OAuth Consent Screen](https://console.cloud.google.com/apis/credentials/consent). This information is shown to the user when giving consent to your app. In particular, make sure you have set up links to your app's privacy policy and terms of service.
-    3. Add only the web client ID from step 1 in the [Google provider on the Supabase Dashboard](https://supabase.com/dashboard/project/_/auth/providers), under _Client IDs_. Enable the `Skip nonce check` option.
+    3. Add web client ID and iOS client ID from step 1 in the [Google provider on the Supabase Dashboard](https://supabase.com/dashboard/project/_/auth/providers), under _Client IDs_, separated by a comma. Enable the `Skip nonce check` option.
 
   </TabPanel>
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the new behavior?

Update instructions for iOS google sign in, instruct user to add both web client ID and iOS client ID, under _Client IDs_ on Supabase Dashboard, by using both IDs, both OAuth and ID token methods should work.

## Additional Context
https://github.com/supabase/supabase-swift/issues/221