### PR TITLE
Fix version selector if only one result returned, and default to first result if no GA version found

### DIFF
--- a/apps/studio/components/interfaces/ProjectCreation/PostgresVersionSelector.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/PostgresVersionSelector.tsx
@@ -70,17 +70,22 @@ export const PostgresVersionSelector = ({
   )
 
   useEffect(() => {
-    const gaVersion = availableVersions.find((x) => x.release_channel === 'ga')
-    const defaultValue = gaVersion ? formatValue(gaVersion) : undefined
-    form.setValue('postgresVersionSelection', defaultValue)
+    if (availableVersions.length > 0) {
+      const gaVersion = availableVersions.find((x) => x.release_channel === 'ga')
+      const defaultValue = gaVersion ? formatValue(gaVersion) : formatValue(availableVersions[0])
+      console.log({ defaultValue })
+      form.setValue('postgresVersionSelection', defaultValue)
+    }
   }, [isSuccess, form])
+
+  const { postgresVersionSelection } = form.watch()
 
   return (
     <FormItemLayout label="Postgres Version" layout={layout}>
       <Select_Shadcn_
-        value={field.value}
+        value={postgresVersionSelection}
         onValueChange={field.onChange}
-        disabled={availableVersions.length <= 1 || isLoadingProjectVersions}
+        disabled={availableVersions.length === 0 || isLoadingProjectVersions}
       >
         <SelectTrigger_Shadcn_ className="[&>:nth-child(1)]:w-full [&>:nth-child(1)]:flex [&>:nth-child(1)]:items-start">
           <SelectValue_Shadcn_ placeholder="Select a Postgres version for your project" />

--- a/apps/studio/components/interfaces/ProjectCreation/PostgresVersionSelector.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/PostgresVersionSelector.tsx
@@ -73,7 +73,6 @@ export const PostgresVersionSelector = ({
     if (availableVersions.length > 0) {
       const gaVersion = availableVersions.find((x) => x.release_channel === 'ga')
       const defaultValue = gaVersion ? formatValue(gaVersion) : formatValue(availableVersions[0])
-      console.log({ defaultValue })
       form.setValue('postgresVersionSelection', defaultValue)
     }
   }, [isSuccess, form])

--- a/apps/studio/components/interfaces/ProjectCreation/PostgresVersionSelector.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/PostgresVersionSelector.tsx
@@ -68,6 +68,7 @@ export const PostgresVersionSelector = ({
   const availableVersions = (data?.available_versions ?? []).sort((a, b) =>
     a.version.localeCompare(b.version)
   )
+  const { postgresVersionSelection } = form.watch()
 
   useEffect(() => {
     if (availableVersions.length > 0) {
@@ -76,8 +77,6 @@ export const PostgresVersionSelector = ({
       form.setValue('postgresVersionSelection', defaultValue)
     }
   }, [isSuccess, form])
-
-  const { postgresVersionSelection } = form.watch()
 
   return (
     <FormItemLayout label="Postgres Version" layout={layout}>

--- a/apps/studio/pages/new/[slug].tsx
+++ b/apps/studio/pages/new/[slug].tsx
@@ -82,9 +82,9 @@ import {
 } from 'ui'
 import { Admonition } from 'ui-patterns/admonition'
 import { Input } from 'ui-patterns/DataInputs/Input'
+import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import { InfoTooltip } from 'ui-patterns/info-tooltip'
-import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
 
 type DesiredInstanceSize = components['schemas']['DesiredInstanceSize']
 


### PR DESCRIPTION
As per PR title - 2 changes here on the creation project page
- The postgres version dropdown was getting disabled as there was a logic for the `disabled` property  `availableVersion.length <= 1`, seems like a mistake so swapped that out to `.length === 0`
- If there's no versions with `release_channel` as `ga`, we currently don't select anything by default, so updating here to at least select the first result from the available_versions endpoint
- (Unrelated) one oddity i noticed in `PostgresVersionSelector` - `field.value` somehow was not reflecting the updated value when we call `setValue` in the `useEffect`, causing the UI dropdown to seemingly have no default selected, but I checked the form state that the value _did_ get updated, and that `onSubmit` also had the updated value. Swapped it to use the value from `form.watch()` to ensure the UI is correct
  - This behaviour is also happening on prod if you hit refresh while on the new project page

Note that this shouldn't have any user-facing changes, the main bug that this PR is fixing is just the first pointer