### PR TITLE
chore: project transfer preview supports messages of level INFO

### DIFF
--- a/apps/studio/components/interfaces/Settings/General/TransferProjectPanel/TransferProjectButton.tsx
+++ b/apps/studio/components/interfaces/Settings/General/TransferProjectPanel/TransferProjectButton.tsx
@@ -11,7 +11,7 @@ import { useProjectTransferPreviewQuery } from 'data/projects/project-transfer-p
 import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { useSelectedProject } from 'hooks/misc/useSelectedProject'
 import { useFlag } from 'hooks/ui/useFlag'
-import { Button, InfoIcon, Listbox, Loading, Modal } from 'ui'
+import { Button, InfoIcon, Listbox, Loading, Modal, WarningIcon } from 'ui'
 import { Admonition } from 'ui-patterns'
 
 const TransferProjectButton = () => {
@@ -206,15 +206,6 @@ const TransferProjectButton = () => {
           <Loading active={selectedOrg !== undefined && transferPreviewIsLoading}>
             <Modal.Content>
               <div className="space-y-2">
-                {transferPreviewData && transferPreviewData.warnings.length > 0 && (
-                  <Admonition type="warning" title="Warnings for project transfer" className="mt-3">
-                    <div className="space-y-1">
-                      {transferPreviewData.warnings.map((warning) => (
-                        <p key={warning.key}>{warning.message}</p>
-                      ))}
-                    </div>
-                  </Admonition>
-                )}
                 {transferPreviewData && transferPreviewData.errors.length > 0 && (
                   <Admonition type="danger" title="Project cannot be transferred">
                     <div className="space-y-1">
@@ -246,6 +237,26 @@ const TransferProjectButton = () => {
                     )}
                   </Admonition>
                 )}
+                {transferPreviewData &&
+                  (transferPreviewData.warnings.length > 0 ||
+                    transferPreviewData.info.length > 0) && (
+                    <Admonition type={'caution'} showIcon={false} className="mt-3">
+                      <div className="space-y-1">
+                        {transferPreviewData.warnings.map((warning) => (
+                          <div key={warning.key} className="flex items-center gap-2">
+                            <WarningIcon className="flex-shrink-0 mt-0.25" />
+                            <p className="mb-0.5">{warning.message}</p>
+                          </div>
+                        ))}
+                        {transferPreviewData.info.map((info) => (
+                          <div key={info.key} className="flex items-center gap-2">
+                            <InfoIcon className="flex-shrink-0 mt-0.25" />
+                            <p className="mb-0.5">{info.message}</p>
+                          </div>
+                        ))}
+                      </div>
+                    </Admonition>
+                  )}
                 {transferPreviewError && !transferError && (
                   <Admonition
                     type="danger"


### PR DESCRIPTION
Besides errors and warnings also messages of level INFO are supported. Introduced for info that project on NANO doesn't automatically get upgraded to MICRO. A warning wouldn't be appropriate here.

<img width="806" alt="warning+info+error" src="https://github.com/user-attachments/assets/8bb44dc6-abbe-4838-ad58-83680644e2a7" />
<img width="808" alt="warning+info" src="https://github.com/user-attachments/assets/e2368072-cadf-4a0c-88ae-4d723294fbfd" />

