### PR TITLE
fix: deprecation comments

### DIFF
--- a/apps/docs/lib/docs.ts
+++ b/apps/docs/lib/docs.ts
@@ -26,7 +26,7 @@ export type GuideFrontmatter = {
   description?: string
   canonical?: string
   hideToc?: boolean
-  // @deprecated
+  /** @deprecated */
   hide_table_of_contents?: boolean
   tocVideo?: string
 }

--- a/packages/ui-patterns/Dialogs/ConfirmDialog.tsx
+++ b/packages/ui-patterns/Dialogs/ConfirmDialog.tsx
@@ -17,7 +17,7 @@ interface ConfirmModalProps {
   onSelectConfirm: () => void
 }
 
-// @deprecated use ConfirmationModal instead
+/** @deprecated use ConfirmationModal instead */
 const ConfirmModal = ({
   visible = false,
   danger = false,

--- a/packages/ui/src/components/Button/Button.tsx
+++ b/packages/ui/src/components/Button/Button.tsx
@@ -59,7 +59,7 @@ const buttonVariants = cva(
           data-[state=open]:border-foreground-lighter
           data-[state=open]:outline-border-strong
         `,
-        // @deprecated use 'primary' instead
+        /** @deprecated use 'primary' instead */
         alternative: `
           text-foreground
           bg-brand-400 hover:bg-brand-500

--- a/packages/ui/src/components/Modal/Modal.tsx
+++ b/packages/ui/src/components/Modal/Modal.tsx
@@ -21,14 +21,14 @@ export interface ModalProps extends React.ComponentProps<typeof DialogContent> {
   Separator?: React.ComponentType
   Content?: React.ComponentType
   visible?: boolean
-  // @deprecated please add the footer directly in component children. This is to prepare for using <DialogFooter/> component
+  /** @deprecated please add the footer directly in component children. This is to prepare for using <DialogFooter/> component */
   customFooter?: React.ReactNode
   description?: string
-  // @deprecated please add the footer directly in component children. This is to prepare for using <DialogFooter/> component
+  /** @deprecated please add the footer directly in component children. This is to prepare for using <DialogFooter/> component */
   hideFooter?: boolean
-  // @deprecated please add the footer directly in component children. This is to prepare for using <DialogFooter/> component
+  /** @deprecated please add the footer directly in component children. This is to prepare for using <DialogFooter/> component */
   alignFooter?: 'right' | 'left'
-  // @deprecated please add the footer directly in component children. This is to prepare for using <DialogFooter/> component
+  /** @deprecated please add the footer directly in component children. This is to prepare for using <DialogFooter/> component */
   layout?: 'horizontal' | 'vertical'
   loading?: boolean
   onCancel?: any
@@ -37,14 +37,14 @@ export interface ModalProps extends React.ComponentProps<typeof DialogContent> {
   confirmText?: string
   showCloseButton?: boolean
   footerBackground?: boolean
-  // @deprecated please add the footer directly in component children. This is to prepare for using <DialogFooter/> component
+  /** @deprecated please add the footer directly in component children. This is to prepare for using <DialogFooter/> component */
   variant?: ButtonVariantProps['type']
   overlayStyle?: React.CSSProperties
   contentStyle?: React.CSSProperties
   dialogOverlayProps?: React.ComponentProps<typeof DialogContent>['dialogOverlayProps']
-  // @deprecated please consider using <Dialog/> and <DialogTrigger/> components
+  /** @deprecated please consider using <Dialog/> and <DialogTrigger/> components */
   triggerElement?: React.ReactNode
-  // @deprecated please consider using <Dialog/> and <DialogHeader/> components
+  /** @deprecated please consider using <Dialog/> and <DialogHeader/> components */
   header?: React.ReactNode
   modal?: React.ComponentProps<typeof Dialog>['modal']
   defaultOpen?: React.ComponentProps<typeof Dialog>['defaultOpen']
@@ -62,7 +62,7 @@ interface ModalType
   Separator: React.ComponentType
 }
 
-// @deprecated use <Dialog/> instead
+/** @deprecated use <Dialog/> instead */
 const Modal = forwardRef<
   React.ElementRef<typeof DialogContent>,
   React.ComponentPropsWithoutRef<typeof DialogContent> & ModalProps


### PR DESCRIPTION
Using `//` deprecations are not properly recognized as JSDoc doesn't work like that.