### PR TITLE
www: supabase cron wrong url

### DIFF
--- a/apps/www/data/products/modules/cron.tsx
+++ b/apps/www/data/products/modules/cron.tsx
@@ -8,7 +8,7 @@ export default () => ({
   metaDescription:
     'Supabase Cron is a Postgres Module that uses the pg_cron database extension to manage recurring tasks. Manage your Cron Jobs using any Postgres tooling.',
   metaImage: '/images/modules/cron/og.png',
-  url: 'https://supabase.com/dashboard/project/_/integrations/cron-jobs/overview',
+  url: 'https://supabase.com/dashboard/project/_/integrations/cron/overview',
   docsUrl: '/docs/guides/cron',
   heroSection: {
     title: 'Supabase Cron',
@@ -22,7 +22,7 @@ export default () => ({
     icon: PRODUCT_MODULES['cron'].icon[24],
     cta: {
       label: 'Schedule your first Job',
-      link: 'https://supabase.com/dashboard/project/_/integrations/cron-jobs/overview',
+      link: 'https://supabase.com/dashboard/project/_/integrations/cron/overview',
     },
     secondaryCta: {
       label: 'Explore documentation',


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Supabase website - [Supabase Cron](https://supabase.com/modules/cron)

## What is the current behavior?

Click on the link will direct you to the your project select but the following happens:

<img width="1291" alt="Screenshot 2025-02-05 at 21 06 20" src="https://github.com/user-attachments/assets/dfc18345-d01d-46ba-94c2-af6037769406" />


## What is the new behavior?

URL goes to the correct integration

