### PR TITLE
Update org roles confirmation to fire requests sequentially

### DIFF
--- a/apps/studio/components/interfaces/Organization/TeamSettings/UpdateRolesPanel/UpdateRolesConfirmationModal.tsx
+++ b/apps/studio/components/interfaces/Organization/TeamSettings/UpdateRolesPanel/UpdateRolesConfirmationModal.tsx
@@ -106,10 +106,11 @@ export const UpdateRolesConfirmationModal = ({
           gotrueId,
           roleId,
           projects: projectIds.map((id) => projects?.find((p) => p.id === id)?.ref) as string[],
+          skipInvalidation: true,
         })
       }
       for (const roleId of toRemove) {
-        await removeRole({ slug, gotrueId, roleId })
+        await removeRole({ slug, gotrueId, roleId, skipInvalidation: true })
       }
       for (const { roleId, projectIds } of toUpdate) {
         await updateRole({
@@ -118,6 +119,7 @@ export const UpdateRolesConfirmationModal = ({
           roleId,
           roleName: project_scoped_roles.find((r) => r.id === roleId)?.name as string,
           projects: projectIds.map((id) => projects?.find((p) => p.id === id)?.ref) as string[],
+          skipInvalidation: true,
         })
       }
 

--- a/apps/studio/components/interfaces/Organization/TeamSettings/UpdateRolesPanel/UpdateRolesConfirmationModal.tsx
+++ b/apps/studio/components/interfaces/Organization/TeamSettings/UpdateRolesPanel/UpdateRolesConfirmationModal.tsx
@@ -112,7 +112,7 @@ export const UpdateRolesConfirmationModal = ({
         await removeRole({ slug, gotrueId, roleId })
       }
       for (const { roleId, projectIds } of toUpdate) {
-        updateRole({
+        await updateRole({
           slug,
           gotrueId,
           roleId,

--- a/apps/studio/components/interfaces/Organization/TeamSettings/UpdateRolesPanel/UpdateRolesConfirmationModal.tsx
+++ b/apps/studio/components/interfaces/Organization/TeamSettings/UpdateRolesPanel/UpdateRolesConfirmationModal.tsx
@@ -100,28 +100,26 @@ export const UpdateRolesConfirmationModal = ({
     const { toRemove, toAssign, toUpdate } = deriveRoleChangeActions(existingRoles, changesToRoles)
 
     try {
-      await Promise.all([
-        ...toAssign.map(({ roleId, projectIds }) =>
-          assignRole({
-            slug,
-            gotrueId,
-            roleId,
-            projects: projectIds.map((id) => projects?.find((p) => p.id === id)?.ref) as string[],
-          })
-        ),
-      ])
-      await Promise.all([
-        ...toRemove.map((roleId) => removeRole({ slug, gotrueId, roleId })),
-        ...toUpdate.map(({ roleId, projectIds }) =>
-          updateRole({
-            slug,
-            gotrueId,
-            roleId,
-            roleName: project_scoped_roles.find((r) => r.id === roleId)?.name as string,
-            projects: projectIds.map((id) => projects?.find((p) => p.id === id)?.ref) as string[],
-          })
-        ),
-      ])
+      for (const { roleId, projectIds } of toAssign) {
+        await assignRole({
+          slug,
+          gotrueId,
+          roleId,
+          projects: projectIds.map((id) => projects?.find((p) => p.id === id)?.ref) as string[],
+        })
+      }
+      for (const roleId of toRemove) {
+        await removeRole({ slug, gotrueId, roleId })
+      }
+      for (const { roleId, projectIds } of toUpdate) {
+        updateRole({
+          slug,
+          gotrueId,
+          roleId,
+          roleName: project_scoped_roles.find((r) => r.id === roleId)?.name as string,
+          projects: projectIds.map((id) => projects?.find((p) => p.id === id)?.ref) as string[],
+        })
+      }
 
       await Promise.all([
         queryClient.invalidateQueries(organizationKeys.rolesV2(slug)),


### PR DESCRIPTION
Changes do not affect local/self-host set up

Updates assigning, removing and updating organization roles to be fully sequential instead of parallel