### PR TITLE
Service Status: fix status checks

### DIFF
--- a/apps/studio/components/interfaces/Home/ServiceStatus.tsx
+++ b/apps/studio/components/interfaces/Home/ServiceStatus.tsx
@@ -35,11 +35,11 @@ const StatusMessage = ({
   status?: ProjectServiceStatus
 }) => {
   if (isLoading) return 'Checking status'
-  if (isProjectNew) return 'Coming up...'
-  if (isSuccess) return 'No issues'
   if (status === 'UNHEALTHY') return 'Unhealthy'
   if (status === 'COMING_UP') return 'Coming up...'
   if (status === 'ACTIVE_HEALTHY') return 'Healthy'
+  if (isProjectNew) return 'Coming up...'
+  if (isSuccess) return 'No issues'
   return 'Unable to connect'
 }
 
@@ -62,10 +62,12 @@ const StatusIcon = ({
   isProjectNew: boolean
   projectStatus?: ProjectServiceStatus
 }) => {
-  if (isLoading || isProjectNew) return <LoaderIcon />
-  if (isSuccess) return <CheckIcon />
+  if (isLoading) return <LoaderIcon />
   if (projectStatus === 'UNHEALTHY') return <AlertIcon />
   if (projectStatus === 'COMING_UP') return <LoaderIcon />
+  if (projectStatus === 'ACTIVE_HEALTHY') return <CheckIcon />
+  if (isProjectNew) return <LoaderIcon />
+  if (isSuccess) return <CheckIcon />
   return <AlertIcon />
 }
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Sorts status checks correctly 

## What is the current behavior?

Incorrect checks will sometimes show status as coming up if project is new

## What is the new behavior?

![CleanShot 2025-01-27 at 19 25 35@2x](https://github.com/user-attachments/assets/1d9bbcc9-35f0-4685-911d-f9a0a319a8fb)
