### PR TITLE
docs: remove references to pgsodium/keys on Vault guide

### DIFF
--- a/apps/docs/content/guides/database/vault.mdx
+++ b/apps/docs/content/guides/database/vault.mdx
@@ -9,9 +9,9 @@ video: 'https://www.youtube.com/v/J9mTPY8rIXE'
 
 Vault is a Postgres extension and accompanying Supabase UI that makes it safe and easy to store encrypted secrets and other data in your database. This opens up a lot of possibilities to use Postgres in ways that go beyond what is available in a stock distribution.
 
-Under the hood, the Vault is a table of Secrets and Encryption Keys that are stored using [Authenticated Encryption](https://en.wikipedia.org/wiki/Authenticated_encryption) on disk. They are then available in decrypted form through a Postgres view so that the secrets can be used by applications from SQL. Because the secrets are stored on disk encrypted and authenticated, any backups or replication streams also preserve this encryption in a way that can't be decrypted or forged.
+Under the hood, the Vault is a table of Secrets that are stored using [Authenticated Encryption](https://en.wikipedia.org/wiki/Authenticated_encryption) on disk. They are then available in decrypted form through a Postgres view so that the secrets can be used by applications from SQL. Because the secrets are stored on disk encrypted and authenticated, any backups or replication streams also preserve this encryption in a way that can't be decrypted or forged.
 
-Supabase provides a dashboard UI for the Vault that makes storing secrets easy. Click a button, type in your secret, and save. Optionally create your own keys you can use to encrypt your secret. Your secret will then be stored on disk encrypted using the specified key.
+Supabase provides a dashboard UI for the Vault that makes storing secrets easy. Click a button, type in your secret, and save.
 
 <video width="99%" muted playsInline controls="true">
   <source
@@ -22,19 +22,11 @@ Supabase provides a dashboard UI for the Vault that makes storing secrets easy. 
   />
 </video>
 
-There are two main parts to the Vault UI, Secrets and Encryption Keys:
+You can use Vault to store secrets - everything from Environment Variables to API Keys. You can then use these secrets anywhere in your database: Postgres [Functions](/docs/guides/database/functions), Triggers, and [Webhooks](/docs/guides/database/webhooks). From a SQL perspective, accessing secrets is as easy as querying a table (or in this case, a view). The underlying secrets tables will be stored in encrypted form.
 
-## Secrets
+## Using Vault
 
-You can use the Vault to store secrets - everything from Environment Variables to API Keys. You can then use these secrets anywhere in your database: Postgres [Functions](/docs/guides/database/functions), Triggers, and [Webhooks](/docs/guides/database/webhooks). From a SQL perspective, accessing secrets is as easy as querying a table (or in this case, a view). The underlying secrets tables will be stored in encrypted form.
-
-## Encryption keys
-
-These are keys used to encrypt data inside your database. You can create different Encryption Keys for different purposes, for example: one for encrypting user-data, and another for application-data. Each key is encrypted itself using a root encryption key that lives outside of the database. See **[Encryption key location](#encryption-key-location)** for more details.
-
-## Using the Vault
-
-You can manage secrets and encryption keys from the UI or using SQL.
+You can manage secrets from the UI or using SQL.
 
 ### Adding secrets
 
@@ -71,35 +63,10 @@ id          | 7095d222-efe5-4cd5-b5c6-5755b451e223
 name        | unique_name
 description | This is the description
 secret      | 3mMeOcoG84a5F2uOfy2ugWYDp9sdxvCTmi6kTeT97bvA8rCEsG5DWWZtTU8VVeE=
-key_id      | c62da7a0-b85d-471d-8ea7-52aae21d7354
+key_id      |
 nonce       | \x9f2d60954ba5eb566445736e0760b0e3
 created_at  | 2022-12-14 02:34:23.85159+00
 updated_at  | 2022-12-14 02:34:23.85159+00
-```
-
-</details>
-
-Alternatively, you can create a secret by inserting data into the `vault.secret` table:
-
-{/* prettier-ignore */}
-```sql
-insert into vault.secrets (secret)
-values ('s3kre3t_k3y') returning *;
-```
-
-<details>
-<summary>Show Result</summary>
-
-```sql
--[ RECORD 1 ]-------------------------------------------------------------
-id          | d91596b8-1047-446c-b9c0-66d98af6d001
-name        |
-description |
-secret      | S02eXS9BBY+kE3r621IS8beAytEEtj+dDHjs9/0AoMy7HTbog+ylxcS22A==
-key_id      | 7f5ad44b-6bd5-4c99-9f68-4b6c7486f927
-nonce       | \x3aa2e92f9808e496aa4163a59304b895
-created_at  | 2022-12-14 02:29:21.3625+00
-updated_at  | 2022-12-14 02:29:21.3625+00
 ```
 
 </details>
@@ -126,7 +93,7 @@ name             | unique_name
 description      | This is the description
 secret           | 3mMeOcoG84a5F2uOfy2ugWYDp9sdxvCTmi6kTeT97bvA8rCEsG5DWWZtTU8VVeE=
 decrypted_secret | another_s3kre3t
-key_id           | c62da7a0-b85d-471d-8ea7-52aae21d7354
+key_id           |
 nonce            | \x9f2d60954ba5eb566445736e0760b0e3
 created_at       | 2022-12-14 02:34:23.85159+00
 updated_at       | 2022-12-14 02:34:23.85159+00
@@ -136,7 +103,7 @@ name             |
 description      |
 secret           | a1CE4vXwQ53+N9bllJj1D7fasm59ykohjb7K90PPsRFUd9IbBdxIGZNoSQLIXl4=
 decrypted_secret | another_s3kre3t
-key_id           | 8c72b05e-b931-4372-abf9-a09cfad18489
+key_id           |
 nonce            | \x1d3b2761548c4efb2d29ca11d44aa22f
 created_at       | 2022-12-14 02:32:50.58921+00
 updated_at       | 2022-12-14 02:32:50.58921+00
@@ -146,7 +113,7 @@ name             |
 description      |
 secret           | S02eXS9BBY+kE3r621IS8beAytEEtj+dDHjs9/0AoMy7HTbog+ylxcS22A==
 decrypted_secret | s3kre3t_k3y
-key_id           | 7f5ad44b-6bd5-4c99-9f68-4b6c7486f927
+key_id           |
 nonce            | \x3aa2e92f9808e496aa4163a59304b895
 created_at       | 2022-12-14 02:29:21.3625+00
 updated_at       | 2022-12-14 02:29:21.3625+00
@@ -186,7 +153,7 @@ name             | updated_unique_name
 description      | This is the updated description
 secret           | lhb3HBFxF+qJzp/HHCwhjl4QFb5dYDsIQEm35DaZQOovdkgp2iy6UMufTKJGH4ThMrU=
 decrypted_secret | n3w_upd@ted_s3kret
-key_id           | c62da7a0-b85d-471d-8ea7-52aae21d7354
+key_id           |
 nonce            | \x9f2d60954ba5eb566445736e0760b0e3
 created_at       | 2022-12-14 02:34:23.85159+00
 updated_at       | 2022-12-14 02:51:13.938396+00
@@ -206,7 +173,7 @@ updated_at       | 2022-12-14 02:51:13.938396+00
   ></iframe>
 </div>
 
-As we mentioned, the Vault uses `pgsodium`'s Transparent Column Encryption (TCE) to store secrets in an authenticated encrypted form. There are some details around that you may be curious about, what does authenticated mean, and where are encryption keys store? This section explains those details.
+As we mentioned, Vault uses Transparent Column Encryption (TCE) to store secrets in an authenticated encrypted form. There are some details around that you may be curious about. What does authenticated mean? Where is the encryption key stored? This section explains those details.
 
 ### Authenticated encryption with associated data
 
@@ -218,34 +185,11 @@ The first important feature of TCE is that it uses an [Authenticated Encryption 
 
 **Associated Data** means that you can include any other columns from the same row as part of the signature computation. This doesn't encrypt those other columns - rather it ensures that your encrypted value is only associated with columns from that row. If an attacker were to copy an encrypted value from another row to the current one, the signature would be rejected (assuming you used a unique column in the associated data).
 
-Another important feature of `pgsodium` is that the encryption keys are never stored in the database alongside the encrypted data. Instead, only a **Key ID** is stored, which is a reference to the key that is only accessible outside of SQL. Even if an attacker can capture a dump of your entire database, they will see only encrypted data and key IDs, _never the raw key itself_.
+Another important feature is that the encryption key is never stored in the database alongside the encrypted data. Even if an attacker can capture a dump of your entire database, they will see only encrypted data, _never the encryption key itself_.
 
 This is an important safety precaution - there is little value in storing the encryption key in the database itself as this would be like locking your front door but leaving the key in the lock! Storing the key outside the database fixes this issue.
 
-Where are the keys stored? Supabase creates and manages the root keys (from which all key IDs are derived) in our secured backend systems. We keep this root key safe and separate from your data. You remain in control of your keys - a separate API endpoint is available that you can use to access the key if you want to decrypt your data outside of Supabase.
-
-### Internal details
-
-To encrypt data, you need a _key id_. You can use the default key id created automatically for every project, or create your own key ids Using the `pgsodium.create_key()` function. Key ids are used to internally derive the encryption key used to encrypt secrets in the vault. Vault users typically do not have access to the key itself, only the key id.
-
-Both `vault.create_secret()` and `vault.update_secret()` take an optional fourth `new_key_id` argument. This argument can be used to store a different key id for the secret instead of the default value.
-
-{/* prettier-ignore */}
-```sql
-select vault.create_secret(
-  'another_s3kre3t_key', 
-  'another_unique_name',
-  'This is another description',
-  (pgsodium.create_key()).id
-);
-```
-
-Result:
-
-```sh
--[ RECORD 1 ]-+-------------------------------------
-create_secret | cec9e005-a44d-4b19-86e1-febf3cd40619
-```
+Where is the key stored? Supabase creates and manages the encryption key in our secured backend systems. We keep this key safe and separate from your data. You remain in control of your key - a separate API endpoint is available that you can use to access the key if you want to decrypt your data outside of Supabase.
 
 Which roles should have access to the `vault.secrets` table should be carefully considered. There are two ways to grant access, the first is that the `postgres` user can explicitly grant access to the vault table itself.
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

Vault docs reference usage of pgsodium, which is already deprecated and in the process of being removed

## What is the new behavior?

Update docs to remove references to pgsodium or key management