### PR TITLE
fix: join org url search params bug

### DIFF
--- a/apps/studio/lib/gotrue.ts
+++ b/apps/studio/lib/gotrue.ts
@@ -81,5 +81,18 @@ export const getReturnToPath = (fallback = '/projects') => {
     validReturnTo = pattern.test(returnTo) ? fallback : returnTo
   }
 
-  return validReturnTo + (remainingSearchParams ? `?${remainingSearchParams}` : '')
+  const [path, existingQuery] = validReturnTo.split('?')
+
+  const finalSearchParams = new URLSearchParams(existingQuery || '')
+
+  // Add all remaining search params to the final search params
+  if (remainingSearchParams) {
+    const remainingParams = new URLSearchParams(remainingSearchParams)
+    remainingParams.forEach((value, key) => {
+      finalSearchParams.append(key, value)
+    })
+  }
+
+  const finalQuery = finalSearchParams.toString()
+  return path + (finalQuery ? `?${finalQuery}` : '')
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Since https://github.com/supabase/supabase/pull/34023, all the query params now correctly get sent over to the join page, which surfaced another bug with multiple query params on the join page.

## What is the new behavior?

The join page now works with any number of query params correctly.

## Additional context

This only occurred when the user was signed out, then signed in with github and got redirected to the join org page. They could still join the org but would have to click the link in their email again.
