### PR TITLE
chore: clarify bursting and recommend compute

### DIFF
--- a/apps/docs/content/guides/platform/compute-and-disk.mdx
+++ b/apps/docs/content/guides/platform/compute-and-disk.mdx
@@ -98,7 +98,7 @@ The compute size of your project sets the upper limit for disk throughput and IO
 | 12XL             | 14,250 MiB/s    | 50,000 IOPS |
 | 16XL             | 19,000 MiB/s    | 80,000 IOPS |
 
-Smaller compute instances like Nano, Micro, Small, and Medium have baseline performance levels that can occasionally be exceeded. These smaller compute instances can burst up to 2,085 MiB/s for 30 minutes a day. Beyond that, it reverts to the baseline performance stated in the table.
+Smaller compute instances like Nano, Micro, Small, and Medium have baseline performance levels that can occasionally be exceeded for short periods of time. If it does exceed the baseline, you should consider upgrading your instance size for a more reliable performance.
 
 Larger compute instances (4XL and above) are designed for sustained, high performance with specific IOPS and throughput limits which you can [configure](/docs/guides/platform/manage-your-usage/disk-throughput). If you hit your IOPS or throughput limit, throttling will occur.
 

--- a/apps/docs/content/guides/platform/compute-and-disk.mdx
+++ b/apps/docs/content/guides/platform/compute-and-disk.mdx
@@ -98,7 +98,9 @@ The compute size of your project sets the upper limit for disk throughput and IO
 | 12XL             | 14,250 MiB/s    | 50,000 IOPS |
 | 16XL             | 19,000 MiB/s    | 80,000 IOPS |
 
-Smaller compute instances like Nano, Micro, and Small have baseline performance levels that can occasionally be exceeded. Larger compute-instances (4XL and above) are designed for sustained, high performance with specific IOPS and throughput limits. If you hit your IOPS or throughput limit, throttling will occur.
+Smaller compute instances like Nano, Micro, Small, and Medium have baseline performance levels that can occasionally be exceeded. These smaller compute instances can burst up to 2,085 MiB/s for 30 minutes a day. Beyond that, it reverts to the baseline performance stated in the table.
+
+Larger compute instances (4XL and above) are designed for sustained, high performance with specific IOPS and throughput limits which you can [configure](/docs/guides/platform/manage-your-usage/disk-throughput). If you hit your IOPS or throughput limit, throttling will occur.
 
 ### Choosing the right compute instance for consistent disk performance
 
@@ -106,7 +108,7 @@ If you need consistent disk performance, choose the 4XL or larger compute instan
 
 ### Provisioned disk throughput and IOPS
 
