### PR TITLE
docs(python): add resumable uploads example

### DIFF
--- a/apps/docs/content/guides/storage/uploads/resumable-uploads.mdx
+++ b/apps/docs/content/guides/storage/uploads/resumable-uploads.mdx
@@ -205,6 +205,53 @@ Supabase Storage implements the [TUS protocol](https://tus.io/) to enable resuma
     ```
 
   </TabPanel>
+
+  <TabPanel id="py" label="Python">
+
+    Here's an example of how to upload a file using [`tus-py-client`](https://github.com/tus/tus-py-client):
+
+    ```python
+    from io import BufferedReader
+    from tusclient import client
+    from supabase import create_client
+
+    def upload_file(
+        bucket_name: str, file_name: str, file: BufferedReader, access_token: str
+    ):
+        # create Tus client
+        my_client = client.TusClient(
+            f"{supabase_url}/storage/v1/upload/resumable",
+            headers={"Authorization": f"Bearer {access_token}", "x-upsert": "true"},
+        )
+        uploader = my_client.uploader(
+            file_stream=file,
+            chunk_size=(6 * 1024 * 1024),
+            metadata={
+                "bucketName": bucket_name,
+                "objectName": file_name,
+                "contentType": "image/png",
+                "cacheControl": "3600",
+            },
+        )
+        uploader.upload()
+
+    # create client and sign in
+    supabase = create_client(supabase_url, supabase_key)
+
+    # retrieve the current user's session for authentication
+    session = supabase.auth.get_session()
+
+    # open file and send file stream to upload
+    with open("./assets/40mb.jpg", "rb") as fs:
+        upload_file(
+            bucket_name="assets",
+            file_name="large_file",
+            file=fs,
+            access_token=session.access_token,
+        )
+    ```
+
+  </TabPanel>
 </Tabs>
 
 ### Upload URL


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

There are no Python examples of handling resumable uploads

## What is the new behavior?

An example for resumable uploads with Python has been added

## Additional context

Add any other context or screenshots.
