### PR TITLE
build (docs): lower docs preview build times

### DIFF
--- a/apps/docs/app/guides/realtime/[[...slug]]/page.tsx
+++ b/apps/docs/app/guides/realtime/[[...slug]]/page.tsx
@@ -1,11 +1,10 @@
+import { GuideTemplate } from '~/features/docs/GuidesMdx.template'
 import {
-  getGuidesMarkdown,
   genGuideMeta,
   genGuidesStaticParams,
+  getGuidesMarkdown,
 } from '~/features/docs/GuidesMdx.utils'
-import { GuideTemplate } from '~/features/docs/GuidesMdx.template'
-
-export const dynamicParams = false
+import { getEmptyArray } from '~/features/helpers.fn'
 
 type Params = { slug?: string[] }
 
@@ -16,10 +15,15 @@ const RealtimeGuidePage = async ({ params }: { params: Params }) => {
   return <GuideTemplate {...data!} />
 }
 
-const generateStaticParams = genGuidesStaticParams('realtime')
+const generateStaticParams =
+  // [Charis 2025-04-21] For some reason, using the IS_PROD export from common
+  // does not work (its type is a function when this is evaluated?)
+  process.env.NEXT_PUBLIC_VERCEL_ENV === 'production'
+    ? genGuidesStaticParams('realtime')
+    : getEmptyArray
 const generateMetadata = genGuideMeta((params: { slug?: string[] }) =>
   getGuidesMarkdown(['realtime', ...(params.slug ?? [])])
 )
 
 export default RealtimeGuidePage
-export { generateStaticParams, generateMetadata }
+export { generateMetadata, generateStaticParams }

--- a/apps/docs/features/helpers.fn.ts
+++ b/apps/docs/features/helpers.fn.ts
@@ -1,5 +1,10 @@
 type RecObj<T extends object, K extends keyof T> = T[K] extends Array<T> ? T : never
 
+const EMPTY_ARRAY = new Array(0)
+export function getEmptyArray() {
+  return EMPTY_ARRAY
+}
+
 export function deepFilterRec<T extends object, K extends keyof T>(
   arr: Array<RecObj<T, K>>,
   recKey: K,
@@ -24,6 +29,7 @@ export function deepFilterRec<T extends object, K extends keyof T>(
   )
 }
 
-export function pluckPromise<T, K extends keyof T>(promise: Promise<T>, key: K) {
-  return promise.then((data) => data[key])
+export async function pluckPromise<T, K extends keyof T>(promise: Promise<T>, key: K) {
+  const data = await promise
+  return data[key]
 }


### PR DESCRIPTION
An experiment in lowering docs preview build times. Build times have gotten quite long again (~12 minutes) because we are generating types on code blocks during prerendering. This wastes compute time building a lot of pages on preview branches that never get viewed, and slows down iteration speed.

Instead, let's only prerender on prod, and build on-demand for preview sites.

Limiting to realtime section for now to monitor the effects of changes.