### PR TITLE
set default value if empty array

### DIFF
--- a/apps/studio/components/ui/FileExplorerAndEditor/FileExplorerAndEditor.tsx
+++ b/apps/studio/components/ui/FileExplorerAndEditor/FileExplorerAndEditor.tsx
@@ -82,7 +82,7 @@ const FileExplorerAndEditor = ({
   }
 
   const addNewFile = () => {
-    const newId = Math.max(...files.map((f) => f.id)) + 1
+    const newId = Math.max(0, ...files.map((f) => f.id)) + 1
     const updatedFiles = files.map((f) => ({ ...f, selected: false }))
     onFilesChange([
       ...updatedFiles,


### PR DESCRIPTION
Resolves `Multiple TreeView nodes have the same ID (-Infinity). IDs must be unique.` error that a couple of people have run in to. This most likely triggeres when there is an empty file list (somehow).