### PR TITLE
fix: handle position

### DIFF
--- a/apps/studio/components/layouts/ProjectLayout/ProjectLayout.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/ProjectLayout.tsx
@@ -185,7 +185,7 @@ const ProjectLayout = forwardRef<HTMLDivElement, PropsWithChildren<ProjectLayout
               <ResizableHandle
                 withHandle
                 disabled={resizableSidebar ? false : true}
-                className="hidden md:block"
+                className="hidden md:flex"
               />
             )}
             <ResizablePanel order={2} id="panel-right" className="h-full flex flex-col w-full">


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

issue was resize handle was at the top of the element.

<img width="220" alt="Screenshot 2025-02-28 at 16 47 52" src="https://github.com/user-attachments/assets/d66e684b-008c-442f-b6ca-e14e7a910ed5" />

