### PR TITLE
feat: add user_id to database webhook function payload

### DIFF
--- a/apps/docs/content/guides/database/webhooks.mdx
+++ b/apps/docs/content/guides/database/webhooks.mdx
@@ -59,6 +59,7 @@ type InsertPayload = {
   schema: string
   record: TableRecord<T>
   old_record: null
+  user_id: string | null
 }
 type UpdatePayload = {
   type: 'UPDATE'
@@ -66,6 +67,7 @@ type UpdatePayload = {
   schema: string
   record: TableRecord<T>
   old_record: TableRecord<T>
+  user_id: string | null
 }
 type DeletePayload = {
   type: 'DELETE'
@@ -73,6 +75,7 @@ type DeletePayload = {
   schema: string
   record: null
   old_record: TableRecord<T>
+  user_id: string | null
 }
 ```
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

The id of the user that triggered the Database Webhook is added to the payload.

## What is the current behavior?

Currently it is inconvenient to determine which user made the change to the database inside a Database Webhook.

The "workaround" I'm using is:
1. writing the user id into a column with a before trigger
2. extracting that info from the payload inside the edge function

## What is the new behavior?

The default implementation of the webhook trigger function, automatically adds the user id to the payload.

Discussion: #34284