### PR TITLE
fix: sign users out if profile request 401s

### DIFF
--- a/apps/studio/lib/profile.tsx
+++ b/apps/studio/lib/profile.tsx
@@ -1,4 +1,5 @@
 import { useIsLoggedIn } from 'common'
+import { useRouter } from 'next/router'
 import { PropsWithChildren, createContext, useContext, useMemo } from 'react'
 import { toast } from 'sonner'
 
@@ -6,9 +7,10 @@ import { usePermissionsQuery } from 'data/permissions/permissions-query'
 import { useProfileCreateMutation } from 'data/profile/profile-create-mutation'
 import { useProfileQuery } from 'data/profile/profile-query'
 import type { Profile } from 'data/profile/types'
-import { useSendIdentifyMutation } from 'data/telemetry/send-identify-mutation'
-import type { ResponseError } from 'types'
 import { useSendEventMutation } from 'data/telemetry/send-event-mutation'
+import { useSendIdentifyMutation } from 'data/telemetry/send-identify-mutation'
+import { ResponseError } from 'types'
+import { useSignOut } from './auth'
 import { TelemetryActions } from './constants/telemetry'
 
 export type ProfileContextType = {
@@ -29,6 +31,8 @@ export const ProfileContext = createContext<ProfileContextType>({
 
 export const ProfileProvider = ({ children }: PropsWithChildren<{}>) => {
   const isLoggedIn = useIsLoggedIn()
+  const router = useRouter()
+  const signOut = useSignOut()
 
   const { mutate: sendEvent } = useSendEventMutation()
   const { mutate: sendIdentify } = useSendIdentifyMutation()
@@ -52,9 +56,18 @@ export const ProfileProvider = ({ children }: PropsWithChildren<{}>) => {
       sendIdentify({ user: profile })
     },
     onError(err) {
+      console.log('err:', err instanceof ResponseError, err)
       // if the user does not yet exist, create a profile for them
-      if (typeof err === 'object' && err !== null && err.message === "User's profile not found") {
+      if (err.message === "User's profile not found") {
         createProfile()
+      }
+
+      // [Alaister] If the user has a bad auth token, auth-js won't know about it
+      // and will think the user is authenticated. Since fetching the profile happens
+      // on every page load, we can check for a 401 here and sign the user out if
+      // they have a bad token.
+      if (err.code === 401) {
+        signOut().then(() => router.push('/sign-in'))
       }
     },
   })

--- a/apps/studio/lib/profile.tsx
+++ b/apps/studio/lib/profile.tsx
@@ -56,7 +56,6 @@ export const ProfileProvider = ({ children }: PropsWithChildren<{}>) => {
       sendIdentify({ user: profile })
     },
     onError(err) {
-      console.log('err:', err instanceof ResponseError, err)
       // if the user does not yet exist, create a profile for them
       if (err.message === "User's profile not found") {
         createProfile()


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

If the user has a bad auth token, auth-js won't know about it and will think the user is authenticated, leading to endless loading states.

## What is the new behavior?

If the profile request returns 401, signs the user out.