### PR TITLE
Billing docs revamp - Cleanup

### DIFF
--- a/apps/docs/content/guides/platform/cost-control.mdx
+++ b/apps/docs/content/guides/platform/cost-control.mdx
@@ -4,19 +4,19 @@ title: 'Control your costs'
 ---
 
 ## Spend Cap
-The Spend Cap determines whether your organization can exceed the subscription plan's free quota allowance for any metric. Scenarios that could lead to high usage—and thus high costs—include system attacks or bugs in your software. The Spend Cap can protect you from these unexpected costs for certain metrics.
+The Spend Cap determines whether your organization can exceed your subscription plan's quota for any metric. Scenarios that could lead to high usage—and thus high costs—include system attacks or bugs in your software. The Spend Cap can protect you from these unexpected costs for certain metrics.
 
 This feature is available only with the Pro Plan. However, you will not be charged while using the Free Plan.
 
 ### What happens when the Spend Cap is on?
-After exceeding the free quota allowance for a metric, further usage of that metric is disallowed until the next billing cycle. You don't get charged for over-usage but your services will be restricted according to our [Fair Use Policy](/docs/guides/platform/billing-faq#fair-use-policy) if you consistently exceed the free quota allowance.
+After exceeding the quota for a metric, further usage of that metric is disallowed until the next billing cycle. You don't get charged for over-usage but your services will be restricted according to our [Fair Use Policy](/docs/guides/platform/billing-faq#fair-use-policy) if you consistently exceed the quota.
 
 <Admonition type="note">
   Note that only certain metrics are covered by the Spend Cap.
 </Admonition>
 
 ### What happens when the Spend Cap is off?
