### PR TITLE
remove flag for just accessing inline editor

### DIFF
--- a/apps/studio/components/interfaces/App/FeaturePreview/InlineEditorPreview.tsx
+++ b/apps/studio/components/interfaces/App/FeaturePreview/InlineEditorPreview.tsx
@@ -14,16 +14,16 @@ export const InlineEditorPreview = () => {
         className="rounded border mb-4"
       />
       <p className="text-sm text-foreground-light">
-        Access an inline SQL editor where you can write and run queries wherever you are in the
-        dashboard. Use the inline Assistant to generate or modify queries without leaving the
-        editor.
+        Edit policies, functions, and triggers directly in the inline SQL editor. When you select
+        any of these database objects, the editor opens automatically, allowing you to make changes
+        without switching contexts.
       </p>
       <Admonition type="note" className="my-4">
-        With the inline editor enabled, editing policies, triggers and database functions will all
-        be done using the editor.
+        Need help writing SQL? Use the inline Assistant to generate or modify code for your
+        policies, triggers, and functions without leaving the editor.
       </Admonition>
       <p className="text-sm text-foreground-light">
-        You can access the inline editor by clicking the code editor icon in the top right corner of
+        Access the inline editor anytime by clicking the code editor icon in the top right corner of
         your dashboard.
       </p>
     </div>

--- a/apps/studio/components/layouts/ProjectLayout/LayoutHeader/LayoutHeader.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/LayoutHeader/LayoutHeader.tsx
@@ -237,11 +237,9 @@ const LayoutHeader = ({
               exit={{ opacity: 0, x: 0, width: 0 }}
               transition={{ duration: 0.15, ease: 'easeOut' }}
             >
-              {isInlineEditorEnabled && (
-                <div className="border-r h-full flex items-center justify-center md:px-2">
-                  <InlineEditorButton />
-                </div>
-              )}
+              <div className="border-r h-full flex items-center justify-center md:px-2">
+                <InlineEditorButton />
+              </div>
               <div className="md:px-2">
                 <AssistantButton />
               </div>

--- a/apps/studio/components/layouts/ProjectLayout/LayoutHeader/LayoutHeader.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/LayoutHeader/LayoutHeader.tsx
@@ -224,23 +224,22 @@ const LayoutHeader = ({
       </div>
 
       <AnimatePresence initial={false}>
-        {!!projectRef &&
-          (isInlineEditorEnabled || (!isInlineEditorEnabled && !isAiAssistantOpen)) && (
-            <motion.div
-              className="border-l h-full flex items-center justify-center flex-shrink-0"
-              initial={{ opacity: 0, x: 0, width: 0 }}
-              animate={{ opacity: 1, x: 0, width: isInlineEditorEnabled ? 'auto' : 48 }}
-              exit={{ opacity: 0, x: 0, width: 0 }}
-              transition={{ duration: 0.15, ease: 'easeOut' }}
-            >
-              <div className="border-r h-full flex items-center justify-center md:px-2">
-                <InlineEditorButton />
-              </div>
-              <div className="md:px-2">
-                <AssistantButton />
-              </div>
-            </motion.div>
-          )}
+        {!!projectRef && (
+          <motion.div
+            className="border-l h-full flex items-center justify-center flex-shrink-0"
+            initial={{ opacity: 0, x: 0, width: 0 }}
+            animate={{ opacity: 1, x: 0, width: 'auto' }}
+            exit={{ opacity: 0, x: 0, width: 0 }}
+            transition={{ duration: 0.15, ease: 'easeOut' }}
+          >
+            <div className="border-r h-full flex items-center justify-center md:px-2">
+              <InlineEditorButton />
+            </div>
+            <div className="md:px-2">
+              <AssistantButton />
+            </div>
+          </motion.div>
+        )}
       </AnimatePresence>
     </header>
   )

--- a/apps/studio/components/layouts/ProjectLayout/LayoutHeader/LayoutHeader.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/LayoutHeader/LayoutHeader.tsx
@@ -3,10 +3,7 @@ import Link from 'next/link'
 import { ReactNode, useMemo } from 'react'
 
 import { useParams } from 'common'
-import {
-  useIsInlineEditorEnabled,
-  useNewLayout,
-} from 'components/interfaces/App/FeaturePreview/FeaturePreviewContext'
+import { useNewLayout } from 'components/interfaces/App/FeaturePreview/FeaturePreviewContext'
 import Connect from 'components/interfaces/Connect/Connect'
 import { ThemeDropdown } from 'components/interfaces/ThemeDropdown'
 import { UserDropdown } from 'components/interfaces/UserDropdown'
@@ -75,7 +72,6 @@ const LayoutHeader = ({
   const { setMobileMenuOpen } = useAppStateSnapshot()
 
   const { open: isAiAssistantOpen } = useAiAssistantStateSnapshot()
-  const isInlineEditorEnabled = useIsInlineEditorEnabled()
 
   const { data } = useCLIReleaseVersionQuery()
   const currentCliVersion = data?.current

--- a/apps/studio/components/ui/EditorPanel/EditorPanel.tsx
+++ b/apps/studio/components/ui/EditorPanel/EditorPanel.tsx
@@ -157,7 +157,7 @@ export const EditorPanel = ({ onChange }: EditorPanelProps) => {
 
   return (
     <div className="flex flex-col h-full bg-surface-100">
-      <div className="border-b flex shrink-0 items-center gap-x-3 px-5 h-[46px]">
+      <div className="border-b flex shrink-0 items-center gap-x-3 px-4 h-[46px]">
         <span className="text-sm flex-1">SQL Editor</span>
         <div className="flex gap-2 items-center">
           <Popover_Shadcn_ open={isTemplatesOpen} onOpenChange={setIsTemplatesOpen}>


### PR DESCRIPTION
<img width="953" alt="image" src="https://github.com/user-attachments/assets/a5f208b7-3e51-47ac-857d-42e01ff198ed" />

Removes the feature preview check for showing inline editor trigger in header. With this merged, anyone will be able to access the inline editor. The feature preview still exists for using the inline editor when creating/modifying policies/functions/triggers.