### PR TITLE
QueryBlock whitelist now() and left() functions

### DIFF
--- a/apps/studio/components/ui/AIAssistantPanel/AiAssistant.constants.ts
+++ b/apps/studio/components/ui/AIAssistantPanel/AiAssistant.constants.ts
@@ -31,4 +31,6 @@ export const SAFE_FUNCTIONS = [
   'date_trunc(',
   'string_agg(',
   'in (',
+  'now(',
+  'left(',
 ]


### PR DESCRIPTION
This is for SQL Blocks in Custom Reports

For context - our SQL blocks will only automatically run in custom reports if we decide that the SQL queries are "readonly", and the way we decide that is currently restrictive by default, in particular the functions that we allow in the SQL query (denoted by the `SAFE_FUNCTIONS` variable - these are mostly postgres native functions). We'll slowly expand this list, but opting to be more careful than flexible atm.

This PR just adds 2 functions to the whitelist `now()` and `left()`