### PR TITLE
docs: sveltekit env warning

### DIFF
--- a/apps/docs/content/guides/auth/server-side/sveltekit.mdx
+++ b/apps/docs/content/guides/auth/server-side/sveltekit.mdx
@@ -36,6 +36,12 @@ Fill in your `PUBLIC_SUPABASE_URL` and `PUBLIC_SUPABASE_ANON_KEY`:
 <ProjectConfigVariables variable="url" />
 <ProjectConfigVariables variable="anonKey" />
 
+<Admonition type="warning">
+
+`PUBLIC_SUPABASE_URL` and `PUBLIC_SUPABASE_ANON_KEY` are intentionally exposed to the client. These values are safe to expose as long as your [enable and create Row Level Security policies](https://supabase.com/docs/guides/getting-started/tutorials/with-sveltekit?queryGroups=database-method&database-method=sql#set-up-the-database-schema).
+
+</Admonition>
+
 </StepHikeCompact.Details>
 
 <StepHikeCompact.Code>

--- a/apps/docs/content/guides/auth/server-side/sveltekit.mdx
+++ b/apps/docs/content/guides/auth/server-side/sveltekit.mdx
@@ -38,7 +38,7 @@ Fill in your `PUBLIC_SUPABASE_URL` and `PUBLIC_SUPABASE_ANON_KEY`:
 
 <Admonition type="warning">
 
-`PUBLIC_SUPABASE_URL` and `PUBLIC_SUPABASE_ANON_KEY` are intentionally exposed to the client. These values are safe to expose as long as your [enable and create Row Level Security policies](https://supabase.com/docs/guides/getting-started/tutorials/with-sveltekit?queryGroups=database-method&database-method=sql#set-up-the-database-schema).
+`PUBLIC_SUPABASE_URL` and `PUBLIC_SUPABASE_ANON_KEY` are intentionally exposed to the client. These values are safe to expose as long as you [enable and create Row Level Security policies](https://supabase.com/docs/guides/getting-started/tutorials/with-sveltekit#set-up-the-database-schema).
 
 </Admonition>
 

--- a/apps/docs/content/guides/auth/server-side/sveltekit.mdx
+++ b/apps/docs/content/guides/auth/server-side/sveltekit.mdx
@@ -36,7 +36,7 @@ Fill in your `PUBLIC_SUPABASE_URL` and `PUBLIC_SUPABASE_ANON_KEY`:
 <ProjectConfigVariables variable="url" />
 <ProjectConfigVariables variable="anonKey" />
 
-<Admonition type="warning">
+<Admonition type="caution">
 
 `PUBLIC_SUPABASE_URL` and `PUBLIC_SUPABASE_ANON_KEY` are intentionally exposed to the client. These values are safe to expose as long as you [enable and create Row Level Security policies](https://supabase.com/docs/guides/getting-started/tutorials/with-sveltekit#set-up-the-database-schema).
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Supabase Docs - [SvelteKit Auth](https://supabase.com/docs/guides/auth/server-side/sveltekit)

## What is the current behavior?

The guide shows env values in the guide but no warning that rls needs to be enabled.

## What is the new behavior?

Admonition added to warn the user:


https://github.com/user-attachments/assets/4916f6d9-b893-4651-b653-da70d02e2b28

## Additional context

Closes #31106
