### PR TITLE
Update timeouts.mdx | correct timeout limit for service_role

### DIFF
--- a/apps/docs/content/guides/database/postgres/timeouts.mdx
+++ b/apps/docs/content/guides/database/postgres/timeouts.mdx
@@ -61,7 +61,7 @@ The default role timeouts are:
 
 - `anon`: 3s
 - `authenticated`: 8s
-- `service_role`: none (capped by API to be 60s)
+- `service_role`: 8s (inherits its timeout from the `authenticator` user)
 - `postgres`: none (capped by default global timeout to be 2min)
 
 Run the following query to change a role's timeout:

--- a/apps/docs/content/guides/database/postgres/timeouts.mdx
+++ b/apps/docs/content/guides/database/postgres/timeouts.mdx
@@ -61,7 +61,7 @@ The default role timeouts are:
 
 - `anon`: 3s
 - `authenticated`: 8s
-- `service_role`: 8s (inherits its timeout from the `authenticator` user)
+- `service_role`: none (defaults to the `authenticator` role's 8s timeout if unset)
 - `postgres`: none (capped by default global timeout to be 2min)
 
 Run the following query to change a role's timeout:


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

Misinforms users that the service_role has a timeout of 60s.

## What is the new behavior?

Clarifies that the service_role inherits a timeout of 8s