### PR TITLE
fix: minor org layout fixes

### DIFF
--- a/apps/studio/components/interfaces/App/FeaturePreview/FeaturePreviewModal.tsx
+++ b/apps/studio/components/interfaces/App/FeaturePreview/FeaturePreviewModal.tsx
@@ -23,8 +23,23 @@ const FeaturePreviewModal = () => {
   const isFeaturePreviewTabsTableEditorFlag = useFlag('featurePreviewTabsTableEditor')
   const isFeaturePreviewTabsSqlEditorFlag = useFlag('featurePreviewSqlEditorTabs')
 
+  function isReleasedToPublic(feature: (typeof FEATURE_PREVIEWS)[number]) {
+    switch (feature.key) {
+      case LOCAL_STORAGE_KEYS.UI_TABLE_EDITOR_TABS:
+        return isFeaturePreviewTabsTableEditorFlag
+      case LOCAL_STORAGE_KEYS.UI_SQL_EDITOR_TABS:
+        return isFeaturePreviewTabsSqlEditorFlag
+      case LOCAL_STORAGE_KEYS.UI_NEW_LAYOUT_PREVIEW:
+        return enableNewLayoutPreview
+      default:
+        return true
+    }
+  }
+
   const selectedFeaturePreview =
-    snap.selectedFeaturePreview === '' ? FEATURE_PREVIEWS[0].key : snap.selectedFeaturePreview
+    snap.selectedFeaturePreview === ''
+      ? FEATURE_PREVIEWS.filter((feature) => isReleasedToPublic(feature))[0].key
+      : snap.selectedFeaturePreview
 
   const [selectedFeatureKey, setSelectedFeatureKey] = useState<string>(selectedFeaturePreview)
 
@@ -53,18 +68,6 @@ const FeaturePreviewModal = () => {
     snap.setSelectedFeaturePreview(FEATURE_PREVIEWS[0].key)
   }
 
-  function isReleasedToPublic(feature: (typeof FEATURE_PREVIEWS)[number]) {
-    switch (feature.key) {
-      case LOCAL_STORAGE_KEYS.UI_TABLE_EDITOR_TABS:
-        return isFeaturePreviewTabsTableEditorFlag
-      case LOCAL_STORAGE_KEYS.UI_SQL_EDITOR_TABS:
-        return isFeaturePreviewTabsSqlEditorFlag
-      case LOCAL_STORAGE_KEYS.UI_NEW_LAYOUT_PREVIEW:
-        return enableNewLayoutPreview
-      default:
-        return true
-    }
-  }
   // this modal can be triggered on other pages
   // Update local state when valtio state changes
 

--- a/apps/studio/hooks/misc/useOrganizationRestrictions.ts
+++ b/apps/studio/hooks/misc/useOrganizationRestrictions.ts
@@ -1,5 +1,6 @@
 import dayjs from 'dayjs'
 
+import { useNewLayout } from 'components/interfaces/App/FeaturePreview/FeaturePreviewContext'
 import { RESTRICTION_MESSAGES } from 'components/interfaces/Organization/restriction.constants'
 import { useOverdueInvoicesQuery } from 'data/invoices/invoices-overdue-query'
 import { useOrganizationsQuery } from 'data/organizations/organizations-query'
@@ -14,6 +15,7 @@ export type WarningBannerProps = {
 
 export function useOrganizationRestrictions() {
   const org = useSelectedOrganization()
+  const isNewLayout = useNewLayout()
 
   const { data: overdueInvoices } = useOverdueInvoicesQuery()
   const { data: organizations } = useOrganizationsQuery()
@@ -36,7 +38,7 @@ export function useOrganizationRestrictions() {
     })
   }
 
-  if (overdueInvoicesFromOtherOrgs?.length) {
+  if (overdueInvoicesFromOtherOrgs?.length && isNewLayout) {
     warnings.push({
       type: 'danger',
       title: RESTRICTION_MESSAGES.OVERDUE_INVOICES_FROM_OTHER_ORGS.title,

--- a/apps/studio/pages/organizations.tsx
+++ b/apps/studio/pages/organizations.tsx
@@ -1,17 +1,25 @@
+import { Boxes } from 'lucide-react'
+import { useRouter } from 'next/router'
+import { useEffect } from 'react'
+
 import AppLayout from 'components/layouts/AppLayout/AppLayout'
 import DefaultLayout from 'components/layouts/DefaultLayout'
 import { ScaffoldContainerLegacy, ScaffoldTitle } from 'components/layouts/Scaffold'
-import { useOrganizationsQuery } from 'data/organizations/organizations-query'
-import { useRouter } from 'next/router'
-import { NextPageWithLayout } from 'types'
-
 import { ActionCard } from 'components/ui/ActionCard'
-import { Boxes } from 'lucide-react'
+import { useOrganizationsQuery } from 'data/organizations/organizations-query'
+import { NextPageWithLayout } from 'types'
 import { Skeleton } from 'ui'
 
 const OrganizationsPage: NextPageWithLayout = () => {
   const router = useRouter()
-  const { data: organizations, isLoading, error } = useOrganizationsQuery()
+  const { data: organizations, isLoading, isError, error, isSuccess } = useOrganizationsQuery()
+
+  useEffect(() => {
+    // If there are no organizations, force the user to create one
+    if (isSuccess && organizations.length <= 0) {
+      router.push('/new')
+    }
+  }, [isSuccess, organizations])
 
   return (
     <>
@@ -20,15 +28,15 @@ const OrganizationsPage: NextPageWithLayout = () => {
       </ScaffoldContainerLegacy>
       <ScaffoldContainerLegacy>
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-          {isLoading ? (
+          {isLoading && (
             <>
               <Skeleton className="h-[62px] rounded-md" />
               <Skeleton className="h-[62px] rounded-md" />
               <Skeleton className="h-[62px] rounded-md" />
             </>
-          ) : error ? (
-            <div>Error loading organizations</div>
-          ) : (
+          )}
+          {isError && <div>Error loading organizations</div>}
+          {isSuccess &&
             organizations?.map((organization) => (
               <ActionCard
                 bgColor="bg border"
@@ -38,8 +46,7 @@ const OrganizationsPage: NextPageWithLayout = () => {
                 title={organization.name}
                 onClick={() => router.push(`/org/${organization.slug}`)}
               />
-            ))
-          )}
+            ))}
         </div>
       </ScaffoldContainerLegacy>
     </>


### PR DESCRIPTION
Fixes:

1. Non supabase team members can enable the layout (wrongly showing the enable modal)
<img width="923" alt="Screenshot 2025-04-08 at 12 06 48" src="https://github.com/user-attachments/assets/68e1dffd-6a72-414b-bd60-9104f162d14c" />

2. Unable to create a new org if you don't have any (new layout)
![Screenshot 2025-04-08 at 11 59 37](https://github.com/user-attachments/assets/c5ef478e-84d4-4e0e-bb6e-decd7c3845a1)

3. Overdue invoice banner showing up in old layout
![Screenshot 2025-04-08 at 12 02 05](https://github.com/user-attachments/assets/b10907cb-d5e2-4f3f-8383-95e917c5d433)
