### PR TITLE
fix: typo in error msg for when duplicate indexes exist

### DIFF
--- a/apps/studio/pages/api/platform/projects/[ref]/run-lints.ts
+++ b/apps/studio/pages/api/platform/projects/[ref]/run-lints.ts
@@ -559,7 +559,7 @@ select
     'WARN' as level,
     'EXTERNAL' as facing,
     array['PERFORMANCE'] as categories,
-    'Detects cases where two ore more identical indexes exist.' as description,
+    'Detects cases where two or more identical indexes exist.' as description,
     format(
         'Table \`%s.%s\` has identical indexes %s. Drop all except one of them',
         n.nspname,


### PR DESCRIPTION
## What is the current behavior?

![CleanShot 2025-02-04 at 21 50 37@2x](https://github.com/user-attachments/assets/695205ad-c996-4cab-856f-b2dbff7cdce7)


## What is the new behavior?

![CleanShot 2025-02-04 at 21 51 27@2x](https://github.com/user-attachments/assets/65908d6a-6855-47b9-8159-ae3bdec117a9)

