### PR TITLE
fix: Fix crash in JS reference page

### DIFF
--- a/apps/docs/components/GuidesTableOfContents.tsx
+++ b/apps/docs/components/GuidesTableOfContents.tsx
@@ -3,9 +3,9 @@
 import { usePathname } from 'next/navigation'
 import { cn } from 'ui'
 import { ExpandableVideo } from 'ui-patterns/ExpandableVideo'
+import { Toc, TOCItems, TOCScrollArea } from 'ui-patterns/Toc'
 import { Feedback } from '~/components/Feedback'
-import { Toc, TOCItems, TOCScrollArea } from 'ui-patterns'
-import { useTocAnchors } from '../features/docs/GuidesMdx.client'
+import { useTocAnchors } from '../features/docs/GuidesMdx.state'
 
 interface TOCHeader {
   id?: string

--- a/apps/docs/features/docs/GuidesMdx.client.tsx
+++ b/apps/docs/features/docs/GuidesMdx.client.tsx
@@ -1,47 +1,21 @@
 'use client'
 
-import { proxy, useSnapshot } from 'valtio'
-
 /**
  * The MDXProvider is necessary so that MDX partials will have access
  * to components.
  */
 
 import { MDXProvider } from '@mdx-js/react'
-import { createContext, useContext, useEffect, useState, type PropsWithChildren } from 'react'
+import { useEffect, useState, type PropsWithChildren } from 'react'
+import { AnchorProvider } from 'ui-patterns'
 import { components } from '~/features/docs/MdxBase.shared'
-import { type AnchorProviderProps, AnchorProvider } from 'ui-patterns'
+import { TocAnchorsContext, useSubscribeTocRerender } from './GuidesMdx.state'
 
 interface TOCHeader {
   id?: string
   text: string
   link: string
   level: number
-}
-
-const TocAnchorsContext = createContext<AnchorProviderProps | undefined>(undefined)
-
-const useTocAnchors = () => {
-  const context = useContext(TocAnchorsContext)
-  if (!context) {
-    throw new Error('useTocAnchors must be used within an TocAnchorsContext')
-  }
-  return context
-}
-
-const useTocRerenderTrigger = () => {
-  const { toggleRenderFlag } = useSnapshot(tocRenderSwitch)
-  return toggleRenderFlag
-}
-
-const tocRenderSwitch = proxy({
-  renderFlag: 0,
-  toggleRenderFlag: () => void (tocRenderSwitch.renderFlag = (tocRenderSwitch.renderFlag + 1) % 2),
-})
-
-const useSubscribeTocRerender = () => {
-  const { renderFlag } = useSnapshot(tocRenderSwitch)
-  return void renderFlag // Prevent it from being detected as unused code
 }
 
 const TocAnchorsProvider = ({ children }: PropsWithChildren) => {
@@ -101,4 +75,4 @@ const MDXProviderGuides = ({ children }: PropsWithChildren) => {
   return <MDXProvider components={components}>{children}</MDXProvider>
 }
 
-export { MDXProviderGuides, TocAnchorsProvider, useTocAnchors, useTocRerenderTrigger }
+export { MDXProviderGuides, TocAnchorsProvider }

--- a/apps/docs/features/docs/GuidesMdx.state.ts
+++ b/apps/docs/features/docs/GuidesMdx.state.ts
@@ -1,0 +1,32 @@
+'use client'
+
+import { createContext, useContext } from 'react'
+import { type AnchorProviderProps } from 'ui-patterns/Toc'
+import { proxy, useSnapshot } from 'valtio'
+
+const TocAnchorsContext = createContext<AnchorProviderProps | undefined>(undefined)
+
+const useTocAnchors = () => {
+  const context = useContext(TocAnchorsContext)
+  if (!context) {
+    throw new Error('useTocAnchors must be used within an TocAnchorsContext')
+  }
+  return context
+}
+
+const useTocRerenderTrigger = () => {
+  const { toggleRenderFlag } = useSnapshot(tocRenderSwitch)
+  return toggleRenderFlag
+}
+
+const tocRenderSwitch = proxy({
+  renderFlag: 0,
+  toggleRenderFlag: () => void (tocRenderSwitch.renderFlag = (tocRenderSwitch.renderFlag + 1) % 2),
+})
+
+const useSubscribeTocRerender = () => {
+  const { renderFlag } = useSnapshot(tocRenderSwitch)
+  return void renderFlag // Prevent it from being detected as unused code
+}
+
+export { TocAnchorsContext, useSubscribeTocRerender, useTocAnchors, useTocRerenderTrigger }

--- a/apps/docs/features/ui/Tabs.tsx
+++ b/apps/docs/features/ui/Tabs.tsx
@@ -3,7 +3,7 @@
 import { useCallback, type ComponentPropsWithoutRef, type PropsWithChildren } from 'react'
 import { Tabs as TabsPrimitive, type TabsProps } from 'ui'
 import { withQueryParams, withSticky, type QueryParamsProps } from 'ui-patterns/ComplexTabs'
-import { useTocRerenderTrigger } from '~/features/docs/GuidesMdx.client'
+import { useTocRerenderTrigger } from '~/features/docs/GuidesMdx.state'
 
 const TabsWithStickyAndQueryParams = withSticky<PropsWithChildren<TabsProps & QueryParamsProps>>(
   withQueryParams(TabsPrimitive)
@@ -40,4 +40,4 @@ const Tabs = ({
   )
 }
 
-export { Tabs, TabPanel }
+export { TabPanel, Tabs }


### PR DESCRIPTION
This PR fixes an issue in the JS reference page in docs. The Tabs component was importing TOC state, which imported the Tabs again and caused a cyclic dependency issue.

Close https://github.com/supabase/supabase-py/issues/1072