### PR TITLE
Decouple updating disk size from retrieving disk util

### DIFF
--- a/apps/studio/components/interfaces/DiskManagement/DiskManagementForm.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagementForm.tsx
@@ -292,10 +292,10 @@ export function DiskManagementForm() {
 
   useEffect(() => {
     // Initialize field values properly when data has been loaded, preserving any user changes
-    if (isSuccess) {
+    if (isDiskAttributesSuccess || isSuccess) {
       form.reset(defaultValues, {})
     }
-  }, [isSuccess])
+  }, [isSuccess, isDiskAttributesSuccess])
 
   // Redirect logic incase disk and compute feature is not live yet
   useEffect(() => {

--- a/apps/studio/components/interfaces/DiskManagement/fields/DiskSizeField.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/fields/DiskSizeField.tsx
@@ -2,6 +2,7 @@ import { UseFormReturn } from 'react-hook-form'
 
 import { InputVariants } from '@ui/components/shadcn/ui/input'
 import { useParams } from 'common'
+import { DocsButton } from 'components/ui/DocsButton'
 import { useDiskAttributesQuery } from 'data/config/disk-attributes-query'
 import { useDiskUtilizationQuery } from 'data/config/disk-utilization-query'
 import { useOrgSubscriptionQuery } from 'data/subscriptions/org-subscription-query'
@@ -19,9 +20,6 @@ import { DiskTypeRecommendationSection } from '../ui/DiskTypeRecommendationSecti
 import FormMessage from '../ui/FormMessage'
 import { InputPostTab } from '../ui/InputPostTab'
 import { InputResetButton } from '../ui/InputResetButton'
-import { Admonition } from 'ui-patterns'
-import Markdown from 'markdown-to-jsx'
-import { DocsButton } from 'components/ui/DocsButton'
 
 type DiskSizeFieldProps = {
   form: UseFormReturn<DiskStorageSchemaType>
@@ -39,6 +37,7 @@ export function DiskSizeField({
   const org = useSelectedOrganization()
 
   const {
+    data,
     isLoading: isLoadingDiskAttributes,
     error: diskAttributesError,
     isError: isDiskAttributesError,
@@ -59,6 +58,8 @@ export function DiskSizeField({
   } = useDiskUtilizationQuery({
     projectRef: projectRef,
   })
+
+  console.log(data)
 
   const isLoading = isSubscriptionLoading || isDiskUtilizationLoading || isLoadingDiskAttributes
   const error = subscriptionError || diskUtilError || diskAttributesError
@@ -94,7 +95,7 @@ export function DiskSizeField({
             <FormItemLayout label="Disk Size" layout="vertical" id={field.name}>
               <div className="relative flex gap-2 items-center">
                 <InputPostTab label="GB">
-                  {isLoading ? (
+                  {isLoadingDiskAttributes ? (
                     <div
                       className={cn(
                         InputVariants({ size: 'small' }),

--- a/apps/studio/components/interfaces/DiskManagement/fields/DiskSizeField.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/fields/DiskSizeField.tsx
@@ -37,7 +37,6 @@ export function DiskSizeField({
   const org = useSelectedOrganization()
 
   const {
-    data,
     isLoading: isLoadingDiskAttributes,
     error: diskAttributesError,
     isError: isDiskAttributesError,

--- a/apps/studio/components/interfaces/DiskManagement/fields/DiskSizeField.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/fields/DiskSizeField.tsx
@@ -44,7 +44,6 @@ export function DiskSizeField({
   } = useDiskAttributesQuery({ projectRef })
   const {
     data: subscription,
-    isLoading: isSubscriptionLoading,
     error: subscriptionError,
     isError: isSubscriptionError,
   } = useOrgSubscriptionQuery({
@@ -52,16 +51,12 @@ export function DiskSizeField({
   })
   const {
     data: diskUtil,
-    isLoading: isDiskUtilizationLoading,
     error: diskUtilError,
     isError: isDiskUtilizationError,
   } = useDiskUtilizationQuery({
     projectRef: projectRef,
   })
 
-  console.log(data)
-
-  const isLoading = isSubscriptionLoading || isDiskUtilizationLoading || isLoadingDiskAttributes
   const error = subscriptionError || diskUtilError || diskAttributesError
   const isError = isSubscriptionError || isDiskUtilizationError || isDiskAttributesError
 


### PR DESCRIPTION
Mainly to support updating disk size, despite disk util failing

Just need to verify on hosted:
- Create a new project
- Jump straight to compute and disk
- Try to update the disk size
- Verify that only the disk size is being updated from the network requests