### PR TITLE
Update timeouts.mdx | modify comment about realtime

### DIFF
--- a/apps/docs/content/guides/database/postgres/timeouts.mdx
+++ b/apps/docs/content/guides/database/postgres/timeouts.mdx
@@ -162,11 +162,10 @@ Each API server uses a designated user for connecting to the database:
 
 | Role                         | API/Tool                                                                  |
 | ---------------------------- | ------------------------------------------------------------------------- |
-| `supabase_admin`             | Used by Supabase to configure projects and for monitoring                 |
+| `supabase_admin`             | Used by Realtime and for project configuration                            |
 | `authenticator`              | PostgREST                                                                 |
 | `supabase_auth_admin`        | Auth                                                                      |
 | `supabase_storage_admin`     | Storage                                                                   |
-| `supabase_realtime_admin`    | Realtime                                                                  |
 | `supabase_replication_admin` | Synchronizes Read Replicas                                                |
 | `postgres`                   | Supabase Dashboard and External Tools (e.g., Prisma, SQLAlchemy, PSQL...) |
 | Custom roles                 | External Tools (e.g., Prisma, SQLAlchemy, PSQL...)                        |


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES/NO

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

States supabase_realtime_admin  is used by realtime

## What is the new behavior?

Clarifies that supabase_admin manages realtime. 

## Additional context

Realtime needs to configure replication slots, so it uses the superuser supabase_admin. Not sure why supabase_realtime_admin exists. Probably residual from prior configs