### PR TITLE
style: align svg icon to the center of the container

### DIFF
--- a/apps/studio/components/ui/States/EmptyListState.tsx
+++ b/apps/studio/components/ui/States/EmptyListState.tsx
@@ -10,8 +10,7 @@ const EmptyListState = ({ title, description }: { title: string; description: st
     "
     >
       <div className="flex flex-col gap-1">
-        <div className="relative flex h-4 w-32 items-center rounded border border-dashed px-2"></div>
-        <div className="relative flex h-4 w-32 items-center rounded border border-dashed px-2">
+        <div className="relative flex h-4 w-32 items-center justify-center rounded border border-dashed px-2">
           <div className="absolute -bottom-4">
             <svg
               xmlns="http://www.w3.org/2000/svg"

--- a/apps/studio/components/ui/States/EmptyListState.tsx
+++ b/apps/studio/components/ui/States/EmptyListState.tsx
@@ -12,7 +12,7 @@ const EmptyListState = ({ title, description }: { title: string; description: st
       <div className="flex flex-col gap-1">
         <div className="relative flex h-4 w-32 items-center rounded border border-dashed px-2"></div>
         <div className="relative flex h-4 w-32 items-center rounded border border-dashed px-2">
-          <div className="absolute right-1 -bottom-4">
+          <div className="absolute -bottom-4">
             <svg
               xmlns="http://www.w3.org/2000/svg"
               className="h-6 w-6"


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.
YES

## What kind of change does this PR introduce?
Style fix - Aligns the SVG icon in the empty state to the center of the container div

## What is the current behavior?

<img width="945" alt="image" src="https://github.com/user-attachments/assets/417207fb-6af3-4208-a28f-26b093e824b6" />

## What is the new behavior?

<img width="922" alt="image" src="https://github.com/user-attachments/assets/42099059-33a4-4e79-bcd3-43de348ace99" />

