### PR TITLE
fix: update TypeScript config in ai-commands package

### DIFF
--- a/packages/ai-commands/tsconfig.json
+++ b/packages/ai-commands/tsconfig.json
@@ -1,8 +1,8 @@
 {
-  "extends": "tsconfig/react-library.json",
+  "extends": "../../packages/tsconfig/react-library.json",
   "include": ["."],
   "exclude": ["dist", "build", "node_modules"],
   "compilerOptions": {
-    "types": ["./test/extensions.d.ts"]
+    "typeRoots": ["./node_modules/@types", "./test"]
   }
 }


### PR DESCRIPTION
**Correcting the path** _to tsconfig/react-library.json_ to use a relative import:
_../../packages/tsconfig/react-library.json_

**Adjusting the** _typeRoots_ to properly handle the test type definitions.