### PR TITLE
fix: hide pnpm update message, update to pnpm 9.15.5, specify pnpm >=9 to unbreak non-corepack pnpm 10, remove corepack in Dockerfile

### DIFF
--- a/.github/workflows/ai-tests.yml
+++ b/.github/workflows/ai-tests.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: 9.10.0
+          version: 9.15.5
           run_install: false
       - name: Use Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/ai-tests.yml
+++ b/.github/workflows/ai-tests.yml
@@ -36,7 +36,6 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: 9.15.5
           run_install: false
       - name: Use Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/autofix_linters.yml
+++ b/.github/workflows/autofix_linters.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: 9.10.0
+          version: 9.15.5
           run_install: false
 
       - uses: actions/setup-node@v4

--- a/.github/workflows/autofix_linters.yml
+++ b/.github/workflows/autofix_linters.yml
@@ -26,7 +26,6 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: 9.15.5
           run_install: false
 
       - uses: actions/setup-node@v4

--- a/.github/workflows/docs-last-changed.yml
+++ b/.github/workflows/docs-last-changed.yml
@@ -29,7 +29,6 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: 9.15.5
           run_install: false
 
       - name: Setup node

--- a/.github/workflows/docs-last-changed.yml
+++ b/.github/workflows/docs-last-changed.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: 9.10.0
+          version: 9.15.5
           run_install: false
 
       - name: Setup node

--- a/.github/workflows/docs-mgmt-api-update.yml
+++ b/.github/workflows/docs-mgmt-api-update.yml
@@ -20,7 +20,6 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: 9.15.5
           run_install: false
 
       - name: Use Node.js

--- a/.github/workflows/docs-mgmt-api-update.yml
+++ b/.github/workflows/docs-mgmt-api-update.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: 9.10.0
+          version: 9.15.5
           run_install: false
 
       - name: Use Node.js

--- a/.github/workflows/docs-tests-smoke.yml
+++ b/.github/workflows/docs-tests-smoke.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: 9.10.0
+          version: 9.15.5
           run_install: false
 
       - name: Use Node.js

--- a/.github/workflows/docs-tests-smoke.yml
+++ b/.github/workflows/docs-tests-smoke.yml
@@ -25,7 +25,6 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: 9.15.5
           run_install: false
 
       - name: Use Node.js

--- a/.github/workflows/docs-tests.yml
+++ b/.github/workflows/docs-tests.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: 9.10.0
+          version: 9.15.5
           run_install: false
 
       - name: Use Node.js

--- a/.github/workflows/docs-tests.yml
+++ b/.github/workflows/docs-tests.yml
@@ -26,7 +26,6 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: 9.15.5
           run_install: false
 
       - name: Use Node.js

--- a/.github/workflows/local-studio-tests.yml
+++ b/.github/workflows/local-studio-tests.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: 9.10.0
+          version: 9.15.5
           run_install: false
       - name: Use Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/local-studio-tests.yml
+++ b/.github/workflows/local-studio-tests.yml
@@ -28,7 +28,6 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: 9.15.5
           run_install: false
       - name: Use Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -21,7 +21,6 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: 9.15.5
           run_install: false
       - name: Setup node
         uses: actions/setup-node@v4
@@ -47,7 +46,6 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: 9.15.5
           run_install: false
       - name: Setup node
         uses: actions/setup-node@v4
@@ -73,7 +71,6 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: 9.15.5
           run_install: false
       - name: Setup node
         uses: actions/setup-node@v4

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: 9.10.0
+          version: 9.15.5
           run_install: false
       - name: Setup node
         uses: actions/setup-node@v4
@@ -47,7 +47,7 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: 9.10.0
+          version: 9.15.5
           run_install: false
       - name: Setup node
         uses: actions/setup-node@v4
@@ -73,7 +73,7 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: 9.10.0
+          version: 9.15.5
           run_install: false
       - name: Setup node
         uses: actions/setup-node@v4

--- a/.github/workflows/search.yml
+++ b/.github/workflows/search.yml
@@ -41,7 +41,6 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: 9.15.5
           run_install: false
 
       - name: Setup node

--- a/.github/workflows/search.yml
+++ b/.github/workflows/search.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: 9.10.0
+          version: 9.15.5
           run_install: false
 
       - name: Setup node

--- a/.github/workflows/studio-tests.yml
+++ b/.github/workflows/studio-tests.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: 9.10.0
+          version: 9.15.5
           run_install: false
       - name: Use Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/studio-tests.yml
+++ b/.github/workflows/studio-tests.yml
@@ -34,7 +34,6 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: 9.15.5
           run_install: false
       - name: Use Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -22,7 +22,6 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: 9.15.5
           run_install: false
 
       - name: Use Node.js

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: 9.10.0
+          version: 9.15.5
           run_install: false
 
       - name: Use Node.js

