### PR TITLE
fix(docs): correct typo in create unlogged queue

### DIFF
--- a/apps/docs/content/guides/queues/pgmq.mdx
+++ b/apps/docs/content/guides/queues/pgmq.mdx
@@ -49,7 +49,7 @@ select from pgmq.create('my_queue');
 
 #### `create_unlogged`
 
-Creates an unlogged table. This is useful when write throughput is more important that durability.
+Creates an unlogged table. This is useful when write throughput is more important than durability.
 See Postgres documentation for [unlogged tables](https://www.postgresql.org/docs/current/sql-createtable.html#SQL-CREATETABLE-UNLOGGED) for more information.
 
 {/* prettier-ignore */}


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Fix docs

## What is the current behavior?

The sentence has a small grammatical error

## What is the new behavior?

Correct and clear sentence

## Additional context

