### PR TITLE
fix(storage): support resumable file upload without storage/v1 prefix for self-hosted setup

### DIFF
--- a/docker/volumes/api/kong.yml
+++ b/docker/volumes/api/kong.yml
@@ -181,6 +181,10 @@ services:
         strip_path: true
         paths:
           - /storage/v1/
+      - name: storage-v1-self-hosted-resumable-file
+        strip_path: false
+        paths:
+          - /upload/resumable
     plugins:
       - name: cors
 


### PR DESCRIPTION
Add a new Kong route to forward /upload/resumable requests to the storage service without stripping the path prefix, specifically for self-hosted Supabase deployments.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

working correct in uppy tus, allow the upload/resumable preflix request to be correctly forwarded to the supabase

## What is the new behavior?

From the error 401 (Unauthorized) of Patch Request after first Post Request to the correct behavior 
