### PR TITLE
Remove isValidating disabled check for CustomDomainVerify cancel action

### DIFF
--- a/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainVerify.tsx
+++ b/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainVerify.tsx
@@ -189,7 +189,7 @@ const CustomDomainVerify = ({ customDomain }: CustomDomainVerifyProps) => {
               type="default"
               onClick={onCancelCustomDomain}
               loading={isDeleting}
-              disabled={isReverifyLoading || isValidating}
+              disabled={isValidating}
               className="self-end"
             >
               Cancel


### PR DESCRIPTION
For this part of the Custom Domains UI
![image](https://github.com/user-attachments/assets/2c1ad65c-7e77-42ca-9d8c-c9ba03d9b3dd)

Realised that we shouldn't need to disable the "Cancel" button while the user is re-verifying the custom domain at this step, as they should be allowed to cancel the custom domain set up any time