### PR TITLE
fix: update column type and add foreign key

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnForeignKey.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnForeignKey.tsx
@@ -47,7 +47,7 @@ const ColumnForeignKey = ({
     return {
       id: c.id,
       name: c.name,
-      format: c.format || column.format,
+      format: column.format || c.format,
       isNewColumn: false,
     }
   })


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

If you update a foreign key type and try to add a foreign key at the same time, you'll get a type mismatch error involving the old column type.
