### PR TITLE
Fix overflow in ResourceList

### DIFF
--- a/apps/studio/components/ui/Resource/ResourceList.tsx
+++ b/apps/studio/components/ui/Resource/ResourceList.tsx
@@ -9,7 +9,7 @@ export interface ResourceListProps extends HTMLAttributes<HTMLDivElement> {
 export const ResourceList = forwardRef<HTMLDivElement, ResourceListProps>(
   ({ children, className, ...props }, ref) => {
     return (
-      <Card ref={ref} {...props}>
+      <Card ref={ref} className="overflow-hidden" {...props}>
         <div className={className}>{children}</div>
       </Card>
     )


### PR DESCRIPTION
As per PR title, can reproduce in the Edge Functions's page empty state and Auth Providers section when you hover over the Resource Item

![image](https://github.com/user-attachments/assets/cc0b365d-bd0a-4cb4-b0b6-dc46610792af)
