### PR TITLE
Fix: mobile styling bugs

### DIFF
--- a/apps/studio/components/ui/CardButton.tsx
+++ b/apps/studio/components/ui/CardButton.tsx
@@ -109,7 +109,7 @@ const CardButton = ({
   }
 
   if (fixedHeight) {
-    containerClasses = [...containerClasses, 'md:h-32']
+    containerClasses = [...containerClasses, 'min-h-32 md:min-h-44']
   }
 
   const ImageContainer = ({ children }: { children: React.ReactNode }) => {

--- a/apps/studio/components/ui/Panel.tsx
+++ b/apps/studio/components/ui/Panel.tsx
@@ -69,7 +69,7 @@ const PanelNotice = forwardRef<
       ref={ref}
       {...props}
       className={cn(
-        'relative mx-4 md:px-4 md:px-6 py-5 bg-studio flex flex-col lg:flex-row lg:justify-between gap-6 overflow-hidden lg:items-center',
+        'relative px-4 md:px-6 py-5 bg-studio flex flex-col lg:flex-row lg:justify-between gap-6 overflow-hidden lg:items-center',
         className
       )}
     >


### PR DESCRIPTION
Fixed:
- ProjectCard height
<img width="446" alt="Screenshot 2025-01-20 at 10 08 54" src="https://github.com/user-attachments/assets/6c3becfb-991a-428d-86c4-d0c0c65dfb3b" />

- PanelNotice x padding
<img width="969" alt="Screenshot 2025-01-20 at 10 07 45" src="https://github.com/user-attachments/assets/d09f8fe9-4ac8-422c-8abe-2f07fe7ee065" />
