### PR TITLE
Select GA version as default when creating project

### DIFF
--- a/apps/studio/components/interfaces/ProjectCreation/PostgresVersionSelector.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/PostgresVersionSelector.tsx
@@ -70,7 +70,8 @@ export const PostgresVersionSelector = ({
   )
 
   useEffect(() => {
-    const defaultValue = availableVersions[0] ? formatValue(availableVersions[0]) : undefined
+    const gaVersion = availableVersions.find((x) => x.release_channel === 'ga')
+    const defaultValue = gaVersion ? formatValue(gaVersion) : undefined
     form.setValue('postgresVersionSelection', defaultValue)
   }, [isSuccess, form])
 


### PR DESCRIPTION
*Only affects staging while `disableProjectVersionSelection` flag is on*

Figured its a better DX for ourselves to ensure that the GA version is selected by default when multiple versions of PG are returned from the `/available-versions` endpoint

> [!NOTE]
> The `available-version` endpoint on staging seems to now return just one result, so probably just need to verify that the Postgres Version field gets automatically selected when loading the project creation form

### To test
- [ ] Project creation page, ensure that GA version is selected for the "Postgres Version" field (only can test on staging as local doesn't return multiple results on the `/available-versions` endpoint