### PR TITLE
docs: add guide on how to implement retries in supabase-js

### DIFF
--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
@@ -1223,7 +1223,6 @@ export const api: NavMenuConstant = {
         { name: 'Creating API routes', url: '/guides/api/creating-routes' },
         { name: 'How API Keys work', url: '/guides/api/api-keys' },
         { name: 'Securing your API', url: '/guides/api/securing-your-api' },
-        { name: 'Automatic retries', url: '/guides/api/automatic-retries-in-supabase-js' },
       ],
     },
     {

--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
@@ -1223,6 +1223,7 @@ export const api: NavMenuConstant = {
         { name: 'Creating API routes', url: '/guides/api/creating-routes' },
         { name: 'How API Keys work', url: '/guides/api/api-keys' },
         { name: 'Securing your API', url: '/guides/api/securing-your-api' },
+        { name: 'Automatic retries', url: '/guides/api/automatic-retries-in-supabase-js' },
       ],
     },
     {

--- a/apps/docs/content/guides/api/automatic-retries-in-supabase-js.mdx
+++ b/apps/docs/content/guides/api/automatic-retries-in-supabase-js.mdx
@@ -69,7 +69,7 @@ fetchData();
 
 ## 5. Fine-Tuning retries for Specific Requests
 
-If you need different retry logic for certain requests, you can use the `retryOn` with a custom function to inpsect the URL or response and decide whether to retry the request.
+If you need different retry logic for certain requests, you can use the `retryOn` with a custom function to inspect the URL or response and decide whether to retry the request.
 
 ```javascript
 const fetchWithRetry = fetchRetry(fetch, {

--- a/apps/docs/content/guides/api/automatic-retries-in-supabase-js.mdx
+++ b/apps/docs/content/guides/api/automatic-retries-in-supabase-js.mdx
@@ -4,6 +4,10 @@ title: 'How to do automatic retries with `supabase-js`'
 subtitle: 'Learn how to add automatic retries to your Supabase API requests using `fetch-retry`.'
 ---
 
+<Admonition type="danger" title="Note title">
+Note description
+</Admonition>
+
 The `fetch-retry` package allows you to add retry logic to `fetch` requests, making it a useful tool for enhancing the resilience of API calls in your Supabase applications. Here's a step-by-step guide on how to integrate `fetch-retry` with the `supabase-js` library.
 
 ## 1. Install dependencies
@@ -46,10 +50,6 @@ const fetchWithRetry = fetchRetry(fetch, {
   retryOn: [520], // Retry only on Cloudflare errors
 })
 ```
-
-<Admonition type="danger" title="Important: Only Retry 520 Errors by Default">
-In most cases, 520 errors (Cloudflare origin errors) indicate temporary network failures, making them safe to retry.
-</Admonition>
 
 In this example, the `retryDelay` function implements an exponential backoff strategy, and retries are triggered only for specific HTTP status codes.
 

--- a/apps/docs/content/guides/api/automatic-retries-in-supabase-js.mdx
+++ b/apps/docs/content/guides/api/automatic-retries-in-supabase-js.mdx
@@ -19,18 +19,18 @@ npm install @supabase/supabase-js fetch-retry
 The `fetch-retry` package works by wrapping the native `fetch` function. You can create a custom fetch instance with retry logic and pass it to the `supabase-js` client.
 
 ```javascript
-import { createClient } from '@supabase/supabase-js';
-import fetchRetry from 'fetch-retry';
+import { createClient } from '@supabase/supabase-js'
+import fetchRetry from 'fetch-retry'
 
 // Wrap the global fetch with fetch-retry
-const fetchWithRetry = fetchRetry(fetch);
+const fetchWithRetry = fetchRetry(fetch)
 
 // Create a Supabase client instance with the custom fetch
 const supabase = createClient('https://your-supabase-url.supabase.co', 'your-anon-key', {
   global: {
     fetch: fetchWithRetry,
   },
-});
+})
 ```
 
 ## 3. Configure retry options
@@ -44,7 +44,7 @@ const fetchWithRetry = fetchRetry(fetch, {
   retries: 3, // Number of retry attempts
   retryDelay: (attempt) => Math.min(1000 * 2 ** attempt, 30000), // Exponential backoff
   retryOn: [500, 502, 503, 504], // Retry on server errors
-});
+})
 ```
 
 In this example, the `retryDelay` function implements an exponential backoff strategy, and retries are triggered only for specific HTTP status codes.
@@ -55,18 +55,16 @@ With `fetch-retry` integrated, you can use the Supabase client as usual. The ret
 
 ```javascript
 async function fetchData() {
-  const { data, error } = await supabase
-    .from('your_table')
-    .select('*');
+  const { data, error } = await supabase.from('your_table').select('*')
 
   if (error) {
-    console.error('Error fetching data:', error);
+    console.error('Error fetching data:', error)
   } else {
-    console.log('Fetched data:', data);
+    console.log('Fetched data:', data)
   }
 }
 
