### PR TITLE
Assistant chat check keycode enter

### DIFF
--- a/packages/ui-patterns/AssistantChat/AssistantChatForm.tsx
+++ b/packages/ui-patterns/AssistantChat/AssistantChatForm.tsx
@@ -56,11 +56,9 @@ const AssistantChatFormComponent = React.forwardRef<HTMLFormElement, FormProps>(
     const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
       // Check if the pressed key is "Enter" (key code 13) without the "Shift" key
       // also checks if the commands popover is open
-      if (event.key === 'Enter' && !event.shiftKey && !commandsOpen) {
+      if (event.key === 'Enter' && event.keyCode === 13 && !event.shiftKey && !commandsOpen) {
         event.preventDefault()
-        if (submitRef.current) {
-          submitRef.current.click()
-        }
+        if (submitRef.current) submitRef.current.click()
       }
 
       // handles closing the commands popover if open
@@ -71,6 +69,7 @@ const AssistantChatFormComponent = React.forwardRef<HTMLFormElement, FormProps>(
 
     return (
       <form
+        id="assistant-chat"
         ref={formRef}
         {...props}
         onSubmit={onSubmit}
@@ -119,7 +118,7 @@ const AssistantChatFormComponent = React.forwardRef<HTMLFormElement, FormProps>(
                 clipRule="evenodd"
                 d="M13.5 3V2.25H15V3V10C15 10.5523 14.5522 11 14 11H3.56062L5.53029 12.9697L6.06062 13.5L4.99996 14.5607L4.46963 14.0303L1.39641 10.9571C1.00588 10.5666 1.00588 9.93342 1.39641 9.54289L4.46963 6.46967L4.99996 5.93934L6.06062 7L5.53029 7.53033L3.56062 9.5H13.5V3Z"
                 fill="currentColor"
-              ></path>
+              />
             </svg>
           </button>
         </div>


### PR DESCRIPTION
## Enforce `keyCode` 13 when hitting enter in the AssistantChatForm before submitting prompt

Context:
For certain languages, like Chinese or Japanese for example, typing in characters allow choosing other characters when you hit the down arrow key as such:

<img width="96" alt="image" src="https://github.com/user-attachments/assets/103927d1-ca94-413d-8382-c4bc13e730cc" />

The typically UX will be to find the character that the user wants, then hit enter to select. However, because the textarea in AssistantChatForm listens to the onKeyDown "Enter" event, this will prematurely submit the prompt. Text areas (afaik) do not really support triggering the "onSubmit" event on forms as the default behaviour for hitting "Enter" in textareas is to create a new line instead.

 I did notice that hitting "Enter" when selecting the japanese character fires a different keyCode of 229 ([more information here](https://github.com/facebook/react/issues/14512)), and hitting Enter when there's no selection fires a keyCode of 13 (despite both "key" properties returning "Enter"). So this should do the trick for now