### PR TITLE
fix: move docs off deprecated endpoint

### DIFF
--- a/apps/docs/components/ProjectConfigVariables/ProjectConfigVariables.tsx
+++ b/apps/docs/components/ProjectConfigVariables/ProjectConfigVariables.tsx
@@ -283,11 +283,9 @@ function VariableView({ variable, className }: { variable: Variable; className?:
   function isInvalid(apiData: ProjectApiData) {
     switch (variable) {
       case 'url':
-        return !apiData.autoApiService.endpoint
+        return !apiData.app_config?.endpoint
       case 'anonKey':
-        // If the anon key is not available, the backend may return the string:
-        // You're using an older version of Supabase. Create a new project for the latest Auth features.
-        return /older version/.test(apiData.autoApiService.defaultApiKey)
+        return !apiData.service_api_keys?.some((key) => key.tags === 'anon')
     }
   }
 
@@ -307,12 +305,10 @@ function VariableView({ variable, className }: { variable: Variable; className?:
   if (stateSummary === 'loggedIn.selectedProject.dataSuccess') {
     switch (variable) {
       case 'url':
-        variableValue = `${apiData.autoApiService.protocol || 'https'}://${
-          apiData.autoApiService.endpoint
-        }`
+        variableValue = `https://${apiData.app_config!.endpoint}`
         break
       case 'anonKey':
-        variableValue = apiData.autoApiService.defaultApiKey
+        variableValue = apiData.service_api_keys!.find((key) => key.tags === 'anon')!.api_key
         break
     }
   }

--- a/apps/docs/lib/fetch/projectApi.ts
+++ b/apps/docs/lib/fetch/projectApi.ts
@@ -15,7 +15,7 @@ async function getProjectApi({ projectRef }: ProjectApiVariables, signal?: Abort
     throw Error('projectRef is required')
   }
 
-  const { data, error } = await get('/platform/props/project/{ref}/api', {
+  const { data, error } = await get('/platform/projects/{ref}/settings', {
     params: {
       path: { ref: projectRef },
     },


### PR DESCRIPTION
Docs is using a deprecated endpoint to get the API keys for the project variables component. Move to a new endpoint.

## Testing

There's no way to sign in on a docs preview site, so sign into a studio preview site, then copy and paste your auth token from local storage to test.