### PR TITLE
Fix editing policy via inline sql, placeholder sql is incorrect

### DIFF
--- a/apps/studio/components/interfaces/Auth/Policies/PolicyTableRow/PolicyRow.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/PolicyTableRow/PolicyRow.tsx
@@ -22,7 +22,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from 'ui'
-import { generatePolicyCreateSQL } from './PolicyTableRow.utils'
+import { generatePolicyUpdateSQL } from './PolicyTableRow.utils'
 
 interface PolicyRowProps {
   policy: PostgresPolicy
@@ -118,7 +118,7 @@ const PolicyRow = ({
               <DropdownMenuItem
                 className="space-x-2"
                 onClick={() => {
-                  const sql = generatePolicyCreateSQL(policy)
+                  const sql = generatePolicyUpdateSQL(policy)
                   aiSnap.newChat({
                     name: `Update policy ${policy.name}`,
                     open: true,

--- a/apps/studio/components/interfaces/Auth/Policies/PolicyTableRow/PolicyTableRow.utils.ts
+++ b/apps/studio/components/interfaces/Auth/Policies/PolicyTableRow/PolicyTableRow.utils.ts
@@ -1,22 +1,20 @@
 import { PostgresPolicy } from '@supabase/postgres-meta'
 
-export const generatePolicyCreateSQL = (policy: PostgresPolicy) => {
+export const generatePolicyUpdateSQL = (policy: PostgresPolicy) => {
   let expression = ''
   if (policy.definition !== null && policy.definition !== undefined) {
-    expression += `USING (${policy.definition})${
+    expression += `using (${policy.definition})${
       policy.check === null || policy.check === undefined ? ';' : ''
     }\n`
   }
   if (policy.check !== null && policy.check !== undefined) {
-    expression += `WITH CHECK (${policy.check});\n`
+    expression += `with check (${policy.check});\n`
   }
 
   return `
-ALTER POLICY "${policy.name}" 
-ON "${policy.schema}"."${policy.table}"
-AS ${policy.action}
-FOR ${policy.command}
-TO ${policy.roles.join(', ')}
+alter policy "${policy.name}" 
+on "${policy.schema}"."${policy.table}"
+to ${policy.roles.join(', ')}
 ${expression}
 `.trim()
 }

--- a/apps/studio/pages/project/[ref]/auth/policies.tsx
+++ b/apps/studio/pages/project/[ref]/auth/policies.tsx
@@ -8,7 +8,7 @@ import { useIsInlineEditorEnabled } from 'components/interfaces/App/FeaturePrevi
 import Policies from 'components/interfaces/Auth/Policies/Policies'
 import { getGeneralPolicyTemplates } from 'components/interfaces/Auth/Policies/PolicyEditorModal/PolicyEditorModal.constants'
 import { PolicyEditorPanel } from 'components/interfaces/Auth/Policies/PolicyEditorPanel'
-import { generatePolicyCreateSQL } from 'components/interfaces/Auth/Policies/PolicyTableRow/PolicyTableRow.utils'
+import { generatePolicyUpdateSQL } from 'components/interfaces/Auth/Policies/PolicyTableRow/PolicyTableRow.utils'
 import AuthLayout from 'components/layouts/AuthLayout/AuthLayout'
 import DefaultLayout from 'components/layouts/DefaultLayout'
 import { useProjectContext } from 'components/layouts/ProjectLayout/ProjectContext'
@@ -174,7 +174,7 @@ const AuthPoliciesPage: NextPageWithLayout = () => {
           }}
           onSelectEditPolicy={(policy) => {
             if (isInlineEditorEnabled) {
-              const sql = generatePolicyCreateSQL(policy)
+              const sql = generatePolicyUpdateSQL(policy)
               const templates = getGeneralPolicyTemplates(policy.schema, policy.table)
               setEditorPanel({
                 open: true,


### PR DESCRIPTION
## Problem
For updating RLS policies: The placeholder SQL that we provided in the Inline SQL when hitting "Edit policy" while the inline SQL editor feature preview is toggled on is incorrect. (Should not have "AS ___" and "FOR ____"

## Changes involved
- Renamed `generatePolicyCreateSQL` in `PolicyTableRow.utils.ts` to `generatePolicyUpdateSQL`
  - The function name was incorrect here since it's generating an `alter policy` statement
- Remove the incorrect statements in the `alter policy` statement
  - Should not have `AS ___` and `FOR ___` - these are specifically only for `create policy` statements
- Lower cased the SQL for consistency

## To test
- Ensure that the "Directly edit database entities" feature preview is toggled on
- Go to Auth -> Policies
- For any policy that you already have, hit "Edit policy" and just change the definition to something simple like `true`
  - To reproduce: On prod, this will error out with a syntax error
  - On preview: should no longer error out