### PR TITLE
Fix vault missing exts alert

### DIFF
--- a/apps/studio/components/interfaces/Integrations/Landing/Integrations.constants.tsx
+++ b/apps/studio/components/interfaces/Integrations/Landing/Integrations.constants.tsx
@@ -56,7 +56,7 @@ const supabaseIntegrations: IntegrationDefinition[] = [
     id: 'queues',
     type: 'postgres_extension' as const,
     requiredExtensions: ['pgmq'],
-    missingExtensionsAlert: <UpgradeDatabaseAlert />,
+    missingExtensionsAlert: <UpgradeDatabaseAlert minimumVersion="15.6.1.143" />,
     name: `Queues`,
     icon: ({ className, ...props } = {}) => (
       <Layers className={cn('inset-0 p-2 text-black w-full h-full', className)} {...props} />

--- a/apps/studio/components/interfaces/Integrations/Landing/Integrations.constants.tsx
+++ b/apps/studio/components/interfaces/Integrations/Landing/Integrations.constants.tsx
@@ -173,6 +173,7 @@ const supabaseIntegrations: IntegrationDefinition[] = [
     id: 'vault',
     type: 'postgres_extension' as const,
     requiredExtensions: ['supabase_vault'],
+    missingExtensionsAlert: <UpgradeDatabaseAlert />,
     name: `Vault`,
     status: 'alpha',
     icon: ({ className, ...props } = {}) => (

--- a/apps/studio/components/interfaces/Integrations/Queues/UpgradeDatabaseAlert.tsx
+++ b/apps/studio/components/interfaces/Integrations/Queues/UpgradeDatabaseAlert.tsx
@@ -11,7 +11,7 @@ export const UpgradeDatabaseAlert = () => {
     <Admonition
       type="warning"
       className="mt-4"
-      title="Database Upgrade Needed"
+      title="Database upgrade needed"
       childProps={{ description: { className: 'flex flex-col gap-y-2' } }}
     >
       <div className="prose text-sm max-w-full">

--- a/apps/studio/components/interfaces/Integrations/Queues/UpgradeDatabaseAlert.tsx
+++ b/apps/studio/components/interfaces/Integrations/Queues/UpgradeDatabaseAlert.tsx
@@ -4,7 +4,11 @@ import { useSelectedProject } from 'hooks/misc/useSelectedProject'
 import { Button } from 'ui'
 import { Admonition } from 'ui-patterns/admonition'
 
-export const UpgradeDatabaseAlert = () => {
+interface UpgradeDatabaseAlertProps {
+  minimumVersion?: string
+}
+
+export const UpgradeDatabaseAlert = ({ minimumVersion = '15.6' }: UpgradeDatabaseAlertProps) => {
   const project = useSelectedProject()
 
   return (
@@ -17,7 +21,7 @@ export const UpgradeDatabaseAlert = () => {
       <div className="prose text-sm max-w-full">
         <p>
           This integration requires the <code>pgmq</code> extension which is not available on this
-          version of Postgres. The extension is available on version 15.6.1.143 and higher.
+          version of Postgres. The extension is available on version {minimumVersion} and higher.
         </p>
       </div>
       <Button color="primary" className="w-fit">


### PR DESCRIPTION
The upgrade database alert was missing for vault integrations - which led to a confusion for why we couldn't find the keys and secrets tabs on one of our projects. (Screenshot below is just for reference as I don't have a project which is on PG14)

![image](https://github.com/user-attachments/assets/194a5fde-6bf6-46be-958d-b973905faf70)
