### PR TITLE
feat: additional billing email addresses

### DIFF
--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingEmail.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingEmail.tsx
@@ -160,7 +160,9 @@ const BillingEmail = () => {
                             <div className="flex items-center gap-x-1">
                               <span>Additional emails</span>
                               <InfoTooltip side="bottom">
-                                These email addresses will be CC'd in automated invoice emails.
+                                These email addresses will be CC'd in automated invoice or payment
+                                failure emails. Payment receipts will still only go to the primary
+                                billing address.
                               </InfoTooltip>
                             </div>
                           }

--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingEmail.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingEmail.tsx
@@ -1,8 +1,11 @@
+import { zodResolver } from '@hookform/resolvers/zod'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
-import { useQueryClient } from '@tanstack/react-query'
 import { useEffect } from 'react'
+import { useForm } from 'react-hook-form'
 import { toast } from 'sonner'
+import { z } from 'zod'
 
+import { Form, FormControl, FormField } from '@ui/components/shadcn/ui/form'
 import { useParams } from 'common'
 import {
   ScaffoldSection,
@@ -12,29 +15,56 @@ import {
 import { FormActions } from 'components/ui/Forms/FormActions'
 import { FormPanel } from 'components/ui/Forms/FormPanel'
 import { FormSection, FormSectionContent } from 'components/ui/Forms/FormSection'
+import NoPermission from 'components/ui/NoPermission'
+import { useOrganizationCustomerProfileQuery } from 'data/organizations/organization-customer-profile-query'
 import { useOrganizationUpdateMutation } from 'data/organizations/organization-update-mutation'
-import { invalidateOrganizationsQuery } from 'data/organizations/organizations-query'
 import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { useSelectedOrganization } from 'hooks/misc/useSelectedOrganization'
-import { Form, Input } from 'ui'
+import { FormMessage_Shadcn_, Input_Shadcn_ } from 'ui'
+import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
+import { InfoTooltip } from 'ui-patterns/info-tooltip'
+import {
+  MultiSelector,
+  MultiSelectorContent,
+  MultiSelectorList,
+  MultiSelectorTrigger,
+} from 'ui-patterns/multi-select'
+
+const FORM_ID = 'org-billing-email'
+const formSchema = z.object({
+  billingEmail: z.string().email('Please provide a valid email address').optional(),
+  additionalBillingEmails: z.string().email({ message: 'invalid_email' }).array().default([]),
+})
 
 const BillingEmail = () => {
   const { slug } = useParams()
-  const queryClient = useQueryClient()
   const selectedOrganization = useSelectedOrganization()
-  const { name, billing_email } = selectedOrganization ?? {}
 
-  const formId = 'org-billing-email'
-  const initialValues = { billing_email: billing_email ?? '' }
+  const { name, billing_email } = selectedOrganization ?? {}
 
   const canUpdateOrganization = useCheckPermissions(PermissionAction.UPDATE, 'organizations')
   const canReadBillingEmail = useCheckPermissions(
     PermissionAction.BILLING_READ,
     'stripe.subscriptions'
   )
+
+  const { data: billingCustomer, isLoading: loadingBillingCustomer } =
+    useOrganizationCustomerProfileQuery({ slug }, { enabled: canReadBillingEmail })
+
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      billingEmail: billing_email ?? '',
+      additionalBillingEmails: billingCustomer?.additional_emails ?? [],
+    },
+  })
+  const { additionalBillingEmails } = form.watch()
+  const { errors } = form.formState
+  const additionalEmailsError = errors.additionalBillingEmails ?? []
+
   const { mutate: updateOrganization, isLoading: isUpdating } = useOrganizationUpdateMutation()
 
