### PR TITLE
Refactor auth users the way we retrieve providers

### DIFF
--- a/apps/studio/components/interfaces/Auth/Users/Users.utils.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/Users.utils.tsx
@@ -6,7 +6,7 @@ import { Column, useRowSelection } from 'react-data-grid'
 import { User } from 'data/auth/users-infinite-query'
 import { BASE_PATH } from 'lib/constants'
 import { Checkbox_Shadcn_, cn } from 'ui'
-import { HeaderCell, SelectHeaderCell } from './UsersGridComponents'
+import { HeaderCell } from './UsersGridComponents'
 import { ColumnConfiguration, USERS_TABLE_COLUMNS } from './UsersV2'
 
 const SUPPORTED_CSP_AVATAR_URLS = [
@@ -21,7 +21,7 @@ export const isAtBottom = ({ currentTarget }: UIEvent<HTMLDivElement>): boolean 
 export const formatUsersData = (users: User[]) => {
   return users.map((user) => {
     const provider: string = user.raw_app_meta_data?.provider ?? ''
-    const providers: string[] = (user.raw_app_meta_data?.providers ?? []).map((x: string) => {
+    const providers: string[] = user.providers.map((x: string) => {
       if (x.startsWith('sso')) return 'SAML'
       return x
     })

--- a/apps/studio/components/interfaces/Auth/Users/UsersV2.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/UsersV2.tsx
@@ -10,6 +10,7 @@ import { useIsAPIDocsSidePanelEnabled } from 'components/interfaces/App/FeatureP
 import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
 import AlertError from 'components/ui/AlertError'
 import APIDocsButton from 'components/ui/APIDocsButton'
+import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import { FilterPopover } from 'components/ui/FilterPopover'
 import { FormHeader } from 'components/ui/Forms/FormHeader'
 import { authKeys } from 'data/auth/keys'
@@ -46,7 +47,6 @@ import AddUserDropdown from './AddUserDropdown'
 import { UserPanel } from './UserPanel'
 import { MAX_BULK_DELETE, PROVIDER_FILTER_OPTIONS } from './Users.constants'
 import { formatUserColumns, formatUsersData, isAtBottom } from './Users.utils'
-import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 
 export type Filter = 'all' | 'verified' | 'unverified' | 'anonymous'
 export type UsersTableColumn = {
@@ -486,10 +486,13 @@ export const UsersV2 = () => {
                         {...props}
                         key={props.row.id}
                         onClick={() => {
-                          const idx = users.indexOf(users.find((u) => u.id === id) ?? {})
-                          if (props.row.id) {
-                            setSelectedUser(props.row.id)
-                            gridRef.current?.scrollToCell({ idx: 0, rowIdx: idx })
+                          const user = users.find((u) => u.id === id)
+                          if (user) {
+                            const idx = users.indexOf(user)
+                            if (props.row.id) {
+                              setSelectedUser(props.row.id)
+                              gridRef.current?.scrollToCell({ idx: 0, rowIdx: idx })
+                            }
                           }
                         }}
                       />

--- a/apps/studio/data/auth/users-infinite-query.ts
+++ b/apps/studio/data/auth/users-infinite-query.ts
@@ -20,7 +20,9 @@ export type UsersVariables = {
 }
 
 export const USERS_PAGE_LIMIT = 50
-export type User = components['schemas']['UserBody']
+export type User = components['schemas']['UserBody'] & {
+  providers: string[]
+}
 
 export const getUsersSQL = ({
   page = 0,
@@ -41,7 +43,9 @@ export const getUsersSQL = ({
   const hasValidKeywords = keywords && keywords !== ''
 
   const conditions: string[] = []
-  const baseQueryUsers = `select * from auth.users`
+  const baseQueryUsers = `
+  select *, coalesce((select array_agg(distinct i.provider) from auth.identities i where i.user_id = auth.users.id), '{}'::text[]) as providers from auth.users
+  `.trim()
 
   if (hasValidKeywords) {
     // [Joshen] Escape single quotes properly

--- a/apps/studio/data/auth/users-infinite-query.ts
+++ b/apps/studio/data/auth/users-infinite-query.ts
@@ -21,7 +21,7 @@ export type UsersVariables = {
 
 export const USERS_PAGE_LIMIT = 50
 export type User = components['schemas']['UserBody'] & {
-  providers: string[]
+  providers: readonly string[]
 }
 
 export const getUsersSQL = ({

--- a/apps/studio/lib/role-impersonation.ts
+++ b/apps/studio/lib/role-impersonation.ts
@@ -14,7 +14,7 @@ type PostgrestImpersonationRole =
       type: 'postgrest'
       role: 'authenticated'
       userType: 'native'
-      user?: Omit<User, 'providers'>
+      user?: User
       aal?: 'aal1' | 'aal2'
     }
   | {

--- a/apps/studio/lib/role-impersonation.ts
+++ b/apps/studio/lib/role-impersonation.ts
@@ -14,7 +14,7 @@ type PostgrestImpersonationRole =
       type: 'postgrest'
       role: 'authenticated'
       userType: 'native'
-      user?: User
+      user?: Omit<User, 'providers'>
       aal?: 'aal1' | 'aal2'
     }
   | {


### PR DESCRIPTION
`raw_app_meta_data` can be anything and can be editable, so we're using the identities table instead to retrieve the providers information