### PR TITLE
Fix CodeBlock component allowing users to backspace content when it should be readonly

### DIFF
--- a/apps/studio/components/interfaces/Integrations/CronJobs/CronJobCard.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CronJobCard.tsx
@@ -9,6 +9,7 @@ import { CronJob } from 'data/database-cron-jobs/database-cron-jobs-query'
 import { useCronJobRunQuery } from 'data/database-cron-jobs/database-cron-jobs-run-query'
 import { useDatabaseCronJobToggleMutation } from 'data/database-cron-jobs/database-cron-jobs-toggle-mutation'
 import { useSendEventMutation } from 'data/telemetry/send-event-mutation'
+import { useSelectedOrganization } from 'hooks/misc/useSelectedOrganization'
 import {
   Badge,
   Button,
@@ -26,7 +27,6 @@ import { TimestampInfo } from 'ui-patterns'
 import { Input } from 'ui-patterns/DataInputs/Input'
 import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
 import { convertCronToString, getNextRun } from './CronJobs.utils'
-import { useSelectedOrganization } from 'hooks/misc/useSelectedOrganization'
 
 interface CronJobCardProps {
   job: CronJob

--- a/packages/ui/src/components/CodeBlock/CodeBlock.tsx
+++ b/packages/ui/src/components/CodeBlock/CodeBlock.tsx
@@ -168,9 +168,9 @@ export const CodeBlock = ({
         >
           {/* @ts-ignore */}
           <SyntaxHighlighter
+            suppressContentEditableWarning
             language={lang}
             wrapLines={wrapLines}
-            // @ts-ignore
             style={monokaiTheme}
             className={cn(
               'code-block border border-surface p-4 w-full !my-0 !bg-surface-100 outline-none focus:border-foreground-lighter/50',
@@ -220,7 +220,12 @@ export const CodeBlock = ({
               e.preventDefault()
               return false
             }}
-            suppressContentEditableWarning={true}
+            onKeyDown={(e: any) => {
+              if (e.code === 'Backspace') {
+                e.preventDefault()
+                return false
+              }
+            }}
           >
             {codeValue}
           </SyntaxHighlighter>


### PR DESCRIPTION
## Content

We had a bug report that users could actually backspace in `CodeBlock` components, although not being able to input any characters. Our `CodeBlock` component has a prop `contentEditable` that we're flagging by default as `true`, mainly to support users being able to focus on the code content, and conveniently `cmd+a` to copy the content.


## Changes involved

`onBeforeInput` prop blocks against entering additional characters but we needed an `onKeyDown` check as well to check for the backspace event

## To test

- [ ] Staging: Go into any project, open the Connect modal, notice you can backspace in the direct connection input field
![image](https://github.com/user-attachments/assets/9fe4c026-732f-4881-80e5-e5a99c0d7f81)
- [ ] Preview: Do the same thing, but verify that you can no longer hit backspace in the field
