### PR TITLE
chore: add code owners for event documentation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,3 +17,5 @@
 /apps/studio/components/interfaces/Organization/BillingSettings/    @supabase/security
 /apps/studio/components/interfaces/Organization/Documents/          @supabase/security
 /apps/studio/pages/new/index.tsx                                    @supabase/security
+
+/apps/studio/lib/constants/telemetry.ts @4L3k51 @loong @pamelachia


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES/NO

## What kind of change does this PR introduce?

As we advance, Aleksi, Pam, or I should review changes to telemetry events.