### PR TITLE
fix: stop sending view definition query all the time

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/GridHeaderActions.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/GridHeaderActions.tsx
@@ -14,7 +14,6 @@ import { useDatabasePoliciesQuery } from 'data/database-policies/database-polici
 import { useDatabasePublicationsQuery } from 'data/database-publications/database-publications-query'
 import { useDatabasePublicationUpdateMutation } from 'data/database-publications/database-publications-update-mutation'
 import { useProjectLintsQuery } from 'data/lint/lint-query'
-import { useSendEventMutation } from 'data/telemetry/send-event-mutation'
 import {
   Entity,
   isTableLike,
@@ -23,8 +22,10 @@ import {
   isView as isTableLikeView,
 } from 'data/table-editor/table-editor-types'
 import { useTableUpdateMutation } from 'data/tables/table-update-mutation'
+import { useSendEventMutation } from 'data/telemetry/send-event-mutation'
 import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
+import { useSelectedOrganization } from 'hooks/misc/useSelectedOrganization'
 import { PROTECTED_SCHEMAS } from 'lib/constants/schemas'
 import {
   Button,
@@ -40,7 +41,6 @@ import ConfirmModal from 'ui-patterns/Dialogs/ConfirmDialog'
 import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
 import { RoleImpersonationPopover } from '../RoleImpersonationSelector'
 import ViewEntityAutofixSecurityModal from './ViewEntityAutofixSecurityModal'
-import { useSelectedOrganization } from 'hooks/misc/useSelectedOrganization'
 
 export interface GridHeaderActionsProps {
   table: Entity
@@ -53,9 +53,7 @@ const GridHeaderActions = ({ table }: GridHeaderActionsProps) => {
   const org = useSelectedOrganization()
 
   // need project lints to get security status for views
-  const { data: lints = [] } = useProjectLintsQuery({
-    projectRef: project?.ref,
-  })
+  const { data: lints = [] } = useProjectLintsQuery({ projectRef: project?.ref })
 
   const isTable = isTableLike(table)
   const isForeignTable = isTableLikeForeignTable(table)
@@ -74,7 +72,6 @@ const GridHeaderActions = ({ table }: GridHeaderActionsProps) => {
     },
   })
 
-  const [open, setOpen] = useState(false)
   const [showEnableRealtime, setShowEnableRealtime] = useState(false)
   const [rlsConfirmModalOpen, setRlsConfirmModalOpen] = useState(false)
   const [isAutofixViewSecurityModalOpen, setIsAutofixViewSecurityModalOpen] = useState(false)
@@ -260,7 +257,7 @@ const GridHeaderActions = ({ table }: GridHeaderActionsProps) => {
                 )}
               </>
             ) : (
-              <Popover_Shadcn_ open={open} onOpenChange={() => setOpen(!open)} modal={false}>
+              <Popover_Shadcn_ modal={false}>
                 <PopoverTrigger_Shadcn_ asChild>
                   <Button type="warning" icon={<Lock strokeWidth={1.5} />}>
                     RLS disabled
@@ -295,7 +292,7 @@ const GridHeaderActions = ({ table }: GridHeaderActionsProps) => {
             )
           ) : null}
           {isView && viewHasLints && (
-            <Popover_Shadcn_ open={open} onOpenChange={() => setOpen(!open)} modal={false}>
+            <Popover_Shadcn_ modal={false}>
               <PopoverTrigger_Shadcn_ asChild>
                 <Button type="warning" icon={<Unlock strokeWidth={1.5} />}>
                   Security Definer view
@@ -340,7 +337,7 @@ const GridHeaderActions = ({ table }: GridHeaderActionsProps) => {
             </Popover_Shadcn_>
           )}
           {isMaterializedView && materializedViewHasLints && (
-            <Popover_Shadcn_ open={open} onOpenChange={() => setOpen(!open)} modal={false}>
+            <Popover_Shadcn_ modal={false}>
               <PopoverTrigger_Shadcn_ asChild>
                 <Button type="warning" icon={<Unlock strokeWidth={1.5} />}>
                   Security Definer view
@@ -377,7 +374,7 @@ const GridHeaderActions = ({ table }: GridHeaderActionsProps) => {
             </Popover_Shadcn_>
           )}
           {isForeignTable && table.schema === 'public' && (
-            <Popover_Shadcn_ open={open} onOpenChange={() => setOpen(!open)} modal={false}>
+            <Popover_Shadcn_ modal={false}>
               <PopoverTrigger_Shadcn_ asChild>
                 <Button type="warning" icon={<Unlock strokeWidth={1.5} />}>
                   Foreign table is accessible via your project's APIs

--- a/apps/studio/components/interfaces/TableGridEditor/ViewEntityAutofixSecurityModal.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/ViewEntityAutofixSecurityModal.tsx
@@ -28,7 +28,7 @@ export default function ViewEntityAutofixSecurityModal({
       connectionString: project?.connectionString,
     },
     {
-      enabled: isViewLike(table),
+      enabled: isAutofixViewSecurityModalOpen && isViewLike(table),
     }
   )
 

--- a/apps/studio/components/interfaces/TableGridEditor/ViewEntityAutofixSecurityModal.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/ViewEntityAutofixSecurityModal.tsx
@@ -1,12 +1,14 @@
 import { useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+
 import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
 import { useViewDefinitionQuery } from 'data/database/view-definition-query'
+import { lintKeys } from 'data/lint/keys'
 import { useExecuteSqlMutation } from 'data/sql/execute-sql-mutation'
 import { Entity, isViewLike } from 'data/table-editor/table-editor-types'
-import { toast } from 'sonner'
 import { ScrollArea, SimpleCodeBlock } from 'ui'
+import { GenericSkeletonLoader } from 'ui-patterns'
 import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
-import { lintKeys } from '../../../data/lint/keys'
 
 interface ViewEntityAutofixSecurityModalProps {
   table: Entity
@@ -21,7 +23,7 @@ export default function ViewEntityAutofixSecurityModal({
 }: ViewEntityAutofixSecurityModalProps) {
   const { project } = useProjectContext()
   const queryClient = useQueryClient()
-  const { isSuccess, data } = useViewDefinitionQuery(
+  const { isSuccess, isLoading, data } = useViewDefinitionQuery(
     {
       id: table?.id,
       projectRef: project?.ref,
@@ -65,9 +67,7 @@ export default function ViewEntityAutofixSecurityModal({
       title="Confirm autofixing view security"
       confirmLabel="Confirm"
       onCancel={() => setIsAutofixViewSecurityModalOpen(false)}
-      onConfirm={() => {
-        handleConfirm()
-      }}
+      onConfirm={() => handleConfirm()}
     >
       <p className="text-sm text-foreground-light">
         Setting <code>security_invoker=on</code> ensures the View runs with the permissions of the
@@ -75,8 +75,9 @@ export default function ViewEntityAutofixSecurityModal({
       </p>
       <div className="flex items-center gap-8 mt-8">
         <div className=" border rounded-md w-1/2">
-          <div className="p-4 bg-200 font-mono text-sm font-semibold">Existing query</div>
+          <div className="p-4 pb-0 bg-200 font-mono text-sm font-semibold">Existing query</div>
           <ScrollArea className="h-[225px] px-4 py-2">
+            {isLoading && <GenericSkeletonLoader />}
             {isSuccess && (
               <SimpleCodeBlock>
                 {`create view ${table.schema}.${table.name} as\n ${data}`}
@@ -86,8 +87,9 @@ export default function ViewEntityAutofixSecurityModal({
         </div>
 
         <div className=" border rounded-md w-1/2">
-          <div className="p-4 bg-200 font-mono text-sm font-semibold">Updated query</div>
+          <div className="p-4 pb-0 bg-200 font-mono text-sm font-semibold">Updated query</div>
           <ScrollArea className="h-[225px] px-4 py-2">
+            {isLoading && <GenericSkeletonLoader />}
             {isSuccess && (
               <SimpleCodeBlock>
                 {`create view ${table.schema}.${table.name} with (security_invoker = on) as\n ${data}`}


### PR DESCRIPTION
It seems the view definition query was sending for any entity type. This limits it to views only and also only when the modal is open