### PR TITLE
Fix in returnTo param

### DIFF
--- a/apps/studio/lib/gotrue.test.ts
+++ b/apps/studio/lib/gotrue.test.ts
@@ -1,5 +1,5 @@
 import { validateReturnTo } from './gotrue'
-
+import { describe, it, expect } from 'vitest'
 describe('validateReturnTo', () => {
   const fallback = '/projects'
 

--- a/apps/studio/lib/gotrue.test.ts
+++ b/apps/studio/lib/gotrue.test.ts
@@ -33,4 +33,12 @@ describe('validateReturnTo', () => {
       '/dashboard?param1=value1&param2=value2'
     )
   })
+
+  it('should handle nextjs dynamic path js', () => {
+    expect(
+      validateReturnTo(
+        '%2F%5B%5Bx%5D%5Djavascript%3Aalert(%22H4CK3D%22)%2F%5By%5D%2F%5B%5Bx%5D%5D%2F%5By%5D%3Fx%26y'
+      )
+    ).toBe(fallback)
+  })
 })

--- a/apps/studio/lib/gotrue.test.ts
+++ b/apps/studio/lib/gotrue.test.ts
@@ -1,0 +1,36 @@
+import { validateReturnTo } from './gotrue'
+
+describe('validateReturnTo', () => {
+  const fallback = '/projects'
+
+  it('should return the path if it is a valid internal path', () => {
+    expect(validateReturnTo('/dashboard')).toBe('/dashboard')
+    expect(validateReturnTo('/settings/profile')).toBe('/settings/profile')
+    expect(validateReturnTo('/projects?id=123')).toBe('/projects?id=123')
+  })
+
+  it('should return fallback if given an external URL', () => {
+    expect(validateReturnTo('https://example.com')).toBe(fallback)
+    expect(validateReturnTo('http://malicious-site.com')).toBe(fallback)
+    expect(validateReturnTo('//evil.com')).toBe(fallback)
+  })
+
+  it('should return fallback for potentially malicious paths', () => {
+    expect(validateReturnTo('/%2e%2e/etc/passwd')).toBe(fallback)
+    expect(validateReturnTo('/..')).toBe(fallback)
+    expect(validateReturnTo('/@evil/path')).toBe(fallback)
+    expect(validateReturnTo('/$malicious')).toBe(fallback)
+  })
+
+  it('should use custom fallback when provided', () => {
+    const customFallback = '/custom-fallback'
+    expect(validateReturnTo('https://example.com', customFallback)).toBe(customFallback)
+    expect(validateReturnTo('/%2e%2e/etc/passwd', customFallback)).toBe(customFallback)
+  })
+
+  it('should handle paths with query parameters correctly', () => {
+    expect(validateReturnTo('/dashboard?param1=value1&param2=value2')).toBe(
+      '/dashboard?param1=value1&param2=value2'
+    )
+  })
+})

--- a/apps/studio/lib/gotrue.test.ts
+++ b/apps/studio/lib/gotrue.test.ts
@@ -40,5 +40,10 @@ describe('validateReturnTo', () => {
         '%2F%5B%5Bx%5D%5Djavascript%3Aalert(%22H4CK3D%22)%2F%5By%5D%2F%5B%5Bx%5D%5D%2F%5By%5D%3Fx%26y'
       )
     ).toBe(fallback)
+    expect(
+      validateReturnTo(
+        '/%2F%5B%5Bx%5D%5Djavascript%3Aalert(%22H4CK3D%22)%2F%5By%5D%2F%5B%5Bx%5D%5D%2F%5By%5D%3Fx%26y'
+      )
+    ).toBe(fallback)
   })
 })

--- a/apps/studio/lib/gotrue.test.ts
+++ b/apps/studio/lib/gotrue.test.ts
@@ -1,5 +1,6 @@
 import { validateReturnTo } from './gotrue'
 import { describe, it, expect } from 'vitest'
