### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -419,6 +419,8 @@ services:
       interval: 5s
       timeout: 5s
       retries: 10
+    ports:
+      - '5432:5432'
     depends_on:
       vector:
         condition: service_healthy


### PR DESCRIPTION
expose port 5432 to access with N8N

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES/NO

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