-  const onUpdateOrganizationEmail = async (values: any, { resetForm }: any) => {
+  const onUpdateOrganizationEmail = async (values: z.infer<typeof formSchema>) => {
     if (!canUpdateOrganization) {
       return toast.error('You do not have the required permissions to update this organization')
     }
@@ -45,19 +75,26 @@ const BillingEmail = () => {
       {
         slug,
         name,
-        billing_email: values.billing_email,
+        billing_email: values.billingEmail,
+        additional_billing_emails: values.additionalBillingEmails,
       },
       {
-        onSuccess: ({ billing_email }) => {
-          resetForm({ values: { billing_email }, initialValues: { billing_email } })
-          invalidateOrganizationsQuery(queryClient)
+        onSuccess: () => {
           toast.success('Successfully saved settings')
+          form.reset(values)
         },
       }
     )
   }
 
-  if (!canReadBillingEmail) return null
+  useEffect(() => {
+    if (billingCustomer) {
+      form.reset({
+        billingEmail: billing_email,
+        additionalBillingEmails: billingCustomer.additional_emails ?? [],
+      })
+    }
+  }, [billingCustomer])
 
   return (
     <ScaffoldSection>
@@ -70,31 +107,23 @@ const BillingEmail = () => {
         </div>
       </ScaffoldSectionDetail>
       <ScaffoldSectionContent>
-        <Form id={formId} initialValues={initialValues} onSubmit={onUpdateOrganizationEmail}>
-          {({ handleReset, values, initialValues, resetForm }: any) => {
-            const hasChanges = JSON.stringify(values) !== JSON.stringify(initialValues)
-
-            // [Alaister] although this "technically" is breaking the rules of React hooks
-            // it won't error because the hooks are always rendered in the same order
-            // eslint-disable-next-line react-hooks/rules-of-hooks
-            useEffect(() => {
-              const values = { billing_email: billing_email ?? '' }
-              resetForm({ values, initialValues: values })
-              // eslint-disable-next-line react-hooks/exhaustive-deps
-            }, [slug])
-
-            return (
+        {!canReadBillingEmail ? (
+          <NoPermission resourceText="view this organization's email recipients" />
+        ) : (
+          <Form {...form}>
+            <form id={FORM_ID} onSubmit={form.handleSubmit(onUpdateOrganizationEmail)}>
               <FormPanel
                 footer={
                   <div className="flex py-4 px-8">
                     <FormActions
-                      form={formId}
+                      form={FORM_ID}
                       isSubmitting={isUpdating}
-                      hasChanges={hasChanges}
-                      handleReset={handleReset}
+                      hasChanges={form.formState.isDirty}
+                      handleReset={form.reset}
+                      disabled={!canUpdateOrganization}
                       helper={
                         !canUpdateOrganization
-                          ? "You need additional permissions to manage this organization's settings"
+                          ? 'You need additional permissions to update billing emails'
                           : undefined
                       }
                     />
@@ -102,20 +131,77 @@ const BillingEmail = () => {
                 }
               >
                 <FormSection>
-                  <FormSectionContent fullWidth loading={false}>
-                    <Input
-                      id="billing_email"
-                      size="small"
-                      label="Email address"
-                      type="text"
-                      disabled={!canUpdateOrganization}
+                  <FormSectionContent fullWidth loading={loadingBillingCustomer}>
+                    <FormField
+                      control={form.control}
+                      name="billingEmail"
+                      render={({ field }) => (
+                        <FormItemLayout label="Email address">
+                          <FormControl>
+                            <Input_Shadcn_
+                              type="email"
+                              {...field}
+                              placeholder="Email"
+                              disabled={!canUpdateOrganization}
+                            />
+                          </FormControl>
+                          <FormMessage_Shadcn_ />
+                        </FormItemLayout>
+                      )}
+                    />
+
+                    <FormField
+                      control={form.control}
+                      name="additionalBillingEmails"
+                      render={({ field }) => (
+                        <FormItemLayout
+                          hideMessage
+                          label={
+                            <div className="flex items-center gap-x-1">
+                              <span>Additional emails</span>
+                              <InfoTooltip side="bottom">
+                                These email addresses will be CC'd in automated invoice emails.
+                              </InfoTooltip>
+                            </div>
+                          }
+                        >
+                          <FormControl>
+                            <MultiSelector values={field.value} onValuesChange={field.onChange}>
+                              <MultiSelectorTrigger
+                                deletableBadge
+                                showIcon={false}
+                                mode="inline-combobox"
+                                label="Add additional recipients"
+                                badgeLimit="wrap"
+                              />
+                              <MultiSelectorContent>
+                                <MultiSelectorList creatable />
+                              </MultiSelectorContent>
+                            </MultiSelector>
+                          </FormControl>
+                          {/* [Joshen] Manually construct the message here as MultiSelector doesn't handle array errors from RHF atm */}
+                          {Array.isArray(additionalEmailsError) &&
+                            additionalEmailsError.length > 0 && (
+                              <div className="flex flex-col gap-y-1 mt-2">
+                                {additionalEmailsError.map((x, idx) => (
+                                  <p
+                                    key={`email-error-${idx}`}
+                                    className="text-sm text-destructive"
+                                  >
+                                    "{additionalBillingEmails[idx]}" is not a valid email address
+                                  </p>
+                                ))}
+                              </div>
+                            )}
+                        </FormItemLayout>
+                      )}
                     />
                   </FormSectionContent>
                 </FormSection>
               </FormPanel>
-            )
-          }}
-        </Form>
+            </form>
+          </Form>
+        )}
       </ScaffoldSectionContent>
     </ScaffoldSection>
   )

--- a/packages/api-types/types/api.d.ts
+++ b/packages/api-types/types/api.d.ts
@@ -1310,7 +1310,7 @@ export interface paths {
       path?: never
       cookie?: never
     }
-    /** Gets the Billing customer */
+    /** Gets the Stripe customer */
     get: operations['CustomerController_getCustomer']
     /** Updates the billing customer */
     put: operations['updateCustomerV2']
@@ -1660,7 +1660,7 @@ export interface paths {
       cookie?: never
     }
     /** Gets the given organization's roles */
-    get: operations['OrganizationRolesController_getAllRoles']
+    get: operations['OrganizationRolesController_getAllRolesV2']
     put?: never
     post?: never
     delete?: never
@@ -2674,24 +2674,6 @@ export interface paths {
     patch: operations['PostgrestConfigController_updatePostgRESTConfig']
     trace?: never
   }
-  '/platform/projects/{ref}/config/realtime': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Gets realtime configuration */
-    get: operations['RealtimeConfigController_getConfig']
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    /** Updates realtime configuration */
-    patch: operations['RealtimeConfigController_updateConfig']
-    trace?: never
-  }
   '/platform/projects/{ref}/config/secrets': {
     parameters: {
       query?: never
@@ -3329,197 +3311,6 @@ export interface paths {
      * @deprecated
      */
     get: operations['PropsSettingsController_getProjectApi']
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  '/platform/replication/{ref}/pipelines': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Gets replication pipelines */
-    get: operations['ReplicationPipelinesController_getPipelines']
-    put?: never
-    /** Creates a pipeline */
-    post: operations['ReplicationPipelinesController_createPipeline']
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  '/platform/replication/{ref}/pipelines/{pipeline_id}': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    post?: never
-    /** Deletes a pipeline */
-    delete: operations['ReplicationPipelinesController_deletePipeline']
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  '/platform/replication/{ref}/pipelines/{pipeline_id}/start': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Starts a pipeline */
-    post: operations['ReplicationPipelinesController_startPipeline']
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  '/platform/replication/{ref}/pipelines/{pipeline_id}/status': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Gets status of a pipeline */
-    get: operations['ReplicationPipelinesController_getPipelineStatus']
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  '/platform/replication/{ref}/pipelines/{pipeline_id}/stop': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Stops a pipeline */
-    post: operations['ReplicationPipelinesController_stopPipeline']
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  '/platform/replication/{ref}/sinks': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Gets replication sinks */
-    get: operations['ReplicationSinksController_getSinks']
-    put?: never
-    /** Creates a sink */
-    post: operations['ReplicationSinksController_createSink']
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  '/platform/replication/{ref}/sinks/{sink_id}': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    post?: never
-    /** Deletes a sink */
-    delete: operations['ReplicationSinksController_deleteSink']
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  '/platform/replication/{ref}/sources': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Returns replication sources. */
-    get: operations['ReplicationSourcesController_getSources']
-    put?: never
-    /** Creates a replication source. */
-    post: operations['ReplicationSourcesController_createSource']
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  '/platform/replication/{ref}/sources/{source_id}/publications': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Returns source publications. */
-    get: operations['ReplicationSourcesController_getPublications']
-    put?: never
-    /** Creates a publication. */
-    post: operations['ReplicationSourcesController_createPublication']
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  '/platform/replication/{ref}/sources/{source_id}/publications/{publication_name}': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    post?: never
-    /** Deletes a publication. */
-    delete: operations['ReplicationSourcesController_deletePublication']
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  '/platform/replication/{ref}/sources/{source_id}/tables': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Returns source tables. */
-    get: operations['ReplicationSourcesController_getTables']
     put?: never
     post?: never
     delete?: never
@@ -4700,23 +4491,6 @@ export interface paths {
     patch?: never
     trace?: never
   }
-  '/system/projects/{ref}/restart': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Restart project database [System API] */
-    post: operations['SystemRestartController_restartProject']
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
   '/system/projects/{ref}/run-lints': {
     parameters: {
       query?: never
@@ -5409,7 +5183,7 @@ export interface paths {
       cookie?: never
     }
     /** Gets the given organization's roles */
-    get: operations['OrganizationRolesController_getAllRoles']
+    get: operations['OrganizationRolesController_getAllRolesV2']
     put?: never
     post?: never
     delete?: never
@@ -6224,24 +5998,6 @@ export interface paths {
     head?: never
     /** Updates project's postgrest config */
     patch: operations['PostgrestConfigController_updatePostgRESTConfig']
-    trace?: never
-  }
-  '/v0/projects/{ref}/config/realtime': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Gets realtime configuration */
-    get: operations['RealtimeConfigController_getConfig']
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    /** Updates realtime configuration */
-    patch: operations['RealtimeConfigController_updateConfig']
     trace?: never
   }
   '/v0/projects/{ref}/config/secrets': {
@@ -8871,40 +8627,6 @@ export interface components {
       publish_update?: boolean
       tables?: string[] | null
     }
-    CreateReplicationPipelineBody: {
-      /** @description Pipeline config */
-      config: {
-        config: {
-          max_fill_secs: number
-          max_size: number
-        }
-      }
-      /** @description Publication name */
-      publication_name: string
-      /** @description Sink id */
-      sink_id: number
-      /** @description Source id */
-      source_id: number
-    }
-    CreateReplicationPublicationBody: {
-      /** @description Publication name */
-      name: string
-      /** @description Publication tables */
-      tables: {
-        name: string
-        schema: string
-      }[]
-    }
-    CreateReplicationSinkBody: {
-      /** @description BigQuery dataset id */
-      dataset_id: string
-      /** @description BigQuery project id */
-      project_id: string
-      /** @description BigQuery service account key */
-      service_account_key: string
-      /** @description Sink name */
-      sink_name: string
-    }
     CreateSchemaBody: {
       name: string
       owner: string
@@ -8916,9 +8638,6 @@ export interface components {
        */
       name: string
       value: string
-    }
-    CreateSourceResponse: {
-      id: number
     }
     CreateStorageBucketBody: {
       allowed_mime_types: string[]
@@ -9399,15 +9118,14 @@ export interface components {
       query: string
     }
     FunctionDeployBody: {
-      file: string[]
-      metadata: components['schemas']['FunctionMetadata']
-    }
-    FunctionMetadata: {
-      entrypoint_path: string
-      import_map_path?: string
-      name?: string
-      static_patterns?: string[]
-      verify_jwt?: boolean
+      file: Record<string, never>[]
+      metadata: {
+        entrypoint_path?: string
+        import_map_path?: string
+        name?: string
+        static_patterns?: string[]
+        verify_jwt?: boolean
+      }
     }
     FunctionResponse: {
       compute_multiplier?: number
@@ -10718,7 +10436,7 @@ export interface components {
     }
     ProjectAvailableRestoreVersion: {
       /** @enum {string} */
-      postgres_engine: '13' | '14' | '15' | '17' | '17-oriole'
+      postgres_engine: '13' | '14' | '15' | '17-oriole'
       /** @enum {string} */
       release_channel: 'internal' | 'alpha' | 'beta' | 'ga' | 'withdrawn' | 'preview'
       version: string
@@ -10941,7 +10659,7 @@ export interface components {
     }
     ProjectUnpauseVersionInfo: {
       /** @enum {string} */
-      postgres_engine: '13' | '14' | '15' | '17' | '17-oriole'
+      postgres_engine: '13' | '14' | '15' | '17-oriole'
       /** @enum {string} */
       release_channel: 'internal' | 'alpha' | 'beta' | 'ga' | 'withdrawn' | 'preview'
       version: string
@@ -11003,22 +10721,6 @@ export interface components {
       override_active_until: string
       override_enabled: boolean
     }
-    RealtimeConfigResponseDto: {
-      /** @description Sets connection pool size for Realtime Authorization */
-      connection_pool: number | null
-      /** @description Sets maximum number of bytes per second rate per channel limit */
-      max_bytes_per_second: number | null
-      /** @description Sets maximum number of channels per client rate limit */
-      max_channels_per_client: number | null
-      /** @description Sets maximum number of concurrent users rate limit */
-      max_concurrent_users: number | null
-      /** @description Sets maximum number of events per second rate per channel limit */
-      max_events_per_second: number | null
-      /** @description Sets maximum number of joins per second rate limit */
-      max_joins_per_second: number | null
-      /** @description Whether to only allow private channels */
-      private_only: boolean | null
-    }
     RealtimeHealthResponse: {
       connected_cluster: number
     }
@@ -11039,73 +10741,6 @@ export interface components {
     }
     RemoveReadReplicaBody: {
       database_identifier: string
-    }
-    ReplicationPipelinesResponse: {
-      pipelines: {
-        config: {
-          config: {
-            max_fill_secs: number
-            max_size: number
-          }
-        }
-        id: number
-        publication_name: string
-        replicator_id: number
-        sink_id: number
-        sink_name: string
-        source_id: number
-        source_name: string
-        tenant_id: string
-      }[]
-    }
-    ReplicationPipelinesStatusResponse: {
-      pipeline_id: number
-      status: string
-    }
-    ReplicationPublicationsResponse: {
-      publications: {
-        name: string
-        tables: {
-          name: string
-          schema: string
-        }[]
-      }[]
-    }
-    ReplicationSinksResponse: {
-      sinks: {
-        config: {
-          big_query: {
-            dataset_id: string
-            project_id: string
-            service_account_key: string
-          }
-        }
-        id: number
-        name: string
-        tenant_id: string
-      }[]
-    }
-    ReplicationSourcesResponse: {
-      sources: {
-        config: {
-          postgres: {
-            host: string
-            name: string
-            port: number
-            slot_name: string
-            username: string
-          }
-        }
-        id: number
-        name: string
-        tenant_id: string
-      }[]
-    }
-    ReplicationTablesResponse: {
-      tables: {
-        name: string
-        schema: string
-      }[]
     }
     ReportStatusBody: {
       databaseIdentifier: string
@@ -11214,7 +10849,7 @@ export interface components {
        */
       supabase_org_id: string
     }
-    RestartProjectBodyDto: {
+    RestartProjectInfo: {
       database_identifier?: string
     }
     RestartServiceRequest: {
@@ -12300,7 +11935,6 @@ export interface components {
       ids: string[]
     }
     UpdateOrganizationBodyDto: {
-      additional_billing_emails?: string[]
       /** Format: email */
       billing_email?: string
       name?: string
@@ -12407,22 +12041,6 @@ export interface components {
       publish_truncate?: boolean
       publish_update?: boolean
       tables?: string[] | null
-    }
-    UpdateRealtimeConfigBodyDto: {
-      /** @description Sets connection pool size for Realtime Authorization */
-      connection_pool?: number
-      /** @description Sets maximum number of bytes per second rate per channel limit */
-      max_bytes_per_second?: number
-      /** @description Sets maximum number of channels per client rate limit */
-      max_channels_per_client?: number
-      /** @description Sets maximum number of concurrent users rate limit */
-      max_concurrent_users?: number
-      /** @description Sets maximum number of events per second rate per channel limit */
-      max_events_per_second?: number
-      /** @description Sets maximum number of joins per second rate limit */
-      max_joins_per_second?: number
-      /** @description Whether to only allow private channels */
-      private_only?: boolean
     }
     UpdateRestrictionsBody: {
       no_notification?: boolean
@@ -15768,7 +15386,7 @@ export interface operations {
           'application/json': components['schemas']['CustomerResponse']
         }
       }
-      /** @description Failed to retrieve the Billing customer */
+      /** @description Failed to retrieve the Stripe customer */
       500: {
         headers: {
           [name: string]: unknown
@@ -16678,7 +16296,7 @@ export interface operations {
       }
     }
   }
-  OrganizationRolesController_getAllRoles: {
+  OrganizationRolesController_getAllRolesV2: {
     parameters: {
       query?: never
       header?: never
@@ -20373,59 +19991,6 @@ export interface operations {
       }
     }
   }
-  RealtimeConfigController_getConfig: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Gets project's realtime configuration */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': components['schemas']['RealtimeConfigResponseDto']
-        }
-      }
-      403: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-    }
-  }
-  RealtimeConfigController_updateConfig: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['UpdateRealtimeConfigBodyDto']
-      }
-    }
-    responses: {
-      204: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-      403: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-    }
-  }
   SecretsConfigController_updateConfig: {
     parameters: {
       query?: never
@@ -21491,12 +21056,15 @@ export interface operations {
     parameters: {
       query?: never
       header?: never
-      path?: never
+      path: {
+        /** @description Project ref */
+        ref: string
+      }
       cookie?: never
     }
     requestBody: {
       content: {
-        'application/json': components['schemas']['RestartProjectBodyDto']
+        'application/json': components['schemas']['RestartProjectInfo']
       }
     }
     responses: {
@@ -21965,534 +21533,6 @@ export interface operations {
         }
       }
       /** @description Failed to retrieve project's settings */
-      500: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-    }
-  }
-  ReplicationPipelinesController_getPipelines: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        ref: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': components['schemas']['ReplicationPipelinesResponse']
-        }
-      }
-      403: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-      /** @description Failed to get replication pipeline */
-      500: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-    }
-  }
-  ReplicationPipelinesController_createPipeline: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        ref: string
-      }
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['CreateReplicationPipelineBody']
-      }
-    }
-    responses: {
-      201: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-      403: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-      /** @description Failed to create pipeline */
-      500: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-    }
-  }
-  ReplicationPipelinesController_deletePipeline: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        pipeline_id: number
-        ref: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-      403: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-      /** @description Failed to delete pipeline */
-      500: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-    }
-  }
-  ReplicationPipelinesController_startPipeline: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        pipeline_id: number
-        ref: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-      403: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-      /** @description Failed to start pipeline */
-      500: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-    }
-  }
-  ReplicationPipelinesController_getPipelineStatus: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        pipeline_id: number
-        ref: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': components['schemas']['ReplicationPipelinesStatusResponse']
-        }
-      }
-      403: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-      /** @description Failed to get pipeline status */
-      500: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-    }
-  }
-  ReplicationPipelinesController_stopPipeline: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        pipeline_id: number
-        ref: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-      403: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-      /** @description Failed to stop pipeline */
-      500: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-    }
-  }
-  ReplicationSinksController_getSinks: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        ref: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': components['schemas']['ReplicationSinksResponse']
-        }
-      }
-      403: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-      /** @description Failed to get replication sinks */
-      500: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-    }
-  }
-  ReplicationSinksController_createSink: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        ref: string
-      }
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['CreateReplicationSinkBody']
-      }
-    }
-    responses: {
-      201: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-      403: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-      /** @description Failed to create sink */
-      500: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-    }
-  }
-  ReplicationSinksController_deleteSink: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        ref: string
-        sink_id: number
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-      403: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-      /** @description Failed to delete sink */
-      500: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-    }
-  }
-  ReplicationSourcesController_getSources: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        ref: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Returns all sources. */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': components['schemas']['ReplicationSourcesResponse']
-        }
-      }
-      403: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-      /** @description Returned when the API fails to get replication sources. */
-      500: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-    }
-  }
-  ReplicationSourcesController_createSource: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        ref: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Returns the created replication source id. */
-      201: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': components['schemas']['CreateSourceResponse']
-        }
-      }
-      403: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-      /** @description Returned when the API fails to create the replication source. */
-      500: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-    }
-  }
-  ReplicationSourcesController_getPublications: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        ref: string
-        source_id: number
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Returns all publications. */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': components['schemas']['ReplicationPublicationsResponse']
-        }
-      }
-      403: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-      /** @description Returned when the API fails to get source publications. */
-      500: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-    }
-  }
-  ReplicationSourcesController_createPublication: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        ref: string
-        source_id: number
-      }
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['CreateReplicationPublicationBody']
-      }
-    }
-    responses: {
-      /** @description Returned when the publication is created. */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-      201: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-      403: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-      /** @description Returned when the API fails to create the publication. */
-      500: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-    }
-  }
-  ReplicationSourcesController_deletePublication: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        publication_name: string
-        ref: string
-        source_id: number
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Returned when the publication is deleted. */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-      403: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-      /** @description Returned when the API fails to delete the publication. */
-      500: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-    }
-  }
-  ReplicationSourcesController_getTables: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        ref: string
-        source_id: number
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Returns all tables. */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': components['schemas']['ReplicationTablesResponse']
-        }
-      }
-      403: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-      /** @description Returned when the API fails to get source tables. */
       500: {
         headers: {
           [name: string]: unknown
@@ -25076,23 +24116,6 @@ export interface operations {
       }
     }
   }
