### PR TITLE
chore(pg-meta): port functions tests

### DIFF
--- a/packages/pg-meta/package.json
+++ b/packages/pg-meta/package.json
@@ -19,8 +19,8 @@
   "devDependencies": {
     "@types/pg": "^8.11.11",
     "npm-run-all": "^4.1.5",
-    "pg": "8.13.1",
-    "postgres": "^3.4.5",
+    "pg": "^8.13.1",
+    "postgres-array": "^3.0.2",
     "typescript": "~5.5.0",
     "vitest": "^2.1.8"
   }

--- a/packages/pg-meta/package.json
+++ b/packages/pg-meta/package.json
@@ -17,7 +17,9 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
+    "@types/pg": "^8.11.11",
     "npm-run-all": "^4.1.5",
+    "pg": "8.13.1",
     "postgres": "^3.4.5",
     "typescript": "~5.5.0",
     "vitest": "^2.1.8"

--- a/packages/pg-meta/src/pg-meta-functions.ts
+++ b/packages/pg-meta/src/pg-meta-functions.ts
@@ -4,30 +4,6 @@ import { DEFAULT_SYSTEM_SCHEMAS } from './constants'
 import { filterByList } from './helpers'
 import { FUNCTIONS_SQL } from './sql/functions'
 
-export type PGFunction = {
-  id: number
-  schema: string
-  name: string
-  language: string
-  definition: string
-  complete_statement: string
-  args: Array<{
-    mode: 'in' | 'out' | 'inout' | 'variadic' | 'table'
-    name: string
-    type_id: number
-    has_default: boolean
-  }>
-  argument_types: string
-  identity_argument_types: string
-  return_type_id: number
-  return_type: string
-  return_type_relation_id: number | null
-  is_set_returning_function: boolean
-  behavior: 'IMMUTABLE' | 'STABLE' | 'VOLATILE'
-  security_definer: boolean
-  config_params: Record<string, string> | null
-}
-
 export const pgFunctionZod = z.object({
   id: z.number(),
   schema: z.string(),
@@ -58,7 +34,9 @@ export const pgFunctionZod = z.object({
   behavior: z.union([z.literal('IMMUTABLE'), z.literal('STABLE'), z.literal('VOLATILE')]),
   security_definer: z.boolean(),
   config_params: z.union([z.record(z.string(), z.string()), z.null()]),
-}) satisfies z.ZodType<PGFunction>
+})
+
+export type PGFunction = z.infer<typeof pgFunctionZod>
 
 export const pgFunctionArrayZod = z.array(pgFunctionZod)
 export const pgFunctionOptionalZod = z.optional(pgFunctionZod)

