### PR TITLE
make children of DrilldownPane to follow scroll

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/JsonEditor/DrilldownViewer/DrilldownPane.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/JsonEditor/DrilldownViewer/DrilldownPane.tsx
@@ -41,42 +41,44 @@ const DrilldownPane = ({ pane, jsonData, activeKey, onSelectKey = noop }: Drilld
 
   return (
     <div className={`max-w-[50%] flex-1 ${pane === 2 ? 'border-l border-default' : ''}`}>
-      {keysWithChildren.map((key: string) => (
-        <div
-          key={key}
-          className={`
+      <div className="fixed">
+        {keysWithChildren.map((key: string) => (
+          <div
+            key={key}
+            className={`
               ${key === activeKey ? 'bg-surface-300' : ''}
               group flex cursor-pointer items-center transition
               justify-between py-2 px-5 hover:bg-surface-200
             `}
-          onClick={() => onSelectKey(key, pane)}
-        >
-          <p className="font-mono text-xs !text-blue-900">{key}</p>
-          <div
-            className={`${
-              key === activeKey ? 'opacity-100' : 'opacity-50'
-            } group-hover:opacity-100 transition`}
+            onClick={() => onSelectKey(key, pane)}
           >
-            <ChevronRight strokeWidth={2} size={16} />
+            <p className="font-mono text-xs !text-blue-900">{key}</p>
+            <div
+              className={`${
+                key === activeKey ? 'opacity-100' : 'opacity-50'
+              } group-hover:opacity-100 transition`}
+            >
+              <ChevronRight strokeWidth={2} size={16} />
+            </div>
           </div>
-        </div>
-      ))}
-      {keysWithoutChildren.map((key: string) => (
-        <div key={key} className="flex space-x-2 py-2 px-5">
-          <p className="font-mono text-xs !text-blue-900">{key}:</p>
-          <p
-            className={`break-all font-mono text-xs ${
-              typeof jsonData[key] !== 'string' ? '!text-green-900' : '!text-yellow-900'
-            }`}
-          >
-            {isNull(jsonData[key])
-              ? 'null'
-              : typeof jsonData[key] === 'string'
-                ? `"${jsonData[key]}"`
-                : jsonData[key].toString()}
-          </p>
-        </div>
-      ))}
+        ))}
+        {keysWithoutChildren.map((key: string) => (
+          <div key={key} className="flex space-x-2 py-2 px-5">
+            <p className="font-mono text-xs !text-blue-900">{key}:</p>
+            <p
+              className={`break-all font-mono text-xs ${
+                typeof jsonData[key] !== 'string' ? '!text-green-900' : '!text-yellow-900'
+              }`}
+            >
+              {isNull(jsonData[key])
+                ? 'null'
+                : typeof jsonData[key] === 'string'
+                  ? `"${jsonData[key]}"`
+                  : jsonData[key].toString()}
+            </p>
+          </div>
+        ))}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

small ui improvement

## What is the current behavior?

Currently if you scroll in that view, you can't see what's inside the object without scroll to the top.

## What is the new behavior?

Now if you scroll you can still see what is inside without having to jump from top to bottom.

## Additional context

The github diff is not clear but i basically just added a fixed div parent on top of the elements.

Current behaviour:
![image](https://github.com/user-attachments/assets/a6151d70-9851-437d-9df8-4d8eb97e5d3d)

New behaviour:
![image](https://github.com/user-attachments/assets/8ad80666-7c61-4cbc-ae17-db5131207b71)

Since it's not really a new feature and the discussion got 0 response for a while i just open this PR, if you are not ok with it just close it.