### PR TITLE
fix: make examples available for isr

### DIFF
--- a/apps/docs/.gitignore
+++ b/apps/docs/.gitignore
@@ -26,3 +26,6 @@ yarn-error.log*
 
 # Sitemap
 public/sitemap.xml
+
+# Copied examples folder
+/examples/

--- a/apps/docs/app/guides/(with-sidebar)/graphql/[[...slug]]/page.tsx
+++ b/apps/docs/app/guides/(with-sidebar)/graphql/[[...slug]]/page.tsx
@@ -5,7 +5,7 @@ import rehypeSlug from 'rehype-slug'
 
 import { genGuideMeta } from '~/features/docs/GuidesMdx.utils'
 import { GuideTemplate, newEditLink } from '~/features/docs/GuidesMdx.template'
-import { fetchRevalidatePerDay } from '~/features/helpers.fetch'
+import { fetchRevalidatePerDay_TEMP_TESTING } from '~/features/helpers.fetch'
 import { UrlTransformFunction, linkTransform } from '~/lib/mdx/plugins/rehypeLinkTransform'
 import remarkMkDocsAdmonition from '~/lib/mdx/plugins/remarkAdmonition'
 import { removeTitle } from '~/lib/mdx/plugins/remarkRemoveTitle'
@@ -133,7 +133,7 @@ const getContent = async ({ slug }: Params) => {
 
   const editLink = newEditLink(`${org}/${repo}/blob/${branch}/${docsDir}/${remoteFile}`)
 
-  const response = await fetchRevalidatePerDay(
+  const response = await fetchRevalidatePerDay_TEMP_TESTING(
     `https://raw.githubusercontent.com/${org}/${repo}/${branch}/${docsDir}/${remoteFile}`
   )
 

--- a/apps/docs/features/helpers.fetch.ts
+++ b/apps/docs/features/helpers.fetch.ts
@@ -18,9 +18,11 @@ function fetchWithNextOptions({
   return (info: RequestInfo) => fetch(info, { next, cache })
 }
 
-// const fetchRevalidatePerDay = fetchWithNextOptions({ next: { revalidate: ONE_DAY_IN_SECONDS } })
+const fetchRevalidatePerDay_TEMP_TESTING = fetchWithNextOptions({
+  next: { revalidate: ONE_DAY_IN_SECONDS },
+})
 // [Charis 2024-12-28]
 // Temporarily disabling revalidation as a hotfix for Vercel NFT problem
 const fetchRevalidatePerDay = fetch
 
-export { fetchWithNextOptions, fetchRevalidatePerDay }
+export { fetchWithNextOptions, fetchRevalidatePerDay, fetchRevalidatePerDay_TEMP_TESTING }

--- a/apps/docs/lib/docs.ts
+++ b/apps/docs/lib/docs.ts
@@ -15,7 +15,7 @@ import codeHikeTheme from 'config/code-hike.theme.json' with { type: 'json' }
 // with outputFileTracingIncludes (not auto-traced) will not be found at
 // runtime.
 export const DOCS_DIRECTORY = process.cwd()
-export const EXAMPLES_DIRECTORY = join(DOCS_DIRECTORY, '..', '..', 'examples')
+export const EXAMPLES_DIRECTORY = join(DOCS_DIRECTORY, 'examples')
 export const GUIDES_DIRECTORY = join(DOCS_DIRECTORY, 'content/guides')
 export const REF_DOCS_DIRECTORY = join(DOCS_DIRECTORY, 'docs/ref')
 export const SPEC_DIRECTORY = join(DOCS_DIRECTORY, 'spec')

--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -57,7 +57,11 @@ const nextConfig = {
   experimental: {
     outputFileTracingIncludes: {
       '/api/crawlers': ['./features/docs/generated/**/*', './docs/ref/**/*'],
-      '/guides/**/*': ['./content/guides/**/*', './content/troubleshooting/**/*'],
+      '/guides/**/*': [
+        './content/guides/**/*',
+        './content/troubleshooting/**/*',
+        './examples/**/*',
+      ],
       '/reference/**/*': ['./features/docs/generated/**/*', './docs/ref/**/*'],
     },
     serverComponentsExternalPackages: ['libpg-query'],

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -16,6 +16,7 @@
     "lint": "next lint",
     "lint:mdx": "supa-mdx-lint content/guides --config ../../supa-mdx-lint.config.toml",
     "typecheck": "tsc --noEmit",
+    "pretest": "pnpm run codegen:examples",
     "test": "vitest --exclude \"**/*.smoke.test.ts\"",
     "test:smoke": "pnpm run codegen:references && vitest -t \"prod smoke test\"",
     "embeddings": "tsx scripts/search/generate-embeddings.ts",

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -4,10 +4,10 @@
   "private": true,
   "scripts": {
     "preinstall": "npx only-allow pnpm",
-    "predev": "pnpm run codegen:references",
+    "predev": "pnpm run codegen:references && pnpm run codegen:examples",
     "dev": "next dev --port 3001",
     "dev:secrets:pull": "AWS_PROFILE=supabase-dev node ../../scripts/getSecrets.js -n local/docs",
-    "prebuild": "pnpm run codegen:references",
+    "prebuild": "pnpm run codegen:references && pnpm run codegen:examples",
     "build": "next build",
     "build:analyze": "ANALYZE=true next build",
     "build:sitemap": "tsx ./internals/generate-sitemap.ts",
@@ -23,9 +23,10 @@
     "troubleshooting:sync": "node features/docs/Troubleshooting.script.mjs",
     "last-changed": "tsx scripts/last-changed.ts",
     "last-changed:reset": "pnpm run last-changed -- --reset",
+    "codegen:examples": "cp -r ../../examples ./examples",
     "codegen:references": "tsx features/docs/Reference.generated.script.ts",
     "codemod:frontmatter": "node ./scripts/codemod/mdx-meta.mjs && prettier --write \"content/**/*.mdx\"",
-    "clean": "rimraf node_modules ./docs/features/docs/generated"
+    "clean": "rimraf node_modules ./docs/features/docs/generated ./examples"
   },
   "dependencies": {
     "@code-hike/mdx": "^0.9.0",

--- a/apps/docs/tsconfig.json
+++ b/apps/docs/tsconfig.json
@@ -5,7 +5,7 @@
     "baseUrl": ".",
     "paths": {
       "~/*": ["./*"],
-      "@ui/*": ["./../../packages/ui/src/*"]
+      "@ui/*": ["./../../packages/ui/src/*"],
     },
     "target": "ES2021",
     "lib": ["dom", "dom.iterable", "esnext"],
@@ -22,10 +22,10 @@
     "module": "esnext",
     "plugins": [
       {
-        "name": "next"
-      }
+        "name": "next",
+      },
     ],
-    "strictNullChecks": false
+    "strictNullChecks": false,
   },
   "include": [
     "next-env.d.ts",
@@ -33,7 +33,7 @@
     "**/*.tsx",
     "pages/guides/append-test.js",
     ".next/types/**/*.ts",
-    "./../../packages/ui/src/**/*.d.ts"
+    "./../../packages/ui/src/**/*.d.ts",
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "examples"],
 }

--- a/apps/docs/tsconfig.json
+++ b/apps/docs/tsconfig.json
@@ -5,7 +5,7 @@
     "baseUrl": ".",
     "paths": {
       "~/*": ["./*"],
-      "@ui/*": ["./../../packages/ui/src/*"],
+      "@ui/*": ["./../../packages/ui/src/*"]
     },
     "target": "ES2021",
     "lib": ["dom", "dom.iterable", "esnext"],
@@ -22,10 +22,10 @@
     "module": "esnext",
     "plugins": [
       {
-        "name": "next",
-      },
+        "name": "next"
+      }
     ],
-    "strictNullChecks": false,
+    "strictNullChecks": false
   },
   "include": [
     "next-env.d.ts",
@@ -33,7 +33,7 @@
     "**/*.tsx",
     "pages/guides/append-test.js",
     ".next/types/**/*.ts",
-    "./../../packages/ui/src/**/*.d.ts",
+    "./../../packages/ui/src/**/*.d.ts"
   ],
-  "exclude": ["node_modules", "examples"],
+  "exclude": ["node_modules", "examples"]
 }

