### PR TITLE
Cache results in assistant panel

### DIFF
--- a/apps/studio/components/layouts/AppLayout/AssistantButton.tsx
+++ b/apps/studio/components/layouts/AppLayout/AssistantButton.tsx
@@ -1,8 +1,10 @@
 import { useAiAssistantStateSnapshot } from 'state/ai-assistant-state'
+import { useAppStateSnapshot } from 'state/app-state'
 import { AiIconAnimation, Button } from 'ui'
 
 const AssistantButton = () => {
   const snap = useAiAssistantStateSnapshot()
+  const { setEditorPanel } = useAppStateSnapshot()
 
   return (
     <Button
@@ -12,6 +14,7 @@ const AssistantButton = () => {
       className="h-full w-full rounded-none"
       onClick={() => {
         snap.toggleAssistant()
+        setEditorPanel({ open: false })
       }}
     >
       <AiIconAnimation allowHoverEffect size={20} />

--- a/apps/studio/components/layouts/AppLayout/InlineEditorButton.tsx
+++ b/apps/studio/components/layouts/AppLayout/InlineEditorButton.tsx
@@ -1,8 +1,10 @@
+import { SqlEditor } from 'icons'
+import { useAiAssistantStateSnapshot } from 'state/ai-assistant-state'
 import { useAppStateSnapshot } from 'state/app-state'
 import { Button } from 'ui'
-import { SqlEditor } from 'icons'
 
 const InlineEditorButton = () => {
+  const { closeAssistant } = useAiAssistantStateSnapshot()
   const { setEditorPanel, editorPanel } = useAppStateSnapshot()
 
   return (
@@ -12,6 +14,7 @@ const InlineEditorButton = () => {
       id="editor-trigger"
       className="h-full w-full rounded-none text-foreground-light"
       onClick={() => {
+        closeAssistant()
         setEditorPanel({ open: !editorPanel.open })
       }}
     >

--- a/apps/studio/components/layouts/ProjectLayout/ProjectLayout.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/ProjectLayout.tsx
@@ -237,10 +237,11 @@ const ProjectLayout = forwardRef<HTMLDivElement, PropsWithChildren<ProjectLayout
                         'w-screen h-[100dvh] md:h-auto md:w-auto'
                       )}
                     >
-                      {aiSnap.open && (
+                      {aiSnap.open ? (
                         <AIAssistant className="w-full h-[100dvh] md:h-full max-h-[100dvh]" />
-                      )}
-                      {editorPanel.open && <EditorPanel />}
+                      ) : editorPanel.open ? (
+                        <EditorPanel />
+                      ) : null}
                     </ResizablePanel>
                   </>
                 )}

--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
@@ -144,6 +144,9 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
     }
   }, [])
 
+  // TODO(refactor): This useChat hook should be moved down into each chat session.
+  // That way we won't have to disable switching chats while the chat is loading,
+  // and don't run the risk of messages getting mixed up between chats.
   const {
     messages: chatMessages,
     isLoading: isChatLoading,

--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
@@ -191,7 +191,6 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
       resultId?: string
       results: any[]
     }) => {
-      console.log('Update message', { id: messageId, resultId, results })
       snap.updateMessage({ id: messageId, resultId, results })
     },
     [snap]

--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
@@ -48,14 +48,24 @@ import { Message } from './Message'
 import { useAutoScroll } from './hooks'
 
 const MemoizedMessage = memo(
-  ({ message, isLoading }: { message: MessageType; isLoading: boolean }) => {
+  ({
+    message,
+    isLoading,
+    onResults,
+  }: {
+    message: MessageType
+    isLoading: boolean
+    onResults: ({ title, results }: { title?: string; results: any[] }) => void
+  }) => {
     return (
       <Message
         key={message.id}
+        id={message.id}
         role={message.role}
         content={message.content}
         readOnly={message.role === 'user'}
         isLoading={isLoading}
+        onResults={onResults}
       />
     )
   }
@@ -168,6 +178,7 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
             key={message.id}
             message={message}
             isLoading={isChatLoading && message.id === chatMessages[chatMessages.length - 1].id}
+            onResults={(props) => snap.updateMessage({ id: message.id, ...props })}
           />
         )
       }),

