### PR TITLE
Docs: WSL note for MCP

### DIFF
--- a/apps/docs/content/guides/getting-started/mcp.mdx
+++ b/apps/docs/content/guides/getting-started/mcp.mdx
@@ -63,6 +63,16 @@ This assumes you have Node.js and npx installed. If you don't have Node.js or pr
 
 </Admonition>
 
+<Admonition type="note" title="Windows users">
+
+If you run Node.js and npx in WSL instead of directly on your Windows host, you'll need to prefix the command with `wsl`:
+
+```shell
+wsl npx -y @modelcontextprotocol/server-postgres <connection-string>
+```
+
+</Admonition>
+
 Below are some ways to connect to the Postgres MCP server using popular AI tools:
 
 #### Cursor


### PR DESCRIPTION
Edit: [Now live](https://supabase.com/docs/guides/getting-started/mcp#step-2-configure-in-your-ai-tool)

---

Adds note to the MCP docs for WSL users who run Node/npx inside WSL instead of on the Windows host. They need to prefix the command with `wsl` in order to run the command in `wsl` instead of Windows.