### PR TITLE
docs(python): add httpx options

### DIFF
--- a/apps/docs/spec/supabase_py_v2.yml
+++ b/apps/docs/spec/supabase_py_v2.yml
@@ -73,6 +73,15 @@ functions:
             isOptional: true
             type: AuthFlowType
             description: flow type to use for authentication.
+          - name: httpx_options
+            isOptional: true
+            type: HttpxOptions
+            description: Options passed to the httpx instance.
+            subContent:
+              - name: verify
+                isOptional: true
+                type: boolean
+                description: Either `True` to use an SSL context with the default CA bundle, `False` to disable verification.
 
     examples:
       - id: create-client


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Add httpx options to the ClientOptions for the Python library in order to set the `verify` option.

## What is the current behavior?

Developer cannot set the `verify` option

## What is the new behavior?

Developer can now set `verify` option

## Additional context

https://github.com/supabase/supabase-py/pull/1091