--- a/.github/workflows/ui-patterns-tests.yml
+++ b/.github/workflows/ui-patterns-tests.yml
@@ -24,7 +24,6 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: 9.15.5
           run_install: false
 
       - name: Use Node.js

--- a/.github/workflows/ui-patterns-tests.yml
+++ b/.github/workflows/ui-patterns-tests.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: 9.10.0
+          version: 9.15.5
           run_install: false
 
       - name: Use Node.js

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -24,7 +24,6 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: 9.15.5
           run_install: false
 
       - name: Use Node.js

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: 9.10.0
+          version: 9.15.5
           run_install: false
 
       - name: Use Node.js

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 engine-strict=true
+update-notifier=false

--- a/apps/studio/Dockerfile
+++ b/apps/studio/Dockerfile
@@ -11,6 +11,10 @@
 FROM node:20-slim AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
+
+# Workaround for https://github.com/nodejs/corepack/issues/612.
+RUN npm install -g corepack@0.31.0
+
 RUN corepack enable
 
 # Fixes issues with Sentry CLI and SSL certificates during build

--- a/apps/studio/Dockerfile
+++ b/apps/studio/Dockerfile
@@ -12,11 +12,6 @@ FROM node:20-slim AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 
-# Workaround for https://github.com/nodejs/corepack/issues/612.
-RUN npm install -g corepack@0.31.0
-
-RUN corepack enable
-
 # Fixes issues with Sentry CLI and SSL certificates during build
 # TODO: Git is added because it's needed to build libpg, remove it once they publish a binary on the S3 bucket
 RUN apt-get update -qq && \
@@ -27,6 +22,8 @@ RUN apt-get update -qq && \
   build-essential && \ 
   rm -rf /var/lib/apt/lists/* && \
   update-ca-certificates
+
+RUN npm install -g pnpm@9.15.5
 
 WORKDIR /app
 

--- a/package.json
+++ b/package.json
@@ -55,8 +55,8 @@
     }
   },
   "engines": {
-    "pnpm": "^9.0.0",
-    "node": ">= 20"
+    "pnpm": ">=9",
+    "node": ">=20"
   },
   "keywords": ["postgres", "firebase", "storage", "functions", "database", "auth"],
   "packageManager": "pnpm@9.15.5"

--- a/package.json
+++ b/package.json
@@ -59,5 +59,5 @@
     "node": ">= 20"
   },
   "keywords": ["postgres", "firebase", "storage", "functions", "database", "auth"],
-  "packageManager": "pnpm@9.10.0"
+  "packageManager": "pnpm@9.15.5"
 }


### PR DESCRIPTION
pnpm 10 upgrade should be handled separately, since it has breaking changes.

- **fix: install pnpm in base stage using npm, remove corepack**
  There's little point using corepack in the Docker image, now that pnpm
10 supports automatically downloading and running the version of pnpm
specified in the `packageManager` field of `package.json` by default:
https://pnpm.io/npmrc#manage-package-manager-versions.

  Having the pnpm version specified in the Dockerfiles instead of having
`packageManager` as the source of truth makes it slightly more likely
that the versions would diverge if we miss updating the version in some
places, but `manage-package-manager-versions` would take care of that
with pnpm 10, and we're on the latest version of pnpm 9 already.

  I think getting rid of corepack is worth the duplication of the pnpm
version within the Dockerfiles. Corepack recently caused issues with
https://github.com/nodejs/corepack/issues/612.

- **fix: remove `version` from `pnpm/action-setup@4`, redundant since it'll be picked up from `packageManager`**
  
- **fix: specify engine as >=9 instead of ^9, which breaks `packageManager` auto-install with pnpm 10 if not using corepack**

```
supabase/apps/studio 
❯ trash /Users/beng/.local/share/pnpm/.tools/pnpm/9.10.0

supabase/apps/studio 
❯ pnpm install
 ERROR  Unsupported engine for /Users/beng/supabase/supabase: wanted: {"pnpm":"^9.0.0"} (current: {"node":"v20.11.1","pnpm":"10.2.0"})
For help, run: pnpm help install

supabase/apps/studio 
❯ pnpm install
 ERROR  Failed to switch pnpm to v9.10.0. Looks like pnpm CLI is missing at "/Users/beng/.local/share/pnpm/.tools/pnpm/9.10.0/bin" or is incorrect
spawnSync /Users/beng/.local/share/pnpm/.tools/pnpm/9.10.0/bin/pnpm ENOENT
```
  
- **fix: install corepack v0.31.0 as workaround for nodejs/corepack#612**
  
- **chore: update to pnpm 9.15.5**
  
- **fix: hide pnpm update message, it's confusing since the pnpm version is locked**