### PR TITLE
Fix custom report charts

### DIFF
--- a/packages/ui/src/components/shadcn/ui/chart.tsx
+++ b/packages/ui/src/components/shadcn/ui/chart.tsx
@@ -37,10 +37,10 @@ function useChart() {
 const ChartContainer = React.forwardRef<
   HTMLDivElement,
   React.ComponentProps<'div'> & {
-    config: ChartConfig
+    config?: ChartConfig
     children: React.ComponentProps<typeof RechartsPrimitive.ResponsiveContainer>['children']
   }
->(({ id, className, children, config, ...props }, ref) => {
+>(({ id, className, children, config = {}, ...props }, ref) => {
   const uniqueId = React.useId()
   const chartId = `chart-${id || uniqueId.replace(/:/g, '')}`
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/6ba6941b-130e-486e-aa71-f0fe2900906c)

Main fix is in here: 
![image](https://github.com/user-attachments/assets/37d964b0-f634-4fd1-ae01-462799a0c59d)
- The value here needs to stay a number, not a formatted string
- This caused values above 1000 to not render as Bars (as they get formatted to "1,000" and recharts doesn't know how to parse it)
- I think this caused problems with the YAxis domain as well as the domain fixed itself after this too