### PR TITLE
fix: bytea null values

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/ForeignRowSelector/SelectorGrid.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/ForeignRowSelector/SelectorGrid.tsx
@@ -8,6 +8,7 @@ import { Key } from 'lucide-react'
 import DataGrid, { Column } from 'react-data-grid'
 import { Tooltip, TooltipContent, TooltipTrigger } from 'ui'
 import { convertByteaToHex } from '../RowEditor.utils'
+import { NullValue } from 'components/grid/components/common/NullValue'
 
 export interface SelectorGridProps {
   table: SupaTable
@@ -34,16 +35,24 @@ const columnRender = (name: string, isPrimaryKey = false) => {
   )
 }
 
+// TODO: move this formatter out to a common component
 const formatter = ({ column, format, row }: { column: string; format: string; row: SupaRow }) => {
   const formattedValue =
     format === 'bytea'
       ? convertByteaToHex(row[column])
-      : typeof row[column] === 'object'
-        ? JSON.stringify(row[column])
-        : row[column]
+      : row[column] === null
+        ? null
+        : typeof row[column] === 'object'
+          ? JSON.stringify(row[column])
+          : row[column]
+
   return (
     <div className="group sb-grid-select-cell__formatter overflow-hidden">
-      <span className="text-sm truncate">{formattedValue}</span>
+      {formattedValue === null ? (
+        <NullValue />
+      ) : (
+        <span className="text-sm truncate">{formattedValue}</span>
+      )}
     </div>
   )
 }

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/ForeignRowSelector/SelectorGrid.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/ForeignRowSelector/SelectorGrid.tsx
@@ -1,3 +1,4 @@
+import { NullValue } from 'components/grid/components/common/NullValue'
 import { COLUMN_MIN_WIDTH } from 'components/grid/constants'
 import type { SupaRow, SupaTable } from 'components/grid/types'
 import {
@@ -8,7 +9,6 @@ import { Key } from 'lucide-react'
 import DataGrid, { Column } from 'react-data-grid'
 import { Tooltip, TooltipContent, TooltipTrigger } from 'ui'
 import { convertByteaToHex } from '../RowEditor.utils'
-import { NullValue } from 'components/grid/components/common/NullValue'
 
 export interface SelectorGridProps {
   table: SupaTable

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.utils.ts
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.utils.ts
@@ -266,5 +266,10 @@ export const isValueTruncated = (value: string | null | undefined) => {
 }
 
 export const convertByteaToHex = (value: { type: 'Buffer'; data: number[] }) => {
+  // [Alaister] this is just a safeguard to catch sneaky null values
+  if (!value) {
+    return value
+  }
+
   return `\\x${Buffer.from(value.data).toString('hex')}`
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When user has `table_a` with a `bytea` column, and `table_b` with a reference to `table_a`, the foreign row selector will error when `table_a` has a `null` value in the `bytea` column.
