### PR TITLE
chore: move visible state for ongoing queries to global app state

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/OngoingQueriesPanel.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/OngoingQueriesPanel.tsx
@@ -1,6 +1,6 @@
 import dayjs from 'dayjs'
 import { RefreshCw, StopCircle } from 'lucide-react'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
 
 import AlertError from 'components/ui/AlertError'
@@ -28,6 +28,7 @@ import {
 } from 'ui'
 import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
 import { useAppStateSnapshot } from 'state/app-state'
+import { useParams } from 'common'
 
 interface OngoingQueriesPanel {
   onClose: () => void
@@ -35,6 +36,7 @@ interface OngoingQueriesPanel {
 
 export const OngoingQueriesPanel = () => {
   const [_, setParams] = useUrlState({ replace: true })
+  const { viewOngoingQueries } = useParams()
   const project = useSelectedProject()
   const state = useDatabaseSelectorStateSnapshot()
   const appState = useAppStateSnapshot()
@@ -61,6 +63,13 @@ export const OngoingQueriesPanel = () => {
     }
   )
   const queries = data ?? []
+
+  useEffect(() => {
+    if (viewOngoingQueries) {
+      appState.setOnGoingQueriesPanelOpen(true)
+      setParams({ viewOngoingQueries: undefined })
+    }
+  }, [viewOngoingQueries])
 
   const { mutate: abortQuery, isLoading } = useQueryAbortMutation({
     onSuccess: () => {

--- a/apps/studio/components/interfaces/SQLEditor/OngoingQueriesPanel.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/OngoingQueriesPanel.tsx
@@ -27,16 +27,17 @@ import {
   cn,
 } from 'ui'
 import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
+import { useAppStateSnapshot } from 'state/app-state'
 
 interface OngoingQueriesPanel {
-  visible: boolean
   onClose: () => void
 }
 
-export const OngoingQueriesPanel = ({ visible, onClose }: OngoingQueriesPanel) => {
+export const OngoingQueriesPanel = () => {
   const [_, setParams] = useUrlState({ replace: true })
   const project = useSelectedProject()
   const state = useDatabaseSelectorStateSnapshot()
+  const appState = useAppStateSnapshot()
   const [selectedId, setSelectedId] = useState<number>()
 
   const { data: databases } = useReadReplicasQuery({ projectRef: project?.ref })
@@ -70,12 +71,12 @@ export const OngoingQueriesPanel = ({ visible, onClose }: OngoingQueriesPanel) =
 
   const closePanel = () => {
     setParams({ viewOngoingQueries: undefined })
-    onClose()
+    appState.setOnGoingQueriesPanelOpen(false)
   }
 
   return (
     <>
-      <Sheet open={visible} onOpenChange={() => closePanel()}>
+      <Sheet open={appState.ongoingQueriesPanelOpen} onOpenChange={() => closePanel()}>
         <SheetContent size="lg">
           <SheetHeader>
             <SheetTitle className="flex items-center gap-x-2">

--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorLayout.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorLayout.tsx
@@ -12,22 +12,7 @@ export interface SQLEditorLayoutProps {
 }
 
 const SQLEditorLayout = ({ title, children }: SQLEditorLayoutProps) => {
-  const { viewOngoingQueries } = useParams()
-  const [showOngoingQueries, setShowOngoingQueries] = useState(false)
-
-  const productMenu = useMemo(
-    () => (
-      <SQLEditorMenu
-        key="sql-editor-menu"
-        onViewOngoingQueries={() => setShowOngoingQueries(true)}
-      />
-    ),
-    []
-  )
-
-  useEffect(() => {
-    if (viewOngoingQueries === 'true') setShowOngoingQueries(true)
-  }, [viewOngoingQueries])
+  const productMenu = useMemo(() => <SQLEditorMenu key="sql-editor-menu" />, [])
 
   return (
     <ProjectLayout

--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorLayout.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorLayout.tsx
@@ -38,10 +38,7 @@ const SQLEditorLayout = ({ title, children }: SQLEditorLayoutProps) => {
       resizableSidebar
     >
       {children}
-      <OngoingQueriesPanel
-        visible={showOngoingQueries}
-        onClose={() => setShowOngoingQueries(false)}
-      />
+      <OngoingQueriesPanel />
     </ProjectLayout>
   )
 }

--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorMenu.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorMenu.tsx
@@ -31,6 +31,7 @@ import {
 } from 'ui-patterns/InnerSideMenu'
 import { SQLEditorNav } from './SQLEditorNavV2/SQLEditorNav'
 import { SearchList } from './SQLEditorNavV2/SearchList'
+import { getAppStateSnapshot } from 'state/app-state'
 
 interface SQLEditorMenuProps {
   onViewOngoingQueries: () => void
@@ -50,6 +51,7 @@ export const SQLEditorMenu = ({ onViewOngoingQueries }: SQLEditorMenuProps) => {
     'inserted_at'
   )
 
+  const appState = getAppStateSnapshot()
   const debouncedSearch = useDebounce(search, 500)
 
   const canCreateSQLSnippet = useCheckPermissions(PermissionAction.CREATE, 'user_content', {
@@ -188,7 +190,7 @@ export const SQLEditorMenu = ({ onViewOngoingQueries }: SQLEditorMenuProps) => {
       </div>
 
       <div className="p-4 border-t sticky bottom-0 bg-studio">
-        <Button block type="default" onClick={onViewOngoingQueries}>
+        <Button block type="default" onClick={() => appState.setOnGoingQueriesPanelOpen(true)}>
           View running queries
         </Button>
       </div>

--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorMenu.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorMenu.tsx
@@ -33,11 +33,7 @@ import { SQLEditorNav } from './SQLEditorNavV2/SQLEditorNav'
 import { SearchList } from './SQLEditorNavV2/SearchList'
 import { getAppStateSnapshot } from 'state/app-state'
 
-interface SQLEditorMenuProps {
-  onViewOngoingQueries: () => void
-}
-
-export const SQLEditorMenu = ({ onViewOngoingQueries }: SQLEditorMenuProps) => {
+export const SQLEditorMenu = () => {
   const router = useRouter()
   const { profile } = useProfile()
   const project = useSelectedProject()

--- a/apps/studio/state/app-state.ts
+++ b/apps/studio/state/app-state.ts
@@ -68,7 +68,6 @@ const getInitialState = () => {
       showGenerateSqlModal: false,
       navigationPanelOpen: false,
       navigationPanelJustClosed: false,
-      showConnectDialog: false,
       ongoingQueriesPanelOpen: false,
     }
   }
@@ -113,7 +112,6 @@ const getInitialState = () => {
     showGenerateSqlModal: false,
     navigationPanelOpen: false,
     navigationPanelJustClosed: false,
-    showConnectDialog: false,
     ongoingQueriesPanelOpen: false,
   }
 }

--- a/apps/studio/state/app-state.ts
+++ b/apps/studio/state/app-state.ts
@@ -68,6 +68,8 @@ const getInitialState = () => {
       showGenerateSqlModal: false,
       navigationPanelOpen: false,
       navigationPanelJustClosed: false,
+      showConnectDialog: false,
+      ongoingQueriesPanelOpen: false,
     }
   }
 
@@ -111,6 +113,8 @@ const getInitialState = () => {
     showGenerateSqlModal: false,
     navigationPanelOpen: false,
     navigationPanelJustClosed: false,
+    showConnectDialog: false,
+    ongoingQueriesPanelOpen: false,
   }
 }
 
@@ -216,6 +220,11 @@ export const appState = proxy({
       ...appState.aiAssistantPanel,
       messages: [...appState.aiAssistantPanel.messages, message],
     }
+  },
+
+  showOngoingQueriesPanelOpen: false,
+  setOnGoingQueriesPanelOpen: (value: boolean) => {
+    appState.ongoingQueriesPanelOpen = value
   },
 })
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

- move ongoing queries panel visible state to app state

