### PR TITLE
Billing docs revamp - Read Replica Usage

### DIFF
--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
@@ -2111,6 +2111,10 @@ export const platform: NavMenuConstant = {
               name: 'Branching',
               url: '/guides/platform/manage-your-usage/branching',
             },
+            {
+              name: 'Read Replicas',
+              url: '/guides/platform/manage-your-usage/read-replicas',
+            },
           ],
         },
         {

--- a/apps/docs/content/guides/platform/manage-your-usage.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage.mdx
@@ -7,3 +7,4 @@ Each subpage breaks down a specific usage item and details what you're charged f
 
 - [Compute](/docs/guides/platform/manage-your-usage/compute)
 - [Branching](/docs/guides/platform/manage-your-usage/branching)
+- [Read Replicas](/docs/guides/platform/manage-your-usage/read-replicas)

--- a/apps/docs/content/guides/platform/manage-your-usage/branching.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/branching.mdx
@@ -58,9 +58,9 @@ In the Usage Summary section, you can see how many hours your Preview branches e
 />
 
 ## Optimize Branching usage
-- merge Preview branches as soon as they are ready
-- delete Preview branches that are no longer in use
-- check whether your [persistent branches](/docs/guides/deployment/branching#persistent-branches) need to be defined as persistent, or if they can be ephemeral instead. Persistent branches will remain active even after the underlying PR is closed.
+- Merge Preview branches as soon as they are ready
+- Delete Preview branches that are no longer in use
+- Check whether your [persistent branches](/docs/guides/deployment/branching#persistent-branches) need to be defined as persistent, or if they can be ephemeral instead. Persistent branches will remain active even after the underlying PR is closed.
 
 ## Branching FAQ
 ### Do Compute Credits apply to Branching Compute?

--- a/apps/docs/content/guides/platform/manage-your-usage/branching.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/branching.mdx
@@ -12,7 +12,7 @@ Usage by Preview branches counts toward your subscription plan's free quota.
 Refer to individual [usage items](/docs/guides/platform/manage-your-usage) for details on how charges are calculated. Branching charges are the sum of all these items.
 
 ### Branching usage on your invoice
-Compute incurred by Preview branches is shown as "Branching Compute Hours" on your invoice. Other usage items are not shown separately for branches.
+Compute incurred by Preview branches is shown as "Branching Compute Hours" on your invoice. Other usage items are not shown separately for branches and are rolled up into the project.
 
 ## Pricing
 There is no fixed fee for a Preview branch. You only pay for the usage it incurs. With Compute costs of $0.01344 per hour, a branch running on Micro Compute size starts at $0.32 per day.

--- a/apps/docs/content/guides/platform/manage-your-usage/read-replicas.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/read-replicas.mdx
@@ -1,0 +1,75 @@
+---
+id: 'manage-usage-read-replicas'
+title: 'Manage Read Replica usage'
+---
+
+## What you are charged for
+Each [Read Replica](/docs/guides/platform/read-replicas) is a dedicated database. You are charged for its resources: [Compute](/docs/guides/platform/compute-and-disk#compute), [Disk Size](/docs/guides/platform/database-size#disk-size), provisioned [Disk IOPS](/docs/guides/platform/compute-and-disk#provisioned-disk-throughput-and-iops), provisioned [Disk Throughput](/docs/guides/platform/compute-and-disk#provisioned-disk-throughput-and-iops), and [IPv4](/docs/guides/platform/ipv4-address).
+
+## How charges are calculated
+Read Replica charges are the total of the charges listed below.
+
+**Compute**
+Compute is charged by the hour, meaning you are charged for the exact number of hours that a Read Replica is running and, therefore, incurring Compute resources. If a Read Replica runs for part of an hour, you are still charged for the full hour.
+
+Read Replicas run on the same Compute size as the primary database.
+
+**Disk Size**
+Refer to [Manage Disk Size usage]() for details on how charges are calculated. The disk size of a Read Replica is 1.25x the size of the primary disk to account for WAL archives. With a Read Replica you go beyond the subscription plan's free quota for Disk Size.
+
+**Provisioned Disk IOPS (optional)**
+Read Replicas inherit any additional provisioned Disk IOPS from the primary database. Refer to [Manage Disk IOPS usage]() for details on how charges are calculated.
+
+**Provisioned Disk Throughput (optional)**
+Read Replicas inherit any additional provisioned Disk Throughput from the primary database. Refer to [Manage Disk Throughput usage]() for details on how charges are calculated.
+
+**IPv4 (optional)**
+If the primary database has a configured IPv4 address, its Read Replicas are also assigned one, with charges for each. Refer to [Manage IPv4 usage]() for details on how charges are calculated.
+
+### Read Replica usage on your invoice
+Compute incurred by Read Replicas is shown as "Replica Compute Hours" on your invoice. Disk Size, Disk IOPS, Disk Throughput and IPv4 are not shown separately for Read Replicas.
+
+## Billing examples
+### No additional resources configured
+The project has no IPv4 and no additional Disk IOPS and Disk Throughput configured.
+
+| Line Item                     | Units     | Costs      |
+|-------------------------------|-----------|------------|
+| Pro Plan                      | 1         | $25        |
+|                               |           |            |
+| Compute Hours Small Project 1 | 744 hours | $15        |
+| Disk Size Project 1           | 8 GB      | $0         |
+|                               |           |            |
+| Compute Hours Small Replica   | 744 hours | $15        |
+| Disk Size Replica             | 10 GB     | $1.27      |
+|                               |           |            |
+| **Subtotal**                  |           | **$56.27** |
+| Compute Credits               |           | -$10       |
+| **Total**                     |           | **$46.27** |
+
+### Additional resources configured
+The project has IPv4 and additional Disk IOPS and Disk Throughput configured.
+
+| Line Item                     | Units     | Costs       |
+|-------------------------------|-----------|-------------|
+| Pro Plan                      | 1         | $25         |
+|                               |           |             |
+| Compute Hours Large Project 1 | 744 hours | $110        |
+| Disk Size Project 1           | 8 GB      | $0          |
+| Disk IOPS Project 1           | 3600      | $14.40      |
+| Disk Throughput Project 1     | 200 MiB/s | $7.13       |
+| IPv4 Project 1                | 1         | $4          |
+|                               |           |             |
+| Compute Hours Large Replica   | 744 hours | $110        |
+| Disk Size Replica             | 10 GB     | $1.27       |
+| Disk IOPS Replica             | 3600      | $14.40      |
+| Disk Throughput Replica       | 200 MiB/s | $7.13       |
+| IPv4 Replica                  | 1         | $4          |
+|                               |           |             |
+| **Subtotal**                  |           | **$297.33** |
+| Compute Credits               |           | -$10        |
+| **Total**                     |           | **$287.33** |
+
+## Read Replica FAQ
+### Do Compute Credits apply to Read Replica Compute?
+No, Compute Credits do not apply to Read Replica Compute

--- a/apps/docs/content/guides/platform/manage-your-usage/read-replicas.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/read-replicas.mdx
@@ -31,7 +31,7 @@ Compute incurred by Read Replicas is shown as "Replica Compute Hours" on your in
 
 ## Billing examples
 ### No additional resources configured
-The project has no IPv4 and no additional Disk IOPS and Disk Throughput configured.
+The project has one Read Replica and no IPv4 and no additional Disk IOPS and Disk Throughput configured.
 
 | Line Item                     | Units     | Costs      |
 |-------------------------------|-----------|------------|
@@ -48,7 +48,7 @@ The project has no IPv4 and no additional Disk IOPS and Disk Throughput configur
 | **Total**                     |           | **$46.27** |
 
 ### Additional resources configured
-The project has IPv4 and additional Disk IOPS and Disk Throughput configured.
+The project two Read Replicas and IPv4 and additional Disk IOPS and Disk Throughput configured.
 
 | Line Item                     | Units     | Costs       |
 |-------------------------------|-----------|-------------|
@@ -60,15 +60,21 @@ The project has IPv4 and additional Disk IOPS and Disk Throughput configured.
 | Disk Throughput Project 1     | 200 MiB/s | $7.13       |
 | IPv4 Project 1                | 1         | $4          |
 |                               |           |             |
-| Compute Hours Large Replica   | 744 hours | $110        |
-| Disk Size Replica             | 10 GB     | $1.27       |
-| Disk IOPS Replica             | 3600      | $14.40      |
-| Disk Throughput Replica       | 200 MiB/s | $7.13       |
-| IPv4 Replica                  | 1         | $4          |
+| Compute Hours Large Replica 1 | 744 hours | $110        |
+| Disk Size Replica 1           | 10 GB     | $1.27       |
+| Disk IOPS Replica 1           | 3600      | $14.40      |
+| Disk Throughput Replica 1     | 200 MiB/s | $7.13       |
+| IPv4 Replica 1                | 1         | $4          |
 |                               |           |             |
-| **Subtotal**                  |           | **$297.33** |
+| Compute Hours Large Replica 2 | 744 hours | $110        |
+| Disk Size Replica 2           | 10 GB     | $1.27       |
+| Disk IOPS Replica 2           | 3600      | $14.40      |
+| Disk Throughput Replica 2     | 200 MiB/s | $7.13       |
+| IPv4 Replica 2                | 1         | $4          |
+|                               |           |             |
+| **Subtotal**                  |           | **$434.13** |
 | Compute Credits               |           | -$10        |
-| **Total**                     |           | **$287.33** |
+| **Total**                     |           | **$424.13** |
 
 ## Read Replica FAQ
 ### Do Compute Credits apply to Read Replica Compute?

--- a/apps/docs/content/guides/platform/manage-your-usage/read-replicas.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/read-replicas.mdx
@@ -72,4 +72,4 @@ The project has IPv4 and additional Disk IOPS and Disk Throughput configured.
 
 ## Read Replica FAQ
 ### Do Compute Credits apply to Read Replica Compute?
-No, Compute Credits do not apply to Read Replica Compute
+No, Compute Credits do not apply to Read Replica Compute.

--- a/apps/docs/content/guides/platform/manage-your-usage/read-replicas.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/read-replicas.mdx
@@ -27,7 +27,7 @@ Read Replicas inherit any additional provisioned Disk Throughput from the primar
 If the primary database has a configured IPv4 address, its Read Replicas are also assigned one, with charges for each. Refer to [Manage IPv4 usage]() for details on how charges are calculated.
 
 ### Read Replica usage on your invoice
-Compute incurred by Read Replicas is shown as "Replica Compute Hours" on your invoice. Disk Size, Disk IOPS, Disk Throughput and IPv4 are not shown separately for Read Replicas.
+Compute incurred by Read Replicas is shown as "Replica Compute Hours" on your invoice. Disk Size, Disk IOPS, Disk Throughput and IPv4 are not shown separately for Read Replicas and are rolled up into the project.
 
 ## Billing examples
 ### No additional resources configured


### PR DESCRIPTION
- like "Branching", we might move this page somewhere else since it's not a usage item / metric on its own but actually a combination of different items / metrics
- didn't include a "View Read Replica uage" section. In my opinion we don't have a place at the moment where you can clearly see all usage (Compute, Disk Size, IOPS etc.) incurred by Read Replicas.
- didn't include a "Optimize Read Replica usage" section since Read Replicas are strongly "tied" to the primary