### PR TITLE
feat: improve MobileSheetNav visibility with border

### DIFF
--- a/packages/ui-patterns/MobileSheetNav/MobileSheetNav.tsx
+++ b/packages/ui-patterns/MobileSheetNav/MobileSheetNav.tsx
@@ -32,7 +32,7 @@ const MobileSheetNav: React.FC<{
         side="bottom"
         className={cn(
           'rounded-t-lg overflow-hidden overflow-y-scroll',
-          'h-[85dvh] md:max-h-[500px] py-2'
+          'h-[85dvh] md:max-h-[500px] py-2 border border-b-0'
         )}
       >
         <ErrorBoundary FallbackComponent={() => <CommandEmpty_Shadcn_ />}>{children}</ErrorBoundary>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Improving mobile user experience

## What is the current behavior?

The colors inside and outside the sheet are similar, making the boundary unclear, especially in light mode.

## What is the new behavior?

It seems to be about 1% more distinguishable.

**Before:**
![before](https://github.com/user-attachments/assets/a12bf455-7ddd-459a-b82f-431394d4be92)

**After:**
![after](https://github.com/user-attachments/assets/eb1a773b-972f-4689-8b17-b75556b8a68a)


## Additional context

I initially submitted [PR #33174](https://github.com/supabase/supabase/pull/33174) adding a header to improve sheet/background visibility in light mode. As requested, I've created this new PR to keep only the border addition while maintaining the current design pattern.


