### PR TITLE
docs: only use JSR for Edge Function testing example

### DIFF
--- a/apps/docs/content/guides/functions/unit-test.mdx
+++ b/apps/docs/content/guides/functions/unit-test.mdx
@@ -34,11 +34,11 @@ The following script is a good example to get started with testing your Edge Fun
 
 ```typescript function-one-test.ts
 // Import required libraries and modules
-import { assert, assertEquals } from 'https://deno.land/std@0.192.0/testing/asserts.ts'
+import { assert, assertEquals } from 'jsr:@std/assert@1'
 import { createClient, SupabaseClient } from 'jsr:@supabase/supabase-js@2'
 
 // Will load the .env file to Deno.env
-import 'https://deno.land/x/dotenv@v3.2.2/load.ts'
+import 'jsr:@std/dotenv/load'
 
 // Set up the configuration for the Supabase client
 const supabaseUrl = Deno.env.get('SUPABASE_URL') ?? ''


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## Description

![image](https://github.com/user-attachments/assets/67c9962d-e6a1-4c87-b54f-faf7766ddd87)

As you can see on https://deno.land/std@0.192.0, the dependency moved `std` to JSR.

Also https://deno.land/x/dotenv is deprecated:

![image](https://github.com/user-attachments/assets/05776311-fa4d-4e18-860b-f53233ffc112)

I replaced https://deno.land/x/dotenv with the recommended dependency.

I tested this change locally:

![image](https://github.com/user-attachments/assets/44e6d01e-5a9b-4434-9aad-e162eaa5176e)

