### PR TITLE
Fix: supabase vector on system using larger pages (16 KB, 64 KB)

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -443,7 +443,7 @@ services:
 
   vector:
     container_name: supabase-vector
-    image: timberio/vector:0.28.1-alpine
+    image: timberio/vector:0.33.0-alpine
     restart: unless-stopped
     volumes:
       - ./volumes/logs/vector.yml:/etc/vector/vector.yml:ro,z

--- a/docker/volumes/logs/vector.yml
+++ b/docker/volumes/logs/vector.yml
@@ -101,7 +101,7 @@ transforms:
       parsed, err = parse_regex(.event_message, r'^(?P<time>.*): (?P<msg>.*)$')
       if err == null {
           .event_message = parsed.msg
-          .timestamp = to_timestamp!(parsed.time)
+          .timestamp = parse_timestamp!(value: parsed.time, format: "YYYY-MM-DDTHH:mm:ss.sssZ")
           .metadata.host = .project
       }
   # Realtime logs are structured so we parse the severity level using regex (ignore time because it has no date)


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?
 
The current timberio vector container can't run when the page size is set to something different then 4 KB
This was mentioned in this [issue](https://github.com/supabase/supabase/issues/18815) however the fix - change the page size to 4 KB - does not work on systems where this is not possible (e.g. Asahi Linux)

## What is the new behavior?

Update to a newer version (0.28.1 -> 0.33.0) to include [this](https://github.com/vectordotdev/vector/pull/18481) change which compiles the container using a larger page size.