### PR TITLE
Add default array for cron http headers

### DIFF
--- a/apps/studio/components/interfaces/Integrations/CronJobs/CreateCronJobSheet.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CreateCronJobSheet.tsx
@@ -17,6 +17,7 @@ import { CronJob, useCronJobsQuery } from 'data/database-cron-jobs/database-cron
 import { useDatabaseExtensionsQuery } from 'data/database-extensions/database-extensions-query'
 import { useSendEventMutation } from 'data/telemetry/send-event-mutation'
 import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import { useSelectedOrganization } from 'hooks/misc/useSelectedOrganization'
 import {
   Button,
   Form_Shadcn_,
@@ -50,7 +51,6 @@ import { HTTPHeaderFieldsSection } from './HttpHeaderFieldsSection'
 import { HttpRequestSection } from './HttpRequestSection'
 import { SqlFunctionSection } from './SqlFunctionSection'
 import { SqlSnippetSection } from './SqlSnippetSection'
-import { useSelectedOrganization } from 'hooks/misc/useSelectedOrganization'
 
 export interface CreateCronJobSheetProps {
   selectedCronJob?: Pick<CronJob, 'jobname' | 'schedule' | 'active' | 'command'>

--- a/apps/studio/components/interfaces/Integrations/CronJobs/CronJobs.utils.ts
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CronJobs.utils.ts
@@ -12,7 +12,7 @@ export const buildCronQuery = (name: string, schedule: string, command: string) 
 export const buildHttpRequestCommand = (
   method: 'GET' | 'POST',
   url: string,
-  headers: HTTPHeader[],
+  headers: HTTPHeader[] = [],
   body: string | undefined,
   timeout: number
 ) => {


### PR DESCRIPTION
Client error occurs as `values.httpHeaders` from `buildCommand` is undefined, so the filter errors out