### PR TITLE
Chore/fix menu item

### DIFF
--- a/apps/docs/components/Navigation/NavigationMenu/GlobalMobileMenu.tsx
+++ b/apps/docs/components/Navigation/NavigationMenu/GlobalMobileMenu.tsx
@@ -163,7 +163,7 @@ const GlobalMobileMenu = ({ open, setOpen }: Props) => {
                 <>
                   {isLoggedIn ? (
                     <Button block size="medium" asChild>
-                      <Link href="/dashboard/projects">Dashboard</Link>
+                      <Link href="https://supabase.com/dashboard/projects">Dashboard</Link>
                     </Button>
                   ) : (
                     <>


### PR DESCRIPTION
Dashboard menu at the bottom of the mobile menu on docs site is broken
per https://x.com/Marty_cFly/status/1900031853446521124

![screenshot-2025-03-14-at-10 39 58](https://github.com/user-attachments/assets/eb8f4f7c-0850-4b77-8b14-3e2585101dcf)
