### PR TITLE
Chore/fix set to now

### DIFF
--- a/apps/studio/components/grid/components/editor/DateTimeEditor.tsx
+++ b/apps/studio/components/grid/components/editor/DateTimeEditor.tsx
@@ -86,7 +86,7 @@ function BaseEditor<TRow, TSummaryRow = unknown>({
           <Input
             ref={ref}
             value={inputValue ?? ''}
-            placeholder={FORMAT_MAP[type]}
+            placeholder={format}
             onChange={(e) => setInputValue(e.target.value)}
             className="border-0 rounded-none bg-dash-sidebar outline-none !ring-0 !ring-offset-0"
           />

--- a/apps/studio/components/grid/components/editor/DateTimeEditor.tsx
+++ b/apps/studio/components/grid/components/editor/DateTimeEditor.tsx
@@ -139,9 +139,14 @@ function BaseEditor<TRow, TSummaryRow = unknown>({
                   <DropdownMenuContent className="w-20" align="end">
                     <DropdownMenuItem
                       onClick={() => {
-                        // [Joshen] The replace here is needed for timestamptz cause dayjs formats "ZZ" with "+" already
-                        const now = dayjs().format(FORMAT_MAP[type]).replace('++', '+')
-                        saveChanges(now)
+                        const formattedNow = dayjs().format(
+                          type === 'date'
+                            ? 'YYYY-MM-DD'
+                            : type === 'datetimetz'
+                              ? 'YYYY-MM-DDTHH:mm:ssZ'
+                              : 'YYYY-MM-DDTHH:mm:ss'
+                        )
+                        saveChanges(formattedNow)
                       }}
                     >
                       Set to NOW

--- a/apps/studio/components/grid/components/editor/DateTimeEditor.tsx
+++ b/apps/studio/components/grid/components/editor/DateTimeEditor.tsx
@@ -50,6 +50,17 @@ function BaseEditor<TRow, TSummaryRow = unknown>({
     onRowChange({ ...row, [column.key]: value }, true)
   }
 
+  const setToNow = () => {
+    const formattedNow = dayjs().format(
+      type === 'date'
+        ? 'YYYY-MM-DD'
+        : type === 'datetimetz'
+          ? 'YYYY-MM-DDTHH:mm:ssZ'
+          : 'YYYY-MM-DDTHH:mm:ss'
+    )
+    saveChanges(formattedNow)
+  }
+
   useEffect(() => {
     try {
       ref.current?.focus({ preventScroll: true })
@@ -123,7 +134,7 @@ function BaseEditor<TRow, TSummaryRow = unknown>({
             </div>
           </div>
           <div className="flex">
-            {isNullable && (
+            {isNullable ? (
               <>
                 <Button type="default" className="rounded-r-none" onClick={() => saveChanges(null)}>
                   Set NULL
@@ -137,23 +148,14 @@ function BaseEditor<TRow, TSummaryRow = unknown>({
                     />
                   </DropdownMenuTrigger>
                   <DropdownMenuContent className="w-20" align="end">
-                    <DropdownMenuItem
-                      onClick={() => {
-                        const formattedNow = dayjs().format(
-                          type === 'date'
-                            ? 'YYYY-MM-DD'
-                            : type === 'datetimetz'
-                              ? 'YYYY-MM-DDTHH:mm:ssZ'
-                              : 'YYYY-MM-DDTHH:mm:ss'
-                        )
-                        saveChanges(formattedNow)
-                      }}
-                    >
-                      Set to NOW
-                    </DropdownMenuItem>
+                    <DropdownMenuItem onClick={setToNow}>Set to NOW</DropdownMenuItem>
                   </DropdownMenuContent>
                 </DropdownMenu>
               </>
+            ) : (
+              <Button type="default" onClick={setToNow}>
+                Set to NOW
+              </Button>
             )}
           </div>
         </div>


### PR DESCRIPTION
There's a bug with the inline implementation of the new date editor

Set to Now causes an error .

![screenshot-2025-01-13-at-12 56 10](https://github.com/user-attachments/assets/8b7f388c-bf8c-436e-b885-b7ee6ea399c1)


This PR reuses the logic from the Sheet panel editor.
![screenshot-2025-01-13-at-12 55 49](https://github.com/user-attachments/assets/63a6635e-907e-4cfd-8764-3307ec26b352)

