### PR TITLE
Warn for certain symbols in database passwords

### DIFF
--- a/apps/studio/components/interfaces/ProjectCreation/ProjectCreation.constants.ts
+++ b/apps/studio/components/interfaces/ProjectCreation/ProjectCreation.constants.ts
@@ -252,3 +252,5 @@ export const COUNTRY_LAT_LON = {
   ZM: { lat: -15, lon: 30 },
   ZW: { lat: -20, lon: 30 },
 }
+
+export const SPECIAL_CHARS_REGEX = /^[^@:\/]*$/

--- a/apps/studio/components/interfaces/ProjectCreation/ProjectCreation.test.ts
+++ b/apps/studio/components/interfaces/ProjectCreation/ProjectCreation.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from 'vitest'
+import { SPECIAL_CHARS_REGEX } from './ProjectCreation.constants'
+
+test('Regex test to surface if password contains @, : or /', () => {
+  expect(!'teststring'.match(SPECIAL_CHARS_REGEX)).toEqual(false)
+  expect(!'test@string'.match(SPECIAL_CHARS_REGEX)).toEqual(true)
+  expect(!'te:ststring'.match(SPECIAL_CHARS_REGEX)).toEqual(true)
+  expect(!`tests/tring`.match(SPECIAL_CHARS_REGEX)).toEqual(true)
+  expect(!'!#$%^&*()'.match(SPECIAL_CHARS_REGEX)).toEqual(false)
+})

--- a/apps/studio/components/interfaces/ProjectCreation/SpecialSymbolsCallout.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/SpecialSymbolsCallout.tsx
@@ -3,11 +3,11 @@ import { InlineLink } from 'components/ui/InlineLink'
 export const SpecialSymbolsCallout = () => {
   return (
     <p className="mb-2">
-      Note: If using a connection string, you will need to{' '}
+      Note: If using the Postgres connection string, you will need to{' '}
       <InlineLink href="https://supabase.com/docs/guides/database/postgres/roles#special-symbols-in-passwords">
         percent-encode
       </InlineLink>{' '}
-      the special symbols in the password
+      your password
     </p>
   )
 }

--- a/apps/studio/components/interfaces/ProjectCreation/SpecialSymbolsCallout.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/SpecialSymbolsCallout.tsx
@@ -7,7 +7,7 @@ export const SpecialSymbolsCallout = () => {
       <InlineLink href="https://supabase.com/docs/guides/database/postgres/roles#special-symbols-in-passwords">
         percent-encode
       </InlineLink>{' '}
-      your password
+      the password
     </p>
   )
 }

--- a/apps/studio/components/interfaces/ProjectCreation/SpecialSymbolsCallout.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/SpecialSymbolsCallout.tsx
@@ -1,0 +1,13 @@
+import { InlineLink } from 'components/ui/InlineLink'
+
+export const SpecialSymbolsCallout = () => {
+  return (
+    <p className="mb-2">
+      Note: If using a connection string, you will need to{' '}
+      <InlineLink href="https://supabase.com/docs/guides/database/postgres/roles#special-symbols-in-passwords">
+        percent-encode
+      </InlineLink>{' '}
+      the special symbols in the password
+    </p>
+  )
+}

--- a/apps/studio/pages/new/[slug].tsx
+++ b/apps/studio/pages/new/[slug].tsx
@@ -12,6 +12,7 @@ import { z } from 'zod'
 import { PopoverSeparator } from '@ui/components/shadcn/ui/popover'
 import { components } from 'api-types'
 import { useParams } from 'common'
