### PR TITLE
chore: add ai assistant event docs

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
@@ -421,7 +421,7 @@ export const SQLEditor = () => {
         }
       }
 
-      sendEvent({ action: TelemetryActions.ASSISTANT_SUGGESTION_ACCEPTED })
+      sendEvent({ action: TelemetryActions.ASSISTANT_SUGGESTION_ACCEPT_CLICKED })
 
       setSelectedDiffType(DiffType.Modification)
       resetPrompt()
@@ -442,7 +442,7 @@ export const SQLEditor = () => {
   ])
 
   const discardAiHandler = useCallback(() => {
-    sendEvent({ action: TelemetryActions.ASSISTANT_SUGGESTION_REJECTED })
+    sendEvent({ action: TelemetryActions.ASSISTANT_SUGGESTION_REJECT_CLICKED })
     resetPrompt()
     closeDiff()
   }, [closeDiff, resetPrompt, sendEvent])

--- a/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
@@ -421,7 +421,10 @@ export const SQLEditor = () => {
         }
       }
 
-      sendEvent({ action: TelemetryActions.ASSISTANT_SUGGESTION_ACCEPT_CLICKED })
+      sendEvent({
+        action: TelemetryActions.ASSISTANT_SQL_DIFF_HANDLER_EVALUATED,
+        properties: { handlerAccepted: true },
+      })
 
       setSelectedDiffType(DiffType.Modification)
       resetPrompt()
@@ -442,7 +445,10 @@ export const SQLEditor = () => {
   ])
 
   const discardAiHandler = useCallback(() => {
-    sendEvent({ action: TelemetryActions.ASSISTANT_SUGGESTION_REJECT_CLICKED })
+    sendEvent({
+      action: TelemetryActions.ASSISTANT_SQL_DIFF_HANDLER_EVALUATED,
+      properties: { handlerAccepted: false },
+    })
     resetPrompt()
     closeDiff()
   }, [closeDiff, resetPrompt, sendEvent])

