### PR TITLE
Realtime Chat UI Fixes

### DIFF
--- a/apps/ui-library/registry/default/blocks/realtime-chat/components/chat-message.tsx
+++ b/apps/ui-library/registry/default/blocks/realtime-chat/components/chat-message.tsx
@@ -11,12 +11,16 @@ export const ChatMessageItem = ({ message, isOwnMessage, showHeader }: ChatMessa
   return (
     <div className={`flex mt-2 ${isOwnMessage ? 'justify-end' : 'justify-start'}`}>
       <div
-        className={cn('max-w-[70%] w-fit flex flex-col gap-1', {
+        className={cn('max-w-[75%] w-fit flex flex-col gap-1', {
           'items-end': isOwnMessage,
         })}
       >
         {showHeader && (
-          <div className="flex items-center gap-2 text-xs">
+          <div
+            className={cn('flex items-center gap-2 text-xs px-3', {
+              'justify-end flex-row-reverse': isOwnMessage,
+            })}
+          >
             <span className={'font-medium'}>{message.user.name}</span>
             <span className="text-foreground/50 text-xs">
               {new Date(message.createdAt).toLocaleTimeString('en-US', {
@@ -29,8 +33,8 @@ export const ChatMessageItem = ({ message, isOwnMessage, showHeader }: ChatMessa
         )}
         <div
           className={cn(
-            'py-1 px-2 rounded-xl text-sm w-fit',
-            isOwnMessage ? 'bg-accent-foreground text-background' : 'bg-secondary text-foreground'
+            'py-2 px-3 rounded-xl text-sm w-fit',
+            isOwnMessage ? 'bg-primary text-primary-foreground' : 'bg-muted text-foreground'
           )}
         >
           {message.content}

--- a/apps/ui-library/registry/default/examples/realtime-chat-demo.tsx
+++ b/apps/ui-library/registry/default/examples/realtime-chat-demo.tsx
@@ -59,7 +59,12 @@ const RealtimeChatDemo = () => {
     <div className="flex flex-col w-full h-[600px] p-4">
       <div className="p-4">
         <Label className="text-xs font-medium mb-1 ml-1 text-foreground-light">Username</Label>
-        <Input className="text-sm" value={username} onChange={(e) => setUsername(e.target.value)} />
+        <Input
+          autoComplete="off"
+          className="text-sm"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+        />
       </div>
       <div className="flex-1 border rounded-lg overflow-hidden">
         <RealtimeChat roomName="chat-demo" username={username} messages={messages} />


### PR DESCRIPTION
- fixes alignment for name and message content
- uses bg-muted and primary like the official shadcn chat example
- reverses order of name and time when its own message 
- bit more padding
- autoComplete off in username input so password manager wont bother

---  

![CleanShot 2025-03-31 at 11 49 08@2x](https://github.com/user-attachments/assets/618ee1fb-1da4-452e-8b49-9cdf182bd7d1)
