### PR TITLE
Fix table editor selected row BG color

### DIFF
--- a/apps/studio/styles/grid.scss
+++ b/apps/studio/styles/grid.scss
@@ -132,8 +132,7 @@
 
 /* select row */
 .rdg-row[aria-selected='true'] {
-  @apply bg-surface-200/50 dark:bg-surface-200/75;
-  @apply hover:bg-surface-200;
+  @apply bg-surface-200;
 }
 
 .tab-cursor {


### PR DESCRIPTION
Realised the CSS has opacity in it