### PR TITLE
docs: add usage to CLI docs

### DIFF
--- a/apps/docs/features/docs/Reference.sections.tsx
+++ b/apps/docs/features/docs/Reference.sections.tsx
@@ -165,6 +165,18 @@ async function CliCommandSection({ link, section }: CliCommandSectionProps) {
         {command.description && (
           <ReactMarkdown className="prose break-words mb-8">{command.description}</ReactMarkdown>
         )}
+        {command.usage && (
+          <div className="mb-8">
+            <h3 className="mb-2 text-base text-foreground">Usage</h3>
+            <CodeBlock
+              language="bash"
+              className="p-4 rounded-md border bg-surface-100"
+              wrapperClassName="break-all"
+            >
+              {command.usage}
+            </CodeBlock>
+          </div>
+        )}
         {(command.subcommands ?? []).length > 0 && (
           <>
             <h3 className="mb-3 text-base text-foreground">Subcommands</h3>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

Yep.

## What kind of change does this PR introduce?

Docs update. Fixes https://github.com/supabase/supabase/issues/33157.

## What is the current behavior?

Usage syntax from the [CLI spec](https://github.com/supabase/supabase/blob/master/apps/docs/spec/cli_v1_commands.yaml#L99) is not displayed in the CLI reference docs. Example:

![Screenshot 2025-03-26 at 1 56 42 PM](https://github.com/user-attachments/assets/dc7d155f-f300-4092-9ef4-7fc9b9a46229)

## What is the new behavior?

Usage syntax is now displayed. Example:

![Screenshot 2025-03-26 at 1 59 01 PM](https://github.com/user-attachments/assets/6a3a5798-40c1-436e-9a68-5283d9fe29af)

## Additional context

The syntax highlighter formats built-in bash commands, like `test` and `unset`. However, this is also the case in the existing examples. I opened a separate issue (https://github.com/supabase/supabase/issues/34449) to address.

![Screenshot 2025-03-26 at 2 02 04 PM](https://github.com/user-attachments/assets/9376d668-5442-4a13-8556-7168299b9599)

