### PR TITLE
fix: (Setting up Server-Side Auth for Next.js) update examples

### DIFF
--- a/apps/docs/content/guides/auth/server-side/nextjs.mdx
+++ b/apps/docs/content/guides/auth/server-side/nextjs.mdx
@@ -122,7 +122,7 @@ export function createClient() {
 ```
 
 ```ts utils/supabase/server.ts
-import { createServerClient, type CookieOptions } from '@supabase/ssr'
+import { createServerClient } from '@supabase/ssr'
 import { cookies } from 'next/headers'
 
 export async function createClient() {
@@ -380,6 +380,8 @@ export async function signup(formData: FormData) {
 ```
 
 ```ts app/error/page.tsx
+'use client'
+
 export default function ErrorPage() {
   return <p>Sorry, something went wrong</p>
 }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

- Unused type included
- Missing `use client` directive on `error.tsx`, causing both runtime and build time failures. ([reference](https://nextjs.org/docs/app/building-your-application/routing/error-handling#using-error-boundaries))

## What is the new behavior?

- Removed unused type
- Added `use client` directive to `error.tsx` to prevent errors.
