### PR TITLE
fix: timeouts

### DIFF
--- a/apps/docs/app/reference/[...slug]/page.tsx
+++ b/apps/docs/app/reference/[...slug]/page.tsx
@@ -12,6 +12,8 @@ import {
   redirectNonexistentReferenceSection,
 } from '~/features/docs/Reference.utils'
 
+export const dynamicParams = false
+
 export default async function ReferencePage({
   params: { slug },
 }: {
@@ -39,7 +41,6 @@ export default async function ReferencePage({
 
     return <ClientSdkReferencePage sdkId={sdkId} libVersion={version} />
   } else if (isCliReference) {
-    console.log('Returning CLI reference page: %o', parsedPath)
     return <CliReferencePage />
   } else if (isApiReference) {
     return <ApiReferencePage />


### PR DESCRIPTION
Trying a thing to deal with the constant behind-the-scenes timeouts we're getting on reference pages. These don't affect the user experience, since a 200 response is correctly served from middleware; it's the behind-the-scenes revalidation function that times out.

Technically we don't need to run any of these revalidation functions, since we've already served the page as a rewrite of a SSG page, and there's no need to regenerate the page on demand at a different (never-used-in-practice) URL. Couldn't figure out how to reliably generate the timeout problem in preview, so I'm not 100% sure it works, but the change seems relatively harmless, so let's try merging this and seeing what it does.