### PR TITLE
fix: correct typo in bucket name validation message

### DIFF
--- a/apps/studio/components/interfaces/Storage/CreateBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/CreateBucketModal.tsx
@@ -60,7 +60,7 @@ const CreateBucketModal = ({ visible, onClose }: CreateBucketModalProps) => {
 
     if (values.name && !/^[a-z0-9.-]+$/.test(values.name)) {
       errors.name =
-        'The name of the bucket must only container lowercase letters, numbers, dots, and hyphens'
+        'The name of the bucket must only contain lowercase letters, numbers, dots, and hyphens'
     }
 
     if (values.name && values.name.endsWith(' ')) {


### PR DESCRIPTION
Noticed a small typo in the error message shown when creating a storage bucket in the website.
Changed "container" to "contain".

Already submitted feedback through the Supabase dashboard, but submitting a PR here to help fix it directly 🙂
Also submitting a screenshot of the typo
![Supabase Typo](https://github.com/user-attachments/assets/8a9de127-4f3e-4a71-ba50-360d554b169a)

