### PR TITLE
Set stale time for users infinite query on auth/users to infinite

### DIFF
--- a/apps/studio/components/grid/components/formatter/ForeignKeyFormatter.tsx
+++ b/apps/studio/components/grid/components/formatter/ForeignKeyFormatter.tsx
@@ -7,22 +7,19 @@ import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import { useTableEditorQuery } from 'data/table-editor/table-editor-query'
 import { isTableLike } from 'data/table-editor/table-editor-types'
 import { useTablesQuery } from 'data/tables/tables-query'
-import { useQuerySchemaState } from 'hooks/misc/useSchemaQueryState'
 import { Popover_Shadcn_, PopoverContent_Shadcn_, PopoverTrigger_Shadcn_ } from 'ui'
 import type { SupaRow } from '../../types'
 import { NullValue } from '../common/NullValue'
 import { ReferenceRecordPeek } from './ReferenceRecordPeek'
 
 interface Props extends PropsWithChildren<RenderCellProps<SupaRow, unknown>> {
-  projectRef?: string
   tableId?: string
 }
 
 export const ForeignKeyFormatter = (props: Props) => {
   const { project } = useProjectContext()
-  const { selectedSchema } = useQuerySchemaState()
 
-  const { projectRef, tableId, row, column } = props
+  const { tableId, row, column } = props
   const id = tableId ? Number(tableId) : undefined
 
   const { data } = useTableEditorQuery({

--- a/apps/studio/components/interfaces/Auth/Users/UsersV2.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/UsersV2.tsx
@@ -124,6 +124,9 @@ export const UsersV2 = () => {
     },
     {
       keepPreviousData: Boolean(filterKeywords),
+      // [Joshen] This is to prevent the dashboard from invalidating when refocusing as it may create
+      // a barrage of requests to invalidate each page esp when the project has many many users.
+      staleTime: Infinity,
     }
   )
 


### PR DESCRIPTION
Small problem observed while using the auth/users page - if the project has many many users (e.g 500) and you've scrolled all the way to the bottom (which means that all the pages are loaded with infinite loading)

When the invalidation kicks in at refocusing, it kicks off a barrage of requests to revalidate each page which
1. i think its unnecessary for an infinitely loaded UI
2. It could cause a spike in load on the project's Postgrest

So setting stale time to infinite to prevent automatic invalidation (There's a refresh button still so no worries)