### PR TITLE
chore/add additional e2e tests

### DIFF
--- a/tests/studio-tests/README.md
+++ b/tests/studio-tests/README.md
@@ -7,12 +7,13 @@ development. Built with [Playwright](https://playwright.dev/docs/intro).
 
 Before running the tests, make sure you've done the following:
 
-- Run `npm install` in the root folder of this repo
+- If you haven't install playwright on your machine, run `pnpm exec playwright install`
+- Run `pnpm install` in the root folder of this repo
 - `docker` or `orbstack` is currently running
 - `supabase` CLI is already [installed](https://github.com/supabase/cli?tab=readme-ov-file#install-the-cli)
 - no other supabase local environment is running (infrastructure environment is ok)
 
-You can run the tests by running `npm run test` in this folder.
+You can run the tests by running `pnpm test:local` in this folder.
 
 When you run the command, it includes:
 
@@ -22,7 +23,7 @@ When you run the command, it includes:
 4. Running the tests
 5. Stopping the `studio` app and the local environment
 
-If the environment does't stop for some reason, you'll see `supabase start is already running` on the next run. In this
+If the environment doesn't stop for some reason, you'll see `supabase start is already running` on the next run. In this
 case, just run `supabase stop` between test runs.
 
 ## How to write tests

--- a/tests/studio-tests/README.md
+++ b/tests/studio-tests/README.md
@@ -7,7 +7,7 @@ development. Built with [Playwright](https://playwright.dev/docs/intro).
 
 Before running the tests, make sure you've done the following:
 
-- If you haven't install playwright on your machine, run `pnpm exec playwright install`
+- If you haven't installed playwright on your machine, run `pnpm exec playwright install`
 - Run `pnpm install` in the root folder of this repo
 - `docker` or `orbstack` is currently running
 - `supabase` CLI is already [installed](https://github.com/supabase/cli?tab=readme-ov-file#install-the-cli)

--- a/tests/studio-tests/tests/common-functionality/sql-editor.spec.ts
+++ b/tests/studio-tests/tests/common-functionality/sql-editor.spec.ts
@@ -1,0 +1,19 @@
+import { expect } from '@playwright/test'
+import { test } from '../../base'
+
+test.describe('SQL Editor', () => {
+  test('should check if SQL editor can run simple commands', async ({
+    page,
+  }) => {
+    await page.goto('project/default/sql/1');
+
+    // fill up sql
+    await page.getByText('select * from (select version').click();
+    await page.getByLabel('Editor content;Press Alt+F1').fill('select now();');
+    await page.getByRole('button', { name: 'Run CTRL' }).click();
+
+    // verify
+    await expect(page.getByRole('code')).toContainText('select now();');
+    await expect(page.getByRole('columnheader')).toContainText('now');
+  })
+})

--- a/tests/studio-tests/tests/common-functionality/table-editor.spec.ts
+++ b/tests/studio-tests/tests/common-functionality/table-editor.spec.ts
@@ -164,4 +164,31 @@ test.describe('Table Editor', () => {
       ])
     )
   })
+
+  test('should show rls disabled accordingly', async ({ page }) => {
+    await page.getByTestId('schema-selector').click()
+    await page.getByRole('option', { name: 'public', exact: true }).click()
+
+    // create tables
+    await page.getByRole('button', { name: 'New table', exact: true }).click();
+    await page.getByTestId('table-name-input').fill('rls-enabled');
+    await page.getByRole('button', { name: 'Save' }).click();
+    await page.getByRole('button', { name: 'New table', exact: true }).click();
+    await page.getByTestId('table-name-input').fill('rls-disabled');
+    await page.getByLabel('Enable Row Level Security (').click();
+    await page.getByRole('button', { name: 'Confirm' }).click();
+    await page.getByRole('button', { name: 'Save' }).click();
+
+    // verify table creation
+    await expect(page.getByLabel('View rls-disabled').locator('span')).toContainText('rls-disabled');
+    await expect(page.getByLabel('View rls-enabled').locator('span')).toContainText('rls-enabled');
+    
+    // verify rls button
+    await page.getByLabel('View rls-disabled').click();
+    await expect(page.getByRole('button', { name: 'RLS disabled' })).toBeVisible();
+    await page.getByLabel('View rls-enabled').click();
+    await expect(page.getByRole('button', { name: 'RLS disabled' })).not.toBeVisible();
+  })
+
+
 })


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES/NO

## What kind of change does this PR introduce?

- add additional e2e test for:
     - [table-editor] Table with RLS Disabled shows RLS Disabled badge
     - [sql-editor] Editor should load and run SQL

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
