### PR TITLE
Adding Sergio Cioban Filho to humans.txt

### DIFF
--- a/apps/docs/public/humans.txt
+++ b/apps/docs/public/humans.txt
@@ -81,6 +81,7 @@ Raminder Singh
 Rodrigo Mansueli
 Rory Wilding
 Sam Rose
+Sergio Cioban Filho
 Sreyas Udayavarman
 Stanislav M
 Stephen Morgan


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

No entry for "Sergio Cioban Filho" in humans.txt

## What is the new behavior?

humans.txt will have an entry for "Sergio Cioban FIlho"

## Additional context

