### PR TITLE
feat: add table description in schema visualizer

### DIFF
--- a/apps/studio/components/interfaces/Database/Schemas/SchemaTableNode.tsx
+++ b/apps/studio/components/interfaces/Database/Schemas/SchemaTableNode.tsx
@@ -1,4 +1,5 @@
-import { DiamondIcon, ExternalLink, Fingerprint, Hash, Key, Table2 } from 'lucide-react'
+import { ButtonTooltip } from 'components/ui/ButtonTooltip'
+import { DiamondIcon, ExternalLink, Fingerprint, Hash, InfoIcon, Key, Table2 } from 'lucide-react'
 import Link from 'next/link'
 import { Handle, NodeProps } from 'reactflow'
 
@@ -13,6 +14,7 @@ export type TableNodeData = {
   name: string
   ref: string
   isForeign: boolean
+  comment?: string
   columns: {
     id: string
     isPrimary: boolean
@@ -35,7 +37,7 @@ const TableNode = ({
   const hiddenNodeConnector = '!h-px !w-px !min-w-0 !min-h-0 !cursor-grab !border-0 !opacity-0'
 
   const itemHeight = 'h-[22px]'
-
+  console.log(data)
   return (
     <>
       {data.isForeign ? (
@@ -65,13 +67,24 @@ const TableNode = ({
               <Table2 strokeWidth={1} size={12} className="text-light" />
               {data.name}
             </div>
-            {data.id && !placeholder && (
-              <Button asChild type="text" className="px-0 w-[16px] h-[16px] rounded">
-                <Link href={`/project/${data.ref}/editor/${data.id}`}>
-                  <ExternalLink size={10} className="text-foreground-light" />
-                </Link>
-              </Button>
-            )}
+            <div className="flex gap-x-1 items-center">
+              <ButtonTooltip
+                type="text"
+                className="px-0 w-[16px] h-[16px] rounded"
+                icon={<InfoIcon size={5} className="text-foreground-light !w-[10px] !h-[10px]" />}
+                onClick={() => {}}
+                tooltip={{
+                  content: { side: 'top', text: data.comment ?? 'No Description Available' },
+                }}
+              />
+              {data.id && !placeholder && (
+                <Button asChild type="text" className="px-0 w-[16px] h-[16px] rounded">
+                  <Link href={`/project/${data.ref}/editor/${data.id}`}>
+                    <ExternalLink size={10} className="text-foreground-light" />
+                  </Link>
+                </Button>
+              )}
+            </div>
           </header>
 
           {data.columns.map((column) => (

--- a/apps/studio/components/interfaces/Database/Schemas/Schemas.utils.ts
+++ b/apps/studio/components/interfaces/Database/Schemas/Schemas.utils.ts
@@ -45,6 +45,7 @@ export async function getGraphDataFromTables(
         id: table.id,
         name: table.name,
         isForeign: false,
+        comment: table.comment,
         columns,
       } as TableNodeData,
       position: { x: 0, y: 0 },


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

Fix: #36072 

## What kind of change does this PR introduce?

feature: now we can view the description of the table in Studio > Database > Schema Visualizer

## What is the current behavior?

**If Description is null or empty**

![image](https://github.com/user-attachments/assets/031dd506-2789-47d7-a347-d1df9d6f2e9b)

Then

![image](https://github.com/user-attachments/assets/791d7ef0-3724-4f7f-8f35-ce15c8d65a6a)

## What is the new behavior?

Here is the complete flow:

**If Description is null or empty**
Table SS:

![image](https://github.com/user-attachments/assets/031dd506-2789-47d7-a347-d1df9d6f2e9b)

Then, in the schema visualizer, I'm displaying the description value like this:

![image](https://github.com/user-attachments/assets/0fbaddd6-a4be-4971-8b26-1eef92625272)


**If Description is available or not empty**
Table SS:
![image](https://github.com/user-attachments/assets/d5d716ac-5408-419d-827a-cab38aa6a732)

Then, in the schema visualizer, I'm displaying the description value like this:

![image](https://github.com/user-attachments/assets/b7c20a3e-ce11-4595-b5e5-e3f7f1ae1f67)


