### PR TITLE
fix: bad indent in Vercel Postgres migration

### DIFF
--- a/apps/docs/content/guides/platform/migrating-to-supabase/vercel-postgres.mdx
+++ b/apps/docs/content/guides/platform/migrating-to-supabase/vercel-postgres.mdx
@@ -63,15 +63,15 @@ You will need the [pg_dump](https://www.postgresql.org/docs/current/app-pgdump.h
 
    Use `pg_dump` with your Postgres credentials to export your database to a file (e.g., `dump.sql`).
 
-```bash
-pg_dump "$OLD_DB_URL" \
-  --clean \
-  --if-exists \
-  --quote-all-identifiers \
-  --no-owner \
-  --no-privileges \
-  > dump.sql
-```
+      ```bash
+      pg_dump "$OLD_DB_URL" \
+      --clean \
+      --if-exists \
+      --quote-all-identifiers \
+      --no-owner \
+      --no-privileges \
+      > dump.sql
+      ```
 
 2. Import the database to your Supabase project
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

Yep.

## What kind of change does this PR introduce?

Fixes some bad indentation that's causing the ordered list to reset.

## What is the current behavior?

![Screenshot 2025-03-27 at 10 41 35 AM](https://github.com/user-attachments/assets/2d5e246a-9207-42a6-8f5e-9bfcda3ddcdb)

## What is the new behavior?

![Screenshot 2025-03-27 at 10 41 40 AM](https://github.com/user-attachments/assets/4fe40ee9-aefa-4f74-baf6-009fe3ebba3a)

## Additional context

We may be able to delete this page entirely. Per the [Vercel docs](https://neon.tech/docs/guides/vercel-postgres-transition-guide), Vercel Postgres migrated to the Neon Postgres Native Integration for Vercel. It does say _almost all_ though.
