### PR TITLE
chore: improve memoization of getDiskAttributes

### DIFF
--- a/apps/studio/components/interfaces/DiskManagement/DiskManagementForm.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagementForm.tsx
@@ -209,6 +209,7 @@ export function DiskManagementForm() {
     useUpdateDiskAttributesMutation({
       // this is to suppress to toast message
       onError: () => {},
+      onSuccess: () => setRefetchInterval(2000),
     })
   const { mutateAsync: updateSubscriptionAddon, isLoading: isUpdatingCompute } =
     useProjectAddonUpdateMutation({

--- a/apps/studio/data/config/disk-attributes-query.ts
+++ b/apps/studio/data/config/disk-attributes-query.ts
@@ -62,7 +62,7 @@ export const useRemainingDurationForDiskAttributeUpdate = ({
     return lastModifiedAtString === undefined || COOLDOWN_DURATION - secondsFromNow < 0
       ? 0
       : COOLDOWN_DURATION - secondsFromNow
-  }, [lastModifiedAtString])
+  }, [lastModifiedAtString, secondsFromNow])
 
   if (data?.last_modified_at === undefined)
     return {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES/~NO~

## What kind of change does this PR introduce?

chore

## What is the current behavior?

`useRemainingDurationForDiskAttributeUpdate` hook can run unnecessarily on certain cycles. 

## What is the new behavior?

`useRemainingDurationForDiskAttributeUpdate` only runs when a dependency has changed.

## Additional context

N/A