+
 describe('validateReturnTo', () => {
   const fallback = '/projects'
 

--- a/apps/studio/lib/gotrue.ts
+++ b/apps/studio/lib/gotrue.ts
@@ -3,6 +3,20 @@ import { getAccessToken, gotrueClient, type User } from 'common'
 export const auth = gotrueClient
 export { getAccessToken }
 
+export const validateReturnTo = (returnTo: string, fallback: string = '/projects'): string => {
+  // Block protocol-relative URLs and external URLs
+  if (returnTo.startsWith('//') || returnTo.includes('://')) {
+    return fallback
+  }
+
+  // For internal paths:
+  // 1. Must start with /
+  // 2. Only allow alphanumeric chars, slashes, hyphens, underscores
+  // 3. For query params, also allow =, &, and ?
+  const safePathPattern = /^\/[a-zA-Z0-9/\-_]*(?:\?[a-zA-Z0-9\-_=&]*)?$/
+  return safePathPattern.test(returnTo) ? returnTo : fallback
+}
+
 export const getAuthUser = async (token: String): Promise<any> => {
   try {
     const {
@@ -64,22 +78,7 @@ export const getReturnToPath = (fallback = '/projects') => {
   searchParams.delete('returnTo')
 
   const remainingSearchParams = searchParams.toString()
-
-  let validReturnTo
-
-  // only allow returning to internal pages. e.g. /projects
-  try {
-    // if returnTo is a relative path, this will throw an error
-    new URL(returnTo)
-    // if no error, returnTo is a valid URL and NOT an internal page
-    validReturnTo = fallback
-  } catch (_) {
-    // check returnTo doesn't try trick the browser to redirect
-    // don't try sanitize, it is a losing battle. Go to fallback
-    // disallow anything that starts with /non-word-char+/ or non-char+/
-    const pattern = /^\/?[\W]+.*\//
-    validReturnTo = pattern.test(returnTo) ? fallback : returnTo
-  }
+  const validReturnTo = validateReturnTo(returnTo, fallback)
 
   const [path, existingQuery] = validReturnTo.split('?')
 

--- a/apps/studio/lib/gotrue.ts
+++ b/apps/studio/lib/gotrue.ts
@@ -77,7 +77,7 @@ export const getReturnToPath = (fallback = '/projects') => {
     // check returnTo doesn't try trick the browser to redirect
     // don't try sanitize, it is a losing battle. Go to fallback
     // disallow anything that starts with /non-word-char+/ or non-char+/
-    const pattern = /^\/?[\W]+\//
+    const pattern = /^\/?[\W]+.*\//
     validReturnTo = pattern.test(returnTo) ? fallback : returnTo
   }
 

--- a/apps/studio/vitest.config.mts
+++ b/apps/studio/vitest.config.mts
@@ -27,6 +27,7 @@ export default defineConfig({
     include: [
       resolve(dirname, './tests/**/*.test.{ts,tsx}'),
       resolve(dirname, './components/**/*.test.{ts,tsx}'),
+      resolve(dirname, './lib/**/*.test.{ts,tsx}'),
     ],
     restoreMocks: true,
     setupFiles: [

--- a/apps/studio/vitest.config.mts
+++ b/apps/studio/vitest.config.mts
@@ -24,11 +24,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom', // TODO(kamil): This should be set per test via header in .tsx files only
-    include: [
-      resolve(dirname, './tests/**/*.test.{ts,tsx}'),
-      resolve(dirname, './components/**/*.test.{ts,tsx}'),
-      resolve(dirname, './lib/**/*.test.{ts,tsx}'),
-    ],
+    include: [resolve(dirname, './**/*.test.{ts,tsx}')],
     restoreMocks: true,
     setupFiles: [
       resolve(dirname, './tests/vitestSetup.ts'),


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Security fix

## What is the current behavior?

Due to nextjs dynamic routing behavior, the regex to filter out non-paths was not working as intended

## What is the new behavior?

The new regular expression will check for more than the first word character within the pattern instead of just the first in detecting a valid path

## Additional context

Fixes SEC-230
