### PR TITLE
fix: rename "No issues" to Healthy

### DIFF
--- a/apps/studio/components/interfaces/Home/ServiceStatus.tsx
+++ b/apps/studio/components/interfaces/Home/ServiceStatus.tsx
@@ -39,7 +39,7 @@ const StatusMessage = ({
   if (status === 'COMING_UP') return 'Coming up...'
   if (status === 'ACTIVE_HEALTHY') return 'Healthy'
   if (isProjectNew) return 'Coming up...'
-  if (isSuccess) return 'No issues'
+  if (isSuccess) return 'Healthy'
   return 'Unable to connect'
 }
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Some service status requests show "No issues" instead of "Healthy", this makes them all show the same status text.

## What is the current behavior?

![CleanShot 2025-02-04 at 11 18 27@2x](https://github.com/user-attachments/assets/7e453a54-0fe0-4ffd-99f1-ae0dd3066517)

## What is the new behavior?

![CleanShot 2025-02-04 at 11 18 10@2x](https://github.com/user-attachments/assets/780fe4ff-707e-44dd-a8cc-4b185cb4b5b8)

