### PR TITLE
misc: Disable Sentry Tracing

### DIFF
--- a/apps/studio/sentry.client.config.ts
+++ b/apps/studio/sentry.client.config.ts
@@ -9,12 +9,8 @@ import { match } from 'path-to-regexp'
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: 0.01,
-
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
-
   beforeSend(event, hint) {
     const consent =
       typeof window !== 'undefined'
@@ -33,21 +29,6 @@ Sentry.init({
     }
     return null
   },
-
-  integrations: [
-    Sentry.browserTracingIntegration({
-      // TODO: update gotrue + api to support Access-Control-Request-Headers: authorization,baggage,sentry-trace,x-client-info
-      // then remove these options
-      traceFetch: false,
-      traceXHR: false,
-      beforeStartSpan: (context) => {
-        return {
-          ...context,
-          name: standardiseRouterUrl(location.pathname),
-        }
-      },
-    }),
-  ],
   ignoreErrors: [
     // Used exclusively in Monaco Editor.
     'ResizeObserver',

--- a/apps/studio/sentry.edge.config.ts
+++ b/apps/studio/sentry.edge.config.ts
@@ -7,10 +7,6 @@ import * as Sentry from '@sentry/nextjs'
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-
-  // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: 0.01,
-
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
 })

--- a/apps/studio/sentry.server.config.ts
+++ b/apps/studio/sentry.server.config.ts
@@ -6,13 +6,8 @@ import * as Sentry from '@sentry/nextjs'
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-
-  // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: 0.01,
-
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
-
   ignoreErrors: [
     // Used exclusively in Monaco Editor.
     'ResizeObserver',


### PR DESCRIPTION
Frontend team is not actively using it so there's no reason to keep it around.