### PR TITLE
updated self hosting guide for edge functions

### DIFF
--- a/apps/docs/docs/ref/self-hosting-functions/introduction.mdx
+++ b/apps/docs/docs/ref/self-hosting-functions/introduction.mdx
@@ -29,15 +29,29 @@ Self hosted Edge functions are in beta. There will be breaking changes to APIs /
 
 ## How to run locally
 
-```bash
-./run.sh start --main-service /path/to/supabase/functions -p 9000
+Place you functions in `<directory_containing_docker-compose.yml>/volumes/functions/` then, edit the `docker-compose.yml` file. In the functions section add
 ```
-
-using Docker:
-
-```bash
-docker build -t edge-runtime .
-docker run -it --rm -p 9000:9000 -v /path/to/supabase/functions:/usr/services supabase/edge-runtime start --main-service /usr/services
+ports:
+  - 9000:9000
+```
+and edit the command to start your function 
+```
+command:
+  - start
+  - --main-service
+  - /home/deno/functions/<function-name>
+```
+or to start all functions
+```
+command:
+  - start
+  - --main-service
+  - /home/deno/functions
+```
+finally restart supabase
+```
+docker compose down
+docker compose up -d
 ```
 
 ## How to update to a newer Deno version


### PR DESCRIPTION
previous version didn't explain anything and was confusing

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

updates self hosting functions guide, specifically the running locally part.

## What is the current behavior?

currently the running locally part only has 3 commands with no explanation whatsoever. It doesn't tell where to run them, the first command also uses a run.sh script with no reference to what that is.

## What is the new behavior?

clearly explains how to get your function up and running when self hosting supabase

## Additional context

I myself had a lot of trouble in the previous days trying to get functions to work and the doc did not help in the slightest. Hopefully no one will go through that again
