### PR TITLE
Skip JSON stringify cell values on string types to remove unnecessary double quotes

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/Results.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/Results.tsx
@@ -63,7 +63,7 @@ const Results = ({ rows }: { rows: readonly any[] }) => {
           >
             {cellValue === null
               ? 'NULL'
-              : typeof cellValue === 'number' || typeof cellValue === 'string'
+              : typeof cellValue === 'string'
                 ? cellValue
                 : JSON.stringify(cellValue)}
           </div>

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/Results.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/Results.tsx
@@ -50,24 +50,29 @@ const Results = ({ rows }: { rows: readonly any[] }) => {
   )
 
   const formatter = (column: any, row: any) => {
+    const cellValue = row[column]
+
     return (
       <ContextMenu_Shadcn_ modal={false}>
         <ContextMenuTrigger_Shadcn_ asChild>
           <div
             className={cn(
               'flex items-center h-full font-mono text-xs w-full whitespace-pre',
-              row[column] === null && 'text-foreground-lighter'
+              cellValue === null && 'text-foreground-lighter'
             )}
           >
-            {row[column] === null ? 'NULL' : JSON.stringify(row[column])}
+            {cellValue === null
+              ? 'NULL'
+              : typeof cellValue === 'number' || typeof cellValue === 'string'
+                ? cellValue
+                : JSON.stringify(cellValue)}
           </div>
         </ContextMenuTrigger_Shadcn_>
         <ContextMenuContent_Shadcn_ onCloseAutoFocus={(e) => e.stopPropagation()}>
           <ContextMenuItem_Shadcn_
             className="gap-x-2"
             onSelect={() => {
-              const cellValue = row[column] ?? ''
-              const value = formatClipboardValue(cellValue)
+              const value = formatClipboardValue(cellValue ?? '')
               copyToClipboard(value)
             }}
             onFocusCapture={(e) => e.stopPropagation()}

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityTabResults.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityTabResults.tsx
@@ -97,7 +97,7 @@ const UtilityTabResults = ({
               ) : (
                 <p className="font-mono text-sm tracking-tight">Error: {result.error?.message}</p>
               )}
-              {result.autoLimit && (
+              {!isTimeout && result.autoLimit && (
                 <p className="text-sm text-foreground-light">
                   Note: A limit of {result.autoLimit} was applied to your query. If this was the
                   cause of a syntax error, try selecting "No limit" instead and re-run the query.


### PR DESCRIPTION
Before:
<img width="406" alt="image" src="https://github.com/user-attachments/assets/37343444-949e-4d96-8080-8762f13e2a2f" />

After:
<img width="402" alt="image" src="https://github.com/user-attachments/assets/e39bce70-386d-4cf7-a7c9-ecef3c9f4bd3" />
