### PR TITLE
Fix edge functions logs refresh button

### DIFF
--- a/apps/studio/components/interfaces/Settings/Logs/LogsPreviewer.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogsPreviewer.tsx
@@ -73,8 +73,8 @@ export const LogsPreviewer = ({
   const [selectedLogId, setSelectedLogId] = useSelectedLog()
   const { data: databases, isSuccess } = useReadReplicasQuery({ projectRef })
 
+  // TODO: Move this to useLogsUrlState to simplify LogsPreviewer. - Jordi
   function getDefaultDatePickerValue() {
-    // if we have values in the URL, use them
     const iso_timestamp_start = router.query.iso_timestamp_start as string
     const iso_timestamp_end = router.query.iso_timestamp_end as string
 

--- a/apps/studio/components/interfaces/Settings/Logs/LogsPreviewer.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogsPreviewer.tsx
@@ -18,7 +18,13 @@ import { useDatabaseSelectorStateSnapshot } from 'state/database-selector'
 import { Button } from 'ui'
 import { LogsBarChart } from 'ui-patterns/LogsBarChart'
 import LogTable from './LogTable'
-import { LOGS_TABLES, LOG_ROUTES_WITH_REPLICA_SUPPORT, LogsTableName } from './Logs.constants'
+import { DatePickerValue } from './Logs.DatePickers'
+import {
+  LOGS_TABLES,
+  LOG_ROUTES_WITH_REPLICA_SUPPORT,
+  LogsTableName,
+  PREVIEWER_DATEPICKER_HELPERS,
+} from './Logs.constants'
 import type { Filters, LogSearchCallback, LogTemplate, QueryType } from './Logs.types'
 import { maybeShowUpgradePrompt } from './Logs.utils'
 import UpgradePrompt from './UpgradePrompt'
@@ -54,16 +60,41 @@ export const LogsPreviewer = ({
 }: PropsWithChildren<LogsPreviewerProps>) => {
   const router = useRouter()
   const { db } = useParams()
-  const [showChart, setShowChart] = useState(true)
-
   const organization = useSelectedOrganization()
   const state = useDatabaseSelectorStateSnapshot()
+
+  const [showChart, setShowChart] = useState(true)
+  const [selectedDatePickerValue, setSelectedDatePickerValue] = useState<DatePickerValue>(
+    getDefaultDatePickerValue()
+  )
+
   const { search, setSearch, timestampStart, timestampEnd, setTimeRange, filters, setFilters } =
     useLogsUrlState()
-
   const [selectedLogId, setSelectedLogId] = useSelectedLog()
-
   const { data: databases, isSuccess } = useReadReplicasQuery({ projectRef })
+
+  function getDefaultDatePickerValue() {
+    // if we have values in the URL, use them
+    const iso_timestamp_start = router.query.iso_timestamp_start as string
+    const iso_timestamp_end = router.query.iso_timestamp_end as string
+
+    if (iso_timestamp_start && iso_timestamp_end) {
+      return {
+        to: iso_timestamp_end,
+        from: iso_timestamp_start,
+        text: `${dayjs(iso_timestamp_start).format('DD MMM, HH:mm')} - ${dayjs(iso_timestamp_end).format('DD MMM, HH:mm')}`,
+        isHelper: false,
+      }
+    }
+
+    const defaultDatePickerValue = PREVIEWER_DATEPICKER_HELPERS.find((x) => x.default)
+    return {
+      to: defaultDatePickerValue!.calcTo(),
+      from: defaultDatePickerValue!.calcFrom(),
+      text: defaultDatePickerValue!.text,
+      isHelper: true,
+    }
+  }
 
   const table = !tableName ? LOGS_TABLES[queryType] : tableName
 
@@ -96,13 +127,18 @@ export const LogsPreviewer = ({
     setFilters({ ...filters, search_query: template.searchString })
   }
 
-  // [Joshen 180425] This logic here all seems unnecessary IMO? handleRefresh just should call refresh?
+  // [Joshen] For helper date picker values, reset the timestamp start to prevent data caching
+  // Since the helpers are "Last n minutes" -> hitting refresh, you'd expect to see the latest result
+  // Whereas if a specific range is selected, you'd not expect new data to show up
   const handleRefresh = () => {
-    if (timestampStart) {
-      const newTimestampStart = dayjs(timestampStart).toISOString()
-      setTimeRange(newTimestampStart, timestampEnd)
-    } else {
-      setTimeRange('', '')
+    if (selectedDatePickerValue.isHelper) {
+      const helper = PREVIEWER_DATEPICKER_HELPERS.find(
+        (x) => x.text === selectedDatePickerValue.text
+      )
+      if (helper) {
+        const newTimestampStart = helper.calcFrom()
+        setTimeRange(newTimestampStart, timestampEnd)
+      }
     }
     refresh()
   }
@@ -180,6 +216,8 @@ export const LogsPreviewer = ({
             query: id !== projectRef ? { ...router.query, db: id } : params,
           })
         }}
+        selectedDatePickerValue={selectedDatePickerValue}
+        setSelectedDatePickerValue={setSelectedDatePickerValue}
       />
       {children}
       <div

--- a/apps/studio/components/interfaces/Settings/Logs/PreviewFilterPanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/PreviewFilterPanel.tsx
@@ -1,4 +1,3 @@
-import dayjs from 'dayjs'
 import { Eye, EyeOff, RefreshCw, Search, Terminal, X } from 'lucide-react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
@@ -42,6 +41,8 @@ interface PreviewFilterPanelProps {
   filters: Filters
   onSelectedDatabaseChange: (id: string) => void
   className?: string
+  selectedDatePickerValue: DatePickerValue
+  setSelectedDatePickerValue: (value: DatePickerValue) => void
 }
 
 /**
@@ -64,6 +65,8 @@ const PreviewFilterPanel = ({
   table,
   onSelectedDatabaseChange,
   className,
+  selectedDatePickerValue,
+  setSelectedDatePickerValue,
 }: PreviewFilterPanelProps) => {
   const router = useRouter()
   const { ref } = useParams()
@@ -78,30 +81,6 @@ const PreviewFilterPanel = ({
     IS_PLATFORM && LOG_ROUTES_WITH_REPLICA_SUPPORT.includes(router.pathname)
 
   const hasEdits = search !== defaultSearchValue
-
-  function getDefaultDatePickerValue() {
-    // if we have values in the URL, use them
-    const iso_timestamp_start = router.query.iso_timestamp_start as string
-    const iso_timestamp_end = router.query.iso_timestamp_end as string
-    if (iso_timestamp_start && iso_timestamp_end) {
-      return {
-        to: iso_timestamp_end,
-        from: iso_timestamp_start,
-        text: `${dayjs(iso_timestamp_start).format('DD MMM, HH:mm')} - ${dayjs(iso_timestamp_end).format('DD MMM, HH:mm')}`,
-        isHelper: false,
-      }
-    }
-    return {
-      to: PREVIEWER_DATEPICKER_HELPERS[2].calcTo(),
-      from: PREVIEWER_DATEPICKER_HELPERS[2].calcFrom(),
-      text: 'Last hour',
-      isHelper: true,
-    }
-  }
-
-  const [selectedDatePickerValue, setSelectedDatePickerValue] = useState<DatePickerValue>(
-    getDefaultDatePickerValue()
-  )
 
   const handleInputSearch = (query: string) => onSearch('search-input-change', { query })
 


### PR DESCRIPTION
Fixes FE-1524

## Context

For the Edge Functions Logs, if you run some test requests on your edge function (use an edge function that console logs something so that it shows up in the logs), if you keep hitting refresh, the logs don't show up.

Only when you switch from the default "Last hour" to "Last n minutes", then the logs show up. Yet again, if you run more test requests on the edge function, and keep hitting refresh, the logs don't show up until you change the date picker value to another "Last n" option

My guess here is that the data from the API might somehow be cached here as hitting the refresh button just resends the same request to fetch the logs with the same exact parameters

## Changes involved

- If the `selectedDatePickerValue` is a helper, reset the timestamp start value whenever refreshing
  - This should prevent any potential caching problems
  - And also i think this makes sense, if you're refreshing data for a "Last n" option, you'd expect any new results to show up. Whereas if you might have selected a specific range (non helper), you probably don't expect new results to show up when you hit refresh

## To test in the preview
- Have an edge function in your project that console.logs out something (The default Hello World one should do I think)
- Open your edge function logs -> probably a clean state will be easier to see
- Run a test request via the dashboard
- Hit refresh a couple of times (it takes a couple of seconds before the logs are returned) until the logs from the request shows up
- As a double check, just verify that this behaviour doesn't happen on current prod / staging (that no matter how many times you refresh, the new logs won't show up)