### PR TITLE
docs: add VSCode MCP config to the MCP page

### DIFF
--- a/apps/design-system/public/llms.txt
+++ b/apps/design-system/public/llms.txt
@@ -1,5 +1,5 @@
 # Supabase Design System
-Last updated: 2025-03-05T12:59:50.911Z
+Last updated: 2025-04-05T09:38:35.676Z
 
 ## Overview
 The Design System used in Supabase Studio.
@@ -144,6 +144,8 @@ The Design System used in Supabase Studio.
     - Multiple selection component.
 - [Text Confirm Dialog](https://supabase-design-system.vercel.app/design-system/docs/fragments/text-confirm-dialog)
     - A modal dialog that interrupts the user with important content and expects a response.
+- [Table of Contents (TOC)](https://supabase-design-system.vercel.app/design-system/docs/fragments/toc)
+    - List of page anchors for the current page.
 - [Icons](https://supabase-design-system.vercel.app/design-system/docs/icons)
     - Icons system breakdown. Copy values of Icons.
 - [Introduction](https://supabase-design-system.vercel.app/design-system/docs/index)

--- a/apps/docs/content/guides/getting-started/mcp.mdx
+++ b/apps/docs/content/guides/getting-started/mcp.mdx
@@ -38,6 +38,7 @@ MCP compatible tools can connect to Supabase using the [Supabase MCP server](htt
 1.  Open Cursor and navigate to **Settings/MCP**. You should see a green active status after the server is successfully connected.
 
 ### VSCode
+
 1.  **Update VSCode** to the latest.
 1.  Open VSCode, search MCP from the settings page and **enable MCP**.
 1.  Search chat agent and **enable Agent mode** for copilot.
@@ -47,7 +48,7 @@ MCP compatible tools can connect to Supabase using the [Supabase MCP server](htt
 
 1.  Save the file and start the server. VSCode should automatically reload the configuration.
 
-1. You should the see **a tool icon with the total tools available** in the chat after the server is successfully connected.
+1.  You should the see **a tool icon with the total tools available** in the chat after the server is successfully connected.
 
 ### Windsurf
 

--- a/apps/docs/content/guides/getting-started/mcp.mdx
+++ b/apps/docs/content/guides/getting-started/mcp.mdx
@@ -9,6 +9,7 @@ sidebar_label: 'Model context protocol (MCP)'
 The [Model Context Protocol](https://modelcontextprotocol.io/introduction) (MCP) is a standard for connecting Large Language Models (LLMs) to platforms like Supabase. This guide covers how to connect Supabase to the following AI tools using MCP:
 
 - [Cursor](https://www.cursor.com/)
+- [VSCode](https://code.visualstudio.com/)
 - [Windsurf](https://docs.codeium.com/windsurf) (Codium)
 - [Cline](https://github.com/cline/cline) (VS Code extension)
 - [Claude desktop](https://claude.ai/download)
@@ -35,6 +36,18 @@ MCP compatible tools can connect to Supabase using the [Supabase MCP server](htt
 1.  Save the configuration file.
 
 1.  Open Cursor and navigate to **Settings/MCP**. You should see a green active status after the server is successfully connected.
+
+### VSCode
+1.  **Update VSCode** to the latest.
+1.  Open VSCode, search MCP from the settings page and **enable MCP**.
+1.  Search chat agent and **enable Agent mode** for copilot.
+1.  Add the following configuration:
+
+    <$Partial path="mcp_supabase_config.mdx" variables={{ "app": "VSCode" }} />
+
+1.  Save the file and start the server. VSCode should automatically reload the configuration.
+
+1. You should the see **a tool icon with the total tools available** in the chat after the server is successfully connected.
 
 ### Windsurf
 

--- a/apps/ui-library/public/llms.txt
+++ b/apps/ui-library/public/llms.txt
@@ -1,5 +1,5 @@
 # Supabase UI Library
-Last updated: 2025-03-28T12:17:05.978Z
+Last updated: 2025-04-05T09:38:30.937Z
 
 ## Overview
 Library of components for your project. The components integrate with Supabase and are shadcn compatible.
@@ -12,32 +12,36 @@ Library of components for your project. The components integrate with Supabase a
 - [Introduction](https://supabase.com/ui/docs/getting-started/introduction)
     - A flexible, open-source UI component library built on shadcn/ui, designed to simplify Supabase-powered projects with pre-built Auth, Storage, and Realtime features.
 - [Quick Start](https://supabase.com/ui/docs/getting-started/quickstart)
-    - Components
-- [Next.js](https://supabase.com/ui/docs/nextjs/client)
+    - Install shadcn/ui and use the components in your project
+- [Supabase Client Libraries](https://supabase.com/ui/docs/nextjs/client)
     - Supabase client for Next.js
 - [Current User Avatar](https://supabase.com/ui/docs/nextjs/current-user-avatar)
     - Supabase Auth-aware avatar
 - [Dropzone (File Upload)](https://supabase.com/ui/docs/nextjs/dropzone)
     - Displays a control for easier uploading of files directly to Supabase Storage
-- [Password-based Auth (Next.js)](https://supabase.com/ui/docs/nextjs/password-based-auth)
-    - Password-based Auth block for Next.js app
+- [Password-based Authentication](https://supabase.com/ui/docs/nextjs/password-based-auth)
+    - Password-based authentication block for Next.js
 - [Realtime Avatar Stack](https://supabase.com/ui/docs/nextjs/realtime-avatar-stack)
     - Avatar stack in realtime
+- [Realtime Chat](https://supabase.com/ui/docs/nextjs/realtime-chat)
+    - Real-time chat component for collaborative applications
 - [Realtime Cursor](https://supabase.com/ui/docs/nextjs/realtime-cursor)
     - Real-time cursor sharing for collaborative applications
-- [Supabase Client for React Router](https://supabase.com/ui/docs/react-router/client)
+- [Supabase Client Libraries](https://supabase.com/ui/docs/react-router/client)
     - Supabase client for React Router
 - [Current User Avatar](https://supabase.com/ui/docs/react-router/current-user-avatar)
     - Supabase Auth-aware avatar
 - [Dropzone (File Upload)](https://supabase.com/ui/docs/react-router/dropzone)
     - Displays a control for easier uploading of files directly to Supabase Storage
-- [Password-based Auth (Next.js)](https://supabase.com/ui/docs/react-router/password-based-auth)
-    - Password-based Auth block for Next.js app
+- [Password-based Authentication](https://supabase.com/ui/docs/react-router/password-based-auth)
+    - Password-based authentication block for React Router
 - [Realtime Avatar Stack](https://supabase.com/ui/docs/react-router/realtime-avatar-stack)
     - Avatar stack in realtime
+- [Realtime Chat](https://supabase.com/ui/docs/react-router/realtime-chat)
+    - Real-time chat component for collaborative applications
 - [Realtime Cursor](https://supabase.com/ui/docs/react-router/realtime-cursor)
     - Real-time cursor sharing for collaborative applications
-- [React Single Page Applications](https://supabase.com/ui/docs/react/client)
+- [Supabase Client Libraries](https://supabase.com/ui/docs/react/client)
     - Supabase client for React Single Page Applications
 - [Current User Avatar](https://supabase.com/ui/docs/react/current-user-avatar)
     - Supabase Auth-aware avatar
@@ -47,17 +51,21 @@ Library of components for your project. The components integrate with Supabase a
     - Password-based authentication block for React Single Page Applications
 - [Realtime Avatar Stack](https://supabase.com/ui/docs/react/realtime-avatar-stack)
     - Avatar stack in realtime
+- [Realtime Chat](https://supabase.com/ui/docs/react/realtime-chat)
+    - Real-time chat component for collaborative applications
 - [Realtime Cursor](https://supabase.com/ui/docs/react/realtime-cursor)
     - Real-time cursor sharing for collaborative applications
-- [TanStack Start](https://supabase.com/ui/docs/tanstack/client)
+- [Supabase Client Libraries](https://supabase.com/ui/docs/tanstack/client)
     - Supabase client for TanStack Start
 - [Current User Avatar](https://supabase.com/ui/docs/tanstack/current-user-avatar)
     - Supabase Auth-aware avatar
 - [Dropzone (File Upload)](https://supabase.com/ui/docs/tanstack/dropzone)
     - Displays a control for easier uploading of files directly to Supabase Storage
-- [TanStack Start](https://supabase.com/ui/docs/tanstack/password-based-auth)
-    - Supabase client for TanStack Start
+- [Password-based Authentication](https://supabase.com/ui/docs/tanstack/password-based-auth)
+    - Password-based authentication block for TanStack Start
 - [Realtime Avatar Stack](https://supabase.com/ui/docs/tanstack/realtime-avatar-stack)
     - Avatar stack in realtime
+- [Realtime Chat](https://supabase.com/ui/docs/tanstack/realtime-chat)
+    - Real-time chat component for collaborative applications
 - [Realtime Cursor](https://supabase.com/ui/docs/tanstack/realtime-cursor)
     - Real-time cursor sharing for collaborative applications

--- a/apps/www/public/sitemap_www.xml
+++ b/apps/www/public/sitemap_www.xml
@@ -1941,6 +1941,96 @@
   </url>
 
   <url>
+    <loc>https://supabase.com/blog/dedicated-poolers</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://supabase.com/blog/migrating-mongodb-data-api-with-supabase</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://supabase.com/blog/migrating-from-fauna-to-supabase</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://supabase.com/blog/postgres-language-server</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://supabase.com/blog/clerk-tpa-pricing</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://supabase.com/blog/supabase-ui-library</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://supabase.com/blog/automatic-embeddings</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://supabase.com/blog/supabase-edge-functions-deploy-dashboard-deno-2-1</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://supabase.com/blog/realtime-broadcast-from-database</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://supabase.com/blog/tabs-dashboard-updates</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://supabase.com/blog/declarative-schemas</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://supabase.com/blog/data-api-nearest-read-replica</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://supabase.com/blog/launch-week-14-top-10</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://supabase.com/blog/mcp-server</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://supabase.com/customers/asap-work</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
     <loc>https://supabase.com/customers/berriai</loc>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
@@ -1948,6 +2038,12 @@
 
   <url>
     <loc>https://supabase.com/customers/chatbase</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://supabase.com/customers/deriv</loc>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
@@ -2001,6 +2097,12 @@
   </url>
 
   <url>
+    <loc>https://supabase.com/customers/meshy</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
     <loc>https://supabase.com/customers/mobbin</loc>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
@@ -2019,6 +2121,12 @@
   </url>
 
   <url>
+    <loc>https://supabase.com/customers/quilia</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
     <loc>https://supabase.com/customers/quivr</loc>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
@@ -2026,6 +2134,12 @@
 
   <url>
     <loc>https://supabase.com/customers/replenysh</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://supabase.com/customers/resend</loc>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
@@ -3051,6 +3165,12 @@
   </url>
 
   <url>
+    <loc>https://supabase.com/launch-week/13</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
     <loc>https://supabase.com/launch-week/6</loc>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
@@ -3153,6 +3273,12 @@
   </url>
 
   <url>
+    <loc>https://supabase.com/privacy-241009</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
     <loc>https://supabase.com/privacy</loc>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
@@ -3172,6 +3298,12 @@
 
   <url>
     <loc>https://supabase.com/sla</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://supabase.com/solutions/ai-builders</loc>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Adds VSCode MCP set up instructions to the docs.

## What is the current behavior?

The docs don't cover VSCode MCP set up.

## What is the new behavior?

The docs now include MCP instructions for VSCode.

https://github.com/user-attachments/assets/f455efdd-2100-4e2b-b2d0-0fe9c52d8cb0

Closes #34762


## Additional context

VSCode support for MCP is new and available in the latest release.
