### PR TITLE
docs:Clarify behavior of email confirmation during email updates

### DIFF
--- a/apps/docs/spec/supabase_js_v2.yml
+++ b/apps/docs/spec/supabase_js_v2.yml
@@ -1387,7 +1387,8 @@ functions:
     examples:
       - id: update-the-email-for-an-authenticated-user
         name: Update the email for an authenticated user
-        description: Sends a "Confirm Email Change" email to the new email address.
+        description: |
+          Sends a "Confirm Email Change" email to the new address. If **Secure Email Change** is enabled (default), confirmation is also required from the **old email** before the change is applied. To skip dual confirmation and apply the change after only the new email is verified, disable **Secure Email Change** in the [Email Auth Provider settings](/dashboard/project/_/auth/providers?provider=Email).
         isSpotlight: false
         code: |
           ```js


### PR DESCRIPTION
Updated the email update note in the docs to explain that confirmation emails are still sent due to the Secure Email Change setting. Added a direct link to the relevant dashboard setting to help users better understand and manage the behavior.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

Currently, the documentation for `supabase.auth.updateUser` states:

"Sends a '**Confirm Email Change**' email to the new email address."

However, this statement lacks clarity regarding why confirmation emails are sent despite the Email Confirmation toggle being disabled in the Supabase dashboard. Developers who rely on phone authentication often expect that adding an email afterward wouldn't trigger confirmation emails. This results in confusion, especially when:

- The Email Confirmation toggle is turned off in the project settings.

- Users update their email via `supabase.auth.updateUser` but still receive a confirmation email at the new address.

The current behavior may lead users to believe that there's an issue with their configuration, even when it's by design to enhance security.

## What is the new behavior?

The updated documentation now clearly explains:

- Why a confirmation email is sent when a user updates their email using `supabase.auth.updateUser`, even if "Email Confirmation" is disabled in the project settings.

- This is due to the Secure Email Change setting, which is enabled by default to prevent unauthorized email changes. It treats email updates as a sensitive action that always requires verification.

- The confirmation email will be sent to both the old and new email addresses (if Secure Email Change is enabled).

- A direct link to the dashboard setting is now included so users can easily locate and manage this behavior.

This helps clarify that email confirmations during updates are a built-in security feature, and shows how to change that behavior if needed.

## Additional context

Developers using phone-only authentication (SMS OTP) often run into confusion when adding an email address to a user account. Even with Email Confirmation turned off in the dashboard, Supabase still sends a confirmation email when updating the email.

This behavior surprises many, leading them to think something is broken — especially when login fails after confirming the new email, but the old email still shows in the database.

This PR improves the documentation by:

- Explaining that Secure Email Change is the reason confirmation emails are sent.

- Clarifying that this is a security feature, not a bug.

- Including a direct link to the relevant dashboard setting for easy access.
