### PR TITLE
docs: add local development guidance for database webhooks

### DIFF
--- a/apps/docs/content/guides/database/webhooks.mdx
+++ b/apps/docs/content/guides/database/webhooks.mdx
@@ -80,6 +80,20 @@ type DeletePayload = {
 
 Logging history of webhook calls is available under the `net` schema of your database. For more info, see the [GitHub Repo](https://github.com/supabase/pg_net).
 
+## Local Development
+
+When using Database Webhooks on your local Supabase instance, you need to be aware that the Postgres database runs inside a Docker container. This means that `localhost` or `127.0.0.1` in your webhook URL will refer to the container itself, not your host machine where your application is running.
+
+To target services running on your host machine, use `host.docker.internal`. If that doesn't work, you may need to use your machine's local IP address instead.
+
+For example, if you want to trigger an edge function when a webhook fires, your webhook URL would be:
+
+```
+http://host.docker.internal:54321/functions/v1/my-function-name
+```
+
+If you're experiencing connection issues with webhooks locally, verify you're using the correct hostname instead of `localhost`.
+
 ## Resources
 
 - [pg_net](/docs/guides/database/extensions/pgnet): an async networking extension for Postgres

--- a/apps/docs/content/guides/database/webhooks.mdx
+++ b/apps/docs/content/guides/database/webhooks.mdx
@@ -80,7 +80,7 @@ type DeletePayload = {
 
 Logging history of webhook calls is available under the `net` schema of your database. For more info, see the [GitHub Repo](https://github.com/supabase/pg_net).
 
-## Local Development
+## Local development
 
 When using Database Webhooks on your local Supabase instance, you need to be aware that the Postgres database runs inside a Docker container. This means that `localhost` or `127.0.0.1` in your webhook URL will refer to the container itself, not your host machine where your application is running.
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Documentation update

## What is the current behavior?

Currently, the Database Webhooks documentation doesn't explain how to properly configure webhooks when using Supabase locally. This leads to connection issues when developers try to use `localhost` or `127.0.0.1` in webhook URLs, as reported in:

- [pg_net#79](https://github.com/supabase/pg_net/issues/79)
- [supabase#13005](https://github.com/supabase/supabase/issues/13005)

## What is the new behavior?

Added a "Local Development" section to the Database Webhooks documentation that:

- Explains why `localhost` doesn't work (Docker container networking context)
- Provides the correct solution (`host.docker.internal`)
- Includes an example URL format for triggering edge functions locally
- Offers troubleshooting advice for connection issues

## Additional context

This documentation improvement helps developers avoid common pitfalls when working with webhooks in a local Supabase environment. The issue has been recurring in the community, and having clear documentation will help reduce the number of support requests related to this topic.