--- a/packages/pg-meta/src/pg-meta-functions.ts
+++ b/packages/pg-meta/src/pg-meta-functions.ts
@@ -93,13 +93,13 @@ export function list({
     !includeSystemSchemas ? DEFAULT_SYSTEM_SCHEMAS : undefined
   )
   if (filter) {
-    sql += ` WHERE schema ${filter}`
+    sql += ` where schema ${filter}`
   }
   if (limit) {
-    sql = `${sql} LIMIT ${limit}`
+    sql = `${sql} limit ${limit}`
   }
   if (offset) {
-    sql = `${sql} OFFSET ${offset}`
+    sql = `${sql} offset ${offset}`
   }
 
   return {

--- a/packages/pg-meta/src/sql/functions.ts
+++ b/packages/pg-meta/src/sql/functions.ts
@@ -89,6 +89,8 @@ from
           oid,
           unnest(arg_modes) as mode,
           unnest(arg_names) as name,
+          -- Coming from: coalesce(p.proallargtypes, p.proargtypes) postgres won't automatically assume
+          -- integer, we need to cast it to be properly parsed
           unnest(arg_types)::int8 as type_id,
           unnest(arg_has_defaults) as has_default
         from

--- a/packages/pg-meta/src/sql/functions.ts
+++ b/packages/pg-meta/src/sql/functions.ts
@@ -89,7 +89,7 @@ from
           oid,
           unnest(arg_modes) as mode,
           unnest(arg_names) as name,
-          unnest(arg_types) as type_id,
+          unnest(arg_types)::int8 as type_id,
           unnest(arg_has_defaults) as has_default
         from
           functions

--- a/packages/pg-meta/src/sql/functions.ts
+++ b/packages/pg-meta/src/sql/functions.ts
@@ -89,7 +89,7 @@ from
           oid,
           unnest(arg_modes) as mode,
           unnest(arg_names) as name,
-          unnest(arg_types)::int8 as type_id,
+          unnest(arg_types) as type_id,
           unnest(arg_has_defaults) as has_default
         from
           functions

--- a/packages/pg-meta/src/sql/functions.ts
+++ b/packages/pg-meta/src/sql/functions.ts
@@ -80,7 +80,8 @@ from
         'mode', t2.mode,
         'name', name,
         'type_id', type_id,
-        'has_default', has_default
+        -- Cast null into false boolean
+        'has_default', COALESCE(has_default, false)
       )) as args
     from
       (
@@ -88,7 +89,7 @@ from
           oid,
           unnest(arg_modes) as mode,
           unnest(arg_names) as name,
-          unnest(arg_types) as type_id,
+          unnest(arg_types)::int8 as type_id,
           unnest(arg_has_defaults) as has_default
         from
           functions

--- a/packages/pg-meta/test/db/00-init.sql
+++ b/packages/pg-meta/test/db/00-init.sql
@@ -1,4 +1,5 @@
-
+-- We apply our test seedings to template1 so every new created db will have the same structure
+\c template1
 
 -- Tables for testing
 

--- a/packages/pg-meta/test/db/01-memes.sql
+++ b/packages/pg-meta/test/db/01-memes.sql
@@ -1,4 +1,5 @@
-
+-- We apply our test seedings to template1 so every new created db will have the same structure
+\c template1
 
 CREATE TABLE public.category (
 	id serial NOT NULL PRIMARY KEY,
@@ -2431,3 +2432,5 @@ INSERT INTO public.memes (name, category, created_at) VALUES
 ('Drinking Out of Cups', 4, NOW()),
 ('Sonic the Hedgehog (2020 Film)', 4, NOW()),
 ('Art Student Owl', 4, NOW());
+
+\c postgres

--- a/packages/pg-meta/test/db/utils.ts
+++ b/packages/pg-meta/test/db/utils.ts
@@ -1,97 +1,73 @@
-import postgres from 'postgres'
 import pg, { Pool } from 'pg'
 import { randomUUID } from 'crypto'
+import { parse as parseArray } from 'postgres-array'
 
-const numberCast = (x: any) => {
+// Those types override are in sync with `postgres-meta` since the queries
+// will get executed via `execQuery` on a pg connection with the same configuration
+// see: https://github.com/supabase/postgres-meta/blob/ca06061b4708971628134f95e49f254c2dfdfa7d/src/lib/db.ts#L6-L23
+pg.types.setTypeParser(pg.types.builtins.INT8, (x) => {
   const asNumber = Number(x)
   if (Number.isSafeInteger(asNumber)) {
     return asNumber
   } else {
     return x
   }
-}
-
-pg.types.setTypeParser(pg.types.builtins.INT8, numberCast)
+})
 pg.types.setTypeParser(pg.types.builtins.DATE, (x) => x)
 pg.types.setTypeParser(pg.types.builtins.INTERVAL, (x) => x)
 pg.types.setTypeParser(pg.types.builtins.TIMESTAMP, (x) => x)
 pg.types.setTypeParser(pg.types.builtins.TIMESTAMPTZ, (x) => x)
+pg.types.setTypeParser(1115, parseArray) // _timestamp
+pg.types.setTypeParser(1182, parseArray) // _date
+pg.types.setTypeParser(1185, parseArray) // _timestamptz
 pg.types.setTypeParser(600, (x) => x) // point
 pg.types.setTypeParser(1017, (x) => x) // _point
 
 const ROOT_DB_URL = process.env.DATABASE_URL ?? 'postgresql://postgres:postgres@localhost:5432'
 const ROOT_DB_NAME = process.env.DATABASE_NAME ?? 'postgres'
 
-// Connection to the postgres server (not a specific database)
-const rootDb = postgres(`${ROOT_DB_URL}/${ROOT_DB_NAME}`)
+// Replace postgres.js root connection with pg connection
+const rootPool = new Pool({
+  connectionString: `${ROOT_DB_URL}/${ROOT_DB_NAME}`,
+  max: 1,
+})
 
-export type DbClient = 'postgres' | 'pg'
+export type DbClient = 'pg' // Remove 'postgres' option
 
-export async function createTestDatabase(client: DbClient = 'postgres') {
+export async function createTestDatabase(_client: DbClient = 'pg') {
+  // Update default
   const dbName = `test_${randomUUID().replace(/-/g, '_')}`
 
   try {
-    // Create a new database for this test
-    await rootDb.unsafe(`CREATE DATABASE ${dbName};`)
+    // Create database using pg instead of postgres.js
+    await rootPool.query(`CREATE DATABASE ${dbName};`)
 
-    if (client === 'postgres') {
-      // Create a new connection to the test database using postgres.js
-      const testDb = postgres(`${ROOT_DB_URL}/${dbName}`, {
-        max: 1,
-        idle_timeout: 20,
-        connect_timeout: 10,
-      })
+    // Remove postgres.js specific code branch and just keep the pg implementation
+    const pool = new Pool({
+      connectionString: `${ROOT_DB_URL}/${dbName}`,
+      max: 1,
+      idleTimeoutMillis: 20000,
+      connectionTimeoutMillis: 10000,
+    })
 
-      return {
-        dbName,
-        client: 'postgres' as const,
-        executeQuery: async <T = any>(query: string): Promise<T> => {
-          try {
-            const execResult = await testDb.unsafe(query)
-            const result = execResult.map((v) => v)
-            return result as T
-          } catch (error) {
-            if (error instanceof Error) {
-              throw new Error(`Failed to execute query: ${error.message}`)
-            }
-            throw error
+    return {
+      dbName,
+      client: 'pg' as const,
+      executeQuery: async <T = any>(query: string): Promise<T> => {
+        try {
+          const res = await pool.query(query)
+          return res.rows as T
+        } catch (error) {
+          if (error instanceof Error) {
+            throw new Error(`Failed to execute query: ${error.message}`)
           }
-        },
-        cleanup: async () => {
-          await testDb.end()
-          await rootDb.unsafe(`DROP DATABASE ${dbName};`)
-        },
-      }
-    } else {
-      // Create a new connection to the test database using node-postgres
-      const pool = new Pool({
-        connectionString: `${ROOT_DB_URL}/${dbName}`,
-        max: 1,
-        idleTimeoutMillis: 20000,
-        connectionTimeoutMillis: 10000,
-      })
-
-      return {
-        dbName,
-        client: 'pg' as const,
-        executeQuery: async <T = any>(query: string): Promise<T> => {
-          try {
-            console.log('query: ', query)
-            const res = await pool.query(query)
-            console.log('rows: ', res)
-            return res.rows as T
-          } catch (error) {
-            if (error instanceof Error) {
-              throw new Error(`Failed to execute query: ${error.message}`)
-            }
-            throw error
-          }
-        },
-        cleanup: async () => {
-          await pool.end()
-          await rootDb.unsafe(`DROP DATABASE ${dbName};`)
-        },
-      }
+          throw error
+        }
+      },
+      cleanup: async () => {
+        await pool.end()
+        await rootPool.query(`DROP DATABASE ${dbName};`)
+      },
     }
   } catch (error) {
     if (error instanceof Error) {
@@ -101,7 +77,7 @@ export async function createTestDatabase(client: DbClient = 'postgres') {
   }
 }
 
-// Cleanup the root connection when all tests are done
+// Update cleanup function to use pg pool
 export async function cleanupRoot() {
-  await rootDb.end()
+  await rootPool.end()
 }

--- a/packages/pg-meta/test/db/utils.ts
+++ b/packages/pg-meta/test/db/utils.ts
@@ -32,17 +32,12 @@ const rootPool = new Pool({
   max: 1,
 })
 
-export type DbClient = 'pg' // Remove 'postgres' option
-
-export async function createTestDatabase(_client: DbClient = 'pg') {
-  // Update default
+export async function createTestDatabase() {
   const dbName = `test_${randomUUID().replace(/-/g, '_')}`
 
   try {
-    // Create database using pg instead of postgres.js
     await rootPool.query(`CREATE DATABASE ${dbName};`)
 
-    // Remove postgres.js specific code branch and just keep the pg implementation
     const pool = new Pool({
       connectionString: `${ROOT_DB_URL}/${dbName}`,
       max: 1,

--- a/packages/pg-meta/test/db/utils.ts
+++ b/packages/pg-meta/test/db/utils.ts
@@ -25,7 +25,8 @@ export async function createTestDatabase() {
       dbName,
       executeQuery: async <T = any>(query: string): Promise<T> => {
         try {
-          const result = (await testDb.unsafe(query)).map((v) => v)
+          const execResult = await testDb.unsafe(query)
+          const result = execResult.map((v) => v)
           return result as T
         } catch (error) {
           if (error instanceof Error) {

--- a/packages/pg-meta/test/db/utils.ts
+++ b/packages/pg-meta/test/db/utils.ts
@@ -1,46 +1,97 @@
 import postgres from 'postgres'
+import pg, { Pool } from 'pg'
 import { randomUUID } from 'crypto'
+
+const numberCast = (x: any) => {
+  const asNumber = Number(x)
+  if (Number.isSafeInteger(asNumber)) {
+    return asNumber
+  } else {
+    return x
+  }
+}
+
+pg.types.setTypeParser(pg.types.builtins.INT8, numberCast)
+pg.types.setTypeParser(pg.types.builtins.DATE, (x) => x)
+pg.types.setTypeParser(pg.types.builtins.INTERVAL, (x) => x)
+pg.types.setTypeParser(pg.types.builtins.TIMESTAMP, (x) => x)
+pg.types.setTypeParser(pg.types.builtins.TIMESTAMPTZ, (x) => x)
+pg.types.setTypeParser(600, (x) => x) // point
+pg.types.setTypeParser(1017, (x) => x) // _point
 
 const ROOT_DB_URL = process.env.DATABASE_URL ?? 'postgresql://postgres:postgres@localhost:5432'
 const ROOT_DB_NAME = process.env.DATABASE_NAME ?? 'postgres'
+
 // Connection to the postgres server (not a specific database)
 const rootDb = postgres(`${ROOT_DB_URL}/${ROOT_DB_NAME}`)
 
-export async function createTestDatabase() {
+export type DbClient = 'postgres' | 'pg'
+
+export async function createTestDatabase(client: DbClient = 'postgres') {
   const dbName = `test_${randomUUID().replace(/-/g, '_')}`
 
   try {
     // Create a new database for this test
     await rootDb.unsafe(`CREATE DATABASE ${dbName};`)
 
-    // Create a new connection to the test database
-    const testDb = postgres(`${ROOT_DB_URL}/${dbName}`, {
-      max: 1,
-      idle_timeout: 20,
-      connect_timeout: 10,
-    })
+    if (client === 'postgres') {
+      // Create a new connection to the test database using postgres.js
+      const testDb = postgres(`${ROOT_DB_URL}/${dbName}`, {
+        max: 1,
+        idle_timeout: 20,
+        connect_timeout: 10,
+      })
 
-    // Return both the database name and the client
-    return {
-      dbName,
-      executeQuery: async <T = any>(query: string): Promise<T> => {
-        try {
-          const execResult = await testDb.unsafe(query)
-          const result = execResult.map((v) => v)
-          return result as T
-        } catch (error) {
-          if (error instanceof Error) {
-            throw new Error(`Failed to execute query: ${error.message}`)
+      return {
+        dbName,
+        client: 'postgres' as const,
+        executeQuery: async <T = any>(query: string): Promise<T> => {
+          try {
+            const execResult = await testDb.unsafe(query)
+            const result = execResult.map((v) => v)
+            return result as T
+          } catch (error) {
+            if (error instanceof Error) {
+              throw new Error(`Failed to execute query: ${error.message}`)
+            }
+            throw error
           }
-          throw error
-        }
-      },
-      cleanup: async () => {
-        // Close the test database connection
-        await testDb.end()
-        // Drop the test database
-        await rootDb.unsafe(`DROP DATABASE ${dbName};`)
-      },
+        },
+        cleanup: async () => {
+          await testDb.end()
+          await rootDb.unsafe(`DROP DATABASE ${dbName};`)
+        },
+      }
+    } else {
+      // Create a new connection to the test database using node-postgres
+      const pool = new Pool({
+        connectionString: `${ROOT_DB_URL}/${dbName}`,
+        max: 1,
+        idleTimeoutMillis: 20000,
+        connectionTimeoutMillis: 10000,
+      })
+
+      return {
+        dbName,
+        client: 'pg' as const,
+        executeQuery: async <T = any>(query: string): Promise<T> => {
+          try {
+            console.log('query: ', query)
+            const res = await pool.query(query)
+            console.log('rows: ', res)
+            return res.rows as T
+          } catch (error) {
+            if (error instanceof Error) {
+              throw new Error(`Failed to execute query: ${error.message}`)
+            }
+            throw error
+          }
+        },
+        cleanup: async () => {
+          await pool.end()
+          await rootDb.unsafe(`DROP DATABASE ${dbName};`)
+        },
+      }
     }
   } catch (error) {
     if (error instanceof Error) {

--- a/packages/pg-meta/test/functions.test.ts
+++ b/packages/pg-meta/test/functions.test.ts
@@ -1,0 +1,305 @@
+import { expect, test, beforeAll, afterAll } from 'vitest'
+import pgMeta from '../src/index'
+import { createTestDatabase, cleanupRoot } from './db/utils'
+
+beforeAll(async () => {
+  // Any global setup if needed
+})
+
+afterAll(async () => {
+  await cleanupRoot()
+})
+
+const withTestDatabase = (
+  name: string,
+  fn: (db: Awaited<ReturnType<typeof createTestDatabase>>) => Promise<void>
+) => {
+  test(name, async () => {
+    const db = await createTestDatabase()
+    try {
+      await fn(db)
+    } finally {
+      await db.cleanup()
+    }
+  })
+}
+
+withTestDatabase('list functions', async ({ executeQuery }) => {
+  const { sql, zod } = await pgMeta.functions.list()
+  const res = zod.parse(await executeQuery(sql))
+
+  // Test for the 'add' function created in init.sql
+  const addFunction = res.find(({ name }) => name === 'add')
+  expect(addFunction).toMatchInlineSnapshot(
+    { id: expect.any(Number) },
+    `
+    {
+      "args": [
+        {
+          "has_default": false,
+          "mode": "in",
+          "name": "",
+          "type_id": 23,
+        },
+        {
+          "has_default": false,
+          "mode": "in",
+          "name": "",
+          "type_id": 23,
+        },
+      ],
+      "argument_types": "integer, integer",
+      "behavior": "IMMUTABLE",
+      "complete_statement": "CREATE OR REPLACE FUNCTION public.add(integer, integer)
+     RETURNS integer
+     LANGUAGE sql
+     IMMUTABLE STRICT
+    AS $function$select $1 + $2;$function$
+    ",
+      "config_params": null,
+      "definition": "select $1 + $2;",
+      "id": Any<Number>,
+      "identity_argument_types": "integer, integer",
+      "is_set_returning_function": false,
+      "language": "sql",
+      "name": "add",
+      "return_type": "integer",
+      "return_type_id": 23,
+      "return_type_relation_id": null,
+      "schema": "public",
+      "security_definer": false,
+    }
+    `
+  )
+})
+
+withTestDatabase('list functions with included schemas', async ({ executeQuery }) => {
+  const { sql, zod } = await pgMeta.functions.list({
+    includedSchemas: ['public'],
+  })
+  const res = zod.parse(await executeQuery(sql))
+
+  expect(res.length).toBeGreaterThan(0)
+  res.forEach((func) => {
+    expect(func.schema).toBe('public')
+  })
+})
+
+withTestDatabase('list functions with excluded schemas', async ({ executeQuery }) => {
+  const { sql, zod } = await pgMeta.functions.list({
+    excludedSchemas: ['public'],
+  })
+  const res = zod.parse(await executeQuery(sql))
+
+  res.forEach((func) => {
+    expect(func.schema).not.toBe('public')
+  })
+})
+
+withTestDatabase(
+  'list functions with excluded schemas and include System Schemas',
+  async ({ executeQuery }) => {
+    const { sql, zod } = await pgMeta.functions.list({
+      excludedSchemas: ['public'],
+      includeSystemSchemas: true,
+    })
+    const res = zod.parse(await executeQuery(sql))
+
+    expect(res.length).toBeGreaterThan(0)
+    res.forEach((func) => {
+      expect(func.schema).not.toBe('public')
+    })
+  }
+)
+
+withTestDatabase('retrieve, create, update, delete', async ({ executeQuery }) => {
+  // Create function
+  const { sql: createSql } = await pgMeta.functions.create({
+    name: 'test_func',
+    schema: 'public',
+    args: ['a int2', 'b int2'],
+    definition: 'select a + b',
+    return_type: 'integer',
+    language: 'sql',
+    behavior: 'STABLE',
+    security_definer: true,
+    config_params: { search_path: 'hooks, auth', role: 'postgres' },
+  })
+  await executeQuery(createSql)
+
+  // // Retrieve function
+  const { sql: retrieveSql, zod: retrieveZod } = await pgMeta.functions.retrieve({
+    name: 'test_func',
+    schema: 'public',
+    args: ['a int2', 'b int2'],
+  })
+  const retrieve = await executeQuery(retrieveSql)
+  const res = retrieveZod.parse(retrieve[0])
+  const functionId = res!.id
+  expect({ data: res, error: null }).toMatchInlineSnapshot(
+    { data: { id: expect.any(Number) } },
+    `
+    {
+      "data": {
+        "args": [
+          {
+            "has_default": false,
+            "mode": "in",
+            "name": "a",
+            "type_id": 21,
+          },
+          {
+            "has_default": false,
+            "mode": "in",
+            "name": "b",
+            "type_id": 21,
+          },
+        ],
+        "argument_types": "a smallint, b smallint",
+        "behavior": "STABLE",
+        "complete_statement": "CREATE OR REPLACE FUNCTION public.test_func(a smallint, b smallint)
+     RETURNS integer
+     LANGUAGE sql
+     STABLE SECURITY DEFINER
+     SET search_path TO 'hooks', 'auth'
+     SET role TO 'postgres'
+    AS $function$select a + b$function$
+    ",
+        "config_params": {
+          "role": "postgres",
+          "search_path": "hooks, auth",
+        },
+        "definition": "select a + b",
+        "id": Any<Number>,
+        "identity_argument_types": "a smallint, b smallint",
+        "is_set_returning_function": false,
+        "language": "sql",
+        "name": "test_func",
+        "return_type": "integer",
+        "return_type_id": 23,
+        "return_type_relation_id": null,
+        "schema": "public",
+        "security_definer": true,
+      },
+      "error": null,
+    }
+  `
+  )
+  // create test_schema to move the function into:
+  const { sql: createSchemaSql } = await pgMeta.schemas.create({ name: 'test_schema' })
+  await executeQuery(createSchemaSql)
+  const { sql: updateSql } = await pgMeta.functions.update(res!, {
+    name: 'test_func_renamed',
+    schema: 'test_schema',
+    definition: 'select b - a',
+  })
+  await executeQuery(updateSql)
+
+  const { sql: retrieveRenamedSql } = await pgMeta.functions.retrieve({ id: functionId })
+  const retrieveRenamed = await executeQuery(retrieveRenamedSql)
+  const resUpdated = retrieveZod.parse(retrieveRenamed[0])
+  expect({ data: resUpdated, error: null }).toMatchInlineSnapshot(
+    { data: { id: expect.any(Number) } },
+    `
+    {
+      "data": {
+        "args": [
+          {
+            "has_default": false,
+            "mode": "in",
+            "name": "a",
+            "type_id": 21,
+          },
+          {
+            "has_default": false,
+            "mode": "in",
+            "name": "b",
+            "type_id": 21,
+          },
+        ],
+        "argument_types": "a smallint, b smallint",
+        "behavior": "STABLE",
+        "complete_statement": "CREATE OR REPLACE FUNCTION test_schema.test_func_renamed(a smallint, b smallint)
+     RETURNS integer
+     LANGUAGE sql
+     STABLE SECURITY DEFINER
+     SET role TO 'postgres'
+     SET search_path TO 'hooks', 'auth'
+    AS $function$select b - a$function$
+    ",
+        "config_params": {
+          "role": "postgres",
+          "search_path": "hooks, auth",
+        },
+        "definition": "select b - a",
+        "id": Any<Number>,
+        "identity_argument_types": "a smallint, b smallint",
+        "is_set_returning_function": false,
+        "language": "sql",
+        "name": "test_func_renamed",
+        "return_type": "integer",
+        "return_type_id": 23,
+        "return_type_relation_id": null,
+        "schema": "test_schema",
+        "security_definer": true,
+      },
+      "error": null,
+    }
+  `
+  )
+
+  // Remove function
+  const { sql: removeSql } = await pgMeta.functions.remove(resUpdated!)
+  await executeQuery(removeSql)
+  // Verify function is removed
+  const { sql: verifyRemoveSql } = await pgMeta.functions.retrieve({ id: functionId })
+  const result = await executeQuery(verifyRemoveSql)
+  expect(result).toHaveLength(0)
+})
+
+withTestDatabase('retrieve set-returning function', async ({ executeQuery }) => {
+  // Retrieve function
+  const { sql: retrieveSql, zod: retrieveZod } = await pgMeta.functions.retrieve({
+    schema: 'public',
+    name: 'function_returning_set_of_rows',
+    args: [],
+  })
+  const retrieve = await executeQuery(retrieveSql)
+  const res = retrieveZod.parse(retrieve[0])
+  expect(res).toMatchInlineSnapshot(
+    {
+      id: expect.any(Number),
+      return_type_id: expect.any(Number),
+      return_type_relation_id: expect.any(Number),
+    },
+    `
+    {
+      "args": [],
+      "argument_types": "",
+      "behavior": "STABLE",
+      "complete_statement": "CREATE OR REPLACE FUNCTION public.function_returning_set_of_rows()
+     RETURNS SETOF users
+     LANGUAGE sql
+     STABLE
+    AS $function$
+      select * from public.users;
+    $function$
+    ",
+      "config_params": null,
+      "definition": "
+      select * from public.users;
+    ",
+      "id": Any<Number>,
+      "identity_argument_types": "",
+      "is_set_returning_function": true,
+      "language": "sql",
+      "name": "function_returning_set_of_rows",
+      "return_type": "SETOF users",
+      "return_type_id": Any<Number>,
+      "return_type_relation_id": Any<Number>,
+      "schema": "public",
+      "security_definer": false,
+    }
+  `
+  )
+})

--- a/packages/pg-meta/test/functions.test.ts
+++ b/packages/pg-meta/test/functions.test.ts
@@ -1,6 +1,6 @@
-import { expect, test, beforeAll, afterAll } from 'vitest'
+import { expect, test, beforeAll, afterAll, describe } from 'vitest'
 import pgMeta from '../src/index'
-import { createTestDatabase, cleanupRoot } from './db/utils'
+import { createTestDatabase, cleanupRoot, DbClient } from './db/utils'
 
 beforeAll(async () => {
   // Any global setup if needed
@@ -10,16 +10,24 @@ afterAll(async () => {
   await cleanupRoot()
 })
 
+// TODO: implement dynamic testing for both pg and postgres
+// will require to opt-out of InlineSnapshot syntax
+const clients: DbClient[] = ['pg']
+
 const withTestDatabase = (
   name: string,
   fn: (db: Awaited<ReturnType<typeof createTestDatabase>>) => Promise<void>
 ) => {
-  test(name, async () => {
-    const db = await createTestDatabase()
-    try {
-      await fn(db)
-    } finally {
-      await db.cleanup()
+  describe(name, () => {
+    for (const client of clients) {
+      test(`with ${client} - ${name}`, async () => {
+        const db = await createTestDatabase(client)
+        try {
+          await fn(db)
+        } finally {
+          await db.cleanup()
+        }
+      })
     }
   })
 }
@@ -73,269 +81,249 @@ withTestDatabase('list functions', async ({ executeQuery }) => {
   )
 })
 
-withTestDatabase('list functions with included schemas', async ({ executeQuery }) => {
-  const { sql, zod } = await pgMeta.functions.list({
-    includedSchemas: ['public'],
-  })
-  const res = zod.parse(await executeQuery(sql))
+// withTestDatabase('list functions with included schemas', async ({ executeQuery }) => {
+//   const { sql, zod } = await pgMeta.functions.list({
+//     includedSchemas: ['public'],
+//   })
+//   const res = zod.parse(await executeQuery(sql))
 
-  expect(res.length).toBeGreaterThan(0)
-  res.forEach((func) => {
-    expect(func.schema).toBe('public')
-  })
-})
+//   expect(res.length).toBeGreaterThan(0)
+//   res.forEach((func) => {
+//     expect(func.schema).toBe('public')
+//   })
+// })
 
-withTestDatabase('list functions with excluded schemas', async ({ executeQuery }) => {
-  const { sql, zod } = await pgMeta.functions.list({
-    excludedSchemas: ['public'],
-  })
-  const res = zod.parse(await executeQuery(sql))
+// withTestDatabase('list functions with excluded schemas', async ({ executeQuery }) => {
+//   const { sql, zod } = await pgMeta.functions.list({
+//     excludedSchemas: ['public'],
+//   })
+//   const res = zod.parse(await executeQuery(sql))
 
-  res.forEach((func) => {
-    expect(func.schema).not.toBe('public')
-  })
-})
+//   res.forEach((func) => {
+//     expect(func.schema).not.toBe('public')
+//   })
+// })
 
-withTestDatabase(
-  'list functions with excluded schemas and include System Schemas',
-  async ({ executeQuery }) => {
-    const { sql, zod } = await pgMeta.functions.list({
-      excludedSchemas: ['public'],
-      includeSystemSchemas: true,
-    })
-    const res = zod.parse(await executeQuery(sql))
+// withTestDatabase(
+//   'list functions with excluded schemas and include System Schemas',
+//   async ({ executeQuery }) => {
+//     const { sql, zod } = await pgMeta.functions.list({
+//       excludedSchemas: ['public'],
+//       includeSystemSchemas: true,
+//     })
+//     const res = zod.parse(await executeQuery(sql))
 
-    expect(res.length).toBeGreaterThan(0)
-    res.forEach((func) => {
-      expect(func.schema).not.toBe('public')
-    })
-  }
-)
+//     expect(res.length).toBeGreaterThan(0)
+//     res.forEach((func) => {
+//       expect(func.schema).not.toBe('public')
+//     })
+//   }
+// )
 
-withTestDatabase('retrieve, create, update, delete', async ({ executeQuery }) => {
-  // Create function
-  const { sql: createSql } = await pgMeta.functions.create({
-    name: 'test_func',
-    schema: 'public',
-    args: ['a int2', 'b int2'],
-    definition: 'select a + b',
-    return_type: 'integer',
-    language: 'sql',
-    behavior: 'STABLE',
-    security_definer: true,
-    config_params: { search_path: 'hooks, auth', role: 'postgres' },
-  })
-  await executeQuery(createSql)
+// withTestDatabase('retrieve, create, update, delete', async ({ executeQuery }) => {
+//   // Create function
+//   const { sql: createSql } = await pgMeta.functions.create({
+//     name: 'test_func',
+//     schema: 'public',
+//     args: ['a int2', 'b int2'],
+//     definition: 'select a + b',
+//     return_type: 'integer',
+//     language: 'sql',
+//     behavior: 'STABLE',
+//     security_definer: true,
+//     config_params: { search_path: 'hooks, auth', role: 'postgres' },
+//   })
+//   await executeQuery(createSql)
 
-  // // Retrieve function
-  const { sql: retrieveSql, zod: retrieveZod } = await pgMeta.functions.retrieve({
-    name: 'test_func',
-    schema: 'public',
-    args: ['a int2', 'b int2'],
-  })
-  const retrieve = await executeQuery(retrieveSql)
-  const res = retrieveZod.parse(retrieve[0])
-  const functionId = res!.id
-  expect({ data: res, error: null }).toMatchInlineSnapshot(
-    { data: { id: expect.any(Number) } },
-    `
-    {
-      "data": {
-        "args": [
-          {
-            "has_default": false,
-            "mode": "in",
-            "name": "a",
-            "type_id": 21,
-          },
-          {
-            "has_default": false,
-            "mode": "in",
-            "name": "b",
-            "type_id": 21,
-          },
-        ],
-        "argument_types": "a smallint, b smallint",
-        "behavior": "STABLE",
-        "complete_statement": "CREATE OR REPLACE FUNCTION public.test_func(a smallint, b smallint)
-     RETURNS integer
-     LANGUAGE sql
-     STABLE SECURITY DEFINER
-     SET search_path TO 'hooks', 'auth'
-     SET role TO 'postgres'
-    AS $function$select a + b$function$
-    ",
-        "config_params": {
-          "role": "postgres",
-          "search_path": "hooks, auth",
-        },
-        "definition": "select a + b",
-        "id": Any<Number>,
-        "identity_argument_types": "a smallint, b smallint",
-        "is_set_returning_function": false,
-        "language": "sql",
-        "name": "test_func",
-        "return_type": "integer",
-        "return_type_id": 23,
-        "return_type_relation_id": null,
-        "schema": "public",
-        "security_definer": true,
-      },
-      "error": null,
-    }
-  `
-  )
-  // create test_schema to move the function into:
-  const { sql: createSchemaSql } = await pgMeta.schemas.create({ name: 'test_schema' })
-  await executeQuery(createSchemaSql)
-  const { sql: updateSql } = await pgMeta.functions.update(res!, {
-    name: 'test_func_renamed',
-    schema: 'test_schema',
-    definition: 'select b - a',
-  })
-  await executeQuery(updateSql)
+//   // // Retrieve function
+//   const { sql: retrieveSql, zod: retrieveZod } = await pgMeta.functions.retrieve({
+//     name: 'test_func',
+//     schema: 'public',
+//     args: ['a int2', 'b int2'],
+//   })
+//   const retrieve = await executeQuery(retrieveSql)
+//   const res = retrieveZod.parse(retrieve[0])
+//   const functionId = res!.id
+//   expect(res).toMatchObject({
+//     args: [
+//       {
+//         has_default: false,
+//         mode: 'in',
+//         name: 'a',
+//         type_id: 21,
+//       },
+//       {
+//         has_default: false,
+//         mode: 'in',
+//         name: 'b',
+//         type_id: 21,
+//       },
+//     ],
+//     argument_types: 'a smallint, b smallint',
+//     behavior: 'STABLE',
+//     complete_statement: expect.stringMatching(
+//       /CREATE OR REPLACE FUNCTION public\.test_func\(a smallint, b smallint\)\s+RETURNS integer\s+LANGUAGE sql\s+STABLE SECURITY DEFINER\s+SET search_path TO 'hooks', 'auth'\s+SET role TO 'postgres'\s+AS \$function\$select a \+ b\$function\$/
+//     ),
+//     config_params: {
+//       role: 'postgres',
+//       search_path: 'hooks, auth',
+//     },
+//     definition: 'select a + b',
+//     id: expect.any(Number),
+//     identity_argument_types: 'a smallint, b smallint',
+//     is_set_returning_function: false,
+//     language: 'sql',
+//     name: 'test_func',
+//     return_type: 'integer',
+//     return_type_id: 23,
+//     return_type_relation_id: null,
+//     schema: 'public',
+//     security_definer: true,
+//   })
+//   // create test_schema to move the function into:
+//   const { sql: createSchemaSql } = await pgMeta.schemas.create({ name: 'test_schema' })
+//   await executeQuery(createSchemaSql)
+//   const { sql: updateSql } = await pgMeta.functions.update(res!, {
+//     name: 'test_func_renamed',
+//     schema: 'test_schema',
+//     definition: 'select b - a',
+//   })
+//   await executeQuery(updateSql)
 
-  const { sql: retrieveRenamedSql } = await pgMeta.functions.retrieve({ id: functionId })
-  const retrieveRenamed = await executeQuery(retrieveRenamedSql)
-  const resUpdated = retrieveZod.parse(retrieveRenamed[0])
-  expect({ data: resUpdated, error: null }).toMatchInlineSnapshot(
-    { data: { id: expect.any(Number) } },
-    `
-    {
-      "data": {
-        "args": [
-          {
-            "has_default": false,
-            "mode": "in",
-            "name": "a",
-            "type_id": 21,
-          },
-          {
-            "has_default": false,
-            "mode": "in",
-            "name": "b",
-            "type_id": 21,
-          },
-        ],
-        "argument_types": "a smallint, b smallint",
-        "behavior": "STABLE",
-        "complete_statement": "CREATE OR REPLACE FUNCTION test_schema.test_func_renamed(a smallint, b smallint)
-     RETURNS integer
-     LANGUAGE sql
-     STABLE SECURITY DEFINER
-     SET role TO 'postgres'
-     SET search_path TO 'hooks', 'auth'
-    AS $function$select b - a$function$
-    ",
-        "config_params": {
-          "role": "postgres",
-          "search_path": "hooks, auth",
-        },
-        "definition": "select b - a",
-        "id": Any<Number>,
-        "identity_argument_types": "a smallint, b smallint",
-        "is_set_returning_function": false,
-        "language": "sql",
-        "name": "test_func_renamed",
-        "return_type": "integer",
-        "return_type_id": 23,
-        "return_type_relation_id": null,
-        "schema": "test_schema",
-        "security_definer": true,
-      },
-      "error": null,
-    }
-  `
-  )
+//   const { sql: retrieveRenamedSql } = await pgMeta.functions.retrieve({ id: functionId })
+//   const retrieveRenamed = await executeQuery(retrieveRenamedSql)
+//   const resUpdated = retrieveZod.parse(retrieveRenamed[0])
+//   expect({ data: resUpdated, error: null }).toMatchInlineSnapshot(
+//     { data: { id: expect.any(Number) } },
+//     `
+//     {
+//       "data": {
+//         "args": [
+//           {
+//             "has_default": false,
+//             "mode": "in",
+//             "name": "a",
+//             "type_id": 21,
+//           },
+//           {
+//             "has_default": false,
+//             "mode": "in",
+//             "name": "b",
+//             "type_id": 21,
+//           },
+//         ],
+//         "argument_types": "a smallint, b smallint",
+//         "behavior": "STABLE",
+//         "complete_statement": "CREATE OR REPLACE FUNCTION test_schema.test_func_renamed(a smallint, b smallint)
+//      RETURNS integer
+//      LANGUAGE sql
+//      STABLE SECURITY DEFINER
+//      SET role TO 'postgres'
+//      SET search_path TO 'hooks', 'auth'
+//     AS $function$select b - a$function$
+//     ",
+//         "config_params": {
+//           "role": "postgres",
+//           "search_path": "hooks, auth",
+//         },
+//         "definition": "select b - a",
+//         "id": Any<Number>,
+//         "identity_argument_types": "a smallint, b smallint",
+//         "is_set_returning_function": false,
+//         "language": "sql",
+//         "name": "test_func_renamed",
+//         "return_type": "integer",
+//         "return_type_id": 23,
+//         "return_type_relation_id": null,
+//         "schema": "test_schema",
+//         "security_definer": true,
+//       },
+//       "error": null,
+//     }
+//   `
+//   )
 
-  // Remove function
-  const { sql: removeSql } = await pgMeta.functions.remove(resUpdated!)
-  await executeQuery(removeSql)
-  // Verify function is removed
-  const { sql: verifyRemoveSql } = await pgMeta.functions.retrieve({ id: functionId })
-  const result = await executeQuery(verifyRemoveSql)
-  expect(result).toHaveLength(0)
-})
+//   // Remove function
+//   const { sql: removeSql } = await pgMeta.functions.remove(resUpdated!)
+//   await executeQuery(removeSql)
+//   // Verify function is removed
+//   const { sql: verifyRemoveSql } = await pgMeta.functions.retrieve({ id: functionId })
+//   const result = await executeQuery(verifyRemoveSql)
+//   expect(result).toHaveLength(0)
+// })
 
-withTestDatabase('retrieve set-returning function', async ({ executeQuery }) => {
-  // Retrieve function
-  const { sql: retrieveSql, zod: retrieveZod } = await pgMeta.functions.retrieve({
-    schema: 'public',
-    name: 'function_returning_set_of_rows',
-    args: [],
-  })
-  const retrieve = await executeQuery(retrieveSql)
-  const res = retrieveZod.parse(retrieve[0])
-  expect(res).toMatchInlineSnapshot(
-    {
-      id: expect.any(Number),
-      return_type_id: expect.any(Number),
-      return_type_relation_id: expect.any(Number),
-    },
-    `
-    {
-      "args": [],
-      "argument_types": "",
-      "behavior": "STABLE",
-      "complete_statement": "CREATE OR REPLACE FUNCTION public.function_returning_set_of_rows()
-     RETURNS SETOF users
-     LANGUAGE sql
-     STABLE
-    AS $function$
-      select * from public.users;
-    $function$
-    ",
-      "config_params": null,
-      "definition": "
-      select * from public.users;
-    ",
-      "id": Any<Number>,
-      "identity_argument_types": "",
-      "is_set_returning_function": true,
-      "language": "sql",
-      "name": "function_returning_set_of_rows",
-      "return_type": "SETOF users",
-      "return_type_id": Any<Number>,
-      "return_type_relation_id": Any<Number>,
-      "schema": "public",
-      "security_definer": false,
-    }
-  `
-  )
-})
+// withTestDatabase('retrieve set-returning function', async ({ executeQuery }) => {
+//   // Retrieve function
+//   const { sql: retrieveSql, zod: retrieveZod } = await pgMeta.functions.retrieve({
+//     schema: 'public',
+//     name: 'function_returning_set_of_rows',
+//     args: [],
+//   })
+//   const retrieve = await executeQuery(retrieveSql)
+//   const res = retrieveZod.parse(retrieve[0])
+//   expect(res).toMatchObject({
+//     args: [],
+//     argument_types: '',
+//     behavior: 'STABLE',
+//     complete_statement: `CREATE OR REPLACE FUNCTION public.function_returning_set_of_rows()
+//  RETURNS SETOF users
+//  LANGUAGE sql
+//  STABLE
+// AS $function$
+//   select * from public.users;
+// $function$
+// `,
+//     config_params: null,
+//     definition: `
+//   select * from public.users;
+// `,
+//     id: expect.any(Number),
+//     identity_argument_types: '',
+//     is_set_returning_function: true,
+//     language: 'sql',
+//     name: 'function_returning_set_of_rows',
+//     return_type: 'SETOF users',
+//     return_type_id: expect.any(Number),
+//     return_type_relation_id: expect.any(Number),
+//     schema: 'public',
+//     security_definer: false,
+//   })
+// })
 
-withTestDatabase('create function with various config_params values', async ({ executeQuery }) => {
-  // Test empty string value
-  const { sql: createSql1 } = await pgMeta.functions.create({
-    name: 'test_func_config_1',
-    schema: 'public',
-    definition: 'select 1',
-    return_type: 'integer',
-    language: 'sql',
-    config_params: {
-      search_path: '""', // Should become ''
-      application_name: 'FROM CURRENT', // Special syntax: SET param FROM CURRENT
-      work_mem: "'8MB'", // Regular syntax: SET param TO value
-    },
-  })
-  await executeQuery(createSql1)
+// withTestDatabase('create function with various config_params values', async ({ executeQuery }) => {
+//   // Set initial application_name for consistent testing
+//   await executeQuery("SET application_name = 'current-app-name'")
 
-  // Verify the function was created correctly
-  const { sql: retrieveSql1, zod: retrieveZod } = await pgMeta.functions.retrieve({
-    name: 'test_func_config_1',
-    schema: 'public',
-    args: [],
-  })
-  const result1 = retrieveZod.parse((await executeQuery(retrieveSql1))[0])
+//   const { sql: createSql1 } = await pgMeta.functions.create({
+//     name: 'test_func_config_1',
+//     schema: 'public',
+//     definition: 'select 1',
+//     return_type: 'integer',
+//     language: 'sql',
+//     config_params: {
+//       search_path: '""', // Should become ''
+//       application_name: 'FROM CURRENT', // Special syntax: SET param FROM CURRENT
+//       work_mem: "'8MB'", // Regular syntax: SET param TO value
+//     },
+//   })
+//   await executeQuery(createSql1)
 
-  expect(result1).toBeDefined()
-  expect(result1!.config_params).toEqual({
-    search_path: '""',
-    application_name: 'postgres.js',
-    work_mem: '8MB',
-  })
+//   // Verify the function was created correctly
+//   const { sql: retrieveSql1, zod: retrieveZod } = await pgMeta.functions.retrieve({
+//     name: 'test_func_config_1',
+//     schema: 'public',
+//     args: [],
+//   })
+//   const result1 = retrieveZod.parse((await executeQuery(retrieveSql1))[0])
 
-  // Clean up
-  const { sql: removeSql1 } = await pgMeta.functions.remove(result1!)
-  await executeQuery(removeSql1)
-})
+//   expect(result1).toBeDefined()
+//   expect(result1!.config_params).toEqual({
+//     search_path: '""',
+//     application_name: 'current-app-name',
+//     work_mem: '8MB',
+//   })
+
+//   // Clean up
+//   const { sql: removeSql1 } = await pgMeta.functions.remove(result1!)
+//   await executeQuery(removeSql1)
+// })

--- a/packages/pg-meta/test/functions.test.ts
+++ b/packages/pg-meta/test/functions.test.ts
@@ -136,42 +136,55 @@ withTestDatabase('retrieve, create, update, delete', async ({ executeQuery }) =>
   const retrieve = await executeQuery(retrieveSql)
   const res = retrieveZod.parse(retrieve[0])
   const functionId = res!.id
-  expect(res).toMatchObject({
-    args: [
-      {
-        has_default: false,
-        mode: 'in',
-        name: 'a',
-        type_id: 21,
+  expect({ data: res, error: null }).toMatchInlineSnapshot(
+    { data: { id: expect.any(Number) } },
+    `
+    {
+      "data": {
+        "args": [
+          {
+            "has_default": false,
+            "mode": "in",
+            "name": "a",
+            "type_id": 21,
+          },
+          {
+            "has_default": false,
+            "mode": "in",
+            "name": "b",
+            "type_id": 21,
+          },
+        ],
+        "argument_types": "a smallint, b smallint",
+        "behavior": "STABLE",
+        "complete_statement": "CREATE OR REPLACE FUNCTION public.test_func(a smallint, b smallint)
+     RETURNS integer
+     LANGUAGE sql
+     STABLE SECURITY DEFINER
+     SET search_path TO 'hooks', 'auth'
+     SET role TO 'postgres'
+    AS $function$select a + b$function$
+    ",
+        "config_params": {
+          "role": "postgres",
+          "search_path": "hooks, auth",
+        },
+        "definition": "select a + b",
+        "id": Any<Number>,
+        "identity_argument_types": "a smallint, b smallint",
+        "is_set_returning_function": false,
+        "language": "sql",
+        "name": "test_func",
+        "return_type": "integer",
+        "return_type_id": 23,
+        "return_type_relation_id": null,
+        "schema": "public",
+        "security_definer": true,
       },
-      {
-        has_default: false,
-        mode: 'in',
-        name: 'b',
-        type_id: 21,
-      },
-    ],
-    argument_types: 'a smallint, b smallint',
-    behavior: 'STABLE',
-    complete_statement: expect.stringMatching(
-      /CREATE OR REPLACE FUNCTION public\.test_func\(a smallint, b smallint\)\s+RETURNS integer\s+LANGUAGE sql\s+STABLE SECURITY DEFINER\s+SET search_path TO 'hooks', 'auth'\s+SET role TO 'postgres'\s+AS \$function\$select a \+ b\$function\$/
-    ),
-    config_params: {
-      role: 'postgres',
-      search_path: 'hooks, auth',
-    },
-    definition: 'select a + b',
-    id: expect.any(Number),
-    identity_argument_types: 'a smallint, b smallint',
-    is_set_returning_function: false,
-    language: 'sql',
-    name: 'test_func',
-    return_type: 'integer',
-    return_type_id: 23,
-    return_type_relation_id: null,
-    schema: 'public',
-    security_definer: true,
-  })
+      "error": null,
+    }
+  `
+  )
   // create test_schema to move the function into:
   const { sql: createSchemaSql } = await pgMeta.schemas.create({ name: 'test_schema' })
   await executeQuery(createSchemaSql)
@@ -253,33 +266,42 @@ withTestDatabase('retrieve set-returning function', async ({ executeQuery }) => 
   })
   const retrieve = await executeQuery(retrieveSql)
   const res = retrieveZod.parse(retrieve[0])
-  expect(res).toMatchObject({
-    args: [],
-    argument_types: '',
-    behavior: 'STABLE',
-    complete_statement: `CREATE OR REPLACE FUNCTION public.function_returning_set_of_rows()
- RETURNS SETOF users
- LANGUAGE sql
- STABLE
-AS $function$
-  select * from public.users;
-$function$
-`,
-    config_params: null,
-    definition: `
-  select * from public.users;
-`,
-    id: expect.any(Number),
-    identity_argument_types: '',
-    is_set_returning_function: true,
-    language: 'sql',
-    name: 'function_returning_set_of_rows',
-    return_type: 'SETOF users',
-    return_type_id: expect.any(Number),
-    return_type_relation_id: expect.any(Number),
-    schema: 'public',
-    security_definer: false,
-  })
+  expect(res).toMatchInlineSnapshot(
+    {
+      id: expect.any(Number),
+      return_type_id: expect.any(Number),
+      return_type_relation_id: expect.any(Number),
+    },
+    `
+    {
+      "args": [],
+      "argument_types": "",
+      "behavior": "STABLE",
+      "complete_statement": "CREATE OR REPLACE FUNCTION public.function_returning_set_of_rows()
+     RETURNS SETOF users
+     LANGUAGE sql
+     STABLE
+    AS $function$
+      select * from public.users;
+    $function$
+    ",
+      "config_params": null,
+      "definition": "
+      select * from public.users;
+    ",
+      "id": Any<Number>,
+      "identity_argument_types": "",
+      "is_set_returning_function": true,
+      "language": "sql",
+      "name": "function_returning_set_of_rows",
+      "return_type": "SETOF users",
+      "return_type_id": Any<Number>,
+      "return_type_relation_id": Any<Number>,
+      "schema": "public",
+      "security_definer": false,
+    }
+  `
+  )
 })
 
 withTestDatabase('create function with various config_params values', async ({ executeQuery }) => {

--- a/packages/pg-meta/test/functions.test.ts
+++ b/packages/pg-meta/test/functions.test.ts
@@ -1,6 +1,6 @@
-import { expect, test, beforeAll, afterAll, describe } from 'vitest'
+import { expect, test, beforeAll, afterAll } from 'vitest'
 import pgMeta from '../src/index'
-import { createTestDatabase, cleanupRoot, DbClient } from './db/utils'
+import { createTestDatabase, cleanupRoot } from './db/utils'
 
 beforeAll(async () => {
   // Any global setup if needed
@@ -10,24 +10,16 @@ afterAll(async () => {
   await cleanupRoot()
 })
 
-// TODO: implement dynamic testing for both pg and postgres
-// will require to opt-out of InlineSnapshot syntax
-const clients: DbClient[] = ['pg']
-
 const withTestDatabase = (
   name: string,
   fn: (db: Awaited<ReturnType<typeof createTestDatabase>>) => Promise<void>
 ) => {
-  describe(name, () => {
-    for (const client of clients) {
-      test(`with ${client} - ${name}`, async () => {
-        const db = await createTestDatabase(client)
-        try {
-          await fn(db)
-        } finally {
-          await db.cleanup()
-        }
-      })
+  test(name, async () => {
+    const db = await createTestDatabase()
+    try {
+      await fn(db)
+    } finally {
+      await db.cleanup()
     }
   })
 }
@@ -81,249 +73,249 @@ withTestDatabase('list functions', async ({ executeQuery }) => {
   )
 })
 
-// withTestDatabase('list functions with included schemas', async ({ executeQuery }) => {
-//   const { sql, zod } = await pgMeta.functions.list({
-//     includedSchemas: ['public'],
-//   })
-//   const res = zod.parse(await executeQuery(sql))
+withTestDatabase('list functions with included schemas', async ({ executeQuery }) => {
+  const { sql, zod } = await pgMeta.functions.list({
+    includedSchemas: ['public'],
+  })
+  const res = zod.parse(await executeQuery(sql))
 
-//   expect(res.length).toBeGreaterThan(0)
-//   res.forEach((func) => {
-//     expect(func.schema).toBe('public')
-//   })
-// })
+  expect(res.length).toBeGreaterThan(0)
+  res.forEach((func) => {
+    expect(func.schema).toBe('public')
+  })
+})
 
-// withTestDatabase('list functions with excluded schemas', async ({ executeQuery }) => {
-//   const { sql, zod } = await pgMeta.functions.list({
-//     excludedSchemas: ['public'],
-//   })
-//   const res = zod.parse(await executeQuery(sql))
+withTestDatabase('list functions with excluded schemas', async ({ executeQuery }) => {
+  const { sql, zod } = await pgMeta.functions.list({
+    excludedSchemas: ['public'],
+  })
+  const res = zod.parse(await executeQuery(sql))
 
-//   res.forEach((func) => {
-//     expect(func.schema).not.toBe('public')
-//   })
-// })
+  res.forEach((func) => {
+    expect(func.schema).not.toBe('public')
+  })
+})
 
-// withTestDatabase(
-//   'list functions with excluded schemas and include System Schemas',
-//   async ({ executeQuery }) => {
-//     const { sql, zod } = await pgMeta.functions.list({
-//       excludedSchemas: ['public'],
-//       includeSystemSchemas: true,
-//     })
-//     const res = zod.parse(await executeQuery(sql))
+withTestDatabase(
+  'list functions with excluded schemas and include System Schemas',
+  async ({ executeQuery }) => {
+    const { sql, zod } = await pgMeta.functions.list({
+      excludedSchemas: ['public'],
+      includeSystemSchemas: true,
+    })
+    const res = zod.parse(await executeQuery(sql))
 
-//     expect(res.length).toBeGreaterThan(0)
-//     res.forEach((func) => {
-//       expect(func.schema).not.toBe('public')
-//     })
-//   }
-// )
+    expect(res.length).toBeGreaterThan(0)
+    res.forEach((func) => {
+      expect(func.schema).not.toBe('public')
+    })
+  }
+)
 
-// withTestDatabase('retrieve, create, update, delete', async ({ executeQuery }) => {
-//   // Create function
-//   const { sql: createSql } = await pgMeta.functions.create({
-//     name: 'test_func',
-//     schema: 'public',
-//     args: ['a int2', 'b int2'],
-//     definition: 'select a + b',
-//     return_type: 'integer',
-//     language: 'sql',
-//     behavior: 'STABLE',
-//     security_definer: true,
-//     config_params: { search_path: 'hooks, auth', role: 'postgres' },
-//   })
-//   await executeQuery(createSql)
+withTestDatabase('retrieve, create, update, delete', async ({ executeQuery }) => {
+  // Create function
+  const { sql: createSql } = await pgMeta.functions.create({
+    name: 'test_func',
+    schema: 'public',
+    args: ['a int2', 'b int2'],
+    definition: 'select a + b',
+    return_type: 'integer',
+    language: 'sql',
+    behavior: 'STABLE',
+    security_definer: true,
+    config_params: { search_path: 'hooks, auth', role: 'postgres' },
+  })
+  await executeQuery(createSql)
 
-//   // // Retrieve function
-//   const { sql: retrieveSql, zod: retrieveZod } = await pgMeta.functions.retrieve({
-//     name: 'test_func',
-//     schema: 'public',
-//     args: ['a int2', 'b int2'],
-//   })
-//   const retrieve = await executeQuery(retrieveSql)
-//   const res = retrieveZod.parse(retrieve[0])
-//   const functionId = res!.id
-//   expect(res).toMatchObject({
-//     args: [
-//       {
-//         has_default: false,
-//         mode: 'in',
-//         name: 'a',
-//         type_id: 21,
-//       },
-//       {
-//         has_default: false,
-//         mode: 'in',
-//         name: 'b',
-//         type_id: 21,
-//       },
-//     ],
-//     argument_types: 'a smallint, b smallint',
-//     behavior: 'STABLE',
-//     complete_statement: expect.stringMatching(
-//       /CREATE OR REPLACE FUNCTION public\.test_func\(a smallint, b smallint\)\s+RETURNS integer\s+LANGUAGE sql\s+STABLE SECURITY DEFINER\s+SET search_path TO 'hooks', 'auth'\s+SET role TO 'postgres'\s+AS \$function\$select a \+ b\$function\$/
-//     ),
-//     config_params: {
-//       role: 'postgres',
-//       search_path: 'hooks, auth',
-//     },
-//     definition: 'select a + b',
-//     id: expect.any(Number),
-//     identity_argument_types: 'a smallint, b smallint',
-//     is_set_returning_function: false,
-//     language: 'sql',
-//     name: 'test_func',
-//     return_type: 'integer',
-//     return_type_id: 23,
-//     return_type_relation_id: null,
-//     schema: 'public',
-//     security_definer: true,
-//   })
-//   // create test_schema to move the function into:
-//   const { sql: createSchemaSql } = await pgMeta.schemas.create({ name: 'test_schema' })
-//   await executeQuery(createSchemaSql)
-//   const { sql: updateSql } = await pgMeta.functions.update(res!, {
-//     name: 'test_func_renamed',
-//     schema: 'test_schema',
-//     definition: 'select b - a',
-//   })
-//   await executeQuery(updateSql)
+  // // Retrieve function
+  const { sql: retrieveSql, zod: retrieveZod } = await pgMeta.functions.retrieve({
+    name: 'test_func',
+    schema: 'public',
+    args: ['a int2', 'b int2'],
+  })
+  const retrieve = await executeQuery(retrieveSql)
+  const res = retrieveZod.parse(retrieve[0])
+  const functionId = res!.id
+  expect(res).toMatchObject({
+    args: [
+      {
+        has_default: false,
+        mode: 'in',
+        name: 'a',
+        type_id: 21,
+      },
+      {
+        has_default: false,
+        mode: 'in',
+        name: 'b',
+        type_id: 21,
+      },
+    ],
+    argument_types: 'a smallint, b smallint',
+    behavior: 'STABLE',
+    complete_statement: expect.stringMatching(
+      /CREATE OR REPLACE FUNCTION public\.test_func\(a smallint, b smallint\)\s+RETURNS integer\s+LANGUAGE sql\s+STABLE SECURITY DEFINER\s+SET search_path TO 'hooks', 'auth'\s+SET role TO 'postgres'\s+AS \$function\$select a \+ b\$function\$/
+    ),
+    config_params: {
+      role: 'postgres',
+      search_path: 'hooks, auth',
+    },
+    definition: 'select a + b',
+    id: expect.any(Number),
+    identity_argument_types: 'a smallint, b smallint',
+    is_set_returning_function: false,
+    language: 'sql',
+    name: 'test_func',
+    return_type: 'integer',
+    return_type_id: 23,
+    return_type_relation_id: null,
+    schema: 'public',
+    security_definer: true,
+  })
+  // create test_schema to move the function into:
+  const { sql: createSchemaSql } = await pgMeta.schemas.create({ name: 'test_schema' })
+  await executeQuery(createSchemaSql)
+  const { sql: updateSql } = await pgMeta.functions.update(res!, {
+    name: 'test_func_renamed',
+    schema: 'test_schema',
+    definition: 'select b - a',
+  })
+  await executeQuery(updateSql)
 
-//   const { sql: retrieveRenamedSql } = await pgMeta.functions.retrieve({ id: functionId })
-//   const retrieveRenamed = await executeQuery(retrieveRenamedSql)
-//   const resUpdated = retrieveZod.parse(retrieveRenamed[0])
-//   expect({ data: resUpdated, error: null }).toMatchInlineSnapshot(
-//     { data: { id: expect.any(Number) } },
-//     `
-//     {
-//       "data": {
-//         "args": [
-//           {
-//             "has_default": false,
-//             "mode": "in",
-//             "name": "a",
-//             "type_id": 21,
-//           },
-//           {
-//             "has_default": false,
-//             "mode": "in",
-//             "name": "b",
-//             "type_id": 21,
-//           },
-//         ],
-//         "argument_types": "a smallint, b smallint",
-//         "behavior": "STABLE",
-//         "complete_statement": "CREATE OR REPLACE FUNCTION test_schema.test_func_renamed(a smallint, b smallint)
-//      RETURNS integer
-//      LANGUAGE sql
-//      STABLE SECURITY DEFINER
-//      SET role TO 'postgres'
-//      SET search_path TO 'hooks', 'auth'
-//     AS $function$select b - a$function$
-//     ",
-//         "config_params": {
-//           "role": "postgres",
-//           "search_path": "hooks, auth",
-//         },
-//         "definition": "select b - a",
-//         "id": Any<Number>,
-//         "identity_argument_types": "a smallint, b smallint",
-//         "is_set_returning_function": false,
-//         "language": "sql",
-//         "name": "test_func_renamed",
-//         "return_type": "integer",
-//         "return_type_id": 23,
-//         "return_type_relation_id": null,
-//         "schema": "test_schema",
-//         "security_definer": true,
-//       },
-//       "error": null,
-//     }
-//   `
-//   )
+  const { sql: retrieveRenamedSql } = await pgMeta.functions.retrieve({ id: functionId })
+  const retrieveRenamed = await executeQuery(retrieveRenamedSql)
+  const resUpdated = retrieveZod.parse(retrieveRenamed[0])
+  expect({ data: resUpdated, error: null }).toMatchInlineSnapshot(
+    { data: { id: expect.any(Number) } },
+    `
+    {
+      "data": {
+        "args": [
+          {
+            "has_default": false,
+            "mode": "in",
+            "name": "a",
+            "type_id": 21,
+          },
+          {
+            "has_default": false,
+            "mode": "in",
+            "name": "b",
+            "type_id": 21,
+          },
+        ],
+        "argument_types": "a smallint, b smallint",
+        "behavior": "STABLE",
+        "complete_statement": "CREATE OR REPLACE FUNCTION test_schema.test_func_renamed(a smallint, b smallint)
+     RETURNS integer
+     LANGUAGE sql
+     STABLE SECURITY DEFINER
+     SET role TO 'postgres'
+     SET search_path TO 'hooks', 'auth'
+    AS $function$select b - a$function$
+    ",
+        "config_params": {
+          "role": "postgres",
+          "search_path": "hooks, auth",
+        },
+        "definition": "select b - a",
+        "id": Any<Number>,
+        "identity_argument_types": "a smallint, b smallint",
+        "is_set_returning_function": false,
+        "language": "sql",
+        "name": "test_func_renamed",
+        "return_type": "integer",
+        "return_type_id": 23,
+        "return_type_relation_id": null,
+        "schema": "test_schema",
+        "security_definer": true,
+      },
+      "error": null,
+    }
+  `
+  )
 
-//   // Remove function
-//   const { sql: removeSql } = await pgMeta.functions.remove(resUpdated!)
-//   await executeQuery(removeSql)
-//   // Verify function is removed
-//   const { sql: verifyRemoveSql } = await pgMeta.functions.retrieve({ id: functionId })
-//   const result = await executeQuery(verifyRemoveSql)
-//   expect(result).toHaveLength(0)
-// })
+  // Remove function
+  const { sql: removeSql } = await pgMeta.functions.remove(resUpdated!)
+  await executeQuery(removeSql)
+  // Verify function is removed
+  const { sql: verifyRemoveSql } = await pgMeta.functions.retrieve({ id: functionId })
+  const result = await executeQuery(verifyRemoveSql)
+  expect(result).toHaveLength(0)
+})
 
-// withTestDatabase('retrieve set-returning function', async ({ executeQuery }) => {
-//   // Retrieve function
-//   const { sql: retrieveSql, zod: retrieveZod } = await pgMeta.functions.retrieve({
-//     schema: 'public',
-//     name: 'function_returning_set_of_rows',
-//     args: [],
-//   })
-//   const retrieve = await executeQuery(retrieveSql)
-//   const res = retrieveZod.parse(retrieve[0])
-//   expect(res).toMatchObject({
-//     args: [],
-//     argument_types: '',
-//     behavior: 'STABLE',
-//     complete_statement: `CREATE OR REPLACE FUNCTION public.function_returning_set_of_rows()
-//  RETURNS SETOF users
-//  LANGUAGE sql
-//  STABLE
-// AS $function$
-//   select * from public.users;
-// $function$
-// `,
-//     config_params: null,
-//     definition: `
-//   select * from public.users;
-// `,
-//     id: expect.any(Number),
-//     identity_argument_types: '',
-//     is_set_returning_function: true,
-//     language: 'sql',
-//     name: 'function_returning_set_of_rows',
-//     return_type: 'SETOF users',
-//     return_type_id: expect.any(Number),
-//     return_type_relation_id: expect.any(Number),
-//     schema: 'public',
-//     security_definer: false,
-//   })
-// })
+withTestDatabase('retrieve set-returning function', async ({ executeQuery }) => {
+  // Retrieve function
+  const { sql: retrieveSql, zod: retrieveZod } = await pgMeta.functions.retrieve({
+    schema: 'public',
+    name: 'function_returning_set_of_rows',
+    args: [],
+  })
+  const retrieve = await executeQuery(retrieveSql)
+  const res = retrieveZod.parse(retrieve[0])
+  expect(res).toMatchObject({
+    args: [],
+    argument_types: '',
+    behavior: 'STABLE',
+    complete_statement: `CREATE OR REPLACE FUNCTION public.function_returning_set_of_rows()
+ RETURNS SETOF users
+ LANGUAGE sql
+ STABLE
+AS $function$
+  select * from public.users;
+$function$
+`,
+    config_params: null,
+    definition: `
+  select * from public.users;
+`,
+    id: expect.any(Number),
+    identity_argument_types: '',
+    is_set_returning_function: true,
+    language: 'sql',
+    name: 'function_returning_set_of_rows',
+    return_type: 'SETOF users',
+    return_type_id: expect.any(Number),
+    return_type_relation_id: expect.any(Number),
+    schema: 'public',
+    security_definer: false,
+  })
+})
 
-// withTestDatabase('create function with various config_params values', async ({ executeQuery }) => {
-//   // Set initial application_name for consistent testing
-//   await executeQuery("SET application_name = 'current-app-name'")
+withTestDatabase('create function with various config_params values', async ({ executeQuery }) => {
+  // Set initial application_name for consistent testing
+  await executeQuery("SET application_name = 'current-app-name'")
 
-//   const { sql: createSql1 } = await pgMeta.functions.create({
-//     name: 'test_func_config_1',
-//     schema: 'public',
-//     definition: 'select 1',
-//     return_type: 'integer',
-//     language: 'sql',
-//     config_params: {
-//       search_path: '""', // Should become ''
-//       application_name: 'FROM CURRENT', // Special syntax: SET param FROM CURRENT
-//       work_mem: "'8MB'", // Regular syntax: SET param TO value
-//     },
-//   })
-//   await executeQuery(createSql1)
+  const { sql: createSql1 } = await pgMeta.functions.create({
+    name: 'test_func_config_1',
+    schema: 'public',
+    definition: 'select 1',
+    return_type: 'integer',
+    language: 'sql',
+    config_params: {
+      search_path: '""', // Should become ''
+      application_name: 'FROM CURRENT', // Special syntax: SET param FROM CURRENT
+      work_mem: "'8MB'", // Regular syntax: SET param TO value
+    },
+  })
+  await executeQuery(createSql1)
 
-//   // Verify the function was created correctly
-//   const { sql: retrieveSql1, zod: retrieveZod } = await pgMeta.functions.retrieve({
-//     name: 'test_func_config_1',
-//     schema: 'public',
-//     args: [],
-//   })
-//   const result1 = retrieveZod.parse((await executeQuery(retrieveSql1))[0])
+  // Verify the function was created correctly
+  const { sql: retrieveSql1, zod: retrieveZod } = await pgMeta.functions.retrieve({
+    name: 'test_func_config_1',
+    schema: 'public',
+    args: [],
+  })
+  const result1 = retrieveZod.parse((await executeQuery(retrieveSql1))[0])
 
-//   expect(result1).toBeDefined()
-//   expect(result1!.config_params).toEqual({
-//     search_path: '""',
-//     application_name: 'current-app-name',
-//     work_mem: '8MB',
-//   })
+  expect(result1).toBeDefined()
+  expect(result1!.config_params).toEqual({
+    search_path: '""',
+    application_name: 'current-app-name',
+    work_mem: '8MB',
+  })
 
-//   // Clean up
-//   const { sql: removeSql1 } = await pgMeta.functions.remove(result1!)
-//   await executeQuery(removeSql1)
-// })
+  // Clean up
+  const { sql: removeSql1 } = await pgMeta.functions.remove(result1!)
+  await executeQuery(removeSql1)
+})

--- a/packages/pg-meta/tsconfig.json
+++ b/packages/pg-meta/tsconfig.json
@@ -1,7 +1,8 @@
 {
-  "extends": "tsconfig/base.json",
+  "extends": "../tsconfig/base.json",
   "compilerOptions": {
-    "module": "ESNext"
+    "module": "ESNext",
+    "moduleResolution": "bundler"
   },
   "include": ["."],
   "exclude": ["dist", "build", "node_modules"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -862,7 +862,7 @@ importers:
         version: 9.3.4
       '@testing-library/jest-dom':
         specifier: ^6.4.6
-        version: 6.4.6(@jest/globals@29.7.0(supports-color@8.1.1))(@types/jest@29.5.5)(jest@29.7.0(@types/node@20.12.11)(supports-color@8.1.1))(vitest@3.0.4(@types/node@20.12.11)(@vitest/ui@3.0.4)(jsdom@20.0.3(supports-color@8.1.1))(msw@2.4.11(typescript@5.5.2))(sass@1.72.0)(supports-color@8.1.1)(terser@5.37.0))
+        version: 6.4.6(@jest/globals@29.7.0(supports-color@8.1.1))(@types/jest@29.5.5)(jest@29.7.0(@types/node@20.12.11)(supports-color@8.1.1))(vitest@3.0.4)
       '@testing-library/react':
         specifier: ^14.0.0
         version: 14.0.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -1475,9 +1475,15 @@ importers:
         specifier: ^3.22.4
         version: 3.23.8
     devDependencies:
+      '@types/pg':
+        specifier: ^8.11.11
+        version: 8.11.11
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
+      pg:
+        specifier: 8.13.1
+        version: 8.13.1
       postgres:
         specifier: ^3.4.5
         version: 3.4.5
@@ -1737,7 +1743,7 @@ importers:
         version: 3.6.1
       '@testing-library/jest-dom':
         specifier: ^6.1.3
-        version: 6.4.6(@jest/globals@29.7.0(supports-color@8.1.1))(@types/jest@29.5.5)(jest@29.7.0(@types/node@20.12.11)(supports-color@8.1.1))(vitest@3.0.4(@types/node@20.12.11)(@vitest/ui@3.0.4)(jsdom@20.0.3(supports-color@8.1.1))(msw@2.4.11(typescript@5.5.2))(sass@1.72.0)(supports-color@8.1.1)(terser@5.37.0))
+        version: 6.4.6(@jest/globals@29.7.0(supports-color@8.1.1))(@types/jest@29.5.5)(jest@29.7.0(@types/node@20.12.11)(supports-color@8.1.1))(vitest@3.0.4)
       '@testing-library/react':
         specifier: ^14.0.0
         version: 14.0.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -1906,7 +1912,7 @@ importers:
         version: 10.1.0
       '@testing-library/jest-dom':
         specifier: ^6.4.6
-        version: 6.4.6(@jest/globals@29.7.0(supports-color@8.1.1))(@types/jest@29.5.5)(jest@29.7.0(@types/node@20.12.11)(supports-color@8.1.1))(vitest@3.0.4(@types/node@20.12.11)(@vitest/ui@3.0.4)(jsdom@20.0.3(supports-color@8.1.1))(msw@2.4.11(typescript@5.5.2))(sass@1.72.0)(supports-color@8.1.1)(terser@5.37.0))
+        version: 6.4.6(@jest/globals@29.7.0(supports-color@8.1.1))(@types/jest@29.5.5)(jest@29.7.0(@types/node@20.12.11)(supports-color@8.1.1))(vitest@3.0.4)
       '@testing-library/react':
         specifier: ^16.0.0
         version: 16.0.0(@testing-library/dom@10.1.0)(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -5768,6 +5774,9 @@ packages:
 
   '@types/pg-pool@2.0.6':
     resolution: {integrity: sha512-TaAUE5rq2VQYxab5Ts7WZhKNmuN78Q6PiFonTDdpbx8a1H0M1vhy3rhiMjl+e2iHmogyMw7jZF4FrE6eJUy5HQ==}
+
+  '@types/pg@8.11.11':
+    resolution: {integrity: sha512-kGT1qKM8wJQ5qlawUrEkXgvMSXoV213KfMGXcwfDwUIfUHXqXYXOfS1nE1LINRJVVVx5wCm70XnFlMHaIcQAfw==}
 
   '@types/pg@8.6.1':
     resolution: {integrity: sha512-1Kc4oAGzAl7uqUStZCDvaLFqZrW9qWSjXOmBfdgyBP5La7Us6Mg4GBvRlSoaZMhQF/zSj1C8CtKMBkoiT8eL8w==}
@@ -10233,6 +10242,9 @@ packages:
   obliterator@2.0.4:
     resolution: {integrity: sha512-lgHwxlxV1qIg1Eap7LgIeoBWIMFibOjbrYPIPJZcI1mmGAI2m3lNYpK12Y+GBdPQ0U1hRwSord7GIaawz962qQ==}
 
+  obuf@1.1.2:
+    resolution: {integrity: sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==}
+
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
@@ -10438,6 +10450,9 @@ packages:
   pg-connection-string@2.6.2:
     resolution: {integrity: sha512-ch6OwaeaPYcova4kKZ15sbJ2hKb/VP48ZD2gE7i1J+L4MspCtBMAx8nMgz7bksc7IojCIIWuEhHibSMFH8m8oA==}
 
+  pg-connection-string@2.7.0:
+    resolution: {integrity: sha512-PI2W9mv53rXJQEOb8xNR8lH7Hr+EKa6oJa38zsK0S/ky2er16ios1wLKhZyxzD7jUReiWokc9WK5nxSnC7W1TA==}
+
   pg-format@1.0.4:
     resolution: {integrity: sha512-YyKEF78pEA6wwTAqOUaHIN/rWpfzzIuMh9KdAhc3rSLQ/7zkRFcCgYBAEGatDstLyZw4g0s9SNICmaTGnBVeyw==}
     engines: {node: '>=4.0'}
@@ -10450,23 +10465,40 @@ packages:
     resolution: {integrity: sha512-NoSsPqXxbkD8RIe+peQCqiea4QzXgosdTKY8p7PsbbGsh2F8TifDj/vJxfuR8qJwNYrijdSs7uf0tAe6WOyCsQ==}
     engines: {node: '>=12.0.0'}
 
-  pg-pool@3.6.1:
-    resolution: {integrity: sha512-jizsIzhkIitxCGfPRzJn1ZdcosIt3pz9Sh3V01fm1vZnbnCMgmGl5wvGGdNN2EL9Rmb0EcFoCkixH4Pu+sP9Og==}
+  pg-numeric@1.0.2:
+    resolution: {integrity: sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==}
+    engines: {node: '>=4'}
+
+  pg-pool@3.7.1:
+    resolution: {integrity: sha512-xIOsFoh7Vdhojas6q3596mXFsR8nwBQBXX5JiV7p9buEVAGqYL4yFzclON5P9vFrpu1u7Zwl2oriyDa89n0wbw==}
     peerDependencies:
       pg: '>=8.0'
 
   pg-protocol@1.6.0:
     resolution: {integrity: sha512-M+PDm637OY5WM307051+bsDia5Xej6d9IR4GwJse1qA1DIhiKlksvrneZOYQq42OM+spubpcNYEo2FcKQrDk+Q==}
 
-  pg-protocol@1.7.0:
-    resolution: {integrity: sha512-hTK/mE36i8fDDhgDFjy6xNOG+LCorxLG3WO17tku+ij6sVHXh1jQUJ8hYAnRhNla4QVD2H8er/FOjc/+EgC6yQ==}
+  pg-protocol@1.7.1:
+    resolution: {integrity: sha512-gjTHWGYWsEgy9MsY0Gp6ZJxV24IjDqdpTW7Eh0x+WfJLFsm/TJx1MzL6T0D88mBvkpxotCQ6TwW6N+Kko7lhgQ==}
 
   pg-types@2.2.0:
     resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
     engines: {node: '>=4'}
 
+  pg-types@4.0.2:
+    resolution: {integrity: sha512-cRL3JpS3lKMGsKaWndugWQoLOCoP+Cic8oseVcbr0qhPzYD5DWXK+RZ9LY9wxRf7RQia4SCwQlXk0q6FCPrVng==}
+    engines: {node: '>=10'}
+
   pg@8.11.3:
     resolution: {integrity: sha512-+9iuvG8QfaaUrrph+kpF24cXkH1YOOUeArRNYIxq1viYHZagBxrTno7cecY1Fa44tJeZvaoG+Djpkc3JwehN5g==}
+    engines: {node: '>= 8.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pg@8.13.1:
+    resolution: {integrity: sha512-OUir1A0rPNZlX//c7ksiu7crsGZTKSOXJPgtNiHGIlC9H0lO+NC6ZDYksSgBYY/thSWhnSRBv8w1lieNNGATNQ==}
     engines: {node: '>= 8.0.0'}
     peerDependencies:
       pg-native: '>=3.0.1'
@@ -10642,13 +10674,28 @@ packages:
     resolution: {integrity: sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==}
     engines: {node: '>=0.10.0'}
 
+  postgres-bytea@3.0.0:
+    resolution: {integrity: sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw==}
+    engines: {node: '>= 6'}
+
   postgres-date@1.0.7:
     resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
     engines: {node: '>=0.10.0'}
 
+  postgres-date@2.1.0:
+    resolution: {integrity: sha512-K7Juri8gtgXVcDfZttFKVmhglp7epKb1K4pgrkLxehjqkrgPhfG6OO8LHLkfaqkbpjNRnra018XwAr1yQFWGcA==}
+    engines: {node: '>=12'}
+
   postgres-interval@1.2.0:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
+
+  postgres-interval@3.0.0:
+    resolution: {integrity: sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw==}
+    engines: {node: '>=12'}
+
+  postgres-range@1.1.4:
+    resolution: {integrity: sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==}
 
   postgres@3.4.5:
     resolution: {integrity: sha512-cDWgoah1Gez9rN3H4165peY9qfpEo+SA61oQv65O3cRUE1pOEoJWwddwcqKE8XZYjbblOJlYDlLV4h67HrEVDg==}
@@ -17512,7 +17559,7 @@ snapshots:
       lz-string: 1.5.0
       pretty-format: 27.5.1
 
-  '@testing-library/jest-dom@6.4.6(@jest/globals@29.7.0(supports-color@8.1.1))(@types/jest@29.5.5)(jest@29.7.0(@types/node@20.12.11)(supports-color@8.1.1))(vitest@3.0.4(@types/node@20.12.11)(@vitest/ui@3.0.4)(jsdom@20.0.3(supports-color@8.1.1))(msw@2.4.11(typescript@5.5.2))(sass@1.72.0)(supports-color@8.1.1)(terser@5.37.0))':
+  '@testing-library/jest-dom@6.4.6(@jest/globals@29.7.0(supports-color@8.1.1))(@types/jest@29.5.5)(jest@29.7.0(@types/node@20.12.11)(supports-color@8.1.1))(vitest@3.0.4)':
     dependencies:
       '@adobe/css-tools': 4.4.0
       '@babel/runtime': 7.24.7
@@ -17949,10 +17996,16 @@ snapshots:
     dependencies:
       '@types/pg': 8.6.1
 
+  '@types/pg@8.11.11':
+    dependencies:
+      '@types/node': 22.12.0
+      pg-protocol: 1.7.1
+      pg-types: 4.0.2
+
   '@types/pg@8.6.1':
     dependencies:
       '@types/node': 22.12.0
-      pg-protocol: 1.7.0
+      pg-protocol: 1.7.1
       pg-types: 2.2.0
 
   '@types/phoenix@1.6.4': {}
@@ -20123,7 +20176,7 @@ snapshots:
       debug: 4.3.7(supports-color@8.1.1)
       enhanced-resolve: 5.17.1
       eslint: 8.57.0(supports-color@8.1.1)
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9(supports-color@8.1.1))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9(supports-color@8.1.1))(eslint-plugin-import@2.29.1)(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1))(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9(supports-color@8.1.1))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.5.2))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.2
@@ -20135,7 +20188,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9(supports-color@8.1.1))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9(supports-color@8.1.1))(eslint-plugin-import@2.29.1)(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1))(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9(supports-color@8.1.1))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
       debug: 3.2.7(supports-color@8.1.1)
     optionalDependencies:
@@ -20162,7 +20215,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0(supports-color@8.1.1)
       eslint-import-resolver-node: 0.3.9(supports-color@8.1.1)
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9(supports-color@8.1.1))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9(supports-color@8.1.1))(eslint-plugin-import@2.29.1)(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1))(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9(supports-color@8.1.1))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0(supports-color@8.1.1))(supports-color@8.1.1)
       hasown: 2.0.2
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -23952,6 +24005,8 @@ snapshots:
 
   obliterator@2.0.4: {}
 
+  obuf@1.1.2: {}
+
   on-exit-leak-free@2.1.2: {}
 
   once@1.4.0:
@@ -24182,19 +24237,27 @@ snapshots:
 
   pg-connection-string@2.6.2: {}
 
+  pg-connection-string@2.7.0: {}
+
   pg-format@1.0.4: {}
 
   pg-int8@1.0.1: {}
 
   pg-minify@1.6.3: {}
 
-  pg-pool@3.6.1(pg@8.11.3):
+  pg-numeric@1.0.2: {}
+
+  pg-pool@3.7.1(pg@8.11.3):
     dependencies:
       pg: 8.11.3
 
+  pg-pool@3.7.1(pg@8.13.1):
+    dependencies:
+      pg: 8.13.1
+
   pg-protocol@1.6.0: {}
 
-  pg-protocol@1.7.0: {}
+  pg-protocol@1.7.1: {}
 
   pg-types@2.2.0:
     dependencies:
@@ -24204,13 +24267,33 @@ snapshots:
       postgres-date: 1.0.7
       postgres-interval: 1.2.0
 
+  pg-types@4.0.2:
+    dependencies:
+      pg-int8: 1.0.1
+      pg-numeric: 1.0.2
+      postgres-array: 3.0.2
+      postgres-bytea: 3.0.0
+      postgres-date: 2.1.0
+      postgres-interval: 3.0.0
+      postgres-range: 1.1.4
+
   pg@8.11.3:
     dependencies:
       buffer-writer: 2.0.0
       packet-reader: 1.0.0
-      pg-connection-string: 2.6.2
-      pg-pool: 3.6.1(pg@8.11.3)
-      pg-protocol: 1.6.0
+      pg-connection-string: 2.7.0
+      pg-pool: 3.7.1(pg@8.11.3)
+      pg-protocol: 1.7.1
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.1.1
+
+  pg@8.13.1:
+    dependencies:
+      pg-connection-string: 2.7.0
+      pg-pool: 3.7.1(pg@8.13.1)
+      pg-protocol: 1.7.1
       pg-types: 2.2.0
       pgpass: 1.0.5
     optionalDependencies:
@@ -24404,11 +24487,21 @@ snapshots:
 
   postgres-bytea@1.0.0: {}
 
+  postgres-bytea@3.0.0:
+    dependencies:
+      obuf: 1.1.2
+
   postgres-date@1.0.7: {}
+
+  postgres-date@2.1.0: {}
 
   postgres-interval@1.2.0:
     dependencies:
       xtend: 4.0.2
+
+  postgres-interval@3.0.0: {}
+
+  postgres-range@1.1.4: {}
 
   postgres@3.4.5: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1390,7 +1390,7 @@ importers:
     dependencies:
       '@mertasan/tailwindcss-variables':
         specifier: ^2.2.3
-        version: 2.7.0(autoprefixer@10.4.16(postcss@8.5.1))(postcss@8.5.1)
+        version: 2.7.0(autoprefixer@10.4.16(postcss@8.4.38))(postcss@8.4.38)
       '@radix-ui/colors':
         specifier: ^0.1.8
         version: 0.1.9
@@ -1482,11 +1482,11 @@ importers:
         specifier: ^4.1.5
         version: 4.1.5
       pg:
-        specifier: 8.13.1
+        specifier: ^8.13.1
         version: 8.13.1
-      postgres:
-        specifier: ^3.4.5
-        version: 3.4.5
+      postgres-array:
+        specifier: ^3.0.2
+        version: 3.0.2
       typescript:
         specifier: ~5.5.0
         version: 5.5.2
@@ -1643,7 +1643,7 @@ importers:
         version: 0.436.0(react@18.2.0)
       next:
         specifier: 'catalog:'
-        version: 14.2.21(@babel/core@7.24.7(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.72.0)
+        version: 14.2.21(@babel/core@7.26.7(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.72.0)
       next-themes:
         specifier: ^0.3.0
         version: 0.3.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -1842,7 +1842,7 @@ importers:
         version: 0.33.0
       next:
         specifier: 'catalog:'
-        version: 14.2.21(@babel/core@7.24.7(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.72.0)
+        version: 14.2.21(@babel/core@7.26.7(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.72.0)
       next-themes:
         specifier: '*'
         version: 0.3.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -1939,7 +1939,7 @@ importers:
         version: link:../api-types
       next-router-mock:
         specifier: ^0.9.13
-        version: 0.9.13(next@14.2.21(@babel/core@7.24.7(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.72.0))(react@18.2.0)
+        version: 0.9.13(next@14.2.21(@babel/core@7.26.7(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.72.0))(react@18.2.0)
       typescript:
         specifier: ~5.5.0
         version: 5.5.2
@@ -7634,7 +7634,6 @@ packages:
     resolution: {integrity: sha512-t0q23FIpvHDTtnORW+bDJziGsal5uh9RJTJ1fyH8drd4lICOoXhJ5pLMUZ5C0VQei6dNmwTzzoTRgMkO9JgHEQ==}
     peerDependencies:
       eslint: '>= 5'
-    bundledDependencies: []
 
   eslint-plugin-import@2.29.1:
     resolution: {integrity: sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==}
@@ -10696,10 +10695,6 @@ packages:
 
   postgres-range@1.1.4:
     resolution: {integrity: sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==}
-
-  postgres@3.4.5:
-    resolution: {integrity: sha512-cDWgoah1Gez9rN3H4165peY9qfpEo+SA61oQv65O3cRUE1pOEoJWwddwcqKE8XZYjbblOJlYDlLV4h67HrEVDg==}
-    engines: {node: '>=12'}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -15080,12 +15075,6 @@ snapshots:
       lodash: 4.17.21
       postcss: 8.4.38
 
-  '@mertasan/tailwindcss-variables@2.7.0(autoprefixer@10.4.16(postcss@8.5.1))(postcss@8.5.1)':
-    dependencies:
-      autoprefixer: 10.4.16(postcss@8.5.1)
-      lodash: 4.17.21
-      postcss: 8.5.1
-
   '@monaco-editor/loader@1.4.0(monaco-editor@0.33.0)':
     dependencies:
       monaco-editor: 0.33.0
@@ -18779,16 +18768,6 @@ snapshots:
       normalize-range: 0.1.2
       picocolors: 1.0.1
       postcss: 8.4.38
-      postcss-value-parser: 4.2.0
-
-  autoprefixer@10.4.16(postcss@8.5.1):
-    dependencies:
-      browserslist: 4.23.3
-      caniuse-lite: 1.0.30001651
-      fraction.js: 4.3.6
-      normalize-range: 0.1.2
-      picocolors: 1.0.1
-      postcss: 8.5.1
       postcss-value-parser: 4.2.0
 
   available-typed-arrays@1.0.7:
@@ -23726,6 +23705,11 @@ snapshots:
       next: 14.2.21(@babel/core@7.24.7(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.72.0)
       react: 18.2.0
 
+  next-router-mock@0.9.13(next@14.2.21(@babel/core@7.26.7(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.72.0))(react@18.2.0):
+    dependencies:
+      next: 14.2.21(@babel/core@7.26.7(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.72.0)
+      react: 18.2.0
+
   next-seo@6.5.0(next@14.2.21(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.72.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       next: 14.2.21(@babel/core@7.24.7(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.72.0)
@@ -23748,6 +23732,34 @@ snapshots:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       styled-jsx: 5.1.1(@babel/core@7.24.7(supports-color@8.1.1))(react@18.2.0)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 14.2.21
+      '@next/swc-darwin-x64': 14.2.21
+      '@next/swc-linux-arm64-gnu': 14.2.21
+      '@next/swc-linux-arm64-musl': 14.2.21
+      '@next/swc-linux-x64-gnu': 14.2.21
+      '@next/swc-linux-x64-musl': 14.2.21
+      '@next/swc-win32-arm64-msvc': 14.2.21
+      '@next/swc-win32-ia32-msvc': 14.2.21
+      '@next/swc-win32-x64-msvc': 14.2.21
+      '@opentelemetry/api': 1.9.0
+      '@playwright/test': 1.49.1
+      sass: 1.72.0
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
+  next@14.2.21(@babel/core@7.26.7(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.49.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.72.0):
+    dependencies:
+      '@next/env': 14.2.21
+      '@swc/helpers': 0.5.5
+      busboy: 1.6.0
+      caniuse-lite: 1.0.30001695
+      graceful-fs: 4.2.11
+      postcss: 8.4.31
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      styled-jsx: 5.1.1(@babel/core@7.26.7(supports-color@8.1.1))(react@18.2.0)
     optionalDependencies:
       '@next/swc-darwin-arm64': 14.2.21
       '@next/swc-darwin-x64': 14.2.21
@@ -24502,8 +24514,6 @@ snapshots:
   postgres-interval@3.0.0: {}
 
   postgres-range@1.1.4: {}
-
-  postgres@3.4.5: {}
 
   prelude-ls@1.2.1: {}
 
@@ -26092,6 +26102,13 @@ snapshots:
       react: 18.2.0
     optionalDependencies:
       '@babel/core': 7.24.7(supports-color@8.1.1)
+
+  styled-jsx@5.1.1(@babel/core@7.26.7(supports-color@8.1.1))(react@18.2.0):
+    dependencies:
+      client-only: 0.0.1
+      react: 18.2.0
+    optionalDependencies:
+      '@babel/core': 7.26.7(supports-color@8.1.1)
 
   stylis@4.3.1: {}
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Continue the effort to migrate pg-meta into a self serving query lib


This PR:

1. Port over the tests for the "functions" query