### PR TITLE
fix(doc): direct connection using supavisor

### DIFF
--- a/apps/docs/content/guides/database/connecting-to-postgres.mdx
+++ b/apps/docs/content/guides/database/connecting-to-postgres.mdx
@@ -84,7 +84,7 @@ Get your project's direct string from the [Database Settings](/dashboard/project
 
 ## Supavisor session mode
 
-The session mode connection string connects to your Postgres instance via a proxy. This is ideal for persistent servers when IPv4 is not supported.
+The session mode connection string connects to your Postgres instance via a proxy. This is ideal for persistent servers when IPv6 is not supported.
 
 The connection string looks like this:
 


### PR DESCRIPTION
- fix typo on documentation where the intend to be `IPv6` instead of `IPv4`

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update/fix

## Additional context

Typo where the intend to say `IPv6 is not supported` instead of `IPv4 is not supported`

![image](https://github.com/user-attachments/assets/9d013001-1e32-4929-aaca-711e965d21fb)

