### PR TITLE
Update docker-compose.yml to fix healthcheck timeout warning.

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,7 +17,7 @@ services:
           "CMD",
           "node",
           "-e",
-          "fetch('http://studio:3000/api/profile').then((r) => {if (r.status !== 200) throw new Error(r.status)})"
+          "fetch('http://studio:3000/api/profile').then((r) => {if (r.status !== 200) throw new Error(r.status); process.exit(0);})"
         ]
       timeout: 10s
       interval: 5s


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

I was running the supabase docker compose with Tilt on local. The health check of studio container always mark as "red"

## What is the new behavior?

Healthcheck passed for studio service.

## Additional context
Before this change:
<img width="1074" alt="image" src="https://github.com/user-attachments/assets/1b80eb00-b9e4-494e-8fee-be5307eae1b3" />

After:
<img width="1146" alt="image" src="https://github.com/user-attachments/assets/c064445a-4058-40d6-97d7-bd524a872153" />


