### PR TITLE
Docs: Fix a small error in an example

### DIFF
--- a/apps/docs/content/guides/local-development/testing/overview.mdx
+++ b/apps/docs/content/guides/local-development/testing/overview.mdx
@@ -54,7 +54,7 @@ This example demonstrates setting up and testing RLS policies for a simple todo 
    -- install tests utilities
    -- install pgtap extension for testing
    create extension if not exists pgtap with schema extensions;
-   -- Start declare we'll have 6 test cases in our test suite
+   -- Start declare we'll have 4 test cases in our test suite
    select plan(4);
 
    -- Setup our testing data


### PR DESCRIPTION
In the example it says it will declare 6 test cases, but it declares 4.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update
