### PR TITLE
ref: Use update-status endpoint for jwt secret queries

### DIFF
--- a/apps/studio/data/config/jwt-secret-updating-status-query.ts
+++ b/apps/studio/data/config/jwt-secret-updating-status-query.ts
@@ -22,14 +22,14 @@ export async function getJwtSecretUpdatingStatus(
     throw new Error('projectRef is required')
   }
 
-  const { data, error } = await get('/platform/props/project/{ref}/jwt-secret-update-status', {
+  const { data, error } = await get('/platform/projects/{ref}/config/secrets/update-status', {
     params: { path: { ref: projectRef } },
     signal,
   })
 
   if (error) handleError(error)
 
-  const meta = data.jwtSecretUpdateStatus
+  const meta = data.update_status
 
   return meta
     ? ({

--- a/packages/api-types/types/platform.d.ts
+++ b/packages/api-types/types/platform.d.ts
@@ -2447,6 +2447,23 @@ export interface paths {
     patch: operations['SecretsConfigController_updateConfig']
     trace?: never
   }
+  '/platform/projects/{ref}/config/secrets/update-status': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** Gets the last JWT secret update status */
+    get: operations['SecretsConfigController_getJwtSecretUpdateStatus']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/platform/projects/{ref}/config/storage': {
     parameters: {
       query?: never
@@ -4894,6 +4911,17 @@ export interface components {
       favorites: number
       private: number
       shared: number
+    }
+    GetJwtSecretUpdateStatus: {
+      update_status: {
+        change_tracking_id: string
+        /** @enum {number} */
+        error?: 0 | 1 | 2 | 3 | 4 | 5
+        /** @enum {number} */
+        progress: 0 | 1 | 2 | 3 | 4 | 5
+        /** @enum {number} */
+        status: 0 | 1 | 2
+      } | null
     }
     GetLeakedServiceKeyLintResponseDto: {
       lints: {
@@ -14665,6 +14693,35 @@ export interface operations {
         content?: never
       }
       /** @description Failed to update project's secrets config */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  SecretsConfigController_getJwtSecretUpdateStatus: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /** @description Project ref */
+        ref: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['GetJwtSecretUpdateStatus']
+        }
+      }
+      /** @description Failed to retrieve JWT secret update status */
       500: {
         headers: {
           [name: string]: unknown


### PR DESCRIPTION
> [!WARNING]
> Do not merge until https://github.com/supabase/infrastructure/pull/22261 is live in prod.

A follow-up to my API update https://github.com/supabase/infrastructure/pull/22261 which aims to deprecate `/props` endpoints (which are "deprecated" for almost 3y.