### PR TITLE
fix: users fetch more on scroll

### DIFF
--- a/apps/studio/components/interfaces/Auth/Users/Users.utils.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/Users.utils.tsx
@@ -14,8 +14,19 @@ const SUPPORTED_CSP_AVATAR_URLS = [
   'https://lh3.googleusercontent.com',
 ]
 
-export const isAtBottom = ({ currentTarget }: UIEvent<HTMLDivElement>): boolean => {
-  return currentTarget.scrollTop + 10 >= currentTarget.scrollHeight - currentTarget.clientHeight
+export const isCloseToBottom = ({ currentTarget }: UIEvent<HTMLDivElement>): boolean => {
+  const { scrollTop, scrollHeight, clientHeight } = currentTarget
+
+  // If the content doesn't overflow, it's not considered "close to bottom"
+  if (scrollHeight <= clientHeight) {
+    return false
+  }
+
+  // Check if we're within 100px of the bottom
+  const bottomThreshold = 100
+  const remainingScroll = scrollHeight - (scrollTop + clientHeight)
+
+  return remainingScroll <= bottomThreshold
 }
 
 export const formatUsersData = (users: User[]) => {

--- a/apps/studio/components/interfaces/Auth/Users/UsersV2.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/UsersV2.tsx
@@ -10,6 +10,7 @@ import { useIsAPIDocsSidePanelEnabled } from 'components/interfaces/App/FeatureP
 import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
 import AlertError from 'components/ui/AlertError'
 import APIDocsButton from 'components/ui/APIDocsButton'
+import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import { FilterPopover } from 'components/ui/FilterPopover'
 import { FormHeader } from 'components/ui/Forms/FormHeader'
 import { authKeys } from 'data/auth/keys'
@@ -45,8 +46,7 @@ import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
 import AddUserDropdown from './AddUserDropdown'
 import { UserPanel } from './UserPanel'
 import { MAX_BULK_DELETE, PROVIDER_FILTER_OPTIONS } from './Users.constants'
-import { formatUserColumns, formatUsersData, isAtBottom } from './Users.utils'
-import { ButtonTooltip } from 'components/ui/ButtonTooltip'
+import { formatUserColumns, formatUsersData, isCloseToBottom } from './Users.utils'
 
 export type Filter = 'all' | 'verified' | 'unverified' | 'anonymous'
 export type UsersTableColumn = {
@@ -109,6 +109,7 @@ export const UsersV2 = () => {
     isError,
     isFetchingNextPage,
     refetch,
+    hasNextPage,
     fetchNextPage,
   } = useUsersInfiniteQuery(
     {
@@ -141,8 +142,9 @@ export const UsersV2 = () => {
   const selectedUserToDelete = users.find((u) => u.id === [...selectedUsers][0])
 
   const handleScroll = (event: UIEvent<HTMLDivElement>) => {
-    if (isLoading || !isAtBottom(event)) return
-    fetchNextPage()
+    if (hasNextPage && !isLoading && isCloseToBottom(event)) {
+      fetchNextPage()
+    }
   }
 
   const clearSearch = () => {


### PR DESCRIPTION
Bug fix

## What is the current behavior?

https://github.com/user-attachments/assets/9ff7e668-62f7-42b6-91ab-9dd4b295df98

## What is the new behavior?

We now only fetch when there's more pages to fetch. I also have tweaked the close to bottom logic.