### PR TITLE
TimestampInfo: Prevent onMouseDown and onPointerDown

### DIFF
--- a/packages/ui-patterns/TimestampInfo/index.tsx
+++ b/packages/ui-patterns/TimestampInfo/index.tsx
@@ -95,6 +95,12 @@ export const TimestampInfo = ({
 
     return (
       <span
+        onPointerDown={(e) => {
+          e.stopPropagation()
+        }}
+        onMouseDown={(e) => {
+          e.stopPropagation()
+        }}
         onClick={(e) => {
           e.stopPropagation()
           e.preventDefault()


### PR DESCRIPTION
- Fixes issue where the onMouseDown or onPointerDown events will trigger parent element events when used inside Dropdowns.

## Before
![CleanShot 2025-01-07 at 13 15 07](https://github.com/user-attachments/assets/26354fee-64c7-48ec-9eb4-4b7f0e7b3bfb)

## After
![CleanShot 2025-01-07 at 13 14 19](https://github.com/user-attachments/assets/ace072f9-96c6-45eb-bfb5-71c42a9555e4)
