### PR TITLE
Update realtime settings based on feedback

### DIFF
--- a/apps/studio/components/interfaces/Realtime/RealtimeSettings.tsx
+++ b/apps/studio/components/interfaces/Realtime/RealtimeSettings.tsx
@@ -85,6 +85,7 @@ export const RealtimeSettings = () => {
   })
 
   const onSubmit: SubmitHandler<z.infer<typeof FormSchema>> = (data) => {
+    console.log('FUNCTION ONSUBMIT')
     if (!projectRef) return console.error('Project ref is required')
     updateRealtimeConfig({
       ref: projectRef,
@@ -403,8 +404,10 @@ export const RealtimeSettings = () => {
                   <Button
                     type="primary"
                     htmlType="submit"
+                    form={formId}
                     disabled={!canUpdateConfig || isUpdatingConfig || !form.formState.isDirty}
                     loading={isUpdatingConfig}
+                    onClick={() => console.log('onCLICK SUBMIT')}
                   >
                     Save changes
                   </Button>

--- a/apps/studio/components/interfaces/Realtime/RealtimeSettings.tsx
+++ b/apps/studio/components/interfaces/Realtime/RealtimeSettings.tsx
@@ -122,7 +122,7 @@ export const RealtimeSettings = () => {
                       <FormSectionContent loading={isLoading} className="!gap-y-2">
                         <FormItemLayout
                           layout="flex"
-                          label="Allow public channels"
+                          label="Allow public access"
                           description="If disabled, only private channels will be allowed"
                         >
                           <FormControl_Shadcn_>

--- a/apps/studio/components/interfaces/Realtime/RealtimeSettings.tsx
+++ b/apps/studio/components/interfaces/Realtime/RealtimeSettings.tsx
@@ -165,11 +165,11 @@ export const RealtimeSettings = () => {
                           />
                         </FormControl_Shadcn_>
                         <FormMessage_Shadcn_ />
-                        {!!maxConn && field.value > maxConn.maxConnections * 0.8 && (
+                        {!!maxConn && field.value > maxConn.maxConnections * 0.5 && (
                           <Admonition
                             showIcon={false}
                             type="warning"
-                            title={`Pool size is greater than 80% of the max connections (${maxConn.maxConnections}) on your database`}
+                            title={`Pool size is greater than 50% of the max connections (${maxConn.maxConnections}) on your database`}
                             description="This may result in instability and unreliability with your database connections."
                           />
                         )}

--- a/apps/studio/components/interfaces/Realtime/RealtimeSettings.tsx
+++ b/apps/studio/components/interfaces/Realtime/RealtimeSettings.tsx
@@ -165,6 +165,14 @@ export const RealtimeSettings = () => {
                           />
                         </FormControl_Shadcn_>
                         <FormMessage_Shadcn_ />
+                        {!!maxConn && field.value > maxConn.maxConnections * 0.8 && (
+                          <Admonition
+                            showIcon={false}
+                            type="warning"
+                            title={`Pool size is greater than 80% of the max connections (${maxConn.maxConnections}) on your database`}
+                            description="This may result in instability and unreliability with your database connections."
+                          />
+                        )}
                       </FormSectionContent>
                     </FormSection>
                   )}

--- a/apps/studio/components/interfaces/Realtime/RealtimeSettings.tsx
+++ b/apps/studio/components/interfaces/Realtime/RealtimeSettings.tsx
@@ -104,7 +104,13 @@ export const RealtimeSettings = () => {
   return (
     <ScaffoldSection isFullWidth>
       <Form_Shadcn_ {...form}>
-        <form id={formId} onSubmit={form.handleSubmit(onSubmit)}>
+        <form
+          id={formId}
+          onSubmit={form.handleSubmit((values) => {
+            console.log('WTF', values)
+            onSubmit(values)
+          })}
+        >
           {isError ? (
             <AlertError error={error} subject="Failed to retrieve realtime settings" />
           ) : (
@@ -387,31 +393,31 @@ export const RealtimeSettings = () => {
                   )}
                 />
               </CardContent> */}
-              <CardFooter className="justify-between">
-                <div>
+              <CardFooter className="justify-end gap-x-2">
+                {/* <div>
                   {!canUpdateConfig && (
                     <p className="text-sm text-foreground-light">
                       You need additional permissions to update realtime settings
                     </p>
                   )}
-                </div>
-                <div className="flex items-center gap-x-2">
-                  {form.formState.isDirty && (
-                    <Button type="default" onClick={() => form.reset(data as any)}>
-                      Cancel
-                    </Button>
-                  )}
-                  <Button
-                    type="primary"
-                    htmlType="submit"
-                    form={formId}
-                    disabled={!canUpdateConfig || isUpdatingConfig || !form.formState.isDirty}
-                    loading={isUpdatingConfig}
-                    onClick={() => console.log('onCLICK SUBMIT')}
-                  >
-                    Save changes
+                </div> */}
+                {/* <div className="flex items-center gap-x-2"> */}
+                {form.formState.isDirty && (
+                  <Button type="default" onClick={() => form.reset(data as any)}>
+                    Cancel
                   </Button>
-                </div>
+                )}
+                <Button
+                  type="primary"
+                  htmlType="submit"
+                  form={formId}
+                  disabled={!canUpdateConfig || isUpdatingConfig || !form.formState.isDirty}
+                  loading={isUpdatingConfig}
+                  onClick={() => console.log('onCLICK SUBMIT')}
+                >
+                  Save changes
+                </Button>
+                {/* </div> */}
               </CardFooter>
             </Card>
           )}

--- a/apps/studio/components/interfaces/Realtime/RealtimeSettings.tsx
+++ b/apps/studio/components/interfaces/Realtime/RealtimeSettings.tsx
@@ -121,7 +121,7 @@ export const RealtimeSettings = () => {
                         <FormItemLayout
                           layout="flex"
                           label="Allow public channels"
-                          description="If this is disabled, only private channels will be allowed"
+                          description="If disabled, only private channels will be allowed"
                         >
                           <FormControl_Shadcn_>
                             <Switch

--- a/apps/studio/components/interfaces/Realtime/RealtimeSettings.tsx
+++ b/apps/studio/components/interfaces/Realtime/RealtimeSettings.tsx
@@ -6,16 +6,20 @@ import { toast } from 'sonner'
 import * as z from 'zod'
 
 import { useParams } from 'common'
+import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
 import { ScaffoldSection } from 'components/layouts/Scaffold'
-import { convertFromBytes } from 'components/to-be-cleaned/Storage/StorageSettings/StorageSettings.utils'
 import AlertError from 'components/ui/AlertError'
 import { FormSection, FormSectionContent, FormSectionLabel } from 'components/ui/Forms/FormSection'
+import { InlineLink } from 'components/ui/InlineLink'
+import { useMaxConnectionsQuery } from 'data/database/max-connections-query'
 import { useRealtimeConfigurationUpdateMutation } from 'data/realtime/realtime-config-mutation'
 import {
   REALTIME_DEFAULT_CONFIG,
   useRealtimeConfigurationQuery,
 } from 'data/realtime/realtime-config-query'
+import { useOrgSubscriptionQuery } from 'data/subscriptions/org-subscription-query'
 import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
+import { useSelectedOrganization } from 'hooks/misc/useSelectedOrganization'
 import {
   Button,
   Card,
@@ -28,27 +32,29 @@ import {
   Input_Shadcn_,
   Switch,
 } from 'ui'
+import { Admonition } from 'ui-patterns'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 
 const formId = 'realtime-configuration-form'
 
-const FormSchema = z.object({
-  private_only: z.boolean(),
-  connection_pool: z.coerce.number().min(1).max(100),
-  max_concurrent_users: z.coerce.number().min(1).max(50000),
-  max_events_per_second: z.coerce.number().min(1).max(50000),
-  max_bytes_per_second: z.coerce.number().min(1).max(10000000),
-  max_channels_per_client: z.coerce.number().min(1).max(10000),
-  max_joins_per_second: z.coerce.number().min(1).max(5000),
-})
-
 export const RealtimeSettings = () => {
   const { ref: projectRef } = useParams()
+  const { project } = useProjectContext()
+  const organization = useSelectedOrganization()
   const canUpdateConfig = useCheckPermissions(PermissionAction.REALTIME_ADMIN_READ, '*')
 
+  const { data: maxConn } = useMaxConnectionsQuery({
+    projectRef: project?.ref,
+    connectionString: project?.connectionString,
+  })
   const { data, error, isLoading, isSuccess, isError } = useRealtimeConfigurationQuery({
     projectRef,
   })
+  const { data: subscription, isSuccess: isSuccessSubscription } = useOrgSubscriptionQuery({
+    orgSlug: organization?.slug,
+  })
+  const isUsageBillingEnabled = subscription?.usage_billing_enabled
+
   const { mutate: updateRealtimeConfig, isLoading: isUpdatingConfig } =
     useRealtimeConfigurationUpdateMutation({
       onSuccess: () => {
@@ -57,20 +63,41 @@ export const RealtimeSettings = () => {
       },
     })
 
+  const FormSchema = z.object({
+    allow_public: z.boolean(),
+    connection_pool: z.coerce
+      .number()
+      .min(1)
+      .max(maxConn?.maxConnections ?? 100),
+    max_concurrent_users: z.coerce.number().min(1).max(50000),
+    max_events_per_second: z.coerce.number().min(1).max(50000),
+    max_bytes_per_second: z.coerce.number().min(1).max(10000000),
+    max_channels_per_client: z.coerce.number().min(1).max(10000),
+    max_joins_per_second: z.coerce.number().min(1).max(5000),
+  })
+
   const form = useForm<z.infer<typeof FormSchema>>({
     resolver: zodResolver(FormSchema),
-    defaultValues: REALTIME_DEFAULT_CONFIG,
+    defaultValues: {
+      ...REALTIME_DEFAULT_CONFIG,
+      allow_public: !REALTIME_DEFAULT_CONFIG.private_only,
+    },
   })
 
   const onSubmit: SubmitHandler<z.infer<typeof FormSchema>> = (data) => {
     if (!projectRef) return console.error('Project ref is required')
-    updateRealtimeConfig({ ref: projectRef, ...data })
+    updateRealtimeConfig({
+      ref: projectRef,
+      private_only: !data.allow_public,
+      connection_pool: data.connection_pool,
+      max_concurrent_users: data.max_concurrent_users,
+    })
   }
 
   useEffect(() => {
     // [Joshen] Temp typed with any - API typing marks all the properties as nullable,
     // but checked with Filipe that they're not supposed to
-    if (data) form.reset(data as any)
+    if (data) form.reset({ ...data, allow_public: !data.private_only } as any)
   }, [isSuccess])
 
   return (
@@ -84,7 +111,7 @@ export const RealtimeSettings = () => {
               <CardContent>
                 <FormField_Shadcn_
                   control={form.control}
-                  name="private_only"
+                  name="allow_public"
                   render={({ field }) => (
                     <FormSection
                       className="!p-0 !pt-2"
@@ -93,8 +120,8 @@ export const RealtimeSettings = () => {
                       <FormSectionContent loading={isLoading} className="!gap-y-2">
                         <FormItemLayout
                           layout="flex"
-                          label="Private channels only"
-                          description="If this is enabled, only private channels will be allowed"
+                          label="Allow public channels"
+                          description="If this is disabled, only private channels will be allowed"
                         >
                           <FormControl_Shadcn_>
                             <Switch
@@ -120,11 +147,11 @@ export const RealtimeSettings = () => {
                         <FormSectionLabel
                           description={
                             <p className="text-foreground-lighter text-sm !mt-1">
-                              Sets connection pool size for Realtime Authorization
+                              Realtime Authorization uses this database pool to check client access
                             </p>
                           }
                         >
-                          Connection pool size
+                          Database connection pool size
                         </FormSectionLabel>
                       }
                     >
@@ -154,11 +181,12 @@ export const RealtimeSettings = () => {
                         <FormSectionLabel
                           description={
                             <p className="text-foreground-lighter text-sm !mt-1">
-                              Sets maximum number of concurrent users rate limit
+                              Sets maximum number of concurrent clients that can connect to your
+                              Realtime service
                             </p>
                           }
                         >
-                          Max concurrent users
+                          Max concurrent clients
                         </FormSectionLabel>
                       }
                     >
@@ -167,17 +195,43 @@ export const RealtimeSettings = () => {
                           <Input_Shadcn_
                             {...field}
                             type="number"
-                            disabled={!canUpdateConfig}
+                            disabled={!isUsageBillingEnabled || !canUpdateConfig}
                             value={field.value || ''}
                           />
                         </FormControl_Shadcn_>
                         <FormMessage_Shadcn_ />
+                        {isSuccessSubscription && !isUsageBillingEnabled && (
+                          <Admonition
+                            showIcon={false}
+                            type="default"
+                            title="Spend cap needs to be disabled to configure this value"
+                            description={
+                              <>
+                                You may adjust this setting in the{' '}
+                                <InlineLink
+                                  href={`/org/${organization?.slug}/billing?panel=costControl`}
+                                >
+                                  organization billing settings
+                                </InlineLink>
+                              </>
+                            }
+                          />
+                        )}
                       </FormSectionContent>
                     </FormSection>
                   )}
                 />
               </CardContent>
-              <CardContent>
+
+              {/* 
+                [Joshen] The following fields are hidden from the UI temporarily while we figure out what settings to expose to the users 
+                - Max events per second
+                - Max bytes per second
+                - Max channels per client
+                - Max joins per second
+              */}
+
+              {/* <CardContent>
                 <FormField_Shadcn_
                   control={form.control}
                   name="max_events_per_second"
@@ -210,8 +264,8 @@ export const RealtimeSettings = () => {
                     </FormSection>
                   )}
                 />
-              </CardContent>
-              <CardContent>
+              </CardContent> */}
+              {/* <CardContent>
                 <FormField_Shadcn_
                   control={form.control}
                   name="max_bytes_per_second"
@@ -253,8 +307,8 @@ export const RealtimeSettings = () => {
                     )
                   }}
                 />
-              </CardContent>
-              <CardContent>
+              </CardContent> */}
+              {/* <CardContent>
                 <FormField_Shadcn_
                   control={form.control}
                   name="max_channels_per_client"
@@ -288,8 +342,8 @@ export const RealtimeSettings = () => {
                     </FormSection>
                   )}
                 />
-              </CardContent>
-              <CardContent>
+              </CardContent> */}
+              {/* <CardContent>
                 <FormField_Shadcn_
                   control={form.control}
                   name="max_joins_per_second"
@@ -323,21 +377,30 @@ export const RealtimeSettings = () => {
                     </FormSection>
                   )}
                 />
-              </CardContent>
-              <CardFooter className="justify-end space-x-2">
-                {form.formState.isDirty && (
-                  <Button type="default" onClick={() => form.reset(data as any)}>
-                    Cancel
+              </CardContent> */}
+              <CardFooter className="justify-between">
+                <div>
+                  {!canUpdateConfig && (
+                    <p className="text-sm text-foreground-light">
+                      You need additional permissions to update realtime settings
+                    </p>
+                  )}
+                </div>
+                <div className="flex items-center gap-x-2">
+                  {form.formState.isDirty && (
+                    <Button type="default" onClick={() => form.reset(data as any)}>
+                      Cancel
+                    </Button>
+                  )}
+                  <Button
+                    type="primary"
+                    htmlType="submit"
+                    disabled={!canUpdateConfig || isUpdatingConfig || !form.formState.isDirty}
+                    loading={isUpdatingConfig}
+                  >
+                    Save changes
                   </Button>
-                )}
-                <Button
-                  type="primary"
-                  htmlType="submit"
-                  disabled={!canUpdateConfig || isUpdatingConfig || !form.formState.isDirty}
-                  loading={isUpdatingConfig}
-                >
-                  Save changes
-                </Button>
+                </div>
               </CardFooter>
             </Card>
           )}

--- a/apps/studio/components/interfaces/Realtime/RealtimeSettings.tsx
+++ b/apps/studio/components/interfaces/Realtime/RealtimeSettings.tsx
@@ -70,10 +70,12 @@ export const RealtimeSettings = () => {
       .min(1)
       .max(maxConn?.maxConnections ?? 100),
     max_concurrent_users: z.coerce.number().min(1).max(50000),
-    max_events_per_second: z.coerce.number().min(1).max(50000),
-    max_bytes_per_second: z.coerce.number().min(1).max(10000000),
-    max_channels_per_client: z.coerce.number().min(1).max(10000),
-    max_joins_per_second: z.coerce.number().min(1).max(5000),
+
+    // [Joshen] These fields are temporarily hidden from the UI
+    // max_events_per_second: z.coerce.number().min(1).max(50000),
+    // max_bytes_per_second: z.coerce.number().min(1).max(10000000),
+    // max_channels_per_client: z.coerce.number().min(1).max(10000),
+    // max_joins_per_second: z.coerce.number().min(1).max(5000),
   })
 
   const form = useForm<z.infer<typeof FormSchema>>({
@@ -85,7 +87,6 @@ export const RealtimeSettings = () => {
   })
 
   const onSubmit: SubmitHandler<z.infer<typeof FormSchema>> = (data) => {
-    console.log('FUNCTION ONSUBMIT')
     if (!projectRef) return console.error('Project ref is required')
     updateRealtimeConfig({
       ref: projectRef,
@@ -104,13 +105,7 @@ export const RealtimeSettings = () => {
   return (
     <ScaffoldSection isFullWidth>
       <Form_Shadcn_ {...form}>
-        <form
-          id={formId}
-          onSubmit={form.handleSubmit((values) => {
-            console.log('WTF', values)
-            onSubmit(values)
-          })}
-        >
+        <form id={formId} onSubmit={form.handleSubmit(onSubmit)}>
           {isError ? (
             <AlertError error={error} subject="Failed to retrieve realtime settings" />
           ) : (
@@ -393,31 +388,30 @@ export const RealtimeSettings = () => {
                   )}
                 />
               </CardContent> */}
-              <CardFooter className="justify-end gap-x-2">
-                {/* <div>
+              <CardFooter className="justify-between">
+                <div>
                   {!canUpdateConfig && (
                     <p className="text-sm text-foreground-light">
                       You need additional permissions to update realtime settings
                     </p>
                   )}
-                </div> */}
-                {/* <div className="flex items-center gap-x-2"> */}
-                {form.formState.isDirty && (
-                  <Button type="default" onClick={() => form.reset(data as any)}>
-                    Cancel
+                </div>
+                <div className="flex items-center gap-x-2">
+                  {form.formState.isDirty && (
+                    <Button type="default" onClick={() => form.reset(data as any)}>
+                      Cancel
+                    </Button>
+                  )}
+                  <Button
+                    type="primary"
+                    htmlType="submit"
+                    form={formId}
+                    disabled={!canUpdateConfig || isUpdatingConfig || !form.formState.isDirty}
+                    loading={isUpdatingConfig}
+                  >
+                    Save changes
                   </Button>
-                )}
-                <Button
-                  type="primary"
-                  htmlType="submit"
-                  form={formId}
-                  disabled={!canUpdateConfig || isUpdatingConfig || !form.formState.isDirty}
-                  loading={isUpdatingConfig}
-                  onClick={() => console.log('onCLICK SUBMIT')}
-                >
-                  Save changes
-                </Button>
-                {/* </div> */}
+                </div>
               </CardFooter>
             </Card>
           )}

--- a/apps/studio/pages/project/[ref]/realtime/settings.tsx
+++ b/apps/studio/pages/project/[ref]/realtime/settings.tsx
@@ -5,6 +5,7 @@ import DefaultLayout from 'components/layouts/DefaultLayout'
 import { PageLayout } from 'components/layouts/PageLayout/PageLayout'
 import RealtimeLayout from 'components/layouts/RealtimeLayout/RealtimeLayout'
 import { ScaffoldContainer } from 'components/layouts/Scaffold'
+import { DocsButton } from 'components/ui/DocsButton'
 
 const RealtimePoliciesPage: NextPageWithLayout = () => {
   return (
@@ -17,7 +18,12 @@ const RealtimePoliciesPage: NextPageWithLayout = () => {
 RealtimePoliciesPage.getLayout = (page) => (
   <DefaultLayout>
     <RealtimeLayout title="Realtime Settings">
-      <PageLayout title="Realtime Settings" subtitle="Configure your project's Realtime settings">
+      <PageLayout
+        title="Realtime Settings"
+        subtitle="Configure your project's Realtime settings"
+        // [Joshen] Scaffolding for now - once docs for this is ready
+        primaryActions={<DocsButton href="https://supabase.com/docs" />}
+      >
         {page}
       </PageLayout>
     </RealtimeLayout>


### PR DESCRIPTION
Fixes FE-1475

As per PR title - just updating language + scoping down the input fields

![image](https://github.com/user-attachments/assets/5c215f08-79c2-4240-84e5-3c8599f89534)

## Changes involved:
- Renamed "Private channels only" to "Allow public channels" + negate field value
- Update copy for connection pool size + max concurrent clients
- Added "You need additional permissions" text beside save button if user doesn't have the perms to update realtime settings
- Added validation for connection pool size to be below max database connection size
- Added warning for connection pool size if 80% of max database connection size
![image](https://github.com/user-attachments/assets/0b257166-31dc-4a90-89bf-33856fb52254)
- Disable max concurrent clients field if subscription doesn't have spend cap disabled
![image](https://github.com/user-attachments/assets/82a0011e-47c9-4636-8e0c-f8111fc43dcb)

## To test
- [ ] Can update realtime settings on a project that doesn't have realtime settings yet (check for 404 on /settings endpoint - this is expected for projects that have yet to save their realtime settings at least once)
- [ ] Can update realtime settings on a project that has realtime settings (basically make more than 1 save changes to the project's realtime settings)