### PR TITLE
Feat/reports v2/create report

### DIFF
--- a/apps/studio/components/interfaces/Reports/ReportBlock/ChartBlock.tsx
+++ b/apps/studio/components/interfaces/Reports/ReportBlock/ChartBlock.tsx
@@ -1,6 +1,6 @@
 import dayjs from 'dayjs'
 import { useRouter } from 'next/router'
-import { ReactNode, useEffect, useState } from 'react'
+import { ReactNode, useEffect, useState, useCallback } from 'react'
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from 'ui'
 
 import { ChartConfig } from 'components/interfaces/SQLEditor/UtilityPanel/ChartConfig'
@@ -62,6 +62,7 @@ export const ChartBlock = ({
 
   const state = useDatabaseSelectorStateSnapshot()
   const [chartStyle, setChartStyle] = useState<string>(defaultChartStyle)
+  const [highlightedValue, setHighlightedValue] = useState<string | undefined>()
 
   const databaseIdentifier = state.selectedDatabaseId
 
@@ -141,9 +142,37 @@ export const ChartBlock = ({
     }
   })
 
+  const getInitialHighlightedValue = useCallback(() => {
+    if (!chartData?.data?.length) return undefined
+    const lastDataPoint = chartData.data[chartData.data.length - 1]
+    const value = lastDataPoint[attribute]
+    return chartData.format === '%'
+      ? `${typeof value === 'number' ? value.toFixed(1) : value}%`
+      : typeof value === 'number'
+        ? value.toLocaleString()
+        : value
+  }, [chartData?.data, chartData?.format, attribute])
+
   useEffect(() => {
     if (defaultChartStyle) setChartStyle(defaultChartStyle)
   }, [defaultChartStyle])
+
+  useEffect(() => {
+    setHighlightedValue(getInitialHighlightedValue())
+  }, [chartData, getInitialHighlightedValue])
+
+  const handleMouseEvent = useCallback(
+    (event: 'move' | 'leave', data?: any) => {
+      if (event === 'leave') {
+        setHighlightedValue(getInitialHighlightedValue())
+        return
+      }
+
+      const value = data?.activePayload?.[0]?.payload?.[metricLabel]
+      setHighlightedValue(chartData?.format === '%' ? `${value}%` : value)
+    },
+    [chartData?.format, metricLabel, getInitialHighlightedValue]
+  )
 
   return (
     <ReportBlockContainer
@@ -197,60 +226,79 @@ export const ChartBlock = ({
           />
         </div>
       ) : (
-        <ChartContainer
-          className="w-full aspect-auto px-3 py-2"
-          config={{}}
-          style={{
-            height: maxHeight ? `${maxHeight}px` : undefined,
-            minHeight: maxHeight ? `${maxHeight}px` : undefined,
-          }}
-        >
-          {chartStyle === 'bar' ? (
-            <BarChart accessibilityLayer margin={{ left: 0, right: 0 }} data={data}>
-              <CartesianGrid vertical={false} />
-              <XAxis
-                dataKey="period_start"
-                tickLine={false}
-                axisLine={false}
-                tickMargin={8}
-                minTickGap={32}
-              />
-              {chartData.format === '%' && <YAxis hide domain={[0, 100]} />}
-              <ChartTooltip
-                content={
-                  <ChartTooltipContent
-                    className="w-[200px]"
-                    labelSuffix={chartData?.format === '%' ? '%' : ''}
-                    labelFormatter={(x) => dayjs(x).format('DD MMM YYYY')}
-                  />
-                }
-              />
-              <Bar dataKey={metricLabel} radius={4} />
-            </BarChart>
-          ) : (
-            <LineChart accessibilityLayer margin={{ left: 0, right: 0 }} data={data}>
-              <CartesianGrid vertical={false} />
-              <XAxis
-                dataKey="period_start"
-                tickLine={false}
-                axisLine={false}
-                tickMargin={8}
-                minTickGap={32}
-              />
-              {chartData.format === '%' && <YAxis hide domain={[0, 100]} />}
-              <ChartTooltip
-                content={
-                  <ChartTooltipContent
-                    className="w-[200px]"
-                    labelSuffix={chartData?.format === '%' ? '%' : ''}
-                    labelFormatter={(x) => dayjs(x).format('DD MMM YYYY')}
-                  />
-                }
-              />
-              <Line dataKey={metricLabel} stroke="var(--chart-1)" radius={4} />
-            </LineChart>
+        <>
+          {highlightedValue && (
+            <div className="p-3 w-full text-left">
+              <p className="text-lg text">{highlightedValue}</p>
+            </div>
           )}
-        </ChartContainer>
+          <ChartContainer
+            className="w-full aspect-auto px-3 py-2"
+            config={{}}
+            style={{
+              height: maxHeight ? `${maxHeight}px` : undefined,
+              minHeight: maxHeight ? `${maxHeight}px` : undefined,
+            }}
+          >
+            {chartStyle === 'bar' ? (
+              <BarChart
+                onMouseMove={(data) => handleMouseEvent('move', data)}
+                onMouseLeave={() => handleMouseEvent('leave')}
+                accessibilityLayer
+                margin={{ left: 0, right: 0 }}
+                data={data}
+              >
+                <CartesianGrid vertical={false} />
+                <XAxis
+                  dataKey="period_start"
+                  tickLine={false}
+                  axisLine={false}
+                  tickMargin={8}
+                  minTickGap={32}
+                />
+                {chartData.format === '%' && <YAxis hide domain={[0, 100]} />}
+                <ChartTooltip
+                  content={
+                    <ChartTooltipContent
+                      className="w-[200px]"
+                      labelSuffix={chartData?.format === '%' ? '%' : ''}
+                      labelFormatter={(x) => dayjs(x).format('DD MMM YYYY')}
+                    />
+                  }
+                />
+                <Bar dataKey={metricLabel} radius={4} />
+              </BarChart>
+            ) : (
+              <LineChart
+                onMouseMove={(data) => handleMouseEvent('move', data)}
+                onMouseLeave={() => handleMouseEvent('leave')}
+                accessibilityLayer
+                margin={{ left: 0, right: 0 }}
+                data={data}
+              >
+                <CartesianGrid vertical={false} />
+                <XAxis
+                  dataKey="period_start"
+                  tickLine={false}
+                  axisLine={false}
+                  tickMargin={8}
+                  minTickGap={32}
+                />
+                {chartData.format === '%' && <YAxis hide domain={[0, 100]} />}
+                <ChartTooltip
+                  content={
+                    <ChartTooltipContent
+                      className="w-[200px]"
+                      labelSuffix={chartData?.format === '%' ? '%' : ''}
+                      labelFormatter={(x) => dayjs(x).format('DD MMM YYYY')}
+                    />
+                  }
+                />
+                <Line dataKey={metricLabel} stroke="var(--chart-1)" radius={4} />
+              </LineChart>
+            )}
+          </ChartContainer>
+        </>
       )}
     </ReportBlockContainer>
   )

--- a/apps/studio/components/interfaces/Reports/ReportBlock/ChartBlock.tsx
+++ b/apps/studio/components/interfaces/Reports/ReportBlock/ChartBlock.tsx
@@ -163,12 +163,13 @@ export const ChartBlock = ({
 
   const handleMouseEvent = useCallback(
     (event: 'move' | 'leave', data?: any) => {
-      if (event === 'leave') {
+      const value = data?.activePayload?.[0]?.payload?.[metricLabel]
+
+      if (event === 'leave' || !value) {
         setHighlightedValue(getInitialHighlightedValue())
         return
       }
 
-      const value = data?.activePayload?.[0]?.payload?.[metricLabel]
       setHighlightedValue(chartData?.format === '%' ? `${value}%` : value)
     },
     [chartData?.format, metricLabel, getInitialHighlightedValue]

--- a/apps/studio/components/interfaces/Reports/ReportBlock/ChartBlock.tsx
+++ b/apps/studio/components/interfaces/Reports/ReportBlock/ChartBlock.tsx
@@ -161,20 +161,6 @@ export const ChartBlock = ({
     setHighlightedValue(getInitialHighlightedValue())
   }, [chartData, getInitialHighlightedValue])
 
-  const handleMouseEvent = useCallback(
-    (event: 'move' | 'leave', data?: any) => {
-      const value = data?.activePayload?.[0]?.payload?.[metricLabel]
-
-      if (event === 'leave' || !value) {
-        setHighlightedValue(getInitialHighlightedValue())
-        return
-      }
-
-      setHighlightedValue(chartData?.format === '%' ? `${value}%` : value)
-    },
-    [chartData?.format, metricLabel, getInitialHighlightedValue]
-  )
-
   return (
     <ReportBlockContainer
       draggable
@@ -229,7 +215,10 @@ export const ChartBlock = ({
       ) : (
         <>
           {highlightedValue && (
-            <div className="p-3 w-full text-left">
+            <div className="pt-2 px-3 w-full text-left leading-tight">
+              <span className="text-xs font-mono uppercase text-foreground-light">
+                Most recently
+              </span>
               <p className="text-lg text">{highlightedValue}</p>
             </div>
           )}
@@ -242,13 +231,7 @@ export const ChartBlock = ({
             }}
           >
             {chartStyle === 'bar' ? (
-              <BarChart
-                onMouseMove={(data) => handleMouseEvent('move', data)}
-                onMouseLeave={() => handleMouseEvent('leave')}
-                accessibilityLayer
-                margin={{ left: 0, right: 0 }}
-                data={data}
-              >
+              <BarChart accessibilityLayer margin={{ left: 0, right: 0 }} data={data}>
                 <CartesianGrid vertical={false} />
                 <XAxis
                   dataKey="period_start"
@@ -270,13 +253,7 @@ export const ChartBlock = ({
                 <Bar dataKey={metricLabel} radius={4} />
               </BarChart>
             ) : (
-              <LineChart
-                onMouseMove={(data) => handleMouseEvent('move', data)}
-                onMouseLeave={() => handleMouseEvent('leave')}
-                accessibilityLayer
-                margin={{ left: 0, right: 0 }}
-                data={data}
-              >
+              <LineChart accessibilityLayer margin={{ left: 0, right: 0 }} data={data}>
                 <CartesianGrid vertical={false} />
                 <XAxis
                   dataKey="period_start"

--- a/apps/studio/components/interfaces/Reports/ReportBlock/ReportBlock.tsx
+++ b/apps/studio/components/interfaces/Reports/ReportBlock/ReportBlock.tsx
@@ -136,7 +136,7 @@ export const ReportBlock = ({
           attribute={item.attribute}
           provider={item.provider}
           defaultChartStyle={item.chart_type}
-          maxHeight={232}
+          maxHeight={180}
           label={`${item.label}${projectRef !== state.selectedDatabaseId ? (item.provider === 'infra-monitoring' ? ' of replica' : ' on project') : ''}`}
           actions={
             !disableUpdate ? (

--- a/apps/studio/components/interfaces/Reports/ReportBlock/ReportBlock.tsx
+++ b/apps/studio/components/interfaces/Reports/ReportBlock/ReportBlock.tsx
@@ -136,7 +136,7 @@ export const ReportBlock = ({
           attribute={item.attribute}
           provider={item.provider}
           defaultChartStyle={item.chart_type}
-          maxHeight={180}
+          maxHeight={176}
           label={`${item.label}${projectRef !== state.selectedDatabaseId ? (item.provider === 'infra-monitoring' ? ' of replica' : ' on project') : ''}`}
           actions={
             !disableUpdate ? (


### PR DESCRIPTION
This re-adds the label that was previously in predefined report blocks. I think we should consider adding this to the QueryBlock as well based on a configuration (e.g. average, total, most recent) but for predefined its always most recent + currently hovered.

Requires https://github.com/supabase/supabase/pull/32989 to be merged first.

<img width="538" alt="image" src="https://github.com/user-attachments/assets/55c799cd-c9b2-4196-993f-42394d0f239a" />
