### PR TITLE
fix: mfa phone alert fixed to show up only if phone is not configured

### DIFF
--- a/apps/studio/components/interfaces/Auth/AdvancedAuthSettingsForm/AdvancedAuthSettingsForm.tsx
+++ b/apps/studio/components/interfaces/Auth/AdvancedAuthSettingsForm/AdvancedAuthSettingsForm.tsx
@@ -140,9 +140,7 @@ const AdvancedAuthSettingsForm = () => {
   // For now, we support Twilio and Vonage. Twilio Verify is not supported and the remaining providers are community maintained.
   const sendSMSHookIsEnabled =
     authConfig?.HOOK_SEND_SMS_URI !== null && authConfig?.HOOK_SEND_SMS_ENABLED === true
-  const hasValidMFAPhoneProvider =
-    authConfig?.EXTERNAL_PHONE_ENABLED === true &&
-    (authConfig?.SMS_PROVIDER === 'twilio' || authConfig?.SMS_PROVIDER === 'vonage')
+  const hasValidMFAPhoneProvider = authConfig?.EXTERNAL_PHONE_ENABLED === true
   const hasValidMFAProvider = hasValidMFAPhoneProvider || sendSMSHookIsEnabled
   const phoneMFAIsEnabled =
     INITIAL_VALUES.MFA_PHONE === 'Enabled' || INITIAL_VALUES.MFA_PHONE === 'Verify Enabled'
@@ -329,8 +327,7 @@ const AdvancedAuthSettingsForm = () => {
                     <Alert_Shadcn_ variant="warning">
                       <WarningIcon />
                       <AlertTitle_Shadcn_>
-                        Please configure a valid phone provider. Only Twilio, Vonage, and Send SMS
-                        Hooks are supported at this time.
+                        To use MFA with Phone you should set up a Phone provider or Send SMS Hook.
                       </AlertTitle_Shadcn_>
                     </Alert_Shadcn_>
                   )}


### PR DESCRIPTION
MFA with Phone now supports all phone providers.