-The default disk type is gp3, which comes with a baseline throughput of 125 MiB/s and a default IOPS of 3,000. You can provision additional IOPS and throughput from the [Database Settings](/dashboard/project/_/settings/database) page, but keep in mind that the effective IOPS and throughput will be limited by the compute instance size.
+The default disk type is gp3, which comes with a baseline throughput of 125 MiB/s and a default IOPS of 3,000. You can provision additional IOPS and throughput from the [Database Settings](https://supabase.com/dashboard/project/_/settings/compute-and-disk) page, but keep in mind that the effective IOPS and throughput will be limited by the compute instance size. This requires Large compute size or above.
 
 <Admonition type="caution">
 

--- a/apps/docs/content/troubleshooting/exhaust-disk-io.mdx
+++ b/apps/docs/content/troubleshooting/exhaust-disk-io.mdx
@@ -9,7 +9,7 @@ database_id = "4844905d-1456-44a1-858e-7a4995e5054c"
 
 Disk IO refers to two metrics: throughput in Megabits per Second and IOPS which are Input/Output Operations per Second. Depending on the compute add-on of your instance you will have [different baseline performances](/docs/guides/platform/compute-add-ons#compute-size).
 
-Smaller compute instances can burst and exceed their baseline performance for a short quota of time every day. This quota is represented as your Disk IO Budget and once your Disk IO Budget is consumed, your instance reverts back to its baseline performance. Learn more about [Choosing the right compute instance for consistent disk performance](/docs/guides/platform/compute-add-ons#choosing-the-right-compute-instance-for-consistent-disk-performance).
+Smaller compute instances can burst and exceed their baseline performance for a short quota of time every day. This quota is represented as your Disk IO Budget and once your Disk IO Budget is consumed, your instance reverts back to its baseline performance. Learn more about [choosing the right compute instance for consistent disk performance](/docs/guides/platform/compute-add-ons#choosing-the-right-compute-instance-for-consistent-disk-performance).
 
 ## Depleting your disk IO budget
 
@@ -25,7 +25,7 @@ Running out of Disk IO Budget means that your instance is using more disk than i
 
 To check your Disk IO Budget on the Supabase Platform, head over to [Database Health in the Reports section](https://supabase.com/dashboard/project/_/reports/database).
 
-It is also possible to monitor your resources and set up alerts using Prometheus/Grafana. With Grafana you will be able to see more metrics across like how much of your RAM is used for caching, your Swap usage and across smaller time windows. Read the [Metrics Guide](/docs/guides/platform/metrics) to learn more.
+It is also possible to monitor your resources and set up alerts using Prometheus/Grafana. With Grafana you will be able to pinpoint potential causes and see more fine-grained metrics like how much of your RAM is used for caching and your Swap usage. Read the [Metrics Guide](/docs/guides/platform/metrics) to learn more.
 
 ## Common reasons for high disk IO usage
 

--- a/apps/docs/content/troubleshooting/exhaust-disk-io.mdx
+++ b/apps/docs/content/troubleshooting/exhaust-disk-io.mdx
@@ -7,9 +7,9 @@ database_id = "4844905d-1456-44a1-858e-7a4995e5054c"
 
 ## Understanding disk IO and disk IO budget
 
-Disk IO refers to two metrics: throughput in Megabits per Second and IOPS which are Input/Output Operations per Second. Depending on the compute add-on of your instance you will have [different baseline performances](https://supabase.com/docs/guides/platform/compute-add-ons#disk-io).
+Disk IO refers to two metrics: throughput in Megabits per Second and IOPS which are Input/Output Operations per Second. Depending on the compute add-on of your instance you will have [different baseline performances](/docs/guides/platform/compute-add-ons#compute-size).
 
-Smaller compute instances can burst and exceed their baseline performance for a short quota of time every day. This quota is represented as your Disk IO Budget and once your Disk IO Budget is consumed, your instance reverts back to its baseline performance. You can read more about this under [Bursting and Disk IO Budget](https://supabase.com/docs/guides/platform/compute-add-ons#bursting-and-disk-io-budget).
+Smaller compute instances can burst and exceed their baseline performance for a short quota of time every day. This quota is represented as your Disk IO Budget and once your Disk IO Budget is consumed, your instance reverts back to its baseline performance. Learn more about [Choosing the right compute instance for consistent disk performance](/docs/guides/platform/compute-add-ons#choosing-the-right-compute-instance-for-consistent-disk-performance).
 
 ## Depleting your disk IO budget
 
@@ -17,26 +17,26 @@ Running out of Disk IO Budget means that your instance is using more disk than i
 
 - Response times on requests can increase noticeably
 - CPU usage rises noticeably due to IO wait
-- Disruption of [daily backup](https://supabase.com/docs/guides/platform/backups#daily-backups) routines
-- Disruption of internal Postgres processes such as [autovacuuming](https://supabase.com/docs/guides/platform/database-size#vacuum-operations)
+- Disruption of [daily backup](/docs/guides/platform/backups#daily-backups) routines
+- Disruption of internal Postgres processes such as [autovacuuming](/docs/guides/platform/database-size#vacuum-operations)
 - Your instance may become unresponsive
 
 ## Monitor your disk IO budget
 
 To check your Disk IO Budget on the Supabase Platform, head over to [Database Health in the Reports section](https://supabase.com/dashboard/project/_/reports/database).
 
-It is also possible to monitor your resources and set up alerts using Prometheus/Grafana. With Grafana you will be able to see how much of your RAM is used for caching and you can track other metrics such as your Swap usage. Read the [Metrics Guide](https://supabase.com/docs/guides/platform/metrics) to learn more.
+It is also possible to monitor your resources and set up alerts using Prometheus/Grafana. With Grafana you will be able to see more metrics across like how much of your RAM is used for caching, your Swap usage and across smaller time windows. Read the [Metrics Guide](/docs/guides/platform/metrics) to learn more.
 
 ## Common reasons for high disk IO usage
 
 Most operations on your Supabase project require disk IO in some form. Hence, there can be many reasons for high disk IO usage. Here are some common ones:
 
 - **High Memory Usage:** Every Supabase project has 1GB of disk allocated for swapping. When your memory usage is high, the operating system might frequently move parts of the memory back and forth of the swap space on the disk.
-- **Low Cache Usage:** If your cache hit rate is low, many of your database requests might go straight to the disk. Go to the [Cache Hit Rate Guide](https://supabase.com/docs/guides/platform/performance#hit-rate) to learn more.
-- **Query performance:** Queries that take a long time to complete (>1 second) could be using your disk inefficiently. Check our guide on [examining query performance](https://supabase.com/docs/guides/platform/performance#examining-query-performance).
+- **Low Cache Usage:** If your cache hit rate is low, many of your database requests might go straight to the disk. Go to the [Cache Hit Rate Guide](/docs/guides/platform/performance#hit-rate) to learn more.
+- **Query performance:** Queries that take a long time to complete (>1 second) could be using your disk inefficiently. Check our guide on [examining query performance](/docs/guides/platform/performance#examining-query-performance).
 - **High popularity:** Congrats! Your side project turned out to be a real success and is getting more requests than it can handle.
 
 ## How to fix
 
-1. **Upgrade your compute:** You can get a Compute Add-on for your project. See your [upgrade options](https://supabase.com/dashboard/project/_/settings/compute-and-disk) by selecting your project. Do reference the [different baseline performances](https://supabase.com/docs/guides/platform/compute-add-ons#disk-io) that come with larger Compute Add-ons.
-2. **Optimize performance:** Get more out of your instance's resources by optimizing your usage. Have a look at our [performance tuning guide](https://supabase.com/docs/guides/platform/performance#examining-query-performance) and our [production readiness guide](https://supabase.com/docs/guides/platform/going-into-prod#performance).
+1. **Upgrade your compute:** You can get a Compute Add-on for your project. Larger compute options (4XL and above) have more consistent disk performance. See your [upgrade options](https://supabase.com/dashboard/project/_/settings/compute-and-disk) by selecting your project. Do reference the [different baseline performances](/docs/guides/platform/compute-add-ons#compute-size) that come with larger Compute Add-ons.
+2. **Optimize performance:** Get more out of your instance's resources by optimizing your usage. Have a look at our [performance tuning guide](/docs/guides/platform/performance#examining-query-performance) and our [production readiness guide](/docs/guides/platform/going-into-prod#performance).

--- a/apps/docs/content/troubleshooting/exhaust-disk-io.mdx
+++ b/apps/docs/content/troubleshooting/exhaust-disk-io.mdx
@@ -9,7 +9,7 @@ database_id = "4844905d-1456-44a1-858e-7a4995e5054c"
 
 Disk IO refers to two metrics: throughput in Megabits per Second and IOPS which are Input/Output Operations per Second. Depending on the compute add-on of your instance you will have [different baseline performances](/docs/guides/platform/compute-add-ons#compute-size).
 
-Smaller compute instances can burst and exceed their baseline performance for a short quota of time every day. This quota is represented as your Disk IO Budget and once your Disk IO Budget is consumed, your instance reverts back to its baseline performance. Learn more about [choosing the right compute instance for consistent disk performance](/docs/guides/platform/compute-add-ons#choosing-the-right-compute-instance-for-consistent-disk-performance).
+Smaller compute instances can burst and exceed their baseline performance for a short quota of time every day. This is represented as your Disk IO Budget and once your Disk IO Budget is consumed, your instance reverts back to its baseline performance. Learn more about [choosing the right compute instance for consistent disk performance](/docs/guides/platform/compute-add-ons#choosing-the-right-compute-instance-for-consistent-disk-performance).
 
 ## Depleting your disk IO budget
 

--- a/apps/studio/components/interfaces/Settings/Infrastructure/Infrastructure.constants.ts
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/Infrastructure.constants.ts
@@ -90,8 +90,8 @@ export const INFRA_ACTIVITY_METRICS: CategoryMeta[] = [
             url: 'https://supabase.com/docs/guides/platform/compute-add-ons#disk-throughput-and-iops',
           },
           {
-            name: 'Interpreting Disk IO budget',
-            url: 'https://supabase.com/docs/guides/platform/compute-add-ons#bursting-and-disk-io-budget',
+            name: 'High Disk I/O',
+            url: 'https://supabase.com/docs/guides/troubleshooting/exhaust-disk-io',
           },
           {
             name: 'Metrics',

--- a/apps/studio/components/interfaces/Settings/Infrastructure/Infrastructure.constants.ts
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/Infrastructure.constants.ts
@@ -99,7 +99,7 @@ export const INFRA_ACTIVITY_METRICS: CategoryMeta[] = [
           },
         ],
         description:
-          'The disk performance of your workload is determined by the Disk IO bandwidth.\nSmaller compute instances (below 4XL) can burst up to their largest throughput and IOPS for 30 minutes in a day. Beyond that, the performance reverts to the baseline. Your disk IO budget gets replenished throughout the day.',
+          'The disk performance of your workload is determined by the Disk IO bandwidth.\nSmaller compute instances (below 4XL) can burst above their baseline disk throughput and IOPS for short periods of time. Beyond that, the performance reverts to the baseline.',
         chartDescription: '',
       },
     ],

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureActivity.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureActivity.tsx
@@ -288,11 +288,9 @@ const InfrastructureActivity = () => {
                           </p>
                         ) : (
                           <p className="text-sm text-foreground-light">
-                            Your current compute can burst up to{' '}
-                            {currentComputeInstanceSpecs.max_disk_io_mbs?.toLocaleString()} Mbps for
-                            30 minutes a day and reverts to the baseline performance of{' '}
+                            Your current compute can burst above the baseline disk throughput of{' '}
                             {currentComputeInstanceSpecs.baseline_disk_io_mbs?.toLocaleString()}{' '}
-                            Mbps.
+                            Mbps for short periods of time.
                           </p>
                         )}
                       </div>
@@ -307,18 +305,18 @@ const InfrastructureActivity = () => {
                           </p>
                         </div>
                         <div className="flex items-center justify-between border-b py-1">
+                          <p className="text-xs text-foreground-light">Baseline IO Bandwidth</p>
+                          <p className="text-xs">
+                            {currentComputeInstanceSpecs.baseline_disk_io_mbs?.toLocaleString()}{' '}
+                            Mbps
+                          </p>
+                        </div>
+                        <div className="flex items-center justify-between border-b py-1">
                           <p className="text-xs text-foreground-light">
                             Maximum IO Bandwidth (burst limit)
                           </p>
                           <p className="text-xs">
                             {currentComputeInstanceSpecs.max_disk_io_mbs?.toLocaleString()} Mbps
-                          </p>
-                        </div>
-                        <div className="flex items-center justify-between border-b py-1">
-                          <p className="text-xs text-foreground-light">Baseline IO Bandwidth</p>
-                          <p className="text-xs">
-                            {currentComputeInstanceSpecs.baseline_disk_io_mbs?.toLocaleString()}{' '}
-                            Mbps
                           </p>
                         </div>
                         {currentComputeInstanceSpecs.max_disk_io_mbs !==

--- a/apps/studio/components/ui/ResourceExhaustionWarningBanner/ResourceExhaustionWarningBanner.constants.ts
+++ b/apps/studio/components/ui/ResourceExhaustionWarningBanner/ResourceExhaustionWarningBanner.constants.ts
@@ -42,7 +42,7 @@ export const RESOURCE_WARNING_MESSAGES: Record<string, ResourceWarningMessage> =
       },
     },
     docsUrl: 'https://supabase.com/docs/guides/platform/database-size#disabling-read-only-mode',
-    buttonText: 'View Compute and Disk',
+    buttonText: 'Learn more',
     metric: 'read_only',
   },
   disk_io_exhaustion: {
@@ -70,7 +70,7 @@ export const RESOURCE_WARNING_MESSAGES: Record<string, ResourceWarningMessage> =
       },
     },
     docsUrl: 'https://supabase.com/docs/guides/troubleshooting/exhaust-disk-io',
-    buttonText: 'Check usage',
+    buttonText: 'Learn more',
     metric: 'disk_io',
   },
   disk_space_exhaustion: {
@@ -125,7 +125,7 @@ export const RESOURCE_WARNING_MESSAGES: Record<string, ResourceWarningMessage> =
       },
     },
     docsUrl: 'https://supabase.com/docs/guides/troubleshooting/high-cpu-usage',
-    buttonText: 'Check usage',
+    buttonText: 'Learn more',
     metric: 'cpu',
   },
   memory_and_swap_exhaustion: {
@@ -153,7 +153,7 @@ export const RESOURCE_WARNING_MESSAGES: Record<string, ResourceWarningMessage> =
       },
     },
     docsUrl: 'https://supabase.com/docs/guides/troubleshooting/exhaust-ram',
-    buttonText: 'Check usage',
+    buttonText: 'Learn more',
     metric: 'ram',
   },
   auth_rate_limit_exhaustion: {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

After discussion, databases shouldn't be designed around bursts so we just need to improve docs and clarify the solution is to upgrade compute. Overall trying to balance the amount of mentions around burst and exceeding of baseline performance. 

- added more details about high disk io and configuring throughput
- fixed all the links to reference better the new pages
- learn more as button text instead of check usage since it leads to docs not a report. 
- changed a link in infrastructure settings disk io section to link to exhaust disk io page
- remove additional mentions of burst time limits and bandwidth in infrastructure settings page (but still kept the burst time limit and max bandwidth mention above the graph, it's only once and helps explain some parts without bringing it up too often)

[RESOLVED on slack] @charislam do we remember why the burst details were removed? 