### PR TITLE
removed typescript specific code from javascript code snippet

### DIFF
--- a/apps/docs/content/guides/getting-started/tutorials/with-nextjs.mdx
+++ b/apps/docs/content/guides/getting-started/tutorials/with-nextjs.mdx
@@ -504,7 +504,7 @@ In the following code snippet, we perform the following steps:
 <$CodeTabs>
 
 ```js name=app/auth/confirm/route.js
-import { type NextRequest, NextResponse } from 'next/server'
+import { NextResponse } from 'next/server'
 
 import { createClient } from '@/utils/supabase/server'
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

fixed documentation at [Confirmation Endpoint](https://supabase.com/docs/guides/getting-started/tutorials/with-nextjs?queryGroups=language&language=js#confirmation-endpoint) in "Build a User Management App with Next.js" tutorial by removing TypeScript specific code from the JavaScript code snippet.

## What is the current behavior?
Current instruction causes the error below because of having `type` in JavaScript.
<img width="420" alt="Screenshot 2025-04-07 at 19 38 28" src="https://github.com/user-attachments/assets/96dd29d0-7d57-43e3-adf0-b3d71510478d" />


## What is the new behavior?

I removed `type NextResponse` from the instruction.

## Additional context

N/A
