### PR TITLE
docs: add more filtering examples to the API docs

### DIFF
--- a/apps/studio/components/interfaces/Docs/Snippets.ts
+++ b/apps/studio/components/interfaces/Docs/Snippets.ts
@@ -342,10 +342,31 @@ let { data: ${resourceId}, error } = await supabase
     bash: {
       language: 'bash',
       code: `
-curl '${endpoint}/rest/v1/${resourceId}?id=eq.1&select=*' \\
+curl --get '${endpoint}/rest/v1/${resourceId}' \\
 -H "apikey: ${apiKey}" \\
 -H "Authorization: Bearer ${apiKey}" \\
--H "Range: 0-9"
+-H "Range: 0-9" \\
+-d "select=*" \\
+\\
+\`# Filters\` \\
+-d "column=eq.Equal+to" \\
+-d "column=gt.Greater+than" \\
+-d "column=lt.Less+than" \\
+-d "column=gte.Greater+than+or+equal+to" \\
+-d "column=lte.Less+than+or+equal+to" \\
+-d "column=like.*CaseSensitive*" \\
+-d "column=ilike.*CaseInsensitive*" \\
+-d "column=is.null" \\
+-d "column=in.(Array,Values)" \\
+-d "column=neq.Not+equal+to" \\
+\\
+\`# Arrays\` \\
+-d "array_column=cs.{array,contains}" \\
+-d "array_column=cd.{contained,by}" \\
+\\
+\`# Logical operators\` \\
+-d "column=not.like.Negate+filter" \\
+-d "or=(some_column.eq.Some+value,other_column.eq.Other+value)"
 `,
     },
     js: {
@@ -354,6 +375,7 @@ curl '${endpoint}/rest/v1/${resourceId}?id=eq.1&select=*' \\
 let { data: ${resourceId}, error } = await supabase
   .from('${resourceId}')
   .select("*")
+
   // Filters
   .eq('column', 'Equal to')
   .gt('column', 'Greater than')
@@ -365,9 +387,14 @@ let { data: ${resourceId}, error } = await supabase
   .is('column', null)
   .in('column', ['Array', 'Values'])
   .neq('column', 'Not equal to')
+
   // Arrays
   .contains('array_column', ['array', 'contains'])
   .containedBy('array_column', ['contained', 'by'])
+
+  // Logical operators
+  .not('column', 'like', 'Negate filter')
+  .or('some_column.eq.Some value, other_column.eq.Other value')
 `,
     },
   }),

--- a/apps/studio/components/interfaces/ProjectAPIDocs/ProjectAPIDocs.constants.ts
+++ b/apps/studio/components/interfaces/ProjectAPIDocs/ProjectAPIDocs.constants.ts
@@ -722,10 +722,31 @@ let { data: ${resourceId}, error } = await supabase
           key: 'with-filtering',
           title: 'With filtering',
           bash: `
-curl '${endpoint}/rest/v1/${resourceId}?id=eq.1&select=*' \\
+curl --get '${endpoint}/rest/v1/${resourceId}' \\
 -H "apikey: ${apikey}" \\
 -H "Authorization: Bearer ${apikey}" \\
--H "Range: 0-9"
+-H "Range: 0-9" \\
+-d "select=*" \\
+\\
+\`# Filters\` \\
+-d "column=eq.Equal+to" \\
+-d "column=gt.Greater+than" \\
+-d "column=lt.Less+than" \\
+-d "column=gte.Greater+than+or+equal+to" \\
+-d "column=lte.Less+than+or+equal+to" \\
+-d "column=like.*CaseSensitive*" \\
+-d "column=ilike.*CaseInsensitive*" \\
+-d "column=is.null" \\
+-d "column=in.(Array,Values)" \\
+-d "column=neq.Not+equal+to" \\
+\\
+\`# Arrays\` \\
+-d "array_column=cs.{array,contains}" \\
+-d "array_column=cd.{contained,by}" \\
+\\
+\`# Logical operators\` \\
+-d "column=not.like.Negate+filter" \\
+-d "or=(some_column.eq.Some+value,other_column.eq.Other+value)"
         `,
           js: `
 let { data: ${resourceId}, error } = await supabase
@@ -747,6 +768,10 @@ let { data: ${resourceId}, error } = await supabase
   // Arrays
   .contains('array_column', ['array', 'contains'])
   .containedBy('array_column', ['contained', 'by'])
+
+  // Logical operators
+  .not('column', 'like', 'Negate filter')
+  .or('some_column.eq.Some value, other_column.eq.Other value')
           `,
         },
       ]


### PR DESCRIPTION
- Adds the logical operators `not` and `or`
- All Javascript examples are now present for Bash. Used `curl --get` to present each query parameter in a different line.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs.

## What is the current behavior?

- There are no "Filtering" examples for the logical operators `not` and `or`.
- There are many Javascript examples for filters, but Bash only shows `id=eq.1`

## What is the new behavior?

<img width="1003" alt="image" src="https://github.com/user-attachments/assets/115c3833-717a-42a4-a88c-d8266c31f108" />

## Additional context

Old behavior:

![image](https://github.com/user-attachments/assets/81383efc-0b24-47d7-ab40-1eb3dada13b7)

