### PR TITLE
Normalize format for .env.example

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -19,9 +19,11 @@ POSTGRES_DB=postgres
 POSTGRES_PORT=5432
 # default user is postgres
 
+
 ############
 # Supavisor -- Database pooler
 ############
+
 POOLER_PROXY_PORT_TRANSACTION=6543
 POOLER_DEFAULT_POOL_SIZE=20
 POOLER_MAX_CLIENT_CONN=100
@@ -95,8 +97,9 @@ OPENAI_API_KEY=
 
 ############
 # Functions - Configuration for Functions
-############
 # NOTE: VERIFY_JWT applies to all functions. Per-function VERIFY_JWT is not supported yet.
+############
+
 FUNCTIONS_VERIFY_JWT=false
 
 ############


### PR DESCRIPTION
There were some inconsistencies in the structure of the comments mostly regarding spacing

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Improves redability of the `.env.example` file

## What is the current behavior?

It works fine but has some inconsistencies in its structure

## What is the new behavior?

Improved redability

## Additional context


