### PR TITLE
Fix uploading files to wrong bucket when navigating to another bucket while files were being uploaded

### DIFF
--- a/apps/studio/localStores/storageExplorer/StorageExplorerStore.tsx
+++ b/apps/studio/localStores/storageExplorer/StorageExplorerStore.tsx
@@ -66,8 +66,6 @@ export function useStorageStore() {
 const CORRUPTED_THRESHOLD_MS = 15 * 60 * 1000 // 15 minutes
 const LIMIT = 200
 const OFFSET = 0
-const DEFAULT_EXPIRY = 10 * 365 * 24 * 60 * 60 // in seconds, default to 10 years
-const PREVIEW_SIZE_LIMIT = 10000000 // 10MB
 const BATCH_SIZE = 2
 const EMPTY_FOLDER_PLACEHOLDER_FILE_NAME = '.emptyFolderPlaceholder'
 const STORAGE_PROGRESS_INFO_TEXT = "Do not close the browser until it's completed"

--- a/apps/studio/localStores/storageExplorer/StorageExplorerStore.tsx
+++ b/apps/studio/localStores/storageExplorer/StorageExplorerStore.tsx
@@ -606,6 +606,7 @@ class StorageExplorerStore {
       }
 
       let startingBytes = 0
+      const bucketName = this.selectedBucket.name
 
       return () => {
         return new Promise<void>(async (resolve, reject) => {
@@ -642,7 +643,7 @@ class StorageExplorerStore {
             uploadDataDuringCreation: uploadDataDuringCreation,
             removeFingerprintOnSuccess: true,
             metadata: {
-              bucketName: this.selectedBucket.name,
+              bucketName,
               objectName: formattedPathToFile,
               ...fileOptions,
             },


### PR DESCRIPTION
As per PR title

### To reproduce:
- Upload a bunch of files (I did 70)
- While the upload is going on, switch to another bucket or create a new one (which will redirect to the new bucket)
- Stay on the bucket until the upload completes
- Notice that the files get uploaded to the bucket that you're currently on the dashboard