### PR TITLE
fillTimeseries: Skip filling if theres a minimum of datapoints

### DIFF
--- a/apps/studio/components/interfaces/Home/ProjectUsage.tsx
+++ b/apps/studio/components/interfaces/Home/ProjectUsage.tsx
@@ -62,7 +62,7 @@ const ProjectUsage = () => {
       'total_storage_requests',
       'total_realtime_requests',
     ],
-    0,
+    '',
     startDateLocal.toISOString(),
     endDateLocal.toISOString(),
     20

--- a/apps/studio/components/interfaces/Home/ProjectUsage.tsx
+++ b/apps/studio/components/interfaces/Home/ProjectUsage.tsx
@@ -62,10 +62,10 @@ const ProjectUsage = () => {
       'total_storage_requests',
       'total_realtime_requests',
     ],
-    '',
+    0,
     startDateLocal.toISOString(),
     endDateLocal.toISOString(),
-    20
+    5
   )
   const datetimeFormat = selectedInterval.format || 'MMM D, ha'
 

--- a/apps/studio/components/interfaces/Home/ProjectUsage.tsx
+++ b/apps/studio/components/interfaces/Home/ProjectUsage.tsx
@@ -62,9 +62,10 @@ const ProjectUsage = () => {
       'total_storage_requests',
       'total_realtime_requests',
     ],
-    0,
+    '',
     startDateLocal.toISOString(),
-    endDateLocal.toISOString()
+    endDateLocal.toISOString(),
+    20
   )
   const datetimeFormat = selectedInterval.format || 'MMM D, ha'
 

--- a/apps/studio/components/interfaces/Home/ProjectUsage.tsx
+++ b/apps/studio/components/interfaces/Home/ProjectUsage.tsx
@@ -62,7 +62,7 @@ const ProjectUsage = () => {
       'total_storage_requests',
       'total_realtime_requests',
     ],
-    '',
+    0,
     startDateLocal.toISOString(),
     endDateLocal.toISOString(),
     20

--- a/apps/studio/components/interfaces/Settings/Logs/Logs.utils.ts
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.utils.ts
@@ -458,8 +458,18 @@ export const fillTimeseries = (
   valueKey: string | string[],
   defaultValue: number,
   min?: string,
-  max?: string
+  max?: string,
+  minPointsToFill: number = 20
 ) => {
+  // If we have more points than minPointsToFill, just normalize timestamps and return
+  if (timeseriesData.length > minPointsToFill) {
+    return timeseriesData.map((datum) => {
+      const iso = dayjs.utc(datum[timestampKey]).toISOString()
+      datum[timestampKey] = iso
+      return datum
+    })
+  }
+
   if (timeseriesData.length <= 1 && !(min || max)) return timeseriesData
   const dates: unknown[] = timeseriesData.map((datum) => dayjs.utc(datum[timestampKey]))
 

--- a/apps/studio/components/interfaces/Settings/Logs/Logs.utils.ts
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.utils.ts
@@ -456,7 +456,7 @@ export const fillTimeseries = (
   timeseriesData: any[],
   timestampKey: string,
   valueKey: string | string[],
-  defaultValue: number,
+  defaultValue: number | string,
   min?: string,
   max?: string,
   minPointsToFill: number = 20

--- a/apps/studio/components/interfaces/Settings/Logs/Logs.utils.ts
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.utils.ts
@@ -456,7 +456,7 @@ export const fillTimeseries = (
   timeseriesData: any[],
   timestampKey: string,
   valueKey: string | string[],
-  defaultValue: number | string,
+  defaultValue: number,
   min?: string,
   max?: string,
   minPointsToFill: number = 20

--- a/apps/studio/components/ui/Charts/BarChart.tsx
+++ b/apps/studio/components/ui/Charts/BarChart.tsx
@@ -112,9 +112,10 @@ const BarChart = ({
         format={format}
         customDateFormat={customDateFormat}
         highlightedValue={
-          typeof resolvedHighlightedValue === 'number'
-            ? numberFormatter(resolvedHighlightedValue, valuePrecision)
-            : resolvedHighlightedValue
+          resolvedHighlightedValue
+          // typeof resolvedHighlightedValue === 'number'
+          //   ? numberFormatter(resolvedHighlightedValue, valuePrecision)
+          //   : resolvedHighlightedValue
         }
         highlightedLabel={resolvedHighlightedLabel}
         minimalHeader={minimalHeader}

--- a/apps/studio/components/ui/Charts/BarChart.tsx
+++ b/apps/studio/components/ui/Charts/BarChart.tsx
@@ -111,12 +111,7 @@ const BarChart = ({
         title={title}
         format={format}
         customDateFormat={customDateFormat}
-        highlightedValue={
-          resolvedHighlightedValue
-          // typeof resolvedHighlightedValue === 'number'
-          //   ? numberFormatter(resolvedHighlightedValue, valuePrecision)
-          //   : resolvedHighlightedValue
-        }
+        highlightedValue={resolvedHighlightedValue}
         highlightedLabel={resolvedHighlightedLabel}
         minimalHeader={minimalHeader}
       />


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

fillTimeseries is a function that adds datapoints with some default values, if we have enough data, we dont need to use it, this change allows to set the minimum of data points to check before filling.

https://github.com/user-attachments/assets/5dab9bb7-4656-49c7-8705-f54de4dd498a


