### PR TITLE
feat(docs): type hints mobile

### DIFF
--- a/apps/docs/features/ui/CodeBlock/CodeBlock.client.tsx
+++ b/apps/docs/features/ui/CodeBlock/CodeBlock.client.tsx
@@ -1,8 +1,89 @@
 'use client'
 
 import { Check, Copy } from 'lucide-react'
-import { useState } from 'react'
-import { cn } from 'ui'
+import { type MouseEvent, useCallback, useEffect, useState } from 'react'
+import { type ThemedToken } from 'shiki'
+import { type NodeHover } from 'twoslash'
+import { cn, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
+
+export function AnnotatedSpan({
+  token,
+  annotations,
+}: {
+  token: ThemedToken
+  annotations: Array<NodeHover>
+}) {
+  const [open, setOpen] = useState(false)
+
+  const [isTouchDevice, setIsTouchDevice] = useState(false)
+  useEffect(() => {
+    const touchDevice = !window.matchMedia('(pointer: fine)').matches
+    setIsTouchDevice(touchDevice)
+  }, [])
+
+  const handleClick = useCallback(
+    (evt: MouseEvent) => {
+      if (isTouchDevice) {
+        evt.preventDefault()
+        evt.stopPropagation()
+        setOpen((open) => !open)
+      }
+    },
+    [isTouchDevice]
+  )
+  const onOpenChange = useCallback(
+    (open: boolean) => {
+      if (!isTouchDevice || !open) {
+        setOpen(open)
+      }
+    },
+    [isTouchDevice]
+  )
+
+  return (
+    <Tooltip open={open} onOpenChange={onOpenChange}>
+      <TooltipTrigger asChild onClick={handleClick}>
+        <button
+          style={token.htmlStyle}
+          className={cn(
+            isTouchDevice &&
+              'underline underline-offset-4 decoration-dashed [text-decoration-color:rgba(from_currentColor_r_g_b_/_0.5)]'
+          )}
+        >
+          {token.content}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent className="max-w-[min(80vw,400px)] p-0 divide-y">
+        {annotations.map((annotation, idx) => (
+          <Annotation key={idx} annotation={annotation} />
+        ))}
+      </TooltipContent>
+    </Tooltip>
+  )
+}
+
+function Annotation({ annotation }: { annotation: NodeHover }) {
+  const { text, docs, tags } = annotation
+  return (
+    <div className="flex flex-col gap-2">
+      <code className={cn('block bg-200 p-2', (docs || tags) && 'border-b border-default')}>
+        {text}
+      </code>
+      {docs && <p className={cn('p-2', tags && 'border-b border-default')}>{docs}</p>}
+      {tags && (
+        <div className="p-2 flex flex-col">
+          {tags.map((tag, idx) => {
+            return (
+              <span key={idx}>
+                <code>@{tag[0]}</code> {tag[1]}
+              </span>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}
 
 export function CodeCopyButton({ className, content }: { className?: string; content: string }) {
   const [copied, setCopied] = useState(false)

--- a/apps/docs/features/ui/CodeBlock/CodeBlock.tsx
+++ b/apps/docs/features/ui/CodeBlock/CodeBlock.tsx
@@ -1,15 +1,22 @@
 import { type PropsWithChildren } from 'react'
 import { type BundledLanguage, codeToTokens, type ThemedToken } from 'shiki'
 import { createTwoslasher, type ExtraFiles, type NodeHover } from 'twoslash'
-import { cn, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
+import { cn } from 'ui'
 
-import { CodeCopyButton } from './CodeBlock.client'
+import { AnnotatedSpan, CodeCopyButton } from './CodeBlock.client'
 import denoTypes from './types/lib.deno.d.ts.include'
 
 const extraFiles: ExtraFiles = { 'deno.d.ts': denoTypes }
 
 const twoslasher = createTwoslasher({ extraFiles })
-const TWOSLASHABLE_LANGS = ['js', 'ts', 'jsx', 'tsx', 'javascript', 'typescript']
+const TWOSLASHABLE_LANGS: ReadonlyArray<string> = [
+  'js',
+  'ts',
+  'jsx',
+  'tsx',
+  'javascript',
+  'typescript',
+]
 
 export async function CodeBlock({
   className,
@@ -116,50 +123,6 @@ function CodeLine({
         )
       )}
     </span>
-  )
-}
-
-export function AnnotatedSpan({
-  token,
-  annotations,
-}: {
-  token: ThemedToken
-  annotations: Array<NodeHover>
-}) {
-  return (
-    <Tooltip>
-      <TooltipTrigger>
-        <span style={token.htmlStyle}>{token.content}</span>
-      </TooltipTrigger>
-      <TooltipContent className="max-w-[min(80vw,400px)] p-0 divide-y">
-        {annotations.map((annotation, idx) => (
-          <Annotation key={idx} annotation={annotation} />
-        ))}
-      </TooltipContent>
-    </Tooltip>
-  )
-}
-
-function Annotation({ annotation }: { annotation: NodeHover }) {
-  const { text, docs, tags } = annotation
-  return (
-    <div className="flex flex-col gap-2">
-      <code className={cn('block bg-200 p-2', (docs || tags) && 'border-b border-default')}>
-        {text}
-      </code>
-      {docs && <p className={cn('p-2', tags && 'border-b border-default')}>{docs}</p>}
-      {tags && (
-        <div className="p-2 flex flex-col">
-          {tags.map((tag, idx) => {
-            return (
-              <span key={idx}>
-                <code>@{tag[0]}</code> {tag[1]}
-              </span>
-            )
-          })}
-        </div>
-      )}
-    </div>
   )
 }
 


### PR DESCRIPTION
Also enable type hints on mobile.

Desktop behavior is same as before, mobile looks like this:

![image](https://github.com/user-attachments/assets/0edc8137-6203-43ed-bbdd-75f95985f3ab)

Check this page: https://docs-git-feat-type-hints-mobile-supabase.vercel.app/docs/guides/auth/passwords
