### PR TITLE
clarify length of recent session

### DIFF
--- a/apps/studio/components/interfaces/Auth/AuthProvidersFormValidation.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersFormValidation.tsx
@@ -32,7 +32,7 @@ const PROVIDER_EMAIL = {
     },
     SECURITY_UPDATE_PASSWORD_REQUIRE_REAUTHENTICATION: {
       title: 'Secure password change',
-      description: `Users will need to be recently logged in to change their password without requiring reauthentication.
+      description: `Users will need to be recently logged in to change their password without requiring reauthentication. (A user is considered recently logged in if the session was created within the last 24 hours.)
       If disabled, a user can change their password at any time.`,
       type: 'boolean',
     },


### PR DESCRIPTION
"logged in recently" is too vague a description to be useful, so added the actual time

<img width="483" alt="image" src="https://github.com/user-attachments/assets/3ac66163-8a11-4638-9492-c905e3088b97" />
