### PR TITLE
fix: Change the users infinite query to use like instead of ilike

### DIFF
--- a/apps/studio/data/auth/users-infinite-query.ts
+++ b/apps/studio/data/auth/users-infinite-query.ts
@@ -45,7 +45,7 @@ export const getUsersSQL = ({
 
   if (hasValidKeywords) {
     conditions.push(
-      `id::text ilike '%${keywords}%' or email ilike '%${keywords}%' or phone ilike '%${keywords}%'`
+      `id::text like '%${keywords}%' or email like '%${keywords}%' or phone like '%${keywords}%'`
     )
   }
 


### PR DESCRIPTION
This PR changes the Users dashboard to use `LIKE` instead of `ILIKE` when searching for a user by id, email or phone. This is technically ok because all ids, emails or phones are already lowercased on insertion.