-fetchData();
+fetchData()
 ```
 
 ## 5. Fine-Tuning retries for specific requests
@@ -112,4 +110,3 @@ By using `retryOn` with a custom function, you can define specific conditions fo
 ## Conclusion
 
 Integrating `fetch-retry` with `supabase-js` is a straightforward way to add robustness to your Supabase API requests. By handling transient errors and implementing retry strategies, you can improve the reliability of your application while maintaining a seamless user experience.
-

--- a/apps/docs/content/guides/api/automatic-retries-in-supabase-js.mdx
+++ b/apps/docs/content/guides/api/automatic-retries-in-supabase-js.mdx
@@ -5,7 +5,8 @@ subtitle: 'Learn how to add automatic retries to your Supabase API requests usin
 ---
 
 <Admonition type="danger" title="Note title">
-Note description
+- You should only enable retries if your requests fail with network errors (e.g. 520 status from Cloudflare)
+- A high number of retries have the potential to exhaust the Data API connection pool, which could result in lower throughput and failed requests.
 </Admonition>
 
 The `fetch-retry` package allows you to add retry logic to `fetch` requests, making it a useful tool for enhancing the resilience of API calls in your Supabase applications. Here's a step-by-step guide on how to integrate `fetch-retry` with the `supabase-js` library.

--- a/apps/docs/content/guides/api/automatic-retries-in-supabase-js.mdx
+++ b/apps/docs/content/guides/api/automatic-retries-in-supabase-js.mdx
@@ -69,21 +69,31 @@ fetchData();
 
 ## 5. Fine-Tuning Retries for Specific Requests
 
-If you need different retry logic for certain requests, you can override the default fetch for specific API calls:
+If you need different retry logic for certain requests, you can use the `retryOn` with a custom function to inpsect the URL or response and decide whether to retry the request.
 
 ```javascript
