### PR TITLE
Chore/update rules in generate v3

### DIFF
--- a/apps/studio/components/ui/AIAssistantPanel/Message.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/Message.tsx
@@ -107,6 +107,18 @@ export const Message = function Message({
             code: (props: any) => {
               return <code className={cn('text-xs', props.className)}>{props.children}</code>
             },
+            a: (props: any) => {
+              return (
+                <a
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  href={props.href}
+                  className="underline transition underline-offset-2 decoration-foreground-lighter hover:decoration-foreground text-foreground"
+                >
+                  {props.children}
+                </a>
+              )
+            },
           }}
         >
           {content}

--- a/apps/studio/pages/api/ai/sql/generate-v3.ts
+++ b/apps/studio/pages/api/ai/sql/generate-v3.ts
@@ -78,11 +78,12 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse) {
 
       When generating tables, do the following:
       - Ensure that all tables always have a primary key
+      - Ensure that all tables have RLS enabled. Inform the user that they will need to create RLS policies before being able to read or write to the table over Supabase APIs.
       - For primary keys, always use "id bigint primary key generated always as identity" (not serial)
       - Prefer creating foreign key references in the create statement
       - Prefer 'text' over 'varchar'
       - Prefer 'timestamp with time zone' over 'date'
-      - If a foreign key is created, include a statement to create database index on the columns involved in the foreign key. This is a best practice as it is common to use foreign key columns in join conditions when querying the database, hence the index will improve the performance of those joins and reduce database resource consumption.
+      - If a foreign key is created, include a statement to create a database index on the columns involved in the foreign key. This is a best practice as it is common to use foreign key columns in join conditions when querying the database, hence the index will improve the performance of those joins and reduce database resource consumption.
 
       Feel free to suggest corrections for suspected typos.
 

--- a/apps/studio/pages/api/ai/sql/generate-v3.ts
+++ b/apps/studio/pages/api/ai/sql/generate-v3.ts
@@ -76,6 +76,7 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse) {
       - In Supabase, the auth schema already has a users table which is used to store users. It is common practice to create a profiles table in the public schema that links to auth.users to store user information instead. You don't need to create a new users table. Never expose the users table in the auth schema through a view in the public schema.
 
       When generating tables, do the following:
+      - Ensure that all tables always have a primary key
       - For primary keys, always use "id bigint primary key generated always as identity" (not serial)
       - Prefer creating foreign key references in the create statement
       - Prefer 'text' over 'varchar'

--- a/apps/studio/pages/api/ai/sql/generate-v3.ts
+++ b/apps/studio/pages/api/ai/sql/generate-v3.ts
@@ -84,10 +84,18 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse) {
       - Prefer 'text' over 'varchar'
       - Prefer 'timestamp with time zone' over 'date'
       - If a foreign key is created, include a statement to create a database index on the columns involved in the foreign key. This is a best practice as it is common to use foreign key columns in join conditions when querying the database, hence the index will improve the performance of those joins and reduce database resource consumption.
+      - If the table is a foreign table, create it in a new schema called private. If the private schema doesnt exist, create it. 
+        - Explain to the user that we create it outside of the public schema as it can present a security risk as foreign tables views cannot be configured to respect RLS policies. Provide this link for users to view more details about the security risk: https://supabase.com/docs/guides/database/database-advisors?queryGroups=lint&lint=0017_foreign_table_in_api
 
       When generating views, do the following:
       - All views should include 'with (security_invoker=on)' clause in the SQL statement for creating views.
       - Place the 'with (security_invoker=on)' immediately after the CREATE VIEW statement, before AS
+      - If the view is a materialized view, create it in a new schema called private. If the private schema doesnt exist, create it. 
+        - Explain to the user that we create it outside of the public schema as it can present a security risk as materialized views cannot be configured to respect RLS policies of the underlying tables they are built upon, nor can they be secured with RLS directly. Provide this link for users to view more details about the security risk: https://supabase.com/docs/guides/database/database-advisors?queryGroups=lint&lint=0016_materialized_view_in_api
+
+      When installing database extensions, do the following:
+      - Never install extensions in the public schema
+      - Extensions should be installed in the extensions schema, or a dedicated schema
 
       Feel free to suggest corrections for suspected typos.
 

--- a/apps/studio/pages/api/ai/sql/generate-v3.ts
+++ b/apps/studio/pages/api/ai/sql/generate-v3.ts
@@ -85,6 +85,10 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse) {
       - Prefer 'timestamp with time zone' over 'date'
       - If a foreign key is created, include a statement to create a database index on the columns involved in the foreign key. This is a best practice as it is common to use foreign key columns in join conditions when querying the database, hence the index will improve the performance of those joins and reduce database resource consumption.
 
+      When generating views, do the following:
+      - All views should include 'with (security_invoker=on)' clause in the SQL statement for creating views.
+      - Place the 'with (security_invoker=on)' immediately after the CREATE VIEW statement, before AS
+
       Feel free to suggest corrections for suspected typos.
 
       # You write row level security policies.

--- a/apps/studio/pages/api/ai/sql/generate-v3.ts
+++ b/apps/studio/pages/api/ai/sql/generate-v3.ts
@@ -90,6 +90,7 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse) {
       - Then retrieve existing RLS policies and guidelines on how to write policies using the getRlsKnowledge tool .
       - Then write new policies or update existing policies based on the prompt
       - When asked to suggest policies, either alter existing policies or add new ones to the public schema.
+      - When writing policies that use a function from the auth schema, ensure that the calls are wrapped with parentheses e.g select auth.uid() should be written as (select auth.uid()) instead
 
       # You write database functions
       Your purpose is to generate a database function with the constraints given by the user. The output may also include a database trigger

--- a/apps/studio/pages/api/ai/sql/generate-v3.ts
+++ b/apps/studio/pages/api/ai/sql/generate-v3.ts
@@ -73,7 +73,7 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse) {
       - Explain what the snippet does in a sentence or two before showing it
       - Use vector(384) data type for any embedding/vector related query
       - When debugging, retrieve sql schema details to ensure sql is correct
-      - In Supabase, the auth schema already has a users table which is used to store users. It is common practice to create a profiles table in the public schema that links to auth.users to store user information instead. You don't need to create a new users table.
+      - In Supabase, the auth schema already has a users table which is used to store users. It is common practice to create a profiles table in the public schema that links to auth.users to store user information instead. You don't need to create a new users table. Never expose the users table in the auth schema through a view in the public schema.
 
       When generating tables, do the following:
       - For primary keys, always use "id bigint primary key generated always as identity" (not serial)

--- a/apps/studio/pages/api/ai/sql/generate-v3.ts
+++ b/apps/studio/pages/api/ai/sql/generate-v3.ts
@@ -73,7 +73,8 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse) {
       - Explain what the snippet does in a sentence or two before showing it
       - Use vector(384) data type for any embedding/vector related query
       - When debugging, retrieve sql schema details to ensure sql is correct
-      - In Supabase, the auth schema already has a users table which is used to store users. It is common practice to create a profiles table in the public schema that links to auth.users to store user information instead. You don't need to create a new users table. Never expose the users table in the auth schema through a view in the public schema.
+      - In Supabase, the auth schema already has a users table which is used to store users. It is common practice to create a profiles table in the public schema that links to auth.users to store user information instead. You don't need to create a new users table.
+      - Never suggest creating a view to retrieve information from the users table of the auth schema. This is against our best practices.
 
       When generating tables, do the following:
       - Ensure that all tables always have a primary key
@@ -81,6 +82,7 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse) {
       - Prefer creating foreign key references in the create statement
       - Prefer 'text' over 'varchar'
       - Prefer 'timestamp with time zone' over 'date'
+      - If a foreign key is created, include a statement to create database index on the columns involved in the foreign key. This is a best practice as it is common to use foreign key columns in join conditions when querying the database, hence the index will improve the performance of those joins and reduce database resource consumption.
 
       Feel free to suggest corrections for suspected typos.
 


### PR DESCRIPTION
- Always have a primary key
- Automatically create an index for foreign keys
- RLS should be enabled by default
- Example prompt: give me tables for countries and cities with foreign keys between them
![Screenshot 2024-12-13 at 11 30 48](https://github.com/user-attachments/assets/a25096db-f1b3-4352-a0b7-caf83e695107)

- Do not expose auth.users in a public.<name> view
![Screenshot 2024-12-13 at 10 59 17](https://github.com/user-attachments/assets/3f7cb6bd-2f6d-4eee-884c-70135433bbcf)

- When writing RLS policies using auth.<function>(), make sure the calls are wrapped with `()`
![Screenshot 2024-12-13 at 10 47 56](https://github.com/user-attachments/assets/f5d6cbf3-7fb4-48af-8b62-a5bed0f3a982)

- Use security invoker for views
![image](https://github.com/user-attachments/assets/ed5fb2b5-a590-4417-8d3e-0796c9bb9191)

- Do not create materialized views in public schema
![image](https://github.com/user-attachments/assets/c7afacde-a4f2-4d01-b90d-905adcbf029e)

- Do not create foreign tables in public schema 
![image](https://github.com/user-attachments/assets/408e971c-2a6d-44ad-ad3b-dd84a87fbd7d)

- Extensions should never be installed in the public schema
![image](https://github.com/user-attachments/assets/122563fd-67dd-487b-b226-cfc3bbe3c6ba)
