### PR TITLE
Logs Previewer fix refresh

### DIFF
--- a/apps/studio/components/interfaces/Settings/Logs/LogsPreviewer.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogsPreviewer.tsx
@@ -125,8 +125,9 @@ export const LogsPreviewer = ({
   }
 
   const handleRefresh = () => {
-    // Call refresh first to ensure we get the count with current timestamps
-    setTimeRange('', '')
+    const newTimestampStart = dayjs(timestampStart).toISOString()
+    const newTimestampEnd = dayjs().toISOString()
+    setTimeRange(newTimestampStart, newTimestampEnd)
     refresh()
   }
 


### PR DESCRIPTION
- Fix refresh in logs previewer so it always updates the timestamp end on click.