--- a/apps/studio/components/ui/AIAssistantPanel/SqlSnippet.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/SqlSnippet.tsx
@@ -261,7 +261,13 @@ export const SqlCard = ({
                     icon={<Edit size={14} />}
                     onClick={() => {
                       handleEditInSQLEditor()
-                      sendEvent({ action: TelemetryActions.ASSISTANT_EDIT_SQL_CLICKED })
+                      sendEvent({
+                        action: TelemetryActions.ASSISTANT_EDIT_IN_SQL_EDITOR_CLICKED,
+                        properties: {
+                          isInSQLEditor,
+                          isInNewSnippet,
+                        },
+                      })
                     }}
                     tooltip={{ content: { side: 'bottom', text: 'Edit in SQL Editor' } }}
                   />

--- a/apps/studio/components/ui/AIAssistantPanel/SqlSnippet.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/SqlSnippet.tsx
@@ -213,7 +213,7 @@ export const SqlCard = ({
                   })
 
                   sendEvent({
-                    action: TelemetryActions.ASSISTANT_SUGGESTION_RAN,
+                    action: TelemetryActions.ASSISTANT_SUGGESTION_RUN_QUERY_CLICKED,
                     properties: {
                       type: 'mutation',
                       category: identifyQueryType(sql) ?? 'unknown',
@@ -306,7 +306,7 @@ export const SqlCard = ({
                     handleExecute()
                     if (isReadOnlySelect(sql)) {
                       sendEvent({
-                        action: TelemetryActions.ASSISTANT_SUGGESTION_RAN,
+                        action: TelemetryActions.ASSISTANT_SUGGESTION_RUN_QUERY_CLICKED,
                         properties: { type: 'select' },
                       })
                     }

--- a/apps/studio/data/telemetry/send-event-mutation.ts
+++ b/apps/studio/data/telemetry/send-event-mutation.ts
@@ -30,6 +30,12 @@ import {
   RealtimeInspectorCopyMessageClickedEvent,
   RealtimeInspectorFiltersAppliedEvent,
   RealtimeInspectorDatabaseRoleUpdatedEvent,
+  AssistantPromptSubmittedEvent,
+  AssistantDebugSubmittedEvent,
+  AssistantSuggestionRanEvent,
+  AssistantSuggestionAcceptedEvent,
+  AssistantSuggestionRejectedEvent,
+  AssistantEditSqlClickedEvent,
 } from 'lib/constants/telemetry'
 import { useRouter } from 'next/router'
 import type { ResponseError } from 'types'
@@ -59,6 +65,12 @@ export type SendEventVariables =
   | SqlEditorResultDownloadCsvClickedEvent
   | SqlEditorResultCopyMarkdownClickedEvent
   | SqlEditorResultCopyJsonClickedEvent
+  | AssistantPromptSubmittedEvent
+  | AssistantDebugSubmittedEvent
+  | AssistantSuggestionRanEvent
+  | AssistantSuggestionAcceptedEvent
+  | AssistantSuggestionRejectedEvent
+  | AssistantEditSqlClickedEvent
 
   // TODO remove this once all events are documented
   | {

--- a/apps/studio/data/telemetry/send-event-mutation.ts
+++ b/apps/studio/data/telemetry/send-event-mutation.ts
@@ -32,9 +32,9 @@ import {
   RealtimeInspectorDatabaseRoleUpdatedEvent,
   AssistantPromptSubmittedEvent,
   AssistantDebugSubmittedEvent,
-  AssistantSuggestionRanEvent,
-  AssistantSuggestionAcceptedEvent,
-  AssistantSuggestionRejectedEvent,
+  AssistantSuggestionRunQueryClickedEvent,
+  AssistantSuggestionAcceptClickedEvent,
+  AssistantSuggestionRejectClickedEvent,
   AssistantEditSqlClickedEvent,
 } from 'lib/constants/telemetry'
 import { useRouter } from 'next/router'
@@ -67,9 +67,9 @@ export type SendEventVariables =
   | SqlEditorResultCopyJsonClickedEvent
   | AssistantPromptSubmittedEvent
   | AssistantDebugSubmittedEvent
-  | AssistantSuggestionRanEvent
-  | AssistantSuggestionAcceptedEvent
-  | AssistantSuggestionRejectedEvent
+  | AssistantSuggestionRunQueryClickedEvent
+  | AssistantSuggestionAcceptClickedEvent
+  | AssistantSuggestionRejectClickedEvent
   | AssistantEditSqlClickedEvent
 
   // TODO remove this once all events are documented

--- a/apps/studio/data/telemetry/send-event-mutation.ts
+++ b/apps/studio/data/telemetry/send-event-mutation.ts
@@ -33,9 +33,8 @@ import {
   AssistantPromptSubmittedEvent,
   AssistantDebugSubmittedEvent,
   AssistantSuggestionRunQueryClickedEvent,
-  AssistantSuggestionAcceptClickedEvent,
-  AssistantSuggestionRejectClickedEvent,
-  AssistantEditSqlClickedEvent,
+  AssistantSqlDiffHandlerEvaluatedEvent,
+  AssistantEditInSqlEditorClickedEvent,
 } from 'lib/constants/telemetry'
 import { useRouter } from 'next/router'
 import type { ResponseError } from 'types'
@@ -68,9 +67,8 @@ export type SendEventVariables =
   | AssistantPromptSubmittedEvent
   | AssistantDebugSubmittedEvent
   | AssistantSuggestionRunQueryClickedEvent
-  | AssistantSuggestionAcceptClickedEvent
-  | AssistantSuggestionRejectClickedEvent
-  | AssistantEditSqlClickedEvent
+  | AssistantSqlDiffHandlerEvaluatedEvent
+  | AssistantEditInSqlEditorClickedEvent
 
   // TODO remove this once all events are documented
   | {

--- a/apps/studio/lib/constants/telemetry.ts
+++ b/apps/studio/lib/constants/telemetry.ts
@@ -9,7 +9,6 @@ export enum TelemetryActions {
   ASSISTANT_SUGGESTION_RAN = 'assistant_suggestion_ran',
   ASSISTANT_SUGGESTION_ACCEPTED = 'assistant_suggestion_accepted',
   ASSISTANT_SUGGESTION_REJECTED = 'assistant_suggestion_rejected',
-  ASSISTANT_SUGGESTION_COPIED = 'assistant_suggestion_copied',
   ASSISTANT_EDIT_SQL_CLICKED = 'assistant_edit_sql_clicked',
 
   CONNECTION_STRING_COPIED = 'connection_string_copied',
@@ -371,4 +370,71 @@ export interface SqlEditorResultCopyMarkdownClickedEvent {
  */
 export interface SqlEditorResultCopyJsonClickedEvent {
   action: TelemetryActions.SQL_EDITOR_RESULT_COPY_JSON_CLICKED
+}
+
+/**
+ * User submitted a prompt to the assistant.
+ *
+ * @group Events
+ * @source studio
+ */
+export interface AssistantPromptSubmittedEvent {
+  action: TelemetryActions.ASSISTANT_PROMPT_SUBMITTED
+}
+
+/**
+ * User submitted a debug request to the assistant or prompt submitted has Help me to debug.
+ *
+ * @group Events
+ * @source studio
+ */
+export interface AssistantDebugSubmittedEvent {
+  action: TelemetryActions.ASSISTANT_DEBUG_SUBMITTED
+}
+
+/**
+ * User ran a suggestion provided by the assistant.
+ *
+ * @group Events
+ * @source studio
+ */
+export interface AssistantSuggestionRanEvent {
+  action: TelemetryActions.ASSISTANT_SUGGESTION_RAN
+  properties: {
+    /**
+     * The type of suggestion that was run by the user. Mutate or Select query types only.
+     */
+    type: string
+    category?: string
+  }
+}
+
+/**
+ * User accepted a suggestion after clicking any option in Edit in Sql Editor in suggestion provided by the assistant.
+ *
+ * @group Events
+ * @source studio
+ */
+export interface AssistantSuggestionAcceptedEvent {
+  action: TelemetryActions.ASSISTANT_SUGGESTION_ACCEPTED
+}
+
+/**
+ * User rejected a suggestion after clicking any option in Edit in SQL Editor in suggestion provided by the assistant.
+ *
+ * @group Events
+ * @source studio
+ */
+export interface AssistantSuggestionRejectedEvent {
+  action: TelemetryActions.ASSISTANT_SUGGESTION_REJECTED
+}
+
+/**
+ * User clicked to edit SQL in the assistant when user is not in SQL editor.
+ *
+ * @group Events
+ * @source studio
+ */
+export interface AssistantEditSqlClickedEvent {
+  action: TelemetryActions.ASSISTANT_EDIT_SQL_CLICKED
 }

--- a/apps/studio/lib/constants/telemetry.ts
+++ b/apps/studio/lib/constants/telemetry.ts
@@ -373,7 +373,7 @@ export interface SqlEditorResultCopyJsonClickedEvent {
 }
 
 /**
- * User submitted a prompt to the assistant.
+ * User submitted a prompt to the assistant sidebar.
  *
  * @group Events
  * @source studio
@@ -383,7 +383,7 @@ export interface AssistantPromptSubmittedEvent {
 }
 
 /**
- * User submitted a debug request to the assistant or prompt submitted has Help me to debug.
+ * User submitted a debug request to the assistant sidebar or prompt submitted has Help me to debug.
  *
  * @group Events
  * @source studio
@@ -393,7 +393,7 @@ export interface AssistantDebugSubmittedEvent {
 }
 
 /**
- * User ran a suggestion provided by the assistant.
+ * User ran a suggestion provided by the assistant sidebar.
  *
  * @group Events
  * @source studio
@@ -414,6 +414,7 @@ export interface AssistantSuggestionRanEvent {
  *
  * @group Events
  * @source studio
+ * @page /dashboard/project/{ref}/sql
  */
 export interface AssistantSuggestionAcceptedEvent {
   action: TelemetryActions.ASSISTANT_SUGGESTION_ACCEPTED
@@ -424,13 +425,14 @@ export interface AssistantSuggestionAcceptedEvent {
  *
  * @group Events
  * @source studio
+ * @page /dashboard/project/{ref}/sql
  */
 export interface AssistantSuggestionRejectedEvent {
   action: TelemetryActions.ASSISTANT_SUGGESTION_REJECTED
 }
 
 /**
- * User clicked to edit SQL in the assistant when user is not in SQL editor.
+ * User clicked to edit SQL in the assistant when user is in any page that does not have 'sql' in url. Will be redirected to SQL editor after clicking.
  *
  * @group Events
  * @source studio

--- a/apps/studio/lib/constants/telemetry.ts
+++ b/apps/studio/lib/constants/telemetry.ts
@@ -6,9 +6,9 @@ export enum TelemetryActions {
 
   ASSISTANT_PROMPT_SUBMITTED = 'assistant_prompt_submitted',
   ASSISTANT_DEBUG_SUBMITTED = 'assistant_debug_submitted',
-  ASSISTANT_SUGGESTION_RAN = 'assistant_suggestion_ran',
-  ASSISTANT_SUGGESTION_ACCEPTED = 'assistant_suggestion_accepted',
-  ASSISTANT_SUGGESTION_REJECTED = 'assistant_suggestion_rejected',
+  ASSISTANT_SUGGESTION_RUN_QUERY_CLICKED = 'assistant_suggestion_run_query_clicked',
+  ASSISTANT_SUGGESTION_ACCEPT_CLICKED = 'assistant_suggestion_accept_clicked',
+  ASSISTANT_SUGGESTION_REJECT_CLICKED = 'assistant_suggestion_reject_clicked',
   ASSISTANT_EDIT_SQL_CLICKED = 'assistant_edit_sql_clicked',
 
   CONNECTION_STRING_COPIED = 'connection_string_copied',
@@ -393,13 +393,13 @@ export interface AssistantDebugSubmittedEvent {
 }
 
 /**
- * User ran a suggestion provided by the assistant sidebar.
+ * User clicked the run query button in the suggestion provided by the assistant sidebar.
  *
  * @group Events
  * @source studio
  */
-export interface AssistantSuggestionRanEvent {
-  action: TelemetryActions.ASSISTANT_SUGGESTION_RAN
+export interface AssistantSuggestionRunQueryClickedEvent {
+  action: TelemetryActions.ASSISTANT_SUGGESTION_RUN_QUERY_CLICKED
   properties: {
     /**
      * The type of suggestion that was run by the user. Mutate or Select query types only.
@@ -416,8 +416,8 @@ export interface AssistantSuggestionRanEvent {
  * @source studio
  * @page /dashboard/project/{ref}/sql
  */
-export interface AssistantSuggestionAcceptedEvent {
-  action: TelemetryActions.ASSISTANT_SUGGESTION_ACCEPTED
+export interface AssistantSuggestionAcceptClickedEvent {
+  action: TelemetryActions.ASSISTANT_SUGGESTION_ACCEPT_CLICKED
 }
 
 /**
@@ -427,8 +427,8 @@ export interface AssistantSuggestionAcceptedEvent {
  * @source studio
  * @page /dashboard/project/{ref}/sql
  */
-export interface AssistantSuggestionRejectedEvent {
-  action: TelemetryActions.ASSISTANT_SUGGESTION_REJECTED
+export interface AssistantSuggestionRejectClickedEvent {
+  action: TelemetryActions.ASSISTANT_SUGGESTION_REJECT_CLICKED
 }
 
 /**

--- a/apps/studio/lib/constants/telemetry.ts
+++ b/apps/studio/lib/constants/telemetry.ts
@@ -410,7 +410,7 @@ export interface AssistantSuggestionRanEvent {
 }
 
 /**
- * User accepted a suggestion after clicking any option in Edit in Sql Editor in suggestion provided by the assistant.
+ * User accepted a suggestion after clicking any option in Edit in Sql Editor in suggestion provided by the assistant. The options only appear in any page with 'sql' in url.
  *
  * @group Events
  * @source studio
@@ -421,7 +421,7 @@ export interface AssistantSuggestionAcceptedEvent {
 }
 
 /**
- * User rejected a suggestion after clicking any option in Edit in SQL Editor in suggestion provided by the assistant.
+ * User rejected a suggestion after clicking any option in Edit in SQL Editor in suggestion provided by the assistant. The options only appear in any page with 'sql' in url.
  *
  * @group Events
  * @source studio

--- a/apps/studio/lib/constants/telemetry.ts
+++ b/apps/studio/lib/constants/telemetry.ts
@@ -7,9 +7,8 @@ export enum TelemetryActions {
   ASSISTANT_PROMPT_SUBMITTED = 'assistant_prompt_submitted',
   ASSISTANT_DEBUG_SUBMITTED = 'assistant_debug_submitted',
   ASSISTANT_SUGGESTION_RUN_QUERY_CLICKED = 'assistant_suggestion_run_query_clicked',
-  ASSISTANT_SUGGESTION_ACCEPT_CLICKED = 'assistant_suggestion_accept_clicked',
-  ASSISTANT_SUGGESTION_REJECT_CLICKED = 'assistant_suggestion_reject_clicked',
-  ASSISTANT_EDIT_SQL_CLICKED = 'assistant_edit_sql_clicked',
+  ASSISTANT_SQL_DIFF_HANDLER_EVALUATED = 'assistant_sql_diff_handler_evaluated',
+  ASSISTANT_EDIT_IN_SQL_EDITOR_CLICKED = 'assistant_edit_in_sql_editor_clicked',
 
   CONNECTION_STRING_COPIED = 'connection_string_copied',
 
@@ -393,7 +392,7 @@ export interface AssistantDebugSubmittedEvent {
 }
 
 /**
- * User clicked the run query button in the suggestion provided by the assistant sidebar.
+ * User clicked the run query button in the suggestion provided in the assistant sidebar.
  *
  * @group Events
  * @source studio
@@ -404,39 +403,41 @@ export interface AssistantSuggestionRunQueryClickedEvent {
     /**
      * The type of suggestion that was run by the user. Mutate or Select query types only.
      */
-    type: string
+    queryType: string
     category?: string
   }
 }
 
 /**
- * User accepted a suggestion after clicking any option in Edit in Sql Editor in suggestion provided by the assistant. The options only appear in any page with 'sql' in url.
+ * User accepted or rejected changes in sql ai diff handler. They can accept change by clicking accept button or typing shortcut (CMD+Enter) or reject by clicking reject button or typing shortcut (Esc). Handler only appears after clicking any dropdown option in Edit in Sql Editor in suggestion provided by the assistant. The dropdown options only appear in any page with 'sql' in url.
  *
  * @group Events
  * @source studio
  * @page /dashboard/project/{ref}/sql
  */
-export interface AssistantSuggestionAcceptClickedEvent {
-  action: TelemetryActions.ASSISTANT_SUGGESTION_ACCEPT_CLICKED
+export interface AssistantSqlDiffHandlerEvaluatedEvent {
+  action: TelemetryActions.ASSISTANT_SQL_DIFF_HANDLER_EVALUATED
+  properties: {
+    /**
+     * Whether the user accepted or rejected the changes.
+     */
+    handlerAccepted: boolean
+  }
 }
 
 /**
- * User rejected a suggestion after clicking any option in Edit in SQL Editor in suggestion provided by the assistant. The options only appear in any page with 'sql' in url.
- *
- * @group Events
- * @source studio
- * @page /dashboard/project/{ref}/sql
- */
-export interface AssistantSuggestionRejectClickedEvent {
-  action: TelemetryActions.ASSISTANT_SUGGESTION_REJECT_CLICKED
-}
-
-/**
- * User clicked to edit SQL in the assistant when user is in any page that does not have 'sql' in url. Will be redirected to SQL editor after clicking.
+ * User clicked Edit in SQL Editor button in the assistant sidebar when user is in any page that does not have 'sql' in url or is in a new snippet.
  *
  * @group Events
  * @source studio
  */
-export interface AssistantEditSqlClickedEvent {
-  action: TelemetryActions.ASSISTANT_EDIT_SQL_CLICKED
+export interface AssistantEditInSqlEditorClickedEvent {
+  action: TelemetryActions.ASSISTANT_EDIT_IN_SQL_EDITOR_CLICKED
+  properties: {
+    /**
+     * Whether the user is in the SQL editor page or in a new snippet.
+     */
+    isInSQLEditor: boolean
+    isInNewSnippet: boolean
+  }
 }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

add documentation and tested requests being sent for ai assistant related events. 

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
