### PR TITLE
ref: Fix all API types after Zod migration

### DIFF
--- a/apps/studio/components/interfaces/Database/Backups/PITR/PITR.utils.ts
+++ b/apps/studio/components/interfaces/Database/Backups/PITR/PITR.utils.ts
@@ -7,7 +7,7 @@ export const getPITRRetentionDuration = (addons: ProjectSelectedAddon[]) => {
   const pitrAddon = addons.find((addon) => addon.type === 'pitr')
   if (!pitrAddon) return 0
 
-  return pitrAddon.variant.meta?.backup_duration_days ?? 0
+  return (pitrAddon.variant.meta as any)?.backup_duration_days ?? 0
 }
 
 export const getDatesBetweenRange = (startDate: dayjs.Dayjs, endDate: dayjs.Dayjs) => {

--- a/apps/studio/components/interfaces/DiskManagement/DiskManagement.types.ts
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagement.types.ts
@@ -1,4 +1,4 @@
-import { AddonVariantId, ProjectAddonVariantMeta } from 'data/subscriptions/types'
+import { AddonVariantId } from 'data/subscriptions/types'
 
 export type ComputeInstanceAddonVariantId =
   | Extract<

--- a/apps/studio/components/interfaces/DiskManagement/fields/ComputeSizeField.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/fields/ComputeSizeField.tsx
@@ -26,7 +26,11 @@ import {
 import { ComputeBadge } from 'ui-patterns'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import { DiskStorageSchemaType } from '../DiskManagement.schema'
-import { ComputeInstanceAddonVariantId } from '../DiskManagement.types'
+import {
+  ComputeInstanceAddonVariantId,
+  ComputeInstanceSize,
+  InfraInstanceSize,
+} from '../DiskManagement.types'
 import {
   calculateComputeSizePrice,
   getAvailableComputeOptions,
@@ -214,9 +218,7 @@ export function ComputeSizeField({ form, disabled }: ComputeSizeFieldProps) {
                                   <div className="relative px-3 opacity-50 group-data-[state=checked]:opacity-100 flex justify-between">
                                     <ComputeBadge
                                       className="inline-flex font-semibold"
-                                      infraComputeSize={
-                                        compute.name as components['schemas']['DbInstanceSize']
-                                      }
+                                      infraComputeSize={compute.name as InfraInstanceSize}
                                     />
                                     <div className="flex items-center space-x-1">
                                       {lockedOption ? (

--- a/apps/studio/components/interfaces/Home/ProjectUsageSection.tsx
+++ b/apps/studio/components/interfaces/Home/ProjectUsageSection.tsx
@@ -38,7 +38,7 @@ const ProjectUsageSection = () => {
 
   // if the project has more than 25 requests, we assume the project has usage
   const hasProjectData =
-    usage?.result && usage.result.length > 0 ? usage.result[0].count > 25 : false
+    usage?.result && usage.result.length > 0 ? (usage.result[0] as any).count > 25 : false
 
   const isNewProject = dayjs(project?.inserted_at).isAfter(dayjs().subtract(2, 'day'))
 

--- a/apps/studio/components/interfaces/LogDrains/LogDrainDestinationSheetForm.tsx
+++ b/apps/studio/components/interfaces/LogDrains/LogDrainDestinationSheetForm.tsx
@@ -136,12 +136,15 @@ export function LogDrainDestinationSheetForm({
   onSubmit: (values: z.infer<typeof formSchema>) => void
   mode: 'create' | 'update'
 }) {
+  // NOTE(kamil): This used to be `any` for a long long time, but after moving to Zod,
+  // it produces a correct union type of all possible configs. Unfortunately, this type was not designed correctly
+  // and it does not include `type` inside the config itself, so it's not trivial to create `discriminatedUnion`
+  // out of it, therefore for an ease of use now, we bail to `any` until the better time come.
+  const defaultConfig = (defaultValues?.config || {}) as any
   const CREATE_DEFAULT_HEADERS = {
     'Content-Type': 'application/json',
   }
-
-  const DEFAULT_HEADERS =
-    mode === 'create' ? CREATE_DEFAULT_HEADERS : defaultValues?.config?.headers || {}
+  const DEFAULT_HEADERS = mode === 'create' ? CREATE_DEFAULT_HEADERS : defaultConfig?.headers || {}
 
   const { ref } = useParams()
   const { data: logDrains } = useLogDrainsQuery({
@@ -157,14 +160,14 @@ export function LogDrainDestinationSheetForm({
       name: defaultValues?.name || '',
       description: defaultValues?.description || '',
       type: defaultType,
-      http: defaultValues?.config?.http || 'http2',
-      gzip: mode === 'create' ? true : defaultValues?.config?.gzip || false,
+      http: defaultConfig?.http || 'http2',
+      gzip: mode === 'create' ? true : defaultConfig?.gzip || false,
       headers: DEFAULT_HEADERS,
-      url: defaultValues?.config?.url || '',
-      api_key: defaultValues?.config?.api_key || '',
-      region: defaultValues?.config?.region || '',
-      username: defaultValues?.config?.username || '',
-      password: defaultValues?.config?.password || '',
+      url: defaultConfig?.url || '',
+      api_key: defaultConfig?.api_key || '',
+      region: defaultConfig?.region || '',
+      username: defaultConfig?.username || '',
+      password: defaultConfig?.password || '',
     },
   })
 

--- a/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/DowngradeModal.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/DowngradeModal.tsx
@@ -1,4 +1,4 @@
-import { AlertOctagon, MinusCircle, PauseCircle } from 'lucide-react'
+import { MinusCircle, PauseCircle } from 'lucide-react'
 
 import type { ProjectInfo } from 'data/projects/projects-query'
 import type { OrgSubscription, ProjectAddon } from 'data/subscriptions/types'

--- a/apps/studio/components/interfaces/Settings/Addons/Addons.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/Addons.tsx
@@ -466,7 +466,7 @@ const Addons = () => {
                     <p className="text-sm text-foreground-light">Current option:</p>
                     <p>
                       {pitr !== undefined
-                        ? `Point in time recovery of ${pitr.variant.meta?.backup_duration_days} days is enabled`
+                        ? `Point in time recovery of ${(pitr.variant.meta as any)?.backup_duration_days} days is enabled`
                         : 'Point in time recovery is not enabled'}
                     </p>
                     {!sufficientPgVersion ? (

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureActivity.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureActivity.tsx
@@ -31,7 +31,7 @@ import { useProjectAddonsQuery } from 'data/subscriptions/project-addons-query'
 import { useResourceWarningsQuery } from 'data/usage/resource-warnings-query'
 import { useSelectedOrganization } from 'hooks/misc/useSelectedOrganization'
 import { useSelectedProject } from 'hooks/misc/useSelectedProject'
-import { INSTANCE_MICRO_SPECS, INSTANCE_NANO_SPECS } from 'lib/constants'
+import { INSTANCE_MICRO_SPECS, INSTANCE_NANO_SPECS, InstanceSpecs } from 'lib/constants'
 import { TIME_PERIODS_BILLING, TIME_PERIODS_REPORTS } from 'lib/constants/metrics'
 import { useDatabaseSelectorStateSnapshot } from 'state/database-selector'
 import { Admonition } from 'ui-patterns/admonition'
@@ -72,7 +72,7 @@ const InfrastructureActivity = () => {
   function getCurrentComputeInstanceSpecs() {
     if (computeInstance?.variant.meta) {
       // If user has a compute instance (called addons) return that
-      return computeInstance?.variant.meta
+      return computeInstance?.variant.meta as InstanceSpecs
     } else {
       // Otherwise, return the default specs
       return project?.infra_compute_size === 'nano' ? INSTANCE_NANO_SPECS : INSTANCE_MICRO_SPECS

--- a/apps/studio/components/ui/ComputeBadgeWrapper.tsx
+++ b/apps/studio/components/ui/ComputeBadgeWrapper.tsx
@@ -11,6 +11,7 @@ import { INSTANCE_MICRO_SPECS } from 'lib/constants'
 import { Button, HoverCard, HoverCardContent, HoverCardTrigger, Separator } from 'ui'
 import { ComputeBadge } from 'ui-patterns/ComputeBadge'
 import ShimmeringLoader from './ShimmeringLoader'
+import { InfraInstanceSize } from 'components/interfaces/DiskManagement/DiskManagement.types'
 
 const Row = ({ label, stat }: { label: string; stat: React.ReactNode | string }) => {
   return (
@@ -26,7 +27,7 @@ interface ComputeBadgeWrapperProps {
     ref?: string
     organization_slug?: string
     cloud_provider?: string
-    infra_compute_size?: components['schemas']['DbInstanceSize']
+    infra_compute_size?: InfraInstanceSize
   }
 }
 

--- a/apps/studio/data/log-drains/create-log-drain-mutation.ts
+++ b/apps/studio/data/log-drains/create-log-drain-mutation.ts
@@ -21,7 +21,7 @@ export async function createLogDrain(payload: LogDrainCreateVariables) {
       name: payload.name,
       description: payload.description,
       type: payload.type,
-      config: payload.config,
+      config: payload.config as any,
     },
   })
 

--- a/apps/studio/data/log-drains/update-log-drain-mutation.ts
+++ b/apps/studio/data/log-drains/update-log-drain-mutation.ts
@@ -25,7 +25,7 @@ export async function updateLogDrain(payload: LogDrainUpdateVariables) {
     body: {
       name: payload.name,
       description: payload.description,
-      config: payload.config,
+      config: payload.config as any,
     },
   })
 

--- a/apps/studio/data/projects/new-project.constants.ts
+++ b/apps/studio/data/projects/new-project.constants.ts
@@ -1,7 +1,18 @@
 import { components } from 'api-types'
 import { PROVIDERS } from 'lib/constants'
 
-type DesiredInstanceSize = components['schemas']['DesiredInstanceSize']
+export type DesiredInstanceSize = Exclude<
+  components['schemas']['CreateProjectBody']['desired_instance_size'],
+  undefined | 'pico' | 'nano'
+>
+export type ReleaseChannel = Exclude<
+  components['schemas']['CreateProjectBody']['release_channel'],
+  undefined
+>
+export type PostgresEngine = Exclude<
+  components['schemas']['CreateProjectBody']['postgres_engine'],
+  undefined
+>
 
 export const instanceSizeSpecs: Record<
   DesiredInstanceSize,

--- a/apps/studio/data/projects/project-create-mutation.ts
+++ b/apps/studio/data/projects/project-create-mutation.ts
@@ -7,6 +7,7 @@ import { handleError, post } from 'data/fetchers'
 import { PROVIDERS } from 'lib/constants'
 import type { ResponseError } from 'types'
 import { projectKeys } from './keys'
+import { DesiredInstanceSize, PostgresEngine, ReleaseChannel } from './new-project.constants'
 
 const WHITELIST_ERRORS = [
   'The following organization members have reached their maximum limits for the number of active free projects',
@@ -18,10 +19,6 @@ const WHITELIST_ERRORS = [
   'already exists in your organization.',
 ]
 
-export type DbInstanceSize = components['schemas']['DesiredInstanceSize']
-export type ReleaseChannel = components['schemas']['ReleaseChannel']
-export type PostgresEngine = components['schemas']['PostgresEngine']
-
 export type ProjectCreateVariables = {
   name: string
   organizationId: number
@@ -32,7 +29,7 @@ export type ProjectCreateVariables = {
   cloudProvider?: string
   authSiteUrl?: string
   customSupabaseRequest?: object
-  dbInstanceSize?: DbInstanceSize
+  dbInstanceSize?: DesiredInstanceSize
   dataApiExposedSchemas?: string[]
   dataApiUseApiSchema?: boolean
   postgresEngine?: PostgresEngine

--- a/apps/studio/data/subscriptions/types.ts
+++ b/apps/studio/data/subscriptions/types.ts
@@ -7,17 +7,17 @@ export type SubscriptionTier =
   | 'tier_team'
   | 'tier_enterprise'
 
-export type AddonVariantId = components['schemas']['AddonVariantId']
+export type AddonVariantId = components['schemas']['UpdateAddonBody']['addon_variant']
 
 export type OrgSubscription = components['schemas']['GetSubscriptionResponse']
 
-export type ProjectAddon = components['schemas']['BillingProjectAddonResponse']
+export type ProjectAddon = components['schemas']['GetSubscriptionResponse']['project_addons'][0]
 
 export type PlanId = components['schemas']['BillingPlanId']
 
 export type OrgPlan = components['schemas']['PlansResponse']['plans'][0]
 
-export type ProjectAddonType = components['schemas']['ProjectAddonType']
+export type ProjectAddonType = components['schemas']['UpdateAddonBody']['addon_type']
 
 export interface ProjectAddonVariantMeta {
   cpu_cores?: number
@@ -31,5 +31,7 @@ export interface ProjectAddonVariantMeta {
   supported_cloud_providers?: string[]
 }
 
-export type ProjectSelectedAddon = components['schemas']['SelectedAddonResponse']
-export type ProjectAvailableAddon = components['schemas']['AvailableAddonResponse']
+export type ProjectSelectedAddon =
+  components['schemas']['ProjectAddonsResponse']['selected_addons'][0]
+export type ProjectAvailableAddon =
+  components['schemas']['ProjectAddonsResponse']['available_addons'][0]

--- a/apps/studio/pages/new/[slug].tsx
+++ b/apps/studio/pages/new/[slug].tsx
@@ -10,7 +10,6 @@ import { toast } from 'sonner'
 import { z } from 'zod'
 
 import { PopoverSeparator } from '@ui/components/shadcn/ui/popover'
-import { components } from 'api-types'
 import { useParams } from 'common'
 import {
   FreeProjectLimitWarning,
@@ -36,9 +35,8 @@ import { useOverdueInvoicesQuery } from 'data/invoices/invoices-overdue-query'
 import { useDefaultRegionQuery } from 'data/misc/get-default-region-query'
 import { useFreeProjectLimitCheckQuery } from 'data/organizations/free-project-limit-check-query'
 import { useOrganizationsQuery } from 'data/organizations/organizations-query'
-import { instanceSizeSpecs } from 'data/projects/new-project.constants'
+import { DesiredInstanceSize, instanceSizeSpecs } from 'data/projects/new-project.constants'
 import {
-  DbInstanceSize,
   ProjectCreateVariables,
   useProjectCreateMutation,
 } from 'data/projects/project-create-mutation'
@@ -86,8 +84,6 @@ import { Input } from 'ui-patterns/DataInputs/Input'
 import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import { InfoTooltip } from 'ui-patterns/info-tooltip'
-
-type DesiredInstanceSize = components['schemas']['DesiredInstanceSize']
 
 const sizes: DesiredInstanceSize[] = [
   'micro',
@@ -411,7 +407,7 @@ const Wizard: NextPageWithLayout = () => {
   const availableComputeCredits = organizationProjects.length === 0 ? 10 : 0
 
   const additionalMonthlySpend =
-    instanceSizeSpecs[instanceSize as DbInstanceSize]!.priceMonthly - availableComputeCredits
+    instanceSizeSpecs[instanceSize as DesiredInstanceSize]!.priceMonthly - availableComputeCredits
 
   // TODO: Remove this after project creation experiment as it delays rendering
   if (
@@ -677,7 +673,7 @@ const Wizard: NextPageWithLayout = () => {
                                   <span className="text-foreground-lighter line-through">
                                     $
                                     {
-                                      instanceSizeSpecs[instanceSize as DbInstanceSize]!
+                                      instanceSizeSpecs[instanceSize as DesiredInstanceSize]!
                                         .priceMonthly
                                     }
                                   </span>
@@ -997,11 +993,11 @@ const Wizard: NextPageWithLayout = () => {
  * Needs to be in the API in the future [kevin]
  */
 const monthlyInstancePrice = (instance: string | undefined): number => {
-  return instanceSizeSpecs[instance as DbInstanceSize]?.priceMonthly || 10
+  return instanceSizeSpecs[instance as DesiredInstanceSize]?.priceMonthly || 10
 }
 
 const instanceLabel = (instance: string | undefined): string => {
-  return instanceSizeSpecs[instance as DbInstanceSize]?.label || 'Micro'
+  return instanceSizeSpecs[instance as DesiredInstanceSize]?.label || 'Micro'
 }
 
 const PageLayout = withAuth(({ children }: PropsWithChildren) => {

--- a/apps/studio/pages/new/v2/[slug].tsx
+++ b/apps/studio/pages/new/v2/[slug].tsx
@@ -1,6 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
-import { components } from 'api-types'
 import { useParams } from 'common'
 import { AnimatePresence, motion } from 'framer-motion'
 import { debounce } from 'lodash'
@@ -41,9 +40,8 @@ import { useOverdueInvoicesQuery } from 'data/invoices/invoices-overdue-query'
 import { useDefaultRegionQuery } from 'data/misc/get-default-region-query'
 import { useFreeProjectLimitCheckQuery } from 'data/organizations/free-project-limit-check-query'
 import { useOrganizationsQuery } from 'data/organizations/organizations-query'
-import { instanceSizeSpecs } from 'data/projects/new-project.constants'
+import { DesiredInstanceSize, instanceSizeSpecs } from 'data/projects/new-project.constants'
 import {
-  DbInstanceSize,
   ProjectCreateVariables,
   useProjectCreateMutation,
 } from 'data/projects/project-create-mutation'
@@ -93,8 +91,6 @@ import { Admonition } from 'ui-patterns/admonition'
 import { Input } from 'ui-patterns/DataInputs/Input'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import { InfoTooltip } from 'ui-patterns/info-tooltip'
-
-type DesiredInstanceSize = components['schemas']['DesiredInstanceSize']
 
 const sizes: DesiredInstanceSize[] = [
   'micro',
@@ -420,7 +416,7 @@ const WizardForm = () => {
   const availableComputeCredits = organizationProjects.length === 0 ? 10 : 0
 
   const additionalMonthlySpend =
-    instanceSizeSpecs[instanceSize as DbInstanceSize]!.priceMonthly - availableComputeCredits
+    instanceSizeSpecs[instanceSize as DesiredInstanceSize]!.priceMonthly - availableComputeCredits
 
   const selectedRegionObject = useMemo((): {
     name: string
@@ -910,8 +906,9 @@ const WizardForm = () => {
                                               <span className="text-foreground-lighter line-through">
                                                 $
                                                 {
-                                                  instanceSizeSpecs[instanceSize as DbInstanceSize]!
-                                                    .priceMonthly
+                                                  instanceSizeSpecs[
+                                                    instanceSize as DesiredInstanceSize
+                                                  ]!.priceMonthly
                                                 }
                                               </span>
                                               <span>${additionalMonthlySpend}</span>
@@ -1242,11 +1239,11 @@ const WizardForm = () => {
  * Needs to be in the API in the future [kevin]
  */
 const monthlyInstancePrice = (instance: string | undefined): number => {
-  return instanceSizeSpecs[instance as DbInstanceSize]?.priceMonthly || 10
+  return instanceSizeSpecs[instance as DesiredInstanceSize]?.priceMonthly || 10
 }
 
 const instanceLabel = (instance: string | undefined): string => {
-  return instanceSizeSpecs[instance as DbInstanceSize]?.label || 'Micro'
+  return instanceSizeSpecs[instance as DesiredInstanceSize]?.label || 'Micro'
 }
 
 const Wizard: NextPageWithLayout = () => {

--- a/packages/api-types/types/api.d.ts
+++ b/packages/api-types/types/api.d.ts
@@ -244,7 +244,15 @@ export interface paths {
       path?: never
       cookie?: never
     }
-    /** Gets project's logs */
+    /**
+     * Gets project's logs
+     * @description Executes a SQL query on the project's logs.
+     *
+     *     Either the 'iso_timestamp_start' and 'iso_timestamp_end' parameters must be provided.
+     *     If both are not provided, only the last 1 minute of logs will be queried.
+     *     The timestamp range must be no more than 24 hours and is rounded to the nearest minute. If the range is more than 24 hours, a validation error will be thrown.
+     *
+     */
     get: operations['getLogs']
     put?: never
     post?: never
@@ -1344,17 +1352,6 @@ export interface components {
         | ('pitr_7' | 'pitr_14' | 'pitr_28')
         | 'ipv4_default'
     }
-    AttributeMapping: {
-      keys: {
-        [key: string]: components['schemas']['AttributeValue']
-      }
-    }
-    AttributeValue: {
-      array?: boolean
-      default?: Record<string, never> | number | string | boolean
-      name?: string
-      names?: string[]
-    }
     AuthConfigResponse: {
       api_max_request_duration: number | null
       db_max_pool_size: number | null
@@ -1527,10 +1524,6 @@ export interface components {
       smtp_user: string | null
       uri_allow_list: string | null
     }
-    AuthHealthResponse: {
-      /** @enum {string} */
-      name: 'GoTrue'
-    }
     /** @enum {string} */
     BillingPlanId: 'free' | 'pro' | 'team' | 'enterprise'
     BranchActionBody: {
@@ -1628,12 +1621,6 @@ export interface components {
         version: number
       }[]
     }
-    CfResponse: {
-      errors: Record<string, never>[]
-      messages: Record<string, never>[]
-      result: components['schemas']['CustomHostnameDetails']
-      success: boolean
-    }
     CreateApiKeyBody: {
       description?: string | null
       secret_jwt_template?: {
@@ -1679,7 +1666,16 @@ export interface components {
       name: string
     }
     CreateProviderBody: {
-      attribute_mapping?: components['schemas']['AttributeMapping']
+      attribute_mapping?: {
+        keys: {
+          [key: string]: {
+            array?: boolean
+            default?: Record<string, never> | number | string | boolean
+            name?: string
+            names?: string[]
+          }
+        }
+      }
       domains?: string[]
       metadata_url?: string
       metadata_xml?: string
@@ -1691,9 +1687,29 @@ export interface components {
     }
     CreateProviderResponse: {
       created_at?: string
-      domains?: components['schemas']['Domain'][]
+      domains?: {
+        created_at?: string
+        domain?: string
+        id: string
+        updated_at?: string
+      }[]
       id: string
-      saml?: components['schemas']['SamlDescriptor']
+      saml?: {
+        attribute_mapping?: {
+          keys: {
+            [key: string]: {
+              array?: boolean
+              default?: Record<string, never> | number | string | boolean
+              name?: string
+              names?: string[]
+            }
+          }
+        }
+        entity_id: string
+        id: string
+        metadata_url?: string
+        metadata_xml?: string
+      }
       updated_at?: string
     }
     CreateSecretBody: {
@@ -1714,15 +1730,6 @@ export interface components {
       custom_jwks?: unknown
       jwks_url?: string
       oidc_issuer_url?: string
-    }
-    CustomHostnameDetails: {
-      custom_origin_server: string
-      hostname: string
-      id: string
-      ownership_verification: components['schemas']['OwnershipVerification']
-      ssl: components['schemas']['SslValidation']
-      status: string
-      verification_errors?: string[]
     }
     DatabaseUpgradeStatusResponse: {
       databaseUpgradeStatus: {
@@ -1758,9 +1765,29 @@ export interface components {
     }
     DeleteProviderResponse: {
       created_at?: string
-      domains?: components['schemas']['Domain'][]
+      domains?: {
+        created_at?: string
+        domain?: string
+        id: string
+        updated_at?: string
+      }[]
       id: string
-      saml?: components['schemas']['SamlDescriptor']
+      saml?: {
+        attribute_mapping?: {
+          keys: {
+            [key: string]: {
+              array?: boolean
+              default?: Record<string, never> | number | string | boolean
+              name?: string
+              names?: string[]
+            }
+          }
+        }
+        entity_id: string
+        id: string
+        metadata_url?: string
+        metadata_xml?: string
+      }
       updated_at?: string
     }
     DeployFunctionResponse: {
@@ -1776,12 +1803,6 @@ export interface components {
       updated_at?: number
       verify_jwt?: boolean
       version: number
-    }
-    Domain: {
-      created_at?: string
-      domain?: string
-      id: string
-      updated_at?: string
     }
     FunctionDeployBody: {
       file?: string[]
@@ -1838,9 +1859,29 @@ export interface components {
     }
     GetProviderResponse: {
       created_at?: string
-      domains?: components['schemas']['Domain'][]
+      domains?: {
+        created_at?: string
+        domain?: string
+        id: string
+        updated_at?: string
+      }[]
       id: string
-      saml?: components['schemas']['SamlDescriptor']
+      saml?: {
+        attribute_mapping?: {
+          keys: {
+            [key: string]: {
+              array?: boolean
+              default?: Record<string, never> | number | string | boolean
+              name?: string
+              names?: string[]
+            }
+          }
+        }
+        entity_id: string
+        id: string
+        metadata_url?: string
+        metadata_xml?: string
+      }
       updated_at?: string
     }
     ListProjectAddonsResponseDto: {
@@ -1875,9 +1916,8 @@ export interface components {
             | 'auth_mfa_phone_default'
             | 'auth_mfa_web_authn_default'
             | 'log_drain_default'
-          meta?: {
-            [key: string]: number | boolean | string | string[]
-          }
+          /** @description Any JSON-serializable value */
+          meta?: unknown
           name: string
           price: {
             amount: number
@@ -1919,9 +1959,8 @@ export interface components {
             | 'auth_mfa_phone_default'
             | 'auth_mfa_web_authn_default'
             | 'log_drain_default'
-          meta?: {
-            [key: string]: number | boolean | string | string[]
-          }
+          /** @description Any JSON-serializable value */
+          meta?: unknown
           name: string
           price: {
             amount: number
@@ -1935,7 +1974,33 @@ export interface components {
       }[]
     }
     ListProvidersResponse: {
-      items: components['schemas']['Provider'][]
+      items: {
+        created_at?: string
+        domains?: {
+          created_at?: string
+          domain?: string
+          id: string
+          updated_at?: string
+        }[]
+        id: string
+        saml?: {
+          attribute_mapping?: {
+            keys: {
+              [key: string]: {
+                array?: boolean
+                default?: Record<string, never> | number | string | boolean
+                name?: string
+                names?: string[]
+              }
+            }
+          }
+          entity_id: string
+          id: string
+          metadata_url?: string
+          metadata_xml?: string
+        }
+        updated_at?: string
+      }[]
     }
     NetworkBanResponse: {
       banned_ipv4_addresses: string[]
@@ -1987,11 +2052,6 @@ export interface components {
     OrganizationResponseV1: {
       id: string
       name: string
-    }
-    OwnershipVerification: {
-      name: string
-      type: string
-      value: string
     }
     PgsodiumConfigResponse: {
       root_key: string
@@ -2064,20 +2124,10 @@ export interface components {
     ProjectUpgradeInitiateResponse: {
       tracking_id: string
     }
-    Provider: {
-      created_at?: string
-      domains?: components['schemas']['Domain'][]
-      id: string
-      saml?: components['schemas']['SamlDescriptor']
-      updated_at?: string
-    }
     ReadOnlyStatusResponse: {
       enabled: boolean
       override_active_until: string
       override_enabled: boolean
-    }
-    RealtimeHealthResponse: {
-      connected_cluster: number
     }
     /** @enum {string} */
     ReleaseChannel: 'internal' | 'alpha' | 'beta' | 'ga' | 'withdrawn' | 'preview'
@@ -2088,13 +2138,6 @@ export interface components {
       database_identifier: string
     }
     RestoreProjectBodyDto: Record<string, never>
-    SamlDescriptor: {
-      attribute_mapping?: components['schemas']['AttributeMapping']
-      entity_id: string
-      id: string
-      metadata_url?: string
-      metadata_xml?: string
-    }
     SecretResponse: {
       name: string
       updated_at?: string
@@ -2213,11 +2256,6 @@ export interface components {
         database: boolean
       }
     }
-    SslValidation: {
-      status: string
-      validation_errors?: components['schemas']['ValidationError'][]
-      validation_records: components['schemas']['ValidationRecord'][]
-    }
     StorageConfigResponse: {
       features: {
         imageTransformation: {
@@ -2271,180 +2309,184 @@ export interface components {
       } | null
     }
     UpdateAuthConfigBody: {
-      api_max_request_duration?: number
-      db_max_pool_size?: number
-      disable_signup?: boolean
-      external_anonymous_users_enabled?: boolean
-      external_apple_additional_client_ids?: string
-      external_apple_client_id?: string
-      external_apple_enabled?: boolean
-      external_apple_secret?: string
-      external_azure_client_id?: string
-      external_azure_enabled?: boolean
-      external_azure_secret?: string
-      external_azure_url?: string
-      external_bitbucket_client_id?: string
-      external_bitbucket_enabled?: boolean
-      external_bitbucket_secret?: string
-      external_discord_client_id?: string
-      external_discord_enabled?: boolean
-      external_discord_secret?: string
-      external_email_enabled?: boolean
-      external_facebook_client_id?: string
-      external_facebook_enabled?: boolean
-      external_facebook_secret?: string
-      external_figma_client_id?: string
-      external_figma_enabled?: boolean
-      external_figma_secret?: string
-      external_github_client_id?: string
-      external_github_enabled?: boolean
-      external_github_secret?: string
-      external_gitlab_client_id?: string
-      external_gitlab_enabled?: boolean
-      external_gitlab_secret?: string
-      external_gitlab_url?: string
-      external_google_additional_client_ids?: string
-      external_google_client_id?: string
-      external_google_enabled?: boolean
-      external_google_secret?: string
-      external_google_skip_nonce_check?: boolean
-      external_kakao_client_id?: string
-      external_kakao_enabled?: boolean
-      external_kakao_secret?: string
-      external_keycloak_client_id?: string
-      external_keycloak_enabled?: boolean
-      external_keycloak_secret?: string
-      external_keycloak_url?: string
-      external_linkedin_oidc_client_id?: string
-      external_linkedin_oidc_enabled?: boolean
-      external_linkedin_oidc_secret?: string
-      external_notion_client_id?: string
-      external_notion_enabled?: boolean
-      external_notion_secret?: string
-      external_phone_enabled?: boolean
-      external_slack_client_id?: string
-      external_slack_enabled?: boolean
-      external_slack_oidc_client_id?: string
-      external_slack_oidc_enabled?: boolean
-      external_slack_oidc_secret?: string
-      external_slack_secret?: string
-      external_spotify_client_id?: string
-      external_spotify_enabled?: boolean
-      external_spotify_secret?: string
-      external_twitch_client_id?: string
-      external_twitch_enabled?: boolean
-      external_twitch_secret?: string
-      external_twitter_client_id?: string
-      external_twitter_enabled?: boolean
-      external_twitter_secret?: string
-      external_workos_client_id?: string
-      external_workos_enabled?: boolean
-      external_workos_secret?: string
-      external_workos_url?: string
-      external_zoom_client_id?: string
-      external_zoom_enabled?: boolean
-      external_zoom_secret?: string
-      hook_custom_access_token_enabled?: boolean
-      hook_custom_access_token_secrets?: string
-      hook_custom_access_token_uri?: string
-      hook_mfa_verification_attempt_enabled?: boolean
-      hook_mfa_verification_attempt_secrets?: string
-      hook_mfa_verification_attempt_uri?: string
-      hook_password_verification_attempt_enabled?: boolean
-      hook_password_verification_attempt_secrets?: string
-      hook_password_verification_attempt_uri?: string
-      hook_send_email_enabled?: boolean
-      hook_send_email_secrets?: string
-      hook_send_email_uri?: string
-      hook_send_sms_enabled?: boolean
-      hook_send_sms_secrets?: string
-      hook_send_sms_uri?: string
-      jwt_exp?: number
-      mailer_allow_unverified_email_sign_ins?: boolean
-      mailer_autoconfirm?: boolean
+      api_max_request_duration?: number | null
+      db_max_pool_size?: number | null
+      disable_signup?: boolean | null
+      external_anonymous_users_enabled?: boolean | null
+      external_apple_additional_client_ids?: string | null
+      external_apple_client_id?: string | null
+      external_apple_enabled?: boolean | null
+      external_apple_secret?: string | null
+      external_azure_client_id?: string | null
+      external_azure_enabled?: boolean | null
+      external_azure_secret?: string | null
+      external_azure_url?: string | null
+      external_bitbucket_client_id?: string | null
+      external_bitbucket_enabled?: boolean | null
+      external_bitbucket_secret?: string | null
+      external_discord_client_id?: string | null
+      external_discord_enabled?: boolean | null
+      external_discord_secret?: string | null
+      external_email_enabled?: boolean | null
+      external_facebook_client_id?: string | null
+      external_facebook_enabled?: boolean | null
+      external_facebook_secret?: string | null
+      external_figma_client_id?: string | null
+      external_figma_enabled?: boolean | null
+      external_figma_secret?: string | null
+      external_github_client_id?: string | null
+      external_github_enabled?: boolean | null
+      external_github_secret?: string | null
+      external_gitlab_client_id?: string | null
+      external_gitlab_enabled?: boolean | null
+      external_gitlab_secret?: string | null
+      external_gitlab_url?: string | null
+      external_google_additional_client_ids?: string | null
+      external_google_client_id?: string | null
+      external_google_enabled?: boolean | null
+      external_google_secret?: string | null
+      external_google_skip_nonce_check?: boolean | null
+      external_kakao_client_id?: string | null
+      external_kakao_enabled?: boolean | null
+      external_kakao_secret?: string | null
+      external_keycloak_client_id?: string | null
+      external_keycloak_enabled?: boolean | null
+      external_keycloak_secret?: string | null
+      external_keycloak_url?: string | null
+      external_linkedin_oidc_client_id?: string | null
+      external_linkedin_oidc_enabled?: boolean | null
+      external_linkedin_oidc_secret?: string | null
+      external_notion_client_id?: string | null
+      external_notion_enabled?: boolean | null
+      external_notion_secret?: string | null
+      external_phone_enabled?: boolean | null
+      external_slack_client_id?: string | null
+      external_slack_enabled?: boolean | null
+      external_slack_oidc_client_id?: string | null
+      external_slack_oidc_enabled?: boolean | null
+      external_slack_oidc_secret?: string | null
+      external_slack_secret?: string | null
+      external_spotify_client_id?: string | null
+      external_spotify_enabled?: boolean | null
+      external_spotify_secret?: string | null
+      external_twitch_client_id?: string | null
+      external_twitch_enabled?: boolean | null
+      external_twitch_secret?: string | null
+      external_twitter_client_id?: string | null
+      external_twitter_enabled?: boolean | null
+      external_twitter_secret?: string | null
+      external_workos_client_id?: string | null
+      external_workos_enabled?: boolean | null
+      external_workos_secret?: string | null
+      external_workos_url?: string | null
+      external_zoom_client_id?: string | null
+      external_zoom_enabled?: boolean | null
+      external_zoom_secret?: string | null
+      hook_custom_access_token_enabled?: boolean | null
+      hook_custom_access_token_secrets?: string | null
+      hook_custom_access_token_uri?: string | null
+      hook_mfa_verification_attempt_enabled?: boolean | null
+      hook_mfa_verification_attempt_secrets?: string | null
+      hook_mfa_verification_attempt_uri?: string | null
+      hook_password_verification_attempt_enabled?: boolean | null
+      hook_password_verification_attempt_secrets?: string | null
+      hook_password_verification_attempt_uri?: string | null
+      hook_send_email_enabled?: boolean | null
+      hook_send_email_secrets?: string | null
+      hook_send_email_uri?: string | null
+      hook_send_sms_enabled?: boolean | null
+      hook_send_sms_secrets?: string | null
+      hook_send_sms_uri?: string | null
+      jwt_exp?: number | null
+      mailer_allow_unverified_email_sign_ins?: boolean | null
+      mailer_autoconfirm?: boolean | null
       mailer_otp_exp?: number
-      mailer_otp_length?: number
-      mailer_secure_email_change_enabled?: boolean
-      mailer_subjects_confirmation?: string
-      mailer_subjects_email_change?: string
-      mailer_subjects_invite?: string
-      mailer_subjects_magic_link?: string
-      mailer_subjects_reauthentication?: string
-      mailer_subjects_recovery?: string
-      mailer_templates_confirmation_content?: string
-      mailer_templates_email_change_content?: string
-      mailer_templates_invite_content?: string
-      mailer_templates_magic_link_content?: string
-      mailer_templates_reauthentication_content?: string
-      mailer_templates_recovery_content?: string
-      mfa_max_enrolled_factors?: number
-      mfa_phone_enroll_enabled?: boolean
-      mfa_phone_max_frequency?: number
-      mfa_phone_otp_length?: number
-      mfa_phone_template?: string
-      mfa_phone_verify_enabled?: boolean
-      mfa_totp_enroll_enabled?: boolean
-      mfa_totp_verify_enabled?: boolean
-      mfa_web_authn_enroll_enabled?: boolean
-      mfa_web_authn_verify_enabled?: boolean
-      password_hibp_enabled?: boolean
-      password_min_length?: number
-      /** @enum {string} */
+      mailer_otp_length?: number | null
+      mailer_secure_email_change_enabled?: boolean | null
+      mailer_subjects_confirmation?: string | null
+      mailer_subjects_email_change?: string | null
+      mailer_subjects_invite?: string | null
+      mailer_subjects_magic_link?: string | null
+      mailer_subjects_reauthentication?: string | null
+      mailer_subjects_recovery?: string | null
+      mailer_templates_confirmation_content?: string | null
+      mailer_templates_email_change_content?: string | null
+      mailer_templates_invite_content?: string | null
+      mailer_templates_magic_link_content?: string | null
+      mailer_templates_reauthentication_content?: string | null
+      mailer_templates_recovery_content?: string | null
+      mfa_max_enrolled_factors?: number | null
+      mfa_phone_enroll_enabled?: boolean | null
+      mfa_phone_max_frequency?: number | null
+      mfa_phone_otp_length?: number | null
+      mfa_phone_template?: string | null
+      mfa_phone_verify_enabled?: boolean | null
+      mfa_totp_enroll_enabled?: boolean | null
+      mfa_totp_verify_enabled?: boolean | null
+      mfa_web_authn_enroll_enabled?: boolean | null
+      mfa_web_authn_verify_enabled?: boolean | null
+      password_hibp_enabled?: boolean | null
+      password_min_length?: number | null
+      /** @enum {string|null} */
       password_required_characters?:
         | 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ:0123456789'
         | 'abcdefghijklmnopqrstuvwxyz:ABCDEFGHIJKLMNOPQRSTUVWXYZ:0123456789'
         | 'abcdefghijklmnopqrstuvwxyz:ABCDEFGHIJKLMNOPQRSTUVWXYZ:0123456789:!@#$%^&*()_+-=[]{};\'\\\\:"|<>?,./`~'
         | ''
-      rate_limit_anonymous_users?: number
-      rate_limit_email_sent?: number
-      rate_limit_otp?: number
-      rate_limit_sms_sent?: number
-      rate_limit_token_refresh?: number
-      rate_limit_verify?: number
-      refresh_token_rotation_enabled?: boolean
-      saml_enabled?: boolean
-      saml_external_url?: string
-      security_captcha_enabled?: boolean
-      security_captcha_provider?: string
-      security_captcha_secret?: string
-      security_manual_linking_enabled?: boolean
-      security_refresh_token_reuse_interval?: number
-      security_update_password_require_reauthentication?: boolean
-      sessions_inactivity_timeout?: number
-      sessions_single_per_user?: boolean
-      sessions_tags?: string
-      sessions_timebox?: number
-      site_url?: string
-      sms_autoconfirm?: boolean
-      sms_max_frequency?: number
-      sms_messagebird_access_key?: string
-      sms_messagebird_originator?: string
-      sms_otp_exp?: number
+        | null
+      rate_limit_anonymous_users?: number | null
+      rate_limit_email_sent?: number | null
+      rate_limit_otp?: number | null
+      rate_limit_sms_sent?: number | null
+      rate_limit_token_refresh?: number | null
+      rate_limit_verify?: number | null
+      refresh_token_rotation_enabled?: boolean | null
+      saml_enabled?: boolean | null
+      saml_external_url?: string | null
+      security_captcha_enabled?: boolean | null
+      /** @enum {string|null} */
+      security_captcha_provider?: 'turnstile' | 'hcaptcha' | null
+      security_captcha_secret?: string | null
+      security_manual_linking_enabled?: boolean | null
+      security_refresh_token_reuse_interval?: number | null
+      security_update_password_require_reauthentication?: boolean | null
+      sessions_inactivity_timeout?: number | null
+      sessions_single_per_user?: boolean | null
+      sessions_tags?: string | null
+      sessions_timebox?: number | null
+      site_url?: string | null
+      sms_autoconfirm?: boolean | null
+      sms_max_frequency?: number | null
+      sms_messagebird_access_key?: string | null
+      sms_messagebird_originator?: string | null
+      sms_otp_exp?: number | null
       sms_otp_length?: number
-      sms_provider?: string
-      sms_template?: string
-      sms_test_otp?: string
-      sms_test_otp_valid_until?: string
-      sms_textlocal_api_key?: string
-      sms_textlocal_sender?: string
-      sms_twilio_account_sid?: string
-      sms_twilio_auth_token?: string
-      sms_twilio_content_sid?: string
-      sms_twilio_message_service_sid?: string
-      sms_twilio_verify_account_sid?: string
-      sms_twilio_verify_auth_token?: string
-      sms_twilio_verify_message_service_sid?: string
-      sms_vonage_api_key?: string
-      sms_vonage_api_secret?: string
-      sms_vonage_from?: string
-      smtp_admin_email?: string
-      smtp_host?: string
-      smtp_max_frequency?: number
-      smtp_pass?: string
-      smtp_port?: string
-      smtp_sender_name?: string
-      smtp_user?: string
-      uri_allow_list?: string
+      /** @enum {string|null} */
+      sms_provider?: 'messagebird' | 'textlocal' | 'twilio' | 'twilio_verify' | 'vonage' | null
+      sms_template?: string | null
+      sms_test_otp?: string | null
+      /** Format: date-time */
+      sms_test_otp_valid_until?: string | null
+      sms_textlocal_api_key?: string | null
+      sms_textlocal_sender?: string | null
+      sms_twilio_account_sid?: string | null
+      sms_twilio_auth_token?: string | null
+      sms_twilio_content_sid?: string | null
+      sms_twilio_message_service_sid?: string | null
+      sms_twilio_verify_account_sid?: string | null
+      sms_twilio_verify_auth_token?: string | null
+      sms_twilio_verify_message_service_sid?: string | null
+      sms_vonage_api_key?: string | null
+      sms_vonage_api_secret?: string | null
+      sms_vonage_from?: string | null
+      smtp_admin_email?: string | null
+      smtp_host?: string | null
+      smtp_max_frequency?: number | null
+      smtp_pass?: string | null
+      smtp_port?: string | null
+      smtp_sender_name?: string | null
+      smtp_user?: string | null
+      uri_allow_list?: string | null
     }
     UpdateBranchBody: {
       branch_name?: string
@@ -2469,7 +2511,33 @@ export interface components {
     }
     UpdateCustomHostnameResponse: {
       custom_hostname: string
-      data: components['schemas']['CfResponse']
+      data: {
+        errors: unknown[]
+        messages: unknown[]
+        result: {
+          custom_origin_server: string
+          hostname: string
+          id: string
+          ownership_verification: {
+            name: string
+            type: string
+            value: string
+          }
+          ssl: {
+            status: string
+            validation_errors?: {
+              message: string
+            }[]
+            validation_records: {
+              txt_name: string
+              txt_value: string
+            }[]
+          }
+          status: string
+          verification_errors?: string[]
+        }
+        success: boolean
+      }
       /** @enum {string} */
       status:
         | '1_not_started'
@@ -2509,16 +2577,45 @@ export interface components {
       work_mem?: string
     }
     UpdateProviderBody: {
-      attribute_mapping?: components['schemas']['AttributeMapping']
+      attribute_mapping?: {
+        keys: {
+          [key: string]: {
+            array?: boolean
+            default?: Record<string, never> | number | string | boolean
+            name?: string
+            names?: string[]
+          }
+        }
+      }
       domains?: string[]
       metadata_url?: string
       metadata_xml?: string
     }
     UpdateProviderResponse: {
       created_at?: string
-      domains?: components['schemas']['Domain'][]
+      domains?: {
+        created_at?: string
+        domain?: string
+        id: string
+        updated_at?: string
+      }[]
       id: string
-      saml?: components['schemas']['SamlDescriptor']
+      saml?: {
+        attribute_mapping?: {
+          keys: {
+            [key: string]: {
+              array?: boolean
+              default?: Record<string, never> | number | string | boolean
+              name?: string
+              names?: string[]
+            }
+          }
+        }
+        entity_id: string
+        id: string
+        metadata_url?: string
+        metadata_xml?: string
+      }
       updated_at?: string
     }
     UpdateSigningKeyBody: {
@@ -2555,20 +2652,20 @@ export interface components {
     }
     V1AnalyticsResponse: {
       error?:
-        | {
-            code?: number
-            errors?: {
-              domain?: string
-              location?: string
-              locationType?: string
-              message?: string
-              reason?: string
-            }[]
-            message?: string
-            status?: string
-          }
         | string
-      result?: Record<string, never>[]
+        | {
+            code: number
+            errors: {
+              domain: string
+              location: string
+              locationType: string
+              message: string
+              reason: string
+            }[]
+            message: string
+            status: string
+          }
+      result?: unknown[]
     }
     V1Backup: {
       inserted_at: string
@@ -2791,8 +2888,17 @@ export interface components {
       error?: string
       healthy: boolean
       info?:
-        | components['schemas']['AuthHealthResponse']
-        | components['schemas']['RealtimeHealthResponse']
+        | {
+            description: string
+            /** @enum {string} */
+            name: 'GoTrue'
+            version: string
+          }
+        | {
+            connected_cluster: number
+            db_connected: boolean
+            healthy: boolean
+          }
       /** @enum {string} */
       name: 'auth' | 'db' | 'pooler' | 'realtime' | 'rest' | 'storage'
       /** @enum {string} */
@@ -2816,13 +2922,6 @@ export interface components {
       db_pool?: number
       db_schema?: string
       max_rows?: number
-    }
-    ValidationError: {
-      message: string
-    }
-    ValidationRecord: {
-      txt_name: string
-      txt_value: string
     }
     VanitySubdomainBody: {
       vanity_subdomain: string
@@ -3722,7 +3821,6 @@ export interface operations {
       query?: never
       header?: never
       path: {
-        /** @description Project ref */
         ref: string
       }
       cookie?: never
@@ -3757,7 +3855,6 @@ export interface operations {
       query?: never
       header?: never
       path: {
-        /** @description Project ref */
         ref: string
       }
       cookie?: never
@@ -3943,7 +4040,6 @@ export interface operations {
       query?: never
       header?: never
       path: {
-        /** @description Project ref */
         ref: string
       }
       cookie?: never
@@ -3978,7 +4074,6 @@ export interface operations {
       query?: never
       header?: never
       path: {
-        /** @description Project ref */
         ref: string
       }
       cookie?: never
@@ -4018,7 +4113,6 @@ export interface operations {
       header?: never
       path: {
         provider_id: string
-        /** @description Project ref */
         ref: string
       }
       cookie?: never
@@ -4054,7 +4148,6 @@ export interface operations {
       header?: never
       path: {
         provider_id: string
-        /** @description Project ref */
         ref: string
       }
       cookie?: never
@@ -4094,7 +4187,6 @@ export interface operations {
       header?: never
       path: {
         provider_id: string
-        /** @description Project ref */
         ref: string
       }
       cookie?: never
@@ -4344,7 +4436,6 @@ export interface operations {
       query?: never
       header?: never
       path: {
-        /** @description Project ref */
         ref: string
       }
       cookie?: never
@@ -4379,7 +4470,6 @@ export interface operations {
       query?: never
       header?: never
       path: {
-        /** @description Project ref */
         ref: string
       }
       cookie?: never
@@ -4418,7 +4508,6 @@ export interface operations {
       query?: never
       header?: never
       path: {
-        /** @description Project ref */
         ref: string
       }
       cookie?: never
@@ -4453,7 +4542,6 @@ export interface operations {
       query?: never
       header?: never
       path: {
-        /** @description Project ref */
         ref: string
       }
       cookie?: never
@@ -4490,7 +4578,6 @@ export interface operations {
       query?: never
       header?: never
       path: {
-        /** @description Project ref */
         ref: string
       }
       cookie?: never
@@ -4525,7 +4612,6 @@ export interface operations {
       query?: never
       header?: never
       path: {
-        /** @description Project ref */
         ref: string
       }
       cookie?: never
@@ -4558,7 +4644,6 @@ export interface operations {
       query?: never
       header?: never
       path: {
-        /** @description Project ref */
         ref: string
       }
       cookie?: never
@@ -4593,7 +4678,6 @@ export interface operations {
       query?: never
       header?: never
       path: {
-        /** @description Project ref */
         ref: string
       }
       cookie?: never
@@ -4632,7 +4716,6 @@ export interface operations {
       query?: never
       header?: never
       path: {
-        /** @description Project ref */
         ref: string
       }
       cookie?: never
@@ -5210,7 +5293,6 @@ export interface operations {
       }
       header?: never
       path: {
-        /** @description Project ref */
         ref: string
       }
       cookie?: never

--- a/packages/api-types/types/platform.d.ts
+++ b/packages/api-types/types/platform.d.ts
@@ -4043,45 +4043,22 @@ export interface components {
       scope?: 'V0'
       token_alias: string
     }
-    /** @enum {string} */
-    AddonVariantId:
-      | 'ci_micro'
-      | 'ci_small'
-      | 'ci_medium'
-      | 'ci_large'
-      | 'ci_xlarge'
-      | 'ci_2xlarge'
-      | 'ci_4xlarge'
-      | 'ci_8xlarge'
-      | 'ci_12xlarge'
-      | 'ci_16xlarge'
-      | 'cd_default'
-      | 'pitr_7'
-      | 'pitr_14'
-      | 'pitr_28'
-      | 'ipv4_default'
-      | 'auth_mfa_phone_default'
-      | 'auth_mfa_web_authn_default'
-      | 'log_drain_default'
-    AmiSearchOptions: {
-      search_tags?: Record<string, never>
-    }
     AnalyticsResponse: {
       error?:
-        | {
-            code?: number
-            errors?: {
-              domain?: string
-              location?: string
-              locationType?: string
-              message?: string
-              reason?: string
-            }[]
-            message?: string
-            status?: string
-          }
         | string
-      result?: Record<string, never>[]
+        | {
+            code: number
+            errors: {
+              domain: string
+              location: string
+              locationType: string
+              message: string
+              reason: string
+            }[]
+            message: string
+            status: string
+          }
+      result?: unknown[]
     }
     ApiResponse: {
       autoApiService: {
@@ -4175,11 +4152,6 @@ export interface components {
         title: string
       }[]
     }
-    AvailableAddonResponse: {
-      name: string
-      type: components['schemas']['ProjectAddonType']
-      variants: components['schemas']['ProjectAddonVariantResponse'][]
-    }
     BackupId: {
       id: number
     }
@@ -4211,22 +4183,6 @@ export interface components {
         postal_code?: string
         state?: string
       }
-    }
-    /** @enum {string} */
-    BillingPlanId: 'free' | 'pro' | 'team' | 'enterprise'
-    BillingProjectAddonResponse: {
-      addons: components['schemas']['SelectedAddonResponse'][]
-      name: string
-      ref: string
-    }
-    BillingSubscriptionAddon: {
-      name: string
-      price: number
-      supabase_prod_id: string
-    }
-    BillingSubscriptionPlan: {
-      id: components['schemas']['BillingPlanId']
-      name: string
     }
     Buffer: Record<string, never>
     BulkDeleteUserContentResponse: {
@@ -4282,7 +4238,45 @@ export interface components {
       token_alias: string
     }
     CreateBackendParams: {
-      config: Record<string, never>
+      config:
+        | {
+            hostname: string
+            password?: string | null
+            port?: number | null
+            schema?: string
+            url?: string | null
+            username?: string | null
+          }
+        | {
+            gzip?: boolean
+            headers?: {
+              [key: string]: string
+            }
+            /** @enum {string} */
+            http?: 'http1' | 'http2'
+            url: string
+          }
+        | {
+            dataset_id: string
+            project_id: string
+          }
+        | {
+            api_key: string
+            region: string
+          }
+        | {
+            password?: string | null
+            url: string
+            username?: string | null
+          }
+        | {
+            headers?: {
+              [key: string]: string
+            }
+            password?: string | null
+            url: string
+            username?: string | null
+          }
       description?: string
       name: string
       /** @enum {string} */
@@ -4500,7 +4494,13 @@ export interface components {
     CreateProjectBody: {
       auth_site_url?: string
       cloud_provider: string
-      custom_supabase_internal_requests?: components['schemas']['CustomSupabaseInternalRequests']
+      custom_supabase_internal_requests?: {
+        ami: {
+          search_tags?: {
+            [key: string]: string
+          }
+        }
+      }
       data_api_exposed_schemas?: string[]
       data_api_use_api_schema?: boolean
       db_pass: string
@@ -4511,13 +4511,33 @@ export interface components {
        */
       db_region: string
       db_sql?: string
-      desired_instance_size?: components['schemas']['DesiredInstanceSize']
+      /** @enum {string} */
+      desired_instance_size?:
+        | 'pico'
+        | 'nano'
+        | 'micro'
+        | 'small'
+        | 'medium'
+        | 'large'
+        | 'xlarge'
+        | '2xlarge'
+        | '4xlarge'
+        | '8xlarge'
+        | '12xlarge'
+        | '16xlarge'
       name: string
-      /** @deprecated */
       org_id?: number
       organization_slug?: string
-      postgres_engine?: components['schemas']['PostgresEngine']
-      release_channel?: components['schemas']['ReleaseChannel']
+      /**
+       * @description Postgres engine version. If not provided, the latest version will be used.
+       * @enum {string}
+       */
+      postgres_engine?: '13' | '14' | '15' | '17' | '17-oriole'
+      /**
+       * @description Release channel. If not provided, GA will be used.
+       * @enum {string}
+       */
+      release_channel?: 'internal' | 'alpha' | 'beta' | 'ga' | 'withdrawn' | 'preview'
     }
     CreateProjectResponse: {
       anon_key: string
@@ -4525,7 +4545,20 @@ export interface components {
       disk_volume_size_gb?: number
       endpoint: string
       id: number
-      infra_compute_size?: components['schemas']['DbInstanceSize']
+      /** @enum {string} */
+      infra_compute_size?:
+        | 'pico'
+        | 'nano'
+        | 'micro'
+        | 'small'
+        | 'medium'
+        | 'large'
+        | 'xlarge'
+        | '2xlarge'
+        | '4xlarge'
+        | '8xlarge'
+        | '12xlarge'
+        | '16xlarge'
       inserted_at: string | null
       is_branch_enabled: boolean
       is_physical_backups_enabled: boolean | null
@@ -4753,12 +4786,10 @@ export interface components {
       billing_via_partner: boolean
       email: string
     }
-    CustomSupabaseInternalRequests: {
-      ami: components['schemas']['AmiSearchOptions']
-    }
     DatabaseDetailResponse: {
       /** @enum {string} */
       cloud_provider: 'AWS' | 'AWS_K8S' | 'FLY'
+      connection_string_read_only: string
       connectionString: string
       db_host: string
       db_name: string
@@ -4786,7 +4817,25 @@ export interface components {
     }
     DatabaseStatusResponse: {
       identifier: string
-      replicaInitializationStatus?: Record<string, never>
+      replicaInitializationStatus?:
+        | {
+            estimations?: {
+              baseBackupDownloadEstimateSeconds: number
+              walArchiveReplayEstimateSeconds: number
+            }
+            progress?: unknown
+            /** @enum {string} */
+            status: 'in_progress'
+          }
+        | {
+            /** @enum {string} */
+            status: 'completed'
+          }
+        | {
+            error?: unknown
+            /** @enum {string} */
+            status: 'failed'
+          }
       /** @enum {string} */
       status:
         | 'ACTIVE_HEALTHY'
@@ -4802,20 +4851,6 @@ export interface components {
         | 'RESTARTING'
         | 'RESIZING'
     }
-    /** @enum {string} */
-    DbInstanceSize:
-      | 'pico'
-      | 'nano'
-      | 'micro'
-      | 'small'
-      | 'medium'
-      | 'large'
-      | 'xlarge'
-      | '2xlarge'
-      | '4xlarge'
-      | '8xlarge'
-      | '12xlarge'
-      | '16xlarge'
     DeclineAuthorizationResponse: {
       id: string
     }
@@ -4835,18 +4870,6 @@ export interface components {
     DeleteVercelConnectionResponse: {
       id: string
     }
-    /** @enum {string} */
-    DesiredInstanceSize:
-      | 'micro'
-      | 'small'
-      | 'medium'
-      | 'large'
-      | 'xlarge'
-      | '2xlarge'
-      | '4xlarge'
-      | '8xlarge'
-      | '12xlarge'
-      | '16xlarge'
     DetachPaymentMethodBody: {
       card_id: string
     }
@@ -4858,53 +4881,59 @@ export interface components {
       /** @description Minimum increment size for disk autoscaling in GB */
       min_increment_gb?: number | null
     }
-    DiskRequestAttributesGP3: {
-      iops: number
-      size_gb: number
-      throughput_mbps: number
-      /** @enum {string} */
-      type: 'gp3'
-    }
-    DiskRequestAttributesIO2: {
-      iops: number
-      size_gb: number
-      /** @enum {string} */
-      type: 'io2'
-    }
     DiskRequestBody: {
       attributes:
-        | components['schemas']['DiskRequestAttributesGP3']
-        | components['schemas']['DiskRequestAttributesIO2']
+        | {
+            iops: number
+            size_gb: number
+            throughput_mbps: number
+            /** @enum {string} */
+            type: 'gp3'
+          }
+        | {
+            iops: number
+            size_gb: number
+            /** @enum {string} */
+            type: 'io2'
+          }
     }
     DiskResponse: {
       attributes:
-        | components['schemas']['DiskResponseAttributesGP3']
-        | components['schemas']['DiskResponseAttributesIO2']
+        | {
+            iops: number
+            size_gb: number
+            throughput_mbps: number
+            /** @enum {string} */
+            type: 'gp3'
+          }
+        | {
+            iops: number
+            size_gb: number
+            /** @enum {string} */
+            type: 'io2'
+          }
       last_modified_at?: string
       requested_modification?:
-        | components['schemas']['DiskResponseAttributesGP3']
-        | components['schemas']['DiskResponseAttributesIO2']
-    }
-    DiskResponseAttributesGP3: {
-      iops: number
-      size_gb: number
-      throughput_mbps: number
-      /** @enum {string} */
-      type: 'gp3'
-    }
-    DiskResponseAttributesIO2: {
-      iops: number
-      size_gb: number
-      /** @enum {string} */
-      type: 'io2'
-    }
-    DiskUtilMetrics: {
-      fs_avail_bytes: number
-      fs_size_bytes: number
-      fs_used_bytes: number
+        | {
+            iops: number
+            size_gb: number
+            throughput_mbps: number
+            /** @enum {string} */
+            type: 'gp3'
+          }
+        | {
+            iops: number
+            size_gb: number
+            /** @enum {string} */
+            type: 'io2'
+          }
     }
     DiskUtilMetricsResponse: {
-      metrics: components['schemas']['DiskUtilMetrics']
+      metrics: {
+        fs_avail_bytes: number
+        fs_size_bytes: number
+        fs_used_bytes: number
+      }
       timestamp: string
     }
     DownloadableBackupsResponse: {
@@ -5197,19 +5226,78 @@ export interface components {
       }[]
     }
     GetSubscriptionResponse: {
-      addons: components['schemas']['BillingSubscriptionAddon'][]
+      addons: {
+        name: string
+        price: number
+        supabase_prod_id: string
+      }[]
       billing_cycle_anchor: number
       /** @enum {string} */
-      billing_partner: 'fly' | 'aws' | 'vercel_marketplace'
+      billing_partner?: 'fly' | 'aws' | 'vercel_marketplace'
       billing_via_partner: boolean
       current_period_end: number
       current_period_start: number
       customer_balance: number
       next_invoice_at: number
       payment_method_type: string
-      plan: components['schemas']['BillingSubscriptionPlan']
-      project_addons: components['schemas']['BillingProjectAddonResponse'][]
-      scheduled_plan_change: components['schemas']['ScheduledPlanChange'] | null
+      plan: {
+        /** @enum {string} */
+        id: 'free' | 'pro' | 'team' | 'enterprise'
+        name: string
+      }
+      project_addons: {
+        addons: {
+          /** @enum {string} */
+          type:
+            | 'custom_domain'
+            | 'compute_instance'
+            | 'pitr'
+            | 'ipv4'
+            | 'auth_mfa_phone'
+            | 'auth_mfa_web_authn'
+            | 'log_drain'
+          variant: {
+            /** @enum {string} */
+            identifier:
+              | 'ci_micro'
+              | 'ci_small'
+              | 'ci_medium'
+              | 'ci_large'
+              | 'ci_xlarge'
+              | 'ci_2xlarge'
+              | 'ci_4xlarge'
+              | 'ci_8xlarge'
+              | 'ci_12xlarge'
+              | 'ci_16xlarge'
+              | 'cd_default'
+              | 'pitr_7'
+              | 'pitr_14'
+              | 'pitr_28'
+              | 'ipv4_default'
+              | 'auth_mfa_phone_default'
+              | 'auth_mfa_web_authn_default'
+              | 'log_drain_default'
+            /** @description Any JSON-serializable value */
+            meta?: unknown
+            name: string
+            price: number
+            price_description: string
+            /** @enum {string} */
+            price_interval: 'monthly' | 'hourly'
+            /** @enum {string} */
+            price_type: 'fixed' | 'usage'
+          }
+        }[]
+        name: string
+        ref: string
+      }[]
+      scheduled_plan_change: {
+        /** Format: date-time */
+        at: string
+        /** @enum {string} */
+        target_plan: 'free' | 'pro' | 'team' | 'enterprise'
+        usage_billing_enabled: boolean
+      } | null
       usage_billing_enabled: boolean
     }
     GetUserContentByIdResponse: {
@@ -5553,13 +5641,52 @@ export interface components {
       token: string
     }
     LFBackend: {
-      config: Record<string, never>
+      config:
+        | {
+            hostname: string
+            password?: string | null
+            port?: number | null
+            schema?: string
+            url?: string | null
+            username?: string | null
+          }
+        | {
+            gzip?: boolean
+            headers?: {
+              [key: string]: string
+            }
+            /** @enum {string} */
+            http?: 'http1' | 'http2'
+            url: string
+          }
+        | {
+            dataset_id: string
+            project_id: string
+          }
+        | {
+            api_key: string
+            region: string
+          }
+        | {
+            password?: string | null
+            url: string
+            username?: string | null
+          }
+        | {
+            headers?: {
+              [key: string]: string
+            }
+            password?: string | null
+            url: string
+            username?: string | null
+          }
       description?: string
       id: number
       metadata: {
-        project_ref?: string
-        type?: string
-      }
+        project_ref: string
+        /** @enum {string} */
+        type: 'log-drain'
+      } | null
       name: string
       token: string
       /** @enum {string} */
@@ -5571,7 +5698,8 @@ export interface components {
       description: string
       enable_auth: number
       id: number
-      language: Record<string, never>
+      /** @enum {string} */
+      language: 'bq_sql' | 'pg_sql'
       max_limit: number
       name: string
       proactive_requerying_seconds: number
@@ -5599,8 +5727,8 @@ export interface components {
       company: string | null
       email: string | null
       email_me_product: string | null
-      metadata: {
-        project_ref?: string
+      metadata?: {
+        project_ref: string
       }
       phone: string | null
       token: string
@@ -5699,19 +5827,23 @@ export interface components {
       to: string
     }
     NotificationResponseV1: {
-      data?: unknown
+      /** @description Any JSON-serializable value */
+      data: unknown
       id: string
       inserted_at: string
-      meta?: unknown
+      /** @description Any JSON-serializable value */
+      meta: unknown
       notification_name: string
       notification_status: string
       project_id: number
     }
     NotificationResponseV2: {
-      data?: unknown
+      /** @description Any JSON-serializable value */
+      data: unknown
       id: string
       inserted_at: string
-      meta?: unknown
+      /** @description Any JSON-serializable value */
+      meta: unknown
       name: string
       /** @enum {string} */
       priority: 'Critical' | 'Warning' | 'Info'
@@ -6104,10 +6236,7 @@ export interface components {
       wal_sender_timeout?: string
       work_mem?: string
     }
-    /**
-     * @description Postgres engine version. If not provided, the latest version will be used.
-     * @enum {string}
-     */
+    /** @enum {string} */
     PostgresEngine: '15' | '17-oriole'
     PostgresExtension: {
       comment: string | null
@@ -6392,32 +6521,93 @@ export interface components {
       primary_email: string
       username: string
     }
-    /** @enum {string} */
-    ProjectAddonPricingInterval: 'monthly' | 'hourly'
     ProjectAddonsResponse: {
-      available_addons: components['schemas']['AvailableAddonResponse'][]
+      available_addons: {
+        name: string
+        /** @enum {string} */
+        type:
+          | 'custom_domain'
+          | 'compute_instance'
+          | 'pitr'
+          | 'ipv4'
+          | 'auth_mfa_phone'
+          | 'auth_mfa_web_authn'
+          | 'log_drain'
+        variants: {
+          /** @enum {string} */
+          identifier:
+            | 'ci_micro'
+            | 'ci_small'
+            | 'ci_medium'
+            | 'ci_large'
+            | 'ci_xlarge'
+            | 'ci_2xlarge'
+            | 'ci_4xlarge'
+            | 'ci_8xlarge'
+            | 'ci_12xlarge'
+            | 'ci_16xlarge'
+            | 'cd_default'
+            | 'pitr_7'
+            | 'pitr_14'
+            | 'pitr_28'
+            | 'ipv4_default'
+            | 'auth_mfa_phone_default'
+            | 'auth_mfa_web_authn_default'
+            | 'log_drain_default'
+          /** @description Any JSON-serializable value */
+          meta?: unknown
+          name: string
+          price: number
+          price_description: string
+          /** @enum {string} */
+          price_interval: 'monthly' | 'hourly'
+          /** @enum {string} */
+          price_type: 'fixed' | 'usage'
+        }[]
+      }[]
       ref: string
-      selected_addons: components['schemas']['SelectedAddonResponse'][]
-    }
-    /** @enum {string} */
-    ProjectAddonType:
-      | 'custom_domain'
-      | 'compute_instance'
-      | 'pitr'
-      | 'ipv4'
-      | 'auth_mfa_phone'
-      | 'auth_mfa_web_authn'
-      | 'log_drain'
-    /** @enum {string} */
-    ProjectAddonVariantPricingType: 'fixed' | 'usage'
-    ProjectAddonVariantResponse: {
-      identifier: components['schemas']['AddonVariantId']
-      meta?: Record<string, never>
-      name: string
-      price: number
-      price_description: string
-      price_interval: components['schemas']['ProjectAddonPricingInterval']
-      price_type: components['schemas']['ProjectAddonVariantPricingType']
+      selected_addons: {
+        /** @enum {string} */
+        type:
+          | 'custom_domain'
+          | 'compute_instance'
+          | 'pitr'
+          | 'ipv4'
+          | 'auth_mfa_phone'
+          | 'auth_mfa_web_authn'
+          | 'log_drain'
+        variant: {
+          /** @enum {string} */
+          identifier:
+            | 'ci_micro'
+            | 'ci_small'
+            | 'ci_medium'
+            | 'ci_large'
+            | 'ci_xlarge'
+            | 'ci_2xlarge'
+            | 'ci_4xlarge'
+            | 'ci_8xlarge'
+            | 'ci_12xlarge'
+            | 'ci_16xlarge'
+            | 'cd_default'
+            | 'pitr_7'
+            | 'pitr_14'
+            | 'pitr_28'
+            | 'ipv4_default'
+            | 'auth_mfa_phone_default'
+            | 'auth_mfa_web_authn_default'
+            | 'log_drain_default'
+          /** @description Any JSON-serializable value */
+          meta?: unknown
+          name: string
+          price: number
+          price_description: string
+          /** @enum {string} */
+          price_interval: 'monthly' | 'hourly'
+          /** @enum {string} */
+          price_type: 'fixed' | 'usage'
+        }
+      }[]
     }
     ProjectAppConfigResponse: {
       db_schema: string
@@ -6512,7 +6702,20 @@ export interface components {
       cloud_provider: string
       disk_volume_size_gb?: number
       id: number
-      infra_compute_size?: components['schemas']['DbInstanceSize']
+      /** @enum {string} */
+      infra_compute_size?:
+        | 'pico'
+        | 'nano'
+        | 'micro'
+        | 'small'
+        | 'medium'
+        | 'large'
+        | 'xlarge'
+        | '2xlarge'
+        | '4xlarge'
+        | '8xlarge'
+        | '12xlarge'
+        | '16xlarge'
       inserted_at: string | null
       is_branch_enabled: boolean
       is_physical_backups_enabled: boolean | null
@@ -6624,10 +6827,7 @@ export interface components {
       /** @description Whether to only allow private channels */
       private_only: boolean | null
     }
-    /**
-     * @description Release channel. If not provided, GA will be used.
-     * @enum {string}
-     */
+    /** @enum {string} */
     ReleaseChannel: 'internal' | 'alpha' | 'beta' | 'ga' | 'withdrawn' | 'preview'
     ReplicationPipelineResponse: {
       config: {
@@ -6785,18 +6985,8 @@ export interface components {
     RunQueryBody: {
       query: string
     }
-    ScheduledPlanChange: {
-      /** Format: date-time */
-      at: string
-      target_plan: components['schemas']['BillingPlanId']
-      usage_billing_enabled: boolean
-    }
     SearchProfileBody: {
       keywords: string
-    }
-    SelectedAddonResponse: {
-      type: components['schemas']['ProjectAddonType']
-      variant: components['schemas']['ProjectAddonVariantResponse']
     }
     SendDocsFeedbackBody: {
       feedback?: string
@@ -7087,11 +7277,76 @@ export interface components {
     }
     UpcomingInvoice: Record<string, never>
     UpdateAddonBody: {
-      addon_type: components['schemas']['ProjectAddonType']
-      addon_variant: components['schemas']['AddonVariantId']
+      /** @enum {string} */
+      addon_type:
+        | 'custom_domain'
+        | 'compute_instance'
+        | 'pitr'
+        | 'ipv4'
+        | 'auth_mfa_phone'
+        | 'auth_mfa_web_authn'
+        | 'log_drain'
+      /** @enum {string} */
+      addon_variant:
+        | 'ci_micro'
+        | 'ci_small'
+        | 'ci_medium'
+        | 'ci_large'
+        | 'ci_xlarge'
+        | 'ci_2xlarge'
+        | 'ci_4xlarge'
+        | 'ci_8xlarge'
+        | 'ci_12xlarge'
+        | 'ci_16xlarge'
+        | 'cd_default'
+        | 'pitr_7'
+        | 'pitr_14'
+        | 'pitr_28'
+        | 'ipv4_default'
+        | 'auth_mfa_phone_default'
+        | 'auth_mfa_web_authn_default'
+        | 'log_drain_default'
     }
     UpdateBackendParams: {
-      config?: Record<string, never>
+      config?:
+        | {
+            hostname: string
+            password?: string | null
+            port?: number | null
+            schema?: string
+            url?: string | null
+            username?: string | null
+          }
+        | {
+            gzip?: boolean
+            headers?: {
+              [key: string]: string
+            }
+            /** @enum {string} */
+            http?: 'http1' | 'http2'
+            url: string
+          }
+        | {
+            dataset_id: string
+            project_id: string
+          }
+        | {
+            api_key: string
+            region: string
+          }
+        | {
+            password?: string | null
+            url: string
+            username?: string | null
+          }
+        | {
+            headers?: {
+              [key: string]: string
+            }
+            password?: string | null
+            url: string
+            username?: string | null
+          }
       description?: string
       name?: string
     }
@@ -7155,198 +7410,202 @@ export interface components {
       workdir?: string
     }
     UpdateGoTrueConfigBody: {
-      API_MAX_REQUEST_DURATION?: number
-      DB_MAX_POOL_SIZE?: number
-      DISABLE_SIGNUP?: boolean
-      EXTERNAL_ANONYMOUS_USERS_ENABLED?: boolean
-      EXTERNAL_APPLE_ADDITIONAL_CLIENT_IDS?: string
-      EXTERNAL_APPLE_CLIENT_ID?: string
-      EXTERNAL_APPLE_ENABLED?: boolean
-      EXTERNAL_APPLE_SECRET?: string
-      EXTERNAL_AZURE_CLIENT_ID?: string
-      EXTERNAL_AZURE_ENABLED?: boolean
-      EXTERNAL_AZURE_SECRET?: string
-      EXTERNAL_AZURE_URL?: string
-      EXTERNAL_BITBUCKET_CLIENT_ID?: string
-      EXTERNAL_BITBUCKET_ENABLED?: boolean
-      EXTERNAL_BITBUCKET_SECRET?: string
-      EXTERNAL_DISCORD_CLIENT_ID?: string
-      EXTERNAL_DISCORD_ENABLED?: boolean
-      EXTERNAL_DISCORD_SECRET?: string
-      EXTERNAL_EMAIL_ENABLED?: boolean
-      EXTERNAL_FACEBOOK_CLIENT_ID?: string
-      EXTERNAL_FACEBOOK_ENABLED?: boolean
-      EXTERNAL_FACEBOOK_SECRET?: string
-      EXTERNAL_FIGMA_CLIENT_ID?: string
-      EXTERNAL_FIGMA_ENABLED?: boolean
-      EXTERNAL_FIGMA_SECRET?: string
-      EXTERNAL_GITHUB_CLIENT_ID?: string
-      EXTERNAL_GITHUB_ENABLED?: boolean
-      EXTERNAL_GITHUB_SECRET?: string
-      EXTERNAL_GITLAB_CLIENT_ID?: string
-      EXTERNAL_GITLAB_ENABLED?: boolean
-      EXTERNAL_GITLAB_SECRET?: string
-      EXTERNAL_GITLAB_URL?: string
-      EXTERNAL_GOOGLE_ADDITIONAL_CLIENT_IDS?: string
-      EXTERNAL_GOOGLE_CLIENT_ID?: string
-      EXTERNAL_GOOGLE_ENABLED?: boolean
-      EXTERNAL_GOOGLE_SECRET?: string
-      EXTERNAL_GOOGLE_SKIP_NONCE_CHECK?: boolean
-      EXTERNAL_KAKAO_CLIENT_ID?: string
-      EXTERNAL_KAKAO_ENABLED?: boolean
-      EXTERNAL_KAKAO_SECRET?: string
-      EXTERNAL_KEYCLOAK_CLIENT_ID?: string
-      EXTERNAL_KEYCLOAK_ENABLED?: boolean
-      EXTERNAL_KEYCLOAK_SECRET?: string
-      EXTERNAL_KEYCLOAK_URL?: string
-      EXTERNAL_LINKEDIN_OIDC_CLIENT_ID?: string
-      EXTERNAL_LINKEDIN_OIDC_ENABLED?: boolean
-      EXTERNAL_LINKEDIN_OIDC_SECRET?: string
-      EXTERNAL_NOTION_CLIENT_ID?: string
-      EXTERNAL_NOTION_ENABLED?: boolean
-      EXTERNAL_NOTION_SECRET?: string
-      EXTERNAL_PHONE_ENABLED?: boolean
-      EXTERNAL_SLACK_CLIENT_ID?: string
-      EXTERNAL_SLACK_ENABLED?: boolean
-      EXTERNAL_SLACK_OIDC_CLIENT_ID?: string
-      EXTERNAL_SLACK_OIDC_ENABLED?: boolean
-      EXTERNAL_SLACK_OIDC_SECRET?: string
-      EXTERNAL_SLACK_SECRET?: string
-      EXTERNAL_SPOTIFY_CLIENT_ID?: string
-      EXTERNAL_SPOTIFY_ENABLED?: boolean
-      EXTERNAL_SPOTIFY_SECRET?: string
-      EXTERNAL_TWITCH_CLIENT_ID?: string
-      EXTERNAL_TWITCH_ENABLED?: boolean
-      EXTERNAL_TWITCH_SECRET?: string
-      EXTERNAL_TWITTER_CLIENT_ID?: string
-      EXTERNAL_TWITTER_ENABLED?: boolean
-      EXTERNAL_TWITTER_SECRET?: string
-      EXTERNAL_WORKOS_CLIENT_ID?: string
-      EXTERNAL_WORKOS_ENABLED?: boolean
-      EXTERNAL_WORKOS_SECRET?: string
-      EXTERNAL_WORKOS_URL?: string
-      EXTERNAL_ZOOM_CLIENT_ID?: string
-      EXTERNAL_ZOOM_ENABLED?: boolean
-      EXTERNAL_ZOOM_SECRET?: string
-      HOOK_CUSTOM_ACCESS_TOKEN_ENABLED?: boolean
-      HOOK_CUSTOM_ACCESS_TOKEN_SECRETS?: string
-      HOOK_CUSTOM_ACCESS_TOKEN_URI?: string
-      HOOK_MFA_VERIFICATION_ATTEMPT_ENABLED?: boolean
-      HOOK_MFA_VERIFICATION_ATTEMPT_SECRETS?: string
-      HOOK_MFA_VERIFICATION_ATTEMPT_URI?: string
-      HOOK_PASSWORD_VERIFICATION_ATTEMPT_ENABLED?: boolean
-      HOOK_PASSWORD_VERIFICATION_ATTEMPT_SECRETS?: string
-      HOOK_PASSWORD_VERIFICATION_ATTEMPT_URI?: string
-      HOOK_SEND_EMAIL_ENABLED?: boolean
-      HOOK_SEND_EMAIL_SECRETS?: string
-      HOOK_SEND_EMAIL_URI?: string
-      HOOK_SEND_SMS_ENABLED?: boolean
-      HOOK_SEND_SMS_SECRETS?: string
-      HOOK_SEND_SMS_URI?: string
-      JWT_EXP?: number
-      MAILER_ALLOW_UNVERIFIED_EMAIL_SIGN_INS?: boolean
-      MAILER_AUTOCONFIRM?: boolean
+      API_MAX_REQUEST_DURATION?: number | null
+      DB_MAX_POOL_SIZE?: number | null
+      DISABLE_SIGNUP?: boolean | null
+      EXTERNAL_ANONYMOUS_USERS_ENABLED?: boolean | null
+      EXTERNAL_APPLE_ADDITIONAL_CLIENT_IDS?: string | null
+      EXTERNAL_APPLE_CLIENT_ID?: string | null
+      EXTERNAL_APPLE_ENABLED?: boolean | null
+      EXTERNAL_APPLE_SECRET?: string | null
+      EXTERNAL_AZURE_CLIENT_ID?: string | null
+      EXTERNAL_AZURE_ENABLED?: boolean | null
+      EXTERNAL_AZURE_SECRET?: string | null
+      EXTERNAL_AZURE_URL?: string | null
+      EXTERNAL_BITBUCKET_CLIENT_ID?: string | null
+      EXTERNAL_BITBUCKET_ENABLED?: boolean | null
+      EXTERNAL_BITBUCKET_SECRET?: string | null
+      EXTERNAL_DISCORD_CLIENT_ID?: string | null
+      EXTERNAL_DISCORD_ENABLED?: boolean | null
+      EXTERNAL_DISCORD_SECRET?: string | null
+      EXTERNAL_EMAIL_ENABLED?: boolean | null
+      EXTERNAL_FACEBOOK_CLIENT_ID?: string | null
+      EXTERNAL_FACEBOOK_ENABLED?: boolean | null
+      EXTERNAL_FACEBOOK_SECRET?: string | null
+      EXTERNAL_FIGMA_CLIENT_ID?: string | null
+      EXTERNAL_FIGMA_ENABLED?: boolean | null
+      EXTERNAL_FIGMA_SECRET?: string | null
+      EXTERNAL_GITHUB_CLIENT_ID?: string | null
+      EXTERNAL_GITHUB_ENABLED?: boolean | null
+      EXTERNAL_GITHUB_SECRET?: string | null
+      EXTERNAL_GITLAB_CLIENT_ID?: string | null
+      EXTERNAL_GITLAB_ENABLED?: boolean | null
+      EXTERNAL_GITLAB_SECRET?: string | null
+      EXTERNAL_GITLAB_URL?: string | null
+      EXTERNAL_GOOGLE_ADDITIONAL_CLIENT_IDS?: string | null
+      EXTERNAL_GOOGLE_CLIENT_ID?: string | null
+      EXTERNAL_GOOGLE_ENABLED?: boolean | null
+      EXTERNAL_GOOGLE_SECRET?: string | null
+      EXTERNAL_GOOGLE_SKIP_NONCE_CHECK?: boolean | null
+      EXTERNAL_KAKAO_CLIENT_ID?: string | null
+      EXTERNAL_KAKAO_ENABLED?: boolean | null
+      EXTERNAL_KAKAO_SECRET?: string | null
+      EXTERNAL_KEYCLOAK_CLIENT_ID?: string | null
+      EXTERNAL_KEYCLOAK_ENABLED?: boolean | null
+      EXTERNAL_KEYCLOAK_SECRET?: string | null
+      EXTERNAL_KEYCLOAK_URL?: string | null
+      EXTERNAL_LINKEDIN_OIDC_CLIENT_ID?: string | null
+      EXTERNAL_LINKEDIN_OIDC_ENABLED?: boolean | null
+      EXTERNAL_LINKEDIN_OIDC_SECRET?: string | null
+      EXTERNAL_NOTION_CLIENT_ID?: string | null
+      EXTERNAL_NOTION_ENABLED?: boolean | null
+      EXTERNAL_NOTION_SECRET?: string | null
+      EXTERNAL_PHONE_ENABLED?: boolean | null
+      EXTERNAL_SLACK_CLIENT_ID?: string | null
+      EXTERNAL_SLACK_ENABLED?: boolean | null
+      EXTERNAL_SLACK_OIDC_CLIENT_ID?: string | null
+      EXTERNAL_SLACK_OIDC_ENABLED?: boolean | null
+      EXTERNAL_SLACK_OIDC_SECRET?: string | null
+      EXTERNAL_SLACK_SECRET?: string | null
+      EXTERNAL_SPOTIFY_CLIENT_ID?: string | null
+      EXTERNAL_SPOTIFY_ENABLED?: boolean | null
+      EXTERNAL_SPOTIFY_SECRET?: string | null
+      EXTERNAL_TWITCH_CLIENT_ID?: string | null
+      EXTERNAL_TWITCH_ENABLED?: boolean | null
+      EXTERNAL_TWITCH_SECRET?: string | null
+      EXTERNAL_TWITTER_CLIENT_ID?: string | null
+      EXTERNAL_TWITTER_ENABLED?: boolean | null
+      EXTERNAL_TWITTER_SECRET?: string | null
+      EXTERNAL_WORKOS_CLIENT_ID?: string | null
+      EXTERNAL_WORKOS_ENABLED?: boolean | null
+      EXTERNAL_WORKOS_SECRET?: string | null
+      EXTERNAL_WORKOS_URL?: string | null
+      EXTERNAL_ZOOM_CLIENT_ID?: string | null
+      EXTERNAL_ZOOM_ENABLED?: boolean | null
+      EXTERNAL_ZOOM_SECRET?: string | null
+      HOOK_CUSTOM_ACCESS_TOKEN_ENABLED?: boolean | null
+      HOOK_CUSTOM_ACCESS_TOKEN_SECRETS?: string | null
+      HOOK_CUSTOM_ACCESS_TOKEN_URI?: string | null
+      HOOK_MFA_VERIFICATION_ATTEMPT_ENABLED?: boolean | null
+      HOOK_MFA_VERIFICATION_ATTEMPT_SECRETS?: string | null
+      HOOK_MFA_VERIFICATION_ATTEMPT_URI?: string | null
+      HOOK_PASSWORD_VERIFICATION_ATTEMPT_ENABLED?: boolean | null
+      HOOK_PASSWORD_VERIFICATION_ATTEMPT_SECRETS?: string | null
+      HOOK_PASSWORD_VERIFICATION_ATTEMPT_URI?: string | null
+      HOOK_SEND_EMAIL_ENABLED?: boolean | null
+      HOOK_SEND_EMAIL_SECRETS?: string | null
+      HOOK_SEND_EMAIL_URI?: string | null
+      HOOK_SEND_SMS_ENABLED?: boolean | null
+      HOOK_SEND_SMS_SECRETS?: string | null
+      HOOK_SEND_SMS_URI?: string | null
+      JWT_EXP?: number | null
+      MAILER_ALLOW_UNVERIFIED_EMAIL_SIGN_INS?: boolean | null
+      MAILER_AUTOCONFIRM?: boolean | null
       MAILER_OTP_EXP?: number
-      MAILER_OTP_LENGTH?: number
-      MAILER_SECURE_EMAIL_CHANGE_ENABLED?: boolean
-      MAILER_SUBJECTS_CONFIRMATION?: string
-      MAILER_SUBJECTS_EMAIL_CHANGE?: string
-      MAILER_SUBJECTS_INVITE?: string
-      MAILER_SUBJECTS_MAGIC_LINK?: string
-      MAILER_SUBJECTS_REAUTHENTICATION?: string
-      MAILER_SUBJECTS_RECOVERY?: string
-      MAILER_TEMPLATES_CONFIRMATION_CONTENT?: string
-      MAILER_TEMPLATES_EMAIL_CHANGE_CONTENT?: string
-      MAILER_TEMPLATES_INVITE_CONTENT?: string
-      MAILER_TEMPLATES_MAGIC_LINK_CONTENT?: string
-      MAILER_TEMPLATES_REAUTHENTICATION_CONTENT?: string
-      MAILER_TEMPLATES_RECOVERY_CONTENT?: string
-      MFA_MAX_ENROLLED_FACTORS?: number
-      MFA_PHONE_ENROLL_ENABLED?: boolean
-      MFA_PHONE_MAX_FREQUENCY?: number
-      MFA_PHONE_OTP_LENGTH?: number
-      MFA_PHONE_TEMPLATE?: string
-      MFA_PHONE_VERIFY_ENABLED?: boolean
-      MFA_TOTP_ENROLL_ENABLED?: boolean
-      MFA_TOTP_VERIFY_ENABLED?: boolean
-      MFA_WEB_AUTHN_ENROLL_ENABLED?: boolean
-      MFA_WEB_AUTHN_VERIFY_ENABLED?: boolean
-      PASSWORD_HIBP_ENABLED?: boolean
-      PASSWORD_MIN_LENGTH?: number
-      /** @enum {string} */
+      MAILER_OTP_LENGTH?: number | null
+      MAILER_SECURE_EMAIL_CHANGE_ENABLED?: boolean | null
+      MAILER_SUBJECTS_CONFIRMATION?: string | null
+      MAILER_SUBJECTS_EMAIL_CHANGE?: string | null
+      MAILER_SUBJECTS_INVITE?: string | null
+      MAILER_SUBJECTS_MAGIC_LINK?: string | null
+      MAILER_SUBJECTS_REAUTHENTICATION?: string | null
+      MAILER_SUBJECTS_RECOVERY?: string | null
+      MAILER_TEMPLATES_CONFIRMATION_CONTENT?: string | null
+      MAILER_TEMPLATES_EMAIL_CHANGE_CONTENT?: string | null
+      MAILER_TEMPLATES_INVITE_CONTENT?: string | null
+      MAILER_TEMPLATES_MAGIC_LINK_CONTENT?: string | null
+      MAILER_TEMPLATES_REAUTHENTICATION_CONTENT?: string | null
+      MAILER_TEMPLATES_RECOVERY_CONTENT?: string | null
+      MFA_MAX_ENROLLED_FACTORS?: number | null
+      MFA_PHONE_ENROLL_ENABLED?: boolean | null
+      MFA_PHONE_MAX_FREQUENCY?: number | null
+      MFA_PHONE_OTP_LENGTH?: number | null
+      MFA_PHONE_TEMPLATE?: string | null
+      MFA_PHONE_VERIFY_ENABLED?: boolean | null
+      MFA_TOTP_ENROLL_ENABLED?: boolean | null
+      MFA_TOTP_VERIFY_ENABLED?: boolean | null
+      MFA_WEB_AUTHN_ENROLL_ENABLED?: boolean | null
+      MFA_WEB_AUTHN_VERIFY_ENABLED?: boolean | null
+      PASSWORD_HIBP_ENABLED?: boolean | null
+      PASSWORD_MIN_LENGTH?: number | null
+      /** @enum {string|null} */
       PASSWORD_REQUIRED_CHARACTERS?:
         | 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ:0123456789'
         | 'abcdefghijklmnopqrstuvwxyz:ABCDEFGHIJKLMNOPQRSTUVWXYZ:0123456789'
         | 'abcdefghijklmnopqrstuvwxyz:ABCDEFGHIJKLMNOPQRSTUVWXYZ:0123456789:!@#$%^&*()_+-=[]{};\'\\\\:"|<>?,./`~'
         | ''
-      RATE_LIMIT_ANONYMOUS_USERS?: number
-      RATE_LIMIT_EMAIL_SENT?: number
-      RATE_LIMIT_OTP?: number
-      RATE_LIMIT_SMS_SENT?: number
-      RATE_LIMIT_TOKEN_REFRESH?: number
-      RATE_LIMIT_VERIFY?: number
-      REFRESH_TOKEN_ROTATION_ENABLED?: boolean
-      SAML_ALLOW_ENCRYPTED_ASSERTIONS?: boolean
-      SAML_ENABLED?: boolean
-      SAML_EXTERNAL_URL?: string
-      SECURITY_CAPTCHA_ENABLED?: boolean
-      SECURITY_CAPTCHA_PROVIDER?: string
-      SECURITY_CAPTCHA_SECRET?: string
-      SECURITY_MANUAL_LINKING_ENABLED?: boolean
-      SECURITY_REFRESH_TOKEN_REUSE_INTERVAL?: number
-      SECURITY_UPDATE_PASSWORD_REQUIRE_REAUTHENTICATION?: boolean
-      SESSIONS_INACTIVITY_TIMEOUT?: number
-      SESSIONS_SINGLE_PER_USER?: boolean
-      SESSIONS_TAGS?: string
-      SESSIONS_TIMEBOX?: number
-      SITE_URL?: string
-      SMS_AUTOCONFIRM?: boolean
-      SMS_MAX_FREQUENCY?: number
-      SMS_MESSAGEBIRD_ACCESS_KEY?: string
-      SMS_MESSAGEBIRD_ORIGINATOR?: string
-      SMS_OTP_EXP?: number
+        | null
+      RATE_LIMIT_ANONYMOUS_USERS?: number | null
+      RATE_LIMIT_EMAIL_SENT?: number | null
+      RATE_LIMIT_OTP?: number | null
+      RATE_LIMIT_SMS_SENT?: number | null
+      RATE_LIMIT_TOKEN_REFRESH?: number | null
+      RATE_LIMIT_VERIFY?: number | null
+      REFRESH_TOKEN_ROTATION_ENABLED?: boolean | null
+      SAML_ALLOW_ENCRYPTED_ASSERTIONS?: boolean | null
+      SAML_ENABLED?: boolean | null
+      SAML_EXTERNAL_URL?: string | null
+      SECURITY_CAPTCHA_ENABLED?: boolean | null
+      /** @enum {string|null} */
+      SECURITY_CAPTCHA_PROVIDER?: 'turnstile' | 'hcaptcha' | null
+      SECURITY_CAPTCHA_SECRET?: string | null
+      SECURITY_MANUAL_LINKING_ENABLED?: boolean | null
+      SECURITY_REFRESH_TOKEN_REUSE_INTERVAL?: number | null
+      SECURITY_UPDATE_PASSWORD_REQUIRE_REAUTHENTICATION?: boolean | null
+      SESSIONS_INACTIVITY_TIMEOUT?: number | null
+      SESSIONS_SINGLE_PER_USER?: boolean | null
+      SESSIONS_TAGS?: string | null
+      SESSIONS_TIMEBOX?: number | null
+      SITE_URL?: string | null
+      SMS_AUTOCONFIRM?: boolean | null
+      SMS_MAX_FREQUENCY?: number | null
+      SMS_MESSAGEBIRD_ACCESS_KEY?: string | null
+      SMS_MESSAGEBIRD_ORIGINATOR?: string | null
+      SMS_OTP_EXP?: number | null
       SMS_OTP_LENGTH?: number
-      SMS_PROVIDER?: string
-      SMS_TEMPLATE?: string
-      SMS_TEST_OTP?: string
-      SMS_TEST_OTP_VALID_UNTIL?: string
-      SMS_TEXTLOCAL_API_KEY?: string
-      SMS_TEXTLOCAL_SENDER?: string
-      SMS_TWILIO_ACCOUNT_SID?: string
-      SMS_TWILIO_AUTH_TOKEN?: string
-      SMS_TWILIO_CONTENT_SID?: string
-      SMS_TWILIO_MESSAGE_SERVICE_SID?: string
-      SMS_TWILIO_VERIFY_ACCOUNT_SID?: string
-      SMS_TWILIO_VERIFY_AUTH_TOKEN?: string
-      SMS_TWILIO_VERIFY_MESSAGE_SERVICE_SID?: string
-      SMS_VONAGE_API_KEY?: string
-      SMS_VONAGE_API_SECRET?: string
-      SMS_VONAGE_FROM?: string
-      SMTP_ADMIN_EMAIL?: string
-      SMTP_HOST?: string
-      SMTP_MAX_FREQUENCY?: number
-      SMTP_PASS?: string
-      SMTP_PORT?: string
-      SMTP_SENDER_NAME?: string
-      SMTP_USER?: string
-      URI_ALLOW_LIST?: string
+      /** @enum {string|null} */
+      SMS_PROVIDER?: 'messagebird' | 'textlocal' | 'twilio' | 'twilio_verify' | 'vonage' | null
+      SMS_TEMPLATE?: string | null
+      SMS_TEST_OTP?: string | null
+      /** Format: date-time */
+      SMS_TEST_OTP_VALID_UNTIL?: string | null
+      SMS_TEXTLOCAL_API_KEY?: string | null
+      SMS_TEXTLOCAL_SENDER?: string | null
+      SMS_TWILIO_ACCOUNT_SID?: string | null
+      SMS_TWILIO_AUTH_TOKEN?: string | null
+      SMS_TWILIO_CONTENT_SID?: string | null
+      SMS_TWILIO_MESSAGE_SERVICE_SID?: string | null
+      SMS_TWILIO_VERIFY_ACCOUNT_SID?: string | null
+      SMS_TWILIO_VERIFY_AUTH_TOKEN?: string | null
+      SMS_TWILIO_VERIFY_MESSAGE_SERVICE_SID?: string | null
+      SMS_VONAGE_API_KEY?: string | null
+      SMS_VONAGE_API_SECRET?: string | null
+      SMS_VONAGE_FROM?: string | null
+      SMTP_ADMIN_EMAIL?: string | null
+      SMTP_HOST?: string | null
+      SMTP_MAX_FREQUENCY?: number | null
+      SMTP_PASS?: string | null
+      SMTP_PORT?: string | null
+      SMTP_SENDER_NAME?: string | null
+      SMTP_USER?: string | null
+      URI_ALLOW_LIST?: string | null
     }
     UpdateGoTrueConfigHooksBody: {
-      HOOK_CUSTOM_ACCESS_TOKEN_ENABLED?: boolean
-      HOOK_CUSTOM_ACCESS_TOKEN_SECRETS?: string
-      HOOK_CUSTOM_ACCESS_TOKEN_URI?: string
-      HOOK_MFA_VERIFICATION_ATTEMPT_ENABLED?: boolean
-      HOOK_MFA_VERIFICATION_ATTEMPT_SECRETS?: string
-      HOOK_MFA_VERIFICATION_ATTEMPT_URI?: string
-      HOOK_PASSWORD_VERIFICATION_ATTEMPT_ENABLED?: boolean
-      HOOK_PASSWORD_VERIFICATION_ATTEMPT_SECRETS?: string
-      HOOK_PASSWORD_VERIFICATION_ATTEMPT_URI?: string
-      HOOK_SEND_EMAIL_ENABLED?: boolean
-      HOOK_SEND_EMAIL_SECRETS?: string
-      HOOK_SEND_EMAIL_URI?: string
-      HOOK_SEND_SMS_ENABLED?: boolean
-      HOOK_SEND_SMS_SECRETS?: string
-      HOOK_SEND_SMS_URI?: string
+      HOOK_CUSTOM_ACCESS_TOKEN_ENABLED?: boolean | null
+      HOOK_CUSTOM_ACCESS_TOKEN_SECRETS?: string | null
+      HOOK_CUSTOM_ACCESS_TOKEN_URI?: string | null
+      HOOK_MFA_VERIFICATION_ATTEMPT_ENABLED?: boolean | null
+      HOOK_MFA_VERIFICATION_ATTEMPT_SECRETS?: string | null
+      HOOK_MFA_VERIFICATION_ATTEMPT_URI?: string | null
+      HOOK_PASSWORD_VERIFICATION_ATTEMPT_ENABLED?: boolean | null
+      HOOK_PASSWORD_VERIFICATION_ATTEMPT_SECRETS?: string | null
+      HOOK_PASSWORD_VERIFICATION_ATTEMPT_URI?: string | null
+      HOOK_SEND_EMAIL_ENABLED?: boolean | null
+      HOOK_SEND_EMAIL_SECRETS?: string | null
+      HOOK_SEND_EMAIL_URI?: string | null
+      HOOK_SEND_SMS_ENABLED?: boolean | null
+      HOOK_SEND_SMS_SECRETS?: string | null
+      HOOK_SEND_SMS_URI?: string | null
     }
     UpdateMemberBody: {
       role_id: number
@@ -7552,7 +7811,7 @@ export interface components {
     UpdateSubscriptionBody: {
       payment_method?: string
       /** @enum {string} */
-      tier: 'tier_payg' | 'tier_pro' | 'tier_free' | 'tier_team' | 'tier_enterprise'
+      tier: 'tier_free' | 'tier_pro' | 'tier_payg' | 'tier_team' | 'tier_enterprise'
     }
     UpdateSupavisorConfigBody: {
       default_pool_size?: number | null
@@ -7798,7 +8057,6 @@ export interface operations {
       query?: never
       header?: never
       path: {
-        /** @description Project ref */
         ref: string
       }
       cookie?: never
@@ -7827,7 +8085,6 @@ export interface operations {
       query?: never
       header?: never
       path: {
-        /** @description Project ref */
         ref: string
       }
       cookie?: never
@@ -7860,7 +8117,6 @@ export interface operations {
       query?: never
       header?: never
       path: {
-        /** @description Project ref */
         ref: string
       }
       cookie?: never
@@ -9970,7 +10226,6 @@ export interface operations {
       query?: never
       header?: never
       path: {
-        /** @description Organization slug */
         slug: string
       }
       cookie?: never
@@ -10005,7 +10260,6 @@ export interface operations {
       query?: never
       header?: never
       path: {
-        /** @description Organization slug */
         slug: string
       }
       cookie?: never
@@ -10042,7 +10296,6 @@ export interface operations {
       query?: never
       header?: never
       path: {
-        /** @description Organization slug */
         slug: string
       }
       cookie?: never
@@ -13846,7 +14099,6 @@ export interface operations {
       query?: never
       header?: never
       path: {
-        /** @description Project ref */
         ref: string
       }
       cookie?: never
@@ -13880,10 +14132,16 @@ export interface operations {
     parameters: {
       query?: never
       header?: never
-      path?: never
+      path: {
+        ref: string
+      }
       cookie?: never
     }
-    requestBody?: never
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['LFSource']
+      }
+    }
     responses: {
       201: {
         headers: {
@@ -13912,7 +14170,10 @@ export interface operations {
     parameters: {
       query?: never
       header?: never
-      path?: never
+      path: {
+        ref: string
+        token: string
+      }
       cookie?: never
     }
     requestBody?: never
@@ -13944,7 +14205,10 @@ export interface operations {
     parameters: {
       query?: never
       header?: never
-      path?: never
+      path: {
+        ref: string
+        token: string
+      }
       cookie?: never
     }
     requestBody?: never
@@ -13976,10 +14240,17 @@ export interface operations {
     parameters: {
       query?: never
       header?: never
-      path?: never
+      path: {
+        ref: string
+        token: string
+      }
       cookie?: never
     }
-    requestBody?: never
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['LFSource']
+      }
+    }
     responses: {
       200: {
         headers: {
@@ -14008,7 +14279,11 @@ export interface operations {
     parameters: {
       query?: never
       header?: never
-      path?: never
+      path: {
+        ref: string
+        token: string
+        variant: 'dot' | 'json_schema'
+      }
       cookie?: never
     }
     requestBody?: never
@@ -14347,7 +14622,6 @@ export interface operations {
       query?: never
       header?: never
       path: {
-        /** @description Project ref */
         ref: string
       }
       cookie?: never
@@ -14382,7 +14656,6 @@ export interface operations {
       query?: never
       header?: never
       path: {
-        /** @description Project ref */
         ref: string
       }
       cookie?: never
@@ -14419,8 +14692,25 @@ export interface operations {
       query?: never
       header?: never
       path: {
-        addon_variant: components['schemas']['AddonVariantId']
-        /** @description Project ref */
+        addon_variant:
+          | 'ci_micro'
+          | 'ci_small'
+          | 'ci_medium'
+          | 'ci_large'
+          | 'ci_xlarge'
+          | 'ci_2xlarge'
+          | 'ci_4xlarge'
+          | 'ci_8xlarge'
+          | 'ci_12xlarge'
+          | 'ci_16xlarge'
+          | 'cd_default'
+          | 'pitr_7'
+          | 'pitr_14'
+          | 'pitr_28'
+          | 'ipv4_default'
+          | 'auth_mfa_phone_default'
+          | 'auth_mfa_web_authn_default'
+          | 'log_drain_default'
         ref: string
       }
       cookie?: never
@@ -14547,7 +14837,6 @@ export interface operations {
       query?: never
       header?: never
       path: {
-        /** @description Project ref */
         ref: string
       }
       cookie?: never
@@ -14576,7 +14865,6 @@ export interface operations {
       query?: never
       header?: never
       path: {
-        /** @description Project ref */
         ref: string
       }
       cookie?: never
@@ -15368,7 +15656,6 @@ export interface operations {
       query?: never
       header?: never
       path: {
-        /** @description Project ref */
         ref: string
       }
       cookie?: never
@@ -15390,7 +15677,6 @@ export interface operations {
       query?: never
       header?: never
       path: {
-        /** @description Project ref */
         ref: string
       }
       cookie?: never
@@ -15456,7 +15742,6 @@ export interface operations {
       query?: never
       header?: never
       path: {
-        /** @description Project ref */
         ref: string
       }
       cookie?: never
@@ -15491,7 +15776,6 @@ export interface operations {
       query?: never
       header?: never
       path: {
-        /** @description Project ref */
         ref: string
       }
       cookie?: never
@@ -15528,7 +15812,6 @@ export interface operations {
       query?: never
       header?: never
       path: {
-        /** @description Project ref */
         ref: string
       }
       cookie?: never
@@ -15563,7 +15846,6 @@ export interface operations {
       query?: never
       header?: never
       path: {
-        /** @description Project ref */
         ref: string
       }
       cookie?: never
@@ -15602,7 +15884,6 @@ export interface operations {
       query?: never
       header?: never
       path: {
-        /** @description Project ref */
         ref: string
       }
       cookie?: never
@@ -15643,33 +15924,21 @@ export interface operations {
           | 'cpu_usage_busy_irqs'
           | 'cpu_usage_busy_other'
           | 'cpu_usage_busy_idle'
-          | 'client_connections_max_limit'
           | 'client_connections_pgbouncer'
-          | 'client_connections_postgres'
-          | 'client_connections_realtime'
-          | 'client_connections_supavisor'
           | 'max_cpu_usage'
           | 'avg_cpu_usage'
           | 'disk_io_budget'
-          | 'disk_iops_usage'
-          | 'disk_iops_max'
+          | 'disk_io_consumption'
           | 'disk_iops_read'
           | 'disk_iops_write'
-          | 'disk_io_consumption'
-          | 'ram_available_max'
+          | 'disk_bytes_read'
+          | 'disk_bytes_written'
           | 'ram_usage'
+          | 'ram_usage_total'
           | 'ram_usage_used'
           | 'ram_usage_free'
-          | 'ram_usage_applications'
-          | 'ram_usage_page_tables'
-          | 'ram_usage_swap_cache'
           | 'ram_usage_cache_and_buffers'
-          | 'ram_usage_slab'
-          | 'ram_usage_cache'
-          | 'ram_usage_buffers'
-          | 'ram_usage_unused'
           | 'ram_usage_swap'
-          | 'ram_usage_hardware_corrupted'
           | 'swap_usage'
           | 'physical_replication_lag_physical_replica_lag_seconds'
           | 'pg_stat_database_num_backends'

--- a/packages/ui-patterns/ComputeBadge/index.tsx
+++ b/packages/ui-patterns/ComputeBadge/index.tsx
@@ -2,7 +2,7 @@ import { components } from 'api-types'
 import { Badge, cn } from 'ui'
 
 interface ComputeBadgeProps extends React.ComponentProps<typeof Badge> {
-  infraComputeSize: components['schemas']['DbInstanceSize'] | '>16XL' | undefined
+  infraComputeSize: components['schemas']['ProjectInfo']['infra_compute_size'] | '>16XL' | undefined
 }
 
 export function ComputeBadge({ infraComputeSize, className, ...props }: ComputeBadgeProps) {


### PR DESCRIPTION
There are few `(X as any)` used, as previously generated schemas always returned `object` which was translated to `any` by the cli tool, where now they either return a concrete type (which is hard to fix here without reworking of the functionality) or an `unknown` or `unknown[]` which is more accurate than previous `any`.
Tried to use as many concrete types as possible.