### PR TITLE
feat(docs): fetch conn string

### DIFF
--- a/apps/docs/components/ProjectConfigVariables/ProjectConfigVariables.utils.ts
+++ b/apps/docs/components/ProjectConfigVariables/ProjectConfigVariables.utils.ts
@@ -6,7 +6,7 @@ export type Org = OrganizationsData[number]
 export type Project = ProjectsData[number]
 export type Branch = BranchesData[number]
 
-export type Variable = 'url' | 'anonKey'
+export type Variable = 'url' | 'anonKey' | 'sessionPooler'
 
 function removeDoubleQuotes(str: string) {
   return str.replaceAll('"', '')
@@ -31,6 +31,7 @@ function unescapeDoubleQuotes(str: string) {
 export const prettyFormatVariable: Record<Variable, string> = {
   url: 'Project URL',
   anonKey: 'Anon key',
+  sessionPooler: 'Connection string (pooler session mode)',
 }
 
 type DeepReadonly<T> = {

--- a/apps/docs/content/guides/getting-started/mcp.mdx
+++ b/apps/docs/content/guides/getting-started/mcp.mdx
@@ -27,7 +27,9 @@ To get started, you will need to retrieve your database connection string. These
 
 #### For a hosted Supabase instance
 
-When running a hosted instance of Supabase, you can find your connection string by:
+<ProjectConfigVariables variable="sessionPooler" />
+
+Log in and choose a project above to find your connection string, or find it in the Dashboard:
 
 1. Navigating to your project's [Connection settings](/dashboard/project/_/settings/database?showConnect=true)
 1. Copying the connection string found under **Session pooler**.

--- a/apps/docs/content/guides/getting-started/mcp.mdx
+++ b/apps/docs/content/guides/getting-started/mcp.mdx
@@ -34,6 +34,12 @@ Log in and choose a project above to find your connection string, or find it in 
 1. Navigating to your project's [Connection settings](/dashboard/project/_/settings/database?showConnect=true)
 1. Copying the connection string found under **Session pooler**.
 
+<Admonition type="note">
+
+Be sure to replace `[YOUR-PASSWORD]` with your database password.
+
+</Admonition>
+
 #### For a local Supabase instance
 
 When running a local instance of Supabase via the [CLI](/docs/reference/cli/introduction), you can find your connection string by running:

--- a/apps/docs/lib/fetch/pooler.ts
+++ b/apps/docs/lib/fetch/pooler.ts
@@ -1,0 +1,42 @@
+import { type UseQueryOptions, useQuery } from '@tanstack/react-query'
+
+import type { ResponseError } from '~/types/fetch'
+import { get } from './fetchWrappers'
+
+const poolerKeys = {
+  supavisorConfig: (projectRef: string | undefined) => ['supavisor', 'config', projectRef] as const,
+}
+
+export interface SupavisorConfigVariables {
+  projectRef?: string
+}
+
+async function getSupavisorConfig({ projectRef }: SupavisorConfigVariables, signal?: AbortSignal) {
+  if (!projectRef) throw Error('projectRef is required')
+
+  const { data, error } = await get(`/platform/projects/{ref}/config/supavisor`, {
+    params: { path: { ref: projectRef } },
+    signal,
+  })
+  if (error) throw error
+
+  return data
+}
+
+export type SupavisorConfigData = Awaited<ReturnType<typeof getSupavisorConfig>>
+type SupavisorConfigError = ResponseError
+
+export function useSupavisorConfigQuery<TData = SupavisorConfigData>(
+  { projectRef }: SupavisorConfigVariables,
+  {
+    enabled = true,
+    ...options
+  }: Omit<UseQueryOptions<SupavisorConfigData, SupavisorConfigError, TData>, 'queryKey'>
+) {
+  return useQuery<SupavisorConfigData, SupavisorConfigError, TData>({
+    queryKey: poolerKeys.supavisorConfig(projectRef),
+    queryFn: ({ signal }) => getSupavisorConfig({ projectRef }, signal),
+    enabled,
+    ...options,
+  })
+}

--- a/apps/docs/lib/fetch/projects.ts
+++ b/apps/docs/lib/fetch/projects.ts
@@ -1,6 +1,7 @@
 import { useQuery, UseQueryOptions } from '@tanstack/react-query'
 import type { ResponseError } from '~/types/fetch'
 import { get } from './fetchWrappers'
+import { type ReadonlyRecursive } from '~/types/utils'
 
 const projectKeys = {
   list: () => ['all-projects'] as const,
@@ -25,4 +26,10 @@ export function useProjectsQuery<TData = ProjectsData>({
     enabled,
     ...options,
   })
+}
+
+export function isProjectPaused(
+  project: ReadonlyRecursive<ProjectsData[number]> | null
+): boolean | undefined {
+  return !project ? undefined : project.status === 'INACTIVE'
 }

--- a/apps/docs/types/utils.ts
+++ b/apps/docs/types/utils.ts
@@ -1,0 +1,3 @@
+export type ReadonlyRecursive<T> = {
+  readonly [P in keyof T]: ReadonlyRecursive<T[P]>
+}


### PR DESCRIPTION
Add option to ProjectConfigVariables to fetch the Supavisor session mode connection string, for setting up MCP server

![image](https://github.com/user-attachments/assets/99058084-2f1b-454c-b0db-c780a63e104c)

## Testing

There's no way to sign in from a docs preview site, so sign in via a studio preview site, then copy and paste your Auth Token from local storage.