### PR TITLE
Fix tabs renaming via AI not updating tab label

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/RenameQueryModal.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/RenameQueryModal.tsx
@@ -95,7 +95,6 @@ const RenameQueryModal = ({
       // [Joshen] For SQL V2 - content is loaded on demand so we need to fetch the data if its not already loaded in the valtio state
       if (!('content' in localSnippet)) {
         localSnippet = await getContentById({ projectRef: ref, id })
-
         snapV2.addSnippet({ projectRef: ref, snippet: localSnippet })
       }
 
@@ -109,10 +108,12 @@ const RenameQueryModal = ({
       })
 
       snapV2.renameSnippet({ id, name: nameInput, description: descriptionInput })
+
       if (isSQLEditorTabsEnabled && ref) {
         const tabId = createTabId('sql', { id })
         updateTab(ref, tabId, { label: nameInput })
       }
+
       toast.success('Successfully renamed snippet!')
       if (onComplete) onComplete()
     } catch (error: any) {

--- a/apps/studio/components/interfaces/SQLEditor/hooks.ts
+++ b/apps/studio/components/interfaces/SQLEditor/hooks.ts
@@ -67,7 +67,6 @@ export const useNewQuery = () => {
 export function useSqlEditorDiff() {
   const [sourceSqlDiff, setSourceSqlDiff] = useState<ContentDiff>()
   const [selectedDiffType, setSelectedDiffType] = useState<DiffType>()
-  const [pendingTitle, setPendingTitle] = useState<string>()
   const [isAcceptDiffLoading, setIsAcceptDiffLoading] = useState(false)
 
   const isDiffOpen = !!sourceSqlDiff
@@ -91,7 +90,6 @@ export function useSqlEditorDiff() {
 
   const closeDiff = useCallback(() => {
     setSourceSqlDiff(undefined)
-    setPendingTitle(undefined)
     setSelectedDiffType(undefined)
   }, [])
 
@@ -100,8 +98,6 @@ export function useSqlEditorDiff() {
     setSourceSqlDiff,
     selectedDiffType,
     setSelectedDiffType,
-    pendingTitle,
-    setPendingTitle,
     isAcceptDiffLoading,
     setIsAcceptDiffLoading,
     isDiffOpen,


### PR DESCRIPTION
Fixes DESIGN-29

## Context

When creating a new snippet in the SQL Editor, if you run the query after writing something in it, we usually run an AI prompt to also generate a title for the snippet so that you don't end up with tons of "Untitled Query"

When the snippet gets renamed like this, the tab label of the snippet doesn't get updated so this PR fixes it

## Changes involved

- Call `updateTab` when renaming via AI
- (Unrelated) Clean up `pendingTitle` and `setPendingTitle` from `useSqlEditorDiff` - unnecessary