### PR TITLE
docs: fix pgmq link text

### DIFF
--- a/apps/docs/content/guides/database/extensions/pgmq.mdx
+++ b/apps/docs/content/guides/database/extensions/pgmq.mdx
@@ -4,4 +4,4 @@ title: 'pgmq: Queues'
 description: 'pgmq: Managed queues in Postgres'
 ---
 
-See the [Supabase Cron docs](/docs/guides/queues).
+See the [Supabase Queues docs](/docs/guides/queues).

--- a/apps/www/lib/redirects.js
+++ b/apps/www/lib/redirects.js
@@ -2187,11 +2187,6 @@ module.exports = [
   },
   {
     permanent: false,
-    source: '/docs/guides/database/extensions/pgmq',
-    destination: '/docs/guides/database/extensions',
-  },
-  {
-    permanent: false,
     source: '/docs/guides/database/extensions/pg_partman',
     destination: '/docs/guides/database/extensions',
   },


### PR DESCRIPTION
The pgmq extension docs reference the queues page but says "cron" on the link. Updates to say "queues". Also removes temp redirect.