### PR TITLE
Fix/table editor read only

### DIFF
--- a/apps/studio/components/grid/components/menu/RowContextMenu.tsx
+++ b/apps/studio/components/grid/components/menu/RowContextMenu.tsx
@@ -30,7 +30,7 @@ const RowContextMenu = ({ rows }: RowContextMenuProps) => {
     if (state.onEditRow) state.onEditRow(row)
   }
 
-  function isItemHidden({ data }: PredicateParams) {
+  function isItemHidden({ data }: { data: string }) {
     if (data === 'edit') return state.onEditRow == undefined
     if (data === 'delete') return !state.editable
     return false
@@ -64,12 +64,12 @@ const RowContextMenu = ({ rows }: RowContextMenuProps) => {
           <Clipboard size={14} />
           <span className="ml-2 text-xs">Copy cell content</span>
         </Item>
-        <Item onClick={onEditRowClick} hidden={isItemHidden} data="edit">
+        <Item onClick={onEditRowClick} hidden={() => isItemHidden({ data: 'edit' })} data="edit">
           <Edit size={14} />
           <span className="ml-2 text-xs">Edit row</span>
         </Item>
         {state.editable && <Separator />}
-        <Item onClick={onDeleteRow} hidden={isItemHidden} data="delete">
+        <Item onClick={onDeleteRow} hidden={() => isItemHidden({ data: 'delete' })} data="delete">
           <Trash size={14} stroke="red" />
           <span className="ml-2 text-xs">Delete row</span>
         </Item>


### PR DESCRIPTION
with a filter enabled, sometimes the table editor won't render these two buttons, only "Copy cell content"

![screenshot-2025-02-27-at-16 46 59](https://github.com/user-attachments/assets/b5253fda-8e82-4c39-a88f-f213503fdafc)
