### PR TITLE
Add null placeholder to RowEditor foreign key input field

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/InputField.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/InputField.tsx
@@ -21,7 +21,6 @@ import { DATETIME_TYPES, JSON_TYPES, TEXT_TYPES } from '../SidePanelEditor.const
 import { DateTimeInput } from './DateTimeInput'
 import type { EditValue, RowField } from './RowEditor.types'
 import { isValueTruncated } from './RowEditor.utils'
-import { checkDomainOfScale } from 'recharts/types/util/ChartUtils'
 
 export interface InputFieldProps {
   field: RowField
@@ -98,6 +97,7 @@ const InputField = ({
       <Input
         data-testid={`${field.name}-input`}
         layout="horizontal"
+        placeholder="NULL"
         label={field.name}
         value={field.value ?? ''}
         descriptionText={


### PR DESCRIPTION
We received a feedback asking for a way to set foreign key input fields to NULL - but clearing the input field would be the way to do it. Adding a NULL placeholder here to make it more obvious (understandably its not that clear without the placeholder)

![image](https://github.com/user-attachments/assets/e35206c3-97b6-484b-af83-0949cf2c0f87)
