### PR TITLE
feat: fetch beta cli release version

### DIFF
--- a/apps/studio/components/layouts/ProjectLayout/LayoutHeader/LayoutHeader.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/LayoutHeader/LayoutHeader.tsx
@@ -14,14 +14,12 @@ import InlineEditorButton from 'components/layouts/AppLayout/InlineEditorButton'
 import OrganizationDropdown from 'components/layouts/AppLayout/OrganizationDropdown'
 import ProjectDropdown from 'components/layouts/AppLayout/ProjectDropdown'
 import { getResourcesExceededLimitsOrg } from 'components/ui/OveragesBanner/OveragesBanner.utils'
-import { useCLIReleaseVersionQuery } from 'data/misc/cli-release-version-query'
 import { useOrgSubscriptionQuery } from 'data/subscriptions/org-subscription-query'
 import { useOrgUsageQuery } from 'data/usage/org-usage-query'
 import { useSelectedOrganization } from 'hooks/misc/useSelectedOrganization'
 import { useSelectedProject } from 'hooks/misc/useSelectedProject'
 import { useShowLayoutHeader } from 'hooks/misc/useShowLayoutHeader'
 import { IS_PLATFORM } from 'lib/constants'
-import { useAiAssistantStateSnapshot } from 'state/ai-assistant-state'
 import { useAppStateSnapshot } from 'state/app-state'
 import { Badge, cn } from 'ui'
 import BreadcrumbsView from './BreadcrumbsView'
