### PR TITLE
Update log schemas for field reference

### DIFF
--- a/packages/shared-data/logConstants.ts
+++ b/packages/shared-data/logConstants.ts
@@ -9,7 +9,6 @@ type LogTable =
   | 'postgrest_logs'
   | 'supavisor_logs'
   | 'pgbouncer_logs'
-  | 'warehouse_logs'
   | 'pg_cron_logs'
 
 type LogSchema = {
@@ -23,7 +22,7 @@ type LogSchema = {
 
 const schemas: LogSchema[] = [
   {
-    name: 'API Edge',
+    name: 'API Gateway',
     reference: 'edge_logs',
     fields: [
       { path: 'id', type: 'string' },

--- a/packages/shared-data/logConstants.ts
+++ b/packages/shared-data/logConstants.ts
@@ -1,4 +1,27 @@
-const schemas = [
+type LogTable =
+  | 'edge_logs'
+  | 'postgres_logs'
+  | 'function_logs'
+  | 'function_edge_logs'
+  | 'auth_logs'
+  | 'realtime_logs'
+  | 'storage_logs'
+  | 'postgrest_logs'
+  | 'supavisor_logs'
+  | 'pgbouncer_logs'
+  | 'warehouse_logs'
+  | 'pg_cron_logs'
+
+type LogSchema = {
+  name: string
+  reference: LogTable
+  fields: {
+    path: string
+    type: string
+  }[]
+}
+
+const schemas: LogSchema[] = [
   {
     name: 'API Edge',
     reference: 'edge_logs',
@@ -229,13 +252,42 @@ const schemas = [
     ],
   },
   {
-    name: 'Supavisor',
+    name: 'Supavisor (Shared Pooler)',
     reference: 'supavisor_logs',
     fields: [
       { path: 'event_message', type: 'string' },
       { path: 'id', type: 'string' },
       { path: 'timestamp', type: 'datetime' },
+      { path: 'metadata.context.application', type: 'string' },
+      { path: 'metadata.context.domain', type: 'string[]' },
+      { path: 'metadata.context.file', type: 'string' },
+      { path: 'metadata.context.function', type: 'string' },
+      { path: 'metadata.context.gl', type: 'string' },
+      { path: 'metadata.context.line', type: 'number' },
+      { path: 'metadata.context.mfa', type: 'string[]' },
+      { path: 'metadata.context.module', type: 'string' },
+      { path: 'metadata.context.pid', type: 'string' },
+      { path: 'metadata.context.time', type: 'number' },
+      { path: 'metadata.context.vm.node', type: 'string' },
+      { path: 'metadata.db_name', type: 'string' },
+      { path: 'metadata.instance_id', type: 'string' },
+      { path: 'metadata.level', type: 'string' },
+      { path: 'metadata.project', type: 'string' },
+      { path: 'metadata.region', type: 'string' },
+      { path: 'metadata.type', type: 'string' },
+      { path: 'metadata.user', type: 'string' },
+    ],
+  },
+  {
+    name: 'PgBouncer (Dedicated Pooler)',
+    reference: 'pgbouncer_logs',
+    fields: [
+      { path: 'id', type: 'string' },
+      { path: 'event_message', type: 'string' },
+      { path: 'file', type: 'string' },
+      { path: 'timestamp', type: 'datetime' },
       { path: 'metadata.host', type: 'string' },
+      { path: 'project', type: 'string' },
     ],
   },
 ]


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Updates the field reference docs in log explorer to show Dedicated and Shared pooler log schemas


![CleanShot 2025-03-26 at 11 58 35@2x](https://github.com/user-attachments/assets/25e2dcba-b9a1-4a13-aae8-b101fd6113ef)
