### PR TITLE
Set URL provider value to null on auth providers on cancel and save

### DIFF
--- a/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
@@ -110,6 +110,7 @@ export const ProviderForm = ({ config, provider, isActive }: ProviderFormProps) 
         onSuccess: () => {
           resetForm({ values: { ...values }, initialValues: { ...values } })
           setOpen(false)
+          setUrlProvider(null)
           toast.success('Successfully updated settings')
         },
       }
@@ -243,6 +244,7 @@ export const ProviderForm = ({ config, provider, isActive }: ProviderFormProps) 
                           onClick={() => {
                             handleReset()
                             setOpen(false)
+                            setUrlProvider(null)
                           }}
                           disabled={isUpdatingConfig}
                         >


### PR DESCRIPTION
As per PR title - addresses an issue whereby if you open a provider in the side panel, then click "Cancel" or "Save", the URL value of `provider` doesnt go away, and you can't open the same provider again without having to click on another provider, then close the panel click on the previous provider 

We have that logic, but its only called in Sheet's `onOpenChange` which i realise only gets triggered when clicking outside of the Sheet 😓 