### PR TITLE
add pointer events none to sidebar notification dot

### DIFF
--- a/apps/studio/components/interfaces/Sidebar.tsx
+++ b/apps/studio/components/interfaces/Sidebar.tsx
@@ -246,7 +246,7 @@ const ActiveDot = (errorArray: any[], warningArray: any[]) => {
   return (
     <div
       className={cn(
-        'absolute flex h-2 w-2 left-[18px] group-data-[state=expanded]:left-[20px] top-2 z-10 rounded-full',
+        'absolute pointer-events-none flex h-2 w-2 left-[18px] group-data-[state=expanded]:left-[20px] top-2 z-10 rounded-full',
         errorArray.length > 0
           ? 'bg-destructive-600'
           : warningArray.length > 0


### PR DESCRIPTION
The notification dot prevents users from clicking the link.
![CleanShot 2025-03-09 at 16 28 11@2x](https://github.com/user-attachments/assets/36345d35-4f94-4566-b1d3-0f557872566d)
