### PR TITLE
ref: Remove redundant oauth apps icon workaround

### DIFF
--- a/apps/studio/components/interfaces/Organization/OAuthApps/PublishAppSidePanel/index.tsx
+++ b/apps/studio/components/interfaces/Organization/OAuthApps/PublishAppSidePanel/index.tsx
@@ -166,7 +166,7 @@ const PublishAppSidePanel = ({
         website,
         redirect_uris,
         scopes,
-        icon: uploadedIconUrl === undefined ? null : uploadedIconUrl,
+        icon: uploadedIconUrl,
       })
     }
   }

--- a/apps/studio/data/oauth/oauth-app-update-mutation.ts
+++ b/apps/studio/data/oauth/oauth-app-update-mutation.ts
@@ -11,7 +11,7 @@ export type OAuthAppUpdateVariables = {
   slug: string
   name: string
   website: string
-  icon?: string | null
+  icon?: string
   scopes?: OAuthScope[]
   redirect_uris: string[]
 }
@@ -36,7 +36,7 @@ export async function updateOAuthApp({
     body: {
       name,
       website,
-      icon: icon as undefined, // Generated type is incorrect an allows for `string | undefined` only, while we need `null` here.
+      icon,
       scopes,
       redirect_uris,
     },


### PR DESCRIPTION
Fixed upstream, not needed anymore.