### PR TITLE
pg cron logs: fix chart query and add error condition

### DIFF
--- a/apps/studio/components/interfaces/Settings/Logs/Logs.utils.ts
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.utils.ts
@@ -326,7 +326,7 @@ export const genChartQuery = (
   // pg_cron logs are a subset of postgres logs
   // to calculate the chart, we need to query postgres logs
   if (table === LogsTableName.PG_CRON) {
-    table = LogsTableName.POSTGREST
+    table = LogsTableName.POSTGRES
     where = `where (parsed.application_name = 'pg_cron' OR event_message LIKE '%cron job%')`
   }
 

--- a/apps/studio/components/interfaces/Settings/Logs/Logs.utils.ts
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.utils.ts
@@ -326,7 +326,7 @@ export const genChartQuery = (
   // pg_cron logs are a subset of postgres logs
   // to calculate the chart, we need to query postgres logs
   if (table === LogsTableName.PG_CRON) {
-    table = 'postgres_logs'
+    table = LogsTableName.POSTGREST
     where = `where (parsed.application_name = 'pg_cron' OR event_message LIKE '%cron job%')`
   }
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES
## What kind of change does this PR introduce?

- fix the chart query for pg cron logs
- adds the error condition for pg cron logs to show errors in the chart

## What is the current behavior?

- The chart wont load because its trying to query a non existing table instead of the postgres_logs table with the correct filter

## What is the new behavior?

![CleanShot 2025-01-22 at 13 15 47@2x](https://github.com/user-attachments/assets/e9f15ec8-2b77-4091-9b5a-153dcaf0223d)


## Additional context

To test this
- Create a cron that selects an existing table in the db
- Create a cron that selects a non existing table

You should see bars in the chart for errors (non existing table) and OKs
