### PR TITLE
fix: run `next build` directly instead of `build` task to avoid uploading static assets when building image

### DIFF
--- a/apps/studio/Dockerfile
+++ b/apps/studio/Dockerfile
@@ -51,7 +51,7 @@ CMD ["pnpm", "dev:studio"]
 # Compile Next.js
 FROM dev AS builder
 
-RUN pnpm dlx turbo@2.3.3 run build --filter studio -- --no-lint
+RUN pnpm --filter studio exec next build
 
 # Copy only compiled code and dependencies
 FROM base AS production


### PR DESCRIPTION
Was broken by #33344, which changed `build` task from `next build` to
`next build && ./../../scripts/upload-static-assets.sh`.