### PR TITLE
docs: update --db-url example in CLI docs to reflect current format

### DIFF
--- a/apps/docs/spec/cli_v1_commands.yaml
+++ b/apps/docs/spec/cli_v1_commands.yaml
@@ -3006,7 +3006,7 @@ commands:
           Linked project is up to date.
       - id: self-hosted
         name: Self hosted
-        code: supabase db push --db-url "postgres://user:pass@127.0.0.1:5432/postgres"
+        code: supabase db push --db-url "postgres://user.tenant:pass@127.0.0.1:5432"
         response: |
           Pushing migration 20230410135622_create_employees_table.sql...
           Finished supabase db push.


### PR DESCRIPTION
### **I have read the [[CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md)](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.**  
✅ **YES**  

### **What kind of change does this PR introduce?**  
📖 **Docs update**  fixes #33469 

### **What is the current behavior?**  
- The example `--db-url` format in the CLI documentation is outdated.  
- It currently shows:  
  ```
  postgres://user:pass@127.0.0.1:5432/postgres
  ```
  which is no longer valid.  
- This causes confusion, especially for self-hosted users who don’t have access to the "Connect" button in the online dashboard.  

### **What is the new behavior?**  
- Updated the `--db-url` example to the correct tenant-based format:  
  ```
  postgres://user.tenant:pass@127.0.0.1:5432
  ```

- Ensured this updated example is applied wherever `--db-url` is referenced, not just in `supabase db push`.  

