### PR TITLE
docs(mcp): vscode setup instructions

### DIFF
--- a/apps/docs/content/_partials/mcp_supabase_vscode_config.mdx
+++ b/apps/docs/content/_partials/mcp_supabase_vscode_config.mdx
@@ -30,8 +30,6 @@
     }
     ```
 
-    Once you begin using the server, you will be prompted to enter your personal access token. Enter the token that you created earlier.
-
   </TabPanel>
 
   <TabPanel id="windows" label="Windows">
@@ -57,8 +55,6 @@
       }
     }
     ```
-
-    Once you begin using the server, you will be prompted to enter your personal access token. Enter the token that you created earlier.
 
     <Admonition type="note">
 
@@ -106,8 +102,6 @@
     }
     ```
 
-    Once you begin using the server, you will be prompted to enter your personal access token. Enter the token that you created earlier.
-
     This assumes you have Windows Subsystem for Linux (WSL) enabled and `node`/`npx` are installed within the WSL environment.
 
   </TabPanel>
@@ -135,8 +129,6 @@
       }
     }
     ```
-
-    Once you begin using the server, you will be prompted to enter your personal access token. Enter the token that you created earlier.
 
   </TabPanel>
 

--- a/apps/docs/content/_partials/mcp_supabase_vscode_config.mdx
+++ b/apps/docs/content/_partials/mcp_supabase_vscode_config.mdx
@@ -1,0 +1,143 @@
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  defaultActiveId="mac"
+  queryGroup="os"
+>
+
+  <TabPanel id="mac" label="macOS">
+
+    ```json
+    {
+      "inputs": [
+        {
+          "type": "promptString",
+          "id": "supabase-access-token",
+          "description": "Supabase personal access token",
+          "password": true
+        }
+      ],
+      "servers": {
+        "supabase": {
+          "command": "npx",
+          "args": ["-y", "@supabase/mcp-server-supabase@latest"],
+          "env": {
+            "SUPABASE_ACCESS_TOKEN": "${input:supabase-access-token}"
+          }
+        }
+      }
+    }
+    ```
+
+    Once you begin using the server, you will be prompted to enter your personal access token. Enter the token that you created earlier.
+
+  </TabPanel>
+
+  <TabPanel id="windows" label="Windows">
+
+    ```json
+    {
+      "inputs": [
+        {
+          "type": "promptString",
+          "id": "supabase-access-token",
+          "description": "Supabase personal access token",
+          "password": true
+        }
+      ],
+      "servers": {
+        "supabase": {
+          "command": "cmd",
+          "args": ["/c", "npx", "-y", "@supabase/mcp-server-supabase@latest"],
+          "env": {
+            "SUPABASE_ACCESS_TOKEN": "${input:supabase-access-token}"
+          }
+        }
+      }
+    }
+    ```
+
+    Once you begin using the server, you will be prompted to enter your personal access token. Enter the token that you created earlier.
+
+    <Admonition type="note">
+
+    Make sure that `node` and `npx` are available in your system `PATH`. Assuming `node` is installed, you can get the path by running:
+
+    ```shell
+    npm config get prefix
+    ```
+
+    Then add it to your system `PATH` by running:
+
+    ```shell
+    setx PATH "%PATH%;<path-to-dir>"
+    ```
+
+    Replacing `<path-to-dir>` with the path you got from the previous command.
+
+    Finally restart VS Code for the changes to take effect.
+
+    </Admonition>
+
+  </TabPanel>
+
+  <TabPanel id="wsl" label="Windows (WSL)">
+
+    ```json
+    {
+      "inputs": [
+        {
+          "type": "promptString",
+          "id": "supabase-access-token",
+          "description": "Supabase personal access token",
+          "password": true
+        }
+      ],
+      "servers": {
+        "supabase": {
+          "command": "wsl",
+          "args": ["npx", "-y", "@supabase/mcp-server-supabase@latest"],
+          "env": {
+            "SUPABASE_ACCESS_TOKEN": "${input:supabase-access-token}"
+          }
+        }
+      }
+    }
+    ```
+
+    Once you begin using the server, you will be prompted to enter your personal access token. Enter the token that you created earlier.
+
+    This assumes you have Windows Subsystem for Linux (WSL) enabled and `node`/`npx` are installed within the WSL environment.
+
+  </TabPanel>
+
+  <TabPanel id="linux" label="Linux">
+
+    ```json
+    {
+      "inputs": [
+        {
+          "type": "promptString",
+          "id": "supabase-access-token",
+          "description": "Supabase personal access token",
+          "password": true
+        }
+      ],
+      "servers": {
+        "supabase": {
+          "command": "npx",
+          "args": ["-y", "@supabase/mcp-server-supabase@latest"],
+          "env": {
+            "SUPABASE_ACCESS_TOKEN": "${input:supabase-access-token}"
+          }
+        }
+      }
+    }
+    ```
+
+    Once you begin using the server, you will be prompted to enter your personal access token. Enter the token that you created earlier.
+
+  </TabPanel>
+
+</Tabs>

