### PR TITLE
chore: increase stale time for project addons / org subscription

### DIFF
--- a/apps/studio/data/subscriptions/org-subscription-query.ts
+++ b/apps/studio/data/subscriptions/org-subscription-query.ts
@@ -50,6 +50,7 @@ export const useOrgSubscriptionQuery = <TData = OrgSubscriptionData>(
     ({ signal }) => getOrgSubscription({ orgSlug }, signal),
     {
       enabled: enabled && canReadSubscriptions && typeof orgSlug !== 'undefined',
+      staleTime: 60 * 60 * 1000, // 60 minutes
       ...options,
     }
   )

--- a/apps/studio/data/subscriptions/project-addons-query.ts
+++ b/apps/studio/data/subscriptions/project-addons-query.ts
@@ -36,6 +36,7 @@ export const useProjectAddonsQuery = <TData = ProjectAddonsData>(
     ({ signal }) => getProjectAddons({ projectRef }, signal),
     {
       enabled: enabled && IS_PLATFORM && typeof projectRef !== 'undefined',
+      staleTime: 60 * 60 * 1000, // 60 minutes
       ...options,
     }
   )


### PR DESCRIPTION
Occasionally results in a 429 in API - there are plans to fix this on the API level, but it's not a quick change, so hoping to reduce the likeliness of 429 with a higher stale time. Subscriptions and project addons rarely change and if they are changed, it's invalidated on the client anyway.
