### PR TITLE
Fix/secret api badge

### DIFF
--- a/apps/studio/components/ui/ProjectSettings/DisplayApiSettings.tsx
+++ b/apps/studio/components/ui/ProjectSettings/DisplayApiSettings.tsx
@@ -101,7 +101,9 @@ const DisplayApiSettings = ({ legacy }: { legacy?: boolean }) => {
                     ))}
                     {x.tags === 'service_role' && (
                       <>
-                        <code className="bg-red-900 text-xs text-white">secret</code>
+                        <code className="bg-red-900 text-xs text-white px-0.5 rounded-sm">
+                          secret
+                        </code>
                       </>
                     )}
                     {x.tags === 'anon' && <code className="text-xs text-code">public</code>}

--- a/apps/studio/components/ui/ProjectSettings/DisplayApiSettings.tsx
+++ b/apps/studio/components/ui/ProjectSettings/DisplayApiSettings.tsx
@@ -101,7 +101,7 @@ const DisplayApiSettings = ({ legacy }: { legacy?: boolean }) => {
                     ))}
                     {x.tags === 'service_role' && (
                       <>
-                        <code className="bg-red-900 text-xs text-white px-0.5 rounded-sm">
+                        <code className="text-xs text-code !bg-destructive !text-white !border-destructive">
                           secret
                         </code>
                       </>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES/NO

fixes FE-1366

## What kind of change does this PR introduce?

- Updates secret badge styling
- uses destructive color

## What is the current behavior?

![image](https://github.com/user-attachments/assets/781ae5b1-802b-4062-ac55-9ae7926dea14)


## What is the new behavior?

<img width="270" alt="Screenshot 2025-02-04 at 15 07 19" src="https://github.com/user-attachments/assets/e9d5910e-b562-4259-bf16-bea388fcd06a" />