--- a/apps/docs/content/guides/getting-started/mcp.mdx
+++ b/apps/docs/content/guides/getting-started/mcp.mdx
@@ -58,7 +58,7 @@ MCP compatible tools can connect to Supabase using the [Supabase MCP server](htt
     <$Partial path="mcp_supabase_vscode_config.mdx" />
 
 1.  Save the configuration file.
-1.  Open Copilot chat and switch to "Agent" mode. You should see a tool icon that you can tap to confirm the MCP tools are available.
+1.  Open Copilot chat and switch to "Agent" mode. You should see a tool icon that you can tap to confirm the MCP tools are available. Once you begin using the server, you will be prompted to enter your personal access token. Enter the token that you created earlier.
 
 For more info on using MCP in VS Code, see the [Copilot documentation](https://code.visualstudio.com/docs/copilot/chat/mcp-servers).
 

--- a/apps/docs/content/guides/getting-started/mcp.mdx
+++ b/apps/docs/content/guides/getting-started/mcp.mdx
@@ -10,7 +10,7 @@ The [Model Context Protocol](https://modelcontextprotocol.io/introduction) (MCP)
 
 - [Cursor](#cursor)
 - [Windsurf](#windsurf) (Codium)
-- [VS Code](#vs-code-copilot) (Copilot)
+- [Visual Studio Code](#vs-code-copilot) (Copilot)
 - [Cline](#cline) (VS Code extension)
 - [Claude desktop](#claude-desktop)
 - [Claude code](#claude-code)
@@ -49,7 +49,7 @@ MCP compatible tools can connect to Supabase using the [Supabase MCP server](htt
 
 1. You should see a green active status after the server is successfully connected.
 
-### VS Code (Copilot)
+### Visual Studio Code (Copilot)
 
 1.  Open [VS Code](https://code.visualstudio.com/) and create a `.vscode` directory in your project root if it doesn't exist.
 1.  Create a `.vscode/mcp.json` file if it doesn't exist and open it.

--- a/apps/docs/content/guides/getting-started/mcp.mdx
+++ b/apps/docs/content/guides/getting-started/mcp.mdx
@@ -8,11 +8,12 @@ sidebar_label: 'Model context protocol (MCP)'
 
 The [Model Context Protocol](https://modelcontextprotocol.io/introduction) (MCP) is a standard for connecting Large Language Models (LLMs) to platforms like Supabase. This guide covers how to connect Supabase to the following AI tools using MCP:
 
-- [Cursor](https://www.cursor.com/)
-- [Windsurf](https://docs.codeium.com/windsurf) (Codium)
-- [Cline](https://github.com/cline/cline) (VS Code extension)
-- [Claude desktop](https://claude.ai/download)
-- [Claude code](https://claude.ai/code)
+- [Cursor](#cursor)
+- [Windsurf](#windsurf) (Codium)
+- [VS Code](#vs-code-copilot) (Copilot)
+- [Cline](#cline) (VS Code extension)
+- [Claude desktop](#claude-desktop)
+- [Claude code](#claude-code)
 
 Once connected, your AI assistants can interact with and query your Supabase projects on your behalf.
 
@@ -26,7 +27,7 @@ MCP compatible tools can connect to Supabase using the [Supabase MCP server](htt
 
 ### Cursor
 
-1.  Open Cursor and create a `.cursor` directory in your project root if it doesn't exist.
+1.  Open [Cursor](https://www.cursor.com/) and create a `.cursor` directory in your project root if it doesn't exist.
 1.  Create a `.cursor/mcp.json` file if it doesn't exist and open it.
 1.  Add the following configuration:
 
@@ -38,7 +39,7 @@ MCP compatible tools can connect to Supabase using the [Supabase MCP server](htt
 
 ### Windsurf
 
-1. Open Windsurf and navigate to the Cascade assistant.
+1. Open [Windsurf](https://docs.codeium.com/windsurf) and navigate to the Cascade assistant.
 1. Tap on the hammer (MCP) icon, then **Configure** to open the configuration file.
 1. Add the following configuration:
 
@@ -48,9 +49,22 @@ MCP compatible tools can connect to Supabase using the [Supabase MCP server](htt
 
 1. You should see a green active status after the server is successfully connected.
 
+### VS Code (Copilot)
+
+1.  Open [VS Code](https://code.visualstudio.com/) and create a `.vscode` directory in your project root if it doesn't exist.
+1.  Create a `.vscode/mcp.json` file if it doesn't exist and open it.
+1.  Add the following configuration:
+
+    <$Partial path="mcp_supabase_vscode_config.mdx" />
+
+1.  Save the configuration file.
+1.  Open Copilot chat and switch to "Agent" mode. You should see a tool icon that you can tap to confirm the MCP tools are available.
+
+For more info on using MCP in VS Code, see the [Copilot documentation](https://code.visualstudio.com/docs/copilot/chat/mcp-servers).
+
 ### Cline
 
-1. Open the Cline extension in VS Code and tap the **MCP Servers** icon.
+1. Open the [Cline](https://github.com/cline/cline) extension in VS Code and tap the **MCP Servers** icon.
 1. Tap **Configure MCP Servers** to open the configuration file.
 1. Add the following configuration:
 
@@ -62,7 +76,7 @@ MCP compatible tools can connect to Supabase using the [Supabase MCP server](htt
 
 ### Claude desktop
 
-1. Open Claude desktop and navigate to **Settings**.
+1. Open [Claude desktop](https://claude.ai/download) and navigate to **Settings**.
 1. Under the **Developer** tab, tap **Edit Config** to open the configuration file.
 1. Add the following configuration:
 
@@ -81,7 +95,7 @@ MCP compatible tools can connect to Supabase using the [Supabase MCP server](htt
 
 1. Save the configuration file.
 
-1. Restart Claude code to apply the new configuration.
+1. Restart [Claude code](https://claude.ai/code) to apply the new configuration.
 
 ### Next steps
 

--- a/apps/docs/content/guides/getting-started/mcp.mdx
+++ b/apps/docs/content/guides/getting-started/mcp.mdx
@@ -10,7 +10,7 @@ The [Model Context Protocol](https://modelcontextprotocol.io/introduction) (MCP)
 
 - [Cursor](#cursor)
 - [Windsurf](#windsurf) (Codium)
-- [Visual Studio Code](#vs-code-copilot) (Copilot)
+- [Visual Studio Code](#visual-studio-code-copilot) (Copilot)
 - [Cline](#cline) (VS Code extension)
 - [Claude desktop](#claude-desktop)
 - [Claude code](#claude-code)

--- a/supa-mdx-lint/Rule001HeadingCase.toml
+++ b/supa-mdx-lint/Rule001HeadingCase.toml
@@ -37,6 +37,7 @@ may_uppercase = [
     "Compute Credits",
     "Compute Hours",
     "Content Delivery Network",
+    "Copilot",
     "Cron",
     "Cron Jobs?",
     "Data API",


### PR DESCRIPTION
Adds setup instructions for connecting our MCP server with VS Code Copilot.

## Preview
https://docs-git-docs-mcp-vscode-instructions-supabase.vercel.app/docs/guides/getting-started/mcp#vs-code-copilot