### PR TITLE
Fix: Add number formatter to Chart Header

### DIFF
--- a/apps/studio/components/ui/Charts/BarChart.tsx
+++ b/apps/studio/components/ui/Charts/BarChart.tsx
@@ -111,7 +111,11 @@ const BarChart = ({
         title={title}
         format={format}
         customDateFormat={customDateFormat}
-        highlightedValue={resolvedHighlightedValue}
+        highlightedValue={
+          typeof resolvedHighlightedValue === 'number'
+            ? numberFormatter(resolvedHighlightedValue, valuePrecision)
+            : resolvedHighlightedValue
+        }
         highlightedLabel={resolvedHighlightedLabel}
         minimalHeader={minimalHeader}
       />


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

- Adds missing number formatter to ChartHeader

## What is the current behavior?

- Large numbers are not formatted correctly
![CleanShot 2025-01-06 at 11 43 39@2x](https://github.com/user-attachments/assets/42d67657-11e3-496d-8f70-cd62c20d3003)

## What is the new behavior?
- Number formatted correctly
![CleanShot 2025-01-06 at 11 43 06@2x](https://github.com/user-attachments/assets/c5ff2ce1-8b62-4d56-bdca-ac86aabcbabd)
