### PR TITLE
Laravel documentation addition to explain schema needs to be created

### DIFF
--- a/apps/docs/content/guides/getting-started/quickstarts/laravel.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/laravel.mdx
@@ -77,8 +77,7 @@ hideToc: true
 
     You can change the schema of your Laravel application by modifying the `search_path` variable `app/config/database.php`.
 
-    Please note the schema you specify in `search_path` has to exist on Supabase. If it doesn't you can create it by going to the *Table Editor*
-    clicking on the schema drop down and selecting `Create a new schema` e.g. in this example `laravel`
+    Please note the schema you specify in `search_path` has to exist on Supabase. You can create a new schema from the [Table Editor](/dashboard/project/_/editor).
 
     </StepHikeCompact.Details>
 

--- a/apps/docs/content/guides/getting-started/quickstarts/laravel.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/laravel.mdx
@@ -77,6 +77,9 @@ hideToc: true
 
     You can change the schema of your Laravel application by modifying the `search_path` variable `app/config/database.php`.
 
+    Please note the schema you specify in `search_path` has to exist on Supabase. If it doesn't you can create it by going to the *Table Editor*
+    clicking on the schema drop down and selecting `Create a new schema` e.g. in this example `laravel`
+
     </StepHikeCompact.Details>
 
     <StepHikeCompact.Code>


### PR DESCRIPTION

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update 

## What is the current behavior?

If a user is following the Laravel documentation a step is missing where a user should create a schema on Supabase as the migration script doesn't do it. Resulting error is shown

```
$ php artisan migrate

   INFO  Preparing database.

  Creating migration table ........................................................................................................... 599.73ms FAIL

   Illuminate\Database\QueryException

  SQLSTATE[3F000]: Invalid schema name: 7 ERROR:  no schema has been selected to create in at character 14 (Connection: pgsql, SQL: create table "migrations" ("id" serial not null
primary key, "migration" varchar(255) not null, "batch" integer not null))

  at vendor/laravel/framework/src/Illuminate/Database/Connection.php:823
    819▕                     $this->getName(), $query, $this->prepareBindings($bindings), $e
    820▕                 );
    821▕             }
    822▕
  ➜ 823▕             throw new QueryException(
    824▕                 $this->getName(), $query, $this->prepareBindings($bindings), $e
    825▕             );
    826▕         }
    827▕     }

      +41 vendor frames

  42  artisan:16
      Illuminate\Foundation\Application::handleCommand()
```

## What is the new behavior?

Adds a note that instructs users to create a schema before running the migrate script. After the creation migration succeeds.

```$ php artisan migrate

   INFO  Preparing database.  

  Creating migration table ........................................................................................................... 487.65ms DONE

   INFO  Running migrations.  

  0001_01_01_000000_create_users_table ..................................................................................................... 4s DONE
  0001_01_01_000001_create_cache_table ..................................................................................................... 2s DONE
  0001_01_01_000002_create_jobs_table ...................................................................................................... 3s DONE
```