### PR TITLE
fix(docs): local dev for troubleshooting sections

### DIFF
--- a/apps/docs/features/docs/Troubleshooting.utils.ts
+++ b/apps/docs/features/docs/Troubleshooting.utils.ts
@@ -2,6 +2,7 @@ import { cache } from 'react'
 import { z } from 'zod'
 
 import { cache_fullProcess_withDevCacheBust } from '~/features/helpers.fs'
+import { IS_PLATFORM } from '~/lib/constants'
 import { supabaseAdmin } from '~/lib/supabaseAdmin'
 import {
   getAllTroubleshootingEntriesInternal,
@@ -88,6 +89,10 @@ export async function getAllTroubleshootingErrors() {
 }
 
 async function getTroubleshootingUpdatedDatesInternal() {
+  if (!IS_PLATFORM) {
+    return new Map<string, Date>()
+  }
+
   const databaseIds = (await getAllTroubleshootingEntries())
     .map((entry) => entry.data.database_id)
     .filter((id) => !id.startsWith('pseudo-'))


### PR DESCRIPTION
Local dev for troubleshooting sections doesn't work because getting the last-updated dates requires database access.

This fix shortcuts the last-updated dates check, so all "last-updated" dates will now show up as today's date for external contributors on local, but at least dev will work.