### PR TITLE
chore: add warning text to restore dialog

### DIFF
--- a/apps/studio/components/interfaces/Database/Backups/BackupsList.tsx
+++ b/apps/studio/components/interfaces/Database/Backups/BackupsList.tsx
@@ -94,7 +94,7 @@ const BackupsList = () => {
         )}
       </div>
       <ConfirmationModal
-        size="small"
+        size="medium"
         confirmLabel="Confirm restore"
         confirmLabelLoading="Restoring"
         visible={selectedBackup !== undefined}

--- a/apps/studio/components/interfaces/Database/Backups/BackupsList.tsx
+++ b/apps/studio/components/interfaces/Database/Backups/BackupsList.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/router'
 import { useState } from 'react'
 import { toast } from 'sonner'
 
+import { useParams } from 'common'
 import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
 import Panel from 'components/ui/Panel'
 import UpgradeToPro from 'components/ui/UpgradeToPro'
@@ -16,7 +17,6 @@ import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
 import BackupItem from './BackupItem'
 import BackupsEmpty from './BackupsEmpty'
 import BackupsStorageAlert from './BackupsStorageAlert'
-import { useParams } from 'common'
 
 const BackupsList = () => {
   const router = useRouter()
@@ -100,6 +100,7 @@ const BackupsList = () => {
         visible={selectedBackup !== undefined}
         title="Confirm to restore from backup"
         alert={{
+          base: { variant: 'warning' },
           title: 'Your project will be offline while the restore is in progress',
           description:
             'It is advised to upgrade at a time when there will be minimal impact for your application.',

--- a/apps/studio/components/interfaces/Database/Backups/BackupsList.tsx
+++ b/apps/studio/components/interfaces/Database/Backups/BackupsList.tsx
@@ -99,6 +99,11 @@ const BackupsList = () => {
         confirmLabelLoading="Restoring"
         visible={selectedBackup !== undefined}
         title="Confirm to restore from backup"
+        alert={{
+          title: 'Your project will be offline while the restore is in progress',
+          description:
+            'It is advised to upgrade at a time when there will be minimal impact for your application.',
+        }}
         loading={isRestoring || isSuccessBackup}
         onCancel={() => setSelectedBackup(undefined)}
         onConfirm={() => {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

- adds warning text to restore dialog
- there's currently no estimate for a restore. might be worth trying to add some indication in.

fixes FE-1545
