### PR TITLE
Prevent sidebar jitter for expand on hover

### DIFF
--- a/apps/studio/components/interfaces/Sidebar.tsx
+++ b/apps/studio/components/interfaces/Sidebar.tsx
@@ -119,7 +119,7 @@ export const Sidebar = ({ className, ...props }: SidebarProps) => {
                   <DropdownMenuTrigger asChild>
                     <Button
                       type="text"
-                      className="w-min px-1.5 mx-0.5 group-data-[state=expanded]:px-2"
+                      className={`w-min px-1.5 mx-0.5 ${sidebarBehaviour === 'open' ? '!px-2' : ''}`}
                       icon={<PanelLeftDashed size={ICON_SIZE} strokeWidth={ICON_STROKE_WIDTH} />}
                     />
                   </DropdownMenuTrigger>
@@ -197,7 +197,7 @@ export function SideBarNavLink({
   const buttonProps = {
     tooltip: sidebarBehaviour === 'closed' ? route.label : '',
     isActive: active,
-    className: 'text-sm',
+    className: cn('text-sm', sidebarBehaviour === 'open' ? '!px-2' : ''),
     size: 'default' as const,
     onClick: onClick,
   }

--- a/packages/ui/src/components/shadcn/ui/sidebar.tsx
+++ b/packages/ui/src/components/shadcn/ui/sidebar.tsx
@@ -502,7 +502,7 @@ SidebarMenuItem.displayName = 'SidebarMenuItem'
 
 const sidebarMenuButtonVariants = cva(
   cn(
-    'peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md py-2 px-2 text-left text-sm outline-none ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-[[data-sidebar=menu-action]]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground [&>span:last-child]:truncate [&>svg]:size-5 [&>svg]:shrink-0 text-foreground-lighter data-[active=true]:text-foreground'
+    'peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md py-2 px-1.5 text-left text-sm outline-none ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-[[data-sidebar=menu-action]]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground [&>span:last-child]:truncate [&>svg]:size-5 [&>svg]:shrink-0 text-foreground-lighter data-[active=true]:text-foreground'
   ),
   {
     variants: {
@@ -750,6 +750,6 @@ export {
   SidebarRail,
   SidebarSeparator,
   SidebarTrigger,
-  useSidebar,
   sidebarMenuButtonVariants,
+  useSidebar,
 }


### PR DESCRIPTION
Fixes FE-1604

If the sidebar behaviour is expand on hover, fix the padding of the side bar buttons so that there's no shift in layout (currently the padding x increases from 1.5 to 2)

However, if the sidebar behaviour is to stay expanded, then padding x can be fixed at px-2