### PR TITLE
docs: fix param name for storage python method

### DIFF
--- a/apps/docs/spec/supabase_py_v2.yml
+++ b/apps/docs/spec/supabase_py_v2.yml
@@ -6925,7 +6925,7 @@ functions:
         isOptional: false
         type: BufferedReader | bytes | FileIO | string | Path
         description: The body of the file to be stored in the bucket.
-      - name: options
+      - name: file_options
         isOptional: false
         type: FileOptions
         subContent:
@@ -6979,7 +6979,7 @@ functions:
         isOptional: false
         type: BufferedReader | bytes | FileIO | string | Path
         description: The body of the file to be stored in the bucket.
-      - name: options
+      - name: file_options
         isOptional: false
         type: FileOptions
         subContent:


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES/NO

## What kind of change does this PR introduce?

Fix https://github.com/supabase/storage-py/issues/348

## What is the current behavior?

Param named as `options`

## What is the new behavior?

Correct param name is `file_options`

## Additional context

Add any other context or screenshots.
