### PR TITLE
Move assistant stored state in to IndexedDB

### DIFF
--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
@@ -129,7 +129,7 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
 
   const currentTable = tables?.find((t) => t.id.toString() === entityId)
   const currentSchema = searchParams?.get('schema') ?? 'public'
-  const currentChat = snap.chats[snap.activeChatId ?? '']?.name
+  const currentChat = snap.activeChat?.name
 
   const { ref } = useParams()
   const org = useSelectedOrganization()

--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
@@ -129,7 +129,7 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
 
   const currentTable = tables?.find((t) => t.id.toString() === entityId)
   const currentSchema = searchParams?.get('schema') ?? 'public'
-  const currentChat = snap.chats[snap.activeChatId ?? ''].name
+  const currentChat = snap.chats[snap.activeChatId ?? '']?.name
 
   const { ref } = useParams()
   const org = useSelectedOrganization()

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -71,6 +71,7 @@
     "generate-password-browser": "^1.1.0",
     "html-to-image": "^1.10.8",
     "icons": "workspace:*",
+    "idb": "^8.0.2",
     "immutability-helper": "^3.1.1",
     "ip-num": "^1.5.1",
     "json-logic-js": "^2.0.2",

--- a/apps/studio/state/ai-assistant-state.tsx
+++ b/apps/studio/state/ai-assistant-state.tsx
@@ -1,6 +1,8 @@
+import { openDB, DBSchema, IDBPDatabase } from 'idb'
 import type { Message as MessageType } from 'ai/react'
 import { createContext, PropsWithChildren, useContext, useEffect, useState } from 'react'
 import { proxy, snapshot, subscribe, useSnapshot } from 'valtio'
+import { debounce } from 'lodash'
 
 import { LOCAL_STORAGE_KEYS } from 'lib/constants'
 
@@ -29,6 +31,14 @@ type AiAssistantData = {
   activeChatId?: string
 }
 
