### PR TITLE
fix margin top for error

### DIFF
--- a/apps/studio/components/interfaces/Settings/Logs/LogTable.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogTable.tsx
@@ -354,7 +354,7 @@ const LogTable = ({
     }
 
     return (
-      <div className="text-foreground flex gap-2 font-mono px-6">
+      <div className="text-foreground flex gap-2 font-mono p-4">
         <DefaultErrorRenderer {...childProps} />
       </div>
     )

--- a/apps/studio/components/interfaces/Settings/Logs/LogsErrorRenderers/DefaultErrorRenderer.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogsErrorRenderers/DefaultErrorRenderer.tsx
@@ -7,7 +7,7 @@ export interface ErrorRendererProps {
 }
 
 export const DefaultErrorRenderer: React.FC<ErrorRendererProps> = ({ error }) => (
-  <div className="w-full prose min-w-full text-foreground text-sm">
+  <div className="w-full prose min-w-full text-foreground text-sm mt-4">
     <CodeBlock
       title="Error fetching logs"
       language="json"

--- a/apps/studio/components/interfaces/Settings/Logs/LogsErrorRenderers/DefaultErrorRenderer.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogsErrorRenderers/DefaultErrorRenderer.tsx
@@ -7,7 +7,7 @@ export interface ErrorRendererProps {
 }
 
 export const DefaultErrorRenderer: React.FC<ErrorRendererProps> = ({ error }) => (
-  <div className="w-full prose min-w-full text-foreground text-sm mt-4">
+  <div className="w-full prose min-w-full text-foreground text-sm">
     <CodeBlock
       title="Error fetching logs"
       language="json"


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

![CleanShot 2025-02-03 at 12 30 27@2x](https://github.com/user-attachments/assets/aa3d5626-5eea-44f4-9234-bd5987825800)

## What is the current behavior?

![CleanShot 2025-01-30 at 14 31 00@2x](https://github.com/user-attachments/assets/36cd54db-7678-482d-98d7-4eaafd64e498)

Theres no space between the header and error section