### PR TITLE
Chore/edge functions fixes

### DIFF
--- a/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionDetails.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionDetails.tsx
@@ -101,7 +101,7 @@ const EdgeFunctionDetails = () => {
 
   return (
     <>
-      <div className="space-y-4 pb-16">
+      <div className="space-y-4 pb-16 pt-3">
         <Form id={formId} initialValues={{}} onSubmit={onUpdateFunction}>
           {({ handleReset, values, initialValues, resetForm }: any) => {
             const hasChanges = JSON.stringify(values) !== JSON.stringify(initialValues)

--- a/apps/studio/components/interfaces/Functions/EdgeFunctionsListItem.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionsListItem.tsx
@@ -36,7 +36,7 @@ const EdgeFunctionsListItem = ({ function: item }: EdgeFunctionsListItemProps) =
     <Table.tr
       key={item.id}
       onClick={() => {
-        router.push(`/project/${ref}/functions/${item.slug}/details`)
+        router.push(`/project/${ref}/functions/${item.slug}`)
       }}
     >
       <Table.td>

--- a/apps/studio/components/interfaces/Functions/FunctionsNav.tsx
+++ b/apps/studio/components/interfaces/Functions/FunctionsNav.tsx
@@ -11,6 +11,7 @@ const FunctionsNav = ({ item }: any) => {
       defaultActiveId="1"
       type="underlined"
       size="medium"
+      baseClassNames="!space-y-0"
       activeId={!activeRoute ? 'metrics' : activeRoute}
       onChange={(e: string) => {
         if (item?.slug) {

--- a/apps/studio/components/interfaces/Functions/FunctionsNav.tsx
+++ b/apps/studio/components/interfaces/Functions/FunctionsNav.tsx
@@ -12,17 +12,17 @@ const FunctionsNav = ({ item }: any) => {
       type="underlined"
       size="medium"
       baseClassNames="!space-y-0"
-      activeId={!activeRoute ? 'metrics' : activeRoute}
+      activeId={!activeRoute ? 'overview' : activeRoute}
       onChange={(e: string) => {
         if (item?.slug) {
-          router.push(`/project/${ref}/functions/${item.slug}/${e === 'metrics' ? '' : e}`)
+          router.push(`/project/${ref}/functions/${item.slug}/${e === 'overview' ? '' : e}`)
         }
       }}
     >
-      <Tabs.Panel id="details" label="Details" />
-      <Tabs.Panel id="metrics" label="Metrics" />
+      <Tabs.Panel id="overview" label="Overview" />
       <Tabs.Panel id="invocations" label="Invocations" />
       <Tabs.Panel id="logs" label="Logs" />
+      <Tabs.Panel id="details" label="Details" />
     </Tabs>
   )
 }

--- a/apps/studio/components/interfaces/Settings/Logs/LogTable.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogTable.tsx
@@ -93,7 +93,6 @@ const LogTable = ({
   const { show: showContextMenu } = useContextMenu()
 
   const [cellPosition, setCellPosition] = useState<any>()
-
   const [selectionOpen, setSelectionOpen] = useState(false)
 
   useEffect(() => {
@@ -249,7 +248,7 @@ const LogTable = ({
   const LogsExplorerTableHeader = () => (
     <div
       className={cn(
-        'flex w-full items-center justify-between border-t  bg-surface-100 px-5 py-2',
+        'flex w-full items-center justify-between border-t bg-surface-100 px-5 py-2',
         className,
         { hidden: !showHeader }
       )}
@@ -369,7 +368,7 @@ const LogTable = ({
           <DataGrid
             role="table"
             style={{ height: '100%' }}
-            className={cn('flex-1 flex-grow h-full border-none', {
+            className={cn('flex-1 flex-grow h-full border-0', {
               'data-grid--simple-logs': queryType,
               'data-grid--logs-explorer': !queryType,
             })}

--- a/apps/studio/components/interfaces/Settings/Logs/Logs.constants.ts
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.constants.ts
@@ -350,6 +350,9 @@ export const SQL_FILTER_TEMPLATES: any = {
     ..._SQL_FILTER_COMMON,
     database: (value: string) => `m.project like '${value}%'`,
   },
+  pg_cron_logs: {
+    ..._SQL_FILTER_COMMON,
+  },
 }
 
 export enum LogsTableName {

--- a/apps/studio/components/interfaces/Settings/Logs/LogsPreviewer.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogsPreviewer.tsx
@@ -150,6 +150,7 @@ export const LogsPreviewer = ({
   }
   const handleSearch: LogSearchCallback = async (event, { query, to, from }) => {
     if (event === 'search-input-change') {
+      setSelectedLogId(null)
       setFilters((prev) => ({ ...prev, search_query: query }))
       router.push({
         pathname: router.pathname,

--- a/apps/studio/components/interfaces/Settings/Logs/LogsPreviewer.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogsPreviewer.tsx
@@ -39,6 +39,7 @@ interface LogsPreviewerProps {
   condensedLayout?: boolean
   tableName?: LogsTableName
   EmptyState?: React.ReactNode
+  filterPanelClassName?: string
 }
 export const LogsPreviewer = ({
   projectRef,
@@ -48,6 +49,7 @@ export const LogsPreviewer = ({
   tableName,
   children,
   EmptyState,
+  filterPanelClassName,
 }: PropsWithChildren<LogsPreviewerProps>) => {
   const router = useRouter()
   const { s, ite, its, db } = useParams()
@@ -200,6 +202,7 @@ export const LogsPreviewer = ({
   return (
     <div className="flex-1 flex flex-col h-full">
       <PreviewFilterPanel
+        className={filterPanelClassName}
         csvData={logData}
         isLoading={isLoading}
         newCount={newCount}

--- a/apps/studio/components/interfaces/Settings/Logs/PreviewFilterPanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/PreviewFilterPanel.tsx
@@ -2,12 +2,13 @@ import { Eye, EyeOff, RefreshCw, Search, Terminal, X } from 'lucide-react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
-import { Button, Input, TooltipContent_Shadcn_, TooltipTrigger_Shadcn_, Tooltip_Shadcn_ } from 'ui'
 
 import { useParams } from 'common'
+import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import CSVButton from 'components/ui/CSVButton'
 import DatabaseSelector from 'components/ui/DatabaseSelector'
 import { useLoadBalancersQuery } from 'data/read-replicas/load-balancers-query'
+import { Button, Input, TooltipContent_Shadcn_, TooltipTrigger_Shadcn_, Tooltip_Shadcn_ } from 'ui'
 import DatePickers from './Logs.DatePickers'
 import {
   FILTER_OPTIONS,
@@ -17,7 +18,6 @@ import {
 } from './Logs.constants'
 import type { Filters, LogSearchCallback, LogTemplate } from './Logs.types'
 import LogsFilterPopover from './LogsFilterPopover'
-import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 
 interface PreviewFilterPanelProps {
   defaultSearchValue?: string

--- a/apps/studio/components/interfaces/Settings/Logs/PreviewFilterPanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/PreviewFilterPanel.tsx
@@ -1,4 +1,4 @@
-import { Eye, EyeOff, RefreshCw, Search, Terminal } from 'lucide-react'
+import { Eye, EyeOff, RefreshCw, Search, Terminal, X } from 'lucide-react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
@@ -17,6 +17,7 @@ import {
 } from './Logs.constants'
 import type { Filters, LogSearchCallback, LogTemplate } from './Logs.types'
 import LogsFilterPopover from './LogsFilterPopover'
+import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 
 interface PreviewFilterPanelProps {
   defaultSearchValue?: string
@@ -147,14 +148,27 @@ const PreviewFilterPanel = ({
             }
             value={search}
             actions={
-              hasEdits && (
-                <button
-                  onClick={() => handleInputSearch(search)}
-                  className="mx-2 text-foreground-light hover:text-foreground"
-                >
-                  {'↲'}
-                </button>
-              )
+              <div className="flex items-center gap-x-1 mr-0.5">
+                {hasEdits && (
+                  <ButtonTooltip
+                    icon={<span>↲</span>}
+                    type="text"
+                    className="px-1 h-[20px]"
+                    onClick={() => handleInputSearch(search)}
+                    tooltip={{ content: { side: 'bottom', text: 'Search for events' } }}
+                  />
+                )}
+
+                {search.length > 0 && (
+                  <ButtonTooltip
+                    icon={<X />}
+                    type="text"
+                    className="p-[1px] h-[20px]"
+                    onClick={() => handleInputSearch('')}
+                    tooltip={{ content: { side: 'bottom', text: 'Clear search' } }}
+                  />
+                )}
+              </div>
             }
           />
         </form>

--- a/apps/studio/components/interfaces/Settings/Logs/PreviewFilterPanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/PreviewFilterPanel.tsx
@@ -8,7 +8,14 @@ import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import CSVButton from 'components/ui/CSVButton'
 import DatabaseSelector from 'components/ui/DatabaseSelector'
 import { useLoadBalancersQuery } from 'data/read-replicas/load-balancers-query'
-import { Button, Input, TooltipContent_Shadcn_, TooltipTrigger_Shadcn_, Tooltip_Shadcn_ } from 'ui'
+import {
+  Button,
+  Input,
+  TooltipContent_Shadcn_,
+  TooltipTrigger_Shadcn_,
+  Tooltip_Shadcn_,
+  cn,
+} from 'ui'
 import DatePickers from './Logs.DatePickers'
 import {
   FILTER_OPTIONS,
@@ -39,6 +46,7 @@ interface PreviewFilterPanelProps {
   onFiltersChange: (filters: Filters) => void
   filters: Filters
   onSelectedDatabaseChange: (id: string) => void
+  className?: string
 }
 
 /**
@@ -62,6 +70,7 @@ const PreviewFilterPanel = ({
   filters,
   table,
   onSelectedDatabaseChange,
+  className,
 }: PreviewFilterPanelProps) => {
   const router = useRouter()
   const { ref } = useParams()
@@ -122,7 +131,13 @@ const PreviewFilterPanel = ({
   const handleInputSearch = (query: string) => onSearch('search-input-change', { query })
 
   return (
-    <div className={'flex w-full items-center justify-between' + (condensedLayout ? ' p-3' : '')}>
+    <div
+      className={cn(
+        'flex w-full items-center justify-between',
+        condensedLayout ? ' p-3' : '',
+        className
+      )}
+    >
       <div className="flex flex-row items-center gap-x-2">
         <form
           id="log-panel-search"

--- a/apps/studio/components/layouts/FunctionsLayout/FunctionsLayout.tsx
+++ b/apps/studio/components/layouts/FunctionsLayout/FunctionsLayout.tsx
@@ -89,12 +89,12 @@ const FunctionsLayout = ({ title, children }: PropsWithChildren<FunctionsLayoutP
                       </h1>
                     </Link>
                     {name && (
-                      <div className="mt-1.5 flex items-center space-x-4">
+                      <div className="flex items-center space-x-4">
                         <span className="text-foreground-light">
                           <svg
                             viewBox="0 0 24 24"
-                            width="16"
-                            height="16"
+                            width="24"
+                            height="24"
                             stroke="currentColor"
                             strokeWidth="1"
                             strokeLinecap="round"
@@ -105,7 +105,7 @@ const FunctionsLayout = ({ title, children }: PropsWithChildren<FunctionsLayoutP
                             <path d="M16 3.549L7.12 20.600"></path>
                           </svg>
                         </span>
-                        <h5 className="text-lg text-foreground">{name}</h5>
+                        <h1 className="text-2xl text-foreground">{name}</h1>
                       </div>
                     )}
                   </div>

--- a/apps/studio/pages/project/[ref]/functions/[functionSlug]/index.tsx
+++ b/apps/studio/pages/project/[ref]/functions/[functionSlug]/index.tsx
@@ -151,7 +151,7 @@ const PageLayout: NextPageWithLayout = () => {
     return <NoPermission isFullPage resourceText="access this edge function" />
   }
   return (
-    <div className="space-y-6 py-2">
+    <div className="space-y-6 py-3">
       <div className="flex flex-row items-center gap-2">
         <div className="flex items-center">
           {CHART_INTERVALS.map((item, i) => {

--- a/apps/studio/pages/project/[ref]/functions/[functionSlug]/invocations.tsx
+++ b/apps/studio/pages/project/[ref]/functions/[functionSlug]/invocations.tsx
@@ -19,9 +19,11 @@ export const LogPage: NextPageWithLayout = () => {
 
   return (
     <LogsPreviewer
+      condensedLayout
       projectRef={ref as string}
       queryType={'fn_edge'}
       filterOverride={{ function_id: selectedFunction.id }}
+      filterPanelClassName="px-0"
     />
   )
 }

--- a/apps/studio/pages/project/[ref]/functions/[functionSlug]/logs.tsx
+++ b/apps/studio/pages/project/[ref]/functions/[functionSlug]/logs.tsx
@@ -16,9 +16,11 @@ export const LogPage: NextPageWithLayout = () => {
 
   return (
     <LogsPreviewer
+      condensedLayout
       projectRef={ref as string}
       queryType={'functions'}
       filterOverride={{ 'metadata.function_id': selectedFunction.id }}
+      filterPanelClassName="px-0"
     />
   )
 }

--- a/apps/studio/pages/project/[ref]/functions/index.tsx
+++ b/apps/studio/pages/project/[ref]/functions/index.tsx
@@ -1,16 +1,5 @@
 import { useParams } from 'common'
-import { useState } from 'react'
-import {
-  Button,
-  Dialog,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogSection,
-  DialogSectionSeparator,
-  DialogTrigger,
-  Modal,
-} from 'ui'
+import { Button, Dialog, DialogContent, DialogSection, DialogTrigger } from 'ui'
 
 import {
   EdgeFunctionsListItem,
@@ -26,7 +15,6 @@ import type { NextPageWithLayout } from 'types'
 
 const PageLayout: NextPageWithLayout = () => {
   const { ref } = useParams()
-  const [showTerminalInstructions, setShowTerminalInstructions] = useState(false)
 
   const {
     data: functions,
@@ -55,9 +43,7 @@ const PageLayout: NextPageWithLayout = () => {
                   } deployed`}</span>
                   <Dialog>
                     <DialogTrigger asChild>
-                      <Button type="primary" onClick={() => setShowTerminalInstructions(true)}>
-                        Deploy a new function
-                      </Button>
+                      <Button type="primary">Deploy a new function</Button>
                     </DialogTrigger>
                     <DialogContent size={'large'}>
                       <DialogSection padding="small">


### PR DESCRIPTION
- Add "Clear search" CTA for logs search input
  - Also added tooltips for the CTAs
- Clear selectedLog + selectedRow when search input changes
- Fix searching in cron logs crashing the client
- Minor fix to align function name
  - But i reckon long term fix is to have the layout here consistent with the rest of the other page
- Fix spacing between header and loading line
- Default entry page to functions metrics (renamed to overview)
- Shift order of edge functions nav tabs to overview, invocations, logs, details