### PR TITLE
chore: update docker tag for dependabot

### DIFF
--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -20,8 +20,8 @@ jobs:
           flavor: |
             latest=true
           tags: |
-            type=sha,prefix={{date 'YYYY.MM.DD'}}-,enable=${{ github.event_name == 'schedule' }}
-            type=sha,prefix={{date 'YYYY.MM.DD'}}-,enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=sha,prefix={{date 'YYYY.MM.DD'}}-sha-,enable=${{ github.event_name == 'schedule' }}
+            type=sha,prefix={{date 'YYYY.MM.DD'}}-sha-,enable=${{ github.event_name == 'workflow_dispatch' }}
 
   release_x86:
     needs: settings


### PR DESCRIPTION
## What kind of change does this PR introduce?

ci

## What is the new behavior?

Another attempt to fix dependabot update because their [regex](https://github.com/dependabot/dependabot-core/blob/main/docker/lib/dependabot/docker/tag.rb#L13) breaks if the suffix begins with a number.

https://regex101.com/r/ulUOr3/2

Turns `2025.04.14-2086b5d` into `2025.04.14-sha-2086b5d`

## Additional context

Add any other context or screenshots.
