### PR TITLE
Chore/esc cron names

### DIFF
--- a/apps/studio/components/interfaces/Integrations/CronJobs/CronJobCard.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CronJobCard.tsx
@@ -102,7 +102,11 @@ export const CronJobCard = ({ job, onEditCronJob, onDeleteCronJob }: CronJobCard
                   })
                 }}
               >
-                <Link href={`/project/${ref}/integrations/cron/jobs/${job.jobname}`}>History</Link>
+                <Link
+                  href={`/project/${ref}/integrations/cron/jobs/${encodeURIComponent(job.jobname)}`}
+                >
+                  History
+                </Link>
               </Button>
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>

--- a/apps/studio/components/interfaces/Integrations/CronJobs/CronJobs.utils.ts
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CronJobs.utils.ts
@@ -5,8 +5,9 @@ import dayjs from 'dayjs'
 import { CronJobType } from './CreateCronJobSheet'
 import { HTTPHeader } from './CronJobs.constants'
 
-export const buildCronQuery = (name: string, schedule: string, command: string) => {
-  return `select cron.schedule('${name}','${schedule}',${command});`
+export function buildCronQuery(name: string, schedule: string, command: string) {
+  const escapedName = name.replace(/'/g, "''")
+  return `select cron.schedule('${escapedName}', '${schedule}', ${command});`
 }
 
 export const buildHttpRequestCommand = (


### PR DESCRIPTION
Allow apostrophes in cron job names

Update: should also allow other special characters, since you can add whatever you want via sql 

Example to reproduce: 
- try creating this job via sql 
- SELECT cron.schedule('Backup /logs/ + daily', '0 3 * * *', 'VACUUM'); 
- the History view for this job should work 


![screenshot-2025-01-31-at-12 44 32](https://github.com/user-attachments/assets/979f008b-43e1-4f49-908f-46f793371d2d)
