### PR TITLE
fix: destructive query warning on run button

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/RunButton.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/RunButton.tsx
@@ -19,9 +19,13 @@ export const SqlRunButton = ({
 }: SqlRunButtonProps) => {
   const os = detectOS()
 
+  function handleOnClick() {
+    onClick()
+  }
+
   return (
     <Button
-      onClick={onClick}
+      onClick={handleOnClick}
       disabled={isDisabled}
       type="primary"
       size="tiny"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Clicking the run button does not open the destructive query warning modal because the event parameter of the button is being passed to the `executeQuery` method, which is acting as a truthy value for the `force` parameter.

## What is the new behavior?

The event parameter is no longer passed so the query will not be force ran.