### PR TITLE
Fix using camel case enum from public schema erroring out in ColumnEditor

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.tsx
@@ -119,7 +119,6 @@ const ColumnEditor = ({
       const columnFields = isNewRecord
         ? generateColumnField({ schema: selectedTable.schema, table: selectedTable.name })
         : generateColumnFieldFromPostgresColumn(column, selectedTable, foreignKeyMeta)
-      console.log(column)
       setColumnFields(columnFields)
       setFkRelations(formatForeignKeys(foreignKeys))
     }

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnEditor.tsx
@@ -119,6 +119,7 @@ const ColumnEditor = ({
       const columnFields = isNewRecord
         ? generateColumnField({ schema: selectedTable.schema, table: selectedTable.name })
         : generateColumnFieldFromPostgresColumn(column, selectedTable, foreignKeyMeta)
+      console.log(column)
       setColumnFields(columnFields)
       setFkRelations(formatForeignKeys(foreignKeys))
     }

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnType.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnType.tsx
@@ -1,7 +1,19 @@
 import * as Tooltip from '@radix-ui/react-tooltip'
 import { noop } from 'lodash'
+import {
+  Calendar,
+  Check,
+  ChevronsUpDown,
+  ExternalLink,
+  Hash,
+  ListPlus,
+  ToggleRight,
+  Type,
+} from 'lucide-react'
 import Link from 'next/link'
 import { ReactNode, useState } from 'react'
+
+import type { EnumeratedType } from 'data/enumerated-types/enumerated-types-query'
 import {
   AlertDescription_Shadcn_,
   AlertTitle_Shadcn_,
@@ -22,19 +34,6 @@ import {
   ScrollArea,
   cn,
 } from 'ui'
-
-import type { EnumeratedType } from 'data/enumerated-types/enumerated-types-query'
-import {
-  Calendar,
-  Check,
-  ChevronsUpDown,
-  ExternalLink,
-  Hash,
-  ListPlus,
-  ToggleRight,
-  Type,
-} from 'lucide-react'
-
 import {
   POSTGRES_DATA_TYPES,
   POSTGRES_DATA_TYPE_OPTIONS,
@@ -68,9 +67,7 @@ const ColumnType = ({
 }: ColumnTypeProps) => {
   const [open, setOpen] = useState(false)
   const availableTypes = POSTGRES_DATA_TYPES.concat(
-    enumTypes.map((type) =>
-      type.schema === 'public' ? type.format.replaceAll('"', '') : type.format
-    )
+    enumTypes.map((type) => type.format.replaceAll('"', ''))
   )
   const isAvailableType = value ? availableTypes.includes(value) : true
   const recommendation = RECOMMENDED_ALTERNATIVE_DATA_TYPE[value]

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnType.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnType.tsx
@@ -67,8 +67,11 @@ const ColumnType = ({
   onOptionSelect = noop,
 }: ColumnTypeProps) => {
   const [open, setOpen] = useState(false)
-  // @ts-ignore
-  const availableTypes = POSTGRES_DATA_TYPES.concat(enumTypes.map((type) => type.format))
+  const availableTypes = POSTGRES_DATA_TYPES.concat(
+    enumTypes.map((type) =>
+      type.schema === 'public' ? type.format.replaceAll('"', '') : type.format
+    )
+  )
   const isAvailableType = value ? availableTypes.includes(value) : true
   const recommendation = RECOMMENDED_ALTERNATIVE_DATA_TYPE[value]
 
@@ -200,7 +203,7 @@ const ColumnType = ({
             {value ? (
               <div className="flex gap-2 items-center">
                 <span>{inferIcon(getOptionByName(value)?.type ?? '')}</span>
-                {value}
+                {value.replaceAll('"', '')}
               </div>
             ) : (
               'Choose a column type...'
@@ -231,11 +234,7 @@ const ColumnType = ({
                         <span className="text-foreground-lighter">{option.description}</span>
                       </div>
                       <span className="absolute right-3 top-2">
-                        {option.name === value ? (
-                          <Check className="text-brand-500" size={14} />
-                        ) : (
-                          ''
-                        )}
+                        {option.name === value ? <Check className="text-brand" size={14} /> : ''}
                       </span>
                     </CommandItem_Shadcn_>
                   ))}
@@ -246,14 +245,18 @@ const ColumnType = ({
                     <CommandGroup_Shadcn_>
                       {enumTypes.map((option) => (
                         <CommandItem_Shadcn_
-                          key={option.format}
+                          key={option.id}
                           value={option.format}
                           className={cn(
                             'relative',
                             option.format === value ? 'bg-surface-200' : ''
                           )}
                           onSelect={(value: string) => {
-                            onOptionSelect(value)
+                            // [Joshen] For camel case types specifically, format property includes escaped double quotes
+                            // which will cause the POST columns call to error out. So we strip it specifically in this context
+                            onOptionSelect(
+                              option.schema === 'public' ? value.replaceAll('"', '') : value
+                            )
                             setOpen(false)
                           }}
                         >
@@ -261,7 +264,9 @@ const ColumnType = ({
                             <div>
                               <ListPlus size={16} className="text-foreground" strokeWidth={1.5} />
                             </div>
-                            <span className="text-foreground">{option.format}</span>
+                            <span className="text-foreground">
+                              {option.format.replaceAll('"', '')}
+                            </span>
                             {option.comment !== undefined && (
                               <span
                                 title={option.comment ?? ''}
@@ -270,9 +275,11 @@ const ColumnType = ({
                                 {option.comment}
                               </span>
                             )}
-                            <span className="flex items-center gap-1.5">
-                              {option.format === value ? <Check size={13} /> : ''}
-                            </span>
+                            {option.format === value && (
+                              <span className="absolute right-3 top-2">
+                                <Check className="text-brand" size={14} />
+                              </span>
+                            )}
                           </div>
                         </CommandItem_Shadcn_>
                       ))}

--- a/apps/studio/data/table-editor/table-editor-query-sql.ts
+++ b/apps/studio/data/table-editor/table-editor-query-sql.ts
@@ -113,7 +113,15 @@ export function getTableEditorSql(id?: number) {
                             else 'USER-DEFINED'
                         end
                 end,
-                'format', coalesce(bt.typname, t.typname),
+                'format', case
+                    when t.typtype = 'e' then
+                        case
+                            when nt.nspname <> 'public' then concat(nt.nspname, '.', coalesce(bt.typname, t.typname))
+                            else coalesce(bt.typname, t.typname)
+                        end
+                    else
+                        coalesce(bt.typname, t.typname)
+                end,
                 'is_identity', a.attidentity in ('a', 'd'),
                 'identity_generation', case a.attidentity
                     when 'a' then 'ALWAYS'


### PR DESCRIPTION
Resolves https://github.com/supabase/supabase/issues/31260


- Removed escaped double quotes for camel cased enums when displaying them in the UI
- Stripe double quotes for enum types in the public schema only