### PR TITLE
the sveltekit example /auth/confirm route is misleading (Update svelt…

### DIFF
--- a/apps/docs/content/guides/auth/server-side/sveltekit.mdx
+++ b/apps/docs/content/guides/auth/server-side/sveltekit.mdx
@@ -483,28 +483,15 @@ import type { RequestHandler } from './$types'
 export const GET: RequestHandler = async ({ url, locals: { supabase } }) => {
   const token_hash = url.searchParams.get('token_hash')
   const type = url.searchParams.get('type') as EmailOtpType | null
-  const next = url.searchParams.get('next') ?? '/'
-
-  /**
-   * Clean up the redirect URL by deleting the Auth flow parameters.
-   *
-   * `next` is preserved for now, because it's needed in the error case.
-   */
-  const redirectTo = new URL(url)
-  redirectTo.pathname = next
-  redirectTo.searchParams.delete('token_hash')
-  redirectTo.searchParams.delete('type')
 
   if (token_hash && type) {
     const { error } = await supabase.auth.verifyOtp({ type, token_hash })
     if (!error) {
-      redirectTo.searchParams.delete('next')
-      redirect(303, redirectTo)
+      redirect(303, '/')
     }
   }
 
-  redirectTo.pathname = '/auth/error'
-  redirect(303, redirectTo)
+  redirect(303, '/auth/error')
 }
 ```
 


### PR DESCRIPTION
The `?next=` parameter remains unused throughout the entire example. It also conflicts with the usage of a recovery email for resetting your password.

For example:

```html
<h2>Reset Password</h2>

<p>Follow this link to reset the password for your user:</p>
<p><a href="{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=email&next={{ .RedirectTo }}">Reset Password</a></p>
```

If the user were to try this setup for their confirmation route it would fail because the documentation at https://supabase.com/docs/reference/javascript/auth-resetpasswordforemail specifically provides this example:

```js
const { data, error } = await supabase.auth.resetPasswordForEmail(email, {
  redirectTo: 'https://example.com/update-password',
})
``` 

Which redirects the user to: https://example.com/https://example.com/update-password

I wouldn't mind adding extended documentation for password reset and others. Let me know if that is something that would be helpful :) cheers

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

Works but is inconsistent with the rest of the documentation

## What is the new behavior?

More consistent with the documentation
