### PR TITLE
fix: Suggestion Dropdown Not Triggering Issue

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/InputWithSuggestions.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/InputWithSuggestions.tsx
@@ -96,7 +96,7 @@ const InputWithSuggestions = ({
         data-testid={dataTestId}
         actions={
           showSuggestions && (
-            <DropdownMenu>
+            <DropdownMenu modal>
               <DropdownMenuTrigger asChild>
                 <ButtonTooltip
                   type="default"


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

fix column default value dropdown state

I believe this requires a hotfix. While I would prefer to conduct a thorough analysis and implement a comprehensive solution, I'm currently facing challenges in fully grasping the codebase. Therefore, I'm submitting this PR first to address the immediate issue.

## What is the current behavior?

column default value dropdown menu ui closes automatically.

I suspect this might be connected to issue #34846 

## What is the new behavior?

`<ColumnDefaultValue>` should work properly.

## Additional context

Add any other context or screenshots.

https://github.com/user-attachments/assets/115bfc95-3903-48f6-81fe-f1336529ca7c
