### PR TITLE
Adding David A. Ventimiglia to humans.txt

### DIFF
--- a/apps/docs/public/humans.txt
+++ b/apps/docs/public/humans.txt
@@ -26,6 +26,7 @@ Chris Gwilliams
 Chris Stockton
 Craig Cannon
 Dave Wilson
+David A. Ventimiglia
 Deji I
 Div Arora
 Divit D


### PR DESCRIPTION
per the onboarding doc:  https://www.notion.so/supabase/David-V-Onboarding-Checklist-1c25004b775f806ca946f3b099a20190?pvs=4#1c25004b775f810aa2a1f5618d16d673

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

It updates the docs (adding new hire "David A. Ventimiglia" to `humans.txt`).

## What is the current behavior?

"David A. Ventimiglia" is not in `humans.txt`.

## What is the new behavior?

"David A. Ventimiglia" will be in `humans.txt`.

## Additional context

N/A
