### PR TITLE
change to untitled default name

### DIFF
--- a/apps/studio/state/ai-assistant-state.tsx
+++ b/apps/studio/state/ai-assistant-state.tsx
@@ -117,7 +117,7 @@ export const createAiAssistantState = (projectRef: string | undefined) => {
       const chatId = crypto.randomUUID()
       const newChat: ChatSession = {
         id: chatId,
-        name: options?.name ?? 'New Chat',
+        name: options?.name ?? 'Untitled',
         messages: [],
         createdAt: new Date(),
         updatedAt: new Date(),


### PR DESCRIPTION
Changes default chat name to "Untitled" as a short term improvement over "New chat" which suggests an action. Long term chat's should name themselves.