### PR TITLE
Revert "Temporarily disable enabling of queues exposure via postgrest"

### DIFF
--- a/apps/studio/components/interfaces/Integrations/Queues/QueuesSettings.tsx
+++ b/apps/studio/components/interfaces/Integrations/Queues/QueuesSettings.tsx
@@ -206,7 +206,7 @@ export const QueuesSettings = () => {
                               <code className="text-xs">send_batch</code>,{' '}
                               <code className="text-xs">read</code>,{' '}
                               <code className="text-xs">pop</code>,
-                              <code className="text-xs">archive</code>, and
+                              <code className="text-xs">archive</code>, and{' '}
                               <code className="text-xs">delete</code>
                             </p>
                           </>

--- a/apps/studio/components/interfaces/Integrations/Queues/QueuesSettings.tsx
+++ b/apps/studio/components/interfaces/Integrations/Queues/QueuesSettings.tsx
@@ -206,7 +206,7 @@ export const QueuesSettings = () => {
                               <code className="text-xs">send_batch</code>,{' '}
                               <code className="text-xs">read</code>,{' '}
                               <code className="text-xs">pop</code>,
-                              <code className="text-xs">archive</code>, and{' '}
+                              <code className="text-xs">archive</code>, and
                               <code className="text-xs">delete</code>
                             </p>
                           </>
@@ -217,27 +217,13 @@ export const QueuesSettings = () => {
                             name="enable"
                             size="large"
                             disabled={
-                              isLoading ||
-                              tablesWithoutRLS.length > 0 ||
-                              !canUpdatePostgrestConfig ||
-                              // [Joshen] Temporarily disable setting, to remove once fix is out
-                              field.value === false
+                              isLoading || tablesWithoutRLS.length > 0 || !canUpdatePostgrestConfig
                             }
                             checked={field.value}
                             onCheckedChange={(value) => field.onChange(value)}
                           />
                         </FormControl_Shadcn_>
                       </FormItemLayout>
-                      <Admonition
-                        type="default"
-                        className="mt-2"
-                        title="Enabling exposure of Queues via PostgREST is temporarily disabled"
-                        description={
-                          field.value === true
-                            ? "This setting can still be toggled off but cannot be re-enabled. We're currently working on a fix to support this setting."
-                            : "We're currently working on a fix to support this setting."
-                        }
-                      />
                       {tablesWithoutRLS.length > 0 && (
                         <Admonition
                           type="default"

--- a/apps/studio/data/database-queues/database-queues-toggle-postgrest-mutation.ts
+++ b/apps/studio/data/database-queues/database-queues-toggle-postgrest-mutation.ts
@@ -202,12 +202,12 @@ grant usage on schema pgmq to postgres, anon, authenticated, service_role;
 */
 grant usage, select, update
 on all sequences in schema pgmq
-to anon, authenticated;
+to anon, authenticated, service_role;
 
 alter default privileges in schema pgmq
 grant usage, select, update
 on sequences
-to anon, authenticated;
+to anon, authenticated, service_role;
 `)
 
 const HIDE_QUEUES_FROM_POSTGREST_SQL = minify(/* SQL */ `

--- a/apps/studio/data/database-queues/database-queues-toggle-postgrest-mutation.ts
+++ b/apps/studio/data/database-queues/database-queues-toggle-postgrest-mutation.ts
@@ -192,6 +192,22 @@ grant all privileges on all tables in schema pgmq to postgres, service_role;
 alter default privileges in schema pgmq grant all privileges on tables to postgres, service_role;
 
 grant usage on schema pgmq to postgres, anon, authenticated, service_role;
+
+
+/*
+  Grant access to sequences to API roles by default. Existing table permissions
+  continue to enforce insert restrictions. This is necessary to accomodate the
+  on-backup hook that rebuild queue table primary keys to avoid a pg_dump segfault.
+  This can be removed once logical backups are completely retired.
+*/
+grant usage, select, update
+on all sequences in schema pgmq
+to anon, authenticated;
+
+alter default privileges in schema pgmq
+grant usage, select, update
+on sequences
+to anon, authenticated;
 `)
 
 const HIDE_QUEUES_FROM_POSTGREST_SQL = minify(/* SQL */ `

--- a/apps/studio/data/database-queues/database-queues-toggle-postgrest-mutation.ts
+++ b/apps/studio/data/database-queues/database-queues-toggle-postgrest-mutation.ts
@@ -196,7 +196,7 @@ grant usage on schema pgmq to postgres, anon, authenticated, service_role;
 
 /*
   Grant access to sequences to API roles by default. Existing table permissions
-  continue to enforce insert restrictions. This is necessary to accomodate the
+  continue to enforce insert restrictions. This is necessary to accommodate the
   on-backup hook that rebuild queue table primary keys to avoid a pg_dump segfault.
   This can be removed once logical backups are completely retired.
 */


### PR DESCRIPTION
Re-enables exposing pgmq over APIs

- Reverts supabase/supabase#32699
- Resolves the underlying permissions issue