### PR TITLE
fix: default state for SqlToRest translator

### DIFF
--- a/packages/ui-patterns/SqlToRest/index.tsx
+++ b/packages/ui-patterns/SqlToRest/index.tsx
@@ -3,6 +3,7 @@
 import dynamic from 'next/dynamic.js'
 import { ErrorBoundary, FallbackProps } from 'react-error-boundary'
 import { Admonition } from '../admonition'
+import { SqlToRestProps } from './sql-to-rest'
 
 function FallbackComponent({ error }: FallbackProps) {
   if (error instanceof Error && error.message === 'WebAssembly is not defined') {
@@ -26,10 +27,10 @@ function FallbackComponent({ error }: FallbackProps) {
 // Lazy load client side to prevent hydration issues when browser produces an error
 const SqlToRest = dynamic(() => import('./sql-to-rest'))
 
-export default function SqlToRestWithFallback() {
+export default function SqlToRestWithFallback(props: SqlToRestProps) {
   return (
     <ErrorBoundary FallbackComponent={FallbackComponent}>
-      <SqlToRest />
+      <SqlToRest {...props} />
     </ErrorBoundary>
   )
 }


### PR DESCRIPTION
This was wrapped in an ErrorBoundary to prevent full-app crashes, but at the time, we forgot about drilling the props through, so the default state no longer shows. -_-""

Before:
![image](https://github.com/user-attachments/assets/b55769cb-1fc2-4863-859c-6d62cd1fe4be)


After:
![image](https://github.com/user-attachments/assets/c4a7ed62-953b-4b58-b01b-550469a82895)

Fixes #33241