### PR TITLE
Fix compute size check in PITR side panel

### DIFF
--- a/apps/studio/components/interfaces/DiskManagement/fields/ComputeSizeField.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/fields/ComputeSizeField.tsx
@@ -274,7 +274,7 @@ export function ComputeSizeField({ form, disabled }: ComputeSizeFieldProps) {
                             {lockedMicroDueToPITR && (
                               <TooltipContent side="bottom" className="w-64 text-center">
                                 Project has PITR enabled which requires a minimum of Small compute.
-                                Please <InlineLink href="/">disable PITR</InlineLink> first before
+                                Please <InlineLink href="/project/_/settings/addons?panel=pitr">disable PITR</InlineLink> first before
                                 selecting Micro
                               </TooltipContent>
                             )}

--- a/apps/studio/components/interfaces/DiskManagement/fields/ComputeSizeField.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/fields/ComputeSizeField.tsx
@@ -274,8 +274,11 @@ export function ComputeSizeField({ form, disabled }: ComputeSizeFieldProps) {
                             {lockedMicroDueToPITR && (
                               <TooltipContent side="bottom" className="w-64 text-center">
                                 Project has PITR enabled which requires a minimum of Small compute.
-                                Please <InlineLink href="/project/_/settings/addons?panel=pitr">disable PITR</InlineLink> first before
-                                selecting Micro
+                                Please{' '}
+                                <InlineLink href="/project/_/settings/addons?panel=pitr">
+                                  disable PITR
+                                </InlineLink>{' '}
+                                first before selecting Micro
                               </TooltipContent>
                             )}
                           </Tooltip>

--- a/apps/studio/components/interfaces/DiskManagement/fields/ComputeSizeField.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/fields/ComputeSizeField.tsx
@@ -6,12 +6,23 @@ import { components } from 'api-types'
 import { useParams } from 'common'
 import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
 import { DocsButton } from 'components/ui/DocsButton'
+import { InlineLink } from 'components/ui/InlineLink'
 import { useOrgSubscriptionQuery } from 'data/subscriptions/org-subscription-query'
 import { useProjectAddonsQuery } from 'data/subscriptions/project-addons-query'
 import { useSelectedOrganization } from 'hooks/misc/useSelectedOrganization'
 import { getCloudProviderArchitecture } from 'lib/cloudprovider-utils'
 import { InstanceSpecs } from 'lib/constants'
-import { cn, FormField_Shadcn_, RadioGroupCard, RadioGroupCardItem, Skeleton } from 'ui'
+import Link from 'next/link'
+import {
+  cn,
+  FormField_Shadcn_,
+  RadioGroupCard,
+  RadioGroupCardItem,
+  Skeleton,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from 'ui'
 import { ComputeBadge } from 'ui-patterns'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import { DiskStorageSchemaType } from '../DiskManagement.schema'
@@ -24,7 +35,6 @@ import {
 import { BillingChangeBadge } from '../ui/BillingChangeBadge'
 import FormMessage from '../ui/FormMessage'
 import { NoticeBar } from '../ui/NoticeBar'
-import Link from 'next/link'
 
 /**
  * to do: this could be a type from api-types
@@ -47,28 +57,9 @@ export function ComputeSizeField({ form, disabled }: ComputeSizeFieldProps) {
   const org = useSelectedOrganization()
   const { control, formState, setValue, trigger } = form
 
-  const {
-    /**
-     * no error/isError states handled here, as a parent component handles them
-     */
-    data: subscription,
-  } = useOrgSubscriptionQuery({ orgSlug: org?.slug })
+  const { data: subscription } = useOrgSubscriptionQuery({ orgSlug: org?.slug })
 
-  const {
-    /**
-     * projectContext is used for:
-     *   - cloud provider
-     *   - infra_compute_size
-     */
-    project,
-    /**
-     * isLoading is used to avoid a useCheckPermissions() race condition
-     */
-    isLoading: isProjectLoading,
-    /**
-     * to do: there is no error/isError variables available for useProjectContext
-     */
-  } = useProjectContext()
+  const { project, isLoading: isProjectLoading } = useProjectContext()
   const {
     data: addons,
     isLoading: isAddonsLoading,
@@ -88,6 +79,8 @@ export function ComputeSizeField({ form, disabled }: ComputeSizeFieldProps) {
      */
     return getAvailableComputeOptions(availableAddons, project?.cloud_provider)
   }, [availableAddons, project?.cloud_provider])
+
+  const subscriptionPitr = addons?.selected_addons.find((addon) => addon.type === 'pitr')
 
   const computeSizePrice = calculateComputeSizePrice({
     availableOptions: availableOptions,
@@ -127,7 +120,7 @@ export function ComputeSizeField({ form, disabled }: ComputeSizeFieldProps) {
             labelOptional={
               <>
                 <BillingChangeBadge
-                  className={'mb-2'}
+                  className="mb-2"
                   show={
                     formState.isDirty &&
                     formState.dirtyFields.computeSize &&
@@ -179,10 +172,14 @@ export function ComputeSizeField({ form, disabled }: ComputeSizeFieldProps) {
                   {availableOptions.map((compute: ComputeOption) => {
                     const cpuArchitecture = getCloudProviderArchitecture(project?.cloud_provider)
 
-                    const lockedOption =
+                    const lockedMicroDueToPITR =
+                      compute.identifier === 'ci_micro' && !!subscriptionPitr
+                    const lockedNanoDueToPlan =
                       subscription?.plan.id !== 'free' &&
                       project?.infra_compute_size !== 'nano' &&
                       compute.identifier === 'ci_nano'
+
+                    const lockedOption = lockedNanoDueToPlan || lockedMicroDueToPITR
 
                     const price =
                       subscription?.plan.id !== 'free' &&
@@ -195,9 +192,9 @@ export function ComputeSizeField({ form, disabled }: ComputeSizeFieldProps) {
 
                     return (
                       <RadioGroupCardItem
+                        showIndicator={false}
                         id={compute.identifier}
                         key={compute.identifier}
-                        showIndicator={false}
                         value={compute.identifier}
                         className={cn(
                           'relative text-sm text-left flex flex-col gap-0 px-0 py-3 [&_label]:w-full group] w-full h-[110px]',
@@ -205,69 +202,83 @@ export function ComputeSizeField({ form, disabled }: ComputeSizeFieldProps) {
                         )}
                         disabled={disabled || lockedOption}
                         label={
-                          <>
-                            {showUpgradeBadge && compute.identifier === 'ci_micro' && (
-                              <div className="absolute -top-4 -right-3 text-violet-1100 flex items-center gap-1 bg-surface-75 py-0.5 px-2 rounded-full border border-violet-900">
-                                <span>No additional charge</span>
-                              </div>
-                            )}
-                            <div className="w-full flex flex-col gap-3 justify-between">
-                              <div className="relative px-3 opacity-50 group-data-[state=checked]:opacity-100 flex justify-between">
-                                <ComputeBadge
-                                  className="inline-flex font-semibold"
-                                  infraComputeSize={
-                                    compute.name as components['schemas']['DbInstanceSize']
-                                  }
-                                />
-                                <div className="flex items-center space-x-1">
-                                  {lockedOption ? (
-                                    <div className="bg border rounded-lg h-7 w-7 flex items-center justify-center">
-                                      <Lock size={14} />
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <div>
+                                {showUpgradeBadge && compute.identifier === 'ci_micro' && (
+                                  <div className="absolute -top-4 -right-3 text-violet-1100 flex items-center gap-1 bg-surface-75 py-0.5 px-2 rounded-full border border-violet-900">
+                                    <span>No additional charge</span>
+                                  </div>
+                                )}
+                                <div className="w-full flex flex-col gap-3 justify-between">
+                                  <div className="relative px-3 opacity-50 group-data-[state=checked]:opacity-100 flex justify-between">
+                                    <ComputeBadge
+                                      className="inline-flex font-semibold"
+                                      infraComputeSize={
+                                        compute.name as components['schemas']['DbInstanceSize']
+                                      }
+                                    />
+                                    <div className="flex items-center space-x-1">
+                                      {lockedOption ? (
+                                        <div className="bg border rounded-lg h-7 w-7 flex items-center justify-center">
+                                          <Lock size={14} />
+                                        </div>
+                                      ) : (
+                                        <>
+                                          <span className="text-foreground text-sm font-semibold">
+                                            ${price}
+                                          </span>
+                                          <span className="text-foreground-light translate-y-[1px]">
+                                            {' '}
+                                            /{' '}
+                                            {compute.price_interval === 'monthly'
+                                              ? 'month'
+                                              : 'hour'}
+                                          </span>
+                                        </>
+                                      )}
                                     </div>
-                                  ) : (
-                                    <>
-                                      <span className="text-foreground text-sm font-semibold">
-                                        ${price}
-                                      </span>
-                                      <span className="text-foreground-light translate-y-[1px]">
-                                        {' '}
-                                        / {compute.price_interval === 'monthly' ? 'month' : 'hour'}
-                                      </span>
-                                    </>
-                                  )}
-                                </div>
-                              </div>
+                                  </div>
 
-                              <div className="w-full">
-                                <div className="px-3 text-sm flex flex-col gap-1">
-                                  <div className="text-foreground-light flex gap-2 items-center">
-                                    <Microchip
-                                      strokeWidth={1}
-                                      size={14}
-                                      className="text-foreground-lighter"
-                                    />
-                                    <span>
-                                      {compute.identifier === 'ci_nano' && 'Up to '}
-                                      {compute.meta?.memory_gb ?? 0} GB memory
-                                    </span>
-                                  </div>
-                                  <div className="text-foreground-light flex gap-2 items-center">
-                                    <CpuIcon
-                                      strokeWidth={1}
-                                      size={14}
-                                      className="text-foreground-lighter"
-                                    />
-                                    <span>
-                                      {compute.meta?.cpu_cores ?? 0}
-                                      {compute.meta?.cpu_cores !== 'Shared' &&
-                                        `-core ${cpuArchitecture}`}{' '}
-                                      CPU
-                                    </span>
+                                  <div className="w-full">
+                                    <div className="px-3 text-sm flex flex-col gap-1">
+                                      <div className="text-foreground-light flex gap-2 items-center">
+                                        <Microchip
+                                          strokeWidth={1}
+                                          size={14}
+                                          className="text-foreground-lighter"
+                                        />
+                                        <span>
+                                          {compute.identifier === 'ci_nano' && 'Up to '}
+                                          {compute.meta?.memory_gb ?? 0} GB memory
+                                        </span>
+                                      </div>
+                                      <div className="text-foreground-light flex gap-2 items-center">
+                                        <CpuIcon
+                                          strokeWidth={1}
+                                          size={14}
+                                          className="text-foreground-lighter"
+                                        />
+                                        <span>
+                                          {compute.meta?.cpu_cores ?? 0}
+                                          {compute.meta?.cpu_cores !== 'Shared' &&
+                                            `-core ${cpuArchitecture}`}{' '}
+                                          CPU
+                                        </span>
+                                      </div>
+                                    </div>
                                   </div>
                                 </div>
                               </div>
-                            </div>
-                          </>
+                            </TooltipTrigger>
+                            {lockedMicroDueToPITR && (
+                              <TooltipContent side="bottom" className="w-64 text-center">
+                                Project has PITR enabled which requires a minimum of Small compute.
+                                Please <InlineLink href="/">disable PITR</InlineLink> first before
+                                selecting Micro
+                              </TooltipContent>
+                            )}
+                          </Tooltip>
                         }
                       />
                     )

--- a/apps/studio/components/interfaces/Settings/Addons/PITRSidePanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/PITRSidePanel.tsx
@@ -106,6 +106,8 @@ const PITRSidePanel = () => {
   const hasChanges = selectedOption !== (subscriptionPitr?.variant.identifier ?? 'pitr_0')
   const isFreePlan = subscription?.plan?.id === 'free'
   const selectedPitr = availableOptions.find((option) => option.identifier === selectedOption)
+  const hasSufficientCompute =
+    !!subscriptionCompute && subscriptionCompute.variant.identifier !== 'ci_micro'
 
   // These are illegal states. If they are true, we should block the user from saving them.
   const blockDowngradeDueToReadReplicas =
@@ -115,6 +117,16 @@ const PITRSidePanel = () => {
     (selectedCategory !== 'on' ||
       // If the project is HIPAA, we don't allow the user to downgrade below 28 days
       selectedPitr?.identifier !== 'pitr_28')
+
+  const onConfirm = async () => {
+    if (!projectRef) return console.error('Project ref is required')
+
+    if (selectedOption === 'pitr_0' && subscriptionPitr !== undefined) {
+      removeAddon({ projectRef, variant: subscriptionPitr.variant.identifier })
+    } else {
+      updateAddon({ projectRef, type: 'pitr', variant: selectedOption as AddonVariantId })
+    }
+  }
 
   useEffect(() => {
     if (visible) {
@@ -127,16 +139,6 @@ const PITRSidePanel = () => {
       }
     }
   }, [visible, isLoading])
-
-  const onConfirm = async () => {
-    if (!projectRef) return console.error('Project ref is required')
-
-    if (selectedOption === 'pitr_0' && subscriptionPitr !== undefined) {
-      removeAddon({ projectRef, variant: subscriptionPitr.variant.identifier })
-    } else {
-      updateAddon({ projectRef, type: 'pitr', variant: selectedOption as AddonVariantId })
-    }
-  }
 
   return (
     <SidePanel
@@ -305,7 +307,7 @@ const PITRSidePanel = () => {
                 >
                   Upgrade your plan to change PITR for your project
                 </Alert>
-              ) : subscriptionCompute === undefined ? (
+              ) : !hasSufficientCompute ? (
                 <Alert
                   withIcon
                   variant="warning"

--- a/apps/studio/components/interfaces/Settings/Addons/PITRSidePanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/PITRSidePanel.tsx
@@ -153,7 +153,7 @@ const PITRSidePanel = () => {
         !hasChanges ||
         isSubmitting ||
         !canUpdatePitr ||
-        !hasSufficientCompute ||
+        (!!selectedPitr && !hasSufficientCompute) ||
         blockDowngradeDueToHipaa ||
         blockDowngradeDueToReadReplicas
       }

--- a/apps/studio/components/interfaces/Settings/Addons/PITRSidePanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/PITRSidePanel.tsx
@@ -153,6 +153,7 @@ const PITRSidePanel = () => {
         !hasChanges ||
         isSubmitting ||
         !canUpdatePitr ||
+        !hasSufficientCompute ||
         blockDowngradeDueToHipaa ||
         blockDowngradeDueToReadReplicas
       }


### PR DESCRIPTION
## Context
- Enabling PITR requires project to be on a minimum Compute Size of Small
- Before the introduction of Nano size, Micro was the smallest, so we used to check for minimum compute size by `subscriptionCompute !== undefined`
- However, currently if the project is on Micro size, `subscriptionCompute` is no longer undefined, and hence the check is now incorrect

## Changes
- Fix check for minimum compute size before enabling PITR by checking for undefined, as well as checking that current compute its not micro
- Prevent downgrading to Micro if PITR is enabled

## To test
- For a project that's never changed its compute size, verify that you cannot enable PITR while you're on a Micro compute
  - e.g New project (Pro -> defaults to Micro, Free -> defaults to Nano)
- Change the project to a small, verify that you _can_ enable PITR
- Then back to micro and verify the same that you cannot enable PITR thereafter