### PR TITLE
chore: Remove unused published_at field from older blog posts

### DIFF
--- a/apps/www/_blog/2023-04-14-dbdev.mdx
+++ b/apps/www/_blog/2023-04-14-dbdev.mdx
@@ -8,7 +8,6 @@ tags:
   - launch-week
   - postgres
 date: '2023-04-14'
-published_at: '2023-04-14T08:00:00.000-07:00'
 toc_depth: 3
 author: oli_rice,daltjoh-aws
 image: launch-week-7/day-5-one-more-thing/day-5-dbdev-og.jpg

--- a/apps/www/_blog/2023-04-14-launch-week-7-community-highlights.mdx
+++ b/apps/www/_blog/2023-04-14-launch-week-7-community-highlights.mdx
@@ -7,7 +7,6 @@ categories:
 tags:
   - launch-week
 date: '2023-04-14'
-published_at: '2023-04-14T07:00:00.000-07:00'
 toc_depth: 3
 author: paul_copplestone
 image: launch-week-7/day-5-community-highlights/day-5-community-highlights-og.jpg

--- a/apps/www/_blog/2023-04-14-pg-tle.mdx
+++ b/apps/www/_blog/2023-04-14-pg-tle.mdx
@@ -8,7 +8,6 @@ tags:
   - launch-week
   - postgres
 date: '2023-04-14'
-published_at: '2023-04-14T07:00:00.000-07:00'
 toc_depth: 3
 author: michel,daltjoh-aws
 image: launch-week-7/day-5-supabase-pg-tle/day-5-postgres-tle-thumb.jpg

--- a/apps/www/_blog/2023-04-14-supabase-studio-2.0.mdx
+++ b/apps/www/_blog/2023-04-14-supabase-studio-2.0.mdx
@@ -8,7 +8,6 @@ tags:
   - launch-week
   - studio
 date: '2023-04-14'
-published_at: '2023-04-14T09:00:00.000-07:00'
 toc_depth: 3
 author: alaister,joshenlim,jonny,saltcod
 image: launch-week-7/day-5-supabase-studio-2.0/day-5-supabase-studio-2.0-og.jpg

--- a/apps/www/_blog/2023-04-21-whats-new-in-pg-graphql-v1-2.mdx
+++ b/apps/www/_blog/2023-04-21-whats-new-in-pg-graphql-v1-2.mdx
@@ -9,7 +9,6 @@ tags:
   - graphql
   - planetpg
 date: '2023-04-21'
-published_at: '2023-04-21:00:00.000-07:00'
 toc_depth: 3
 author: oli_rice
 image: launch-week-6/pggraphql/og-pg-graphql.png

--- a/apps/www/_blog/2023-08-09-supabase-studio-3-0.mdx
+++ b/apps/www/_blog/2023-08-09-supabase-studio-3-0.mdx
@@ -9,7 +9,6 @@ tags:
   - studio
   - AI
 date: '2023-08-09'
-published_at: '2023-08-09T09:00:00.000-07:00'
 toc_depth: 3
 author: alaister,gregnr,joshenlim
 image: launch-week-8/day-3/og-day3.jpg

--- a/apps/www/_blog/2023-08-10-supabase-integrations-marketplace.mdx
+++ b/apps/www/_blog/2023-08-10-supabase-integrations-marketplace.mdx
@@ -8,7 +8,6 @@ tags:
   - launch-week
   - integrations
 date: '2023-08-10'
-published_at: '2023-08-10T09:00:00.001-07:00'
 toc_depth: 3
 author: thor_schaeff
 image: launch-week-8/day-4/integration-marketplace-og.jpg

--- a/apps/www/_blog/2023-08-10-using-supabase-with-vercel.mdx
+++ b/apps/www/_blog/2023-08-10-using-supabase-with-vercel.mdx
@@ -8,7 +8,6 @@ tags:
   - launch-week
   - integrations
 date: '2023-08-10'
-published_at: '2023-08-10T09:00:00.000-07:00'
 toc_depth: 3
 author: jonny,jonmeyers_io
 image: launch-week-8/day-4/vercel-and-supabase-og.jpg

--- a/apps/www/_blog/2023-08-11-launch-week-8-community-highlights.mdx
+++ b/apps/www/_blog/2023-08-11-launch-week-8-community-highlights.mdx
@@ -7,7 +7,6 @@ categories:
 tags:
   - launch-week
 date: '2023-08-11'
