### PR TITLE
fix: revert instruments to countries

### DIFF
--- a/apps/docs/components/MDX/quickstart_db_setup.mdx
+++ b/apps/docs/components/MDX/quickstart_db_setup.mdx
@@ -4,7 +4,7 @@ Go to [database.new](https://database.new) and create a new Supabase project.
 
 When your project is up and running, go to the [Table Editor](https://supabase.com/dashboard/project/_/editor), create a new table and insert some data.
 
-Alternatively, you can run the following snippet in your project's [SQL Editor](https://supabase.com/dashboard/project/_/sql/new). This will create a `instruments` table with some sample data.
+Alternatively, you can run the following snippet in your project's [SQL Editor](https://supabase.com/dashboard/project/_/sql/new). This will create a `countries` table with some sample data.
 
 </StepHikeCompact.Details>
 
@@ -12,18 +12,18 @@ Alternatively, you can run the following snippet in your project's [SQL Editor](
 
     ```sql SQL_EDITOR
     -- Create the table
-    create table instruments (
+    create table countries (
       id bigint primary key generated always as identity,
       name text not null
     );
     -- Insert some sample data into the table
-    insert into instruments (name)
+    insert into countries (name)
     values
-      ('violin'),
-      ('viola'),
-      ('cello');
+      ('Canada'),
+      ('United States'),
+      ('Mexico');
 
-    alter table instruments enable row level security;
+    alter table countries enable row level security;
     ```
 
 </StepHikeCompact.Code>
@@ -37,8 +37,8 @@ Make the data in your table publicly readable by adding an RLS policy:
 <StepHikeCompact.Code>
 
     ```sql SQL_EDITOR
-    create policy "public can read instruments"
-    on public.instruments
+    create policy "public can read countries"
+    on public.countries
     for select to anon
     using (true);
     ```

--- a/apps/docs/content/guides/getting-started/quickstarts/nextjs.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/nextjs.mdx
@@ -58,9 +58,9 @@ hideToc: true
   <StepHikeCompact.Step step={4}>
     <StepHikeCompact.Details title="Query Supabase data from Next.js">
 
-    Create a new file at `app/countries/page.tsx` and populate with the following.
+    Create a new file at `app/instruments/page.tsx` and populate with the following.
 
-    This will select all the rows from the `countries` table in Supabase and render them on the page.
+    This will select all the rows from the `instruments` table in Supabase and render them on the page.
 
     </StepHikeCompact.Details>
 
@@ -68,14 +68,14 @@ hideToc: true
 
     <CH.Code className="min-h-[34rem]">
 
-      ```ts app/countries/page.tsx
+      ```ts app/instruments/page.tsx
         import { createClient } from '@/utils/supabase/server';
 
-        export default async function Countries() {
+        export default async function Instruments() {
           const supabase = await createClient();
-          const { data: countries } = await supabase.from("countries").select();
+          const { data: instruments } = await supabase.from("instruments").select();
 
-          return <pre>{JSON.stringify(countries, null, 2)}</pre>
+          return <pre>{JSON.stringify(instruments, null, 2)}</pre>
         }
       ```
 
@@ -120,7 +120,7 @@ hideToc: true
   <StepHikeCompact.Step step={5}>
     <StepHikeCompact.Details title="Start the app">
 
-    Run the development server, go to http://localhost:3000/countries in a browser and you should see the list of countries.
+    Run the development server, go to http://localhost:3000/instruments in a browser and you should see the list of instruments.
 
     </StepHikeCompact.Details>
 

--- a/apps/docs/content/guides/getting-started/quickstarts/nextjs.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/nextjs.mdx
@@ -58,9 +58,9 @@ hideToc: true
   <StepHikeCompact.Step step={4}>
     <StepHikeCompact.Details title="Query Supabase data from Next.js">
 
-    Create a new file at `app/instruments/page.tsx` and populate with the following.
+    Create a new file at `app/countries/page.tsx` and populate with the following.
 
-    This will select all the rows from the `instruments` table in Supabase and render them on the page.
+    This will select all the rows from the `countries` table in Supabase and render them on the page.
 
     </StepHikeCompact.Details>
 
@@ -68,14 +68,14 @@ hideToc: true
 
     <CH.Code className="min-h-[34rem]">
 
-      ```ts app/instruments/page.tsx
+      ```ts app/countries/page.tsx
         import { createClient } from '@/utils/supabase/server';
 
-        export default async function Instruments() {
+        export default async function Countries() {
           const supabase = await createClient();
-          const { data: instruments } = await supabase.from("instruments").select();
+          const { data: countries } = await supabase.from("countries").select();
 
-          return <pre>{JSON.stringify(instruments, null, 2)}</pre>
+          return <pre>{JSON.stringify(countries, null, 2)}</pre>
         }
       ```
 
@@ -120,7 +120,7 @@ hideToc: true
   <StepHikeCompact.Step step={5}>
     <StepHikeCompact.Details title="Start the app">
 
-    Run the development server, go to http://localhost:3000/instruments in a browser and you should see the list of instruments.
+    Run the development server, go to http://localhost:3000/countries in a browser and you should see the list of countries.
 
     </StepHikeCompact.Details>
 


### PR DESCRIPTION
apps/docs/components/MDX/quickstart_db_setup.mdx uses instruments instead of countries

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

https://github.com/supabase/supabase/issues/33239 also for Flutter, Swift, Kotlin, Nuxt, React, Refine, Solid, Sveltekit and Vue

## What is the new behavior?

Consistent use of "countries".

## Additional context

![CleanShot 2025-02-01 at 22 29 10](https://github.com/user-attachments/assets/60c08fe9-343d-4111-87cd-d74e2aad7bad)
![CleanShot 2025-02-01 at 22 29 26](https://github.com/user-attachments/assets/3a7c0f34-0d5d-4c84-a5e4-2a8c0aceca25)
