### PR TITLE
Update metabase.mdx | a user complained about IPv4 issues with metabase

### DIFF
--- a/apps/docs/content/guides/database/metabase.mdx
+++ b/apps/docs/content/guides/database/metabase.mdx
@@ -41,8 +41,17 @@ hideToc: true
 
     Connect your Postgres server to Metabase.
     - On your project dashboard click on [Connect](https://supabase.com/dashboard/project/_?showConnect=true)
-    - View parameters under Direct Connection
+    - View parameters under "Session pooler"
+
+    <Admonition type="note" label="password manager">
+
+            If you're in an [IPv6 environment](https://supabase.com/docs/guides/platform/ipv4-address#checking-your-network-ipv6-support) or have the [IPv4 Add-On](https://supabase.com/docs/guides/platform/ipv4-address#understanding-ip-addresses), you can use the direct connection string instead of Supavisor in Session mode.
+
+    </Admonition>
+
     - Enter your database credentials into Metabase
+
+
 
     </StepHikeCompact.Details>
 

--- a/apps/docs/content/guides/database/metabase.mdx
+++ b/apps/docs/content/guides/database/metabase.mdx
@@ -43,7 +43,7 @@ hideToc: true
     - On your project dashboard click on [Connect](https://supabase.com/dashboard/project/_?showConnect=true)
     - View parameters under "Session pooler"
 
-    <Admonition type="note" label="password manager">
+    <Admonition type="note" label="connection notice">
 
             If you're in an [IPv6 environment](https://supabase.com/docs/guides/platform/ipv4-address#checking-your-network-ipv6-support) or have the [IPv4 Add-On](https://supabase.com/docs/guides/platform/ipv4-address#understanding-ip-addresses), you can use the direct connection string instead of Supavisor in Session mode.
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

It tells users to rely on direct connections. As far as I know, Metabase is not IPv6 compatible

## What is the new behavior?

Changes the guide to recommend session mode.

## Additional context

A user complained about the issue:
- https://www.reddit.com/r/Supabase/comments/1iuxr6l/connecting_metabase_to_supabase_free_tier/