### PR TITLE
chore: add via cli origin tracking

### DIFF
--- a/apps/studio/components/interfaces/Functions/FunctionsEmptyState.tsx
+++ b/apps/studio/components/interfaces/Functions/FunctionsEmptyState.tsx
@@ -121,6 +121,7 @@ export const FunctionsEmptyState = () => {
                   onClick={() =>
                     sendEvent({
                       action: 'edge_function_via_cli_button_clicked',
+                      properties: { origin: 'no_functions_block' },
                       groups: { project: ref ?? 'Unknown', organization: org?.slug ?? 'Unknown' },
                     })
                   }

--- a/apps/studio/pages/project/[ref]/functions/index.tsx
+++ b/apps/studio/pages/project/[ref]/functions/index.tsx
@@ -81,7 +81,17 @@ const EdgeFunctionsPage: NextPageWithLayout = () => {
         )}
         <Dialog>
           <DialogTrigger asChild>
-            <DropdownMenuItem className="gap-4" onSelect={(e) => e.preventDefault()}>
+            <DropdownMenuItem
+              className="gap-4"
+              onSelect={(e) => {
+                e.preventDefault()
+                sendEvent({
+                  action: 'edge_function_via_cli_button_clicked',
+                  properties: { origin: 'secondary_action' },
+                  groups: { project: ref ?? 'Unknown', organization: org?.slug ?? 'Unknown' },
+                })
+              }}
+            >
               <Terminal className="shrink-0" size={16} strokeWidth={1.5} />
               <div>
                 <span className="text-foreground">Via CLI</span>

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -1166,6 +1166,14 @@ export interface EdgeFunctionTemplateClickedEvent {
  */
 export interface EdgeFunctionViaCliButtonClickedEvent {
   action: 'edge_function_via_cli_button_clicked'
+  properties: {
+    /**
+     * Click on Via CLI can either happen:
+     *   1. on the main block when there are no functions
+     *   2. in the secondary action section of the page
+     */
+    origin: 'no_functions_block' | 'secondary_action'
+  }
   groups: {
     project: string
     organization: string


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

- track via_cli origin property 
- tested in preview that it shows on posthog