### PR TITLE
Reorder CLI upgrade details to instruct users on CLI pre-upgrade requirement

### DIFF
--- a/apps/docs/content/guides/local-development/cli/getting-started.mdx
+++ b/apps/docs/content/guides/local-development/cli/getting-started.mdx
@@ -83,6 +83,20 @@ npm install supabase --save-dev
 
 ## Updating the Supabase CLI
 
+Before updating the CLI, stop any Supabase containers running locally and delete their data volumes before proceeding with the upgrade. This ensures that Supabase managed services can apply new migrations on a clean state of the local database.
+
+<Admonition type="tip" label="Backup and stop running containers">
+
+Remember to save any local schema and data changes before stopping because the `--no-backup` flag will delete them.
+
+```sh
+supabase db diff -f my_schema
+supabase db dump --local --data-only > supabase/seed.sql
+supabase stop --no-backup
+```
+
+</Admonition>
+
 When a new [version](https://github.com/supabase/cli/releases) is released, you can update the CLI using the same methods.
 
 <Tabs
@@ -133,20 +147,6 @@ npm update supabase --save-dev
 
 </TabPanel>
 </Tabs>
-
-If you have any Supabase containers running locally, stop them and delete their data volumes before proceeding with the upgrade. This ensures that Supabase managed services can apply new migrations on a clean state of the local database.
-
-<Admonition type="tip" label="Backup and stop running containers">
-
-Remember to save any local schema and data changes before stopping because the `--no-backup` flag will delete them.
-
-```sh
-supabase db diff -f my_schema
-supabase db dump --local --data-only > supabase/seed.sql
-supabase stop --no-backup
-```
-
-</Admonition>
 
 ## Running Supabase locally
 


### PR DESCRIPTION
Actually provide fair warning by placing instructions to "stop any currently running local instance of Supabase" before the commands to run an upgrade. In haste, I ran the update command before reading I should stop my currently, locally running supabase instance and was worried that dev issues I was experiencing were due to that (instead of, say, my codebase or real logic errors in my architecture).

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

Yes

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

See above

## What is the new behavior?

See above

## Additional context
See above
