### PR TITLE
Update SQL editor search to return a flat list

### DIFF
--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorMenu.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorMenu.tsx
@@ -6,7 +6,6 @@ import { toast } from 'sonner'
 
 import { useDebounce } from '@uidotdev/usehooks'
 import { useParams } from 'common'
-import { Content } from 'data/content/content-query'
 import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { useLocalStorage } from 'hooks/misc/useLocalStorage'
 import { useSelectedProject } from 'hooks/misc/useSelectedProject'
@@ -52,11 +51,6 @@ export const SQLEditorMenu = ({ onViewOngoingQueries }: SQLEditorMenuProps) => {
     resource: { type: 'sql', owner_id: profile?.id },
     subject: { id: profile?.id },
   })
-
-  const onShowSection = (visibility: 'user' | 'project' | 'org' | 'public') => {
-    if (visibility === 'user') setShowPrivateSnippets(true)
-    else if (visibility === 'project') setShowSharedSnippets(true)
-  }
 
   const createNewFolder = () => {
     if (!ref) return console.error('Project ref is required')
@@ -135,10 +129,9 @@ export const SQLEditorMenu = ({ onViewOngoingQueries }: SQLEditorMenuProps) => {
         {showSearch ? (
           <SearchList
             search={debouncedSearch}
-            onSelectSnippet={(snippet: Content) => {
+            onSelectSnippet={() => {
               setSearch('')
               setShowSearch(false)
-              onShowSection(snippet.visibility)
             }}
           />
         ) : (
@@ -160,13 +153,7 @@ export const SQLEditorMenu = ({ onViewOngoingQueries }: SQLEditorMenuProps) => {
               </InnerSideMenuItem>
             </div>
 
-            <SQLEditorNav
-              sort={sort}
-              showPrivateSnippets={showPrivateSnippets}
-              showSharedSnippets={showSharedSnippets}
-              setShowPrivateSnippets={setShowPrivateSnippets}
-              setShowSharedSnippets={setShowSharedSnippets}
-            />
+            <SQLEditorNav sort={sort} />
           </>
         )}
       </div>

--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorMenu.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorMenu.tsx
@@ -54,6 +54,8 @@ export const SQLEditorMenu = ({ onViewOngoingQueries }: SQLEditorMenuProps) => {
 
   const createNewFolder = () => {
     if (!ref) return console.error('Project ref is required')
+    setSearch('')
+    setShowSearch(false)
     snapV2.addNewFolder({ projectRef: ref })
   }
 
@@ -67,6 +69,7 @@ export const SQLEditorMenu = ({ onViewOngoingQueries }: SQLEditorMenuProps) => {
     try {
       router.push(`/project/${ref}/sql/new?skip=true`)
       setSearch('')
+      setShowSearch(false)
     } catch (error: any) {
       toast.error(`Failed to create new query: ${error.message}`)
     }
@@ -90,6 +93,12 @@ export const SQLEditorMenu = ({ onViewOngoingQueries }: SQLEditorMenuProps) => {
                 const value = e.target.value
                 setSearch(value)
                 if (value.length === 0) setShowSearch(false)
+              }}
+              onKeyDown={(e) => {
+                if (e.code === 'Escape') {
+                  setSearch('')
+                  setShowSearch(false)
+                }
               }}
             >
               <InnerSideBarFilterSortDropdown

--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorMenu.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorMenu.tsx
@@ -1,5 +1,5 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
-import { FilePlus, FolderPlus, Plus } from 'lucide-react'
+import { FilePlus, FolderPlus, Plus, X } from 'lucide-react'
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
@@ -17,12 +17,15 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
 } from 'ui'
 import {
+  InnerSideBarFilters,
   InnerSideBarFilterSearchInput,
   InnerSideBarFilterSortDropdown,
   InnerSideBarFilterSortDropdownItem,
-  InnerSideBarFilters,
   InnerSideMenuItem,
 } from 'ui-patterns/InnerSideMenu'
 import { SQLEditorNav } from './SQLEditorNavV2/SQLEditorNav'
@@ -42,8 +45,6 @@ export const SQLEditorMenu = ({ onViewOngoingQueries }: SQLEditorMenuProps) => {
   const [search, setSearch] = useState('')
   const [showSearch, setShowSearch] = useState(false)
   const [sort, setSort] = useLocalStorage<'name' | 'inserted_at'>('sql-editor-sort', 'inserted_at')
-  const [showSharedSnippets, setShowSharedSnippets] = useState(false)
-  const [showPrivateSnippets, setShowPrivateSnippets] = useState(true)
 
   const debouncedSearch = useDebounce(search, 500)
 
@@ -101,17 +102,32 @@ export const SQLEditorMenu = ({ onViewOngoingQueries }: SQLEditorMenuProps) => {
                 }
               }}
             >
-              <InnerSideBarFilterSortDropdown
-                value={sort}
-                onValueChange={(value: any) => setSort(value)}
-              >
-                <InnerSideBarFilterSortDropdownItem key="name" value="name">
-                  Alphabetical
-                </InnerSideBarFilterSortDropdownItem>
-                <InnerSideBarFilterSortDropdownItem key="inserted_at" value="inserted_at">
-                  Created At
-                </InnerSideBarFilterSortDropdownItem>
-              </InnerSideBarFilterSortDropdown>
+              {showSearch ? (
+                <Tooltip>
+                  <TooltipTrigger
+                    className="absolute right-1 top-[.4rem] md:top-[.3rem] transition-colors text-foreground-light hover:text-foreground"
+                    onClick={() => {
+                      setSearch('')
+                      setShowSearch(false)
+                    }}
+                  >
+                    <X size={18} />
+                  </TooltipTrigger>
+                  <TooltipContent>Clear search</TooltipContent>
+                </Tooltip>
+              ) : (
+                <InnerSideBarFilterSortDropdown
+                  value={sort}
+                  onValueChange={(value: any) => setSort(value)}
+                >
+                  <InnerSideBarFilterSortDropdownItem key="name" value="name">
+                    Alphabetical
+                  </InnerSideBarFilterSortDropdownItem>
+                  <InnerSideBarFilterSortDropdownItem key="inserted_at" value="inserted_at">
+                    Created At
+                  </InnerSideBarFilterSortDropdownItem>
+                </InnerSideBarFilterSortDropdown>
+              )}
             </InnerSideBarFilterSearchInput>
           </InnerSideBarFilters>
           <DropdownMenu>

--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SearchList.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SearchList.tsx
@@ -1,0 +1,78 @@
+import { useParams } from 'common'
+import InfiniteList from 'components/ui/InfiniteList'
+import { useContentCountQuery } from 'data/content/content-count-query'
+import { useContentInfiniteQuery } from 'data/content/content-infinite-query'
+import { Content } from 'data/content/content-query'
+import Link from 'next/link'
+import { useMemo } from 'react'
+import { SQL_ICON } from 'ui'
+import ShimmeringLoader from 'ui-patterns/ShimmeringLoader'
+
+interface SearchListProps {
+  search: string
+  onSelectSnippet: (snippet: Content) => void
+}
+
+export const SearchList = ({ search, onSelectSnippet }: SearchListProps) => {
+  const { ref: projectRef } = useParams()
+
+  const { data, isLoading, hasNextPage, fetchNextPage, isFetchingNextPage } =
+    useContentInfiniteQuery(
+      { projectRef, type: 'sql', limit: 10, name: search.length === 0 ? undefined : search },
+      { keepPreviousData: true }
+    )
+
+  const { data: count, isLoading: isLoadingCount } = useContentCountQuery({
+    projectRef,
+    type: 'sql',
+    name: search,
+  })
+  const { private: _private, shared, favorites } = count || { private: 0, shared: 0, favorites: 0 }
+  const totalNumber = _private + shared - favorites
+
+  const snippets = useMemo(() => data?.pages.flatMap((page) => page.content), [data?.pages])
+
+  return (
+    <div className="flex flex-col flex-grow">
+      {isLoadingCount ? (
+        <div className="px-4 pb-2">
+          <ShimmeringLoader className="py-2.5" />
+        </div>
+      ) : !!count ? (
+        <p className="px-4 pb-2 text-sm text-foreground-lighter">
+          {totalNumber} result{totalNumber > 1 ? 's' : ''} found
+        </p>
+      ) : null}
+      {isLoading ? (
+        <div className="px-4 flex flex-col gap-y-1">
+          <ShimmeringLoader className="py-2.5" />
+          <ShimmeringLoader className="py-2.5 w-5/6" />
+          <ShimmeringLoader className="py-2.5 w-3/4" />
+        </div>
+      ) : (
+        <InfiniteList
+          items={snippets}
+          ItemComponent={(props) => (
+            <Link
+              className="h-full flex items-center gap-x-3 pl-4 hover:bg-control"
+              href={`/project/${projectRef}/sql/${props.item.id}`}
+              onClick={() => onSelectSnippet(props.item)}
+            >
+              <SQL_ICON
+                size={16}
+                strokeWidth={1.5}
+                className="w-5 h-5 -ml-0.5 transition-colors fill-foreground-muted group-aria-selected:fill-foreground"
+              />
+              <p className="text-sm text-foreground-light truncate">{props.item.name}</p>
+            </Link>
+          )}
+          itemProps={{}}
+          getItemSize={() => 28}
+          hasNextPage={hasNextPage}
+          isLoadingNextPage={isFetchingNextPage}
+          onLoadNextPage={() => fetchNextPage()}
+        />
+      )}
+    </div>
+  )
+}

--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SearchList.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SearchList.tsx
@@ -1,16 +1,16 @@
+import Link from 'next/link'
+import { useMemo } from 'react'
+
 import { useParams } from 'common'
 import InfiniteList from 'components/ui/InfiniteList'
 import { useContentCountQuery } from 'data/content/content-count-query'
 import { useContentInfiniteQuery } from 'data/content/content-infinite-query'
-import { Content } from 'data/content/content-query'
-import Link from 'next/link'
-import { useMemo } from 'react'
 import { SQL_ICON } from 'ui'
 import ShimmeringLoader from 'ui-patterns/ShimmeringLoader'
 
 interface SearchListProps {
   search: string
-  onSelectSnippet: (snippet: Content) => void
+  onSelectSnippet: () => void
 }
 
 export const SearchList = ({ search, onSelectSnippet }: SearchListProps) => {
@@ -56,7 +56,7 @@ export const SearchList = ({ search, onSelectSnippet }: SearchListProps) => {
             <Link
               className="h-full flex items-center gap-x-3 pl-4 hover:bg-control"
               href={`/project/${projectRef}/sql/${props.item.id}`}
-              onClick={() => onSelectSnippet(props.item)}
+              onClick={() => onSelectSnippet()}
             >
               <SQL_ICON
                 size={16}

--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SearchList.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SearchList.tsx
@@ -28,11 +28,14 @@ export const SearchList = ({ search, onSelectSnippet }: SearchListProps) => {
       { keepPreviousData: true }
     )
 
-  const { data: count, isLoading: isLoadingCount } = useContentCountQuery({
-    projectRef,
-    type: 'sql',
-    name: search,
-  })
+  const { data: count, isLoading: isLoadingCount } = useContentCountQuery(
+    {
+      projectRef,
+      type: 'sql',
+      name: search,
+    },
+    { keepPreviousData: true }
+  )
   const { private: _private, shared, favorites } = count || { private: 0, shared: 0, favorites: 0 }
   const totalNumber = _private + shared - favorites
 

--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SearchList.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SearchList.tsx
@@ -1,3 +1,4 @@
+import { Loader2 } from 'lucide-react'
 import Link from 'next/link'
 import { useMemo } from 'react'
 
@@ -54,9 +55,9 @@ export const SearchList = ({ search, onSelectSnippet }: SearchListProps) => {
 
   return (
     <div className="flex flex-col flex-grow">
-      {isLoadingCount ? (
-        <div className="px-4 pb-2">
-          <ShimmeringLoader className="py-2.5" />
+      {isLoading ? (
+        <div className="px-4 py-1 pb-2.5">
+          <Loader2 className="animate-spin" size={14} />
         </div>
       ) : !!count ? (
         <p className="px-4 pb-2 text-sm text-foreground-lighter">

--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SearchList.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SearchList.tsx
@@ -5,6 +5,7 @@ import { useParams } from 'common'
 import InfiniteList from 'components/ui/InfiniteList'
 import { useContentCountQuery } from 'data/content/content-count-query'
 import { useContentInfiniteQuery } from 'data/content/content-infinite-query'
+import { SNIPPET_PAGE_LIMIT } from 'data/content/sql-folders-query'
 import { SQL_ICON } from 'ui'
 import ShimmeringLoader from 'ui-patterns/ShimmeringLoader'
 
@@ -18,7 +19,12 @@ export const SearchList = ({ search, onSelectSnippet }: SearchListProps) => {
 
   const { data, isLoading, hasNextPage, fetchNextPage, isFetchingNextPage } =
     useContentInfiniteQuery(
-      { projectRef, type: 'sql', limit: 10, name: search.length === 0 ? undefined : search },
+      {
+        projectRef,
+        type: 'sql',
+        limit: SNIPPET_PAGE_LIMIT,
+        name: search.length === 0 ? undefined : search,
+      },
       { keepPreviousData: true }
     )
 

--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SearchList.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SearchList.tsx
@@ -42,13 +42,13 @@ export const SearchList = ({ search, onSelectSnippet }: SearchListProps) => {
   const { data: count, isLoading: isLoadingCount } = useContentCountQuery(
     {
       projectRef,
+      cumulative: true,
       type: 'sql',
       name: search,
     },
     { keepPreviousData: true }
   )
-  const { private: _private, shared, favorites } = count || { private: 0, shared: 0, favorites: 0 }
-  const totalNumber = _private + shared - favorites
+  const totalNumber = (count as unknown as { count: number })?.count ?? 0
 
   const snippets = useMemo(() => data?.pages.flatMap((page) => page.content), [data?.pages])
 

--- a/apps/studio/data/content/content-count-query.ts
+++ b/apps/studio/data/content/content-count-query.ts
@@ -8,10 +8,11 @@ import { contentKeys } from './keys'
 type GetContentCountVariables =
   operations['ContentController_getContentCountV2']['parameters']['query'] & {
     projectRef?: string
+    cumulative?: boolean
   }
 
 export async function getContentCount(
-  { projectRef, type, name }: GetContentCountVariables,
+  { projectRef, cumulative, type, name }: GetContentCountVariables,
   signal?: AbortSignal
 ) {
   if (typeof projectRef === 'undefined') throw new Error('projectRef is required')
@@ -24,7 +25,7 @@ export async function getContentCount(
         ...(name && { name }),
       },
     },
-    headers: { Version: '2' },
+    ...(cumulative ? {} : { headers: { Version: '2' } }),
     signal,
   })
 
@@ -36,14 +37,15 @@ export type ContentIdData = Awaited<ReturnType<typeof getContentCount>>
 export type ContentIdError = ResponseError
 
 export const useContentCountQuery = <TData = ContentIdData>(
-  { projectRef, type, name }: GetContentCountVariables,
+  { projectRef, cumulative, type, name }: GetContentCountVariables,
   { enabled = true, ...options }: UseQueryOptions<ContentIdData, ContentIdError, TData> = {}
 ) =>
   useQuery<ContentIdData, ContentIdError, TData>(
     contentKeys.count(projectRef, type, {
+      cumulative,
       name,
     }),
-    ({ signal }) => getContentCount({ projectRef, type, name }, signal),
+    ({ signal }) => getContentCount({ projectRef, cumulative, type, name }, signal),
     {
       enabled: enabled && typeof projectRef !== 'undefined',
       ...options,

--- a/apps/studio/data/content/content-infinite-query.ts
+++ b/apps/studio/data/content/content-infinite-query.ts
@@ -1,0 +1,63 @@
+import { useInfiniteQuery, UseInfiniteQueryOptions } from '@tanstack/react-query'
+
+import { get, handleError } from 'data/fetchers'
+import { Content, ContentType } from './content-query'
+import { contentKeys } from './keys'
+
+interface GetContentVariables {
+  projectRef?: string
+  cursor?: string
+  type: ContentType
+  name?: string
+  limit?: number
+  sort?: 'name' | 'inserted_at'
+}
+
+export async function getContent(
+  { projectRef, type, name, limit = 10, sort, cursor }: GetContentVariables,
+  signal?: AbortSignal
+) {
+  if (typeof projectRef === 'undefined') {
+    throw new Error('projectRef is required for getContent')
+  }
+
+  const { data, error } = await get('/platform/projects/{ref}/content', {
+    params: {
+      path: { ref: projectRef },
+      query: {
+        type,
+        name,
+        sort_by: sort,
+        limit: limit.toString(),
+        cursor,
+      },
+    },
+    signal,
+  })
+
+  if (error) handleError(error)
+
+  return {
+    cursor: data.cursor,
+    content: data.data as unknown as Content[],
+  }
+}
+
+export type ContentData = Awaited<ReturnType<typeof getContent>>
+export type ContentError = unknown
+
+export const useContentInfiniteQuery = <TData = ContentData>(
+  { projectRef, type, name, limit, sort }: GetContentVariables,
+  { enabled = true, ...options }: UseInfiniteQueryOptions<ContentData, ContentError, TData> = {}
+) => {
+  return useInfiniteQuery<ContentData, ContentError, TData>(
+    contentKeys.infiniteList(projectRef, { type, name, limit, sort }),
+    ({ signal, pageParam }) =>
+      getContent({ projectRef, type, name, limit, sort, cursor: pageParam }, signal),
+    {
+      enabled: enabled && typeof projectRef !== 'undefined',
+      getNextPageParam: (lastPage) => lastPage.cursor,
+      ...options,
+    }
+  )
+}

--- a/apps/studio/data/content/keys.ts
+++ b/apps/studio/data/content/keys.ts
@@ -39,6 +39,11 @@ export const contentKeys = {
   count: (
     projectRef: string | undefined,
     type?: string,
-    options?: { visibility?: SqlSnippet['visibility']; favorite?: boolean; name?: string }
+    options?: {
+      cumulative?: boolean
+      visibility?: SqlSnippet['visibility']
+      favorite?: boolean
+      name?: string
+    }
   ) => ['projects', projectRef, 'content', 'count', type, options].filter(Boolean),
 }

--- a/apps/studio/data/content/keys.ts
+++ b/apps/studio/data/content/keys.ts
@@ -3,9 +3,18 @@ import type { SqlSnippet } from './sql-snippets-query'
 
 export const contentKeys = {
   allContentLists: (projectRef: string | undefined) => ['projects', projectRef, 'content'] as const,
+  infiniteList: (
+    projectRef: string | undefined,
+    options: {
+      type: ContentType | undefined
+      name: string | undefined
+      limit?: number
+      sort?: string
+    }
+  ) => ['projects', projectRef, 'content-infinite', options] as const,
   list: (
     projectRef: string | undefined,
-    options: { type: ContentType | undefined; name: string | undefined }
+    options: { type?: ContentType; name?: string; limit?: number }
   ) => ['projects', projectRef, 'content', options] as const,
   sqlSnippets: (
     projectRef: string | undefined,

--- a/apps/studio/data/content/sql-folder-contents-query.ts
+++ b/apps/studio/data/content/sql-folder-contents-query.ts
@@ -36,7 +36,7 @@ export async function getSQLSnippetFolderContents(
     signal,
   })
 
-  if (error) throw handleError(error)
+  if (error) handleError(error)
   return {
     ...data.data,
     cursor: data.cursor,

--- a/apps/studio/data/content/sql-folders-query.ts
+++ b/apps/studio/data/content/sql-folders-query.ts
@@ -43,7 +43,7 @@ export async function getSQLSnippetFolders(
     signal,
   })
 
-  if (error) throw handleError(error)
+  if (error) handleError(error)
   return {
     ...data.data,
     cursor: data.cursor,

--- a/packages/ui-patterns/InnerSideMenu/index.tsx
+++ b/packages/ui-patterns/InnerSideMenu/index.tsx
@@ -197,7 +197,7 @@ const InnerSideBarFilterSortDropdown = forwardRef<
           asChild
           className={cn(
             'absolute right-1 top-[.4rem] md:top-[.3rem]',
-            'text-foreground-muted transition-colors hover:text-foreground data-[state=open]:text-foreground',
+            'text-foreground transition-colors hover:text-foreground data-[state=open]:text-foreground',
             triggerClassName
           )}
         >

--- a/packages/ui/src/components/shadcn/ui/context-menu.tsx
+++ b/packages/ui/src/components/shadcn/ui/context-menu.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import * as React from 'react'
 import * as ContextMenuPrimitive from '@radix-ui/react-context-menu'
 import { Check, ChevronRight, Circle } from 'lucide-react'
+import * as React from 'react'
 
 import { cn } from '../../../lib/utils/cn'
 
@@ -172,18 +172,18 @@ ContextMenuShortcut.displayName = 'ContextMenuShortcut'
 
 export {
   ContextMenu,
-  ContextMenuTrigger,
-  ContextMenuContent,
-  ContextMenuItem,
   ContextMenuCheckboxItem,
-  ContextMenuRadioItem,
+  ContextMenuContent,
+  ContextMenuGroup,
+  ContextMenuItem,
   ContextMenuLabel,
+  ContextMenuPortal,
+  ContextMenuRadioGroup,
+  ContextMenuRadioItem,
   ContextMenuSeparator,
   ContextMenuShortcut,
-  ContextMenuGroup,
-  ContextMenuPortal,
   ContextMenuSub,
   ContextMenuSubContent,
   ContextMenuSubTrigger,
-  ContextMenuRadioGroup,
+  ContextMenuTrigger,
 }

--- a/packages/ui/src/components/shadcn/ui/hover-card.tsx
+++ b/packages/ui/src/components/shadcn/ui/hover-card.tsx
@@ -15,19 +15,21 @@ const HoverCardContent = React.forwardRef<
     animate?: 'zoom-in' | 'slide-in'
   }
 >(({ className, align = 'center', animate = 'zoom-in', sideOffset = 4, ...props }, ref) => (
-  <HoverCardPrimitive.Content
-    ref={ref}
-    align={align}
-    sideOffset={sideOffset}
-    className={cn(
-      'z-50 w-64 rounded-md border bg-overlay p-4 text-popover-foreground shadow-md outline-none',
-      animate === 'zoom-in'
-        ? 'animate-in zoom-in-[99%]'
-        : 'animate-in fade-in-50 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1',
-      className
-    )}
-    {...props}
-  />
+  <HoverCardPrimitive.Portal>
+    <HoverCardPrimitive.Content
+      ref={ref}
+      align={align}
+      sideOffset={sideOffset}
+      className={cn(
+        'z-50 w-64 rounded-md border bg-overlay p-4 text-popover-foreground shadow-md outline-none',
+        animate === 'zoom-in'
+          ? 'animate-in zoom-in-[99%]'
+          : 'animate-in fade-in-50 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1',
+        className
+      )}
+      {...props}
+    />
+  </HoverCardPrimitive.Portal>
 ))
 HoverCardContent.displayName = HoverCardPrimitive.Content.displayName
 


### PR DESCRIPTION
## Opting to show a flat list of snippets instead
- IMO faster searching UX for finding what you're looking for
  - Exposes queries that are within folders (easier finding)
    - Currently when searching, we still render the folders and you'd need to open the folders to check if the snippets are in them or not
  - Hides the 3 separate sections, makes it easier to scan for what you're looking for
    - Am also thinking when you're searching for something, you don't really care which section they're in
- Probably more importantly, relieves some load off the API
  - We were making 3 requests each time we trigger a search since each section (shared, favorites and private) was controlled by their own react query state
  - This change ensures that we only fire one

https://github.com/user-attachments/assets/3cd07693-882d-486b-b848-842d67d0316a

## Misc fixes:
- Resolves a common bug "Node ID doesn't exist in tree" -> happens when opening a snippet that's within a folder on a fresh browser session
- Makes the sort icon in the search field higher contrast (feedback was that users kept missing this action)
