### PR TITLE
Add refresh button to reports

### DIFF
--- a/apps/studio/components/interfaces/Reports/GridResize.tsx
+++ b/apps/studio/components/interfaces/Reports/GridResize.tsx
@@ -29,6 +29,7 @@ interface GridResizeProps {
   interval: AnalyticsInterval
   editableReport: Dashboards.Content
   disableUpdate: boolean
+  isRefreshing: boolean
   onRemoveChart: ({ metric }: { metric: { key: string } }) => void
   onUpdateChart: (
     id: string,
@@ -46,6 +47,7 @@ export const GridResize = ({
   interval,
   editableReport,
   disableUpdate,
+  isRefreshing,
   onRemoveChart,
   onUpdateChart,
   setEditableReport,
@@ -167,6 +169,7 @@ export const GridResize = ({
               endDate={endDate}
               interval={interval}
               disableUpdate={disableUpdate}
+              isRefreshing={isRefreshing}
               onRemoveChart={onRemoveChart}
               onUpdateChart={(config) => onUpdateChart(item.id, config)}
             />

--- a/apps/studio/components/interfaces/Reports/ReportBlock/ChartBlock.tsx
+++ b/apps/studio/components/interfaces/Reports/ReportBlock/ChartBlock.tsx
@@ -1,6 +1,6 @@
 import dayjs from 'dayjs'
 import { useRouter } from 'next/router'
-import { ReactNode, useEffect, useState, useCallback } from 'react'
+import { ReactNode, useCallback, useEffect, useState } from 'react'
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from 'ui'
 
 import { ChartConfig } from 'components/interfaces/SQLEditor/UtilityPanel/ChartConfig'
@@ -66,7 +66,11 @@ export const ChartBlock = ({
 
   const databaseIdentifier = state.selectedDatabaseId
 
-  const { data: dailyStatsData, isLoading: isFetchingDailyStats } = useProjectDailyStatsQuery(
+  const {
+    data: dailyStatsData,
+    isFetching: isFetchingDailyStats,
+    isLoading: isLoadingDailyStats,
+  } = useProjectDailyStatsQuery(
     {
       projectRef: ref as string,
       attribute: attribute as ProjectDailyStatsAttribute,
@@ -78,18 +82,21 @@ export const ChartBlock = ({
     { enabled: provider === 'daily-stats' }
   )
 
-  const { data: infraMonitoringData, isLoading: isFetchingInfraMonitoring } =
-    useInfraMonitoringQuery(
-      {
-        projectRef: ref as string,
-        attribute: attribute as InfraMonitoringAttribute,
-        startDate,
-        endDate,
-        interval: interval as AnalyticsInterval,
-        databaseIdentifier,
-      },
-      { enabled: provider === 'infra-monitoring' }
-    )
+  const {
+    data: infraMonitoringData,
+    isFetching: isFetchingInfraMonitoring,
+    isLoading: isLoadingInfraMonitoring,
+  } = useInfraMonitoringQuery(
+    {
+      projectRef: ref as string,
+      attribute: attribute as InfraMonitoringAttribute,
+      startDate,
+      endDate,
+      interval: interval as AnalyticsInterval,
+      databaseIdentifier,
+    },
+    { enabled: provider === 'infra-monitoring' }
+  )
 
   const chartData =
     provider === 'infra-monitoring'
@@ -98,13 +105,20 @@ export const ChartBlock = ({
         ? dailyStatsData
         : undefined
 
+  const isFetching =
+    provider === 'infra-monitoring'
+      ? isFetchingInfraMonitoring
+      : provider === 'daily-stats'
+        ? isFetchingDailyStats
+        : false
+
   const loading =
     isLoading ||
     attribute.startsWith('new_snippet_') ||
     (provider === 'infra-monitoring'
-      ? isFetchingInfraMonitoring
+      ? isLoadingInfraMonitoring
       : provider === 'daily-stats'
-        ? isFetchingDailyStats
+        ? isLoadingDailyStats
         : isLoading)
 
   const metric = METRICS.find((x) => x.key === attribute)
@@ -165,6 +179,7 @@ export const ChartBlock = ({
     <ReportBlockContainer
       draggable
       showDragHandle
+      loading={isFetching}
       icon={metric?.category?.icon('text-foreground-muted')}
       label={label}
       actions={

--- a/apps/studio/components/interfaces/Reports/ReportBlock/ReportBlock.tsx
+++ b/apps/studio/components/interfaces/Reports/ReportBlock/ReportBlock.tsx
@@ -19,6 +19,7 @@ interface ReportBlockProps {
   endDate: string
   interval: AnalyticsInterval
   disableUpdate: boolean
+  isRefreshing: boolean
   onRemoveChart: ({ metric }: { metric: { key: string } }) => void
   onUpdateChart: ({
     chart,
@@ -35,6 +36,7 @@ export const ReportBlock = ({
   endDate,
   interval,
   disableUpdate,
+  isRefreshing,
   onRemoveChart,
   onUpdateChart,
 }: ReportBlockProps) => {
@@ -71,6 +73,7 @@ export const ReportBlock = ({
           disableRunIfMutation
           id={item.id}
           isLoading={isLoading}
+          isRefreshing={isRefreshing}
           label={item.label}
           chartConfig={chartConfig}
           sql={sql}

--- a/apps/studio/components/interfaces/Reports/ReportBlock/ReportBlockContainer.tsx
+++ b/apps/studio/components/interfaces/Reports/ReportBlock/ReportBlockContainer.tsx
@@ -1,4 +1,4 @@
-import { GripHorizontal } from 'lucide-react'
+import { GripHorizontal, Loader2 } from 'lucide-react'
 import { DragEvent, PropsWithChildren, ReactNode } from 'react'
 import { cn, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
 
@@ -6,6 +6,7 @@ interface ReportBlockContainerProps {
   icon: ReactNode
   label: string
   actions: ReactNode
+  loading?: boolean
   draggable?: boolean
   showDragHandle?: boolean
   tooltip?: ReactNode
@@ -16,6 +17,7 @@ export const ReportBlockContainer = ({
   icon,
   label,
   actions,
+  loading = false,
   draggable = false,
   showDragHandle = false,
   tooltip,
@@ -46,7 +48,14 @@ export const ReportBlockContainer = ({
                 showDragHandle && 'transition-opacity opacity-100 group-hover:opacity-0'
               )}
             >
-              {icon}
+              {loading ? (
+                <Loader2
+                  size={(icon as any)?.props?.size ?? 16}
+                  className="text-foreground-lighter animate-spin"
+                />
+              ) : (
+                icon
+              )}
             </div>
             {showDragHandle && (
               <div className="absolute left-3 top-2.5 z-10 opacity-0 transition-opacity group-hover:opacity-100">

--- a/apps/studio/components/interfaces/Reports/ReportFilterBar.tsx
+++ b/apps/studio/components/interfaces/Reports/ReportFilterBar.tsx
@@ -1,8 +1,9 @@
-import { ChevronDown, Database, Plus, X } from 'lucide-react'
+import { ChevronDown, Database, Plus, RefreshCw, X } from 'lucide-react'
 import { ComponentProps, useState } from 'react'
 import SVG from 'react-inlinesvg'
 
 import { useParams } from 'common'
+import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import DatabaseSelector from 'components/ui/DatabaseSelector'
 import { useLoadBalancersQuery } from 'data/read-replicas/load-balancers-query'
 import { Auth, Realtime, Storage } from 'icons'
@@ -25,8 +26,10 @@ import type { ReportFilterItem } from './Reports.types'
 
 interface ReportFilterBarProps {
   filters: ReportFilterItem[]
+  isLoading: boolean
   onAddFilter: (filter: ReportFilterItem) => void
   onRemoveFilters: (filters: ReportFilterItem[]) => void
+  onRefresh: () => void
   onDatepickerChange: ComponentProps<typeof DatePickers>['onChange']
   datepickerTo?: string
   datepickerFrom?: string
@@ -78,11 +81,13 @@ const PRODUCT_FILTERS = [
 
 const ReportFilterBar = ({
   filters,
+  isLoading = false,
   onAddFilter,
   onDatepickerChange,
   datepickerTo = '',
   datepickerFrom = '',
   onRemoveFilters,
+  onRefresh,
   datepickerHelpers,
 }: ReportFilterBarProps) => {
   const { ref } = useParams()
@@ -138,7 +143,15 @@ const ReportFilterBar = ({
 
   return (
     <div className="flex items-center justify-between">
-      <div className="flex flex-row justify-start items-center flex-wrap gap-2">
+      <div className="flex flex-row justify-start items-center flex-wrap gap-x-2">
+        <ButtonTooltip
+          type="default"
+          disabled={isLoading}
+          icon={<RefreshCw className={isLoading ? 'animate-spin' : ''} />}
+          className="w-7"
+          tooltip={{ content: { side: 'bottom', text: 'Refresh report' } }}
+          onClick={() => onRefresh()}
+        />
         <DatePickers
           onChange={onDatepickerChange}
           to={datepickerTo}

--- a/apps/studio/components/ui/QueryBlock/QueryBlock.tsx
+++ b/apps/studio/components/ui/QueryBlock/QueryBlock.tsx
@@ -82,6 +82,8 @@ interface QueryBlockProps {
   disableRunIfMutation?: boolean
   /** UI to render if there's no query results (Used in Reports) */
   noResultPlaceholder?: ReactNode
+  /** To trigger a refresh of the query */
+  isRefreshing?: boolean
   /** Optional callback whenever a chart configuration is updated (Used in Reports) */
   onUpdateChartConfig?: ({
     chart,
@@ -109,6 +111,7 @@ export const QueryBlock = ({
   runQuery = false,
   lockColumns = false,
   draggable = false,
+  isRefreshing = false,
   disableRunIfMutation = false,
   noResultPlaceholder = null,
   tooltip,
@@ -181,20 +184,25 @@ export const QueryBlock = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sql, isLoading, runQuery, project])
 
+  useEffect(() => {
+    if (isRefreshing) handleExecute()
+  }, [isRefreshing])
+
   return (
     <ReportBlockContainer
       draggable={draggable}
       showDragHandle={draggable}
       tooltip={tooltip}
+      loading={isExecuting}
       onDragStart={(e: DragEvent<Element>) => onDragStart?.(e)}
       icon={
         <SQL_ICON
+          size={18}
+          strokeWidth={1.5}
           className={cn(
             'transition-colors fill-foreground-muted group-aria-selected:fill-foreground',
             'w-5 h-5 shrink-0 grow-0 -ml-0.5'
           )}
-          size={16}
-          strokeWidth={1.5}
         />
       }
       label={label}

--- a/apps/studio/data/analytics/keys.ts
+++ b/apps/studio/data/analytics/keys.ts
@@ -124,6 +124,8 @@ export const analyticsKeys = {
         projectRef,
       },
     ] as const,
+  allInfraMonitoring: (projectRef?: string) =>
+    ['projects', projectRef, 'infra-monitoring'] as const,
   infraMonitoring: (
     projectRef: string | undefined,
     {

--- a/apps/studio/data/analytics/keys.ts
+++ b/apps/studio/data/analytics/keys.ts
@@ -124,8 +124,6 @@ export const analyticsKeys = {
         projectRef,
       },
     ] as const,
-  allInfraMonitoring: (projectRef?: string) =>
-    ['projects', projectRef, 'infra-monitoring'] as const,
   infraMonitoring: (
     projectRef: string | undefined,
     {

--- a/apps/studio/data/reports/database-report-query.ts
+++ b/apps/studio/data/reports/database-report-query.ts
@@ -27,5 +27,6 @@ export const useDatabaseReport = () => {
     },
     largeObjectsSql: largeObjects.resolvedSql,
     isLoading,
+    refresh: () => largeObjects.runQuery,
   }
 }

--- a/apps/studio/pages/project/[ref]/reports/api-overview.tsx
+++ b/apps/studio/pages/project/[ref]/reports/api-overview.tsx
@@ -22,11 +22,23 @@ export const ApiReport: NextPageWithLayout = () => {
   const report = useApiReport()
   const organization = useSelectedOrganization()
 
+  const {
+    data,
+    error,
+    filters,
+    isLoading,
+    params,
+    mergeParams,
+    removeFilters,
+    addFilter,
+    refresh,
+  } = report
+
   const { data: subscription } = useOrgSubscriptionQuery({ orgSlug: organization?.slug })
   const plan = subscription?.plan
 
   const handleDatepickerChange = ({ from, to }: DatePickerToFrom) => {
-    report.mergeParams({
+    mergeParams({
       iso_timestamp_start: from || '',
       iso_timestamp_end: to || '',
     })
@@ -37,65 +49,67 @@ export const ApiReport: NextPageWithLayout = () => {
       <ReportHeader title="API" />
       <div className="w-full flex flex-col gap-1">
         <ReportFilterBar
-          onRemoveFilters={report.removeFilters}
+          onRemoveFilters={removeFilters}
           onDatepickerChange={handleDatepickerChange}
-          datepickerFrom={report.params.totalRequests.iso_timestamp_start}
-          datepickerTo={report.params.totalRequests.iso_timestamp_end}
-          onAddFilter={report.addFilter}
-          filters={report.filters}
+          datepickerFrom={params.totalRequests.iso_timestamp_start}
+          datepickerTo={params.totalRequests.iso_timestamp_end}
+          onAddFilter={addFilter}
+          onRefresh={refresh}
+          isLoading={isLoading}
+          filters={filters}
           datepickerHelpers={REPORTS_DATEPICKER_HELPERS.map((helper, index) => ({
             ...helper,
             disabled: (index > 0 && plan?.id === 'free') || (index > 1 && plan?.id !== 'pro'),
           }))}
         />
         <div className="h-2 w-full">
-          <ShimmerLine active={report.isLoading} />
+          <ShimmerLine active={isLoading} />
         </div>
       </div>
 
       <ReportWidget
-        isLoading={report.isLoading}
-        params={report.params.totalRequests}
+        isLoading={isLoading}
+        params={params.totalRequests}
         title="Total Requests"
-        data={report.data.totalRequests || []}
-        error={report.error.totalRequest}
+        data={data.totalRequests || []}
+        error={error.totalRequest}
         renderer={TotalRequestsChartRenderer}
         append={TopApiRoutesRenderer}
-        appendProps={{ data: report.data.topRoutes || [], params: report.params.topRoutes }}
+        appendProps={{ data: data.topRoutes || [], params: params.topRoutes }}
       />
       <ReportWidget
-        isLoading={report.isLoading}
-        params={report.params.errorCounts}
+        isLoading={isLoading}
+        params={params.errorCounts}
         title="Response Errors"
         tooltip="Error responses with 4XX or 5XX status codes"
-        data={report.data.errorCounts || []}
-        error={report.error.errorCounts}
+        data={data.errorCounts || []}
+        error={error.errorCounts}
         renderer={ErrorCountsChartRenderer}
         appendProps={{
-          data: report.data.topErrorRoutes || [],
-          params: report.params.topErrorRoutes,
+          data: data.topErrorRoutes || [],
+          params: params.topErrorRoutes,
         }}
         append={TopApiRoutesRenderer}
       />
       <ReportWidget
-        isLoading={report.isLoading}
-        params={report.params.responseSpeed}
+        isLoading={isLoading}
+        params={params.responseSpeed}
         title="Response Speed"
         tooltip="Average response speed (in miliseconds) of a request"
-        data={report.data.responseSpeed || []}
-        error={report.error.responseSpeed}
+        data={data.responseSpeed || []}
+        error={error.responseSpeed}
         renderer={ResponseSpeedChartRenderer}
-        appendProps={{ data: report.data.topSlowRoutes || [], params: report.params.topSlowRoutes }}
+        appendProps={{ data: data.topSlowRoutes || [], params: params.topSlowRoutes }}
         append={TopApiRoutesRenderer}
       />
 
       <ReportWidget
-        isLoading={report.isLoading}
-        params={report.params.networkTraffic}
-        error={report.error.networkTraffic}
+        isLoading={isLoading}
+        params={params.networkTraffic}
+        error={error.networkTraffic}
         title="Network Traffic"
         tooltip="Ingress and egress of requests and responses respectively"
-        data={report.data.networkTraffic || []}
+        data={data.networkTraffic || []}
         renderer={NetworkTrafficRenderer}
       />
     </ReportPadding>

--- a/apps/studio/pages/project/[ref]/reports/storage.tsx
+++ b/apps/studio/pages/project/[ref]/reports/storage.tsx
@@ -11,15 +11,19 @@ import {
 import DatePickers from 'components/interfaces/Settings/Logs/Logs.DatePickers'
 import type { DatePickerToFrom } from 'components/interfaces/Settings/Logs/Logs.types'
 import ReportsLayout from 'components/layouts/ReportsLayout/ReportsLayout'
+import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import ShimmerLine from 'components/ui/ShimmerLine'
 import { useStorageReport } from 'data/reports/storage-report-query'
 import { useOrgSubscriptionQuery } from 'data/subscriptions/org-subscription-query'
 import { useSelectedOrganization } from 'hooks/misc/useSelectedOrganization'
+import { RefreshCw } from 'lucide-react'
 import type { NextPageWithLayout } from 'types'
 
 export const StorageReport: NextPageWithLayout = () => {
   const report = useStorageReport()
   const organization = useSelectedOrganization()
+
+  const { isLoading, refresh } = report
 
   const { data: subscription } = useOrgSubscriptionQuery({ orgSlug: organization?.slug })
   const plan = subscription?.plan
@@ -44,7 +48,15 @@ export const StorageReport: NextPageWithLayout = () => {
     <ReportPadding>
       <ReportHeader title="Storage" />
       <div className="w-full flex flex-col gap-1">
-        <div>
+        <div className="flex items-center gap-x-2">
+          <ButtonTooltip
+            type="default"
+            disabled={isLoading}
+            icon={<RefreshCw className={isLoading ? 'animate-spin' : ''} />}
+            className="w-7"
+            tooltip={{ content: { side: 'bottom', text: 'Refresh report' } }}
+            onClick={() => refresh()}
+          />
           <DatePickers
             onChange={handleDatepickerChange}
             to={report.params.cacheHitRate.iso_timestamp_end || ''}


### PR DESCRIPTION
Quick heads up for Custom Reports and Database reports:
- These trigger the refreshes asynchronously so the "loading" state of the refresh button is just 1 second and not dependent on the actual loading state of the charts, because the parent component is unable to track the loading state
- Verified locally that each refresh button triggers the corresponding RQs to invalidate

Custom reports:
![image](https://github.com/user-attachments/assets/5b7834ce-1477-4fc0-b9d7-a37b682b09ae)

API report:
![image](https://github.com/user-attachments/assets/64600dc2-6c6b-4a61-8275-edf80aaa3279)

Storage report:
![image](https://github.com/user-attachments/assets/ebd0838c-c7fc-441c-a074-ac2c130d4933)

Database report:
![image](https://github.com/user-attachments/assets/5ba87d5c-21a8-40e3-948d-8812fba5526b)

