### PR TITLE
Cleanup reports

### DIFF
--- a/apps/studio/components/interfaces/Reports/MetricOptions.tsx
+++ b/apps/studio/components/interfaces/Reports/MetricOptions.tsx
@@ -24,6 +24,7 @@ import {
   SQL_ICON,
 } from 'ui'
 import ShimmeringLoader from 'ui-patterns/ShimmeringLoader'
+import { DEPRECATED_REPORTS } from './Reports.constants'
 
 interface MetricOptionsProps {
   config?: Dashboards.Content
@@ -73,7 +74,10 @@ export const MetricOptions = ({ config, handleChartSelection }: MetricOptionsPro
             </DropdownMenuSubTrigger>
             <DropdownMenuPortal>
               <DropdownMenuSubContent>
-                {METRICS.filter((metric) => metric?.category?.key === cat.key).map((metric) => {
+                {METRICS.filter(
+                  (metric) =>
+                    !DEPRECATED_REPORTS.includes(metric.key) && metric?.category?.key === cat.key
+                ).map((metric) => {
                   return (
                     <DropdownMenuCheckboxItem
                       key={metric.key}

--- a/apps/studio/components/interfaces/Reports/ReportBlock/DeprecatedChartBlock.tsx
+++ b/apps/studio/components/interfaces/Reports/ReportBlock/DeprecatedChartBlock.tsx
@@ -1,0 +1,51 @@
+import { useParams } from 'common'
+import { InlineLink } from 'components/ui/InlineLink'
+import { METRICS } from 'lib/constants/metrics'
+import { ReactNode } from 'react'
+import { ReportBlockContainer } from './ReportBlockContainer'
+
+interface DeprecatedChartBlockProps {
+  label: string
+  attribute: string
+  actions?: ReactNode
+}
+
+export const DeprecatedChartBlock = ({ label, attribute, actions }: DeprecatedChartBlockProps) => {
+  const { ref } = useParams()
+  const metric = METRICS.find((x) => x.key === attribute)
+
+  const logsName = metric?.category?.label
+
+  const getLogsUrl = (logsName?: string) => {
+    switch (logsName) {
+      case 'Realtime':
+        return '/logs/realtime-logs'
+      case 'Storage':
+        return '/logs/storage-logs'
+      case 'Authentication':
+        return '/logs/auth-logs'
+      default:
+        return ''
+    }
+  }
+
+  return (
+    <ReportBlockContainer
+      draggable
+      showDragHandle
+      loading={false}
+      icon={metric?.category?.icon('text-foreground-muted')}
+      label={label}
+      actions={actions}
+    >
+      <p className="text-xs text-foreground-light">
+        This chart is not longer available, and can be removed from your report
+      </p>
+      <p className="text-xs text-foreground-lighter">
+        You may view the equivalent of this data from the{' '}
+        <InlineLink href={`/project/${ref}/${getLogsUrl(logsName)}`}>{logsName} Logs</InlineLink>{' '}
+        instead
+      </p>
+    </ReportBlockContainer>
+  )
+}

--- a/apps/studio/components/interfaces/Reports/ReportBlock/ReportBlock.tsx
+++ b/apps/studio/components/interfaces/Reports/ReportBlock/ReportBlock.tsx
@@ -11,7 +11,9 @@ import { useDatabaseSelectorStateSnapshot } from 'state/database-selector'
 import { Dashboards, SqlSnippets } from 'types'
 import { cn } from 'ui'
 import ShimmeringLoader from 'ui-patterns/ShimmeringLoader'
+import { DEPRECATED_REPORTS } from '../Reports.constants'
 import { ChartBlock } from './ChartBlock'
+import { DeprecatedChartBlock } from './DeprecatedChartBlock'
 
 interface ReportBlockProps {
   item: Dashboards.Chart
@@ -61,6 +63,7 @@ export const ReportBlock = ({
   const sql = isSnippet ? (data?.content as SqlSnippets.Content)?.sql : undefined
   const chartConfig = { ...DEFAULT_CHART_CONFIG, ...(item.chartConfig ?? {}) }
   const isReadOnlySQL = isReadOnlySelect(sql ?? '')
+  const isDeprecatedChart = DEPRECATED_REPORTS.includes(item.attribute)
   const snippetMissing = error?.message.includes('Content not found')
 
   return (
@@ -129,6 +132,22 @@ export const ReportBlock = ({
                 </>
               )}
             </div>
+          }
+        />
+      ) : isDeprecatedChart ? (
+        <DeprecatedChartBlock
+          attribute={item.attribute}
+          label={`${item.label}${projectRef !== state.selectedDatabaseId ? (item.provider === 'infra-monitoring' ? ' of replica' : ' on project') : ''}`}
+          actions={
+            !disableUpdate ? (
+              <ButtonTooltip
+                type="text"
+                icon={<X />}
+                className="w-7 h-7"
+                onClick={() => onRemoveChart({ metric: { key: item.attribute } })}
+                tooltip={{ content: { side: 'bottom', text: 'Remove chart' } }}
+              />
+            ) : null
           }
         />
       ) : (

--- a/apps/studio/components/interfaces/Reports/Reports.constants.ts
+++ b/apps/studio/components/interfaces/Reports/Reports.constants.ts
@@ -388,3 +388,16 @@ select
     },
   },
 }
+
+export const DEPRECATED_REPORTS = [
+  'total_realtime_ingress',
+  'total_rest_options_requests',
+  'total_auth_ingress',
+  'total_auth_get_requests',
+  'total_auth_post_requests',
+  'total_auth_patch_requests',
+  'total_auth_options_requests',
+  'total_storage_options_requests',
+  'total_storage_patch_requests',
+  'total_options_requests',
+]

--- a/apps/studio/lib/constants/metrics.tsx
+++ b/apps/studio/lib/constants/metrics.tsx
@@ -91,6 +91,18 @@ export const METRICS: Metric[] = [
     provider: 'daily-stats',
     category: METRIC_CATEGORIES.API,
   },
+  {
+    key: 'total_realtime_requests',
+    label: 'Realtime Connection Requests',
+    provider: 'daily-stats',
+    category: METRIC_CATEGORIES.API_REALTIME,
+  },
+  {
+    key: 'total_realtime_ingress',
+    label: 'Realtime Connection Ingress',
+    provider: 'daily-stats',
+    category: METRIC_CATEGORIES.API_REALTIME,
+  },
 
   /**
    * API
@@ -113,6 +125,36 @@ export const METRICS: Metric[] = [
     provider: 'daily-stats',
     category: METRIC_CATEGORIES.API_DATABASE,
   },
+  {
+    key: 'total_rest_get_requests',
+    label: 'API GET Requests',
+    provider: 'daily-stats',
+    category: METRIC_CATEGORIES.API_DATABASE,
+  },
+  {
+    key: 'total_rest_post_requests',
+    label: 'API POST Requests',
+    provider: 'daily-stats',
+    category: METRIC_CATEGORIES.API_DATABASE,
+  },
+  {
+    key: 'total_rest_patch_requests',
+    label: 'API PATCH Requests',
+    provider: 'daily-stats',
+    category: METRIC_CATEGORIES.API_DATABASE,
+  },
+  {
+    key: 'total_rest_delete_requests',
+    label: 'API DELETE Requests',
+    provider: 'daily-stats',
+    category: METRIC_CATEGORIES.API_DATABASE,
+  },
+  {
+    key: 'total_rest_options_requests',
+    label: 'API OPTIONS Requests',
+    provider: 'daily-stats',
+    category: METRIC_CATEGORIES.API_DATABASE,
+  },
 
   /**
    * Auth
@@ -131,6 +173,12 @@ export const METRICS: Metric[] = [
     category: METRIC_CATEGORIES.API_AUTH,
   },
   {
+    key: 'total_auth_ingress',
+    label: 'Auth Ingress',
+    provider: 'daily-stats',
+    category: METRIC_CATEGORIES.API_AUTH,
+  },
+  {
     key: 'total_auth_egress',
     label: 'Auth Egress',
     provider: 'daily-stats',
@@ -139,6 +187,30 @@ export const METRICS: Metric[] = [
   {
     key: 'total_auth_requests',
     label: 'Auth Requests',
+    provider: 'daily-stats',
+    category: METRIC_CATEGORIES.API_AUTH,
+  },
+  {
+    key: 'total_auth_get_requests',
+    label: 'Auth GET Requests',
+    provider: 'daily-stats',
+    category: METRIC_CATEGORIES.API_AUTH,
+  },
+  {
+    key: 'total_auth_post_requests',
+    label: 'Auth POST Requests',
+    provider: 'daily-stats',
+    category: METRIC_CATEGORIES.API_AUTH,
+  },
+  {
+    key: 'total_auth_patch_requests',
+    label: 'Auth PATCH Requests',
+    provider: 'daily-stats',
+    category: METRIC_CATEGORIES.API_AUTH,
+  },
+  {
+    key: 'total_auth_options_requests',
+    label: 'Auth OPTIONS Requests',
     provider: 'daily-stats',
     category: METRIC_CATEGORIES.API_AUTH,
   },
@@ -170,6 +242,36 @@ export const METRICS: Metric[] = [
     provider: 'daily-stats',
     category: METRIC_CATEGORIES.API_STORAGE,
   },
+  {
+    key: 'total_storage_get_requests',
+    label: 'Storage GET Requests',
+    provider: 'daily-stats',
+    category: METRIC_CATEGORIES.API_STORAGE,
+  },
+  {
+    key: 'total_storage_post_requests',
+    label: 'Storage POST Requests',
+    provider: 'daily-stats',
+    category: METRIC_CATEGORIES.API_STORAGE,
+  },
+  {
+    key: 'total_storage_delete_requests',
+    label: 'Storage DELETE Requests',
+    provider: 'daily-stats',
+    category: METRIC_CATEGORIES.API_STORAGE,
+  },
+  {
+    key: 'total_storage_options_requests',
+    label: 'Storage OPTIONS Requests',
+    provider: 'daily-stats',
+    category: METRIC_CATEGORIES.API_STORAGE,
+  },
+  {
+    key: 'total_auth_delete_requests',
+    label: 'Auth DELETE Requests',
+    provider: 'daily-stats',
+    category: METRIC_CATEGORIES.API_AUTH,
+  },
 
   {
     key: 'total_egress',
@@ -179,8 +281,32 @@ export const METRICS: Metric[] = [
   },
 
   {
+    key: 'total_get_requests',
+    label: 'All GET Requests',
+    provider: 'daily-stats',
+    category: METRIC_CATEGORIES.API,
+  },
+  {
+    key: 'total_storage_patch_requests',
+    label: 'Storage PATCH Requests',
+    provider: 'daily-stats',
+    category: METRIC_CATEGORIES.API_STORAGE,
+  },
+  {
     key: 'total_requests',
     label: 'All Requests',
+    provider: 'daily-stats',
+    category: METRIC_CATEGORIES.API,
+  },
+  {
+    key: 'total_patch_requests',
+    label: 'All PATCH Requests',
+    provider: 'daily-stats',
+    category: METRIC_CATEGORIES.API,
+  },
+  {
+    key: 'total_post_requests',
+    label: 'All POST Requests',
     provider: 'daily-stats',
     category: METRIC_CATEGORIES.API,
   },
@@ -188,6 +314,18 @@ export const METRICS: Metric[] = [
   {
     key: 'total_ingress',
     label: 'All Ingress',
+    provider: 'daily-stats',
+    category: METRIC_CATEGORIES.API,
+  },
+  {
+    key: 'total_delete_requests',
+    label: 'All DELETE Requests',
+    provider: 'daily-stats',
+    category: METRIC_CATEGORIES.API,
+  },
+  {
+    key: 'total_options_requests',
+    label: 'All OPTIONS Requests',
     provider: 'daily-stats',
     category: METRIC_CATEGORIES.API,
   },

--- a/apps/studio/lib/constants/metrics.tsx
+++ b/apps/studio/lib/constants/metrics.tsx
@@ -28,17 +28,17 @@ export const METRIC_CATEGORIES = {
     key: 'api_database',
   },
   API_AUTH: {
-    label: 'Auth API',
+    label: 'Authentication',
     icon: (className?: string) => <Auth size={16} className={className} />,
     key: 'api_auth',
   },
   API_STORAGE: {
-    label: 'Storage API',
+    label: 'Storage',
     icon: (className?: string) => <Storage size={16} className={className} />,
     key: 'api_storage',
   },
   API_REALTIME: {
-    label: 'Realtime API',
+    label: 'Realtime',
     icon: (className?: string) => <Realtime size={16} className={className} />,
     key: 'api_realtime',
   },
@@ -54,6 +54,7 @@ export const METRIC_CATEGORIES = {
   },
 }
 
+// [Joshen] Eventually we can remove some charts here from DEPRECATED_REPORTS from Reports.constants.ts
 export const METRICS: Metric[] = [
   {
     key: 'avg_cpu_usage',
@@ -94,6 +95,12 @@ export const METRICS: Metric[] = [
   {
     key: 'total_realtime_requests',
     label: 'Realtime Connection Requests',
+    provider: 'daily-stats',
+    category: METRIC_CATEGORIES.API_REALTIME,
+  },
+  {
+    key: 'total_realtime_ingress',
+    label: 'Realtime Connection Ingress',
     provider: 'daily-stats',
     category: METRIC_CATEGORIES.API_REALTIME,
   },
@@ -143,6 +150,12 @@ export const METRICS: Metric[] = [
     provider: 'daily-stats',
     category: METRIC_CATEGORIES.API_DATABASE,
   },
+  {
+    key: 'total_rest_options_requests',
+    label: 'API OPTIONS Requests',
+    provider: 'daily-stats',
+    category: METRIC_CATEGORIES.API_DATABASE,
+  },
 
   /**
    * Auth
@@ -161,6 +174,12 @@ export const METRICS: Metric[] = [
     category: METRIC_CATEGORIES.API_AUTH,
   },
   {
+    key: 'total_auth_ingress',
+    label: 'Auth Ingress',
+    provider: 'daily-stats',
+    category: METRIC_CATEGORIES.API_AUTH,
+  },
+  {
     key: 'total_auth_egress',
     label: 'Auth Egress',
     provider: 'daily-stats',
@@ -169,6 +188,30 @@ export const METRICS: Metric[] = [
   {
     key: 'total_auth_requests',
     label: 'Auth Requests',
+    provider: 'daily-stats',
+    category: METRIC_CATEGORIES.API_AUTH,
+  },
+  {
+    key: 'total_auth_get_requests',
+    label: 'Auth GET Requests',
+    provider: 'daily-stats',
+    category: METRIC_CATEGORIES.API_AUTH,
+  },
+  {
+    key: 'total_auth_post_requests',
+    label: 'Auth POST Requests',
+    provider: 'daily-stats',
+    category: METRIC_CATEGORIES.API_AUTH,
+  },
+  {
+    key: 'total_auth_patch_requests',
+    label: 'Auth PATCH Requests',
+    provider: 'daily-stats',
+    category: METRIC_CATEGORIES.API_AUTH,
+  },
+  {
+    key: 'total_auth_options_requests',
+    label: 'Auth OPTIONS Requests',
     provider: 'daily-stats',
     category: METRIC_CATEGORIES.API_AUTH,
   },
@@ -219,6 +262,12 @@ export const METRICS: Metric[] = [
     category: METRIC_CATEGORIES.API_STORAGE,
   },
   {
+    key: 'total_storage_options_requests',
+    label: 'Storage OPTIONS Requests',
+    provider: 'daily-stats',
+    category: METRIC_CATEGORIES.API_STORAGE,
+  },
+  {
     key: 'total_auth_delete_requests',
     label: 'Auth DELETE Requests',
     provider: 'daily-stats',
@@ -237,6 +286,12 @@ export const METRICS: Metric[] = [
     label: 'All GET Requests',
     provider: 'daily-stats',
     category: METRIC_CATEGORIES.API,
+  },
+  {
+    key: 'total_storage_patch_requests',
+    label: 'Storage PATCH Requests',
+    provider: 'daily-stats',
+    category: METRIC_CATEGORIES.API_STORAGE,
   },
   {
     key: 'total_requests',
@@ -266,6 +321,12 @@ export const METRICS: Metric[] = [
   {
     key: 'total_delete_requests',
     label: 'All DELETE Requests',
+    provider: 'daily-stats',
+    category: METRIC_CATEGORIES.API,
+  },
+  {
+    key: 'total_options_requests',
+    label: 'All OPTIONS Requests',
     provider: 'daily-stats',
     category: METRIC_CATEGORIES.API,
   },

--- a/apps/studio/lib/constants/metrics.tsx
+++ b/apps/studio/lib/constants/metrics.tsx
@@ -91,18 +91,6 @@ export const METRICS: Metric[] = [
     provider: 'daily-stats',
     category: METRIC_CATEGORIES.API,
   },
-  {
-    key: 'total_realtime_requests',
-    label: 'Realtime Connection Requests',
-    provider: 'daily-stats',
-    category: METRIC_CATEGORIES.API_REALTIME,
-  },
-  {
-    key: 'total_realtime_ingress',
-    label: 'Realtime Connection Ingress',
-    provider: 'daily-stats',
-    category: METRIC_CATEGORIES.API_REALTIME,
-  },
 
   /**
    * API
@@ -125,36 +113,6 @@ export const METRICS: Metric[] = [
     provider: 'daily-stats',
     category: METRIC_CATEGORIES.API_DATABASE,
   },
-  {
-    key: 'total_rest_get_requests',
-    label: 'API GET Requests',
-    provider: 'daily-stats',
-    category: METRIC_CATEGORIES.API_DATABASE,
-  },
-  {
-    key: 'total_rest_post_requests',
-    label: 'API POST Requests',
-    provider: 'daily-stats',
-    category: METRIC_CATEGORIES.API_DATABASE,
-  },
-  {
-    key: 'total_rest_patch_requests',
-    label: 'API PATCH Requests',
-    provider: 'daily-stats',
-    category: METRIC_CATEGORIES.API_DATABASE,
-  },
-  {
-    key: 'total_rest_delete_requests',
-    label: 'API DELETE Requests',
-    provider: 'daily-stats',
-    category: METRIC_CATEGORIES.API_DATABASE,
-  },
-  {
-    key: 'total_rest_options_requests',
-    label: 'API OPTIONS Requests',
-    provider: 'daily-stats',
-    category: METRIC_CATEGORIES.API_DATABASE,
-  },
 
   /**
    * Auth
@@ -173,12 +131,6 @@ export const METRICS: Metric[] = [
     category: METRIC_CATEGORIES.API_AUTH,
   },
   {
-    key: 'total_auth_ingress',
-    label: 'Auth Ingress',
-    provider: 'daily-stats',
-    category: METRIC_CATEGORIES.API_AUTH,
-  },
-  {
     key: 'total_auth_egress',
     label: 'Auth Egress',
     provider: 'daily-stats',
@@ -187,30 +139,6 @@ export const METRICS: Metric[] = [
   {
     key: 'total_auth_requests',
     label: 'Auth Requests',
-    provider: 'daily-stats',
-    category: METRIC_CATEGORIES.API_AUTH,
-  },
-  {
-    key: 'total_auth_get_requests',
-    label: 'Auth GET Requests',
-    provider: 'daily-stats',
-    category: METRIC_CATEGORIES.API_AUTH,
-  },
-  {
-    key: 'total_auth_post_requests',
-    label: 'Auth POST Requests',
-    provider: 'daily-stats',
-    category: METRIC_CATEGORIES.API_AUTH,
-  },
-  {
-    key: 'total_auth_patch_requests',
-    label: 'Auth PATCH Requests',
-    provider: 'daily-stats',
-    category: METRIC_CATEGORIES.API_AUTH,
-  },
-  {
-    key: 'total_auth_options_requests',
-    label: 'Auth OPTIONS Requests',
     provider: 'daily-stats',
     category: METRIC_CATEGORIES.API_AUTH,
   },
@@ -242,36 +170,6 @@ export const METRICS: Metric[] = [
     provider: 'daily-stats',
     category: METRIC_CATEGORIES.API_STORAGE,
   },
-  {
-    key: 'total_storage_get_requests',
-    label: 'Storage GET Requests',
-    provider: 'daily-stats',
-    category: METRIC_CATEGORIES.API_STORAGE,
-  },
-  {
-    key: 'total_storage_post_requests',
-    label: 'Storage POST Requests',
-    provider: 'daily-stats',
-    category: METRIC_CATEGORIES.API_STORAGE,
-  },
-  {
-    key: 'total_storage_delete_requests',
-    label: 'Storage DELETE Requests',
-    provider: 'daily-stats',
-    category: METRIC_CATEGORIES.API_STORAGE,
-  },
-  {
-    key: 'total_storage_options_requests',
-    label: 'Storage OPTIONS Requests',
-    provider: 'daily-stats',
-    category: METRIC_CATEGORIES.API_STORAGE,
-  },
-  {
-    key: 'total_auth_delete_requests',
-    label: 'Auth DELETE Requests',
-    provider: 'daily-stats',
-    category: METRIC_CATEGORIES.API_AUTH,
-  },
 
   {
     key: 'total_egress',
@@ -281,32 +179,8 @@ export const METRICS: Metric[] = [
   },
 
   {
-    key: 'total_get_requests',
-    label: 'All GET Requests',
-    provider: 'daily-stats',
-    category: METRIC_CATEGORIES.API,
-  },
-  {
-    key: 'total_storage_patch_requests',
-    label: 'Storage PATCH Requests',
-    provider: 'daily-stats',
-    category: METRIC_CATEGORIES.API_STORAGE,
-  },
-  {
     key: 'total_requests',
     label: 'All Requests',
-    provider: 'daily-stats',
-    category: METRIC_CATEGORIES.API,
-  },
-  {
-    key: 'total_patch_requests',
-    label: 'All PATCH Requests',
-    provider: 'daily-stats',
-    category: METRIC_CATEGORIES.API,
-  },
-  {
-    key: 'total_post_requests',
-    label: 'All POST Requests',
     provider: 'daily-stats',
     category: METRIC_CATEGORIES.API,
   },
@@ -314,18 +188,6 @@ export const METRICS: Metric[] = [
   {
     key: 'total_ingress',
     label: 'All Ingress',
-    provider: 'daily-stats',
-    category: METRIC_CATEGORIES.API,
-  },
-  {
-    key: 'total_delete_requests',
-    label: 'All DELETE Requests',
-    provider: 'daily-stats',
-    category: METRIC_CATEGORIES.API,
-  },
-  {
-    key: 'total_options_requests',
-    label: 'All OPTIONS Requests',
     provider: 'daily-stats',
     category: METRIC_CATEGORIES.API,
   },

--- a/apps/studio/lib/constants/metrics.tsx
+++ b/apps/studio/lib/constants/metrics.tsx
@@ -97,12 +97,6 @@ export const METRICS: Metric[] = [
     provider: 'daily-stats',
     category: METRIC_CATEGORIES.API_REALTIME,
   },
-  {
-    key: 'total_realtime_ingress',
-    label: 'Realtime Connection Ingress',
-    provider: 'daily-stats',
-    category: METRIC_CATEGORIES.API_REALTIME,
-  },
 
   /**
    * API
@@ -149,12 +143,6 @@ export const METRICS: Metric[] = [
     provider: 'daily-stats',
     category: METRIC_CATEGORIES.API_DATABASE,
   },
-  {
-    key: 'total_rest_options_requests',
-    label: 'API OPTIONS Requests',
-    provider: 'daily-stats',
-    category: METRIC_CATEGORIES.API_DATABASE,
-  },
 
   /**
    * Auth
@@ -173,12 +161,6 @@ export const METRICS: Metric[] = [
     category: METRIC_CATEGORIES.API_AUTH,
   },
   {
-    key: 'total_auth_ingress',
-    label: 'Auth Ingress',
-    provider: 'daily-stats',
-    category: METRIC_CATEGORIES.API_AUTH,
-  },
-  {
     key: 'total_auth_egress',
     label: 'Auth Egress',
     provider: 'daily-stats',
@@ -187,30 +169,6 @@ export const METRICS: Metric[] = [
   {
     key: 'total_auth_requests',
     label: 'Auth Requests',
-    provider: 'daily-stats',
-    category: METRIC_CATEGORIES.API_AUTH,
-  },
-  {
-    key: 'total_auth_get_requests',
-    label: 'Auth GET Requests',
-    provider: 'daily-stats',
-    category: METRIC_CATEGORIES.API_AUTH,
-  },
-  {
-    key: 'total_auth_post_requests',
-    label: 'Auth POST Requests',
-    provider: 'daily-stats',
-    category: METRIC_CATEGORIES.API_AUTH,
-  },
-  {
-    key: 'total_auth_patch_requests',
-    label: 'Auth PATCH Requests',
-    provider: 'daily-stats',
-    category: METRIC_CATEGORIES.API_AUTH,
-  },
-  {
-    key: 'total_auth_options_requests',
-    label: 'Auth OPTIONS Requests',
     provider: 'daily-stats',
     category: METRIC_CATEGORIES.API_AUTH,
   },
@@ -261,12 +219,6 @@ export const METRICS: Metric[] = [
     category: METRIC_CATEGORIES.API_STORAGE,
   },
   {
-    key: 'total_storage_options_requests',
-    label: 'Storage OPTIONS Requests',
-    provider: 'daily-stats',
-    category: METRIC_CATEGORIES.API_STORAGE,
-  },
-  {
     key: 'total_auth_delete_requests',
     label: 'Auth DELETE Requests',
     provider: 'daily-stats',
@@ -285,12 +237,6 @@ export const METRICS: Metric[] = [
     label: 'All GET Requests',
     provider: 'daily-stats',
     category: METRIC_CATEGORIES.API,
-  },
-  {
-    key: 'total_storage_patch_requests',
-    label: 'Storage PATCH Requests',
-    provider: 'daily-stats',
-    category: METRIC_CATEGORIES.API_STORAGE,
   },
   {
     key: 'total_requests',
@@ -320,12 +266,6 @@ export const METRICS: Metric[] = [
   {
     key: 'total_delete_requests',
     label: 'All DELETE Requests',
-    provider: 'daily-stats',
-    category: METRIC_CATEGORIES.API,
-  },
-  {
-    key: 'total_options_requests',
-    label: 'All OPTIONS Requests',
     provider: 'daily-stats',
     category: METRIC_CATEGORIES.API,
   },


### PR DESCRIPTION
The following reports are planned to be deprecated as the data returned from these charts are not intrinsically helpful of a daily aggregate basis:
- total_realtime_ingress
- total_rest_options_requests
- total_auth_ingress
- total_auth_get_requests
- total_auth_post_requests
- total_auth_patch_requests
- total_auth_options_requests
- total_storage_options_requests
- total_storage_patch_requests
- total_options_requests

For those charts that are affected, they'll no longer be selectable in the Add block dropdown, and we'll be rendering the following empty state instead if they're currently used in custom reports:
![image](https://github.com/user-attachments/assets/96e1843a-88e1-4e4c-a87e-d79faa5d93db)
