### PR TITLE
fix(docs): "Read Documentation"-button gives 404

### DIFF
--- a/apps/www/data/features.tsx
+++ b/apps/www/data/features.tsx
@@ -1550,7 +1550,7 @@ By utilizing the Supabase Management API, you can create more efficient, scalabl
     products: [ADDITIONAL_PRODUCTS.PLATFORM],
     heroImage: '/images/features/management-api.png',
     heroImageLight: '/images/features/management-api-light.png',
-    docsUrl: 'https://supabase.com/docs/guides/project-management/api',
+    docsUrl: 'https://supabase.com/docs/reference/api/introduction',
     slug: 'management-api',
     status: {
       stage: PRODUCT_STAGES.GA,


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The "Read Documentation"-button links to a non-existing page (404). 

## What is the new behavior?

The "Read Documentation"-button links to the Management API docs
