### PR TITLE
nextjs.mdx: Correct links in nextjs auth example

### DIFF
--- a/apps/docs/content/guides/auth/quickstarts/nextjs.mdx
+++ b/apps/docs/content/guides/auth/quickstarts/nextjs.mdx
@@ -72,7 +72,7 @@ hideToc: true
 
     Start the development server, go to http://localhost:3000 in a browser, and you should see the contents of `app/page.tsx`.
 
-    To sign up a new user, navigate to http://localhost:3000/login, and click `Sign Up Now`.
+    To sign up a new user, navigate to http://localhost:3000/sign-up, and click `Sign up`. *NOTE: .env.example must be renamed to .env.local before this route becomes available*
 
     </StepHikeCompact.Details>
 


### PR DESCRIPTION
The docs directed to localhost:3000/login
It seems the nextjs template now has a new route `/sign-in`
Added note: 
the route does not become available until .env.local is in env

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

NO

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

[next.js example docs](https://supabase.com/docs/guides/auth/quickstarts/nextjs) Gave an outdated route

## What is the new behavior?

The docs should now direct the user to the correct /sign-up route
