### PR TITLE
fix: disk config layout gap

### DIFF
--- a/apps/studio/components/interfaces/DiskManagement/fields/ComputeSizeField.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/fields/ComputeSizeField.tsx
@@ -122,6 +122,7 @@ export function ComputeSizeField({ form, disabled }: ComputeSizeFieldProps) {
             layout="horizontal"
             label={'Compute size'}
             id={field.name}
+            className="md:flex lg:grid gap-4 lg:gap-2"
             labelOptional={
               <>
                 <BillingChangeBadge

--- a/packages/ui-patterns/form/Layout/FormLayout.tsx
+++ b/packages/ui-patterns/form/Layout/FormLayout.tsx
@@ -42,7 +42,7 @@ const ContainerVariants = cva('relative grid gap-10', {
       false: '',
     },
     layout: {
-      horizontal: 'flex flex-col gap-2 md:gap-0 md:grid md:grid-cols-12',
+      horizontal: 'flex flex-col gap-2 md:grid md:grid-cols-12',
       vertical: 'flex flex-col gap-3',
       flex: 'flex flex-row gap-3',
       'flex-row-reverse': 'flex flex-row gap-3 flex-row-reverse justify-between',


### PR DESCRIPTION
## Before
- Missing gap
<img width="1025" alt="Screenshot 2025-02-18 at 15 56 48" src="https://github.com/user-attachments/assets/69a8735d-8ead-488c-b7cd-c6c215d79ca4" />

- Content overflowing for insufficient space
<img width="786" alt="Screenshot 2025-02-18 at 16 00 38" src="https://github.com/user-attachments/assets/46e1f539-e78d-4850-9217-cd81567cc137" />

## After

<img width="1137" alt="Screenshot 2025-02-18 at 15 57 09" src="https://github.com/user-attachments/assets/3117bd49-2810-410c-bcc2-d589e608583c" />

<img width="926" alt="Screenshot 2025-02-18 at 16 01 25" src="https://github.com/user-attachments/assets/3a85f54b-884b-46bd-8f73-1a8da98f2019" />
