### PR TITLE
fix: Fix the lint command in all apps

### DIFF
--- a/apps/design-system/package.json
+++ b/apps/design-system/package.json
@@ -9,7 +9,7 @@
     "build": "pnpm run content:build && pnpm run build:registry && next build",
     "build:registry": "tsx --tsconfig ./tsconfig.scripts.json ./scripts/build-registry.mts && prettier --log-level silent --write \"registry/**/*.{ts,tsx,mdx}\" --cache",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "eslint .",
     "content:build": "contentlayer2 build",
     "clean": "rimraf node_modules .next .turbo",
     "typecheck": "contentlayer2 build && tsc --noEmit -p tsconfig.json"

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -12,7 +12,7 @@
     "build:sitemap": "tsx ./internals/generate-sitemap.ts",
     "postbuild": "pnpm run build:sitemap",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "eslint .",
     "lint:mdx": "supa-mdx-lint content/guides --config ../../supa-mdx-lint.config.toml",
     "typecheck": "tsc --noEmit",
     "pretest": "pnpm run codegen:examples",

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -8,7 +8,7 @@
     "dev:secrets:pull": "AWS_PROFILE=supabase-dev node ../../scripts/getSecrets.js -n local/studio",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "eslint .",
     "clean": "rimraf node_modules tsconfig.tsbuildinfo .next .turbo",
     "test": "vitest --run",
     "test:watch": "vitest watch",

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -9,7 +9,7 @@
     "build": "pnpm run content:build && next build",
     "export": "next export",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "eslint .",
     "clean": "rimraf node_modules",
     "typecheck": "pnpm run content:build && tsc --noEmit",
     "content:build": "contentlayer2 build && node scripts/generateStaticContent.mjs",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "dev:docs": "turbo run dev --filter=docs --parallel",
     "dev:www": "turbo run dev --filter=www --parallel",
     "dev:design-system": "turbo run dev --filter=design-system --parallel",
-    "lint": "turbo run lint",
+    "lint": "turbo run lint --log-order grouped --continue --parallel",
     "typecheck": "turbo --continue typecheck",
     "test:prettier": "prettier -c '{apps,packages}/**/*.{js,jsx,ts,tsx,css,md,mdx,json}'",
     "format": "prettier --write '{apps,packages}/**/*.{js,jsx,ts,tsx,css,md,mdx,json}'",

--- a/packages/eslint-config-supabase/next.js
+++ b/packages/eslint-config-supabase/next.js
@@ -1,5 +1,6 @@
 module.exports = {
-  extends: ['prettier', 'next/core-web-vitals', 'eslint-config-turbo'],
+  // next rules should be last
+  extends: ['prettier', 'eslint-config-turbo', 'next/core-web-vitals'],
   rules: {
     '@next/next/no-html-link-for-pages': 'off',
     'react/jsx-key': 'off',

--- a/turbo.json
+++ b/turbo.json
@@ -110,7 +110,7 @@
       "outputs": [".next/**", "!.next/cache/**", ".contentlayer/**"]
     },
     "lint": {
-      "outputs": []
+      "cache": false
     },
     "clean": {
       "outputs": [],


### PR DESCRIPTION
This PR fixes the lint commands to run properly. They used `next lint` previously which for some reason doesn't run custom rulesets when you add them. I've switched the commands to `eslint .` instead which is working correctly.

I've also optimized the turbo command for better log output and parallel execution.