### PR TITLE
fix: double ? on sign in urls

### DIFF
--- a/apps/studio/lib/gotrue.ts
+++ b/apps/studio/lib/gotrue.ts
@@ -37,8 +37,19 @@ export const getIdentity = (gotrueUser: User) => {
  * Transfers the search params from the current location path to a newly built path
  */
 export const buildPathWithParams = (pathname: string) => {
-  const searchParams = new URLSearchParams(location.search)
-  return `${pathname}?${searchParams.toString()}`
+  const [basePath, existingParams] = pathname.split('?', 2)
+
+  const pathnameSearchParams = new URLSearchParams(existingParams || '')
+
+  // Merge the parameters, with pathname parameters taking precedence
+  // over the current location's search parameters
+  const mergedParams = new URLSearchParams(location.search)
+  for (const [key, value] of pathnameSearchParams.entries()) {
+    mergedParams.set(key, value)
+  }
+
+  const queryString = mergedParams.toString()
+  return queryString ? `${basePath}?${queryString}` : basePath
 }
 
 export const getReturnToPath = (fallback = '/projects') => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

<img width="830" alt="Screenshot 2025-03-05 at 19 07 33" src="https://github.com/user-attachments/assets/143fe990-2ca5-43ec-8b2d-92f5b7cabb19" />

## What is the new behavior?

The URL gets created properly.