### PR TITLE
Update auth-google.mdx: Fix documentation, GoogleSignin throws an error is there is no iosClientId

### DIFF
--- a/apps/docs/content/guides/auth/social-login/auth-google.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-google.mdx
@@ -456,7 +456,7 @@ import { supabase } from '../utils/supabase'
 export default function () {
   GoogleSignin.configure({
     scopes: ['https://www.googleapis.com/auth/drive.readonly'],
-    webClientId: 'YOUR CLIENT ID FROM GOOGLE CONSOLE',
+    iosClientId: 'YOUR CLIENT ID FROM GOOGLE CONSOLE',
   })
 
   return (


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

With a webClientId, the expo app will throw an error. GoogleSignin needs an iosClientId.

## What is the new behavior?

Works as expected

## Additional context


![IMG_B96ACFD332FF-1](https://github.com/user-attachments/assets/2641cc4c-af42-4e7d-86a3-caed4e596c43)

