### PR TITLE
Use whitespace-pre in TextConfirmModal

### DIFF
--- a/packages/ui-patterns/Dialogs/TextConfirmModal.tsx
+++ b/packages/ui-patterns/Dialogs/TextConfirmModal.tsx
@@ -21,9 +21,9 @@ import {
   Input_Shadcn_,
   cn,
 } from 'ui'
-import { Admonition } from './../admonition'
 import { DialogHeader } from 'ui/src/components/shadcn/ui/dialog'
 import { z } from 'zod'
+import { Admonition } from './../admonition'
 
 export interface TextConfirmModalProps {
   loading: boolean
@@ -154,8 +154,11 @@ const TextConfirmModal = forwardRef<
                 render={({ field }) => (
                   <FormItem_Shadcn_ className="flex flex-col gap-y-1">
                     <FormLabel_Shadcn_ {...label}>
-                      Type <span className="text-foreground break-all">{confirmString}</span> to
-                      confirm.
+                      Type{' '}
+                      <span className="text-foreground break-all whitespace-pre">
+                        {confirmString}
+                      </span>{' '}
+                      to confirm.
                     </FormLabel_Shadcn_>
                     <FormControl_Shadcn_>
                       <Input_Shadcn_


### PR DESCRIPTION
Address an edge case whereby the text to confirm has multiple spaces in between words - e.g `Test   Project`

Before:
![image](https://github.com/user-attachments/assets/1eef9304-2e24-42ab-a1ad-8737b13e5db3)

After:
![image](https://github.com/user-attachments/assets/6aa16c63-4d8a-4b39-8b18-6892d0029600)
