### PR TITLE
API Docs side panel preview, only show keys button in introduction section

### DIFF
--- a/apps/studio/components/interfaces/ProjectAPIDocs/ProjectAPIDocs.tsx
+++ b/apps/studio/components/interfaces/ProjectAPIDocs/ProjectAPIDocs.tsx
@@ -36,6 +36,8 @@ import SecondLevelNav from './SecondLevelNav'
 const ProjectAPIDocs = () => {
   const { ref } = useParams()
   const snap = useAppStateSnapshot()
+  const isIntroduction =
+    snap.activeDocsSection.length === 1 && snap.activeDocsSection[0] === 'introduction'
   const isEntityDocs =
     snap.activeDocsSection.length === 2 && snap.activeDocsSection[0] === 'entities'
 
@@ -76,9 +78,11 @@ const ProjectAPIDocs = () => {
             <h4>API Docs</h4>
             <div className="flex items-center space-x-1">
               {!isEntityDocs && <LanguageSelector simplifiedVersion />}
-              <Button type="default" onClick={() => setShowKeys(!showKeys)}>
-                {showKeys ? 'Hide keys' : 'Show keys'}
-              </Button>
+              {isIntroduction && (
+                <Button type="default" onClick={() => setShowKeys(!showKeys)}>
+                  {showKeys ? 'Hide keys' : 'Show keys'}
+                </Button>
+              )}
             </div>
           </div>
 


### PR DESCRIPTION
RE the API docs side panel feature preview - realised that the "Show/Hide keys" button is only relevant in the introduction page when you're setting up your Supabase client, so opting to only show that button while on that page to reduce confusion (since toggling that button on any other page has no visual change)

![image](https://github.com/user-attachments/assets/494b28e5-80f7-40d7-9449-d4f8b4455361)
