### PR TITLE
Remove [contain:layout] class in ProjectLayout to fix tabs not following cursor position

### DIFF
--- a/apps/studio/components/layouts/ProjectLayout/ProjectLayout.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/ProjectLayout.tsx
@@ -208,7 +208,7 @@ const ProjectLayout = forwardRef<HTMLDivElement, PropsWithChildren<ProjectLayout
                   className={cn('w-full xl:min-w-[600px] bg-dash-sidebar')}
                 >
                   <main
-                    className="h-full flex flex-col flex-1 w-full overflow-y-auto overflow-x-hidden @container [contain:layout]"
+                    className="h-full flex flex-col flex-1 w-full overflow-y-auto overflow-x-hidden @container"
                     ref={ref}
                   >
                     {showPausedState ? (


### PR DESCRIPTION
Fixes FE-1607

## Context
- Noticed that the tabs interface, the tabs weren't following the cursor position when being dragged
- Traced it down to the cause being `[contain:layout]` class that's applied to ProjectLayout
- ^ This class was previously added to fix an issue with Popovers not rendering with their Triggers, most notably in the Table Editor's sort and filter popovers
- However, I think that issue was rather caused by a bug with Radix Dialog (that also caused a number of issues with the Dropdown components we had). We've since downgraded the Radix Dialog version, and after removing the `[contain:layout]` class, I can verify that the Popovers render correctly across Chrome, Safari and Firefox

## To test:
- Verify that in the tabs interface (SQL / Table Editor), when dragging tabs, the tabs follow your cursor, and you can sort the tabs in an expected behaviour
- Also verify that popovers are rendering correctly (Table Editor, Project Dropdown, etc, etc)