### PR TITLE
chore(studio): cache favicon

### DIFF
--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -115,6 +115,10 @@ const nextConfig = {
           },
         ],
       },
+      {
+        source: '/favicon/:slug*',
+        headers: [{ key: 'cache-control', value: 'public, max-age=86400' }],
+      },
     ]
   },
 

--- a/apps/studio/next.config.js
+++ b/apps/studio/next.config.js
@@ -506,18 +506,19 @@ const nextConfig = {
       },
       {
         source: '/img/:slug*',
-        headers: [{ key: 'cache-control', value: 'max-age=2592000' }],
+        headers: [{ key: 'cache-control', value: 'public, max-age=2592000' }],
+      },
+      {
+        source: '/css/fonts.css',
+        headers: [{ key: 'cache-control', value: 'public, max-age=86400' }],
       },
       {
         source: '/fonts/:slug*',
-        headers: [{ key: 'cache-control', value: 'max-age=2592000' }],
+        headers: [{ key: 'cache-control', value: 'public, max-age=2592000' }],
       },
       {
-        source: '/favicon/favicon.ico',
-        headers: [
-          // Cached for 1 day, but browsers can use a stale version for up to 7 days
-          { key: 'cache-control', value: 'public, max-age=86400, stale-while-revalidate=604800' },
-        ],
+        source: '/favicon/:slug*',
+        headers: [{ key: 'cache-control', value: 'public, max-age=86400' }],
       },
     ]
   },

--- a/apps/studio/next.config.js
+++ b/apps/studio/next.config.js
@@ -512,6 +512,13 @@ const nextConfig = {
         source: '/fonts/:slug*',
         headers: [{ key: 'cache-control', value: 'max-age=2592000' }],
       },
+      {
+        source: '/favicon/favicon.ico',
+        headers: [
+          // Cached for 1 day, but browsers can use a stale version for up to 7 days
+          { key: 'cache-control', value: 'public, max-age=86400, stale-while-revalidate=604800' },
+        ],
+      },
     ]
   },
   images: {

--- a/apps/www/next.config.mjs
+++ b/apps/www/next.config.mjs
@@ -80,6 +80,10 @@ const nextConfig = {
           },
         ],
       },
+      {
+        source: '/favicon/:slug*',
+        headers: [{ key: 'cache-control', value: 'public, max-age=86400' }],
+      },
     ]
   },
   async rewrites() {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Our largest bandwidth usage path on vercel is this particular favicon. By enabling browser caching it should prevent it being requested so much.

This PR also tweaks the font cache control rules.