### PR TITLE
Update delete-objects.mdx

### DIFF
--- a/apps/docs/content/guides/storage/management/delete-objects.mdx
+++ b/apps/docs/content/guides/storage/management/delete-objects.mdx
@@ -36,6 +36,15 @@ on storage.objects
 for delete
 TO authenticated
 USING (
-    owner = (select auth.uid()::text)
+owner = (select auth.uid()::text)
 );
 ```
+
+Limits:
+
+The remove method can handle up to 1000 object paths in a single call. If you need to delete more objects, consider batching your delete operations.
+
+Timing:
+
+The time taken for the delete operation can vary based on the number of objects and the server load. In a serverless context, it is recommended to batch delete operations to avoid timeouts.
+


### PR DESCRIPTION
This pull request updates the documentation to include information about the limits and timing for the `delete` operation in Supabase Storage. The previous documentation did not specify these details, which are important for developers, especially when using the operation in a serverless context.

#### Changes
- Updated the [Delete Objects Guide](https://supabase.com/docs/guides/storage/management/delete-objects) to include limits on the number of objects that can be deleted in a single call.
- Added information about the expected timing for delete operations and recommendations for batching.

#### Testing
- Verified that the updated instructions work as expected on a local setup.

#### Additional Context
N/A

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES/NO

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
