### PR TITLE
Reinstate SQL editor results events

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityPanel.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityPanel.tsx
@@ -1,9 +1,12 @@
 import { toast } from 'sonner'
 
 import { useParams } from 'common'
+import { TelemetryActions } from 'common/telemetry-constants'
 import { DownloadResultsButton } from 'components/ui/DownloadResultsButton'
 import { useContentUpsertMutation } from 'data/content/content-upsert-mutation'
 import { Snippet } from 'data/content/sql-folders-query'
+import { useSendEventMutation } from 'data/telemetry/send-event-mutation'
+import { useSelectedOrganization } from 'hooks/misc/useSelectedOrganization'
 import { useSqlEditorV2StateSnapshot } from 'state/sql-editor-v2'
 import { TabsContent_Shadcn_, TabsList_Shadcn_, TabsTrigger_Shadcn_, Tabs_Shadcn_ } from 'ui'
 import { ChartConfig } from './ChartConfig'
@@ -41,10 +44,13 @@ const UtilityPanel = ({
   onDebug,
 }: UtilityPanelProps) => {
   const { ref } = useParams()
+  const org = useSelectedOrganization()
   const snapV2 = useSqlEditorV2StateSnapshot()
 
   const snippet = snapV2.snippets[id]?.snippet
   const result = snapV2.results[id]?.[0]
+
+  const { mutate: sendEvent } = useSendEventMutation()
 
   const { mutate: upsertContent } = useContentUpsertMutation({
     invalidateQueriesOnSuccess: false,
@@ -119,6 +125,24 @@ const UtilityPanel = ({
               type="text"
               results={result.rows as any[]}
               fileName={`Supabase Snippet ${snippet.name}`}
+              onDownloadAsCSV={() =>
+                sendEvent({
+                  action: TelemetryActions.SQL_EDITOR_RESULT_DOWNLOAD_CSV_CLICKED,
+                  groups: { project: ref ?? '', organization: org?.slug ?? '' },
+                })
+              }
+              onCopyAsMarkdown={() => {
+                sendEvent({
+                  action: TelemetryActions.SQL_EDITOR_RESULT_COPY_MARKDOWN_CLICKED,
+                  groups: { project: ref ?? '', organization: org?.slug ?? '' },
+                })
+              }}
+              onCopyAsJSON={() => {
+                sendEvent({
+                  action: TelemetryActions.SQL_EDITOR_RESULT_COPY_JSON_CLICKED,
+                  groups: { project: ref ?? '', organization: org?.slug ?? '' },
+                })
+              }}
             />
           )}
         </div>

--- a/apps/studio/components/ui/DownloadResultsButton.tsx
+++ b/apps/studio/components/ui/DownloadResultsButton.tsx
@@ -18,6 +18,7 @@ interface DownloadResultsButtonProps {
   align?: 'start' | 'center' | 'end'
   results: any[]
   fileName: string
+  onDownloadAsCSV?: () => void
   onCopyAsMarkdown?: () => void
   onCopyAsJSON?: () => void
 }
@@ -27,6 +28,7 @@ export const DownloadResultsButton = ({
   align = 'start',
   results,
   fileName,
+  onDownloadAsCSV,
   onCopyAsMarkdown,
   onCopyAsJSON,
 }: DownloadResultsButtonProps) => {
@@ -93,6 +95,7 @@ export const DownloadResultsButton = ({
             onClick={() => {
               csvRef.current?.link.click()
               toast.success('Downloading results as CSV')
+              onDownloadAsCSV?.()
             }}
           >
             <Download size={14} />

--- a/apps/studio/data/sql/execute-sql-mutation.ts
+++ b/apps/studio/data/sql/execute-sql-mutation.ts
@@ -43,7 +43,6 @@ export const useExecuteSqlMutation = ({
         // [Joshen] Default to false for now, only used for SQL editor to dynamically invalidate
         if (contextualInvalidation && projectRef) {
           const invalidationKeys = inferInvalidationKeys(projectRef, sql)
-          console.log({ invalidationKeys })
           await Promise.all(invalidationKeys.map((key) => queryClient.invalidateQueries(key)))
         }
         await onSuccess?.(data, variables, context)

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -45,7 +45,7 @@ export enum TelemetryActions {
   SQL_EDITOR_TEMPLATE_CLICKED = 'sql_editor_template_clicked',
   SQL_EDITOR_RESULT_DOWNLOAD_CSV_CLICKED = 'sql_editor_result_download_csv_clicked',
   SQL_EDITOR_RESULT_COPY_MARKDOWN_CLICKED = 'sql_editor_result_copy_markdown_clicked',
-  SQL_EDITOR_RESULT_COPY_JSON_CLICKED = 'sql_editor_result_copy_markdown_clicked',
+  SQL_EDITOR_RESULT_COPY_JSON_CLICKED = 'sql_editor_result_copy_json_clicked',
 
   DOCS_FEEDBACK_CLICKED = 'docs_feedback_clicked',
 


### PR DESCRIPTION
Reinstate the following 3 events for SQL editor results
- SQL_EDITOR_RESULT_DOWNLOAD_CSV_CLICKED
- SQL_EDITOR_RESULT_COPY_MARKDOWN_CLICKED
- SQL_EDITOR_RESULT_COPY_JSON_CLICKED