### PR TITLE
fix: troubleshooting sync script

### DIFF
--- a/apps/docs/features/docs/Troubleshooting.script.mjs
+++ b/apps/docs/features/docs/Troubleshooting.script.mjs
@@ -125,7 +125,7 @@ async function syncTroubleshootingEntries() {
     if (result.status === 'rejected') {
       console.error(
         `[ERROR] Failed to insert and/or update for ${troubleshootingEntries[index].filePath}:\n%O`,
-        result.reason
+        result.reason?.errors ?? result.reason
       )
       hasErrors = true
     }
@@ -169,7 +169,14 @@ function calculateChecksum(content) {
     extensions: [gfm(), mdxjs()],
     mdastExtensions: [gfmFromMarkdown(), mdxFromMarkdown()],
   })
-  const normalized = toMarkdown(mdast, { extensions: [gfmToMarkdown(), mdxToMarkdown()] })
+  const bodyNormalized = toMarkdown(mdast, { extensions: [gfmToMarkdown(), mdxToMarkdown()] })
+
+  const { data, content: body } = matter(bodyNormalized, {
+    language: 'toml',
+    engines: { toml: toml.parse.bind(toml) },
+  })
+  const newFrontmatter = stringify(data)
+  const normalized = `---\n${newFrontmatter}\n---\n${body}`
 
   return createHash('sha256').update(normalized).digest('base64')
 }
@@ -262,11 +269,18 @@ function addCanonicalUrl(entry) {
 }
 
 /**
+ * @param {string} str
+ */
+function escapeGraphQlString(str) {
+  return str.replace(/"/g, '\\"')
+}
+
+/**
  * @param {TroubleshootingEntry} entry
  */
 async function createGithubDiscussion(entry) {
   console.log(`[INFO] Creating GitHub discussion for ${entry.data.title}`)
-  const content = addCanonicalUrl(entry)
+  const content = escapeGraphQlString(addCanonicalUrl(entry))
 
   const mutation = `
     mutation {
@@ -364,7 +378,7 @@ async function updateGithubDiscussion(entry) {
     throw error
   }
 
-  const content = addCanonicalUrl(entry)
+  const content = escapeGraphQlString(addCanonicalUrl(entry))
   const mutation = `
     mutation {
       updateDiscussion(input: {


### PR DESCRIPTION
Fix some issues with the script:

- GraphQL query strings were built from template literals without escaping, leading to errors when sending to GitHub API, now added escaping
- Lack of visibility when GitHub API errors because the actual errors array is buried below the expanded portion of the object output, now drilling down to the usable portion of the returned error
- When the sync bot auto-adds the database ID, it also reformats the TOML frontmatter, which leads to a spurious "content changed" update when the checksums don't match in the next check run. Resolve this by normalizing the frontmatter before calculating the checksum.