-async function fetchWithCustomRetry() {
-  const fetchWithCustomOptions = fetchRetry(fetch, {
-    retries: 5,
-    retryDelay: (attempt) => 1000 * attempt, // Linear backoff
-  });
+const fetchWithRetry = fetchRetry(fetch, {
+  retryDelay: (attempt) => Math.min(1000 * 2 ** attempt, 30000),
+  retryOn: (attempt, error, response) => {
+    const shouldRetry
+      = (attempt: number, error: Error | null, response: Response | null) =>
+        attempt < 3
+          && response
+          && response.status >= 500
+          && response.url.includes('rpc/your_stored_procedure')
 
+    if (shouldRetry(attempt, error, response)) {
+      console.log(`Retrying request... Attempt #${attempt}`, response)
+      return true
+    }
+
+    return false
+  }
+})
+
+async function yourStoredProcedure() {
   const { data, error } = await supabase
-    .rpc('your_stored_procedure', {
-      param1: 'value1'
-    }, {
-      fetch: fetchWithCustomOptions
-    });
+    .rpc('your_stored_procedure', { param1: 'value1' });
 
   if (error) {
     console.log('Error executing RPC:', error);
@@ -92,22 +102,10 @@ async function fetchWithCustomRetry() {
   }
 }
 
-fetchWithCustomRetry();
+yourStoredProcedure();
 ```
 
-## 6. Debugging and Logs
-
-To debug retry behavior, you can use the `onRetry` callback to log retry attempts:
-
-```javascript
-const fetchWithRetry = fetchRetry(fetch, {
-  retries: 3,
-  retryDelay: (attempt) => Math.min(1000 * 2 ** attempt, 30000),
-  onRetry: (attempt, error, response) => {
-    console.log(`Retrying request... Attempt #${attempt}`, error || response);
-  },
-});
-```
+By using `retryOn` with a custom function, you can define specific conditions for retrying requests. In this example, the retry logic is applied only to requests targeting a specific stored procedure.
 
 ## Conclusion
 

--- a/apps/docs/content/guides/api/automatic-retries-in-supabase-js.mdx
+++ b/apps/docs/content/guides/api/automatic-retries-in-supabase-js.mdx
@@ -6,7 +6,7 @@ subtitle: 'Learn how to add automatic retries to your Supabase API requests usin
 
 The `fetch-retry` package allows you to add retry logic to `fetch` requests, making it a useful tool for enhancing the resilience of API calls in your Supabase applications. Here's a step-by-step guide on how to integrate `fetch-retry` with the `supabase-js` library.
 
-## 1. Install Dependencies
+## 1. Install dependencies
 
 To get started, ensure you have both `supabase-js` and `fetch-retry` installed in your project:
 
@@ -14,7 +14,7 @@ To get started, ensure you have both `supabase-js` and `fetch-retry` installed i
 npm install @supabase/supabase-js fetch-retry
 ```
 
-## 2. Wrap the Fetch Function
+## 2. Wrap the fetch Function
 
 The `fetch-retry` package works by wrapping the native `fetch` function. You can create a custom fetch instance with retry logic and pass it to the `supabase-js` client.
 
@@ -31,7 +31,7 @@ const supabase = createClient('https://your-supabase-url.supabase.co', 'your-ano
 });
 ```
 
-## 3. Configure Retry Options
+## 3. Configure retry Options
 
 You can configure `fetch-retry` options to control retry behavior, such as the number of retries, retry delay, and which errors should trigger a retry.
 
@@ -47,7 +47,7 @@ const fetchWithRetry = fetchRetry(fetch, {
 
 In this example, the `retryDelay` function implements an exponential backoff strategy, and retries are triggered only for specific HTTP status codes.
 
-## 4. Using the Supabase Client
+## 4. Using the Supabase client
 
 With `fetch-retry` integrated, you can use the Supabase client as usual. The retry logic will automatically apply to all network requests made by `supabase-js`.
 
@@ -67,7 +67,7 @@ async function fetchData() {
 fetchData();
 ```
 
-## 5. Fine-Tuning Retries for Specific Requests
+## 5. Fine-Tuning retries for Specific Requests
 
 If you need different retry logic for certain requests, you can use the `retryOn` with a custom function to inpsect the URL or response and decide whether to retry the request.
 

--- a/apps/docs/content/guides/api/automatic-retries-in-supabase-js.mdx
+++ b/apps/docs/content/guides/api/automatic-retries-in-supabase-js.mdx
@@ -43,9 +43,13 @@ Here is an example with custom retry options:
 const fetchWithRetry = fetchRetry(fetch, {
   retries: 3, // Number of retry attempts
   retryDelay: (attempt) => Math.min(1000 * 2 ** attempt, 30000), // Exponential backoff
-  retryOn: [500, 502, 503, 504], // Retry on server errors
+  retryOn: [520], // Retry only on Cloudflare errors
 })
 ```
+
+<Admonition type="danger" title="Important: Only Retry 520 Errors by Default">
+In most cases, 520 errors (Cloudflare origin errors) indicate temporary network failures, making them safe to retry.
+</Admonition>
 
 In this example, the `retryDelay` function implements an exponential backoff strategy, and retries are triggered only for specific HTTP status codes.
 
@@ -79,7 +83,7 @@ const fetchWithRetry = fetchRetry(fetch, {
       = (attempt: number, error: Error | null, response: Response | null) =>
         attempt < 3
           && response
-          && response.status >= 500
+          && response.status == 520 // Cloudflare errors
           && response.url.includes('rpc/your_stored_procedure')
 
     if (shouldRetry(attempt, error, response)) {

--- a/apps/docs/content/guides/api/automatic-retries-in-supabase-js.mdx
+++ b/apps/docs/content/guides/api/automatic-retries-in-supabase-js.mdx
@@ -67,7 +67,7 @@ async function fetchData() {
 fetchData();
 ```
 
-## 5. Fine-Tuning retries for specific Requests
+## 5. Fine-Tuning retries for specific requests
 
 If you need different retry logic for certain requests, you can use the `retryOn` with a custom function to inspect the URL or response and decide whether to retry the request.
 

--- a/apps/docs/content/guides/api/automatic-retries-in-supabase-js.mdx
+++ b/apps/docs/content/guides/api/automatic-retries-in-supabase-js.mdx
@@ -1,0 +1,115 @@
+---
+id: automatic-retries-in-supabase-js
+title: 'How to do automatic retries with `supabase-js`'
+subtitle: 'Learn how to add automatic retries to your Supabase API requests using `fetch-retry`.'
+---
+
+The `fetch-retry` package allows you to add retry logic to `fetch` requests, making it a useful tool for enhancing the resilience of API calls in your Supabase applications. Here's a step-by-step guide on how to integrate `fetch-retry` with the `supabase-js` library.
+
+## 1. Install Dependencies
+
+To get started, ensure you have both `supabase-js` and `fetch-retry` installed in your project:
+
+```bash
+npm install @supabase/supabase-js fetch-retry
+```
+
+## 2. Wrap the Fetch Function
+
+The `fetch-retry` package works by wrapping the native `fetch` function. You can create a custom fetch instance with retry logic and pass it to the `supabase-js` client.
+
+```javascript
+import { createClient } from '@supabase/supabase-js';
+import fetchRetry from 'fetch-retry';
+
+// Wrap the global fetch with fetch-retry
+const fetchWithRetry = fetchRetry(fetch);
+
+// Create a Supabase client instance with the custom fetch
+const supabase = createClient('https://your-supabase-url.supabase.co', 'your-anon-key', {
+  fetch: fetchWithRetry,
+});
+```
+
+## 3. Configure Retry Options
+
+You can configure `fetch-retry` options to control retry behavior, such as the number of retries, retry delay, and which errors should trigger a retry.
+
+Here is an example with custom retry options:
+
+```javascript
+const fetchWithRetry = fetchRetry(fetch, {
+  retries: 3, // Number of retry attempts
+  retryDelay: (attempt) => Math.min(1000 * 2 ** attempt, 30000), // Exponential backoff
+  retryOn: [500, 502, 503, 504], // Retry on server errors
+});
+```
+
+In this example, the `retryDelay` function implements an exponential backoff strategy, and retries are triggered only for specific HTTP status codes.
+
+## 4. Using the Supabase Client
+
+With `fetch-retry` integrated, you can use the Supabase client as usual. The retry logic will automatically apply to all network requests made by `supabase-js`.
+
+```javascript
+async function fetchData() {
+  const { data, error } = await supabase
+    .from('your_table')
+    .select('*');
+
+  if (error) {
+    console.error('Error fetching data:', error);
+  } else {
+    console.log('Fetched data:', data);
+  }
+}
+
+fetchData();
+```
+
+## 5. Fine-Tuning Retries for Specific Requests
+
+If you need different retry logic for certain requests, you can override the default fetch for specific API calls:
+
+```javascript
+async function fetchWithCustomRetry() {
+  const fetchWithCustomOptions = fetchRetry(fetch, {
+    retries: 5,
+    retryDelay: (attempt) => 1000 * attempt, // Linear backoff
+  });
+
+  const { data, error } = await supabase
+    .rpc('your_stored_procedure', {
+      param1: 'value1'
+    }, {
+      fetch: fetchWithCustomOptions
+    });
+
+  if (error) {
+    console.log('Error executing RPC:', error);
+  } else {
+    console.log('Response:', data);
+  }
+}
+
+fetchWithCustomRetry();
+```
+
+## 6. Debugging and Logs
+
+To debug retry behavior, you can use the `onRetry` callback to log retry attempts:
+
+```javascript
+const fetchWithRetry = fetchRetry(fetch, {
+  retries: 3,
+  retryDelay: (attempt) => Math.min(1000 * 2 ** attempt, 30000),
+  onRetry: (attempt, error, response) => {
+    console.log(`Retrying request... Attempt #${attempt}`, error || response);
+  },
+});
+```
+
+## Conclusion
+
+Integrating `fetch-retry` with `supabase-js` is a straightforward way to add robustness to your Supabase API requests. By handling transient errors and implementing retry strategies, you can improve the reliability of your application while maintaining a seamless user experience.
+

--- a/apps/docs/content/guides/api/automatic-retries-in-supabase-js.mdx
+++ b/apps/docs/content/guides/api/automatic-retries-in-supabase-js.mdx
@@ -27,7 +27,9 @@ const fetchWithRetry = fetchRetry(fetch);
 
 // Create a Supabase client instance with the custom fetch
 const supabase = createClient('https://your-supabase-url.supabase.co', 'your-anon-key', {
-  fetch: fetchWithRetry,
+  global: {
+    fetch: fetchWithRetry,
+  },
 });
 ```
 

