### PR TITLE
fix: update json editor initial value formatting (#30990)

### DIFF
--- a/apps/studio/components/grid/components/editor/JsonEditor.tsx
+++ b/apps/studio/components/grid/components/editor/JsonEditor.tsx
@@ -1,4 +1,3 @@
-import { isNil } from 'lodash'
 import { Maximize } from 'lucide-react'
 import { useCallback, useState } from 'react'
 import type { RenderEditCellProps } from 'react-data-grid'
@@ -65,13 +64,15 @@ export const JsonEditor = <TRow, TSummaryRow = unknown>({
   })
 
   const gridColumn = state.gridColumns.find((x) => x.name == column.key)
-  const initialValue = row[column.key as keyof TRow]
-  const stringifiedValue = Array.isArray(initialValue)
-    ? JSON.stringify(initialValue)
-    : (initialValue as string)
-  const jsonString = prettifyJSON(
-    !isNil(stringifiedValue) ? tryFormatInitialValue(stringifiedValue) : ''
-  )
+
+  const rawInitialValue = row[column.key as keyof TRow] as unknown
+  const initialValue =
+    rawInitialValue === null || rawInitialValue === undefined || typeof rawInitialValue === 'string'
+      ? rawInitialValue
+      : JSON.stringify(rawInitialValue)
+
+  const jsonString = prettifyJSON(initialValue ? tryFormatInitialValue(initialValue) : '')
+
   const isTruncated =
     typeof initialValue === 'string' &&
     initialValue.endsWith('...') &&

--- a/apps/studio/components/grid/components/editor/JsonEditor.tsx
+++ b/apps/studio/components/grid/components/editor/JsonEditor.tsx
@@ -65,8 +65,13 @@ export const JsonEditor = <TRow, TSummaryRow = unknown>({
   })
 
   const gridColumn = state.gridColumns.find((x) => x.name == column.key)
-  const initialValue = row[column.key as keyof TRow] as string
-  const jsonString = prettifyJSON(!isNil(initialValue) ? tryFormatInitialValue(initialValue) : '')
+  const initialValue = row[column.key as keyof TRow]
+  const stringifiedValue = Array.isArray(initialValue)
+    ? JSON.stringify(initialValue)
+    : (initialValue as string)
+  const jsonString = prettifyJSON(
+    !isNil(stringifiedValue) ? tryFormatInitialValue(stringifiedValue) : ''
+  )
   const isTruncated =
     typeof initialValue === 'string' &&
     initialValue.endsWith('...') &&


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Grid Json Editor initial value bug fix for arrays containing one item.

## What is the current behavior?

Issue #30990 

![jsonEditorCurrent](https://github.com/user-attachments/assets/3d90c804-76e1-4ea4-8d9b-19130e27839c)

## What is the new behavior?

![jsonEditorFix](https://github.com/user-attachments/assets/b220b7b6-8b1c-4c62-9947-018adb2f7e34)

## Additional context

Add any other context or screenshots.
