### PR TITLE
Added hsts preload directive to vercel config

### DIFF
--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -74,7 +74,7 @@ const nextConfig = {
         headers: [
           {
             key: 'Strict-Transport-Security',
-            value: process.env.VERCEL === '1' ? 'max-age=1200; includeSubDomains' : '',
+            value: process.env.VERCEL === '1' ? 'max-age=31536000; includeSubDomains; preload' : '',
           },
           {
             key: 'X-Robots-Tag',
@@ -97,7 +97,7 @@ const nextConfig = {
         headers: [
           {
             key: 'Strict-Transport-Security',
-            value: process.env.VERCEL === '1' ? 'max-age=1200; includeSubDomains' : '',
+            value: process.env.VERCEL === '1' ? 'max-age=31536000; includeSubDomains; preload' : '',
           },
           {
             key: 'X-Robots-Tag',

--- a/apps/studio/next.config.js
+++ b/apps/studio/next.config.js
@@ -494,7 +494,7 @@ const nextConfig = {
             key: 'Strict-Transport-Security',
             value:
               process.env.NEXT_PUBLIC_IS_PLATFORM === 'true' && process.env.VERCEL === '1'
-                ? 'max-age=1200; includeSubDomains'
+                ? 'max-age=31536000; includeSubDomains; preload'
                 : '',
           },
           {

--- a/apps/www/next.config.mjs
+++ b/apps/www/next.config.mjs
@@ -100,7 +100,7 @@ const nextConfig = {
             key: 'Strict-Transport-Security',
             value:
               process.env.NEXT_PUBLIC_IS_PLATFORM === 'true' && process.env.VERCEL === '1'
-                ? 'max-age=1200; includeSubDomains'
+                ? 'max-age=31536000; includeSubDomains; preload'
                 : '',
           },
         ],


### PR DESCRIPTION
Final step of the hsts preload journey.
This adds the preload directive to our vercel HSTS config. This is necessary for the .com after Cloudflare no longer proxies.
The age is back to its original pre-includeSubdomains length.

Part of SEC-120