### PR TITLE
Fix openai api key empty state not showing in local

### DIFF
--- a/apps/studio/pages/api/ai/sql/check-api-key.ts
+++ b/apps/studio/pages/api/ai/sql/check-api-key.ts
@@ -19,6 +19,6 @@ const handleGet = async (req: NextApiRequest, res: NextApiResponse) => {
   if (process.env.OPENAI_API_KEY) {
     return res.status(200).json({ hasKey: true })
   } else {
-    return res.status(404).json({ hasKey: false })
+    return res.status(200).json({ hasKey: false })
   }
 }


### PR DESCRIPTION
Realised that the OPENAI_API_KEY empty state was not showing up, because we were sending a 404 error for check-api-key endpoint which in turn the react query was treating it as an error. Updated the check-api-key endpoint to return a 200 instead (which i think makes sense - its still a correct response if the API key is not set)

<img width="508" alt="image" src="https://github.com/user-attachments/assets/852b81bc-63e4-426e-9d0c-3383ab4dc2b1" />
