### PR TITLE
fix: don't retry queries on 4xx errors

### DIFF
--- a/apps/studio/data/query-client.ts
+++ b/apps/studio/data/query-client.ts
@@ -19,8 +19,13 @@ export function getQueryClient() {
         queries: {
           staleTime: 60 * 1000, // 1 minute
           retry(failureCount, error) {
-            // Don't retry on 404s
-            if (error instanceof ResponseError && error.code === 404) {
+            // Don't retry on 4xx errors
+            if (
+              error instanceof ResponseError &&
+              error.code !== undefined &&
+              error.code >= 400 &&
+              error.code < 500
+            ) {
               return false
             }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix/chore

## What is the current behavior?

All errors other than 404 are retried up to 3 times.

## What is the new behavior?

All 400 class errors are not retried. It's unlikely that retrying these type of errors will result in a different response, and the cost of retrying them is the user having to wait a long time before they see the error message – which is usually a result of a bad input on the users part.

## Testing

An easy way to test this is input the wrong type in the filter input in the table editor and you'll immediately see an error now:
<img width="723" alt="Screenshot 2025-01-20 at 13 34 32" src="https://github.com/user-attachments/assets/095988ea-2689-4148-9f18-b86a862a1c9e" />
