### PR TITLE
move templates in inline editor

### DIFF
--- a/apps/studio/components/ui/AIEditor/index.tsx
+++ b/apps/studio/components/ui/AIEditor/index.tsx
@@ -218,6 +218,20 @@ const AIEditor = ({
   }, [value, defaultValue])
 
   useEffect(() => {
+    if (initialPrompt) {
+      setPromptInput(initialPrompt)
+      setPromptState({
+        isOpen: Boolean(initialPrompt),
+        selection: '',
+        beforeSelection: '',
+        afterSelection: '',
+        startLineNumber: 0,
+        endLineNumber: 0,
+      })
+    }
+  }, [initialPrompt])
+
+  useEffect(() => {
     if (!isDiffMode) {
       setIsDiffEditorMounted(false)
     }


### PR DESCRIPTION

<img width="1008" alt="image" src="https://github.com/user-attachments/assets/115cbed1-b136-438d-86d1-4ace2ce8f0d4" />

## What kind of change does this PR introduce?

This moves the template selector from the bottom of the inline editor to the top. It uses a hover card for peeking at template code rather than replacing editor code. We aren't affecting editor state that way and can compare to our existing code too.

This PR also makes it so you can change prompt externally and have it show up.

## Steps to test

1. Enable the inline editor feature preview
2. Open editor
3. Click templates in top right
4. See list of templates
5. Hover templates to see preview
6. Click to insert
