### PR TITLE
fix: not-prose on admonition.tsx

### DIFF
--- a/packages/ui-patterns/admonition.tsx
+++ b/packages/ui-patterns/admonition.tsx
@@ -102,6 +102,7 @@ export const Admonition = forwardRef<
         variant={typeMapped}
         {...props}
         className={cn(
+          'not-prose',
           'mb-2',
           admonitionSVG({ type: typeMapped }),
           admonitionBase({ type: typeMapped }),


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

uses `not-prose` admonition so that tailwind typography styles don't apply