### PR TITLE
chore: inform about non-encrypted instance risk in doc

### DIFF
--- a/apps/docs/content/guides/self-hosting/docker.mdx
+++ b/apps/docs/content/guides/self-hosting/docker.mdx
@@ -159,6 +159,13 @@ You'll want to update the Studio(Dashboard) frequently to get the latest feature
 
 While we provided you with some example secrets for getting started, you should NEVER deploy your Supabase setup using the defaults we have provided. Follow all of the steps in this section to ensure you have a secure setup, and then [restart all services](#restarting-all-services) to pick up the changes.
 
+<Admonition type="danger">
+
+Your instance is running without any type of encryption.
+This guide does not walk you through how to secure your instance using SSL (`https://...`). Before exposing your instance on the Internet, make sure all traffic is secure. This is outside of the scope for this guide for the time being.
+</Admonition>
+
+
 ### Generate API keys
 
 We need to generate secure keys for accessing your services. We'll use the `JWT Secret` to generate `anon` and `service` API keys using the form below.
@@ -437,6 +444,9 @@ docker rm supabase-analytics
 ## Demo
 
 A minimal setup working on Ubuntu, hosted on DigitalOcean.
+
+After completing the guide your DigitalOcean instance will be running without any type of encryption.
+This means that anything you communicate with your instance could be intercepted. This guide does not walk you through how to secure your instance using SSL (`https://...`).
 
 <div className="video-container">
   <iframe


### PR DESCRIPTION
- fixes #34215

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The video showing the user how to setup a self hosted instance on DigitalOcean never informs that the resulting instance is not SSL protected.

## What is the new behavior?

Warnings are added under the heading Securing your services and above the video itself.

## Additional context

I don't believe Supabase should assume that a user playing around with self-hosting fully understand the implication of deploying an instance publicly available on the Internet.

