### PR TITLE
docs: fix incorrect filename in nextjs auth example README

### DIFF
--- a/examples/auth/nextjs/README.md
+++ b/examples/auth/nextjs/README.md
@@ -63,7 +63,7 @@ If you wish to just develop locally and not deploy to Vercel, [follow the steps 
    cd name-of-new-app
    ```
 
-4. Rename `.env.local.example` to `.env.local` and update the following:
+4. Rename `.env.example` to `.env.local` and update the following:
 
    ```
    NEXT_PUBLIC_SUPABASE_URL=[INSERT SUPABASE PROJECT URL]


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

The auth nextjs README refers to `.env.local.example` instead `.env.example`. This commit updates the README with the correct filename.

## What is the current behavior?

N/A

## What is the new behavior?

N/A

## Additional context

N/A