-published_at: '2023-08-11T06:00:00.000-06:00'
 toc_depth: 3
 author: paul_copplestone
 image: launch-week-8/day-5-community/community-highlights-OG.jpg

--- a/apps/www/_blog/2023-08-11-supabase-soc2-hipaa.mdx
+++ b/apps/www/_blog/2023-08-11-supabase-soc2-hipaa.mdx
@@ -8,7 +8,6 @@ tags:
   - launch-week
   - security
 date: '2023-08-11'
-published_at: '2023-08-11T09:00:00.000-07:00'
 toc_depth: 3
 author: inian
 image: launch-week-8/day-5/OG-day5-compliance.jpg

--- a/apps/www/_blog/2023-08-11-supavisor-1-million.mdx
+++ b/apps/www/_blog/2023-08-11-supavisor-1-million.mdx
@@ -9,7 +9,6 @@ tags:
   - supavisor
   - postgres
 date: '2023-08-11'
-published_at: '2023-08-11T09:00:00.000-07:00'
 toc_depth: 3
 author: egor_romanov,chasers,stas
 image: launch-week-8/day-5/supavisor-og.jpg

--- a/apps/www/_blog/2023-10-03-postgres-dynamic-table-partitioning.mdx
+++ b/apps/www/_blog/2023-10-03-postgres-dynamic-table-partitioning.mdx
@@ -6,7 +6,6 @@ categories:
 tags:
   - postgres
 date: '2023-10-03'
-published_at: '2023-10-03T07:00:00.000-07:00'
 toc_depth: 3
 author: michel
 image: partitions/dynamic-table-partitioning-og.png

--- a/apps/www/_blog/2023-12-08-how-design-works-at-supabase.mdx
+++ b/apps/www/_blog/2023-12-08-how-design-works-at-supabase.mdx
@@ -8,7 +8,6 @@ tags:
   - launch-week
   - design
 date: '2023-12-08'
-published_at: '2023-12-08T08:59:59.000-07:00'
 toc_depth: 3
 author: jonny,marijana,fsansalvadore
 image: lwx-how-design-works-at-supabase/og.png

--- a/apps/www/_blog/2023-12-08-postgres-language-server-implementing-parser.mdx
+++ b/apps/www/_blog/2023-12-08-postgres-language-server-implementing-parser.mdx
@@ -9,7 +9,6 @@ tags:
   - postgres
   - planetpg
 date: '2023-12-08'
-published_at: '2023-12-08T09:00:00.000-07:00'
 toc_depth: 3
 author: philipp
 image: lwx-postgres-language-server/postgres-language-server-og-02.jpg

--- a/apps/www/_blog/2023-12-11-studio-introducing-assistant.mdx
+++ b/apps/www/_blog/2023-12-11-studio-introducing-assistant.mdx
@@ -8,7 +8,6 @@ tags:
   - launch-week
   - studio
 date: '2023-12-11'
-published_at: '2023-12-11T09:00:00.000-07:00'
 toc_depth: 3
 author: alaister,ivasilov,joshenlim
 image: launch-week-x/day-1/day-1-supabase-assistant-thumb.png

--- a/apps/www/_blog/2023-12-12-edge-functions-node-npm.mdx
+++ b/apps/www/_blog/2023-12-12-edge-functions-node-npm.mdx
@@ -8,7 +8,6 @@ tags:
   - launch-week
   - edge-functions
 date: '2023-12-12'
-published_at: '2023-12-12T09:05:00.000-07:00'
 toc_depth: 3
 author: laktek,andreespirela
 image: launch-week-x/day-2/og-edge-runtime.png

--- a/apps/www/_blog/2023-12-12-pg-graphql-postgres-functions.mdx
+++ b/apps/www/_blog/2023-12-12-pg-graphql-postgres-functions.mdx
@@ -9,7 +9,6 @@ tags:
   - pg-graphql
   - planetpg
 date: '2023-12-12'
-published_at: '2023-12-12:00:00.000-07:00'
 toc_depth: 3
 author: oli_rice
 image: lwx-pg-graphql/pg-graphql-og.png

--- a/apps/www/_blog/2023-12-13-postgrest-12.mdx
+++ b/apps/www/_blog/2023-12-13-postgrest-12.mdx
@@ -9,7 +9,6 @@ tags:
   - postgrest
   - planetpg
 date: '2023-12-13'
-published_at: '2023-12-13:00:00.000-07:00'
 toc_depth: 3
 author: oli_rice
 image: lwx-postgrest-12/postgrest12-OG.png

