### PR TITLE
docs: fix JS syntax errors in the setRoleCustomClaim example in firebase-auth

### DIFF
--- a/apps/docs/content/guides/auth/third-party/firebase-auth.mdx
+++ b/apps/docs/content/guides/auth/third-party/firebase-auth.mdx
@@ -322,7 +322,7 @@ const { initializeApp } = require('firebase-admin/app');
 const { getAuth } = require('firebase-admin/auth');
 initializeApp();
 
-async function setRoleCustomClaim() => {
+async function setRoleCustomClaim() {
   let nextPageToken = undefined
 
   do {
@@ -338,7 +338,7 @@ async function setRoleCustomClaim() => {
       } catch (error) {
         console.error('Failed to set custom role for user', userRecord.id)
       }
-    })
+    }))
   } while (nextPageToken);
 };
 

--- a/apps/docs/content/guides/auth/third-party/firebase-auth.mdx
+++ b/apps/docs/content/guides/auth/third-party/firebase-auth.mdx
@@ -332,11 +332,11 @@ async function setRoleCustomClaim() {
 
     await Promise.all(listUsersResult.users.map(async (userRecord) => {
       try {
-        await getAuth().setCustomUserClaims(userRecord.id, {
+        await getAuth().setCustomUserClaims(userRecord.uid, {
           role: 'authenticated'
         })
       } catch (error) {
-        console.error('Failed to set custom role for user', userRecord.id)
+        console.error('Failed to set custom role for user', userRecord.uid)
       }
     }))
   } while (nextPageToken);


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update: in an example (setRoleCustomClaim), fix some small JS syntax errors, and one Firebase Auth type error.

## What is the current behavior?

Copy-pasting the example code currently doesn't give a working JS script/function.

## What is the new behavior?

/

## Additional context

/
