### PR TITLE
Remove pixel based css classes, and use minSize and maxSize property instead

### DIFF
--- a/apps/studio/components/layouts/ProjectLayout/ProjectLayout.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/ProjectLayout.tsx
@@ -1,8 +1,8 @@
 import { useParams } from 'common'
 import ProjectAPIDocs from 'components/interfaces/ProjectAPIDocs/ProjectAPIDocs'
 import { AIAssistantPanel } from 'components/ui/AIAssistantPanel/AIAssistantPanel'
-import { EditorPanel } from 'components/ui/EditorPanel/EditorPanel'
 import AISettingsModal from 'components/ui/AISettingsModal'
+import { EditorPanel } from 'components/ui/EditorPanel/EditorPanel'
 import { Loading } from 'components/ui/Loading'
 import { ResourceExhaustionWarningBanner } from 'components/ui/ResourceExhaustionWarningBanner/ResourceExhaustionWarningBanner'
 import { AnimatePresence, motion } from 'framer-motion'
@@ -143,7 +143,7 @@ const ProjectLayout = forwardRef<HTMLDivElement, PropsWithChildren<ProjectLayout
           <meta name="description" content="Supabase Studio" />
         </Head>
         <div className="flex flex-row h-full w-full">
-          <ResizablePanelGroup className="" direction="horizontal" autoSaveId="project-layout">
+          <ResizablePanelGroup direction="horizontal" autoSaveId="project-layout">
             {showProductMenu && productMenu && (
               <ResizablePanel
                 order={1}
@@ -190,8 +190,8 @@ const ProjectLayout = forwardRef<HTMLDivElement, PropsWithChildren<ProjectLayout
             )}
             <ResizablePanel order={2} id="panel-right" className="h-full flex flex-col w-full">
               <ResizablePanelGroup
-                className="h-full w-full overflow-x-hidden flex-1 flex flex-row gap-0"
                 direction="horizontal"
+                className="h-full w-full overflow-x-hidden flex-1 flex flex-row gap-0"
                 autoSaveId="project-layout-content"
               >
                 <ResizablePanel
@@ -221,10 +221,11 @@ const ProjectLayout = forwardRef<HTMLDivElement, PropsWithChildren<ProjectLayout
                     <ResizableHandle withHandle />
                     <ResizablePanel
                       id="panel-assistant"
+                      minSize={30}
+                      maxSize={50}
                       className={cn(
                         'border-l xl:border-l-0 bg fixed z-40 md:absolute md:z-0 right-0 top-0 md:top-[48px] bottom-0 xl:relative xl:top-0',
-                        'w-screen h-[100dvh] md:h-auto md:w-auto md:min-w-[400px] max-w-[500px]',
-                        '2xl:min-w-[500px] 2xl:max-w-[600px]'
+                        'w-screen h-[100dvh] md:h-auto md:w-auto'
                       )}
                     >
                       {aiAssistantPanel.open && <AIAssistantPanel />}


### PR DESCRIPTION
Realised that we need to avoid pixel based constraints for resizeable panels as per https://github.com/bvaughn/react-resizable-panels/issues/46

Resolves 2 issues:
- Awkward spacing when expanding the panel up to a certain width
![image](https://github.com/user-attachments/assets/8aee073f-11cf-471c-8e82-c4fdaf505d7f)
- Awkward dragging behaviour when expanding/minimizing panel (due to pixel based constraints)
  - e.g when the panel is at its smallests, dragging to expand the panel doesnt make the panel expand until the mouse has been dragged away far enough
