### PR TITLE
Fixed issue where changing postgres password breaks analytics container due to misaligned logflare version

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -328,7 +328,7 @@ services:
 
   analytics:
     container_name: supabase-analytics
-    image: supabase/logflare:1.4.0
+    image: supabase/logflare:1.8.9
     healthcheck:
       test: [ "CMD", "curl", "http://localhost:4000/health" ]
       timeout: 5s


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

This is a bugfix where the self hosted version of the app had some lagging dependency updates leading to a bugged version of logflare not working for all new users. This resolves the issue where updating a postgres password doesn't inherently update and work, but instead breaks the analytics container and ruins your deploy.

To reproduce, simply change the postgres password for a self deployed instance of supabase, and attempt to re-deploy. You should fail to launch on mac osx at minimum, and also debian Jesse. 

To fix, update and no cache build the docker container with logflare 1.8.9 and the issue no longer persists. This will fix the issues experienced by users below, as it did for our app! Enjoy the fix!

## What is the current behavior?

[issue](https://github.com/supabase/supabase/issues/28348)

## What is the new behavior?

This issue is fully resolved with this small fix.

## Additional context

👯 🕺 💃 
