### PR TITLE
DropdownMenu component modal prop default to false, but allow passing prop value

### DIFF
--- a/apps/studio/components/interfaces/Advisors/AdvisorRuleItem.tsx
+++ b/apps/studio/components/interfaces/Advisors/AdvisorRuleItem.tsx
@@ -32,12 +32,9 @@ interface AdvisorRuleItemProps {
 export const AdvisorRuleItem = ({ lint }: AdvisorRuleItemProps) => {
   const { ref: projectRef } = useParams()
   const organization = useSelectedOrganization()
-  // const [expandedLint, setExpandedLint] = useQueryState('lint')
-
-  const expandedLint = 'lint'
-  const setExpandedLint = (value: string | null) => {}
 
   const [open, setOpen] = useState(false)
+  const [expandedLint, setExpandedLint] = useState<string>()
   const [selectedRuleToDelete, setSelectedRuleToDelete] = useState<string>()
 
   const { data: members = [] } = useOrganizationMembersQuery({ slug: organization?.slug })
@@ -73,7 +70,7 @@ export const AdvisorRuleItem = ({ lint }: AdvisorRuleItemProps) => {
         open={expandedLint === lint.name}
         onOpenChange={(open) => {
           if (open) setExpandedLint(lint.name)
-          else setExpandedLint(null)
+          else setExpandedLint(undefined)
         }}
       >
         <CollapsibleTrigger_Shadcn_ asChild className="[&[data-state=open]>div>svg]:!rotate-90">

--- a/apps/studio/components/interfaces/Database/Functions/FunctionsList/FunctionList.tsx
+++ b/apps/studio/components/interfaces/Database/Functions/FunctionsList/FunctionList.tsx
@@ -110,7 +110,7 @@ const FunctionList = ({
               {!isLocked && (
                 <div className="flex items-center justify-end">
                   {canUpdateFunctions ? (
-                    <DropdownMenu modal={false}>
+                    <DropdownMenu>
                       <DropdownMenuTrigger asChild>
                         <Button type="default" className="px-1" icon={<MoreVertical />} />
                       </DropdownMenuTrigger>

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/InputField.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/InputField.tsx
@@ -121,7 +121,7 @@ const InputField = ({
         onChange={(event: any) => onUpdateField({ [field.name]: event.target.value })}
         actions={
           isEditable && (
-            <DropdownMenu>
+            <DropdownMenu modal>
               <DropdownMenuTrigger asChild>
                 <Button type="default" icon={<Edit />} className="px-1.5" />
               </DropdownMenuTrigger>

--- a/packages/ui/src/components/shadcn/ui/dropdown-menu.tsx
+++ b/packages/ui/src/components/shadcn/ui/dropdown-menu.tsx
@@ -10,7 +10,12 @@ import * as React from 'react'
 
 import { cn } from '../../../lib/utils/cn'
 
-const DropdownMenu = DropdownMenuPrimitive.Root
+const DropdownMenu = ({
+  modal = false,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Root>) => (
+  <DropdownMenuPrimitive.Root modal={modal} {...props} />
+)
 
 const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger
 


### PR DESCRIPTION
## Context
The removal of `modal=false` for **all** dropdowns broke some interactions with dropdowns and dialogs/sheets, so while it fixed DropdownMenu for the RowEditor in the Table Editor, it caused problems in other parts of the dashboard

## Changes involved
- Keep allowing `modal` prop to be passed in DropdownMenu, but default the value to `false`
- Reduce the blast radius for the change in this [PR](https://github.com/supabase/supabase/pull/34829)
  - So only usage of DropdownMenu in InputField is updated, everything else across the dashboard remains status quo
- Revert the changes in this [PR](https://github.com/supabase/supabase/pull/34829/files)