### PR TITLE
Show replica tooltip text in modal directly

### DIFF
--- a/apps/studio/components/interfaces/DiskManagement/DiskManagementReviewAndSubmitDialog.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagementReviewAndSubmitDialog.tsx
@@ -382,6 +382,12 @@ export const DiskManagementReviewAndSubmitDialog = ({
           </TableBody>
         </Table>
 
+        {numReplicas > 0 && (
+          <div className="border-t px-4 py-2 text-sm text-foreground-lighter">
+            {replicaTooltipText}
+          </div>
+        )}
+
         <DialogFooter>
           <Button block size="large" type="default" onClick={() => setIsDialogOpen(false)}>
             Cancel


### PR DESCRIPTION
As per PR title - this text was hidden in a tooltip when hovering over the price change badge but it's really hidden and not intuitive, reckon this is much clearer

![image](https://github.com/user-attachments/assets/00d9c22f-a7cb-4543-a491-8b0356259272)
