### PR TITLE
refactor: database size metric for Free Plan

### DIFF
--- a/apps/docs/content/guides/platform/org-based-billing.mdx
+++ b/apps/docs/content/guides/platform/org-based-billing.mdx
@@ -155,9 +155,9 @@ You can see a breakdown of the different types of egress on your [organization u
 
 ## Disk size
 
-We differentiate between database space usage and disk size. Database Space is the actual amount of space used by all your database objects, whereas disk size is the size of the underlying provisioned disk. Each database has a provisioned disk.
+We differentiate between database size and disk size. Database size is the actual amount of space used by all your database objects, whereas disk size is the size of the underlying provisioned disk. Each database has a provisioned disk.
 
-Free Plan customers are limited to 500 MB of database space.
+Free Plan customers are limited to 500 MB of database size per project.
 
 For paid plan customers:
 
@@ -189,7 +189,7 @@ Here are the quotas for the Free Plan:
 | Usage Item                | Free Plan                     |
 | ------------------------- | ----------------------------- |
 | Egress                    | 5GB across Database + Storage |
-| Database Space            | 500MB                         |
+| Database Size             | 500MB                         |
 | Storage Space             | 1GB                           |
 | Monthly Active Users      | 50,000 MAU                    |
 | Edge Function Invocations | 500K                          |

--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/BillingBreakdown.constants.ts
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/BillingBreakdown.constants.ts
@@ -24,6 +24,7 @@ export const BILLING_BREAKDOWN_METRICS: Metric[] = [
     anchor: 'dbSize',
     category: 'Database',
     unitName: 'GB',
+    tip: 'Database size refers to the actual amount of space used by all your database objects, as reported by Postgres. Free Plan projects are limited to 0.5 GB Database Size each.'
   },
   {
     key: PricingMetric.EGRESS,

--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/BillingBreakdown.constants.ts
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/BillingBreakdown.constants.ts
@@ -24,7 +24,7 @@ export const BILLING_BREAKDOWN_METRICS: Metric[] = [
     anchor: 'dbSize',
     category: 'Database',
     unitName: 'GB',
-    tip: 'Database size refers to the actual amount of space used by all your database objects, as reported by Postgres. Free Plan projects are limited to 0.5 GB Database Size each.'
+    tip: 'Database size refers to the actual amount of space used by all your database objects, as reported by Postgres. Free Plan projects are limited to 0.5 GB Database Size each.',
   },
   {
     key: PricingMetric.EGRESS,

--- a/apps/studio/components/interfaces/Organization/Usage/Usage.constants.tsx
+++ b/apps/studio/components/interfaces/Organization/Usage/Usage.constants.tsx
@@ -109,7 +109,7 @@ export const USAGE_CATEGORIES: (subscription?: OrgSubscription) => CategoryMeta[
             chartPrefix: 'Average',
             unit: 'bytes',
             description:
-              'Database size refers to the actual amount of space used by all your database objects, as reported by Postgres. Paid Plans use auto-scaling disks and are billed on allocated disk instead of database size.',
+              'Database size refers to the actual amount of space used by all your database objects, as reported by Postgres.',
             links: [
               {
                 name: 'Documentation',

--- a/apps/studio/components/interfaces/Organization/Usage/Usage.constants.tsx
+++ b/apps/studio/components/interfaces/Organization/Usage/Usage.constants.tsx
@@ -109,7 +109,7 @@ export const USAGE_CATEGORIES: (subscription?: OrgSubscription) => CategoryMeta[
             chartPrefix: 'Average',
             unit: 'bytes',
             description:
-              'Database size refers to the monthly average database space usage, as reported by Postgres. Paid Plans use auto-scaling disks.\nBilling is based on the average daily database size used in GB throughout the billing period. Billing is independent of the provisioned disk size.',
+              'Database size refers to the actual amount of space used by all your database objects, as reported by Postgres. Paid Plans use auto-scaling disks and are billed on allocated disk instead of database size.',
             links: [
               {
                 name: 'Documentation',

--- a/apps/studio/components/interfaces/Organization/Usage/UsageSection/DatabaseSizeUsage.tsx
+++ b/apps/studio/components/interfaces/Organization/Usage/UsageSection/DatabaseSizeUsage.tsx
@@ -133,7 +133,9 @@ const DatabaseSizeUsage = ({
                           Database Size
                         </span>
                         <InfoTooltip side="top">
-                          <p>{formatBytes(project.usage)} GB database size as reported by Postgres.</p>
+                          <p>
+                            {formatBytes(project.usage)} GB database size as reported by Postgres.
+                          </p>
                         </InfoTooltip>
                       </div>
                     </div>

--- a/apps/studio/components/interfaces/Organization/Usage/UsageSection/DatabaseSizeUsage.tsx
+++ b/apps/studio/components/interfaces/Organization/Usage/UsageSection/DatabaseSizeUsage.tsx
@@ -77,7 +77,9 @@ const DatabaseSizeUsage = ({
 
             <div className="flex items-center justify-between">
               <p className="text-xs text-foreground-light">Max database size</p>
-              <p className="text-xs">{databaseSizeUsage?.usage ? formatBytes(databaseSizeUsage?.usage_original) : '-'}</p>
+              <p className="text-xs">
+                {databaseSizeUsage?.usage ? formatBytes(databaseSizeUsage?.usage_original) : '-'}
+              </p>
             </div>
           </div>
 
@@ -105,7 +107,9 @@ const DatabaseSizeUsage = ({
                   <div
                     key={`usage-project-${project.ref}`}
                     className={
-                      idx !== databaseSizeUsage.project_allocations.length - 1 ? 'border-b pb-2' : ''
+                      idx !== databaseSizeUsage.project_allocations.length - 1
+                        ? 'border-b pb-2'
+                        : ''
                     }
                   >
                     <div className="flex justify-between">
@@ -113,7 +117,9 @@ const DatabaseSizeUsage = ({
                         {project.name}
                       </span>
                       <Button asChild type="default" size={'tiny'}>
-                        <Link href={`/project/${project.ref}/reports/database#database-size-report`}>
+                        <Link
+                          href={`/project/${project.ref}/reports/database#database-size-report`}
+                        >
                           Manage Database Size
                         </Link>
                       </Button>

--- a/apps/studio/components/interfaces/Organization/Usage/UsageSection/DatabaseSizeUsage.tsx
+++ b/apps/studio/components/interfaces/Organization/Usage/UsageSection/DatabaseSizeUsage.tsx
@@ -1,0 +1,156 @@
+import AlertError from 'components/ui/AlertError'
+import ShimmeringLoader from 'components/ui/ShimmeringLoader'
+import type { OrgSubscription } from 'data/subscriptions/types'
+import SectionContent from '../SectionContent'
+import { CategoryAttribute } from '../Usage.constants'
+import { useOrgProjectsQuery } from 'data/projects/org-projects'
+import { PROJECT_STATUS } from 'lib/constants'
+import {
+  Button,
+  Alert_Shadcn_,
+  CriticalIcon,
+  AlertTitle_Shadcn_,
+  AlertDescription_Shadcn_,
+} from 'ui'
+import MotionNumber from '@number-flow/react'
+import Link from 'next/link'
+import { useMemo } from 'react'
+import { InfoTooltip } from 'ui-patterns/info-tooltip'
+import { OrgUsageResponse } from 'data/usage/org-usage-query'
+import { PricingMetric } from 'data/analytics/org-daily-stats-query'
+import Panel from 'components/ui/Panel'
+import { formatBytes } from 'lib/helpers'
+
+export interface DatabaseSizeUsageProps {
+  slug: string
+  projectRef?: string
+  attribute: CategoryAttribute
+  subscription?: OrgSubscription
+  usage?: OrgUsageResponse
+
+  currentBillingCycleSelected: boolean
+}
+
+const DatabaseSizeUsage = ({
+  attribute,
+  subscription,
+  usage,
+  currentBillingCycleSelected,
+}: DatabaseSizeUsageProps) => {
+  const databaseSizeUsage = useMemo(
+    () => usage?.usages.find((it) => it.metric === PricingMetric.DATABASE_SIZE),
+    [usage]
+  )
+
+  const hasProjectsExceedingDatabaseSize = useMemo(() => {
+    return databaseSizeUsage?.project_allocations.some((it) => it.usage > 0.5 * 1e9)
+  }, [databaseSizeUsage])
+
+  return (
+    <div id={attribute.anchor} className="scroll-my-12">
+      <SectionContent section={attribute}>
+        <div className="space-y-4">
+          {currentBillingCycleSelected && hasProjectsExceedingDatabaseSize && (
+            <Alert_Shadcn_ variant="warning">
+              <CriticalIcon />
+              <AlertTitle_Shadcn_>Projects exceeding quota</AlertTitle_Shadcn_>
+              <AlertDescription_Shadcn_>
+                You have projects that are exceeding 0.5 GB of database size. Reduce the database
+                size or upgrade to a paid plan.
+              </AlertDescription_Shadcn_>
+            </Alert_Shadcn_>
+          )}
+
+          <div>
+            <div className="flex items-center justify-between">
+              <div className="flex items-center space-x-4">
+                <p className="text-sm">{attribute.name} usage</p>
+              </div>
+            </div>
+
+            <div className="flex items-center justify-between border-b py-1">
+              <p className="text-xs text-foreground-light">
+                Included in {subscription?.plan?.name} Plan
+              </p>
+              <p className="text-xs">0.5 GB per project</p>
+            </div>
+
+            <div className="flex items-center justify-between">
+              <p className="text-xs text-foreground-light">Max database size</p>
+              <p className="text-xs">{databaseSizeUsage?.usage ? formatBytes(databaseSizeUsage?.usage_original) : '-'}</p>
+            </div>
+          </div>
+
+          {currentBillingCycleSelected ? (
+            <div className="space-y-4">
+              <div className="space-y-1">
+                <p className="text-sm">Current database size per project</p>
+              </div>
+
+              {databaseSizeUsage?.project_allocations.length === 0 && (
+                <Panel>
+                  <Panel.Content>
+                    <div className="flex flex-col items-center justify-center">
+                      <p className="text-sm">No active projects</p>
+                      <p className="text-sm text-foreground-light">
+                        You don't have any active projects in this organization.
+                      </p>
+                    </div>
+                  </Panel.Content>
+                </Panel>
+              )}
+
+              {databaseSizeUsage?.project_allocations.map((project, idx) => {
+                return (
+                  <div
+                    key={`usage-project-${project.ref}`}
+                    className={
+                      idx !== databaseSizeUsage.project_allocations.length - 1 ? 'border-b pb-2' : ''
+                    }
+                  >
+                    <div className="flex justify-between">
+                      <span className="text-foreground-light flex items-center gap-2">
+                        {project.name}
+                      </span>
+                      <Button asChild type="default" size={'tiny'}>
+                        <Link href={`/project/${project.ref}/reports/database#database-size-report`}>
+                          Manage Database Size
+                        </Link>
+                      </Button>
+                    </div>
+                    <div className="flex flex-col gap-2">
+                      <div className="flex items-center h-6 gap-3">
+                        <span className="text-foreground-light text-sm font-mono flex items-center gap-2">
+                          <span className="text-foreground font-semibold font-mono -mt-[2px]">
+                            {formatBytes(project.usage)}
+                          </span>{' '}
+                          Database Size
+                        </span>
+                        <InfoTooltip side="top">
+                          <p>{project.usage} GB database size as reported by Postgres.</p>
+                        </InfoTooltip>
+                      </div>
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          ) : (
+            <Panel>
+              <Panel.Content>
+                <div className="flex flex-col items-center justify-center">
+                  <p className="text-sm">Data not available</p>
+                  <p className="text-sm text-foreground-light">
+                    Switch to current billing cycle to see current database size per project.
+                  </p>
+                </div>
+              </Panel.Content>
+            </Panel>
+          )}
+        </div>
+      </SectionContent>
+    </div>
+  )
+}
+
+export default DatabaseSizeUsage

--- a/apps/studio/components/interfaces/Organization/Usage/UsageSection/DatabaseSizeUsage.tsx
+++ b/apps/studio/components/interfaces/Organization/Usage/UsageSection/DatabaseSizeUsage.tsx
@@ -127,7 +127,7 @@ const DatabaseSizeUsage = ({
                           Database Size
                         </span>
                         <InfoTooltip side="top">
-                          <p>{project.usage} GB database size as reported by Postgres.</p>
+                          <p>{formatBytes(project.usage)} GB database size as reported by Postgres.</p>
                         </InfoTooltip>
                       </div>
                     </div>

--- a/apps/studio/components/interfaces/Organization/Usage/UsageSection/DiskUsage.tsx
+++ b/apps/studio/components/interfaces/Organization/Usage/UsageSection/DiskUsage.tsx
@@ -146,7 +146,7 @@ const DiskUsage = ({
                   <p className="text-sm">Current disk size per project</p>
                   <p className="text-sm text-foreground-light">
                     Breakdown of disk per project. Head to your project's disk management section to
-                    see database space used.
+                    see database size used.
                   </p>
                 </div>
 

--- a/apps/studio/components/interfaces/Organization/Usage/UsageSection/UsageSection.tsx
+++ b/apps/studio/components/interfaces/Organization/Usage/UsageSection/UsageSection.tsx
@@ -6,6 +6,8 @@ import SectionHeader from '../SectionHeader'
 import { CategoryMetaKey, USAGE_CATEGORIES } from '../Usage.constants'
 import AttributeUsage from './AttributeUsage'
 import DiskUsage from './DiskUsage'
+import { PricingMetric } from 'data/analytics/org-daily-stats-query'
+import DatabaseSizeUsage from './DatabaseSizeUsage'
 
 export interface ChartMeta {
   [key: string]: { data: DataPoint[]; margin: number; isLoading: boolean }
@@ -52,6 +54,16 @@ const UsageSection = ({
       {categoryMeta.attributes.map((attribute) =>
         attribute.key === 'diskSize' ? (
           <DiskUsage
+            key={attribute.name}
+            slug={orgSlug}
+            projectRef={projectRef}
+            attribute={attribute}
+            subscription={subscription}
+            currentBillingCycleSelected={currentBillingCycleSelected}
+            usage={usage}
+          />
+        ) : attribute.key === PricingMetric.DATABASE_SIZE ? (
+          <DatabaseSizeUsage
             key={attribute.name}
             slug={orgSlug}
             projectRef={projectRef}

--- a/packages/shared-data/plans.ts
+++ b/packages/shared-data/plans.ts
@@ -32,7 +32,7 @@ export const plans: PricingInformation[] = [
         features: [
           'Unlimited API requests',
           '50,000 monthly active users',
-          ['500 MB database space', 'Shared CPU • 500 MB RAM'],
+          ['500 MB database size', 'Shared CPU • 500 MB RAM'],
           '5 GB bandwidth',
           '1 GB file storage',
           'Community support',
@@ -43,7 +43,7 @@ export const plans: PricingInformation[] = [
         features: [
           'Unlimited API requests',
           '50,000 monthly active users',
-          ['500 MB database space', 'Shared CPU • 500 MB RAM'],
+          ['500 MB database size', 'Shared CPU • 500 MB RAM'],
           '5 GB bandwidth',
           'Community support',
         ],

--- a/packages/shared-data/pricing.ts
+++ b/packages/shared-data/pricing.ts
@@ -61,7 +61,7 @@ export const pricing: Pricing = {
           main: 'Billing is based on the provisioned disk size. Paid plan projects get provisioned with 8 GB of disk by default and autoscale to 1.5x the size once you get close to the limit. The first 8 GB of disk per project comes with no additional fees.\nFree plan customers are limited to 500 MB database size per project.',
         },
         plans: {
-          free: '500 MB database size included',
+          free: '500 MB database size per project included',
           pro: ['8 GB disk size per project included', 'then $0.125 per GB'],
           team: ['8 GB disk size per project included', 'then $0.125 per GB'],
           enterprise: 'Custom',

--- a/packages/shared-data/pricing.ts
+++ b/packages/shared-data/pricing.ts
@@ -58,10 +58,10 @@ export const pricing: Pricing = {
       {
         title: 'Database size',
         tooltips: {
-          main: 'Billing is based on the provisioned disk size. Paid plan projects get provisioned with 8GB of disk by default and autoscale to 1.5x the size once you get close to the limit. The first 8GB of disk per project comes with no additional fees.\nFree plan customers are limited to 500MB database space usage per organization.',
+          main: 'Billing is based on the provisioned disk size. Paid plan projects get provisioned with 8 GB of disk by default and autoscale to 1.5x the size once you get close to the limit. The first 8 GB of disk per project comes with no additional fees.\nFree plan customers are limited to 500 MB database size per project.',
         },
         plans: {
-          free: '500 MB database space included',
+          free: '500 MB database size included',
           pro: ['8 GB disk size per project included', 'then $0.125 per GB'],
           team: ['8 GB disk size per project included', 'then $0.125 per GB'],
           enterprise: 'Custom',


### PR DESCRIPTION
Instead of basing the database size metric for the Free Plan on summing up the average database size per project in the organization, we are going to simply enforce a database size limit of 0.5 GB per active project. Deleted projects are irrelevant and it should be much easier for customers to understand. We are querying the database size directly via the project to avoid delays.

Should be merged shortly after prod deployment (once https://github.com/supabase/infrastructure/pull/21318 is merged)

<img width="1043" alt="Screenshot 2025-01-23 at 22 26 47" src="https://github.com/user-attachments/assets/7ddcafa0-c8f4-4b33-b969-8138f5eb5450" />
<img width="497" alt="Screenshot 2025-01-23 at 22 26 44" src="https://github.com/user-attachments/assets/31843169-aecf-402f-8d6f-54941b92fbdc" />
