### PR TITLE
chore: Fix Monaco editor in strict mode

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
@@ -66,6 +66,7 @@ import {
   isUpdateWithoutWhere,
   suffixWithLimit,
 } from './SQLEditor.utils'
+import { useAddDefinitions } from './useAddDefinitions'
 import UtilityPanel from './UtilityPanel/UtilityPanel'
 
 // Load the monaco editor client-side only (does not behave well server-side)
@@ -130,6 +131,8 @@ export const SQLEditor = () => {
     id in snapV2.snippets && snapV2.snippets[id].snippet.content !== undefined
   )
   const isLoading = urlId === 'new' ? false : snippetIsLoading
+
+  useAddDefinitions(id, monacoRef.current)
 
   /** React query data fetching  */
   const { data: subscription } = useOrgSubscriptionQuery({ orgSlug: organization?.slug })

--- a/apps/studio/components/interfaces/SQLEditor/useAddDefinitions.ts
+++ b/apps/studio/components/interfaces/SQLEditor/useAddDefinitions.ts
@@ -1,0 +1,111 @@
+import { Monaco } from '@monaco-editor/react'
+import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
+import getPgsqlCompletionProvider from 'components/ui/CodeEditor/Providers/PgSQLCompletionProvider'
+import getPgsqlSignatureHelpProvider from 'components/ui/CodeEditor/Providers/PgSQLSignatureHelpProvider'
+import { useDatabaseFunctionsQuery } from 'data/database-functions/database-functions-query'
+import { useKeywordsQuery } from 'data/database/keywords-query'
+import { useSchemasQuery } from 'data/database/schemas-query'
+import { useTableColumnsQuery } from 'data/database/table-columns-query'
+import { useLocalStorageQuery } from 'hooks/misc/useLocalStorage'
+import { LOCAL_STORAGE_KEYS } from 'lib/constants'
+import { formatSql } from 'lib/formatSql'
+import { IDisposable } from 'monaco-editor'
+import { useEffect, useRef } from 'react'
+import { useSqlEditorV2StateSnapshot } from 'state/sql-editor-v2'
+
+export const useAddDefinitions = (id: string, monaco: Monaco | null) => {
+  const { project } = useProjectContext()
+  const snapV2 = useSqlEditorV2StateSnapshot()
+
+  const [intellisenseEnabled] = useLocalStorageQuery(
+    LOCAL_STORAGE_KEYS.SQL_EDITOR_INTELLISENSE,
+    true
+  )
+
+  const { data: keywords, isSuccess: isKeywordsSuccess } = useKeywordsQuery(
+    {
+      projectRef: project?.ref,
+      connectionString: project?.connectionString,
+    },
+    { enabled: intellisenseEnabled }
+  )
+  const { data: functions, isSuccess: isFunctionsSuccess } = useDatabaseFunctionsQuery(
+    {
+      projectRef: project?.ref,
+      connectionString: project?.connectionString,
+    },
+    { enabled: intellisenseEnabled }
+  )
+  const { data: schemas, isSuccess: isSchemasSuccess } = useSchemasQuery(
+    {
+      projectRef: project?.ref,
+      connectionString: project?.connectionString,
+    },
+    { enabled: intellisenseEnabled }
+  )
+  const { data: tableColumns, isSuccess: isTableColumnsSuccess } = useTableColumnsQuery(
+    {
+      projectRef: project?.ref,
+      connectionString: project?.connectionString,
+    },
+    { enabled: intellisenseEnabled }
+  )
+
+  const pgInfoRef = useRef<any>(null)
+
+  const isPgInfoReady =
+    intellisenseEnabled &&
+    isTableColumnsSuccess &&
+    isSchemasSuccess &&
+    isKeywordsSuccess &&
+    isFunctionsSuccess
+
+  if (isPgInfoReady) {
+    if (pgInfoRef.current === null) {
+      pgInfoRef.current = {}
+    }
+    pgInfoRef.current.tableColumns = tableColumns
+    pgInfoRef.current.schemas = schemas
+    pgInfoRef.current.keywords = keywords
+    pgInfoRef.current.functions = functions
+  }
+
+  //  Enable pgsql format
+  useEffect(() => {
+    if (monaco) {
+      const formatProvider = monaco.languages.registerDocumentFormattingEditProvider('pgsql', {
+        async provideDocumentFormattingEdits(model) {
+          const value = model.getValue()
+          const formatted = formatSql(value)
+          if (id) snapV2.setSql(id, formatted)
+          return [{ range: model.getFullModelRange(), text: formatted }]
+        },
+      })
+      return () => formatProvider.dispose()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [monaco])
+
+  // Register auto completion item provider for pgsql
+  useEffect(() => {
+    let completeProvider: IDisposable | null = null
+    let signatureHelpProvider: IDisposable | null = null
+
+    if (isPgInfoReady) {
+      if (monaco && isPgInfoReady) {
+        completeProvider = monaco.languages.registerCompletionItemProvider(
+          'pgsql',
+          getPgsqlCompletionProvider(monaco, pgInfoRef)
+        )
+        signatureHelpProvider = monaco.languages.registerSignatureHelpProvider(
+          'pgsql',
+          getPgsqlSignatureHelpProvider(monaco, pgInfoRef)
+        )
+      }
+    }
+    return () => {
+      completeProvider?.dispose()
+      signatureHelpProvider?.dispose()
+    }
+  }, [isPgInfoReady, monaco])
+}

--- a/apps/studio/pages/project/[ref]/sql/[id].tsx
+++ b/apps/studio/pages/project/[ref]/sql/[id].tsx
@@ -1,40 +1,22 @@
-import { useMonaco } from '@monaco-editor/react'
 import { useRouter } from 'next/router'
-import { useEffect, useRef } from 'react'
+import { useEffect } from 'react'
 
 import { useParams } from 'common/hooks/useParams'
 import { SQLEditor } from 'components/interfaces/SQLEditor/SQLEditor'
-import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
 import SQLEditorLayout from 'components/layouts/SQLEditorLayout/SQLEditorLayout'
-import getPgsqlCompletionProvider from 'components/ui/CodeEditor/Providers/PgSQLCompletionProvider'
-import getPgsqlSignatureHelpProvider from 'components/ui/CodeEditor/Providers/PgSQLSignatureHelpProvider'
 import { useContentIdQuery } from 'data/content/content-id-query'
-import { useDatabaseFunctionsQuery } from 'data/database-functions/database-functions-query'
-import { useKeywordsQuery } from 'data/database/keywords-query'
-import { useSchemasQuery } from 'data/database/schemas-query'
-import { useTableColumnsQuery } from 'data/database/table-columns-query'
-import { useLocalStorageQuery } from 'hooks/misc/useLocalStorage'
-import { LOCAL_STORAGE_KEYS } from 'lib/constants'
-import { formatSql } from 'lib/formatSql'
 import { useAppStateSnapshot } from 'state/app-state'
 import { SnippetWithContent, useSnippets, useSqlEditorV2StateSnapshot } from 'state/sql-editor-v2'
 import type { NextPageWithLayout } from 'types'
 
 const SqlEditor: NextPageWithLayout = () => {
   const router = useRouter()
-  const monaco = useMonaco()
   const { id, ref, content, skip } = useParams()
 
-  const { project } = useProjectContext()
   const appSnap = useAppStateSnapshot()
   const snapV2 = useSqlEditorV2StateSnapshot()
 
   const allSnippets = useSnippets(ref!)
-
-  const [intellisenseEnabled] = useLocalStorageQuery(
-    LOCAL_STORAGE_KEYS.SQL_EDITOR_INTELLISENSE,
-    true
-  )
 
   // [Refactor] There's an unnecessary request getting triggered when we start typing while on /new
   // the URL ID gets updated and we attempt to fetch content for a snippet that's not been created yet
@@ -54,54 +36,6 @@ const SqlEditor: NextPageWithLayout = () => {
     }
   }, [ref, data])
 
-  const { data: keywords, isSuccess: isKeywordsSuccess } = useKeywordsQuery(
-    {
-      projectRef: project?.ref,
-      connectionString: project?.connectionString,
-    },
-    { enabled: intellisenseEnabled }
-  )
-  const { data: functions, isSuccess: isFunctionsSuccess } = useDatabaseFunctionsQuery(
-    {
-      projectRef: project?.ref,
-      connectionString: project?.connectionString,
-    },
-    { enabled: intellisenseEnabled }
-  )
-  const { data: schemas, isSuccess: isSchemasSuccess } = useSchemasQuery(
-    {
-      projectRef: project?.ref,
-      connectionString: project?.connectionString,
-    },
-    { enabled: intellisenseEnabled }
-  )
-  const { data: tableColumns, isSuccess: isTableColumnsSuccess } = useTableColumnsQuery(
-    {
-      projectRef: project?.ref,
-      connectionString: project?.connectionString,
-    },
-    { enabled: intellisenseEnabled }
-  )
-
-  const pgInfoRef = useRef<any>(null)
-
-  const isPgInfoReady =
-    intellisenseEnabled &&
-    isTableColumnsSuccess &&
-    isSchemasSuccess &&
-    isKeywordsSuccess &&
-    isFunctionsSuccess
-
-  if (isPgInfoReady) {
-    if (pgInfoRef.current === null) {
-      pgInfoRef.current = {}
-    }
-    pgInfoRef.current.tableColumns = tableColumns
-    pgInfoRef.current.schemas = schemas
-    pgInfoRef.current.keywords = keywords
-    pgInfoRef.current.functions = functions
-  }
-
   // Load the last visited snippet when landing on /new
   useEffect(() => {
     if (
@@ -115,47 +49,6 @@ const SqlEditor: NextPageWithLayout = () => {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [id, allSnippets, content])
-
-  // Enable pgsql format
-  useEffect(() => {
-    if (monaco) {
-      const formatProvider = monaco.languages.registerDocumentFormattingEditProvider('pgsql', {
-        async provideDocumentFormattingEdits(model: any) {
-          const value = model.getValue()
-          const formatted = formatSql(value)
-          if (id) snapV2.setSql(id, formatted)
-          return [{ range: model.getFullModelRange(), text: formatted }]
-        },
-      })
-      return () => formatProvider.dispose()
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [monaco])
-
-  // Register auto completion item provider for pgsql
-  useEffect(() => {
-    if (isPgInfoReady) {
-      let completeProvider: any
-      let signatureHelpProvider: any
-
-      if (monaco && isPgInfoReady) {
-        completeProvider = monaco.languages.registerCompletionItemProvider(
-          'pgsql',
-          getPgsqlCompletionProvider(monaco, pgInfoRef)
-        )
-        signatureHelpProvider = monaco.languages.registerSignatureHelpProvider(
-          'pgsql',
-          getPgsqlSignatureHelpProvider(monaco, pgInfoRef)
-        )
-      }
-
-      return () => {
-        completeProvider?.dispose()
-        signatureHelpProvider?.dispose()
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isPgInfoReady])
 
   return (
     <div className="flex-1 overflow-auto">


### PR DESCRIPTION
This PR fixes an issue in the SQL editor which causes the monaco instance to be initialized twice in React Strict mode which results in an console error. This happens every time when you refresh the /dashboard/project/_/sql/new page (but not if you're navigating to it from elsewhere). 

The issue is reported in https://github.com/suren-atoyan/monaco-react/issues/440.

https://github.com/supabase/supabase/pull/33071 should be merged first.