### PR TITLE
fix (docs): middleware rewrites for reference pages

### DIFF
--- a/apps/docs/app/api/crawlers/route.smoke.test.ts
+++ b/apps/docs/app/api/crawlers/route.smoke.test.ts
@@ -70,3 +70,10 @@ describe('prod smoke test: crawler pages return correct data', () => {
     expect(headings.includes('examples')).toBe(true)
   })
 })
+
+describe('prod smoke test: ref pages without crawler versions', async () => {
+  it('returns 200', async () => {
+    const result = await fetch(REFERENCE_DOCS_URL + '/api/v1-deploy-a-function')
+    expect(result.status).toBe(200)
+  })
+})

--- a/apps/docs/middleware.ts
+++ b/apps/docs/middleware.ts
@@ -1,15 +1,12 @@
 import { isbot } from 'isbot'
-import type { NextRequest } from 'next/server'
-import { NextResponse } from 'next/server'
-
+import { type NextRequest, NextResponse } from 'next/server'
 import { clientSdkIds } from '~/content/navigation.references'
 import { BASE_PATH } from '~/lib/constants'
 
-const REFERENCE_PATH = `${(BASE_PATH ?? '') + '/'}reference`
+const REFERENCE_PATH = `${BASE_PATH ?? ''}/reference`
 
 export function middleware(request: NextRequest) {
   const url = new URL(request.url)
-
   if (!url.pathname.startsWith(REFERENCE_PATH)) {
     return NextResponse.next()
   }
@@ -26,38 +23,37 @@ export function middleware(request: NextRequest) {
       if (slug.length > 0) {
         const rewriteUrl = new URL(url)
         rewriteUrl.pathname = (BASE_PATH ?? '') + '/api/crawlers'
-
         return NextResponse.rewrite(rewriteUrl)
       }
     }
-  } else {
-    const [, lib, maybeVersion] = url.pathname.replace(REFERENCE_PATH, '').split('/')
+  }
 
-    if (lib === 'cli') {
-      const rewritePath = [REFERENCE_PATH, 'cli'].join('/')
-      return NextResponse.rewrite(new URL(rewritePath, request.url))
-    }
+  const [, lib, maybeVersion] = url.pathname.replace(REFERENCE_PATH, '').split('/')
 
-    if (lib === 'api') {
-      const rewritePath = [REFERENCE_PATH, 'api'].join('/')
-      return NextResponse.rewrite(new URL(rewritePath, request.url))
-    }
+  if (lib === 'cli') {
+    const rewritePath = [REFERENCE_PATH, 'cli'].join('/')
+    return NextResponse.rewrite(new URL(rewritePath, request.url))
+  }
 
-    if (lib?.startsWith('self-hosting-')) {
-      const rewritePath = [REFERENCE_PATH, lib].join('/')
-      return NextResponse.rewrite(new URL(rewritePath, request.url))
-    }
+  if (lib === 'api') {
+    const rewritePath = [REFERENCE_PATH, 'api'].join('/')
+    return NextResponse.rewrite(new URL(rewritePath, request.url))
+  }
 
-    if (clientSdkIds.includes(lib)) {
-      const version = /v\d+/.test(maybeVersion) ? maybeVersion : null
-      const rewritePath = [REFERENCE_PATH, lib, version].filter(Boolean).join('/')
-      return NextResponse.rewrite(new URL(rewritePath, request.url))
-    }
+  if (lib?.startsWith('self-hosting-')) {
+    const rewritePath = [REFERENCE_PATH, lib].join('/')
+    return NextResponse.rewrite(new URL(rewritePath, request.url))
+  }
+
+  if (clientSdkIds.includes(lib)) {
+    const version = /v\d+/.test(maybeVersion) ? maybeVersion : null
+    const rewritePath = [REFERENCE_PATH, lib, version].filter(Boolean).join('/')
+    return NextResponse.rewrite(new URL(rewritePath, request.url))
   }
 
   return NextResponse.next()
 }
 
 export const config = {
-  matcher: '/((?!api|_next|static|public|favicon.ico).*)',
+  matcher: '/reference/:path*',
 }


### PR DESCRIPTION
Before:

There was a bug with middleware rewrites for reference pages without crawler versions (basically all references except the client SDKs). There was a branch that was not handled (the requesting user agent is a a bot, but the reference is not a client SDK), so it failed through to the base case of NextResponse.next(), which 404s as that page does not exist for a path like /reference/api/v1-deploy-a-function

<img width="436" alt="image" src="https://github.com/user-attachments/assets/1c73bd90-9625-449c-bafc-e4ba06c53327" />

After:

Fixed the branch. If all of the following are true:

- Is a reference page
- Requesting user agent is a bot
- Reference is not a client SDK

Then it should follow the same path as a non-bot request, because there is no bot-specific version. That means it should be rewritten to the slugless page: /reference/api/v1-deploy-a-function => /reference/api

<img width="430" alt="image" src="https://github.com/user-attachments/assets/8f3b56f3-ac31-49e1-8fa0-b70745f45216" />

