### PR TITLE
Remove extend your database header

### DIFF
--- a/apps/studio/components/layouts/WizardLayout.tsx
+++ b/apps/studio/components/layouts/WizardLayout.tsx
@@ -3,10 +3,10 @@ import { PropsWithChildren } from 'react'
 
 import { withAuth } from 'hooks/misc/withAuth'
 import { BASE_PATH } from 'lib/constants'
+import { ChevronRight } from 'lucide-react'
 import type { Organization, Project } from 'types'
 import { FeedbackDropdown } from './ProjectLayout/LayoutHeader/FeedbackDropdown'
 import HelpPopover from './ProjectLayout/LayoutHeader/HelpPopover'
-import { ChevronRight } from 'lucide-react'
 
 interface WizardLayoutProps {
   organization: Organization | null | undefined
@@ -57,10 +57,6 @@ const Header = ({ organization, project }: WizardLayoutProps) => {
               <ChevronRight size="18" className="text-foreground-light" strokeWidth={1} />
               <p className={`text-sm ${stepNumber < 1 ? 'text-foreground-light' : ''}`}>
                 {project ? project.name : 'Create a new project'}
-              </p>
-              <ChevronRight size="18" className="text-foreground-light" strokeWidth={1} />
-              <p className={`text-sm ${stepNumber < 2 ? 'text-foreground-light' : ''}`}>
-                {project ? project.name : 'Extend your database'}
               </p>
             </div>
           </div>


### PR DESCRIPTION
We don't have a subsequent step after creating your project so this can be removed.

WizardLayout is used for new org and new project - verified on those pages that the removal is sound