### PR TITLE
Table editor fix is extra options state for PK columns

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/Column.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/Column.tsx
@@ -12,7 +12,6 @@ import {
   PopoverContent_Shadcn_,
   PopoverTrigger_Shadcn_,
   Popover_Shadcn_,
-  Separator,
   cn,
 } from 'ui'
 
@@ -268,7 +267,13 @@ const Column = ({
         <Checkbox
           label=""
           checked={column.isPrimaryKey}
-          onChange={() => onUpdateColumn({ isPrimaryKey: !column.isPrimaryKey })}
+          onChange={() => {
+            const updatedValue = !column.isPrimaryKey
+            onUpdateColumn({
+              isPrimaryKey: updatedValue,
+              isNullable: updatedValue ? false : column.isNullable,
+            })
+          }}
         />
       </div>
       <div className={`${hasImportContent ? 'w-[10%]' : 'w-[0%]'}`} />
@@ -295,16 +300,13 @@ const Column = ({
 
               <div className="flex flex-col space-y-1" key={`${column.id}_configuration`}>
                 {!column.isPrimaryKey && (
-                  <>
-                    <Checkbox
-                      label="Is Nullable"
-                      description="Specify if the column can assume a NULL value if no value is provided"
-                      checked={column.isNullable}
-                      className="p-4"
-                      onChange={() => onUpdateColumn({ isNullable: !column.isNullable })}
-                    />
-                    <Separator />
-                  </>
+                  <Checkbox
+                    label="Is Nullable"
+                    description="Specify if the column can assume a NULL value if no value is provided"
+                    checked={column.isNullable}
+                    className="p-4"
+                    onChange={() => onUpdateColumn({ isNullable: !column.isNullable })}
+                  />
                 )}
                 <Checkbox
                   label="Is Unique"
@@ -313,7 +315,6 @@ const Column = ({
                   className="p-4"
                   onChange={() => onUpdateColumn({ isUnique: !column.isUnique })}
                 />
-                <Separator />
                 {column.format.includes('int') && (
                   <Checkbox
                     label="Is Identity"


### PR DESCRIPTION
### To reproduce
- Table editor -> New table
- Uncheck the default id column as primary key
- set id column to is nullable
- check if back as primary key
- Notice that the number here is 2, despite is nullable no longer showing up as an option in extra options
<img width="69" alt="image" src="https://github.com/user-attachments/assets/c582a8fe-9fe0-46a1-a00a-893eef3bb69f" />
