### PR TITLE
Fix more dropdowns, specifically in ForeignRowSelector

### DIFF
--- a/apps/studio/components/grid/components/common/DropdownControl.tsx
+++ b/apps/studio/components/grid/components/common/DropdownControl.tsx
@@ -21,7 +21,7 @@ export const DropdownControl = ({
   onSelect,
 }: PropsWithChildren<DropdownControlProps>) => {
   return (
-    <DropdownMenu>
+    <DropdownMenu modal>
       <DropdownMenuTrigger>{children}</DropdownMenuTrigger>
       <DropdownMenuContent side={side} align={align}>
         <div className="dropdown-control" style={{ maxHeight: '30vh' }}>

--- a/apps/studio/components/grid/components/header/filter/FilterPopover.tsx
+++ b/apps/studio/components/grid/components/header/filter/FilterPopover.tsx
@@ -29,7 +29,7 @@ const FilterPopover = ({ filters, onApplyFilters }: FilterPopoverProps) => {
       : 'Filter'
 
   return (
-    <Popover_Shadcn_ open={open} onOpenChange={setOpen} modal={false}>
+    <Popover_Shadcn_ modal open={open} onOpenChange={setOpen}>
       <PopoverTrigger_Shadcn_ asChild>
         <Button type={(filters || []).length > 0 ? 'link' : 'text'} icon={<FilterIcon />}>
           {btnText}

--- a/apps/studio/components/grid/components/header/filter/FilterRow.tsx
+++ b/apps/studio/components/grid/components/header/filter/FilterRow.tsx
@@ -4,7 +4,8 @@ import { KeyboardEvent, memo } from 'react'
 import { DropdownControl } from 'components/grid/components/common/DropdownControl'
 import type { Filter, FilterOperator } from 'components/grid/types'
 import { useTableEditorTableStateSnapshot } from 'state/table-editor-table'
-import { Button, Input } from 'ui'
+import { Button } from 'ui'
+import { Input } from 'ui-patterns/DataInputs/Input'
 import { FilterOperatorOptions } from './Filter.constants'
 
 export interface FilterRowProps {

--- a/apps/studio/components/grid/components/header/sort/SortPopover.tsx
+++ b/apps/studio/components/grid/components/header/sort/SortPopover.tsx
@@ -30,7 +30,7 @@ const SortPopover = ({ sorts, onApplySorts }: SortPopoverProps) => {
       : 'Sort'
 
   return (
-    <Popover_Shadcn_ modal={false} open={open} onOpenChange={setOpen}>
+    <Popover_Shadcn_ modal open={open} onOpenChange={setOpen}>
       <PopoverTrigger_Shadcn_ asChild>
         <Button type={(sorts || []).length > 0 ? 'link' : 'text'} icon={<List />}>
           {btnText}

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/DateTimeInput/DateTimeInput.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/DateTimeInput/DateTimeInput.tsx
@@ -59,7 +59,7 @@ const DateTimeInput = ({
       step={inputType == 'datetime-local' || inputType == 'time' ? '1' : undefined}
       actions={
         !disabled && (
-          <DropdownMenu>
+          <DropdownMenu modal>
             <DropdownMenuTrigger asChild>
               <Button type="default" icon={<Edit />} className="px-1.5" />
             </DropdownMenuTrigger>

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/InputField.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/InputField.tsx
@@ -177,7 +177,7 @@ const InputField = ({
                   : `NULL (Default: ${field.defaultValue})`
           }
           actions={
-            <DropdownMenu>
+            <DropdownMenu modal>
               <DropdownMenuTrigger asChild>
                 <Button type="default" icon={<Edit />} className="px-1.5" />
               </DropdownMenuTrigger>


### PR DESCRIPTION
Adding more `modal` param in the dropdowns within ForeignRowSelector

This particular part of the UI wasn't clickable
![image](https://github.com/user-attachments/assets/b12ee0e3-f78d-4005-945c-8c24eeac11a8)

Also added `modal` param for these part of the Table Editor
- DateTimeInput
![image](https://github.com/user-attachments/assets/f312fd8b-95d4-4209-a129-0e23072d12b4)
- InputField -> Text Area
![image](https://github.com/user-attachments/assets/6f1675d3-03e3-4d35-82f2-6ba0c19743da)
