### PR TITLE
Second phase of HSTS header settings

### DIFF
--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -74,7 +74,7 @@ const nextConfig = {
         headers: [
           {
             key: 'Strict-Transport-Security',
-            value: process.env.VERCEL === '1' ? 'max-age=31536000' : '',
+            value: process.env.VERCEL === '1' ? 'max-age=1200; includeSubDomains' : '',
           },
           {
             key: 'X-Robots-Tag',
@@ -97,7 +97,7 @@ const nextConfig = {
         headers: [
           {
             key: 'Strict-Transport-Security',
-            value: process.env.VERCEL === '1' ? 'max-age=31536000' : '',
+            value: process.env.VERCEL === '1' ? 'max-age=1200; includeSubDomains' : '',
           },
           {
             key: 'X-Robots-Tag',

--- a/apps/studio/next.config.js
+++ b/apps/studio/next.config.js
@@ -489,7 +489,7 @@ const nextConfig = {
             key: 'Strict-Transport-Security',
             value:
               process.env.NEXT_PUBLIC_IS_PLATFORM === 'true' && process.env.VERCEL === '1'
-                ? 'max-age=31536000'
+                ? 'max-age=1200; includeSubDomains'
                 : '',
           },
           {

--- a/apps/www/next.config.mjs
+++ b/apps/www/next.config.mjs
@@ -84,7 +84,7 @@ const nextConfig = {
         source: "/(.*)",
         headers: [{ 
           key: 'Strict-Transport-Security', 
-          value: process.env.NEXT_PUBLIC_IS_PLATFORM === 'true' && process.env.VERCEL === '1' ? 'max-age=31536000' : '' }],
+          value: process.env.NEXT_PUBLIC_IS_PLATFORM === 'true' && process.env.VERCEL === '1' ? 'max-age=1200; includeSubDomains' : '' }],
       },
     ]
   },


### PR DESCRIPTION
First phase of this rollout added the HSTS header via vercel config. This setting was less strict than the original Cloudflare sourced directive that was lost when the proxy was disabled.
That setting was maxage=31536000; includeSubdomains

This phase is temporary but takes a cautious approach to applying the includeSubdomains directive. The max age is set at 30 minutes so that we can back out if necessary. 

This setting is not intended to be in place for any longer than a month. Phase three will restore the longer maxAge directive as well as including the preload directive.

Part of SEC-120
