### PR TITLE
fix: add link to password reset from react native

### DIFF
--- a/apps/docs/content/guides/auth/native-mobile-deep-linking.mdx
+++ b/apps/docs/content/guides/auth/native-mobile-deep-linking.mdx
@@ -9,7 +9,7 @@ Many Auth methods involve a redirect to your app. For example:
 - Signup confirmation emails, Magic Link signins, and password reset emails contain a link that redirects to your app.
 - In OAuth signins, an automatic redirect occurs to your app.
 
-With Deep Linking, you can configure this redirect to open a specific page. This is necessary if, for example, you need to display a form for password reset, or to manually exchange a token hash.
+With Deep Linking, you can configure this redirect to open a specific page. This is necessary if, for example, you need to display a form for [password reset](/docs/guides/auth/passwords#resetting-a-users-password-forgot-password), or to manually exchange a token hash.
 
 ## Setting up deep linking
 


### PR DESCRIPTION
## Context

Following up from [this internal task](https://www.notion.so/supabase/Add-Docs-on-Reset-Password-to-React-Native-c34fa8ae1a1b436286f4b5e57688d61b) Feel free to close if there's another preferred approach