### PR TITLE
docs: MCP queries are read-only

### DIFF
--- a/apps/docs/content/guides/getting-started/mcp.mdx
+++ b/apps/docs/content/guides/getting-started/mcp.mdx
@@ -5,20 +5,20 @@ description: 'Connect AI tools to Supabase using MCP'
 sidebar_label: 'Model context protocol (MCP)'
 ---
 
-The [Model Context Protocol](https://modelcontextprotocol.io/introduction) (MCP) is a standard for connecting Large Language Models (LLMs) to external services. This guide will walk you through how to connect AI tools to Supabase using MCP.
+The [Model Context Protocol](https://modelcontextprotocol.io/introduction) (MCP) is a standard for connecting Large Language Models (LLMs) to external services.
 
-There are a number of popular AI tools that support MCP, including:
+This guide covers how to connect Supabase to the following AI tools using MCP:
 
 - [Cursor](https://www.cursor.com/)
 - [Windsurf](https://docs.codeium.com/windsurf) (Codium)
 - [Cline](https://github.com/cline/cline) (VS Code extension)
 - [Claude desktop](https://claude.ai/download)
 
-Connecting these tools to Supabase will allow you to query your database and perform other SQL operations using natural language commands.
+Once connected, you can use natural language commands to run read-only database queries in the AI tool.
 
 ## Connect to Supabase using MCP
 
-We will use the [Postgres MCP server](https://github.com/modelcontextprotocol/servers/tree/main/src/postgres) to connect AI tools to Supabase.
+Supabase uses the [Postgres MCP server](https://github.com/modelcontextprotocol/servers/tree/main/src/postgres) to provide MCP access to your database. The MCP server runs all queries as read-only transactions.
 
 ### Step 1: Find your database connection string
 
@@ -101,4 +101,4 @@ MCP compatible tools can connect to Supabase using the [Postgres MCP server](htt
 
 ## Next steps
 
-You are now connected to Supabase using MCP! You can now interact with your database using natural language commands. Try asking your AI tool to query your database, create a new table, or perform other SQL operations.
+Your AI tool is now connected to Supabase using MCP. Try asking the AI tool to query your database using natural language commands.


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

Yep

## What kind of change does this PR introduce?

Docs update (docs bug fix). Closes https://github.com/supabase/supabase/issues/34405.

## What is the current behavior?

The current MCP docs indicate users can perform write queries, such as creating a table. However, only read queries are supported.

## What is the new behavior?

Edits the docs to clarify that only read queries are supported. Includes other minor edits for conciseness.

## Additional context

I confirmed Postgres MCP server only runs read-only transactions. Trying to create a table in Cursor:

![Screenshot 2025-03-27 at 12 39 21 PM](https://github.com/user-attachments/assets/faabc8fe-d3e3-4de5-b0cc-2ac91466abeb)