--- a/apps/docs/content/guides/api/automatic-retries-in-supabase-js.mdx
+++ b/apps/docs/content/guides/api/automatic-retries-in-supabase-js.mdx
@@ -31,7 +31,7 @@ const supabase = createClient('https://your-supabase-url.supabase.co', 'your-ano
 });
 ```
 
-## 3. Configure retry Options
+## 3. Configure retry options
 
 You can configure `fetch-retry` options to control retry behavior, such as the number of retries, retry delay, and which errors should trigger a retry.
 
@@ -67,7 +67,7 @@ async function fetchData() {
 fetchData();
 ```
 
-## 5. Fine-Tuning retries for Specific Requests
+## 5. Fine-Tuning retries for specific Requests
 
 If you need different retry logic for certain requests, you can use the `retryOn` with a custom function to inspect the URL or response and decide whether to retry the request.
 

--- a/apps/docs/content/guides/api/automatic-retries-in-supabase-js.mdx
+++ b/apps/docs/content/guides/api/automatic-retries-in-supabase-js.mdx
@@ -4,9 +4,10 @@ title: 'How to do automatic retries with `supabase-js`'
 subtitle: 'Learn how to add automatic retries to your Supabase API requests using `fetch-retry`.'
 ---
 
-<Admonition type="danger" title="Note title">
-- You should only enable retries if your requests fail with network errors (e.g. 520 status from Cloudflare)
-- A high number of retries have the potential to exhaust the Data API connection pool, which could result in lower throughput and failed requests.
+<Admonition type="danger" title="Important">
+  - You should only enable retries if your requests fail with network errors (e.g. 520 status from
+  Cloudflare) - A high number of retries have the potential to exhaust the Data API connection pool,
+  which could result in lower throughput and failed requests.
 </Admonition>
 
 The `fetch-retry` package allows you to add retry logic to `fetch` requests, making it a useful tool for enhancing the resilience of API calls in your Supabase applications. Here's a step-by-step guide on how to integrate `fetch-retry` with the `supabase-js` library.

