### PR TITLE
docs(auth): clarify mapping of user metadata in updateUser example

### DIFF
--- a/apps/docs/spec/supabase_js_v2.yml
+++ b/apps/docs/spec/supabase_js_v2.yml
@@ -1470,9 +1470,9 @@ functions:
       - id: update-the-users-metadata
         name: Update the user's metadata
         description: |
-          Updates the user's custom metadata.  
-          > **Note**: The `data` field maps to the `auth.users.raw_user_meta_data` column in your Supabase database.  
-          When calling `getUser()`, the data will be available as `user.user_metadata`.
+          Updates the user's custom metadata.
+
+          **Note**: The `data` field maps to the `auth.users.raw_user_meta_data` column in your Supabase database. When calling `getUser()`, the data will be available as `user.user_metadata`.
         isSpotlight: true
         code: |
           ```js

--- a/apps/docs/spec/supabase_js_v2.yml
+++ b/apps/docs/spec/supabase_js_v2.yml
@@ -1469,6 +1469,10 @@ functions:
           ```
       - id: update-the-users-metadata
         name: Update the user's metadata
+        description: |
+          Updates the user's custom metadata.  
+          > **Note**: The `data` field maps to the `auth.users.raw_user_meta_data` column in your Supabase database.  
+          When calling `getUser()`, the data will be available as `user.user_metadata`.
         isSpotlight: true
         code: |
           ```js


### PR DESCRIPTION
Adds a note explaining that the `data` field maps to `raw_user_meta_data` in the database, and is returned as `user_metadata` when calling `getUser()`.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

Currently, the documentation does not clearly state that metadata set via `updateUser({ data })` is stored in `raw_user_meta_data` and retrieved under `user_metadata`. This may confuse users when trying to access the updated data.

## What is the new behavior?

The PR adds a short explanation clarifying how metadata is stored and retrieved, helping developers understand the mapping between the input `(data)` and the output `(user_metadata)`.

## Additional context

This change was made to clear up some confusion I had while using Supabase Auth. A simple note helps make it easier to understand how data is stored and retrieved.
