### PR TITLE
Fix move query to new folder

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/MoveQueryModal.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/MoveQueryModal.tsx
@@ -164,7 +164,7 @@ export const MoveQueryModal = ({ visible, snippets = [], onClose }: MoveQueryMod
       snippets.forEach((snippet) => {
         snapV2.updateSnippet({
           id: snippet.id,
-          snippet: { ...snippet, folder_id: selectedId === 'root' ? null : selectedId },
+          snippet: { ...snippet, folder_id: selectedId === 'root' ? null : folderId },
           skipSave: true,
         })
       })


### PR DESCRIPTION
Client error occurs when moving a query to a new folder via the modal:
<img width="568" alt="image" src="https://github.com/user-attachments/assets/085fe7fb-30da-4417-b07a-263a79e1ebd3" />
