### PR TITLE
Add E2E tests for local studio logs

### DIFF
--- a/apps/studio/components/interfaces/Settings/Logs/LogSelectionRenderers/DefaultPreviewSelectionRenderer.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogSelectionRenderers/DefaultPreviewSelectionRenderer.tsx
@@ -16,7 +16,15 @@ import { useState, useEffect } from 'react'
 
 const LogRowSeparator = () => <Separator className="bg-border my-1" />
 
-const PropertyRow = ({ keyName, value }: { keyName: string; value: any }) => {
+const PropertyRow = ({
+  keyName,
+  value,
+  dataTestId,
+}: {
+  keyName: string
+  value: any
+  dataTestId?: string
+}) => {
   const isTimestamp =
     keyName === 'timestamp' || keyName === 'created_at' || keyName === 'updated_at'
 
@@ -83,7 +91,7 @@ const PropertyRow = ({ keyName, value }: { keyName: string; value: any }) => {
 
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger className="group w-full">
+      <DropdownMenuTrigger className="group w-full" data-testid={dataTestId}>
         <div className="rounded-md w-full overflow-hidden">
           <div
             className={cn('flex py-2 w-full', {
@@ -131,10 +139,15 @@ const DefaultPreviewSelectionRenderer = ({ log }: { log: PreviewLogData }) => {
   const { timestamp, event_message, metadata, id, ...rest } = log
 
   return (
-    <div className={`p-2 flex flex-col`}>
+    <div data-testid="log-selection" className={`p-2 flex flex-col`}>
       {log?.id && <PropertyRow key={'id'} keyName={'id'} value={log.id} />}
       {log?.timestamp && (
-        <PropertyRow key={'timestamp'} keyName={'timestamp'} value={log.timestamp} />
+        <PropertyRow
+          dataTestId="log-selection-timestamp"
+          key={'timestamp'}
+          keyName={'timestamp'}
+          value={log.timestamp}
+        />
       )}
 
       {log?.event_message && (

--- a/tests/local-studio-tests/playwright.config.ts
+++ b/tests/local-studio-tests/playwright.config.ts
@@ -30,13 +30,18 @@ export default defineConfig({
     trace: 'on-first-retry',
     // record a video for failed tests, but only for local testing. We can't store videos on CI atm.
     video: 'retain-on-failure',
+    launchOptions: {
+      env: {
+        NODE_ENV: 'test',
+      },
+    },
   },
 
   /* Configure projects for major browsers */
   projects: [
     {
       name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      use: { ...devices['Desktop Chrome'], viewport: { width: 1366, height: 768 } },
     },
 
     // {

--- a/tests/local-studio-tests/tests/snapshot/spec/logs.spec.ts
+++ b/tests/local-studio-tests/tests/snapshot/spec/logs.spec.ts
@@ -1,6 +1,13 @@
 import { test, expect } from '@playwright/test'
 
-const LOGS_PAGES = ['API Gateway', 'Postgres', 'PostgREST', 'Auth', 'Storage', 'Realtime']
+const LOGS_PAGES = [
+  'API Gateway',
+  'Postgres',
+  'PostgREST',
+  // 'Auth', Wont have logs on first load
+  // 'Storage', Wont have logs on first load
+  //'Realtime' Wont have logs on first load
+]
 
 test.describe('Logs', async () => {
   for (const logPage of LOGS_PAGES) {

--- a/tests/local-studio-tests/tests/snapshot/spec/logs.spec.ts
+++ b/tests/local-studio-tests/tests/snapshot/spec/logs.spec.ts
@@ -1,0 +1,74 @@
+import { test, expect } from '@playwright/test'
+
+const LOGS_PAGES = ['API Gateway', 'Postgres', 'PostgREST', 'Auth', 'Storage', 'Realtime']
+
+test.describe('Logs', async () => {
+  for (const logPage of LOGS_PAGES) {
+    test.describe(`${logPage} logs page`, () => {
+      test('can navigate to logs page', async ({ page }) => {
+        await page.goto('http://localhost:8082/project/default')
+        await page.locator('a', { hasText: 'Logs' }).click({ timeout: 4000 })
+        await expect(page.getByText('Logs & Analytics')).toBeVisible()
+
+        // Click anywhere on the screen to close the sidebar
+        await page.click('body')
+
+        await page
+          .getByRole('link', { name: logPage, exact: true })
+          .click()
+          .catch((e) => {
+            console.log('🔴 Error clicking', logPage, e)
+            throw e
+          })
+
+        // Wait for and verify the logs table is present
+        const logsTable = page.getByRole('table')
+        await expect(logsTable).toBeVisible()
+      })
+
+      test('shows logs data without errors', async ({ page }) => {
+        // Navigate to page first
+        await page.goto('http://localhost:8082/project/default')
+        await page.locator('a', { hasText: 'Logs' }).click({ timeout: 4000 })
+        await page.click('body')
+        await page.getByRole('link', { name: logPage, exact: true }).click()
+
+        // Wait a bit and check for errors with a longer timeout
+        const error = page.getByText('Error fetching logs')
+        await expect(error).not.toBeVisible({ timeout: 10000 })
+
+        // Check if the logs table has any rows
+        const gridcells = page.getByRole('gridcell')
+        await expect(gridcells.first()).toBeVisible()
+      })
+
+      test('can select and view log details', async ({ page }) => {
+        // Navigate to page first
+        await page.goto('http://localhost:8082/project/default')
+        await page.locator('a', { hasText: 'Logs' }).click({ timeout: 4000 })
+        await page.click('body')
+        await page.getByRole('link', { name: logPage, exact: true }).click()
+
+        const gridcells = page.getByRole('gridcell')
+
+        // Click first row and verify details
+        await gridcells.first().click()
+        const tabPanel = page.getByTestId('log-selection')
+        await expect(tabPanel).toBeVisible({ timeout: 2000 })
+
+        const selectionPanelTimestamp = tabPanel.getByTestId('log-selection-timestamp')
+        await expect(selectionPanelTimestamp).toBeVisible()
+
+        const rawTimestamp = await selectionPanelTimestamp.textContent()
+        const timestamp = rawTimestamp?.replace('timestamp', '')
+        const rowText = await gridcells.first().textContent()
+        expect(rowText).toContain(timestamp)
+
+        // Click second row and verify different content
+        await gridcells.nth(1).click()
+        const tabPanelText2 = await tabPanel.textContent()
+        expect(tabPanelText2).not.toBe(rowText)
+      })
+    })
+  }
+})

--- a/tests/local-studio-tests/tests/snapshot/spec/table-editor.spec.ts
+++ b/tests/local-studio-tests/tests/snapshot/spec/table-editor.spec.ts
@@ -146,7 +146,6 @@ test.describe('Table Editor page', () => {
         'mfa_amr_claims',
         'mfa_challenges',
         'mfa_factors',
-        'one_time_tokens',
         'refresh_tokens',
         'saml_providers',
         'saml_relay_states',
@@ -154,6 +153,7 @@ test.describe('Table Editor page', () => {
         'sessions',
         'sso_domains',
         'sso_providers',
+        'users',
       ])
     )
   })

--- a/tests/local-studio-tests/tests/snapshot/spec/table-editor.spec.ts
+++ b/tests/local-studio-tests/tests/snapshot/spec/table-editor.spec.ts
@@ -130,6 +130,7 @@ test.describe('Table Editor page', () => {
         'mfa_amr_claims',
         'mfa_challenges',
         'mfa_factors',
+        'one_time_tokens',
         'refresh_tokens',
         'saml_providers',
         'saml_relay_states',
@@ -137,7 +138,6 @@ test.describe('Table Editor page', () => {
         'sessions',
         'sso_domains',
         'sso_providers',
-        'users',
       ])
     )
   })


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Adds local studio E2E tests for logs that will
- navigate to logs pages
- expect an error NOT to show
- click in a log
- expect the panel to open up and show the same timestamp as the log clicked


## What is the current behavior?

- We dont have any e2e tests for logs in local studio and if it breaks it can be painful to update and wait for the release

## What is the new behavior?

- hopefully the tests will prevent anything from breaking in local studio
