### PR TITLE
move API keys launch date to Q2 2025

### DIFF
--- a/apps/studio/components/ui/ProjectSettings/DisplayApiSettings.tsx
+++ b/apps/studio/components/ui/ProjectSettings/DisplayApiSettings.tsx
@@ -161,7 +161,7 @@ const DisplayApiSettings = ({
           ) : (
             <Panel.Notice
               className="border-t"
-              title="New API keys coming Q4 2024"
+              title="New API keys coming Q2 2025"
               description={`
 \`anon\` and \`service_role\` API keys will be changing to \`publishable\` and \`secret\` API keys.
 `}


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Update API keys announcement to Q2 2025 for release