--- a/apps/www/_blog/2023-12-13-supabase-branching.mdx
+++ b/apps/www/_blog/2023-12-13-supabase-branching.mdx
@@ -9,7 +9,6 @@ tags:
   - supavisor
   - postgres
 date: '2023-12-13'
-published_at: '2023-12-13:00:00.000-09:00'
 toc_depth: 3
 author: qiao,jonny
 image: lwx-supabase-branching/branching-og.png

--- a/apps/www/_blog/2023-12-13-supavisor-postgres-connection-pooler.mdx
+++ b/apps/www/_blog/2023-12-13-supavisor-postgres-connection-pooler.mdx
@@ -10,7 +10,6 @@ tags:
   - postgres
   - planetpg
 date: '2023-12-13'
-published_at: '2023-12-13:00:00.000-07:00'
 toc_depth: 3
 author: stas
 image: lwx-supavisor/supavisor-og.png

--- a/apps/www/_blog/2023-12-14-supabase-auth-identity-linking-hooks.mdx
+++ b/apps/www/_blog/2023-12-14-supabase-auth-identity-linking-hooks.mdx
@@ -8,7 +8,6 @@ tags:
   - launch-week
   - auth
 date: '2023-12-14'
-published_at: '2023-12-14:00:05.000-07:00'
 toc_depth: 3
 author: stojan,joel,kangmingtay
 image: lwx-supabase-auth/auth-og.png

--- a/apps/www/_blog/2023-12-14-supabase-wrappers-v02.mdx
+++ b/apps/www/_blog/2023-12-14-supabase-wrappers-v02.mdx
@@ -9,7 +9,6 @@ tags:
   - foreign-data-wrappers
   - planetpg
 date: '2023-12-14'
-published_at: '2023-12-14:00:00.000-07:00'
 toc_depth: 3
 author: bo_lu
 image: lwx-wrappers/wrappers-OG.png

--- a/apps/www/_blog/2023-12-15-client-libraries-v2.mdx
+++ b/apps/www/_blog/2023-12-15-client-libraries-v2.mdx
@@ -7,7 +7,6 @@ categories:
 tags:
   - launch-week
 date: '2023-12-15'
-published_at: '2023-12-15:00:05.000-07:00'
 toc_depth: 3
 author: tyler_shukert,andrew_smith,thor_schaeff
 image: lwx-client-libs/client-libs-OG.png

--- a/apps/www/_blog/2023-12-15-introducing-read-replicas.mdx
+++ b/apps/www/_blog/2023-12-15-introducing-read-replicas.mdx
@@ -8,7 +8,6 @@ tags:
   - launch-week
   - postgres
 date: '2023-12-15'
-published_at: '2023-12-15:01:00.000-07:00'
 toc_depth: 3
 author: angelico_de_los_reyes
 image: lwx-read-replicas/introducing-read-replicas-og.png

--- a/apps/www/_blog/2023-12-15-postgres-on-fly-by-supabase.mdx
+++ b/apps/www/_blog/2023-12-15-postgres-on-fly-by-supabase.mdx
@@ -8,7 +8,6 @@ tags:
   - launch-week
   - postgres
 date: '2023-12-15'
-published_at: '2023-12-15:00:00.000-07:00'
 toc_depth: 3
 author: inian,paul_copplestone
 image: lwx-supafly/fly-postgres-og.png

--- a/apps/www/_blog/2023-12-19-launch-week-x-best-launches.mdx
+++ b/apps/www/_blog/2023-12-19-launch-week-x-best-launches.mdx
@@ -8,7 +8,6 @@ tags:
   - launch-week
   - postgres
 date: '2023-12-19'
-published_at: '2023-12-19:00:00.000-07:00'
 toc_depth: 3
 author: paul_copplestone
 image: lwx-best-launches/top-10-og.png

--- a/apps/www/_blog/2024-01-04-launch-week-x-hackathon-winners.mdx
+++ b/apps/www/_blog/2024-01-04-launch-week-x-hackathon-winners.mdx
@@ -8,7 +8,6 @@ tags:
   - launch-week
   - hackathon
 date: '2024-01-04'
-published_at: '2024-01-04:00:00.000-07:00'
 toc_depth: 3
 author: andrew_smith,tyler_shukert
 image: lwx-hackathon-winners/lwx-hackathon-winners.png


### PR DESCRIPTION
Fix warnings during `contentlayer` build.

![Screenshot 2025-01-15 at 16 41 58](https://github.com/user-attachments/assets/d34e3461-afcc-46d6-b31f-c4debd1d7290)
