### PR TITLE
Remove useKeyboardShortcuts in Results.tsx

### DIFF
--- a/apps/studio/components/grid/SupabaseGrid.utils.ts
+++ b/apps/studio/components/grid/SupabaseGrid.utils.ts
@@ -1,14 +1,16 @@
 import AwesomeDebouncePromise from 'awesome-debounce-promise'
 import { compact } from 'lodash'
 import { useEffect } from 'react'
-import { CalculatedColumn } from 'react-data-grid'
+import { CalculatedColumn, CellKeyboardEvent } from 'react-data-grid'
 
 import type { Filter, SavedState } from 'components/grid/types'
 import { Entity, isTableLike } from 'data/table-editor/table-editor-types'
 import { useUrlState } from 'hooks/ui/useUrlState'
+import { copyToClipboard } from 'ui'
 import { FilterOperatorOptions } from './components/header/filter/Filter.constants'
 import { STORAGE_KEY_PREFIX } from './constants'
 import type { Sort, SupaColumn, SupaTable } from './types'
+import { formatClipboardValue } from './utils/common'
 
 export function formatSortURLParams(tableName: string, sort?: string[]): Sort[] {
   if (Array.isArray(sort)) {
@@ -209,4 +211,16 @@ export function useLoadTableEditorStateFromLocalStorageIntoUrl({
       setParams((prevParams) => ({ ...prevParams, ...params }))
     }
   }, [projectRef, table])
+}
+
+export const handleCopyCell = (
+  { column, row }: { column: CalculatedColumn<any, unknown>; row: any },
+  event: CellKeyboardEvent
+) => {
+  if (event.code === 'KeyC' && (event.metaKey || event.ctrlKey)) {
+    const colKey = column.key
+    const cellValue = row[colKey] ?? ''
+    const value = formatClipboardValue(cellValue)
+    copyToClipboard(value)
+  }
 }

--- a/apps/studio/components/grid/components/common/Shortcuts.tsx
+++ b/apps/studio/components/grid/components/common/Shortcuts.tsx
@@ -1,13 +1,12 @@
-import { useMemo } from 'react'
+import { RefObject, useMemo } from 'react'
 import type { DataGridHandle } from 'react-data-grid'
 
 import { SupaRow } from 'components/grid/types'
 import { useTableEditorTableStateSnapshot } from 'state/table-editor-table'
-import { copyToClipboard, formatClipboardValue } from '../../utils/common'
 import { useKeyboardShortcuts } from './Hooks'
 
 type ShortcutsProps = {
-  gridRef: React.RefObject<DataGridHandle>
+  gridRef: RefObject<DataGridHandle>
   rows: SupaRow[]
 }
 
@@ -66,18 +65,6 @@ export function Shortcuts({ gridRef, rows }: ShortcutsProps) {
           idx: snap.gridColumns.length - 2, // -2 because we don't want to select the end extra col
           rowIdx: snap.selectedCellPosition?.rowIdx ?? 0,
         })
-      },
-      [`${metaKey}+c`]: (event) => {
-        event.stopPropagation()
-        if (snap.selectedCellPosition) {
-          const { idx, rowIdx } = snap.selectedCellPosition
-          if (idx > 0) {
-            const colKey = snap.gridColumns[idx].key
-            const cellValue = rows[rowIdx]?.[colKey] ?? ''
-            const value = formatClipboardValue(cellValue)
-            copyToClipboard(value)
-          }
-        }
       },
     },
     ['INPUT', 'TEXTAREA', 'SELECT']

--- a/apps/studio/components/grid/components/grid/Grid.tsx
+++ b/apps/studio/components/grid/components/grid/Grid.tsx
@@ -14,7 +14,6 @@ import { useTableEditorStateSnapshot } from 'state/table-editor'
 import { useTableEditorTableStateSnapshot } from 'state/table-editor-table'
 import { Button, cn } from 'ui'
 import type { Filter, GridProps, SupaRow } from '../../types'
