### PR TITLE
fix: local dev cache bust

### DIFF
--- a/apps/docs/features/docs/GuidesMdx.utils.tsx
+++ b/apps/docs/features/docs/GuidesMdx.utils.tsx
@@ -89,7 +89,7 @@ const getGuidesMarkdownInternal = async (slug: string[]) => {
 const getGuidesMarkdown = cache_fullProcess_withDevCacheBust(
   getGuidesMarkdownInternal,
   GUIDES_DIRECTORY,
-  (filename: string) => JSON.stringify([{ slug: filename.replace(/\.mdx$/, '').split(sep) }])
+  (filename: string) => JSON.stringify([filename.replace(/\.mdx$/, '').split(sep)])
 )
 
 const genGuidesStaticParams = (directory?: string) => async () => {


### PR DESCRIPTION
Forgot to update the cache key generation logic after we moved around all the files, so Markdown files were not cache-busting in local dev.