### PR TITLE
Fix height of storage panel

### DIFF
--- a/apps/studio/components/ui/InfiniteList.tsx
+++ b/apps/studio/components/ui/InfiniteList.tsx
@@ -111,33 +111,34 @@ function InfiniteList<T, P>({
 
   return (
     <>
-      <AutoSizer>
-        {({ height, width }: { height: number; width: number }) => (
-          <InfiniteLoader
-            itemCount={itemCount}
-            isItemLoaded={isItemLoaded}
-            loadMoreItems={loadMoreItems}
-          >
-            {({ onItemsRendered, ref }) => (
-              <VariableSizeList
-                ref={(refy) => {
-                  ref(refy)
-                  listRef.current = refy
-                }}
-                height={height ?? 0}
-                width={width ?? 0}
-                itemCount={itemCount}
-                itemData={itemData}
-                itemSize={getItemSize}
-                onItemsRendered={onItemsRendered}
-              >
-                {Item}
-              </VariableSizeList>
-            )}
-          </InfiniteLoader>
-        )}
-      </AutoSizer>
-
+      <div className="flex-grow">
+        <AutoSizer>
+          {({ height, width }: { height: number; width: number }) => (
+            <InfiniteLoader
+              itemCount={itemCount}
+              isItemLoaded={isItemLoaded}
+              loadMoreItems={loadMoreItems}
+            >
+              {({ onItemsRendered, ref }) => (
+                <VariableSizeList
+                  ref={(refy) => {
+                    ref(refy)
+                    listRef.current = refy
+                  }}
+                  height={height ?? 0}
+                  width={width ?? 0}
+                  itemCount={itemCount}
+                  itemData={itemData}
+                  itemSize={getItemSize}
+                  onItemsRendered={onItemsRendered}
+                >
+                  {Item}
+                </VariableSizeList>
+              )}
+            </InfiniteLoader>
+          )}
+        </AutoSizer>
+      </div>
       <div
         style={{
           position: 'absolute',


### PR DESCRIPTION
Just wraps the <autosizer> component in the flex-grow div. 
Problem seemed to be introduced with the layouts PR last week

The top storage item is always hidden behind the header:
https://share.cleanshot.com/6NDTxKXb

Note:  I checked the other instances of this InfiniteList component and all seem good to me.
