### PR TITLE
Chore/prepare org nav rollout

### DIFF
--- a/apps/studio/components/interfaces/App/FeaturePreview/FeaturePreviewContext.tsx
+++ b/apps/studio/components/interfaces/App/FeaturePreview/FeaturePreviewContext.tsx
@@ -17,7 +17,7 @@ export const FEATURE_PREVIEWS = [
     key: LOCAL_STORAGE_KEYS.UI_NEW_LAYOUT_PREVIEW,
     name: 'Layout Update for Organizations',
     content: <LayoutUpdatePreview />,
-    discussionsUrl: 'https://github.com/orgs/supabase/discussions/18038',
+    discussionsUrl: 'https://github.com/orgs/supabase/discussions/33670',
     isNew: false,
     isPlatformOnly: true,
   },

--- a/apps/studio/components/interfaces/App/FeaturePreview/FeaturePreviewContext.tsx
+++ b/apps/studio/components/interfaces/App/FeaturePreview/FeaturePreviewContext.tsx
@@ -1,5 +1,7 @@
 import { noop } from 'lodash'
 
+import { FeatureFlagContext } from 'common'
+import { useFlag } from 'hooks/ui/useFlag'
 import { IS_PLATFORM, LOCAL_STORAGE_KEYS } from 'lib/constants'
 import { EMPTY_OBJ } from 'lib/void'
 import { PropsWithChildren, createContext, useContext, useEffect, useState } from 'react'
