### PR TITLE
Create MultiSelector with creatable flag

### DIFF
--- a/apps/design-system/__registry__/index.tsx
+++ b/apps/design-system/__registry__/index.tsx
@@ -1919,6 +1919,17 @@ export const Index: Record<string, any> = {
       subcategory: "undefined",
       chunks: []
     },
+    "multi-select-combobox-creatable": {
+      name: "multi-select-combobox-creatable",
+      type: "components:example",
+      registryDependencies: undefined,
+      component: React.lazy(() => import("@/registry/default/example/multi-select-combobox-creatable")),
+      source: "",
+      files: ["registry/default/example/multi-select-combobox.tsx"],
+      category: "undefined",
+      subcategory: "undefined",
+      chunks: []
+    },
     "multi-select-deletable-badge": {
       name: "multi-select-deletable-badge",
       type: "components:example",

--- a/apps/design-system/content/docs/fragments/multi-select.mdx
+++ b/apps/design-system/content/docs/fragments/multi-select.mdx
@@ -50,7 +50,7 @@ Use `MultiSelectorInput`to add a search input.
 ### Badge Combo Box with creatable selector
 
 creatable: `boolean`
-`creatable` prop on the `MultiSelectorList` component can be used to add a new option if no items match 
+`creatable` prop on the `MultiSelectorList` component can be used to add a new option if no items match
 
 <ComponentPreview name="multi-select-combobox-creatable" />
 

--- a/apps/design-system/content/docs/fragments/multi-select.mdx
+++ b/apps/design-system/content/docs/fragments/multi-select.mdx
@@ -47,6 +47,13 @@ Use `MultiSelectorInput`to add a search input.
 
 <ComponentPreview name="multi-select-combobox" />
 
+### Badge Combo Box with creatable selector
+
+creatable: `boolean`
+`creatable` prop on the `MultiSelectorList` component can be used to add a new option if no items match 
+
+<ComponentPreview name="multi-select-combobox-creatable" />
+
 ### Badge Limit
 
 badgeLimit: `number` | `"wrap"`.

--- a/apps/design-system/registry/default/example/multi-select-combobox-creatable.tsx
+++ b/apps/design-system/registry/default/example/multi-select-combobox-creatable.tsx
@@ -1,0 +1,34 @@
+import { useState } from 'react'
+import {
+  MultiSelector,
+  MultiSelectorContent,
+  MultiSelectorInput,
+  MultiSelectorItem,
+  MultiSelectorList,
+  MultiSelectorTrigger,
+} from 'ui-patterns/multi-select'
+
+export default function MultiSelectDemo() {
+  const [selectedValues, setSelectedValues] = useState<string[]>([])
+
+  return (
+    <MultiSelector values={selectedValues} onValuesChange={setSelectedValues}>
+      <MultiSelectorTrigger className="w-72" label="Select fruits" badgeLimit="wrap" />
+      <MultiSelectorContent>
+        <MultiSelectorInput placeholder="Search fruits" showResetIcon />
+        <MultiSelectorList creatable>
+          <MultiSelectorItem value="Mango">Mango</MultiSelectorItem>
+          <MultiSelectorItem value="Date">Date</MultiSelectorItem>
+          <MultiSelectorItem value="Apple">Apple</MultiSelectorItem>
+          <MultiSelectorItem value="Elderberrie">Elderberrie</MultiSelectorItem>
+          <MultiSelectorItem value="Fig">Fig</MultiSelectorItem>
+          <MultiSelectorItem value="Grape">Grape</MultiSelectorItem>
+          <MultiSelectorItem value="Banana">Banana</MultiSelectorItem>
+          <MultiSelectorItem value="Kiwi">Kiwi</MultiSelectorItem>
+          <MultiSelectorItem value="Strawberry">Strawberry</MultiSelectorItem>
+          <MultiSelectorItem value="Cherry">Cherry</MultiSelectorItem>
+        </MultiSelectorList>
+      </MultiSelectorContent>
+    </MultiSelector>
+  )
+}

--- a/apps/design-system/registry/examples.ts
+++ b/apps/design-system/registry/examples.ts
@@ -1092,6 +1092,11 @@ export const examples: Registry = [
     files: ['example/multi-select-combobox.tsx'],
   },
   {
+    name: 'multi-select-combobox-creatable',
+    type: 'components:example',
+    files: ['example/multi-select-combobox-creatable.tsx'],
+  },
+  {
     name: 'multi-select-deletable-badge',
     type: 'components:example',
     files: ['example/multi-select-deletable-badge.tsx'],

--- a/packages/ui-patterns/multi-select/multi-select.tsx
+++ b/packages/ui-patterns/multi-select/multi-select.tsx
@@ -236,6 +236,7 @@ const MultiSelectorTrigger = React.forwardRef<HTMLButtonElement, MultiSelectorTr
         ref={inputRef}
         onClick={(e) => !isDeleteHovered && handleTriggerClick(e)}
         disabled={disabled}
+        type="button"
         role="combobox"
         className={cn(
           'flex w-full min-w-[200px] min-h-[40px] items-center justify-between rounded-md border',
@@ -264,7 +265,8 @@ const MultiSelectorTrigger = React.forwardRef<HTMLButtonElement, MultiSelectorTr
                 <div
                   onMouseEnter={() => setIsDeleteHovered(true)}
                   onMouseLeave={() => setIsDeleteHovered(false)}
-                  onClick={() => {
+                  onClick={(e) => {
+                    e.stopPropagation()
                     toggleValue(value)
                     setIsDeleteHovered(false)
                   }}

--- a/packages/ui-patterns/multi-select/multi-select.tsx
+++ b/packages/ui-patterns/multi-select/multi-select.tsx
@@ -1,12 +1,12 @@
 'use client'
 
-import React, { useEffect } from 'react'
 import { Check, ChevronsUpDown, X as RemoveIcon } from 'lucide-react'
+import React, { useEffect } from 'react'
 
-import { SIZE_VARIANTS, SIZE_VARIANTS_DEFAULT } from 'ui/src/lib/constants'
 import { VariantProps, cva } from 'class-variance-authority'
+import { SIZE_VARIANTS, SIZE_VARIANTS_DEFAULT } from 'ui/src/lib/constants'
 
-import { cn, Badge, useOnClickOutside } from 'ui'
+import { Badge, cn, useOnClickOutside } from 'ui'
 import {
   Command,
   CommandEmpty,
@@ -30,6 +30,12 @@ interface MultiSelectContextProps {
 }
 
 const MultiSelectContext = React.createContext<MultiSelectContextProps | null>(null)
+
+const commandItemClass = cn(
+  'relative text-foreground-lighter text-left px-2 py-1.5 rounded',
+  'hover:text-foreground hover:!bg-overlay-hover w-full flex items-center space-x-2',
+  'peer-data-[value=true]:bg-overlay-hover peer-data-[value=true]:text-strong'
+)
 
 function useMultiSelect() {
   const context = React.useContext(MultiSelectContext)
@@ -211,6 +217,7 @@ const MultiSelectorTrigger = React.forwardRef<HTMLButtonElement, MultiSelectorTr
     const handleTriggerClick: React.MouseEventHandler<HTMLButtonElement> = React.useCallback(
       (event) => {
         setOpen(true)
+        setInputValue('')
 
         if (IS_INLINE_MODE) {
           event.stopPropagation()
@@ -419,21 +426,44 @@ MultiSelector.Content = MultiSelectorContent
 
 const MultiSelectorList = React.forwardRef<
   React.ElementRef<typeof CommandList>,
-  React.ComponentPropsWithoutRef<typeof CommandList>
->(({ className, children }, ref) => {
+  React.ComponentPropsWithoutRef<typeof CommandList> & {
+    creatable?: boolean
+  }
+>(({ className, children, creatable = false }, ref) => {
+  const { open, inputValue, setInputValue, toggleValue } = useMultiSelect()
+
+  const availableOptions = (children as React.ReactNode[])
+    .filter((x: any) => !!x.props.value)
+    .map((x: any) => x.props.value.toLowerCase())
+  const isOptionExists = availableOptions.some((x) => x === inputValue.toLowerCase())
+
   return (
     <CommandList
       ref={ref}
       className={cn(
-        'p-2 flex flex-col gap-2 scrollbar-thin scrollbar-track-transparent transition-colors scrollbar-thumb-muted-foreground dark:scrollbar-thumb-muted scrollbar-thumb-rounded-lg w-full',
-        'max-h-[300px] overflow-y-auto',
+        'p-2 flex flex-col gap-2 scrollbar-thin scrollbar-track-transparent transition-colors',
+        'scrollbar-thumb-muted-foreground dark:scrollbar-thumb-muted',
+        'scrollbar-thumb-rounded-lg w-full max-h-[300px] overflow-y-auto',
         className
       )}
     >
+      {creatable && inputValue.length > 0 && !isOptionExists ? (
+        <CommandItem
+          role="option"
+          onSelect={() => {
+            open && toggleValue(inputValue)
+            setInputValue('')
+          }}
+          className={commandItemClass}
+        >
+          Create "{inputValue}"
+        </CommandItem>
+      ) : (
+        <CommandEmpty>
+          <span className="text-foreground-muted">No results found</span>
+        </CommandEmpty>
+      )}
       {children}
-      <CommandEmpty>
-        <span className="text-foreground-muted">No results found</span>
-      </CommandEmpty>
     </CommandList>
   )
 })
@@ -457,15 +487,7 @@ const MultiSelectorItem = React.forwardRef<
         open && toggleValue(value)
         setInputValue('')
       }}
-      className={cn(
-        'relative',
-        'text-foreground-lighter text-left',
-        'px-2 py-1.5 rounded',
-        'hover:text-foreground hover:!bg-overlay-hover',
-        'w-full flex items-center space-x-2',
-        'peer-data-[value=true]:bg-overlay-hover peer-data-[value=true]:text-strong',
-        className
-      )}
+      className={cn(commandItemClass, className)}
       {...props}
     >
       <div

--- a/packages/ui-patterns/multi-select/multi-select.tsx
+++ b/packages/ui-patterns/multi-select/multi-select.tsx
@@ -447,6 +447,7 @@ const MultiSelectorList = React.forwardRef<
         className
       )}
     >
+      {children}
       {creatable && inputValue.length > 0 && !isOptionExists ? (
         <CommandItem
           role="option"
@@ -463,7 +464,6 @@ const MultiSelectorList = React.forwardRef<
           <span className="text-foreground-muted">No results found</span>
         </CommandEmpty>
       )}
-      {children}
     </CommandList>
   )
 })

--- a/packages/ui-patterns/multi-select/multi-select.tsx
+++ b/packages/ui-patterns/multi-select/multi-select.tsx
@@ -432,7 +432,8 @@ const MultiSelectorList = React.forwardRef<
 >(({ className, children, creatable = false }, ref) => {
   const { open, inputValue, setInputValue, toggleValue } = useMultiSelect()
 
-  const availableOptions = (children as React.ReactNode[])
+  const options = (children as React.ReactNode[]) ?? []
+  const availableOptions = options
     .filter((x: any) => !!x.props.value)
     .map((x: any) => x.props.value.toLowerCase())
   const isOptionExists = availableOptions.some((x) => x === inputValue.toLowerCase())
@@ -459,6 +460,10 @@ const MultiSelectorList = React.forwardRef<
         >
           Create "{inputValue}"
         </CommandItem>
+      ) : creatable && options.length === 0 ? (
+        <div className="p-2 py-1.5 text-xs text-foreground-lighter font-italic">
+          Type to add a value
+        </div>
       ) : (
         <CommandEmpty>
           <span className="text-foreground-muted">No results found</span>


### PR DESCRIPTION
Adds a `creatable` flag to `MultiSelectorList` component

https://github.com/user-attachments/assets/501169de-3cd2-47cc-9bb0-d3baf88015e3

JFYI there's an existing bug with the `MultiSelector` component that I can't seem to figure out - if the options are not sorted alphabetically, and you enter a value into the search input then clear it, the options somehow keep ordering themselves alphabetically - it's also messing with the Create n CTA if the `creatable` flag is true too

https://github.com/user-attachments/assets/8c8f129c-43df-41e2-a8d3-582594ecb0a1

