### PR TITLE
fix: nodejs and golang direct connection strings

### DIFF
--- a/apps/studio/components/interfaces/Connect/DatabaseSettings.utils.ts
+++ b/apps/studio/components/interfaces/Connect/DatabaseSettings.utils.ts
@@ -51,7 +51,7 @@ export const getConnectionStrings = (
 
   const directUriString = `postgresql://${directUser}:${password}@${directHost}:${directPort}/${directName}`
 
-  const directGolangString = `DATABASE_URL=${poolingInfo.connectionString}`
+  const directGolangString = `DATABASE_URL=${directUriString}`
 
   const directJdbcString = `jdbc:postgresql://${directHost}:${directPort}/${directName}?user=${directUser}&password=${password}`
 
@@ -68,6 +68,8 @@ export const getConnectionStrings = (
     "DefaultConnection": "User Id=${poolerUser};Password=${password};Server=${poolerHost};Port=${poolerPort};Database=${poolerName}${isMd5 ? `;Options='reference=${projectRef}'` : ''}"
   }
 }`
+
+  const directNodejsString = `DATABASE_URL=${directUriString}`
 
   // Pooler connection strings
   const poolerPsqlString = isMd5
@@ -105,7 +107,7 @@ dbname=${poolerName}`
       golang: directGolangString,
       jdbc: directJdbcString,
       dotnet: directDotNetString,
-      nodejs: nodejsPoolerUriString,
+      nodejs: directNodejsString,
       php: directGolangString,
       python: directGolangString,
       sqlalchemy: sqlalchemyString,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Node.js and Go showing the pooler connection string instead of the direct connection string.

## What is the new behavior?

Properly showing the direct connection string.