### PR TITLE
Increase padding for org and project dropdown in new layout

### DIFF
--- a/apps/studio/components/layouts/AppLayout/OrganizationDropdown.tsx
+++ b/apps/studio/components/layouts/AppLayout/OrganizationDropdown.tsx
@@ -62,7 +62,7 @@ const OrganizationDropdown = () => {
           {newLayoutPreview ? (
             <Button
               type="text"
-              className={cn('px-0.25 [&_svg]:w-5 [&_svg]:h-5 ml-1')}
+              className={cn('px-1 py-4 [&_svg]:w-5 [&_svg]:h-5 ml-1')}
               iconRight={<ChevronsUpDown strokeWidth={1.5} />}
             />
           ) : (

--- a/apps/studio/components/layouts/AppLayout/OrganizationDropdown.tsx
+++ b/apps/studio/components/layouts/AppLayout/OrganizationDropdown.tsx
@@ -62,7 +62,7 @@ const OrganizationDropdown = () => {
           {newLayoutPreview ? (
             <Button
               type="text"
-              className={cn('px-1 py-4 [&_svg]:w-5 [&_svg]:h-5 ml-1')}
+              className={cn('px-1.5 py-4 [&_svg]:w-5 [&_svg]:h-5 ml-1')}
               iconRight={<ChevronsUpDown strokeWidth={1.5} />}
             />
           ) : (

--- a/apps/studio/components/layouts/AppLayout/ProjectDropdown.tsx
+++ b/apps/studio/components/layouts/AppLayout/ProjectDropdown.tsx
@@ -136,7 +136,7 @@ const ProjectDropdown = ({ isNewNav = true }: ProjectDropdownProps) => {
             <Button
               type="text"
               size="tiny"
-              className={cn('px-1 py-4 [&_svg]:w-5 [&_svg]:h-5 ml-1')}
+              className={cn('px-1.5 py-4 [&_svg]:w-5 [&_svg]:h-5 ml-1')}
               iconRight={<ChevronsUpDown strokeWidth={1.5} />}
             />
           ) : (

--- a/apps/studio/components/layouts/AppLayout/ProjectDropdown.tsx
+++ b/apps/studio/components/layouts/AppLayout/ProjectDropdown.tsx
@@ -136,7 +136,7 @@ const ProjectDropdown = ({ isNewNav = true }: ProjectDropdownProps) => {
             <Button
               type="text"
               size="tiny"
-              className={cn('px-0.25 [&_svg]:w-5 [&_svg]:h-5 ml-1')}
+              className={cn('px-1 py-4 [&_svg]:w-5 [&_svg]:h-5 ml-1')}
               iconRight={<ChevronsUpDown strokeWidth={1.5} />}
             />
           ) : (


### PR DESCRIPTION
Fixes FE-1584

Addressing some internal feedback that it's confusing + hard to hit the dropdown button in the layout to switch organization / projects

It was a deliberate decision to have it such that clicking the org name will redirect users to /org/slug route, and clicking the project name will redirect users to /project/ref route now instead of opening the dropdown - so only the chevron button will open the dropdown instead. But agree that the hit box for that dropdown trigger is quite tiny - so the changes in this PR just expands it a little

## Before
![image](https://github.com/user-attachments/assets/4c9877cd-0d04-4c30-b00e-8e1ca5a358a8)

![image](https://github.com/user-attachments/assets/f8d37cdd-4433-43d9-a0eb-b409c7ad1d43)

## After
![image](https://github.com/user-attachments/assets/cd071cc4-477e-4a93-bb66-d463019ae928)

![image](https://github.com/user-attachments/assets/f8393c76-ece8-4845-a8a8-fe6ed7dc12e3)

