### PR TITLE
fix: add missing feature preview enabled event def

### DIFF
--- a/apps/studio/data/telemetry/send-event-mutation.ts
+++ b/apps/studio/data/telemetry/send-event-mutation.ts
@@ -13,6 +13,9 @@ import {
   CronJobHistoryClickedEvent,
   CronJobUpdateClickedEvent,
   CronJobUpdatedEvent,
+  FeaturePreviewsClickedEvent,
+  FeaturePreviewEnabledEvent,
+  FeaturePreviewDisabledEvent,
   TelemetryActions,
 } from 'lib/constants/telemetry'
 import { useRouter } from 'next/router'
@@ -27,6 +30,9 @@ export type SendEventVariables =
   | CronJobUpdateClickedEvent
   | CronJobDeleteClickedEvent
   | CronJobHistoryClickedEvent
+  | FeaturePreviewsClickedEvent
+  | FeaturePreviewEnabledEvent
+  | FeaturePreviewDisabledEvent
 
   // TODO remove this once all events are documented
   | {

--- a/apps/studio/lib/constants/telemetry.ts
+++ b/apps/studio/lib/constants/telemetry.ts
@@ -174,6 +174,24 @@ export interface FeaturePreviewsClickedEvent {
 }
 
 /**
+ * A feature preview was enabled by the user through the FeaturePreviewModal.
+ *
+ * The FeaturePreviewModal can be opened clicking at the profile icon at the bottom left corner of the project sidebar.
+ *
+ * @group Events
+ * @source studio
+ */
+export interface FeaturePreviewEnabledEvent {
+  action: TelemetryActions.FEATURE_PREVIEW_ENABLED
+  properties: {
+    /**
+     * Feature key of the preview that was enabled. e.g. supabase-ui-api-side-panel
+     */
+    feature: string
+  }
+}
+
+/**
  * A feature preview was disabled by the user through the FeaturePreviewModal.
  *
  * The FeaturePreviewModal can be opened clicking at the profile icon at the bottom left corner of the project sidebar.


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES/NO

## What kind of change does this PR introduce?

`FeaturePreviewEnabledEvent` was missing. Everything still worked since we still have the 'catch-all' type.