### PR TITLE
Downgrade and fix radix dialog version to 1.0.5, and remove unnecessary modal props from all usages of DropdownMenu

### DIFF
--- a/apps/studio/components/grid/components/header/Header.tsx
+++ b/apps/studio/components/grid/components/header/Header.tsx
@@ -161,8 +161,8 @@ const DefaultHeader = () => {
   return (
     <div className="flex items-center gap-4">
       <div className="flex items-center gap-2">
-        <FilterPopover portal filters={filters} onApplyFilters={onApplyFilters} />
-        <SortPopover portal sorts={sorts} onApplySorts={onApplySorts} />
+        <FilterPopover filters={filters} onApplyFilters={onApplyFilters} />
+        <SortPopover sorts={sorts} onApplySorts={onApplySorts} />
       </div>
       {canAddNew && (
         <>

--- a/apps/studio/components/grid/components/header/Header.tsx
+++ b/apps/studio/components/grid/components/header/Header.tsx
@@ -161,8 +161,8 @@ const DefaultHeader = () => {
   return (
     <div className="flex items-center gap-4">
       <div className="flex items-center gap-2">
-        <FilterPopover filters={filters} onApplyFilters={onApplyFilters} />
-        <SortPopover sorts={sorts} onApplySorts={onApplySorts} />
+        <FilterPopover portal filters={filters} onApplyFilters={onApplyFilters} />
+        <SortPopover portal sorts={sorts} onApplySorts={onApplySorts} />
       </div>
       {canAddNew && (
         <>

--- a/apps/studio/components/grid/components/header/filter/FilterPopover.tsx
+++ b/apps/studio/components/grid/components/header/filter/FilterPopover.tsx
@@ -21,7 +21,7 @@ export interface FilterPopoverProps {
   onApplyFilters: (filters: Filter[]) => void
 }
 
-const FilterPopover = ({ filters, portal = false, onApplyFilters }: FilterPopoverProps) => {
+const FilterPopover = ({ filters, portal = true, onApplyFilters }: FilterPopoverProps) => {
   const [open, setOpen] = useState(false)
 
   const btnText =

--- a/apps/studio/components/grid/components/header/filter/FilterPopover.tsx
+++ b/apps/studio/components/grid/components/header/filter/FilterPopover.tsx
@@ -17,10 +17,11 @@ import FilterRow from './FilterRow'
 
 export interface FilterPopoverProps {
   filters: string[]
+  portal?: boolean
   onApplyFilters: (filters: Filter[]) => void
 }
 
-const FilterPopover = ({ filters, onApplyFilters }: FilterPopoverProps) => {
+const FilterPopover = ({ filters, portal = false, onApplyFilters }: FilterPopoverProps) => {
   const [open, setOpen] = useState(false)
 
   const btnText =
@@ -35,14 +36,7 @@ const FilterPopover = ({ filters, onApplyFilters }: FilterPopoverProps) => {
           {btnText}
         </Button>
       </PopoverTrigger_Shadcn_>
-      <PopoverContent_Shadcn_
-        className="p-0 w-96"
-        side="bottom"
-        align="start"
-        // using `portal` for a safari fix. issue with rendering outside of body element
-        // https://www.radix-ui.com/primitives/docs/components/popover#portal
-        portal={true}
-      >
+      <PopoverContent_Shadcn_ className="p-0 w-96" side="bottom" align="start" portal={portal}>
         <FilterOverlay filters={filters} onApplyFilters={onApplyFilters} />
       </PopoverContent_Shadcn_>
     </Popover_Shadcn_>

--- a/apps/studio/components/grid/components/header/sort/SortPopover.tsx
+++ b/apps/studio/components/grid/components/header/sort/SortPopover.tsx
@@ -22,7 +22,7 @@ export interface SortPopoverProps {
   onApplySorts: (sorts: Sort[]) => void
 }
 
-const SortPopover = ({ sorts, portal = false, onApplySorts }: SortPopoverProps) => {
+const SortPopover = ({ sorts, portal = true, onApplySorts }: SortPopoverProps) => {
   const [open, setOpen] = useState(false)
 
   const btnText =

--- a/apps/studio/components/grid/components/header/sort/SortPopover.tsx
+++ b/apps/studio/components/grid/components/header/sort/SortPopover.tsx
@@ -18,10 +18,11 @@ import SortRow from './SortRow'
 
 export interface SortPopoverProps {
   sorts: string[]
+  portal?: boolean
   onApplySorts: (sorts: Sort[]) => void
 }
 
-const SortPopover = ({ sorts, onApplySorts }: SortPopoverProps) => {
+const SortPopover = ({ sorts, portal = false, onApplySorts }: SortPopoverProps) => {
   const [open, setOpen] = useState(false)
 
   const btnText =
@@ -36,14 +37,7 @@ const SortPopover = ({ sorts, onApplySorts }: SortPopoverProps) => {
           {btnText}
         </Button>
       </PopoverTrigger_Shadcn_>
-      <PopoverContent_Shadcn_
-        className="p-0 w-96"
-        side="bottom"
-        align="start"
-        // using `portal` for a safari fix. issue with rendering outside of body element
-        // https://www.radix-ui.com/primitives/docs/components/popover#portal
-        portal={true}
-      >
+      <PopoverContent_Shadcn_ className="p-0 w-96" side="bottom" align="start" portal={portal}>
         <SortOverlay sorts={sorts} onApplySorts={onApplySorts} />
       </PopoverContent_Shadcn_>
     </Popover_Shadcn_>

--- a/apps/studio/components/interfaces/Auth/Hooks/AddHookDropdown.tsx
+++ b/apps/studio/components/interfaces/Auth/Hooks/AddHookDropdown.tsx
@@ -6,7 +6,6 @@ import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import { useAuthConfigQuery } from 'data/auth/auth-config-query'
 import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { useSelectedOrganization } from 'hooks/misc/useSelectedOrganization'
-import { IS_PLATFORM } from 'lib/constants'
 import {
   Button,
   DropdownMenu,
@@ -21,11 +20,13 @@ import { extractMethod, isValidHook } from './hooks.utils'
 
 interface AddHookDropdownProps {
   buttonText?: string
+  align?: 'end' | 'center'
   onSelectHook: (hook: HOOK_DEFINITION_TITLE) => void
 }
 
 export const AddHookDropdown = ({
   buttonText = 'Add hook',
+  align = 'end',
   onSelectHook,
 }: AddHookDropdownProps) => {
   const { ref: projectRef } = useParams()
@@ -66,13 +67,13 @@ export const AddHookDropdown = ({
   }
 
   return (
-    <DropdownMenu modal={false}>
+    <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <Button type="primary" iconRight={<ChevronDown className="w-4 h-4" strokeWidth={1} />}>
           {buttonText}
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent className="w-76" align="end">
+      <DropdownMenuContent className="w-76" align={align}>
         <div>
           {nonEnterpriseHookOptions.map((h) => (
             <DropdownMenuItem key={h.title} onClick={() => onSelectHook(h.title)}>

--- a/apps/studio/components/interfaces/Auth/Hooks/HooksListing.tsx
+++ b/apps/studio/components/interfaces/Auth/Hooks/HooksListing.tsx
@@ -82,7 +82,11 @@ export const HooksListing = () => {
           ].join(' ')}
         >
           <p className="text-sm text-foreground-light">No hooks configured yet</p>
-          <AddHookDropdown buttonText="Add a new hook" onSelectHook={setSelectedHook} />
+          <AddHookDropdown
+            align="center"
+            buttonText="Add a new hook"
+            onSelectHook={setSelectedHook}
+          />
         </div>
       )}
 

--- a/apps/studio/components/interfaces/Auth/ThirdPartyAuthForm/AddIntegrationDropdown.tsx
+++ b/apps/studio/components/interfaces/Auth/ThirdPartyAuthForm/AddIntegrationDropdown.tsx
@@ -19,6 +19,7 @@ import {
 
 interface AddIntegrationDropdownProps {
   buttonText?: string
+  align?: 'end' | 'center'
   onSelectIntegrationType: (type: INTEGRATION_TYPES) => void
 }
 
@@ -45,16 +46,17 @@ const ProviderDropdownItem = ({
 }
 
 export const AddIntegrationDropdown = ({
+  align = 'end',
   onSelectIntegrationType,
 }: AddIntegrationDropdownProps) => {
   return (
-    <DropdownMenu modal={false}>
+    <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <Button type="primary" iconRight={<ChevronDown size={14} strokeWidth={1} />}>
           Add provider
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-56">
+      <DropdownMenuContent align={align} className="w-56">
         <DropdownMenuLabel>Select Provider</DropdownMenuLabel>
         <DropdownMenuSeparator />
 

--- a/apps/studio/components/interfaces/Auth/ThirdPartyAuthForm/index.tsx
+++ b/apps/studio/components/interfaces/Auth/ThirdPartyAuthForm/index.tsx
@@ -102,6 +102,7 @@ export const ThirdPartyAuthForm = () => {
           >
             <p className="text-sm text-foreground-light">No providers configured yet</p>
             <AddIntegrationDropdown
+              align="center"
               buttonText="Add a new integration"
               onSelectIntegrationType={setSelectedIntegration}
             />
@@ -149,9 +150,10 @@ export const ThirdPartyAuthForm = () => {
       />
 
       <ConfirmationModal
+        size="medium"
         visible={!!selectedIntegrationForDeletion}
         variant="destructive"
-        title="Confirm to delete"
+        title="Confirm to delete integration"
         confirmLabel="Delete"
         confirmLabelLoading="Deleting"
         onCancel={() => setSelectedIntegrationForDeletion(undefined)}
@@ -174,8 +176,9 @@ export const ThirdPartyAuthForm = () => {
           }
         }}
       >
-        <p className="py-4 text-sm text-foreground-light">
-          {`Are you sure you want to delete the ${getIntegrationTypeLabel(getIntegrationType(selectedIntegrationForDeletion))} integration?`}
+        <p className="text-sm text-foreground-light">
+          Are you sure you want to delete the{' '}
+          {getIntegrationTypeLabel(getIntegrationType(selectedIntegrationForDeletion))} integration?
         </p>
       </ConfirmationModal>
     </ScaffoldSection>

--- a/apps/studio/components/interfaces/BranchManagement/BranchPanels.tsx
+++ b/apps/studio/components/interfaces/BranchManagement/BranchPanels.tsx
@@ -213,7 +213,7 @@ export const BranchRow = ({
                   </Link>
                 </Button>
                 <WorkflowLogs projectRef={branch.project_ref} />
-                <DropdownMenu modal={false}>
+                <DropdownMenu>
                   <DropdownMenuTrigger asChild>
                     <Button type="text" icon={<MoreVertical />} className="px-1" />
                   </DropdownMenuTrigger>
@@ -260,7 +260,7 @@ export const BranchRow = ({
               </div>
             )}
             <WorkflowLogs projectRef={branch.project_ref} />
-            <DropdownMenu modal={false}>
+            <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button type="text" icon={<MoreVertical />} className="px-1" />
               </DropdownMenuTrigger>

--- a/apps/studio/components/interfaces/Database/Hooks/HTTPRequestFields.tsx
+++ b/apps/studio/components/interfaces/Database/Hooks/HTTPRequestFields.tsx
@@ -163,7 +163,7 @@ const HTTPRequestFields = ({
                 Add a new header
               </Button>
               {type === 'supabase_function' && (
-                <DropdownMenu modal>
+                <DropdownMenu>
                   <DropdownMenuTrigger asChild>
                     <Button type="default" className="rounded-l-none px-[4px] py-[5px]">
                       <ChevronDown />

--- a/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionTesterSheet.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionTesterSheet.tsx
@@ -433,7 +433,7 @@ export const EdgeFunctionTesterSheet = ({ visible, onClose }: EdgeFunctionTester
 
             <SheetFooter className="px-5 py-3 border-t">
               <div className="flex items-center gap-2">
-                <RoleImpersonationPopover />
+                <RoleImpersonationPopover portal={false} />
                 <Button
                   type="primary"
                   htmlType="submit"

--- a/apps/studio/components/interfaces/Integrations/CronJobs/HttpHeaderFieldsSection.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/HttpHeaderFieldsSection.tsx
@@ -95,7 +95,7 @@ export const HTTPHeaderFieldsSection = ({ variant }: HTTPHeaderFieldsSectionProp
             Add a new header
           </Button>
           {variant === 'edge_function' && (
-            <DropdownMenu modal>
+            <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button type="default" className="rounded-l-none px-[4px] py-[5px]">
                   <ChevronDown size={14} />

--- a/apps/studio/components/interfaces/Organization/OAuthApps/PublishAppSidePanel/Scopes.tsx
+++ b/apps/studio/components/interfaces/Organization/OAuthApps/PublishAppSidePanel/Scopes.tsx
@@ -73,13 +73,13 @@ const Scope = ({
         <span className="text-foreground text-sm">{title}</span>
         <span className="text-foreground-light text-xs">{description}</span>
       </div>
-      <DropdownMenu modal={true}>
+      <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button type="default" iconRight={<ChevronDown />}>
             <p>{accessDescription}</p>
           </Button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="end">
+        <DropdownMenuContent align="end" className="w-40">
           <DropdownMenuLabel>Select an access level</DropdownMenuLabel>
           <DropdownMenuSeparator />
           <ScopeDropdownCheckboxItem scopeName={readScopeName} scopes={scopes} onChange={setScopes}>

--- a/apps/studio/components/interfaces/Realtime/Inspector/RealtimeTokensPopover/index.tsx
+++ b/apps/studio/components/interfaces/Realtime/Inspector/RealtimeTokensPopover/index.tsx
@@ -1,16 +1,16 @@
 import { Dispatch, SetStateAction, useEffect, useRef } from 'react'
 import { toast } from 'sonner'
 
+import { useParams } from 'common'
 import { RoleImpersonationPopover } from 'components/interfaces/RoleImpersonationSelector'
 import { useProjectPostgrestConfigQuery } from 'data/config/project-postgrest-config-query'
 import { getAPIKeys, useProjectSettingsV2Query } from 'data/config/project-settings-v2-query'
 import { useSendEventMutation } from 'data/telemetry/send-event-mutation'
+import { useSelectedOrganization } from 'hooks/misc/useSelectedOrganization'
 import { IS_PLATFORM } from 'lib/constants'
 import { getRoleImpersonationJWT } from 'lib/role-impersonation'
 import { useRoleImpersonationStateSnapshot } from 'state/role-impersonation-state'
 import { RealtimeConfig } from '../useRealtimeMessages'
-import { useParams } from 'common'
-import { useSelectedOrganization } from 'hooks/misc/useSelectedOrganization'
 
 interface RealtimeTokensPopoverProps {
   config: RealtimeConfig

--- a/apps/studio/components/interfaces/RoleImpersonationSelector/RoleImpersonationPopover.tsx
+++ b/apps/studio/components/interfaces/RoleImpersonationSelector/RoleImpersonationPopover.tsx
@@ -8,12 +8,14 @@ import { getAvatarUrl, getDisplayName } from '../Auth/Users/Users.utils'
 import RoleImpersonationSelector from './RoleImpersonationSelector'
 
 export interface RoleImpersonationPopoverProps {
+  portal?: boolean
   serviceRoleLabel?: string
   variant?: 'regular' | 'connected-on-right' | 'connected-on-left' | 'connected-on-both'
   align?: 'center' | 'start' | 'end'
 }
 
 const RoleImpersonationPopover = ({
+  portal = true,
   serviceRoleLabel,
   variant = 'regular',
   align = 'end',
@@ -57,12 +59,10 @@ const RoleImpersonationPopover = ({
         </Button>
       </PopoverTrigger_Shadcn_>
       <PopoverContent_Shadcn_
+        portal={portal}
         className="p-0 w-full overflow-hidden"
         side="bottom"
         align={align}
-        // using `portal` for a safari fix. issue with rendering outside of body element
-        // https://www.radix-ui.com/primitives/docs/components/popover#portal
-        portal={true}
       >
         <RoleImpersonationSelector serviceRoleLabel={serviceRoleLabel} />
       </PopoverContent_Shadcn_>

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceNode.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceNode.tsx
@@ -87,7 +87,7 @@ export const LoadBalancerNode = ({ data }: NodeProps<LoadBalancerData>) => {
               </p>
             </div>
           </div>
-          <DropdownMenu modal={false}>
+          <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button type="text" icon={<MoreVertical />} className="px-1" />
             </DropdownMenuTrigger>
@@ -336,7 +336,7 @@ export const ReplicaNode = ({ data }: NodeProps<ReplicaNodeData>) => {
             )}
           </div>
         </div>
-        <DropdownMenu modal={false}>
+        <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button type="text" icon={<MoreVertical />} className="px-1" />
           </DropdownMenuTrigger>

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/MapView.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/MapView.tsx
@@ -290,7 +290,7 @@ const MapView = ({
                         )}
                       </div>
                       {database.identifier !== ref && (
-                        <DropdownMenu modal={false}>
+                        <DropdownMenu>
                           <DropdownMenuTrigger asChild>
                             <Button type="text" icon={<MoreVertical />} className="px-1" />
                           </DropdownMenuTrigger>

--- a/apps/studio/components/interfaces/TableGridEditor/GridHeaderActions.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/GridHeaderActions.tsx
@@ -263,11 +263,10 @@ const GridHeaderActions = ({ table }: GridHeaderActionsProps) => {
                   </Button>
                 </PopoverTrigger_Shadcn_>
                 <PopoverContent_Shadcn_
+                  // using `portal` for a safari fix. issue with rendering outside of body element
+                  portal
                   className="min-w-[395px] text-sm"
                   align="end"
-                  // using `portal` for a safari fix. issue with rendering outside of body element
-                  // https://www.radix-ui.com/primitives/docs/components/popover#portal
-                  portal={true}
                 >
                   <h3 className="flex items-center gap-2">
                     <Lock size={16} /> Row Level Security (RLS)
@@ -304,11 +303,10 @@ const GridHeaderActions = ({ table }: GridHeaderActionsProps) => {
                 </Button>
               </PopoverTrigger_Shadcn_>
               <PopoverContent_Shadcn_
+                // using `portal` for a safari fix. issue with rendering outside of body element
+                portal
                 className="min-w-[395px] text-sm"
                 align="end"
-                // using `portal` for a safari fix. issue with rendering outside of body element
-                // https://www.radix-ui.com/primitives/docs/components/popover#portal
-                portal={true}
               >
                 <h3 className="flex items-center gap-2">
                   <Unlock size={16} /> Secure your View
@@ -355,11 +353,10 @@ const GridHeaderActions = ({ table }: GridHeaderActionsProps) => {
                 </Button>
               </PopoverTrigger_Shadcn_>
               <PopoverContent_Shadcn_
+                // using `portal` for a safari fix. issue with rendering outside of body element
+                portal
                 className="min-w-[395px] text-sm"
                 align="end"
-                // using `portal` for a safari fix. issue with rendering outside of body element
-                // https://www.radix-ui.com/primitives/docs/components/popover#portal
-                portal={true}
               >
                 <h3 className="flex items-center gap-2">
                   <Unlock size={16} /> Secure your View
@@ -398,11 +395,10 @@ const GridHeaderActions = ({ table }: GridHeaderActionsProps) => {
                 </Button>
               </PopoverTrigger_Shadcn_>
               <PopoverContent_Shadcn_
+                // using `portal` for a safari fix. issue with rendering outside of body element
+                portal
                 className="min-w-[395px] text-sm"
                 align="end"
-                // using `portal` for a safari fix. issue with rendering outside of body element
-                // https://www.radix-ui.com/primitives/docs/components/popover#portal
-                portal={true}
               >
                 <h3 className="flex items-center gap-2">
                   <Unlock size={16} /> Secure Foreign table

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/InputWithSuggestions.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/InputWithSuggestions.tsx
@@ -96,7 +96,7 @@ const InputWithSuggestions = ({
         data-testid={dataTestId}
         actions={
           showSuggestions && (
-            <DropdownMenu modal>
+            <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <ButtonTooltip
                   type="default"

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/DateTimeInput/DateTimeInput.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/DateTimeInput/DateTimeInput.tsx
@@ -63,7 +63,7 @@ const DateTimeInput = ({
             <DropdownMenuTrigger asChild>
               <Button type="default" icon={<Edit />} className="px-1.5" />
             </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-28">
+            <DropdownMenuContent align="end" className="w-28 pointer-events-auto">
               {isNullable && (
                 <DropdownMenuItem onClick={() => onChange('')}>Set to NULL</DropdownMenuItem>
               )}

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/ForeignRowSelector/ForeignRowSelector.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/ForeignRowSelector/ForeignRowSelector.tsx
@@ -160,9 +160,13 @@ const ForeignRowSelector = ({
                 <div className="flex items-center justify-between my-2 mx-3">
                   <div className="flex items-center">
                     <RefreshButton tableId={table?.id} isRefetching={isRefetching} />
-                    <FilterPopover filters={filters} onApplyFilters={onApplyFilters} />
+                    <FilterPopover
+                      portal={false}
+                      filters={filters}
+                      onApplyFilters={onApplyFilters}
+                    />
                     <DndProvider backend={HTML5Backend} context={window}>
-                      <SortPopover sorts={sorts} onApplySorts={onApplySorts} />
+                      <SortPopover portal={false} sorts={sorts} onApplySorts={onApplySorts} />
                     </DndProvider>
                   </div>
 

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/InputField.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/InputField.tsx
@@ -121,7 +121,7 @@ const InputField = ({
         onChange={(event: any) => onUpdateField({ [field.name]: event.target.value })}
         actions={
           isEditable && (
-            <DropdownMenu modal>
+            <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button type="default" icon={<Edit />} className="px-1.5" />
               </DropdownMenuTrigger>

--- a/apps/studio/components/to-be-cleaned/Storage/StorageExplorer/FileExplorerRow.tsx
+++ b/apps/studio/components/to-be-cleaned/Storage/StorageExplorer/FileExplorerRow.tsx
@@ -408,7 +408,7 @@ const FileExplorerRow: ItemRenderer<StorageItem, FileExplorerRowProps> = ({
               strokeWidth={2}
             />
           ) : (
-            <DropdownMenu modal={false}>
+            <DropdownMenu>
               <DropdownMenuTrigger>
                 <div className="storage-row-menu opacity-0">
                   <MoreVertical size={16} strokeWidth={2} />

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -26,7 +26,7 @@
     "@radix-ui/react-collapsible": "^1.0.3",
     "@radix-ui/react-context": "^1.0.1",
     "@radix-ui/react-context-menu": "^2.1.5",
-    "@radix-ui/react-dialog": "^1.1.4",
+    "@radix-ui/react-dialog": "1.0.5",
     "@radix-ui/react-dropdown-menu": "^2.0.6",
     "@radix-ui/react-hover-card": "^1.0.7",
     "@radix-ui/react-label": "^2.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1730,8 +1730,8 @@ importers:
         specifier: ^2.1.5
         version: 2.1.5(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@radix-ui/react-dialog':
-        specifier: ^1.1.4
-        version: 1.1.6(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: 1.0.5
+        version: 1.0.5(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@radix-ui/react-dropdown-menu':
         specifier: ^2.0.6
         version: 2.0.6(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -4582,19 +4582,6 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-dialog@1.1.6':
-    resolution: {integrity: sha512-/IVhJV5AceX620DUJ4uYVMymzsipdKBzo3edo+omeskCKGm9FRHM0ebIdbPnlQVJqyuHbuBltQUOG2mOTq2IYw==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
   '@radix-ui/react-direction@1.0.1':
     resolution: {integrity: sha512-RXcvnXgyvYvBEOhCBuddKecVkoMiI10Jcm5cTI7abJRAHYfFxeu+FBQs/DvdxSYucxR5mna0dNsL6QFlds5TMA==}
     peerDependencies:
@@ -4674,15 +4661,6 @@ packages:
       '@types/react':
         optional: true
 
-  '@radix-ui/react-focus-guards@1.1.1':
-    resolution: {integrity: sha512-pSIwfrT1a6sIoDASCSpFwOasEwKTZWDw/iBdtnqKO7v6FeOzYJ7U53cPzYFVR3geGGXgVHaH+CdngrrAzqUGxg==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
   '@radix-ui/react-focus-scope@1.0.4':
     resolution: {integrity: sha512-sL04Mgvf+FmyvZeYfNu1EPAaaxD+aw7cYeIB9L9Fvq8+urhltTRaEo5ysKOpHuKPclsZcSUMKlN05x4u+CINpA==}
     peerDependencies:
@@ -4698,19 +4676,6 @@ packages:
 
   '@radix-ui/react-focus-scope@1.1.0':
     resolution: {integrity: sha512-200UD8zylvEyL8Bx+z76RJnASR2gRMuxlgFCPAe/Q/679a/r0eK3MBVYMb7vZODZcffZBdob1EGnky78xmVvcA==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-focus-scope@1.1.2':
-    resolution: {integrity: sha512-zxwE80FCU7lcXUGWkdt6XpTTCKPitG1XKOwViTxHVKIJhZl9MvIl2dVHeZENCWD9+EdWv05wlaEkRXUykU27RA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -9870,9 +9835,6 @@ packages:
   intersection-observer@0.10.0:
     resolution: {integrity: sha512-fn4bQ0Xq8FTej09YC/jqKZwtijpvARlRp6wxL5WTA6yPe2YWSJ5RJh7Nm79rK2qB0wr6iDQzH60XGq5V/7u8YQ==}
 
-  invariant@2.2.4:
-    resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
-
   ioredis@5.6.0:
     resolution: {integrity: sha512-tBZlIIWbndeWBWCXWZiqtOF/yxf6yZX3tAlTJ7nfo5jhd6dctNxF7QnYlZLZ1a0o0pDoen7CgZqO+zjNaFbJAg==}
     engines: {node: '>=12.22.0'}
@@ -12736,16 +12698,6 @@ packages:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
     engines: {node: '>=0.10.0'}
 
-  react-remove-scroll-bar@2.3.4:
-    resolution: {integrity: sha512-63C4YQBUt0m6ALadE9XV56hV8BgJWDmmTPY758iIJjfQKt2nYwoUrPk0LXRXcB/yIj82T1/Ixfdpdk68LwIB0A==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
     engines: {node: '>=10'}
@@ -12772,16 +12724,6 @@ packages:
     peerDependencies:
       '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  react-remove-scroll@2.6.3:
-    resolution: {integrity: sha512-pnAi91oOk8g8ABQKGF5/M9qxmmOPxaAnopyTHYfqYEwJhyFrbbBtHuSgtKEoH0jpcxx5o3hXqH1mNd9/Oi+8iQ==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -12819,16 +12761,6 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-
-  react-style-singleton@2.2.1:
-    resolution: {integrity: sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
 
   react-style-singleton@2.2.3:
     resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
@@ -14571,16 +14503,6 @@ packages:
   url-template@2.0.8:
     resolution: {integrity: sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==}
 
-  use-callback-ref@1.3.0:
-    resolution: {integrity: sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
   use-callback-ref@1.3.3:
     resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
     engines: {node: '>=10'}
@@ -14601,16 +14523,6 @@ packages:
     resolution: {integrity: sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
-
-  use-sidecar@1.1.2:
-    resolution: {integrity: sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      '@types/react': ^16.9.0 || ^17.0.0 || ^18.0.0
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
 
   use-sidecar@1.1.3:
     resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
@@ -18388,32 +18300,10 @@ snapshots:
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@radix-ui/react-slot': 1.0.2(@types/react@18.3.3)(react@18.2.0)
       '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.3.3)(react@18.2.0)
-      aria-hidden: 1.2.3
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      react-remove-scroll: 2.5.5(@types/react@18.3.3)(react@18.2.0)
-    optionalDependencies:
-      '@types/react': 18.3.3
-      '@types/react-dom': 18.3.0
-
-  '@radix-ui/react-dialog@1.1.6(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.1
-      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.3)(react@18.2.0)
-      '@radix-ui/react-context': 1.1.1(@types/react@18.3.3)(react@18.2.0)
-      '@radix-ui/react-dismissable-layer': 1.1.5(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-focus-guards': 1.1.1(@types/react@18.3.3)(react@18.2.0)
-      '@radix-ui/react-focus-scope': 1.1.2(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-id': 1.1.0(@types/react@18.3.3)(react@18.2.0)
-      '@radix-ui/react-portal': 1.1.4(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-presence': 1.1.2(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-slot': 1.1.2(@types/react@18.3.3)(react@18.2.0)
-      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.3)(react@18.2.0)
       aria-hidden: 1.2.4
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      react-remove-scroll: 2.6.3(@types/react@18.3.3)(react@18.2.0)
+      react-remove-scroll: 2.5.5(@types/react@18.3.3)(react@18.2.0)
     optionalDependencies:
       '@types/react': 18.3.3
       '@types/react-dom': 18.3.0
@@ -18494,12 +18384,6 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.3
 
-  '@radix-ui/react-focus-guards@1.1.1(@types/react@18.3.3)(react@18.2.0)':
-    dependencies:
-      react: 18.2.0
-    optionalDependencies:
-      '@types/react': 18.3.3
-
   '@radix-ui/react-focus-scope@1.0.4(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.26.10
@@ -18516,17 +18400,6 @@ snapshots:
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.3)(react@18.2.0)
       '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.3)(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-    optionalDependencies:
-      '@types/react': 18.3.3
-      '@types/react-dom': 18.3.0
-
-  '@radix-ui/react-focus-scope@1.1.2(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
-    dependencies:
-      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.3)(react@18.2.0)
-      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.3)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -25256,10 +25129,6 @@ snapshots:
 
   intersection-observer@0.10.0: {}
 
-  invariant@2.2.4:
-    dependencies:
-      loose-envify: 1.4.0
-
   ioredis@5.6.0(supports-color@8.1.1):
     dependencies:
       '@ioredis/commands': 1.2.0
@@ -29252,14 +29121,6 @@ snapshots:
 
   react-refresh@0.14.2: {}
 
-  react-remove-scroll-bar@2.3.4(@types/react@18.3.3)(react@18.2.0):
-    dependencies:
-      react: 18.2.0
-      react-style-singleton: 2.2.1(@types/react@18.3.3)(react@18.2.0)
-      tslib: 2.8.1
-    optionalDependencies:
-      '@types/react': 18.3.3
-
   react-remove-scroll-bar@2.3.8(@types/react@18.3.3)(react@18.2.0):
     dependencies:
       react: 18.2.0
@@ -29271,26 +29132,15 @@ snapshots:
   react-remove-scroll@2.5.5(@types/react@18.3.3)(react@18.2.0):
     dependencies:
       react: 18.2.0
-      react-remove-scroll-bar: 2.3.4(@types/react@18.3.3)(react@18.2.0)
-      react-style-singleton: 2.2.1(@types/react@18.3.3)(react@18.2.0)
+      react-remove-scroll-bar: 2.3.8(@types/react@18.3.3)(react@18.2.0)
+      react-style-singleton: 2.2.3(@types/react@18.3.3)(react@18.2.0)
       tslib: 2.8.1
-      use-callback-ref: 1.3.0(@types/react@18.3.3)(react@18.2.0)
-      use-sidecar: 1.1.2(@types/react@18.3.3)(react@18.2.0)
+      use-callback-ref: 1.3.3(@types/react@18.3.3)(react@18.2.0)
+      use-sidecar: 1.1.3(@types/react@18.3.3)(react@18.2.0)
     optionalDependencies:
       '@types/react': 18.3.3
 
   react-remove-scroll@2.5.7(@types/react@18.3.3)(react@18.2.0):
-    dependencies:
-      react: 18.2.0
-      react-remove-scroll-bar: 2.3.4(@types/react@18.3.3)(react@18.2.0)
-      react-style-singleton: 2.2.1(@types/react@18.3.3)(react@18.2.0)
-      tslib: 2.8.1
-      use-callback-ref: 1.3.0(@types/react@18.3.3)(react@18.2.0)
-      use-sidecar: 1.1.2(@types/react@18.3.3)(react@18.2.0)
-    optionalDependencies:
-      '@types/react': 18.3.3
-
-  react-remove-scroll@2.6.3(@types/react@18.3.3)(react@18.2.0):
     dependencies:
       react: 18.2.0
       react-remove-scroll-bar: 2.3.8(@types/react@18.3.3)(react@18.2.0)
@@ -29341,15 +29191,6 @@ snapshots:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       react-transition-group: 4.4.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-
-  react-style-singleton@2.2.1(@types/react@18.3.3)(react@18.2.0):
-    dependencies:
-      get-nonce: 1.0.1
-      invariant: 2.2.4
-      react: 18.2.0
-      tslib: 2.8.1
-    optionalDependencies:
-      '@types/react': 18.3.3
 
   react-style-singleton@2.2.3(@types/react@18.3.3)(react@18.2.0):
     dependencies:
@@ -29507,7 +29348,7 @@ snapshots:
       esprima: 4.0.1
       source-map: 0.6.1
       tiny-invariant: 1.3.3
-      tslib: 2.6.2
+      tslib: 2.8.1
 
   recharts-scale@0.4.5:
     dependencies:
@@ -31518,13 +31359,6 @@ snapshots:
 
   url-template@2.0.8: {}
 
-  use-callback-ref@1.3.0(@types/react@18.3.3)(react@18.2.0):
-    dependencies:
-      react: 18.2.0
-      tslib: 2.8.1
-    optionalDependencies:
-      '@types/react': 18.3.3
-
   use-callback-ref@1.3.3(@types/react@18.3.3)(react@18.2.0):
     dependencies:
       react: 18.2.0
@@ -31539,14 +31373,6 @@ snapshots:
   use-memo-one@1.1.3(react@18.2.0):
     dependencies:
       react: 18.2.0
-
-  use-sidecar@1.1.2(@types/react@18.3.3)(react@18.2.0):
-    dependencies:
-      detect-node-es: 1.1.0
-      react: 18.2.0
-      tslib: 2.8.1
-    optionalDependencies:
-      '@types/react': 18.3.3
 
   use-sidecar@1.1.3(@types/react@18.3.3)(react@18.2.0):
     dependencies:
@@ -31613,7 +31439,7 @@ snapshots:
 
   vaul@0.9.1(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
-      '@radix-ui/react-dialog': 1.1.6(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-dialog': 1.0.5(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:


### PR DESCRIPTION
Radix Dialog versions 1.1.6 have been causing quite a number of [issues](https://github.com/radix-ui/primitives/issues?q=is%3Aissue%20state%3Aopen%20dialog), notably the ones that have been affecting the dashboard were
- DropdownMenus immediately closing when rendered + opened within a Sheet
- Inputs not being editable when rendered in a Dialog based component

Am fixing the version to 1.0.5 which was what we were on before, and that seemed to have fixed all the issues we've been running into. Also reverted all the injection of `modal` params we've been putting in to fix the above issues, and also removed some unnecessary `modal=false` params as well, have verified locally that all the updated files are working correctly 

Also fixes FilterPopover and SortPopover when they're rendered in ForeignRowSelector being unclickable due to portal set to true - the fix [here](https://github.com/supabase/supabase/pull/35024) addressed the Popovers rendering incorrectly in Safari in the TableEditor, but broke the Popovers in the ForeignRowSelector - so making the `portal` param passable as a prop instead. Also broke the RoleImpersonationPopover used in EdgeFunctionTesterSheet

## To test
- In the Table Editor, verify that you can open these sort of dropdown menus in the RowEditor
![image](https://github.com/user-attachments/assets/eb362a6a-ddec-413c-b667-48c50b7ccd97)
- For a table that has a foreign key, verify that you can hit "Select a record" and then filter + sort in the ForeignRowSelector
- In an Edge Function, verify that you can select a role when testing an edge function
- In realtime inspector, verify that you can select a role
- Verify all the above in Safari