### PR TITLE
studio: update >90 day Paused project docs link

### DIFF
--- a/apps/studio/components/layouts/ProjectLayout/PausedState/PauseDisabledState.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/PausedState/PauseDisabledState.tsx
@@ -184,9 +184,9 @@ export const PauseDisabledState = () => {
           <a
             target="_blank"
             rel="noreferrer"
-            href="https://supabase.com/docs/guides/platform/migrating-and-upgrading-projects#time-limits"
+            href="https://supabase.com/docs/guides/platform/migrating-within-supabase/dashboard-restore"
           >
-            More information
+            How to restore to a new project
           </a>
         </Button>
       </AlertDescription_Shadcn_>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Update button URL and label in studio

## What is the current behavior?
Current "More information" button links to the guide to restore the backup locally instead of to a new Supabase project as there was no dedicated guide to this till now

## What is the new behavior?

Change the URL the More information link on paused projects >90 days to the dedicated guide for dashboard restores

## Additional context
![Screenshot 2025-01-05 at 7 09 53 PM](https://github.com/user-attachments/assets/78fa28c9-edba-4f63-8633-d3fd7cfb0d59)

- The "More information" label changed to "How to restore to a new project" 
- The URL is changed from "https://supabase.com/docs/guides/platform/upgrading#time-limits" to "https://supabase.com/docs/guides/platform/migrating-within-supabase/dashboard-restore"
