### PR TITLE
Removed Number of Functions limit from Pricing page

### DIFF
--- a/packages/shared-data/pricing.ts
+++ b/packages/shared-data/pricing.ts
@@ -488,17 +488,6 @@ export const pricing: Pricing = {
         },
         usage_based: false,
       },
-      {
-        key: 'functions.numberOfFunctions',
-        title: 'Number of functions',
-        plans: {
-          free: '25 included',
-          pro: '500 included',
-          team: '1000 included',
-          enterprise: 'Unlimited',
-        },
-        usage_based: false,
-      },
     ],
   },
   realtime: {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Removes Number of functions limit from pricing page

## What is the current behavior?

<img width="1174" alt="image" src="https://github.com/user-attachments/assets/327080d9-7b47-47ae-b074-442851938532" />


## What is the new behavior?

<img width="1156" alt="image" src="https://github.com/user-attachments/assets/e61a6290-7ec7-4eb9-98ab-b7d4f00e2910" />

## Additional context

https://linear.app/supabase/project/horizontal-project-scaling-for-ai-builders-c37477998fc3#comment-c6c71576

Confirmed by Laks
