### PR TITLE
chore(docs): add spelling exception

### DIFF
--- a/supa-mdx-lint/Rule003Spelling.toml
+++ b/supa-mdx-lint/Rule003Spelling.toml
@@ -75,6 +75,7 @@ allow_list = [
     "[Pp]laintext",
     "[Pp]olyfill(s|ed)?",
     "[Pp]oolers?",
+    "[Pp]resign(ed|ing)?",
     "[Pp]sycopg",
     "[Qq]uickstarts?",
     "[Rr]ealtime",


### PR DESCRIPTION
Presigned/presigning should be allowed