### PR TITLE
update docs: pool mode is permanently set to Transaction

### DIFF
--- a/apps/docs/content/guides/database/drizzle.mdx
+++ b/apps/docs/content/guides/database/drizzle.mdx
@@ -66,7 +66,7 @@ If you plan on solely using Drizzle instead of the Supabase Data API (PostgREST)
 
     Connect to your database using the Connection Pooler.
 
-    In your [`Database Settings`](https://supabase.com/dashboard/project/_/settings/database), make sure `Use connection pooler` is checked, then copy the URI and save it as the `DATABASE_URL` environment variable. Remember to replace the password placeholder with your actual database password.
+   In your [`Database Settings`](https://supabase.com/dashboard/project/_/settings/database), copy the URI and save it as the `DATABASE_URL` environment variable. Remember to replace the password placeholder with your actual database password.
 
     </StepHikeCompact.Details>
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## Additional context

Since the pool mode is permanently set to Transaction on port 6543, there is no need to check the option
