### PR TITLE
Docs: add explicit reference to the gis. schema

### DIFF
--- a/apps/docs/content/guides/database/extensions/postgis.mdx
+++ b/apps/docs/content/guides/database/extensions/postgis.mdx
@@ -98,9 +98,9 @@ You can insert geographical data through SQL or through our API.
 insert into public.restaurants
   (name, location)
 values
-  ('Supa Burger', st_point(-73.946823, 40.807416)),
-  ('Supa Pizza', st_point(-73.94581, 40.807475)),
-  ('Supa Taco', st_point(-73.945826, 40.80629));
+  ('Supa Burger', gis.st_point(-73.946823, 40.807416)),
+  ('Supa Pizza', gis.st_point(-73.94581, 40.807475)),
+  ('Supa Taco', gis.st_point(-73.945826, 40.80629));
 ```
 
 </TabPanel>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update.

## What is the current behavior?

Running the code below: 
```
insert into public.restaurants
  (name, location)
values
  ('Supa Burger', st_point(-73.946823, 40.807416)),
  ('Supa Pizza', st_point(-73.94581, 40.807475)),
  ('Supa Taco', st_point(-73.945826, 40.80629));
```

Results in the following error in the SQL Editor:
```
ERROR:  42883: function st_point(numeric, numeric) does not exist
LINE 4:   ('Supa Burger', st_point(-73.946823, 40.807416)),
```

Fix: Fully qualify the st_point function. 