### PR TITLE
Fix Wasm Edge Function Docs

### DIFF
--- a/apps/docs/content/guides/functions/wasm.mdx
+++ b/apps/docs/content/guides/functions/wasm.mdx
@@ -1,4 +1,3 @@
-# filename: apps/docs/content/guides/functions/wasm.mdx
 ---
 id: 'function-wasm'
 title: 'Using Wasm modules'

--- a/apps/docs/content/guides/functions/wasm.mdx
+++ b/apps/docs/content/guides/functions/wasm.mdx
@@ -1,3 +1,4 @@
+# filename: apps/docs/content/guides/functions/wasm.mdx
 ---
 id: 'function-wasm'
 title: 'Using Wasm modules'
@@ -77,7 +78,7 @@ Before deploying the Edge Function, we need to ensure it bundles the Wasm module
 
 ```toml
 [functions.wasm-add]
-static_files = [ "./functions/wasm-add/add-wasm/pkg/*.wasm"]
+static_files = [ "./functions/wasm-add/add-wasm/pkg/*"]
 ```
 
 Deploy the function by running:

--- a/examples/edge-functions/supabase/functions/wasm-modules/index.ts
+++ b/examples/edge-functions/supabase/functions/wasm-modules/index.ts
@@ -1,4 +1,3 @@
-// filename: examples/edge-functions/supabase/functions/wasm-modules/index.ts
 import { add } from "./add-wasm/pkg/add_wasm.js";
 
 Deno.serve(async (req) => {

--- a/examples/edge-functions/supabase/functions/wasm-modules/index.ts
+++ b/examples/edge-functions/supabase/functions/wasm-modules/index.ts
@@ -1,11 +1,5 @@
-const wasmBuffer = await Deno.readFile(
-  new URL("./add-wasm/pkg/add_wasm_bg.wasm", import.meta.url),
-);
-
-const { instance } = await WebAssembly.instantiate(
-  wasmBuffer,
-);
-const { add } = instance.exports;
+// filename: examples/edge-functions/supabase/functions/wasm-modules/index.ts
+import { add } from "./add-wasm/pkg/add_wasm.js";
 
 Deno.serve(async (req) => {
   const { a, b } = await req.json();


### PR DESCRIPTION
fixed docs and examples wasm bug: when importing wasm, you need to include the js and use this. Otherwise, there will be wasm instantiate errors

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs and example update for wasm edge function

## What is the current behavior?

Fixes #33909

## What is the new behavior?

```
curl -X POST \ 
  http://127.0.0.1:54321/functions/v1/wasm-add \
  -H "Content-Type: application/json" \
  -d '{"a": 5, "b": 3}'

{"result":8}
```
