### PR TITLE
Reports V2: support dragging blocks from assistant to custom report

### DIFF
--- a/apps/studio/components/interfaces/Reports/GridResize.tsx
+++ b/apps/studio/components/interfaces/Reports/GridResize.tsx
@@ -1,11 +1,12 @@
 import RGL, { WidthProvider } from 'react-grid-layout'
 import 'react-grid-layout/css/styles.css'
 import 'react-resizable/css/styles.css'
+import { toast } from 'sonner'
 
 import { DEFAULT_CHART_CONFIG } from 'components/ui/QueryBlock/QueryBlock'
 import { AnalyticsInterval } from 'data/analytics/constants'
 import { Dashboards } from 'types'
-import useNewQuery from '../SQLEditor/hooks'
+import { useNewQuery } from '../SQLEditor/hooks'
 import { ChartConfig } from '../SQLEditor/UtilityPanel/ChartConfig'
 import { ReportBlock } from './ReportBlock/ReportBlock'
 import { LAYOUT_COLUMN_COUNT } from './Reports.constants'
@@ -60,6 +61,7 @@ export const GridResize = ({
 
     if (!label || !sql) return console.error('SQL and Label required')
     const id = await newQuery(sql, label, false)
+    toast.success(`Successfully created new query: ${label}`)
 
     const updatedLayout = layout.map((x) => {
       const existingBlock = editableReport.layout.find((y) => x.i === y.id)

--- a/apps/studio/components/interfaces/Reports/GridResize.tsx
+++ b/apps/studio/components/interfaces/Reports/GridResize.tsx
@@ -94,7 +94,7 @@ export const GridResize = ({
       } else {
         return {
           id,
-          attribute: `snippetnew_${id}`,
+          attribute: `new_snippet_${id}`,
           chartConfig: { ...DEFAULT_CHART_CONFIG },
           label,
           chart_type: 'bar',

--- a/apps/studio/components/interfaces/Reports/GridResize.tsx
+++ b/apps/studio/components/interfaces/Reports/GridResize.tsx
@@ -71,7 +71,10 @@ export const GridResize = ({
     if (!profile) return console.error('Profile is required')
     if (!project) return console.error('Project is required')
 
-    const queryData = JSON.parse(e.dataTransfer.getData('application/json'))
+    const data = e.dataTransfer.getData('application/json')
+    if (!data) return
+
+    const queryData = JSON.parse(data)
     const { label, sql } = queryData
     if (!label || !sql) return console.error('SQL and Label required')
 

--- a/apps/studio/components/interfaces/Reports/GridResize.tsx
+++ b/apps/studio/components/interfaces/Reports/GridResize.tsx
@@ -28,7 +28,13 @@ interface GridResizeProps {
   editableReport: Dashboards.Content
   disableUpdate: boolean
   onRemoveChart: ({ metric }: { metric: { key: string } }) => void
-  onUpdateChart: (id: string, config: Partial<ChartConfig>) => void
+  onUpdateChart: (
+    id: string,
+    {
+      chart,
+      chartConfig,
+    }: { chart?: Partial<Dashboards.Chart>; chartConfig?: Partial<ChartConfig> }
+  ) => void
   setEditableReport: (payload: any) => void
 }
 

--- a/apps/studio/components/interfaces/Reports/GridResize.tsx
+++ b/apps/studio/components/interfaces/Reports/GridResize.tsx
@@ -81,7 +81,7 @@ export const GridResize = ({
     if (!data) return
 
     const queryData = JSON.parse(data)
-    const { label, sql } = queryData
+    const { label, sql, config } = queryData
     if (!label || !sql) return console.error('SQL and Label required')
 
     const toastId = toast.loading(`Creating new query: ${label}`)
@@ -95,7 +95,7 @@ export const GridResize = ({
         return {
           id,
           attribute: `new_snippet_${id}`,
-          chartConfig: { ...DEFAULT_CHART_CONFIG },
+          chartConfig: { ...DEFAULT_CHART_CONFIG, ...(config ?? {}) },
           label,
           chart_type: 'bar',
           h: layoutItem.h,

--- a/apps/studio/components/interfaces/Reports/ReportBlock/ChartBlock.tsx
+++ b/apps/studio/components/interfaces/Reports/ReportBlock/ChartBlock.tsx
@@ -1,8 +1,9 @@
 import dayjs from 'dayjs'
 import { useRouter } from 'next/router'
-import { ReactNode, useState } from 'react'
+import { ReactNode, useEffect, useState } from 'react'
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from 'ui'
 
+import { ChartConfig } from 'components/interfaces/SQLEditor/UtilityPanel/ChartConfig'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import NoDataPlaceholder from 'components/ui/Charts/NoDataPlaceholder'
 import { AnalyticsInterval } from 'data/analytics/constants'
@@ -18,6 +19,7 @@ import { METRICS } from 'lib/constants/metrics'
 import { Activity, BarChartIcon, Loader2 } from 'lucide-react'
 import { Bar, BarChart, CartesianGrid, Line, LineChart, XAxis, YAxis } from 'recharts'
 import { useDatabaseSelectorStateSnapshot } from 'state/database-selector'
+import { Dashboards } from 'types'
 import { WarningIcon } from 'ui'
 import { METRIC_THRESHOLDS } from './ReportBlock.constants'
 import { ReportBlockContainer } from './ReportBlockContainer'
@@ -33,6 +35,13 @@ interface ChartBlockProps {
   isLoading?: boolean
   actions?: ReactNode
   maxHeight?: number
+  onUpdateChartConfig?: ({
+    chart,
+    chartConfig,
+  }: {
+    chart?: Partial<Dashboards.Chart>
+    chartConfig?: Partial<ChartConfig>
+  }) => void
 }
 
 export const ChartBlock = ({
@@ -46,6 +55,7 @@ export const ChartBlock = ({
   isLoading = false,
   actions,
   maxHeight,
+  onUpdateChartConfig,
 }: ChartBlockProps) => {
   const router = useRouter()
   const { ref } = router.query
@@ -131,6 +141,10 @@ export const ChartBlock = ({
     }
   })
 
+  useEffect(() => {
+    if (defaultChartStyle) setChartStyle(defaultChartStyle)
+  }, [defaultChartStyle])
+
   return (
     <ReportBlockContainer
       draggable
@@ -145,7 +159,11 @@ export const ChartBlock = ({
             disabled={loading}
             className="w-7 h-7"
             icon={chartStyle === 'bar' ? <Activity /> : <BarChartIcon />}
-            onClick={() => setChartStyle(chartStyle === 'bar' ? 'line' : 'bar')}
+            onClick={() => {
+              const style = chartStyle === 'bar' ? 'line' : 'bar'
+              if (onUpdateChartConfig) onUpdateChartConfig({ chart: { chart_type: style } })
+              setChartStyle(style)
+            }}
             tooltip={{
               content: {
                 side: 'bottom',

--- a/apps/studio/components/interfaces/Reports/ReportBlock/ChartBlock.tsx
+++ b/apps/studio/components/interfaces/Reports/ReportBlock/ChartBlock.tsx
@@ -224,7 +224,7 @@ export const ChartBlock = ({
                 content={
                   <ChartTooltipContent
                     className="w-[200px]"
-                    labelSuffix="%"
+                    labelSuffix={chartData?.format === '%' ? '%' : ''}
                     labelFormatter={(x) => dayjs(x).format('DD MMM YYYY')}
                   />
                 }

--- a/apps/studio/components/interfaces/Reports/ReportBlock/ChartBlock.tsx
+++ b/apps/studio/components/interfaces/Reports/ReportBlock/ChartBlock.tsx
@@ -89,6 +89,7 @@ export const ChartBlock = ({
 
   const loading =
     isLoading ||
+    attribute.startsWith('snippetnew') ||
     (provider === 'infra-monitoring'
       ? isFetchingInfraMonitoring
       : provider === 'daily-stats'
@@ -157,14 +158,16 @@ export const ChartBlock = ({
       }
     >
       {loading ? (
-        <div className="flex flex-grow w-full flex-col items-center justify-center gap-y-2">
+        <div className="flex flex-grow w-full flex-col items-center justify-center gap-y-2 px-4">
           <Loader2 size={18} className="animate-spin text-border-strong" />
-          <p className="text-xs text-foreground-lighter">Loading data for {label}</p>
+          <p className="text-xs text-foreground-lighter text-center">Loading data for {label}</p>
         </div>
       ) : chartData === undefined ? (
-        <div className="flex flex-grow w-full flex-col items-center justify-center gap-y-2">
+        <div className="flex flex-grow w-full flex-col items-center justify-center gap-y-2 px-4">
           <WarningIcon />
-          <p className="text-xs text-foreground-lighter">Unable to load data for {label}</p>
+          <p className="text-xs text-foreground-lighter text-center">
+            Unable to load data for {label}
+          </p>
         </div>
       ) : data.length === 0 ? (
         <div className="flex flex-grow w-full flex-col items-center justify-center gap-y-2">

--- a/apps/studio/components/interfaces/Reports/ReportBlock/ChartBlock.tsx
+++ b/apps/studio/components/interfaces/Reports/ReportBlock/ChartBlock.tsx
@@ -201,7 +201,7 @@ export const ChartBlock = ({
                 content={
                   <ChartTooltipContent
                     className="w-[200px]"
-                    labelSuffix="%"
+                    labelSuffix={chartData?.format === '%' ? '%' : ''}
                     labelFormatter={(x) => dayjs(x).format('DD MMM YYYY')}
                   />
                 }

--- a/apps/studio/components/interfaces/Reports/ReportBlock/ChartBlock.tsx
+++ b/apps/studio/components/interfaces/Reports/ReportBlock/ChartBlock.tsx
@@ -31,7 +31,6 @@ interface ChartBlockProps {
   interval?: AnalyticsInterval
   defaultChartStyle?: 'bar' | 'line'
   isLoading?: boolean
-  draggable?: boolean
   actions?: ReactNode
   maxHeight?: number
 }
@@ -45,7 +44,6 @@ export const ChartBlock = ({
   interval = '1d',
   defaultChartStyle = 'bar',
   isLoading = false,
-  draggable = false,
   actions,
   maxHeight,
 }: ChartBlockProps) => {
@@ -133,7 +131,8 @@ export const ChartBlock = ({
 
   return (
     <ReportBlockContainer
-      draggable={draggable}
+      draggable
+      showDragHandle
       icon={metric?.category?.icon('text-foreground-muted')}
       label={label}
       actions={

--- a/apps/studio/components/interfaces/Reports/ReportBlock/ChartBlock.tsx
+++ b/apps/studio/components/interfaces/Reports/ReportBlock/ChartBlock.tsx
@@ -99,7 +99,7 @@ export const ChartBlock = ({
 
   const loading =
     isLoading ||
-    attribute.startsWith('snippetnew') ||
+    attribute.startsWith('new_snippet_') ||
     (provider === 'infra-monitoring'
       ? isFetchingInfraMonitoring
       : provider === 'daily-stats'

--- a/apps/studio/components/interfaces/Reports/ReportBlock/ChartBlock.tsx
+++ b/apps/studio/components/interfaces/Reports/ReportBlock/ChartBlock.tsx
@@ -118,7 +118,8 @@ export const ChartBlock = ({
   }
 
   const data = (chartData?.data ?? []).map((x: any) => {
-    const value = chartData?.format === '%' ? x[attribute].toFixed(1) : x[attribute].toFixed(2)
+    const value =
+      chartData?.format === '%' ? x[attribute].toFixed(1) : x[attribute].toLocaleString()
     const color = getCellColor(attribute, x[attribute])
     return {
       ...x,

--- a/apps/studio/components/interfaces/Reports/ReportBlock/ReportBlock.tsx
+++ b/apps/studio/components/interfaces/Reports/ReportBlock/ReportBlock.tsx
@@ -34,7 +34,6 @@ export const ReportBlock = ({
 }: ReportBlockProps) => {
   const { ref: projectRef } = useParams()
   const state = useDatabaseSelectorStateSnapshot()
-  // const [refetchInterval, setRefetchInterval] = useState(0)
 
   const isSnippet = item.attribute.startsWith('snippet_')
 
@@ -46,7 +45,7 @@ export const ReportBlock = ({
       refetchOnMount: false,
       refetchIntervalInBackground: false,
       retry: (failureCount: number) => {
-        if (failureCount >= 3) return false
+        if (failureCount >= 2) return false
         return true
       },
     }

--- a/apps/studio/components/interfaces/Reports/ReportBlock/ReportBlock.tsx
+++ b/apps/studio/components/interfaces/Reports/ReportBlock/ReportBlock.tsx
@@ -56,8 +56,6 @@ export const ReportBlock = ({
   const isReadOnlySQL = isReadOnlySelect(sql ?? '')
   const snippetMissing = error?.message.includes('Content not found')
 
-  if (isSnippet) console.log(item.id, { data, isLoading })
-
   return (
     <>
       {isSnippet ? (

--- a/apps/studio/components/interfaces/Reports/ReportBlock/ReportBlock.tsx
+++ b/apps/studio/components/interfaces/Reports/ReportBlock/ReportBlock.tsx
@@ -20,7 +20,13 @@ interface ReportBlockProps {
   interval: AnalyticsInterval
   disableUpdate: boolean
   onRemoveChart: ({ metric }: { metric: { key: string } }) => void
-  onUpdateChart: (config: Partial<ChartConfig>) => void
+  onUpdateChart: ({
+    chart,
+    chartConfig,
+  }: {
+    chart?: Partial<Dashboards.Chart>
+    chartConfig?: Partial<ChartConfig>
+  }) => void
 }
 
 export const ReportBlock = ({
@@ -129,6 +135,7 @@ export const ReportBlock = ({
           interval={interval}
           attribute={item.attribute}
           provider={item.provider}
+          defaultChartStyle={item.chart_type}
           maxHeight={232}
           label={`${item.label}${projectRef !== state.selectedDatabaseId ? (item.provider === 'infra-monitoring' ? ' of replica' : ' on project') : ''}`}
           actions={
@@ -142,6 +149,7 @@ export const ReportBlock = ({
               />
             ) : null
           }
+          onUpdateChartConfig={onUpdateChart}
         />
       )}
     </>

--- a/apps/studio/components/interfaces/Reports/ReportBlock/ReportBlock.tsx
+++ b/apps/studio/components/interfaces/Reports/ReportBlock/ReportBlock.tsx
@@ -1,6 +1,7 @@
 import { X } from 'lucide-react'
 
 import { useParams } from 'common'
+import { ChartConfig } from 'components/interfaces/SQLEditor/UtilityPanel/ChartConfig'
 import { isReadOnlySelect } from 'components/ui/AIAssistantPanel/AIAssistant.utils'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import { DEFAULT_CHART_CONFIG, QueryBlock } from 'components/ui/QueryBlock/QueryBlock'
@@ -10,7 +11,6 @@ import { useDatabaseSelectorStateSnapshot } from 'state/database-selector'
 import { Dashboards, SqlSnippets } from 'types'
 import { cn } from 'ui'
 import ShimmeringLoader from 'ui-patterns/ShimmeringLoader'
-import { ChartConfig } from '../../SQLEditor/UtilityPanel/ChartConfig'
 import { ChartBlock } from './ChartBlock'
 
 interface ReportBlockProps {

--- a/apps/studio/components/interfaces/Reports/ReportBlock/ReportBlockContainer.tsx
+++ b/apps/studio/components/interfaces/Reports/ReportBlock/ReportBlockContainer.tsx
@@ -31,7 +31,12 @@ export const ReportBlockContainer = ({
       onDragStart={onDragStart}
       className="h-full flex flex-col overflow-hidden bg-surface-100 border-overlay relative rounded border shadow-sm"
     >
-      <div className="grid-item-drag-handle cursor-move flex py-1 pl-3 pr-1 items-center gap-2 z-10 shrink-0 group">
+      <div
+        className={cn(
+          'grid-item-drag-handle flex py-1 pl-3 pr-1 items-center gap-2 z-10 shrink-0 group',
+          draggable && 'cursor-move'
+        )}
+      >
         <div
           className={cn(showDragHandle && 'transition-opacity opacity-100 group-hover:opacity-0')}
         >

--- a/apps/studio/components/interfaces/Reports/ReportBlock/ReportBlockContainer.tsx
+++ b/apps/studio/components/interfaces/Reports/ReportBlock/ReportBlockContainer.tsx
@@ -1,5 +1,5 @@
 import { GripHorizontal } from 'lucide-react'
-import { PropsWithChildren, ReactNode } from 'react'
+import { DragEvent, PropsWithChildren, ReactNode } from 'react'
 import { cn } from 'ui'
 
 interface ReportBlockContainerProps {
@@ -7,6 +7,8 @@ interface ReportBlockContainerProps {
   label: string
   actions: ReactNode
   draggable?: boolean
+  showDragHandle?: boolean
+  onDragStart?: (e: DragEvent) => void
 }
 
 export const ReportBlockContainer = ({
@@ -14,6 +16,8 @@ export const ReportBlockContainer = ({
   label,
   actions,
   draggable = false,
+  showDragHandle = false,
+  onDragStart,
   children,
 }: PropsWithChildren<ReportBlockContainerProps>) => {
   const hasChildren = Array.isArray(children)
@@ -21,17 +25,26 @@ export const ReportBlockContainer = ({
     : !!children
 
   return (
-    <div className="h-full flex flex-col overflow-hidden bg-surface-100 border-overlay relative rounded border shadow-sm">
+    <div
+      draggable={draggable}
+      unselectable={draggable ? 'on' : undefined}
+      onDragStart={onDragStart}
+      className="h-full flex flex-col overflow-hidden bg-surface-100 border-overlay relative rounded border shadow-sm"
+    >
       <div className="grid-item-drag-handle cursor-move flex py-1 pl-3 pr-1 items-center gap-2 z-10 shrink-0 group">
-        <div className={cn(draggable && 'transition-opacity opacity-100 group-hover:opacity-0')}>
+        <div
+          className={cn(showDragHandle && 'transition-opacity opacity-100 group-hover:opacity-0')}
+        >
           {icon}
         </div>
-        {draggable && (
+        {showDragHandle && (
           <div className="absolute left-3 top-2.5 z-10 opacity-0 transition-opacity group-hover:opacity-100">
             <GripHorizontal size={16} strokeWidth={1.5} />
           </div>
         )}
-        <h3 className="text-xs font-medium text-foreground-light flex-1">{label}</h3>
+        <h3 title={label} className="text-xs font-medium text-foreground-light flex-1 truncate">
+          {label}
+        </h3>
         <div className="flex items-center">{actions}</div>
       </div>
       <div

--- a/apps/studio/components/interfaces/Reports/Reports.tsx
+++ b/apps/studio/components/interfaces/Reports/Reports.tsx
@@ -200,12 +200,22 @@ const Reports = () => {
     setConfig({ ...config, layout: [...current] })
   }
 
-  const updateChart = (id: string, chartConfig: Partial<ChartConfig>) => {
+  const updateChart = (
+    id: string,
+    {
+      chart,
+      chartConfig,
+    }: { chart?: Partial<Dashboards.Chart>; chartConfig?: Partial<ChartConfig> }
+  ) => {
     const currentChart = config?.layout.find((x) => x.id === id)
+
     if (currentChart) {
       const updatedChart: Dashboards.Chart = {
         ...currentChart,
-        chartConfig: { ...(currentChart?.chartConfig ?? {}), ...chartConfig },
+        ...(chart ?? {}),
+      }
+      if (chartConfig) {
+        updatedChart.chartConfig = { ...(currentChart?.chartConfig ?? {}), ...chartConfig }
       }
 
       const foundIndex = config?.layout.findIndex((x) => x.id === id)
@@ -251,16 +261,16 @@ const Reports = () => {
           <div className="flex items-center gap-x-2">
             <Button
               type="default"
-              onClick={() => setConfig(currentReportContent)}
               disabled={isSaving}
+              onClick={() => setConfig(currentReportContent)}
             >
               Cancel
             </Button>
             <Button
               type="primary"
               icon={<Save />}
-              onClick={() => onSaveReport()}
               loading={isSaving}
+              onClick={() => onSaveReport()}
             >
               Save changes
             </Button>

--- a/apps/studio/components/interfaces/Reports/Reports.tsx
+++ b/apps/studio/components/interfaces/Reports/Reports.tsx
@@ -350,7 +350,7 @@ const Reports = () => {
           )}
         </div>
       ) : (
-        <div className="relative mb-16 max-w-7xl flex-grow">
+        <div className="relative mb-16 flex-grow">
           {config && startDate && endDate && (
             <GridResize
               startDate={startDate}

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/ChartConfig.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/ChartConfig.tsx
@@ -22,7 +22,7 @@ type Results = { rows: readonly any[] }
 
 export type ChartConfig = {
   view?: 'table' | 'chart'
-  type: 'bar'
+  type: 'bar' | 'line'
   cumulative: boolean
   xKey: string
   yKey: string

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityPanel.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityPanel.tsx
@@ -1,4 +1,3 @@
-import { useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { useParams } from 'common'
@@ -42,7 +41,6 @@ const UtilityPanel = ({
   onDebug,
 }: UtilityPanelProps) => {
   const { ref } = useParams()
-  const queryClient = useQueryClient()
   const snapV2 = useSqlEditorV2StateSnapshot()
 
   const snippet = snapV2.snippets[id]?.snippet

--- a/apps/studio/components/interfaces/SQLEditor/hooks.ts
+++ b/apps/studio/components/interfaces/SQLEditor/hooks.ts
@@ -29,13 +29,14 @@ export const useNewQuery = () => {
     subject: { id: profile?.id },
   })
 
-  const newQuery = async (sql: string, name: string) => {
+  const newQuery = async (sql: string, name: string, shouldRedirect: boolean = true) => {
     if (!ref) return console.error('Project ref is required')
     if (!project) return console.error('Project is required')
     if (!profile) return console.error('Profile is required')
 
     if (!canCreateSQLSnippet) {
-      return toast('Your queries will not be saved as you do not have sufficient permissions')
+      toast('Your queries will not be saved as you do not have sufficient permissions')
+      return undefined
     }
 
     try {
@@ -48,9 +49,15 @@ export const useNewQuery = () => {
       })
       snapV2.addSnippet({ projectRef: ref, snippet })
       snapV2.addNeedsSaving(snippet.id)
-      router.push(`/project/${ref}/sql/${snippet.id}`)
+      if (shouldRedirect) {
+        router.push(`/project/${ref}/sql/${snippet.id}`)
+        return undefined
+      } else {
+        return snippet.id
+      }
     } catch (error: any) {
       toast.error(`Failed to create new query: ${error.message}`)
+      return undefined
     }
   }
 

--- a/apps/studio/components/ui/AIAssistantPanel/MessageMarkdown.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/MessageMarkdown.tsx
@@ -2,6 +2,7 @@ import { useRouter } from 'next/router'
 import { memo, ReactNode, useContext } from 'react'
 
 import { useSendEventMutation } from 'data/telemetry/send-event-mutation'
+import { useFlag } from 'hooks/ui/useFlag'
 import { TelemetryActions } from 'lib/constants/telemetry'
 import { cn, CodeBlock, CodeBlockLang } from 'ui'
 import { DebouncedComponent } from '../DebouncedComponent'
@@ -103,6 +104,7 @@ export const MarkdownPre = ({ children }: { children: any }) => {
   const router = useRouter()
   const { isLoading, readOnly } = useContext(MessageContext)
   const { mutate: sendEvent } = useSendEventMutation()
+  const supportSQLBlocks = useFlag('reportsV2')
 
   const language = children[0].props.className?.replace('language-', '') || 'sql'
   const rawSql = language === 'sql' ? children[0].props.children : undefined
@@ -115,7 +117,7 @@ export const MarkdownPre = ({ children }: { children: any }) => {
   const isChart = snippetProps.isChart === 'true'
   const runQuery = snippetProps.runQuery === 'true'
   const sql = formatted?.replace(/--\s*props:\s*\{[^}]+\}/, '').trim()
-  const isDraggable = router.pathname.endsWith('/reports/[id]')
+  const isDraggable = supportSQLBlocks && router.pathname.endsWith('/reports/[id]')
 
   const onRunQuery = async (queryType: 'select' | 'mutation') => {
     sendEvent({

--- a/apps/studio/components/ui/AIAssistantPanel/MessageMarkdown.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/MessageMarkdown.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from 'next/router'
 import { memo, ReactNode, useContext } from 'react'
 
 import { useSendEventMutation } from 'data/telemetry/send-event-mutation'
@@ -52,6 +53,7 @@ const MemoizedQueryBlock = memo(
     yAxis,
     isChart,
     isLoading,
+    isDraggable,
     runQuery,
     onRunQuery,
   }: {
@@ -61,6 +63,7 @@ const MemoizedQueryBlock = memo(
     yAxis?: string
     isChart: boolean
     isLoading: boolean
+    isDraggable: boolean
     runQuery: boolean
     onRunQuery: (queryType: 'select' | 'mutation') => void
   }) => (
@@ -74,8 +77,6 @@ const MemoizedQueryBlock = memo(
       }
     >
       <QueryBlock
-        // [Joshen] To update only draggable if in custom reports
-        draggable
         lockColumns
         label={title}
         sql={sql}
@@ -89,6 +90,7 @@ const MemoizedQueryBlock = memo(
         showSql={!isChart}
         isChart={isChart}
         isLoading={isLoading}
+        draggable={isDraggable}
         runQuery={runQuery}
         onRunQuery={onRunQuery}
       />
@@ -98,6 +100,7 @@ const MemoizedQueryBlock = memo(
 MemoizedQueryBlock.displayName = 'MemoizedQueryBlock'
 
 export const MarkdownPre = ({ children }: { children: any }) => {
+  const router = useRouter()
   const { isLoading, readOnly } = useContext(MessageContext)
   const { mutate: sendEvent } = useSendEventMutation()
 
@@ -112,6 +115,7 @@ export const MarkdownPre = ({ children }: { children: any }) => {
   const isChart = snippetProps.isChart === 'true'
   const runQuery = snippetProps.runQuery === 'true'
   const sql = formatted?.replace(/--\s*props:\s*\{[^}]+\}/, '').trim()
+  const isDraggable = router.pathname.endsWith('/reports/[id]')
 
   const onRunQuery = async (queryType: 'select' | 'mutation') => {
     sendEvent({
@@ -140,6 +144,7 @@ export const MarkdownPre = ({ children }: { children: any }) => {
             yAxis={yAxis}
             isChart={isChart}
             isLoading={isLoading}
+            isDraggable={isDraggable}
             runQuery={runQuery}
             onRunQuery={onRunQuery}
           />

--- a/apps/studio/components/ui/AIAssistantPanel/MessageMarkdown.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/MessageMarkdown.tsx
@@ -74,6 +74,8 @@ const MemoizedQueryBlock = memo(
       }
     >
       <QueryBlock
+        // [Joshen] To update only draggable if in custom reports
+        draggable
         lockColumns
         label={title}
         sql={sql}

--- a/apps/studio/components/ui/AIAssistantPanel/MessageMarkdown.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/MessageMarkdown.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/router'
-import { memo, ReactNode, useContext } from 'react'
+import { DragEvent, memo, ReactNode, useContext } from 'react'
 
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { useSendEventMutation } from 'data/telemetry/send-event-mutation'
@@ -60,6 +60,7 @@ const MemoizedQueryBlock = memo(
     isDraggable,
     runQuery,
     onRunQuery,
+    onDragStart,
   }: {
     sql: string
     title: string
@@ -70,6 +71,7 @@ const MemoizedQueryBlock = memo(
     isDraggable: boolean
     runQuery: boolean
     onRunQuery: (queryType: 'select' | 'mutation') => void
+    onDragStart: (e: DragEvent<Element>) => void
   }) => (
     <DebouncedComponent
       delay={500}
@@ -97,6 +99,7 @@ const MemoizedQueryBlock = memo(
         draggable={isDraggable}
         runQuery={runQuery}
         onRunQuery={onRunQuery}
+        onDragStart={onDragStart}
       />
     </DebouncedComponent>
   )
@@ -159,6 +162,9 @@ export const MarkdownPre = ({ children }: { children: any }) => {
             isDraggable={isDraggableToReports}
             runQuery={runQuery}
             onRunQuery={onRunQuery}
+            onDragStart={(e: DragEvent<Element>) =>
+              e.dataTransfer.setData('application/json', JSON.stringify({ label: title, sql }))
+            }
           />
         )
       ) : (

--- a/apps/studio/components/ui/QueryBlock/QueryBlock.tsx
+++ b/apps/studio/components/ui/QueryBlock/QueryBlock.tsx
@@ -63,14 +63,14 @@ interface QueryBlockProps {
   lockColumns?: boolean
   /** Max height set to render results / charts (Defaults to 250) */
   maxHeight?: number
+  /** Whether query block is draggable */
+  draggable?: boolean
   /** Not implemented yet: Will be the next part of ReportsV2 */
   onSetParameter?: (params: Parameter[]) => void
   /** Optional callback the SQL query is run */
   onRunQuery?: (queryType: 'select' | 'mutation') => void
 
   // [Joshen] Params below are currently only used by ReportsV2 (Might revisit to see how to improve these)
-  /** Whether query block is draggable */
-  draggable?: boolean
   /** Optional height set to render the SQL query (Used in Reports) */
   queryHeight?: number
   /** Override hiding Run Query button if SQL query is NOT readonly (Used in Reports) */
@@ -167,6 +167,14 @@ export const QueryBlock = ({
   return (
     <ReportBlockContainer
       draggable={draggable}
+      showDragHandle={draggable}
+      onDragStart={
+        draggable
+          ? (e) => {
+              e.dataTransfer.setData('application/json', JSON.stringify({ label, sql }))
+            }
+          : undefined
+      }
       icon={
         <SQL_ICON
           className={cn(

--- a/apps/studio/components/ui/QueryBlock/QueryBlock.tsx
+++ b/apps/studio/components/ui/QueryBlock/QueryBlock.tsx
@@ -1,5 +1,5 @@
 import { Code, Play } from 'lucide-react'
-import { ReactNode, useEffect, useMemo, useState } from 'react'
+import { DragEvent, ReactNode, useEffect, useMemo, useState } from 'react'
 import { Bar, BarChart, CartesianGrid, XAxis } from 'recharts'
 import { toast } from 'sonner'
 
@@ -69,6 +69,8 @@ interface QueryBlockProps {
   onSetParameter?: (params: Parameter[]) => void
   /** Optional callback the SQL query is run */
   onRunQuery?: (queryType: 'select' | 'mutation') => void
+  /** Optional callback on drag start */
+  onDragStart?: (e: DragEvent<Element>) => void
 
   // [Joshen] Params below are currently only used by ReportsV2 (Might revisit to see how to improve these)
   /** Optional height set to render the SQL query (Used in Reports) */
@@ -103,6 +105,7 @@ export const QueryBlock = ({
   onRunQuery,
   onSetParameter,
   onUpdateChartConfig,
+  onDragStart,
 }: QueryBlockProps) => {
   const { ref } = useParams()
   const { project } = useProjectContext()
@@ -168,13 +171,7 @@ export const QueryBlock = ({
     <ReportBlockContainer
       draggable={draggable}
       showDragHandle={draggable}
-      onDragStart={
-        draggable
-          ? (e) => {
-              e.dataTransfer.setData('application/json', JSON.stringify({ label, sql }))
-            }
-          : undefined
-      }
+      onDragStart={(e: DragEvent<Element>) => onDragStart?.(e)}
       icon={
         <SQL_ICON
           className={cn(

--- a/apps/studio/components/ui/QueryBlock/QueryBlock.tsx
+++ b/apps/studio/components/ui/QueryBlock/QueryBlock.tsx
@@ -10,6 +10,7 @@ import Results from 'components/interfaces/SQLEditor/UtilityPanel/Results'
 import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
 import { useExecuteSqlMutation } from 'data/sql/execute-sql-mutation'
 import { Parameter, parseParameters } from 'lib/sql-parameters'
+import { Dashboards } from 'types'
 import {
   Button,
   ChartContainer,
@@ -80,7 +81,13 @@ interface QueryBlockProps {
   /** UI to render if there's no query results (Used in Reports) */
   noResultPlaceholder?: ReactNode
   /** Optional callback whenever a chart configuration is updated (Used in Reports) */
-  onUpdateChartConfig?: (config: Partial<ChartConfig>) => void
+  onUpdateChartConfig?: ({
+    chart,
+    chartConfig,
+  }: {
+    chart?: Partial<Dashboards.Chart>
+    chartConfig: Partial<ChartConfig>
+  }) => void
 }
 
 // [Joshen ReportsV2] JFYI we may adjust this in subsequent PRs when we implement this into Reports V2
@@ -151,6 +158,10 @@ export const QueryBlock = ({
     }
   }
 
+  useEffect(() => {
+    setChartSettings(chartConfig)
+  }, [chartConfig])
+
   // Run once on mount to parse parameters and notify parent
   useEffect(() => {
     if (!!sql && onSetParameter) {
@@ -214,11 +225,11 @@ export const QueryBlock = ({
                   chartConfig={chartSettings}
                   columns={Object.keys(queryResult[0] || {})}
                   changeView={(view) => {
-                    if (onUpdateChartConfig) onUpdateChartConfig({ view })
+                    if (onUpdateChartConfig) onUpdateChartConfig({ chartConfig: { view } })
                     setChartSettings({ ...chartSettings, view })
                   }}
                   updateChartConfig={(config) => {
-                    if (onUpdateChartConfig) onUpdateChartConfig(config)
+                    if (onUpdateChartConfig) onUpdateChartConfig({ chartConfig: config })
                     setChartSettings(config)
                   }}
                 />

--- a/apps/studio/types/userContent.ts
+++ b/apps/studio/types/userContent.ts
@@ -108,7 +108,7 @@ export namespace Dashboards {
     label: string
     attribute: ChartType
     provider: 'daily-stats' | 'infra-monitoring'
-    chart_type: 'bar' | 'line' | 'area'
+    chart_type: 'bar' | 'line'
     chartConfig?: Partial<ChartConfig>
   }
 }

--- a/apps/studio/types/userContent.ts
+++ b/apps/studio/types/userContent.ts
@@ -43,7 +43,7 @@ export namespace SqlSnippets {
     favorite: boolean
 
     chart?: {
-      type: 'bar'
+      type: 'bar' | 'line'
       cumulative: boolean
       xKey: string
       yKey: string


### PR DESCRIPTION
## Support dragging query blocks from the Assistant panel to a custom report

Have the help of the Assistant to build charts using SQL in your custom reports! Ask the Assistant to chart any data, then drag it into a custom report (this creates a new SQL snippet for you that you can access / edit in the SQL editor thereafter)

Some notes:
- Charts are only draggable while in a custom report page
- This sits behind the same feature flag as adding SQL blocks to custom reports, so will not be publicly available just yet.
- Only users who have permissions to create queries drag blocks into custom reports

https://github.com/user-attachments/assets/c2f0c644-6bdf-4019-8f22-de2785a7ce99

