### PR TITLE
service status: hide info footer if all services OK

### DIFF
--- a/apps/studio/components/interfaces/Home/ServiceStatus.tsx
+++ b/apps/studio/components/interfaces/Home/ServiceStatus.tsx
@@ -291,13 +291,17 @@ const ServiceStatus = () => {
             </div>
           </Link>
         ))}
-        <PopoverSeparator />
-        <div className="flex gap-2 text-xs text-foreground-light px-3 py-2">
-          <div className="mt-0.5">
-            <InfoIcon />
-          </div>
-          Recently restored projects can take up to 5 minutes to become fully operational.
-        </div>
+        {allServicesOperational ? null : (
+          <>
+            <PopoverSeparator />
+            <div className="flex gap-2 text-xs text-foreground-light px-3 py-2">
+              <div className="mt-0.5">
+                <InfoIcon />
+              </div>
+              Recently restored projects can take up to 5 minutes to become fully operational.
+            </div>
+          </>
+        )}
       </PopoverContent_Shadcn_>
     </Popover_Shadcn_>
   )


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

I HAVE

## What kind of change does this PR introduce?

hides the footer in service status dropdown if everythings good

## What is the current behavior?

footer always there

## What is the new behavior?

footer not there if good

![CleanShot 2025-01-21 at 17 40 39@2x](https://github.com/user-attachments/assets/791c18a7-4d26-4af0-9172-17d44c8e7fa2)

