### PR TITLE
Fix next run data for cron job not using UTC

### DIFF
--- a/apps/studio/components/interfaces/Integrations/CronJobs/CronJobCard.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CronJobCard.tsx
@@ -47,6 +47,7 @@ export const CronJobCard = ({ job, onEditCronJob, onDeleteCronJob }: CronJobCard
   })
   const lastRun = data?.start_time ? dayjs(data.start_time).valueOf() : undefined
   const nextRun = getNextRun(job.schedule, data?.start_time)
+  console.log(job.jobname, { nextRun: dayjs(nextRun).format('DD MMM YYYY HH:mm:ss (ZZ)') })
   const schedule = convertCronToString(job.schedule)
 
   const { mutate: sendEvent } = useSendEventMutation()

--- a/apps/studio/components/interfaces/Integrations/CronJobs/CronJobCard.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CronJobCard.tsx
@@ -47,7 +47,6 @@ export const CronJobCard = ({ job, onEditCronJob, onDeleteCronJob }: CronJobCard
   })
   const lastRun = data?.start_time ? dayjs(data.start_time).valueOf() : undefined
   const nextRun = getNextRun(job.schedule, data?.start_time)
-  console.log(job.jobname, { nextRun: dayjs(nextRun).format('DD MMM YYYY HH:mm:ss (ZZ)') })
   const schedule = convertCronToString(job.schedule)
 
   const { mutate: sendEvent } = useSendEventMutation()

--- a/apps/studio/components/interfaces/Integrations/CronJobs/CronJobs.utils.ts
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CronJobs.utils.ts
@@ -209,7 +209,7 @@ export const getNextRun = (schedule: string, lastRun?: string) => {
   // (can't guarantee as scope is quite big)
   if (schedule.includes('*')) {
     try {
-      const interval = parser.parseExpression(schedule)
+      const interval = parser.parseExpression(schedule, { tz: 'UTC' })
       return interval.next().getTime()
     } catch (error) {
       return undefined


### PR DESCRIPTION
"Next run" currently generates a timestamp (using cron-parser) that's in the local timezone already, whereas it should be returned as UTC since cron jobs are all in UTC TZ (Refer to screenshot under "Before")

Before:
![image](https://github.com/user-attachments/assets/cc4ff7fd-d6ea-475d-9fb6-32250215c363)

After:
![image](https://github.com/user-attachments/assets/a62cd7cb-c19c-49c6-b18c-fb6597ba9c8e)
