### PR TITLE
fix crashes in useLogsPreview

### DIFF
--- a/apps/studio/hooks/analytics/useLogsPreview.tsx
+++ b/apps/studio/hooks/analytics/useLogsPreview.tsx
@@ -138,21 +138,20 @@ function useLogsPreview({
     refresh(newSql)
   }, [JSON.stringify(mergedFilters)])
 
-  // memoize all this calculations stuff
   const { logData, error, oldestTimestamp } = useMemo(() => {
     let logData: LogData[] = []
-
     let error: null | string | object = rqError ? (rqError as any).message : null
-    data?.pages.forEach((response) => {
-      if (response.result) {
+
+    data?.pages?.forEach((response) => {
+      if (response?.result) {
         logData = [...logData, ...response.result]
       }
-      if (!error && response && response.error) {
+      if (!error && response?.error) {
         error = response.error
       }
     })
 
-    const oldestTimestamp = logData[logData.length - 1]?.timestamp
+    const oldestTimestamp = logData.length > 0 ? logData[logData.length - 1]?.timestamp : undefined
 
     return { logData, error, oldestTimestamp }
   }, [data?.pages])

--- a/apps/studio/hooks/analytics/useLogsPreview.tsx
+++ b/apps/studio/hooks/analytics/useLogsPreview.tsx
@@ -186,7 +186,7 @@ function useLogsPreview({
       // refresh each minute only
       refetchInterval: 60000,
       // only enable if no errors are found and data has already been loaded
-      enabled: !error && data && data.pages.length > 0 ? true : false,
+      enabled: !error && data && data?.pages?.length > 0 ? true : false,
     }
   )
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

pages cound be undefined so it can crash the app.

## REPRO CRASH

In prod or staging:
- Go to a logs page
- Open a log
- Copy the event message
- Paste it in the search and press enter
- Click "Open in Logs Explorer" button in top right
- Run query
- Press back button in browser (two times probably)
- Logs Previewer component crashes

