### PR TITLE
fix: fix horizontal scroll reset when clicking timestamp cells on the Dashboard

### DIFF
--- a/apps/studio/components/grid/components/editor/DateTimeEditor.tsx
+++ b/apps/studio/components/grid/components/editor/DateTimeEditor.tsx
@@ -73,7 +73,7 @@ function BaseEditor<TRow, TSummaryRow = unknown>({
           onEnter={saveChanges}
         >
           <Input
-            autoFocus
+            ref={ref}
             value={inputValue ?? ''}
             placeholder={FORMAT_MAP[type]}
             onChange={(e) => setInputValue(e.target.value)}

--- a/apps/studio/components/grid/components/editor/DateTimeEditor.tsx
+++ b/apps/studio/components/grid/components/editor/DateTimeEditor.tsx
@@ -51,7 +51,11 @@ function BaseEditor<TRow, TSummaryRow = unknown>({
   }
 
   useEffect(() => {
-    if (ref.current) ref.current.focus()
+    try {
+      ref.current?.focus({ preventScroll: true })
+    } catch (e) {
+      ref.current?.focus()
+    }
   }, [])
 
   return (


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Horizontal scroll resets when clicking timestamp cells on the Dashboard

## What is the new behavior?

Prevent Dashboard from resetting horizontal scroll on timestamp cell click

## Additional Context
https://github.com/supabase/supabase/issues/31623