### PR TITLE
fix(docs): favicons

### DIFF
--- a/packages/common/MetaFavicons/app-router.ts
+++ b/packages/common/MetaFavicons/app-router.ts
@@ -10,42 +10,42 @@ const genFaviconData = (basePath: string): Metadata['icons'] => ({
   other: [
     {
       rel: 'apple-touch-icon-precomposed',
-      url: `${basePath}/favicon/apple-touch-icon-57x57.png`,
+      url: `${basePath}/favicon/apple-icon-57x57.png`,
       sizes: '57x57',
     },
     {
       rel: 'apple-touch-icon-precomposed',
-      url: `${basePath}/favicon/apple-touch-icon-60x60.png`,
+      url: `${basePath}/favicon/apple-icon-60x60.png`,
       sizes: '60x60',
     },
     {
       rel: 'apple-touch-icon-precomposed',
-      url: `${basePath}/favicon/apple-touch-icon-72x72.png`,
+      url: `${basePath}/favicon/apple-icon-72x72.png`,
       sizes: '72x72',
     },
     {
       rel: 'apple-touch-icon-precomposed',
-      url: `${basePath}/favicon/apple-touch-icon-76x76.png`,
+      url: `${basePath}/favicon/apple-icon-76x76.png`,
       sizes: '76x76',
     },
     {
       rel: 'apple-touch-icon-precomposed',
-      url: `${basePath}/favicon/apple-touch-icon-114x114.png`,
+      url: `${basePath}/favicon/apple-icon-114x114.png`,
       sizes: '114x114',
     },
     {
       rel: 'apple-touch-icon-precomposed',
-      url: `${basePath}/favicon/apple-touch-icon-120x120.png`,
+      url: `${basePath}/favicon/apple-icon-120x120.png`,
       sizes: '120x120',
     },
     {
       rel: 'apple-touch-icon-precomposed',
-      url: `${basePath}/favicon/apple-touch-icon-144x144.png`,
+      url: `${basePath}/favicon/apple-icon-144x144.png`,
       sizes: '144x144',
     },
     {
       rel: 'apple-touch-icon-precomposed',
-      url: `${basePath}/favicon/apple-touch-icon-152x152.png`,
+      url: `${basePath}/favicon/apple-icon-152x152.png`,
       sizes: '152x152',
     },
     {


### PR DESCRIPTION
The incorrect favicon URLs are being used for Apple touch icons. Corrected now.