### PR TITLE
Fix account audit logs date range selection

### DIFF
--- a/apps/studio/components/interfaces/Account/AuditLogs.tsx
+++ b/apps/studio/components/interfaces/Account/AuditLogs.tsx
@@ -14,6 +14,7 @@ import { useOrganizationsQuery } from 'data/organizations/organizations-query'
 import { useProfileAuditLogsQuery } from 'data/profile/profile-audit-logs-query'
 import { useProjectsQuery } from 'data/projects/projects-query'
 import { Alert, Button } from 'ui'
+import { TimestampInfo } from 'ui-patterns'
 
 const AuditLogs = () => {
   const currentTime = dayjs().utc().set('millisecond', 0)
@@ -71,7 +72,7 @@ const AuditLogs = () => {
 
   return (
     <>
-      <div className="space-y-4 flex flex-col">
+      <div className="space-y-4 flex flex-col pb-8">
         <div className="flex flex-col md:flex-row md:items-center justify-between">
           <div className="flex items-center space-x-2">
             <p className="text-xs prose">Filter by</p>
@@ -94,20 +95,43 @@ const AuditLogs = () => {
               maxDate={dayjs().toDate()}
               onChange={(value) => {
                 if (value.from !== null && value.to !== null) {
-                  const current = dayjs().utc()
+                  const current = dayjs()
                   const from = dayjs(value.from)
-                    .utc()
                     .hour(current.hour())
                     .minute(current.minute())
                     .second(current.second())
-                    .toISOString()
                   const to = dayjs(value.to)
-                    .utc()
                     .hour(current.hour())
                     .minute(current.minute())
                     .second(current.second())
-                    .toISOString()
-                  setDateRange({ from, to })
+
+                  if (from.date() === to.date()) {
+                    // [Joshen] If a single date is selected, we either set the "from" to start from 00:00
+                    // or "to" to end at 23:59 depending on which date was selected
+                    if (from.date() === current.date()) {
+                      setDateRange({
+                        from: from
+                          .set('hour', 0)
+                          .set('minute', 0)
+                          .set('second', 0)
+                          .utc()
+                          .toISOString(),
+                        to: to.utc().toISOString(),
+                      })
+                    } else {
+                      setDateRange({
+                        from: from.utc().toISOString(),
+                        to: to
+                          .set('hour', 23)
+                          .set('minute', 59)
+                          .set('second', 59)
+                          .utc()
+                          .toISOString(),
+                      })
+                    }
+                  } else {
+                    setDateRange({ from: from.utc().toISOString(), to: to.utc().toISOString() })
+                  }
                 }
               }}
               renderFooter={() => {
@@ -253,7 +277,7 @@ const AuditLogs = () => {
                             </p>
                           </Table.td>
                           <Table.td>
-                            {dayjs(log.occurred_at).format('DD MMM YYYY, HH:mm:ss')}
+                            <TimestampInfo className="text-sm" utcTimestamp={log.occurred_at} />
                           </Table.td>
                           <Table.td align="right">
                             <Button type="default">View details</Button>


### PR DESCRIPTION
Realised that we were sending the same start and end time when selecting a single date in account audit logs, hence why returning 0 results. This PR fixes that + use TimestampInfo for account audit logs date column

## To test:
- [ ] Can select a single date (the day before) in the date range selector for account audit logs
- [ ] Can select a single date (the current day) in the date range selector for account audit logs
- [ ] Can select a date range in the date range selector for account audit logs (default)