### PR TITLE
fix: additional ingest hosts for sentry

### DIFF
--- a/apps/studio/next.config.js
+++ b/apps/studio/next.config.js
@@ -49,7 +49,8 @@ const GITHUB_USER_CONTENT_URL = 'https://raw.githubusercontent.com'
 const GITHUB_USER_AVATAR_URL = 'https://avatars.githubusercontent.com'
 const GOOGLE_USER_AVATAR_URL = 'https://lh3.googleusercontent.com'
 const VERCEL_LIVE_URL = 'https://vercel.live'
-const SENTRY_URL = 'https://*.ingest.sentry.io'
+const SENTRY_URL =
+  'https://*.ingest.sentry.io https://*.ingest.us.sentry.io https://*.ingest.de.sentry.io'
 
 // used by vercel live preview
 const PUSHER_URL = 'https://*.pusher.com'


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

CSP blocks `o<id>.ingest.us.sentry.io` and `o<id>.ingest.de.sentry.io`


## Additional context

Sentry has US and Europe ingest hosts (us, de). [Allow these in CSP](https://docs.sentry.io/security-legal-pii/security/ip-ranges/#event-ingestion)

It seems like these are interchangeable, and I've seen at least one CSP error for `o<id>.ingest.us.sentry.io`

* `o<id>.ingest.us.sentry.io` == `o<id>.us.ingest.sentry.io`
* `o<id>.ingest.de.sentry.io` == `o<id>.de.ingest.sentry.io`