-Your projects will continue to operate after exceeding the free quota allowance for a metric. Any additional usage will be charged based on the metric's cost per unit, as outlined on the [pricing page](https://supabase.com/pricing).
+Your projects will continue to operate after exceeding the quota for a metric. Any additional usage will be charged based on the metric's cost per unit, as outlined on the [pricing page](https://supabase.com/pricing).
 
 <Admonition type="note">
   When the Spend Cap is off, we recommend monitoring your usage and costs on the [organization's usage page](https://supabase.com/dashboard/org/_/usage).

--- a/apps/docs/content/guides/platform/cost-control.mdx
+++ b/apps/docs/content/guides/platform/cost-control.mdx
@@ -23,32 +23,31 @@ Your projects will continue to operate after exceeding the quota for a metric. A
 </Admonition>
 
 ### Metrics covered by the Spend Cap
-- Disk Size
-- Egress
-- Function Invocations
-- Monthly Active Users
-- Monthly Active SSO Users
-- Monthly Active Third Party Users
-- Realtime Messages
-- Realtime Peak Connections
-- Storage Image Transformations
-- Storage Size
+- [Disk Size](/docs/guides/platform/manage-your-usage/disk-size)
+- [Egress](/docs/guides/platform/manage-your-usage/egress)
+- [Edge Function Invocations](/docs/guides/platform/manage-your-usage/edge-function-invocations)
+- [Monthly Active Users](/docs/guides/platform/manage-your-usage/monthly-active-users)
+- [Monthly Active SSO Users](/docs/guides/platform/manage-your-usage/monthly-active-users-sso)
+- [Monthly Active Third Party Users](/docs/guides/platform/manage-your-usage/monthly-active-users-third-party)
+- [Realtime Messages](/docs/guides/platform/manage-your-usage/realtime-messages)
+- [Realtime Peak Connections](/docs/guides/platform/manage-your-usage/realtime-peak-connections)
+- [Storage Image Transformations](/docs/guides/platform/manage-your-usage/storage-image-transformations)
+- [Storage Size](/docs/guides/platform/manage-your-usage/storage-size)
 
 ### Metrics not covered by the Spend Cap
 Metrics that are predictable and explicitly opted into by the user are excluded.
 
-- Compute
-- Branching Compute
-- Read Replica Compute
-- Custom Domain
-- Additionally provisioned Disk IOPS
-- Additionally provisioned Disk Throughput
-- IPv4 address
+- [Compute](/docs/guides/platform/manage-your-usage/compute)
+- [Branching Compute](/docs/guides/platform/manage-your-usage/branching)
+- [Read Replica Compute](/docs/guides/platform/manage-your-usage/read-replicas)
+- [Custom Domain](/docs/guides/platform/manage-your-usage/custom-domains)
+- Additionally provisioned [Disk IOPS](/docs/guides/platform/manage-your-usage/disk-iops)
+- Additionally provisioned [Disk Throughput](/docs/guides/platform/manage-your-usage/disk-throughput)
+- [IPv4 address](/docs/guides/platform/manage-your-usage/ipv4)
 - Log Drain
 - Log Drain Events
-- Multi-Factor Authentication Phone
-- Multi-Factor Authentication WebAuthn
-- Point-In-Time-Recovery
+- [Multi-Factor Authentication Phone](/docs/guides/platform/manage-your-usage/advanced-mfa-phone)
+- [Point-in-Time-Recovery](/docs/guides/platform/manage-your-usage/point-in-time-recovery)
 
 ### What the Spend Cap is not
 The Spend Cap doesn't allow for fine-grained cost control, such as setting budgets for specific metrics or receiving notifications when certain costs are reached. We plan to make cost control more flexible in the future.

--- a/apps/docs/content/guides/platform/cost-control.mdx
+++ b/apps/docs/content/guides/platform/cost-control.mdx
@@ -4,25 +4,25 @@ title: 'Control your costs'
 ---
 
 ## Spend Cap
-The Spend Cap determines whether your organization can exceed your subscription plan's quota for any metric. Scenarios that could lead to high usage—and thus high costs—include system attacks or bugs in your software. The Spend Cap can protect you from these unexpected costs for certain metrics.
+The Spend Cap determines whether your organization can exceed your subscription plan's quota for any usage item. Scenarios that could lead to high usage—and thus high costs—include system attacks or bugs in your software. The Spend Cap can protect you from these unexpected costs for certain usage items.
 
 This feature is available only with the Pro Plan. However, you will not be charged while using the Free Plan.
 
 ### What happens when the Spend Cap is on?
-After exceeding the quota for a metric, further usage of that metric is disallowed until the next billing cycle. You don't get charged for over-usage but your services will be restricted according to our [Fair Use Policy](/docs/guides/platform/billing-faq#fair-use-policy) if you consistently exceed the quota.
+After exceeding the quota for a usage item, further usage of that item is disallowed until the next billing cycle. You don't get charged for over-usage but your services will be restricted according to our [Fair Use Policy](/docs/guides/platform/billing-faq#fair-use-policy) if you consistently exceed the quota.
 
 <Admonition type="note">
-  Note that only certain metrics are covered by the Spend Cap.
+  Note that only certain usage items are covered by the Spend Cap.
 </Admonition>
 
 ### What happens when the Spend Cap is off?
-Your projects will continue to operate after exceeding the quota for a metric. Any additional usage will be charged based on the metric's cost per unit, as outlined on the [pricing page](https://supabase.com/pricing).
+Your projects will continue to operate after exceeding the quota for a usage item. Any additional usage will be charged based on the item's cost per unit, as outlined on the [pricing page](https://supabase.com/pricing).
 
 <Admonition type="note">
   When the Spend Cap is off, we recommend monitoring your usage and costs on the [organization's usage page](https://supabase.com/dashboard/org/_/usage).
 </Admonition>
 
-### Metrics covered by the Spend Cap
+### Usage items covered by the Spend Cap
 - [Disk Size](/docs/guides/platform/manage-your-usage/disk-size)
 - [Egress](/docs/guides/platform/manage-your-usage/egress)
 - [Edge Function Invocations](/docs/guides/platform/manage-your-usage/edge-function-invocations)
@@ -34,8 +34,8 @@ Your projects will continue to operate after exceeding the quota for a metric. A
 - [Storage Image Transformations](/docs/guides/platform/manage-your-usage/storage-image-transformations)
 - [Storage Size](/docs/guides/platform/manage-your-usage/storage-size)
 
-### Metrics not covered by the Spend Cap
-Metrics that are predictable and explicitly opted into by the user are excluded.
+### Usage items not covered by the Spend Cap
+Usage items that are predictable and explicitly opted into by the user are excluded.
 
 - [Compute](/docs/guides/platform/manage-your-usage/compute)
 - [Branching Compute](/docs/guides/platform/manage-your-usage/branching)
@@ -50,7 +50,7 @@ Metrics that are predictable and explicitly opted into by the user are excluded.
 - [Point-in-Time-Recovery](/docs/guides/platform/manage-your-usage/point-in-time-recovery)
 
 ### What the Spend Cap is not
-The Spend Cap doesn't allow for fine-grained cost control, such as setting budgets for specific metrics or receiving notifications when certain costs are reached. We plan to make cost control more flexible in the future.
+The Spend Cap doesn't allow for fine-grained cost control, such as setting budgets for specific usage item or receiving notifications when certain costs are reached. We plan to make cost control more flexible in the future.
 
 ### Configure the Spend Cap
 You can configure the Spend Cap when creating an organization on the Pro Plan or at any time in the Cost Control section of the [organization's billing page](https://supabase.com/dashboard/org/_/billing).

--- a/apps/docs/content/guides/platform/get-set-up-for-billing.mdx
+++ b/apps/docs/content/guides/platform/get-set-up-for-billing.mdx
@@ -14,14 +14,14 @@ Paid plans require a credit card to be on file. Ensure the correct credit card i
 - has sufficient funds
 - has a sufficient transaction limit
 
-For more information on managing payment methods, see [Manage payment methods](/docs/guides/platform/manage-your-subscription/manage-your-payment-information#manage-payment-methods).
+For more information on managing payment methods, see [Manage your payment methods](/docs/guides/platform/manage-your-subscription#manage-your-payment-methods).
 
 ### Alternatives to monthly charges
 Instead of having your credit card charged every month, you can make an upfront payment by topping up your credit balance.
 
 You may want to consider this option to avoid issues with recurring payments, gain more control over how often your credit card is charged, and potentially make things easier for your accounting department.
 
-For more information on credits and credit top-ups, see the [Credits](/docs/guides/platform/credits) page.
+For more information on credits and credit top-ups, see the [Credits page](/docs/guides/platform/credits).
 
 ## Billing details
 Billing details cannot be changed once an invoice is issued, so it's crucial to configure them correctly from the start.

--- a/apps/docs/content/guides/platform/manage-your-usage/branching.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/branching.mdx
@@ -4,7 +4,7 @@ title: 'Manage Branching usage'
 ---
 
 ## What you are charged for
-Each [Preview branch](/docs/guides/deployment/branching) is a separate environment with all Supabase services (Database, Auth, Storage, etc.). You're charged for usage within that environment—such as [Compute](/docs/guides/platform/manage-your-usage/compute), Disk Size, Egress, and Storage—just like the project you branched from.
+Each [Preview branch](/docs/guides/deployment/branching) is a separate environment with all Supabase services (Database, Auth, Storage, etc.). You're charged for usage within that environment—such as [Compute](/docs/guides/platform/manage-your-usage/compute), [Disk Size](/docs/guides/platform/manage-your-usage/disk-size), [Egress](/docs/guides/platform/manage-your-usage/egress), and [Storage](/docs/guides/platform/manage-your-usage/storage-size)—just like the project you branched from.
 
 Usage by Preview branches counts toward your subscription plan's quota.
 

--- a/apps/docs/content/guides/platform/manage-your-usage/branching.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/branching.mdx
@@ -6,7 +6,7 @@ title: 'Manage Branching usage'
 ## What you are charged for
 Each [Preview branch](/docs/guides/deployment/branching) is a separate environment with all Supabase services (Database, Auth, Storage, etc.). You're charged for usage within that environment—such as [Compute](/docs/guides/platform/manage-your-usage/compute), Disk Size, Egress, and Storage—just like the project you branched from.
 
-Usage by Preview branches counts toward your subscription plan's free quota.
+Usage by Preview branches counts toward your subscription plan's quota.
 
 ## How charges are calculated
 Refer to individual [usage items](/docs/guides/platform/manage-your-usage) for details on how charges are calculated. Branching charges are the sum of all these items.

--- a/apps/docs/content/guides/platform/manage-your-usage/branching.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/branching.mdx
@@ -11,7 +11,7 @@ Usage by Preview branches counts toward your subscription plan's free quota.
 ## How charges are calculated
 Refer to individual [usage items](/docs/guides/platform/manage-your-usage) for details on how charges are calculated. Branching charges are the sum of all these items.
 
-### Branching usage on your invoice
+### Usage on your invoice
 Compute incurred by Preview branches is shown as "Branching Compute Hours" on your invoice. Other usage items are not shown separately for branches and are rolled up into the project.
 
 ## Pricing
@@ -36,7 +36,7 @@ The project has a Preview branch "XYZ", that runs for 30 hours, incurring Comput
 | Compute Credits                | -$10      |
 | **Total**                      | **$41.4** |
 
-## View Branching usage
+## View usage
 You can view Branching usage on the [organization's usage page](https://supabase.com/dashboard/org/_/usage). The page shows the usage of all projects by default. To view the usage for a specific project, select it from the dropdown. You can also select a different time period.
 <Image
   alt="Usage page navigation bar"
@@ -57,11 +57,11 @@ In the Usage Summary section, you can see how many hours your Preview branches e
   zoomable
 />
 
-## Optimize Branching usage
+## Optimize usage
 - Merge Preview branches as soon as they are ready
 - Delete Preview branches that are no longer in use
 - Check whether your [persistent branches](/docs/guides/deployment/branching#persistent-branches) need to be defined as persistent, or if they can be ephemeral instead. Persistent branches will remain active even after the underlying PR is closed.
 
-## Branching FAQ
+## FAQ
 ### Do Compute Credits apply to Branching Compute?
 No, Compute Credits do not apply to Branching Compute.

--- a/apps/docs/content/guides/platform/manage-your-usage/compute.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/compute.mdx
@@ -4,7 +4,7 @@ title: 'Manage Compute usage'
 ---
 
 ## What you are charged for
-Each project on the Supabase platform includes a dedicated Postgres instance running on its own server. You are charged for the Compute resources of that server, independent of your database usage.
+Each project on the Supabase platform includes a dedicated Postgres instance running on its own server. You are charged for the [Compute](/docs/guides/platform/compute-and-disk#compute) resources of that server, independent of your database usage.
 
 ## How charges are calculated
 Compute is charged by the hour, meaning you are charged for the exact number of hours that a project is running and, therefore, incurring Compute resources. If a project runs for part of an hour, you are still charged for the full hour.
@@ -87,7 +87,7 @@ The project's Compute size changes throughout the billing cycle.
 | Compute Credits               |       | -$10    |
 | **Total**                     |       | **$29** |
 
-## View Compute usage
+## View usage
 You can view Compute usage on the [organization's usage page](https://supabase.com/dashboard/org/_/usage). The page shows the usage of all projects by default. To view the usage for a specific project, select it from the dropdown. You can also select a different time period.
 <Image
   alt="Usage page navigation bar"
@@ -108,12 +108,12 @@ In the Compute Hours section, you can see how many hours of a specific Compute s
   zoomable
 />
 
-## Optimize Compute usage
+## Optimize usage
 - start out on a smaller Compute size, [create a report](https://supabase.com/dashboard/project/_/reports) on the Dashboard to monitor your CPU and memory utilization, and upgrade the Compute size as needed
 - load test your application in staging to understand your Compute requirements
 - [transfer projects](/docs/guides/platform/project-transfer) to a Free Plan organization to reduce Compute usage
 - delete unused projects
 
-## Compute FAQ
+## FAQ
 ### Do Compute Credits apply to line items other than Compute?
 No, Compute Credits apply only to Compute and do not cover other line items, including Read Replica Compute and Branching Compute.

--- a/apps/docs/content/guides/platform/manage-your-usage/compute.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/compute.mdx
@@ -23,8 +23,8 @@ Your billing cycle runs from January 1 to January 31. On January 10 at 4:30 PM, 
 | January 10, 04:30 PM - January 10, 5:00 PM  | Small        | 0            | time window is allocated to Micro Compute size |
 | January 10, 05:00 PM - January 31, 23:59 PM | Small        | 511          |                                                |
 
-### Compute usage on your invoice
- Compute usage is shown as "Compute Hours" on your invoice.
+### Usage on your invoice
+Usage is shown as "Compute Hours" on your invoice.
 
 ## Compute Credits
 Paid plans include $10 in Compute Credits, which cover one project running on the Micro/Nano Compute size or portions of other Compute sizes. Compute Credits are applied to your Compute costs and are provided to an organization each month. They reset monthly and do not accumulate.

--- a/apps/docs/content/guides/platform/manage-your-usage/custom-domains.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/custom-domains.mdx
@@ -21,7 +21,7 @@ Your billing cycle runs from January 1 to January 31. On January 10 at 4:30 PM, 
 
 
 ### Usage on your invoice
-Custom Domain usage is shown as "Custom Domain Hours" on your invoice.
+Usage is shown as "Custom Domain Hours" on your invoice.
 
 ## Pricing
 1 hour is $0.0137 ($10 per month).

--- a/apps/docs/content/guides/platform/manage-your-usage/custom-domains.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/custom-domains.mdx
@@ -24,7 +24,7 @@ Your billing cycle runs from January 1 to January 31. On January 10 at 4:30 PM, 
 Usage is shown as "Custom Domain Hours" on your invoice.
 
 ## Pricing
-1 hour is $0.0137 ($10 per month).
+$0.0137 per hour ($10 per month).
 
 ## Billing examples
 ### One project

--- a/apps/docs/content/guides/platform/manage-your-usage/disk-size.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/disk-size.mdx
@@ -14,8 +14,8 @@ Each database has a dedicated [disk](/docs/guides/platform/compute-and-disk#disk
 Disk size is charged by Gigabyte-Hours (GB-Hrs). 1 GB-Hrs represents 1 GB being provisioned for 1 hour.
 For example, having 10 GB provisioned for 5 hours results in 50 GB-Hrs (10 GB × 5 hours).
 
-### Disk size usage on your invoice
-Disk size usage is shown as "Disk Size GB-Hrs" on your invoice.
+### Usage on your invoice
+Usage is shown as "Disk Size GB-Hrs" on your invoice.
 
 ## Pricing
 Pricing depends on the [disk type](/docs/guides/platform/compute-and-disk#disk-types), with type gp3 being the default.
@@ -85,7 +85,7 @@ This disk type is billed from the first byte of provisioned disk, meaning for 66
 | Compute Credits               |           | -$10       |
 | **Total**                     |           | **$57.87** |
 
-## View Disk size usage
+## View usage
 You can view Disk size usage on the [organization's usage page](https://supabase.com/dashboard/org/_/usage). The page shows the usage of all projects by default. To view the usage for a specific project, select it from the dropdown.
 <Image
   alt="Usage page navigation bar"

--- a/apps/docs/content/guides/platform/manage-your-usage/disk-size.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/disk-size.mdx
@@ -21,8 +21,7 @@ Usage is shown as "Disk Size GB-Hrs" on your invoice.
 Pricing depends on the [disk type](/docs/guides/platform/compute-and-disk#disk-types), with type gp3 being the default.
 
 ### General purpose disks (gp3)
-
-1 GB-Hrs is $0.000171 ($0.125 per GB per month). The primary database of your project gets provisioned with an 8 GB disk. You are only charged for provisioned disk size exceeding these 8 GB.
+$0.000171 per GB-Hrs ($0.125 per GB per month). The primary database of your project gets provisioned with an 8 GB disk. You are only charged for provisioned disk size exceeding these 8 GB.
 
 | Plan       | Included Disk Size | Over-Usage per GB per month | Over-Usage per GB-Hrs |
 |------------|--------------------|-----------------------------|-----------------------|

--- a/apps/docs/content/guides/platform/manage-your-usage/edge-function-invocations.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/edge-function-invocations.mdx
@@ -22,7 +22,7 @@ For simplicity, let's assume a package size of 5 and a charge of $2 per package.
 Usage is shown as "Function Invocations" on your invoice.
 
 ## Pricing
-1 million invocations are $2. You are only charged for usage exceeding your subscription plan's quota.
+$2 per 1 million invocations. You are only charged for usage exceeding your subscription plan's quota.
 
 | Plan       | Quota                 | Over-Usage       |
 |------------|-----------------------|------------------|

--- a/apps/docs/content/guides/platform/manage-your-usage/edge-function-invocations.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/edge-function-invocations.mdx
@@ -19,7 +19,7 @@ For simplicity, let's assume a package size of 5 and a charge of $2 per package.
 | 6                     | 2                         | $4    |
 
 ### Usage on your invoice
-Edge Function Invocations usage is shown as "Function Invocations" on your invoice.
+Usage is shown as "Function Invocations" on your invoice.
 
 ## Pricing
 1 million invocations are $2. You are only charged for usage exceeding your subscription plan's quota.

--- a/apps/docs/content/guides/platform/manage-your-usage/edge-function-invocations.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/edge-function-invocations.mdx
@@ -24,12 +24,12 @@ Usage is shown as "Function Invocations" on your invoice.
 ## Pricing
 $2 per 1 million invocations. You are only charged for usage exceeding your subscription plan's quota.
 
-| Plan       | Quota                 | Over-Usage       |
-|------------|-----------------------|------------------|
-| Free       | 500,000 invocations   | -                |
-| Pro        | 2 Million invocations | $2 per 1 Million |
-| Team       | 2 Million invocations | $2 per 1 Million |
-| Enterprise | Custom                | Custom           |
+| Plan       | Quota     | Over-Usage                   |
+|------------|-----------|------------------------------|
+| Free       | 500,000   | -                            |
+| Pro        | 2 million | $2 per 1 million invocations |
+| Team       | 2 million | $2 per 1 million invocations |
+| Enterprise | Custom    | Custom                       |
 
 ## Billing examples
 ### Within quota

--- a/apps/docs/content/guides/platform/manage-your-usage/egress.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/egress.mdx
@@ -38,8 +38,8 @@ Data pushed to clients via Supabase Realtime for subscribed events.
 ## How charges are calculated
 Egress is charged by byte. Charges apply only for usage exceeding your subscription plan's quota. This quota is called the Unified Egress Quota because it can be used across all services (Database, Auth, Storage etc.).
 
-### Egress usage on your invoice
-Egress usage is shown as "Egress GB" on your invoice.
+### Usage on your invoice
+Usage is shown as "Egress GB" on your invoice.
 
 ## Pricing
 1 GB is $0.09 per month. You are only charged for usage exceeding your subscription plan's quota.
@@ -76,7 +76,7 @@ The organization's Egress usage exceeds the quota by 50 GB, incurring charges fo
 | Compute Credits     |           | -$10      |
 | **Total**           |           | **$29.5** |
 
-## View Egress usage
+## View usage
 ### Usage page
 You can view Egress usage on the [organization's usage page](https://supabase.com/dashboard/org/_/usage). The page shows the usage of all projects by default. To view the usage for a specific project, select it from the dropdown. You can also select a different time period.
 <Image
@@ -110,7 +110,7 @@ In the Total Egress section, you can see the usage for the selected time period.
   zoomable
 />
 
-## Debug Egress usage
+## Debug usage
 To better understand your Egress usage, identify what’s driving the most traffic. Check the most frequent database queries, or analyze the most requested API paths to pinpoint high-bandwidth endpoints.
 
 ### Frequent database queries
@@ -135,7 +135,7 @@ In the [Logs Explorer](https://supabase.com/dashboard/project/_/logs/explorer) y
   zoomable
 />
 
-## Optimize Egress usage
+## Optimize usage
 - Reduce the number of fields or entries selected when querying your database
 - Reduce the number of queries or calls by optimizing client code or using caches
 - For update or insert queries, configure your ORM or queries to not return the entire row if not needed

--- a/apps/docs/content/guides/platform/manage-your-usage/egress.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/egress.mdx
@@ -44,12 +44,12 @@ Usage is shown as "Egress GB" on your invoice.
 ## Pricing
 $0.09 per GB per month. You are only charged for usage exceeding your subscription plan's quota.
 
-| Plan       | Unified Egress Quota | Over-Usage per GB per month |
-|------------|----------------------|-----------------------------|
-| Free       | 5 GB                 | -                           |
-| Pro        | 250 GB               | $0.09                       |
-| Team       | 250 GB               | $0.09                       |
-| Enterprise | Custom               | Custom                      |
+| Plan       | Unified Egress Quota | Over-Usage per month |
+|------------|----------------------|----------------------|
+| Free       | 5 GB                 | -                    |
+| Pro        | 250 GB               | $0.09 per GB         |
+| Team       | 250 GB               | $0.09 per GB         |
+| Enterprise | Custom               | Custom               |
 
 ## Billing examples
 ### Within quota

--- a/apps/docs/content/guides/platform/manage-your-usage/egress.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/egress.mdx
@@ -42,7 +42,7 @@ Egress is charged by byte. Charges apply only for usage exceeding your subscript
 Usage is shown as "Egress GB" on your invoice.
 
 ## Pricing
-1 GB is $0.09 per month. You are only charged for usage exceeding your subscription plan's quota.
+$0.09 per GB per month. You are only charged for usage exceeding your subscription plan's quota.
 
 | Plan       | Unified Egress Quota | Over-Usage per GB per month |
 |------------|----------------------|-----------------------------|

--- a/apps/docs/content/guides/platform/manage-your-usage/ipv4.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/ipv4.mdx
@@ -28,7 +28,7 @@ Your billing cycle runs from January 1 to January 31. On January 10 at 4:30 PM, 
 Usage is shown as "IPv4 Hours" on your invoice.
 
 ## Pricing
-1 hour is $0.0055 ($4 per month).
+$0.0055 per hour ($4 per month).
 
 ## Billing examples
 ### One project

--- a/apps/docs/content/guides/platform/manage-your-usage/ipv4.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/ipv4.mdx
@@ -25,7 +25,7 @@ Your billing cycle runs from January 1 to January 31. On January 10 at 4:30 PM, 
 
 
 ### Usage on your invoice
-IPv4 usage is shown as "IPv4 Hours" on your invoice.
+Usage is shown as "IPv4 Hours" on your invoice.
 
 ## Pricing
 1 hour is $0.0055 ($4 per month).

--- a/apps/docs/content/guides/platform/manage-your-usage/monthly-active-users-sso.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/monthly-active-users-sso.mdx
@@ -76,26 +76,26 @@ $0.015 per SSO MAU. You are only charged for usage exceeding your subscription p
 ### Within quota
 The organization's SSO MAU usage for the billing cycle is within the quota, so no charges apply.
 
-| Line Item                | Units       | Costs   |
-|--------------------------|-------------|---------|
-| Pro Plan                 | 1           | $25     |
-| Compute Hours Micro      | 744 hours   | $10     |
-| Monthly Active SSO Users | 37 SSO MAUs | $0      |
-| **Subtotal**             |             | **$35** |
-| Compute Credits          |             | -$10    |
-| **Total**                |             | **$25** |
+| Line Item                | Units      | Costs   |
+|--------------------------|------------|---------|
+| Pro Plan                 | 1          | $25     |
+| Compute Hours Micro      | 744 hours  | $10     |
+| Monthly Active SSO Users | 37 SSO MAU | $0      |
+| **Subtotal**             |            | **$35** |
+| Compute Credits          |            | -$10    |
+| **Total**                |            | **$25** |
 
 ### Exceeding quota
 The organization's SSO MAU usage for the billing cycle exceeds the quota by 10, incurring charges for this additional usage.
 
-| Line Item                | Units       | Costs      |
-|--------------------------|-------------|------------|
-| Pro Plan                 | 1           | $25        |
-| Compute Hours Micro      | 744 hours   | $10        |
-| Monthly Active SSO Users | 60 SSO MAUs | $0.15      |
-| **Subtotal**             |             | **$35.15** |
-| Compute Credits          |             | -$10       |
-| **Total**                |             | **$25.15** |
+| Line Item                | Units      | Costs      |
+|--------------------------|------------|------------|
+| Pro Plan                 | 1          | $25        |
+| Compute Hours Micro      | 744 hours  | $10        |
+| Monthly Active SSO Users | 60 SSO MAU | $0.15      |
+| **Subtotal**             |            | **$35.15** |
+| Compute Credits          |            | -$10       |
+| **Total**                |            | **$25.15** |
 
 ## View usage
 You can view Monthly Active SSO Users usage on the [organization's usage page](https://supabase.com/dashboard/org/_/usage). The page shows the usage of all projects by default. To view the usage for a specific project, select it from the dropdown. You can also select a different time period.

--- a/apps/docs/content/guides/platform/manage-your-usage/monthly-active-users-third-party.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/monthly-active-users-third-party.mdx
@@ -75,26 +75,26 @@ $0.00325 per Third-Party MAU. You are only charged for usage exceeding your subs
 ### Within quota
 The organization's Third-Party MAU usage for the billing cycle is within the quota, so no charges apply.
 
-| Line Item                        | Units               | Costs   |
-|----------------------------------|---------------------|---------|
-| Pro Plan                         | 1                   | $25     |
-| Compute Hours Micro              | 744 hours           | $10     |
-| Monthly Active Third-Party Users | 37 Third-Party MAUs | $0      |
-| **Subtotal**                     |                     | **$35** |
-| Compute Credits                  |                     | -$10    |
-| **Total**                        |                     | **$25** |
+| Line Item                        | Units              | Costs   |
+|----------------------------------|--------------------|---------|
+| Pro Plan                         | 1                  | $25     |
+| Compute Hours Micro              | 744 hours          | $10     |
+| Monthly Active Third-Party Users | 37 Third-Party MAU | $0      |
+| **Subtotal**                     |                    | **$35** |
+| Compute Credits                  |                    | -$10    |
+| **Total**                        |                    | **$25** |
 
 ### Exceeding quota
 The organization's Third-Party MAU usage for the billing cycle exceeds the quota by 4950, incurring charges for this additional usage.
 
-| Line Item                        | Units                 | Costs      |
-|----------------------------------|-----------------------|------------|
-| Pro Plan                         | 1                     | $25        |
-| Compute Hours Micro              | 744 hours             | $10        |
-| Monthly Active Third-Party Users | 5000 Third-Party MAUs | $16.09     |
-| **Subtotal**                     |                       | **$51.09** |
-| Compute Credits                  |                       | -$10       |
-| **Total**                        |                       | **$41.09** |
+| Line Item                        | Units                | Costs      |
+|----------------------------------|----------------------|------------|
+| Pro Plan                         | 1                    | $25        |
+| Compute Hours Micro              | 744 hours            | $10        |
+| Monthly Active Third-Party Users | 5000 Third-Party MAU | $16.09     |
+| **Subtotal**                     |                      | **$51.09** |
+| Compute Credits                  |                      | -$10       |
+| **Total**                        |                      | **$41.09** |
 
 ## View usage
 You can view Monthly Active Third-Party Users usage on the [organization's usage page](https://supabase.com/dashboard/org/_/usage). The page shows the usage of all projects by default. To view the usage for a specific project, select it from the dropdown. You can also select a different time period.

--- a/apps/docs/content/guides/platform/manage-your-usage/monthly-active-users.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/monthly-active-users.mdx
@@ -69,26 +69,26 @@ $0.00325 per MAU. You are only charged for usage exceeding your subscription pla
 ### Within quota
 The organization's MAU usage for the billing cycle is within the quota, so no charges apply.
 
-| Line Item            | Units       | Costs   |
-|----------------------|-------------|---------|
-| Pro Plan             | 1           | $25     |
-| Compute Hours Micro  | 744 hours   | $10     |
-| Monthly Active Users | 23,000 MAUs | $0      |
-| **Subtotal**         |             | **$35** |
-| Compute Credits      |             | -$10    |
-| **Total**            |             | **$25** |
+| Line Item            | Units      | Costs   |
+|----------------------|------------|---------|
+| Pro Plan             | 1          | $25     |
+| Compute Hours Micro  | 744 hours  | $10     |
+| Monthly Active Users | 23,000 MAU | $0      |
+| **Subtotal**         |            | **$35** |
+| Compute Credits      |            | -$10    |
+| **Total**            |            | **$25** |
 
 ### Exceeding quota
 The organization's MAU usage for the billing cycle exceeds the quota by 60,000, incurring charges for this additional usage.
 
-| Line Item            | Units        | Costs    |
-|----------------------|--------------|----------|
-| Pro Plan             | 1            | $25      |
-| Compute Hours Micro  | 744 hours    | $10      |
-| Monthly Active Users | 160,000 MAUs | $195     |
-| **Subtotal**         |              | **$230** |
-| Compute Credits      |              | -$10     |
-| **Total**            |              | **$220** |
+| Line Item            | Units       | Costs    |
+|----------------------|-------------|----------|
+| Pro Plan             | 1           | $25      |
+| Compute Hours Micro  | 744 hours   | $10      |
+| Monthly Active Users | 160,000 MAU | $195     |
+| **Subtotal**         |             | **$230** |
+| Compute Credits      |             | -$10     |
+| **Total**            |             | **$220** |
 
 ## View usage
 You can view Monthly Active Users usage on the [organization's usage page](https://supabase.com/dashboard/org/_/usage). The page shows the usage of all projects by default. To view the usage for a specific project, select it from the dropdown. You can also select a different time period.

--- a/apps/docs/content/guides/platform/manage-your-usage/point-in-time-recovery.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/point-in-time-recovery.mdx
@@ -21,7 +21,7 @@ Your billing cycle runs from January 1 to January 31. On January 10 at 4:30 PM, 
 
 
 ### Usage on your invoice
-PITR usage is shown as "Point-in-time recovery Hours" on your invoice.
+Usage is shown as "Point-in-time recovery Hours" on your invoice.
 
 ## Pricing
 Pricing depends on the recovery retention period, which determines how many days back you can restore data to any chosen point of up to seconds in granularity.

--- a/apps/docs/content/guides/platform/manage-your-usage/read-replicas.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/read-replicas.mdx
@@ -15,7 +15,7 @@ Compute is charged by the hour, meaning you are charged for the exact number of 
 Read Replicas run on the same Compute size as the primary database.
 
 **Disk Size**
-Refer to [Manage Disk Size usage](/docs/guides/platform/manage-your-usage/disk-size) for details on how charges are calculated. The disk size of a Read Replica is 1.25x the size of the primary disk to account for WAL archives. With a Read Replica you go beyond the subscription plan's free quota for Disk Size.
+Refer to [Manage Disk Size usage](/docs/guides/platform/manage-your-usage/disk-size) for details on how charges are calculated. The disk size of a Read Replica is 1.25x the size of the primary disk to account for WAL archives. With a Read Replica you go beyond your subscription plan's quota for Disk Size.
 
 **Provisioned Disk IOPS (optional)**
 Read Replicas inherit any additional provisioned Disk IOPS from the primary database. Refer to [Manage Disk IOPS usage](/docs/guides/platform/manage-your-usage/disk-iops) for details on how charges are calculated.

--- a/apps/docs/content/guides/platform/manage-your-usage/read-replicas.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/read-replicas.mdx
@@ -26,7 +26,7 @@ Read Replicas inherit any additional provisioned Disk Throughput from the primar
 **IPv4 (optional)**
 If the primary database has a configured IPv4 address, its Read Replicas are also assigned one, with charges for each. Refer to [Manage IPv4 usage](/docs/guides/platform/manage-your-usage/ipv4) for details on how charges are calculated.
 
-### Read Replica usage on your invoice
+### Usage on your invoice
 Compute incurred by Read Replicas is shown as "Replica Compute Hours" on your invoice. Disk Size, Disk IOPS, Disk Throughput and IPv4 are not shown separately for Read Replicas and are rolled up into the project.
 
 ## Billing examples
@@ -76,6 +76,6 @@ The project has two Read Replicas and IPv4 and additional Disk IOPS and Disk Thr
 | Compute Credits               |           | -$10        |
 | **Total**                     |           | **$424.13** |
 
-## Read Replica FAQ
+## FAQ
 ### Do Compute Credits apply to Read Replica Compute?
 No, Compute Credits do not apply to Read Replica Compute.

--- a/apps/docs/content/guides/platform/manage-your-usage/read-replicas.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/read-replicas.mdx
@@ -57,19 +57,19 @@ The project has two Read Replicas and IPv4 and additional Disk IOPS and Disk Thr
 | Compute Hours Large Project 1 | 744 hours | $110        |
 | Disk Size Project 1           | 8 GB      | $0          |
 | Disk IOPS Project 1           | 3600      | $14.40      |
-| Disk Throughput Project 1     | 200 MiB/s | $7.13       |
+| Disk Throughput Project 1     | 200 Mbps  | $7.13       |
 | IPv4 Hours Project 1          | 744 hours | $4          |
 |                               |           |             |
 | Compute Hours Large Replica 1 | 744 hours | $110        |
 | Disk Size Replica 1           | 10 GB     | $1.27       |
 | Disk IOPS Replica 1           | 3600      | $14.40      |
-| Disk Throughput Replica 1     | 200 MiB/s | $7.13       |
+| Disk Throughput Replica 1     | 200 Mbps  | $7.13       |
 | IPv4 Hours Replica 1          | 744 hours | $4          |
 |                               |           |             |
 | Compute Hours Large Replica 2 | 744 hours | $110        |
 | Disk Size Replica 2           | 10 GB     | $1.27       |
 | Disk IOPS Replica 2           | 3600      | $14.40      |
-| Disk Throughput Replica 2     | 200 MiB/s | $7.13       |
+| Disk Throughput Replica 2     | 200 Mbps  | $7.13       |
 | IPv4 Hours Replica 2          | 744 hours | $4          |
 |                               |           |             |
 | **Subtotal**                  |           | **$434.13** |

--- a/apps/docs/content/guides/platform/manage-your-usage/realtime-messages.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/realtime-messages.mdx
@@ -18,11 +18,11 @@ Realtime Messages are billed using Package pricing, with each package representi
 ### Example
 For simplicity, let's assume a package size of 5 and a charge of $2 per package.
 
-| Number Of Messages | Number Of Packages Billed | Costs |
-|--------------------|---------------------------|-------|
-| 4                  | 1                         | $2    |
-| 5                  | 1                         | $2    |
-| 6                  | 2                         | $4    |
+| Messages | Packages Billed | Costs |
+|----------|-----------------|-------|
+| 4        | 1               | $2    |
+| 5        | 1               | $2    |
+| 6        | 2               | $4    |
 
 ### Usage on your invoice
 Usage is shown as "Realtime Messages" on your invoice.
@@ -30,12 +30,12 @@ Usage is shown as "Realtime Messages" on your invoice.
 ## Pricing
 $2.50 per 1 million messages. You are only charged for usage exceeding your subscription plan's quota.
 
-| Plan       | Quota              | Over-Usage          |
-|------------|--------------------|---------------------|
-| Free       | 2 Million messages | -                   |
-| Pro        | 5 Million messages | $2.50 per 1 Million |
-| Team       | 5 Million messages | $2.50 per 1 Million |
-| Enterprise | Custom             | Custom              |
+| Plan       | Quota     | Over-Usage                   |
+|------------|-----------|------------------------------|
+| Free       | 2 million | -                            |
+| Pro        | 5 million | $2.50 per 1 million messages |
+| Team       | 5 million | $2.50 per 1 million messages |
+| Enterprise | Custom    | Custom                       |
 
 ## Billing examples
 ### Within quota

--- a/apps/docs/content/guides/platform/manage-your-usage/realtime-messages.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/realtime-messages.mdx
@@ -12,9 +12,6 @@ Each database change counts as one message per client that listens to the event.
 **Broadcast**
 Each broadcast message counts as one message sent plus one message per subscribed client that receives it. For example, if you broadcast a message and 4 clients listen to it, it counts as 5 messages—1 sent and 4 received.
 
-**Presence**
-TODO: Ask Data Engineering.
-
 ## How charges are calculated
 Realtime Messages are billed using Package pricing, with each package representing 1 million messages. If your usage falls between two packages, you are billed for the next whole package.
 

--- a/apps/docs/content/guides/platform/manage-your-usage/realtime-peak-connections.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/realtime-peak-connections.mdx
@@ -9,10 +9,10 @@ Realtime Peak Connections are measured by tracking the highest number of concurr
 ### Example
 For simplicity, this example assumes a billing cycle of only three days.
 
-| **Project** | **Peak Connections Day 1** | **Peak Connections Day 2** | **Peak Connections Day 3** |
-|-------------|----------------------------|----------------------------|----------------------------|
-| Project A   | 80                         | 100                        | 90                         |
-| Project B   | 120                        | 110                        | 150                        |
+| Project   | Peak Connections Day 1 | Peak Connections Day 2 | Peak Connections Day 3 |
+|-----------|------------------------|------------------------|------------------------|
+| Project A | 80                     | 100                    | 90                     |
+| Project B | 120                    | 110                    | 150                    |
 
 **Total billed connections:** 100 (Project A) + 150 (Project B) = **250 connections**
 
@@ -22,11 +22,11 @@ Realtime Peak Connections are billed using Package pricing, with each package re
 ### Example
 For simplicity, let's assume a package size of 5 and a charge of $2 per package.
 
-| Peak Connections | Number Of Packages Billed | Costs |
-|------------------|---------------------------|-------|
-| 4                | 1                         | $2    |
-| 5                | 1                         | $2    |
-| 6                | 2                         | $4    |
+| Peak Connections | Packages Billed | Costs |
+|------------------|-----------------|-------|
+| 4                | 1               | $2    |
+| 5                | 1               | $2    |
+| 6                | 2               | $4    |
 
 ### Usage on your invoice
 Usage is shown as "Realtime Peak Connections" on your invoice.
@@ -34,12 +34,12 @@ Usage is shown as "Realtime Peak Connections" on your invoice.
 ## Pricing
 $10 per 1,000 peak connections. You are only charged for usage exceeding your subscription plan's quota.
 
-| Plan       | Quota           | Over-Usage    |
-|------------|-----------------|---------------|
-| Free       | 200 connections | -             |
-| Pro        | 500 connections | $10 per 1,000 |
-| Team       | 500 connections | $10 per 1,000 |
-| Enterprise | Custom          | Custom        |
+| Plan       | Quota  | Over-Usage                     |
+|------------|--------|--------------------------------|
+| Free       | 200    | -                              |
+| Pro        | 500    | $10 per 1,000 peak connections |
+| Team       | 500    | $10 per 1,000 peak connections |
+| Enterprise | Custom | Custom                         |
 
 ## Billing examples
 ### Within quota

--- a/apps/docs/content/guides/platform/manage-your-usage/storage-image-transformations.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/storage-image-transformations.mdx
@@ -58,7 +58,7 @@ For simplicity, let's assume a package size of 5 and a charge of $2 per package.
 | 6                       | 2                         | $4    |
 
 ### Usage on your invoice
-Storage Image Transformations usage is shown as "Storage Image Transformations" on your invoice.
+Usage is shown as "Storage Image Transformations" on your invoice.
 
 ## Pricing
 $5 per 1000 origin images. You are only charged for usage exceeding your subscription plan's quota.

--- a/apps/docs/content/guides/platform/manage-your-usage/storage-image-transformations.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/storage-image-transformations.mdx
@@ -51,27 +51,27 @@ Storage Image Transformations are billed using Package pricing, with each packag
 ### Example
 For simplicity, let's assume a package size of 5 and a charge of $2 per package.
 
-| Number of Origin Images | Number of Packages Billed | Costs |
-|-------------------------|---------------------------|-------|
-| 4                       | 1                         | $2    |
-| 5                       | 1                         | $2    |
-| 6                       | 2                         | $4    |
+| Origin Images | Packages Billed | Costs |
+|---------------|-----------------|-------|
+| 4             | 1               | $2    |
+| 5             | 1               | $2    |
+| 6             | 2               | $4    |
 
 ### Usage on your invoice
 Usage is shown as "Storage Image Transformations" on your invoice.
 
 ## Pricing
-$5 per 1000 origin images. You are only charged for usage exceeding your subscription plan's quota.
+$5 per 1,000 origin images. You are only charged for usage exceeding your subscription plan's quota.
 
 <Admonition type="note">
   The count resets at the start of each billing cycle.
 </Admonition>
 
-| Plan       | Quota             | Over-Usage  |
-|------------|-------------------|-------------|
-| Pro        | 100 origin images | $5 per 1000 |
-| Team       | 100 origin images | $5 per 1000 |
-| Enterprise | Custom            | Custom      |
+| Plan       | Quota  | Over-Usage                 |
+|------------|--------|----------------------------|
+| Pro        | 100    | $5 per 1,000 origin images |
+| Team       | 100    | $5 per 1,000 origin images |
+| Enterprise | Custom | Custom                     |
 
 ## Billing examples
 ### Within quota

--- a/apps/docs/content/guides/platform/manage-your-usage/storage-size.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/storage-size.mdx
@@ -16,12 +16,12 @@ Usage is shown as "Storage Size GB-Hrs" on your invoice.
 ## Pricing
 $0.00002919 per GB-Hrs ($0.021 per GB per month). You are only charged for usage exceeding your subscription plan's quota.
 
-| Plan       | Free Quota in GB | Over-Usage per GB | Free Quota in GB-Hrs | Over-Usage per GB-Hrs |
-|------------|------------------|-------------------|----------------------|-----------------------|
-| Free       | 1 GB             | -                 | 744                  | -                     |
-| Pro        | 100 GB           | $0.021            | 74,400               | $0.00002919           |
-| Team       | 100 GB           | $0.021            | 74,400               | $0.00002919           |
-| Enterprise | Custom           | Custom            | Custom               | Custom                |
+| Plan       | Quota in GB | Over-Usage per GB | Quota in GB-Hrs | Over-Usage per GB-Hrs |
+|------------|-------------|-------------------|-----------------|-----------------------|
+| Free       | 1           | -                 | 744             | -                     |
+| Pro        | 100         | $0.021            | 74,400          | $0.00002919           |
+| Team       | 100         | $0.021            | 74,400          | $0.00002919           |
+| Enterprise | Custom      | Custom            | Custom          | Custom                |
 
 ## Billing examples
 ### Within quota

--- a/apps/docs/content/guides/platform/manage-your-usage/storage-size.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/storage-size.mdx
@@ -14,7 +14,7 @@ For example, storing 10 GB of data for 5 hours results in 50 GB-Hrs (10 GB × 5 
 Usage is shown as "Storage Size GB-Hrs" on your invoice.
 
 ## Pricing
-$0.00002919 per GB-Hrs ($0.021 per GB per month). You are only charged for usage exceeding your subscription plan's free quota.
+$0.00002919 per GB-Hrs ($0.021 per GB per month). You are only charged for usage exceeding your subscription plan's quota.
 
 | Plan       | Free Quota in GB | Over-Usage per GB | Free Quota in GB-Hrs | Over-Usage per GB-Hrs |
 |------------|------------------|-------------------|----------------------|-----------------------|

--- a/apps/docs/content/guides/platform/manage-your-usage/storage-size.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/storage-size.mdx
@@ -10,8 +10,8 @@ You are charged for the total size of all assets in your buckets.
 Storage size is charged by Gigabyte-Hours (GB-Hrs). 1 GB-Hrs represents the use of 1 GB of storage for 1 hour.
 For example, storing 10 GB of data for 5 hours results in 50 GB-Hrs (10 GB × 5 hours).
 
-### Storage size usage on your invoice
-Storage size usage is shown as "Storage Size GB-Hrs" on your invoice.
+### Usage on your invoice
+Usage is shown as "Storage Size GB-Hrs" on your invoice.
 
 ## Pricing
 1 GB-Hrs is $0.00002919. That is $0.021 per GB per month. You are only charged for usage exceeding your subscription plan's free quota.
@@ -48,7 +48,7 @@ The organization's Storage size usage exceeds the free quota by 257 GB, incurrin
 | Compute Credits     |           | -$10      |
 | **Total**           |           | **$30.4** |
 
-## View Storage size usage
+## View usage
 ### Usage page
 You can view Storage size usage on the [organization's usage page](https://supabase.com/dashboard/org/_/usage). The page shows the usage of all projects by default. To view the usage for a specific project, select it from the dropdown. You can also select a different time period.
 <Image
@@ -108,6 +108,6 @@ order by
     total_size_megabyte desc;
 ```
 
-## Optimize Storage size usage
+## Optimize usage
 - [Limit the upload size](/docs/guides/storage/production/scaling#limit-the-upload-size) for your buckets
 - [Delete assets](/docs/guides/storage/management/delete-objects) that are no longer in use

--- a/apps/docs/content/guides/platform/manage-your-usage/storage-size.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/storage-size.mdx
@@ -14,7 +14,7 @@ For example, storing 10 GB of data for 5 hours results in 50 GB-Hrs (10 GB × 5 
 Usage is shown as "Storage Size GB-Hrs" on your invoice.
 
 ## Pricing
-1 GB-Hrs is $0.00002919. That is $0.021 per GB per month. You are only charged for usage exceeding your subscription plan's free quota.
+$0.00002919 per GB-Hrs ($0.021 per GB per month). You are only charged for usage exceeding your subscription plan's free quota.
 
 | Plan       | Free Quota in GB | Over-Usage per GB | Free Quota in GB-Hrs | Over-Usage per GB-Hrs |
 |------------|------------------|-------------------|----------------------|-----------------------|


### PR DESCRIPTION
Clean up of "minor" things
- use the term "usage item" instead of "metric" on "Control your costs" page
- shorten section headlines on usage pages
- consistent wording for prices on usage pages
- use "quota" everywhere instead of "free quota" / "free quota allowance"
- use "Mbps" everywhere
- fix all links
- rework pricing tables regarding column names and units