+import { TelemetryActions } from 'common/telemetry-constants'
 import {
   FreeProjectLimitWarning,
   NotOrganizationOwnerWarning,
@@ -28,6 +29,7 @@ import DisabledWarningDueToIncident from 'components/ui/DisabledWarningDueToInci
 import Panel from 'components/ui/Panel'
 import PartnerManagedResource from 'components/ui/PartnerManagedResource'
 import PasswordStrengthBar from 'components/ui/PasswordStrengthBar'
+import { useAvailableOrioleImageVersion } from 'data/config/project-creation-postgres-versions-query'
 import { useOverdueInvoicesQuery } from 'data/invoices/invoices-overdue-query'
 import { useDefaultRegionQuery } from 'data/misc/get-default-region-query'
 import { useFreeProjectLimitCheckQuery } from 'data/organizations/free-project-limit-check-query'
@@ -38,9 +40,9 @@ import {
   ProjectCreateVariables,
   useProjectCreateMutation,
 } from 'data/projects/project-create-mutation'
-import { TelemetryActions } from 'common/telemetry-constants'
 import { useProjectsQuery } from 'data/projects/projects-query'
 import { useOrgSubscriptionQuery } from 'data/subscriptions/org-subscription-query'
+import { useSendEventMutation } from 'data/telemetry/send-event-mutation'
 import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { withAuth } from 'hooks/misc/withAuth'
 import { useFlag } from 'hooks/ui/useFlag'
@@ -81,8 +83,6 @@ import { Admonition } from 'ui-patterns/admonition'
 import { Input } from 'ui-patterns/DataInputs/Input'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import { InfoTooltip } from 'ui-patterns/info-tooltip'
-import { useAvailableOrioleImageVersion } from 'data/config/project-creation-postgres-versions-query'
-import { useSendEventMutation } from 'data/telemetry/send-event-mutation'
 
 type DesiredInstanceSize = components['schemas']['DesiredInstanceSize']
 
@@ -119,9 +119,8 @@ const FormSchema = z.object({
   }),
   dbPassStrength: z.number(),
   dbPass: z
-    .string({
-      required_error: 'Please enter a database password.',
-    })
+    .string({ required_error: 'Please enter a database password.' })
+    .regex(/^[^@:\/]*$/, 'Passwords cannot include @, :, or / characters')
     .min(1, 'Password is required.'),
   instanceSize: z.string(),
   dataApi: z.boolean(),

--- a/apps/studio/pages/new/[slug].tsx
+++ b/apps/studio/pages/new/[slug].tsx
@@ -26,6 +26,7 @@ import { RegionSelector } from 'components/interfaces/ProjectCreation/RegionSele
 import { SecurityOptions } from 'components/interfaces/ProjectCreation/SecurityOptions'
 import { WizardLayoutWithoutAuth } from 'components/layouts/WizardLayout'
 import DisabledWarningDueToIncident from 'components/ui/DisabledWarningDueToIncident'
+import { InlineLink } from 'components/ui/InlineLink'
 import Panel from 'components/ui/Panel'
 import PartnerManagedResource from 'components/ui/PartnerManagedResource'
 import PasswordStrengthBar from 'components/ui/PasswordStrengthBar'
@@ -120,7 +121,6 @@ const FormSchema = z.object({
   dbPassStrength: z.number(),
   dbPass: z
     .string({ required_error: 'Please enter a database password.' })
-    .regex(/^[^@:\/]*$/, 'Passwords cannot include @, :, or / characters')
     .min(1, 'Password is required.'),
   instanceSize: z.string(),
   dataApi: z.boolean(),
@@ -778,41 +778,58 @@ const Wizard: NextPageWithLayout = () => {
                       <FormField_Shadcn_
                         control={form.control}
                         name="dbPass"
-                        render={({ field }) => (
-                          <FormItemLayout
-                            label="Database Password"
-                            layout="horizontal"
-                            description={
-                              <PasswordStrengthBar
-                                passwordStrengthScore={form.getValues('dbPassStrength')}
-                                password={field.value}
-                                passwordStrengthMessage={passwordStrengthMessage}
-                                generateStrongPassword={generatePassword}
-                              />
-                            }
-                          >
-                            <FormControl_Shadcn_>
-                              <Input
-                                copy={field.value.length > 0}
-                                type="password"
-                                placeholder="Type in a strong password"
-                                {...field}
-                                autoComplete="off"
-                                onChange={async (event) => {
-                                  field.onChange(event)
-                                  form.trigger('dbPassStrength')
-                                  const value = event.target.value
-                                  if (event.target.value === '') {
-                                    await form.setValue('dbPassStrength', 0)
-                                    await form.trigger('dbPass')
-                                  } else {
-                                    await delayedCheckPasswordStrength(value)
-                                  }
-                                }}
-                              />
-                            </FormControl_Shadcn_>
-                          </FormItemLayout>
-                        )}
+                        render={({ field }) => {
+                          const regex = /^[^@:\/]*$/
+                          const hasSpecialCharacters =
+                            field.value.length > 0 && !field.value.match(regex)
+
+                          return (
+                            <FormItemLayout
+                              label="Database Password"
+                              layout="horizontal"
+                              description={
+                                <>
+                                  {hasSpecialCharacters && (
+                                    <p className="mb-2">
+                                      Note: Special symbols need to be{' '}
+                                      <InlineLink href="https://supabase.com/docs/guides/database/postgres/roles#special-symbols-in-passwords">
+                                        percent-encoded
+                                      </InlineLink>{' '}
+                                      when using your password later in Postgres connection strings
+                                    </p>
+                                  )}
+                                  <PasswordStrengthBar
+                                    passwordStrengthScore={form.getValues('dbPassStrength')}
+                                    password={field.value}
+                                    passwordStrengthMessage={passwordStrengthMessage}
+                                    generateStrongPassword={generatePassword}
+                                  />
+                                </>
+                              }
+                            >
+                              <FormControl_Shadcn_>
+                                <Input
+                                  copy={field.value.length > 0}
+                                  type="password"
+                                  placeholder="Type in a strong password"
+                                  {...field}
+                                  autoComplete="off"
+                                  onChange={async (event) => {
+                                    field.onChange(event)
+                                    form.trigger('dbPassStrength')
+                                    const value = event.target.value
+                                    if (event.target.value === '') {
+                                      await form.setValue('dbPassStrength', 0)
+                                      await form.trigger('dbPass')
+                                    } else {
+                                      await delayedCheckPasswordStrength(value)
+                                    }
+                                  }}
+                                />
+                              </FormControl_Shadcn_>
+                            </FormItemLayout>
+                          )
+                        }}
                       />
                     </Panel.Content>
 

--- a/apps/studio/pages/new/[slug].tsx
+++ b/apps/studio/pages/new/[slug].tsx
@@ -22,11 +22,12 @@ import {
   PostgresVersionSelector,
   extractPostgresVersionDetails,
 } from 'components/interfaces/ProjectCreation/PostgresVersionSelector'
+import { SPECIAL_CHARS_REGEX } from 'components/interfaces/ProjectCreation/ProjectCreation.constants'
 import { RegionSelector } from 'components/interfaces/ProjectCreation/RegionSelector'
 import { SecurityOptions } from 'components/interfaces/ProjectCreation/SecurityOptions'
+import { SpecialSymbolsCallout } from 'components/interfaces/ProjectCreation/SpecialSymbolsCallout'
 import { WizardLayoutWithoutAuth } from 'components/layouts/WizardLayout'
 import DisabledWarningDueToIncident from 'components/ui/DisabledWarningDueToIncident'
-import { InlineLink } from 'components/ui/InlineLink'
 import Panel from 'components/ui/Panel'
 import PartnerManagedResource from 'components/ui/PartnerManagedResource'
 import PasswordStrengthBar from 'components/ui/PasswordStrengthBar'
@@ -779,9 +780,8 @@ const Wizard: NextPageWithLayout = () => {
                         control={form.control}
                         name="dbPass"
                         render={({ field }) => {
-                          const regex = /^[^@:\/]*$/
                           const hasSpecialCharacters =
-                            field.value.length > 0 && !field.value.match(regex)
+                            field.value.length > 0 && !field.value.match(SPECIAL_CHARS_REGEX)
 
                           return (
                             <FormItemLayout
@@ -789,15 +789,7 @@ const Wizard: NextPageWithLayout = () => {
                               layout="horizontal"
                               description={
                                 <>
-                                  {hasSpecialCharacters && (
-                                    <p className="mb-2">
-                                      Note: If using a connection string, you will need to{' '}
-                                      <InlineLink href="https://supabase.com/docs/guides/database/postgres/roles#special-symbols-in-passwords">
-                                        percent-encode
-                                      </InlineLink>{' '}
-                                      the special symbols in the password
-                                    </p>
-                                  )}
+                                  {hasSpecialCharacters && <SpecialSymbolsCallout />}
                                   <PasswordStrengthBar
                                     passwordStrengthScore={form.getValues('dbPassStrength')}
                                     password={field.value}

--- a/apps/studio/pages/new/[slug].tsx
+++ b/apps/studio/pages/new/[slug].tsx
@@ -791,11 +791,11 @@ const Wizard: NextPageWithLayout = () => {
                                 <>
                                   {hasSpecialCharacters && (
                                     <p className="mb-2">
-                                      Note: Special symbols need to be{' '}
+                                      Note: If using a connection string, you will need to{' '}
                                       <InlineLink href="https://supabase.com/docs/guides/database/postgres/roles#special-symbols-in-passwords">
-                                        percent-encoded
+                                        percent-encode
                                       </InlineLink>{' '}
-                                      when using your password later in Postgres connection strings
+                                      the special symbols in the password
                                     </p>
                                   )}
                                   <PasswordStrengthBar

--- a/apps/studio/pages/new/v2/[slug].tsx
+++ b/apps/studio/pages/new/v2/[slug].tsx
@@ -725,12 +725,12 @@ const WizardForm = () => {
                                             <>
                                               {hasSpecialCharacters && (
                                                 <p className="mb-2">
-                                                  Note: Special symbols need to be{' '}
+                                                  Note: If using a connection string, you will need
+                                                  to{' '}
                                                   <InlineLink href="https://supabase.com/docs/guides/database/postgres/roles#special-symbols-in-passwords">
-                                                    percent-encoded
+                                                    percent-encode
                                                   </InlineLink>{' '}
-                                                  when using your password later in Postgres
-                                                  connection strings
+                                                  the special symbols in the password
                                                 </p>
                                               )}
                                               <PasswordStrengthBar

--- a/apps/studio/pages/new/v2/[slug].tsx
+++ b/apps/studio/pages/new/v2/[slug].tsx
@@ -25,14 +25,15 @@ import {
   PostgresVersionSelector,
   extractPostgresVersionDetails,
 } from 'components/interfaces/ProjectCreation/PostgresVersionSelector'
+import { SPECIAL_CHARS_REGEX } from 'components/interfaces/ProjectCreation/ProjectCreation.constants'
 import { ProjectVisual } from 'components/interfaces/ProjectCreation/ProjectVisual'
 import { RegionSelector } from 'components/interfaces/ProjectCreation/RegionSelector'
 import { SchemaGenerator } from 'components/interfaces/ProjectCreation/SchemaGenerator'
 import { SecurityOptions } from 'components/interfaces/ProjectCreation/SecurityOptions'
+import { SpecialSymbolsCallout } from 'components/interfaces/ProjectCreation/SpecialSymbolsCallout'
 import { FeedbackDropdown } from 'components/layouts/ProjectLayout/LayoutHeader/FeedbackDropdown'
 import HelpPopover from 'components/layouts/ProjectLayout/LayoutHeader/HelpPopover'
 import DisabledWarningDueToIncident from 'components/ui/DisabledWarningDueToIncident'
-import { InlineLink } from 'components/ui/InlineLink'
 import PartnerManagedResource from 'components/ui/PartnerManagedResource'
 import PasswordStrengthBar from 'components/ui/PasswordStrengthBar'
 import { ScrollGradient } from 'components/ui/ScrollGradient'
@@ -714,25 +715,16 @@ const WizardForm = () => {
                                     control={form.control}
                                     name="dbPass"
                                     render={({ field }) => {
-                                      const regex = /^[^@:\/]*$/
                                       const hasSpecialCharacters =
-                                        field.value.length > 0 && !field.value.match(regex)
+                                        field.value.length > 0 &&
+                                        !field.value.match(SPECIAL_CHARS_REGEX)
 
                                       return (
                                         <FormItemLayout
                                           label="Database Password"
                                           description={
                                             <>
-                                              {hasSpecialCharacters && (
-                                                <p className="mb-2">
-                                                  Note: If using a connection string, you will need
-                                                  to{' '}
-                                                  <InlineLink href="https://supabase.com/docs/guides/database/postgres/roles#special-symbols-in-passwords">
-                                                    percent-encode
-                                                  </InlineLink>{' '}
-                                                  the special symbols in the password
-                                                </p>
-                                              )}
+                                              {hasSpecialCharacters && <SpecialSymbolsCallout />}
                                               <PasswordStrengthBar
                                                 passwordStrengthScore={form.getValues(
                                                   'dbPassStrength'

--- a/apps/studio/pages/new/v2/[slug].tsx
+++ b/apps/studio/pages/new/v2/[slug].tsx
@@ -32,6 +32,7 @@ import { SecurityOptions } from 'components/interfaces/ProjectCreation/SecurityO
 import { FeedbackDropdown } from 'components/layouts/ProjectLayout/LayoutHeader/FeedbackDropdown'
 import HelpPopover from 'components/layouts/ProjectLayout/LayoutHeader/HelpPopover'
 import DisabledWarningDueToIncident from 'components/ui/DisabledWarningDueToIncident'
+import { InlineLink } from 'components/ui/InlineLink'
 import PartnerManagedResource from 'components/ui/PartnerManagedResource'
 import PasswordStrengthBar from 'components/ui/PasswordStrengthBar'
 import { ScrollGradient } from 'components/ui/ScrollGradient'
@@ -129,7 +130,6 @@ const FormSchema = z.object({
   dbPassStrength: z.number(),
   dbPass: z
     .string({ required_error: 'Please enter a database password.' })
-    .regex(/^[^@:\/]*$/, 'Passwords cannot include @, :, or / characters')
     .min(1, 'Password is required.'),
   instanceSize: z.string(),
   dataApi: z.boolean(),
@@ -713,40 +713,60 @@ const WizardForm = () => {
                                   <FormField_Shadcn_
                                     control={form.control}
                                     name="dbPass"
-                                    render={({ field }) => (
-                                      <FormItemLayout
-                                        label="Database Password"
-                                        description={
-                                          <PasswordStrengthBar
-                                            passwordStrengthScore={form.getValues('dbPassStrength')}
-                                            password={field.value}
-                                            passwordStrengthMessage={passwordStrengthMessage}
-                                            generateStrongPassword={generatePassword}
-                                          />
-                                        }
-                                      >
-                                        <FormControl_Shadcn_>
-                                          <Input
-                                            copy={field.value.length > 0}
-                                            type="password"
-                                            placeholder="Type in a strong password"
-                                            {...field}
-                                            autoComplete="off"
-                                            onChange={async (event) => {
-                                              field.onChange(event)
-                                              form.trigger('dbPassStrength')
-                                              const value = event.target.value
-                                              if (event.target.value === '') {
-                                                await form.setValue('dbPassStrength', 0)
-                                                await form.trigger('dbPass')
-                                              } else {
-                                                await delayedCheckPasswordStrength(value)
-                                              }
-                                            }}
-                                          />
-                                        </FormControl_Shadcn_>
-                                      </FormItemLayout>
-                                    )}
+                                    render={({ field }) => {
+                                      const regex = /^[^@:\/]*$/
+                                      const hasSpecialCharacters =
+                                        field.value.length > 0 && !field.value.match(regex)
+
+                                      return (
+                                        <FormItemLayout
+                                          label="Database Password"
+                                          description={
+                                            <>
+                                              {hasSpecialCharacters && (
+                                                <p className="mb-2">
+                                                  Note: Special symbols need to be{' '}
+                                                  <InlineLink href="https://supabase.com/docs/guides/database/postgres/roles#special-symbols-in-passwords">
+                                                    percent-encoded
+                                                  </InlineLink>{' '}
+                                                  when using your password later in Postgres
+                                                  connection strings
+                                                </p>
+                                              )}
+                                              <PasswordStrengthBar
+                                                passwordStrengthScore={form.getValues(
+                                                  'dbPassStrength'
+                                                )}
+                                                password={field.value}
+                                                passwordStrengthMessage={passwordStrengthMessage}
+                                                generateStrongPassword={generatePassword}
+                                              />
+                                            </>
+                                          }
+                                        >
+                                          <FormControl_Shadcn_>
+                                            <Input
+                                              copy={field.value.length > 0}
+                                              type="password"
+                                              placeholder="Type in a strong password"
+                                              {...field}
+                                              autoComplete="off"
+                                              onChange={async (event) => {
+                                                field.onChange(event)
+                                                form.trigger('dbPassStrength')
+                                                const value = event.target.value
+                                                if (event.target.value === '') {
+                                                  await form.setValue('dbPassStrength', 0)
+                                                  await form.trigger('dbPass')
+                                                } else {
+                                                  await delayedCheckPasswordStrength(value)
+                                                }
+                                              }}
+                                            />
+                                          </FormControl_Shadcn_>
+                                        </FormItemLayout>
+                                      )
+                                    }}
                                   />
                                 </div>
                                 <div className="py-5 border-t border-b">


### PR DESCRIPTION
Fixes FE-484

Callout when `@`, `:`, and `/` in database passwords that users need to percent-encode them (as they are used as delimiters in postgres connection strings and are a source of confusion where it appears the customer's client side tooling can't connect.)

Generate password function doesnt need updating since it's only alphanumerical

![image](https://github.com/user-attachments/assets/3a880f44-b204-48b0-88d8-b1e1758e0a3c)
