### PR TITLE
Add backup type label

### DIFF
--- a/apps/studio/components/interfaces/Database/Backups/BackupItem.tsx
+++ b/apps/studio/components/interfaces/Database/Backups/BackupItem.tsx
@@ -3,10 +3,11 @@ import { Download } from 'lucide-react'
 
 import { useParams } from 'common'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
+import { InlineLink } from 'components/ui/InlineLink'
 import { useBackupDownloadMutation } from 'data/database/backup-download-mutation'
 import type { DatabaseBackup } from 'data/database/backups-query'
 import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
-import { Badge } from 'ui'
+import { Badge, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
 import { TimestampInfo } from 'ui-patterns'
 
 interface BackupItemProps {
@@ -70,11 +71,19 @@ const BackupItem = ({ index, isHealthy, backup, onSelectBackup }: BackupItemProp
             tooltip={{
               content: {
                 side: 'bottom',
-                text: backup.isPhysicalBackup
-                  ? 'Physical backups cannot be downloaded'
-                  : !canTriggerScheduledBackups
-                    ? 'You need additional permissions to download backups'
-                    : undefined,
+                className: backup.isPhysicalBackup ? 'w-64' : '',
+                text: backup.isPhysicalBackup ? (
+                  <>
+                    Physical backups cannot be downloaded through the dashboard. You can still
+                    download it via pgdump by following our guide{' '}
+                    <InlineLink href="https://supabase.com/docs/guides/troubleshooting/download-logical-backups">
+                      here
+                    </InlineLink>
+                    .
+                  </>
+                ) : !canTriggerScheduledBackups ? (
+                  'You need additional permissions to download backups'
+                ) : undefined,
               },
             }}
           >
@@ -98,7 +107,17 @@ const BackupItem = ({ index, isHealthy, backup, onSelectBackup }: BackupItemProp
           labelFormat="DD MMM YYYY HH:mm:ss (ZZ)"
           className="text-left !text-sm font-mono tracking-tight"
         />
-        <Badge variant="default">{backup.isPhysicalBackup ? 'Physical' : 'Logical'}</Badge>
+        <Tooltip>
+          <TooltipTrigger>
+            <Badge variant="default">{backup.isPhysicalBackup ? 'Physical' : 'Logical'}</Badge>
+          </TooltipTrigger>
+          <TooltipContent>
+            Learn more about backup types{' '}
+            <InlineLink href="https://supabase.com/blog/postgresql-physical-logical-backups">
+              here
+            </InlineLink>
+          </TooltipContent>
+        </Tooltip>
       </div>
       <div>{generateSideButtons(backup)}</div>
     </div>

--- a/apps/studio/components/interfaces/Database/Backups/BackupItem.tsx
+++ b/apps/studio/components/interfaces/Database/Backups/BackupItem.tsx
@@ -58,28 +58,28 @@ const BackupItem = ({ index, isHealthy, backup, onSelectBackup }: BackupItemProp
           >
             Restore
           </ButtonTooltip>
-          {!backup.isPhysicalBackup && (
-            <ButtonTooltip
-              type="default"
-              icon={<Download />}
-              loading={isDownloading}
-              disabled={!canTriggerScheduledBackups || isDownloading}
-              onClick={() => {
-                if (!projectRef) return console.error('Project ref is required')
-                downloadBackup({ ref: projectRef, backup })
-              }}
-              tooltip={{
-                content: {
-                  side: 'bottom',
-                  text: !canTriggerScheduledBackups
+          <ButtonTooltip
+            type="default"
+            icon={<Download />}
+            loading={isDownloading}
+            disabled={!canTriggerScheduledBackups || isDownloading || backup.isPhysicalBackup}
+            onClick={() => {
+              if (!projectRef) return console.error('Project ref is required')
+              downloadBackup({ ref: projectRef, backup })
+            }}
+            tooltip={{
+              content: {
+                side: 'bottom',
+                text: backup.isPhysicalBackup
+                  ? 'Physical backups cannot be downloaded'
+                  : !canTriggerScheduledBackups
                     ? 'You need additional permissions to download backups'
                     : undefined,
-                },
-              }}
-            >
-              Download
-            </ButtonTooltip>
-          )}
+              },
+            }}
+          >
+            Download
+          </ButtonTooltip>
         </div>
       )
     return <Badge variant="warning">Backup In Progress...</Badge>
@@ -91,12 +91,15 @@ const BackupItem = ({ index, isHealthy, backup, onSelectBackup }: BackupItemProp
         index ? 'border-t border-default' : ''
       }`}
     >
-      <TimestampInfo
-        displayAs="utc"
-        utcTimestamp={backup.inserted_at}
-        labelFormat="DD MMM YYYY HH:mm:ss (ZZ)"
-        className="text-left !text-sm font-mono tracking-tight"
-      />
+      <div className="flex items-center gap-x-2">
+        <TimestampInfo
+          displayAs="utc"
+          utcTimestamp={backup.inserted_at}
+          labelFormat="DD MMM YYYY HH:mm:ss (ZZ)"
+          className="text-left !text-sm font-mono tracking-tight"
+        />
+        <Badge variant="default">{backup.isPhysicalBackup ? 'Physical' : 'Logical'}</Badge>
+      </div>
       <div>{generateSideButtons(backup)}</div>
     </div>
   )

--- a/apps/studio/components/interfaces/Database/Backups/BackupItem.tsx
+++ b/apps/studio/components/interfaces/Database/Backups/BackupItem.tsx
@@ -111,7 +111,7 @@ const BackupItem = ({ index, isHealthy, backup, onSelectBackup }: BackupItemProp
           <TooltipTrigger>
             <Badge variant="default">{backup.isPhysicalBackup ? 'Physical' : 'Logical'}</Badge>
           </TooltipTrigger>
-          <TooltipContent>
+          <TooltipContent side="bottom">
             Learn more about backup types{' '}
             <InlineLink href="https://supabase.com/blog/postgresql-physical-logical-backups">
               here

--- a/apps/studio/components/layouts/ProjectLayout/RestoringState.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/RestoringState.tsx
@@ -25,6 +25,7 @@ const RestoringState = () => {
 
   const { data } = useDownloadableBackupQuery({ projectRef: ref })
   const backups = data?.backups ?? []
+  const logicalBackups = backups.filter((b) => !b.isPhysicalBackup)
 
   const { mutate: downloadBackup, isLoading: isDownloading } = useBackupDownloadMutation({
     onSuccess: (res) => {
@@ -41,8 +42,9 @@ const RestoringState = () => {
 
   const onClickDownloadBackup = () => {
     if (!ref) return console.error('Project ref is required')
-    if (backups.length === 0) return console.error('No available backups to download')
-    downloadBackup({ ref, backup: backups[0] })
+    if (logicalBackups.length === 0) return console.error('No available backups to download')
+
+    downloadBackup({ ref, backup: logicalBackups[0] })
   }
 
   async function checkServer() {
@@ -125,16 +127,17 @@ const RestoringState = () => {
                 type="default"
                 icon={<Download />}
                 loading={isDownloading}
-                disabled={backups.length === 0}
+                disabled={logicalBackups.length === 0}
                 tooltip={{
                   content: {
                     side: 'bottom',
-                    text: backups.length === 0 ? 'No available backups to download' : undefined,
+                    text:
+                      logicalBackups.length === 0 ? 'No available backups to download' : undefined,
                   },
                 }}
                 onClick={onClickDownloadBackup}
               >
-                Download backup
+                Download latest backup
               </ButtonTooltip>
             </div>
           </>


### PR DESCRIPTION
There's a confusion regarding downloading of backups from the scheduled backups page in the database section of a project. 
- Logical backups can be downloaded, but not physical backups
- The scheduled backups page can show physical  backups too depending on its set up
- But the download button is hidden if the backup is physical, which is the source of the confusion.
- Adding a label to indicate what type of backup it is + tooltip with disabled state for download button instead of hiding it

<img width="390" alt="image" src="https://github.com/user-attachments/assets/27e0b854-57c0-4256-8031-d5ec6f0bffcb" />

RestoringState also has a CTA for "Download backup" which could be confusing if you land in this state from restoring a backup.
- Updated CTA to indicate "latest" backup
- Updated logic to download only latest logical backup (physical will fail)

Note to self:
https://supabase.com/blog/postgresql-physical-logical-backups
https://supabase.com/docs/guides/troubleshooting/download-logical-backups