### PR TITLE
handle string error

### DIFF
--- a/apps/studio/data/edge-functions/edge-function-body-query.ts
+++ b/apps/studio/data/edge-functions/edge-function-body-query.ts
@@ -41,8 +41,14 @@ export async function getEdgeFunctionBody(
     })
 
     if (!parseResponse.ok) {
-      const error = await parseResponse.json()
-      handleError(error)
+      const { error } = await parseResponse.json()
+      handleError(
+        typeof error === 'object'
+          ? error
+          : typeof error === 'string'
+            ? { message: error }
+            : { message: 'Unknown error' }
+      )
     }
 
     const { files } = await parseResponse.json()


### PR DESCRIPTION
New edge function body query uses handleError which doesn't "support" strings and instead logs via Sentry. This adds some extra checking and parses into format handleError supports. 