### PR TITLE
docs: add example to order parent table by referenced table

### DIFF
--- a/apps/docs/spec/examples/examples.yml
+++ b/apps/docs/spec/examples/examples.yml
@@ -4555,6 +4555,64 @@ functions:
           </TabPanel>
           </Tabs>
         hideCodeBlock: true
+      - id: order-parent-table-by-a-referenced-table
+        name: Order parent table by a referenced table
+        code: |
+          ```ts
+            const { data, error } = await supabase
+              .from('cities')
+              .select(`
+                name,
+                country:countries (
+                  name
+                )
+              `)
+              .order('country(name)', { ascending: true })
+            ```
+        data:
+          sql: |
+            ```sql
+            create table
+              countries (id int8 primary key, name text);
+            create table
+              cities (
+                id int8 primary key,
+                country_id int8 not null references countries,
+                name text
+              );
+
+            insert into
+              countries (id, name)
+            values
+              (1, 'Germany'),
+              (2, 'Indonesia');
+            insert into
+              cities (id, country_id, name)
+            values
+              (1, 1, 'Munich'),
+              (2, 1, 'Bali');
+            ```
+        response: |
+          ```json
+          {
+            "data": [
+              {
+                "name": "Munich",
+                "country": { "name": "Germany" }
+              },
+              {
+                "name": "Bali",
+                "country": { "name": "Indonesia" }
+              }
+            ],
+            "status": 200,
+            "statusText": "OK"
+          }
+          ```
+        description: |
+          Ordering with `referenced_table(col)` affects the ordering of the
+          parent table.
+        hideCodeBlock: true
 
   - id: limit()
     $ref: '@supabase/postgrest-js.PostgrestTransformBuilder.limit'

--- a/apps/docs/spec/supabase_csharp_v1.yml
+++ b/apps/docs/spec/supabase_csharp_v1.yml
@@ -1190,6 +1190,15 @@ functions:
             .Order("cities", "name", Ordering.Descending)
             .Get();
           ```
+      - id: order-parent-table-by-a-referenced-table
+        name: Order parent table by a referenced table
+        code: |
+          ```c#
+          var result = await supabase.From<City>()
+            .Select("name, country:countries(name)")
+            .Order("country(name)", Ordering.Ascending)
+            .Get();
+          ```
 
   - id: range
     title: Range()

--- a/apps/docs/spec/supabase_dart_v2.yml
+++ b/apps/docs/spec/supabase_dart_v2.yml
@@ -4683,6 +4683,56 @@ functions:
             }
           ]
           ```
+      - id: order-parent-table-by-a-referenced-table
+        name: Order parent table by a referenced table
+        code: |
+          ```dart
+          final data = await supabase
+              .from('cities')
+              .select('''
+                name,
+                country:countries (
+                  name
+                )
+              ''')
+              .order('country(name)', ascending: true)
+          ```
+        data:
+          sql: |
+            ```sql
+            create table
+              countries (id int8 primary key, name text);
+            create table
+              cities (
+                id int8 primary key,
+                country_id int8 not null references countries,
+                name text
+              );
+
+            insert into
+              countries (id, name)
+            values
+              (1, 'Germany'),
+              (2, 'Indonesia');
+            insert into
+              cities (id, country_id, name)
+            values
+              (1, 1, 'Munich'),
+              (2, 2, 'Bali');
+            ```
+        response: |
+          ```json
+          [
+            {
+              "name": "Munich",
+              "country": { "name": "Germany" }
+            },
+            {
+              "name": "Bali",
+              "country": { "name": "Indonesia" }
+            }
+          ]
+          ```
   - id: limit
     title: limit()
     description: |