+// Data structure stored in IndexedDB
+type StoredAiAssistantState = {
+  projectRef: string
+  open: boolean
+  activeChatId?: string
+  chats: Record<string, ChatSession>
+}
+
 const INITIAL_AI_ASSISTANT: AiAssistantData = {
   open: false,
   initialInput: '',
@@ -39,56 +49,178 @@ const INITIAL_AI_ASSISTANT: AiAssistantData = {
   activeChatId: undefined,
 }
 
-export const createAiAssistantState = (projectRef: string | undefined) => {
-  const getInitialState = (): AiAssistantData => {
-    if (typeof window === 'undefined') {
-      return INITIAL_AI_ASSISTANT
-    }
+const DB_NAME = 'ai-assistant-db'
+const DB_VERSION = 1
+const STORE_NAME = 'assistantState'
 
-    const stored = localStorage.getItem(LOCAL_STORAGE_KEYS.AI_ASSISTANT_STATE(projectRef))
-    const urlParams = new URLSearchParams(window.location.search)
-    const aiAssistantPanelOpenParam = urlParams.get('aiAssistantPanelOpen')
+interface AiAssistantDB extends DBSchema {
+  [STORE_NAME]: {
+    key: string
+    value: StoredAiAssistantState
+  }
+}
 
-    let parsedAiAssistant = INITIAL_AI_ASSISTANT
-
-    try {
-      if (stored) {
-        parsedAiAssistant = JSON.parse(stored, (key, value) => {
-          if ((key === 'createdAt' || key === 'updatedAt') && value) {
-            return new Date(value)
-          }
-          return value
-        })
+async function openAiDb(): Promise<IDBPDatabase<AiAssistantDB>> {
+  return openDB<AiAssistantDB>(DB_NAME, DB_VERSION, {
+    upgrade(db) {
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME, { keyPath: 'projectRef' })
       }
-    } catch {
-      // Ignore parsing errors
-    }
+    },
+  })
+}
 
-    return {
-      ...parsedAiAssistant,
-      open:
-        aiAssistantPanelOpenParam !== null
-          ? aiAssistantPanelOpenParam === 'true'
-          : parsedAiAssistant.open,
+async function getAiState(projectRef: string): Promise<StoredAiAssistantState | undefined> {
+  if (!projectRef) return undefined
+  try {
+    const db = await openAiDb()
+    return await db.get(STORE_NAME, projectRef)
+  } catch (error) {
+    console.error('Failed to get AI state from IndexedDB:', error)
+    return undefined
+  }
+}
+
+async function saveAiState(state: StoredAiAssistantState): Promise<void> {
+  if (!state.projectRef) return
+  try {
+    const db = await openAiDb()
+    await db.put(STORE_NAME, state)
+  } catch (error) {
+    console.error('Failed to save AI state to IndexedDB:', error)
+  }
+}
+
+// Helper function to load state from IndexedDB
+async function loadFromIndexedDB(projectRef: string): Promise<StoredAiAssistantState | null> {
+  try {
+    const persistedState = await getAiState(projectRef)
+    if (persistedState) {
+      console.log('Loaded state from IndexedDB:', persistedState)
+      // Revive dates
+      Object.values(persistedState.chats).forEach((chat: ChatSession) => {
+        if (chat && typeof chat === 'object') {
+          chat.createdAt = new Date(chat.createdAt)
+          chat.updatedAt = new Date(chat.updatedAt)
+        }
+      })
+      return persistedState
+    }
+  } catch (error) {
+    console.error('Error loading AI state from IndexedDB:', error)
+  }
+  return null
+}
+
+// Helper function to attempt migration from localStorage
+async function tryMigrateFromLocalStorage(
+  projectRef: string
+): Promise<StoredAiAssistantState | null> {
+  console.log('No state found in IndexedDB for', projectRef, 'checking localStorage...')
+  const stored = localStorage.getItem(LOCAL_STORAGE_KEYS.AI_ASSISTANT_STATE(projectRef))
+  if (!stored) {
+    console.log('No state found in localStorage for', projectRef)
+    return null
+  }
+
+  let migratedState: StoredAiAssistantState | null = null
+  try {
+    const parsedFromLocalStorage = JSON.parse(stored, (key, value) => {
+      if ((key === 'createdAt' || key === 'updatedAt') && value) {
+        return new Date(value)
+      }
+      return value
+    })
+
+    if (parsedFromLocalStorage && typeof parsedFromLocalStorage.chats === 'object') {
+      console.log('Found state in localStorage, attempting migration...')
+      migratedState = {
+        projectRef: projectRef,
+        open: parsedFromLocalStorage.open ?? false,
+        activeChatId: parsedFromLocalStorage.activeChatId,
+        chats: parsedFromLocalStorage.chats,
+      }
+    } else {
+      console.warn('Data in localStorage is not in the expected format, ignoring.')
+      // Clean up invalid data
+      localStorage.removeItem(LOCAL_STORAGE_KEYS.AI_ASSISTANT_STATE(projectRef))
+    }
+  } catch (error) {
+    console.error('Failed to parse state from localStorage:', error)
+    // Clear potentially corrupted data
+    localStorage.removeItem(LOCAL_STORAGE_KEYS.AI_ASSISTANT_STATE(projectRef))
+  }
+
+  if (migratedState) {
+    try {
+      await saveAiState(migratedState)
+      console.log('Successfully migrated state from localStorage to IndexedDB.')
+      localStorage.removeItem(LOCAL_STORAGE_KEYS.AI_ASSISTANT_STATE(projectRef))
+      return migratedState
+    } catch (saveError) {
+      console.error('Failed to save migrated state to IndexedDB:', saveError)
+      // Don't remove from localStorage if save failed, maybe retry later?
+      // Return null as migration wasn't fully successful
+      return null
     }
   }
 
-  const initialState = getInitialState()
+  return null
+}
 
-  const state = proxy({
-    open: initialState.open,
-    initialInput: initialState.initialInput,
-    sqlSnippets: initialState.sqlSnippets,
-    suggestions: initialState.suggestions,
-    tables: initialState.tables,
-    chats: initialState.chats,
-    activeChatId: initialState.activeChatId,
+// Helper function to ensure an active chat exists or initialize a new one
+function ensureActiveChatOrInitialize(state: AiAssistantState) {
+  // Check URL param again to override loaded 'open' state if present
+  // This check should happen *after* loading/migration potentially sets 'open'
+  if (typeof window !== 'undefined') {
+    const urlParams = new URLSearchParams(window.location.search)
+    const aiAssistantPanelOpenParam = urlParams.get('aiAssistantPanelOpen')
+    if (aiAssistantPanelOpenParam !== null) {
+      state.open = aiAssistantPanelOpenParam === 'true'
+    }
+  }
+
+  // Ensure an active chat exists after loading/migration
+  if (!state.activeChatId || !state.chats[state.activeChatId]) {
+    const chatIds = Object.keys(state.chats)
+    if (chatIds.length > 0) {
+      // Select the most recently updated chat
+      state.activeChatId = chatIds.sort(
+        (a, b) =>
+          (state.chats[b].updatedAt?.getTime() || 0) - (state.chats[a].updatedAt?.getTime() || 0)
+      )[0]
+      console.log('Selected most recent chat:', state.activeChatId)
+    } else {
+      // If loaded/migrated state had no chats, create a new one
+      console.log('No chats found after loading/migration, creating a new chat.')
+      state.newChat() // newChat now handles setting the activeChatId
+    }
+  }
+}
+
+export const createAiAssistantState = (
+  initialStateOverride?: Partial<AiAssistantData>
+): AiAssistantState => {
+  // Initialize with defaults or overrides, loading happens asynchronously in the provider
+  const initialState = { ...INITIAL_AI_ASSISTANT, ...initialStateOverride }
+
+  // Check URL params for initial 'open' state, overriding any loaded state later if present
+  if (typeof window !== 'undefined') {
+    const urlParams = new URLSearchParams(window.location.search)
+    const aiAssistantPanelOpenParam = urlParams.get('aiAssistantPanelOpen')
+    if (aiAssistantPanelOpenParam !== null) {
+      initialState.open = aiAssistantPanelOpenParam === 'true'
+    }
+  }
+
+  const state: AiAssistantState = proxy({
+    ...initialState, // Spread initial values directly
 
     resetAiAssistantPanel: () => {
-      state.open = state.open
-      state.chats = state.chats
-      state.activeChatId = state.activeChatId
+      // Reset should probably reset to initial defaults, not current state values
       Object.assign(state, INITIAL_AI_ASSISTANT)
+      // If resetting should clear persisted state, we might need an async operation here
+      // For now, just resets the in-memory state
     },
 
     // Panel visibility
@@ -105,7 +237,7 @@ export const createAiAssistantState = (projectRef: string | undefined) => {
     },
 
     // Chat management
-    get activeChat() {
+    get activeChat(): ChatSession | undefined {
       return state.activeChatId ? state.chats[state.activeChatId] : undefined
     },
 
@@ -129,11 +261,12 @@ export const createAiAssistantState = (projectRef: string | undefined) => {
       }
       state.activeChatId = chatId
 
+      // Update non-chat related state based on options, falling back to current state, then initial
       state.open = options?.open ?? state.open
-      state.initialInput = options?.initialInput ?? initialState.initialInput
-      state.sqlSnippets = options?.sqlSnippets ?? initialState.sqlSnippets
-      state.suggestions = options?.suggestions ?? initialState.suggestions
-      state.tables = options?.tables ?? initialState.tables
+      state.initialInput = options?.initialInput ?? INITIAL_AI_ASSISTANT.initialInput
+      state.sqlSnippets = options?.sqlSnippets ?? INITIAL_AI_ASSISTANT.sqlSnippets
+      state.suggestions = options?.suggestions ?? INITIAL_AI_ASSISTANT.suggestions
+      state.tables = options?.tables ?? INITIAL_AI_ASSISTANT.tables
 
       return chatId
     },
@@ -148,7 +281,6 @@ export const createAiAssistantState = (projectRef: string | undefined) => {
       const { [id]: _, ...remainingChats } = state.chats
       state.chats = remainingChats
 
-      // If the deleted chat was the active one, select a new active chat
       if (id === state.activeChatId) {
         const remainingChatIds = Object.keys(remainingChats)
         state.activeChatId = remainingChatIds.length > 0 ? remainingChatIds[0] : undefined
@@ -170,30 +302,47 @@ export const createAiAssistantState = (projectRef: string | undefined) => {
     },
 
     clearMessages: () => {
-      const chat = state.activeChat
-      if (chat) {
-        chat.messages = []
-        chat.updatedAt = new Date()
-
+      const activeChatId = state.activeChatId // Get ID before potential modification
+      if (activeChatId && state.chats[activeChatId]) {
+        // Update immutablely
+        state.chats = {
+          ...state.chats,
+          [activeChatId]: {
+            ...state.chats[activeChatId],
+            messages: [],
+            updatedAt: new Date(),
+          },
+        }
         state.sqlSnippets = []
         state.initialInput = ''
       }
     },
 
     saveMessage: (message: MessageType | MessageType[]) => {
-      let chat = state.activeChat
-      if (!chat) return
+      const activeChatId = state.activeChatId
+      if (!activeChatId || !state.chats[activeChatId]) return
 
+      const chat = state.chats[activeChatId]
       const existingMessages = chat.messages
       const messagesToAdd = Array.isArray(message)
-        ? message.filter((msg) => !existingMessages.some((existing) => existing.id === msg.id))
-        : !existingMessages.some((existing) => existing.id === message.id)
+        ? message.filter(
+            (msg) =>
+              !existingMessages.some((existing: AssistantMessageType) => existing.id === msg.id)
+          )
+        : !existingMessages.some((existing: AssistantMessageType) => existing.id === message.id)
           ? [message]
           : []
 
       if (messagesToAdd.length > 0) {
-        chat.messages = [...existingMessages, ...messagesToAdd]
-        chat.updatedAt = new Date()
+        // Update immutablely
+        state.chats = {
+          ...state.chats,
+          [activeChatId]: {
+            ...chat,
+            messages: [...existingMessages, ...messagesToAdd],
+            updatedAt: new Date(),
+          },
+        }
       }
     },
 
@@ -206,60 +355,113 @@ export const createAiAssistantState = (projectRef: string | undefined) => {
       resultId?: string
       results: any[]
     }) => {
-      let chat = state.activeChat
-      if (!chat || !resultId) return
+      const activeChatId = state.activeChatId
+      if (!activeChatId || !state.chats[activeChatId] || !resultId) return
 
+      const chat = state.chats[activeChatId]
       const existingMessages = chat.messages
-      const updatedMessages = existingMessages.map((msg) => {
+      let messageUpdated = false
+
+      const updatedMessages = existingMessages.map((msg: AssistantMessageType) => {
         if (msg.id === id) {
+          messageUpdated = true
           return { ...msg, results: { ...(msg.results ?? {}), [resultId]: results } }
         } else {
           return msg
         }
       })
-      chat.messages = updatedMessages
+
+      if (messageUpdated) {
+        // Update immutablely
+        state.chats = {
+          ...state.chats,
+          [activeChatId]: {
+            ...chat,
+            messages: updatedMessages,
+            // Optionally update updatedAt timestamp here if needed
+          },
+        }
+      }
     },
 
     setSqlSnippets: (snippets: string[]) => {
       state.sqlSnippets = snippets
     },
 
-    // SQL snippets and suggestions
     clearSqlSnippets: () => {
       state.sqlSnippets = undefined
-      // Remove suggestions if sqlSnippets were removed
       state.suggestions = undefined
     },
 
     getCachedSQLResults: ({ messageId, snippetId }: { messageId: string; snippetId?: string }) => {
-      let chat = state.activeChat
+      const chat = state.activeChat // Reading is fine
       if (!chat || !snippetId) return
 
       const message = chat.messages.find((msg) => msg.id === messageId)
       const results = (message?.results ?? {})[snippetId]
       return results
     },
-  })
 
-  // If there's no active chat when the state is created
-  // select the first chat, or create a new one if there are none
-  if (!state.activeChat) {
-    const chatIds = Object.keys(state.chats)
-    if (chatIds.length > 0) {
-      state.activeChatId = chatIds[0]
-    } else {
-      state.newChat()
-    }
-  }
+    // --- New function to load persisted state ---
+    loadPersistedState: (persistedState: StoredAiAssistantState) => {
+      state.open = persistedState.open
+      state.chats = persistedState.chats
+      state.activeChatId = persistedState.activeChatId
+
+      // Check URL param again to override loaded 'open' state if present
+      if (typeof window !== 'undefined') {
+        const urlParams = new URLSearchParams(window.location.search)
+        const aiAssistantPanelOpenParam = urlParams.get('aiAssistantPanelOpen')
+        if (aiAssistantPanelOpenParam !== null) {
+          state.open = aiAssistantPanelOpenParam === 'true'
+        }
+      }
+
+      // Ensure an active chat exists after loading
+      if (!state.activeChat) {
+        const chatIds = Object.keys(state.chats)
+        if (chatIds.length > 0) {
+          // Maybe select the most recently updated? For now, first.
+          state.activeChatId = chatIds.sort(
+            (a, b) =>
+              (state.chats[b].updatedAt?.getTime() || 0) -
+              (state.chats[a].updatedAt?.getTime() || 0)
+          )[0]
+        } else {
+          // If loaded state had no chats, create a new one
+          state.newChat()
+        }
+      }
+    },
+  })
 
   return state
 }
 
-export type AiAssistantState = ReturnType<typeof createAiAssistantState>
+export type AiAssistantState = AiAssistantData & {
+  resetAiAssistantPanel: () => void
+  openAssistant: () => void
+  closeAssistant: () => void
+  toggleAssistant: () => void
+  activeChat: ChatSession | undefined
+  newChat: (
+    options?: { name?: string } & Partial<
+      Pick<AiAssistantData, 'open' | 'initialInput' | 'sqlSnippets' | 'suggestions' | 'tables'>
+    >
+  ) => string
+  selectChat: (id: string) => void
+  deleteChat: (id: string) => void
+  renameChat: (id: string, name: string) => void
+  clearMessages: () => void
+  saveMessage: (message: MessageType | MessageType[]) => void
+  updateMessage: (args: { id: string; resultId?: string; results: any[] }) => void
+  setSqlSnippets: (snippets: string[]) => void
+  clearSqlSnippets: () => void
+  getCachedSQLResults: (args: { messageId: string; snippetId?: string }) => any[] | undefined
+  loadPersistedState: (persistedState: StoredAiAssistantState) => void
+}
 
-export const AiAssistantStateContext = createContext<AiAssistantState>(
-  createAiAssistantState(undefined)
-)
+export const AiAssistantStateContext = createContext<AiAssistantState | null>(null)
 
 export const AiAssistantStateContextProvider = ({
   projectRef,
@@ -267,40 +469,88 @@ export const AiAssistantStateContextProvider = ({
 }: PropsWithChildren<{
   projectRef: string | undefined
 }>) => {
-  const [state, setState] = useState(() => createAiAssistantState(projectRef))
+  // Initialize state. createAiAssistantState now just sets defaults.
+  const [state] = useState(() => createAiAssistantState())
 
+  // Effect to load state from IndexedDB on mount or projectRef change
   useEffect(() => {
-    setState(createAiAssistantState(projectRef))
-  }, [projectRef])
+    let isMounted = true
 
+    async function loadAndInitializeState() {
+      if (!projectRef || typeof window === 'undefined') {
+        if (projectRef === undefined) {
+          console.log('ProjectRef is undefined, resetting state.')
+          state.resetAiAssistantPanel()
+        }
+        return // Don't load if no projectRef or not in browser
+      }
+
+      let loadedState: StoredAiAssistantState | null = null
+
+      // 1. Try loading from IndexedDB
+      loadedState = await loadFromIndexedDB(projectRef)
+
+      // 2. If not in IndexedDB, try migrating from localStorage
+      if (!loadedState) {
+        loadedState = await tryMigrateFromLocalStorage(projectRef)
+      }
+
+      if (!isMounted) return // Component unmounted during async operations
+
+      // 3. If state was loaded or migrated, update the valtio state
+      if (loadedState) {
+        state.loadPersistedState(loadedState)
+      }
+
+      // 4. Ensure an active chat exists and handle URL overrides
+      ensureActiveChatOrInitialize(state)
+    }
+
+    loadAndInitializeState()
+
+    return () => {
+      isMounted = false
+    }
+  }, [projectRef, state]) // Keep `state` in dependency array as methods like reset/newChat are used
+
+  // Effect to save state to IndexedDB on changes
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      return subscribe(state, () => {
+    if (typeof window !== 'undefined' && projectRef) {
+      // Create a debounced version of saveAiState
+      const debouncedSaveAiState = debounce(saveAiState, 500) // Debounce by 500ms
+
+      const unsubscribe = subscribe(state, () => {
         const snap = snapshot(state)
-        // Save AI assistant state with limited message history
-        const aiAssistantState = {
+        // Prepare state for IndexedDB
+        const stateToSave: StoredAiAssistantState = {
+          projectRef: projectRef, // Ensure projectRef is included
           open: snap.open,
           activeChatId: snap.activeChatId,
           chats: snap.chats
             ? Object.entries(snap.chats).reduce((acc, [chatId, chat]) => {
+                // Limit messages before saving
                 return {
                   ...acc,
                   [chatId]: {
                     ...chat,
-                    messages: chat.messages?.slice(-20) || [], // Only keep last 20 messages
+                    messages: chat.messages?.slice(-20) || [], // Keep limiting messages
                   },
                 }
               }, {})
             : {},
         }
-
-        localStorage.setItem(
-          LOCAL_STORAGE_KEYS.AI_ASSISTANT_STATE(projectRef),
-          JSON.stringify(aiAssistantState)
-        )
+        // Call the debounced save function
+        debouncedSaveAiState(stateToSave)
       })
+      // Clean up subscription and cancel any pending saves on unmount or projectRef change
+      return () => {
+        debouncedSaveAiState.cancel() // Cancel pending saves
+        unsubscribe()
+      }
     }
-  }, [state, projectRef])
+    // No cleanup needed if projectRef is undefined or not in browser
+    return undefined
+  }, [state, projectRef]) // Depend on state and projectRef
 
   return (
     <AiAssistantStateContext.Provider value={state}>{children}</AiAssistantStateContext.Provider>
@@ -309,6 +559,10 @@ export const AiAssistantStateContextProvider = ({
 
 export const useAiAssistantStateSnapshot = (options?: Parameters<typeof useSnapshot>[1]) => {
   const state = useContext(AiAssistantStateContext)
-
+  if (!state) {
+    throw new Error(
+      'useAiAssistantStateSnapshot must be used within an AiAssistantStateContextProvider'
+    )
+  }
   return useSnapshot(state, options)
 }

--- a/apps/studio/state/ai-assistant-state.tsx
+++ b/apps/studio/state/ai-assistant-state.tsx
@@ -410,7 +410,7 @@ export type AiAssistantState = AiAssistantData & {
   loadPersistedState: (persistedState: StoredAiAssistantState) => void
 }
 
-export const AiAssistantStateContext = createContext<AiAssistantState | null>(null)
+export const AiAssistantStateContext = createContext<AiAssistantState>(createAiAssistantState())
 
 export const AiAssistantStateContextProvider = ({
   projectRef,
@@ -505,10 +505,5 @@ export const AiAssistantStateContextProvider = ({
 
 export const useAiAssistantStateSnapshot = (options?: Parameters<typeof useSnapshot>[1]) => {
   const state = useContext(AiAssistantStateContext)
-  if (!state) {
-    throw new Error(
-      'useAiAssistantStateSnapshot must be used within an AiAssistantStateContextProvider'
-    )
-  }
   return useSnapshot(state, options)
 }

--- a/apps/studio/state/ai-assistant-state.tsx
+++ b/apps/studio/state/ai-assistant-state.tsx
@@ -382,7 +382,7 @@ export const createAiAssistantState = (
     },
 
     getCachedSQLResults: ({ messageId, snippetId }: { messageId: string; snippetId?: string }) => {
-      const chat = state.activeChat // Reading is fine
+      const chat = state.activeChat
       if (!chat || !snippetId) return
 
       const message = chat.messages.find((msg) => msg.id === messageId)

--- a/apps/studio/state/ai-assistant-state.tsx
+++ b/apps/studio/state/ai-assistant-state.tsx
@@ -188,11 +188,9 @@ function ensureActiveChatOrInitialize(state: AiAssistantState) {
   }
 }
 
-export const createAiAssistantState = (
-  initialStateOverride?: Partial<AiAssistantData>
-): AiAssistantState => {
-  // Initialize with defaults or overrides, loading happens asynchronously in the provider
-  const initialState = { ...INITIAL_AI_ASSISTANT, ...initialStateOverride }
+export const createAiAssistantState = (): AiAssistantState => {
+  // Initialize with defaults, loading happens asynchronously in the provider
+  const initialState = { ...INITIAL_AI_ASSISTANT }
 
   // Check URL params for initial 'open' state, overriding any loaded state later if present
   if (typeof window !== 'undefined') {

--- a/apps/studio/state/ai-assistant-state.tsx
+++ b/apps/studio/state/ai-assistant-state.tsx
@@ -207,7 +207,6 @@ export const createAiAssistantState = (
     ...initialState, // Spread initial values directly
 
     resetAiAssistantPanel: () => {
-      // Reset should probably reset to initial defaults, not current state values
       Object.assign(state, INITIAL_AI_ASSISTANT)
     },
 

--- a/apps/studio/state/ai-assistant-state.tsx
+++ b/apps/studio/state/ai-assistant-state.tsx
@@ -292,7 +292,6 @@ export const createAiAssistantState = (
     clearMessages: () => {
       const activeChatId = state.activeChatId // Get ID before potential modification
       if (activeChatId && state.chats[activeChatId]) {
-        // Update immutablely
         state.chats = {
           ...state.chats,
           [activeChatId]: {
@@ -322,7 +321,6 @@ export const createAiAssistantState = (
           : []
 
       if (messagesToAdd.length > 0) {
-        // Update immutablely
         state.chats = {
           ...state.chats,
           [activeChatId]: {
@@ -360,7 +358,6 @@ export const createAiAssistantState = (
       })
 
       if (messageUpdated) {
-        // Update immutablely
         state.chats = {
           ...state.chats,
           [activeChatId]: {

--- a/apps/studio/state/ai-assistant-state.tsx
+++ b/apps/studio/state/ai-assistant-state.tsx
@@ -497,7 +497,6 @@ export const AiAssistantStateContextProvider = ({
         unsubscribe()
       }
     }
-    // No cleanup needed if projectRef is undefined or not in browser
     return undefined
   }, [state, projectRef])
 

--- a/apps/studio/tests/pages/projects/reports/api-report.test.tsx
+++ b/apps/studio/tests/pages/projects/reports/api-report.test.tsx
@@ -11,14 +11,21 @@ import { render } from '../../../helpers'
 // I'd be keen to see how we can do this better if anyone is more familiar to jest 🙏
 
 // Mock the common module to provide useParams with a project ref
-vi.mock('common', async () => {
+vi.mock('common', async (importOriginal) => {
+  const actual = await importOriginal()
+
   return {
     useParams: vi.fn().mockReturnValue({ ref: 'test-project-ref' }),
     isBrowser: false,
     useIsLoggedIn: vi.fn(),
-    // Add other common exports as needed
+    LOCAL_STORAGE_KEYS: (actual as any).LOCAL_STORAGE_KEYS,
   }
 })
+
+// Mock gotrue library
+vi.mock('lib/gotrue', () => ({
+  auth: { onAuthStateChange: vi.fn() },
+}))
 
 // Mock project detail query
 vi.mock('data/projects/project-detail-query', async () => {

--- a/apps/studio/tests/pages/projects/reports/api-report.test.tsx
+++ b/apps/studio/tests/pages/projects/reports/api-report.test.tsx
@@ -10,39 +10,6 @@ import { render } from '../../../helpers'
 // which for some reason none of them worked when I was trying to mock the data within the file itself
 // I'd be keen to see how we can do this better if anyone is more familiar to jest 🙏
 
-// Mock the common module to provide useParams with a project ref
-vi.mock('common', async (importOriginal) => {
-  const actual = await importOriginal()
-
-  return {
-    useParams: vi.fn().mockReturnValue({ ref: 'test-project-ref' }),
-    isBrowser: false,
-    useIsLoggedIn: vi.fn(),
-    LOCAL_STORAGE_KEYS: (actual as any).LOCAL_STORAGE_KEYS,
-  }
-})
-
-// Mock gotrue library
-vi.mock('lib/gotrue', () => ({
-  auth: { onAuthStateChange: vi.fn() },
-}))
-
-// Mock project detail query
-vi.mock('data/projects/project-detail-query', async () => {
-  return {
-    useProjectDetailQuery: vi.fn().mockReturnValue({
-      data: {
-        id: 1,
-        ref: 'test-project-ref',
-        name: 'Test Project',
-        status: 'ACTIVE_HEALTHY',
-        postgrestStatus: 'ONLINE',
-      },
-      isLoading: false,
-    }),
-  }
-})
-
 beforeAll(() => {
   vi.mock('nuqs', async () => {
     let queryValue = 'example'

--- a/apps/studio/tests/pages/projects/reports/api-report.test.tsx
+++ b/apps/studio/tests/pages/projects/reports/api-report.test.tsx
@@ -10,6 +10,32 @@ import { render } from '../../../helpers'
 // which for some reason none of them worked when I was trying to mock the data within the file itself
 // I'd be keen to see how we can do this better if anyone is more familiar to jest 🙏
 
+// Mock the common module to provide useParams with a project ref
+vi.mock('common', async () => {
+  return {
+    useParams: vi.fn().mockReturnValue({ ref: 'test-project-ref' }),
+    isBrowser: false,
+    useIsLoggedIn: vi.fn(),
+    // Add other common exports as needed
+  }
+})
+
+// Mock project detail query
+vi.mock('data/projects/project-detail-query', async () => {
+  return {
+    useProjectDetailQuery: vi.fn().mockReturnValue({
+      data: {
+        id: 1,
+        ref: 'test-project-ref',
+        name: 'Test Project',
+        status: 'ACTIVE_HEALTHY',
+        postgrestStatus: 'ONLINE',
+      },
+      isLoading: false,
+    }),
+  }
+})
+
 beforeAll(() => {
   vi.mock('nuqs', async () => {
     let queryValue = 'example'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -673,6 +673,9 @@ importers:
       icons:
         specifier: workspace:*
         version: link:../../packages/icons
+      idb:
+        specifier: ^8.0.2
+        version: 8.0.2
       immutability-helper:
         specifier: ^3.1.1
         version: 3.1.1
@@ -6831,6 +6834,7 @@ packages:
 
   '@vercel/flags@2.6.0':
     resolution: {integrity: sha512-GvLX0CK/OsIqq672OBvcCeu0k3tb3QdE0lRn1P5zulMQJIPTLlUDEH0y9TeAyC7TMWlpTTT5Bealqu0rmncyXQ==}
+    deprecated: This package was renamed to flags, which offers the same functionality. https://vercel.com/changelog/npm-i-flags
     peerDependencies:
       '@sveltejs/kit': '*'
       next: '*'
@@ -9767,6 +9771,9 @@ packages:
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
+
+  idb@8.0.2:
+    resolution: {integrity: sha512-CX70rYhx7GDDQzwwQMDwF6kDRQi5vVs6khHUumDrMecBylKkwvZ8HWvKV08AGb7VbpoGCWUQ4aHzNDgoUiOIUg==}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -25175,6 +25182,8 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
     optional: true
+
+  idb@8.0.2: {}
 
   ieee754@1.2.1: {}
 


### PR DESCRIPTION
We currently use local storage to store Assistant history but some users are hitting quota limits which also affects other parts of the dashboard. This PR moves state storage into an IndexedDB store with keys for each project instead.

It also attempts to migrate from old local storage into new IndexedDB if it doesn't yet exist and old local storage keys exist.

**How to test**
1. Open chat in one project, make some requests
2. Create a separate chat in same project, make some requests
3. Switch project and notice new project list
4. Make some requests on new project
5. Switch back to old project to see other projects chats
6. Rename, delete a chat

 