### PR TITLE
Update latest Stripe version

### DIFF
--- a/examples/edge-functions/supabase/functions/stripe-webhooks/index.ts
+++ b/examples/edge-functions/supabase/functions/stripe-webhooks/index.ts
@@ -3,16 +3,14 @@
 // This enables autocomplete, go to definition, etc.
 
 // Import via bare specifier thanks to the import_map.json file.
-import Stripe from 'https://esm.sh/stripe@11.1.0?target=deno'
+import Stripe from "npm:stripe@17.6.0";
 
 const stripe = new Stripe(Deno.env.get('STRIPE_API_KEY') as string, {
   // This is needed to use the Fetch API rather than relying on the Node http
   // package.
-  apiVersion: '2022-11-15',
+  apiVersion: "2025-01-27.acacia",
   httpClient: Stripe.createFetchHttpClient(),
 })
-// This is needed in order to use the Web Crypto API in Deno.
-const cryptoProvider = Stripe.createSubtleCryptoProvider()
 
 console.log('Hello from Stripe Webhook!')
 
@@ -28,8 +26,7 @@ Deno.serve(async (request) => {
       body,
       signature!,
       Deno.env.get('STRIPE_WEBHOOK_SIGNING_SECRET')!,
-      undefined,
-      cryptoProvider
+      undefined
     )
   } catch (err) {
     return new Response(err.message, { status: 400 })


### PR DESCRIPTION
Use npm:stripe, instead of esm, to have typescript features. And use the latest version of the Stripe API

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?
With current config, the types are not resolved from the Stripe sdk

![CleanShot 2025-02-06 at 12 16 16@2x](https://github.com/user-attachments/assets/0fbe45fe-05d3-4265-8e44-d952f99173d5)

## What is the new behavior?
Now it works
![CleanShot 2025-02-06 at 12 16 57@2x](https://github.com/user-attachments/assets/9a2c647d-4581-4610-81a6-f64d2b4ab138)

And the `cryptoProvider` is not required anymore, so I removed it for clarification

