### PR TITLE
Add org plan and num projects to organization action card

### DIFF
--- a/apps/studio/components/interfaces/App/FeaturePreview/FeaturePreviewModal.tsx
+++ b/apps/studio/components/interfaces/App/FeaturePreview/FeaturePreviewModal.tsx
@@ -1,6 +1,6 @@
 import { ExternalLink, Eye, EyeOff, FlaskConical } from 'lucide-react'
 import Link from 'next/link'
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
 
 import { useParams } from 'common'
 import { useSendEventMutation } from 'data/telemetry/send-event-mutation'
@@ -36,12 +36,10 @@ const FeaturePreviewModal = () => {
     }
   }
 
-  const selectedFeaturePreview =
+  const selectedFeatureKey =
     snap.selectedFeaturePreview === ''
       ? FEATURE_PREVIEWS.filter((feature) => isReleasedToPublic(feature))[0].key
       : snap.selectedFeaturePreview
-
-  const [selectedFeatureKey, setSelectedFeatureKey] = useState<string>(selectedFeaturePreview)
 
   const { flags, onUpdateFlag } = featurePreviewContext
   const selectedFeature = FEATURE_PREVIEWS.find((preview) => preview.key === selectedFeatureKey)
@@ -65,17 +63,7 @@ const FeaturePreviewModal = () => {
 
   function handleCloseFeaturePreviewModal() {
     snap.setShowFeaturePreviewModal(false)
-    snap.setSelectedFeaturePreview(FEATURE_PREVIEWS[0].key)
   }
-
-  // this modal can be triggered on other pages
-  // Update local state when valtio state changes
-
-  useEffect(() => {
-    if (snap.selectedFeaturePreview !== '') {
-      setSelectedFeatureKey(snap.selectedFeaturePreview)
-    }
-  }, [snap.selectedFeaturePreview])
 
   useEffect(() => {
     if (snap.showFeaturePreviewModal) {
@@ -109,7 +97,7 @@ const FeaturePreviewModal = () => {
                 return (
                   <div
                     key={feature.key}
-                    onClick={() => setSelectedFeatureKey(feature.key)}
+                    onClick={() => snap.setSelectedFeaturePreview(feature.key)}
                     className={cn(
                       'flex items-center space-x-3 p-4 border-b cursor-pointer bg transition',
                       selectedFeatureKey === feature.key ? 'bg-surface-300' : 'bg-surface-100'

--- a/apps/studio/components/ui/ActionCard.tsx
+++ b/apps/studio/components/ui/ActionCard.tsx
@@ -30,7 +30,7 @@ export const ActionCard = (card: {
         </div>
         <div className="flex flex-col gap-0">
           <h3 className="text-sm text-foreground mb-0">{card.title}</h3>
-          <p className="text-xs text-foreground-light">{card.description}</p>
+          <pre className="text-xs text-foreground-light font-sans">{card.description}</pre>
         </div>
       </div>
     </Card>

--- a/apps/studio/pages/organizations.tsx
+++ b/apps/studio/pages/organizations.tsx
@@ -7,12 +7,15 @@ import DefaultLayout from 'components/layouts/DefaultLayout'
 import { ScaffoldContainerLegacy, ScaffoldTitle } from 'components/layouts/Scaffold'
 import { ActionCard } from 'components/ui/ActionCard'
 import { useOrganizationsQuery } from 'data/organizations/organizations-query'
+import { useProjectsQuery } from 'data/projects/projects-query'
 import { NextPageWithLayout } from 'types'
 import { Skeleton } from 'ui'
 
 const OrganizationsPage: NextPageWithLayout = () => {
   const router = useRouter()
+
   const { data: organizations, isLoading, isError, error, isSuccess } = useOrganizationsQuery()
+  const { data: projects = [] } = useProjectsQuery()
 
   useEffect(() => {
     // If there are no organizations, force the user to create one
@@ -37,16 +40,23 @@ const OrganizationsPage: NextPageWithLayout = () => {
           )}
           {isError && <div>Error loading organizations</div>}
           {isSuccess &&
-            organizations?.map((organization) => (
-              <ActionCard
-                bgColor="bg border"
-                className="[&>div]:items-center"
-                key={organization.id}
-                icon={<Boxes size={18} strokeWidth={1} className="text-foreground" />}
-                title={organization.name}
-                onClick={() => router.push(`/org/${organization.slug}`)}
-              />
-            ))}
+            organizations?.map((organization) => {
+              const numProjects = projects.filter(
+                (x) => x.organization_slug === organization.slug
+              ).length
+
+              return (
+                <ActionCard
+                  bgColor="bg border"
+                  className="[&>div]:items-center"
+                  key={organization.id}
+                  icon={<Boxes size={18} strokeWidth={1} className="text-foreground" />}
+                  title={organization.name}
+                  description={`${organization.plan.name} Plan${numProjects > 0 ? `${'  '}•${'  '}${numProjects} project${numProjects > 1 ? 's' : ''}` : ''}`}
+                  onClick={() => router.push(`/org/${organization.slug}`)}
+                />
+              )
+            })}
         </div>
       </ScaffoldContainerLegacy>
     </>


### PR DESCRIPTION
Fixes FE-1585

Just adds a bit more details to the organization action card, specifically the org's plan and number of projects
![image](https://github.com/user-attachments/assets/92318096-773a-4bc4-9f5f-77d088c53a22)

Also added in a small refactor for the feature preview modal by removing an unnecessary state
