### PR TITLE
Adjust AI assistant panel styles

### DIFF
--- a/apps/studio/components/layouts/ProjectLayout/ProjectLayout.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/ProjectLayout.tsx
@@ -233,8 +233,10 @@ const ProjectLayout = forwardRef<HTMLDivElement, PropsWithChildren<ProjectLayout
                       minSize={30}
                       maxSize={50}
                       className={cn(
-                        'border-l xl:border-l-0 bg fixed z-40 md:absolute md:z-0 right-0 top-0 md:top-[48px] bottom-0 xl:relative xl:top-0',
-                        'w-screen h-[100dvh] md:h-auto md:w-auto'
+                        'border-l bg fixed z-40 right-0 top-0 bottom-0',
+                        'w-screen h-[100dvh]',
+                        'md:absolute md:h-auto md:w-3/4',
+                        'xl:relative xl:border-l-0'
                       )}
                     >
                       {aiSnap.open ? (


### PR DESCRIPTION
## Changes
- On desktop:
![image](https://github.com/user-attachments/assets/93d5ee38-a593-455a-a5d3-0ee52ecbab57)

- At `md` (1280px): Opting for 75% width (not adjustable), overlay dashboard contents including banners
  - Fixes the odd `top` placement + width of panel changing when the panel starts from empty state to having some content:
![image](https://github.com/user-attachments/assets/66fd8883-e9c1-4823-be02-9d488b09da5c)
![image](https://github.com/user-attachments/assets/84cccc41-170d-4559-a229-b8ef33266085)

- Any smaller: No change, panel takes up full screen width
![image](https://github.com/user-attachments/assets/181cd09d-5ae6-46b0-8475-81398e3c3d87)


