### PR TITLE
fix: Update function docs to include platform limits + remove them from pricing page

### DIFF
--- a/apps/docs/content/guides/functions/limits.mdx
+++ b/apps/docs/content/guides/functions/limits.mdx
@@ -14,7 +14,15 @@ subtitle: "Limits applied Edge Functions in Supabase's hosted platform."
   - Paid plans: 400s
 - Maximum CPU Time: 2s (Amount of actual time spent on the CPU per request - does not include async I/O.)
 - Request idle timeout: 150s (If an Edge Function doesn't send a response before the timeout, 504 Gateway Timeout will be returned)
+
+## Platform limits
+
 - Maximum Function Size: 20MB (After bundling using CLI)
+- Maximum no. of Functions per project:
+  - Free: 100
+  - Pro: 500
+  - Team: 1000
+  - Enterprise: Unlimited
 - Maximum log message length: 10,000 characters
 - Log event threshold: 100 events per 10 seconds
 

--- a/packages/shared-data/pricing.ts
+++ b/packages/shared-data/pricing.ts
@@ -488,6 +488,17 @@ export const pricing: Pricing = {
         },
         usage_based: false,
       },
+      {
+        key: 'functions.numberOfFunctions',
+        title: 'Number of functions',
+        plans: {
+          free: '100 included',
+          pro: '500 included',
+          team: '1000 included',
+          enterprise: 'Unlimited',
+        },
+        usage_based: false,
+      },
     ],
   },
   realtime: {

--- a/packages/shared-data/pricing.ts
+++ b/packages/shared-data/pricing.ts
@@ -477,28 +477,6 @@ export const pricing: Pricing = {
         },
         usage_based: true,
       },
-      {
-        key: 'functions.scriptSize',
-        title: 'Script size',
-        plans: {
-          free: '20 MB',
-          pro: '20 MB',
-          team: '20 MB',
-          enterprise: 'Custom',
-        },
-        usage_based: false,
-      },
-      {
-        key: 'functions.numberOfFunctions',
-        title: 'Number of functions',
-        plans: {
-          free: '100 included',
-          pro: '500 included',
-          team: '1000 included',
-          enterprise: 'Unlimited',
-        },
-        usage_based: false,
-      },
     ],
   },
   realtime: {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES/NO

## What kind of change does this PR introduce?

Moves no. of functions and script size to function docs from pricing page (as discussed internally)