### PR TITLE
Fix/safari browser rendering Popover in grid header

### DIFF
--- a/apps/studio/components/grid/components/header/filter/FilterPopover.tsx
+++ b/apps/studio/components/grid/components/header/filter/FilterPopover.tsx
@@ -39,7 +39,7 @@ const FilterPopover = ({ filters, onApplyFilters }: FilterPopoverProps) => {
         className="p-0 w-96"
         side="bottom"
         align="start"
-        // safari fix
+        // using `portal` for a safari fix. issue with rendering outside of body element
         // https://www.radix-ui.com/primitives/docs/components/popover#portal
         portal={true}
       >

--- a/apps/studio/components/grid/components/header/filter/FilterPopover.tsx
+++ b/apps/studio/components/grid/components/header/filter/FilterPopover.tsx
@@ -35,7 +35,14 @@ const FilterPopover = ({ filters, onApplyFilters }: FilterPopoverProps) => {
           {btnText}
         </Button>
       </PopoverTrigger_Shadcn_>
-      <PopoverContent_Shadcn_ className="p-0 w-96" side="bottom" align="start" portal={true}>
+      <PopoverContent_Shadcn_
+        className="p-0 w-96"
+        side="bottom"
+        align="start"
+        // safari fix
+        // https://www.radix-ui.com/primitives/docs/components/popover#portal
+        portal={true}
+      >
         <FilterOverlay filters={filters} onApplyFilters={onApplyFilters} />
       </PopoverContent_Shadcn_>
     </Popover_Shadcn_>

--- a/apps/studio/components/grid/components/header/filter/FilterPopover.tsx
+++ b/apps/studio/components/grid/components/header/filter/FilterPopover.tsx
@@ -35,7 +35,7 @@ const FilterPopover = ({ filters, onApplyFilters }: FilterPopoverProps) => {
           {btnText}
         </Button>
       </PopoverTrigger_Shadcn_>
-      <PopoverContent_Shadcn_ className="p-0 w-96" side="bottom" align="start">
+      <PopoverContent_Shadcn_ className="p-0 w-96" side="bottom" align="start" portal={true}>
         <FilterOverlay filters={filters} onApplyFilters={onApplyFilters} />
       </PopoverContent_Shadcn_>
     </Popover_Shadcn_>

--- a/apps/studio/components/grid/components/header/sort/SortPopover.tsx
+++ b/apps/studio/components/grid/components/header/sort/SortPopover.tsx
@@ -36,7 +36,14 @@ const SortPopover = ({ sorts, onApplySorts }: SortPopoverProps) => {
           {btnText}
         </Button>
       </PopoverTrigger_Shadcn_>
-      <PopoverContent_Shadcn_ className="p-0 w-96" side="bottom" align="start" portal={true}>
+      <PopoverContent_Shadcn_
+        className="p-0 w-96"
+        side="bottom"
+        align="start"
+        // using `portal` for a safari fix. issue with rendering outside of body element
+        // https://www.radix-ui.com/primitives/docs/components/popover#portal
+        portal={true}
+      >
         <SortOverlay sorts={sorts} onApplySorts={onApplySorts} />
       </PopoverContent_Shadcn_>
     </Popover_Shadcn_>

--- a/apps/studio/components/grid/components/header/sort/SortPopover.tsx
+++ b/apps/studio/components/grid/components/header/sort/SortPopover.tsx
@@ -36,7 +36,7 @@ const SortPopover = ({ sorts, onApplySorts }: SortPopoverProps) => {
           {btnText}
         </Button>
       </PopoverTrigger_Shadcn_>
-      <PopoverContent_Shadcn_ className="p-0 w-96" side="bottom" align="start">
+      <PopoverContent_Shadcn_ className="p-0 w-96" side="bottom" align="start" portal={true}>
         <SortOverlay sorts={sorts} onApplySorts={onApplySorts} />
       </PopoverContent_Shadcn_>
     </Popover_Shadcn_>

--- a/apps/studio/components/interfaces/RoleImpersonationSelector/RoleImpersonationPopover.tsx
+++ b/apps/studio/components/interfaces/RoleImpersonationSelector/RoleImpersonationPopover.tsx
@@ -25,7 +25,7 @@ const RoleImpersonationPopover = ({
   const currentRole = state.role?.role ?? serviceRoleLabel ?? 'service role'
 
   return (
-    <Popover_Shadcn_ open={isOpen} onOpenChange={setIsOpen} modal={false}>
+    <Popover_Shadcn_ open={isOpen} onOpenChange={setIsOpen}>
       <PopoverTrigger_Shadcn_ asChild>
         <Button
           size="tiny"
@@ -56,7 +56,14 @@ const RoleImpersonationPopover = ({
           </div>
         </Button>
       </PopoverTrigger_Shadcn_>
-      <PopoverContent_Shadcn_ className="p-0 w-full overflow-hidden" side="bottom" align={align}>
+      <PopoverContent_Shadcn_
+        className="p-0 w-full overflow-hidden"
+        side="bottom"
+        align={align}
+        // using `portal` for a safari fix. issue with rendering outside of body element
+        // https://www.radix-ui.com/primitives/docs/components/popover#portal
+        portal={true}
+      >
         <RoleImpersonationSelector serviceRoleLabel={serviceRoleLabel} />
       </PopoverContent_Shadcn_>
     </Popover_Shadcn_>

--- a/apps/studio/components/interfaces/TableGridEditor/GridHeaderActions.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/GridHeaderActions.tsx
@@ -262,7 +262,13 @@ const GridHeaderActions = ({ table }: GridHeaderActionsProps) => {
                     RLS disabled
                   </Button>
                 </PopoverTrigger_Shadcn_>
-                <PopoverContent_Shadcn_ className="min-w-[395px] text-sm" align="end">
+                <PopoverContent_Shadcn_
+                  className="min-w-[395px] text-sm"
+                  align="end"
+                  // using `portal` for a safari fix. issue with rendering outside of body element
+                  // https://www.radix-ui.com/primitives/docs/components/popover#portal
+                  portal={true}
+                >
                   <h3 className="flex items-center gap-2">
                     <Lock size={16} /> Row Level Security (RLS)
                   </h3>
@@ -297,7 +303,13 @@ const GridHeaderActions = ({ table }: GridHeaderActionsProps) => {
                   Security Definer view
                 </Button>
               </PopoverTrigger_Shadcn_>
-              <PopoverContent_Shadcn_ className="min-w-[395px] text-sm" align="end">
+              <PopoverContent_Shadcn_
+                className="min-w-[395px] text-sm"
+                align="end"
+                // using `portal` for a safari fix. issue with rendering outside of body element
+                // https://www.radix-ui.com/primitives/docs/components/popover#portal
+                portal={true}
+              >
                 <h3 className="flex items-center gap-2">
                   <Unlock size={16} /> Secure your View
                 </h3>
@@ -342,7 +354,13 @@ const GridHeaderActions = ({ table }: GridHeaderActionsProps) => {
                   Security Definer view
                 </Button>
               </PopoverTrigger_Shadcn_>
-              <PopoverContent_Shadcn_ className="min-w-[395px] text-sm" align="end">
+              <PopoverContent_Shadcn_
+                className="min-w-[395px] text-sm"
+                align="end"
+                // using `portal` for a safari fix. issue with rendering outside of body element
+                // https://www.radix-ui.com/primitives/docs/components/popover#portal
+                portal={true}
+              >
                 <h3 className="flex items-center gap-2">
                   <Unlock size={16} /> Secure your View
                 </h3>
@@ -379,7 +397,13 @@ const GridHeaderActions = ({ table }: GridHeaderActionsProps) => {
                   Unprotected Data API access
                 </Button>
               </PopoverTrigger_Shadcn_>
-              <PopoverContent_Shadcn_ className="min-w-[395px] text-sm" align="end">
+              <PopoverContent_Shadcn_
+                className="min-w-[395px] text-sm"
+                align="end"
+                // using `portal` for a safari fix. issue with rendering outside of body element
+                // https://www.radix-ui.com/primitives/docs/components/popover#portal
+                portal={true}
+              >
                 <h3 className="flex items-center gap-2">
                   <Unlock size={16} /> Secure Foreign table
                 </h3>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

- adds `portal` to force Popover to render in body element