### PR TITLE
fix: multi-select

### DIFF
--- a/packages/ui-patterns/multi-select/multi-select.tsx
+++ b/packages/ui-patterns/multi-select/multi-select.tsx
@@ -247,7 +247,7 @@ const MultiSelectorTrigger = React.forwardRef<HTMLButtonElement, MultiSelectorTr
             'flex gap-1 -ml-1 overflow-hidden flex-1',
             IS_BADGE_LIMIT_WRAP && 'flex-wrap',
             !IS_BADGE_LIMIT_WRAP &&
-              'overflow-x-scroll scrollbar-thin scrollbar-track-transparent transition-colors scrollbar-thumb-muted-foreground dark:scrollbar-thumb-muted scrollbar-thumb-rounded-lg'
+              'overflow-x-auto scrollbar-thin scrollbar-track-transparent transition-colors scrollbar-thumb-muted-foreground dark:scrollbar-thumb-muted scrollbar-thumb-rounded-lg'
           )}
         >
           {visibleBadges.map((value) => (


### PR DESCRIPTION
Multi-select has an always-on scrollbar gutter, which is a bit strange-looking and not identifiable as a scrollbar gutter when there's nothing to scroll (I thought it was some weird border for a long time...)

Removing it makes it look a bit better

Before:

![image](https://github.com/user-attachments/assets/86a39d04-170e-4f69-88de-26b228200c67)
![image](https://github.com/user-attachments/assets/64798612-5b8b-46d9-97a9-85dd34746f73)

After:

![image](https://github.com/user-attachments/assets/dcb04ceb-2f6b-4120-94a7-92704dd2f554)
![image](https://github.com/user-attachments/assets/94ea1c23-a000-427c-a2e6-a5649ad78398)
