### PR TITLE
ref: Use non-deprecated delete user endpoint

### DIFF
--- a/apps/studio/components/interfaces/Auth/Users/UserDropdown.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/UserDropdown.tsx
@@ -98,7 +98,8 @@ const UserDropdown = ({
   async function handleDelete() {
     await timeout(200)
     if (!ref) return console.error('Project ref is required')
-    deleteUser({ projectRef: ref, user })
+    if (!user.id) return console.error('User id is required')
+    deleteUser({ projectRef: ref, userId: user.id })
   }
 
   async function handleDeleteFactors() {

--- a/apps/studio/components/interfaces/Auth/Users/UserOverview.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/UserOverview.tsx
@@ -132,7 +132,10 @@ export const UserOverview = ({ user, onDeleteSuccess }: UserOverviewProps) => {
   const handleDelete = async () => {
     await timeout(200)
     if (!projectRef) return console.error('Project ref is required')
-    deleteUser({ projectRef, user })
+    if (user.id === undefined) {
+      return toast.error(`Failed to delete user: User ID not found`)
+    }
+    deleteUser({ projectRef, userId: user.id })
   }
 
   const handleDeleteFactors = async () => {
@@ -142,7 +145,7 @@ export const UserOverview = ({ user, onDeleteSuccess }: UserOverviewProps) => {
   }
 
   const handleUnban = () => {
-    if (projectRef === undefined) return console.error('Proejct ref is required')
+    if (projectRef === undefined) return console.error('Project ref is required')
     if (user.id === undefined) {
       return toast.error(`Failed to ban user: User ID not found`)
     }

--- a/apps/studio/data/auth/user-delete-mutation.ts
+++ b/apps/studio/data/auth/user-delete-mutation.ts
@@ -4,17 +4,15 @@ import { toast } from 'sonner'
 import { del, handleError } from 'data/fetchers'
 import type { ResponseError } from 'types'
 import { authKeys } from './keys'
-import type { User } from './users-infinite-query'
 
 export type UserDeleteVariables = {
   projectRef: string
-  user: User
+  userId: string
 }
 
-export async function deleteUser({ projectRef, user }: UserDeleteVariables) {
-  const { data, error } = await del('/platform/auth/{ref}/users', {
-    params: { path: { ref: projectRef } },
-    body: user,
+export async function deleteUser({ projectRef, userId }: UserDeleteVariables) {
+  const { data, error } = await del('/platform/auth/{ref}/users/{id}', {
+    params: { path: { ref: projectRef, id: userId } },
   })
   if (error) handleError(error)
   return data


### PR DESCRIPTION
Fixes an issue when someone modifies `auth.users` schema and tries to delete a user by passing whole user object to the endpoint.