--- a/apps/docs/content/guides/api/automatic-retries-in-supabase-js.mdx
+++ b/apps/docs/content/guides/api/automatic-retries-in-supabase-js.mdx
@@ -6,7 +6,8 @@ subtitle: 'Learn how to add automatic retries to your Supabase API requests usin
 
 <Admonition type="danger" title="Important">
   - You should only enable retries if your requests fail with network errors (e.g. 520 status from
-  Cloudflare) - A high number of retries have the potential to exhaust the Data API connection pool,
+  Cloudflare) 
+  - A high number of retries have the potential to exhaust the Data API connection pool,
   which could result in lower throughput and failed requests.
 </Admonition>
 

--- a/apps/docs/content/guides/api/automatic-retries-in-supabase-js.mdx
+++ b/apps/docs/content/guides/api/automatic-retries-in-supabase-js.mdx
@@ -5,9 +5,8 @@ subtitle: 'Learn how to add automatic retries to your Supabase API requests usin
 ---
 
 <Admonition type="danger" title="Important">
-  - You should only enable retries if your requests fail with network errors (e.g. 520 status from
-  Cloudflare) 
-  - A high number of retries have the potential to exhaust the Data API connection pool,
+  You should only enable retries if your requests fail with network errors (e.g. 520 status from
+  Cloudflare). A high number of retries have the potential to exhaust the Data API connection pool,
   which could result in lower throughput and failed requests.
 </Admonition>
 

