### PR TITLE
fix: stop needlessly saving snippets

### DIFF
--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorNav.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorNav.tsx
@@ -561,7 +561,7 @@ export const SQLEditorNav = ({ sort = 'inserted_at' }: SQLEditorNavProps) => {
         <InnerSideMenuCollapsibleContent className="group-data-[state=open]:pt-2">
           {isLoadingSharedSqlSnippets ? (
             <SQLEditorLoadingSnippets />
-          ) : numProjectSnippets === 0 ? (
+          ) : sharedSnippets.length === 0 ? (
             <InnerSideBarEmptyPanel
               className="mx-2"
               title="No shared queries"
@@ -638,7 +638,7 @@ export const SQLEditorNav = ({ sort = 'inserted_at' }: SQLEditorNavProps) => {
         <InnerSideMenuCollapsibleContent className="group-data-[state=open]:pt-2">
           {isLoadingFavoriteSqlSnippets ? (
             <SQLEditorLoadingSnippets />
-          ) : numFavoriteSnippets === 0 ? (
+          ) : favoriteSnippets.length === 0 ? (
             <InnerSideBarEmptyPanel
               title="No favorite queries"
               className="mx-2 px-3"
@@ -722,7 +722,7 @@ export const SQLEditorNav = ({ sort = 'inserted_at' }: SQLEditorNavProps) => {
         <InnerSideMenuCollapsibleContent className="group-data-[state=open]:pt-2">
           {isLoading ? (
             <EditorMenuListSkeleton />
-          ) : folders.length === 0 && numPrivateSnippets === 0 ? (
+          ) : folders.length === 0 && privateSnippets.length === 0 ? (
             <EmptyPrivateQueriesPanel />
           ) : (
             <TreeView

--- a/apps/studio/state/sql-editor-v2.ts
+++ b/apps/studio/state/sql-editor-v2.ts
@@ -108,7 +108,6 @@ export const sqlEditorState = proxy({
     if (storedSnippet) {
       if (!storedSnippet.snippet.content) {
         storedSnippet.snippet.content = snippet.content
-        sqlEditorState.needsSaving.set(storedSnippet.snippet.id, true)
       }
     } else {
       sqlEditorState.addSnippet({ projectRef: projectRef, snippet })


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When a user switches snippets, we immediately send a PUT request to update it.

## What is the new behavior?

Nothing has been updated, so nothing needs to be saved.