@@ -70,11 +68,6 @@ const LayoutHeader = ({
   const selectedOrganization = useSelectedOrganization()
   const isBranchingEnabled = selectedProject?.is_branch_enabled === true
   const { setMobileMenuOpen } = useAppStateSnapshot()
-
-  const { open: isAiAssistantOpen } = useAiAssistantStateSnapshot()
-
-  const { data } = useCLIReleaseVersionQuery()
-  const currentCliVersion = data?.current
 
   const { data: subscription } = useOrgSubscriptionQuery({
     orgSlug: selectedOrganization?.slug,
@@ -216,7 +209,7 @@ const LayoutHeader = ({
             </>
           ) : (
             <>
-              {!!currentCliVersion && <LocalVersionPopover />}
+              <LocalVersionPopover />
               <ThemeDropdown />
             </>
           )}

--- a/apps/studio/components/layouts/ProjectLayout/LayoutHeader/LocalVersionPopover.test.ts
+++ b/apps/studio/components/layouts/ProjectLayout/LayoutHeader/LocalVersionPopover.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'vitest'
+import { semverGte, semverLte } from './LocalVersionPopover.utils'
+
+describe('LocalVersionPopover.utils:semverLte', () => {
+  test('1.2.2 should be lower than 2.1.1', () => {
+    const version = { major: 1, minor: 2, patch: 2 }
+    const versionCompare = { major: 2, minor: 1, patch: 1 }
+    const result = semverLte(version, versionCompare)
+    expect(result).toBe(true)
+  })
+  test('2.1.0 should not be lower than 1.0.0', () => {
+    const version = { major: 2, minor: 1, patch: 0 }
+    const versionCompare = { major: 1, minor: 0, patch: 0 }
+    const result = semverLte(version, versionCompare)
+    expect(result).toBe(false)
+  })
+  test('2.1.2 should not be lower than 1.99.99', () => {
+    const version = { major: 2, minor: 1, patch: 2 }
+    const versionCompare = { major: 1, minor: 99, patch: 99 }
+    const result = semverLte(version, versionCompare)
+    expect(result).toBe(false)
+  })
+  test('Same value comparison should return true', () => {
+    const version = { major: 2, minor: 1, patch: 2 }
+    const versionCompare = { major: 2, minor: 1, patch: 2 }
+    const result = semverLte(version, versionCompare)
+    expect(result).toBe(true)
+  })
+})
+
+describe('LocalVersionPopover.utils:semverGte', () => {
+  test('2.0.0 should be greater than 1.99.99', () => {
+    const version = { major: 2, minor: 0, patch: 0 }
+    const versionCompare = { major: 1, minor: 99, patch: 99 }
+    const result = semverGte(version, versionCompare)
+    expect(result).toBe(true)
+  })
+  test('1.99.99 should be not be greater than 2.0.1', () => {
+    const version = { major: 1, minor: 99, patch: 99 }
+    const versionCompare = { major: 2, minor: 0, patch: 1 }
+    const result = semverGte(version, versionCompare)
+    expect(result).toBe(false)
+  })
+  test('Same value comparison should return true', () => {
+    const version = { major: 2, minor: 1, patch: 2 }
+    const versionCompare = { major: 2, minor: 1, patch: 2 }
+    const result = semverLte(version, versionCompare)
+    expect(result).toBe(true)
+  })
+})

--- a/apps/studio/components/layouts/ProjectLayout/LayoutHeader/LocalVersionPopover.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/LayoutHeader/LocalVersionPopover.tsx
@@ -24,25 +24,21 @@ import {
 } from 'ui'
 import { Admonition } from 'ui-patterns'
 
-/**
- * TODO: Chat with Qiao how we can pass the CLI version into the env var for STUDIO_VERSION
- * Ideally we can also mark the beta version via STUDIO_VERSION too
- */
-
 export const LocalVersionPopover = () => {
   const { data, isSuccess } = useCLIReleaseVersionQuery()
+  const currentCliVersion = data?.current
   const hasLatestCLIVersion = isSuccess && !!data?.latest
-  const isLatestVersion = data?.current === data?.latest
+  const isLatestVersion = currentCliVersion === data?.latest
 
-  // [Joshen] This is just scaffolding - will need to figure out how to identify beta versions
-  // We can do this separately
-  const isBeta = false ///(data?.latest ?? '').includes('beta')
+  const isBeta = currentCliVersion === data?.beta
+  // [Joshen] Not sure atm if we need this logic, but in case we need to figure out availability of new beta releases
+  // const hasBetaUpdate = semver.gt(semver.coerce(current), semver.coerce(latest)) && semver.lt(semver.coerce(current), semver.coerce(beta))
 
   const approximateNextRelease = !!data?.published_at
     ? dayjs(data?.published_at).utc().add(14, 'day').format('DD MMM YYYY')
     : undefined
 
-  if (!isSuccess) return null
+  if (!isSuccess || !currentCliVersion) return null
 
   return (
     <Popover_Shadcn_>
@@ -143,11 +139,16 @@ export const LocalVersionPopover = () => {
                   description="Beta releases are also available between stable releases through the Beta version of the CLI, which might be helpful if you are waiting for a specific fix."
                 >
                   <p className="!mt-2">If you'd like to try, we recommend doing so via npm:</p>
-                  <div className="flex items-center bg-surface-200 py-1 px-2 rounded mt-2">
+                  <div className="flex items-center bg-surface-200 py-1 px-2 rounded mt-2 mb-1">
                     <SimpleCodeBlock parentClassName="bg-surface-200">
                       npm i supabase@beta --save-dev
                     </SimpleCodeBlock>
                   </div>
+                  {
+                    <p className="text-sm text-foreground-lighter">
+                      Latest Beta version: <span>{data.beta}</span>
+                    </p>
+                  }
                   <DocsButton
                     href="https://supabase.com/docs/guides/local-development/cli/getting-started?queryGroups=platform&platform=linux#using-beta-version"
                     className="!no-underline mt-2"
@@ -170,7 +171,7 @@ export const LocalVersionPopover = () => {
         <div className="flex items-center gap-x-4 px-4">
           <div className="flex flex-col gap-y-1">
             <p className="text-xs">Current version:</p>
-            <p className="text-sm font-mono">{data.current}</p>
+            <p className="text-sm font-mono">{currentCliVersion}</p>
           </div>
           {hasLatestCLIVersion && !isLatestVersion && !isBeta && (
             <div className="flex flex-col gap-y-1">

--- a/apps/studio/components/layouts/ProjectLayout/LayoutHeader/LocalVersionPopover.utils.ts
+++ b/apps/studio/components/layouts/ProjectLayout/LayoutHeader/LocalVersionPopover.utils.ts
@@ -8,9 +8,21 @@ export const getSemver = (version?: string) => {
 }
 
 export const semverLte = (a: CLIVersionSemver, b: CLIVersionSemver) => {
-  return a.major <= b.major && a.minor <= b.minor && a.patch <= b.patch
+  if (
+    a.major > b.major ||
+    (a.major === b.major && a.minor > b.minor) ||
+    (a.major === b.major && a.minor === b.minor && a.patch > b.patch)
+  )
+    return false
+  return true
 }
 
 export const semverGte = (a: CLIVersionSemver, b: CLIVersionSemver) => {
-  return a.major >= b.major && a.minor >= b.minor && a.patch >= b.patch
+  if (
+    a.major < b.major ||
+    (a.major === b.major && a.minor < b.minor) ||
+    (a.major === b.major && a.minor === b.minor && a.patch < b.patch)
+  )
+    return false
+  return true
 }

--- a/apps/studio/components/layouts/ProjectLayout/LayoutHeader/LocalVersionPopover.utils.ts
+++ b/apps/studio/components/layouts/ProjectLayout/LayoutHeader/LocalVersionPopover.utils.ts
@@ -1,0 +1,16 @@
+type CLIVersionSemver = { major: number; minor: number; patch: number }
+
+// [Joshen] Specifically in the syntax of `v0.0.0`
+export const getSemver = (version?: string) => {
+  if (!version) return undefined
+  const [major, minor, patch] = version.slice(1).split('.')
+  return { major: Number(major), minor: Number(minor), patch: Number(patch) }
+}
+
+export const semverLte = (a: CLIVersionSemver, b: CLIVersionSemver) => {
+  return a.major <= b.major && a.minor <= b.minor && a.patch <= b.patch
+}
+
+export const semverGte = (a: CLIVersionSemver, b: CLIVersionSemver) => {
+  return a.major >= b.major && a.minor >= b.minor && a.patch >= b.patch
+}

--- a/apps/studio/data/misc/cli-release-version-query.ts
+++ b/apps/studio/data/misc/cli-release-version-query.ts
@@ -7,7 +7,7 @@ import { miscKeys } from './keys'
 export async function getCLIReleaseVersion() {
   try {
     const data = await fetch(`${BASE_PATH}/api/cli-release-version`).then((res) => res.json())
-    return data as { current: string | null; latest: string | null; published_at: string | null }
+    return data as { current?: string; latest?: string; beta?: string; published_at?: string }
   } catch (error) {
     throw error
   }

--- a/apps/studio/pages/api/cli-release-version.ts
+++ b/apps/studio/pages/api/cli-release-version.ts
@@ -8,23 +8,25 @@ type GitHubRepositoryRelease = {
   published_at: string
 }
 
+const current = process.env.CURRENT_CLI_VERSION
+
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
-  // [Joshen] Added under supabase/turbo.json, but not sure why it's still warning
-  // eslint-disable-next-line turbo/no-undeclared-env-vars
-  const version = process.env.CURRENT_CLI_VERSION
-  const fallback = { current: version, latest: null, published_at: null }
   try {
-    const data: GitHubRepositoryRelease[] = await fetch(
-      'https://api.github.com/repos/supabase/cli/releases?per_page=1'
+    const { tag_name: latest, published_at }: GitHubRepositoryRelease = await fetch(
+      'https://api.github.com/repos/supabase/cli/releases/latest'
     ).then((res) => res.json())
 
-    if (data.length === 0) return res.status(200).json(fallback)
+    const data: GitHubRepositoryRelease[] = await fetch(
+      'https://api.github.com/repos/supabase/cli/releases?per_page=1'
+    )
+      .then((res) => res.json())
+      // Ignore errors fetching beta release version
+      .catch(() => [])
+    const beta = data[0]?.tag_name
 
-    return res
-      .status(200)
-      .json({ current: version, latest: data[0].tag_name, published_at: data[0].published_at })
+    return res.status(200).json({ current, latest, beta, published_at })
   } catch {
-    return res.status(200).json(fallback)
+    return res.status(200).json({ current })
   }
 }
 

--- a/turbo.json
+++ b/turbo.json
@@ -71,9 +71,9 @@
         "FORCE_ASSET_CDN",
         "ASSET_CDN_S3_ENDPOINT",
         "SITE_NAME",
-        "VERCEL_URL",
-        "CURRENT_CLI_VERSION"
+        "VERCEL_URL"
       ],
+      "passThroughEnv": ["CURRENT_CLI_VERSION"],
       "outputs": [".next/**", "!.next/cache/**"]
     },
     "www#build": {


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the new behavior?

- Fetches both CLI beta and latest release version.
- Adds `CURRENT_CLI_VERSION` as passThroughEnv because it's not needed at build time.

## Additional context

Add any other context or screenshots.