-import { useKeyboardShortcuts } from '../common/Hooks'
 import { useOnRowsChange } from './Grid.utils'
 import RowRenderer from './RowRenderer'
 
@@ -62,28 +61,6 @@ export const Grid = memo(
       }
 
       const selectedCellRef = useRef<{ rowIdx: number; row: any; column: any } | null>(null)
-
-      function copyCellValue() {
-        const selectedCellValue =
-          selectedCellRef.current?.row?.[selectedCellRef.current?.column?.key]
-        const text = formatClipboardValue(selectedCellValue)
-        if (!text) return
-        copyToClipboard(text)
-      }
-
-      useKeyboardShortcuts(
-        {
-          'Command+c': (event: KeyboardEvent) => {
-            event.stopPropagation()
-            copyCellValue()
-          },
-          'Control+c': (event: KeyboardEvent) => {
-            event.stopPropagation()
-            copyCellValue()
-          },
-        },
-        ['INPUT', 'TEXTAREA']
-      )
 
       function onSelectedCellChange(args: { rowIdx: number; row: any; column: any }) {
         selectedCellRef.current = args
@@ -224,6 +201,14 @@ export const Grid = memo(
             onSelectedCellChange={onSelectedCellChange}
             onSelectedRowsChange={onSelectedRowsChange}
             onCellDoubleClick={(props) => onRowDoubleClick(props.row, props.column)}
+            onCellKeyDown={({ column, row }, event) => {
+              if (event.code === 'KeyC' && event.metaKey) {
+                const colKey = column.key
+                const cellValue = row[colKey] ?? ''
+                const value = formatClipboardValue(cellValue)
+                copyToClipboard(value)
+              }
+            }}
           />
         </div>
       )

--- a/apps/studio/components/grid/components/grid/Grid.tsx
+++ b/apps/studio/components/grid/components/grid/Grid.tsx
@@ -1,7 +1,7 @@
 import { forwardRef, memo, useRef } from 'react'
 import DataGrid, { CalculatedColumn, DataGridHandle } from 'react-data-grid'
 
-import { formatClipboardValue } from 'components/grid/utils/common'
+import { handleCopyCell } from 'components/grid/SupabaseGrid.utils'
 import { TableGridInnerLoadingState } from 'components/interfaces/TableGridEditor/LoadingState'
 import { formatForeignKeys } from 'components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.utils'
 import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
@@ -9,7 +9,6 @@ import AlertError from 'components/ui/AlertError'
 import { useForeignKeyConstraintsQuery } from 'data/database/foreign-key-constraints-query'
 import { useSendEventMutation } from 'data/telemetry/send-event-mutation'
 import { useSelectedOrganization } from 'hooks/misc/useSelectedOrganization'
-import { copyToClipboard } from 'lib/helpers'
 import { useTableEditorStateSnapshot } from 'state/table-editor'
 import { useTableEditorTableStateSnapshot } from 'state/table-editor-table'
 import { Button, cn } from 'ui'
@@ -201,14 +200,7 @@ export const Grid = memo(
             onSelectedCellChange={onSelectedCellChange}
             onSelectedRowsChange={onSelectedRowsChange}
             onCellDoubleClick={(props) => onRowDoubleClick(props.row, props.column)}
-            onCellKeyDown={({ column, row }, event) => {
-              if (event.code === 'KeyC' && event.metaKey) {
-                const colKey = column.key
-                const cellValue = row[colKey] ?? ''
-                const value = formatClipboardValue(cellValue)
-                copyToClipboard(value)
-              }
-            }}
+            onCellKeyDown={handleCopyCell}
           />
         </div>
       )

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/Results.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/Results.tsx
@@ -2,6 +2,7 @@ import { Clipboard, Expand } from 'lucide-react'
 import { useState } from 'react'
 import DataGrid, { CalculatedColumn } from 'react-data-grid'
 
+import { handleCopyCell } from 'components/grid/SupabaseGrid.utils'
 import { copyToClipboard } from 'lib/helpers'
 import {
   cn,
@@ -121,14 +122,7 @@ const Results = ({ rows }: { rows: readonly any[] }) => {
             className="h-full flex-grow border-t-0"
             rowClass={() => '[&>.rdg-cell]:items-center'}
             onSelectedCellChange={setCellPosition}
-            onCellKeyDown={({ column, row }, event) => {
-              if (event.code === 'KeyC' && event.metaKey) {
-                const colKey = column.key
-                const cellValue = row[colKey] ?? ''
-                const value = formatClipboardValue(cellValue)
-                copyToClipboard(value)
-              }
-            }}
+            onCellKeyDown={handleCopyCell}
           />
           <CellDetailPanel
             column={cellPosition?.column.name ?? ''}

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/Results.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/Results.tsx
@@ -2,7 +2,6 @@ import { Clipboard, Expand } from 'lucide-react'
 import { useState } from 'react'
 import DataGrid, { CalculatedColumn } from 'react-data-grid'
 
-import { useKeyboardShortcuts } from 'hooks/deprecated'
 import { copyToClipboard } from 'lib/helpers'
 import {
   cn,
@@ -24,30 +23,6 @@ function formatClipboardValue(value: any) {
 const Results = ({ rows }: { rows: readonly any[] }) => {
   const [expandCell, setExpandCell] = useState(false)
   const [cellPosition, setCellPosition] = useState<{ column: any; row: any; rowIdx: number }>()
-
-  const onCopyCell = () => {
-    if (cellPosition) {
-      const { rowIdx, column } = cellPosition
-      const colKey = column.key
-      const cellValue = rows[rowIdx]?.[colKey] ?? ''
-      const value = formatClipboardValue(cellValue)
-      copyToClipboard(value)
-    }
-  }
-
-  useKeyboardShortcuts(
-    {
-      'Command+c': (event: any) => {
-        event.stopPropagation()
-        onCopyCell()
-      },
-      'Control+c': (event: any) => {
-        event.stopPropagation()
-        onCopyCell()
-      },
-    },
-    ['INPUT', 'TEXTAREA'] as any
-  )
 
   const formatter = (column: any, row: any) => {
     const cellValue = row[column]
@@ -146,6 +121,14 @@ const Results = ({ rows }: { rows: readonly any[] }) => {
             className="h-full flex-grow border-t-0"
             rowClass={() => '[&>.rdg-cell]:items-center'}
             onSelectedCellChange={setCellPosition}
+            onCellKeyDown={({ column, row }, event) => {
+              if (event.code === 'KeyC' && event.metaKey) {
+                const colKey = column.key
+                const cellValue = row[colKey] ?? ''
+                const value = formatClipboardValue(cellValue)
+                copyToClipboard(value)
+              }
+            }}
           />
           <CellDetailPanel
             column={cellPosition?.column.name ?? ''}

--- a/apps/studio/components/ui/AIAssistantPanel/Message.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/Message.tsx
@@ -46,7 +46,6 @@ export const Message = function Message({
   content,
   isLoading,
   readOnly,
-  children,
   action = null,
   variant = 'default',
   onResults,
@@ -76,8 +75,6 @@ export const Message = function Message({
           variant === 'warning' && 'bg-warning-200'
         )}
       >
-        {children}
-
         {variant === 'warning' && <WarningIcon className="w-6 h-6" />}
 
         {action}

--- a/apps/studio/hooks/deprecated.ts
+++ b/apps/studio/hooks/deprecated.ts
@@ -1,84 +1,5 @@
-import { useRef, useEffect, useState } from 'react'
-import { includes } from 'lodash'
 import TooltipListener from 'components/to-be-cleaned/TooltipListener'
-
-/**
- * Hook for listening on key events.
- *
- * @param {Object|Map} keyMap       Key names mapped to event handlers. If a key name exists, its
- *                                  default behavior will be suppressed.
- * @param {Array} whitelistNodes    If target element is in the whitelist nodes array, will not
- *                                  trigger shortcut event
- * @param {Array} whitelistClasses  If target class is in the whitelist classes array, will not
- *                                  trigger shortcut event
- */
-function useKeyboardShortcuts(
-  keyMap: any,
-  whitelistNodes: string[] = [],
-  whitelistClasses: string[] = []
-) {
-  const [lastKeydown, setLastKeydown] = useState()
-
-  const handleKeydown = (event: any) => {
-    if (
-      !keyMap ||
-      includes(whitelistNodes, event.target.nodeName) ||
-      includes(whitelistClasses, event.target.className)
-    ) {
-      return
-    }
-
-    let keyPressed = getKeyPresses(event)
-
-    if (keyMap[keyPressed]) {
-      /**
-       * combined keymap will trigger action on KeyDown event
-       * while single keymap  will trigger action on KeyUp event
-       */
-      if (keyPressed.includes('+')) {
-        event.preventDefault()
-        keyMap[keyPressed](event)
-        // @ts-ignore
-        setLastKeydown(null)
-      } else {
-        setLastKeydown(event.key)
-        event.preventDefault()
-      }
-    }
-  }
-
-  const handleKeyup = (event: any) => {
-    if (!keyMap) return
-
-    if (keyMap[event.key] && lastKeydown === event.key) {
-      event.preventDefault()
-      keyMap[event.key](event)
-      // @ts-ignore
-      setLastKeydown(null)
-    }
-  }
-
-  function getKeyPresses(event: any) {
-    return event.metaKey && event.shiftKey
-      ? `Command+Shift+${event.key}`
-      : event.metaKey
-        ? `Command+${event.key}`
-        : event.shiftKey && event.key === 'Enter'
-          ? `Shift+${event.key}`
-          : event.ctrlKey && event.key
-            ? `Control+${event.key}`
-            : event.key
-  }
-
-  useEffect(() => {
-    document.body.addEventListener('keydown', handleKeydown)
-    document.body.addEventListener('keyup', handleKeyup)
-    return () => {
-      document.body.removeEventListener('keydown', handleKeydown)
-      document.body.removeEventListener('keyup', handleKeyup)
-    }
-  })
-}
+import { useEffect, useRef } from 'react'
 
 function usePrevious(value: any) {
   const ref = useRef()
@@ -88,4 +9,4 @@ function usePrevious(value: any) {
   return ref.current
 }
 
-export { useKeyboardShortcuts, TooltipListener, usePrevious }
+export { TooltipListener, usePrevious }


### PR DESCRIPTION
## Context on the bug
`Results.tsx` was using the `useKeyboardShortcuts` to handle `Cmd + C` to copy cell contents from the `DataGrid`, but this hook overrides the keyboard shortcut globally across the page. Because `copyCellValue` specifically checks for `cellPosition`, this resulted in hitting `Cmd + C` on anywhere else but the `DataGrid` to run into `event.stopPropagation()` and the default browser copying text behaviour is ignored.

## Changes involved
- Use `useCellKeydown` event handler from `DataGrid` thats scoped to just the DataGrid
- Remove `Cmd + C` overrides in Table Editor as well, use `useCellKeydown` instead
- Remove `useKeyboardShortcuts` hook from `deprecated.ts` -> there's a dupe in `grid/components/common/Hooks.tsx`

## To reproduce
- Open the Assistant panel and ask it to generate some query that returns some results (e.g "How many colors are there in the colors table")
- Once the Assistant replies with the SQL query with results, try copying any text on the page that you're on in the dashboard via `Cmd + C`. Notice that you won't be able to paste it subsequently
- This bug applies also to the SQL Editor when you run a select query and the results get returned (since they use the same `Results` component
- This bug applies also to the Table Editor when rendering a table, you won't be able to Cmd + C any text in the page