### PR TITLE
Prevent setting Authorization header to empty string by default in AI Assistant component

### DIFF
--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
@@ -221,9 +221,10 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
     // Store the user message in the ref before appending
     lastUserMessageRef.current = payload
 
-    append(payload, {
-      headers: { Authorization: headerData.get('Authorization') ?? '' },
-    })
+    const Authorization = headerData.get('Authorization')
+    if (Authorization) {
+      append(payload, { headers: { Authorization } })
+    }
 
     setValue('')
 


### PR DESCRIPTION
Currently on self-hosted supabase, which uses HTTP Basic Auth on the dashboard/API by default, the AI Assistant component of the dashboard will set the `Authorization` header to be an empty string even when `headerData` is empty. 

This can override the existing basic auth credentials and cause auth errors on the API.

The change fixes this by first checking whether `headerData` contains an `Authorization` value and only appending it to the payload when it does, allowing `Authorization` to fall back to the browser sessions' existing basic auth credentials.