### PR TITLE
docs: add deep link reference to quickstart

### DIFF
--- a/apps/docs/content/guides/getting-started/quickstarts/flutter.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/flutter.mdx
@@ -171,6 +171,10 @@ hideToc: true
 
 </StepHikeCompact>
 
+## Setup deep links
+
+Many sign in methods require deep links to redirect the user back to your app after authentication. Read more about setting deep links up for all platforms (including web) in the [Flutter Mobile Guide](/docs/guides/getting-started/tutorials/with-flutter#setup-deep-links).
+
 ## Going to production
 
 ### Android


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

The documentation on how to properly set up deep links is kind of hidden and not easy to find.

## What is the new behavior?

The flutter quickstart guide now includes a link to the mobile guide section on how to setup deep links.
