### PR TITLE
fix: syntax highlighting in cli reference

### DIFF
--- a/apps/docs/features/docs/Reference.sections.tsx
+++ b/apps/docs/features/docs/Reference.sections.tsx
@@ -1,13 +1,6 @@
 import { Fragment } from 'react'
 import ReactMarkdown from 'react-markdown'
-import {
-  Tabs_Shadcn_,
-  TabsContent_Shadcn_,
-  TabsList_Shadcn_,
-  TabsTrigger_Shadcn_,
-  cn,
-  CodeBlock,
-} from 'ui'
+import { Tabs_Shadcn_, TabsContent_Shadcn_, TabsList_Shadcn_, TabsTrigger_Shadcn_, cn } from 'ui'
 
 import ApiSchema from '~/components/ApiSchema'
 import { REFERENCES } from '~/content/navigation.references'
@@ -34,6 +27,7 @@ import {
 } from '~/features/docs/Reference.ui'
 import type { AbbrevApiReferenceSection } from '~/features/docs/Reference.utils'
 import { normalizeMarkdown } from '~/features/docs/Reference.utils'
+import { CodeBlock } from '~/features/ui/CodeBlock/CodeBlock'
 import { RefInternalLink } from './Reference.navigation.client'
 import { ApiOperationBodySchemeSelector } from './Reference.ui.client'
 
@@ -161,20 +155,16 @@ async function CliCommandSection({ link, section }: CliCommandSectionProps) {
   return (
     <RefSubLayout.Section columns="double" link={link} {...section}>
       <StickyHeader title={command.title} className="col-[1_/_-1]" monoFont={true} />
-      <div>
+      <div className="w-full min-w-0">
         {command.description && (
-          <ReactMarkdown className="prose break-words mb-8">{command.description}</ReactMarkdown>
+          <ReactMarkdown className="prose w-full break-words mb-8">
+            {command.description}
+          </ReactMarkdown>
         )}
         {command.usage && (
           <div className="mb-8">
             <h3 className="mb-2 text-base text-foreground">Usage</h3>
-            <CodeBlock
-              language="bash"
-              className="p-4 rounded-md border bg-surface-100"
-              wrapperClassName="break-all"
-            >
-              {command.usage}
-            </CodeBlock>
+            <CodeBlock lang="bash">{command.usage}</CodeBlock>
           </div>
         )}
         {(command.subcommands ?? []).length > 0 && (
@@ -249,17 +239,11 @@ async function CliCommandSection({ link, section }: CliCommandSectionProps) {
               </TabsList_Shadcn_>
               {command.examples.map((example) => (
                 <TabsContent_Shadcn_ key={example.id} value={example.id}>
-                  <CodeBlock
-                    language="bash"
-                    className="p-4 rounded-md border"
-                    wrapperClassName="mb-8"
-                  >
+                  <CodeBlock lang="bash" className="mb-6">
                     {example.code}
                   </CodeBlock>
                   <h3 className="text-foreground-lighter text-sm mb-2">Response</h3>
-                  <CodeBlock language="bash" className="p-4 rounded-md border">
-                    {example.response}
-                  </CodeBlock>
+                  <CodeBlock lang="txt">{example.response}</CodeBlock>
                 </TabsContent_Shadcn_>
               ))}
             </Tabs_Shadcn_>


### PR DESCRIPTION
Swap out the old code blocks for Shiki, which has a better highlighter and is consistent with code block styling elsewhere in docs.

Before:

<img width="565" alt="image" src="https://github.com/user-attachments/assets/d5c9a4cd-e235-4087-bfaa-4d489bd9f28a" />

After:

<img width="565" alt="image" src="https://github.com/user-attachments/assets/d2c8b48f-1982-4566-90cd-0c6a7a100e69" />

Resolves #34449