### PR TITLE
Fix re-rendering of Account AuditLogs

### DIFF
--- a/apps/studio/components/interfaces/Account/AuditLogs.tsx
+++ b/apps/studio/components/interfaces/Account/AuditLogs.tsx
@@ -72,7 +72,7 @@ const AuditLogs = () => {
     }, 5 * 60000)
 
     return () => clearInterval(interval)
-  }, [])
+  }, [dateRange.from, dateRange.to])
 
   return (
     <>

--- a/apps/studio/components/interfaces/Account/AuditLogs.tsx
+++ b/apps/studio/components/interfaces/Account/AuditLogs.tsx
@@ -57,10 +57,6 @@ const AuditLogs = () => {
   const minDate = dayjs().subtract(retentionPeriod, 'days')
   const maxDate = dayjs()
 
-  useEffect(() => {
-    console.log('Check')
-  }, [])
-
   // This feature depends on the subscription tier of the user. Free user can view logs up to 1 day
   // in the past. The API limits the logs to maximum of 1 day and 5 minutes so when the page is
   // viewed for more than 5 minutes, the call parameters needs to be updated. This also works with

--- a/apps/studio/components/interfaces/Account/AuditLogs.tsx
+++ b/apps/studio/components/interfaces/Account/AuditLogs.tsx
@@ -38,23 +38,6 @@ const AuditLogs = () => {
       iso_timestamp_end: dateRange.to,
     })
 
-  // This feature depends on the subscription tier of the user. Free user can view logs up to 1 day
-  // in the past. The API limits the logs to maximum of 1 day and 5 minutes so when the page is
-  // viewed for more than 5 minutes, the call parameters needs to be updated. This also works with
-  // higher tiers (7 days of logs).The user will see a loading shimmer.
-  useEffect(() => {
-    const duration = dayjs(dateRange.from).diff(dayjs(dateRange.to))
-    const interval = setInterval(() => {
-      const currentTime = dayjs().utc().set('millisecond', 0)
-      setDateRange({
-        from: currentTime.add(duration).toISOString(),
-        to: currentTime.toISOString(),
-      })
-    }, 5 * 60000)
-
-    return () => clearInterval(interval)
-  }, [dateRange.from, dateRange.to])
-
   const retentionPeriod = data?.retention_period ?? 0
   const logs = data?.result ?? []
   const sortedLogs = logs
@@ -73,6 +56,27 @@ const AuditLogs = () => {
 
   const minDate = dayjs().subtract(retentionPeriod, 'days')
   const maxDate = dayjs()
+
+  useEffect(() => {
+    console.log('Check')
+  }, [])
+
+  // This feature depends on the subscription tier of the user. Free user can view logs up to 1 day
+  // in the past. The API limits the logs to maximum of 1 day and 5 minutes so when the page is
+  // viewed for more than 5 minutes, the call parameters needs to be updated. This also works with
+  // higher tiers (7 days of logs).The user will see a loading shimmer.
+  useEffect(() => {
+    const duration = dayjs(dateRange.from).diff(dayjs(dateRange.to))
+    const interval = setInterval(() => {
+      const currentTime = dayjs().utc().set('millisecond', 0)
+      setDateRange({
+        from: currentTime.add(duration).toISOString(),
+        to: currentTime.toISOString(),
+      })
+    }, 5 * 60000)
+
+    return () => clearInterval(interval)
+  }, [])
 
   return (
     <>

--- a/apps/studio/components/layouts/AccountLayout/AccountLayout.tsx
+++ b/apps/studio/components/layouts/AccountLayout/AccountLayout.tsx
@@ -47,42 +47,42 @@ const AccountLayout = ({ children, title }: PropsWithChildren<AccountLayoutProps
     }
   }, [router])
 
-  if (!newLayoutPreview) {
-    return children
-  }
-
   return (
     <>
       <Head>
         <title>{title ? `${title} | Supabase` : 'Supabase'}</title>
         <meta name="description" content="Supabase Studio" />
       </Head>
-      <div className="flex flex-col h-screen w-screen">
-        <ScaffoldContainerLegacy>
-          <Link
-            href={appSnap.lastRouteBeforeVisitingAccountPage ?? '/'}
-            className="flex text-xs flex-row gap-2 items-center text-foreground-lighter focus-visible:text-foreground hover:text-foreground"
-          >
-            <ArrowLeft strokeWidth={1.5} size={14} />
-            Back to dashboard
-          </Link>
-          <ScaffoldTitle>Account settings</ScaffoldTitle>
-        </ScaffoldContainerLegacy>
-        <div className="border-b">
-          <NavMenu
-            className={cn(PADDING_CLASSES, MAX_WIDTH_CLASSES, 'border-none')}
-            aria-label="Organization menu navigation"
-          >
-            {accountLinks.map((item, i) => (
-              <NavMenuItem
-                key={`${item.key}-${i}`}
-                active={(item.key === currentPath || item.keys?.includes(currentPath)) ?? false}
+      <div className={cn(newLayoutPreview ? 'flex flex-col h-screen w-screen' : '')}>
+        {newLayoutPreview && (
+          <>
+            <ScaffoldContainerLegacy>
+              <Link
+                href={appSnap.lastRouteBeforeVisitingAccountPage ?? '/'}
+                className="flex text-xs flex-row gap-2 items-center text-foreground-lighter focus-visible:text-foreground hover:text-foreground"
               >
-                <Link href={item.href}>{item.label}</Link>
-              </NavMenuItem>
-            ))}
-          </NavMenu>
-        </div>
+                <ArrowLeft strokeWidth={1.5} size={14} />
+                Back to dashboard
+              </Link>
+              <ScaffoldTitle>Account settings</ScaffoldTitle>
+            </ScaffoldContainerLegacy>
+            <div className="border-b">
+              <NavMenu
+                className={cn(PADDING_CLASSES, MAX_WIDTH_CLASSES, 'border-none')}
+                aria-label="Organization menu navigation"
+              >
+                {accountLinks.map((item, i) => (
+                  <NavMenuItem
+                    key={`${item.key}-${i}`}
+                    active={(item.key === currentPath || item.keys?.includes(currentPath)) ?? false}
+                  >
+                    <Link href={item.href}>{item.label}</Link>
+                  </NavMenuItem>
+                ))}
+              </NavMenu>
+            </div>
+          </>
+        )}
         {children}
       </div>
     </>

--- a/apps/studio/components/layouts/OrganizationLayout.tsx
+++ b/apps/studio/components/layouts/OrganizationLayout.tsx
@@ -1,6 +1,6 @@
 import { ExternalLink } from 'lucide-react'
 import { useRouter } from 'next/router'
-import type { PropsWithChildren } from 'react'
+import { type PropsWithChildren } from 'react'
 
 import { useNewLayout } from 'components/interfaces/App/FeaturePreview/FeaturePreviewContext'
 import PartnerIcon from 'components/ui/PartnerIcon'
@@ -16,16 +16,103 @@ import WithSidebar from './AccountLayout/WithSidebar'
 import LayoutHeader from './ProjectLayout/LayoutHeader/LayoutHeader'
 
 const OrganizationLayout = ({ children }: PropsWithChildren<{}>) => {
+  const router = useRouter()
   const newLayoutPreview = useNewLayout()
 
   const selectedOrganization = useSelectedOrganization()
   const { data: organizations } = useOrganizationsQuery()
 
-  const router = useRouter()
-
   const { data, isSuccess } = useVercelRedirectQuery({
     installationId: selectedOrganization?.partner_id,
   })
+
+  const organizationsLinks = (organizations ?? [])
+    .map((organization) => ({
+      isActive:
+        router.pathname.startsWith('/org/') && selectedOrganization?.slug === organization.slug,
+      label: organization.name,
+      href: `/org/${organization.slug}/general`,
+      key: organization.slug,
+      icon: <PartnerIcon organization={organization} />,
+    }))
+    .sort((a, b) => a.label.localeCompare(b.label))
+
+  const sectionsWithHeaders: SidebarSection[] = [
+    {
+      heading: 'Projects',
+      key: 'projects',
+      links: [
+        {
+          isActive: router.pathname === '/projects',
+          label: 'All projects',
+          href: '/projects',
+          key: 'all-projects-item',
+        },
+      ],
+    },
+    ...(IS_PLATFORM && organizationsLinks?.length > 0
+      ? [
+          {
+            heading: 'Organizations',
+            key: 'organizations',
+            links: organizationsLinks,
+          },
+        ]
+      : []),
+    ...(IS_PLATFORM
+      ? [
+          {
+            heading: 'Account',
+            key: 'account',
+            links: [
+              {
+                isActive: router.pathname === `/account/me`,
+                label: 'Preferences',
+                href: `/account/me`,
+                key: `/account/me`,
+              },
+              {
+                isActive: router.pathname === `/account/tokens`,
+                label: 'Access Tokens',
+                href: `/account/tokens`,
+                key: `/account/tokens`,
+              },
+
+              {
+                isActive: router.pathname === `/account/security`,
+                label: 'Security',
+                href: `/account/security`,
+                key: `/account/security`,
+              },
+              {
+                isActive: router.pathname === `/account/audit`,
+                label: 'Audit Logs',
+                href: `/account/audit`,
+                key: `/account/audit`,
+              },
+            ],
+          },
+        ]
+      : []),
+    {
+      heading: 'Documentation',
+      key: 'documentation',
+      links: [
+        {
+          key: 'ext-guides',
+          label: 'Guides',
+          href: 'https://supabase.com/docs',
+          isExternal: true,
+        },
+        {
+          key: 'ext-guides',
+          label: 'API Reference',
+          href: 'https://supabase.com/docs/guides/api',
+          isExternal: true,
+        },
+      ],
+    },
+  ]
 
   const Content = () => (
     <div className={cn('w-full flex flex-col overflow-hidden')}>
@@ -50,95 +137,6 @@ const OrganizationLayout = ({ children }: PropsWithChildren<{}>) => {
   )
 
   if (!newLayoutPreview) {
-    const organizationsLinks = (organizations ?? [])
-
-      .map((organization) => ({
-        isActive:
-          router.pathname.startsWith('/org/') && selectedOrganization?.slug === organization.slug,
-        label: organization.name,
-        href: `/org/${organization.slug}/general`,
-        key: organization.slug,
-        icon: <PartnerIcon organization={organization} />,
-      }))
-      .sort((a, b) => a.label.localeCompare(b.label))
-
-    const sectionsWithHeaders: SidebarSection[] = [
-      {
-        heading: 'Projects',
-        key: 'projects',
-        links: [
-          {
-            isActive: router.pathname === '/projects',
-            label: 'All projects',
-            href: '/projects',
-            key: 'all-projects-item',
-          },
-        ],
-      },
-      ...(IS_PLATFORM && organizationsLinks?.length > 0
-        ? [
-            {
-              heading: 'Organizations',
-              key: 'organizations',
-              links: organizationsLinks,
-            },
-          ]
-        : []),
-      ...(IS_PLATFORM
-        ? [
-            {
-              heading: 'Account',
-              key: 'account',
-              links: [
-                {
-                  isActive: router.pathname === `/account/me`,
-                  label: 'Preferences',
-                  href: `/account/me`,
-                  key: `/account/me`,
-                },
-                {
-                  isActive: router.pathname === `/account/tokens`,
-                  label: 'Access Tokens',
-                  href: `/account/tokens`,
-                  key: `/account/tokens`,
-                },
-
-                {
-                  isActive: router.pathname === `/account/security`,
-                  label: 'Security',
-                  href: `/account/security`,
-                  key: `/account/security`,
-                },
-                {
-                  isActive: router.pathname === `/account/audit`,
-                  label: 'Audit Logs',
-                  href: `/account/audit`,
-                  key: `/account/audit`,
-                },
-              ],
-            },
-          ]
-        : []),
-      {
-        heading: 'Documentation',
-        key: 'documentation',
-        links: [
-          {
-            key: 'ext-guides',
-            label: 'Guides',
-            href: 'https://supabase.com/docs',
-            isExternal: true,
-          },
-          {
-            key: 'ext-guides',
-            label: 'API Reference',
-            href: 'https://supabase.com/docs/guides/api',
-            isExternal: true,
-          },
-        ],
-      },
-    ]
-
     return (
       <WithSidebar
         title={selectedOrganization?.name ?? 'Supabase'}

--- a/apps/studio/components/layouts/OrganizationLayout.tsx
+++ b/apps/studio/components/layouts/OrganizationLayout.tsx
@@ -138,7 +138,7 @@ const OrganizationLayout = ({ children }: PropsWithChildren<{}>) => {
     },
   ]
 
-  const OrganizationLayoutContentWrapper = newLayoutPreview ? WithSidebar : Fragment
+  const OrganizationLayoutContentWrapper = !newLayoutPreview ? WithSidebar : Fragment
 
   return (
     <OrganizationLayoutContentWrapper

--- a/apps/studio/data/profile/profile-audit-logs-query.ts
+++ b/apps/studio/data/profile/profile-audit-logs-query.ts
@@ -2,6 +2,7 @@ import { useQuery, UseQueryOptions } from '@tanstack/react-query'
 
 import { get, handleError } from 'data/fetchers'
 import type { AuditLog } from 'data/organizations/organization-audit-logs-query'
+import { IS_PLATFORM } from 'lib/constants'
 import type { ResponseError } from 'types'
 import { profileKeys } from './keys'
 
@@ -43,6 +44,7 @@ export const useProfileAuditLogsQuery = <TData = ProfileAuditLogsData>(
     profileKeys.auditLogs({ date_start: iso_timestamp_start, date_end: iso_timestamp_end }),
     ({ signal }) => getProfileAuditLogs(vars, signal),
     {
+      enabled: IS_PLATFORM && options.enabled,
       ...options,
     }
   )

--- a/apps/studio/pages/account/audit.tsx
+++ b/apps/studio/pages/account/audit.tsx
@@ -6,32 +6,26 @@ import DefaultLayout from 'components/layouts/DefaultLayout'
 import OrganizationLayout from 'components/layouts/OrganizationLayout'
 import {
   ScaffoldContainer,
-  ScaffoldContainerLegacy,
   ScaffoldDescription,
   ScaffoldHeader,
   ScaffoldTitle,
 } from 'components/layouts/Scaffold'
 import type { NextPageWithLayout } from 'types'
+import { cn } from 'ui'
 
 const Audit: NextPageWithLayout = () => {
   const newLayoutPreview = useNewLayout()
 
-  if (newLayoutPreview) {
-    return (
-      <ScaffoldContainerLegacy className="gap-0">
-        <AuditLogs />
-      </ScaffoldContainerLegacy>
-    )
-  }
-
   return (
-    <ScaffoldContainer>
-      <ScaffoldHeader>
-        <ScaffoldTitle>Account Audit Logs</ScaffoldTitle>
-        <ScaffoldDescription>
-          View the audit log trail of actions made from your account
-        </ScaffoldDescription>
-      </ScaffoldHeader>
+    <ScaffoldContainer className={cn(newLayoutPreview ? '[&>div]:mt-8' : '')}>
+      {!newLayoutPreview && (
+        <ScaffoldHeader>
+          <ScaffoldTitle>Account Audit Logs</ScaffoldTitle>
+          <ScaffoldDescription>
+            View the audit log trail of actions made from your account
+          </ScaffoldDescription>
+        </ScaffoldHeader>
+      )}
       <AuditLogs />
     </ScaffoldContainer>
   )


### PR DESCRIPTION
There's some unnecessary re-renders happening on the account audit logs pages, mainly caused by the layout components - this resulted in many unnecessary API requests getting triggered to fetch the audit logs but ultimately getting cancelled.

The fixes here adjusts 2 layouts - AccountLayout and OrganizationLayout, with the main fix being in the latter by pulling out `<Content>` outside of the `OrganizationLayout`. This brings the re-render down from 10-ish to 2 - the 2 re-renders are unavoidable atm due to the org nav layout feature preview (it'll go away once the org nav layout feature preview becomes the default)

## To reproduce
- Go to Account Audit Logs page, then refresh - you'll notice that the browser fires several endpoints to the audit logs endpoint, which get cancelled, one of them resulting in a 500, and the last one coming back successfully

## To test
- Verify that there's at most max 2 requests only when refreshing the browser while on the account audit logs page