--- a/apps/docs/vitest.config.ts
+++ b/apps/docs/vitest.config.ts
@@ -2,5 +2,8 @@ import { defineConfig } from 'vitest/config'
 import tsconfigPaths from 'vite-tsconfig-paths'
 
 export default defineConfig({
+  test: {
+    exclude: ['examples/**/*', '**/node_modules/**'],
+  },
   plugins: [tsconfigPaths({ root: import.meta.dirname })],
 })


### PR DESCRIPTION
The examples folder needs to be explicitly included in the Vercel Serverless bundle. Because it's at the root of the monorepo rather than being within the `app/docs` folder, we copy it over pre-build (and pre-dev).

Test this fix by re-enabling revalidations on graphql pages. Added a temp version of the fetch function so we can gradually reenable and monitor Vercel error rates over time.

## How to check

- On the [Getting Started page](https://docs-git-fix-examples-availability-isr-supabase.vercel.app/docs/guides/getting-started/ai-prompts), check that AI prompts are listed correctly
- Go to the [GraphQL section](https://docs-git-fix-examples-availability-isr-supabase.vercel.app/docs/guides/graphql), click around a bit, then in Vercel logs for this preview (link in Vercel comment below), check that the serverless function for those requests runs without errors. Might have to search backwards in the logs a bit for the last time the revalidation ran, if your requests have been served from cache.
