### PR TITLE
Tiny fix for copy client id

### DIFF
--- a/apps/studio/components/interfaces/Organization/OAuthApps/OAuthApps.tsx
+++ b/apps/studio/components/interfaces/Organization/OAuthApps/OAuthApps.tsx
@@ -142,7 +142,7 @@ const OAuthApps = () => {
                   <div className="flex items-center gap-2">
                     <p className="text-sm text-foreground-light">Client ID</p>
                     <p className="font-mono text-sm">{createdApp.client_id}</p>
-                    <CopyButton text={createdApp.client_secret} type="default" iconOnly />
+                    <CopyButton text={createdApp.client_id} type="default" iconOnly />
                   </div>
 
                   <div className="flex items-center gap-2">


### PR DESCRIPTION
This is for Organization Settings when creating a new OAuth app - the copy button for client ID was accidentally copying the secret instead