### PR TITLE
Chore: Support form | support access true as default 

### DIFF
--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingSettings.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingSettings.tsx
@@ -1,4 +1,4 @@
-import { useNewLayout } from 'components/interfaces/App/FeaturePreview/FeaturePreviewContext'
+import { useIsNewLayoutEnabled } from 'components/interfaces/App/FeaturePreview/FeaturePreviewContext'
 import {
   ScaffoldContainer,
   ScaffoldContainerLegacy,
@@ -32,7 +32,7 @@ const BillingSettings = () => {
     'billing:invoices',
   ])
 
-  const newLayoutPreview = useNewLayout()
+  const newLayoutPreview = useIsNewLayoutEnabled()
 
   const org = useSelectedOrganization()
   const { data: subscription } = useOrgSubscriptionQuery({ orgSlug: org?.slug })

--- a/apps/studio/components/interfaces/Support/SupportFormV2.tsx
+++ b/apps/studio/components/interfaces/Support/SupportFormV2.tsx
@@ -1,6 +1,16 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import * as Sentry from '@sentry/nextjs'
-import { ChevronRight, ExternalLink, Loader2, Mail, Plus, X } from 'lucide-react'
+import {
+  Check,
+  ChevronRight,
+  CircleUserRound,
+  ExternalLink,
+  Loader2,
+  Mail,
+  Plus,
+  SquareUserRound,
+  X,
+} from 'lucide-react'
 import Link from 'next/link'
 import { ChangeEvent, useEffect, useMemo, useRef, useState } from 'react'
 import { SubmitHandler, useForm } from 'react-hook-form'
