### PR TITLE
fix: oauth scopes dropdown bug

### DIFF
--- a/apps/studio/components/interfaces/Organization/OAuthApps/PublishAppSidePanel/Scopes.tsx
+++ b/apps/studio/components/interfaces/Organization/OAuthApps/PublishAppSidePanel/Scopes.tsx
@@ -73,7 +73,7 @@ const Scope = ({
         <span className="text-foreground text-sm">{title}</span>
         <span className="text-foreground-light text-xs">{description}</span>
       </div>
-      <DropdownMenu>
+      <DropdownMenu modal={true}>
         <DropdownMenuTrigger asChild>
           <Button type="default" iconRight={<ChevronDown />}>
             <p>{accessDescription}</p>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

These won't open
<img width="647" alt="Screenshot 2025-04-10 at 21 14 50" src="https://github.com/user-attachments/assets/155ae9a9-6f57-48a3-9928-4bafe90af51a" />


## What is the new behavior?

They open.