### PR TITLE
docs: update troubleshooting for invalid claim

### DIFF
--- a/apps/docs/content/troubleshooting/auth-error-401-invalid-claim-missing-sub--AFwMR.mdx
+++ b/apps/docs/content/troubleshooting/auth-error-401-invalid-claim-missing-sub--AFwMR.mdx
@@ -12,6 +12,10 @@ sdk = [ "auth-getuser" ]
 [[errors]]
 http_status_code = 401
 message = "invalid claim: missing sub"
+
+[[errors]]
+http_status_code = 403
+message = "invalid claim: missing sub"
 ---
 
 The missing sub claim error is returned when `supabase.auth.getUser()` is called with an invalid JWT in the session or when the user attempts to register/sign in but hasn't completed the sign in when the `getUser` call is made.


### PR DESCRIPTION
invalid claim: missing sub seems to (also?) be returned as a 403, not a 401. Discovered this when I was testing something else, so updating the troubleshooting guide for it.