### PR TITLE
chore: vault -> supabase_vault

### DIFF
--- a/apps/www/_blog/2022-08-19-supabase-vault.mdx
+++ b/apps/www/_blog/2022-08-19-supabase-vault.mdx
@@ -75,7 +75,7 @@ If you install pgsodium locally the default is to generate a random root key fro
 Installing the `vault` extension is the same as any other Postgres extension:
 
 ```sql
-create extension vault with schema vault;
+create extension supabase_vault with schema vault;
 ```
 
 Once enabled, you can insert secrets into the `vault.secrets` table:


### PR DESCRIPTION
`create extension vault` doesn't exist - it should be `create extension supabase_vault`