### PR TITLE
fix: foreign key panel text

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.tsx
@@ -294,7 +294,7 @@ export const ForeignKeySelector = ({
                   <code className="text-xs">
                     {fk.schema}.{fk.table}
                   </code>
-                  to reference to
+                  {' '}to reference to
                 </label>
                 <div className="grid grid-cols-10 gap-y-2">
                   <div className="col-span-5 text-xs text-foreground-lighter">


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Supabase Studio - Table Editor - Add Foreign Key

## What is the current behavior?

<img width="436" alt="Screenshot 2025-04-17 at 08 51 29" src="https://github.com/user-attachments/assets/312607a7-a62a-466f-a1cb-e6f9044028ff" />


## What is the new behavior?

<img width="436" alt="Screenshot 2025-04-17 at 08 51 40" src="https://github.com/user-attachments/assets/897ac0e2-c33f-4ef6-8aa0-47d08b01f5bf" />

## Additional context

Closes #35083 