-  SystemRestartController_restartProject: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      201: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-    }
-  }
   SystemProjectRunLintsController_runProjectLints: {
     parameters: {
       query?: never
@@ -26723,7 +25746,7 @@ export interface operations {
       }
     }
   }
-  OrganizationRolesController_getAllRoles: {
+  OrganizationRolesController_getAllRolesV2: {
     parameters: {
       query?: never
       header?: never
@@ -29887,59 +28910,6 @@ export interface operations {
       }
     }
   }
-  RealtimeConfigController_getConfig: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Gets project's realtime configuration */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': components['schemas']['RealtimeConfigResponseDto']
-        }
-      }
-      403: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-    }
-  }
-  RealtimeConfigController_updateConfig: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['UpdateRealtimeConfigBodyDto']
-      }
-    }
-    responses: {
-      204: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-      403: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-    }
-  }
   SecretsConfigController_updateConfig: {
     parameters: {
       query?: never
@@ -30768,12 +29738,15 @@ export interface operations {
     parameters: {
       query?: never
       header?: never
-      path?: never
+      path: {
+        /** @description Project ref */
+        ref: string
+      }
       cookie?: never
     }
     requestBody: {
       content: {
-        'application/json': components['schemas']['RestartProjectBodyDto']
+        'application/json': components['schemas']['RestartProjectInfo']
       }
     }
     responses: {

--- a/packages/api-types/types/api.d.ts
+++ b/packages/api-types/types/api.d.ts
@@ -8255,7 +8255,7 @@ export interface components {
       walg_enabled: boolean
     }
     BillingCustomerUpdateBody: {
-      additional_emails: string[]
+      additional_emails?: string[] | undefined
       address?: components['schemas']['CustomerBillingAddress']
     }
     /** @enum {string} */

--- a/packages/api-types/types/api.d.ts
+++ b/packages/api-types/types/api.d.ts
@@ -1310,7 +1310,7 @@ export interface paths {
       path?: never
       cookie?: never
     }
-    /** Gets the Stripe customer */
+    /** Gets the Billing customer */
     get: operations['CustomerController_getCustomer']
     /** Updates the billing customer */
     put: operations['updateCustomerV2']
@@ -1660,7 +1660,7 @@ export interface paths {
       cookie?: never
     }
     /** Gets the given organization's roles */
-    get: operations['OrganizationRolesController_getAllRolesV2']
+    get: operations['OrganizationRolesController_getAllRoles']
     put?: never
     post?: never
     delete?: never
@@ -2674,6 +2674,24 @@ export interface paths {
     patch: operations['PostgrestConfigController_updatePostgRESTConfig']
     trace?: never
   }
+  '/platform/projects/{ref}/config/realtime': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** Gets realtime configuration */
+    get: operations['RealtimeConfigController_getConfig']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    /** Updates realtime configuration */
+    patch: operations['RealtimeConfigController_updateConfig']
+    trace?: never
+  }
   '/platform/projects/{ref}/config/secrets': {
     parameters: {
       query?: never
@@ -3311,6 +3329,197 @@ export interface paths {
      * @deprecated
      */
     get: operations['PropsSettingsController_getProjectApi']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/platform/replication/{ref}/pipelines': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** Gets replication pipelines */
+    get: operations['ReplicationPipelinesController_getPipelines']
+    put?: never
+    /** Creates a pipeline */
+    post: operations['ReplicationPipelinesController_createPipeline']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/platform/replication/{ref}/pipelines/{pipeline_id}': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    post?: never
+    /** Deletes a pipeline */
+    delete: operations['ReplicationPipelinesController_deletePipeline']
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/platform/replication/{ref}/pipelines/{pipeline_id}/start': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Starts a pipeline */
+    post: operations['ReplicationPipelinesController_startPipeline']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/platform/replication/{ref}/pipelines/{pipeline_id}/status': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** Gets status of a pipeline */
+    get: operations['ReplicationPipelinesController_getPipelineStatus']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/platform/replication/{ref}/pipelines/{pipeline_id}/stop': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Stops a pipeline */
+    post: operations['ReplicationPipelinesController_stopPipeline']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/platform/replication/{ref}/sinks': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** Gets replication sinks */
+    get: operations['ReplicationSinksController_getSinks']
+    put?: never
+    /** Creates a sink */
+    post: operations['ReplicationSinksController_createSink']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/platform/replication/{ref}/sinks/{sink_id}': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    post?: never
+    /** Deletes a sink */
+    delete: operations['ReplicationSinksController_deleteSink']
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/platform/replication/{ref}/sources': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** Returns replication sources. */
+    get: operations['ReplicationSourcesController_getSources']
+    put?: never
+    /** Creates a replication source. */
+    post: operations['ReplicationSourcesController_createSource']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/platform/replication/{ref}/sources/{source_id}/publications': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** Returns source publications. */
+    get: operations['ReplicationSourcesController_getPublications']
+    put?: never
+    /** Creates a publication. */
+    post: operations['ReplicationSourcesController_createPublication']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/platform/replication/{ref}/sources/{source_id}/publications/{publication_name}': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    post?: never
+    /** Deletes a publication. */
+    delete: operations['ReplicationSourcesController_deletePublication']
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/platform/replication/{ref}/sources/{source_id}/tables': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** Returns source tables. */
+    get: operations['ReplicationSourcesController_getTables']
     put?: never
     post?: never
     delete?: never
@@ -4491,6 +4700,23 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/system/projects/{ref}/restart': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Restart project database [System API] */
+    post: operations['SystemRestartController_restartProject']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/system/projects/{ref}/run-lints': {
     parameters: {
       query?: never
@@ -5183,7 +5409,7 @@ export interface paths {
       cookie?: never
     }
     /** Gets the given organization's roles */
-    get: operations['OrganizationRolesController_getAllRolesV2']
+    get: operations['OrganizationRolesController_getAllRoles']
     put?: never
     post?: never
     delete?: never
@@ -5998,6 +6224,24 @@ export interface paths {
     head?: never
     /** Updates project's postgrest config */
     patch: operations['PostgrestConfigController_updatePostgRESTConfig']
+    trace?: never
+  }
+  '/v0/projects/{ref}/config/realtime': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** Gets realtime configuration */
+    get: operations['RealtimeConfigController_getConfig']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    /** Updates realtime configuration */
+    patch: operations['RealtimeConfigController_updateConfig']
     trace?: never
   }
   '/v0/projects/{ref}/config/secrets': {
@@ -8255,6 +8499,7 @@ export interface components {
       walg_enabled: boolean
     }
     BillingCustomerUpdateBody: {
+      additional_emails: string[]
       address?: components['schemas']['CustomerBillingAddress']
     }
     /** @enum {string} */
@@ -8626,6 +8871,40 @@ export interface components {
       publish_update?: boolean
       tables?: string[] | null
     }
+    CreateReplicationPipelineBody: {
+      /** @description Pipeline config */
+      config: {
+        config: {
+          max_fill_secs: number
+          max_size: number
+        }
+      }
+      /** @description Publication name */
+      publication_name: string
+      /** @description Sink id */
+      sink_id: number
+      /** @description Source id */
+      source_id: number
+    }
+    CreateReplicationPublicationBody: {
+      /** @description Publication name */
+      name: string
+      /** @description Publication tables */
+      tables: {
+        name: string
+        schema: string
+      }[]
+    }
+    CreateReplicationSinkBody: {
+      /** @description BigQuery dataset id */
+      dataset_id: string
+      /** @description BigQuery project id */
+      project_id: string
+      /** @description BigQuery service account key */
+      service_account_key: string
+      /** @description Sink name */
+      sink_name: string
+    }
     CreateSchemaBody: {
       name: string
       owner: string
@@ -8637,6 +8916,9 @@ export interface components {
        */
       name: string
       value: string
+    }
+    CreateSourceResponse: {
+      id: number
     }
     CreateStorageBucketBody: {
       allowed_mime_types: string[]
@@ -8791,6 +9073,7 @@ export interface components {
       state?: string
     }
     CustomerResponse: {
+      additional_emails: string[] | null
       address: components['schemas']['CustomerBillingAddress'] | null
       balance: number
       billing_via_partner: boolean
@@ -9116,14 +9399,15 @@ export interface components {
       query: string
     }
     FunctionDeployBody: {
-      file: Record<string, never>[]
-      metadata: {
-        entrypoint_path?: string
-        import_map_path?: string
-        name?: string
-        static_patterns?: string[]
-        verify_jwt?: boolean
-      }
+      file: string[]
+      metadata: components['schemas']['FunctionMetadata']
+    }
+    FunctionMetadata: {
+      entrypoint_path: string
+      import_map_path?: string
+      name?: string
+      static_patterns?: string[]
+      verify_jwt?: boolean
     }
     FunctionResponse: {
       compute_multiplier?: number
@@ -10434,7 +10718,7 @@ export interface components {
     }
     ProjectAvailableRestoreVersion: {
       /** @enum {string} */
-      postgres_engine: '13' | '14' | '15' | '17-oriole'
+      postgres_engine: '13' | '14' | '15' | '17' | '17-oriole'
       /** @enum {string} */
       release_channel: 'internal' | 'alpha' | 'beta' | 'ga' | 'withdrawn' | 'preview'
       version: string
@@ -10657,7 +10941,7 @@ export interface components {
     }
     ProjectUnpauseVersionInfo: {
       /** @enum {string} */
-      postgres_engine: '13' | '14' | '15' | '17-oriole'
+      postgres_engine: '13' | '14' | '15' | '17' | '17-oriole'
       /** @enum {string} */
       release_channel: 'internal' | 'alpha' | 'beta' | 'ga' | 'withdrawn' | 'preview'
       version: string
@@ -10719,6 +11003,22 @@ export interface components {
       override_active_until: string
       override_enabled: boolean
     }
+    RealtimeConfigResponseDto: {
+      /** @description Sets connection pool size for Realtime Authorization */
+      connection_pool: number | null
+      /** @description Sets maximum number of bytes per second rate per channel limit */
+      max_bytes_per_second: number | null
+      /** @description Sets maximum number of channels per client rate limit */
+      max_channels_per_client: number | null
+      /** @description Sets maximum number of concurrent users rate limit */
+      max_concurrent_users: number | null
+      /** @description Sets maximum number of events per second rate per channel limit */
+      max_events_per_second: number | null
+      /** @description Sets maximum number of joins per second rate limit */
+      max_joins_per_second: number | null
+      /** @description Whether to only allow private channels */
+      private_only: boolean | null
+    }
     RealtimeHealthResponse: {
       connected_cluster: number
     }
@@ -10739,6 +11039,73 @@ export interface components {
     }
     RemoveReadReplicaBody: {
       database_identifier: string
+    }
+    ReplicationPipelinesResponse: {
+      pipelines: {
+        config: {
+          config: {
+            max_fill_secs: number
+            max_size: number
+          }
+        }
+        id: number
+        publication_name: string
+        replicator_id: number
+        sink_id: number
+        sink_name: string
+        source_id: number
+        source_name: string
+        tenant_id: string
+      }[]
+    }
+    ReplicationPipelinesStatusResponse: {
+      pipeline_id: number
+      status: string
+    }
+    ReplicationPublicationsResponse: {
+      publications: {
+        name: string
+        tables: {
+          name: string
+          schema: string
+        }[]
+      }[]
+    }
+    ReplicationSinksResponse: {
+      sinks: {
+        config: {
+          big_query: {
+            dataset_id: string
+            project_id: string
+            service_account_key: string
+          }
+        }
+        id: number
+        name: string
+        tenant_id: string
+      }[]
+    }
+    ReplicationSourcesResponse: {
+      sources: {
+        config: {
+          postgres: {
+            host: string
+            name: string
+            port: number
+            slot_name: string
+            username: string
+          }
+        }
+        id: number
+        name: string
+        tenant_id: string
+      }[]
+    }
+    ReplicationTablesResponse: {
+      tables: {
+        name: string
+        schema: string
+      }[]
     }
     ReportStatusBody: {
       databaseIdentifier: string
@@ -10847,7 +11214,7 @@ export interface components {
        */
       supabase_org_id: string
     }
-    RestartProjectInfo: {
+    RestartProjectBodyDto: {
       database_identifier?: string
     }
     RestartServiceRequest: {
@@ -11933,6 +12300,7 @@ export interface components {
       ids: string[]
     }
     UpdateOrganizationBodyDto: {
+      additional_billing_emails?: string[]
       /** Format: email */
       billing_email?: string
       name?: string
@@ -12039,6 +12407,22 @@ export interface components {
       publish_truncate?: boolean
       publish_update?: boolean
       tables?: string[] | null
+    }
+    UpdateRealtimeConfigBodyDto: {
+      /** @description Sets connection pool size for Realtime Authorization */
+      connection_pool?: number
+      /** @description Sets maximum number of bytes per second rate per channel limit */
+      max_bytes_per_second?: number
+      /** @description Sets maximum number of channels per client rate limit */
+      max_channels_per_client?: number
+      /** @description Sets maximum number of concurrent users rate limit */
+      max_concurrent_users?: number
+      /** @description Sets maximum number of events per second rate per channel limit */
+      max_events_per_second?: number
+      /** @description Sets maximum number of joins per second rate limit */
+      max_joins_per_second?: number
+      /** @description Whether to only allow private channels */
+      private_only?: boolean
     }
     UpdateRestrictionsBody: {
       no_notification?: boolean
@@ -15384,7 +15768,7 @@ export interface operations {
           'application/json': components['schemas']['CustomerResponse']
         }
       }
-      /** @description Failed to retrieve the Stripe customer */
+      /** @description Failed to retrieve the Billing customer */
       500: {
         headers: {
           [name: string]: unknown
@@ -16294,7 +16678,7 @@ export interface operations {
       }
     }
   }
-  OrganizationRolesController_getAllRolesV2: {
+  OrganizationRolesController_getAllRoles: {
     parameters: {
       query?: never
       header?: never
@@ -19989,6 +20373,59 @@ export interface operations {
       }
     }
   }
+  RealtimeConfigController_getConfig: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Gets project's realtime configuration */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['RealtimeConfigResponseDto']
+        }
+      }
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  RealtimeConfigController_updateConfig: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['UpdateRealtimeConfigBodyDto']
+      }
+    }
+    responses: {
+      204: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
   SecretsConfigController_updateConfig: {
     parameters: {
       query?: never
@@ -21054,15 +21491,12 @@ export interface operations {
     parameters: {
       query?: never
       header?: never
-      path: {
-        /** @description Project ref */
-        ref: string
-      }
+      path?: never
       cookie?: never
     }
     requestBody: {
       content: {
-        'application/json': components['schemas']['RestartProjectInfo']
+        'application/json': components['schemas']['RestartProjectBodyDto']
       }
     }
     responses: {
@@ -21531,6 +21965,534 @@ export interface operations {
         }
       }
       /** @description Failed to retrieve project's settings */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  ReplicationPipelinesController_getPipelines: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        ref: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ReplicationPipelinesResponse']
+        }
+      }
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Failed to get replication pipeline */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  ReplicationPipelinesController_createPipeline: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        ref: string
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['CreateReplicationPipelineBody']
+      }
+    }
+    responses: {
+      201: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Failed to create pipeline */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  ReplicationPipelinesController_deletePipeline: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        pipeline_id: number
+        ref: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Failed to delete pipeline */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  ReplicationPipelinesController_startPipeline: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        pipeline_id: number
+        ref: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Failed to start pipeline */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  ReplicationPipelinesController_getPipelineStatus: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        pipeline_id: number
+        ref: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ReplicationPipelinesStatusResponse']
+        }
+      }
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Failed to get pipeline status */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  ReplicationPipelinesController_stopPipeline: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        pipeline_id: number
+        ref: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Failed to stop pipeline */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  ReplicationSinksController_getSinks: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        ref: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ReplicationSinksResponse']
+        }
+      }
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Failed to get replication sinks */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  ReplicationSinksController_createSink: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        ref: string
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['CreateReplicationSinkBody']
+      }
+    }
+    responses: {
+      201: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Failed to create sink */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  ReplicationSinksController_deleteSink: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        ref: string
+        sink_id: number
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Failed to delete sink */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  ReplicationSourcesController_getSources: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        ref: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Returns all sources. */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ReplicationSourcesResponse']
+        }
+      }
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Returned when the API fails to get replication sources. */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  ReplicationSourcesController_createSource: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        ref: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Returns the created replication source id. */
+      201: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['CreateSourceResponse']
+        }
+      }
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Returned when the API fails to create the replication source. */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  ReplicationSourcesController_getPublications: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        ref: string
+        source_id: number
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Returns all publications. */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ReplicationPublicationsResponse']
+        }
+      }
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Returned when the API fails to get source publications. */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  ReplicationSourcesController_createPublication: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        ref: string
+        source_id: number
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['CreateReplicationPublicationBody']
+      }
+    }
+    responses: {
+      /** @description Returned when the publication is created. */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      201: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Returned when the API fails to create the publication. */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  ReplicationSourcesController_deletePublication: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        publication_name: string
+        ref: string
+        source_id: number
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Returned when the publication is deleted. */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Returned when the API fails to delete the publication. */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  ReplicationSourcesController_getTables: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        ref: string
+        source_id: number
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Returns all tables. */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ReplicationTablesResponse']
+        }
+      }
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Returned when the API fails to get source tables. */
       500: {
         headers: {
           [name: string]: unknown
@@ -24114,6 +25076,23 @@ export interface operations {
       }
     }
   }
+  SystemRestartController_restartProject: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      201: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
   SystemProjectRunLintsController_runProjectLints: {
     parameters: {
       query?: never
@@ -25744,7 +26723,7 @@ export interface operations {
       }
     }
   }
-  OrganizationRolesController_getAllRolesV2: {
+  OrganizationRolesController_getAllRoles: {
     parameters: {
       query?: never
       header?: never
@@ -28908,6 +29887,59 @@ export interface operations {
       }
     }
   }
+  RealtimeConfigController_getConfig: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Gets project's realtime configuration */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['RealtimeConfigResponseDto']
+        }
+      }
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  RealtimeConfigController_updateConfig: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['UpdateRealtimeConfigBodyDto']
+      }
+    }
+    responses: {
+      204: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
   SecretsConfigController_updateConfig: {
     parameters: {
       query?: never
@@ -29736,15 +30768,12 @@ export interface operations {
     parameters: {
       query?: never
       header?: never
-      path: {
-        /** @description Project ref */
-        ref: string
-      }
+      path?: never
       cookie?: never
     }
     requestBody: {
       content: {
-        'application/json': components['schemas']['RestartProjectInfo']
+        'application/json': components['schemas']['RestartProjectBodyDto']
       }
     }
     responses: {


### PR DESCRIPTION
Customers can now set up additional billing email addresses themselves without having to reach out to us. This covers the following emails thus far:
- Invoice emails
- Payment failure emails

Dunning emails will still go out to all members to ensure visibility. The only thing this does not cover is payment receipts from Stripe, as Stripe still provides no API for setting additional emails (dashboard only for many years now)