### PR TITLE
Update seed `sql_paths` config

### DIFF
--- a/apps/docs/content/guides/local-development/declarative-database-schemas.mdx
+++ b/apps/docs/content/guides/local-development/declarative-database-schemas.mdx
@@ -219,8 +219,8 @@ Your schema files are run in lexicographic order by default. The order is import
 For small projects with only a few tables, the default schema order may be sufficient. However, as your project grows, you might need more control over the order in which schemas are applied. To specify a custom order for applying the schemas, you can declare them explicitly in `config.toml`. Any glob patterns will evaluated, deduplicated, and sorted in lexicographic order. For example, the following pattern ensures `employees.sql` is always executed first.
 
 ```toml supabase/config.toml
-[db.migrations]
-schema_paths = [
+[db.seed]
+sql_paths = [
   "./schemas/employees.sql",
   "./schemas/*.sql",
 ]


### PR DESCRIPTION
This must have changed at some point. See https://supabase.com/docs/guides/local-development/cli/config#db.seed.sql_paths

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

Outdated seed SQL paths config approach

## What is the new behavior?

Correct seed SQL paths config according to https://supabase.com/docs/guides/local-development/cli/config#db.seed.sql_paths
