### PR TITLE
Chore/fix ef secret paste

### DIFF
--- a/apps/studio/components/interfaces/Functions/EdgeFunctionSecrets/AddNewSecretForm.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionSecrets/AddNewSecretForm.tsx
@@ -60,6 +60,22 @@ const AddNewSecretForm = () => {
     const text = e.clipboardData?.getData('text')
     if (!text) return
 
+    // If text doesn't contain '=' and is being pasted into a specific field, handle as single value
+    if (!text.includes('=')) {
+      const inputName = (e.target as HTMLInputElement).name
+      if (inputName?.includes('secrets')) {
+        const [_, indexStr, field] = inputName.match(/secrets\.(\d+)\.(\w+)/) || []
+        if (indexStr && field) {
+          const index = parseInt(indexStr)
+          form.setValue(
+            `secrets.${index}.${field}` as `secrets.${number}.name` | `secrets.${number}.value`,
+            text
+          )
+          return
+        }
+      }
+    }
+
     const pairs: Array<SecretPair> = []
 
     try {


### PR DESCRIPTION
Current ui doesn't let you paste in just a key or value (it requires pasting format key=value). 
