### PR TITLE
Update prisma-troubleshooting.mdx | updated default connection count

### DIFF
--- a/apps/docs/content/guides/database/prisma/prisma-troubleshooting.mdx
+++ b/apps/docs/content/guides/database/prisma/prisma-troubleshooting.mdx
@@ -71,7 +71,7 @@ Prisma is unable to allocate connections to pending queries fast enough to meet 
 
 ### Possible causes: [#possible-causes-timed-out-fetching-a-new-connection]
 
-- **Overwhelmed server**: The server hosting Prisma is under heavy load, limiting its ability to manage connections. By default, Prisma will create the default `2 * num_cpus / 2` worth of connections. A common cause for server strain is increasing the `connection_limit` significantly past the default.
+- **Overwhelmed server**: The server hosting Prisma is under heavy load, limiting its ability to manage connections. By default, Prisma will create the default `num_cpus * 2 + 1` worth of connections. A common cause for server strain is increasing the `connection_limit` significantly past the default.
 - **Insufficient pool size**: The Supavisor pooler does not have enough connections available to quickly satisfy Prisma's requests.
 - **Slow queries**: Prisma's queries are taking too long to execute, preventing it from releasing connections for reuse.
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

Displays dated pool size default

## What is the new behavior?

Updates pool size

## Additional context

Add any other context or screenshots.
