### PR TITLE
Set chart height to 1

### DIFF
--- a/apps/studio/components/interfaces/Reports/GridResize.tsx
+++ b/apps/studio/components/interfaces/Reports/GridResize.tsx
@@ -70,7 +70,7 @@ export const GridResize = ({
         return (
           <div
             key={item.id}
-            data-grid={{ ...item, minH: 1, maxH: 1, minW: 1, maxW: LAYOUT_COLUMN_COUNT }}
+            data-grid={{ ...item, h: 1, minH: 1, maxH: 1, minW: 1, maxW: LAYOUT_COLUMN_COUNT }}
           >
             <ReportBlock
               key={item.id}


### PR DESCRIPTION
Mitigates an issue whereby charts in custom reports that were saved before the recent Reports V2 changes are looking huge