### PR TITLE
Add URL param support to toggle connect UI

### DIFF
--- a/apps/studio/components/interfaces/Connect/Connect.tsx
+++ b/apps/studio/components/interfaces/Connect/Connect.tsx
@@ -1,7 +1,7 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { useParams } from 'common'
 import { ExternalLink, Plug } from 'lucide-react'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { DatabaseConnectionString } from 'components/interfaces/Connect/DatabaseConnectionString'
 import { DatabaseConnectionString as OldDatabaseConnectionString } from 'components/interfaces/Settings/Database/DatabaseSettings/DatabaseConnectionString'
@@ -10,6 +10,7 @@ import Panel from 'components/ui/Panel'
 import { getAPIKeys, useProjectSettingsV2Query } from 'data/config/project-settings-v2-query'
 import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { useFlag } from 'hooks/ui/useFlag'
+import { useUrlState } from 'hooks/ui/useUrlState'
 import { useAppStateSnapshot } from 'state/app-state'
 import {
   Button,
@@ -34,8 +35,10 @@ import ConnectTabContent from './ConnectTabContent'
 
 const Connect = () => {
   const state = useAppStateSnapshot()
+  const { showConnectDialog, setShowConnectDialog } = state
   const { ref: projectRef } = useParams()
   const connectDialogUpdate = useFlag('connectDialogUpdate')
+  const [{ showConnect }, setParams] = useUrlState({ replace: true })
 
   const [connectionObject, setConnectionObject] = useState<ConnectionType[]>(FRAMEWORKS)
   const [selectedParent, setSelectedParent] = useState(connectionObject[0].key) // aka nextjs
@@ -147,9 +150,20 @@ const Connect = () => {
     selectedGrandchild,
   })
 
+  useEffect(() => {
+    if (showConnect === 'true') setShowConnectDialog(true)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [showConnect])
+
   return (
     <>
-      <Dialog open={state.showConnectDialog} onOpenChange={state.setShowConnectDialog}>
+      <Dialog
+        open={state.showConnectDialog}
+        onOpenChange={(open) => {
+          if (!open) setParams({ showConnect: undefined })
+          state.setShowConnectDialog(open)
+        }}
+      >
         <DialogTrigger asChild>
           <Button
             type={connectDialogUpdate ? 'default' : 'primary'}

--- a/apps/studio/components/interfaces/Connect/Connect.tsx
+++ b/apps/studio/components/interfaces/Connect/Connect.tsx
@@ -1,7 +1,7 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { useParams } from 'common'
 import { ExternalLink, Plug } from 'lucide-react'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 
 import { DatabaseConnectionString } from 'components/interfaces/Connect/DatabaseConnectionString'
 import { DatabaseConnectionString as OldDatabaseConnectionString } from 'components/interfaces/Settings/Database/DatabaseSettings/DatabaseConnectionString'
@@ -10,8 +10,7 @@ import Panel from 'components/ui/Panel'
 import { getAPIKeys, useProjectSettingsV2Query } from 'data/config/project-settings-v2-query'
 import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { useFlag } from 'hooks/ui/useFlag'
-import { useUrlState } from 'hooks/ui/useUrlState'
-import { useAppStateSnapshot } from 'state/app-state'
+import { parseAsBoolean, useQueryState } from 'nuqs'
 import {
   Button,
   DIALOG_PADDING_X,
@@ -34,11 +33,13 @@ import ConnectDropdown from './ConnectDropdown'
 import ConnectTabContent from './ConnectTabContent'
 
 const Connect = () => {
-  const state = useAppStateSnapshot()
-  const { showConnectDialog, setShowConnectDialog } = state
   const { ref: projectRef } = useParams()
   const connectDialogUpdate = useFlag('connectDialogUpdate')
-  const [{ showConnect }, setParams] = useUrlState({ replace: true })
+
+  const [showConnect, setShowConnect] = useQueryState(
+    'showConnect',
+    parseAsBoolean.withDefault(false)
+  )
 
   const [connectionObject, setConnectionObject] = useState<ConnectionType[]>(FRAMEWORKS)
   const [selectedParent, setSelectedParent] = useState(connectionObject[0].key) // aka nextjs
@@ -150,153 +151,136 @@ const Connect = () => {
     selectedGrandchild,
   })
 
-  useEffect(() => {
-    if (showConnect === 'true') setShowConnectDialog(true)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [showConnect])
-
   return (
-    <>
-      <Dialog
-        open={state.showConnectDialog}
-        onOpenChange={(open) => {
-          if (!open) setParams({ showConnect: undefined })
-          state.setShowConnectDialog(open)
-        }}
-      >
-        <DialogTrigger asChild>
-          <Button
-            type={connectDialogUpdate ? 'default' : 'primary'}
-            className={cn(connectDialogUpdate && 'rounded-full')}
-            icon={<Plug className="rotate-90" />}
-          >
-            <span>Connect</span>
-          </Button>
-        </DialogTrigger>
-        <DialogContent className={cn('sm:max-w-5xl p-0')} centered={false}>
-          <DialogHeader className={DIALOG_PADDING_X}>
-            <DialogTitle>Connect to your project</DialogTitle>
-            <DialogDescription>
-              Get the connection strings and environment variables for your app
-            </DialogDescription>
-          </DialogHeader>
+    <Dialog open={showConnect} onOpenChange={(open) => setShowConnect(!open ? null : open)}>
+      <DialogTrigger asChild>
+        <Button
+          type={connectDialogUpdate ? 'default' : 'primary'}
+          className={cn(connectDialogUpdate && 'rounded-full')}
+          icon={<Plug className="rotate-90" />}
+        >
+          <span>Connect</span>
+        </Button>
+      </DialogTrigger>
+      <DialogContent className={cn('sm:max-w-5xl p-0')} centered={false}>
+        <DialogHeader className={DIALOG_PADDING_X}>
+          <DialogTitle>Connect to your project</DialogTitle>
+          <DialogDescription>
+            Get the connection strings and environment variables for your app
+          </DialogDescription>
+        </DialogHeader>
 
-          <Tabs_Shadcn_
-            defaultValue="direct"
-            onValueChange={(value) => handleConnectionType(value)}
-          >
-            <TabsList_Shadcn_ className={cn('flex gap-x-4', DIALOG_PADDING_X)}>
-              {CONNECTION_TYPES.map((type) => (
-                <TabsTrigger_Shadcn_ key={type.key} value={type.key} className="px-0">
-                  {type.label}
-                </TabsTrigger_Shadcn_>
-              ))}
-            </TabsList_Shadcn_>
+        <Tabs_Shadcn_ defaultValue="direct" onValueChange={(value) => handleConnectionType(value)}>
+          <TabsList_Shadcn_ className={cn('flex gap-x-4', DIALOG_PADDING_X)}>
+            {CONNECTION_TYPES.map((type) => (
+              <TabsTrigger_Shadcn_ key={type.key} value={type.key} className="px-0">
+                {type.label}
+              </TabsTrigger_Shadcn_>
+            ))}
+          </TabsList_Shadcn_>
 
-            {CONNECTION_TYPES.map((type) => {
-              const hasChildOptions =
-                (connectionObject.find((parent) => parent.key === selectedParent)?.children
-                  .length || 0) > 0
-              const hasGrandChildOptions =
-                (connectionObject
-                  .find((parent) => parent.key === selectedParent)
-                  ?.children.find((child) => child.key === selectedChild)?.children.length || 0) > 0
+          {CONNECTION_TYPES.map((type) => {
+            const hasChildOptions =
+              (connectionObject.find((parent) => parent.key === selectedParent)?.children.length ||
+                0) > 0
+            const hasGrandChildOptions =
+              (connectionObject
+                .find((parent) => parent.key === selectedParent)
+                ?.children.find((child) => child.key === selectedChild)?.children.length || 0) > 0
 
-              if (type.key === 'direct') {
-                return (
-                  <TabsContent_Shadcn_
-                    key="direct"
-                    value="direct"
-                    className={cn('!mt-0', 'p-0', 'flex flex-col gap-6')}
-                  >
-                    <div className={DIALOG_PADDING_Y}>
-                      {connectDialogUpdate ? (
-                        <DatabaseConnectionString />
-                      ) : (
-                        <div className="px-7">
-                          <OldDatabaseConnectionString appearance="minimal" />
-                        </div>
-                      )}
-                    </div>
-                  </TabsContent_Shadcn_>
-                )
-              }
-
+            if (type.key === 'direct') {
               return (
                 <TabsContent_Shadcn_
-                  key={`content-${type.key}`}
-                  value={type.key}
-                  className={cn(DIALOG_PADDING_X, DIALOG_PADDING_Y, '!mt-0')}
+                  key="direct"
+                  value="direct"
+                  className={cn('!mt-0', 'p-0', 'flex flex-col gap-6')}
                 >
-                  <div className="flex justify-between">
-                    <div className="flex items-center gap-3">
-                      <ConnectDropdown
-                        state={selectedParent}
-                        updateState={handleParentChange}
-                        label={
-                          connectionObject === FRAMEWORKS || connectionObject === MOBILES
-                            ? 'Framework'
-                            : 'Tool'
-                        }
-                        items={connectionObject}
-                      />
-                      {selectedParent && hasChildOptions && (
-                        <ConnectDropdown
-                          state={selectedChild}
-                          updateState={handleChildChange}
-                          label="Using"
-                          items={getChildOptions()}
-                        />
-                      )}
-                      {selectedChild && hasGrandChildOptions && (
-                        <ConnectDropdown
-                          state={selectedGrandchild}
-                          updateState={handleGrandchildChange}
-                          label="With"
-                          items={getGrandchildrenOptions()}
-                        />
-                      )}
-                    </div>
-                    {connectionObject.find((item) => item.key === selectedParent)?.guideLink && (
-                      <Button asChild type="default" icon={<ExternalLink strokeWidth={1.5} />}>
-                        <a
-                          target="_blank"
-                          rel="noreferrer"
-                          href={
-                            connectionObject.find((item) => item.key === selectedParent)
-                              ?.guideLink || ''
-                          }
-                        >
-                          {connectionObject.find((item) => item.key === selectedParent)?.label}{' '}
-                          guide
-                        </a>
-                      </Button>
+                  <div className={DIALOG_PADDING_Y}>
+                    {connectDialogUpdate ? (
+                      <DatabaseConnectionString />
+                    ) : (
+                      <div className="px-7">
+                        <OldDatabaseConnectionString appearance="minimal" />
+                      </div>
                     )}
                   </div>
-                  <p className="text-xs text-foreground-lighter my-3">
-                    Add the following files below to your application
-                  </p>
-                  <ConnectTabContent
-                    projectKeys={projectKeys}
-                    filePath={filePath}
-                    className="rounded-b-none"
-                  />
-                  <Panel.Notice
-                    className="border border-t-0 rounded-lg rounded-t-none"
-                    title="New API keys coming Q4 2024"
-                    description={`
-\`anon\` and \`service_role\` API keys will be changing to \`publishable\` and \`secret\` API keys.   
-`}
-                    href="https://github.com/orgs/supabase/discussions/29260"
-                    buttonText="Read the announcement"
-                  />
                 </TabsContent_Shadcn_>
               )
-            })}
-          </Tabs_Shadcn_>
-        </DialogContent>
-      </Dialog>
-    </>
+            }
+
+            return (
+              <TabsContent_Shadcn_
+                key={`content-${type.key}`}
+                value={type.key}
+                className={cn(DIALOG_PADDING_X, DIALOG_PADDING_Y, '!mt-0')}
+              >
+                <div className="flex justify-between">
+                  <div className="flex items-center gap-3">
+                    <ConnectDropdown
+                      state={selectedParent}
+                      updateState={handleParentChange}
+                      label={
+                        connectionObject === FRAMEWORKS || connectionObject === MOBILES
+                          ? 'Framework'
+                          : 'Tool'
+                      }
+                      items={connectionObject}
+                    />
+                    {selectedParent && hasChildOptions && (
+                      <ConnectDropdown
+                        state={selectedChild}
+                        updateState={handleChildChange}
+                        label="Using"
+                        items={getChildOptions()}
+                      />
+                    )}
+                    {selectedChild && hasGrandChildOptions && (
+                      <ConnectDropdown
+                        state={selectedGrandchild}
+                        updateState={handleGrandchildChange}
+                        label="With"
+                        items={getGrandchildrenOptions()}
+                      />
+                    )}
+                  </div>
+                  {connectionObject.find((item) => item.key === selectedParent)?.guideLink && (
+                    <Button asChild type="default" icon={<ExternalLink strokeWidth={1.5} />}>
+                      <a
+                        target="_blank"
+                        rel="noreferrer"
+                        href={
+                          connectionObject.find((item) => item.key === selectedParent)?.guideLink ||
+                          ''
+                        }
+                      >
+                        {connectionObject.find((item) => item.key === selectedParent)?.label} guide
+                      </a>
+                    </Button>
+                  )}
+                </div>
+                <p className="text-xs text-foreground-lighter my-3">
+                  Add the following files below to your application
+                </p>
+                <ConnectTabContent
+                  projectKeys={projectKeys}
+                  filePath={filePath}
+                  className="rounded-b-none"
+                />
+                <Panel.Notice
+                  className="border border-t-0 rounded-lg rounded-t-none"
+                  title="New API keys coming Q4 2024"
+                  description={`
+\`anon\` and \`service_role\` API keys will be changing to \`publishable\` and \`secret\` API keys.   
+`}
+                  href="https://github.com/orgs/supabase/discussions/29260"
+                  buttonText="Read the announcement"
+                />
+              </TabsContent_Shadcn_>
+            )
+          })}
+        </Tabs_Shadcn_>
+      </DialogContent>
+    </Dialog>
   )
 }
 

--- a/apps/studio/components/interfaces/Organization/TeamSettings/TeamSettings.tsx
+++ b/apps/studio/components/interfaces/Organization/TeamSettings/TeamSettings.tsx
@@ -81,6 +81,7 @@ const TeamSettings = () => {
         <ScaffoldFilterAndContent>
           <ScaffoldActionsContainer className="justify-between">
             <Input
+              autoComplete="off"
               icon={<Search size={12} />}
               size="small"
               value={searchString}

--- a/apps/studio/components/interfaces/Organization/TeamSettings/TeamSettings.tsx
+++ b/apps/studio/components/interfaces/Organization/TeamSettings/TeamSettings.tsx
@@ -17,6 +17,7 @@ import { useOrganizationMembersQuery } from 'data/organizations/organization-mem
 import { usePermissionsQuery } from 'data/permissions/permissions-query'
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
 import { useSelectedOrganization } from 'hooks/misc/useSelectedOrganization'
+import { BASE_PATH } from 'lib/constants'
 import { useProfile } from 'lib/profile'
 import { Input } from 'ui'
 import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
@@ -25,13 +26,12 @@ import MembersView from './MembersView'
 import { hasMultipleOwners, useGetRolesManagementPermissions } from './TeamSettings.utils'
 
 const TeamSettings = () => {
-  const { slug } = useParams()
-
   const {
     organizationMembersCreate: organizationMembersCreationEnabled,
     organizationMembersDelete: organizationMembersDeletionEnabled,
   } = useIsFeatureEnabled(['organization_members:create', 'organization_members:delete'])
 
+  const { slug } = useParams()
   const { profile } = useProfile()
   const selectedOrganization = useSelectedOrganization()
   const isOwner = selectedOrganization?.is_owner
@@ -58,7 +58,7 @@ const TeamSettings = () => {
     onSuccess: () => {
       setIsLeaving(false)
       setIsLeaveTeamModalOpen(false)
-      window?.location.replace('/dashboard') // Force reload to clear Store
+      window?.location.replace(BASE_PATH) // Force reload to clear Store
     },
     onError: (error) => {
       setIsLeaving(false)

--- a/apps/studio/components/interfaces/Organization/TeamSettings/TeamSettings.tsx
+++ b/apps/studio/components/interfaces/Organization/TeamSettings/TeamSettings.tsx
@@ -58,7 +58,7 @@ const TeamSettings = () => {
     onSuccess: () => {
       setIsLeaving(false)
       setIsLeaveTeamModalOpen(false)
-      window?.location.replace('/') // Force reload to clear Store
+      window?.location.replace('/dashboard') // Force reload to clear Store
     },
     onError: (error) => {
       setIsLeaving(false)

--- a/apps/studio/components/interfaces/Settings/Infrastructure/Infrastructure.constants.ts
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/Infrastructure.constants.ts
@@ -58,7 +58,7 @@ export const INFRA_ACTIVITY_METRICS: CategoryMeta[] = [
         name: 'Memory',
         unit: 'percentage',
         description:
-          'Memory usage of your server.\nYou might observe elevated memory usage, even with little to no load. Besides Postgres, a wide range of services is running under the hood resulting in an elevated base memory usage.',
+          'Memory usage of your server.\nYou might observe elevated memory usage, even with little to no load. Besides Postgres, a wide range of services are running under the hood resulting in an elevated base memory usage.',
         chartDescription: '',
         links: [
           {

--- a/apps/studio/components/layouts/ProjectLayout/ProjectLayout.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/ProjectLayout.tsx
@@ -1,14 +1,6 @@
 import Head from 'next/head'
 import { useRouter } from 'next/router'
-import {
-  forwardRef,
-  Fragment,
-  PropsWithChildren,
-  ReactNode,
-  useCallback,
-  useEffect,
-  useState,
-} from 'react'
+import { forwardRef, Fragment, PropsWithChildren, ReactNode, useEffect, useState } from 'react'
 
 import { useParams } from 'common'
 import ProjectAPIDocs from 'components/interfaces/ProjectAPIDocs/ProjectAPIDocs'
@@ -22,16 +14,17 @@ import { withAuth } from 'hooks/misc/withAuth'
 import { IS_PLATFORM, PROJECT_STATUS } from 'lib/constants'
 import { useAppStateSnapshot } from 'state/app-state'
 import { useDatabaseSelectorStateSnapshot } from 'state/database-selector'
-import { cn, ResizableHandle, ResizablePanel, ResizablePanelGroup, Sheet, SheetContent } from 'ui'
+import { cn, ResizableHandle, ResizablePanel, ResizablePanelGroup } from 'ui'
+import MobileSheetNav from 'ui-patterns/MobileSheetNav/MobileSheetNav'
 import AppLayout from '../AppLayout/AppLayout'
 import EnableBranchingModal from '../AppLayout/EnableBranchingButton/EnableBranchingModal'
 import BuildingState from './BuildingState'
 import ConnectingState from './ConnectingState'
 import { LayoutHeader } from './LayoutHeader'
 import LoadingState from './LoadingState'
-import NavigationBar from './NavigationBar/NavigationBar'
 import MobileNavigationBar from './NavigationBar/MobileNavigationBar'
 import MobileViewNav from './NavigationBar/MobileViewNav'
+import NavigationBar from './NavigationBar/NavigationBar'
 import { ProjectPausedState } from './PausedState/ProjectPausedState'
 import PauseFailedState from './PauseFailedState'
 import PausingState from './PausingState'
@@ -42,8 +35,6 @@ import RestartingState from './RestartingState'
 import RestoreFailedState from './RestoreFailedState'
 import RestoringState from './RestoringState'
 import { UpgradingState } from './UpgradingState'
-import MobileSheetNav from 'ui-patterns/MobileSheetNav/MobileSheetNav'
-import { useFlag } from 'hooks/ui/useFlag'
 
 // [Joshen] This is temporary while we unblock users from managing their project
 // if their project is not responding well for any reason. Eventually needs a bit of an overhaul
@@ -101,13 +92,12 @@ const ProjectLayout = forwardRef<HTMLDivElement, PropsWithChildren<ProjectLayout
     const router = useRouter()
     const [isClient, setIsClient] = useState(false)
     const [isSheetOpen, setIsSheetOpen] = useState(false)
-    const { ref: projectRef, showConnect } = useParams()
+    const { ref: projectRef } = useParams()
     const selectedOrganization = useSelectedOrganization()
     const selectedProject = useSelectedProject()
-    const { aiAssistantPanel, setAiAssistantPanel, setShowConnectDialog } = useAppStateSnapshot()
+    const { aiAssistantPanel, setAiAssistantPanel } = useAppStateSnapshot()
     const { open } = aiAssistantPanel
 
-    const connectDialogUpdate = useFlag('connectDialogUpdate')
     const projectName = selectedProject?.name
     const organizationName = selectedOrganization?.name
 
@@ -129,11 +119,6 @@ const ProjectLayout = forwardRef<HTMLDivElement, PropsWithChildren<ProjectLayout
     useEffect(() => {
       setIsClient(true)
     }, [])
-
-    useEffect(() => {
-      if (showConnect === 'true' && connectDialogUpdate) setShowConnectDialog(true)
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [showConnect, connectDialogUpdate])
 
     useEffect(() => {
       const handler = (e: KeyboardEvent) => {

--- a/apps/studio/components/layouts/ProjectLayout/ProjectLayout.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/ProjectLayout.tsx
@@ -43,6 +43,7 @@ import RestoreFailedState from './RestoreFailedState'
 import RestoringState from './RestoringState'
 import { UpgradingState } from './UpgradingState'
 import MobileSheetNav from 'ui-patterns/MobileSheetNav/MobileSheetNav'
+import { useFlag } from 'hooks/ui/useFlag'
 
 // [Joshen] This is temporary while we unblock users from managing their project
 // if their project is not responding well for any reason. Eventually needs a bit of an overhaul
@@ -98,13 +99,15 @@ const ProjectLayout = forwardRef<HTMLDivElement, PropsWithChildren<ProjectLayout
     ref
   ) => {
     const router = useRouter()
+    const [isClient, setIsClient] = useState(false)
     const [isSheetOpen, setIsSheetOpen] = useState(false)
-    const { ref: projectRef } = useParams()
+    const { ref: projectRef, showConnect } = useParams()
     const selectedOrganization = useSelectedOrganization()
     const selectedProject = useSelectedProject()
-    const { aiAssistantPanel, setAiAssistantPanel } = useAppStateSnapshot()
+    const { aiAssistantPanel, setAiAssistantPanel, setShowConnectDialog } = useAppStateSnapshot()
     const { open } = aiAssistantPanel
 
+    const connectDialogUpdate = useFlag('connectDialogUpdate')
     const projectName = selectedProject?.name
     const organizationName = selectedOrganization?.name
 
@@ -119,11 +122,18 @@ const ProjectLayout = forwardRef<HTMLDivElement, PropsWithChildren<ProjectLayout
       router.pathname === '/project/[ref]' || router.pathname.includes('/project/[ref]/settings')
     const showPausedState = isPaused && !ignorePausedState
 
-    const [isClient, setIsClient] = useState(false)
+    const handleMobileMenu = () => {
+      setIsSheetOpen(true)
+    }
 
     useEffect(() => {
       setIsClient(true)
     }, [])
+
+    useEffect(() => {
+      if (showConnect === 'true' && connectDialogUpdate) setShowConnectDialog(true)
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [showConnect, connectDialogUpdate])
 
     useEffect(() => {
       const handler = (e: KeyboardEvent) => {
@@ -137,10 +147,6 @@ const ProjectLayout = forwardRef<HTMLDivElement, PropsWithChildren<ProjectLayout
       return () => window.removeEventListener('keydown', handler)
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [open])
-
-    const handleMobileMenu = () => {
-      setIsSheetOpen(true)
-    }
 
     return (
       <AppLayout>

--- a/apps/studio/components/ui/DatabaseSelector.tsx
+++ b/apps/studio/components/ui/DatabaseSelector.tsx
@@ -2,6 +2,7 @@ import { noop } from 'lodash'
 import { Check, ChevronDown, Loader2, Plus } from 'lucide-react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
+import { parseAsBoolean, useQueryState } from 'nuqs'
 import { useState } from 'react'
 
 import { useParams } from 'common'
@@ -9,6 +10,7 @@ import { Markdown } from 'components/interfaces/Markdown'
 import { REPLICA_STATUS } from 'components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceConfiguration.constants'
 import { useReadReplicasQuery } from 'data/read-replicas/replicas-query'
 import { formatDatabaseID, formatDatabaseRegion } from 'data/read-replicas/replicas.utils'
+import { useAppStateSnapshot } from 'state/app-state'
 import { useDatabaseSelectorStateSnapshot } from 'state/database-selector'
 import {
   Button,
@@ -26,7 +28,6 @@ import {
   Tooltip_Shadcn_,
   cn,
 } from 'ui'
-import { useAppStateSnapshot } from 'state/app-state'
 
 interface DatabaseSelectorProps {
   variant?: 'regular' | 'connected-on-right' | 'connected-on-left' | 'connected-on-both'
@@ -45,6 +46,7 @@ const DatabaseSelector = ({
   const router = useRouter()
   const { ref: projectRef } = useParams()
   const [open, setOpen] = useState(false)
+  const [, setShowConnect] = useQueryState('showConnect', parseAsBoolean.withDefault(false))
 
   const appState = useAppStateSnapshot()
   const state = useDatabaseSelectorStateSnapshot()
@@ -206,7 +208,7 @@ const DatabaseSelector = ({
                   onClick={() => {
                     setOpen(false)
                     // [Joshen] This is used in the Connect UI which is available across all pages
-                    appState.setShowConnectDialog(false)
+                    setShowConnect(null)
                   }}
                   className="w-full flex items-center gap-2"
                 >

--- a/apps/studio/hooks/ui/useUrlState.ts
+++ b/apps/studio/hooks/ui/useUrlState.ts
@@ -5,6 +5,7 @@ export type UrlStateParams = {
   [k: string]: string | string[] | undefined
 }
 
+/** @deprecated Use useQueryState from nuqs instead for URL state */
 export function useUrlState<ValueParams extends UrlStateParams>({
   replace = true,
   arrayKeys = [],

--- a/apps/studio/state/app-state.ts
+++ b/apps/studio/state/app-state.ts
@@ -68,7 +68,6 @@ const getInitialState = () => {
       showGenerateSqlModal: false,
       navigationPanelOpen: false,
       navigationPanelJustClosed: false,
-      showConnectDialog: false,
     }
   }
 
@@ -112,7 +111,6 @@ const getInitialState = () => {
     showGenerateSqlModal: false,
     navigationPanelOpen: false,
     navigationPanelJustClosed: false,
-    showConnectDialog: false,
   }
 }
 
@@ -211,11 +209,6 @@ export const appState = proxy({
       content: hasEntityChanged ? '' : appState.aiAssistantPanel.content,
       ...value,
     }
-  },
-
-  showConnectDialog: false,
-  setShowConnectDialog: (value: boolean) => {
-    appState.showConnectDialog = value
   },
 })
 

--- a/apps/studio/tests/pages/projects/reports/api-report.test.tsx
+++ b/apps/studio/tests/pages/projects/reports/api-report.test.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react'
-import { test } from 'vitest'
+import { test, vi } from 'vitest'
 
 import { ApiReport } from 'pages/project/[ref]/reports/api-overview'
 import { render } from '../../../helpers'
@@ -9,6 +9,18 @@ import { render } from '../../../helpers'
 // But this is the method that worked for me after hours of wrangling with jest.spyOn and jest.mock
 // which for some reason none of them worked when I was trying to mock the data within the file itself
 // I'd be keen to see how we can do this better if anyone is more familiar to jest 🙏
+
+beforeAll(() => {
+  vi.mock('nuqs', async () => {
+    let queryValue = 'example'
+    return {
+      useQueryState: () => [queryValue, (v: string) => (queryValue = v)],
+      parseAsBoolean: {
+        withDefault: () => true,
+      },
+    }
+  })
+})
 
 test(`Render static elements`, async () => {
   render(<ApiReport dehydratedState={{}} />)

--- a/packages/ui-patterns/Dialogs/TextConfirmModal.tsx
+++ b/packages/ui-patterns/Dialogs/TextConfirmModal.tsx
@@ -143,7 +143,11 @@ const TextConfirmModal = forwardRef<
             </>
           )}
           <Form_Shadcn_ {...form}>
-            <form onSubmit={form.handleSubmit(onSubmit)} className="px-5 flex flex-col gap-2 pt-3">
+            <form
+              autoComplete="off"
+              onSubmit={form.handleSubmit(onSubmit)}
+              className="px-5 flex flex-col gap-2 pt-3"
+            >
               <FormField_Shadcn_
                 control={form.control}
                 name="confirmValue"
@@ -154,7 +158,12 @@ const TextConfirmModal = forwardRef<
                       confirm.
                     </FormLabel_Shadcn_>
                     <FormControl_Shadcn_>
-                      <Input_Shadcn_ placeholder={confirmPlaceholder} {...input} {...field} />
+                      <Input_Shadcn_
+                        autoComplete="off"
+                        placeholder={confirmPlaceholder}
+                        {...input}
+                        {...field}
+                      />
                     </FormControl_Shadcn_>
                     <FormDescription_Shadcn_ {...description} />
                     <FormMessage_Shadcn_ {...formMessage} />


### PR DESCRIPTION
Works on all project routes, and if the connectDialog flag is on

Chucked in a few other small fixes too:
- Fix leaving a team redirects back to the landing page instead of the dashboard
- Fix grammar in [`Infrastructure.constants.ts`](https://github.com/supabase/supabase/pull/31241/commits/cc0332f7691aa9caca020dd88cc0da7081f667f7#diff-bdc7a1c23e72a8d24f645ab5fb4ae39910a501a5aaccd2917d129951fdb5e294)
- Add `autoComplete='off'` for TeamSettings search input + DeleteProjectModal input