### PR TITLE
Hide pool mode field in connection pooling

### DIFF
--- a/apps/studio/components/interfaces/Connect/DatabaseConnectionString.tsx
+++ b/apps/studio/components/interfaces/Connect/DatabaseConnectionString.tsx
@@ -377,7 +377,7 @@ export const DatabaseConnectionString = () => {
                 ]}
                 onCopyCallback={() => handleCopy(selectedTab, 'transaction_pooler')}
               />
-              {ipv4Addon && (
+              {ipv4Addon && !isPgBouncerEnabled && (
                 <Admonition
                   type="warning"
                   title="Highly recommended to not use Session Pooler"

--- a/apps/studio/components/interfaces/Settings/Database/ConnectionPooling/ConnectionPooling.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/ConnectionPooling/ConnectionPooling.tsx
@@ -281,7 +281,6 @@ export const ConnectionPooling = () => {
         {
           ref: projectRef,
           default_pool_size,
-          pool_mode: pool_mode as 'transaction' | 'session',
         },
         {
           onSuccess: (data) => {
@@ -524,100 +523,102 @@ export const ConnectionPooling = () => {
                     />
                   )}
 
-                  <FormField_Shadcn_
-                    control={form.control}
-                    name="pool_mode"
-                    render={({ field }) => (
-                      <FormItemLayout
-                        layout="horizontal"
-                        label="Pool Mode"
-                        description={
-                          <>
-                            {disablePoolModeSelection && (
-                              <Alert_Shadcn_ className="mt-0">
-                                <AlertTitle_Shadcn_ className="text-foreground">
-                                  Pool mode is permanently set to Transaction on port 6543
-                                </AlertTitle_Shadcn_>
-                                <AlertDescription_Shadcn_>
-                                  You can use Session mode by connecting to the pooler on port 5432
-                                  instead
-                                </AlertDescription_Shadcn_>
-                              </Alert_Shadcn_>
-                            )}
-                            {showPoolModeWarning && (
-                              <>
-                                {field.value === 'transaction' ? (
-                                  <Admonition
-                                    type="warning"
-                                    title="Pool mode will be set to transaction permanently on port 6543"
-                                    description="This will take into effect once saved. If you are using Session mode with port 6543 in your applications, please update to use port 5432 instead before saving."
-                                  />
-                                ) : (
-                                  <>
-                                    <Panel.Notice
-                                      layout="vertical"
-                                      className="border rounded-lg"
-                                      title="Deprecating Session Mode on Port 6543"
-                                      description="On February 28, 2025, Supavisor is deprecating Session Mode on port 6543. Please update your application/database clients to use port 5432 for Session Mode."
-                                      href="https://github.com/orgs/supabase/discussions/32755"
-                                      buttonText="Read the announcement"
-                                    />
+                  {type === 'PgBouncer' && (
+                    <FormField_Shadcn_
+                      control={form.control}
+                      name="pool_mode"
+                      render={({ field }) => (
+                        <FormItemLayout
+                          layout="horizontal"
+                          label="Pool Mode"
+                          description={
+                            <>
+                              {disablePoolModeSelection && (
+                                <Alert_Shadcn_ className="mt-0">
+                                  <AlertTitle_Shadcn_ className="text-foreground">
+                                    Pool mode is permanently set to Transaction on port 6543
+                                  </AlertTitle_Shadcn_>
+                                  <AlertDescription_Shadcn_>
+                                    You can use Session mode by connecting to the pooler on port
+                                    5432 instead
+                                  </AlertDescription_Shadcn_>
+                                </Alert_Shadcn_>
+                              )}
+                              {showPoolModeWarning && (
+                                <>
+                                  {field.value === 'transaction' ? (
                                     <Admonition
-                                      className="mt-2"
-                                      showIcon={false}
-                                      type="default"
-                                      title="Set to transaction mode to use both pooling modes concurrently"
-                                      description="Session mode can be used concurrently with transaction mode by
+                                      type="warning"
+                                      title="Pool mode will be set to transaction permanently on port 6543"
+                                      description="This will take into effect once saved. If you are using Session mode with port 6543 in your applications, please update to use port 5432 instead before saving."
+                                    />
+                                  ) : (
+                                    <>
+                                      <Panel.Notice
+                                        layout="vertical"
+                                        className="border rounded-lg"
+                                        title="Deprecating Session Mode on Port 6543"
+                                        description="On February 28, 2025, Supavisor is deprecating Session Mode on port 6543. Please update your application/database clients to use port 5432 for Session Mode."
+                                        href="https://github.com/orgs/supabase/discussions/32755"
+                                        buttonText="Read the announcement"
+                                      />
+                                      <Admonition
+                                        className="mt-2"
+                                        showIcon={false}
+                                        type="default"
+                                        title="Set to transaction mode to use both pooling modes concurrently"
+                                        description="Session mode can be used concurrently with transaction mode by
                                                     using 5432 for session and 6543 for transaction. However, by
                                                     configuring the pooler mode to session here, you will not be able
                                                     to use transaction mode at the same time."
-                                    />
-                                  </>
-                                )}
-                              </>
-                            )}
-                            <p className="mt-2">
-                              Specify when a connection can be returned to the pool.{' '}
-                              <span
-                                tabIndex={0}
-                                onClick={() => snap.setShowPoolingModeHelper(true)}
-                                className="transition cursor-pointer underline underline-offset-2 decoration-foreground-lighter hover:decoration-foreground text-foreground"
-                              >
-                                Learn more about pool modes
-                              </span>
-                              .
-                            </p>
-                          </>
-                        }
-                      >
-                        <FormControl_Shadcn_>
-                          <Listbox
-                            disabled={disablePoolModeSelection}
-                            value={field.value}
-                            className="w-full"
-                            onChange={(value) => field.onChange(value)}
-                          >
-                            <Listbox.Option
-                              key="transaction"
-                              label="Transaction"
-                              value="transaction"
+                                      />
+                                    </>
+                                  )}
+                                </>
+                              )}
+                              <p className="mt-2">
+                                Specify when a connection can be returned to the pool.{' '}
+                                <span
+                                  tabIndex={0}
+                                  onClick={() => snap.setShowPoolingModeHelper(true)}
+                                  className="transition cursor-pointer underline underline-offset-2 decoration-foreground-lighter hover:decoration-foreground text-foreground"
+                                >
+                                  Learn more about pool modes
+                                </span>
+                                .
+                              </p>
+                            </>
+                          }
+                        >
+                          <FormControl_Shadcn_>
+                            <Listbox
+                              disabled={disablePoolModeSelection}
+                              value={field.value}
+                              className="w-full"
+                              onChange={(value) => field.onChange(value)}
                             >
-                              <p>Transaction mode</p>
-                              <p className="text-xs text-foreground-lighter">
-                                {TRANSACTION_MODE_DESCRIPTION}
-                              </p>
-                            </Listbox.Option>
-                            <Listbox.Option key="session" label="Session" value="session">
-                              <p>Session mode</p>
-                              <p className="text-xs text-foreground-lighter">
-                                {SESSION_MODE_DESCRIPTION}
-                              </p>
-                            </Listbox.Option>
-                          </Listbox>
-                        </FormControl_Shadcn_>
-                      </FormItemLayout>
-                    )}
-                  />
+                              <Listbox.Option
+                                key="transaction"
+                                label="Transaction"
+                                value="transaction"
+                              >
+                                <p>Transaction mode</p>
+                                <p className="text-xs text-foreground-lighter">
+                                  {TRANSACTION_MODE_DESCRIPTION}
+                                </p>
+                              </Listbox.Option>
+                              <Listbox.Option key="session" label="Session" value="session">
+                                <p>Session mode</p>
+                                <p className="text-xs text-foreground-lighter">
+                                  {SESSION_MODE_DESCRIPTION}
+                                </p>
+                              </Listbox.Option>
+                            </Listbox>
+                          </FormControl_Shadcn_>
+                        </FormItemLayout>
+                      )}
+                    />
+                  )}
 
                   <FormField_Shadcn_
                     control={form.control}

--- a/apps/studio/data/database/supavisor-configuration-update-mutation.ts
+++ b/apps/studio/data/database/supavisor-configuration-update-mutation.ts
@@ -12,14 +12,13 @@ type SupavisorConfigurationUpdateVariables = {
 
 export async function updateSupavisorConfiguration({
   ref,
-  pool_mode,
   default_pool_size,
 }: SupavisorConfigurationUpdateVariables) {
   if (!ref) return console.error('Project ref is required')
 
   const { data, error } = await patch('/platform/projects/{ref}/config/supavisor', {
     params: { path: { ref } },
-    body: { default_pool_size, pool_mode },
+    body: { default_pool_size, pool_mode: 'transaction' },
   })
 
   if (error) handleError(error)

--- a/apps/studio/data/database/supavisor-configuration-update-mutation.ts
+++ b/apps/studio/data/database/supavisor-configuration-update-mutation.ts
@@ -18,6 +18,10 @@ export async function updateSupavisorConfiguration({
 
   const { data, error } = await patch('/platform/projects/{ref}/config/supavisor', {
     params: { path: { ref } },
+    // [Joshen] Manually setting pool mode to transaction here as there's a bug on API end
+    // whereby updating pool_mode on pgbouncer affects the pool_mode that gets returned on
+    // GET config/supavisor. Which means if I'm on PgBouncer Session, and I swap to Supavisor
+    // then Supavisor's pool_mode will be "session" (when it's meant to persist as transaction permanently)
     body: { default_pool_size, pool_mode: 'transaction' },
   })
 


### PR DESCRIPTION
Fixes FE-1445

As per PR title - also removes `pool_mode` as a param in supavisor-configuration-update-mutation
but we're manually setting pool_mode as 'transaction' in the mutation itself as I noticed a bug in the API end for updating pgbouncer or supavisor's configuratiojn

We can remove that eventually tho once the API is fixed

Also removes the session mode warning banner in Connect UI if dedicated pooler is selected 

## To test:
- Ensure `dualPoolerSupport` flag is off (so as to ensure that we're testing what's seen on production)
- Pool mode field no longer present in connection pooling under settings/database
- Can still update pool_size for connection pooling