### PR TITLE
feat(studio): sql editor add/remove favorite queries in navigation

### DIFF
--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorNav.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorNav.tsx
@@ -524,6 +524,24 @@ export const SQLEditorNav = ({
     setSelectedSnippets(_selectedSnippets)
   }
 
+  const onAddFavorite = async (snippet: Snippet) => {
+    if (!profile) return console.error('Profile is required')
+    if (!project) return console.error('Project is required')
+    if (!projectRef) return console.error('Project ref is required')
+    if (!id) return console.error('Snippet ID is required')
+
+    snapV2.addFavorite(snippet.id)
+  }
+
+  const onRemoveFavorite = async (snippet: Snippet) => {
+    if (!profile) return console.error('Profile is required')
+    if (!project) return console.error('Project is required')
+    if (!projectRef) return console.error('Project ref is required')
+    if (!id) return console.error('Snippet ID is required')
+
+    snapV2.removeFavorite(snippet.id)
+  }
+
   // ===============
   // useEffects
   // ===============
@@ -596,6 +614,12 @@ export const SQLEditorNav = ({
                   onSelectUnshare={() => {
                     setSelectedSnippetToUnshare(element.metadata as Snippet)
                   }}
+                  onAddFavorite={() => {
+                    onAddFavorite(element.metadata as Snippet)
+                  }}
+                  onRemoveFavorite={() => {
+                    onRemoveFavorite(element.metadata as Snippet)
+                  }}
                   isLastItem={projectSnippetsLastItemIds.has(element.id as string)}
                   hasNextPage={hasMoreSharedSqlSnippets}
                   fetchNextPage={fetchNextSharedSqlSnippets}
@@ -656,6 +680,9 @@ export const SQLEditorNav = ({
                   onSelectShare={() => setSelectedSnippetToShare(element.metadata as Snippet)}
                   onSelectUnshare={() => {
                     setSelectedSnippetToUnshare(element.metadata as Snippet)
+                  }}
+                  onRemoveFavorite={() => {
+                    onRemoveFavorite(element.metadata as Snippet)
                   }}
                   isLastItem={favoriteSnippetsLastItemIds.has(element.id as string)}
                   hasNextPage={hasMoreFavoriteSqlSnippets}
@@ -748,6 +775,12 @@ export const SQLEditorNav = ({
                     } else if (name.length > 0) {
                       snapV2.saveFolder({ id: element.id as string, name })
                     }
+                  }}
+                  onAddFavorite={() => {
+                    onAddFavorite(element.metadata as Snippet)
+                  }}
+                  onRemoveFavorite={() => {
+                    onRemoveFavorite(element.metadata as Snippet)
                   }}
                   hasNextPage={hasNextPage}
                   fetchNextPage={fetchNextPage}

--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorTreeViewItem.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorTreeViewItem.tsx
@@ -1,5 +1,16 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
-import { Copy, Download, Edit, ExternalLink, Lock, Move, Plus, Share, Trash } from 'lucide-react'
+import {
+  Copy,
+  Download,
+  Edit,
+  ExternalLink,
+  Heart,
+  Lock,
+  Move,
+  Plus,
+  Share,
+  Trash,
+} from 'lucide-react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useEffect } from 'react'
@@ -42,6 +53,8 @@ interface SQLEditorTreeViewItemProps {
   onSelectDeleteFolder?: () => void
   onEditSave?: (name: string) => void
   onMultiSelect?: (id: string) => void
+  onAddFavorite?: () => void
+  onRemoveFavorite?: () => void
 
   // Pagination/filtering options
   isLastItem: boolean
@@ -72,6 +85,8 @@ export const SQLEditorTreeViewItem = ({
   onSelectCopyPersonal,
   onEditSave,
   onMultiSelect,
+  onAddFavorite,
+  onRemoveFavorite,
   isLastItem,
   hasNextPage: _hasNextPage,
   fetchNextPage: _fetchNextPage,
@@ -100,6 +115,9 @@ export const SQLEditorTreeViewItem = ({
   const parentId = element.parent === 0 ? undefined : element.parent
 
   const isEnabled = isBranch && isExpanded
+
+  const snippet = snapV2.snippets[element.id]
+  const isFavorite = snippet !== undefined ? snippet.snippet.favorite : false
 
   const {
     data,
@@ -273,6 +291,27 @@ export const SQLEditorTreeViewItem = ({
                   Open in new tab
                 </Link>
               </ContextMenuItem_Shadcn_>
+              <ContextMenuSeparator_Shadcn_ />
+              {onRemoveFavorite !== undefined && (
+                <ContextMenuItem_Shadcn_
+                  className="gap-x-2"
+                  onSelect={() => {
+                    if (isFavorite) onRemoveFavorite()
+                    else onAddFavorite?.()
+                  }}
+                  onFocusCapture={(e) => e.stopPropagation()}
+                >
+                  <Heart
+                    size={14}
+                    strokeWidth={2}
+                    className={
+                      isFavorite ? 'fill-brand stroke-none' : 'fill-none stroke-foreground-light'
+                    }
+                  />
+                  {isFavorite ? 'Remove from' : 'Add to'} favorites
+                </ContextMenuItem_Shadcn_>
+              )}
+
               <ContextMenuSeparator_Shadcn_ />
               {onSelectRename !== undefined && isOwner && (
                 <ContextMenuItem_Shadcn_


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

**Feature**

## What is the current behavior?

To add or remove a query to the favorites section, the user has to open the query and go to the actions dropdown (vertical ellipsis icon).

Doing this the first time, I was a bit confused where the heart icon was that the banner mentioned.

![CleanShot 2024-12-22 at 00 02 44@2x](https://github.com/user-attachments/assets/109e2e75-558c-4956-8139-700ded7972e2)

## What is the new behavior?

Users can add or remove queries to the favorites list right from the query navigation by right clicking the query

## Additional context

Queries that are already in the favorites section of course can only be removed from it.

I didn't bother with a logic for multi-selected queries, because what happens if some of the selected queries are already favorites / not favorited yet?
