### PR TITLE
improve postgres logs rows and detail

### DIFF
--- a/apps/studio/components/interfaces/Settings/Logs/LogColumnRenderers/DatabasePostgresColumnRender.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogColumnRenderers/DatabasePostgresColumnRender.tsx
@@ -17,6 +17,8 @@ const columns: Column<LogData>[] = [
           <TimestampInfo utcTimestamp={props.row.timestamp!} />
           <SeverityFormatter value={props.row.error_severity as string} />
           <TextFormatter className="w-full" value={props.row.event_message} />
+          {props.row.detail ? <TextFormatter value={props.row.detail as string} /> : null}
+          {props.row.hint ? <TextFormatter value={props.row.hint as string} /> : null}
         </RowLayout>
       )
     },

--- a/apps/studio/components/interfaces/Settings/Logs/LogSelection.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogSelection.tsx
@@ -50,6 +50,18 @@ const LogSelection = ({ log, onClose, queryType, isLoading, error }: LogSelectio
         }
 
         return <DefaultPreviewSelectionRenderer log={apiLog} />
+
+      case 'database':
+        const hint = log?.metadata?.[0]?.parsed?.[0]?.hint
+        const detail = log?.metadata?.[0]?.parsed?.[0]?.detail
+        const query = log?.metadata?.[0]?.parsed?.[0]?.query
+        const postgresLog = {
+          ...(hint && { hint }),
+          ...(detail && { detail }),
+          ...(query && { query }),
+          ...log,
+        }
+        return <DefaultPreviewSelectionRenderer log={postgresLog} />
       default:
         return <DefaultPreviewSelectionRenderer log={log} />
     }

--- a/apps/studio/components/interfaces/Settings/Logs/Logs.utils.ts
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.utils.ts
@@ -164,7 +164,7 @@ limit ${limit};
     case 'postgres_logs':
       if (IS_PLATFORM === false) {
         return `
-select postgres_logs.timestamp, id, event_message, parsed.error_severity
+select postgres_logs.timestamp, id, event_message, parsed.error_severity, parsed.detail, parsed.hint
 from postgres_logs
 ${joins}
 ${where}
@@ -172,7 +172,7 @@ ${orderBy}
 limit ${limit}
   `
       }
-      return `select identifier, postgres_logs.timestamp, id, event_message, parsed.error_severity from ${table}
+      return `select identifier, postgres_logs.timestamp, id, event_message, parsed.error_severity, parsed.detail, parsed.hint from ${table}
   ${joins}
   ${where}
   ${orderBy}


### PR DESCRIPTION
- Adds hint and detail to postgres logs rows
- Adds hint query and query to the first level of the detail panel

## To test this:
- Run some sql that generates logs with hints or detail (you can ask assistant)
I used this
```sql
BEGIN;

INSERT INTO public.customers (id, first_name, email) VALUES (1, 'John', 'john@example.com');

-- Attempt to insert the same id again to trigger a unique constraint violation
INSERT INTO public.customers (id, first_name, email) VALUES (1, 'Jane', 'jane@example.com');

ROLLBACK;
```
- Check that the `detail` or `hint` field shows up in the results 

![CleanShot 2025-03-12 at 17 11 35@2x](https://github.com/user-attachments/assets/e9940833-8376-42a6-94b4-026b53651f0b)
