### PR TITLE
Table editor filter convert empty string value to null if column is not text based type

### DIFF
--- a/apps/studio/components/grid/components/grid/Grid.tsx
+++ b/apps/studio/components/grid/components/grid/Grid.tsx
@@ -155,7 +155,14 @@ export const Grid = memo(
                   {isLoading && <TableGridInnerLoadingState />}
                   {isError && (
                     <div className="p-2 col-span-full">
-                      <AlertError error={error} subject="Failed to retrieve rows from table" />
+                      <AlertError error={error} subject="Failed to retrieve rows from table">
+                        {filters.length > 0 && (
+                          <p>
+                            Verify that the filter values are correct, as the error may stem from an
+                            incorrectly applied filter
+                          </p>
+                        )}
+                      </AlertError>
                     </div>
                   )}
                   {isSuccess && (

--- a/apps/studio/components/ui/AlertError.tsx
+++ b/apps/studio/components/ui/AlertError.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link'
+import { PropsWithChildren } from 'react'
 
-import type { ResponseError } from 'types'
 import {
   AlertDescription_Shadcn_,
   AlertTitle_Shadcn_,
@@ -25,7 +25,8 @@ const AlertError = ({
   error,
   className,
   showIcon = true,
-}: AlertErrorProps) => {
+  children,
+}: PropsWithChildren<AlertErrorProps>) => {
   const subjectString = subject?.replace(/ /g, '%20')
   let href = `/support/new?category=dashboard_bug`
 
@@ -49,11 +50,10 @@ const AlertError = ({
             support.
           </p>
         </div>
-        <div>
-          <Button asChild type="warning">
-            <Link href={href}>Contact support</Link>
-          </Button>
-        </div>
+        {children}
+        <Button asChild type="warning" className="w-min">
+          <Link href={href}>Contact support</Link>
+        </Button>
       </AlertDescription_Shadcn_>
     </Alert_Shadcn_>
   )

--- a/packages/pg-meta/src/query/table-row-query.ts
+++ b/packages/pg-meta/src/query/table-row-query.ts
@@ -1,10 +1,10 @@
 import { ident } from '../pg-format'
-import { PGTable } from '../pg-meta-tables'
-import { Query } from './Query'
-import { Sort, Filter } from './types'
-import { PGView } from '../pg-meta-views'
 import { PGForeignTable } from '../pg-meta-foreign-tables'
 import { PGMaterializedView } from '../pg-meta-materialized-views'
+import { PGTable } from '../pg-meta-tables'
+import { PGView } from '../pg-meta-views'
+import { Query } from './Query'
+import { Filter, Sort } from './types'
 
 // Constants
 export const MAX_CHARACTERS = 10 * 1024 // 10KB
@@ -166,7 +166,13 @@ export const getTableRowsSql = ({
   let queryChains = query.from(table.name, table.schema).select(selectClause)
 
   filters.forEach((x) => {
-    queryChains = queryChains.filter(x.column, x.operator, x.value)
+    const col = table.columns?.find((y) => y.name === x.column)
+    const isStringTypeColumn = !!col ? TEXT_TYPES.includes(col.format) : true
+    queryChains = queryChains.filter(
+      x.column,
+      x.operator,
+      !isStringTypeColumn && x.value === '' ? null : x.value
+    )
   })
 
   // If sorts is empty and table row count is within threshold, use the primary key as the default sort


### PR DESCRIPTION
As per PR title, addresses a case whereby applying an empty filter results in a type mismatch for a column that's a numerical type for e.g
![image](https://github.com/user-attachments/assets/9709cc21-39b2-4cf5-a7bc-a9686e488127)

so e.g in the case of an `id` `int8` column, the filter will be `id = null` instead of `id == ''`
![image](https://github.com/user-attachments/assets/9c3d7e21-eefd-4505-a452-a5f34a0e9a8f)

Also updated error state in table editor to add a hint if a filter was applied
![image](https://github.com/user-attachments/assets/52d75869-d178-4a0f-923f-2d3b0ba9c7e1)
