### PR TITLE
Update column-level-security.mdx

### DIFF
--- a/apps/docs/content/guides/database/postgres/column-level-security.mdx
+++ b/apps/docs/content/guides/database/postgres/column-level-security.mdx
@@ -7,9 +7,15 @@ description: 'Secure your data using Postgres Column Level Security.'
 PostgreSQL's [Row Level Security (RLS)](https://www.postgresql.org/docs/current/ddl-rowsecurity.html) gives you granular control over who can access rows of data. However, it doesn't give you control over which columns they can access within rows. Sometimes you want to restrict access to specific columns in your database. Column Level Privileges allows you to do just that.
 
 <Admonition type="caution">
-  This is an advanced feature. We do not recommend using column-level privileges for most users.
-  Instead, we recommend using RLS policies in combination with a dedicated table for handling user
-  roles.
+
+This is an advanced feature. We do not recommend using column-level privileges for most users. Instead, we recommend using RLS policies in combination with a dedicated table for handling user roles.
+
+</Admonition>
+
+<Admonition type="caution">
+
+Restricted roles cannot use the wildcard operator (`*`) on the affected table. Instead of using `SELECT * FROM <restricted_table>;` or its API equivalent, you must specify the column names explicitly.
+
 </Admonition>
 
 ## Policies at the row level


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

Doesn't warn users that CLS disables the option to use the wildcard operator (*)

## What is the new behavior?

Informs users that * will be disabled for a role once CLS is used

## Additional context

Add any other context or screenshots.
