### PR TITLE
Support bytea data type in table editor

### DIFF
--- a/apps/studio/components/grid/components/formatter/BinaryFormatter.tsx
+++ b/apps/studio/components/grid/components/formatter/BinaryFormatter.tsx
@@ -7,7 +7,7 @@ import { NullValue } from '../common/NullValue'
 
 export const BinaryFormatter = (p: PropsWithChildren<RenderCellProps<SupaRow, unknown>>) => {
   const value = p.row[p.column.key]
-  if (value === null) return <NullValue />
+  if (!value) return <NullValue />
   const binaryValue = convertByteaToHex(value)
   return <>{binaryValue}</>
 }

--- a/apps/studio/components/grid/components/formatter/BinaryFormatter.tsx
+++ b/apps/studio/components/grid/components/formatter/BinaryFormatter.tsx
@@ -1,0 +1,13 @@
+import { PropsWithChildren } from 'react'
+import type { RenderCellProps } from 'react-data-grid'
+
+import { SupaRow } from 'components/grid/types'
+import { convertByteaToHex } from 'components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.utils'
+import { NullValue } from '../common/NullValue'
+
+export const BinaryFormatter = (p: PropsWithChildren<RenderCellProps<SupaRow, unknown>>) => {
+  const value = p.row[p.column.key]
+  if (value === null) return <NullValue />
+  const binaryValue = convertByteaToHex(value)
+  return <>{binaryValue}</>
+}

--- a/apps/studio/components/grid/components/formatter/DefaultFormatter.tsx
+++ b/apps/studio/components/grid/components/formatter/DefaultFormatter.tsx
@@ -1,10 +1,11 @@
-import * as React from 'react'
+import { PropsWithChildren } from 'react'
 import type { RenderCellProps } from 'react-data-grid'
-import type { SupaRow } from '../../types'
+
+import { SupaRow } from 'components/grid/types'
 import { EmptyValue } from '../common/EmptyValue'
 import { NullValue } from '../common/NullValue'
 
