### PR TITLE
Only send required data for reset password, magic link and send OTP

### DIFF
--- a/apps/studio/data/auth/user-reset-password-mutation.ts
+++ b/apps/studio/data/auth/user-reset-password-mutation.ts
@@ -13,7 +13,7 @@ export type UserResetPasswordVariables = {
 export async function resetPassword({ projectRef, user }: UserResetPasswordVariables) {
   const { data, error } = await post('/platform/auth/{ref}/recover', {
     params: { path: { ref: projectRef } },
-    body: user,
+    body: { email: user.email },
   })
 
   if (error) handleError(error)

--- a/apps/studio/data/auth/user-send-magic-link-mutation.ts
+++ b/apps/studio/data/auth/user-send-magic-link-mutation.ts
@@ -13,7 +13,7 @@ export type UserSendMagicLinkVariables = {
 export async function sendMagicLink({ projectRef, user }: UserSendMagicLinkVariables) {
   const { data, error } = await post('/platform/auth/{ref}/magiclink', {
     params: { path: { ref: projectRef } },
-    body: user,
+    body: { email: user.email },
   })
 
   if (error) handleError(error)

--- a/apps/studio/data/auth/user-send-otp-mutation.ts
+++ b/apps/studio/data/auth/user-send-otp-mutation.ts
@@ -13,7 +13,7 @@ export type UserSendOTPVariables = {
 export async function sendOTP({ projectRef, user }: UserSendOTPVariables) {
   const { data, error } = await post('/platform/auth/{ref}/otp', {
     params: { path: { ref: projectRef } },
-    body: user,
+    body: { phone: user.phone },
   })
 
   if (error) handleError(error)


### PR DESCRIPTION
Auth/users: Hitting "Send password recovery", "Send Magic link" (and Send OTP probably) shows an error "property providers should not exist"
![image](https://github.com/user-attachments/assets/834af55b-ae8a-467c-b4a6-46902fa83d86)

We recently added a new property when fetching users to display on that page, but because we're sending the whole user JSON to those calls, the API is hence throwing an error. We don't need to send the whole user JSON actually, just the required data
