### PR TITLE
Fix database tables not showing FKs on first panel open

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.tsx
@@ -130,11 +130,12 @@ const TableEditor = ({
     (constraint) => constraint.type === CONSTRAINT_TYPE.PRIMARY_KEY_CONSTRAINT
   )
 
-  const { data: foreignKeyMeta } = useForeignKeyConstraintsQuery({
-    projectRef: project?.ref,
-    connectionString: project?.connectionString,
-    schema: table?.schema,
-  })
+  const { data: foreignKeyMeta, isSuccess: isSuccessForeignKeyMeta } =
+    useForeignKeyConstraintsQuery({
+      projectRef: project?.ref,
+      connectionString: project?.connectionString,
+      schema: table?.schema,
+    })
   const foreignKeys = (foreignKeyMeta ?? []).filter(
     (fk) => fk.source_schema === table?.schema && fk.source_table === table?.name
   )
@@ -230,10 +231,13 @@ const TableEditor = ({
           isRealtimeEnabled
         )
         setTableFields(tableFields)
-        setFkRelations(formatForeignKeys(foreignKeys))
       }
     }
   }, [visible])
+
+  useEffect(() => {
+    if (isSuccessForeignKeyMeta) setFkRelations(formatForeignKeys(foreignKeys))
+  }, [isSuccessForeignKeyMeta])
 
   useEffect(() => {
     if (importContent && !isEmpty(importContent)) {


### PR DESCRIPTION
To reproduce:
- Go to Database -> Tables (It's not happening in Table Editor)
- Select "Edit table" on a table that has foreign keys
- Scroll down to the Foreign Keys section of the side panel, notice that's 0 keys
- Close the panel, and open the panel again via "Edit table"
- Foreign keys are there now