### PR TITLE
chore: add how to dedicated pooler

### DIFF
--- a/apps/docs/content/guides/database/connecting-to-postgres.mdx
+++ b/apps/docs/content/guides/database/connecting-to-postgres.mdx
@@ -119,6 +119,8 @@ For paying customers, we provision a Dedicated Pooler ([PgBouncer](https://www.p
 
 The Dedicated Pooler ensures best performance and latency, while using up more of your project's compute resources. If your network supports IPv6 or you have the IPv4 add-on, we encourage you to use the Dedicated Pooler over the Shared Pooler.
 
+Get your project's Dedicated pooler connection string from your project dashboard by clicking [Connect](https://supabase.com/dashboard/project/_?showConnect=true).
+
 <Admonition type="note">
 
 PgBouncer always runs in Transaction mode and the current version does not support prepared statement (will be added in a few weeks).


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

dedicated pooler doesn't show where or how to connect but supavisor does. Just a small addon