@@ -72,6 +74,19 @@ const FeaturePreviewContext = createContext<FeaturePreviewContextType>({
 export const useFeaturePreviewContext = () => useContext(FeaturePreviewContext)
 
 export const FeaturePreviewContextProvider = ({ children }: PropsWithChildren<{}>) => {
+  const { hasLoaded } = useContext(FeatureFlagContext)
+  const enableNewLayoutPreview = useFlag('newLayoutPreview')
+
+  // [Joshen] Similar logic to feature flagging previews, we can use flags to default opt in previews
+  const isDefaultOptIn = (feature: (typeof FEATURE_PREVIEWS)[number]) => {
+    switch (feature.key) {
+      case LOCAL_STORAGE_KEYS.UI_NEW_LAYOUT_PREVIEW:
+        return enableNewLayoutPreview
+      default:
+        return false
+    }
+  }
+
   const [flags, setFlags] = useState(() =>
     FEATURE_PREVIEWS.reduce((a, b) => {
       return { ...a, [b.key]: false }
@@ -82,11 +97,16 @@ export const FeaturePreviewContextProvider = ({ children }: PropsWithChildren<{}
     if (typeof window !== 'undefined') {
       setFlags(
         FEATURE_PREVIEWS.reduce((a, b) => {
-          return { ...a, [b.key]: localStorage.getItem(b.key) === 'true' }
+          const defaultOptIn = isDefaultOptIn(b)
+          const localStorageValue = localStorage.getItem(b.key)
+          return {
+            ...a,
+            [b.key]: !localStorageValue ? defaultOptIn : localStorageValue === 'true',
+          }
         }, {})
       )
     }
-  }, [])
+  }, [hasLoaded])
 
   const value = {
     flags,

--- a/apps/studio/components/interfaces/App/FeaturePreview/FeaturePreviewModal.tsx
+++ b/apps/studio/components/interfaces/App/FeaturePreview/FeaturePreviewModal.tsx
@@ -5,7 +5,6 @@ import { useEffect } from 'react'
 import { useParams } from 'common'
 import { useSendEventMutation } from 'data/telemetry/send-event-mutation'
 import { useSelectedOrganization } from 'hooks/misc/useSelectedOrganization'
-import { useFlag } from 'hooks/ui/useFlag'
 import { IS_PLATFORM, LOCAL_STORAGE_KEYS } from 'lib/constants'
 import { useAppStateSnapshot } from 'state/app-state'
 import { removeTabsByEditor } from 'state/tabs'
@@ -19,12 +18,9 @@ const FeaturePreviewModal = () => {
   const featurePreviewContext = useFeaturePreviewContext()
   const { mutate: sendEvent } = useSendEventMutation()
 
-  const enableNewLayoutPreview = useFlag('newLayoutPreview')
-
+  // [Joshen] Use this if we want to feature flag previews
   function isReleasedToPublic(feature: (typeof FEATURE_PREVIEWS)[number]) {
     switch (feature.key) {
-      case LOCAL_STORAGE_KEYS.UI_NEW_LAYOUT_PREVIEW:
-        return enableNewLayoutPreview
       default:
         return true
     }

--- a/apps/studio/components/interfaces/App/FeaturePreview/LayoutUpdatePreview.tsx
+++ b/apps/studio/components/interfaces/App/FeaturePreview/LayoutUpdatePreview.tsx
@@ -63,8 +63,8 @@ export const LayoutUpdateBanner = () => {
         Dashboard layout has been updated!
       </AlertTitle_Shadcn_>
       <AlertDescription_Shadcn_>
-        We've updated the layout of the dashboard to enhance the UX around managing team members and
-        billing for organizations.
+        We've updated the dashboard layout to make it easier to find and manage your organization
+        settings.
       </AlertDescription_Shadcn_>
       <AlertDescription_Shadcn_ className="mt-4 flex items-center gap-x-2">
         <Button asChild type="default" icon={<ExternalLink />}>

--- a/apps/studio/components/interfaces/App/FeaturePreview/LayoutUpdatePreview.tsx
+++ b/apps/studio/components/interfaces/App/FeaturePreview/LayoutUpdatePreview.tsx
@@ -1,5 +1,10 @@
-import { BASE_PATH } from 'lib/constants'
+import { ButtonTooltip } from 'components/ui/ButtonTooltip'
+import { useLocalStorageQuery } from 'hooks/misc/useLocalStorage'
+import { BASE_PATH, LOCAL_STORAGE_KEYS } from 'lib/constants'
+import { ExternalLink, X } from 'lucide-react'
 import Image from 'next/image'
+import { Alert_Shadcn_, AlertDescription_Shadcn_, AlertTitle_Shadcn_, Badge, Button } from 'ui'
+import { useIsNewLayoutEnabled } from './FeaturePreviewContext'
 
 export const LayoutUpdatePreview = () => {
   return (
@@ -35,5 +40,50 @@ export const LayoutUpdatePreview = () => {
         </ul>
       </div>
     </div>
+  )
+}
+
+export const LayoutUpdateBanner = () => {
+  const newLayoutPreview = useIsNewLayoutEnabled()
+  const [newLayoutPreviewState] = useLocalStorageQuery(LOCAL_STORAGE_KEYS.UI_NEW_LAYOUT_PREVIEW, '')
+  const [newLayoutAcknowledged, setNewLayoutAcknowledged] = useLocalStorageQuery(
+    LOCAL_STORAGE_KEYS.NEW_LAYOUT_NOTICE_ACKNOWLEDGED,
+    false
+  )
+  const isDefaultOptedInNewLayout = newLayoutPreview && newLayoutPreviewState === ''
+
+  if (!isDefaultOptedInNewLayout || newLayoutAcknowledged) return null
+
+  return (
+    <Alert_Shadcn_ className="mb-4 relative">
+      <AlertTitle_Shadcn_>
+        <Badge variant="brand" className="mr-2">
+          NEW
+        </Badge>
+        Dashboard layout has been updated!
+      </AlertTitle_Shadcn_>
+      <AlertDescription_Shadcn_>
+        We've updated the layout of the dashboard to enhance the UX around managing team members and
+        billing for organizations.
+      </AlertDescription_Shadcn_>
+      <AlertDescription_Shadcn_ className="mt-4 flex items-center gap-x-2">
+        <Button asChild type="default" icon={<ExternalLink />}>
+          <a
+            target="_blank"
+            rel="noreferrer noopener"
+            href="https://github.com/orgs/supabase/discussions/33670"
+          >
+            View announcement
+          </a>
+        </Button>
+      </AlertDescription_Shadcn_>
+      <ButtonTooltip
+        type="text"
+        icon={<X />}
+        className="absolute top-2 right-2 px-1"
+        onClick={() => setNewLayoutAcknowledged(true)}
+        tooltip={{ content: { side: 'bottom', text: 'Dismiss' } }}
+      />
+    </Alert_Shadcn_>
   )
 }

--- a/apps/studio/lib/constants/index.ts
+++ b/apps/studio/lib/constants/index.ts
@@ -53,7 +53,7 @@ export const LOCAL_STORAGE_KEYS = {
   UI_SQL_EDITOR_TABS: 'supabase-ui-sql-editor-tabs',
   UI_NEW_LAYOUT_PREVIEW: 'supabase-ui-new-layout-preview',
 
-  SQL_SCRATCH_PAD_BANNER_ACKNOWLEDGED: 'supabase-sql-scratch-pad-banner-acknowledged',
+  NEW_LAYOUT_NOTICE_ACKNOWLEDGED: 'new-layout-notice-acknowledge',
 
   DASHBOARD_HISTORY: (ref: string) => `dashboard-history-${ref}`,
 
@@ -72,7 +72,6 @@ export const LOCAL_STORAGE_KEYS = {
   GRAPHIQL_RLS_BYPASS_WARNING: 'graphiql-rls-bypass-warning-dismissed',
   CLS_DIFF_WARNING: 'cls-diff-warning-dismissed',
   CLS_SELECT_STAR_WARNING: 'cls-select-star-warning-dismissed',
-  PROJECT_LINT_IGNORE_LIST: 'supabase-project-lint-ignore-list',
   QUERY_PERF_SHOW_BOTTOM_SECTION: 'supabase-query-perf-show-bottom-section',
   // Key to track account deletion requests
   ACCOUNT_DELETION_REQUEST: 'supabase-account-deletion-request',
@@ -82,8 +81,6 @@ export const LOCAL_STORAGE_KEYS = {
   LAST_SIGN_IN_METHOD: 'supabase-last-sign-in-method',
   // Key to track the last selected schema. The project ref is intentionally put at the end for easier search in the browser console.
   LAST_SELECTED_SCHEMA: (ref: string) => `last-selected-schema-${ref}`,
-  // Key to show a warning on the SQL Editor AI Assistant that the org hasn't opted-in to sending anon data
-  SHOW_AI_NOT_OPTIMIZED_WARNING: (ref: string) => `supabase-show-ai-not-optimized-${ref}`,
   // Track position of nodes for schema visualizer
   SCHEMA_VISUALIZER_POSITIONS: (ref: string, schemaId: number) =>
     `schema-visualizer-positions-${ref}-${schemaId}`,
@@ -92,9 +89,7 @@ export const LOCAL_STORAGE_KEYS = {
   GITHUB_AUTHORIZATION_STATE: 'supabase-github-authorization-state',
   // Notice banner keys
   FLY_POSTGRES_DEPRECATION_WARNING: 'fly-postgres-deprecation-warning-dismissed',
-
   AUTH_USERS_COLUMNS_CONFIGURATION: (ref: string) => `supabase-auth-users-columns-${ref}`,
-  STORAGE_BUCKETS_COLUMN_CONFIG: (ref: string) => `supabase-storage-buckets-columns-${ref}`,
 
   // api keys view switcher for new and legacy api keys
   API_KEYS_VIEW: (ref: string) => `supabase-api-keys-view-${ref}`,

--- a/apps/studio/pages/org/[slug]/index.tsx
+++ b/apps/studio/pages/org/[slug]/index.tsx
@@ -3,13 +3,15 @@ import { useEffect, useState } from 'react'
 
 import { useParams } from 'common'
 import { useIsNewLayoutEnabled } from 'components/interfaces/App/FeaturePreview/FeaturePreviewContext'
+import { LayoutUpdateBanner } from 'components/interfaces/App/FeaturePreview/LayoutUpdatePreview'
 import { ProjectList } from 'components/interfaces/Home/ProjectList'
 import HomePageActions from 'components/interfaces/HomePageActions'
 import DefaultLayout from 'components/layouts/DefaultLayout'
 import OrganizationLayout from 'components/layouts/OrganizationLayout'
 import { ScaffoldContainerLegacy } from 'components/layouts/Scaffold'
 import { useAutoProjectsPrefetch } from 'data/projects/projects-query'
-import { PROJECT_STATUS } from 'lib/constants'
+import { useLocalStorageQuery } from 'hooks/misc/useLocalStorage'
+import { LOCAL_STORAGE_KEYS, PROJECT_STATUS } from 'lib/constants'
 import type { NextPageWithLayout } from 'types'
 
 const ProjectsPage: NextPageWithLayout = () => {
@@ -24,6 +26,13 @@ const ProjectsPage: NextPageWithLayout = () => {
     PROJECT_STATUS.INACTIVE,
   ])
 
+  const [newLayoutPreviewState] = useLocalStorageQuery(LOCAL_STORAGE_KEYS.UI_NEW_LAYOUT_PREVIEW, '')
+  const [newLayoutAcknowledged, setNewLayoutAcknowledged] = useLocalStorageQuery(
+    LOCAL_STORAGE_KEYS.NEW_LAYOUT_NOTICE_ACKNOWLEDGED,
+    false
+  )
+  const isDefaultOptedInNewLayout = newLayoutPreview && newLayoutPreviewState === ''
+
   useAutoProjectsPrefetch()
 
   useEffect(() => {
@@ -37,12 +46,15 @@ const ProjectsPage: NextPageWithLayout = () => {
   return (
     <ScaffoldContainerLegacy>
       <div>
+        <LayoutUpdateBanner />
+
         <HomePageActions
           search={search}
           setSearch={setSearch}
           filterStatus={filterStatus}
           setFilterStatus={setFilterStatus}
         />
+
         <div className="my-6 space-y-8">
           <ProjectList
             filterToSlug

--- a/apps/studio/pages/org/[slug]/index.tsx
+++ b/apps/studio/pages/org/[slug]/index.tsx
@@ -10,8 +10,7 @@ import DefaultLayout from 'components/layouts/DefaultLayout'
 import OrganizationLayout from 'components/layouts/OrganizationLayout'
 import { ScaffoldContainerLegacy } from 'components/layouts/Scaffold'
 import { useAutoProjectsPrefetch } from 'data/projects/projects-query'
-import { useLocalStorageQuery } from 'hooks/misc/useLocalStorage'
-import { LOCAL_STORAGE_KEYS, PROJECT_STATUS } from 'lib/constants'
+import { PROJECT_STATUS } from 'lib/constants'
 import type { NextPageWithLayout } from 'types'
 
 const ProjectsPage: NextPageWithLayout = () => {
@@ -25,13 +24,6 @@ const ProjectsPage: NextPageWithLayout = () => {
     PROJECT_STATUS.ACTIVE_HEALTHY,
     PROJECT_STATUS.INACTIVE,
   ])
-
-  const [newLayoutPreviewState] = useLocalStorageQuery(LOCAL_STORAGE_KEYS.UI_NEW_LAYOUT_PREVIEW, '')
-  const [newLayoutAcknowledged, setNewLayoutAcknowledged] = useLocalStorageQuery(
-    LOCAL_STORAGE_KEYS.NEW_LAYOUT_NOTICE_ACKNOWLEDGED,
-    false
-  )
-  const isDefaultOptedInNewLayout = newLayoutPreview && newLayoutPreviewState === ''
 
   useAutoProjectsPrefetch()
 

--- a/apps/studio/pages/organizations.tsx
+++ b/apps/studio/pages/organizations.tsx
@@ -2,6 +2,7 @@ import { Boxes } from 'lucide-react'
 import { useRouter } from 'next/router'
 import { useEffect } from 'react'
 
+import { LayoutUpdateBanner } from 'components/interfaces/App/FeaturePreview/LayoutUpdatePreview'
 import AppLayout from 'components/layouts/AppLayout/AppLayout'
 import DefaultLayout from 'components/layouts/DefaultLayout'
 import { ScaffoldContainerLegacy, ScaffoldTitle } from 'components/layouts/Scaffold'
@@ -27,6 +28,7 @@ const OrganizationsPage: NextPageWithLayout = () => {
   return (
     <>
       <ScaffoldContainerLegacy>
+        <LayoutUpdateBanner />
         <ScaffoldTitle>Your Organizations</ScaffoldTitle>
       </ScaffoldContainerLegacy>
       <ScaffoldContainerLegacy>

--- a/packages/common/feature-flags.tsx
+++ b/packages/common/feature-flags.tsx
@@ -33,7 +33,7 @@ export type FeatureFlagContextType = {
   hasLoaded?: boolean
 }
 
-const FeatureFlagContext = createContext<FeatureFlagContextType>({
+export const FeatureFlagContext = createContext<FeatureFlagContextType>({
   API_URL: undefined,
   configcat: {},
   posthog: {},


### PR DESCRIPTION
Fixes FE-1605
Fixes FE-1606

## Context

We're preparing to do an incremental rollout for the dashboard organization layout changes after a week of internal testing and feedback iteration:
- Initial PR: https://github.com/supabase/supabase/pull/33150
- GH Discussion: https://github.com/orgs/supabase/discussions/33670

The layout changes will still be a feature preview, but we'll be opting users into the preview by default based on a percentage-based random sampling. We'll observe any error rates or feedback as we slowly increase the percentage value till all our users are using the new layout. 🙂🙏 

> [!NOTE]  
> While the behaviour is opt in by default, if any users might want to opt out of the changes, this is still in the user's control by disabling the preview within the Feature Previews section

## Changes involved
- Make org layout feature preview available for all users
  - Users can still opt in if they want to, although I reckon chances are no one really checks out the feature previews normally
- Add logic to support default opt in feature preview
  - If the user doesn't have the corresponding key in local storage, will default to the boolean value set by our feature flag
- Add a dismissible notice banner to inform users of the layout change to mitigate any potential surprise
  - Mainly on the /org/[slug] page and /organizations page
![image](https://github.com/user-attachments/assets/de4a492c-1cfc-4619-8eaa-dbed9be7a43c)
![image](https://github.com/user-attachments/assets/dfc82c8b-b259-4703-8cb7-d3149ecb727a)
- Fix feedback link for nav layout feature preview to the correct GH discussion for users to leave feedback on
- (Unrelated) Clean up some `LOCAL_STORAGE_KEYS` that are no longer in use

## To test
- Ensure that your local storage doesn't have the new layout preview key (you shouldn't have it if testing on the staging preview)
- Since staging is fully opted in, you should be redirected to /organizations after signing in
- [ ] Ensure that you can see the notice banner in /organizations
- [ ] Ensure that you can see the notice banner in /org/[slug] (By clicking into an organization)
- [ ] Ensure that the layout feature preview is enabled in the Feature Preview modal
- [ ] Ensure that you can dismiss the notice banner (and it should no longer show up across browser sessions)
- [ ] (Reset your local storage new layout key here) Ensure that if you disable, then enable the nav layout feature preview and refresh, you shouldn't see the notice banner again (since it's no longer opt in "by default")
- Apart from these ^ not sure if there might be any other test cases here that I might be overlooking
