### PR TITLE
Fix single date selection in organization audit logs

### DIFF
--- a/apps/studio/components/interfaces/Account/AuditLogs.tsx
+++ b/apps/studio/components/interfaces/Account/AuditLogs.tsx
@@ -15,6 +15,7 @@ import { useProfileAuditLogsQuery } from 'data/profile/profile-audit-logs-query'
 import { useProjectsQuery } from 'data/projects/projects-query'
 import { Alert, Button } from 'ui'
 import { TimestampInfo } from 'ui-patterns'
+import { formatSelectedDateRange } from '../Organization/AuditLogs/AuditLogs.utils'
 
 const AuditLogs = () => {
   const currentTime = dayjs().utc().set('millisecond', 0)
@@ -70,6 +71,9 @@ const AuditLogs = () => {
       }
     })
 
+  const minDate = dayjs().subtract(retentionPeriod, 'days')
+  const maxDate = dayjs()
+
   return (
     <>
       <div className="space-y-4 flex flex-col pb-8">
@@ -91,47 +95,13 @@ const AuditLogs = () => {
               triggerButtonTitle=""
               from={dateRange.from}
               to={dateRange.to}
-              minDate={dayjs().subtract(retentionPeriod, 'days').toDate()}
-              maxDate={dayjs().toDate()}
+              minDate={minDate.toDate()}
+              maxDate={maxDate.toDate()}
               onChange={(value) => {
+                console.log('onChange', value)
                 if (value.from !== null && value.to !== null) {
-                  const current = dayjs()
-                  const from = dayjs(value.from)
-                    .hour(current.hour())
-                    .minute(current.minute())
-                    .second(current.second())
-                  const to = dayjs(value.to)
-                    .hour(current.hour())
-                    .minute(current.minute())
-                    .second(current.second())
-
-                  if (from.date() === to.date()) {
-                    // [Joshen] If a single date is selected, we either set the "from" to start from 00:00
-                    // or "to" to end at 23:59 depending on which date was selected
-                    if (from.date() === current.date()) {
-                      setDateRange({
-                        from: from
-                          .set('hour', 0)
-                          .set('minute', 0)
-                          .set('second', 0)
-                          .utc()
-                          .toISOString(),
-                        to: to.utc().toISOString(),
-                      })
-                    } else {
-                      setDateRange({
-                        from: from.utc().toISOString(),
-                        to: to
-                          .set('hour', 23)
-                          .set('minute', 59)
-                          .set('second', 59)
-                          .utc()
-                          .toISOString(),
-                      })
-                    }
-                  } else {
-                    setDateRange({ from: from.utc().toISOString(), to: to.utc().toISOString() })
-                  }
+                  const { from, to } = formatSelectedDateRange(value)
+                  setDateRange({ from, to })
                 }
               }}
               renderFooter={() => {

--- a/apps/studio/components/interfaces/Account/AuditLogs.tsx
+++ b/apps/studio/components/interfaces/Account/AuditLogs.tsx
@@ -98,7 +98,6 @@ const AuditLogs = () => {
               minDate={minDate.toDate()}
               maxDate={maxDate.toDate()}
               onChange={(value) => {
-                console.log('onChange', value)
                 if (value.from !== null && value.to !== null) {
                   const { from, to } = formatSelectedDateRange(value)
                   setDateRange({ from, to })

--- a/apps/studio/components/interfaces/Organization/AuditLogs/AuditLogs.utils.ts
+++ b/apps/studio/components/interfaces/Organization/AuditLogs/AuditLogs.utils.ts
@@ -1,0 +1,34 @@
+import { DatePickerToFrom } from 'components/interfaces/Settings/Logs/Logs.types'
+import dayjs from 'dayjs'
+
+// [Joshen] Mainly to handle if a single date is selected - currently just for Audit Logs as
+// i'm on the fence if this logic should be within the DatePicker component itself
+// e.g for Logs.DatePicker which uses this component, the component itself has its own time selection UI
+// JFYI currentDate is just a parameter so that I can run tests for this
+
+export const formatSelectedDateRange = (value: DatePickerToFrom) => {
+  const current = dayjs()
+  const from = dayjs(value.from)
+    .hour(current.hour())
+    .minute(current.minute())
+    .second(current.second())
+  const to = dayjs(value.to).hour(current.hour()).minute(current.minute()).second(current.second())
+
+  if (from.date() === to.date()) {
+    // [Joshen] If a single date is selected, we either set the "from" to start from 00:00
+    // or "to" to end at 23:59 depending on which date was selected
+    if (from.date() === current.date()) {
+      return {
+        from: from.set('hour', 0).set('minute', 0).set('second', 0).utc().toISOString(),
+        to: to.utc().toISOString(),
+      }
+    } else {
+      return {
+        from: from.utc().toISOString(),
+        to: to.set('hour', 23).set('minute', 59).set('second', 59).utc().toISOString(),
+      }
+    }
+  } else {
+    return { from: from.utc().toISOString(), to: to.utc().toISOString() }
+  }
+}

--- a/apps/studio/components/interfaces/Settings/Logs/Logs.DatePickers.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.DatePickers.tsx
@@ -1,7 +1,8 @@
-import { DatePicker } from 'components/ui/DatePicker'
 import dayjs from 'dayjs'
-import { useEffect, useState } from 'react'
+import { Clock } from 'lucide-react'
+import { ComponentProps, PropsWithChildren, useEffect, useState } from 'react'
 
+import { DatePicker } from 'components/ui/DatePicker'
 import {
   Alert,
   Button,
@@ -13,15 +14,14 @@ import {
 } from 'ui'
 import { LOGS_LARGE_DATE_RANGE_DAYS_THRESHOLD, getDefaultHelper } from './Logs.constants'
 import type { DatetimeHelper } from './Logs.types'
-import { Clock } from 'lucide-react'
 
 interface Props {
   to: string
   from: string
-  onChange: React.ComponentProps<typeof DatePicker>['onChange']
+  onChange: ComponentProps<typeof DatePicker>['onChange']
   helpers: DatetimeHelper[]
 }
-const DatePickers: React.FC<Props> = ({ to, from, onChange, helpers }) => {
+const DatePickers = ({ to, from, onChange, helpers }: PropsWithChildren<Props>) => {
   const defaultHelper = getDefaultHelper(helpers)
   const [helperValue, setHelperValue] = useState<string>(to || from ? '' : defaultHelper.text)
 

--- a/apps/studio/data/organizations/organization-audit-logs-query.ts
+++ b/apps/studio/data/organizations/organization-audit-logs-query.ts
@@ -1,5 +1,4 @@
 import { useQuery, UseQueryOptions } from '@tanstack/react-query'
-import dayjs from 'dayjs'
 
 import { get, handleError } from 'data/fetchers'
 import type { ResponseError } from 'types'
@@ -68,11 +67,12 @@ export const useOrganizationAuditLogsQuery = <TData = OrganizationAuditLogsData>
   }: UseQueryOptions<OrganizationAuditLogsData, OrganizationAuditLogsError, TData> = {}
 ) => {
   const { slug, iso_timestamp_start, iso_timestamp_end } = vars
-  const date_start = dayjs(iso_timestamp_start).utc().format('YYYY-MM-DD')
-  const date_end = dayjs(iso_timestamp_end).utc().format('YYYY-MM-DD')
 
   return useQuery<OrganizationAuditLogsData, OrganizationAuditLogsError, TData>(
-    organizationKeys.auditLogs(slug, { date_start, date_end }),
+    organizationKeys.auditLogs(slug, {
+      date_start: iso_timestamp_start,
+      date_end: iso_timestamp_end,
+    }),
     ({ signal }) => getOrganizationAuditLogs(vars, signal),
     {
       enabled: enabled && typeof slug !== 'undefined',


### PR DESCRIPTION
Mainly just shifting the fix that I did in Account AuditLogs from this [PR](https://github.com/supabase/supabase/pull/34421) into a utils that is also shared with Organization AuditLogs

## To test
- [ ] Can filter single date on Account Audit Logs
- [ ] Can filter single date on Organization Audit Logs