@@ -17,6 +27,7 @@ import { useProjectsQuery } from 'data/projects/projects-query'
 import { detectBrowser } from 'lib/helpers'
 import { useProfile } from 'lib/profile'
 import {
+  AiIconAnimation,
   Badge,
   Button,
   cn,
@@ -112,7 +123,7 @@ export const SupportFormV2 = ({ setSentCategory, setSelectedProject }: SupportFo
     subject: '',
     message: '',
     affectedServices: '',
-    allowSupportAccess: false,
+    allowSupportAccess: true,
   }
 
   const form = useForm<z.infer<typeof FormSchema>>({
@@ -682,59 +693,124 @@ export const SupportFormV2 = ({ setSentCategory, setSelectedProject }: SupportFo
 
         {['Problem', 'Database_unresponsive', 'Performance'].includes(category) && (
           <>
-            <FormField_Shadcn_
-              name="allowSupportAccess"
-              control={form.control}
-              render={({ field }) => (
-                <FormItemLayout
-                  name="allowSupportAccess"
-                  className="px-6"
-                  layout="flex"
-                  label="Allow Supabase Support and AI-Assisted Diagnostics access to your project"
-                  description={
-                    <Collapsible_Shadcn_>
-                      <div className="flex items-center gap-x-2">
-                        <CollapsibleTrigger_Shadcn_ className="group flex items-center gap-x-2 ">
-                          <ChevronRight
-                            strokeWidth={2}
-                            size={14}
-                            className="transition-all group-data-[state=open]:rotate-90 text-foreground-lighter duration-200 -ml-1"
-                          />
-                          <p className="text-xs text-foreground-light underline">
-                            More information about temporary access
-                          </p>
-                        </CollapsibleTrigger_Shadcn_>
-                      </div>
-                      <CollapsibleContent_Shadcn_ className="text-xs text-foreground-light mt-2 space-y-2">
-                        <p>
-                          By enabling this, you grant permission for our support team to access your
-                          project temporarily and, if applicable, to use AI tools to assist in
-                          diagnosing and resolving issues. This access may involve analyzing
-                          database configurations, query performance, and other relevant data to
-                          expedite troubleshooting and enhance support accuracy. We are committed to
-                          maintaining strict data privacy and security standards in all support
-                          activities.{' '}
-                          <Link
-                            href="https://supabase.com/privacy"
-                            target="_blank"
-                            rel="noreferrer"
-                            className="text-foreground-light underline hover:text-foreground transition"
-                          >
-                            Privacy Policy
-                          </Link>
-                        </p>
-                      </CollapsibleContent_Shadcn_>
-                    </Collapsible_Shadcn_>
-                  }
-                >
-                  <Switch
-                    id="allowSupportAccess"
-                    checked={field.value}
-                    onCheckedChange={field.onChange}
-                  />
-                </FormItemLayout>
-              )}
-            />
+            <div>
+              <FormField_Shadcn_
+                name="allowSupportAccess"
+                control={form.control}
+                render={({ field }) => {
+                  return (
+                    <FormItemLayout
+                      name="allowSupportAccess"
+                      className="px-6"
+                      layout="flex"
+                      label={'Allow support access to your project'}
+                      description={
+                        <div className="flex flex-col">
+                          <span className="text-foreground-light">
+                            Human support and AI support authorized access.
+                          </span>
+                          <Collapsible_Shadcn_ className="mt-2">
+                            <CollapsibleTrigger_Shadcn_
+                              className={
+                                'group flex items-center gap-x-1 group-data-[state=open]:text-foreground hover:text-foreground transition'
+                              }
+                            >
+                              <ChevronRight
+                                strokeWidth={2}
+                                size={14}
+                                className="transition-all group-data-[state=open]:rotate-90 text-foreground-muted -ml-1"
+                              />
+                              <span className="text-sm">More information</span>
+                            </CollapsibleTrigger_Shadcn_>
+                            <CollapsibleContent_Shadcn_ className="text-sm text-foreground-light mt-2 space-y-2">
+                              <p>
+                                By enabling this, you grant permission for our support team to
+                                access your project temporarily and, if applicable, to use AI tools
+                                to assist in diagnosing and resolving issues. This access may
+                                involve analyzing database configurations, query performance, and
+                                other relevant data to expedite troubleshooting and enhance support
+                                accuracy.
+                              </p>
+                              <p>
+                                We are committed to maintaining strict data privacy and security
+                                standards in all support activities.{' '}
+                                <Link
+                                  href="https://supabase.com/privacy"
+                                  target="_blank"
+                                  rel="noreferrer"
+                                  className="text-foreground-light underline hover:text-foreground transition"
+                                >
+                                  Privacy Policy
+                                </Link>
+                              </p>
+                            </CollapsibleContent_Shadcn_>
+                          </Collapsible_Shadcn_>
+                        </div>
+                      }
+                    >
+                      <Switch
+                        size="large"
+                        id="allowSupportAccess"
+                        checked={field.value}
+                        onCheckedChange={field.onChange}
+                      />
+                    </FormItemLayout>
+                  )
+                }}
+              />
+              {/* <div className="flex flex-col gap-y-2 px-5 text-sm">
+                <div className="text-foreground-light flex items-center gap-x-2">
+                  <div className="w-7 h-7 bg-surface-200 rounded border flex items-center justify-center">
+                    <SquareUserRound className="w-5 h-5" strokeWidth={1} />
+                  </div>
+                  <span className="font-medium">Human access</span>
+                  <span>- Access to your project data and configuration</span>
+                </div>
+                <div className="text-foreground-light flex items-center gap-x-2">
+                  <div className="w-7 h-7 bg-surface-200 rounded border flex items-center justify-center">
+                    <AiIconAnimation size={16} />
+                  </div>
+                  <span className="font-medium">AI access</span>
+                  <span>- Access to your project data and configuration</span>
+                </div>
+              </div>
+              <Collapsible_Shadcn_>
+                <div className="flex items-center gap-x-2">
+                  <CollapsibleTrigger_Shadcn_ className="group flex items-center gap-x-1 ">
+                    <ChevronRight
+                      strokeWidth={2}
+                      size={14}
+                      className="transition-all group-data-[state=open]:rotate-90 text-foreground-muted -ml-1"
+                    />
+                    <p className="text-sm text-foreground-light">
+                      More information about temporary access
+                    </p>
+                  </CollapsibleTrigger_Shadcn_>
+                </div>
+                <CollapsibleContent_Shadcn_ className="text-xs text-foreground-light mt-2 space-y-2">
+                  <p>
+                    By enabling this, you grant permission for our support team to access your
+                    project temporarily and, if applicable, to use AI tools to assist in diagnosing
+                    and resolving issues. This access may involve analyzing database configurations,
+                    query performance, and other relevant data to expedite troubleshooting and
+                    enhance support accuracy.
+                  </p>
+                  <p>
+                    We are committed to maintaining strict data privacy and security standards in
+                    all support activities.{' '}
+                    <Link
+                      href="https://supabase.com/privacy"
+                      target="_blank"
+                      rel="noreferrer"
+                      className="text-foreground-light underline hover:text-foreground transition"
+                    >
+                      Privacy Policy
+                    </Link>
+                  </p>
+                </CollapsibleContent_Shadcn_>
+              </Collapsible_Shadcn_>  */}
+            </div>
+            <Separator />
           </>
         )}
 

--- a/apps/studio/components/interfaces/Support/SupportFormV2.tsx
+++ b/apps/studio/components/interfaces/Support/SupportFormV2.tsx
@@ -693,79 +693,76 @@ export const SupportFormV2 = ({ setSentCategory, setSelectedProject }: SupportFo
 
         {['Problem', 'Database_unresponsive', 'Performance'].includes(category) && (
           <>
-            <div>
-              <FormField_Shadcn_
-                name="allowSupportAccess"
-                control={form.control}
-                render={({ field }) => {
-                  return (
-                    <FormItemLayout
-                      name="allowSupportAccess"
-                      className="px-6"
-                      layout="flex"
-                      label={
-                        <div className="flex items-center gap-x-2">
-                          <span className="text-foreground">
-                            Allow support access to your project
-                          </span>
-                          <Badge className="bg-opacity-100">Recommended</Badge>
-                        </div>
-                      }
-                      description={
-                        <div className="flex flex-col">
-                          <span className="text-foreground-light">
-                            Human support and AI diagnostic access.
-                          </span>
-                          <Collapsible_Shadcn_ className="mt-2">
-                            <CollapsibleTrigger_Shadcn_
-                              className={
-                                'group flex items-center gap-x-1 group-data-[state=open]:text-foreground hover:text-foreground transition'
-                              }
-                            >
-                              <ChevronRight
-                                strokeWidth={2}
-                                size={14}
-                                className="transition-all group-data-[state=open]:rotate-90 text-foreground-muted -ml-1"
-                              />
-                              <span className="text-sm">More information</span>
-                            </CollapsibleTrigger_Shadcn_>
-                            <CollapsibleContent_Shadcn_ className="text-sm text-foreground-light mt-2 space-y-2">
-                              <p>
-                                By enabling this, you grant permission for our support team to
-                                access your project temporarily and, if applicable, to use AI tools
-                                to assist in diagnosing and resolving issues. This access may
-                                involve analyzing database configurations, query performance, and
-                                other relevant data to expedite troubleshooting and enhance support
-                                accuracy.
-                              </p>
-                              <p>
-                                We are committed to maintaining strict data privacy and security
-                                standards in all support activities.{' '}
-                                <Link
-                                  href="https://supabase.com/privacy"
-                                  target="_blank"
-                                  rel="noreferrer"
-                                  className="text-foreground-light underline hover:text-foreground transition"
-                                >
-                                  Privacy Policy
-                                </Link>
-                              </p>
-                            </CollapsibleContent_Shadcn_>
-                          </Collapsible_Shadcn_>
-                        </div>
-                      }
-                    >
-                      <Switch
-                        size="large"
-                        id="allowSupportAccess"
-                        checked={field.value}
-                        onCheckedChange={field.onChange}
-                      />
-                    </FormItemLayout>
-                  )
-                }}
-              />
-            </div>
+            <FormField_Shadcn_
+              name="allowSupportAccess"
+              control={form.control}
+              render={({ field }) => {
+                return (
+                  <FormItemLayout
+                    name="allowSupportAccess"
+                    className="px-6"
+                    layout="flex"
+                    label={
+                      <div className="flex items-center gap-x-2">
+                        <span className="text-foreground">
+                          Allow support access to your project
+                        </span>
+                        <Badge className="bg-opacity-100">Recommended</Badge>
+                      </div>
+                    }
+                    description={
+                      <div className="flex flex-col">
+                        <span className="text-foreground-light">
+                          Human support and AI diagnostic access.
+                        </span>
+                        <Collapsible_Shadcn_ className="mt-2">
+                          <CollapsibleTrigger_Shadcn_
+                            className={
+                              'group flex items-center gap-x-1 group-data-[state=open]:text-foreground hover:text-foreground transition'
+                            }
+                          >
+                            <ChevronRight
+                              strokeWidth={2}
+                              size={14}
+                              className="transition-all group-data-[state=open]:rotate-90 text-foreground-muted -ml-1"
+                            />
+                            <span className="text-sm">More information</span>
+                          </CollapsibleTrigger_Shadcn_>
+                          <CollapsibleContent_Shadcn_ className="text-sm text-foreground-light mt-2 space-y-2">
+                            <p>
+                              By enabling this, you grant permission for our support team to access
+                              your project temporarily and, if applicable, to use AI tools to assist
+                              in diagnosing and resolving issues. This access may involve analyzing
+                              database configurations, query performance, and other relevant data to
+                              expedite troubleshooting and enhance support accuracy.
+                            </p>
+                            <p>
+                              We are committed to maintaining strict data privacy and security
+                              standards in all support activities.{' '}
+                              <Link
+                                href="https://supabase.com/privacy"
+                                target="_blank"
+                                rel="noreferrer"
+                                className="text-foreground-light underline hover:text-foreground transition"
+                              >
+                                Privacy Policy
+                              </Link>
+                            </p>
+                          </CollapsibleContent_Shadcn_>
+                        </Collapsible_Shadcn_>
+                      </div>
+                    }
+                  >
+                    <Switch
+                      size="large"
+                      id="allowSupportAccess"
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                    />
+                  </FormItemLayout>
+                )
+              }}
+            />
             <Separator />
           </>
         )}

--- a/apps/studio/components/interfaces/Support/SupportFormV2.tsx
+++ b/apps/studio/components/interfaces/Support/SupportFormV2.tsx
@@ -1,16 +1,6 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import * as Sentry from '@sentry/nextjs'
-import {
-  Check,
-  ChevronRight,
-  CircleUserRound,
-  ExternalLink,
-  Loader2,
-  Mail,
-  Plus,
-  SquareUserRound,
-  X,
-} from 'lucide-react'
+import { ChevronRight, ExternalLink, Mail, Plus, X } from 'lucide-react'
 import Link from 'next/link'
 import { ChangeEvent, useEffect, useMemo, useRef, useState } from 'react'
 import { SubmitHandler, useForm } from 'react-hook-form'
@@ -27,7 +17,6 @@ import { useProjectsQuery } from 'data/projects/projects-query'
 import { detectBrowser } from 'lib/helpers'
 import { useProfile } from 'lib/profile'
 import {
-  AiIconAnimation,
   Badge,
   Button,
   cn,
@@ -693,84 +682,81 @@ export const SupportFormV2 = ({ setSentCategory, setSelectedProject }: SupportFo
 
         {['Problem', 'Database_unresponsive', 'Performance'].includes(category) && (
           <>
-            <div>
-              <FormField_Shadcn_
-                name="allowSupportAccess"
-                control={form.control}
-                render={({ field }) => {
-                  return (
-                    <FormItemLayout
-                      name="allowSupportAccess"
-                      className="px-6"
-                      layout="flex"
-                      label={
-                        <div className="flex items-center gap-x-2">
-                          <span className="text-foreground">
-                            Allow support access to your project
-                          </span>
-                          <Badge className="bg-opacity-100">Recommended</Badge>
-                        </div>
-                      }
-                      description={
-                        <div className="flex flex-col">
-                          <span className="text-foreground-light">
-                            Human support and AI diagnostic access.
-                          </span>
-                          <Collapsible_Shadcn_ className="mt-2">
-                            <CollapsibleTrigger_Shadcn_
-                              className={
-                                'group flex items-center gap-x-1 group-data-[state=open]:text-foreground hover:text-foreground transition'
-                              }
-                            >
-                              <ChevronRight
-                                strokeWidth={2}
-                                size={14}
-                                className="transition-all group-data-[state=open]:rotate-90 text-foreground-muted -ml-1"
-                              />
-                              <span className="text-sm">More information</span>
-                            </CollapsibleTrigger_Shadcn_>
-                            <CollapsibleContent_Shadcn_ className="text-sm text-foreground-light mt-2 space-y-2">
-                              <p>
-                                By enabling this, you grant permission for our support team to
-                                access your project temporarily and, if applicable, to use AI tools
-                                to assist in diagnosing and resolving issues. This access may
-                                involve analyzing database configurations, query performance, and
-                                other relevant data to expedite troubleshooting and enhance support
-                                accuracy.
-                              </p>
-                              <p>
-                                We are committed to maintaining strict data privacy and security
-                                standards in all support activities.{' '}
-                                <Link
-                                  href="https://supabase.com/privacy"
-                                  target="_blank"
-                                  rel="noreferrer"
-                                  className="text-foreground-light underline hover:text-foreground transition"
-                                >
-                                  Privacy Policy
-                                </Link>
-                              </p>
-                            </CollapsibleContent_Shadcn_>
-                          </Collapsible_Shadcn_>
-                        </div>
-                      }
-                    >
-                      <Switch
-                        size="large"
-                        id="allowSupportAccess"
-                        checked={field.value}
-                        onCheckedChange={field.onChange}
-                      />
-                    </FormItemLayout>
-                  )
-                }}
-              />
-            </div>
+            <FormField_Shadcn_
+              name="allowSupportAccess"
+              control={form.control}
+              render={({ field }) => {
+                return (
+                  <FormItemLayout
+                    name="allowSupportAccess"
+                    className="px-6"
+                    layout="flex"
+                    label={
+                      <div className="flex items-center gap-x-2">
+                        <span className="text-foreground">
+                          Allow support access to your project
+                        </span>
+                        <Badge className="bg-opacity-100">Recommended</Badge>
+                      </div>
+                    }
+                    description={
+                      <div className="flex flex-col">
+                        <span className="text-foreground-light">
+                          Human support and AI diagnostic access.
+                        </span>
+                        <Collapsible_Shadcn_ className="mt-2">
+                          <CollapsibleTrigger_Shadcn_
+                            className={
+                              'group flex items-center gap-x-1 group-data-[state=open]:text-foreground hover:text-foreground transition'
+                            }
+                          >
+                            <ChevronRight
+                              strokeWidth={2}
+                              size={14}
+                              className="transition-all group-data-[state=open]:rotate-90 text-foreground-muted -ml-1"
+                            />
+                            <span className="text-sm">More information</span>
+                          </CollapsibleTrigger_Shadcn_>
+                          <CollapsibleContent_Shadcn_ className="text-sm text-foreground-light mt-2 space-y-2">
+                            <p>
+                              By enabling this, you grant permission for our support team to access
+                              your project temporarily and, if applicable, to use AI tools to assist
+                              in diagnosing and resolving issues. This access may involve analyzing
+                              database configurations, query performance, and other relevant data to
+                              expedite troubleshooting and enhance support accuracy.
+                            </p>
+                            <p>
+                              We are committed to maintaining strict data privacy and security
+                              standards in all support activities.{' '}
+                              <Link
+                                href="https://supabase.com/privacy"
+                                target="_blank"
+                                rel="noreferrer"
+                                className="text-foreground-light underline hover:text-foreground transition"
+                              >
+                                Privacy Policy
+                              </Link>
+                            </p>
+                          </CollapsibleContent_Shadcn_>
+                        </Collapsible_Shadcn_>
+                      </div>
+                    }
+                  >
+                    <Switch
+                      size="large"
+                      id="allowSupportAccess"
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                    />
+                  </FormItemLayout>
+                )
+              }}
+            />
             <Separator />
           </>
         )}
 
-        <div className={cn(CONTAINER_CLASSES, 'flex flex-col items-end gap-3 -mt-4')}>
+        <div className={cn(CONTAINER_CLASSES, 'flex flex-col items-end gap-3')}>
           <Button
             htmlType="submit"
             size="large"

--- a/apps/studio/components/interfaces/Support/SupportFormV2.tsx
+++ b/apps/studio/components/interfaces/Support/SupportFormV2.tsx
@@ -765,57 +765,6 @@ export const SupportFormV2 = ({ setSentCategory, setSelectedProject }: SupportFo
                   )
                 }}
               />
-              {/* <div className="flex flex-col gap-y-2 px-5 text-sm">
-                <div className="text-foreground-light flex items-center gap-x-2">
-                  <div className="w-7 h-7 bg-surface-200 rounded border flex items-center justify-center">
-                    <SquareUserRound className="w-5 h-5" strokeWidth={1} />
-                  </div>
-                  <span className="font-medium">Human access</span>
-                  <span>- Access to your project data and configuration</span>
-                </div>
-                <div className="text-foreground-light flex items-center gap-x-2">
-                  <div className="w-7 h-7 bg-surface-200 rounded border flex items-center justify-center">
-                    <AiIconAnimation size={16} />
-                  </div>
-                  <span className="font-medium">AI access</span>
-                  <span>- Access to your project data and configuration</span>
-                </div>
-              </div>
-              <Collapsible_Shadcn_>
-                <div className="flex items-center gap-x-2">
-                  <CollapsibleTrigger_Shadcn_ className="group flex items-center gap-x-1 ">
-                    <ChevronRight
-                      strokeWidth={2}
-                      size={14}
-                      className="transition-all group-data-[state=open]:rotate-90 text-foreground-muted -ml-1"
-                    />
-                    <p className="text-sm text-foreground-light">
-                      More information about temporary access
-                    </p>
-                  </CollapsibleTrigger_Shadcn_>
-                </div>
-                <CollapsibleContent_Shadcn_ className="text-xs text-foreground-light mt-2 space-y-2">
-                  <p>
-                    By enabling this, you grant permission for our support team to access your
-                    project temporarily and, if applicable, to use AI tools to assist in diagnosing
-                    and resolving issues. This access may involve analyzing database configurations,
-                    query performance, and other relevant data to expedite troubleshooting and
-                    enhance support accuracy.
-                  </p>
-                  <p>
-                    We are committed to maintaining strict data privacy and security standards in
-                    all support activities.{' '}
-                    <Link
-                      href="https://supabase.com/privacy"
-                      target="_blank"
-                      rel="noreferrer"
-                      className="text-foreground-light underline hover:text-foreground transition"
-                    >
-                      Privacy Policy
-                    </Link>
-                  </p>
-                </CollapsibleContent_Shadcn_>
-              </Collapsible_Shadcn_>  */}
             </div>
             <Separator />
           </>

--- a/apps/studio/components/interfaces/Support/SupportFormV2.tsx
+++ b/apps/studio/components/interfaces/Support/SupportFormV2.tsx
@@ -685,72 +685,68 @@ export const SupportFormV2 = ({ setSentCategory, setSelectedProject }: SupportFo
             <FormField_Shadcn_
               name="allowSupportAccess"
               control={form.control}
-              render={({ field }) => {
-                return (
-                  <FormItemLayout
-                    name="allowSupportAccess"
-                    className="px-6"
-                    layout="flex"
-                    label={
-                      <div className="flex items-center gap-x-2">
-                        <span className="text-foreground">
-                          Allow support access to your project
-                        </span>
-                        <Badge className="bg-opacity-100">Recommended</Badge>
-                      </div>
-                    }
-                    description={
-                      <div className="flex flex-col">
-                        <span className="text-foreground-light">
-                          Human support and AI diagnostic access.
-                        </span>
-                        <Collapsible_Shadcn_ className="mt-2">
-                          <CollapsibleTrigger_Shadcn_
-                            className={
-                              'group flex items-center gap-x-1 group-data-[state=open]:text-foreground hover:text-foreground transition'
-                            }
-                          >
-                            <ChevronRight
-                              strokeWidth={2}
-                              size={14}
-                              className="transition-all group-data-[state=open]:rotate-90 text-foreground-muted -ml-1"
-                            />
-                            <span className="text-sm">More information</span>
-                          </CollapsibleTrigger_Shadcn_>
-                          <CollapsibleContent_Shadcn_ className="text-sm text-foreground-light mt-2 space-y-2">
-                            <p>
-                              By enabling this, you grant permission for our support team to access
-                              your project temporarily and, if applicable, to use AI tools to assist
-                              in diagnosing and resolving issues. This access may involve analyzing
-                              database configurations, query performance, and other relevant data to
-                              expedite troubleshooting and enhance support accuracy.
-                            </p>
-                            <p>
-                              We are committed to maintaining strict data privacy and security
-                              standards in all support activities.{' '}
-                              <Link
-                                href="https://supabase.com/privacy"
-                                target="_blank"
-                                rel="noreferrer"
-                                className="text-foreground-light underline hover:text-foreground transition"
-                              >
-                                Privacy Policy
-                              </Link>
-                            </p>
-                          </CollapsibleContent_Shadcn_>
-                        </Collapsible_Shadcn_>
-                      </div>
-                    }
-                  >
-                    <Switch
-                      size="large"
-                      id="allowSupportAccess"
-                      checked={field.value}
-                      onCheckedChange={field.onChange}
-                    />
-                  </FormItemLayout>
-                )
-              }}
+              render={({ field }) => (
+                <FormItemLayout
+                  name="allowSupportAccess"
+                  className="px-6"
+                  layout="flex"
+                  label={
+                    <div className="flex items-center gap-x-2">
+                      <span className="text-foreground">Allow support access to your project</span>
+                      <Badge className="bg-opacity-100">Recommended</Badge>
+                    </div>
+                  }
+                  description={
+                    <div className="flex flex-col">
+                      <span className="text-foreground-light">
+                        Human support and AI diagnostic access.
+                      </span>
+                      <Collapsible_Shadcn_ className="mt-2">
+                        <CollapsibleTrigger_Shadcn_
+                          className={
+                            'group flex items-center gap-x-1 group-data-[state=open]:text-foreground hover:text-foreground transition'
+                          }
+                        >
+                          <ChevronRight
+                            strokeWidth={2}
+                            size={14}
+                            className="transition-all group-data-[state=open]:rotate-90 text-foreground-muted -ml-1"
+                          />
+                          <span className="text-sm">More information</span>
+                        </CollapsibleTrigger_Shadcn_>
+                        <CollapsibleContent_Shadcn_ className="text-sm text-foreground-light mt-2 space-y-2">
+                          <p>
+                            By enabling this, you grant permission for our support team to access
+                            your project temporarily and, if applicable, to use AI tools to assist
+                            in diagnosing and resolving issues. This access may involve analyzing
+                            database configurations, query performance, and other relevant data to
+                            expedite troubleshooting and enhance support accuracy.
+                          </p>
+                          <p>
+                            We are committed to maintaining strict data privacy and security
+                            standards in all support activities.{' '}
+                            <Link
+                              href="https://supabase.com/privacy"
+                              target="_blank"
+                              rel="noreferrer"
+                              className="text-foreground-light underline hover:text-foreground transition"
+                            >
+                              Privacy Policy
+                            </Link>
+                          </p>
+                        </CollapsibleContent_Shadcn_>
+                      </Collapsible_Shadcn_>
+                    </div>
+                  }
+                >
+                  <Switch
+                    size="large"
+                    id="allowSupportAccess"
+                    checked={field.value}
+                    onCheckedChange={field.onChange}
+                  />
+                </FormItemLayout>
+              )}
             />
             <Separator />
           </>

--- a/apps/studio/components/interfaces/Support/SupportFormV2.tsx
+++ b/apps/studio/components/interfaces/Support/SupportFormV2.tsx
@@ -703,11 +703,18 @@ export const SupportFormV2 = ({ setSentCategory, setSelectedProject }: SupportFo
                       name="allowSupportAccess"
                       className="px-6"
                       layout="flex"
-                      label={'Allow support access to your project'}
+                      label={
+                        <div className="flex items-center gap-x-2">
+                          <span className="text-foreground">
+                            Allow support access to your project
+                          </span>
+                          <Badge className="bg-opacity-100">Recommended</Badge>
+                        </div>
+                      }
                       description={
                         <div className="flex flex-col">
                           <span className="text-foreground-light">
-                            Human support and AI support authorized access.
+                            Human support and AI diagnostic access.
                           </span>
                           <Collapsible_Shadcn_ className="mt-2">
                             <CollapsibleTrigger_Shadcn_

--- a/apps/studio/components/layouts/ProjectLayout/LayoutHeader/LayoutHeader.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/LayoutHeader/LayoutHeader.tsx
@@ -19,6 +19,7 @@ import { useSelectedOrganization } from 'hooks/misc/useSelectedOrganization'
 import { useSelectedProject } from 'hooks/misc/useSelectedProject'
 import { useShowLayoutHeader } from 'hooks/misc/useShowLayoutHeader'
 import { IS_PLATFORM } from 'lib/constants'
+import { useAppStateSnapshot } from 'state/app-state'
 import { Badge, cn } from 'ui'
 import BreadcrumbsView from './BreadcrumbsView'
 import { FeedbackDropdown } from './FeedbackDropdown'
@@ -49,12 +50,14 @@ interface LayoutHeaderProps {
   customHeaderComponents?: ReactNode
   breadcrumbs?: any[]
   headerTitle?: string
+  showProductMenu?: boolean
 }
 
 const LayoutHeader = ({
   customHeaderComponents,
   breadcrumbs = [],
   headerTitle,
+  showProductMenu,
 }: LayoutHeaderProps) => {
   const newLayoutPreview = useIsNewLayoutEnabled()
 
@@ -62,6 +65,7 @@ const LayoutHeader = ({
   const { ref: projectRef, slug } = useParams()
   const selectedProject = useSelectedProject()
   const selectedOrganization = useSelectedOrganization()
+  const { setMobileMenuOpen } = useAppStateSnapshot()
   const isBranchingEnabled = selectedProject?.is_branch_enabled === true
 
   // We only want to query the org usage and check for possible over-ages for plans without usage billing enabled (free or pro with spend cap)


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

- Changes AI support form, allowSupportAccess is set to default
- Adds recommendation badge
- Simplified messaging / copy


after changes:
<img width="707" alt="Screenshot 2025-04-16 at 20 12 02" src="https://github.com/user-attachments/assets/52c46dc0-96be-4b8f-8a54-ecc712995efd" />

before:
<img width="747" alt="Screenshot 2025-04-16 at 20 04 08" src="https://github.com/user-attachments/assets/89dc26c8-946d-426b-b549-2ec0adab8101" />

