### PR TITLE
docs: access control operator type

### DIFF
--- a/apps/docs/content/guides/storage/management/delete-objects.mdx
+++ b/apps/docs/content/guides/storage/management/delete-objects.mdx
@@ -32,6 +32,6 @@ on storage.objects
 for delete
 TO authenticated
 USING (
-    owner = (select auth.uid())
+    owner = (select auth.uid()::text)
 );
 ```


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Supabase Docs - [Access Controls](https://supabase.com/docs/guides/storage/security/ownership#access-control)

## What is the current behavior?

Example does not work due to operator type.

## What is the new behavior?

Cast the auth.uid to text

## Additional context

Closes #29836
