### PR TITLE
Update react.mdx

### DIFF
--- a/apps/docs/content/guides/auth/quickstarts/react.mdx
+++ b/apps/docs/content/guides/auth/quickstarts/react.mdx
@@ -30,10 +30,30 @@ hideToc: true
 
     <StepHikeCompact.Details title="Create a React app">
 
-    Create a React app using the `create-react-app` command.
+   Create a React app using one of the recommended methods:
 
-    </StepHikeCompact.Details>
+- **Vite**:
+  ```bash name=Terminal
+  npm create vite@latest my-app
+  cd my-app
+  npm install
+  ```
 
+- **Next.js**:
+  ```bash name=Terminal
+  npx create-next-app@latest my-app
+  cd my-app
+  npm install
+  ```
+
+- **Create React App's successor**:
+  ```bash name=Terminal
+  npx create-react-app my-app
+  cd my-app
+  npm install
+  ```
+
+</StepHikeCompact.Details>
     <StepHikeCompact.Code>
 
       ```bash name=Terminal


### PR DESCRIPTION
Description
This pull request updates the Supabase Auth documentation to replace the deprecated create-react-app command with the now officially recommended ways to start a React app from scratch. The previous documentation used create-react-app, which has been deprecated and is no longer recommended.

Changes
Updated the Supabase Auth Quickstart Guide for React to include the new recommended methods for starting a React app. Added instructions for using modern alternatives such as Vite, Next.js, and Create React App's successor. Testing
Verified that the updated instructions work as expected on a local setup. Additional Context
References:
Sunsetting Create React App
Build a React App from Scratch

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES/NO

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
