### PR TITLE
update treeview spacing

### DIFF
--- a/apps/design-system/registry/default/example/tree-view-demo.tsx
+++ b/apps/design-system/registry/default/example/tree-view-demo.tsx
@@ -26,7 +26,7 @@ export default function TreeViewDemo() {
     <TreeView
       data={flattenTree(data)}
       aria-label="directory tree"
-      className="w-[420px]"
+      className="w-[420px] border bg py-2"
       nodeRenderer={({ element, isBranch, isExpanded, getNodeProps, level, isSelected }) => (
         <TreeViewItem
           isExpanded={isExpanded}

--- a/apps/design-system/registry/default/example/tree-view-directories.tsx
+++ b/apps/design-system/registry/default/example/tree-view-directories.tsx
@@ -92,7 +92,7 @@ export default function TreeViewDemo() {
     <TreeView
       data={flattenTree(data)}
       aria-label="directory tree"
-      className="w-[420px]"
+      className="w-[420px] border bg py-2"
       nodeRenderer={({ element, isBranch, isExpanded, getNodeProps, level, isSelected }) => (
         <TreeViewItem
           isExpanded={isExpanded}

--- a/apps/design-system/registry/default/example/tree-view-directories.tsx
+++ b/apps/design-system/registry/default/example/tree-view-directories.tsx
@@ -5,34 +5,85 @@ export default function TreeViewDemo() {
     name: '',
     children: [
       {
-        name: 'Current batch',
-        children: [{ name: 'index.js' }, { name: 'styles.css' }],
+        name: 'Active Projects',
+        children: [{ name: 'main.js' }, { name: 'styles.css' }],
       },
       {
-        name: 'Older queries',
+        name: 'Archived Queries',
         children: [
           {
-            name: 'all countries',
+            name: 'Historical Data',
+            children: [
+              {
+                name: 'Country Statistics',
+              },
+              {
+                name: 'Add New Countries',
+              },
+              {
+                name: 'Regional Insights',
+              },
+              {
+                name: 'Customer-Specific Regions',
+              },
+            ],
           },
           {
-            name: 'add new countries',
+            name: 'Previous Queries',
+            children: [
+              {
+                name: 'Country Statistics',
+                children: [
+                  {
+                    name: 'Country Overview',
+                  },
+                  {
+                    name: 'Add New Countries',
+                  },
+                  {
+                    name: 'Regional Insights',
+                  },
+                  {
+                    name: 'Customer-Specific Regions',
+                  },
+                ],
+              },
+              {
+                name: 'Country Overview',
+              },
+              {
+                name: 'Add New Countries',
+              },
+              {
+                name: 'Regional Insights',
+              },
+              {
+                name: 'Customer-Specific Regions',
+              },
+            ],
           },
           {
-            name: 'regions',
+            name: 'Country Overview',
           },
           {
-            name: 'regions by customer',
+            name: 'Add New Countries',
+          },
+          {
+            name: 'Regional Insights',
+          },
+          {
+            name: 'Customer-Specific Regions',
           },
         ],
       },
       {
-        name: 'query all users',
+        name: 'User Query Logs',
       },
       {
-        name: 'users in last day',
+        name: 'Recent User Activity',
       },
       {
-        name: 'new users over time',
+        name: 'User Growth Trends',
       },
     ],
   }
@@ -48,7 +99,6 @@ export default function TreeViewDemo() {
           isBranch={isBranch}
           isSelected={isSelected}
           level={level}
-          xPadding={16}
           name={element.name}
           {...getNodeProps()}
         />

--- a/apps/design-system/registry/default/example/tree-view-edit.tsx
+++ b/apps/design-system/registry/default/example/tree-view-edit.tsx
@@ -80,6 +80,7 @@ export default function TreeViewDemo() {
   return (
     <TreeView
       data={flattenTree(data)}
+      className="w-[420px] border bg py-2"
       aria-label="directory tree"
       nodeRenderer={({ element, isBranch, isExpanded, getNodeProps, level, isSelected }) => {
         return (

--- a/apps/design-system/registry/default/example/tree-view-multi-select.tsx
+++ b/apps/design-system/registry/default/example/tree-view-multi-select.tsx
@@ -84,6 +84,7 @@ export default function TreeViewDemo() {
       togglableSelect
       clickAction="EXCLUSIVE_SELECT"
       multiSelect
+      className="w-[420px] border bg py-2"
       nodeRenderer={({ element, isBranch, isExpanded, getNodeProps, level, isSelected }) => {
         return (
           <ContextMenu_Shadcn_ modal={false}>

--- a/apps/ui-library/components/block-item-code.tsx
+++ b/apps/ui-library/components/block-item-code.tsx
@@ -91,8 +91,8 @@ export function BlockItemCode({ files }: BlockItemCodeProps) {
               isSelected={isSelected}
               level={level}
               icon={<File strokeWidth={1.5} size={16} className="shrink-0" />}
-              xPadding={16}
               name={element.name}
+              className="gap-1.5"
             />
           )}
         />

--- a/packages/ui/src/components/TreeView/TreeView.tsx
+++ b/packages/ui/src/components/TreeView/TreeView.tsx
@@ -9,6 +9,9 @@ import { Input } from '../shadcn/ui/input'
 
 const TreeView = TreeViewPrimitive
 
+const CHEVRON_ICON_SIZE = 14
+const ENTITY_ICON_SIZE = 16
+
 export type TreeViewItemVariantProps = VariantProps<typeof TreeViewItemVariant>
 export const TreeViewItemVariant = cva(
   // [Joshen Temp]: aria-selected:text-foreground not working as aria-selected property not rendered in DOM,
@@ -50,7 +53,7 @@ const TreeViewItem = forwardRef<
     /** Specifies if the item is selected */
     isSelected?: boolean
     /** The horizontal padding of the item */
-    xPadding: number
+    xPadding?: number
     /** name of entity */
     name: string
     /** icon of entity */
@@ -68,7 +71,7 @@ const TreeViewItem = forwardRef<
   (
     {
       level = 1,
-      levelPadding = 56,
+      levelPadding = 38,
       isExpanded = false,
       isOpened = false,
       isBranch = false,
@@ -161,32 +164,24 @@ const TreeViewItem = forwardRef<
         aria-expanded={!isEditing && isExpanded}
         onDoubleClick={onDoubleClick}
         {...props}
-        className={cn(props.className, TreeViewItemVariant({ isSelected, isOpened, isPreview }))}
+        className={cn(TreeViewItemVariant({ isSelected, isOpened, isPreview }), props.className)}
         style={{
-          paddingLeft:
-            level === 1 && !isBranch
-              ? xPadding
-              : level
-                ? levelPadding * (level - 1) + xPadding + (!isBranch ? 0 : 0)
-                : levelPadding,
+          paddingLeft: xPadding + ((level - 1) * levelPadding) / 2,
           ...props.style,
         }}
         data-treeview-is-branch={isBranch}
         data-treeview-level={level}
       >
-        {level && level > 1 && (
+        {Array.from({ length: level - 1 }).map((_, i) => (
           <div
+            key={i}
             style={{
-              left: (levelPadding / 2 + 4) * (level - 1) + xPadding,
+              left: xPadding + (i * levelPadding) / 2 + CHEVRON_ICON_SIZE / 2,
             }}
-            className={
-              'absolute h-full w-px group-data-[treeview-is-branch=false]:bg-border-strong'
-            }
+            className={'absolute h-full w-px bg-border-strong'}
           ></div>
-        )}
-        {/* [Joshen] Temp fix as the white border on the left was not showing up via group-aria-selected */}
+        ))}
         {isSelected && <div className="absolute left-0 h-full w-0.5 bg-foreground" />}
-        {/* <div className="absolute left-0 h-full w-0.5 group-aria-selected:bg-foreground" /> */}
         {isBranch ? (
           <>
             {isLoading ? (
@@ -200,7 +195,8 @@ const TreeViewItem = forwardRef<
                   'transition-transform duration-200',
                   'group-aria-expanded:rotate-90'
                 )}
-                size={14}
+                size={CHEVRON_ICON_SIZE}
+                strokeWidth={1.5}
               />
             )}
             <TreeViewFolderIcon
@@ -211,7 +207,7 @@ const TreeViewItem = forwardRef<
                 'group-aria-expanded:text-foreground-light'
               )}
               isOpen={isExpanded}
-              size={16}
+              size={ENTITY_ICON_SIZE}
               strokeWidth={1.5}
             />
           </>
@@ -225,7 +221,7 @@ const TreeViewItem = forwardRef<
                 'w-5 h-5 shrink-0',
                 '-ml-0.5'
               )}
-              size={16}
+              size={ENTITY_ICON_SIZE}
               strokeWidth={1.5}
             />
           )


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES/NO

## What kind of change does this PR introduce?

- updated spacing of tree view items
- also updated preview style background (see screenshot)

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context
<img width="656" alt="Screenshot 2025-03-31 at 16 13 06" src="https://github.com/user-attachments/assets/2c6987af-540c-4e75-baac-2647d3c910a9" />

Add any other context or screenshots.
