### PR TITLE
Notification filters: fix icon size

### DIFF
--- a/apps/studio/components/layouts/ProjectLayout/LayoutHeader/NotificationsPopoverV2/NotificationsFilter.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/LayoutHeader/NotificationsPopoverV2/NotificationsFilter.tsx
@@ -91,7 +91,7 @@ export const NotificationsFilter = ({ activeTab }: { activeTab: 'inbox' | 'archi
                       name="warning"
                       checked={snap.filterPriorities.includes('Warning')}
                     ></Checkbox_Shadcn_>
-                    <WarningIcon className="w-2 h-2" />
+                    <WarningIcon className="size-4" />
                     Warning
                   </Label_Shadcn_>
                 </CommandItem_Shadcn_>
@@ -112,7 +112,7 @@ export const NotificationsFilter = ({ activeTab }: { activeTab: 'inbox' | 'archi
                       name="critical"
                       checked={snap.filterPriorities.includes('Critical')}
                     ></Checkbox_Shadcn_>
-                    <CriticalIcon className="w-2 h-2" />
+                    <CriticalIcon className="size-4" />
                     Critical
                   </Label_Shadcn_>
                 </CommandItem_Shadcn_>

--- a/apps/studio/components/layouts/ProjectLayout/LayoutHeader/NotificationsPopoverV2/NotificationsPopover.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/LayoutHeader/NotificationsPopoverV2/NotificationsPopover.tsx
@@ -106,9 +106,9 @@ const NotificationsPopoverV2 = () => {
           )}
           icon={
             hasCritical ? (
-              <CriticalIcon className="relative size-3.5 transition-all -mr-3.5 group-hover:-mr-1 z-10" />
+              <CriticalIcon className="relative size-3.5 !h-3.5 transition-all -mr-3.5 group-hover:-mr-1 z-10" />
             ) : hasWarning ? (
-              <WarningIcon className="relative size-3.5 transition-all -mr-3.5 group-hover:-mr-1 z-10" />
+              <WarningIcon className="relative !w-3.5 !h-3.5 transition-all -mr-3.5 group-hover:-mr-1 z-10" />
             ) : hasNewNotifications ? (
               <div
                 className={cn(

--- a/apps/studio/components/layouts/ProjectLayout/LayoutHeader/NotificationsPopoverV2/NotificationsPopover.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/LayoutHeader/NotificationsPopoverV2/NotificationsPopover.tsx
@@ -96,9 +96,7 @@ const NotificationsPopoverV2 = () => {
         <Button
           type={hasNewNotifications ? 'outline' : 'text'}
           className={cn(
-            'h-[26px]',
-            // !hasCritical || !hasWarning || !hasNewNotifications ? 'w-[26px]' : '',
-            'group',
+            'h-[26px] group',
             hasNewNotifications ? 'rounded-full px-1.5' : 'px-1',
             hasCritical
               ? 'border-destructive-500 hover:border-destructive-600 hover:bg-destructive-300'
@@ -108,9 +106,9 @@ const NotificationsPopoverV2 = () => {
           )}
           icon={
             hasCritical ? (
-              <CriticalIcon className="relative !w-3.5 !h-3.5 transition-all -mr-3.5 group-hover:-mr-1 z-10" />
+              <CriticalIcon className="relative size-3.5 transition-all -mr-3.5 group-hover:-mr-1 z-10" />
             ) : hasWarning ? (
-              <WarningIcon className="relative !w-3.5 !h-3.5 transition-all -mr-3.5 group-hover:-mr-1 z-10" />
+              <WarningIcon className="relative size-3.5 transition-all -mr-3.5 group-hover:-mr-1 z-10" />
             ) : hasNewNotifications ? (
               <div
                 className={cn(

--- a/apps/studio/components/layouts/ProjectLayout/LayoutHeader/NotificationsPopoverV2/NotificationsPopover.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/LayoutHeader/NotificationsPopoverV2/NotificationsPopover.tsx
@@ -96,7 +96,9 @@ const NotificationsPopoverV2 = () => {
         <Button
           type={hasNewNotifications ? 'outline' : 'text'}
           className={cn(
-            'h-[26px] group',
+            'h-[26px]',
+            // !hasCritical || !hasWarning || !hasNewNotifications ? 'w-[26px]' : '',
+            'group',
             hasNewNotifications ? 'rounded-full px-1.5' : 'px-1',
             hasCritical
               ? 'border-destructive-500 hover:border-destructive-600 hover:bg-destructive-300'
@@ -106,7 +108,7 @@ const NotificationsPopoverV2 = () => {
           )}
           icon={
             hasCritical ? (
-              <CriticalIcon className="relative size-3.5 !h-3.5 transition-all -mr-3.5 group-hover:-mr-1 z-10" />
+              <CriticalIcon className="relative !w-3.5 !h-3.5 transition-all -mr-3.5 group-hover:-mr-1 z-10" />
             ) : hasWarning ? (
               <WarningIcon className="relative !w-3.5 !h-3.5 transition-all -mr-3.5 group-hover:-mr-1 z-10" />
             ) : hasNewNotifications ? (


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Fix notification filter icon size

## What is the current behavior?

![image](https://github.com/user-attachments/assets/b23d1226-6172-45d8-bb5e-ac5e1e1bef76)

## What is the new behavior?

![CleanShot 2025-01-27 at 11 48 23@2x](https://github.com/user-attachments/assets/97df9a0f-b8cb-4243-82e9-a11a34fed308)


