### PR TITLE
Fix check before constructing new URL in TerminalInstructions

### DIFF
--- a/apps/studio/components/interfaces/Functions/TerminalInstructions.tsx
+++ b/apps/studio/components/interfaces/Functions/TerminalInstructions.tsx
@@ -45,7 +45,7 @@ const TerminalInstructions = forwardRef<
 
   // get the .co or .net TLD from the restUrl
   const restUrl = `https://${endpoint}`
-  const restUrlTld = restUrl ? new URL(restUrl).hostname.split('.').pop() : 'co'
+  const restUrlTld = !!endpoint ? new URL(restUrl).hostname.split('.').pop() : 'co'
 
   const commands: Commands[] = [
     {


### PR DESCRIPTION
Fixes FE-1432

As per PR title - there was a tendency to error out as the project settings have yet to be loaded
Whereas checking on `restUrl` will always return true since its appended with `https://` and not an empty string