### PR TITLE
Fixed local trigger in webhooks docs.mdx

### DIFF
--- a/apps/docs/content/guides/database/webhooks.mdx
+++ b/apps/docs/content/guides/database/webhooks.mdx
@@ -38,7 +38,7 @@ Since webhooks are just database triggers, you can also create one from SQL stat
 create trigger "my_webhook" after insert
 on "public"."my_table" for each row
 execute function "supabase_functions"."http_request"(
-  'http://localhost:3000',
+  'http://host.docker.internal:3000',
   'POST',
   '{"Content-Type":"application/json"}',
   '{}',


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

Webhooks are not firing locally unless we use `host.docker.internal` instead of `localhost`

## What is the new behavior?

Fixes webhooks firing locally 

## Additional context

Multiple people were encountering this issue, and it was discussed here:

https://github.com/supabase/supabase/issues/13005

Thanks!

