### PR TITLE
Remove hard coded modal false in dropdown-menu

### DIFF
--- a/packages/ui/src/components/shadcn/ui/dropdown-menu.tsx
+++ b/packages/ui/src/components/shadcn/ui/dropdown-menu.tsx
@@ -10,9 +10,7 @@ import * as React from 'react'
 
 import { cn } from '../../../lib/utils/cn'
 
-const DropdownMenu = (props: React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Root>) => (
-  <DropdownMenuPrimitive.Root modal={false} {...props} />
-)
+const DropdownMenu = DropdownMenuPrimitive.Root
 
 const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger
 


### PR DESCRIPTION
## Context:
There's a bug whereby somehow the DropdownMenu component, only when rendered in a SidePanel or Sheet, would immediately close when clicking on the trigger component (`onOpenChange` gets called immediately). 

## To reproduce
This can be reproduce in the Table Editor on a table which has a column that's referencing another. If you hit "Insert row" to pop open the Row Editor side panel, clicking on the "Edit" button for the column that has a reference will immediately close the dropdown.

https://github.com/user-attachments/assets/09bf3b3f-25dd-407e-9541-6836e9ef5009

## Investigation
- Can confirm that this bug was introduced in this [PR](https://github.com/supabase/supabase/pull/33150/files)
  - The bug can be reproduced in the preview builds of this PR
  - It cannot be reproduced on preview builds of PRs that were created before the offending PR got merged in
- To be clear, I still am not able to pinpoint which change in the offending PR caused this behaviour
  - I tried to rollback all the package.json version changes, but still no luck
- What I found worked was the `modal` property on the DropdownMenu component, it was getting hardcoded to false
  - All other UI components that had a similar UI behaviour was allowing `modal` to be passed through as a prop
    - e.g Popover 
  - Removing the hardcode seems to have solved the issue

## To test
- Repeat the reproduce steps to ensure that the bug is no longer present
- Also double check on other places where we're using Dropdown component
  - e.g SQL Editor -> UtilityActions
![image](https://github.com/user-attachments/assets/625e69fb-f2d1-42cd-834e-b9ecdf4c2b5c)
  - e.g Table Editor -> Filter / Sorts
  - e.g Storage Explorer -> Bucket actions