### PR TITLE
docs: add Notion Wasm FDW docs

### DIFF
--- a/apps/docs/app/guides/database/extensions/wrappers/[[...slug]]/page.tsx
+++ b/apps/docs/app/guides/database/extensions/wrappers/[[...slug]]/page.tsx
@@ -86,6 +86,13 @@ const pageMap = [
     remoteFile: 'mssql.md',
   },
   {
+    slug: 'notion',
+    meta: {
+      title: 'Notion',
+    },
+    remoteFile: 'notion.md',
+  },
+  {
     slug: 'paddle',
     meta: {
       title: 'Paddle',

--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
@@ -1108,6 +1108,10 @@ export const database: NavMenuConstant = {
           url: '/guides/database/extensions/wrappers/mssql',
         },
         {
+          name: 'Connecting to Notion',
+          url: '/guides/database/extensions/wrappers/notion',
+        },
+        {
           name: 'Connecting to Paddle',
           url: '/guides/database/extensions/wrappers/paddle',
         },


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

This PR is to add docs for Notion Wasm FDW.

## What is the current behavior?

N/A

## What is the new behavior?

N/A

## Additional context

N/A
