### PR TITLE
Fix API docs introction

### DIFF
--- a/apps/studio/components/interfaces/Docs/Authentication.tsx
+++ b/apps/studio/components/interfaces/Docs/Authentication.tsx
@@ -48,7 +48,7 @@ const Authentication = ({ selectedLang, showApiKey }: AuthenticationProps) => {
       </div>
 
       <h2 className="doc-heading">Client API Keys</h2>
-      <div className="doc-section ">
+      <div className="doc-section">
         <article className="code-column text-foreground">
           <p>
             Client keys allow "anonymous access" to your database, until the user has logged in.
@@ -79,7 +79,7 @@ const Authentication = ({ selectedLang, showApiKey }: AuthenticationProps) => {
       </div>
 
       <h2 className="doc-heading">Service Keys</h2>
-      <div className="doc-section ">
+      <div className="doc-section">
         <article className="code-column text-foreground">
           <p>
             Service keys have FULL access to your data, bypassing any security policies. Be VERY

--- a/apps/studio/components/interfaces/Docs/Introduction.tsx
+++ b/apps/studio/components/interfaces/Docs/Introduction.tsx
@@ -2,6 +2,7 @@ import { useParams } from 'common'
 import Snippets from 'components/interfaces/Docs/Snippets'
 import { useProjectPostgrestConfigQuery } from 'data/config/project-postgrest-config-query'
 
+import { InlineLink } from 'components/ui/InlineLink'
 import { useProjectSettingsV2Query } from 'data/config/project-settings-v2-query'
 import CodeSnippet from './CodeSnippet'
 import PublicSchemaNotEnabledAlert from './PublicSchemaNotEnabledAlert'
@@ -26,12 +27,26 @@ export default function Introduction({ selectedLang }: Props) {
     .includes('public')
 
   return (
-    <div className="doc-section doc-section--client-libraries">
-      <article className="code">
-        <CodeSnippet selectedLang={selectedLang} snippet={Snippets.init(endpoint)} />
-
-        {!isPublicSchemaEnabled && <PublicSchemaNotEnabledAlert />}
-      </article>
-    </div>
+    <>
+      <h2 className="doc-heading">Connect to your project</h2>
+      <div className="doc-section">
+        <article className="code-column text-foreground">
+          <p>
+            All projects have a RESTful endpoint that you can use with your project's API key to
+            query and manage your database. These can be obtained from the{' '}
+            <InlineLink href={`/project/${projectRef}/settings/api`}>API settings</InlineLink>.
+          </p>
+          <p>
+            You can initialize a new Supabase client using the <code>createClient()</code> method.
+            The Supabase client is your entrypoint to the rest of the Supabase functionality and is
+            the easiest way to interact with everything we offer within the Supabase ecosystem.
+          </p>
+        </article>
+        <article className="code">
+          <CodeSnippet selectedLang={selectedLang} snippet={Snippets.init(endpoint)} />
+          {!isPublicSchemaEnabled && <PublicSchemaNotEnabledAlert />}
+        </article>
+      </div>
+    </>
   )
 }


### PR DESCRIPTION
Adds some content for the API introduction page, referenced from our docs site to fix the alignment

Before:
![image](https://github.com/user-attachments/assets/ff992d0b-5887-4973-a628-aefad283a576)

After:
![image](https://github.com/user-attachments/assets/c4792faf-478e-4e93-99fb-97db3c171127)
