### PR TITLE
fix: remove duplicate archive function from pgmq_public

### DIFF
--- a/apps/studio/data/database-queues/database-queues-toggle-postgrest-mutation.ts
+++ b/apps/studio/data/database-queues/database-queues-toggle-postgrest-mutation.ts
@@ -104,26 +104,6 @@ $$;
 comment on function ${QUEUES_SCHEMA}.archive(queue_name text, message_id bigint) is 'Archives a message by moving it from the queue to a permanent archive.';
 
 
-create or replace function ${QUEUES_SCHEMA}.archive(
-    queue_name text,
-    message_id bigint
-)
-  returns boolean
-  language plpgsql
-  set search_path = ''
-as $$
-begin
-    return
-    pgmq.archive(
-        queue_name := queue_name,
-        msg_id := message_id
-    );
-end;
-$$;
-
-comment on function ${QUEUES_SCHEMA}.archive(queue_name text, message_id bigint) is 'Archives a message by moving it from the queue to a permanent archive.';
-
-
 create or replace function ${QUEUES_SCHEMA}.delete(
     queue_name text,
     message_id bigint


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Two identical archive functions.

## What is the new behavior?

Only one.
