### PR TITLE
fix: do not block project/replica creation with due invoices on team/enterprise

### DIFF
--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/DeployNewReplicaPanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/DeployNewReplicaPanel.tsx
@@ -1,6 +1,6 @@
 import { ChevronDown } from 'lucide-react'
 import Link from 'next/link'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { toast } from 'sonner'
 
 import { useParams } from 'common'
@@ -79,14 +79,17 @@ const DeployNewReplicaPanel = ({
   const { data: subscription } = useOrgSubscriptionQuery({ orgSlug: org?.slug })
   const { data: diskConfiguration } = useDiskAttributesQuery({ projectRef })
 
+  const isNotOnTeamOrEnterprisePlan = useMemo(
+    () => !['team', 'enterprise'].includes(subscription?.plan.id ?? ''),
+    [subscription]
+  )
   const { data: allOverdueInvoices } = useOverdueInvoicesQuery({
-    enabled:
-      subscription !== undefined && !['team', 'enterprise'].includes(subscription?.plan.id ?? ''),
+    enabled: isNotOnTeamOrEnterprisePlan,
   })
   const overdueInvoices = (allOverdueInvoices ?? []).filter(
     (x) => x.organization_id === project?.organization_id
   )
-  const hasOverdueInvoices = overdueInvoices.length > 0
+  const hasOverdueInvoices = overdueInvoices.length > 0 && isNotOnTeamOrEnterprisePlan
 
   // Opting for useState temporarily as Listbox doesn't seem to work with react-hook-form yet
   const [defaultRegion] = Object.entries(AWS_REGIONS).find(

--- a/apps/studio/pages/new/[slug].tsx
+++ b/apps/studio/pages/new/[slug].tsx
@@ -4,7 +4,7 @@ import { debounce } from 'lodash'
 import { ExternalLink } from 'lucide-react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
-import { PropsWithChildren, useEffect, useRef, useState } from 'react'
+import { PropsWithChildren, useEffect, useMemo, useRef, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { toast } from 'sonner'
 import { z } from 'zod'
@@ -149,15 +149,19 @@ const Wizard: NextPageWithLayout = () => {
 
   const { data: orgSubscription } = useOrgSubscriptionQuery({ orgSlug: slug })
 
+  const isNotOnTeamOrEnterprisePlan = useMemo(
+    () => !['team', 'enterprise'].includes(orgSubscription?.plan.id ?? ''),
+    [orgSubscription]
+  )
+
   const { data: allOverdueInvoices } = useOverdueInvoicesQuery({
-    enabled:
-      orgSubscription !== undefined &&
-      !['team', 'enterprise'].includes(orgSubscription?.plan.id ?? ''),
+    enabled: isNotOnTeamOrEnterprisePlan,
   })
+
   const overdueInvoices = (allOverdueInvoices ?? []).filter(
     (x) => x.organization_id === currentOrg?.id
   )
-  const hasOutstandingInvoices = overdueInvoices.length > 0
+  const hasOutstandingInvoices = overdueInvoices.length > 0 && isNotOnTeamOrEnterprisePlan
 
   const { data: allProjects } = useProjectsQuery({})
   const organizationProjects =


### PR DESCRIPTION
Just setting `enabled` flag on react-query is not sufficient, as the data may be preloaded already. To ensure we're not blocking team/enterprise customers with outstanding invoices from launching new projects or replicas, we have to add an additional check.

Backend is already validating this properly, only a frontend issue.
