### PR TITLE
Update connecting-to-postgres.mdx | made example region agnostic

### DIFF
--- a/apps/docs/content/guides/database/connecting-to-postgres.mdx
+++ b/apps/docs/content/guides/database/connecting-to-postgres.mdx
@@ -90,7 +90,7 @@ The session mode connection string connects to your Postgres instance via a prox
 The connection string looks like this:
 
 ```
-postgres://postgres.apbkobhfnmcqqzqeeqss:[YOUR-PASSWORD]@aws-0-ca-central-1.pooler.supabase.com:5432/postgres
+postgres://postgres.apbkobhfnmcqqzqeeqss:[YOUR-PASSWORD]@aws-0-[REGION].pooler.supabase.com:5432/postgres
 ```
 
 Get your project's session mode string from the [Database Settings](/dashboard/project/_/settings/database) page:
@@ -112,7 +112,7 @@ Transaction mode does not support [prepared statements](https://postgresql.org/d
 The connection string looks like this:
 
 ```
-postgres://postgres.apbkobhfnmcqqzqeeqss:[YOUR-PASSWORD]@aws-0-ca-central-1.pooler.supabase.com:6543/postgres
+postgres://postgres.apbkobhfnmcqqzqeeqss:[YOUR-PASSWORD]@aws-0-[REGION].pooler.supabase.com:6543/postgres
 ```
 
 Get your project's transaction mode string from the [Database Settings](/dashboard/project/_/settings/database) page:


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

The example connection string references Canada

## What is the new behavior?

Replaced `ca-central-1` with `[REGION]` to make it more generalizable

## Additional context

A [user](https://app.hubspot.com/live-messages/19953346/inbox/8797816606#email) was confused that the region was present, so this change should help avoid confusion in the future