### PR TITLE
fix: Suggestion Dropdown Not Triggering Issue

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/InputWithSuggestions.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/InputWithSuggestions.tsx
@@ -96,7 +96,7 @@ const InputWithSuggestions = ({
         data-testid={dataTestId}
         actions={
           showSuggestions && (
-            <DropdownMenu>
+            <DropdownMenu modal>
               <DropdownMenuTrigger asChild>
                 <ButtonTooltip
                   type="default"


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

- Fix Suggestion Dropdown Not Triggering Issue
- This resolves a critical UI bug affecting production users. The dropdown flickering causes significant UX disruption.

## What is the current behavior?
- column default value dropdown menu ui closes automatically.
- I suspect this might be connected to issue https://github.com/supabase/supabase/pull/34846


https://github.com/user-attachments/assets/dd9d5836-2b16-4c85-b887-39218e9afae0

## What is the new behavior?

- `<InputWithSuggestions>` should work properly.

## Additional context

Video shows severity: https://github.com/user-attachments/assets/27c3816c-9ab3-4463-b752-4568491d3384
