### PR TITLE
Hide r2np for fly hosted projects

### DIFF
--- a/apps/studio/components/interfaces/Database/Backups/DatabaseBackupsNav.tsx
+++ b/apps/studio/components/interfaces/Database/Backups/DatabaseBackupsNav.tsx
@@ -11,7 +11,7 @@ type Props = {
 
 function DatabaseBackupsNav({ active }: Props) {
   const isCloneToNewProjectEnabled = useFlag('clonetonewproject')
-  const { ref, cloud_provider } = useProjectContext()?.project
+  const { ref, cloud_provider } = useProjectContext()?.project || {}
 
   const navMenuItems = [
     {

--- a/apps/studio/components/interfaces/Database/Backups/DatabaseBackupsNav.tsx
+++ b/apps/studio/components/interfaces/Database/Backups/DatabaseBackupsNav.tsx
@@ -11,7 +11,7 @@ type Props = {
 
 function DatabaseBackupsNav({ active }: Props) {
   const isCloneToNewProjectEnabled = useFlag('clonetonewproject')
-  const ref = useProjectContext()?.project?.ref
+  const { ref, cloud_provider } = useProjectContext()?.project
 
   const navMenuItems = [
     {
@@ -27,7 +27,7 @@ function DatabaseBackupsNav({ active }: Props) {
       href: `/project/${ref}/database/backups/pitr`,
     },
     {
-      enabled: isCloneToNewProjectEnabled,
+      enabled: isCloneToNewProjectEnabled && cloud_provider !== 'FLY',
       id: 'rtnp',
       label: (
         <div className="flex items-center gap-1">

--- a/apps/studio/pages/project/[ref]/database/backups/restore-to-new-project.tsx
+++ b/apps/studio/pages/project/[ref]/database/backups/restore-to-new-project.tsx
@@ -84,8 +84,8 @@ const RestoreToNewProject = () => {
   )
   const PITR_ENABLED = cloneBackups?.pitr_enabled
   const PHYSICAL_BACKUPS_ENABLED = project?.is_physical_backups_enabled
-  const IS_PG15_OR_ABOVE = dbVersion >= 15
   const dbVersion = getDatabaseMajorVersion(project?.dbVersion ?? '')
+  const IS_PG15_OR_ABOVE = dbVersion >= 15
 
   const {
     data: cloneStatus,

--- a/apps/studio/pages/project/[ref]/database/backups/restore-to-new-project.tsx
+++ b/apps/studio/pages/project/[ref]/database/backups/restore-to-new-project.tsx
@@ -83,10 +83,10 @@ const RestoreToNewProject = () => {
     'queue_job.restore.prepare'
   )
   const PITR_ENABLED = cloneBackups?.pitr_enabled
-
-  const dbVersion = getDatabaseMajorVersion(project?.dbVersion ?? '')
-  const IS_PG15_OR_ABOVE = dbVersion >= 15
   const PHYSICAL_BACKUPS_ENABLED = project?.is_physical_backups_enabled
+  const IS_PG15_OR_ABOVE = dbVersion >= 15
+  const dbVersion = getDatabaseMajorVersion(project?.dbVersion ?? '')
+  const isFly = project?.cloud_provider === 'FLY'
 
   const {
     data: cloneStatus,
@@ -202,6 +202,20 @@ const RestoreToNewProject = () => {
     )
   }
 
+  if (isFly) {
+    return (
+      <Admonition
+        type="default"
+        title="Restoring to new projects are not available for Fly hosted projects"
+      >
+        <Markdown
+          className="max-w-full [&>p]:!leading-normal"
+          content={`If you need to a Fly project, please reach out via [support](/support/new?ref=${project?.ref}).`}
+        />
+      </Admonition>
+    )
+  }
+
   if (!canReadPhysicalBackups) {
     return <NoPermission resourceText="view backups" />
   }
@@ -260,7 +274,7 @@ const RestoreToNewProject = () => {
         <Markdown
           className="max-w-full [&>p]:!leading-normal"
           content={`This is a temporary limitation whereby projects that were originally restored from another project cannot be restored to yet another project. 
-          If you need to restore a project to multiple other projects, please reach out via [support](/support/new?ref=${project?.ref}).`}
+          If you need to restore from a restored project, please reach out via [support](/support/new?ref=${project?.ref}).`}
         />
         <Button asChild type="default">
           <Link href={`/project/${(cloneStatus?.cloned_from?.source_project as any)?.ref || ''}`}>

--- a/apps/studio/pages/project/[ref]/database/backups/restore-to-new-project.tsx
+++ b/apps/studio/pages/project/[ref]/database/backups/restore-to-new-project.tsx
@@ -86,7 +86,6 @@ const RestoreToNewProject = () => {
   const PHYSICAL_BACKUPS_ENABLED = project?.is_physical_backups_enabled
   const IS_PG15_OR_ABOVE = dbVersion >= 15
   const dbVersion = getDatabaseMajorVersion(project?.dbVersion ?? '')
-  const isFly = project?.cloud_provider === 'FLY'
 
   const {
     data: cloneStatus,
@@ -198,20 +197,6 @@ const RestoreToNewProject = () => {
         description="OrioleDB is currently in public alpha and projects created are strictly ephemeral with no database backups"
       >
         <DocsButton abbrev={false} className="mt-2" href="https://supabase.com/docs" />
-      </Admonition>
-    )
-  }
-
-  if (isFly) {
-    return (
-      <Admonition
-        type="default"
-        title="Restoring to new projects are not available for Fly hosted projects"
-      >
-        <Markdown
-          className="max-w-full [&>p]:!leading-normal"
-          content={`If you need to a Fly project, please reach out via [support](/support/new?ref=${project?.ref}).`}
-        />
       </Admonition>
     )
   }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

- Hides the link to restore to new project feature for fly hosted projects
- Updates copy to clarify limitation in restoring from a restored project

## What is the current behavior?

Fly hosted projects don't support r2np so the forms to restore will not work

## What is the new behavior?

Inform users of limitation
