### PR TITLE
Query logs from Assistant

### DIFF
--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistant.types.ts
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistant.types.ts
@@ -5,6 +5,7 @@ export interface AssistantSnippetProps {
   title?: string
   isChart?: string
   runQuery?: string
+  logs?: string
   xAxis?: string
   yAxis?: string
   name?: string

--- a/apps/studio/components/ui/AIAssistantPanel/MessageMarkdown.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/MessageMarkdown.tsx
@@ -167,8 +167,6 @@ export const MarkdownPre = ({ children }: { children: any }) => {
   const runQuery = snippetProps.runQuery === 'true'
   const isLogs = snippetProps.logs === 'true'
 
-  console.log('raw:', rawContent, snippetProps, isLogs)
-
   // Strip props from the content for both SQL and edge functions
   const cleanContent = rawContent.replace(/(?:--|\/\/)\s*props:\s*\{[^}]+\}/, '').trim()
 
@@ -227,7 +225,12 @@ export const MarkdownPre = ({ children }: { children: any }) => {
             onDragStart={(e: DragEvent<Element>) => {
               e.dataTransfer.setData(
                 'application/json',
-                JSON.stringify({ label: title, sql: cleanContent, config: chartConfig.current })
+                JSON.stringify({
+                  label: title,
+                  sql: cleanContent,
+                  isLogs,
+                  config: chartConfig.current,
+                })
               )
             }}
           />

--- a/apps/studio/components/ui/AIAssistantPanel/MessageMarkdown.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/MessageMarkdown.tsx
@@ -62,6 +62,7 @@ const MemoizedQueryBlock = memo(
     isLoading,
     isDraggable,
     runQuery,
+    logs,
     onRunQuery,
     onDragStart,
     onUpdateChartConfig,
@@ -74,6 +75,7 @@ const MemoizedQueryBlock = memo(
     isLoading: boolean
     isDraggable: boolean
     runQuery: boolean
+    logs?: boolean
     onRunQuery: (queryType: 'select' | 'mutation') => void
     onDragStart: (e: DragEvent<Element>) => void
     onUpdateChartConfig?: ({
@@ -97,6 +99,7 @@ const MemoizedQueryBlock = memo(
         lockColumns
         label={title}
         sql={sql}
+        logs={logs}
         chartConfig={{
           type: 'bar',
           cumulative: false,
@@ -162,6 +165,9 @@ export const MarkdownPre = ({ children }: { children: any }) => {
   const title = snippetProps.title || (language === 'edge' ? 'Edge Function' : 'SQL Query')
   const isChart = snippetProps.isChart === 'true'
   const runQuery = snippetProps.runQuery === 'true'
+  const isLogs = snippetProps.logs === 'true'
+
+  console.log('raw:', rawContent, snippetProps, isLogs)
 
   // Strip props from the content for both SQL and edge functions
   const cleanContent = rawContent.replace(/(?:--|\/\/)\s*props:\s*\{[^}]+\}/, '').trim()
@@ -213,6 +219,7 @@ export const MarkdownPre = ({ children }: { children: any }) => {
             isLoading={isLoading}
             isDraggable={isDraggableToReports}
             runQuery={runQuery}
+            logs={isLogs}
             onRunQuery={onRunQuery}
             onUpdateChartConfig={({ chartConfig: config }) => {
               chartConfig.current = { ...chartConfig.current, ...config }

--- a/apps/studio/components/ui/QueryBlock/QueryBlock.tsx
+++ b/apps/studio/components/ui/QueryBlock/QueryBlock.tsx
@@ -1,7 +1,6 @@
 import { Code, ExternalLink, Play } from 'lucide-react'
 import { DragEvent, ReactNode, useEffect, useMemo, useState } from 'react'
 import { Bar, BarChart, CartesianGrid, XAxis } from 'recharts'
-import { toast } from 'sonner'
 import Link from 'next/link'
 
 import { useParams } from 'common'

--- a/apps/studio/pages/api/ai/sql/generate-v3.ts
+++ b/apps/studio/pages/api/ai/sql/generate-v3.ts
@@ -135,6 +135,27 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse) {
         # You convert sql to supabase-js client code
         Use the convertSqlToSupabaseJs tool to convert select sql to supabase-js client code. Only provide js code snippets if explicitly asked. If conversion isn't supported, build a postgres function instead and suggest using supabase-js to call it via  "const { data, error } = await supabase.rpc('echo', { say: '👋'})"
   
+        # You write log queries for the Supabase Logs Explorer
+        Your purpose is to help users write effective queries for the Supabase Logs Explorer.
+        - First, always use the getLogsExplorerKnowledge tool to get knowledge about how to write log queries
+        - When writing log queries, follow these guidelines:
+          - Always use DATETIME() to format timestamps in a human-readable way
+          - Always include appropriate UNNEST joins when accessing nested fields
+          - Always include a LIMIT clause (max 1000 rows)
+          - Always include appropriate timestamp filters to optimize performance
+          - Avoid selecting entire nested objects, select specific fields instead
+          - When outputting queries, always include a props comment in the first line where logs is set to true:
+            -- props: {"title": "Log Query", "logs": "true", "runQuery": "true"}
+        - The Logs Explorer uses BigQuery syntax and supports all BigQuery functions and operators
+        - Available log sources include:
+          - auth_logs: Authentication/authorization activity
+          - edge_logs: Edge network requests and responses
+          - function_edge_logs: Edge function network activity
+          - function_logs: Edge function console logs
+          - postgres_logs: Database statements
+          - realtime_logs: Client connection information
+          - storage_logs: Object upload and retrieval
+  
         # For all your abilities, follow these instructions:
         - First look at the list of provided schemas and if needed, get more information about a schema. You will almost always need to retrieve information about the public schema before answering a question.
         - If the question is about users or involves creating a users table, also retrieve the auth schema.

--- a/apps/studio/pages/api/ai/sql/generate-v3.ts
+++ b/apps/studio/pages/api/ai/sql/generate-v3.ts
@@ -147,6 +147,7 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse) {
           - When outputting queries, always include a props comment in the first line where logs is set to true:
             -- props: {"title": "Log Query", "logs": "true", "runQuery": "true"}
         - The Logs Explorer uses BigQuery syntax and supports all BigQuery functions and operators
+        - The Logs Explorer will show the last one hour of logs by default.
         - Available log sources include:
           - auth_logs: Authentication/authorization activity
           - edge_logs: Edge network requests and responses

--- a/apps/studio/pages/api/ai/sql/tools.ts
+++ b/apps/studio/pages/api/ai/sql/tools.ts
@@ -685,6 +685,25 @@ export const getTools = ({
         LIMIT 1000;
         \`\`\`
 
+        ### Slowest queries
+
+        \`\`\`sql
+        SELECT 
+          DATETIME(pl.timestamp) AS time,
+          p.command_tag,
+          p.backend_type,
+          p.connection_from
+      FROM 
+        postgres_logs AS pl
+      CROSS JOIN UNNEST(pl.metadata) AS m
+      CROSS JOIN UNNEST(m.parsed) AS p
+      WHERE 
+        p.command_tag IS NOT NULL
+        ORDER BY 
+          pl.timestamp DESC
+        LIMIT 1000;
+        \`\`\`
+
         ### Filter logs by time range:
         \`\`\`sql
         SELECT 

--- a/apps/studio/pages/api/ai/sql/tools.ts
+++ b/apps/studio/pages/api/ai/sql/tools.ts
@@ -707,6 +707,7 @@ export const getTools = ({
 
         Below is the complete field reference for each log source. To access nested fields, you'll need to use the appropriate UNNEST joins as shown in the examples above.
 
+        
         ### Function Edge Logs (\`function_edge_logs\`)
 
         | Field | Type |
@@ -837,6 +838,105 @@ export const getTools = ({
         | metadata.remote_addr | string |
         | metadata.status | number |
         | metadata.timestamp | string |
+
+        ### Storage Logs (\`storage_logs\`)
+
+        | Field | Type |
+        |-------|------|
+        | event_message | string |
+        | id | string |
+        | timestamp | datetime |
+        | metadata.context.host | string |
+        | metadata.context.pid | number |
+        | metadata.level | string |
+        | metadata.project | string |
+        | metadata.req.headers.accept | string |
+        | metadata.req.headers.cf_connecting_ip | string |
+        | metadata.req.headers.cf_ray | string |
+        | metadata.req.headers.content_length | string |
+        | metadata.req.headers.content_type | string |
+        | metadata.req.headers.host | string |
+        | metadata.req.headers.referer | string |
+        | metadata.req.headers.user_agent | string |
+        | metadata.req.headers.x_client_info | string |
+        | metadata.req.headers.x_forwarded_proto | string |
+        | metadata.req.hostname | string |
+        | metadata.req.method | string |
+        | metadata.req.remoteAddress | string |
+        | metadata.req.remotePort | number |
+        | metadata.req.url | string |
+        | metadata.reqId | string |
+        | metadata.res.statusCode | number |
+        | metadata.res.headers.content_length | number |
+        | metadata.res.headers.content_type | string |
+        | metadata.responseTime | number |
+        | metadata.tenantId | string |
+        | metadata.rawError | string |
+
+        ### Function Runtime Logs (\`function_logs\`)
+
+        | Field | Type |
+        |-------|------|
+        | event_message | string |
+        | id | string |
+        | timestamp | datetime |
+        | metadata.deployment_id | string |
+        | metadata.event_type | string |
+        | metadata.execution_id | string |
+        | metadata.function_id | string |
+        | metadata.level | string |
+        | metadata.project_ref | string |
+        | metadata.region | string |
+        | metadata.timestamp | string |
+        | metadata.version | string |
+
+        ### Postgres Logs (\`postgres_logs\`)
+
+        | Field | Type |
+        |-------|------|
+        | event_message | string |
+        | id | string |
+        | timestamp | datetime |
+        | identifier | string |
+        | metadata.host | string |
+        | metadata.parsed.backend_type | string |
+        | metadata.parsed.command_tag | string |
+        | metadata.parsed.connection_from | string |
+        | metadata.parsed.database_name | string |
+        | metadata.parsed.error_severity | string |
+        | metadata.parsed.process_id | number |
+        | metadata.parsed.query_id | number |
+        | metadata.parsed.session_id | string |
+        | metadata.parsed.session_line_num | number |
+        | metadata.parsed.session_start_time | string |
+        | metadata.parsed.sql_state_code | string |
+        | metadata.parsed.timestamp | string |
+        | metadata.parsed.transaction_id | number |
+        | metadata.parsed.user_name | string |
+        | metadata.parsed.virtual_transaction_id | string |
+
+        ### Realtime Logs (\`realtime_logs\`)
+
+        | Field | Type |
+        |-------|------|
+        | event_message | string |
+        | id | string |
+        | timestamp | datetime |
+        | metadata.level | string |
+        | metadata.measurements.connected | number |
+        | metadata.measurements.connected_cluster | number |
+        | metadata.measurements.limit | number |
+        | metadata.measurements.sum | number |
+        | metadata.external_id | string |
+
+        ### Supavisor Logs (\`supavisor_logs\`)
+
+        | Field | Type |
+        |-------|------|
+        | event_message | string |
+        | id | string |
+        | timestamp | datetime |
+        | metadata.host | string |
 
         Example query using nested fields:
         \`\`\`sql


### PR DESCRIPTION

<img width="1088" alt="image" src="https://github.com/user-attachments/assets/dfd548a5-8e26-4f1b-ba77-ce9a1225809f" />


## What kind of change does this PR introduce?

This makes it possible to query logging sources directly from the assistant.

## What is the current behavior?

Assistant has no knowledge or ability to query logs.

## What is the new behavior?

Assistant now has knowledge and access to logging sources.

The changes we've made to make this possible:
- A tool that returns knowledge around how to query logs, including sources and available fields
- Adjusting to generate-v3 to include a section on how to query logs
- An update to QueryBlock that checks to see if query written by Assistant is a logs query, and if it is it will use a separate useQueryLogs hook vs executeSql. 
- QueryBlock edit links to logs explorer vs SQL Editor

