### PR TITLE
[FE-1491] fix: pgbouncer ignore_startup_parameters field getting overridden

### DIFF
--- a/apps/studio/components/interfaces/Settings/Database/ConnectionPooling/ConnectionPooling.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/ConnectionPooling/ConnectionPooling.tsx
@@ -104,6 +104,7 @@ export const ConnectionPooling = () => {
   const defaultPoolSize = poolingOptimizations.poolSize ?? 15
   const defaultMaxClientConn = poolingOptimizations.maxClientConn ?? 200
   const connectionPoolingUnavailable = pgbouncerConfig?.pool_mode === null
+  const ignoreStartupParameters = pgbouncerConfig?.ignore_startup_parameters
 
   const onSubmit: SubmitHandler<z.infer<typeof PoolingConfigurationFormSchema>> = async (data) => {
     const { default_pool_size } = data
@@ -114,6 +115,7 @@ export const ConnectionPooling = () => {
       {
         ref: projectRef,
         default_pool_size: default_pool_size === null ? undefined : default_pool_size,
+        ignore_startup_parameters: ignoreStartupParameters ?? '',
       },
       {
         onSuccess: (data) => {

--- a/apps/studio/data/database/pgbouncer-config-update-mutation.ts
+++ b/apps/studio/data/database/pgbouncer-config-update-mutation.ts
@@ -10,13 +10,14 @@ export type PgbouncerConfigurationUpdateVariables = {
   ref: string
 } & Pick<
   components['schemas']['UpdatePgbouncerConfigBody'],
-  'default_pool_size' | 'max_client_conn'
+  'default_pool_size' | 'max_client_conn' | 'ignore_startup_parameters'
 >
 
 export async function updatePgbouncerConfiguration({
   ref,
   default_pool_size,
   max_client_conn,
+  ignore_startup_parameters,
 }: PgbouncerConfigurationUpdateVariables) {
   if (!ref) return console.error('Project ref is required')
 
@@ -25,7 +26,7 @@ export async function updatePgbouncerConfiguration({
     body: {
       default_pool_size,
       max_client_conn,
-      ignore_startup_parameters: '',
+      ignore_startup_parameters,
     },
   })
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

`ignore_startup_parameters` gets reset to `''`.

## What is the new behavior?

`ignore_startup_parameters` is maintained.

<img width="459" alt="Screenshot 2025-03-27 at 15 19 31" src="https://github.com/user-attachments/assets/d431da7d-6ccb-47ac-98a7-f1f698571138" />
