### PR TITLE
fix: codeowners for telemetry based on team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 /packages/shared-data/pricing.ts @roryw10 @kevcodez
 /packages/shared-data/plans.ts @roryw10 @kevcodez
-/packages/common/telemetry-constants.ts @4L3k51 @loong @pamelachia
+/packages/common/telemetry-constants.ts @4L3k51 @supabase/growth-eng
 
 /apps/studio/ @supabase/Dashboard
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

- get telemetry-constants codeowner to rely on team instead of individuals but still keeping aleksi as an individual. 