### PR TITLE
deprecated: alert - revoke app modal

### DIFF
--- a/apps/studio/components/interfaces/Organization/OAuthApps/RevokeAppModal.tsx
+++ b/apps/studio/components/interfaces/Organization/OAuthApps/RevokeAppModal.tsx
@@ -1,10 +1,11 @@
 import { useParams } from 'common'
 import { Lock } from 'lucide-react'
 import { toast } from 'sonner'
-import { Alert, Modal } from 'ui'
+import { Modal } from 'ui'
 
 import { useAuthorizedAppRevokeMutation } from 'data/oauth/authorized-app-revoke-mutation'
 import type { AuthorizedApp } from 'data/oauth/authorized-apps-query'
+import { Admonition } from 'ui-patterns'
 
 export interface RevokeAppModalProps {
   selectedApp?: AuthorizedApp
@@ -37,10 +38,12 @@ const RevokeAppModal = ({ selectedApp, onClose }: RevokeAppModalProps) => {
       onConfirm={onConfirmDelete}
     >
       <Modal.Content>
-        <Alert withIcon variant="warning" title="This action cannot be undone">
-          {selectedApp?.name} application will no longer have access to your organization's settings
-          and projects.
-        </Alert>
+        <Admonition
+          type="warning"
+          title="This action cannot be undone"
+          description={`${selectedApp?.name} application will no longer have access to your organization's settings
+          and projects.`}
+        />
       </Modal.Content>
       <Modal.Content>
         <ul className="space-y-5">


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?


Supabase Studio - [Org Settings > OAuth Apps](https://supabase.com/dashboard/org/_/apps)

## What is the current behavior?

<img width="547" alt="Screenshot 2024-12-15 at 16 11 14" src="https://github.com/user-attachments/assets/d09ca75a-4f5b-445d-a08f-cac2c3d9695d" />


## What is the new behavior?

<img width="547" alt="Screenshot 2024-12-15 at 16 18 02" src="https://github.com/user-attachments/assets/173b8c8f-c1e2-4d48-8ad5-07ac83517ce9" />
