### PR TITLE
Chore/fix webhook params

### DIFF
--- a/apps/studio/components/interfaces/Database/Hooks/EditHookPanel.tsx
+++ b/apps/studio/components/interfaces/Database/Hooks/EditHookPanel.tsx
@@ -106,18 +106,15 @@ const EditHookPanel = ({ visible, selectedHook, onClose }: EditHookPanelProps) =
         const [url, method, headers, parameters] = selectedHook.function_args
 
         let parsedParameters: Record<string, string> = {}
+
+        // Try to parse the parameters with escaped quotes
         try {
-          // First, try normal JSON parse
-          parsedParameters = JSON.parse(parameters)
+          parsedParameters = JSON.parse(parameters.replace(/\\"/g, '"'))
         } catch (e) {
-          console.log('Failed to parse parameters:', e)
-          // If that fails, try to handle escaped quotes
-          try {
-            parsedParameters = JSON.parse(parameters.replace(/\\\"/g, '"'))
-          } catch (e2) {
-            console.log('Failed second parse attempt:', e2)
-          }
+          // If parsing still fails, fallback to an empty object
+          parsedParameters = {}
         }
+
         const formattedHeaders = tryParseJson(headers) || {}
         setHttpHeaders(
           Object.keys(formattedHeaders).map((key) => {

--- a/apps/studio/components/interfaces/Database/Hooks/EditHookPanel.tsx
+++ b/apps/studio/components/interfaces/Database/Hooks/EditHookPanel.tsx
@@ -115,10 +115,17 @@ const EditHookPanel = ({ visible, selectedHook, onClose }: EditHookPanelProps) =
           parsedParameters = {}
         }
 
-        const formattedHeaders = tryParseJson(headers) || {}
+        let parsedHeaders: Record<string, string> = {}
+        try {
+          parsedHeaders = JSON.parse(headers.replace(/\\"/g, '"'))
+        } catch (e) {
+          // If parsing still fails, fallback to an empty object
+          parsedHeaders = {}
+        }
+
         setHttpHeaders(
-          Object.keys(formattedHeaders).map((key) => {
-            return { id: uuidv4(), name: key, value: formattedHeaders[key] }
+          Object.keys(parsedHeaders).map((key) => {
+            return { id: uuidv4(), name: key, value: parsedHeaders[key] }
           })
         )
 


### PR DESCRIPTION
Webhook params with quotes aren't getting parsed/saved properly

![screenshot-2025-01-28-at-16 05 51](https://github.com/user-attachments/assets/4968a89d-b748-49fc-8e9d-85c17d941699)


To reproduce: 
- create a new webhook
- add http parameters (name: hello, value:  to you), hit save, re-open panel and edit, should work 
- change `to you`  to `"to you"` (with quotes) and it won't save properly 