--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
@@ -55,7 +55,15 @@ const MemoizedMessage = memo(
   }: {
     message: MessageType
     isLoading: boolean
-    onResults: ({ resultId, results }: { resultId?: string; results: any[] }) => void
+    onResults: ({
+      messageId,
+      resultId,
+      results,
+    }: {
+      messageId: string
+      resultId?: string
+      results: any[]
+    }) => void
   }) => {
     return (
       <Message
@@ -183,6 +191,7 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
       resultId?: string
       results: any[]
     }) => {
+      console.log('Update message', { id: messageId, resultId, results })
       snap.updateMessage({ id: messageId, resultId, results })
     },
     [snap]
@@ -196,7 +205,7 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
             key={message.id}
             message={message}
             isLoading={isChatLoading && message.id === chatMessages[chatMessages.length - 1].id}
-            onResults={(props) => updateMessage({ messageId: message.id, ...props })}
+            onResults={updateMessage}
           />
         )
       }),

--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
@@ -55,7 +55,7 @@ const MemoizedMessage = memo(
   }: {
     message: MessageType
     isLoading: boolean
-    onResults: ({ title, results }: { title?: string; results: any[] }) => void
+    onResults: ({ resultId, results }: { resultId?: string; results: any[] }) => void
   }) => {
     return (
       <Message
@@ -173,6 +173,21 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
   const canUpdateOrganization = useCheckPermissions(PermissionAction.UPDATE, 'organizations')
   const { mutate: updateOrganization, isLoading: isUpdating } = useOrganizationUpdateMutation()
 
+  const updateMessage = useCallback(
+    ({
+      messageId,
+      resultId,
+      results,
+    }: {
+      messageId: string
+      resultId?: string
+      results: any[]
+    }) => {
+      snap.updateMessage({ id: messageId, resultId, results })
+    },
+    [snap]
+  )
+
   const renderedMessages = useMemo(
     () =>
       chatMessages.map((message) => {
@@ -181,7 +196,7 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
             key={message.id}
             message={message}
             isLoading={isChatLoading && message.id === chatMessages[chatMessages.length - 1].id}
-            onResults={(props) => snap.updateMessage({ id: message.id, ...props })}
+            onResults={(props) => updateMessage({ messageId: message.id, ...props })}
           />
         )
       }),

--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
@@ -305,7 +305,7 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
                   <TooltipContent side="bottom">Current chat: {currentChat}</TooltipContent>
                 </Tooltip>
                 <div className="flex items-center gap-x-2">
-                  <AIAssistantChatSelector />
+                  <AIAssistantChatSelector disabled={isChatLoading} />
                   <ButtonTooltip
                     type="default"
                     size="tiny"

--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistant.types.ts
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistant.types.ts
@@ -2,6 +2,7 @@ export type SupportedAssistantEntities = 'rls-policies' | 'functions'
 export type SupportedAssistantQuickPromptTypes = 'suggest' | 'examples' | 'ask'
 
 export interface AssistantSnippetProps {
+  id?: string
   title?: string
   isChart?: string
   runQuery?: string

--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistantChatSelector.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistantChatSelector.tsx
@@ -32,7 +32,6 @@ export const AIAssistantChatSelector = ({ className }: AIAssistantChatSelectorPr
   const [editingChatName, setEditingChatName] = useState('')
 
   const chats = Object.entries(snap.chats)
-  console.log(snap.chats)
 
   const handleSelectChat = (id: string) => {
     snap.selectChat(id)
@@ -110,7 +109,7 @@ export const AIAssistantChatSelector = ({ className }: AIAssistantChatSelectorPr
                     value={id}
                     onSelect={() => handleSelectChat(id)}
                     className="flex items-center justify-between gap-2 py-1 w-full overflow-hidden group"
-                    keywords={[chat.name ?? '']}
+                    keywords={!!chat.name ? [chat.name] : undefined}
                   >
                     <div className="flex items-center w-full flex-1 min-w-0">
                       {editingChatId === id ? (

--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistantChatSelector.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistantChatSelector.tsx
@@ -102,6 +102,7 @@ export const AIAssistantChatSelector = ({ className }: AIAssistantChatSelectorPr
             <CommandEmpty_Shadcn_>No chats found.</CommandEmpty_Shadcn_>
             <CommandGroup_Shadcn_>
               <ScrollArea className={chats.length > 4 ? 'h-40' : ''}>
+                {/* @ts-ignore */}
                 {chats.map(([id, chat]) => (
                   <CommandItem_Shadcn_
                     key={id}

--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistantChatSelector.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistantChatSelector.tsx
@@ -22,9 +22,13 @@ import { ButtonTooltip } from '../ButtonTooltip'
 
 interface AIAssistantChatSelectorProps {
   className?: string
+  disabled?: boolean
 }
 
-export const AIAssistantChatSelector = ({ className }: AIAssistantChatSelectorProps) => {
+export const AIAssistantChatSelector = ({
+  className,
+  disabled = false,
+}: AIAssistantChatSelectorProps) => {
   const snap = useAiAssistantStateSnapshot()
 
   const [chatSelectorOpen, setChatSelectorOpen] = useState(false)
@@ -110,6 +114,7 @@ export const AIAssistantChatSelector = ({ className }: AIAssistantChatSelectorPr
                     onSelect={() => handleSelectChat(id)}
                     className="flex items-center justify-between gap-2 py-1 w-full overflow-hidden group"
                     keywords={!!chat.name ? [chat.name] : undefined}
+                    disabled={disabled}
                   >
                     <div className="flex items-center w-full flex-1 min-w-0">
                       {editingChatId === id ? (
@@ -201,6 +206,7 @@ export const AIAssistantChatSelector = ({ className }: AIAssistantChatSelectorPr
                   snap.newChat()
                   setChatSelectorOpen(false)
                 }}
+                disabled={disabled}
               >
                 <Plus size={14} strokeWidth={1.5} />
                 <span>New chat</span>

--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistantChatSelector.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistantChatSelector.tsx
@@ -32,6 +32,7 @@ export const AIAssistantChatSelector = ({ className }: AIAssistantChatSelectorPr
   const [editingChatName, setEditingChatName] = useState('')
 
   const chats = Object.entries(snap.chats)
+  console.log(snap.chats)
 
   const handleSelectChat = (id: string) => {
     snap.selectChat(id)
@@ -109,7 +110,7 @@ export const AIAssistantChatSelector = ({ className }: AIAssistantChatSelectorPr
                     value={id}
                     onSelect={() => handleSelectChat(id)}
                     className="flex items-center justify-between gap-2 py-1 w-full overflow-hidden group"
-                    keywords={[chat.name]}
+                    keywords={[chat.name ?? '']}
                   >
                     <div className="flex items-center w-full flex-1 min-w-0">
                       {editingChatId === id ? (

--- a/apps/studio/components/ui/AIAssistantPanel/Message.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/Message.tsx
@@ -19,19 +19,21 @@ const baseMarkdownComponents: Partial<Components> = {
   h3: Heading3,
   code: InlineCode,
   a: Link,
-  pre: MarkdownPre,
 }
 
 interface MessageProps {
+  id: string
   role: 'function' | 'system' | 'user' | 'assistant' | 'data' | 'tool'
   content?: string
   isLoading: boolean
   readOnly?: boolean
   action?: React.ReactNode
   variant?: 'default' | 'warning'
+  onResults: ({ resultId, results }: { resultId?: string; results: any[] }) => void
 }
 
 export const Message = function Message({
+  id,
   role,
   content,
   isLoading,
@@ -39,10 +41,19 @@ export const Message = function Message({
   children,
   action = null,
   variant = 'default',
+  onResults,
 }: PropsWithChildren<MessageProps>) {
   const isUser = role === 'user'
-  const allMarkdownComponents = useMemo(
-    () => ({ ...markdownComponents, ...baseMarkdownComponents }),
+  const allMarkdownComponents: Partial<Components> = useMemo(
+    () => ({
+      ...markdownComponents,
+      ...baseMarkdownComponents,
+      pre: ({ children }) => (
+        <MarkdownPre id={id} onResults={onResults}>
+          {children}
+        </MarkdownPre>
+      ),
+    }),
     []
   )
 

--- a/apps/studio/components/ui/AIAssistantPanel/Message.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/Message.tsx
@@ -29,7 +29,15 @@ interface MessageProps {
   readOnly?: boolean
   action?: React.ReactNode
   variant?: 'default' | 'warning'
-  onResults: ({ resultId, results }: { resultId?: string; results: any[] }) => void
+  onResults: ({
+    messageId,
+    resultId,
+    results,
+  }: {
+    messageId: string
+    resultId?: string
+    results: any[]
+  }) => void
 }
 
 export const Message = function Message({

--- a/apps/studio/components/ui/AIAssistantPanel/MessageMarkdown.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/MessageMarkdown.tsx
@@ -150,7 +150,15 @@ export const MarkdownPre = ({
 }: {
   children: any
   id: string
-  onResults: ({ resultId, results }: { resultId?: string; results: any[] }) => void
+  onResults: ({
+    messageId,
+    resultId,
+    results,
+  }: {
+    messageId: string
+    resultId?: string
+    results: any[]
+  }) => void
 }) => {
   const router = useRouter()
   const { profile } = useProfile()
@@ -207,7 +215,7 @@ export const MarkdownPre = ({
 
   const onResultsReturned = useCallback(
     (results: any[]) => {
-      onResults({ resultId: snippetProps.id, results })
+      onResults({ messageId: id, resultId: snippetProps.id, results })
     },
     [onResults, snippetProps.id]
   )
@@ -248,7 +256,7 @@ export const MarkdownPre = ({
             runQuery={!results && runQuery}
             results={results}
             onRunQuery={onRunQuery}
-            onResults={(results) => onResultsReturned(results)}
+            onResults={onResultsReturned}
             onUpdateChartConfig={({ chartConfig: config }) => {
               chartConfig.current = { ...chartConfig.current, ...config }
             }}

--- a/apps/studio/components/ui/AIAssistantPanel/MessageMarkdown.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/MessageMarkdown.tsx
@@ -1,5 +1,14 @@
 import { useRouter } from 'next/router'
-import { DragEvent, memo, ReactNode, useContext, useEffect, useMemo, useRef } from 'react'
+import {
+  DragEvent,
+  memo,
+  ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+} from 'react'
 
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { ChartConfig } from 'components/interfaces/SQLEditor/UtilityPanel/ChartConfig'
@@ -196,6 +205,13 @@ export const MarkdownPre = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [snippetProps])
 
+  const onResultsReturned = useCallback(
+    (results: any[]) => {
+      onResults({ resultId: snippetProps.id, results })
+    },
+    [onResults, snippetProps.id]
+  )
+
   const onRunQuery = async (queryType: 'select' | 'mutation') => {
     sendEvent({
       action: 'assistant_suggestion_run_query_clicked',
@@ -232,7 +248,7 @@ export const MarkdownPre = ({
             runQuery={!results && runQuery}
             results={results}
             onRunQuery={onRunQuery}
-            onResults={(results) => onResults({ resultId: snippetProps.id, results })}
+            onResults={(results) => onResultsReturned(results)}
             onUpdateChartConfig={({ chartConfig: config }) => {
               chartConfig.current = { ...chartConfig.current, ...config }
             }}

--- a/apps/studio/pages/api/ai/sql/generate-v3.ts
+++ b/apps/studio/pages/api/ai/sql/generate-v3.ts
@@ -69,9 +69,10 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse) {
         - Always use semicolons
         - Output as markdown
         - Always include code snippets if available
-        - If a code snippet is SQL, the first line of the snippet should always be -- props: {"title": "Query title", "runQuery": "false", "isChart": "true", "xAxis": "columnOrAlias", "yAxis": "columnOrAlias"}
+        - If a code snippet is SQL, the first line of the snippet should always be -- props: {"id": "id", "title": "Query title", "runQuery": "false", "isChart": "true", "xAxis": "columnOrAlias", "yAxis": "columnOrAlias"}
         - Only include one line of comment props per markdown snippet, even if the snippet has multiple queries
         - Only set chart to true if the query makes sense as a chart. xAxis and yAxis need to be columns or aliases returned by the query.
+        - Set the id to a random uuidv4 value
         - Only set runQuery to true if the query has no risk of writing data and is not a debugging request. Set it to false if there are any values that need to be replaced with real data.
         - Explain what the snippet does in a sentence or two before showing it
         - Use vector(384) data type for any embedding/vector related query

--- a/apps/studio/state/ai-assistant-state.tsx
+++ b/apps/studio/state/ai-assistant-state.tsx
@@ -9,10 +9,12 @@ type SuggestionsType = {
   prompts?: string[]
 }
 
+type AssistantMessageType = MessageType & { results?: { [id: string]: any[] } }
+
 type ChatSession = {
   id: string
   name: string
-  messages: readonly MessageType[]
+  messages: readonly AssistantMessageType[]
   createdAt: Date
   updatedAt: Date
 }
@@ -195,6 +197,30 @@ export const createAiAssistantState = (projectRef: string | undefined) => {
       }
     },
 
+    updateMessage: ({
+      id,
+      resultId,
+      results,
+    }: {
+      id: string
+      resultId?: string
+      results: any[]
+    }) => {
+      let chat = state.activeChat
+      if (!chat || !resultId) return
+
+      const existingMessages = chat.messages
+      const updatedMessages = existingMessages.map((msg) => {
+        if (msg.id === id) {
+          console.log(msg)
+          return { ...msg, results: { ...(msg.results ?? {}), [resultId]: results } }
+        } else {
+          return msg
+        }
+      })
+      chat.messages = updatedMessages
+    },
+
     setSqlSnippets: (snippets: string[]) => {
       state.sqlSnippets = snippets
     },
@@ -204,6 +230,15 @@ export const createAiAssistantState = (projectRef: string | undefined) => {
       state.sqlSnippets = undefined
       // Remove suggestions if sqlSnippets were removed
       state.suggestions = undefined
+    },
+
+    getCachedSQLResults: ({ messageId, snippetId }: { messageId: string; snippetId?: string }) => {
+      let chat = state.activeChat
+      if (!chat || !snippetId) return
+
+      const message = chat.messages.find((msg) => msg.id === messageId)
+      const results = (message?.results ?? {})[snippetId]
+      return results
     },
   })
 
@@ -248,15 +283,16 @@ export const AiAssistantStateContextProvider = ({
           open: snap.open,
           activeChatId: snap.activeChatId,
           chats: snap.chats
-            ? Object.entries(snap.chats).reduce((acc, [chatId, chat]) => {
+            ? Object.entries(snap.chats).reduce((prev, next) => {
+                const [chatId, chat] = next
                 return {
-                  ...acc,
+                  ...prev,
                   [chatId]: {
                     ...chat,
                     messages: chat.messages?.slice(-20) || [], // Only keep last 20 messages
                   },
                 }
-              }, {})
+              })
             : {},
         }
 

--- a/apps/studio/state/ai-assistant-state.tsx
+++ b/apps/studio/state/ai-assistant-state.tsx
@@ -212,7 +212,6 @@ export const createAiAssistantState = (projectRef: string | undefined) => {
       const existingMessages = chat.messages
       const updatedMessages = existingMessages.map((msg) => {
         if (msg.id === id) {
-          console.log(msg)
           return { ...msg, results: { ...(msg.results ?? {}), [resultId]: results } }
         } else {
           return msg
@@ -283,16 +282,15 @@ export const AiAssistantStateContextProvider = ({
           open: snap.open,
           activeChatId: snap.activeChatId,
           chats: snap.chats
-            ? Object.entries(snap.chats).reduce((prev, next) => {
-                const [chatId, chat] = next
+            ? Object.entries(snap.chats).reduce((acc, [chatId, chat]) => {
                 return {
-                  ...prev,
+                  ...acc,
                   [chatId]: {
                     ...chat,
                     messages: chat.messages?.slice(-20) || [], // Only keep last 20 messages
                   },
                 }
-              })
+              }, {})
             : {},
         }
 


### PR DESCRIPTION
Changes here are mainly to prevent the Assistant from running SQL queries each time that it's opened as it might unexpectedly consume resources (in particular if the query is resource heavy)

## Changes involved
- SQL queries no longer run when the assistant is re-opened
- Results from SQL queries are cached, so that they persist when the assistant is re-opened (also across browser sessions)
- Unrelated bugfix: Ensure that either the Assistant Panel of the Inline SQL editor panel is opened, never both (was running into a bug whereby the panels were overlapping, so opening the Inline SQL editor while the Assistant was open never showed the Inline SQL editor)

## Things to test
- [ ] Ensure that `SELECT` SQL queries only run once when first loaded, and no longer run when the assistant is re-opened within the same browser session (and their results should be cached)
- [ ] Ensure that `SELECT` SQL queries only run once when first loaded, and no longer run when the assistant is re-opened after a browser refresh (and their results should be cached)
- [ ] Ensure that ^ such queries can be re-ran manually by clicking the run icon, and the results should be updated + cached too
- [ ] Ensure that ^ this behaviour is consistent across chats (since we support multiple chats now)
- [ ] Ensure that Inline Editor panel and AI Assistant panel can be swapped between each other properly (open and close)