### PR TITLE
feat: add warnings to logs bar chart

### DIFF
--- a/apps/studio/components/interfaces/Settings/Logs/Logs.utils.ts
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.utils.ts
@@ -329,8 +329,9 @@ export const genChartQuery = (
 SELECT
 -- log-event-chart
   timestamp_trunc(t.timestamp, ${trunc}) as timestamp,
-  count(CASE WHEN NOT (${errorCondition}) THEN 1 END) as ok_count,
+  count(CASE WHEN NOT (${errorCondition}) AND NOT (${getWarningCondition(table)}) THEN 1 END) as ok_count,
   count(CASE WHEN ${errorCondition} THEN 1 END) as error_count,
+  count(CASE WHEN ${getWarningCondition(table)} THEN 1 END) as warning_count,
 FROM
   ${table} t
   ${joins}
@@ -583,16 +584,33 @@ export function checkForWildcard(query: string) {
   return wildcardRegex.test(queryWithoutCount)
 }
 
+function getWarningCondition(table: LogsTableName): string {
+  switch (table) {
+    case 'edge_logs':
+      return 'response.status_code >= 400 AND response.status_code < 500'
+    case 'postgres_logs':
+      return "parsed.error_severity = 'WARNING'"
+    case 'auth_logs':
+      return "metadata.level = 'warning' OR (metadata.status >= 400 AND metadata.status < 500)"
+    case 'function_edge_logs':
+      return 'response.status_code >= 400 AND response.status_code < 500'
+    case 'function_logs':
+      return "metadata.level = 'warn'"
+    default:
+      return 'false' // Default to no warnings if table type is unknown
+  }
+}
+
 function getErrorCondition(table: LogsTableName): string {
   switch (table) {
     case 'edge_logs':
-      return 'response.status_code >= 400'
+      return 'response.status_code >= 500'
     case 'postgres_logs':
       return "parsed.error_severity IN ('ERROR', 'FATAL', 'PANIC')"
     case 'auth_logs':
-      return "metadata.level = 'error' OR metadata.status >= 400"
+      return "metadata.level = 'error' OR metadata.status >= 500"
     case 'function_edge_logs':
-      return 'response.status_code >= 400'
+      return 'response.status_code >= 500'
     case 'function_logs':
       return "metadata.level IN ('error', 'fatal')"
     default:

--- a/packages/ui-patterns/LogsBarChart/index.tsx
+++ b/packages/ui-patterns/LogsBarChart/index.tsx
@@ -10,12 +10,15 @@ const CHART_COLORS = {
   AXIS: 'hsl(var(--background-overlay-hover))',
   GREEN_1: 'hsl(var(--brand-default))',
   GREEN_2: 'hsl(var(--brand-500))',
+  YELLOW_1: 'hsl(var(--warning-default))',
+  YELLOW_2: 'hsl(var(--warning-500))',
   RED_1: 'hsl(var(--destructive-default))',
   RED_2: 'hsl(var(--destructive-500))',
 }
 type LogsBarChartDatum = {
   timestamp: string
   error_count: number
+  warning_count: number
   ok_count: number
 }
 export const LogsBarChart = ({
@@ -46,6 +49,9 @@ export const LogsBarChart = ({
           {
             error_count: {
               label: 'Errors',
+            },
+            warning_count: {
+              label: 'Warnings',
             },
             ok_count: {
               label: 'Ok',
@@ -99,6 +105,21 @@ export const LogsBarChart = ({
                   focusDataIndex === index || focusDataIndex === null
                     ? CHART_COLORS.RED_1
                     : CHART_COLORS.RED_2
+                }
+              />
+            ))}
+          </Bar>
+
+          {/* Warning bars */}
+          <Bar dataKey="warning_count" fill={CHART_COLORS.YELLOW_1} maxBarSize={24} stackId="stack">
+            {data?.map((_entry: LogsBarChartDatum, index: number) => (
+              <Cell
+                className="cursor-pointer transition-colors"
+                key={`warning-${index}`}
+                fill={
+                  focusDataIndex === index || focusDataIndex === null
+                    ? CHART_COLORS.YELLOW_1
+                    : CHART_COLORS.YELLOW_2
                 }
               />
             ))}


### PR DESCRIPTION
This PR adds warnings to the logs bar chart with the following changes:

- Add warning category to logs bar chart with yellow color scheme
- Move 4xx errors to warning category (from error)
- Add warning conditions for different log types (edge_logs, postgres_logs, auth_logs, function_logs)
- Update chart query to include warning counts

The changes include:
1. Updated LogsBarChart component to support warning_count with yellow color scheme
2. Added getWarningCondition function to handle different warning conditions per log type
3. Updated getErrorCondition to only consider 5xx as errors
4. Modified chart query to properly count warnings and separate them from errors

### Testing
The changes can be tested by:
1. Viewing the logs bar chart and verifying the yellow warning bars appear
2. Confirming that 4xx errors show up as warnings (yellow) instead of errors (red)
3. Checking that 5xx errors still show up as errors (red)
4. Verifying that the counts are correct for each category (ok, warning, error)