--- a/apps/docs/content/guides/api/automatic-retries-in-supabase-js.mdx
+++ b/apps/docs/content/guides/api/automatic-retries-in-supabase-js.mdx
@@ -5,9 +5,9 @@ subtitle: 'Learn how to add automatic retries to your Supabase API requests usin
 ---
 
 <Admonition type="danger" title="Important">
-  You should only enable retries if your requests fail with network errors (e.g. 520 status from
-  Cloudflare). A high number of retries have the potential to exhaust the Data API connection pool,
-  which could result in lower throughput and failed requests.
+
+You should only enable retries if your requests fail with network errors (e.g. 520 status from Cloudflare). A high number of retries have the potential to exhaust the Data API connection pool, which could result in lower throughput and failed requests.
+
 </Admonition>
 
 The `fetch-retry` package allows you to add retry logic to `fetch` requests, making it a useful tool for enhancing the resilience of API calls in your Supabase applications. Here's a step-by-step guide on how to integrate `fetch-retry` with the `supabase-js` library.
@@ -20,7 +20,7 @@ To get started, ensure you have both `supabase-js` and `fetch-retry` installed i
 npm install @supabase/supabase-js fetch-retry
 ```
 
-## 2. Wrap the fetch Function
+## 2. Wrap the fetch function
 
 The `fetch-retry` package works by wrapping the native `fetch` function. You can create a custom fetch instance with retry logic and pass it to the `supabase-js` client.
 

--- a/apps/docs/features/docs/GuidesMdx.template.tsx
+++ b/apps/docs/features/docs/GuidesMdx.template.tsx
@@ -1,6 +1,7 @@
 import { ExternalLink } from 'lucide-react'
 import { type SerializeOptions } from 'next-mdx-remote/dist/types'
 import { type ReactNode } from 'react'
+import ReactMarkdown from 'react-markdown'
 
 import { cn } from 'ui'
 
@@ -78,9 +79,13 @@ const GuideTemplate = ({ meta, content, children, editLink, mdxOptions }: GuideT
           id="sb-docs-guide-main-article"
           className="prose max-w-none"
         >
-          <h1 className="mb-0">{meta?.title || 'Supabase Docs'}</h1>
+          <h1 className="mb-0">
+            <ReactMarkdown>{meta?.title || 'Supabase Docs'}</ReactMarkdown>
+          </h1>
           {meta?.subtitle && (
-            <h2 className="mt-3 text-xl text-foreground-light">{meta.subtitle}</h2>
+            <h2 className="mt-3 text-xl text-foreground-light">
+              <ReactMarkdown>{meta.subtitle}</ReactMarkdown>
+            </h2>
           )}
           <hr className="not-prose border-t-0 border-b my-8" />
           <MDXProviderGuides>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add a new guide on how to properly retry failed requests in `supabase-js` using `fetch-retry`.