### PR TITLE
Hide org members pending invite acceptance in org audit logs users filter

### DIFF
--- a/apps/studio/components/interfaces/Organization/AuditLogs/AuditLogs.tsx
+++ b/apps/studio/components/interfaces/Organization/AuditLogs/AuditLogs.tsx
@@ -96,6 +96,7 @@ const AuditLogs = () => {
     return () => clearInterval(interval)
   }, [dateRange.from, dateRange.to])
 
+  const activeMembers = (members ?? []).filter((x) => !x.invited_at)
   const roles = [...(rolesData?.org_scoped_roles ?? []), ...(rolesData?.project_scoped_roles ?? [])]
 
   const retentionPeriod = data?.retention_period ?? 0
@@ -184,7 +185,7 @@ const AuditLogs = () => {
                   <p className="text-xs prose">Filter by</p>
                   <FilterPopover
                     name="Users"
-                    options={members ?? []}
+                    options={activeMembers}
                     labelKey="username"
                     valueKey="gotrue_id"
                     activeOptions={filters.users}


### PR DESCRIPTION
Invited members who have yet to accept the invite would show up as a single alphabet here
![image](https://github.com/user-attachments/assets/e4ff4134-6c12-4bd2-819c-d43c1cabdacf)