--- a/apps/docs/spec/supabase_js_v2.yml
+++ b/apps/docs/spec/supabase_js_v2.yml
@@ -6155,8 +6155,66 @@ functions:
           }
           ```
         description: |
-          Ordering on referenced tables doesn't affect the ordering of
-          the parent table.
+          Ordering with `referencedTable` doesn't affect the ordering of the
+          parent table.
+        hideCodeBlock: true
+      - id: order-parent-table-by-a-referenced-table
+        name: Order parent table by a referenced table
+        code: |
+          ```ts
+            const { data, error } = await supabase
+              .from('cities')
+              .select(`
+                name,
+                country:countries (
+                  name
+                )
+              `)
+              .order('country(name)', { ascending: true })
+            ```
+        data:
+          sql: |
+            ```sql
+            create table
+              countries (id int8 primary key, name text);
+            create table
+              cities (
+                id int8 primary key,
+                country_id int8 not null references countries,
+                name text
+              );
+
+            insert into
+              countries (id, name)
+            values
+              (1, 'Germany'),
+              (2, 'Indonesia');
+            insert into
+              cities (id, country_id, name)
+            values
+              (1, 1, 'Munich'),
+              (2, 2, 'Bali');
+            ```
+        response: |
+          ```json
+          {
+            "data": [
+              {
+                "name": "Munich",
+                "country": { "name": "Germany" }
+              },
+              {
+                "name": "Bali",
+                "country": { "name": "Indonesia" }
+              }
+            ],
+            "status": 200,
+            "statusText": "OK"
+          }
+          ```
+        description: |
+          Ordering with `referenced_table(col)` affects the ordering of the
+          parent table.
         hideCodeBlock: true
 
   - id: limit

--- a/apps/docs/spec/supabase_kt_v3.yml
+++ b/apps/docs/spec/supabase_kt_v3.yml
@@ -2507,6 +2507,64 @@ functions:
           Ordering on foreign tables doesn't affect the ordering of
           the parent table.
         hideCodeBlock: true
+      - id: order-parent-table-by-a-referenced-table
+        name: Order parent table by a referenced table
+        code: |
+          ```kotlin
+          val columns = Columns.raw("""
+              name,
+              country:countries(name)
+          """.trimIndent())
+          supabase.from("cities").select(
+              columns = columns
+          ) {
+              order(column = "country(name)", order = Order.ASCENDING)
+          }
+          ```
+        data:
+          sql: |
+            ```sql
+            create table
+              countries (id int8 primary key, name text);
+            create table
+              cities (
+                id int8 primary key,
+                country_id int8 not null references countries,
+                name text
+              );
+
+            insert into
+              countries (id, name)
+            values
+              (1, 'Germany'),
+              (2, 'Indonesia');
+            insert into
+              cities (id, country_id, name)
+            values
+              (1, 1, 'Munich'),
+              (2, 2, 'Bali');
+            ```
+        response: |
+          ```json
+          {
+            "data": [
+              {
+                "name": "Munich",
+                "country": { "name": "Germany" }
+              },
+              {
+                "name": "Bali",
+                "country": { "name": "Indonesia" }
+              }
+            ],
+            "status": 200,
+            "statusText": "OK"
+          }
+          ```
+        description: |
+          Ordering with `referenced_table(col)` affects the ordering of the
+          parent table.
+        hideCodeBlock: true
 
   - id: limit
     title: limit()

--- a/apps/docs/spec/supabase_py_v2.yml
+++ b/apps/docs/spec/supabase_py_v2.yml
@@ -5909,6 +5909,60 @@ functions:
           Ordering on foreign tables doesn't affect the ordering of
           the parent table.
         hideCodeBlock: true
+      - id: order-parent-table-by-a-referenced-table
+        name: Order parent table by a referenced table
+        code: |
+          ```python
+          response = (
+              supabase.table("cities")
+              .select("name, country:countries(name)")
+              .order("country(name)", desc=False)
+          )
+          ```
+        data:
+          sql: |
+            ```sql
+            create table
+              countries (id int8 primary key, name text);
+            create table
+              cities (
+                id int8 primary key,
+                country_id int8 not null references countries,
+                name text
+              );
+
+            insert into
+              countries (id, name)
+            values
+              (1, 'Germany'),
+              (2, 'Indonesia');
+            insert into
+              cities (id, country_id, name)
+            values
+              (1, 1, 'Munich'),
+              (2, 2, 'Bali');
+            ```
+        response: |
+          ```json
+          {
+            "data": [
+              {
+                "name": "Munich",
+                "country": { "name": "Germany" }
+              },
+              {
+                "name": "Bali",
+                "country": { "name": "Indonesia" }
+              }
+            ],
+            "status": 200,
+            "statusText": "OK"
+          }
+          ```
+        description: |
+          Ordering with `referenced_table(col)` affects the ordering of the
+          parent table.
+        hideCodeBlock: true
   - id: limit
     title: limit()
     params:

--- a/apps/docs/spec/supabase_swift_v2.yml
+++ b/apps/docs/spec/supabase_swift_v2.yml
@@ -3095,6 +3095,66 @@ functions:
           Ordering on foreign tables doesn't affect the ordering of
           the parent table.
         hideCodeBlock: true
+      - id: order-parent-table-by-a-referenced-table
+        name: Order parent table by a referenced table
+        code: |
+          ```swift
+            try await supabase
+              .from("cities")
+              .select(
+                """
+                  name,
+                  country:countries (
+                    name
+                  )
+                """
+              )
+              .order("country(name)", ascending: true)
+            ```
+        data:
+          sql: |
+            ```sql
+            create table
+              countries (id int8 primary key, name text);
+            create table
+              cities (
+                id int8 primary key,
+                country_id int8 not null references countries,
+                name text
+              );
+
+            insert into
+              countries (id, name)
+            values
+              (1, 'Germany'),
+              (2, 'Indonesia');
+            insert into
+              cities (id, country_id, name)
+            values
+              (1, 1, 'Munich'),
+              (2, 2, 'Bali');
+            ```
+        response: |
+          ```swifton
+          {
+            "data": [
+              {
+                "name": "Munich",
+                "country": { "name": "Germany" }
+              },
+              {
+                "name": "Bali",
+                "country": { "name": "Indonesia" }
+              }
+            ],
+            "status": 200,
+            "statusText": "OK"
+          }
+          ```
+        description: |
+          Ordering with `referenced_table(col)` affects the ordering of the
+          parent table.
+        hideCodeBlock: true
 
   - id: limit
     title: limit()


### PR DESCRIPTION
[Context](https://www.notion.so/supabase/Add-example-of-ordering-parent-table-by-foreign-table-with-inner-bb2751e43dc04b71bdec507360877555?pvs=4)