### PR TITLE
feat: add `error_code` to log preview

### DIFF
--- a/apps/studio/components/interfaces/Settings/Logs/LogSelection.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogSelection.tsx
@@ -35,6 +35,7 @@ const LogSelection = ({ log, onClose, queryType, isLoading, error }: LogSelectio
         const method = log?.metadata?.[0]?.request?.[0]?.method
         const path = log?.metadata?.[0]?.request?.[0]?.path
         const user_agent = log?.metadata?.[0]?.request?.[0]?.headers[0].user_agent
+        const error_code = log?.metadata?.[0]?.response?.[0]?.headers?.[0]?.x_sb_error_code
         const { id, metadata, timestamp, event_message, ...rest } = log
 
         const apiLog = {
@@ -46,6 +47,7 @@ const LogSelection = ({ log, onClose, queryType, isLoading, error }: LogSelectio
           timestamp,
           event_message,
           metadata,
+          ...(error_code ? { error_code } : null),
           ...rest,
         }
 


### PR DESCRIPTION
Makes it easy to see the error code behind an API Gateway log entry.

Example:
<img width="540" alt="image" src="https://github.com/user-attachments/assets/94e12bf3-f8ce-495b-9b1d-6270cb4535f4" />
