### PR TITLE
keep polling til all services are healthy

### DIFF
--- a/apps/studio/components/interfaces/Home/ServiceStatus.tsx
+++ b/apps/studio/components/interfaces/Home/ServiceStatus.tsx
@@ -82,9 +82,15 @@ const ServiceStatus = () => {
     data: status,
     isLoading,
     refetch: refetchServiceStatus,
-  } = useProjectServiceStatusQuery({ projectRef: ref })
+  } = useProjectServiceStatusQuery({
+    projectRef: ref,
+    refetchInterval: !status || status.some((service) => !service.healthy) ? 5000 : false,
+  })
   const { data: edgeFunctionsStatus, refetch: refetchEdgeFunctionServiceStatus } =
-    useEdgeFunctionServiceStatusQuery({ projectRef: ref })
+    useEdgeFunctionServiceStatusQuery({
+      projectRef: ref,
+      refetchInterval: !edgeFunctionsStatus?.healthy ? 5000 : false,
+    })
   const {
     isLoading: isLoadingPostgres,
     isSuccess: isSuccessPostgres,
@@ -92,6 +98,7 @@ const ServiceStatus = () => {
   } = usePostgresServiceStatusQuery({
     projectRef: ref,
     connectionString: project?.connectionString,
+    refetchInterval: !isSuccessPostgres ? 5000 : false,
   })
 
   const authStatus = status?.find((service) => service.name === 'auth')

--- a/apps/studio/components/interfaces/Home/ServiceStatus.tsx
+++ b/apps/studio/components/interfaces/Home/ServiceStatus.tsx
@@ -1,5 +1,5 @@
 import dayjs from 'dayjs'
-import { AlertTriangle, CheckCircle2, ChevronRight, Info, Loader2 } from 'lucide-react'
+import { AlertTriangle, CheckCircle2, ChevronRight, Loader2 } from 'lucide-react'
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
 
@@ -8,7 +8,6 @@ import { useEdgeFunctionServiceStatusQuery } from 'data/service-status/edge-func
 import { usePostgresServiceStatusQuery } from 'data/service-status/postgres-service-status-query'
 import {
   ProjectServiceStatus,
-  ProjectServiceStatusData,
   useProjectServiceStatusQuery,
 } from 'data/service-status/service-status-query'
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
@@ -44,6 +43,14 @@ const StatusMessage = ({
   return 'Unable to connect'
 }
 
+const iconProps = {
+  size: 18,
+  strokeWidth: 1.5,
+}
+const LoaderIcon = () => <Loader2 {...iconProps} className="animate-spin" />
+const AlertIcon = () => <AlertTriangle {...iconProps} />
+const CheckIcon = () => <CheckCircle2 {...iconProps} className="text-brand" />
+
 const StatusIcon = ({
   isLoading,
   isSuccess,
@@ -55,12 +62,11 @@ const StatusIcon = ({
   isProjectNew: boolean
   projectStatus?: ProjectServiceStatus
 }) => {
-  if (isLoading || isProjectNew) return <Loader2 size={14} className="animate-spin" />
-  if (isSuccess) return <CheckCircle2 className="text-brand" size={18} strokeWidth={1.5} />
-  if (projectStatus === 'UNHEALTHY')
-    return <AlertTriangle className="text-warning" size={18} strokeWidth={1.5} />
-  if (projectStatus === 'COMING_UP') return <Loader2 size={14} className="animate-spin" />
-  return <AlertTriangle className="text-warning" size={18} strokeWidth={1.5} />
+  if (isLoading || isProjectNew) return <LoaderIcon />
+  if (isSuccess) return <CheckIcon />
+  if (projectStatus === 'UNHEALTHY') return <AlertIcon />
+  if (projectStatus === 'COMING_UP') return <LoaderIcon />
+  return <AlertIcon />
 }
 
 const ServiceStatus = () => {
@@ -240,7 +246,7 @@ const ServiceStatus = () => {
           type="default"
           icon={
             isLoadingChecks || isProjectNew ? (
-              <Loader2 className="animate-spin" />
+              <LoaderIcon />
             ) : (
               <div
                 className={`w-2 h-2 rounded-full ${

--- a/apps/studio/components/interfaces/Home/ServiceStatus.tsx
+++ b/apps/studio/components/interfaces/Home/ServiceStatus.tsx
@@ -48,13 +48,18 @@ const StatusIcon = ({
   isLoading,
   isSuccess,
   isProjectNew,
+  projectStatus,
 }: {
   isLoading: boolean
   isSuccess: boolean
   isProjectNew: boolean
+  projectStatus?: ProjectServiceStatus
 }) => {
   if (isLoading || isProjectNew) return <Loader2 size={14} className="animate-spin" />
   if (isSuccess) return <CheckCircle2 className="text-brand" size={18} strokeWidth={1.5} />
+  if (projectStatus === 'UNHEALTHY')
+    return <AlertTriangle className="text-warning" size={18} strokeWidth={1.5} />
+  if (projectStatus === 'COMING_UP') return <Loader2 size={14} className="animate-spin" />
   return <AlertTriangle className="text-warning" size={18} strokeWidth={1.5} />
 }
 
@@ -260,6 +265,7 @@ const ServiceStatus = () => {
                 isLoading={service.isLoading}
                 isSuccess={!!service.isSuccess}
                 isProjectNew={isProjectNew}
+                projectStatus={service.status}
               />
               <div className="flex-1">
                 <p>{service.name}</p>

--- a/apps/studio/components/interfaces/Home/ServiceStatus.tsx
+++ b/apps/studio/components/interfaces/Home/ServiceStatus.tsx
@@ -82,24 +82,36 @@ const ServiceStatus = () => {
     data: status,
     isLoading,
     refetch: refetchServiceStatus,
-  } = useProjectServiceStatusQuery({
-    projectRef: ref,
-    refetchInterval: !status || status.some((service) => !service.healthy) ? 5000 : false,
-  })
-  const { data: edgeFunctionsStatus, refetch: refetchEdgeFunctionServiceStatus } =
-    useEdgeFunctionServiceStatusQuery({
+  } = useProjectServiceStatusQuery(
+    {
       projectRef: ref,
-      refetchInterval: !edgeFunctionsStatus?.healthy ? 5000 : false,
-    })
+    },
+    {
+      refetchInterval: (data) => (data?.some((service) => !service.healthy) ? 5000 : false),
+    }
+  )
+  const { data: edgeFunctionsStatus, refetch: refetchEdgeFunctionServiceStatus } =
+    useEdgeFunctionServiceStatusQuery(
+      {
+        projectRef: ref,
+      },
+      {
+        refetchInterval: (data) => (!data?.healthy ? 5000 : false),
+      }
+    )
   const {
     isLoading: isLoadingPostgres,
     isSuccess: isSuccessPostgres,
     refetch: refetchPostgresServiceStatus,
-  } = usePostgresServiceStatusQuery({
-    projectRef: ref,
-    connectionString: project?.connectionString,
-    refetchInterval: !isSuccessPostgres ? 5000 : false,
-  })
+  } = usePostgresServiceStatusQuery(
+    {
+      projectRef: ref,
+      connectionString: project?.connectionString,
+    },
+    {
+      refetchInterval: (data) => (data === null ? 5000 : false),
+    }
+  )
 
   const authStatus = status?.find((service) => service.name === 'auth')
   const restStatus = status?.find((service) => service.name === 'rest')


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

- if any service is not healthy refetch every 5sec

## What is the current behavior?

- no polling

## What is the new behavior?

- yes polling til all is healthy
