### PR TITLE
Ensure diff editor and sql editor do not show up together

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/InlineWidget.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/InlineWidget.tsx
@@ -40,10 +40,11 @@ const InlineWidget = ({
   editor,
   id,
   beforeLineNumber,
-  afterLineNumber,
+  afterLineNumber = 0,
   heightInLines = 1,
 }: PropsWithChildren<InlineWidgetProps>) => {
   const lineNumber = beforeLineNumber ?? afterLineNumber
+  console.log({ lineNumber })
   const key = `${id}-${lineNumber.toString()}`
 
   const containerElement = useMemo(() => document.createElement('div'), [])

--- a/apps/studio/components/interfaces/SQLEditor/InlineWidget.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/InlineWidget.tsx
@@ -44,7 +44,6 @@ const InlineWidget = ({
   heightInLines = 1,
 }: PropsWithChildren<InlineWidgetProps>) => {
   const lineNumber = beforeLineNumber ?? afterLineNumber
-  console.log({ lineNumber })
   const key = `${id}-${lineNumber.toString()}`
 
   const containerElement = useMemo(() => document.createElement('div'), [])

--- a/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
@@ -48,6 +48,7 @@ import {
   TooltipContent_Shadcn_,
   TooltipTrigger_Shadcn_,
   Tooltip_Shadcn_,
+  cn,
 } from 'ui'
 import { subscriptionHasHipaaAddon } from '../Billing/Subscription/Subscription.utils'
 import { AskAIWidget } from './AskAIWidget'
@@ -98,8 +99,6 @@ export const SQLEditor = () => {
     selectedDiffType,
     setSelectedDiffType,
     pendingTitle,
-    setPendingTitle,
-    isAcceptDiffLoading,
     setIsAcceptDiffLoading,
     isDiffOpen,
     defaultSqlDiff,
@@ -721,6 +720,7 @@ export const SQLEditor = () => {
                       <MonacoEditor
                         autoFocus
                         id={id}
+                        className={cn(isDiffOpen && 'hidden')}
                         editorRef={editorRef}
                         monacoRef={monacoRef}
                         executeQuery={executeQuery}


### PR DESCRIPTION
Odd one - this bug somehow only shows up on safari despite the code making sense that the diff editor and sql editor will show up together. Either way, this PR fixes that
![image](https://github.com/user-attachments/assets/fbb8af7b-bfc0-4051-a060-768eec80a9de)
