### PR TITLE
fix: fixed the broken external link for "view access control docs" in auth settings

### DIFF
--- a/apps/studio/components/interfaces/Auth/BasicAuthSettingsForm/BasicAuthSettingsForm.tsx
+++ b/apps/studio/components/interfaces/Auth/BasicAuthSettingsForm/BasicAuthSettingsForm.tsx
@@ -254,7 +254,7 @@ const BasicAuthSettingsForm = () => {
                               className="w-min"
                               icon={<ExternalLink />}
                             >
-                              <Link href="/docs/guides/auth/auth-anonymous#access-control">
+                              <Link href="https://supabase.com/docs/guides/auth/auth-anonymous#access-control">
                                 View access control docs
                               </Link>
                             </Button>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Fixed the broken link in Project Settings  → Auth Settings

![CleanShot 2024-12-31 at 14 36 07@2x](https://github.com/user-attachments/assets/041d34c1-222a-4634-a058-71c84710c71e)


## What is the current behavior?

Currently the link points to /docs/guides/auth/auth-anonymous#access-control
It will cause an error because the Dashboard URL is relative to https://supabase.com/dashboard

## What is the new behavior?

Fixed the link point to https://supabase.com/docs/guides/auth/auth-anonymous#access-control with the full docs URL

## Additional context

Customer feedback in support ticket #18258161809
