### PR TITLE
Export the Supabase client instance from with-expo-react-native.mdx

### DIFF
--- a/apps/docs/content/guides/getting-started/tutorials/with-expo-react-native.mdx
+++ b/apps/docs/content/guides/getting-started/tutorials/with-expo-react-native.mdx
@@ -145,7 +145,7 @@ These variables are safe to expose in your Expo app since Supabase has
     const supabaseUrl = YOUR_REACT_NATIVE_SUPABASE_URL
     const supabaseAnonKey = YOUR_REACT_NATIVE_SUPABASE_ANON_KEY
 
-    const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+    export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
       auth: {
         storage: new LargeSecureStore(),
         autoRefreshToken: true,


### PR DESCRIPTION
## I have read the [[CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md)](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Currently, when we try to import `supabase` with:
```js
import { supabase } from '../lib/supabase'
```
it fails because `supabase` is not exported as a named export in `lib/supabase.ts`. This means other parts of the code cannot properly import the Supabase client, leading to errors.

## What is the new behavior?

By adding `export` before `const supabase = createClient(...)`, `supabase` is now exposed as a named export. This ensures that `import { supabase } from '../lib/supabase'` will work correctly and that the rest of the application can utilize the Supabase client without issues.

## Additional context

No additional context at this time. Please let me know if there’s any further information needed.