### PR TITLE
Fix SQL editor styling when multiple snippets are selected

### DIFF
--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorNav.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorNav.tsx
@@ -582,12 +582,13 @@ export const SQLEditorNav = ({ sort = 'inserted_at' }: SQLEditorNavProps) => {
                 })
                 const isPreview = isSQLEditorTabsEnabled && tabStore.previewTabId === tabId
                 const isActive = !isPreview && element.metadata?.id === id
+                const isSelected = selectedSnippets.some((x) => x.id === element.metadata?.id)
 
                 return (
                   <SQLEditorTreeViewItem
                     {...props}
                     isOpened={isOpened && !isPreview}
-                    isSelected={isActive}
+                    isSelected={isActive || isSelected}
                     isPreview={isPreview}
                     onDoubleClick={(e) => {
                       e.preventDefault()
@@ -665,10 +666,12 @@ export const SQLEditorNav = ({ sort = 'inserted_at' }: SQLEditorNavProps) => {
                 })
                 const isPreview = isSQLEditorTabsEnabled && tabStore.previewTabId === tabId
                 const isActive = !isPreview && element.metadata?.id === id
+                const isSelected = selectedSnippets.some((x) => x.id === element.metadata?.id)
+
                 return (
                   <SQLEditorTreeViewItem
                     {...props}
-                    isSelected={isActive}
+                    isSelected={isActive || isSelected}
                     isOpened={isOpened && !isPreview}
                     isPreview={isPreview}
                     onDoubleClick={(e) => {
@@ -753,13 +756,14 @@ export const SQLEditorNav = ({ sort = 'inserted_at' }: SQLEditorNavProps) => {
                 })
                 const isPreview = isSQLEditorTabsEnabled && tabStore.previewTabId === tabId
                 const isActive = !isPreview && element.metadata?.id === id
+                const isSelected = selectedSnippets.some((x) => x.id === element.metadata?.id)
 
                 return (
                   <SQLEditorTreeViewItem
                     {...props}
                     element={element}
                     isOpened={isOpened && !isPreview}
-                    isSelected={isActive}
+                    isSelected={isActive || isSelected}
                     isPreview={isPreview}
                     isMultiSelected={selectedSnippets.length > 1}
                     isLastItem={privateSnippetsLastItemIds.has(element.id as string)}


### PR DESCRIPTION
Fixes FE-1596, Bug was probably introduced with the tabs changes

Before:
![image](https://github.com/user-attachments/assets/c17972ad-5f31-4949-87e3-5a08a47d22a0)

After:
![image](https://github.com/user-attachments/assets/ffe822e0-4b1a-4739-b0c0-526e34531349)

## To test
- [ ] SQL Editor -> select a query, then shift+click on another query to select all the queries between them, ensure that there's a UI indication to show which queries are selected