### PR TITLE
Fix mobile nav menu for org nav layout

### DIFF
--- a/apps/studio/components/layouts/ProjectLayout/LayoutHeader/LayoutHeader.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/LayoutHeader/LayoutHeader.tsx
@@ -101,25 +101,9 @@ const LayoutHeader = ({
     <header className={cn('flex h-12 items-center flex-shrink-0 border-b')}>
       <div
         className={cn(
-          'flex items-center justify-between h-full pr-3 flex-1 overflow-x-auto gap-x-4 md:pl-4'
+          'flex items-center justify-between h-full pr-3 flex-1 overflow-x-auto gap-x-8 pl-4'
         )}
       >
-        {showProductMenu && (
-          <div className="flex items-center justify-center border-r flex-0 md:hidden h-full aspect-square">
-            <button
-              title="Menu dropdown button"
-              className={cn(
-                'group/view-toggle flex justify-center items-center border-none gap-1 !bg-transparent rounded-md min-w-[30px] w-[30px] h-[30px]'
-              )}
-              onClick={() => setMobileMenuOpen(true)}
-            >
-              <div className="flex flex-col gap-y-1">
-                <div className="h-px inline-block left-0 w-4 transition-all ease-out bg-foreground-lighter group-hover/view-toggle:bg-foreground p-0 m-0" />
-                <div className="h-px inline-block left-0 w-3 transition-all ease-out bg-foreground-lighter group-hover/view-toggle:bg-foreground p-0 m-0" />
-              </div>
-            </button>
-          </div>
-        )}
         <div className="flex items-center text-sm">
           <HomeIcon />
           <>
@@ -232,10 +216,10 @@ const LayoutHeader = ({
             exit={{ opacity: 0, x: 0, width: 0 }}
             transition={{ duration: 0.15, ease: 'easeOut' }}
           >
-            <div className="border-r h-full flex items-center justify-center md:px-2">
+            <div className="border-r h-full flex items-center justify-center px-2">
               <InlineEditorButton />
             </div>
-            <div className="md:px-2">
+            <div className="px-2">
               <AssistantButton />
             </div>
           </motion.div>


### PR DESCRIPTION
Fixes FE-1573

Addresses the following issues that were identified
- The mobile navigation menu was using the new org layout one despite the feature preview being toggled off. This resulted in incorrect links to org settings pages as the org slug in the URL was undefined. Fix is to reinstate the old mobile nav menu when feature preview is off
![image](https://github.com/user-attachments/assets/58c02c98-4d5a-4d1b-a133-0c33f8ee390a)

- Fixes some padding issues in a  when nav layout preview is on
  - Before:
![image](https://github.com/user-attachments/assets/c6201ca8-a5bc-408f-889b-ac5b4c771bda)
![image](https://github.com/user-attachments/assets/9228a91c-4685-4c18-9e61-9a0efb8b5c17)
  - After:
![image](https://github.com/user-attachments/assets/17a27479-9622-46b3-9f2c-be1878db59f0)
![image](https://github.com/user-attachments/assets/11041e98-acda-4583-bd56-debc1aa9dd89)

