### PR TITLE
docs: fix typo on quickstarts/hono

### DIFF
--- a/apps/docs/content/guides/getting-started/quickstarts/hono.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/hono.mdx
@@ -15,7 +15,7 @@ hideToc: true
 
   <StepHikeCompact.Step step={2}>
 
-    <StepHikeCompact.Details title="Create a React app">
+    <StepHikeCompact.Details title="Create a Hono app">
 
     Boostrap the Hono example app from the Supabase Samples using the CLI.
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

"Create a React app" on Hono quickstart document

## What is the new behavior?

Replace "React" with "Hono"
