### PR TITLE
fix: foreign row selector dnd sorts bug

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/ForeignRowSelector/ForeignRowSelector.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/ForeignRowSelector/ForeignRowSelector.tsx
@@ -1,5 +1,7 @@
 import { Loader2 } from 'lucide-react'
 import { useState } from 'react'
+import { DndProvider } from 'react-dnd'
+import { HTML5Backend } from 'react-dnd-html5-backend'
 
 import { useParams } from 'common'
 import {
@@ -156,7 +158,9 @@ const ForeignRowSelector = ({
                   <div className="flex items-center">
                     <RefreshButton tableId={table?.id} isRefetching={isRefetching} />
                     <FilterPopover filters={filters} onApplyFilters={onApplyFilters} />
-                    <SortPopover sorts={sorts} onApplySorts={onApplySorts} />
+                    <DndProvider backend={HTML5Backend} context={window}>
+                      <SortPopover sorts={sorts} onApplySorts={onApplySorts} />
+                    </DndProvider>
                   </div>
 
                   <div className="flex items-center gap-x-3 divide-x">


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When trying to add a sort in the foreign row selector you get the error:
![Screenshot 2025-03-26 at 17 11 46](https://github.com/user-attachments/assets/40e38b83-3d4d-44ca-a6bb-d3ca04da2ffa)

## Testing

Try linking to a foreign row and add some sorts:

<img width="703" alt="Screenshot 2025-03-26 at 17 14 29" src="https://github.com/user-attachments/assets/c70135e3-3190-409b-bb51-26adbb1cb66b" />
