### PR TITLE
docs(auth): update step for creating a react app

### DIFF
--- a/apps/docs/content/guides/auth/quickstarts/react.mdx
+++ b/apps/docs/content/guides/auth/quickstarts/react.mdx
@@ -30,14 +30,14 @@ hideToc: true
 
     <StepHikeCompact.Details title="Create a React app">
 
-    Create a React app using the `create-react-app` command.
+    Create a React app using the Vite build tool.
 
     </StepHikeCompact.Details>
 
     <StepHikeCompact.Code>
 
       ```bash Terminal
-      npx create-react-app my-app
+      npm create vite@latest my-app -- --template react
       ```
 
     </StepHikeCompact.Code>
@@ -75,38 +75,38 @@ hideToc: true
 
 
       ```js src/App.js
-        import './index.css'
-        import { useState, useEffect } from 'react'
-        import { createClient } from '@supabase/supabase-js'
-        import { Auth } from '@supabase/auth-ui-react'
-        import { ThemeSupa } from '@supabase/auth-ui-shared'
+      import './index.css'
+      import { useState, useEffect } from 'react'
+      import { createClient } from '@supabase/supabase-js'
+      import { Auth } from '@supabase/auth-ui-react'
+      import { ThemeSupa } from '@supabase/auth-ui-shared'
 
-        const supabase = createClient('https://<project>.supabase.co', '<your-anon-key>')
+      const supabase = createClient('https://<project>.supabase.co', '<your-anon-key>')
 
-        export default function App() {
-          const [session, setSession] = useState(null)
+      export default function App() {
+        const [session, setSession] = useState(null)
 
-          useEffect(() => {
-            supabase.auth.getSession().then(({ data: { session } }) => {
-              setSession(session)
-            })
+        useEffect(() => {
+          supabase.auth.getSession().then(({ data: { session } }) => {
+            setSession(session)
+          })
 
-            const {
-              data: { subscription },
-            } = supabase.auth.onAuthStateChange((_event, session) => {
-              setSession(session)
-            })
+          const {
+            data: { subscription },
+          } = supabase.auth.onAuthStateChange((_event, session) => {
+            setSession(session)
+          })
 
-            return () => subscription.unsubscribe()
-          }, [])
+          return () => subscription.unsubscribe()
+        }, [])
 
-          if (!session) {
-            return (<Auth supabaseClient={supabase} appearance={{ theme: ThemeSupa }} />)
-          }
-          else {
-            return (<div>Logged in!</div>)
-          }
+        if (!session) {
+          return (<Auth supabaseClient={supabase} appearance={{ theme: ThemeSupa }} />)
         }
+        else {
+          return (<div>Logged in!</div>)
+        }
+      }
       ```
 
     </StepHikeCompact.Code>


### PR DESCRIPTION
create-react-app has been recently deprecates and is no longer a recommended way to start a React App from scratch:

- https://react.dev/blog/2025/02/14/sunsetting-create-react-app 
- https://react.dev/learn/build-a-react-app-from-scratch

I'm not sure what exactly to replace the CRA command here with, so I simply took the first recommended command from the docs. It uses Vite. In my opinion, of the 3 officially recommended build tools (Vite, Parcel, Rsbuild), Vite is also best suited for creating a sample React app fast.

Let me know if listing commands for all 3 tools is better, or if this change is unnecessary.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

Yes

## What kind of change does this PR introduce?

Docs update.

## What is the current behavior?

Please link any relevant issues here.

#34388 

## What is the new behavior?

N/A

## Additional context

I have also opened an issue for this PR: #34388 
Additionally, this PR fixes indentation for the App.js file (on the docs page, the first line is not indented and all the rest are indented with two spaces, at the moment).
