### PR TITLE
Fix keyboard shortcut assistant

### DIFF
--- a/apps/studio/components/layouts/ProjectLayout/ProjectLayout.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/ProjectLayout.tsx
@@ -115,7 +115,7 @@ const ProjectLayout = forwardRef<HTMLDivElement, PropsWithChildren<ProjectLayout
 
     useEffect(() => {
       const handler = (e: KeyboardEvent) => {
-        if (e.metaKey && e.code === 'KeyI' && !e.altKey && !e.shiftKey) {
+        if (e.metaKey && e.key === 'i' && !e.altKey && !e.shiftKey) {
           setAiAssistantPanel({ open: !open })
           e.preventDefault()
           e.stopPropagation()


### PR DESCRIPTION
From MDN docs: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code

> For example, the code returned is "KeyQ" for the Q key on a QWERTY layout keyboard, but the same code value also represents the ' key on Dvorak keyboards and the A key on AZERTY keyboards. That makes it impossible to use the value of code to determine what the name of the key is to users if they're not using an anticipated keyboard layout.

> To determine what character corresponds with the key event, use the KeyboardEvent.key property instead.

Swapping to use `key` instead of `code` property to support non qwerty keyboards (we had a feedback that the Cmd I shortcut was overlapping with Cmd C behavior on Dvorak 😅 )