### PR TITLE
Fix the syntax of JS `.select`

### DIFF
--- a/apps/docs/spec/supabase_js_v2.yml
+++ b/apps/docs/spec/supabase_js_v2.yml
@@ -6055,7 +6055,7 @@ functions:
           ```ts
           const { data, error } = await supabase
             .from('characters')
-            .select('id', 'name')
+            .select('id, name')
             .order('id', { ascending: false })
           ```
         data:


### PR DESCRIPTION
It doesn't support passing a list of columns as varargs, only as a comma-separated string.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

NO, but agree

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The `select` when passed several arguments just ignores everything except the first one:
```javascript
await supabase.from('countries').select('id', 'name')
[ { id: 1 }, { id: 2 }, { id: 3 } ]
```

## What is the new behavior?

-

## Additional context

https://supabase.com/docs/reference/javascript/order

🙏 It would be nice to describe `select` in its own section. In Modifiers, or where it fits.
It would be nice to support passing multiple column names as varargs, too.
