### PR TITLE
fix: increase snippet limit within folders

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/MoveQueryModal.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/MoveQueryModal.tsx
@@ -192,8 +192,8 @@ export const MoveQueryModal = ({ visible, snippets = [], onClose }: MoveQueryMod
           <form id="move-snippet" onSubmit={form.handleSubmit(onConfirmMove)}>
             <DialogHeader>
               <DialogTitle>
-                Move {snippets.length === 1 ? `"${snippets[0].name}"` : `${snippets.length}`} to a
-                folder
+                Move {snippets.length === 1 ? `"${snippets[0].name}"` : `${snippets.length}`}{' '}
+                snippet{snippets.length > 1 ? 's' : ''} to a folder
               </DialogTitle>
               <DialogDescription>
                 Select which folder to move your quer{snippets.length > 1 ? 'ies' : 'y'} to

--- a/apps/studio/data/content/sql-folder-contents-query.ts
+++ b/apps/studio/data/content/sql-folder-contents-query.ts
@@ -3,6 +3,7 @@ import { useInfiniteQuery, UseInfiniteQueryOptions } from '@tanstack/react-query
 import { get, handleError } from 'data/fetchers'
 import { ResponseError } from 'types'
 import { contentKeys } from './keys'
+import { SNIPPET_PAGE_LIMIT } from './sql-folders-query'
 
 export type SQLSnippetFolderContentsVariables = {
   projectRef?: string
@@ -24,7 +25,13 @@ export async function getSQLSnippetFolderContents(
   const { data, error } = await get('/platform/projects/{ref}/content/folders/{id}', {
     params: {
       path: { ref: projectRef, id: folderId },
-      query: { cursor, limit: '3', sort_by: sort, sort_order: sortOrder, name },
+      query: {
+        cursor,
+        limit: SNIPPET_PAGE_LIMIT.toString(),
+        sort_by: sort,
+        sort_order: sortOrder,
+        name,
+      },
     },
     signal,
   })


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Loads 3 snippets within a folder at a time (leftover from testing).

## What is the new behavior?

Loads 100