### PR TITLE
Swap CALL to SELECT for database functions in cron jobs

### DIFF
--- a/apps/studio/components/interfaces/Integrations/CronJobs/CreateCronJobSheet.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CreateCronJobSheet.tsx
@@ -186,7 +186,7 @@ const buildCommand = (values: CronJobType) => {
       values.timeoutMs
     )
   } else if (values.type === 'sql_function') {
-    command = `CALL ${values.schema}.${values.functionName}()`
+    command = `SELECT ${values.schema}.${values.functionName}()`
   }
   return command
 }

--- a/apps/studio/components/interfaces/Integrations/CronJobs/CronJobs.utils.test.ts
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CronJobs.utils.test.ts
@@ -20,12 +20,22 @@ describe('parseCronJobCommand', () => {
     })
   })
 
-  it('should return a sql function command when the command is CALL auth.jwt ()', () => {
-    const command = 'CALL auth.jwt ()'
+  it('should return a sql function command when the command is SELECT auth.jwt ()', () => {
+    const command = 'SELECT auth.jwt ()'
     expect(parseCronJobCommand(command, 'random_project_ref')).toStrictEqual({
       type: 'sql_function',
       schema: 'auth',
       functionName: 'jwt',
+      snippet: command,
+    })
+  })
+
+  it('should return a sql function command when the command is SELECT public.test_fn(1, 2)', () => {
+    const command = 'SELECT public.test_fn(1, 2)'
+    expect(parseCronJobCommand(command, 'random_project_ref')).toStrictEqual({
+      type: 'sql_function',
+      schema: 'public',
+      functionName: 'test_fn',
       snippet: command,
     })
   })

--- a/apps/studio/components/interfaces/Integrations/CronJobs/CronJobs.utils.ts
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CronJobs.utils.ts
@@ -91,7 +91,7 @@ export const parseCronJobCommand = (originalCommand: string, projectRef: string)
         edgeFunctionName: url,
         httpHeaders: headersObjs,
         httpBody: body,
-        timeoutMs: +timeout ?? 1000,
+        timeoutMs: Number(timeout ?? 1000),
         snippet: originalCommand,
       }
     }
@@ -102,15 +102,16 @@ export const parseCronJobCommand = (originalCommand: string, projectRef: string)
       endpoint: url,
       httpHeaders: headersObjs,
       httpBody: body,
-      timeoutMs: +timeout ?? 1000,
+      timeoutMs: Number(timeout ?? 1000),
       snippet: originalCommand,
     }
   }
 
-  if (command.toLocaleLowerCase().startsWith('call ')) {
+  const regexDBFunction = /select\s+[a-zA-Z-_]*\.?[a-zA-Z-_]*\s*\(.+/g
+  if (command.toLocaleLowerCase().match(regexDBFunction)) {
     const [schemaName, functionName] = command
-      .replace('CALL ', '')
-      .replace('()', '')
+      .replace('SELECT ', '')
+      .replace(/\(.*\)/, '')
       .trim()
       .split('.')
 


### PR DESCRIPTION
CALL is for stored procedures but our UI is letting users select database functions, which need to SELECT command instead. Have verified on prod that cron jobs using database functions are error-ing out
![image](https://github.com/user-attachments/assets/39bf82ff-6fda-4a6c-9153-99828a3aae0e)
