### PR TITLE
Fix SQL editor menu wrongly hiding results

### DIFF
--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorNav.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorNav.tsx
@@ -240,10 +240,10 @@ export const SQLEditorNav = ({
 
   const favoritesTreeState = useMemo(
     () =>
-      numFavoriteSnippets === 0
+      favoriteSnippets.length === 0
         ? [ROOT_NODE]
         : formatFolderResponseForTreeView({ contents: favoriteSnippets }),
-    [favoriteSnippets, numFavoriteSnippets]
+    [favoriteSnippets]
   )
 
   const favoriteSnippetsLastItemIds = useMemo(
@@ -303,10 +303,10 @@ export const SQLEditorNav = ({
 
   const projectSnippetsTreeState = useMemo(
     () =>
-      numProjectSnippets === 0
+      sharedSnippets.length === 0
         ? [ROOT_NODE]
         : formatFolderResponseForTreeView({ contents: sharedSnippets }),
-    [sharedSnippets, numProjectSnippets]
+    [sharedSnippets]
   )
 
   const projectSnippetsLastItemIds = useMemo(


### PR DESCRIPTION
For favourites and shared, we were depending on whether their corresponding `count` values (from `/content/count`) to decide what to render.

Because the result from `/content/count` didn't tally with what's coming from `/content`:
- e.g `/content/count` returns that shared snippets count is 0, but `/content` returns 2 results for shared snippets
- Hence why FE didn't render the shared snippets results due to the incorrect `/content/count` value

However, looking twice at this, I reckon we don't need to rely on the `/content/count` value to determine the UI rendering, can solely depend on the results from `/content/count`