### PR TITLE
Check for value before converting bytea to hex in ForeignKeyFormatter

### DIFF
--- a/apps/studio/components/grid/components/formatter/ForeignKeyFormatter.tsx
+++ b/apps/studio/components/grid/components/formatter/ForeignKeyFormatter.tsx
@@ -50,7 +50,8 @@ export const ForeignKeyFormatter = (props: Props) => {
   )
 
   const value = row[column.key]
-  const formattedValue = foreignKeyColumn?.format === 'bytea' ? convertByteaToHex(value) : value
+  const formattedValue =
+    foreignKeyColumn?.format === 'bytea' && !!value ? convertByteaToHex(value) : value
 
   return (
     <div className="sb-grid-foreign-key-formatter flex justify-between">


### PR DESCRIPTION
As per title - causes an issue if the column is bytea data type, has a foreign key, and is NULL