### PR TITLE
auth-email-passwordless.mdx: use magiclink auth type in email

### DIFF
--- a/apps/docs/content/guides/auth/auth-email-passwordless.mdx
+++ b/apps/docs/content/guides/auth/auth-email-passwordless.mdx
@@ -135,7 +135,7 @@ If you're using PKCE flow, edit the Magic Link [email template](/docs/guides/aut
 <h2>Magic Link</h2>
 
 <p>Follow this link to login:</p>
-<p><a href="{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=email">Log In</a></p>
+<p><a href="{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=magiclink">Log In</a></p>
 ```
 
 At the `/auth/confirm` endpoint, exchange the hash for the session:


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update. 

## What is the current behavior?

I *think* the suggested template is not completely right, as it passes type `email` which is then used when calling `verifyOtp`, for example when integrating with next.js: https://supabase.com/docs/guides/auth/server-side/nextjs?queryGroups=router&router=app. Type `email` seems to be when login with a username/password rather than a magic link, and I can see the supabase type `EmailOtpType` has a possible value `magiclink`.

Or maybe it doesn't matter so much, the token is enough to recognize the type?

## What is the new behavior?

Passes `magiclink` as type instead.

## Additional context

n/a
