### PR TITLE
Fix: Fix the set null button when the value is empty

### DIFF
--- a/apps/studio/components/grid/components/editor/TextEditor.tsx
+++ b/apps/studio/components/grid/components/editor/TextEditor.tsx
@@ -43,7 +43,7 @@ export const TextEditor = <TRow, TSummaryRow = unknown>({
 
   const gridColumn = state.gridColumns.find((x) => x.name == column.key)
   const rawValue = row[column.key as keyof TRow] as unknown
-  const initialValue = rawValue ? String(rawValue) : null
+  const initialValue = rawValue || rawValue === '' ? String(rawValue) : null
   const [isPopoverOpen, setIsPopoverOpen] = useState(true)
   const [value, setValue] = useState<string | null>(initialValue)
   const [isConfirmNextModalOpen, setIsConfirmNextModalOpen] = useState(false)


### PR DESCRIPTION
To replicate the issue:
1. Go to table editor
2. Try to edit a text value (via the inline edit)
3. Set the value to empty string and save it.
4. The cell should say `EMPTY`
5. Expand the inline edit again on that cell.
6. Click Set to NULL, click confirm on the modal.
7. The modal never closes.