### PR TITLE
fix (content api): return graphql-spec compliant error

### DIFF
--- a/apps/docs/app/api/graphql/route.test.ts
+++ b/apps/docs/app/api/graphql/route.test.ts
@@ -7,39 +7,44 @@ describe('GraphQL API endpoint', () => {
     vi.spyOn(console, 'error').mockImplementation(() => {})
   })
 
-  it('should return 400 if request body is not valid JSON', async () => {
+  it('should return error if request body is not valid JSON', async () => {
     const request = new Request('http://localhost/api/graphql', {
       method: 'POST',
       body: 'not json',
     })
 
     const response = await POST(request)
-    expect(response.status).toBe(400)
-    expect(await response.text()).toBe('Invalid request: Request body must be valid JSON')
+    const json = await response.json()
+    expect(json.errors[0].message).toBe('Invalid request: Request body must be valid JSON')
   })
 
-  it('should return 400 if request body is missing required fields', async () => {
+  it('should return error if request body is missing required fields', async () => {
     const request = new Request('http://localhost/api/graphql', {
       method: 'POST',
       body: JSON.stringify({ variables: {} }),
     })
 
     const response = await POST(request)
-    expect(response.status).toBe(400)
-    expect(await response.text()).toContain('Request body must be a valid GraphQL request object')
+    const json = await response.json()
+    expect(json.errors[0].message).toContain(
+      'Invalid request: Request body must be valid GraphQL request object'
+    )
   })
 
-  it('should return 400 if query is not a string', async () => {
+  it('should return error if query is not a string', async () => {
     const request = new Request('http://localhost/api/graphql', {
       method: 'POST',
       body: JSON.stringify({ query: 123 }),
     })
 
     const response = await POST(request)
-    expect(response.status).toBe(400)
+    const json = await response.json()
+    expect(json.errors[0].message).toContain(
+      'Invalid request: Request body must be valid GraphQL request object'
+    )
   })
 
-  it('should return 500 for internal server errors', async () => {
+  it('should return error for internal server errors', async () => {
     const request = new Request('http://localhost/api/graphql', {
       method: 'POST',
       body: JSON.stringify({ query: 'query { hello }' }),
@@ -50,7 +55,7 @@ describe('GraphQL API endpoint', () => {
     })
 
     const response = await POST(request)
-    expect(response.status).toBe(500)
-    expect(await response.text()).toBe('Internal Server Error')
+    const json = await response.json()
+    expect(json.errors[0].message).toBe('Internal Server Error')
   })
 })

--- a/apps/docs/app/api/utils.ts
+++ b/apps/docs/app/api/utils.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+import { z, type ZodError } from 'zod'
 
 export class ApiError extends Error {
   constructor(message: string) {
@@ -15,7 +15,7 @@ export class ApiError extends Error {
 }
 
 export class InvalidRequestError extends ApiError {
-  constructor(message: string) {
+  constructor(message: string, source?: unknown) {
     super(`Invalid request: ${message}`)
   }
 
@@ -26,4 +26,15 @@ export class InvalidRequestError extends ApiError {
   statusCode() {
     return 400
   }
+}
+
+export function convertZodToInvalidRequestError(
+  error: ZodError,
+  prelude?: string
+): InvalidRequestError {
+  const issue = error.issues[0]
+  const pathStr = issue.path.join('.')
+  const message = `${prelude ? `${prelude}: ` : ''}${issue.message} at key "${pathStr}"`
+
+  return new InvalidRequestError(message, error)
 }


### PR DESCRIPTION
GraphQL errors were occasionally returned as normal HTTP status code errors, switched to using only GraphQL-spec compliant errors for the /docs/api/graphql endpoint.