### PR TITLE
docs: fix typo in auth-github social login guide

### DIFF
--- a/apps/docs/content/guides/auth/social-login/auth-github.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-github.mdx
@@ -80,7 +80,7 @@ Future<void> signInWithGithub() async {
 </TabPanel>
 <TabPanel id="swift" label="Swift">
 
-When your user signs in, call [signInWithWithOAuth](/docs/reference/swift/auth-signinwithoauth) with `.github` as the `Provider`:
+When your user signs in, call [signInWithOAuth](/docs/reference/swift/auth-signinwithoauth) with `.github` as the `Provider`:
 
 ```swift
 func signInWithGithub() async throws {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

There is a typo in the Swift integration section of the auth-github social login guide. The text incorrectly states:
_"When your user signs in, call signInWithWithOAuth"_

## What is the new behavior?

The typo has been corrected to:
_"When your user signs in, call signInWithOAuth"_

## Additional context

This is a minor documentation fix for clarity. No functional changes. Resolves #33191.
