### PR TITLE
Add user token initialization in auth.mdx

### DIFF
--- a/apps/docs/content/guides/functions/auth.mdx
+++ b/apps/docs/content/guides/functions/auth.mdx
@@ -19,6 +19,11 @@ Deno.serve(async (req: Request) => {
   const supabaseClient = createClient(
     Deno.env.get('SUPABASE_URL') ?? '',
     Deno.env.get('SUPABASE_ANON_KEY') ?? '',
+    {
+      global: {
+        headers: { Authorization: req.headers.get('Authorization')! },
+      },
+    }
   );
 
   // Get the session or user object
@@ -43,6 +48,11 @@ Deno.serve(async (req: Request) => {
   const supabaseClient = createClient(
     Deno.env.get('SUPABASE_URL') ?? '',
     Deno.env.get('SUPABASE_ANON_KEY') ?? '',
+    {
+      global: {
+        headers: { Authorization: req.headers.get('Authorization')! },
+      },
+    }
   )
 
   // Get the session or user object
@@ -71,6 +81,11 @@ Deno.serve(async (req: Request) => {
   const supabaseClient = createClient(
     Deno.env.get('SUPABASE_URL') ?? '',
     Deno.env.get('SUPABASE_ANON_KEY') ?? '',
+    {
+      global: {
+        headers: { Authorization: req.headers.get('Authorization')! },
+      },
+    }
   );
 
   // Get the session or user object

--- a/apps/docs/content/guides/functions/auth.mdx
+++ b/apps/docs/content/guides/functions/auth.mdx
@@ -21,7 +21,7 @@ Deno.serve(async (req: Request) => {
     Deno.env.get('SUPABASE_ANON_KEY') ?? '',
     {
       global: {
-        headers: { Authorization: req.headers.get('Authorization')! },
+        headers: { Authorization: req.headers.get('Authorization') },
       },
     }
   );
@@ -50,7 +50,7 @@ Deno.serve(async (req: Request) => {
     Deno.env.get('SUPABASE_ANON_KEY') ?? '',
     {
       global: {
-        headers: { Authorization: req.headers.get('Authorization')! },
+        headers: { Authorization: req.headers.get('Authorization') },
       },
     }
   )
@@ -83,7 +83,7 @@ Deno.serve(async (req: Request) => {
     Deno.env.get('SUPABASE_ANON_KEY') ?? '',
     {
       global: {
-        headers: { Authorization: req.headers.get('Authorization')! },
+        headers: { Authorization: req.headers.get('Authorization') },
       },
     }
   );


### PR DESCRIPTION
I added the part of the code responsible for initializing the Supabase client with the token passed via the header, to ensure compliance with RLS (Row-Level Security).

As shown on this page:
https://github.com/supabase/supabase/blob/master/examples/edge-functions/supabase/functions/select-from-table-with-auth-rls/index.ts

Otherwise authentication will not be completed.

## What kind of change does this PR introduce?

Docs update
