### PR TITLE
Use portal for reference record peek

### DIFF
--- a/apps/studio/components/grid/components/formatter/ForeignKeyFormatter.tsx
+++ b/apps/studio/components/grid/components/formatter/ForeignKeyFormatter.tsx
@@ -1,3 +1,4 @@
+import { ArrowRight } from 'lucide-react'
 import type { PropsWithChildren } from 'react'
 import type { RenderCellProps } from 'react-data-grid'
 
@@ -7,7 +8,6 @@ import { useTableEditorQuery } from 'data/table-editor/table-editor-query'
 import { isTableLike } from 'data/table-editor/table-editor-types'
 import { useTablesQuery } from 'data/tables/tables-query'
 import { useQuerySchemaState } from 'hooks/misc/useSchemaQueryState'
-import { ArrowRight } from 'lucide-react'
 import { Popover_Shadcn_, PopoverContent_Shadcn_, PopoverTrigger_Shadcn_ } from 'ui'
 import type { SupaRow } from '../../types'
 import { NullValue } from '../common/NullValue'

--- a/apps/studio/components/grid/components/formatter/ForeignKeyFormatter.tsx
+++ b/apps/studio/components/grid/components/formatter/ForeignKeyFormatter.tsx
@@ -1,4 +1,3 @@
-import { ArrowRight } from 'lucide-react'
 import type { PropsWithChildren } from 'react'
 import type { RenderCellProps } from 'react-data-grid'
 
@@ -8,6 +7,7 @@ import { useTableEditorQuery } from 'data/table-editor/table-editor-query'
 import { isTableLike } from 'data/table-editor/table-editor-types'
 import { useTablesQuery } from 'data/tables/tables-query'
 import { useQuerySchemaState } from 'hooks/misc/useSchemaQueryState'
+import { ArrowRight } from 'lucide-react'
 import { Popover_Shadcn_, PopoverContent_Shadcn_, PopoverTrigger_Shadcn_ } from 'ui'
 import type { SupaRow } from '../../types'
 import { NullValue } from '../common/NullValue'
@@ -68,7 +68,7 @@ export const ForeignKeyFormatter = (props: Props) => {
               tooltip={{ content: { side: 'bottom', text: 'View referencing record' } }}
             />
           </PopoverTrigger_Shadcn_>
-          <PopoverContent_Shadcn_ align="end" className="p-0 w-96">
+          <PopoverContent_Shadcn_ portal align="end" className="p-0 w-96">
             <ReferenceRecordPeek
               table={targetTable}
               column={relationship.target_column_name}


### PR DESCRIPTION
As per PR title, solves an issue whereby clicking on "View referencing record" somehow scrolls the table editor to the left most (For reference - we had to use portal for tooltips in the table editor too cause of how react data grid is)