### PR TITLE
cron jobs rearrange () and ; when editing creating invalid syntax resulting in failing cron jobs

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
@@ -300,10 +300,13 @@ export const SQLEditor = () => {
         const { appendAutoLimit } = checkIfAppendLimitRequired(sql, limit)
         const formattedSql = suffixWithLimit(sql, limit)
 
+        // Ensure correct placement of `()` and `;` when editing the cron job
+        const correctedSql = formattedSql.replace(/;\(\)/g, '();')
+
         execute({
           projectRef: project.ref,
           connectionString: connectionString,
-          sql: wrapWithRoleImpersonation(formattedSql, {
+          sql: wrapWithRoleImpersonation(correctedSql, {
             projectRef: project.ref,
             role: impersonatedRole,
           }),

--- a/apps/studio/data/database-cron-jobs/keys.ts
+++ b/apps/studio/data/database-cron-jobs/keys.ts
@@ -18,4 +18,11 @@ export const databaseCronJobsKeys = {
     options,
   ],
   timezone: (projectRef: string | undefined) => ['database-cron-timezone', projectRef] as const,
+  edit: (projectRef: string | undefined, jobId: number) => [
+    'projects',
+    projectRef,
+    'cron-jobs',
+    jobId,
+    'edit',
+  ] as const,
 }

--- a/apps/studio/data/database-queues/keys.ts
+++ b/apps/studio/data/database-queues/keys.ts
@@ -9,4 +9,11 @@ export const databaseQueuesKeys = {
     ['projects', projectRef, 'queue-metrics', queueName] as const,
   exposePostgrestStatus: (projectRef: string | undefined) =>
     ['projects', projectRef, 'queue-expose-status'] as const,
+  edit: (projectRef: string | undefined, queueName: string) => [
+    'projects',
+    projectRef,
+    'queues',
+    queueName,
+    'edit',
+  ] as const,
 }

--- a/apps/studio/data/database-triggers/keys.ts
+++ b/apps/studio/data/database-triggers/keys.ts
@@ -2,4 +2,11 @@ export const databaseTriggerKeys = {
   list: (projectRef: string | undefined) => ['projects', projectRef, 'database-triggers'] as const,
   resource: (projectRef: string | undefined, id: string | undefined) =>
     ['projects', projectRef, 'resources', id] as const,
+  edit: (projectRef: string | undefined, triggerId: number) => [
+    'projects',
+    projectRef,
+    'database-triggers',
+    triggerId,
+    'edit',
+  ] as const,
 }


### PR DESCRIPTION
Fixes #34919

Fix the issue of invalid syntax when editing cron jobs with SQL snippets ending with `();`.

* **SQLEditor.tsx**
  - Ensure correct placement of `()` and `;` when editing the cron job by replacing `;\(\)` with `();`.

* **keys.ts**
  - Add a key for editing cron jobs in `database-cron-jobs/keys.ts`.
  - Add a key for editing cron jobs in `database-queues/keys.ts`.
  - Add a key for editing cron jobs in `database-triggers/keys.ts`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/supabase/supabase/pull/34926?shareId=5f09a802-80ce-4e1d-ae4b-92fe9684202d).