### PR TITLE
ci (docs): prevent concurrent search update processes

### DIFF
--- a/.github/workflows/search.yml
+++ b/.github/workflows/search.yml
@@ -17,6 +17,10 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+concurrency:
+  group: ${{ github.workflow }}-prod
+  cancel-in-progress: false
+
 permissions:
   contents: read
 


### PR DESCRIPTION
Before:

Closely spaced merges of new docs content can result in embedding generation processes clobbering each other. For example:

- Merge A creates version ID A, starts uploading changed rows
- Merge B creates version ID B, starts uploading changed rows
- Workflow A finishes, starts deleting all rows without version ID A, including rows with Version ID B, which is still in progress
- Docs DB ends up missing a lot of content

After:

Merge A and Merge B cannot run in parallel, so they cannot clobber each other.