### PR TITLE
fix: bucket name validation

### DIFF
--- a/apps/studio/components/interfaces/Storage/CreateBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/CreateBucketModal.tsx
@@ -50,9 +50,16 @@ const CreateBucketModal = ({ visible, onClose }: CreateBucketModalProps) => {
 
   const validate = (values: any) => {
     const errors = {} as any
+
     if (!values.name) {
       errors.name = 'Please provide a name for your bucket'
     }
+
+    if (values.name && !/^[a-z0-9.-]+$/.test(values.name)) {
+      errors.name =
+        'The name of the bucket must only container lowercase letters, numbers, dots, and hyphens'
+    }
+
     if (values.name && values.name.endsWith(' ')) {
       errors.name = 'The name of the bucket cannot end with a whitespace'
     }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Supabase Studio > Storage > Create Bucket

## What is the current behavior?

You can currently add a bucket with out the validation rules being applied.

## What is the new behavior?

<img width="1440" alt="Screenshot 2025-03-09 at 18 40 54" src="https://github.com/user-attachments/assets/fcb63737-8a65-48bd-b9fc-32cd8650a632" />

Validation applied on the modal.

## Additional context

Closes #34064 
