### PR TITLE
Fix: change the colour of the 'failed' badge for the cron UI

### DIFF
--- a/apps/studio/components/interfaces/Integrations/CronJobs/CronJobCard.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CronJobCard.tsx
@@ -146,17 +146,12 @@ export const CronJobCard = ({ job, onEditCronJob, onDeleteCronJob }: CronJobCard
                           className="font-sans text-sm"
                         />
                         {data?.status && (
-                          <>
-                            {data.status !== 'failed' ? (
-                              <Badge variant="success" className="capitalize ml-2">
-                                {data.status}
-                              </Badge>
-                            ) : (
-                              <Badge variant="destructive" className="capitalize ml-2">
-                                {data.status}
-                              </Badge>
-                            )}
-                          </>
+                          <Badge
+                            variant={data.status === 'failed' ? 'destructive' : 'success'}
+                            className="capitalize ml-2"
+                          >
+                            {data.status}
+                          </Badge>
                         )}
                       </>
                     ) : (

--- a/apps/studio/components/interfaces/Integrations/CronJobs/CronJobCard.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CronJobCard.tsx
@@ -146,9 +146,17 @@ export const CronJobCard = ({ job, onEditCronJob, onDeleteCronJob }: CronJobCard
                           className="font-sans text-sm"
                         />
                         {data?.status && (
-                          <Badge variant="success" className="capitalize ml-2">
-                            {data.status}
-                          </Badge>
+                          <>
+                            {data.status !== 'failed' ? (
+                              <Badge variant="success" className="capitalize ml-2">
+                                {data.status}
+                              </Badge>
+                            ) : (
+                              <Badge variant="destructive" className="capitalize ml-2">
+                                {data.status}
+                              </Badge>
+                            )}
+                          </>
                         )}
                       </>
                     ) : (


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Only a green badge is displayed, even for the failed status.

## What is the new behavior?

Red badge is displayed when the status is failed.

## Additional context
<img width="579" alt="image" src="https://github.com/user-attachments/assets/a09335e0-e6f2-4020-bc01-fdca6c58dd68" />
