### PR TITLE
chore: fix quoting for json column export

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/TableEntity.utils.test.ts
+++ b/apps/studio/components/interfaces/TableGridEditor/TableEntity.utils.test.ts
@@ -70,9 +70,16 @@ describe('TableEntity.utils: formatTableRowsToSQL', () => {
         tags: ['tag-a', 'tag-c'],
         metadata: '{"version": 1}',
       },
+      {
+        idx: 2,
+        id: 3,
+        name: 'ONeil',
+        tags: ['tag-a'],
+        metadata: `{"version": 1, "name": "O'Neil"}`,
+      },
     ]
     const result = formatTableRowsToSQL(table, rows)
-    const expected = `INSERT INTO "public"."demo" ("id", "name", "tags", "metadata") VALUES ('2', 'Person 1', '{"tag-a","tag-c"}', '{"version": 1}');`
+    const expected = `INSERT INTO "public"."demo" ("id", "name", "tags", "metadata") VALUES ('2', 'Person 1', '{"tag-a","tag-c"}', '{"version": 1}'), ('3', 'ONeil', '{"tag-a"}', '{"version": 1, "name": "O''Neil"}');`
     expect(result).toBe(expected)
   })
 

--- a/apps/studio/components/interfaces/TableGridEditor/TableEntity.utils.ts
+++ b/apps/studio/components/interfaces/TableGridEditor/TableEntity.utils.ts
@@ -44,7 +44,7 @@ export const formatTableRowsToSQL = (table: SupaTable, rows: any[]) => {
         } else if (dataType === 'ARRAY') {
           return `'${JSON.stringify(val).replace('[', '{').replace(/.$/, '}')}'`
         } else if (format?.includes('json')) {
-          return `${JSON.stringify(val).replace(/\\"/g, '"').replace('"', "'").replace(/.$/, "'")}`
+          return `${JSON.stringify(val).replace(/\\"/g, '"').replace(/'/g, "''").replace('"', "'").replace(/.$/, "'")}`
         } else {
           return `'${val}'`
         }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

JSON and JSONB columns aren't exported in a manner that allows re-import when a single quote is stored in a json string.

## What is the new behavior?

Single quotes don't break generated SQL used for imports.

