### PR TITLE
Billing docs revamp - Dashboard links, Redirects, high-level billing page

### DIFF
--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
@@ -2080,6 +2080,10 @@ export const platform: NavMenuConstant = {
       url: undefined,
       items: [
         {
+          name: 'About billing on Supabase',
+          url: '/guides/platform/billing-on-supabase',
+        },
+        {
           name: 'Get set up for billing',
           url: '/guides/platform/get-set-up-for-billing',
         },

--- a/apps/docs/content/guides/platform/billing-on-supabase.mdx
+++ b/apps/docs/content/guides/platform/billing-on-supabase.mdx
@@ -1,0 +1,61 @@
+---
+id: 'billing-on-supabase'
+title: 'About billing on Supabase'
+---
+
+## Subscription plans
+Supabase offers different subscription plans—Free, Pro, Team, and Enterprise. For a closer look at each plan's features and pricing, visit our [pricing page](https://supabase.com/pricing).
+
+### Free Plan
+The Free Plan helps you get started and explore the platform. You are granted two free projects. The project limit applies across all organizations where you are an Owner or Administrator. This means you could have two Free Plan organizations with one project each, or one Free Plan organization with two projects. Paused projects do not count towards your free project limit.
+
+### Paid plans
+Upgrading your organization to a paid plan provides additional features, and you receive a higher [usage quota](/docs/guides/platform/billing-on-supabase#usage-quota). You unlock the benefits of the paid plan for all projects within your organization - for example, no projects in your Pro Plan organization will be paused.
+
+## Organization-based billing
+Supabase bills separately for each organization. That means that each organization has its own subscription, including a unique subscription plan (Free, Pro, Team, or Enterprise), payment method, billing cycle, and invoices.
+
+Different plans cannot be mixed within a single organization. For example, you cannot have both a Pro Plan project and a Free Plan project in the same organization. To have projects on different plans, you must create separate organizations. See [Project Transfers](/docs/guides/platform/project-transfer) if you need to move a project to a different organization.
+<div className="text-center">
+  <Image
+    alt="Subscription downgrade modal"
+    src={{
+      light: '/docs/img/guides/platform/billing-overview--light.png',
+      dark: '/docs/img/guides/platform/billing-overview--dark.png',
+    }}
+    className="max-w-[600px] inline-block"
+    zoomable
+  />
+</div>
+
+
+## Usage quota
+Each subscription plan includes a built-in quota for some selected usage items, such as [Egress](/docs/guides/platform/manage-your-usage/egress), [Storage Size](/docs/guides/platform/manage-your-usage/storage-size), or [Edge Function Invocations](/docs/guides/platform/manage-your-usage/edge-function-invocations). This quota represents your free usage allowance. If you stay within it, you incur no extra charges for these items. Only usage beyond the quota is billed as overage.
+
+For usage items without a quota, such as [Compute](/docs/guides/platform/manage-your-usage/compute) or [Custom Domains](/docs/guides/platform/manage-your-usage/custom-domains), you are charged for your entire usage.
+
+The quota is applied to your entire organization, independent of how many projects you launch within that organization. For billing purposes, we sum the usage across all projects in a monthly invoice.
+
+| Usage Item                       | Free                     | Pro/Team                                           | Enterprise |
+|----------------------------------|--------------------------|----------------------------------------------------|------------|
+| Egress                           | 5 GB                     | 250 GB included, then $0.09 per GB                 | Custom     |
+| Database Size                    | 500 MB                   | 8 GB disk per project included, then $0.125 per GB | Custom     |
+| Storage Size                     | 1 GB                     | 100 GB included, then $0.021 per GB                | Custom     |
+| Monthly Active Users             | 50,000 MAU               | 100,000 MAU included, then $0.00325 per MAU        | Custom     |
+| Monthly Active Third-Party Users | 50 MAU                   | 50 MAU included, then $0.00325 per MAU             | Custom     |
+| Monthly Active SSO Users         | Unavailable on Free Plan | 50 MAU included, then $0.015 per MAU               | Custom     |
+| Edge Function Invocations        | 500,000                  | 2 million included, then $2 per million            | Custom     |
+| Edge Function Count              | 25                       | 500/1000                                           | Unlimited  |
+| Storage Images Transformed       | Unavailable on Free Plan | 100 included, then $5 per 1000                     | Custom     |
+| Realtime Message Count           | 2 million                | 5 million included, then $2.5 per million          | Custom     |
+| Realtime Peak Connections        | 200                      | 500 included, then $10 per 1000                    | Custom     |
+
+You can find a detailed breakdown of all usage items and how they are billed on the [Manage your usage](/docs/guides/platform/manage-your-usage) page.
+
+## Costs
+Monthly costs for paid plans include a fixed subscription fee based on your chosen plan and variable usage fees. To learn more about billing and cost management, refer to the following resources.
+
+- [Your monthly invoice](/docs/guides/platform/your-monthly-invoice) - For a detailed breakdown of what a monthly invoice includes
+- [Manage your usage](/docs/guides/platform/manage-your-usage) - For details on how the different usage items are billed, and how to optimize usage and reduce costs
+- [Control your costs]() - For details on how you can control your costs in case unexpected high usage occurs
+

--- a/apps/docs/content/guides/platform/manage-your-subscription.mdx
+++ b/apps/docs/content/guides/platform/manage-your-subscription.mdx
@@ -3,20 +3,6 @@ id: 'manage-your-subscription'
 title: 'Manage your subscription'
 ---
 
-## About billing on Supabase
-Supabase bills separately for each organization. That means that each organization has its own subscription, including a unique plan (Free, Pro, Team, or Enterprise), payment method, billing cycle, and invoices.
-
-Different plans cannot be mixed within a single organization. For example, you cannot have both a Pro Plan project and a Free Plan project in the same organization. To have projects on different plans, you must create separate organizations. See [Project Transfers](/docs/guides/platform/project-transfer) if you need to move a project to a different organization.
-<Image
-  alt="Subscription downgrade modal"
-  src={{
-    light: '/docs/img/guides/platform/billing-overview--light.png',
-    dark: '/docs/img/guides/platform/billing-overview.png',
-  }}
-  className="max-w-[577px]"
-  zoomable
-/>
-
 ## Manage your subscription plan
 To change your subscription plan
 1. On the [organization's billing page](https://supabase.com/dashboard/org/_/billing), go to section **Subscription Plan**

--- a/apps/studio/components/interfaces/Billing/SpendCapModal.tsx
+++ b/apps/studio/components/interfaces/Billing/SpendCapModal.tsx
@@ -15,7 +15,7 @@ const SpendCapModal = ({ visible, onHide }: SpendCapModalProps) => {
       header={
         <div className="flex justify-between items-center">
           <span>Spend Cap</span>
-          <DocsButton href="https://supabase.com/docs/guides/platform/spend-cap" />
+          <DocsButton href="https://supabase.com/docs/guides/platform/cost-control#spend-cap" />
         </div>
       }
       showCloseButton={false}

--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/BillingBreakdown.constants.ts
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/BillingBreakdown.constants.ts
@@ -102,7 +102,7 @@ export const BILLING_BREAKDOWN_METRICS: Metric[] = [
     tip: 'Each project gets provisioned with 8 GB of GP3 disk for free. When you get close to the disk size limit, we autoscale your disk by 1.5x. Each GB of provisioned disk size beyond 8 GB incurs a GB-Hr every hour. Each extra GB is billed at $0.125/month ($0.000171/GB-Hr), prorated down to the hour.',
     docLink: {
       title: 'Read more',
-      url: 'https://supabase.com/docs/guides/platform/org-based-billing#disk-size',
+      url: 'https://supabase.com/docs/guides/platform/manage-your-usage/disk-size',
     },
   },
   {

--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/ComputeMetric.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/ComputeMetric.tsx
@@ -63,7 +63,7 @@ const ComputeMetric = ({ slug, metric, usage, relativeToSubscription }: ComputeM
               active, it incurs compute costs based on the compute size of your project. Paused
               projects do not incur compute costs.{' '}
               <Link
-                href="https://supabase.com/docs/guides/platform/org-based-billing#billing-for-compute-compute-hours"
+                href="https://supabase.com/docs/guides/platform/manage-your-usage/compute"
                 target="_blank"
                 className="transition text-brand hover:text-brand-600 underline"
               >

--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
@@ -23,8 +23,7 @@ const feeTooltipData: TooltipData[] = [
   {
     identifier: 'COMPUTE',
     text: 'Every project is a dedicated server and database. For every hour your project is active, it incurs compute costs based on the compute size of your project. Paused projects do not incur compute costs.',
-    linkRef:
-      'https://supabase.com/docs/guides/platform/org-based-billing#billing-for-compute-compute-hours',
+    linkRef: 'https://supabase.com/docs/guides/platform/manage-your-usage/compute',
   },
 ]
 
@@ -244,7 +243,7 @@ const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
                     <span className="mr-2">{computeCredits.description}</span>
                     <InvoiceTooltip
                       text="Paid plans come with $10 in Compute Credits to cover one Micro instance or parts of any other instance. Compute Credits are given to you every month and do not stack up while you are on a paid plan."
-                      linkRef="https://supabase.com/docs/guides/platform/org-based-billing#compute-credits"
+                      linkRef="https://supabase.com/docs/guides/platform/manage-your-usage/compute#compute-credits"
                     />
                   </td>
                   <td className="py-2 text-sm text-right" colSpan={3}>

--- a/apps/studio/components/interfaces/Organization/BillingSettings/CostControl/CostControl.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/CostControl/CostControl.tsx
@@ -64,7 +64,7 @@ const CostControl = ({}: CostControlProps) => {
               <p className="text-sm text-foreground-light m-0">More information</p>
               <div>
                 <Link
-                  href="https://supabase.com/docs/guides/platform/spend-cap"
+                  href="https://supabase.com/docs/guides/platform/cost-control#spend-cap"
                   target="_blank"
                   rel="noreferrer"
                 >

--- a/apps/studio/components/interfaces/Organization/BillingSettings/CostControl/SpendCapSidePanel.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/CostControl/SpendCapSidePanel.tsx
@@ -108,7 +108,7 @@ const SpendCapSidePanel = () => {
           <h4>Spend cap</h4>
           <Button asChild type="default" icon={<ExternalLink strokeWidth={1.5} />}>
             <Link
-              href="https://supabase.com/docs/guides/platform/spend-cap"
+              href="https://supabase.com/docs/guides/platform/cost-control#spend-cap"
               target="_blank"
               rel="noreferrer"
             >

--- a/apps/studio/components/interfaces/Organization/BillingSettings/Restriction.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Restriction.tsx
@@ -74,7 +74,9 @@ export const Restriction = () => {
                 </Link>
               </Button>
               <Button asChild type="default" icon={<ExternalLink />}>
-                <a href="https://supabase.com/docs/guides/platform/spend-cap">About spend cap</a>
+                <a href="https://supabase.com/docs/guides/platform/cost-control#spend-cap">
+                  About spend cap
+                </a>
               </Button>
             </div>
           </AlertDescription_Shadcn_>

--- a/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/PlanUpdateSidePanel.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/PlanUpdateSidePanel.tsx
@@ -477,11 +477,11 @@ const PlanUpdateSidePanel = () => {
                     <div className="space-x-3 mt-2">
                       <Button asChild type="default" icon={<ExternalLink strokeWidth={1.5} />}>
                         <Link
-                          href="https://supabase.com/docs/guides/platform/org-based-billing"
+                          href="https://supabase.com/docs/guides/platform/manage-your-usage/compute"
                           target="_blank"
                           rel="noreferrer"
                         >
-                          How billing works
+                          How billing for Compute works
                         </Link>
                       </Button>
                       {subscription?.plan?.id === 'free' && (

--- a/apps/studio/components/interfaces/Organization/Usage/Compute.tsx
+++ b/apps/studio/components/interfaces/Organization/Usage/Compute.tsx
@@ -78,7 +78,7 @@ const Compute = ({ orgSlug, projectRef, startDate, endDate }: ComputeProps) => {
             },
             {
               name: 'Usage-billing for Compute',
-              url: 'https://supabase.com/docs/guides/platform/org-based-billing#billing-for-compute-compute-hours',
+              url: 'https://supabase.com/docs/guides/platform/manage-your-usage/compute',
             },
           ],
         }}

--- a/apps/studio/components/interfaces/Organization/Usage/TotalUsage.tsx
+++ b/apps/studio/components/interfaces/Organization/Usage/TotalUsage.tsx
@@ -120,7 +120,7 @@ const TotalUsage = ({
           links: [
             {
               name: 'How billing works',
-              url: 'https://supabase.com/docs/guides/platform/org-based-billing',
+              url: 'https://supabase.com/docs/guides/platform/billing-on-supabase',
             },
             {
               name: 'Supabase Plans',

--- a/apps/studio/components/interfaces/Organization/Usage/Usage.constants.tsx
+++ b/apps/studio/components/interfaces/Organization/Usage/Usage.constants.tsx
@@ -169,7 +169,7 @@ export const USAGE_CATEGORIES: (subscription?: OrgSubscription) => CategoryMeta[
             links: [
               {
                 name: 'Documentation',
-                url: 'https://supabase.com/docs/guides/platform/org-based-billing#disk-size',
+                url: 'https://supabase.com/docs/guides/platform/manage-your-usage/disk-size',
               },
               {
                 name: 'Disk Management',

--- a/apps/studio/components/interfaces/Organization/Usage/Usage.tsx
+++ b/apps/studio/components/interfaces/Organization/Usage/Usage.tsx
@@ -190,7 +190,7 @@ const Usage = () => {
           >
             <DocsButton
               abbrev={false}
-              href="https://supabase.com/docs/guides/platform/org-based-billing"
+              href="https://supabase.com/docs/guides/platform/billing-on-supabase#organization-based-billing"
             />
           </Admonition>
         </ScaffoldContainer>

--- a/apps/studio/components/interfaces/Settings/Addons/ComputeInstanceSidePanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/ComputeInstanceSidePanel.tsx
@@ -369,7 +369,7 @@ const ComputeInstanceSidePanel = () => {
                 usage-based item and you're billed at the end of your billing cycle based on your
                 compute usage. Read more about{' '}
                 <Link
-                  href="https://supabase.com/docs/guides/platform/org-based-billing#billing-for-compute-compute-hours"
+                  href="https://supabase.com/docs/guides/platform/manage-your-usage/compute"
                   target="_blank"
                   rel="noreferrer"
                   className="underline"

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/DeployNewReplicaPanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/DeployNewReplicaPanel.tsx
@@ -528,7 +528,7 @@ const DeployNewReplicaPanel = ({
             <p className="text-foreground-light text-sm">
               Read more about{' '}
               <Link
-                href="https://supabase.com/docs/guides/platform/org-based-billing#read-replicas"
+                href="https://supabase.com/docs/guides/platform/manage-your-usage/read-replicas"
                 target="_blank"
                 rel="noreferrer"
                 className="underline hover:text-foreground transition"

--- a/apps/studio/components/layouts/ProjectLayout/RestorePaidPlanProjectNotice.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/RestorePaidPlanProjectNotice.tsx
@@ -21,7 +21,7 @@ export const RestorePaidPlanProjectNotice = () => {
       <AlertDescription_Shadcn_ className="mt-3">
         <Button asChild type="default" icon={<ExternalLink />}>
           <a
-            href="https://supabase.com/docs/guides/platform/org-based-billing#billing-for-compute-compute-hours"
+            href="https://supabase.com/docs/guides/platform/manage-your-usage/compute"
             target="_blank"
             rel="noreferrer"
           >

--- a/apps/studio/pages/new/[slug].tsx
+++ b/apps/studio/pages/new/[slug].tsx
@@ -559,7 +559,7 @@ const Wizard: NextPageWithLayout = () => {
                                     <Link
                                       target="_blank"
                                       rel="noopener noreferrer"
-                                      href="https://supabase.com/docs/guides/platform/org-based-billing#billing-for-compute-compute-hours"
+                                      href="https://supabase.com/docs/guides/platform/manage-your-usage/compute"
                                     >
                                       <div className="flex items-center space-x-2 opacity-75 hover:opacity-100 transition">
                                         <p className="text-sm m-0">Compute Billing</p>

--- a/apps/studio/pages/new/v2/[slug].tsx
+++ b/apps/studio/pages/new/v2/[slug].tsx
@@ -805,7 +805,7 @@ const WizardForm = () => {
                                               <Link
                                                 target="_blank"
                                                 rel="noopener noreferrer"
-                                                href="https://supabase.com/docs/guides/platform/org-based-billing#billing-for-compute-compute-hours"
+                                                href="https://supabase.com/docs/guides/platform/manage-your-usage/compute"
                                               >
                                                 <div className="flex items-center space-x-2 opacity-75 hover:opacity-100 transition">
                                                   <p className="text-sm m-0">Compute Billing</p>

--- a/apps/www/lib/redirects.js
+++ b/apps/www/lib/redirects.js
@@ -2851,6 +2851,86 @@ module.exports = [
   },
   {
     permanent: false,
+    source: '/docs/guides/platform/org-based-billing#how-billing-is-organized',
+    destination: '/docs/guides/platform/billing-on-supabase#organization-based-billing',
+  },
+  {
+    permanent: false,
+    source: '/docs/guides/platform/org-based-billing#quotas-and-features',
+    destination: '/docs/guides/platform/billing-on-supabase#usage-quota',
+  },
+  {
+    permanent: false,
+    source: '/docs/guides/platform/org-based-billing#usage-items',
+    destination: '/docs/guides/platform/billing-on-supabase#usage-quota',
+  },
+  {
+    permanent: false,
+    source: '/docs/guides/platform/org-based-billing#billing-for-compute-compute-hours',
+    destination: '/docs/guides/platform/manage-your-usage/compute',
+  },
+  {
+    permanent: false,
+    source: '/docs/guides/platform/org-based-billing#compute-pricing',
+    destination: '/docs/guides/platform/manage-your-usage/compute#pricing',
+  },
+  {
+    permanent: false,
+    source: '/docs/guides/platform/org-based-billing#compute-credits',
+    destination: '/docs/guides/platform/manage-your-usage/compute#compute-credits',
+  },
+  {
+    permanent: false,
+    source: '/docs/guides/platform/org-based-billing#read-replicas',
+    destination: '/docs/guides/platform/manage-your-usage/read-replicas',
+  },
+  {
+    permanent: false,
+    source: '/docs/docs/guides/platform/org-based-billing#project-add-ons',
+    destination: '/docs/guides/platform/manage-your-usage',
+  },
+  {
+    permanent: false,
+    source: '/docs/guides/platform/org-based-billing#unified-egress',
+    destination: '/docs/guides/platform/manage-your-usage/egress',
+  },
+  {
+    permanent: false,
+    source: '/docs/guides/platform/org-based-billing#included-egress-quota',
+    destination: '/docs/guides/platform/manage-your-usage/egress#pricing',
+  },
+  {
+    permanent: false,
+    source: '/docs/guides/platform/org-based-billing#egress-dashboards',
+    destination: '/docs/guides/platform/manage-your-usage/egress#usage-page',
+  },
+  {
+    permanent: false,
+    source: '/docs/guides/platform/org-based-billing#disk-size',
+    destination: '/docs/guides/platform/manage-your-usage/disk-size',
+  },
+  {
+    permanent: false,
+    source: '/docs/guides/platform/org-based-billing#free-plan',
+    destination: '/docs/guides/platform/billing-on-supabase#free-plan',
+  },
+  {
+    permanent: false,
+    source: '/docs/guides/platform/org-based-billing#billing-examples',
+    destination: '/docs/guides/platform/billing-on-supabase',
+  },
+  {
+    permanent: false,
+    source: '/docs/guides/platform/org-based-billing#multiple-projects-in-a-free-plan-organization',
+    destination: '/docs/guides/platform/billing-on-supabase',
+  },
+  {
+    permanent: false,
+    source: '/docs/guides/platform/org-based-billing#multiple-projects-in-a-pro-plan-organization',
+    destination: '/docs/guides/platform/billing-on-supabase',
+  },
+  {
+    permanent: false,
     source: '/docs/guides/platform/spend-cap',
     destination: '/docs/guides/platform/cost-control#spend-cap',
   },

--- a/apps/www/lib/redirects.js
+++ b/apps/www/lib/redirects.js
@@ -2844,6 +2844,16 @@ module.exports = [
     source: '/partners/experts/:path*',
     destination: '/partners',
   },
+  {
+    permanent: false,
+    source: '/docs/guides/platform/org-based-billing',
+    destination: '/docs/guides/platform/billing-on-supabase',
+  },
+  {
+    permanent: false,
+    source: '/docs/guides/platform/spend-cap',
+    destination: '/docs/guides/platform/cost-control#spend-cap',
+  },
 
   // marketing
 

--- a/apps/www/lib/redirects.js
+++ b/apps/www/lib/redirects.js
@@ -2886,7 +2886,7 @@ module.exports = [
   },
   {
     permanent: false,
-    source: '/docs/docs/guides/platform/org-based-billing#project-add-ons',
+    source: '/docs/guides/platform/org-based-billing#project-add-ons',
     destination: '/docs/guides/platform/manage-your-usage',
   },
   {


### PR DESCRIPTION
This PR includes a few different things
- adds a page "About billing on Supabase"
  - supposed to be high-level. That's why there's no examples for billing or anything like that. Might be changed later (e.g. converted into a "Get started" page or somehting) but is fine for now I guess.
- adjusts links on the Dashboard to new billing docs pages
  - so far I've only adjusted existing links. Now that we have dedicated pages for different topics/usage items we could theoretically add more links to specific sections. But not part of this PR
- adds redirects from current/old billing docs pages to new pages
  - went for non-permanent links in case we change the pages of the new docs again. Unless I got something wrong regarding the redirect logic 