### PR TITLE
fix: show how to include generated types in SvelteKit context

### DIFF
--- a/apps/docs/content/guides/auth/server-side/sveltekit.mdx
+++ b/apps/docs/content/guides/auth/server-side/sveltekit.mdx
@@ -163,12 +163,13 @@ To prevent TypeScript errors, add type definitions for the new `event.locals` pr
 
 ```ts src/app.d.ts
 import type { Session, SupabaseClient, User } from '@supabase/supabase-js'
+import type { Database } from './database.types.ts' // import generated types
 
 declare global {
   namespace App {
     // interface Error {}
     interface Locals {
-      supabase: SupabaseClient
+      supabase: SupabaseClient<Database>
       safeGetSession: () => Promise<{ session: Session | null; user: User | null }>
       session: Session | null
       user: User | null


### PR DESCRIPTION
Resolves https://github.com/supabase/ssr/issues/89, https://github.com/supabase/supabase/issues/29235