### PR TITLE
Fix creation of Server Component client in Server-Side (Nextjs)

### DIFF
--- a/apps/docs/content/guides/auth/server-side/nextjs.mdx
+++ b/apps/docs/content/guides/auth/server-side/nextjs.mdx
@@ -125,8 +125,9 @@ export function createClient() {
 import { createServerClient } from '@supabase/ssr'
 import { cookies } from 'next/headers'
 
+const cookieStore = await cookies()
+
 export async function createClient() {
-  const cookieStore = await cookies()
 
   return createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

Currently we are invoking `const cookieStore = await cookies()` inside `createClient`, which causing below error:
```
Error: `cookies` was called outside a request scope. Read more: https://nextjs.org/docs/messages/next-dynamic-api-wrong-context
```
## What is the new behavior?
Now we are creating `cookieStore` outside of `createClient`.
Ensuring that Dynamic API calls happen in a request scope. 

## Additional context

[Read more](https://nextjs.org/docs/messages/next-dynamic-api-wrong-context)
