### PR TITLE
Use new log detail for local

### DIFF
--- a/apps/studio/components/interfaces/Settings/Logs/LogSelection.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogSelection.tsx
@@ -18,6 +18,7 @@ import type { LogData, QueryType } from './Logs.types'
 import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
 import { WarehouseSelectionRenderer } from './LogSelectionRenderers/WarehouseSelectionRenderer'
 import { useFlag } from 'hooks/ui/useFlag'
+import { IS_PLATFORM } from 'lib/constants'
 
 export interface LogSelectionProps {
   log?: LogData
@@ -35,7 +36,8 @@ const LogSelection = ({ log, onClose, queryType, isLoading, error }: LogSelectio
   const LogDetails = () => {
     if (error) return <LogErrorState error={error} />
     if (!log) return <LogDetailEmptyState />
-    if (useNewLogDetail) return <DefaultPreviewSelectionRenderer log={log} />
+    if (useNewLogDetail || IS_PLATFORM === false)
+      return <DefaultPreviewSelectionRenderer log={log} />
 
     switch (queryType) {
       case 'warehouse':

--- a/tests/local-studio-tests/supabase/config.toml
+++ b/tests/local-studio-tests/supabase/config.toml
@@ -139,8 +139,8 @@ redirect_uri = ""
 url = ""
 
 [analytics]
-enabled = false
-port = 54327
+enabled = true
+port = 54329
 vector_port = 54328
 # Configure one of the supported backends: `postgres`, `bigquery`.
 backend = "postgres"


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Uses the new Log Detail component for local.
The new Log Detail component doesnt crash when a Log doesnt have the expected structure.

Also fixes the port for analytics in config.toml for local studio tests. I plan on adding tests for logs.

## What is the current behavior?

Log Detail crashes in local studio due to the metadata field missing in logs.

## What is the new behavior?

Fixes crash and uses the new log detail component

## Related issues
#33550
