### PR TITLE
Add Eleftheria Trivyzaki to humans.txt

### DIFF
--- a/apps/docs/public/humans.txt
+++ b/apps/docs/public/humans.txt
@@ -30,6 +30,7 @@ Deji I
 Div Arora
 Divit D
 Egor Romanov
+Eleftheria Trivyzaki
 Etienne Stalmans
 Fabrizio Fenoglio
 Francesco Sansalvadore


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Updates `humans.txt`

## What is the current behavior?

Eleftheria Trivyzaki is not in humans.txt

## What is the new behavior?

Eleftheria Trivyzaki will be in humans.txt

## Additional context

n/a