### PR TITLE
Small refactor to use a separate confirmation modal for right click delete user

### DIFF
--- a/apps/studio/components/interfaces/Auth/Users/UsersV2.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/UsersV2.tsx
@@ -203,11 +203,6 @@ export const UsersV2 = () => {
     500
   )
 
-  const onSelectDeleteUser = (user: User) => {
-    setSelectedUsers(new Set([user.id]))
-    setShowDeleteModal(true)
-  }
-
   const handleDeleteUsers = async () => {
     if (!projectRef) return console.error('Project ref is required')
     const userIds = [...selectedUsers]
@@ -246,7 +241,7 @@ export const UsersV2 = () => {
         users: users ?? [],
         visibleColumns: selectedColumns,
         setSortByValue,
-        onSelectDeleteUser,
+        onSelectDeleteUser: setSelectedUserToDelete,
       })
       setColumns(columns)
       if (columns.length < USERS_TABLE_COLUMNS.length) {
@@ -387,7 +382,7 @@ export const UsersV2 = () => {
                       users: users ?? [],
                       visibleColumns: value,
                       setSortByValue,
-                      onSelectDeleteUser,
+                      onSelectDeleteUser: setSelectedUserToDelete,
                     })
 
                     setSelectedColumns(value)


### PR DESCRIPTION
Just so that we don't trigger the user's checkbox when we right click to delete a user (odd UX esp if we hit cancel and the checkbox stays checked)

I had this set up previously actually, but forgot to hook it up 😓 