### PR TITLE
fix(docs ui): spacing of title

### DIFF
--- a/apps/docs/features/docs/GuidesMdx.template.tsx
+++ b/apps/docs/features/docs/GuidesMdx.template.tsx
@@ -79,7 +79,7 @@ const GuideTemplate = ({ meta, content, children, editLink, mdxOptions }: GuideT
           id="sb-docs-guide-main-article"
           className="prose max-w-none"
         >
-          <h1 className="mb-0">
+          <h1 className="mb-0 [&>p]:m-0">
             <ReactMarkdown>{meta?.title || 'Supabase Docs'}</ReactMarkdown>
           </h1>
           {meta?.subtitle && (


### PR DESCRIPTION
A `p` element appeared in the heading after we started using ReactMarkdonw to format it, which adds an extra margin. Need to get rid of it to restore spacing to what it was before.