-export const DefaultFormatter = (p: React.PropsWithChildren<RenderCellProps<SupaRow, unknown>>) => {
+export const DefaultFormatter = (p: PropsWithChildren<RenderCellProps<SupaRow, unknown>>) => {
   let value = p.row[p.column.key]
   if (value === null) return <NullValue />
   if (value === '') return <EmptyValue />

--- a/apps/studio/components/grid/components/formatter/ForeignKeyFormatter.tsx
+++ b/apps/studio/components/grid/components/formatter/ForeignKeyFormatter.tsx
@@ -2,6 +2,7 @@ import { ArrowRight } from 'lucide-react'
 import type { PropsWithChildren } from 'react'
 import type { RenderCellProps } from 'react-data-grid'
 
+import { convertByteaToHex } from 'components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.utils'
 import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import { useTableEditorQuery } from 'data/table-editor/table-editor-query'
@@ -30,6 +31,7 @@ export const ForeignKeyFormatter = (props: Props) => {
     connectionString: project?.connectionString,
     id,
   })
+  const foreignKeyColumn = data?.columns.find((x) => x.name === column.key)
   const selectedTable = isTableLike(data) ? data : undefined
 
   const relationship = (selectedTable?.relationships ?? []).find(
@@ -51,13 +53,14 @@ export const ForeignKeyFormatter = (props: Props) => {
   )
 
   const value = row[column.key]
+  const formattedValue = foreignKeyColumn?.format === 'bytea' ? convertByteaToHex(value) : value
 
   return (
     <div className="sb-grid-foreign-key-formatter flex justify-between">
       <span className="sb-grid-foreign-key-formatter__text">
-        {value === null ? <NullValue /> : value}
+        {formattedValue === null ? <NullValue /> : formattedValue}
       </span>
-      {relationship !== undefined && targetTable !== undefined && value !== null && (
+      {relationship !== undefined && targetTable !== undefined && formattedValue !== null && (
         <Popover_Shadcn_>
           <PopoverTrigger_Shadcn_ asChild>
             <ButtonTooltip
@@ -72,7 +75,7 @@ export const ForeignKeyFormatter = (props: Props) => {
             <ReferenceRecordPeek
               table={targetTable}
               column={relationship.target_column_name}
-              value={value}
+              value={formattedValue}
             />
           </PopoverContent_Shadcn_>
         </Popover_Shadcn_>

--- a/apps/studio/components/grid/components/formatter/ReferenceRecordPeek.tsx
+++ b/apps/studio/components/grid/components/formatter/ReferenceRecordPeek.tsx
@@ -8,6 +8,7 @@ import {
   ESTIMATED_CHARACTER_PIXEL_WIDTH,
   getColumnDefaultWidth,
 } from 'components/grid/utils/gridColumns'
+import { convertByteaToHex } from 'components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.utils'
 import { EditorTablePageLink } from 'data/prefetchers/project.$ref.editor.$id'
 import { useTableRowsQuery } from 'data/table-rows/table-rows-query'
 import { useSelectedProject } from 'hooks/misc/useSelectedProject'
@@ -72,16 +73,17 @@ export const ReferenceRecordPeek = ({ table, column, value }: ReferenceRecordPee
           <span className="text-xs text-foreground-light font-normal">{column.format}</span>
         </div>
       ),
-      renderCell: ({ column, row }) => {
-        const value = row[column.name as any]
+      renderCell: ({ column: col, row }) => {
+        const value = row[col.name as any]
+        const formattedValue = column.format === 'bytea' ? convertByteaToHex(value) : value
         return (
           <div
             className={cn(
               'flex items-center h-full w-full whitespace-pre',
-              value === null && 'text-foreground-lighter'
+              formattedValue === null && 'text-foreground-lighter'
             )}
           >
-            {value === null ? 'NULL' : value}
+            {formattedValue === null ? 'NULL' : formattedValue}
           </div>
         )
       },

--- a/apps/studio/components/grid/components/grid/ColumnHeader.tsx
+++ b/apps/studio/components/grid/components/grid/ColumnHeader.tsx
@@ -140,7 +140,10 @@ export function ColumnHeader<R>({
           <span className="sb-grid-column-header__inner__name" title={hoverValue}>
             {column.name}
           </span>
-          <span className="sb-grid-column-header__inner__format">{columnFormat}</span>
+          <span className="sb-grid-column-header__inner__format">
+            {columnFormat}
+            {columnFormat === 'bytea' ? ` (hex)` : ''}
+          </span>
           {isEncrypted && (
             <Tooltip>
               <TooltipTrigger>

--- a/apps/studio/components/grid/components/grid/RowRenderer.tsx
+++ b/apps/studio/components/grid/components/grid/RowRenderer.tsx
@@ -1,7 +1,8 @@
 import type { Key } from 'react'
 import { TriggerEvent, useContextMenu } from 'react-contexify'
-import { Row, RenderRowProps } from 'react-data-grid'
-import type { SupaRow } from '../../types'
+import { RenderRowProps, Row } from 'react-data-grid'
+
+import { SupaRow } from 'components/grid/types'
 import { ROW_CONTEXT_MENU_ID } from '../menu'
 
 export default function RowRenderer(key: Key, props: RenderRowProps<SupaRow>) {

--- a/apps/studio/components/grid/types/base.ts
+++ b/apps/studio/components/grid/types/base.ts
@@ -51,6 +51,7 @@ export type ColumnType =
   | 'text'
   | 'citext'
   | 'time'
+  | 'binary'
   | 'unknown'
 
 export interface GridForeignKey {

--- a/apps/studio/components/grid/utils/gridColumns.tsx
+++ b/apps/studio/components/grid/utils/gridColumns.tsx
@@ -8,6 +8,7 @@ import { NumberEditor } from '../components/editor/NumberEditor'
 import { SelectEditor } from '../components/editor/SelectEditor'
 import { TextEditor } from '../components/editor/TextEditor'
 import { TimeEditor, TimeWithTimezoneEditor } from '../components/editor/TimeEditor'
+import { BinaryFormatter } from '../components/formatter/BinaryFormatter'
 import { BooleanFormatter } from '../components/formatter/BooleanFormatter'
 import { DefaultFormatter } from '../components/formatter/DefaultFormatter'
 import { ForeignKeyFormatter } from '../components/formatter/ForeignKeyFormatter'
@@ -18,6 +19,7 @@ import { SelectColumn } from '../components/grid/SelectColumn'
 import type { ColumnType, SupaColumn, SupaRow, SupaTable } from '../types'
 import {
   isArrayColumn,
+  isBinaryColumn,
   isBoolColumn,
   isCiTextColumn,
   isDateColumn,
@@ -65,7 +67,6 @@ export function getGridColumns(
       minWidth: COLUMN_MIN_WIDTH,
       frozen: x.isPrimaryKey || false,
       isLastFrozenColumn: false,
-      // rowGroup: false,
       renderHeaderCell: (props) => (
         <ColumnHeader
           {...props}
@@ -204,6 +205,9 @@ function getCellRenderer(
         )
       }
     }
+    case 'binary': {
+      return BinaryFormatter
+    }
     case 'json': {
       return JsonFormatter
     }
@@ -236,6 +240,8 @@ function getColumnType(columnDef: SupaColumn): ColumnType {
     return 'boolean'
   } else if (isEnumColumn(columnDef.dataType)) {
     return 'enum'
+  } else if (isBinaryColumn(columnDef.dataType)) {
+    return 'binary'
   } else return 'unknown'
 }
 

--- a/apps/studio/components/grid/utils/types.ts
+++ b/apps/studio/components/grid/utils/types.ts
@@ -69,6 +69,11 @@ export function isEnumColumn(type: string) {
   return ENUM_TYPES.indexOf(type.toLowerCase()) > -1
 }
 
+const BINARY_TYPES = ['bytea']
+export function isBinaryColumn(type: string) {
+  return BINARY_TYPES.indexOf(type.toLowerCase()) > -1
+}
+
 export function isForeignKeyColumn(columnDef: SupaColumn) {
   const { targetTableSchema, targetTableName, targetColumnName } = columnDef?.foreignKey ?? {}
   return !!targetTableSchema && !!targetTableName && !!targetColumnName

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnType.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnType.tsx
@@ -74,6 +74,8 @@ const ColumnType = ({
   const isAvailableType = value ? availableTypes.includes(value) : true
   const recommendation = RECOMMENDED_ALTERNATIVE_DATA_TYPE[value]
 
+  const unsupportedDataTypeText = `This column's data type cannot be changed via the Table Editor as it is not supported yet. You can do so through the SQL Editor instead.`
+
   const getOptionByName = (name: string) => {
     // handle built in types
     const pgOption = POSTGRES_DATA_TYPE_OPTIONS.find((option) => option.name === name)
@@ -124,17 +126,12 @@ const ColumnType = ({
             size="small"
             icon={inferIcon(POSTGRES_DATA_TYPE_OPTIONS.find((x) => x.name === value)?.type ?? '')}
             value={value}
-            descriptionText={
-              showLabel
-                ? 'Custom non-native psql data types currently cannot be changed to a different data type via Supabase Studio'
-                : ''
-            }
+            descriptionText={showLabel ? unsupportedDataTypeText : undefined}
           />
         </TooltipTrigger>
         {!showLabel && (
           <TooltipContent side="bottom" className="w-80">
-            Custom non-native psql data types currently cannot be changed to a different data type
-            via Supabase Studio
+            {unsupportedDataTypeText}
           </TooltipContent>
         )}
       </Tooltip>

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/ForeignRowSelector/ForeignRowSelector.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/ForeignRowSelector/ForeignRowSelector.tsx
@@ -19,6 +19,7 @@ import { useRoleImpersonationStateSnapshot } from 'state/role-impersonation-stat
 import { Button, SidePanel } from 'ui'
 import ActionBar from '../../ActionBar'
 import { ForeignKey } from '../../ForeignKeySelector/ForeignKeySelector.types'
+import { convertByteaToHex } from '../RowEditor.utils'
 import Pagination from './Pagination'
 import SelectorGrid from './SelectorGrid'
 
@@ -176,7 +177,12 @@ const ForeignRowSelector = ({
                   rows={data.rows}
                   onRowSelect={(row) => {
                     const value = columns?.reduce((a, b) => {
-                      return { ...a, [b.source]: row[b.target] }
+                      const targetColumn = selectedTable?.columns.find((x) => x.name === b.target)
+                      const value =
+                        targetColumn?.format === 'bytea'
+                          ? convertByteaToHex(row[b.target])
+                          : row[b.target]
+                      return { ...a, [b.source]: value }
                     }, {})
                     onSelect(value)
                   }}

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/ForeignRowSelector/SelectorGrid.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/ForeignRowSelector/SelectorGrid.tsx
@@ -7,6 +7,7 @@ import {
 import { Key } from 'lucide-react'
 import DataGrid, { Column } from 'react-data-grid'
 import { Tooltip, TooltipContent, TooltipTrigger } from 'ui'
+import { convertByteaToHex } from '../RowEditor.utils'
 
 export interface SelectorGridProps {
   table: SupaTable
@@ -33,8 +34,13 @@ const columnRender = (name: string, isPrimaryKey = false) => {
   )
 }
 
-const formatter = (column: string, row: SupaRow) => {
-  const formattedValue = typeof row[column] === 'object' ? JSON.stringify(row[column]) : row[column]
+const formatter = ({ column, format, row }: { column: string; format: string; row: SupaRow }) => {
+  const formattedValue =
+    format === 'bytea'
+      ? convertByteaToHex(row[column])
+      : typeof row[column] === 'object'
+        ? JSON.stringify(row[column])
+        : row[column]
   return (
     <div className="group sb-grid-select-cell__formatter overflow-hidden">
       <span className="text-sm truncate">{formattedValue}</span>
@@ -53,7 +59,8 @@ const SelectorGrid = ({ table, rows, onRowSelect }: SelectorGridProps) => {
     const result: Column<SupaRow> = {
       key: column.name,
       name: column.name,
-      renderCell: (props) => formatter(column.name, props.row),
+      renderCell: (props) =>
+        formatter({ column: column.name, format: column.format, row: props.row }),
       renderHeaderCell: () => columnRender(column.name, column.isPrimaryKey),
       resizable: true,
       width: columnWidth,

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/InputField.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/InputField.tsx
@@ -293,6 +293,28 @@ const InputField = ({
     )
   }
 
+  if (field.format === 'bytea') {
+    return (
+      <Input
+        data-testid={`${field.name}-input`}
+        layout="horizontal"
+        label={field.name}
+        descriptionText={
+          <>
+            {field.comment && <p>{field.comment}</p>}
+            <p>Bytea columns are edited and displayed as hex in the dashboard</p>
+          </>
+        }
+        labelOptional={field.format}
+        error={errors[field.name]}
+        value={field.value ?? ''}
+        placeholder={`\\x`}
+        disabled={!isEditable}
+        onChange={(event: any) => onUpdateField({ [field.name]: event.target.value })}
+      />
+    )
+  }
+
   return (
     <Input
       data-testid={`${field.name}-input`}

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.tsx
@@ -14,6 +14,7 @@ import InputField from './InputField'
 import { JsonEditor } from './JsonEditor'
 import type { EditValue, RowField } from './RowEditor.types'
 import {
+  convertByteaToHex,
   generateRowFields,
   generateRowObjectFromFields,
   generateUpdateRowPayload,
@@ -130,7 +131,10 @@ const RowEditor = ({
       if (!isNewRecord) {
         const primaryKeyColumns = rowFields.filter((field) => field.isPrimaryKey)
         const identifiers = {} as Dictionary<any>
-        primaryKeyColumns.forEach((column) => (identifiers[column.name] = row![column.name]))
+        primaryKeyColumns.forEach((column) => {
+          identifiers[column.name] =
+            column.format === 'bytea' ? convertByteaToHex(row![column.name]) : row![column.name]
+        })
         configuration.identifiers = identifiers
         configuration.rowIdx = row!.idx
       }

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.utils.ts
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.utils.ts
@@ -121,6 +121,8 @@ export const parseValue = (originalValue: any, format: string) => {
       return originalValue
     } else if (typeof originalValue === 'number' || !format) {
       return originalValue
+    } else if (format === 'bytea') {
+      return convertByteaToHex(originalValue)
     } else if (typeof originalValue === 'object') {
       return JSON.stringify(originalValue)
     } else if (typeof originalValue === 'boolean') {
@@ -261,4 +263,8 @@ export const generateUpdateRowPayload = (originalRow: any, fields: RowField[]) =
  */
 export const isValueTruncated = (value: string | null | undefined) => {
   return value?.endsWith('...') && (value ?? '').length > MAX_CHARACTERS
+}
+
+export const convertByteaToHex = (value: { type: 'Buffer'; data: number[] }) => {
+  return `\\x${Buffer.from(value.data).toString('hex')}`
 }

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.constants.ts
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.constants.ts
@@ -1,4 +1,4 @@
-import { sortBy, concat } from 'lodash'
+import { concat, sortBy } from 'lodash'
 import type { PostgresDataTypeOption } from './SidePanelEditor.types'
 
 export const NUMERICAL_TYPES = [
@@ -18,7 +18,7 @@ export const DATE_TYPES = ['date']
 export const TIME_TYPES = ['time', 'timetz']
 export const DATETIME_TYPES = concat(TIMESTAMP_TYPES, DATE_TYPES, TIME_TYPES)
 
-export const OTHER_DATA_TYPES = ['uuid', 'bool', 'vector']
+export const OTHER_DATA_TYPES = ['uuid', 'bool', 'vector', 'bytea']
 export const POSTGRES_DATA_TYPES = sortBy(
   concat(NUMERICAL_TYPES, JSON_TYPES, TEXT_TYPES, DATETIME_TYPES, OTHER_DATA_TYPES)
 )

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.constants.ts
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.constants.ts
@@ -132,4 +132,9 @@ export const POSTGRES_DATA_TYPE_OPTIONS: PostgresDataTypeOption[] = [
     description: 'Logical boolean (true/false)',
     type: 'bool',
   },
+  {
+    name: 'bytea',
+    description: 'Variable-length binary string',
+    type: 'others',
+  },
 ]

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
@@ -30,6 +30,7 @@ import type { ForeignKey } from './ForeignKeySelector/ForeignKeySelector.types'
 import ForeignRowSelector from './RowEditor/ForeignRowSelector/ForeignRowSelector'
 import JsonEditor from './RowEditor/JsonEditor/JsonEditor'
 import RowEditor from './RowEditor/RowEditor'
+import { convertByteaToHex } from './RowEditor/RowEditor.utils'
 import { TextEditor } from './RowEditor/TextEditor'
 import SchemaEditor from './SchemaEditor'
 import type { ColumnField, CreateColumnPayload, UpdateColumnPayload } from './SidePanelEditor.types'
@@ -196,7 +197,11 @@ const SidePanelEditor = ({
     try {
       const { row } = selectedForeignKeyToEdit
       const identifiers = {} as Dictionary<any>
-      selectedTable.primary_keys.forEach((column) => (identifiers[column.name] = row![column.name]))
+      selectedTable.primary_keys.forEach((column) => {
+        const col = selectedTable.columns?.find((x) => x.name === column.name)
+        identifiers[column.name] =
+          col?.format === 'bytea' ? convertByteaToHex(row![column.name]) : row![column.name]
+      })
 
       const isNewRecord = false
       const configuration = { identifiers, rowIdx: row.idx }

--- a/apps/studio/components/interfaces/TableGridEditor/TableGridEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/TableGridEditor.tsx
@@ -29,6 +29,7 @@ import type { Dictionary } from 'types'
 import GridHeaderActions from './GridHeaderActions'
 import { TableGridSkeletonLoader } from './LoadingState'
 import NotFoundState from './NotFoundState'
+import { convertByteaToHex } from './SidePanelEditor/RowEditor/RowEditor.utils'
 import SidePanelEditor from './SidePanelEditor/SidePanelEditor'
 import TableDefinition from './TableDefinition'
 
@@ -170,9 +171,13 @@ const TableGridEditor = ({
 
     const identifiers = {} as Dictionary<any>
     isTableLike(selectedTable) &&
-      selectedTable.primary_keys.forEach(
-        (column) => (identifiers[column.name] = previousRow[column.name])
-      )
+      selectedTable.primary_keys.forEach((column) => {
+        const col = selectedTable.columns.find((c) => c.name === column.name)
+        identifiers[column.name] =
+          col?.format === 'bytea'
+            ? convertByteaToHex(previousRow[column.name])
+            : previousRow[column.name]
+      })
 
     const configuration = { identifiers }
     if (Object.keys(identifiers).length === 0) {

--- a/apps/studio/components/interfaces/TableGridEditor/TableGridEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/TableGridEditor.tsx
@@ -33,9 +33,7 @@ import SidePanelEditor from './SidePanelEditor/SidePanelEditor'
 import TableDefinition from './TableDefinition'
 
 export interface TableGridEditorProps {
-  /** Theme for the editor */
   theme?: 'dark' | 'light'
-
   isLoadingSelectedTable?: boolean
   selectedTable?: Entity
 }


### PR DESCRIPTION
Fixes FE-1373

`bytea` data type will be rendered and managed as hexadecimal values in the Table Editor

- Can select `bytea` as a column type 
<img src="https://github.com/user-attachments/assets/e4d73d62-495d-4909-acf5-6edecbb65a42" width="600" />

- Can render `bytea` data in RowEditor + Grid
![image](https://github.com/user-attachments/assets/15bf6d33-2890-4518-baca-da3a4658e031)

- Can edit `bytea` data in RowEditor + Grid
![image](https://github.com/user-attachments/assets/1b3bc87f-0a10-4d91-a53c-548eadc2d69d)

Just need to check on the following
- [ ] Can create a bytea column
- [ ] Can insert a row in a table with a bytea column
- [ ] Can update a row in a table with a bytea column with SidePanelEditor
- [ ] Can update a row in a table with a bytea column in Grid
- [ ] Can delete a row in a table with a bytea column with SidePanelEditor
- [ ] Can delete a row in a table with a bytea column in Grid
