### PR TITLE
Remove safe parse checking in NewOrgForm updateForm preventing completely removing organization name in input field

### DIFF
--- a/apps/studio/components/interfaces/Organization/NewOrg/NewOrgForm.tsx
+++ b/apps/studio/components/interfaces/Organization/NewOrg/NewOrgForm.tsx
@@ -4,6 +4,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import { Edit2, ExternalLink, HelpCircle } from 'lucide-react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
+import { parseAsString, useQueryStates } from 'nuqs'
 import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
 import { z } from 'zod'
@@ -18,7 +19,6 @@ import {
 import { BASE_PATH, PRICING_TIER_LABELS_ORG } from 'lib/constants'
 import { getURL } from 'lib/helpers'
 import { useProfile } from 'lib/profile'
-import { parseAsBoolean, parseAsString, parseAsStringLiteral, useQueryStates } from 'nuqs'
 import { Button, Input, Listbox, Toggle } from 'ui'
 
 const ORG_KIND_TYPES = {
@@ -64,6 +64,7 @@ type FormState = z.infer<typeof formSchema>
 
 /**
  * No org selected yet, create a new one
+ * [Joshen] Need to refactor to use Form_Shadcn here
  */
 const NewOrgForm = ({ onPaymentMethodReset }: NewOrgFormProps) => {
   const router = useRouter()
@@ -87,14 +88,7 @@ const NewOrgForm = ({ onPaymentMethodReset }: NewOrgFormProps) => {
   })
 
   const updateForm = (key: keyof FormState, value: unknown) => {
-    try {
-      const result = formSchema.shape[key].safeParse(value)
-      if (result.success) {
-        setFormState((prev) => ({ ...prev, [key]: result.data }))
-      }
-    } catch {
-      // Invalid value, ignore
-    }
+    setFormState((prev) => ({ ...prev, [key]: value }))
   }
 
   useEffect(() => {


### PR DESCRIPTION
As per PR title - the safe parse checking was preventing clearing the input field of the organization name, but we still have a validation either way when hitting the submit button if the name input field is empty.

Ideal refactor here is use a proper form handler but will do for now